### PR TITLE
fix(adapters): sanitize connector tool names for OpenAI Codex

### DIFF
--- a/packages/adapters/src/pi-runtime.test.ts
+++ b/packages/adapters/src/pi-runtime.test.ts
@@ -1,5 +1,10 @@
+import type { ConnectorTool } from "@rakazo/adapter-kit";
 import { describe, expect, it } from "vitest";
-import { PiAgentRuntime } from "./pi-runtime.js";
+import { normalizeAgentToolName, normalizeAgentToolNames, PiAgentRuntime } from "./pi-runtime.js";
+
+function tool(name: string): ConnectorTool {
+  return { name, description: name, inputSchema: { type: "object" } };
+}
 
 describe("Pi agent runtime", () => {
   it("reports an unknown model without calling a provider", async () => {
@@ -27,5 +32,47 @@ describe("Pi agent runtime", () => {
       if (event.type === "text") events.push(event.text);
     }
     expect(events.join(" ")).toMatch(/Unknown model/i);
+  });
+});
+
+describe("Pi model-facing connector tool names", () => {
+  it("leaves builtin-compatible names unchanged", () => {
+    expect(normalizeAgentToolName("write_file")).toBe("write_file");
+    expect(normalizeAgentToolNames([tool("write_file"), tool("shell")])).toEqual([
+      "write_file",
+      "shell",
+    ]);
+  });
+
+  it("normalizes punctuation, whitespace, and Unicode to the provider-safe pattern", () => {
+    const names = normalizeAgentToolNames([
+      tool("destination.write"),
+      tool("Google Calendar / criar evento"),
+      tool("🦊"),
+    ]);
+
+    expect(names[0]).toBe("destination_write");
+    expect(names[1]).toBe("Google_Calendar_criar_evento");
+    expect(names[2]).toBe("connector_tool");
+    expect(names.every((name) => /^[a-zA-Z0-9_-]+$/.test(name))).toBe(true);
+  });
+
+  it("limits long names to the provider's 64-character maximum", () => {
+    const name = normalizeAgentToolName(`very-long-${"x".repeat(100)}`);
+
+    expect(name).toHaveLength(64);
+    expect(name).toMatch(/^[a-zA-Z0-9_-]+$/);
+  });
+
+  it("keeps normalized names unique and deterministic without shadowing valid names", () => {
+    const tools = [tool("foo.bar"), tool("foo bar"), tool("foo_bar"), tool("🦊"), tool("🦊")];
+
+    const first = normalizeAgentToolNames(tools);
+    const second = normalizeAgentToolNames(tools);
+
+    expect(second).toEqual(first);
+    expect(new Set(first).size).toBe(tools.length);
+    expect(first[2]).toBe("foo_bar");
+    expect(first.every((name) => /^[a-zA-Z0-9_-]+$/.test(name))).toBe(true);
   });
 });

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -13,6 +13,11 @@ import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
 const running = new Map<string, AbortController>();
 const models = builtinModels();
 const MAX_PARALLEL_SUBAGENTS = 4;
+// Pi forwards these names to OpenAI Responses, whose function-name contract is
+// ^[a-zA-Z0-9_-]+$ with a maximum length of 64 characters.
+const AGENT_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_AGENT_TOOL_NAME_LENGTH = 64;
+const FALLBACK_AGENT_TOOL_NAME = "connector_tool";
 
 export class PiAgentRuntime implements AgentRuntime {
   describe() {
@@ -62,7 +67,7 @@ export class PiAgentRuntime implements AgentRuntime {
           signal,
           depth: 0,
         };
-        const tools = toolDefs.map((tool) => toAgentTool(tool, host));
+        const tools = toAgentTools(toolDefs, host);
         const history = toHistory(request.history, request.prompt);
 
         const agent = new Agent({
@@ -154,6 +159,75 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
+function toAgentTools(toolDefs: readonly ConnectorTool[], host: ToolHost): AgentTool[] {
+  const names = normalizeAgentToolNames(toolDefs);
+  return toolDefs.map((tool, index) => toAgentTool(tool, host, names[index]!));
+}
+
+/**
+ * Normalize connector names only at the boundary where they are exposed to Pi.
+ * Connector execution continues to use the original name captured by toAgentTool.
+ */
+export function normalizeAgentToolName(name: string): string {
+  if (isProviderSafeAgentToolName(name)) return name;
+  const normalized = name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return (normalized || FALLBACK_AGENT_TOOL_NAME).slice(0, MAX_AGENT_TOOL_NAME_LENGTH);
+}
+
+/**
+ * Return one valid, unique model-facing name per connector tool.
+ * Existing valid names are reserved first so sanitizing a connector cannot
+ * rename or shadow a builtin tool with the same valid name.
+ */
+export function normalizeAgentToolNames(tools: readonly ConnectorTool[]): string[] {
+  const reservedValidNames = new Set(
+    tools.filter((tool) => isProviderSafeAgentToolName(tool.name)).map((tool) => tool.name),
+  );
+  const usedNames = new Set<string>();
+
+  return tools.map((tool) => {
+    const base = normalizeAgentToolName(tool.name);
+    const originalIsValid = isProviderSafeAgentToolName(tool.name);
+    let candidate = base;
+
+    if (usedNames.has(candidate) || (!originalIsValid && reservedValidNames.has(candidate))) {
+      candidate = withToolNameSuffix(base, stableToolNameHash(tool.name));
+    }
+
+    let suffix = 2;
+    while (usedNames.has(candidate) || (!originalIsValid && reservedValidNames.has(candidate))) {
+      candidate = withToolNameSuffix(base, `${stableToolNameHash(tool.name)}_${suffix}`);
+      suffix += 1;
+    }
+
+    usedNames.add(candidate);
+    return candidate;
+  });
+}
+
+function isProviderSafeAgentToolName(name: string): boolean {
+  return AGENT_TOOL_NAME_PATTERN.test(name) && name.length <= MAX_AGENT_TOOL_NAME_LENGTH;
+}
+
+function withToolNameSuffix(base: string, suffix: string): string {
+  const suffixWithSeparator = `_${suffix}`;
+  const prefixLength = Math.max(1, MAX_AGENT_TOOL_NAME_LENGTH - suffixWithSeparator.length);
+  return `${base.slice(0, prefixLength)}${suffixWithSeparator}`;
+}
+
+function stableToolNameHash(name: string): string {
+  let hash = 2166136261;
+  for (const character of name) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
 function toHistory(history: AgentRunRequest["history"], prompt: string) {
   const last = history.at(-1);
   const prior = last?.role === "user" && last.content === prompt ? history.slice(0, -1) : history;
@@ -166,9 +240,9 @@ function toHistory(history: AgentRunRequest["history"], prompt: string) {
     );
 }
 
-function toAgentTool(tool: ConnectorTool, host: ToolHost): AgentTool {
+function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): AgentTool {
   return {
-    name: tool.name,
+    name: exposedName,
     label: tool.name,
     description: tool.description,
     parameters: parametersFor(tool),
@@ -293,7 +367,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
         .join(" "),
       model: host.model,
       thinkingLevel: "off",
-      tools: childDefs.map((tool) => toAgentTool(tool, nestedHost)),
+      tools: toAgentTools(childDefs, nestedHost),
       messages: [],
     },
   });


### PR DESCRIPTION
## Problem

Connector-discovered tools can contain characters such as `.`, `/`, whitespace, accents, or Unicode. Pi forwards these names as function tool names, but OpenAI Codex requires names matching `^[a-zA-Z0-9_-]+$` and no longer than 64 characters.

This can fail with an error such as:

```text
[StringParam] [tools[7].name] [invalid_string]
Invalid 'tools[7].name': string does not match pattern.
```

## Fix

- Sanitize only the model-facing tool name at the Pi boundary.
- Preserve the original connector name for execution and dispatch.
- Keep already-valid names unchanged.
- Ensure normalized names are unique and within the provider limit.
- Apply the same boundary to nested subagents.

## Tests

- `pnpm verify:fast`
- `pnpm check`
- `pnpm lint`
- `git diff --check`

The tests cover punctuation, whitespace, Unicode, long names, deterministic collision handling, and protection against shadowing valid tool names.
