### PR TITLE
Add locked-down production auto-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: ci
 on:
   push:
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -44,3 +48,44 @@ jobs:
         env:
           DATABASE_URL: postgres://rakazo:rakazo@127.0.0.1:5433/rakazo
       - run: pnpm verify:fast
+
+  deploy-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [lint, check, verify-fast]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: production
+      cancel-in-progress: false
+    environment:
+      name: production
+      url: https://app.rakazo.com
+    steps:
+      - name: Configure production SSH identity
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
+        run: |
+          test -n "$SSH_PRIVATE_KEY"
+          test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$HOME/.ssh/rakazo-production"
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/rakazo-production" "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/rakazo-production" >/dev/null
+
+      - name: Deploy successful main revision
+        env:
+          SSH_HOST: ${{ secrets.PRODUCTION_SSH_HOST }}
+          SSH_USER: ${{ secrets.PRODUCTION_SSH_USER }}
+        run: |
+          test -n "$SSH_HOST"
+          test -n "$SSH_USER"
+          ssh -F /dev/null \
+            -i "$HOME/.ssh/rakazo-production" \
+            -o BatchMode=yes \
+            -o ConnectTimeout=15 \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            "$SSH_USER@$SSH_HOST" deploy-main

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,7 @@ artifacts
 backups
 verify-report
 .astro
+.deploy.lock
+.last-deployed-revision
 design/
 PRODUCT_PLAN.md


### PR DESCRIPTION
## Summary
- deploy successful pushes to `main` only after lint, type checks, and fast verification pass
- use GitHub Environment secrets with strict SSH host-key verification
- connect through a dedicated server key restricted to a root-owned deploy command
- serialize deployments and keep deployment metadata out of Git

## Security
- no host address, SSH key, account identifier, or private configuration is committed
- pull-request workflows cannot run the production deploy job
- the deploy key cannot open a shell, allocate a PTY, or forward ports

## Verification
- `pnpm lint`
- `pnpm verify:fast` (166 passed, 18 skipped in offline mode)
- Gitleaks staged diff scan
- forced-command key tested against production
- production health and direct-origin rejection verified after manual deploy of current `main`