### PR TITLE
Make production deployment opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
       - run: pnpm verify:fast
 
   deploy-production:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      vars.PRODUCTION_DEPLOY_ENABLED == 'true'
     needs: [lint, check, verify-fast]
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- gate the production deployment job behind `PRODUCTION_DEPLOY_ENABLED=true`
- keep production deploys enabled for the official repository via a repository variable
- let forks and self-hosted copies skip the private production job by default

## Validation
- `pnpm exec prettier --check .github/workflows/ci.yml`
- `gitleaks dir --no-banner --redact .github`
- reviewed staged diff; only the public workflow changed and no private infrastructure data was added