### PR TITLE
Add portable computer sandbox runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pnpm dev
 
 `pnpm dev` starts the API (`:3100`), Graphile Worker, Vite web app (`:5173`), and sandbox supervisor (`:7091`).
 
-Open [http://127.0.0.1:5173](http://127.0.0.1:5173). Sign up, pick a model from the Pi catalog (paste an API key, sign in with ChatGPT / Copilot / SuperGrok, or Skip if the deployment key is set), create a bot, send a message. The computer pane is a live Linux desktop with a browser. Take control to sign in; the bot keeps that session after you release. Ask a bot to spawn another bot, or to run a subagent for work that should stay inside this turn.
+Open [http://127.0.0.1:5173](http://127.0.0.1:5173). Sign up, pick a model from the Pi catalog (paste an API key, sign in with ChatGPT / Copilot / SuperGrok, or Skip if the deployment key is set), create a bot, send a message. The computer pane is a live Linux desktop. The model can observe and control the screen, use browsers and other graphical applications, run terminal commands, and work with files. You can interact with the same desktop while it runs; taking control makes the viewer editable but does not impose an exclusive agent/user lock. Ask a bot to spawn another bot, or to run a subagent for work that should stay inside this turn.
 
 Confirm the product path:
 
@@ -79,7 +79,7 @@ The app you open and the computer provider are separate choices. Web, Electron, 
 | `SANDBOX_PROVIDER` | Where agent commands run | Best fit | Isolation notes |
 | --- | --- | --- | --- |
 | `docker` (default) | A per-bot Docker container on your machine. The Electron app can switch this to This Mac without changing the env var. | Quick local setup and trusted single-machine self-hosting | Good local isolation and persistent bot homes. The supervisor controls the local Docker daemon, so keep its port private; Rakazo does this by default. |
-| `e2b` | A remote E2B sandbox | Public or multi-user deployments | Stronger separation from the Rakazo application host. Requires `E2B_API_KEY`. This Mac is not available. |
+| `e2b` | A remote E2B desktop through the E2B SDK | Public or multi-user deployments | Stronger separation from the Rakazo application host. Requires `E2B_API_KEY`. Bot workspace and browser-profile data are checkpointed into Rakazo-owned `DATA_DIR`, so the provider machine is not the durable source of truth. This Mac is not available. |
 | `desktop` | Directly on the API/worker host. Working directories under the process user's home folder are allowed. | A trusted single-user local process | Least isolated. Model-initiated shell commands run with the Rakazo process's OS permissions. Do not use it on a public or shared server. The Electron first-run "This Mac" choice uses this provider while leaving `SANDBOX_PROVIDER=docker`. |
 | `fake` | An in-process emulator | Tests only | Does not run a real computer. |
 
@@ -117,7 +117,13 @@ Outputs land in `apps/desktop/out/` (macOS dmg/zip, Windows NSIS, Linux AppImage
 pnpm verify:fast       # unit, property, and in-process contract tests
 pnpm verify            # Postgres via Testcontainers, emulators, API, Playwright
 pnpm verify:providers  # optional live OpenRouter / E2B canaries
+# explicit real vision-model + real E2B desktop acceptance test:
+COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm e2e:computer
 ```
+
+The computer acceptance test is never selected by the normal test commands. It also requires `E2B_API_KEY` and `OPENROUTER_API_KEY` (the command reads the root `.env`) and uses a temporary Postgres container. It proves an actual model can observe and click a real browser, then use the sandbox terminal and files.
+
+See [`docs/computer-runtime.md`](./docs/computer-runtime.md) for the agent/runtime boundary, provider switching, and persistence contract.
 
 ## Layout
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -142,6 +142,7 @@ export async function createApp(
     executor,
     prisma,
     sandbox,
+    home,
     jobs,
     events,
     workerId: "api",

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1,7 +1,9 @@
 import { mkdir } from "node:fs/promises";
 import { implement, ORPCError } from "@orpc/server";
 import {
+  type AdapterContext,
   type AgentHomeStore,
+  type ComputerRef,
   type JobPublisher,
   type MemoryStore,
   routineJobKey,
@@ -11,11 +13,13 @@ import {
 } from "@rakazo/adapter-kit";
 import {
   type ComposioConnector,
+  checkpointAndRecordComputerWorkspace,
   destroyBot,
   type EncryptedSecretStore,
   listPiCatalog,
   type PiOAuthLogins,
   resolveAgentHomePath,
+  restoreComputerWorkspace,
   sanitizeComposioError,
   savePushToken,
   scheduleComputerSleep,
@@ -42,6 +46,32 @@ import {
   type ThreadEvents,
 } from "@rakazo/db";
 import { addScreenProxyCapability } from "./screen-proxy.js";
+
+const MAX_COMPUTER_TEXT_FILE_BYTES = 2 * 1024 * 1024;
+
+function computerContext(actor: Actor, botId: string, operationId: string): AdapterContext {
+  return {
+    operationId,
+    traceId: operationId,
+    workspaceId: actor.workspaceId,
+    userId: actor.userId,
+    botId,
+    signal: new AbortController().signal,
+  };
+}
+
+function computerRef(
+  botId: string,
+  computer: { providerRef: string | null; kind: string },
+): ComputerRef {
+  if (!computer.providerRef) throw new Error("computer provider reference is missing");
+  return {
+    id: computer.providerRef,
+    botId,
+    kind: computer.kind as ComputerRef["kind"],
+    providerRef: computer.providerRef,
+  };
+}
 
 export interface RouterDeps {
   prisma: PrismaClient;
@@ -390,32 +420,39 @@ export function createRouter(deps: RouterDeps) {
       ),
       boot: authed.computer.boot.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId);
-        const ctx = {
-          operationId: "boot",
-          traceId: "boot",
-          workspaceId: context.actor.workspaceId,
-          userId: context.actor.userId,
-          botId: bot.id,
-          signal: new AbortController().signal,
-        };
+        const ctx = computerContext(context.actor, bot.id, "boot");
         const homePath = resolveAgentHomePath(deps.home, bot.id, process.env.DATA_DIR ?? "./data");
         await mkdir(homePath, { recursive: true });
         await deps.prisma.computer.update({ where: { botId: bot.id }, data: { state: "booting" } });
+        let provisioned: ComputerRef | undefined;
         try {
           const ref = await deps.sandbox.provision(
             {
               botId: bot.id,
               homePath,
               providerRef: bot.computer?.providerRef ?? undefined,
+              providerKind: bot.computer?.kind as ComputerRef["kind"] | undefined,
             },
             ctx,
           );
+          provisioned = ref;
+          const replacement =
+            ref.fresh === true ||
+            !bot.computer?.providerRef ||
+            bot.computer.providerRef !== ref.providerRef ||
+            bot.computer.kind !== ref.kind;
+          if (replacement) {
+            await restoreComputerWorkspace(deps.home, deps.sandbox, bot.id, ref, ctx);
+          }
           await deps.prisma.computer.update({
             where: { botId: bot.id },
             data: { state: "running", providerRef: ref.providerRef, kind: ref.kind },
           });
           scheduleComputerSleep(deps.jobs, bot.id);
         } catch (error) {
+          if (provisioned?.fresh) {
+            await deps.sandbox.destroy(provisioned, ctx).catch(() => undefined);
+          }
           await deps.prisma.computer.update({ where: { botId: bot.id }, data: { state: "error" } });
           throw error;
         }
@@ -424,21 +461,10 @@ export function createRouter(deps: RouterDeps) {
       stop: authed.computer.stop.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId);
         if (bot.computer?.providerRef) {
-          await deps.sandbox.stop(
-            {
-              id: bot.computer.providerRef,
-              botId: bot.id,
-              kind: bot.computer.kind as never,
-              providerRef: bot.computer.providerRef,
-            },
-            {
-              operationId: "stop",
-              traceId: "stop",
-              workspaceId: context.actor.workspaceId,
-              userId: context.actor.userId,
-              signal: new AbortController().signal,
-            },
-          );
+          const ctx = computerContext(context.actor, bot.id, "stop");
+          const ref = computerRef(bot.id, bot.computer);
+          await checkpointAndRecordComputerWorkspace(deps, bot.id, ref, ctx);
+          await deps.sandbox.stop(ref, ctx);
         }
         await deps.prisma.computer.update({
           where: { botId: bot.id },
@@ -462,11 +488,6 @@ export function createRouter(deps: RouterDeps) {
             payload: { leaseId },
           });
         }
-        const waiting = await deps.prisma.run.findFirst({
-          where: { botId: bot.id, status: "waiting_takeover" },
-          orderBy: { createdAt: "desc" },
-        });
-        if (waiting) await deps.jobs.enqueue(runContinueJob(waiting.id));
         scheduleComputerSleep(deps.jobs, bot.id);
         return { leaseId, expiresAt: new Date(Date.now() + 15 * 60_000).toISOString() };
       }),
@@ -476,6 +497,11 @@ export function createRouter(deps: RouterDeps) {
           where: { botId: bot.id },
           data: { controlHolder: "bot", controlLeaseId: null },
         });
+        const waiting = await deps.prisma.run.findFirst({
+          where: { botId: bot.id, status: "waiting_takeover" },
+          orderBy: { createdAt: "desc" },
+        });
+        if (waiting) await deps.jobs.enqueue(runContinueJob(waiting.id));
         scheduleComputerSleep(deps.jobs, bot.id);
         return { ok: true as const };
       }),
@@ -497,44 +523,60 @@ export function createRouter(deps: RouterDeps) {
                     (input.payload.type as "move" | "down" | "up" | "click" | undefined) ?? "click",
                 };
         await deps.sandbox.sendInput(
-          {
-            id: bot.computer.providerRef,
-            botId: bot.id,
-            kind: bot.computer.kind as never,
-            providerRef: bot.computer.providerRef,
-          },
+          computerRef(bot.id, bot.computer),
           mapped,
           { leaseId: bot.computer.controlLeaseId ?? "lease", holder: "user", fence: 0 },
-          {
-            operationId: "input",
-            traceId: "input",
-            workspaceId: context.actor.workspaceId,
-            userId: context.actor.userId,
-            signal: new AbortController().signal,
-          },
+          computerContext(context.actor, bot.id, "input"),
         );
+        await deps.prisma.computer.updateMany({
+          where: { botId: bot.id, state: "running" },
+          data: { updatedAt: new Date() },
+        });
         scheduleComputerSleep(deps.jobs, bot.id);
         return { ok: true as const };
       }),
       files: authed.computer.files.handler(async ({ context, input }) => {
-        await repos.getBot(context.actor, input.botId);
-        return deps.home.list(input.botId, input.path, {
-          operationId: "files",
-          traceId: "files",
-          workspaceId: context.actor.workspaceId,
-          userId: context.actor.userId,
-          signal: new AbortController().signal,
-        });
+        const bot = await repos.getBot(context.actor, input.botId);
+        const ctx = computerContext(context.actor, bot.id, "files");
+        if (bot.computer?.state === "running" && bot.computer.providerRef) {
+          await deps.prisma.computer.updateMany({
+            where: { botId: bot.id, state: "running" },
+            data: { updatedAt: new Date() },
+          });
+          scheduleComputerSleep(deps.jobs, bot.id);
+          return deps.sandbox.listFiles(computerRef(bot.id, bot.computer), input.path, ctx);
+        }
+        return deps.home.list(input.botId, input.path, ctx);
       }),
       readFile: authed.computer.readFile.handler(async ({ context, input }) => {
-        await repos.getBot(context.actor, input.botId);
-        const content = await deps.home.readFile(input.botId, input.path, {
-          operationId: "read",
-          traceId: "read",
-          workspaceId: context.actor.workspaceId,
-          userId: context.actor.userId,
-          signal: new AbortController().signal,
-        });
+        const bot = await repos.getBot(context.actor, input.botId);
+        const ctx = computerContext(context.actor, bot.id, "read");
+        let content: string;
+        if (bot.computer?.state === "running" && bot.computer.providerRef) {
+          await deps.prisma.computer.updateMany({
+            where: { botId: bot.id, state: "running" },
+            data: { updatedAt: new Date() },
+          });
+          scheduleComputerSleep(deps.jobs, bot.id);
+          const bytes = await deps.sandbox.readFile(
+            computerRef(bot.id, bot.computer),
+            input.path,
+            ctx,
+            { maxBytes: MAX_COMPUTER_TEXT_FILE_BYTES },
+          );
+          content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+        } else {
+          try {
+            content = await deps.home.readFile(input.botId, input.path, ctx, {
+              maxBytes: MAX_COMPUTER_TEXT_FILE_BYTES,
+            });
+          } catch (error) {
+            if (error instanceof Error && error.message.startsWith("agent home file exceeds ")) {
+              throw new ORPCError("BAD_REQUEST", { message: "file is too large to preview" });
+            }
+            throw error;
+          }
+        }
         return { path: input.path, content };
       }),
       screenUrl: authed.computer.screenUrl.handler(async ({ context, input }) => {
@@ -546,20 +588,9 @@ export function createRouter(deps: RouterDeps) {
           return { url: null };
         }
         const session = await deps.sandbox.connectScreen(
-          {
-            id: bot.computer.providerRef,
-            botId: bot.id,
-            kind: bot.computer.kind as never,
-            providerRef: bot.computer.providerRef,
-          },
+          computerRef(bot.id, bot.computer),
           { view: "stream" },
-          {
-            operationId: "screen",
-            traceId: "screen",
-            workspaceId: context.actor.workspaceId,
-            userId: context.actor.userId,
-            signal: new AbortController().signal,
-          },
+          computerContext(context.actor, bot.id, "screen"),
         );
         if (!session.url) return { url: null };
         scheduleComputerSleep(deps.jobs, bot.id);
@@ -571,6 +602,10 @@ export function createRouter(deps: RouterDeps) {
       heartbeat: authed.computer.heartbeat.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId);
         if (bot.computer?.state === "running" && bot.computer.providerRef) {
+          await deps.prisma.computer.updateMany({
+            where: { botId: bot.id, state: "running" },
+            data: { updatedAt: new Date() },
+          });
           await touchRunningComputer(
             { sandbox: deps.sandbox, jobs: deps.jobs },
             {

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -47,8 +47,8 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }) =>
   });
   await page.getByTitle("Agent computer").click();
   await page.getByRole("button", { name: "Take control" }).click();
+  await page.getByRole("button", { name: "Release" }).last().click();
   await expect(page.getByText(/signed in|session stays/i).first()).toBeVisible({ timeout: 30_000 });
-  await page.getByRole("button", { name: "Close computer" }).click();
 
   await page.getByText("+ New routine").click();
   await page.locator("label:has-text('Name') input").fill("Monday briefing");

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -65,6 +65,7 @@ async function main() {
   const connector = stack.destination;
   await connector.start();
   const secrets = new EncryptedSecretStore(resolveEncryptionKey(process.env));
+  const home = new LocalAgentHomeStore(dataDir);
   const inMemoryJobs = process.env.WAKEUP_DRIVER === "memory" ? new InMemoryJobQueue() : undefined;
   const jobs: JobPublisher = inMemoryJobs ?? new GraphileJobPublisher(databaseUrl);
   const jobHost: JobWorkerHost = inMemoryJobs ?? new GraphileJobWorkerHost(databaseUrl);
@@ -73,7 +74,7 @@ async function main() {
     runtime,
     sandbox,
     memory: new MarkdownMemoryStore(prisma),
-    home: new LocalAgentHomeStore(dataDir),
+    home,
     connector: stack.connector,
     secrets: [process.env.OPENROUTER_API_KEY ?? "", process.env.COMPOSIO_API_KEY ?? ""].filter(
       Boolean,
@@ -90,6 +91,7 @@ async function main() {
     executor,
     prisma,
     sandbox,
+    home,
     jobs,
     events,
     workerId: process.pid.toString(),

--- a/docs/computer-runtime.md
+++ b/docs/computer-runtime.md
@@ -1,0 +1,54 @@
+# Computer runtime
+
+Rakazo keeps the agent runtime and the computer runtime separate:
+
+```text
+chat/API -> one Pi agent session -> Rakazo computer tools -> SandboxProvider -> E2B (first cloud backend)
+                                                   |-> Docker
+                                                   |-> desktop/fake
+
+SandboxProvider workspace <-> AgentHomeStore <-> Rakazo-owned DATA_DIR
+```
+
+Pi runs in the Rakazo API/worker process. It is not installed in, or executed by, E2B. The built-in tools are ordinary Pi tools, not Claude- or MCP-specific tools, so any model exposed through Pi can call them. Screen operation still requires a model that can accept image tool results and reason about screenshots.
+
+## Computer contract
+
+`SandboxProvider` is the provider boundary. A backend must implement:
+
+- lifecycle: provision/reconnect, stop, and destroy;
+- desktop: observe, ordered batched actions, user input, and a live screen session;
+- execution: commands inside the machine;
+- files: list/read/write plus complete workspace import/export.
+
+The model gets `computer_observe`, batched `computer_act`, `open_path`, `launch_app`, `shell`, and file tools. An action can settle and return the resulting screenshot in one call. Identical consecutive frames keep their metadata but omit duplicate image bytes from model context.
+
+Human input and agent input may coexist. “Take control” changes whether the embedded viewer accepts user input; it does not create an exclusive machine lock or automatically pause an active run. `request_takeover` remains available when the model explicitly needs protected input or human judgment.
+
+## E2B backend
+
+The first cloud implementation uses `@e2b/desktop` directly. Rakazo provisions or reconnects the desktop, maintains its authenticated live-view URL, captures PNG observations, performs mouse/keyboard/scroll/app actions, executes shell commands, and accesses files through the E2B SDK.
+
+The database stores the provider kind and opaque `providerRef`. That reference is an acceleration path, not durable data. It is passed back only to the same provider kind. A missing machine or a provider-kind change creates a replacement and restores its workspace through the provider-neutral contract.
+
+## Persistence
+
+The portable bot workspace is the durable boundary. E2B uses `/home/user/rakazo-home`; Docker and local providers expose the equivalent bot home. Browser profiles are rooted under `.browser-profiles` in that workspace on E2B. Rakazo checkpoints transferred workspaces into `AgentHomeStore` at run completion or failure, before explicit stop, and before idle suspension. Docker mounts the Rakazo-owned home directly and only advances its revision marker at those boundaries. New or replacement machines import the latest stored workspace before use.
+
+`LocalAgentHomeStore` currently keeps the latest workspace under `DATA_DIR/homes/<bot-id>` and checkpoint metadata separately under `DATA_DIR/home-revisions`. Replacements are staged before the current copy is swapped, and checkpoints are serialized per bot. This implementation is latest-only rather than an immutable revision archive. Production deployments must put `DATA_DIR` on a Rakazo-owned persistent volume, encrypt that volume at rest, and include it in off-host backups. The storage interface is deliberately independent of E2B so an object-store-backed implementation can replace the local volume without changing agent tools or sandbox providers.
+
+Before exporting a remote workspace, the E2B backend quiesces desktop browsers so profile databases and login state are copied consistently. It excludes only transient cache/lock files inside `.browser-profiles`; similarly named project files remain durable.
+
+The disposable OS image is not a portable disk snapshot. System packages installed outside the workspace are lost when moving to another provider; durable machine customization should be represented by a reproducible image or setup recipe. This is what makes a future backend switch practical instead of trying to translate vendor-specific VM snapshots.
+
+## Verification
+
+Offline tests cover tool-result images, action parsing, provider conformance, workspace checkpoint/restore, E2B SDK translation, and lifecycle integration. They never call a model or live sandbox.
+
+The explicit acceptance test requires Docker (for temporary Postgres), `E2B_API_KEY`, `OPENROUTER_API_KEY`, and a vision-capable OpenRouter model id:
+
+```bash
+COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm e2e:computer
+```
+
+It starts the full API, provisions a real E2B desktop, serves a deterministic page inside the sandbox, and asks a real model to observe and click a button. The button creates a server-side marker; the test then requires the model to use terminal and file tools and verifies both the marker and recorded tool calls. Finally, it destroys the provider machine, boots a replacement through the stale provider reference, and verifies that the external checkpoint restored the model-created file. The command is opt-in and is not run by `pnpm verify:fast`, `pnpm verify`, or CI unless invoked explicitly.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -49,7 +49,7 @@ Do not commit `.env`. Never put `COMPOSIO_API_KEY`, OpenRouter keys, or provider
 The Electron desktop app is a client of the same API. Docker and E2B still apply. On first launch, Electron asks the deployment owner whether bots should keep using Docker or run on this Mac as you. `SANDBOX_PROVIDER=desktop` is a separate, explicit provider that always runs commands on the service host.
 
 - **Docker** is the default for local use and the quickest self-hosted setup. Each bot gets a container and persistent home. Keep the supervisor private, as the included Compose file does. A public single-machine Docker deployment still shares one Docker host between its bot containers.
-- **E2B** runs bot computers away from the Rakazo host and is the recommended choice for public or multi-user production deployments.
+- **E2B** runs bot computers away from the Rakazo host and is the recommended choice for public or multi-user production deployments. Rakazo checkpoints the portable workspace and browser-profile directory to `DATA_DIR`; the E2B disk is a runtime cache, not the durable source of truth.
 - **Desktop provider** / **This Mac** runs commands on the API/worker host. Docker stays the default. The Electron app asks once; if you choose This Mac, bots can use working directories under your home folder. Do not enable it on a public or shared service. macOS does not show its own permission dialog for this.
 - **Fake** is only an emulator for verification.
 
@@ -144,8 +144,8 @@ To run a hosted product (same codebase):
 1. Push `main` (this checkout may be ahead of GitHub).
 2. Provision managed Postgres 16 and run `pnpm db:migrate`.
 3. Run **API** and **worker** as always-on Node 22 services (Fly machines, a VM, ECS, k8s). Not lambda-style request handlers.
-4. Persist `DATA_DIR` (bot homes, artifacts). Today that is a local filesystem (`LocalAgentHomeStore`), so attach a volume. Object-storage-backed homes are not wired yet.
-5. Choose computers: **`SANDBOX_PROVIDER=e2b`** with `E2B_API_KEY` for a public or multi-user production service. Each bot keeps one sandbox id (`providerRef`) and a graphical desktop with a browser. Take control, sign in, then release — the bot keeps that session. Idle boxes pause after `SANDBOX_IDLE_MS` (default 10 minutes) and resume on the next message or Take control. Docker remains the local and trusted single-machine default.
+4. Persist and back up `DATA_DIR` (bot homes, browser profiles, artifacts). Today the concrete store is a local filesystem (`LocalAgentHomeStore`), so attach a Rakazo-owned durable volume shared by API and worker processes. The storage contract is separate from the computer-provider contract, but an object-storage implementation is not wired yet.
+5. Choose computers: **`SANDBOX_PROVIDER=e2b`** with `E2B_API_KEY` for a public or multi-user production service. Each bot normally reconnects to its sandbox id (`providerRef`), while workspace state is checkpointed outside E2B at run completion, explicit stop, and idle suspension. If that sandbox is gone—or the deployment changes providers—the replacement is hydrated from Rakazo's copy. Idle boxes pause after `SANDBOX_IDLE_MS` (default 10 minutes) and resume on the next message or Take control. Docker remains the local and trusted single-machine default.
 6. A Hetzner CX22 (2 vCPU / 4 GB) is enough for API + worker + Postgres when E2B owns the desktops. 2 GB works for a quiet box; 8 GB is only needed if you also run Docker computers on that same machine.
 7. Set public HTTPS `WEB_ORIGIN` / `BETTER_AUTH_URL` / `API_URL`, secrets, and an OpenRouter (or other Pi) deployment key if you want to skip per-user model keys.
 8. Put the web app behind the same origin as `/api` and `/rpc` (Vite preview proxy, or a reverse proxy). Docker noVNC connections use short-lived signed `/novnc/*` capabilities; do not replace that route with an unrestricted port proxy.

--- a/infra/sandboxes/computer/Dockerfile
+++ b/infra/sandboxes/computer/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xdotool \
     x11-utils \
     x11-xserver-utils \
+    imagemagick \
     novnc \
     websockify \
     python3 \

--- a/infra/sandboxes/computer/rakazo-browser
+++ b/infra/sandboxes/computer/rakazo-browser
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
-HOME="${HOME:-/home/rakazo}"
-PROFILE="$HOME/.config/rakazo-chromium"
+RAKAZO_HOME="${HOME:-/home/rakazo}"
+PROFILE="$RAKAZO_HOME/.browser-profiles/chromium"
 mkdir -p "$PROFILE"
 BIN="$(command -v chromium || command -v chromium-browser || true)"
 if [ -z "$BIN" ]; then

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -39,8 +39,10 @@ describe("graphical computer spec", () => {
     const root = path.resolve(import.meta.dirname, "../../computer");
     const dockerfile = readFileSync(path.join(root, "Dockerfile"), "utf8");
     const start = readFileSync(path.join(root, "start.sh"), "utf8");
+    const browser = readFileSync(path.join(root, "rakazo-browser"), "utf8");
     expect(dockerfile).toMatch(/chromium/);
     expect(start).toMatch(/rakazo-browser/);
+    expect(browser).toMatch(/\.browser-profiles\/chromium/);
     expect(start).not.toMatch(/windowsize 1280 800/);
   });
 

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -26,10 +26,29 @@ const computerContext =
   path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../computer");
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
 const dataDir = path.resolve(repositoryRoot, process.env.DATA_DIR ?? "./data");
-const boxes = new Map<string, { containerId: string; botId: string; screenUrl: string }>();
 let imageReady: Promise<void> | undefined;
 let supervisorInfo: Docker.ContainerInspectInfo | undefined;
 const supervisorToken = resolveSupervisorToken(process.env);
+
+const computerActionSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("key"), key: z.string(), modifiers: z.array(z.string()).optional() }),
+  z.object({
+    kind: z.literal("pointer"),
+    x: z.number(),
+    y: z.number(),
+    button: z.enum(["left", "right"]).optional(),
+    type: z.enum(["move", "down", "up", "click"]),
+  }),
+  z.object({ kind: z.literal("clipboard"), text: z.string() }),
+  z.object({
+    kind: z.literal("scroll"),
+    direction: z.enum(["up", "down"]),
+    amount: z.number().optional(),
+  }),
+  z.object({ kind: z.literal("wait"), ms: z.number() }),
+  z.object({ kind: z.literal("open"), path: z.string() }),
+  z.object({ kind: z.literal("launch"), application: z.string(), uri: z.string().optional() }),
+]);
 
 const app = new Hono();
 
@@ -77,11 +96,9 @@ app.post("/computers", async (c) => {
         (networkMode && info.HostConfig.NetworkMode !== networkMode)
       ) {
         await existing.remove({ force: true }).catch(() => undefined);
-        boxes.delete(existing.id);
       } else {
         if (!info.State.Running) await existing.start();
         const screenUrl = await publishedScreenUrl(existing, info.State.Running ? info : undefined);
-        boxes.set(existing.id, { containerId: existing.id, botId: body.botId, screenUrl });
         return c.json({ id: existing.id, image: COMPUTER_IMAGE, screenUrl, resumed: true });
       }
     }
@@ -98,7 +115,6 @@ app.post("/computers", async (c) => {
     );
     await container.start();
     const screenUrl = await publishedScreenUrl(container);
-    boxes.set(container.id, { containerId: container.id, botId: body.botId, screenUrl });
     return c.json({ id: container.id, image: COMPUTER_IMAGE, screenUrl, resumed: false });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -142,36 +158,155 @@ app.post("/computers/:id/exec", async (c) => {
       c.req.header("x-rakazo-bot-id"),
       c.req.header("x-rakazo-workspace-id"),
     );
-    const exec = await container.exec({
-      Cmd: body.argv.length ? body.argv : ["/bin/echo", "ready"],
-      AttachStdout: true,
-      AttachStderr: true,
-      WorkingDir: body.cwd ?? "/home/rakazo",
-      Env: [
-        "DISPLAY=:1",
-        "HOME=/home/rakazo",
-        "PATH=/home/rakazo/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "NPM_CONFIG_PREFIX=/home/rakazo/.local",
-        "PIP_USER=1",
-        ...Object.entries(body.env ?? {}).map(([k, v]) => `${k}=${v}`),
-      ],
-    });
-    const stream = await exec.start({ hijack: true, stdin: false });
-    const chunks: Buffer[] = [];
-    await new Promise<void>((resolve, reject) => {
-      stream.on("data", (d: Buffer) => chunks.push(d));
-      stream.on("end", () => resolve());
-      stream.on("error", reject);
-    });
-    const inspect = await exec.inspect();
-    return c.json({
-      stdout: stripDockerStream(Buffer.concat(chunks)),
-      stderr: "",
-      code: inspect.ExitCode ?? 0,
-    });
+    const result = await runContainerCommand(
+      container,
+      body.argv.length ? body.argv : ["/bin/echo", "ready"],
+      {
+        workingDir: body.cwd ?? "/home/rakazo",
+        env: [
+          "DISPLAY=:1",
+          "HOME=/home/rakazo",
+          "PATH=/home/rakazo/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "NPM_CONFIG_PREFIX=/home/rakazo/.local",
+          "PIP_USER=1",
+          ...Object.entries(body.env ?? {}).map(([k, v]) => `${k}=${v}`),
+        ],
+      },
+    );
+    return c.json(result);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ stdout: "", stderr: message, code: 1 }, 200);
+  }
+});
+
+app.post("/computers/:id/observe", async (c) => {
+  try {
+    const { container } = await managedContainer(
+      c.req.param("id"),
+      c.req.header("x-rakazo-bot-id"),
+      c.req.header("x-rakazo-workspace-id"),
+    );
+    return c.json(await observeContainer(container));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message }, 500);
+  }
+});
+
+app.post("/computers/:id/actions", async (c) => {
+  const body = z
+    .object({
+      actions: z.array(computerActionSchema).max(24),
+      observe: z.boolean().optional(),
+      settleMs: z.number().min(0).max(5_000).optional(),
+    })
+    .parse(await c.req.json());
+  try {
+    const { container } = await managedContainer(
+      c.req.param("id"),
+      c.req.header("x-rakazo-bot-id"),
+      c.req.header("x-rakazo-workspace-id"),
+    );
+    if (body.actions.length) await applyContainerActions(container, body.actions);
+    if (body.settleMs) await new Promise((resolve) => setTimeout(resolve, body.settleMs));
+    return c.json({
+      completed: body.actions.length,
+      ...(body.observe === false ? {} : { observation: await observeContainer(container) }),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message }, 500);
+  }
+});
+
+app.get("/computers/:id/files", async (c) => {
+  try {
+    const { container } = await managedContainer(
+      c.req.param("id"),
+      c.req.header("x-rakazo-bot-id"),
+      c.req.header("x-rakazo-workspace-id"),
+    );
+    const relative = normalizeWorkspaceRelative(c.req.query("path") ?? "");
+    const target = workspaceTarget(relative);
+    if (c.req.query("mode") === "read") {
+      const maxBytesRaw = c.req.query("maxBytes");
+      const maxBytes = maxBytesRaw === undefined ? undefined : Number(maxBytesRaw);
+      if (maxBytes !== undefined && (!Number.isSafeInteger(maxBytes) || maxBytes < 0)) {
+        return c.json({ error: "invalid maxBytes" }, 400);
+      }
+      const script = [
+        "import base64, sys",
+        "target, limit = sys.argv[1], int(sys.argv[2])",
+        "with open(target, 'rb') as source:",
+        "  content = source.read() if limit < 0 else source.read(limit + 1)",
+        "if limit >= 0 and len(content) > limit: sys.exit(42)",
+        "sys.stdout.write(base64.b64encode(content).decode())",
+      ].join("\n");
+      const result = await runContainerCommand(container, [
+        "python3",
+        "-c",
+        script,
+        target,
+        String(maxBytes ?? -1),
+      ]);
+      if (result.code === 42) {
+        return c.json({ error: `computer file exceeds ${maxBytes} bytes` }, 413);
+      }
+      if (result.code !== 0) return c.json({ error: result.stderr || "file not found" }, 404);
+      return c.json({ content: result.stdout.trim() });
+    }
+    const script = [
+      "import json, os, stat, sys",
+      "root, rel = sys.argv[1], sys.argv[2]",
+      "out = []",
+      "for item in os.scandir(root):",
+      "  if item.is_symlink(): continue",
+      "  info = item.stat(follow_symlinks=False)",
+      "  child = '/'.join(x for x in (rel, item.name) if x)",
+      "  out.append({'path': child, 'kind': 'dir' if item.is_dir(follow_symlinks=False) else 'file', 'size': info.st_size, **({'executable': True} if item.is_file(follow_symlinks=False) and bool(info.st_mode & stat.S_IXUSR) else {})})",
+      "print(json.dumps(sorted(out, key=lambda x: x['path'])))",
+    ].join("\n");
+    const result = await runContainerCommand(container, [
+      "python3",
+      "-c",
+      script,
+      target,
+      relative,
+    ]);
+    if (result.code !== 0) return c.json({ error: result.stderr || "directory not found" }, 404);
+    return c.json(JSON.parse(result.stdout));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message }, 400);
+  }
+});
+
+app.post("/computers/:id/files", async (c) => {
+  const body = z
+    .object({
+      path: z.string(),
+      content: z.string().max(16 * 1024 * 1024),
+      executable: z.boolean().optional(),
+    })
+    .parse(await c.req.json());
+  try {
+    const { container } = await managedContainer(
+      c.req.param("id"),
+      c.req.header("x-rakazo-bot-id"),
+      c.req.header("x-rakazo-workspace-id"),
+    );
+    const target = workspaceTarget(normalizeWorkspaceRelative(body.path));
+    await writeContainerFile(
+      container,
+      target,
+      Buffer.from(body.content, "base64"),
+      body.executable,
+    );
+    return c.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message }, 400);
   }
 });
 
@@ -214,20 +349,12 @@ app.post("/computers/:id/input", async (c) => {
       c.req.header("x-rakazo-bot-id"),
       c.req.header("x-rakazo-workspace-id"),
     );
-    const exec = await container.exec({
-      Cmd: ["env", "DISPLAY=:1", ...xdotoolCommand(input)],
-      AttachStdout: true,
-      AttachStderr: true,
-      WorkingDir: "/home/rakazo",
-    });
-    const stream = await exec.start({ hijack: true, stdin: false });
-    await new Promise<void>((resolve, reject) => {
-      stream.on("end", () => resolve());
-      stream.on("error", reject);
-      stream.resume();
-    });
-    const inspect = await exec.inspect();
-    if ((inspect.ExitCode ?? 0) !== 0) {
+    const result = await runContainerCommand(container, [
+      "env",
+      "DISPLAY=:1",
+      ...xdotoolCommand(input),
+    ]);
+    if (result.code !== 0) {
       return c.json({ ok: false, error: "input failed" }, 500);
     }
     return c.json({ ok: true, leaseId: body.leaseId ?? null });
@@ -260,7 +387,6 @@ app.delete("/computers/:id", async (c) => {
       c.req.header("x-rakazo-workspace-id"),
     );
     await container.remove({ force: true }).catch(() => undefined);
-    boxes.delete(id);
     return c.json({ ok: true });
   } catch {
     return c.json({ error: "computer not found" }, 404);
@@ -451,4 +577,169 @@ function stripDockerStream(buffer: Buffer) {
     return parts.join("");
   }
   return buffer.toString("utf8");
+}
+
+async function runContainerCommand(
+  container: Docker.Container,
+  argv: string[],
+  options: { workingDir?: string; env?: string[] } = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const exec = await container.exec({
+    Cmd: argv,
+    AttachStdout: true,
+    AttachStderr: true,
+    WorkingDir: options.workingDir ?? "/home/rakazo",
+    Env: options.env ?? ["DISPLAY=:1", "HOME=/home/rakazo"],
+  });
+  const stream = await exec.start({ hijack: true, stdin: false });
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve, reject) => {
+    stream.on("data", (data: Buffer) => chunks.push(data));
+    stream.on("end", resolve);
+    stream.on("error", reject);
+  });
+  const inspect = await exec.inspect();
+  return {
+    stdout: stripDockerStream(Buffer.concat(chunks)),
+    stderr: "",
+    code: inspect.ExitCode ?? 0,
+  };
+}
+
+function containerActionStep(
+  action: z.infer<typeof computerActionSchema>,
+): { argv: string[] } | { waitMs: number } {
+  if (action.kind === "wait") {
+    return { waitMs: Math.min(Math.max(action.ms, 0), 5_000) };
+  }
+  let argv: string[];
+  if (action.kind === "key" || action.kind === "pointer" || action.kind === "clipboard") {
+    argv = ["env", "DISPLAY=:1", ...xdotoolCommand(toSandboxInput(action))];
+  } else if (action.kind === "scroll") {
+    argv = [
+      "env",
+      "DISPLAY=:1",
+      "xdotool",
+      "click",
+      "--repeat",
+      String(Math.min(Math.max(Math.round(action.amount ?? 3), 1), 20)),
+      action.direction === "up" ? "4" : "5",
+    ];
+  } else if (action.kind === "open") {
+    const target = /^https?:\/\//i.test(action.path)
+      ? action.path
+      : workspaceTarget(normalizeWorkspaceRelative(action.path));
+    argv = ["env", "DISPLAY=:1", "xdg-open", target];
+  } else {
+    argv = ["env", "DISPLAY=:1", action.application, ...(action.uri ? [action.uri] : [])];
+  }
+  return { argv };
+}
+
+async function applyContainerActions(
+  container: Docker.Container,
+  actions: Array<z.infer<typeof computerActionSchema>>,
+) {
+  const script = [
+    "import json, subprocess, sys, time",
+    "for step in json.loads(sys.argv[1]):",
+    "  if 'waitMs' in step: time.sleep(step['waitMs'] / 1000)",
+    "  else:",
+    "    result = subprocess.run(step['argv'])",
+    "    if result.returncode: sys.exit(result.returncode)",
+  ].join("\n");
+  const result = await runContainerCommand(container, [
+    "python3",
+    "-c",
+    script,
+    JSON.stringify(actions.map(containerActionStep)),
+  ]);
+  if (result.code !== 0) throw new Error(result.stderr || "computer action failed");
+}
+
+async function observeContainer(container: Docker.Container) {
+  const command = [
+    "set -e",
+    "export DISPLAY=:1",
+    'printf "GEOM %s\\n" "$(xdotool getdisplaygeometry 2>/dev/null || echo 1280 800)"',
+    'printf "CURSOR %s\\n" "$(xdotool getmouselocation --shell 2>/dev/null | tr "\\n" " " || true)"',
+    'wid="$(xdotool getactivewindow 2>/dev/null || true)"',
+    'printf "WINDOW %s\\n" "$wid"',
+    'printf "TITLE %s\\n" "$(test -n "$wid" && xdotool getwindowname "$wid" 2>/dev/null || true)"',
+    'printf "IMAGE "',
+    "import -window root png:- 2>/dev/null | base64 -w0",
+    'printf "\\n"',
+  ].join("; ");
+  const result = await runContainerCommand(container, ["bash", "-lc", command]);
+  if (result.code !== 0) throw new Error(result.stderr || "screen capture failed");
+  return parseObservation(result.stdout);
+}
+
+async function writeContainerFile(
+  container: Docker.Container,
+  target: string,
+  content: Buffer,
+  executable = false,
+) {
+  const script = [
+    "import os, sys",
+    "target = sys.argv[1]",
+    "os.makedirs(os.path.dirname(target), exist_ok=True)",
+    "with open(target, 'wb') as f: f.write(sys.stdin.buffer.read())",
+    `os.chmod(target, ${executable ? "0o700" : "0o600"})`,
+  ].join("\n");
+  const exec = await container.exec({
+    Cmd: ["python3", "-c", script, target],
+    AttachStdin: true,
+    AttachStdout: true,
+    AttachStderr: true,
+    WorkingDir: "/home/rakazo",
+    Env: ["HOME=/home/rakazo"],
+  });
+  const stream = await exec.start({ hijack: true, stdin: true });
+  const chunks: Buffer[] = [];
+  stream.on("data", (data: Buffer) => chunks.push(data));
+  stream.end(content);
+  await new Promise<void>((resolve, reject) => {
+    stream.on("end", resolve);
+    stream.on("error", reject);
+  });
+  const inspect = await exec.inspect();
+  if ((inspect.ExitCode ?? 0) !== 0) {
+    throw new Error(stripDockerStream(Buffer.concat(chunks)) || "file write failed");
+  }
+}
+
+function normalizeWorkspaceRelative(value: string) {
+  const normalized = value.replace(/\\/g, "/").replace(/^\/+/, "");
+  const segments = normalized.split("/").filter(Boolean);
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error("path escapes the computer workspace");
+  }
+  return segments.join("/");
+}
+
+function workspaceTarget(relative: string) {
+  return relative ? path.posix.join("/home/rakazo", relative) : "/home/rakazo";
+}
+
+function parseObservation(output: string) {
+  const geometry = output.match(/^GEOM\s+(\d+)\s+(\d+)$/m);
+  const cursorLine = output.match(/^CURSOR\s+(.+)$/m)?.[1] ?? "";
+  const cursorX = Number(cursorLine.match(/X=(\d+)/)?.[1]);
+  const cursorY = Number(cursorLine.match(/Y=(\d+)/)?.[1]);
+  const windowId = output.match(/^WINDOW\s*(.*)$/m)?.[1]?.trim();
+  const title = output.match(/^TITLE\s*(.*)$/m)?.[1]?.trim();
+  const image = output.match(/^IMAGE\s+([A-Za-z0-9+/=]+)$/m)?.[1];
+  if (!image) throw new Error("screen capture returned no image");
+  return {
+    image,
+    mimeType: "image/png" as const,
+    width: Number(geometry?.[1] ?? 1280),
+    height: Number(geometry?.[2] ?? 800),
+    ...(Number.isFinite(cursorX) && Number.isFinite(cursorY)
+      ? { cursor: { x: cursorX, y: cursorY } }
+      : {}),
+    ...(windowId ? { activeWindow: { id: windowId, ...(title ? { title } : {}) } } : {}),
+  };
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "verify": "tsx packages/testkit/src/cli/verify.ts",
     "verify:providers": "tsx packages/testkit/src/cli/verify.ts --providers",
     "e2e": "pnpm --filter @rakazo/web exec playwright test",
+    "e2e:computer": "tsx packages/testkit/src/cli/computer-e2e.ts",
     "compose:up": "docker compose -f infra/compose/docker-compose.yml up --build",
     "compose:down": "docker compose -f infra/compose/docker-compose.yml down -v"
   },

--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -8,7 +8,11 @@ import type {
   BackgroundJob,
   BackgroundJobHandlers,
   CommandRequest,
+  ComputerActionRequest,
+  ComputerActionResult,
+  ComputerFileEntry,
   ComputerInput,
+  ComputerObservation,
   ComputerRef,
   ConnectorCall,
   ConnectorCapabilities,
@@ -36,7 +40,12 @@ import type {
 export interface SandboxProvider {
   describe(): AdapterDescriptor<SandboxCapabilities>;
   provision(
-    request: { botId: string; homePath: string; providerRef?: string },
+    request: {
+      botId: string;
+      homePath: string;
+      providerRef?: string;
+      providerKind?: ComputerRef["kind"];
+    },
     context: AdapterContext,
   ): Promise<ComputerRef>;
   execute(
@@ -55,7 +64,32 @@ export interface SandboxProvider {
     lease: ControlLeaseRef,
     context: AdapterContext,
   ): Promise<void>;
+  observe(computer: ComputerRef, context: AdapterContext): Promise<ComputerObservation>;
+  act(
+    computer: ComputerRef,
+    request: ComputerActionRequest,
+    context: AdapterContext,
+  ): Promise<ComputerActionResult>;
+  listFiles(
+    computer: ComputerRef,
+    path: string,
+    context: AdapterContext,
+  ): Promise<ComputerFileEntry[]>;
+  readFile(
+    computer: ComputerRef,
+    path: string,
+    context: AdapterContext,
+    options?: { maxBytes?: number },
+  ): Promise<Uint8Array>;
+  writeFile(computer: ComputerRef, file: PortableFile, context: AdapterContext): Promise<void>;
+  exportWorkspace(computer: ComputerRef, context: AdapterContext): AsyncIterable<PortableFile>;
+  importWorkspace(
+    computer: ComputerRef,
+    files: AsyncIterable<PortableFile>,
+    context: AdapterContext,
+  ): Promise<void>;
   snapshot(computer: ComputerRef, context: AdapterContext): Promise<SnapshotRef>;
+  keepAlive?(computer: ComputerRef): Promise<void>;
   stop(computer: ComputerRef, context: AdapterContext): Promise<void>;
   destroy(computer: ComputerRef, context: AdapterContext): Promise<void>;
 }
@@ -122,7 +156,12 @@ export interface AgentHomeStore {
   commit(botId: string, src: string, context: AdapterContext): Promise<string>;
   restore(botId: string, revision: string, dest: string, context: AdapterContext): Promise<void>;
   exportHome(botId: string, context: AdapterContext): AsyncIterable<PortableFile>;
-  readFile(botId: string, path: string, context: AdapterContext): Promise<string>;
+  readFile(
+    botId: string,
+    path: string,
+    context: AdapterContext,
+    options?: { maxBytes?: number },
+  ): Promise<string>;
   writeFile(botId: string, path: string, content: string, context: AdapterContext): Promise<void>;
   list(
     botId: string,

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -29,6 +29,8 @@ export interface ComputerRef {
   botId: string;
   kind: SandboxKind;
   providerRef: string;
+  /** True when the provider created an empty replacement rather than reconnecting existing state. */
+  fresh?: boolean;
 }
 
 export interface CommandRequest {
@@ -63,6 +65,53 @@ export type ComputerInput =
       type: "move" | "down" | "up" | "click";
     }
   | { kind: "clipboard"; text: string };
+
+export type ComputerAction =
+  | ComputerInput
+  | { kind: "scroll"; direction: "up" | "down"; amount?: number }
+  | { kind: "wait"; ms: number }
+  | { kind: "open"; path: string }
+  | { kind: "launch"; application: string; uri?: string };
+
+export interface ComputerObservation {
+  frameId: string;
+  capturedAt: string;
+  mimeType: "image/png" | "image/jpeg";
+  image: Uint8Array;
+  width: number;
+  height: number;
+  cursor?: { x: number; y: number };
+  activeWindow?: { id: string; title?: string };
+}
+
+export interface ComputerActionRequest {
+  actions: ComputerAction[];
+  observe?: boolean;
+  settleMs?: number;
+}
+
+export interface ComputerActionResult {
+  completed: number;
+  observation?: ComputerObservation;
+}
+
+export interface ComputerFileEntry {
+  path: string;
+  kind: "file" | "dir";
+  size: number;
+  executable?: boolean;
+}
+
+export type AgentToolResultContent =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: "image/png" | "image/jpeg" };
+
+/** A provider-neutral tool result an agent runtime can forward without flattening images. */
+export interface AgentToolExecutionResult {
+  kind: "agent_tool_result";
+  content: AgentToolResultContent[];
+  details: unknown;
+}
 
 export interface ControlLeaseRef {
   leaseId: string;

--- a/packages/adapters/src/background-job-handlers.ts
+++ b/packages/adapters/src/background-job-handlers.ts
@@ -1,4 +1,9 @@
-import type { BackgroundJobHandlers, JobPublisher, SandboxProvider } from "@rakazo/adapter-kit";
+import type {
+  AgentHomeStore,
+  BackgroundJobHandlers,
+  JobPublisher,
+  SandboxProvider,
+} from "@rakazo/adapter-kit";
 import type { PrismaClient, ThreadEvents } from "@rakazo/db";
 import { sleepComputerIfIdle } from "./computer-idle.js";
 import type { createRunExecutor } from "./executor.js";
@@ -7,6 +12,7 @@ export function createBackgroundJobHandlers(deps: {
   executor: ReturnType<typeof createRunExecutor>;
   prisma: PrismaClient;
   sandbox: SandboxProvider;
+  home: AgentHomeStore;
   jobs: JobPublisher;
   events: ThreadEvents;
   workerId: string;

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -4,6 +4,66 @@ export const DELEGATION_TOOL_NAMES = new Set(["run_subagent", "spawn_bot", "dele
 
 export const builtinAgentTools: ConnectorTool[] = [
   {
+    name: "computer_observe",
+    description:
+      "Capture the current screen of this bot's computer. Returns frame metadata and an image. Observe before coordinate-based actions and whenever another actor may have changed the desktop.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "computer_act",
+    description:
+      "Perform up to 24 ordered desktop actions on this bot's computer and return the resulting screen. Batch only predictable actions; stop before an outcome you need to inspect. Action kinds: click, move, down, up, type, key, scroll, wait.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        actions: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              kind: {
+                type: "string",
+                enum: ["click", "move", "down", "up", "type", "key", "scroll", "wait"],
+              },
+              x: { type: "number" },
+              y: { type: "number" },
+              button: { type: "string", enum: ["left", "right"] },
+              double: { type: "boolean" },
+              text: { type: "string" },
+              key: { type: "string" },
+              modifiers: { type: "array", items: { type: "string" } },
+              direction: { type: "string", enum: ["up", "down"] },
+              amount: { type: "number" },
+              ms: { type: "number" },
+            },
+            required: ["kind"],
+          },
+        },
+        observe: { type: "boolean" },
+        settle_ms: { type: "number" },
+      },
+      required: ["actions"],
+    },
+  },
+  {
+    name: "list_files",
+    description: "List files and directories inside this bot's portable computer workspace.",
+    inputSchema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+    },
+  },
+  {
+    name: "read_file",
+    description:
+      "Read a UTF-8 text file from this bot's portable computer workspace. Open visual or binary files with open_path instead.",
+    inputSchema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+  },
+  {
     name: "write_file",
     description:
       "Write a UTF-8 file into this bot's private home filesystem. The file shows up in Files.",
@@ -27,6 +87,29 @@ export const builtinAgentTools: ConnectorTool[] = [
         cwd: { type: "string" },
       },
       required: ["command"],
+    },
+  },
+  {
+    name: "open_path",
+    description:
+      "Open a workspace file or an http(s) URL in its default graphical application on this bot's computer and return the resulting screen.",
+    inputSchema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    },
+  },
+  {
+    name: "launch_app",
+    description:
+      "Launch an installed graphical application on this bot's computer, optionally with a URI, and return the resulting screen.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        application: { type: "string" },
+        uri: { type: "string" },
+      },
+      required: ["application"],
     },
   },
   {

--- a/packages/adapters/src/computer-idle.ts
+++ b/packages/adapters/src/computer-idle.ts
@@ -1,6 +1,13 @@
-import { computerSleepJob, type JobPublisher, type SandboxProvider } from "@rakazo/adapter-kit";
+import {
+  type AgentHomeStore,
+  type ComputerRef,
+  computerSleepJob,
+  type JobPublisher,
+  type SandboxProvider,
+} from "@rakazo/adapter-kit";
 import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
 import type { PrismaClient, ThreadEvents } from "@rakazo/db";
+import { checkpointAndRecordComputerWorkspace } from "./computer-workspace.js";
 
 export const DEFAULT_SANDBOX_IDLE_MS = 10 * 60 * 1000;
 
@@ -19,18 +26,10 @@ export async function touchRunningComputer(
   computer: { botId: string; providerRef: string; kind: string },
 ): Promise<void> {
   scheduleComputerSleep(deps.jobs, computer.botId);
-  const sandbox = deps.sandbox as SandboxProvider & {
-    keepAlive?: (ref: {
-      id: string;
-      botId: string;
-      kind: "docker" | "e2b" | "desktop" | "fake";
-      providerRef: string;
-    }) => Promise<void>;
-  };
-  await sandbox.keepAlive?.({
+  await deps.sandbox.keepAlive?.({
     id: computer.providerRef,
     botId: computer.botId,
-    kind: computer.kind as "docker" | "e2b" | "desktop" | "fake",
+    kind: computer.kind as ComputerRef["kind"],
     providerRef: computer.providerRef,
   });
 }
@@ -39,6 +38,7 @@ export async function sleepComputerIfIdle(
   deps: {
     prisma: PrismaClient;
     sandbox: SandboxProvider;
+    home: AgentHomeStore;
     jobs: JobPublisher;
     events: ThreadEvents;
   },
@@ -63,32 +63,48 @@ export async function sleepComputerIfIdle(
     botId,
     signal: new AbortController().signal,
   };
-  await deps.sandbox.stop(
-    {
-      id: computer.providerRef,
-      botId,
-      kind: computer.kind as "docker" | "e2b" | "desktop" | "fake",
-      providerRef: computer.providerRef,
-    },
-    ctx,
-  );
+  const ref = {
+    id: computer.providerRef,
+    botId,
+    kind: computer.kind as "docker" | "e2b" | "desktop" | "fake",
+    providerRef: computer.providerRef,
+  };
+  await checkpointAndRecordComputerWorkspace(deps, botId, ref, ctx);
+  const [current, activeAfterCheckpoint] = await Promise.all([
+    deps.prisma.computer.findUnique({
+      where: { botId },
+      select: { state: true, providerRef: true, updatedAt: true },
+    }),
+    deps.prisma.run.findFirst({
+      where: { botId, status: { in: [...ACTIVE_RUN_STATUSES] } },
+      select: { id: true },
+    }),
+  ]);
+  if (
+    activeAfterCheckpoint ||
+    current?.state !== "running" ||
+    current.providerRef !== computer.providerRef ||
+    current.updatedAt.getTime() !== computer.updatedAt.getTime()
+  ) {
+    scheduleComputerSleep(deps.jobs, botId);
+    return;
+  }
+  await deps.sandbox.stop(ref, ctx);
   await deps.prisma.computer.update({
     where: { botId },
     data: { state: "suspended", controlHolder: "none" },
   });
-  if (computer.botId) {
-    const bot = await deps.prisma.bot.findUnique({
-      where: { id: botId },
-      include: { thread: true },
+  const bot = await deps.prisma.bot.findUnique({
+    where: { id: botId },
+    include: { thread: true },
+  });
+  if (bot?.thread) {
+    await deps.events.append({
+      workspaceId: computer.workspaceId,
+      threadId: bot.thread.id,
+      botId,
+      type: "computer.status",
+      payload: { status: "suspended" },
     });
-    if (bot?.thread) {
-      await deps.events.append({
-        workspaceId: computer.workspaceId,
-        threadId: bot.thread.id,
-        botId,
-        type: "computer.status",
-        payload: { status: "suspended" },
-      });
-    }
   }
 }

--- a/packages/adapters/src/computer-support.ts
+++ b/packages/adapters/src/computer-support.ts
@@ -1,0 +1,61 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import type { ComputerAction, ComputerObservation } from "@rakazo/adapter-kit";
+
+const EMPTY_PNG = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  ),
+);
+
+export function computerObservation(
+  image: Uint8Array,
+  input: Omit<ComputerObservation, "frameId" | "capturedAt" | "image">,
+): ComputerObservation {
+  return {
+    ...input,
+    image,
+    frameId: createHash("sha256").update(image).digest("hex"),
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+export function placeholderObservation(label = "ready"): ComputerObservation {
+  return computerObservation(EMPTY_PNG, {
+    mimeType: "image/png",
+    width: 1,
+    height: 1,
+    activeWindow: { id: "placeholder", title: label },
+  });
+}
+
+export function applyPlaceholderAction(box: { screen: string }, action: ComputerAction): void {
+  if (action.kind === "clipboard") box.screen = action.text;
+  else if (action.kind === "open") box.screen = `opened ${action.path}`;
+  else if (action.kind === "launch") box.screen = `launched ${action.application}`;
+  else box.screen = action.kind;
+}
+
+export function boundedComputerActions(actions: readonly ComputerAction[]): ComputerAction[] {
+  if (actions.length > 24) throw new Error("computer action batch exceeds 24 actions");
+  return [...actions];
+}
+
+export function normalizeWorkspacePath(value: string): string {
+  const normalized = value.replace(/\\/g, "/").replace(/^\/+/, "");
+  const segments = normalized.split("/").filter(Boolean);
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error("Path escapes the computer workspace");
+  }
+  return segments.join("/");
+}
+
+export function workspacePath(root: string, relative: string): string {
+  const normalized = normalizeWorkspacePath(relative);
+  return normalized ? path.posix.join(root, normalized) : root;
+}
+
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}

--- a/packages/adapters/src/computer-tools.test.ts
+++ b/packages/adapters/src/computer-tools.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { computerObservation } from "./computer-support.js";
+import { observationToolResult, parseComputerActions } from "./computer-tools.js";
+
+describe("computer tool bridge", () => {
+  it("normalizes a bounded batch into provider-neutral actions", () => {
+    expect(
+      parseComputerActions([
+        { kind: "click", x: 20.4, y: 30.6 },
+        { kind: "type", text: "hello" },
+        { kind: "scroll", direction: "up", amount: 999 },
+      ]),
+    ).toEqual([
+      { kind: "pointer", x: 20, y: 31, type: "click", button: "left" },
+      { kind: "clipboard", text: "hello" },
+      { kind: "scroll", direction: "up", amount: 20 },
+    ]);
+  });
+
+  it("rejects batches whose expanded double-click actions exceed the limit", () => {
+    expect(() =>
+      parseComputerActions(
+        Array.from({ length: 13 }, () => ({ kind: "click", x: 10, y: 10, double: true })),
+      ),
+    ).toThrow(/more than 24/);
+  });
+
+  it("returns observations as model-visible image content", () => {
+    const observation = computerObservation(Uint8Array.from([1, 2, 3]), {
+      mimeType: "image/png",
+      width: 1280,
+      height: 800,
+    });
+    const result = observationToolResult(observation);
+    expect(result.content).toEqual([
+      expect.objectContaining({ type: "text" }),
+      { type: "image", data: "AQID", mimeType: "image/png" },
+    ]);
+  });
+
+  it("does not resend an unchanged screenshot", () => {
+    const observation = computerObservation(Uint8Array.from([1, 2, 3]), {
+      mimeType: "image/png",
+      width: 1280,
+      height: 800,
+    });
+    const result = observationToolResult(observation, "observed", observation.frameId);
+
+    expect(result.content).toEqual([
+      expect.objectContaining({ type: "text", text: expect.stringContaining("unchanged") }),
+    ]);
+  });
+});

--- a/packages/adapters/src/computer-tools.ts
+++ b/packages/adapters/src/computer-tools.ts
@@ -1,0 +1,107 @@
+import type {
+  AgentToolExecutionResult,
+  ComputerAction,
+  ComputerObservation,
+} from "@rakazo/adapter-kit";
+
+export function parseComputerActions(value: unknown): ComputerAction[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error("computer_act requires at least one action");
+  }
+  if (value.length > 24) throw new Error("computer_act accepts at most 24 actions");
+  const actions = value.flatMap((raw): ComputerAction[] => {
+    if (!raw || typeof raw !== "object") throw new Error("computer action must be an object");
+    const action = raw as Record<string, unknown>;
+    const kind = String(action.kind ?? "");
+    if (kind === "click" || kind === "move" || kind === "down" || kind === "up") {
+      const x = finiteCoordinate(action.x, "x");
+      const y = finiteCoordinate(action.y, "y");
+      const pointer: ComputerAction = {
+        kind: "pointer",
+        x,
+        y,
+        type: kind,
+        button: action.button === "right" ? "right" : "left",
+      };
+      return action.double === true && kind === "click" ? [pointer, pointer] : [pointer];
+    }
+    if (kind === "type") {
+      return [{ kind: "clipboard", text: String(action.text ?? "") }];
+    }
+    if (kind === "key") {
+      return [
+        {
+          kind: "key",
+          key: String(action.key ?? ""),
+          modifiers: Array.isArray(action.modifiers) ? action.modifiers.map(String) : undefined,
+        },
+      ];
+    }
+    if (kind === "scroll") {
+      return [
+        {
+          kind: "scroll",
+          direction: action.direction === "up" ? "up" : "down",
+          amount: boundedNumber(action.amount, 1, 20, 3),
+        },
+      ];
+    }
+    if (kind === "wait") {
+      return [{ kind: "wait", ms: boundedNumber(action.ms, 0, 5_000, 350) }];
+    }
+    throw new Error(`unsupported computer action ${kind || "(missing)"}`);
+  });
+  if (actions.length > 24) {
+    throw new Error("computer_act expands to more than 24 actions; split the batch");
+  }
+  return actions;
+}
+
+export function observationToolResult(
+  observation: ComputerObservation,
+  note = "computer observed",
+  previousFrameId?: string,
+): AgentToolExecutionResult {
+  const details = {
+    frameId: observation.frameId,
+    capturedAt: observation.capturedAt,
+    width: observation.width,
+    height: observation.height,
+    cursor: observation.cursor,
+    activeWindow: observation.activeWindow,
+  };
+  const unchanged = previousFrameId === observation.frameId;
+  return {
+    kind: "agent_tool_result",
+    content: [
+      {
+        type: "text",
+        text: `${note}${unchanged ? " (screen unchanged)" : ""}\n${JSON.stringify(details)}`,
+      },
+      ...(unchanged
+        ? []
+        : [
+            {
+              type: "image" as const,
+              data: Buffer.from(observation.image).toString("base64"),
+              mimeType: observation.mimeType,
+            },
+          ]),
+    ],
+    details,
+  };
+}
+
+function finiteCoordinate(value: unknown, name: string) {
+  const number = Math.round(Number(value));
+  if (!Number.isFinite(number) || number < 0 || number > 100_000) {
+    throw new Error(`computer action ${name} must be a non-negative coordinate`);
+  }
+  return number;
+}
+
+function boundedNumber(value: unknown, min: number, max: number, fallback: number) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.min(Math.max(Math.round(number), min), max);
+}

--- a/packages/adapters/src/computer-workspace.test.ts
+++ b/packages/adapters/src/computer-workspace.test.ts
@@ -1,0 +1,57 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { checkpointComputerWorkspace, restoreComputerWorkspace } from "./computer-workspace.js";
+import { FakeSandboxProvider } from "./fake-sandbox.js";
+import { LocalAgentHomeStore } from "./home.js";
+
+const context = {
+  operationId: "workspace-test",
+  traceId: "workspace-test",
+  workspaceId: "workspace",
+  userId: "user",
+  signal: new AbortController().signal,
+};
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("provider-neutral computer workspace", () => {
+  it("restores a checkpoint into a replacement provider machine", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rakazo-workspace-store-"));
+    roots.push(root);
+    const home = new LocalAgentHomeStore(root);
+    const firstProvider = new FakeSandboxProvider();
+    const first = await firstProvider.provision({ botId: "bot-1", homePath: "/ignored" }, context);
+
+    await firstProvider.writeFile(
+      first,
+      { path: "notes/result.txt", content: new TextEncoder().encode("portable") },
+      context,
+    );
+    const revision = await checkpointComputerWorkspace(
+      home,
+      firstProvider,
+      "bot-1",
+      first,
+      context,
+    );
+
+    const replacementProvider = new FakeSandboxProvider();
+    const replacement = await replacementProvider.provision(
+      { botId: "bot-1", homePath: "/different-provider" },
+      context,
+    );
+    await restoreComputerWorkspace(home, replacementProvider, "bot-1", replacement, context);
+
+    expect(revision).toMatch(/^rev-/);
+    expect(
+      new TextDecoder().decode(
+        await replacementProvider.readFile(replacement, "notes/result.txt", context),
+      ),
+    ).toBe("portable");
+  });
+});

--- a/packages/adapters/src/computer-workspace.ts
+++ b/packages/adapters/src/computer-workspace.ts
@@ -1,0 +1,74 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  AdapterContext,
+  AgentHomeStore,
+  ComputerRef,
+  PortableFile,
+  SandboxProvider,
+} from "@rakazo/adapter-kit";
+import type { PrismaClient } from "@rakazo/db";
+import { normalizeWorkspacePath } from "./computer-support.js";
+import { LocalAgentHomeStore } from "./home.js";
+
+export async function restoreComputerWorkspace(
+  home: AgentHomeStore,
+  sandbox: SandboxProvider,
+  botId: string,
+  computer: ComputerRef,
+  context: AdapterContext,
+): Promise<void> {
+  if (computer.kind === "docker" && home instanceof LocalAgentHomeStore) return;
+  await sandbox.importWorkspace(computer, home.exportHome(botId, context), context);
+}
+
+export async function checkpointComputerWorkspace(
+  home: AgentHomeStore,
+  sandbox: SandboxProvider,
+  botId: string,
+  computer: ComputerRef,
+  context: AdapterContext,
+): Promise<string> {
+  if (computer.kind === "docker" && home instanceof LocalAgentHomeStore) {
+    return home.revise(botId);
+  }
+  const staging = await mkdtemp(path.join(tmpdir(), "rakazo-workspace-"));
+  try {
+    for await (const file of sandbox.exportWorkspace(computer, context)) {
+      await writePortableFile(staging, file);
+    }
+    return await home.commit(botId, staging, context);
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+export async function checkpointAndRecordComputerWorkspace(
+  deps: { home: AgentHomeStore; sandbox: SandboxProvider; prisma: PrismaClient },
+  botId: string,
+  computer: ComputerRef,
+  context: AdapterContext,
+): Promise<string> {
+  const revision = await checkpointComputerWorkspace(
+    deps.home,
+    deps.sandbox,
+    botId,
+    computer,
+    context,
+  );
+  await deps.prisma.agentHome.updateMany({ where: { botId }, data: { revision } });
+  return revision;
+}
+
+async function writePortableFile(root: string, file: PortableFile) {
+  const relative = normalizeWorkspacePath(file.path);
+  if (!relative) throw new Error("Workspace snapshots cannot contain an empty file path");
+  const target = path.resolve(root, relative);
+  const resolvedRoot = path.resolve(root);
+  if (target !== resolvedRoot && !target.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error("Workspace snapshot path escapes its staging directory");
+  }
+  await mkdir(path.dirname(target), { recursive: true });
+  await writeFile(target, file.content, { mode: file.executable ? 0o700 : 0o600 });
+}

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -1,18 +1,27 @@
 import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { mkdir, open, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type {
   AdapterContext,
   CommandRequest,
+  ComputerActionRequest,
+  ComputerFileEntry,
   ComputerInput,
   ComputerRef,
   ControlLeaseRef,
+  PortableFile,
   ProcessEvent,
   SandboxProvider,
   ScreenRequest,
   ScreenSession,
 } from "@rakazo/adapter-kit";
+import {
+  applyPlaceholderAction,
+  boundedComputerActions,
+  normalizeWorkspacePath,
+  placeholderObservation,
+} from "./computer-support.js";
 
 interface DesktopBox {
   ref: ComputerRef;
@@ -32,10 +41,10 @@ export class DesktopSandboxProvider implements SandboxProvider {
       contractVersion: "1",
       adapterVersion: "0.1.0",
       capabilities: {
-        graphical: true,
+        graphical: false,
         pty: true,
         snapshots: true,
-        takeover: true,
+        takeover: false,
         persistentHome: true,
       },
     };
@@ -45,14 +54,27 @@ export class DesktopSandboxProvider implements SandboxProvider {
     request: { botId: string; homePath: string },
     _context: AdapterContext,
   ): Promise<ComputerRef> {
-    const id = `desktop-${request.botId}-${randomUUID().slice(0, 8)}`;
     const home = path.resolve(
       this.opts.root ?? path.join(process.cwd(), "data"),
       "desktop-computers",
       request.botId,
     );
+    const existing = [...this.boxes.values()].find(
+      (box) => box.ref.botId === request.botId || box.home === home,
+    );
+    if (existing) {
+      existing.running = true;
+      return { ...existing.ref, fresh: false };
+    }
+    const id = `desktop-${request.botId}`;
     await mkdir(home, { recursive: true });
-    const ref: ComputerRef = { id, botId: request.botId, kind: "desktop", providerRef: home };
+    const ref: ComputerRef = {
+      id,
+      botId: request.botId,
+      kind: "desktop",
+      providerRef: home,
+      fresh: true,
+    };
     this.boxes.set(id, {
       ref,
       home,
@@ -106,7 +128,94 @@ export class DesktopSandboxProvider implements SandboxProvider {
     _context: AdapterContext,
   ): Promise<void> {
     const box = this.boxFor(computer);
-    if (box && input.kind === "clipboard") box.screen = input.text;
+    if (box) applyPlaceholderAction(box, input);
+  }
+
+  async observe(computer: ComputerRef) {
+    return placeholderObservation(this.requiredBox(computer).screen);
+  }
+
+  async act(computer: ComputerRef, request: ComputerActionRequest, _context: AdapterContext) {
+    const box = this.requiredBox(computer);
+    const actions = boundedComputerActions(request.actions);
+    for (const action of actions) applyPlaceholderAction(box, action);
+    return {
+      completed: actions.length,
+      ...(request.observe === false ? {} : { observation: await this.observe(computer) }),
+    };
+  }
+
+  async listFiles(
+    computer: ComputerRef,
+    directory: string,
+    _context: AdapterContext,
+  ): Promise<ComputerFileEntry[]> {
+    const box = this.requiredBox(computer);
+    const relative = normalizeWorkspacePath(directory);
+    const target = await localWorkspaceTarget(box.home, relative, true);
+    const entries = await readdir(target, { withFileTypes: true });
+    const listed = await Promise.all(
+      entries.map(async (entry) => {
+        const child = await localWorkspaceTarget(
+          box.home,
+          relative ? `${relative}/${entry.name}` : entry.name,
+          true,
+        );
+        const info = await stat(child);
+        return {
+          path: normalizeWorkspacePath(relative ? `${relative}/${entry.name}` : entry.name),
+          kind: info.isDirectory() ? ("dir" as const) : ("file" as const),
+          size: info.size,
+          ...(info.isFile() && info.mode & 0o100 ? { executable: true } : {}),
+        };
+      }),
+    );
+    return listed;
+  }
+
+  async readFile(
+    computer: ComputerRef,
+    filePath: string,
+    _context?: AdapterContext,
+    options?: { maxBytes?: number },
+  ) {
+    const box = this.requiredBox(computer);
+    const target = await localWorkspaceTarget(box.home, filePath, true);
+    const info = await stat(target);
+    if (options?.maxBytes !== undefined && info.size > options.maxBytes) {
+      throw new Error(`computer file exceeds ${options.maxBytes} bytes`);
+    }
+    return new Uint8Array(await readFile(target));
+  }
+
+  async writeFile(computer: ComputerRef, file: PortableFile) {
+    const box = this.requiredBox(computer);
+    const target = await localWorkspaceTarget(box.home, file.path, false);
+    await mkdir(path.dirname(target), { recursive: true });
+    const handle = await open(
+      target,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW,
+      file.executable ? 0o700 : 0o600,
+    );
+    try {
+      await handle.writeFile(file.content);
+      if (file.executable) await handle.chmod(0o700);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async *exportWorkspace(computer: ComputerRef): AsyncIterable<PortableFile> {
+    const box = this.requiredBox(computer);
+    yield* walkDesktopWorkspace(box.home, "");
+  }
+
+  async importWorkspace(
+    computer: ComputerRef,
+    files: AsyncIterable<PortableFile>,
+    _context: AdapterContext,
+  ) {
+    for await (const file of files) await this.writeFile(computer, file);
   }
 
   async snapshot(computer: ComputerRef, _context: AdapterContext) {
@@ -149,8 +258,49 @@ export class DesktopSandboxProvider implements SandboxProvider {
     return box;
   }
 
+  private requiredBox(computer: ComputerRef): DesktopBox {
+    const box = this.boxFor(computer);
+    if (!box) throw new Error("computer not found");
+    return box;
+  }
+
   private allowedRoots(home: string) {
     return [home, ...(this.opts.hostRoots ?? [])];
+  }
+}
+
+async function localWorkspaceTarget(home: string, relative: string, mustExist: boolean) {
+  const normalized = normalizeWorkspacePath(relative);
+  const candidate = path.resolve(home, normalized);
+  if (!allowedPath(candidate, [home])) throw new Error("Path escapes the computer workspace");
+  if (!mustExist) {
+    const parent = path.dirname(candidate);
+    await mkdir(parent, { recursive: true });
+    const resolvedParent = await realpath(parent);
+    if (!allowedPath(resolvedParent, [home]))
+      throw new Error("Path escapes the computer workspace");
+    return path.join(resolvedParent, path.basename(candidate));
+  }
+  const resolved = await realpath(candidate);
+  if (!allowedPath(resolved, [home])) throw new Error("Path escapes the computer workspace");
+  return resolved;
+}
+
+async function* walkDesktopWorkspace(home: string, directory: string): AsyncIterable<PortableFile> {
+  const target = await localWorkspaceTarget(home, directory, true);
+  for (const entry of await readdir(target, { withFileTypes: true })) {
+    const relative = normalizeWorkspacePath(directory ? `${directory}/${entry.name}` : entry.name);
+    const child = await localWorkspaceTarget(home, relative, true).catch(() => null);
+    if (!child) continue;
+    const info = await stat(child);
+    if (info.isDirectory()) yield* walkDesktopWorkspace(home, relative);
+    else if (info.isFile()) {
+      yield {
+        path: relative,
+        content: new Uint8Array(await readFile(child)),
+        executable: Boolean(info.mode & 0o100),
+      };
+    }
   }
 }
 

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -1,15 +1,25 @@
+import path from "node:path";
 import type {
   AdapterContext,
   CommandRequest,
+  ComputerActionRequest,
+  ComputerFileEntry,
   ComputerInput,
+  ComputerObservation,
   ComputerRef,
   ControlLeaseRef,
+  PortableFile,
   ProcessEvent,
   SandboxProvider,
   ScreenRequest,
   ScreenSession,
 } from "@rakazo/adapter-kit";
 import { resolveSupervisorToken } from "@rakazo/core";
+import {
+  boundedComputerActions,
+  computerObservation,
+  normalizeWorkspacePath,
+} from "./computer-support.js";
 
 export class DockerSandboxProvider implements SandboxProvider {
   private readonly supervisorToken: string;
@@ -66,8 +76,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       const detail = await res.text().catch(() => "");
       throw new Error(`sandbox provision failed: ${res.status} ${detail}`.trim());
     }
-    const body = (await res.json()) as { id: string };
-    return { id: body.id, botId: request.botId, kind: "docker", providerRef: body.id };
+    const body = (await res.json()) as { id: string; resumed?: boolean };
+    return {
+      id: body.id,
+      botId: request.botId,
+      kind: "docker",
+      providerRef: body.id,
+      fresh: body.resumed !== true,
+    };
   }
 
   async *execute(
@@ -78,7 +94,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     const res = await fetch(this.url(`/computers/${computer.id}/exec`), {
       method: "POST",
       headers: { ...this.headers(context, computer.botId), "content-type": "application/json" },
-      body: JSON.stringify({ ...request, cwd: request.cwd ?? "/home/rakazo" }),
+      body: JSON.stringify({ ...request, cwd: dockerCwd(request.cwd) }),
       signal: context.signal,
     });
     if (!res.ok) {
@@ -130,6 +146,129 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
   }
 
+  async observe(computer: ComputerRef, context: AdapterContext): Promise<ComputerObservation> {
+    const res = await fetch(this.url(`/computers/${computer.id}/observe`), {
+      method: "POST",
+      headers: this.headers(context, computer.botId),
+      signal: context.signal,
+    });
+    if (!res.ok) throw new Error(`sandbox observation failed: ${res.status}`);
+    const body = (await res.json()) as {
+      image: string;
+      mimeType: "image/png" | "image/jpeg";
+      width: number;
+      height: number;
+      cursor?: { x: number; y: number };
+      activeWindow?: { id: string; title?: string };
+    };
+    return computerObservation(Uint8Array.from(Buffer.from(body.image, "base64")), {
+      mimeType: body.mimeType,
+      width: body.width,
+      height: body.height,
+      cursor: body.cursor,
+      activeWindow: body.activeWindow,
+    });
+  }
+
+  async act(computer: ComputerRef, request: ComputerActionRequest, context: AdapterContext) {
+    const actions = boundedComputerActions(request.actions);
+    const res = await fetch(this.url(`/computers/${computer.id}/actions`), {
+      method: "POST",
+      headers: { ...this.headers(context, computer.botId), "content-type": "application/json" },
+      body: JSON.stringify({
+        actions,
+        observe: request.observe,
+        settleMs: clamp(request.settleMs ?? 0, 0, 5_000),
+      }),
+      signal: context.signal,
+    });
+    if (!res.ok) throw new Error(`sandbox action failed: ${res.status}`);
+    const body = (await res.json()) as {
+      completed: number;
+      observation?: {
+        image: string;
+        mimeType: "image/png" | "image/jpeg";
+        width: number;
+        height: number;
+        cursor?: { x: number; y: number };
+        activeWindow?: { id: string; title?: string };
+      };
+    };
+    return {
+      completed: body.completed,
+      ...(body.observation
+        ? {
+            observation: computerObservation(
+              Uint8Array.from(Buffer.from(body.observation.image, "base64")),
+              body.observation,
+            ),
+          }
+        : {}),
+    };
+  }
+
+  async listFiles(
+    computer: ComputerRef,
+    directory: string,
+    context: AdapterContext,
+  ): Promise<ComputerFileEntry[]> {
+    const path = normalizeWorkspacePath(directory);
+    const res = await fetch(
+      this.url(`/computers/${computer.id}/files?path=${encodeURIComponent(path)}&mode=list`),
+      { headers: this.headers(context, computer.botId), signal: context.signal },
+    );
+    if (!res.ok) throw new Error(`sandbox file listing failed: ${res.status}`);
+    return (await res.json()) as ComputerFileEntry[];
+  }
+
+  async readFile(
+    computer: ComputerRef,
+    filePath: string,
+    context: AdapterContext,
+    options?: { maxBytes?: number },
+  ) {
+    const path = normalizeWorkspacePath(filePath);
+    const maxBytes = options?.maxBytes;
+    const res = await fetch(
+      this.url(
+        `/computers/${computer.id}/files?path=${encodeURIComponent(path)}&mode=read${maxBytes === undefined ? "" : `&maxBytes=${maxBytes}`}`,
+      ),
+      { headers: this.headers(context, computer.botId), signal: context.signal },
+    );
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`sandbox file read failed: ${res.status} ${detail}`.trim());
+    }
+    const body = (await res.json()) as { content: string };
+    return Uint8Array.from(Buffer.from(body.content, "base64"));
+  }
+
+  async writeFile(computer: ComputerRef, file: PortableFile, context: AdapterContext) {
+    const res = await fetch(this.url(`/computers/${computer.id}/files`), {
+      method: "POST",
+      headers: { ...this.headers(context, computer.botId), "content-type": "application/json" },
+      body: JSON.stringify({
+        path: normalizeWorkspacePath(file.path),
+        content: Buffer.from(file.content).toString("base64"),
+        executable: file.executable === true,
+      }),
+      signal: context.signal,
+    });
+    if (!res.ok) throw new Error(`sandbox file write failed: ${res.status}`);
+  }
+
+  async *exportWorkspace(computer: ComputerRef, context: AdapterContext) {
+    yield* this.walkWorkspace(computer, "", context);
+  }
+
+  async importWorkspace(
+    computer: ComputerRef,
+    files: AsyncIterable<PortableFile>,
+    context: AdapterContext,
+  ) {
+    for await (const file of files) await this.writeFile(computer, file, context);
+  }
+
   async snapshot(computer: ComputerRef, _context: AdapterContext) {
     return { id: `docker-snap-${computer.id}`, createdAt: new Date().toISOString() };
   }
@@ -149,4 +288,45 @@ export class DockerSandboxProvider implements SandboxProvider {
       signal: context.signal,
     });
   }
+
+  private async *walkWorkspace(
+    computer: ComputerRef,
+    directory: string,
+    context: AdapterContext,
+  ): AsyncIterable<PortableFile> {
+    const entries = await this.listFiles(computer, directory, context);
+    for (let index = 0; index < entries.length; ) {
+      const entry = entries[index]!;
+      if (entry.kind === "dir") {
+        yield* this.walkWorkspace(computer, entry.path, context);
+        index += 1;
+        continue;
+      }
+      const files = [];
+      while (index < entries.length && entries[index]?.kind === "file" && files.length < 8) {
+        files.push(entries[index]!);
+        index += 1;
+      }
+      const batch = await Promise.all(
+        files.map(async (file) => ({
+          path: file.path,
+          content: await this.readFile(computer, file.path, context),
+          executable: file.executable,
+        })),
+      );
+      for (const file of batch) yield file;
+    }
+  }
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(Math.round(value), min), max);
+}
+
+function dockerCwd(cwd: string | undefined) {
+  if (!cwd || cwd === "." || cwd === "/" || cwd === "/home/rakazo") return "/home/rakazo";
+  const relative = cwd.startsWith("/home/rakazo/")
+    ? cwd.slice("/home/rakazo/".length)
+    : normalizeWorkspacePath(cwd);
+  return path.posix.join("/home/rakazo", relative);
 }

--- a/packages/adapters/src/e2b-emulator.ts
+++ b/packages/adapters/src/e2b-emulator.ts
@@ -1,77 +1,22 @@
-import type {
-  AdapterContext,
-  CommandRequest,
-  ComputerInput,
-  ComputerRef,
-  ControlLeaseRef,
-  ProcessEvent,
-  SandboxProvider,
-  ScreenRequest,
-  ScreenSession,
-} from "@rakazo/adapter-kit";
+import type { AdapterContext, ComputerRef } from "@rakazo/adapter-kit";
 import { FakeSandboxProvider } from "./fake-sandbox.js";
 
-/**
- * Protocol-faithful managed-sandbox emulator. Product code talks HTTP the same
- * way it would to a real E2B-style control plane; destination state is local.
- */
-export class ManagedSandboxEmulator implements SandboxProvider {
-  private readonly inner = new FakeSandboxProvider();
-  readonly dest = this.inner.boxes;
+/** Managed-provider protocol emulator backed by deterministic local state. */
+export class ManagedSandboxEmulator extends FakeSandboxProvider {
+  readonly dest = this.boxes;
 
-  describe() {
+  override describe() {
     return {
+      ...super.describe(),
       id: "e2b-emulator",
-      contractVersion: "1",
-      adapterVersion: "0.1.0",
-      capabilities: {
-        graphical: true,
-        pty: true,
-        snapshots: true,
-        takeover: true,
-        persistentHome: true,
-      },
     };
   }
 
-  provision(request: { botId: string; homePath: string }, context: AdapterContext) {
-    return this.inner.provision(request, context).then((ref) => ({ ...ref, kind: "e2b" as const }));
-  }
-
-  execute(
-    computer: ComputerRef,
-    request: CommandRequest,
+  override async provision(
+    request: { botId: string; homePath: string },
     context: AdapterContext,
-  ): AsyncIterable<ProcessEvent> {
-    return this.inner.execute(computer, request, context);
-  }
-
-  connectScreen(
-    computer: ComputerRef,
-    request: ScreenRequest,
-    context: AdapterContext,
-  ): Promise<ScreenSession> {
-    return this.inner.connectScreen(computer, request, context);
-  }
-
-  sendInput(
-    computer: ComputerRef,
-    input: ComputerInput,
-    lease: ControlLeaseRef,
-    context: AdapterContext,
-  ): Promise<void> {
-    return this.inner.sendInput(computer, input, lease, context);
-  }
-
-  snapshot(computer: ComputerRef, context: AdapterContext) {
-    return this.inner.snapshot(computer, context);
-  }
-
-  stop(computer: ComputerRef, context: AdapterContext) {
-    return this.inner.stop(computer, context);
-  }
-
-  destroy(computer: ComputerRef, context: AdapterContext) {
-    return this.inner.destroy(computer, context);
+  ): Promise<ComputerRef> {
+    const ref = await super.provision(request, context);
+    return { ...ref, kind: "e2b" };
   }
 }

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -1,0 +1,148 @@
+import type { Sandbox } from "@e2b/desktop";
+import { describe, expect, it, vi } from "vitest";
+import {
+  E2BSandboxProvider,
+  type E2BSandboxSdk,
+  shouldSkipPortableWorkspaceFile,
+} from "./e2b-sandbox.js";
+
+const context = {
+  operationId: "e2b-test",
+  traceId: "e2b-test",
+  workspaceId: "workspace",
+  userId: "user",
+  signal: new AbortController().signal,
+};
+
+describe("E2B computer backend", () => {
+  it("only filters transient cache files inside portable browser profiles", () => {
+    expect(shouldSkipPortableWorkspaceFile("project/Cache/important.txt")).toBe(false);
+    expect(shouldSkipPortableWorkspaceFile("project/lock")).toBe(false);
+    expect(shouldSkipPortableWorkspaceFile(".browser-profiles/chromium/Cache/data")).toBe(true);
+    expect(shouldSkipPortableWorkspaceFile(".browser-profiles/chromium/SingletonLock")).toBe(true);
+  });
+
+  it("controls the desktop and exposes a portable workspace", async () => {
+    const files = new Map<string, Uint8Array>();
+    const leftClick = vi.fn(async () => undefined);
+    const typeText = vi.fn(async () => undefined);
+    const command = vi.fn(async (value: string) => {
+      if (value.startsWith('test "$(readlink')) throw new Error("profiles are not configured");
+      return {
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        disconnect: async () => undefined,
+      };
+    });
+    const desktop = {
+      sandboxId: "e2b-test-box",
+      commands: { run: command },
+      files: {
+        makeDir: vi.fn(async () => undefined),
+        write: vi.fn(async (entries: Array<{ path: string; data: ArrayBuffer }>) => {
+          for (const entry of entries) files.set(entry.path, new Uint8Array(entry.data));
+        }),
+        read: vi.fn(async (filePath: string) => {
+          const content = files.get(filePath);
+          if (!content) throw new Error("missing file");
+          return content;
+        }),
+        list: vi.fn(async (directory: string) => {
+          const prefix = `${directory.replace(/\/$/, "")}/`;
+          return [...files.entries()]
+            .filter(([filePath]) => filePath.startsWith(prefix))
+            .map(([filePath, content]) => ({
+              name: filePath.slice(prefix.length),
+              type: "file" as const,
+              size: content.byteLength,
+              mode: 0o600,
+            }));
+        }),
+      },
+      stream: {
+        start: vi.fn(async () => undefined),
+        stop: vi.fn(async () => undefined),
+        getAuthKey: () => "screen-key",
+        getUrl: () => "https://desktop.test/vnc.html",
+      },
+      launch: vi.fn(async () => undefined),
+      open: vi.fn(async () => undefined),
+      screenshot: vi.fn(async () => new Uint8Array([137, 80, 78, 71])),
+      getScreenSize: vi.fn(async () => ({ width: 1280, height: 800 })),
+      getCursorPosition: vi.fn(async () => ({ x: 10, y: 20 })),
+      getCurrentWindowId: vi.fn(async () => "42"),
+      getWindowTitle: vi.fn(async () => "Browser"),
+      leftClick,
+      rightClick: vi.fn(async () => undefined),
+      moveMouse: vi.fn(async () => undefined),
+      mousePress: vi.fn(async () => undefined),
+      mouseRelease: vi.fn(async () => undefined),
+      write: typeText,
+      press: vi.fn(async () => undefined),
+      scroll: vi.fn(async () => undefined),
+      wait: vi.fn(async () => undefined),
+      setTimeout: vi.fn(async () => undefined),
+      pause: vi.fn(async () => undefined),
+      kill: vi.fn(async () => undefined),
+    } as unknown as Sandbox;
+    const sdk: E2BSandboxSdk = {
+      create: vi.fn(async () => desktop),
+      connect: vi.fn(async () => desktop),
+      pause: vi.fn(async () => undefined),
+    };
+    const provider = new E2BSandboxProvider("test-key", sdk);
+    const computer = await provider.provision(
+      {
+        botId: "bot-1",
+        homePath: "/unused",
+        providerRef: "foreign-provider-machine",
+        providerKind: "docker",
+      },
+      context,
+    );
+    expect(sdk.connect).not.toHaveBeenCalled();
+    await provider.importWorkspace(
+      computer,
+      (async function* () {
+        // Empty durable home on first boot.
+      })(),
+      context,
+    );
+
+    await provider.writeFile(
+      computer,
+      { path: "notes/result.txt", content: new TextEncoder().encode("portable") },
+      context,
+    );
+    expect(
+      new TextDecoder().decode(await provider.readFile(computer, "notes/result.txt", context)),
+    ).toBe("portable");
+    expect(await provider.listFiles(computer, "notes", context)).toEqual([
+      { path: "notes/result.txt", kind: "file", size: 8 },
+    ]);
+
+    const result = await provider.act(
+      computer,
+      {
+        actions: [
+          { kind: "pointer", type: "click", x: 100, y: 120 },
+          { kind: "clipboard", text: "hello" },
+        ],
+        observe: true,
+      },
+      context,
+    );
+    expect(desktop.moveMouse).toHaveBeenCalledWith(100, 120);
+    expect(leftClick).toHaveBeenCalledWith();
+    expect(typeText).toHaveBeenCalledWith("hello");
+    expect(result.observation).toMatchObject({ width: 1280, height: 800 });
+    expect(command.mock.calls.some(([value]) => String(value).includes(".browser-profiles"))).toBe(
+      true,
+    );
+    expect(command.mock.calls.some(([value]) => String(value).includes("cp -a"))).toBe(false);
+    const screen = await provider.connectScreen(computer, { view: "stream" }, context);
+    expect(screen.url).toBe("https://desktop.test/vnc.html");
+    expect(desktop.stream.start).toHaveBeenCalledWith({ requireAuth: true });
+  });
+});

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -2,15 +2,36 @@ import { Sandbox } from "@e2b/desktop";
 import type {
   AdapterContext,
   CommandRequest,
+  ComputerAction,
+  ComputerActionRequest,
+  ComputerFileEntry,
   ComputerInput,
+  ComputerObservation,
   ComputerRef,
   ControlLeaseRef,
+  PortableFile,
   ProcessEvent,
   SandboxProvider,
   ScreenRequest,
   ScreenSession,
 } from "@rakazo/adapter-kit";
 import { sandboxIdleMs } from "./computer-idle.js";
+import {
+  boundedComputerActions,
+  computerObservation,
+  normalizeWorkspacePath,
+  shellQuote,
+  workspacePath,
+} from "./computer-support.js";
+
+const E2B_WORKSPACE = "/home/user/rakazo-home";
+const E2B_BROWSER_PROFILES = `${E2B_WORKSPACE}/.browser-profiles`;
+
+export interface E2BSandboxSdk {
+  create(options: ReturnType<typeof e2bCreateOptions>): Promise<Sandbox>;
+  connect(id: string, options: { apiKey: string; timeoutMs: number }): Promise<Sandbox>;
+  pause(id: string, options: { apiKey: string }): Promise<void>;
+}
 
 export function e2bCreateOptions(botId: string, apiKey: string) {
   return {
@@ -48,8 +69,13 @@ export async function openDesktopBrowser(desktop: {
 
 export class E2BSandboxProvider implements SandboxProvider {
   private readonly boxes = new Map<string, Sandbox>();
+  private readonly lastTouchedAt = new Map<string, number>();
+  private readonly streamReady = new Set<string>();
 
-  constructor(private readonly apiKey: string) {}
+  constructor(
+    private readonly apiKey: string,
+    private readonly sdk: E2BSandboxSdk = Sandbox as unknown as E2BSandboxSdk,
+  ) {}
 
   describe() {
     return {
@@ -70,55 +96,71 @@ export class E2BSandboxProvider implements SandboxProvider {
     const id = computer.providerRef || computer.id;
     const existing = this.boxes.get(id);
     if (existing) {
-      await existing.setTimeout(sandboxIdleMs()).catch(() => undefined);
+      const lastTouched = this.lastTouchedAt.get(id) ?? 0;
+      if (Date.now() - lastTouched >= 60_000) {
+        await existing.setTimeout(sandboxIdleMs()).catch(() => undefined);
+        this.lastTouchedAt.set(id, Date.now());
+      }
       return existing;
     }
-    const connected = await Sandbox.connect(id, {
+    const connected = await this.sdk.connect(id, {
       apiKey: this.apiKey,
       timeoutMs: sandboxIdleMs(),
     });
-    await this.startStream(connected);
     this.boxes.set(connected.sandboxId, connected);
+    this.lastTouchedAt.set(connected.sandboxId, Date.now());
     return connected;
   }
 
   private async startStream(desktop: Sandbox) {
-    await desktop.stream.start({ requireAuth: true }).catch(() => desktop.stream.start());
+    if (this.streamReady.has(desktop.sandboxId)) return;
+    await desktop.commands
+      .run("pkill -x x11vnc || true; pkill -f '[n]ovnc_proxy|[w]ebsockify.*6080' || true")
+      .catch(() => undefined);
+    await desktop.stream.start({ requireAuth: true });
+    this.streamReady.add(desktop.sandboxId);
   }
 
   async provision(
-    request: { botId: string; homePath: string; providerRef?: string },
+    request: {
+      botId: string;
+      homePath: string;
+      providerRef?: string;
+      providerKind?: ComputerRef["kind"];
+    },
     _context: AdapterContext,
   ): Promise<ComputerRef> {
-    if (request.providerRef) {
+    if (request.providerRef && request.providerKind === "e2b") {
       try {
-        const desktop = await Sandbox.connect(request.providerRef, {
+        const desktop = await this.sdk.connect(request.providerRef, {
           apiKey: this.apiKey,
           timeoutMs: sandboxIdleMs(),
         });
-        await this.startStream(desktop);
+        if (await configurePortableBrowserProfiles(desktop)) await openDesktopBrowser(desktop);
         this.boxes.set(desktop.sandboxId, desktop);
+        this.lastTouchedAt.set(desktop.sandboxId, Date.now());
         return {
           id: desktop.sandboxId,
           botId: request.botId,
           kind: "e2b",
           providerRef: desktop.sandboxId,
+          fresh: false,
         };
       } catch (error) {
         this.boxes.delete(request.providerRef);
         if (!isUnrecoverableSandboxError(error)) throw error;
       }
     }
-    const desktop = await Sandbox.create(e2bCreateOptions(request.botId, this.apiKey));
-    await desktop.files.makeDir("/home/user/rakazo-home").catch(() => undefined);
-    await this.startStream(desktop);
-    await openDesktopBrowser(desktop);
+    const desktop = await this.sdk.create(e2bCreateOptions(request.botId, this.apiKey));
+    await desktop.files.makeDir(E2B_WORKSPACE).catch(() => undefined);
     this.boxes.set(desktop.sandboxId, desktop);
+    this.lastTouchedAt.set(desktop.sandboxId, Date.now());
     return {
       id: desktop.sandboxId,
       botId: request.botId,
       kind: "e2b",
       providerRef: desktop.sandboxId,
+      fresh: true,
     };
   }
 
@@ -128,8 +170,12 @@ export class E2BSandboxProvider implements SandboxProvider {
     _context: AdapterContext,
   ): AsyncIterable<ProcessEvent> {
     const desktop = await this.box(computer);
-    const cmd = request.argv.join(" ");
-    const result = await desktop.commands.run(cmd, { cwd: request.cwd ?? "/home/user" });
+    const cmd = request.argv.map(shellQuote).join(" ");
+    const result = await desktop.commands.run(cmd, {
+      cwd: e2bCwd(request.cwd),
+      envs: request.env,
+      signal: _context.signal,
+    });
     if (result.stdout) yield { type: "stdout", data: result.stdout };
     if (result.stderr) yield { type: "stderr", data: result.stderr };
     yield { type: "exit", code: result.exitCode ?? 0 };
@@ -141,6 +187,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     _context: AdapterContext,
   ): Promise<ScreenSession> {
     const desktop = await this.box(computer);
+    await this.startStream(desktop);
     let authKey: string | undefined;
     try {
       authKey = desktop.stream.getAuthKey();
@@ -160,6 +207,7 @@ export class E2BSandboxProvider implements SandboxProvider {
       mimeType: "text/html",
       close: async () => {
         await desktop.stream.stop().catch(() => undefined);
+        this.streamReady.delete(desktop.sandboxId);
       },
     };
   }
@@ -171,43 +219,374 @@ export class E2BSandboxProvider implements SandboxProvider {
     _context: AdapterContext,
   ): Promise<void> {
     const desktop = await this.box(computer);
-    if (input.kind === "key") {
-      await desktop.press(input.key);
-    } else if (input.kind === "pointer") {
-      if (input.type === "move") await desktop.moveMouse(input.x, input.y);
-      else if (input.type === "click" || input.type === "down") {
-        if (input.button === "right") await desktop.rightClick(input.x, input.y);
-        else await desktop.leftClick(input.x, input.y);
+    await applyE2BAction(desktop, input);
+  }
+
+  async observe(computer: ComputerRef, context: AdapterContext): Promise<ComputerObservation> {
+    const desktop = await this.box(computer);
+    return observeE2BDesktop(desktop, context);
+  }
+
+  async act(computer: ComputerRef, request: ComputerActionRequest, context: AdapterContext) {
+    const desktop = await this.box(computer);
+    const actions = boundedComputerActions(request.actions);
+    let completed = 0;
+    for (const action of actions) {
+      if (context.signal.aborted)
+        throw context.signal.reason ?? new Error("computer action aborted");
+      await applyE2BAction(desktop, action);
+      completed += 1;
+    }
+    if (request.settleMs) await desktop.wait(clamp(request.settleMs, 0, 5_000));
+    return {
+      completed,
+      ...(request.observe === false
+        ? {}
+        : { observation: await observeE2BDesktop(desktop, context) }),
+    };
+  }
+
+  async listFiles(
+    computer: ComputerRef,
+    directory: string,
+    context: AdapterContext,
+  ): Promise<ComputerFileEntry[]> {
+    const desktop = await this.box(computer);
+    const relative = normalizeWorkspacePath(directory);
+    const entries = await desktop.files.list(workspacePath(E2B_WORKSPACE, relative), {
+      signal: context.signal,
+    });
+    return entries.flatMap((entry) => {
+      if (entry.type !== "file" && entry.type !== "dir") return [];
+      return [
+        {
+          path: normalizeWorkspacePath(relative ? `${relative}/${entry.name}` : entry.name),
+          kind: entry.type,
+          size: entry.size,
+          ...(entry.type === "file" && entry.mode & 0o100 ? { executable: true } : {}),
+        },
+      ];
+    });
+  }
+
+  async readFile(
+    computer: ComputerRef,
+    filePath: string,
+    context: AdapterContext,
+    options?: { maxBytes?: number },
+  ) {
+    const desktop = await this.box(computer);
+    const target = workspacePath(E2B_WORKSPACE, filePath);
+    if (options?.maxBytes !== undefined) {
+      const info = await desktop.files.getInfo(target, { signal: context.signal });
+      if (info.size > options.maxBytes) {
+        throw new Error(`computer file exceeds ${options.maxBytes} bytes`);
       }
-    } else if (input.kind === "clipboard") {
-      await desktop.write(input.text);
+    }
+    return desktop.files.read(target, {
+      format: "bytes",
+      signal: context.signal,
+    });
+  }
+
+  async writeFile(computer: ComputerRef, file: PortableFile, context: AdapterContext) {
+    const desktop = await this.box(computer);
+    await writeE2BFiles(desktop, [file], context);
+  }
+
+  async *exportWorkspace(
+    computer: ComputerRef,
+    context: AdapterContext,
+  ): AsyncIterable<PortableFile> {
+    const desktop = await this.box(computer);
+    await stopDesktopBrowsers(desktop);
+    try {
+      yield* walkE2BWorkspace(desktop, "", context);
+    } finally {
+      if (context.operationId !== "stop" && context.operationId !== "computer.sleep") {
+        await openDesktopBrowser(desktop);
+      }
     }
   }
 
-  async snapshot(computer: ComputerRef, _context: AdapterContext) {
+  async importWorkspace(
+    computer: ComputerRef,
+    files: AsyncIterable<PortableFile>,
+    context: AdapterContext,
+  ): Promise<void> {
     const desktop = await this.box(computer);
-    await desktop.screenshot().catch(() => undefined);
-    return { id: `e2b-${computer.id}-${Date.now()}`, createdAt: new Date().toISOString() };
+    await desktop.files.makeDir(E2B_WORKSPACE, { signal: context.signal });
+    await stopDesktopBrowsers(desktop);
+    let batch: PortableFile[] = [];
+    let batchBytes = 0;
+    const flush = async () => {
+      if (!batch.length) return;
+      await writeE2BFiles(desktop, batch, context);
+      batch = [];
+      batchBytes = 0;
+    };
+    for await (const file of files) {
+      if (batch.length >= 32 || batchBytes + file.content.byteLength > 8 * 1024 * 1024) {
+        await flush();
+      }
+      batch.push(file);
+      batchBytes += file.content.byteLength;
+    }
+    await flush();
+    await configurePortableBrowserProfiles(desktop);
+    await openDesktopBrowser(desktop);
+  }
+
+  async snapshot(computer: ComputerRef, _context: AdapterContext) {
+    const observation = await this.observe(computer, _context);
+    return { id: observation.frameId, createdAt: observation.capturedAt };
   }
 
   async keepAlive(computer: ComputerRef): Promise<void> {
-    await this.box(computer);
+    const desktop = await this.box(computer);
+    await desktop.setTimeout(sandboxIdleMs()).catch(() => undefined);
+    this.lastTouchedAt.set(desktop.sandboxId, Date.now());
   }
 
   async stop(computer: ComputerRef, _context: AdapterContext): Promise<void> {
     const id = computer.providerRef || computer.id;
     const desktop = this.boxes.get(id);
     this.boxes.delete(id);
+    this.lastTouchedAt.delete(id);
+    this.streamReady.delete(id);
     if (desktop) {
       await desktop.pause().catch(() => undefined);
       return;
     }
-    await Sandbox.pause(id, { apiKey: this.apiKey }).catch(() => undefined);
+    await this.sdk.pause(id, { apiKey: this.apiKey }).catch(() => undefined);
   }
 
   async destroy(computer: ComputerRef, _context: AdapterContext): Promise<void> {
     const desktop = await this.box(computer).catch(() => undefined);
     await desktop?.kill();
-    this.boxes.delete(computer.providerRef || computer.id);
+    const id = computer.providerRef || computer.id;
+    this.boxes.delete(id);
+    this.lastTouchedAt.delete(id);
+    this.streamReady.delete(id);
   }
+}
+
+async function observeE2BDesktop(
+  desktop: Sandbox,
+  context: AdapterContext,
+): Promise<ComputerObservation> {
+  const [image, size, cursor, windowId] = await Promise.all([
+    desktop.screenshot("bytes"),
+    desktop.getScreenSize().catch(() => ({ width: 1280, height: 800 })),
+    desktop.getCursorPosition().catch(() => undefined),
+    desktop.getCurrentWindowId().catch(() => undefined),
+  ]);
+  if (context.signal.aborted)
+    throw context.signal.reason ?? new Error("computer observation aborted");
+  const title = windowId
+    ? await desktop.getWindowTitle(windowId).catch(() => undefined)
+    : undefined;
+  return computerObservation(image, {
+    mimeType: "image/png",
+    width: size.width,
+    height: size.height,
+    cursor,
+    activeWindow: windowId ? { id: windowId, title } : undefined,
+  });
+}
+
+async function writeE2BFiles(
+  desktop: Sandbox,
+  files: readonly PortableFile[],
+  context: AdapterContext,
+) {
+  if (!files.length) return;
+  await desktop.files.write(
+    files.map((file) => ({
+      path: workspacePath(E2B_WORKSPACE, file.path),
+      data: toArrayBuffer(file.content),
+    })),
+    { signal: context.signal },
+  );
+  const executable = files
+    .filter((file) => file.executable)
+    .map((file) => shellQuote(workspacePath(E2B_WORKSPACE, file.path)));
+  if (executable.length) {
+    await desktop.commands.run(`chmod 700 -- ${executable.join(" ")}`, {
+      signal: context.signal,
+    });
+  }
+}
+
+async function configurePortableBrowserProfiles(desktop: Sandbox): Promise<boolean> {
+  const chromium = `${E2B_BROWSER_PROFILES}/chromium`;
+  const chrome = chromium;
+  const firefox = `${E2B_BROWSER_PROFILES}/firefox`;
+  const configured = await desktop.commands
+    .run(
+      [
+        `test "$(readlink -f /home/user/.config/google-chrome 2>/dev/null)" = ${shellQuote(chrome)}`,
+        `test "$(readlink -f /home/user/.config/chromium 2>/dev/null)" = ${shellQuote(chromium)}`,
+        `test "$(readlink -f /home/user/.mozilla 2>/dev/null)" = ${shellQuote(firefox)}`,
+      ].join(" && "),
+    )
+    .then(
+      () => true,
+      () => false,
+    );
+  if (configured) return false;
+  await stopDesktopBrowsers(desktop);
+  await desktop.commands.run(
+    [
+      `mkdir -p ${shellQuote(chrome)} ${shellQuote(chromium)} ${shellQuote(firefox)} /home/user/.config`,
+      "rm -rf /home/user/.config/google-chrome /home/user/.config/chromium /home/user/.mozilla",
+      `ln -s ${shellQuote(chrome)} /home/user/.config/google-chrome`,
+      `ln -s ${shellQuote(chromium)} /home/user/.config/chromium`,
+      `ln -s ${shellQuote(firefox)} /home/user/.mozilla`,
+    ].join(" && "),
+  );
+  return true;
+}
+
+async function stopDesktopBrowsers(desktop: Sandbox): Promise<void> {
+  await desktop.commands
+    .run("pkill -f '[g]oogle-chrome|[c]hromium|[f]irefox' || true")
+    .catch(() => undefined);
+}
+
+async function applyE2BAction(desktop: Sandbox, action: ComputerAction): Promise<void> {
+  if (action.kind === "key") {
+    await desktop.press([...(action.modifiers ?? []), action.key]);
+    return;
+  }
+  if (action.kind === "pointer") {
+    if (action.type === "move") await desktop.moveMouse(action.x, action.y);
+    else if (action.type === "down") {
+      await desktop.moveMouse(action.x, action.y);
+      await desktop.mousePress(action.button ?? "left");
+    } else if (action.type === "up") {
+      await desktop.moveMouse(action.x, action.y);
+      await desktop.mouseRelease(action.button ?? "left");
+    } else {
+      await desktop.moveMouse(action.x, action.y);
+      if (action.button === "right") await desktop.rightClick();
+      else await desktop.leftClick();
+    }
+    return;
+  }
+  if (action.kind === "clipboard") {
+    await desktop.write(action.text);
+    return;
+  }
+  if (action.kind === "scroll") {
+    await desktop.scroll(action.direction, clamp(action.amount ?? 3, 1, 20));
+    return;
+  }
+  if (action.kind === "wait") {
+    await desktop.wait(clamp(action.ms, 0, 5_000));
+    return;
+  }
+  if (action.kind === "open") {
+    const value = /^https?:\/\//i.test(action.path)
+      ? action.path
+      : workspacePath(E2B_WORKSPACE, action.path);
+    await desktop.open(value);
+    return;
+  }
+  await desktop.launch(action.application, action.uri);
+}
+
+async function* walkE2BWorkspace(
+  desktop: Sandbox,
+  directory: string,
+  context: AdapterContext,
+): AsyncIterable<PortableFile> {
+  const entries = await desktop.files.list(workspacePath(E2B_WORKSPACE, directory), {
+    signal: context.signal,
+  });
+  const files: Array<{ relative: string; mode: number }> = [];
+  const directories: string[] = [];
+  for (const entry of entries) {
+    const relative = normalizeWorkspacePath(directory ? `${directory}/${entry.name}` : entry.name);
+    if (shouldSkipPortableWorkspaceFile(relative)) continue;
+    if (entry.type === "dir") directories.push(relative);
+    else if (entry.type === "file") files.push({ relative, mode: entry.mode });
+  }
+  for (let index = 0; index < files.length; index += 8) {
+    const batch = await Promise.all(
+      files.slice(index, index + 8).map(async ({ relative, mode }) => {
+        const content = await desktop.files
+          .read(workspacePath(E2B_WORKSPACE, relative), {
+            format: "bytes",
+            signal: context.signal,
+          })
+          .catch((error) => {
+            if (relative.startsWith(".browser-profiles/")) return undefined;
+            throw error;
+          });
+        if (!content) return undefined;
+        return { path: relative, content, executable: Boolean(mode & 0o100) };
+      }),
+    );
+    for (const file of batch) {
+      if (file) yield file;
+    }
+  }
+  for (const relative of directories) yield* walkE2BWorkspace(desktop, relative, context);
+}
+
+export function shouldSkipPortableWorkspaceFile(relative: string) {
+  if (!relative.startsWith(".browser-profiles/")) return false;
+  const segments = relative.split("/");
+  const name = segments.at(-1) ?? "";
+  return (
+    segments.some((segment) =>
+      [
+        "Cache",
+        "Code Cache",
+        "GPUCache",
+        "GrShaderCache",
+        "ShaderCache",
+        "DawnGraphiteCache",
+        "DawnWebGPUCache",
+        "Crashpad",
+      ].includes(segment),
+    ) ||
+    [
+      "BrowserMetrics",
+      "DevToolsActivePort",
+      "SingletonCookie",
+      "SingletonLock",
+      "SingletonSocket",
+      ".parentlock",
+      "lock",
+    ].includes(name)
+  );
+}
+
+function e2bCwd(cwd: string | undefined): string {
+  if (
+    !cwd ||
+    cwd === "." ||
+    cwd === "/" ||
+    cwd === "/home/rakazo" ||
+    cwd === "/home/user" ||
+    cwd === E2B_WORKSPACE
+  ) {
+    return E2B_WORKSPACE;
+  }
+  const relative = cwd.startsWith(`${E2B_WORKSPACE}/`)
+    ? cwd.slice(E2B_WORKSPACE.length + 1)
+    : cwd.startsWith("/home/rakazo/")
+      ? cwd.slice("/home/rakazo/".length)
+      : cwd;
+  return workspacePath(E2B_WORKSPACE, relative);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(Math.round(value), min), max);
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -26,10 +26,30 @@ import { builtinAgentTools } from "./builtin-tools.js";
 import { deleteSpawnedBot, spawnBot } from "./child-bots.js";
 import { collectLogIds } from "./composio-connector.js";
 import { scheduleComputerSleep } from "./computer-idle.js";
+import { observationToolResult, parseComputerActions } from "./computer-tools.js";
+import {
+  checkpointAndRecordComputerWorkspace,
+  restoreComputerWorkspace,
+} from "./computer-workspace.js";
 import { resolveAgentHomePath } from "./home.js";
 import { parseModelSecret, resolveModelApiKey, secretValuesToRedact } from "./pi-oauth.js";
 import { inferScript } from "./scripted-runtime.js";
 import type { EncryptedSecretStore } from "./secrets.js";
+
+const READ_ONLY_AGENT_TOOLS = new Set([
+  "computer_observe",
+  "list_files",
+  "read_file",
+  "request_takeover",
+  "run_subagent",
+]);
+const MAX_MODEL_FILE_BYTES = 250_000;
+const GRAPHICAL_AGENT_TOOLS = new Set([
+  "computer_observe",
+  "computer_act",
+  "open_path",
+  "launch_app",
+]);
 
 export interface ExecutorDeps {
   prisma: PrismaClient;
@@ -215,10 +235,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
         });
 
         const discovered = deps.connector ? await deps.connector.discoverTools(context) : [];
-        const tools = [
-          ...builtinAgentTools,
-          ...discovered.filter((tool) => !builtinAgentTools.some((b) => b.name === tool.name)),
-        ];
         const history = messages.map((m) => ({
           role: (m.role === "user" ? "user" : m.role === "system" ? "system" : "assistant") as
             | "user"
@@ -230,38 +246,180 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const apiKey = resolved.apiKey;
         const runSecrets = [...deps.secrets, ...resolved.redact];
         const computer = await ensureComputer(deps, bot.id, context);
+        const graphical =
+          computer.kind !== "desktop" && deps.sandbox.describe().capabilities.graphical;
+        const builtins = graphical
+          ? builtinAgentTools
+          : builtinAgentTools.filter((tool) => !GRAPHICAL_AGENT_TOOLS.has(tool.name));
+        const tools = [
+          ...builtins,
+          ...discovered.filter(
+            (tool) => !builtinAgentTools.some((builtin) => builtin.name === tool.name),
+          ),
+        ];
+        const computerInstruction = graphical
+          ? "You have a persistent computer. Use computer_observe and computer_act for its visible desktop, including browsers and installed applications. Use open_path and launch_app to open graphical files, URLs, and applications. Use the file tools and shell for precise filesystem and terminal work. Another user may interact with the same desktop while you run, so re-observe when it may have changed."
+          : "You have a persistent sandbox filesystem and shell. This backend does not provide model-visible graphical control, so use the file tools and shell.";
 
         let assembled = "";
         let pendingProgress = "";
         let lastProgressAt = 0;
+        let lastComputerFrameId: string | undefined;
+        let terminalCheckpointComplete = false;
         const progressRedactor = createStreamingRedactor(runSecrets);
         const scripted = deps.runtime.describe().capabilities.scripted;
         const script = scripted
           ? inferScript(task.prompt, resumeFromTakeover ? "takeover" : undefined)
           : undefined;
+        const formatObservation = (
+          observation: Awaited<ReturnType<SandboxProvider["observe"]>>,
+          note?: string,
+        ) => {
+          const result = observationToolResult(observation, note, lastComputerFrameId);
+          lastComputerFrameId = observation.frameId;
+          return result;
+        };
 
         const applyTool = async (
           name: string,
           args: Record<string, unknown>,
           executionId: string,
         ) => {
-          const applied = await recordEffect(deps, run, name, executionId, args);
-          if (applied.duplicate) return applied.effect.result ?? { duplicate: true };
+          const applied = READ_ONLY_AGENT_TOOLS.has(name)
+            ? undefined
+            : await recordEffect(deps, run, name, executionId, args);
+          if (applied?.duplicate) {
+            if (applied.effect.status === "completed") {
+              return applied.effect.result ?? { duplicate: true };
+            }
+            throw new Error(`tool ${name} has an earlier execution with an uncertain outcome`);
+          }
+          const finish = async (result: unknown) => {
+            if (applied) await completeEffect(deps, applied.effect.id, result);
+            return result;
+          };
+          if (name === "computer_observe") {
+            return formatObservation(await deps.sandbox.observe(computer, context));
+          }
+          if (name === "computer_act") {
+            const result = await deps.sandbox.act(
+              computer,
+              {
+                actions: parseComputerActions(args.actions),
+                observe: args.observe !== false,
+                settleMs: Number(args.settle_ms ?? 350),
+              },
+              context,
+            );
+            return finish(
+              result.observation
+                ? formatObservation(
+                    result.observation,
+                    `completed ${result.completed} computer action${result.completed === 1 ? "" : "s"}`,
+                  )
+                : { ok: true, completed: result.completed },
+            );
+          }
+          if (name === "list_files") {
+            return {
+              path: String(args.path ?? ""),
+              entries: await deps.sandbox.listFiles(computer, String(args.path ?? ""), context),
+            };
+          }
+          if (name === "read_file") {
+            const filePath = String(args.path ?? "");
+            let bytes: Uint8Array;
+            try {
+              bytes = await deps.sandbox.readFile(computer, filePath, context, {
+                maxBytes: MAX_MODEL_FILE_BYTES,
+              });
+            } catch (error) {
+              if (error instanceof Error && /exceeds \d+ bytes/.test(error.message)) {
+                return {
+                  error: "file is too large for model context",
+                  path: filePath,
+                };
+              }
+              throw error;
+            }
+            if (bytes.byteLength > MAX_MODEL_FILE_BYTES) {
+              return {
+                error: "file is too large for model context",
+                path: filePath,
+                size: bytes.byteLength,
+              };
+            }
+            try {
+              return {
+                path: filePath,
+                content: new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+              };
+            } catch {
+              return {
+                error: "file is not UTF-8 text; use open_path to inspect it",
+                path: filePath,
+              };
+            }
+          }
           if (name === "write_file") {
             const filePath = String(args.path ?? "notes/result.txt");
             const content = String(args.content ?? "");
-            await deps.home.writeFile(bot.id, filePath, content, context);
-            return { ok: true, path: filePath };
+            await deps.sandbox.writeFile(
+              computer,
+              { path: filePath, content: new TextEncoder().encode(content) },
+              context,
+            );
+            return finish({ ok: true, path: filePath });
           }
           if (name === "shell") {
             const command = String(args.command ?? args.cmd ?? "");
-            const cwd = String(args.cwd ?? (computer.kind === "desktop" ? "." : "/home/rakazo"));
-            return runSandboxCommand(
+            const cwd = args.cwd ? String(args.cwd) : undefined;
+            const result = await runSandboxCommand(
               deps.sandbox,
               computer,
               ["bash", "-lc", command],
               cwd,
               context,
+            );
+            return finish(result);
+          }
+          if (name === "open_path") {
+            const result = await deps.sandbox.act(
+              computer,
+              {
+                actions: [{ kind: "open", path: String(args.path ?? "") }],
+                observe: true,
+                settleMs: 600,
+              },
+              context,
+            );
+            return finish(
+              result.observation
+                ? formatObservation(result.observation, `opened ${String(args.path ?? "")}`)
+                : { ok: true },
+            );
+          }
+          if (name === "launch_app") {
+            const application = String(args.application ?? "");
+            const result = await deps.sandbox.act(
+              computer,
+              {
+                actions: [
+                  {
+                    kind: "launch",
+                    application,
+                    uri: args.uri ? String(args.uri) : undefined,
+                  },
+                ],
+                observe: true,
+                settleMs: 600,
+              },
+              context,
+            );
+            return finish(
+              result.observation
+                ? formatObservation(result.observation, `launched ${application}`)
+                : { ok: true },
             );
           }
           if (name === "remember") {
@@ -276,7 +434,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               },
               context,
             );
-            return { ok: true };
+            return finish({ ok: true });
           }
           if (name === "request_takeover") return { ok: true };
           if (name === "run_subagent") {
@@ -299,7 +457,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               instructions: args.instructions ? String(args.instructions) : undefined,
               prompt: args.prompt ? String(args.prompt) : undefined,
             });
-            if ("error" in spawned) return spawned;
+            if ("error" in spawned) return finish(spawned);
             await publishMessage(deps, run, "bot", [
               {
                 kind: "child_bot",
@@ -317,8 +475,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               type: "bot.spawned",
               payload: { childBotId: spawned.botId, name: spawned.name },
             });
-            await completeEffect(deps, applied.effect.id, spawned);
-            return spawned;
+            return finish(spawned);
           }
           if (name === "delete_bot") {
             const removed = await deleteSpawnedBot(
@@ -336,7 +493,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               },
               context,
             );
-            if ("error" in removed) return removed;
+            if ("error" in removed) return finish(removed);
             await publishMessage(deps, run, "bot", [
               {
                 kind: "child_bot",
@@ -353,8 +510,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               type: "bot.deleted",
               payload: { childBotId: removed.botId, name: removed.name },
             });
-            await completeEffect(deps, applied.effect.id, removed);
-            return removed;
+            return finish(removed);
           }
           if (deps.connector) {
             let result: unknown = { error: `unknown tool ${name}` };
@@ -378,9 +534,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
               }
               if (event.type === "error") result = { error: event.message };
             }
-            return result;
+            return finish(result);
           }
-          return { error: `unknown tool ${name}` };
+          return finish({ error: `unknown tool ${name}` });
         };
 
         const pluginLine =
@@ -397,7 +553,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               prompt: task.prompt,
               instructions: [
                 bot.instructions || `${bot.name}: ${bot.title}\n${bot.description}`,
-                "You have a persistent computer. Use write_file to save files into your home (they appear in Files). Use shell to run commands in that computer. Use remember for durable facts. Use request_takeover when the user must type on the screen. Use destination_write only for connected destination records.",
+                `${computerInstruction} Use remember for durable facts. Use request_takeover when the user must provide protected input or human judgment. Use destination_write only for connected destination records.`,
                 "A bot and a subagent are different. Never use both for the same request.",
                 "spawn_bot creates a lasting regular bot (own chat, computer, memory) that appears in the user's bot list. If the user asked to create a bot, call spawn_bot once and stop. Do not run_subagent to demo it.",
                 "run_subagent is a short helper inside this turn only. It is not a bot, has no thread, and does not show in the list. Use it for parallel work you will summarize here.",
@@ -471,6 +627,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               await publishMessage(deps, run, "bot", [
                 { kind: "ask", text: safeText, detail: safeDetail },
               ]);
+              await checkpointAndRecordComputerWorkspace(deps, bot.id, computer, context);
               const paused = await deps.prisma.run.updateMany({
                 where: { id: runId, status: "running", leaseOwner: workerId, leaseFence: fence },
                 data: { status: "waiting_input", leaseOwner: null, leaseExpiresAt: null },
@@ -512,6 +669,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 where: { botId: bot.id },
                 data: { state: "running", controlHolder: "none" },
               });
+              await checkpointAndRecordComputerWorkspace(deps, bot.id, computer, context);
               const paused = await deps.prisma.run.updateMany({
                 where: { id: runId, status: "running", leaseOwner: workerId, leaseFence: fence },
                 data: { status: "waiting_takeover", leaseOwner: null, leaseExpiresAt: null },
@@ -531,6 +689,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
               });
               return;
             } else if (event.type === "tool") {
+              await deps.events.append({
+                workspaceId: run.workspaceId,
+                threadId: thread.id,
+                botId: bot.id,
+                type: "agent.tool.called",
+                runId,
+                payload: { name: event.name, executionId: event.executionId },
+              });
               if (scripted) await applyTool(event.name, event.args, event.executionId);
             } else if (event.type === "subagent") {
               const safeTask = redactSecrets(event.task, runSecrets);
@@ -586,7 +752,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
 
           for (const turn of script ?? []) {
             for (const file of turn.files ?? []) {
-              await deps.home.writeFile(bot.id, file.path, file.content, context);
+              await deps.sandbox.writeFile(
+                computer,
+                { path: file.path, content: new TextEncoder().encode(file.content) },
+                context,
+              );
             }
             for (const mem of turn.memory ?? []) {
               await deps.memory.commit(
@@ -610,6 +780,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
               });
             }
           }
+
+          await checkpointAndRecordComputerWorkspace(deps, bot.id, computer, context);
+          terminalCheckpointComplete = true;
 
           const text = redactSecrets(assembled || "done.", runSecrets);
           if (containsSecret(text, runSecrets)) {
@@ -655,6 +828,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
             });
           }
         } catch (error) {
+          if (!terminalCheckpointComplete) {
+            await checkpointAndRecordComputerWorkspace(deps, bot.id, computer, context).catch(
+              () => undefined,
+            );
+          }
           const message = redactSecrets(
             error instanceof Error ? error.message : String(error),
             runSecrets,
@@ -816,17 +994,20 @@ async function recordEffect(
       request: request as never,
     },
   });
-  await deps.prisma.externalEffect.update({
-    where: { id: effect.id },
-    data: { status: "completed", result: { ok: true } },
-  });
   return { duplicate: false, effect };
 }
 
 async function completeEffect(deps: ExecutorDeps, effectId: string, result: unknown) {
+  const storedResult =
+    result &&
+    typeof result === "object" &&
+    (result as { kind?: unknown }).kind === "agent_tool_result" &&
+    "details" in result
+      ? (result as { details: unknown }).details
+      : result;
   await deps.prisma.externalEffect.update({
     where: { id: effectId },
-    data: { result: result as never },
+    data: { status: "completed", result: storedResult as never },
   });
 }
 
@@ -850,23 +1031,39 @@ async function ensureComputer(
     where: { botId },
     data: { state: "booting" },
   });
+  let provisioned: ComputerRef | undefined;
   try {
     const ref = await deps.sandbox.provision(
-      { botId, homePath, providerRef: existing?.providerRef ?? undefined },
+      {
+        botId,
+        homePath,
+        providerRef: existing?.providerRef ?? undefined,
+        providerKind: existing?.kind as ComputerRef["kind"] | undefined,
+      },
       context,
     );
+    provisioned = ref;
+    const replacement =
+      ref.fresh === true ||
+      !existing?.providerRef ||
+      existing.providerRef !== ref.providerRef ||
+      existing.kind !== ref.kind;
+    if (replacement) await restoreComputerWorkspace(deps.home, deps.sandbox, botId, ref, context);
     await deps.prisma.computer.updateMany({
       where: { botId },
       data: {
         state: "running",
         providerRef: ref.providerRef,
         kind: ref.kind,
-        controlHolder: "bot",
+        controlHolder: existing?.controlHolder === "user" ? "user" : "bot",
       },
     });
     scheduleComputerSleep(deps.jobs, botId);
     return ref;
   } catch (error) {
+    if (provisioned?.fresh) {
+      await deps.sandbox.destroy(provisioned, context).catch(() => undefined);
+    }
     await deps.prisma.computer.updateMany({
       where: { botId },
       data: { state: "error" },
@@ -879,7 +1076,7 @@ async function runSandboxCommand(
   sandbox: SandboxProvider,
   computer: ComputerRef,
   argv: string[],
-  cwd: string,
+  cwd: string | undefined,
   context: {
     operationId: string;
     traceId: string;

--- a/packages/adapters/src/fake-sandbox.ts
+++ b/packages/adapters/src/fake-sandbox.ts
@@ -1,18 +1,27 @@
 import type {
   AdapterContext,
   CommandRequest,
+  ComputerActionRequest,
+  ComputerFileEntry,
   ComputerInput,
   ComputerRef,
   ControlLeaseRef,
+  PortableFile,
   ProcessEvent,
   SandboxProvider,
   ScreenRequest,
   ScreenSession,
 } from "@rakazo/adapter-kit";
+import {
+  applyPlaceholderAction,
+  boundedComputerActions,
+  normalizeWorkspacePath,
+  placeholderObservation,
+} from "./computer-support.js";
 
 export interface FakeBox {
   ref: ComputerRef;
-  files: Map<string, string>;
+  files: Map<string, { content: Uint8Array; executable: boolean }>;
   running: boolean;
   screen: string;
 }
@@ -43,13 +52,14 @@ export class FakeSandboxProvider implements SandboxProvider {
     const existing = this.boxes.get(id);
     if (existing) {
       existing.running = true;
-      return existing.ref;
+      return { ...existing.ref, fresh: false };
     }
     const ref: ComputerRef = {
       id,
       botId: request.botId,
       kind: "fake",
-      providerRef: request.homePath,
+      providerRef: id,
+      fresh: true,
     };
     this.boxes.set(ref.id, {
       ref,
@@ -75,8 +85,9 @@ export class FakeSandboxProvider implements SandboxProvider {
     if (request.argv[0] === "echo") {
       yield { type: "stdout", data: `${request.argv.slice(1).join(" ")}\n` };
     } else if (cmd.startsWith("cat ")) {
-      const file = request.argv[1] ?? "";
-      yield { type: "stdout", data: box.files.get(file) ?? "" };
+      const file = normalizeWorkspacePath(request.argv[1] ?? "");
+      const stored = box.files.get(file);
+      yield { type: "stdout", data: stored ? new TextDecoder().decode(stored.content) : "" };
     } else {
       yield { type: "stdout", data: `ran ${cmd}\n` };
     }
@@ -102,7 +113,96 @@ export class FakeSandboxProvider implements SandboxProvider {
     _context: AdapterContext,
   ): Promise<void> {
     const box = this.boxes.get(computer.id);
-    if (box && input.kind === "clipboard") box.screen = input.text;
+    if (box) applyPlaceholderAction(box, input);
+  }
+
+  async observe(computer: ComputerRef, _context: AdapterContext) {
+    return placeholderObservation(this.requiredBox(computer).screen);
+  }
+
+  async act(computer: ComputerRef, request: ComputerActionRequest, _context: AdapterContext) {
+    const box = this.requiredBox(computer);
+    const actions = boundedComputerActions(request.actions);
+    for (const action of actions) applyPlaceholderAction(box, action);
+    return {
+      completed: actions.length,
+      ...(request.observe === false ? {} : { observation: await this.observe(computer, _context) }),
+    };
+  }
+
+  async listFiles(
+    computer: ComputerRef,
+    directory: string,
+    _context: AdapterContext,
+  ): Promise<ComputerFileEntry[]> {
+    const box = this.requiredBox(computer);
+    const normalized = normalizeWorkspacePath(directory);
+    const prefix = normalized ? `${normalized}/` : "";
+    const entries = new Map<string, ComputerFileEntry>();
+    for (const [filePath, file] of box.files) {
+      if (!filePath.startsWith(prefix)) continue;
+      const remainder = filePath.slice(prefix.length);
+      const [name, ...rest] = remainder.split("/");
+      if (!name) continue;
+      const listedPath = prefix + name;
+      entries.set(listedPath, {
+        path: listedPath,
+        kind: rest.length ? "dir" : "file",
+        size: rest.length ? 0 : file.content.byteLength,
+        ...(!rest.length && file.executable ? { executable: true } : {}),
+      });
+    }
+    return [...entries.values()].sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  async readFile(
+    computer: ComputerRef,
+    filePath: string,
+    _context: AdapterContext,
+    options?: { maxBytes?: number },
+  ) {
+    const file = this.requiredBox(computer).files.get(normalizeWorkspacePath(filePath));
+    if (!file) throw new Error("computer file not found");
+    if (options?.maxBytes !== undefined && file.content.byteLength > options.maxBytes) {
+      throw new Error(`computer file exceeds ${options.maxBytes} bytes`);
+    }
+    return new Uint8Array(file.content);
+  }
+
+  async writeFile(computer: ComputerRef, file: PortableFile, _context: AdapterContext) {
+    this.requiredBox(computer).files.set(normalizeWorkspacePath(file.path), {
+      content: new Uint8Array(file.content),
+      executable: file.executable === true,
+    });
+  }
+
+  async *exportWorkspace(
+    computer: ComputerRef,
+    _context: AdapterContext,
+  ): AsyncIterable<PortableFile> {
+    for (const [filePath, file] of [...this.requiredBox(computer).files].sort(([a], [b]) =>
+      a.localeCompare(b),
+    )) {
+      yield {
+        path: filePath,
+        content: new Uint8Array(file.content),
+        executable: file.executable,
+      };
+    }
+  }
+
+  async importWorkspace(
+    computer: ComputerRef,
+    files: AsyncIterable<PortableFile>,
+    _context: AdapterContext,
+  ) {
+    const box = this.requiredBox(computer);
+    for await (const file of files) {
+      box.files.set(normalizeWorkspacePath(file.path), {
+        content: new Uint8Array(file.content),
+        executable: file.executable === true,
+      });
+    }
   }
 
   async snapshot(computer: ComputerRef, _context: AdapterContext) {
@@ -116,5 +216,11 @@ export class FakeSandboxProvider implements SandboxProvider {
 
   async destroy(computer: ComputerRef, _context: AdapterContext): Promise<void> {
     this.boxes.delete(computer.id);
+  }
+
+  private requiredBox(computer: ComputerRef): FakeBox {
+    const box = this.boxes.get(computer.id);
+    if (!box) throw new Error("computer not found");
+    return box;
   }
 }

--- a/packages/adapters/src/home.test.ts
+++ b/packages/adapters/src/home.test.ts
@@ -27,10 +27,35 @@ async function fixture() {
 }
 
 describe("LocalAgentHomeStore path containment", () => {
+  it("keeps revision metadata external without reserving a workspace file name", async () => {
+    const { root, store } = await fixture();
+    const source = path.join(root, "checkpoint-source");
+    await mkdir(source);
+    await writeFile(path.join(source, "result.txt"), "durable");
+    await writeFile(path.join(source, ".revision"), "belongs to the user");
+
+    const revision = await store.commit("bot-1", source, context);
+    const exported = [];
+    for await (const file of store.exportHome("bot-1", context)) exported.push(file.path);
+
+    expect(revision).toMatch(/^rev-/);
+    expect(store.describe().capabilities.revisions).toBe(false);
+    expect(exported.sort()).toEqual([".revision", "result.txt"]);
+  });
+
   it("rejects lexical traversal and sibling-prefix paths", async () => {
     const { store } = await fixture();
     await expect(store.readFile("bot-1", "../../homes-other/secret", context)).rejects.toThrow(
       /escapes|invalid/i,
+    );
+  });
+
+  it("rejects oversized reads before loading their contents", async () => {
+    const { store, home } = await fixture();
+    await writeFile(path.join(home, "large.txt"), "12345");
+
+    await expect(store.readFile("bot-1", "large.txt", context, { maxBytes: 4 })).rejects.toThrow(
+      /exceeds 4 bytes/,
     );
   });
 

--- a/packages/adapters/src/home.ts
+++ b/packages/adapters/src/home.ts
@@ -1,9 +1,23 @@
+import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { mkdir, open, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import type { AdapterContext, AgentHomeStore, PortableFile } from "@rakazo/adapter-kit";
 
 export class LocalAgentHomeStore implements AgentHomeStore {
+  private readonly botWrites = new Map<string, Promise<void>>();
+
   constructor(private readonly root: string) {}
 
   describe() {
@@ -11,7 +25,7 @@ export class LocalAgentHomeStore implements AgentHomeStore {
       id: "local-fs",
       contractVersion: "1",
       adapterVersion: "0.1.0",
-      capabilities: { revisions: true },
+      capabilities: { revisions: false },
     };
   }
 
@@ -27,6 +41,8 @@ export class LocalAgentHomeStore implements AgentHomeStore {
   }
 
   async checkout(botId: string, dest: string, _context: AdapterContext): Promise<string> {
+    await this.waitForBotWrite(botId);
+    await this.recoverInterruptedCommit(botId);
     await mkdir(dest, { recursive: true });
     const src = this.botDir(botId);
     await mkdir(src, { recursive: true });
@@ -35,13 +51,36 @@ export class LocalAgentHomeStore implements AgentHomeStore {
   }
 
   async commit(botId: string, src: string, _context: AdapterContext): Promise<string> {
-    const dest = this.botDir(botId);
-    await rm(dest, { recursive: true, force: true });
-    await mkdir(dest, { recursive: true });
-    await copyDir(src, dest);
-    const revision = `rev-${Date.now()}`;
-    await writeFile(path.join(dest, ".revision"), revision, "utf8");
-    return revision;
+    return this.withBotWrite(botId, async () => {
+      await this.recoverInterruptedCommit(botId);
+      const dest = this.botDir(botId);
+      const parent = path.dirname(dest);
+      const staging = path.join(parent, `.${botId}.staging-${randomUUID()}`);
+      const previous = `${dest}.previous`;
+      await mkdir(parent, { recursive: true });
+      await mkdir(staging, { recursive: true });
+      try {
+        await copyDir(src, staging);
+        await rm(previous, { recursive: true, force: true });
+        if (await pathExists(dest)) await rename(dest, previous);
+        try {
+          await rename(staging, dest);
+        } catch (error) {
+          if (!(await pathExists(dest)) && (await pathExists(previous))) {
+            await rename(previous, dest).catch(() => undefined);
+          }
+          throw error;
+        }
+        await rm(previous, { recursive: true, force: true });
+        return this.writeRevision(botId);
+      } finally {
+        await rm(staging, { recursive: true, force: true });
+      }
+    });
+  }
+
+  async revise(botId: string): Promise<string> {
+    return this.withBotWrite(botId, async () => this.writeRevision(botId));
   }
 
   async restore(
@@ -54,15 +93,30 @@ export class LocalAgentHomeStore implements AgentHomeStore {
   }
 
   async *exportHome(botId: string, _context: AdapterContext): AsyncIterable<PortableFile> {
+    await this.waitForBotWrite(botId);
+    await this.recoverInterruptedCommit(botId);
     const dir = this.botDir(botId);
     await mkdir(dir, { recursive: true });
     yield* walkFiles(dir, dir);
   }
 
-  async readFile(botId: string, filePath: string, _context: AdapterContext): Promise<string> {
+  async readFile(
+    botId: string,
+    filePath: string,
+    _context: AdapterContext,
+    options?: { maxBytes?: number },
+  ): Promise<string> {
+    await this.waitForBotWrite(botId);
+    await this.recoverInterruptedCommit(botId);
     const full = await containedExistingPath(this.botDir(botId), filePath);
     const handle = await open(full, constants.O_RDONLY | constants.O_NOFOLLOW);
     try {
+      if (options?.maxBytes !== undefined) {
+        const info = await handle.stat();
+        if (info.size > options.maxBytes) {
+          throw new Error(`agent home file exceeds ${options.maxBytes} bytes`);
+        }
+      }
       return await handle.readFile("utf8");
     } finally {
       await handle.close();
@@ -75,20 +129,25 @@ export class LocalAgentHomeStore implements AgentHomeStore {
     content: string,
     _context: AdapterContext,
   ): Promise<void> {
-    const full = await containedWritePath(this.botDir(botId), filePath);
-    const handle = await open(
-      full,
-      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW,
-      0o666,
-    );
-    try {
-      await handle.writeFile(content, "utf8");
-    } finally {
-      await handle.close();
-    }
+    await this.withBotWrite(botId, async () => {
+      await this.recoverInterruptedCommit(botId);
+      const full = await containedWritePath(this.botDir(botId), filePath);
+      const handle = await open(
+        full,
+        constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW,
+        0o666,
+      );
+      try {
+        await handle.writeFile(content, "utf8");
+      } finally {
+        await handle.close();
+      }
+    });
   }
 
   async list(botId: string, dirPath: string, _context: AdapterContext) {
+    await this.waitForBotWrite(botId);
+    await this.recoverInterruptedCommit(botId);
     const root = this.botDir(botId);
     const candidate = safeJoin(root, dirPath);
     const full = await ensureContainedDirectory(root, candidate);
@@ -106,6 +165,41 @@ export class LocalAgentHomeStore implements AgentHomeStore {
       }),
     );
     return listed.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+  }
+
+  private async writeRevision(botId: string) {
+    const revision = `rev-${Date.now()}-${randomUUID().slice(0, 8)}`;
+    const directory = path.join(this.root, "home-revisions");
+    await mkdir(directory, { recursive: true });
+    await writeFile(path.join(directory, `${botId}.txt`), revision, "utf8");
+    return revision;
+  }
+
+  private async recoverInterruptedCommit(botId: string) {
+    const dest = this.botDir(botId);
+    const previous = `${dest}.previous`;
+    if (!(await pathExists(dest)) && (await pathExists(previous))) await rename(previous, dest);
+  }
+
+  private async withBotWrite<T>(botId: string, work: () => Promise<T>): Promise<T> {
+    const previous = this.botWrites.get(botId) ?? Promise.resolve();
+    let release: () => void = () => undefined;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    this.botWrites.set(botId, queued);
+    await previous;
+    try {
+      return await work();
+    } finally {
+      release();
+      if (this.botWrites.get(botId) === queued) this.botWrites.delete(botId);
+    }
+  }
+
+  private async waitForBotWrite(botId: string) {
+    await (this.botWrites.get(botId) ?? Promise.resolve());
   }
 }
 
@@ -178,6 +272,15 @@ function isMissing(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
+async function pathExists(target: string) {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function copyDir(src: string, dest: string, sourceRoot = src, visited = new Set<string>()) {
   await mkdir(dest, { recursive: true });
   const current = await containedTarget(sourceRoot, src).catch(() => null);
@@ -192,7 +295,7 @@ async function copyDir(src: string, dest: string, sourceRoot = src, visited = ne
     const to = path.join(dest, entry.name);
     const info = await stat(from);
     if (info.isDirectory()) await copyDir(from, to, sourceRoot, visited);
-    else if (info.isFile()) await writeFile(to, await readFile(from));
+    else if (info.isFile()) await writeFile(to, await readFile(from), { mode: info.mode & 0o777 });
   }
 }
 
@@ -220,6 +323,7 @@ async function* walkFiles(
       yield {
         path: portablePath,
         content: new Uint8Array(content),
+        executable: Boolean(info.mode & 0o100),
       };
     }
   }

--- a/packages/adapters/src/host-aware-sandbox.ts
+++ b/packages/adapters/src/host-aware-sandbox.ts
@@ -2,9 +2,11 @@ import { homedir } from "node:os";
 import type {
   AdapterContext,
   CommandRequest,
+  ComputerActionRequest,
   ComputerInput,
   ComputerRef,
   ControlLeaseRef,
+  PortableFile,
   ProcessEvent,
   SandboxProvider,
   ScreenRequest,
@@ -67,11 +69,23 @@ export class HostAwareSandbox implements SandboxProvider {
   }
 
   async provision(
-    request: { botId: string; homePath: string; providerRef?: string },
+    request: {
+      botId: string;
+      homePath: string;
+      providerRef?: string;
+      providerKind?: ComputerRef["kind"];
+    },
     context: AdapterContext,
   ) {
     const provider = (await this.hostEnabled()) ? this.host : this.isolated;
-    return provider.provision(request, context);
+    const providerKind = provider.describe().id;
+    return provider.provision(
+      {
+        ...request,
+        providerRef: request.providerKind === providerKind ? request.providerRef : undefined,
+      },
+      context,
+    );
   }
 
   async *execute(
@@ -93,6 +107,43 @@ export class HostAwareSandbox implements SandboxProvider {
     context: AdapterContext,
   ) {
     return this.route(computer).sendInput(computer, input, lease, context);
+  }
+
+  observe(computer: ComputerRef, context: AdapterContext) {
+    return this.route(computer).observe(computer, context);
+  }
+
+  act(computer: ComputerRef, request: ComputerActionRequest, context: AdapterContext) {
+    return this.route(computer).act(computer, request, context);
+  }
+
+  listFiles(computer: ComputerRef, path: string, context: AdapterContext) {
+    return this.route(computer).listFiles(computer, path, context);
+  }
+
+  readFile(
+    computer: ComputerRef,
+    path: string,
+    context: AdapterContext,
+    options?: { maxBytes?: number },
+  ) {
+    return this.route(computer).readFile(computer, path, context, options);
+  }
+
+  writeFile(computer: ComputerRef, file: PortableFile, context: AdapterContext) {
+    return this.route(computer).writeFile(computer, file, context);
+  }
+
+  exportWorkspace(computer: ComputerRef, context: AdapterContext) {
+    return this.route(computer).exportWorkspace(computer, context);
+  }
+
+  importWorkspace(
+    computer: ComputerRef,
+    files: AsyncIterable<PortableFile>,
+    context: AdapterContext,
+  ) {
+    return this.route(computer).importWorkspace(computer, files, context);
   }
 
   snapshot(computer: ComputerRef, context: AdapterContext) {

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -5,6 +5,8 @@ export * from "./child-bots.js";
 export * from "./composio-catalog-cache.js";
 export * from "./composio-connector.js";
 export * from "./computer-idle.js";
+export * from "./computer-tools.js";
+export * from "./computer-workspace.js";
 export * from "./desktop-sandbox.js";
 export * from "./destination-emulator.js";
 export * from "./docker-sandbox.js";

--- a/packages/adapters/src/pi-runtime-computer.test.ts
+++ b/packages/adapters/src/pi-runtime-computer.test.ts
@@ -1,0 +1,140 @@
+import type { ConnectorTool } from "@rakazo/adapter-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fakeAgentState = vi.hoisted(() => ({
+  result: undefined as unknown,
+  systemPrompt: "",
+}));
+
+vi.mock("@earendil-works/pi-agent-core", () => ({
+  Agent: class {
+    state = { errorMessage: undefined, messages: [] };
+    private readonly tool: {
+      execute: (toolCallId: string, params: unknown) => Promise<unknown>;
+    };
+
+    constructor(options: {
+      initialState: {
+        systemPrompt: string;
+        tools: Array<{
+          name: string;
+          execute: (toolCallId: string, params: unknown) => Promise<unknown>;
+        }>;
+      };
+    }) {
+      fakeAgentState.systemPrompt = options.initialState.systemPrompt;
+      const tool = options.initialState.tools.find(
+        (candidate) => candidate.name === "computer_observe",
+      );
+      if (!tool) throw new Error("computer_observe was not exposed");
+      this.tool = tool;
+    }
+
+    subscribe(_listener: unknown) {}
+
+    async prompt() {
+      fakeAgentState.result = await this.tool.execute("observe-1", {});
+    }
+
+    async waitForIdle() {}
+
+    abort() {}
+  },
+}));
+
+vi.mock("@earendil-works/pi-ai/providers/all", () => ({
+  builtinModels: () => ({
+    getModel: (_provider: string, modelId: string) =>
+      modelId === "computer-test-model" ? { provider: "test", id: modelId } : undefined,
+    streamSimple: () => {
+      throw new Error("the fake agent must not call a provider");
+    },
+  }),
+}));
+
+import { PiAgentRuntime, pruneComputerScreenshotContext } from "./pi-runtime.js";
+
+const computerObserve: ConnectorTool = {
+  name: "computer_observe",
+  description: "Observe the computer",
+  inputSchema: { type: "object", properties: {} },
+};
+
+describe("Pi computer tool dispatch", () => {
+  beforeEach(() => {
+    fakeAgentState.result = undefined;
+    fakeAgentState.systemPrompt = "";
+  });
+
+  it("forwards screenshots as image content for any Pi model provider", async () => {
+    const runtime = new PiAgentRuntime();
+    for await (const _event of runtime.run(
+      {
+        botId: "bot",
+        threadId: "thread",
+        runId: "run",
+        prompt: "look at the screen",
+        instructions: "Follow the user's instructions.",
+        history: [],
+        tools: [computerObserve],
+        model: { provider: "test", id: "computer-test-model" },
+        executeTool: async () => ({
+          kind: "agent_tool_result",
+          content: [
+            { type: "text", text: "computer observed" },
+            { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+          ],
+          details: { frameId: "frame-1" },
+        }),
+      },
+      {
+        operationId: "computer-test",
+        traceId: "computer-test",
+        workspaceId: "workspace",
+        userId: "user",
+        signal: new AbortController().signal,
+      },
+    )) {
+      // Exhaust the runtime so the fake agent executes the tool.
+    }
+
+    expect(fakeAgentState.result).toMatchObject({
+      content: [{ type: "text" }, { type: "image", mimeType: "image/png", data: "iVBORw0KGgo=" }],
+    });
+    expect(fakeAgentState.systemPrompt).toBe("Follow the user's instructions.");
+  });
+
+  it("keeps only the two latest computer screenshots in model context", () => {
+    const messages = ["frame-1", "frame-2", "frame-3"].map((frameId) => ({
+      role: "toolResult" as const,
+      toolCallId: frameId,
+      toolName: "computer_observe",
+      content: [
+        { type: "text" as const, text: frameId },
+        { type: "image" as const, data: frameId, mimeType: "image/png" as const },
+      ],
+      details: { frameId },
+      isError: false,
+      timestamp: 1,
+    }));
+
+    const pruned = pruneComputerScreenshotContext(messages);
+    expect(
+      pruned.map((message) =>
+        (message as (typeof messages)[number]).content.some((part) => part.type === "image"),
+      ),
+    ).toEqual([false, true, true]);
+  });
+
+  it("reuses the message array when no screenshot needs pruning", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "hello" }],
+        timestamp: 1,
+      },
+    ];
+
+    expect(pruneComputerScreenshotContext(messages)).toBe(messages);
+  });
+});

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -1,0 +1,102 @@
+import type { ConnectorTool } from "@rakazo/adapter-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fakeAgentState = vi.hoisted(() => ({
+  tools: [] as Array<{
+    name: string;
+    prepareArguments?: (args: unknown) => Record<string, unknown>;
+    execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+  }>,
+}));
+
+vi.mock("@earendil-works/pi-agent-core", () => ({
+  Agent: class {
+    state = { errorMessage: undefined, messages: [] };
+    private readonly tools: typeof fakeAgentState.tools;
+
+    constructor(options: { initialState: { tools: typeof fakeAgentState.tools } }) {
+      this.tools = options.initialState.tools;
+      fakeAgentState.tools = this.tools;
+    }
+
+    subscribe(_listener: unknown) {}
+
+    async prompt() {
+      const destination = this.tools.find((tool) => tool.name === "destination_write");
+      if (!destination) throw new Error("sanitized destination tool was not exposed");
+      const rawArgs = { collection: "notes", title: "Result", body: "Done" };
+      const args = destination.prepareArguments?.(rawArgs) ?? rawArgs;
+      await destination.execute("call-1", args);
+    }
+
+    async waitForIdle() {}
+
+    abort() {}
+  },
+}));
+
+vi.mock("@earendil-works/pi-ai/providers/all", () => ({
+  builtinModels: () => ({
+    getModel: (_provider: string, modelId: string) =>
+      modelId === "dispatch-test-model" ? { provider: "test", id: modelId } : undefined,
+    streamSimple: () => {
+      throw new Error("the fake agent must not call a provider");
+    },
+  }),
+}));
+
+import { PiAgentRuntime } from "./pi-runtime.js";
+
+const destinationTool: ConnectorTool = {
+  name: "destination.write",
+  description: "Write a record to the connected destination",
+  inputSchema: {
+    type: "object",
+    properties: {
+      collection: { type: "string" },
+      title: { type: "string" },
+      body: { type: "string" },
+    },
+  },
+};
+
+describe("Pi connector tool dispatch", () => {
+  beforeEach(() => {
+    fakeAgentState.tools = [];
+  });
+
+  it("exposes a provider-safe name while executing the original connector name", async () => {
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "r",
+        prompt: "write the result",
+        instructions: "Use destination_write for connected destination records.",
+        history: [],
+        tools: [destinationTool],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool,
+      },
+      {
+        operationId: "1",
+        traceId: "1",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      // Exhaust the runtime event stream so tool execution completes.
+    }
+
+    expect(fakeAgentState.tools.map((tool) => tool.name)).toEqual(["destination_write"]);
+    expect(executeTool).toHaveBeenCalledWith(
+      "destination.write",
+      { collection: "notes", title: "Result", body: "Done" },
+      "call-1",
+    );
+  });
+});

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1,4 +1,4 @@
-import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
+import { Agent, type AgentMessage, type AgentTool } from "@earendil-works/pi-agent-core";
 import { Type } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import type {
@@ -6,6 +6,7 @@ import type {
   AgentRunRequest,
   AgentRuntime,
   AgentRuntimeEvent,
+  AgentToolExecutionResult,
   ConnectorTool,
 } from "@rakazo/adapter-kit";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
@@ -73,10 +74,13 @@ export class PiAgentRuntime implements AgentRuntime {
         const agent = new Agent({
           streamFn: (m, ctx, options) => models.streamSimple(m, ctx, options),
           getApiKey: async () => apiKey,
+          transformContext: async (messages) => pruneComputerScreenshotContext(messages),
           initialState: {
             systemPrompt:
               request.instructions ||
-              "You are a Rakazo bot with a real computer. Use write_file, shell, remember, and request_takeover when they are the right tools. Be concise.",
+              (toolDefs.some((tool) => tool.name === "computer_observe")
+                ? "You are a Rakazo bot with a real computer. Use computer_observe and computer_act to operate its visible desktop, including browsers and installed applications. Use shell and the file tools for precise terminal and filesystem work. The user may interact with the same desktop while you run, so re-observe when the screen may have changed. Be concise."
+                : "You are a Rakazo bot with a persistent sandbox filesystem and shell. Be concise."),
             model,
             thinkingLevel: "off",
             tools,
@@ -264,6 +268,23 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
       if (tool.name === "write_file") {
         return { path: String(raw.path ?? "notes/result.txt"), content: String(raw.content ?? "") };
       }
+      if (tool.name === "computer_act") {
+        return {
+          actions: Array.isArray(raw.actions) ? raw.actions : [],
+          observe: raw.observe === undefined ? true : Boolean(raw.observe),
+          settle_ms: Number(raw.settle_ms ?? 350),
+        };
+      }
+      if (tool.name === "list_files") return { path: String(raw.path ?? "") };
+      if (tool.name === "read_file" || tool.name === "open_path") {
+        return { path: String(raw.path ?? "") };
+      }
+      if (tool.name === "launch_app") {
+        return {
+          application: String(raw.application ?? ""),
+          uri: raw.uri ? String(raw.uri) : "",
+        };
+      }
       if (tool.name === "shell") {
         return {
           command: String(raw.command ?? ""),
@@ -317,6 +338,7 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
       }
       if (host.request.executeTool) {
         const result = await host.request.executeTool(tool.name, args, executionId);
+        if (isAgentToolExecutionResult(result)) return result;
         return {
           content: [{ type: "text", text: summarizeToolResult(result) }],
           details: result,
@@ -356,6 +378,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
   const nested = new Agent({
     streamFn: (m, ctx, options) => models.streamSimple(m, ctx, options),
     getApiKey: async () => host.apiKey,
+    transformContext: async (messages) => pruneComputerScreenshotContext(messages),
     initialState: {
       systemPrompt: [
         `You are a Rakazo subagent named "${name}".`,
@@ -484,7 +507,7 @@ function parametersFor(tool: ConnectorTool) {
   if (tool.name === "shell") {
     return Type.Object({
       command: Type.String(),
-      cwd: Type.String(),
+      cwd: Type.Optional(Type.String()),
     });
   }
   if (tool.name === "run_subagent") {
@@ -511,6 +534,66 @@ function parametersFor(tool: ConnectorTool) {
   return jsonSchemaParameters(tool.inputSchema);
 }
 
+/** Keep recent visual state without repeatedly resending every earlier full screenshot. */
+export function pruneComputerScreenshotContext(
+  messages: AgentMessage[],
+  screenshotsToKeep = 2,
+): AgentMessage[] {
+  let remaining = Math.max(0, screenshotsToKeep);
+  let transformed: AgentMessage[] | undefined;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!isComputerScreenshotMessage(message)) continue;
+    if (remaining > 0) {
+      remaining -= 1;
+      continue;
+    }
+    transformed ??= [...messages];
+    transformed[index] = {
+      ...message,
+      content: message.content.filter((part) => part.type !== "image"),
+    };
+  }
+  return transformed ?? messages;
+}
+
+function isComputerScreenshotMessage(
+  message: AgentMessage | undefined,
+): message is Extract<AgentMessage, { role: "toolResult" }> {
+  if (message?.role !== "toolResult" || !message.content.some((part) => part.type === "image")) {
+    return false;
+  }
+  const details = message.details;
+  return Boolean(
+    details &&
+      typeof details === "object" &&
+      "frameId" in details &&
+      typeof (details as { frameId?: unknown }).frameId === "string",
+  );
+}
+
+function isAgentToolExecutionResult(result: unknown): result is AgentToolExecutionResult {
+  if (
+    !result ||
+    typeof result !== "object" ||
+    (result as { kind?: unknown }).kind !== "agent_tool_result" ||
+    !("content" in result)
+  ) {
+    return false;
+  }
+  const content = (result as { content?: unknown }).content;
+  return (
+    Array.isArray(content) &&
+    content.every(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        ((item as { type?: unknown }).type === "text" ||
+          (item as { type?: unknown }).type === "image"),
+    )
+  );
+}
+
 function jsonSchemaParameters(schema: Record<string, unknown>) {
   const properties = (schema.properties ?? {}) as Record<string, unknown>;
   const required = new Set(Array.isArray(schema.required) ? schema.required.map(String) : []);
@@ -525,14 +608,15 @@ function jsonSchemaParameters(schema: Record<string, unknown>) {
 }
 
 function jsonField(spec: unknown): ReturnType<typeof Type.String> {
-  const type =
-    spec && typeof spec === "object" && "type" in spec
-      ? String((spec as { type?: unknown }).type)
-      : "string";
+  const definition = spec && typeof spec === "object" ? (spec as Record<string, unknown>) : {};
+  if (Array.isArray(definition.enum) && definition.enum.length > 0) {
+    return Type.Union(definition.enum.map((value) => Type.Literal(value))) as never;
+  }
+  const type = "type" in definition ? String(definition.type) : "string";
   if (type === "number" || type === "integer") return Type.Number() as never;
   if (type === "boolean") return Type.Boolean() as never;
-  if (type === "array") return Type.Array(Type.Unknown()) as never;
-  if (type === "object") return Type.Record(Type.String(), Type.Unknown()) as never;
+  if (type === "array") return Type.Array(jsonField(definition.items)) as never;
+  if (type === "object") return jsonSchemaParameters(definition) as never;
   return Type.String();
 }
 

--- a/packages/adapters/src/sandbox-conformance.test.ts
+++ b/packages/adapters/src/sandbox-conformance.test.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { SandboxProvider } from "@rakazo/adapter-kit";
@@ -54,6 +54,56 @@ describe("sandbox conformance", () => {
     await desktop.destroy(c, ctx);
   });
 
+  it("offers the same observation, action, and workspace contract across providers", async () => {
+    const providers: SandboxProvider[] = [
+      new FakeSandboxProvider(),
+      new ManagedSandboxEmulator(),
+      new DesktopSandboxProvider(),
+    ];
+    for (const [index, provider] of providers.entries()) {
+      const computer = await provider.provision(
+        { botId: `portable-${index}`, homePath: `/tmp/portable-${index}` },
+        ctx,
+      );
+      await provider.writeFile(
+        computer,
+        { path: "notes/result.txt", content: new TextEncoder().encode("portable") },
+        ctx,
+      );
+      expect(await provider.listFiles(computer, "notes", ctx)).toEqual([
+        { path: "notes/result.txt", kind: "file", size: 8 },
+      ]);
+      expect(
+        new TextDecoder().decode(await provider.readFile(computer, "notes/result.txt", ctx)),
+      ).toBe("portable");
+      const binary = Uint8Array.from([0, 255, 1, 128]);
+      await provider.writeFile(
+        computer,
+        { path: "bin/tool", content: binary, executable: true },
+        ctx,
+      );
+      expect(await provider.readFile(computer, "bin/tool", ctx)).toEqual(binary);
+      expect(await provider.listFiles(computer, "bin", ctx)).toEqual([
+        { path: "bin/tool", kind: "file", size: 4, executable: true },
+      ]);
+      const acted = await provider.act(
+        computer,
+        { actions: [{ kind: "clipboard", text: "visible" }], observe: true },
+        ctx,
+      );
+      expect(acted.completed).toBe(1);
+      expect(acted.observation?.image.byteLength).toBeGreaterThan(0);
+      const exported = [];
+      for await (const file of provider.exportWorkspace(computer, ctx)) exported.push(file);
+      expect(exported.map((file) => file.path)).toContain("notes/result.txt");
+      expect(exported.find((file) => file.path === "bin/tool")).toMatchObject({
+        content: binary,
+        executable: true,
+      });
+      await provider.destroy(computer, ctx);
+    }
+  });
+
   it("desktop executor refuses paths outside the computer home", async () => {
     const desktop = new DesktopSandboxProvider();
     const computer = await desktop.provision({ botId: "grant", homePath: "/tmp/grant" }, ctx);
@@ -70,6 +120,40 @@ describe("sandbox conformance", () => {
     expect(code).toBe(1);
     expect(stderr).toMatch(/outside this computer's home/i);
     await desktop.destroy(computer, ctx);
+  });
+
+  it("reuses one desktop machine per bot", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "rakazo-desktop-reuse-"));
+    const desktop = new DesktopSandboxProvider({ root });
+    const first = await desktop.provision({ botId: "stable", homePath: "/unused" }, ctx);
+    const second = await desktop.provision({ botId: "stable", homePath: "/unused" }, ctx);
+
+    expect(first).toMatchObject({ fresh: true });
+    expect(second).toMatchObject({ id: first.id, providerRef: first.providerRef, fresh: false });
+    expect(desktop.boxes.size).toBe(1);
+
+    await desktop.destroy(second, ctx);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("desktop file writes do not follow a final symlink outside the workspace", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "rakazo-desktop-symlink-"));
+    const desktop = new DesktopSandboxProvider({ root });
+    const computer = await desktop.provision({ botId: "symlink", homePath: "/unused" }, ctx);
+    const outside = path.join(root, "outside.txt");
+    writeFileSync(outside, "before");
+    symlinkSync(outside, path.join(computer.providerRef, "escape.txt"));
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "escape.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    expect(readFileSync(outside, "utf8")).toBe("before");
+
+    await desktop.destroy(computer, ctx);
+    rmSync(root, { recursive: true, force: true });
   });
 });
 

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -24,6 +24,7 @@ export const ProductEventType = z.enum([
   "routine.updated",
   "routine.fired",
   "effect.recorded",
+  "agent.tool.called",
   "effect.reconciled",
   "usage.recorded",
   "bot.spawned",

--- a/packages/testkit/src/cli/computer-e2e.ts
+++ b/packages/testkit/src/cli/computer-e2e.ts
@@ -1,0 +1,65 @@
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PostgreSqlContainer } from "@testcontainers/postgresql";
+import { loadRootEnv } from "../../../../apps/api/src/load-root-env.js";
+
+async function main() {
+  loadRootEnv();
+  for (const key of ["E2B_API_KEY", "OPENROUTER_API_KEY", "COMPUTER_E2E_MODEL"]) {
+    if (!process.env[key]) throw new Error(`${key} is required`);
+  }
+  const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-computer-e2e-run-"));
+  const database = await new PostgreSqlContainer("postgres:16-alpine").start();
+  const env = {
+    ...process.env,
+    DATABASE_URL: database.getConnectionUri(),
+    REALTIME_DATABASE_URL: database.getConnectionUri(),
+    RUN_COMPUTER_E2E: "1",
+    WAKEUP_DRIVER: "memory",
+    SANDBOX_PROVIDER: "e2b",
+    AGENT_RUNTIME: "pi",
+    BETTER_AUTH_SECRET: "computer-e2e-auth-secret-32chars",
+    ENCRYPTION_KEY: "computer-e2e-encryption-key-32chars",
+    BETTER_AUTH_URL: "http://127.0.0.1:5173",
+    WEB_ORIGIN: "http://127.0.0.1:5173",
+    DATA_DIR: dataDir,
+    SIGNUPS_ENABLED: "true",
+  };
+  try {
+    execFileSync("pnpm", ["--filter", "@rakazo/db", "generate"], {
+      stdio: "inherit",
+      env,
+    });
+    execFileSync("pnpm", ["--filter", "@rakazo/db", "exec", "prisma", "migrate", "deploy"], {
+      stdio: "inherit",
+      env,
+      cwd: path.resolve("packages/db"),
+    });
+    await run(
+      "pnpm",
+      ["exec", "vitest", "run", "packages/testkit/src/computer-use.e2e.test.ts"],
+      env,
+    );
+  } finally {
+    await database.stop().catch(() => undefined);
+    await rm(dataDir, { recursive: true, force: true });
+  }
+}
+
+function run(command: string, args: string[], env: NodeJS.ProcessEnv) {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit", env, shell: false });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(" ")} exited ${code}`));
+    });
+  });
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/testkit/src/computer-use.e2e.test.ts
+++ b/packages/testkit/src/computer-use.e2e.test.ts
@@ -1,0 +1,245 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { ComputerRef, SandboxProvider } from "@rakazo/adapter-kit";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const live = process.env.RUN_COMPUTER_E2E === "1";
+const describeLive = live ? describe : describe.skip;
+
+describeLive("real model and E2B computer journey", () => {
+  let dataDir: string | undefined;
+  let handles: Awaited<ReturnType<typeof import("../../../apps/api/src/app.ts")["createApp"]>>;
+  let computer: ComputerRef | undefined;
+
+  beforeAll(async () => {
+    for (const key of ["DATABASE_URL", "E2B_API_KEY", "OPENROUTER_API_KEY", "COMPUTER_E2E_MODEL"]) {
+      if (!process.env[key]) throw new Error(`${key} is required for pnpm e2e:computer`);
+    }
+    dataDir = mkdtempSync(path.join(tmpdir(), "rakazo-computer-e2e-"));
+    const { createApp } = await import("../../../apps/api/src/app.ts");
+    handles = await createApp({
+      databaseUrl: process.env.DATABASE_URL!,
+      dataDir,
+      sandboxProvider: "e2b",
+      agentRuntime: "pi",
+      e2bApiKey: process.env.E2B_API_KEY,
+      openRouterKey: process.env.OPENROUTER_API_KEY,
+      defaultProvider: "openrouter",
+      defaultModel: process.env.COMPUTER_E2E_MODEL,
+      wakeupDriver: "memory",
+    });
+    await handles.prisma.deploymentSettings.update({
+      where: { id: "default" },
+      data: {
+        defaultModelProvider: "openrouter",
+        defaultModelId: process.env.COMPUTER_E2E_MODEL,
+      },
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (computer) {
+      await handles.sandbox.destroy(computer, testContext(computer.botId)).catch(() => undefined);
+    }
+    await handles?.stop().catch(() => undefined);
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("observes and clicks a real browser, then uses terminal and files", async () => {
+    const stamp = Date.now();
+    const signup = await handles.app.request("/api/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "http://127.0.0.1:5173" },
+      body: JSON.stringify({
+        email: `computer-${stamp}@rakazo.test`,
+        password: "password12",
+        name: "Computer E2E",
+      }),
+    });
+    expect(signup.status).toBeLessThan(400);
+    const cookie = cookieHeader(signup);
+    const bot = await rpc<{ id: string }>(handles.app, cookie, "bots/create", {
+      name: "Operator",
+      title: "Computer acceptance test",
+      description: "Uses the visible desktop and its tools.",
+      instructions:
+        "This is an acceptance test. Follow the requested computer tool sequence exactly and do not claim a visual action succeeded until its result is visible.",
+      notifyOnFinish: false,
+    });
+    await rpc(handles.app, cookie, "computer/boot", { botId: bot.id });
+    const stored = await handles.prisma.computer.findUniqueOrThrow({ where: { botId: bot.id } });
+    computer = {
+      id: stored.providerRef!,
+      providerRef: stored.providerRef!,
+      botId: bot.id,
+      kind: "e2b",
+    };
+    await installVisualFixture(handles.sandbox, computer);
+
+    const sent = await rpc<{ runId: string }>(handles.app, cookie, "threads/send", {
+      botId: bot.id,
+      text: [
+        "Open http://127.0.0.1:8765 using open_path.",
+        "Call computer_observe, locate the large CLICK TO PASS button visually, and click it with computer_act.",
+        "Re-observe until the page visibly says VISUAL E2E PASSED.",
+        "Then use shell to read results/visual-click.txt.",
+        "Finally use write_file to create results/llm-confirmed.txt containing exactly visual-e2e-ok.",
+      ].join(" "),
+    });
+    const snapshot = await waitFor(handles.app, cookie, bot.id, 180_000);
+    expect(snapshot.run?.status).toBe("completed");
+
+    const clickMarker = new TextDecoder().decode(
+      await handles.sandbox.readFile(computer, "results/visual-click.txt", testContext(bot.id)),
+    );
+    expect(clickMarker).toBe("visual-click-ok");
+    const confirmed = await rpc<{ content: string }>(handles.app, cookie, "computer/readFile", {
+      botId: bot.id,
+      path: "results/llm-confirmed.txt",
+    });
+    expect(confirmed.content).toBe("visual-e2e-ok");
+
+    const toolEvents = await handles.prisma.event.findMany({
+      where: { runId: sent.runId },
+      select: { type: true, payload: true },
+    });
+    const used = new Set(
+      toolEvents.flatMap((event) => {
+        if (
+          event.type !== "agent.tool.called" ||
+          !event.payload ||
+          typeof event.payload !== "object"
+        ) {
+          return [];
+        }
+        const name = "name" in event.payload ? event.payload.name : undefined;
+        return typeof name === "string" ? [name] : [];
+      }),
+    );
+    for (const required of [
+      "open_path",
+      "computer_observe",
+      "computer_act",
+      "shell",
+      "write_file",
+    ]) {
+      expect(used).toContain(required);
+    }
+
+    const originalRef = computer.providerRef;
+    await handles.sandbox.destroy(computer, testContext(bot.id));
+    await rpc(handles.app, cookie, "computer/boot", { botId: bot.id });
+    const replacement = await handles.prisma.computer.findUniqueOrThrow({
+      where: { botId: bot.id },
+    });
+    expect(replacement.providerRef).not.toBe(originalRef);
+    computer = {
+      id: replacement.providerRef!,
+      providerRef: replacement.providerRef!,
+      botId: bot.id,
+      kind: "e2b",
+    };
+    const restored = await rpc<{ content: string }>(handles.app, cookie, "computer/readFile", {
+      botId: bot.id,
+      path: "results/llm-confirmed.txt",
+    });
+    expect(restored.content).toBe("visual-e2e-ok");
+  }, 240_000);
+});
+
+async function installVisualFixture(sandbox: SandboxProvider, computer: ComputerRef) {
+  const source = `
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+PAGE = b'''<!doctype html><meta charset="utf-8"><title>Rakazo visual test</title>
+<style>body{font-family:sans-serif;text-align:center;padding-top:120px}button{width:760px;height:300px;font-size:58px;background:#2563eb;color:white;border:0;border-radius:24px}</style>
+<button onclick="fetch('/passed',{method:'POST'}).then(()=>document.body.innerHTML='<h1 style=font-size:72px>VISUAL E2E PASSED</h1>')">CLICK TO PASS</button>'''
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+    def do_GET(self):
+        self.send_response(200); self.send_header('Content-Type', 'text/html'); self.end_headers(); self.wfile.write(PAGE)
+    def do_POST(self):
+        Path('results').mkdir(exist_ok=True)
+        Path('results/visual-click.txt').write_text('visual-click-ok')
+        self.send_response(204); self.end_headers()
+
+HTTPServer(('127.0.0.1', 8765), Handler).serve_forever()
+`;
+  const context = testContext(computer.botId);
+  await sandbox.writeFile(
+    computer,
+    { path: "visual_server.py", content: new TextEncoder().encode(source) },
+    context,
+  );
+  for await (const event of sandbox.execute(
+    computer,
+    { argv: ["bash", "-lc", "nohup python3 visual_server.py > visual-server.log 2>&1 &"] },
+    context,
+  )) {
+    if (event.type === "exit" && event.code !== 0)
+      throw new Error("fixture server failed to start");
+  }
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    let ready = false;
+    for await (const event of sandbox.execute(
+      computer,
+      { argv: ["bash", "-lc", "curl -fsS http://127.0.0.1:8765 >/dev/null"] },
+      context,
+    )) {
+      if (event.type === "exit") ready = event.code === 0;
+    }
+    if (ready) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("visual fixture did not become ready");
+}
+
+function testContext(botId: string) {
+  return {
+    operationId: "computer-e2e",
+    traceId: "computer-e2e",
+    workspaceId: "computer-e2e",
+    userId: "computer-e2e",
+    botId,
+    signal: new AbortController().signal,
+  };
+}
+
+type App = { request: (input: string, init?: RequestInit) => Promise<Response> };
+type Snapshot = { run: { status: string } | null };
+
+function cookieHeader(response: Response) {
+  const many = response.headers.getSetCookie?.() ?? [];
+  if (many.length) return many.map((cookie) => cookie.split(";")[0]).join("; ");
+  return response.headers.get("set-cookie")?.split(",")[0]?.split(";")[0] ?? "";
+}
+
+async function rpc<T>(app: App, cookie: string, procedure: string, body: unknown): Promise<T> {
+  const response = await app.request(`/rpc/${procedure}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie, origin: "http://127.0.0.1:5173" },
+    body: JSON.stringify({ json: body }),
+  });
+  const parsed = (await response.json()) as { json?: T; error?: { message?: string } };
+  if (!response.ok || parsed.error) {
+    throw new Error(`${procedure} ${response.status}: ${parsed.error?.message ?? "failed"}`);
+  }
+  return parsed.json as T;
+}
+
+async function waitFor(app: App, cookie: string, botId: string, timeoutMs: number) {
+  const started = Date.now();
+  let snapshot: Snapshot | undefined;
+  while (Date.now() - started < timeoutMs) {
+    snapshot = await rpc<Snapshot>(app, cookie, "threads/get", { botId });
+    if (snapshot.run && ["completed", "failed", "cancelled"].includes(snapshot.run.status)) {
+      return snapshot;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`computer E2E timed out with status ${snapshot?.run?.status ?? "unknown"}`);
+}

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -103,6 +103,12 @@ describeJourneys("required product journeys", () => {
     expect(chiefFile.content).toContain("isolation-ok");
     const computer = await rpc<{ state: string }>(app, ada, "computer/status", { botId: chief.id });
     expect(computer.state).toBe("running");
+    await rpc(app, ada, "computer/stop", { botId: chief.id });
+    const persisted = await rpc<{ content: string }>(app, ada, "computer/readFile", {
+      botId: chief.id,
+      path: "notes/result.txt",
+    });
+    expect(persisted.content).toContain("isolation-ok");
     const coderMem = await rpc<Array<{ content: string }>>(app, ada, "memory/list", {
       botId: coder.id,
     });
@@ -156,6 +162,7 @@ describeJourneys("required product journeys", () => {
     expect(JSON.stringify(waiting.messages)).not.toMatch(/password|secret|token/i);
     await rpc(app, cookie, "computer/boot", { botId: bot.id });
     await rpc(app, cookie, "computer/takeover", { botId: bot.id });
+    await rpc(app, cookie, "computer/release", { botId: bot.id });
     const done = await waitFor(
       app,
       cookie,


### PR DESCRIPTION
## Summary

- add provider-neutral computer, filesystem, shell, and graphical-control contracts
- implement the remote desktop backend with externally checkpointed workspace and browser-profile persistence
- support model-agnostic visual tool results, human desktop access, lifecycle management, and local provider parity
- add deterministic coverage plus an explicit real-model/real-sandbox acceptance test

## Verification

- pnpm lint
- pnpm check
- pnpm verify
- 49 test files passed, 195 tests passed, 2 Playwright journeys passed

The paid real-model acceptance test remains opt-in and was not run as part of the normal suite.