### PR TITLE
Fix the live computer acceptance test

### DIFF
--- a/packages/testkit/src/cli/computer.ts
+++ b/packages/testkit/src/cli/computer.ts
@@ -18,6 +18,7 @@ async function main() {
     REALTIME_DATABASE_URL: database.getConnectionUri(),
     RUN_COMPUTER_E2E: "1",
     VERIFY_PROVIDERS: "1",
+    COMPOSIO_API_KEY: "",
     WAKEUP_DRIVER: "memory",
     SANDBOX_PROVIDER: "e2b",
     AGENT_RUNTIME: "pi",

--- a/packages/testkit/src/cli/computer.ts
+++ b/packages/testkit/src/cli/computer.ts
@@ -17,6 +17,7 @@ async function main() {
     DATABASE_URL: database.getConnectionUri(),
     REALTIME_DATABASE_URL: database.getConnectionUri(),
     RUN_COMPUTER_E2E: "1",
+    VERIFY_PROVIDERS: "1",
     WAKEUP_DRIVER: "memory",
     SANDBOX_PROVIDER: "e2b",
     AGENT_RUNTIME: "pi",

--- a/packages/testkit/src/computer-use.e2e.test.ts
+++ b/packages/testkit/src/computer-use.e2e.test.ts
@@ -88,8 +88,15 @@ describeLive("real model and E2B computer journey", () => {
         "Finally use write_file to create results/llm-confirmed.txt containing exactly visual-e2e-ok.",
       ].join(" "),
     });
-    const snapshot = await waitFor(handles.app, cookie, bot.id, 180_000);
-    expect(snapshot.run?.status).toBe("completed");
+    const completedRun = await waitForRun(
+      () =>
+        handles.prisma.run.findUnique({
+          where: { id: sent.runId },
+          select: { status: true, error: true },
+        }),
+      180_000,
+    );
+    expect(completedRun.status, completedRun.error ?? undefined).toBe("completed");
 
     const clickMarker = new TextDecoder().decode(
       await handles.sandbox.readFile(computer, "results/visual-click.txt", testContext(bot.id)),
@@ -211,7 +218,7 @@ function testContext(botId: string) {
 }
 
 type App = { request: (input: string, init?: RequestInit) => Promise<Response> };
-type Snapshot = { run: { status: string } | null };
+type RunState = { status: string; error: string | null };
 
 async function rpc<T>(app: App, cookie: string, procedure: string, body: unknown): Promise<T> {
   const response = await app.request(`/rpc/${procedure}`, {
@@ -226,15 +233,13 @@ async function rpc<T>(app: App, cookie: string, procedure: string, body: unknown
   return parsed.json as T;
 }
 
-async function waitFor(app: App, cookie: string, botId: string, timeoutMs: number) {
+async function waitForRun(load: () => Promise<RunState | null>, timeoutMs: number) {
   const started = Date.now();
-  let snapshot: Snapshot | undefined;
+  let run: RunState | null = null;
   while (Date.now() - started < timeoutMs) {
-    snapshot = await rpc<Snapshot>(app, cookie, "threads/get", { botId });
-    if (snapshot.run && ["completed", "failed", "cancelled"].includes(snapshot.run.status)) {
-      return snapshot;
-    }
+    run = await load();
+    if (run && ["completed", "failed", "cancelled"].includes(run.status)) return run;
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
-  throw new Error(`computer E2E timed out with status ${snapshot?.run?.status ?? "unknown"}`);
+  throw new Error(`computer E2E timed out with status ${run?.status ?? "unknown"}`);
 }


### PR DESCRIPTION
Summary:
- preserve the live provider/database environment inside the computer acceptance Vitest process while explicitly disabling unrelated Composio initialization
- wait on the persisted run record because thread snapshots intentionally expose only active runs
- surface terminal run errors directly in the assertion

Verification on current main 9d7e7a6:
- pnpm test (244 passed, 38 skipped)
- full workspace typecheck
- COMPUTER_E2E_MODEL=openai/gpt-5.6-luna-pro pnpm test:computer (real OpenRouter + real E2B; passed in 124 seconds after the test-command refactor, with Composio disabled)

The live run observed and clicked the E2B desktop, verified the click marker, created a requested file, reprovisioned the sandbox, and verified checkpoint restoration. No credentials or live data are included.