### PR TITLE
Fix mobile Metro TypeScript source resolution

### DIFF
--- a/apps/mobile/lib/metro-resolver.test.ts
+++ b/apps/mobile/lib/metro-resolver.test.ts
@@ -1,0 +1,52 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { resolveTypeScriptSource } = require("../metro-resolver.js") as {
+  resolveTypeScriptSource: (
+    context: { originModulePath?: string },
+    moduleName: string,
+    platform: string,
+    resolveRequest: (
+      context: { originModulePath?: string },
+      moduleName: string,
+      platform: string,
+    ) => unknown,
+  ) => unknown;
+};
+
+describe("mobile Metro resolver", () => {
+  it("resolves Node ESM-style JavaScript specifiers to TypeScript source", () => {
+    const resolved = { type: "sourceFile", filePath: "/repo/packages/core/src/async.ts" };
+    const resolveRequest = vi.fn((_context, moduleName: string) => {
+      if (moduleName === "./async") return resolved;
+      throw new Error(`Unexpected module: ${moduleName}`);
+    });
+
+    expect(
+      resolveTypeScriptSource(
+        { originModulePath: "/repo/packages/core/src/index.ts" },
+        "./async.js",
+        "ios",
+        resolveRequest,
+      ),
+    ).toEqual(resolved);
+    expect(resolveRequest).toHaveBeenCalledWith(
+      { originModulePath: "/repo/packages/core/src/index.ts" },
+      "./async",
+      "ios",
+    );
+  });
+
+  it("keeps ordinary JavaScript imports on Metro's normal path", () => {
+    const resolved = { type: "sourceFile", filePath: "/repo/app/helper.js" };
+    const resolveRequest = vi.fn(() => resolved);
+    const context = { originModulePath: "/repo/app/index.js" };
+
+    expect(resolveTypeScriptSource(context, "./helper.js", "ios", resolveRequest)).toEqual(
+      resolved,
+    );
+    expect(resolveRequest).toHaveBeenCalledOnce();
+    expect(resolveRequest).toHaveBeenCalledWith(context, "./helper.js", "ios");
+  });
+});

--- a/apps/mobile/metro-resolver.js
+++ b/apps/mobile/metro-resolver.js
@@ -1,0 +1,16 @@
+function resolveTypeScriptSource(context, moduleName, platform, resolveRequest) {
+  const importer = context.originModulePath ?? "";
+  const isTypeScriptImporter = /\.[cm]?tsx?$/.test(importer);
+
+  if (isTypeScriptImporter && moduleName.startsWith(".") && moduleName.endsWith(".js")) {
+    try {
+      return resolveRequest(context, moduleName.slice(0, -3), platform);
+    } catch {
+      // Preserve Metro's normal resolution and error for real JavaScript imports.
+    }
+  }
+
+  return resolveRequest(context, moduleName, platform);
+}
+
+module.exports = { resolveTypeScriptSource };

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig } = require("expo/metro-config");
+const { resolveTypeScriptSource } = require("./metro-resolver");
 
 const projectRoot = __dirname;
 const config = getDefaultConfig(projectRoot);
@@ -18,9 +19,9 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
     }
   }
   if (defaultResolveRequest) {
-    return defaultResolveRequest(context, moduleName, platform);
+    return resolveTypeScriptSource(context, moduleName, platform, defaultResolveRequest);
   }
-  return context.resolveRequest(context, moduleName, platform);
+  return resolveTypeScriptSource(context, moduleName, platform, context.resolveRequest);
 };
 
 module.exports = config;


### PR DESCRIPTION
## Summary
- resolve Node ESM-style relative `.js` specifiers from TypeScript workspace source in the mobile Metro config
- preserve normal Metro resolution for ordinary JavaScript imports
- add focused resolver regression coverage

## Verification
- `pnpm --filter @rakazo/mobile check`
- `pnpm --filter @rakazo/mobile test` (44 tests)
- `biome check` on changed files
- `expo export --platform ios --clear`
- `expo export --platform android --clear`
- native iOS Simulator launch on iPhone 17 / iOS 26.5 through the sign-in screen and authenticated app shell

Before this change, both the native dev client and `expo export` failed on `packages/core/src/index.ts` because Metro looked for `./async.js` while the workspace source is `async.ts`.