### PR TITLE
Refresh the mobile bot list on return

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,4 +1,4 @@
-import { Redirect, useRouter } from "expo-router";
+import { Redirect, useFocusEffect, useRouter } from "expo-router";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
@@ -59,11 +59,16 @@ export default function Home() {
   useEffect(() => {
     if (!hasSession) return;
     void registerPushToken().catch(() => undefined);
-    void loadBots();
     void rpc<MobileMe>("me")
       .then(setMe)
       .catch(() => undefined);
-  }, [hasSession, loadBots]);
+  }, [hasSession]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (hasSession) void loadBots();
+    }, [hasSession, loadBots]),
+  );
 
   const visible = useMemo(() => filterBots(bots, query), [bots, query]);
   const initials = userInitials(me?.name ?? "");

--- a/apps/mobile/lib/metro-resolver.test.ts
+++ b/apps/mobile/lib/metro-resolver.test.ts
@@ -1,0 +1,52 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { resolveTypeScriptSource } = require("../metro-resolver.js") as {
+  resolveTypeScriptSource: (
+    context: { originModulePath?: string },
+    moduleName: string,
+    platform: string,
+    resolveRequest: (
+      context: { originModulePath?: string },
+      moduleName: string,
+      platform: string,
+    ) => unknown,
+  ) => unknown;
+};
+
+describe("mobile Metro resolver", () => {
+  it("resolves Node ESM-style JavaScript specifiers to TypeScript source", () => {
+    const resolved = { type: "sourceFile", filePath: "/repo/packages/core/src/async.ts" };
+    const resolveRequest = vi.fn((_context, moduleName: string) => {
+      if (moduleName === "./async") return resolved;
+      throw new Error(`Unexpected module: ${moduleName}`);
+    });
+
+    expect(
+      resolveTypeScriptSource(
+        { originModulePath: "/repo/packages/core/src/index.ts" },
+        "./async.js",
+        "ios",
+        resolveRequest,
+      ),
+    ).toEqual(resolved);
+    expect(resolveRequest).toHaveBeenCalledWith(
+      { originModulePath: "/repo/packages/core/src/index.ts" },
+      "./async",
+      "ios",
+    );
+  });
+
+  it("keeps ordinary JavaScript imports on Metro's normal path", () => {
+    const resolved = { type: "sourceFile", filePath: "/repo/app/helper.js" };
+    const resolveRequest = vi.fn(() => resolved);
+    const context = { originModulePath: "/repo/app/index.js" };
+
+    expect(resolveTypeScriptSource(context, "./helper.js", "ios", resolveRequest)).toEqual(
+      resolved,
+    );
+    expect(resolveRequest).toHaveBeenCalledOnce();
+    expect(resolveRequest).toHaveBeenCalledWith(context, "./helper.js", "ios");
+  });
+});

--- a/apps/mobile/metro-resolver.js
+++ b/apps/mobile/metro-resolver.js
@@ -1,0 +1,16 @@
+function resolveTypeScriptSource(context, moduleName, platform, resolveRequest) {
+  const importer = context.originModulePath ?? "";
+  const isTypeScriptImporter = /\.[cm]?tsx?$/.test(importer);
+
+  if (isTypeScriptImporter && moduleName.startsWith(".") && moduleName.endsWith(".js")) {
+    try {
+      return resolveRequest(context, moduleName.slice(0, -3), platform);
+    } catch {
+      // Preserve Metro's normal resolution and error for real JavaScript imports.
+    }
+  }
+
+  return resolveRequest(context, moduleName, platform);
+}
+
+module.exports = { resolveTypeScriptSource };

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig } = require("expo/metro-config");
+const { resolveTypeScriptSource } = require("./metro-resolver");
 
 const projectRoot = __dirname;
 const config = getDefaultConfig(projectRoot);
@@ -18,9 +19,9 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
     }
   }
   if (defaultResolveRequest) {
-    return defaultResolveRequest(context, moduleName, platform);
+    return resolveTypeScriptSource(context, moduleName, platform, defaultResolveRequest);
   }
-  return context.resolveRequest(context, moduleName, platform);
+  return resolveTypeScriptSource(context, moduleName, platform, context.resolveRequest);
 };
 
 module.exports = config;


### PR DESCRIPTION
## Summary
- reload the mobile bot list whenever the home screen regains focus
- keep account/push setup on its existing session lifecycle

## Verification
- `pnpm --filter @rakazo/mobile check`
- `pnpm --filter @rakazo/mobile test` (44 tests)
- `biome check apps/mobile/app/index.tsx`
- manual iOS Simulator flow against an ephemeral local Postgres/API: sign in, create a second bot, return to home, and confirm both bots render immediately without restarting

## Dependency
This is stacked on #14 because current `main` cannot bundle the mobile app until that Metro fix lands. Once #14 merges, this PR can be retargeted to `main`.