### PR TITLE
fix(www): repair the mobile hero and header

### DIFF
--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -8,17 +8,29 @@ type Props = {
 };
 
 const { starsLabel } = Astro.props;
+
+const NAV_LINKS = [
+  { href: "/#demo", label: "Product" },
+  { href: "/#roster", label: "Bots" },
+  { href: "/#selfhost", label: "Self-host" },
+  { href: "/#open-source", label: "Open source" },
+  { href: DOCS_URL, label: "Docs", external: true },
+];
+
+const externalAttrs = { target: "_blank", rel: "noreferrer" };
 ---
 
 <header class="site-header">
   <div class="site-header__left">
     <Logo />
     <nav class="site-nav" aria-label="Primary">
-      <a href="/#demo">Product</a>
-      <a href="/#roster">Bots</a>
-      <a href="/#selfhost">Self-host</a>
-      <a href="/#open-source">Open source</a>
-      <a href={DOCS_URL} target="_blank" rel="noreferrer">Docs</a>
+      {
+        NAV_LINKS.map((link) => (
+          <a href={link.href} {...(link.external ? externalAttrs : {})}>
+            {link.label}
+          </a>
+        ))
+      }
     </nav>
   </div>
   <div class="site-header__right">
@@ -26,6 +38,45 @@ const { starsLabel } = Astro.props;
       <span aria-hidden="true">★</span>
       <span>{starsLabel}</span>
     </a>
-    <Button href={GITHUB_URL} size="sm" external>View on GitHub</Button>
+    <div class="site-header__cta">
+      <Button href={GITHUB_URL} size="sm" external>View on GitHub</Button>
+    </div>
+    <details class="site-menu" data-site-menu>
+      <summary class="site-menu__toggle" aria-label="Menu">
+        <svg class="site-menu__icon site-menu__icon--open" viewBox="0 0 20 20" aria-hidden="true">
+          <path d="M3 6h14M3 10h14M3 14h14" />
+        </svg>
+        <svg class="site-menu__icon site-menu__icon--close" viewBox="0 0 20 20" aria-hidden="true">
+          <path d="M5 5l10 10M15 5L5 15" />
+        </svg>
+      </summary>
+      <nav class="site-menu__panel" aria-label="Site">
+        {
+          NAV_LINKS.map((link) => (
+            <a href={link.href} {...(link.external ? externalAttrs : {})}>
+              {link.label}
+            </a>
+          ))
+        }
+      </nav>
+    </details>
   </div>
 </header>
+
+<script>
+  const menu = document.querySelector<HTMLDetailsElement>("[data-site-menu]");
+
+  if (menu) {
+    menu.addEventListener("click", (event) => {
+      if ((event.target as HTMLElement).closest("a")) menu.open = false;
+    });
+
+    document.addEventListener("click", (event) => {
+      if (menu.open && !menu.contains(event.target as Node)) menu.open = false;
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") menu.open = false;
+    });
+  }
+</script>

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -21,7 +21,7 @@ const starsLabel = stars === null ? "Star" : formatStarCount(stars);
       <section class="hero">
         <a class="hero__pill" href="#selfhost">
           <span class="hero__badge">Apache-2.0</span>
-          <span>Open source alternative to Grok Bot — run it on your own machine</span>
+          <span>Open source alternative to Grok Bot<span class="hero__pill-tail"> — run it on your own machine</span></span>
         </a>
         <h1>AI teammates you actually own</h1>
         <p class="lead">
@@ -30,7 +30,7 @@ const starsLabel = stars === null ? "Star" : formatStarCount(stars);
         </p>
         <div class="hero__actions">
           <Button href={GITHUB_URL} external>View on GitHub</Button>
-          <Button href={GITHUB_URL} variant="secondary" external>Star on GitHub</Button>
+          <Button href="#demo" variant="secondary">See it in action</Button>
         </div>
       </section>
 
@@ -132,7 +132,6 @@ const starsLabel = stars === null ? "Star" : formatStarCount(stars);
           <p>Clone the repo, add a model key, and hand it something you have been putting off.</p>
           <div class="cta-actions">
             <Button href={GITHUB_URL} external>View on GitHub</Button>
-            <Button href={GITHUB_URL} variant="secondary" external>Star on GitHub</Button>
           </div>
         </div>
         <div class="stats-grid">

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -200,6 +200,7 @@ button {
   padding: 7px 14px;
   color: #525252;
   font-size: 14px;
+  white-space: nowrap;
   box-shadow: var(--shadow-soft);
   transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
 }
@@ -209,6 +210,75 @@ button {
 .button:hover,
 .button:focus-visible {
   transform: translateY(-1px);
+}
+
+.site-menu {
+  position: relative;
+  display: none;
+}
+
+.site-menu__toggle {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  color: var(--ink);
+  box-shadow: var(--shadow-soft);
+  list-style: none;
+  cursor: pointer;
+}
+
+.site-menu__toggle::-webkit-details-marker {
+  display: none;
+}
+
+.site-menu__icon {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+
+.site-menu__icon--close,
+.site-menu[open] .site-menu__icon--open {
+  display: none;
+}
+
+.site-menu[open] .site-menu__icon--close {
+  display: block;
+}
+
+.site-menu__panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 10px);
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  min-width: 208px;
+  border: 1px solid var(--line-2);
+  border-radius: 16px;
+  background: #fff;
+  padding: 8px;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.12);
+}
+
+.site-menu__panel a {
+  border-radius: 10px;
+  padding: 11px 12px;
+  color: var(--body);
+  font-size: 15.5px;
+}
+
+.site-menu__panel a:hover,
+.site-menu__panel a:focus-visible {
+  background: var(--surface-soft);
+  color: var(--ink);
 }
 
 .button {
@@ -264,6 +334,7 @@ button {
   display: inline-flex;
   align-items: center;
   gap: 10px;
+  max-width: 100%;
   margin-bottom: 30px;
   padding: 6px 14px 6px 8px;
   border: 1px solid var(--blue-line);
@@ -271,13 +342,17 @@ button {
   background: linear-gradient(to bottom, var(--blue-soft), var(--blue-soft-2));
   color: var(--blue);
   font-size: 13px;
+  line-height: 1.4;
+  text-align: left;
 }
 
 .hero__badge {
+  flex: none;
   border-radius: 999px;
   background: #fff;
   padding: 2px 8px;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .hero h1,
@@ -1729,19 +1804,18 @@ button {
   }
 }
 
-@media (max-width: 960px) {
-  .site-header,
-  .site-header__left,
-  .site-header__right {
-    flex-direction: column;
-    align-items: stretch;
+@media (max-width: 1000px) {
+  .site-header__left {
+    gap: 26px;
   }
 
   .site-nav {
-    flex-wrap: wrap;
-    gap: 14px 20px;
+    gap: 18px;
+    font-size: 14.5px;
   }
+}
 
+@media (max-width: 960px) {
   .card-grid-3,
   .comparison-grid,
   .stats-band {
@@ -1755,6 +1829,20 @@ button {
 }
 
 @media (max-width: 860px) {
+  .site-header {
+    gap: 12px;
+    padding: 16px 0;
+  }
+
+  .site-nav,
+  .site-header__cta {
+    display: none;
+  }
+
+  .site-menu {
+    display: block;
+  }
+
   .product-demo__frame,
   .product-demo__frame.is-collapsed {
     display: block;
@@ -1781,11 +1869,30 @@ button {
   }
 
   .hero {
-    padding-top: 32px;
+    padding-top: 26px;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.375rem, 9vw, 3rem);
   }
 
   .hero__pill {
-    text-align: left;
+    margin-bottom: 22px;
+    padding: 5px 12px 5px 6px;
+    font-size: 12.5px;
+  }
+
+  .hero__pill-tail {
+    display: none;
+  }
+
+  .lead {
+    margin-top: 18px;
+    font-size: 17px;
+  }
+
+  .hero__actions {
+    margin-top: 26px;
   }
 
   .hero__actions,


### PR DESCRIPTION
Below 960px the header stacked into three full-width rows — logo, wrapped nav, star pill, and a full-width "View on GitHub" button — which pushed the hero clean off the first screen on a phone, and the `Apache-2.0` badge in the hero pill wrapped mid-word.

The nav now collapses into a disclosure menu below 860px so the header stays a single row (logo · star count · menu), the badge is pinned to one line and the pill drops its trailing clause on small screens, and the hero type scales down so the headline, subhead, and both CTAs land in the first viewport. Also removed the duplicate GitHub CTAs: the header button is hidden on mobile since the star pill already links to the repo, the hero's second button now points at the demo instead of repeating the same URL, and the bottom band is a single button.

Verified in a browser at 320 / 390 / 820 / 940 / 1280px; `biome check` and `astro check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)