### PR TITLE
feat: add bot context menu actions

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -229,6 +229,17 @@ export function createRouter(deps: RouterDeps) {
       create: authed.bots.create.handler(async ({ context, input }) =>
         repos.createBot(context.actor, input),
       ),
+      duplicate: authed.bots.duplicate.handler(async ({ context, input }) => {
+        const source = await repos.getBot(context.actor, input.botId);
+        return repos.createBot(context.actor, {
+          name: duplicateBotName(source.name),
+          title: source.title,
+          description: source.description,
+          instructions: source.instructions,
+          notifyOnFinish: source.notifyOnFinish,
+          color: source.color,
+        });
+      }),
       update: authed.bots.update.handler(async ({ context, input }) => {
         await repos.getBot(context.actor, input.botId);
         await deps.prisma.bot.update({
@@ -240,6 +251,7 @@ export function createRouter(deps: RouterDeps) {
             instructions: input.instructions,
             notifyOnFinish: input.notifyOnFinish,
             color: input.color,
+            pinned: input.pinned,
           },
         });
         const bots = await repos.listBots(context.actor);
@@ -1322,4 +1334,8 @@ function withViewOnly(url: string, viewOnly: boolean) {
     const join = url.includes("?") ? "&" : "?";
     return `${url}${join}view_only=${viewOnly ? "true" : "false"}`;
   }
+}
+
+function duplicateBotName(name: string) {
+  return `${name.slice(0, 75)} copy`;
 }

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -132,6 +132,7 @@ export type MobileBot = {
   preview: string;
   title: string;
   color: string;
+  pinned: boolean;
   updatedAt: string;
   parentBotId?: string | null;
 };

--- a/apps/mobile/lib/inbox.test.ts
+++ b/apps/mobile/lib/inbox.test.ts
@@ -67,5 +67,13 @@ function local(base: Date, daysAgo: number, hours: number, minutes: number) {
 }
 
 function bot(id: string, name: string, title: string, preview: string) {
-  return { id, name, title, preview, color: "#9B5CF6", updatedAt: now.toISOString() };
+  return {
+    id,
+    name,
+    title,
+    preview,
+    color: "#9B5CF6",
+    pinned: false,
+    updatedAt: now.toISOString(),
+  };
 }

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -114,6 +114,35 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }) => {
   ).toBeVisible();
 });
 
+test("bot context menu pins, duplicates, edits, and confirms deletion", async ({ page }) => {
+  const stamp = Date.now();
+  await signup(page, `menu-${stamp}@rakazo.test`, "password12", "Menu");
+  await completeOnboarding(page, ["A bit of everything", "Clear and tight"]);
+
+  const chief = page.getByRole("button", { name: /Chief/ }).first();
+  await chief.click({ button: "right" });
+  await expect(page.getByRole("menu", { name: "Actions for Chief" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Edit Profile" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Duplicate" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Delete" })).toBeVisible();
+  await page.getByRole("menuitem", { name: "Pin", exact: true }).click();
+
+  await chief.click({ button: "right" });
+  await expect(page.getByRole("menuitem", { name: "Unpin", exact: true })).toBeVisible();
+  await page.getByRole("menuitem", { name: "Duplicate" }).click();
+  await expect(page.getByText("Chief copy").first()).toBeVisible();
+
+  const copy = page.getByRole("button", { name: /Chief copy/ }).first();
+  await copy.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await expect(page.getByRole("alertdialog", { name: "Delete Chief copy?" })).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
+
+  await chief.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Edit Profile" }).click();
+  await expect(page.locator("label:has-text('Name') input")).toHaveValue("Chief");
+});
+
 async function completeOnboarding(page: Page, answers: string[]) {
   await page.waitForURL(/\/(onboarding|app)/, { timeout: 20_000 });
   const heading = page.getByRole("heading", { name: /Connect a model|Create your first bot/ });

--- a/apps/web/src/pages/BotContextMenu.tsx
+++ b/apps/web/src/pages/BotContextMenu.tsx
@@ -1,0 +1,147 @@
+import type { Bot } from "@rakazo/contracts";
+import { type ReactNode, type Ref, useEffect, useRef } from "react";
+
+export type ContextMenuPosition = { x: number; y: number };
+
+export function BotContextMenu({
+  bot,
+  position,
+  onClose,
+  onTogglePinned,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: {
+  bot: Bot;
+  position: ContextMenuPosition;
+  onClose: () => void;
+  onTogglePinned: () => void;
+  onEdit: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  const firstItem = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    firstItem.current?.focus();
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const menuWidth = 264;
+  const menuHeight = 210;
+  const margin = 8;
+  const left = Math.min(position.x, window.innerWidth - menuWidth - margin);
+  const top = Math.min(position.y, window.innerHeight - menuHeight - margin);
+
+  return (
+    <div className="fixed inset-0 z-40">
+      <button
+        type="button"
+        aria-label="Close bot menu"
+        className="absolute inset-0 cursor-default"
+        onClick={onClose}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          onClose();
+        }}
+      />
+      <div
+        role="menu"
+        aria-label={`Actions for ${bot.name}`}
+        className="fixed w-[264px] rounded-[18px] border border-[#343438] bg-[#1A1A1D] p-2 shadow-[0_24px_60px_rgba(0,0,0,.62)]"
+        style={{ left: Math.max(margin, left), top: Math.max(margin, top) }}
+      >
+        <MenuItem
+          buttonRef={firstItem}
+          icon={<PinIcon />}
+          label={bot.pinned ? "Unpin" : "Pin"}
+          onSelect={onTogglePinned}
+        />
+        <div className="my-1 border-t border-[#343438]" />
+        <MenuItem icon={<EditIcon />} label="Edit Profile" onSelect={onEdit} />
+        <MenuItem icon={<DuplicateIcon />} label="Duplicate" onSelect={onDuplicate} />
+        <div className="my-1 border-t border-[#343438]" />
+        <MenuItem icon={<TrashIcon />} label="Delete" tone="danger" onSelect={onDelete} />
+      </div>
+    </div>
+  );
+}
+
+function MenuItem({
+  buttonRef,
+  icon,
+  label,
+  tone = "default",
+  onSelect,
+}: {
+  buttonRef?: Ref<HTMLButtonElement>;
+  icon: ReactNode;
+  label: string;
+  tone?: "default" | "danger";
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      role="menuitem"
+      className={`flex w-full items-center gap-3 rounded-[11px] px-3 py-2.5 text-left text-[15px] outline-none hover:bg-[#29292D] focus-visible:bg-[#29292D] ${
+        tone === "danger" ? "text-[#FF5364]" : "text-[#ECECEE]"
+      }`}
+      onClick={onSelect}
+    >
+      <span className="grid h-5 w-5 shrink-0 place-items-center">{icon}</span>
+      <span>{label}</span>
+    </button>
+  );
+}
+
+const iconProps = {
+  width: 19,
+  height: 19,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.8,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  "aria-hidden": true,
+};
+
+function PinIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="m15 4 5 5-4 2-3 5-2-2-5 5-1-1 5-5-2-2 5-3 2-4Z" />
+    </svg>
+  );
+}
+
+function EditIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L8 18l-4 1 1-4Z" />
+    </svg>
+  );
+}
+
+function DuplicateIcon() {
+  return (
+    <svg {...iconProps}>
+      <rect x="8" y="8" width="12" height="12" rx="2" />
+      <path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2" />
+    </svg>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="M3 6h18M8 6V4h8v2m-9 0 1 15h8l1-15M10 10v7m4-7v7" />
+    </svg>
+  );
+}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -15,7 +15,15 @@ import {
   presetFromCron,
 } from "@rakazo/core";
 import { BotAvatar, Button } from "@rakazo/ui-web";
-import { type Dispatch, type SetStateAction, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { authClient } from "../lib/auth";
 import { rpc } from "../lib/rpc";
@@ -25,6 +33,7 @@ import {
   reduceComputerStatus,
   reduceThreadSnapshot,
 } from "../lib/thread-events";
+import { BotContextMenu, type ContextMenuPosition } from "./BotContextMenu";
 import { HostComputerPrompt } from "./HostComputerPrompt";
 import { PluginsOverlay } from "./PluginsOverlay";
 import { RoutineSchedule } from "./RoutineSchedule";
@@ -45,6 +54,11 @@ export function ShellPage() {
   const [computer, setComputer] = useState<ComputerStatus | null>(null);
   const [pluginsOpen, setPluginsOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [botMenu, setBotMenu] = useState<{
+    botId: string;
+    position: ContextMenuPosition;
+  } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Bot | null>(null);
   const [booting, setBooting] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [routineDraft, setRoutineDraft] = useState({
@@ -64,6 +78,8 @@ export function ShellPage() {
   const messageScroll = useRef<HTMLDivElement>(null);
 
   const active = bots.find((b) => b.id === botId) ?? bots[0];
+  const contextBot = botMenu ? bots.find((bot) => bot.id === botMenu.botId) : undefined;
+  const closeBotMenu = useCallback(() => setBotMenu(null), []);
 
   async function refreshBots() {
     const list = await rpc.bots.list();
@@ -326,6 +342,10 @@ export function ShellPage() {
               key={bot.id}
               type="button"
               onClick={() => navigate(`/app/${bot.id}`)}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                setBotMenu({ botId: bot.id, position: { x: event.clientX, y: event.clientY } });
+              }}
               className="flex gap-3 rounded-xl px-2.5 py-[11px] text-left"
               style={{
                 background: active?.id === bot.id ? "#161618" : "transparent",
@@ -751,6 +771,49 @@ export function ShellPage() {
           </div>
         ) : null}
       </aside>
+
+      {contextBot && botMenu ? (
+        <BotContextMenu
+          bot={contextBot}
+          position={botMenu.position}
+          onClose={closeBotMenu}
+          onTogglePinned={() => {
+            setBotMenu(null);
+            void rpc.bots
+              .update({ botId: contextBot.id, pinned: !contextBot.pinned })
+              .then(() => refreshBots());
+          }}
+          onEdit={() => {
+            navigate(`/app/${contextBot.id}`);
+            setPanel("settings");
+            setBotMenu(null);
+          }}
+          onDuplicate={() => {
+            setBotMenu(null);
+            void rpc.bots.duplicate({ botId: contextBot.id }).then(async (bot) => {
+              await refreshBots();
+              navigate(`/app/${bot.id}`);
+            });
+          }}
+          onDelete={() => {
+            setDeleteTarget(contextBot);
+            setBotMenu(null);
+          }}
+        />
+      ) : null}
+
+      {deleteTarget ? (
+        <DeleteBotDialog
+          bot={deleteTarget}
+          onCancel={() => setDeleteTarget(null)}
+          onConfirm={async () => {
+            await rpc.bots.remove({ botId: deleteTarget.id });
+            setDeleteTarget(null);
+            setPanel(null);
+            await refreshBots();
+          }}
+        />
+      ) : null}
 
       {pluginsOpen ? <PluginsOverlay onClose={() => setPluginsOpen(false)} /> : null}
 
@@ -1211,6 +1274,80 @@ function BotSettings({
             Delete bot
           </button>
         )}
+      </div>
+    </div>
+  );
+}
+
+function DeleteBotDialog({
+  bot,
+  onCancel,
+  onConfirm,
+}: {
+  bot: Bot;
+  onCancel: () => void;
+  onConfirm: () => Promise<void>;
+}) {
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !deleting) onCancel();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [deleting, onCancel]);
+
+  return (
+    <div
+      role="presentation"
+      className="absolute inset-0 z-50 grid place-items-center bg-[rgba(4,4,5,.76)] px-5"
+      onPointerDown={() => {
+        if (!deleting) onCancel();
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="delete-bot-title"
+        aria-describedby="delete-bot-description"
+        className="w-full max-w-[420px] rounded-[18px] border border-[#343438] bg-[#1A1A1D] p-5 shadow-[0_24px_70px_rgba(0,0,0,.65)]"
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <h2 id="delete-bot-title" className="text-[17px] font-medium text-[#F1F1F2]">
+          Delete {bot.name}?
+        </h2>
+        <p id="delete-bot-description" className="mt-2 text-[14px] leading-6 text-[#9A9AA0]">
+          This permanently deletes its conversation, computer, memory, and routines. Bots it created
+          stay in your list.
+        </p>
+        {error ? <p className="mt-3 text-[13.5px] text-[#FF5364]">{error}</p> : null}
+        <div className="mt-5 flex justify-end gap-2.5">
+          <button
+            type="button"
+            disabled={deleting}
+            onClick={onCancel}
+            className="rounded-[10px] px-3.5 py-2 text-[14px] text-[#C9C9CE] hover:bg-[#29292D] disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={deleting}
+            onClick={() => {
+              setDeleting(true);
+              setError(null);
+              void onConfirm().catch((err: unknown) => {
+                setError(err instanceof Error ? err.message : "Could not delete bot");
+                setDeleting(false);
+              });
+            }}
+            className="rounded-[10px] bg-[#FF5364] px-3.5 py-2 text-[14px] font-medium text-white disabled:opacity-40"
+          >
+            {deleting ? "Deleting…" : "Delete"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -11,6 +11,7 @@ export const BotSchema = z.object({
   instructions: z.string(),
   color: z.string(),
   notifyOnFinish: z.boolean(),
+  pinned: z.boolean(),
   parentBotId: Id.nullable(),
   threadId: Id,
   preview: z.string(),
@@ -38,6 +39,7 @@ export const UpdateBotInput = z.object({
   instructions: z.string().max(20000).optional(),
   notifyOnFinish: z.boolean().optional(),
   color: z.string().optional(),
+  pinned: z.boolean().optional(),
 });
 
 export const RoutineSchema = z.object({

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -100,6 +100,7 @@ export const appContract = {
     list: oc.output(z.array(BotSchema)),
     get: oc.input(botId).output(BotSchema),
     create: oc.input(CreateBotInput).output(BotSchema),
+    duplicate: oc.input(botId).output(BotSchema),
     update: oc.input(UpdateBotInput).output(BotSchema),
     remove: oc.input(botId).output(z.object({ ok: z.literal(true) })),
   },

--- a/packages/db/prisma/migrations/0005_bot_pinned/migration.sql
+++ b/packages/db/prisma/migrations/0005_bot_pinned/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "bots" ADD COLUMN "pinned" BOOLEAN NOT NULL DEFAULT false;
+
+DROP INDEX "bots_workspaceId_userId_idx";
+
+CREATE INDEX "bots_workspaceId_userId_pinned_updatedAt_idx"
+ON "bots"("workspaceId", "userId", "pinned", "updatedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -179,6 +179,7 @@ model Bot {
   instructions   String   @default("")
   color          String
   notifyOnFinish Boolean  @default(true)
+  pinned         Boolean  @default(false)
   parentBotId    String?
   parent         Bot?     @relation("BotChildren", fields: [parentBotId], references: [id], onDelete: SetNull)
   children       Bot[]    @relation("BotChildren")
@@ -195,7 +196,7 @@ model Bot {
   tasks          Task[]
   runs           Run[]
 
-  @@index([workspaceId, userId])
+  @@index([workspaceId, userId, pinned, updatedAt])
   @@index([parentBotId])
   @@map("bots")
 }

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -12,6 +12,7 @@ function mapBot(
     instructions: string;
     color: string;
     notifyOnFinish: boolean;
+    pinned: boolean;
     parentBotId: string | null;
     createdAt: Date;
     updatedAt: Date;
@@ -32,6 +33,7 @@ function mapBot(
     instructions: bot.instructions,
     color: bot.color,
     notifyOnFinish: bot.notifyOnFinish,
+    pinned: bot.pinned,
     parentBotId: bot.parentBotId,
     threadId: bot.thread.id,
     preview,
@@ -60,7 +62,7 @@ export function createRepos(prisma: PrismaClient) {
             take: 1,
           },
         },
-        orderBy: { updatedAt: "desc" },
+        orderBy: [{ pinned: "desc" }, { updatedAt: "desc" }],
       });
       return bots.map((bot) => {
         const blocks = (bot.thread?.messages[0]?.blocks ?? []) as Array<{
@@ -93,10 +95,13 @@ export function createRepos(prisma: PrismaClient) {
         parentBotId?: string | null;
       },
     ): Promise<Bot> {
-      const count = await prisma.bot.count({
-        where: { workspaceId: actor.workspaceId, userId: actor.userId },
-      });
-      const color = input.color ?? BOT_COLORS[count % BOT_COLORS.length] ?? BOT_COLORS[0];
+      let color = input.color;
+      if (color === undefined) {
+        const count = await prisma.bot.count({
+          where: { workspaceId: actor.workspaceId, userId: actor.userId },
+        });
+        color = BOT_COLORS[count % BOT_COLORS.length] ?? BOT_COLORS[0];
+      }
       if (input.parentBotId) {
         const parent = await prisma.bot.findFirst({
           where: {

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -61,6 +61,7 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["bots/list"],
       ["bots/get", { botId: "missing-bot" }],
       ["bots/create", botInput("Unauthenticated")],
+      ["bots/duplicate", { botId: "missing-bot" }],
       ["bots/update", { botId: "missing-bot", name: "Nope" }],
       ["bots/remove", { botId: "missing-bot" }],
       ["threads/get", { botId: "missing-bot" }],
@@ -195,6 +196,7 @@ describeWithDatabase("API authorization and resource isolation", () => {
 
     const botIdCalls: Array<[string, unknown]> = [
       ["bots/get", { botId: ownerBot.id }],
+      ["bots/duplicate", { botId: ownerBot.id }],
       ["bots/update", { botId: ownerBot.id, name: "Stolen Bot" }],
       ["threads/get", { botId: ownerBot.id }],
       ["threads/messages", { botId: ownerBot.id, before: 1 }],

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -89,6 +89,21 @@ describeJourneys("required product journeys", () => {
     const forbidden = await raw(app, bob, "bots/get", { botId: chief.id });
     expect(forbidden.status).toBeGreaterThanOrEqual(400);
 
+    const pinned = await rpc<Bot>(app, ada, "bots/update", { botId: coder.id, pinned: true });
+    expect(pinned.pinned).toBe(true);
+    const duplicate = await rpc<Bot>(app, ada, "bots/duplicate", { botId: chief.id });
+    expect(duplicate).toMatchObject({
+      name: "Chief copy",
+      title: chief.title,
+      description: chief.description,
+      instructions: chief.instructions,
+      notifyOnFinish: chief.notifyOnFinish,
+      color: chief.color,
+      pinned: false,
+    });
+    expect(duplicate.id).not.toBe(chief.id);
+    expect((await rpc<Bot[]>(app, ada, "bots/list"))[0]?.id).toBe(coder.id);
+
     await sendAndWait(
       app,
       ada,
@@ -706,7 +721,17 @@ describeJourneys("required product journeys", () => {
 });
 
 type Me = { workspaceId: string; userId: string; canChooseHostComputer: boolean };
-type Bot = { id: string; name: string; title?: string; parentBotId?: string | null };
+type Bot = {
+  id: string;
+  name: string;
+  title: string;
+  description: string;
+  instructions: string;
+  notifyOnFinish: boolean;
+  color: string;
+  pinned: boolean;
+  parentBotId?: string | null;
+};
 type Snap = {
   messages: Array<{ seq: number; blocks: unknown[] }>;
   run: { status: string } | null;


### PR DESCRIPTION
## Summary

- Add a right-click bot menu for Pin/Unpin, Edit Profile, Duplicate, and Delete.
- Persist pinned state and keep pinned bots first across web, Electron, API clients, and mobile ordering.
- Duplicate only the bot profile into a fresh thread/home; conversation history, files, browser state, sessions, and secrets are not copied.
- Confirm destructive deletion in an accessible dialog.

## Verification

- pnpm lint
- pnpm check
- pnpm verify:fast — 231 passed
- pnpm verify:integration — 23 passed
- pnpm verify:web — 3 Playwright flows passed

## Stack

Bottom layer of GitHub stack #21. Follow-up: #20 adds read/unread state.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>