### PR TITLE
Enforce server-side screen control boundaries

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -506,6 +506,13 @@ export function createRouter(deps: RouterDeps) {
       }),
       release: authed.computer.release.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId);
+        if (bot.computer?.providerRef) {
+          await deps.sandbox.setScreenControl?.(
+            computerRef(bot.id, bot.computer),
+            false,
+            computerContext(context.actor, bot.id, "screen.release"),
+          );
+        }
         await deps.prisma.computer.update({
           where: { botId: bot.id },
           data: { controlHolder: "bot", controlLeaseId: null },
@@ -602,7 +609,7 @@ export function createRouter(deps: RouterDeps) {
         }
         const session = await deps.sandbox.connectScreen(
           computerRef(bot.id, bot.computer),
-          { view: "stream" },
+          { view: "stream", interactive: bot.computer.controlHolder === "user" },
           computerContext(context.actor, bot.id, "screen"),
         );
         if (!session.url) return { url: null };

--- a/apps/api/src/screen-proxy.test.ts
+++ b/apps/api/src/screen-proxy.test.ts
@@ -12,7 +12,9 @@ describe("screen proxy capability", () => {
       ),
     );
     expect(result.origin).toBe("https://app.example");
-    expect(result.pathname).toMatch(/^\/novnc\/[\w-]+\/49152\/3600100\.[\w-]{43}\/embed\.html$/);
+    expect(result.pathname).toMatch(
+      /^\/novnc\/[\w-]+\/49152\/view\/3600100\.[\w-]{43}\/embed\.html$/,
+    );
     expect(result.searchParams.get("view_only")).toBe("true");
   });
 

--- a/apps/api/src/screen-proxy.ts
+++ b/apps/api/src/screen-proxy.ts
@@ -13,11 +13,13 @@ export function addScreenProxyCapability(
     if (parsed.protocol !== "http:" || !parsed.hostname || !parsed.port) return url;
     const expiresAt = now + SCREEN_PROXY_TTL_MS;
     const target = Buffer.from(parsed.hostname).toString("base64url");
+    const policy = parsed.searchParams.get("view_only") === "false" ? "control" : "view";
+    const destination = `${parsed.pathname}${parsed.search}`;
     const signature = createHmac("sha256", secret)
-      .update(`${parsed.hostname}:${parsed.port}:${expiresAt}`)
+      .update(`${parsed.hostname}:${parsed.port}:${policy}:${expiresAt}`)
       .digest("base64url");
     const origin = new URL(proxyOrigin).origin;
-    return `${origin}/novnc/${target}/${parsed.port}/${expiresAt}.${signature}${parsed.pathname}${parsed.search}`;
+    return `${origin}/novnc/${target}/${parsed.port}/${policy}/${expiresAt}.${signature}${destination}`;
   } catch {
     return url;
   }

--- a/apps/web/src/screen-proxy.test.ts
+++ b/apps/web/src/screen-proxy.test.ts
@@ -13,12 +13,13 @@ function signedPath(
   secret: string,
   rest = "/embed.html",
   hostname = "127.0.0.1",
+  policy: "view" | "control" = "view",
 ) {
   const signature = createHmac("sha256", secret)
-    .update(`${hostname}:${port}:${expiresAt}`)
+    .update(`${hostname}:${port}:${policy}:${expiresAt}`)
     .digest("base64url");
   const target = Buffer.from(hostname).toString("base64url");
-  return `/novnc/${target}/${port}/${expiresAt}.${signature}${rest}`;
+  return `/novnc/${target}/${port}/${policy}/${expiresAt}.${signature}${rest}`;
 }
 
 describe("noVNC proxy authorization", () => {
@@ -26,7 +27,8 @@ describe("noVNC proxy authorization", () => {
     expect(resolveNovncTarget(signedPath(49152, 2_000, "secret"), "secret", 1_000)).toEqual({
       hostname: "127.0.0.1",
       port: 49152,
-      path: "/embed.html",
+      path: "/embed.html?view_only=true",
+      interactive: false,
     });
   });
 
@@ -34,6 +36,36 @@ describe("noVNC proxy authorization", () => {
     expect(resolveNovncTarget("/novnc/5432/index.html", "secret", 1_000)).toBeNull();
     expect(resolveNovncTarget(signedPath(49152, 2_000, "wrong"), "secret", 1_000)).toBeNull();
     expect(resolveNovncTarget(signedPath(49152, 999, "secret"), "secret", 1_000)).toBeNull();
+  });
+
+  it("binds server-enforced view mode while allowing required noVNC paths", () => {
+    const viewOnly = signedPath(49152, 2_000, "secret", "/embed.html?view_only=true");
+    expect(resolveNovncTarget(viewOnly, "secret", 1_000)?.path).toBe("/embed.html?view_only=true");
+    expect(
+      resolveNovncTarget(viewOnly.replace("view_only=true", "view_only=false"), "secret", 1_000),
+    ).toMatchObject({ path: "/embed.html?view_only=true", interactive: false });
+    expect(
+      resolveNovncTarget(
+        viewOnly.replace(/\/embed\.html\?view_only=true$/, "/websockify"),
+        "secret",
+        1_000,
+      ),
+    ).toMatchObject({ path: "/websockify", interactive: false });
+    expect(resolveNovncTarget(viewOnly.replace("/view/", "/control/"), "secret", 1_000)).toBeNull();
+    expect(resolveNovncTarget(viewOnly.replace("/49152/", "/49153/"), "secret", 1_000)).toBeNull();
+
+    const control = signedPath(
+      49153,
+      2_000,
+      "secret",
+      "/embed.html?view_only=true",
+      "127.0.0.1",
+      "control",
+    );
+    expect(resolveNovncTarget(control, "secret", 1_000)).toMatchObject({
+      path: "/embed.html?view_only=false",
+      interactive: true,
+    });
   });
 
   it("does not forward application credentials", () => {

--- a/apps/web/src/screen-proxy.ts
+++ b/apps/web/src/screen-proxy.ts
@@ -12,17 +12,19 @@ const SENSITIVE_RESPONSE_HEADERS = new Set(["clear-site-data", "set-cookie", "se
 
 export function resolveNovncTarget(url: string | undefined, secret: string, now = Date.now()) {
   const match = url?.match(
-    /^\/novnc\/([A-Za-z0-9_-]+)\/(\d+)\/(\d+)\.([A-Za-z0-9_-]{43})(\/[^?]*)?(\?.*)?$/,
+    /^\/novnc\/([A-Za-z0-9_-]+)\/(\d+)\/(view|control)\/(\d+)\.([A-Za-z0-9_-]{43})(\/[^?]*)?(\?.*)?$/,
   );
   if (!match) return null;
   const hostname = Buffer.from(match[1]!, "base64url").toString("utf8");
   const port = Number(match[2]);
-  const expiresAt = Number(match[3]);
-  const signature = match[4]!;
+  const policy = match[3]! as "view" | "control";
+  const expiresAt = Number(match[4]);
+  const signature = match[5]!;
+  const requestedPath = `${match[6] || "/"}${match[7] || ""}`;
   if (!isAllowedTargetName(hostname)) return null;
   if (!Number.isInteger(port) || port < 1024 || port > 65_535 || expiresAt < now) return null;
   const expected = createHmac("sha256", secret)
-    .update(`${hostname}:${port}:${expiresAt}`)
+    .update(`${hostname}:${port}:${policy}:${expiresAt}`)
     .digest("base64url");
   const suppliedBytes = Buffer.from(signature);
   const expectedBytes = Buffer.from(expected);
@@ -32,7 +34,20 @@ export function resolveNovncTarget(url: string | undefined, secret: string, now 
   ) {
     return null;
   }
-  return { hostname, port, path: `${match[5] || "/"}${match[6] || ""}` };
+  return {
+    hostname,
+    port,
+    path: screenPolicyPath(requestedPath, policy === "control"),
+    interactive: policy === "control",
+  };
+}
+
+export function screenPolicyPath(requestedPath: string, interactive: boolean) {
+  const parsed = new URL(requestedPath, "http://screen.invalid");
+  if (parsed.pathname === "/embed.html") {
+    return `/embed.html?view_only=${interactive ? "false" : "true"}`;
+  }
+  return parsed.pathname;
 }
 
 function isAllowedTargetName(hostname: string) {

--- a/infra/sandboxes/computer/Dockerfile
+++ b/infra/sandboxes/computer/Dockerfile
@@ -33,5 +33,5 @@ COPY fluxbox.apps /etc/rakazo/fluxbox/apps
 COPY fluxbox.menu /etc/rakazo/fluxbox/menu
 COPY embed.html /usr/share/novnc/embed.html
 RUN chmod +x /usr/local/bin/rakazo-computer /usr/local/bin/rakazo-browser
-EXPOSE 6080
+EXPOSE 6080 6081
 CMD ["/usr/local/bin/rakazo-computer"]

--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -64,7 +64,7 @@ if [[ "$browser_up" -ne 1 ]]; then
   xterm -geometry 100x28+48+48 -bg "#111113" -fg "#E8E8EA" -cr "#E8E8EA" -title "Terminal" >/tmp/rakazo/xterm.log 2>&1 &
 fi
 
-x11vnc -display :1 -forever -shared -nopw -listen 127.0.0.1 -rfbport 5900 -xkb -ncache 0 >/tmp/rakazo/x11vnc.log 2>&1 &
+x11vnc -display :1 -forever -shared -viewonly -nopw -listen 127.0.0.1 -rfbport 5900 -xkb -ncache 0 >/tmp/rakazo/x11vnc.log 2>&1 &
 
 NOVNC_ROOT=/usr/share/novnc
 if [[ ! -d "$NOVNC_ROOT" ]]; then

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -28,8 +28,9 @@ describe("graphical computer spec", () => {
       "PATH=/home/rakazo/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     );
     expect(options.Env).toContain("NPM_CONFIG_PREFIX=/home/rakazo/.local");
-    expect(options.ExposedPorts).toEqual({ "6080/tcp": {} });
+    expect(options.ExposedPorts).toEqual({ "6080/tcp": {}, "6081/tcp": {} });
     expect(options.HostConfig.PortBindings["6080/tcp"]?.[0]?.HostIp).toBe("127.0.0.1");
+    expect(options.HostConfig.PortBindings["6081/tcp"]?.[0]?.HostIp).toBe("127.0.0.1");
     expect(options.HostConfig.ShmSize).toBeGreaterThanOrEqual(256 * 1024 * 1024);
     expect(options.HostConfig.ReadonlyPaths).toContain("/usr/share/novnc");
     expect(options.HostConfig.NetworkMode).toBe("rakazo_default");
@@ -42,6 +43,7 @@ describe("graphical computer spec", () => {
     const browser = readFileSync(path.join(root, "rakazo-browser"), "utf8");
     expect(dockerfile).toMatch(/chromium/);
     expect(start).toMatch(/rakazo-browser/);
+    expect(start).toMatch(/x11vnc .* -viewonly /);
     expect(browser).toMatch(/\.browser-profiles\/chromium/);
     expect(start).not.toMatch(/windowsize 1280 800/);
   });

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -40,11 +40,12 @@ export function containerCreateOptions(input: ComputerCreateInput) {
       "rakazo.botId": input.botId,
       "rakazo.workspaceId": input.workspaceId,
     },
-    ExposedPorts: { "6080/tcp": {} },
+    ExposedPorts: { "6080/tcp": {}, "6081/tcp": {} },
     HostConfig: {
       Binds: [`${input.homePath}:/home/rakazo`],
       PortBindings: {
         "6080/tcp": [{ HostIp: "127.0.0.1", HostPort: "0" }],
+        "6081/tcp": [{ HostIp: "127.0.0.1", HostPort: "0" }],
       },
       ShmSize: 256 * 1024 * 1024,
       ReadonlyPaths: ["/usr/share/novnc"],

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   assertRequestIdentity,
   containerActionStep,
   hasValidBearerToken,
+  interactiveScreenCommand,
   normalizeWorkspaceRelative,
   parseObservation,
 } from "./supervisor-logic.js";
@@ -26,6 +27,7 @@ describe("sandbox supervisor HTTP boundary", () => {
       ["GET", "/computers/id/files"],
       ["POST", "/computers/id/files"],
       ["GET", "/computers/id/screen"],
+      ["POST", "/computers/id/screen-mode"],
       ["POST", "/computers/id/input"],
       ["POST", "/computers/id/stop"],
       ["DELETE", "/computers/id"],
@@ -94,6 +96,14 @@ describe("sandbox supervisor input containment", () => {
     expect(containerActionStep({ kind: "scroll", direction: "up", amount: 99 })).toEqual({
       argv: ["env", "DISPLAY=:1", "xdotool", "click", "--repeat", "20", "4"],
     });
+  });
+
+  it("keeps the viewer read-only and uses a separate process for takeover control", () => {
+    expect(interactiveScreenCommand(false)).toMatch(/pkill .*5901/);
+    expect(interactiveScreenCommand(false)).not.toMatch(/x11vnc -display/);
+    expect(interactiveScreenCommand(true)).toMatch(/x11vnc -display .* -rfbport 5901/);
+    expect(interactiveScreenCommand(true)).toMatch(/6081/);
+    expect(interactiveScreenCommand(true)).not.toMatch(/-rfbport 5900/);
   });
 
   it("parses a captured frame without trusting optional desktop metadata", () => {

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -20,6 +20,7 @@ import {
   computerActionSchema,
   containerActionStep,
   hasValidBearerToken,
+  interactiveScreenCommand,
   normalizeWorkspaceRelative,
   parseObservation,
   toSandboxInput,
@@ -315,6 +316,23 @@ app.get("/computers/:id/screen", async (c) => {
   }
 });
 
+app.post("/computers/:id/screen-mode", async (c) => {
+  const body = z.object({ interactive: z.boolean() }).parse(await c.req.json());
+  try {
+    const { container, info } = await managedContainer(
+      c.req.param("id"),
+      c.req.header("x-rakazo-bot-id"),
+      c.req.header("x-rakazo-workspace-id"),
+    );
+    await setInteractiveScreen(container, body.interactive);
+    const screenUrl = await publishedScreenUrl(container, info, body.interactive ? "6081" : "6080");
+    return c.json({ screenUrl });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json({ error: message }, 400);
+  }
+});
+
 app.post("/computers/:id/input", async (c) => {
   const id = c.req.param("id");
   const body = z
@@ -489,6 +507,7 @@ function loadRootEnv() {
 async function publishedScreenUrl(
   container: Docker.Container,
   initialInfo?: Docker.ContainerInspectInfo,
+  containerPort = "6080",
 ) {
   for (let i = 0; i < 30; i += 1) {
     const info = i === 0 && initialInfo ? initialInfo : await container.inspect();
@@ -497,13 +516,22 @@ async function publishedScreenUrl(
       const address = networkMode
         ? info.NetworkSettings?.Networks?.[networkMode]?.IPAddress
         : undefined;
-      if (address) return screenUrlFor("6080", address);
+      if (address) return screenUrlFor(containerPort, address);
     }
-    const hostPort = info.NetworkSettings?.Ports?.["6080/tcp"]?.[0]?.HostPort;
+    const hostPort = info.NetworkSettings?.Ports?.[`${containerPort}/tcp`]?.[0]?.HostPort;
     if (hostPort) return screenUrlFor(hostPort);
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error("computer screen port was not published");
+}
+
+async function setInteractiveScreen(container: Docker.Container, interactive: boolean) {
+  const result = await runContainerCommand(container, [
+    "bash",
+    "-lc",
+    interactiveScreenCommand(interactive),
+  ]);
+  if (result.code !== 0) throw new Error(result.stderr || "control screen failed to start");
 }
 
 function computerNetworkMode(info: Docker.ContainerInspectInfo | undefined) {

--- a/infra/sandboxes/supervisor/src/supervisor-logic.ts
+++ b/infra/sandboxes/supervisor/src/supervisor-logic.ts
@@ -106,6 +106,22 @@ export function workspaceTarget(relative: string) {
   return relative ? path.posix.join("/home/rakazo", relative) : "/home/rakazo";
 }
 
+export function interactiveScreenCommand(interactive: boolean) {
+  const stop =
+    "pkill -f '^x11vnc .* -rfbport 5901' || true; " +
+    "pkill -f '^/usr/bin/python3 .*websockify.*6081' || true";
+  if (!interactive) return stop;
+  return [
+    "pgrep -f '^x11vnc .* -rfbport 5901' >/dev/null && pgrep -f '^/usr/bin/python3 .*websockify.*6081' >/dev/null && exit 0 || true",
+    stop,
+    "export DISPLAY=:1",
+    "(x11vnc -display :1 -forever -shared -nopw -listen 127.0.0.1 -rfbport 5901 -xkb -ncache 0 >/tmp/rakazo/x11vnc-control.log 2>&1 &)",
+    "(websockify --web=/usr/share/novnc 0.0.0.0:6081 127.0.0.1:5901 >/tmp/rakazo/novnc-control.log 2>&1 &)",
+    "for i in $(seq 1 50); do (echo >/dev/tcp/127.0.0.1/6081) >/dev/null 2>&1 && exit 0; sleep 0.1; done",
+    "exit 1",
+  ].join("; ");
+}
+
 export function parseObservation(output: string) {
   const geometry = output.match(/^GEOM\s+(\d+)\s+(\d+)$/m);
   const cursorLine = output.match(/^CURSOR\s+(.+)$/m)?.[1] ?? "";

--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -58,6 +58,11 @@ export interface SandboxProvider {
     request: ScreenRequest,
     context: AdapterContext,
   ): Promise<ScreenSession>;
+  setScreenControl?(
+    computer: ComputerRef,
+    interactive: boolean,
+    context: AdapterContext,
+  ): Promise<void>;
   sendInput(
     computer: ComputerRef,
     input: ComputerInput,

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -60,6 +60,8 @@ export type ProcessEvent =
 
 export interface ScreenRequest {
   view: "stream" | "snapshot";
+  /** Request a separately authorized control stream instead of the read-only viewer. */
+  interactive?: boolean;
 }
 
 export interface ScreenSession {

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -111,11 +111,13 @@ export class DockerSandboxProvider implements SandboxProvider {
 
   async connectScreen(
     computer: ComputerRef,
-    _request: ScreenRequest,
+    request: ScreenRequest,
     context: AdapterContext,
   ): Promise<ScreenSession> {
-    const res = await fetch(this.url(`/computers/${computer.id}`), {
-      headers: this.headers(context, computer.botId),
+    const res = await fetch(this.url(`/computers/${computer.id}/screen-mode`), {
+      method: "POST",
+      headers: { ...this.headers(context, computer.botId), "content-type": "application/json" },
+      body: JSON.stringify({ interactive: request.interactive === true }),
       signal: context.signal,
     });
     if (!res.ok) {
@@ -127,6 +129,16 @@ export class DockerSandboxProvider implements SandboxProvider {
       mimeType: "text/html",
       close: async () => undefined,
     };
+  }
+
+  async setScreenControl(computer: ComputerRef, interactive: boolean, context: AdapterContext) {
+    const res = await fetch(this.url(`/computers/${computer.id}/screen-mode`), {
+      method: "POST",
+      headers: { ...this.headers(context, computer.botId), "content-type": "application/json" },
+      body: JSON.stringify({ interactive }),
+      signal: context.signal,
+    });
+    if (!res.ok) throw new Error(`sandbox screen mode failed: ${res.status}`);
   }
 
   async sendInput(

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -35,8 +35,11 @@ describe("E2B computer backend", () => {
         disconnect: async () => undefined,
       };
     });
+    const getStreamUrl = vi.fn(() => "https://desktop.test/vnc.html");
     const desktop = {
       sandboxId: "e2b-test-box",
+      display: ":0",
+      getHost: (port: number) => `${port}-desktop.test`,
       commands: { run: command },
       files: {
         makeDir: vi.fn(async () => undefined),
@@ -64,7 +67,7 @@ describe("E2B computer backend", () => {
         start: vi.fn(async () => undefined),
         stop: vi.fn(async () => undefined),
         getAuthKey: () => "screen-key",
-        getUrl: () => "https://desktop.test/vnc.html",
+        getUrl: getStreamUrl,
       },
       launch: vi.fn(async () => undefined),
       open: vi.fn(async () => undefined),
@@ -144,5 +147,32 @@ describe("E2B computer backend", () => {
     const screen = await provider.connectScreen(computer, { view: "stream" }, context);
     expect(screen.url).toBe("https://desktop.test/vnc.html");
     expect(desktop.stream.start).toHaveBeenCalledWith({ requireAuth: true });
+    expect(getStreamUrl).toHaveBeenCalledWith(
+      expect.objectContaining({ viewOnly: true, authKey: "screen-key" }),
+    );
+    expect(command).toHaveBeenCalledWith("x11vnc -R viewonly");
+
+    const control = await provider.connectScreen(
+      computer,
+      { view: "stream", interactive: true },
+      context,
+    );
+    expect(control.url).toMatch(/^https:\/\/6081-desktop\.test\/vnc\.html\?/);
+    expect(command.mock.calls.some(([value]) => String(value).includes("-rfbport 5901"))).toBe(
+      true,
+    );
+
+    await provider.setScreenControl(computer, false);
+    expect(
+      command.mock.calls.some(([value]) =>
+        String(value).includes("pkill -f '^x11vnc .* -rfbport 5901'"),
+      ),
+    ).toBe(true);
+    const replacementControl = await provider.connectScreen(
+      computer,
+      { view: "stream", interactive: true },
+      context,
+    );
+    expect(replacementControl.url).not.toBe(control.url);
   });
 });

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { Sandbox } from "@e2b/desktop";
 import type {
   AdapterContext,
@@ -72,6 +73,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   private readonly boxes = new Map<string, Sandbox>();
   private readonly lastTouchedAt = new Map<string, number>();
   private readonly streamReady = new Set<string>();
+  private readonly controlStreamPasswords = new Map<string, string>();
 
   constructor(
     private readonly apiKey: string,
@@ -119,6 +121,12 @@ export class E2BSandboxProvider implements SandboxProvider {
       .run("pkill -x x11vnc || true; pkill -f '[n]ovnc_proxy|[w]ebsockify.*6080' || true")
       .catch(() => undefined);
     await desktop.stream.start({ requireAuth: true });
+    try {
+      await desktop.commands.run("x11vnc -R viewonly");
+    } catch (error) {
+      await desktop.stream.stop().catch(() => undefined);
+      throw error;
+    }
     this.streamReady.add(desktop.sandboxId);
   }
 
@@ -184,11 +192,24 @@ export class E2BSandboxProvider implements SandboxProvider {
 
   async connectScreen(
     computer: ComputerRef,
-    _request: ScreenRequest,
+    request: ScreenRequest,
     _context: AdapterContext,
   ): Promise<ScreenSession> {
     const desktop = await this.box(computer);
     await this.startStream(desktop);
+    if (request.interactive) {
+      const password = await this.startControlStream(desktop);
+      const url = new URL(`https://${desktop.getHost(6081)}/vnc.html`);
+      url.searchParams.set("autoconnect", "true");
+      url.searchParams.set("resize", "scale");
+      url.searchParams.set("password", password);
+      return {
+        url: url.toString(),
+        mimeType: "text/html",
+        close: async () => undefined,
+      };
+    }
+    await this.stopControlStream(desktop);
     let authKey: string | undefined;
     try {
       authKey = desktop.stream.getAuthKey();
@@ -199,6 +220,7 @@ export class E2BSandboxProvider implements SandboxProvider {
       typeof desktop.stream.getUrl === "function"
         ? desktop.stream.getUrl({
             autoConnect: true,
+            viewOnly: true,
             resize: "scale",
             ...(authKey ? { authKey } : {}),
           })
@@ -211,6 +233,12 @@ export class E2BSandboxProvider implements SandboxProvider {
         this.streamReady.delete(desktop.sandboxId);
       },
     };
+  }
+
+  async setScreenControl(computer: ComputerRef, interactive: boolean): Promise<void> {
+    const desktop = await this.box(computer);
+    if (interactive) await this.startControlStream(desktop);
+    else await this.stopControlStream(desktop);
   }
 
   async sendInput(
@@ -355,6 +383,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     this.boxes.delete(id);
     this.lastTouchedAt.delete(id);
     this.streamReady.delete(id);
+    this.controlStreamPasswords.delete(id);
     if (desktop) {
       await desktop.pause().catch(() => undefined);
       return;
@@ -369,7 +398,41 @@ export class E2BSandboxProvider implements SandboxProvider {
     this.boxes.delete(id);
     this.lastTouchedAt.delete(id);
     this.streamReady.delete(id);
+    this.controlStreamPasswords.delete(id);
   }
+
+  private async startControlStream(desktop: Sandbox): Promise<string> {
+    const existing = this.controlStreamPasswords.get(desktop.sandboxId);
+    if (existing) return existing;
+    const password = randomBytes(6).toString("base64url");
+    const passwordFile = "/tmp/rakazo-control.vncpass";
+    const command = [
+      controlStreamStopCommand(),
+      `x11vnc -storepasswd ${shellQuote(password)} ${passwordFile} >/dev/null`,
+      `x11vnc -bg -display ${shellQuote(desktop.display)} -forever -wait 50 -shared -rfbport 5901 -rfbauth ${passwordFile} 2>/tmp/rakazo-control-x11vnc.log`,
+      "cd /opt/noVNC/utils",
+      "(nohup ./novnc_proxy --vnc localhost:5901 --listen 6081 --web /opt/noVNC >/tmp/rakazo-control-novnc.log 2>&1 &)",
+      "for i in $(seq 1 50); do netstat -tuln | grep -q ':6081 ' && exit 0; sleep 0.1; done",
+      "exit 1",
+    ].join(" && ");
+    const result = await desktop.commands.run(command);
+    if (result.exitCode !== 0) throw new Error(result.stderr || "control stream failed to start");
+    this.controlStreamPasswords.set(desktop.sandboxId, password);
+    return password;
+  }
+
+  private async stopControlStream(desktop: Sandbox): Promise<void> {
+    await desktop.commands.run(controlStreamStopCommand());
+    this.controlStreamPasswords.delete(desktop.sandboxId);
+  }
+}
+
+function controlStreamStopCommand() {
+  return [
+    "pkill -f '^x11vnc .* -rfbport 5901' || true",
+    "pkill -f '^/usr/bin/python3 .*websockify.*6081' || true",
+    "rm -f /tmp/rakazo-control.vncpass",
+  ].join("; ");
 }
 
 async function observeE2BDesktop(


### PR DESCRIPTION
## Summary
- bind local noVNC capabilities to an immutable view/control policy while preserving required asset and websocket paths
- keep Docker and E2B viewers server-side read-only and expose a distinct, revocable takeover stream
- revoke the control stream before releasing computer control

## Verification
- full offline suite: 241 passed, 37 skipped
- focused screen/sandbox tests: 22 passed
- affected TypeScript projects: passed
- live Docker + signed Vite proxy: tampered view URL could not move the cursor; takeover stream could
- live E2B: tampered view URL could not move the cursor; takeover stream could; old control stream could not move it after release
