### PR TITLE
Improve marketing site SEO metadata

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -1,11 +1,12 @@
 import react from "@astrojs/react";
+import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
   site: "https://rakazo.com",
   output: "static",
-  integrations: [react()],
+  integrations: [react(), sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^6.0.2",
+    "@astrojs/sitemap": "3.7.3",
     "@rakazo/ui-web": "workspace:*",
     "astro": "^7.2.1",
     "react": "19.2.3",

--- a/apps/www/public/site.webmanifest
+++ b/apps/www/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Rakazo",
   "short_name": "Rakazo",
-  "description": "Open-source home for persistent AI bots that can do real work.",
+  "description": "An open source Grok Bot alternative for persistent AI teammates that do real work.",
   "start_url": "/",
   "display": "browser",
   "background_color": "#FDFDFD",

--- a/apps/www/src/components/Footer.astro
+++ b/apps/www/src/components/Footer.astro
@@ -16,7 +16,7 @@ import Logo from "./Logo.astro";
     <a href={GITHUB_URL} target="_blank" rel="noreferrer">GitHub</a>
     <a href={DOCS_URL} target="_blank" rel="noreferrer">Docs</a>
     <a href={CHANGELOG_URL} target="_blank" rel="noreferrer">Changelog</a>
-    <a href="/support">Support</a>
-    <a href="/privacy">Privacy</a>
+    <a href="/support/">Support</a>
+    <a href="/privacy/">Privacy</a>
   </nav>
 </footer>

--- a/apps/www/src/layouts/BaseLayout.astro
+++ b/apps/www/src/layouts/BaseLayout.astro
@@ -5,11 +5,15 @@ import { SITE_NAME, SITE_URL } from "../site";
 type Props = {
   title?: string;
   description: string;
+  structuredData?: object;
 };
 
-const { title = SITE_NAME, description } = Astro.props;
+const { title = SITE_NAME, description, structuredData } = Astro.props;
 const canonical = new URL(Astro.url.pathname, SITE_URL).toString();
 const socialImage = new URL("/og-image.png", SITE_URL).toString();
+const structuredDataJson = structuredData
+  ? JSON.stringify(structuredData).replaceAll("<", "\\u003c")
+  : null;
 ---
 
 <!doctype html>
@@ -18,6 +22,7 @@ const socialImage = new URL("/og-image.png", SITE_URL).toString();
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
     <meta name="theme-color" content="#FDFDFD" />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
@@ -36,6 +41,7 @@ const socialImage = new URL("/og-image.png", SITE_URL).toString();
     <meta name="twitter:image" content={socialImage} />
     <meta name="twitter:image:alt" content="Rakazo — AI teammates you actually own. Your keys, your model, your machine." />
     <link rel="canonical" href={canonical} />
+    <link rel="sitemap" href="/sitemap-index.xml" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
@@ -46,6 +52,7 @@ const socialImage = new URL("/og-image.png", SITE_URL).toString();
       href="https://fonts.googleapis.com/css2?family=Geist:wght@400..700&family=Geist+Mono:wght@400..600&display=swap"
       rel="stylesheet"
     />
+    {structuredDataJson && <script is:inline type="application/ld+json" set:html={structuredDataJson} />}
     <title>{title}</title>
   </head>
   <body>

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -7,13 +7,44 @@ import { ProductDemo } from "../components/ProductDemo";
 import { DEMO_ROSTER } from "../demo";
 import { fetchGithubStars, formatStarCount } from "../github";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { DOCS_URL, GITHUB_URL, SITE_DESCRIPTION, WAITLIST_HREF } from "../site";
+import { DOCS_URL, GITHUB_URL, SITE_DESCRIPTION, SITE_NAME, SITE_URL, WAITLIST_HREF } from "../site";
 
 const stars = await fetchGithubStars();
 const starsLabel = stars === null ? "Star" : formatStarCount(stars);
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#website`,
+      url: `${SITE_URL}/`,
+      name: SITE_NAME,
+      description: SITE_DESCRIPTION,
+      inLanguage: "en",
+    },
+    {
+      "@type": "SoftwareApplication",
+      "@id": `${SITE_URL}/#software`,
+      name: SITE_NAME,
+      url: `${SITE_URL}/`,
+      description: SITE_DESCRIPTION,
+      applicationCategory: "BusinessApplication",
+      applicationSubCategory: "AI agent platform",
+      operatingSystem: "Web, macOS, Linux, iOS, Android",
+      isAccessibleForFree: true,
+      codeRepository: GITHUB_URL,
+      license: `${GITHUB_URL}/blob/main/LICENSE`,
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+      },
+    },
+  ],
+};
 ---
 
-<BaseLayout title="Rakazo" description={SITE_DESCRIPTION}>
+<BaseLayout title="Rakazo" description={SITE_DESCRIPTION} {structuredData}>
   <div class="container">
     <Header starsLabel={starsLabel} />
 

--- a/apps/www/src/pages/robots.txt.ts
+++ b/apps/www/src/pages/robots.txt.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = ({ site }) => {
+  const sitemap = new URL("sitemap-index.xml", site);
+  const body = `User-agent: *\nAllow: /\n\nSitemap: ${sitemap.href}\n`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+};

--- a/apps/www/src/site.ts
+++ b/apps/www/src/site.ts
@@ -1,7 +1,7 @@
 export const SITE_NAME = "Rakazo";
 export const SITE_URL = "https://rakazo.com";
 export const SITE_DESCRIPTION =
-  "Open-source home for persistent AI bots that can do real work. Your keys, your model, your machine.";
+  "Rakazo is an open source Grok Bot alternative for persistent AI teammates that do real work. Your keys, your model, your machine.";
 
 export const GITHUB_URL = "https://github.com/elie222/rakazo";
 export const GITHUB_API_REPO = "https://api.github.com/repos/elie222/rakazo";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@astrojs/react':
         specifier: ^6.0.2
         version: 6.0.2(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      '@astrojs/sitemap':
+        specifier: 3.7.3
+        version: 3.7.3
       '@rakazo/ui-web':
         specifier: workspace:*
         version: link:../../packages/ui-web
@@ -720,6 +723,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: 19.2.3
       react-dom: 19.2.3
+
+  '@astrojs/sitemap@3.7.3':
+    resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
 
   '@astrojs/telemetry@3.3.3':
     resolution: {integrity: sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==}
@@ -3345,6 +3351,9 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/semver@7.8.0':
     resolution: {integrity: sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==}
@@ -7070,6 +7079,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   slugify@1.6.9:
     resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
     engines: {node: '>=8.0.0'}
@@ -7155,6 +7169,9 @@ packages:
   stream-buffers@2.2.0:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
     engines: {node: '>= 0.10.0'}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
@@ -8231,6 +8248,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/sitemap@3.7.3':
+    dependencies:
+      sitemap: 9.0.1
+      stream-replace-string: 2.0.0
+      zod: 4.4.3
 
   '@astrojs/telemetry@3.3.3':
     dependencies:
@@ -11364,6 +11387,10 @@ snapshots:
       '@types/node': 24.13.3
 
   '@types/retry@0.12.0': {}
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 24.13.3
 
   '@types/semver@7.8.0': {}
 
@@ -15953,6 +15980,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.6.1
+
   slugify@1.6.9: {}
 
   smol-toml@1.8.0: {}
@@ -16015,6 +16049,8 @@ snapshots:
   std-env@4.2.0: {}
 
   stream-buffers@2.2.0: {}
+
+  stream-replace-string@2.0.0: {}
 
   streamx@2.28.0:
     dependencies:


### PR DESCRIPTION
## Summary

- generate and advertise an XML sitemap through `robots.txt`
- add crawl directives plus WebSite and SoftwareApplication structured data
- target the proven "open source Grok Bot" phrase in descriptive metadata
- align internal footer links with canonical URLs

## Verification

- `pnpm --filter @rakazo/www check`
- `pnpm --filter @rakazo/www build`
- generated sitemap XML parsed successfully