### PR TITLE
Enforce takeover lease expiry

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -542,7 +542,11 @@ export function createRouter(deps: RouterDeps) {
         const leaseId = randomUUID();
         const expiresAt = new Date(Date.now() + takeoverLeaseMs());
         const granted = await deps.prisma.computer.updateMany({
-          where: { botId: bot.id, controlHolder: { not: "user" } },
+          where: {
+            botId: bot.id,
+            controlHolder: { not: "user" },
+            controlLeaseId: null,
+          },
           data: {
             controlHolder: "user",
             controlLeaseId: leaseId,
@@ -604,8 +608,10 @@ export function createRouter(deps: RouterDeps) {
             computerRef(bot.id, bot.computer),
             false,
             computerContext(context.actor, bot.id, "screen.release"),
+            bot.computer.controlLeaseId ?? undefined,
           );
         }
+        await deps.jobs.cancel(computerControlExpireJobKey(bot.id));
         await deps.prisma.computer.update({
           where: { botId: bot.id },
           data: {
@@ -614,7 +620,6 @@ export function createRouter(deps: RouterDeps) {
             controlLeaseExpiresAt: null,
           },
         });
-        await deps.jobs.cancel(computerControlExpireJobKey(bot.id));
         if (bot.thread && controlChanged) {
           await deps.events.append({
             workspaceId: context.actor.workspaceId,
@@ -723,7 +728,11 @@ export function createRouter(deps: RouterDeps) {
         }
         const session = await deps.sandbox.connectScreen(
           computerRef(bot.id, bot.computer),
-          { view: "stream", interactive: hasActiveComputerControl(bot.computer) },
+          {
+            view: "stream",
+            interactive: hasActiveComputerControl(bot.computer),
+            controlToken: bot.computer.controlLeaseId ?? undefined,
+          },
           computerContext(context.actor, bot.id, "screen"),
         );
         if (!session.url) return { url: null };

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { implement, ORPCError } from "@orpc/server";
 import {
   type AdapterContext,
   type AgentHomeStore,
   type ComputerRef,
+  computerControlExpireJobKey,
   type JobPublisher,
   type MemoryStore,
   routineJobKey,
@@ -16,15 +18,19 @@ import {
   checkpointAndRecordComputerWorkspace,
   destroyBot,
   type EncryptedSecretStore,
+  expireComputerControl,
+  hasActiveComputerControl,
   listPiCatalog,
   type PiOAuthLogins,
   resolveAgentHomePath,
   restoreComputerWorkspace,
   sanitizeComposioError,
   savePushToken,
+  scheduleComputerControlExpiry,
   scheduleComputerSleep,
   scriptedCatalogEntry,
   serializeModelSecret,
+  takeoverLeaseMs,
   touchRunningComputer,
 } from "@rakazo/adapters";
 import type { Auth } from "@rakazo/auth";
@@ -501,17 +507,78 @@ export function createRouter(deps: RouterDeps) {
         }
         await deps.prisma.computer.update({
           where: { botId: bot.id },
-          data: { state: "stopped", controlHolder: "none" },
+          data: {
+            state: "stopped",
+            controlHolder: "none",
+            controlLeaseId: null,
+            controlLeaseExpiresAt: null,
+          },
         });
+        await deps.jobs.cancel(computerControlExpireJobKey(bot.id));
         return computerStatus(deps, context.actor, input.botId);
       }),
       takeover: authed.computer.takeover.handler(async ({ context, input }) => {
-        const bot = await repos.getBot(context.actor, input.botId);
-        const leaseId = `lease-${bot.id}`;
-        await deps.prisma.computer.update({
-          where: { botId: bot.id },
-          data: { controlHolder: "user", controlLeaseId: leaseId, state: "running" },
+        let bot = await repos.getBot(context.actor, input.botId);
+        if (!bot.computer?.providerRef || bot.computer.state !== "running") {
+          throw new ORPCError("BAD_REQUEST", { message: "computer must be running" });
+        }
+        if (hasActiveComputerControl(bot.computer)) {
+          await scheduleComputerControlExpiry(
+            deps.jobs,
+            bot.id,
+            bot.computer.controlLeaseId!,
+            bot.computer.controlLeaseExpiresAt!,
+          );
+          return {
+            leaseId: bot.computer.controlLeaseId!,
+            expiresAt: bot.computer.controlLeaseExpiresAt!.toISOString(),
+          };
+        }
+        if (bot.computer.controlLeaseId) {
+          await expireComputerControl(deps, bot.id, bot.computer.controlLeaseId);
+          bot = await repos.getBot(context.actor, input.botId);
+        }
+
+        const leaseId = randomUUID();
+        const expiresAt = new Date(Date.now() + takeoverLeaseMs());
+        const granted = await deps.prisma.computer.updateMany({
+          where: { botId: bot.id, controlHolder: { not: "user" } },
+          data: {
+            controlHolder: "user",
+            controlLeaseId: leaseId,
+            controlLeaseExpiresAt: expiresAt,
+            state: "running",
+          },
         });
+        if (granted.count !== 1) {
+          const current = await deps.prisma.computer.findUniqueOrThrow({
+            where: { botId: bot.id },
+          });
+          if (!hasActiveComputerControl(current)) throw new ORPCError("CONFLICT");
+          await scheduleComputerControlExpiry(
+            deps.jobs,
+            bot.id,
+            current.controlLeaseId!,
+            current.controlLeaseExpiresAt!,
+          );
+          return {
+            leaseId: current.controlLeaseId!,
+            expiresAt: current.controlLeaseExpiresAt!.toISOString(),
+          };
+        }
+        try {
+          await scheduleComputerControlExpiry(deps.jobs, bot.id, leaseId, expiresAt);
+        } catch (error) {
+          await deps.prisma.computer.updateMany({
+            where: { botId: bot.id, controlLeaseId: leaseId },
+            data: {
+              controlHolder: "none",
+              controlLeaseId: null,
+              controlLeaseExpiresAt: null,
+            },
+          });
+          throw error;
+        }
         if (bot.thread) {
           await deps.events.append({
             workspaceId: context.actor.workspaceId,
@@ -522,11 +589,17 @@ export function createRouter(deps: RouterDeps) {
           });
         }
         scheduleComputerSleep(deps.jobs, bot.id);
-        return { leaseId, expiresAt: new Date(Date.now() + 15 * 60_000).toISOString() };
+        return { leaseId, expiresAt: expiresAt.toISOString() };
       }),
       release: authed.computer.release.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId);
-        if (bot.computer?.providerRef) {
+        const controlChanged =
+          bot.computer?.controlHolder !== "bot" ||
+          bot.computer.controlLeaseId !== null ||
+          bot.computer.controlLeaseExpiresAt !== null;
+        const shouldRevokeUserControl =
+          bot.computer?.controlHolder === "user" || Boolean(bot.computer?.controlLeaseId);
+        if (bot.computer?.providerRef && shouldRevokeUserControl) {
           await deps.sandbox.setScreenControl?.(
             computerRef(bot.id, bot.computer),
             false,
@@ -535,8 +608,22 @@ export function createRouter(deps: RouterDeps) {
         }
         await deps.prisma.computer.update({
           where: { botId: bot.id },
-          data: { controlHolder: "bot", controlLeaseId: null },
+          data: {
+            controlHolder: "bot",
+            controlLeaseId: null,
+            controlLeaseExpiresAt: null,
+          },
         });
+        await deps.jobs.cancel(computerControlExpireJobKey(bot.id));
+        if (bot.thread && controlChanged) {
+          await deps.events.append({
+            workspaceId: context.actor.workspaceId,
+            threadId: bot.thread.id,
+            botId: bot.id,
+            type: "computer.takeover.released",
+            payload: { holder: "bot", reason: "released" },
+          });
+        }
         const waiting = await deps.prisma.run.findFirst({
           where: { botId: bot.id, status: "waiting_takeover" },
           orderBy: { createdAt: "desc" },
@@ -547,8 +634,12 @@ export function createRouter(deps: RouterDeps) {
       }),
       input: authed.computer.input.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId);
-        if (bot.computer?.controlHolder !== "user") throw new ORPCError("FORBIDDEN");
-        if (!bot.computer.providerRef) return { ok: true as const };
+        const computer = bot.computer;
+        if (!computer || !hasActiveComputerControl(computer)) {
+          await expireStaleComputerControl(deps, bot.id, computer);
+          throw new ORPCError("FORBIDDEN");
+        }
+        if (!computer.providerRef) return { ok: true as const };
         const mapped =
           input.kind === "key"
             ? { kind: "key" as const, key: String(input.payload.key ?? "") }
@@ -563,9 +654,9 @@ export function createRouter(deps: RouterDeps) {
                     (input.payload.type as "move" | "down" | "up" | "click" | undefined) ?? "click",
                 };
         await deps.sandbox.sendInput(
-          computerRef(bot.id, bot.computer),
+          computerRef(bot.id, computer),
           mapped,
-          { leaseId: bot.computer.controlLeaseId ?? "lease", holder: "user", fence: 0 },
+          { leaseId: computer.controlLeaseId ?? "lease", holder: "user", fence: 0 },
           computerContext(context.actor, bot.id, "input"),
         );
         await deps.prisma.computer.updateMany({
@@ -620,7 +711,10 @@ export function createRouter(deps: RouterDeps) {
         return { path: input.path, content };
       }),
       screenUrl: authed.computer.screenUrl.handler(async ({ context, input }) => {
-        const bot = await repos.getBot(context.actor, input.botId);
+        let bot = await repos.getBot(context.actor, input.botId);
+        if (await expireStaleComputerControl(deps, bot.id, bot.computer)) {
+          bot = await repos.getBot(context.actor, input.botId);
+        }
         if (
           !bot.computer?.providerRef ||
           (bot.computer.state !== "running" && bot.computer.state !== "booting")
@@ -629,12 +723,12 @@ export function createRouter(deps: RouterDeps) {
         }
         const session = await deps.sandbox.connectScreen(
           computerRef(bot.id, bot.computer),
-          { view: "stream", interactive: bot.computer.controlHolder === "user" },
+          { view: "stream", interactive: hasActiveComputerControl(bot.computer) },
           computerContext(context.actor, bot.id, "screen"),
         );
         if (!session.url) return { url: null };
         scheduleComputerSleep(deps.jobs, bot.id);
-        const viewUrl = withViewOnly(session.url, bot.computer.controlHolder !== "user");
+        const viewUrl = withViewOnly(session.url, !hasActiveComputerControl(bot.computer));
         return {
           url: addScreenProxyCapability(viewUrl, deps.env.screenProxySecret, deps.env.webOrigin),
         };
@@ -1211,12 +1305,27 @@ async function computerStatus(
   actor: Actor,
   botId: string,
 ): Promise<ComputerStatus> {
-  const bot = await createRepos(deps.prisma).getBot(actor, botId);
+  const repos = createRepos(deps.prisma);
+  let bot = await repos.getBot(actor, botId);
+  if (await expireStaleComputerControl(deps, bot.id, bot.computer)) {
+    bot = await repos.getBot(actor, botId);
+  }
   const home = await deps.prisma.agentHome.findUnique({
     where: { botId },
     select: { revision: true },
   });
   return toComputerStatus(botId, bot.computer, home?.revision ?? null);
+}
+
+async function expireStaleComputerControl(
+  deps: RouterDeps,
+  botId: string,
+  computer: Parameters<typeof hasActiveComputerControl>[0],
+): Promise<boolean> {
+  const leaseId = computer?.controlLeaseId;
+  if (!leaseId || hasActiveComputerControl(computer)) return false;
+  await expireComputerControl(deps, botId, leaseId).catch(() => undefined);
+  return true;
 }
 
 function toComputerStatus(

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -177,6 +177,26 @@ describe("computer event reduction", () => {
       reduceComputerStatus(granted, event({ type: "computer.takeover.granted", payload: {} })),
     ).toBe(granted);
   });
+
+  it("applies the authoritative holder when a takeover is released or expires", () => {
+    const initial = computer({ state: "running", controlHolder: "user" });
+    const expired = reduceComputerStatus(
+      initial,
+      event({
+        type: "computer.takeover.released",
+        payload: { holder: "none", reason: "expired" },
+      }),
+    );
+    const released = reduceComputerStatus(
+      initial,
+      event({
+        type: "computer.takeover.released",
+        payload: { holder: "bot", reason: "released" },
+      }),
+    );
+    expect(expired).toMatchObject({ state: "running", controlHolder: "none" });
+    expect(released).toMatchObject({ state: "running", controlHolder: "bot" });
+  });
 });
 
 function snapshot(messages: ThreadMessage[], olderCursor: number | null = null): ThreadSnapshot {

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -106,9 +106,14 @@ export function reduceComputerStatus(
   event: ProductEvent,
 ): ComputerStatus | null {
   if (!prev) return prev;
-  if (event.type !== "computer.status" && event.type !== "computer.takeover.granted") return prev;
+  if (!isComputerStatusEvent(event)) return prev;
   if (event.type === "computer.takeover.granted") {
     return prev.controlHolder === "user" ? prev : { ...prev, controlHolder: "user" };
+  }
+  if (event.type === "computer.takeover.released") {
+    const holder = event.payload.holder;
+    if (holder !== "bot" && holder !== "none") return prev;
+    return prev.controlHolder === holder ? prev : { ...prev, controlHolder: holder };
   }
   const status = event.payload.status;
   if (!isComputerState(status)) return prev;
@@ -119,6 +124,14 @@ export function reduceComputerStatus(
     state: status,
     screenAvailable,
   };
+}
+
+export function isComputerStatusEvent(event: ProductEvent): boolean {
+  return (
+    event.type === "computer.status" ||
+    event.type === "computer.takeover.granted" ||
+    event.type === "computer.takeover.released"
+  );
 }
 
 function isComputerState(value: unknown): value is ComputerStatus["state"] {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -28,6 +28,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { authClient } from "../lib/auth";
 import { rpc } from "../lib/rpc";
 import {
+  isComputerStatusEvent,
   mergeThreadSnapshot,
   prependThreadMessagePage,
   reduceComputerStatus,
@@ -77,6 +78,8 @@ export function ShellPage() {
   const expandedHistoryThread = useRef<string | null>(null);
   const messageScroll = useRef<HTMLDivElement>(null);
   const manuallyUnread = useRef(new Set<string>());
+  const computerVisible = useRef(false);
+  computerVisible.current = panel === "computer" || computerOpen;
 
   const active = bots.find((b) => b.id === botId) ?? bots[0];
   const contextBot = botMenu ? bots.find((bot) => bot.id === botMenu.botId) : undefined;
@@ -147,10 +150,7 @@ export function ShellPage() {
     setComputer(snap.computer);
     const routines = await rpc.routines.list({ botId: id });
     setRoutines(routines);
-    if (panel === "computer" || computerOpen) {
-      const screen = await rpc.computer.screenUrl({ botId: id }).catch(() => ({ url: null }));
-      setScreenUrl(screen.url);
-    }
+    await refreshComputerScreen(id);
     if (stickToEnd) {
       window.requestAnimationFrame(() => {
         const element = messageScroll.current;
@@ -158,6 +158,12 @@ export function ShellPage() {
       });
     }
     return snap;
+  }
+
+  async function refreshComputerScreen(id: string) {
+    if (!computerVisible.current) return;
+    const screen = await rpc.computer.screenUrl({ botId: id }).catch(() => ({ url: null }));
+    setScreenUrl(screen.url);
   }
 
   async function loadOlderMessages() {
@@ -237,12 +243,10 @@ export function ShellPage() {
               }
               if (event.payload.role === "bot") markBotReadIfVisible(active.id);
             }
-            if (
-              event.type === "run.completed" ||
-              event.type === "computer.status" ||
-              event.type === "computer.takeover.granted"
-            ) {
+            if (event.type === "run.completed") {
               void refreshThread(active.id).catch(() => undefined);
+            } else if (isComputerStatusEvent(event)) {
+              void refreshComputerScreen(active.id).catch(() => undefined);
             }
           }
         } catch {
@@ -991,7 +995,7 @@ function applyThreadEvent(
   ) {
     setSnapshot((prev) => reduceThreadSnapshot(prev, event));
   }
-  if (event.type === "computer.status" || event.type === "computer.takeover.granted") {
+  if (isComputerStatusEvent(event)) {
     setComputer((prev) => reduceComputerStatus(prev, event));
   }
 }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -82,6 +82,9 @@ export function ShellPage() {
   computerVisible.current = panel === "computer" || computerOpen;
 
   const active = bots.find((b) => b.id === botId) ?? bots[0];
+  const activeBotId = useRef<string | undefined>(active?.id);
+  activeBotId.current = active?.id;
+  const screenRequest = useRef(0);
   const contextBot = botMenu ? bots.find((bot) => bot.id === botMenu.botId) : undefined;
   const closeBotMenu = useCallback(() => setBotMenu(null), []);
   const updateBotUnread = useCallback((id: string, unread: boolean) => {
@@ -162,7 +165,15 @@ export function ShellPage() {
 
   async function refreshComputerScreen(id: string) {
     if (!computerVisible.current) return;
+    const request = ++screenRequest.current;
     const screen = await rpc.computer.screenUrl({ botId: id }).catch(() => ({ url: null }));
+    if (
+      request !== screenRequest.current ||
+      activeBotId.current !== id ||
+      !computerVisible.current
+    ) {
+      return;
+    }
     setScreenUrl(screen.url);
   }
 
@@ -211,6 +222,8 @@ export function ShellPage() {
 
   useEffect(() => {
     if (!active) return;
+    screenRequest.current += 1;
+    setScreenUrl(null);
     expandedHistoryThread.current = null;
     const abort = new AbortController();
     void (async () => {

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -101,9 +101,10 @@ describe("sandbox supervisor input containment", () => {
   it("keeps the viewer read-only and uses a separate process for takeover control", () => {
     expect(interactiveScreenCommand(false)).toMatch(/pkill .*5901/);
     expect(interactiveScreenCommand(false)).not.toMatch(/x11vnc -display/);
-    expect(interactiveScreenCommand(true)).toMatch(/x11vnc -display .* -rfbport 5901/);
-    expect(interactiveScreenCommand(true)).toMatch(/6081/);
-    expect(interactiveScreenCommand(true)).not.toMatch(/-rfbport 5900/);
+    expect(interactiveScreenCommand(true, "lease-new")).toMatch(/x11vnc -display .* -rfbport 5901/);
+    expect(interactiveScreenCommand(true, "lease-new")).toMatch(/6081/);
+    expect(interactiveScreenCommand(true, "lease-new")).not.toMatch(/-rfbport 5900/);
+    expect(interactiveScreenCommand(false, "lease-old")).toContain("!= 'lease-old'");
   });
 
   it("parses a captured frame without trusting optional desktop metadata", () => {

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -317,14 +317,28 @@ app.get("/computers/:id/screen", async (c) => {
 });
 
 app.post("/computers/:id/screen-mode", async (c) => {
-  const body = z.object({ interactive: z.boolean() }).parse(await c.req.json());
+  const body = z
+    .object({
+      interactive: z.boolean(),
+      controlToken: z
+        .string()
+        .regex(/^[A-Za-z0-9_-]{1,128}$/)
+        .optional(),
+      revokeControl: z.boolean().optional(),
+    })
+    .refine((value) => !value.interactive || value.controlToken, {
+      message: "interactive screen requires a control token",
+    })
+    .parse(await c.req.json());
   try {
     const { container, info } = await managedContainer(
       c.req.param("id"),
       c.req.header("x-rakazo-bot-id"),
       c.req.header("x-rakazo-workspace-id"),
     );
-    await setInteractiveScreen(container, body.interactive);
+    if (body.interactive || body.revokeControl !== false) {
+      await setInteractiveScreen(container, body.interactive, body.controlToken);
+    }
     const screenUrl = await publishedScreenUrl(container, info, body.interactive ? "6081" : "6080");
     return c.json({ screenUrl });
   } catch (error) {
@@ -525,11 +539,15 @@ async function publishedScreenUrl(
   throw new Error("computer screen port was not published");
 }
 
-async function setInteractiveScreen(container: Docker.Container, interactive: boolean) {
+async function setInteractiveScreen(
+  container: Docker.Container,
+  interactive: boolean,
+  controlToken?: string,
+) {
   const result = await runContainerCommand(container, [
     "bash",
     "-lc",
-    interactiveScreenCommand(interactive),
+    interactiveScreenCommand(interactive, controlToken),
   ]);
   if (result.code !== 0) throw new Error(result.stderr || "control screen failed to start");
 }

--- a/infra/sandboxes/supervisor/src/supervisor-logic.ts
+++ b/infra/sandboxes/supervisor/src/supervisor-logic.ts
@@ -106,20 +106,31 @@ export function workspaceTarget(relative: string) {
   return relative ? path.posix.join("/home/rakazo", relative) : "/home/rakazo";
 }
 
-export function interactiveScreenCommand(interactive: boolean) {
-  const stop =
+export function interactiveScreenCommand(interactive: boolean, controlToken?: string) {
+  const tokenFile = "/tmp/rakazo/control-token";
+  const stopProcesses =
     "pkill -f '^x11vnc .* -rfbport 5901' || true; " +
-    "pkill -f '^/usr/bin/python3 .*websockify.*6081' || true";
+    "pkill -f '^/usr/bin/python3 .*websockify.*6081' || true; " +
+    `rm -f ${tokenFile}`;
+  const stop = controlToken
+    ? `[ -f ${tokenFile} ] && [ "$(cat ${tokenFile})" != ${shellQuote(controlToken)} ] || { ${stopProcesses}; }`
+    : stopProcesses;
   if (!interactive) return stop;
+  if (!controlToken) throw new Error("interactive screen requires a control token");
   return [
-    "pgrep -f '^x11vnc .* -rfbport 5901' >/dev/null && pgrep -f '^/usr/bin/python3 .*websockify.*6081' >/dev/null && exit 0 || true",
-    stop,
+    `[ -f ${tokenFile} ] && [ "$(cat ${tokenFile})" = ${shellQuote(controlToken)} ] && pgrep -f '^x11vnc .* -rfbport 5901' >/dev/null && pgrep -f '^/usr/bin/python3 .*websockify.*6081' >/dev/null && exit 0 || true`,
+    stopProcesses,
+    `printf %s ${shellQuote(controlToken)} > ${tokenFile}`,
     "export DISPLAY=:1",
     "(x11vnc -display :1 -forever -shared -nopw -listen 127.0.0.1 -rfbport 5901 -xkb -ncache 0 >/tmp/rakazo/x11vnc-control.log 2>&1 &)",
     "(websockify --web=/usr/share/novnc 0.0.0.0:6081 127.0.0.1:5901 >/tmp/rakazo/novnc-control.log 2>&1 &)",
     "for i in $(seq 1 50); do (echo >/dev/tcp/127.0.0.1/6081) >/dev/null 2>&1 && exit 0; sleep 0.1; done",
     "exit 1",
   ].join("; ");
+}
+
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 export function parseObservation(output: string) {

--- a/packages/adapter-kit/src/background-jobs.test.ts
+++ b/packages/adapter-kit/src/background-jobs.test.ts
@@ -7,6 +7,7 @@ function handlers(): BackgroundJobHandlers {
     "run.continue": vi.fn(async () => undefined),
     "routine.wakeup": vi.fn(async () => undefined),
     "computer.sleep": vi.fn(async () => undefined),
+    "computer.control-expire": vi.fn(async () => undefined),
   };
 }
 
@@ -32,5 +33,20 @@ describe("background job contracts", () => {
       }),
     ).toThrow();
     expect(() => parseBackgroundJob("run.continue", { runId: "" })).toThrow();
+    expect(() =>
+      parseBackgroundJob("computer.control-expire", { botId: "bot-1", leaseId: "" }),
+    ).toThrow();
+  });
+
+  it("validates and dispatches a control-expiry job", async () => {
+    const target = handlers();
+    await dispatchBackgroundJob(target, "computer.control-expire", {
+      botId: "bot-1",
+      leaseId: "lease-1",
+    });
+    expect(target["computer.control-expire"]).toHaveBeenCalledWith({
+      botId: "bot-1",
+      leaseId: "lease-1",
+    });
   });
 });

--- a/packages/adapter-kit/src/background-jobs.ts
+++ b/packages/adapter-kit/src/background-jobs.ts
@@ -13,6 +13,10 @@ const payloadSchemas = {
     scheduledFor: z.string().datetime({ offset: true }),
   }),
   "computer.sleep": z.object({ botId: z.string().min(1) }),
+  "computer.control-expire": z.object({
+    botId: z.string().min(1),
+    leaseId: z.string().min(1),
+  }),
 } satisfies { [Name in BackgroundJobName]: z.ZodType<BackgroundJobPayloads[Name]> };
 
 export function parseBackgroundJob(name: string, payload: unknown): BackgroundJob {
@@ -44,6 +48,10 @@ export function computerSleepJobKey(botId: string): string {
   return `computer.sleep:${botId}`;
 }
 
+export function computerControlExpireJobKey(botId: string): string {
+  return `computer.control-expire:${botId}`;
+}
+
 export function runContinueJob(runId: string): BackgroundJob {
   return {
     name: "run.continue",
@@ -67,5 +75,18 @@ export function computerSleepJob(botId: string, availableAt: Date): BackgroundJo
     payload: { botId },
     availableAt,
     replaceKey: computerSleepJobKey(botId),
+  };
+}
+
+export function computerControlExpireJob(
+  botId: string,
+  leaseId: string,
+  availableAt: Date,
+): BackgroundJob {
+  return {
+    name: "computer.control-expire",
+    payload: { botId, leaseId },
+    availableAt,
+    replaceKey: computerControlExpireJobKey(botId),
   };
 }

--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -62,6 +62,7 @@ export interface SandboxProvider {
     computer: ComputerRef,
     interactive: boolean,
     context: AdapterContext,
+    controlToken?: string,
   ): Promise<void>;
   sendInput(
     computer: ComputerRef,

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -62,6 +62,8 @@ export interface ScreenRequest {
   view: "stream" | "snapshot";
   /** Request a separately authorized control stream instead of the read-only viewer. */
   interactive?: boolean;
+  /** Fences an interactive stream so an older lease cannot revoke its replacement. */
+  controlToken?: string;
 }
 
 export interface ScreenSession {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -287,6 +287,7 @@ export interface BackgroundJobPayloads {
   "run.continue": { runId: string };
   "routine.wakeup": { routineId: string; scheduledFor: string };
   "computer.sleep": { botId: string };
+  "computer.control-expire": { botId: string; leaseId: string };
 }
 
 export type BackgroundJobName = keyof BackgroundJobPayloads;

--- a/packages/adapters/src/background-job-handlers.ts
+++ b/packages/adapters/src/background-job-handlers.ts
@@ -5,7 +5,8 @@ import type {
   SandboxProvider,
 } from "@rakazo/adapter-kit";
 import type { PrismaClient, ThreadEvents } from "@rakazo/db";
-import { sleepComputerIfIdle } from "./computer-idle.js";
+import { expireComputerControl } from "./computer-control.js";
+import { scheduleComputerSleep, sleepComputerIfIdle } from "./computer-idle.js";
 import type { createRunExecutor } from "./executor.js";
 
 export function createBackgroundJobHandlers(deps: {
@@ -26,6 +27,11 @@ export function createBackgroundJobHandlers(deps: {
     },
     "computer.sleep": async (payload) => {
       await sleepComputerIfIdle(deps, payload.botId);
+    },
+    "computer.control-expire": async (payload) => {
+      if (await expireComputerControl(deps, payload.botId, payload.leaseId)) {
+        scheduleComputerSleep(deps.jobs, payload.botId);
+      }
     },
   };
 }

--- a/packages/adapters/src/computer-control.test.ts
+++ b/packages/adapters/src/computer-control.test.ts
@@ -67,20 +67,15 @@ describe("computer control leases", () => {
       expect.objectContaining({ providerRef: "computer" }),
       false,
       expect.objectContaining({ operationId: "computer.control-expire" }),
+      "lease-1",
     );
-    expect(harness.prisma.computer.updateMany.mock.calls[1]?.[0]).toMatchObject({
-      data: {
-        controlHolder: "none",
-        controlLeaseId: null,
-        controlLeaseExpiresAt: null,
-      },
+    expect(harness.events.finalizeComputerControlRelease).toHaveBeenCalledWith({
+      workspaceId: "workspace",
+      botId: "bot",
+      leaseId: "lease-1",
+      holder: "none",
+      reason: "expired",
     });
-    expect(harness.events.append).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "computer.takeover.released",
-        payload: { holder: "none", leaseId: "lease-1", reason: "expired" },
-      }),
-    );
   });
 
   it("keeps the denied lease retryable when provider revocation fails", async () => {
@@ -97,7 +92,7 @@ describe("computer control leases", () => {
       where: { botId: "bot", controlLeaseId: "lease-1" },
       data: { controlHolder: "none" },
     });
-    expect(harness.events.append).not.toHaveBeenCalled();
+    expect(harness.events.finalizeComputerControlRelease).not.toHaveBeenCalled();
   });
 
   it("does not revoke a replacement lease", async () => {
@@ -144,7 +139,10 @@ function controlHarness(
   const sandbox = { setScreenControl };
   const enqueue = vi.fn(async (_job: BackgroundJob) => undefined);
   const jobs = { enqueue, cancel: vi.fn(), close: vi.fn() };
-  const events = { append: vi.fn().mockResolvedValue({}) };
+  const events = {
+    append: vi.fn().mockResolvedValue({}),
+    finalizeComputerControlRelease: vi.fn().mockResolvedValue(true),
+  };
   return {
     prisma,
     setScreenControl,

--- a/packages/adapters/src/computer-control.test.ts
+++ b/packages/adapters/src/computer-control.test.ts
@@ -1,0 +1,160 @@
+import type { BackgroundJob, JobPublisher, SandboxProvider } from "@rakazo/adapter-kit";
+import type { PrismaClient, ThreadEvents } from "@rakazo/db";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_TAKEOVER_LEASE_MS,
+  expireComputerControl,
+  hasActiveComputerControl,
+  takeoverLeaseMs,
+} from "./computer-control.js";
+
+describe("computer control leases", () => {
+  it("defaults to fifteen minutes and rejects unsafe configuration", () => {
+    const previous = process.env.COMPUTER_TAKEOVER_TTL_MS;
+    try {
+      delete process.env.COMPUTER_TAKEOVER_TTL_MS;
+      expect(takeoverLeaseMs()).toBe(15 * 60 * 1000);
+      process.env.COMPUTER_TAKEOVER_TTL_MS = "999";
+      expect(takeoverLeaseMs()).toBe(DEFAULT_TAKEOVER_LEASE_MS);
+      process.env.COMPUTER_TAKEOVER_TTL_MS = "1000";
+      expect(takeoverLeaseMs()).toBe(1000);
+    } finally {
+      if (previous === undefined) delete process.env.COMPUTER_TAKEOVER_TTL_MS;
+      else process.env.COMPUTER_TAKEOVER_TTL_MS = previous;
+    }
+  });
+
+  it("requires every persisted lease boundary to authorize control", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const active = {
+      controlHolder: "user",
+      controlLeaseId: "lease-1",
+      controlLeaseExpiresAt: new Date(now.getTime() + 1),
+    };
+    expect(hasActiveComputerControl(active, now)).toBe(true);
+    expect(hasActiveComputerControl({ ...active, controlHolder: "none" }, now)).toBe(false);
+    expect(hasActiveComputerControl({ ...active, controlLeaseId: null }, now)).toBe(false);
+    expect(hasActiveComputerControl({ ...active, controlLeaseExpiresAt: now }, now)).toBe(false);
+  });
+
+  it("reschedules an early delivery without revoking control", async () => {
+    const expiresAt = new Date("2026-01-01T00:00:01.000Z");
+    const harness = controlHarness({ controlLeaseExpiresAt: expiresAt });
+
+    await expect(
+      expireComputerControl(harness.deps, "bot", "lease-1", new Date("2026-01-01T00:00:00.000Z")),
+    ).resolves.toBe(false);
+
+    expect(harness.enqueue).toHaveBeenCalledWith({
+      name: "computer.control-expire",
+      payload: { botId: "bot", leaseId: "lease-1" },
+      availableAt: expiresAt,
+      replaceKey: "computer.control-expire:bot",
+    });
+    expect(harness.setScreenControl).not.toHaveBeenCalled();
+  });
+
+  it("denies control, revokes the stream, clears the lease, and publishes expiry", async () => {
+    const harness = controlHarness();
+
+    await expect(expireComputerControl(harness.deps, "bot", "lease-1")).resolves.toBe(true);
+
+    expect(harness.prisma.computer.updateMany.mock.calls[0]?.[0]).toMatchObject({
+      where: { botId: "bot", controlLeaseId: "lease-1" },
+      data: { controlHolder: "none" },
+    });
+    expect(harness.setScreenControl).toHaveBeenCalledWith(
+      expect.objectContaining({ providerRef: "computer" }),
+      false,
+      expect.objectContaining({ operationId: "computer.control-expire" }),
+    );
+    expect(harness.prisma.computer.updateMany.mock.calls[1]?.[0]).toMatchObject({
+      data: {
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+      },
+    });
+    expect(harness.events.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "computer.takeover.released",
+        payload: { holder: "none", leaseId: "lease-1", reason: "expired" },
+      }),
+    );
+  });
+
+  it("keeps the denied lease retryable when provider revocation fails", async () => {
+    const harness = controlHarness({
+      revokeError: new Error("provider unavailable"),
+    });
+
+    await expect(expireComputerControl(harness.deps, "bot", "lease-1")).rejects.toThrow(
+      "provider unavailable",
+    );
+
+    expect(harness.prisma.computer.updateMany).toHaveBeenCalledTimes(1);
+    expect(harness.prisma.computer.updateMany).toHaveBeenCalledWith({
+      where: { botId: "bot", controlLeaseId: "lease-1" },
+      data: { controlHolder: "none" },
+    });
+    expect(harness.events.append).not.toHaveBeenCalled();
+  });
+
+  it("does not revoke a replacement lease", async () => {
+    const harness = controlHarness({ controlLeaseId: "lease-2" });
+    await expect(expireComputerControl(harness.deps, "bot", "lease-1")).resolves.toBe(false);
+    expect(harness.setScreenControl).not.toHaveBeenCalled();
+    expect(harness.prisma.computer.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+function controlHarness(
+  options: {
+    controlLeaseId?: string;
+    controlLeaseExpiresAt?: Date | null;
+    revokeError?: Error;
+  } = {},
+) {
+  const computer = {
+    botId: "bot",
+    providerRef: "computer",
+    kind: "docker",
+    state: "running",
+    controlHolder: "user",
+    controlLeaseId: options.controlLeaseId ?? "lease-1",
+    controlLeaseExpiresAt:
+      options.controlLeaseExpiresAt === undefined
+        ? new Date("2026-01-01T00:00:00.000Z")
+        : options.controlLeaseExpiresAt,
+    workspaceId: "workspace",
+    userId: "user",
+  };
+  const prisma = {
+    computer: {
+      findUnique: vi.fn().mockResolvedValue(computer),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+    bot: {
+      findUnique: vi.fn().mockResolvedValue({ id: "bot", thread: { id: "thread" } }),
+    },
+  };
+  const setScreenControl = vi.fn(async () => {
+    if (options.revokeError) throw options.revokeError;
+  });
+  const sandbox = { setScreenControl };
+  const enqueue = vi.fn(async (_job: BackgroundJob) => undefined);
+  const jobs = { enqueue, cancel: vi.fn(), close: vi.fn() };
+  const events = { append: vi.fn().mockResolvedValue({}) };
+  return {
+    prisma,
+    setScreenControl,
+    enqueue,
+    events,
+    deps: {
+      prisma: prisma as unknown as PrismaClient,
+      sandbox: sandbox as unknown as SandboxProvider,
+      jobs: jobs as unknown as JobPublisher,
+      events: events as unknown as ThreadEvents,
+    },
+  };
+}

--- a/packages/adapters/src/computer-control.test.ts
+++ b/packages/adapters/src/computer-control.test.ts
@@ -95,6 +95,17 @@ describe("computer control leases", () => {
     expect(harness.events.finalizeComputerControlRelease).not.toHaveBeenCalled();
   });
 
+  it("retries atomic lease cleanup when release-event persistence fails", async () => {
+    const harness = controlHarness({ finalizeError: new Error("event unavailable") });
+
+    await expect(expireComputerControl(harness.deps, "bot", "lease-1")).rejects.toThrow(
+      "event unavailable",
+    );
+    await expect(expireComputerControl(harness.deps, "bot", "lease-1")).resolves.toBe(true);
+
+    expect(harness.events.finalizeComputerControlRelease).toHaveBeenCalledTimes(2);
+  });
+
   it("does not revoke a replacement lease", async () => {
     const harness = controlHarness({ controlLeaseId: "lease-2" });
     await expect(expireComputerControl(harness.deps, "bot", "lease-1")).resolves.toBe(false);
@@ -108,6 +119,7 @@ function controlHarness(
     controlLeaseId?: string;
     controlLeaseExpiresAt?: Date | null;
     revokeError?: Error;
+    finalizeError?: Error;
   } = {},
 ) {
   const computer = {
@@ -139,9 +151,13 @@ function controlHarness(
   const sandbox = { setScreenControl };
   const enqueue = vi.fn(async (_job: BackgroundJob) => undefined);
   const jobs = { enqueue, cancel: vi.fn(), close: vi.fn() };
+  const finalizeComputerControlRelease = vi.fn().mockResolvedValue(true);
+  if (options.finalizeError) {
+    finalizeComputerControlRelease.mockRejectedValueOnce(options.finalizeError);
+  }
   const events = {
     append: vi.fn().mockResolvedValue({}),
-    finalizeComputerControlRelease: vi.fn().mockResolvedValue(true),
+    finalizeComputerControlRelease,
   };
   return {
     prisma,

--- a/packages/adapters/src/computer-control.ts
+++ b/packages/adapters/src/computer-control.ts
@@ -86,31 +86,15 @@ export async function expireComputerControl(
       },
       false,
       context,
+      leaseId,
     );
   }
 
-  const cleared = await deps.prisma.computer.updateMany({
-    where: { botId, controlLeaseId: leaseId },
-    data: {
-      controlHolder: "none",
-      controlLeaseId: null,
-      controlLeaseExpiresAt: null,
-    },
+  return deps.events.finalizeComputerControlRelease({
+    workspaceId: computer.workspaceId,
+    botId,
+    leaseId,
+    holder: "none",
+    reason: "expired",
   });
-  if (cleared.count !== 1) return false;
-
-  const bot = await deps.prisma.bot.findUnique({
-    where: { id: botId },
-    include: { thread: true },
-  });
-  if (bot?.thread) {
-    await deps.events.append({
-      workspaceId: computer.workspaceId,
-      threadId: bot.thread.id,
-      botId,
-      type: "computer.takeover.released",
-      payload: { holder: "none", leaseId, reason: "expired" },
-    });
-  }
-  return true;
 }

--- a/packages/adapters/src/computer-control.ts
+++ b/packages/adapters/src/computer-control.ts
@@ -1,0 +1,116 @@
+import {
+  type AdapterContext,
+  computerControlExpireJob,
+  type JobPublisher,
+  type SandboxProvider,
+} from "@rakazo/adapter-kit";
+import type { PrismaClient, ThreadEvents } from "@rakazo/db";
+
+export const DEFAULT_TAKEOVER_LEASE_MS = 15 * 60 * 1000;
+
+export function takeoverLeaseMs(): number {
+  const raw = Number(process.env.COMPUTER_TAKEOVER_TTL_MS ?? DEFAULT_TAKEOVER_LEASE_MS);
+  return Number.isFinite(raw) && raw >= 1_000 ? raw : DEFAULT_TAKEOVER_LEASE_MS;
+}
+
+export function hasActiveComputerControl(
+  computer:
+    | {
+        controlHolder: string;
+        controlLeaseId: string | null;
+        controlLeaseExpiresAt: Date | null;
+      }
+    | null
+    | undefined,
+  now = new Date(),
+): boolean {
+  return Boolean(
+    computer?.controlHolder === "user" &&
+      computer.controlLeaseId &&
+      computer.controlLeaseExpiresAt &&
+      computer.controlLeaseExpiresAt.getTime() > now.getTime(),
+  );
+}
+
+export function scheduleComputerControlExpiry(
+  jobs: JobPublisher,
+  botId: string,
+  leaseId: string,
+  expiresAt: Date,
+): Promise<void> {
+  return jobs.enqueue(computerControlExpireJob(botId, leaseId, expiresAt));
+}
+
+export async function expireComputerControl(
+  deps: {
+    prisma: PrismaClient;
+    sandbox: SandboxProvider;
+    jobs: JobPublisher;
+    events: ThreadEvents;
+  },
+  botId: string,
+  leaseId: string,
+  now = new Date(),
+): Promise<boolean> {
+  const computer = await deps.prisma.computer.findUnique({ where: { botId } });
+  if (!computer || computer.controlLeaseId !== leaseId) return false;
+
+  if (computer.controlLeaseExpiresAt && computer.controlLeaseExpiresAt.getTime() > now.getTime()) {
+    await scheduleComputerControlExpiry(deps.jobs, botId, leaseId, computer.controlLeaseExpiresAt);
+    return false;
+  }
+
+  // Deny API input before touching the provider. Retaining the lease ID makes a
+  // failed provider revocation recoverable by the job retry or reconciler.
+  const claimed = await deps.prisma.computer.updateMany({
+    where: { botId, controlLeaseId: leaseId },
+    data: { controlHolder: "none" },
+  });
+  if (claimed.count !== 1) return false;
+
+  if (computer.providerRef) {
+    const context: AdapterContext = {
+      operationId: "computer.control-expire",
+      traceId: "computer.control-expire",
+      workspaceId: computer.workspaceId,
+      userId: computer.userId,
+      botId,
+      signal: new AbortController().signal,
+    };
+    await deps.sandbox.setScreenControl?.(
+      {
+        id: computer.providerRef,
+        botId,
+        kind: computer.kind as "docker" | "e2b" | "desktop" | "fake",
+        providerRef: computer.providerRef,
+      },
+      false,
+      context,
+    );
+  }
+
+  const cleared = await deps.prisma.computer.updateMany({
+    where: { botId, controlLeaseId: leaseId },
+    data: {
+      controlHolder: "none",
+      controlLeaseId: null,
+      controlLeaseExpiresAt: null,
+    },
+  });
+  if (cleared.count !== 1) return false;
+
+  const bot = await deps.prisma.bot.findUnique({
+    where: { id: botId },
+    include: { thread: true },
+  });
+  if (bot?.thread) {
+    await deps.events.append({
+      workspaceId: computer.workspaceId,
+      threadId: bot.thread.id,
+      botId,
+      type: "computer.takeover.released",
+      payload: { holder: "none", leaseId, reason: "expired" },
+    });
+  }
+  return true;
+}

--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -32,6 +32,24 @@ describe("sandbox idle", () => {
     expect(harness.jobs.enqueue).toHaveBeenCalledOnce();
   });
 
+  it("does not let an abandoned waiting takeover prevent idle suspension", async () => {
+    const harness = idleHarness();
+    harness.prisma.computer.findUnique
+      .mockResolvedValueOnce(harness.computer)
+      .mockResolvedValueOnce({
+        state: "running",
+        providerRef: harness.computer.providerRef,
+        updatedAt: harness.computer.updatedAt,
+      });
+    harness.prisma.run.findFirst.mockImplementation(async ({ where }) =>
+      where.status.in.includes("waiting_takeover") ? { id: "waiting" } : null,
+    );
+
+    await sleepComputerIfIdle(harness.deps, "bot");
+
+    expect(harness.sandbox.stop).toHaveBeenCalledOnce();
+  });
+
   it("rechecks the lease boundary after checkpointing before it suspends", async () => {
     const harness = idleHarness();
     harness.prisma.computer.findUnique
@@ -68,7 +86,12 @@ describe("sandbox idle", () => {
     expect(harness.sandbox.stop).toHaveBeenCalledOnce();
     expect(harness.prisma.computer.update).toHaveBeenCalledWith({
       where: { botId: "bot" },
-      data: { state: "suspended", controlHolder: "none" },
+      data: {
+        state: "suspended",
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+      },
     });
     expect(harness.events.append).toHaveBeenCalledWith(
       expect.objectContaining({ type: "computer.status", payload: { status: "suspended" } }),
@@ -124,6 +147,9 @@ function idleHarness(options: { exportError?: Error } = {}) {
     state: "running",
     workspaceId: "workspace",
     userId: "user",
+    controlHolder: "none",
+    controlLeaseId: null,
+    controlLeaseExpiresAt: null,
     updatedAt: new Date("2026-01-01T00:00:00.000Z"),
   };
   const prisma = {

--- a/packages/adapters/src/computer-idle.ts
+++ b/packages/adapters/src/computer-idle.ts
@@ -7,6 +7,7 @@ import {
 } from "@rakazo/adapter-kit";
 import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
 import type { PrismaClient, ThreadEvents } from "@rakazo/db";
+import { expireComputerControl, hasActiveComputerControl } from "./computer-control.js";
 import { checkpointAndRecordComputerWorkspace } from "./computer-workspace.js";
 
 export const DEFAULT_SANDBOX_IDLE_MS = 10 * 60 * 1000;
@@ -44,11 +45,19 @@ export async function sleepComputerIfIdle(
   },
   botId: string,
 ): Promise<void> {
-  const computer = await deps.prisma.computer.findUnique({ where: { botId } });
+  let computer = await deps.prisma.computer.findUnique({ where: { botId } });
   if (!computer?.providerRef) return;
   if (computer.state !== "running") return;
+  if (computer.controlLeaseId && !hasActiveComputerControl(computer)) {
+    await expireComputerControl(deps, botId, computer.controlLeaseId);
+    computer = await deps.prisma.computer.findUnique({ where: { botId } });
+    if (!computer?.providerRef || computer.state !== "running") return;
+  }
+  const activeStatuses = hasActiveComputerControl(computer)
+    ? [...ACTIVE_RUN_STATUSES]
+    : ACTIVE_RUN_STATUSES.filter((status) => status !== "waiting_takeover");
   const active = await deps.prisma.run.findFirst({
-    where: { botId, status: { in: [...ACTIVE_RUN_STATUSES] } },
+    where: { botId, status: { in: activeStatuses } },
     select: { id: true },
   });
   if (active) {
@@ -76,7 +85,7 @@ export async function sleepComputerIfIdle(
       select: { state: true, providerRef: true, updatedAt: true },
     }),
     deps.prisma.run.findFirst({
-      where: { botId, status: { in: [...ACTIVE_RUN_STATUSES] } },
+      where: { botId, status: { in: activeStatuses } },
       select: { id: true },
     }),
   ]);
@@ -92,7 +101,12 @@ export async function sleepComputerIfIdle(
   await deps.sandbox.stop(ref, ctx);
   await deps.prisma.computer.update({
     where: { botId },
-    data: { state: "suspended", controlHolder: "none" },
+    data: {
+      state: "suspended",
+      controlHolder: "none",
+      controlLeaseId: null,
+      controlLeaseExpiresAt: null,
+    },
   });
   const bot = await deps.prisma.bot.findUnique({
     where: { id: botId },

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -117,7 +117,11 @@ export class DockerSandboxProvider implements SandboxProvider {
     const res = await fetch(this.url(`/computers/${computer.id}/screen-mode`), {
       method: "POST",
       headers: { ...this.headers(context, computer.botId), "content-type": "application/json" },
-      body: JSON.stringify({ interactive: request.interactive === true }),
+      body: JSON.stringify({
+        interactive: request.interactive === true,
+        controlToken: request.controlToken,
+        revokeControl: false,
+      }),
       signal: context.signal,
     });
     if (!res.ok) {
@@ -131,11 +135,16 @@ export class DockerSandboxProvider implements SandboxProvider {
     };
   }
 
-  async setScreenControl(computer: ComputerRef, interactive: boolean, context: AdapterContext) {
+  async setScreenControl(
+    computer: ComputerRef,
+    interactive: boolean,
+    context: AdapterContext,
+    controlToken?: string,
+  ) {
     const res = await fetch(this.url(`/computers/${computer.id}/screen-mode`), {
       method: "POST",
       headers: { ...this.headers(context, computer.botId), "content-type": "application/json" },
-      body: JSON.stringify({ interactive }),
+      body: JSON.stringify({ interactive, controlToken }),
       signal: context.signal,
     });
     if (!res.ok) throw new Error(`sandbox screen mode failed: ${res.status}`);

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -154,7 +154,7 @@ describe("E2B computer backend", () => {
 
     const control = await provider.connectScreen(
       computer,
-      { view: "stream", interactive: true },
+      { view: "stream", interactive: true, controlToken: "lease-1" },
       context,
     );
     expect(control.url).toMatch(/^https:\/\/6081-desktop\.test\/vnc\.html\?/);
@@ -162,7 +162,7 @@ describe("E2B computer backend", () => {
       true,
     );
 
-    await provider.setScreenControl(computer, false);
+    await provider.setScreenControl(computer, false, context, "lease-1");
     expect(
       command.mock.calls.some(([value]) =>
         String(value).includes("pkill -f '^x11vnc .* -rfbport 5901'"),
@@ -170,9 +170,18 @@ describe("E2B computer backend", () => {
     ).toBe(true);
     const replacementControl = await provider.connectScreen(
       computer,
-      { view: "stream", interactive: true },
+      { view: "stream", interactive: true, controlToken: "lease-2" },
       context,
     );
     expect(replacementControl.url).not.toBe(control.url);
+
+    await provider.setScreenControl(computer, false, context, "lease-1");
+    expect(command).toHaveBeenLastCalledWith(expect.stringContaining("!= 'lease-1'"));
+    const stillCurrent = await provider.connectScreen(
+      computer,
+      { view: "stream", interactive: true, controlToken: "lease-2" },
+      context,
+    );
+    expect(stillCurrent.url).toBe(replacementControl.url);
   });
 });

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -162,6 +162,14 @@ describe("E2B computer backend", () => {
       true,
     );
 
+    await provider.connectScreen(computer, { view: "stream" }, context);
+    const sameControl = await provider.connectScreen(
+      computer,
+      { view: "stream", interactive: true, controlToken: "lease-1" },
+      context,
+    );
+    expect(sameControl.url).toBe(control.url);
+
     await provider.setScreenControl(computer, false, context, "lease-1");
     expect(
       command.mock.calls.some(([value]) =>

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -73,7 +73,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   private readonly boxes = new Map<string, Sandbox>();
   private readonly lastTouchedAt = new Map<string, number>();
   private readonly streamReady = new Set<string>();
-  private readonly controlStreamPasswords = new Map<string, string>();
+  private readonly controlStreams = new Map<string, { password: string; controlToken: string }>();
 
   constructor(
     private readonly apiKey: string,
@@ -198,7 +198,8 @@ export class E2BSandboxProvider implements SandboxProvider {
     const desktop = await this.box(computer);
     await this.startStream(desktop);
     if (request.interactive) {
-      const password = await this.startControlStream(desktop);
+      if (!request.controlToken) throw new Error("interactive screen requires a control token");
+      const password = await this.startControlStream(desktop, request.controlToken);
       const url = new URL(`https://${desktop.getHost(6081)}/vnc.html`);
       url.searchParams.set("autoconnect", "true");
       url.searchParams.set("resize", "scale");
@@ -209,7 +210,6 @@ export class E2BSandboxProvider implements SandboxProvider {
         close: async () => undefined,
       };
     }
-    await this.stopControlStream(desktop);
     let authKey: string | undefined;
     try {
       authKey = desktop.stream.getAuthKey();
@@ -235,10 +235,19 @@ export class E2BSandboxProvider implements SandboxProvider {
     };
   }
 
-  async setScreenControl(computer: ComputerRef, interactive: boolean): Promise<void> {
+  async setScreenControl(
+    computer: ComputerRef,
+    interactive: boolean,
+    _context: AdapterContext,
+    controlToken?: string,
+  ): Promise<void> {
     const desktop = await this.box(computer);
-    if (interactive) await this.startControlStream(desktop);
-    else await this.stopControlStream(desktop);
+    if (interactive) {
+      if (!controlToken) throw new Error("interactive screen requires a control token");
+      await this.startControlStream(desktop, controlToken);
+    } else {
+      await this.stopControlStream(desktop, controlToken);
+    }
   }
 
   async sendInput(
@@ -383,7 +392,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     this.boxes.delete(id);
     this.lastTouchedAt.delete(id);
     this.streamReady.delete(id);
-    this.controlStreamPasswords.delete(id);
+    this.controlStreams.delete(id);
     if (desktop) {
       await desktop.pause().catch(() => undefined);
       return;
@@ -398,16 +407,18 @@ export class E2BSandboxProvider implements SandboxProvider {
     this.boxes.delete(id);
     this.lastTouchedAt.delete(id);
     this.streamReady.delete(id);
-    this.controlStreamPasswords.delete(id);
+    this.controlStreams.delete(id);
   }
 
-  private async startControlStream(desktop: Sandbox): Promise<string> {
-    const existing = this.controlStreamPasswords.get(desktop.sandboxId);
-    if (existing) return existing;
+  private async startControlStream(desktop: Sandbox, controlToken: string): Promise<string> {
+    const existing = this.controlStreams.get(desktop.sandboxId);
+    if (existing?.controlToken === controlToken) return existing.password;
     const password = randomBytes(6).toString("base64url");
     const passwordFile = "/tmp/rakazo-control.vncpass";
+    const tokenFile = "/tmp/rakazo-control.token";
     const command = [
       controlStreamStopCommand(),
+      `printf %s ${shellQuote(controlToken)} > ${tokenFile}`,
       `x11vnc -storepasswd ${shellQuote(password)} ${passwordFile} >/dev/null`,
       `x11vnc -bg -display ${shellQuote(desktop.display)} -forever -wait 50 -shared -rfbport 5901 -rfbauth ${passwordFile} 2>/tmp/rakazo-control-x11vnc.log`,
       "cd /opt/noVNC/utils",
@@ -417,22 +428,28 @@ export class E2BSandboxProvider implements SandboxProvider {
     ].join(" && ");
     const result = await desktop.commands.run(command);
     if (result.exitCode !== 0) throw new Error(result.stderr || "control stream failed to start");
-    this.controlStreamPasswords.set(desktop.sandboxId, password);
+    this.controlStreams.set(desktop.sandboxId, { password, controlToken });
     return password;
   }
 
-  private async stopControlStream(desktop: Sandbox): Promise<void> {
-    await desktop.commands.run(controlStreamStopCommand());
-    this.controlStreamPasswords.delete(desktop.sandboxId);
+  private async stopControlStream(desktop: Sandbox, controlToken?: string): Promise<void> {
+    await desktop.commands.run(controlStreamStopCommand(controlToken));
+    const existing = this.controlStreams.get(desktop.sandboxId);
+    if (!controlToken || existing?.controlToken === controlToken) {
+      this.controlStreams.delete(desktop.sandboxId);
+    }
   }
 }
 
-function controlStreamStopCommand() {
-  return [
+function controlStreamStopCommand(controlToken?: string) {
+  const stop = [
     "pkill -f '^x11vnc .* -rfbport 5901' || true",
     "pkill -f '^/usr/bin/python3 .*websockify.*6081' || true",
     "rm -f /tmp/rakazo-control.vncpass",
+    "rm -f /tmp/rakazo-control.token",
   ].join("; ");
+  if (!controlToken) return stop;
+  return `[ -f /tmp/rakazo-control.token ] && [ "$(cat /tmp/rakazo-control.token)" != ${shellQuote(controlToken)} ] || { ${stop}; }`;
 }
 
 async function observeE2BDesktop(

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -26,7 +26,7 @@ import { createThreadMessage, type PrismaClient, type ThreadEvents } from "@raka
 import { builtinAgentTools } from "./builtin-tools.js";
 import { deleteSpawnedBot, spawnBot } from "./child-bots.js";
 import { collectLogIds } from "./composio-connector.js";
-import { hasActiveComputerControl } from "./computer-control.js";
+import { expireComputerControl, hasActiveComputerControl } from "./computer-control.js";
 import { scheduleComputerSleep } from "./computer-idle.js";
 import { observationToolResult, parseComputerActions } from "./computer-tools.js";
 import {
@@ -1031,7 +1031,14 @@ async function ensureComputer(
 ): Promise<ComputerRef> {
   const homePath = resolveAgentHomePath(deps.home, botId, deps.dataDir ?? "./data");
   await mkdir(homePath, { recursive: true });
-  const existing = await deps.prisma.computer.findUnique({ where: { botId } });
+  let existing = await deps.prisma.computer.findUnique({ where: { botId } });
+  if (existing?.controlLeaseId && !hasActiveComputerControl(existing)) {
+    await expireComputerControl(deps, botId, existing.controlLeaseId);
+    existing = await deps.prisma.computer.findUnique({ where: { botId } });
+    if (existing?.controlLeaseId && !hasActiveComputerControl(existing)) {
+      throw new Error("computer control revocation is still in progress");
+    }
+  }
   await deps.prisma.computer.updateMany({
     where: { botId },
     data: { state: "booting" },

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -26,6 +26,7 @@ import { createThreadMessage, type PrismaClient, type ThreadEvents } from "@raka
 import { builtinAgentTools } from "./builtin-tools.js";
 import { deleteSpawnedBot, spawnBot } from "./child-bots.js";
 import { collectLogIds } from "./composio-connector.js";
+import { hasActiveComputerControl } from "./computer-control.js";
 import { scheduleComputerSleep } from "./computer-idle.js";
 import { observationToolResult, parseComputerActions } from "./computer-tools.js";
 import {
@@ -686,7 +687,12 @@ export function createRunExecutor(deps: ExecutorDeps) {
               });
               await deps.prisma.computer.updateMany({
                 where: { botId: bot.id },
-                data: { state: "running", controlHolder: "none" },
+                data: {
+                  state: "running",
+                  controlHolder: "none",
+                  controlLeaseId: null,
+                  controlLeaseExpiresAt: null,
+                },
               });
               await checkpointAndRecordComputerWorkspace(deps, bot.id, computer, context);
               const paused = await deps.prisma.run.updateMany({
@@ -1048,13 +1054,15 @@ async function ensureComputer(
       existing.providerRef !== ref.providerRef ||
       existing.kind !== ref.kind;
     if (replacement) await restoreComputerWorkspace(deps.home, deps.sandbox, botId, ref, context);
+    const activeControl = hasActiveComputerControl(existing);
     await deps.prisma.computer.updateMany({
       where: { botId },
       data: {
         state: "running",
         providerRef: ref.providerRef,
         kind: ref.kind,
-        controlHolder: existing?.controlHolder === "user" ? "user" : "bot",
+        controlHolder: activeControl ? "user" : "bot",
+        ...(!activeControl ? { controlLeaseId: null, controlLeaseExpiresAt: null } : {}),
       },
     });
     scheduleComputerSleep(deps.jobs, botId);

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -4,6 +4,7 @@ export * from "./builtin-tools.js";
 export * from "./child-bots.js";
 export * from "./composio-catalog-cache.js";
 export * from "./composio-connector.js";
+export * from "./computer-control.js";
 export * from "./computer-idle.js";
 export * from "./computer-tools.js";
 export * from "./computer-workspace.js";

--- a/packages/adapters/src/job-reconciler.test.ts
+++ b/packages/adapters/src/job-reconciler.test.ts
@@ -92,7 +92,7 @@ describe("createJobReconciler", () => {
     );
   });
 
-  it("pages near-due control leases by their persisted deadline", async () => {
+  it("finishes a frozen control scan before admitting leases ahead of its cursor", async () => {
     const firstExpiry = new Date(Date.now() + 10_000);
     const secondExpiry = new Date(Date.now() + 20_000);
     const controls = [
@@ -118,7 +118,15 @@ describe("createJobReconciler", () => {
     const computerFindMany = vi
       .fn()
       .mockResolvedValueOnce(controls.slice(0, 2))
-      .mockResolvedValueOnce(controls.slice(2));
+      .mockResolvedValueOnce(controls.slice(2))
+      .mockResolvedValueOnce([
+        {
+          id: "computer-0",
+          botId: "bot-0",
+          controlLeaseId: "lease-0",
+          controlLeaseExpiresAt: firstExpiry,
+        },
+      ]);
     const prisma = {
       run: { findMany: vi.fn(async () => []) },
       routine: { findMany: vi.fn(async () => []) },
@@ -129,8 +137,9 @@ describe("createJobReconciler", () => {
 
     await reconciler.reconcileOnce();
     await reconciler.reconcileOnce();
+    await reconciler.reconcileOnce();
 
-    expect(enqueue).toHaveBeenCalledTimes(3);
+    expect(enqueue).toHaveBeenCalledTimes(4);
     expect(computerFindMany.mock.calls[1]?.[0]).toMatchObject({
       orderBy: [{ controlLeaseExpiresAt: "asc" }, { id: "asc" }],
       where: {
@@ -147,6 +156,15 @@ describe("createJobReconciler", () => {
         ],
       },
     });
+    const firstDeadline =
+      computerFindMany.mock.calls[0]?.[0].where.AND[1].OR[1].controlLeaseExpiresAt.lte;
+    const secondDeadline =
+      computerFindMany.mock.calls[1]?.[0].where.AND[1].OR[1].controlLeaseExpiresAt.lte;
+    expect(secondDeadline).toEqual(firstDeadline);
+    expect(computerFindMany.mock.calls[2]?.[0].where.AND).toHaveLength(2);
+    expect(enqueue).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { botId: "bot-0", leaseId: "lease-0" } }),
+    );
   });
 
   it("advances stable cursors so recoverable work beyond one batch is dispatched", async () => {

--- a/packages/adapters/src/job-reconciler.test.ts
+++ b/packages/adapters/src/job-reconciler.test.ts
@@ -20,19 +20,37 @@ function publisher() {
 function fakePrisma(
   runs: Array<{ id: string; updatedAt: Date }> = [],
   routines: Array<{ id: string; nextRunAt: Date | null }> = [],
+  controls: Array<{
+    id: string;
+    botId: string;
+    controlLeaseId: string | null;
+    controlLeaseExpiresAt: Date | null;
+    updatedAt: Date;
+  }> = [],
 ) {
   return {
     run: { findMany: vi.fn(async () => runs) },
     routine: { findMany: vi.fn(async () => routines) },
+    computer: { findMany: vi.fn(async () => controls) },
   } as unknown as PrismaClient;
 }
 
 describe("createJobReconciler", () => {
   it("restores queued runs and near-due routines with stable replacement keys", async () => {
     const scheduledFor = new Date(Date.now() + 30_000);
+    const controlExpiresAt = new Date(Date.now() + 15_000);
     const prisma = fakePrisma(
       [{ id: "run-1", updatedAt: new Date() }],
       [{ id: "routine-1", nextRunAt: scheduledFor }],
+      [
+        {
+          id: "computer-1",
+          botId: "bot-1",
+          controlLeaseId: "lease-1",
+          controlLeaseExpiresAt: controlExpiresAt,
+          updatedAt: new Date(),
+        },
+      ],
     );
     const { jobs, enqueue } = publisher();
     const reconciler = createJobReconciler({ prisma, jobs });
@@ -49,6 +67,85 @@ describe("createJobReconciler", () => {
       payload: { routineId: "routine-1", scheduledFor: scheduledFor.toISOString() },
       availableAt: scheduledFor,
       replaceKey: "routine:routine-1",
+    });
+    expect(enqueue).toHaveBeenCalledWith({
+      name: "computer.control-expire",
+      payload: { botId: "bot-1", leaseId: "lease-1" },
+      availableAt: controlExpiresAt,
+      replaceKey: "computer.control-expire:bot-1",
+    });
+    expect(vi.mocked(prisma.computer.findMany)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            { controlLeaseId: { not: null } },
+            {
+              OR: [
+                { controlLeaseExpiresAt: null },
+                { controlLeaseExpiresAt: { lte: expect.any(Date) } },
+              ],
+            },
+          ],
+        },
+        orderBy: [{ controlLeaseExpiresAt: "asc" }, { id: "asc" }],
+      }),
+    );
+  });
+
+  it("pages near-due control leases by their persisted deadline", async () => {
+    const firstExpiry = new Date(Date.now() + 10_000);
+    const secondExpiry = new Date(Date.now() + 20_000);
+    const controls = [
+      {
+        id: "computer-1",
+        botId: "bot-1",
+        controlLeaseId: "lease-1",
+        controlLeaseExpiresAt: firstExpiry,
+      },
+      {
+        id: "computer-2",
+        botId: "bot-2",
+        controlLeaseId: "lease-2",
+        controlLeaseExpiresAt: secondExpiry,
+      },
+      {
+        id: "computer-3",
+        botId: "bot-3",
+        controlLeaseId: "lease-3",
+        controlLeaseExpiresAt: null,
+      },
+    ];
+    const computerFindMany = vi
+      .fn()
+      .mockResolvedValueOnce(controls.slice(0, 2))
+      .mockResolvedValueOnce(controls.slice(2));
+    const prisma = {
+      run: { findMany: vi.fn(async () => []) },
+      routine: { findMany: vi.fn(async () => []) },
+      computer: { findMany: computerFindMany },
+    } as unknown as PrismaClient;
+    const { jobs, enqueue } = publisher();
+    const reconciler = createJobReconciler({ prisma, jobs }, { batchSize: 2 });
+
+    await reconciler.reconcileOnce();
+    await reconciler.reconcileOnce();
+
+    expect(enqueue).toHaveBeenCalledTimes(3);
+    expect(computerFindMany.mock.calls[1]?.[0]).toMatchObject({
+      orderBy: [{ controlLeaseExpiresAt: "asc" }, { id: "asc" }],
+      where: {
+        AND: [
+          expect.anything(),
+          expect.anything(),
+          {
+            OR: [
+              { controlLeaseExpiresAt: { gt: secondExpiry } },
+              { controlLeaseExpiresAt: secondExpiry, id: { gt: "computer-2" } },
+              { controlLeaseExpiresAt: null },
+            ],
+          },
+        ],
+      },
     });
   });
 
@@ -75,6 +172,7 @@ describe("createJobReconciler", () => {
     const prisma = {
       run: { findMany: runFindMany },
       routine: { findMany: routineFindMany },
+      computer: { findMany: vi.fn(async () => []) },
     } as unknown as PrismaClient;
     const { jobs, enqueue } = publisher();
     const reconciler = createJobReconciler({ prisma, jobs }, { batchSize: 2 });
@@ -140,6 +238,7 @@ describe("createJobReconciler", () => {
 
     expect(prisma.run.findMany).not.toHaveBeenCalled();
     expect(prisma.routine.findMany).not.toHaveBeenCalled();
+    expect(prisma.computer.findMany).not.toHaveBeenCalled();
     expect(enqueue).not.toHaveBeenCalled();
     expect(leadership.release).toHaveBeenCalledOnce();
   });

--- a/packages/adapters/src/job-reconciler.ts
+++ b/packages/adapters/src/job-reconciler.ts
@@ -1,16 +1,19 @@
 import { type JobPublisher, routineWakeupJob, runContinueJob } from "@rakazo/adapter-kit";
 import type { Pool, PrismaClient } from "@rakazo/db";
 import type { PoolClient } from "pg";
+import { scheduleComputerControlExpiry } from "./computer-control.js";
 
 const DEFAULT_INTERVAL_MS = 30_000;
 const DEFAULT_BATCH_SIZE = 100;
 const ROUTINE_LOOKAHEAD_MS = 60_000;
+const CONTROL_LOOKAHEAD_MS = 60_000;
 // Two keys give Rakazo's lock a namespace without relying on a hash that might collide
 // with an application using the one-key advisory-lock API.
 const RECONCILIATION_LOCK_NAMESPACE = 1_380_019_075;
 const RECONCILIATION_LOCK_ID = 1;
 
 type Cursor = { at: Date; id: string };
+type ControlCursor = { at: Date | null; id: string };
 
 export interface ReconciliationLeadership {
   tryAcquire(): Promise<boolean>;
@@ -100,6 +103,7 @@ export function createJobReconciler(
   let reconciling: Promise<void> | undefined;
   let runCursor: Cursor | undefined;
   let routineCursor: Cursor | undefined;
+  let controlCursor: ControlCursor | undefined;
 
   const reconcileOnce = async () => {
     if (reconciling) return reconciling;
@@ -123,7 +127,21 @@ export function createJobReconciler(
             ],
           }
         : undefined;
-      const [runs, routines] = await Promise.all([
+      const controlCursorFilter = controlCursor
+        ? controlCursor.at
+          ? {
+              OR: [
+                { controlLeaseExpiresAt: { gt: controlCursor.at } },
+                {
+                  controlLeaseExpiresAt: controlCursor.at,
+                  id: { gt: controlCursor.id },
+                },
+                { controlLeaseExpiresAt: null },
+              ],
+            }
+          : { controlLeaseExpiresAt: null, id: { gt: controlCursor.id } }
+        : undefined;
+      const [runs, routines, controls] = await Promise.all([
         deps.prisma.run.findMany({
           where: {
             AND: [
@@ -157,6 +175,32 @@ export function createJobReconciler(
           take: batchSize,
           select: { id: true, nextRunAt: true },
         }),
+        deps.prisma.computer.findMany({
+          where: {
+            AND: [
+              { controlLeaseId: { not: null } },
+              {
+                OR: [
+                  { controlLeaseExpiresAt: null },
+                  {
+                    controlLeaseExpiresAt: {
+                      lte: new Date(now.getTime() + CONTROL_LOOKAHEAD_MS),
+                    },
+                  },
+                ],
+              },
+              ...(controlCursorFilter ? [controlCursorFilter] : []),
+            ],
+          },
+          orderBy: [{ controlLeaseExpiresAt: "asc" }, { id: "asc" }],
+          take: batchSize,
+          select: {
+            id: true,
+            botId: true,
+            controlLeaseId: true,
+            controlLeaseExpiresAt: true,
+          },
+        }),
       ]);
 
       await Promise.all([
@@ -165,6 +209,14 @@ export function createJobReconciler(
           routine.nextRunAt
             ? [deps.jobs.enqueue(routineWakeupJob(routine.id, routine.nextRunAt))]
             : [],
+        ),
+        ...controls.map((computer) =>
+          scheduleComputerControlExpiry(
+            deps.jobs,
+            computer.botId,
+            computer.controlLeaseId!,
+            computer.controlLeaseExpiresAt ?? now,
+          ),
         ),
       ]);
 
@@ -177,6 +229,11 @@ export function createJobReconciler(
       routineCursor =
         routines.length === batchSize && lastRoutine?.nextRunAt
           ? { at: lastRoutine.nextRunAt, id: lastRoutine.id }
+          : undefined;
+      const lastControl = controls.at(-1);
+      controlCursor =
+        controls.length === batchSize && lastControl
+          ? { at: lastControl.controlLeaseExpiresAt, id: lastControl.id }
           : undefined;
     })().finally(() => {
       reconciling = undefined;

--- a/packages/adapters/src/job-reconciler.ts
+++ b/packages/adapters/src/job-reconciler.ts
@@ -104,6 +104,7 @@ export function createJobReconciler(
   let runCursor: Cursor | undefined;
   let routineCursor: Cursor | undefined;
   let controlCursor: ControlCursor | undefined;
+  let controlScanDeadline: Date | undefined;
 
   const reconcileOnce = async () => {
     if (reconciling) return reconciling;
@@ -111,6 +112,7 @@ export function createJobReconciler(
       if (deps.leadership && !(await deps.leadership.tryAcquire())) return;
 
       const now = new Date();
+      controlScanDeadline ??= new Date(now.getTime() + CONTROL_LOOKAHEAD_MS);
       const runCursorFilter = runCursor
         ? {
             OR: [
@@ -184,7 +186,7 @@ export function createJobReconciler(
                   { controlLeaseExpiresAt: null },
                   {
                     controlLeaseExpiresAt: {
-                      lte: new Date(now.getTime() + CONTROL_LOOKAHEAD_MS),
+                      lte: controlScanDeadline,
                     },
                   },
                 ],
@@ -235,6 +237,7 @@ export function createJobReconciler(
         controls.length === batchSize && lastControl
           ? { at: lastControl.controlLeaseExpiresAt, id: lastControl.id }
           : undefined;
+      if (!controlCursor) controlScanDeadline = undefined;
     })().finally(() => {
       reconciling = undefined;
     });

--- a/packages/adapters/src/wakeup.postgres.test.ts
+++ b/packages/adapters/src/wakeup.postgres.test.ts
@@ -11,6 +11,7 @@ function handlers(overrides: Partial<BackgroundJobHandlers> = {}): BackgroundJob
     "run.continue": vi.fn(async () => undefined),
     "routine.wakeup": vi.fn(async () => undefined),
     "computer.sleep": vi.fn(async () => undefined),
+    "computer.control-expire": vi.fn(async () => undefined),
     ...overrides,
   };
 }

--- a/packages/adapters/src/wakeup.test.ts
+++ b/packages/adapters/src/wakeup.test.ts
@@ -7,6 +7,7 @@ function handlers(): BackgroundJobHandlers {
     "run.continue": vi.fn(async () => undefined),
     "routine.wakeup": vi.fn(async () => undefined),
     "computer.sleep": vi.fn(async () => undefined),
+    "computer.control-expire": vi.fn(async () => undefined),
   };
 }
 

--- a/packages/db/prisma/migrations/0006_computer_control_lease_expiry/migration.sql
+++ b/packages/db/prisma/migrations/0006_computer_control_lease_expiry/migration.sql
@@ -1,0 +1,20 @@
+-- Persist takeover deadlines so API and worker replicas enforce the same lease.
+ALTER TABLE "computers" ADD COLUMN "controlLeaseExpiresAt" TIMESTAMP(3);
+
+-- Existing interactive leases had no authoritative deadline. Expire them on deploy
+-- so the reconciler can revoke their provider streams instead of extending them.
+UPDATE "computers"
+SET
+    "controlLeaseExpiresAt" = CASE
+        WHEN "controlLeaseId" IS NOT NULL THEN CURRENT_TIMESTAMP
+        ELSE NULL
+    END,
+    "controlHolder" = CASE
+        WHEN "controlLeaseId" IS NULL THEN 'none'
+        ELSE "controlHolder"
+    END
+WHERE "controlHolder" = 'user';
+
+CREATE INDEX "computers_controlLeaseExpiresAt_id_idx"
+ON "computers"("controlLeaseExpiresAt", "id")
+WHERE "controlLeaseId" IS NOT NULL;

--- a/packages/db/prisma/migrations/0006_computer_control_lease_expiry/migration.sql
+++ b/packages/db/prisma/migrations/0006_computer_control_lease_expiry/migration.sql
@@ -14,7 +14,3 @@ SET
         ELSE "controlHolder"
     END
 WHERE "controlHolder" = 'user';
-
-CREATE INDEX "computers_controlLeaseExpiresAt_id_idx"
-ON "computers"("controlLeaseExpiresAt", "id")
-WHERE "controlLeaseId" IS NOT NULL;

--- a/packages/db/prisma/migrations/0007_computer_control_lease_expiry_index/migration.sql
+++ b/packages/db/prisma/migrations/0007_computer_control_lease_expiry_index/migration.sql
@@ -1,0 +1,4 @@
+-- Build the reconciler index without blocking writes to active computers.
+CREATE INDEX CONCURRENTLY "computers_controlLeaseExpiresAt_id_idx"
+ON "computers"("controlLeaseExpiresAt", "id")
+WHERE "controlLeaseId" IS NOT NULL;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -476,6 +476,7 @@ model Computer {
   state        String   @default("stopped")
   controlHolder String  @default("none")
   controlLeaseId String?
+  controlLeaseExpiresAt DateTime?
   controlFence Int      @default(0)
   screenUrl    String?
   createdAt    DateTime @default(now())

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -1,7 +1,7 @@
 import type { RealtimeFanout } from "@rakazo/adapter-kit";
 import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "./client.js";
-import { followThreadEvents } from "./events.js";
+import { finalizeComputerControlRelease, followThreadEvents } from "./events.js";
 
 class TestFanout implements RealtimeFanout {
   subscriber: ((payload: string) => void) | undefined;
@@ -79,5 +79,61 @@ describe("followThreadEvents", () => {
     await expect(stream.next()).resolves.toMatchObject({ value: { seq: 0 }, done: false });
     abort.abort();
     await stream.return(undefined);
+  });
+});
+
+describe("finalizeComputerControlRelease", () => {
+  it("clears the matching lease and appends its release event in one transaction", async () => {
+    const fanout = new TestFanout();
+    const publish = vi.spyOn(fanout, "publish");
+    const tx = {
+      computer: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      bot: {
+        findUnique: vi.fn().mockResolvedValue({ thread: { id: "thread-1" } }),
+      },
+      thread: { update: vi.fn().mockResolvedValue({ nextEventSeq: 8 }) },
+      event: {
+        create: vi.fn().mockResolvedValue({
+          ...event(7),
+          type: "computer.takeover.released",
+          payload: { holder: "none", leaseId: "lease-1", reason: "expired" },
+        }),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      finalizeComputerControlRelease(
+        prisma,
+        {
+          workspaceId: "workspace-1",
+          botId: "bot-1",
+          leaseId: "lease-1",
+          holder: "none",
+          reason: "expired",
+        },
+        fanout,
+      ),
+    ).resolves.toBe(true);
+
+    expect(tx.computer.updateMany).toHaveBeenCalledWith({
+      where: { botId: "bot-1", controlLeaseId: "lease-1" },
+      data: {
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+      },
+    });
+    expect(tx.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "computer.takeover.released",
+          payload: { holder: "none", leaseId: "lease-1", reason: "expired" },
+        }),
+      }),
+    );
+    expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 7 }));
   });
 });

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -18,8 +18,17 @@ export interface AppendEventInput {
 
 export interface ThreadEvents {
   append(input: AppendEventInput): Promise<ProductEvent>;
+  finalizeComputerControlRelease(input: FinalizeComputerControlReleaseInput): Promise<boolean>;
   finalizeRun(input: FinalizeRunInput): Promise<boolean>;
   follow(threadId: string, cursor: number, signal?: AbortSignal): AsyncGenerator<ProductEvent>;
+}
+
+export interface FinalizeComputerControlReleaseInput {
+  workspaceId: string;
+  botId: string;
+  leaseId: string;
+  holder: "bot" | "none";
+  reason: "expired" | "released";
 }
 
 interface FinalizeRunBase {
@@ -43,10 +52,54 @@ export function createThreadEvents(
 ): ThreadEvents {
   return {
     append: (input) => appendEvent(prisma, input, realtime),
+    finalizeComputerControlRelease: (input) =>
+      finalizeComputerControlRelease(prisma, input, realtime),
     finalizeRun: (input) => finalizeRun(prisma, input, realtime),
     follow: (threadId, cursor, signal) =>
       followThreadEvents(prisma, threadId, cursor, realtime, signal, options.catchUpMs),
   };
+}
+
+export async function finalizeComputerControlRelease(
+  prisma: PrismaClient,
+  input: FinalizeComputerControlReleaseInput,
+  realtime?: RealtimeFanout,
+): Promise<boolean> {
+  const committed = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    const cleared = await tx.computer.updateMany({
+      where: { botId: input.botId, controlLeaseId: input.leaseId },
+      data: {
+        controlHolder: input.holder,
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+      },
+    });
+    if (cleared.count !== 1) return null;
+
+    const bot = await tx.bot.findUnique({
+      where: { id: input.botId },
+      select: { thread: { select: { id: true } } },
+    });
+    if (!bot?.thread) return { threadId: null, seq: null };
+    const event = await appendEventInTransaction(tx, {
+      workspaceId: input.workspaceId,
+      threadId: bot.thread.id,
+      botId: input.botId,
+      type: "computer.takeover.released",
+      payload: {
+        holder: input.holder,
+        leaseId: input.leaseId,
+        reason: input.reason,
+      },
+    });
+    return { threadId: event.threadId, seq: event.seq };
+  });
+
+  if (!committed) return false;
+  if (committed.threadId && committed.seq !== null) {
+    await notifyRealtime(realtime, committed.threadId, committed.seq);
+  }
+  return true;
 }
 
 export async function appendEvent(

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -199,6 +199,92 @@ describeJourneys("required product journeys", () => {
     );
     expect(JSON.stringify(done.messages).toLowerCase()).toMatch(/signed in|session/);
     expect(done.run?.status ?? "completed").not.toBe("waiting_takeover");
+
+    const releaseEvents = await prisma.event.count({
+      where: { botId: bot.id, type: "computer.takeover.released" },
+    });
+    await rpc(app, cookie, "computer/release", { botId: bot.id });
+    expect(
+      await prisma.event.count({
+        where: { botId: bot.id, type: "computer.takeover.released" },
+      }),
+    ).toBe(releaseEvents);
+  });
+
+  it("4b: an expired takeover denies input and reconciles API and database state", async () => {
+    const previousTakeoverTtl = process.env.COMPUTER_TAKEOVER_TTL_MS;
+    process.env.COMPUTER_TAKEOVER_TTL_MS = "1000";
+    try {
+      const cookie = await signup(app, `takeover-expiry-j-${stamp}@rakazo.test`, "Expiry");
+      const bot = await rpc<Bot>(app, cookie, "bots/create", {
+        name: "Chief",
+        title: "",
+        description: "",
+        instructions: "",
+        notifyOnFinish: true,
+      });
+      await rpc(app, cookie, "threads/send", {
+        botId: bot.id,
+        text: "install the gsc cli and sign in",
+      });
+      await waitFor(app, cookie, bot.id, (snap) => snap.run?.status === "waiting_takeover");
+      await rpc(app, cookie, "computer/boot", { botId: bot.id });
+      const lease = await rpc<{ leaseId: string; expiresAt: string }>(
+        app,
+        cookie,
+        "computer/takeover",
+        { botId: bot.id },
+      );
+      expect(new Date(lease.expiresAt).getTime() - Date.now()).toBeLessThanOrEqual(1000);
+      expect(
+        (await rpc<{ url: string | null }>(app, cookie, "computer/screenUrl", { botId: bot.id }))
+          .url,
+      ).toContain("view_only=false");
+      await rpc(app, cookie, "computer/input", {
+        botId: bot.id,
+        kind: "key",
+        payload: { key: "a" },
+      });
+
+      await waitForDatabase(async () => {
+        const computer = await prisma.computer.findUniqueOrThrow({ where: { botId: bot.id } });
+        return computer.controlLeaseId === null && computer.controlHolder === "none";
+      });
+
+      expect(
+        (await rpc<{ controlHolder: string }>(app, cookie, "computer/status", { botId: bot.id }))
+          .controlHolder,
+      ).toBe("none");
+      expect(
+        (await rpc<{ url: string | null }>(app, cookie, "computer/screenUrl", { botId: bot.id }))
+          .url,
+      ).toContain("view_only=true");
+      expect(
+        (
+          await raw(app, cookie, "computer/input", {
+            botId: bot.id,
+            kind: "key",
+            payload: { key: "b" },
+          })
+        ).status,
+      ).toBeGreaterThanOrEqual(400);
+      expect((await rpc<Snap>(app, cookie, "threads/get", { botId: bot.id })).run?.status).toBe(
+        "waiting_takeover",
+      );
+
+      await rpc(app, cookie, "computer/takeover", { botId: bot.id });
+      await rpc(app, cookie, "computer/release", { botId: bot.id });
+      const done = await waitFor(
+        app,
+        cookie,
+        bot.id,
+        (snap) => !snap.run || ["completed", "failed", "cancelled"].includes(snap.run.status),
+      );
+      expect(done.run?.status ?? "completed").not.toBe("waiting_takeover");
+    } finally {
+      if (previousTakeoverTtl === undefined) delete process.env.COMPUTER_TAKEOVER_TTL_MS;
+      else process.env.COMPUTER_TAKEOVER_TTL_MS = previousTakeoverTtl;
+    }
   });
 
   it("5: a routine wakes the bot and posts into the existing thread", async () => {
@@ -811,4 +897,13 @@ async function waitFor(app: App, cookie: string, botId: string, pred: (snap: Sna
     await new Promise((r) => setTimeout(r, 100));
   }
   throw new Error(`timeout waiting for thread: ${JSON.stringify(last)}`);
+}
+
+async function waitForDatabase(pred: () => Promise<boolean>) {
+  const start = Date.now();
+  while (Date.now() - start < 10_000) {
+    if (await pred()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("timeout waiting for database state");
 }


### PR DESCRIPTION
## Summary
- persist takeover lease deadlines and enforce them for input and interactive screen URLs
- expire leases through a durable background job, revoke Docker/E2B control streams deny-first, and recover missing jobs with a bounded indexed reconciliation scan
- reconcile UI/control-holder state and allow abandoned waiting_takeover computers to become idle

## Validation
- full offline suite: 255 passed, 40 skipped
- fresh PostgreSQL migration plus required product journeys: 18 passed
- focused lease/reconciler/UI contracts: 35 passed
- all TypeScript check targets passed directly in the isolated worktree
- real Docker short-TTL acceptance: a reachable 6081 interactive stream was revoked automatically after a 1-second lease with no UI release

## Operations
Migration 0006 is additive, backfills existing user-held leases as immediately expired, and adds a partial deadline index. Deploy the migration before the new API/worker and roll API and worker together so the new job name is understood; the reconciler will revoke legacy interactive streams after deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added time-limited computer-control takeovers with automatic expiration.
  - Users can reacquire control after a lease expires or is released.
  - Computers switch to view-only mode when control is unavailable.
  - Expired control is automatically cleaned up, with idle computers eligible for suspension.

- **Bug Fixes**
  - Prevented stale or replaced leases from retaining computer control.
  - Improved handling of concurrent takeover requests and expired control input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->