### PR TITLE
Fix the testkit package-local test command

### DIFF
--- a/packages/testkit/src/pin-test-env.test.ts
+++ b/packages/testkit/src/pin-test-env.test.ts
@@ -25,7 +25,9 @@ describeFast("pnpm test emulator pin", () => {
   );
 
   it("exposes one test command family and no leftover verify/e2e aliases", () => {
-    const pkg = JSON.parse(readFileSync(path.resolve("package.json"), "utf8")) as {
+    const pkg = JSON.parse(
+      readFileSync(path.resolve(import.meta.dirname, "../../../package.json"), "utf8"),
+    ) as {
       scripts: Record<string, string>;
     };
     expect(pkg.scripts.test).toBe("vitest run");


### PR DESCRIPTION
## Summary
- resolve the repository package manifest relative to the test file
- keep the test-command contract check independent of the invoking working directory

## Verification
- `pnpm --filter @rakazo/db generate`
- `pnpm --filter @rakazo/testkit check`
- `pnpm --filter @rakazo/testkit test` (6 passed, 32 skipped)
- `pnpm test` (244 passed, 38 skipped)
- `biome check packages/testkit/src/pin-test-env.test.ts`