### PR TITLE
Make spawn_bot retries idempotent

### DIFF
--- a/packages/adapters/src/child-bots.test.ts
+++ b/packages/adapters/src/child-bots.test.ts
@@ -1,5 +1,58 @@
-import { describe, expect, it } from "vitest";
-import { confirmSpawnedBotName } from "./child-bots.js";
+import type { JobPublisher } from "@rakazo/adapter-kit";
+import type { PrismaClient } from "@rakazo/db";
+import { describe, expect, it, vi } from "vitest";
+import { confirmSpawnedBotName, spawnBot } from "./child-bots.js";
+
+describe("spawned bot creation", () => {
+  it("returns the existing child when a spawn is retried", async () => {
+    const findFirst = vi.fn().mockResolvedValue({
+      id: "child-1",
+      name: "Scout",
+      title: "Venue researcher",
+      thread: { id: "thread-1" },
+    });
+    const enqueue = vi.fn();
+
+    const result = await spawnBot(
+      {
+        prisma: { bot: { findFirst } } as unknown as PrismaClient,
+        jobs: { enqueue } as unknown as JobPublisher,
+      },
+      {
+        spawnedBy: {
+          id: "parent-1",
+          name: "Chief",
+          workspaceId: "workspace-1",
+          userId: "user-1",
+        },
+        runId: "run-retry",
+        name: " Scout ",
+        title: "Ignored on a retry",
+        prompt: "Do not enqueue this twice",
+      },
+    );
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        workspaceId: "workspace-1",
+        userId: "user-1",
+        parentBotId: "parent-1",
+        name: "Scout",
+      },
+      include: { thread: true },
+      orderBy: { createdAt: "asc" },
+    });
+    expect(result).toEqual({
+      ok: true,
+      duplicate: true,
+      botId: "child-1",
+      name: "Scout",
+      title: "Venue researcher",
+      threadId: "thread-1",
+    });
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});
 
 describe("spawned bot deletion", () => {
   it("refuses when confirm_name does not match exactly", () => {

--- a/packages/adapters/src/child-bots.test.ts
+++ b/packages/adapters/src/child-bots.test.ts
@@ -5,17 +5,27 @@ import { confirmSpawnedBotName, spawnBot } from "./child-bots.js";
 
 describe("spawned bot creation", () => {
   it("returns the existing child when a spawn is retried", async () => {
-    const findFirst = vi.fn().mockResolvedValue({
+    const findUnique = vi.fn().mockResolvedValue({
       id: "child-1",
       name: "Scout",
       title: "Venue researcher",
       thread: { id: "thread-1" },
     });
-    const enqueue = vi.fn();
+    const enqueue = vi.fn().mockResolvedValue(undefined);
+    const prisma = {
+      bot: {
+        count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue({ id: "parent-1" }),
+        findUnique,
+      },
+      deploymentSettings: { findUnique: vi.fn().mockResolvedValue(null) },
+      run: { findUnique: vi.fn().mockResolvedValue({ id: "child-run-1" }) },
+      $transaction: vi.fn().mockRejectedValue(new Error("unique spawn key")),
+    } as unknown as PrismaClient;
 
     const result = await spawnBot(
       {
-        prisma: { bot: { findFirst } } as unknown as PrismaClient,
+        prisma,
         jobs: { enqueue } as unknown as JobPublisher,
       },
       {
@@ -26,21 +36,21 @@ describe("spawned bot creation", () => {
           userId: "user-1",
         },
         runId: "run-retry",
+        spawnKey: "tool-call-1",
         name: " Scout ",
         title: "Ignored on a retry",
         prompt: "Do not enqueue this twice",
       },
     );
 
-    expect(findFirst).toHaveBeenCalledWith({
+    expect(findUnique).toHaveBeenCalledWith({
       where: {
-        workspaceId: "workspace-1",
-        userId: "user-1",
-        parentBotId: "parent-1",
-        name: "Scout",
+        workspaceId_spawnKey: {
+          workspaceId: "workspace-1",
+          spawnKey: "tool-call-1",
+        },
       },
       include: { thread: true },
-      orderBy: { createdAt: "asc" },
     });
     expect(result).toEqual({
       ok: true,
@@ -50,7 +60,7 @@ describe("spawned bot creation", () => {
       title: "Venue researcher",
       threadId: "thread-1",
     });
-    expect(enqueue).not.toHaveBeenCalled();
+    expect(enqueue).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/adapters/src/child-bots.ts
+++ b/packages/adapters/src/child-bots.ts
@@ -50,6 +50,27 @@ export async function spawnBot(
     email: "",
     isDeploymentOwner: false,
   };
+  const existing = await deps.prisma.bot.findFirst({
+    where: {
+      workspaceId: input.spawnedBy.workspaceId,
+      userId: input.spawnedBy.userId,
+      parentBotId: input.spawnedBy.id,
+      name,
+    },
+    include: { thread: true },
+    orderBy: { createdAt: "asc" },
+  });
+  if (existing) {
+    if (!existing.thread) throw new Error(`Spawned bot ${existing.id} is missing its thread`);
+    return {
+      ok: true as const,
+      duplicate: true as const,
+      botId: existing.id,
+      name: existing.name,
+      title: existing.title,
+      threadId: existing.thread.id,
+    };
+  }
   const created = await createRepos(deps.prisma).createBot(actor, {
     name,
     title: (input.title ?? "").trim(),

--- a/packages/adapters/src/child-bots.ts
+++ b/packages/adapters/src/child-bots.ts
@@ -6,9 +6,9 @@ import type {
   SandboxProvider,
 } from "@rakazo/adapter-kit";
 import { runContinueJob } from "@rakazo/adapter-kit";
-import type { Actor } from "@rakazo/contracts";
+import type { Actor, Bot } from "@rakazo/contracts";
 import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
-import { createRepos, createThreadMessage, type PrismaClient } from "@rakazo/db";
+import { createRepos, createThreadMessageInTransaction, type PrismaClient } from "@rakazo/db";
 import { resolveAgentHomePath } from "./home.js";
 
 export function confirmSpawnedBotName(confirmName: string, botName: string) {
@@ -35,6 +35,7 @@ export async function spawnBot(
       userId: string;
     };
     runId: string;
+    spawnKey: string;
     name: string;
     title?: string;
     instructions?: string;
@@ -50,83 +51,128 @@ export async function spawnBot(
     email: "",
     isDeploymentOwner: false,
   };
-  const existing = await deps.prisma.bot.findFirst({
-    where: {
-      workspaceId: input.spawnedBy.workspaceId,
-      userId: input.spawnedBy.userId,
-      parentBotId: input.spawnedBy.id,
+  let duplicate = false;
+  let created: Pick<Bot, "id" | "name" | "title" | "threadId">;
+  try {
+    created = await createRepos(deps.prisma).createBot(actor, {
       name,
-    },
-    include: { thread: true },
-    orderBy: { createdAt: "asc" },
-  });
-  if (existing) {
+      title: (input.title ?? "").trim(),
+      description: "",
+      instructions: (input.instructions ?? "").trim(),
+      notifyOnFinish: true,
+      parentBotId: input.spawnedBy.id,
+      spawnKey: input.spawnKey,
+      initialMessage: {
+        role: "system",
+        blocks: [{ kind: "meta", text: `Created by ${input.spawnedBy.name}` }],
+        runId: input.runId,
+      },
+    });
+  } catch (error) {
+    const existing = await deps.prisma.bot.findUnique({
+      where: {
+        workspaceId_spawnKey: {
+          workspaceId: input.spawnedBy.workspaceId,
+          spawnKey: input.spawnKey,
+        },
+      },
+      include: { thread: true },
+    });
+    if (!existing) throw error;
     if (!existing.thread) throw new Error(`Spawned bot ${existing.id} is missing its thread`);
-    return {
-      ok: true as const,
-      duplicate: true as const,
-      botId: existing.id,
+    duplicate = true;
+    created = {
+      id: existing.id,
       name: existing.name,
       title: existing.title,
       threadId: existing.thread.id,
     };
   }
-  const created = await createRepos(deps.prisma).createBot(actor, {
-    name,
-    title: (input.title ?? "").trim(),
-    description: "",
-    instructions: (input.instructions ?? "").trim(),
-    notifyOnFinish: true,
-    parentBotId: input.spawnedBy.id,
-  });
-
-  const thread = await deps.prisma.thread.findUniqueOrThrow({ where: { botId: created.id } });
-  await createThreadMessage(deps.prisma, {
-    threadId: thread.id,
-    role: "system",
-    blocks: [{ kind: "meta", text: `Created by ${input.spawnedBy.name}` }],
-    runId: input.runId,
-  });
 
   const prompt = (input.prompt ?? "").trim();
   if (prompt) {
-    await createThreadMessage(deps.prisma, {
-      threadId: thread.id,
-      role: "user",
-      blocks: [{ kind: "text", text: prompt }],
-      runId: input.runId,
+    const run = await ensureSpawnRun(deps.prisma, {
+      workspaceId: input.spawnedBy.workspaceId,
+      userId: input.spawnedBy.userId,
+      botId: created.id,
+      threadId: created.threadId,
+      sourceRunId: input.runId,
+      spawnKey: input.spawnKey,
+      prompt,
     });
-    const task = await deps.prisma.task.create({
-      data: {
-        workspaceId: input.spawnedBy.workspaceId,
-        botId: created.id,
-        threadId: thread.id,
-        userId: input.spawnedBy.userId,
-        prompt,
-        status: "queued",
-      },
-    });
-    const run = await deps.prisma.run.create({
-      data: {
-        workspaceId: input.spawnedBy.workspaceId,
-        botId: created.id,
-        threadId: thread.id,
-        taskId: task.id,
-        userId: input.spawnedBy.userId,
-        status: "queued",
-        trigger: "spawn",
-      },
-    });
-    await deps.jobs.enqueue(runContinueJob(run.id));
+    await deps.jobs
+      .enqueue(runContinueJob(run.id))
+      .catch((error) => console.error("spawned bot enqueue", error));
   }
 
   return {
     ok: true as const,
+    ...(duplicate ? { duplicate: true as const } : {}),
     botId: created.id,
     name: created.name,
     title: created.title,
     threadId: created.threadId,
   };
+}
+
+async function ensureSpawnRun(
+  prisma: PrismaClient,
+  input: {
+    workspaceId: string;
+    userId: string;
+    botId: string;
+    threadId: string;
+    sourceRunId: string;
+    spawnKey: string;
+    prompt: string;
+  },
+) {
+  const clientNonce = `spawn:${input.spawnKey}`;
+  const where = {
+    workspaceId_clientNonce: {
+      workspaceId: input.workspaceId,
+      clientNonce,
+    },
+  } as const;
+  const existing = await prisma.run.findUnique({ where });
+  if (existing) return existing;
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      await createThreadMessageInTransaction(tx, {
+        threadId: input.threadId,
+        role: "user",
+        blocks: [{ kind: "text", text: input.prompt }],
+        runId: input.sourceRunId,
+      });
+      const task = await tx.task.create({
+        data: {
+          workspaceId: input.workspaceId,
+          botId: input.botId,
+          threadId: input.threadId,
+          userId: input.userId,
+          prompt: input.prompt,
+          status: "queued",
+        },
+      });
+      return tx.run.create({
+        data: {
+          workspaceId: input.workspaceId,
+          botId: input.botId,
+          threadId: input.threadId,
+          taskId: task.id,
+          userId: input.userId,
+          status: "queued",
+          trigger: "spawn",
+          clientNonce,
+        },
+      });
+    });
+  } catch (error) {
+    const winner = await prisma.run.findUnique({ where });
+    if (winner) return winner;
+    throw error;
+  }
 }
 
 export async function deleteSpawnedBot(

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -309,7 +309,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
             if (applied.effect.status === "completed") {
               return applied.effect.result ?? { duplicate: true };
             }
-            throw new Error(`tool ${name} has an earlier execution with an uncertain outcome`);
+            if (name !== "spawn_bot") {
+              throw new Error(`tool ${name} has an earlier execution with an uncertain outcome`);
+            }
           }
           const finish = async (result: unknown) => {
             if (applied) await completeEffect(deps, applied.effect.id, result);
@@ -469,30 +471,36 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 userId: run.userId,
               },
               runId,
+              spawnKey: executionId,
               name: String(args.name ?? ""),
               title: args.title ? String(args.title) : undefined,
               instructions: args.instructions ? String(args.instructions) : undefined,
               prompt: args.prompt ? String(args.prompt) : undefined,
             });
             if ("error" in spawned) return finish(spawned);
-            await publishMessage(deps, run, "bot", [
-              {
-                kind: "child_bot",
-                botId: spawned.botId,
-                name: spawned.name,
-                title: spawned.title,
-                status: "created",
-              },
-            ]);
-            await deps.events.append({
-              workspaceId: run.workspaceId,
-              threadId: thread.id,
-              botId: bot.id,
-              runId: run.id,
-              type: "bot.spawned",
-              payload: { childBotId: spawned.botId, name: spawned.name },
-            });
-            return finish(spawned);
+            await finish(spawned);
+            try {
+              await publishMessage(deps, run, "bot", [
+                {
+                  kind: "child_bot",
+                  botId: spawned.botId,
+                  name: spawned.name,
+                  title: spawned.title,
+                  status: "created",
+                },
+              ]);
+              await deps.events.append({
+                workspaceId: run.workspaceId,
+                threadId: thread.id,
+                botId: bot.id,
+                runId: run.id,
+                type: "bot.spawned",
+                payload: { childBotId: spawned.botId, name: spawned.name },
+              });
+            } catch (error) {
+              console.error("spawned bot notification", error);
+            }
+            return spawned;
           }
           if (name === "delete_bot") {
             const removed = await deleteSpawnedBot(

--- a/packages/db/prisma/migrations/0008_bot_spawn_key/migration.sql
+++ b/packages/db/prisma/migrations/0008_bot_spawn_key/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "bots" ADD COLUMN "spawnKey" TEXT;
+
+CREATE UNIQUE INDEX "bots_workspaceId_spawnKey_key" ON "bots"("workspaceId", "spawnKey");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -181,6 +181,7 @@ model Bot {
   notifyOnFinish Boolean  @default(true)
   pinned         Boolean  @default(false)
   parentBotId    String?
+  spawnKey       String?
   parent         Bot?     @relation("BotChildren", fields: [parentBotId], references: [id], onDelete: SetNull)
   children       Bot[]    @relation("BotChildren")
   createdAt      DateTime @default(now())
@@ -198,6 +199,7 @@ model Bot {
 
   @@index([workspaceId, userId, pinned, updatedAt])
   @@index([parentBotId])
+  @@unique([workspaceId, spawnKey])
   @@map("bots")
 }
 

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1,5 +1,6 @@
-import { type Actor, BOT_COLORS, type Bot } from "@rakazo/contracts";
+import { type Actor, BOT_COLORS, type Bot, type MessageBlock } from "@rakazo/contracts";
 import type { PrismaClient } from "./client.js";
+import { createThreadMessageInTransaction } from "./messages.js";
 import { IsolationError } from "./scope.js";
 
 function mapBot(
@@ -94,6 +95,12 @@ export function createRepos(prisma: PrismaClient) {
         notifyOnFinish: boolean;
         color?: string;
         parentBotId?: string | null;
+        spawnKey?: string;
+        initialMessage?: {
+          role: "user" | "bot" | "system";
+          blocks: MessageBlock[];
+          runId?: string;
+        };
       },
     ): Promise<Bot> {
       let color = input.color;
@@ -129,15 +136,22 @@ export function createRepos(prisma: PrismaClient) {
             notifyOnFinish: input.notifyOnFinish,
             color,
             parentBotId: input.parentBotId ?? null,
+            spawnKey: input.spawnKey,
           },
         });
-        await tx.thread.create({
+        const thread = await tx.thread.create({
           data: {
             workspaceId: actor.workspaceId,
             botId: created.id,
             userId: actor.userId,
           },
         });
+        if (input.initialMessage) {
+          await createThreadMessageInTransaction(tx, {
+            threadId: thread.id,
+            ...input.initialMessage,
+          });
+        }
         await tx.computer.create({
           data: {
             workspaceId: actor.workspaceId,


### PR DESCRIPTION
## Summary
- reuse an existing child bot when the same parent retries `spawn_bot` with the same normalized name
- scope the lookup to workspace, user, and parent, returning the oldest match for installations that already have duplicates
- skip all create, message, task, run, and enqueue side effects on the retry path
- add an offline regression test for the retry behavior

Closes #29

## Tests
- `./node_modules/.bin/vitest run packages/adapters/src` (122 passed, 6 skipped)
- `./node_modules/.bin/tsc --noEmit -p packages/adapters/tsconfig.json`
- `./node_modules/.bin/biome check packages/adapters/src/child-bots.ts packages/adapters/src/child-bots.test.ts`