### PR TITLE
Terminate timed-out sandbox commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ AGENT_RUNTIME=pi
 WAKEUP_DRIVER=graphile
 # Pause E2B (or stop Docker) computers after this many idle ms. Minimum 30000.
 SANDBOX_IDLE_MS=600000
+SANDBOX_COMMAND_TIMEOUT_MS=300000
 OPENROUTER_API_KEY=
 PI_DEFAULT_PROVIDER=openrouter
 PI_DEFAULT_MODEL=deepseek/deepseek-v4-flash-0731

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -39,6 +39,7 @@ SANDBOX_PROVIDER=docker   # or e2b. Keep fake only for pnpm test.
 AGENT_RUNTIME=pi          # Keep scripted only for pnpm test.
 WAKEUP_DRIVER=graphile
 SANDBOX_IDLE_MS=600000    # pause the bot computer after 10 minutes idle
+SANDBOX_COMMAND_TIMEOUT_MS=300000 # stop a shell command after 5 minutes
 E2B_API_KEY=              # when SANDBOX_PROVIDER=e2b
 ```
 

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   interactiveScreenCommand,
   normalizeWorkspaceRelative,
   parseObservation,
+  sandboxTimeoutCommand,
 } from "./supervisor-logic.js";
 
 const token = resolveSupervisorToken(process.env);
@@ -96,6 +97,17 @@ describe("sandbox supervisor input containment", () => {
     expect(containerActionStep({ kind: "scroll", direction: "up", amount: 99 })).toEqual({
       argv: ["env", "DISPLAY=:1", "xdotool", "click", "--repeat", "20", "4"],
     });
+  });
+
+  it("wraps sandbox commands in a process-tree timeout", () => {
+    expect(sandboxTimeoutCommand(["bash", "-lc", "sleep 10"], 2_500)).toEqual([
+      "timeout",
+      "--kill-after=1s",
+      "2.5s",
+      "bash",
+      "-lc",
+      "sleep 10",
+    ]);
   });
 
   it("keeps the viewer read-only and uses a separate process for takeover control", () => {

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -8,6 +8,7 @@ import {
   interactiveScreenCommand,
   normalizeWorkspaceRelative,
   parseObservation,
+  sandboxCommandTimedOut,
   sandboxTimeoutCommand,
 } from "./supervisor-logic.js";
 
@@ -100,14 +101,23 @@ describe("sandbox supervisor input containment", () => {
   });
 
   it("wraps sandbox commands in a process-tree timeout", () => {
-    expect(sandboxTimeoutCommand(["bash", "-lc", "sleep 10"], 2_500)).toEqual([
-      "timeout",
-      "--kill-after=1s",
-      "2.5s",
-      "bash",
-      "-lc",
-      "sleep 10",
-    ]);
+    expect(sandboxTimeoutCommand(["bash", "-lc", "sleep 10"], 2_500, "/tmp/completed-124")).toEqual(
+      [
+        "timeout",
+        "--kill-after=1s",
+        "2.5s",
+        "sh",
+        "-c",
+        '"$@"; status=$?; if [ "$status" -eq 124 ]; then : > "$0"; fi; exit "$status"',
+        "/tmp/completed-124",
+        "bash",
+        "-lc",
+        "sleep 10",
+      ],
+    );
+    expect(sandboxCommandTimedOut(124, false)).toBe(true);
+    expect(sandboxCommandTimedOut(124, true)).toBe(false);
+    expect(sandboxCommandTimedOut(1, false)).toBe(false);
   });
 
   it("keeps the viewer read-only and uses a separate process for takeover control", () => {

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
@@ -23,6 +24,7 @@ import {
   interactiveScreenCommand,
   normalizeWorkspaceRelative,
   parseObservation,
+  sandboxCommandTimedOut,
   sandboxTimeoutCommand,
   toSandboxInput,
   workspaceTarget,
@@ -591,7 +593,13 @@ async function runContainerCommand(
   options: { workingDir?: string; env?: string[]; timeoutMs?: number } = {},
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const timeoutMs = options.timeoutMs;
-  const command = timeoutMs ? sandboxTimeoutCommand(argv, timeoutMs) : argv;
+  const completionMarker = timeoutMs
+    ? `/tmp/rakazo-command-${randomUUID()}.completed-124`
+    : undefined;
+  const command =
+    completionMarker && timeoutMs !== undefined
+      ? sandboxTimeoutCommand(argv, timeoutMs, completionMarker)
+      : argv;
   const exec = await container.exec({
     Cmd: command,
     AttachStdout: true,
@@ -608,11 +616,26 @@ async function runContainerCommand(
   });
   const inspect = await exec.inspect();
   const code = inspect.ExitCode ?? 0;
+  const completedWithExit124 =
+    code === 124 && completionMarker
+      ? await consumeCompletionMarker(container, completionMarker)
+      : false;
+  const timedOut = sandboxCommandTimedOut(code, completedWithExit124);
   return {
     stdout: stripDockerStream(Buffer.concat(chunks)),
-    stderr: timeoutMs && code === 124 ? `command timed out after ${timeoutMs} ms\n` : "",
+    stderr: timedOut ? `command timed out after ${timeoutMs} ms\n` : "",
     code,
   };
+}
+
+async function consumeCompletionMarker(container: Docker.Container, marker: string) {
+  const result = await runContainerCommand(container, [
+    "sh",
+    "-c",
+    'if [ -f "$0" ]; then rm -f "$0"; exit 0; fi; exit 1',
+    marker,
+  ]);
+  return result.code === 0;
 }
 
 async function applyContainerActions(

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { loadEnvFile } from "node:process";
 import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
-import { resolveSupervisorToken } from "@rakazo/core";
+import { boundedSandboxCommandTimeoutMs, resolveSupervisorToken } from "@rakazo/core";
 import Docker from "dockerode";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -23,6 +23,7 @@ import {
   interactiveScreenCommand,
   normalizeWorkspaceRelative,
   parseObservation,
+  sandboxTimeoutCommand,
   toSandboxInput,
   workspaceTarget,
 } from "./supervisor-logic.js";
@@ -141,6 +142,7 @@ app.post("/computers/:id/exec", async (c) => {
       argv: z.array(z.string()),
       cwd: z.string().optional(),
       env: z.record(z.string(), z.string()).optional(),
+      timeoutMs: z.number().int().positive().optional(),
     })
     .parse(await c.req.json());
   try {
@@ -162,6 +164,7 @@ app.post("/computers/:id/exec", async (c) => {
           "PIP_USER=1",
           ...Object.entries(body.env ?? {}).map(([k, v]) => `${k}=${v}`),
         ],
+        timeoutMs: boundedSandboxCommandTimeoutMs(body.timeoutMs),
       },
     );
     return c.json(result);
@@ -585,10 +588,12 @@ function stripDockerStream(buffer: Buffer) {
 async function runContainerCommand(
   container: Docker.Container,
   argv: string[],
-  options: { workingDir?: string; env?: string[] } = {},
+  options: { workingDir?: string; env?: string[]; timeoutMs?: number } = {},
 ): Promise<{ stdout: string; stderr: string; code: number }> {
+  const timeoutMs = options.timeoutMs;
+  const command = timeoutMs ? sandboxTimeoutCommand(argv, timeoutMs) : argv;
   const exec = await container.exec({
-    Cmd: argv,
+    Cmd: command,
     AttachStdout: true,
     AttachStderr: true,
     WorkingDir: options.workingDir ?? "/home/rakazo",
@@ -602,10 +607,11 @@ async function runContainerCommand(
     stream.on("error", reject);
   });
   const inspect = await exec.inspect();
+  const code = inspect.ExitCode ?? 0;
   return {
     stdout: stripDockerStream(Buffer.concat(chunks)),
-    stderr: "",
-    code: inspect.ExitCode ?? 0,
+    stderr: timeoutMs && code === 124 ? `command timed out after ${timeoutMs} ms\n` : "",
+    code,
   };
 }
 

--- a/infra/sandboxes/supervisor/src/supervisor-logic.ts
+++ b/infra/sandboxes/supervisor/src/supervisor-logic.ts
@@ -106,6 +106,10 @@ export function workspaceTarget(relative: string) {
   return relative ? path.posix.join("/home/rakazo", relative) : "/home/rakazo";
 }
 
+export function sandboxTimeoutCommand(argv: string[], timeoutMs: number) {
+  return ["timeout", "--kill-after=1s", `${timeoutMs / 1_000}s`, ...argv];
+}
+
 export function interactiveScreenCommand(interactive: boolean, controlToken?: string) {
   const tokenFile = "/tmp/rakazo/control-token";
   const stopProcesses =

--- a/infra/sandboxes/supervisor/src/supervisor-logic.ts
+++ b/infra/sandboxes/supervisor/src/supervisor-logic.ts
@@ -106,8 +106,21 @@ export function workspaceTarget(relative: string) {
   return relative ? path.posix.join("/home/rakazo", relative) : "/home/rakazo";
 }
 
-export function sandboxTimeoutCommand(argv: string[], timeoutMs: number) {
-  return ["timeout", "--kill-after=1s", `${timeoutMs / 1_000}s`, ...argv];
+export function sandboxTimeoutCommand(argv: string[], timeoutMs: number, completionMarker: string) {
+  return [
+    "timeout",
+    "--kill-after=1s",
+    `${timeoutMs / 1_000}s`,
+    "sh",
+    "-c",
+    '"$@"; status=$?; if [ "$status" -eq 124 ]; then : > "$0"; fi; exit "$status"',
+    completionMarker,
+    ...argv,
+  ];
+}
+
+export function sandboxCommandTimedOut(exitCode: number, completedWithExit124: boolean) {
+  return exitCode === 124 && !completedWithExit124;
 }
 
 export function interactiveScreenCommand(interactive: boolean, controlToken?: string) {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -51,6 +51,8 @@ export interface CommandRequest {
   cwd?: string;
   env?: Record<string, string>;
   pty?: boolean;
+  /** Maximum wall-clock runtime before the command and its descendants are terminated. */
+  timeoutMs?: number;
 }
 
 export type ProcessEvent =

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -16,6 +16,7 @@ import type {
   ScreenRequest,
   ScreenSession,
 } from "@rakazo/adapter-kit";
+import { boundedSandboxCommandTimeoutMs } from "@rakazo/core";
 import {
   applyPlaceholderAction,
   boundedComputerActions,
@@ -87,7 +88,7 @@ export class DesktopSandboxProvider implements SandboxProvider {
   async *execute(
     computer: ComputerRef,
     request: CommandRequest,
-    _context: AdapterContext,
+    context: AdapterContext,
   ): AsyncIterable<ProcessEvent> {
     const box = this.boxFor(computer);
     if (!box) {
@@ -103,7 +104,12 @@ export class DesktopSandboxProvider implements SandboxProvider {
     }
     await mkdir(cwd, { recursive: true });
     const argv = request.argv.length ? request.argv : ["echo", "ready"];
-    const result = await runCommand(argv, cwd);
+    const result = await runCommand(
+      argv,
+      cwd,
+      boundedSandboxCommandTimeoutMs(request.timeoutMs),
+      context.signal,
+    );
     if (result.stdout) yield { type: "stdout", data: result.stdout };
     if (result.stderr) yield { type: "stderr", data: result.stderr };
     yield { type: "exit", code: result.code };
@@ -320,11 +326,38 @@ function allowedPath(target: string, roots: string[]) {
 function runCommand(
   argv: string[],
   cwd: string,
+  timeoutMs: number,
+  signal: AbortSignal,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   return new Promise((resolve) => {
-    const child = spawn(argv[0]!, argv.slice(1), { cwd, env: process.env });
+    const child = spawn(argv[0]!, argv.slice(1), {
+      cwd,
+      env: process.env,
+      detached: process.platform !== "win32",
+    });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    const finish = (result: { stdout: string; stderr: string; code: number }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", abort);
+      resolve(result);
+    };
+    const terminate = (message: string, code: number) => {
+      killProcessTree(child.pid);
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      finish({ stdout, stderr: appendLine(stderr, message), code });
+    };
+    const abort = () => terminate("command aborted", 130);
+    const timeout = setTimeout(
+      () => terminate(`command timed out after ${timeoutMs} ms`, 124),
+      timeoutMs,
+    );
+    timeout.unref?.();
+    signal.addEventListener("abort", abort, { once: true });
     child.stdout?.on("data", (chunk: Buffer) => {
       stdout += chunk.toString("utf8");
     });
@@ -333,13 +366,36 @@ function runCommand(
     });
     child.on("error", (error) => {
       if (argv[0] === "echo") {
-        resolve({ stdout: `${argv.slice(1).join(" ")}\n`, stderr: "", code: 0 });
+        finish({ stdout: `${argv.slice(1).join(" ")}\n`, stderr: "", code: 0 });
         return;
       }
-      resolve({ stdout: "", stderr: error.message, code: 1 });
+      finish({ stdout: "", stderr: error.message, code: 1 });
     });
     child.on("close", (code) => {
-      resolve({ stdout, stderr, code: code ?? 0 });
+      finish({ stdout, stderr, code: code ?? 0 });
     });
+    if (signal.aborted) abort();
   });
+}
+
+function killProcessTree(pid: number | undefined) {
+  if (!pid) return;
+  if (process.platform === "win32") {
+    const killer = spawn("taskkill", ["/pid", String(pid), "/t", "/f"], { stdio: "ignore" });
+    killer.unref();
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // The process exited between the timeout and termination attempt.
+    }
+  }
+}
+
+function appendLine(existing: string, message: string) {
+  return `${existing}${existing && !existing.endsWith("\n") ? "\n" : ""}${message}\n`;
 }

--- a/packages/adapters/src/docker-sandbox.test.ts
+++ b/packages/adapters/src/docker-sandbox.test.ts
@@ -1,0 +1,47 @@
+import type { ProcessEvent } from "@rakazo/adapter-kit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DockerSandboxProvider } from "./docker-sandbox.js";
+
+const context = {
+  operationId: "docker-test",
+  traceId: "docker-test",
+  workspaceId: "workspace",
+  userId: "user",
+  signal: new AbortController().signal,
+};
+
+describe("Docker sandbox command timeout", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("sends the bounded timeout to the supervisor and preserves its honest result", async () => {
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      Response.json({
+        stdout: "partial output\n",
+        stderr: "command timed out after 75 ms\n",
+        code: 124,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new DockerSandboxProvider("http://supervisor.test", "test-token");
+    const events: ProcessEvent[] = [];
+
+    for await (const event of provider.execute(
+      { id: "computer", botId: "bot", kind: "docker", providerRef: "computer" },
+      { argv: ["sleep", "10"], timeoutMs: 75 },
+      context,
+    )) {
+      events.push(event);
+    }
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+      argv: ["sleep", "10"],
+      cwd: "/home/rakazo",
+      timeoutMs: 75,
+    });
+    expect(events).toEqual([
+      { type: "stdout", data: "partial output\n" },
+      { type: "stderr", data: "command timed out after 75 ms\n" },
+      { type: "exit", code: 124 },
+    ]);
+  });
+});

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -14,7 +14,7 @@ import type {
   ScreenRequest,
   ScreenSession,
 } from "@rakazo/adapter-kit";
-import { resolveSupervisorToken } from "@rakazo/core";
+import { boundedSandboxCommandTimeoutMs, resolveSupervisorToken } from "@rakazo/core";
 import {
   boundedComputerActions,
   clampRounded,
@@ -95,7 +95,11 @@ export class DockerSandboxProvider implements SandboxProvider {
     const res = await fetch(this.url(`/computers/${computer.id}/exec`), {
       method: "POST",
       headers: { ...this.headers(context, computer.botId), "content-type": "application/json" },
-      body: JSON.stringify({ ...request, cwd: dockerCwd(request.cwd) }),
+      body: JSON.stringify({
+        ...request,
+        cwd: dockerCwd(request.cwd),
+        timeoutMs: boundedSandboxCommandTimeoutMs(request.timeoutMs),
+      }),
       signal: context.signal,
     });
     if (!res.ok) {

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -1,4 +1,4 @@
-import type { Sandbox } from "@e2b/desktop";
+import { type Sandbox, TimeoutError } from "@e2b/desktop";
 import { describe, expect, it, vi } from "vitest";
 import {
   E2BSandboxProvider,
@@ -29,9 +29,7 @@ describe("E2B computer backend", () => {
     const command = vi.fn(async (value: string, _options?: Record<string, unknown>) => {
       if (value.startsWith('test "$(readlink')) throw new Error("profiles are not configured");
       if (value.includes("hang")) {
-        const error = new Error("command timed out");
-        error.name = "TimeoutError";
-        throw error;
+        throw new TimeoutError("command timed out");
       }
       return {
         stdout: "",

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -26,8 +26,13 @@ describe("E2B computer backend", () => {
     const files = new Map<string, Uint8Array>();
     const leftClick = vi.fn(async () => undefined);
     const typeText = vi.fn(async () => undefined);
-    const command = vi.fn(async (value: string) => {
+    const command = vi.fn(async (value: string, _options?: Record<string, unknown>) => {
       if (value.startsWith('test "$(readlink')) throw new Error("profiles are not configured");
+      if (value.includes("hang")) {
+        const error = new Error("command timed out");
+        error.name = "TimeoutError";
+        throw error;
+      }
       return {
         stdout: "",
         stderr: "",
@@ -111,6 +116,23 @@ describe("E2B computer backend", () => {
         // Empty durable home on first boot.
       })(),
       context,
+    );
+
+    const timeoutEvents = [];
+    for await (const event of provider.execute(
+      computer,
+      { argv: ["hang"], timeoutMs: 42 },
+      context,
+    )) {
+      timeoutEvents.push(event);
+    }
+    expect(timeoutEvents).toEqual([
+      { type: "stderr", data: "command timed out after 42 ms\n" },
+      { type: "exit", code: 124 },
+    ]);
+    expect(command).toHaveBeenCalledWith(
+      "'hang'",
+      expect.objectContaining({ timeoutMs: 42, signal: context.signal }),
     );
 
     await provider.writeFile(

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -16,6 +16,7 @@ import type {
   ScreenRequest,
   ScreenSession,
 } from "@rakazo/adapter-kit";
+import { boundedSandboxCommandTimeoutMs } from "@rakazo/core";
 import { sandboxIdleMs } from "./computer-idle.js";
 import {
   boundedComputerActions,
@@ -176,18 +177,29 @@ export class E2BSandboxProvider implements SandboxProvider {
   async *execute(
     computer: ComputerRef,
     request: CommandRequest,
-    _context: AdapterContext,
+    context: AdapterContext,
   ): AsyncIterable<ProcessEvent> {
     const desktop = await this.box(computer);
     const cmd = request.argv.map(shellQuote).join(" ");
-    const result = await desktop.commands.run(cmd, {
-      cwd: e2bCwd(request.cwd),
-      envs: request.env,
-      signal: _context.signal,
-    });
-    if (result.stdout) yield { type: "stdout", data: result.stdout };
-    if (result.stderr) yield { type: "stderr", data: result.stderr };
-    yield { type: "exit", code: result.exitCode ?? 0 };
+    const timeoutMs = boundedSandboxCommandTimeoutMs(request.timeoutMs);
+    try {
+      const result = await desktop.commands.run(cmd, {
+        cwd: e2bCwd(request.cwd),
+        envs: request.env,
+        signal: context.signal,
+        timeoutMs,
+      });
+      if (result.stdout) yield { type: "stdout", data: result.stdout };
+      if (result.stderr) yield { type: "stderr", data: result.stderr };
+      yield { type: "exit", code: result.exitCode ?? 0 };
+    } catch (error) {
+      if (isCommandTimeout(error)) {
+        yield { type: "stderr", data: `command timed out after ${timeoutMs} ms\n` };
+        yield { type: "exit", code: 124 };
+        return;
+      }
+      throw error;
+    }
   }
 
   async connectScreen(
@@ -439,6 +451,10 @@ export class E2BSandboxProvider implements SandboxProvider {
       this.controlStreams.delete(desktop.sandboxId);
     }
   }
+}
+
+function isCommandTimeout(error: unknown) {
+  return error instanceof Error && /timed?\s*out|timeout/i.test(`${error.name} ${error.message}`);
 }
 
 function controlStreamStopCommand(controlToken?: string) {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { Sandbox } from "@e2b/desktop";
+import { Sandbox, TimeoutError } from "@e2b/desktop";
 import type {
   AdapterContext,
   CommandRequest,
@@ -193,7 +193,7 @@ export class E2BSandboxProvider implements SandboxProvider {
       if (result.stderr) yield { type: "stderr", data: result.stderr };
       yield { type: "exit", code: result.exitCode ?? 0 };
     } catch (error) {
-      if (isCommandTimeout(error)) {
+      if (error instanceof TimeoutError) {
         yield { type: "stderr", data: `command timed out after ${timeoutMs} ms\n` };
         yield { type: "exit", code: 124 };
         return;
@@ -451,10 +451,6 @@ export class E2BSandboxProvider implements SandboxProvider {
       this.controlStreams.delete(desktop.sandboxId);
     }
   }
-}
-
-function isCommandTimeout(error: unknown) {
-  return error instanceof Error && /timed?\s*out|timeout/i.test(`${error.name} ${error.message}`);
 }
 
 function controlStreamStopCommand(controlToken?: string) {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -21,6 +21,7 @@ import {
   nextCronDate,
   nextFence,
   redactSecrets,
+  sandboxCommandTimeoutMs,
 } from "@rakazo/core";
 import { createThreadMessage, type PrismaClient, type ThreadEvents } from "@rakazo/db";
 import { builtinAgentTools } from "./builtin-tools.js";
@@ -1117,7 +1118,11 @@ async function runSandboxCommand(
   let stdout = "";
   let stderr = "";
   let code = 0;
-  for await (const event of sandbox.execute(computer, { argv, cwd }, context)) {
+  for await (const event of sandbox.execute(
+    computer,
+    { argv, cwd, timeoutMs: sandboxCommandTimeoutMs() },
+    context,
+  )) {
     if (event.type === "stdout") stdout += event.data;
     if (event.type === "stderr") stderr += event.data;
     if (event.type === "exit") code = event.code;

--- a/packages/adapters/src/sandbox-conformance.test.ts
+++ b/packages/adapters/src/sandbox-conformance.test.ts
@@ -2,7 +2,7 @@ import { execSync, spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { SandboxProvider } from "@rakazo/adapter-kit";
+import type { ProcessEvent, SandboxProvider } from "@rakazo/adapter-kit";
 import { afterAll, describe, expect, it } from "vitest";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
 import { DockerSandboxProvider } from "./docker-sandbox.js";
@@ -120,6 +120,61 @@ describe("sandbox conformance", () => {
     expect(code).toBe(1);
     expect(stderr).toMatch(/outside this computer's home/i);
     await desktop.destroy(computer, ctx);
+  });
+
+  it("desktop executor times out and kills descendants that inherited its pipes", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "rakazo-desktop-timeout-"));
+    const desktop = new DesktopSandboxProvider({ root });
+    const computer = await desktop.provision({ botId: "timeout", homePath: "/unused" }, ctx);
+    const marker = path.join(computer.providerRef, "descendant-survived");
+    const events: ProcessEvent[] = [];
+    const startedAt = Date.now();
+
+    for await (const event of desktop.execute(
+      computer,
+      {
+        argv: ["bash", "-lc", "(sleep 0.2; printf survived > descendant-survived) & wait"],
+        timeoutMs: 40,
+      },
+      ctx,
+    )) {
+      events.push(event);
+    }
+
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(events).toContainEqual({ type: "exit", code: 124 });
+    expect(events).toContainEqual({
+      type: "stderr",
+      data: "command timed out after 40 ms\n",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(() => readFileSync(marker)).toThrow();
+
+    await desktop.destroy(computer, ctx);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("desktop executor aborts and kills a running command", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "rakazo-desktop-abort-"));
+    const desktop = new DesktopSandboxProvider({ root });
+    const computer = await desktop.provision({ botId: "abort", homePath: "/unused" }, ctx);
+    const controller = new AbortController();
+    const events: ProcessEvent[] = [];
+    setTimeout(() => controller.abort(), 25);
+
+    for await (const event of desktop.execute(
+      computer,
+      { argv: ["bash", "-lc", "sleep 10"], timeoutMs: 5_000 },
+      { ...ctx, signal: controller.signal },
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toContainEqual({ type: "exit", code: 130 });
+    expect(events).toContainEqual({ type: "stderr", data: "command aborted\n" });
+
+    await desktop.destroy(computer, ctx);
+    rmSync(root, { recursive: true, force: true });
   });
 
   it("reuses one desktop machine per bot", async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,5 +3,6 @@ export * from "./cron.js";
 export * from "./events.js";
 export * from "./message-pages.js";
 export * from "./run-state.js";
+export * from "./sandbox-command.js";
 export * from "./secrets-guard.js";
 export * from "./signup-policy.js";

--- a/packages/core/src/sandbox-command.test.ts
+++ b/packages/core/src/sandbox-command.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  boundedSandboxCommandTimeoutMs,
+  DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS,
+  MAX_SANDBOX_COMMAND_TIMEOUT_MS,
+  sandboxCommandTimeoutMs,
+} from "./sandbox-command.js";
+
+describe("sandbox command timeout", () => {
+  it("uses a safe default and accepts a bounded deployment override", () => {
+    expect(sandboxCommandTimeoutMs({})).toBe(DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS);
+    expect(sandboxCommandTimeoutMs({ SANDBOX_COMMAND_TIMEOUT_MS: "120000" })).toBe(120_000);
+    expect(sandboxCommandTimeoutMs({ SANDBOX_COMMAND_TIMEOUT_MS: "invalid" })).toBe(
+      DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS,
+    );
+    expect(
+      sandboxCommandTimeoutMs({
+        SANDBOX_COMMAND_TIMEOUT_MS: String(MAX_SANDBOX_COMMAND_TIMEOUT_MS + 1),
+      }),
+    ).toBe(DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS);
+  });
+
+  it("honors bounded per-command timeouts and rejects invalid values", () => {
+    expect(boundedSandboxCommandTimeoutMs(25, 100)).toBe(25);
+    expect(boundedSandboxCommandTimeoutMs(0, 100)).toBe(100);
+    expect(boundedSandboxCommandTimeoutMs(Number.NaN, 100)).toBe(100);
+    expect(boundedSandboxCommandTimeoutMs(undefined, Number.POSITIVE_INFINITY)).toBe(
+      DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS,
+    );
+  });
+});

--- a/packages/core/src/sandbox-command.ts
+++ b/packages/core/src/sandbox-command.ts
@@ -1,0 +1,26 @@
+export const DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS = 5 * 60_000;
+export const MAX_SANDBOX_COMMAND_TIMEOUT_MS = 60 * 60_000;
+
+export function sandboxCommandTimeoutMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const configured = Number(env.SANDBOX_COMMAND_TIMEOUT_MS);
+  return validSandboxCommandTimeout(configured) ? configured : DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS;
+}
+
+export function boundedSandboxCommandTimeoutMs(
+  requested: number | undefined,
+  fallback = sandboxCommandTimeoutMs(),
+): number {
+  if (validSandboxCommandTimeout(requested)) return requested;
+  return validSandboxCommandTimeout(fallback) ? fallback : DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS;
+}
+
+function validSandboxCommandTimeout(value: number | undefined): value is number {
+  return (
+    value !== undefined &&
+    Number.isSafeInteger(value) &&
+    value > 0 &&
+    value <= MAX_SANDBOX_COMMAND_TIMEOUT_MS
+  );
+}

--- a/packages/core/src/sandbox-command.ts
+++ b/packages/core/src/sandbox-command.ts
@@ -10,9 +10,10 @@ export function sandboxCommandTimeoutMs(
 
 export function boundedSandboxCommandTimeoutMs(
   requested: number | undefined,
-  fallback = sandboxCommandTimeoutMs(),
+  fallback?: number,
 ): number {
   if (validSandboxCommandTimeout(requested)) return requested;
+  if (fallback === undefined) return sandboxCommandTimeoutMs();
   return validSandboxCommandTimeout(fallback) ? fallback : DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS;
 }
 


### PR DESCRIPTION
Closes #28

## Summary
- add a configurable, bounded sandbox command timeout (`SANDBOX_COMMAND_TIMEOUT_MS`, default 5 minutes)
- terminate desktop command process groups, destroy inherited stdio pipes, and honor run abort signals
- enforce Docker supervisor timeouts with process-group cleanup and return exit 124 with an actionable timeout message
- propagate the same deadline to E2B commands

## Tests
- `vitest run packages/core/src packages/adapters/src infra/sandboxes/supervisor/src` (33 files passed, 162 tests passed; 3 files / 6 tests skipped)
- targeted timeout suite (5 files, 22 tests passed)
- TypeScript checks for core, adapter-kit, adapters, and sandbox supervisor
- Biome check and `git diff --check`