### PR TITLE
Add safe bot archive and deletion

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -105,18 +105,23 @@ export async function createApp(
     beforeDeleteUser: async (userId) => {
       const bots = await prisma.bot.findMany({
         where: { userId },
-        select: { id: true, workspaceId: true },
+        select: { id: true, workspaceId: true, name: true, archivedAt: true },
       });
       await Promise.all(
         bots.map((bot) =>
-          destroyBot({ prisma, sandbox, home, dataDir: env.dataDir }, bot.id, {
-            operationId: `account-delete:${userId}`,
-            traceId: `account-delete:${userId}`,
-            workspaceId: bot.workspaceId,
-            userId,
-            botId: bot.id,
-            signal: new AbortController().signal,
-          }),
+          destroyBot(
+            { prisma, sandbox, home, jobs, dataDir: env.dataDir },
+            bot,
+            {
+              operationId: `account-delete:${userId}`,
+              traceId: `account-delete:${userId}`,
+              workspaceId: bot.workspaceId,
+              userId,
+              botId: bot.id,
+              signal: new AbortController().signal,
+            },
+            { deleteMemories: true },
+          ),
         ),
       );
       await rm(pushTokenPath(env.dataDir, userId), { force: true }).catch(() => undefined);

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -13,6 +13,7 @@ import {
 } from "@rakazo/adapter-kit";
 import {
   acquireComputerExecutionLease,
+  archiveBot,
   type ComposioConnector,
   ComputerBusyError,
   type ComputerExecutionLease,
@@ -219,6 +220,9 @@ export function createRouter(deps: RouterDeps) {
     },
     bots: {
       list: authed.bots.list.handler(async ({ context }) => repos.listBots(context.actor)),
+      listArchived: authed.bots.listArchived.handler(async ({ context }) =>
+        repos.listBots(context.actor, { archived: true }),
+      ),
       get: authed.bots.get.handler(async ({ context, input }) => {
         const found = (await repos.listBots(context.actor)).find((bot) => bot.id === input.botId);
         if (!found) throw new IsolationError();
@@ -310,16 +314,38 @@ export function createRouter(deps: RouterDeps) {
           });
         }
       }),
+      archive: authed.bots.archive.handler(async ({ context, input }) => {
+        const bot = await repos.getBot(context.actor, input.botId, { includeArchived: true });
+        await archiveBot(
+          {
+            prisma: deps.prisma,
+            sandbox: deps.sandbox,
+            home: deps.home,
+            jobs: deps.jobs,
+            dataDir: deps.dataDir,
+          },
+          bot,
+          computerContext(context.actor, bot.id, "archive"),
+        );
+        return { ok: true as const };
+      }),
+      restore: authed.bots.restore.handler(async ({ context, input }) => {
+        const bot = await repos.getBot(context.actor, input.botId, { includeArchived: true });
+        if (!bot.archivedAt) return { ok: true as const };
+        await deps.prisma.bot.update({ where: { id: bot.id }, data: { archivedAt: null } });
+        return { ok: true as const };
+      }),
       remove: authed.bots.remove.handler(async ({ context, input }) => {
-        const bot = await repos.getBot(context.actor, input.botId);
+        const bot = await repos.getBot(context.actor, input.botId, { includeArchived: true });
         await destroyBot(
           {
             prisma: deps.prisma,
             sandbox: deps.sandbox,
             home: deps.home,
+            jobs: deps.jobs,
             dataDir: deps.dataDir,
           },
-          bot.id,
+          bot,
           {
             operationId: "destroy",
             traceId: "destroy",
@@ -327,6 +353,7 @@ export function createRouter(deps: RouterDeps) {
             userId: context.actor.userId,
             signal: new AbortController().signal,
           },
+          { deleteMemories: input.deleteMemories },
         );
         return { ok: true as const };
       }),

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -4,13 +4,16 @@ import {
   ActivityIndicator,
   Alert,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import type { MobileBot } from "../lib/api";
 import { deleteAccount, type MobileMe, rpc, signOut } from "../lib/api";
+import { confirmDeleteBot } from "../lib/bot-lifecycle";
 import { native } from "../lib/native";
 
 export default function Account() {
@@ -19,12 +22,28 @@ export default function Account() {
   const [password, setPassword] = useState("");
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [archivedBots, setArchivedBots] = useState<MobileBot[]>([]);
 
   useEffect(() => {
     void rpc<MobileMe>("me")
       .then(setMe)
       .catch(() => undefined);
+    void rpc<MobileBot[]>("bots/listArchived")
+      .then(setArchivedBots)
+      .catch(() => undefined);
   }, []);
+
+  async function restoreBot(botId: string) {
+    try {
+      await rpc("bots/restore", { botId });
+      setArchivedBots((bots) => bots.filter((bot) => bot.id !== botId));
+    } catch (restoreError) {
+      Alert.alert(
+        "Could not restore bot",
+        restoreError instanceof Error ? restoreError.message : "Try again.",
+      );
+    }
+  }
 
   async function handleSignOut() {
     setPending(true);
@@ -65,7 +84,7 @@ export default function Account() {
 
   return (
     <SafeAreaView edges={["bottom"]} style={styles.screen}>
-      <View style={styles.content}>
+      <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.profile}>
           <Text style={styles.name}>{me?.name || "Your account"}</Text>
           {me?.email ? <Text style={styles.email}>{me.email}</Text> : null}
@@ -79,6 +98,32 @@ export default function Account() {
         >
           <Text style={styles.buttonLabel}>Sign out</Text>
         </Pressable>
+
+        {archivedBots.length > 0 ? (
+          <View style={styles.archivedSection}>
+            <Text style={styles.sectionTitle}>Archived bots</Text>
+            {archivedBots.map((bot) => (
+              <View key={bot.id} style={styles.archivedRow}>
+                <Text numberOfLines={1} style={styles.archivedName}>
+                  {bot.name}
+                </Text>
+                <Pressable onPress={() => void restoreBot(bot.id)} hitSlop={8}>
+                  <Text style={styles.restoreLabel}>Restore</Text>
+                </Pressable>
+                <Pressable
+                  onPress={() =>
+                    confirmDeleteBot(bot, () =>
+                      setArchivedBots((bots) => bots.filter((item) => item.id !== bot.id)),
+                    )
+                  }
+                  hitSlop={8}
+                >
+                  <Text style={styles.archivedDeleteLabel}>Delete</Text>
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        ) : null}
 
         <View style={styles.dangerZone}>
           <Text style={styles.dangerTitle}>Delete account</Text>
@@ -120,7 +165,7 @@ export default function Account() {
             )}
           </Pressable>
         </View>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -131,7 +176,7 @@ const styles = StyleSheet.create({
     backgroundColor: native.page,
   },
   content: {
-    flex: 1,
+    flexGrow: 1,
     padding: 20,
     gap: 20,
   },
@@ -161,6 +206,36 @@ const styles = StyleSheet.create({
     color: native.label,
     fontSize: 17,
     fontWeight: "600",
+  },
+  archivedSection: {
+    borderRadius: 16,
+    backgroundColor: native.fill,
+    padding: 18,
+    gap: 14,
+  },
+  sectionTitle: {
+    color: native.secondaryLabel,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  archivedRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+  },
+  archivedName: {
+    flex: 1,
+    color: native.label,
+    fontSize: 16,
+  },
+  restoreLabel: {
+    color: native.label,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  archivedDeleteLabel: {
+    color: "#FF6961",
+    fontSize: 14,
   },
   dangerZone: {
     marginTop: 12,

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -2,7 +2,7 @@ import { ChatMarkdown } from "@rakazo/chat-ui/native";
 import { abortableDelay } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { AppState, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { Alert, AppState, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { NativeSymbol } from "../components/native-symbol";
 import {
   applyMobileThreadEvent,
@@ -15,6 +15,7 @@ import {
   rpc,
   subscribeThread,
 } from "../lib/api";
+import { confirmDeleteBot } from "../lib/bot-lifecycle";
 
 export default function Thread() {
   const navigation = useNavigation();
@@ -29,8 +30,41 @@ export default function Thread() {
   const [loadingOlder, setLoadingOlder] = useState(false);
 
   useLayoutEffect(() => {
-    navigation.setOptions({ title: name || "Thread" });
-  }, [name, navigation]);
+    navigation.setOptions({
+      title: name || "Thread",
+      headerRight: () => (
+        <Pressable accessibilityLabel="Bot actions" hitSlop={8} onPress={showBotActions}>
+          <NativeSymbol ios="ellipsis" android="ellipsis-horizontal" size={21} color="#ECECEE" />
+        </Pressable>
+      ),
+    });
+  }, [botId, name, navigation]);
+
+  function leaveBot() {
+    router.dismissAll();
+    router.replace("/");
+  }
+
+  function showBotActions() {
+    if (!botId) return;
+    const bot = { id: botId, name: name || "Bot" };
+    Alert.alert(bot.name, "Archive keeps everything and can be undone. Delete is permanent.", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Archive",
+        onPress: () =>
+          void rpc("bots/archive", { botId })
+            .then(leaveBot)
+            .catch((error) =>
+              Alert.alert(
+                "Could not archive bot",
+                error instanceof Error ? error.message : "Try again.",
+              ),
+            ),
+      },
+      { text: "Delete…", style: "destructive", onPress: () => confirmDeleteBot(bot, leaveBot) },
+    ]);
+  }
 
   async function refresh() {
     if (!botId) return;
@@ -277,10 +311,10 @@ function MessageBubble({
     );
   }
   if (special?.kind === "child_bot") {
-    const deleted = special.status === "deleted";
+    const removed = special.status === "deleted" || special.status === "archived";
     return (
       <Pressable
-        disabled={deleted}
+        disabled={removed}
         onPress={() => onOpenBot(special.botId ?? "", special.name ?? "Bot")}
         style={{
           width: "90%",
@@ -290,20 +324,26 @@ function MessageBubble({
           backgroundColor: "#17171A",
           paddingHorizontal: 16,
           paddingVertical: 14,
-          opacity: deleted ? 0.6 : 1,
+          opacity: removed ? 0.6 : 1,
         }}
       >
         <View style={{ flexDirection: "row", justifyContent: "space-between", gap: 8 }}>
           <Text style={{ color: "#ECECEE", fontSize: 15, fontWeight: "600" }}>
             {special.name || "Bot"}
           </Text>
-          <Text style={{ color: deleted ? "#E65707" : "#4ECB71", fontSize: 13 }}>
-            {deleted ? "deleted" : "bot"}
+          <Text style={{ color: removed ? "#E65707" : "#4ECB71", fontSize: 13 }}>
+            {special.status === "archived"
+              ? "archived"
+              : special.status === "deleted"
+                ? "deleted"
+                : "bot"}
           </Text>
         </View>
         <Text style={{ color: "#A8A8AD", marginTop: 8, fontSize: 14.5, lineHeight: 21 }}>
-          {deleted
-            ? "Removed this bot, including its chat, computer, and memory."
+          {removed
+            ? special.status === "archived"
+              ? "Archived this bot. Its chat, memory, and files are preserved."
+              : "Removed this bot, including its chat, computer, and memory."
             : special.title || "Opened its own thread. Tap to switch."}
         </Text>
       </Pressable>

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ComputerMode } from "@rakazo/contracts";
+import type { Bot, ComputerMode } from "@rakazo/contracts";
 import {
   mergeThreadHistory,
   prependThreadHistoryPage,
@@ -127,18 +127,20 @@ export async function rpc<T>(proc: string, body: unknown = {}): Promise<T> {
   return parsed.json as T;
 }
 
-export type MobileBot = {
-  id: string;
-  name: string;
-  preview: string;
-  title: string;
-  color: string;
-  pinned: boolean;
-  unread: boolean;
-  updatedAt: string;
-  parentBotId?: string | null;
-  computerMode: ComputerMode;
-};
+export type MobileBot = Pick<
+  Bot,
+  | "id"
+  | "name"
+  | "preview"
+  | "title"
+  | "color"
+  | "pinned"
+  | "archivedAt"
+  | "unread"
+  | "updatedAt"
+  | "computerMode"
+> &
+  Partial<Pick<Bot, "parentBotId">>;
 
 export type MobileMe = {
   name: string;
@@ -206,7 +208,7 @@ export function blockText(message: MobileMessage) {
         return `${block.name ?? "subagent"}: ${block.result || block.progress || block.task || ""}`;
       }
       if (block.kind === "child_bot") {
-        return `${block.status === "deleted" ? "Deleted" : "Bot"} ${block.name ?? ""}`;
+        return `${block.status === "archived" ? "Archived" : block.status === "deleted" ? "Deleted" : "Bot"} ${block.name ?? ""}`;
       }
       return block.text ?? block.state ?? "";
     })

--- a/apps/mobile/lib/bot-lifecycle.ts
+++ b/apps/mobile/lib/bot-lifecycle.ts
@@ -1,0 +1,27 @@
+import { Alert } from "react-native";
+import { rpc } from "./api";
+
+export function confirmDeleteBot(bot: { id: string; name: string }, onDeleted: () => void) {
+  const remove = async (deleteMemories: boolean) => {
+    try {
+      await rpc("bots/remove", { botId: bot.id, deleteMemories });
+      onDeleted();
+    } catch (error) {
+      Alert.alert("Could not delete bot", error instanceof Error ? error.message : "Try again.");
+    }
+  };
+
+  Alert.alert(
+    `Delete ${bot.name}?`,
+    "Its conversation, files, and routines will be permanently deleted. What should happen to its memories?",
+    [
+      { text: "Cancel", style: "cancel" },
+      { text: "Keep memories", onPress: () => void remove(false) },
+      {
+        text: "Delete memories too",
+        style: "destructive",
+        onPress: () => void remove(true),
+      },
+    ],
+  );
+}

--- a/apps/mobile/lib/inbox.test.ts
+++ b/apps/mobile/lib/inbox.test.ts
@@ -75,6 +75,7 @@ function bot(id: string, name: string, title: string, preview: string) {
     preview,
     color: "#9B5CF6",
     pinned: false,
+    archivedAt: null,
     unread: false,
     updatedAt: now.toISOString(),
   };

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -80,7 +80,12 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await page.getByRole("button", { name: "Export" }).click();
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toMatch(/chief-export\.json/i);
+  await expect(page.getByRole("button", { name: "Archive bot" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Delete bot" })).toBeVisible();
+  await page.getByRole("button", { name: "Delete bot" }).click();
+  await expect(page.getByRole("radio", { name: /Keep memories/ })).toBeChecked();
+  await expect(page.getByRole("radio", { name: /Delete memories too/ })).toBeVisible();
+  await page.getByRole("button", { name: "Cancel" }).click();
   await captureScreenshot(page, testInfo, "12-bot-settings");
 });
 

--- a/apps/web/src/pages/BotContextMenu.tsx
+++ b/apps/web/src/pages/BotContextMenu.tsx
@@ -11,6 +11,7 @@ export function BotContextMenu({
   onToggleUnread,
   onEdit,
   onDuplicate,
+  onArchive,
   onDelete,
 }: {
   bot: Bot;
@@ -20,6 +21,7 @@ export function BotContextMenu({
   onToggleUnread: () => void;
   onEdit: () => void;
   onDuplicate: () => void;
+  onArchive: () => void;
   onDelete: () => void;
 }) {
   const firstItem = useRef<HTMLButtonElement>(null);
@@ -34,7 +36,7 @@ export function BotContextMenu({
   }, [onClose]);
 
   const menuWidth = 264;
-  const menuHeight = 252;
+  const menuHeight = 296;
   const margin = 8;
   const left = Math.min(position.x, window.innerWidth - menuWidth - margin);
   const top = Math.min(position.y, window.innerHeight - menuHeight - margin);
@@ -72,6 +74,7 @@ export function BotContextMenu({
         <MenuItem icon={<EditIcon />} label="Edit Profile" onSelect={onEdit} />
         <MenuItem icon={<DuplicateIcon />} label="Duplicate" onSelect={onDuplicate} />
         <div className="my-1 border-t border-[#343438]" />
+        <MenuItem icon={<ArchiveIcon />} label="Archive" onSelect={onArchive} />
         <MenuItem icon={<TrashIcon />} label="Delete" tone="danger" onSelect={onDelete} />
       </div>
     </div>
@@ -158,6 +161,14 @@ function TrashIcon() {
   return (
     <svg {...iconProps}>
       <path d="M3 6h18M8 6V4h8v2m-9 0 1 15h8l1-15M10 10v7m4-7v7" />
+    </svg>
+  );
+}
+
+function ArchiveIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="M4 7h16v13H4zM3 4h18v3H3zM9 11h6" />
     </svg>
   );
 }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -49,6 +49,8 @@ export function ShellPage() {
   const navigate = useNavigate();
   const session = authClient.useSession();
   const [bots, setBots] = useState<Bot[]>([]);
+  const [archivedBots, setArchivedBots] = useState<Bot[]>([]);
+  const [archivedOpen, setArchivedOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [snapshot, setSnapshot] = useState<ThreadSnapshot | null>(null);
   const [draft, setDraft] = useState("");
@@ -131,15 +133,19 @@ export function ShellPage() {
     [markBotRead],
   );
 
-  async function refreshBots() {
-    const list = await rpc.bots.list();
+  async function refreshBots(includeArchived = false) {
+    const [list, archived] = await Promise.all([
+      rpc.bots.list(),
+      includeArchived ? rpc.bots.listArchived() : Promise.resolve(null),
+    ]);
     setBots(list);
-    if (list.length === 0) {
+    if (archived) setArchivedBots(archived);
+    if (includeArchived && list.length === 0 && archived?.length === 0) {
       navigate("/onboarding", { replace: true });
       return;
     }
     if (!botId || !list.some((bot) => bot.id === botId)) {
-      navigate(`/app/${list[0]!.id}`, { replace: true });
+      navigate(list[0] ? `/app/${list[0].id}` : "/app", { replace: true });
     }
   }
 
@@ -201,7 +207,7 @@ export function ShellPage() {
   }
 
   useEffect(() => {
-    void refreshBots();
+    void refreshBots(true);
     const poll = window.setInterval(() => void refreshBots().catch(() => undefined), 4000);
     return () => window.clearInterval(poll);
   }, []);
@@ -244,7 +250,9 @@ export function ShellPage() {
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
             applyThreadEvent(event, setSnapshot, setComputer);
-            if (
+            if (event.type === "bot.archived") {
+              void refreshBots(true).catch(() => undefined);
+            } else if (
               event.type === "bot.spawned" ||
               event.type === "bot.deleted" ||
               event.type === "run.completed"
@@ -467,6 +475,46 @@ export function ShellPage() {
               </div>
             </button>
           ))}
+          {archivedBots.length > 0 ? (
+            <div className="mt-2 border-t border-[#202023] pt-2">
+              <button
+                type="button"
+                aria-expanded={archivedOpen}
+                onClick={() => setArchivedOpen((open) => !open)}
+                className="flex w-full items-center justify-between rounded-lg px-2.5 py-2 text-[13.5px] text-[#85858A] hover:bg-[#131315]"
+              >
+                <span>Archived</span>
+                <span>{archivedBots.length}</span>
+              </button>
+              {archivedOpen
+                ? archivedBots.map((bot) => (
+                    <div key={bot.id} className="flex items-center gap-2 rounded-lg px-2.5 py-2">
+                      <BotAvatar color={bot.color} size={28} />
+                      <span className="min-w-0 flex-1 truncate text-[14px] text-[#A8A8AD]">
+                        {bot.name}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          void rpc.bots.restore({ botId: bot.id }).then(() => refreshBots(true))
+                        }
+                        className="text-[12.5px] text-[#C9C9CE] hover:text-white"
+                      >
+                        Restore
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Delete ${bot.name}`}
+                        onClick={() => setDeleteTarget(bot)}
+                        className="text-[12.5px] text-[#FF5364]"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  ))
+                : null}
+            </div>
+          ) : null}
         </div>
         <button
           type="button"
@@ -822,11 +870,12 @@ export function ShellPage() {
                   a.click();
                   URL.revokeObjectURL(url);
                 }}
-                onDelete={async () => {
-                  await rpc.bots.remove({ botId: active.id });
+                onArchive={async () => {
+                  await rpc.bots.archive({ botId: active.id });
                   setPanel(null);
-                  await refreshBots();
+                  await refreshBots(true);
                 }}
+                onDelete={() => setDeleteTarget(active)}
               />
             ) : null}
             {panel === "routine" ? (
@@ -922,6 +971,10 @@ export function ShellPage() {
               navigate(`/app/${bot.id}`);
             });
           }}
+          onArchive={() => {
+            setBotMenu(null);
+            void rpc.bots.archive({ botId: contextBot.id }).then(() => refreshBots(true));
+          }}
           onDelete={() => {
             setDeleteTarget(contextBot);
             setBotMenu(null);
@@ -933,11 +986,11 @@ export function ShellPage() {
         <DeleteBotDialog
           bot={deleteTarget}
           onCancel={() => setDeleteTarget(null)}
-          onConfirm={async () => {
-            await rpc.bots.remove({ botId: deleteTarget.id });
+          onConfirm={async (deleteMemories) => {
+            await rpc.bots.remove({ botId: deleteTarget.id, deleteMemories });
             setDeleteTarget(null);
             setPanel(null);
-            await refreshBots();
+            await refreshBots(true);
           }}
         />
       ) : null}
@@ -1128,12 +1181,12 @@ function MessageView({
           );
         }
         if (block.kind === "child_bot") {
-          const deleted = block.status === "deleted";
+          const removed = block.status === "deleted" || block.status === "archived";
           return (
             <button
               key={i}
               type="button"
-              disabled={deleted}
+              disabled={removed}
               onClick={() => onOpenBot(block.botId)}
               className="w-[min(340px,90%)] rounded-[18px] border border-[#232326] bg-[#17171A] px-[18px] py-4 text-left disabled:opacity-60"
             >
@@ -1142,16 +1195,22 @@ function MessageView({
                 <span
                   className="rounded-full px-[11px] py-1 text-[13px]"
                   style={{
-                    background: deleted ? "rgba(230,87,7,.14)" : "rgba(48,162,75,.14)",
-                    color: deleted ? "#E65707" : "#4ECB71",
+                    background: removed ? "rgba(230,87,7,.14)" : "rgba(48,162,75,.14)",
+                    color: removed ? "#E65707" : "#4ECB71",
                   }}
                 >
-                  {deleted ? "deleted" : "bot"}
+                  {block.status === "archived"
+                    ? "archived"
+                    : block.status === "deleted"
+                      ? "deleted"
+                      : "bot"}
                 </span>
               </div>
               <div className="mt-2 text-[14.5px] leading-[1.5] text-[#A8A8AD]">
-                {deleted
-                  ? "Removed this bot, including its chat, computer, and memory."
+                {removed
+                  ? block.status === "archived"
+                    ? "Archived this bot. Its chat, memory, and files are preserved."
+                    : "Removed this bot, including its chat, computer, and memory."
                   : block.title || "Opened its own thread. Tap to switch."}
               </div>
             </button>
@@ -1421,6 +1480,7 @@ function BotSettings({
   bot,
   onSave,
   onExport,
+  onArchive,
   onDelete,
 }: {
   bot: Bot;
@@ -1432,15 +1492,15 @@ function BotSettings({
     computerMode: ComputerMode;
   }) => Promise<void>;
   onExport: () => Promise<void>;
-  onDelete: () => Promise<void>;
+  onArchive: () => Promise<void>;
+  onDelete: () => void;
 }) {
   const [name, setName] = useState(bot.name);
   const [title, setTitle] = useState(bot.title);
   const [description, setDescription] = useState(bot.description);
   const [computerMode, setComputerMode] = useState(bot.computerMode);
-  const [confirming, setConfirming] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
+  const [archiving, setArchiving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   return (
@@ -1474,7 +1534,7 @@ function BotSettings({
         />
       </label>
       <ComputerModePicker value={computerMode} onChange={setComputerMode} />
-      {error && !confirming ? <p className="mt-2 text-[13px] text-[#E65707]">{error}</p> : null}
+      {error ? <p className="mt-2 text-[13px] text-[#E65707]">{error}</p> : null}
       <div className="mt-5 flex flex-col items-start gap-3">
         <button
           type="button"
@@ -1503,51 +1563,23 @@ function BotSettings({
         >
           Export
         </button>
-        {confirming ? (
-          <div className="w-full rounded-[11px] border border-[#3A1F14] bg-[#1A100C] px-3.5 py-3">
-            <p className="text-[13.5px] leading-[1.45] text-[#C9C9CE]">
-              This permanently deletes {bot.name}, including its thread, memory, and routines. Bots
-              it created stay in your list.
-            </p>
-            <div className="mt-3 flex items-center gap-3">
-              <button
-                type="button"
-                disabled={deleting}
-                onClick={() => {
-                  setConfirming(false);
-                  setError(null);
-                }}
-                className="text-[14px] text-[#85858A] disabled:opacity-40"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                disabled={deleting}
-                onClick={() => {
-                  setDeleting(true);
-                  setError(null);
-                  void onDelete().catch((err: unknown) => {
-                    setError(err instanceof Error ? err.message : "Could not delete bot");
-                    setDeleting(false);
-                  });
-                }}
-                className="rounded-[11px] bg-[#E65707] px-3.5 py-1.5 text-[14px] text-[#F1F1EF] disabled:opacity-40"
-              >
-                {deleting ? "Deleting…" : "Delete"}
-              </button>
-            </div>
-            {error ? <p className="mt-2 text-[13px] text-[#E65707]">{error}</p> : null}
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => setConfirming(true)}
-            className="text-[14px] text-[#E65707]"
-          >
-            Delete bot
-          </button>
-        )}
+        <button
+          type="button"
+          disabled={archiving}
+          onClick={() => {
+            setArchiving(true);
+            setError(null);
+            void onArchive()
+              .catch((err) => setError(err instanceof Error ? err.message : "Could not archive"))
+              .finally(() => setArchiving(false));
+          }}
+          className="text-[14px] text-[#85858A] disabled:opacity-40"
+        >
+          {archiving ? "Archiving…" : "Archive bot"}
+        </button>
+        <button type="button" onClick={onDelete} className="text-[14px] text-[#E65707]">
+          Delete bot…
+        </button>
       </div>
     </div>
   );
@@ -1560,9 +1592,10 @@ function DeleteBotDialog({
 }: {
   bot: Bot;
   onCancel: () => void;
-  onConfirm: () => Promise<void>;
+  onConfirm: (deleteMemories: boolean) => Promise<void>;
 }) {
   const [deleting, setDeleting] = useState(false);
+  const [deleteMemories, setDeleteMemories] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -1593,9 +1626,40 @@ function DeleteBotDialog({
           Delete {bot.name}?
         </h2>
         <p id="delete-bot-description" className="mt-2 text-[14px] leading-6 text-[#9A9AA0]">
-          This permanently deletes its conversation, computer, memory, and routines. Bots it created
-          stay in your list.
+          Its conversation, files, and routines will be permanently deleted. Bots it created stay in
+          your list.
         </p>
+        <fieldset className="mt-4 space-y-2">
+          <legend className="mb-2 text-[13.5px] text-[#C9C9CE]">What about its memories?</legend>
+          <label className="flex cursor-pointer gap-3 rounded-[11px] border border-[#343438] p-3">
+            <input
+              type="radio"
+              name="delete-memory"
+              checked={!deleteMemories}
+              onChange={() => setDeleteMemories(false)}
+            />
+            <span>
+              <span className="block text-[14px] text-[#ECECEE]">Keep memories</span>
+              <span className="mt-0.5 block text-[12.5px] text-[#85858A]">
+                Move them to your shared memory.
+              </span>
+            </span>
+          </label>
+          <label className="flex cursor-pointer gap-3 rounded-[11px] border border-[#343438] p-3">
+            <input
+              type="radio"
+              name="delete-memory"
+              checked={deleteMemories}
+              onChange={() => setDeleteMemories(true)}
+            />
+            <span>
+              <span className="block text-[14px] text-[#ECECEE]">Delete memories too</span>
+              <span className="mt-0.5 block text-[12.5px] text-[#85858A]">
+                This cannot be undone.
+              </span>
+            </span>
+          </label>
+        </fieldset>
         {error ? <p className="mt-3 text-[13.5px] text-[#FF5364]">{error}</p> : null}
         <div className="mt-5 flex justify-end gap-2.5">
           <button
@@ -1612,7 +1676,7 @@ function DeleteBotDialog({
             onClick={() => {
               setDeleting(true);
               setError(null);
-              void onConfirm().catch((err: unknown) => {
+              void onConfirm(deleteMemories).catch((err: unknown) => {
                 setError(err instanceof Error ? err.message : "Could not delete bot");
                 setDeleting(false);
               });

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -1,6 +1,11 @@
 import type { ConnectorTool } from "@rakazo/adapter-kit";
 
-export const DELEGATION_TOOL_NAMES = new Set(["run_subagent", "spawn_bot", "delete_bot"]);
+export const DELEGATION_TOOL_NAMES = new Set([
+  "run_subagent",
+  "spawn_bot",
+  "archive_bot",
+  "delete_bot",
+]);
 
 export const builtinAgentTools: ConnectorTool[] = [
   {
@@ -174,17 +179,17 @@ export const builtinAgentTools: ConnectorTool[] = [
     },
   },
   {
-    name: "delete_bot",
+    name: "archive_bot",
     description:
-      "Permanently delete a bot this bot created, including its thread, computer, memory, and files. Only do this when the user asked or that bot is finished and unused. confirm_name must exactly match its name. This cannot delete you, bots the user created, or bots another bot created.",
+      "Archive a bot this bot created. Archiving stops its work and routines, hides it from the active list, and preserves its conversation, memory, and files for the user to restore or delete later. confirm_name must exactly match its name. This cannot archive you, bots the user created, or bots another bot created.",
     inputSchema: {
       type: "object",
       properties: {
-        confirm_name: { type: "string", description: "Exact current name of the bot to delete." },
+        confirm_name: { type: "string", description: "Exact current name of the bot to archive." },
         bot_id: {
           type: "string",
           description:
-            "Optional bot id. If omitted, the unique bot this bot created with confirm_name is deleted.",
+            "Optional bot id. If omitted, the unique bot this bot created with confirm_name is archived.",
         },
       },
       required: ["confirm_name"],

--- a/packages/adapters/src/child-bots.test.ts
+++ b/packages/adapters/src/child-bots.test.ts
@@ -1,7 +1,26 @@
-import type { JobPublisher } from "@rakazo/adapter-kit";
+import type {
+  AdapterContext,
+  AgentHomeStore,
+  JobPublisher,
+  SandboxProvider,
+} from "@rakazo/adapter-kit";
 import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
-import { confirmSpawnedBotName, spawnBot } from "./child-bots.js";
+import {
+  archiveBot,
+  archiveSpawnedBot,
+  confirmSpawnedBotName,
+  destroyBot,
+  spawnBot,
+} from "./child-bots.js";
+
+const context = {
+  operationId: "test",
+  traceId: "test",
+  workspaceId: "workspace-1",
+  userId: "user-1",
+  signal: new AbortController().signal,
+} satisfies AdapterContext;
 
 describe("spawned bot creation", () => {
   it("returns the existing child when a spawn is retried", async () => {
@@ -63,8 +82,7 @@ describe("spawned bot creation", () => {
     expect(enqueue).toHaveBeenCalledOnce();
   });
 });
-
-describe("spawned bot deletion", () => {
+describe("spawned bot archival", () => {
   it("refuses when confirm_name does not match exactly", () => {
     expect(confirmSpawnedBotName("scout", "Scout")).toMatchObject({ ok: false });
     expect(confirmSpawnedBotName("Scout ", "Scout")).toMatchObject({ ok: false });
@@ -72,5 +90,314 @@ describe("spawned bot deletion", () => {
 
   it("accepts an exact name match", () => {
     expect(confirmSpawnedBotName("Scout", "Scout")).toEqual({ ok: true });
+  });
+
+  it("reconciles a retry when the child is already archived", async () => {
+    const archivedAt = new Date("2026-08-16T12:00:00.000Z");
+    const prisma = {
+      bot: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "child-1",
+            workspaceId: "workspace-1",
+            userId: "user-1",
+            parentBotId: "parent-1",
+            name: "Scout",
+            archivedAt,
+          },
+        ]),
+      },
+      computer: { findUnique: vi.fn().mockResolvedValue(null) },
+      run: { findMany: vi.fn().mockResolvedValue([]) },
+      routine: { findMany: vi.fn().mockResolvedValue([]) },
+      $transaction: vi.fn(async (callback: (tx: unknown) => Promise<void>) =>
+        callback({
+          run: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+          task: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+          routine: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+          computer: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+          bot: { update: vi.fn().mockResolvedValue({}) },
+        }),
+      ),
+    } as unknown as PrismaClient;
+
+    await expect(
+      archiveSpawnedBot(
+        {
+          prisma,
+          sandbox: {} as SandboxProvider,
+          home: {} as AgentHomeStore,
+          jobs: { cancel: vi.fn() } as unknown as JobPublisher,
+        },
+        {
+          spawnedByBotId: "parent-1",
+          userId: "user-1",
+          workspaceId: "workspace-1",
+          confirmName: "Scout",
+          botId: "child-1",
+        },
+        context,
+      ),
+    ).resolves.toMatchObject({ ok: true, botId: "child-1", name: "Scout" });
+  });
+});
+
+describe("destroyBot", () => {
+  it("moves bot memories into shared memory before the cascading delete", async () => {
+    const createDeletion = vi.fn().mockResolvedValue({});
+    const deleteBot = vi.fn().mockResolvedValue({});
+    const executeRaw = vi.fn().mockResolvedValue(1);
+    const releaseComputers = vi.fn().mockResolvedValue({ count: 1 });
+    const transaction = vi.fn(async (callback: (tx: unknown) => Promise<void>) =>
+      callback({
+        computer: { updateMany: releaseComputers },
+        $executeRaw: executeRaw,
+        botDeletion: { create: createDeletion },
+        bot: { delete: deleteBot },
+      }),
+    );
+    const prisma = {
+      bot: {
+        findUnique: vi.fn(),
+      },
+      computer: { findUnique: vi.fn().mockResolvedValue(null) },
+      run: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      routine: { findMany: vi.fn().mockResolvedValue([]) },
+      $transaction: transaction,
+    } as unknown as PrismaClient;
+
+    await destroyBot(
+      {
+        prisma,
+        sandbox: {} as SandboxProvider,
+        home: {} as AgentHomeStore,
+        jobs: { cancel: vi.fn() } as unknown as JobPublisher,
+      },
+      { id: "bot-1", workspaceId: "workspace-1", name: "Researcher", archivedAt: null },
+      context,
+      { deleteMemories: false },
+    );
+
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(releaseComputers).toHaveBeenCalledWith({
+      where: {
+        OR: [{ controlBotId: "bot-1" }, { executionBotId: "bot-1" }],
+      },
+      data: expect.objectContaining({
+        controlHolder: "none",
+        controlBotId: null,
+        executionBotId: null,
+      }),
+    });
+    expect(executeRaw).toHaveBeenCalledOnce();
+    expect(executeRaw.mock.calls[0]?.slice(1)).toEqual([
+      "Archived bots/Researcher (bot-1)",
+      "bot-1",
+    ]);
+    expect(createDeletion).toHaveBeenCalledWith({
+      data: {
+        id: "bot-1",
+        workspaceId: "workspace-1",
+        name: "Researcher",
+        deletedByUserId: "user-1",
+        memoriesPreserved: true,
+      },
+    });
+    expect(deleteBot).toHaveBeenCalledWith({ where: { id: "bot-1" } });
+  });
+
+  it("surfaces transaction failures instead of reporting deletion success", async () => {
+    const transaction = vi.fn().mockRejectedValue(new Error("delete failed"));
+    const prisma = {
+      bot: {
+        findUnique: vi.fn(),
+      },
+      computer: { findUnique: vi.fn().mockResolvedValue(null) },
+      run: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      routine: { findMany: vi.fn().mockResolvedValue([]) },
+      $transaction: transaction,
+    } as unknown as PrismaClient;
+
+    await expect(
+      destroyBot(
+        {
+          prisma,
+          sandbox: {} as SandboxProvider,
+          home: {} as AgentHomeStore,
+          jobs: { cancel: vi.fn() } as unknown as JobPublisher,
+          dataDir: "/tmp/rakazo-destroy-bot-test",
+        },
+        { id: "bot-1", workspaceId: "workspace-1", name: "Researcher", archivedAt: null },
+        context,
+        { deleteMemories: true },
+      ),
+    ).rejects.toThrow("delete failed");
+  });
+});
+
+describe("archiveBot", () => {
+  it("stops work and routines while preserving the bot", async () => {
+    const updateBot = vi.fn().mockResolvedValue({});
+    const disableRoutines = vi.fn().mockResolvedValue({ count: 2 });
+    const transaction = vi.fn(async (callback: (tx: unknown) => Promise<void>) =>
+      callback({
+        run: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+        task: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+        routine: { updateMany: disableRoutines },
+        computer: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        bot: { update: updateBot },
+      }),
+    );
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const prisma = {
+      bot: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "bot-1",
+          workspaceId: "workspace-1",
+          archivedAt: null,
+        }),
+      },
+      computer: { findUnique: vi.fn().mockResolvedValue(null) },
+      run: { findMany: vi.fn().mockResolvedValue([{ id: "run-1" }]) },
+      routine: { findMany: vi.fn().mockResolvedValue([]) },
+      $transaction: transaction,
+    } as unknown as PrismaClient;
+
+    await archiveBot(
+      {
+        prisma,
+        sandbox: {} as SandboxProvider,
+        home: {} as AgentHomeStore,
+        jobs: { cancel } as unknown as JobPublisher,
+      },
+      { id: "bot-1", workspaceId: "workspace-1", name: "Researcher", archivedAt: null },
+      context,
+    );
+
+    expect(disableRoutines).toHaveBeenCalledWith({
+      where: { botId: "bot-1" },
+      data: { active: false, nextRunAt: null },
+    });
+    expect(updateBot).toHaveBeenCalledWith({
+      where: { id: "bot-1" },
+      data: { archivedAt: expect.any(Date), pinned: false },
+    });
+    expect(cancel).toHaveBeenCalledWith("run:run-1");
+  });
+
+  it("surfaces computer stop failures and leaves the provider state retryable", async () => {
+    const archivedAt = new Date("2026-08-16T12:00:00.000Z");
+    const updateComputer = vi.fn().mockResolvedValue({});
+    const transaction = vi.fn(async (callback: (tx: unknown) => Promise<void>) =>
+      callback({
+        run: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        task: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        routine: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        computer: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+        bot: { update: vi.fn().mockResolvedValue({}) },
+      }),
+    );
+    const dedicated = {
+      id: "computer-1",
+      homeKey: "bot-1",
+      kind: "cloud",
+      providerRef: "provider-1",
+      state: "running",
+    };
+    const stop = vi.fn().mockRejectedValue(new Error("stop failed"));
+    const prisma = {
+      computer: {
+        findUnique: vi.fn().mockResolvedValue(dedicated),
+        update: updateComputer,
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      run: { findMany: vi.fn().mockResolvedValue([]) },
+      routine: { findMany: vi.fn().mockResolvedValue([]) },
+      $transaction: transaction,
+    } as unknown as PrismaClient;
+    const sandbox = {
+      exportWorkspace: async function* () {},
+      stop,
+    } as unknown as SandboxProvider;
+    const home = {
+      commit: vi.fn().mockResolvedValue("revision-1"),
+    } as unknown as AgentHomeStore;
+
+    await expect(
+      archiveBot(
+        {
+          prisma,
+          sandbox,
+          home,
+          jobs: { cancel: vi.fn() } as unknown as JobPublisher,
+        },
+        { id: "bot-1", workspaceId: "workspace-1", name: "Researcher", archivedAt },
+        context,
+      ),
+    ).rejects.toThrow("stop failed");
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(updateComputer).not.toHaveBeenCalled();
+  });
+
+  it("stops a provider that finishes booting while the bot is archived", async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const booting = {
+      id: "computer-1",
+      homeKey: "bot-1",
+      kind: "cloud",
+      providerRef: null,
+      state: "booting",
+    };
+    const running = { ...booting, providerRef: "provider-1", state: "running" };
+    const transaction = vi.fn(async (callback: (tx: unknown) => Promise<void>) =>
+      callback({
+        run: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        task: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        routine: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        computer: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+        bot: { update: vi.fn().mockResolvedValue({}) },
+      }),
+    );
+    const prisma = {
+      computer: {
+        findUnique: vi.fn().mockResolvedValueOnce(booting).mockResolvedValueOnce(running),
+        updateMany,
+      },
+      run: { findMany: vi.fn().mockResolvedValue([]) },
+      routine: { findMany: vi.fn().mockResolvedValue([]) },
+      $transaction: transaction,
+    } as unknown as PrismaClient;
+    const sandbox = {
+      exportWorkspace: async function* () {},
+      stop,
+    } as unknown as SandboxProvider;
+    const home = {
+      commit: vi.fn().mockResolvedValue("revision-1"),
+    } as unknown as AgentHomeStore;
+
+    await archiveBot(
+      {
+        prisma,
+        sandbox,
+        home,
+        jobs: { cancel: vi.fn() } as unknown as JobPublisher,
+      },
+      { id: "bot-1", workspaceId: "workspace-1", name: "Researcher", archivedAt: null },
+      context,
+    );
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(updateMany).toHaveBeenLastCalledWith({
+      where: { id: "computer-1", state: "running", providerRef: "provider-1" },
+      data: { state: "stopped" },
+    });
   });
 });

--- a/packages/adapters/src/child-bots.ts
+++ b/packages/adapters/src/child-bots.ts
@@ -5,7 +5,7 @@ import type {
   JobPublisher,
   SandboxProvider,
 } from "@rakazo/adapter-kit";
-import { runContinueJob } from "@rakazo/adapter-kit";
+import { routineJobKey, runContinueJob, runJobKey } from "@rakazo/adapter-kit";
 import type { Actor, Bot } from "@rakazo/contracts";
 import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
 import {
@@ -15,14 +15,14 @@ import {
   type PrismaClient,
 } from "@rakazo/db";
 import { toComputerRef } from "./computer-support.js";
+import { checkpointAndRecordComputerWorkspace } from "./computer-workspace.js";
 import { resolveAgentHomePath } from "./home.js";
 
 export function confirmSpawnedBotName(confirmName: string, botName: string) {
   if (confirmName !== botName) {
     return {
       ok: false as const,
-      error:
-        "confirm_name must exactly match the bot's name. Refusing to delete. This is permanent — double-check before retrying.",
+      error: "confirm_name must exactly match the bot's name. Refusing to archive.",
     };
   }
   return { ok: true as const };
@@ -181,13 +181,23 @@ async function ensureSpawnRun(
   }
 }
 
-export async function deleteSpawnedBot(
-  deps: {
-    prisma: PrismaClient;
-    sandbox: SandboxProvider;
-    home: AgentHomeStore;
-    dataDir?: string;
-  },
+type BotLifecycleDeps = {
+  prisma: PrismaClient;
+  sandbox: SandboxProvider;
+  home: AgentHomeStore;
+  jobs: JobPublisher;
+  dataDir?: string;
+};
+
+type LifecycleBot = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  archivedAt: Date | null;
+};
+
+export async function archiveSpawnedBot(
+  deps: BotLifecycleDeps,
   input: {
     spawnedByBotId: string;
     userId: string;
@@ -199,7 +209,7 @@ export async function deleteSpawnedBot(
 ) {
   const confirmName = input.confirmName.trim();
   if (!confirmName) {
-    return { error: "confirm_name is required. Refusing to delete." };
+    return { error: "confirm_name is required. Refusing to archive." };
   }
 
   const spawned = await deps.prisma.bot.findMany({
@@ -214,10 +224,10 @@ export async function deleteSpawnedBot(
     : spawned.filter((bot) => bot.name === confirmName);
 
   if (input.botId && matches.length === 0) {
-    return { error: "That bot was not created by this bot. Refusing to delete." };
+    return { error: "That bot was not created by this bot. Refusing to archive." };
   }
   if (!input.botId && matches.length === 0) {
-    return { error: `This bot did not create a bot named "${confirmName}". Refusing to delete.` };
+    return { error: `This bot did not create a bot named "${confirmName}". Refusing to archive.` };
   }
   if (!input.botId && matches.length > 1) {
     return {
@@ -229,48 +239,165 @@ export async function deleteSpawnedBot(
   const confirmed = confirmSpawnedBotName(confirmName, target.name);
   if (!confirmed.ok) return confirmed;
   if (target.id === input.spawnedByBotId) {
-    return { error: "A bot cannot delete itself with delete_bot." };
+    return { error: "A bot cannot archive itself with archive_bot." };
   }
 
-  await destroyBot(deps, target.id, context);
+  await archiveBot(deps, target, context);
   return { ok: true as const, botId: target.id, name: target.name };
 }
 
-export async function destroyBot(
-  deps: {
-    prisma: PrismaClient;
-    sandbox: SandboxProvider;
-    home: AgentHomeStore;
-    dataDir?: string;
-  },
-  botId: string,
+export async function archiveBot(
+  deps: BotLifecycleDeps,
+  bot: LifecycleBot,
   context: AdapterContext,
 ) {
-  const bot = await deps.prisma.bot.findUnique({
-    where: { id: botId },
+  const [dedicated, activeRuns, activeRoutines] = await Promise.all([
+    deps.prisma.computer.findUnique({
+      where: { scopeKey: computerScopeKey("dedicated", bot.workspaceId, bot.id) },
+    }),
+    deps.prisma.run.findMany({
+      where: { botId: bot.id, status: { in: [...ACTIVE_RUN_STATUSES] } },
+      select: { id: true },
+    }),
+    deps.prisma.routine.findMany({
+      where: { botId: bot.id, active: true },
+      select: { id: true },
+    }),
+  ]);
+  const runIds = activeRuns.map((run) => run.id);
+  const now = new Date();
+  await deps.prisma.$transaction(async (tx) => {
+    await tx.run.updateMany({
+      where: { id: { in: runIds } },
+      data: { status: "cancelled", completedAt: now },
+    });
+    await tx.task.updateMany({
+      where: { runs: { some: { id: { in: runIds } } } },
+      data: { status: "cancelled" },
+    });
+    await tx.routine.updateMany({
+      where: { botId: bot.id },
+      data: { active: false, nextRunAt: null },
+    });
+    await tx.computer.updateMany({
+      where: {
+        OR: [{ controlBotId: bot.id }, { executionBotId: bot.id }],
+      },
+      data: releasedComputerLease(),
+    });
+    if (dedicated) {
+      await tx.computer.updateMany({
+        where: { id: dedicated.id, state: { not: "running" } },
+        data: { state: "stopped" },
+      });
+    }
+    await tx.bot.update({
+      where: { id: bot.id },
+      data: { archivedAt: bot.archivedAt ?? now, pinned: false },
+    });
   });
-  if (!bot) return;
-  const dedicated = await deps.prisma.computer.findUnique({
-    where: { scopeKey: computerScopeKey("dedicated", bot.workspaceId, botId) },
-  });
+  await Promise.allSettled([
+    ...activeRuns.map((run) => deps.jobs.cancel(runJobKey(run.id))),
+    ...activeRoutines.map((routine) => deps.jobs.cancel(routineJobKey(routine.id))),
+  ]);
+  const currentDedicated = dedicated
+    ? await deps.prisma.computer.findUnique({ where: { id: dedicated.id } })
+    : null;
+  if (currentDedicated?.providerRef && currentDedicated.state === "running") {
+    const ref = toComputerRef(currentDedicated);
+    await checkpointAndRecordComputerWorkspace(deps, currentDedicated, ref, context);
+    await deps.sandbox.stop(ref, context);
+    await deps.prisma.computer.updateMany({
+      where: {
+        id: currentDedicated.id,
+        state: "running",
+        providerRef: currentDedicated.providerRef,
+      },
+      data: { state: "stopped" },
+    });
+  }
+}
+
+export async function destroyBot(
+  deps: BotLifecycleDeps,
+  bot: LifecycleBot,
+  context: AdapterContext,
+  options: { deleteMemories: boolean },
+) {
+  const [dedicated, activeRuns, routines] = await Promise.all([
+    deps.prisma.computer.findUnique({
+      where: { scopeKey: computerScopeKey("dedicated", bot.workspaceId, bot.id) },
+    }),
+    deps.prisma.run.findMany({
+      where: { botId: bot.id, status: { in: [...ACTIVE_RUN_STATUSES] } },
+      select: { id: true },
+    }),
+    deps.prisma.routine.findMany({ where: { botId: bot.id }, select: { id: true } }),
+  ]);
+  const runIds = activeRuns.map((run) => run.id);
   await deps.prisma.run.updateMany({
-    where: {
-      botId,
-      status: { in: [...ACTIVE_RUN_STATUSES] },
-    },
+    where: { id: { in: runIds } },
     data: { status: "cancelled", completedAt: new Date() },
   });
+  await Promise.allSettled([
+    ...activeRuns.map((run) => deps.jobs.cancel(runJobKey(run.id))),
+    ...routines.map((routine) => deps.jobs.cancel(routineJobKey(routine.id))),
+  ]);
   if (dedicated?.providerRef) {
     await deps.sandbox.destroy(toComputerRef(dedicated), context).catch(() => undefined);
   }
-  if (dedicated) {
-    await deps.prisma.computer.delete({ where: { id: dedicated.id } }).catch(() => undefined);
-  }
-  await deps.prisma.bot.delete({ where: { id: botId } }).catch(() => undefined);
+  await deps.prisma.$transaction(async (tx) => {
+    await tx.computer.updateMany({
+      where: {
+        ...(dedicated ? { id: { not: dedicated.id } } : {}),
+        OR: [{ controlBotId: bot.id }, { executionBotId: bot.id }],
+      },
+      data: releasedComputerLease(),
+    });
+    if (!options.deleteMemories) {
+      const directory = archivedMemoryDirectory(bot.name, bot.id);
+      await tx.$executeRaw`
+        UPDATE "memory_documents"
+        SET "botId" = NULL,
+            "scope" = 'user',
+            "path" = ${directory} || '/' || "path",
+            "updatedAt" = CURRENT_TIMESTAMP
+        WHERE "botId" = ${bot.id}
+      `;
+    }
+    await tx.botDeletion.create({
+      data: {
+        id: bot.id,
+        workspaceId: bot.workspaceId,
+        name: bot.name,
+        deletedByUserId: context.userId,
+        memoriesPreserved: !options.deleteMemories,
+      },
+    });
+    await tx.bot.delete({ where: { id: bot.id } });
+    if (dedicated) await tx.computer.delete({ where: { id: dedicated.id } });
+  });
   if (dedicated) {
     await rm(resolveAgentHomePath(deps.home, dedicated.homeKey, deps.dataDir ?? "./data"), {
       recursive: true,
       force: true,
     }).catch(() => undefined);
   }
+}
+
+function archivedMemoryDirectory(name: string, botId: string) {
+  const safeName = name.replace(/[\\/]/g, "-").trim() || "Bot";
+  return `Archived bots/${safeName} (${botId})`;
+}
+
+function releasedComputerLease() {
+  return {
+    controlHolder: "none" as const,
+    controlLeaseId: null,
+    controlLeaseExpiresAt: null,
+    controlBotId: null,
+    executionRunId: null,
+    executionBotId: null,
+    executionLeaseExpiresAt: null,
+  };
 }

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -1,10 +1,94 @@
-import type { PrismaClient } from "@rakazo/db";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  AdapterContext,
+  AgentHomeStore,
+  JobPublisher,
+  SandboxProvider,
+} from "@rakazo/adapter-kit";
+import type { PrismaClient, ThreadEvents } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireComputerExecutionLease,
+  provisionComputer,
   releaseComputerExecutionLease,
   renewComputerExecutionLease,
 } from "./computer-lifecycle.js";
+
+const context = {
+  operationId: "test",
+  traceId: "test",
+  workspaceId: "workspace-1",
+  userId: "user-1",
+  botId: "bot-1",
+  signal: new AbortController().signal,
+} satisfies AdapterContext;
+
+describe("computer provisioning", () => {
+  it("stops a provider when archive invalidates its boot claim", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-provision-race-"));
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 0 });
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "provider-1",
+          kind: "cloud",
+          scope: "dedicated",
+          state: "stopped",
+          controlLeaseId: null,
+        }),
+        updateMany,
+      },
+    } as unknown as PrismaClient;
+    const sandbox = {
+      provision: vi.fn().mockResolvedValue({
+        id: "provider-1",
+        botId: "bot-1",
+        kind: "cloud",
+        providerRef: "provider-1",
+      }),
+      stop,
+    } as unknown as SandboxProvider;
+
+    try {
+      await expect(
+        provisionComputer(
+          {
+            prisma,
+            sandbox,
+            home: {} as AgentHomeStore,
+            jobs: {} as JobPublisher,
+            events: {} as ThreadEvents,
+            dataDir,
+          },
+          "computer-1",
+          context,
+        ),
+      ).rejects.toThrow("Computer is busy");
+      expect(stop).toHaveBeenCalledOnce();
+      expect(updateMany).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          where: {
+            id: "computer-1",
+            state: "booting",
+            bots: { some: { id: "bot-1", archivedAt: null } },
+          },
+        }),
+      );
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("computer execution leases", () => {
   it("does not serialize dedicated computers", async () => {

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -46,7 +46,11 @@ export async function provisionComputer(
   const homePath = resolveAgentHomePath(deps.home, existing.homeKey, deps.dataDir ?? "./data");
   await mkdir(homePath, { recursive: true });
   const claimed = await deps.prisma.computer.updateMany({
-    where: { id: computerId, state: { not: "suspending" } },
+    where: {
+      id: computerId,
+      state: { not: "suspending" },
+      ...(context.botId ? { bots: { some: { id: context.botId, archivedAt: null } } } : {}),
+    },
     data: { state: "booting" },
   });
   if (claimed.count !== 1) throw new ComputerBusyError();
@@ -78,8 +82,12 @@ export async function provisionComputer(
       context,
     );
     const activeControl = hasActiveComputerControl(existing);
-    await deps.prisma.computer.update({
-      where: { id: computerId },
+    const activated = await deps.prisma.computer.updateMany({
+      where: {
+        id: computerId,
+        state: "booting",
+        ...(context.botId ? { bots: { some: { id: context.botId, archivedAt: null } } } : {}),
+      },
       data: {
         state: "running",
         providerRef: ref.providerRef,
@@ -90,11 +98,15 @@ export async function provisionComputer(
           : {}),
       },
     });
+    if (activated.count !== 1) {
+      await deps.sandbox.stop(ref, context).catch(() => deps.sandbox.destroy(ref, context));
+      throw new ComputerBusyError();
+    }
     return ref;
   } catch (error) {
     if (provisioned?.fresh) await deps.sandbox.destroy(provisioned, context).catch(() => undefined);
     await deps.prisma.computer.updateMany({
-      where: { id: computerId },
+      where: { id: computerId, state: "booting" },
       data: { state: "error" },
     });
     throw error;

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -29,7 +29,7 @@ import {
   type ThreadEvents,
 } from "@rakazo/db";
 import { builtinAgentTools } from "./builtin-tools.js";
-import { deleteSpawnedBot, spawnBot } from "./child-bots.js";
+import { archiveSpawnedBot, spawnBot } from "./child-bots.js";
 import { collectLogIds } from "./composio-connector.js";
 import { scheduleComputerSleep } from "./computer-idle.js";
 import {
@@ -377,7 +377,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             if (applied.effect.status === "completed") {
               return applied.effect.result ?? { duplicate: true };
             }
-            if (name !== "spawn_bot") {
+            if (name !== "spawn_bot" && name !== "archive_bot" && name !== "delete_bot") {
               throw new Error(`tool ${name} has an earlier execution with an uncertain outcome`);
             }
           }
@@ -595,8 +595,8 @@ export function createRunExecutor(deps: ExecutorDeps) {
             }
             return spawned;
           }
-          if (name === "delete_bot") {
-            const removed = await deleteSpawnedBot(
+          if (name === "archive_bot" || name === "delete_bot") {
+            const archived = await archiveSpawnedBot(
               deps,
               {
                 spawnedByBotId: bot.id,
@@ -611,24 +611,29 @@ export function createRunExecutor(deps: ExecutorDeps) {
               },
               context,
             );
-            if ("error" in removed) return finish(removed);
-            await publishMessage(deps, run, "bot", [
-              {
-                kind: "child_bot",
-                botId: removed.botId,
-                name: removed.name,
-                status: "deleted",
-              },
-            ]);
-            await deps.events.append({
-              workspaceId: run.workspaceId,
-              threadId: thread.id,
-              botId: bot.id,
-              runId: run.id,
-              type: "bot.deleted",
-              payload: { childBotId: removed.botId, name: removed.name },
-            });
-            return finish(removed);
+            if ("error" in archived) return finish(archived);
+            await finish(archived);
+            try {
+              await publishMessage(deps, run, "bot", [
+                {
+                  kind: "child_bot",
+                  botId: archived.botId,
+                  name: archived.name,
+                  status: "archived",
+                },
+              ]);
+              await deps.events.append({
+                workspaceId: run.workspaceId,
+                threadId: thread.id,
+                botId: bot.id,
+                runId: run.id,
+                type: "bot.archived",
+                payload: { childBotId: archived.botId, name: archived.name },
+              });
+            } catch (error) {
+              console.error("archived bot notification", error);
+            }
+            return archived;
           }
           if (deps.connector) {
             let result: unknown = { error: `unknown tool ${name}` };
@@ -677,7 +682,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 "A bot and a subagent are different. Never use both for the same request.",
                 "spawn_bot creates a lasting regular bot (own chat, computer, memory) that appears in the user's bot list. If the user asked to create a bot, call spawn_bot once and stop. Do not run_subagent to demo it.",
                 "run_subagent is a short helper inside this turn only. It is not a bot, has no thread, and does not show in the list. Use it for parallel work you will summarize here.",
-                "delete_bot permanently destroys a bot this bot created, and only that bot. Only delete when the user asked or that bot is finished and unused. confirm_name must exactly match its name.",
+                "archive_bot safely archives a bot this bot created, and only that bot. Use it when the user asks to remove that bot or when it is finished and unused. The user can restore it or permanently delete it later. confirm_name must exactly match its name.",
                 pluginLine,
                 "Never print API keys, access tokens, or secret values. Prefer tools over claiming you already did the work.",
               ]

--- a/packages/adapters/src/index.test.ts
+++ b/packages/adapters/src/index.test.ts
@@ -86,11 +86,11 @@ describe("scripted runtime", () => {
     expect(types.at(-1)).toBe("done");
   });
 
-  it("deletes a spawned bot by exact name", () => {
+  it("archives a spawned bot by exact name", () => {
     const script = inferScript("delete the bot named Scout");
     expect(
       script?.some((t) =>
-        t.toolCalls?.some((c) => c.name === "delete_bot" && c.args.confirm_name === "Scout"),
+        t.toolCalls?.some((c) => c.name === "archive_bot" && c.args.confirm_name === "Scout"),
       ),
     ).toBe(true);
   });
@@ -107,7 +107,7 @@ describe("builtin tools", () => {
         "request_takeover",
         "run_subagent",
         "spawn_bot",
-        "delete_bot",
+        "archive_bot",
       ]),
     );
   });

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -325,7 +325,7 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
           prompt: raw.prompt ? String(raw.prompt) : "",
         };
       }
-      if (tool.name === "delete_bot") {
+      if (tool.name === "archive_bot" || tool.name === "delete_bot") {
         return {
           confirm_name: String(raw.confirm_name ?? raw.confirmName ?? ""),
           bot_id: raw.bot_id ? String(raw.bot_id) : raw.botId ? String(raw.botId) : "",
@@ -544,7 +544,7 @@ function parametersFor(tool: ConnectorTool) {
       prompt: Type.Optional(Type.String()),
     });
   }
-  if (tool.name === "delete_bot") {
+  if (tool.name === "archive_bot" || tool.name === "delete_bot") {
     return Type.Object({
       confirm_name: Type.String(),
       bot_id: Type.Optional(Type.String()),

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -156,8 +156,8 @@ export function inferScript(
     const name = namedBot(prompt) ?? "Scout";
     return [
       {
-        assistant: "removing that bot permanently.",
-        toolCalls: [{ name: "delete_bot", args: { confirm_name: name } }],
+        assistant: "archiving that bot.",
+        toolCalls: [{ name: "archive_bot", args: { confirm_name: name } }],
         complete: true,
       },
     ];

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -15,6 +15,7 @@ export const BotSchema = z.object({
   color: z.string(),
   notifyOnFinish: z.boolean(),
   pinned: z.boolean(),
+  archivedAt: z.string().nullable(),
   unread: z.boolean(),
   parentBotId: Id.nullable(),
   threadId: Id,

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -30,6 +30,7 @@ export const ProductEventType = z.enum([
   "effect.reconciled",
   "usage.recorded",
   "bot.spawned",
+  "bot.archived",
   "bot.deleted",
 ]);
 export type ProductEventType = z.infer<typeof ProductEventType>;
@@ -84,7 +85,7 @@ export const MessageBlock = z.discriminatedUnion("kind", [
     botId: z.string(),
     name: z.string(),
     title: z.string().optional(),
-    status: z.enum(["created", "deleted"]),
+    status: z.enum(["created", "archived", "deleted"]),
   }),
 ]);
 export type MessageBlock = z.infer<typeof MessageBlock>;

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -12,6 +12,8 @@ describe("contracts", () => {
     expect(appContract.models.beginOAuth).toBeTruthy();
     expect(appContract.models.completeOAuth).toBeTruthy();
     expect(appContract.bots.create).toBeTruthy();
+    expect(appContract.bots.archive).toBeTruthy();
+    expect(appContract.bots.restore).toBeTruthy();
     expect(appContract.bots.remove).toBeTruthy();
     expect(appContract.threads.subscribe).toBeTruthy();
     expect(appContract.notifications.registerPush).toBeTruthy();

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -99,12 +99,17 @@ export const appContract = {
   },
   bots: {
     list: oc.output(z.array(BotSchema)),
+    listArchived: oc.output(z.array(BotSchema)),
     get: oc.input(botId).output(BotSchema),
     create: oc.input(CreateBotInput).output(BotSchema),
     duplicate: oc.input(botId).output(BotSchema),
     update: oc.input(UpdateBotInput).output(BotSchema),
     setComputer: oc.input(z.object({ botId: Id, mode: ComputerModeSchema })).output(BotSchema),
-    remove: oc.input(botId).output(z.object({ ok: z.literal(true) })),
+    archive: oc.input(botId).output(z.object({ ok: z.literal(true) })),
+    restore: oc.input(botId).output(z.object({ ok: z.literal(true) })),
+    remove: oc
+      .input(z.object({ botId: Id, deleteMemories: z.boolean().default(false) }))
+      .output(z.object({ ok: z.literal(true) })),
   },
   threads: {
     get: oc.input(z.object({ botId: Id })).output(ThreadSnapshotSchema),

--- a/packages/db/prisma/migrations/0008_bot_deletions/migration.sql
+++ b/packages/db/prisma/migrations/0008_bot_deletions/migration.sql
@@ -1,0 +1,25 @@
+-- Archive is the safe default. Permanent deletion keeps a workspace-scoped audit
+-- record and can optionally preserve bot memory as shared user memory.
+ALTER TABLE "bots" ADD COLUMN "archivedAt" TIMESTAMP(3);
+
+CREATE TABLE "bot_deletions" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "deletedByUserId" TEXT NOT NULL,
+    "memoriesPreserved" BOOLEAN NOT NULL,
+    "deletedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "bot_deletions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "bot_deletions_workspaceId_deletedAt_idx"
+ON "bot_deletions"("workspaceId", "deletedAt");
+
+CREATE INDEX "bots_workspaceId_userId_archivedAt_pinned_updatedAt_idx"
+ON "bots"("workspaceId", "userId", "archivedAt", "pinned", "updatedAt");
+
+DROP INDEX "bots_workspaceId_userId_pinned_updatedAt_idx";
+
+ALTER TABLE "bot_deletions" ADD CONSTRAINT "bot_deletions_workspaceId_fkey"
+FOREIGN KEY ("workspaceId") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Organization {
   members     Member[]
   invitations Invitation[]
   bots        Bot[]
+  botDeletions BotDeletion[]
   threads     Thread[]
   events      Event[]
   tasks       Task[]
@@ -180,6 +181,7 @@ model Bot {
   color          String
   notifyOnFinish Boolean  @default(true)
   pinned         Boolean  @default(false)
+  archivedAt     DateTime?
   parentBotId    String?
   spawnKey       String?
   parent         Bot?     @relation("BotChildren", fields: [parentBotId], references: [id], onDelete: SetNull)
@@ -199,11 +201,24 @@ model Bot {
   tasks          Task[]
   runs           Run[]
 
-  @@index([workspaceId, userId, pinned, updatedAt])
+  @@index([workspaceId, userId, archivedAt, pinned, updatedAt])
   @@index([computerId])
   @@index([parentBotId])
   @@unique([workspaceId, spawnKey])
   @@map("bots")
+}
+
+model BotDeletion {
+  id                String   @id
+  workspaceId       String
+  workspace         Organization @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  name              String
+  deletedByUserId   String
+  memoriesPreserved Boolean
+  deletedAt         DateTime @default(now())
+
+  @@index([workspaceId, deletedAt])
+  @@map("bot_deletions")
 }
 
 model Thread {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -15,6 +15,7 @@ function mapBot(
     color: string;
     notifyOnFinish: boolean;
     pinned: boolean;
+    archivedAt: Date | null;
     parentBotId: string | null;
     createdAt: Date;
     updatedAt: Date;
@@ -37,6 +38,7 @@ function mapBot(
     color: bot.color,
     notifyOnFinish: bot.notifyOnFinish,
     pinned: bot.pinned,
+    archivedAt: bot.archivedAt?.toISOString() ?? null,
     unread: bot.thread.unread,
     parentBotId: bot.parentBotId,
     threadId: bot.thread.id,
@@ -50,9 +52,13 @@ function mapBot(
 
 export function createRepos(prisma: PrismaClient) {
   return {
-    async listBots(actor: Actor): Promise<Bot[]> {
+    async listBots(actor: Actor, options: { archived?: boolean } = {}): Promise<Bot[]> {
       const bots = await prisma.bot.findMany({
-        where: { workspaceId: actor.workspaceId, userId: actor.userId },
+        where: {
+          workspaceId: actor.workspaceId,
+          userId: actor.userId,
+          archivedAt: options.archived ? { not: null } : null,
+        },
         include: {
           thread: {
             include: {
@@ -80,9 +86,14 @@ export function createRepos(prisma: PrismaClient) {
       });
     },
 
-    async getBot(actor: Actor, botId: string) {
+    async getBot(actor: Actor, botId: string, options: { includeArchived?: boolean } = {}) {
       const bot = await prisma.bot.findFirst({
-        where: { id: botId, workspaceId: actor.workspaceId, userId: actor.userId },
+        where: {
+          id: botId,
+          workspaceId: actor.workspaceId,
+          userId: actor.userId,
+          ...(options.includeArchived ? {} : { archivedAt: null }),
+        },
         include: { thread: true, computer: true },
       });
       if (!bot) throw new IsolationError();

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -59,10 +59,13 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["models/completeOAuth", { loginId: "missing-login" }],
       ["models/setDefault", { provider: "test", modelId: "test/model" }],
       ["bots/list"],
+      ["bots/listArchived"],
       ["bots/get", { botId: "missing-bot" }],
       ["bots/create", botInput("Unauthenticated")],
       ["bots/duplicate", { botId: "missing-bot" }],
       ["bots/update", { botId: "missing-bot", name: "Nope" }],
+      ["bots/archive", { botId: "missing-bot" }],
+      ["bots/restore", { botId: "missing-bot" }],
       ["bots/remove", { botId: "missing-bot" }],
       ["threads/get", { botId: "missing-bot" }],
       ["threads/messages", { botId: "missing-bot", before: 1 }],
@@ -208,6 +211,8 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["bots/get", { botId: ownerBot.id }],
       ["bots/duplicate", { botId: ownerBot.id }],
       ["bots/update", { botId: ownerBot.id, name: "Stolen Bot" }],
+      ["bots/archive", { botId: ownerBot.id }],
+      ["bots/restore", { botId: ownerBot.id }],
       ["threads/get", { botId: ownerBot.id }],
       ["threads/messages", { botId: ownerBot.id, before: 1 }],
       ["threads/subscribe", { botId: ownerBot.id, cursor: -1 }],
@@ -301,7 +306,10 @@ describeWithDatabase("API authorization and resource isolation", () => {
     ).toMatchObject({ content: "owner-only-memory" });
 
     // Destructive bot removal is checked last so an authorization regression is unmistakable.
-    await expectDenied(app, intruder, "bots/remove", { botId: ownerBot.id });
+    await expectDenied(app, intruder, "bots/remove", {
+      botId: ownerBot.id,
+      deleteMemories: true,
+    });
     expect(await handles.prisma.bot.findUnique({ where: { id: ownerBot.id } })).not.toBeNull();
   });
 

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -526,7 +526,7 @@ describeJourneys("required product journeys", () => {
     expect(rawJson).not.toMatch(/browserProfile|ciphertext|sessionCookie/i);
   });
 
-  it("10: deleting a bot removes it, its home, and is isolated", async () => {
+  it("10: bots can be archived safely and deleted with or without their memories", async () => {
     const ada = await signup(app, `delete-j-${stamp}@rakazo.test`, "Delete Ada");
     const bob = await signup(app, `delete-bob-j-${stamp}@rakazo.test`, "Delete Bob");
     const keep = await rpc<Bot>(app, ada, "bots/create", {
@@ -544,6 +544,21 @@ describeJourneys("required product journeys", () => {
       notifyOnFinish: true,
       computerMode: "dedicated",
     });
+    const forget = await rpc<Bot>(app, ada, "bots/create", {
+      name: "Forget",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const goneMemory = await prisma.memoryDocument.findFirstOrThrow({ where: { botId: gone.id } });
+    const forgetMemory = await prisma.memoryDocument.findFirstOrThrow({
+      where: { botId: forget.id },
+    });
+    await prisma.memoryDocument.update({
+      where: { id: goneMemory.id },
+      data: { content: "important retained context" },
+    });
     await sendAndWait(
       app,
       ada,
@@ -553,17 +568,40 @@ describeJourneys("required product journeys", () => {
     const home = path.join(dataDir, "homes", gone.id);
     expect(existsSync(home)).toBe(true);
 
-    const stolen = await raw(app, bob, "bots/remove", { botId: gone.id });
+    const stolen = await raw(app, bob, "bots/archive", { botId: gone.id });
     expect(stolen.status).toBeGreaterThanOrEqual(400);
     expect((await rpc<Bot[]>(app, ada, "bots/list")).map((bot) => bot.id)).toContain(gone.id);
 
-    await rpc(app, ada, "bots/remove", { botId: gone.id });
+    await rpc(app, ada, "bots/archive", { botId: gone.id });
+    expect((await rpc<Bot[]>(app, ada, "bots/list")).map((bot) => bot.id)).not.toContain(gone.id);
+    expect((await rpc<Bot[]>(app, ada, "bots/listArchived")).map((bot) => bot.id)).toContain(
+      gone.id,
+    );
+    expect(existsSync(home)).toBe(true);
+
+    await rpc(app, ada, "bots/restore", { botId: gone.id });
+    expect((await rpc<Bot[]>(app, ada, "bots/list")).map((bot) => bot.id)).toContain(gone.id);
+
+    await rpc(app, ada, "bots/remove", { botId: gone.id, deleteMemories: false });
     const list = await rpc<Bot[]>(app, ada, "bots/list");
-    expect(list.map((bot) => bot.id)).toEqual([keep.id]);
+    expect(list.map((bot) => bot.id)).toEqual(expect.arrayContaining([keep.id, forget.id]));
     expect((await raw(app, ada, "bots/get", { botId: gone.id })).status).toBeGreaterThanOrEqual(
       400,
     );
+    expect(
+      await prisma.memoryDocument.findUniqueOrThrow({ where: { id: goneMemory.id } }),
+    ).toMatchObject({
+      botId: null,
+      scope: "user",
+      content: "important retained context",
+    });
+    expect(await prisma.botDeletion.findUniqueOrThrow({ where: { id: gone.id } })).toMatchObject({
+      memoriesPreserved: true,
+    });
     expect(existsSync(home)).toBe(false);
+
+    await rpc(app, ada, "bots/remove", { botId: forget.id, deleteMemories: true });
+    expect(await prisma.memoryDocument.findUnique({ where: { id: forgetMemory.id } })).toBeNull();
   });
 
   it("11: deleting an account removes the user and personal workspace data", async () => {


### PR DESCRIPTION
Closes #30

## Summary
- make Archive the safe, reversible removal path while preserving chat, files, routines, and memory
- make permanent Delete explicitly choose whether bot memories move to shared user memory or are deleted too
- add simple web and mobile controls for archive, restore, and permanent deletion
- keep a workspace-scoped audit of permanent deletion and safely cancel runs, jobs, leases, and computers
- make agent-triggered removal archive-only and replay-safe

## Verification
- 19/19 workspace type checks
- 298 unit tests passed, 39 skipped
- 34/34 fresh-Postgres integration and authorization journeys
- 11/11 Chromium E2E journeys
- production build and Biome checks
- final independent blocker review: no remaining blockers