### PR TITLE
Bound model-facing RPC text inputs

### DIFF
--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -2,6 +2,11 @@ import * as z from "zod";
 import { ThreadMessageSchema } from "./events.js";
 import { Id, MemoryScope, RunStatus, SandboxKind } from "./ids.js";
 
+export const MAX_MODEL_INPUT_CHARS = 20_000;
+export const ModelInputText = z.string().min(1).max(MAX_MODEL_INPUT_CHARS);
+export const MemoryContentInput = z.string().max(MAX_MODEL_INPUT_CHARS);
+const RoutineNameInput = z.string().min(1).max(80);
+
 export const BotSchema = z.object({
   id: Id,
   workspaceId: Id,
@@ -60,12 +65,22 @@ export type Routine = z.infer<typeof RoutineSchema>;
 
 export const CreateRoutineInput = z.object({
   botId: Id,
-  name: z.string().min(1).max(80),
-  prompt: z.string().min(1),
+  name: RoutineNameInput,
+  prompt: ModelInputText,
   cron: z.string().min(1),
   timezone: z.string().default("UTC"),
   notify: z.boolean().default(true),
   active: z.boolean().default(false),
+});
+
+export const UpdateRoutineInput = z.object({
+  routineId: Id,
+  name: RoutineNameInput.optional(),
+  prompt: ModelInputText.optional(),
+  cron: z.string().min(1).optional(),
+  timezone: z.string().optional(),
+  active: z.boolean().optional(),
+  notify: z.boolean().optional(),
 });
 
 export const MemoryDocumentSchema = z.object({

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { appContract, CreateBotInput, ProductEventType } from "./index.js";
+import {
+  appContract,
+  CreateBotInput,
+  CreateRoutineInput,
+  MAX_MODEL_INPUT_CHARS,
+  MemoryContentInput,
+  ModelInputText,
+  ProductEventType,
+  UpdateRoutineInput,
+} from "./index.js";
 
 describe("contracts", () => {
   it("parses bot create input", () => {
@@ -19,4 +28,58 @@ describe("contracts", () => {
     expect(ProductEventType.options).toContain("thread.subagent");
     expect(ProductEventType.options).toContain("bot.spawned");
   });
+
+  it("bounds every model-facing free-text input", () => {
+    const maximum = "x".repeat(MAX_MODEL_INPUT_CHARS);
+    const oversized = `${maximum}x`;
+
+    expect(ModelInputText.safeParse(maximum).success).toBe(true);
+    expect(ModelInputText.safeParse(oversized).success).toBe(false);
+    expect(MemoryContentInput.safeParse("").success).toBe(true);
+    expect(MemoryContentInput.safeParse(oversized).success).toBe(false);
+    expect(
+      CreateRoutineInput.safeParse({
+        botId: "bot",
+        name: "Daily check",
+        prompt: oversized,
+        cron: "0 9 * * *",
+      }).success,
+    ).toBe(false);
+    expect(UpdateRoutineInput.safeParse({ routineId: "routine", prompt: oversized }).success).toBe(
+      false,
+    );
+
+    const rpcInputs: Array<[unknown, Record<string, unknown>]> = [
+      [appContract.threads.send, { botId: "bot", text: oversized }],
+      [appContract.threads.followUp, { botId: "bot", text: oversized }],
+      [appContract.threads.answer, { botId: "bot", runId: "run", answer: oversized }],
+      [appContract.memory.update, { documentId: "memory", content: oversized }],
+      [
+        appContract.routines.create,
+        { botId: "bot", name: "Daily check", prompt: oversized, cron: "0 9 * * *" },
+      ],
+      [appContract.routines.update, { routineId: "routine", prompt: oversized }],
+    ];
+    for (const [procedure, input] of rpcInputs) {
+      expect(parseRpcInput(procedure, input).success).toBe(false);
+    }
+  });
+
+  it("applies the create-time routine name constraints to updates", () => {
+    expect(UpdateRoutineInput.safeParse({ routineId: "routine", name: "" }).success).toBe(false);
+    expect(
+      UpdateRoutineInput.safeParse({ routineId: "routine", name: "x".repeat(81) }).success,
+    ).toBe(false);
+    expect(
+      UpdateRoutineInput.safeParse({ routineId: "routine", name: "Daily check" }).success,
+    ).toBe(true);
+  });
 });
+
+function parseRpcInput(procedure: unknown, input: unknown): { success: boolean } {
+  return (
+    procedure as {
+      "~orpc": { inputSchema: { safeParse(value: unknown): { success: boolean } } };
+    }
+  )["~orpc"].inputSchema.safeParse(input);
+}

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -11,13 +11,16 @@ import {
   CreateRoutineInput,
   DeploymentSettingsSchema,
   ExportManifestSchema,
+  MemoryContentInput,
   MemoryDocumentSchema,
   MeSchema,
   ModelCredentialSchema,
+  ModelInputText,
   RoutineSchema,
   ThreadMessagePageSchema,
   ThreadSnapshotSchema,
   UpdateBotInput,
+  UpdateRoutineInput,
   UsageRecordSchema,
 } from "./domain.js";
 import { ProductEventSchema } from "./events.js";
@@ -116,17 +119,17 @@ export const appContract = {
       .input(
         z.object({
           botId: Id,
-          text: z.string().min(1),
+          text: ModelInputText,
           clientNonce: z.string().optional(),
         }),
       )
       .output(z.object({ taskId: Id, runId: Id, seq: z.number().int() })),
     stop: oc.input(botId).output(z.object({ ok: z.literal(true) })),
     followUp: oc
-      .input(z.object({ botId: Id, text: z.string().min(1) }))
+      .input(z.object({ botId: Id, text: ModelInputText }))
       .output(z.object({ ok: z.literal(true) })),
     answer: oc
-      .input(z.object({ botId: Id, runId: Id, answer: z.string().min(1) }))
+      .input(z.object({ botId: Id, runId: Id, answer: ModelInputText }))
       .output(z.object({ ok: z.literal(true) })),
     markRead: oc.input(botId).output(z.object({ ok: z.literal(true) })),
     markUnread: oc.input(botId).output(z.object({ ok: z.literal(true) })),
@@ -162,26 +165,14 @@ export const appContract = {
       .input(z.object({ botId: Id.optional(), scope: z.enum(["bot", "user"]).optional() }))
       .output(z.array(MemoryDocumentSchema)),
     update: oc
-      .input(z.object({ documentId: Id, content: z.string() }))
+      .input(z.object({ documentId: Id, content: MemoryContentInput }))
       .output(MemoryDocumentSchema),
     exportMarkdown: oc.input(z.object({ botId: Id.optional() })).output(z.string()),
   },
   routines: {
     list: oc.input(botId).output(z.array(RoutineSchema)),
     create: oc.input(CreateRoutineInput).output(RoutineSchema),
-    update: oc
-      .input(
-        z.object({
-          routineId: Id,
-          name: z.string().optional(),
-          prompt: z.string().optional(),
-          cron: z.string().optional(),
-          timezone: z.string().optional(),
-          active: z.boolean().optional(),
-          notify: z.boolean().optional(),
-        }),
-      )
-      .output(RoutineSchema),
+    update: oc.input(UpdateRoutineInput).output(RoutineSchema),
     remove: oc.input(z.object({ routineId: Id })).output(z.object({ ok: z.literal(true) })),
     testRun: oc.input(z.object({ routineId: Id })).output(z.object({ runId: Id })),
   },


### PR DESCRIPTION
Closes #33

## Summary
- cap thread messages, follow-ups, and answers at 20,000 characters
- apply the same bound to memory updates and routine create/update prompts
- share routine update schemas with create-time constraints so updates cannot bypass them
- add direct RPC contract boundary coverage for every affected input

## Tests
- `vitest run packages/contracts/src` (4 tests passed)
- `tsc --noEmit -p packages/contracts/tsconfig.json`
- Biome check and `git diff --check`