### PR TITLE
Add daily data retention sweeps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ SANDBOX_SUPERVISOR_TOKEN=
 SANDBOX_PROVIDER=docker
 AGENT_RUNTIME=pi
 WAKEUP_DRIVER=graphile
+# Delete events, messages, and memory revision history older than this many days. Set 0 to disable.
+DATA_RETENTION_DAYS=90
 # Pause E2B (or stop Docker) computers after this many idle ms. Minimum 30000.
 SANDBOX_IDLE_MS=600000
 OPENROUTER_API_KEY=

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -22,7 +22,12 @@ import {
   ScriptedAgentRuntime,
 } from "@rakazo/adapters";
 import { resolveEncryptionKey } from "@rakazo/core";
-import { createDb, createThreadEvents } from "@rakazo/db";
+import {
+  createDataRetentionSweeper,
+  createDb,
+  createThreadEvents,
+  resolveDataRetentionDays,
+} from "@rakazo/db";
 import { MarkdownMemoryStore } from "@rakazo/memory";
 
 async function main() {
@@ -85,11 +90,16 @@ async function main() {
     leadership: createPostgresReconciliationLeadership(pool),
   });
   reconciler.start();
+  const retention = createDataRetentionSweeper(prisma, {
+    retentionDays: resolveDataRetentionDays(process.env.DATA_RETENTION_DAYS),
+  });
+  retention.start();
 
   let stopping = false;
   const stop = async () => {
     if (stopping) return;
     stopping = true;
+    await retention.stop();
     await reconciler.stop();
     await jobHost.stop();
     await jobs.close();

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -38,6 +38,7 @@ SIGNUP_ALLOWLIST=you@example.com,@company.com
 SANDBOX_PROVIDER=docker   # or e2b. Keep fake only for pnpm test.
 AGENT_RUNTIME=pi          # Keep scripted only for pnpm test.
 WAKEUP_DRIVER=graphile
+DATA_RETENTION_DAYS=90     # daily pruning; set 0 to retain indefinitely
 SANDBOX_IDLE_MS=600000    # pause the bot computer after 10 minutes idle
 E2B_API_KEY=              # when SANDBOX_PROVIDER=e2b
 ```

--- a/packages/db/prisma/migrations/0008_data_retention_indexes/migration.sql
+++ b/packages/db/prisma/migrations/0008_data_retention_indexes/migration.sql
@@ -1,0 +1,3 @@
+CREATE INDEX "messages_createdAt_idx" ON "messages"("createdAt");
+CREATE INDEX "events_createdAt_idx" ON "events"("createdAt");
+CREATE INDEX "memory_revisions_createdAt_idx" ON "memory_revisions"("createdAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -233,6 +233,7 @@ model Message {
 
   @@unique([threadId, seq])
   @@index([threadId, seq])
+  @@index([createdAt])
   @@map("messages")
 }
 
@@ -253,6 +254,7 @@ model Event {
   @@index([workspaceId, createdAt])
   @@index([threadId, seq])
   @@index([runId, type, seq])
+  @@index([createdAt])
   @@map("events")
 }
 
@@ -433,6 +435,7 @@ model MemoryRevision {
   createdAt  DateTime @default(now())
 
   @@unique([documentId, revision])
+  @@index([createdAt])
   @@map("memory_revisions")
 }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,4 +2,5 @@ export * from "./client.js";
 export * from "./events.js";
 export * from "./messages.js";
 export * from "./repos.js";
+export * from "./retention.js";
 export * from "./scope.js";

--- a/packages/db/src/retention.test.ts
+++ b/packages/db/src/retention.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "./client.js";
+import {
+  createDataRetentionSweeper,
+  DEFAULT_DATA_RETENTION_DAYS,
+  pruneExpiredData,
+  resolveDataRetentionDays,
+} from "./retention.js";
+
+function fakePrisma(counts = [3, 2, 1]) {
+  const eventDeleteMany = vi.fn(async () => ({ count: counts[0] ?? 0 }));
+  const messageDeleteMany = vi.fn(async () => ({ count: counts[1] ?? 0 }));
+  const memoryRevisionDeleteMany = vi.fn(async () => ({ count: counts[2] ?? 0 }));
+  const transaction = vi.fn(async (operations: Promise<unknown>[]) => Promise.all(operations));
+  const prisma = {
+    event: { deleteMany: eventDeleteMany },
+    message: { deleteMany: messageDeleteMany },
+    memoryRevision: { deleteMany: memoryRevisionDeleteMany },
+    $transaction: transaction,
+  } as unknown as PrismaClient;
+  return {
+    prisma,
+    eventDeleteMany,
+    messageDeleteMany,
+    memoryRevisionDeleteMany,
+    transaction,
+  };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("resolveDataRetentionDays", () => {
+  it("defaults to 90 days and allows an operator to disable pruning", () => {
+    expect(resolveDataRetentionDays(undefined)).toBe(DEFAULT_DATA_RETENTION_DAYS);
+    expect(resolveDataRetentionDays(" ")).toBe(DEFAULT_DATA_RETENTION_DAYS);
+    expect(resolveDataRetentionDays("0")).toBe(0);
+  });
+
+  it.each(["-1", "1.5", "many", "9007199254740992"])("rejects invalid value %s", (value) => {
+    expect(() => resolveDataRetentionDays(value)).toThrow(
+      "DATA_RETENTION_DAYS must be a non-negative integer",
+    );
+  });
+});
+
+describe("pruneExpiredData", () => {
+  it("deletes expired events, messages, and memory revisions in one transaction", async () => {
+    const { prisma, eventDeleteMany, messageDeleteMany, memoryRevisionDeleteMany, transaction } =
+      fakePrisma();
+    const now = new Date("2026-08-16T12:00:00.000Z");
+
+    await expect(pruneExpiredData(prisma, 30, now)).resolves.toEqual({
+      cutoff: new Date("2026-07-17T12:00:00.000Z"),
+      events: 3,
+      messages: 2,
+      memoryRevisions: 1,
+    });
+
+    const where = { where: { createdAt: { lt: new Date("2026-07-17T12:00:00.000Z") } } };
+    expect(eventDeleteMany).toHaveBeenCalledWith(where);
+    expect(messageDeleteMany).toHaveBeenCalledWith(where);
+    expect(memoryRevisionDeleteMany).toHaveBeenCalledWith(where);
+    expect(transaction).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createDataRetentionSweeper", () => {
+  it("runs immediately and then once per interval", async () => {
+    vi.useFakeTimers();
+    const { prisma, transaction } = fakePrisma();
+    const log = { info: vi.fn(), error: vi.fn() };
+    const sweeper = createDataRetentionSweeper(prisma, {
+      retentionDays: 30,
+      intervalMs: 1_000,
+      now: () => new Date("2026-08-16T12:00:00.000Z"),
+      log,
+    });
+
+    sweeper.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(transaction).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(transaction).toHaveBeenCalledTimes(2);
+    expect(log.info).toHaveBeenCalledTimes(2);
+    await sweeper.stop();
+  });
+
+  it("does no work when retention is disabled", async () => {
+    vi.useFakeTimers();
+    const { prisma, transaction } = fakePrisma();
+    const sweeper = createDataRetentionSweeper(prisma, { retentionDays: 0 });
+
+    sweeper.start();
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1_000);
+    expect(transaction).not.toHaveBeenCalled();
+    await sweeper.stop();
+  });
+});

--- a/packages/db/src/retention.ts
+++ b/packages/db/src/retention.ts
@@ -1,0 +1,86 @@
+import type { PrismaClient } from "./client.js";
+
+export const DEFAULT_DATA_RETENTION_DAYS = 90;
+export const DEFAULT_RETENTION_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+
+export interface DataRetentionResult {
+  cutoff: Date;
+  events: number;
+  messages: number;
+  memoryRevisions: number;
+}
+
+export function resolveDataRetentionDays(value: string | undefined): number {
+  if (value === undefined || value.trim() === "") return DEFAULT_DATA_RETENTION_DAYS;
+  const days = Number(value);
+  if (!Number.isSafeInteger(days) || days < 0) {
+    throw new Error("DATA_RETENTION_DAYS must be a non-negative integer");
+  }
+  return days;
+}
+
+export async function pruneExpiredData(
+  prisma: PrismaClient,
+  retentionDays: number,
+  now = new Date(),
+): Promise<DataRetentionResult> {
+  if (!Number.isSafeInteger(retentionDays) || retentionDays <= 0) {
+    throw new Error("retentionDays must be a positive integer");
+  }
+  const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1_000);
+  const [events, messages, memoryRevisions] = await prisma.$transaction([
+    prisma.event.deleteMany({ where: { createdAt: { lt: cutoff } } }),
+    prisma.message.deleteMany({ where: { createdAt: { lt: cutoff } } }),
+    prisma.memoryRevision.deleteMany({ where: { createdAt: { lt: cutoff } } }),
+  ]);
+  return {
+    cutoff,
+    events: events.count,
+    messages: messages.count,
+    memoryRevisions: memoryRevisions.count,
+  };
+}
+
+export function createDataRetentionSweeper(
+  prisma: PrismaClient,
+  options: {
+    retentionDays: number;
+    intervalMs?: number;
+    now?: () => Date;
+    log?: Pick<Console, "error" | "info">;
+  },
+) {
+  const intervalMs = options.intervalMs ?? DEFAULT_RETENTION_SWEEP_INTERVAL_MS;
+  const now = options.now ?? (() => new Date());
+  const log = options.log ?? console;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let sweeping: Promise<DataRetentionResult> | undefined;
+
+  const sweepOnce = () => {
+    if (sweeping) return sweeping;
+    sweeping = pruneExpiredData(prisma, options.retentionDays, now()).finally(() => {
+      sweeping = undefined;
+    });
+    return sweeping;
+  };
+  const sweepSafely = () => {
+    void sweepOnce()
+      .then((result) => log.info("data retention sweep", result))
+      .catch((error) => log.error("data retention sweep", error));
+  };
+
+  return {
+    sweepOnce,
+    start() {
+      if (timer || options.retentionDays === 0) return;
+      sweepSafely();
+      timer = setInterval(sweepSafely, intervalMs);
+      timer.unref?.();
+    },
+    async stop() {
+      if (timer) clearInterval(timer);
+      timer = undefined;
+      await sweeping?.catch(() => undefined);
+    },
+  };
+}


### PR DESCRIPTION
Closes #34

## Summary
- prune events, messages, and memory revision history older than the configured retention window
- run the sweep at worker startup and daily, with counts/error logging and graceful shutdown
- default to 90 days via DATA_RETENTION_DAYS, with 0 as an explicit opt-out
- add cutoff indexes and document the self-hosted setting

## Tests
- full offline Vitest suite: 266 passed, 39 skipped
- database and worker TypeScript checks
- Biome check on changed source/schema/docs
- Prisma schema validation
- all migrations applied successfully to a clean PostgreSQL 16 database