### PR TITLE
Add daily Playwright visual reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,9 @@ jobs:
     with:
       publish_report: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       upload_artifacts: ${{ github.event_name == 'pull_request' }}
-    secrets: inherit
+    secrets:
+      S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+      S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
 
   deploy-production:
     if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,7 @@ jobs:
     name: Web E2E
     uses: ./.github/workflows/playwright.yml
     with:
-      publish_report: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      upload_artifacts: ${{ github.event_name == 'pull_request' }}
-    secrets:
-      S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-      S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+      upload_artifacts: true
 
   deploy-production:
     if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,19 +93,11 @@ jobs:
 
   test-e2e:
     name: Web E2E
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - name: Install Chromium
-        run: pnpm --filter @rakazo/web exec playwright install --with-deps chromium
-      - run: pnpm test:e2e
+    uses: ./.github/workflows/playwright.yml
+    with:
+      publish_report: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      upload_artifacts: ${{ github.event_name == 'pull_request' }}
+    secrets: inherit
 
   deploy-production:
     if: >-

--- a/.github/workflows/nightly-verification.yml
+++ b/.github/workflows/nightly-verification.yml
@@ -24,7 +24,9 @@ jobs:
     uses: ./.github/workflows/playwright.yml
     with:
       publish_report: true
-    secrets: inherit
+    secrets:
+      S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+      S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
 
   topology:
     name: Production topology smoke

--- a/.github/workflows/nightly-verification.yml
+++ b/.github/workflows/nightly-verification.yml
@@ -19,6 +19,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  visual-web:
+    name: Daily web screenshots
+    uses: ./.github/workflows/playwright.yml
+    with:
+      publish_report: true
+    secrets: inherit
+
   topology:
     name: Production topology smoke
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,13 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      S3_ACCESS_KEY_ID:
+        description: Access key used to publish visual reports
+        required: false
+      S3_SECRET_ACCESS_KEY:
+        description: Secret key used to publish visual reports
+        required: false
 
 permissions:
   contents: read
@@ -22,6 +29,9 @@ jobs:
     name: Web E2E
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: ${{ inputs.publish_report && 'playwright-publication' || format('playwright-{0}', github.run_id) }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
@@ -49,12 +59,12 @@ jobs:
       - name: Publish Playwright visual report
         if: always() && inputs.publish_report
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
-          AWS_DEFAULT_REGION: ${{ vars.HETZNER_S3_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.S3_REGION }}
           AWS_EC2_METADATA_DISABLED: "true"
-          HETZNER_S3_BUCKET: ${{ vars.HETZNER_S3_BUCKET }}
-          HETZNER_S3_ENDPOINT: ${{ vars.HETZNER_S3_ENDPOINT }}
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}
           PLAYWRIGHT_PUBLIC_BASE_URL: ${{ vars.PLAYWRIGHT_PUBLIC_BASE_URL }}
           PLAYWRIGHT_RESULT: ${{ steps.playwright_tests.outcome }}
           PLAYWRIGHT_RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,67 @@
+name: Playwright
+
+on:
+  workflow_call:
+    inputs:
+      publish_report:
+        description: Publish this run to the persistent visual dashboard
+        required: false
+        type: boolean
+        default: false
+      upload_artifacts:
+        description: Retain the report and diagnostics as GitHub artifacts
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    name: Web E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Install Chromium
+        run: pnpm --filter @rakazo/web exec playwright install --with-deps chromium
+      - name: Run Playwright tests
+        id: playwright_tests
+        run: pnpm test:e2e
+      - name: Upload Playwright artifacts
+        if: always() && inputs.upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            playwright-report
+            apps/web/test-results
+            test-report/e2e/summary.json
+          retention-days: 7
+          if-no-files-found: warn
+      - name: Publish Playwright visual report
+        if: always() && inputs.publish_report
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.HETZNER_S3_REGION }}
+          AWS_EC2_METADATA_DISABLED: "true"
+          HETZNER_S3_BUCKET: ${{ vars.HETZNER_S3_BUCKET }}
+          HETZNER_S3_ENDPOINT: ${{ vars.HETZNER_S3_ENDPOINT }}
+          PLAYWRIGHT_PUBLIC_BASE_URL: ${{ vars.PLAYWRIGHT_PUBLIC_BASE_URL }}
+          PLAYWRIGHT_RESULT: ${{ steps.playwright_tests.outcome }}
+          PLAYWRIGHT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          PLAYWRIGHT_RUN_ID: ${{ github.run_id }}
+          PLAYWRIGHT_RUN_NUMBER: ${{ github.run_number }}
+          PLAYWRIGHT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PLAYWRIGHT_SHA: ${{ github.sha }}
+          PLAYWRIGHT_EVENT: ${{ github.event_name }}
+          PLAYWRIGHT_BRANCH: ${{ github.ref_name }}
+        run: bash scripts/publish-playwright-report.sh

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Run Playwright tests
         id: playwright_tests
         run: pnpm test:e2e
+      - name: Record Playwright result
+        if: always() && inputs.upload_artifacts
+        env:
+          PLAYWRIGHT_RESULT: ${{ steps.playwright_tests.outcome }}
+        run: |
+          mkdir -p test-report/e2e
+          printf '%s\n' "$PLAYWRIGHT_RESULT" > test-report/e2e/outcome.txt
       - name: Upload Playwright artifacts
         if: always() && inputs.upload_artifacts
         uses: actions/upload-artifact@v4
@@ -53,7 +60,7 @@ jobs:
           path: |
             playwright-report
             apps/web/test-results
-            test-report/e2e/summary.json
+            test-report/e2e
           retention-days: 7
           if-no-files-found: warn
       - name: Publish Playwright visual report

--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -1,0 +1,60 @@
+name: publish Playwright report
+
+on:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: playwright-publication
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download Playwright artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-artifacts-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Read Playwright result
+        id: playwright
+        shell: bash
+        run: |
+          read -r result < test-report/e2e/outcome.txt
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+      - name: Publish Playwright visual report
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.S3_REGION }}
+          AWS_EC2_METADATA_DISABLED: "true"
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}
+          PLAYWRIGHT_PUBLIC_BASE_URL: ${{ vars.PLAYWRIGHT_PUBLIC_BASE_URL }}
+          PLAYWRIGHT_RESULT: ${{ steps.playwright.outputs.result }}
+          PLAYWRIGHT_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          PLAYWRIGHT_RUN_ID: ${{ github.event.workflow_run.id }}
+          PLAYWRIGHT_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          PLAYWRIGHT_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          PLAYWRIGHT_SHA: ${{ github.event.workflow_run.head_sha }}
+          PLAYWRIGHT_EVENT: ${{ github.event.workflow_run.event }}
+          PLAYWRIGHT_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: bash scripts/publish-playwright-report.sh

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ pnpm test:canary       # live OpenRouter / E2B canaries
 COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm test:computer
 ```
 
+Pull requests retain the Playwright HTML report, screenshots, traces, and videos as short-lived
+GitHub Actions artifacts. Successful merges and the nightly verification publish a persistent run
+history plus a scan-friendly screenshot gallery at
+<https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/index.html>.
+
 `pnpm test:topology`, `pnpm test:canary`, and `pnpm test:computer` are for running the product path on your machine. They are not part of pull-request CI. The computer acceptance test also requires `E2B_API_KEY` and `OPENROUTER_API_KEY` (the command reads the root `.env`) and uses a temporary Postgres container. It proves an actual model can observe and click a real browser, then use the sandbox terminal and files.
 
 See [`docs/computer-runtime.md`](./docs/computer-runtime.md) for the agent/runtime boundary, provider switching, and persistence contract.

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -1,16 +1,16 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Page, type TestInfo, test } from "@playwright/test";
 
 test.describe.configure({ mode: "serial" });
 
-test("two users are isolated and a bot completes durable work", async ({ browser }) => {
+test("two users are isolated and a bot completes durable work", async ({ browser }, testInfo) => {
   const a = await browser.newContext();
   const b = await browser.newContext();
   const pageA = await a.newPage();
   const pageB = await b.newPage();
 
   const stamp = Date.now();
-  await signup(pageA, `ada-${stamp}@rakazo.test`, "password12", "Ada");
-  await completeOnboarding(pageA, ["A bit of everything", "Clear and tight"]);
+  await signup(pageA, `ada-${stamp}@rakazo.test`, "password12", "Ada", testInfo);
+  await completeOnboarding(pageA, ["A bit of everything", "Clear and tight"], testInfo);
   await expect(pageA.getByText("Chief").first()).toBeVisible();
 
   await signup(pageB, `bob-${stamp}@rakazo.test`, "password12", "Bob");
@@ -29,12 +29,13 @@ test("two users are isolated and a bot completes durable work", async ({ browser
 
   await pageA.reload();
   await expect(pageA.getByText(/isolation-ok|writing that into my home/i).first()).toBeVisible();
+  await captureScreenshot(pageA, testInfo, "07-durable-bot-work");
 
   await a.close();
   await b.close();
 });
 
-test("takeover, routine, plugins, and export are reachable", async ({ page }) => {
+test("takeover, routine, plugins, and export are reachable", async ({ page }, testInfo) => {
   const stamp = Date.now();
   await signup(page, `flow-${stamp}@rakazo.test`, "password12", "Flow");
   await completeOnboarding(page, ["A bit of everything", "Clear and tight"]);
@@ -45,9 +46,11 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }) =>
   await expect(page.getByText(/sign in to continue|protected input/i).first()).toBeVisible({
     timeout: 30_000,
   });
+  await captureScreenshot(page, testInfo, "08-protected-input-request");
   await page.getByTitle("Agent computer").click();
   await page.getByRole("button", { name: "Take control" }).click();
   await expect(page.getByRole("button", { name: "Close computer" })).toBeVisible();
+  await captureScreenshot(page, testInfo, "09-computer-takeover");
   await page.getByRole("button", { name: "Release" }).last().click();
   await expect(page.getByRole("button", { name: "Close computer" })).toBeHidden();
   await expect(page.getByText(/signed in|session stays/i).first()).toBeVisible({ timeout: 30_000 });
@@ -59,9 +62,11 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }) =>
     .fill("write a file in your home called notes/result.txt that says routine-ok");
   await page.getByRole("button", { name: "Save" }).click();
   await expect(page.getByText("Monday briefing")).toBeVisible();
+  await captureScreenshot(page, testInfo, "10-routine-created");
 
   await page.getByText("Plugins").click();
   await expect(page.getByPlaceholder("Search apps")).toBeVisible();
+  await captureScreenshot(page, testInfo, "11-plugins-catalog");
   await page.getByRole("button", { name: "Close plugins" }).click();
 
   await page.getByText("Chief").first().click();
@@ -75,9 +80,10 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }) =>
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toMatch(/chief-export\.json/i);
   await expect(page.getByRole("button", { name: "Delete bot" })).toBeVisible();
+  await captureScreenshot(page, testInfo, "12-bot-settings");
 });
 
-test("sign-in, spawn, and stop work in the shell", async ({ page }) => {
+test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) => {
   const stamp = Date.now();
   const email = `shell-${stamp}@rakazo.test`;
   await signup(page, email, "password12", "Shell");
@@ -89,6 +95,7 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }) => {
   await expect(page.getByRole("complementary").getByRole("button", { name: /Scout/ })).toBeVisible({
     timeout: 30_000,
   });
+  await captureScreenshot(page, testInfo, "13-spawned-bot");
 
   await page
     .getByRole("complementary")
@@ -97,6 +104,7 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }) => {
   await composer.fill("keep working until I stop you");
   await page.keyboard.press("Enter");
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
+  await captureScreenshot(page, testInfo, "14-active-bot-work");
   await page.getByRole("button", { name: "Stop" }).click();
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
 
@@ -112,9 +120,12 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }) => {
   await expect(
     page.getByRole("complementary").getByRole("button", { name: /Scout/ }),
   ).toBeVisible();
+  await captureScreenshot(page, testInfo, "15-restored-session");
 });
 
-test("bot context menu pins, duplicates, edits, and confirms deletion", async ({ page }) => {
+test("bot context menu pins, duplicates, edits, and confirms deletion", async ({
+  page,
+}, testInfo) => {
   const stamp = Date.now();
   await signup(page, `menu-${stamp}@rakazo.test`, "password12", "Menu");
   await completeOnboarding(page, ["A bit of everything", "Clear and tight"]);
@@ -125,6 +136,7 @@ test("bot context menu pins, duplicates, edits, and confirms deletion", async ({
   await expect(page.getByRole("menuitem", { name: "Edit Profile" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Duplicate" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Delete" })).toBeVisible();
+  await captureScreenshot(page, testInfo, "16-bot-context-menu");
   await page.getByRole("menuitem", { name: "Mark as Unread" }).click();
 
   // Chief is the open bot, so the auto-read on window focus must not undo the manual mark.
@@ -140,19 +152,22 @@ test("bot context menu pins, duplicates, edits, and confirms deletion", async ({
   await expect(page.getByRole("menuitem", { name: "Unpin", exact: true })).toBeVisible();
   await page.getByRole("menuitem", { name: "Duplicate" }).click();
   await expect(page.getByText("Chief copy").first()).toBeVisible();
+  await captureScreenshot(page, testInfo, "17-pinned-and-duplicated-bot");
 
   const copy = page.getByRole("button", { name: /Chief copy/ }).first();
   await copy.click({ button: "right" });
   await page.getByRole("menuitem", { name: "Delete" }).click();
   await expect(page.getByRole("alertdialog", { name: "Delete Chief copy?" })).toBeVisible();
+  await captureScreenshot(page, testInfo, "18-delete-confirmation");
   await page.getByRole("button", { name: "Cancel" }).click();
 
   await chief.click({ button: "right" });
   await page.getByRole("menuitem", { name: "Edit Profile" }).click();
   await expect(page.locator("label:has-text('Name') input")).toHaveValue("Chief");
+  await captureScreenshot(page, testInfo, "19-edit-profile");
 });
 
-async function completeOnboarding(page: Page, answers: string[]) {
+async function completeOnboarding(page: Page, answers: string[], testInfo?: TestInfo) {
   await page.waitForURL(/\/(onboarding|app)/, { timeout: 20_000 });
   const heading = page.getByRole("heading", { name: /Connect a model|Create your first bot/ });
   const chief = page.getByText("Chief").first();
@@ -164,6 +179,7 @@ async function completeOnboarding(page: Page, answers: string[]) {
       .isVisible()
       .catch(() => false)
   ) {
+    if (testInfo) await captureScreenshot(page, testInfo, "02-connect-model");
     await page.getByRole("button", { name: "Skip for now" }).click();
   }
   if (
@@ -172,21 +188,46 @@ async function completeOnboarding(page: Page, answers: string[]) {
       .isVisible()
       .catch(() => false)
   ) {
+    if (testInfo) await captureScreenshot(page, testInfo, "03-create-first-bot");
     await page.locator("label:has-text('Name') input").fill("Chief");
     await page.getByRole("button", { name: "Continue" }).click();
-    for (const answer of answers) {
-      await page.getByText(answer, { exact: true }).click();
+    for (const [index, answer] of answers.entries()) {
+      const option = page.getByText(answer, { exact: true });
+      await expect(option).toBeVisible();
+      if (testInfo) {
+        await captureScreenshot(page, testInfo, `0${index + 4}-onboarding-question-${index + 1}`);
+      }
+      await option.click();
     }
     await page.getByRole("button", { name: "Open Rakazo" }).click();
   }
   await page.waitForURL(/\/app/);
   await expect(page.getByText("Chief").first()).toBeVisible();
+  if (testInfo) await captureScreenshot(page, testInfo, "06-onboarding-complete");
 }
 
-async function signup(page: Page, email: string, password: string, name: string) {
+async function signup(
+  page: Page,
+  email: string,
+  password: string,
+  name: string,
+  testInfo?: TestInfo,
+) {
   await page.goto("/sign-up");
+  if (testInfo) await captureScreenshot(page, testInfo, "01-sign-up");
   await page.getByPlaceholder("Your name").fill(name);
   await page.getByPlaceholder("Your email address").fill(email);
   await page.getByPlaceholder("Password").fill(password);
   await page.getByRole("button", { name: "Create account" }).click();
+}
+
+async function captureScreenshot(page: Page, testInfo: TestInfo, name: string) {
+  const screenshotPath = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({
+    animations: "disabled",
+    caret: "hide",
+    fullPage: true,
+    path: screenshotPath,
+  });
+  await testInfo.attach(name, { contentType: "image/png", path: screenshotPath });
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
   testDir: "./e2e",
   forbidOnly: Boolean(process.env.CI),
   fullyParallel: false,
-  retries: process.env.CI ? 1 : 0,
   timeout: 120_000,
   expect: { timeout: 20_000 },
   reporter: reporters,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,17 +2,25 @@ import { defineConfig, devices } from "@playwright/test";
 
 const webPort = Number(process.env.WEB_PORT ?? 5173);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${webPort}`;
+const reporters = [
+  ...(process.env.CI ? ([["github"]] as const) : []),
+  ["list"] as const,
+  ["html", { open: "never", outputFolder: "../../playwright-report" }] as const,
+];
 
 export default defineConfig({
   testDir: "./e2e",
+  forbidOnly: Boolean(process.env.CI),
   fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
   timeout: 120_000,
   expect: { timeout: 20_000 },
-  reporter: [["list"], ["html", { open: "never", outputFolder: "../../playwright-report" }]],
+  reporter: reporters,
   use: {
     baseURL,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {

--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -1,0 +1,143 @@
+import type { Dirent } from "node:fs";
+import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  type PlaywrightScreenshot,
+  renderPlaywrightDashboard,
+  renderScreenshotGallery,
+  updatePlaywrightHistory,
+} from "../playwright-report-dashboard.js";
+
+const [historyPath, dashboardPath, testResultsPath, galleryPath] = process.argv.slice(2);
+
+if (!historyPath || !dashboardPath || !testResultsPath || !galleryPath) {
+  throw new Error(
+    "Usage: generate-playwright-report-dashboard <history-path> <dashboard-path> <test-results-path> <gallery-path>",
+  );
+}
+
+const screenshots = await collectScreenshots(testResultsPath, galleryPath);
+const createdAt = new Date().toISOString();
+const dashboardUrl = getRequiredEnvironmentVariable("PLAYWRIGHT_DASHBOARD_URL");
+const reportUrl = getRequiredEnvironmentVariable("PLAYWRIGHT_REPORT_URL");
+const screenshotsUrl = getRequiredEnvironmentVariable("PLAYWRIGHT_SCREENSHOTS_URL");
+const result = getRequiredEnvironmentVariable("PLAYWRIGHT_RESULT");
+const runUrl = getRequiredEnvironmentVariable("PLAYWRIGHT_RUN_URL");
+const sha = getRequiredEnvironmentVariable("PLAYWRIGHT_SHA");
+const existingHistory = await readHistory(historyPath);
+const history = updatePlaywrightHistory(existingHistory, {
+  attempt: getRequiredNumber("PLAYWRIGHT_RUN_ATTEMPT"),
+  branch: getRequiredEnvironmentVariable("PLAYWRIGHT_BRANCH"),
+  createdAt,
+  event: getRequiredEnvironmentVariable("PLAYWRIGHT_EVENT"),
+  id: getRequiredEnvironmentVariable("PLAYWRIGHT_RUN_ID"),
+  reportUrl,
+  result,
+  runNumber: getRequiredNumber("PLAYWRIGHT_RUN_NUMBER"),
+  runUrl,
+  screenshotCount: screenshots.length,
+  screenshotsUrl,
+  sha,
+});
+
+await mkdir(path.dirname(historyPath), { recursive: true });
+await mkdir(path.dirname(dashboardPath), { recursive: true });
+await mkdir(galleryPath, { recursive: true });
+await writeFile(historyPath, `${JSON.stringify(history, null, 2)}\n`);
+await writeFile(dashboardPath, renderPlaywrightDashboard(history));
+await writeFile(
+  path.join(galleryPath, "index.html"),
+  renderScreenshotGallery({
+    createdAt,
+    dashboardUrl,
+    reportUrl,
+    result,
+    runUrl,
+    screenshots,
+    sha,
+  }),
+);
+
+console.log(
+  `Playwright dashboard generated with ${history.length} runs and ${screenshots.length} screenshots.`,
+);
+
+async function collectScreenshots(
+  resultsPath: string,
+  outputPath: string,
+): Promise<PlaywrightScreenshot[]> {
+  const files = (await findPngFiles(resultsPath)).sort((left, right) =>
+    path.basename(left).localeCompare(path.basename(right)),
+  );
+  const imagePath = path.join(outputPath, "images");
+  await mkdir(imagePath, { recursive: true });
+
+  return Promise.all(
+    files.map(async (file, index) => {
+      const source = path.relative(resultsPath, file);
+      const fileName = `${String(index + 1).padStart(3, "0")}-${sanitizeFileName(path.basename(file))}`;
+      await copyFile(file, path.join(imagePath, fileName));
+      return {
+        fileName: `images/${fileName}`,
+        source,
+        title: titleFromFileName(path.basename(file)),
+      };
+    }),
+  );
+}
+
+async function findPngFiles(directory: string): Promise<string[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return [];
+    throw error;
+  }
+
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory() && entry.name === "attachments") return [];
+      if (entry.isDirectory()) return findPngFiles(entryPath);
+      return entry.isFile() && entry.name.toLowerCase().endsWith(".png") ? [entryPath] : [];
+    }),
+  );
+  return files.flat();
+}
+
+function sanitizeFileName(fileName: string): string {
+  return fileName.replaceAll(/[^a-zA-Z0-9._-]/g, "-");
+}
+
+function titleFromFileName(fileName: string): string {
+  return fileName
+    .replace(/\.png$/i, "")
+    .replace(/^\d+-/, "")
+    .replaceAll(/[-_]+/g, " ");
+}
+
+function getRequiredEnvironmentVariable(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function getRequiredNumber(name: string): number {
+  const value = Number(getRequiredEnvironmentVariable(name));
+  if (!Number.isFinite(value)) throw new Error(`${name} must be a number`);
+  return value;
+}
+
+async function readHistory(filePath: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -71,6 +71,8 @@ describe("renderPlaywrightDashboard", () => {
 
     expect(html).not.toContain("</script><script>alert(1)</script>");
     expect(html).toContain("\\u003c/script>\\u003cscript>alert(1)\\u003c/script>");
+    expect(html).toContain("latestReport.href = history[0].reportUrl");
+    expect(html).toContain("latestScreenshots.href = history[0].screenshotsUrl");
   });
 });
 

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -31,7 +31,24 @@ describe("updatePlaywrightHistory", () => {
 
     expect(history).toHaveLength(100);
     expect(history[0]?.id).toBe("200");
-    expect(history.at(-1)?.id).toBe("98");
+    expect(history.at(-1)?.id).toBe("6");
+  });
+
+  it("keeps a delayed older run behind the newest run", () => {
+    const newestRun = getRun({ id: "300", runNumber: 11 });
+    const delayedRun = getRun({ id: "250", runNumber: 10 });
+
+    expect(updatePlaywrightHistory([newestRun], delayedRun)).toEqual([newestRun, delayedRun]);
+  });
+
+  it("orders rerun attempts from newest to oldest", () => {
+    const firstAttempt = getRun({ attempt: 1 });
+    const secondAttempt = getRun({ attempt: 2 });
+
+    expect(updatePlaywrightHistory([secondAttempt], firstAttempt)).toEqual([
+      secondAttempt,
+      firstAttempt,
+    ]);
   });
 
   it("drops malformed and unsafe history entries", () => {

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  type PlaywrightRun,
+  renderPlaywrightDashboard,
+  renderScreenshotGallery,
+  updatePlaywrightHistory,
+} from "./playwright-report-dashboard.js";
+
+describe("updatePlaywrightHistory", () => {
+  it("places the current attempt first and replaces an existing copy", () => {
+    const previousRun = getRun({ id: "100", runNumber: 8 });
+    const currentRun = getRun({ id: "200", runNumber: 9 });
+    const existingCurrentRun = getRun({
+      id: currentRun.id,
+      reportUrl: "https://example.com/old-report",
+      runNumber: currentRun.runNumber,
+    });
+
+    expect(updatePlaywrightHistory([previousRun, existingCurrentRun], currentRun)).toEqual([
+      currentRun,
+      previousRun,
+    ]);
+  });
+
+  it("keeps the latest 100 valid runs", () => {
+    const previousRuns = Array.from({ length: 105 }, (_, index) =>
+      getRun({ id: String(index), runNumber: index }),
+    );
+
+    const history = updatePlaywrightHistory(previousRuns, getRun());
+
+    expect(history).toHaveLength(100);
+    expect(history[0]?.id).toBe("200");
+    expect(history.at(-1)?.id).toBe("98");
+  });
+
+  it("drops malformed and unsafe history entries", () => {
+    const currentRun = getRun();
+
+    expect(
+      updatePlaywrightHistory(
+        [null, { id: "broken" }, getRun({ reportUrl: "javascript:alert(1)" })],
+        currentRun,
+      ),
+    ).toEqual([currentRun]);
+  });
+});
+
+describe("renderPlaywrightDashboard", () => {
+  it("embeds run history without allowing a script breakout", () => {
+    const html = renderPlaywrightDashboard([
+      getRun({ branch: "</script><script>alert(1)</script>" }),
+    ]);
+
+    expect(html).not.toContain("</script><script>alert(1)</script>");
+    expect(html).toContain("\\u003c/script>\\u003cscript>alert(1)\\u003c/script>");
+  });
+});
+
+describe("renderScreenshotGallery", () => {
+  it("renders scan-friendly images and escapes labels", () => {
+    const html = renderScreenshotGallery({
+      createdAt: "2026-08-16T10:00:00.000Z",
+      dashboardUrl: "https://example.com/playwright/index.html",
+      reportUrl: "https://example.com/report",
+      result: "success",
+      runUrl: "https://github.com/example/repository/actions/runs/200",
+      screenshots: [
+        {
+          fileName: "images/001-shell.png",
+          source: "golden/<script>.png",
+          title: "main <script>alert(1)</script>",
+        },
+      ],
+      sha: "abcdef1234567890",
+    });
+
+    expect(html).toContain('src="images/001-shell.png"');
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("main &lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+});
+
+function getRun(overrides: Partial<PlaywrightRun> = {}): PlaywrightRun {
+  return {
+    attempt: 1,
+    branch: "main",
+    createdAt: "2026-08-16T10:00:00.000Z",
+    event: "push",
+    id: "200",
+    reportUrl: "https://example.com/playwright/runs/200-1/report/index.html",
+    result: "success",
+    runNumber: 10,
+    runUrl: "https://github.com/example/repository/actions/runs/200",
+    screenshotCount: 12,
+    screenshotsUrl: "https://example.com/playwright/runs/200-1/screenshots/index.html",
+    sha: "abcdef1234567890",
+    ...overrides,
+  };
+}

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -110,8 +110,8 @@ export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
         <p class="subtitle">Persistent visual evidence and results from the emulated end-to-end suite.</p>
       </div>
       <div class="actions">
-        <a class="button" href="./latest/screenshots/index.html" id="latest-screenshots">Latest screenshots</a>
-        <a class="button" href="./latest/report/index.html" id="latest-report">Latest report</a>
+        <a class="button" href="#" id="latest-screenshots">Latest screenshots</a>
+        <a class="button" href="#" id="latest-report">Latest report</a>
         <a class="button" href="https://github.com/elie222/rakazo/actions">GitHub Actions</a>
       </div>
     </header>
@@ -141,6 +141,9 @@ export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
       empty.hidden = false;
       latestReport.hidden = true;
       latestScreenshots.hidden = true;
+    } else {
+      latestReport.href = history[0].reportUrl;
+      latestScreenshots.href = history[0].screenshotsUrl;
     }
 
     const latest = history[0];

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -1,0 +1,317 @@
+const MAX_HISTORY_LENGTH = 100;
+const SHARED_PAGE_STYLES = `
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #09090b; color: #fafafa; }
+    * { box-sizing: border-box; }
+    header { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 32px; }
+    h1 { margin: 0; font-size: clamp(2rem, 6vw, 4.5rem); letter-spacing: -0.06em; }
+    .eyebrow { margin: 0 0 10px; color: #c4b5fd; font-size: 0.75rem; font-weight: 700; letter-spacing: 0.16em; text-transform: uppercase; }
+    .subtitle { margin: 10px 0 0; color: #a1a1aa; }
+    .actions { display: flex; flex-wrap: wrap; gap: 10px; }
+    .button { display: inline-flex; align-items: center; min-height: 40px; padding: 0 16px; border: 1px solid #3f3f46; border-radius: 999px; color: #fafafa; text-decoration: none; background: rgba(24, 24, 27, 0.78); }
+    .button:hover { border-color: #a78bfa; background: #2e1065; }
+`;
+
+export type PlaywrightRun = {
+  attempt: number;
+  branch: string;
+  createdAt: string;
+  event: string;
+  id: string;
+  reportUrl: string;
+  result: string;
+  runNumber: number;
+  runUrl: string;
+  screenshotCount: number;
+  screenshotsUrl: string;
+  sha: string;
+};
+
+export type PlaywrightScreenshot = {
+  fileName: string;
+  source: string;
+  title: string;
+};
+
+export function updatePlaywrightHistory(
+  existingHistory: unknown,
+  run: PlaywrightRun,
+): PlaywrightRun[] {
+  const history = Array.isArray(existingHistory) ? existingHistory.filter(isPlaywrightRun) : [];
+
+  return [
+    run,
+    ...history.filter(
+      (previousRun) => previousRun.id !== run.id || previousRun.attempt !== run.attempt,
+    ),
+  ].slice(0, MAX_HISTORY_LENGTH);
+}
+
+export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
+  const data = JSON.stringify(history).replaceAll("<", "\\u003c");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>Playwright · Rakazo</title>
+  <style>
+    ${SHARED_PAGE_STYLES}
+    body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top, #312e81 0, #09090b 34rem); }
+    main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 64px 0; }
+    .summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; margin-bottom: 20px; }
+    .card, .table-wrap { border: 1px solid rgba(113, 113, 122, 0.38); border-radius: 18px; background: rgba(9, 9, 11, 0.78); box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28); backdrop-filter: blur(16px); }
+    .card { padding: 20px; }
+    .label { color: #a1a1aa; font-size: 0.72rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; }
+    .value { display: block; margin-top: 8px; font-size: 1.5rem; font-weight: 700; }
+    .table-wrap { overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 16px 18px; border-bottom: 1px solid rgba(63, 63, 70, 0.72); text-align: left; }
+    th { color: #a1a1aa; font-size: 0.7rem; letter-spacing: 0.1em; text-transform: uppercase; }
+    tbody tr:last-child td { border-bottom: 0; }
+    tbody tr:hover { background: rgba(46, 16, 101, 0.32); }
+    .status { display: inline-flex; align-items: center; gap: 8px; font-weight: 700; text-transform: capitalize; }
+    .status::before { width: 9px; height: 9px; border-radius: 50%; background: #f59e0b; content: ""; box-shadow: 0 0 18px currentColor; }
+    .status.success { color: #4ade80; }
+    .status.success::before { background: #4ade80; }
+    .status.failure, .status.cancelled { color: #fb7185; }
+    .status.failure::before, .status.cancelled::before { background: #fb7185; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .links { display: flex; gap: 14px; }
+    .links a { color: #c4b5fd; text-decoration: none; }
+    .links a:hover { text-decoration: underline; }
+    .empty { padding: 56px 24px; color: #a1a1aa; text-align: center; }
+    footer { margin-top: 18px; color: #71717a; font-size: 0.8rem; text-align: right; }
+    @media (max-width: 760px) {
+      main { padding: 36px 0; }
+      header { align-items: start; flex-direction: column; }
+      .summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .table-wrap { overflow-x: auto; }
+      table { min-width: 880px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">Rakazo · browser checks</p>
+        <h1>Playwright</h1>
+        <p class="subtitle">Persistent visual evidence and results from the emulated end-to-end suite.</p>
+      </div>
+      <div class="actions">
+        <a class="button" href="./latest/screenshots/index.html" id="latest-screenshots">Latest screenshots</a>
+        <a class="button" href="./latest/report/index.html" id="latest-report">Latest report</a>
+        <a class="button" href="https://github.com/elie222/rakazo/actions">GitHub Actions</a>
+      </div>
+    </header>
+
+    <section class="summary" id="summary"></section>
+    <section class="table-wrap">
+      <table>
+        <thead>
+          <tr><th>Result</th><th>Run</th><th>Commit</th><th>Trigger</th><th>Screenshots</th><th>Published</th><th>Links</th></tr>
+        </thead>
+        <tbody id="runs"></tbody>
+      </table>
+      <div class="empty" id="empty" hidden>No Playwright runs have been published yet.</div>
+    </section>
+    <footer id="generated-at"></footer>
+  </main>
+  <script>
+    const history = ${data};
+    const runs = document.querySelector("#runs");
+    const empty = document.querySelector("#empty");
+    const summary = document.querySelector("#summary");
+    const generatedAt = document.querySelector("#generated-at");
+    const latestReport = document.querySelector("#latest-report");
+    const latestScreenshots = document.querySelector("#latest-screenshots");
+
+    if (history.length === 0) {
+      empty.hidden = false;
+      latestReport.hidden = true;
+      latestScreenshots.hidden = true;
+    }
+
+    const latest = history[0];
+    const recent = history.slice(0, 10);
+    const recentPassing = recent.filter((run) => run.result === "success").length;
+    const cards = [
+      ["Latest result", latest?.result ?? "No runs"],
+      ["Latest screenshots", latest ? String(latest.screenshotCount) : "—"],
+      ["Recent pass rate", recent.length ? Math.round((recentPassing / recent.length) * 100) + "%" : "—"],
+      ["Stored runs", String(history.length)],
+    ];
+
+    for (const [label, value] of cards) {
+      const card = document.createElement("article");
+      card.className = "card";
+      const labelElement = document.createElement("span");
+      labelElement.className = "label";
+      labelElement.textContent = label;
+      const valueElement = document.createElement("span");
+      valueElement.className = "value";
+      valueElement.textContent = value;
+      card.append(labelElement, valueElement);
+      summary.append(card);
+    }
+
+    for (const run of history) {
+      const row = document.createElement("tr");
+      const result = document.createElement("td");
+      const status = document.createElement("span");
+      const knownStatus = ["success", "failure", "cancelled"].includes(run.result) ? run.result : "other";
+      status.className = "status " + knownStatus;
+      status.textContent = run.result;
+      result.append(status);
+
+      const runNumber = document.createElement("td");
+      runNumber.textContent = "#" + run.runNumber + " · attempt " + run.attempt;
+      const commit = document.createElement("td");
+      commit.className = "mono";
+      commit.textContent = run.sha.slice(0, 7);
+      const event = document.createElement("td");
+      event.textContent = run.event + " · " + run.branch;
+      const screenshotCount = document.createElement("td");
+      screenshotCount.textContent = String(run.screenshotCount);
+      const published = document.createElement("td");
+      published.textContent = new Date(run.createdAt).toLocaleString();
+      const links = document.createElement("td");
+      links.className = "links";
+      const screenshots = document.createElement("a");
+      screenshots.href = run.screenshotsUrl;
+      screenshots.textContent = "Screenshots";
+      const report = document.createElement("a");
+      report.href = run.reportUrl;
+      report.textContent = "Report";
+      const actions = document.createElement("a");
+      actions.href = run.runUrl;
+      actions.textContent = "Actions";
+      links.append(screenshots, report, actions);
+
+      row.append(result, runNumber, commit, event, screenshotCount, published, links);
+      runs.append(row);
+    }
+
+    generatedAt.textContent = latest
+      ? "Latest result published " + new Date(latest.createdAt).toLocaleString()
+      : "Waiting for the first published run";
+  </script>
+</body>
+</html>`;
+}
+
+export function renderScreenshotGallery(input: {
+  createdAt: string;
+  dashboardUrl: string;
+  reportUrl: string;
+  result: string;
+  runUrl: string;
+  screenshots: PlaywrightScreenshot[];
+  sha: string;
+}): string {
+  const screenshots = input.screenshots
+    .map(
+      (screenshot, index) => `
+        <figure>
+          <a href="${escapeHtml(screenshot.fileName)}" target="_blank" rel="noreferrer">
+            <img src="${escapeHtml(screenshot.fileName)}" alt="${escapeHtml(screenshot.title)}" loading="lazy" />
+          </a>
+          <figcaption>
+            <span class="number">${String(index + 1).padStart(2, "0")}</span>
+            <span><strong>${escapeHtml(screenshot.title)}</strong><small>${escapeHtml(screenshot.source)}</small></span>
+          </figcaption>
+        </figure>`,
+    )
+    .join("");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark" />
+  <title>Run screenshots · Rakazo</title>
+  <style>
+    ${SHARED_PAGE_STYLES}
+    body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top, #312e81 0, #09090b 36rem); }
+    main { width: min(1440px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0 80px; }
+    header { margin-bottom: 30px; }
+    .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 28px; }
+    .pill { padding: 8px 12px; border: 1px solid rgba(113, 113, 122, 0.45); border-radius: 999px; color: #d4d4d8; background: rgba(9, 9, 11, 0.7); }
+    .gallery { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 22px; }
+    figure { margin: 0; overflow: hidden; border: 1px solid rgba(113, 113, 122, 0.42); border-radius: 18px; background: rgba(9, 9, 11, 0.84); box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28); }
+    figure > a { display: grid; min-height: 300px; place-items: center; padding: 12px; background: #18181b; }
+    img { display: block; width: 100%; max-height: 820px; object-fit: contain; object-position: top; border-radius: 10px; }
+    figcaption { display: flex; align-items: center; gap: 14px; padding: 16px 18px; border-top: 1px solid rgba(63, 63, 70, 0.72); }
+    figcaption span:last-child { min-width: 0; }
+    figcaption strong, figcaption small { display: block; }
+    figcaption strong { text-transform: capitalize; }
+    figcaption small { margin-top: 4px; overflow: hidden; color: #71717a; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; text-overflow: ellipsis; white-space: nowrap; }
+    .number { display: grid; width: 36px; height: 36px; flex: 0 0 auto; place-items: center; border-radius: 50%; color: #ddd6fe; background: #2e1065; font-size: 0.78rem; font-weight: 700; }
+    .empty { padding: 80px 24px; border: 1px solid rgba(113, 113, 122, 0.38); border-radius: 18px; color: #a1a1aa; text-align: center; background: rgba(9, 9, 11, 0.78); }
+    @media (max-width: 900px) {
+      header { align-items: start; flex-direction: column; }
+      .gallery { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <p class="eyebrow">Rakazo · visual review</p>
+        <h1>Run screenshots</h1>
+        <p class="subtitle">Scan every captured product state from this Playwright run.</p>
+      </div>
+      <div class="actions">
+        <a class="button" href="${escapeHtml(input.reportUrl)}">Full report</a>
+        <a class="button" href="${escapeHtml(input.runUrl)}">GitHub Actions</a>
+        <a class="button" href="${escapeHtml(input.dashboardUrl)}">All runs</a>
+      </div>
+    </header>
+    <section class="meta">
+      <span class="pill">${escapeHtml(input.result)}</span>
+      <span class="pill">${escapeHtml(input.sha.slice(0, 7))}</span>
+      <span class="pill">${input.screenshots.length} screenshots</span>
+      <span class="pill">${escapeHtml(new Date(input.createdAt).toLocaleString("en-US", { timeZone: "UTC" }))} UTC</span>
+    </section>
+    ${screenshots ? `<section class="gallery">${screenshots}</section>` : '<div class="empty">No screenshots were produced by this run.</div>'}
+  </main>
+</body>
+</html>`;
+}
+
+function isPlaywrightRun(value: unknown): value is PlaywrightRun {
+  if (!value || typeof value !== "object") return false;
+
+  const run = value as Partial<PlaywrightRun>;
+  return (
+    typeof run.attempt === "number" &&
+    typeof run.branch === "string" &&
+    typeof run.createdAt === "string" &&
+    typeof run.event === "string" &&
+    typeof run.id === "string" &&
+    isHttpsUrl(run.reportUrl) &&
+    typeof run.result === "string" &&
+    typeof run.runNumber === "number" &&
+    isHttpsUrl(run.runUrl) &&
+    typeof run.screenshotCount === "number" &&
+    isHttpsUrl(run.screenshotsUrl) &&
+    typeof run.sha === "string"
+  );
+}
+
+function isHttpsUrl(value: unknown): value is string {
+  return typeof value === "string" && URL.canParse(value) && new URL(value).protocol === "https:";
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -43,7 +43,16 @@ export function updatePlaywrightHistory(
     ...history.filter(
       (previousRun) => previousRun.id !== run.id || previousRun.attempt !== run.attempt,
     ),
-  ].slice(0, MAX_HISTORY_LENGTH);
+  ]
+    .sort(compareRunRecency)
+    .slice(0, MAX_HISTORY_LENGTH);
+}
+
+function compareRunRecency(left: PlaywrightRun, right: PlaywrightRun): number {
+  const leftId = BigInt(left.id);
+  const rightId = BigInt(right.id);
+  if (leftId !== rightId) return leftId > rightId ? -1 : 1;
+  return right.attempt - left.attempt;
 }
 
 export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
@@ -293,6 +302,7 @@ function isPlaywrightRun(value: unknown): value is PlaywrightRun {
     typeof run.createdAt === "string" &&
     typeof run.event === "string" &&
     typeof run.id === "string" &&
+    /^\d+$/.test(run.id) &&
     isHttpsUrl(run.reportUrl) &&
     typeof run.result === "string" &&
     typeof run.runNumber === "number" &&

--- a/scripts/publish-playwright-report.sh
+++ b/scripts/publish-playwright-report.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
-: "${HETZNER_S3_BUCKET:?HETZNER_S3_BUCKET is required}"
-: "${HETZNER_S3_ENDPOINT:?HETZNER_S3_ENDPOINT is required}"
+: "${S3_BUCKET:?S3_BUCKET is required}"
+: "${S3_ENDPOINT:?S3_ENDPOINT is required}"
 : "${PLAYWRIGHT_PUBLIC_BASE_URL:?PLAYWRIGHT_PUBLIC_BASE_URL is required}"
 : "${PLAYWRIGHT_RESULT:?PLAYWRIGHT_RESULT is required}"
 : "${PLAYWRIGHT_RUN_ATTEMPT:?PLAYWRIGHT_RUN_ATTEMPT is required}"
@@ -23,14 +23,14 @@ if [[ ! -f "$report_dir/index.html" ]]; then
   exit 0
 fi
 
-if [[ ! "$HETZNER_S3_BUCKET" =~ ^[a-zA-Z0-9.-]+$ ]]; then
-  echo "HETZNER_S3_BUCKET contains invalid characters." >&2
+if [[ ! "$S3_BUCKET" =~ ^[a-zA-Z0-9.-]+$ ]]; then
+  echo "S3_BUCKET contains invalid characters." >&2
   exit 1
 fi
 
-case "$HETZNER_S3_ENDPOINT" in
+case "$S3_ENDPOINT" in
   https://*) ;;
-  *) echo "HETZNER_S3_ENDPOINT must use HTTPS." >&2; exit 1 ;;
+  *) echo "S3_ENDPOINT must use HTTPS." >&2; exit 1 ;;
 esac
 
 case "$PLAYWRIGHT_PUBLIC_BASE_URL" in
@@ -44,7 +44,7 @@ dashboard_path="$dashboard_dir/index.html"
 gallery_dir="$dashboard_dir/screenshots"
 history_error_path="$dashboard_dir/history-download-error.log"
 run_key="${PLAYWRIGHT_RUN_ID}-${PLAYWRIGHT_RUN_ATTEMPT}"
-bucket_uri="s3://${HETZNER_S3_BUCKET}/playwright"
+bucket_uri="s3://${S3_BUCKET}/playwright"
 public_base_url="${PLAYWRIGHT_PUBLIC_BASE_URL%/}"
 report_url="$public_base_url/runs/$run_key/report/index.html"
 screenshots_url="$public_base_url/runs/$run_key/screenshots/index.html"
@@ -53,7 +53,7 @@ mkdir -p "$dashboard_dir"
 if aws s3 cp \
   "$bucket_uri/history.json" \
   "$history_path" \
-  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --endpoint-url "$S3_ENDPOINT" \
   2>"$history_error_path"; then
   echo "Downloaded existing Playwright history."
 elif grep -Eq "404|NoSuchKey|Not Found" "$history_error_path"; then
@@ -76,35 +76,35 @@ PLAYWRIGHT_DASHBOARD_URL="$public_base_url/index.html" \
 aws s3 sync \
   "$report_dir/" \
   "$bucket_uri/runs/$run_key/report/" \
-  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --endpoint-url "$S3_ENDPOINT" \
   --cache-control "public,max-age=31536000,immutable"
 aws s3 sync \
   "$gallery_dir/" \
   "$bucket_uri/runs/$run_key/screenshots/" \
-  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --endpoint-url "$S3_ENDPOINT" \
   --cache-control "public,max-age=31536000,immutable"
 aws s3 sync \
   "$report_dir/" \
   "$bucket_uri/latest/report/" \
-  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --endpoint-url "$S3_ENDPOINT" \
   --delete \
   --cache-control "no-cache"
 aws s3 sync \
   "$gallery_dir/" \
   "$bucket_uri/latest/screenshots/" \
-  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --endpoint-url "$S3_ENDPOINT" \
   --delete \
   --cache-control "no-cache"
 aws s3 cp \
   "$history_path" \
   "$bucket_uri/history.json" \
-  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --endpoint-url "$S3_ENDPOINT" \
   --content-type "application/json" \
   --cache-control "no-store"
 aws s3 cp \
   "$dashboard_path" \
   "$bucket_uri/index.html" \
-  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --endpoint-url "$S3_ENDPOINT" \
   --content-type "text/html" \
   --cache-control "no-store"
 

--- a/scripts/publish-playwright-report.sh
+++ b/scripts/publish-playwright-report.sh
@@ -83,18 +83,25 @@ aws s3 sync \
   "$bucket_uri/runs/$run_key/screenshots/" \
   --endpoint-url "$S3_ENDPOINT" \
   --cache-control "public,max-age=31536000,immutable"
-aws s3 sync \
-  "$report_dir/" \
-  "$bucket_uri/latest/report/" \
-  --endpoint-url "$S3_ENDPOINT" \
-  --delete \
-  --cache-control "no-cache"
-aws s3 sync \
-  "$gallery_dir/" \
-  "$bucket_uri/latest/screenshots/" \
-  --endpoint-url "$S3_ENDPOINT" \
-  --delete \
-  --cache-control "no-cache"
+
+latest_run_id=$(jq -r '.[0].id' "$history_path")
+latest_run_attempt=$(jq -r '.[0].attempt' "$history_path")
+if [[ "$latest_run_id" == "$PLAYWRIGHT_RUN_ID" && "$latest_run_attempt" == "$PLAYWRIGHT_RUN_ATTEMPT" ]]; then
+  aws s3 sync \
+    "$report_dir/" \
+    "$bucket_uri/latest/report/" \
+    --endpoint-url "$S3_ENDPOINT" \
+    --delete \
+    --cache-control "no-cache"
+  aws s3 sync \
+    "$gallery_dir/" \
+    "$bucket_uri/latest/screenshots/" \
+    --endpoint-url "$S3_ENDPOINT" \
+    --delete \
+    --cache-control "no-cache"
+else
+  echo "Published historical run $run_key without replacing the newer latest report."
+fi
 aws s3 cp \
   "$history_path" \
   "$bucket_uri/history.json" \

--- a/scripts/publish-playwright-report.sh
+++ b/scripts/publish-playwright-report.sh
@@ -83,25 +83,6 @@ aws s3 sync \
   "$bucket_uri/runs/$run_key/screenshots/" \
   --endpoint-url "$S3_ENDPOINT" \
   --cache-control "public,max-age=31536000,immutable"
-
-latest_run_id=$(jq -r '.[0].id' "$history_path")
-latest_run_attempt=$(jq -r '.[0].attempt' "$history_path")
-if [[ "$latest_run_id" == "$PLAYWRIGHT_RUN_ID" && "$latest_run_attempt" == "$PLAYWRIGHT_RUN_ATTEMPT" ]]; then
-  aws s3 sync \
-    "$report_dir/" \
-    "$bucket_uri/latest/report/" \
-    --endpoint-url "$S3_ENDPOINT" \
-    --delete \
-    --cache-control "no-cache"
-  aws s3 sync \
-    "$gallery_dir/" \
-    "$bucket_uri/latest/screenshots/" \
-    --endpoint-url "$S3_ENDPOINT" \
-    --delete \
-    --cache-control "no-cache"
-else
-  echo "Published historical run $run_key without replacing the newer latest report."
-fi
 aws s3 cp \
   "$history_path" \
   "$bucket_uri/history.json" \
@@ -120,7 +101,6 @@ summary=$(cat <<EOF
 - [Screenshot gallery]($screenshots_url)
 - [Full report]($report_url)
 - [Dashboard]($public_base_url/index.html)
-- [Latest screenshots]($public_base_url/latest/screenshots/index.html)
 EOF
 )
 

--- a/scripts/publish-playwright-report.sh
+++ b/scripts/publish-playwright-report.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
+: "${HETZNER_S3_BUCKET:?HETZNER_S3_BUCKET is required}"
+: "${HETZNER_S3_ENDPOINT:?HETZNER_S3_ENDPOINT is required}"
+: "${PLAYWRIGHT_PUBLIC_BASE_URL:?PLAYWRIGHT_PUBLIC_BASE_URL is required}"
+: "${PLAYWRIGHT_RESULT:?PLAYWRIGHT_RESULT is required}"
+: "${PLAYWRIGHT_RUN_ATTEMPT:?PLAYWRIGHT_RUN_ATTEMPT is required}"
+: "${PLAYWRIGHT_RUN_ID:?PLAYWRIGHT_RUN_ID is required}"
+: "${PLAYWRIGHT_RUN_NUMBER:?PLAYWRIGHT_RUN_NUMBER is required}"
+: "${PLAYWRIGHT_RUN_URL:?PLAYWRIGHT_RUN_URL is required}"
+: "${PLAYWRIGHT_SHA:?PLAYWRIGHT_SHA is required}"
+: "${PLAYWRIGHT_EVENT:?PLAYWRIGHT_EVENT is required}"
+: "${PLAYWRIGHT_BRANCH:?PLAYWRIGHT_BRANCH is required}"
+
+report_dir="${PLAYWRIGHT_REPORT_DIR:-playwright-report}"
+test_results_dir="${PLAYWRIGHT_TEST_RESULTS_DIR:-apps/web/test-results}"
+
+if [[ ! -f "$report_dir/index.html" ]]; then
+  echo "::warning::Playwright did not produce an HTML report; keeping the existing public dashboard."
+  exit 0
+fi
+
+if [[ ! "$HETZNER_S3_BUCKET" =~ ^[a-zA-Z0-9.-]+$ ]]; then
+  echo "HETZNER_S3_BUCKET contains invalid characters." >&2
+  exit 1
+fi
+
+case "$HETZNER_S3_ENDPOINT" in
+  https://*) ;;
+  *) echo "HETZNER_S3_ENDPOINT must use HTTPS." >&2; exit 1 ;;
+esac
+
+case "$PLAYWRIGHT_PUBLIC_BASE_URL" in
+  https://*) ;;
+  *) echo "PLAYWRIGHT_PUBLIC_BASE_URL must use HTTPS." >&2; exit 1 ;;
+esac
+
+dashboard_dir="$GITHUB_WORKSPACE/.tmp/playwright-dashboard"
+history_path="$dashboard_dir/history.json"
+dashboard_path="$dashboard_dir/index.html"
+gallery_dir="$dashboard_dir/screenshots"
+history_error_path="$dashboard_dir/history-download-error.log"
+run_key="${PLAYWRIGHT_RUN_ID}-${PLAYWRIGHT_RUN_ATTEMPT}"
+bucket_uri="s3://${HETZNER_S3_BUCKET}/playwright"
+public_base_url="${PLAYWRIGHT_PUBLIC_BASE_URL%/}"
+report_url="$public_base_url/runs/$run_key/report/index.html"
+screenshots_url="$public_base_url/runs/$run_key/screenshots/index.html"
+
+mkdir -p "$dashboard_dir"
+if aws s3 cp \
+  "$bucket_uri/history.json" \
+  "$history_path" \
+  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  2>"$history_error_path"; then
+  echo "Downloaded existing Playwright history."
+elif grep -Eq "404|NoSuchKey|Not Found" "$history_error_path"; then
+  echo "No existing Playwright history found; creating it."
+else
+  cat "$history_error_path"
+  exit 1
+fi
+
+PLAYWRIGHT_REPORT_URL="$report_url" \
+PLAYWRIGHT_SCREENSHOTS_URL="$screenshots_url" \
+PLAYWRIGHT_DASHBOARD_URL="$public_base_url/index.html" \
+  pnpm exec tsx \
+    packages/testkit/src/cli/generate-playwright-report-dashboard.ts \
+    "$history_path" \
+    "$dashboard_path" \
+    "$test_results_dir" \
+    "$gallery_dir"
+
+aws s3 sync \
+  "$report_dir/" \
+  "$bucket_uri/runs/$run_key/report/" \
+  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --cache-control "public,max-age=31536000,immutable"
+aws s3 sync \
+  "$gallery_dir/" \
+  "$bucket_uri/runs/$run_key/screenshots/" \
+  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --cache-control "public,max-age=31536000,immutable"
+aws s3 sync \
+  "$report_dir/" \
+  "$bucket_uri/latest/report/" \
+  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --delete \
+  --cache-control "no-cache"
+aws s3 sync \
+  "$gallery_dir/" \
+  "$bucket_uri/latest/screenshots/" \
+  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --delete \
+  --cache-control "no-cache"
+aws s3 cp \
+  "$history_path" \
+  "$bucket_uri/history.json" \
+  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --content-type "application/json" \
+  --cache-control "no-store"
+aws s3 cp \
+  "$dashboard_path" \
+  "$bucket_uri/index.html" \
+  --endpoint-url "$HETZNER_S3_ENDPOINT" \
+  --content-type "text/html" \
+  --cache-control "no-store"
+
+summary=$(cat <<EOF
+### Playwright visual report
+- [Screenshot gallery]($screenshots_url)
+- [Full report]($report_url)
+- [Dashboard]($public_base_url/index.html)
+- [Latest screenshots]($public_base_url/latest/screenshots/index.html)
+EOF
+)
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
+else
+  printf '%s\n' "$summary"
+fi


### PR DESCRIPTION
## Summary
- capture and attach 19 ordered screenshots across the existing web E2E journeys
- publish a persistent Playwright history, full report, and scan-friendly screenshot gallery to S3-compatible object storage on main and nightly runs
- retain PR reports and diagnostics as seven-day GitHub artifacts
- share one reusable Playwright workflow between CI and nightly verification
- serialize public report publication and keep retry output unambiguous
- isolate publishing credentials in trusted nightly and post-merge workflows; PR-controlled jobs receive no S3 credentials
- order history by run ID and resolve Latest links to immutable run assets so delayed or partial publications cannot regress the dashboard

## Verification
- `pnpm lint`
- `pnpm check`
- `pnpm test` (275 passed, 38 skipped)
- Playwright dashboard tests (7 passed)
- `pnpm test:e2e` (4 passed; 19 screenshots)
- dashboard/gallery generator smoke test
- workflow YAML parse and publisher shell syntax checks
- successful live nightly publication using the generic S3 settings
- staged secret scans