### PR TITLE
feat: add Daytona sandbox provider and real-provider E2E

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,12 @@ SANDBOX_SUPERVISOR_URL=http://127.0.0.1:7091
 # Optional separate service credential; defaults to BETTER_AUTH_SECRET when empty.
 SANDBOX_SUPERVISOR_TOKEN=
 SANDBOX_PROVIDER=docker
+DAYTONA_API_KEY=
+DAYTONA_API_URL=
+DAYTONA_TARGET=
 AGENT_RUNTIME=pi
 WAKEUP_DRIVER=graphile
-# Pause E2B (or stop Docker) computers after this many idle ms. Minimum 30000.
+# Pause or stop computers after this many idle ms. Minimum 30000.
 SANDBOX_IDLE_MS=600000
 SANDBOX_COMMAND_TIMEOUT_MS=300000
 OPENROUTER_API_KEY=

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,8 +1,23 @@
 name: Playwright
 
 on:
+  workflow_dispatch:
+    inputs:
+      sandbox_provider:
+        description: Sandbox provider
+        required: true
+        type: choice
+        options:
+          - fake
+          - e2b
+        default: fake
   workflow_call:
     inputs:
+      sandbox_provider:
+        description: Sandbox provider
+        required: false
+        type: string
+        default: fake
       publish_report:
         description: Publish this run to the persistent visual dashboard
         required: false
@@ -20,6 +35,9 @@ on:
       S3_SECRET_ACCESS_KEY:
         description: Secret key used to publish visual reports
         required: false
+      E2B_API_KEY:
+        description: E2B API key used only when the E2B sandbox is selected
+        required: false
 
 permissions:
   contents: read
@@ -28,7 +46,7 @@ jobs:
   playwright:
     name: Web E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     concurrency:
       group: ${{ inputs.publish_report && 'playwright-publication' || format('playwright-{0}', github.run_id) }}
       cancel-in-progress: false
@@ -42,9 +60,16 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Install Chromium
         run: pnpm --filter @rakazo/web exec playwright install --with-deps chromium
+      - name: Validate E2B credentials
+        if: inputs.sandbox_provider == 'e2b'
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: test -n "$E2B_API_KEY"
       - name: Run Playwright tests
         id: playwright_tests
-        run: pnpm test:e2e
+        env:
+          E2B_API_KEY: ${{ inputs.sandbox_provider == 'e2b' && secrets.E2B_API_KEY || '' }}
+        run: pnpm test:e2e -- --sandbox=${{ inputs.sandbox_provider }}
       - name: Record Playwright result
         if: always() && inputs.upload_artifacts
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,7 @@ on:
         options:
           - fake
           - e2b
+          - daytona
         default: fake
   workflow_call:
     inputs:
@@ -38,6 +39,9 @@ on:
       E2B_API_KEY:
         description: E2B API key used only when the E2B sandbox is selected
         required: false
+      DAYTONA_API_KEY:
+        description: Daytona API key used only when the Daytona sandbox is selected
+        required: false
 
 permissions:
   contents: read
@@ -65,11 +69,18 @@ jobs:
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
         run: test -n "$E2B_API_KEY"
+      - name: Validate Daytona credentials
+        if: inputs.sandbox_provider == 'daytona'
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+        run: test -n "$DAYTONA_API_KEY"
       - name: Run Playwright tests
         id: playwright_tests
         env:
+          SANDBOX_TEST_PROVIDER: ${{ inputs.sandbox_provider }}
           E2B_API_KEY: ${{ inputs.sandbox_provider == 'e2b' && secrets.E2B_API_KEY || '' }}
-        run: pnpm test:e2e -- --sandbox=${{ inputs.sandbox_provider }}
+          DAYTONA_API_KEY: ${{ inputs.sandbox_provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
+        run: pnpm test:e2e -- --sandbox="$SANDBOX_TEST_PROVIDER"
       - name: Record Playwright result
         if: always() && inputs.upload_artifacts
         env:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Outputs land in `apps/desktop/out/` (macOS dmg/zip, Windows NSIS, Linux AppImage
 pnpm test              # unit, property, and in-process contract tests
 pnpm test:integration  # Postgres journeys, Graphile jobs, LISTEN/NOTIFY
 pnpm test:e2e          # Playwright against the emulated stack
+pnpm test:e2e -- --sandbox=e2b # the same deterministic suite against real E2B
 pnpm test:topology     # local Docker + Graphile worker recovery (needs Docker)
 pnpm test:canary       # live OpenRouter / E2B canaries
 # explicit real vision-model + real E2B desktop acceptance test:
@@ -127,6 +128,10 @@ Pull requests retain the Playwright HTML report, screenshots, traces, and videos
 GitHub Actions artifacts. Successful merges and the nightly verification publish a persistent run
 history plus a scan-friendly screenshot gallery at
 <https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/index.html>.
+
+The Playwright workflow can also be started manually with **Sandbox provider** set to `e2b`.
+That option requires `E2B_API_KEY`, keeps the deterministic scripted agent runtime, and destroys
+the provider machines after the run. The default and all automatic runs remain on `fake`.
 
 `pnpm test:topology`, `pnpm test:canary`, and `pnpm test:computer` are for running the product path on your machine. They are not part of pull-request CI. The computer acceptance test also requires `E2B_API_KEY` and `OPENROUTER_API_KEY` (the command reads the root `.env`) and uses a temporary Postgres container. It proves an actual model can observe and click a real browser, then use the sandbox terminal and files.
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -73,6 +73,9 @@ export async function createApp(
     supervisorUrl: env.sandboxSupervisorUrl,
     supervisorToken: env.sandboxSupervisorToken,
     e2bApiKey: env.e2bApiKey,
+    daytonaApiKey: env.daytonaApiKey,
+    daytonaApiUrl: env.daytonaApiUrl,
+    daytonaTarget: env.daytonaTarget,
     dataDir: env.dataDir,
     prisma,
   });

--- a/apps/api/src/env.test.ts
+++ b/apps/api/src/env.test.ts
@@ -26,6 +26,22 @@ describe("loadEnv", () => {
     expect(env.wakeupDriver).toBe("memory");
   });
 
+  it("loads provider-specific Daytona configuration", () => {
+    const env = loadEnv({
+      ...base,
+      SANDBOX_PROVIDER: "daytona",
+      DAYTONA_API_KEY: "test-daytona-key",
+      DAYTONA_API_URL: "https://daytona.test/api",
+      DAYTONA_TARGET: "test-target",
+    });
+    expect(env).toMatchObject({
+      sandboxProvider: "daytona",
+      daytonaApiKey: "test-daytona-key",
+      daytonaApiUrl: "https://daytona.test/api",
+      daytonaTarget: "test-target",
+    });
+  });
+
   it("throws when production omits secrets", () => {
     expect(() =>
       loadEnv({

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -17,6 +17,9 @@ export interface AppEnv {
   agentRuntime: string;
   openRouterKey: string | undefined;
   e2bApiKey: string | undefined;
+  daytonaApiKey: string | undefined;
+  daytonaApiUrl: string | undefined;
+  daytonaTarget: string | undefined;
   composioApiKey: string | undefined;
   defaultProvider: string;
   defaultModel: string;
@@ -43,6 +46,9 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     agentRuntime: source.AGENT_RUNTIME ?? "pi",
     openRouterKey: source.OPENROUTER_API_KEY,
     e2bApiKey: source.E2B_API_KEY,
+    daytonaApiKey: source.DAYTONA_API_KEY,
+    daytonaApiUrl: source.DAYTONA_API_URL,
+    daytonaTarget: source.DAYTONA_TARGET,
     composioApiKey: source.COMPOSIO_API_KEY,
     defaultProvider: source.PI_DEFAULT_PROVIDER ?? "openrouter",
     defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731",

--- a/apps/web/e2e/approval-resume.spec.ts
+++ b/apps/web/e2e/approval-resume.spec.ts
@@ -12,9 +12,8 @@ test("approval input resumes durable work", async ({ page }, testInfo) => {
   await composer.fill("ask me which city to use");
   await page.keyboard.press("Enter");
 
-  await expect(page.getByText("Which city should I use?", { exact: true })).toBeVisible({
-    timeout: 30_000,
-  });
+  const prompt = page.locator("p").filter({ hasText: /^Which city should I use\?$/ });
+  await expect(prompt).toBeVisible({ timeout: 30_000 });
   await expect(page.getByText("Reply with one city name.", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Send it" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Edit first" })).toBeVisible();
@@ -27,7 +26,6 @@ test("approval input resumes durable work", async ({ page }, testInfo) => {
   await captureScreenshot(page, testInfo, "21-approval-custom-answer");
   await page.getByRole("button", { name: "Send answer" }).click();
 
-  const prompt = page.getByText("Which city should I use?", { exact: true });
   await expect(prompt).toHaveCount(2, { timeout: 30_000 });
   await expect(
     page.getByText("Answered: ask me which city to use again", { exact: true }),

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, realSandboxTimeout, signup } from "./helpers";
 
 test.describe.configure({ mode: "serial" });
 
@@ -49,7 +49,7 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   });
   await expect
     .poll(() => threadRunStatus(page), {
-      timeout: process.env.SANDBOX_PROVIDER === "e2b" ? 90_000 : 30_000,
+      timeout: realSandboxTimeout(90_000, 30_000),
       message: "the protected-input run must be ready for takeover",
     })
     .toBe("waiting_takeover");

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { captureScreenshot, completeOnboarding, signup } from "./helpers";
 
 test.describe.configure({ mode: "serial" });
@@ -47,6 +47,12 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await expect(page.getByText(/sign in to continue|protected input/i).first()).toBeVisible({
     timeout: 30_000,
   });
+  await expect
+    .poll(() => threadRunStatus(page), {
+      timeout: process.env.SANDBOX_PROVIDER === "e2b" ? 90_000 : 30_000,
+      message: "the protected-input run must be ready for takeover",
+    })
+    .toBe("waiting_takeover");
   await captureScreenshot(page, testInfo, "08-protected-input-request");
   await page.getByTitle("Agent computer").click();
   await page.getByRole("button", { name: "Take control" }).click();
@@ -111,7 +117,7 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await page.keyboard.press("Enter");
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
   await captureScreenshot(page, testInfo, "14-active-bot-work");
-  await page.getByRole("button", { name: "Stop" }).click();
+  await page.getByRole("button", { name: "Stop", exact: true }).click();
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
 
   await page.context().clearCookies();
@@ -172,3 +178,12 @@ test("bot context menu pins, duplicates, edits, and confirms deletion", async ({
   await expect(page.locator("label:has-text('Name') input")).toHaveValue("Chief");
   await captureScreenshot(page, testInfo, "19-edit-profile");
 });
+
+async function threadRunStatus(page: Page) {
+  const botId = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
+  if (!botId || botId === "app") throw new Error(`missing bot id in ${page.url()}`);
+  const response = await page.request.post("/rpc/threads/get", { data: { json: { botId } } });
+  const result = (await response.json()) as { json?: { run?: { status?: string } | null } };
+  if (!response.ok()) throw new Error(`threads/get ${response.status()}`);
+  return result.json?.run?.status ?? "idle";
+}

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -1,5 +1,12 @@
 import { expect, type Page, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, realSandboxTimeout, signup } from "./helpers";
+import {
+  activeBotId,
+  captureScreenshot,
+  completeOnboarding,
+  realSandboxTimeout,
+  rpc,
+  signup,
+} from "./helpers";
 
 test.describe.configure({ mode: "serial" });
 
@@ -180,10 +187,8 @@ test("bot context menu pins, duplicates, edits, and confirms deletion", async ({
 });
 
 async function threadRunStatus(page: Page) {
-  const botId = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
-  if (!botId || botId === "app") throw new Error(`missing bot id in ${page.url()}`);
-  const response = await page.request.post("/rpc/threads/get", { data: { json: { botId } } });
-  const result = (await response.json()) as { json?: { run?: { status?: string } | null } };
-  if (!response.ok()) throw new Error(`threads/get ${response.status()}`);
-  return result.json?.run?.status ?? "idle";
+  const result = await rpc<{ run?: { status?: string } | null }>(page, "threads/get", {
+    botId: activeBotId(page),
+  });
+  return result.run?.status ?? "idle";
 }

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -1,5 +1,9 @@
 import { expect, type Page, type TestInfo } from "@playwright/test";
 
+export function realSandboxTimeout(real: number, emulated: number) {
+  return ["e2b", "daytona"].includes(process.env.SANDBOX_PROVIDER ?? "") ? real : emulated;
+}
+
 export async function completeOnboarding(page: Page, answers: string[], testInfo?: TestInfo) {
   await page.waitForURL(/\/(onboarding|app)/, { timeout: 20_000 });
   const heading = page.getByRole("heading", { name: /Connect a model|Create your first bot/ });

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -1,7 +1,26 @@
 import { expect, type Page, type TestInfo } from "@playwright/test";
 
+export function isRealSandboxProvider(provider = process.env.SANDBOX_PROVIDER) {
+  return provider === "e2b" || provider === "daytona";
+}
+
 export function realSandboxTimeout(real: number, emulated: number) {
-  return ["e2b", "daytona"].includes(process.env.SANDBOX_PROVIDER ?? "") ? real : emulated;
+  return isRealSandboxProvider() ? real : emulated;
+}
+
+export function activeBotId(page: Page) {
+  const id = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
+  if (!id || id === "app") throw new Error(`missing bot id in ${page.url()}`);
+  return id;
+}
+
+export async function rpc<T>(page: Page, procedure: string, body: unknown): Promise<T> {
+  const response = await page.request.post(`/rpc/${procedure}`, { data: { json: body } });
+  const parsed = (await response.json()) as { json?: T; error?: { message?: string } };
+  if (!response.ok() || parsed.error) {
+    throw new Error(`${procedure} ${response.status()}: ${parsed.error?.message ?? "failed"}`);
+  }
+  return parsed.json as T;
 }
 
 export async function completeOnboarding(page: Page, answers: string[], testInfo?: TestInfo) {

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -1,5 +1,12 @@
 import { expect, type Page, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, realSandboxTimeout, signup } from "./helpers";
+import {
+  activeBotId,
+  captureScreenshot,
+  completeOnboarding,
+  realSandboxTimeout,
+  rpc,
+  signup,
+} from "./helpers";
 
 test("Team Computer gives bots a home folder plus shared space while Private stays isolated", async ({
   page,
@@ -262,12 +269,6 @@ async function waitForIdle(page: Page, botId: string) {
     .toBe("idle");
 }
 
-function activeBotId(page: Page) {
-  const id = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
-  if (!id || id === "app") throw new Error(`missing bot id in ${page.url()}`);
-  return id;
-}
-
 function threadSnapshot(page: Page, botId: string) {
   return rpc<{
     run: { id: string; status: string } | null;
@@ -287,13 +288,4 @@ async function readFileResponse(page: Page, botId: string, path: string) {
 async function rpcResponse(page: Page, procedure: string, body: unknown) {
   const response = await page.request.post(`/rpc/${procedure}`, { data: { json: body } });
   return { ok: response.ok(), status: response.status() };
-}
-
-async function rpc<T>(page: Page, procedure: string, body: unknown): Promise<T> {
-  const response = await page.request.post(`/rpc/${procedure}`, { data: { json: body } });
-  const parsed = (await response.json()) as { json?: T; error?: { message?: string } };
-  if (!response.ok() || parsed.error) {
-    throw new Error(`${procedure} ${response.status()}: ${parsed.error?.message ?? "failed"}`);
-  }
-  return parsed.json as T;
 }

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, realSandboxTimeout, signup } from "./helpers";
 
 test("Team Computer gives bots a home folder plus shared space while Private stays isolated", async ({
   page,
@@ -247,7 +247,7 @@ async function waitForRun(page: Page, botId: string, runId: string) {
         return snapshot.messages.some((message) => message.runId === runId);
       },
       {
-        timeout: process.env.SANDBOX_PROVIDER === "e2b" ? 90_000 : 20_000,
+        timeout: realSandboxTimeout(90_000, 20_000),
         message: `run ${runId} must finish before its result is inspected`,
       },
     )
@@ -257,7 +257,7 @@ async function waitForRun(page: Page, botId: string, runId: string) {
 async function waitForIdle(page: Page, botId: string) {
   await expect
     .poll(async () => (await threadSnapshot(page, botId)).run?.status ?? "idle", {
-      timeout: process.env.SANDBOX_PROVIDER === "e2b" ? 90_000 : 20_000,
+      timeout: realSandboxTimeout(90_000, 20_000),
     })
     .toBe("idle");
 }

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -53,6 +53,7 @@ test("Team Computer gives bots a home folder plus shared space while Private sta
     privateId,
     `write a file in your home called notes/result.txt that says ${privateMarker}`,
   );
+  await expect(readFile(page, privateId, "notes/result.txt")).resolves.toContain(privateMarker);
   await expect(readFileResponse(page, chiefId, "notes/result.txt")).resolves.toMatchObject({
     ok: false,
   });
@@ -90,7 +91,10 @@ test("user control blocks another Team bot until the computer is released", asyn
   await page.getByRole("button", { name: "Close computer" }).click();
 
   await openBot(page, "Worker");
-  await sendMessage(page, `write a file in your home called notes/result.txt that says ${marker}`);
+  const workerRunId = await sendMessage(
+    page,
+    `write a file in your home called notes/result.txt that says ${marker}`,
+  );
 
   await expect
     .poll(async () => (await threadSnapshot(page, workerId)).run?.status ?? "idle", {
@@ -117,7 +121,7 @@ test("user control blocks another Team bot until the computer is released", asyn
   await expect(page.getByText("You have control", { exact: true })).toBeVisible();
   await release.click();
 
-  await waitForRun(page, workerId);
+  await waitForRun(page, workerId, workerRunId);
   await expect(readFile(page, workerId, "notes/result.txt")).resolves.toContain(marker);
   await expect(readFileResponse(page, chiefId, "notes/result.txt")).resolves.toMatchObject({
     ok: false,
@@ -156,7 +160,7 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
     .toBe("running");
 
   await rpc(page, "threads/stop", { botId: chiefId });
-  await waitForRun(page, chiefId);
+  await waitForIdle(page, chiefId);
   await expect
     .poll(async () => (await rpcResponse(page, "computer/takeover", { botId: chiefId })).ok)
     .toBe(true);
@@ -215,8 +219,8 @@ async function openComputerPanel(page: Page) {
 }
 
 async function sendAndWait(page: Page, botId: string, text: string) {
-  await sendMessage(page, text);
-  await waitForRun(page, botId);
+  const runId = await sendMessage(page, text);
+  await waitForRun(page, botId, runId);
 }
 
 async function sendMessage(page: Page, text: string) {
@@ -227,13 +231,33 @@ async function sendMessage(page: Page, text: string) {
       response.url().includes("/rpc/threads/send") && response.request().method() === "POST",
   );
   await page.keyboard.press("Enter");
-  expect((await sent).ok()).toBe(true);
+  const response = await sent;
+  expect(response.ok()).toBe(true);
+  const result = (await response.json()) as { json?: { runId?: string } };
+  if (!result.json?.runId) throw new Error("threads/send did not return a run id");
+  return result.json.runId;
 }
 
-async function waitForRun(page: Page, botId: string) {
+async function waitForRun(page: Page, botId: string, runId: string) {
+  await expect
+    .poll(
+      async () => {
+        const snapshot = await threadSnapshot(page, botId);
+        if (snapshot.run?.id === runId) return false;
+        return snapshot.messages.some((message) => message.runId === runId);
+      },
+      {
+        timeout: process.env.SANDBOX_PROVIDER === "e2b" ? 90_000 : 20_000,
+        message: `run ${runId} must finish before its result is inspected`,
+      },
+    )
+    .toBe(true);
+}
+
+async function waitForIdle(page: Page, botId: string) {
   await expect
     .poll(async () => (await threadSnapshot(page, botId)).run?.status ?? "idle", {
-      timeout: 20_000,
+      timeout: process.env.SANDBOX_PROVIDER === "e2b" ? 90_000 : 20_000,
     })
     .toBe("idle");
 }
@@ -245,7 +269,10 @@ function activeBotId(page: Page) {
 }
 
 function threadSnapshot(page: Page, botId: string) {
-  return rpc<{ run: { status: string } | null }>(page, "threads/get", { botId });
+  return rpc<{
+    run: { id: string; status: string } | null;
+    messages: Array<{ runId?: string | null }>;
+  }>(page, "threads/get", { botId });
 }
 
 async function readFile(page: Page, botId: string, path: string) {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const webPort = Number(process.env.WEB_PORT ?? 5173);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${webPort}`;
-const realSandbox = process.env.SANDBOX_PROVIDER === "e2b";
+const realSandbox = ["e2b", "daytona"].includes(process.env.SANDBOX_PROVIDER ?? "");
 const reporters = [
   ...(process.env.CI ? ([["github"]] as const) : []),
   ["list"] as const,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
+import { isRealSandboxProvider } from "./e2e/helpers";
 
 const webPort = Number(process.env.WEB_PORT ?? 5173);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${webPort}`;
-const realSandbox = ["e2b", "daytona"].includes(process.env.SANDBOX_PROVIDER ?? "");
+const realSandbox = isRealSandboxProvider();
 const reporters = [
   ...(process.env.CI ? ([["github"]] as const) : []),
   ["list"] as const,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const webPort = Number(process.env.WEB_PORT ?? 5173);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${webPort}`;
+const realSandbox = process.env.SANDBOX_PROVIDER === "e2b";
 const reporters = [
   ...(process.env.CI ? ([["github"]] as const) : []),
   ["list"] as const,
@@ -12,8 +13,9 @@ export default defineConfig({
   testDir: "./e2e",
   forbidOnly: Boolean(process.env.CI),
   fullyParallel: false,
-  timeout: 120_000,
-  expect: { timeout: 20_000 },
+  workers: realSandbox ? 1 : undefined,
+  timeout: realSandbox ? 300_000 : 120_000,
+  expect: { timeout: realSandbox ? 90_000 : 20_000 },
   reporter: reporters,
   use: {
     baseURL,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -40,6 +40,9 @@ async function main() {
   const sandbox = createRunSandbox(process.env.SANDBOX_PROVIDER ?? "docker", {
     supervisorUrl: process.env.SANDBOX_SUPERVISOR_URL ?? "http://127.0.0.1:7091",
     e2bApiKey: process.env.E2B_API_KEY,
+    daytonaApiKey: process.env.DAYTONA_API_KEY,
+    daytonaApiUrl: process.env.DAYTONA_API_URL,
+    daytonaTarget: process.env.DAYTONA_TARGET,
     dataDir,
     prisma,
   });

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@composio/core": "0.16.0",
+    "@daytona/sdk": "^0.204.1",
     "@e2b/desktop": "^2.3.1",
     "@earendil-works/pi-agent-core": "^0.84.1",
     "@earendil-works/pi-ai": "^0.84.1",

--- a/packages/adapters/src/computer-workspace.ts
+++ b/packages/adapters/src/computer-workspace.ts
@@ -13,33 +13,38 @@ import type { PrismaClient } from "@rakazo/db";
 import { normalizeWorkspacePath, teamBotWorkspaceDirectory } from "./computer-support.js";
 import { LocalAgentHomeStore } from "./home.js";
 
+export const PORTABLE_BROWSER_STOP_COMMAND =
+  "pkill -f '[g]oogle-chrome|[c]hromium|[f]irefox' || true";
+export const PORTABLE_TRANSFER_BATCH_BYTES = 8 * 1024 * 1024;
+
+const skippedBrowserProfileDirectories = new Set([
+  "Cache",
+  "Code Cache",
+  "GPUCache",
+  "GrShaderCache",
+  "ShaderCache",
+  "DawnGraphiteCache",
+  "DawnWebGPUCache",
+  "Crashpad",
+]);
+const skippedBrowserProfileFiles = new Set([
+  "BrowserMetrics",
+  "DevToolsActivePort",
+  "SingletonCookie",
+  "SingletonLock",
+  "SingletonSocket",
+  ".parentlock",
+  "lock",
+]);
+
 /** Excludes transient browser state that is unsafe or wasteful to restore. */
 export function shouldSkipPortableWorkspaceFile(relative: string) {
   if (!relative.startsWith(".browser-profiles/")) return false;
   const segments = relative.split("/");
   const name = segments.at(-1) ?? "";
   return (
-    segments.some((segment) =>
-      [
-        "Cache",
-        "Code Cache",
-        "GPUCache",
-        "GrShaderCache",
-        "ShaderCache",
-        "DawnGraphiteCache",
-        "DawnWebGPUCache",
-        "Crashpad",
-      ].includes(segment),
-    ) ||
-    [
-      "BrowserMetrics",
-      "DevToolsActivePort",
-      "SingletonCookie",
-      "SingletonLock",
-      "SingletonSocket",
-      ".parentlock",
-      "lock",
-    ].includes(name)
+    segments.some((segment) => skippedBrowserProfileDirectories.has(segment)) ||
+    skippedBrowserProfileFiles.has(name)
   );
 }
 

--- a/packages/adapters/src/computer-workspace.ts
+++ b/packages/adapters/src/computer-workspace.ts
@@ -13,6 +13,36 @@ import type { PrismaClient } from "@rakazo/db";
 import { normalizeWorkspacePath, teamBotWorkspaceDirectory } from "./computer-support.js";
 import { LocalAgentHomeStore } from "./home.js";
 
+/** Excludes transient browser state that is unsafe or wasteful to restore. */
+export function shouldSkipPortableWorkspaceFile(relative: string) {
+  if (!relative.startsWith(".browser-profiles/")) return false;
+  const segments = relative.split("/");
+  const name = segments.at(-1) ?? "";
+  return (
+    segments.some((segment) =>
+      [
+        "Cache",
+        "Code Cache",
+        "GPUCache",
+        "GrShaderCache",
+        "ShaderCache",
+        "DawnGraphiteCache",
+        "DawnWebGPUCache",
+        "Crashpad",
+      ].includes(segment),
+    ) ||
+    [
+      "BrowserMetrics",
+      "DevToolsActivePort",
+      "SingletonCookie",
+      "SingletonLock",
+      "SingletonSocket",
+      ".parentlock",
+      "lock",
+    ].includes(name)
+  );
+}
+
 export async function restoreComputerWorkspace(
   home: AgentHomeStore,
   sandbox: SandboxProvider,

--- a/packages/adapters/src/daytona-emulator.ts
+++ b/packages/adapters/src/daytona-emulator.ts
@@ -1,0 +1,8 @@
+import { ManagedSandboxEmulator } from "./e2b-emulator.js";
+
+/** Managed-provider emulator configured with Daytona identity. */
+export class DaytonaSandboxEmulator extends ManagedSandboxEmulator {
+  constructor() {
+    super({ id: "daytona-emulator", kind: "daytona" });
+  }
+}

--- a/packages/adapters/src/daytona-sandbox.test.ts
+++ b/packages/adapters/src/daytona-sandbox.test.ts
@@ -1,0 +1,286 @@
+import type { Sandbox } from "@daytona/sdk";
+import { describe, expect, it, vi } from "vitest";
+import { DaytonaSandboxProvider, type DaytonaSandboxSdk } from "./daytona-sandbox.js";
+
+const context = {
+  operationId: "test",
+  traceId: "test",
+  workspaceId: "workspace",
+  userId: "user",
+  signal: new AbortController().signal,
+};
+
+describe("DaytonaSandboxProvider", () => {
+  it("implements the portable command, file, screen, and computer-use contract", async () => {
+    const fixture = daytonaFixture();
+    const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+
+    expect(computer).toMatchObject({
+      id: "daytona-box",
+      kind: "daytona",
+      providerRef: "daytona-box",
+      fresh: true,
+    });
+    expect(fixture.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: { botId: "bot-a", rakazo: "computer" },
+        envVars: { VNC_RESOLUTION: "1280x800" },
+      }),
+      { timeout: 120 },
+    );
+
+    const events = [];
+    for await (const event of provider.execute(computer, { argv: ["echo", "hello"] }, context)) {
+      events.push(event);
+    }
+    expect(events).toEqual([
+      { type: "stdout", data: "hello\n" },
+      { type: "exit", code: 0 },
+    ]);
+    expect(fixture.executeCommand).toHaveBeenCalledWith(
+      "'echo' 'hello'",
+      "/home/daytona/rakazo-home",
+      undefined,
+      300,
+    );
+
+    const binary = Uint8Array.from([0, 255, 1, 128]);
+    await provider.writeFile(
+      computer,
+      { path: "bin/tool", content: binary, executable: true },
+      context,
+    );
+    expect(await provider.readFile(computer, "bin/tool", context)).toEqual(binary);
+    expect(await provider.listFiles(computer, "bin", context)).toEqual([
+      { path: "bin/tool", kind: "file", size: 4, executable: true },
+    ]);
+    const exported = [];
+    for await (const file of provider.exportWorkspace(computer, context)) exported.push(file);
+    expect(exported).toContainEqual({ path: "bin/tool", content: binary, executable: true });
+
+    const observation = await provider.observe(computer, context);
+    expect(observation).toMatchObject({
+      mimeType: "image/png",
+      width: 1280,
+      height: 800,
+      cursor: { x: 10, y: 20 },
+      activeWindow: { id: "7", title: "Browser" },
+    });
+    expect(observation.image).toEqual(Uint8Array.from([1, 2, 3]));
+
+    const result = await provider.act(
+      computer,
+      {
+        actions: [
+          { kind: "pointer", type: "down", x: 10, y: 20 },
+          { kind: "pointer", type: "up", x: 30, y: 40 },
+          { kind: "key", key: "enter" },
+          { kind: "clipboard", text: "hello" },
+          { kind: "scroll", direction: "down", amount: 2 },
+        ],
+        observe: false,
+      },
+      context,
+    );
+    expect(result).toEqual({ completed: 5 });
+    expect(fixture.drag).toHaveBeenCalledWith(10, 20, 30, 40, "left");
+    expect(fixture.press).toHaveBeenCalledWith("enter", undefined);
+    expect(fixture.type).toHaveBeenCalledWith("hello");
+    expect(fixture.scroll).toHaveBeenCalledWith(10, 20, "down", 2);
+
+    const screen = await provider.connectScreen(
+      computer,
+      { view: "stream", interactive: false },
+      context,
+    );
+    expect(screen.url).toContain("/vnc.html");
+    expect(screen.url).toContain("view_only=true");
+    await screen.close();
+    const interactiveScreen = await provider.connectScreen(
+      computer,
+      { view: "stream", interactive: true },
+      context,
+    );
+    expect(interactiveScreen.url).toContain("view_only=false");
+    expect(fixture.getSignedPreviewUrl).toHaveBeenCalledTimes(1);
+
+    await provider.stop(computer, context);
+    expect(fixture.expireSignedPreviewUrl).toHaveBeenCalledWith(6080, "preview-token");
+    expect(fixture.stop).toHaveBeenCalledWith(120);
+  });
+
+  it("reconnects stopped sandboxes and replaces missing ones", async () => {
+    const existing = daytonaFixture({ id: "existing", state: "stopped" });
+    const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, existing.client);
+    const reconnected = await provider.provision(
+      {
+        botId: "bot-a",
+        homePath: "/unused",
+        providerRef: "existing",
+        providerKind: "daytona",
+      },
+      context,
+    );
+    expect(existing.start).toHaveBeenCalledWith(120);
+    expect(reconnected).toMatchObject({ providerRef: "existing", fresh: false });
+
+    const replacement = daytonaFixture({ id: "replacement" });
+    replacement.get.mockRejectedValueOnce({ statusCode: 404 });
+    const replacingProvider = new DaytonaSandboxProvider(
+      { apiKey: "test-key" },
+      replacement.client,
+    );
+    const replaced = await replacingProvider.provision(
+      {
+        botId: "bot-b",
+        homePath: "/unused",
+        providerRef: "missing",
+        providerKind: "daytona",
+      },
+      context,
+    );
+    expect(replaced).toMatchObject({ providerRef: "replacement", fresh: true });
+  });
+
+  it("coalesces concurrent reconnect and workspace preparation", async () => {
+    const fixture = daytonaFixture({ id: "shared", state: "stopped" });
+    const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const request = {
+      botId: "bot-a",
+      homePath: "/unused",
+      providerRef: "shared",
+      providerKind: "daytona" as const,
+    };
+
+    await Promise.all([provider.provision(request, context), provider.provision(request, context)]);
+
+    expect(fixture.get).toHaveBeenCalledTimes(1);
+    expect(fixture.start).toHaveBeenCalledTimes(1);
+    expect(
+      fixture.executeCommand.mock.calls.filter(([command]) =>
+        String(command).startsWith("mkdir -p -- "),
+      ),
+    ).toHaveLength(1);
+  });
+});
+
+function daytonaFixture(options: { id?: string; state?: string } = {}) {
+  const files = new Map<string, Buffer>();
+  const modes = new Map<string, string>();
+  const id = options.id ?? "daytona-box";
+  const executeCommand = vi.fn(
+    async (command: string, _cwd?: string, _env?: Record<string, string>, _timeout?: number) => {
+      if (command === "'echo' 'hello'") return { exitCode: 0, result: "hello\n" };
+      if (command.startsWith("chmod 700 -- ")) {
+        for (const match of command.matchAll(/'([^']+)'/g)) modes.set(match[1]!, "0755");
+      }
+      return { exitCode: 0, result: "" };
+    },
+  );
+  const uploadFile = vi.fn(async (content: Buffer, target: string) => {
+    files.set(target, Buffer.from(content));
+    modes.set(target, modes.get(target) ?? "0644");
+  });
+  const downloadFile = vi.fn(async (target: string) => Buffer.from(files.get(target) ?? []));
+  const listFiles = vi.fn(async (directory: string) => {
+    const prefix = `${directory.replace(/\/$/, "")}/`;
+    const entries = new Map<string, ReturnType<typeof fileInfo>>();
+    for (const [target, content] of files) {
+      if (!target.startsWith(prefix)) continue;
+      const remainder = target.slice(prefix.length);
+      const [name, ...rest] = remainder.split("/");
+      if (!name) continue;
+      entries.set(
+        name,
+        fileInfo(name, rest.length > 0, rest.length ? 0 : content.byteLength, modes.get(target)),
+      );
+    }
+    return [...entries.values()];
+  });
+  const start = vi.fn(async () => undefined);
+  const stop = vi.fn(async () => undefined);
+  const deleteSandbox = vi.fn(async () => undefined);
+  const expireSignedPreviewUrl = vi.fn(async () => undefined);
+  const drag = vi.fn(async () => ({}));
+  const press = vi.fn(async () => undefined);
+  const type = vi.fn(async () => undefined);
+  const scroll = vi.fn(async () => true);
+  const sandbox = {
+    id,
+    state: options.state ?? "started",
+    process: { executeCommand },
+    fs: {
+      uploadFile,
+      downloadFile,
+      listFiles,
+      getFileDetails: vi.fn(async (target: string) =>
+        fileInfo(target.split("/").at(-1) ?? target, false, files.get(target)?.byteLength ?? 0),
+      ),
+    },
+    computerUse: {
+      start: vi.fn(async () => ({ message: "started" })),
+      stop: vi.fn(async () => ({ message: "stopped" })),
+      screenshot: {
+        takeFullScreen: vi.fn(async () => ({
+          screenshot: Buffer.from([1, 2, 3]).toString("base64"),
+        })),
+      },
+      display: {
+        getInfo: vi.fn(async () => ({ displays: [{ width: 1280, height: 800, isActive: true }] })),
+        getWindows: vi.fn(async () => ({ windows: [{ id: 7, title: "Browser", isActive: true }] })),
+      },
+      mouse: {
+        getPosition: vi.fn(async () => ({ x: 10, y: 20 })),
+        move: vi.fn(async () => ({ x: 10, y: 20 })),
+        click: vi.fn(async () => ({})),
+        drag,
+        scroll,
+      },
+      keyboard: { press, type },
+    },
+    getUserHomeDir: vi.fn(async () => "/home/daytona"),
+    getWorkDir: vi.fn(async () => "/home/daytona"),
+    getSignedPreviewUrl: vi.fn(async () => ({
+      url: "https://6080-preview.proxy.daytona.test",
+      token: "preview-token",
+    })),
+    expireSignedPreviewUrl,
+    refreshActivity: vi.fn(async () => undefined),
+    start,
+    stop,
+    delete: deleteSandbox,
+  } as unknown as Sandbox;
+  const create = vi.fn(async () => sandbox);
+  const get = vi.fn(async () => sandbox);
+  return {
+    sandbox,
+    client: { create, get } satisfies DaytonaSandboxSdk,
+    create,
+    get,
+    executeCommand,
+    start,
+    stop,
+    deleteSandbox,
+    getSignedPreviewUrl: sandbox.getSignedPreviewUrl,
+    expireSignedPreviewUrl,
+    drag,
+    press,
+    type,
+    scroll,
+  };
+}
+
+function fileInfo(name: string, isDir: boolean, size: number, mode = "0644") {
+  return {
+    group: "daytona",
+    isDir,
+    modTime: "",
+    modifiedAt: "2026-01-01T00:00:00Z",
+    mode,
+    name,
+    owner: "daytona",
+    permissions: mode === "0755" ? "rwxr-xr-x" : "rw-r--r--",
+    size,
+  };
+}

--- a/packages/adapters/src/daytona-sandbox.test.ts
+++ b/packages/adapters/src/daytona-sandbox.test.ts
@@ -89,19 +89,13 @@ describe("DaytonaSandboxProvider", () => {
     expect(fixture.type).toHaveBeenCalledWith("hello");
     expect(fixture.scroll).toHaveBeenCalledWith(10, 20, "down", 2);
 
-    const screen = await provider.connectScreen(
-      computer,
-      { view: "stream", interactive: false },
-      context,
-    );
+    const [screen, interactiveScreen] = await Promise.all([
+      provider.connectScreen(computer, { view: "stream", interactive: false }, context),
+      provider.connectScreen(computer, { view: "stream", interactive: true }, context),
+    ]);
     expect(screen.url).toContain("/vnc.html");
     expect(screen.url).toContain("view_only=true");
     await screen.close();
-    const interactiveScreen = await provider.connectScreen(
-      computer,
-      { view: "stream", interactive: true },
-      context,
-    );
     expect(interactiveScreen.url).toContain("view_only=false");
     expect(fixture.getSignedPreviewUrl).toHaveBeenCalledTimes(1);
 
@@ -163,15 +157,57 @@ describe("DaytonaSandboxProvider", () => {
       ),
     ).toHaveLength(1);
   });
+
+  it("deletes a fresh sandbox when workspace preparation fails", async () => {
+    const fixture = daytonaFixture({ prepareFails: true });
+    const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
+
+    await expect(
+      provider.provision({ botId: "bot-a", homePath: "/unused" }, context),
+    ).rejects.toThrow(/could not create Daytona workspace/);
+    expect(fixture.deleteSandbox).toHaveBeenCalledWith(120, true);
+  });
+
+  it("surfaces transient stop failures so cleanup can retry", async () => {
+    const fixture = daytonaFixture();
+    const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+    fixture.stop.mockRejectedValueOnce(new Error("temporary Daytona outage"));
+
+    await expect(provider.stop(computer, context)).rejects.toThrow("temporary Daytona outage");
+    await expect(provider.stop(computer, context)).resolves.toBeUndefined();
+    expect(fixture.get).toHaveBeenCalledTimes(1);
+    expect(fixture.stop).toHaveBeenCalledTimes(2);
+  });
+
+  it("distinguishes transient lookup failures from an already deleted sandbox", async () => {
+    const fixture = daytonaFixture({ id: "remote" });
+    const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = {
+      id: "remote",
+      botId: "bot-a",
+      kind: "daytona" as const,
+      providerRef: "remote",
+      fresh: false,
+    };
+    fixture.get.mockRejectedValueOnce(new Error("temporary Daytona outage"));
+    fixture.get.mockRejectedValueOnce({ statusCode: 404 });
+
+    await expect(provider.stop(computer, context)).rejects.toThrow("temporary Daytona outage");
+    await expect(provider.stop(computer, context)).resolves.toBeUndefined();
+  });
 });
 
-function daytonaFixture(options: { id?: string; state?: string } = {}) {
+function daytonaFixture(options: { id?: string; state?: string; prepareFails?: boolean } = {}) {
   const files = new Map<string, Buffer>();
   const modes = new Map<string, string>();
   const id = options.id ?? "daytona-box";
   const executeCommand = vi.fn(
     async (command: string, _cwd?: string, _env?: Record<string, string>, _timeout?: number) => {
       if (command === "'echo' 'hello'") return { exitCode: 0, result: "hello\n" };
+      if (options.prepareFails && command.startsWith("mkdir -p -- ")) {
+        return { exitCode: 1, result: "could not create Daytona workspace" };
+      }
       if (command.startsWith("chmod 700 -- ")) {
         for (const match of command.matchAll(/'([^']+)'/g)) modes.set(match[1]!, "0755");
       }

--- a/packages/adapters/src/daytona-sandbox.ts
+++ b/packages/adapters/src/daytona-sandbox.ts
@@ -1,0 +1,695 @@
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  Daytona,
+  type DaytonaConfig,
+  DaytonaNotFoundError,
+  DaytonaProcessExecutionTimeoutError,
+  type Sandbox,
+  SandboxState,
+} from "@daytona/sdk";
+import type {
+  AdapterContext,
+  CommandRequest,
+  ComputerAction,
+  ComputerActionRequest,
+  ComputerFileEntry,
+  ComputerInput,
+  ComputerObservation,
+  ComputerRef,
+  ControlLeaseRef,
+  PortableFile,
+  ProcessEvent,
+  SandboxProvider,
+  ScreenRequest,
+  ScreenSession,
+} from "@rakazo/adapter-kit";
+import { boundedSandboxCommandTimeoutMs } from "@rakazo/core";
+import {
+  boundedComputerActions,
+  clampRounded,
+  computerObservation,
+  normalizeWorkspacePath,
+  shellQuote,
+  workspacePath,
+} from "./computer-support.js";
+import { shouldSkipPortableWorkspaceFile } from "./computer-workspace.js";
+
+const DAYTONA_VNC_PORT = 6080;
+const DAYTONA_SCREEN_TTL_SECONDS = 3_600;
+const DAYTONA_TRANSFER_BATCH_BYTES = 8 * 1024 * 1024;
+
+export type DaytonaSandboxSdk = Pick<Daytona, "create" | "get">;
+
+export class DaytonaSandboxProvider implements SandboxProvider {
+  private readonly client: DaytonaSandboxSdk;
+  private readonly boxes = new Map<string, Sandbox>();
+  private readonly connections = new Map<string, Promise<Sandbox>>();
+  private readonly workspaceRoots = new Map<string, string>();
+  private readonly prepared = new Set<string>();
+  private readonly preparations = new Map<string, Promise<void>>();
+  private readonly desktopReady = new Set<string>();
+  private readonly desktopStarts = new Map<string, Promise<void>>();
+  private readonly screenPreviews = new Map<
+    string,
+    { url: string; token: string; expiresAt: number }
+  >();
+  private readonly pointerDown = new Map<
+    string,
+    { x: number; y: number; button: "left" | "right" }
+  >();
+
+  constructor(config: DaytonaConfig & { apiKey: string }, client?: DaytonaSandboxSdk) {
+    this.client =
+      client ??
+      new Daytona({
+        apiKey: config.apiKey,
+        apiUrl: config.apiUrl,
+        target: config.target,
+      });
+  }
+
+  describe() {
+    return {
+      id: "daytona",
+      contractVersion: "1",
+      adapterVersion: "0.1.0",
+      capabilities: {
+        graphical: true,
+        pty: false,
+        snapshots: true,
+        takeover: true,
+        persistentHome: true,
+      },
+    };
+  }
+
+  async provision(
+    request: {
+      botId: string;
+      homePath: string;
+      providerRef?: string;
+      providerKind?: ComputerRef["kind"];
+    },
+    _context: AdapterContext,
+  ): Promise<ComputerRef> {
+    if (request.providerRef && request.providerKind === "daytona") {
+      try {
+        const sandbox = await this.connect(request.providerRef);
+        await this.prepareWorkspace(sandbox);
+        return this.ref(sandbox, request.botId, false);
+      } catch (error) {
+        this.forget(request.providerRef);
+        if (!isUnrecoverableDaytonaError(error)) throw error;
+      }
+    }
+
+    const sandbox = await this.client.create(
+      {
+        labels: { botId: request.botId, rakazo: "computer" },
+        envVars: { VNC_RESOLUTION: "1280x800" },
+        autoStopInterval: 0,
+        autoDeleteInterval: -1,
+      },
+      { timeout: 120 },
+    );
+    this.boxes.set(sandbox.id, sandbox);
+    await this.prepareWorkspace(sandbox);
+    return this.ref(sandbox, request.botId, true);
+  }
+
+  async *execute(
+    computer: ComputerRef,
+    request: CommandRequest,
+    context: AdapterContext,
+  ): AsyncIterable<ProcessEvent> {
+    if (context.signal.aborted) {
+      yield { type: "stderr", data: "command aborted\n" };
+      yield { type: "exit", code: 130 };
+      return;
+    }
+    const sandbox = await this.box(computer);
+    const root = await this.workspaceRoot(sandbox);
+    const timeoutMs = boundedSandboxCommandTimeoutMs(request.timeoutMs);
+    try {
+      const result = await sandbox.process.executeCommand(
+        request.argv.map(shellQuote).join(" "),
+        daytonaCwd(root, request.cwd),
+        request.env,
+        Math.max(1, Math.ceil(timeoutMs / 1_000)),
+      );
+      if (context.signal.aborted) {
+        yield { type: "stderr", data: "command aborted\n" };
+        yield { type: "exit", code: 130 };
+        return;
+      }
+      if (result.result) yield { type: "stdout", data: result.result };
+      yield { type: "exit", code: result.exitCode };
+    } catch (error) {
+      if (error instanceof DaytonaProcessExecutionTimeoutError) {
+        yield { type: "stderr", data: `command timed out after ${timeoutMs} ms\n` };
+        yield { type: "exit", code: 124 };
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async connectScreen(
+    computer: ComputerRef,
+    request: ScreenRequest,
+    _context: AdapterContext,
+  ): Promise<ScreenSession> {
+    const sandbox = await this.box(computer);
+    await this.ensureDesktop(sandbox);
+    const preview = await this.screenPreview(sandbox);
+    const url = new URL(preview.url);
+    url.pathname = "/vnc.html";
+    url.searchParams.set("autoconnect", "true");
+    url.searchParams.set("resize", "scale");
+    url.searchParams.set("view_only", request.interactive ? "false" : "true");
+    return {
+      url: url.toString(),
+      mimeType: "text/html",
+      close: async () => undefined,
+    };
+  }
+
+  async setScreenControl(
+    computer: ComputerRef,
+    _interactive: boolean,
+    _context: AdapterContext,
+  ): Promise<void> {
+    await this.ensureDesktop(await this.box(computer));
+  }
+
+  async sendInput(
+    computer: ComputerRef,
+    input: ComputerInput,
+    _lease: ControlLeaseRef,
+    _context: AdapterContext,
+  ): Promise<void> {
+    const sandbox = await this.box(computer);
+    await this.ensureDesktop(sandbox);
+    await this.applyAction(sandbox, input);
+  }
+
+  async observe(computer: ComputerRef, context: AdapterContext): Promise<ComputerObservation> {
+    const sandbox = await this.box(computer);
+    await this.ensureDesktop(sandbox);
+    const [screenshot, display, windows, cursor] = await Promise.all([
+      sandbox.computerUse.screenshot.takeFullScreen(true),
+      sandbox.computerUse.display.getInfo().catch(() => undefined),
+      sandbox.computerUse.display.getWindows().catch(() => undefined),
+      sandbox.computerUse.mouse.getPosition().catch(() => undefined),
+    ]);
+    if (context.signal.aborted) {
+      throw context.signal.reason ?? new Error("computer observation aborted");
+    }
+    if (!screenshot.screenshot) throw new Error("Daytona screenshot did not contain image data");
+    const primary = display?.displays?.find((entry) => entry.isActive) ?? display?.displays?.[0];
+    const activeWindow = windows?.windows?.find((entry) => entry.isActive);
+    return computerObservation(decodeBase64Image(screenshot.screenshot), {
+      mimeType: screenshot.screenshot.startsWith("data:image/jpeg") ? "image/jpeg" : "image/png",
+      width: primary?.width ?? 1280,
+      height: primary?.height ?? 800,
+      ...(cursor?.x !== undefined && cursor.y !== undefined
+        ? { cursor: { x: cursor.x, y: cursor.y } }
+        : {}),
+      ...(activeWindow?.id !== undefined
+        ? { activeWindow: { id: String(activeWindow.id), title: activeWindow.title } }
+        : {}),
+    });
+  }
+
+  async act(computer: ComputerRef, request: ComputerActionRequest, context: AdapterContext) {
+    const sandbox = await this.box(computer);
+    await this.ensureDesktop(sandbox);
+    const actions = boundedComputerActions(request.actions);
+    let completed = 0;
+    for (const action of actions) {
+      if (context.signal.aborted) {
+        throw context.signal.reason ?? new Error("computer action aborted");
+      }
+      await this.applyAction(sandbox, action);
+      completed += 1;
+    }
+    if (request.settleMs) {
+      await delay(clampRounded(request.settleMs ?? 0, 0, 5_000));
+    }
+    return {
+      completed,
+      ...(request.observe === false ? {} : { observation: await this.observe(computer, context) }),
+    };
+  }
+
+  async listFiles(
+    computer: ComputerRef,
+    directory: string,
+    _context: AdapterContext,
+  ): Promise<ComputerFileEntry[]> {
+    const sandbox = await this.box(computer);
+    const relative = normalizeWorkspacePath(directory);
+    const entries = await sandbox.fs.listFiles(
+      workspacePath(await this.workspaceRoot(sandbox), relative),
+    );
+    return entries
+      .map((entry) => ({
+        path: normalizeWorkspacePath(relative ? `${relative}/${entry.name}` : entry.name),
+        kind: entry.isDir ? ("dir" as const) : ("file" as const),
+        size: entry.size,
+        ...(!entry.isDir && isDaytonaExecutable(entry.mode, entry.permissions)
+          ? { executable: true }
+          : {}),
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  async readFile(
+    computer: ComputerRef,
+    filePath: string,
+    _context: AdapterContext,
+    options?: { maxBytes?: number },
+  ): Promise<Uint8Array> {
+    const sandbox = await this.box(computer);
+    const target = workspacePath(await this.workspaceRoot(sandbox), filePath);
+    if (options?.maxBytes !== undefined) {
+      const info = await sandbox.fs.getFileDetails(target);
+      if (info.size > options.maxBytes) {
+        throw new Error(`computer file exceeds ${options.maxBytes} bytes`);
+      }
+    }
+    const content = await sandbox.fs.downloadFile(target);
+    return new Uint8Array(content.buffer, content.byteOffset, content.byteLength);
+  }
+
+  async writeFile(computer: ComputerRef, file: PortableFile, _context: AdapterContext) {
+    const sandbox = await this.box(computer);
+    await this.writeFiles(sandbox, [file]);
+  }
+
+  async *exportWorkspace(
+    computer: ComputerRef,
+    context: AdapterContext,
+  ): AsyncIterable<PortableFile> {
+    const sandbox = await this.box(computer);
+    await stopDaytonaBrowsers(sandbox);
+    try {
+      yield* walkDaytonaWorkspace(sandbox, await this.workspaceRoot(sandbox), "", context);
+    } finally {
+      if (context.operationId !== "stop" && context.operationId !== "computer.sleep") {
+        await this.openBrowser(sandbox).catch(() => undefined);
+      }
+    }
+  }
+
+  async importWorkspace(
+    computer: ComputerRef,
+    files: AsyncIterable<PortableFile>,
+    context: AdapterContext,
+  ): Promise<void> {
+    const sandbox = await this.box(computer);
+    await stopDaytonaBrowsers(sandbox);
+    let batch: PortableFile[] = [];
+    let batchBytes = 0;
+    const flush = async () => {
+      if (!batch.length) return;
+      await this.writeFiles(sandbox, batch);
+      batch = [];
+      batchBytes = 0;
+    };
+    for await (const file of files) {
+      if (context.signal.aborted) throw context.signal.reason ?? new Error("import aborted");
+      if (
+        batch.length >= 8 ||
+        batchBytes + file.content.byteLength > DAYTONA_TRANSFER_BATCH_BYTES
+      ) {
+        await flush();
+      }
+      batch.push(file);
+      batchBytes += file.content.byteLength;
+    }
+    await flush();
+    await configurePortableBrowserProfiles(sandbox, await this.workspaceRoot(sandbox));
+    this.prepared.add(sandbox.id);
+    await this.openBrowser(sandbox).catch(() => undefined);
+  }
+
+  async snapshot(computer: ComputerRef, context: AdapterContext) {
+    const observation = await this.observe(computer, context);
+    return { id: observation.frameId, createdAt: observation.capturedAt };
+  }
+
+  async keepAlive(computer: ComputerRef): Promise<void> {
+    await (await this.box(computer)).refreshActivity();
+  }
+
+  async stop(computer: ComputerRef, _context: AdapterContext): Promise<void> {
+    const id = computer.providerRef || computer.id;
+    const sandbox = this.boxes.get(id) ?? (await this.client.get(id).catch(() => undefined));
+    if (sandbox) {
+      await this.revokeScreenPreview(sandbox);
+      await sandbox.computerUse.stop().catch(() => undefined);
+      await sandbox.stop(120).catch(() => undefined);
+    }
+    this.forget(id);
+  }
+
+  async destroy(computer: ComputerRef, _context: AdapterContext): Promise<void> {
+    const id = computer.providerRef || computer.id;
+    const sandbox = this.boxes.get(id) ?? (await this.client.get(id).catch(() => undefined));
+    if (sandbox) await this.revokeScreenPreview(sandbox);
+    await sandbox?.delete(120, true);
+    this.forget(id);
+  }
+
+  private ref(sandbox: Sandbox, botId: string, fresh: boolean): ComputerRef {
+    return {
+      id: sandbox.id,
+      botId,
+      kind: "daytona",
+      providerRef: sandbox.id,
+      fresh,
+    };
+  }
+
+  private async connect(id: string): Promise<Sandbox> {
+    const existing = this.boxes.get(id);
+    if (existing) return existing;
+    const pending = this.connections.get(id);
+    if (pending) return pending;
+    const connection = (async () => {
+      const sandbox = await this.client.get(id);
+      if (sandbox.state !== SandboxState.STARTED) await sandbox.start(120);
+      this.boxes.set(id, sandbox);
+      return sandbox;
+    })().finally(() => {
+      this.connections.delete(id);
+    });
+    this.connections.set(id, connection);
+    return connection;
+  }
+
+  private async box(computer: ComputerRef): Promise<Sandbox> {
+    return this.connect(computer.providerRef || computer.id);
+  }
+
+  private async workspaceRoot(sandbox: Sandbox): Promise<string> {
+    const cached = this.workspaceRoots.get(sandbox.id);
+    if (cached) return cached;
+    const home = (await sandbox.getUserHomeDir()) ?? (await sandbox.getWorkDir());
+    if (!home) throw new Error("Daytona did not report a sandbox home directory");
+    const root = path.posix.join(home, "rakazo-home");
+    this.workspaceRoots.set(sandbox.id, root);
+    return root;
+  }
+
+  private async prepareWorkspace(sandbox: Sandbox): Promise<void> {
+    if (this.prepared.has(sandbox.id)) return;
+    const pending = this.preparations.get(sandbox.id);
+    if (pending) return pending;
+    const preparation = (async () => {
+      const root = await this.workspaceRoot(sandbox);
+      const result = await sandbox.process.executeCommand(`mkdir -p -- ${shellQuote(root)}`);
+      if (result.exitCode !== 0) {
+        throw new Error(result.result || "could not create Daytona workspace");
+      }
+      await configurePortableBrowserProfiles(sandbox, root);
+      this.prepared.add(sandbox.id);
+    })().finally(() => {
+      this.preparations.delete(sandbox.id);
+    });
+    this.preparations.set(sandbox.id, preparation);
+    return preparation;
+  }
+
+  private async ensureDesktop(sandbox: Sandbox): Promise<void> {
+    if (this.desktopReady.has(sandbox.id)) return;
+    const pending = this.desktopStarts.get(sandbox.id);
+    if (pending) return pending;
+    const start = sandbox.computerUse
+      .start()
+      .then(() => {
+        this.desktopReady.add(sandbox.id);
+      })
+      .finally(() => {
+        this.desktopStarts.delete(sandbox.id);
+      });
+    this.desktopStarts.set(sandbox.id, start);
+    return start;
+  }
+
+  private async openBrowser(sandbox: Sandbox): Promise<void> {
+    await this.ensureDesktop(sandbox);
+    await launchDaytonaApplication(sandbox, "browser");
+  }
+
+  private async applyAction(sandbox: Sandbox, action: ComputerAction): Promise<void> {
+    if (action.kind === "key") {
+      await sandbox.computerUse.keyboard.press(action.key, action.modifiers);
+      return;
+    }
+    if (action.kind === "clipboard") {
+      await sandbox.computerUse.keyboard.type(action.text);
+      return;
+    }
+    if (action.kind === "pointer") {
+      const button = action.button ?? "left";
+      if (action.type === "move") await sandbox.computerUse.mouse.move(action.x, action.y);
+      else if (action.type === "click") {
+        await sandbox.computerUse.mouse.click(action.x, action.y, button);
+      } else if (action.type === "down") {
+        await sandbox.computerUse.mouse.move(action.x, action.y);
+        this.pointerDown.set(sandbox.id, { x: action.x, y: action.y, button });
+      } else {
+        const start = this.pointerDown.get(sandbox.id);
+        this.pointerDown.delete(sandbox.id);
+        if (start && (start.x !== action.x || start.y !== action.y)) {
+          await sandbox.computerUse.mouse.drag(start.x, start.y, action.x, action.y, start.button);
+        } else {
+          await sandbox.computerUse.mouse.click(action.x, action.y, start?.button ?? button);
+        }
+      }
+      return;
+    }
+    if (action.kind === "scroll") {
+      const position = await sandbox.computerUse.mouse.getPosition();
+      await sandbox.computerUse.mouse.scroll(
+        position.x ?? 0,
+        position.y ?? 0,
+        action.direction,
+        clampRounded(action.amount ?? 3, 1, 20),
+      );
+      return;
+    }
+    if (action.kind === "wait") {
+      await delay(clampRounded(action.ms, 0, 5_000));
+      return;
+    }
+    if (action.kind === "open") {
+      const root = await this.workspaceRoot(sandbox);
+      const value = /^https?:\/\//i.test(action.path)
+        ? action.path
+        : workspacePath(root, action.path);
+      await launchDaytonaApplication(sandbox, "browser", value);
+      return;
+    }
+    await launchDaytonaApplication(sandbox, action.application, action.uri);
+  }
+
+  private async writeFiles(sandbox: Sandbox, files: readonly PortableFile[]): Promise<void> {
+    if (!files.length) return;
+    const root = await this.workspaceRoot(sandbox);
+    const directories = new Set(
+      files.map((file) => path.posix.dirname(workspacePath(root, file.path))),
+    );
+    const mkdir = await sandbox.process.executeCommand(
+      `mkdir -p -- ${[...directories].map(shellQuote).join(" ")}`,
+    );
+    if (mkdir.exitCode !== 0) throw new Error(mkdir.result || "could not create file directories");
+    await Promise.all(
+      files.map((file) =>
+        sandbox.fs.uploadFile(
+          Buffer.from(file.content.buffer, file.content.byteOffset, file.content.byteLength),
+          workspacePath(root, file.path),
+        ),
+      ),
+    );
+    const executable = files
+      .filter((file) => file.executable)
+      .map((file) => shellQuote(workspacePath(root, file.path)));
+    if (executable.length) {
+      const chmod = await sandbox.process.executeCommand(`chmod 700 -- ${executable.join(" ")}`);
+      if (chmod.exitCode !== 0) throw new Error(chmod.result || "could not mark files executable");
+    }
+  }
+
+  private async screenPreview(sandbox: Sandbox) {
+    const cached = this.screenPreviews.get(sandbox.id);
+    if (cached && cached.expiresAt > Date.now() + 60_000) return cached;
+    const preview = await sandbox.getSignedPreviewUrl(DAYTONA_VNC_PORT, DAYTONA_SCREEN_TTL_SECONDS);
+    const cachedPreview = {
+      url: preview.url,
+      token: preview.token,
+      expiresAt: Date.now() + DAYTONA_SCREEN_TTL_SECONDS * 1_000,
+    };
+    this.screenPreviews.set(sandbox.id, cachedPreview);
+    return cachedPreview;
+  }
+
+  private async revokeScreenPreview(sandbox: Sandbox): Promise<void> {
+    const preview = this.screenPreviews.get(sandbox.id);
+    this.screenPreviews.delete(sandbox.id);
+    if (!preview) return;
+    await sandbox.expireSignedPreviewUrl(DAYTONA_VNC_PORT, preview.token).catch(() => undefined);
+  }
+
+  private forget(id: string): void {
+    this.boxes.delete(id);
+    this.connections.delete(id);
+    this.workspaceRoots.delete(id);
+    this.prepared.delete(id);
+    this.preparations.delete(id);
+    this.desktopReady.delete(id);
+    this.desktopStarts.delete(id);
+    this.screenPreviews.delete(id);
+    this.pointerDown.delete(id);
+  }
+}
+
+export function isUnrecoverableDaytonaError(error: unknown): boolean {
+  if (error instanceof DaytonaNotFoundError) return true;
+  if (!error || typeof error !== "object") return false;
+  const details = error as { status?: unknown; statusCode?: unknown; code?: unknown };
+  return (
+    details.status === 404 ||
+    details.statusCode === 404 ||
+    details.code === 404 ||
+    details.code === "NOT_FOUND"
+  );
+}
+
+function daytonaCwd(root: string, cwd: string | undefined): string {
+  if (
+    !cwd ||
+    cwd === "." ||
+    cwd === "/" ||
+    cwd === "/home/rakazo" ||
+    cwd === "/home/user" ||
+    cwd === "/home/daytona" ||
+    cwd === root
+  ) {
+    return root;
+  }
+  return workspacePath(root, cwd);
+}
+
+function decodeBase64Image(value: string): Uint8Array {
+  const content = Buffer.from(value.replace(/^data:image\/[a-z0-9.+-]+;base64,/i, ""), "base64");
+  return new Uint8Array(content.buffer, content.byteOffset, content.byteLength);
+}
+
+function isDaytonaExecutable(mode: string, permissions: string): boolean {
+  return /x/.test(permissions) || (Number.parseInt(mode, 8) & 0o100) !== 0;
+}
+
+async function configurePortableBrowserProfiles(sandbox: Sandbox, root: string): Promise<boolean> {
+  const profileRoot = path.posix.join(root, ".browser-profiles");
+  const chrome = path.posix.join(profileRoot, "chromium");
+  const firefox = path.posix.join(profileRoot, "firefox");
+  const home = (await sandbox.getUserHomeDir()) ?? "/home/daytona";
+  const googleChromeLink = path.posix.join(home, ".config/google-chrome");
+  const chromiumLink = path.posix.join(home, ".config/chromium");
+  const firefoxLink = path.posix.join(home, ".mozilla");
+  const configured = await sandbox.process
+    .executeCommand(
+      [
+        `test "$(readlink -f ${shellQuote(googleChromeLink)} 2>/dev/null)" = ${shellQuote(chrome)}`,
+        `test "$(readlink -f ${shellQuote(chromiumLink)} 2>/dev/null)" = ${shellQuote(chrome)}`,
+        `test "$(readlink -f ${shellQuote(firefoxLink)} 2>/dev/null)" = ${shellQuote(firefox)}`,
+      ].join(" && "),
+    )
+    .then(
+      (result) => result.exitCode === 0,
+      () => false,
+    );
+  if (configured) return false;
+  await stopDaytonaBrowsers(sandbox);
+  const result = await sandbox.process.executeCommand(
+    [
+      `mkdir -p ${shellQuote(chrome)} ${shellQuote(firefox)} ${shellQuote(path.posix.join(home, ".config"))}`,
+      `rm -rf ${shellQuote(googleChromeLink)} ${shellQuote(chromiumLink)} ${shellQuote(firefoxLink)}`,
+      `ln -s ${shellQuote(chrome)} ${shellQuote(googleChromeLink)}`,
+      `ln -s ${shellQuote(chrome)} ${shellQuote(chromiumLink)}`,
+      `ln -s ${shellQuote(firefox)} ${shellQuote(firefoxLink)}`,
+    ].join(" && "),
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(result.result || "could not configure portable Daytona browser profiles");
+  }
+  return true;
+}
+
+async function stopDaytonaBrowsers(sandbox: Sandbox): Promise<void> {
+  await sandbox.process
+    .executeCommand("pkill -f '[g]oogle-chrome|[c]hromium|[f]irefox' || true")
+    .catch(() => undefined);
+}
+
+async function launchDaytonaApplication(
+  sandbox: Sandbox,
+  application: string,
+  uri?: string,
+): Promise<void> {
+  const app = application === "browser" ? "google-chrome chromium firefox" : application;
+  const candidates = app.split(/\s+/).filter(Boolean);
+  const command = [
+    String.raw`export DISPLAY=\${DISPLAY:-:99}`,
+    `for app in ${candidates.map(shellQuote).join(" ")}; do`,
+    '  if command -v "$app" >/dev/null 2>&1; then',
+    `    nohup "$app"${uri ? ` ${shellQuote(uri)}` : ""} >/tmp/rakazo-app.log 2>&1 &`,
+    "    exit 0",
+    "  fi",
+    "done",
+    "exit 1",
+  ].join("\n");
+  const result = await sandbox.process.executeCommand(command);
+  if (result.exitCode !== 0) {
+    throw new Error(result.result || `Daytona application ${application} is not installed`);
+  }
+}
+
+async function* walkDaytonaWorkspace(
+  sandbox: Sandbox,
+  root: string,
+  directory: string,
+  context: AdapterContext,
+): AsyncIterable<PortableFile> {
+  if (context.signal.aborted) throw context.signal.reason ?? new Error("export aborted");
+  const entries = await sandbox.fs.listFiles(workspacePath(root, directory));
+  const files = entries.filter((entry) => !entry.isDir);
+  const directories = entries.filter((entry) => entry.isDir);
+  for (let index = 0; index < files.length; index += 8) {
+    const batch = await Promise.all(
+      files.slice(index, index + 8).map(async (entry) => {
+        const relative = normalizeWorkspacePath(
+          directory ? `${directory}/${entry.name}` : entry.name,
+        );
+        if (shouldSkipPortableWorkspaceFile(relative)) return undefined;
+        const content = await sandbox.fs.downloadFile(workspacePath(root, relative));
+        return {
+          path: relative,
+          content: new Uint8Array(content.buffer, content.byteOffset, content.byteLength),
+          executable: isDaytonaExecutable(entry.mode, entry.permissions),
+        };
+      }),
+    );
+    for (const file of batch) if (file) yield file;
+  }
+  for (const entry of directories) {
+    const relative = normalizeWorkspacePath(directory ? `${directory}/${entry.name}` : entry.name);
+    if (!shouldSkipPortableWorkspaceFile(`${relative}/placeholder`)) {
+      yield* walkDaytonaWorkspace(sandbox, root, relative, context);
+    }
+  }
+}

--- a/packages/adapters/src/daytona-sandbox.ts
+++ b/packages/adapters/src/daytona-sandbox.ts
@@ -33,11 +33,14 @@ import {
   shellQuote,
   workspacePath,
 } from "./computer-support.js";
-import { shouldSkipPortableWorkspaceFile } from "./computer-workspace.js";
+import {
+  PORTABLE_BROWSER_STOP_COMMAND,
+  PORTABLE_TRANSFER_BATCH_BYTES,
+  shouldSkipPortableWorkspaceFile,
+} from "./computer-workspace.js";
 
 const DAYTONA_VNC_PORT = 6080;
 const DAYTONA_SCREEN_TTL_SECONDS = 3_600;
-const DAYTONA_TRANSFER_BATCH_BYTES = 8 * 1024 * 1024;
 
 export type DaytonaSandboxSdk = Pick<Daytona, "create" | "get">;
 
@@ -53,6 +56,10 @@ export class DaytonaSandboxProvider implements SandboxProvider {
   private readonly screenPreviews = new Map<
     string,
     { url: string; token: string; expiresAt: number }
+  >();
+  private readonly screenPreviewStarts = new Map<
+    string,
+    Promise<{ url: string; token: string; expiresAt: number }>
   >();
   private readonly pointerDown = new Map<
     string,
@@ -114,8 +121,21 @@ export class DaytonaSandboxProvider implements SandboxProvider {
       { timeout: 120 },
     );
     this.boxes.set(sandbox.id, sandbox);
-    await this.prepareWorkspace(sandbox);
-    return this.ref(sandbox, request.botId, true);
+    try {
+      await this.prepareWorkspace(sandbox);
+      return this.ref(sandbox, request.botId, true);
+    } catch (error) {
+      this.forget(sandbox.id);
+      try {
+        await sandbox.delete(120, true);
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "Daytona workspace preparation and sandbox cleanup failed",
+        );
+      }
+      throw error;
+    }
   }
 
   async *execute(
@@ -322,7 +342,7 @@ export class DaytonaSandboxProvider implements SandboxProvider {
       if (context.signal.aborted) throw context.signal.reason ?? new Error("import aborted");
       if (
         batch.length >= 8 ||
-        batchBytes + file.content.byteLength > DAYTONA_TRANSFER_BATCH_BYTES
+        batchBytes + file.content.byteLength > PORTABLE_TRANSFER_BATCH_BYTES
       ) {
         await flush();
       }
@@ -346,21 +366,29 @@ export class DaytonaSandboxProvider implements SandboxProvider {
 
   async stop(computer: ComputerRef, _context: AdapterContext): Promise<void> {
     const id = computer.providerRef || computer.id;
-    const sandbox = this.boxes.get(id) ?? (await this.client.get(id).catch(() => undefined));
-    if (sandbox) {
-      await this.revokeScreenPreview(sandbox);
-      await sandbox.computerUse.stop().catch(() => undefined);
-      await sandbox.stop(120).catch(() => undefined);
+    const sandbox = await this.findForTeardown(id);
+    if (!sandbox) {
+      this.forget(id);
+      return;
     }
+    const preview = this.screenPreviews.get(id);
     this.forget(id);
+    await this.revokeScreenPreview(sandbox, preview);
+    await sandbox.computerUse.stop().catch(() => undefined);
+    await sandbox.stop(120);
   }
 
   async destroy(computer: ComputerRef, _context: AdapterContext): Promise<void> {
     const id = computer.providerRef || computer.id;
-    const sandbox = this.boxes.get(id) ?? (await this.client.get(id).catch(() => undefined));
-    if (sandbox) await this.revokeScreenPreview(sandbox);
-    await sandbox?.delete(120, true);
+    const sandbox = await this.findForTeardown(id);
+    if (!sandbox) {
+      this.forget(id);
+      return;
+    }
+    const preview = this.screenPreviews.get(id);
     this.forget(id);
+    await this.revokeScreenPreview(sandbox, preview);
+    await sandbox.delete(120, true);
   }
 
   private ref(sandbox: Sandbox, botId: string, fresh: boolean): ComputerRef {
@@ -378,13 +406,17 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     if (existing) return existing;
     const pending = this.connections.get(id);
     if (pending) return pending;
-    const connection = (async () => {
+    let connection!: Promise<Sandbox>;
+    connection = (async () => {
       const sandbox = await this.client.get(id);
       if (sandbox.state !== SandboxState.STARTED) await sandbox.start(120);
+      if (this.connections.get(id) !== connection) {
+        throw new Error("Daytona connection was invalidated during teardown");
+      }
       this.boxes.set(id, sandbox);
       return sandbox;
     })().finally(() => {
-      this.connections.delete(id);
+      if (this.connections.get(id) === connection) this.connections.delete(id);
     });
     this.connections.set(id, connection);
     return connection;
@@ -394,13 +426,24 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     return this.connect(computer.providerRef || computer.id);
   }
 
+  private async findForTeardown(id: string): Promise<Sandbox | undefined> {
+    const existing = this.boxes.get(id);
+    if (existing) return existing;
+    try {
+      return await this.client.get(id);
+    } catch (error) {
+      if (isUnrecoverableDaytonaError(error)) return undefined;
+      throw error;
+    }
+  }
+
   private async workspaceRoot(sandbox: Sandbox): Promise<string> {
     const cached = this.workspaceRoots.get(sandbox.id);
     if (cached) return cached;
     const home = (await sandbox.getUserHomeDir()) ?? (await sandbox.getWorkDir());
     if (!home) throw new Error("Daytona did not report a sandbox home directory");
     const root = path.posix.join(home, "rakazo-home");
-    this.workspaceRoots.set(sandbox.id, root);
+    if (this.boxes.get(sandbox.id) === sandbox) this.workspaceRoots.set(sandbox.id, root);
     return root;
   }
 
@@ -408,16 +451,22 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     if (this.prepared.has(sandbox.id)) return;
     const pending = this.preparations.get(sandbox.id);
     if (pending) return pending;
-    const preparation = (async () => {
+    let preparation!: Promise<void>;
+    preparation = (async () => {
       const root = await this.workspaceRoot(sandbox);
       const result = await sandbox.process.executeCommand(`mkdir -p -- ${shellQuote(root)}`);
       if (result.exitCode !== 0) {
         throw new Error(result.result || "could not create Daytona workspace");
       }
       await configurePortableBrowserProfiles(sandbox, root);
+      if (this.preparations.get(sandbox.id) !== preparation) {
+        throw new Error("Daytona workspace preparation was invalidated during teardown");
+      }
       this.prepared.add(sandbox.id);
     })().finally(() => {
-      this.preparations.delete(sandbox.id);
+      if (this.preparations.get(sandbox.id) === preparation) {
+        this.preparations.delete(sandbox.id);
+      }
     });
     this.preparations.set(sandbox.id, preparation);
     return preparation;
@@ -427,13 +476,19 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     if (this.desktopReady.has(sandbox.id)) return;
     const pending = this.desktopStarts.get(sandbox.id);
     if (pending) return pending;
-    const start = sandbox.computerUse
+    let start!: Promise<void>;
+    start = sandbox.computerUse
       .start()
       .then(() => {
+        if (this.desktopStarts.get(sandbox.id) !== start) {
+          throw new Error("Daytona desktop start was invalidated during teardown");
+        }
         this.desktopReady.add(sandbox.id);
       })
       .finally(() => {
-        this.desktopStarts.delete(sandbox.id);
+        if (this.desktopStarts.get(sandbox.id) === start) {
+          this.desktopStarts.delete(sandbox.id);
+        }
       });
     this.desktopStarts.set(sandbox.id, start);
     return start;
@@ -527,19 +582,39 @@ export class DaytonaSandboxProvider implements SandboxProvider {
   private async screenPreview(sandbox: Sandbox) {
     const cached = this.screenPreviews.get(sandbox.id);
     if (cached && cached.expiresAt > Date.now() + 60_000) return cached;
-    const preview = await sandbox.getSignedPreviewUrl(DAYTONA_VNC_PORT, DAYTONA_SCREEN_TTL_SECONDS);
-    const cachedPreview = {
-      url: preview.url,
-      token: preview.token,
-      expiresAt: Date.now() + DAYTONA_SCREEN_TTL_SECONDS * 1_000,
-    };
-    this.screenPreviews.set(sandbox.id, cachedPreview);
-    return cachedPreview;
+    const pending = this.screenPreviewStarts.get(sandbox.id);
+    if (pending) return pending;
+    let start!: Promise<{ url: string; token: string; expiresAt: number }>;
+    start = sandbox
+      .getSignedPreviewUrl(DAYTONA_VNC_PORT, DAYTONA_SCREEN_TTL_SECONDS)
+      .then(async (preview) => {
+        const cachedPreview = {
+          url: preview.url,
+          token: preview.token,
+          expiresAt: Date.now() + DAYTONA_SCREEN_TTL_SECONDS * 1_000,
+        };
+        if (this.screenPreviewStarts.get(sandbox.id) !== start) {
+          await sandbox
+            .expireSignedPreviewUrl(DAYTONA_VNC_PORT, preview.token)
+            .catch(() => undefined);
+          throw new Error("Daytona screen preview was invalidated during teardown");
+        }
+        this.screenPreviews.set(sandbox.id, cachedPreview);
+        return cachedPreview;
+      })
+      .finally(() => {
+        if (this.screenPreviewStarts.get(sandbox.id) === start) {
+          this.screenPreviewStarts.delete(sandbox.id);
+        }
+      });
+    this.screenPreviewStarts.set(sandbox.id, start);
+    return start;
   }
 
-  private async revokeScreenPreview(sandbox: Sandbox): Promise<void> {
-    const preview = this.screenPreviews.get(sandbox.id);
-    this.screenPreviews.delete(sandbox.id);
+  private async revokeScreenPreview(
+    sandbox: Sandbox,
+    preview = this.screenPreviews.get(sandbox.id),
+  ): Promise<void> {
     if (!preview) return;
     await sandbox.expireSignedPreviewUrl(DAYTONA_VNC_PORT, preview.token).catch(() => undefined);
   }
@@ -553,6 +628,7 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     this.desktopReady.delete(id);
     this.desktopStarts.delete(id);
     this.screenPreviews.delete(id);
+    this.screenPreviewStarts.delete(id);
     this.pointerDown.delete(id);
   }
 }
@@ -631,9 +707,7 @@ async function configurePortableBrowserProfiles(sandbox: Sandbox, root: string):
 }
 
 async function stopDaytonaBrowsers(sandbox: Sandbox): Promise<void> {
-  await sandbox.process
-    .executeCommand("pkill -f '[g]oogle-chrome|[c]hromium|[f]irefox' || true")
-    .catch(() => undefined);
+  await sandbox.process.executeCommand(PORTABLE_BROWSER_STOP_COMMAND).catch(() => undefined);
 }
 
 async function launchDaytonaApplication(
@@ -667,15 +741,17 @@ async function* walkDaytonaWorkspace(
 ): AsyncIterable<PortableFile> {
   if (context.signal.aborted) throw context.signal.reason ?? new Error("export aborted");
   const entries = await sandbox.fs.listFiles(workspacePath(root, directory));
-  const files = entries.filter((entry) => !entry.isDir);
+  const files = entries
+    .filter((entry) => !entry.isDir)
+    .map((entry) => ({
+      entry,
+      relative: normalizeWorkspacePath(directory ? `${directory}/${entry.name}` : entry.name),
+    }))
+    .filter(({ relative }) => !shouldSkipPortableWorkspaceFile(relative));
   const directories = entries.filter((entry) => entry.isDir);
-  for (let index = 0; index < files.length; index += 8) {
+  for (const entries of daytonaExportBatches(files)) {
     const batch = await Promise.all(
-      files.slice(index, index + 8).map(async (entry) => {
-        const relative = normalizeWorkspacePath(
-          directory ? `${directory}/${entry.name}` : entry.name,
-        );
-        if (shouldSkipPortableWorkspaceFile(relative)) return undefined;
+      entries.map(async ({ entry, relative }) => {
         const content = await sandbox.fs.downloadFile(workspacePath(root, relative));
         return {
           path: relative,
@@ -684,7 +760,7 @@ async function* walkDaytonaWorkspace(
         };
       }),
     );
-    for (const file of batch) if (file) yield file;
+    for (const file of batch) yield file;
   }
   for (const entry of directories) {
     const relative = normalizeWorkspacePath(directory ? `${directory}/${entry.name}` : entry.name);
@@ -692,4 +768,24 @@ async function* walkDaytonaWorkspace(
       yield* walkDaytonaWorkspace(sandbox, root, relative, context);
     }
   }
+}
+
+function daytonaExportBatches<T extends { entry: { size: number } }>(files: readonly T[]): T[][] {
+  const batches: T[][] = [];
+  let batch: T[] = [];
+  let batchBytes = 0;
+  for (const file of files) {
+    if (
+      batch.length > 0 &&
+      (batch.length >= 8 || batchBytes + file.entry.size > PORTABLE_TRANSFER_BATCH_BYTES)
+    ) {
+      batches.push(batch);
+      batch = [];
+      batchBytes = 0;
+    }
+    batch.push(file);
+    batchBytes += file.entry.size;
+  }
+  if (batch.length) batches.push(batch);
+  return batches;
 }

--- a/packages/adapters/src/e2b-emulator.ts
+++ b/packages/adapters/src/e2b-emulator.ts
@@ -3,12 +3,19 @@ import { FakeSandboxProvider } from "./fake-sandbox.js";
 
 /** Managed-provider protocol emulator backed by deterministic local state. */
 export class ManagedSandboxEmulator extends FakeSandboxProvider {
-  readonly dest = this.boxes;
+  constructor(
+    private readonly emulator: {
+      id: string;
+      kind: ComputerRef["kind"];
+    } = { id: "e2b-emulator", kind: "e2b" },
+  ) {
+    super();
+  }
 
   override describe() {
     return {
       ...super.describe(),
-      id: "e2b-emulator",
+      id: this.emulator.id,
     };
   }
 
@@ -17,6 +24,6 @@ export class ManagedSandboxEmulator extends FakeSandboxProvider {
     context: AdapterContext,
   ): Promise<ComputerRef> {
     const ref = await super.provision(request, context);
-    return { ...ref, kind: "e2b" };
+    return { ...ref, kind: this.emulator.kind };
   }
 }

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -1,10 +1,7 @@
 import { type Sandbox, TimeoutError } from "@e2b/desktop";
 import { describe, expect, it, vi } from "vitest";
-import {
-  E2BSandboxProvider,
-  type E2BSandboxSdk,
-  shouldSkipPortableWorkspaceFile,
-} from "./e2b-sandbox.js";
+import { shouldSkipPortableWorkspaceFile } from "./computer-workspace.js";
+import { E2BSandboxProvider, type E2BSandboxSdk } from "./e2b-sandbox.js";
 
 const context = {
   operationId: "e2b-test",
@@ -39,6 +36,8 @@ describe("E2B computer backend", () => {
       };
     });
     const getStreamUrl = vi.fn(() => "https://desktop.test/vnc.html");
+    const streamStart = vi.fn(async () => undefined);
+    const streamStop = vi.fn(async () => undefined);
     const desktop = {
       sandboxId: "e2b-test-box",
       display: ":0",
@@ -67,8 +66,8 @@ describe("E2B computer backend", () => {
         }),
       },
       stream: {
-        start: vi.fn(async () => undefined),
-        stop: vi.fn(async () => undefined),
+        start: streamStart,
+        stop: streamStop,
         getAuthKey: () => "screen-key",
         getUrl: getStreamUrl,
       },
@@ -215,5 +214,22 @@ describe("E2B computer backend", () => {
       context,
     );
     expect(stillCurrent.url).toBe(replacementControl.url);
+
+    await screen.close();
+    let finishStart!: () => void;
+    streamStart.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finishStart = () => resolve(undefined);
+        }),
+    );
+    const connecting = provider.connectScreen(computer, { view: "stream" }, context);
+    await vi.waitFor(() => expect(desktop.stream.start).toHaveBeenCalledTimes(2));
+    const stopping = provider.stop(computer, context);
+    finishStart();
+    await expect(connecting).rejects.toThrow(/teardown/);
+    await stopping;
+    expect(desktop.pause).toHaveBeenCalled();
+    expect(streamStop).toHaveBeenCalled();
   });
 });

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -164,9 +164,13 @@ describe("E2B computer backend", () => {
       true,
     );
     expect(command.mock.calls.some(([value]) => String(value).includes("cp -a"))).toBe(false);
-    const screen = await provider.connectScreen(computer, { view: "stream" }, context);
+    const [screen] = await Promise.all([
+      provider.connectScreen(computer, { view: "stream" }, context),
+      provider.connectScreen(computer, { view: "stream" }, context),
+    ]);
     expect(screen.url).toBe("https://desktop.test/vnc.html");
     expect(desktop.stream.start).toHaveBeenCalledWith({ requireAuth: true });
+    expect(desktop.stream.start).toHaveBeenCalledTimes(1);
     expect(getStreamUrl).toHaveBeenCalledWith(
       expect.objectContaining({ viewOnly: true, authKey: "screen-key" }),
     );

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import { Sandbox, TimeoutError } from "@e2b/desktop";
 import type {
   AdapterContext,
@@ -26,6 +27,7 @@ import {
   shellQuote,
   workspacePath,
 } from "./computer-support.js";
+import { shouldSkipPortableWorkspaceFile } from "./computer-workspace.js";
 
 const E2B_WORKSPACE = "/home/user/rakazo-home";
 const E2B_BROWSER_PROFILES = `${E2B_WORKSPACE}/.browser-profiles`;
@@ -118,6 +120,9 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 
   private async startStream(desktop: Sandbox) {
+    if (this.boxes.get(desktop.sandboxId) !== desktop) {
+      throw new Error("screen stream stopped during computer teardown");
+    }
     if (this.streamReady.has(desktop.sandboxId)) return;
     const pending = this.streamStarts.get(desktop.sandboxId);
     if (pending) return pending;
@@ -138,6 +143,10 @@ export class E2BSandboxProvider implements SandboxProvider {
     } catch (error) {
       await desktop.stream.stop().catch(() => undefined);
       throw error;
+    }
+    if (this.boxes.get(desktop.sandboxId) !== desktop) {
+      await desktop.stream.stop().catch(() => undefined);
+      throw new Error("screen stream stopped during computer teardown");
     }
     this.streamReady.add(desktop.sandboxId);
   }
@@ -411,12 +420,10 @@ export class E2BSandboxProvider implements SandboxProvider {
 
   async stop(computer: ComputerRef, _context: AdapterContext): Promise<void> {
     const id = computer.providerRef || computer.id;
+    const pending = this.streamStarts.get(id);
     const desktop = this.boxes.get(id);
-    this.boxes.delete(id);
-    this.lastTouchedAt.delete(id);
-    this.streamReady.delete(id);
-    this.streamStarts.delete(id);
-    this.controlStreams.delete(id);
+    this.forget(id);
+    await settleForTeardown(pending);
     if (desktop) {
       await desktop.pause().catch(() => undefined);
       return;
@@ -425,9 +432,15 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 
   async destroy(computer: ComputerRef, _context: AdapterContext): Promise<void> {
-    const desktop = await this.box(computer).catch(() => undefined);
-    await desktop?.kill();
     const id = computer.providerRef || computer.id;
+    const desktop = this.boxes.get(id) ?? (await this.box(computer).catch(() => undefined));
+    const pending = this.streamStarts.get(id);
+    this.forget(id);
+    await settleForTeardown(pending);
+    await desktop?.kill();
+  }
+
+  private forget(id: string): void {
     this.boxes.delete(id);
     this.lastTouchedAt.delete(id);
     this.streamReady.delete(id);
@@ -464,6 +477,11 @@ export class E2BSandboxProvider implements SandboxProvider {
       this.controlStreams.delete(desktop.sandboxId);
     }
   }
+}
+
+async function settleForTeardown(pending: Promise<void> | undefined): Promise<void> {
+  if (!pending) return;
+  await Promise.race([pending.catch(() => undefined), delay(5_000, undefined, { ref: false })]);
 }
 
 function controlStreamStopCommand(controlToken?: string) {
@@ -639,35 +657,6 @@ async function* walkE2BWorkspace(
     }
   }
   for (const relative of directories) yield* walkE2BWorkspace(desktop, relative, context);
-}
-
-export function shouldSkipPortableWorkspaceFile(relative: string) {
-  if (!relative.startsWith(".browser-profiles/")) return false;
-  const segments = relative.split("/");
-  const name = segments.at(-1) ?? "";
-  return (
-    segments.some((segment) =>
-      [
-        "Cache",
-        "Code Cache",
-        "GPUCache",
-        "GrShaderCache",
-        "ShaderCache",
-        "DawnGraphiteCache",
-        "DawnWebGPUCache",
-        "Crashpad",
-      ].includes(segment),
-    ) ||
-    [
-      "BrowserMetrics",
-      "DevToolsActivePort",
-      "SingletonCookie",
-      "SingletonLock",
-      "SingletonSocket",
-      ".parentlock",
-      "lock",
-    ].includes(name)
-  );
 }
 
 function e2bCwd(cwd: string | undefined): string {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -27,7 +27,11 @@ import {
   shellQuote,
   workspacePath,
 } from "./computer-support.js";
-import { shouldSkipPortableWorkspaceFile } from "./computer-workspace.js";
+import {
+  PORTABLE_BROWSER_STOP_COMMAND,
+  PORTABLE_TRANSFER_BATCH_BYTES,
+  shouldSkipPortableWorkspaceFile,
+} from "./computer-workspace.js";
 
 const E2B_WORKSPACE = "/home/user/rakazo-home";
 const E2B_BROWSER_PROFILES = `${E2B_WORKSPACE}/.browser-profiles`;
@@ -126,8 +130,11 @@ export class E2BSandboxProvider implements SandboxProvider {
     if (this.streamReady.has(desktop.sandboxId)) return;
     const pending = this.streamStarts.get(desktop.sandboxId);
     if (pending) return pending;
-    const start = this.initializeStream(desktop).finally(() => {
-      this.streamStarts.delete(desktop.sandboxId);
+    let start!: Promise<void>;
+    start = this.initializeStream(desktop).finally(() => {
+      if (this.streamStarts.get(desktop.sandboxId) === start) {
+        this.streamStarts.delete(desktop.sandboxId);
+      }
     });
     this.streamStarts.set(desktop.sandboxId, start);
     return start;
@@ -144,8 +151,9 @@ export class E2BSandboxProvider implements SandboxProvider {
       await desktop.stream.stop().catch(() => undefined);
       throw error;
     }
-    if (this.boxes.get(desktop.sandboxId) !== desktop) {
-      await desktop.stream.stop().catch(() => undefined);
+    const current = this.boxes.get(desktop.sandboxId);
+    if (current !== desktop) {
+      if (!current) await desktop.stream.stop().catch(() => undefined);
       throw new Error("screen stream stopped during computer teardown");
     }
     this.streamReady.add(desktop.sandboxId);
@@ -396,7 +404,10 @@ export class E2BSandboxProvider implements SandboxProvider {
       batchBytes = 0;
     };
     for await (const file of files) {
-      if (batch.length >= 32 || batchBytes + file.content.byteLength > 8 * 1024 * 1024) {
+      if (
+        batch.length >= 32 ||
+        batchBytes + file.content.byteLength > PORTABLE_TRANSFER_BATCH_BYTES
+      ) {
         await flush();
       }
       batch.push(file);
@@ -573,9 +584,7 @@ async function configurePortableBrowserProfiles(desktop: Sandbox): Promise<boole
 }
 
 async function stopDesktopBrowsers(desktop: Sandbox): Promise<void> {
-  await desktop.commands
-    .run("pkill -f '[g]oogle-chrome|[c]hromium|[f]irefox' || true")
-    .catch(() => undefined);
+  await desktop.commands.run(PORTABLE_BROWSER_STOP_COMMAND).catch(() => undefined);
 }
 
 async function applyE2BAction(desktop: Sandbox, action: ComputerAction): Promise<void> {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -74,6 +74,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   private readonly boxes = new Map<string, Sandbox>();
   private readonly lastTouchedAt = new Map<string, number>();
   private readonly streamReady = new Set<string>();
+  private readonly streamStarts = new Map<string, Promise<void>>();
   private readonly controlStreams = new Map<string, { password: string; controlToken: string }>();
 
   constructor(
@@ -118,6 +119,16 @@ export class E2BSandboxProvider implements SandboxProvider {
 
   private async startStream(desktop: Sandbox) {
     if (this.streamReady.has(desktop.sandboxId)) return;
+    const pending = this.streamStarts.get(desktop.sandboxId);
+    if (pending) return pending;
+    const start = this.initializeStream(desktop).finally(() => {
+      this.streamStarts.delete(desktop.sandboxId);
+    });
+    this.streamStarts.set(desktop.sandboxId, start);
+    return start;
+  }
+
+  private async initializeStream(desktop: Sandbox) {
     await desktop.commands
       .run("pkill -x x11vnc || true; pkill -f '[n]ovnc_proxy|[w]ebsockify.*6080' || true")
       .catch(() => undefined);
@@ -404,6 +415,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     this.boxes.delete(id);
     this.lastTouchedAt.delete(id);
     this.streamReady.delete(id);
+    this.streamStarts.delete(id);
     this.controlStreams.delete(id);
     if (desktop) {
       await desktop.pause().catch(() => undefined);
@@ -419,6 +431,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     this.boxes.delete(id);
     this.lastTouchedAt.delete(id);
     this.streamReady.delete(id);
+    this.streamStarts.delete(id);
     this.controlStreams.delete(id);
   }
 

--- a/packages/adapters/src/host-aware-sandbox.ts
+++ b/packages/adapters/src/host-aware-sandbox.ts
@@ -13,7 +13,7 @@ import type {
 } from "@rakazo/adapter-kit";
 import type { PrismaClient } from "@rakazo/db";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
-import { createSandboxProvider } from "./sandbox-factory.js";
+import { createSandboxProvider, type SandboxProviderOptions } from "./sandbox-factory.js";
 
 export function sandboxKindForBot(envKind: string, computerHost: string | null | undefined) {
   if (envKind === "docker" && computerHost === "this-mac") return "desktop";
@@ -22,13 +22,7 @@ export function sandboxKindForBot(envKind: string, computerHost: string | null |
 
 export function createRunSandbox(
   kind: string,
-  opts: {
-    supervisorUrl?: string;
-    supervisorToken?: string;
-    e2bApiKey?: string;
-    dataDir?: string;
-    prisma?: PrismaClient;
-  },
+  opts: SandboxProviderOptions & { prisma?: PrismaClient },
 ): SandboxProvider {
   if (kind === "desktop") {
     return new DesktopSandboxProvider({

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -10,6 +10,8 @@ export * from "./computer-lifecycle.js";
 export * from "./computer-support.js";
 export * from "./computer-tools.js";
 export * from "./computer-workspace.js";
+export * from "./daytona-emulator.js";
+export * from "./daytona-sandbox.js";
 export * from "./desktop-sandbox.js";
 export * from "./destination-emulator.js";
 export * from "./docker-sandbox.js";

--- a/packages/adapters/src/sandbox-conformance.test.ts
+++ b/packages/adapters/src/sandbox-conformance.test.ts
@@ -2,8 +2,9 @@ import { execSync, spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { ProcessEvent, SandboxProvider } from "@rakazo/adapter-kit";
+import type { ComputerRef, ProcessEvent, SandboxProvider } from "@rakazo/adapter-kit";
 import { afterAll, describe, expect, it } from "vitest";
+import { DaytonaSandboxEmulator } from "./daytona-emulator.js";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
 import { DockerSandboxProvider } from "./docker-sandbox.js";
 import { ManagedSandboxEmulator } from "./e2b-emulator.js";
@@ -17,15 +18,7 @@ const ctx = {
   signal: new AbortController().signal,
 };
 
-async function drain(
-  provider: SandboxProvider,
-  computer: {
-    id: string;
-    botId: string;
-    kind: "fake" | "e2b" | "docker" | "desktop";
-    providerRef: string;
-  },
-) {
+async function drain(provider: SandboxProvider, computer: ComputerRef) {
   let stdout = "";
   for await (const event of provider.execute(computer, { argv: ["echo", "graphical-ok"] }, ctx)) {
     if (event.type === "stdout") stdout += event.data;
@@ -35,29 +28,35 @@ async function drain(
 }
 
 describe("sandbox conformance", () => {
-  it("runs the same graphical command on fake, managed-sandbox emulator, and desktop", async () => {
+  it("runs the same graphical command across fake, managed-provider emulators, and desktop", async () => {
     const fake = new FakeSandboxProvider();
     const managed = new ManagedSandboxEmulator();
+    const daytona = new DaytonaSandboxEmulator();
     const desktop = new DesktopSandboxProvider();
     const a = await fake.provision({ botId: "bot-a", homePath: "/tmp/a" }, ctx);
     const b = await managed.provision({ botId: "bot-b", homePath: "/tmp/b" }, ctx);
-    const c = await desktop.provision({ botId: "bot-c", homePath: "/tmp/c" }, ctx);
+    const c = await daytona.provision({ botId: "bot-c", homePath: "/tmp/c" }, ctx);
+    const d = await desktop.provision({ botId: "bot-d", homePath: "/tmp/d" }, ctx);
     const outA = await drain(fake, a);
     const outB = await drain(managed, b);
-    const outC = await drain(desktop, c);
+    const outC = await drain(daytona, c);
+    const outD = await drain(desktop, d);
     expect(outA).toContain("graphical-ok");
     expect(outB).toContain("graphical-ok");
     expect(outC).toContain("graphical-ok");
-    expect(new Set([a.id, b.id, c.id]).size).toBe(3);
+    expect(outD).toContain("graphical-ok");
+    expect(new Set([a.id, b.id, c.id, d.id]).size).toBe(4);
     await fake.destroy(a, ctx);
     await managed.destroy(b, ctx);
-    await desktop.destroy(c, ctx);
+    await daytona.destroy(c, ctx);
+    await desktop.destroy(d, ctx);
   });
 
   it("offers the same observation, action, and workspace contract across providers", async () => {
     const providers: SandboxProvider[] = [
       new FakeSandboxProvider(),
       new ManagedSandboxEmulator(),
+      new DaytonaSandboxEmulator(),
       new DesktopSandboxProvider(),
     ];
     for (const [index, provider] of providers.entries()) {

--- a/packages/adapters/src/sandbox-factory.test.ts
+++ b/packages/adapters/src/sandbox-factory.test.ts
@@ -7,9 +7,19 @@ describe("createSandboxProvider", () => {
     expect(sandbox.describe().id).toBe("fake");
   });
 
+  it("returns provider-specific managed sandbox emulators", () => {
+    expect(createSandboxProvider("e2b-emulator", {}).describe().id).toBe("e2b-emulator");
+    expect(createSandboxProvider("daytona-emulator", {}).describe().id).toBe("daytona-emulator");
+  });
+
+  it("requires provider-specific credentials", () => {
+    expect(() => createSandboxProvider("e2b", {})).toThrow(/E2B_API_KEY/);
+    expect(() => createSandboxProvider("daytona", {})).toThrow(/DAYTONA_API_KEY/);
+  });
+
   it("throws on unknown provider", () => {
     expect(() => createSandboxProvider("bogus", {})).toThrow(
-      'Unknown SANDBOX_PROVIDER "bogus". Use docker | e2b | e2b-emulator | desktop | fake.',
+      'Unknown SANDBOX_PROVIDER "bogus". Use docker | e2b | daytona | e2b-emulator | daytona-emulator | desktop | fake.',
     );
   });
 });

--- a/packages/adapters/src/sandbox-factory.ts
+++ b/packages/adapters/src/sandbox-factory.ts
@@ -1,23 +1,36 @@
 import type { SandboxProvider } from "@rakazo/adapter-kit";
+import { DaytonaSandboxEmulator } from "./daytona-emulator.js";
+import { DaytonaSandboxProvider } from "./daytona-sandbox.js";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
 import { DockerSandboxProvider } from "./docker-sandbox.js";
 import { ManagedSandboxEmulator } from "./e2b-emulator.js";
 import { E2BSandboxProvider } from "./e2b-sandbox.js";
 import { FakeSandboxProvider } from "./fake-sandbox.js";
 
-export function createSandboxProvider(
-  kind: string,
-  opts: {
-    supervisorUrl?: string;
-    supervisorToken?: string;
-    e2bApiKey?: string;
-    dataDir?: string;
-  },
-): SandboxProvider {
+export interface SandboxProviderOptions {
+  supervisorUrl?: string;
+  supervisorToken?: string;
+  e2bApiKey?: string;
+  daytonaApiKey?: string;
+  daytonaApiUrl?: string;
+  daytonaTarget?: string;
+  dataDir?: string;
+}
+
+export function createSandboxProvider(kind: string, opts: SandboxProviderOptions): SandboxProvider {
   switch (kind) {
     case "e2b":
       if (!opts.e2bApiKey) throw new Error("E2B_API_KEY is required for the e2b sandbox provider");
       return new E2BSandboxProvider(opts.e2bApiKey);
+    case "daytona":
+      if (!opts.daytonaApiKey) {
+        throw new Error("DAYTONA_API_KEY is required for the daytona sandbox provider");
+      }
+      return new DaytonaSandboxProvider({
+        apiKey: opts.daytonaApiKey,
+        apiUrl: opts.daytonaApiUrl,
+        target: opts.daytonaTarget,
+      });
     case "docker":
       return new DockerSandboxProvider(
         opts.supervisorUrl ?? "http://127.0.0.1:7091",
@@ -25,6 +38,8 @@ export function createSandboxProvider(
       );
     case "e2b-emulator":
       return new ManagedSandboxEmulator();
+    case "daytona-emulator":
+      return new DaytonaSandboxEmulator();
     case "desktop":
       return new DesktopSandboxProvider({
         root: opts.dataDir,
@@ -33,7 +48,7 @@ export function createSandboxProvider(
       return new FakeSandboxProvider();
     default:
       throw new Error(
-        `Unknown SANDBOX_PROVIDER "${kind}". Use docker | e2b | e2b-emulator | desktop | fake.`,
+        `Unknown SANDBOX_PROVIDER "${kind}". Use docker | e2b | daytona | e2b-emulator | daytona-emulator | desktop | fake.`,
       );
   }
 }

--- a/packages/adapters/src/sandbox-faults.test.ts
+++ b/packages/adapters/src/sandbox-faults.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { PortableFile, SandboxProvider } from "@rakazo/adapter-kit";
 import { afterEach, describe, expect, it } from "vitest";
+import { DaytonaSandboxEmulator } from "./daytona-emulator.js";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
 import { ManagedSandboxEmulator } from "./e2b-emulator.js";
 import { FakeSandboxProvider } from "./fake-sandbox.js";
@@ -26,6 +27,7 @@ afterEach(async () => {
 describe.each([
   ["fake", () => Promise.resolve(new FakeSandboxProvider())],
   ["managed emulator", () => Promise.resolve(new ManagedSandboxEmulator())],
+  ["Daytona emulator", () => Promise.resolve(new DaytonaSandboxEmulator())],
   [
     "desktop",
     async () => {
@@ -230,6 +232,7 @@ async function providerSet(label: string): Promise<Array<[string, SandboxProvide
   return [
     ["fake", new FakeSandboxProvider()],
     ["managed", new ManagedSandboxEmulator()],
+    ["daytona", new DaytonaSandboxEmulator()],
     ["desktop", new DesktopSandboxProvider({ root: await realpath(root) })],
   ];
 }

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -222,7 +222,6 @@ export function inferScript(
       { assistant: "writing that into my home now." },
       {
         toolCalls: [{ name: "write_file", args: { path: filePath, content } }],
-        files: [{ path: filePath, content }],
         complete: true,
       },
     ];

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -39,5 +39,5 @@ export type EffectStatus = z.infer<typeof EffectStatus>;
 export const MemoryScope = z.enum(["bot", "user"]);
 export type MemoryScope = z.infer<typeof MemoryScope>;
 
-export const SandboxKind = z.enum(["docker", "e2b", "desktop", "fake"]);
+export const SandboxKind = z.enum(["docker", "e2b", "daytona", "desktop", "fake"]);
 export type SandboxKind = z.infer<typeof SandboxKind>;

--- a/packages/testkit/src/cli/computer.ts
+++ b/packages/testkit/src/cli/computer.ts
@@ -1,9 +1,10 @@
-import { execFileSync, spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
+import { runProcess } from "./process.js";
 
 async function main() {
   loadRootEnv();
@@ -39,7 +40,7 @@ async function main() {
       env,
       cwd: path.resolve("packages/db"),
     });
-    await run(
+    await runProcess(
       "pnpm",
       ["exec", "vitest", "run", "packages/testkit/src/computer-use.e2e.test.ts"],
       env,
@@ -48,17 +49,6 @@ async function main() {
     await database.stop().catch(() => undefined);
     await rm(dataDir, { recursive: true, force: true });
   }
-}
-
-function run(command: string, args: string[], env: NodeJS.ProcessEnv) {
-  return new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, { stdio: "inherit", env, shell: false });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`${command} ${args.join(" ")} exited ${code}`));
-    });
-  });
 }
 
 main().catch((error) => {

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -18,14 +18,17 @@ const e2eGrep = grepArg?.slice("--grep=".length);
 if (Number(integration) + Number(e2e) !== 1) {
   throw new Error("Pass exactly one of --integration or --e2e");
 }
-if (sandboxProvider !== "fake" && sandboxProvider !== "e2b") {
-  throw new Error('Sandbox must be "fake" or "e2b"');
+if (!["fake", "e2b", "daytona"].includes(sandboxProvider)) {
+  throw new Error('Sandbox must be "fake", "e2b", or "daytona"');
 }
 if (integration && sandboxProvider !== "fake") {
   throw new Error("Integration tests only support the fake sandbox");
 }
 if (sandboxProvider === "e2b" && !process.env.E2B_API_KEY) {
   throw new Error("E2B_API_KEY is required when --sandbox=e2b");
+}
+if (sandboxProvider === "daytona" && !process.env.DAYTONA_API_KEY) {
+  throw new Error("DAYTONA_API_KEY is required when --sandbox=daytona");
 }
 
 async function main() {
@@ -149,7 +152,7 @@ async function main() {
       });
     } finally {
       const cleanupErrors: unknown[] = [];
-      const computers = await e2bComputers(handles).catch((error) => {
+      const computers = await managedComputers(handles).catch((error) => {
         cleanupErrors.push(error);
         return [];
       });
@@ -158,31 +161,33 @@ async function main() {
         await new Promise<void>((resolve) => requestWaiters.add(resolve));
       }
       await handles.stop().catch(() => undefined);
-      for (const computer of computers) {
-        if (!computer.providerRef) continue;
-        try {
-          await handles.sandbox.destroy(
-            {
-              id: computer.providerRef,
-              botId: computer.homeKey,
-              kind: "e2b",
-              providerRef: computer.providerRef,
-            },
-            {
-              operationId: "e2e-cleanup",
-              traceId: "e2e-cleanup",
-              workspaceId: computer.workspaceId,
-              userId: computer.userId,
-              signal: new AbortController().signal,
-            },
-          );
-        } catch (error) {
-          cleanupErrors.push(error);
+      for (let index = 0; index < computers.length; index += 4) {
+        const results = await Promise.allSettled(
+          computers.slice(index, index + 4).map((computer) =>
+            handles.sandbox.destroy(
+              {
+                id: computer.providerRef!,
+                botId: computer.homeKey,
+                kind: computer.kind as "e2b" | "daytona",
+                providerRef: computer.providerRef!,
+              },
+              {
+                operationId: "e2e-cleanup",
+                traceId: "e2e-cleanup",
+                workspaceId: computer.workspaceId,
+                userId: computer.userId,
+                signal: new AbortController().signal,
+              },
+            ),
+          ),
+        );
+        for (const result of results) {
+          if (result.status === "rejected") cleanupErrors.push(result.reason);
         }
       }
       if (cleanupErrors.length) {
         console.error(
-          new AggregateError(cleanupErrors, "Could not destroy every E2B test sandbox"),
+          new AggregateError(cleanupErrors, "Could not destroy every managed test sandbox"),
         );
         process.exitCode = 1;
       }
@@ -196,11 +201,11 @@ type AppHandles = Awaited<
   ReturnType<typeof import("../../../../apps/api/src/app.ts")["createApp"]>
 >;
 
-async function e2bComputers(handles: AppHandles) {
-  if (sandboxProvider !== "e2b") return [];
+async function managedComputers(handles: AppHandles) {
+  if (sandboxProvider !== "e2b" && sandboxProvider !== "daytona") return [];
   return handles.prisma.computer.findMany({
     where: { providerRef: { not: null } },
-    select: { homeKey: true, providerRef: true, userId: true, workspaceId: true },
+    select: { homeKey: true, kind: true, providerRef: true, userId: true, workspaceId: true },
   });
 }
 

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -1,13 +1,31 @@
 import { execSync, spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
+
+loadRootEnv();
 
 const integration = process.argv.includes("--integration");
 const e2e = process.argv.includes("--e2e");
+const sandboxArg = process.argv.find((arg) => arg.startsWith("--sandbox="));
+const specArg = process.argv.find((arg) => arg.startsWith("--spec="));
+const grepArg = process.argv.find((arg) => arg.startsWith("--grep="));
+const sandboxProvider = sandboxArg?.slice("--sandbox=".length) ?? "fake";
+const e2eSpec = specArg?.slice("--spec=".length);
+const e2eGrep = grepArg?.slice("--grep=".length);
 
 if (Number(integration) + Number(e2e) !== 1) {
   throw new Error("Pass exactly one of --integration or --e2e");
+}
+if (sandboxProvider !== "fake" && sandboxProvider !== "e2b") {
+  throw new Error('Sandbox must be "fake" or "e2b"');
+}
+if (integration && sandboxProvider !== "fake") {
+  throw new Error("Integration tests only support the fake sandbox");
+}
+if (sandboxProvider === "e2b" && !process.env.E2B_API_KEY) {
+  throw new Error("E2B_API_KEY is required when --sandbox=e2b");
 }
 
 async function main() {
@@ -24,8 +42,9 @@ async function main() {
     process.env.DATABASE_URL = databaseUrl;
     process.env.VERIFY_DATABASE = "1";
     process.env.WAKEUP_DRIVER = "memory";
-    process.env.SANDBOX_PROVIDER = "fake";
+    process.env.SANDBOX_PROVIDER = sandboxProvider;
     process.env.AGENT_RUNTIME = "scripted";
+    process.env.COMPOSIO_API_KEY = "";
     process.env.BETTER_AUTH_SECRET = "test-secret-test-secret-32chars!";
     process.env.ENCRYPTION_KEY = "test-encryption-key-test-encryption-key";
     process.env.BETTER_AUTH_URL = webOrigin;
@@ -74,14 +93,52 @@ async function main() {
     const { createApp } = await import("../../../../apps/api/src/app.ts");
     const { serve } = await import("@hono/node-server");
     const handles = await createApp({ databaseUrl, prisma: undefined });
-    const server = serve({ fetch: handles.app.fetch, port: apiPort, hostname: "127.0.0.1" });
+    let activeRequests = 0;
+    const requestWaiters = new Set<() => void>();
+    const server = serve({
+      fetch: async (request) => {
+        activeRequests += 1;
+        try {
+          return await handles.app.fetch(request);
+        } finally {
+          activeRequests -= 1;
+          if (activeRequests === 0) {
+            for (const resolve of requestWaiters) resolve();
+            requestWaiters.clear();
+          }
+        }
+      },
+      port: apiPort,
+      hostname: "127.0.0.1",
+    });
     await waitForHealth(`http://127.0.0.1:${apiPort}/health`, 15_000);
 
     try {
-      await run("pnpm", ["--filter", "@rakazo/web", "exec", "playwright", "test"], {
-        ...process.env,
-        CI: "1",
-      });
+      try {
+        await run(
+          "pnpm",
+          [
+            "--filter",
+            "@rakazo/web",
+            "exec",
+            "playwright",
+            "test",
+            ...(e2eSpec ? [e2eSpec] : []),
+            ...(e2eGrep ? ["--grep", e2eGrep] : []),
+          ],
+          {
+            ...process.env,
+            CI: "1",
+          },
+        );
+      } catch (error) {
+        const failedRuns = await handles.prisma.run.findMany({
+          where: { status: "failed" },
+          select: { id: true, error: true },
+        });
+        if (failedRuns.length) console.error("Failed agent runs:", failedRuns);
+        throw error;
+      }
       await writeSummary(reportDir, {
         ok: true,
         mode,
@@ -91,12 +148,60 @@ async function main() {
         webPort,
       });
     } finally {
-      server.close();
+      const cleanupErrors: unknown[] = [];
+      const computers = await e2bComputers(handles).catch((error) => {
+        cleanupErrors.push(error);
+        return [];
+      });
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (activeRequests > 0) {
+        await new Promise<void>((resolve) => requestWaiters.add(resolve));
+      }
       await handles.stop().catch(() => undefined);
+      for (const computer of computers) {
+        if (!computer.providerRef) continue;
+        try {
+          await handles.sandbox.destroy(
+            {
+              id: computer.providerRef,
+              botId: computer.homeKey,
+              kind: "e2b",
+              providerRef: computer.providerRef,
+            },
+            {
+              operationId: "e2e-cleanup",
+              traceId: "e2e-cleanup",
+              workspaceId: computer.workspaceId,
+              userId: computer.userId,
+              signal: new AbortController().signal,
+            },
+          );
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+      if (cleanupErrors.length) {
+        console.error(
+          new AggregateError(cleanupErrors, "Could not destroy every E2B test sandbox"),
+        );
+        process.exitCode = 1;
+      }
     }
   } finally {
     await container.stop().catch(() => undefined);
   }
+}
+
+type AppHandles = Awaited<
+  ReturnType<typeof import("../../../../apps/api/src/app.ts")["createApp"]>
+>;
+
+async function e2bComputers(handles: AppHandles) {
+  if (sandboxProvider !== "e2b") return [];
+  return handles.prisma.computer.findMany({
+    where: { providerRef: { not: null } },
+    select: { homeKey: true, providerRef: true, userId: true, workspaceId: true },
+  });
 }
 
 async function writeSummary(reportDir: string, summary: Record<string, unknown>) {
@@ -133,7 +238,10 @@ async function waitForHealth(url: string, ms: number) {
   throw new Error(`API health check failed for ${url}: ${last}`);
 }
 
-main().catch(async (error) => {
-  console.error(error);
-  process.exit(1);
-});
+main().then(
+  () => process.exit(process.exitCode ?? 0),
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  },
+);

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -1,8 +1,9 @@
-import { execSync, spawn } from "node:child_process";
+import { execSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
+import { runProcess } from "./process.js";
 
 loadRootEnv();
 
@@ -118,7 +119,7 @@ async function main() {
 
     try {
       try {
-        await run(
+        await runProcess(
           "pnpm",
           [
             "--filter",
@@ -214,17 +215,6 @@ async function writeSummary(reportDir: string, summary: Record<string, unknown>)
     path.join(reportDir, "summary.json"),
     JSON.stringify({ ...summary, at: new Date().toISOString() }, null, 2),
   );
-}
-
-function run(command: string, args: string[], env: NodeJS.ProcessEnv) {
-  return new Promise<void>((resolve, reject) => {
-    const child = spawn(command, args, { stdio: "inherit", env, shell: false });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`${command} ${args.join(" ")} exited ${code}`));
-    });
-  });
 }
 
 async function waitForHealth(url: string, ms: number) {

--- a/packages/testkit/src/cli/process.ts
+++ b/packages/testkit/src/cli/process.ts
@@ -1,0 +1,12 @@
+import { spawn } from "node:child_process";
+
+export function runProcess(command: string, args: string[], env: NodeJS.ProcessEnv) {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, { stdio: "inherit", env, shell: false });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(" ")} exited ${code}`));
+    });
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/api:
     dependencies:
@@ -38,7 +38,7 @@ importers:
         version: 1.19.17(hono@4.13.1)
       '@orpc/server':
         specifier: ^1.15.0
-        version: 1.15.0(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.21.3)
+        version: 1.15.0(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)
       '@rakazo/adapter-kit':
         specifier: workspace:*
         version: link:../../packages/adapter-kit
@@ -69,7 +69,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/desktop:
     dependencies:
@@ -91,7 +91,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/mobile:
     dependencies:
@@ -182,16 +182,16 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/web:
     dependencies:
       '@orpc/client':
         specifier: ^1.15.0
-        version: 1.15.0(@opentelemetry/api@1.9.0)
+        version: 1.15.0(@opentelemetry/api@1.9.1)
       '@orpc/contract':
         specifier: ^1.15.0
-        version: 1.15.0(@opentelemetry/api@1.9.0)
+        version: 1.15.0(@opentelemetry/api@1.9.1)
       '@rakazo/chat-ui':
         specifier: workspace:*
         version: link:../../packages/chat-ui
@@ -212,7 +212,7 @@ importers:
         version: 5.101.4(react@19.2.3)
       better-auth:
         specifier: ^1.6.27
-        version: 1.6.27(@opentelemetry/api@1.9.0)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
+        version: 1.6.27(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -249,7 +249,7 @@ importers:
         version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/worker:
     dependencies:
@@ -274,7 +274,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/www:
     dependencies:
@@ -348,7 +348,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/adapter-kit:
     dependencies:
@@ -364,13 +364,16 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/adapters:
     dependencies:
       '@composio/core':
         specifier: 0.16.0
-        version: 0.16.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3)
+        version: 0.16.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3)
+      '@daytona/sdk':
+        specifier: ^0.204.1
+        version: 0.204.1
       '@e2b/desktop':
         specifier: ^2.3.1
         version: 2.3.1
@@ -422,14 +425,14 @@ importers:
         version: link:../db
       better-auth:
         specifier: ^1.6.27
-        version: 1.6.27(@opentelemetry/api@1.9.0)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
+        version: 1.6.27(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
     devDependencies:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/chat-ui:
     dependencies:
@@ -457,13 +460,13 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/contracts:
     dependencies:
       '@orpc/contract':
         specifier: ^1.15.0
-        version: 1.15.0(@opentelemetry/api@1.9.0)
+        version: 1.15.0(@opentelemetry/api@1.9.1)
       zod:
         specifier: ^4.1.5
         version: 4.4.3
@@ -473,7 +476,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -492,7 +495,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/db:
     dependencies:
@@ -526,7 +529,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/memory:
     dependencies:
@@ -542,7 +545,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/testkit:
     dependencies:
@@ -573,7 +576,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/ui-tokens:
     devDependencies:
@@ -582,7 +585,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/ui-web:
     dependencies:
@@ -616,7 +619,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
 packages:
 
@@ -756,52 +759,106 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/checksums@3.1000.28':
+    resolution: {integrity: sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-bedrock-runtime@3.1048.0':
     resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1111.0':
+    resolution: {integrity: sha512-VnLT6aSTN8tWl/NsXUysXNZor7wQBp9CRwufo7kt8cwGXvHLZ0S/cV1K9WFcREGboVYSo3NGQ3ZvU7LRidh2aQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.977.7':
     resolution: {integrity: sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.8':
+    resolution: {integrity: sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.68':
     resolution: {integrity: sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.69':
+    resolution: {integrity: sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.70':
     resolution: {integrity: sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.71':
+    resolution: {integrity: sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.973.13':
     resolution: {integrity: sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    resolution: {integrity: sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.75':
     resolution: {integrity: sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.76':
+    resolution: {integrity: sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.79':
     resolution: {integrity: sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.80':
+    resolution: {integrity: sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.68':
     resolution: {integrity: sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.69':
+    resolution: {integrity: sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.973.12':
     resolution: {integrity: sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    resolution: {integrity: sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.74':
     resolution: {integrity: sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    resolution: {integrity: sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/eventstream-handler-node@3.972.32':
     resolution: {integrity: sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/lib-storage@3.1111.0':
+    resolution: {integrity: sha512-UjLJE0Zxv/m8Xgd3DLBXssZYISgoEPZpJiPWY+MadEdP36oOcjHVsR8ToUq6MMmKdzuBFYB6qGHWS/yKAG4fow==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1111.0
+
   '@aws-sdk/middleware-eventstream@3.972.27':
     resolution: {integrity: sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.74':
+    resolution: {integrity: sha512-2lzoV2z2QO5KJZYGOCnIZ1WVQgzMECvwuzr1xb034a++8QW4U4eGrmC2u4yg1xvNv4TLL/Uv5DLyuAiw0b9z7Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-websocket@3.972.50':
@@ -812,8 +869,16 @@ packages:
     resolution: {integrity: sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.43':
+    resolution: {integrity: sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.44':
     resolution: {integrity: sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    resolution: {integrity: sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -824,8 +889,16 @@ packages:
     resolution: {integrity: sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1111.0':
+    resolution: {integrity: sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.974.3':
     resolution: {integrity: sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.4':
+    resolution: {integrity: sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.9':
@@ -834,6 +907,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.38':
     resolution: {integrity: sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.39':
+    resolution: {integrity: sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -1447,6 +1524,18 @@ packages:
     peerDependencies:
       '@bufbuild/protobuf': ^2.7.0
 
+  '@daytona/analytics-api-client@0.204.1':
+    resolution: {integrity: sha512-d0iZDB0b3Fx70+f9IoU1yfJNDW9xhqpld33HkvQbCMlelSA7BFSObcLJfrf24B2KzlvWu61UM9mycYRlVt5ZIw==}
+
+  '@daytona/api-client@0.204.1':
+    resolution: {integrity: sha512-aRE6iduYtpStJ8nQqDid73SA4tI/yjq34s7maiVlmU7m83bIXkwMJFVana1KXwIDtPsAhSfSFHNIl666Q+ehEQ==}
+
+  '@daytona/sdk@0.204.1':
+    resolution: {integrity: sha512-xgNwgHF1jL+nySyfqwr8kH6j4UwgAqofK1VId2RN36SqPP+xlgSlo7v2NBB/bKw4zqt/5+Sb0uib0fyaTiExAQ==}
+
+  '@daytona/toolbox-api-client@0.204.1':
+    resolution: {integrity: sha512-uuUpiPWX0eaWbIFmYJZzt72xDtHEUAKRW62JxsoubUPSs/iNeCUcOA8GivSULWKLZCKZJQAvKJUl7y2B+73RTw==}
+
   '@e2b/desktop@2.3.1':
     resolution: {integrity: sha512-/WVgs4LpOk28PU9bzMkUWPdYVI0QBPVdclpXC99bsSeNTbG5QuWiS4tgznulzwW2HE0+etxzoOhkQ7fl0gagYw==}
     engines: {node: '>=20.18.1'}
@@ -1930,6 +2019,9 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -2162,9 +2254,197 @@ packages:
     resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.221.0':
+    resolution: {integrity: sha512-uE9y56Zdi9Gt/RdxYnVOo3YmFZkKJJMA0gqtBe8wh8gdtF5Asqe+Oh/TWiDtFb1s+31jNY4CWgnfIB1KOITfFA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.10.0':
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-txG1G0IrYSsKKMeiWZfj/i5cQmWB+h+hf3HzPpF3RqZVwp+iQQEIsv8Vtmzy6RWVdHdJZfygmVrBI39YTBvWcw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.221.0':
+    resolution: {integrity: sha512-nKXkr4Tomi6fjYVOf+ytcW3dZAVr4v4Bv5gsT6dr2gvpUPJpKgHB4XbMufMsPotRE3g0XH2GwVVCkN2w6SON+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-AH6EY+47gXFaWYgG3hfeOneGiE9xIZGtDBk+9g0sM8NZWzsQhhmqPbQQXJzS7pyCh5jRRr2nYNXVrkCmoojRvQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-KOgCtO15FC6C1T/xOqBcr7EyUs7B+7yomGNb5Y97d3s38rPbCCk5sewkmE2b0/itOkQ/PptX8CLlD+kn2mEtTg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.221.0':
+    resolution: {integrity: sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-YMF4LveY2I3yhw61rn6nmC9FE8U24IZHPeKU1Duc5+sbwjMd8FwZAwba318ImdThCg/HuVQvhm2y6bfgNPnfYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.221.0':
+    resolution: {integrity: sha512-kW79a20qWESIuAdDrxzg9WKM98twV/NBWBFRAH57ap/+ssZhiCo0hckzKT0zpuwR/gSHrFAQhJL0bYDrnEM34g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-zXminlZedtq9LvOW64CnNkOqk15zV75k8JgtdTuWFge6+jk2m4GmAUm6L2eIiG1o2a2bZxXw2PDrszm+bps0IA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0':
+    resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-Z9i2T7vgZbWe9rSLYxXVIbeW+XyzUq4rZanW3ZyVNwVDqCsh0EJKUgBWWQ0CZfeuUA+RQPzKgJQHMuWAUnKqXw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.10.0':
+    resolution: {integrity: sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-http@0.221.0':
+    resolution: {integrity: sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.221.0':
+    resolution: {integrity: sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.221.0':
+    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.221.0':
+    resolution: {integrity: sha512-rQDmNgyiGCTrescjnzH2ntVyUKVIq6I2UjuK8+stT/Xg0ZOT71FVJqwjFdspQl6Yol/Yqsut9bDo+ame8oTmDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.221.0':
+    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.10.0':
+    resolution: {integrity: sha512-GnA5B24H+1w8BO21J0q+IWNB0z1v+AGbcquTdIt/dufibhnhgxaA8YKvz0I3akRZhB1jHT+/tlzK+qlAjEDybQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.10.0':
+    resolution: {integrity: sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.221.0':
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.221.0':
+    resolution: {integrity: sha512-UbYuvtBrQQB5Prsh9KOKy4kxzexFxfMs5MkteHeWMoswsEB7kiNhyUVkAOFW/qsEzNHtrkgyghrD2ilZJa+5YA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.10.0':
+    resolution: {integrity: sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
@@ -3066,6 +3346,9 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -3531,6 +3814,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -3678,6 +3965,9 @@ packages:
 
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3939,6 +4229,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -3956,6 +4249,10 @@ packages:
   builder-util@26.15.3:
     resolution: {integrity: sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==}
     engines: {node: '>=14.0.0'}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
 
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
@@ -4074,6 +4371,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -4591,6 +4891,13 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  engine.io-client@6.6.6:
+    resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
@@ -4689,6 +4996,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  expand-tilde@2.0.2:
+    resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -4885,6 +5196,10 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
@@ -4899,6 +5214,9 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fb-dotslash@0.5.8:
     resolution: {integrity: sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==}
@@ -4966,6 +5284,15 @@ packages:
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
 
@@ -4987,6 +5314,9 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -5095,6 +5425,10 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -5219,6 +5553,10 @@ packages:
   hermes-parser@0.36.1:
     resolution: {integrity: sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==}
 
+  homedir-polyfill@1.0.3:
+    resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
+    engines: {node: '>=0.10.0'}
+
   hono@4.13.1:
     resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
@@ -5255,6 +5593,10 @@ packages:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -5285,6 +5627,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -5346,12 +5692,20 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fs-case-sensitive@2.0.0:
     resolution: {integrity: sha512-JoCsyGITdYPM+pUbeMQ4IiEuQ4wjPdeWORlG7n644isewbcxiQIr+9gmF5k7UabTP/jLBRkbgydEamR7JZBKHA==}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
@@ -5396,6 +5750,11 @@ packages:
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -5819,6 +6178,10 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   metro-babel-transformer@0.84.4:
     resolution: {integrity: sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
@@ -6049,6 +6412,9 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -6321,6 +6687,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-passwd@1.0.0:
+    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
+    engines: {node: '>=0.10.0'}
+
   parse-png@2.1.0:
     resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
     engines: {node: '>=10'}
@@ -6590,6 +6960,10 @@ packages:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -6619,6 +6993,9 @@ packages:
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -6909,6 +7286,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
@@ -6957,6 +7338,10 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -6981,6 +7366,9 @@ packages:
 
   rou3@0.9.2:
     resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -7136,6 +7524,14 @@ packages:
     resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
+    engines: {node: '>=10.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -7210,12 +7606,19 @@ packages:
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
   stream-buffers@2.2.0:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
     engines: {node: '>= 0.10.0'}
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
 
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
@@ -8065,6 +8468,10 @@ packages:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
 
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -8342,6 +8749,14 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/checksums@3.1000.28':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/client-bedrock-runtime@3.1048.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -8359,10 +8774,35 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-s3@3.1111.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.28
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/middleware-sdk-s3': 3.972.74
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.977.7':
     dependencies:
       '@aws-sdk/types': 3.974.3
       '@aws-sdk/xml-builder': 3.972.38
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.32.0
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.8':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/xml-builder': 3.972.39
       '@aws/lambda-invoke-store': 0.3.0
       '@smithy/core': 3.32.0
       '@smithy/signature-v4': 5.7.0
@@ -8378,10 +8818,28 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.70':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0
       '@smithy/node-http-handler': 4.10.0
@@ -8404,11 +8862,36 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-login': 3.972.76
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.75':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/nested-clients': 3.997.42
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -8427,10 +8910,32 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.80':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-ini': 3.973.14
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.68':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -8445,11 +8950,30 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/token-providers': 3.1111.0
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.74':
     dependencies:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/nested-clients': 3.997.42
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -8461,9 +8985,28 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/lib-storage@3.1111.0(@aws-sdk/client-s3@3.1111.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1111.0
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-eventstream@3.972.27':
     dependencies:
       '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.74':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -8489,9 +9032,27 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.43':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/fetch-http-handler': 5.7.0
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.44':
     dependencies:
       '@aws-sdk/types': 3.974.3
+      '@smithy/signature-v4': 5.7.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
       '@smithy/signature-v4': 5.7.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -8514,7 +9075,21 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.974.3':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.4':
     dependencies:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -8524,6 +9099,11 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.38':
+    dependencies:
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.39':
     dependencies:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
@@ -9016,7 +9596,7 @@ snapshots:
 
   '@balena/dockerignore@1.0.2': {}
 
-  '@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)':
+  '@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -9028,41 +9608,41 @@ snapshots:
       nanostores: 1.4.2
       zod: 4.4.3
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
+  '@better-auth/kysely-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.5
 
-  '@better-auth/memory-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))':
+  '@better-auth/prisma-adapter@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
 
-  '@better-auth/telemetry@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -9162,13 +9742,13 @@ snapshots:
 
   '@composio/client@0.1.0-alpha.76': {}
 
-  '@composio/core@0.16.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3)':
+  '@composio/core@0.16.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3)':
     dependencies:
       '@composio/client': 0.1.0-alpha.76
       '@composio/json-schema-to-zod': 0.3.0(zod@4.4.3)
       '@types/json-schema': 7.0.15
       is-fs-case-sensitive: 2.0.0
-      openai: 7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3)
+      openai: 7.4.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3)
       picocolors: 1.1.1
       pusher-js: 8.6.0
       semver: 7.8.5
@@ -9192,6 +9772,62 @@ snapshots:
   '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.13.0)':
     dependencies:
       '@bufbuild/protobuf': 2.13.0
+
+  '@daytona/analytics-api-client@0.204.1':
+    dependencies:
+      axios: 1.19.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@daytona/api-client@0.204.1':
+    dependencies:
+      axios: 1.19.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@daytona/sdk@0.204.1':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1111.0
+      '@aws-sdk/lib-storage': 3.1111.0(@aws-sdk/client-s3@3.1111.0)
+      '@daytona/analytics-api-client': 0.204.1
+      '@daytona/api-client': 0.204.1
+      '@daytona/toolbox-api-client': 0.204.1
+      '@iarna/toml': 2.2.5
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      axios: 1.19.0
+      busboy: 1.6.0
+      dotenv: 17.4.2
+      expand-tilde: 2.0.2
+      fast-glob: 3.3.3
+      form-data: 4.0.6
+      isomorphic-ws: 5.0.0(ws@8.21.3)
+      pathe: 2.0.3
+      shell-quote: 1.10.0
+      socket.io-client: 4.8.3
+      tar: 7.5.22
+      tslib: 2.8.1
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@daytona/toolbox-api-client@0.204.1':
+    dependencies:
+      axios: 1.19.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@e2b/desktop@2.3.1':
     dependencies:
@@ -9899,6 +10535,8 @@ snapshots:
     dependencies:
       hono: 4.13.1
 
+  '@iarna/toml@2.2.5': {}
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -10107,23 +10745,267 @@ snapshots:
 
   '@noble/hashes@2.3.0': {}
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@opentelemetry/api-logs@0.221.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/configuration@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      yaml: 2.9.0
+
+  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-b3@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-node@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/configuration': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
-  '@orpc/client@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/client@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-peer': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-peer': 1.15.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/contract@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/contract@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/client': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/client': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
       '@standard-schema/spec': 1.1.0
       openapi-types: 12.1.3
     transitivePeerDependencies:
@@ -10131,18 +11013,18 @@ snapshots:
 
   '@orpc/interop@1.15.0': {}
 
-  '@orpc/server@1.15.0(@opentelemetry/api@1.9.0)(crossws@0.3.5)(ws@8.21.3)':
+  '@orpc/server@1.15.0(@opentelemetry/api@1.9.1)(crossws@0.3.5)(ws@8.21.3)':
     dependencies:
-      '@orpc/client': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/contract': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/client': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/contract': 1.15.0(@opentelemetry/api@1.9.1)
       '@orpc/interop': 1.15.0
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-aws-lambda': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-fastify': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-peer': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-aws-lambda': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-fastify': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-peer': 1.15.0(@opentelemetry/api@1.9.1)
       cookie: 1.1.1
     optionalDependencies:
       crossws: 0.3.5
@@ -10151,55 +11033,55 @@ snapshots:
       - '@opentelemetry/api'
       - fastify
 
-  '@orpc/shared@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/shared@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
       radash: 12.1.1
       type-fest: 5.8.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
-  '@orpc/standard-server-aws-lambda@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/standard-server-aws-lambda@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server-fastify@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/standard-server-fastify@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-node': 1.15.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server-fetch@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/standard-server-fetch@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server-node@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/standard-server-node@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server-fetch': 1.15.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server-peer@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/standard-server-peer@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
-      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/standard-server': 1.15.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/standard-server@1.15.0(@opentelemetry/api@1.9.0)':
+  '@orpc/standard-server@1.15.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.0)
+      '@orpc/shared': 1.15.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
@@ -11129,6 +12011,8 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@szmarczak/http-timer@4.0.6':
@@ -11750,6 +12634,12 @@ snapshots:
 
   acorn@8.18.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   agent-cli-detector@0.1.5: {}
@@ -12006,6 +12896,16 @@ snapshots:
 
   aws4@1.13.2: {}
 
+  axios@1.19.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   axobject-query@4.1.0: {}
 
   b4a@1.8.1: {}
@@ -12151,15 +13051,15 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.6.27(@opentelemetry/api@1.9.0)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))):
+  better-auth@1.6.27(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))):
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
-      '@better-auth/memory-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
-      '@better-auth/telemetry': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
+      '@better-auth/memory-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
+      '@better-auth/telemetry': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.3.0
@@ -12177,20 +13077,20 @@ snapshots:
       prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.6.27(@opentelemetry/api@1.9.0)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))):
+  better-auth@1.6.27(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))):
     dependencies:
-      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
-      '@better-auth/memory-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
-      '@better-auth/telemetry': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
+      '@better-auth/memory-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))
+      '@better-auth/telemetry': 1.6.27(@better-auth/core@1.6.27(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.3.0
@@ -12208,7 +13108,7 @@ snapshots:
       prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(magicast@0.5.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -12292,6 +13192,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -12330,6 +13235,10 @@ snapshots:
       tiny-async-pool: 1.3.0
     transitivePeerDependencies:
       - supports-color
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
 
   byline@5.0.0: {}
 
@@ -12444,6 +13353,8 @@ snapshots:
   ci-info@4.3.1: {}
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@2.2.1: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -12997,6 +13908,20 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  engine.io-client@6.6.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
+
   enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -13098,6 +14023,10 @@ snapshots:
       - bare-abort-controller
 
   events@3.3.0: {}
+
+  expand-tilde@2.0.2:
+    dependencies:
+      homedir-polyfill: 1.0.3
 
   expect-type@1.4.0: {}
 
@@ -13350,6 +14279,14 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
@@ -13365,6 +14302,10 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fb-dotslash@0.5.8: {}
 
@@ -13440,6 +14381,8 @@ snapshots:
 
   flow-enums-runtime@0.0.6: {}
 
+  follow-redirects@1.16.0: {}
+
   fontace@0.4.1:
     dependencies:
       fontkitten: 1.0.3
@@ -13466,6 +14409,8 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  forwarded-parse@2.1.2: {}
 
   fresh@0.5.2: {}
 
@@ -13581,6 +14526,10 @@ snapshots:
   giget@3.3.1: {}
 
   github-slugger@2.0.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@10.5.0:
     dependencies:
@@ -13808,6 +14757,10 @@ snapshots:
     dependencies:
       hermes-estree: 0.36.1
 
+  homedir-polyfill@1.0.3:
+    dependencies:
+      parse-passwd: 1.0.0
+
   hono@4.13.1: {}
 
   hosted-git-info@4.1.0:
@@ -13846,6 +14799,13 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -13873,6 +14833,12 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-in-the-middle@3.3.3:
+    dependencies:
+      cjs-module-lexer: 2.2.1
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
 
   indent-string@4.0.0: {}
 
@@ -13920,9 +14886,15 @@ snapshots:
 
   is-docker@4.0.0: {}
 
+  is-extglob@2.1.1: {}
+
   is-fs-case-sensitive@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
 
@@ -13949,6 +14921,10 @@ snapshots:
   isexe@3.1.5: {}
 
   isexe@4.0.0: {}
+
+  isomorphic-ws@5.0.0(ws@8.21.3):
+    dependencies:
+      ws: 8.21.3
 
   jackspeak@3.4.3:
     dependencies:
@@ -14428,6 +15404,8 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
+  merge2@1.4.1: {}
+
   metro-babel-transformer@0.84.4:
     dependencies:
       '@babel/core': 7.29.7
@@ -14856,6 +15834,8 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
+  module-details-from-path@1.0.4: {}
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -15020,9 +16000,9 @@ snapshots:
       ws: 8.21.3
       zod: 4.4.3
 
-  openai@7.4.0(@aws-sdk/credential-provider-node@3.972.79)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3):
+  openai@7.4.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3):
     optionalDependencies:
-      '@aws-sdk/credential-provider-node': 3.972.79
+      '@aws-sdk/credential-provider-node': 3.972.80
       '@smithy/signature-v4': 5.7.0
       ws: 8.21.3
       zod: 4.4.3
@@ -15098,6 +16078,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-passwd@1.0.0: {}
 
   parse-png@2.1.0:
     dependencies:
@@ -15387,6 +16369,8 @@ snapshots:
       '@types/node': 24.13.3
       long: 5.3.2
 
+  proxy-from-env@2.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -15416,6 +16400,8 @@ snapshots:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
+
+  queue-microtask@1.2.3: {}
 
   queue@6.0.2:
     dependencies:
@@ -15786,6 +16772,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   resedit@1.7.2:
     dependencies:
       pe-library: 0.4.1
@@ -15827,6 +16820,8 @@ snapshots:
   retry@0.12.0: {}
 
   retry@0.13.1: {}
+
+  reusify@1.1.0: {}
 
   rimraf@2.6.3:
     dependencies:
@@ -15897,6 +16892,10 @@ snapshots:
       fsevents: 2.3.3
 
   rou3@0.9.2: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   safe-buffer@5.1.2: {}
 
@@ -16082,6 +17081,24 @@ snapshots:
 
   smol-toml@1.8.0: {}
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.6
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.7:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -16139,9 +17156,16 @@ snapshots:
 
   std-env@4.2.0: {}
 
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   stream-buffers@2.2.0: {}
 
   stream-replace-string@2.0.0: {}
+
+  streamsearch@1.1.0: {}
 
   streamx@2.28.0:
     dependencies:
@@ -16661,34 +17685,6 @@ snapshots:
     optionalDependencies:
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.1
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 24.13.3
-    transitivePeerDependencies:
-      - msw
-
   vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -16713,6 +17709,62 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
     transitivePeerDependencies:
       - msw
@@ -16916,6 +17968,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@15.1.1: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary

- add a production Daytona sandbox adapter and deterministic Daytona emulator behind the shared sandbox interface
- keep automatic Playwright runs on Fake, with a manual Fake/E2B/Daytona workflow selector and provider-specific secrets
- run the same Team/Private Computer, takeover, persistence, approval, and lifecycle journeys against real managed sandboxes
- harden managed-provider teardown, reconnect coalescing, portable browser profiles, preview-token reuse, transfer bounds, and guaranteed cleanup

## Verification

- `pnpm check` — 19/19 packages passed
- `pnpm lint`
- `pnpm test` — 312 passed, 38 skipped
- focused adapter/conformance suite — 37 passed
- `pnpm test:e2e -- --sandbox=fake` — 11 passed
- `pnpm test:e2e -- --sandbox=e2b` — 11 passed on real E2B (4.0m)
- real Daytona full run — 10 passed; one unrelated strict-selector failure
- real Daytona rerun of the corrected approval journey — passed; all 11 journeys have passed against Daytona

Real-provider runs create disposable sandboxes and destroy them during harness teardown. No provider credentials are committed.
