### PR TITLE
Centralize sandbox preparation and rollback

### DIFF
--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -39,6 +39,7 @@ import type {
 
 export interface SandboxProvider {
   describe(): AdapterDescriptor<SandboxCapabilities>;
+  /** Allocate or reconnect the computer, returning its reference before fallible setup. */
   provision(
     request: {
       botId: string;
@@ -48,6 +49,8 @@ export interface SandboxProvider {
     },
     context: AdapterContext,
   ): Promise<ComputerRef>;
+  /** Perform idempotent provider setup after the lifecycle has captured the reference. */
+  prepare(computer: ComputerRef, context: AdapterContext): Promise<void>;
   execute(
     computer: ComputerRef,
     request: CommandRequest,

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -55,6 +55,7 @@ describe("computer provisioning", () => {
         kind: "cloud",
         providerRef: "provider-1",
       }),
+      prepare: vi.fn().mockResolvedValue(undefined),
       stop,
     } as unknown as SandboxProvider;
 
@@ -84,6 +85,126 @@ describe("computer provisioning", () => {
           },
         }),
       );
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { fresh: true, cleanup: "destroy" as const },
+    { fresh: false, cleanup: "stop" as const },
+  ])("rolls back $cleanup when shared preparation fails", async ({ fresh, cleanup }) => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-prepare-rollback-"));
+    const ref = {
+      id: "provider-1",
+      botId: "bot-1",
+      kind: "fake" as const,
+      providerRef: "provider-1",
+      fresh,
+    };
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const prepare = vi.fn().mockRejectedValue(new Error("provider preparation failed"));
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: fresh ? null : "provider-1",
+          kind: "fake",
+          scope: "dedicated",
+          state: "stopped",
+          controlLeaseId: null,
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    } as unknown as PrismaClient;
+    const sandbox = {
+      provision: vi.fn().mockResolvedValue(ref),
+      prepare,
+      stop,
+      destroy,
+    } as unknown as SandboxProvider;
+
+    try {
+      await expect(
+        provisionComputer(
+          {
+            prisma,
+            sandbox,
+            home: {} as AgentHomeStore,
+            jobs: {} as JobPublisher,
+            events: {} as ThreadEvents,
+            dataDir,
+          },
+          "computer-1",
+          context,
+        ),
+      ).rejects.toThrow("provider preparation failed");
+      expect(prepare).toHaveBeenCalledWith(ref, context);
+      expect(cleanup === "destroy" ? destroy : stop).toHaveBeenCalledWith(ref, context);
+      expect(cleanup === "destroy" ? stop : destroy).not.toHaveBeenCalled();
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retains a fresh provider reference when rollback also fails", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-prepare-rollback-failure-"));
+    const prepareError = new Error("provider preparation failed");
+    const rollbackError = new Error("provider deletion failed");
+    const ref = {
+      id: "new-provider-1",
+      botId: "bot-1",
+      kind: "e2b" as const,
+      providerRef: "new-provider-1",
+      fresh: true,
+    };
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: null,
+          kind: "e2b",
+          scope: "dedicated",
+          state: "stopped",
+          controlLeaseId: null,
+        }),
+        updateMany,
+      },
+    } as unknown as PrismaClient;
+    const sandbox = {
+      provision: vi.fn().mockResolvedValue(ref),
+      prepare: vi.fn().mockRejectedValue(prepareError),
+      destroy: vi.fn().mockRejectedValue(rollbackError),
+    } as unknown as SandboxProvider;
+
+    try {
+      const result = provisionComputer(
+        {
+          prisma,
+          sandbox,
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+          dataDir,
+        },
+        "computer-1",
+        context,
+      );
+      await expect(result).rejects.toMatchObject({
+        errors: [prepareError, rollbackError],
+      });
+      expect(updateMany).toHaveBeenLastCalledWith({
+        where: { id: "computer-1", state: "booting" },
+        data: {
+          state: "error",
+          providerRef: "new-provider-1",
+          kind: "e2b",
+        },
+      });
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -66,6 +66,7 @@ export async function provisionComputer(
       context,
     );
     provisioned = ref;
+    await deps.sandbox.prepare(ref, context);
     const replacement =
       ref.fresh === true ||
       !existing.providerRef ||
@@ -99,17 +100,60 @@ export async function provisionComputer(
       },
     });
     if (activated.count !== 1) {
-      await deps.sandbox.stop(ref, context).catch(() => deps.sandbox.destroy(ref, context));
       throw new ComputerBusyError();
     }
     return ref;
   } catch (error) {
-    if (provisioned?.fresh) await deps.sandbox.destroy(provisioned, context).catch(() => undefined);
-    await deps.prisma.computer.updateMany({
-      where: { id: computerId, state: "booting" },
-      data: { state: "error" },
-    });
+    const rollbackError = provisioned
+      ? await rollbackProvisionedComputer(deps.sandbox, provisioned, context, error)
+      : undefined;
+    try {
+      await deps.prisma.computer.updateMany({
+        where: { id: computerId, state: "booting" },
+        data: {
+          state: "error",
+          ...(rollbackError && provisioned
+            ? { providerRef: provisioned.providerRef, kind: provisioned.kind }
+            : {}),
+        },
+      });
+    } catch (recordError) {
+      throw new AggregateError(
+        [error, ...(rollbackError ? [rollbackError] : []), recordError],
+        "Computer provisioning failed and its failure could not be recorded",
+      );
+    }
+    if (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "Computer provisioning failed and its sandbox could not be rolled back",
+      );
+    }
     throw error;
+  }
+}
+
+async function rollbackProvisionedComputer(
+  sandbox: SandboxProvider,
+  computer: ComputerRef,
+  context: AdapterContext,
+  cause: unknown,
+): Promise<unknown | undefined> {
+  try {
+    if (computer.fresh) {
+      await sandbox.destroy(computer, context);
+    } else if (cause instanceof ComputerBusyError) {
+      try {
+        await sandbox.stop(computer, context);
+      } catch {
+        await sandbox.destroy(computer, context);
+      }
+    } else {
+      await sandbox.stop(computer, context);
+    }
+    return undefined;
+  } catch (error) {
+    return error;
   }
 }
 

--- a/packages/adapters/src/daytona-sandbox.test.ts
+++ b/packages/adapters/src/daytona-sandbox.test.ts
@@ -15,6 +15,7 @@ describe("DaytonaSandboxProvider", () => {
     const fixture = daytonaFixture();
     const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
     const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+    await provider.prepare(computer, context);
 
     expect(computer).toMatchObject({
       id: "daytona-box",
@@ -147,7 +148,11 @@ describe("DaytonaSandboxProvider", () => {
       providerKind: "daytona" as const,
     };
 
-    await Promise.all([provider.provision(request, context), provider.provision(request, context)]);
+    const computers = await Promise.all([
+      provider.provision(request, context),
+      provider.provision(request, context),
+    ]);
+    await Promise.all(computers.map((computer) => provider.prepare(computer, context)));
 
     expect(fixture.get).toHaveBeenCalledTimes(1);
     expect(fixture.start).toHaveBeenCalledTimes(1);
@@ -158,20 +163,23 @@ describe("DaytonaSandboxProvider", () => {
     ).toHaveLength(1);
   });
 
-  it("deletes a fresh sandbox when workspace preparation fails", async () => {
+  it("returns a fresh reference before workspace preparation fails", async () => {
     const fixture = daytonaFixture({ prepareFails: true });
     const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
 
-    await expect(
-      provider.provision({ botId: "bot-a", homePath: "/unused" }, context),
-    ).rejects.toThrow(/could not create Daytona workspace/);
-    expect(fixture.deleteSandbox).toHaveBeenCalledWith(120, true);
+    expect(computer).toMatchObject({ providerRef: "daytona-box", fresh: true });
+    await expect(provider.prepare(computer, context)).rejects.toThrow(
+      /could not create Daytona workspace/,
+    );
+    expect(fixture.deleteSandbox).not.toHaveBeenCalled();
   });
 
   it("surfaces transient stop failures so cleanup can retry", async () => {
     const fixture = daytonaFixture();
     const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
     const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+    await provider.prepare(computer, context);
     fixture.stop.mockRejectedValueOnce(new Error("temporary Daytona outage"));
 
     await expect(provider.stop(computer, context)).rejects.toThrow("temporary Daytona outage");

--- a/packages/adapters/src/daytona-sandbox.ts
+++ b/packages/adapters/src/daytona-sandbox.ts
@@ -103,7 +103,6 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     if (request.providerRef && request.providerKind === "daytona") {
       try {
         const sandbox = await this.connect(request.providerRef);
-        await this.prepareWorkspace(sandbox);
         return this.ref(sandbox, request.botId, false);
       } catch (error) {
         this.forget(request.providerRef);
@@ -121,21 +120,11 @@ export class DaytonaSandboxProvider implements SandboxProvider {
       { timeout: 120 },
     );
     this.boxes.set(sandbox.id, sandbox);
-    try {
-      await this.prepareWorkspace(sandbox);
-      return this.ref(sandbox, request.botId, true);
-    } catch (error) {
-      this.forget(sandbox.id);
-      try {
-        await sandbox.delete(120, true);
-      } catch (cleanupError) {
-        throw new AggregateError(
-          [error, cleanupError],
-          "Daytona workspace preparation and sandbox cleanup failed",
-        );
-      }
-      throw error;
-    }
+    return this.ref(sandbox, request.botId, true);
+  }
+
+  async prepare(computer: ComputerRef, _context: AdapterContext): Promise<void> {
+    await this.prepareWorkspace(await this.box(computer));
   }
 
   async *execute(
@@ -350,8 +339,6 @@ export class DaytonaSandboxProvider implements SandboxProvider {
       batchBytes += file.content.byteLength;
     }
     await flush();
-    await configurePortableBrowserProfiles(sandbox, await this.workspaceRoot(sandbox));
-    this.prepared.add(sandbox.id);
     await this.openBrowser(sandbox).catch(() => undefined);
   }
 

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -85,6 +85,8 @@ export class DesktopSandboxProvider implements SandboxProvider {
     return ref;
   }
 
+  async prepare(_computer: ComputerRef, _context: AdapterContext): Promise<void> {}
+
   async *execute(
     computer: ComputerRef,
     request: CommandRequest,

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -87,6 +87,8 @@ export class DockerSandboxProvider implements SandboxProvider {
     };
   }
 
+  async prepare(_computer: ComputerRef, _context: AdapterContext): Promise<void> {}
+
   async *execute(
     computer: ComputerRef,
     request: CommandRequest,

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -19,6 +19,44 @@ describe("E2B computer backend", () => {
     expect(shouldSkipPortableWorkspaceFile(".browser-profiles/chromium/SingletonLock")).toBe(true);
   });
 
+  it("prepares a reused computer idempotently", async () => {
+    let profilesConfigured = false;
+    const command = vi.fn(async (value: string) => {
+      if (value.startsWith('test "$(readlink') && !profilesConfigured) {
+        throw new Error("profiles are not configured");
+      }
+      if (value.includes("ln -s")) profilesConfigured = true;
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const desktop = {
+      sandboxId: "reused-e2b-box",
+      commands: { run: command },
+      launch: vi.fn(async () => undefined),
+      open: vi.fn(async () => undefined),
+    } as unknown as Sandbox;
+    const sdk: E2BSandboxSdk = {
+      create: vi.fn(async () => desktop),
+      connect: vi.fn(async () => desktop),
+      pause: vi.fn(async () => undefined),
+    };
+    const provider = new E2BSandboxProvider("test-key", sdk);
+    const computer = await provider.provision(
+      {
+        botId: "bot-1",
+        homePath: "/unused",
+        providerRef: "reused-e2b-box",
+        providerKind: "e2b",
+      },
+      context,
+    );
+
+    await provider.prepare(computer, context);
+    await provider.prepare(computer, context);
+
+    expect(command.mock.calls.filter(([value]) => String(value).includes("ln -s"))).toHaveLength(1);
+    expect(desktop.launch).toHaveBeenCalledTimes(1);
+  });
+
   it("controls the desktop and exposes a portable workspace", async () => {
     const files = new Map<string, Uint8Array>();
     const leftClick = vi.fn(async () => undefined);
@@ -107,6 +145,7 @@ describe("E2B computer backend", () => {
       context,
     );
     expect(sdk.connect).not.toHaveBeenCalled();
+    await provider.prepare(computer, context);
     await provider.importWorkspace(
       computer,
       (async function* () {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -174,7 +174,6 @@ export class E2BSandboxProvider implements SandboxProvider {
           apiKey: this.apiKey,
           timeoutMs: sandboxIdleMs(),
         });
-        if (await configurePortableBrowserProfiles(desktop)) await openDesktopBrowser(desktop);
         this.boxes.set(desktop.sandboxId, desktop);
         this.lastTouchedAt.set(desktop.sandboxId, Date.now());
         return {
@@ -190,7 +189,6 @@ export class E2BSandboxProvider implements SandboxProvider {
       }
     }
     const desktop = await this.sdk.create(e2bCreateOptions(request.botId, this.apiKey));
-    await desktop.files.makeDir(E2B_WORKSPACE).catch(() => undefined);
     this.boxes.set(desktop.sandboxId, desktop);
     this.lastTouchedAt.set(desktop.sandboxId, Date.now());
     return {
@@ -200,6 +198,13 @@ export class E2BSandboxProvider implements SandboxProvider {
       providerRef: desktop.sandboxId,
       fresh: true,
     };
+  }
+
+  async prepare(computer: ComputerRef, _context: AdapterContext): Promise<void> {
+    const desktop = await this.box(computer);
+    if (computer.fresh) await desktop.files.makeDir(E2B_WORKSPACE);
+    const profilesChanged = await configurePortableBrowserProfiles(desktop);
+    if (!computer.fresh && profilesChanged) await openDesktopBrowser(desktop);
   }
 
   async *execute(
@@ -393,7 +398,6 @@ export class E2BSandboxProvider implements SandboxProvider {
     context: AdapterContext,
   ): Promise<void> {
     const desktop = await this.box(computer);
-    await desktop.files.makeDir(E2B_WORKSPACE, { signal: context.signal });
     await stopDesktopBrowsers(desktop);
     let batch: PortableFile[] = [];
     let batchBytes = 0;
@@ -414,7 +418,6 @@ export class E2BSandboxProvider implements SandboxProvider {
       batchBytes += file.content.byteLength;
     }
     await flush();
-    await configurePortableBrowserProfiles(desktop);
     await openDesktopBrowser(desktop);
   }
 

--- a/packages/adapters/src/fake-sandbox.ts
+++ b/packages/adapters/src/fake-sandbox.ts
@@ -70,6 +70,8 @@ export class FakeSandboxProvider implements SandboxProvider {
     return ref;
   }
 
+  async prepare(_computer: ComputerRef, _context: AdapterContext): Promise<void> {}
+
   async *execute(
     computer: ComputerRef,
     request: CommandRequest,

--- a/packages/adapters/src/host-aware-sandbox.ts
+++ b/packages/adapters/src/host-aware-sandbox.ts
@@ -82,6 +82,10 @@ export class HostAwareSandbox implements SandboxProvider {
     );
   }
 
+  prepare(computer: ComputerRef, context: AdapterContext) {
+    return this.route(computer).prepare(computer, context);
+  }
+
   async *execute(
     computer: ComputerRef,
     request: CommandRequest,

--- a/packages/adapters/src/sandbox-conformance.test.ts
+++ b/packages/adapters/src/sandbox-conformance.test.ts
@@ -9,6 +9,7 @@ import { DesktopSandboxProvider } from "./desktop-sandbox.js";
 import { DockerSandboxProvider } from "./docker-sandbox.js";
 import { ManagedSandboxEmulator } from "./e2b-emulator.js";
 import { FakeSandboxProvider } from "./fake-sandbox.js";
+import { provisionPrepared } from "./sandbox-test-support.js";
 
 const ctx = {
   operationId: "1",
@@ -33,10 +34,10 @@ describe("sandbox conformance", () => {
     const managed = new ManagedSandboxEmulator();
     const daytona = new DaytonaSandboxEmulator();
     const desktop = new DesktopSandboxProvider();
-    const a = await fake.provision({ botId: "bot-a", homePath: "/tmp/a" }, ctx);
-    const b = await managed.provision({ botId: "bot-b", homePath: "/tmp/b" }, ctx);
-    const c = await daytona.provision({ botId: "bot-c", homePath: "/tmp/c" }, ctx);
-    const d = await desktop.provision({ botId: "bot-d", homePath: "/tmp/d" }, ctx);
+    const a = await provisionPrepared(fake, { botId: "bot-a", homePath: "/tmp/a" }, ctx);
+    const b = await provisionPrepared(managed, { botId: "bot-b", homePath: "/tmp/b" }, ctx);
+    const c = await provisionPrepared(daytona, { botId: "bot-c", homePath: "/tmp/c" }, ctx);
+    const d = await provisionPrepared(desktop, { botId: "bot-d", homePath: "/tmp/d" }, ctx);
     const outA = await drain(fake, a);
     const outB = await drain(managed, b);
     const outC = await drain(daytona, c);
@@ -60,10 +61,12 @@ describe("sandbox conformance", () => {
       new DesktopSandboxProvider(),
     ];
     for (const [index, provider] of providers.entries()) {
-      const computer = await provider.provision(
+      const computer = await provisionPrepared(
+        provider,
         { botId: `portable-${index}`, homePath: `/tmp/portable-${index}` },
         ctx,
       );
+      await provider.prepare(computer, ctx);
       await provider.writeFile(
         computer,
         { path: "notes/result.txt", content: new TextEncoder().encode("portable") },

--- a/packages/adapters/src/sandbox-faults.test.ts
+++ b/packages/adapters/src/sandbox-faults.test.ts
@@ -7,6 +7,7 @@ import { DaytonaSandboxEmulator } from "./daytona-emulator.js";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
 import { ManagedSandboxEmulator } from "./e2b-emulator.js";
 import { FakeSandboxProvider } from "./fake-sandbox.js";
+import { provisionPrepared } from "./sandbox-test-support.js";
 
 const context = {
   operationId: "sandbox-fault-test",
@@ -39,7 +40,14 @@ describe.each([
 ] as const)("%s sandbox negative contract", (_name, makeProvider) => {
   it("rejects traversal through every portable workspace entry point", async () => {
     const provider = await makeProvider();
-    const computer = await provider.provision({ botId: "traversal", homePath: "/unused" }, context);
+    const computer = await provisionPrepared(
+      provider,
+      {
+        botId: "traversal",
+        homePath: "/unused",
+      },
+      context,
+    );
     const escapingFile = {
       path: "safe/../../outside.txt",
       content: new TextEncoder().encode("nope"),
@@ -61,7 +69,11 @@ describe.each([
 
   it("reports missing and oversized reads without returning partial data", async () => {
     const provider = await makeProvider();
-    const computer = await provider.provision({ botId: "reads", homePath: "/unused" }, context);
+    const computer = await provisionPrepared(
+      provider,
+      { botId: "reads", homePath: "/unused" },
+      context,
+    );
     await provider.writeFile(
       computer,
       { path: "payload.bin", content: Uint8Array.from([0, 1, 2, 3, 255]) },
@@ -83,7 +95,14 @@ describe.each([
 
   it("rejects oversized action batches before applying any action", async () => {
     const provider = await makeProvider();
-    const computer = await provider.provision({ botId: "actions", homePath: "/unused" }, context);
+    const computer = await provisionPrepared(
+      provider,
+      {
+        botId: "actions",
+        homePath: "/unused",
+      },
+      context,
+    );
     const before = await provider.observe(computer, context);
 
     await expect(
@@ -105,7 +124,7 @@ describe.each([
   it("stops idempotently, resumes the same machine, and provisions fresh after destroy", async () => {
     const provider = await makeProvider();
     const request = { botId: "lifecycle", homePath: "/unused" };
-    const first = await provider.provision(request, context);
+    const first = await provisionPrepared(provider, request, context);
     await provider.writeFile(
       first,
       { path: "state.txt", content: new TextEncoder().encode("preserved") },
@@ -114,7 +133,7 @@ describe.each([
 
     await provider.stop(first, context);
     await provider.stop(first, context);
-    const resumed = await provider.provision(request, context);
+    const resumed = await provisionPrepared(provider, request, context);
     expect(resumed).toMatchObject({
       id: first.id,
       providerRef: first.providerRef,
@@ -126,19 +145,26 @@ describe.each([
 
     await provider.destroy(resumed, context);
     await provider.destroy(resumed, context);
-    const replacement = await provider.provision(request, context);
+    const replacement = await provisionPrepared(provider, request, context);
     expect(replacement.fresh).toBe(true);
     await provider.destroy(replacement, context);
   });
 
   it("surfaces injected lifecycle and transfer failures and remains retryable", async () => {
     const provider = await makeProvider();
-    const faulted = faultOnce(provider, ["provision", "importWorkspace", "exportWorkspace"]);
+    const faulted = faultOnce(provider, [
+      "provision",
+      "prepare",
+      "importWorkspace",
+      "exportWorkspace",
+    ]);
     const request = { botId: "faults", homePath: "/unused" };
 
     await expect(faulted.provision(request, context)).rejects.toThrow("injected provision failure");
     const computer = await faulted.provision(request, context);
     expect(computer.fresh).toBe(true);
+    await expect(faulted.prepare(computer, context)).rejects.toThrow("injected prepare failure");
+    await faulted.prepare(computer, context);
 
     const file = {
       path: "retry.bin",
@@ -165,8 +191,12 @@ describe("portable workspace transfer", () => {
     const binary = Uint8Array.from([0, 255, 1, 128, 2, 127]);
 
     for (const [sourceName, source] of sourceProviders) {
-      const sourceComputer = await source.provision(
-        { botId: `source-${sourceName}`, homePath: "/unused" },
+      const sourceComputer = await provisionPrepared(
+        source,
+        {
+          botId: `source-${sourceName}`,
+          homePath: "/unused",
+        },
         context,
       );
       await source.writeFile(
@@ -177,8 +207,12 @@ describe("portable workspace transfer", () => {
       const exported = await collect(source.exportWorkspace(sourceComputer, context));
 
       for (const [targetName, target] of targetProviders) {
-        const targetComputer = await target.provision(
-          { botId: `${sourceName}-to-${targetName}`, homePath: "/unused" },
+        const targetComputer = await provisionPrepared(
+          target,
+          {
+            botId: `${sourceName}-to-${targetName}`,
+            homePath: "/unused",
+          },
           context,
         );
         await target.importWorkspace(targetComputer, portableFiles(exported), context);
@@ -197,7 +231,7 @@ describe("portable workspace transfer", () => {
   });
 });
 
-type FaultableMethod = "provision" | "importWorkspace" | "exportWorkspace";
+type FaultableMethod = "provision" | "prepare" | "importWorkspace" | "exportWorkspace";
 
 function faultOnce(provider: SandboxProvider, methods: FaultableMethod[]): SandboxProvider {
   const pending = new Set(methods);
@@ -207,6 +241,7 @@ function faultOnce(provider: SandboxProvider, methods: FaultableMethod[]): Sandb
       if (typeof value !== "function") return value;
       if (
         property !== "provision" &&
+        property !== "prepare" &&
         property !== "importWorkspace" &&
         property !== "exportWorkspace"
       ) {

--- a/packages/adapters/src/sandbox-test-support.ts
+++ b/packages/adapters/src/sandbox-test-support.ts
@@ -1,0 +1,11 @@
+import type { AdapterContext, SandboxProvider } from "@rakazo/adapter-kit";
+
+export async function provisionPrepared(
+  provider: SandboxProvider,
+  request: { botId: string; homePath: string },
+  context: AdapterContext,
+) {
+  const computer = await provider.provision(request, context);
+  await provider.prepare(computer, context);
+  return computer;
+}

--- a/packages/testkit/src/providers.canary.test.ts
+++ b/packages/testkit/src/providers.canary.test.ts
@@ -44,6 +44,7 @@ describeE2b("live E2B canary", () => {
       ctx,
     );
     try {
+      await sandbox.prepare(computer, ctx);
       let stdout = "";
       for await (const event of sandbox.execute(computer, { argv: ["echo", "e2b-ok"] }, ctx)) {
         if (event.type === "stdout") stdout += event.data;


### PR DESCRIPTION
## Summary
- split sandbox allocation from idempotent provider preparation in the shared provider contract
- centralize fresh/reused cleanup in the computer lifecycle for every provider
- retain provider references and surface aggregate errors when rollback fails
- extend conformance, fault, lifecycle, E2B, Daytona, and live canary coverage

## Verification
- pnpm check (19/19 tasks)
- pnpm lint (274 files)
- pnpm test (318 passed, 39 skipped)
- live E2B canary
- real Daytona Team Computer E2E (3 passed)
- real E2B Team Computer E2E (3 passed)