### PR TITLE
Enforce PR review follow-through

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Rakazo targets web, Electron desktop, and Expo mobile; Electron hosts the web UI. Consider every surface when changing features or contracts.
 - Prefer shared packages for domain logic, contracts, API behavior, and reusable UI. Keep genuinely native navigation, storage, permissions, and interactions platform-specific.
 - Treat auth, secret handling, sandbox boundaries, host commands, and integrations as security-sensitive. Keep tests deterministic and offline by default.
+- After creating a pull request, stay with it until CI and automated review bots have finished. Poll checks, reviews, review threads, and PR comments at roughly 60-second intervals; passing checks alone do not mean the review is complete. Address every actionable issue, push the fixes, and repeat the review cycle until no actionable feedback remains. Do not merge while review bots are still pending or review issues remain unresolved.

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -101,8 +101,12 @@ describe("renderScreenshotGallery", () => {
     expect(html).toContain('data-columns="1" aria-label="One column" aria-pressed="true"');
     expect(html).toContain('data-columns="4" aria-label="Four columns" aria-pressed="false"');
     expect(html).toContain("initialColumns = localStorage.getItem(storageKey) || initialColumns");
-    expect(html).toContain("@media (max-width: 900px)");
-    expect(html).toContain(".gallery { grid-template-columns: 1fr; }");
+    expect(html).toContain(`@media (max-width: 900px) {
+      header { align-items: start; flex-direction: column; }
+      .toolbar { align-items: start; flex-direction: column; }
+      .view-options { display: none; }
+      .gallery { grid-template-columns: 1fr; }
+    }`);
   });
 });
 

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -101,6 +101,8 @@ describe("renderScreenshotGallery", () => {
     expect(html).toContain('data-columns="1" aria-label="One column" aria-pressed="true"');
     expect(html).toContain('data-columns="4" aria-label="Four columns" aria-pressed="false"');
     expect(html).toContain("initialColumns = localStorage.getItem(storageKey) || initialColumns");
+    expect(html).toContain("@media (max-width: 900px)");
+    expect(html).toContain(".gallery { grid-template-columns: 1fr; }");
   });
 });
 

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -275,6 +275,7 @@ export function renderScreenshotGallery(input: {
     @media (max-width: 900px) {
       header { align-items: start; flex-direction: column; }
       .toolbar { align-items: start; flex-direction: column; }
+      .gallery { grid-template-columns: 1fr; }
     }
   </style>
 </head>

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -275,6 +275,7 @@ export function renderScreenshotGallery(input: {
     @media (max-width: 900px) {
       header { align-items: start; flex-direction: column; }
       .toolbar { align-items: start; flex-direction: column; }
+      .view-options { display: none; }
       .gallery { grid-template-columns: 1fr; }
     }
   </style>


### PR DESCRIPTION
## Summary
- require agents to monitor CI, review bots, threads, and comments after creating a PR
- require iterative fixes until no actionable review feedback remains
- address the missed PR #65 review by preserving a one-column gallery below 900px
- add regression coverage for the responsive override

## Verification
- `pnpm exec vitest run packages/testkit/src/playwright-report-dashboard.test.ts`
- `pnpm exec biome check packages/testkit/src/playwright-report-dashboard.ts packages/testkit/src/playwright-report-dashboard.test.ts`
- isolated TypeScript check for the gallery generator