### PR TITLE
Wait for signup UI before Playwright screenshot

### DIFF
--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -79,6 +79,7 @@ export async function signup(
   testInfo?: TestInfo,
 ) {
   await page.goto("/sign-up");
+  await expect(page.getByRole("heading", { name: "Create your Rakazo" })).toBeVisible();
   if (testInfo) await captureScreenshot(page, testInfo, "01-sign-up");
   await page.getByPlaceholder("Your name").fill(name);
   await page.getByPlaceholder("Your email address").fill(email);


### PR DESCRIPTION
## Summary

- wait for the signup heading before capturing the golden-flow screenshot
- prevent the route-level Suspense fallback from being published as a black frame
- make signup readiness an explicit assertion instead of relying on later locator auto-waiting

## Verification

- `pnpm --filter @rakazo/web check`
- `pnpm exec biome check apps/web/e2e/helpers.ts`
- `pnpm test:e2e --spec=golden.spec.ts --grep="two users are isolated and a bot completes durable work"`
- visually inspected the regenerated `01-sign-up.png`