### PR TITLE
Fix side panel overlap

### DIFF
--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -62,6 +62,15 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
     .toBe("waiting_takeover");
   await captureScreenshot(page, testInfo, "08-protected-input-request");
   await page.getByTitle("Agent computer").click();
+  const sidePanel = page.getByTestId("side-panel");
+  await expect(sidePanel).toHaveCSS("width", "384px");
+  const [mainBox, panelBox] = await Promise.all([
+    page.locator("main").boundingBox(),
+    sidePanel.boundingBox(),
+  ]);
+  expect(mainBox).not.toBeNull();
+  expect(panelBox).not.toBeNull();
+  expect((mainBox?.x ?? 0) + (mainBox?.width ?? 0)).toBeLessThanOrEqual(panelBox?.x ?? 0);
   await page.getByRole("button", { name: "Take control" }).click();
   await expect(page.getByRole("button", { name: "Close computer" })).toBeVisible();
   await captureScreenshot(page, testInfo, "09-computer-takeover");

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -799,8 +799,8 @@ export function ShellPage() {
       <aside
         data-testid="side-panel"
         data-panel={panel ?? "closed"}
-        className={`absolute inset-y-0 right-0 z-20 flex w-[384px] min-h-0 flex-col overflow-hidden border-l border-[#141416] bg-[#0A0A0B] shadow-[-18px_0_45px_rgba(0,0,0,.24)] transition-transform duration-150 ease-out ${
-          panel && active ? "translate-x-0" : "pointer-events-none translate-x-full"
+        className={`relative z-20 flex min-h-0 shrink-0 flex-col overflow-hidden bg-[#0A0A0B] transition-[width] duration-150 ease-out ${
+          panel && active ? "w-[384px] border-l border-[#141416]" : "pointer-events-none w-0"
         }`}
       >
         {panel && active ? (


### PR DESCRIPTION
Moves the desktop side panel into the shell flex layout so it reserves its own 384px column instead of covering chat content. The closed panel now collapses to zero width while preserving the existing transition behavior. Adds an end-to-end bounding-box assertion to prevent panel/main overlap regressions.

Verified with Biome, the web TypeScript check, 29 web unit tests, and a production web build.