### PR TITLE
Remove archive and delete from bot settings

### DIFF
--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -102,9 +102,17 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await page.getByRole("button", { name: "Export" }).click();
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toMatch(/chief-export\.json/i);
-  await expect(page.getByRole("button", { name: "Archive bot" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Delete bot" })).toBeVisible();
-  await page.getByRole("button", { name: "Delete bot" }).click();
+  const settings = page.getByTestId("bot-settings");
+  await expect(settings.getByRole("button", { name: "Archive bot" })).toHaveCount(0);
+  await expect(settings.getByRole("button", { name: "Delete bot" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Close panel" }).click();
+
+  await page.locator("aside").first().getByRole("button", { name: /Chief/ }).first().click({
+    button: "right",
+  });
+  const botMenu = page.getByRole("menu", { name: "Actions for Chief" });
+  await expect(botMenu.getByRole("menuitem", { name: "Archive" })).toBeVisible();
+  await botMenu.getByRole("menuitem", { name: "Delete" }).click();
   await expect(page.getByRole("radio", { name: /Keep memories/ })).toBeChecked();
   await expect(page.getByRole("radio", { name: /Delete memories too/ })).toBeVisible();
   await page.getByRole("button", { name: "Cancel" }).click();

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -976,12 +976,6 @@ export function ShellPage() {
                   a.click();
                   URL.revokeObjectURL(url);
                 }}
-                onArchive={async () => {
-                  await rpc.bots.archive({ botId: active.id });
-                  setPanel(null);
-                  await refreshBots(true);
-                }}
-                onDelete={() => setDeleteTarget(active)}
               />
             ) : null}
             {panel === "routine" ? (
@@ -1773,8 +1767,6 @@ function BotSettings({
   bot,
   onSave,
   onExport,
-  onArchive,
-  onDelete,
 }: {
   bot: Bot;
   onSave: (patch: {
@@ -1785,15 +1777,12 @@ function BotSettings({
     computerMode: ComputerMode;
   }) => Promise<void>;
   onExport: () => Promise<void>;
-  onArchive: () => Promise<void>;
-  onDelete: () => void;
 }) {
   const [name, setName] = useState(bot.name);
   const [title, setTitle] = useState(bot.title);
   const [description, setDescription] = useState(bot.description);
   const [computerMode, setComputerMode] = useState(bot.computerMode);
   const [saving, setSaving] = useState(false);
-  const [archiving, setArchiving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   return (
@@ -1855,23 +1844,6 @@ function BotSettings({
           className="text-[14px] text-[#85858A]"
         >
           Export
-        </button>
-        <button
-          type="button"
-          disabled={archiving}
-          onClick={() => {
-            setArchiving(true);
-            setError(null);
-            void onArchive()
-              .catch((err) => setError(err instanceof Error ? err.message : "Could not archive"))
-              .finally(() => setArchiving(false));
-          }}
-          className="text-[14px] text-[#85858A] disabled:opacity-40"
-        >
-          {archiving ? "Archiving…" : "Archive bot"}
-        </button>
-        <button type="button" onClick={onDelete} className="text-[14px] text-[#E65707]">
-          Delete bot…
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the redundant Archive bot action from the bot settings side panel
- remove the redundant Delete bot action from the bot settings side panel
- keep both actions accessible from the bot right-click menu and cover that path in the golden E2E flow

## Tests
- `pnpm exec biome check apps/web/src/pages/Shell.tsx apps/web/e2e/golden.spec.ts`
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web test`
- `pnpm test:e2e --spec=golden.spec.ts --grep="takeover, routine, plugins, and export are reachable"`