### PR TITLE
Emulate Composio catalog in end-to-end tests

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,7 +2,7 @@ import { rm } from "node:fs/promises";
 import { RPCHandler } from "@orpc/server/fetch";
 import type { JobPublisher, RealtimeFanout, SandboxProvider } from "@rakazo/adapter-kit";
 import {
-  type ComposioConnector,
+  type ComposioProvider,
   createBackgroundJobHandlers,
   createConnectorStack,
   createJobReconciler,
@@ -37,22 +37,32 @@ export interface AppHandles {
   jobs: JobPublisher;
   sandbox: SandboxProvider;
   connector: DestinationEmulator;
-  composio?: ComposioConnector;
+  composio?: ComposioProvider;
   executor: ReturnType<typeof createRunExecutor>;
   stop: () => Promise<void>;
 }
 
 export async function createApp(
-  overrides: Partial<AppEnv> & { prisma?: PrismaClient; realtime?: RealtimeFanout } = {},
+  overrides: Partial<AppEnv> & {
+    prisma?: PrismaClient;
+    realtime?: RealtimeFanout;
+    composio?: ComposioProvider;
+  } = {},
 ): Promise<AppHandles> {
-  const env = { ...loadEnv(process.env), ...overrides };
-  const created = overrides.prisma
-    ? { prisma: overrides.prisma, pool: undefined }
+  const {
+    prisma: prismaOverride,
+    realtime: realtimeOverride,
+    composio: composioOverride,
+    ...envOverrides
+  } = overrides;
+  const env = { ...loadEnv(process.env), ...envOverrides };
+  const created = prismaOverride
+    ? { prisma: prismaOverride, pool: undefined }
     : createDb(env.databaseUrl);
   const { prisma } = created;
   created.pool?.on("error", () => undefined);
   const realtime =
-    overrides.realtime ??
+    realtimeOverride ??
     (created.pool
       ? new PostgresRealtimeFanout({
           connectionString: env.realtimeDatabaseUrl,
@@ -83,7 +93,7 @@ export async function createApp(
   const oauthLogins = new PiOAuthLogins();
   const home = new LocalAgentHomeStore(env.dataDir);
   const memory = new MarkdownMemoryStore(prisma);
-  const stack = createConnectorStack(isComposioEnabled(env.composioApiKey));
+  const stack = createConnectorStack(isComposioEnabled(env.composioApiKey), composioOverride);
   const connector = stack.destination;
   await connector.start();
   void stack.composio?.warmDirectory().catch(() => undefined);

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -14,7 +14,7 @@ import {
 import {
   acquireComputerExecutionLease,
   archiveBot,
-  type ComposioConnector,
+  type ComposioProvider,
   ComputerBusyError,
   type ComputerExecutionLease,
   checkpointAndRecordComputerWorkspace,
@@ -87,7 +87,7 @@ export interface RouterDeps {
   home: AgentHomeStore;
   secrets: EncryptedSecretStore;
   oauthLogins: PiOAuthLogins;
-  composio?: ComposioConnector;
+  composio?: ComposioProvider;
   dataDir: string;
   env: {
     defaultProvider: string;

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -86,6 +86,15 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await expect(page.getByText("GitHub", { exact: true })).toBeVisible();
   await expect(page.getByText("Notion", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11-plugins-catalog");
+
+  const gmailRow = page.getByText("Gmail", { exact: true }).locator("..").locator("..");
+  await gmailRow.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect(gmailRow.getByRole("button", { name: "Revoke", exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "11a-plugin-connected");
+
+  await gmailRow.getByRole("button", { name: "Revoke", exact: true }).click();
+  await expect(gmailRow.getByRole("button", { name: "Connect", exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "11b-plugin-revoked");
   await page.getByRole("button", { name: "Close plugins" }).click();
 
   await page.getByText("Chief").first().click();

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -80,7 +80,6 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
 
   await page.getByText("Plugins").click();
   await expect(page.getByPlaceholder("Search apps")).toBeVisible();
-  await expect(page.getByText("4 apps", { exact: true })).toBeVisible();
   await expect(page.getByText("Gmail", { exact: true })).toBeVisible();
   await expect(page.getByText("Slack", { exact: true })).toBeVisible();
   await expect(page.getByText("GitHub", { exact: true })).toBeVisible();
@@ -90,11 +89,18 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   const gmailRow = page.getByText("Gmail", { exact: true }).locator("..").locator("..");
   await gmailRow.getByRole("button", { name: "Connect", exact: true }).click();
   await expect(gmailRow.getByRole("button", { name: "Revoke", exact: true })).toBeVisible();
-  await captureScreenshot(page, testInfo, "11a-plugin-connected");
+  await page.getByRole("tab", { name: "Connected", exact: true }).click();
+  await expect(page.getByText("Slack", { exact: true })).toBeHidden();
+  await captureScreenshot(page, testInfo, "11a-connected-plugins");
 
   await gmailRow.getByRole("button", { name: "Revoke", exact: true }).click();
+  await expect(page.getByText("No connected apps yet.", { exact: true })).toBeVisible();
+  await expect(page.getByText("Gmail", { exact: true })).toBeHidden();
+  await captureScreenshot(page, testInfo, "11b-connected-plugins-empty");
+
+  await page.getByRole("tab", { name: "All", exact: true }).click();
+  await expect(page.getByText("Gmail", { exact: true })).toBeVisible();
   await expect(gmailRow.getByRole("button", { name: "Connect", exact: true })).toBeVisible();
-  await captureScreenshot(page, testInfo, "11b-plugin-revoked");
   await page.getByRole("button", { name: "Close plugins" }).click();
 
   await page.getByText("Chief").first().click();

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -80,6 +80,11 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
 
   await page.getByText("Plugins").click();
   await expect(page.getByPlaceholder("Search apps")).toBeVisible();
+  await expect(page.getByText("4 apps", { exact: true })).toBeVisible();
+  await expect(page.getByText("Gmail", { exact: true })).toBeVisible();
+  await expect(page.getByText("Slack", { exact: true })).toBeVisible();
+  await expect(page.getByText("GitHub", { exact: true })).toBeVisible();
+  await expect(page.getByText("Notion", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11-plugins-catalog");
   await page.getByRole("button", { name: "Close plugins" }).click();
 

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { rpc } from "../lib/rpc";
 
 let cachedCatalog: ConnectionCatalogItem[] = [];
+type CatalogView = "all" | "connected";
 
 function markConnected(items: ConnectionCatalogItem[], slug: string, connected: boolean) {
   return items.map((entry) => (entry.slug === slug ? { ...entry, connected } : entry));
@@ -11,6 +12,7 @@ function markConnected(items: ConnectionCatalogItem[], slug: string, connected: 
 
 export function PluginsOverlay({ onClose }: { onClose: () => void }) {
   const [query, setQuery] = useState("");
+  const [view, setView] = useState<CatalogView>("all");
   const [catalog, setCatalog] = useState<ConnectionCatalogItem[]>(cachedCatalog);
   const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -33,12 +35,13 @@ export function PluginsOverlay({ onClose }: { onClose: () => void }) {
 
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    if (!needle) return catalog;
-    return catalog.filter(
+    const scoped = view === "connected" ? catalog.filter((item) => item.connected) : catalog;
+    if (!needle) return scoped;
+    return scoped.filter(
       (item) =>
         item.name.toLowerCase().includes(needle) || item.slug.toLowerCase().includes(needle),
     );
-  }, [catalog, query]);
+  }, [catalog, query, view]);
 
   function setItemConnected(slug: string, connected: boolean) {
     cachedCatalog = markConnected(cachedCatalog, slug, connected);
@@ -100,9 +103,7 @@ export function PluginsOverlay({ onClose }: { onClose: () => void }) {
         <div className="flex items-start justify-between px-8 pt-7">
           <div>
             <div className="text-2xl font-medium text-[#F1F1F2]">Plugins</div>
-            <p className="mt-1 text-[13.5px] text-[#7A7A80]">
-              {loading ? "Loading catalog…" : `${catalog.length} apps`}
-            </p>
+            {loading ? <p className="mt-1 text-[13.5px] text-[#7A7A80]">Loading catalog…</p> : null}
           </div>
           <button
             type="button"
@@ -121,10 +122,38 @@ export function PluginsOverlay({ onClose }: { onClose: () => void }) {
             className="w-full rounded-[13px] border border-[#26262A] bg-[#101012] px-4 py-3 text-[15px] text-[#ECECEE] outline-none"
           />
         </div>
-        <div className="rk-scroll flex-1 overflow-y-auto px-8 py-6">
+        <div role="tablist" aria-label="Plugin views" className="flex gap-1 px-8 pt-4">
+          {(["all", "connected"] as const).map((option) => (
+            <button
+              key={option}
+              type="button"
+              role="tab"
+              aria-selected={view === option}
+              aria-controls="plugin-list"
+              onClick={() => setView(option)}
+              className={`rounded-full px-3.5 py-1.5 text-sm transition-colors ${
+                view === option
+                  ? "bg-[#2C2C30] text-[#F1F1F2]"
+                  : "text-[#7A7A80] hover:text-[#C8C8CC]"
+              }`}
+            >
+              {option === "all" ? "All" : "Connected"}
+            </button>
+          ))}
+        </div>
+        <div
+          id="plugin-list"
+          role="tabpanel"
+          className="rk-scroll flex-1 overflow-y-auto px-8 py-6"
+        >
           {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
           {!loading && catalog.length === 0 ? (
             <p className="text-[#6C6C70]">Composio is not configured on this deployment.</p>
+          ) : null}
+          {!loading && catalog.length > 0 && view === "connected" && visible.length === 0 ? (
+            <p className="text-[#6C6C70]">
+              {query.trim() ? "No connected apps match your search." : "No connected apps yet."}
+            </p>
           ) : null}
           {visible.map((item) => (
             <div key={item.slug} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -1,7 +1,6 @@
 import { Composio } from "@composio/core";
 import type {
   AdapterContext,
-  ConnectionAuthProvider,
   ConnectorCall,
   ConnectorEvent,
   ConnectorProvider,
@@ -72,6 +71,21 @@ export interface ComposioCatalogItem {
   noAuth: boolean;
 }
 
+export interface ComposioProvider extends ConnectorProvider {
+  catalog(userId: string, query?: string): Promise<ComposioCatalogItem[]>;
+  warmDirectory(): Promise<void>;
+  connectionReady(userId: string, slug: string): Promise<boolean>;
+  begin(
+    request: { provider: string; redirectUrl: string },
+    context: AdapterContext,
+  ): Promise<{ authorizationUrl: string | null; state: string }>;
+  complete(
+    request: { state: string; code?: string },
+    context: AdapterContext,
+  ): Promise<{ connectionRef: string }>;
+  revoke(connectionRef: string, context: AdapterContext): Promise<void>;
+}
+
 export function filterCatalog(items: ComposioCatalogItem[], query: string): ComposioCatalogItem[] {
   const needle = query.trim().toLowerCase();
   if (!needle) return items;
@@ -99,7 +113,7 @@ export function executeSessionKey(toolkits: string[]): string {
   return [...new Set(toolkits.map((slug) => slug.trim()).filter(Boolean))].sort().join(",");
 }
 
-export class ComposioConnector implements ConnectorProvider, ConnectionAuthProvider {
+export class ComposioConnector implements ComposioProvider {
   private client: Composio | undefined;
   private readonly catalogSessions = new Map<string, string>();
   private readonly executeSessions = new Map<string, { sessionId: string; key: string }>();
@@ -279,7 +293,7 @@ export class ComposioConnector implements ConnectorProvider, ConnectionAuthProvi
 export class CompositeConnector implements ConnectorProvider {
   constructor(
     readonly destination: DestinationEmulator,
-    readonly composio?: ComposioConnector,
+    readonly composio?: ComposioProvider,
   ) {}
 
   describe() {
@@ -307,9 +321,12 @@ export class CompositeConnector implements ConnectorProvider {
   }
 }
 
-export function createConnectorStack(composioEnabled: boolean) {
+export function createConnectorStack(
+  composioEnabled: boolean,
+  composioOverride?: ComposioProvider,
+) {
   const destination = new DestinationEmulator();
-  const composio = composioEnabled ? new ComposioConnector() : undefined;
+  const composio = composioOverride ?? (composioEnabled ? new ComposioConnector() : undefined);
   return {
     destination,
     composio,

--- a/packages/adapters/src/composio-emulator.test.ts
+++ b/packages/adapters/src/composio-emulator.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { ComposioEmulator } from "./composio-emulator.js";
+
+const context = {
+  operationId: "test",
+  traceId: "test",
+  workspaceId: "workspace",
+  userId: "user-1",
+  signal: new AbortController().signal,
+};
+
+describe("ComposioEmulator", () => {
+  it("serves and searches a deterministic catalog", async () => {
+    const emulator = new ComposioEmulator();
+
+    await expect(emulator.catalog(context.userId)).resolves.toHaveLength(4);
+    await expect(emulator.catalog(context.userId, "git")).resolves.toEqual([
+      expect.objectContaining({ slug: "GITHUB", name: "GitHub", connected: false }),
+    ]);
+  });
+
+  it("isolates connection state by user and supports revoke", async () => {
+    const emulator = new ComposioEmulator();
+    await emulator.begin({ provider: "GMAIL", redirectUrl: "http://example.test" }, context);
+
+    await expect(emulator.connectionReady(context.userId, "GMAIL")).resolves.toBe(true);
+    await expect(emulator.connectionReady("user-2", "GMAIL")).resolves.toBe(false);
+    await expect(emulator.catalog(context.userId, "gmail")).resolves.toEqual([
+      expect.objectContaining({ slug: "GMAIL", connected: true }),
+    ]);
+
+    await emulator.revoke("GMAIL", context);
+    await expect(emulator.connectionReady(context.userId, "GMAIL")).resolves.toBe(false);
+  });
+});

--- a/packages/adapters/src/composio-emulator.ts
+++ b/packages/adapters/src/composio-emulator.ts
@@ -1,0 +1,81 @@
+import type {
+  AdapterContext,
+  ConnectorCall,
+  ConnectorEvent,
+  ConnectorTool,
+} from "@rakazo/adapter-kit";
+import {
+  type ComposioCatalogItem,
+  type ComposioProvider,
+  filterCatalog,
+} from "./composio-connector.js";
+
+const DEFAULT_CATALOG: ReadonlyArray<Omit<ComposioCatalogItem, "connected">> = [
+  { slug: "GMAIL", name: "Gmail", logo: null, noAuth: false },
+  { slug: "SLACK", name: "Slack", logo: null, noAuth: false },
+  { slug: "GITHUB", name: "GitHub", logo: null, noAuth: false },
+  { slug: "NOTION", name: "Notion", logo: null, noAuth: false },
+];
+
+/** Deterministic, offline Composio catalog and connection emulator for product tests. */
+export class ComposioEmulator implements ComposioProvider {
+  private readonly connectedByUser = new Map<string, Set<string>>();
+
+  constructor(
+    private readonly directory: ReadonlyArray<
+      Omit<ComposioCatalogItem, "connected">
+    > = DEFAULT_CATALOG,
+  ) {}
+
+  describe() {
+    return {
+      id: "composio-emulator",
+      contractVersion: "1",
+      adapterVersion: "0.1.0",
+      capabilities: { discover: true, oauth: true, secretsBrokered: true },
+    };
+  }
+
+  async catalog(userId: string, query?: string): Promise<ComposioCatalogItem[]> {
+    const connected = this.connectedByUser.get(userId) ?? new Set<string>();
+    return filterCatalog(
+      this.directory.map((item) => ({ ...item, connected: connected.has(item.slug) })),
+      query ?? "",
+    );
+  }
+
+  async warmDirectory(): Promise<void> {}
+
+  async discoverTools(_context: AdapterContext): Promise<ConnectorTool[]> {
+    return [];
+  }
+
+  async *execute(call: ConnectorCall, _context: AdapterContext): AsyncIterable<ConnectorEvent> {
+    yield { type: "error", message: `Composio emulator cannot execute ${call.tool}` };
+  }
+
+  async begin(
+    request: { provider: string; redirectUrl: string },
+    context: AdapterContext,
+  ): Promise<{ authorizationUrl: string | null; state: string }> {
+    const connected = this.connectedByUser.get(context.userId) ?? new Set<string>();
+    connected.add(request.provider);
+    this.connectedByUser.set(context.userId, connected);
+    return { authorizationUrl: null, state: request.provider };
+  }
+
+  async connectionReady(userId: string, slug: string): Promise<boolean> {
+    return this.connectedByUser.get(userId)?.has(slug) ?? false;
+  }
+
+  async complete(
+    request: { state: string; code?: string },
+    _context: AdapterContext,
+  ): Promise<{ connectionRef: string }> {
+    return { connectionRef: request.state };
+  }
+
+  async revoke(connectionRef: string, context: AdapterContext): Promise<void> {
+    this.connectedByUser.get(context.userId)?.delete(connectionRef);
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -4,6 +4,7 @@ export * from "./builtin-tools.js";
 export * from "./child-bots.js";
 export * from "./composio-catalog-cache.js";
 export * from "./composio-connector.js";
+export * from "./composio-emulator.js";
 export * from "./computer-control.js";
 export * from "./computer-idle.js";
 export * from "./computer-lifecycle.js";

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -1,7 +1,6 @@
 import { execSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { ComposioEmulator } from "@rakazo/adapters";
 import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
 import { runProcess } from "./process.js";
@@ -95,7 +94,10 @@ async function main() {
       return;
     }
 
-    const { createApp } = await import("../../../../apps/api/src/app.ts");
+    const [{ ComposioEmulator }, { createApp }] = await Promise.all([
+      import("@rakazo/adapters"),
+      import("../../../../apps/api/src/app.ts"),
+    ]);
     const { serve } = await import("@hono/node-server");
     const handles = await createApp({
       databaseUrl,

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { ComposioEmulator } from "@rakazo/adapters";
 import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
 import { runProcess } from "./process.js";
@@ -96,7 +97,11 @@ async function main() {
 
     const { createApp } = await import("../../../../apps/api/src/app.ts");
     const { serve } = await import("@hono/node-server");
-    const handles = await createApp({ databaseUrl, prisma: undefined });
+    const handles = await createApp({
+      databaseUrl,
+      prisma: undefined,
+      composio: new ComposioEmulator(),
+    });
     let activeRequests = 0;
     const requestWaiters = new Set<() => void>();
     const server = serve({


### PR DESCRIPTION
Adds an injectable Composio provider seam and a deterministic offline emulator for catalog search plus connect/revoke state.
Wires the E2E harness to documented Gmail, Slack, GitHub, and Notion fixtures without using a live key or network calls.
Adds count-free All and Connected plugin views with an explicit empty state, covered by catalog, connected, and revoked golden screenshots.
Verification: focused Vitest coverage, affected package type-checks, Biome, Postgres journeys, and Web E2E.