### PR TITLE
Add coding-agent setup prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ https://github.com/user-attachments/assets/dccdeddb-2134-4a56-8eed-b2e591736b1c
 
 ## Run locally (web)
 
+Want a coding agent to handle the setup? Copy the [`SETUP_PROMPT.md`](./SETUP_PROMPT.md) prompt into your agent.
+
 From the repo root:
 
 ```bash

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -1,0 +1,80 @@
+# Set up Rakazo with a coding agent
+
+Copy the prompt below into a coding agent. It sets up the local web app first; Electron is an optional final step.
+
+```text
+Set up Rakazo locally and leave it running in a usable state.
+
+Repository: https://github.com/elie222/rakazo.git
+
+Work like a careful onboarding engineer: perform the setup yourself, explain only decisions or blockers, and verify the product through the UI rather than stopping after dependency installation.
+
+Safety rules:
+
+- Never overwrite an existing `.env`. If one exists, inspect only which keys are present (never print values), preserve it, and ask before changing existing values.
+- Never print, log, commit, or paste secrets into tracked files. Confirm `.env` is ignored. Do not commit anything as part of setup.
+- Do not discard local changes if the repository already exists. Inspect `git status` first.
+- Do not kill unrelated processes or containers to free ports. Identify conflicts and ask before stopping anything; otherwise use a safe alternate configuration and document it.
+- Treat Docker/Desktop host access and model or integration credentials as security-sensitive.
+
+Before making changes, ask me these concise questions:
+
+1. Should you clone into the current directory, or what parent directory should contain `rakazo`? If you are already inside a Rakazo checkout, offer to use it without recloning.
+2. How should models be connected?
+   - Add a deployment-wide `OPENROUTER_API_KEY` to `.env`.
+   - Connect during Rakazo onboarding with a provider API key or with ChatGPT Plus/Pro, GitHub Copilot, or SuperGrok / X Premium.
+   - Defer model setup and verify infrastructure only. Make clear that bots cannot answer until a model is connected.
+3. Do I want live app plugins? If yes, arrange for `COMPOSIO_API_KEY`; otherwise leave it empty. Explain that this is optional.
+4. Set up the web app only (recommended), or also launch the Electron desktop shell after the web stack works?
+
+Do not ask me to invent `BETTER_AUTH_SECRET` or `ENCRYPTION_KEY`; generate strong random local values yourself. If I choose an API key, let me enter it through an available secure secret mechanism or directly into `.env`; never echo it back. OAuth or device-code sign-in must remain under my control.
+
+Preflight:
+
+- Verify Git, Node.js, pnpm, Docker, and Docker Compose.
+- Use Node.js 22 LTS (at least 22.12) and the repository-declared pnpm 9.15.0. Do not silently use pnpm 10 or 11: newer pnpm versions can reject this lockfile or rewrite it. Prefer Corepack; if Corepack is unavailable, use `npx --yes pnpm@9.15.0` for repo commands rather than globally installing a different version. Show the effective versions.
+- Verify the Docker daemon is running.
+- Check whether `127.0.0.1` ports 5433, 3100, 5173, and 7091 are available. Resolve conflicts without touching unrelated workloads.
+
+Setup:
+
+1. Clone the repository if needed and enter its root.
+2. Read `AGENTS.md`, `README.md`, `.env.example`, and the root `package.json` before acting. Follow repository instructions if they have changed since this prompt was written.
+3. If `.env` does not exist, copy `.env.example` to `.env`. Generate independent random values of at least 32 bytes for `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY`. Keep local defaults for Postgres, origins, Pi, Docker, and Graphile unless the preflight found a conflict. Add only the model and Composio credentials I selected. Leave optional credentials blank.
+4. Confirm `.env` is ignored and that no secret-bearing file is staged.
+5. Start only local Postgres:
+
+   `docker compose --env-file .env -f infra/compose/docker-compose.yml up postgres -d`
+
+6. With pnpm 9.15.0, run:
+
+   `pnpm install --frozen-lockfile`
+   `pnpm db:generate`
+   `pnpm db:migrate`
+   `pnpm sandbox:build`
+
+   The first sandbox build may take several minutes because it installs a graphical Linux desktop and Chromium. If a command fails, diagnose the cause; do not bypass the lockfile or approve arbitrary dependency build scripts just to make progress.
+
+7. Start `pnpm dev` in a persistent terminal. Wait until the API, worker, web app, and sandbox supervisor are ready. Keep the process running for me.
+
+Verification:
+
+- Request `http://127.0.0.1:3100/health`. Require `ok: true`, `runtime: "pi"`, `sandbox: "docker"`, `jobs: "graphile"`, and `realtime: "postgres"`. Expect `composio: true` only when its key was configured.
+- Open `http://127.0.0.1:5173` in a browser. If browser automation is available, use it for non-sensitive steps; otherwise give me the exact UI steps.
+- Create a local test account with clearly fake data, complete first-run onboarding, and create a test bot. Do not use personal data.
+- If a model is connected, send a harmless test message and confirm the bot replies. If model setup was deferred, explicitly report that the stack is healthy but a first message will fail until a provider is configured; do not call the setup fully usable without that caveat.
+- Open the Agent computer pane and confirm the Docker computer reaches `running` and renders its desktop.
+- If Composio was not configured, confirm Plugins explains that it is not configured. If it was configured, verify the Plugins view loads without exposing the key.
+- Run `pnpm test` and `pnpm check`. Report failures with the relevant output; do not claim success if either fails.
+- If I requested Electron, leave the web stack running and then launch `pnpm --filter @rakazo/desktop dev`. Verify the shell loads the same app. Let me make the Docker-versus-This-Mac choice because This Mac grants bots access under my OS account.
+
+When finished, report:
+
+- The absolute repository path and checked-out commit.
+- Effective Node, pnpm, Docker, and Docker Compose versions.
+- Which model-auth path and optional integrations are configured, without revealing secrets.
+- App URL, health result, UI/message/computer verification, and test/type-check results.
+- Every workaround or remaining limitation.
+- How to restart the stack.
+- How to stop it without deleting data. Do not use `pnpm compose:down` for a normal stop because that script includes `-v` and removes Compose volumes; use a non-destructive stop/down command without `-v` and explain it.
+```

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -7,10 +7,19 @@ import { ProductDemo } from "../components/ProductDemo";
 import { DEMO_ROSTER } from "../demo";
 import { fetchGithubStars, formatStarCount } from "../github";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { DOCS_URL, GITHUB_URL, SITE_DESCRIPTION, SITE_NAME, SITE_URL, WAITLIST_HREF } from "../site";
+import {
+  DOCS_URL,
+  GITHUB_URL,
+  SETUP_PROMPT_URL,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+  WAITLIST_HREF,
+} from "../site";
 
 const stars = await fetchGithubStars();
 const starsLabel = stars === null ? "Star" : formatStarCount(stars);
+const setupAgentPrompt = `Set up Rakazo for me. Follow the setup prompt at ${SETUP_PROMPT_URL}`;
 const structuredData = {
   "@context": "https://schema.org",
   "@graph": [
@@ -62,6 +71,16 @@ const structuredData = {
         <div class="hero__actions">
           <Button href={GITHUB_URL} external>View on GitHub</Button>
           <Button href="#demo" variant="secondary">See it in action</Button>
+        </div>
+        <div class="hero__agent-setup">
+          <button class="setup-copy" type="button" data-setup-copy={setupAgentPrompt}>
+            <span class="setup-copy__prefix" aria-hidden="true">$</span>
+            <span class="setup-copy__label">Set up with your agent</span>
+            <svg class="setup-copy__icon" viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="8" y="8" width="12" height="12" rx="2"></rect>
+              <path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2"></path>
+            </svg>
+          </button>
         </div>
       </section>
 
@@ -189,3 +208,23 @@ const structuredData = {
     <Footer />
   </div>
 </BaseLayout>
+
+<script>
+  const setupCopy = document.querySelector<HTMLButtonElement>("[data-setup-copy]");
+  const setupCopyLabel = setupCopy?.querySelector<HTMLElement>(".setup-copy__label");
+
+  setupCopy?.addEventListener("click", async () => {
+    const prompt = setupCopy.dataset.setupCopy;
+    if (!prompt || !setupCopyLabel) return;
+
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setupCopyLabel.textContent = "Copied for your agent";
+      window.setTimeout(() => {
+        setupCopyLabel.textContent = "Set up with your agent";
+      }, 2400);
+    } catch {
+      setupCopyLabel.textContent = "Copy failed — try again";
+    }
+  });
+</script>

--- a/apps/www/src/site.ts
+++ b/apps/www/src/site.ts
@@ -6,6 +6,7 @@ export const SITE_DESCRIPTION =
 export const GITHUB_URL = "https://github.com/elie222/rakazo";
 export const GITHUB_API_REPO = "https://api.github.com/repos/elie222/rakazo";
 export const DOCS_URL = "https://github.com/elie222/rakazo/blob/main/docs/self-host.md";
+export const SETUP_PROMPT_URL = "https://github.com/elie222/rakazo/blob/main/SETUP_PROMPT.md";
 export const CHANGELOG_URL = "https://github.com/elie222/rakazo/releases";
 export const WAITLIST_HREF = "mailto:hello@rakazo.com?subject=Rakazo%20Cloud%20waitlist";
 export const INBOX_ZERO_URL =

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -394,6 +394,55 @@ button {
   margin-top: 34px;
 }
 
+.hero__agent-setup {
+  display: flex;
+  justify-content: center;
+  margin-top: 14px;
+}
+
+.setup-copy {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 0 16px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--muted);
+  font: 500 14px/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  letter-spacing: -0.02em;
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    opacity 150ms ease;
+}
+
+.setup-copy:hover {
+  color: var(--blue);
+}
+
+.setup-copy:focus-visible {
+  outline: 2px solid var(--blue-line);
+  outline-offset: 3px;
+}
+
+.setup-copy__prefix {
+  color: var(--muted-2);
+}
+
+.setup-copy__icon {
+  width: 17px;
+  height: 17px;
+  flex: none;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
 .cta-actions {
   margin-top: 26px;
 }
@@ -1903,7 +1952,8 @@ button {
   }
 
   .button,
-  .button--small {
+  .button--small,
+  .setup-copy {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- add a paste-ready coding-agent prompt for safe local Rakazo setup
- link the prompt from the README
- add a quiet copy-to-clipboard setup line below the existing marketing hero actions

## Verification
- `pnpm lint`
- `pnpm --filter @rakazo/www check`
- `pnpm --filter @rakazo/www build`
- clean-clone setup: dependencies, Prisma generation/migrations, Docker computer image, health endpoint, browser onboarding, and Docker computer pane
- clean-clone checks: 367 tests passed; all 19 type-check tasks passed