### PR TITLE
Move routine run action into editor

### DIFF
--- a/apps/web/e2e/routine-execution.spec.ts
+++ b/apps/web/e2e/routine-execution.spec.ts
@@ -7,6 +7,7 @@ test("routine run-now completes and survives reload", async ({ page }, testInfo)
   await completeOnboarding(page, ["A bit of everything", "Clear and tight"]);
 
   await page.getByTitle("Agent computer").click();
+  await expect(page.getByRole("button", { name: "Run now" })).toHaveCount(0);
   await page.getByText("+ New routine").click();
   await page.locator("label:has-text('Name') input").fill("Daily verification");
   await page
@@ -22,6 +23,7 @@ test("routine run-now completes and survives reload", async ({ page }, testInfo)
   await expect(routine).toContainText("Weekdays at 9:00 AM");
   await captureScreenshot(page, testInfo, "33-routine-scheduled");
 
+  await routine.click();
   await page.getByRole("button", { name: "Run now" }).click();
   await expect(page.getByText(/routine-run-now-ok/i).first()).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -96,6 +96,7 @@ export function ShellPage() {
   const [editingRoutine, setEditingRoutine] = useState<Routine | null>(null);
   const [deleteRoutineTarget, setDeleteRoutineTarget] = useState<Routine | null>(null);
   const [savingRoutine, setSavingRoutine] = useState(false);
+  const [runningRoutine, setRunningRoutine] = useState(false);
   const [screenUrl, setScreenUrl] = useState<string | null>(null);
   const [computerOpen, setComputerOpen] = useState(false);
   const [usage, setUsage] = useState<{
@@ -105,6 +106,7 @@ export function ShellPage() {
   } | null>(null);
   const autoBooted = useRef<string | null>(null);
   const routineSavePending = useRef(false);
+  const routineRunPending = useRef(false);
   const bootstrappedThread = useRef<ThreadSnapshot | null>(null);
   const expandedHistoryThread = useRef<string | null>(null);
   const initiallyScrolledThread = useRef<string | null>(null);
@@ -916,23 +918,6 @@ export function ShellPage() {
                 ))}
                 <button
                   type="button"
-                  onClick={async () => {
-                    const first = activeRoutines[0];
-                    if (first) {
-                      await rpc.routines.testRun({ routineId: first.id });
-                      await refreshThread(active.id);
-                    } else {
-                      setRoutineDraft({ name: "", prompt: "", schedule: defaultCronPreset() });
-                      setEditingRoutine(null);
-                      setPanel("routine");
-                    }
-                  }}
-                  className="mt-1 flex items-center gap-2.5 px-2.5 py-2.5 text-[14.5px] text-[#7A7A80]"
-                >
-                  Run now
-                </button>
-                <button
-                  type="button"
                   onClick={() => {
                     setRoutineDraft({ name: "", prompt: "", schedule: defaultCronPreset() });
                     setEditingRoutine(null);
@@ -1028,7 +1013,7 @@ export function ShellPage() {
                 <div className="mt-5 flex items-center gap-3">
                   <button
                     type="button"
-                    disabled={savingRoutine}
+                    disabled={savingRoutine || runningRoutine}
                     onClick={async () => {
                       if (routineSavePending.current) return;
                       const targetBotId = active.id;
@@ -1068,14 +1053,37 @@ export function ShellPage() {
                     {savingRoutine ? "Saving…" : "Save"}
                   </button>
                   {editingRoutine?.botId === active.id ? (
-                    <button
-                      type="button"
-                      disabled={savingRoutine}
-                      onClick={() => setDeleteRoutineTarget(editingRoutine)}
-                      className="rounded-[11px] px-4 py-2 text-[14px] text-[#FF5364]"
-                    >
-                      Delete routine
-                    </button>
+                    <>
+                      <button
+                        type="button"
+                        disabled={savingRoutine || runningRoutine}
+                        onClick={async () => {
+                          if (routineRunPending.current) return;
+                          const targetBotId = active.id;
+                          const targetRoutine = editingRoutine;
+                          routineRunPending.current = true;
+                          setRunningRoutine(true);
+                          try {
+                            await rpc.routines.testRun({ routineId: targetRoutine.id });
+                            await refreshThread(targetBotId);
+                          } finally {
+                            routineRunPending.current = false;
+                            setRunningRoutine(false);
+                          }
+                        }}
+                        className="rounded-[11px] border border-[#26262A] px-4 py-2 text-[14px] text-[#ECECEE] disabled:opacity-40"
+                      >
+                        {runningRoutine ? "Running…" : "Run now"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={savingRoutine || runningRoutine}
+                        onClick={() => setDeleteRoutineTarget(editingRoutine)}
+                        className="rounded-[11px] px-4 py-2 text-[14px] text-[#FF5364] disabled:opacity-40"
+                      >
+                        Delete routine
+                      </button>
+                    </>
                   ) : null}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- remove the ambiguous global Run now action from the routines list
- expose Run now only while editing an existing routine
- disable routine mutations while a manual run request is being queued
- update the Playwright journey to cover the new placement and empty state

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm test` (366 passed, 41 skipped)
- `pnpm test:e2e -- --spec=e2e/routine-execution.spec.ts` (1 passed)