### PR TITLE
Publish safe screenshots for pull requests

### DIFF
--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -43,6 +43,20 @@ jobs:
           path: .
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
+      - name: Read Playwright job result
+        id: playwright
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          result="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.name == "Web E2E / Web E2E") | .conclusion] | unique | if length == 1 then .[0] else error("expected exactly one Playwright job") end')"
+          case "$result" in
+            success|failure) ;;
+            *) echo "Unexpected Playwright job conclusion: $result" >&2; exit 1 ;;
+          esac
+          echo "result=$result" >> "$GITHUB_OUTPUT"
       - name: Publish trusted Playwright screenshot gallery
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
@@ -52,7 +66,7 @@ jobs:
           S3_BUCKET: ${{ vars.S3_BUCKET }}
           S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}
           PLAYWRIGHT_PUBLIC_BASE_URL: ${{ vars.PLAYWRIGHT_PUBLIC_BASE_URL }}
-          PLAYWRIGHT_RESULT: ${{ github.event.workflow_run.conclusion }}
+          PLAYWRIGHT_RESULT: ${{ steps.playwright.outputs.result }}
           PLAYWRIGHT_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           PLAYWRIGHT_RUN_ID: ${{ github.event.workflow_run.id }}
           PLAYWRIGHT_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}

--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -54,6 +54,7 @@ jobs:
             --jq '[.jobs[] | select(.name == "Web E2E / Web E2E") | .conclusion] | unique | if length == 1 then .[0] else error("expected exactly one Playwright job") end')"
           case "$result" in
             success|failure) ;;
+            timed_out) result="failure" ;;
             *) echo "Unexpected Playwright job conclusion: $result" >&2; exit 1 ;;
           esac
           echo "result=$result" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -17,7 +17,8 @@ jobs:
   publish:
     if: >-
       (github.event.workflow_run.conclusion == 'success' ||
-       github.event.workflow_run.conclusion == 'failure') &&
+       github.event.workflow_run.conclusion == 'failure' ||
+       github.event.workflow_run.conclusion == 'timed_out') &&
       (github.event.workflow_run.event == 'pull_request' ||
        (github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_branch == 'main'))

--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
+  issues: write
 
 concurrency:
   group: playwright-publication
@@ -106,3 +107,34 @@ jobs:
           PLAYWRIGHT_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
           PLAYWRIGHT_PUBLISH_REPORT: ${{ github.event.workflow_run.event == 'push' }}
         run: bash scripts/publish-playwright-report.sh
+      - name: Link screenshot gallery from pull request
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLAYWRIGHT_PUBLIC_BASE_URL: ${{ vars.PLAYWRIGHT_PUBLIC_BASE_URL }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        shell: bash
+        run: |
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "PR_NUMBER must be a positive integer." >&2
+            exit 1
+          fi
+          public_base_url="${PLAYWRIGHT_PUBLIC_BASE_URL%/}"
+          gallery_url="$public_base_url/runs/$RUN_ID-$RUN_ATTEMPT/screenshots/index.html"
+          marker="<!-- rakazo-playwright-screenshots -->"
+          body="$(printf '%s\n### Playwright screenshots\n[Open screenshot gallery](%s) · [Dashboard](%s/index.html) · [CI run](%s)\n\nUpdated for commit `%s`.' \
+            "$marker" "$gallery_url" "$public_base_url" "$RUN_URL" "${SHA:0:7}")"
+          comment_id="$(gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" | \
+            jq -r --arg marker "$marker" \
+              '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains($marker)))] | last | .id // empty')"
+          payload="$(jq -n --arg body "$body" '{body: $body}')"
+          if [[ -n "$comment_id" ]]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" --input - <<<"$payload"
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --input - <<<"$payload"
+          fi

--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -9,18 +9,27 @@ permissions:
   actions: read
   contents: read
 
+concurrency:
+  group: playwright-publication
+  cancel-in-progress: false
+
 jobs:
   publish:
     if: >-
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main'
+      (github.event.workflow_run.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'failure') &&
+      (github.event.workflow_run.event == 'pull_request' ||
+       (github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    concurrency:
-      group: playwright-publication
-      cancel-in-progress: false
     steps:
+      # workflow_run has repository secrets. Always use trusted default-branch code here;
+      # never check out or execute the contributor's pull-request revision.
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -34,13 +43,7 @@ jobs:
           path: .
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-      - name: Read Playwright result
-        id: playwright
-        shell: bash
-        run: |
-          read -r result < test-report/e2e/outcome.txt
-          echo "result=$result" >> "$GITHUB_OUTPUT"
-      - name: Publish Playwright visual report
+      - name: Publish trusted Playwright screenshot gallery
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
@@ -49,7 +52,7 @@ jobs:
           S3_BUCKET: ${{ vars.S3_BUCKET }}
           S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}
           PLAYWRIGHT_PUBLIC_BASE_URL: ${{ vars.PLAYWRIGHT_PUBLIC_BASE_URL }}
-          PLAYWRIGHT_RESULT: ${{ steps.playwright.outputs.result }}
+          PLAYWRIGHT_RESULT: ${{ github.event.workflow_run.conclusion }}
           PLAYWRIGHT_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           PLAYWRIGHT_RUN_ID: ${{ github.event.workflow_run.id }}
           PLAYWRIGHT_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
@@ -57,4 +60,7 @@ jobs:
           PLAYWRIGHT_SHA: ${{ github.event.workflow_run.head_sha }}
           PLAYWRIGHT_EVENT: ${{ github.event.workflow_run.event }}
           PLAYWRIGHT_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PLAYWRIGHT_PR_NUMBER: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].number || '' }}
+          PLAYWRIGHT_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+          PLAYWRIGHT_PUBLISH_REPORT: ${{ github.event.workflow_run.event == 'push' }}
         run: bash scripts/publish-playwright-report.sh

--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -37,13 +37,6 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Download Playwright artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: playwright-artifacts-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
-          path: .
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
       - name: Read Playwright job result
         id: playwright
         env:
@@ -55,10 +48,43 @@ jobs:
             --jq '[.jobs[] | select(.name == "Web E2E / Web E2E") | .conclusion] | unique | if length == 1 then .[0] else error("expected exactly one Playwright job") end')"
           case "$result" in
             success|failure) ;;
-            timed_out) result="failure" ;;
+            timed_out) ;;
             *) echo "Unexpected Playwright job conclusion: $result" >&2; exit 1 ;;
           esac
+          echo "job_result=$result" >> "$GITHUB_OUTPUT"
+          if [[ "$result" == "timed_out" ]]; then result="failure"; fi
           echo "result=$result" >> "$GITHUB_OUTPUT"
+      - name: Check for Playwright artifact
+        id: artifact
+        env:
+          ARTIFACT_NAME: playwright-artifacts-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLAYWRIGHT_JOB_RESULT: ${{ steps.playwright.outputs.job_result }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          artifacts="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts?name=${ARTIFACT_NAME}")"
+          count="$(jq --arg name "$ARTIFACT_NAME" \
+            '[.artifacts[] | select(.name == $name and .expired == false)] | length' \
+            <<<"$artifacts")"
+          if [[ "$count" == "1" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$count" == "0" && "$PLAYWRIGHT_JOB_RESULT" == "timed_out" ]]; then
+            echo "::warning::The timed-out Playwright job ended before it uploaded an artifact. Publishing an empty gallery."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Expected exactly one unexpired Playwright artifact; found $count." >&2
+            exit 1
+          fi
+      - name: Download Playwright artifacts
+        if: steps.artifact.outputs.exists == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-artifacts-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
       - name: Publish trusted Playwright screenshot gallery
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -5,58 +5,38 @@
 
 ![Rakazo — AI teammates you actually own](./docs/readme-hero.png)
 
-Open-source Grok Bot alternative. [rakazo.com](https://rakazo.com)
+Rakazo is an open-source platform for running persistent AI teammates. It is available on the web,
+as an Electron desktop app, and through an Expo mobile app. Bring your own model and computer
+provider, or run the complete stack locally.
 
-Web, desktop, and mobile. Bring your own AI and sandbox. The product is still early (beta).
+Rakazo is in beta. Learn more at [rakazo.com](https://rakazo.com).
 
-Each bot has its own thread, memory, routines, and history. Workspace bots share a Team Computer by default; a bot can use a Private computer instead. A bot can also spawn more bots — each a regular peer with its own thread — or run short-lived subagents inside the current turn.
+## Features
 
-Looking for bots to install? Check out [botdirectory.ai](https://botdirectory.ai/).
-
-Have questions, ideas, or want to contribute? [Join the Rakazo community on Discord](https://discord.gg/RWwKa2Sn7h).
+- Persistent bots with their own conversations, memory, routines, and history
+- Shared Team Computers and isolated Private computers
+- Browser, terminal, file, and graphical desktop access
+- Bots that can delegate to peer bots or short-lived subagents
+- Bring-your-own model credentials through Pi
+- Optional app integrations through Composio
+- Docker, E2B, Daytona, and trusted local-computer support
 
 ## Demo
 
 https://github.com/user-attachments/assets/dccdeddb-2134-4a56-8eed-b2e591736b1c
 
-## Stack
+## Quick start
 
-- TypeScript
-- React 19, Vite, Tailwind
-- Electron
-- Expo
-- Hono, oRPC
-- Postgres, Prisma
-- Better Auth
-- Graphile Worker
-- Pi
-- Any sandbox provider (tested with Docker, E2B, and Daytona)
-- Composio
-
-## Requirements
-
-- Node.js 22+
-- pnpm 9
-- Docker Desktop (Postgres plus the graphical bot computer)
-
-## Run locally (web)
-
-Want a coding agent to handle the setup? Copy the [`SETUP_PROMPT.md`](./SETUP_PROMPT.md) prompt into your agent.
-
-From the repo root:
+You need Node.js 22+, pnpm 9, and Docker Desktop.
 
 ```bash
+git clone https://github.com/elie222/rakazo.git
+cd rakazo
 cp .env.example .env
 ```
 
-Edit `.env`:
-
-- Set `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` to long random strings before any network exposure. Placeholder values only work in local `development` / `test` runs.
-- Put your OpenRouter key in `OPENROUTER_API_KEY` (or skip the key and paste one during onboarding).
-- ChatGPT Plus or Pro, GitHub Copilot, or SuperGrok / X Premium: skip the key and sign in on the **Connect a model** screen. Pick **OpenAI Codex**, **GitHub Copilot**, or **xAI**, then sign in with the device code Pi shows. Claude Pro is not in the Rakazo UI yet — Pi's Claude login opens a localhost callback, which does not work from the web app.
-- Optional: `COMPOSIO_API_KEY` if you want Plugins to talk to live apps.
-
-Then:
+Set `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` in `.env` to independent, long random values. You can
+also set `OPENROUTER_API_KEY`, or connect a supported model provider during onboarding.
 
 ```bash
 docker compose --env-file .env -f infra/compose/docker-compose.yml up postgres -d
@@ -67,103 +47,61 @@ pnpm sandbox:build
 pnpm dev
 ```
 
-`pnpm dev` starts the API (`:3100`), Graphile Worker, Vite web app (`:5173`), and sandbox supervisor (`:7091`).
+Open [http://127.0.0.1:5173](http://127.0.0.1:5173), create an account, connect a model, and create
+your first bot.
 
-Open [http://127.0.0.1:5173](http://127.0.0.1:5173). Sign up, pick a model from the Pi catalog (paste an API key, sign in with ChatGPT / Copilot / SuperGrok, or Skip if the deployment key is set), create a bot, send a message. The computer pane is a live Linux desktop. The model can observe and control the screen, use browsers and other graphical applications, run terminal commands, and work with files. You can interact with the same desktop while it runs; taking control makes the viewer editable but does not impose an exclusive agent/user lock. Ask a bot to spawn another bot, or to run a subagent for work that should stay inside this turn.
+For an agent-assisted installation, use [SETUP_PROMPT.md](./SETUP_PROMPT.md). For deployment,
+provider selection, backups, and upgrades, see the [self-hosting guide](./docs/self-host.md).
 
-Confirm the product path:
+## Desktop and mobile
 
-```bash
-curl -s http://127.0.0.1:3100/health
-```
+The Electron and Expo apps are clients of the same Rakazo API used by the web app.
 
-You want `"runtime":"pi"`, `"sandbox":"docker"`, `"jobs":"graphile"`, and `"realtime":"postgres"`. `"composio":true` only if the Composio key is set.
-
-Product defaults are Pi + Docker + Graphile. `pnpm test` pins the emulators (`AGENT_RUNTIME=scripted`, `SANDBOX_PROVIDER=fake`, `WAKEUP_DRIVER=memory`) so default tests never call live models or Composio.
-
-### Computer and app modes
-
-The app you open and the computer provider are separate choices. Web, Electron, and mobile are clients of the same API. Workspace bots share a Team Computer by default; Private computers are optional. Docker stays the default provider. In the Electron app the deployment owner is asked once whether bots should keep using Docker or run on this Mac as you.
-
-| `SANDBOX_PROVIDER` | Where agent commands run | Best fit | Isolation notes |
-| --- | --- | --- | --- |
-| `docker` (default) | A Docker computer on your machine. The Electron app can switch this to This Mac without changing the env var. | Quick local setup and trusted single-machine self-hosting | Workspace bots share the Team Computer by default; Private computers are optional. The supervisor controls the local Docker daemon, so keep its port private; Rakazo does this by default. |
-| `e2b` | A remote E2B desktop through the E2B SDK | Public or multi-user deployments | Team and Private computers are isolated from the Rakazo application host. Requires `E2B_API_KEY`. Workspace and browser-profile data are checkpointed into Rakazo-owned `DATA_DIR`, so the provider machine is not the durable source of truth. This Mac is not available. |
-| `daytona` | A remote Daytona desktop through the Daytona SDK | Public or multi-user deployments | Team and Private computers are isolated from the Rakazo application host. Requires `DAYTONA_API_KEY`. Workspace and browser-profile data are checkpointed into Rakazo-owned `DATA_DIR`, so the provider machine is not the durable source of truth. This Mac is not available. |
-| `desktop` | Directly on the API/worker host. Working directories under the process user's home folder are allowed. | A trusted single-user local process | Least isolated. Model-initiated shell commands run with the Rakazo process's OS permissions. Do not use it on a public or shared server. The Electron first-run "This Mac" choice uses this provider while leaving `SANDBOX_PROVIDER=docker`. |
-| `fake` | An in-process emulator | Tests only | Does not run a real computer. |
-
-Docker remains the recommended quick start for someone running Rakazo on their own machine. E2B or Daytona is the safer boundary when untrusted users or public traffic share a deployment.
-
-If this Postgres was created with `prisma db push` before checked-in migrations existed, mark the baseline once:
-
-```bash
-pnpm --filter @rakazo/db exec prisma migrate resolve --applied 0001_init
-```
-
-## Run the desktop app
-
-The Electron shell loads the same web UI. Leave `pnpm dev` running, then:
+With the development stack running, launch Electron with:
 
 ```bash
 pnpm --filter @rakazo/desktop dev
 ```
 
-Native red / yellow / green buttons close, minimize, and zoom that window. They do nothing in the browser tab. On first launch the desktop app asks whether bots should keep using Docker or run on this Mac as you. Docker stays the default. macOS will not show a permission prompt for that choice — the consent is Rakazo's.
+Mobile build and release instructions live in [docs/mobile-release.md](./docs/mobile-release.md).
 
-Point Electron at a different origin with `RAKAZO_WEB_URL` (default `http://127.0.0.1:5173`).
+## Development
 
-Packaged installers (optional):
+Rakazo is a TypeScript monorepo built with React, Electron, Expo, Hono, Postgres, Prisma, Graphile
+Worker, and Pi.
+
+```text
+apps/       web, api, worker, desktop, mobile, and public website
+packages/   domain, contracts, persistence, adapters, UI, and test tooling
+infra/      local services and computer images
+docs/       architecture, operations, and release guides
+```
+
+Common checks:
 
 ```bash
-pnpm --filter @rakazo/desktop pack
+pnpm lint
+pnpm check
+pnpm test
+pnpm test:integration
+pnpm test:e2e
 ```
 
-Outputs land in `apps/desktop/out/` (macOS dmg/zip, Windows NSIS, Linux AppImage). Those builds still need a running API and web origin.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development workflow and test matrix.
 
-## Test
+## Documentation
 
-```bash
-pnpm test              # unit, property, and in-process contract tests
-pnpm test:integration  # Postgres journeys, Graphile jobs, LISTEN/NOTIFY
-pnpm test:e2e          # Playwright against the emulated stack
-pnpm test:e2e -- --sandbox=e2b # the same deterministic suite against real E2B
-pnpm test:e2e -- --sandbox=daytona # the same suite against real Daytona
-pnpm test:topology     # local Docker + Graphile worker recovery (needs Docker)
-pnpm test:canary       # live OpenRouter / E2B canaries
-# explicit real vision-model + real E2B desktop acceptance test:
-COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm test:computer
-```
+- [Self-hosting](./docs/self-host.md)
+- [Computer runtime and isolation](./docs/computer-runtime.md)
+- [Mobile releases](./docs/mobile-release.md)
+- [Performance testing](./docs/performance.md)
 
-Pull requests retain the Playwright HTML report, screenshots, traces, and videos as short-lived
-GitHub Actions artifacts. A trusted follow-up workflow also publishes validated PNG screenshots
-from every pull request—without publishing contributor-controlled HTML or exposing repository
-credentials—to the persistent, scan-friendly dashboard at
-<https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/index.html>.
-Successful merges and nightly verification add their full Playwright reports to the same history.
+## Contributing
 
-The Playwright workflow can also be started manually with **Sandbox provider** set to `e2b` or `daytona`.
-Those options require `E2B_API_KEY` or `DAYTONA_API_KEY`, keep the deterministic scripted agent runtime, and destroy
-the provider machines after the run. The default and all automatic runs remain on `fake`.
+Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull
+request. For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) instead of filing a public
+issue.
 
-`pnpm test:topology`, `pnpm test:canary`, and `pnpm test:computer` are for running the product path on your machine. They are not part of pull-request CI. The computer acceptance test also requires `E2B_API_KEY` and `OPENROUTER_API_KEY` (the command reads the root `.env`) and uses a temporary Postgres container. It proves an actual model can observe and click a real browser, then use the sandbox terminal and files.
+Rakazo is licensed under the [Apache License 2.0](./LICENSE).
 
-See [`docs/computer-runtime.md`](./docs/computer-runtime.md) for the agent/runtime boundary, provider switching, and persistence contract.
-
-## Layout
-
-```
-apps/web api worker desktop mobile www
-packages/core contracts db auth memory ui-web adapter-kit adapters testkit
-infra/compose sandboxes
-```
-
-`apps/www` is the public marketing site (`rakazo.com`). It is not the signed-in product.
-
-## Self-host and Cloud
-
-See `docs/self-host.md`. Cloud and self-hosted editions share the same application and contracts. A public Cloud deploy is a VPS (or E2B / Daytona) plus the marketing site.
-
----
-
-[Inbox Zero Inc.](https://www.getinboxzero.com/?utm_source=rakazo&utm_medium=github&utm_campaign=readme)
+Questions and ideas are welcome in the [Rakazo Discord community](https://discord.gg/RWwKa2Sn7h).

--- a/README.md
+++ b/README.md
@@ -5,15 +5,21 @@
 
 ![Rakazo — AI teammates you actually own](./docs/readme-hero.png)
 
-Open-source Grok Bot alternative. [rakazo.com](https://rakazo.com)
+Rakazo is an open-source platform for running persistent AI teammates. It is available on the web,
+as an Electron desktop app, and through an Expo mobile app. Bring your own model and computer
+provider, or run the complete stack locally.
 
-Web, desktop, and mobile. Bring your own AI and sandbox. The product is still early (beta).
+Rakazo is in beta. Learn more at [rakazo.com](https://rakazo.com).
 
-Each bot has its own thread, memory, routines, and history. Workspace bots share a Team Computer by default; a bot can use a Private computer instead. A bot can also spawn more bots — each a regular peer with its own thread — or run short-lived subagents inside the current turn.
+## Features
 
-Looking for bots to install? Check out [botdirectory.ai](https://botdirectory.ai/).
-
-Have questions, ideas, or want to contribute? [Join the Rakazo community on Discord](https://discord.gg/RWwKa2Sn7h).
+- Persistent bots with their own conversations, memory, routines, and history
+- Shared Team Computers and isolated Private computers
+- Browser, terminal, file, and graphical desktop access
+- Bots that can delegate to peer bots or short-lived subagents
+- Bring-your-own model credentials through Pi
+- Optional app integrations through Composio
+- Docker, E2B, Daytona, and trusted local-computer support
 
 ## Demo
 
@@ -22,41 +28,28 @@ https://github.com/user-attachments/assets/dccdeddb-2134-4a56-8eed-b2e591736b1c
 ## Stack
 
 - TypeScript
-- React 19, Vite, Tailwind
-- Electron
-- Expo
-- Hono, oRPC
-- Postgres, Prisma
+- React 19, Vite, and Tailwind CSS
+- Electron and Expo
+- Hono and oRPC
+- PostgreSQL and Prisma
 - Better Auth
 - Graphile Worker
 - Pi
-- Any sandbox provider (tested with Docker, E2B, and Daytona)
+- Docker, E2B, and Daytona
 - Composio
 
-## Requirements
+## Quick start
 
-- Node.js 22+
-- pnpm 9
-- Docker Desktop (Postgres plus the graphical bot computer)
-
-## Run locally (web)
-
-Want a coding agent to handle the setup? Copy the [`SETUP_PROMPT.md`](./SETUP_PROMPT.md) prompt into your agent.
-
-From the repo root:
+You need Node.js 22+, pnpm 9, and Docker Desktop.
 
 ```bash
+git clone https://github.com/elie222/rakazo.git
+cd rakazo
 cp .env.example .env
 ```
 
-Edit `.env`:
-
-- Set `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` to long random strings before any network exposure. Placeholder values only work in local `development` / `test` runs.
-- Put your OpenRouter key in `OPENROUTER_API_KEY` (or skip the key and paste one during onboarding).
-- ChatGPT Plus or Pro, GitHub Copilot, or SuperGrok / X Premium: skip the key and sign in on the **Connect a model** screen. Pick **OpenAI Codex**, **GitHub Copilot**, or **xAI**, then sign in with the device code Pi shows. Claude Pro is not in the Rakazo UI yet — Pi's Claude login opens a localhost callback, which does not work from the web app.
-- Optional: `COMPOSIO_API_KEY` if you want Plugins to talk to live apps.
-
-Then:
+Set `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` in `.env` to independent, long random values. You can
+also set `OPENROUTER_API_KEY`, or connect a supported model provider during onboarding.
 
 ```bash
 docker compose --env-file .env -f infra/compose/docker-compose.yml up postgres -d
@@ -67,96 +60,61 @@ pnpm sandbox:build
 pnpm dev
 ```
 
-`pnpm dev` starts the API (`:3100`), Graphile Worker, Vite web app (`:5173`), and sandbox supervisor (`:7091`).
+Open [http://127.0.0.1:5173](http://127.0.0.1:5173), create an account, connect a model, and create
+your first bot.
 
-Open [http://127.0.0.1:5173](http://127.0.0.1:5173). Sign up, pick a model from the Pi catalog (paste an API key, sign in with ChatGPT / Copilot / SuperGrok, or Skip if the deployment key is set), create a bot, send a message. The computer pane is a live Linux desktop. The model can observe and control the screen, use browsers and other graphical applications, run terminal commands, and work with files. You can interact with the same desktop while it runs; taking control makes the viewer editable but does not impose an exclusive agent/user lock. Ask a bot to spawn another bot, or to run a subagent for work that should stay inside this turn.
+For an agent-assisted installation, use [SETUP_PROMPT.md](./SETUP_PROMPT.md). For deployment,
+provider selection, backups, and upgrades, see the [self-hosting guide](./docs/self-host.md).
 
-Confirm the product path:
+## Desktop and mobile
 
-```bash
-curl -s http://127.0.0.1:3100/health
-```
+The Electron and Expo apps are clients of the same Rakazo API used by the web app.
 
-You want `"runtime":"pi"`, `"sandbox":"docker"`, `"jobs":"graphile"`, and `"realtime":"postgres"`. `"composio":true` only if the Composio key is set.
-
-Product defaults are Pi + Docker + Graphile. `pnpm test` pins the emulators (`AGENT_RUNTIME=scripted`, `SANDBOX_PROVIDER=fake`, `WAKEUP_DRIVER=memory`) so default tests never call live models or Composio.
-
-### Computer and app modes
-
-The app you open and the computer provider are separate choices. Web, Electron, and mobile are clients of the same API. Workspace bots share a Team Computer by default; Private computers are optional. Docker stays the default provider. In the Electron app the deployment owner is asked once whether bots should keep using Docker or run on this Mac as you.
-
-| `SANDBOX_PROVIDER` | Where agent commands run | Best fit | Isolation notes |
-| --- | --- | --- | --- |
-| `docker` (default) | A Docker computer on your machine. The Electron app can switch this to This Mac without changing the env var. | Quick local setup and trusted single-machine self-hosting | Workspace bots share the Team Computer by default; Private computers are optional. The supervisor controls the local Docker daemon, so keep its port private; Rakazo does this by default. |
-| `e2b` | A remote E2B desktop through the E2B SDK | Public or multi-user deployments | Team and Private computers are isolated from the Rakazo application host. Requires `E2B_API_KEY`. Workspace and browser-profile data are checkpointed into Rakazo-owned `DATA_DIR`, so the provider machine is not the durable source of truth. This Mac is not available. |
-| `daytona` | A remote Daytona desktop through the Daytona SDK | Public or multi-user deployments | Team and Private computers are isolated from the Rakazo application host. Requires `DAYTONA_API_KEY`. Workspace and browser-profile data are checkpointed into Rakazo-owned `DATA_DIR`, so the provider machine is not the durable source of truth. This Mac is not available. |
-| `desktop` | Directly on the API/worker host. Working directories under the process user's home folder are allowed. | A trusted single-user local process | Least isolated. Model-initiated shell commands run with the Rakazo process's OS permissions. Do not use it on a public or shared server. The Electron first-run "This Mac" choice uses this provider while leaving `SANDBOX_PROVIDER=docker`. |
-| `fake` | An in-process emulator | Tests only | Does not run a real computer. |
-
-Docker remains the recommended quick start for someone running Rakazo on their own machine. E2B or Daytona is the safer boundary when untrusted users or public traffic share a deployment.
-
-If this Postgres was created with `prisma db push` before checked-in migrations existed, mark the baseline once:
-
-```bash
-pnpm --filter @rakazo/db exec prisma migrate resolve --applied 0001_init
-```
-
-## Run the desktop app
-
-The Electron shell loads the same web UI. Leave `pnpm dev` running, then:
+With the development stack running, launch Electron with:
 
 ```bash
 pnpm --filter @rakazo/desktop dev
 ```
 
-Native red / yellow / green buttons close, minimize, and zoom that window. They do nothing in the browser tab. On first launch the desktop app asks whether bots should keep using Docker or run on this Mac as you. Docker stays the default. macOS will not show a permission prompt for that choice — the consent is Rakazo's.
+Mobile build and release instructions live in [docs/mobile-release.md](./docs/mobile-release.md).
 
-Point Electron at a different origin with `RAKAZO_WEB_URL` (default `http://127.0.0.1:5173`).
+## Development
 
-Packaged installers (optional):
+Rakazo is a TypeScript monorepo built with React, Electron, Expo, Hono, Postgres, Prisma, Graphile
+Worker, and Pi.
+
+```text
+apps/       web, api, worker, desktop, mobile, and public website
+packages/   domain, contracts, persistence, adapters, UI, and test tooling
+infra/      local services and computer images
+docs/       architecture, operations, and release guides
+```
+
+Common checks:
 
 ```bash
-pnpm --filter @rakazo/desktop pack
+pnpm lint
+pnpm check
+pnpm test
+pnpm test:integration
+pnpm test:e2e
 ```
 
-Outputs land in `apps/desktop/out/` (macOS dmg/zip, Windows NSIS, Linux AppImage). Those builds still need a running API and web origin.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development workflow and test matrix.
 
-## Test
+## Documentation
 
-```bash
-pnpm test              # unit, property, and in-process contract tests
-pnpm test:integration  # Postgres journeys, Graphile jobs, LISTEN/NOTIFY
-pnpm test:e2e          # Playwright against the emulated stack
-pnpm test:e2e -- --sandbox=e2b # the same deterministic suite against real E2B
-pnpm test:e2e -- --sandbox=daytona # the same suite against real Daytona
-pnpm test:topology     # local Docker + Graphile worker recovery (needs Docker)
-pnpm test:canary       # live OpenRouter / E2B canaries
-# explicit real vision-model + real E2B desktop acceptance test:
-COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm test:computer
-```
+- [Self-hosting](./docs/self-host.md)
+- [Computer runtime and isolation](./docs/computer-runtime.md)
+- [Mobile releases](./docs/mobile-release.md)
+- [Performance testing](./docs/performance.md)
 
-The Playwright workflow can also be started manually with **Sandbox provider** set to `e2b` or `daytona`.
-Those options require `E2B_API_KEY` or `DAYTONA_API_KEY`, keep the deterministic scripted agent runtime, and destroy
-the provider machines after the run. The default and all automatic runs remain on `fake`.
+## Contributing
 
-`pnpm test:topology`, `pnpm test:canary`, and `pnpm test:computer` are for running the product path on your machine. They are not part of pull-request CI. The computer acceptance test also requires `E2B_API_KEY` and `OPENROUTER_API_KEY` (the command reads the root `.env`) and uses a temporary Postgres container. It proves an actual model can observe and click a real browser, then use the sandbox terminal and files.
+Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull
+request. For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) instead of filing a public
+issue.
 
-See [`docs/computer-runtime.md`](./docs/computer-runtime.md) for the agent/runtime boundary, provider switching, and persistence contract.
+Rakazo is licensed under the [Apache License 2.0](./LICENSE).
 
-## Layout
-
-```
-apps/web api worker desktop mobile www
-packages/core contracts db auth memory ui-web adapter-kit adapters testkit
-infra/compose sandboxes
-```
-
-`apps/www` is the public marketing site (`rakazo.com`). It is not the signed-in product.
-
-## Self-host and Cloud
-
-See `docs/self-host.md`. Cloud and self-hosted editions share the same application and contracts. A public Cloud deploy is a VPS (or E2B / Daytona) plus the marketing site.
-
----
-
-[Inbox Zero Inc.](https://www.getinboxzero.com/?utm_source=rakazo&utm_medium=github&utm_campaign=readme)
+Questions and ideas are welcome in the [Rakazo Discord community](https://discord.gg/RWwKa2Sn7h).

--- a/README.md
+++ b/README.md
@@ -5,38 +5,58 @@
 
 ![Rakazo — AI teammates you actually own](./docs/readme-hero.png)
 
-Rakazo is an open-source platform for running persistent AI teammates. It is available on the web,
-as an Electron desktop app, and through an Expo mobile app. Bring your own model and computer
-provider, or run the complete stack locally.
+Open-source Grok Bot alternative. [rakazo.com](https://rakazo.com)
 
-Rakazo is in beta. Learn more at [rakazo.com](https://rakazo.com).
+Web, desktop, and mobile. Bring your own AI and sandbox. The product is still early (beta).
 
-## Features
+Each bot has its own thread, memory, routines, and history. Workspace bots share a Team Computer by default; a bot can use a Private computer instead. A bot can also spawn more bots — each a regular peer with its own thread — or run short-lived subagents inside the current turn.
 
-- Persistent bots with their own conversations, memory, routines, and history
-- Shared Team Computers and isolated Private computers
-- Browser, terminal, file, and graphical desktop access
-- Bots that can delegate to peer bots or short-lived subagents
-- Bring-your-own model credentials through Pi
-- Optional app integrations through Composio
-- Docker, E2B, Daytona, and trusted local-computer support
+Looking for bots to install? Check out [botdirectory.ai](https://botdirectory.ai/).
+
+Have questions, ideas, or want to contribute? [Join the Rakazo community on Discord](https://discord.gg/RWwKa2Sn7h).
 
 ## Demo
 
 https://github.com/user-attachments/assets/dccdeddb-2134-4a56-8eed-b2e591736b1c
 
-## Quick start
+## Stack
 
-You need Node.js 22+, pnpm 9, and Docker Desktop.
+- TypeScript
+- React 19, Vite, Tailwind
+- Electron
+- Expo
+- Hono, oRPC
+- Postgres, Prisma
+- Better Auth
+- Graphile Worker
+- Pi
+- Any sandbox provider (tested with Docker, E2B, and Daytona)
+- Composio
+
+## Requirements
+
+- Node.js 22+
+- pnpm 9
+- Docker Desktop (Postgres plus the graphical bot computer)
+
+## Run locally (web)
+
+Want a coding agent to handle the setup? Copy the [`SETUP_PROMPT.md`](./SETUP_PROMPT.md) prompt into your agent.
+
+From the repo root:
 
 ```bash
-git clone https://github.com/elie222/rakazo.git
-cd rakazo
 cp .env.example .env
 ```
 
-Set `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` in `.env` to independent, long random values. You can
-also set `OPENROUTER_API_KEY`, or connect a supported model provider during onboarding.
+Edit `.env`:
+
+- Set `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` to long random strings before any network exposure. Placeholder values only work in local `development` / `test` runs.
+- Put your OpenRouter key in `OPENROUTER_API_KEY` (or skip the key and paste one during onboarding).
+- ChatGPT Plus or Pro, GitHub Copilot, or SuperGrok / X Premium: skip the key and sign in on the **Connect a model** screen. Pick **OpenAI Codex**, **GitHub Copilot**, or **xAI**, then sign in with the device code Pi shows. Claude Pro is not in the Rakazo UI yet — Pi's Claude login opens a localhost callback, which does not work from the web app.
+- Optional: `COMPOSIO_API_KEY` if you want Plugins to talk to live apps.
+
+Then:
 
 ```bash
 docker compose --env-file .env -f infra/compose/docker-compose.yml up postgres -d
@@ -47,61 +67,96 @@ pnpm sandbox:build
 pnpm dev
 ```
 
-Open [http://127.0.0.1:5173](http://127.0.0.1:5173), create an account, connect a model, and create
-your first bot.
+`pnpm dev` starts the API (`:3100`), Graphile Worker, Vite web app (`:5173`), and sandbox supervisor (`:7091`).
 
-For an agent-assisted installation, use [SETUP_PROMPT.md](./SETUP_PROMPT.md). For deployment,
-provider selection, backups, and upgrades, see the [self-hosting guide](./docs/self-host.md).
+Open [http://127.0.0.1:5173](http://127.0.0.1:5173). Sign up, pick a model from the Pi catalog (paste an API key, sign in with ChatGPT / Copilot / SuperGrok, or Skip if the deployment key is set), create a bot, send a message. The computer pane is a live Linux desktop. The model can observe and control the screen, use browsers and other graphical applications, run terminal commands, and work with files. You can interact with the same desktop while it runs; taking control makes the viewer editable but does not impose an exclusive agent/user lock. Ask a bot to spawn another bot, or to run a subagent for work that should stay inside this turn.
 
-## Desktop and mobile
+Confirm the product path:
 
-The Electron and Expo apps are clients of the same Rakazo API used by the web app.
+```bash
+curl -s http://127.0.0.1:3100/health
+```
 
-With the development stack running, launch Electron with:
+You want `"runtime":"pi"`, `"sandbox":"docker"`, `"jobs":"graphile"`, and `"realtime":"postgres"`. `"composio":true` only if the Composio key is set.
+
+Product defaults are Pi + Docker + Graphile. `pnpm test` pins the emulators (`AGENT_RUNTIME=scripted`, `SANDBOX_PROVIDER=fake`, `WAKEUP_DRIVER=memory`) so default tests never call live models or Composio.
+
+### Computer and app modes
+
+The app you open and the computer provider are separate choices. Web, Electron, and mobile are clients of the same API. Workspace bots share a Team Computer by default; Private computers are optional. Docker stays the default provider. In the Electron app the deployment owner is asked once whether bots should keep using Docker or run on this Mac as you.
+
+| `SANDBOX_PROVIDER` | Where agent commands run | Best fit | Isolation notes |
+| --- | --- | --- | --- |
+| `docker` (default) | A Docker computer on your machine. The Electron app can switch this to This Mac without changing the env var. | Quick local setup and trusted single-machine self-hosting | Workspace bots share the Team Computer by default; Private computers are optional. The supervisor controls the local Docker daemon, so keep its port private; Rakazo does this by default. |
+| `e2b` | A remote E2B desktop through the E2B SDK | Public or multi-user deployments | Team and Private computers are isolated from the Rakazo application host. Requires `E2B_API_KEY`. Workspace and browser-profile data are checkpointed into Rakazo-owned `DATA_DIR`, so the provider machine is not the durable source of truth. This Mac is not available. |
+| `daytona` | A remote Daytona desktop through the Daytona SDK | Public or multi-user deployments | Team and Private computers are isolated from the Rakazo application host. Requires `DAYTONA_API_KEY`. Workspace and browser-profile data are checkpointed into Rakazo-owned `DATA_DIR`, so the provider machine is not the durable source of truth. This Mac is not available. |
+| `desktop` | Directly on the API/worker host. Working directories under the process user's home folder are allowed. | A trusted single-user local process | Least isolated. Model-initiated shell commands run with the Rakazo process's OS permissions. Do not use it on a public or shared server. The Electron first-run "This Mac" choice uses this provider while leaving `SANDBOX_PROVIDER=docker`. |
+| `fake` | An in-process emulator | Tests only | Does not run a real computer. |
+
+Docker remains the recommended quick start for someone running Rakazo on their own machine. E2B or Daytona is the safer boundary when untrusted users or public traffic share a deployment.
+
+If this Postgres was created with `prisma db push` before checked-in migrations existed, mark the baseline once:
+
+```bash
+pnpm --filter @rakazo/db exec prisma migrate resolve --applied 0001_init
+```
+
+## Run the desktop app
+
+The Electron shell loads the same web UI. Leave `pnpm dev` running, then:
 
 ```bash
 pnpm --filter @rakazo/desktop dev
 ```
 
-Mobile build and release instructions live in [docs/mobile-release.md](./docs/mobile-release.md).
+Native red / yellow / green buttons close, minimize, and zoom that window. They do nothing in the browser tab. On first launch the desktop app asks whether bots should keep using Docker or run on this Mac as you. Docker stays the default. macOS will not show a permission prompt for that choice — the consent is Rakazo's.
 
-## Development
+Point Electron at a different origin with `RAKAZO_WEB_URL` (default `http://127.0.0.1:5173`).
 
-Rakazo is a TypeScript monorepo built with React, Electron, Expo, Hono, Postgres, Prisma, Graphile
-Worker, and Pi.
-
-```text
-apps/       web, api, worker, desktop, mobile, and public website
-packages/   domain, contracts, persistence, adapters, UI, and test tooling
-infra/      local services and computer images
-docs/       architecture, operations, and release guides
-```
-
-Common checks:
+Packaged installers (optional):
 
 ```bash
-pnpm lint
-pnpm check
-pnpm test
-pnpm test:integration
-pnpm test:e2e
+pnpm --filter @rakazo/desktop pack
 ```
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development workflow and test matrix.
+Outputs land in `apps/desktop/out/` (macOS dmg/zip, Windows NSIS, Linux AppImage). Those builds still need a running API and web origin.
 
-## Documentation
+## Test
 
-- [Self-hosting](./docs/self-host.md)
-- [Computer runtime and isolation](./docs/computer-runtime.md)
-- [Mobile releases](./docs/mobile-release.md)
-- [Performance testing](./docs/performance.md)
+```bash
+pnpm test              # unit, property, and in-process contract tests
+pnpm test:integration  # Postgres journeys, Graphile jobs, LISTEN/NOTIFY
+pnpm test:e2e          # Playwright against the emulated stack
+pnpm test:e2e -- --sandbox=e2b # the same deterministic suite against real E2B
+pnpm test:e2e -- --sandbox=daytona # the same suite against real Daytona
+pnpm test:topology     # local Docker + Graphile worker recovery (needs Docker)
+pnpm test:canary       # live OpenRouter / E2B canaries
+# explicit real vision-model + real E2B desktop acceptance test:
+COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm test:computer
+```
 
-## Contributing
+The Playwright workflow can also be started manually with **Sandbox provider** set to `e2b` or `daytona`.
+Those options require `E2B_API_KEY` or `DAYTONA_API_KEY`, keep the deterministic scripted agent runtime, and destroy
+the provider machines after the run. The default and all automatic runs remain on `fake`.
 
-Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull
-request. For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) instead of filing a public
-issue.
+`pnpm test:topology`, `pnpm test:canary`, and `pnpm test:computer` are for running the product path on your machine. They are not part of pull-request CI. The computer acceptance test also requires `E2B_API_KEY` and `OPENROUTER_API_KEY` (the command reads the root `.env`) and uses a temporary Postgres container. It proves an actual model can observe and click a real browser, then use the sandbox terminal and files.
 
-Rakazo is licensed under the [Apache License 2.0](./LICENSE).
+See [`docs/computer-runtime.md`](./docs/computer-runtime.md) for the agent/runtime boundary, provider switching, and persistence contract.
 
-Questions and ideas are welcome in the [Rakazo Discord community](https://discord.gg/RWwKa2Sn7h).
+## Layout
+
+```
+apps/web api worker desktop mobile www
+packages/core contracts db auth memory ui-web adapter-kit adapters testkit
+infra/compose sandboxes
+```
+
+`apps/www` is the public marketing site (`rakazo.com`). It is not the signed-in product.
+
+## Self-host and Cloud
+
+See `docs/self-host.md`. Cloud and self-hosted editions share the same application and contracts. A public Cloud deploy is a VPS (or E2B / Daytona) plus the marketing site.
+
+---
+
+[Inbox Zero Inc.](https://www.getinboxzero.com/?utm_source=rakazo&utm_medium=github&utm_campaign=readme)

--- a/README.md
+++ b/README.md
@@ -136,9 +136,11 @@ COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm test:computer
 ```
 
 Pull requests retain the Playwright HTML report, screenshots, traces, and videos as short-lived
-GitHub Actions artifacts. Successful merges and the nightly verification publish a persistent run
-history plus a scan-friendly screenshot gallery at
+GitHub Actions artifacts. A trusted follow-up workflow also publishes validated PNG screenshots
+from every pull request—without publishing contributor-controlled HTML or exposing repository
+credentials—to the persistent, scan-friendly dashboard at
 <https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/index.html>.
+Successful merges and nightly verification add their full Playwright reports to the same history.
 
 The Playwright workflow can also be started manually with **Sandbox provider** set to `e2b` or `daytona`.
 Those options require `E2B_API_KEY` or `DAYTONA_API_KEY`, keep the deterministic scripted agent runtime, and destroy

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -11,16 +11,18 @@
     "test": "vitest run --root ../.. packages/testkit/src"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.1",
     "@rakazo/adapter-kit": "workspace:*",
     "@rakazo/adapters": "workspace:*",
     "@rakazo/contracts": "workspace:*",
     "@rakazo/core": "workspace:*",
     "@rakazo/db": "workspace:*",
-    "@hono/node-server": "^1.19.1",
-    "@testcontainers/postgresql": "^11.5.1"
+    "@testcontainers/postgresql": "^11.5.1",
+    "pngjs": "7.0.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
+    "@types/pngjs": "6.0.5",
     "typescript": "^5.9.2",
     "vitest": "^4.1.10"
   }

--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -1,5 +1,5 @@
 import type { Dirent } from "node:fs";
-import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, open, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   type PlaywrightScreenshot,
@@ -9,6 +9,12 @@ import {
 } from "../playwright-report-dashboard.js";
 
 const [historyPath, dashboardPath, testResultsPath, galleryPath] = process.argv.slice(2);
+const MAX_SCREENSHOT_COUNT = 100;
+const MAX_SCREENSHOT_BYTES = 15 * 1024 * 1024;
+const MAX_SCREENSHOT_DIMENSION = 10_000;
+const MAX_SCREENSHOT_PIXELS = 50_000_000;
+const MAX_ARTIFACT_ENTRIES = 2_000;
+const MAX_ARTIFACT_DEPTH = 12;
 
 if (!historyPath || !dashboardPath || !testResultsPath || !galleryPath) {
   throw new Error(
@@ -19,11 +25,13 @@ if (!historyPath || !dashboardPath || !testResultsPath || !galleryPath) {
 const screenshots = await collectScreenshots(testResultsPath, galleryPath);
 const createdAt = new Date().toISOString();
 const dashboardUrl = getRequiredEnvironmentVariable("PLAYWRIGHT_DASHBOARD_URL");
-const reportUrl = getRequiredEnvironmentVariable("PLAYWRIGHT_REPORT_URL");
+const reportUrl = getOptionalHttpsEnvironmentVariable("PLAYWRIGHT_REPORT_URL");
 const screenshotsUrl = getRequiredEnvironmentVariable("PLAYWRIGHT_SCREENSHOTS_URL");
 const result = getRequiredEnvironmentVariable("PLAYWRIGHT_RESULT");
 const runUrl = getRequiredEnvironmentVariable("PLAYWRIGHT_RUN_URL");
 const sha = getRequiredEnvironmentVariable("PLAYWRIGHT_SHA");
+const pullRequestNumber = getOptionalNumber("PLAYWRIGHT_PR_NUMBER");
+const pullRequestUrl = getOptionalHttpsEnvironmentVariable("PLAYWRIGHT_PR_URL");
 const existingHistory = await readHistory(historyPath);
 const history = updatePlaywrightHistory(existingHistory, {
   attempt: getRequiredNumber("PLAYWRIGHT_RUN_ATTEMPT"),
@@ -31,6 +39,8 @@ const history = updatePlaywrightHistory(existingHistory, {
   createdAt,
   event: getRequiredEnvironmentVariable("PLAYWRIGHT_EVENT"),
   id: getRequiredEnvironmentVariable("PLAYWRIGHT_RUN_ID"),
+  pullRequestNumber,
+  pullRequestUrl,
   reportUrl,
   result,
   runNumber: getRequiredNumber("PLAYWRIGHT_RUN_NUMBER"),
@@ -50,6 +60,8 @@ await writeFile(
   renderScreenshotGallery({
     createdAt,
     dashboardUrl,
+    pullRequestNumber,
+    pullRequestUrl,
     reportUrl,
     result,
     runUrl,
@@ -69,11 +81,17 @@ async function collectScreenshots(
   const files = (await findPngFiles(resultsPath)).sort((left, right) =>
     path.basename(left).localeCompare(path.basename(right)),
   );
+  if (files.length > MAX_SCREENSHOT_COUNT) {
+    throw new Error(
+      `Playwright artifact contains ${files.length} screenshots; maximum is ${MAX_SCREENSHOT_COUNT}`,
+    );
+  }
   const imagePath = path.join(outputPath, "images");
   await mkdir(imagePath, { recursive: true });
 
   return Promise.all(
     files.map(async (file, index) => {
+      await validatePngScreenshot(file);
       const source = path.relative(resultsPath, file);
       const fileName = `${String(index + 1).padStart(3, "0")}-${sanitizeFileName(path.basename(file))}`;
       await copyFile(file, path.join(imagePath, fileName));
@@ -86,7 +104,47 @@ async function collectScreenshots(
   );
 }
 
-async function findPngFiles(directory: string): Promise<string[]> {
+async function validatePngScreenshot(filePath: string): Promise<void> {
+  const info = await stat(filePath);
+  if (!info.isFile() || info.size <= 0 || info.size > MAX_SCREENSHOT_BYTES) {
+    throw new Error(`Invalid screenshot size for ${filePath}`);
+  }
+
+  const header = Buffer.alloc(24);
+  const handle = await open(filePath, "r");
+  try {
+    const { bytesRead } = await handle.read(header, 0, header.length, 0);
+    if (bytesRead !== header.length) throw new Error(`Truncated PNG screenshot: ${filePath}`);
+  } finally {
+    await handle.close();
+  }
+
+  const pngSignature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  if (!header.subarray(0, 8).equals(pngSignature) || header.toString("ascii", 12, 16) !== "IHDR") {
+    throw new Error(`Screenshot is not a PNG image: ${filePath}`);
+  }
+
+  const width = header.readUInt32BE(16);
+  const height = header.readUInt32BE(20);
+  if (
+    width === 0 ||
+    height === 0 ||
+    width > MAX_SCREENSHOT_DIMENSION ||
+    height > MAX_SCREENSHOT_DIMENSION ||
+    width * height > MAX_SCREENSHOT_PIXELS
+  ) {
+    throw new Error(`Invalid PNG dimensions for ${filePath}: ${width}x${height}`);
+  }
+}
+
+async function findPngFiles(
+  directory: string,
+  depth = 0,
+  budget = { entries: 0 },
+): Promise<string[]> {
+  if (depth > MAX_ARTIFACT_DEPTH) {
+    throw new Error(`Playwright artifact exceeds maximum directory depth of ${MAX_ARTIFACT_DEPTH}`);
+  }
   let entries: Dirent[];
   try {
     entries = await readdir(directory, { withFileTypes: true });
@@ -94,12 +152,16 @@ async function findPngFiles(directory: string): Promise<string[]> {
     if (isNodeError(error) && error.code === "ENOENT") return [];
     throw error;
   }
+  budget.entries += entries.length;
+  if (budget.entries > MAX_ARTIFACT_ENTRIES) {
+    throw new Error(`Playwright artifact exceeds maximum entry count of ${MAX_ARTIFACT_ENTRIES}`);
+  }
 
   const files = await Promise.all(
     entries.map(async (entry) => {
       const entryPath = path.join(directory, entry.name);
       if (entry.isDirectory() && entry.name === "attachments") return [];
-      if (entry.isDirectory()) return findPngFiles(entryPath);
+      if (entry.isDirectory()) return findPngFiles(entryPath, depth + 1, budget);
       return entry.isFile() && entry.name.toLowerCase().endsWith(".png") ? [entryPath] : [];
     }),
   );
@@ -123,10 +185,28 @@ function getRequiredEnvironmentVariable(name: string): string {
   return value;
 }
 
+function getOptionalHttpsEnvironmentVariable(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  if (!value) return undefined;
+  if (!URL.canParse(value) || new URL(value).protocol !== "https:") {
+    throw new Error(`${name} must use HTTPS`);
+  }
+  return value;
+}
+
 function getRequiredNumber(name: string): number {
   const value = Number(getRequiredEnvironmentVariable(name));
   if (!Number.isFinite(value)) throw new Error(`${name} must be a number`);
   return value;
+}
+
+function getOptionalNumber(name: string): number | undefined {
+  const value = process.env[name]?.trim();
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0)
+    throw new Error(`${name} must be a positive integer`);
+  return parsed;
 }
 
 async function readHistory(filePath: string): Promise<unknown> {

--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -1,5 +1,5 @@
 import type { Dirent } from "node:fs";
-import { copyFile, mkdir, open, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   type PlaywrightScreenshot,
@@ -7,12 +7,10 @@ import {
   renderScreenshotGallery,
   updatePlaywrightHistory,
 } from "../playwright-report-dashboard.js";
+import { MAX_PNG_SCREENSHOT_BYTES, validatePngScreenshot } from "../png-validation.js";
 
 const [historyPath, dashboardPath, testResultsPath, galleryPath] = process.argv.slice(2);
 const MAX_SCREENSHOT_COUNT = 100;
-const MAX_SCREENSHOT_BYTES = 15 * 1024 * 1024;
-const MAX_SCREENSHOT_DIMENSION = 10_000;
-const MAX_SCREENSHOT_PIXELS = 50_000_000;
 const MAX_ARTIFACT_ENTRIES = 2_000;
 const MAX_ARTIFACT_DEPTH = 12;
 
@@ -89,52 +87,24 @@ async function collectScreenshots(
   const imagePath = path.join(outputPath, "images");
   await mkdir(imagePath, { recursive: true });
 
-  return Promise.all(
-    files.map(async (file, index) => {
-      await validatePngScreenshot(file);
-      const source = path.relative(resultsPath, file);
-      const fileName = `${String(index + 1).padStart(3, "0")}-${sanitizeFileName(path.basename(file))}`;
-      await copyFile(file, path.join(imagePath, fileName));
-      return {
-        fileName: `images/${fileName}`,
-        source,
-        title: titleFromFileName(path.basename(file)),
-      };
-    }),
-  );
-}
-
-async function validatePngScreenshot(filePath: string): Promise<void> {
-  const info = await stat(filePath);
-  if (!info.isFile() || info.size <= 0 || info.size > MAX_SCREENSHOT_BYTES) {
-    throw new Error(`Invalid screenshot size for ${filePath}`);
+  const screenshots: PlaywrightScreenshot[] = [];
+  for (const [index, file] of files.entries()) {
+    const info = await stat(file);
+    if (!info.isFile() || info.size <= 0 || info.size > MAX_PNG_SCREENSHOT_BYTES) {
+      throw new Error(`Invalid screenshot size for ${file}`);
+    }
+    const screenshot = await readFile(file);
+    validatePngScreenshot(screenshot, file);
+    const source = path.relative(resultsPath, file);
+    const fileName = `${String(index + 1).padStart(3, "0")}-${sanitizeFileName(path.basename(file))}`;
+    await copyFile(file, path.join(imagePath, fileName));
+    screenshots.push({
+      fileName: `images/${fileName}`,
+      source,
+      title: titleFromFileName(path.basename(file)),
+    });
   }
-
-  const header = Buffer.alloc(24);
-  const handle = await open(filePath, "r");
-  try {
-    const { bytesRead } = await handle.read(header, 0, header.length, 0);
-    if (bytesRead !== header.length) throw new Error(`Truncated PNG screenshot: ${filePath}`);
-  } finally {
-    await handle.close();
-  }
-
-  const pngSignature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
-  if (!header.subarray(0, 8).equals(pngSignature) || header.toString("ascii", 12, 16) !== "IHDR") {
-    throw new Error(`Screenshot is not a PNG image: ${filePath}`);
-  }
-
-  const width = header.readUInt32BE(16);
-  const height = header.readUInt32BE(20);
-  if (
-    width === 0 ||
-    height === 0 ||
-    width > MAX_SCREENSHOT_DIMENSION ||
-    height > MAX_SCREENSHOT_DIMENSION ||
-    width * height > MAX_SCREENSHOT_PIXELS
-  ) {
-    throw new Error(`Invalid PNG dimensions for ${filePath}: ${width}x${height}`);
-  }
+  return screenshots;
 }
 
 async function findPngFiles(

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -61,6 +61,18 @@ describe("updatePlaywrightHistory", () => {
       ),
     ).toEqual([currentRun]);
   });
+
+  it("keeps screenshot-only pull request runs", () => {
+    const pullRequestRun = getRun({
+      branch: "external-contributor-branch",
+      event: "pull_request",
+      pullRequestNumber: 59,
+      pullRequestUrl: "https://github.com/example/repository/pull/59",
+      reportUrl: undefined,
+    });
+
+    expect(updatePlaywrightHistory([], pullRequestRun)).toEqual([pullRequestRun]);
+  });
 });
 
 describe("renderPlaywrightDashboard", () => {
@@ -71,7 +83,7 @@ describe("renderPlaywrightDashboard", () => {
 
     expect(html).not.toContain("</script><script>alert(1)</script>");
     expect(html).toContain("\\u003c/script>\\u003cscript>alert(1)\\u003c/script>");
-    expect(html).toContain("latestReport.href = history[0].reportUrl");
+    expect(html).toContain("latestReport.href = latestWithReport.reportUrl");
     expect(html).toContain("latestScreenshots.href = history[0].screenshotsUrl");
   });
 });
@@ -107,6 +119,22 @@ describe("renderScreenshotGallery", () => {
       .view-options { display: none; }
       .gallery { grid-template-columns: 1fr; }
     }`);
+  });
+
+  it("links a pull request without exposing an untrusted HTML report", () => {
+    const html = renderScreenshotGallery({
+      createdAt: "2026-08-16T10:00:00.000Z",
+      dashboardUrl: "https://example.com/playwright/index.html",
+      pullRequestNumber: 59,
+      pullRequestUrl: "https://github.com/example/repository/pull/59",
+      result: "success",
+      runUrl: "https://github.com/example/repository/actions/runs/200",
+      screenshots: [],
+      sha: "abcdef1234567890",
+    });
+
+    expect(html).toContain('href="https://github.com/example/repository/pull/59">PR #59</a>');
+    expect(html).not.toContain("Full report");
   });
 });
 

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -17,7 +17,9 @@ export type PlaywrightRun = {
   createdAt: string;
   event: string;
   id: string;
-  reportUrl: string;
+  pullRequestNumber?: number;
+  pullRequestUrl?: string;
+  reportUrl?: string;
   result: string;
   runNumber: number;
   runUrl: string;
@@ -136,13 +138,18 @@ export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
     const generatedAt = document.querySelector("#generated-at");
     const latestReport = document.querySelector("#latest-report");
     const latestScreenshots = document.querySelector("#latest-screenshots");
+    const latestWithReport = history.find((run) => run.reportUrl);
 
     if (history.length === 0) {
       empty.hidden = false;
       latestReport.hidden = true;
       latestScreenshots.hidden = true;
     } else {
-      latestReport.href = history[0].reportUrl;
+      if (latestWithReport) {
+        latestReport.href = latestWithReport.reportUrl;
+      } else {
+        latestReport.hidden = true;
+      }
       latestScreenshots.href = history[0].screenshotsUrl;
     }
 
@@ -184,7 +191,9 @@ export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
       commit.className = "mono";
       commit.textContent = run.sha.slice(0, 7);
       const event = document.createElement("td");
-      event.textContent = run.event + " · " + run.branch;
+      event.textContent = run.pullRequestNumber
+        ? "PR #" + run.pullRequestNumber + " · " + run.branch
+        : run.event + " · " + run.branch;
       const screenshotCount = document.createElement("td");
       screenshotCount.textContent = String(run.screenshotCount);
       const published = document.createElement("td");
@@ -195,13 +204,23 @@ export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
       const screenshots = document.createElement("a");
       screenshots.href = run.screenshotsUrl;
       screenshots.textContent = "Screenshots";
-      const report = document.createElement("a");
-      report.href = run.reportUrl;
-      report.textContent = "Report";
       const actions = document.createElement("a");
       actions.href = run.runUrl;
       actions.textContent = "Actions";
-      linkList.append(screenshots, report, actions);
+      linkList.append(screenshots);
+      if (run.reportUrl) {
+        const report = document.createElement("a");
+        report.href = run.reportUrl;
+        report.textContent = "Report";
+        linkList.append(report);
+      }
+      if (run.pullRequestUrl) {
+        const pullRequest = document.createElement("a");
+        pullRequest.href = run.pullRequestUrl;
+        pullRequest.textContent = "PR";
+        linkList.append(pullRequest);
+      }
+      linkList.append(actions);
       links.append(linkList);
 
       row.append(result, runNumber, commit, event, screenshotCount, published, links);
@@ -219,7 +238,9 @@ export function renderPlaywrightDashboard(history: PlaywrightRun[]): string {
 export function renderScreenshotGallery(input: {
   createdAt: string;
   dashboardUrl: string;
-  reportUrl: string;
+  pullRequestNumber?: number;
+  pullRequestUrl?: string;
+  reportUrl?: string;
   result: string;
   runUrl: string;
   screenshots: PlaywrightScreenshot[];
@@ -289,7 +310,8 @@ export function renderScreenshotGallery(input: {
         <p class="subtitle">Scan every captured product state from this Playwright run.</p>
       </div>
       <div class="actions">
-        <a class="button" href="${escapeHtml(input.reportUrl)}">Full report</a>
+        ${input.reportUrl ? `<a class="button" href="${escapeHtml(input.reportUrl)}">Full report</a>` : ""}
+        ${input.pullRequestUrl ? `<a class="button" href="${escapeHtml(input.pullRequestUrl)}">PR #${input.pullRequestNumber}</a>` : ""}
         <a class="button" href="${escapeHtml(input.runUrl)}">GitHub Actions</a>
         <a class="button" href="${escapeHtml(input.dashboardUrl)}">All runs</a>
       </div>
@@ -367,7 +389,12 @@ function isPlaywrightRun(value: unknown): value is PlaywrightRun {
     typeof run.event === "string" &&
     typeof run.id === "string" &&
     /^\d+$/.test(run.id) &&
-    isHttpsUrl(run.reportUrl) &&
+    (run.reportUrl === undefined || isHttpsUrl(run.reportUrl)) &&
+    (run.pullRequestNumber === undefined ||
+      (Number.isInteger(run.pullRequestNumber) && run.pullRequestNumber > 0)) &&
+    (run.pullRequestUrl === undefined || isHttpsUrl(run.pullRequestUrl)) &&
+    ((run.pullRequestNumber === undefined && run.pullRequestUrl === undefined) ||
+      (run.pullRequestNumber !== undefined && run.pullRequestUrl !== undefined)) &&
     typeof run.result === "string" &&
     typeof run.runNumber === "number" &&
     isHttpsUrl(run.runUrl) &&

--- a/packages/testkit/src/png-validation.test.ts
+++ b/packages/testkit/src/png-validation.test.ts
@@ -1,0 +1,33 @@
+import { PNG } from "pngjs";
+import { describe, expect, it } from "vitest";
+import { validatePngScreenshot } from "./png-validation.js";
+
+function validPng() {
+  return PNG.sync.write({
+    width: 1,
+    height: 1,
+    data: Buffer.from([23, 45, 67, 255]),
+  });
+}
+
+describe("validatePngScreenshot", () => {
+  it("accepts a complete decodable PNG", () => {
+    expect(() => validatePngScreenshot(validPng(), "valid.png")).not.toThrow();
+  });
+
+  it("rejects a truncated PNG with a valid signature and header", () => {
+    const truncated = validPng().subarray(0, -12);
+    expect(() => validatePngScreenshot(truncated, "truncated.png")).toThrow(/IEND|Truncated/);
+  });
+
+  it("rejects bytes appended after IEND", () => {
+    const trailing = Buffer.concat([validPng(), Buffer.from("not-an-image")]);
+    expect(() => validatePngScreenshot(trailing, "trailing.png")).toThrow(/end/);
+  });
+
+  it("rejects corrupt image data even when the PNG structure is present", () => {
+    const corrupt = validPng();
+    corrupt[corrupt.length - 13] ^= 0xff;
+    expect(() => validatePngScreenshot(corrupt, "corrupt.png")).toThrow(/Invalid PNG/);
+  });
+});

--- a/packages/testkit/src/png-validation.ts
+++ b/packages/testkit/src/png-validation.ts
@@ -1,0 +1,62 @@
+import { PNG } from "pngjs";
+
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+export const MAX_PNG_SCREENSHOT_BYTES = 15 * 1024 * 1024;
+const MAX_SCREENSHOT_DIMENSION = 10_000;
+const MAX_SCREENSHOT_PIXELS = 50_000_000;
+
+export function validatePngScreenshot(buffer: Buffer, source: string): void {
+  if (buffer.length === 0 || buffer.length > MAX_PNG_SCREENSHOT_BYTES) {
+    throw new Error(`Invalid screenshot size for ${source}`);
+  }
+  if (buffer.length < 24 || !buffer.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    throw new Error(`Screenshot is not a PNG image: ${source}`);
+  }
+
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  if (
+    width === 0 ||
+    height === 0 ||
+    width > MAX_SCREENSHOT_DIMENSION ||
+    height > MAX_SCREENSHOT_DIMENSION ||
+    width * height > MAX_SCREENSHOT_PIXELS
+  ) {
+    throw new Error(`Invalid PNG dimensions for ${source}: ${width}x${height}`);
+  }
+
+  assertCompleteChunkStream(buffer, source);
+  try {
+    const decoded = PNG.sync.read(buffer, { checkCRC: true });
+    if (decoded.width !== width || decoded.height !== height) {
+      throw new Error("decoded dimensions do not match IHDR");
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid PNG screenshot ${source}: ${detail}`);
+  }
+}
+
+function assertCompleteChunkStream(buffer: Buffer, source: string): void {
+  let offset = PNG_SIGNATURE.length;
+  let chunkIndex = 0;
+  while (offset < buffer.length) {
+    if (offset + 12 > buffer.length) throw new Error(`Truncated PNG screenshot: ${source}`);
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.toString("ascii", offset + 4, offset + 8);
+    const chunkEnd = offset + 12 + length;
+    if (chunkEnd > buffer.length) throw new Error(`Truncated PNG screenshot: ${source}`);
+    if (chunkIndex === 0 && (type !== "IHDR" || length !== 13)) {
+      throw new Error(`Invalid PNG header for ${source}`);
+    }
+    if (type === "IEND") {
+      if (length !== 0 || chunkEnd !== buffer.length) {
+        throw new Error(`Invalid PNG end for ${source}`);
+      }
+      return;
+    }
+    offset = chunkEnd;
+    chunkIndex += 1;
+  }
+  throw new Error(`PNG screenshot is missing IEND: ${source}`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,10 +573,16 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^11.5.1
         version: 11.14.0
+      pngjs:
+        specifier: 7.0.0
+        version: 7.0.0
     devDependencies:
       '@playwright/test':
         specifier: ^1.55.0
         version: 1.62.1
+      '@types/pngjs':
+        specifier: 6.0.5
+        version: 6.0.5
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -3640,6 +3646,9 @@ packages:
 
   '@types/pg@8.21.0':
     resolution: {integrity: sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
@@ -6819,6 +6828,10 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -12304,6 +12317,10 @@ snapshots:
       pg-protocol: 1.16.0
       pg-types: 2.2.0
 
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@types/prismjs@1.26.6': {}
 
   '@types/react-dom@19.2.4(@types/react@19.2.18)':
@@ -16175,6 +16192,8 @@ snapshots:
       xmlbuilder: 15.1.1
 
   pngjs@3.4.0: {}
+
+  pngjs@7.0.0: {}
 
   postcss-value-parser@4.2.0: {}
 

--- a/scripts/publish-playwright-report.sh
+++ b/scripts/publish-playwright-report.sh
@@ -17,8 +17,14 @@ set -euo pipefail
 
 report_dir="${PLAYWRIGHT_REPORT_DIR:-playwright-report}"
 test_results_dir="${PLAYWRIGHT_TEST_RESULTS_DIR:-apps/web/test-results}"
+publish_report="${PLAYWRIGHT_PUBLISH_REPORT:-true}"
 
-if [[ ! -f "$report_dir/index.html" ]]; then
+if [[ "$publish_report" != "true" && "$publish_report" != "false" ]]; then
+  echo "PLAYWRIGHT_PUBLISH_REPORT must be true or false." >&2
+  exit 1
+fi
+
+if [[ "$publish_report" == "true" && ! -f "$report_dir/index.html" ]]; then
   echo "::warning::Playwright did not produce an HTML report; keeping the existing public dashboard."
   exit 0
 fi
@@ -48,6 +54,24 @@ bucket_uri="s3://${S3_BUCKET}/playwright"
 public_base_url="${PLAYWRIGHT_PUBLIC_BASE_URL%/}"
 report_url="$public_base_url/runs/$run_key/report/index.html"
 screenshots_url="$public_base_url/runs/$run_key/screenshots/index.html"
+pull_request_url=""
+
+if [[ -n "${PLAYWRIGHT_PR_NUMBER:-}" ]]; then
+  if [[ ! "$PLAYWRIGHT_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+    echo "PLAYWRIGHT_PR_NUMBER must be a positive integer." >&2
+    exit 1
+  fi
+  : "${PLAYWRIGHT_REPOSITORY_URL:?PLAYWRIGHT_REPOSITORY_URL is required for pull request runs}"
+  case "$PLAYWRIGHT_REPOSITORY_URL" in
+    https://*) ;;
+    *) echo "PLAYWRIGHT_REPOSITORY_URL must use HTTPS." >&2; exit 1 ;;
+  esac
+  pull_request_url="${PLAYWRIGHT_REPOSITORY_URL%/}/pull/$PLAYWRIGHT_PR_NUMBER"
+fi
+
+if [[ "$publish_report" == "false" ]]; then
+  report_url=""
+fi
 
 mkdir -p "$dashboard_dir"
 if aws s3 cp \
@@ -66,6 +90,7 @@ fi
 PLAYWRIGHT_REPORT_URL="$report_url" \
 PLAYWRIGHT_SCREENSHOTS_URL="$screenshots_url" \
 PLAYWRIGHT_DASHBOARD_URL="$public_base_url/index.html" \
+PLAYWRIGHT_PR_URL="$pull_request_url" \
   pnpm exec tsx \
     packages/testkit/src/cli/generate-playwright-report-dashboard.ts \
     "$history_path" \
@@ -73,15 +98,25 @@ PLAYWRIGHT_DASHBOARD_URL="$public_base_url/index.html" \
     "$test_results_dir" \
     "$gallery_dir"
 
+if [[ "$publish_report" == "true" ]]; then
+  aws s3 sync \
+    "$report_dir/" \
+    "$bucket_uri/runs/$run_key/report/" \
+    --endpoint-url "$S3_ENDPOINT" \
+    --cache-control "public,max-age=31536000,immutable"
+fi
 aws s3 sync \
-  "$report_dir/" \
-  "$bucket_uri/runs/$run_key/report/" \
+  "$gallery_dir/images/" \
+  "$bucket_uri/runs/$run_key/screenshots/images/" \
   --endpoint-url "$S3_ENDPOINT" \
+  --content-type "image/png" \
+  --no-guess-mime-type \
   --cache-control "public,max-age=31536000,immutable"
-aws s3 sync \
-  "$gallery_dir/" \
-  "$bucket_uri/runs/$run_key/screenshots/" \
+aws s3 cp \
+  "$gallery_dir/index.html" \
+  "$bucket_uri/runs/$run_key/screenshots/index.html" \
   --endpoint-url "$S3_ENDPOINT" \
+  --content-type "text/html" \
   --cache-control "public,max-age=31536000,immutable"
 aws s3 cp \
   "$history_path" \
@@ -99,10 +134,18 @@ aws s3 cp \
 summary=$(cat <<EOF
 ### Playwright visual report
 - [Screenshot gallery]($screenshots_url)
-- [Full report]($report_url)
 - [Dashboard]($public_base_url/index.html)
 EOF
 )
+
+if [[ -n "$report_url" ]]; then
+  summary="$summary
+- [Full report]($report_url)"
+fi
+if [[ -n "$pull_request_url" ]]; then
+  summary="$summary
+- [Pull request]($pull_request_url)"
+fi
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/publish-playwright-report.sh
+++ b/scripts/publish-playwright-report.sh
@@ -25,8 +25,8 @@ if [[ "$publish_report" != "true" && "$publish_report" != "false" ]]; then
 fi
 
 if [[ "$publish_report" == "true" && ! -f "$report_dir/index.html" ]]; then
-  echo "::warning::Playwright did not produce an HTML report; keeping the existing public dashboard."
-  exit 0
+  echo "::warning::Playwright did not produce an HTML report; publishing the gallery and dashboard entry without it."
+  publish_report="false"
 fi
 
 if [[ ! "$S3_BUCKET" =~ ^[a-zA-Z0-9.-]+$ ]]; then


### PR DESCRIPTION
## What this changes

Publishes validated Playwright PNG screenshots from approved pull-request CI runs to the existing hosted dashboard before merge. PR rows link back to GitHub; full contributor-controlled HTML reports remain private Actions artifacts.

## Security boundary

The privileged `workflow_run` job always checks out default-branch code, never executes the PR revision, derives run metadata from GitHub, validates PNG signatures/dimensions/count/size, and uploads images with an explicit `image/png` content type. Repository credentials are never exposed to contributor code.

## Why this is separate

GitHub only loads privileged `workflow_run` definitions from the default branch. Landing this maintainer-owned prerequisite independently lets PR #59 and future external PRs publish screenshots pre-merge after their CI runs are approved.

## Validation

- `pnpm db:generate`
- `pnpm --filter @rakazo/testkit test` (21 passed)
- `pnpm --filter @rakazo/testkit check`
- focused Biome check
- shell syntax and workflow YAML parse
- `git diff --check`