### PR TITLE
Add Box sandbox provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ SANDBOX_PROVIDER=docker
 DAYTONA_API_KEY=
 DAYTONA_API_URL=
 DAYTONA_TARGET=
+BOX_API_KEY=
+# Optional Box API base URL; defaults to https://ascii.dev/api/box/v1.
+BOX_API_URL=
 AGENT_RUNTIME=pi
 WAKEUP_DRIVER=graphile
 # Pause or stop computers after this many idle ms. Minimum 30000.

--- a/.github/workflows/nightly-verification.yml
+++ b/.github/workflows/nightly-verification.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       run_live_providers:
-        description: Run secret-gated OpenRouter and E2B canaries
+        description: Run secret-gated OpenRouter, E2B, and Box canaries
         required: false
         type: boolean
         default: false
@@ -48,6 +48,7 @@ jobs:
     timeout-minutes: 30
     env:
       E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+      BOX_API_KEY: ${{ secrets.BOX_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       RUN_LIVE_PROVIDERS: ${{ github.event_name == 'schedule' || inputs.run_live_providers }}
     steps:
@@ -55,7 +56,7 @@ jobs:
         id: gate
         shell: bash
         run: |
-          if [[ "$RUN_LIVE_PROVIDERS" == "true" && ( -n "$E2B_API_KEY" || -n "$OPENROUTER_API_KEY" ) ]]; then
+          if [[ "$RUN_LIVE_PROVIDERS" == "true" && ( -n "$E2B_API_KEY" || -n "$BOX_API_KEY" || -n "$OPENROUTER_API_KEY" ) ]]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "No requested live canary has a configured key; skipping safely."

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,6 +11,7 @@ on:
           - fake
           - e2b
           - daytona
+          - box
         default: fake
   workflow_call:
     inputs:
@@ -41,6 +42,9 @@ on:
         required: false
       DAYTONA_API_KEY:
         description: Daytona API key used only when the Daytona sandbox is selected
+        required: false
+      BOX_API_KEY:
+        description: Box API key used only when the Box sandbox is selected
         required: false
 
 permissions:
@@ -74,12 +78,18 @@ jobs:
         env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
         run: test -n "$DAYTONA_API_KEY"
+      - name: Validate Box credentials
+        if: inputs.sandbox_provider == 'box'
+        env:
+          BOX_API_KEY: ${{ secrets.BOX_API_KEY }}
+        run: test -n "$BOX_API_KEY"
       - name: Run Playwright tests
         id: playwright_tests
         env:
           SANDBOX_TEST_PROVIDER: ${{ inputs.sandbox_provider }}
           E2B_API_KEY: ${{ inputs.sandbox_provider == 'e2b' && secrets.E2B_API_KEY || '' }}
           DAYTONA_API_KEY: ${{ inputs.sandbox_provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
+          BOX_API_KEY: ${{ inputs.sandbox_provider == 'box' && secrets.BOX_API_KEY || '' }}
         run: pnpm test:e2e -- --sandbox="$SANDBOX_TEST_PROVIDER"
       - name: Record Playwright result
         if: always() && inputs.upload_artifacts

--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ pnpm test:integration  # Postgres journeys, Graphile jobs, LISTEN/NOTIFY
 pnpm test:e2e          # Playwright against the emulated stack
 pnpm test:e2e -- --sandbox=e2b # the same deterministic suite against real E2B
 pnpm test:e2e -- --sandbox=daytona # the same suite against real Daytona
+pnpm test:e2e -- --sandbox=box # the same suite against real Box
 pnpm test:topology     # local Docker + Graphile worker recovery (needs Docker)
-pnpm test:canary       # live OpenRouter / E2B canaries
+pnpm test:canary       # live OpenRouter / E2B / Box canaries
 # explicit real vision-model + real E2B desktop acceptance test:
 COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm test:computer
 ```
@@ -140,8 +141,8 @@ GitHub Actions artifacts. Successful merges and the nightly verification publish
 history plus a scan-friendly screenshot gallery at
 <https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/index.html>.
 
-The Playwright workflow can also be started manually with **Sandbox provider** set to `e2b` or `daytona`.
-Those options require `E2B_API_KEY` or `DAYTONA_API_KEY`, keep the deterministic scripted agent runtime, and destroy
+The Playwright workflow can also be started manually with **Sandbox provider** set to `e2b`, `daytona`, or `box`.
+Those options require `E2B_API_KEY`, `DAYTONA_API_KEY`, or `BOX_API_KEY`, keep the deterministic scripted agent runtime, and destroy
 the provider machines after the run. The default and all automatic runs remain on `fake`.
 
 `pnpm test:topology`, `pnpm test:canary`, and `pnpm test:computer` are for running the product path on your machine. They are not part of pull-request CI. The computer acceptance test also requires `E2B_API_KEY` and `OPENROUTER_API_KEY` (the command reads the root `.env`) and uses a temporary Postgres container. It proves an actual model can observe and click a real browser, then use the sandbox terminal and files.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -86,6 +86,8 @@ export async function createApp(
     daytonaApiKey: env.daytonaApiKey,
     daytonaApiUrl: env.daytonaApiUrl,
     daytonaTarget: env.daytonaTarget,
+    boxApiKey: env.boxApiKey,
+    boxApiUrl: env.boxApiUrl,
     dataDir: env.dataDir,
     prisma,
   });

--- a/apps/api/src/env.test.ts
+++ b/apps/api/src/env.test.ts
@@ -42,6 +42,20 @@ describe("loadEnv", () => {
     });
   });
 
+  it("loads provider-specific Box configuration", () => {
+    const env = loadEnv({
+      ...base,
+      SANDBOX_PROVIDER: "box",
+      BOX_API_KEY: "test-box-key",
+      BOX_API_URL: "https://box.test/api/v1",
+    });
+    expect(env).toMatchObject({
+      sandboxProvider: "box",
+      boxApiKey: "test-box-key",
+      boxApiUrl: "https://box.test/api/v1",
+    });
+  });
+
   it("throws when production omits secrets", () => {
     expect(() =>
       loadEnv({

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -20,6 +20,8 @@ export interface AppEnv {
   daytonaApiKey: string | undefined;
   daytonaApiUrl: string | undefined;
   daytonaTarget: string | undefined;
+  boxApiKey: string | undefined;
+  boxApiUrl: string | undefined;
   composioApiKey: string | undefined;
   defaultProvider: string;
   defaultModel: string;
@@ -49,6 +51,8 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     daytonaApiKey: source.DAYTONA_API_KEY,
     daytonaApiUrl: source.DAYTONA_API_URL,
     daytonaTarget: source.DAYTONA_TARGET,
+    boxApiKey: source.BOX_API_KEY,
+    boxApiUrl: source.BOX_API_URL ?? source.BOX_BASE_URL,
     composioApiKey: source.COMPOSIO_API_KEY,
     defaultProvider: source.PI_DEFAULT_PROVIDER ?? "openrouter",
     defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731",

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -52,7 +52,7 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await composer.fill("install the gsc cli and sign in");
   await page.keyboard.press("Enter");
   await expect(page.getByText(/sign in to continue|protected input/i).first()).toBeVisible({
-    timeout: 30_000,
+    timeout: realSandboxTimeout(90_000, 30_000),
   });
   await expect
     .poll(() => threadRunStatus(page), {
@@ -73,10 +73,13 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   expect((mainBox?.x ?? 0) + (mainBox?.width ?? 0)).toBeLessThanOrEqual(panelBox?.x ?? 0);
   await page.getByRole("button", { name: "Take control" }).click();
   await expect(page.getByRole("button", { name: "Close computer" })).toBeVisible();
+  if (process.env.SANDBOX_PROVIDER === "box") await waitForBoxFramebuffer(page);
   await captureScreenshot(page, testInfo, "09-computer-takeover");
   await page.getByRole("button", { name: "Release" }).last().click();
   await expect(page.getByRole("button", { name: "Close computer" })).toBeHidden();
-  await expect(page.getByText(/signed in|session stays/i).first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText(/signed in|session stays/i).first()).toBeVisible({
+    timeout: realSandboxTimeout(90_000, 30_000),
+  });
 
   await page.getByText("+ New routine").click();
   await page.locator("label:has-text('Name') input").fill("Monday briefing");
@@ -228,4 +231,27 @@ async function threadRunStatus(page: Page) {
     botId: activeBotId(page),
   });
   return result.run?.status ?? "idle";
+}
+
+async function waitForBoxFramebuffer(page: Page) {
+  await expect
+    .poll(
+      async () => {
+        for (const frame of page.frames()) {
+          if (frame === page.mainFrame()) continue;
+          const canvas = frame.locator("canvas").first();
+          if ((await canvas.count()) === 0) continue;
+          const ready = await canvas
+            .evaluate((element) => {
+              const framebuffer = element as HTMLCanvasElement;
+              return framebuffer.width > 0 && framebuffer.height > 0;
+            })
+            .catch(() => false);
+          if (ready) return true;
+        }
+        return false;
+      },
+      { timeout: 60_000, message: "the Box noVNC framebuffer must be ready" },
+    )
+    .toBe(true);
 }

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -1,10 +1,11 @@
 import { expect, type Page, type TestInfo } from "@playwright/test";
 
 export function isRealSandboxProvider(provider = process.env.SANDBOX_PROVIDER) {
-  return provider === "e2b" || provider === "daytona";
+  return provider === "e2b" || provider === "daytona" || provider === "box";
 }
 
 export function realSandboxTimeout(real: number, emulated: number) {
+  if (process.env.SANDBOX_PROVIDER === "box") return Math.max(real, 300_000);
   return isRealSandboxProvider() ? real : emulated;
 }
 

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -4,6 +4,7 @@ import { isRealSandboxProvider } from "./e2e/helpers";
 const webPort = Number(process.env.WEB_PORT ?? 5173);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${webPort}`;
 const realSandbox = isRealSandboxProvider();
+const boxSandbox = process.env.SANDBOX_PROVIDER === "box";
 const reporters = [
   ...(process.env.CI ? ([["github"]] as const) : []),
   ["list"] as const,
@@ -15,8 +16,8 @@ export default defineConfig({
   forbidOnly: Boolean(process.env.CI),
   fullyParallel: false,
   workers: realSandbox ? 1 : undefined,
-  timeout: realSandbox ? 300_000 : 120_000,
-  expect: { timeout: realSandbox ? 90_000 : 20_000 },
+  timeout: boxSandbox ? 600_000 : realSandbox ? 300_000 : 120_000,
+  expect: { timeout: boxSandbox ? 300_000 : realSandbox ? 90_000 : 20_000 },
   reporter: reporters,
   use: {
     baseURL,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -43,6 +43,8 @@ async function main() {
     daytonaApiKey: process.env.DAYTONA_API_KEY,
     daytonaApiUrl: process.env.DAYTONA_API_URL,
     daytonaTarget: process.env.DAYTONA_TARGET,
+    boxApiKey: process.env.BOX_API_KEY,
+    boxApiUrl: process.env.BOX_API_URL ?? process.env.BOX_BASE_URL,
     dataDir,
     prisma,
   });

--- a/docs/computer-runtime.md
+++ b/docs/computer-runtime.md
@@ -3,7 +3,7 @@
 Rakazo keeps the agent runtime and the computer runtime separate:
 
 ```text
-chat/API -> one Pi agent session -> Rakazo computer tools -> SandboxProvider -> E2B (first cloud backend)
+chat/API -> one Pi agent session -> Rakazo computer tools -> SandboxProvider -> E2B / Daytona / Box
                                                    |-> Docker
                                                    |-> desktop/fake
 
@@ -16,7 +16,7 @@ Pi runs in the Rakazo API/worker process. It is not installed in, or executed by
 
 Each workspace gets one Team Computer by default, so bots share its browser sessions and installed tools. Each Team bot starts in `bots/<bot-id>/`, while deliberately shared work belongs in `shared/`. These folders organize work but are not security boundaries: every Team bot can access the full Team workspace. A bot can instead use a Private Computer, where the whole workspace is its home. Team Computer runs use a fenced per-bot database lease, so two Team bots can work at the same time on distinct screens. One bot still runs only one computer-use task on its own screen. When a provider cannot spawn another display, that bot's graphical tools fail with `MULTI_SCREEN_UNAVAILABLE` instead of queueing behind a single computer lock.
 
-`SandboxProvider.describe().capabilities.multiScreen` tells clients whether the backend can allocate distinct Team screens. Fake and Docker providers spawn extra Xvfb stacks inside one machine. E2B and Daytona keep the vendor's primary desktop stream on index 0 and spawn extra Xvfb + x11vnc + preview ports for additional Team bots on the same sandbox. If required tools are missing or all eight screen slots are taken, graphical tools for that bot return `MULTI_SCREEN_UNAVAILABLE` while shell and file tools keep working.
+`SandboxProvider.describe().capabilities.multiScreen` tells clients whether the backend can allocate distinct Team screens. Fake and Docker providers spawn extra Xvfb stacks inside one machine. E2B and Daytona keep the vendor's primary desktop stream on index 0 and spawn extra Xvfb + x11vnc + preview ports for additional Team bots on the same sandbox. Box exposes its primary desktop but does not ship the secondary-display stack, so its adapter reports `multiScreen: false`. If a provider cannot allocate another display, graphical tools for that bot return `MULTI_SCREEN_UNAVAILABLE` while shell and file tools keep working.
 
 `SandboxProvider` is the provider boundary. A backend must implement:
 
@@ -39,19 +39,25 @@ On Team Computers, bot index 0 uses the E2B desktop stream and SDK screenshot/in
 
 The database stores the provider kind and opaque `providerRef`. That reference is an acceleration path, not durable data. It is passed back only to the same provider kind. A missing machine or a provider-kind change creates a replacement and restores its workspace through the provider-neutral contract.
 
+## Box backend
+
+The Box adapter uses ASCII's official TypeScript SDK for lifecycle, command, desktop, and file operations. It creates and resumes boxes with `noEnv: true`, as required when a third party supplies the API key, and keeps a two-hour TTL refreshed while the computer is active. The provider's authenticated noVNC page is embedded for human viewing and takeover; observations and model actions use the same primary `DISPLAY=:0` through ImageMagick and `xdotool`.
+
+Box stop archives the machine and resume reconnects the same opaque box id. Browser profiles live under the portable workspace and are linked into the machine's Chrome/Firefox config, so normal checkpoint/export behavior includes them. Box has one desktop stream per machine, and the Box emulator reproduces that single-screen constraint for deterministic tests.
+
 ## Persistence
 
 The portable computer workspace is the durable boundary. E2B uses `/home/user/rakazo-home`; Docker and local providers expose the equivalent home. Browser profiles are rooted under `.browser-profiles` in that workspace on E2B. Rakazo checkpoints transferred workspaces into `AgentHomeStore` at run completion or failure, before explicit stop, and before idle suspension. Docker mounts the Rakazo-owned home directly and only advances its revision marker at those boundaries. New or replacement machines import the latest stored workspace before use.
 
 `LocalAgentHomeStore` currently keeps the latest workspace under `DATA_DIR/homes/<computer-home-key>` and checkpoint metadata separately under `DATA_DIR/home-revisions`. Replacements are staged before the current copy is swapped, and checkpoints are serialized per computer. This implementation is latest-only rather than an immutable revision archive. Production deployments must put `DATA_DIR` on a Rakazo-owned persistent volume, encrypt that volume at rest, and include it in off-host backups. The storage interface is deliberately independent of E2B so an object-store-backed implementation can replace the local volume without changing agent tools or sandbox providers.
 
-Before exporting a remote workspace, the E2B backend quiesces desktop browsers so profile databases and login state are copied consistently. It excludes only transient cache/lock files inside `.browser-profiles`; similarly named project files remain durable.
+Before exporting a remote workspace, remote backends quiesce desktop browsers so profile databases and login state are copied consistently. They exclude only transient cache/lock files inside `.browser-profiles`; similarly named project files remain durable.
 
 The disposable OS image is not a portable disk snapshot. System packages installed outside the workspace are lost when moving to another provider; durable machine customization should be represented by a reproducible image or setup recipe. This is what makes a future backend switch practical instead of trying to translate vendor-specific VM snapshots.
 
 ## Verification
 
-Offline tests cover tool-result images, action parsing, provider conformance, workspace checkpoint/restore, E2B SDK translation, and lifecycle integration. They never call a model or live sandbox.
+Offline tests cover tool-result images, action parsing, provider conformance, workspace checkpoint/restore, provider SDK translation, lifecycle integration, and the Box single-screen emulator. They never call a model or live sandbox.
 
 The explicit acceptance test requires Docker (for temporary Postgres), `E2B_API_KEY`, `OPENROUTER_API_KEY`, and a vision-capable OpenRouter model id:
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -1,6 +1,6 @@
 # Self-hosting Rakazo
 
-The signed-in product is a long-running API, a Graphile Worker, Postgres, and a computer provider (Docker supervisor or E2B). It is not a static site. The marketing site in `apps/www` can be hosted separately.
+The signed-in product is a long-running API, a Graphile Worker, Postgres, and a computer provider (Docker supervisor, E2B, Daytona, or Box). It is not a static site. The marketing site in `apps/www` can be hosted separately.
 
 ## Local (source checkout)
 
@@ -35,12 +35,14 @@ Optional:
 ```env
 SIGNUPS_ENABLED=true
 SIGNUP_ALLOWLIST=you@example.com,@company.com
-SANDBOX_PROVIDER=docker   # or e2b. Keep fake only for pnpm test.
+SANDBOX_PROVIDER=docker   # or e2b, daytona, box. Keep fake only for pnpm test.
 AGENT_RUNTIME=pi          # Keep scripted only for pnpm test.
 WAKEUP_DRIVER=graphile
 SANDBOX_IDLE_MS=600000    # pause the bot computer after 10 minutes idle
 SANDBOX_COMMAND_TIMEOUT_MS=300000 # stop a shell command after 5 minutes
 E2B_API_KEY=              # when SANDBOX_PROVIDER=e2b
+DAYTONA_API_KEY=          # when SANDBOX_PROVIDER=daytona
+BOX_API_KEY=              # when SANDBOX_PROVIDER=box
 ```
 
 Do not commit `.env`. Never put `COMPOSIO_API_KEY`, OpenRouter keys, or provider tokens in git, logs, or chat.
@@ -51,6 +53,8 @@ The Electron desktop app is a client of the same API. Docker and E2B still apply
 
 - **Docker** is the default for local use and the quickest self-hosted setup. Workspace bots share a persistent Team Computer by default; Private computers are optional. Keep the supervisor private, as the included Compose file does.
 - **E2B** runs bot computers away from the Rakazo host and is the recommended choice for public or multi-user production deployments. Rakazo checkpoints the portable workspace and browser-profile directory to `DATA_DIR`; the E2B disk is a runtime cache, not the durable source of truth.
+- **Daytona** provides the same remote-computer contract through Daytona sandboxes. Configure `DAYTONA_API_KEY` and optionally `DAYTONA_API_URL` / `DAYTONA_TARGET`.
+- **Box by ASCII** provides a managed Linux desktop through `BOX_API_KEY` and optionally `BOX_API_URL`. Rakazo always creates or resumes boxes with `noEnv: true`, keeps the portable workspace under `/home/user/rakazo-home`, and refreshes a two-hour TTL. A Box currently exposes one shared desktop, so concurrent Team bots can still use shell and files but only one can use graphical tools at a time.
 - **Desktop provider** / **This Mac** runs commands on the API/worker host. Docker stays the default. The Electron app asks once; if you choose This Mac, bots can use working directories under your home folder. Do not enable it on a public or shared service. macOS does not show its own permission dialog for this.
 - **Fake** is only an emulator for verification.
 
@@ -146,7 +150,7 @@ To run a hosted product (same codebase):
 2. Provision managed Postgres 16 and run `pnpm db:migrate`.
 3. Run **API** and **worker** as always-on Node 22 services (Fly machines, a VM, ECS, k8s). Not lambda-style request handlers.
 4. Persist and back up `DATA_DIR` (bot homes, browser profiles, artifacts). Today the concrete store is a local filesystem (`LocalAgentHomeStore`), so attach a Rakazo-owned durable volume shared by API and worker processes. The storage contract is separate from the computer-provider contract, but an object-storage implementation is not wired yet.
-5. Choose computers: **`SANDBOX_PROVIDER=e2b`** with `E2B_API_KEY` for a public or multi-user production service. Each Team or Private Computer reconnects to its sandbox id (`providerRef`), while workspace state is checkpointed outside E2B at run completion, explicit stop, and idle suspension. If that sandbox is gone—or the deployment changes providers—the replacement is hydrated from Rakazo's copy. Idle boxes pause after `SANDBOX_IDLE_MS` (default 10 minutes) and resume on the next message or Take control. Docker remains the local and trusted single-machine default.
+5. Choose computers: **`SANDBOX_PROVIDER=e2b`**, `daytona`, or `box` with the matching provider key for a public or multi-user production service. Each Team or Private Computer reconnects to its sandbox id (`providerRef`), while workspace state is checkpointed outside the provider at run completion, explicit stop, and idle suspension. If that sandbox is gone—or the deployment changes providers—the replacement is hydrated from Rakazo's copy. Idle computers pause after `SANDBOX_IDLE_MS` (default 10 minutes) and resume on the next message or Take control. Docker remains the local and trusted single-machine default.
 6. A Hetzner CX22 (2 vCPU / 4 GB) is enough for API + worker + Postgres when E2B owns the desktops. 2 GB works for a quiet box; 8 GB is only needed if you also run Docker computers on that same machine.
 7. Set public HTTPS `WEB_ORIGIN` / `BETTER_AUTH_URL` / `API_URL`, secrets, and an OpenRouter (or other Pi) deployment key if you want to skip per-user model keys.
 8. Put the web app behind the same origin as `/api` and `/rpc` (Vite preview proxy, or a reverse proxy). Docker noVNC connections use short-lived signed `/novnc/*` capabilities; do not replace that route with an unrestricted port proxy.

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run --root ../.. packages/adapters/src"
   },
   "dependencies": {
+    "@asciidev/box-sdk": "^0.0.28",
     "@composio/core": "0.16.0",
     "@daytona/sdk": "^0.204.1",
     "@e2b/desktop": "^2.3.1",

--- a/packages/adapters/src/box-emulator.ts
+++ b/packages/adapters/src/box-emulator.ts
@@ -1,0 +1,8 @@
+import { ManagedSandboxEmulator } from "./e2b-emulator.js";
+
+/** Box protocol emulator with the provider's single-desktop constraint. */
+export class BoxSandboxEmulator extends ManagedSandboxEmulator {
+  constructor() {
+    super({ id: "box-emulator", kind: "box" });
+  }
+}

--- a/packages/adapters/src/box-sandbox.test.ts
+++ b/packages/adapters/src/box-sandbox.test.ts
@@ -1,0 +1,324 @@
+import type { Command200Response } from "@asciidev/box-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { BoxSandboxProvider, type BoxSandboxSdk, isUnrecoverableBoxError } from "./box-sandbox.js";
+
+const context = {
+  operationId: "test",
+  traceId: "trace",
+  workspaceId: "workspace",
+  userId: "user",
+  botId: "bot-a",
+  signal: new AbortController().signal,
+};
+
+describe("BoxSandboxProvider", () => {
+  it("creates no-env boxes and implements execution and file operations", async () => {
+    const fixture = boxFixture();
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+
+    expect(computer).toMatchObject({
+      id: "bx_testbox2",
+      providerRef: "bx_testbox2",
+      kind: "box",
+      fresh: true,
+    });
+    expect(fixture.create).toHaveBeenCalledWith(
+      {
+        createBoxRequest: {
+          ttlSeconds: 7200,
+          noEnv: true,
+          env: { RAKAZO_BOT_ID: "bot-a", RAKAZO_SANDBOX: "computer" },
+        },
+      },
+      { signal: context.signal },
+    );
+
+    await provider.prepare(computer, context);
+    expect(
+      fixture.command.mock.calls.some(([request]) =>
+        request.commandRequest.command.includes("rakazo-home/.browser-profiles"),
+      ),
+    ).toBe(true);
+
+    const events = [];
+    for await (const event of provider.execute(
+      computer,
+      { argv: ["echo", "hello"], cwd: "notes", env: { TEST_VALUE: "works" } },
+      context,
+    )) {
+      events.push(event);
+    }
+    expect(events).toEqual([
+      { type: "stdout", data: "hello\n" },
+      { type: "exit", code: 0 },
+    ]);
+    const executeRequest = fixture.command.mock.calls.find(([request]) =>
+      request.commandRequest.command.includes("TEST_VALUE=works"),
+    )?.[0];
+    expect(executeRequest?.commandRequest.cwd).toBe("rakazo-home/notes");
+
+    await provider.writeFile(
+      computer,
+      { path: "bin/tool", content: Uint8Array.from([0, 255, 1]), executable: true },
+      context,
+    );
+    expect(await provider.readFile(computer, "bin/tool", context)).toEqual(
+      Uint8Array.from([0, 255, 1]),
+    );
+    expect(await provider.listFiles(computer, "bin", context)).toEqual([
+      { path: "bin/tool", kind: "file", size: 3, executable: true },
+    ]);
+    const exported = [];
+    for await (const file of provider.exportWorkspace(computer, context)) exported.push(file);
+    expect(exported).toEqual([
+      { path: "bin/tool", content: Uint8Array.from([0, 255, 1]), executable: true },
+    ]);
+  });
+
+  it("resumes archived boxes and replaces deleted references", async () => {
+    const archived = boxFixture({ state: "archived" });
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" }, archived.client);
+    const reconnected = await provider.provision(
+      {
+        botId: "bot-a",
+        homePath: "/unused",
+        providerRef: "bx_existing2",
+        providerKind: "box",
+      },
+      context,
+    );
+    expect(reconnected).toMatchObject({ providerRef: "bx_existing2", fresh: false });
+    expect(archived.resume).toHaveBeenCalledWith(
+      {
+        boxId: "bx_existing2",
+        resumeRequest: { noEnv: true, ttlSeconds: 7200 },
+      },
+      { signal: context.signal },
+    );
+
+    const missing = boxFixture();
+    missing.get.mockRejectedValueOnce({ status: 404 });
+    const replacing = new BoxSandboxProvider({ apiKey: "test-key" }, missing.client);
+    const replacement = await replacing.provision(
+      {
+        botId: "bot-b",
+        homePath: "/unused",
+        providerRef: "bx_missing2",
+        providerKind: "box",
+      },
+      context,
+    );
+    expect(replacement).toMatchObject({ providerRef: "bx_testbox2", fresh: true });
+  });
+
+  it("captures the desktop, exposes a private view, and enforces one screen", async () => {
+    const fixture = boxFixture();
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+    await provider.prepare(computer, context);
+
+    const observation = await provider.observe(computer, context);
+    expect(observation).toMatchObject({
+      mimeType: "image/png",
+      width: 1920,
+      height: 1080,
+      cursor: { x: 21, y: 34 },
+      activeWindow: { id: "42", title: "Box browser" },
+    });
+    expect(observation.image).toEqual(Uint8Array.from([137, 80, 78, 71]));
+
+    const screen = await provider.connectScreen(
+      computer,
+      { view: "stream", interactive: false },
+      context,
+    );
+    expect(screen.url).toContain("view_only=true");
+    expect(screen.url).toContain("_token=secret");
+
+    await provider.act(
+      computer,
+      { actions: [{ kind: "pointer", type: "click", x: 100, y: 200 }], observe: false },
+      context,
+    );
+    expect(
+      fixture.command.mock.calls.some(([request]) =>
+        request.commandRequest.command.includes("xdotool mousemove 100 200 click 1"),
+      ),
+    ).toBe(true);
+
+    await expect(provider.observe(computer, { ...context, botId: "bot-b" })).rejects.toThrow(
+      /multiple screens/i,
+    );
+    expect(provider.describe().capabilities.multiScreen).toBe(false);
+  });
+
+  it("releases the screen claim when desktop connection fails", async () => {
+    const fixture = boxFixture();
+    fixture.desktop.mockRejectedValueOnce(new Error("desktop unavailable"));
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+
+    await expect(
+      provider.connectScreen(computer, { view: "stream", interactive: false }, context),
+    ).rejects.toThrow("desktop unavailable");
+    await expect(provider.observe(computer, { ...context, botId: "bot-b" })).resolves.toMatchObject(
+      { width: 1920, height: 1080 },
+    );
+  });
+
+  it("archives on stop and permanently deletes on destroy", async () => {
+    const fixture = boxFixture();
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+    fixture.stop.mockResolvedValueOnce(actionResponse("archiving"));
+    fixture.get
+      .mockResolvedValueOnce(infoResponse("bx_testbox2", "ready"))
+      .mockResolvedValue(infoResponse("bx_testbox2", "archived"));
+
+    await provider.stop(computer, context);
+    expect(fixture.stop).toHaveBeenCalledWith({ boxId: "bx_testbox2" }, { signal: context.signal });
+    await provider.destroy(computer, context);
+    expect(fixture.deleteBox).toHaveBeenCalledWith("bx_testbox2");
+  });
+
+  it("recognizes provider 404 errors without swallowing transient failures", () => {
+    expect(isUnrecoverableBoxError({ status: 404 })).toBe(true);
+    expect(isUnrecoverableBoxError(new Error("temporary Box outage"))).toBe(false);
+  });
+});
+
+function boxFixture(options: { state?: string } = {}) {
+  const files = new Map<string, Uint8Array>();
+  const create = vi.fn(async () => createResponse());
+  const fixture = {
+    state: options.state ?? "ready",
+    create,
+    get: vi.fn(async ({ boxId }: { boxId: string }) => infoResponse(boxId, fixture.state)),
+    resume: vi.fn(async ({ boxId }: { boxId: string }) => {
+      fixture.state = "ready";
+      return actionResponse("ready", boxId);
+    }),
+    stop: vi.fn(async ({ boxId }: { boxId: string }) => actionResponse("archiving", boxId)),
+    update: vi.fn(async ({ boxId }: { boxId: string }) => infoResponse(boxId, fixture.state)),
+    deleteBox: vi.fn(async () => undefined),
+    desktop: vi.fn(async () => ({
+      ok: true,
+      type: "desktop.url",
+      success: true,
+      desktopUrl: "https://vnc.box.test/vnc.html?password=pw&_token=secret",
+      mode: "vnc",
+    })),
+    commandStatus: vi.fn(),
+    command: vi.fn(async (request: { commandRequest: { command: string; cwd?: string } }) => {
+      const command = request.commandRequest.command;
+      if (command.includes("TEST_VALUE=works")) return finished({ stdout: "hello\n" });
+      if (command.includes("find ") && command.includes("rakazo-home/bin")) {
+        const target = "/home/user/rakazo-home/bin/tool";
+        return finished({
+          stdout: `${Buffer.from(target).toString("base64")}\tfile\t3\t1\n`,
+        });
+      }
+      if (
+        command.includes("find ") &&
+        command.includes("rakazo-home") &&
+        command.includes("-type f")
+      ) {
+        const stdout = [...files.entries()]
+          .filter(([filePath]) => filePath.startsWith("/home/user/rakazo-home/"))
+          .map(([filePath, content]) => {
+            const executable = filePath.endsWith("/bin/tool") ? "1" : "0";
+            return `${Buffer.from(filePath).toString("base64")}\tfile\t${content.byteLength}\t${executable}\n`;
+          })
+          .join("");
+        return finished({ stdout });
+      }
+      if (command.includes("import -window root")) {
+        return finished({
+          stdout: [
+            "WIDTH=1920",
+            "HEIGHT=1080",
+            "X=21",
+            "Y=34",
+            "WINDOW=42",
+            `TITLE=${Buffer.from("Box browser").toString("base64")}`,
+            "",
+          ].join("\n"),
+        });
+      }
+      return finished();
+    }),
+    writeFile: vi.fn(
+      async ({ fileWriteRequest }: { fileWriteRequest: { path: string; content: string } }) => {
+        files.set(
+          fileWriteRequest.path,
+          Uint8Array.from(Buffer.from(fileWriteRequest.content, "base64")),
+        );
+        return {
+          ok: true,
+          type: "file.written" as const,
+          success: true,
+          path: fileWriteRequest.path,
+          encoding: "base64" as const,
+          size: files.get(fileWriteRequest.path)?.byteLength ?? 0,
+        };
+      },
+    ),
+    readFile: vi.fn(async ({ path }: { path: string }) => {
+      const content = path.startsWith("/tmp/rakazo-observe-")
+        ? Uint8Array.from([137, 80, 78, 71])
+        : (files.get(path) ?? new Uint8Array());
+      return {
+        ok: true,
+        type: "file.read" as const,
+        success: true,
+        path,
+        encoding: "base64" as const,
+        size: content.byteLength,
+        content: Buffer.from(content).toString("base64"),
+      };
+    }),
+  };
+  return { ...fixture, client: fixture as unknown as BoxSandboxSdk };
+}
+
+function box(id: string, state: string) {
+  return {
+    id,
+    name: "Test Box",
+    state,
+    desktopAvailable: true,
+    snapshotAvailable: state === "archived",
+  };
+}
+
+function createResponse() {
+  return {
+    ok: true,
+    type: "box.created",
+    status: "provisioning",
+    ttlSeconds: null,
+    box: box("bx_testbox2", "provisioning"),
+  };
+}
+
+function infoResponse(id: string, state: string) {
+  return { ok: true, type: "box.info", box: box(id, state) };
+}
+
+function actionResponse(status: string, id = "bx_testbox2") {
+  return { ok: true, type: "box.action", id, status, box: box(id, status) };
+}
+
+function finished(overrides: Partial<Command200Response> = {}): Command200Response {
+  return {
+    ok: true,
+    type: "command.finished",
+    success: true,
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+    ...overrides,
+  } as Command200Response;
+}

--- a/packages/adapters/src/box-sandbox.ts
+++ b/packages/adapters/src/box-sandbox.ts
@@ -1,0 +1,1022 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  type Box,
+  BoxApi,
+  type Command200Response,
+  type CommandResponse,
+  Configuration,
+  ResponseError,
+} from "@asciidev/box-sdk";
+import type {
+  AdapterContext,
+  CommandRequest,
+  ComputerAction,
+  ComputerActionRequest,
+  ComputerFileEntry,
+  ComputerInput,
+  ComputerObservation,
+  ComputerRef,
+  ControlLeaseRef,
+  PortableFile,
+  ProcessEvent,
+  SandboxProvider,
+  ScreenRequest,
+  ScreenSession,
+} from "@rakazo/adapter-kit";
+import { boundedSandboxCommandTimeoutMs } from "@rakazo/core";
+import { SingleScreenClaimTracker } from "./computer-screens.js";
+import {
+  boundedComputerActions,
+  clampRounded,
+  computerObservation,
+  normalizeWorkspacePath,
+  shellQuote,
+  workspacePath,
+} from "./computer-support.js";
+import {
+  PORTABLE_BROWSER_STOP_COMMAND,
+  PORTABLE_TRANSFER_BATCH_BYTES,
+  shouldSkipPortableWorkspaceFile,
+} from "./computer-workspace.js";
+
+const BOX_API_BASE = "https://ascii.dev/api/box/v1";
+const BOX_WORKSPACE = "/home/user/rakazo-home";
+const BOX_BROWSER_PROFILES = `${BOX_WORKSPACE}/.browser-profiles`;
+const BOX_READY_TIMEOUT_MS = 5 * 60_000;
+const BOX_API_COMMAND_TIMEOUT_SECONDS = 600;
+const BOX_TTL_SECONDS = 2 * 60 * 60;
+const BOX_EXPORT_CONCURRENCY = 16;
+
+export type BoxSandboxSdk = Pick<
+  BoxApi,
+  | "command"
+  | "commandStatus"
+  | "create"
+  | "desktop"
+  | "get"
+  | "readFile"
+  | "resume"
+  | "stop"
+  | "update"
+  | "writeFile"
+> & {
+  deleteBox(boxId: string): Promise<void>;
+};
+
+interface BoxCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+export class BoxSandboxProvider implements SandboxProvider {
+  private readonly client: BoxSandboxSdk;
+  private readonly pendingProvisions = new Map<string, Promise<ComputerRef>>();
+  private readonly prepared = new Set<string>();
+  private readonly preparations = new Map<string, Promise<void>>();
+  private readonly screens = new SingleScreenClaimTracker();
+
+  constructor(
+    config: { apiKey: string; apiUrl?: string },
+    client: BoxSandboxSdk = createBoxSdk(config),
+  ) {
+    this.client = client;
+  }
+
+  describe() {
+    return {
+      id: "box",
+      contractVersion: "1",
+      adapterVersion: "0.1.0",
+      capabilities: {
+        graphical: true,
+        pty: false,
+        snapshots: true,
+        takeover: true,
+        persistentHome: true,
+        multiScreen: false,
+      },
+    };
+  }
+
+  async provision(
+    request: {
+      botId: string;
+      homePath: string;
+      providerRef?: string;
+      providerKind?: ComputerRef["kind"];
+    },
+    context: AdapterContext,
+  ): Promise<ComputerRef> {
+    const reconnecting = request.providerRef && request.providerKind === "box";
+    const key = reconnecting ? request.providerRef! : `new:${request.botId}`;
+    const pending = this.pendingProvisions.get(key);
+    if (pending) return pending;
+    let provision!: Promise<ComputerRef>;
+    provision = this.provisionOnce(request, context).finally(() => {
+      if (this.pendingProvisions.get(key) === provision) this.pendingProvisions.delete(key);
+    });
+    this.pendingProvisions.set(key, provision);
+    return provision;
+  }
+
+  private async provisionOnce(
+    request: {
+      botId: string;
+      providerRef?: string;
+      providerKind?: ComputerRef["kind"];
+    },
+    context: AdapterContext,
+  ): Promise<ComputerRef> {
+    if (request.providerRef && request.providerKind === "box") {
+      try {
+        const existing = await this.client.get(
+          { boxId: request.providerRef },
+          { signal: context.signal },
+        );
+        if (existing.box.state === "archived") {
+          await this.client.resume(
+            {
+              boxId: request.providerRef,
+              resumeRequest: { noEnv: true, ttlSeconds: BOX_TTL_SECONDS },
+            },
+            { signal: context.signal },
+          );
+        }
+        return this.ref(request.providerRef, request.botId, false);
+      } catch (error) {
+        if (!isUnrecoverableBoxError(error)) throw error;
+        this.forget(request.providerRef);
+      }
+    }
+
+    const created = await this.client.create(
+      {
+        createBoxRequest: {
+          ttlSeconds: BOX_TTL_SECONDS,
+          noEnv: true,
+          env: {
+            RAKAZO_BOT_ID: request.botId,
+            RAKAZO_SANDBOX: "computer",
+          },
+        },
+      },
+      { signal: context.signal },
+    );
+    return this.ref(created.box.id, request.botId, true);
+  }
+
+  async prepare(computer: ComputerRef, context: AdapterContext): Promise<void> {
+    const id = this.id(computer);
+    if (this.prepared.has(id)) return;
+    const pending = this.preparations.get(id);
+    if (pending) return pending;
+    let preparation!: Promise<void>;
+    preparation = (async () => {
+      await this.ensureRunnable(id, context);
+      await this.stopBrowsers(id);
+      const result = await this.runCommand(
+        id,
+        configureBoxWorkspaceCommand(),
+        undefined,
+        60_000,
+        context.signal,
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(result.stderr || result.stdout || "could not prepare Box workspace");
+      }
+      await this.openBrowser(id);
+      if (this.preparations.get(id) !== preparation) {
+        throw new Error("Box workspace preparation was invalidated during teardown");
+      }
+      this.prepared.add(id);
+    })().finally(() => {
+      if (this.preparations.get(id) === preparation) this.preparations.delete(id);
+    });
+    this.preparations.set(id, preparation);
+    return preparation;
+  }
+
+  async *execute(
+    computer: ComputerRef,
+    request: CommandRequest,
+    context: AdapterContext,
+  ): AsyncIterable<ProcessEvent> {
+    if (context.signal.aborted) {
+      yield { type: "stderr", data: "command aborted\n" };
+      yield { type: "exit", code: 130 };
+      return;
+    }
+    const timeoutMs = boundedSandboxCommandTimeoutMs(request.timeoutMs);
+    const argv = request.argv.length ? request.argv : ["true"];
+    const environment = Object.entries(request.env ?? {}).map(([key, value]) => `${key}=${value}`);
+    const command = [...(environment.length ? ["env", ...environment] : []), ...argv]
+      .map(shellQuote)
+      .join(" ");
+    try {
+      const result = await this.runCommand(
+        this.id(computer),
+        command,
+        boxCwd(request.cwd),
+        timeoutMs,
+        context.signal,
+      );
+      if (context.signal.aborted) {
+        yield { type: "stderr", data: "command aborted\n" };
+        yield { type: "exit", code: 130 };
+        return;
+      }
+      if (result.stdout) yield { type: "stdout", data: result.stdout };
+      if (result.timedOut) {
+        yield { type: "stderr", data: `command timed out after ${timeoutMs} ms\n` };
+        yield { type: "exit", code: 124 };
+        return;
+      }
+      if (result.stderr) yield { type: "stderr", data: result.stderr };
+      yield { type: "exit", code: result.exitCode };
+    } catch (error) {
+      if (context.signal.aborted || isAbortError(error)) {
+        yield { type: "stderr", data: "command aborted\n" };
+        yield { type: "exit", code: 130 };
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async connectScreen(
+    computer: ComputerRef,
+    request: ScreenRequest,
+    context: AdapterContext,
+  ): Promise<ScreenSession> {
+    const id = this.id(computer);
+    this.screens.claim(id, context);
+    try {
+      const deadline = Date.now() + 60_000;
+      while (true) {
+        if (context.signal.aborted) {
+          throw context.signal.reason ?? new Error("screen connection aborted");
+        }
+        const desktop = await this.client.desktop(
+          {
+            boxId: id,
+            vnc: 1,
+            desktopRequest: { publicAccess: false },
+          },
+          { signal: context.signal },
+        );
+        if (!desktop.provisioning && desktop.desktopUrl) {
+          const url = new URL(desktop.desktopUrl);
+          url.searchParams.set("autoconnect", "true");
+          url.searchParams.set("resize", "scale");
+          url.searchParams.set("view_only", request.interactive ? "false" : "true");
+          return {
+            url: url.toString(),
+            mimeType: "text/html",
+            close: async () => undefined,
+          };
+        }
+        if (Date.now() >= deadline) throw new Error("Box desktop did not become ready");
+        await delay(1_000, undefined, { signal: context.signal });
+      }
+    } catch (error) {
+      this.screens.release(id, context);
+      throw error;
+    }
+  }
+
+  async setScreenControl(
+    computer: ComputerRef,
+    interactive: boolean,
+    context: AdapterContext,
+    _controlToken?: string,
+  ): Promise<void> {
+    if (interactive) this.screens.claim(this.id(computer), context);
+  }
+
+  async sendInput(
+    computer: ComputerRef,
+    input: ComputerInput,
+    _lease: ControlLeaseRef,
+    context: AdapterContext,
+  ): Promise<void> {
+    const id = this.id(computer);
+    this.screens.claim(id, context);
+    await this.applyAction(id, input, context);
+  }
+
+  async observe(computer: ComputerRef, context: AdapterContext): Promise<ComputerObservation> {
+    const id = this.id(computer);
+    this.screens.claim(id, context);
+    const imagePath = `/tmp/rakazo-observe-${randomUUID()}.png`;
+    try {
+      const result = await this.runCommand(
+        id,
+        observeBoxCommand(imagePath),
+        undefined,
+        60_000,
+        context.signal,
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(result.stderr || result.stdout || "Box screenshot failed");
+      }
+      const image = await this.readRemoteFile(id, imagePath, context.signal);
+      if (!image.byteLength) throw new Error("Box screenshot did not contain image data");
+      return parseBoxObservation(image, result.stdout);
+    } finally {
+      await this.rawCommand(id, `rm -f -- ${shellQuote(imagePath)}`, 10).catch(() => undefined);
+    }
+  }
+
+  async act(computer: ComputerRef, request: ComputerActionRequest, context: AdapterContext) {
+    const id = this.id(computer);
+    this.screens.claim(id, context);
+    const actions = boundedComputerActions(request.actions);
+    let completed = 0;
+    for (const action of actions) {
+      if (context.signal.aborted) {
+        throw context.signal.reason ?? new Error("computer action aborted");
+      }
+      await this.applyAction(id, action, context);
+      completed += 1;
+    }
+    if (request.settleMs) {
+      await delay(clampRounded(request.settleMs, 0, 5_000), undefined, {
+        signal: context.signal,
+      });
+    }
+    return {
+      completed,
+      ...(request.observe === false ? {} : { observation: await this.observe(computer, context) }),
+    };
+  }
+
+  async listFiles(
+    computer: ComputerRef,
+    directory: string,
+    context: AdapterContext,
+  ): Promise<ComputerFileEntry[]> {
+    const relative = normalizeWorkspacePath(directory);
+    const result = await this.runCommand(
+      this.id(computer),
+      listBoxFilesCommand(workspacePath(BOX_WORKSPACE, relative)),
+      undefined,
+      60_000,
+      context.signal,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || result.stdout || "could not list Box workspace");
+    }
+    return parseBoxFileEntries(result.stdout);
+  }
+
+  async readFile(
+    computer: ComputerRef,
+    filePath: string,
+    context: AdapterContext,
+    options?: { maxBytes?: number },
+  ): Promise<Uint8Array> {
+    const response = await this.client.readFile(
+      {
+        boxId: this.id(computer),
+        path: workspacePath(BOX_WORKSPACE, filePath),
+        encoding: "base64",
+      },
+      { signal: context.signal },
+    );
+    if (options?.maxBytes !== undefined && response.size > options.maxBytes) {
+      throw new Error(`computer file exceeds ${options.maxBytes} bytes`);
+    }
+    return Uint8Array.from(Buffer.from(response.content, "base64"));
+  }
+
+  async writeFile(computer: ComputerRef, file: PortableFile, context: AdapterContext) {
+    await this.writeFiles(this.id(computer), [file], context);
+  }
+
+  async *exportWorkspace(
+    computer: ComputerRef,
+    context: AdapterContext,
+  ): AsyncIterable<PortableFile> {
+    const id = this.id(computer);
+    await this.stopBrowsers(id);
+    try {
+      const entries = await this.listWorkspaceFiles(id, context);
+      for (let index = 0; index < entries.length; index += BOX_EXPORT_CONCURRENCY) {
+        const files = await Promise.all(
+          entries.slice(index, index + BOX_EXPORT_CONCURRENCY).map(async (entry) => ({
+            path: entry.path,
+            content: await this.readFile(computer, entry.path, context),
+            executable: entry.executable,
+          })),
+        );
+        yield* files;
+      }
+    } finally {
+      if (context.operationId !== "stop" && context.operationId !== "computer.sleep") {
+        await this.openBrowser(id).catch(() => undefined);
+      }
+    }
+  }
+
+  async importWorkspace(
+    computer: ComputerRef,
+    files: AsyncIterable<PortableFile>,
+    context: AdapterContext,
+  ): Promise<void> {
+    const id = this.id(computer);
+    await this.stopBrowsers(id);
+    let batch: PortableFile[] = [];
+    let batchBytes = 0;
+    const flush = async () => {
+      if (!batch.length) return;
+      await this.writeFiles(id, batch, context);
+      batch = [];
+      batchBytes = 0;
+    };
+    for await (const file of files) {
+      if (context.signal.aborted) throw context.signal.reason ?? new Error("import aborted");
+      if (
+        batch.length >= 8 ||
+        batchBytes + file.content.byteLength > PORTABLE_TRANSFER_BATCH_BYTES
+      ) {
+        await flush();
+      }
+      batch.push(file);
+      batchBytes += file.content.byteLength;
+    }
+    await flush();
+    await this.openBrowser(id).catch(() => undefined);
+  }
+
+  async snapshot(computer: ComputerRef, context: AdapterContext) {
+    const observation = await this.observe(computer, context);
+    return { id: observation.frameId, createdAt: observation.capturedAt };
+  }
+
+  async keepAlive(computer: ComputerRef): Promise<void> {
+    await this.client.update({
+      boxId: this.id(computer),
+      updateBoxRequest: { ttlSeconds: BOX_TTL_SECONDS },
+    });
+  }
+
+  async releaseScreen(computer: ComputerRef, context: AdapterContext): Promise<void> {
+    this.screens.release(this.id(computer), context);
+  }
+
+  async stop(computer: ComputerRef, context: AdapterContext): Promise<void> {
+    const id = this.id(computer);
+    try {
+      const current = await this.client.get({ boxId: id }, { signal: context.signal });
+      if (current.box.state !== "archived" && current.box.state !== "archiving") {
+        await this.client.stop({ boxId: id }, { signal: context.signal });
+      }
+      await this.waitForState(id, new Set(["archived"]), context);
+    } catch (error) {
+      if (!isUnrecoverableBoxError(error)) throw error;
+    } finally {
+      this.forget(id);
+    }
+  }
+
+  async destroy(computer: ComputerRef, _context: AdapterContext): Promise<void> {
+    const id = this.id(computer);
+    try {
+      await this.client.deleteBox(id);
+    } catch (error) {
+      if (!isUnrecoverableBoxError(error)) throw error;
+    } finally {
+      this.forget(id);
+    }
+  }
+
+  private async ensureRunnable(id: string, context: AdapterContext): Promise<Box> {
+    const deadline = Date.now() + BOX_READY_TIMEOUT_MS;
+    let resumed = false;
+    while (true) {
+      if (context.signal.aborted) {
+        throw context.signal.reason ?? new Error("Box preparation aborted");
+      }
+      const response = await this.client.get({ boxId: id }, { signal: context.signal });
+      const box = response.box;
+      if (box.state === "ready" || box.state === "idle" || box.state === "running") return box;
+      if (box.state === "archived" && !resumed) {
+        await this.client.resume(
+          { boxId: id, resumeRequest: { noEnv: true, ttlSeconds: BOX_TTL_SECONDS } },
+          { signal: context.signal },
+        );
+        resumed = true;
+      } else if (box.state === "error") {
+        throw new Error(`Box ${id} entered the error state`);
+      }
+      if (Date.now() >= deadline) throw new Error(`Box ${id} did not become ready`);
+      await delay(1_000, undefined, { signal: context.signal });
+    }
+  }
+
+  private async waitForState(
+    id: string,
+    states: Set<Box["state"]>,
+    context: AdapterContext,
+  ): Promise<Box> {
+    const deadline = Date.now() + BOX_READY_TIMEOUT_MS;
+    while (true) {
+      if (context.signal.aborted) throw context.signal.reason ?? new Error("Box wait aborted");
+      const response = await this.client.get({ boxId: id }, { signal: context.signal });
+      if (states.has(response.box.state)) return response.box;
+      if (response.box.state === "error") throw new Error(`Box ${id} entered the error state`);
+      if (Date.now() >= deadline)
+        throw new Error(`Box ${id} did not reach ${[...states].join("/")}`);
+      await delay(1_000, undefined, { signal: context.signal });
+    }
+  }
+
+  private async applyAction(
+    id: string,
+    action: ComputerAction,
+    context: AdapterContext,
+  ): Promise<void> {
+    if (action.kind === "wait") {
+      await delay(clampRounded(action.ms, 0, 5_000), undefined, { signal: context.signal });
+      return;
+    }
+    const command = boxActionCommand(action);
+    const result = await this.runCommand(id, command, undefined, 60_000, context.signal);
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || result.stdout || `Box ${action.kind} action failed`);
+    }
+  }
+
+  private async writeFiles(
+    id: string,
+    files: readonly PortableFile[],
+    context: AdapterContext,
+  ): Promise<void> {
+    if (!files.length) return;
+    await Promise.all(
+      files.map((file) =>
+        this.client.writeFile(
+          {
+            boxId: id,
+            fileWriteRequest: {
+              path: workspacePath(BOX_WORKSPACE, file.path),
+              content: Buffer.from(file.content).toString("base64"),
+              encoding: "base64",
+            },
+          },
+          { signal: context.signal },
+        ),
+      ),
+    );
+    const executable = files.map(
+      (file) =>
+        `${file.executable ? "700" : "600"} ${shellQuote(workspacePath(BOX_WORKSPACE, file.path))}`,
+    );
+    const result = await this.runCommand(
+      id,
+      executable.map((entry) => `chmod ${entry}`).join(" && "),
+      undefined,
+      60_000,
+      context.signal,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || result.stdout || "could not set Box file permissions");
+    }
+  }
+
+  private async listWorkspaceFiles(
+    id: string,
+    context: AdapterContext,
+  ): Promise<ComputerFileEntry[]> {
+    const result = await this.runCommand(
+      id,
+      listBoxWorkspaceFilesCommand(),
+      undefined,
+      60_000,
+      context.signal,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || result.stdout || "could not enumerate Box workspace");
+    }
+    return parseBoxFileEntries(result.stdout).filter(
+      (entry) => entry.kind === "file" && !shouldSkipPortableWorkspaceFile(entry.path),
+    );
+  }
+
+  private async stopBrowsers(id: string): Promise<void> {
+    await this.rawCommand(id, PORTABLE_BROWSER_STOP_COMMAND, 30).catch(() => undefined);
+  }
+
+  private async openBrowser(id: string): Promise<void> {
+    const result = await this.rawCommand(id, launchBoxBrowserCommand(), 30);
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || result.stdout || "Box browser is not installed");
+    }
+  }
+
+  private async readRemoteFile(
+    id: string,
+    filePath: string,
+    signal?: AbortSignal,
+  ): Promise<Uint8Array> {
+    const response = await this.client.readFile(
+      { boxId: id, path: filePath, encoding: "base64" },
+      signal ? { signal } : undefined,
+    );
+    return Uint8Array.from(Buffer.from(response.content, "base64"));
+  }
+
+  private async runCommand(
+    id: string,
+    command: string,
+    cwd: string | undefined,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<BoxCommandResult> {
+    const marker = `/tmp/rakazo-command-${randomUUID()}.completed-124`;
+    const wrapped = timeoutCommand(command, timeoutMs, marker);
+    const timeoutSeconds = Math.ceil(timeoutMs / 1_000);
+    const detached = timeoutSeconds + 5 > BOX_API_COMMAND_TIMEOUT_SECONDS;
+    try {
+      const response = await this.client.command(
+        {
+          boxId: id,
+          commandRequest: {
+            command: wrapped,
+            cwd,
+            ...(detached
+              ? { detached: true }
+              : { timeoutSeconds: Math.min(timeoutSeconds + 5, BOX_API_COMMAND_TIMEOUT_SECONDS) }),
+          },
+        },
+        signal ? { signal } : undefined,
+      );
+      const result = isFinishedCommand(response)
+        ? commandResponse(response)
+        : await this.pollCommand(id, response.processId, timeoutMs + 10_000, signal);
+      if (result.exitCode !== 124 || result.timedOut) return result;
+      const completed = await this.rawCommand(id, `test -f ${shellQuote(marker)}`, 10);
+      if (completed.exitCode === 0) {
+        await this.rawCommand(id, `rm -f -- ${shellQuote(marker)}`, 10).catch(() => undefined);
+        return result;
+      }
+      return { ...result, timedOut: true };
+    } catch (error) {
+      if (signal?.aborted || isAbortError(error)) {
+        await this.terminateCommand(id, marker).catch(() => undefined);
+      }
+      throw error;
+    }
+  }
+
+  private async pollCommand(
+    id: string,
+    processId: number,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<BoxCommandResult> {
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      if (signal?.aborted) throw signal.reason ?? new Error("command aborted");
+      const status = await this.client.commandStatus(
+        { boxId: id, processId, tailBytes: 1_000_000 },
+        signal ? { signal } : undefined,
+      );
+      if (!status.running) {
+        return {
+          stdout: status.stdout,
+          stderr: status.stderr,
+          exitCode: status.exitCode ?? 1,
+          timedOut: false,
+        };
+      }
+      if (Date.now() >= deadline) {
+        const pid = status.pid ?? processId;
+        await this.rawCommand(
+          id,
+          `kill -TERM -- -${pid} 2>/dev/null || kill -TERM ${pid} 2>/dev/null || true`,
+          10,
+        ).catch(() => undefined);
+        return { stdout: status.stdout, stderr: status.stderr, exitCode: 124, timedOut: true };
+      }
+      await delay(500, undefined, signal ? { signal } : undefined);
+    }
+  }
+
+  private async terminateCommand(id: string, marker: string): Promise<void> {
+    const pattern = marker.replace("rakazo", "[r]akazo");
+    await this.rawCommand(
+      id,
+      `pkill -TERM -f ${shellQuote(pattern)} 2>/dev/null || true; sleep 0.2; pkill -KILL -f ${shellQuote(pattern)} 2>/dev/null || true`,
+      10,
+    );
+  }
+
+  private async rawCommand(id: string, command: string, timeoutSeconds: number) {
+    const response = await this.client.command({
+      boxId: id,
+      commandRequest: { command, timeoutSeconds },
+    });
+    if (!isFinishedCommand(response)) {
+      return this.pollCommand(id, response.processId, timeoutSeconds * 1_000 + 5_000);
+    }
+    return commandResponse(response);
+  }
+
+  private ref(id: string, botId: string, fresh: boolean): ComputerRef {
+    return { id, botId, kind: "box", providerRef: id, fresh };
+  }
+
+  private id(computer: ComputerRef): string {
+    return computer.providerRef || computer.id;
+  }
+
+  private forget(id: string): void {
+    this.pendingProvisions.delete(id);
+    this.prepared.delete(id);
+    this.preparations.delete(id);
+    this.screens.release(id);
+  }
+}
+
+export function isUnrecoverableBoxError(error: unknown): boolean {
+  if (error instanceof ResponseError) return error.response.status === 404;
+  if (!error || typeof error !== "object") return false;
+  const value = error as { status?: unknown; statusCode?: unknown; code?: unknown };
+  return value.status === 404 || value.statusCode === 404 || value.code === 404;
+}
+
+function createBoxSdk(config: { apiKey: string; apiUrl?: string }): BoxSandboxSdk {
+  const apiUrl = (config.apiUrl ?? BOX_API_BASE).replace(/\/$/, "");
+  const api = new BoxApi(
+    new Configuration({
+      basePath: apiUrl,
+      accessToken: config.apiKey,
+    }),
+  );
+  return {
+    command: api.command.bind(api),
+    commandStatus: api.commandStatus.bind(api),
+    create: api.create.bind(api),
+    desktop: api.desktop.bind(api),
+    get: api.get.bind(api),
+    readFile: api.readFile.bind(api),
+    resume: api.resume.bind(api),
+    stop: api.stop.bind(api),
+    update: api.update.bind(api),
+    writeFile: api.writeFile.bind(api),
+    deleteBox: async (boxId: string) => {
+      const url = `${apiUrl}/boxes/${encodeURIComponent(boxId)}`;
+      const headers = { Authorization: `Bearer ${config.apiKey}` };
+      const response = await fetch(url, {
+        method: "DELETE",
+        headers: {
+          ...headers,
+          "X-Ascii-Confirm-Delete": boxId,
+        },
+      });
+      if (response.status === 404) return;
+      if (!response.ok) {
+        const message = await boxErrorMessage(response);
+        const error = new Error(message) as Error & { status: number };
+        error.status = response.status;
+        throw error;
+      }
+      const deadline = Date.now() + 60_000;
+      while (Date.now() < deadline) {
+        const status = await fetch(url, { headers });
+        if (status.status === 404) return;
+        if (!status.ok) {
+          const message = await boxErrorMessage(status);
+          const error = new Error(message) as Error & { status: number };
+          error.status = status.status;
+          throw error;
+        }
+        await delay(500);
+      }
+      throw new Error(`Box ${boxId} was not deleted within 60 seconds`);
+    },
+  };
+}
+
+async function boxErrorMessage(response: Response): Promise<string> {
+  const fallback = `Box API request failed with ${response.status}`;
+  try {
+    const body = (await response.json()) as { message?: unknown; requestId?: unknown };
+    const message = typeof body.message === "string" ? body.message : fallback;
+    return typeof body.requestId === "string" ? `${message} (${body.requestId})` : message;
+  } catch {
+    return fallback;
+  }
+}
+
+function timeoutCommand(command: string, timeoutMs: number, marker: string): string {
+  const seconds = Math.max(timeoutMs / 1_000, 0.001);
+  const completionScript =
+    '"$@"; status=$?; if [ "$status" -eq 124 ]; then : > "$0"; fi; exit "$status"';
+  return [
+    "timeout",
+    "--kill-after=1s",
+    `${seconds}s`,
+    "sh",
+    "-c",
+    completionScript,
+    marker,
+    "bash",
+    "-lc",
+    command,
+  ]
+    .map(shellQuote)
+    .join(" ");
+}
+
+function isFinishedCommand(response: Command200Response): response is CommandResponse {
+  return response.type === "command.finished";
+}
+
+function commandResponse(response: CommandResponse): BoxCommandResult {
+  return {
+    stdout: response.stdout,
+    stderr: response.stderr,
+    exitCode: response.exitCode ?? 1,
+    timedOut: response.timedOut,
+  };
+}
+
+function boxCwd(cwd: string | undefined): string {
+  if (
+    !cwd ||
+    cwd === "." ||
+    cwd === "/" ||
+    cwd === "/home/rakazo" ||
+    cwd === "/home/user" ||
+    cwd === BOX_WORKSPACE
+  ) {
+    return "rakazo-home";
+  }
+  const relative = cwd.startsWith(`${BOX_WORKSPACE}/`)
+    ? cwd.slice(BOX_WORKSPACE.length + 1)
+    : cwd.startsWith("/home/rakazo/")
+      ? cwd.slice("/home/rakazo/".length)
+      : cwd;
+  return path.posix.join("rakazo-home", normalizeWorkspacePath(relative));
+}
+
+function configureBoxWorkspaceCommand(): string {
+  const chrome = `${BOX_BROWSER_PROFILES}/chromium`;
+  const firefox = `${BOX_BROWSER_PROFILES}/firefox`;
+  return [
+    `mkdir -p ${shellQuote(chrome)} ${shellQuote(firefox)} /home/user/.config`,
+    `if [ "$(readlink -f /home/user/.config/google-chrome 2>/dev/null)" != ${shellQuote(chrome)} ] || [ "$(readlink -f /home/user/.config/chromium 2>/dev/null)" != ${shellQuote(chrome)} ] || [ "$(readlink -f /home/user/.mozilla 2>/dev/null)" != ${shellQuote(firefox)} ]; then`,
+    "  rm -rf /home/user/.config/google-chrome /home/user/.config/chromium /home/user/.mozilla",
+    `  ln -s ${shellQuote(chrome)} /home/user/.config/google-chrome`,
+    `  ln -s ${shellQuote(chrome)} /home/user/.config/chromium`,
+    `  ln -s ${shellQuote(firefox)} /home/user/.mozilla`,
+    "fi",
+  ].join("\n");
+}
+
+function launchBoxBrowserCommand(): string {
+  return [
+    "for app in google-chrome-stable google-chrome chromium firefox; do",
+    '  if command -v "$app" >/dev/null 2>&1; then',
+    '    nohup env DISPLAY=:0 "$app" --no-first-run --no-default-browser-check --start-maximized >/tmp/rakazo-browser.log 2>&1 &',
+    "    sleep 1",
+    "    DISPLAY=:0 wmctrl -r :ACTIVE: -b add,maximized_vert,maximized_horz 2>/dev/null || true",
+    "    exit 0",
+    "  fi",
+    "done",
+    "exit 1",
+  ].join("\n");
+}
+
+function observeBoxCommand(imagePath: string): string {
+  return [
+    `DISPLAY=:0 import -window root ${shellQuote(imagePath)}`,
+    `test -s ${shellQuote(imagePath)}`,
+    "set -- $(DISPLAY=:0 xdotool getdisplaygeometry 2>/dev/null || printf '1920 1080')",
+    'printf \'WIDTH=%s\\nHEIGHT=%s\\n\' "$1" "$2"',
+    "DISPLAY=:0 xdotool getmouselocation --shell 2>/dev/null || true",
+    "window=$(DISPLAY=:0 xdotool getactivewindow 2>/dev/null || true)",
+    "printf 'WINDOW=%s\\n' \"$window\"",
+    'if [ -n "$window" ]; then title=$(DISPLAY=:0 xdotool getwindowname "$window" 2>/dev/null | base64 -w0 || true); printf \'TITLE=%s\\n\' "$title"; fi',
+  ].join("\n");
+}
+
+function parseBoxObservation(image: Uint8Array, metadata: string): ComputerObservation {
+  const number = (name: string, fallback: number) =>
+    Number(metadata.match(new RegExp(`(?:^|\\n)${name}=(\\d+)`))?.[1]) || fallback;
+  const windowId = metadata.match(/(?:^|\n)WINDOW=(\d+)/)?.[1];
+  const encodedTitle = metadata.match(/(?:^|\n)TITLE=([^\n]*)/)?.[1];
+  const title = encodedTitle ? Buffer.from(encodedTitle, "base64").toString("utf8") : undefined;
+  const x = metadata.match(/(?:^|\n)X=(\d+)/)?.[1];
+  const y = metadata.match(/(?:^|\n)Y=(\d+)/)?.[1];
+  return computerObservation(image, {
+    mimeType: "image/png",
+    width: number("WIDTH", 1920),
+    height: number("HEIGHT", 1080),
+    ...(x && y ? { cursor: { x: Number(x), y: Number(y) } } : {}),
+    ...(windowId ? { activeWindow: { id: windowId, title } } : {}),
+  });
+}
+
+function listBoxFilesCommand(directory: string): string {
+  return [
+    "set -o pipefail",
+    `directory=${shellQuote(directory)}`,
+    'test -d "$directory"',
+    'find "$directory" -mindepth 1 -maxdepth 1 -print0 | sort -z | while IFS= read -r -d "" entry; do',
+    '  if [ -d "$entry" ]; then kind=dir; elif [ -f "$entry" ]; then kind=file; else continue; fi',
+    '  encoded=$(printf %s "$entry" | base64 -w0)',
+    '  size=$(stat -c %s "$entry")',
+    '  if [ "$kind" = file ] && [ -x "$entry" ]; then executable=1; else executable=0; fi',
+    '  printf \'%s\\t%s\\t%s\\t%s\\n\' "$encoded" "$kind" "$size" "$executable"',
+    "done",
+  ].join("\n");
+}
+
+function listBoxWorkspaceFilesCommand(): string {
+  return [
+    "set -o pipefail",
+    `find ${shellQuote(BOX_WORKSPACE)} -type f -print0 | sort -z | while IFS= read -r -d "" entry; do`,
+    '  encoded=$(printf %s "$entry" | base64 -w0)',
+    '  size=$(stat -c %s "$entry")',
+    '  if [ -x "$entry" ]; then executable=1; else executable=0; fi',
+    '  printf \'%s\\tfile\\t%s\\t%s\\n\' "$encoded" "$size" "$executable"',
+    "done",
+  ].join("\n");
+}
+
+function parseBoxFileEntries(output: string): ComputerFileEntry[] {
+  return output
+    .split("\n")
+    .filter(Boolean)
+    .flatMap((line): ComputerFileEntry[] => {
+      const [encoded, kind, size, executable] = line.split("\t");
+      if (!encoded || (kind !== "file" && kind !== "dir")) return [];
+      const absolute = Buffer.from(encoded, "base64").toString("utf8");
+      if (!absolute.startsWith(`${BOX_WORKSPACE}/`)) return [];
+      const child = normalizeWorkspacePath(absolute.slice(BOX_WORKSPACE.length + 1));
+      return [
+        {
+          path: child,
+          kind,
+          size: Number(size) || 0,
+          ...(kind === "file" && executable === "1" ? { executable: true } : {}),
+        },
+      ];
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function boxActionCommand(action: Exclude<ComputerAction, { kind: "wait" }>): string {
+  if (action.kind === "scroll") {
+    const repeat = clampRounded(action.amount ?? 3, 1, 20);
+    return `DISPLAY=:0 xdotool click --repeat ${repeat} ${action.direction === "up" ? "4" : "5"}`;
+  }
+  if (action.kind === "key") {
+    const keys = [...(action.modifiers ?? []), action.key].join("+");
+    return `DISPLAY=:0 xdotool key ${shellQuote(keys)}`;
+  }
+  if (action.kind === "clipboard") {
+    return `DISPLAY=:0 xdotool type --delay 1 -- ${shellQuote(action.text)}`;
+  }
+  if (action.kind === "pointer") {
+    const button = action.button === "right" ? "3" : "1";
+    if (action.type === "move") return `DISPLAY=:0 xdotool mousemove ${action.x} ${action.y}`;
+    if (action.type === "down") {
+      return `DISPLAY=:0 xdotool mousemove ${action.x} ${action.y} mousedown ${button}`;
+    }
+    if (action.type === "up") {
+      return `DISPLAY=:0 xdotool mousemove ${action.x} ${action.y} mouseup ${button}`;
+    }
+    return `DISPLAY=:0 xdotool mousemove ${action.x} ${action.y} click ${button}`;
+  }
+  if (action.kind === "open") {
+    const target = /^https?:\/\//i.test(action.path)
+      ? action.path
+      : workspacePath(BOX_WORKSPACE, action.path);
+    return `nohup env DISPLAY=:0 xdg-open ${shellQuote(target)} >/tmp/rakazo-open.log 2>&1 &`;
+  }
+  const applications =
+    action.application === "browser"
+      ? ["google-chrome-stable", "google-chrome", "chromium", "firefox"]
+      : [action.application];
+  return [
+    `for app in ${applications.map(shellQuote).join(" ")}; do`,
+    '  if command -v "$app" >/dev/null 2>&1; then',
+    `    nohup env DISPLAY=:0 "$app"${action.uri ? ` ${shellQuote(action.uri)}` : ""} >/tmp/rakazo-app.log 2>&1 &`,
+    "    exit 0",
+    "  fi",
+    "done",
+    "exit 1",
+  ].join("\n");
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || /aborted/i.test(error.message));
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./artifacts.js";
 export * from "./background-job-handlers.js";
+export * from "./box-emulator.js";
+export * from "./box-sandbox.js";
 export * from "./builtin-tools.js";
 export * from "./child-bots.js";
 export * from "./composio-catalog-cache.js";

--- a/packages/adapters/src/sandbox-conformance.test.ts
+++ b/packages/adapters/src/sandbox-conformance.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { ComputerRef, ProcessEvent, SandboxProvider } from "@rakazo/adapter-kit";
 import { afterAll, describe, expect, it } from "vitest";
+import { BoxSandboxEmulator } from "./box-emulator.js";
 import { DaytonaSandboxEmulator } from "./daytona-emulator.js";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
 import { DockerSandboxProvider } from "./docker-sandbox.js";
@@ -33,24 +34,29 @@ describe("sandbox conformance", () => {
     const fake = new FakeSandboxProvider();
     const managed = new ManagedSandboxEmulator();
     const daytona = new DaytonaSandboxEmulator();
+    const box = new BoxSandboxEmulator();
     const desktop = new DesktopSandboxProvider();
     const a = await provisionPrepared(fake, { botId: "bot-a", homePath: "/tmp/a" }, ctx);
     const b = await provisionPrepared(managed, { botId: "bot-b", homePath: "/tmp/b" }, ctx);
     const c = await provisionPrepared(daytona, { botId: "bot-c", homePath: "/tmp/c" }, ctx);
-    const d = await provisionPrepared(desktop, { botId: "bot-d", homePath: "/tmp/d" }, ctx);
+    const d = await provisionPrepared(box, { botId: "bot-d", homePath: "/tmp/d" }, ctx);
+    const e = await provisionPrepared(desktop, { botId: "bot-e", homePath: "/tmp/e" }, ctx);
     const outA = await drain(fake, a);
     const outB = await drain(managed, b);
     const outC = await drain(daytona, c);
-    const outD = await drain(desktop, d);
+    const outD = await drain(box, d);
+    const outE = await drain(desktop, e);
     expect(outA).toContain("graphical-ok");
     expect(outB).toContain("graphical-ok");
     expect(outC).toContain("graphical-ok");
     expect(outD).toContain("graphical-ok");
-    expect(new Set([a.id, b.id, c.id, d.id]).size).toBe(4);
+    expect(outE).toContain("graphical-ok");
+    expect(new Set([a.id, b.id, c.id, d.id, e.id]).size).toBe(5);
     await fake.destroy(a, ctx);
     await managed.destroy(b, ctx);
     await daytona.destroy(c, ctx);
-    await desktop.destroy(d, ctx);
+    await box.destroy(d, ctx);
+    await desktop.destroy(e, ctx);
   });
 
   it("offers the same observation, action, and workspace contract across providers", async () => {
@@ -58,6 +64,7 @@ describe("sandbox conformance", () => {
       new FakeSandboxProvider(),
       new ManagedSandboxEmulator(),
       new DaytonaSandboxEmulator(),
+      new BoxSandboxEmulator(),
       new DesktopSandboxProvider(),
     ];
     for (const [index, provider] of providers.entries()) {

--- a/packages/adapters/src/sandbox-factory.test.ts
+++ b/packages/adapters/src/sandbox-factory.test.ts
@@ -10,16 +10,22 @@ describe("createSandboxProvider", () => {
   it("returns provider-specific managed sandbox emulators", () => {
     expect(createSandboxProvider("e2b-emulator", {}).describe().id).toBe("e2b-emulator");
     expect(createSandboxProvider("daytona-emulator", {}).describe().id).toBe("daytona-emulator");
+    expect(createSandboxProvider("box-emulator", {}).describe()).toMatchObject({
+      id: "box-emulator",
+      capabilities: { multiScreen: false },
+    });
   });
 
   it("requires provider-specific credentials", () => {
     expect(() => createSandboxProvider("e2b", {})).toThrow(/E2B_API_KEY/);
     expect(() => createSandboxProvider("daytona", {})).toThrow(/DAYTONA_API_KEY/);
+    expect(() => createSandboxProvider("box", {})).toThrow(/BOX_API_KEY/);
+    expect(createSandboxProvider("box", { boxApiKey: "test-box-key" }).describe().id).toBe("box");
   });
 
   it("throws on unknown provider", () => {
     expect(() => createSandboxProvider("bogus", {})).toThrow(
-      'Unknown SANDBOX_PROVIDER "bogus". Use docker | e2b | daytona | e2b-emulator | daytona-emulator | desktop | fake.',
+      'Unknown SANDBOX_PROVIDER "bogus". Use docker | e2b | daytona | box | e2b-emulator | daytona-emulator | box-emulator | desktop | fake.',
     );
   });
 });

--- a/packages/adapters/src/sandbox-factory.ts
+++ b/packages/adapters/src/sandbox-factory.ts
@@ -1,4 +1,6 @@
 import type { SandboxProvider } from "@rakazo/adapter-kit";
+import { BoxSandboxEmulator } from "./box-emulator.js";
+import { BoxSandboxProvider } from "./box-sandbox.js";
 import { DaytonaSandboxEmulator } from "./daytona-emulator.js";
 import { DaytonaSandboxProvider } from "./daytona-sandbox.js";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
@@ -14,6 +16,8 @@ export interface SandboxProviderOptions {
   daytonaApiKey?: string;
   daytonaApiUrl?: string;
   daytonaTarget?: string;
+  boxApiKey?: string;
+  boxApiUrl?: string;
   dataDir?: string;
 }
 
@@ -31,6 +35,9 @@ export function createSandboxProvider(kind: string, opts: SandboxProviderOptions
         apiUrl: opts.daytonaApiUrl,
         target: opts.daytonaTarget,
       });
+    case "box":
+      if (!opts.boxApiKey) throw new Error("BOX_API_KEY is required for the box sandbox provider");
+      return new BoxSandboxProvider({ apiKey: opts.boxApiKey, apiUrl: opts.boxApiUrl });
     case "docker":
       return new DockerSandboxProvider(
         opts.supervisorUrl ?? "http://127.0.0.1:7091",
@@ -40,6 +47,8 @@ export function createSandboxProvider(kind: string, opts: SandboxProviderOptions
       return new ManagedSandboxEmulator();
     case "daytona-emulator":
       return new DaytonaSandboxEmulator();
+    case "box-emulator":
+      return new BoxSandboxEmulator();
     case "desktop":
       return new DesktopSandboxProvider({
         root: opts.dataDir,
@@ -48,7 +57,7 @@ export function createSandboxProvider(kind: string, opts: SandboxProviderOptions
       return new FakeSandboxProvider();
     default:
       throw new Error(
-        `Unknown SANDBOX_PROVIDER "${kind}". Use docker | e2b | daytona | e2b-emulator | daytona-emulator | desktop | fake.`,
+        `Unknown SANDBOX_PROVIDER "${kind}". Use docker | e2b | daytona | box | e2b-emulator | daytona-emulator | box-emulator | desktop | fake.`,
       );
   }
 }

--- a/packages/adapters/src/sandbox-faults.test.ts
+++ b/packages/adapters/src/sandbox-faults.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { PortableFile, SandboxProvider } from "@rakazo/adapter-kit";
 import { afterEach, describe, expect, it } from "vitest";
+import { BoxSandboxEmulator } from "./box-emulator.js";
 import { DaytonaSandboxEmulator } from "./daytona-emulator.js";
 import { DesktopSandboxProvider } from "./desktop-sandbox.js";
 import { ManagedSandboxEmulator } from "./e2b-emulator.js";
@@ -29,6 +30,7 @@ describe.each([
   ["fake", () => Promise.resolve(new FakeSandboxProvider())],
   ["managed emulator", () => Promise.resolve(new ManagedSandboxEmulator())],
   ["Daytona emulator", () => Promise.resolve(new DaytonaSandboxEmulator())],
+  ["Box emulator", () => Promise.resolve(new BoxSandboxEmulator())],
   [
     "desktop",
     async () => {
@@ -268,6 +270,7 @@ async function providerSet(label: string): Promise<Array<[string, SandboxProvide
     ["fake", new FakeSandboxProvider()],
     ["managed", new ManagedSandboxEmulator()],
     ["daytona", new DaytonaSandboxEmulator()],
+    ["box", new BoxSandboxEmulator()],
     ["desktop", new DesktopSandboxProvider({ root: await realpath(root) })],
   ];
 }

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -39,5 +39,5 @@ export type EffectStatus = z.infer<typeof EffectStatus>;
 export const MemoryScope = z.enum(["bot", "user"]);
 export type MemoryScope = z.infer<typeof MemoryScope>;
 
-export const SandboxKind = z.enum(["docker", "e2b", "daytona", "desktop", "fake"]);
+export const SandboxKind = z.enum(["docker", "e2b", "daytona", "box", "desktop", "fake"]);
 export type SandboxKind = z.infer<typeof SandboxKind>;

--- a/packages/testkit/src/cli/canary.ts
+++ b/packages/testkit/src/cli/canary.ts
@@ -4,8 +4,10 @@ import { PostgreSqlContainer } from "@testcontainers/postgresql";
 
 async function main() {
   const runOpenRouter = Boolean(process.env.OPENROUTER_API_KEY);
-  if (!process.env.E2B_API_KEY && !runOpenRouter) {
-    throw new Error("E2B_API_KEY or OPENROUTER_API_KEY is required for live provider canaries");
+  if (!process.env.E2B_API_KEY && !process.env.BOX_API_KEY && !runOpenRouter) {
+    throw new Error(
+      "E2B_API_KEY, BOX_API_KEY, or OPENROUTER_API_KEY is required for live provider canaries",
+    );
   }
 
   const postgres = runOpenRouter

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -19,8 +19,8 @@ const e2eGrep = grepArg?.slice("--grep=".length);
 if (Number(integration) + Number(e2e) !== 1) {
   throw new Error("Pass exactly one of --integration or --e2e");
 }
-if (!["fake", "e2b", "daytona"].includes(sandboxProvider)) {
-  throw new Error('Sandbox must be "fake", "e2b", or "daytona"');
+if (!["fake", "e2b", "daytona", "box"].includes(sandboxProvider)) {
+  throw new Error('Sandbox must be "fake", "e2b", "daytona", or "box"');
 }
 if (integration && sandboxProvider !== "fake") {
   throw new Error("Integration tests only support the fake sandbox");
@@ -30,6 +30,9 @@ if (sandboxProvider === "e2b" && !process.env.E2B_API_KEY) {
 }
 if (sandboxProvider === "daytona" && !process.env.DAYTONA_API_KEY) {
   throw new Error("DAYTONA_API_KEY is required when --sandbox=daytona");
+}
+if (sandboxProvider === "box" && !process.env.BOX_API_KEY) {
+  throw new Error("BOX_API_KEY is required when --sandbox=box");
 }
 
 async function main() {
@@ -176,7 +179,7 @@ async function main() {
               {
                 id: computer.providerRef!,
                 botId: computer.homeKey,
-                kind: computer.kind as "e2b" | "daytona",
+                kind: computer.kind as "e2b" | "daytona" | "box",
                 providerRef: computer.providerRef!,
               },
               {
@@ -210,7 +213,7 @@ type AppHandles = Awaited<
 >;
 
 async function managedComputers(handles: AppHandles) {
-  if (sandboxProvider !== "e2b" && sandboxProvider !== "daytona") return [];
+  if (!["e2b", "daytona", "box"].includes(sandboxProvider)) return [];
   return handles.prisma.computer.findMany({
     where: { providerRef: { not: null } },
     select: { homeKey: true, kind: true, providerRef: true, userId: true, workspaceId: true },

--- a/packages/testkit/src/providers.canary.test.ts
+++ b/packages/testkit/src/providers.canary.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { E2BSandboxProvider, PiAgentRuntime } from "@rakazo/adapters";
+import { BoxSandboxProvider, E2BSandboxProvider, PiAgentRuntime } from "@rakazo/adapters";
 import { afterAll, describe, expect, it } from "vitest";
 import { sessionCookieHeader } from "./index.js";
 
@@ -15,17 +15,19 @@ function loadEnvFile() {
     if (eq < 1) continue;
     const key = trimmed.slice(0, eq);
     const value = trimmed.slice(eq + 1).replace(/^["']|["']$/g, "");
-    if (!process.env[key]) process.env[key] = value;
+    if (!(key in process.env)) process.env[key] = value;
   }
 }
 
 loadEnvFile();
 
 const liveE2b = Boolean(process.env.VERIFY_PROVIDERS && process.env.E2B_API_KEY);
+const liveBox = Boolean(process.env.VERIFY_PROVIDERS && process.env.BOX_API_KEY);
 const livePi = Boolean(process.env.VERIFY_PROVIDERS && process.env.OPENROUTER_API_KEY);
 const livePiApp = Boolean(livePi && process.env.DATABASE_URL);
 
 const describeE2b = liveE2b ? describe : describe.skip;
+const describeBox = liveBox ? describe : describe.skip;
 const describePi = livePi ? describe : describe.skip;
 const describePiApp = livePiApp ? describe : describe.skip;
 
@@ -55,6 +57,52 @@ describeE2b("live E2B canary", () => {
       await sandbox.destroy(computer, ctx);
     }
   }, 120_000);
+});
+
+describeBox("live Box canary", () => {
+  it("provisions a desktop, observes it, preserves a file across stop/resume, and destroys it", async () => {
+    const sandbox = new BoxSandboxProvider({
+      apiKey: process.env.BOX_API_KEY!,
+      apiUrl: process.env.BOX_API_URL ?? process.env.BOX_BASE_URL,
+    });
+    const ctx = {
+      operationId: "box-canary",
+      traceId: "box-canary",
+      workspaceId: "box-canary",
+      userId: "box-canary",
+      signal: new AbortController().signal,
+    };
+    const request = { botId: "box-canary", homePath: "/home/user/rakazo-home" };
+    let computer = await sandbox.provision(request, ctx);
+    try {
+      await sandbox.prepare(computer, ctx);
+      let stdout = "";
+      for await (const event of sandbox.execute(computer, { argv: ["echo", "box-ok"] }, ctx)) {
+        if (event.type === "stdout") stdout += event.data;
+        if (event.type === "exit") expect(event.code).toBe(0);
+      }
+      expect(stdout).toContain("box-ok");
+      await sandbox.writeFile(
+        computer,
+        { path: "canary.txt", content: new TextEncoder().encode("preserved") },
+        ctx,
+      );
+      expect((await sandbox.observe(computer, ctx)).image.byteLength).toBeGreaterThan(0);
+
+      await sandbox.stop(computer, ctx);
+      computer = await sandbox.provision(
+        { ...request, providerRef: computer.providerRef, providerKind: computer.kind },
+        ctx,
+      );
+      expect(computer.fresh).toBe(false);
+      await sandbox.prepare(computer, ctx);
+      expect(new TextDecoder().decode(await sandbox.readFile(computer, "canary.txt", ctx))).toBe(
+        "preserved",
+      );
+    } finally {
+      await sandbox.destroy(computer, ctx);
+    }
+  }, 240_000);
 });
 
 describePi("live OpenRouter / Pi canary", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
 
   packages/adapters:
     dependencies:
+      '@asciidev/box-sdk':
+        specifier: ^0.0.28
+        version: 0.0.28
       '@composio/core':
         specifier: 0.16.0
         version: 0.16.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3)
@@ -640,6 +643,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asciidev/box-sdk@0.0.28':
+    resolution: {integrity: sha512-IaDFZ5dP3XrbbI87rH2Exhrp9JCUGiCwzdTY8HKBiq7TOyzgx1mX5OrPJuy1VV0wR1pLDX+9esnqekhkR0+OJA==}
 
   '@astrojs/check@0.9.10':
     resolution: {integrity: sha512-zgx/UQMozdjOa3bOxjgeCFdtpE3c9rRX6xHwa+2QXvy8z8Akifu2AtubHyv/zzC2znO8dl8fFWL4K+Ba9kS8HQ==}
@@ -8557,6 +8563,8 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
+
+  '@asciidev/box-sdk@0.0.28': {}
 
   '@astrojs/check@0.9.10(prettier@3.9.6)(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- add an official ASCII Box sandbox adapter with lifecycle, shell, files, workspace checkpoint/restore, browser streaming, screenshots, and computer actions
- add Box configuration, factory/contracts, canary and Playwright wiring, docs, and deterministic emulator/conformance/fault tests
- enforce Box's single-desktop limitation while keeping shell/files usable in parallel

## Live validation

- real Box canary passed
- targeted Rakazo UI journey passed against a live Box (onboarding, protected input, noVNC takeover, release/resume, routine/plugins/export)
- independent real computer-use pointer click verified against a live Box
- cleaned up all live boxes; no API key is included in the commit

## Verification

- `pnpm lint`
- `pnpm check`
- `pnpm test` (415 passed, 44 skipped)
- `git diff --check`

The Box trial account hit its daily request limit during an extra post-validation rerun; that retry created no box. Pre-existing local Currents/desktop/docs changes remain unstaged and are not part of this PR.