### PR TITLE
Harden Box view-only desktop proxy

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1043,7 +1043,13 @@ export function createRouter(deps: RouterDeps) {
           !(hasActiveComputerControl(bot.computer) && bot.computer.controlBotId === bot.id),
         );
         return {
-          url: addScreenProxyCapability(viewUrl, deps.env.screenProxySecret, deps.env.webOrigin),
+          url: addScreenProxyCapability(
+            viewUrl,
+            deps.env.screenProxySecret,
+            deps.env.webOrigin,
+            undefined,
+            { proxyExternal: bot.computer.kind === "box" },
+          ),
         };
       }),
       heartbeat: authed.computer.heartbeat.handler(async ({ context, input }) => {

--- a/apps/api/src/screen-proxy.test.ts
+++ b/apps/api/src/screen-proxy.test.ts
@@ -22,4 +22,19 @@ describe("screen proxy capability", () => {
     const url = "https://sandbox.example/embed.html?token=provider-token";
     expect(addScreenProxyCapability(url, "secret", "https://app.example", 100)).toBe(url);
   });
+
+  it("keeps external desktop secrets behind an encrypted, policy-bound capability", () => {
+    const result = new URL(
+      addScreenProxyCapability(
+        "https://box.example/vnc.html?token=provider-token&view_only=true",
+        "secret",
+        "https://app.example",
+        100,
+        { proxyExternal: true },
+      ),
+    );
+    expect(result.origin).toBe("https://app.example");
+    expect(result.pathname).toMatch(/^\/novnc\/remote\/view\/3600100\.[\w-]+\/vnc\.html$/);
+    expect(result.toString()).not.toContain("provider-token");
+  });
 });

--- a/apps/api/src/screen-proxy.ts
+++ b/apps/api/src/screen-proxy.ts
@@ -1,15 +1,30 @@
-import { createHmac } from "node:crypto";
+import { createCipheriv, createHash, createHmac, randomBytes } from "node:crypto";
 
 const SCREEN_PROXY_TTL_MS = 60 * 60_000;
+const SCREEN_PROXY_CIPHER = "aes-256-gcm";
+const SCREEN_PROXY_REMOTE_PREFIX = "/novnc/remote";
+
+export interface ScreenProxyOptions {
+  /** Keep provider desktop secrets server-side and enforce the view/control policy in the proxy. */
+  proxyExternal?: boolean;
+}
 
 export function addScreenProxyCapability(
   url: string,
   secret: string,
   proxyOrigin: string,
   now = Date.now(),
+  options: ScreenProxyOptions = {},
 ): string {
   try {
     const parsed = new URL(url);
+    if (options.proxyExternal && parsed.protocol === "https:" && parsed.hostname) {
+      const expiresAt = now + SCREEN_PROXY_TTL_MS;
+      const policy = parsed.searchParams.get("view_only") === "false" ? "control" : "view";
+      const token = sealScreenTarget(parsed.toString(), secret, policy, expiresAt);
+      const origin = new URL(proxyOrigin).origin;
+      return `${origin}${SCREEN_PROXY_REMOTE_PREFIX}/${policy}/${expiresAt}.${token}${parsed.pathname || "/"}`;
+    }
     if (parsed.protocol !== "http:" || !parsed.hostname || !parsed.port) return url;
     const expiresAt = now + SCREEN_PROXY_TTL_MS;
     const target = Buffer.from(parsed.hostname).toString("base64url");
@@ -23,4 +38,21 @@ export function addScreenProxyCapability(
   } catch {
     return url;
   }
+}
+
+function sealScreenTarget(
+  url: string,
+  secret: string,
+  policy: "view" | "control",
+  expiresAt: number,
+) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(SCREEN_PROXY_CIPHER, screenProxyKey(secret), iv);
+  cipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
+  const ciphertext = Buffer.concat([cipher.update(url, "utf8"), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString("base64url");
+}
+
+function screenProxyKey(secret: string) {
+  return createHash("sha256").update(secret).digest();
 }

--- a/apps/web/src/screen-proxy.test.ts
+++ b/apps/web/src/screen-proxy.test.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createCipheriv, createHash, createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   resolveNovncTarget,
@@ -20,6 +20,20 @@ function signedPath(
     .digest("base64url");
   const target = Buffer.from(hostname).toString("base64url");
   return `/novnc/${target}/${port}/${policy}/${expiresAt}.${signature}${rest}`;
+}
+
+function remotePath(
+  expiresAt: number,
+  secret: string,
+  url: string,
+  policy: "view" | "control" = "view",
+) {
+  const iv = Buffer.alloc(12, 1);
+  const cipher = createCipheriv("aes-256-gcm", createHash("sha256").update(secret).digest(), iv);
+  cipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
+  const ciphertext = Buffer.concat([cipher.update(url, "utf8"), cipher.final()]);
+  const token = Buffer.concat([iv, cipher.getAuthTag(), ciphertext]).toString("base64url");
+  return `/novnc/remote/${policy}/${expiresAt}.${token}/vnc.html`;
 }
 
 describe("noVNC proxy authorization", () => {
@@ -66,6 +80,25 @@ describe("noVNC proxy authorization", () => {
       path: "/embed.html?view_only=false",
       interactive: true,
     });
+  });
+
+  it("keeps encrypted external Box targets bound to their view/control policy", () => {
+    const target = "https://box.example/vnc.html?token=provider-secret&view_only=true";
+    const view = remotePath(2_000, "secret", target);
+    expect(resolveNovncTarget(view, "secret", 1_000)).toMatchObject({
+      protocol: "https:",
+      hostname: "box.example",
+      port: 443,
+      path: "/vnc.html?token=provider-secret&view_only=true",
+      interactive: false,
+    });
+    expect(
+      resolveNovncTarget(view.replace("/vnc.html", "/vnc.html?view_only=false"), "secret", 1_000),
+    ).toMatchObject({
+      path: "/vnc.html?token=provider-secret&view_only=true",
+      interactive: false,
+    });
+    expect(resolveNovncTarget(view.replace("/view/", "/control/"), "secret", 1_000)).toBeNull();
   });
 
   it("does not forward application credentials", () => {

--- a/apps/web/src/screen-proxy.ts
+++ b/apps/web/src/screen-proxy.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createDecipheriv, createHash, createHmac, timingSafeEqual } from "node:crypto";
 import type { IncomingHttpHeaders } from "node:http";
 
 const SENSITIVE_FORWARD_HEADERS = new Set([
@@ -9,12 +9,34 @@ const SENSITIVE_FORWARD_HEADERS = new Set([
   "proxy-authorization",
 ]);
 const SENSITIVE_RESPONSE_HEADERS = new Set(["clear-site-data", "set-cookie", "set-cookie2"]);
+const SCREEN_PROXY_CIPHER = "aes-256-gcm";
 
 export function resolveNovncTarget(url: string | undefined, secret: string, now = Date.now()) {
   const match = url?.match(
     /^\/novnc\/([A-Za-z0-9_-]+)\/(\d+)\/(view|control)\/(\d+)\.([A-Za-z0-9_-]{43})(\/[^?]*)?(\?.*)?$/,
   );
-  if (!match) return null;
+  if (match) return resolveLocalTarget(match, secret, now);
+
+  const remoteMatch = url?.match(
+    /^\/novnc\/remote\/(view|control)\/(\d+)\.([A-Za-z0-9_-]+)(\/[^?]*)?(\?.*)?$/,
+  );
+  if (!remoteMatch) return null;
+  const policy = remoteMatch[1]! as "view" | "control";
+  const expiresAt = Number(remoteMatch[2]);
+  if (!Number.isInteger(expiresAt) || expiresAt < now) return null;
+  const target = openScreenTarget(remoteMatch[3]!, secret, policy, expiresAt);
+  if (target?.protocol !== "https:") return null;
+  const requestedPath = `${remoteMatch[4] || target.pathname || "/"}${remoteMatch[5] || ""}`;
+  return {
+    protocol: target.protocol,
+    hostname: target.hostname,
+    port: Number(target.port || 443),
+    path: screenPolicyPath(remoteTargetPath(target, requestedPath), policy === "control"),
+    interactive: policy === "control",
+  };
+}
+
+function resolveLocalTarget(match: RegExpMatchArray, secret: string, now: number) {
   const hostname = Buffer.from(match[1]!, "base64url").toString("utf8");
   const port = Number(match[2]);
   const policy = match[3]! as "view" | "control";
@@ -44,10 +66,44 @@ export function resolveNovncTarget(url: string | undefined, secret: string, now 
 
 export function screenPolicyPath(requestedPath: string, interactive: boolean) {
   const parsed = new URL(requestedPath, "http://screen.invalid");
-  if (parsed.pathname === "/embed.html") {
-    return `/embed.html?view_only=${interactive ? "false" : "true"}`;
+  if (parsed.pathname === "/embed.html" || parsed.pathname === "/vnc.html") {
+    parsed.searchParams.set("view_only", interactive ? "false" : "true");
   }
-  return parsed.pathname;
+  return `${parsed.pathname}${parsed.search}`;
+}
+
+function remoteTargetPath(target: URL, requestedPath: string) {
+  const requested = new URL(requestedPath, "https://screen.invalid");
+  const path = requested.pathname || target.pathname || "/";
+  if (path === target.pathname || path === "/websockify") {
+    return `${path}${target.search}`;
+  }
+  return `${path}${requested.search}`;
+}
+
+function openScreenTarget(
+  token: string,
+  secret: string,
+  policy: "view" | "control",
+  expiresAt: number,
+) {
+  try {
+    const sealed = Buffer.from(token, "base64url");
+    if (sealed.length <= 28) return null;
+    const decipher = createDecipheriv(
+      SCREEN_PROXY_CIPHER,
+      createHash("sha256").update(secret).digest(),
+      sealed.subarray(0, 12),
+    );
+    decipher.setAAD(Buffer.from(`${policy}:${expiresAt}`));
+    decipher.setAuthTag(sealed.subarray(12, 28));
+    const target = new URL(
+      Buffer.concat([decipher.update(sealed.subarray(28)), decipher.final()]).toString("utf8"),
+    );
+    return target.hostname && target.protocol === "https:" ? target : null;
+  } catch {
+    return null;
+  }
 }
 
 function isAllowedTargetName(hostname: string) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,8 @@
 import http from "node:http";
+import https from "node:https";
 import net from "node:net";
 import path from "node:path";
+import tls from "node:tls";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv, type PreviewServer, type ViteDevServer } from "vite";
@@ -30,13 +32,15 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string)
       ...safeProxyHeaders(req.headers),
       host: `${target.hostname}:${target.port}`,
     };
-    const upstream = http.request(
+    const transport = target.protocol === "https:" ? https : http;
+    const upstream = transport.request(
       {
         hostname: target.hostname,
         port: target.port,
         path: target.path,
         method: req.method,
         headers,
+        ...(target.protocol === "https:" ? { servername: target.hostname } : {}),
       },
       (incoming) => {
         res.writeHead(incoming.statusCode ?? 502, {
@@ -60,7 +64,11 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string)
       socket.destroy();
       return;
     }
-    const upstream = net.connect(target.port, target.hostname, () => {
+    const upstream =
+      target.protocol === "https:"
+        ? tls.connect({ port: target.port, host: target.hostname, servername: target.hostname })
+        : net.connect(target.port, target.hostname);
+    upstream.once(target.protocol === "https:" ? "secureConnect" : "connect", () => {
       const headerLines = [
         `${req.method ?? "GET"} ${target.path} HTTP/1.1`,
         `Host: ${target.hostname}:${target.port}`,

--- a/docs/computer-runtime.md
+++ b/docs/computer-runtime.md
@@ -41,7 +41,7 @@ The database stores the provider kind and opaque `providerRef`. That reference i
 
 ## Box backend
 
-The Box adapter uses ASCII's official TypeScript SDK for lifecycle, command, desktop, and file operations. It creates and resumes boxes with `noEnv: true`, as required when a third party supplies the API key, and keeps a two-hour TTL refreshed while the computer is active. The provider's authenticated noVNC page is embedded for human viewing and takeover; observations and model actions use the same primary `DISPLAY=:0` through ImageMagick and `xdotool`.
+The Box adapter uses ASCII's official TypeScript SDK for lifecycle, command, desktop, and file operations. It creates and resumes boxes with `noEnv: true`, as required when a third party supplies the API key, and keeps a two-hour TTL refreshed while the computer is active. The provider's authenticated noVNC page is kept behind Rakazo's encrypted screen capability proxy, which binds the view/control policy and keeps the Box desktop secret out of browser-visible URLs; observations and model actions use the same primary `DISPLAY=:0` through ImageMagick and `xdotool`.
 
 Box stop archives the machine and resume reconnects the same opaque box id. Browser profiles live under the portable workspace and are linked into the machine's Chrome/Firefox config, so normal checkpoint/export behavior includes them. Box has one desktop stream per machine, and the Box emulator reproduces that single-screen constraint for deterministic tests.
 


### PR DESCRIPTION
## Summary

Follow-up to #80. Box's desktop API returns a secret-bearing noVNC URL but does not expose a separate server-bound read-only stream. This PR keeps that provider URL out of the browser and enforces the view/control policy in Rakazo's proxy.

- encrypt external Box desktop targets into short-lived `/novnc/remote/...` capabilities
- proxy Box HTTPS/noVNC traffic through the existing Vite/preview relay
- bind the capability policy with AES-GCM authenticated data and re-apply `view_only` for `embed.html` and `vnc.html`
- preserve Box secret URLs and credentials from browser-visible paths
- add API/web tests and runtime documentation

## Verification

- `pnpm lint`
- `pnpm check`
- `pnpm test` (423 passed, 44 skipped)
- `pnpm --filter @rakazo/web build`
- targeted API/web screen-proxy tests

Pre-existing local Currents/desktop/docs changes remain unstaged and are not part of this PR.