### PR TITLE
feat(www): put landing demo bot list behind a hamburger on mobile

### DIFF
--- a/apps/www/src/components/ProductDemo.tsx
+++ b/apps/www/src/components/ProductDemo.tsx
@@ -342,6 +342,8 @@ export function ProductDemo() {
   const [routineDraft, setRoutineDraft] = useState<RoutineDraft | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const timersRef = useRef<number[]>([]);
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const widePanelRef = useRef(true);
   const booting = bootPct > 0;
 
   const active = bots.find((bot) => bot.id === activeId) ?? bots[0];
@@ -391,13 +393,17 @@ export function ProductDemo() {
     return () => query.removeEventListener("change", sync);
   }, []);
 
-  // Phone widths show one screen at a time, so the bot list starts hidden
-  // behind the hamburger and the side panel stays closed until asked for.
+  // Phone widths show one screen at a time, so the bot list starts hidden behind
+  // the hamburger and the side panel stays closed until asked for. Growing the
+  // window back restores however the panel was left at wide widths: this effect
+  // only runs when `compact` flips, so it closes over that render's panelOpen.
   useEffect(() => {
     if (compact) {
+      widePanelRef.current = panelOpen;
       setPanelOpen(false);
     } else {
       setMenuOpen(false);
+      setPanelOpen(widePanelRef.current);
     }
   }, [compact]);
 
@@ -407,7 +413,7 @@ export function ProductDemo() {
     }
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
-        setMenuOpen(false);
+        closeMenu();
       }
     }
     window.addEventListener("keydown", onKey);
@@ -438,6 +444,16 @@ export function ProductDemo() {
       callback();
     }, delayMs);
     timersRef.current.push(timer);
+  }
+
+  function closeMenu() {
+    if (!menuOpen) {
+      return;
+    }
+    setMenuOpen(false);
+    // The drawer is hidden from the focus order once closed, so hand focus back
+    // to the control that opened it.
+    menuButtonRef.current?.focus();
   }
 
   function openComputer() {
@@ -570,7 +586,7 @@ export function ProductDemo() {
     setBots((current) => [bot, ...current]);
     setActiveId(bot.id);
     setDraft("");
-    setMenuOpen(false);
+    closeMenu();
     openSettings();
   }
 
@@ -647,7 +663,7 @@ export function ProductDemo() {
 
   function selectBot(id: string) {
     setActiveId(id);
-    setMenuOpen(false);
+    closeMenu();
     if (panelMode === "routine") {
       setPanelMode("computer");
       setRoutineDraft(null);
@@ -704,7 +720,7 @@ export function ProductDemo() {
                 type="button"
                 className="product-demo__sidebar-close"
                 aria-label="Hide bots"
-                onClick={() => setMenuOpen(false)}
+                onClick={closeMenu}
               >
                 ✕
               </button>
@@ -752,7 +768,7 @@ export function ProductDemo() {
             type="button"
             className="product-demo__scrim"
             aria-label="Hide bots"
-            onClick={() => setMenuOpen(false)}
+            onClick={closeMenu}
           />
         ) : null}
 
@@ -761,6 +777,7 @@ export function ProductDemo() {
             <div className="product-demo__topbar-left">
               <button
                 type="button"
+                ref={menuButtonRef}
                 className="product-demo__menu-btn"
                 aria-label="Show bots"
                 aria-expanded={menuOpen}

--- a/apps/www/src/components/ProductDemo.tsx
+++ b/apps/www/src/components/ProductDemo.tsx
@@ -330,6 +330,8 @@ export function ProductDemo() {
   const [bots, setBots] = useState<LiveBot[]>(cloneBots);
   const [activeId, setActiveId] = useState("inbox");
   const [panelOpen, setPanelOpen] = useState(true);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [compact, setCompact] = useState(false);
   const [panelMode, setPanelMode] = useState<PanelMode>("computer");
   const [hasControl, setHasControl] = useState(false);
   const [takeover, setTakeover] = useState(false);
@@ -380,6 +382,37 @@ export function ProductDemo() {
       }
     };
   }, []);
+
+  useEffect(() => {
+    const query = window.matchMedia("(max-width: 860px)");
+    const sync = () => setCompact(query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  // Phone widths show one screen at a time, so the bot list starts hidden
+  // behind the hamburger and the side panel stays closed until asked for.
+  useEffect(() => {
+    if (compact) {
+      setPanelOpen(false);
+    } else {
+      setMenuOpen(false);
+    }
+  }, [compact]);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [menuOpen]);
 
   useEffect(() => {
     if (!takeover && !booting) {
@@ -537,6 +570,7 @@ export function ProductDemo() {
     setBots((current) => [bot, ...current]);
     setActiveId(bot.id);
     setDraft("");
+    setMenuOpen(false);
     openSettings();
   }
 
@@ -613,6 +647,7 @@ export function ProductDemo() {
 
   function selectBot(id: string) {
     setActiveId(id);
+    setMenuOpen(false);
     if (panelMode === "routine") {
       setPanelMode("computer");
       setRoutineDraft(null);
@@ -644,21 +679,36 @@ export function ProductDemo() {
   return (
     <div className="product-demo">
       <div className={`product-demo__frame${panelOpen ? "" : " is-collapsed"}`}>
-        <aside className="product-demo__sidebar">
+        <aside
+          id="product-demo-bots"
+          className={`product-demo__sidebar${menuOpen ? " is-open" : ""}`}
+          aria-hidden={compact && !menuOpen}
+        >
           <div className="product-demo__chrome">
             <div className="product-demo__traffic" aria-hidden="true">
               <span />
               <span />
               <span />
             </div>
-            <button
-              type="button"
-              className="product-demo__new"
-              aria-label="New bot"
-              onClick={startNewBot}
-            >
-              +
-            </button>
+            <span className="product-demo__drawer-title">Bots</span>
+            <div className="product-demo__chrome-actions">
+              <button
+                type="button"
+                className="product-demo__new"
+                aria-label="New bot"
+                onClick={startNewBot}
+              >
+                +
+              </button>
+              <button
+                type="button"
+                className="product-demo__sidebar-close"
+                aria-label="Hide bots"
+                onClick={() => setMenuOpen(false)}
+              >
+                ✕
+              </button>
+            </div>
           </div>
           <label className="product-demo__search">
             <span aria-hidden="true">⌕</span>
@@ -697,12 +747,43 @@ export function ProductDemo() {
           </div>
         </aside>
 
+        {menuOpen ? (
+          <button
+            type="button"
+            className="product-demo__scrim"
+            aria-label="Hide bots"
+            onClick={() => setMenuOpen(false)}
+          />
+        ) : null}
+
         <main className="product-demo__main">
           <div className="product-demo__topbar">
-            <button type="button" className="product-demo__name-btn" onClick={openSettings}>
-              <LandingBotAvatar color={active.color} size={28} />
-              <span className="product-demo__active-name">{active.name}</span>
-            </button>
+            <div className="product-demo__topbar-left">
+              <button
+                type="button"
+                className="product-demo__menu-btn"
+                aria-label="Show bots"
+                aria-expanded={menuOpen}
+                aria-controls="product-demo-bots"
+                onClick={() => setMenuOpen(true)}
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  strokeLinecap="round"
+                >
+                  <path d="M4 7h16M4 12h16M4 17h16" />
+                </svg>
+              </button>
+              <button type="button" className="product-demo__name-btn" onClick={openSettings}>
+                <LandingBotAvatar color={active.color} size={28} />
+                <span className="product-demo__active-name">{active.name}</span>
+              </button>
+            </div>
             <button
               type="button"
               className="product-demo__panel-toggle"

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -721,7 +721,21 @@ button {
   padding: 16px 16px 12px;
 }
 
-.product-demo__new {
+.product-demo__drawer-title {
+  display: none;
+  color: #e9e9ea;
+  font-size: 14.5px;
+  font-weight: 500;
+}
+
+.product-demo__chrome-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.product-demo__new,
+.product-demo__sidebar-close {
   border: 0;
   background: transparent;
   color: var(--panel-muted-2);
@@ -730,8 +744,15 @@ button {
   cursor: pointer;
 }
 
+.product-demo__sidebar-close {
+  display: none;
+  font-size: 15px;
+}
+
 .product-demo__new:hover,
-.product-demo__new:focus-visible {
+.product-demo__new:focus-visible,
+.product-demo__sidebar-close:hover,
+.product-demo__sidebar-close:focus-visible {
   color: #c9c9ce;
 }
 
@@ -891,6 +912,34 @@ button {
   gap: 16px;
   border-bottom: 1px solid var(--panel-line);
   padding: 16px 20px;
+}
+
+.product-demo__topbar-left {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.product-demo__menu-btn {
+  display: none;
+  width: 32px;
+  height: 28px;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: #1b1b1e;
+  color: #a8a8ad;
+  cursor: pointer;
+}
+
+.product-demo__menu-btn:hover,
+.product-demo__menu-btn:focus-visible {
+  background: var(--panel-line-2);
+}
+
+.product-demo__scrim {
+  display: none;
 }
 
 .product-demo__name-btn,
@@ -1870,23 +1919,63 @@ button {
     display: block;
   }
 
+  /* One screen at a time, like the mobile app: the bot list slides in from the
+     hamburger and the computer panel covers the thread while it is open. */
   .product-demo__frame,
   .product-demo__frame.is-collapsed {
-    display: block;
-    height: auto;
+    grid-template-columns: minmax(0, 1fr);
+    height: min(620px, 82vh);
+  }
+
+  .product-demo__menu-btn {
+    display: grid;
   }
 
   .product-demo__sidebar {
-    border-right: 0;
-    border-bottom: 1px solid var(--panel-line);
+    position: absolute;
+    z-index: 6;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: min(300px, 86%);
+    background: var(--panel);
+    box-shadow: 0 0 40px rgba(0, 0, 0, 0.5);
+    visibility: hidden;
+    transform: translateX(-100%);
+    transition:
+      transform 0.22s ease,
+      visibility 0.22s ease;
   }
 
-  .product-demo__bot-list {
-    max-height: 260px;
+  .product-demo__sidebar.is-open {
+    visibility: visible;
+    transform: none;
   }
 
-  .product-demo__main {
-    min-height: 540px;
+  .product-demo__traffic {
+    display: none;
+  }
+
+  .product-demo__drawer-title,
+  .product-demo__sidebar-close {
+    display: block;
+  }
+
+  .product-demo__scrim {
+    position: absolute;
+    z-index: 5;
+    display: block;
+    inset: 0;
+    border: 0;
+    padding: 0;
+    background: rgba(4, 4, 5, 0.6);
+  }
+
+  .product-demo__panel {
+    position: absolute;
+    z-index: 4;
+    inset: 0;
+    border-left: 0;
   }
 }
 
@@ -1959,8 +2048,7 @@ button {
   }
 
   .product-demo__topbar {
-    align-items: flex-start;
-    flex-direction: column;
+    padding: 12px 14px;
   }
 
   .product-demo__thread {


### PR DESCRIPTION
At phone widths the landing demo stacked the whole bot list above the thread, so the chat was pushed off screen. It now mirrors the mobile app: one screen at a time, with the bot list in a slide-in drawer opened from a hamburger in the thread topbar (closes on select, scrim tap, or Escape) and the computer/settings panel as a full-frame overlay that starts closed.

The `≤860px` layout is now a single column with the sidebar and panel positioned over it; a `matchMedia` listener drives the compact behaviour so hydration stays consistent, and the drawer is `visibility: hidden` when closed to keep it out of the focus order. Desktop layout is unchanged.

Tested with `pnpm --filter @rakazo/www check` and `build`, plus Playwright screenshots at 390px, 820px and 1440px covering drawer open/close, bot select, the computer panel overlay, and resizing between mobile and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)