### PR TITLE
Reconcile stale pending Composio connections on catalog fetch

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1306,7 +1306,23 @@ export function createRouter(deps: RouterDeps) {
       catalog: authed.connections.catalog.handler(async ({ context, input }) => {
         if (!deps.composio) return [];
         try {
-          return await deps.composio.catalog(context.actor.userId, input.query);
+          const items = await deps.composio.catalog(context.actor.userId, input.query);
+          const nowConnected = items.filter((item) => item.connected).map((item) => item.slug);
+          if (nowConnected.length > 0) {
+            // A connection can finish on Composio's side after our own completion check gave
+            // up (see PluginsOverlay's polling timeout) — reconcile stale "pending" rows here
+            // so callers like the run executor, which trust our local status, stay in sync.
+            await deps.prisma.connection.updateMany({
+              where: {
+                workspaceId: context.actor.workspaceId,
+                userId: context.actor.userId,
+                status: "pending",
+                provider: { in: nowConnected },
+              },
+              data: { status: "connected" },
+            });
+          }
+          return items;
         } catch {
           return [];
         }

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -30,6 +30,7 @@ import {
   isSupermemoryEnabled,
   listPiCatalog,
   type PiOAuthLogins,
+  planLiveConnectionSync,
   provisionComputer,
   releaseComputerExecutionLease,
   resolveBotWorkspacePath,
@@ -96,6 +97,53 @@ import {
 const MAX_COMPUTER_TEXT_FILE_BYTES = 2 * 1024 * 1024;
 const THREAD_MESSAGE_PAGE_SIZE = 100;
 const EXPORT_MESSAGE_PAGE_SIZE = 500;
+
+async function reconcilePendingComposioConnections(
+  prisma: PrismaClient,
+  owner: Pick<Actor, "workspaceId" | "userId">,
+  connectedProviders: string[],
+): Promise<void> {
+  const rows = await prisma.connection.findMany({
+    where: {
+      workspaceId: owner.workspaceId,
+      userId: owner.userId,
+      provider: { in: connectedProviders },
+      status: { in: ["pending", "connected"] },
+    },
+    select: { id: true, provider: true, displayName: true, status: true },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  });
+  const sync = planLiveConnectionSync(rows, connectedProviders);
+  const updates = [
+    ...(sync.connectIds.length > 0
+      ? [
+          prisma.connection.updateMany({
+            where: {
+              id: { in: sync.connectIds },
+              workspaceId: owner.workspaceId,
+              userId: owner.userId,
+              status: "pending",
+            },
+            data: { status: "connected" },
+          }),
+        ]
+      : []),
+    ...(sync.revokeIds.length > 0
+      ? [
+          prisma.connection.updateMany({
+            where: {
+              id: { in: sync.revokeIds },
+              workspaceId: owner.workspaceId,
+              userId: owner.userId,
+              status: "pending",
+            },
+            data: { status: "revoked" },
+          }),
+        ]
+      : []),
+  ];
+  if (updates.length > 0) await prisma.$transaction(updates);
+}
 
 function computerContext(actor: Actor, botId: string, operationId: string): AdapterContext {
   return {
@@ -1312,21 +1360,17 @@ export function createRouter(deps: RouterDeps) {
             // A connection can finish on Composio's side after our own completion check gave
             // up (see PluginsOverlay's polling timeout) — reconcile stale "pending" rows here
             // so callers like the run executor, which trust our local status, stay in sync.
+            // Reuse the executor's one-row-per-provider plan so duplicate auth attempts do not
+            // leave stale locally connected rows behind after a later revoke.
             // Best effort: a failed reconciliation write shouldn't blank out an otherwise
             // successful catalog fetch — the caller still gets accurate, if unreconciled, data.
-            await deps.prisma.connection
-              .updateMany({
-                where: {
-                  workspaceId: context.actor.workspaceId,
-                  userId: context.actor.userId,
-                  status: "pending",
-                  provider: { in: nowConnected },
-                },
-                data: { status: "connected" },
-              })
-              .catch((error) => {
-                console.error("composio pending-connection reconciliation failed", error);
-              });
+            await reconcilePendingComposioConnections(
+              deps.prisma,
+              context.actor,
+              nowConnected,
+            ).catch((error) => {
+              console.error("composio pending-connection reconciliation failed", error);
+            });
           }
           return items;
         } catch {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1312,15 +1312,21 @@ export function createRouter(deps: RouterDeps) {
             // A connection can finish on Composio's side after our own completion check gave
             // up (see PluginsOverlay's polling timeout) — reconcile stale "pending" rows here
             // so callers like the run executor, which trust our local status, stay in sync.
-            await deps.prisma.connection.updateMany({
-              where: {
-                workspaceId: context.actor.workspaceId,
-                userId: context.actor.userId,
-                status: "pending",
-                provider: { in: nowConnected },
-              },
-              data: { status: "connected" },
-            });
+            // Best effort: a failed reconciliation write shouldn't blank out an otherwise
+            // successful catalog fetch — the caller still gets accurate, if unreconciled, data.
+            await deps.prisma.connection
+              .updateMany({
+                where: {
+                  workspaceId: context.actor.workspaceId,
+                  userId: context.actor.userId,
+                  status: "pending",
+                  provider: { in: nowConnected },
+                },
+                data: { status: "connected" },
+              })
+              .catch((error) => {
+                console.error("composio pending-connection reconciliation failed", error);
+              });
           }
           return items;
         } catch {

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -82,6 +82,7 @@ async function main() {
           "packages/testkit/src/voice.test.ts",
           "packages/testkit/src/search.test.ts",
           "packages/testkit/src/executor-lifecycle.test.ts",
+          "packages/testkit/src/connections.test.ts",
           "packages/adapters/src/wakeup.postgres.test.ts",
           "packages/adapters/src/realtime.postgres.test.ts",
           "packages/adapters/src/job-reconciler.postgres.test.ts",

--- a/packages/testkit/src/connections.test.ts
+++ b/packages/testkit/src/connections.test.ts
@@ -1,0 +1,202 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ComposioEmulator } from "@rakazo/adapters";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { sessionCookieHeader } from "./index.js";
+
+type App = { request: (input: string, init?: RequestInit) => Promise<Response> };
+type AppHandles = Awaited<ReturnType<typeof import("../../../apps/api/src/app.ts").createApp>>;
+type Actor = { workspaceId: string; userId: string };
+
+process.env.WAKEUP_DRIVER = "memory";
+process.env.SANDBOX_PROVIDER = "fake";
+process.env.AGENT_RUNTIME = "scripted";
+
+const hasDb = process.env.VERIFY_DATABASE === "1" && Boolean(process.env.DATABASE_URL);
+const describeWithDatabase = hasDb ? describe : describe.skip;
+
+describeWithDatabase("Composio catalog reconciliation", () => {
+  let handles: AppHandles;
+  let app: App;
+  let composio: ComposioEmulator;
+  let connectionOrdinal = 0;
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const dataDir = mkdtempSync(path.join(tmpdir(), "rakazo-connections-"));
+
+  beforeAll(async () => {
+    const { createApp } = await import("../../../apps/api/src/app.ts");
+    composio = new ComposioEmulator();
+    handles = await createApp({
+      databaseUrl: process.env.DATABASE_URL!,
+      dataDir,
+      sandboxProvider: "fake",
+      agentRuntime: "scripted",
+      composio,
+      signupsEnabled: "true",
+    });
+    app = handles.app;
+  });
+
+  afterAll(async () => {
+    await handles?.stop();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reconciles one scoped row per provider under concurrent catalog fetches", async () => {
+    const ownerCookie = await signup(app, `owner-connections-${stamp}@rakazo.test`, "Owner");
+    const otherCookie = await signup(app, `other-connections-${stamp}@rakazo.test`, "Other");
+    const owner = await rpc<Actor>(app, ownerCookie, "me");
+    const other = await rpc<Actor>(app, otherCookie, "me");
+    await connectRemote(composio, owner, "GMAIL");
+
+    const first = await createConnection(owner, "GMAIL");
+    const duplicate = await createConnection(owner, "GMAIL");
+    const otherProvider = await createConnection(owner, "SLACK");
+    const otherUser = await createConnection(
+      { workspaceId: owner.workspaceId, userId: other.userId },
+      "GMAIL",
+    );
+    const otherWorkspace = await createConnection(
+      { workspaceId: other.workspaceId, userId: owner.userId },
+      "GMAIL",
+    );
+
+    const catalogs = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        rpc<Array<{ slug: string; connected: boolean }>>(app, ownerCookie, "connections/catalog"),
+      ),
+    );
+    for (const catalog of catalogs) {
+      expect(catalog).toContainEqual(expect.objectContaining({ slug: "GMAIL", connected: true }));
+    }
+
+    await expect(statuses([first.id, duplicate.id])).resolves.toEqual([
+      { id: first.id, status: "connected" },
+      { id: duplicate.id, status: "revoked" },
+    ]);
+    await expect(statuses([otherProvider.id, otherUser.id, otherWorkspace.id])).resolves.toEqual([
+      { id: otherProvider.id, status: "pending" },
+      { id: otherUser.id, status: "pending" },
+      { id: otherWorkspace.id, status: "pending" },
+    ]);
+
+    await rpc(app, ownerCookie, "connections/catalog");
+    await expect(statuses([first.id, duplicate.id])).resolves.toEqual([
+      { id: first.id, status: "connected" },
+      { id: duplicate.id, status: "revoked" },
+    ]);
+  });
+
+  it("returns the remote catalog when local reconciliation fails", async () => {
+    const cookie = await signup(app, `db-failure-connections-${stamp}@rakazo.test`, "DB Failure");
+    const actor = await rpc<Actor>(app, cookie, "me");
+    await connectRemote(composio, actor, "SLACK");
+    const pending = await createConnection(actor, "SLACK");
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const failure = vi
+      .spyOn(handles.prisma.connection, "findMany")
+      .mockRejectedValueOnce(new Error("simulated reconciliation failure"));
+
+    const catalog = await rpc<Array<{ slug: string; connected: boolean }>>(
+      app,
+      cookie,
+      "connections/catalog",
+    );
+
+    expect(catalog).toContainEqual(expect.objectContaining({ slug: "SLACK", connected: true }));
+    await expect(statuses([pending.id])).resolves.toEqual([{ id: pending.id, status: "pending" }]);
+    expect(log).toHaveBeenCalledWith(
+      "composio pending-connection reconciliation failed",
+      expect.any(Error),
+    );
+    failure.mockRestore();
+    log.mockRestore();
+  });
+
+  it("does not mutate local state when the provider catalog fails", async () => {
+    const cookie = await signup(
+      app,
+      `provider-failure-connections-${stamp}@rakazo.test`,
+      "Provider Failure",
+    );
+    const actor = await rpc<Actor>(app, cookie, "me");
+    const pending = await createConnection(actor, "GITHUB");
+    const failure = vi
+      .spyOn(composio, "catalog")
+      .mockRejectedValueOnce(new Error("simulated provider failure"));
+
+    await expect(rpc(app, cookie, "connections/catalog")).resolves.toEqual([]);
+    await expect(statuses([pending.id])).resolves.toEqual([{ id: pending.id, status: "pending" }]);
+    failure.mockRestore();
+  });
+
+  async function createConnection(owner: Actor, provider: string) {
+    return handles.prisma.connection.create({
+      data: {
+        workspaceId: owner.workspaceId,
+        userId: owner.userId,
+        provider,
+        displayName: provider,
+        status: "pending",
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, connectionOrdinal++)),
+      },
+    });
+  }
+
+  async function statuses(ids: string[]) {
+    return handles.prisma.connection.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, status: true },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+});
+
+async function connectRemote(composio: ComposioEmulator, actor: Actor, provider: string) {
+  await composio.begin(
+    { provider, redirectUrl: "http://127.0.0.1.invalid/callback" },
+    {
+      operationId: "connections-test",
+      traceId: "connections-test",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      signal: new AbortController().signal,
+    },
+  );
+}
+
+async function signup(app: App, email: string, name: string) {
+  const response = await app.request("/api/auth/sign-up/email", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "http://127.0.0.1:5173",
+    },
+    body: JSON.stringify({ email, password: "password12", name }),
+  });
+  if (!response.ok) throw new Error(`signup failed ${response.status}: ${await response.text()}`);
+  return sessionCookieHeader(response);
+}
+
+async function rpc<T>(app: App, cookie: string, procedure: string, body: unknown = {}): Promise<T> {
+  const response = await app.request(`/rpc/${procedure}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie,
+      origin: "http://127.0.0.1:5173",
+    },
+    body: JSON.stringify({ json: body }),
+  });
+  const text = await response.text();
+  const parsed = JSON.parse(text) as { json?: T; error?: { message?: string } };
+  if (!response.ok || parsed.error) {
+    throw new Error(`${procedure} ${response.status}: ${parsed.error?.message ?? text}`);
+  }
+  return parsed.json as T;
+}


### PR DESCRIPTION
## Summary

A Composio connection can finish on Composio's side after our own completion check gave up (see `PluginsOverlay`'s polling timeout), leaving the local `Connection` row stuck at status `pending` even though Composio reports it connected. Callers that trust the local status — like the run executor — never learn the connection actually succeeded.

This reconciles stale `pending` rows whenever the plugin catalog is fetched: `connections.catalog` now diffs Composio's reported `connected` slugs against locally `pending` rows for that workspace/user and flips them to `connected` before returning the catalog to the caller.

## Test plan

- [x] `pnpm lint` — passes
- [x] `pnpm check` — passes (all 19 packages typecheck)
- [x] `pnpm test` — passes (578 passed, 49 skipped)
- [x] `pnpm test:integration` — passes (44 passed, needs Docker)
- [ ] `pnpm test:e2e` — blocked in my environment: Playwright's dev server port (5174) was already in use by an unrelated local process, unrelated to this change. Not run.