### PR TITLE
Wire model.reasoning through to PiAgentRuntime's thinkingLevel

### DIFF
--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+const fakeAgentState = vi.hoisted(() => ({
+  thinkingLevel: undefined as string | undefined,
+}));
+
+vi.mock("@earendil-works/pi-agent-core", () => ({
+  Agent: class {
+    state = { errorMessage: undefined, messages: [] };
+
+    constructor(options: { initialState: { thinkingLevel: string } }) {
+      fakeAgentState.thinkingLevel = options.initialState.thinkingLevel;
+    }
+
+    subscribe(_listener: unknown) {}
+    async prompt() {}
+    async waitForIdle() {}
+    abort() {}
+  },
+}));
+
+vi.mock("@earendil-works/pi-ai/providers/all", () => ({
+  builtinModels: () => ({
+    getModel: (_provider: string, modelId: string) => {
+      if (modelId === "reasoning-model") return { provider: "test", id: modelId, reasoning: true };
+      if (modelId === "plain-model") return { provider: "test", id: modelId, reasoning: false };
+      return undefined;
+    },
+    streamSimple: () => {
+      throw new Error("the fake agent must not call a provider");
+    },
+  }),
+}));
+
+vi.mock("./local-providers.js", () => ({
+  withLocalProviders: (models: unknown) => models,
+}));
+
+import { PiAgentRuntime } from "./pi-runtime.js";
+
+async function runWithModel(modelId: string) {
+  const runtime = new PiAgentRuntime();
+  for await (const _event of runtime.run(
+    {
+      botId: "b",
+      threadId: "t",
+      runId: "r",
+      prompt: "hello",
+      instructions: "",
+      history: [],
+      tools: [],
+      model: { provider: "test", id: modelId },
+      executeTool: vi.fn(async () => ({ ok: true })),
+    },
+    {
+      operationId: "1",
+      traceId: "1",
+      workspaceId: "w",
+      userId: "u",
+      signal: new AbortController().signal,
+    },
+  )) {
+    // Exhaust the runtime event stream so the run completes.
+  }
+  return fakeAgentState.thinkingLevel;
+}
+
+describe("Pi agent thinking level", () => {
+  it("enables reasoning for a model configured with reasoning support", async () => {
+    expect(await runWithModel("reasoning-model")).not.toBe("off");
+  });
+
+  it("keeps reasoning off for a model without reasoning support", async () => {
+    expect(await runWithModel("plain-model")).toBe("off");
+  });
+});

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -15,6 +15,14 @@ import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js
 const running = new Map<string, AbortController>();
 const catalogModels = builtinModels();
 const MAX_PARALLEL_SUBAGENTS = 4;
+// A model with reasoning configured (currently only local-mlx) reliably repeats a failed tool
+// call verbatim when run with thinking off — confirmed live and reproduced against the model
+// directly. Enabling reasoning fixes it: the model narrates its diagnosis and adapts instead of
+// retrying blind. Cloud models keep "off" per Rakazo's existing global default.
+const LOCAL_REASONING_THINKING_LEVEL = "medium";
+function thinkingLevelFor(model: { reasoning?: boolean }) {
+  return model.reasoning ? LOCAL_REASONING_THINKING_LEVEL : "off";
+}
 // Pi forwards these names to OpenAI Responses, whose function-name contract is
 // ^[a-zA-Z0-9_-]+$ with a maximum length of 64 characters.
 const AGENT_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
@@ -87,7 +95,7 @@ export class PiAgentRuntime implements AgentRuntime {
                 ? "You are a Rakazo bot with a real computer. Use computer_observe and computer_act to operate its visible desktop, including browsers and installed applications. Use shell and the file tools for precise terminal and filesystem work. The user may interact with the same desktop while you run, so re-observe when the screen may have changed. Be concise."
                 : "You are a Rakazo bot with a persistent sandbox filesystem and shell. Be concise."),
             model,
-            thinkingLevel: "off",
+            thinkingLevel: thinkingLevelFor(model),
             tools,
             messages: history,
           },
@@ -413,7 +421,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
         .filter(Boolean)
         .join(" "),
       model: host.model,
-      thinkingLevel: "off",
+      thinkingLevel: thinkingLevelFor(host.model),
       tools: toAgentTools(childDefs, nestedHost),
       messages: [],
     },


### PR DESCRIPTION
## Summary
- `PiAgentRuntime` hardcoded `thinkingLevel: "off"` for every run regardless of the model's own `reasoning` flag, so registering a model with `reasoning: true` (e.g. local-mlx) had no effect on what actually got sent to the agent.
- Derive `thinkingLevel` from `model.reasoning` instead: `"medium"` for a model configured with reasoning support (confirmed live against local-mlx — with thinking off it reliably repeats a failed tool call verbatim instead of adapting), `"off"` for everything else, matching Rakazo's existing global default.
- Applies to both the main run and subagent execution.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm test:integration` (Docker)
- [x] `pnpm test:e2e` (Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
