### PR TITLE
Add Ollama and local MLX server as OpenAI-compatible model providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,14 @@ SANDBOX_COMMAND_TIMEOUT_MS=300000
 OPENROUTER_API_KEY=
 PI_DEFAULT_PROVIDER=openrouter
 PI_DEFAULT_MODEL=deepseek/deepseek-v4-flash-0731
+# Local OpenAI-compatible providers registered by packages/adapters/src/local-providers.ts.
+# Both are optional — omit a var to skip registering that provider. If you also run Clawdia
+# locally, do NOT point LOCAL_MLX_BASE_URL at 127.0.0.1:8082 — that's Clawdia's own resident
+# mlx-openai-server (src/clawdia/mlx/daemon.py). Sharing it causes silent request contention
+# between the two apps. Give Rakazo its own dedicated mlx-openai-server on a different port.
+OLLAMA_BASE_URL=http://127.0.0.1:11434/v1
+LOCAL_MLX_BASE_URL=http://127.0.0.1:8081/v1
+LOCAL_MLX_MODEL_ID=DreamFoundries/Ornith-1.0-35B-6bit
 E2B_API_KEY=
 COMPOSIO_API_KEY=
 SUPERMEMORY_API_KEY=

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -122,10 +122,19 @@ export function OnboardingPage() {
   async function saveModel() {
     setError(null);
     try {
-      if (apiKey) {
+      // Gate on acceptsKey (not apiKey): setDefault only updates an EXISTING
+      // credential row, so a keyless local provider (Ollama, Local MLX — no
+      // key needed, apiKey left blank) must still get one created here, or
+      // setDefault silently no-ops (0 rows matched, no error) and the
+      // account never has a working default model.
+      if (acceptsKey) {
+        // The server's apiKey field requires 8+ chars; a keyless local
+        // provider's own auth resolver ignores the value entirely, so any
+        // placeholder that clears validation is fine.
+        const keyToSend = apiKey || (selected?.keyless ? "not-required-local-provider" : apiKey);
         await rpc.models.connect({
           provider,
-          apiKey,
+          apiKey: keyToSend,
           modelId,
           label: selected?.providerName ?? provider,
         });

--- a/packages/adapters/src/local-providers.test.ts
+++ b/packages/adapters/src/local-providers.test.ts
@@ -1,0 +1,17 @@
+import { createModels, hasApi } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { withLocalProviders } from "./local-providers.js";
+
+describe("Local MLX provider reasoning config", () => {
+  it("disables Qwen's <think> block by default instead of always reasoning at max effort", () => {
+    const models = withLocalProviders(createModels());
+    const provider = models.getProvider("local-mlx");
+    const [model] = provider?.getModels() ?? [];
+    if (!model || !hasApi(model, "openai-completions")) {
+      throw new Error("expected an openai-completions local-mlx model");
+    }
+
+    expect(model.reasoning).toBe(true);
+    expect(model.compat?.thinkingFormat).toBe("qwen-chat-template");
+  });
+});

--- a/packages/adapters/src/local-providers.test.ts
+++ b/packages/adapters/src/local-providers.test.ts
@@ -14,4 +14,15 @@ describe("Local MLX provider reasoning config", () => {
     expect(model.reasoning).toBe(true);
     expect(model.compat?.thinkingFormat).toBe("qwen-chat-template");
   });
+
+  it("sends the system prompt as role 'system', not the 'developer' role mlx-openai-server rejects", () => {
+    const models = withLocalProviders(createModels());
+    const provider = models.getProvider("local-mlx");
+    const [model] = provider?.getModels() ?? [];
+    if (!model || !hasApi(model, "openai-completions")) {
+      throw new Error("expected an openai-completions local-mlx model");
+    }
+
+    expect(model.compat?.supportsDeveloperRole).toBe(false);
+  });
 });

--- a/packages/adapters/src/local-providers.ts
+++ b/packages/adapters/src/local-providers.ts
@@ -37,10 +37,16 @@ function localModel(
     provider,
     baseUrl,
     reasoning,
-    // mlx-openai-server's Qwen3.5 chat template reads chat_template_kwargs.enable_thinking;
-    // without this, it defaults to reasoning_effort "xhigh" on every turn, which can burn the
-    // whole maxTokens budget on <think> and never reach an answer.
-    ...(reasoning ? { compat: { thinkingFormat: "qwen-chat-template" as const } } : {}),
+    compat: {
+      // Neither Ollama's nor mlx-openai-server's OpenAI-compatible endpoint recognizes the
+      // newer "developer" role pi defaults to for the system prompt; mlx-openai-server rejects
+      // it outright with a 422. "system" is the role every such server actually understands.
+      supportsDeveloperRole: false,
+      // mlx-openai-server's Qwen3.5 chat template reads chat_template_kwargs.enable_thinking;
+      // without this, it defaults to reasoning_effort "xhigh" on every turn, which can burn the
+      // whole maxTokens budget on <think> and never reach an answer.
+      ...(reasoning ? { thinkingFormat: "qwen-chat-template" as const } : {}),
+    },
     input: ["text"],
     contextWindow,
     maxTokens: DEFAULT_MAX_TOKENS,

--- a/packages/adapters/src/local-providers.ts
+++ b/packages/adapters/src/local-providers.ts
@@ -28,6 +28,7 @@ function localModel(
   baseUrl: string,
   id: string,
   contextWindow: number,
+  reasoning = false,
 ): Model<"openai-completions"> {
   return {
     id,
@@ -35,7 +36,11 @@ function localModel(
     api: "openai-completions",
     provider,
     baseUrl,
-    reasoning: false,
+    reasoning,
+    // mlx-openai-server's Qwen3.5 chat template reads chat_template_kwargs.enable_thinking;
+    // without this, it defaults to reasoning_effort "xhigh" on every turn, which can burn the
+    // whole maxTokens budget on <think> and never reach an answer.
+    ...(reasoning ? { compat: { thinkingFormat: "qwen-chat-template" as const } } : {}),
     input: ["text"],
     contextWindow,
     maxTokens: DEFAULT_MAX_TOKENS,
@@ -83,7 +88,7 @@ function localMlxProvider(): Provider<"openai-completions"> {
     name: "Local MLX server",
     baseUrl,
     auth: { apiKey: keylessAuth("Local MLX server — no key required") },
-    models: [localModel(LOCAL_MLX_PROVIDER_ID, baseUrl, modelId, LOCAL_MLX_CONTEXT_WINDOW)],
+    models: [localModel(LOCAL_MLX_PROVIDER_ID, baseUrl, modelId, LOCAL_MLX_CONTEXT_WINDOW, true)],
     api: openAICompletionsApi(),
   });
 }

--- a/packages/adapters/src/local-providers.ts
+++ b/packages/adapters/src/local-providers.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process";
+import { createProvider, type ApiKeyAuth, type Model, type MutableModels, type Provider } from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+const OLLAMA_PROVIDER_ID = "ollama";
+const OLLAMA_DEFAULT_BASE_URL = "http://127.0.0.1:11434/v1";
+const LOCAL_MLX_PROVIDER_ID = "local-mlx";
+const LOCAL_MLX_DEFAULT_BASE_URL = "http://127.0.0.1:8081/v1";
+const LOCAL_MLX_DEFAULT_MODEL_ID = "DreamFoundries/Ornith-1.0-35B-6bit";
+const OLLAMA_LIST_TIMEOUT_MS = 3_000;
+const DEFAULT_CONTEXT_WINDOW = 32_768;
+const LOCAL_MLX_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 8_192;
+
+/** Provider ids added by this module — used to give them local-appropriate billing copy. */
+export const LOCAL_PROVIDER_IDS = new Set([OLLAMA_PROVIDER_ID, LOCAL_MLX_PROVIDER_ID]);
+
+/** Ollama and self-hosted MLX servers take no API key; resolution always succeeds. */
+function keylessAuth(name: string): ApiKeyAuth {
+  return {
+    name,
+    resolve: async () => ({ auth: { apiKey: "not-required" }, source: "none" }),
+  };
+}
+
+function localModel(
+  provider: string,
+  baseUrl: string,
+  id: string,
+  contextWindow: number,
+): Model<"openai-completions"> {
+  return {
+    id,
+    name: id,
+    api: "openai-completions",
+    provider,
+    baseUrl,
+    reasoning: false,
+    input: ["text"],
+    contextWindow,
+    maxTokens: DEFAULT_MAX_TOKENS,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  };
+}
+
+/** `ollama list`'s first column, skipping the header row. Model names never contain whitespace. */
+function listOllamaModelIds(): string[] {
+  try {
+    const stdout = execFileSync("ollama", ["list"], {
+      encoding: "utf8",
+      timeout: OLLAMA_LIST_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return stdout
+      .split("\n")
+      .slice(1)
+      .map((line) => line.trim().split(/\s+/)[0])
+      .filter((name): name is string => Boolean(name));
+  } catch {
+    return [];
+  }
+}
+
+function ollamaProvider(): Provider<"openai-completions"> {
+  const baseUrl = (process.env.OLLAMA_BASE_URL ?? OLLAMA_DEFAULT_BASE_URL).replace(/\/+$/, "");
+  return createProvider({
+    id: OLLAMA_PROVIDER_ID,
+    name: "Ollama (local)",
+    baseUrl,
+    auth: { apiKey: keylessAuth("Ollama — no key required") },
+    models: listOllamaModelIds().map((id) =>
+      localModel(OLLAMA_PROVIDER_ID, baseUrl, id, DEFAULT_CONTEXT_WINDOW),
+    ),
+    api: openAICompletionsApi(),
+  });
+}
+
+function localMlxProvider(): Provider<"openai-completions"> {
+  const baseUrl = (process.env.LOCAL_MLX_BASE_URL ?? LOCAL_MLX_DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const modelId = process.env.LOCAL_MLX_MODEL_ID ?? LOCAL_MLX_DEFAULT_MODEL_ID;
+  return createProvider({
+    id: LOCAL_MLX_PROVIDER_ID,
+    name: "Local MLX server",
+    baseUrl,
+    auth: { apiKey: keylessAuth("Local MLX server — no key required") },
+    models: [localModel(LOCAL_MLX_PROVIDER_ID, baseUrl, modelId, LOCAL_MLX_CONTEXT_WINDOW)],
+    api: openAICompletionsApi(),
+  });
+}
+
+/**
+ * Registers Ollama plus a configurable local OpenAI-compatible server (e.g. an
+ * mlx-openai-server instance) on top of Pi's built-in provider catalog.
+ * Ollama's model list is read from `ollama list` at startup; restart the API
+ * process after pulling new models. The MLX entry is static, configured via
+ * LOCAL_MLX_BASE_URL / LOCAL_MLX_MODEL_ID.
+ */
+export function withLocalProviders(models: MutableModels): MutableModels {
+  models.setProvider(ollamaProvider());
+  models.setProvider(localMlxProvider());
+  return models;
+}

--- a/packages/adapters/src/local-providers.ts
+++ b/packages/adapters/src/local-providers.ts
@@ -1,5 +1,11 @@
 import { execFileSync } from "node:child_process";
-import { createProvider, type ApiKeyAuth, type Model, type MutableModels, type Provider } from "@earendil-works/pi-ai";
+import {
+  type ApiKeyAuth,
+  createProvider,
+  type Model,
+  type MutableModels,
+  type Provider,
+} from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 
 const OLLAMA_PROVIDER_ID = "ollama";
@@ -87,7 +93,10 @@ function ollamaProvider(): Provider<"openai-completions"> {
 }
 
 function localMlxProvider(): Provider<"openai-completions"> {
-  const baseUrl = (process.env.LOCAL_MLX_BASE_URL ?? LOCAL_MLX_DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const baseUrl = (process.env.LOCAL_MLX_BASE_URL ?? LOCAL_MLX_DEFAULT_BASE_URL).replace(
+    /\/+$/,
+    "",
+  );
   const modelId = process.env.LOCAL_MLX_MODEL_ID ?? LOCAL_MLX_DEFAULT_MODEL_ID;
   return createProvider({
     id: LOCAL_MLX_PROVIDER_ID,

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -1,4 +1,5 @@
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import { LOCAL_PROVIDER_IDS, withLocalProviders } from "./local-providers.js";
 import { DEVICE_CODE_PROVIDERS, DEVICE_CODE_SIGN_IN, isDeviceCodeProvider } from "./pi-oauth.js";
 
 export type PiCatalogAuth = "api-key" | "oauth" | "both";
@@ -14,6 +15,8 @@ export type PiCatalogEntry = {
   oauthLabel?: string;
   subscription: boolean;
   signIn?: PiCatalogSignIn;
+  /** True for local providers that take no API key (Ollama, Local MLX server). */
+  keyless?: boolean;
 };
 
 export function listPiCatalog(): PiCatalogEntry[] {
@@ -24,7 +27,7 @@ export function listPiCatalog(): PiCatalogEntry[] {
 let cachedCatalog: PiCatalogEntry[] | undefined;
 
 function buildPiCatalog(): PiCatalogEntry[] {
-  const models = builtinModels();
+  const models = withLocalProviders(builtinModels());
   const entries: PiCatalogEntry[] = [];
   for (const provider of models.getProviders()) {
     const apiKey = Boolean(provider.auth.apiKey);
@@ -39,6 +42,7 @@ function buildPiCatalog(): PiCatalogEntry[] {
       apiKey,
       oauth,
     });
+    const keyless = LOCAL_PROVIDER_IDS.has(provider.id);
     for (const model of provider.getModels()) {
       entries.push({
         provider: provider.id,
@@ -50,6 +54,7 @@ function buildPiCatalog(): PiCatalogEntry[] {
         oauthLabel,
         subscription,
         signIn,
+        keyless,
       });
     }
   }
@@ -63,6 +68,9 @@ function catalogBilling(
 ) {
   const device = DEVICE_CODE_PROVIDERS[providerId];
   if (device) return device.billing;
+  if (LOCAL_PROVIDER_IDS.has(providerId)) {
+    return `Runs on your own machine via ${name}. No API key, no network egress, no cost.`;
+  }
   if (opts.oauth && !opts.apiKey) {
     return `${name} subscription login is not in the Rakazo UI yet. Skip if this deployment already has credentials.`;
   }

--- a/packages/adapters/src/pi-runtime-attachments.test.ts
+++ b/packages/adapters/src/pi-runtime-attachments.test.ts
@@ -29,6 +29,11 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
   }),
 }));
 
+// Attachment forwarding is unrelated to local-provider registration; keep the fake models untouched.
+vi.mock("./local-providers.js", () => ({
+  withLocalProviders: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime } from "./pi-runtime.js";
 
 describe("Pi runtime attachments", () => {

--- a/packages/adapters/src/pi-runtime-computer.test.ts
+++ b/packages/adapters/src/pi-runtime-computer.test.ts
@@ -52,6 +52,11 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
   }),
 }));
 
+// Computer-tool dispatch is unrelated to local-provider registration; keep the fake models untouched.
+vi.mock("./local-providers.js", () => ({
+  withLocalProviders: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime, pruneComputerScreenshotContext } from "./pi-runtime.js";
 
 const computerObserve: ConnectorTool = {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -45,6 +45,11 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
   }),
 }));
 
+// Tool dispatch is unrelated to local-provider registration; keep the fake models untouched.
+vi.mock("./local-providers.js", () => ({
+  withLocalProviders: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime } from "./pi-runtime.js";
 
 const destinationTool: ConnectorTool = {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -14,7 +14,19 @@ import { withLocalProviders } from "./local-providers.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
 
 const running = new Map<string, AbortController>();
-const catalogModels = withLocalProviders(builtinModels());
+// Lazy, not module-top-level: ESM import evaluation runs this module's body
+// (including any top-level call here) before apps/api's index.ts reaches its
+// own first statement (loadRootEnv()), so an eager `withLocalProviders(...)`
+// here would build the local-provider catalog BEFORE .env is loaded into
+// process.env — silently registering local-providers.ts's hardcoded fallback
+// model/base-url defaults instead of the configured ones. Deferring the call
+// to first use (inside run(), well after the server is listening) sidesteps
+// the ordering entirely.
+let _catalogModels: ReturnType<typeof withLocalProviders> | undefined;
+function getCatalogModels() {
+  _catalogModels ??= withLocalProviders(builtinModels());
+  return _catalogModels;
+}
 const MAX_PARALLEL_SUBAGENTS = 4;
 // Pi forwards these names to OpenAI Responses, whose function-name contract is
 // ^[a-zA-Z0-9_-]+$ with a maximum length of 64 characters.
@@ -176,7 +188,7 @@ export class PiAgentRuntime implements AgentRuntime {
 
 function modelsForRequest(request: AgentRunRequest, provider: string): Models {
   const oauth = request.model.oauth;
-  if (!oauth) return catalogModels;
+  if (!oauth) return getCatalogModels();
 
   const persist = oauth.persist;
   return withLocalProviders(

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -10,10 +10,11 @@ import type {
   ConnectorTool,
 } from "@rakazo/adapter-kit";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
+import { withLocalProviders } from "./local-providers.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
 
 const running = new Map<string, AbortController>();
-const catalogModels = builtinModels();
+const catalogModels = withLocalProviders(builtinModels());
 const MAX_PARALLEL_SUBAGENTS = 4;
 // Pi forwards these names to OpenAI Responses, whose function-name contract is
 // ^[a-zA-Z0-9_-]+$ with a maximum length of 64 characters.
@@ -178,13 +179,15 @@ function modelsForRequest(request: AgentRunRequest, provider: string): Models {
   if (!oauth) return catalogModels;
 
   const persist = oauth.persist;
-  return builtinModels({
-    credentials: new PiRuntimeCredentialStore(
-      provider,
-      toOAuthCredential(oauth.credential),
-      persist ? (next) => persist(next) : undefined,
-    ),
-  });
+  return withLocalProviders(
+    builtinModels({
+      credentials: new PiRuntimeCredentialStore(
+        provider,
+        toOAuthCredential(oauth.credential),
+        persist ? (next) => persist(next) : undefined,
+      ),
+    }),
+  );
 }
 
 function toAgentTools(toolDefs: readonly ConnectorTool[], host: ToolHost): AgentTool[] {

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -211,6 +211,7 @@ export const ModelCatalogEntrySchema = z.object({
   oauthLabel: z.string().optional(),
   subscription: z.boolean().optional(),
   signIn: z.enum(["device-code"]).optional(),
+  keyless: z.boolean().optional(),
 });
 export type ModelCatalogEntry = z.infer<typeof ModelCatalogEntrySchema>;
 

--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,7 @@
     },
     "dev": {
       "cache": false,
-      "env": ["PUBLIC_POSTHOG_HOST", "PUBLIC_POSTHOG_KEY"],
+      "env": ["PUBLIC_POSTHOG_HOST", "PUBLIC_POSTHOG_KEY", "WEB_PORT"],
       "persistent": true
     }
   }


### PR DESCRIPTION
## Summary

Adds Ollama and a self-hosted MLX server (e.g. `mlx-openai-server`) as keyless, OpenAI-compatible model providers on top of Pi's built-in catalog, so bots can run entirely on-device with no API key and no network egress. The rest of the commits are fixes discovered while dogfooding a local-mlx model end-to-end: onboarding, dev-server startup, env ordering, reasoning effort, and the system-prompt role.

## Changes

- Register Ollama (model list read live via `ollama list`) and a configurable local MLX/OpenAI-compatible server (`LOCAL_MLX_BASE_URL` / `LOCAL_MLX_MODEL_ID`) as providers in `packages/adapters/src/local-providers.ts`.
- Fix `pnpm dev`'s `WEB_PORT` env var not reaching the Vite child task under turbo's strict env mode.
- Fix onboarding's "connect a model" flow silently no-oping for keyless local providers: it gated on `apiKey` being non-empty, so leaving the (correctly optional) key field blank skipped `connect()` entirely and left the account on the `scripted`/OpenRouter fallback with no visible error.
- Fix local providers being registered before `.env` was loaded: `withLocalProviders()` ran at module-top-level (during ESM import evaluation), before the app's entrypoint called `loadRootEnv()`, so it always baked in the hardcoded fallback base URL/model instead of the configured one. Deferred to first use inside `run()`.
- Document `OLLAMA_BASE_URL` / `LOCAL_MLX_BASE_URL` / `LOCAL_MLX_MODEL_ID` in `.env.example`.
- Stop the local-mlx model reasoning at max effort on every turn: `mlx-openai-server`'s Qwen3.5 template defaults to `reasoning_effort: "xhigh"` unless told otherwise via `chat_template_kwargs`; now wired through `compat.thinkingFormat` so it respects Rakazo's own thinking-level policy.
- Send the system prompt as role `"system"` instead of pi's default `"developer"` role for local providers — `mlx-openai-server` rejects `"developer"` outright with a 422; reproduced against a live server with real message history and tools.
- Mock `withLocalProviders` in the tool-dispatch, computer, and attachment-forwarding runtime tests, whose bare `builtinModels()` stubs have no `setProvider` and would otherwise throw before the agent was ever constructed once every model lookup started routing through it.

## Test plan

- [x] `pnpm lint` — passes (fixed a biome import-order/formatting violation in `local-providers.ts` while packaging this PR)
- [x] `pnpm check` — 19/19 packages, typecheck clean
- [x] `pnpm test` — 580 passed, 49 skipped (fixed one test, `pi-runtime-attachments.test.ts`, that this change set broke — same missing-mock gap already fixed for the tool-dispatch/computer tests, just missed for this one)
- [x] `pnpm test:integration` — 44 passed
- [x] `pnpm test:e2e` — 15 passed
