### PR TITLE
Reconcile stale pending Composio connections on catalog fetch

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1306,7 +1306,23 @@ export function createRouter(deps: RouterDeps) {
       catalog: authed.connections.catalog.handler(async ({ context, input }) => {
         if (!deps.composio) return [];
         try {
-          return await deps.composio.catalog(context.actor.userId, input.query);
+          const items = await deps.composio.catalog(context.actor.userId, input.query);
+          const nowConnected = items.filter((item) => item.connected).map((item) => item.slug);
+          if (nowConnected.length > 0) {
+            // A connection can finish on Composio's side after our own completion check gave
+            // up (see PluginsOverlay's polling timeout) — reconcile stale "pending" rows here
+            // so callers like the run executor, which trust our local status, stay in sync.
+            await deps.prisma.connection.updateMany({
+              where: {
+                workspaceId: context.actor.workspaceId,
+                userId: context.actor.userId,
+                status: "pending",
+                provider: { in: nowConnected },
+              },
+              data: { status: "connected" },
+            });
+          }
+          return items;
         } catch {
           return [];
         }


### PR DESCRIPTION
## Summary
- A connection can finish on Composio's side after our own completion check gave up (see PluginsOverlay's polling timeout), leaving the local row stuck at status "pending" even though Composio reports it connected.
- Reconcile on catalog fetch (`connections.catalog` in `apps/api/src/router.ts`) so callers that trust our local status, like the run executor, stay in sync: after fetching the catalog, any item Composio reports as connected has its matching local `Connection` rows flipped from `pending` to `connected`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm test:integration` (Postgres via Testcontainers)
- [x] `pnpm test:e2e` (Playwright against the emulated API; ran with `WEB_PORT=5199` override due to a local port conflict on the default port during development — not related to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)