### PR TITLE
Fix Chrome autofilling the account password into the model API key field

### DIFF
--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -374,7 +374,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         onChange={(event) => setApiKey(event.target.value)}
                         placeholder="sk-…"
                         type="password"
-                        autoComplete="off"
+                        autoComplete="new-password"
                         className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
                       />
                     </label>


### PR DESCRIPTION
## Summary
- The model-connection API key input used `type="password"` with `autoComplete="off"`. Chrome deliberately ignores `autoComplete="off"` on password-type fields — it's the documented workaround sites used to defeat the password manager, so Chromium stopped honoring it there.
- On this origin that meant Chrome silently autofilled the user's actual account login password into the model API key field the instant the settings overlay opened, with no user interaction.
- Found via live browser testing: opening the Model Settings overlay immediately populated the "connect an API key" field with the real account password.
- Fix: change `autoComplete` to `"new-password"`, the value Chrome does respect as "this isn't a login field."

## Test plan
- [x] `pnpm lint`
- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm test:integration`
- [x] `pnpm test:e2e` (including `model-settings.spec.ts`)
- [x] Verified live in-browser: before the fix, opening Model Settings immediately populated the API key field with the real account password; after the fix, the field comes up empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)