### PR TITLE
Fix takeover control state updates

### DIFF
--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -278,14 +278,22 @@ describe("computer event reduction", () => {
       computer({ state: "suspended", controlHolder: "bot" }),
       event({ type: "computer.takeover.granted", payload: {} }),
     );
-    expect(granted).toMatchObject({ state: "suspended", controlHolder: "user" });
+    expect(granted).toMatchObject({
+      state: "suspended",
+      controlHolder: "user",
+      controlBotId: "bot-1",
+    });
     expect(
       reduceComputerStatus(granted, event({ type: "computer.takeover.granted", payload: {} })),
     ).toBe(granted);
   });
 
   it("applies the authoritative holder when a takeover is released or expires", () => {
-    const initial = computer({ state: "running", controlHolder: "user" });
+    const initial = computer({
+      state: "running",
+      controlHolder: "user",
+      controlBotId: "bot-1",
+    });
     const expired = reduceComputerStatus(
       initial,
       event({
@@ -300,8 +308,16 @@ describe("computer event reduction", () => {
         payload: { holder: "bot", reason: "released" },
       }),
     );
-    expect(expired).toMatchObject({ state: "running", controlHolder: "none" });
-    expect(released).toMatchObject({ state: "running", controlHolder: "bot" });
+    expect(expired).toMatchObject({
+      state: "running",
+      controlHolder: "none",
+      controlBotId: null,
+    });
+    expect(released).toMatchObject({
+      state: "running",
+      controlHolder: "bot",
+      controlBotId: null,
+    });
   });
 });
 

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -131,12 +131,16 @@ export function reduceComputerStatus(
   if (!prev) return prev;
   if (!isComputerStatusEvent(event)) return prev;
   if (event.type === "computer.takeover.granted") {
-    return prev.controlHolder === "user" ? prev : { ...prev, controlHolder: "user" };
+    return prev.controlHolder === "user" && prev.controlBotId === event.botId
+      ? prev
+      : { ...prev, controlHolder: "user", controlBotId: event.botId };
   }
   if (event.type === "computer.takeover.released") {
     const holder = event.payload.holder;
     if (holder !== "bot" && holder !== "none") return prev;
-    return prev.controlHolder === holder ? prev : { ...prev, controlHolder: holder };
+    return prev.controlHolder === holder && prev.controlBotId === null
+      ? prev
+      : { ...prev, controlHolder: holder, controlBotId: null };
   }
   const status = event.payload.status;
   if (!isComputerState(status)) return prev;


### PR DESCRIPTION
## Summary

Updates web takeover event reduction to keep `controlHolder` and `controlBotId` synchronized when control is granted, released, or expires. Adds regression coverage for both grant and release state transitions, fixing the Team Computer E2E failure where the UI continued to show “Take control” after a successful takeover.

## Validation

- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web test`
- `pnpm test:e2e` (16 passed)