### PR TITLE
Fix Chrome offering to save the account password in the chat message box

### DIFF
--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -9,6 +9,11 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   const password = "password12";
   const userName = "Auth Lifecycle";
 
+  await page.goto("/sign-up");
+  await expect(page.getByLabel("Name")).toHaveAttribute("autocomplete", "name");
+  await expect(page.getByLabel("Email")).toHaveAttribute("autocomplete", "username");
+  await expect(page.getByLabel("Password")).toHaveAttribute("autocomplete", "new-password");
+
   await signup(page, email, password, userName);
   await completeOnboarding(page, ["A bit of everything", "Clear and tight"]);
 
@@ -32,6 +37,8 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await expect(page.getByRole("heading", { name: "Sign in to Rakazo" })).toBeVisible();
   await expect(page.getByText("Chief", { exact: true })).toHaveCount(0);
   await expect(page.getByText(userName, { exact: true })).toHaveCount(0);
+  await expect(page.getByLabel("Email")).toHaveAttribute("autocomplete", "username");
+  await expect(page.getByLabel("Password")).toHaveAttribute("autocomplete", "current-password");
   await captureScreenshot(page, testInfo, "38-protected-deep-link-sign-in");
 
   await page.getByPlaceholder("Your email address").fill(email);
@@ -50,7 +57,15 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await page.waitForURL((url) => url.pathname === protectedBotPath, {
     timeout: 20_000,
   });
-  await expect(page.getByPlaceholder("Message Chief")).toBeVisible();
+  const composer = page.getByRole("textbox", { name: "Message Chief" });
+  await expect(composer).toHaveAttribute("name", "chat-message");
+  await expect(composer).toHaveAttribute("autocomplete", "off");
+  await expect(composer).toHaveAttribute("aria-label", "Message Chief");
   await expect(page.getByRole("button", { name: new RegExp(userName, "i") })).toBeVisible();
+  const message = "Fake composer regression check.";
+  await composer.fill(message);
   await captureScreenshot(page, testInfo, "40-restored-auth-session");
+  await composer.press("Enter");
+  await expect(composer).toHaveValue("");
+  await expect(page.getByText(message, { exact: true })).toBeVisible();
 });

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -43,6 +43,9 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
           <label className="mb-4 w-full text-[16px] text-[#6E6E68]">
             Name
             <input
+              id="name"
+              name="name"
+              autoComplete="name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Your name"
@@ -53,6 +56,9 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
         <label className="w-full text-[16px] text-[#6E6E68]">
           Email
           <input
+            id="email"
+            name="email"
+            autoComplete="username"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="Your email address"
@@ -64,6 +70,9 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
         <label className="mt-4 w-full text-[16px] text-[#6E6E68]">
           Password
           <input
+            id={mode === "in" ? "current-password" : "new-password"}
+            name="password"
+            autoComplete={mode === "in" ? "current-password" : "new-password"}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Password"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2006,6 +2006,7 @@ const Composer = memo(function Composer({
           }}
           disabled={disabled}
           placeholder={activeName ? `Message ${activeName}` : "Message…"}
+          aria-label={activeName ? `Message ${activeName}` : "Message"}
           name="chat-message"
           autoComplete="off"
           className="flex-1 bg-transparent text-[15.5px] text-[#E9E9EA] outline-none disabled:opacity-40"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2006,6 +2006,8 @@ const Composer = memo(function Composer({
           }}
           disabled={disabled}
           placeholder={activeName ? `Message ${activeName}` : "Message…"}
+          name="chat-message"
+          autoComplete="off"
           className="flex-1 bg-transparent text-[15.5px] text-[#E9E9EA] outline-none disabled:opacity-40"
         />
         {running ? (


### PR DESCRIPTION
## Summary
The chat composer's message input had no `name` or `autoComplete` attribute, so on a page where the user just authenticated, Chrome's field-classification heuristics could mistake the empty text input for a login field and surface a saved-password suggestion directly over the message box.

## Fix
Add `name="chat-message"` and `autoComplete="off"` to the composer input, matching the same pattern used to fix the equivalent issue on the model/API-key settings inputs.

## Test plan
- [x] `tsc --noEmit` on `apps/web` passes
- [x] Manually reproduced the password suggestion popover before the fix, confirmed it no longer appears after