### PR TITLE
Sync computer panel status after RPC takeover

### DIFF
--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -159,9 +159,7 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
     .poll(async () => (await rpcResponse(page, "computer/takeover", { botId: chiefId })).ok)
     .toBe(true);
   await page.getByTitle("Agent computer").click();
-  await expect(page.getByText("You have control", { exact: true })).toBeVisible({
-    timeout: 30_000,
-  });
+  await expect(page.getByText("You have control", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "49-team-computer-takeover-after-stop");
   await rpc(page, "computer/release", { botId: chiefId });
 });

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -6,11 +6,13 @@ import type {
 } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
 import {
+  computerPanelShouldBoot,
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
   prependThreadMessagePage,
   reduceComputerStatus,
   reduceThreadSnapshot,
+  userHoldsComputerControl,
 } from "./thread-events.js";
 
 describe("thread event reduction", () => {
@@ -318,6 +320,29 @@ describe("computer event reduction", () => {
       controlHolder: "bot",
       controlBotId: null,
     });
+  });
+
+  it("fills in controlBotId when a grant arrives after controlHolder is already user", () => {
+    const granted = reduceComputerStatus(
+      computer({ state: "running", controlHolder: "user", controlBotId: null }),
+      event({ type: "computer.takeover.granted", payload: {} }),
+    );
+    expect(granted).toMatchObject({
+      state: "running",
+      controlHolder: "user",
+      controlBotId: "bot-1",
+    });
+    expect(userHoldsComputerControl(granted, "bot-1")).toBe(true);
+    expect(userHoldsComputerControl(granted, "bot-2")).toBe(false);
+  });
+
+  it("only auto-boots a computer panel that is stopped or failed", () => {
+    expect(computerPanelShouldBoot("stopped")).toBe(true);
+    expect(computerPanelShouldBoot("error")).toBe(true);
+    expect(computerPanelShouldBoot(undefined)).toBe(true);
+    expect(computerPanelShouldBoot("running")).toBe(false);
+    expect(computerPanelShouldBoot("booting")).toBe(false);
+    expect(computerPanelShouldBoot("suspended")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -6,7 +6,7 @@ import type {
 } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
 import {
-  computerPanelShouldBoot,
+  computerPanelAutoBoot,
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
   prependThreadMessagePage,
@@ -336,13 +336,14 @@ describe("computer event reduction", () => {
     expect(userHoldsComputerControl(granted, "bot-2")).toBe(false);
   });
 
-  it("only auto-boots a computer panel that is stopped or failed", () => {
-    expect(computerPanelShouldBoot("stopped")).toBe(true);
-    expect(computerPanelShouldBoot("error")).toBe(true);
-    expect(computerPanelShouldBoot(undefined)).toBe(true);
-    expect(computerPanelShouldBoot("running")).toBe(false);
-    expect(computerPanelShouldBoot("booting")).toBe(false);
-    expect(computerPanelShouldBoot("suspended")).toBe(false);
+  it("auto-boots stopped computers and recovers a running screen that has no URL", () => {
+    expect(computerPanelAutoBoot("stopped")).toBe("boot");
+    expect(computerPanelAutoBoot("error")).toBe("boot");
+    expect(computerPanelAutoBoot(undefined)).toBe("boot");
+    expect(computerPanelAutoBoot("running", "https://screen.example")).toBe("wait");
+    expect(computerPanelAutoBoot("running", null)).toBe("recover-screen");
+    expect(computerPanelAutoBoot("booting")).toBe("wait");
+    expect(computerPanelAutoBoot("suspended")).toBe("wait");
   });
 });
 

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -124,6 +124,17 @@ export function reduceThreadSnapshot(
   return prev;
 }
 
+export function userHoldsComputerControl(
+  computer: Pick<ComputerStatus, "controlHolder" | "controlBotId"> | null | undefined,
+  botId: string | undefined,
+): boolean {
+  return Boolean(botId && computer?.controlHolder === "user" && computer.controlBotId === botId);
+}
+
+export function computerPanelShouldBoot(state: ComputerStatus["state"] | undefined): boolean {
+  return state !== "running" && state !== "booting" && state !== "suspended";
+}
+
 export function reduceComputerStatus(
   prev: ComputerStatus | null,
   event: ProductEvent,

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -131,8 +131,13 @@ export function userHoldsComputerControl(
   return Boolean(botId && computer?.controlHolder === "user" && computer.controlBotId === botId);
 }
 
-export function computerPanelShouldBoot(state: ComputerStatus["state"] | undefined): boolean {
-  return state !== "running" && state !== "booting" && state !== "suspended";
+export function computerPanelAutoBoot(
+  state: ComputerStatus["state"] | undefined,
+  screenUrl?: string | null,
+): "boot" | "recover-screen" | "wait" {
+  if (state === "booting" || state === "suspended") return "wait";
+  if (state === "running") return screenUrl ? "wait" : "recover-screen";
+  return "boot";
 }
 
 export function reduceComputerStatus(

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -74,7 +74,7 @@ import { revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
 import { rpc } from "../lib/rpc";
 import {
-  computerPanelShouldBoot,
+  computerPanelAutoBoot,
   isComputerStatusEvent,
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
@@ -319,7 +319,7 @@ export function ShellPage() {
   }
 
   async function refreshComputerScreen(id: string) {
-    if (!computerVisible.current) return;
+    if (!computerVisible.current) return null;
     const request = ++screenRequest.current;
     const screen = await rpc.computer.screenUrl({ botId: id }).catch(() => ({ url: null }));
     if (
@@ -327,9 +327,10 @@ export function ShellPage() {
       activeBotId.current !== id ||
       !computerVisible.current
     ) {
-      return;
+      return null;
     }
     setScreenUrl(screen.url);
+    return screen.url;
   }
 
   async function loadOlderMessages() {
@@ -878,7 +879,10 @@ export function ShellPage() {
       const snap = await refreshThread(botId).catch(() => null);
       if (cancelled || activeBotId.current !== botId) return;
       const state = snap?.computer?.state;
-      if (!computerPanelShouldBoot(state)) {
+      const screen = state === "running" ? await refreshComputerScreen(botId) : null;
+      if (cancelled || activeBotId.current !== botId) return;
+      const action = computerPanelAutoBoot(state, screen);
+      if (action === "wait") {
         if (state === "running") autoBooted.current = botId;
         return;
       }
@@ -886,7 +890,7 @@ export function ShellPage() {
       autoBooted.current = botId;
       await bootComputer({
         takeControl: false,
-        overlay: true,
+        overlay: action === "boot",
         force: true,
       });
     })();

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -886,7 +886,7 @@ export function ShellPage() {
         if (state === "running") autoBooted.current = botId;
         return;
       }
-      if (autoBooted.current === botId) return;
+      if (action === "boot" && autoBooted.current === botId) return;
       autoBooted.current = botId;
       await bootComputer({
         takeControl: false,

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -74,12 +74,14 @@ import { revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
 import { rpc } from "../lib/rpc";
 import {
+  computerPanelShouldBoot,
   isComputerStatusEvent,
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
   prependThreadMessagePage,
   reduceComputerStatus,
   reduceThreadSnapshot,
+  userHoldsComputerControl,
 } from "../lib/thread-events";
 import { speaker } from "../lib/tts";
 import type { ContextMenuPosition } from "./BotContextMenu";
@@ -868,15 +870,30 @@ export function ShellPage() {
       return;
     }
     if (!active) return;
-    if (computer?.state === "booting" || computer?.state === "suspended") return;
-    if (autoBooted.current === active.id && computer?.state === "running" && screenUrl) return;
-    autoBooted.current = active.id;
-    void bootComputer({
-      takeControl: false,
-      overlay: computer?.state !== "running",
-      force: true,
-    });
-  }, [panel, active?.id, computer?.state, screenUrl]);
+    const botId = active.id;
+    let cancelled = false;
+    void (async () => {
+      // Refresh from the server first. A stale SSE "booting" snapshot used to
+      // skip this effect, so an RPC takeover never showed "You have control".
+      const snap = await refreshThread(botId).catch(() => null);
+      if (cancelled || activeBotId.current !== botId) return;
+      const state = snap?.computer?.state;
+      if (!computerPanelShouldBoot(state)) {
+        if (state === "running") autoBooted.current = botId;
+        return;
+      }
+      if (autoBooted.current === botId) return;
+      autoBooted.current = botId;
+      await bootComputer({
+        takeControl: false,
+        overlay: true,
+        force: true,
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [panel, active?.id]);
 
   useEffect(() => {
     setComputerOpen(false);
@@ -920,7 +937,7 @@ export function ShellPage() {
 
   async function openComputer() {
     if (!active) return;
-    const needsTakeover = computer?.controlHolder !== "user";
+    const needsTakeover = !userHoldsComputerControl(computer, active.id);
     await bootComputer({
       takeControl: needsTakeover,
       overlay: needsTakeover || computer?.state !== "running",
@@ -937,6 +954,7 @@ export function ShellPage() {
   }
 
   const embeddedScreenUrl = embeddableScreenUrl(screenUrl);
+  const hasControl = userHoldsComputerControl(computer, active?.id);
 
   const userName = session.data?.user.name ?? "You";
   const initials = userName
@@ -1309,13 +1327,13 @@ export function ShellPage() {
                   <span className="text-[13.5px] text-[#85858A]">
                     {computer?.busyBotName
                       ? `${computer.busyBotName} is using it`
-                      : computer?.controlHolder === "user" && computer.controlBotId === active.id
+                      : hasControl
                         ? "You have control"
                         : computer?.state === "suspended"
                           ? "Asleep"
                           : computerLabel(computer?.mode, active.name)}
                   </span>
-                  {computer?.controlHolder === "user" && computer.controlBotId === active.id ? (
+                  {hasControl ? (
                     <Button
                       type="button"
                       variant="outline"
@@ -1699,9 +1717,7 @@ export function ShellPage() {
                   {computerLabel(computer?.mode, active.name)}
                 </span>
               )}
-              {!recordingSkill &&
-              computer?.controlHolder === "user" &&
-              computer.controlBotId === active.id ? (
+              {!recordingSkill && hasControl ? (
                 <span className="rounded-full bg-[rgba(48,162,75,.14)] px-[11px] py-1 text-[13px] text-[#4ECB71]">
                   You have control
                 </span>
@@ -1710,7 +1726,7 @@ export function ShellPage() {
             <div className="flex items-center gap-3">
               {recordingSkill ? (
                 <TeachStopButton busy={teachBusy} onStop={stopTeaching} />
-              ) : computer?.controlHolder === "user" && computer.controlBotId === active.id ? (
+              ) : hasControl ? (
                 <Button
                   type="button"
                   variant="outline"
@@ -1754,11 +1770,7 @@ export function ShellPage() {
                   className="h-full w-full border-0 bg-black"
                   allow="clipboard-read; clipboard-write; fullscreen"
                   style={{
-                    pointerEvents:
-                      recordingSkill ||
-                      !(computer?.controlHolder === "user" && computer.controlBotId === active.id)
-                        ? "none"
-                        : "auto",
+                    pointerEvents: recordingSkill || !hasControl ? "none" : "auto",
                   }}
                 />
                 {active ? (


### PR DESCRIPTION
## Summary
- Opening the computer panel now refreshes from the server before deciding to auto-boot, so a stale SSE `booting` snapshot cannot skip the update after `computer/takeover`.
- The panel shows **You have control** from the authoritative `controlBotId`, matching the Team Computer takeover e2e that was failing on main.
- Removes the 30s timeout that papered over this race.

## Test plan
- [ ] `pnpm --filter @rakazo/web test` (thread-events coverage for grant/`controlBotId` and panel boot decisions)
- [ ] CI Web E2E: `an active Team bot must be stopped before user takeover`
- [ ] Manually: start a hanging Team bot, stop it, take over over RPC or UI, open the computer panel and confirm **You have control** appears without a long wait


Made with [Cursor](https://cursor.com)