### PR TITLE
Add pinned bot groups and sidebar sections

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -156,9 +156,10 @@ export function createRouter(deps: RouterDeps) {
     me: authed.me.handler(async ({ context }): Promise<Me> => meDto(deps, context.actor)),
     bootstrap: authed.bootstrap.handler(async ({ context, input }) => {
       const actor = context.actor;
-      const [me, bots, archivedBots] = await Promise.all([
+      const [me, bots, botSections, archivedBots] = await Promise.all([
         meDto(deps, actor),
         repos.listBots(actor),
+        repos.listBotSections(actor),
         repos.listBots(actor, { archived: true }),
       ]);
       const active = bots.find((bot) => bot.id === input.botId) ?? bots[0];
@@ -168,7 +169,7 @@ export function createRouter(deps: RouterDeps) {
             listRoutinesDto(deps, actor, active.id),
           ])
         : [null, []];
-      return { me, bots, archivedBots, thread, routines };
+      return { me, bots, botSections, archivedBots, thread, routines };
     }),
     deployment: {
       get: authed.deployment.get.handler(async ({ context }) => {
@@ -331,6 +332,17 @@ export function createRouter(deps: RouterDeps) {
       }),
       update: authed.bots.update.handler(async ({ context, input }) => {
         await repos.getBot(context.actor, input.botId);
+        if (input.sectionId) {
+          const section = await deps.prisma.botSection.findFirst({
+            where: {
+              id: input.sectionId,
+              workspaceId: context.actor.workspaceId,
+              userId: context.actor.userId,
+            },
+            select: { id: true },
+          });
+          if (!section) throw new IsolationError();
+        }
         await deps.prisma.bot.update({
           where: { id: input.botId },
           data: {
@@ -341,6 +353,7 @@ export function createRouter(deps: RouterDeps) {
             notifyOnFinish: input.notifyOnFinish,
             color: input.color,
             pinned: input.pinned,
+            sectionId: input.sectionId,
             voiceId: input.voiceId,
             autoSpeak: input.autoSpeak,
           },
@@ -449,6 +462,14 @@ export function createRouter(deps: RouterDeps) {
         );
         return { ok: true as const };
       }),
+    },
+    botSections: {
+      list: authed.botSections.list.handler(async ({ context }) =>
+        repos.listBotSections(context.actor),
+      ),
+      create: authed.botSections.create.handler(async ({ context, input }) =>
+        repos.createBotSection(context.actor, input),
+      ),
     },
     threads: {
       get: authed.threads.get.handler(async ({ context, input }) =>

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,4 +1,5 @@
 import type { SearchHit } from "@rakazo/contracts";
+import { groupBotsForSidebar } from "@rakazo/core";
 import { Redirect, useFocusEffect, useRouter } from "expo-router";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -13,8 +14,15 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { BotAvatar } from "../components/bot-avatar";
+import { BotOrganizeModal } from "../components/bot-organize-modal";
 import { NativeSymbol } from "../components/native-symbol";
-import { loadSessionToken, type MobileBot, type MobileMe, rpc } from "../lib/api";
+import {
+  loadSessionToken,
+  type MobileBot,
+  type MobileBotSection,
+  type MobileMe,
+  rpc,
+} from "../lib/api";
 import { botTag, filterBots, formatThreadTime, userInitials } from "../lib/inbox";
 import { native } from "../lib/native";
 import { previewSnippet } from "../lib/preview";
@@ -24,8 +32,14 @@ import { mobileSearchDestination } from "../lib/search-destination";
 
 const FALLBACK_COLOR = "#9B5CF6";
 
+type InboxItem =
+  | { type: "bot"; bot: MobileBot }
+  | { type: "search"; hit: SearchHit }
+  | { type: "heading"; key: string; title: string };
+
 export default function Home() {
   const [bots, setBots] = useState<MobileBot[]>([]);
+  const [botSections, setBotSections] = useState<MobileBotSection[]>([]);
   const [me, setMe] = useState<MobileMe | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
@@ -35,11 +49,17 @@ export default function Home() {
   const [searching, setSearching] = useState(false);
   const [searchHits, setSearchHits] = useState<SearchHit[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
+  const [organizeBotId, setOrganizeBotId] = useState<string | null>(null);
 
   const loadBots = useCallback(async () => {
     setError(null);
     try {
-      setBots(await rpc<MobileBot[]>("bots/list"));
+      const [nextBots, nextSections] = await Promise.all([
+        rpc<MobileBot[]>("bots/list"),
+        rpc<MobileBotSection[]>("botSections/list"),
+      ]);
+      setBots(nextBots);
+      setBotSections(nextSections);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not load bots");
     }
@@ -103,11 +123,17 @@ export default function Home() {
   }, [query, searching]);
 
   const visible = useMemo(() => filterBots(bots, query), [bots, query]);
-  const listData = useMemo(
-    (): Array<MobileBot | SearchHit> => (query.trim() && searching ? searchHits : visible),
-    [query, searching, searchHits, visible],
-  );
+  const listData = useMemo((): InboxItem[] => {
+    if (query.trim() && searching) {
+      return searchHits.map((hit) => ({ type: "search", hit }));
+    }
+    return groupBotsForSidebar(visible, botSections).flatMap((group) => [
+      ...(group.title ? [{ type: "heading" as const, key: group.key, title: group.title }] : []),
+      ...group.bots.map((bot) => ({ type: "bot" as const, bot })),
+    ]);
+  }, [botSections, query, searching, searchHits, visible]);
   const initials = userInitials(me?.name ?? "");
+  const organizeBot = bots.find((bot) => bot.id === organizeBotId) ?? null;
   const insets = useSafeAreaInsets();
   const router = useRouter();
 
@@ -163,13 +189,14 @@ export default function Home() {
 
       {error ? <Text style={styles.error}>{error}</Text> : null}
 
-      <FlatList<MobileBot | SearchHit>
+      <FlatList<InboxItem>
         data={listData}
-        keyExtractor={(item) =>
-          "kind" in item
-            ? `${item.kind}-${item.botId}-${item.messageId ?? item.artifactId ?? item.routineId ?? item.url}`
-            : item.id
-        }
+        keyExtractor={(item) => {
+          if (item.type === "heading") return `heading-${item.key}`;
+          if (item.type === "bot") return item.bot.id;
+          const hit = item.hit;
+          return `${hit.kind}-${hit.botId}-${hit.messageId ?? hit.artifactId ?? hit.routineId ?? hit.url}`;
+        }}
         keyboardDismissMode="interactive"
         keyboardShouldPersistTaps="handled"
         indicatorStyle="white"
@@ -197,20 +224,37 @@ export default function Home() {
           </Text>
         }
         renderItem={({ item }) =>
-          "kind" in item ? (
+          item.type === "search" ? (
             <SearchRow
-              hit={item}
+              hit={item.hit}
               onPress={() => {
                 setQuery("");
                 setSearchHits([]);
-                router.push(mobileSearchDestination(item));
+                router.push(mobileSearchDestination(item.hit));
               }}
             />
+          ) : item.type === "heading" ? (
+            <Text style={styles.sectionHeading}>{item.title}</Text>
           ) : (
-            <BotRow bot={item} />
+            <BotRow bot={item.bot} onLongPress={() => setOrganizeBotId(item.bot.id)} />
           )
         }
       />
+      {organizeBot ? (
+        <BotOrganizeModal
+          bot={organizeBot}
+          sections={botSections}
+          onClose={() => setOrganizeBotId(null)}
+          onUpdate={async (update) => {
+            await rpc("bots/update", { botId: organizeBot.id, ...update });
+            await loadBots();
+          }}
+          onCreateSection={async (name) => {
+            await rpc("botSections/create", { botId: organizeBot.id, name });
+            await loadBots();
+          }}
+        />
+      ) : null}
     </View>
   );
 }
@@ -260,7 +304,7 @@ function SearchRow({ hit, onPress }: { hit: SearchHit; onPress: () => void }) {
   );
 }
 
-function BotRow({ bot }: { bot: MobileBot }) {
+function BotRow({ bot, onLongPress }: { bot: MobileBot; onLongPress: () => void }) {
   const router = useRouter();
   const preview = previewSnippet(bot.preview, 40) || bot.title || "No messages yet";
   const time = bot.updatedAt ? formatThreadTime(bot.updatedAt) : "";
@@ -272,9 +316,11 @@ function BotRow({ bot }: { bot: MobileBot }) {
   return (
     <Pressable
       accessibilityLabel={label}
+      accessibilityHint="Long press to pin or move to a section"
       onPress={() =>
         router.push({ pathname: "/thread", params: { botId: bot.id, name: bot.name } })
       }
+      onLongPress={onLongPress}
       style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
     >
       <BotAvatar color={bot.color || FALLBACK_COLOR} />
@@ -366,6 +412,14 @@ const styles = StyleSheet.create({
   list: {
     flexGrow: 1,
     paddingBottom: 32,
+  },
+  sectionHeading: {
+    color: native.secondaryLabel,
+    fontSize: 14,
+    fontWeight: "600",
+    paddingHorizontal: 20,
+    paddingTop: 18,
+    paddingBottom: 6,
   },
   empty: {
     color: native.secondaryLabel,

--- a/apps/mobile/components/bot-organize-modal.tsx
+++ b/apps/mobile/components/bot-organize-modal.tsx
@@ -1,0 +1,255 @@
+import { useState } from "react";
+import { Modal, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
+import type { MobileBot, MobileBotSection } from "../lib/api";
+import { native } from "../lib/native";
+import { NativeSymbol } from "./native-symbol";
+
+export type BotOrganizationUpdate = {
+  pinned?: boolean;
+  sectionId?: string | null;
+};
+
+export function BotOrganizeModal({
+  bot,
+  sections,
+  onClose,
+  onUpdate,
+  onCreateSection,
+}: {
+  bot: MobileBot;
+  sections: MobileBotSection[];
+  onClose: () => void;
+  onUpdate: (update: BotOrganizationUpdate) => Promise<void>;
+  onCreateSection: (name: string) => Promise<void>;
+}) {
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save(request: () => Promise<void>) {
+    if (saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await request();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not update bot");
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Modal transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <Pressable
+          accessibilityLabel="Close bot organization"
+          style={StyleSheet.absoluteFill}
+          onPress={onClose}
+        />
+        <View style={styles.sheet}>
+          <Text style={styles.title} numberOfLines={1}>
+            {bot.name}
+          </Text>
+          <Pressable
+            disabled={saving}
+            onPress={() => void save(() => onUpdate({ pinned: !bot.pinned }))}
+            style={({ pressed }) => [styles.action, pressed && styles.pressed]}
+          >
+            <NativeSymbol
+              ios={bot.pinned ? "pin.slash" : "pin"}
+              android={bot.pinned ? "pin-outline" : "pin"}
+              size={18}
+            />
+            <Text style={styles.actionLabel}>{bot.pinned ? "Unpin" : "Pin"}</Text>
+          </Pressable>
+          <Text style={styles.sectionLabel}>Move to</Text>
+          <ScrollView style={styles.sectionOptions} keyboardShouldPersistTaps="handled">
+            {sections.map((section) => (
+              <SectionOption
+                key={section.id}
+                label={section.name}
+                selected={bot.sectionId === section.id}
+                disabled={saving || bot.sectionId === section.id}
+                onPress={() => void save(() => onUpdate({ sectionId: section.id }))}
+              />
+            ))}
+            <SectionOption
+              label="Unassigned"
+              selected={bot.sectionId === null}
+              disabled={saving || bot.sectionId === null}
+              onPress={() => void save(() => onUpdate({ sectionId: null }))}
+            />
+          </ScrollView>
+          {creating ? (
+            <View style={styles.newSectionRow}>
+              <TextInput
+                autoFocus
+                value={name}
+                onChangeText={setName}
+                maxLength={60}
+                placeholder="Section name"
+                placeholderTextColor={native.secondaryLabel}
+                style={styles.newSectionInput}
+              />
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Create section"
+                disabled={saving || !name.trim()}
+                onPress={() => void save(() => onCreateSection(name.trim()))}
+                style={styles.newSectionSubmit}
+              >
+                <Text style={styles.newSectionSubmitLabel}>Create</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <Pressable
+              disabled={saving}
+              onPress={() => setCreating(true)}
+              style={({ pressed }) => [styles.action, pressed && styles.pressed]}
+            >
+              <NativeSymbol ios="folder.badge.plus" android="folder-outline" size={18} />
+              <Text style={styles.actionLabel}>New section</Text>
+            </Pressable>
+          )}
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+          <Pressable onPress={onClose} style={styles.cancel}>
+            <Text style={styles.cancelLabel}>Cancel</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function SectionOption({
+  label,
+  selected,
+  disabled,
+  onPress,
+}: {
+  label: string;
+  selected: boolean;
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected, disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [styles.sectionOption, pressed && styles.pressed]}
+    >
+      <NativeSymbol ios="folder" android="folder-outline" size={18} />
+      <Text style={styles.actionLabel} numberOfLines={1}>
+        {label}
+      </Text>
+      {selected ? <NativeSymbol ios="checkmark" android="checkmark" size={17} /> : null}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0, 0, 0, 0.62)",
+  },
+  sheet: {
+    maxHeight: "82%",
+    borderTopLeftRadius: 22,
+    borderTopRightRadius: 22,
+    backgroundColor: "#1C1C1E",
+    paddingHorizontal: 16,
+    paddingTop: 18,
+    paddingBottom: 28,
+  },
+  title: {
+    color: native.label,
+    fontSize: 18,
+    fontWeight: "600",
+    paddingHorizontal: 8,
+    paddingBottom: 10,
+  },
+  action: {
+    minHeight: 46,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderRadius: 11,
+    paddingHorizontal: 10,
+  },
+  pressed: {
+    backgroundColor: native.fill,
+  },
+  actionLabel: {
+    flex: 1,
+    color: native.label,
+    fontSize: 16,
+  },
+  sectionLabel: {
+    color: native.secondaryLabel,
+    fontSize: 13,
+    fontWeight: "600",
+    paddingHorizontal: 10,
+    paddingTop: 12,
+    paddingBottom: 6,
+  },
+  sectionOptions: {
+    maxHeight: 230,
+  },
+  sectionOption: {
+    minHeight: 44,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    borderRadius: 11,
+    paddingHorizontal: 10,
+  },
+  newSectionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  newSectionInput: {
+    flex: 1,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: native.fill,
+    color: native.label,
+    paddingHorizontal: 12,
+    fontSize: 16,
+  },
+  newSectionSubmit: {
+    minHeight: 40,
+    justifyContent: "center",
+    borderRadius: 10,
+    backgroundColor: native.label,
+    paddingHorizontal: 14,
+  },
+  newSectionSubmitLabel: {
+    color: native.page,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  error: {
+    color: "#FF5364",
+    fontSize: 13,
+    paddingHorizontal: 10,
+    paddingTop: 8,
+  },
+  cancel: {
+    alignItems: "center",
+    paddingTop: 14,
+    paddingBottom: 2,
+  },
+  cancelLabel: {
+    color: native.secondaryLabel,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -1,4 +1,11 @@
-import type { Bot, ComputerMode, Me, ModelCatalogEntry, ModelCredential } from "@rakazo/contracts";
+import type {
+  Bot,
+  BotSection,
+  ComputerMode,
+  Me,
+  ModelCatalogEntry,
+  ModelCredential,
+} from "@rakazo/contracts";
 import {
   mergeThreadHistory,
   prependThreadHistoryPage,
@@ -140,12 +147,15 @@ export type MobileBot = Pick<
   | "title"
   | "color"
   | "pinned"
+  | "sectionId"
   | "archivedAt"
   | "unread"
   | "updatedAt"
   | "computerMode"
 > &
   Partial<Pick<Bot, "parentBotId">>;
+
+export type MobileBotSection = BotSection;
 
 export type MobileMe = Pick<
   Me,

--- a/apps/mobile/lib/inbox.test.ts
+++ b/apps/mobile/lib/inbox.test.ts
@@ -75,6 +75,7 @@ function bot(id: string, name: string, title: string, preview: string) {
     preview,
     color: "#9B5CF6",
     pinned: false,
+    sectionId: null,
     archivedAt: null,
     unread: false,
     updatedAt: now.toISOString(),

--- a/apps/web/e2e/bot-organization.spec.ts
+++ b/apps/web/e2e/bot-organization.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+test("pinned bots and sidebar sections persist", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `bot-organize-${stamp}@rakazo.test`, "password12", "Test User");
+  await completeOnboarding(page, ["A bit of everything", "Clear and tight"]);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  const sidebar = page.locator("aside").first();
+  const bot = sidebar.getByRole("button", { name: /^Chief/ });
+
+  await bot.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Pin", exact: true }).click();
+  await expect(sidebar.locator('[data-sidebar-group="pinned"]')).toContainText("Chief");
+  await captureScreenshot(page, testInfo, "pinned-bots");
+
+  await bot.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Unpin", exact: true }).click();
+  await expect(sidebar.locator('[data-sidebar-group="pinned"]')).toHaveCount(0);
+
+  await bot.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Move to", exact: true }).click();
+  await captureScreenshot(page, testInfo, "move-to-section-menu");
+  await page
+    .getByRole("menu", { name: /Move Chief to section/ })
+    .getByText("New section")
+    .click();
+  const dialog = page.getByRole("dialog", { name: "New section" });
+  await dialog.getByLabel("Name").fill("Projects");
+  await dialog.getByRole("button", { name: "Create" }).click();
+
+  const projects = sidebar.locator('[data-sidebar-group^="section:"]');
+  await expect(projects).toContainText("Projects");
+  await expect(projects).toContainText("Chief");
+  await captureScreenshot(page, testInfo, "bot-sections");
+
+  await page.reload();
+  await expect(projects).toContainText("Projects");
+  await expect(projects).toContainText("Chief");
+
+  await bot.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Move to", exact: true }).click();
+  await page
+    .getByRole("menu", { name: /Move Chief to section/ })
+    .getByRole("menuitem", { name: "Unassigned", exact: true })
+    .click();
+  await expect(sidebar.locator('[data-sidebar-group="unassigned"]')).toContainText("Chief");
+});

--- a/apps/web/src/pages/BotContextMenu.tsx
+++ b/apps/web/src/pages/BotContextMenu.tsx
@@ -1,5 +1,5 @@
-import type { Bot } from "@rakazo/contracts";
-import { type ReactNode, type Ref, useEffect, useRef } from "react";
+import type { Bot, BotSection } from "@rakazo/contracts";
+import { type ReactNode, type Ref, useEffect, useRef, useState } from "react";
 
 export type ContextMenuPosition = { x: number; y: number };
 
@@ -8,6 +8,9 @@ export function BotContextMenu({
   position,
   onClose,
   onTogglePinned,
+  sections,
+  onMoveToSection,
+  onCreateSection,
   onToggleUnread,
   onEdit,
   onDuplicate,
@@ -19,6 +22,9 @@ export function BotContextMenu({
   position: ContextMenuPosition;
   onClose: () => void;
   onTogglePinned: () => void;
+  sections: BotSection[];
+  onMoveToSection: (sectionId: string | null) => void;
+  onCreateSection: () => void;
   onToggleUnread: () => void;
   onEdit: () => void;
   onDuplicate: () => void;
@@ -27,6 +33,7 @@ export function BotContextMenu({
   onDelete: () => void;
 }) {
   const firstItem = useRef<HTMLButtonElement>(null);
+  const [sectionMenuOpen, setSectionMenuOpen] = useState(false);
 
   useEffect(() => {
     firstItem.current?.focus();
@@ -38,10 +45,16 @@ export function BotContextMenu({
   }, [onClose]);
 
   const menuWidth = 264;
-  const menuHeight = 340;
+  const menuHeight = 390;
   const margin = 8;
   const left = Math.min(position.x, window.innerWidth - menuWidth - margin);
   const top = Math.min(position.y, window.innerHeight - menuHeight - margin);
+  const safeLeft = Math.max(margin, left);
+  const safeTop = Math.max(margin, top);
+  const sectionLeft =
+    safeLeft + menuWidth * 2 + margin <= window.innerWidth
+      ? safeLeft + menuWidth + 6
+      : safeLeft - menuWidth - 6;
 
   return (
     <div className="fixed inset-0 z-40">
@@ -59,13 +72,20 @@ export function BotContextMenu({
         role="menu"
         aria-label={`Actions for ${bot.name}`}
         className="fixed w-[264px] rounded-[18px] border border-[#343438] bg-[#1A1A1D] p-2 shadow-[0_24px_60px_rgba(0,0,0,.62)]"
-        style={{ left: Math.max(margin, left), top: Math.max(margin, top) }}
+        style={{ left: safeLeft, top: safeTop }}
       >
         <MenuItem
           buttonRef={firstItem}
           icon={<PinIcon />}
           label={bot.pinned ? "Unpin" : "Pin"}
           onSelect={onTogglePinned}
+        />
+        <MenuItem
+          icon={<FolderIcon />}
+          endIcon={<ChevronIcon />}
+          label="Move to"
+          expanded={sectionMenuOpen}
+          onSelect={() => setSectionMenuOpen((open) => !open)}
         />
         <MenuItem
           icon={<ReadStatusIcon unread={bot.unread} />}
@@ -80,6 +100,32 @@ export function BotContextMenu({
         <MenuItem icon={<ArchiveIcon />} label="Archive" onSelect={onArchive} />
         <MenuItem icon={<TrashIcon />} label="Delete" tone="danger" onSelect={onDelete} />
       </div>
+      {sectionMenuOpen ? (
+        <div
+          role="menu"
+          aria-label={`Move ${bot.name} to section`}
+          className="fixed max-h-[min(420px,calc(100vh-16px))] w-[264px] overflow-y-auto rounded-[18px] border border-[#343438] bg-[#1A1A1D] p-2 shadow-[0_24px_60px_rgba(0,0,0,.62)]"
+          style={{ left: Math.max(margin, sectionLeft), top: safeTop }}
+        >
+          {sections.map((section) => (
+            <MenuItem
+              key={section.id}
+              icon={<FolderIcon />}
+              endIcon={bot.sectionId === section.id ? <CheckIcon /> : null}
+              label={section.name}
+              onSelect={() => onMoveToSection(section.id)}
+            />
+          ))}
+          <MenuItem
+            icon={<FolderIcon />}
+            endIcon={bot.sectionId === null ? <CheckIcon /> : null}
+            label="Unassigned"
+            onSelect={() => onMoveToSection(null)}
+          />
+          <div className="my-1 border-t border-[#343438]" />
+          <MenuItem icon={<NewFolderIcon />} label="New section" onSelect={onCreateSection} />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -87,13 +133,17 @@ export function BotContextMenu({
 function MenuItem({
   buttonRef,
   icon,
+  endIcon,
   label,
+  expanded,
   tone = "default",
   onSelect,
 }: {
   buttonRef?: Ref<HTMLButtonElement>;
   icon: ReactNode;
+  endIcon?: ReactNode;
   label: string;
+  expanded?: boolean;
   tone?: "default" | "danger";
   onSelect: () => void;
 }) {
@@ -102,6 +152,7 @@ function MenuItem({
       ref={buttonRef}
       type="button"
       role="menuitem"
+      aria-expanded={expanded}
       className={`flex w-full items-center gap-3 rounded-[11px] px-3 py-2.5 text-left text-[15px] outline-none hover:bg-[#29292D] focus-visible:bg-[#29292D] ${
         tone === "danger" ? "text-[#FF5364]" : "text-[#ECECEE]"
       }`}
@@ -109,6 +160,7 @@ function MenuItem({
     >
       <span className="grid h-5 w-5 shrink-0 place-items-center">{icon}</span>
       <span>{label}</span>
+      {endIcon ? <span className="ml-auto grid h-5 w-5 place-items-center">{endIcon}</span> : null}
     </button>
   );
 }
@@ -129,6 +181,38 @@ function PinIcon() {
   return (
     <svg {...iconProps}>
       <path d="m15 4 5 5-4 2-3 5-2-2-5 5-1-1 5-5-2-2 5-3 2-4Z" />
+    </svg>
+  );
+}
+
+function FolderIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="M3 6h7l2 2h9v11H3z" />
+    </svg>
+  );
+}
+
+function NewFolderIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="M3 6h7l2 2h9v11H3zM16 11v5m-2.5-2.5h5" />
+    </svg>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="m9 5 7 7-7 7" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg {...iconProps}>
+      <path d="m5 12 4 4L19 6" />
     </svg>
   );
 }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1,6 +1,7 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type {
   Bot,
+  BotSection,
   ComputerMode,
   ComputerStatus,
   Me,
@@ -24,6 +25,7 @@ import {
   cronFromPreset,
   defaultCronPreset,
   formatCron,
+  groupBotsForSidebar,
   inferAttachmentMimeType,
   isActive,
   presetFromCron,
@@ -123,6 +125,7 @@ export function ShellPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const session = authClient.useSession();
   const [bots, setBots] = useState<Bot[]>([]);
+  const [botSections, setBotSections] = useState<BotSection[]>([]);
   const [archivedBots, setArchivedBots] = useState<Bot[]>([]);
   const [archivedOpen, setArchivedOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -156,6 +159,7 @@ export function ShellPage() {
   } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Bot | null>(null);
   const [clearTarget, setClearTarget] = useState<Bot | null>(null);
+  const [newSectionBot, setNewSectionBot] = useState<Bot | null>(null);
   const [booting, setBooting] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [initialBotsLoaded, setInitialBotsLoaded] = useState(false);
@@ -256,12 +260,14 @@ export function ShellPage() {
 
   async function refreshBots(includeArchived = false) {
     markOnce("rk:renderer:bots-request-start");
-    const [list, archived] = await Promise.all([
+    const [list, sections, archived] = await Promise.all([
       rpc.bots.list(),
+      rpc.botSections.list(),
       includeArchived ? rpc.bots.listArchived() : Promise.resolve(null),
     ]);
     markOnce("rk:renderer:bots-response");
     setBots(list);
+    setBotSections(sections);
     setInitialBotsLoaded(true);
     if (archived) setArchivedBots(archived);
     if (includeArchived && list.length === 0 && archived?.length === 0) {
@@ -364,6 +370,7 @@ export function ShellPage() {
         if (cancelled) return;
         setBootstrapMe(bootstrap.me);
         setBots(bootstrap.bots);
+        setBotSections(bootstrap.botSections);
         setArchivedBots(bootstrap.archivedBots);
         setInitialBotsLoaded(true);
         if (bootstrap.thread) {
@@ -543,6 +550,10 @@ export function ShellPage() {
   const filtered = useMemo(
     () => bots.filter((b) => `${b.name} ${b.preview}`.toLowerCase().includes(query.toLowerCase())),
     [bots, query],
+  );
+  const sidebarGroups = useMemo(
+    () => groupBotsForSidebar(filtered, botSections),
+    [botSections, filtered],
   );
   const workspaceQuery = query.trim();
   const showWorkspaceSearch = workspaceQuery.length > 0;
@@ -1006,50 +1017,62 @@ export function ShellPage() {
               onSelect={(hit) => void jumpToSearchHit(hit)}
             />
           ) : (
-            filtered.map((bot) => (
-              <button
-                key={bot.id}
-                type="button"
-                onClick={() => navigate(`/app/${bot.id}`)}
-                onContextMenu={(event) => {
-                  event.preventDefault();
-                  setBotMenu({ botId: bot.id, position: { x: event.clientX, y: event.clientY } });
-                }}
-                className="flex gap-3 rounded-xl px-2.5 py-[11px] text-left"
-                style={{
-                  background: active?.id === bot.id ? "#161618" : "transparent",
-                }}
-              >
-                <BotAvatar color={bot.color} size={38} />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-baseline justify-between gap-2">
-                    <span
-                      className={`text-[15px] text-[#ECECEE] ${
-                        bot.unread ? "font-semibold" : "font-medium"
-                      }`}
-                    >
-                      {bot.name}
-                      {bot.unread ? <span className="sr-only"> (unread)</span> : null}
-                    </span>
-                    <span className="flex shrink-0 items-center gap-1.5 text-[12.5px] text-[#6C6C70]">
-                      {bot.status === "idle" ? "" : bot.status}
-                      {bot.unread ? (
-                        <span
-                          aria-hidden="true"
-                          className="inline-block h-2 w-2 rounded-full bg-[#8B5CF6]"
-                        />
-                      ) : null}
-                    </span>
+            sidebarGroups.map((group) => (
+              <div key={group.key} data-sidebar-group={group.key}>
+                {group.title ? (
+                  <div className="px-2.5 pb-1 pt-3 text-[12.5px] font-medium text-[#6C6C70]">
+                    {group.title}
                   </div>
-                  <div
-                    className={`mt-0.5 truncate text-[13.5px] ${
-                      bot.unread ? "font-medium text-[#C9C9CE]" : "text-[#85858A]"
-                    }`}
+                ) : null}
+                {group.bots.map((bot) => (
+                  <button
+                    key={bot.id}
+                    type="button"
+                    onClick={() => navigate(`/app/${bot.id}`)}
+                    onContextMenu={(event) => {
+                      event.preventDefault();
+                      setBotMenu({
+                        botId: bot.id,
+                        position: { x: event.clientX, y: event.clientY },
+                      });
+                    }}
+                    className="flex w-full gap-3 rounded-xl px-2.5 py-[11px] text-left"
+                    style={{
+                      background: active?.id === bot.id ? "#161618" : "transparent",
+                    }}
                   >
-                    {bot.preview || bot.title}
-                  </div>
-                </div>
-              </button>
+                    <BotAvatar color={bot.color} size={38} />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-baseline justify-between gap-2">
+                        <span
+                          className={`truncate text-[15px] text-[#ECECEE] ${
+                            bot.unread ? "font-semibold" : "font-medium"
+                          }`}
+                        >
+                          {bot.name}
+                          {bot.unread ? <span className="sr-only"> (unread)</span> : null}
+                        </span>
+                        <span className="flex shrink-0 items-center gap-1.5 text-[12.5px] text-[#6C6C70]">
+                          {bot.status === "idle" ? "" : bot.status}
+                          {bot.unread ? (
+                            <span
+                              aria-hidden="true"
+                              className="inline-block h-2 w-2 rounded-full bg-[#8B5CF6]"
+                            />
+                          ) : null}
+                        </span>
+                      </div>
+                      <div
+                        className={`mt-0.5 truncate text-[13.5px] ${
+                          bot.unread ? "font-medium text-[#C9C9CE]" : "text-[#85858A]"
+                        }`}
+                      >
+                        {bot.preview || bot.title}
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
             ))
           )}
           {archivedBots.length > 0 && !showWorkspaceSearch ? (
@@ -1577,6 +1600,7 @@ export function ShellPage() {
             bot={contextBot}
             position={botMenu.position}
             onClose={closeBotMenu}
+            sections={botSections}
             onTogglePinned={() => {
               setBotMenu(null);
               void rpc.bots
@@ -1588,6 +1612,15 @@ export function ShellPage() {
               setBotMenu(null);
               const request = unread ? markBotUnread(contextBot.id) : markBotRead(contextBot.id);
               void request.catch(() => undefined);
+            }}
+            onMoveToSection={(sectionId) => {
+              setBotMenu(null);
+              if (sectionId === contextBot.sectionId) return;
+              void rpc.bots.update({ botId: contextBot.id, sectionId }).then(() => refreshBots());
+            }}
+            onCreateSection={() => {
+              setNewSectionBot(contextBot);
+              setBotMenu(null);
             }}
             onEdit={() => {
               navigate(`/app/${contextBot.id}`);
@@ -1625,6 +1658,18 @@ export function ShellPage() {
               setDeleteTarget(null);
               setPanel(null);
               await refreshBots(true);
+            }}
+          />
+        ) : null}
+
+        {newSectionBot ? (
+          <NewBotSectionDialog
+            bot={newSectionBot}
+            onCancel={() => setNewSectionBot(null)}
+            onConfirm={async (name) => {
+              await rpc.botSections.create({ botId: newSectionBot.id, name });
+              setNewSectionBot(null);
+              await refreshBots();
             }}
           />
         ) : null}
@@ -2634,6 +2679,91 @@ function BotSettings({
           Clear conversation
         </button>
       </div>
+    </div>
+  );
+}
+
+function NewBotSectionDialog({
+  bot,
+  onCancel,
+  onConfirm,
+}: {
+  bot: Bot;
+  onCancel: () => void;
+  onConfirm: (name: string) => Promise<void>;
+}) {
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !saving) onCancel();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onCancel, saving]);
+
+  return (
+    <div
+      role="presentation"
+      className="absolute inset-0 z-50 grid place-items-center bg-[rgba(4,4,5,.76)] px-5"
+      onPointerDown={() => {
+        if (!saving) onCancel();
+      }}
+    >
+      <form
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="new-bot-section-title"
+        className="w-full max-w-[420px] rounded-[18px] border border-[#343438] bg-[#1A1A1D] p-5 shadow-[0_24px_70px_rgba(0,0,0,.65)]"
+        onPointerDown={(event) => event.stopPropagation()}
+        onSubmit={(event) => {
+          event.preventDefault();
+          const trimmed = name.trim();
+          if (!trimmed || saving) return;
+          setSaving(true);
+          setError(null);
+          void onConfirm(trimmed).catch((err: unknown) => {
+            setError(err instanceof Error ? err.message : "Could not create section");
+            setSaving(false);
+          });
+        }}
+      >
+        <h2 id="new-bot-section-title" className="text-[17px] font-medium text-[#F1F1F2]">
+          New section
+        </h2>
+        <p className="mt-2 text-[14px] leading-6 text-[#9A9AA0]">
+          Create a section and move {bot.name} into it.
+        </p>
+        <label className="mt-4 block text-[13.5px] text-[#C9C9CE]">
+          Name
+          <input
+            maxLength={60}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="mt-2 w-full rounded-[11px] border border-[#343438] bg-[#101012] px-3.5 py-2.5 text-[14.5px] text-[#ECECEE] outline-none focus:border-[#66666D]"
+          />
+        </label>
+        {error ? <p className="mt-3 text-[13.5px] text-[#FF5364]">{error}</p> : null}
+        <div className="mt-5 flex justify-end gap-2.5">
+          <button
+            type="button"
+            disabled={saving}
+            onClick={onCancel}
+            className="rounded-[10px] px-3.5 py-2 text-[14px] text-[#C9C9CE] hover:bg-[#29292D] disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !name.trim()}
+            className="rounded-[10px] bg-[#F1F1EF] px-3.5 py-2 text-[14px] font-medium text-[#17171A] disabled:opacity-40"
+          >
+            {saving ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -15,6 +15,7 @@ export const BotSchema = z.object({
   color: z.string(),
   notifyOnFinish: z.boolean(),
   pinned: z.boolean(),
+  sectionId: Id.nullable(),
   archivedAt: z.string().nullable(),
   unread: z.boolean(),
   parentBotId: Id.nullable(),
@@ -28,6 +29,15 @@ export const BotSchema = z.object({
   autoSpeak: z.boolean(),
 });
 export type Bot = z.infer<typeof BotSchema>;
+
+export const BotSectionSchema = z.object({
+  id: Id,
+  name: z.string(),
+  position: z.number().int().nonnegative(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type BotSection = z.infer<typeof BotSectionSchema>;
 
 export const CreateBotInput = z.object({
   name: z.string().min(1).max(80),
@@ -49,6 +59,7 @@ export const UpdateBotInput = z.object({
   notifyOnFinish: z.boolean().optional(),
   color: z.string().optional(),
   pinned: z.boolean().optional(),
+  sectionId: Id.nullable().optional(),
   voiceId: z.string().max(120).nullable().optional(),
   autoSpeak: z.boolean().optional(),
 });
@@ -335,6 +346,7 @@ export type Me = z.infer<typeof MeSchema>;
 export const AppBootstrapSchema = z.object({
   me: MeSchema,
   bots: z.array(BotSchema),
+  botSections: z.array(BotSectionSchema),
   archivedBots: z.array(BotSchema),
   thread: ThreadSnapshotSchema.nullable(),
   routines: z.array(RoutineSchema),

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -16,6 +16,8 @@ describe("contracts", () => {
     expect(appContract.bots.archive).toBeTruthy();
     expect(appContract.bots.restore).toBeTruthy();
     expect(appContract.bots.remove).toBeTruthy();
+    expect(appContract.botSections.list).toBeTruthy();
+    expect(appContract.botSections.create).toBeTruthy();
     expect(appContract.threads.subscribe).toBeTruthy();
     expect(appContract.threads.clear).toBeTruthy();
     expect(appContract.voice.prepare).toBeTruthy();

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -6,6 +6,7 @@ import {
   ArtifactSchema,
   ArtifactWithContentSchema,
   BotSchema,
+  BotSectionSchema,
   CapabilityInstallSchema,
   ComputerModeSchema,
   ComputerStatusSchema,
@@ -113,6 +114,12 @@ export const appContract = {
     remove: oc
       .input(z.object({ botId: Id, deleteMemories: z.boolean().default(false) }))
       .output(z.object({ ok: z.literal(true) })),
+  },
+  botSections: {
+    list: oc.output(z.array(BotSectionSchema)),
+    create: oc
+      .input(z.object({ botId: Id, name: z.string().trim().min(1).max(60) }))
+      .output(BotSectionSchema),
   },
   threads: {
     get: oc.input(z.object({ botId: Id })).output(ThreadSnapshotSchema),

--- a/packages/core/src/bot-sections.test.ts
+++ b/packages/core/src/bot-sections.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { groupBotsForSidebar } from "./bot-sections.js";
+
+const sections = [
+  { id: "work", name: "Work" },
+  { id: "home", name: "Home" },
+];
+
+describe("groupBotsForSidebar", () => {
+  it("keeps pinned bots in one top-level group without duplicating them", () => {
+    const groups = groupBotsForSidebar(
+      [
+        { id: "pinned", pinned: true, sectionId: "home" },
+        { id: "work", pinned: false, sectionId: "work" },
+        { id: "home", pinned: false, sectionId: "home" },
+        { id: "loose", pinned: false, sectionId: null },
+      ],
+      sections,
+    );
+
+    expect(groups.map((group) => [group.title, group.bots.map((bot) => bot.id)])).toEqual([
+      ["Pinned", ["pinned"]],
+      ["Work", ["work"]],
+      ["Home", ["home"]],
+      ["Unassigned", ["loose"]],
+    ]);
+  });
+
+  it("treats bots pointing at an unavailable section as unassigned", () => {
+    const groups = groupBotsForSidebar(
+      [{ id: "orphan", pinned: false, sectionId: "missing" }],
+      sections,
+    );
+    expect(groups).toEqual([
+      {
+        key: "unassigned",
+        title: "Unassigned",
+        bots: [{ id: "orphan", pinned: false, sectionId: "missing" }],
+      },
+    ]);
+  });
+
+  it("does not add a heading before sections or pins exist", () => {
+    const groups = groupBotsForSidebar([{ id: "first", pinned: false, sectionId: null }], []);
+    expect(groups[0]?.title).toBeNull();
+  });
+});

--- a/packages/core/src/bot-sections.ts
+++ b/packages/core/src/bot-sections.ts
@@ -1,0 +1,50 @@
+export type BotListSection<T> = {
+  key: string;
+  title: string | null;
+  bots: T[];
+};
+
+type Section = { id: string; name: string };
+type SectionedBot = { pinned: boolean; sectionId: string | null };
+
+export function groupBotsForSidebar<T extends SectionedBot>(
+  bots: readonly T[],
+  sections: readonly Section[],
+): BotListSection<T>[] {
+  const knownSectionIds = new Set(sections.map((section) => section.id));
+  const pinned: T[] = [];
+  const sectionMembers = new Map<string, T[]>();
+  const unassigned: T[] = [];
+  const grouped: BotListSection<T>[] = [];
+
+  for (const bot of bots) {
+    if (bot.pinned) {
+      pinned.push(bot);
+    } else if (bot.sectionId && knownSectionIds.has(bot.sectionId)) {
+      const members = sectionMembers.get(bot.sectionId) ?? [];
+      members.push(bot);
+      sectionMembers.set(bot.sectionId, members);
+    } else {
+      unassigned.push(bot);
+    }
+  }
+
+  if (pinned.length > 0) {
+    grouped.push({ key: "pinned", title: "Pinned", bots: pinned });
+  }
+  for (const section of sections) {
+    const members = sectionMembers.get(section.id) ?? [];
+    if (members.length > 0) {
+      grouped.push({ key: `section:${section.id}`, title: section.name, bots: members });
+    }
+  }
+  if (unassigned.length > 0) {
+    grouped.push({
+      key: "unassigned",
+      title: pinned.length > 0 || sections.length > 0 ? "Unassigned" : null,
+      bots: unassigned,
+    });
+  }
+
+  return grouped;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./async.js";
 export * from "./attachments.js";
+export * from "./bot-sections.js";
 export * from "./cron.js";
 export * from "./events.js";
 export * from "./message-pages.js";

--- a/packages/db/prisma/migrations/0012_bot_sections/migration.sql
+++ b/packages/db/prisma/migrations/0012_bot_sections/migration.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "bot_sections" (
+  "id" TEXT NOT NULL,
+  "workspaceId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "position" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "bot_sections_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "bots" ADD COLUMN "sectionId" TEXT;
+
+CREATE UNIQUE INDEX "bot_sections_workspaceId_userId_name_key"
+ON "bot_sections"("workspaceId", "userId", "name");
+
+CREATE INDEX "bot_sections_workspaceId_userId_position_createdAt_idx"
+ON "bot_sections"("workspaceId", "userId", "position", "createdAt");
+
+CREATE INDEX "bots_sectionId_idx" ON "bots"("sectionId");
+
+ALTER TABLE "bot_sections"
+ADD CONSTRAINT "bot_sections_workspaceId_fkey"
+FOREIGN KEY ("workspaceId") REFERENCES "organization"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "bot_sections"
+ADD CONSTRAINT "bot_sections_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "user"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "bots"
+ADD CONSTRAINT "bots_sectionId_fkey"
+FOREIGN KEY ("sectionId") REFERENCES "bot_sections"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   modelCredentials UserModelCredential[]
   voiceCredentials UserVoiceCredential[]
   secrets          Secret[]
+  botSections      BotSection[]
 
   @@unique([email])
   @@map("user")
@@ -86,6 +87,7 @@ model Organization {
   members     Member[]
   invitations Invitation[]
   bots        Bot[]
+  botSections BotSection[]
   botDeletions BotDeletion[]
   threads     Thread[]
   events      Event[]
@@ -199,6 +201,8 @@ model Bot {
   color          String
   notifyOnFinish Boolean  @default(true)
   pinned         Boolean  @default(false)
+  sectionId      String?
+  section        BotSection? @relation(fields: [sectionId], references: [id], onDelete: SetNull)
   archivedAt     DateTime?
   parentBotId    String?
   spawnKey       String?
@@ -223,10 +227,28 @@ model Bot {
   runs           Run[]
 
   @@index([workspaceId, userId, archivedAt, pinned, updatedAt])
+  @@index([sectionId])
   @@index([computerId])
   @@index([parentBotId])
   @@unique([workspaceId, spawnKey])
   @@map("bots")
+}
+
+model BotSection {
+  id          String       @id @default(cuid())
+  workspaceId String
+  workspace   Organization @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  userId      String
+  user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name        String
+  position    Int          @default(0)
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  bots        Bot[]
+
+  @@unique([workspaceId, userId, name])
+  @@index([workspaceId, userId, position, createdAt])
+  @@map("bot_sections")
 }
 
 model BotDeletion {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -92,23 +92,28 @@ export function createRepos(prisma: PrismaClient) {
         });
         if (!bot) throw new IsolationError();
 
-        let section = await tx.botSection.findFirst({
-          where: { workspaceId: actor.workspaceId, userId: actor.userId, name },
+        const aggregate = await tx.botSection.aggregate({
+          where: { workspaceId: actor.workspaceId, userId: actor.userId },
+          _max: { position: true },
         });
-        if (!section) {
-          const aggregate = await tx.botSection.aggregate({
-            where: { workspaceId: actor.workspaceId, userId: actor.userId },
-            _max: { position: true },
-          });
-          section = await tx.botSection.create({
-            data: {
+        await tx.botSection.createMany({
+          data: {
+            workspaceId: actor.workspaceId,
+            userId: actor.userId,
+            name,
+            position: (aggregate._max.position ?? -1) + 1,
+          },
+          skipDuplicates: true,
+        });
+        const section = await tx.botSection.findUniqueOrThrow({
+          where: {
+            workspaceId_userId_name: {
               workspaceId: actor.workspaceId,
               userId: actor.userId,
               name,
-              position: (aggregate._max.position ?? -1) + 1,
             },
-          });
-        }
+          },
+        });
         await tx.bot.update({ where: { id: bot.id }, data: { sectionId: section.id } });
         return {
           id: section.id,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1,4 +1,10 @@
-import { type Actor, BOT_COLORS, type Bot, type MessageBlock } from "@rakazo/contracts";
+import {
+  type Actor,
+  BOT_COLORS,
+  type Bot,
+  type BotSection,
+  type MessageBlock,
+} from "@rakazo/contracts";
 import type { PrismaClient } from "./client.js";
 import { type ComputerMode, ensureComputerRecord, parseComputerMode } from "./computers.js";
 import { createThreadMessageInTransaction } from "./messages.js";
@@ -15,6 +21,7 @@ function mapBot(
     color: string;
     notifyOnFinish: boolean;
     pinned: boolean;
+    sectionId: string | null;
     archivedAt: Date | null;
     parentBotId: string | null;
     createdAt: Date;
@@ -40,6 +47,7 @@ function mapBot(
     color: bot.color,
     notifyOnFinish: bot.notifyOnFinish,
     pinned: bot.pinned,
+    sectionId: bot.sectionId,
     archivedAt: bot.archivedAt?.toISOString() ?? null,
     unread: bot.thread.unread,
     parentBotId: bot.parentBotId,
@@ -56,6 +64,62 @@ function mapBot(
 
 export function createRepos(prisma: PrismaClient) {
   return {
+    async listBotSections(actor: Actor): Promise<BotSection[]> {
+      const sections = await prisma.botSection.findMany({
+        where: { workspaceId: actor.workspaceId, userId: actor.userId },
+        orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+      });
+      return sections.map((section) => ({
+        id: section.id,
+        name: section.name,
+        position: section.position,
+        createdAt: section.createdAt.toISOString(),
+        updatedAt: section.updatedAt.toISOString(),
+      }));
+    },
+
+    async createBotSection(actor: Actor, input: { botId: string; name: string }) {
+      const { name } = input;
+      return prisma.$transaction(async (tx) => {
+        const bot = await tx.bot.findFirst({
+          where: {
+            id: input.botId,
+            workspaceId: actor.workspaceId,
+            userId: actor.userId,
+            archivedAt: null,
+          },
+          select: { id: true },
+        });
+        if (!bot) throw new IsolationError();
+
+        let section = await tx.botSection.findFirst({
+          where: { workspaceId: actor.workspaceId, userId: actor.userId, name },
+        });
+        if (!section) {
+          const aggregate = await tx.botSection.aggregate({
+            where: { workspaceId: actor.workspaceId, userId: actor.userId },
+            _max: { position: true },
+          });
+          section = await tx.botSection.create({
+            data: {
+              workspaceId: actor.workspaceId,
+              userId: actor.userId,
+              name,
+              position: (aggregate._max.position ?? -1) + 1,
+            },
+          });
+        }
+        await tx.bot.update({ where: { id: bot.id }, data: { sectionId: section.id } });
+        return {
+          id: section.id,
+          name: section.name,
+          position: section.position,
+          createdAt: section.createdAt.toISOString(),
+          updatedAt: section.updatedAt.toISOString(),
+        } satisfies BotSection;
+      });
+    },
+
     async listBots(actor: Actor, options: { archived?: boolean } = {}): Promise<Bot[]> {
       const bots = await prisma.bot.findMany({
         where: {

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -69,6 +69,8 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["bots/archive", { botId: "missing-bot" }],
       ["bots/restore", { botId: "missing-bot" }],
       ["bots/remove", { botId: "missing-bot" }],
+      ["botSections/list"],
+      ["botSections/create", { botId: "missing-bot", name: "Planning" }],
       ["threads/get", { botId: "missing-bot" }],
       ["threads/messages", { botId: "missing-bot", before: 1 }],
       ["threads/subscribe", { botId: "missing-bot", cursor: -1 }],

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -122,16 +122,26 @@ describeJourneys("required product journeys", () => {
 
     const pinned = await rpc<Bot>(app, ada, "bots/update", { botId: coder.id, pinned: true });
     expect(pinned.pinned).toBe(true);
-    const section = await rpc<{ id: string; name: string }>(app, ada, "botSections/create", {
-      botId: chief.id,
-      name: "Planning",
-    });
+    const [section, concurrentSection] = await Promise.all([
+      rpc<{ id: string; name: string }>(app, ada, "botSections/create", {
+        botId: chief.id,
+        name: "Planning",
+      }),
+      rpc<{ id: string; name: string }>(app, ada, "botSections/create", {
+        botId: coder.id,
+        name: "Planning",
+      }),
+    ]);
     expect(section.name).toBe("Planning");
+    expect(concurrentSection.id).toBe(section.id);
     expect(await rpc<Array<{ id: string }>>(app, ada, "botSections/list")).toEqual([
       expect.objectContaining({ id: section.id }),
     ]);
     expect(
       (await rpc<Bot[]>(app, ada, "bots/list")).find((bot) => bot.id === chief.id)?.sectionId,
+    ).toBe(section.id);
+    expect(
+      (await rpc<Bot[]>(app, ada, "bots/list")).find((bot) => bot.id === coder.id)?.sectionId,
     ).toBe(section.id);
     const foreignSection = await raw(app, bob, "bots/update", {
       botId: bobBot.id,

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -122,6 +122,23 @@ describeJourneys("required product journeys", () => {
 
     const pinned = await rpc<Bot>(app, ada, "bots/update", { botId: coder.id, pinned: true });
     expect(pinned.pinned).toBe(true);
+    const section = await rpc<{ id: string; name: string }>(app, ada, "botSections/create", {
+      botId: chief.id,
+      name: "Planning",
+    });
+    expect(section.name).toBe("Planning");
+    expect(await rpc<Array<{ id: string }>>(app, ada, "botSections/list")).toEqual([
+      expect.objectContaining({ id: section.id }),
+    ]);
+    expect(
+      (await rpc<Bot[]>(app, ada, "bots/list")).find((bot) => bot.id === chief.id)?.sectionId,
+    ).toBe(section.id);
+    const foreignSection = await raw(app, bob, "bots/update", {
+      botId: bobBot.id,
+      sectionId: section.id,
+    });
+    expect(foreignSection.status).toBeGreaterThanOrEqual(400);
+    expect(await rpc<unknown[]>(app, bob, "botSections/list")).toEqual([]);
     const duplicate = await rpc<Bot>(app, ada, "bots/duplicate", { botId: chief.id });
     expect(duplicate).toMatchObject({
       name: "Chief copy",
@@ -131,6 +148,7 @@ describeJourneys("required product journeys", () => {
       notifyOnFinish: chief.notifyOnFinish,
       color: chief.color,
       pinned: false,
+      sectionId: null,
       unread: false,
     });
     expect(duplicate.id).not.toBe(chief.id);
@@ -1242,6 +1260,7 @@ type Bot = {
   notifyOnFinish: boolean;
   color: string;
   pinned: boolean;
+  sectionId: string | null;
   unread: boolean;
   computerMode: "team" | "dedicated";
   parentBotId?: string | null;


### PR DESCRIPTION
## Summary
- render pinned bots and user-defined sections in the web/Electron sidebar and mobile inbox
- add section creation and bot assignment actions with workspace/user isolation
- persist sections with a database migration and include them in app bootstrap data
- cover grouping, authorization, persistence, migration, and browser workflows

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm test` (622 passed)
- `pnpm test:integration` (46 passed)
- `pnpm test:e2e -- --spec=bot-organization.spec.ts` (1 passed)