### PR TITLE
Fix routine E2E request interception race

### DIFF
--- a/apps/web/e2e/routine-crud.spec.ts
+++ b/apps/web/e2e/routine-crud.spec.ts
@@ -150,15 +150,15 @@ test("switching bots while a routine save is pending does not reopen stale state
   const staleListIntercepted = new Promise<void>((resolve) => {
     sawStaleList = resolve;
   });
-  await page.route(
-    "**/rpc/routines/list",
-    async (route) => {
-      sawStaleList();
-      await staleListReleased;
+  await page.route("**/rpc/routines/list", async (route) => {
+    if (route.request().postData()?.includes(firstBotId) !== true) {
       await route.continue();
-    },
-    { times: 1 },
-  );
+      return;
+    }
+    sawStaleList();
+    await staleListReleased;
+    await route.continue();
+  });
   const staleListResponse = page.waitForResponse(
     (response) =>
       response.url().includes("/rpc/routines/list") &&
@@ -172,6 +172,7 @@ test("switching bots while a routine save is pending does not reopen stale state
   await page.waitForURL(new RegExp(`/app/${secondBot.id}$`));
   releaseStaleList();
   await staleListResponse;
+  await page.unroute("**/rpc/routines/list");
 
   await expect(page.getByRole("button", { name: /Second routine/ })).toHaveCount(1);
   await expect(page.getByRole("button", { name: /First routine/ })).toHaveCount(0);


### PR DESCRIPTION
## Summary

- scope the delayed routines/list interception to the intended bot
- allow unrelated background list refreshes to complete so computer boot does not deadlock
- remove the route after the stale-response assertion

Fixes the failure seen in Actions run 32493470285.

## Testing

- pnpm check
- pnpm lint
- focused routine regression test passed four consecutive runs
- full fake-sandbox E2E run passed the repaired test; one unrelated model-settings test was flaky and passed immediately in isolation