### PR TITLE
Add custom inference gateways and live reasoning traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Rakazo is in beta. Learn more at [rakazo.com](https://rakazo.com).
 ## Features
 
 - Persistent bots with their own conversations, memory, routines, and history
-- Voice mode: speak replies, dictate, and call a bot. Bring your own ElevenLabs, OpenAI, or Cartesia key
+- Live reasoning traces while a bot runs (thinking, tools, and status — not a generic “working…” spinner)
 - Shared Team Computers and isolated Private computers
 - Browser, terminal, file, and graphical desktop access
 - Bots that can delegate to peer bots or short-lived subagents
-- Bring-your-own model credentials through Pi
+- Bring-your-own model credentials through Pi, including OpenAI-compatible base URLs
+- Multiple inference providers, with a model chosen per bot
+- Voice mode: speak replies, dictate, and call a bot. Bring your own ElevenLabs, OpenAI, or Cartesia key
 - Optional app integrations through Composio
 - Docker, E2B, Daytona, and trusted local-computer support
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Rakazo is in beta. Learn more at [rakazo.com](https://rakazo.com).
 - Shared Team Computers and isolated Private computers
 - Browser, terminal, file, and graphical desktop access
 - Bots that can delegate to peer bots or short-lived subagents
-- Bring-your-own model credentials through Pi, including OpenAI-compatible base URLs and multiple API keys per custom endpoint
+- Bring-your-own model credentials through Pi, including OpenAI-compatible base URLs and multiple API keys per custom endpoint. Rakazo discovers which models each key can run and picks the matching key automatically.
 - Multiple inference providers, with a model chosen per bot
 - Voice mode: speak replies, dictate, and call a bot. Bring your own ElevenLabs, OpenAI, or Cartesia key
 - Optional app integrations through Composio

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Rakazo is in beta. Learn more at [rakazo.com](https://rakazo.com).
 - Shared Team Computers and isolated Private computers
 - Browser, terminal, file, and graphical desktop access
 - Bots that can delegate to peer bots or short-lived subagents
-- Bring-your-own model credentials through Pi, including OpenAI-compatible base URLs
+- Bring-your-own model credentials through Pi, including OpenAI-compatible base URLs and multiple API keys per custom endpoint
 - Multiple inference providers, with a model chosen per bot
 - Voice mode: speak replies, dictate, and call a bot. Bring your own ElevenLabs, OpenAI, or Cartesia key
 - Optional app integrations through Composio

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -22,24 +22,23 @@ import {
   type ComputerExecutionLease,
   checkpointAndRecordComputerWorkspace,
   createVoiceProvider,
+  customEndpointCatalogEntry,
   deleteSupermemoryContainer,
   destroyBot,
   displayBotWorkspacePath,
   type EncryptedSecretStore,
   expireComputerControl,
+  fetchOpenAICompatibleModels,
+  gatewayCatalogEntries,
   hasActiveComputerControl,
+  isGatewayProvider,
   isSupermemoryEnabled,
   listPiCatalog,
   mintGatewayProviderId,
   normalizeOpenAICompatibleBaseUrl,
-  fetchOpenAICompatibleModels,
-  gatewayCatalogEntries,
-  customEndpointCatalogEntry,
-  isGatewayProvider,
   OPENAI_COMPATIBLE_PROVIDER,
-  parseAvailableModels,
-  serializeAvailableModels,
   type PiOAuthLogins,
+  parseAvailableModels,
   provisionComputer,
   releaseComputerExecutionLease,
   resolveBotWorkspacePath,
@@ -49,6 +48,7 @@ import {
   scheduleComputerSleep,
   screenLeaseIdForRun,
   scriptedCatalogEntry,
+  serializeAvailableModels,
   serializeModelSecret,
   supermemoryContainerTag,
   takeoverLeaseMs,
@@ -244,11 +244,7 @@ export function createRouter(deps: RouterDeps) {
         throwIfAborted(context.signal);
         try {
           return {
-            models: await fetchOpenAICompatibleModels(
-              input.baseUrl,
-              input.apiKey,
-              context.signal,
-            ),
+            models: await fetchOpenAICompatibleModels(input.baseUrl, input.apiKey, context.signal),
           };
         } catch (error) {
           throw new ORPCError("BAD_REQUEST", {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -237,6 +237,7 @@ export function createRouter(deps: RouterDeps) {
         const rows = await deps.prisma.userModelCredential.findMany({
           where: { userId: context.actor.userId, workspaceId: context.actor.workspaceId },
           orderBy: newestModelCredentialOrder,
+          include: credentialKeyInclude,
         });
         return rows.map((row) => credentialDto(row));
       }),
@@ -365,6 +366,33 @@ export function createRouter(deps: RouterDeps) {
         );
         return { ok: true as const };
       }),
+      addKey: authed.models.addKey.handler(async ({ context, input }) => {
+        const credential = await findWorkspaceModelCredential(
+          deps.prisma,
+          context.actor,
+          input.provider,
+        );
+        if (!credential || !isGatewayProvider(credential.provider) || !credential.baseUrl) {
+          throw new ORPCError("BAD_REQUEST", {
+            message: "Connect a custom endpoint before adding API keys.",
+          });
+        }
+        return persistModelCredential(deps, context.actor, {
+          provider: credential.provider,
+          plaintext: input.apiKey,
+          label: credential.label,
+          keyLabel: input.label,
+          appendKey: true,
+          setDefault: false,
+          signal: context.signal,
+        });
+      }),
+      removeKey: authed.models.removeKey.handler(async ({ context, input }) =>
+        removeModelCredentialKey(deps, context.actor, input.provider, input.keyId),
+      ),
+      setActiveKey: authed.models.setActiveKey.handler(async ({ context, input }) =>
+        setActiveModelCredentialKey(deps, context.actor, input.provider, input.keyId),
+      ),
     },
     bots: {
       list: authed.bots.list.handler(async ({ context }) => repos.listBots(context.actor)),
@@ -1887,17 +1915,44 @@ function credentialDto(row: {
   defaultModel: string | null;
   baseUrl: string | null;
   availableModels: string;
+  keys?: Array<{ id: string; label: string; isActive: boolean; createdAt: Date }>;
 }): ModelCredential {
+  const keys = (row.keys ?? []).map((key) => ({
+    id: key.id,
+    label: key.label,
+    isActive: key.isActive,
+    createdAt: key.createdAt.toISOString(),
+  }));
   return {
     id: row.id,
     provider: row.provider,
     label: row.label,
-    hasKey: true,
+    hasKey: keys.length > 0,
     isDefault: row.isDefault,
     defaultModel: row.defaultModel,
     baseUrl: row.baseUrl,
     availableModels: parseAvailableModels(row.availableModels),
+    keys,
   };
+}
+
+const credentialKeyInclude = {
+  keys: { orderBy: [{ createdAt: "asc" as const }, { id: "asc" as const }] },
+};
+
+async function loadCredentialDto(prisma: PrismaClient, id: string): Promise<ModelCredential> {
+  const row = await prisma.userModelCredential.findUniqueOrThrow({
+    where: { id },
+    include: credentialKeyInclude,
+  });
+  return credentialDto(row);
+}
+
+function findWorkspaceModelCredential(prisma: PrismaClient, actor: Actor, provider: string) {
+  return prisma.userModelCredential.findFirst({
+    where: { userId: actor.userId, workspaceId: actor.workspaceId, provider },
+    orderBy: newestModelCredentialOrder,
+  });
 }
 
 async function computerStatus(
@@ -2012,14 +2067,52 @@ async function persistModelCredential(
     provider: string;
     plaintext: string;
     label?: string;
+    keyLabel?: string;
     modelId?: string;
     baseUrl?: string;
     availableModels?: string[];
+    appendKey?: boolean;
+    setDefault?: boolean;
     signal?: AbortSignal;
   },
 ) {
   throwIfAborted(input.signal);
-  const stored = await deps.secrets.put(input.plaintext, {
+  const plaintext = input.plaintext.trim();
+  const appendKey = Boolean(input.appendKey || (input.baseUrl && plaintext));
+  const makeDefault = input.setDefault !== false;
+  const existing = await findWorkspaceModelCredential(deps.prisma, actor, input.provider);
+  if (!plaintext && existing && !appendKey) {
+    const updated = await withSerializableRetry(() =>
+      deps.prisma.$transaction(
+        async (tx) => {
+          throwIfAborted(input.signal);
+          if (makeDefault) {
+            await tx.userModelCredential.updateMany({
+              where: { userId: actor.userId, workspaceId: actor.workspaceId },
+              data: { isDefault: false },
+            });
+          }
+          return tx.userModelCredential.update({
+            where: { id: existing.id },
+            data: {
+              label: input.label ?? existing.label,
+              isDefault: makeDefault ? true : existing.isDefault,
+              defaultModel: input.modelId || existing.defaultModel || deps.env.defaultModel,
+              baseUrl: input.baseUrl ?? existing.baseUrl,
+              availableModels:
+                input.availableModels !== undefined
+                  ? serializeAvailableModels(input.availableModels)
+                  : existing.availableModels,
+            },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      ),
+    );
+    return loadCredentialDto(deps.prisma, updated.id);
+  }
+
+  const stored = await deps.secrets.put(plaintext, {
     operationId: "cred",
     traceId: "cred",
     workspaceId: actor.workspaceId,
@@ -2031,13 +2124,14 @@ async function persistModelCredential(
     deps.prisma.$transaction(
       async (tx) => {
         throwIfAborted(input.signal);
-        const existing = await tx.userModelCredential.findFirst({
+        const current = await tx.userModelCredential.findFirst({
           where: {
             userId: actor.userId,
             workspaceId: actor.workspaceId,
             provider: input.provider,
           },
           orderBy: newestModelCredentialOrder,
+          include: credentialKeyInclude,
         });
         throwIfAborted(input.signal);
         const secret = await tx.secret.create({
@@ -2050,12 +2144,14 @@ async function persistModelCredential(
           },
         });
         throwIfAborted(input.signal);
-        await tx.userModelCredential.updateMany({
-          where: { userId: actor.userId, workspaceId: actor.workspaceId },
-          data: { isDefault: false },
-        });
+        if (makeDefault) {
+          await tx.userModelCredential.updateMany({
+            where: { userId: actor.userId, workspaceId: actor.workspaceId },
+            data: { isDefault: false },
+          });
+        }
         throwIfAborted(input.signal);
-        if (!existing) {
+        if (!current) {
           const created = await tx.userModelCredential.create({
             data: {
               userId: actor.userId,
@@ -2069,38 +2165,185 @@ async function persistModelCredential(
               availableModels: serializeAvailableModels(input.availableModels ?? []),
             },
           });
+          if (plaintext) {
+            await tx.userModelCredentialKey.create({
+              data: {
+                credentialId: created.id,
+                secretId: secret.id,
+                label: input.keyLabel ?? "API key",
+                isActive: true,
+              },
+            });
+          }
           throwIfAborted(input.signal);
           return created;
         }
+
+        if (appendKey && isGatewayProvider(current.provider)) {
+          const previousSecretId = current.secretId;
+          if (current.keys.length) {
+            await tx.userModelCredentialKey.updateMany({
+              where: { credentialId: current.id },
+              data: { isActive: false },
+            });
+          }
+          await tx.userModelCredentialKey.create({
+            data: {
+              credentialId: current.id,
+              secretId: secret.id,
+              label: input.keyLabel ?? "API key",
+              isActive: true,
+            },
+          });
+          const updated = await tx.userModelCredential.update({
+            where: { id: current.id },
+            data: {
+              label: input.label ?? current.label,
+              secretId: secret.id,
+              isDefault: makeDefault ? true : current.isDefault,
+              defaultModel: input.modelId || current.defaultModel || deps.env.defaultModel,
+              baseUrl: input.baseUrl ?? current.baseUrl,
+              availableModels:
+                input.availableModels !== undefined
+                  ? serializeAvailableModels(input.availableModels)
+                  : current.availableModels,
+            },
+          });
+          await deleteSecretIfUnused(tx, previousSecretId);
+          return updated;
+        }
+
+        await tx.userModelCredentialKey.deleteMany({ where: { credentialId: current.id } });
+        if (plaintext) {
+          await tx.userModelCredentialKey.create({
+            data: {
+              credentialId: current.id,
+              secretId: secret.id,
+              label: input.keyLabel ?? "API key",
+              isActive: true,
+            },
+          });
+        }
         const updated = await tx.userModelCredential.update({
-          where: { id: existing.id },
+          where: { id: current.id },
           data: {
             label: input.label ?? input.provider,
             secretId: secret.id,
-            isDefault: true,
-            defaultModel: input.modelId || existing.defaultModel || deps.env.defaultModel,
-            baseUrl: input.baseUrl ?? existing.baseUrl,
+            isDefault: makeDefault ? true : current.isDefault,
+            defaultModel: input.modelId || current.defaultModel || deps.env.defaultModel,
+            baseUrl: input.baseUrl ?? current.baseUrl,
             availableModels:
               input.availableModels !== undefined
                 ? serializeAvailableModels(input.availableModels)
-                : existing.availableModels,
+                : current.availableModels,
           },
         });
         throwIfAborted(input.signal);
-        const sharedSecret = await tx.userModelCredential.count({
-          where: { id: { not: existing.id }, secretId: existing.secretId },
-        });
+        await deleteSecretIfUnused(tx, current.secretId);
         throwIfAborted(input.signal);
-        if (sharedSecret === 0) {
-          await tx.secret.deleteMany({ where: { id: existing.secretId } });
-          throwIfAborted(input.signal);
-        }
         return updated;
       },
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     ),
   );
-  return credentialDto(cred);
+  return loadCredentialDto(deps.prisma, cred.id);
+}
+
+async function removeModelCredentialKey(
+  deps: RouterDeps,
+  actor: Actor,
+  provider: string,
+  keyId: string,
+) {
+  const updatedId = await withSerializableRetry(() =>
+    deps.prisma.$transaction(
+      async (tx) => {
+        const credential = await tx.userModelCredential.findFirst({
+          where: { userId: actor.userId, workspaceId: actor.workspaceId, provider },
+          orderBy: newestModelCredentialOrder,
+          include: credentialKeyInclude,
+        });
+        if (!credential || !isGatewayProvider(credential.provider)) {
+          throw new ORPCError("NOT_FOUND", { message: "Custom endpoint not found." });
+        }
+        const key = credential.keys.find((entry) => entry.id === keyId);
+        if (!key) throw new ORPCError("NOT_FOUND", { message: "API key not found." });
+        if (credential.keys.length < 2) {
+          throw new ORPCError("BAD_REQUEST", {
+            message: "Keep at least one API key, or connect the endpoint without a key.",
+          });
+        }
+        await tx.userModelCredentialKey.delete({ where: { id: key.id } });
+        const remaining = credential.keys.filter((entry) => entry.id !== key.id);
+        const nextActive = remaining.find((entry) => entry.isActive) ?? remaining.at(-1)!;
+        await tx.userModelCredentialKey.updateMany({
+          where: { credentialId: credential.id },
+          data: { isActive: false },
+        });
+        await tx.userModelCredentialKey.update({
+          where: { id: nextActive.id },
+          data: { isActive: true },
+        });
+        await tx.userModelCredential.update({
+          where: { id: credential.id },
+          data: { secretId: nextActive.secretId },
+        });
+        await deleteSecretIfUnused(tx, key.secretId);
+        return credential.id;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    ),
+  );
+  return loadCredentialDto(deps.prisma, updatedId);
+}
+
+async function setActiveModelCredentialKey(
+  deps: RouterDeps,
+  actor: Actor,
+  provider: string,
+  keyId: string,
+) {
+  const updatedId = await withSerializableRetry(() =>
+    deps.prisma.$transaction(
+      async (tx) => {
+        const credential = await tx.userModelCredential.findFirst({
+          where: { userId: actor.userId, workspaceId: actor.workspaceId, provider },
+          orderBy: newestModelCredentialOrder,
+          include: credentialKeyInclude,
+        });
+        if (!credential || !isGatewayProvider(credential.provider)) {
+          throw new ORPCError("NOT_FOUND", { message: "Custom endpoint not found." });
+        }
+        const key = credential.keys.find((entry) => entry.id === keyId);
+        if (!key) throw new ORPCError("NOT_FOUND", { message: "API key not found." });
+        await tx.userModelCredentialKey.updateMany({
+          where: { credentialId: credential.id },
+          data: { isActive: false },
+        });
+        await tx.userModelCredentialKey.update({
+          where: { id: key.id },
+          data: { isActive: true },
+        });
+        await tx.userModelCredential.update({
+          where: { id: credential.id },
+          data: { secretId: key.secretId },
+        });
+        return credential.id;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    ),
+  );
+  return loadCredentialDto(deps.prisma, updatedId);
+}
+
+async function deleteSecretIfUnused(tx: Prisma.TransactionClient, secretId: string) {
+  const [credentials, keys] = await Promise.all([
+    tx.userModelCredential.count({ where: { secretId } }),
+    tx.userModelCredentialKey.count({ where: { secretId } }),
+  ]);
+  if (credentials === 0 && keys === 0) {
+    await tx.secret.deleteMany({ where: { id: secretId } });
+  }
 }
 
 function throwIfAborted(signal?: AbortSignal) {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -33,12 +33,14 @@ import {
   hasActiveComputerControl,
   isGatewayProvider,
   isSupermemoryEnabled,
+  labelForDiscoveredModels,
   listPiCatalog,
   mintGatewayProviderId,
   normalizeOpenAICompatibleBaseUrl,
   OPENAI_COMPATIBLE_PROVIDER,
   type PiOAuthLogins,
   parseAvailableModels,
+  parseModelSecret,
   provisionComputer,
   releaseComputerExecutionLease,
   resolveBotWorkspacePath,
@@ -54,6 +56,8 @@ import {
   takeoverLeaseMs,
   toComputerRef,
   touchRunningComputer,
+  tryFetchOpenAICompatibleModels,
+  unionAvailableModels,
 } from "@rakazo/adapters";
 import type { Auth } from "@rakazo/auth";
 import {
@@ -392,6 +396,9 @@ export function createRouter(deps: RouterDeps) {
       ),
       setActiveKey: authed.models.setActiveKey.handler(async ({ context, input }) =>
         setActiveModelCredentialKey(deps, context.actor, input.provider, input.keyId),
+      ),
+      refreshKeys: authed.models.refreshKeys.handler(async ({ context, input }) =>
+        refreshGatewayKeyCoverage(deps, context.actor, input.provider, context.signal),
       ),
     },
     bots: {
@@ -1915,13 +1922,24 @@ function credentialDto(row: {
   defaultModel: string | null;
   baseUrl: string | null;
   availableModels: string;
-  keys?: Array<{ id: string; label: string; isActive: boolean; createdAt: Date }>;
+  keys?: Array<{
+    id: string;
+    label: string;
+    isActive: boolean;
+    createdAt: Date;
+    availableModels?: string;
+    probedAt?: Date | null;
+    probeError?: string;
+  }>;
 }): ModelCredential {
   const keys = (row.keys ?? []).map((key) => ({
     id: key.id,
     label: key.label,
     isActive: key.isActive,
     createdAt: key.createdAt.toISOString(),
+    availableModels: parseAvailableModels(key.availableModels),
+    probedAt: key.probedAt?.toISOString() ?? null,
+    probeError: key.probeError || undefined,
   }));
   return {
     id: row.id,
@@ -2246,7 +2264,11 @@ async function persistModelCredential(
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     ),
   );
-  return loadCredentialDto(deps.prisma, cred.id);
+  const dto = await loadCredentialDto(deps.prisma, cred.id);
+  if (plaintext && isGatewayProvider(dto.provider) && dto.baseUrl) {
+    return discoverModelsForActiveGatewayKey(deps, dto, plaintext, input.keyLabel, input.signal);
+  }
+  return dto;
 }
 
 async function removeModelCredentialKey(
@@ -2286,7 +2308,10 @@ async function removeModelCredentialKey(
         });
         await tx.userModelCredential.update({
           where: { id: credential.id },
-          data: { secretId: nextActive.secretId },
+          data: {
+            secretId: nextActive.secretId,
+            availableModels: serializeAvailableModels(unionAvailableModels(remaining)),
+          },
         });
         await deleteSecretIfUnused(tx, key.secretId);
         return credential.id;
@@ -2334,6 +2359,111 @@ async function setActiveModelCredentialKey(
     ),
   );
   return loadCredentialDto(deps.prisma, updatedId);
+}
+
+async function discoverModelsForActiveGatewayKey(
+  deps: RouterDeps,
+  credential: ModelCredential,
+  plaintext: string,
+  requestedLabel: string | undefined,
+  signal?: AbortSignal,
+) {
+  if (!credential.baseUrl) return credential;
+  throwIfAborted(signal);
+  const discovered = await tryFetchOpenAICompatibleModels(credential.baseUrl, plaintext, signal);
+  const row = await deps.prisma.userModelCredential.findUnique({
+    where: { id: credential.id },
+    include: credentialKeyInclude,
+  });
+  const active = row?.keys.find((key) => key.isActive) ?? row?.keys.at(-1);
+  if (!row || !active) return credential;
+  const nextLabel =
+    requestedLabel?.trim() ||
+    (active.label && active.label !== "API key"
+      ? active.label
+      : labelForDiscoveredModels(discovered.models, active.label || "API key"));
+  await deps.prisma.userModelCredentialKey.update({
+    where: { id: active.id },
+    data: {
+      availableModels: serializeAvailableModels(discovered.models),
+      probedAt: new Date(),
+      probeError: discovered.error,
+      label: nextLabel,
+    },
+  });
+  await recomputeCredentialAvailableModels(deps.prisma, row.id, row.availableModels);
+  return loadCredentialDto(deps.prisma, row.id);
+}
+
+async function refreshGatewayKeyCoverage(
+  deps: RouterDeps,
+  actor: Actor,
+  provider: string,
+  signal?: AbortSignal,
+) {
+  const credential = await deps.prisma.userModelCredential.findFirst({
+    where: { userId: actor.userId, workspaceId: actor.workspaceId, provider },
+    orderBy: newestModelCredentialOrder,
+    include: credentialKeyInclude,
+  });
+  if (!credential || !isGatewayProvider(credential.provider) || !credential.baseUrl) {
+    throw new ORPCError("BAD_REQUEST", {
+      message: "Connect a custom endpoint before refreshing API keys.",
+    });
+  }
+  throwIfAborted(signal);
+  for (const key of credential.keys) {
+    throwIfAborted(signal);
+    const secret = await deps.prisma.secret.findUnique({ where: { id: key.secretId } });
+    if (!secret) {
+      await deps.prisma.userModelCredentialKey.update({
+        where: { id: key.id },
+        data: {
+          availableModels: "",
+          probedAt: new Date(),
+          probeError: "API key is missing.",
+        },
+      });
+      continue;
+    }
+    const parsed = parseModelSecret(deps.secrets.load(secret.ciphertext));
+    const apiKey = parsed.kind === "api_key" ? parsed.key : "";
+    const discovered = apiKey
+      ? await tryFetchOpenAICompatibleModels(credential.baseUrl, apiKey, signal)
+      : { models: [] as string[], error: "This key cannot list models." };
+    const nextLabel =
+      key.label && key.label !== "API key"
+        ? key.label
+        : labelForDiscoveredModels(discovered.models, key.label || "API key");
+    await deps.prisma.userModelCredentialKey.update({
+      where: { id: key.id },
+      data: {
+        availableModels: serializeAvailableModels(discovered.models),
+        probedAt: new Date(),
+        probeError: discovered.error,
+        label: nextLabel,
+      },
+    });
+  }
+  await recomputeCredentialAvailableModels(deps.prisma, credential.id, credential.availableModels);
+  return loadCredentialDto(deps.prisma, credential.id);
+}
+
+async function recomputeCredentialAvailableModels(
+  prisma: PrismaClient,
+  credentialId: string,
+  fallbackSerialized?: string,
+) {
+  const keys = await prisma.userModelCredentialKey.findMany({
+    where: { credentialId },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  });
+  const fromKeys = unionAvailableModels(keys);
+  const next = fromKeys.length ? fromKeys : parseAvailableModels(fallbackSerialized);
+  await prisma.userModelCredential.update({
+    where: { id: credentialId },
+    data: { availableModels: serializeAvailableModels(next) },
+  });
 }
 
 async function deleteSecretIfUnused(tx: Prisma.TransactionClient, secretId: string) {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -30,6 +30,15 @@ import {
   hasActiveComputerControl,
   isSupermemoryEnabled,
   listPiCatalog,
+  mintGatewayProviderId,
+  normalizeOpenAICompatibleBaseUrl,
+  fetchOpenAICompatibleModels,
+  gatewayCatalogEntries,
+  customEndpointCatalogEntry,
+  isGatewayProvider,
+  OPENAI_COMPATIBLE_PROVIDER,
+  parseAvailableModels,
+  serializeAvailableModels,
   type PiOAuthLogins,
   provisionComputer,
   releaseComputerExecutionLease,
@@ -52,6 +61,7 @@ import {
   appContract,
   type ComputerStatus,
   type Me,
+  type ModelCredential,
   type ThreadSnapshot,
 } from "@rakazo/contracts";
 import {
@@ -203,21 +213,76 @@ export function createRouter(deps: RouterDeps) {
       }),
     },
     models: {
-      list: authed.models.list.handler(async () => [...listPiCatalog(), scriptedCatalogEntry]),
+      list: authed.models.list.handler(async ({ context }) => {
+        const rows = await deps.prisma.userModelCredential.findMany({
+          where: { userId: context.actor.userId, workspaceId: context.actor.workspaceId },
+          orderBy: newestModelCredentialOrder,
+        });
+        return [
+          customEndpointCatalogEntry,
+          ...listPiCatalog(),
+          scriptedCatalogEntry,
+          ...gatewayCatalogEntries(
+            rows.map((row) => ({
+              provider: row.provider,
+              label: row.label,
+              baseUrl: row.baseUrl,
+              defaultModel: row.defaultModel,
+              availableModels: parseAvailableModels(row.availableModels),
+            })),
+          ),
+        ];
+      }),
       credentials: authed.models.credentials.handler(async ({ context }) => {
         const rows = await deps.prisma.userModelCredential.findMany({
           where: { userId: context.actor.userId, workspaceId: context.actor.workspaceId },
           orderBy: newestModelCredentialOrder,
         });
-        return rows.map((row) => ({
-          id: row.id,
-          provider: row.provider,
-          label: row.label,
-          hasKey: true,
-          isDefault: row.isDefault,
-        }));
+        return rows.map((row) => credentialDto(row));
+      }),
+      probe: authed.models.probe.handler(async ({ input, context }) => {
+        throwIfAborted(context.signal);
+        try {
+          return {
+            models: await fetchOpenAICompatibleModels(
+              input.baseUrl,
+              input.apiKey,
+              context.signal,
+            ),
+          };
+        } catch (error) {
+          throw new ORPCError("BAD_REQUEST", {
+            message: error instanceof Error ? error.message : "Could not list models",
+          });
+        }
       }),
       connect: authed.models.connect.handler(async ({ context, input }) => {
+        if (input.baseUrl) {
+          let baseUrl: string;
+          try {
+            baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl);
+          } catch (error) {
+            throw new ORPCError("BAD_REQUEST", {
+              message: error instanceof Error ? error.message : "Invalid base URL",
+            });
+          }
+          const provider =
+            isGatewayProvider(input.provider) && input.provider !== OPENAI_COMPATIBLE_PROVIDER
+              ? input.provider
+              : mintGatewayProviderId();
+          return persistModelCredential(deps, context.actor, {
+            provider,
+            plaintext: input.apiKey,
+            label: input.label ?? "Custom endpoint",
+            modelId: input.modelId,
+            baseUrl,
+            availableModels: input.availableModels,
+            signal: context.signal,
+          });
+        }
+        if (input.apiKey.trim().length < 8) {
+          throw new ORPCError("BAD_REQUEST", { message: "API key is too short" });
+        }
         return persistModelCredential(deps, context.actor, {
           provider: input.provider,
           plaintext: input.apiKey,
@@ -328,6 +393,8 @@ export function createRouter(deps: RouterDeps) {
           notifyOnFinish: source.notifyOnFinish,
           color: source.color,
           computerMode: source.computer?.scope === "dedicated" ? "dedicated" : "team",
+          modelProvider: source.modelProvider,
+          modelId: source.modelId,
         });
       }),
       update: authed.bots.update.handler(async ({ context, input }) => {
@@ -356,6 +423,8 @@ export function createRouter(deps: RouterDeps) {
             sectionId: input.sectionId,
             voiceId: input.voiceId,
             autoSpeak: input.autoSpeak,
+            modelProvider: input.modelProvider,
+            modelId: input.modelId,
           },
         });
         const bots = await repos.listBots(context.actor);
@@ -1748,7 +1817,7 @@ async function snapshot(deps: RouterDeps, actor: Actor, botId: string): Promise<
         where: {
           threadId: bot.thread.id,
           runId: run.id,
-          type: { in: ["thread.progress", "thread.subagent"] },
+          type: { in: ["thread.progress", "thread.subagent", "thread.reasoning"] },
         },
         orderBy: { seq: "asc" },
       })
@@ -1756,7 +1825,8 @@ async function snapshot(deps: RouterDeps, actor: Actor, botId: string): Promise<
   const projected = projectMessages(liveEvents);
   const persisted = messagePage.messages;
   const live = projected.filter((message) => {
-    if (message.blocks.some((block) => block.kind === "progress")) return true;
+    if (message.blocks.some((block) => block.kind === "progress" || block.kind === "reasoning"))
+      return true;
     if (!message.id.startsWith("subagent:")) return false;
     return !persisted.some((row) =>
       row.blocks.some(
@@ -1810,6 +1880,27 @@ async function meDto(deps: RouterDeps, actor: Actor): Promise<Me> {
     defaultModel: cred?.defaultModel ?? settings?.defaultModelId ?? deps.env.defaultModel,
     computerHost: computerHostFor(settings?.computerHost, deps.env.sandboxProvider),
     canChooseHostComputer: actor.isDeploymentOwner && deps.env.sandboxProvider === "docker",
+  };
+}
+
+function credentialDto(row: {
+  id: string;
+  provider: string;
+  label: string;
+  isDefault: boolean;
+  defaultModel: string | null;
+  baseUrl: string | null;
+  availableModels: string;
+}): ModelCredential {
+  return {
+    id: row.id,
+    provider: row.provider,
+    label: row.label,
+    hasKey: true,
+    isDefault: row.isDefault,
+    defaultModel: row.defaultModel,
+    baseUrl: row.baseUrl,
+    availableModels: parseAvailableModels(row.availableModels),
   };
 }
 
@@ -1926,6 +2017,8 @@ async function persistModelCredential(
     plaintext: string;
     label?: string;
     modelId?: string;
+    baseUrl?: string;
+    availableModels?: string[];
     signal?: AbortSignal;
   },
 ) {
@@ -1975,7 +2068,9 @@ async function persistModelCredential(
               label: input.label ?? input.provider,
               secretId: secret.id,
               isDefault: true,
-              defaultModel: input.modelId ?? deps.env.defaultModel,
+              defaultModel: input.modelId || deps.env.defaultModel,
+              baseUrl: input.baseUrl,
+              availableModels: serializeAvailableModels(input.availableModels ?? []),
             },
           });
           throwIfAborted(input.signal);
@@ -1987,7 +2082,12 @@ async function persistModelCredential(
             label: input.label ?? input.provider,
             secretId: secret.id,
             isDefault: true,
-            defaultModel: input.modelId ?? deps.env.defaultModel,
+            defaultModel: input.modelId || existing.defaultModel || deps.env.defaultModel,
+            baseUrl: input.baseUrl ?? existing.baseUrl,
+            availableModels:
+              input.availableModels !== undefined
+                ? serializeAvailableModels(input.availableModels)
+                : existing.availableModels,
           },
         });
         throwIfAborted(input.signal);
@@ -2004,13 +2104,7 @@ async function persistModelCredential(
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     ),
   );
-  return {
-    id: cred.id,
-    provider: cred.provider,
-    label: cred.label,
-    hasKey: true,
-    isDefault: true,
-  };
+  return credentialDto(cred);
 }
 
 function throwIfAborted(signal?: AbortSignal) {

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -318,7 +318,10 @@ function BotRow({ bot, onLongPress }: { bot: MobileBot; onLongPress: () => void 
       accessibilityLabel={label}
       accessibilityHint="Long press to pin or move to a section"
       onPress={() =>
-        router.push({ pathname: "/thread", params: { botId: bot.id, name: bot.name } })
+        router.push({
+          pathname: "/thread",
+          params: { botId: bot.id, name: bot.name, color: bot.color },
+        })
       }
       onLongPress={onLongPress}
       style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -29,6 +29,12 @@ type ModelSelection = {
   modelId?: string;
 };
 
+function formatKeyCoverage(models: string[] | undefined) {
+  if (!models?.length) return "Not probed yet. Refresh coverage after you add keys.";
+  if (models.length <= 8) return models.join(", ");
+  return `${models.slice(0, 8).join(", ")} +${models.length - 8} more`;
+}
+
 export default function Models() {
   const [catalog, setCatalog] = useState<MobileModel[]>([]);
   const [credentials, setCredentials] = useState<MobileModelCredential[]>([]);
@@ -42,7 +48,10 @@ export default function Models() {
   const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | "probe" | "key" | null>(null);
+  const [pending, setPending] = useState<
+    "connect" | "default" | "probe" | "key" | "refresh" | null
+  >(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -250,9 +259,25 @@ export default function Models() {
       setApiKey("");
       setKeyLabel("");
       await load({ provider, modelId });
-      setNotice("Added an API key to this endpoint.");
+      setNotice("Saved that key. Rakazo will use it for the models it can access.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not add API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function refreshEndpointKeys() {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("refresh");
+    try {
+      await rpc("models/refreshKeys", { provider: selected.provider });
+      await load({ provider, modelId });
+      setNotice("Updated which models each API key can use.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not refresh API keys");
     } finally {
       setPending(null);
     }
@@ -266,7 +291,7 @@ export default function Models() {
     try {
       await rpc("models/setActiveKey", { provider: selected.provider, keyId });
       await load({ provider, modelId });
-      setNotice("This key is now used for the endpoint.");
+      setNotice("This key is the fallback when a model is not on any other key.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not switch API key");
     } finally {
@@ -509,72 +534,120 @@ export default function Models() {
                     ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
                     : "Your key or subscription token is stored securely and is never shown here."
                   : isCustom
-                    ? "Paste any OpenAI-compatible base URL. Add one or more API keys after you connect."
+                    ? "Paste any OpenAI-compatible base URL. Extra API keys live under Advanced — Rakazo matches each key to the models it can run."
                     : "Connect this provider to use it as your personal model."}
               </Text>
             </View>
 
             {isCustom && credential ? (
               <View style={styles.credentialCard}>
-                <Text style={styles.eyebrow}>API keys</Text>
-                {credential.keys.length ? (
-                  credential.keys.map((key) => (
-                    <View key={key.id} style={styles.keyRow}>
-                      <Text style={styles.keyName}>{key.label}</Text>
-                      {key.isActive ? (
-                        <Text style={styles.connected}>Active</Text>
-                      ) : (
-                        <Pressable disabled={busy} onPress={() => void activateEndpointKey(key.id)}>
-                          <Text style={styles.secondaryAction}>Use</Text>
-                        </Pressable>
-                      )}
-                      {credential.keys.length > 1 ? (
-                        <Pressable disabled={busy} onPress={() => void removeEndpointKey(key.id)}>
-                          <Text style={styles.error}>Remove</Text>
-                        </Pressable>
-                      ) : null}
-                    </View>
-                  ))
-                ) : (
-                  <Text style={styles.secondary}>
-                    No keys yet. Local servers can run without one.
-                  </Text>
-                )}
-                <TextInput
-                  accessibilityLabel="Key label"
-                  onChangeText={setKeyLabel}
-                  placeholder="Pool key 2"
-                  placeholderTextColor={native.tertiaryLabel}
-                  style={styles.keyInput}
-                  value={keyLabel}
-                />
-                <TextInput
-                  accessibilityLabel="Add API key"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  autoComplete="off"
-                  editable={!busy}
-                  onChangeText={setApiKey}
-                  placeholder="sk-…"
-                  placeholderTextColor={native.tertiaryLabel}
-                  secureTextEntry
-                  style={styles.keyInput}
-                  value={apiKey}
-                />
                 <Pressable
                   accessibilityRole="button"
-                  disabled={busy || !apiKey.trim()}
-                  onPress={() => void addEndpointKey()}
-                  style={({ pressed }) => [
-                    styles.outlineButton,
-                    (busy || !apiKey.trim()) && styles.disabled,
-                    pressed && styles.pressed,
-                  ]}
+                  onPress={() => setAdvancedOpen((open) => !open)}
+                  style={styles.advancedHeader}
                 >
-                  <Text style={styles.outlineLabel}>
-                    {pending === "key" ? "Adding…" : "Add API key"}
+                  <Text style={styles.eyebrow}>Advanced</Text>
+                  <Text style={styles.secondaryAction}>
+                    {advancedOpen
+                      ? "Hide"
+                      : credential.keys.length
+                        ? `${credential.keys.length} API key${credential.keys.length === 1 ? "" : "s"}`
+                        : "API keys"}
                   </Text>
                 </Pressable>
+                {advancedOpen ? (
+                  <>
+                    <Text style={styles.secondary}>
+                      Save every provider key here. Rakazo asks the endpoint which models each key
+                      can access, then uses that key automatically.
+                    </Text>
+                    <Pressable
+                      accessibilityRole="button"
+                      disabled={busy || !credential.keys.length}
+                      onPress={() => void refreshEndpointKeys()}
+                      style={({ pressed }) => [
+                        styles.outlineButton,
+                        (busy || !credential.keys.length) && styles.disabled,
+                        pressed && styles.pressed,
+                      ]}
+                    >
+                      <Text style={styles.outlineLabel}>
+                        {pending === "refresh" ? "Refreshing…" : "Refresh model coverage"}
+                      </Text>
+                    </Pressable>
+                    {credential.keys.length ? (
+                      credential.keys.map((key) => (
+                        <View key={key.id} style={styles.keyCard}>
+                          <View style={styles.keyRow}>
+                            <Text style={styles.keyName}>{key.label}</Text>
+                            {key.isActive ? (
+                              <Text style={styles.connected}>Fallback</Text>
+                            ) : (
+                              <Pressable
+                                disabled={busy}
+                                onPress={() => void activateEndpointKey(key.id)}
+                              >
+                                <Text style={styles.secondaryAction}>Fallback</Text>
+                              </Pressable>
+                            )}
+                            {credential.keys.length > 1 ? (
+                              <Pressable
+                                disabled={busy}
+                                onPress={() => void removeEndpointKey(key.id)}
+                              >
+                                <Text style={styles.error}>Remove</Text>
+                              </Pressable>
+                            ) : null}
+                          </View>
+                          <Text style={styles.secondary}>
+                            {key.probeError
+                              ? key.probeError
+                              : formatKeyCoverage(key.availableModels)}
+                          </Text>
+                        </View>
+                      ))
+                    ) : (
+                      <Text style={styles.secondary}>
+                        No keys yet. Local servers can run without one.
+                      </Text>
+                    )}
+                    <TextInput
+                      accessibilityLabel="Key label"
+                      onChangeText={setKeyLabel}
+                      placeholder="Optional"
+                      placeholderTextColor={native.tertiaryLabel}
+                      style={styles.keyInput}
+                      value={keyLabel}
+                    />
+                    <TextInput
+                      accessibilityLabel="Add API key"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      autoComplete="off"
+                      editable={!busy}
+                      onChangeText={setApiKey}
+                      placeholder="sk-…"
+                      placeholderTextColor={native.tertiaryLabel}
+                      secureTextEntry
+                      style={styles.keyInput}
+                      value={apiKey}
+                    />
+                    <Pressable
+                      accessibilityRole="button"
+                      disabled={busy || !apiKey.trim()}
+                      onPress={() => void addEndpointKey()}
+                      style={({ pressed }) => [
+                        styles.outlineButton,
+                        (busy || !apiKey.trim()) && styles.disabled,
+                        pressed && styles.pressed,
+                      ]}
+                    >
+                      <Text style={styles.outlineLabel}>
+                        {pending === "key" ? "Adding…" : "Add API key"}
+                      </Text>
+                    </Pressable>
+                  </>
+                ) : null}
               </View>
             ) : null}
 
@@ -841,6 +914,15 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 10,
+    marginTop: 10,
+  },
+  advancedHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  keyCard: {
     marginTop: 10,
   },
   keyName: {

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -36,12 +36,13 @@ export default function Models() {
   const [provider, setProvider] = useState("");
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [keyLabel, setKeyLabel] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
   const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | "probe" | null>(null);
+  const [pending, setPending] = useState<"connect" | "default" | "probe" | "key" | null>(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -128,6 +129,7 @@ export default function Models() {
     setProvider(nextProvider);
     setModelId(catalog.find((entry) => entry.provider === nextProvider)?.id ?? "");
     setApiKey("");
+    setKeyLabel("");
     setBaseUrl(catalog.find((entry) => entry.provider === nextProvider)?.baseUrl ?? "");
     setEndpointLabel(
       catalog.find((entry) => entry.provider === nextProvider)?.providerName ?? "Custom endpoint",
@@ -169,7 +171,7 @@ export default function Models() {
       try {
         const connected = await rpc<MobileModelCredential>("models/connect", {
           provider: selected.provider,
-          apiKey: apiKey.trim(),
+          apiKey: credential ? "" : apiKey.trim(),
           modelId: modelId.trim() || selected.id,
           label: endpointLabel.trim() || selected.providerName || "Custom endpoint",
           baseUrl: url,
@@ -229,6 +231,60 @@ export default function Models() {
       setNotice(`Found ${result.models.length} model${result.models.length === 1 ? "" : "s"}.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not list models");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function addEndpointKey() {
+    if (!selected || !apiKey.trim()) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc("models/addKey", {
+        provider: selected.provider,
+        apiKey: apiKey.trim(),
+        label: keyLabel.trim() || undefined,
+      });
+      setApiKey("");
+      setKeyLabel("");
+      await load({ provider, modelId });
+      setNotice("Added an API key to this endpoint.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not add API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function activateEndpointKey(keyId: string) {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc("models/setActiveKey", { provider: selected.provider, keyId });
+      await load({ provider, modelId });
+      setNotice("This key is now used for the endpoint.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not switch API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function removeEndpointKey(keyId: string) {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc("models/removeKey", { provider: selected.provider, keyId });
+      await load({ provider, modelId });
+      setNotice("Removed that API key.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not remove API key");
     } finally {
       setPending(null);
     }
@@ -453,10 +509,74 @@ export default function Models() {
                     ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
                     : "Your key or subscription token is stored securely and is never shown here."
                   : isCustom
-                    ? "Paste any OpenAI-compatible base URL. The API key is optional for local servers."
+                    ? "Paste any OpenAI-compatible base URL. Add one or more API keys after you connect."
                     : "Connect this provider to use it as your personal model."}
               </Text>
             </View>
+
+            {isCustom && credential ? (
+              <View style={styles.credentialCard}>
+                <Text style={styles.eyebrow}>API keys</Text>
+                {credential.keys.length ? (
+                  credential.keys.map((key) => (
+                    <View key={key.id} style={styles.keyRow}>
+                      <Text style={styles.keyName}>{key.label}</Text>
+                      {key.isActive ? (
+                        <Text style={styles.connected}>Active</Text>
+                      ) : (
+                        <Pressable disabled={busy} onPress={() => void activateEndpointKey(key.id)}>
+                          <Text style={styles.secondaryAction}>Use</Text>
+                        </Pressable>
+                      )}
+                      {credential.keys.length > 1 ? (
+                        <Pressable disabled={busy} onPress={() => void removeEndpointKey(key.id)}>
+                          <Text style={styles.error}>Remove</Text>
+                        </Pressable>
+                      ) : null}
+                    </View>
+                  ))
+                ) : (
+                  <Text style={styles.secondary}>
+                    No keys yet. Local servers can run without one.
+                  </Text>
+                )}
+                <TextInput
+                  accessibilityLabel="Key label"
+                  onChangeText={setKeyLabel}
+                  placeholder="Pool key 2"
+                  placeholderTextColor={native.tertiaryLabel}
+                  style={styles.keyInput}
+                  value={keyLabel}
+                />
+                <TextInput
+                  accessibilityLabel="Add API key"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  autoComplete="off"
+                  editable={!busy}
+                  onChangeText={setApiKey}
+                  placeholder="sk-…"
+                  placeholderTextColor={native.tertiaryLabel}
+                  secureTextEntry
+                  style={styles.keyInput}
+                  value={apiKey}
+                />
+                <Pressable
+                  accessibilityRole="button"
+                  disabled={busy || !apiKey.trim()}
+                  onPress={() => void addEndpointKey()}
+                  style={({ pressed }) => [
+                    styles.outlineButton,
+                    (busy || !apiKey.trim()) && styles.disabled,
+                    pressed && styles.pressed,
+                  ]}
+                >
+                  <Text style={styles.outlineLabel}>
+                    {pending === "key" ? "Adding…" : "Add API key"}
+                  </Text>
+                </Pressable>
+              </View>
+            ) : null}
 
             {deviceSignIn ? (
               oauth ? (
@@ -486,7 +606,7 @@ export default function Models() {
               )
             ) : null}
 
-            {acceptsKey ? (
+            {acceptsKey && !(isCustom && credential) ? (
               <View style={styles.keySection}>
                 <Text style={styles.sectionTitle}>
                   {credential
@@ -549,6 +669,23 @@ export default function Models() {
                 This subscription sign-in is not available in Rakazo yet. Use a deployment
                 credential or choose another provider.
               </Text>
+            ) : null}
+
+            {isCustom && credential ? (
+              <Pressable
+                accessibilityRole="button"
+                disabled={busy || !(baseUrl.trim() || selected.baseUrl)}
+                onPress={() => void connectKey()}
+                style={({ pressed }) => [
+                  styles.primaryButton,
+                  (busy || !(baseUrl.trim() || selected.baseUrl)) && styles.disabled,
+                  pressed && styles.pressed,
+                ]}
+              >
+                <Text style={styles.primaryLabel}>
+                  {pending === "connect" ? "Saving…" : "Save endpoint"}
+                </Text>
+              </Pressable>
             ) : null}
 
             {credential ? (
@@ -699,6 +836,21 @@ const styles = StyleSheet.create({
     color: native.label,
     fontSize: 16,
     marginTop: 6,
+  },
+  keyRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginTop: 10,
+  },
+  keyName: {
+    flex: 1,
+    color: native.label,
+    fontSize: 15,
+  },
+  secondaryAction: {
+    color: native.secondaryLabel,
+    fontSize: 13,
   },
   oauthCard: {
     borderRadius: 14,

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -36,9 +36,12 @@ export default function Models() {
   const [provider, setProvider] = useState("");
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
+  const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | null>(null);
+  const [pending, setPending] = useState<"connect" | "default" | "probe" | null>(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -113,8 +116,10 @@ export default function Models() {
   const currentEntry = catalog.find(
     (entry) => entry.provider === me?.defaultProvider && entry.id === me?.defaultModel,
   );
+  const isCustom = Boolean(selected?.custom);
+  const isCustomTemplate = selected?.provider === "openai-compatible";
   const isActive = me?.defaultProvider === selected?.provider && me?.defaultModel === selected?.id;
-  const acceptsKey = selected?.auth !== "oauth";
+  const acceptsKey = selected?.auth !== "oauth" || isCustom;
   const deviceSignIn = selected?.signIn === "device-code";
   const busy = pending !== null || oauthPending;
 
@@ -123,6 +128,13 @@ export default function Models() {
     setProvider(nextProvider);
     setModelId(catalog.find((entry) => entry.provider === nextProvider)?.id ?? "");
     setApiKey("");
+    setBaseUrl(catalog.find((entry) => entry.provider === nextProvider)?.baseUrl ?? "");
+    setEndpointLabel(
+      catalog.find((entry) => entry.provider === nextProvider)?.providerName ?? "Custom endpoint",
+    );
+    setProbedModels(
+      credentials.find((entry) => entry.provider === nextProvider)?.availableModels ?? [],
+    );
     setError(null);
     setNotice(null);
   }
@@ -144,7 +156,40 @@ export default function Models() {
   }
 
   async function connectKey() {
-    if (!selected || !apiKey.trim()) return;
+    if (!selected) return;
+    if (isCustom) {
+      const url = baseUrl.trim() || selected.baseUrl;
+      if (!url) {
+        setError("Enter a base URL for this endpoint.");
+        return;
+      }
+      setError(null);
+      setNotice(null);
+      setPending("connect");
+      try {
+        const connected = await rpc<MobileModelCredential>("models/connect", {
+          provider: selected.provider,
+          apiKey: apiKey.trim(),
+          modelId: modelId.trim() || selected.id,
+          label: endpointLabel.trim() || selected.providerName || "Custom endpoint",
+          baseUrl: url,
+          availableModels: probedModels.length
+            ? probedModels
+            : modelId.trim()
+              ? [modelId.trim()]
+              : undefined,
+        });
+        setApiKey("");
+        await load({ provider: connected.provider, modelId: connected.defaultModel ?? modelId });
+        setNotice(`Connected ${connected.label}.`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not connect this endpoint");
+      } finally {
+        setPending(null);
+      }
+      return;
+    }
+    if (!apiKey.trim()) return;
     setError(null);
     setNotice(null);
     setPending("connect");
@@ -160,6 +205,30 @@ export default function Models() {
       setNotice(`Connected and using ${selected.label}.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not connect this provider");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function probeModels() {
+    const url = baseUrl.trim() || selected?.baseUrl;
+    if (!url) {
+      setError("Enter a base URL to list models.");
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    setPending("probe");
+    try {
+      const result = await rpc<{ models: string[] }>("models/probe", {
+        baseUrl: url,
+        apiKey: apiKey.trim() || undefined,
+      });
+      setProbedModels(result.models);
+      if (!result.models.includes(modelId) && result.models[0]) setModelId(result.models[0]);
+      setNotice(`Found ${result.models.length} model${result.models.length === 1 ? "" : "s"}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not list models");
     } finally {
       setPending(null);
     }
@@ -264,33 +333,114 @@ export default function Models() {
 
         {selected ? (
           <>
-            <Text style={styles.sectionTitle}>Model</Text>
-            <View style={styles.card}>
-              {modelsForProvider.map((entry) => (
+            {isCustom ? (
+              <>
+                <Text style={styles.sectionTitle}>Custom endpoint</Text>
+                <TextInput
+                  accessibilityLabel="Endpoint name"
+                  onChangeText={setEndpointLabel}
+                  placeholder="Office vLLM"
+                  placeholderTextColor={native.tertiaryLabel}
+                  style={styles.keyInput}
+                  value={endpointLabel}
+                />
+                <TextInput
+                  accessibilityLabel="Base URL"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  onChangeText={setBaseUrl}
+                  placeholder="https://api.example.com/v1"
+                  placeholderTextColor={native.tertiaryLabel}
+                  style={styles.keyInput}
+                  value={baseUrl}
+                />
+                <Text style={styles.billing}>{selected.billing}</Text>
+                {probedModels.length || (!isCustomTemplate && modelsForProvider.length > 1) ? (
+                  <View style={styles.card}>
+                    {[
+                      ...new Set([
+                        ...probedModels,
+                        ...modelsForProvider.map((entry) => entry.id),
+                        modelId,
+                      ]),
+                    ]
+                      .filter(Boolean)
+                      .map((id) => (
+                        <Pressable
+                          key={id}
+                          accessibilityRole="radio"
+                          onPress={() => setModelId(id)}
+                          style={({ pressed }) => [
+                            styles.modelRow,
+                            id === modelId && styles.selectedRow,
+                            pressed && styles.pressed,
+                          ]}
+                        >
+                          <View style={styles.radio}>
+                            {id === modelId ? <View style={styles.radioDot} /> : null}
+                          </View>
+                          <Text style={styles.modelLabel}>{id}</Text>
+                        </Pressable>
+                      ))}
+                  </View>
+                ) : (
+                  <TextInput
+                    accessibilityLabel="Model id"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    onChangeText={setModelId}
+                    placeholder="llama3.1"
+                    placeholderTextColor={native.tertiaryLabel}
+                    style={styles.keyInput}
+                    value={isCustomTemplate && modelId === "custom" ? "" : modelId}
+                  />
+                )}
                 <Pressable
-                  key={`${entry.provider}:${entry.id}`}
-                  accessibilityRole="radio"
-                  accessibilityState={{ selected: entry.id === selected.id }}
-                  onPress={() => {
-                    cancelOAuth();
-                    setModelId(entry.id);
-                    setError(null);
-                    setNotice(null);
-                  }}
+                  accessibilityRole="button"
+                  disabled={busy || !(baseUrl.trim() || selected.baseUrl)}
+                  onPress={() => void probeModels()}
                   style={({ pressed }) => [
-                    styles.modelRow,
-                    entry.id === selected.id && styles.selectedRow,
+                    styles.outlineButton,
                     pressed && styles.pressed,
+                    (busy || !(baseUrl.trim() || selected.baseUrl)) && styles.disabled,
                   ]}
                 >
-                  <View style={styles.radio}>
-                    {entry.id === selected.id ? <View style={styles.radioDot} /> : null}
-                  </View>
-                  <Text style={styles.modelLabel}>{entry.label}</Text>
+                  <Text style={styles.outlineLabel}>
+                    {pending === "probe" ? "Fetching…" : "Fetch models"}
+                  </Text>
                 </Pressable>
-              ))}
-            </View>
-            <Text style={styles.billing}>{selected.billing}</Text>
+              </>
+            ) : (
+              <>
+                <Text style={styles.sectionTitle}>Model</Text>
+                <View style={styles.card}>
+                  {modelsForProvider.map((entry) => (
+                    <Pressable
+                      key={`${entry.provider}:${entry.id}`}
+                      accessibilityRole="radio"
+                      accessibilityState={{ selected: entry.id === selected.id }}
+                      onPress={() => {
+                        cancelOAuth();
+                        setModelId(entry.id);
+                        setError(null);
+                        setNotice(null);
+                      }}
+                      style={({ pressed }) => [
+                        styles.modelRow,
+                        entry.id === selected.id && styles.selectedRow,
+                        pressed && styles.pressed,
+                      ]}
+                    >
+                      <View style={styles.radio}>
+                        {entry.id === selected.id ? <View style={styles.radioDot} /> : null}
+                      </View>
+                      <Text style={styles.modelLabel}>{entry.label}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+                <Text style={styles.billing}>{selected.billing}</Text>
+              </>
+            )}
 
             <View style={styles.credentialCard}>
               <Text style={styles.eyebrow}>Personal credential</Text>
@@ -299,8 +449,12 @@ export default function Models() {
               </Text>
               <Text style={styles.secondary}>
                 {credential
-                  ? "Your key or subscription token is stored securely and is never shown here."
-                  : "Connect this provider to use it as your personal model."}
+                  ? isCustom
+                    ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
+                    : "Your key or subscription token is stored securely and is never shown here."
+                  : isCustom
+                    ? "Paste any OpenAI-compatible base URL. The API key is optional for local servers."
+                    : "Connect this provider to use it as your personal model."}
               </Text>
             </View>
 
@@ -336,10 +490,14 @@ export default function Models() {
               <View style={styles.keySection}>
                 <Text style={styles.sectionTitle}>
                   {credential
-                    ? "Replace API key"
+                    ? isCustom
+                      ? "Replace API key (optional)"
+                      : "Replace API key"
                     : deviceSignIn
                       ? "Or connect an API key"
-                      : "API key"}
+                      : isCustom
+                        ? "API key (optional)"
+                        : "API key"}
                 </Text>
                 <TextInput
                   accessibilityLabel="API key"
@@ -356,20 +514,31 @@ export default function Models() {
                 />
                 <Pressable
                   accessibilityRole="button"
-                  disabled={busy || apiKey.trim().length < 8}
+                  disabled={
+                    busy ||
+                    (isCustom ? !(baseUrl.trim() || selected.baseUrl) : apiKey.trim().length < 8)
+                  }
                   onPress={() => void connectKey()}
                   style={({ pressed }) => [
                     styles.primaryButton,
-                    (busy || apiKey.trim().length < 8) && styles.disabled,
+                    (busy ||
+                      (isCustom
+                        ? !(baseUrl.trim() || selected.baseUrl)
+                        : apiKey.trim().length < 8)) &&
+                      styles.disabled,
                     pressed && styles.pressed,
                   ]}
                 >
                   <Text style={styles.primaryLabel}>
                     {pending === "connect"
                       ? "Saving…"
-                      : credential
-                        ? "Replace API key"
-                        : "Connect API key"}
+                      : isCustom
+                        ? credential
+                          ? "Save endpoint"
+                          : "Connect endpoint"
+                        : credential
+                          ? "Replace API key"
+                          : "Connect API key"}
                   </Text>
                 </Pressable>
               </View>

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -39,7 +39,10 @@ export default function NewBot() {
         notifyOnFinish: true,
         computerMode,
       });
-      router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
+      router.replace({
+        pathname: "/thread",
+        params: { botId: bot.id, name: bot.name, color: bot.color },
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not create bot");
     } finally {

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1,8 +1,19 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/native";
 import { abortableDelay, attachmentsForBot } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Alert, AppState, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Animated,
+  AppState,
+  Image,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { BotAvatar } from "../components/bot-avatar";
 import { NativeSymbol } from "../components/native-symbol";
 import {
   applyMobileThreadEvent,
@@ -30,10 +41,11 @@ type PendingAttachment = PickedAttachment & { botId: string };
 export default function Thread() {
   const navigation = useNavigation();
   const router = useRouter();
-  const { botId, name, messageId } = useLocalSearchParams<{
+  const { botId, name, messageId, color } = useLocalSearchParams<{
     botId?: string;
     name?: string;
     messageId?: string;
+    color?: string;
   }>();
   const scroll = useRef<ScrollView>(null);
   const loadingOlderContent = useRef(false);
@@ -47,6 +59,7 @@ export default function Thread() {
     olderCursor: number | null;
   } | null>(null);
   const jumpScrollTarget = useRef<string | null>(null);
+  const enterState = useRef({ botId: "", seen: new Set<string>(), primed: false });
   const activeBotId = useRef(botId);
   activeBotId.current = botId;
   const [snap, setSnap] = useState<MobileSnapshot | null>(null);
@@ -56,7 +69,27 @@ export default function Thread() {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const [enteringIds, setEnteringIds] = useState<Set<string>>(() => new Set());
   const activePendingAttachments = attachmentsForBot(pendingAttachments, botId);
+  const botName = name || "Bot";
+  const botColor = typeof color === "string" && color ? color : "#3EC5A8";
+  const botWorking = Boolean(
+    snap?.run && ["running", "queued", "leased"].includes(snap.run.status),
+  );
+  const hasLiveReasoning = (snap?.messages ?? []).some((message) =>
+    message.id.startsWith("reasoning:"),
+  );
+
+  useLayoutEffect(() => {
+    const nextBotId = botId ?? "";
+    const switchedBot = enterState.current.botId !== nextBotId;
+    const next = collectEnteringUserMessageIds(nextBotId, snap?.messages ?? [], enterState.current);
+    if (switchedBot) {
+      setEnteringIds(new Set());
+      return;
+    }
+    if (next.size > 0) setEnteringIds(next);
+  }, [botId, snap?.messages]);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -404,43 +437,49 @@ export default function Thread() {
           </Pressable>
         ) : null}
         {(snap?.messages ?? []).map((message) => (
-          <View
-            key={message.id}
-            onLayout={(event) => {
-              if (jumpScrollTarget.current !== message.id) return;
-              scroll.current?.scrollTo({
-                y: Math.max(0, event.nativeEvent.layout.y - 24),
-                animated: true,
-              });
-              jumpScrollTarget.current = null;
-            }}
-            style={{
-              marginTop: 12,
-              width: "100%",
-              flexDirection: "row",
-              justifyContent: message.role === "user" ? "flex-end" : "flex-start",
-            }}
-          >
-            <MessageBubble
-              botId={botId ?? ""}
-              message={message}
-              onOpenBot={(id, botName) =>
-                router.push({ pathname: "/thread", params: { botId: id, name: botName } })
-              }
-              onSpeak={
-                message.role === "bot"
-                  ? () =>
-                      void speakMessage(botId ?? "", message).catch((err) =>
-                        Alert.alert(
-                          "Could not speak",
-                          err instanceof Error ? err.message : "Try again.",
-                        ),
-                      )
-                  : undefined
-              }
-            />
-          </View>
+          <DropInMessage key={message.id} active={enteringIds.has(message.id)}>
+            <View
+              onLayout={(event) => {
+                if (jumpScrollTarget.current !== message.id) return;
+                scroll.current?.scrollTo({
+                  y: Math.max(0, event.nativeEvent.layout.y - 24),
+                  animated: true,
+                });
+                jumpScrollTarget.current = null;
+              }}
+              style={{
+                marginTop: 12,
+                width: "100%",
+                flexDirection: "row",
+                justifyContent: message.role === "user" ? "flex-end" : "flex-start",
+              }}
+            >
+              <MessageBubble
+                botId={botId ?? ""}
+                botName={botName}
+                botColor={botColor}
+                message={message}
+                onOpenBot={(id, botName) =>
+                  router.push({ pathname: "/thread", params: { botId: id, name: botName } })
+                }
+                onSpeak={
+                  message.role === "bot"
+                    ? () =>
+                        void speakMessage(botId ?? "", message).catch((err) =>
+                          Alert.alert(
+                            "Could not speak",
+                            err instanceof Error ? err.message : "Try again.",
+                          ),
+                        )
+                    : undefined
+                }
+              />
+            </View>
+          </DropInMessage>
         ))}
+        {botWorking && !hasLiveReasoning ? (
+          <BotWorkingStatus name={botName} color={botColor} />
+        ) : null}
       </ScrollView>
       {attachmentNotice ? (
         <Text style={{ color: "#D6CFA0", marginTop: 12, fontSize: 13 }}>{attachmentNotice}</Text>
@@ -548,6 +587,91 @@ export default function Thread() {
   );
 }
 
+function collectEnteringUserMessageIds(
+  botId: string,
+  messages: MobileMessage[],
+  state: { botId: string; seen: Set<string>; primed: boolean },
+) {
+  if (state.botId !== botId) {
+    state.botId = botId;
+    state.seen = new Set(messages.map((message) => message.id));
+    state.primed = messages.length > 0;
+    return new Set<string>();
+  }
+  if (!state.primed) {
+    if (!messages.length) return new Set<string>();
+    for (const message of messages) state.seen.add(message.id);
+    state.primed = true;
+    return new Set<string>();
+  }
+  const recent = new Set(messages.slice(-4).map((message) => message.id));
+  const entering = new Set<string>();
+  for (const message of messages) {
+    if (!state.seen.has(message.id) && message.role === "user" && recent.has(message.id)) {
+      entering.add(message.id);
+    }
+    state.seen.add(message.id);
+  }
+  return entering;
+}
+
+function DropInMessage({ active, children }: { active: boolean; children: ReactNode }) {
+  const progress = useRef(new Animated.Value(active ? 0 : 1)).current;
+  useEffect(() => {
+    if (!active) return;
+    progress.setValue(0);
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: 380,
+      useNativeDriver: true,
+    }).start();
+  }, [active, progress]);
+  if (!active) return <>{children}</>;
+  return (
+    <Animated.View
+      style={{
+        opacity: progress,
+        transform: [
+          {
+            translateY: progress.interpolate({ inputRange: [0, 1], outputRange: [-18, 0] }),
+          },
+        ],
+      }}
+    >
+      {children}
+    </Animated.View>
+  );
+}
+
+function WorkingShimmerText({ text }: { text: string }) {
+  const shine = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.timing(shine, { toValue: 1, duration: 1600, useNativeDriver: true }),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [shine]);
+  const opacity = shine.interpolate({
+    inputRange: [0, 0.5, 1],
+    outputRange: [0.42, 1, 0.42],
+  });
+  return (
+    <Animated.Text style={{ color: "#E8E8EC", fontSize: 15, fontWeight: "600", opacity }}>
+      {text}
+    </Animated.Text>
+  );
+}
+
+function BotWorkingStatus({ name, color }: { name: string; color: string }) {
+  return (
+    <View style={{ flexDirection: "row", alignItems: "center", gap: 10, marginTop: 14 }}>
+      <BotAvatar color={color} size={28} thinking />
+      <WorkingShimmerText text={`${name} is working`} />
+    </View>
+  );
+}
+
 async function speakMessage(botId: string, message: MobileMessage) {
   const text = blockText(message);
   if (!text.trim()) return;
@@ -563,11 +687,14 @@ async function speakMessage(botId: string, message: MobileMessage) {
 
 function ReasoningCard({
   steps,
+  botName,
+  botColor,
 }: {
   steps: Array<{ id?: string; kind?: string; title?: string; detail?: string; status?: string }>;
+  botName: string;
+  botColor: string;
 }) {
   const running = steps.some((step) => step.status === "running");
-  const active = [...steps].reverse().find((step) => step.status === "running") ?? steps.at(-1);
   return (
     <View
       style={{
@@ -579,9 +706,14 @@ function ReasoningCard({
         paddingVertical: 14,
       }}
     >
-      <Text style={{ color: "#C9C9CE", fontSize: 14, fontWeight: "600" }}>
-        {running ? active?.title || "Thinking" : "Thought process"}
-      </Text>
+      {running ? (
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
+          <BotAvatar color={botColor} size={22} thinking />
+          <WorkingShimmerText text={`${botName} is working`} />
+        </View>
+      ) : (
+        <Text style={{ color: "#C9C9CE", fontSize: 14, fontWeight: "600" }}>Thought process</Text>
+      )}
       {steps.map((step, index) => (
         <View key={step.id || String(index)} style={{ marginTop: 10 }}>
           <Text style={{ color: step.status === "running" ? "#F5A03C" : "#A8A8AD", fontSize: 13 }}>
@@ -598,11 +730,15 @@ function ReasoningCard({
 
 function MessageBubble({
   botId,
+  botName,
+  botColor,
   message,
   onOpenBot,
   onSpeak,
 }: {
   botId: string;
+  botName: string;
+  botColor: string;
   message: MobileMessage;
   onOpenBot: (botId: string, name: string) => void;
   onSpeak?: () => void;
@@ -617,7 +753,7 @@ function MessageBubble({
     );
     return (
       <View style={{ gap: 8, maxWidth: "90%" }}>
-        <ReasoningCard steps={reasoning.steps} />
+        <ReasoningCard steps={reasoning.steps} botName={botName} botColor={botColor} />
         {textBlocks.length ? (
           <View
             style={{

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -4,6 +4,7 @@ import {
   attachmentsForBot,
   createPendingUserMessageId,
   pendingUserMessageTextKey,
+  visibleReasoningSteps,
 } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -18,7 +19,6 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { BotAvatar } from "../components/bot-avatar";
 import { NativeSymbol } from "../components/native-symbol";
 import {
   applyMobileThreadEvent,
@@ -46,11 +46,10 @@ type PendingAttachment = PickedAttachment & { botId: string };
 export default function Thread() {
   const navigation = useNavigation();
   const router = useRouter();
-  const { botId, name, messageId, color } = useLocalSearchParams<{
+  const { botId, name, messageId } = useLocalSearchParams<{
     botId?: string;
     name?: string;
     messageId?: string;
-    color?: string;
   }>();
   const scroll = useRef<ScrollView>(null);
   const loadingOlderContent = useRef(false);
@@ -76,8 +75,6 @@ export default function Thread() {
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [enteringIds, setEnteringIds] = useState<Set<string>>(() => new Set());
   const activePendingAttachments = attachmentsForBot(pendingAttachments, botId);
-  const botName = name || "Bot";
-  const botColor = typeof color === "string" && color ? color : "#3EC5A8";
   const botWorking = Boolean(
     snap?.run && ["running", "queued", "leased"].includes(snap.run.status),
   );
@@ -381,7 +378,6 @@ export default function Thread() {
       if (activeBotId.current === targetBotId) {
         if (!text) setDraft("");
         setAttachmentNotice(null);
-        void refresh();
       }
     } catch (err) {
       if (activeBotId.current === targetBotId) {
@@ -484,8 +480,6 @@ export default function Thread() {
             >
               <MessageBubble
                 botId={botId ?? ""}
-                botName={botName}
-                botColor={botColor}
                 message={message}
                 onOpenBot={(id, botName) =>
                   router.push({ pathname: "/thread", params: { botId: id, name: botName } })
@@ -505,9 +499,7 @@ export default function Thread() {
             </View>
           </DropInMessage>
         ))}
-        {botWorking && !hasLiveReasoning ? (
-          <BotWorkingStatus name={botName} color={botColor} />
-        ) : null}
+        {botWorking && !hasLiveReasoning ? <BotWorkingStatus /> : null}
       </ScrollView>
       {attachmentNotice ? (
         <Text style={{ color: "#D6CFA0", marginTop: 12, fontSize: 13 }}>{attachmentNotice}</Text>
@@ -661,9 +653,10 @@ function DropInMessage({ active, children }: { active: boolean; children: ReactN
   useEffect(() => {
     if (!active) return;
     progress.setValue(0);
-    Animated.timing(progress, {
+    Animated.spring(progress, {
       toValue: 1,
-      duration: 380,
+      friction: 6.4,
+      tension: 148,
       useNativeDriver: true,
     }).start();
   }, [active, progress]);
@@ -674,7 +667,10 @@ function DropInMessage({ active, children }: { active: boolean; children: ReactN
         opacity: progress,
         transform: [
           {
-            translateY: progress.interpolate({ inputRange: [0, 1], outputRange: [-18, 0] }),
+            translateY: progress.interpolate({ inputRange: [0, 1], outputRange: [-14, 0] }),
+          },
+          {
+            scale: progress.interpolate({ inputRange: [0, 1], outputRange: [0.96, 1] }),
           },
         ],
       }}
@@ -688,7 +684,7 @@ function WorkingShimmerText({ text }: { text: string }) {
   const shine = useRef(new Animated.Value(0)).current;
   useEffect(() => {
     const loop = Animated.loop(
-      Animated.timing(shine, { toValue: 1, duration: 1600, useNativeDriver: true }),
+      Animated.timing(shine, { toValue: 1, duration: 980, useNativeDriver: true }),
     );
     loop.start();
     return () => loop.stop();
@@ -704,11 +700,11 @@ function WorkingShimmerText({ text }: { text: string }) {
   );
 }
 
-function BotWorkingStatus({ name, color }: { name: string; color: string }) {
+function BotWorkingStatus() {
   return (
-    <View style={{ flexDirection: "row", alignItems: "center", gap: 10, marginTop: 14 }}>
-      <BotAvatar color={color} size={28} thinking />
-      <WorkingShimmerText text={`${name} is working`} />
+    <View style={{ flexDirection: "row", alignItems: "center", gap: 6, marginTop: 8 }}>
+      <NativeSymbol ios="chevron.right" android="chevron-forward" size={14} color="#8E8EA0" />
+      <WorkingShimmerText text="Thinking" />
     </View>
   );
 }
@@ -728,58 +724,113 @@ async function speakMessage(botId: string, message: MobileMessage) {
 
 function ReasoningCard({
   steps,
-  botName,
-  botColor,
 }: {
-  steps: Array<{ id?: string; kind?: string; title?: string; detail?: string; status?: string }>;
-  botName: string;
-  botColor: string;
+  steps: Array<{
+    id?: string;
+    kind?: "status" | "think" | "tool";
+    title?: string;
+    detail?: string;
+    status?: "running" | "done";
+  }>;
 }) {
   const running = steps.some((step) => step.status === "running");
+  const [open, setOpen] = useState(running);
+  const rotation = useRef(new Animated.Value(running ? 1 : 0)).current;
+  const visible = visibleReasoningSteps(
+    steps.flatMap((step, index) => {
+      if (step.kind !== "status" && step.kind !== "think" && step.kind !== "tool") return [];
+      if (step.status !== "running" && step.status !== "done") return [];
+      return [
+        {
+          id: step.id || String(index),
+          kind: step.kind,
+          title: step.title ?? "",
+          detail: step.detail,
+          status: step.status,
+        },
+      ];
+    }),
+  );
+  useEffect(() => {
+    setOpen(running);
+  }, [running]);
+  useEffect(() => {
+    Animated.timing(rotation, {
+      toValue: open ? 1 : 0,
+      duration: 180,
+      useNativeDriver: true,
+    }).start();
+  }, [open, rotation]);
   return (
-    <View
-      style={{
-        borderRadius: 18,
-        borderWidth: 1,
-        borderColor: "#232326",
-        backgroundColor: "#141416",
-        paddingHorizontal: 16,
-        paddingVertical: 14,
-      }}
-    >
-      {running ? (
-        <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
-          <BotAvatar color={botColor} size={22} thinking />
-          <WorkingShimmerText text={`${botName} is working`} />
+    <View>
+      <Pressable
+        onPress={() => setOpen((current) => !current)}
+        style={{ flexDirection: "row", alignItems: "center", gap: 6, paddingVertical: 2 }}
+      >
+        <Animated.View
+          style={{
+            transform: [
+              {
+                rotate: rotation.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: ["0deg", "90deg"],
+                }),
+              },
+            ],
+          }}
+        >
+          <NativeSymbol ios="chevron.right" android="chevron-forward" size={14} color="#8E8EA0" />
+        </Animated.View>
+        {running ? (
+          <WorkingShimmerText text="Thinking" />
+        ) : (
+          <Text style={{ color: "#B4B4B8", fontSize: 15, fontWeight: "600" }}>Thought</Text>
+        )}
+      </Pressable>
+      {open && visible.length ? (
+        <View
+          style={{
+            marginLeft: 7,
+            marginTop: 8,
+            borderLeftWidth: 1,
+            borderLeftColor: "#3A3A40",
+            paddingLeft: 14,
+            gap: 10,
+          }}
+        >
+          {visible.map((step) => (
+            <View key={step.id}>
+              {step.kind === "tool" || !step.detail ? (
+                <Text
+                  style={{
+                    color: step.status === "running" ? "#D0D0D4" : "#8E8EA0",
+                    fontSize: 14,
+                    lineHeight: 21,
+                  }}
+                >
+                  {step.title}
+                </Text>
+              ) : null}
+              {step.detail ? (
+                <Text style={{ color: "#8E8EA0", fontSize: 14, lineHeight: 21 }}>
+                  {step.detail}
+                </Text>
+              ) : null}
+            </View>
+          ))}
         </View>
-      ) : (
-        <Text style={{ color: "#C9C9CE", fontSize: 14, fontWeight: "600" }}>Thought process</Text>
-      )}
-      {steps.map((step, index) => (
-        <View key={step.id || String(index)} style={{ marginTop: 10 }}>
-          <Text style={{ color: step.status === "running" ? "#F5A03C" : "#A8A8AD", fontSize: 13 }}>
-            {step.title}
-          </Text>
-          {step.detail ? (
-            <Text style={{ color: "#85858A", fontSize: 13, marginTop: 4 }}>{step.detail}</Text>
-          ) : null}
-        </View>
-      ))}
+      ) : null}
     </View>
   );
 }
 
 function MessageBubble({
   botId,
-  botName,
-  botColor,
   message,
   onOpenBot,
   onSpeak,
 }: {
   botId: string;
-  botName: string;
-  botColor: string;
   message: MobileMessage;
   onOpenBot: (botId: string, name: string) => void;
   onSpeak?: () => void;
@@ -794,7 +845,7 @@ function MessageBubble({
     );
     return (
       <View style={{ gap: 8, maxWidth: "90%" }}>
-        <ReasoningCard steps={reasoning.steps} botName={botName} botColor={botColor} />
+        <ReasoningCard steps={reasoning.steps} />
         {textBlocks.length ? (
           <View
             style={{

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1,5 +1,10 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/native";
-import { abortableDelay, attachmentsForBot } from "@rakazo/core";
+import {
+  abortableDelay,
+  attachmentsForBot,
+  createPendingUserMessageId,
+  pendingUserMessageTextKey,
+} from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
@@ -338,6 +343,20 @@ export default function Thread() {
     const attachments = attachmentsForBot(pendingAttachments, targetBotId);
     const text = draft.trim();
     if (!text && attachments.length === 0) return;
+    const pendingId = createPendingUserMessageId();
+    if (text) {
+      setDraft("");
+      setSnap((current) => {
+        if (!current) return current;
+        return {
+          ...current,
+          messages: [
+            ...current.messages,
+            { id: pendingId, role: "user", blocks: [{ kind: "text", text }] },
+          ],
+        };
+      });
+    }
     setSending(true);
     setError(null);
     try {
@@ -360,12 +379,21 @@ export default function Thread() {
         current.filter((attachment) => attachment.botId !== targetBotId),
       );
       if (activeBotId.current === targetBotId) {
-        setDraft("");
+        if (!text) setDraft("");
         setAttachmentNotice(null);
-        await refresh();
+        void refresh();
       }
     } catch (err) {
       if (activeBotId.current === targetBotId) {
+        setSnap((current) =>
+          current
+            ? {
+                ...current,
+                messages: current.messages.filter((message) => message.id !== pendingId),
+              }
+            : current,
+        );
+        if (text) setDraft(text);
         setError(err instanceof Error ? err.message : "Failed to send message");
       }
     } finally {
@@ -607,12 +635,25 @@ function collectEnteringUserMessageIds(
   const recent = new Set(messages.slice(-4).map((message) => message.id));
   const entering = new Set<string>();
   for (const message of messages) {
+    const text = userMessagePlainText(message);
+    const pendingKey = pendingUserMessageTextKey(text);
     if (!state.seen.has(message.id) && message.role === "user" && recent.has(message.id)) {
-      entering.add(message.id);
+      const replacingPending = !message.id.startsWith("pending:") && state.seen.has(pendingKey);
+      if (!replacingPending) entering.add(message.id);
     }
     state.seen.add(message.id);
+    if (message.role === "user") {
+      if (message.id.startsWith("pending:")) state.seen.add(pendingKey);
+      else state.seen.delete(pendingKey);
+    }
   }
   return entering;
+}
+
+function userMessagePlainText(message: MobileMessage): string {
+  return message.blocks
+    .flatMap((block) => (block.kind === "text" ? [block.text ?? ""] : []))
+    .join("\n");
 }
 
 function DropInMessage({ active, children }: { active: boolean; children: ReactNode }) {

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -248,6 +248,7 @@ export default function Thread() {
               retryMs = 250;
               if (
                 event.type === "thread.progress" ||
+                event.type === "thread.reasoning" ||
                 event.type === "thread.message.created" ||
                 event.type === "thread.message.updated" ||
                 event.type === "thread.subagent" ||
@@ -560,6 +561,41 @@ async function speakMessage(botId: string, message: MobileMessage) {
   }
 }
 
+function ReasoningCard({
+  steps,
+}: {
+  steps: Array<{ id?: string; kind?: string; title?: string; detail?: string; status?: string }>;
+}) {
+  const running = steps.some((step) => step.status === "running");
+  const active = [...steps].reverse().find((step) => step.status === "running") ?? steps.at(-1);
+  return (
+    <View
+      style={{
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor: "#232326",
+        backgroundColor: "#141416",
+        paddingHorizontal: 16,
+        paddingVertical: 14,
+      }}
+    >
+      <Text style={{ color: "#C9C9CE", fontSize: 14, fontWeight: "600" }}>
+        {running ? active?.title || "Thinking" : "Thought process"}
+      </Text>
+      {steps.map((step, index) => (
+        <View key={step.id || String(index)} style={{ marginTop: 10 }}>
+          <Text style={{ color: step.status === "running" ? "#F5A03C" : "#A8A8AD", fontSize: 13 }}>
+            {step.title}
+          </Text>
+          {step.detail ? (
+            <Text style={{ color: "#85858A", fontSize: 13, marginTop: 4 }}>{step.detail}</Text>
+          ) : null}
+        </View>
+      ))}
+    </View>
+  );
+}
+
 function MessageBubble({
   botId,
   message,
@@ -571,9 +607,33 @@ function MessageBubble({
   onOpenBot: (botId: string, name: string) => void;
   onSpeak?: () => void;
 }) {
+  const reasoning = message.blocks.find((block) => block.kind === "reasoning");
   const special = message.blocks.find(
     (block) => block.kind === "subagent" || block.kind === "child_bot",
   );
+  if (reasoning?.kind === "reasoning" && reasoning.steps?.length && !special) {
+    const textBlocks = message.blocks.filter(
+      (block) => (block.kind === "text" || block.kind === "progress") && block.text,
+    );
+    return (
+      <View style={{ gap: 8, maxWidth: "90%" }}>
+        <ReasoningCard steps={reasoning.steps} />
+        {textBlocks.length ? (
+          <View
+            style={{
+              backgroundColor: "#1A1A1D",
+              padding: 12,
+              borderRadius: 20,
+            }}
+          >
+            <ChatMarkdown streaming={message.id.startsWith("progress:")}>
+              {textBlocks.map((block) => block.text).join("\n")}
+            </ChatMarkdown>
+          </View>
+        ) : null}
+      </View>
+    );
+  }
   if (special?.kind === "subagent") {
     const running = special.status === "running";
     const failed = special.status === "failed";

--- a/apps/mobile/components/bot-avatar.tsx
+++ b/apps/mobile/components/bot-avatar.tsx
@@ -1,12 +1,47 @@
-import { View } from "react-native";
+import { useEffect, useRef } from "react";
+import { Animated, View } from "react-native";
 
-export function BotAvatar({ color, size = 54 }: { color: string; size?: number }) {
+export function BotAvatar({
+  color,
+  size = 54,
+  thinking = false,
+}: {
+  color: string;
+  size?: number;
+  thinking?: boolean;
+}) {
   const visorW = Math.round(size * 0.68);
   const visorH = Math.round(size * 0.4);
   const dot = Math.max(3, Math.round(size * 0.1));
   const gap = Math.max(4, Math.round(size * 0.13));
+  const bob = useRef(new Animated.Value(0)).current;
+  const blink = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (!thinking) {
+      bob.setValue(0);
+      blink.setValue(1);
+      return;
+    }
+    const motion = Animated.loop(
+      Animated.parallel([
+        Animated.sequence([
+          Animated.timing(bob, { toValue: 1, duration: 520, useNativeDriver: true }),
+          Animated.timing(bob, { toValue: 0, duration: 520, useNativeDriver: true }),
+        ]),
+        Animated.sequence([
+          Animated.delay(900),
+          Animated.timing(blink, { toValue: 0.2, duration: 90, useNativeDriver: true }),
+          Animated.timing(blink, { toValue: 1, duration: 90, useNativeDriver: true }),
+        ]),
+      ]),
+    );
+    motion.start();
+    return () => motion.stop();
+  }, [thinking, bob, blink]);
+
   return (
-    <View
+    <Animated.View
       style={{
         width: size,
         height: size,
@@ -14,6 +49,11 @@ export function BotAvatar({ color, size = 54 }: { color: string; size?: number }
         backgroundColor: color,
         alignItems: "center",
         justifyContent: "center",
+        transform: [
+          {
+            translateY: bob.interpolate({ inputRange: [0, 1], outputRange: [0, -4] }),
+          },
+        ],
       }}
     >
       <View
@@ -28,9 +68,27 @@ export function BotAvatar({ color, size = 54 }: { color: string; size?: number }
           gap,
         }}
       >
-        <View style={{ width: dot, height: dot, borderRadius: dot / 2, backgroundColor: "#fff" }} />
-        <View style={{ width: dot, height: dot, borderRadius: dot / 2, backgroundColor: "#fff" }} />
+        <Animated.View
+          style={{
+            width: dot,
+            height: dot,
+            borderRadius: dot / 2,
+            backgroundColor: "#fff",
+            opacity: blink,
+            transform: [{ scaleY: blink }],
+          }}
+        />
+        <Animated.View
+          style={{
+            width: dot,
+            height: dot,
+            borderRadius: dot / 2,
+            backgroundColor: "#fff",
+            opacity: blink,
+            transform: [{ scaleY: blink }],
+          }}
+        />
       </View>
-    </View>
+    </Animated.View>
   );
 }

--- a/apps/mobile/components/bot-avatar.tsx
+++ b/apps/mobile/components/bot-avatar.tsx
@@ -26,8 +26,8 @@ export function BotAvatar({
     const motion = Animated.loop(
       Animated.parallel([
         Animated.sequence([
-          Animated.timing(bob, { toValue: 1, duration: 520, useNativeDriver: true }),
-          Animated.timing(bob, { toValue: 0, duration: 520, useNativeDriver: true }),
+          Animated.timing(bob, { toValue: 1, duration: 380, useNativeDriver: true }),
+          Animated.timing(bob, { toValue: 0, duration: 380, useNativeDriver: true }),
         ]),
         Animated.sequence([
           Animated.delay(900),

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -234,7 +234,10 @@ describe("mobile thread event reduction", () => {
     expect(second?.messages.map((item) => item.id)).toEqual(["reasoning:run-1", "progress:run-1"]);
     expect(second?.messages[0]?.blocks[0]).toMatchObject({
       kind: "reasoning",
-      steps: [expect.objectContaining({ title: "Starting" }), expect.objectContaining({ title: "Running a command" })],
+      steps: [
+        expect.objectContaining({ title: "Starting" }),
+        expect.objectContaining({ title: "Running a command" }),
+      ],
     });
   });
 

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -214,6 +214,30 @@ describe("mobile thread event reduction", () => {
     ]);
   });
 
+  it("streams a live reasoning trace ahead of answer progress", () => {
+    const first = applyMobileThreadEvent(snapshot(), {
+      type: "thread.progress",
+      runId: "run-1",
+      payload: { delta: "Draft" },
+    });
+    const second = applyMobileThreadEvent(first, {
+      type: "thread.reasoning",
+      runId: "run-1",
+      payload: {
+        steps: [
+          { id: "status", kind: "status", title: "Starting", status: "running" },
+          { id: "tool-1", kind: "tool", title: "Running a command", status: "running" },
+        ],
+      },
+    });
+
+    expect(second?.messages.map((item) => item.id)).toEqual(["reasoning:run-1", "progress:run-1"]);
+    expect(second?.messages[0]?.blocks[0]).toMatchObject({
+      kind: "reasoning",
+      steps: [expect.objectContaining({ title: "Starting" }), expect.objectContaining({ title: "Running a command" })],
+    });
+  });
+
   it("deduplicates durable messages and replaces matching transient subagent state", () => {
     const initial = snapshot([
       mobileMessage("message-1", [{ kind: "text", text: "old" }]),

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -7,10 +7,13 @@ import type {
   ModelCredential,
 } from "@rakazo/contracts";
 import {
+  isEphemeralThreadMessageId,
   mergeThreadHistory,
   prependThreadHistoryPage,
   progressMessageId,
   progressMessageText,
+  reasoningMessageId,
+  reasoningStepsFromPayload,
   type ThreadHistory,
 } from "@rakazo/core";
 import * as SecureStore from "expo-secure-store";
@@ -187,6 +190,13 @@ export type MobileMessage = {
     artifactId?: string;
     mimeType?: string;
     size?: number;
+    steps?: Array<{
+      id: string;
+      kind: string;
+      title: string;
+      detail?: string;
+      status: string;
+    }>;
   }>;
 };
 
@@ -235,6 +245,12 @@ export function blockText(message: MobileMessage) {
       if (block.kind === "image") return `[image: ${block.name ?? "attachment"}]`;
       if (block.kind === "file") {
         return `[file: ${block.name ?? "attachment"}${block.size ? ` (${block.size} bytes)` : ""}]`;
+      }
+      if (block.kind === "reasoning") {
+        return (block.steps ?? [])
+          .map((step) => step.title)
+          .filter(Boolean)
+          .join(". ");
       }
       return block.text ?? block.state ?? "";
     })
@@ -325,6 +341,23 @@ export function applyMobileThreadEvent(
       ],
     };
   }
+  if (event.type === "thread.reasoning") {
+    const streaming: MobileMessage = {
+      id: reasoningMessageId(event),
+      role: "bot",
+      blocks: [{ kind: "reasoning", steps: reasoningStepsFromPayload(event.payload ?? {}) }],
+    };
+    return {
+      ...prev,
+      messages: [
+        ...prev.messages.filter(
+          (message) => message.id !== streaming.id && !message.id.startsWith("progress:"),
+        ),
+        streaming,
+        ...prev.messages.filter((message) => message.id.startsWith("progress:")),
+      ],
+    };
+  }
   if (event.type === "thread.subagent") {
     const agentId = String(event.payload?.agentId ?? event.id ?? "live");
     const streaming: MobileMessage = {
@@ -364,7 +397,7 @@ export function applyMobileThreadEvent(
         ...prev.messages.filter(
           (message) =>
             message.id !== next.id &&
-            !message.id.startsWith("progress:") &&
+            !isEphemeralThreadMessageId(message.id) &&
             !(
               message.id.startsWith("subagent:") &&
               next.blocks.some(

--- a/apps/web/src/lib/model-auth.ts
+++ b/apps/web/src/lib/model-auth.ts
@@ -6,6 +6,7 @@ export type { ModelCatalogEntry, ModelCredential } from "@rakazo/contracts";
 export { cancelModelOAuthAttempt, finishModelOAuthAttempt } from "@rakazo/core";
 
 export function providerHint(entry: ModelCatalogEntry) {
+  if (entry.custom) return entry.baseUrl ? hostFromUrl(entry.baseUrl) : "Base URL";
   if (entry.signIn === "device-code") {
     if (entry.provider === "openai-codex") return "ChatGPT Plus/Pro";
     if (entry.provider === "github-copilot") return "Copilot";
@@ -20,4 +21,12 @@ export async function waitForModelOAuth(loginId: string, signal?: AbortSignal) {
   return waitForModelOAuthCompletion(() => rpc.models.completeOAuth({ loginId }, { signal }), {
     signal,
   });
+}
+
+function hostFromUrl(value: string): string {
+  try {
+    return new URL(value).host || "Base URL";
+  } catch {
+    return "Base URL";
+  }
 }

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -116,6 +116,26 @@ describe("thread event reduction", () => {
     });
   });
 
+  it("replaces a pending user bubble with the durable message", () => {
+    const initial = snapshot([
+      { ...message("pending:local", [{ kind: "text", text: "yo" }], 1), role: "user" },
+    ]);
+    const next = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.message.created",
+        seq: 4,
+        payload: {
+          messageId: "m-real",
+          role: "user",
+          blocks: [{ kind: "text", text: "yo" }],
+        },
+      }),
+    );
+    expect(next?.messages.map((item) => item.id)).toEqual(["m-real"]);
+    expect(next?.messages[0]?.role).toBe("user");
+  });
+
   it("replaces transient progress and a matching live subagent with the durable message", () => {
     const initial = snapshot([
       message("durable", [{ kind: "text", text: "old value" }]),

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -186,7 +186,13 @@ describe("thread event reduction", () => {
         payload: {
           steps: [
             { id: "status", kind: "status", title: "Starting", status: "done" },
-            { id: "think", kind: "think", title: "Thought", detail: "Let me check", status: "done" },
+            {
+              id: "think",
+              kind: "think",
+              title: "Thought",
+              detail: "Let me check",
+              status: "done",
+            },
             { id: "tool-1", kind: "tool", title: "Running a command", status: "running" },
           ],
         },

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -162,6 +162,82 @@ describe("thread event reduction", () => {
     expect(next?.messages[1]?.blocks).toEqual([completedBlock]);
   });
 
+  it("streams a live reasoning trace ahead of answer progress", () => {
+    const initial = snapshot([message("progress:run-1", [{ kind: "progress", text: "Draft" }])]);
+
+    const first = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.reasoning",
+        seq: 6,
+        payload: {
+          steps: [
+            { id: "status", kind: "status", title: "Starting", status: "running" },
+            { id: "think", kind: "think", title: "Thinking", detail: "Let me", status: "running" },
+          ],
+        },
+      }),
+    );
+    const second = reduceThreadSnapshot(
+      first,
+      event({
+        type: "thread.reasoning",
+        seq: 7,
+        payload: {
+          steps: [
+            { id: "status", kind: "status", title: "Starting", status: "done" },
+            { id: "think", kind: "think", title: "Thought", detail: "Let me check", status: "done" },
+            { id: "tool-1", kind: "tool", title: "Running a command", status: "running" },
+          ],
+        },
+      }),
+    );
+
+    expect(isThreadSnapshotEvent(event({ type: "thread.reasoning" }))).toBe(true);
+    expect(second?.messages.map((item) => item.id)).toEqual(["reasoning:run-1", "progress:run-1"]);
+    expect(second?.messages[0]?.blocks[0]).toMatchObject({
+      kind: "reasoning",
+      steps: [
+        expect.objectContaining({ id: "status", status: "done" }),
+        expect.objectContaining({ id: "think", title: "Thought", detail: "Let me check" }),
+        expect.objectContaining({ id: "tool-1", title: "Running a command", status: "running" }),
+      ],
+    });
+  });
+
+  it("drops the live reasoning trace when the durable reply arrives", () => {
+    const initial = snapshot([
+      message("reasoning:run-1", [
+        {
+          kind: "reasoning",
+          steps: [{ id: "status", kind: "status", title: "Starting", status: "running" }],
+        },
+      ]),
+      message("progress:run-1", [{ kind: "progress", text: "Draft" }]),
+    ]);
+
+    const next = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.message.created",
+        seq: 9,
+        payload: {
+          messageId: "durable",
+          role: "bot",
+          blocks: [
+            {
+              kind: "reasoning",
+              steps: [{ id: "status", kind: "status", title: "Starting", status: "done" }],
+            },
+            { kind: "text", text: "Done" },
+          ],
+        },
+      }),
+    );
+
+    expect(next?.messages.map((item) => item.id)).toEqual(["durable"]);
+  });
+
   it("clears durable and transient history when another client clears the thread", () => {
     const initial = snapshot(
       [

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -6,10 +6,13 @@ import type {
   ThreadSnapshot,
 } from "@rakazo/contracts";
 import {
+  isEphemeralThreadMessageId,
   mergeThreadHistory,
   prependThreadHistoryPage,
   progressMessageId,
   progressMessageText,
+  reasoningMessageId,
+  reasoningStepsFromPayload,
   subagentBlockFromPayload,
 } from "@rakazo/core";
 
@@ -40,6 +43,7 @@ export function isThreadSnapshotEvent(event: ProductEvent): boolean {
   return (
     event.type === "thread.cleared" ||
     event.type === "thread.progress" ||
+    event.type === "thread.reasoning" ||
     event.type === "thread.subagent" ||
     event.type === "thread.message.created" ||
     event.type === "thread.message.updated" ||
@@ -81,6 +85,22 @@ export function reduceThreadSnapshot(
     const without = prev.messages.filter((message) => !message.id.startsWith("progress:"));
     return { ...prev, cursor: event.seq, messages: [...without, streaming] };
   }
+  if (event.type === "thread.reasoning") {
+    const next: ThreadMessage = {
+      id: reasoningMessageId(event),
+      threadId: event.threadId,
+      seq: event.seq,
+      role: "bot",
+      blocks: [{ kind: "reasoning", steps: reasoningStepsFromPayload(event.payload) }],
+      runId: event.runId,
+      createdAt: event.createdAt,
+    };
+    const without = prev.messages.filter(
+      (message) => message.id !== next.id && !message.id.startsWith("progress:"),
+    );
+    const progress = prev.messages.filter((message) => message.id.startsWith("progress:"));
+    return { ...prev, cursor: event.seq, messages: [...without, next, ...progress] };
+  }
   if (event.type === "thread.subagent") {
     const block = subagentBlockFromPayload(event.payload);
     const next: ThreadMessage = {
@@ -116,7 +136,7 @@ export function reduceThreadSnapshot(
     const without = prev.messages.filter(
       (message) =>
         message.id !== next.id &&
-        !message.id.startsWith("progress:") &&
+        !isEphemeralThreadMessageId(message.id) &&
         !replacedSubagent(message, replacedSubagentIds),
     );
     return { ...prev, cursor: event.seq, messages: [...without, next] };

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -31,12 +31,13 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [providerQuery, setProviderQuery] = useState("");
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [keyLabel, setKeyLabel] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
   const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | "probe" | null>(null);
+  const [pending, setPending] = useState<"connect" | "default" | "probe" | "key" | null>(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -131,6 +132,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     setModelId(catalog.find((entry) => entry.provider === nextProvider)?.id ?? "");
     detailScrollRef.current?.scrollTo({ top: 0 });
     setApiKey("");
+    setKeyLabel("");
     setBaseUrl(catalog.find((entry) => entry.provider === nextProvider)?.baseUrl ?? "");
     setEndpointLabel(
       catalog.find((entry) => entry.provider === nextProvider)?.providerName ?? "Custom endpoint",
@@ -172,7 +174,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       try {
         const connected = await rpc.models.connect({
           provider: selected.provider,
-          apiKey: apiKey.trim(),
+          apiKey: credential ? "" : apiKey.trim(),
           modelId: modelId.trim() || selected.id,
           label: endpointLabel.trim() || selected.providerName || "Custom endpoint",
           baseUrl: url,
@@ -234,6 +236,60 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       setNotice(`Found ${result.models.length} model${result.models.length === 1 ? "" : "s"}.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not list models");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function addEndpointKey() {
+    if (!selected || !apiKey.trim()) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc.models.addKey({
+        provider: selected.provider,
+        apiKey: apiKey.trim(),
+        label: keyLabel.trim() || undefined,
+      });
+      setApiKey("");
+      setKeyLabel("");
+      await refresh();
+      setNotice("Added an API key to this endpoint.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not add API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function activateEndpointKey(keyId: string) {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc.models.setActiveKey({ provider: selected.provider, keyId });
+      await refresh();
+      setNotice("This key is now used for the endpoint.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not switch API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function removeEndpointKey(keyId: string) {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc.models.removeKey({ provider: selected.provider, keyId });
+      await refresh();
+      setNotice("Removed that API key.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not remove API key");
     } finally {
       setPending(null);
     }
@@ -471,10 +527,88 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
                         : "Your key or subscription token is stored securely and is never shown here."
                       : isCustom
-                        ? "Paste any OpenAI-compatible base URL. The API key is optional for local servers."
+                        ? "Paste any OpenAI-compatible base URL. Add one or more API keys after you connect."
                         : "Connect this provider to use it as your personal model."}
                   </div>
                 </div>
+
+                {isCustom && credential ? (
+                  <div className="mt-5 rounded-[13px] border border-[#26262A] px-4 py-3">
+                    <div className="text-[12.5px] uppercase tracking-[0.08em] text-[#6C6C70]">
+                      API keys
+                    </div>
+                    {credential.keys.length ? (
+                      <ul className="mt-3 space-y-2">
+                        {credential.keys.map((key) => (
+                          <li
+                            key={key.id}
+                            className="flex items-center gap-2 rounded-[10px] bg-[#101012] px-3 py-2"
+                          >
+                            <span className="min-w-0 flex-1 truncate text-[14px] text-[#ECECEE]">
+                              {key.label}
+                            </span>
+                            {key.isActive ? (
+                              <span className="text-[12px] text-[#4ECB71]">Active</span>
+                            ) : (
+                              <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() => void activateEndpointKey(key.id)}
+                                className="text-[12px] text-[#85858A] hover:text-[#ECECEE]"
+                              >
+                                Use
+                              </button>
+                            )}
+                            {credential.keys.length > 1 ? (
+                              <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() => void removeEndpointKey(key.id)}
+                                className="text-[12px] text-[#E65707]"
+                              >
+                                Remove
+                              </button>
+                            ) : null}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="mt-2 text-[13px] text-[#85858A]">
+                        No keys yet. Local servers can run without one.
+                      </p>
+                    )}
+                    <label className="mt-4 block text-[13.5px] text-[#85858A]">
+                      Key label
+                      <input
+                        value={keyLabel}
+                        onChange={(event) => setKeyLabel(event.target.value)}
+                        placeholder="Pool key 2"
+                        className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                      />
+                    </label>
+                    <label className="mt-3 block text-[13.5px] text-[#85858A]">
+                      Add API key
+                      <input
+                        value={apiKey}
+                        onChange={(event) => setApiKey(event.target.value)}
+                        placeholder="sk-…"
+                        type="password"
+                        autoComplete="off"
+                        className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                      />
+                    </label>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={busy || !apiKey.trim()}
+                      onClick={() => void addEndpointKey()}
+                      className="mt-3"
+                    >
+                      {pending === "key" ? "Adding…" : "Add API key"}
+                    </Button>
+                  </div>
+                ) : null}
 
                 {deviceSignIn ? (
                   <div className="mt-5">
@@ -510,13 +644,11 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                   </div>
                 ) : null}
 
-                {acceptsKey ? (
+                {acceptsKey && !(isCustom && credential) ? (
                   <div className="mt-5">
                     <label className="block text-[13.5px] text-[#85858A]">
                       {credential
-                        ? isCustom
-                          ? "Replace API key (optional)"
-                          : "Replace API key"
+                        ? "Replace API key"
                         : deviceSignIn
                           ? "Or connect an API key"
                           : isCustom
@@ -547,12 +679,24 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                       {pending === "connect"
                         ? "Saving…"
                         : isCustom
-                          ? credential
-                            ? "Save endpoint"
-                            : "Connect endpoint"
+                          ? "Connect endpoint"
                           : credential
                             ? "Replace API key"
                             : "Connect API key"}
+                    </Button>
+                  </div>
+                ) : null}
+
+                {isCustom && credential ? (
+                  <div className="mt-5">
+                    <Button
+                      type="button"
+                      variant="pill"
+                      size="sm"
+                      disabled={busy || !(baseUrl.trim() || selected.baseUrl)}
+                      onClick={() => void connectKey()}
+                    >
+                      {pending === "connect" ? "Saving…" : "Save endpoint"}
                     </Button>
                   </div>
                 ) : null}

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -23,6 +23,12 @@ type OAuthNotice = {
   userCode: string;
 };
 
+function formatKeyCoverage(models: string[] | undefined) {
+  if (!models?.length) return "Not probed yet. Refresh coverage after you add keys.";
+  if (models.length <= 8) return models.join(", ");
+  return `${models.slice(0, 8).join(", ")} +${models.length - 8} more`;
+}
+
 export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
   const [credentials, setCredentials] = useState<ModelCredential[]>([]);
@@ -37,7 +43,9 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | "probe" | "key" | null>(null);
+  const [pending, setPending] = useState<
+    "connect" | "default" | "probe" | "key" | "refresh" | null
+  >(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -247,17 +255,35 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     setNotice(null);
     setPending("key");
     try {
-      await rpc.models.addKey({
+      const updated = await rpc.models.addKey({
         provider: selected.provider,
         apiKey: apiKey.trim(),
         label: keyLabel.trim() || undefined,
       });
       setApiKey("");
       setKeyLabel("");
+      setProbedModels(updated.availableModels ?? []);
       await refresh();
-      setNotice("Added an API key to this endpoint.");
+      setNotice("Saved that key. Rakazo will use it for the models it can access.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not add API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function refreshEndpointKeys() {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("refresh");
+    try {
+      const updated = await rpc.models.refreshKeys({ provider: selected.provider });
+      setProbedModels(updated.availableModels ?? []);
+      await refresh();
+      setNotice("Updated which models each API key can use.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not refresh API keys");
     } finally {
       setPending(null);
     }
@@ -527,53 +553,77 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
                         : "Your key or subscription token is stored securely and is never shown here."
                       : isCustom
-                        ? "Paste any OpenAI-compatible base URL. Add one or more API keys after you connect."
+                        ? "Paste any OpenAI-compatible base URL. Extra API keys live under Advanced — Rakazo matches each key to the models it can run."
                         : "Connect this provider to use it as your personal model."}
                   </div>
                 </div>
 
                 {isCustom && credential ? (
-                  <div className="mt-5 rounded-[13px] border border-[#26262A] px-4 py-3">
-                    <div className="text-[12.5px] uppercase tracking-[0.08em] text-[#6C6C70]">
-                      API keys
-                    </div>
+                  <details className="mt-5 rounded-[13px] border border-[#26262A] px-4 py-3">
+                    <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-[13.5px] text-[#ECECEE] [&::-webkit-details-marker]:hidden">
+                      <span className="font-medium">Advanced</span>
+                      <span className="text-[12px] text-[#6C6C70]">
+                        {credential.keys.length
+                          ? `${credential.keys.length} API key${credential.keys.length === 1 ? "" : "s"}`
+                          : "API keys"}
+                      </span>
+                    </summary>
+                    <p className="mt-3 text-[13px] leading-[1.5] text-[#85858A]">
+                      Save every provider key here. Rakazo asks the endpoint which models each key
+                      can access, then uses that key automatically — Gemini keys for Gemini models,
+                      and so on. You do not assign keys yourself.
+                    </p>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={busy || !credential.keys.length}
+                      onClick={() => void refreshEndpointKeys()}
+                      className="mt-3"
+                    >
+                      {pending === "refresh" ? "Refreshing…" : "Refresh model coverage"}
+                    </Button>
                     {credential.keys.length ? (
                       <ul className="mt-3 space-y-2">
                         {credential.keys.map((key) => (
-                          <li
-                            key={key.id}
-                            className="flex items-center gap-2 rounded-[10px] bg-[#101012] px-3 py-2"
-                          >
-                            <span className="min-w-0 flex-1 truncate text-[14px] text-[#ECECEE]">
-                              {key.label}
-                            </span>
-                            {key.isActive ? (
-                              <span className="text-[12px] text-[#4ECB71]">Active</span>
-                            ) : (
-                              <button
-                                type="button"
-                                disabled={busy}
-                                onClick={() => void activateEndpointKey(key.id)}
-                                className="text-[12px] text-[#85858A] hover:text-[#ECECEE]"
-                              >
-                                Use
-                              </button>
-                            )}
-                            {credential.keys.length > 1 ? (
-                              <button
-                                type="button"
-                                disabled={busy}
-                                onClick={() => void removeEndpointKey(key.id)}
-                                className="text-[12px] text-[#E65707]"
-                              >
-                                Remove
-                              </button>
-                            ) : null}
+                          <li key={key.id} className="rounded-[10px] bg-[#101012] px-3 py-2">
+                            <div className="flex items-center gap-2">
+                              <span className="min-w-0 flex-1 truncate text-[14px] text-[#ECECEE]">
+                                {key.label}
+                              </span>
+                              {key.isActive ? (
+                                <span className="text-[12px] text-[#4ECB71]">Fallback</span>
+                              ) : (
+                                <button
+                                  type="button"
+                                  disabled={busy}
+                                  onClick={() => void activateEndpointKey(key.id)}
+                                  className="text-[12px] text-[#85858A] hover:text-[#ECECEE]"
+                                >
+                                  Fallback
+                                </button>
+                              )}
+                              {credential.keys.length > 1 ? (
+                                <button
+                                  type="button"
+                                  disabled={busy}
+                                  onClick={() => void removeEndpointKey(key.id)}
+                                  className="text-[12px] text-[#E65707]"
+                                >
+                                  Remove
+                                </button>
+                              ) : null}
+                            </div>
+                            <p className="mt-1 text-[12px] leading-[1.45] text-[#85858A]">
+                              {key.probeError
+                                ? key.probeError
+                                : formatKeyCoverage(key.availableModels)}
+                            </p>
                           </li>
                         ))}
                       </ul>
                     ) : (
-                      <p className="mt-2 text-[13px] text-[#85858A]">
+                      <p className="mt-3 text-[13px] text-[#85858A]">
                         No keys yet. Local servers can run without one.
                       </p>
                     )}
@@ -582,7 +632,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                       <input
                         value={keyLabel}
                         onChange={(event) => setKeyLabel(event.target.value)}
-                        placeholder="Pool key 2"
+                        placeholder="Optional"
                         className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
                       />
                     </label>
@@ -607,7 +657,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                     >
                       {pending === "key" ? "Adding…" : "Add API key"}
                     </Button>
-                  </div>
+                  </details>
                 ) : null}
 
                 {deviceSignIn ? (

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -31,9 +31,12 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [providerQuery, setProviderQuery] = useState("");
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
+  const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | null>(null);
+  const [pending, setPending] = useState<"connect" | "default" | "probe" | null>(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -115,8 +118,10 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const currentEntry = catalog.find(
     (entry) => entry.provider === me?.defaultProvider && entry.id === me?.defaultModel,
   );
+  const isCustom = Boolean(selected?.custom);
+  const isCustomTemplate = selected?.provider === "openai-compatible";
   const isActive = me?.defaultProvider === selected?.provider && me?.defaultModel === selected?.id;
-  const acceptsKey = selected?.auth !== "oauth";
+  const acceptsKey = selected?.auth !== "oauth" || isCustom;
   const deviceSignIn = selected?.signIn === "device-code";
   const busy = pending !== null || oauthPending;
 
@@ -126,6 +131,13 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     setModelId(catalog.find((entry) => entry.provider === nextProvider)?.id ?? "");
     detailScrollRef.current?.scrollTo({ top: 0 });
     setApiKey("");
+    setBaseUrl(catalog.find((entry) => entry.provider === nextProvider)?.baseUrl ?? "");
+    setEndpointLabel(
+      catalog.find((entry) => entry.provider === nextProvider)?.providerName ?? "Custom endpoint",
+    );
+    setProbedModels(
+      credentials.find((entry) => entry.provider === nextProvider)?.availableModels ?? [],
+    );
     setError(null);
     setNotice(null);
   }
@@ -147,7 +159,42 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   }
 
   async function connectKey() {
-    if (!selected || !apiKey.trim()) return;
+    if (!selected) return;
+    if (isCustom) {
+      const url = baseUrl.trim() || selected.baseUrl;
+      if (!url) {
+        setError("Enter a base URL for this endpoint.");
+        return;
+      }
+      setError(null);
+      setNotice(null);
+      setPending("connect");
+      try {
+        const connected = await rpc.models.connect({
+          provider: selected.provider,
+          apiKey: apiKey.trim(),
+          modelId: modelId.trim() || selected.id,
+          label: endpointLabel.trim() || selected.providerName || "Custom endpoint",
+          baseUrl: url,
+          availableModels: probedModels.length
+            ? probedModels
+            : modelId.trim()
+              ? [modelId.trim()]
+              : undefined,
+        });
+        setApiKey("");
+        await refresh();
+        setProvider(connected.provider);
+        setModelId(connected.defaultModel ?? modelId);
+        setNotice(`Connected ${connected.label}.`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not connect this endpoint");
+      } finally {
+        setPending(null);
+      }
+      return;
+    }
+    if (!apiKey.trim()) return;
     setError(null);
     setNotice(null);
     setPending("connect");
@@ -163,6 +210,30 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       setNotice(`Connected and using ${selected.label}.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not connect this provider");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function probeModels() {
+    const url = baseUrl.trim() || selected?.baseUrl;
+    if (!url) {
+      setError("Enter a base URL to list models.");
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    setPending("probe");
+    try {
+      const result = await rpc.models.probe({
+        baseUrl: url,
+        apiKey: apiKey.trim() || undefined,
+      });
+      setProbedModels(result.models);
+      if (!result.models.includes(modelId) && result.models[0]) setModelId(result.models[0]);
+      setNotice(`Found ${result.models.length} model${result.models.length === 1 ? "" : "s"}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not list models");
     } finally {
       setPending(null);
     }
@@ -298,20 +369,83 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
             {notice ? <p className="mb-4 text-sm text-[#4ECB71]">{notice}</p> : null}
             {selected ? (
               <>
-                <div className="block text-[13.5px] text-[#85858A]">
-                  <span>Model</span>
-                  <ModelPicker
-                    options={modelsForProvider}
-                    value={selected.id}
-                    onChange={(nextModelId) => {
-                      cancelOAuthAttempt();
-                      setModelId(nextModelId);
-                      setError(null);
-                      setNotice(null);
-                    }}
-                  />
-                </div>
-                <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
+                {isCustom ? (
+                  <div className="space-y-4">
+                    <label className="block text-[13.5px] text-[#85858A]">
+                      Name
+                      <input
+                        value={endpointLabel}
+                        onChange={(event) => setEndpointLabel(event.target.value)}
+                        placeholder="Office vLLM"
+                        className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                      />
+                    </label>
+                    <label className="block text-[13.5px] text-[#85858A]">
+                      Base URL
+                      <input
+                        value={baseUrl}
+                        onChange={(event) => setBaseUrl(event.target.value)}
+                        placeholder="https://api.example.com/v1"
+                        autoComplete="off"
+                        className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                      />
+                    </label>
+                    <p className="text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
+                    <div className="flex flex-wrap items-end gap-3">
+                      <label className="block min-w-[220px] flex-1 text-[13.5px] text-[#85858A]">
+                        Model id
+                        {probedModels.length || (!isCustomTemplate && modelsForProvider.length > 1) ? (
+                          <select
+                            value={modelId}
+                            onChange={(event) => setModelId(event.target.value)}
+                            className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                          >
+                            {[...new Set([...probedModels, ...modelsForProvider.map((entry) => entry.id), modelId])]
+                              .filter(Boolean)
+                              .map((id) => (
+                                <option key={id} value={id}>
+                                  {id}
+                                </option>
+                              ))}
+                          </select>
+                        ) : (
+                          <input
+                            value={isCustomTemplate && modelId === "custom" ? "" : modelId}
+                            onChange={(event) => setModelId(event.target.value)}
+                            placeholder="llama3.1"
+                            className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                          />
+                        )}
+                      </label>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={busy || !(baseUrl.trim() || selected.baseUrl)}
+                        onClick={() => void probeModels()}
+                      >
+                        {pending === "probe" ? "Fetching…" : "Fetch models"}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="block text-[13.5px] text-[#85858A]">
+                      <span>Model</span>
+                      <ModelPicker
+                        options={modelsForProvider}
+                        value={selected.id}
+                        onChange={(nextModelId) => {
+                          cancelOAuthAttempt();
+                          setModelId(nextModelId);
+                          setError(null);
+                          setNotice(null);
+                        }}
+                      />
+                    </div>
+                    <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
+                  </>
+                )}
 
                 <div className="mt-5 rounded-[13px] border border-[#26262A] px-4 py-3">
                   <div className="text-[12.5px] uppercase tracking-[0.08em] text-[#6C6C70]">
@@ -322,8 +456,12 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                   </div>
                   <div className="mt-1 text-[13px] text-[#85858A]">
                     {credential
-                      ? "Your key or subscription token is stored securely and is never shown here."
-                      : "Connect this provider to use it as your personal model."}
+                      ? isCustom
+                        ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
+                        : "Your key or subscription token is stored securely and is never shown here."
+                      : isCustom
+                        ? "Paste any OpenAI-compatible base URL. The API key is optional for local servers."
+                        : "Connect this provider to use it as your personal model."}
                   </div>
                 </div>
 
@@ -365,10 +503,14 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                   <div className="mt-5">
                     <label className="block text-[13.5px] text-[#85858A]">
                       {credential
-                        ? "Replace API key"
+                        ? isCustom
+                          ? "Replace API key (optional)"
+                          : "Replace API key"
                         : deviceSignIn
                           ? "Or connect an API key"
-                          : "API key"}
+                          : isCustom
+                            ? "API key (optional)"
+                            : "API key"}
                       <input
                         value={apiKey}
                         onChange={(event) => setApiKey(event.target.value)}
@@ -382,15 +524,24 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                       type="button"
                       variant="pill"
                       size="sm"
-                      disabled={busy || apiKey.trim().length < 8}
+                      disabled={
+                        busy ||
+                        (isCustom
+                          ? !(baseUrl.trim() || selected.baseUrl)
+                          : apiKey.trim().length < 8)
+                      }
                       onClick={() => void connectKey()}
                       className="mt-3"
                     >
                       {pending === "connect"
                         ? "Saving…"
-                        : credential
-                          ? "Replace API key"
-                          : "Connect API key"}
+                        : isCustom
+                          ? credential
+                            ? "Save endpoint"
+                            : "Connect endpoint"
+                          : credential
+                            ? "Replace API key"
+                            : "Connect API key"}
                     </Button>
                   </div>
                 ) : null}

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -392,15 +392,23 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                     </label>
                     <p className="text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
                     <div className="flex flex-wrap items-end gap-3">
-                      <label className="block min-w-[220px] flex-1 text-[13.5px] text-[#85858A]">
-                        Model id
-                        {probedModels.length || (!isCustomTemplate && modelsForProvider.length > 1) ? (
+                      <div className="block min-w-[220px] flex-1 text-[13.5px] text-[#85858A]">
+                        <label htmlFor="custom-endpoint-model">Model id</label>
+                        {probedModels.length ||
+                        (!isCustomTemplate && modelsForProvider.length > 1) ? (
                           <select
+                            id="custom-endpoint-model"
                             value={modelId}
                             onChange={(event) => setModelId(event.target.value)}
                             className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
                           >
-                            {[...new Set([...probedModels, ...modelsForProvider.map((entry) => entry.id), modelId])]
+                            {[
+                              ...new Set([
+                                ...probedModels,
+                                ...modelsForProvider.map((entry) => entry.id),
+                                modelId,
+                              ]),
+                            ]
                               .filter(Boolean)
                               .map((id) => (
                                 <option key={id} value={id}>
@@ -410,13 +418,14 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                           </select>
                         ) : (
                           <input
+                            id="custom-endpoint-model"
                             value={isCustomTemplate && modelId === "custom" ? "" : modelId}
                             onChange={(event) => setModelId(event.target.value)}
                             placeholder="llama3.1"
                             className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
                           />
                         )}
-                      </label>
+                      </div>
                       <Button
                         type="button"
                         variant="outline"
@@ -443,7 +452,9 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         }}
                       />
                     </div>
-                    <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
+                    <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">
+                      {selected.billing}
+                    </p>
                   </>
                 )}
 

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -41,6 +41,10 @@ export function OnboardingPage() {
   const [provider, setProvider] = useState("openrouter");
   const [modelId, setModelId] = useState("deepseek/deepseek-v4-flash-0731");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
+  const [probedModels, setProbedModels] = useState<string[]>([]);
+  const [probing, setProbing] = useState(false);
   const [name, setName] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -115,14 +119,30 @@ export function OnboardingPage() {
   );
 
   const selected = modelsForProvider.find((entry) => entry.id === modelId) ?? modelsForProvider[0];
+  const isCustom = Boolean(selected?.custom);
+  const isCustomTemplate = selected?.provider === "openai-compatible";
   const deviceSignIn = selected?.signIn === "device-code";
-  const acceptsKey = selected?.auth !== "oauth";
+  const acceptsKey = selected?.auth !== "oauth" || isCustom;
   const signInLabel = selected?.oauthLabel ?? "Sign in";
 
   async function saveModel() {
     setError(null);
     try {
-      if (apiKey) {
+      if (isCustom) {
+        const url = baseUrl.trim();
+        if (!url) {
+          setError("Enter a base URL for this endpoint.");
+          return;
+        }
+        await rpc.models.connect({
+          provider,
+          apiKey,
+          modelId: isCustomTemplate && modelId === "custom" ? probedModels[0] : modelId,
+          label: endpointLabel.trim() || selected?.providerName || "Custom endpoint",
+          baseUrl: url,
+          availableModels: probedModels.length ? probedModels : undefined,
+        });
+      } else if (apiKey) {
         await rpc.models.connect({
           provider,
           apiKey,
@@ -133,6 +153,27 @@ export function OnboardingPage() {
       setStep("bot");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not save model");
+    }
+  }
+
+  async function probeModels() {
+    if (!baseUrl.trim()) {
+      setError("Enter a base URL to list models.");
+      return;
+    }
+    setError(null);
+    setProbing(true);
+    try {
+      const result = await rpc.models.probe({
+        baseUrl: baseUrl.trim(),
+        apiKey: apiKey.trim() || undefined,
+      });
+      setProbedModels(result.models);
+      if (result.models[0]) setModelId(result.models[0]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not list models");
+    } finally {
+      setProbing(false);
     }
   }
 
@@ -200,8 +241,9 @@ export function OnboardingPage() {
           <div>
             <h1 className="text-[32px] font-medium text-[#F1F1F2]">Connect a model</h1>
             <p className="mt-2 text-[#85858A]">
-              Rakazo does not pay for model usage. Paste an API key, sign in with ChatGPT, Copilot,
-              or SuperGrok, or skip if this deployment already has a key.
+              Rakazo does not pay for model usage. Paste an API key, connect any OpenAI-compatible
+              base URL, sign in with ChatGPT, Copilot, or SuperGrok, or skip if this deployment
+              already has a key.
             </p>
             <input
               value={query}
@@ -219,6 +261,9 @@ export function OnboardingPage() {
                     setProvider(entry.provider);
                     const first = catalog.find((item) => item.provider === entry.provider);
                     if (first) setModelId(first.id);
+                    setBaseUrl(first?.baseUrl ?? "");
+                    setEndpointLabel(first?.providerName ?? "Custom endpoint");
+                    setProbedModels([]);
                     setError(null);
                   }}
                   className={`flex w-full items-center justify-between border-b border-[#202023] px-3.5 py-2.5 text-left last:border-0 ${
@@ -232,23 +277,77 @@ export function OnboardingPage() {
                 </button>
               ))}
             </div>
-            <label className="mt-4 block text-sm text-[#85858A]">
-              Model
-              <select
-                value={selected?.id ?? modelId}
-                onChange={(e) => {
-                  cancelOAuthAttempt();
-                  setModelId(e.target.value);
-                }}
-                className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
-              >
-                {modelsForProvider.map((entry) => (
-                  <option key={`${entry.provider}:${entry.id}`} value={entry.id}>
-                    {entry.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            {isCustom ? (
+              <>
+                <label className="mt-4 block text-sm text-[#85858A]">
+                  Name
+                  <input
+                    value={endpointLabel}
+                    onChange={(e) => setEndpointLabel(e.target.value)}
+                    placeholder="Office vLLM"
+                    className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                  />
+                </label>
+                <label className="mt-4 block text-sm text-[#85858A]">
+                  Base URL
+                  <input
+                    value={baseUrl}
+                    onChange={(e) => setBaseUrl(e.target.value)}
+                    placeholder="https://api.example.com/v1"
+                    className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                  />
+                </label>
+                <label className="mt-4 block text-sm text-[#85858A]">
+                  Model
+                  {probedModels.length ? (
+                    <select
+                      value={modelId}
+                      onChange={(e) => setModelId(e.target.value)}
+                      className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                    >
+                      {probedModels.map((id) => (
+                        <option key={id} value={id}>
+                          {id}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      value={isCustomTemplate && modelId === "custom" ? "" : modelId}
+                      onChange={(e) => setModelId(e.target.value)}
+                      placeholder="llama3.1"
+                      className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                    />
+                  )}
+                </label>
+                <button
+                  type="button"
+                  disabled={probing || !baseUrl.trim()}
+                  onClick={() => void probeModels()}
+                  className="mt-3 text-[14px] text-[#C9C9CE] disabled:opacity-40"
+                >
+                  {probing ? "Fetching…" : "Fetch models"}
+                </button>
+              </>
+            ) : (
+              <label className="mt-4 block text-sm text-[#85858A]">
+                Model
+                <select
+                  value={selected?.id ?? modelId}
+                  onChange={(e) => {
+                    cancelOAuthAttempt();
+                    setModelId(e.target.value);
+                  }}
+                  className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                >
+                  {modelsForProvider.map((entry) => (
+                    <option key={`${entry.provider}:${entry.id}`} value={entry.id}>
+                      {entry.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
             <p className="mt-2 text-[13px] text-[#85858A]">{selected?.billing}</p>
             {deviceSignIn ? (
               <div className="mt-4">
@@ -284,7 +383,7 @@ export function OnboardingPage() {
             ) : null}
             {acceptsKey ? (
               <label className="mt-4 block text-sm text-[#85858A]">
-                {deviceSignIn ? "Or paste an API key" : "API key"}
+                {deviceSignIn ? "Or paste an API key" : isCustom ? "API key (optional)" : "API key"}
                 <input
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -297,10 +297,11 @@ export function OnboardingPage() {
                     className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
                   />
                 </label>
-                <label className="mt-4 block text-sm text-[#85858A]">
-                  Model
+                <div className="mt-4 block text-sm text-[#85858A]">
+                  <label htmlFor="onboarding-custom-model">Model</label>
                   {probedModels.length ? (
                     <select
+                      id="onboarding-custom-model"
                       value={modelId}
                       onChange={(e) => setModelId(e.target.value)}
                       className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
@@ -313,13 +314,14 @@ export function OnboardingPage() {
                     </select>
                   ) : (
                     <input
+                      id="onboarding-custom-model"
                       value={isCustomTemplate && modelId === "custom" ? "" : modelId}
                       onChange={(e) => setModelId(e.target.value)}
                       placeholder="llama3.1"
                       className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
                     />
                   )}
-                </label>
+                </div>
                 <button
                   type="button"
                   disabled={probing || !baseUrl.trim()}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -205,6 +205,9 @@ export function ShellPage() {
   const autoSpokenBotId = useRef<string | null>(null);
 
   const active = bots.find((b) => b.id === botId) ?? bots[0];
+  const botWorking = Boolean(
+    snapshot?.run && ["running", "queued", "leased"].includes(snapshot.run.status),
+  );
   const activePendingAttachments = useMemo(
     () => attachmentsForBot(pendingAttachments, active?.id),
     [active?.id, pendingAttachments],
@@ -1200,7 +1203,7 @@ export function ShellPage() {
             onClick={() => setPanel("settings")}
             className="flex min-w-0 items-center gap-3"
           >
-            {active ? <BotAvatar color={active.color} size={26} /> : null}
+            {active ? <BotAvatar color={active.color} size={26} thinking={botWorking} /> : null}
             <span className="min-w-0">
               <span className="block truncate text-[16px] font-medium text-[#ECECEE]">
                 {active?.name ?? "Select a bot"}
@@ -1244,9 +1247,9 @@ export function ShellPage() {
           olderCursor={snapshot?.olderCursor ?? null}
           loadingOlder={loadingOlder}
           answerableAskMessageId={answerableAskMessageId}
-          running={Boolean(
-            snapshot?.run && ["running", "queued", "leased"].includes(snapshot.run.status),
-          )}
+          running={botWorking}
+          botName={active?.name ?? "Bot"}
+          botColor={active?.color ?? "#3EC5A8"}
           onLoadOlder={loadOlder}
           onOpenBot={openBot}
           onAnswer={answerMessage}
@@ -1852,6 +1855,8 @@ export function ShellPage() {
 const Transcript = memo(function Transcript({
   scrollRef,
   botId,
+  botName,
+  botColor,
   messages,
   olderCursor,
   loadingOlder,
@@ -1868,6 +1873,8 @@ const Transcript = memo(function Transcript({
 }: {
   scrollRef: RefObject<HTMLDivElement | null>;
   botId: string;
+  botName: string;
+  botColor: string;
   messages: ThreadMessage[];
   olderCursor: number | null;
   loadingOlder: boolean;
@@ -1882,6 +1889,18 @@ const Transcript = memo(function Transcript({
   speakingMessageId: string | null;
   onSpeak: (message: ThreadMessage) => void;
 }) {
+  const enterState = useRef({ botId: "", seen: new Set<string>(), primed: false });
+  const [enteringIds, setEnteringIds] = useState<Set<string>>(() => new Set());
+  useLayoutEffect(() => {
+    const switchedBot = enterState.current.botId !== botId;
+    const next = collectEnteringUserMessageIds(botId, messages, enterState.current);
+    if (switchedBot) {
+      setEnteringIds(new Set());
+      return;
+    }
+    if (next.size > 0) setEnteringIds(next);
+  }, [botId, messages]);
+  const hasLiveReasoning = messages.some((message) => message.id.startsWith("reasoning:"));
   return (
     <div
       ref={scrollRef}
@@ -1899,9 +1918,15 @@ const Transcript = memo(function Transcript({
         </button>
       ) : null}
       {messages.map((message) => (
-        <div key={message.id} data-message-id={message.id}>
+        <div
+          key={message.id}
+          data-message-id={message.id}
+          className={enteringIds.has(message.id) ? "rk-drop-in" : undefined}
+        >
           <MessageView
             botId={botId}
+            botName={botName}
+            botColor={botColor}
             message={message}
             canAnswer={message.id === answerableAskMessageId}
             onOpenBot={onOpenBot}
@@ -1914,14 +1939,7 @@ const Transcript = memo(function Transcript({
           />
         </div>
       ))}
-      {running &&
-      !messages.some(
-        (message) => message.id.startsWith("progress:") || message.id.startsWith("reasoning:"),
-      ) ? (
-        <ReasoningTrace
-          steps={[{ id: "status", kind: "status", title: "Starting", status: "running" }]}
-        />
-      ) : null}
+      {running && !hasLiveReasoning ? <BotWorkingStatus name={botName} color={botColor} /> : null}
     </div>
   );
 });
@@ -2122,6 +2140,8 @@ function latestAnswerableAskMessageId(snapshot: ThreadSnapshot | null): string |
 
 const MessageView = memo(function MessageView({
   botId,
+  botName,
+  botColor,
   canAnswer,
   message,
   onAnswer,
@@ -2133,6 +2153,8 @@ const MessageView = memo(function MessageView({
   onSpeak,
 }: {
   botId: string;
+  botName: string;
+  botColor: string;
   canAnswer: boolean;
   message: ThreadMessage;
   onAnswer: (message: ThreadMessage, text: string) => Promise<void>;
@@ -2167,7 +2189,9 @@ const MessageView = memo(function MessageView({
           );
         }
         if (block.kind === "reasoning") {
-          return <ReasoningTrace key={i} steps={block.steps} />;
+          return (
+            <ReasoningTrace key={i} steps={block.steps} botName={botName} botColor={botColor} />
+          );
         }
         if (block.kind === "subagent") {
           const running = block.status === "running";
@@ -2556,7 +2580,52 @@ function CreateBotForm({
   );
 }
 
-function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
+function collectEnteringUserMessageIds(
+  botId: string,
+  messages: ThreadMessage[],
+  state: { botId: string; seen: Set<string>; primed: boolean },
+) {
+  if (state.botId !== botId) {
+    state.botId = botId;
+    state.seen = new Set(messages.map((message) => message.id));
+    state.primed = messages.length > 0;
+    return new Set<string>();
+  }
+  if (!state.primed) {
+    if (!messages.length) return new Set<string>();
+    for (const message of messages) state.seen.add(message.id);
+    state.primed = true;
+    return new Set<string>();
+  }
+  const recent = new Set(messages.slice(-4).map((message) => message.id));
+  const entering = new Set<string>();
+  for (const message of messages) {
+    if (!state.seen.has(message.id) && message.role === "user" && recent.has(message.id)) {
+      entering.add(message.id);
+    }
+    state.seen.add(message.id);
+  }
+  return entering;
+}
+
+function BotWorkingStatus({ name, color }: { name: string; color: string }) {
+  return (
+    <div className="flex items-center gap-3 py-1" data-testid="bot-working">
+      <BotAvatar color={color} size={28} thinking />
+      <span className="rk-working-text text-[15px] font-medium">{name} is working</span>
+    </div>
+  );
+}
+
+function ReasoningTrace({
+  steps,
+  botName,
+  botColor,
+}: {
+  steps: ReasoningStep[];
+  botName: string;
+  botColor: string;
+}) {
   if (!steps.length) return null;
   const running = steps.some((step) => step.status === "running");
   const active = [...steps].reverse().find((step) => step.status === "running") ?? steps.at(-1);
@@ -2566,18 +2635,21 @@ function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
       open={running}
       className="w-[min(520px,90%)] rounded-[18px] border border-[#232326] bg-[#141416] px-4 py-3"
     >
-      <summary className="flex cursor-pointer list-none items-center gap-2 text-[13.5px] text-[#A8A8AD] [&::-webkit-details-marker]:hidden">
-        <span
-          className="h-1.5 w-1.5 shrink-0 rounded-full"
-          style={{
-            background: running ? "#F5A03C" : "#4ECB71",
-            animation: running ? "rkPulse 1.2s ease-in-out infinite" : undefined,
-          }}
-        />
-        <span className="min-w-0 truncate font-medium text-[#C9C9CE]">{headline}</span>
-        <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">
-          {running ? "live" : "done"}
-        </span>
+      <summary className="flex cursor-pointer list-none items-center gap-3 text-[13.5px] text-[#A8A8AD] [&::-webkit-details-marker]:hidden">
+        {running ? (
+          <>
+            <BotAvatar color={botColor} size={22} thinking />
+            <span className="rk-working-text min-w-0 truncate text-[15px] font-medium">
+              {botName} is working
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ background: "#4ECB71" }} />
+            <span className="min-w-0 truncate font-medium text-[#C9C9CE]">{headline}</span>
+            <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">done</span>
+          </>
+        )}
       </summary>
       <ol className="mt-3 space-y-2.5 border-t border-[#232326] pt-3">
         {steps.map((step) => (

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -5,7 +5,10 @@ import type {
   ComputerMode,
   ComputerStatus,
   Me,
+  ModelCatalogEntry,
+  ModelCredential,
   ProductEvent,
+  ReasoningStep,
   Routine,
   SearchHit,
   TaughtSkill,
@@ -1911,15 +1914,13 @@ const Transcript = memo(function Transcript({
           />
         </div>
       ))}
-      {running ? (
-        <div className="flex justify-start">
-          <div
-            className="rounded-[20px] bg-[#1A1A1D] px-[18px] py-[13px] text-[14.5px] text-[#85858A]"
-            style={{ animation: "rkPulse 1.2s ease-in-out infinite" }}
-          >
-            working…
-          </div>
-        </div>
+      {running &&
+      !messages.some(
+        (message) => message.id.startsWith("progress:") || message.id.startsWith("reasoning:"),
+      ) ? (
+        <ReasoningTrace
+          steps={[{ id: "status", kind: "status", title: "Starting", status: "running" }]}
+        />
       ) : null}
     </div>
   );
@@ -2164,6 +2165,9 @@ const MessageView = memo(function MessageView({
               </div>
             </div>
           );
+        }
+        if (block.kind === "reasoning") {
+          return <ReasoningTrace key={i} steps={block.steps} />;
         }
         if (block.kind === "subagent") {
           const running = block.status === "running";
@@ -2552,6 +2556,52 @@ function CreateBotForm({
   );
 }
 
+function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
+  if (!steps.length) return null;
+  const running = steps.some((step) => step.status === "running");
+  const active = [...steps].reverse().find((step) => step.status === "running") ?? steps.at(-1);
+  const headline = running ? (active?.title ?? "Thinking") : "Thought process";
+  return (
+    <details
+      open={running}
+      className="w-[min(520px,90%)] rounded-[18px] border border-[#232326] bg-[#141416] px-4 py-3"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-[13.5px] text-[#A8A8AD] [&::-webkit-details-marker]:hidden">
+        <span
+          className="h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{
+            background: running ? "#F5A03C" : "#4ECB71",
+            animation: running ? "rkPulse 1.2s ease-in-out infinite" : undefined,
+          }}
+        />
+        <span className="min-w-0 truncate font-medium text-[#C9C9CE]">{headline}</span>
+        <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">{running ? "live" : "done"}</span>
+      </summary>
+      <ol className="mt-3 space-y-2.5 border-t border-[#232326] pt-3">
+        {steps.map((step) => (
+          <li key={step.id} className="text-[13.5px]">
+            <div className="flex items-start gap-2">
+              <span className="mt-0.5 w-12 shrink-0 text-[11px] uppercase tracking-[0.06em] text-[#6C6C70]">
+                {step.kind === "think" ? "think" : step.kind === "tool" ? "tool" : "step"}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className={step.status === "running" ? "text-[#F5A03C]" : "text-[#C9C9CE]"}>
+                  {step.title}
+                </div>
+                {step.detail ? (
+                  <pre className="rk-scroll mt-1 max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-sans text-[13px] leading-[1.45] text-[#85858A]">
+                    {step.detail}
+                  </pre>
+                ) : null}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
 function BotSettings({
   bot,
   onSave,
@@ -2567,6 +2617,8 @@ function BotSettings({
     computerMode: ComputerMode;
     autoSpeak?: boolean;
     voiceId?: string | null;
+    modelProvider?: string | null;
+    modelId?: string | null;
   }) => Promise<void>;
   onExport: () => Promise<void>;
   onClear: () => void;
@@ -2578,6 +2630,10 @@ function BotSettings({
   const [autoSpeak, setAutoSpeak] = useState(bot.autoSpeak);
   const [voiceId, setVoiceId] = useState(bot.voiceId ?? "");
   const [voices, setVoices] = useState<VoiceInfo[]>([]);
+  const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
+  const [credentials, setCredentials] = useState<ModelCredential[]>([]);
+  const [modelProvider, setModelProvider] = useState(bot.modelProvider ?? "");
+  const [modelId, setModelId] = useState(bot.modelId ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -2586,7 +2642,31 @@ function BotSettings({
       .voices({})
       .then(setVoices)
       .catch(() => setVoices([]));
+    void Promise.all([rpc.models.list(), rpc.models.credentials()])
+      .then(([nextCatalog, nextCredentials]) => {
+        setCatalog(nextCatalog);
+        setCredentials(nextCredentials);
+      })
+      .catch(() => undefined);
   }, []);
+
+  const connectedProviders = useMemo(() => {
+    const ids = new Set(credentials.map((entry) => entry.provider));
+    if (bot.modelProvider) ids.add(bot.modelProvider);
+    const grouped = new Map<string, ModelCatalogEntry[]>();
+    for (const entry of catalog) {
+      if (!ids.has(entry.provider)) continue;
+      const entries = grouped.get(entry.provider) ?? [];
+      entries.push(entry);
+      grouped.set(entry.provider, entries);
+    }
+    return [...grouped].map(([id, entries]) => ({
+      id,
+      name: entries[0]?.providerName ?? credentials.find((row) => row.provider === id)?.label ?? id,
+      entries,
+    }));
+  }, [bot.modelProvider, catalog, credentials]);
+  const modelsForProvider = catalog.filter((entry) => entry.provider === modelProvider);
 
   return (
     <div data-testid="bot-settings">
@@ -2618,6 +2698,52 @@ function BotSettings({
           className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
         />
       </label>
+      <label className="mt-4 block text-[14px] text-[#85858A]">
+        Inference
+        <select
+          value={modelProvider}
+          onChange={(event) => {
+            const nextProvider = event.target.value;
+            setModelProvider(nextProvider);
+            setModelId(
+              catalog.find((entry) => entry.provider === nextProvider)?.id ?? bot.modelId ?? "",
+            );
+          }}
+          className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+        >
+          <option value="">Workspace default</option>
+          {connectedProviders.map((group) => (
+            <option key={group.id} value={group.id}>
+              {group.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      {modelProvider ? (
+        <label className="mt-4 block text-[14px] text-[#85858A]">
+          Model
+          <select
+            value={modelId}
+            onChange={(event) => setModelId(event.target.value)}
+            className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+          >
+            {modelsForProvider.length ? (
+              modelsForProvider.map((entry) => (
+                <option key={`${entry.provider}:${entry.id}`} value={entry.id}>
+                  {entry.label}
+                </option>
+              ))
+            ) : (
+              <option value={modelId || ""}>{modelId || "Choose a model"}</option>
+            )}
+          </select>
+        </label>
+      ) : (
+        <p className="mt-2 text-[13px] text-[#6C6C70]">
+          Uses the workspace default from Models. Connect a custom endpoint there to add another
+          provider.
+        </p>
+      )}
       <ComputerModePicker value={computerMode} onChange={setComputerMode} />
       <label className="mt-5 flex cursor-pointer items-center gap-3 text-[14px] text-[#C9C9CE]">
         <input
@@ -2660,6 +2786,8 @@ function BotSettings({
               computerMode,
               autoSpeak,
               voiceId: voiceId || null,
+              modelProvider: modelProvider || null,
+              modelId: modelProvider ? modelId || null : null,
             })
               .catch((err) => setError(err instanceof Error ? err.message : "Could not save"))
               .finally(() => setSaving(false));

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -25,12 +25,14 @@ import {
 import {
   abortableDelay,
   attachmentsForBot,
+  createPendingUserMessageId,
   cronFromPreset,
   defaultCronPreset,
   formatCron,
   groupBotsForSidebar,
   inferAttachmentMimeType,
   isActive,
+  pendingUserMessageTextKey,
   presetFromCron,
   speechFromBlocks,
 } from "@rakazo/core";
@@ -753,6 +755,26 @@ export function ShellPage() {
       const attachments = attachmentsForBot(pendingAttachments, id);
       const trimmed = text.trim();
       if (!trimmed && attachments.length === 0) return;
+      const pendingId = createPendingUserMessageId();
+      if (trimmed) {
+        setSnapshot((current) => {
+          if (!current || current.botId !== id) return current;
+          return {
+            ...current,
+            messages: [
+              ...current.messages.filter((message) => message.id !== pendingId),
+              {
+                id: pendingId,
+                threadId: current.threadId,
+                seq: (current.messages.at(-1)?.seq ?? 0) + 1,
+                role: "user",
+                blocks: [{ kind: "text", text: trimmed }],
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          };
+        });
+      }
       setSending(true);
       setSendError(null);
       try {
@@ -779,9 +801,17 @@ export function ShellPage() {
         revokePendingAttachmentPreviews(attachments);
         setPendingAttachments((current) => current.filter((attachment) => attachment.botId !== id));
         if (activeBotId.current === id) setAttachmentNotice(null);
-        await refreshThreadRef.current(id);
+        void refreshThreadRef.current(id);
       } catch (error) {
         if (activeBotId.current === id) {
+          setSnapshot((current) =>
+            current
+              ? {
+                  ...current,
+                  messages: current.messages.filter((message) => message.id !== pendingId),
+                }
+              : current,
+          );
           setSendError(error instanceof Error ? error.message : "Failed to send message");
         }
       } finally {
@@ -2600,12 +2630,23 @@ function collectEnteringUserMessageIds(
   const recent = new Set(messages.slice(-4).map((message) => message.id));
   const entering = new Set<string>();
   for (const message of messages) {
+    const text = userMessagePlainText(message);
+    const pendingKey = pendingUserMessageTextKey(text);
     if (!state.seen.has(message.id) && message.role === "user" && recent.has(message.id)) {
-      entering.add(message.id);
+      const replacingPending = !message.id.startsWith("pending:") && state.seen.has(pendingKey);
+      if (!replacingPending) entering.add(message.id);
     }
     state.seen.add(message.id);
+    if (message.role === "user") {
+      if (message.id.startsWith("pending:")) state.seen.add(pendingKey);
+      else state.seen.delete(pendingKey);
+    }
   }
   return entering;
+}
+
+function userMessagePlainText(message: ThreadMessage): string {
+  return message.blocks.flatMap((block) => (block.kind === "text" ? [block.text] : [])).join("\n");
 }
 
 function BotWorkingStatus({ name, color }: { name: string; color: string }) {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -524,6 +524,7 @@ export function ShellPage() {
               event.type === "bot.spawned" ||
               event.type === "bot.deleted" ||
               event.type === "run.completed" ||
+              event.type === "run.failed" ||
               event.type === "thread.cleared"
             ) {
               void refreshBots().catch(() => undefined);
@@ -535,7 +536,11 @@ export function ShellPage() {
               }
               if (event.payload.role === "bot") markBotReadIfVisible(active.id);
             }
-            if (event.type === "run.completed" || event.type === "skill.teaching.stopped") {
+            if (
+              event.type === "run.completed" ||
+              event.type === "run.failed" ||
+              event.type === "skill.teaching.stopped"
+            ) {
               void refreshThread(active.id).catch(() => undefined);
             } else if (isComputerStatusEvent(event)) {
               void refreshComputerScreen(active.id).catch(() => undefined);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2575,7 +2575,9 @@ function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
           }}
         />
         <span className="min-w-0 truncate font-medium text-[#C9C9CE]">{headline}</span>
-        <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">{running ? "live" : "done"}</span>
+        <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">
+          {running ? "live" : "done"}
+        </span>
       </summary>
       <ol className="mt-3 space-y-2.5 border-t border-[#232326] pt-3">
         {steps.map((step) => (

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -35,11 +35,13 @@ import {
   pendingUserMessageTextKey,
   presetFromCron,
   speechFromBlocks,
+  visibleReasoningSteps,
 } from "@rakazo/core";
 import { BotAvatar, Button } from "@rakazo/ui-web";
 import {
   ArrowUp,
   ChevronLeft,
+  ChevronRight,
   Cpu,
   Gauge,
   LogOut,
@@ -806,7 +808,6 @@ export function ShellPage() {
         revokePendingAttachmentPreviews(attachments);
         setPendingAttachments((current) => current.filter((attachment) => attachment.botId !== id));
         if (activeBotId.current === id) setAttachmentNotice(null);
-        void refreshThreadRef.current(id);
       } catch (error) {
         if (activeBotId.current === id) {
           setSnapshot((current) =>
@@ -1283,8 +1284,6 @@ export function ShellPage() {
           loadingOlder={loadingOlder}
           answerableAskMessageId={answerableAskMessageId}
           running={botWorking}
-          botName={active?.name ?? "Bot"}
-          botColor={active?.color ?? "#3EC5A8"}
           onLoadOlder={loadOlder}
           onOpenBot={openBot}
           onAnswer={answerMessage}
@@ -1890,8 +1889,6 @@ export function ShellPage() {
 const Transcript = memo(function Transcript({
   scrollRef,
   botId,
-  botName,
-  botColor,
   messages,
   olderCursor,
   loadingOlder,
@@ -1908,8 +1905,6 @@ const Transcript = memo(function Transcript({
 }: {
   scrollRef: RefObject<HTMLDivElement | null>;
   botId: string;
-  botName: string;
-  botColor: string;
   messages: ThreadMessage[];
   olderCursor: number | null;
   loadingOlder: boolean;
@@ -1960,8 +1955,6 @@ const Transcript = memo(function Transcript({
         >
           <MessageView
             botId={botId}
-            botName={botName}
-            botColor={botColor}
             message={message}
             canAnswer={message.id === answerableAskMessageId}
             onOpenBot={onOpenBot}
@@ -1974,7 +1967,7 @@ const Transcript = memo(function Transcript({
           />
         </div>
       ))}
-      {running && !hasLiveReasoning ? <BotWorkingStatus name={botName} color={botColor} /> : null}
+      {running && !hasLiveReasoning ? <BotWorkingStatus /> : null}
     </div>
   );
 });
@@ -2175,8 +2168,6 @@ function latestAnswerableAskMessageId(snapshot: ThreadSnapshot | null): string |
 
 const MessageView = memo(function MessageView({
   botId,
-  botName,
-  botColor,
   canAnswer,
   message,
   onAnswer,
@@ -2188,8 +2179,6 @@ const MessageView = memo(function MessageView({
   onSpeak,
 }: {
   botId: string;
-  botName: string;
-  botColor: string;
   canAnswer: boolean;
   message: ThreadMessage;
   onAnswer: (message: ThreadMessage, text: string) => Promise<void>;
@@ -2224,9 +2213,7 @@ const MessageView = memo(function MessageView({
           );
         }
         if (block.kind === "reasoning") {
-          return (
-            <ReasoningTrace key={i} steps={block.steps} botName={botName} botColor={botColor} />
-          );
+          return <ReasoningTrace key={i} steps={block.steps} />;
         }
         if (block.kind === "subagent") {
           const running = block.status === "running";
@@ -2654,70 +2641,60 @@ function userMessagePlainText(message: ThreadMessage): string {
   return message.blocks.flatMap((block) => (block.kind === "text" ? [block.text] : [])).join("\n");
 }
 
-function BotWorkingStatus({ name, color }: { name: string; color: string }) {
+function BotWorkingStatus() {
   return (
-    <div className="flex items-center gap-3 py-1" data-testid="bot-working">
-      <BotAvatar color={color} size={28} thinking />
-      <span className="rk-working-text text-[15px] font-medium">{name} is working</span>
+    <div className="rk-thought flex items-center gap-1.5 py-0.5" data-testid="bot-working">
+      <ChevronRight size={16} strokeWidth={2} className="rk-thought-caret text-[#8E8EA0]" />
+      <span className="rk-working-text text-[15px] font-medium">Thinking</span>
     </div>
   );
 }
 
-function ReasoningTrace({
-  steps,
-  botName,
-  botColor,
-}: {
-  steps: ReasoningStep[];
-  botName: string;
-  botColor: string;
-}) {
-  if (!steps.length) return null;
+function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
   const running = steps.some((step) => step.status === "running");
-  const active = [...steps].reverse().find((step) => step.status === "running") ?? steps.at(-1);
-  const headline = running ? (active?.title ?? "Thinking") : "Thought process";
+  const visible = visibleReasoningSteps(steps);
+  useEffect(() => {
+    const el = detailsRef.current;
+    if (!el) return;
+    el.open = running;
+  }, [running]);
+  if (!steps.length) return null;
   return (
-    <details
-      open={running}
-      className="w-[min(520px,90%)] rounded-[18px] border border-[#232326] bg-[#141416] px-4 py-3"
-    >
-      <summary className="flex cursor-pointer list-none items-center gap-3 text-[13.5px] text-[#A8A8AD] [&::-webkit-details-marker]:hidden">
+    <details ref={detailsRef} className="rk-thought w-[min(560px,100%)]">
+      <summary className="rk-thought-summary flex cursor-pointer list-none items-center gap-1.5 [&::-webkit-details-marker]:hidden">
+        <ChevronRight
+          size={16}
+          strokeWidth={2}
+          className="rk-thought-caret shrink-0 text-[#8E8EA0]"
+        />
         {running ? (
-          <>
-            <BotAvatar color={botColor} size={22} thinking />
-            <span className="rk-working-text min-w-0 truncate text-[15px] font-medium">
-              {botName} is working
-            </span>
-          </>
+          <span className="rk-working-text text-[15px] font-medium">Thinking</span>
         ) : (
-          <>
-            <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ background: "#4ECB71" }} />
-            <span className="min-w-0 truncate font-medium text-[#C9C9CE]">{headline}</span>
-            <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">done</span>
-          </>
+          <span className="text-[15px] font-medium text-[#B4B4B8]">Thought</span>
         )}
       </summary>
-      <ol className="mt-3 space-y-2.5 border-t border-[#232326] pt-3">
-        {steps.map((step) => (
-          <li key={step.id} className="text-[13.5px]">
-            <div className="flex items-start gap-2">
-              <span className="mt-0.5 w-12 shrink-0 text-[11px] uppercase tracking-[0.06em] text-[#6C6C70]">
-                {step.kind === "think" ? "think" : step.kind === "tool" ? "tool" : "step"}
-              </span>
-              <div className="min-w-0 flex-1">
-                <div className={step.status === "running" ? "text-[#F5A03C]" : "text-[#C9C9CE]"}>
+      {visible.length ? (
+        <div className="rk-thought-body ml-[7px] mt-2 space-y-2.5 border-l border-[#3A3A40] pl-3.5">
+          {visible.map((step) => (
+            <div key={step.id} className="text-[14px] leading-[1.55] text-[#8E8EA0]">
+              {step.kind === "tool" || !step.detail ? (
+                <div className={step.status === "running" ? "text-[#D0D0D4]" : undefined}>
                   {step.title}
                 </div>
-                {step.detail ? (
-                  <pre className="rk-scroll mt-1 max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-sans text-[13px] leading-[1.45] text-[#85858A]">
-                    {step.detail}
-                  </pre>
-                ) : null}
-              </div>
+              ) : null}
+              {step.detail ? (
+                <pre className="rk-scroll max-h-72 overflow-y-auto whitespace-pre-wrap break-words font-sans text-[14px] leading-[1.55] text-[#8E8EA0]">
+                  {step.detail}
+                  {running && step.status === "running" ? (
+                    <span className="rk-thought-cursor">▍</span>
+                  ) : null}
+                </pre>
+              ) : null}
             </div>
-          </li>
-        ))}
-      </ol>
+          ))}
+        </div>
+      ) : null}
     </details>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -66,3 +66,92 @@ body,
     opacity: 0.3;
   }
 }
+
+@keyframes rkDropIn {
+  from {
+    opacity: 0;
+    transform: translateY(-22px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes rkAvatarBob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+@keyframes rkAvatarEyes {
+  0%,
+  70%,
+  100% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  80% {
+    opacity: 0.35;
+    transform: scaleY(0.2);
+  }
+}
+
+@keyframes rkWorkingShimmer {
+  0% {
+    background-position: 120% 0;
+  }
+  100% {
+    background-position: -120% 0;
+  }
+}
+
+.rk-drop-in {
+  animation: rkDropIn 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transform-origin: right center;
+}
+
+.rk-avatar-think {
+  animation: rkAvatarBob 1.15s ease-in-out infinite;
+}
+
+.rk-avatar-think .rk-avatar-eye {
+  transform-origin: center;
+  animation: rkAvatarEyes 1.6s ease-in-out infinite;
+}
+
+.rk-working-text {
+  background-image: linear-gradient(
+    90deg,
+    #6c6c70 0%,
+    #6c6c70 32%,
+    #f4f4f6 50%,
+    #6c6c70 68%,
+    #6c6c70 100%
+  );
+  background-size: 220% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: rkWorkingShimmer 1.7s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rk-drop-in,
+  .rk-avatar-think,
+  .rk-avatar-think .rk-avatar-eye,
+  .rk-working-text {
+    animation: none;
+  }
+
+  .rk-working-text {
+    background: none;
+    color: #a8a8ad;
+    -webkit-text-fill-color: #a8a8ad;
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -68,11 +68,15 @@ body,
 }
 
 @keyframes rkDropIn {
-  from {
+  0% {
     opacity: 0;
-    transform: translateY(-22px) scale(0.96);
+    transform: translateY(-16px) scale(0.94);
   }
-  to {
+  62% {
+    opacity: 1;
+    transform: translateY(4px) scale(1.03);
+  }
+  100% {
     opacity: 1;
     transform: translateY(0) scale(1);
   }
@@ -81,10 +85,12 @@ body,
 @keyframes rkAvatarBob {
   0%,
   100% {
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
+    filter: brightness(1);
   }
   50% {
-    transform: translateY(-4px);
+    transform: translateY(-5px) scale(1.06);
+    filter: brightness(1.22);
   }
 }
 
@@ -103,50 +109,105 @@ body,
 
 @keyframes rkWorkingShimmer {
   0% {
-    background-position: 120% 0;
+    background-position: 140% 0;
   }
   100% {
-    background-position: -120% 0;
+    background-position: -140% 0;
+  }
+}
+
+@keyframes rkThoughtReveal {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes rkCaretBlink {
+  0%,
+  45% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
   }
 }
 
 .rk-drop-in {
-  animation: rkDropIn 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
-  transform-origin: right center;
+  animation: rkDropIn 0.34s cubic-bezier(0.22, 1.18, 0.32, 1) both;
+  transform-origin: right top;
+  will-change: transform, opacity;
 }
 
 .rk-avatar-think {
-  animation: rkAvatarBob 1.15s ease-in-out infinite;
+  animation: rkAvatarBob 0.85s ease-in-out infinite;
+  will-change: transform, filter;
 }
 
 .rk-avatar-think .rk-avatar-eye {
   transform-origin: center;
-  animation: rkAvatarEyes 1.6s ease-in-out infinite;
+  animation: rkAvatarEyes 1.35s ease-in-out infinite;
 }
 
 .rk-working-text {
   background-image: linear-gradient(
     90deg,
     #6c6c70 0%,
-    #6c6c70 32%,
-    #f4f4f6 50%,
-    #6c6c70 68%,
+    #6c6c70 28%,
+    #f7f7f8 50%,
+    #6c6c70 72%,
     #6c6c70 100%
   );
-  background-size: 220% 100%;
+  background-size: 180% 100%;
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
   -webkit-text-fill-color: transparent;
-  animation: rkWorkingShimmer 1.7s linear infinite;
+  animation: rkWorkingShimmer 1.05s linear infinite;
+}
+
+.rk-thought-summary {
+  outline: none;
+}
+
+.rk-thought-caret {
+  display: block;
+  transform-origin: center;
+  transition: transform 0.18s cubic-bezier(0.22, 1.2, 0.36, 1);
+}
+
+.rk-thought[open] .rk-thought-caret {
+  transform: rotate(90deg);
+}
+
+.rk-thought-body {
+  animation: rkThoughtReveal 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.rk-thought-cursor {
+  display: inline-block;
+  margin-left: 1px;
+  color: #c9c9ce;
+  animation: rkCaretBlink 0.9s steps(1) infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .rk-drop-in,
   .rk-avatar-think,
   .rk-avatar-think .rk-avatar-eye,
-  .rk-working-text {
+  .rk-working-text,
+  .rk-thought-body,
+  .rk-thought-cursor {
     animation: none;
+  }
+
+  .rk-thought-caret {
+    transition: none;
   }
 
   .rk-working-text {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -281,7 +281,13 @@ export type AgentRuntimeEvent =
   | { type: "text"; text: string }
   | { type: "progress"; text: string }
   | { type: "reasoning"; step: ReasoningStep }
-  | { type: "tool"; name: string; args: Record<string, unknown>; executionId: string; status?: "running" | "done" }
+  | {
+      type: "tool";
+      name: string;
+      args: Record<string, unknown>;
+      executionId: string;
+      status?: "running" | "done";
+    }
   | { type: "ask"; text: string; detail?: string }
   | { type: "takeover"; reason: string }
   | { type: "usage"; inputTokens: number; outputTokens: number; provider: string; model: string }

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -1,4 +1,4 @@
-import type { SandboxKind } from "@rakazo/contracts";
+import type { ReasoningStep, SandboxKind } from "@rakazo/contracts";
 
 export interface AdapterContext {
   operationId: string;
@@ -251,6 +251,7 @@ export interface AgentRunRequest {
     provider: string;
     id: string;
     apiKey?: string;
+    baseUrl?: string;
     /** In-process OAuth credential from the encrypted store for this run. */
     oauth?: {
       credential: AgentModelOAuthCredential;
@@ -279,7 +280,8 @@ export interface ScriptedTurn {
 export type AgentRuntimeEvent =
   | { type: "text"; text: string }
   | { type: "progress"; text: string }
-  | { type: "tool"; name: string; args: Record<string, unknown>; executionId: string }
+  | { type: "reasoning"; step: ReasoningStep }
+  | { type: "tool"; name: string; args: Record<string, unknown>; executionId: string; status?: "running" | "done" }
   | { type: "ask"; text: string; detail?: string }
   | { type: "takeover"; reason: string }
   | { type: "usage"; inputTokens: number; outputTokens: number; provider: string; model: string }

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -343,30 +343,38 @@ export function createRunExecutor(deps: ExecutorDeps) {
 
       const runSecrets = [...deps.secrets];
       try {
-        const [bot, thread, messages, task, storedConnections, defaultCredential, settings, savedSkills] =
-          await Promise.all([
-            deps.prisma.bot.findUniqueOrThrow({
-              where: { id: run.botId },
-              include: { computer: true },
-            }),
-            deps.prisma.thread.findUniqueOrThrow({ where: { id: run.threadId } }),
-            deps.prisma.message.findMany({
-              where: { threadId: run.threadId },
-              orderBy: { seq: "desc" },
-              take: LEGACY_HISTORY_WINDOW_SIZE,
-              select: { role: true, runId: true, blocks: true },
-            }),
-            deps.prisma.task.findUniqueOrThrow({ where: { id: run.taskId } }),
-            deps.prisma.connection.findMany({
-              where: { userId: run.userId, workspaceId: run.workspaceId },
-              select: { id: true, provider: true, displayName: true, status: true },
-            }),
-            findDefaultModelCredential(deps.prisma, run),
-            deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
-            deps.prisma.taughtSkill.findMany({
-              where: { botId: run.botId, workspaceId: run.workspaceId, status: "saved" },
-            }),
-          ]);
+        const [
+          bot,
+          thread,
+          messages,
+          task,
+          storedConnections,
+          defaultCredential,
+          settings,
+          savedSkills,
+        ] = await Promise.all([
+          deps.prisma.bot.findUniqueOrThrow({
+            where: { id: run.botId },
+            include: { computer: true },
+          }),
+          deps.prisma.thread.findUniqueOrThrow({ where: { id: run.threadId } }),
+          deps.prisma.message.findMany({
+            where: { threadId: run.threadId },
+            orderBy: { seq: "desc" },
+            take: LEGACY_HISTORY_WINDOW_SIZE,
+            select: { role: true, runId: true, blocks: true },
+          }),
+          deps.prisma.task.findUniqueOrThrow({ where: { id: run.taskId } }),
+          deps.prisma.connection.findMany({
+            where: { userId: run.userId, workspaceId: run.workspaceId },
+            select: { id: true, provider: true, displayName: true, status: true },
+          }),
+          findDefaultModelCredential(deps.prisma, run),
+          deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
+          deps.prisma.taughtSkill.findMany({
+            where: { botId: run.botId, workspaceId: run.workspaceId, status: "saved" },
+          }),
+        ]);
         runAbortController = new AbortController();
         if (!leaseValid) runAbortController.abort();
         let credential = defaultCredential;
@@ -938,8 +946,13 @@ export function createRunExecutor(deps: ExecutorDeps) {
               currentTurnImages,
               tools,
               model: {
-                provider: bot.modelProvider ?? credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
-                id: bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
+                provider:
+                  bot.modelProvider ??
+                  credential?.provider ??
+                  settings?.defaultModelProvider ??
+                  "scripted",
+                id:
+                  bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 baseUrl: credential?.baseUrl ?? undefined,
                 oauth: resolved.oauth

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -110,6 +110,7 @@ const READ_ONLY_AGENT_TOOLS = new Set([
   "run_subagent",
 ]);
 const MAX_MODEL_FILE_BYTES = 250_000;
+const STREAM_FLUSH_MS = 32;
 const GRAPHICAL_AGENT_TOOLS = new Set([
   "computer_observe",
   "computer_act",
@@ -518,7 +519,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const publishReasoning = async (force = false) => {
           if (!reasoningSteps.length) return;
           const now = Date.now();
-          if (!force && now - lastReasoningAt < 120) return;
+          if (!force && now - lastReasoningAt < STREAM_FLUSH_MS) return;
           lastReasoningAt = now;
           await deps.events.append({
             workspaceId: run.workspaceId,
@@ -991,7 +992,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               assembled += event.text;
               pendingProgress += progressRedactor.push(event.text);
               const now = Date.now();
-              if (!scripted && pendingProgress && now - lastProgressAt >= 250) {
+              if (!scripted && pendingProgress && now - lastProgressAt >= STREAM_FLUSH_MS) {
                 lastProgressAt = now;
                 await deps.events.append({
                   workspaceId: run.workspaceId,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -13,7 +13,7 @@ import type {
   SandboxProvider,
 } from "@rakazo/adapter-kit";
 import { historyCompactJob, routineWakeupJob, runContinueJob } from "@rakazo/adapter-kit";
-import type { MessageBlock, RunStatus } from "@rakazo/contracts";
+import type { MessageBlock, ReasoningStep, RunStatus } from "@rakazo/contracts";
 import { ATTACHMENT_MAX_BYTES, isAttachmentImageMimeType } from "@rakazo/contracts";
 import {
   assertTransition,
@@ -26,13 +26,17 @@ import {
   nextCronDate,
   nextFence,
   promptInvokesSkill,
+  reasoningToolDetail,
+  reasoningToolTitle,
   redactSecrets,
   sandboxCommandTimeoutMs,
+  upsertReasoningStep,
   userTurnBlocksForRun,
 } from "@rakazo/core";
 import {
   createThreadMessage,
   findDefaultModelCredential,
+  newestModelCredentialOrder,
   type PrismaClient,
   parseComputerMode,
   type ThreadEvents,
@@ -339,7 +343,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
 
       const runSecrets = [...deps.secrets];
       try {
-        const [bot, thread, messages, task, storedConnections, credential, settings, savedSkills] =
+        const [bot, thread, messages, task, storedConnections, defaultCredential, settings, savedSkills] =
           await Promise.all([
             deps.prisma.bot.findUniqueOrThrow({
               where: { id: run.botId },
@@ -365,6 +369,18 @@ export function createRunExecutor(deps: ExecutorDeps) {
           ]);
         runAbortController = new AbortController();
         if (!leaseValid) runAbortController.abort();
+        let credential = defaultCredential;
+        if (bot.modelProvider) {
+          const specific = await deps.prisma.userModelCredential.findFirst({
+            where: {
+              userId: run.userId,
+              workspaceId: run.workspaceId,
+              provider: bot.modelProvider,
+            },
+            orderBy: newestModelCredentialOrder,
+          });
+          if (specific) credential = specific;
+        }
         let liveSlugs: string[] = [];
         if (needsLivePluginSync(storedConnections)) {
           const listing = await loadLivePluginSlugs(deps.listConnectedPluginSlugs, run.userId);
@@ -482,9 +498,25 @@ export function createRunExecutor(deps: ExecutorDeps) {
         let assembled = "";
         let pendingProgress = "";
         let lastProgressAt = 0;
+        let lastReasoningAt = 0;
+        let reasoningSteps: ReasoningStep[] = [];
         let lastComputerFrameId: string | undefined;
         let terminalCheckpointComplete = false;
         const progressRedactor = createStreamingRedactor(runSecrets);
+        const publishReasoning = async (force = false) => {
+          if (!reasoningSteps.length) return;
+          const now = Date.now();
+          if (!force && now - lastReasoningAt < 120) return;
+          lastReasoningAt = now;
+          await deps.events.append({
+            workspaceId: run.workspaceId,
+            threadId: thread.id,
+            botId: bot.id,
+            type: "thread.reasoning",
+            runId,
+            payload: { steps: reasoningSteps },
+          });
+        };
         const scripted = deps.runtime.describe().capabilities.scripted;
         const script = scripted
           ? inferScript(task.prompt, resumeFromTakeover ? "takeover" : undefined)
@@ -871,6 +903,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
             )}\n\n${taskPrompt}`
           : taskPrompt;
 
+        reasoningSteps = upsertReasoningStep(reasoningSteps, {
+          id: "status",
+          kind: "status",
+          title: "Starting",
+          status: "running",
+        });
+        await publishReasoning(true);
+
         try {
           for await (const event of deps.runtime.run(
             {
@@ -898,9 +938,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
               currentTurnImages,
               tools,
               model: {
-                provider: credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
-                id: credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
+                provider: bot.modelProvider ?? credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
+                id: bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
+                baseUrl: credential?.baseUrl ?? undefined,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }
                   : undefined,
@@ -955,6 +996,16 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 runId,
                 payload: { text: redactSecrets(event.text, runSecrets) },
               });
+            } else if (event.type === "reasoning") {
+              const step = {
+                ...event.step,
+                title: redactSecrets(event.step.title, runSecrets),
+                detail: event.step.detail
+                  ? redactSecrets(event.step.detail, runSecrets)
+                  : undefined,
+              };
+              reasoningSteps = upsertReasoningStep(reasoningSteps, step);
+              await publishReasoning(event.step.status === "done");
             } else if (event.type === "ask") {
               if (!(await renewRunLease(deps, runId, workerId, fence))) return;
               const safeText = redactSecrets(event.text, runSecrets);
@@ -1042,6 +1093,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 runId,
                 payload: { name: event.name, executionId: event.executionId },
               });
+              reasoningSteps = upsertReasoningStep(reasoningSteps, {
+                id: event.executionId,
+                kind: "tool",
+                title: reasoningToolTitle(event.name, event.args),
+                detail: reasoningToolDetail(event.name, event.args),
+                status: event.status === "done" ? "done" : "running",
+              });
+              await publishReasoning(event.status === "done");
               if (scripted) await applyTool(event.name, event.args, event.executionId);
             } else if (event.type === "subagent") {
               const safeTask = redactSecrets(event.task, runSecrets);
@@ -1092,6 +1151,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
               });
             } else if (event.type === "done") {
               assembled = assembled || event.text || assembled;
+              reasoningSteps = reasoningSteps.map((step) =>
+                step.status === "running" ? { ...step, status: "done" as const } : step,
+              );
+              await publishReasoning(true);
             }
           }
 
@@ -1137,6 +1200,16 @@ export function createRunExecutor(deps: ExecutorDeps) {
             throw new Error("refusing to persist a secret in the thread");
           }
           if (!(await renewRunLease(deps, runId, workerId, fence))) return;
+          const completedBlocks: MessageBlock[] = [];
+          if (reasoningSteps.length) {
+            completedBlocks.push({
+              kind: "reasoning",
+              steps: reasoningSteps.map((step) =>
+                step.status === "running" ? { ...step, status: "done" as const } : step,
+              ),
+            });
+          }
+          completedBlocks.push({ kind: "text", text });
           const completed = await deps.events.finalizeRun({
             workspaceId: run.workspaceId,
             threadId: thread.id,
@@ -1147,7 +1220,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             leaseOwner: workerId,
             leaseFence: fence,
             outcome: "completed",
-            blocks: [{ kind: "text", text }],
+            blocks: completedBlocks,
           });
           if (!completed) return;
           if (bot.notifyOnFinish) {
@@ -1340,7 +1413,9 @@ async function requeueComputerRun(
 }
 
 async function clearRunProgress(deps: ExecutorDeps, runId: string): Promise<void> {
-  await deps.prisma.event.deleteMany({ where: { runId, type: "thread.progress" } });
+  await deps.prisma.event.deleteMany({
+    where: { runId, type: { in: ["thread.progress", "thread.reasoning"] } },
+  });
 }
 
 async function publishMessage(

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -79,6 +79,7 @@ import {
   shouldEnqueueCompaction,
 } from "./history-compaction.js";
 import { loadAgentMemoryContext } from "./memory-context.js";
+import { isGatewayProvider, secretIdForGatewayModel } from "./openai-compatible.js";
 import { toOAuthCredential } from "./pi-credentials.js";
 import {
   parseModelSecret,
@@ -462,11 +463,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
             recallSucceeded,
           }),
         );
+        const resolvedModelId =
+          bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted";
         const resolved = await resolveModelKey(
           deps,
           run.userId,
           run.workspaceId,
           credential,
+          resolvedModelId,
           (values) => runSecrets.push(...values),
         );
         runSecrets.push(...resolved.redact);
@@ -951,8 +955,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                   credential?.provider ??
                   settings?.defaultModelProvider ??
                   "scripted",
-                id:
-                  bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
+                id: resolvedModelId,
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 baseUrl: credential?.baseUrl ?? undefined,
                 oauth: resolved.oauth
@@ -1536,7 +1539,8 @@ async function resolveModelKey(
   deps: ExecutorDeps,
   userId: string,
   workspaceId: string,
-  credential: { secretId: string; provider: string } | null,
+  credential: { id: string; secretId: string; provider: string } | null,
+  modelId: string | undefined,
   registerSecrets?: (values: string[]) => void,
 ): Promise<{
   apiKey?: string;
@@ -1545,8 +1549,16 @@ async function resolveModelKey(
   redact: string[];
 }> {
   if (credential && deps.secretStore) {
-    return withModelCredentialLock(credential.secretId, async () => {
-      const row = await deps.prisma.secret.findUnique({ where: { id: credential.secretId } });
+    let secretId = credential.secretId;
+    if (isGatewayProvider(credential.provider)) {
+      const row = await deps.prisma.userModelCredential.findUnique({
+        where: { id: credential.id },
+        include: { keys: { orderBy: [{ createdAt: "asc" }, { id: "asc" }] } },
+      });
+      if (row) secretId = secretIdForGatewayModel(row, modelId);
+    }
+    return withModelCredentialLock(secretId, async () => {
+      const row = await deps.prisma.secret.findUnique({ where: { id: secretId } });
       if (!row) return { apiKey: deps.deploymentModelKey, redact: [] };
       const plaintext = deps.secretStore!.load(row.ciphertext);
       registerSecrets?.(secretValuesToRedact(parseModelSecret(plaintext)));
@@ -1572,9 +1584,9 @@ async function resolveModelKey(
         oauth,
         persistOAuth: oauth
           ? async (next) => {
-              await withModelCredentialLock(credential.secretId, async () => {
+              await withModelCredentialLock(secretId, async () => {
                 const currentRow = await deps.prisma.secret.findUnique({
-                  where: { id: credential.secretId },
+                  where: { id: secretId },
                 });
                 if (!currentRow) return;
                 const current = parseModelSecret(deps.secretStore!.load(currentRow.ciphertext));

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1211,7 +1211,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
           await checkpointAndRecordComputerWorkspace(deps, storedComputer, computer, context);
           terminalCheckpointComplete = true;
 
-          const text = redactSecrets(assembled || "done.", runSecrets);
+          const assembledText = assembled.trim();
+          if (!assembledText) {
+            throw new Error("The model returned no text");
+          }
+          const text = redactSecrets(assembledText, runSecrets);
           if (containsSecret(text, runSecrets)) {
             throw new Error("refusing to persist a secret in the thread");
           }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -30,7 +30,7 @@ export * from "./home.js";
 export * from "./host-aware-sandbox.js";
 export * from "./job-reconciler.js";
 export * from "./mcp-emulator.js";
-export * from "./openai-voice.js";
+export * from "./openai-compatible.js";
 export * from "./pi-models.js";
 export * from "./pi-oauth.js";
 export * from "./pi-runtime.js";

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  GATEWAY_PROVIDER_PREFIX,
+  isGatewayProvider,
+  normalizeOpenAICompatibleBaseUrl,
+  parseAvailableModels,
+  serializeAvailableModels,
+} from "./openai-compatible.js";
+
+describe("openai-compatible gateways", () => {
+  it("normalizes hostnames, trailing slashes, and missing protocols", () => {
+    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe("http://localhost:11434/v1");
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/")).toBe(
+      "https://api.example.com/v1",
+    );
+  });
+
+  it("rejects non-http URLs", () => {
+    expect(() => normalizeOpenAICompatibleBaseUrl("ftp://example.com")).toThrow(/http/);
+  });
+
+  it("round-trips model lists and recognizes gateway provider ids", () => {
+    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual(["gpt-4o", "llama3", "mistral"]);
+    expect(serializeAvailableModels(["gpt-4o", "gpt-4o", "llama3"])).toBe("gpt-4o\nllama3");
+    expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
+    expect(isGatewayProvider("openai-compatible")).toBe(true);
+    expect(isGatewayProvider("openrouter")).toBe(false);
+  });
+});

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  errorFromOpenAICompatibleBody,
   extractChatMessageText,
   GATEWAY_PROVIDER_PREFIX,
   isGatewayProvider,
@@ -112,5 +113,27 @@ describe("openai-compatible gateways", () => {
         "text/event-stream",
       ),
     ).toBe("Hi");
+  });
+
+  it("surfaces the gateway error body, not a generic status", () => {
+    expect(
+      errorFromOpenAICompatibleBody(
+        JSON.stringify({
+          error: { message: "Invalid API key provided", type: "invalid_request_error" },
+        }),
+        401,
+      ),
+    ).toBe("401: Invalid API key provided");
+    expect(
+      errorFromOpenAICompatibleBody(
+        JSON.stringify({
+          error: { errors: [{ message: "Model gemini-2.5-pro is not found" }] },
+        }),
+        404,
+      ),
+    ).toBe("404: Model gemini-2.5-pro is not found");
+    expect(errorFromOpenAICompatibleBody("upstream refused the stream", 502)).toBe(
+      "502: upstream refused the stream",
+    );
   });
 });

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -24,6 +24,21 @@ describe("openai-compatible gateways", () => {
     );
   });
 
+  it("appends /v1 when the pasted URL is a host or a completions path", () => {
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com")).toBe(
+      "https://api.example.com/v1",
+    );
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/chat/completions")).toBe(
+      "https://api.example.com/v1",
+    );
+    expect(normalizeOpenAICompatibleBaseUrl("https://openrouter.ai/api")).toBe(
+      "https://openrouter.ai/api/v1",
+    );
+    expect(
+      normalizeOpenAICompatibleBaseUrl("https://generativelanguage.googleapis.com/v1beta/openai"),
+    ).toBe("https://generativelanguage.googleapis.com/v1beta/openai");
+  });
+
   it("rejects non-http URLs", () => {
     expect(() => normalizeOpenAICompatibleBaseUrl("ftp://example.com")).toThrow(/http/);
   });
@@ -135,5 +150,8 @@ describe("openai-compatible gateways", () => {
     expect(errorFromOpenAICompatibleBody("upstream refused the stream", 502)).toBe(
       "502: upstream refused the stream",
     );
+    expect(
+      errorFromOpenAICompatibleBody("<!DOCTYPE html><html><head><title>Home</title></head>", 200),
+    ).toMatch(/HTML page instead of the OpenAI-compatible API/);
   });
 });

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -9,7 +9,9 @@ import {
 
 describe("openai-compatible gateways", () => {
   it("normalizes hostnames, trailing slashes, and missing protocols", () => {
-    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe("http://localhost:11434/v1");
+    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe(
+      "http://localhost:11434/v1",
+    );
     expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/")).toBe(
       "https://api.example.com/v1",
     );
@@ -20,7 +22,11 @@ describe("openai-compatible gateways", () => {
   });
 
   it("round-trips model lists and recognizes gateway provider ids", () => {
-    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual(["gpt-4o", "llama3", "mistral"]);
+    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual([
+      "gpt-4o",
+      "llama3",
+      "mistral",
+    ]);
     expect(serializeAvailableModels(["gpt-4o", "gpt-4o", "llama3"])).toBe("gpt-4o\nllama3");
     expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
     expect(isGatewayProvider("openai-compatible")).toBe(true);

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   GATEWAY_PROVIDER_PREFIX,
   isGatewayProvider,
+  labelForDiscoveredModels,
   normalizeOpenAICompatibleBaseUrl,
   parseAvailableModels,
+  secretIdForGatewayModel,
   serializeAvailableModels,
+  unionAvailableModels,
 } from "./openai-compatible.js";
 
 describe("openai-compatible gateways", () => {
@@ -31,5 +34,37 @@ describe("openai-compatible gateways", () => {
     expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
     expect(isGatewayProvider("openai-compatible")).toBe(true);
     expect(isGatewayProvider("openrouter")).toBe(false);
+  });
+
+  it("picks the key whose discovered models include the requested model", () => {
+    const credential = {
+      secretId: "active-secret",
+      keys: [
+        {
+          secretId: "gemini-secret",
+          isActive: false,
+          availableModels: "gemini-2.5-pro\ngemini-2.5-flash",
+        },
+        {
+          secretId: "active-secret",
+          isActive: true,
+          availableModels: "gpt-4o\no4-mini",
+        },
+      ],
+    };
+    expect(secretIdForGatewayModel(credential, "gemini-2.5-flash")).toBe("gemini-secret");
+    expect(secretIdForGatewayModel(credential, "gpt-4o")).toBe("active-secret");
+    expect(secretIdForGatewayModel(credential, "unknown-model")).toBe("active-secret");
+    expect(secretIdForGatewayModel(credential, undefined)).toBe("active-secret");
+    expect(unionAvailableModels(credential.keys)).toEqual([
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gpt-4o",
+      "o4-mini",
+    ]);
+    expect(labelForDiscoveredModels(["gemini-2.5-pro", "gemini-2.0-flash"])).toBe("Gemini");
+    expect(labelForDiscoveredModels(["gpt-4o", "gpt-4.1"])).toBe("GPT");
+    expect(labelForDiscoveredModels(["o4-mini"])).toBe("OpenAI");
+    expect(labelForDiscoveredModels(["gemini-2.5-pro", "gpt-4o"])).toBe("API key");
   });
 });

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -4,6 +4,7 @@ import {
   isGatewayProvider,
   labelForDiscoveredModels,
   normalizeOpenAICompatibleBaseUrl,
+  openaiCompatibleModel,
   parseAvailableModels,
   secretIdForGatewayModel,
   serializeAvailableModels,
@@ -34,6 +35,20 @@ describe("openai-compatible gateways", () => {
     expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
     expect(isGatewayProvider("openai-compatible")).toBe(true);
     expect(isGatewayProvider("openrouter")).toBe(false);
+  });
+
+  it("does not require streamed finish_reason on custom endpoints", () => {
+    const model = openaiCompatibleModel(
+      `${GATEWAY_PROVIDER_PREFIX}abc`,
+      "gemini-2.5-flash",
+      "https://generativelanguage.googleapis.com/v1beta/openai",
+    );
+    expect(model.compat).toMatchObject({
+      supportsFinishReason: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    });
   });
 
   it("picks the key whose discovered models include the requested model", () => {

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  extractChatMessageText,
   GATEWAY_PROVIDER_PREFIX,
   isGatewayProvider,
   labelForDiscoveredModels,
@@ -8,6 +9,7 @@ import {
   parseAvailableModels,
   secretIdForGatewayModel,
   serializeAvailableModels,
+  textFromOpenAICompatibleBody,
   unionAvailableModels,
 } from "./openai-compatible.js";
 
@@ -49,6 +51,7 @@ describe("openai-compatible gateways", () => {
       supportsStrictMode: false,
       maxTokensField: "max_tokens",
     });
+    expect(model.reasoning).toBe(false);
   });
 
   it("picks the key whose discovered models include the requested model", () => {
@@ -81,5 +84,33 @@ describe("openai-compatible gateways", () => {
     expect(labelForDiscoveredModels(["gpt-4o", "gpt-4.1"])).toBe("GPT");
     expect(labelForDiscoveredModels(["o4-mini"])).toBe("OpenAI");
     expect(labelForDiscoveredModels(["gemini-2.5-pro", "gpt-4o"])).toBe("API key");
+  });
+
+  it("reads string, array, and SSE chat completion bodies", () => {
+    expect(
+      extractChatMessageText({
+        choices: [{ message: { content: "Hello from JSON" } }],
+      }),
+    ).toBe("Hello from JSON");
+    expect(
+      extractChatMessageText({
+        choices: [
+          {
+            delta: {
+              content: [
+                { type: "text", text: "Hel" },
+                { type: "text", text: "lo" },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toBe("Hello");
+    expect(
+      textFromOpenAICompatibleBody(
+        'data: {"choices":[{"delta":{"content":"Hi"}}]}\ndata: [DONE]\n',
+        "text/event-stream",
+      ),
+    ).toBe("Hi");
   });
 });

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -15,6 +15,9 @@ export function mintGatewayProviderId(): string {
 export function normalizeOpenAICompatibleBaseUrl(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error("Enter a base URL");
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed) && !/^https?:\/\//i.test(trimmed)) {
+    throw new Error("Base URL must be http or https");
+  }
   const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
   let parsed: URL;
   try {
@@ -61,11 +64,7 @@ export async function fetchOpenAICompatibleModels(
     throw new Error(`Could not list models (${response.status})`);
   }
   const body = (await response.json()) as { data?: unknown; models?: unknown };
-  const rows = Array.isArray(body.data)
-    ? body.data
-    : Array.isArray(body.models)
-      ? body.models
-      : [];
+  const rows = Array.isArray(body.data) ? body.data : Array.isArray(body.models) ? body.models : [];
   const ids = rows.flatMap((row) => {
     if (typeof row === "string") return [row];
     if (row && typeof row === "object" && "id" in row) return [String((row as { id: unknown }).id)];
@@ -119,7 +118,9 @@ export function attachOpenAICompatibleProvider(
       auth: {
         apiKey: {
           name: "Custom endpoint",
-          resolve: async () => ({ auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {} }),
+          resolve: async () => ({
+            auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {},
+          }),
         },
       },
       models: ids.map((id) => openaiCompatibleModel(input.provider, id, baseUrl)),

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -1,0 +1,129 @@
+import { createProvider, type Model, type MutableModels } from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+export const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
+export const GATEWAY_PROVIDER_PREFIX = "gateway:";
+
+export function isGatewayProvider(provider: string): boolean {
+  return provider === OPENAI_COMPATIBLE_PROVIDER || provider.startsWith(GATEWAY_PROVIDER_PREFIX);
+}
+
+export function mintGatewayProviderId(): string {
+  return `${GATEWAY_PROVIDER_PREFIX}${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
+}
+
+export function normalizeOpenAICompatibleBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("Enter a base URL");
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(withProtocol);
+  } catch {
+    throw new Error("Enter a valid http(s) base URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Base URL must be http or https");
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  const path = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = path || "/";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+export function parseAvailableModels(value: string | null | undefined): string[] {
+  if (!value?.trim()) return [];
+  return [
+    ...new Set(
+      value
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+export function serializeAvailableModels(models: string[]): string {
+  return [...new Set(models.map((entry) => entry.trim()).filter(Boolean))].join("\n");
+}
+
+export async function fetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const endpoint = `${normalizeOpenAICompatibleBaseUrl(baseUrl)}/models`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (apiKey?.trim()) headers.authorization = `Bearer ${apiKey.trim()}`;
+  const response = await fetch(endpoint, { headers, signal });
+  if (!response.ok) {
+    throw new Error(`Could not list models (${response.status})`);
+  }
+  const body = (await response.json()) as { data?: unknown; models?: unknown };
+  const rows = Array.isArray(body.data)
+    ? body.data
+    : Array.isArray(body.models)
+      ? body.models
+      : [];
+  const ids = rows.flatMap((row) => {
+    if (typeof row === "string") return [row];
+    if (row && typeof row === "object" && "id" in row) return [String((row as { id: unknown }).id)];
+    return [];
+  });
+  if (!ids.length) throw new Error("That endpoint did not return any models");
+  return [...new Set(ids)];
+}
+
+export function openaiCompatibleModel(
+  provider: string,
+  modelId: string,
+  baseUrl: string,
+): Model<"openai-completions"> {
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    provider,
+    baseUrl,
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStore: false,
+    },
+  };
+}
+
+export function attachOpenAICompatibleProvider(
+  models: MutableModels,
+  input: {
+    provider: string;
+    baseUrl: string;
+    modelId: string;
+    apiKey?: string;
+    extraModelIds?: string[];
+  },
+): void {
+  const baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl);
+  const ids = [...new Set([input.modelId, ...(input.extraModelIds ?? [])].filter(Boolean))];
+  models.setProvider(
+    createProvider({
+      id: input.provider,
+      name: input.provider,
+      baseUrl,
+      auth: {
+        apiKey: {
+          name: "Custom endpoint",
+          resolve: async () => ({ auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {} }),
+        },
+      },
+      models: ids.map((id) => openaiCompatibleModel(input.provider, id, baseUrl)),
+      api: openAICompletionsApi(),
+    }),
+  );
+}

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -235,11 +235,81 @@ export async function completeOpenAICompatibleChat(input: {
   });
   const raw = await response.text();
   if (!response.ok) {
-    throw new Error(`Chat completion failed (${response.status})`);
+    throw new Error(errorFromOpenAICompatibleBody(raw, response.status));
   }
   const text = textFromOpenAICompatibleBody(raw, response.headers.get("content-type") ?? "");
-  if (!text.trim()) throw new Error("The model returned an empty reply");
+  if (!text.trim()) {
+    throw new Error(errorFromOpenAICompatibleBody(raw, response.status));
+  }
   return text;
+}
+
+const MAX_GATEWAY_ERROR_CHARS = 4000;
+
+export function errorFromOpenAICompatibleBody(raw: string, status?: number): string {
+  const trimmed = raw.trim();
+  const extracted = extractGatewayErrorMessage(trimmed) || trimmed;
+  const clipped =
+    extracted.length > MAX_GATEWAY_ERROR_CHARS
+      ? `${extracted.slice(0, MAX_GATEWAY_ERROR_CHARS)}…`
+      : extracted;
+  if (status && status >= 400) {
+    if (!clipped) return `Gateway request failed (${status})`;
+    return /^\d{3}\b/.test(clipped) ? clipped : `${status}: ${clipped}`;
+  }
+  return clipped || "The gateway returned an empty reply";
+}
+
+function extractGatewayErrorMessage(raw: string): string {
+  if (!raw) return "";
+  try {
+    const fromJson = errorMessageFromValue(JSON.parse(raw) as unknown);
+    if (fromJson) return fromJson;
+  } catch {
+    // Fall through to SSE / plain text.
+  }
+  if (raw.includes("data:")) {
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const fromEvent = errorMessageFromValue(JSON.parse(payload) as unknown);
+        if (fromEvent) return fromEvent;
+      } catch {
+        // Ignore malformed SSE lines.
+      }
+    }
+  }
+  return "";
+}
+
+function errorMessageFromValue(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (!value || typeof value !== "object") return "";
+  const record = value as Record<string, unknown>;
+  const nested = record.error;
+  if (typeof nested === "string" && nested.trim()) return nested.trim();
+  if (nested && typeof nested === "object") {
+    const inner = nested as Record<string, unknown>;
+    if (typeof inner.message === "string" && inner.message.trim()) return inner.message.trim();
+    if (typeof inner.msg === "string" && inner.msg.trim()) return inner.msg.trim();
+    if (typeof inner.error === "string" && inner.error.trim()) return inner.error.trim();
+    const errors = inner.errors;
+    if (Array.isArray(errors)) {
+      const first = errors.find(
+        (entry) =>
+          entry &&
+          typeof entry === "object" &&
+          typeof (entry as { message?: unknown }).message === "string",
+      ) as { message: string } | undefined;
+      if (first?.message.trim()) return first.message.trim();
+    }
+  }
+  if (typeof record.message === "string" && record.message.trim()) return record.message.trim();
+  if (typeof record.msg === "string" && record.msg.trim()) return record.msg.trim();
+  if (typeof record.detail === "string" && record.detail.trim()) return record.detail.trim();
+  return "";
 }
 
 export function textFromOpenAICompatibleBody(raw: string, contentType = ""): string {

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -51,6 +51,80 @@ export function serializeAvailableModels(models: string[]): string {
   return [...new Set(models.map((entry) => entry.trim()).filter(Boolean))].join("\n");
 }
 
+export function modelsFromKeyCoverage(value: string | string[] | null | undefined): string[] {
+  return Array.isArray(value)
+    ? [...new Set(value.map((entry) => entry.trim()).filter(Boolean))]
+    : parseAvailableModels(value);
+}
+
+export function unionAvailableModels(
+  keys: Array<{ availableModels?: string | string[] | null }>,
+): string[] {
+  return [...new Set(keys.flatMap((key) => modelsFromKeyCoverage(key.availableModels)))];
+}
+
+export function secretIdForGatewayModel(
+  credential: {
+    secretId: string;
+    keys: Array<{
+      secretId: string;
+      isActive: boolean;
+      availableModels?: string | string[] | null;
+    }>;
+  },
+  modelId?: string | null,
+): string {
+  const fallback = credential.keys.find((key) => key.isActive)?.secretId ?? credential.secretId;
+  if (!modelId?.trim() || !credential.keys.length) return fallback;
+  const matching = credential.keys.filter((key) =>
+    modelsFromKeyCoverage(key.availableModels).includes(modelId),
+  );
+  if (!matching.length) return fallback;
+  return matching.find((key) => key.isActive)?.secretId ?? matching[0]!.secretId;
+}
+
+const MODEL_FAMILY_LABELS: Array<[string, string]> = [
+  ["gemini", "Gemini"],
+  ["claude", "Claude"],
+  ["gpt", "GPT"],
+  ["o1", "OpenAI"],
+  ["o3", "OpenAI"],
+  ["o4", "OpenAI"],
+  ["llama", "Llama"],
+  ["mistral", "Mistral"],
+  ["grok", "Grok"],
+  ["deepseek", "DeepSeek"],
+  ["qwen", "Qwen"],
+  ["command", "Command"],
+];
+
+export function labelForDiscoveredModels(models: string[], fallback = "API key"): string {
+  if (!models.length) return fallback;
+  const lower = models.map((id) => id.toLowerCase());
+  for (const [needle, label] of MODEL_FAMILY_LABELS) {
+    const hits = lower.filter((id) => id.includes(needle)).length;
+    if (hits === models.length || hits >= Math.max(1, Math.ceil(models.length * 0.7))) {
+      return label;
+    }
+  }
+  return fallback;
+}
+
+export async function tryFetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<{ models: string[]; error: string }> {
+  try {
+    return { models: await fetchOpenAICompatibleModels(baseUrl, apiKey, signal), error: "" };
+  } catch (error) {
+    return {
+      models: [],
+      error: error instanceof Error ? error.message : "Could not list models",
+    };
+  }
+}
+
 export async function fetchOpenAICompatibleModels(
   baseUrl: string,
   apiKey?: string,

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -159,7 +159,7 @@ export function openaiCompatibleModel(
     api: "openai-completions",
     provider,
     baseUrl,
-    reasoning: true,
+    reasoning: false,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128_000,
@@ -208,4 +208,99 @@ export function attachOpenAICompatibleProvider(
       api: openAICompletionsApi(),
     }),
   );
+}
+
+export async function completeOpenAICompatibleChat(input: {
+  baseUrl: string;
+  apiKey?: string;
+  modelId: string;
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const endpoint = `${normalizeOpenAICompatibleBaseUrl(input.baseUrl)}/chat/completions`;
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "content-type": "application/json",
+  };
+  if (input.apiKey?.trim()) headers.authorization = `Bearer ${input.apiKey.trim()}`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    signal: input.signal,
+    body: JSON.stringify({
+      model: input.modelId,
+      messages: input.messages,
+      stream: false,
+    }),
+  });
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(`Chat completion failed (${response.status})`);
+  }
+  const text = textFromOpenAICompatibleBody(raw, response.headers.get("content-type") ?? "");
+  if (!text.trim()) throw new Error("The model returned an empty reply");
+  return text;
+}
+
+export function textFromOpenAICompatibleBody(raw: string, contentType = ""): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (contentType.includes("text/event-stream") || trimmed.startsWith("data:")) {
+    return textFromChatCompletionSse(trimmed);
+  }
+  try {
+    return extractChatMessageText(JSON.parse(trimmed) as unknown);
+  } catch {
+    return trimmed.includes("data:") ? textFromChatCompletionSse(trimmed) : "";
+  }
+}
+
+export function extractChatMessageText(body: unknown): string {
+  if (!body || typeof body !== "object") return "";
+  const record = body as Record<string, unknown>;
+  const choices = Array.isArray(record.choices) ? record.choices : [];
+  const choice = choices[0];
+  if (!choice || typeof choice !== "object") return extractContent(record.content);
+  const row = choice as Record<string, unknown>;
+  const message =
+    row.message && typeof row.message === "object"
+      ? (row.message as Record<string, unknown>)
+      : undefined;
+  const delta =
+    row.delta && typeof row.delta === "object" ? (row.delta as Record<string, unknown>) : undefined;
+  return (
+    extractContent(message?.content) ||
+    extractContent(delta?.content) ||
+    extractContent(row.content)
+  );
+}
+
+function textFromChatCompletionSse(raw: string): string {
+  let text = "";
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    try {
+      text += extractChatMessageText(JSON.parse(payload) as unknown);
+    } catch {
+      // Ignore malformed SSE lines from non-standard proxies.
+    }
+  }
+  return text;
+}
+
+function extractContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (!part || typeof part !== "object") return "";
+      const record = part as Record<string, unknown>;
+      if (typeof record.text === "string") return record.text;
+      if (typeof record.content === "string") return record.content;
+      return "";
+    })
+    .join("");
 }

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -168,6 +168,13 @@ export function openaiCompatibleModel(
       supportsDeveloperRole: false,
       supportsReasoningEffort: false,
       supportsStore: false,
+      // Custom OpenAI-compatible proxies (Gemini, Ollama, LiteLLM, Groq, …) often
+      // close the SSE stream after tokens without a terminal finish_reason chunk.
+      // Pi treats that as a hard error unless this is off.
+      supportsFinishReason: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
     },
   };
 }

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -30,8 +30,13 @@ export function normalizeOpenAICompatibleBaseUrl(value: string): string {
   }
   parsed.hash = "";
   parsed.search = "";
-  const path = parsed.pathname.replace(/\/+$/, "");
-  parsed.pathname = path || "/";
+  let path = parsed.pathname.replace(/\/+$/, "") || "/";
+  path = path.replace(/\/(chat\/completions|completions|models|responses)$/i, "");
+  path = path.replace(/\/+$/, "") || "/";
+  if (!/\/v\d+[a-z0-9]*(\/|$)/i.test(path)) {
+    path = path === "/" ? "/v1" : `${path}/v1`;
+  }
+  parsed.pathname = path;
   return parsed.toString().replace(/\/+$/, "");
 }
 
@@ -248,6 +253,11 @@ const MAX_GATEWAY_ERROR_CHARS = 4000;
 
 export function errorFromOpenAICompatibleBody(raw: string, status?: number): string {
   const trimmed = raw.trim();
+  if (looksLikeHtmlDocument(trimmed)) {
+    const hint =
+      "The endpoint returned an HTML page instead of the OpenAI-compatible API. Use a base URL that ends in /v1 (for example https://api.example.com/v1) and confirm the API key is saved.";
+    return status && status >= 400 ? `${status}: ${hint}` : hint;
+  }
   const extracted = extractGatewayErrorMessage(trimmed) || trimmed;
   const clipped =
     extracted.length > MAX_GATEWAY_ERROR_CHARS
@@ -258,6 +268,15 @@ export function errorFromOpenAICompatibleBody(raw: string, status?: number): str
     return /^\d{3}\b/.test(clipped) ? clipped : `${status}: ${clipped}`;
   }
   return clipped || "The gateway returned an empty reply";
+}
+
+function looksLikeHtmlDocument(raw: string): boolean {
+  const head = raw.slice(0, 256).toLowerCase();
+  return (
+    head.startsWith("<!doctype html") ||
+    head.startsWith("<html") ||
+    (head.startsWith("<") && (head.includes("<head") || head.includes("<title")))
+  );
 }
 
 function extractGatewayErrorMessage(raw: string): string {

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -15,6 +15,8 @@ export type PiCatalogEntry = {
   oauthLabel?: string;
   subscription: boolean;
   signIn?: PiCatalogSignIn;
+  custom?: boolean;
+  baseUrl?: string;
 };
 
 export function listPiCatalog(): PiCatalogEntry[] {
@@ -85,3 +87,50 @@ export const scriptedCatalogEntry: PiCatalogEntry = {
   auth: "api-key",
   subscription: false,
 };
+
+export const customEndpointCatalogEntry: PiCatalogEntry = {
+  provider: "openai-compatible",
+  providerName: "Custom endpoint",
+  id: "custom",
+  label: "OpenAI-compatible",
+  billing:
+    "Any OpenAI-compatible server. Paste a base URL — Ollama, vLLM, LiteLLM, OpenAI, Azure-compatible proxies, or your own gateway.",
+  auth: "api-key",
+  subscription: false,
+  custom: true,
+};
+
+export function gatewayCatalogEntries(
+  credentials: Array<{
+    provider: string;
+    label: string;
+    baseUrl?: string | null;
+    defaultModel?: string | null;
+    availableModels?: string[];
+  }>,
+): PiCatalogEntry[] {
+  return credentials.flatMap((credential) => {
+    if (!credential.baseUrl && !credential.provider.startsWith("gateway:")) return [];
+    const models = [
+      ...new Set(
+        [credential.defaultModel, ...(credential.availableModels ?? [])].filter(
+          (id): id is string => Boolean(id),
+        ),
+      ),
+    ];
+    const ids = models.length ? models : ["custom"];
+    return ids.map((id) => ({
+      provider: credential.provider,
+      providerName: credential.label || "Custom endpoint",
+      id,
+      label: id,
+      billing: credential.baseUrl
+        ? `Uses ${credential.baseUrl}. Rakazo does not pay for model usage.`
+        : "Custom OpenAI-compatible endpoint.",
+      auth: "api-key" as const,
+      subscription: false,
+      custom: true,
+      baseUrl: credential.baseUrl ?? undefined,
+    }));
+  });
+}

--- a/packages/adapters/src/pi-runtime-stream-close.test.ts
+++ b/packages/adapters/src/pi-runtime-stream-close.test.ts
@@ -1,0 +1,72 @@
+import type { ConnectorTool } from "@rakazo/adapter-kit";
+import { describe, expect, it, vi } from "vitest";
+import { isMissingFinishReasonError, PiAgentRuntime } from "./pi-runtime.js";
+
+vi.mock("@earendil-works/pi-agent-core", () => ({
+  Agent: class {
+    state = {
+      errorMessage: "Stream ended without finish_reason",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "The gateway already sent this reply." }],
+        },
+      ],
+    };
+    subscribe() {}
+    async prompt() {}
+    async waitForIdle() {}
+    abort() {}
+  },
+}));
+
+vi.mock("@earendil-works/pi-ai/providers/all", () => ({
+  builtinModels: () => ({
+    getModel: (_provider: string, modelId: string) =>
+      modelId === "flash" ? { provider: "gateway:test", id: modelId } : undefined,
+    streamSimple: () => {
+      throw new Error("provider should not be called");
+    },
+  }),
+}));
+
+const tools: ConnectorTool[] = [];
+
+describe("missing streamed finish_reason", () => {
+  it("recognizes the Pi protocol error", () => {
+    expect(isMissingFinishReasonError("Stream ended without finish_reason")).toBe(true);
+    expect(isMissingFinishReasonError("Provider finish_reason: length")).toBe(false);
+  });
+
+  it("keeps the model reply instead of posting I hit a problem", async () => {
+    const runtime = new PiAgentRuntime();
+    const events: Array<{ type?: string; text?: string }> = [];
+    for await (const event of runtime.run(
+      {
+        botId: "bot",
+        threadId: "thread",
+        runId: "run",
+        prompt: "hello",
+        instructions: "Be concise.",
+        history: [],
+        tools,
+        model: { provider: "gateway:test", id: "flash" },
+      },
+      {
+        operationId: "stream-close",
+        traceId: "stream-close",
+        workspaceId: "workspace",
+        userId: "user",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(events.some((event) => event.text?.includes("I hit a problem"))).toBe(false);
+    expect(events.some((event) => event.text === "The gateway already sent this reply.")).toBe(
+      true,
+    );
+    expect(events.at(-1)?.type).toBe("done");
+  });
+});

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -141,7 +141,7 @@ export class PiAgentRuntime implements AgentRuntime {
             if (delta) {
               thinking += delta;
               const now = Date.now();
-              if (now - lastThinkPush >= 80) {
+              if (now - lastThinkPush >= 24) {
                 lastThinkPush = now;
                 emitReasoning({
                   id: "think",

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -802,8 +802,18 @@ function pushRunError(
 ) {
   const message = sanitizeError(error);
   queue.push({
+    type: "reasoning",
+    step: {
+      id: "status",
+      kind: "status",
+      title: fromGateway ? "Gateway error" : "Failed",
+      detail: message,
+      status: "done",
+    },
+  });
+  queue.push({
     type: "text",
-    text: fromGateway ? message : `I hit a problem: ${message}`,
+    text: message,
   });
   queue.push({ type: "done", text: message });
 }

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1,5 +1,5 @@
 import { Agent, type AgentMessage, type AgentTool } from "@earendil-works/pi-agent-core";
-import { type Api, type Model, type Models, Type } from "@earendil-works/pi-ai";
+import { type Api, type Model, type Models, type MutableModels, Type } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import type {
   AdapterContext,
@@ -9,7 +9,10 @@ import type {
   AgentToolExecutionResult,
   ConnectorTool,
 } from "@rakazo/adapter-kit";
+import type { ReasoningStep } from "@rakazo/contracts";
+import { reasoningToolDetail, reasoningToolTitle } from "@rakazo/core";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
+import { attachOpenAICompatibleProvider } from "./openai-compatible.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
 import { registerLocalProvider } from "./pi-local-provider.js";
 
@@ -58,7 +61,9 @@ export class PiAgentRuntime implements AgentRuntime {
             ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731")
             : request.model.id;
         const models = modelsForRequest(request, provider);
-        const model = models.getModel(provider, modelId) ?? models.getModel("openrouter", modelId);
+        const model =
+          models.getModel(provider, modelId) ??
+          (request.model.baseUrl ? undefined : models.getModel("openrouter", modelId));
         if (!model) {
           queue.push({ type: "text", text: `Unknown model ${provider}/${modelId}` });
           queue.push({ type: "done" });
@@ -95,7 +100,7 @@ export class PiAgentRuntime implements AgentRuntime {
                 ? "You are a Rakazo bot with a real computer. Use computer_observe and computer_act to operate its visible desktop, including browsers and installed applications. Use shell and the file tools for precise terminal and filesystem work. The user may interact with the same desktop while you run, so re-observe when the screen may have changed. Be concise."
                 : "You are a Rakazo bot with a persistent sandbox filesystem and shell. Be concise."),
             model,
-            thinkingLevel: "off",
+            thinkingLevel: model.reasoning ? "medium" : "off",
             tools,
             messages: history,
           },
@@ -112,7 +117,72 @@ export class PiAgentRuntime implements AgentRuntime {
         signal.addEventListener("abort", onAbort);
 
         let streamed = "";
+        let thinking = "";
+        let lastThinkPush = 0;
+        const emitReasoning = (step: ReasoningStep) => {
+          queue.push({ type: "reasoning", step });
+        };
+        emitReasoning({
+          id: "status",
+          kind: "status",
+          title: "Working through the request",
+          status: "running",
+        });
         agent.subscribe((event) => {
+          if (
+            event.type === "message_update" &&
+            event.assistantMessageEvent.type === "thinking_delta"
+          ) {
+            const delta = event.assistantMessageEvent.delta;
+            if (delta) {
+              thinking += delta;
+              const now = Date.now();
+              if (now - lastThinkPush >= 80) {
+                lastThinkPush = now;
+                emitReasoning({
+                  id: "think",
+                  kind: "think",
+                  title: "Thinking",
+                  detail: thinking.slice(-4000),
+                  status: "running",
+                });
+              }
+            }
+          }
+          if (
+            event.type === "message_update" &&
+            event.assistantMessageEvent.type === "thinking_end"
+          ) {
+            const content = event.assistantMessageEvent.content || thinking;
+            if (content) {
+              thinking = content;
+              emitReasoning({
+                id: "think",
+                kind: "think",
+                title: "Thought",
+                detail: content.slice(-8000),
+                status: "done",
+              });
+            }
+          }
+          if (event.type === "tool_execution_start") {
+            emitReasoning({
+              id: event.toolCallId,
+              kind: "tool",
+              title: reasoningToolTitle(event.toolName, event.args ?? {}),
+              detail: reasoningToolDetail(event.toolName, event.args ?? {}),
+              status: "running",
+            });
+          }
+          if (event.type === "tool_execution_end") {
+            emitReasoning({
+              id: event.toolCallId,
+              kind: "tool",
+              title: reasoningToolTitle(event.toolName, event.args ?? {}),
+              detail: event.isError ? "failed" : "done",
+              status: "done",
+            });
+          }
           if (
             event.type === "message_update" &&
             event.assistantMessageEvent.type === "text_delta"
@@ -141,7 +211,6 @@ export class PiAgentRuntime implements AgentRuntime {
           }
         });
 
-        queue.push({ type: "progress", text: "working…" });
         const images = request.currentTurnImages?.map((image) => ({
           type: "image" as const,
           data: Buffer.from(image.data).toString("base64"),
@@ -163,6 +232,12 @@ export class PiAgentRuntime implements AgentRuntime {
           streamed = fallback;
         }
         queue.push({ type: "done", text: streamed });
+        emitReasoning({
+          id: "status",
+          kind: "status",
+          title: "Finished",
+          status: "done",
+        });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
         queue.push({ type: "text", text: `I hit a problem: ${message}` });
@@ -181,20 +256,28 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
-function modelsForRequest(request: AgentRunRequest, provider: string): Models {
+function modelsForRequest(request: AgentRunRequest, provider: string): ReturnType<typeof builtinModels> {
   const oauth = request.model.oauth;
-  if (!oauth) return catalogModels();
-
-  const persist = oauth.persist;
-  return registerLocalProvider(
-    builtinModels({
-      credentials: new PiRuntimeCredentialStore(
-        provider,
-        toOAuthCredential(oauth.credential),
-        persist ? (next) => persist(next) : undefined,
-      ),
-    }),
-  );
+  const models = oauth
+    ? registerLocalProvider(
+        builtinModels({
+          credentials: new PiRuntimeCredentialStore(
+            provider,
+            toOAuthCredential(oauth.credential),
+            oauth.persist ? (next) => oauth.persist!(next) : undefined,
+          ),
+        }),
+      )
+    : catalogModels();
+  if (request.model.baseUrl) {
+    attachOpenAICompatibleProvider(models as MutableModels, {
+      provider,
+      baseUrl: request.model.baseUrl,
+      modelId: request.model.id,
+      apiKey: request.model.apiKey,
+    });
+  }
+  return models;
 }
 
 function toAgentTools(toolDefs: readonly ConnectorTool[], host: ToolHost): AgentTool[] {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -12,7 +12,10 @@ import type {
 import type { ReasoningStep } from "@rakazo/contracts";
 import { reasoningToolDetail, reasoningToolTitle } from "@rakazo/core";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
-import { attachOpenAICompatibleProvider } from "./openai-compatible.js";
+import {
+  attachOpenAICompatibleProvider,
+  completeOpenAICompatibleChat,
+} from "./openai-compatible.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
 import { registerLocalProvider } from "./pi-local-provider.js";
 
@@ -230,9 +233,18 @@ export class PiAgentRuntime implements AgentRuntime {
           return;
         }
         if (!streamed) {
-          const fallback = assistantText(agent.state.messages.at(-1)) || "I finished the work.";
-          queue.push({ type: "text", text: fallback });
-          streamed = fallback;
+          const recovered =
+            (await recoverGatewayReply(request, signal).catch(() => "")) ||
+            assistantText(agent.state.messages.at(-1));
+          if (recovered) {
+            queue.push({ type: "text", text: recovered });
+            streamed = recovered;
+          } else {
+            const message =
+              "The model returned an empty reply. Check the custom endpoint and model id, then try again.";
+            queue.push({ type: "text", text: message });
+            streamed = message;
+          }
         }
         emitReasoning({
           id: "status",
@@ -244,9 +256,12 @@ export class PiAgentRuntime implements AgentRuntime {
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
         if (isMissingFinishReasonError(message)) {
-          queue.push({ type: "text", text: "I finished the work." });
-          queue.push({ type: "done", text: "I finished the work." });
-          return;
+          const recovered = await recoverGatewayReply(request, signal).catch(() => "");
+          if (recovered) {
+            queue.push({ type: "text", text: recovered });
+            queue.push({ type: "done", text: recovered });
+            return;
+          }
         }
         queue.push({ type: "text", text: `I hit a problem: ${message}` });
         queue.push({ type: "done", text: message });
@@ -760,6 +775,35 @@ function summarizeToolResult(result: unknown) {
 
 export function isMissingFinishReasonError(error: string): boolean {
   return /stream ended without finish_reason/i.test(error);
+}
+
+async function recoverGatewayReply(request: AgentRunRequest, signal: AbortSignal): Promise<string> {
+  if (!request.model.baseUrl) return "";
+  return completeOpenAICompatibleChat({
+    baseUrl: request.model.baseUrl,
+    apiKey: request.model.apiKey,
+    modelId: request.model.id,
+    messages: gatewayChatMessages(request),
+    signal,
+  });
+}
+
+function gatewayChatMessages(
+  request: AgentRunRequest,
+): Array<{ role: "system" | "user" | "assistant"; content: string }> {
+  const messages: Array<{ role: "system" | "user" | "assistant"; content: string }> = [];
+  if (request.instructions?.trim()) {
+    messages.push({ role: "system", content: request.instructions });
+  }
+  for (const item of request.history) {
+    if (item.role === "user" || item.role === "assistant") {
+      messages.push({ role: item.role, content: item.content });
+    }
+  }
+  if (messages.at(-1)?.role !== "user" || messages.at(-1)?.content !== request.prompt) {
+    messages.push({ role: "user", content: request.prompt });
+  }
+  return messages;
 }
 
 function assistantText(message: unknown): string {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -119,6 +119,7 @@ export class PiAgentRuntime implements AgentRuntime {
         let streamed = "";
         let thinking = "";
         let lastThinkPush = 0;
+        const toolArgs = new Map<string, Record<string, unknown>>();
         const emitReasoning = (step: ReasoningStep) => {
           queue.push({ type: "reasoning", step });
         };
@@ -166,6 +167,7 @@ export class PiAgentRuntime implements AgentRuntime {
             }
           }
           if (event.type === "tool_execution_start") {
+            toolArgs.set(event.toolCallId, event.args ?? {});
             emitReasoning({
               id: event.toolCallId,
               kind: "tool",
@@ -175,10 +177,11 @@ export class PiAgentRuntime implements AgentRuntime {
             });
           }
           if (event.type === "tool_execution_end") {
+            const args = toolArgs.get(event.toolCallId) ?? {};
             emitReasoning({
               id: event.toolCallId,
               kind: "tool",
-              title: reasoningToolTitle(event.toolName, event.args ?? {}),
+              title: reasoningToolTitle(event.toolName, args),
               detail: event.isError ? "failed" : "done",
               status: "done",
             });
@@ -231,13 +234,13 @@ export class PiAgentRuntime implements AgentRuntime {
           queue.push({ type: "text", text: fallback });
           streamed = fallback;
         }
-        queue.push({ type: "done", text: streamed });
         emitReasoning({
           id: "status",
           kind: "status",
           title: "Finished",
           status: "done",
         });
+        queue.push({ type: "done", text: streamed });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
         queue.push({ type: "text", text: `I hit a problem: ${message}` });
@@ -256,7 +259,10 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
-function modelsForRequest(request: AgentRunRequest, provider: string): ReturnType<typeof builtinModels> {
+function modelsForRequest(
+  request: AgentRunRequest,
+  provider: string,
+): ReturnType<typeof builtinModels> {
   const oauth = request.model.oauth;
   const models = oauth
     ? registerLocalProvider(

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -224,7 +224,7 @@ export class PiAgentRuntime implements AgentRuntime {
         signal.removeEventListener("abort", onAbort);
 
         const error = agent.state.errorMessage;
-        if (error) {
+        if (error && !isMissingFinishReasonError(error)) {
           queue.push({ type: "text", text: `I hit a problem: ${sanitizeError(error)}` });
           queue.push({ type: "done", text: sanitizeError(error) });
           return;
@@ -243,6 +243,11 @@ export class PiAgentRuntime implements AgentRuntime {
         queue.push({ type: "done", text: streamed });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
+        if (isMissingFinishReasonError(message)) {
+          queue.push({ type: "text", text: "I finished the work." });
+          queue.push({ type: "done", text: "I finished the work." });
+          return;
+        }
         queue.push({ type: "text", text: `I hit a problem: ${message}` });
         queue.push({ type: "done", text: message });
       } finally {
@@ -584,7 +589,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
     await nested.waitForIdle();
     host.signal.removeEventListener("abort", onAbort);
     const error = nested.state.errorMessage;
-    if (error) {
+    if (error && !isMissingFinishReasonError(error)) {
       const message = sanitizeError(error);
       host.queue.push({ type: "subagent", agentId, name, task, status: "failed", result: message });
       return `Subagent failed: ${message}`;
@@ -751,6 +756,10 @@ function summarizeToolResult(result: unknown) {
   } catch {
     return "ok";
   }
+}
+
+export function isMissingFinishReasonError(error: string): boolean {
+  return /stream ended without finish_reason/i.test(error);
 }
 
 function assistantText(message: unknown): string {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -228,22 +228,32 @@ export class PiAgentRuntime implements AgentRuntime {
 
         const error = agent.state.errorMessage;
         if (error && !isMissingFinishReasonError(error)) {
-          queue.push({ type: "text", text: `I hit a problem: ${sanitizeError(error)}` });
-          queue.push({ type: "done", text: sanitizeError(error) });
+          pushRunError(queue, error, Boolean(request.model.baseUrl));
           return;
         }
         if (!streamed) {
-          const recovered =
-            (await recoverGatewayReply(request, signal).catch(() => "")) ||
-            assistantText(agent.state.messages.at(-1));
-          if (recovered) {
-            queue.push({ type: "text", text: recovered });
-            streamed = recovered;
-          } else {
-            const message =
-              "The model returned an empty reply. Check the custom endpoint and model id, then try again.";
-            queue.push({ type: "text", text: message });
-            streamed = message;
+          try {
+            const recovered =
+              (await recoverGatewayReply(request, signal)) ||
+              assistantText(agent.state.messages.at(-1));
+            if (recovered) {
+              queue.push({ type: "text", text: recovered });
+              streamed = recovered;
+            } else {
+              pushRunError(
+                queue,
+                error || "The gateway returned an empty reply",
+                Boolean(request.model.baseUrl),
+              );
+              return;
+            }
+          } catch (recoveryError) {
+            pushRunError(
+              queue,
+              recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+              Boolean(request.model.baseUrl),
+            );
+            return;
           }
         }
         emitReasoning({
@@ -255,16 +265,24 @@ export class PiAgentRuntime implements AgentRuntime {
         queue.push({ type: "done", text: streamed });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
-        if (isMissingFinishReasonError(message)) {
-          const recovered = await recoverGatewayReply(request, signal).catch(() => "");
-          if (recovered) {
-            queue.push({ type: "text", text: recovered });
-            queue.push({ type: "done", text: recovered });
+        if (isMissingFinishReasonError(message) && request.model.baseUrl) {
+          try {
+            const recovered = await recoverGatewayReply(request, signal);
+            if (recovered) {
+              queue.push({ type: "text", text: recovered });
+              queue.push({ type: "done", text: recovered });
+              return;
+            }
+          } catch (recoveryError) {
+            pushRunError(
+              queue,
+              recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+              true,
+            );
             return;
           }
         }
-        queue.push({ type: "text", text: `I hit a problem: ${message}` });
-        queue.push({ type: "done", text: message });
+        pushRunError(queue, message, Boolean(request.model.baseUrl));
       } finally {
         queue.close();
       }
@@ -775,6 +793,19 @@ function summarizeToolResult(result: unknown) {
 
 export function isMissingFinishReasonError(error: string): boolean {
   return /stream ended without finish_reason/i.test(error);
+}
+
+function pushRunError(
+  queue: { push(event: AgentRuntimeEvent): void },
+  error: string,
+  fromGateway: boolean,
+) {
+  const message = sanitizeError(error);
+  queue.push({
+    type: "text",
+    text: fromGateway ? message : `I hit a problem: ${message}`,
+  });
+  queue.push({ type: "done", text: message });
 }
 
 async function recoverGatewayReply(request: AgentRunRequest, signal: AbortSignal): Promise<string> {

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -44,7 +44,15 @@ export class ScriptedAgentRuntime implements AgentRuntime {
           return;
         }
         if (turn.assistant) {
-          yield { type: "progress", text: "working…" };
+          yield {
+            type: "reasoning",
+            step: {
+              id: "status",
+              kind: "status",
+              title: "Writing a reply",
+              status: "running",
+            },
+          };
           yield { type: "text", text: turn.assistant };
         }
         for (const call of turn.toolCalls ?? []) {
@@ -81,6 +89,7 @@ export class ScriptedAgentRuntime implements AgentRuntime {
             name: call.name,
             args: call.args,
             executionId: `${request.runId}:${call.name}`,
+            status: "running",
           };
         }
         if (turn.ask) {

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -27,6 +27,8 @@ export const BotSchema = z.object({
   createdAt: z.string(),
   voiceId: z.string().nullable(),
   autoSpeak: z.boolean(),
+  modelProvider: z.string().nullable(),
+  modelId: z.string().nullable(),
 });
 export type Bot = z.infer<typeof BotSchema>;
 
@@ -47,6 +49,8 @@ export const CreateBotInput = z.object({
   notifyOnFinish: z.boolean().default(true),
   color: z.string().optional(),
   computerMode: ComputerModeSchema.default("team"),
+  modelProvider: z.string().max(120).nullable().optional(),
+  modelId: z.string().max(200).nullable().optional(),
 });
 export type CreateBotInput = z.infer<typeof CreateBotInput>;
 
@@ -62,6 +66,8 @@ export const UpdateBotInput = z.object({
   sectionId: Id.nullable().optional(),
   voiceId: z.string().max(120).nullable().optional(),
   autoSpeak: z.boolean().optional(),
+  modelProvider: z.string().max(120).nullable().optional(),
+  modelId: z.string().max(200).nullable().optional(),
 });
 
 export const RoutineSchema = z.object({
@@ -268,6 +274,9 @@ export const ModelCredentialSchema = z.object({
   label: z.string(),
   hasKey: z.boolean(),
   isDefault: z.boolean(),
+  baseUrl: z.string().nullable().optional(),
+  defaultModel: z.string().nullable().optional(),
+  availableModels: z.array(z.string()).optional(),
 });
 export type ModelCredential = z.infer<typeof ModelCredentialSchema>;
 
@@ -281,6 +290,8 @@ export const ModelCatalogEntrySchema = z.object({
   oauthLabel: z.string().optional(),
   subscription: z.boolean().optional(),
   signIn: z.enum(["device-code"]).optional(),
+  custom: z.boolean().optional(),
+  baseUrl: z.string().optional(),
 });
 export type ModelCatalogEntry = z.infer<typeof ModelCatalogEntrySchema>;
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -268,6 +268,14 @@ export const ThreadSnapshotSchema = z.object({
 });
 export type ThreadSnapshot = z.infer<typeof ThreadSnapshotSchema>;
 
+export const ModelCredentialKeySchema = z.object({
+  id: Id,
+  label: z.string(),
+  isActive: z.boolean(),
+  createdAt: z.string(),
+});
+export type ModelCredentialKey = z.infer<typeof ModelCredentialKeySchema>;
+
 export const ModelCredentialSchema = z.object({
   id: Id,
   provider: z.string(),
@@ -277,6 +285,7 @@ export const ModelCredentialSchema = z.object({
   baseUrl: z.string().nullable().optional(),
   defaultModel: z.string().nullable().optional(),
   availableModels: z.array(z.string()).optional(),
+  keys: z.array(ModelCredentialKeySchema),
 });
 export type ModelCredential = z.infer<typeof ModelCredentialSchema>;
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -273,6 +273,9 @@ export const ModelCredentialKeySchema = z.object({
   label: z.string(),
   isActive: z.boolean(),
   createdAt: z.string(),
+  availableModels: z.array(z.string()).optional(),
+  probedAt: z.string().nullable().optional(),
+  probeError: z.string().optional(),
 });
 export type ModelCredentialKey = z.infer<typeof ModelCredentialKeySchema>;
 

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -6,6 +6,7 @@ export const ProductEventType = z.enum([
   "thread.cleared",
   "thread.message.updated",
   "thread.progress",
+  "thread.reasoning",
   "thread.artifact",
   "thread.ask",
   "thread.choice",
@@ -42,6 +43,15 @@ export type ProductEventType = z.infer<typeof ProductEventType>;
 
 export const MessageRole = z.enum(["user", "bot", "system"]);
 
+export const ReasoningStepSchema = z.object({
+  id: z.string(),
+  kind: z.enum(["status", "think", "tool"]),
+  title: z.string(),
+  detail: z.string().optional(),
+  status: z.enum(["running", "done"]),
+});
+export type ReasoningStep = z.infer<typeof ReasoningStepSchema>;
+
 export const MessageBlock = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("text"), text: z.string() }),
   z.object({
@@ -76,6 +86,10 @@ export const MessageBlock = z.discriminatedUnion("kind", [
   }),
   z.object({ kind: z.literal("meta"), text: z.string() }),
   z.object({ kind: z.literal("progress"), text: z.string() }),
+  z.object({
+    kind: z.literal("reasoning"),
+    steps: z.array(ReasoningStepSchema),
+  }),
   z.object({
     kind: z.literal("subagent"),
     agentId: z.string(),

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -25,6 +25,7 @@ describe("contracts", () => {
     expect(ProductEventType.options).toContain("thread.message.created");
     expect(ProductEventType.options).toContain("thread.cleared");
     expect(ProductEventType.options).toContain("thread.subagent");
+    expect(ProductEventType.options).toContain("thread.reasoning");
     expect(ProductEventType.options).toContain("bot.spawned");
   });
 });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -110,6 +110,21 @@ export const appContract = {
     setDefault: oc
       .input(z.object({ provider: z.string(), modelId: z.string() }))
       .output(z.object({ ok: z.literal(true) })),
+    addKey: oc
+      .input(
+        z.object({
+          provider: z.string(),
+          apiKey: z.string().min(1).max(4000),
+          label: z.string().trim().min(1).max(80).optional(),
+        }),
+      )
+      .output(ModelCredentialSchema),
+    removeKey: oc
+      .input(z.object({ provider: z.string(), keyId: Id }))
+      .output(ModelCredentialSchema),
+    setActiveKey: oc
+      .input(z.object({ provider: z.string(), keyId: Id }))
+      .output(ModelCredentialSchema),
   },
   bots: {
     list: oc.output(z.array(BotSchema)),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -62,12 +62,22 @@ export const appContract = {
       .input(
         z.object({
           provider: z.string(),
-          apiKey: z.string().min(8),
+          apiKey: z.string().max(4000).optional().default(""),
           label: z.string().optional(),
           modelId: z.string().optional(),
+          baseUrl: z.string().max(500).optional(),
+          availableModels: z.array(z.string().min(1).max(200)).max(200).optional(),
         }),
       )
       .output(ModelCredentialSchema),
+    probe: oc
+      .input(
+        z.object({
+          baseUrl: z.string().min(1).max(500),
+          apiKey: z.string().max(4000).optional(),
+        }),
+      )
+      .output(z.object({ models: z.array(z.string()) })),
     beginOAuth: oc
       .input(
         z.object({

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -125,6 +125,7 @@ export const appContract = {
     setActiveKey: oc
       .input(z.object({ provider: z.string(), keyId: Id }))
       .output(ModelCredentialSchema),
+    refreshKeys: oc.input(z.object({ provider: z.string() })).output(ModelCredentialSchema),
   },
   bots: {
     list: oc.output(z.array(BotSchema)),

--- a/packages/core/src/attachments.ts
+++ b/packages/core/src/attachments.ts
@@ -90,6 +90,12 @@ export function blocksToAgentHistoryText(blocks: MessageBlock[]): string {
   return blocks
     .map((block) => {
       if (block.kind === "text") return block.text;
+      if (block.kind === "reasoning") {
+        return block.steps
+          .map((step) => [step.title, step.detail].filter(Boolean).join(": "))
+          .filter(Boolean)
+          .join("\n");
+      }
       if (block.kind === "image") return `[image: ${block.name}]`;
       if (block.kind === "file") {
         return `[file: ${block.name} (${block.mimeType}, ${block.size} bytes)]`;

--- a/packages/core/src/events.test.ts
+++ b/packages/core/src/events.test.ts
@@ -128,6 +128,70 @@ describe("projectMessages", () => {
     expect(durable[0]?.blocks[0]).toMatchObject({ status: "completed", result: "ok" });
   });
 
+  it("keeps a live reasoning trace until the completed message is durable", () => {
+    const live = projectMessages([
+      {
+        id: "e1",
+        threadId: "t1",
+        seq: 0,
+        type: "thread.reasoning",
+        runId: "r1",
+        payload: {
+          steps: [
+            {
+              id: "think",
+              kind: "think",
+              title: "Thinking",
+              detail: "checking the inbox",
+              status: "running",
+            },
+          ],
+        },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+    ]);
+    expect(live[0]?.id).toBe("reasoning:r1");
+    expect(live[0]?.blocks[0]).toMatchObject({
+      kind: "reasoning",
+      steps: [expect.objectContaining({ title: "Thinking", detail: "checking the inbox" })],
+    });
+
+    const durable = projectMessages([
+      {
+        id: "e1",
+        threadId: "t1",
+        seq: 0,
+        type: "thread.reasoning",
+        runId: "r1",
+        payload: {
+          steps: [{ id: "think", kind: "think", title: "Thinking", status: "done" }],
+        },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+      {
+        id: "e2",
+        threadId: "t1",
+        seq: 1,
+        type: "thread.message.created",
+        runId: "r1",
+        payload: {
+          messageId: "m2",
+          role: "bot",
+          blocks: [
+            {
+              kind: "reasoning",
+              steps: [{ id: "think", kind: "think", title: "Thinking", status: "done" }],
+            },
+            { kind: "text", text: "Done." },
+          ],
+        },
+        createdAt: "2026-01-01T00:00:03.000Z",
+      },
+    ]);
+    expect(durable).toHaveLength(1);
+    expect(durable[0]?.blocks.map((block) => block.kind)).toEqual(["reasoning", "text"]);
+  });
+
   it("drops prior history when a later clear event is replayed", () => {
     const messages = projectMessages([
       {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,4 +1,5 @@
 import type { MessageBlock, ThreadMessage } from "@rakazo/contracts";
+import { reasoningMessageId, reasoningStepsFromPayload } from "./reasoning.js";
 
 export function projectMessages(
   events: Array<{
@@ -13,6 +14,7 @@ export function projectMessages(
 ): ThreadMessage[] {
   const messages: ThreadMessage[] = [];
   let streaming: ThreadMessage | null = null;
+  let reasoning: ThreadMessage | null = null;
   const liveSubagents = new Map<string, ThreadMessage>();
   const durableSubagents = new Set<string>();
   for (const event of events) {
@@ -21,6 +23,7 @@ export function projectMessages(
       typeof event.createdAt === "string" ? event.createdAt : event.createdAt.toISOString();
     if (event.type === "thread.message.created") {
       streaming = null;
+      reasoning = null;
       const role = (payload.role as ThreadMessage["role"]) ?? "bot";
       const blocks = (payload.blocks as MessageBlock[]) ?? [];
       for (const block of blocks) {
@@ -58,9 +61,23 @@ export function projectMessages(
       };
       continue;
     }
+    if (event.type === "thread.reasoning") {
+      const steps = reasoningStepsFromPayload(payload);
+      reasoning = {
+        id: reasoningMessageId(event),
+        threadId: event.threadId,
+        seq: event.seq,
+        role: "bot",
+        blocks: [{ kind: "reasoning", steps }],
+        runId: event.runId ?? undefined,
+        createdAt,
+      };
+      continue;
+    }
     if (event.type === "thread.cleared") {
       messages.length = 0;
       streaming = null;
+      reasoning = null;
       liveSubagents.clear();
       durableSubagents.clear();
       continue;
@@ -85,9 +102,11 @@ export function projectMessages(
       event.type === "run.cancelled"
     ) {
       streaming = null;
+      reasoning = null;
     }
   }
   for (const live of liveSubagents.values()) messages.push(live);
+  if (reasoning) messages.push(reasoning);
   if (streaming) messages.push(streaming);
   return messages;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@ export * from "./cron.js";
 export * from "./events.js";
 export * from "./message-pages.js";
 export * from "./model-oauth.js";
-export * from "./run-state.js";
+export * from "./reasoning.js";
 export * from "./sandbox-command.js";
 export * from "./screen-lease.js";
 export * from "./search.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./events.js";
 export * from "./message-pages.js";
 export * from "./model-oauth.js";
 export * from "./reasoning.js";
+export * from "./run-state.js";
 export * from "./sandbox-command.js";
 export * from "./screen-lease.js";
 export * from "./search.js";

--- a/packages/core/src/message-pages.ts
+++ b/packages/core/src/message-pages.ts
@@ -1,3 +1,5 @@
+import { isEphemeralThreadMessageId } from "./reasoning.js";
+
 interface MessageIdentity {
   id: string;
   seq?: number;
@@ -68,5 +70,5 @@ export function mergeMessagesById<T extends { id: string }>(
 }
 
 function isDurableMessage(message: { id: string }): boolean {
-  return !message.id.startsWith("progress:") && !message.id.startsWith("subagent:");
+  return !isEphemeralThreadMessageId(message.id) && !message.id.startsWith("subagent:");
 }

--- a/packages/core/src/reasoning.test.ts
+++ b/packages/core/src/reasoning.test.ts
@@ -4,6 +4,7 @@ import {
   reasoningMessageId,
   reasoningToolTitle,
   upsertReasoningStep,
+  visibleReasoningSteps,
 } from "./reasoning.js";
 
 describe("reasoning helpers", () => {
@@ -31,6 +32,23 @@ describe("reasoning helpers", () => {
     expect(second).toHaveLength(1);
     expect(second[0]?.detail).toBe("considering files");
     expect(reasoningMessageId({ runId: "r1" })).toBe("reasoning:r1");
+  });
+
+  it("hides filler status steps from the ChatGPT-style thought body", () => {
+    expect(
+      visibleReasoningSteps([
+        { id: "status", kind: "status", title: "Working through the request", status: "running" },
+        { id: "think", kind: "think", title: "Thinking", detail: "checking files", status: "done" },
+        { id: "status-done", kind: "status", title: "Finished", status: "done" },
+        {
+          id: "err",
+          kind: "status",
+          title: "Gateway error",
+          detail: "401: bad key",
+          status: "done",
+        },
+      ]).map((step) => step.id),
+    ).toEqual(["think", "err"]);
   });
 
   it("names common tools in the trace", () => {

--- a/packages/core/src/reasoning.test.ts
+++ b/packages/core/src/reasoning.test.ts
@@ -7,9 +7,10 @@ import {
 } from "./reasoning.js";
 
 describe("reasoning helpers", () => {
-  it("identifies live progress and reasoning ids", () => {
+  it("identifies live progress, reasoning, and pending ids", () => {
     expect(isEphemeralThreadMessageId("progress:run-1")).toBe(true);
     expect(isEphemeralThreadMessageId("reasoning:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("pending:abc")).toBe(true);
     expect(isEphemeralThreadMessageId("m-1")).toBe(false);
   });
 

--- a/packages/core/src/reasoning.test.ts
+++ b/packages/core/src/reasoning.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  isEphemeralThreadMessageId,
+  reasoningMessageId,
+  reasoningToolTitle,
+  upsertReasoningStep,
+} from "./reasoning.js";
+
+describe("reasoning helpers", () => {
+  it("identifies live progress and reasoning ids", () => {
+    expect(isEphemeralThreadMessageId("progress:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("reasoning:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("m-1")).toBe(false);
+  });
+
+  it("upserts reasoning steps by id", () => {
+    const first = upsertReasoningStep([], {
+      id: "think",
+      kind: "think",
+      title: "Thinking",
+      status: "running",
+    });
+    const second = upsertReasoningStep(first, {
+      id: "think",
+      kind: "think",
+      title: "Thinking",
+      detail: "considering files",
+      status: "running",
+    });
+    expect(second).toHaveLength(1);
+    expect(second[0]?.detail).toBe("considering files");
+    expect(reasoningMessageId({ runId: "r1" })).toBe("reasoning:r1");
+  });
+
+  it("names common tools in the trace", () => {
+    expect(reasoningToolTitle("shell")).toBe("Running a command");
+    expect(reasoningToolTitle("write_file", { path: "notes/result.txt" })).toBe(
+      "Writing result.txt",
+    );
+  });
+});

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -1,0 +1,96 @@
+import type { ReasoningStep } from "@rakazo/contracts";
+
+export function isEphemeralThreadMessageId(id: string): boolean {
+  return id.startsWith("progress:") || id.startsWith("reasoning:");
+}
+
+export function reasoningMessageId(event: { runId?: string | null; id?: string }): string {
+  return `reasoning:${event.runId ?? event.id ?? "live"}`;
+}
+
+export function upsertReasoningStep(
+  steps: ReasoningStep[],
+  step: ReasoningStep,
+): ReasoningStep[] {
+  const next = steps.map((entry) => (entry.id === step.id ? { ...entry, ...step } : entry));
+  if (next.some((entry) => entry.id === step.id)) return next;
+  return [...next, step];
+}
+
+export function reasoningStepsFromPayload(payload: Record<string, unknown> | undefined): ReasoningStep[] {
+  const raw = payload?.steps;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const record = entry as Record<string, unknown>;
+    const kind = record.kind;
+    const status = record.status;
+    if (kind !== "status" && kind !== "think" && kind !== "tool") return [];
+    if (status !== "running" && status !== "done") return [];
+    return [
+      {
+        id: String(record.id ?? ""),
+        kind,
+        title: String(record.title ?? ""),
+        detail: record.detail ? String(record.detail) : undefined,
+        status,
+      },
+    ];
+  });
+}
+
+export function reasoningToolTitle(name: string, args: Record<string, unknown> = {}): string {
+  switch (name) {
+    case "shell":
+      return "Running a command";
+    case "write_file":
+      return args.path ? `Writing ${shortPath(String(args.path))}` : "Writing a file";
+    case "read_file":
+      return args.path ? `Reading ${shortPath(String(args.path))}` : "Reading a file";
+    case "list_files":
+      return "Listing files";
+    case "open_path":
+      return args.path ? `Opening ${shortPath(String(args.path))}` : "Opening a path";
+    case "computer_observe":
+      return "Looking at the screen";
+    case "computer_act":
+      return "Using the computer";
+    case "launch_app":
+      return args.application ? `Opening ${String(args.application)}` : "Opening an app";
+    case "remember":
+      return "Saving a memory";
+    case "request_takeover":
+      return "Asking you to take over";
+    case "run_subagent":
+      return args.name ? `Starting ${String(args.name)}` : "Starting a subagent";
+    case "spawn_bot":
+      return args.name ? `Creating ${String(args.name)}` : "Creating a bot";
+    case "destination.write":
+      return "Writing to a destination";
+    default:
+      return `Using ${name.replaceAll("_", " ").replaceAll(".", " ")}`;
+  }
+}
+
+export function reasoningToolDetail(
+  name: string,
+  args: Record<string, unknown> = {},
+): string | undefined {
+  if (name === "shell") return clip(String(args.command ?? ""));
+  if (name === "write_file") return clip(String(args.content ?? ""));
+  if (name === "remember") return clip(String(args.content ?? args.path ?? ""));
+  if (name === "run_subagent") return clip(String(args.task ?? ""));
+  if (name === "request_takeover") return clip(String(args.reason ?? ""));
+  return undefined;
+}
+
+function shortPath(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts.at(-1) || path;
+}
+
+function clip(value: string, max = 400): string | undefined {
+  const text = value.trim();
+  if (!text) return undefined;
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -8,16 +8,15 @@ export function reasoningMessageId(event: { runId?: string | null; id?: string }
   return `reasoning:${event.runId ?? event.id ?? "live"}`;
 }
 
-export function upsertReasoningStep(
-  steps: ReasoningStep[],
-  step: ReasoningStep,
-): ReasoningStep[] {
+export function upsertReasoningStep(steps: ReasoningStep[], step: ReasoningStep): ReasoningStep[] {
   const next = steps.map((entry) => (entry.id === step.id ? { ...entry, ...step } : entry));
   if (next.some((entry) => entry.id === step.id)) return next;
   return [...next, step];
 }
 
-export function reasoningStepsFromPayload(payload: Record<string, unknown> | undefined): ReasoningStep[] {
+export function reasoningStepsFromPayload(
+  payload: Record<string, unknown> | undefined,
+): ReasoningStep[] {
   const raw = payload?.steps;
   if (!Array.isArray(raw)) return [];
   return raw.flatMap((entry) => {

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -22,6 +22,19 @@ export function reasoningMessageId(event: { runId?: string | null; id?: string }
   return `reasoning:${event.runId ?? event.id ?? "live"}`;
 }
 
+const FILLER_REASONING_TITLES = new Set(["working through the request", "finished"]);
+
+export function visibleReasoningSteps(steps: ReasoningStep[]): ReasoningStep[] {
+  return steps.filter((step) => {
+    if (step.detail?.trim()) return true;
+    if (step.kind === "tool" || step.kind === "think") return true;
+    if (step.kind === "status") {
+      return !FILLER_REASONING_TITLES.has(step.title.trim().toLowerCase());
+    }
+    return Boolean(step.title.trim());
+  });
+}
+
 export function upsertReasoningStep(steps: ReasoningStep[], step: ReasoningStep): ReasoningStep[] {
   const next = steps.map((entry) => (entry.id === step.id ? { ...entry, ...step } : entry));
   if (next.some((entry) => entry.id === step.id)) return next;

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -1,7 +1,21 @@
 import type { ReasoningStep } from "@rakazo/contracts";
 
+export const PENDING_USER_MESSAGE_PREFIX = "pending:";
+
+export function isPendingUserMessageId(id: string): boolean {
+  return id.startsWith(PENDING_USER_MESSAGE_PREFIX);
+}
+
+export function createPendingUserMessageId(): string {
+  return `${PENDING_USER_MESSAGE_PREFIX}${crypto.randomUUID()}`;
+}
+
 export function isEphemeralThreadMessageId(id: string): boolean {
-  return id.startsWith("progress:") || id.startsWith("reasoning:");
+  return id.startsWith("progress:") || id.startsWith("reasoning:") || isPendingUserMessageId(id);
+}
+
+export function pendingUserMessageTextKey(text: string): string {
+  return `pending-text:${text}`;
 }
 
 export function reasoningMessageId(event: { runId?: string | null; id?: string }): string {

--- a/packages/core/src/speech-text.ts
+++ b/packages/core/src/speech-text.ts
@@ -198,6 +198,12 @@ export function speechFromBlocks(blocks: MessageBlock[]): string {
     .map((block) => {
       if (block.kind === "text" || block.kind === "progress" || block.kind === "meta")
         return block.text;
+      if (block.kind === "reasoning") {
+        return block.steps
+          .filter((step) => step.kind !== "think")
+          .map((step) => step.title)
+          .join(". ");
+      }
       if (block.kind === "ask") return block.text;
       if (block.kind === "computer") return block.text;
       if (block.kind === "subagent") {

--- a/packages/db/prisma/migrations/0013_gateway_and_bot_model/migration.sql
+++ b/packages/db/prisma/migrations/0013_gateway_and_bot_model/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "user_model_credentials" ADD COLUMN "baseUrl" TEXT;
+ALTER TABLE "user_model_credentials" ADD COLUMN "availableModels" TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE "bots" ADD COLUMN "modelProvider" TEXT;
+ALTER TABLE "bots" ADD COLUMN "modelId" TEXT;

--- a/packages/db/prisma/migrations/0014_model_credential_keys/migration.sql
+++ b/packages/db/prisma/migrations/0014_model_credential_keys/migration.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "user_model_credential_keys" (
+  "id" TEXT NOT NULL,
+  "credentialId" TEXT NOT NULL,
+  "secretId" TEXT NOT NULL,
+  "label" TEXT NOT NULL DEFAULT 'API key',
+  "isActive" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "user_model_credential_keys_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "user_model_credential_keys_credentialId_createdAt_id_idx"
+ON "user_model_credential_keys"("credentialId", "createdAt", "id");
+
+ALTER TABLE "user_model_credential_keys"
+ADD CONSTRAINT "user_model_credential_keys_credentialId_fkey"
+FOREIGN KEY ("credentialId") REFERENCES "user_model_credentials"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+INSERT INTO "user_model_credential_keys" ("id", "credentialId", "secretId", "label", "isActive", "createdAt")
+SELECT
+  "id",
+  "id",
+  "secretId",
+  'API key',
+  TRUE,
+  "createdAt"
+FROM "user_model_credentials";

--- a/packages/db/prisma/migrations/0015_key_model_coverage/migration.sql
+++ b/packages/db/prisma/migrations/0015_key_model_coverage/migration.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "user_model_credential_keys"
+ADD COLUMN "availableModels" TEXT NOT NULL DEFAULT '',
+ADD COLUMN "probedAt" TIMESTAMP(3),
+ADD COLUMN "probeError" TEXT NOT NULL DEFAULT '';
+
+UPDATE "user_model_credential_keys" AS k
+SET "availableModels" = c."availableModels"
+FROM "user_model_credentials" AS c
+WHERE k."credentialId" = c."id"
+  AND k."isActive" = TRUE
+  AND c."availableModels" <> '';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -183,6 +183,9 @@ model UserModelCredentialKey {
   secretId     String
   label        String   @default("API key")
   isActive     Boolean  @default(false)
+  availableModels String @default("")
+  probedAt     DateTime?
+  probeError   String   @default("")
   createdAt    DateTime @default(now())
 
   @@index([credentialId, createdAt, id])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -170,9 +170,23 @@ model UserModelCredential {
   availableModels String @default("")
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  keys         UserModelCredentialKey[]
 
   @@index([userId, workspaceId])
   @@map("user_model_credentials")
+}
+
+model UserModelCredentialKey {
+  id           String   @id @default(cuid())
+  credentialId String
+  credential   UserModelCredential @relation(fields: [credentialId], references: [id], onDelete: Cascade)
+  secretId     String
+  label        String   @default("API key")
+  isActive     Boolean  @default(false)
+  createdAt    DateTime @default(now())
+
+  @@index([credentialId, createdAt, id])
+  @@map("user_model_credential_keys")
 }
 
 model UserVoiceCredential {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -166,6 +166,8 @@ model UserModelCredential {
   secretId     String
   isDefault    Boolean  @default(false)
   defaultModel String?
+  baseUrl      String?
+  availableModels String @default("")
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
@@ -216,6 +218,8 @@ model Bot {
   computerSwitching Boolean @default(false)
   voiceId        String?
   autoSpeak      Boolean  @default(false)
+  modelProvider  String?
+  modelId        String?
   routines       Routine[]
   taughtSkills   TaughtSkill[]
   memoryDocuments MemoryDocument[]

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -543,6 +543,22 @@ export async function finalizeRun(
         runId: input.runId,
         payload: { messageId: message.id, role: "bot", blocks: input.blocks },
       });
+    } else {
+      const blocks = [{ kind: "text" as const, text: input.error }];
+      const message = await createThreadMessageInTransaction(tx, {
+        threadId: input.threadId,
+        role: "bot",
+        blocks,
+        runId: input.runId,
+      });
+      await appendEventInTransaction(tx, {
+        workspaceId: input.workspaceId,
+        threadId: input.threadId,
+        botId: input.botId,
+        type: "thread.message.created",
+        runId: input.runId,
+        payload: { messageId: message.id, role: "bot", blocks },
+      });
     }
     const lastEvent = await appendEventInTransaction(tx, {
       workspaceId: input.workspaceId,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -30,6 +30,8 @@ function mapBot(
     computer: { scope: string } | null;
     voiceId?: string | null;
     autoSpeak?: boolean;
+    modelProvider?: string | null;
+    modelId?: string | null;
   },
   preview = "",
   status = "idle",
@@ -59,6 +61,8 @@ function mapBot(
     updatedAt: bot.updatedAt.toISOString(),
     voiceId: bot.voiceId ?? null,
     autoSpeak: bot.autoSpeak ?? false,
+    modelProvider: bot.modelProvider ?? null,
+    modelId: bot.modelId ?? null,
   };
 }
 
@@ -185,6 +189,8 @@ export function createRepos(prisma: PrismaClient) {
         parentBotId?: string | null;
         computerMode?: ComputerMode;
         spawnKey?: string;
+        modelProvider?: string | null;
+        modelId?: string | null;
         initialMessage?: {
           role: "user" | "bot" | "system";
           blocks: MessageBlock[];
@@ -233,6 +239,8 @@ export function createRepos(prisma: PrismaClient) {
             parentBotId: input.parentBotId ?? null,
             computerId: teamComputer.id,
             spawnKey: input.spawnKey,
+            modelProvider: input.modelProvider ?? null,
+            modelId: input.modelId ?? null,
           },
         });
         const thread = await tx.thread.create({

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -50,22 +50,28 @@ describeWithDatabase("API authorization and resource isolation", () => {
   it("rejects unauthenticated calls to every protected RPC family", async () => {
     const calls = exhaustiveProtectedCalls([
       ["me"],
+      ["bootstrap", {}],
       ["deployment/get"],
       ["deployment/update", { signupsEnabled: true }],
       ["models/list"],
       ["models/credentials"],
       ["models/connect", { provider: "test", apiKey: "not-a-real-key" }],
+      ["models/probe", { baseUrl: "http://127.0.0.1:9/v1" }],
       ["models/beginOAuth", { provider: "openai-codex" }],
       ["models/completeOAuth", { loginId: "missing-login" }],
       ["models/finishOAuth", { loginId: "missing-login" }],
       ["models/cancelOAuth", { loginId: "missing-login" }],
       ["models/setDefault", { provider: "test", modelId: "test/model" }],
+      ["models/addKey", { provider: "test", apiKey: "not-a-real-key" }],
+      ["models/removeKey", { provider: "test", keyId: "missing-key" }],
+      ["models/setActiveKey", { provider: "test", keyId: "missing-key" }],
       ["bots/list"],
       ["bots/listArchived"],
       ["bots/get", { botId: "missing-bot" }],
       ["bots/create", botInput("Unauthenticated")],
       ["bots/duplicate", { botId: "missing-bot" }],
       ["bots/update", { botId: "missing-bot", name: "Nope" }],
+      ["bots/setComputer", { botId: "missing-bot", mode: "team" }],
       ["bots/archive", { botId: "missing-bot" }],
       ["bots/restore", { botId: "missing-bot" }],
       ["bots/remove", { botId: "missing-bot" }],
@@ -132,6 +138,15 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["connections/complete", { connectionId: "missing-connection" }],
       ["connections/revoke", { connectionId: "missing-connection" }],
       ["artifacts/list", { botId: "missing-bot" }],
+      [
+        "artifacts/create",
+        {
+          botId: "missing-bot",
+          name: "nope.txt",
+          mimeType: "text/plain",
+          contentBase64: "Tm9wZQ==",
+        },
+      ],
       ["usage/list"],
       ["usage/summary"],
       ["export/bot", { botId: "missing-bot" }],
@@ -494,6 +509,115 @@ describeWithDatabase("API authorization and resource isolation", () => {
     });
     expect(missing.status).toBeGreaterThanOrEqual(400);
     expect(await missing.text()).toMatch(/credential/i);
+
+    const addKeyDenied = await raw(app, cookie, "models/addKey", {
+      provider: "provider-a",
+      apiKey: "another-provider-a-key",
+      label: "Spare",
+    });
+    expect(addKeyDenied.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it("lets a custom endpoint keep multiple labeled API keys", async () => {
+    const cookie = await signup(app, `model-keys-${stamp}@rakazo.test`, "Model Keys");
+    const actor = await rpc<Actor>(app, cookie, "me");
+    const connected = await rpc<ModelCredential>(app, cookie, "models/connect", {
+      provider: "openai-compatible",
+      apiKey: "custom-endpoint-key-one-xxxx",
+      label: "Office vLLM",
+      modelId: "llama3.1",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    });
+    expect(connected.provider).toMatch(/^gateway:/);
+    expect(connected.hasKey).toBe(true);
+    expect(connected.keys).toHaveLength(1);
+    expect(connected.keys[0]).toMatchObject({ label: "API key", isActive: true });
+    expect(JSON.stringify(connected)).not.toContain("custom-endpoint-key");
+
+    const withSecond = await rpc<ModelCredential>(app, cookie, "models/addKey", {
+      provider: connected.provider,
+      apiKey: "custom-endpoint-key-two-xxxx",
+      label: "Pool key 2",
+    });
+    expect(withSecond.id).toBe(connected.id);
+    expect(withSecond.isDefault).toBe(true);
+    expect(withSecond.keys).toHaveLength(2);
+    const originalKey = withSecond.keys.find((key) => key.label === "API key");
+    const poolKey = withSecond.keys.find((key) => key.label === "Pool key 2");
+    expect(originalKey?.isActive).toBe(false);
+    expect(poolKey?.isActive).toBe(true);
+
+    const storedKeys = await handles.prisma.userModelCredentialKey.findMany({
+      where: { credentialId: connected.id },
+    });
+    expect(new Set(storedKeys.map((key) => key.secretId)).size).toBe(2);
+
+    const activated = await rpc<ModelCredential>(app, cookie, "models/setActiveKey", {
+      provider: connected.provider,
+      keyId: originalKey!.id,
+    });
+    expect(activated.keys.find((key) => key.id === originalKey?.id)?.isActive).toBe(true);
+    expect(activated.keys.find((key) => key.id === poolKey?.id)?.isActive).toBe(false);
+    const originalSecretId = storedKeys.find((key) => key.id === originalKey?.id)?.secretId;
+    expect(originalSecretId).toBeTruthy();
+    const afterSwitch = await handles.prisma.userModelCredential.findUniqueOrThrow({
+      where: { id: connected.id },
+    });
+    expect(afterSwitch.secretId).toBe(originalSecretId);
+
+    const removed = await rpc<ModelCredential>(app, cookie, "models/removeKey", {
+      provider: connected.provider,
+      keyId: originalKey!.id,
+    });
+    expect(removed.keys).toHaveLength(1);
+    expect(removed.keys[0]?.id).toBe(poolKey?.id);
+    expect(removed.keys[0]?.isActive).toBe(true);
+    expect(await handles.prisma.secret.findUnique({ where: { id: originalSecretId! } })).toBeNull();
+
+    const lastRemove = await raw(app, cookie, "models/removeKey", {
+      provider: connected.provider,
+      keyId: poolKey!.id,
+    });
+    expect(lastRemove.status).toBeGreaterThanOrEqual(400);
+
+    const renamed = await rpc<ModelCredential>(app, cookie, "models/connect", {
+      provider: connected.provider,
+      apiKey: "",
+      label: "Office vLLM renamed",
+      modelId: "llama3.1",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    });
+    expect(renamed.keys).toHaveLength(1);
+    expect(renamed.label).toBe("Office vLLM renamed");
+
+    const empty = await rpc<ModelCredential>(app, cookie, "models/connect", {
+      provider: "openai-compatible",
+      apiKey: "",
+      label: "Local Ollama",
+      modelId: "llama3.1",
+      baseUrl: "http://127.0.0.1:22434/v1",
+    });
+    expect(empty.provider).not.toBe(connected.provider);
+    expect(empty.hasKey).toBe(false);
+    expect(empty.keys).toEqual([]);
+    const secretsBeforeAdd = await handles.prisma.secret.count({
+      where: { userId: actor.userId, kind: "model" },
+    });
+    const added = await rpc<ModelCredential>(app, cookie, "models/addKey", {
+      provider: empty.provider,
+      apiKey: "ollama-optional-key-xxxx",
+      label: "Spare",
+    });
+    expect(added.keys).toHaveLength(1);
+    expect(added.keys[0]).toMatchObject({ label: "Spare", isActive: true });
+    expect(added.hasKey).toBe(true);
+    expect(
+      await handles.prisma.secret.count({ where: { userId: actor.userId, kind: "model" } }),
+    ).toBe(secretsBeforeAdd);
+
+    const listed = await rpc<ModelCredential[]>(app, cookie, "models/credentials");
+    expect(JSON.stringify(listed)).not.toContain("custom-endpoint-key");
+    expect(JSON.stringify(listed)).not.toContain("ollama-optional-key");
   });
 
   it("chooses the newest duplicate provider credential when selecting a default", async () => {
@@ -699,6 +823,7 @@ interface ModelCredential {
   label: string;
   hasKey: boolean;
   isDefault: boolean;
+  keys: Array<{ id: string; label: string; isActive: boolean; createdAt: string }>;
 }
 
 interface Bot {

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { appContract } from "@rakazo/contracts";
@@ -65,6 +66,7 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["models/addKey", { provider: "test", apiKey: "not-a-real-key" }],
       ["models/removeKey", { provider: "test", keyId: "missing-key" }],
       ["models/setActiveKey", { provider: "test", keyId: "missing-key" }],
+      ["models/refreshKeys", { provider: "test" }],
       ["bots/list"],
       ["bots/listArchived"],
       ["bots/get", { botId: "missing-bot" }],
@@ -620,6 +622,74 @@ describeWithDatabase("API authorization and resource isolation", () => {
     expect(JSON.stringify(listed)).not.toContain("ollama-optional-key");
   });
 
+  it("discovers which models each custom endpoint key can use", async () => {
+    const server = createServer((req, res) => {
+      if (!req.url?.endsWith("/models")) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      const auth = String(req.headers.authorization ?? "");
+      const ids = auth.includes("gemini-key")
+        ? ["gemini-2.5-pro", "gemini-2.5-flash"]
+        : auth.includes("openai-key")
+          ? ["gpt-4o", "gpt-4.1"]
+          : [];
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: ids.map((id) => ({ id })) }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    try {
+      const cookie = await signup(app, `model-coverage-${stamp}@rakazo.test`, "Model Coverage");
+      const connected = await rpc<ModelCredential>(app, cookie, "models/connect", {
+        provider: "openai-compatible",
+        apiKey: "gemini-key-xxxx-xxxx",
+        label: "Inference router",
+        modelId: "gemini-2.5-flash",
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+      });
+      expect(connected.keys).toHaveLength(1);
+      expect(connected.keys[0]).toMatchObject({
+        label: "Gemini",
+        availableModels: ["gemini-2.5-pro", "gemini-2.5-flash"],
+      });
+      expect(connected.availableModels).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
+
+      const withSecond = await rpc<ModelCredential>(app, cookie, "models/addKey", {
+        provider: connected.provider,
+        apiKey: "openai-key-xxxx-xxxx",
+      });
+      expect(withSecond.keys).toHaveLength(2);
+      const gemini = withSecond.keys.find((key) =>
+        key.availableModels?.includes("gemini-2.5-flash"),
+      );
+      const openai = withSecond.keys.find((key) => key.availableModels?.includes("gpt-4o"));
+      expect(gemini).toMatchObject({ label: "Gemini" });
+      expect(openai).toMatchObject({ label: "GPT" });
+      expect(withSecond.availableModels).toEqual(
+        expect.arrayContaining(["gemini-2.5-pro", "gemini-2.5-flash", "gpt-4o", "gpt-4.1"]),
+      );
+
+      const refreshed = await rpc<ModelCredential>(app, cookie, "models/refreshKeys", {
+        provider: connected.provider,
+      });
+      expect(refreshed.keys.find((key) => key.id === openai?.id)?.availableModels).toEqual([
+        "gpt-4o",
+        "gpt-4.1",
+      ]);
+      expect(JSON.stringify(refreshed)).not.toContain("gemini-key");
+      expect(JSON.stringify(refreshed)).not.toContain("openai-key");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("chooses the newest duplicate provider credential when selecting a default", async () => {
     const cookie = await signup(app, `model-duplicates-${stamp}@rakazo.test`, "Model Duplicates");
     const actor = await rpc<Actor>(app, cookie, "me");
@@ -823,7 +893,14 @@ interface ModelCredential {
   label: string;
   hasKey: boolean;
   isDefault: boolean;
-  keys: Array<{ id: string; label: string; isActive: boolean; createdAt: string }>;
+  keys: Array<{
+    id: string;
+    label: string;
+    isActive: boolean;
+    createdAt: string;
+    availableModels?: string[];
+  }>;
+  availableModels?: string[];
 }
 
 interface Bot {

--- a/packages/ui-web/src/bot-avatar.tsx
+++ b/packages/ui-web/src/bot-avatar.tsx
@@ -3,10 +3,12 @@ import { cn } from "./lib/utils.js";
 export function BotAvatar({
   color,
   size = 38,
+  thinking = false,
   className,
 }: {
   color: string;
   size?: number;
+  thinking?: boolean;
   className?: string;
 }) {
   const visorW = Math.round(size * 0.68);
@@ -14,7 +16,11 @@ export function BotAvatar({
   const dot = Math.max(3, Math.round(size * 0.1));
   return (
     <div
-      className={cn("flex items-center justify-center rounded-full", className)}
+      className={cn(
+        "flex items-center justify-center rounded-full",
+        thinking && "rk-avatar-think",
+        className,
+      )}
       style={{ width: size, height: size, background: color, flex: "none" }}
     >
       <div
@@ -27,8 +33,8 @@ export function BotAvatar({
           gap: Math.max(4, Math.round(size * 0.13)),
         }}
       >
-        <span className="rounded-full bg-white" style={{ width: dot, height: dot }} />
-        <span className="rounded-full bg-white" style={{ width: dot, height: dot }} />
+        <span className="rk-avatar-eye rounded-full bg-white" style={{ width: dot, height: dot }} />
+        <span className="rk-avatar-eye rounded-full bg-white" style={{ width: dot, height: dot }} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible inference gateways plus live reasoning traces in chat.

Rebased onto current `elie222/main` (includes #105 local model provider). Keeps #105's lazy `registerLocalProvider` catalog and attaches a per-request custom gateway when the bot has a base URL.

**Stack:** 1 of 6. No dependency on later split PRs.

### Gateways
- Store a custom OpenAI-compatible base URL on the bot/model credential (migration `0013_gateway_and_bot_model`).
- Multiple API keys per custom endpoint (`0014_model_credential_keys`).
- Restrict each key to the models it can actually run (`0015_key_model_coverage`).
- Settings UI (web + mobile) to paste a gateway URL and manage keys.

### Reasoning and reliability
- Stream live reasoning / thought traces into the transcript.
- Treat a missing stream `finish_reason` as a normal stop (common on local/custom servers).
- Show the user's message immediately; recover empty model replies instead of hanging.
- Surface the gateway's own error text in chat.
- Persist gateway errors on the run instead of marking empty runs complete.
- Sent-message animation, thinking avatars, and working status.
- Faster chat updates and ChatGPT-style thought UI.

## Test plan
- [ ] `pnpm check` / adapters tests for `openai-compatible` and stream-close
- [ ] Add a custom endpoint + key in Model Settings; start a bot; confirm a reply
- [ ] Force a bad gateway URL and confirm the provider error appears in chat (run is not silently completed)
- [ ] Confirm #105 local models (`RAKAZO_LOCAL_MODELS`) still appear in the catalog

## Known limitations
- Vercel deploy authorization on fork PRs is an elie222 org OAuth setting; this PR cannot grant that.
- Later product work (bot DMs, channels, self-update) is **not** in this PR.
