### PR TITLE
Fix streaming correctness and persist gateway errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Rakazo is in beta. Learn more at [rakazo.com](https://rakazo.com).
 ## Features
 
 - Persistent bots with their own conversations, memory, routines, and history
-- Voice mode: speak replies, dictate, and call a bot. Bring your own ElevenLabs, OpenAI, or Cartesia key
+- Live reasoning traces while a bot runs (thinking, tools, and status — not a generic “working…” spinner)
 - Shared Team Computers and isolated Private computers
 - Browser, terminal, file, and graphical desktop access
 - Bots that can delegate to peer bots or short-lived subagents
-- Bring-your-own model credentials through Pi
+- Bring-your-own model credentials through Pi, including OpenAI-compatible base URLs
+- Multiple inference providers, with a model chosen per bot
+- Voice mode: speak replies, dictate, and call a bot. Bring your own ElevenLabs, OpenAI, or Cartesia key
 - Optional app integrations through Composio
 - Docker, E2B, Daytona, and trusted local-computer support
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Rakazo is in beta. Learn more at [rakazo.com](https://rakazo.com).
 - Shared Team Computers and isolated Private computers
 - Browser, terminal, file, and graphical desktop access
 - Bots that can delegate to peer bots or short-lived subagents
-- Bring-your-own model credentials through Pi
+- Bring-your-own model credentials through Pi, including OpenAI-compatible base URLs and multiple API keys per custom endpoint. Rakazo discovers which models each key can run and picks the matching key automatically.
 - Optional app integrations through Composio
 - Docker, E2B, Daytona, and trusted local-computer support
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -22,24 +22,23 @@ import {
   type ComputerExecutionLease,
   checkpointAndRecordComputerWorkspace,
   createVoiceProvider,
+  customEndpointCatalogEntry,
   deleteSupermemoryContainer,
   destroyBot,
   displayBotWorkspacePath,
   type EncryptedSecretStore,
   expireComputerControl,
+  fetchOpenAICompatibleModels,
+  gatewayCatalogEntries,
   hasActiveComputerControl,
+  isGatewayProvider,
   isSupermemoryEnabled,
   listPiCatalog,
   mintGatewayProviderId,
   normalizeOpenAICompatibleBaseUrl,
-  fetchOpenAICompatibleModels,
-  gatewayCatalogEntries,
-  customEndpointCatalogEntry,
-  isGatewayProvider,
   OPENAI_COMPATIBLE_PROVIDER,
-  parseAvailableModels,
-  serializeAvailableModels,
   type PiOAuthLogins,
+  parseAvailableModels,
   provisionComputer,
   releaseComputerExecutionLease,
   resolveBotWorkspacePath,
@@ -49,6 +48,7 @@ import {
   scheduleComputerSleep,
   screenLeaseIdForRun,
   scriptedCatalogEntry,
+  serializeAvailableModels,
   serializeModelSecret,
   supermemoryContainerTag,
   takeoverLeaseMs,
@@ -244,11 +244,7 @@ export function createRouter(deps: RouterDeps) {
         throwIfAborted(context.signal);
         try {
           return {
-            models: await fetchOpenAICompatibleModels(
-              input.baseUrl,
-              input.apiKey,
-              context.signal,
-            ),
+            models: await fetchOpenAICompatibleModels(input.baseUrl, input.apiKey, context.signal),
           };
         } catch (error) {
           throw new ORPCError("BAD_REQUEST", {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -17,6 +17,7 @@ import {
   acquireComputerExecutionLease,
   applyTeachingDesktopInput,
   archiveBot,
+  assertOpenAICompatibleEndpointAllowed,
   type ComposioProvider,
   ComputerBusyError,
   type ComputerExecutionLease,
@@ -2031,9 +2032,15 @@ async function persistModelCredential(
 ) {
   throwIfAborted(input.signal);
   const plaintext = input.plaintext.trim();
-  const appendKey = Boolean(input.appendKey || (input.baseUrl && plaintext));
-  const makeDefault = input.setDefault !== false;
   const existing = await findWorkspaceModelCredential(deps.prisma, actor, input.provider);
+  const baseUrl =
+    input.baseUrl && input.baseUrl !== existing?.baseUrl
+      ? await assertOpenAICompatibleEndpointAllowed(input.baseUrl, {
+          allowPrivateNetwork: actor.isDeploymentOwner,
+        })
+      : input.baseUrl;
+  const appendKey = Boolean(input.appendKey || (baseUrl && plaintext));
+  const makeDefault = input.setDefault !== false;
   if (!plaintext && existing && !appendKey) {
     const updated = await withSerializableRetry(() =>
       deps.prisma.$transaction(
@@ -2051,7 +2058,7 @@ async function persistModelCredential(
               label: input.label ?? existing.label,
               isDefault: makeDefault ? true : existing.isDefault,
               defaultModel: input.modelId || existing.defaultModel || deps.env.defaultModel,
-              baseUrl: input.baseUrl ?? existing.baseUrl,
+              baseUrl: baseUrl ?? existing.baseUrl,
               availableModels:
                 input.availableModels !== undefined
                   ? serializeAvailableModels(input.availableModels)
@@ -2131,6 +2138,11 @@ async function persistModelCredential(
         }
 
         if (appendKey && isGatewayProvider(current.provider)) {
+          if (current.keys.length >= 20) {
+            throw new ORPCError("BAD_REQUEST", {
+              message: "A custom endpoint can store at most 20 API keys.",
+            });
+          }
           const previousSecretId = current.secretId;
           if (current.keys.length) {
             await tx.userModelCredentialKey.updateMany({
@@ -2153,7 +2165,7 @@ async function persistModelCredential(
               secretId: secret.id,
               isDefault: makeDefault ? true : current.isDefault,
               defaultModel: input.modelId || current.defaultModel || deps.env.defaultModel,
-              baseUrl: input.baseUrl ?? current.baseUrl,
+              baseUrl: baseUrl ?? current.baseUrl,
               availableModels:
                 input.availableModels !== undefined
                   ? serializeAvailableModels(input.availableModels)
@@ -2182,7 +2194,7 @@ async function persistModelCredential(
             secretId: secret.id,
             isDefault: makeDefault ? true : current.isDefault,
             defaultModel: input.modelId || current.defaultModel || deps.env.defaultModel,
-            baseUrl: input.baseUrl ?? current.baseUrl,
+            baseUrl: baseUrl ?? current.baseUrl,
             availableModels:
               input.availableModels !== undefined
                 ? serializeAvailableModels(input.availableModels)
@@ -2199,7 +2211,21 @@ async function persistModelCredential(
   );
   const dto = await loadCredentialDto(deps.prisma, cred.id);
   if (plaintext && isGatewayProvider(dto.provider) && dto.baseUrl) {
-    return discoverModelsForActiveGatewayKey(deps, dto, plaintext, input.keyLabel, input.signal);
+    const savedKey = await deps.prisma.userModelCredentialKey.findFirst({
+      where: { credentialId: cred.id, secretId: stored.id },
+      select: { id: true },
+    });
+    if (savedKey) {
+      return discoverModelsForGatewayKey(
+        deps,
+        dto,
+        savedKey.id,
+        plaintext,
+        input.keyLabel,
+        actor.isDeploymentOwner,
+        input.signal,
+      );
+    }
   }
   return dto;
 }
@@ -2294,29 +2320,31 @@ async function setActiveModelCredentialKey(
   return loadCredentialDto(deps.prisma, updatedId);
 }
 
-async function discoverModelsForActiveGatewayKey(
+async function discoverModelsForGatewayKey(
   deps: RouterDeps,
   credential: ModelCredential,
+  keyId: string,
   plaintext: string,
   requestedLabel: string | undefined,
+  allowPrivateNetwork: boolean,
   signal?: AbortSignal,
 ) {
   if (!credential.baseUrl) return credential;
   throwIfAborted(signal);
-  const discovered = await tryFetchOpenAICompatibleModels(credential.baseUrl, plaintext, signal);
-  const row = await deps.prisma.userModelCredential.findUnique({
-    where: { id: credential.id },
-    include: credentialKeyInclude,
+  const discovered = await tryFetchOpenAICompatibleModels(credential.baseUrl, plaintext, signal, {
+    allowPrivateNetwork,
   });
-  const active = row?.keys.find((key) => key.isActive) ?? row?.keys.at(-1);
-  if (!row || !active) return credential;
+  const key = await deps.prisma.userModelCredentialKey.findFirst({
+    where: { id: keyId, credentialId: credential.id },
+  });
+  if (!key) return loadCredentialDto(deps.prisma, credential.id);
   const nextLabel =
     requestedLabel?.trim() ||
-    (active.label && active.label !== "API key"
-      ? active.label
-      : labelForDiscoveredModels(discovered.models, active.label || "API key"));
-  await deps.prisma.userModelCredentialKey.update({
-    where: { id: active.id },
+    (key.label && key.label !== "API key"
+      ? key.label
+      : labelForDiscoveredModels(discovered.models, key.label || "API key"));
+  await deps.prisma.userModelCredentialKey.updateMany({
+    where: { id: key.id, credentialId: credential.id },
     data: {
       availableModels: serializeAvailableModels(discovered.models),
       probedAt: new Date(),
@@ -2324,8 +2352,12 @@ async function discoverModelsForActiveGatewayKey(
       label: nextLabel,
     },
   });
-  await recomputeCredentialAvailableModels(deps.prisma, row.id, row.availableModels);
-  return loadCredentialDto(deps.prisma, row.id);
+  await recomputeCredentialAvailableModels(
+    deps.prisma,
+    credential.id,
+    serializeAvailableModels(credential.availableModels ?? []),
+  );
+  return loadCredentialDto(deps.prisma, credential.id);
 }
 
 async function refreshGatewayKeyCoverage(
@@ -2345,38 +2377,63 @@ async function refreshGatewayKeyCoverage(
     });
   }
   throwIfAborted(signal);
-  for (const key of credential.keys) {
-    throwIfAborted(signal);
-    const secret = await deps.prisma.secret.findUnique({ where: { id: key.secretId } });
-    if (!secret) {
-      await deps.prisma.userModelCredentialKey.update({
-        where: { id: key.id },
-        data: {
-          availableModels: "",
-          probedAt: new Date(),
-          probeError: "API key is missing.",
-        },
-      });
-      continue;
-    }
-    const parsed = parseModelSecret(deps.secrets.load(secret.ciphertext));
-    const apiKey = parsed.kind === "api_key" ? parsed.key : "";
-    const discovered = apiKey
-      ? await tryFetchOpenAICompatibleModels(credential.baseUrl, apiKey, signal)
-      : { models: [] as string[], error: "This key cannot list models." };
-    const nextLabel =
-      key.label && key.label !== "API key"
-        ? key.label
-        : labelForDiscoveredModels(discovered.models, key.label || "API key");
-    await deps.prisma.userModelCredentialKey.update({
-      where: { id: key.id },
-      data: {
-        availableModels: serializeAvailableModels(discovered.models),
-        probedAt: new Date(),
-        probeError: discovered.error,
-        label: nextLabel,
-      },
-    });
+  for (let offset = 0; offset < credential.keys.length; offset += 4) {
+    await Promise.all(
+      credential.keys.slice(offset, offset + 4).map(async (key) => {
+        throwIfAborted(signal);
+        const secret = await deps.prisma.secret.findFirst({
+          where: {
+            id: key.secretId,
+            userId: actor.userId,
+            workspaceId: actor.workspaceId,
+          },
+        });
+        if (!secret) {
+          await deps.prisma.userModelCredentialKey.updateMany({
+            where: { id: key.id, credentialId: credential.id },
+            data: {
+              availableModels: "",
+              probedAt: new Date(),
+              probeError: "API key is missing.",
+            },
+          });
+          return;
+        }
+        let apiKey = "";
+        try {
+          const parsed = parseModelSecret(deps.secrets.load(secret.ciphertext));
+          apiKey = parsed.kind === "api_key" ? parsed.key : "";
+        } catch {
+          await deps.prisma.userModelCredentialKey.updateMany({
+            where: { id: key.id, credentialId: credential.id },
+            data: {
+              availableModels: "",
+              probedAt: new Date(),
+              probeError: "API key could not be read.",
+            },
+          });
+          return;
+        }
+        const discovered = apiKey
+          ? await tryFetchOpenAICompatibleModels(credential.baseUrl!, apiKey, signal, {
+              allowPrivateNetwork: actor.isDeploymentOwner,
+            })
+          : { models: [] as string[], error: "This key cannot list models." };
+        const nextLabel =
+          key.label && key.label !== "API key"
+            ? key.label
+            : labelForDiscoveredModels(discovered.models, key.label || "API key");
+        await deps.prisma.userModelCredentialKey.updateMany({
+          where: { id: key.id, credentialId: credential.id },
+          data: {
+            availableModels: serializeAvailableModels(discovered.models),
+            probedAt: new Date(),
+            probeError: discovered.error,
+            label: nextLabel,
+          },
+        });
+      }),
+    );
   }
   await recomputeCredentialAvailableModels(deps.prisma, credential.id, credential.availableModels);
   return loadCredentialDto(deps.prisma, credential.id);

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -30,6 +30,15 @@ import {
   hasActiveComputerControl,
   isSupermemoryEnabled,
   listPiCatalog,
+  mintGatewayProviderId,
+  normalizeOpenAICompatibleBaseUrl,
+  fetchOpenAICompatibleModels,
+  gatewayCatalogEntries,
+  customEndpointCatalogEntry,
+  isGatewayProvider,
+  OPENAI_COMPATIBLE_PROVIDER,
+  parseAvailableModels,
+  serializeAvailableModels,
   type PiOAuthLogins,
   provisionComputer,
   releaseComputerExecutionLease,
@@ -52,6 +61,7 @@ import {
   appContract,
   type ComputerStatus,
   type Me,
+  type ModelCredential,
   type ThreadSnapshot,
 } from "@rakazo/contracts";
 import {
@@ -203,21 +213,76 @@ export function createRouter(deps: RouterDeps) {
       }),
     },
     models: {
-      list: authed.models.list.handler(async () => [...listPiCatalog(), scriptedCatalogEntry]),
+      list: authed.models.list.handler(async ({ context }) => {
+        const rows = await deps.prisma.userModelCredential.findMany({
+          where: { userId: context.actor.userId, workspaceId: context.actor.workspaceId },
+          orderBy: newestModelCredentialOrder,
+        });
+        return [
+          customEndpointCatalogEntry,
+          ...listPiCatalog(),
+          scriptedCatalogEntry,
+          ...gatewayCatalogEntries(
+            rows.map((row) => ({
+              provider: row.provider,
+              label: row.label,
+              baseUrl: row.baseUrl,
+              defaultModel: row.defaultModel,
+              availableModels: parseAvailableModels(row.availableModels),
+            })),
+          ),
+        ];
+      }),
       credentials: authed.models.credentials.handler(async ({ context }) => {
         const rows = await deps.prisma.userModelCredential.findMany({
           where: { userId: context.actor.userId, workspaceId: context.actor.workspaceId },
           orderBy: newestModelCredentialOrder,
         });
-        return rows.map((row) => ({
-          id: row.id,
-          provider: row.provider,
-          label: row.label,
-          hasKey: true,
-          isDefault: row.isDefault,
-        }));
+        return rows.map((row) => credentialDto(row));
+      }),
+      probe: authed.models.probe.handler(async ({ input, context }) => {
+        throwIfAborted(context.signal);
+        try {
+          return {
+            models: await fetchOpenAICompatibleModels(
+              input.baseUrl,
+              input.apiKey,
+              context.signal,
+            ),
+          };
+        } catch (error) {
+          throw new ORPCError("BAD_REQUEST", {
+            message: error instanceof Error ? error.message : "Could not list models",
+          });
+        }
       }),
       connect: authed.models.connect.handler(async ({ context, input }) => {
+        if (input.baseUrl) {
+          let baseUrl: string;
+          try {
+            baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl);
+          } catch (error) {
+            throw new ORPCError("BAD_REQUEST", {
+              message: error instanceof Error ? error.message : "Invalid base URL",
+            });
+          }
+          const provider =
+            isGatewayProvider(input.provider) && input.provider !== OPENAI_COMPATIBLE_PROVIDER
+              ? input.provider
+              : mintGatewayProviderId();
+          return persistModelCredential(deps, context.actor, {
+            provider,
+            plaintext: input.apiKey,
+            label: input.label ?? "Custom endpoint",
+            modelId: input.modelId,
+            baseUrl,
+            availableModels: input.availableModels,
+            signal: context.signal,
+          });
+        }
+        if (input.apiKey.trim().length < 8) {
+          throw new ORPCError("BAD_REQUEST", { message: "API key is too short" });
+        }
         return persistModelCredential(deps, context.actor, {
           provider: input.provider,
           plaintext: input.apiKey,
@@ -328,6 +393,8 @@ export function createRouter(deps: RouterDeps) {
           notifyOnFinish: source.notifyOnFinish,
           color: source.color,
           computerMode: source.computer?.scope === "dedicated" ? "dedicated" : "team",
+          modelProvider: source.modelProvider,
+          modelId: source.modelId,
         });
       }),
       update: authed.bots.update.handler(async ({ context, input }) => {
@@ -356,6 +423,8 @@ export function createRouter(deps: RouterDeps) {
             sectionId: input.sectionId,
             voiceId: input.voiceId,
             autoSpeak: input.autoSpeak,
+            modelProvider: input.modelProvider,
+            modelId: input.modelId,
           },
         });
         const bots = await repos.listBots(context.actor);
@@ -1748,7 +1817,7 @@ async function snapshot(deps: RouterDeps, actor: Actor, botId: string): Promise<
         where: {
           threadId: bot.thread.id,
           runId: run.id,
-          type: { in: ["thread.progress", "thread.subagent"] },
+          type: { in: ["thread.progress", "thread.subagent", "thread.reasoning"] },
         },
         orderBy: { seq: "asc" },
       })
@@ -1756,7 +1825,8 @@ async function snapshot(deps: RouterDeps, actor: Actor, botId: string): Promise<
   const projected = projectMessages(liveEvents);
   const persisted = messagePage.messages;
   const live = projected.filter((message) => {
-    if (message.blocks.some((block) => block.kind === "progress")) return true;
+    if (message.blocks.some((block) => block.kind === "progress" || block.kind === "reasoning"))
+      return true;
     if (!message.id.startsWith("subagent:")) return false;
     return !persisted.some((row) =>
       row.blocks.some(
@@ -1810,6 +1880,27 @@ async function meDto(deps: RouterDeps, actor: Actor): Promise<Me> {
     defaultModel: cred?.defaultModel ?? settings?.defaultModelId ?? deps.env.defaultModel,
     computerHost: computerHostFor(settings?.computerHost, deps.env.sandboxProvider),
     canChooseHostComputer: actor.isDeploymentOwner && deps.env.sandboxProvider === "docker",
+  };
+}
+
+function credentialDto(row: {
+  id: string;
+  provider: string;
+  label: string;
+  isDefault: boolean;
+  defaultModel: string | null;
+  baseUrl: string | null;
+  availableModels: string;
+}): ModelCredential {
+  return {
+    id: row.id,
+    provider: row.provider,
+    label: row.label,
+    hasKey: true,
+    isDefault: row.isDefault,
+    defaultModel: row.defaultModel,
+    baseUrl: row.baseUrl,
+    availableModels: parseAvailableModels(row.availableModels),
   };
 }
 
@@ -1926,6 +2017,8 @@ async function persistModelCredential(
     plaintext: string;
     label?: string;
     modelId?: string;
+    baseUrl?: string;
+    availableModels?: string[];
     signal?: AbortSignal;
   },
 ) {
@@ -1975,7 +2068,9 @@ async function persistModelCredential(
               label: input.label ?? input.provider,
               secretId: secret.id,
               isDefault: true,
-              defaultModel: input.modelId ?? deps.env.defaultModel,
+              defaultModel: input.modelId || deps.env.defaultModel,
+              baseUrl: input.baseUrl,
+              availableModels: serializeAvailableModels(input.availableModels ?? []),
             },
           });
           throwIfAborted(input.signal);
@@ -1987,7 +2082,12 @@ async function persistModelCredential(
             label: input.label ?? input.provider,
             secretId: secret.id,
             isDefault: true,
-            defaultModel: input.modelId ?? deps.env.defaultModel,
+            defaultModel: input.modelId || existing.defaultModel || deps.env.defaultModel,
+            baseUrl: input.baseUrl ?? existing.baseUrl,
+            availableModels:
+              input.availableModels !== undefined
+                ? serializeAvailableModels(input.availableModels)
+                : existing.availableModels,
           },
         });
         throwIfAborted(input.signal);
@@ -2004,13 +2104,7 @@ async function persistModelCredential(
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     ),
   );
-  return {
-    id: cred.id,
-    provider: cred.provider,
-    label: cred.label,
-    hasKey: true,
-    isDefault: true,
-  };
+  return credentialDto(cred);
 }
 
 function throwIfAborted(signal?: AbortSignal) {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -29,8 +29,11 @@ import {
   expireComputerControl,
   hasActiveComputerControl,
   isSupermemoryEnabled,
+  labelForDiscoveredModels,
   listPiCatalog,
   type PiOAuthLogins,
+  parseAvailableModels,
+  parseModelSecret,
   provisionComputer,
   releaseComputerExecutionLease,
   resolveBotWorkspacePath,
@@ -45,6 +48,8 @@ import {
   takeoverLeaseMs,
   toComputerRef,
   touchRunningComputer,
+  tryFetchOpenAICompatibleModels,
+  unionAvailableModels,
 } from "@rakazo/adapters";
 import type { Auth } from "@rakazo/auth";
 import {
@@ -208,6 +213,7 @@ export function createRouter(deps: RouterDeps) {
         const rows = await deps.prisma.userModelCredential.findMany({
           where: { userId: context.actor.userId, workspaceId: context.actor.workspaceId },
           orderBy: newestModelCredentialOrder,
+          include: credentialKeyInclude,
         });
         return rows.map((row) => ({
           id: row.id,
@@ -304,6 +310,36 @@ export function createRouter(deps: RouterDeps) {
         );
         return { ok: true as const };
       }),
+      addKey: authed.models.addKey.handler(async ({ context, input }) => {
+        const credential = await findWorkspaceModelCredential(
+          deps.prisma,
+          context.actor,
+          input.provider,
+        );
+        if (!credential || !isGatewayProvider(credential.provider) || !credential.baseUrl) {
+          throw new ORPCError("BAD_REQUEST", {
+            message: "Connect a custom endpoint before adding API keys.",
+          });
+        }
+        return persistModelCredential(deps, context.actor, {
+          provider: credential.provider,
+          plaintext: input.apiKey,
+          label: credential.label,
+          keyLabel: input.label,
+          appendKey: true,
+          setDefault: false,
+          signal: context.signal,
+        });
+      }),
+      removeKey: authed.models.removeKey.handler(async ({ context, input }) =>
+        removeModelCredentialKey(deps, context.actor, input.provider, input.keyId),
+      ),
+      setActiveKey: authed.models.setActiveKey.handler(async ({ context, input }) =>
+        setActiveModelCredentialKey(deps, context.actor, input.provider, input.keyId),
+      ),
+      refreshKeys: authed.models.refreshKeys.handler(async ({ context, input }) =>
+        refreshGatewayKeyCoverage(deps, context.actor, input.provider, context.signal),
+      ),
     },
     bots: {
       list: authed.bots.list.handler(async ({ context }) => repos.listBots(context.actor)),
@@ -1813,6 +1849,65 @@ async function meDto(deps: RouterDeps, actor: Actor): Promise<Me> {
   };
 }
 
+function credentialDto(row: {
+  id: string;
+  provider: string;
+  label: string;
+  isDefault: boolean;
+  defaultModel: string | null;
+  baseUrl: string | null;
+  availableModels: string;
+  keys?: Array<{
+    id: string;
+    label: string;
+    isActive: boolean;
+    createdAt: Date;
+    availableModels?: string;
+    probedAt?: Date | null;
+    probeError?: string;
+  }>;
+}): ModelCredential {
+  const keys = (row.keys ?? []).map((key) => ({
+    id: key.id,
+    label: key.label,
+    isActive: key.isActive,
+    createdAt: key.createdAt.toISOString(),
+    availableModels: parseAvailableModels(key.availableModels),
+    probedAt: key.probedAt?.toISOString() ?? null,
+    probeError: key.probeError || undefined,
+  }));
+  return {
+    id: row.id,
+    provider: row.provider,
+    label: row.label,
+    hasKey: keys.length > 0,
+    isDefault: row.isDefault,
+    defaultModel: row.defaultModel,
+    baseUrl: row.baseUrl,
+    availableModels: parseAvailableModels(row.availableModels),
+    keys,
+  };
+}
+
+const credentialKeyInclude = {
+  keys: { orderBy: [{ createdAt: "asc" as const }, { id: "asc" as const }] },
+};
+
+async function loadCredentialDto(prisma: PrismaClient, id: string): Promise<ModelCredential> {
+  const row = await prisma.userModelCredential.findUniqueOrThrow({
+    where: { id },
+    include: credentialKeyInclude,
+  });
+  return credentialDto(row);
+}
+
+function findWorkspaceModelCredential(prisma: PrismaClient, actor: Actor, provider: string) {
+  return prisma.userModelCredential.findFirst({
+    where: { userId: actor.userId, workspaceId: actor.workspaceId, provider },
+    orderBy: newestModelCredentialOrder,
+  });
+}
+
 async function computerStatus(
   deps: RouterDeps,
   actor: Actor,
@@ -1925,12 +2020,52 @@ async function persistModelCredential(
     provider: string;
     plaintext: string;
     label?: string;
+    keyLabel?: string;
     modelId?: string;
+    baseUrl?: string;
+    availableModels?: string[];
+    appendKey?: boolean;
+    setDefault?: boolean;
     signal?: AbortSignal;
   },
 ) {
   throwIfAborted(input.signal);
-  const stored = await deps.secrets.put(input.plaintext, {
+  const plaintext = input.plaintext.trim();
+  const appendKey = Boolean(input.appendKey || (input.baseUrl && plaintext));
+  const makeDefault = input.setDefault !== false;
+  const existing = await findWorkspaceModelCredential(deps.prisma, actor, input.provider);
+  if (!plaintext && existing && !appendKey) {
+    const updated = await withSerializableRetry(() =>
+      deps.prisma.$transaction(
+        async (tx) => {
+          throwIfAborted(input.signal);
+          if (makeDefault) {
+            await tx.userModelCredential.updateMany({
+              where: { userId: actor.userId, workspaceId: actor.workspaceId },
+              data: { isDefault: false },
+            });
+          }
+          return tx.userModelCredential.update({
+            where: { id: existing.id },
+            data: {
+              label: input.label ?? existing.label,
+              isDefault: makeDefault ? true : existing.isDefault,
+              defaultModel: input.modelId || existing.defaultModel || deps.env.defaultModel,
+              baseUrl: input.baseUrl ?? existing.baseUrl,
+              availableModels:
+                input.availableModels !== undefined
+                  ? serializeAvailableModels(input.availableModels)
+                  : existing.availableModels,
+            },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      ),
+    );
+    return loadCredentialDto(deps.prisma, updated.id);
+  }
+
+  const stored = await deps.secrets.put(plaintext, {
     operationId: "cred",
     traceId: "cred",
     workspaceId: actor.workspaceId,
@@ -1942,13 +2077,14 @@ async function persistModelCredential(
     deps.prisma.$transaction(
       async (tx) => {
         throwIfAborted(input.signal);
-        const existing = await tx.userModelCredential.findFirst({
+        const current = await tx.userModelCredential.findFirst({
           where: {
             userId: actor.userId,
             workspaceId: actor.workspaceId,
             provider: input.provider,
           },
           orderBy: newestModelCredentialOrder,
+          include: credentialKeyInclude,
         });
         throwIfAborted(input.signal);
         const secret = await tx.secret.create({
@@ -1961,12 +2097,14 @@ async function persistModelCredential(
           },
         });
         throwIfAborted(input.signal);
-        await tx.userModelCredential.updateMany({
-          where: { userId: actor.userId, workspaceId: actor.workspaceId },
-          data: { isDefault: false },
-        });
+        if (makeDefault) {
+          await tx.userModelCredential.updateMany({
+            where: { userId: actor.userId, workspaceId: actor.workspaceId },
+            data: { isDefault: false },
+          });
+        }
         throwIfAborted(input.signal);
-        if (!existing) {
+        if (!current) {
           const created = await tx.userModelCredential.create({
             data: {
               userId: actor.userId,
@@ -1978,39 +2116,297 @@ async function persistModelCredential(
               defaultModel: input.modelId ?? deps.env.defaultModel,
             },
           });
+          if (plaintext) {
+            await tx.userModelCredentialKey.create({
+              data: {
+                credentialId: created.id,
+                secretId: secret.id,
+                label: input.keyLabel ?? "API key",
+                isActive: true,
+              },
+            });
+          }
           throwIfAborted(input.signal);
           return created;
         }
+
+        if (appendKey && isGatewayProvider(current.provider)) {
+          const previousSecretId = current.secretId;
+          if (current.keys.length) {
+            await tx.userModelCredentialKey.updateMany({
+              where: { credentialId: current.id },
+              data: { isActive: false },
+            });
+          }
+          await tx.userModelCredentialKey.create({
+            data: {
+              credentialId: current.id,
+              secretId: secret.id,
+              label: input.keyLabel ?? "API key",
+              isActive: true,
+            },
+          });
+          const updated = await tx.userModelCredential.update({
+            where: { id: current.id },
+            data: {
+              label: input.label ?? current.label,
+              secretId: secret.id,
+              isDefault: makeDefault ? true : current.isDefault,
+              defaultModel: input.modelId || current.defaultModel || deps.env.defaultModel,
+              baseUrl: input.baseUrl ?? current.baseUrl,
+              availableModels:
+                input.availableModels !== undefined
+                  ? serializeAvailableModels(input.availableModels)
+                  : current.availableModels,
+            },
+          });
+          await deleteSecretIfUnused(tx, previousSecretId);
+          return updated;
+        }
+
+        await tx.userModelCredentialKey.deleteMany({ where: { credentialId: current.id } });
+        if (plaintext) {
+          await tx.userModelCredentialKey.create({
+            data: {
+              credentialId: current.id,
+              secretId: secret.id,
+              label: input.keyLabel ?? "API key",
+              isActive: true,
+            },
+          });
+        }
         const updated = await tx.userModelCredential.update({
-          where: { id: existing.id },
+          where: { id: current.id },
           data: {
             label: input.label ?? input.provider,
             secretId: secret.id,
-            isDefault: true,
-            defaultModel: input.modelId ?? deps.env.defaultModel,
+            isDefault: makeDefault ? true : current.isDefault,
+            defaultModel: input.modelId || current.defaultModel || deps.env.defaultModel,
+            baseUrl: input.baseUrl ?? current.baseUrl,
+            availableModels:
+              input.availableModels !== undefined
+                ? serializeAvailableModels(input.availableModels)
+                : current.availableModels,
           },
         });
         throwIfAborted(input.signal);
-        const sharedSecret = await tx.userModelCredential.count({
-          where: { id: { not: existing.id }, secretId: existing.secretId },
-        });
+        await deleteSecretIfUnused(tx, current.secretId);
         throwIfAborted(input.signal);
-        if (sharedSecret === 0) {
-          await tx.secret.deleteMany({ where: { id: existing.secretId } });
-          throwIfAborted(input.signal);
-        }
         return updated;
       },
       { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
     ),
   );
-  return {
-    id: cred.id,
-    provider: cred.provider,
-    label: cred.label,
-    hasKey: true,
-    isDefault: true,
-  };
+  const dto = await loadCredentialDto(deps.prisma, cred.id);
+  if (plaintext && isGatewayProvider(dto.provider) && dto.baseUrl) {
+    return discoverModelsForActiveGatewayKey(deps, dto, plaintext, input.keyLabel, input.signal);
+  }
+  return dto;
+}
+
+async function removeModelCredentialKey(
+  deps: RouterDeps,
+  actor: Actor,
+  provider: string,
+  keyId: string,
+) {
+  const updatedId = await withSerializableRetry(() =>
+    deps.prisma.$transaction(
+      async (tx) => {
+        const credential = await tx.userModelCredential.findFirst({
+          where: { userId: actor.userId, workspaceId: actor.workspaceId, provider },
+          orderBy: newestModelCredentialOrder,
+          include: credentialKeyInclude,
+        });
+        if (!credential || !isGatewayProvider(credential.provider)) {
+          throw new ORPCError("NOT_FOUND", { message: "Custom endpoint not found." });
+        }
+        const key = credential.keys.find((entry) => entry.id === keyId);
+        if (!key) throw new ORPCError("NOT_FOUND", { message: "API key not found." });
+        if (credential.keys.length < 2) {
+          throw new ORPCError("BAD_REQUEST", {
+            message: "Keep at least one API key, or connect the endpoint without a key.",
+          });
+        }
+        await tx.userModelCredentialKey.delete({ where: { id: key.id } });
+        const remaining = credential.keys.filter((entry) => entry.id !== key.id);
+        const nextActive = remaining.find((entry) => entry.isActive) ?? remaining.at(-1)!;
+        await tx.userModelCredentialKey.updateMany({
+          where: { credentialId: credential.id },
+          data: { isActive: false },
+        });
+        await tx.userModelCredentialKey.update({
+          where: { id: nextActive.id },
+          data: { isActive: true },
+        });
+        await tx.userModelCredential.update({
+          where: { id: credential.id },
+          data: {
+            secretId: nextActive.secretId,
+            availableModels: serializeAvailableModels(unionAvailableModels(remaining)),
+          },
+        });
+        await deleteSecretIfUnused(tx, key.secretId);
+        return credential.id;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    ),
+  );
+  return loadCredentialDto(deps.prisma, updatedId);
+}
+
+async function setActiveModelCredentialKey(
+  deps: RouterDeps,
+  actor: Actor,
+  provider: string,
+  keyId: string,
+) {
+  const updatedId = await withSerializableRetry(() =>
+    deps.prisma.$transaction(
+      async (tx) => {
+        const credential = await tx.userModelCredential.findFirst({
+          where: { userId: actor.userId, workspaceId: actor.workspaceId, provider },
+          orderBy: newestModelCredentialOrder,
+          include: credentialKeyInclude,
+        });
+        if (!credential || !isGatewayProvider(credential.provider)) {
+          throw new ORPCError("NOT_FOUND", { message: "Custom endpoint not found." });
+        }
+        const key = credential.keys.find((entry) => entry.id === keyId);
+        if (!key) throw new ORPCError("NOT_FOUND", { message: "API key not found." });
+        await tx.userModelCredentialKey.updateMany({
+          where: { credentialId: credential.id },
+          data: { isActive: false },
+        });
+        await tx.userModelCredentialKey.update({
+          where: { id: key.id },
+          data: { isActive: true },
+        });
+        await tx.userModelCredential.update({
+          where: { id: credential.id },
+          data: { secretId: key.secretId },
+        });
+        return credential.id;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    ),
+  );
+  return loadCredentialDto(deps.prisma, updatedId);
+}
+
+async function discoverModelsForActiveGatewayKey(
+  deps: RouterDeps,
+  credential: ModelCredential,
+  plaintext: string,
+  requestedLabel: string | undefined,
+  signal?: AbortSignal,
+) {
+  if (!credential.baseUrl) return credential;
+  throwIfAborted(signal);
+  const discovered = await tryFetchOpenAICompatibleModels(credential.baseUrl, plaintext, signal);
+  const row = await deps.prisma.userModelCredential.findUnique({
+    where: { id: credential.id },
+    include: credentialKeyInclude,
+  });
+  const active = row?.keys.find((key) => key.isActive) ?? row?.keys.at(-1);
+  if (!row || !active) return credential;
+  const nextLabel =
+    requestedLabel?.trim() ||
+    (active.label && active.label !== "API key"
+      ? active.label
+      : labelForDiscoveredModels(discovered.models, active.label || "API key"));
+  await deps.prisma.userModelCredentialKey.update({
+    where: { id: active.id },
+    data: {
+      availableModels: serializeAvailableModels(discovered.models),
+      probedAt: new Date(),
+      probeError: discovered.error,
+      label: nextLabel,
+    },
+  });
+  await recomputeCredentialAvailableModels(deps.prisma, row.id, row.availableModels);
+  return loadCredentialDto(deps.prisma, row.id);
+}
+
+async function refreshGatewayKeyCoverage(
+  deps: RouterDeps,
+  actor: Actor,
+  provider: string,
+  signal?: AbortSignal,
+) {
+  const credential = await deps.prisma.userModelCredential.findFirst({
+    where: { userId: actor.userId, workspaceId: actor.workspaceId, provider },
+    orderBy: newestModelCredentialOrder,
+    include: credentialKeyInclude,
+  });
+  if (!credential || !isGatewayProvider(credential.provider) || !credential.baseUrl) {
+    throw new ORPCError("BAD_REQUEST", {
+      message: "Connect a custom endpoint before refreshing API keys.",
+    });
+  }
+  throwIfAborted(signal);
+  for (const key of credential.keys) {
+    throwIfAborted(signal);
+    const secret = await deps.prisma.secret.findUnique({ where: { id: key.secretId } });
+    if (!secret) {
+      await deps.prisma.userModelCredentialKey.update({
+        where: { id: key.id },
+        data: {
+          availableModels: "",
+          probedAt: new Date(),
+          probeError: "API key is missing.",
+        },
+      });
+      continue;
+    }
+    const parsed = parseModelSecret(deps.secrets.load(secret.ciphertext));
+    const apiKey = parsed.kind === "api_key" ? parsed.key : "";
+    const discovered = apiKey
+      ? await tryFetchOpenAICompatibleModels(credential.baseUrl, apiKey, signal)
+      : { models: [] as string[], error: "This key cannot list models." };
+    const nextLabel =
+      key.label && key.label !== "API key"
+        ? key.label
+        : labelForDiscoveredModels(discovered.models, key.label || "API key");
+    await deps.prisma.userModelCredentialKey.update({
+      where: { id: key.id },
+      data: {
+        availableModels: serializeAvailableModels(discovered.models),
+        probedAt: new Date(),
+        probeError: discovered.error,
+        label: nextLabel,
+      },
+    });
+  }
+  await recomputeCredentialAvailableModels(deps.prisma, credential.id, credential.availableModels);
+  return loadCredentialDto(deps.prisma, credential.id);
+}
+
+async function recomputeCredentialAvailableModels(
+  prisma: PrismaClient,
+  credentialId: string,
+  fallbackSerialized?: string,
+) {
+  const keys = await prisma.userModelCredentialKey.findMany({
+    where: { credentialId },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  });
+  const fromKeys = unionAvailableModels(keys);
+  const next = fromKeys.length ? fromKeys : parseAvailableModels(fallbackSerialized);
+  await prisma.userModelCredential.update({
+    where: { id: credentialId },
+    data: { availableModels: serializeAvailableModels(next) },
+  });
+}
+
+async function deleteSecretIfUnused(tx: Prisma.TransactionClient, secretId: string) {
+  const [credentials, keys] = await Promise.all([
+    tx.userModelCredential.count({ where: { secretId } }),
+    tx.userModelCredentialKey.count({ where: { secretId } }),
+  ]);
+  if (credentials === 0 && keys === 0) {
+    await tx.secret.deleteMany({ where: { id: secretId } });
+  }
 }
 
 function throwIfAborted(signal?: AbortSignal) {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -2033,12 +2033,18 @@ async function persistModelCredential(
   throwIfAborted(input.signal);
   const plaintext = input.plaintext.trim();
   const existing = await findWorkspaceModelCredential(deps.prisma, actor, input.provider);
-  const baseUrl =
-    input.baseUrl && input.baseUrl !== existing?.baseUrl
-      ? await assertOpenAICompatibleEndpointAllowed(input.baseUrl, {
-          allowPrivateNetwork: actor.isDeploymentOwner,
-        })
-      : input.baseUrl;
+  let baseUrl = input.baseUrl;
+  if (baseUrl && baseUrl !== existing?.baseUrl) {
+    try {
+      baseUrl = await assertOpenAICompatibleEndpointAllowed(baseUrl, {
+        allowPrivateNetwork: actor.isDeploymentOwner,
+      });
+    } catch (error) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: error instanceof Error ? error.message : "Invalid base URL",
+      });
+    }
+  }
   const appendKey = Boolean(input.appendKey || (baseUrl && plaintext));
   const makeDefault = input.setDefault !== false;
   if (!plaintext && existing && !appendKey) {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -17,6 +17,7 @@ import {
   acquireComputerExecutionLease,
   applyTeachingDesktopInput,
   archiveBot,
+  assertOpenAICompatibleBaseUrlAllowed,
   type ComposioProvider,
   ComputerBusyError,
   type ComputerExecutionLease,
@@ -35,7 +36,6 @@ import {
   isSupermemoryEnabled,
   listPiCatalog,
   mintGatewayProviderId,
-  normalizeOpenAICompatibleBaseUrl,
   OPENAI_COMPATIBLE_PROVIDER,
   type PiOAuthLogins,
   parseAvailableModels,
@@ -292,7 +292,9 @@ export function createRouter(deps: RouterDeps) {
         throwIfAborted(context.signal);
         try {
           return {
-            models: await fetchOpenAICompatibleModels(input.baseUrl, input.apiKey, context.signal),
+            models: await fetchOpenAICompatibleModels(input.baseUrl, input.apiKey, context.signal, {
+              allowPrivateNetwork: context.actor.isDeploymentOwner,
+            }),
           };
         } catch (error) {
           throw new ORPCError("BAD_REQUEST", {
@@ -304,7 +306,10 @@ export function createRouter(deps: RouterDeps) {
         if (input.baseUrl) {
           let baseUrl: string;
           try {
-            baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl);
+            baseUrl = await assertOpenAICompatibleBaseUrlAllowed(input.baseUrl, {
+              allowPrivateNetwork: context.actor.isDeploymentOwner,
+              hasCredentials: Boolean(input.apiKey.trim()),
+            });
           } catch (error) {
             throw new ORPCError("BAD_REQUEST", {
               message: error instanceof Error ? error.message : "Invalid base URL",
@@ -685,7 +690,7 @@ export function createRouter(deps: RouterDeps) {
         }
         await deps.prisma.event.deleteMany({
           where: {
-            type: "thread.progress",
+            type: { in: ["thread.progress", "thread.reasoning"] },
             runId: { in: activeRuns.map((run) => run.id) },
           },
         });

--- a/apps/api/src/taught-skills.ts
+++ b/apps/api/src/taught-skills.ts
@@ -121,7 +121,10 @@ async function cancelActiveRuns(
     data: { executionRunId: null, executionBotId: null, executionLeaseExpiresAt: null },
   });
   await deps.prisma.event.deleteMany({
-    where: { type: "thread.progress", runId: { in: activeRuns.map((run) => run.id) } },
+    where: {
+      type: { in: ["thread.progress", "thread.reasoning"] },
+      runId: { in: activeRuns.map((run) => run.id) },
+    },
   });
 }
 

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -29,6 +29,12 @@ type ModelSelection = {
   modelId?: string;
 };
 
+function formatKeyCoverage(models: string[] | undefined) {
+  if (!models?.length) return "Not probed yet. Refresh coverage after you add keys.";
+  if (models.length <= 8) return models.join(", ");
+  return `${models.slice(0, 8).join(", ")} +${models.length - 8} more`;
+}
+
 export default function Models() {
   const [catalog, setCatalog] = useState<MobileModel[]>([]);
   const [credentials, setCredentials] = useState<MobileModelCredential[]>([]);
@@ -36,9 +42,16 @@ export default function Models() {
   const [provider, setProvider] = useState("");
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [keyLabel, setKeyLabel] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
+  const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | null>(null);
+  const [pending, setPending] = useState<
+    "connect" | "default" | "probe" | "key" | "refresh" | null
+  >(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -123,6 +136,14 @@ export default function Models() {
     setProvider(nextProvider);
     setModelId(catalog.find((entry) => entry.provider === nextProvider)?.id ?? "");
     setApiKey("");
+    setKeyLabel("");
+    setBaseUrl(catalog.find((entry) => entry.provider === nextProvider)?.baseUrl ?? "");
+    setEndpointLabel(
+      catalog.find((entry) => entry.provider === nextProvider)?.providerName ?? "Custom endpoint",
+    );
+    setProbedModels(
+      credentials.find((entry) => entry.provider === nextProvider)?.availableModels ?? [],
+    );
     setError(null);
     setNotice(null);
   }
@@ -144,7 +165,40 @@ export default function Models() {
   }
 
   async function connectKey() {
-    if (!selected || !apiKey.trim()) return;
+    if (!selected) return;
+    if (isCustom) {
+      const url = baseUrl.trim() || selected.baseUrl;
+      if (!url) {
+        setError("Enter a base URL for this endpoint.");
+        return;
+      }
+      setError(null);
+      setNotice(null);
+      setPending("connect");
+      try {
+        const connected = await rpc<MobileModelCredential>("models/connect", {
+          provider: selected.provider,
+          apiKey: credential ? "" : apiKey.trim(),
+          modelId: modelId.trim() || selected.id,
+          label: endpointLabel.trim() || selected.providerName || "Custom endpoint",
+          baseUrl: url,
+          availableModels: probedModels.length
+            ? probedModels
+            : modelId.trim()
+              ? [modelId.trim()]
+              : undefined,
+        });
+        setApiKey("");
+        await load({ provider: connected.provider, modelId: connected.defaultModel ?? modelId });
+        setNotice(`Connected ${connected.label}.`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not connect this endpoint");
+      } finally {
+        setPending(null);
+      }
+      return;
+    }
+    if (!apiKey.trim()) return;
     setError(null);
     setNotice(null);
     setPending("connect");
@@ -160,6 +214,100 @@ export default function Models() {
       setNotice(`Connected and using ${selected.label}.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not connect this provider");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function probeModels() {
+    const url = baseUrl.trim() || selected?.baseUrl;
+    if (!url) {
+      setError("Enter a base URL to list models.");
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    setPending("probe");
+    try {
+      const result = await rpc<{ models: string[] }>("models/probe", {
+        baseUrl: url,
+        apiKey: apiKey.trim() || undefined,
+      });
+      setProbedModels(result.models);
+      if (!result.models.includes(modelId) && result.models[0]) setModelId(result.models[0]);
+      setNotice(`Found ${result.models.length} model${result.models.length === 1 ? "" : "s"}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not list models");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function addEndpointKey() {
+    if (!selected || !apiKey.trim()) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc("models/addKey", {
+        provider: selected.provider,
+        apiKey: apiKey.trim(),
+        label: keyLabel.trim() || undefined,
+      });
+      setApiKey("");
+      setKeyLabel("");
+      await load({ provider, modelId });
+      setNotice("Saved that key. Rakazo will use it for the models it can access.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not add API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function refreshEndpointKeys() {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("refresh");
+    try {
+      await rpc("models/refreshKeys", { provider: selected.provider });
+      await load({ provider, modelId });
+      setNotice("Updated which models each API key can use.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not refresh API keys");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function activateEndpointKey(keyId: string) {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc("models/setActiveKey", { provider: selected.provider, keyId });
+      await load({ provider, modelId });
+      setNotice("This key is the fallback when a model is not on any other key.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not switch API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function removeEndpointKey(keyId: string) {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc("models/removeKey", { provider: selected.provider, keyId });
+      await load({ provider, modelId });
+      setNotice("Removed that API key.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not remove API key");
     } finally {
       setPending(null);
     }
@@ -299,10 +447,126 @@ export default function Models() {
               </Text>
               <Text style={styles.secondary}>
                 {credential
-                  ? "Your key or subscription token is stored securely and is never shown here."
-                  : "Connect this provider to use it as your personal model."}
+                  ? isCustom
+                    ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
+                    : "Your key or subscription token is stored securely and is never shown here."
+                  : isCustom
+                    ? "Paste any OpenAI-compatible base URL. Extra API keys live under Advanced — Rakazo matches each key to the models it can run."
+                    : "Connect this provider to use it as your personal model."}
               </Text>
             </View>
+
+            {isCustom && credential ? (
+              <View style={styles.credentialCard}>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={() => setAdvancedOpen((open) => !open)}
+                  style={styles.advancedHeader}
+                >
+                  <Text style={styles.eyebrow}>Advanced</Text>
+                  <Text style={styles.secondaryAction}>
+                    {advancedOpen
+                      ? "Hide"
+                      : credential.keys.length
+                        ? `${credential.keys.length} API key${credential.keys.length === 1 ? "" : "s"}`
+                        : "API keys"}
+                  </Text>
+                </Pressable>
+                {advancedOpen ? (
+                  <>
+                    <Text style={styles.secondary}>
+                      Save every provider key here. Rakazo asks the endpoint which models each key
+                      can access, then uses that key automatically.
+                    </Text>
+                    <Pressable
+                      accessibilityRole="button"
+                      disabled={busy || !credential.keys.length}
+                      onPress={() => void refreshEndpointKeys()}
+                      style={({ pressed }) => [
+                        styles.outlineButton,
+                        (busy || !credential.keys.length) && styles.disabled,
+                        pressed && styles.pressed,
+                      ]}
+                    >
+                      <Text style={styles.outlineLabel}>
+                        {pending === "refresh" ? "Refreshing…" : "Refresh model coverage"}
+                      </Text>
+                    </Pressable>
+                    {credential.keys.length ? (
+                      credential.keys.map((key) => (
+                        <View key={key.id} style={styles.keyCard}>
+                          <View style={styles.keyRow}>
+                            <Text style={styles.keyName}>{key.label}</Text>
+                            {key.isActive ? (
+                              <Text style={styles.connected}>Fallback</Text>
+                            ) : (
+                              <Pressable
+                                disabled={busy}
+                                onPress={() => void activateEndpointKey(key.id)}
+                              >
+                                <Text style={styles.secondaryAction}>Fallback</Text>
+                              </Pressable>
+                            )}
+                            {credential.keys.length > 1 ? (
+                              <Pressable
+                                disabled={busy}
+                                onPress={() => void removeEndpointKey(key.id)}
+                              >
+                                <Text style={styles.error}>Remove</Text>
+                              </Pressable>
+                            ) : null}
+                          </View>
+                          <Text style={styles.secondary}>
+                            {key.probeError
+                              ? key.probeError
+                              : formatKeyCoverage(key.availableModels)}
+                          </Text>
+                        </View>
+                      ))
+                    ) : (
+                      <Text style={styles.secondary}>
+                        No keys yet. Local servers can run without one.
+                      </Text>
+                    )}
+                    <TextInput
+                      accessibilityLabel="Key label"
+                      onChangeText={setKeyLabel}
+                      placeholder="Optional"
+                      placeholderTextColor={native.tertiaryLabel}
+                      style={styles.keyInput}
+                      value={keyLabel}
+                    />
+                    <TextInput
+                      accessibilityLabel="Add API key"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      autoComplete="off"
+                      editable={!busy}
+                      onChangeText={setApiKey}
+                      placeholder="sk-…"
+                      placeholderTextColor={native.tertiaryLabel}
+                      secureTextEntry
+                      style={styles.keyInput}
+                      value={apiKey}
+                    />
+                    <Pressable
+                      accessibilityRole="button"
+                      disabled={busy || !apiKey.trim()}
+                      onPress={() => void addEndpointKey()}
+                      style={({ pressed }) => [
+                        styles.outlineButton,
+                        (busy || !apiKey.trim()) && styles.disabled,
+                        pressed && styles.pressed,
+                      ]}
+                    >
+                      <Text style={styles.outlineLabel}>
+                        {pending === "key" ? "Adding…" : "Add API key"}
+                      </Text>
+                    </Pressable>
+                  </>
+                ) : null}
+              </View>
+            ) : null}
 
             {deviceSignIn ? (
               oauth ? (
@@ -332,7 +596,7 @@ export default function Models() {
               )
             ) : null}
 
-            {acceptsKey ? (
+            {acceptsKey && !(isCustom && credential) ? (
               <View style={styles.keySection}>
                 <Text style={styles.sectionTitle}>
                   {credential
@@ -382,6 +646,23 @@ export default function Models() {
                 This subscription sign-in is not available in Rakazo yet. Use a deployment
                 credential or choose another provider.
               </Text>
+            ) : null}
+
+            {isCustom && credential ? (
+              <Pressable
+                accessibilityRole="button"
+                disabled={busy || !(baseUrl.trim() || selected.baseUrl)}
+                onPress={() => void connectKey()}
+                style={({ pressed }) => [
+                  styles.primaryButton,
+                  (busy || !(baseUrl.trim() || selected.baseUrl)) && styles.disabled,
+                  pressed && styles.pressed,
+                ]}
+              >
+                <Text style={styles.primaryLabel}>
+                  {pending === "connect" ? "Saving…" : "Save endpoint"}
+                </Text>
+              </Pressable>
             ) : null}
 
             {credential ? (
@@ -532,6 +813,30 @@ const styles = StyleSheet.create({
     color: native.label,
     fontSize: 16,
     marginTop: 6,
+  },
+  keyRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginTop: 10,
+  },
+  advancedHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  keyCard: {
+    marginTop: 10,
+  },
+  keyName: {
+    flex: 1,
+    color: native.label,
+    fontSize: 15,
+  },
+  secondaryAction: {
+    color: native.secondaryLabel,
+    fontSize: 13,
   },
   oauthCard: {
     borderRadius: 14,

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -542,11 +542,13 @@ export default function Models() {
                       autoCorrect={false}
                       autoComplete="off"
                       editable={!busy}
+                      importantForAutofill="no"
                       onChangeText={setApiKey}
                       placeholder="sk-…"
                       placeholderTextColor={native.tertiaryLabel}
                       secureTextEntry
                       style={styles.keyInput}
+                      textContentType="none"
                       value={apiKey}
                     />
                     <Pressable

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -249,13 +249,14 @@ export default function Models() {
     setNotice(null);
     setPending("key");
     try {
-      await rpc("models/addKey", {
+      const updated = await rpc<MobileModelCredential>("models/addKey", {
         provider: selected.provider,
         apiKey: apiKey.trim(),
         label: keyLabel.trim() || undefined,
       });
       setApiKey("");
       setKeyLabel("");
+      setProbedModels(updated.availableModels ?? []);
       await load({ provider, modelId });
       setNotice("Saved that key. Rakazo will use it for the models it can access.");
     } catch (err) {
@@ -271,7 +272,10 @@ export default function Models() {
     setNotice(null);
     setPending("refresh");
     try {
-      await rpc("models/refreshKeys", { provider: selected.provider });
+      const updated = await rpc<MobileModelCredential>("models/refreshKeys", {
+        provider: selected.provider,
+      });
+      setProbedModels(updated.availableModels ?? []);
       await load({ provider, modelId });
       setNotice("Updated which models each API key can use.");
     } catch (err) {
@@ -303,7 +307,11 @@ export default function Models() {
     setNotice(null);
     setPending("key");
     try {
-      await rpc("models/removeKey", { provider: selected.provider, keyId });
+      const updated = await rpc<MobileModelCredential>("models/removeKey", {
+        provider: selected.provider,
+        keyId,
+      });
+      setProbedModels(updated.availableModels ?? []);
       await load({ provider, modelId });
       setNotice("Removed that API key.");
     } catch (err) {

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -36,9 +36,12 @@ export default function Models() {
   const [provider, setProvider] = useState("");
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
+  const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | null>(null);
+  const [pending, setPending] = useState<"connect" | "default" | "probe" | null>(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -113,8 +116,10 @@ export default function Models() {
   const currentEntry = catalog.find(
     (entry) => entry.provider === me?.defaultProvider && entry.id === me?.defaultModel,
   );
+  const isCustom = Boolean(selected?.custom);
+  const isCustomTemplate = selected?.provider === "openai-compatible";
   const isActive = me?.defaultProvider === selected?.provider && me?.defaultModel === selected?.id;
-  const acceptsKey = selected?.auth !== "oauth";
+  const acceptsKey = selected?.auth !== "oauth" || isCustom;
   const deviceSignIn = selected?.signIn === "device-code";
   const busy = pending !== null || oauthPending;
 
@@ -123,6 +128,13 @@ export default function Models() {
     setProvider(nextProvider);
     setModelId(catalog.find((entry) => entry.provider === nextProvider)?.id ?? "");
     setApiKey("");
+    setBaseUrl(catalog.find((entry) => entry.provider === nextProvider)?.baseUrl ?? "");
+    setEndpointLabel(
+      catalog.find((entry) => entry.provider === nextProvider)?.providerName ?? "Custom endpoint",
+    );
+    setProbedModels(
+      credentials.find((entry) => entry.provider === nextProvider)?.availableModels ?? [],
+    );
     setError(null);
     setNotice(null);
   }
@@ -144,7 +156,40 @@ export default function Models() {
   }
 
   async function connectKey() {
-    if (!selected || !apiKey.trim()) return;
+    if (!selected) return;
+    if (isCustom) {
+      const url = baseUrl.trim() || selected.baseUrl;
+      if (!url) {
+        setError("Enter a base URL for this endpoint.");
+        return;
+      }
+      setError(null);
+      setNotice(null);
+      setPending("connect");
+      try {
+        const connected = await rpc<MobileModelCredential>("models/connect", {
+          provider: selected.provider,
+          apiKey: apiKey.trim(),
+          modelId: modelId.trim() || selected.id,
+          label: endpointLabel.trim() || selected.providerName || "Custom endpoint",
+          baseUrl: url,
+          availableModels: probedModels.length
+            ? probedModels
+            : modelId.trim()
+              ? [modelId.trim()]
+              : undefined,
+        });
+        setApiKey("");
+        await load({ provider: connected.provider, modelId: connected.defaultModel ?? modelId });
+        setNotice(`Connected ${connected.label}.`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not connect this endpoint");
+      } finally {
+        setPending(null);
+      }
+      return;
+    }
+    if (!apiKey.trim()) return;
     setError(null);
     setNotice(null);
     setPending("connect");
@@ -160,6 +205,30 @@ export default function Models() {
       setNotice(`Connected and using ${selected.label}.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not connect this provider");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function probeModels() {
+    const url = baseUrl.trim() || selected?.baseUrl;
+    if (!url) {
+      setError("Enter a base URL to list models.");
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    setPending("probe");
+    try {
+      const result = await rpc<{ models: string[] }>("models/probe", {
+        baseUrl: url,
+        apiKey: apiKey.trim() || undefined,
+      });
+      setProbedModels(result.models);
+      if (!result.models.includes(modelId) && result.models[0]) setModelId(result.models[0]);
+      setNotice(`Found ${result.models.length} model${result.models.length === 1 ? "" : "s"}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not list models");
     } finally {
       setPending(null);
     }
@@ -264,33 +333,114 @@ export default function Models() {
 
         {selected ? (
           <>
-            <Text style={styles.sectionTitle}>Model</Text>
-            <View style={styles.card}>
-              {modelsForProvider.map((entry) => (
+            {isCustom ? (
+              <>
+                <Text style={styles.sectionTitle}>Custom endpoint</Text>
+                <TextInput
+                  accessibilityLabel="Endpoint name"
+                  onChangeText={setEndpointLabel}
+                  placeholder="Office vLLM"
+                  placeholderTextColor={native.tertiaryLabel}
+                  style={styles.keyInput}
+                  value={endpointLabel}
+                />
+                <TextInput
+                  accessibilityLabel="Base URL"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  onChangeText={setBaseUrl}
+                  placeholder="https://api.example.com/v1"
+                  placeholderTextColor={native.tertiaryLabel}
+                  style={styles.keyInput}
+                  value={baseUrl}
+                />
+                <Text style={styles.billing}>{selected.billing}</Text>
+                {probedModels.length || (!isCustomTemplate && modelsForProvider.length > 1) ? (
+                  <View style={styles.card}>
+                    {[
+                      ...new Set([
+                        ...probedModels,
+                        ...modelsForProvider.map((entry) => entry.id),
+                        modelId,
+                      ]),
+                    ]
+                      .filter(Boolean)
+                      .map((id) => (
+                        <Pressable
+                          key={id}
+                          accessibilityRole="radio"
+                          onPress={() => setModelId(id)}
+                          style={({ pressed }) => [
+                            styles.modelRow,
+                            id === modelId && styles.selectedRow,
+                            pressed && styles.pressed,
+                          ]}
+                        >
+                          <View style={styles.radio}>
+                            {id === modelId ? <View style={styles.radioDot} /> : null}
+                          </View>
+                          <Text style={styles.modelLabel}>{id}</Text>
+                        </Pressable>
+                      ))}
+                  </View>
+                ) : (
+                  <TextInput
+                    accessibilityLabel="Model id"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    onChangeText={setModelId}
+                    placeholder="llama3.1"
+                    placeholderTextColor={native.tertiaryLabel}
+                    style={styles.keyInput}
+                    value={isCustomTemplate && modelId === "custom" ? "" : modelId}
+                  />
+                )}
                 <Pressable
-                  key={`${entry.provider}:${entry.id}`}
-                  accessibilityRole="radio"
-                  accessibilityState={{ selected: entry.id === selected.id }}
-                  onPress={() => {
-                    cancelOAuth();
-                    setModelId(entry.id);
-                    setError(null);
-                    setNotice(null);
-                  }}
+                  accessibilityRole="button"
+                  disabled={busy || !(baseUrl.trim() || selected.baseUrl)}
+                  onPress={() => void probeModels()}
                   style={({ pressed }) => [
-                    styles.modelRow,
-                    entry.id === selected.id && styles.selectedRow,
+                    styles.outlineButton,
                     pressed && styles.pressed,
+                    (busy || !(baseUrl.trim() || selected.baseUrl)) && styles.disabled,
                   ]}
                 >
-                  <View style={styles.radio}>
-                    {entry.id === selected.id ? <View style={styles.radioDot} /> : null}
-                  </View>
-                  <Text style={styles.modelLabel}>{entry.label}</Text>
+                  <Text style={styles.outlineLabel}>
+                    {pending === "probe" ? "Fetching…" : "Fetch models"}
+                  </Text>
                 </Pressable>
-              ))}
-            </View>
-            <Text style={styles.billing}>{selected.billing}</Text>
+              </>
+            ) : (
+              <>
+                <Text style={styles.sectionTitle}>Model</Text>
+                <View style={styles.card}>
+                  {modelsForProvider.map((entry) => (
+                    <Pressable
+                      key={`${entry.provider}:${entry.id}`}
+                      accessibilityRole="radio"
+                      accessibilityState={{ selected: entry.id === selected.id }}
+                      onPress={() => {
+                        cancelOAuth();
+                        setModelId(entry.id);
+                        setError(null);
+                        setNotice(null);
+                      }}
+                      style={({ pressed }) => [
+                        styles.modelRow,
+                        entry.id === selected.id && styles.selectedRow,
+                        pressed && styles.pressed,
+                      ]}
+                    >
+                      <View style={styles.radio}>
+                        {entry.id === selected.id ? <View style={styles.radioDot} /> : null}
+                      </View>
+                      <Text style={styles.modelLabel}>{entry.label}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+                <Text style={styles.billing}>{selected.billing}</Text>
+              </>
+            )}
 
             <View style={styles.credentialCard}>
               <Text style={styles.eyebrow}>Personal credential</Text>
@@ -299,8 +449,12 @@ export default function Models() {
               </Text>
               <Text style={styles.secondary}>
                 {credential
-                  ? "Your key or subscription token is stored securely and is never shown here."
-                  : "Connect this provider to use it as your personal model."}
+                  ? isCustom
+                    ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
+                    : "Your key or subscription token is stored securely and is never shown here."
+                  : isCustom
+                    ? "Paste any OpenAI-compatible base URL. The API key is optional for local servers."
+                    : "Connect this provider to use it as your personal model."}
               </Text>
             </View>
 
@@ -336,10 +490,14 @@ export default function Models() {
               <View style={styles.keySection}>
                 <Text style={styles.sectionTitle}>
                   {credential
-                    ? "Replace API key"
+                    ? isCustom
+                      ? "Replace API key (optional)"
+                      : "Replace API key"
                     : deviceSignIn
                       ? "Or connect an API key"
-                      : "API key"}
+                      : isCustom
+                        ? "API key (optional)"
+                        : "API key"}
                 </Text>
                 <TextInput
                   accessibilityLabel="API key"
@@ -356,20 +514,31 @@ export default function Models() {
                 />
                 <Pressable
                   accessibilityRole="button"
-                  disabled={busy || apiKey.trim().length < 8}
+                  disabled={
+                    busy ||
+                    (isCustom ? !(baseUrl.trim() || selected.baseUrl) : apiKey.trim().length < 8)
+                  }
                   onPress={() => void connectKey()}
                   style={({ pressed }) => [
                     styles.primaryButton,
-                    (busy || apiKey.trim().length < 8) && styles.disabled,
+                    (busy ||
+                      (isCustom
+                        ? !(baseUrl.trim() || selected.baseUrl)
+                        : apiKey.trim().length < 8)) &&
+                      styles.disabled,
                     pressed && styles.pressed,
                   ]}
                 >
                   <Text style={styles.primaryLabel}>
                     {pending === "connect"
                       ? "Saving…"
-                      : credential
-                        ? "Replace API key"
-                        : "Connect API key"}
+                      : isCustom
+                        ? credential
+                          ? "Save endpoint"
+                          : "Connect endpoint"
+                        : credential
+                          ? "Replace API key"
+                          : "Connect API key"}
                   </Text>
                 </Pressable>
               </View>

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -248,6 +248,7 @@ export default function Thread() {
               retryMs = 250;
               if (
                 event.type === "thread.progress" ||
+                event.type === "thread.reasoning" ||
                 event.type === "thread.message.created" ||
                 event.type === "thread.message.updated" ||
                 event.type === "thread.subagent" ||
@@ -560,6 +561,41 @@ async function speakMessage(botId: string, message: MobileMessage) {
   }
 }
 
+function ReasoningCard({
+  steps,
+}: {
+  steps: Array<{ id?: string; kind?: string; title?: string; detail?: string; status?: string }>;
+}) {
+  const running = steps.some((step) => step.status === "running");
+  const active = [...steps].reverse().find((step) => step.status === "running") ?? steps.at(-1);
+  return (
+    <View
+      style={{
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor: "#232326",
+        backgroundColor: "#141416",
+        paddingHorizontal: 16,
+        paddingVertical: 14,
+      }}
+    >
+      <Text style={{ color: "#C9C9CE", fontSize: 14, fontWeight: "600" }}>
+        {running ? active?.title || "Thinking" : "Thought process"}
+      </Text>
+      {steps.map((step, index) => (
+        <View key={step.id || String(index)} style={{ marginTop: 10 }}>
+          <Text style={{ color: step.status === "running" ? "#F5A03C" : "#A8A8AD", fontSize: 13 }}>
+            {step.title}
+          </Text>
+          {step.detail ? (
+            <Text style={{ color: "#85858A", fontSize: 13, marginTop: 4 }}>{step.detail}</Text>
+          ) : null}
+        </View>
+      ))}
+    </View>
+  );
+}
+
 function MessageBubble({
   botId,
   message,
@@ -571,9 +607,33 @@ function MessageBubble({
   onOpenBot: (botId: string, name: string) => void;
   onSpeak?: () => void;
 }) {
+  const reasoning = message.blocks.find((block) => block.kind === "reasoning");
   const special = message.blocks.find(
     (block) => block.kind === "subagent" || block.kind === "child_bot",
   );
+  if (reasoning?.kind === "reasoning" && reasoning.steps?.length && !special) {
+    const textBlocks = message.blocks.filter(
+      (block) => (block.kind === "text" || block.kind === "progress") && block.text,
+    );
+    return (
+      <View style={{ gap: 8, maxWidth: "90%" }}>
+        <ReasoningCard steps={reasoning.steps} />
+        {textBlocks.length ? (
+          <View
+            style={{
+              backgroundColor: "#1A1A1D",
+              padding: 12,
+              borderRadius: 20,
+            }}
+          >
+            <ChatMarkdown streaming={message.id.startsWith("progress:")}>
+              {textBlocks.map((block) => block.text).join("\n")}
+            </ChatMarkdown>
+          </View>
+        ) : null}
+      </View>
+    );
+  }
   if (special?.kind === "subagent") {
     const running = special.status === "running";
     const failed = special.status === "failed";

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -264,7 +264,7 @@ export default function Thread() {
               if (event.type === "thread.message.created" && event.payload?.role === "bot") {
                 markReadIfVisible();
               }
-              if (event.type === "run.completed") {
+              if (event.type === "run.completed" || event.type === "run.failed") {
                 void refresh().catch(() => undefined);
               }
             },

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -234,7 +234,10 @@ describe("mobile thread event reduction", () => {
     expect(second?.messages.map((item) => item.id)).toEqual(["reasoning:run-1", "progress:run-1"]);
     expect(second?.messages[0]?.blocks[0]).toMatchObject({
       kind: "reasoning",
-      steps: [expect.objectContaining({ title: "Starting" }), expect.objectContaining({ title: "Running a command" })],
+      steps: [
+        expect.objectContaining({ title: "Starting" }),
+        expect.objectContaining({ title: "Running a command" }),
+      ],
     });
   });
 

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -214,6 +214,30 @@ describe("mobile thread event reduction", () => {
     ]);
   });
 
+  it("streams a live reasoning trace ahead of answer progress", () => {
+    const first = applyMobileThreadEvent(snapshot(), {
+      type: "thread.progress",
+      runId: "run-1",
+      payload: { delta: "Draft" },
+    });
+    const second = applyMobileThreadEvent(first, {
+      type: "thread.reasoning",
+      runId: "run-1",
+      payload: {
+        steps: [
+          { id: "status", kind: "status", title: "Starting", status: "running" },
+          { id: "tool-1", kind: "tool", title: "Running a command", status: "running" },
+        ],
+      },
+    });
+
+    expect(second?.messages.map((item) => item.id)).toEqual(["reasoning:run-1", "progress:run-1"]);
+    expect(second?.messages[0]?.blocks[0]).toMatchObject({
+      kind: "reasoning",
+      steps: [expect.objectContaining({ title: "Starting" }), expect.objectContaining({ title: "Running a command" })],
+    });
+  });
+
   it("deduplicates durable messages and replaces matching transient subagent state", () => {
     const initial = snapshot([
       mobileMessage("message-1", [{ kind: "text", text: "old" }]),

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -7,10 +7,13 @@ import type {
   ModelCredential,
 } from "@rakazo/contracts";
 import {
+  isEphemeralThreadMessageId,
   mergeThreadHistory,
   prependThreadHistoryPage,
   progressMessageId,
   progressMessageText,
+  reasoningMessageId,
+  reasoningStepsFromPayload,
   type ThreadHistory,
 } from "@rakazo/core";
 import * as SecureStore from "expo-secure-store";
@@ -187,6 +190,13 @@ export type MobileMessage = {
     artifactId?: string;
     mimeType?: string;
     size?: number;
+    steps?: Array<{
+      id: string;
+      kind: string;
+      title: string;
+      detail?: string;
+      status: string;
+    }>;
   }>;
 };
 
@@ -235,6 +245,12 @@ export function blockText(message: MobileMessage) {
       if (block.kind === "image") return `[image: ${block.name ?? "attachment"}]`;
       if (block.kind === "file") {
         return `[file: ${block.name ?? "attachment"}${block.size ? ` (${block.size} bytes)` : ""}]`;
+      }
+      if (block.kind === "reasoning") {
+        return (block.steps ?? [])
+          .map((step) => step.title)
+          .filter(Boolean)
+          .join(". ");
       }
       return block.text ?? block.state ?? "";
     })
@@ -325,6 +341,23 @@ export function applyMobileThreadEvent(
       ],
     };
   }
+  if (event.type === "thread.reasoning") {
+    const streaming: MobileMessage = {
+      id: reasoningMessageId(event),
+      role: "bot",
+      blocks: [{ kind: "reasoning", steps: reasoningStepsFromPayload(event.payload ?? {}) }],
+    };
+    return {
+      ...prev,
+      messages: [
+        ...prev.messages.filter(
+          (message) => message.id !== streaming.id && !message.id.startsWith("progress:"),
+        ),
+        streaming,
+        ...prev.messages.filter((message) => message.id.startsWith("progress:")),
+      ],
+    };
+  }
   if (event.type === "thread.subagent") {
     const agentId = String(event.payload?.agentId ?? event.id ?? "live");
     const streaming: MobileMessage = {
@@ -364,7 +397,7 @@ export function applyMobileThreadEvent(
         ...prev.messages.filter(
           (message) =>
             message.id !== next.id &&
-            !message.id.startsWith("progress:") &&
+            !isEphemeralThreadMessageId(message.id) &&
             !(
               message.id.startsWith("subagent:") &&
               next.blocks.some(

--- a/apps/web/src/lib/model-auth.ts
+++ b/apps/web/src/lib/model-auth.ts
@@ -6,6 +6,7 @@ export type { ModelCatalogEntry, ModelCredential } from "@rakazo/contracts";
 export { cancelModelOAuthAttempt, finishModelOAuthAttempt } from "@rakazo/core";
 
 export function providerHint(entry: ModelCatalogEntry) {
+  if (entry.custom) return entry.baseUrl ? hostFromUrl(entry.baseUrl) : "Base URL";
   if (entry.signIn === "device-code") {
     if (entry.provider === "openai-codex") return "ChatGPT Plus/Pro";
     if (entry.provider === "github-copilot") return "Copilot";
@@ -20,4 +21,12 @@ export async function waitForModelOAuth(loginId: string, signal?: AbortSignal) {
   return waitForModelOAuthCompletion(() => rpc.models.completeOAuth({ loginId }, { signal }), {
     signal,
   });
+}
+
+function hostFromUrl(value: string): string {
+  try {
+    return new URL(value).host || "Base URL";
+  } catch {
+    return "Base URL";
+  }
 }

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -116,6 +116,26 @@ describe("thread event reduction", () => {
     });
   });
 
+  it("replaces a pending user bubble with the durable message", () => {
+    const initial = snapshot([
+      { ...message("pending:local", [{ kind: "text", text: "yo" }], 1), role: "user" },
+    ]);
+    const next = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.message.created",
+        seq: 4,
+        payload: {
+          messageId: "m-real",
+          role: "user",
+          blocks: [{ kind: "text", text: "yo" }],
+        },
+      }),
+    );
+    expect(next?.messages.map((item) => item.id)).toEqual(["m-real"]);
+    expect(next?.messages[0]?.role).toBe("user");
+  });
+
   it("replaces transient progress and a matching live subagent with the durable message", () => {
     const initial = snapshot([
       message("durable", [{ kind: "text", text: "old value" }]),

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -186,7 +186,13 @@ describe("thread event reduction", () => {
         payload: {
           steps: [
             { id: "status", kind: "status", title: "Starting", status: "done" },
-            { id: "think", kind: "think", title: "Thought", detail: "Let me check", status: "done" },
+            {
+              id: "think",
+              kind: "think",
+              title: "Thought",
+              detail: "Let me check",
+              status: "done",
+            },
             { id: "tool-1", kind: "tool", title: "Running a command", status: "running" },
           ],
         },

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -162,6 +162,82 @@ describe("thread event reduction", () => {
     expect(next?.messages[1]?.blocks).toEqual([completedBlock]);
   });
 
+  it("streams a live reasoning trace ahead of answer progress", () => {
+    const initial = snapshot([message("progress:run-1", [{ kind: "progress", text: "Draft" }])]);
+
+    const first = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.reasoning",
+        seq: 6,
+        payload: {
+          steps: [
+            { id: "status", kind: "status", title: "Starting", status: "running" },
+            { id: "think", kind: "think", title: "Thinking", detail: "Let me", status: "running" },
+          ],
+        },
+      }),
+    );
+    const second = reduceThreadSnapshot(
+      first,
+      event({
+        type: "thread.reasoning",
+        seq: 7,
+        payload: {
+          steps: [
+            { id: "status", kind: "status", title: "Starting", status: "done" },
+            { id: "think", kind: "think", title: "Thought", detail: "Let me check", status: "done" },
+            { id: "tool-1", kind: "tool", title: "Running a command", status: "running" },
+          ],
+        },
+      }),
+    );
+
+    expect(isThreadSnapshotEvent(event({ type: "thread.reasoning" }))).toBe(true);
+    expect(second?.messages.map((item) => item.id)).toEqual(["reasoning:run-1", "progress:run-1"]);
+    expect(second?.messages[0]?.blocks[0]).toMatchObject({
+      kind: "reasoning",
+      steps: [
+        expect.objectContaining({ id: "status", status: "done" }),
+        expect.objectContaining({ id: "think", title: "Thought", detail: "Let me check" }),
+        expect.objectContaining({ id: "tool-1", title: "Running a command", status: "running" }),
+      ],
+    });
+  });
+
+  it("drops the live reasoning trace when the durable reply arrives", () => {
+    const initial = snapshot([
+      message("reasoning:run-1", [
+        {
+          kind: "reasoning",
+          steps: [{ id: "status", kind: "status", title: "Starting", status: "running" }],
+        },
+      ]),
+      message("progress:run-1", [{ kind: "progress", text: "Draft" }]),
+    ]);
+
+    const next = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.message.created",
+        seq: 9,
+        payload: {
+          messageId: "durable",
+          role: "bot",
+          blocks: [
+            {
+              kind: "reasoning",
+              steps: [{ id: "status", kind: "status", title: "Starting", status: "done" }],
+            },
+            { kind: "text", text: "Done" },
+          ],
+        },
+      }),
+    );
+
+    expect(next?.messages.map((item) => item.id)).toEqual(["durable"]);
+  });
+
   it("clears durable and transient history when another client clears the thread", () => {
     const initial = snapshot(
       [

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -6,10 +6,13 @@ import type {
   ThreadSnapshot,
 } from "@rakazo/contracts";
 import {
+  isEphemeralThreadMessageId,
   mergeThreadHistory,
   prependThreadHistoryPage,
   progressMessageId,
   progressMessageText,
+  reasoningMessageId,
+  reasoningStepsFromPayload,
   subagentBlockFromPayload,
 } from "@rakazo/core";
 
@@ -40,6 +43,7 @@ export function isThreadSnapshotEvent(event: ProductEvent): boolean {
   return (
     event.type === "thread.cleared" ||
     event.type === "thread.progress" ||
+    event.type === "thread.reasoning" ||
     event.type === "thread.subagent" ||
     event.type === "thread.message.created" ||
     event.type === "thread.message.updated" ||
@@ -81,6 +85,22 @@ export function reduceThreadSnapshot(
     const without = prev.messages.filter((message) => !message.id.startsWith("progress:"));
     return { ...prev, cursor: event.seq, messages: [...without, streaming] };
   }
+  if (event.type === "thread.reasoning") {
+    const next: ThreadMessage = {
+      id: reasoningMessageId(event),
+      threadId: event.threadId,
+      seq: event.seq,
+      role: "bot",
+      blocks: [{ kind: "reasoning", steps: reasoningStepsFromPayload(event.payload) }],
+      runId: event.runId,
+      createdAt: event.createdAt,
+    };
+    const without = prev.messages.filter(
+      (message) => message.id !== next.id && !message.id.startsWith("progress:"),
+    );
+    const progress = prev.messages.filter((message) => message.id.startsWith("progress:"));
+    return { ...prev, cursor: event.seq, messages: [...without, next, ...progress] };
+  }
   if (event.type === "thread.subagent") {
     const block = subagentBlockFromPayload(event.payload);
     const next: ThreadMessage = {
@@ -116,7 +136,7 @@ export function reduceThreadSnapshot(
     const without = prev.messages.filter(
       (message) =>
         message.id !== next.id &&
-        !message.id.startsWith("progress:") &&
+        !isEphemeralThreadMessageId(message.id) &&
         !replacedSubagent(message, replacedSubagentIds),
     );
     return { ...prev, cursor: event.seq, messages: [...without, next] };

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -309,7 +309,8 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     setNotice(null);
     setPending("key");
     try {
-      await rpc.models.removeKey({ provider: selected.provider, keyId });
+      const updated = await rpc.models.removeKey({ provider: selected.provider, keyId });
+      setProbedModels(updated.availableModels ?? []);
       await refresh();
       setNotice("Removed that API key.");
     } catch (err) {

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -23,6 +23,12 @@ type OAuthNotice = {
   userCode: string;
 };
 
+function formatKeyCoverage(models: string[] | undefined) {
+  if (!models?.length) return "Not probed yet. Refresh coverage after you add keys.";
+  if (models.length <= 8) return models.join(", ");
+  return `${models.slice(0, 8).join(", ")} +${models.length - 8} more`;
+}
+
 export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
   const [credentials, setCredentials] = useState<ModelCredential[]>([]);
@@ -31,9 +37,15 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [providerQuery, setProviderQuery] = useState("");
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [keyLabel, setKeyLabel] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
+  const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | null>(null);
+  const [pending, setPending] = useState<
+    "connect" | "default" | "probe" | "key" | "refresh" | null
+  >(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -126,6 +138,14 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     setModelId(catalog.find((entry) => entry.provider === nextProvider)?.id ?? "");
     detailScrollRef.current?.scrollTo({ top: 0 });
     setApiKey("");
+    setKeyLabel("");
+    setBaseUrl(catalog.find((entry) => entry.provider === nextProvider)?.baseUrl ?? "");
+    setEndpointLabel(
+      catalog.find((entry) => entry.provider === nextProvider)?.providerName ?? "Custom endpoint",
+    );
+    setProbedModels(
+      credentials.find((entry) => entry.provider === nextProvider)?.availableModels ?? [],
+    );
     setError(null);
     setNotice(null);
   }
@@ -147,7 +167,42 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   }
 
   async function connectKey() {
-    if (!selected || !apiKey.trim()) return;
+    if (!selected) return;
+    if (isCustom) {
+      const url = baseUrl.trim() || selected.baseUrl;
+      if (!url) {
+        setError("Enter a base URL for this endpoint.");
+        return;
+      }
+      setError(null);
+      setNotice(null);
+      setPending("connect");
+      try {
+        const connected = await rpc.models.connect({
+          provider: selected.provider,
+          apiKey: credential ? "" : apiKey.trim(),
+          modelId: modelId.trim() || selected.id,
+          label: endpointLabel.trim() || selected.providerName || "Custom endpoint",
+          baseUrl: url,
+          availableModels: probedModels.length
+            ? probedModels
+            : modelId.trim()
+              ? [modelId.trim()]
+              : undefined,
+        });
+        setApiKey("");
+        await refresh();
+        setProvider(connected.provider);
+        setModelId(connected.defaultModel ?? modelId);
+        setNotice(`Connected ${connected.label}.`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not connect this endpoint");
+      } finally {
+        setPending(null);
+      }
+      return;
+    }
+    if (!apiKey.trim()) return;
     setError(null);
     setNotice(null);
     setPending("connect");
@@ -163,6 +218,102 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       setNotice(`Connected and using ${selected.label}.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not connect this provider");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function probeModels() {
+    const url = baseUrl.trim() || selected?.baseUrl;
+    if (!url) {
+      setError("Enter a base URL to list models.");
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    setPending("probe");
+    try {
+      const result = await rpc.models.probe({
+        baseUrl: url,
+        apiKey: apiKey.trim() || undefined,
+      });
+      setProbedModels(result.models);
+      if (!result.models.includes(modelId) && result.models[0]) setModelId(result.models[0]);
+      setNotice(`Found ${result.models.length} model${result.models.length === 1 ? "" : "s"}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not list models");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function addEndpointKey() {
+    if (!selected || !apiKey.trim()) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      const updated = await rpc.models.addKey({
+        provider: selected.provider,
+        apiKey: apiKey.trim(),
+        label: keyLabel.trim() || undefined,
+      });
+      setApiKey("");
+      setKeyLabel("");
+      setProbedModels(updated.availableModels ?? []);
+      await refresh();
+      setNotice("Saved that key. Rakazo will use it for the models it can access.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not add API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function refreshEndpointKeys() {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("refresh");
+    try {
+      const updated = await rpc.models.refreshKeys({ provider: selected.provider });
+      setProbedModels(updated.availableModels ?? []);
+      await refresh();
+      setNotice("Updated which models each API key can use.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not refresh API keys");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function activateEndpointKey(keyId: string) {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc.models.setActiveKey({ provider: selected.provider, keyId });
+      await refresh();
+      setNotice("This key is now used for the endpoint.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not switch API key");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function removeEndpointKey(keyId: string) {
+    if (!selected) return;
+    setError(null);
+    setNotice(null);
+    setPending("key");
+    try {
+      await rpc.models.removeKey({ provider: selected.provider, keyId });
+      await refresh();
+      setNotice("Removed that API key.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not remove API key");
     } finally {
       setPending(null);
     }
@@ -322,10 +473,116 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                   </div>
                   <div className="mt-1 text-[13px] text-[#85858A]">
                     {credential
-                      ? "Your key or subscription token is stored securely and is never shown here."
-                      : "Connect this provider to use it as your personal model."}
+                      ? isCustom
+                        ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
+                        : "Your key or subscription token is stored securely and is never shown here."
+                      : isCustom
+                        ? "Paste any OpenAI-compatible base URL. Extra API keys live under Advanced — Rakazo matches each key to the models it can run."
+                        : "Connect this provider to use it as your personal model."}
                   </div>
                 </div>
+
+                {isCustom && credential ? (
+                  <details className="mt-5 rounded-[13px] border border-[#26262A] px-4 py-3">
+                    <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-[13.5px] text-[#ECECEE] [&::-webkit-details-marker]:hidden">
+                      <span className="font-medium">Advanced</span>
+                      <span className="text-[12px] text-[#6C6C70]">
+                        {credential.keys.length
+                          ? `${credential.keys.length} API key${credential.keys.length === 1 ? "" : "s"}`
+                          : "API keys"}
+                      </span>
+                    </summary>
+                    <p className="mt-3 text-[13px] leading-[1.5] text-[#85858A]">
+                      Save every provider key here. Rakazo asks the endpoint which models each key
+                      can access, then uses that key automatically — Gemini keys for Gemini models,
+                      and so on. You do not assign keys yourself.
+                    </p>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={busy || !credential.keys.length}
+                      onClick={() => void refreshEndpointKeys()}
+                      className="mt-3"
+                    >
+                      {pending === "refresh" ? "Refreshing…" : "Refresh model coverage"}
+                    </Button>
+                    {credential.keys.length ? (
+                      <ul className="mt-3 space-y-2">
+                        {credential.keys.map((key) => (
+                          <li key={key.id} className="rounded-[10px] bg-[#101012] px-3 py-2">
+                            <div className="flex items-center gap-2">
+                              <span className="min-w-0 flex-1 truncate text-[14px] text-[#ECECEE]">
+                                {key.label}
+                              </span>
+                              {key.isActive ? (
+                                <span className="text-[12px] text-[#4ECB71]">Fallback</span>
+                              ) : (
+                                <button
+                                  type="button"
+                                  disabled={busy}
+                                  onClick={() => void activateEndpointKey(key.id)}
+                                  className="text-[12px] text-[#85858A] hover:text-[#ECECEE]"
+                                >
+                                  Fallback
+                                </button>
+                              )}
+                              {credential.keys.length > 1 ? (
+                                <button
+                                  type="button"
+                                  disabled={busy}
+                                  onClick={() => void removeEndpointKey(key.id)}
+                                  className="text-[12px] text-[#E65707]"
+                                >
+                                  Remove
+                                </button>
+                              ) : null}
+                            </div>
+                            <p className="mt-1 text-[12px] leading-[1.45] text-[#85858A]">
+                              {key.probeError
+                                ? key.probeError
+                                : formatKeyCoverage(key.availableModels)}
+                            </p>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="mt-3 text-[13px] text-[#85858A]">
+                        No keys yet. Local servers can run without one.
+                      </p>
+                    )}
+                    <label className="mt-4 block text-[13.5px] text-[#85858A]">
+                      Key label
+                      <input
+                        value={keyLabel}
+                        onChange={(event) => setKeyLabel(event.target.value)}
+                        placeholder="Optional"
+                        className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                      />
+                    </label>
+                    <label className="mt-3 block text-[13.5px] text-[#85858A]">
+                      Add API key
+                      <input
+                        value={apiKey}
+                        onChange={(event) => setApiKey(event.target.value)}
+                        placeholder="sk-…"
+                        type="password"
+                        autoComplete="off"
+                        className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                      />
+                    </label>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={busy || !apiKey.trim()}
+                      onClick={() => void addEndpointKey()}
+                      className="mt-3"
+                    >
+                      {pending === "key" ? "Adding…" : "Add API key"}
+                    </Button>
+                  </details>
+                ) : null}
 
                 {deviceSignIn ? (
                   <div className="mt-5">
@@ -361,7 +618,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                   </div>
                 ) : null}
 
-                {acceptsKey ? (
+                {acceptsKey && !(isCustom && credential) ? (
                   <div className="mt-5">
                     <label className="block text-[13.5px] text-[#85858A]">
                       {credential
@@ -388,9 +645,25 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                     >
                       {pending === "connect"
                         ? "Saving…"
-                        : credential
-                          ? "Replace API key"
-                          : "Connect API key"}
+                        : isCustom
+                          ? "Connect endpoint"
+                          : credential
+                            ? "Replace API key"
+                            : "Connect API key"}
+                    </Button>
+                  </div>
+                ) : null}
+
+                {isCustom && credential ? (
+                  <div className="mt-5">
+                    <Button
+                      type="button"
+                      variant="pill"
+                      size="sm"
+                      disabled={busy || !(baseUrl.trim() || selected.baseUrl)}
+                      onClick={() => void connectKey()}
+                    >
+                      {pending === "connect" ? "Saving…" : "Save endpoint"}
                     </Button>
                   </div>
                 ) : null}

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -31,9 +31,12 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [providerQuery, setProviderQuery] = useState("");
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
+  const [probedModels, setProbedModels] = useState<string[]>([]);
   const [oauth, setOauth] = useState<OAuthNotice | null>(null);
   const [loading, setLoading] = useState(true);
-  const [pending, setPending] = useState<"connect" | "default" | null>(null);
+  const [pending, setPending] = useState<"connect" | "default" | "probe" | null>(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -115,8 +118,10 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const currentEntry = catalog.find(
     (entry) => entry.provider === me?.defaultProvider && entry.id === me?.defaultModel,
   );
+  const isCustom = Boolean(selected?.custom);
+  const isCustomTemplate = selected?.provider === "openai-compatible";
   const isActive = me?.defaultProvider === selected?.provider && me?.defaultModel === selected?.id;
-  const acceptsKey = selected?.auth !== "oauth";
+  const acceptsKey = selected?.auth !== "oauth" || isCustom;
   const deviceSignIn = selected?.signIn === "device-code";
   const busy = pending !== null || oauthPending;
 
@@ -126,6 +131,13 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     setModelId(catalog.find((entry) => entry.provider === nextProvider)?.id ?? "");
     detailScrollRef.current?.scrollTo({ top: 0 });
     setApiKey("");
+    setBaseUrl(catalog.find((entry) => entry.provider === nextProvider)?.baseUrl ?? "");
+    setEndpointLabel(
+      catalog.find((entry) => entry.provider === nextProvider)?.providerName ?? "Custom endpoint",
+    );
+    setProbedModels(
+      credentials.find((entry) => entry.provider === nextProvider)?.availableModels ?? [],
+    );
     setError(null);
     setNotice(null);
   }
@@ -147,7 +159,42 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   }
 
   async function connectKey() {
-    if (!selected || !apiKey.trim()) return;
+    if (!selected) return;
+    if (isCustom) {
+      const url = baseUrl.trim() || selected.baseUrl;
+      if (!url) {
+        setError("Enter a base URL for this endpoint.");
+        return;
+      }
+      setError(null);
+      setNotice(null);
+      setPending("connect");
+      try {
+        const connected = await rpc.models.connect({
+          provider: selected.provider,
+          apiKey: apiKey.trim(),
+          modelId: modelId.trim() || selected.id,
+          label: endpointLabel.trim() || selected.providerName || "Custom endpoint",
+          baseUrl: url,
+          availableModels: probedModels.length
+            ? probedModels
+            : modelId.trim()
+              ? [modelId.trim()]
+              : undefined,
+        });
+        setApiKey("");
+        await refresh();
+        setProvider(connected.provider);
+        setModelId(connected.defaultModel ?? modelId);
+        setNotice(`Connected ${connected.label}.`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not connect this endpoint");
+      } finally {
+        setPending(null);
+      }
+      return;
+    }
+    if (!apiKey.trim()) return;
     setError(null);
     setNotice(null);
     setPending("connect");
@@ -163,6 +210,30 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       setNotice(`Connected and using ${selected.label}.`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not connect this provider");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function probeModels() {
+    const url = baseUrl.trim() || selected?.baseUrl;
+    if (!url) {
+      setError("Enter a base URL to list models.");
+      return;
+    }
+    setError(null);
+    setNotice(null);
+    setPending("probe");
+    try {
+      const result = await rpc.models.probe({
+        baseUrl: url,
+        apiKey: apiKey.trim() || undefined,
+      });
+      setProbedModels(result.models);
+      if (!result.models.includes(modelId) && result.models[0]) setModelId(result.models[0]);
+      setNotice(`Found ${result.models.length} model${result.models.length === 1 ? "" : "s"}.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not list models");
     } finally {
       setPending(null);
     }
@@ -298,20 +369,83 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
             {notice ? <p className="mb-4 text-sm text-[#4ECB71]">{notice}</p> : null}
             {selected ? (
               <>
-                <div className="block text-[13.5px] text-[#85858A]">
-                  <span>Model</span>
-                  <ModelPicker
-                    options={modelsForProvider}
-                    value={selected.id}
-                    onChange={(nextModelId) => {
-                      cancelOAuthAttempt();
-                      setModelId(nextModelId);
-                      setError(null);
-                      setNotice(null);
-                    }}
-                  />
-                </div>
-                <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
+                {isCustom ? (
+                  <div className="space-y-4">
+                    <label className="block text-[13.5px] text-[#85858A]">
+                      Name
+                      <input
+                        value={endpointLabel}
+                        onChange={(event) => setEndpointLabel(event.target.value)}
+                        placeholder="Office vLLM"
+                        className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                      />
+                    </label>
+                    <label className="block text-[13.5px] text-[#85858A]">
+                      Base URL
+                      <input
+                        value={baseUrl}
+                        onChange={(event) => setBaseUrl(event.target.value)}
+                        placeholder="https://api.example.com/v1"
+                        autoComplete="off"
+                        className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                      />
+                    </label>
+                    <p className="text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
+                    <div className="flex flex-wrap items-end gap-3">
+                      <label className="block min-w-[220px] flex-1 text-[13.5px] text-[#85858A]">
+                        Model id
+                        {probedModels.length || (!isCustomTemplate && modelsForProvider.length > 1) ? (
+                          <select
+                            value={modelId}
+                            onChange={(event) => setModelId(event.target.value)}
+                            className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                          >
+                            {[...new Set([...probedModels, ...modelsForProvider.map((entry) => entry.id), modelId])]
+                              .filter(Boolean)
+                              .map((id) => (
+                                <option key={id} value={id}>
+                                  {id}
+                                </option>
+                              ))}
+                          </select>
+                        ) : (
+                          <input
+                            value={isCustomTemplate && modelId === "custom" ? "" : modelId}
+                            onChange={(event) => setModelId(event.target.value)}
+                            placeholder="llama3.1"
+                            className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
+                          />
+                        )}
+                      </label>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={busy || !(baseUrl.trim() || selected.baseUrl)}
+                        onClick={() => void probeModels()}
+                      >
+                        {pending === "probe" ? "Fetching…" : "Fetch models"}
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="block text-[13.5px] text-[#85858A]">
+                      <span>Model</span>
+                      <ModelPicker
+                        options={modelsForProvider}
+                        value={selected.id}
+                        onChange={(nextModelId) => {
+                          cancelOAuthAttempt();
+                          setModelId(nextModelId);
+                          setError(null);
+                          setNotice(null);
+                        }}
+                      />
+                    </div>
+                    <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
+                  </>
+                )}
 
                 <div className="mt-5 rounded-[13px] border border-[#26262A] px-4 py-3">
                   <div className="text-[12.5px] uppercase tracking-[0.08em] text-[#6C6C70]">
@@ -322,8 +456,12 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                   </div>
                   <div className="mt-1 text-[13px] text-[#85858A]">
                     {credential
-                      ? "Your key or subscription token is stored securely and is never shown here."
-                      : "Connect this provider to use it as your personal model."}
+                      ? isCustom
+                        ? credential.baseUrl || "Custom OpenAI-compatible endpoint."
+                        : "Your key or subscription token is stored securely and is never shown here."
+                      : isCustom
+                        ? "Paste any OpenAI-compatible base URL. The API key is optional for local servers."
+                        : "Connect this provider to use it as your personal model."}
                   </div>
                 </div>
 
@@ -365,10 +503,14 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                   <div className="mt-5">
                     <label className="block text-[13.5px] text-[#85858A]">
                       {credential
-                        ? "Replace API key"
+                        ? isCustom
+                          ? "Replace API key (optional)"
+                          : "Replace API key"
                         : deviceSignIn
                           ? "Or connect an API key"
-                          : "API key"}
+                          : isCustom
+                            ? "API key (optional)"
+                            : "API key"}
                       <input
                         value={apiKey}
                         onChange={(event) => setApiKey(event.target.value)}
@@ -382,15 +524,24 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                       type="button"
                       variant="pill"
                       size="sm"
-                      disabled={busy || apiKey.trim().length < 8}
+                      disabled={
+                        busy ||
+                        (isCustom
+                          ? !(baseUrl.trim() || selected.baseUrl)
+                          : apiKey.trim().length < 8)
+                      }
                       onClick={() => void connectKey()}
                       className="mt-3"
                     >
                       {pending === "connect"
                         ? "Saving…"
-                        : credential
-                          ? "Replace API key"
-                          : "Connect API key"}
+                        : isCustom
+                          ? credential
+                            ? "Save endpoint"
+                            : "Connect endpoint"
+                          : credential
+                            ? "Replace API key"
+                            : "Connect API key"}
                     </Button>
                   </div>
                 ) : null}

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -392,15 +392,23 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                     </label>
                     <p className="text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
                     <div className="flex flex-wrap items-end gap-3">
-                      <label className="block min-w-[220px] flex-1 text-[13.5px] text-[#85858A]">
-                        Model id
-                        {probedModels.length || (!isCustomTemplate && modelsForProvider.length > 1) ? (
+                      <div className="block min-w-[220px] flex-1 text-[13.5px] text-[#85858A]">
+                        <label htmlFor="custom-endpoint-model">Model id</label>
+                        {probedModels.length ||
+                        (!isCustomTemplate && modelsForProvider.length > 1) ? (
                           <select
+                            id="custom-endpoint-model"
                             value={modelId}
                             onChange={(event) => setModelId(event.target.value)}
                             className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
                           >
-                            {[...new Set([...probedModels, ...modelsForProvider.map((entry) => entry.id), modelId])]
+                            {[
+                              ...new Set([
+                                ...probedModels,
+                                ...modelsForProvider.map((entry) => entry.id),
+                                modelId,
+                              ]),
+                            ]
                               .filter(Boolean)
                               .map((id) => (
                                 <option key={id} value={id}>
@@ -410,13 +418,14 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                           </select>
                         ) : (
                           <input
+                            id="custom-endpoint-model"
                             value={isCustomTemplate && modelId === "custom" ? "" : modelId}
                             onChange={(event) => setModelId(event.target.value)}
                             placeholder="llama3.1"
                             className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
                           />
                         )}
-                      </label>
+                      </div>
                       <Button
                         type="button"
                         variant="outline"
@@ -443,7 +452,9 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         }}
                       />
                     </div>
-                    <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">{selected.billing}</p>
+                    <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">
+                      {selected.billing}
+                    </p>
                   </>
                 )}
 

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -295,7 +295,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     try {
       await rpc.models.setActiveKey({ provider: selected.provider, keyId });
       await refresh();
-      setNotice("This key is now used for the endpoint.");
+      setNotice("This key is the fallback when a model is not on any other key.");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not switch API key");
     } finally {
@@ -567,7 +567,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         onChange={(event) => setApiKey(event.target.value)}
                         placeholder="sk-…"
                         type="password"
-                        autoComplete="off"
+                        autoComplete="new-password"
                         className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
                       />
                     </label>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -41,6 +41,10 @@ export function OnboardingPage() {
   const [provider, setProvider] = useState("openrouter");
   const [modelId, setModelId] = useState("deepseek/deepseek-v4-flash-0731");
   const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [endpointLabel, setEndpointLabel] = useState("Custom endpoint");
+  const [probedModels, setProbedModels] = useState<string[]>([]);
+  const [probing, setProbing] = useState(false);
   const [name, setName] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -115,14 +119,30 @@ export function OnboardingPage() {
   );
 
   const selected = modelsForProvider.find((entry) => entry.id === modelId) ?? modelsForProvider[0];
+  const isCustom = Boolean(selected?.custom);
+  const isCustomTemplate = selected?.provider === "openai-compatible";
   const deviceSignIn = selected?.signIn === "device-code";
-  const acceptsKey = selected?.auth !== "oauth";
+  const acceptsKey = selected?.auth !== "oauth" || isCustom;
   const signInLabel = selected?.oauthLabel ?? "Sign in";
 
   async function saveModel() {
     setError(null);
     try {
-      if (apiKey) {
+      if (isCustom) {
+        const url = baseUrl.trim();
+        if (!url) {
+          setError("Enter a base URL for this endpoint.");
+          return;
+        }
+        await rpc.models.connect({
+          provider,
+          apiKey,
+          modelId: isCustomTemplate && modelId === "custom" ? probedModels[0] : modelId,
+          label: endpointLabel.trim() || selected?.providerName || "Custom endpoint",
+          baseUrl: url,
+          availableModels: probedModels.length ? probedModels : undefined,
+        });
+      } else if (apiKey) {
         await rpc.models.connect({
           provider,
           apiKey,
@@ -133,6 +153,27 @@ export function OnboardingPage() {
       setStep("bot");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not save model");
+    }
+  }
+
+  async function probeModels() {
+    if (!baseUrl.trim()) {
+      setError("Enter a base URL to list models.");
+      return;
+    }
+    setError(null);
+    setProbing(true);
+    try {
+      const result = await rpc.models.probe({
+        baseUrl: baseUrl.trim(),
+        apiKey: apiKey.trim() || undefined,
+      });
+      setProbedModels(result.models);
+      if (result.models[0]) setModelId(result.models[0]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not list models");
+    } finally {
+      setProbing(false);
     }
   }
 
@@ -200,8 +241,9 @@ export function OnboardingPage() {
           <div>
             <h1 className="text-[32px] font-medium text-[#F1F1F2]">Connect a model</h1>
             <p className="mt-2 text-[#85858A]">
-              Rakazo does not pay for model usage. Paste an API key, sign in with ChatGPT, Copilot,
-              or SuperGrok, or skip if this deployment already has a key.
+              Rakazo does not pay for model usage. Paste an API key, connect any OpenAI-compatible
+              base URL, sign in with ChatGPT, Copilot, or SuperGrok, or skip if this deployment
+              already has a key.
             </p>
             <input
               value={query}
@@ -219,6 +261,9 @@ export function OnboardingPage() {
                     setProvider(entry.provider);
                     const first = catalog.find((item) => item.provider === entry.provider);
                     if (first) setModelId(first.id);
+                    setBaseUrl(first?.baseUrl ?? "");
+                    setEndpointLabel(first?.providerName ?? "Custom endpoint");
+                    setProbedModels([]);
                     setError(null);
                   }}
                   className={`flex w-full items-center justify-between border-b border-[#202023] px-3.5 py-2.5 text-left last:border-0 ${
@@ -232,23 +277,77 @@ export function OnboardingPage() {
                 </button>
               ))}
             </div>
-            <label className="mt-4 block text-sm text-[#85858A]">
-              Model
-              <select
-                value={selected?.id ?? modelId}
-                onChange={(e) => {
-                  cancelOAuthAttempt();
-                  setModelId(e.target.value);
-                }}
-                className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
-              >
-                {modelsForProvider.map((entry) => (
-                  <option key={`${entry.provider}:${entry.id}`} value={entry.id}>
-                    {entry.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            {isCustom ? (
+              <>
+                <label className="mt-4 block text-sm text-[#85858A]">
+                  Name
+                  <input
+                    value={endpointLabel}
+                    onChange={(e) => setEndpointLabel(e.target.value)}
+                    placeholder="Office vLLM"
+                    className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                  />
+                </label>
+                <label className="mt-4 block text-sm text-[#85858A]">
+                  Base URL
+                  <input
+                    value={baseUrl}
+                    onChange={(e) => setBaseUrl(e.target.value)}
+                    placeholder="https://api.example.com/v1"
+                    className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                  />
+                </label>
+                <label className="mt-4 block text-sm text-[#85858A]">
+                  Model
+                  {probedModels.length ? (
+                    <select
+                      value={modelId}
+                      onChange={(e) => setModelId(e.target.value)}
+                      className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                    >
+                      {probedModels.map((id) => (
+                        <option key={id} value={id}>
+                          {id}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      value={isCustomTemplate && modelId === "custom" ? "" : modelId}
+                      onChange={(e) => setModelId(e.target.value)}
+                      placeholder="llama3.1"
+                      className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                    />
+                  )}
+                </label>
+                <button
+                  type="button"
+                  disabled={probing || !baseUrl.trim()}
+                  onClick={() => void probeModels()}
+                  className="mt-3 text-[14px] text-[#C9C9CE] disabled:opacity-40"
+                >
+                  {probing ? "Fetching…" : "Fetch models"}
+                </button>
+              </>
+            ) : (
+              <label className="mt-4 block text-sm text-[#85858A]">
+                Model
+                <select
+                  value={selected?.id ?? modelId}
+                  onChange={(e) => {
+                    cancelOAuthAttempt();
+                    setModelId(e.target.value);
+                  }}
+                  className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+                >
+                  {modelsForProvider.map((entry) => (
+                    <option key={`${entry.provider}:${entry.id}`} value={entry.id}>
+                      {entry.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
             <p className="mt-2 text-[13px] text-[#85858A]">{selected?.billing}</p>
             {deviceSignIn ? (
               <div className="mt-4">
@@ -284,7 +383,7 @@ export function OnboardingPage() {
             ) : null}
             {acceptsKey ? (
               <label className="mt-4 block text-sm text-[#85858A]">
-                {deviceSignIn ? "Or paste an API key" : "API key"}
+                {deviceSignIn ? "Or paste an API key" : isCustom ? "API key (optional)" : "API key"}
                 <input
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -297,10 +297,11 @@ export function OnboardingPage() {
                     className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
                   />
                 </label>
-                <label className="mt-4 block text-sm text-[#85858A]">
-                  Model
+                <div className="mt-4 block text-sm text-[#85858A]">
+                  <label htmlFor="onboarding-custom-model">Model</label>
                   {probedModels.length ? (
                     <select
+                      id="onboarding-custom-model"
                       value={modelId}
                       onChange={(e) => setModelId(e.target.value)}
                       className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
@@ -313,13 +314,14 @@ export function OnboardingPage() {
                     </select>
                   ) : (
                     <input
+                      id="onboarding-custom-model"
                       value={isCustomTemplate && modelId === "custom" ? "" : modelId}
                       onChange={(e) => setModelId(e.target.value)}
                       placeholder="llama3.1"
                       className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
                     />
                   )}
-                </label>
+                </div>
                 <button
                   type="button"
                   disabled={probing || !baseUrl.trim()}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -5,7 +5,10 @@ import type {
   ComputerMode,
   ComputerStatus,
   Me,
+  ModelCatalogEntry,
+  ModelCredential,
   ProductEvent,
+  ReasoningStep,
   Routine,
   SearchHit,
   TaughtSkill,
@@ -1911,15 +1914,13 @@ const Transcript = memo(function Transcript({
           />
         </div>
       ))}
-      {running ? (
-        <div className="flex justify-start">
-          <div
-            className="rounded-[20px] bg-[#1A1A1D] px-[18px] py-[13px] text-[14.5px] text-[#85858A]"
-            style={{ animation: "rkPulse 1.2s ease-in-out infinite" }}
-          >
-            working…
-          </div>
-        </div>
+      {running &&
+      !messages.some(
+        (message) => message.id.startsWith("progress:") || message.id.startsWith("reasoning:"),
+      ) ? (
+        <ReasoningTrace
+          steps={[{ id: "status", kind: "status", title: "Starting", status: "running" }]}
+        />
       ) : null}
     </div>
   );
@@ -2164,6 +2165,9 @@ const MessageView = memo(function MessageView({
               </div>
             </div>
           );
+        }
+        if (block.kind === "reasoning") {
+          return <ReasoningTrace key={i} steps={block.steps} />;
         }
         if (block.kind === "subagent") {
           const running = block.status === "running";
@@ -2552,6 +2556,52 @@ function CreateBotForm({
   );
 }
 
+function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
+  if (!steps.length) return null;
+  const running = steps.some((step) => step.status === "running");
+  const active = [...steps].reverse().find((step) => step.status === "running") ?? steps.at(-1);
+  const headline = running ? (active?.title ?? "Thinking") : "Thought process";
+  return (
+    <details
+      open={running}
+      className="w-[min(520px,90%)] rounded-[18px] border border-[#232326] bg-[#141416] px-4 py-3"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-[13.5px] text-[#A8A8AD] [&::-webkit-details-marker]:hidden">
+        <span
+          className="h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{
+            background: running ? "#F5A03C" : "#4ECB71",
+            animation: running ? "rkPulse 1.2s ease-in-out infinite" : undefined,
+          }}
+        />
+        <span className="min-w-0 truncate font-medium text-[#C9C9CE]">{headline}</span>
+        <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">{running ? "live" : "done"}</span>
+      </summary>
+      <ol className="mt-3 space-y-2.5 border-t border-[#232326] pt-3">
+        {steps.map((step) => (
+          <li key={step.id} className="text-[13.5px]">
+            <div className="flex items-start gap-2">
+              <span className="mt-0.5 w-12 shrink-0 text-[11px] uppercase tracking-[0.06em] text-[#6C6C70]">
+                {step.kind === "think" ? "think" : step.kind === "tool" ? "tool" : "step"}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className={step.status === "running" ? "text-[#F5A03C]" : "text-[#C9C9CE]"}>
+                  {step.title}
+                </div>
+                {step.detail ? (
+                  <pre className="rk-scroll mt-1 max-h-48 overflow-y-auto whitespace-pre-wrap break-words font-sans text-[13px] leading-[1.45] text-[#85858A]">
+                    {step.detail}
+                  </pre>
+                ) : null}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
 function BotSettings({
   bot,
   onSave,
@@ -2567,6 +2617,8 @@ function BotSettings({
     computerMode: ComputerMode;
     autoSpeak?: boolean;
     voiceId?: string | null;
+    modelProvider?: string | null;
+    modelId?: string | null;
   }) => Promise<void>;
   onExport: () => Promise<void>;
   onClear: () => void;
@@ -2578,6 +2630,10 @@ function BotSettings({
   const [autoSpeak, setAutoSpeak] = useState(bot.autoSpeak);
   const [voiceId, setVoiceId] = useState(bot.voiceId ?? "");
   const [voices, setVoices] = useState<VoiceInfo[]>([]);
+  const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
+  const [credentials, setCredentials] = useState<ModelCredential[]>([]);
+  const [modelProvider, setModelProvider] = useState(bot.modelProvider ?? "");
+  const [modelId, setModelId] = useState(bot.modelId ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -2586,7 +2642,31 @@ function BotSettings({
       .voices({})
       .then(setVoices)
       .catch(() => setVoices([]));
+    void Promise.all([rpc.models.list(), rpc.models.credentials()])
+      .then(([nextCatalog, nextCredentials]) => {
+        setCatalog(nextCatalog);
+        setCredentials(nextCredentials);
+      })
+      .catch(() => undefined);
   }, []);
+
+  const connectedProviders = useMemo(() => {
+    const ids = new Set(credentials.map((entry) => entry.provider));
+    if (bot.modelProvider) ids.add(bot.modelProvider);
+    const grouped = new Map<string, ModelCatalogEntry[]>();
+    for (const entry of catalog) {
+      if (!ids.has(entry.provider)) continue;
+      const entries = grouped.get(entry.provider) ?? [];
+      entries.push(entry);
+      grouped.set(entry.provider, entries);
+    }
+    return [...grouped].map(([id, entries]) => ({
+      id,
+      name: entries[0]?.providerName ?? credentials.find((row) => row.provider === id)?.label ?? id,
+      entries,
+    }));
+  }, [bot.modelProvider, catalog, credentials]);
+  const modelsForProvider = catalog.filter((entry) => entry.provider === modelProvider);
 
   return (
     <div data-testid="bot-settings">
@@ -2618,6 +2698,52 @@ function BotSettings({
           className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
         />
       </label>
+      <label className="mt-4 block text-[14px] text-[#85858A]">
+        Inference
+        <select
+          value={modelProvider}
+          onChange={(event) => {
+            const nextProvider = event.target.value;
+            setModelProvider(nextProvider);
+            setModelId(
+              catalog.find((entry) => entry.provider === nextProvider)?.id ?? bot.modelId ?? "",
+            );
+          }}
+          className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+        >
+          <option value="">Workspace default</option>
+          {connectedProviders.map((group) => (
+            <option key={group.id} value={group.id}>
+              {group.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      {modelProvider ? (
+        <label className="mt-4 block text-[14px] text-[#85858A]">
+          Model
+          <select
+            value={modelId}
+            onChange={(event) => setModelId(event.target.value)}
+            className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+          >
+            {modelsForProvider.length ? (
+              modelsForProvider.map((entry) => (
+                <option key={`${entry.provider}:${entry.id}`} value={entry.id}>
+                  {entry.label}
+                </option>
+              ))
+            ) : (
+              <option value={modelId || ""}>{modelId || "Choose a model"}</option>
+            )}
+          </select>
+        </label>
+      ) : (
+        <p className="mt-2 text-[13px] text-[#6C6C70]">
+          Uses the workspace default from Models. Connect a custom endpoint there to add another
+          provider.
+        </p>
+      )}
       <ComputerModePicker value={computerMode} onChange={setComputerMode} />
       <label className="mt-5 flex cursor-pointer items-center gap-3 text-[14px] text-[#C9C9CE]">
         <input
@@ -2660,6 +2786,8 @@ function BotSettings({
               computerMode,
               autoSpeak,
               voiceId: voiceId || null,
+              modelProvider: modelProvider || null,
+              modelId: modelProvider ? modelId || null : null,
             })
               .catch((err) => setError(err instanceof Error ? err.message : "Could not save"))
               .finally(() => setSaving(false));

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -516,6 +516,7 @@ export function ShellPage() {
               event.type === "bot.spawned" ||
               event.type === "bot.deleted" ||
               event.type === "run.completed" ||
+              event.type === "run.failed" ||
               event.type === "thread.cleared"
             ) {
               void refreshBots().catch(() => undefined);
@@ -527,7 +528,11 @@ export function ShellPage() {
               }
               if (event.payload.role === "bot") markBotReadIfVisible(active.id);
             }
-            if (event.type === "run.completed" || event.type === "skill.teaching.stopped") {
+            if (
+              event.type === "run.completed" ||
+              event.type === "run.failed" ||
+              event.type === "skill.teaching.stopped"
+            ) {
               void refreshThread(active.id).catch(() => undefined);
             } else if (isComputerStatusEvent(event)) {
               void refreshComputerScreen(active.id).catch(() => undefined);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2575,7 +2575,9 @@ function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
           }}
         />
         <span className="min-w-0 truncate font-medium text-[#C9C9CE]">{headline}</span>
-        <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">{running ? "live" : "done"}</span>
+        <span className="ml-auto shrink-0 text-[12px] text-[#6C6C70]">
+          {running ? "live" : "done"}
+        </span>
       </summary>
       <ol className="mt-3 space-y-2.5 border-t border-[#232326] pt-3">
         {steps.map((step) => (

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -252,6 +252,8 @@ export interface AgentRunRequest {
     id: string;
     apiKey?: string;
     baseUrl?: string;
+    /** Deployment-owner opt-in for loopback/LAN gateway requests. */
+    allowPrivateNetwork?: boolean;
     /** In-process OAuth credential from the encrypted store for this run. */
     oauth?: {
       credential: AgentModelOAuthCredential;

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -281,7 +281,13 @@ export type AgentRuntimeEvent =
   | { type: "text"; text: string }
   | { type: "progress"; text: string }
   | { type: "reasoning"; step: ReasoningStep }
-  | { type: "tool"; name: string; args: Record<string, unknown>; executionId: string; status?: "running" | "done" }
+  | {
+      type: "tool";
+      name: string;
+      args: Record<string, unknown>;
+      executionId: string;
+      status?: "running" | "done";
+    }
   | { type: "ask"; text: string; detail?: string }
   | { type: "takeover"; reason: string }
   | { type: "usage"; inputTokens: number; outputTokens: number; provider: string; model: string }

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -1,4 +1,4 @@
-import type { SandboxKind } from "@rakazo/contracts";
+import type { ReasoningStep, SandboxKind } from "@rakazo/contracts";
 
 export interface AdapterContext {
   operationId: string;
@@ -251,6 +251,7 @@ export interface AgentRunRequest {
     provider: string;
     id: string;
     apiKey?: string;
+    baseUrl?: string;
     /** In-process OAuth credential from the encrypted store for this run. */
     oauth?: {
       credential: AgentModelOAuthCredential;
@@ -279,7 +280,8 @@ export interface ScriptedTurn {
 export type AgentRuntimeEvent =
   | { type: "text"; text: string }
   | { type: "progress"; text: string }
-  | { type: "tool"; name: string; args: Record<string, unknown>; executionId: string }
+  | { type: "reasoning"; step: ReasoningStep }
+  | { type: "tool"; name: string; args: Record<string, unknown>; executionId: string; status?: "running" | "done" }
   | { type: "ask"; text: string; detail?: string }
   | { type: "takeover"; reason: string }
   | { type: "usage"; inputTokens: number; outputTokens: number; provider: string; model: string }

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -278,6 +278,7 @@ export interface ScriptedTurn {
 
 export type AgentRuntimeEvent =
   | { type: "text"; text: string }
+  | { type: "error"; message: string }
   | { type: "progress"; text: string }
   | { type: "tool"; name: string; args: Record<string, unknown>; executionId: string }
   | { type: "ask"; text: string; detail?: string }

--- a/packages/adapters/src/background-job-handlers.test.ts
+++ b/packages/adapters/src/background-job-handlers.test.ts
@@ -7,12 +7,42 @@ import type {
 import type { PrismaClient, ThreadEvents } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import { createBackgroundJobHandlers } from "./background-job-handlers.js";
-import { createRunExecutor } from "./executor.js";
+import {
+  createRunExecutor,
+  redactedToolReasoningStep,
+  selectProviderCredential,
+} from "./executor.js";
 import { compactHistory } from "./history-compaction.js";
+import { EncryptedSecretStore } from "./secrets.js";
 
 vi.mock("./history-compaction.js", () => ({ compactHistory: vi.fn(async () => undefined) }));
 
 describe("createBackgroundJobHandlers", () => {
+  it("never crosses a default credential into a different requested provider", () => {
+    const defaultCredential = { provider: "provider-a", secretId: "secret-a" };
+    const requestedCredential = { provider: "provider-b", secretId: "secret-b" };
+
+    expect(selectProviderCredential(undefined, defaultCredential, null)).toBe(defaultCredential);
+    expect(selectProviderCredential("provider-b", defaultCredential, requestedCredential)).toBe(
+      requestedCredential,
+    );
+    expect(selectProviderCredential("provider-b", defaultCredential, null)).toBeNull();
+  });
+
+  it("redacts tool arguments before they enter live or durable reasoning traces", () => {
+    const step = redactedToolReasoningStep(
+      {
+        name: "shell",
+        args: { command: "curl -H 'Authorization: Bearer fake-sensitive-key' example.test" },
+        executionId: "tool-1",
+      },
+      ["fake-sensitive-key"],
+    );
+
+    expect(JSON.stringify(step)).not.toContain("fake-sensitive-key");
+    expect(JSON.stringify(step)).toContain("[redacted]");
+  });
+
   it("compacts the requested thread with the runtime, job publisher, and model key it was given", async () => {
     const prisma = {} as unknown as PrismaClient;
     const runtime = {} as unknown as AgentRuntime;
@@ -54,6 +84,8 @@ describe("createBackgroundJobHandlers", () => {
       provider: "openrouter",
       id: "deepseek/deepseek-v4-flash-0731",
       apiKey: "deployment-key",
+      baseUrl: undefined,
+      allowPrivateNetwork: false,
       oauth: undefined,
     });
   });
@@ -78,7 +110,63 @@ describe("createBackgroundJobHandlers", () => {
       provider: "local",
       id: "qwen3:4b",
       apiKey: undefined,
+      baseUrl: undefined,
+      allowPrivateNetwork: false,
       oauth: undefined,
+    });
+  });
+
+  it("resolves a custom background model with its own URL and never substitutes the deployment key", async () => {
+    const secretStore = new EncryptedSecretStore("fake-test-encryption-key");
+    const stored = await secretStore.put("fake-custom-gateway-key", {
+      operationId: "test",
+      traceId: "test",
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      signal: new AbortController().signal,
+    });
+    const credential = {
+      secretId: "secret-1",
+      provider: "gateway:fake",
+      defaultModel: "fake/model",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    };
+    const findSecret = vi.fn(
+      async (): Promise<{ id: string; ciphertext: string } | null> => ({
+        id: "secret-1",
+        ciphertext: stored.ciphertext,
+      }),
+    );
+    const prisma = {
+      userModelCredential: { findFirst: vi.fn(async () => credential) },
+      deploymentSettings: {
+        findUnique: vi.fn(async () => ({ ownerUserId: "user-1" })),
+      },
+      secret: { findUnique: findSecret },
+    } as unknown as PrismaClient;
+    const executor = createRunExecutor({
+      prisma,
+      secretStore,
+      deploymentModelKey: "fake-openrouter-deployment-key",
+    } as Parameters<typeof createRunExecutor>[0]);
+
+    await expect(
+      executor.resolveModel({ userId: "user-1", workspaceId: "workspace-1" }),
+    ).resolves.toEqual({
+      provider: "gateway:fake",
+      id: "fake/model",
+      apiKey: "fake-custom-gateway-key",
+      baseUrl: "http://127.0.0.1:11434/v1",
+      allowPrivateNetwork: true,
+      oauth: undefined,
+    });
+
+    findSecret.mockResolvedValueOnce(null);
+    await expect(
+      executor.resolveModel({ userId: "user-1", workspaceId: "workspace-1" }),
+    ).resolves.toMatchObject({
+      provider: "gateway:fake",
+      apiKey: undefined,
     });
   });
 });

--- a/packages/adapters/src/executor-model-credentials.test.ts
+++ b/packages/adapters/src/executor-model-credentials.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { type ExecutorDeps, resolveModelKey } from "./executor.js";
+
+function credentialDeps(secret: { id: string; ciphertext: string } | null) {
+  return {
+    prisma: {
+      userModelCredential: {
+        findUnique: vi.fn(async () => ({
+          secretId: "fallback-secret",
+          keys: [
+            {
+              secretId: "matching-secret",
+              isActive: false,
+              availableModels: "gemini-test-model",
+            },
+            {
+              secretId: "fallback-secret",
+              isActive: true,
+              availableModels: "gpt-test-model",
+            },
+          ],
+        })),
+      },
+      secret: {
+        findUnique: vi.fn(async () => secret),
+        update: vi.fn(async () => undefined),
+      },
+    },
+    secretStore: {
+      load: vi.fn((ciphertext: string) => ciphertext),
+      put: vi.fn(async () => ({ id: "replacement", ciphertext: "replacement" })),
+    },
+    deploymentModelKey: "fake-deployment-key",
+  } as unknown as ExecutorDeps;
+}
+
+describe("gateway model credential resolution", () => {
+  it("selects the key whose coverage contains the requested model", async () => {
+    const deps = credentialDeps({ id: "matching-secret", ciphertext: "fake-matching-key" });
+
+    const resolved = await resolveModelKey(
+      deps,
+      "user-1",
+      "workspace-1",
+      { id: "credential-1", secretId: "fallback-secret", provider: "gateway:test" },
+      "gemini-test-model",
+    );
+
+    expect(deps.prisma.secret.findUnique).toHaveBeenCalledWith({
+      where: { id: "matching-secret" },
+    });
+    expect(resolved.apiKey).toBe("fake-matching-key");
+    expect(resolved.redact).toContain("fake-matching-key");
+  });
+
+  it("never sends the deployment key to a custom endpoint when its personal key is missing", async () => {
+    const deps = credentialDeps(null);
+
+    const resolved = await resolveModelKey(
+      deps,
+      "user-1",
+      "workspace-1",
+      { id: "credential-1", secretId: "fallback-secret", provider: "gateway:test" },
+      "gemini-test-model",
+    );
+
+    expect(resolved).toEqual({ redact: [] });
+    expect(JSON.stringify(resolved)).not.toContain("fake-deployment-key");
+  });
+
+  it("still uses the deployment key when no personal credential exists", async () => {
+    const deps = credentialDeps(null);
+
+    await expect(
+      resolveModelKey(deps, "user-1", "workspace-1", null, "gpt-test-model"),
+    ).resolves.toEqual({ apiKey: "fake-deployment-key", redact: [] });
+  });
+});

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -343,30 +343,38 @@ export function createRunExecutor(deps: ExecutorDeps) {
 
       const runSecrets = [...deps.secrets];
       try {
-        const [bot, thread, messages, task, storedConnections, defaultCredential, settings, savedSkills] =
-          await Promise.all([
-            deps.prisma.bot.findUniqueOrThrow({
-              where: { id: run.botId },
-              include: { computer: true },
-            }),
-            deps.prisma.thread.findUniqueOrThrow({ where: { id: run.threadId } }),
-            deps.prisma.message.findMany({
-              where: { threadId: run.threadId },
-              orderBy: { seq: "desc" },
-              take: LEGACY_HISTORY_WINDOW_SIZE,
-              select: { role: true, runId: true, blocks: true },
-            }),
-            deps.prisma.task.findUniqueOrThrow({ where: { id: run.taskId } }),
-            deps.prisma.connection.findMany({
-              where: { userId: run.userId, workspaceId: run.workspaceId },
-              select: { id: true, provider: true, displayName: true, status: true },
-            }),
-            findDefaultModelCredential(deps.prisma, run),
-            deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
-            deps.prisma.taughtSkill.findMany({
-              where: { botId: run.botId, workspaceId: run.workspaceId, status: "saved" },
-            }),
-          ]);
+        const [
+          bot,
+          thread,
+          messages,
+          task,
+          storedConnections,
+          defaultCredential,
+          settings,
+          savedSkills,
+        ] = await Promise.all([
+          deps.prisma.bot.findUniqueOrThrow({
+            where: { id: run.botId },
+            include: { computer: true },
+          }),
+          deps.prisma.thread.findUniqueOrThrow({ where: { id: run.threadId } }),
+          deps.prisma.message.findMany({
+            where: { threadId: run.threadId },
+            orderBy: { seq: "desc" },
+            take: LEGACY_HISTORY_WINDOW_SIZE,
+            select: { role: true, runId: true, blocks: true },
+          }),
+          deps.prisma.task.findUniqueOrThrow({ where: { id: run.taskId } }),
+          deps.prisma.connection.findMany({
+            where: { userId: run.userId, workspaceId: run.workspaceId },
+            select: { id: true, provider: true, displayName: true, status: true },
+          }),
+          findDefaultModelCredential(deps.prisma, run),
+          deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
+          deps.prisma.taughtSkill.findMany({
+            where: { botId: run.botId, workspaceId: run.workspaceId, status: "saved" },
+          }),
+        ]);
         runAbortController = new AbortController();
         if (!leaseValid) runAbortController.abort();
         let credential = defaultCredential;
@@ -938,8 +946,13 @@ export function createRunExecutor(deps: ExecutorDeps) {
               currentTurnImages,
               tools,
               model: {
-                provider: bot.modelProvider ?? credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
-                id: bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
+                provider:
+                  bot.modelProvider ??
+                  credential?.provider ??
+                  settings?.defaultModelProvider ??
+                  "scripted",
+                id:
+                  bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 baseUrl: credential?.baseUrl ?? undefined,
                 oauth: resolved.oauth

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -946,6 +946,8 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 });
                 pendingProgress = "";
               }
+            } else if (event.type === "error") {
+              throw new Error(event.message);
             } else if (event.type === "progress") {
               await deps.events.append({
                 workspaceId: run.workspaceId,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1452,7 +1452,7 @@ async function runSandboxCommand(
   return { stdout, stderr, code };
 }
 
-async function resolveModelKey(
+export async function resolveModelKey(
   deps: ExecutorDeps,
   userId: string,
   workspaceId: string,
@@ -1476,7 +1476,9 @@ async function resolveModelKey(
     }
     return withModelCredentialLock(secretId, async () => {
       const row = await deps.prisma.secret.findUnique({ where: { id: secretId } });
-      if (!row) return { apiKey: deps.deploymentModelKey, redact: [] };
+      // A missing personal secret must never fall through to the deployment-wide key,
+      // especially when the credential points at a user-controlled custom endpoint.
+      if (!row) return { redact: [] };
       const plaintext = deps.secretStore!.load(row.ciphertext);
       registerSecrets?.(secretValuesToRedact(parseModelSecret(plaintext)));
       const persist = async (next: string) => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1132,7 +1132,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
           await checkpointAndRecordComputerWorkspace(deps, storedComputer, computer, context);
           terminalCheckpointComplete = true;
 
-          const text = redactSecrets(assembled || "done.", runSecrets);
+          const assembledText = assembled.trim();
+          if (!assembledText) {
+            throw new Error("The model returned no text");
+          }
+          const text = redactSecrets(assembledText, runSecrets);
           if (containsSecret(text, runSecrets)) {
             throw new Error("refusing to persist a secret in the thread");
           }

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -75,6 +75,7 @@ import {
   shouldEnqueueCompaction,
 } from "./history-compaction.js";
 import { loadAgentMemoryContext } from "./memory-context.js";
+import { isGatewayProvider, secretIdForGatewayModel } from "./openai-compatible.js";
 import { toOAuthCredential } from "./pi-credentials.js";
 import {
   parseModelSecret,
@@ -438,11 +439,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
             recallSucceeded,
           }),
         );
+        const resolvedModelId =
+          bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted";
         const resolved = await resolveModelKey(
           deps,
           run.userId,
           run.workspaceId,
           credential,
+          resolvedModelId,
           (values) => runSecrets.push(...values),
         );
         runSecrets.push(...resolved.redact);
@@ -898,8 +902,12 @@ export function createRunExecutor(deps: ExecutorDeps) {
               currentTurnImages,
               tools,
               model: {
-                provider: credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
-                id: credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
+                provider:
+                  bot.modelProvider ??
+                  credential?.provider ??
+                  settings?.defaultModelProvider ??
+                  "scripted",
+                id: resolvedModelId,
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }
@@ -1448,7 +1456,8 @@ async function resolveModelKey(
   deps: ExecutorDeps,
   userId: string,
   workspaceId: string,
-  credential: { secretId: string; provider: string } | null,
+  credential: { id: string; secretId: string; provider: string } | null,
+  modelId: string | undefined,
   registerSecrets?: (values: string[]) => void,
 ): Promise<{
   apiKey?: string;
@@ -1457,8 +1466,16 @@ async function resolveModelKey(
   redact: string[];
 }> {
   if (credential && deps.secretStore) {
-    return withModelCredentialLock(credential.secretId, async () => {
-      const row = await deps.prisma.secret.findUnique({ where: { id: credential.secretId } });
+    let secretId = credential.secretId;
+    if (isGatewayProvider(credential.provider)) {
+      const row = await deps.prisma.userModelCredential.findUnique({
+        where: { id: credential.id },
+        include: { keys: { orderBy: [{ createdAt: "asc" }, { id: "asc" }] } },
+      });
+      if (row) secretId = secretIdForGatewayModel(row, modelId);
+    }
+    return withModelCredentialLock(secretId, async () => {
+      const row = await deps.prisma.secret.findUnique({ where: { id: secretId } });
       if (!row) return { apiKey: deps.deploymentModelKey, redact: [] };
       const plaintext = deps.secretStore!.load(row.ciphertext);
       registerSecrets?.(secretValuesToRedact(parseModelSecret(plaintext)));
@@ -1484,9 +1501,9 @@ async function resolveModelKey(
         oauth,
         persistOAuth: oauth
           ? async (next) => {
-              await withModelCredentialLock(credential.secretId, async () => {
+              await withModelCredentialLock(secretId, async () => {
                 const currentRow = await deps.prisma.secret.findUnique({
-                  where: { id: credential.secretId },
+                  where: { id: secretId },
                 });
                 if (!currentRow) return;
                 const current = parseModelSecret(deps.secretStore!.load(currentRow.ciphertext));

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -137,6 +137,34 @@ export interface ExecutorDeps {
   listConnectedPluginSlugs?: (userId: string) => Promise<string[]>;
 }
 
+export function selectProviderCredential<T extends { provider: string }>(
+  requestedProvider: string | null | undefined,
+  defaultCredential: T | null,
+  requestedCredential: T | null,
+): T | null {
+  if (!requestedProvider) return defaultCredential;
+  return requestedCredential?.provider === requestedProvider ? requestedCredential : null;
+}
+
+export function redactedToolReasoningStep(
+  event: {
+    name: string;
+    args: Record<string, unknown>;
+    executionId: string;
+    status?: "running" | "done";
+  },
+  secrets: string[],
+): ReasoningStep {
+  const detail = reasoningToolDetail(event.name, event.args);
+  return {
+    id: event.executionId,
+    kind: "tool",
+    title: redactSecrets(reasoningToolTitle(event.name, event.args), secrets),
+    detail: detail ? redactSecrets(detail, secrets) : undefined,
+    status: event.status === "done" ? "done" : "running",
+  };
+}
+
 export async function deferFutureRoutine(
   jobs: JobPublisher,
   routineId: string,
@@ -198,11 +226,17 @@ export function createRunExecutor(deps: ExecutorDeps) {
         findDefaultModelCredential(deps.prisma, scope),
         deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
       ]);
-      const resolved = await resolveModelKey(deps, scope.userId, scope.workspaceId, credential);
       const provider =
         credential?.provider ??
         settings?.defaultModelProvider ??
         (deps.deploymentModelKey ? "openrouter" : "scripted");
+      const resolved = await resolveModelKey(
+        deps,
+        scope.userId,
+        scope.workspaceId,
+        credential,
+        provider,
+      );
       const id =
         credential?.defaultModel ??
         settings?.defaultModelId ??
@@ -213,6 +247,8 @@ export function createRunExecutor(deps: ExecutorDeps) {
         provider,
         id,
         apiKey: resolved.oauth ? undefined : resolved.apiKey,
+        baseUrl: credential?.baseUrl ?? undefined,
+        allowPrivateNetwork: Boolean(credential?.baseUrl) && settings?.ownerUserId === scope.userId,
         oauth: resolved.oauth
           ? { credential: resolved.oauth, persist: resolved.persistOAuth }
           : undefined,
@@ -419,7 +455,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             },
             orderBy: newestModelCredentialOrder,
           });
-          if (specific) credential = specific;
+          credential = selectProviderCredential(bot.modelProvider, defaultCredential, specific);
         }
         let liveSlugs: string[] = [];
         if (needsLivePluginSync(storedConnections)) {
@@ -506,11 +542,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
             }),
           );
         }
+        const provider =
+          bot.modelProvider ?? credential?.provider ?? settings?.defaultModelProvider ?? "scripted";
+        if (credential?.provider !== provider) credential = null;
         const resolved = await resolveModelKey(
           deps,
           run.userId,
           run.workspaceId,
           credential,
+          provider,
           (values) => runSecrets.push(...values),
         );
         runSecrets.push(...resolved.redact);
@@ -1009,15 +1049,13 @@ export function createRunExecutor(deps: ExecutorDeps) {
               currentTurnImages,
               tools,
               model: {
-                provider:
-                  bot.modelProvider ??
-                  credential?.provider ??
-                  settings?.defaultModelProvider ??
-                  "scripted",
+                provider,
                 id:
                   bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 baseUrl: credential?.baseUrl ?? undefined,
+                allowPrivateNetwork:
+                  Boolean(credential?.baseUrl) && settings?.ownerUserId === run.userId,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }
                   : undefined,
@@ -1169,13 +1207,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 runId,
                 payload: { name: event.name, executionId: event.executionId },
               });
-              reasoningSteps = upsertReasoningStep(reasoningSteps, {
-                id: event.executionId,
-                kind: "tool",
-                title: reasoningToolTitle(event.name, event.args),
-                detail: reasoningToolDetail(event.name, event.args),
-                status: event.status === "done" ? "done" : "running",
-              });
+              reasoningSteps = upsertReasoningStep(
+                reasoningSteps,
+                redactedToolReasoningStep(event, runSecrets),
+              );
               await publishReasoning(event.status === "done");
               if (scripted) await applyTool(event.name, event.args, event.executionId);
             } else if (event.type === "subagent") {
@@ -1601,6 +1636,7 @@ async function resolveModelKey(
   userId: string,
   workspaceId: string,
   credential: { secretId: string; provider: string } | null,
+  provider: string,
   registerSecrets?: (values: string[]) => void,
 ): Promise<{
   apiKey?: string;
@@ -1611,7 +1647,7 @@ async function resolveModelKey(
   if (credential && deps.secretStore) {
     return withModelCredentialLock(credential.secretId, async () => {
       const row = await deps.prisma.secret.findUnique({ where: { id: credential.secretId } });
-      if (!row) return { apiKey: deps.deploymentModelKey, redact: [] };
+      if (!row) return { redact: [] };
       const plaintext = deps.secretStore!.load(row.ciphertext);
       registerSecrets?.(secretValuesToRedact(parseModelSecret(plaintext)));
       const persist = async (next: string) => {
@@ -1665,7 +1701,11 @@ async function resolveModelKey(
       };
     });
   }
-  return { apiKey: deps.deploymentModelKey, redact: [] };
+  return {
+    apiKey:
+      provider === "openrouter" || provider === "scripted" ? deps.deploymentModelKey : undefined,
+    redact: [],
+  };
 }
 
 async function withModelCredentialLock<T>(key: string, fn: () => Promise<T>): Promise<T> {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -13,7 +13,7 @@ import type {
   SandboxProvider,
 } from "@rakazo/adapter-kit";
 import { historyCompactJob, routineWakeupJob, runContinueJob } from "@rakazo/adapter-kit";
-import type { MessageBlock, RunStatus } from "@rakazo/contracts";
+import type { MessageBlock, ReasoningStep, RunStatus } from "@rakazo/contracts";
 import { ATTACHMENT_MAX_BYTES, isAttachmentImageMimeType } from "@rakazo/contracts";
 import {
   assertTransition,
@@ -26,13 +26,17 @@ import {
   nextCronDate,
   nextFence,
   promptInvokesSkill,
+  reasoningToolDetail,
+  reasoningToolTitle,
   redactSecrets,
   sandboxCommandTimeoutMs,
+  upsertReasoningStep,
   userTurnBlocksForRun,
 } from "@rakazo/core";
 import {
   createThreadMessage,
   findDefaultModelCredential,
+  newestModelCredentialOrder,
   type PrismaClient,
   parseComputerMode,
   type ThreadEvents,
@@ -339,7 +343,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
 
       const runSecrets = [...deps.secrets];
       try {
-        const [bot, thread, messages, task, storedConnections, credential, settings, savedSkills] =
+        const [bot, thread, messages, task, storedConnections, defaultCredential, settings, savedSkills] =
           await Promise.all([
             deps.prisma.bot.findUniqueOrThrow({
               where: { id: run.botId },
@@ -365,6 +369,18 @@ export function createRunExecutor(deps: ExecutorDeps) {
           ]);
         runAbortController = new AbortController();
         if (!leaseValid) runAbortController.abort();
+        let credential = defaultCredential;
+        if (bot.modelProvider) {
+          const specific = await deps.prisma.userModelCredential.findFirst({
+            where: {
+              userId: run.userId,
+              workspaceId: run.workspaceId,
+              provider: bot.modelProvider,
+            },
+            orderBy: newestModelCredentialOrder,
+          });
+          if (specific) credential = specific;
+        }
         let liveSlugs: string[] = [];
         if (needsLivePluginSync(storedConnections)) {
           const listing = await loadLivePluginSlugs(deps.listConnectedPluginSlugs, run.userId);
@@ -482,9 +498,25 @@ export function createRunExecutor(deps: ExecutorDeps) {
         let assembled = "";
         let pendingProgress = "";
         let lastProgressAt = 0;
+        let lastReasoningAt = 0;
+        let reasoningSteps: ReasoningStep[] = [];
         let lastComputerFrameId: string | undefined;
         let terminalCheckpointComplete = false;
         const progressRedactor = createStreamingRedactor(runSecrets);
+        const publishReasoning = async (force = false) => {
+          if (!reasoningSteps.length) return;
+          const now = Date.now();
+          if (!force && now - lastReasoningAt < 120) return;
+          lastReasoningAt = now;
+          await deps.events.append({
+            workspaceId: run.workspaceId,
+            threadId: thread.id,
+            botId: bot.id,
+            type: "thread.reasoning",
+            runId,
+            payload: { steps: reasoningSteps },
+          });
+        };
         const scripted = deps.runtime.describe().capabilities.scripted;
         const script = scripted
           ? inferScript(task.prompt, resumeFromTakeover ? "takeover" : undefined)
@@ -871,6 +903,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
             )}\n\n${taskPrompt}`
           : taskPrompt;
 
+        reasoningSteps = upsertReasoningStep(reasoningSteps, {
+          id: "status",
+          kind: "status",
+          title: "Starting",
+          status: "running",
+        });
+        await publishReasoning(true);
+
         try {
           for await (const event of deps.runtime.run(
             {
@@ -898,9 +938,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
               currentTurnImages,
               tools,
               model: {
-                provider: credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
-                id: credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
+                provider: bot.modelProvider ?? credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
+                id: bot.modelId ?? credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
+                baseUrl: credential?.baseUrl ?? undefined,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }
                   : undefined,
@@ -955,6 +996,16 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 runId,
                 payload: { text: redactSecrets(event.text, runSecrets) },
               });
+            } else if (event.type === "reasoning") {
+              const step = {
+                ...event.step,
+                title: redactSecrets(event.step.title, runSecrets),
+                detail: event.step.detail
+                  ? redactSecrets(event.step.detail, runSecrets)
+                  : undefined,
+              };
+              reasoningSteps = upsertReasoningStep(reasoningSteps, step);
+              await publishReasoning(event.step.status === "done");
             } else if (event.type === "ask") {
               if (!(await renewRunLease(deps, runId, workerId, fence))) return;
               const safeText = redactSecrets(event.text, runSecrets);
@@ -1042,6 +1093,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 runId,
                 payload: { name: event.name, executionId: event.executionId },
               });
+              reasoningSteps = upsertReasoningStep(reasoningSteps, {
+                id: event.executionId,
+                kind: "tool",
+                title: reasoningToolTitle(event.name, event.args),
+                detail: reasoningToolDetail(event.name, event.args),
+                status: event.status === "done" ? "done" : "running",
+              });
+              await publishReasoning(event.status === "done");
               if (scripted) await applyTool(event.name, event.args, event.executionId);
             } else if (event.type === "subagent") {
               const safeTask = redactSecrets(event.task, runSecrets);
@@ -1092,6 +1151,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
               });
             } else if (event.type === "done") {
               assembled = assembled || event.text || assembled;
+              reasoningSteps = reasoningSteps.map((step) =>
+                step.status === "running" ? { ...step, status: "done" as const } : step,
+              );
+              await publishReasoning(true);
             }
           }
 
@@ -1137,6 +1200,16 @@ export function createRunExecutor(deps: ExecutorDeps) {
             throw new Error("refusing to persist a secret in the thread");
           }
           if (!(await renewRunLease(deps, runId, workerId, fence))) return;
+          const completedBlocks: MessageBlock[] = [];
+          if (reasoningSteps.length) {
+            completedBlocks.push({
+              kind: "reasoning",
+              steps: reasoningSteps.map((step) =>
+                step.status === "running" ? { ...step, status: "done" as const } : step,
+              ),
+            });
+          }
+          completedBlocks.push({ kind: "text", text });
           const completed = await deps.events.finalizeRun({
             workspaceId: run.workspaceId,
             threadId: thread.id,
@@ -1147,7 +1220,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             leaseOwner: workerId,
             leaseFence: fence,
             outcome: "completed",
-            blocks: [{ kind: "text", text }],
+            blocks: completedBlocks,
           });
           if (!completed) return;
           if (bot.notifyOnFinish) {
@@ -1340,7 +1413,9 @@ async function requeueComputerRun(
 }
 
 async function clearRunProgress(deps: ExecutorDeps, runId: string): Promise<void> {
-  await deps.prisma.event.deleteMany({ where: { runId, type: "thread.progress" } });
+  await deps.prisma.event.deleteMany({
+    where: { runId, type: { in: ["thread.progress", "thread.reasoning"] } },
+  });
 }
 
 async function publishMessage(

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -30,7 +30,7 @@ export * from "./home.js";
 export * from "./host-aware-sandbox.js";
 export * from "./job-reconciler.js";
 export * from "./mcp-emulator.js";
-export * from "./openai-voice.js";
+export * from "./openai-compatible.js";
 export * from "./pi-models.js";
 export * from "./pi-oauth.js";
 export * from "./pi-runtime.js";

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  GATEWAY_PROVIDER_PREFIX,
+  isGatewayProvider,
+  normalizeOpenAICompatibleBaseUrl,
+  parseAvailableModels,
+  serializeAvailableModels,
+} from "./openai-compatible.js";
+
+describe("openai-compatible gateways", () => {
+  it("normalizes hostnames, trailing slashes, and missing protocols", () => {
+    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe("http://localhost:11434/v1");
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/")).toBe(
+      "https://api.example.com/v1",
+    );
+  });
+
+  it("rejects non-http URLs", () => {
+    expect(() => normalizeOpenAICompatibleBaseUrl("ftp://example.com")).toThrow(/http/);
+  });
+
+  it("round-trips model lists and recognizes gateway provider ids", () => {
+    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual(["gpt-4o", "llama3", "mistral"]);
+    expect(serializeAvailableModels(["gpt-4o", "gpt-4o", "llama3"])).toBe("gpt-4o\nllama3");
+    expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
+    expect(isGatewayProvider("openai-compatible")).toBe(true);
+    expect(isGatewayProvider("openrouter")).toBe(false);
+  });
+});

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,5 +1,7 @@
+import { createServer } from "node:http";
 import { describe, expect, it } from "vitest";
 import {
+  fetchOpenAICompatibleModels,
   GATEWAY_PROVIDER_PREFIX,
   isGatewayProvider,
   labelForDiscoveredModels,
@@ -22,6 +24,80 @@ describe("openai-compatible gateways", () => {
 
   it("rejects non-http URLs", () => {
     expect(() => normalizeOpenAICompatibleBaseUrl("ftp://example.com")).toThrow(/http/);
+    expect(() => normalizeOpenAICompatibleBaseUrl("https://user:pass@example.com/v1")).toThrow(
+      /credentials/,
+    );
+  });
+
+  it("blocks private-network model probes unless deployment-owner access is explicit", async () => {
+    let requests = 0;
+    const server = createServer((_request, response) => {
+      requests += 1;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: [{ id: "local-model" }] }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const baseUrl = `http://127.0.0.1:${port}/v1`;
+    try {
+      await expect(fetchOpenAICompatibleModels(baseUrl, "fake-probe-key")).rejects.toThrow(
+        /deployment-owner/,
+      );
+      expect(requests).toBe(0);
+      await expect(
+        fetchOpenAICompatibleModels(baseUrl, "fake-probe-key", undefined, {
+          allowPrivateNetwork: true,
+        }),
+      ).resolves.toEqual(["local-model"]);
+      expect(requests).toBe(1);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("does not forward an API key across model-discovery origins", async () => {
+    let forwardedAuthorization = "";
+    const destination = createServer((request, response) => {
+      forwardedAuthorization = String(request.headers.authorization ?? "");
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: [{ id: "redirected-model" }] }));
+    });
+    await new Promise<void>((resolve) => destination.listen(0, "127.0.0.1", resolve));
+    const destinationAddress = destination.address();
+    const destinationPort =
+      typeof destinationAddress === "object" && destinationAddress ? destinationAddress.port : 0;
+    const source = createServer((_request, response) => {
+      response.writeHead(302, {
+        location: `http://127.0.0.1:${destinationPort}/v1/models`,
+      });
+      response.end();
+    });
+    await new Promise<void>((resolve) => source.listen(0, "127.0.0.1", resolve));
+    const sourceAddress = source.address();
+    const sourcePort = typeof sourceAddress === "object" && sourceAddress ? sourceAddress.port : 0;
+    try {
+      await expect(
+        fetchOpenAICompatibleModels(
+          `http://127.0.0.1:${sourcePort}/v1`,
+          "fake-origin-key",
+          undefined,
+          { allowPrivateNetwork: true },
+        ),
+      ).resolves.toEqual(["redirected-model"]);
+      expect(forwardedAuthorization).toBe("");
+    } finally {
+      await Promise.all(
+        [source, destination].map(
+          (server) =>
+            new Promise<void>((resolve, reject) =>
+              server.close((error) => (error ? reject(error) : resolve())),
+            ),
+        ),
+      );
+    }
   });
 
   it("round-trips model lists and recognizes gateway provider ids", () => {

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  errorFromOpenAICompatibleBody,
+  extractChatMessageText,
+  GATEWAY_PROVIDER_PREFIX,
+  isGatewayProvider,
+  labelForDiscoveredModels,
+  normalizeOpenAICompatibleBaseUrl,
+  openaiCompatibleModel,
+  parseAvailableModels,
+  secretIdForGatewayModel,
+  serializeAvailableModels,
+  textFromOpenAICompatibleBody,
+  unionAvailableModels,
+} from "./openai-compatible.js";
+
+describe("openai-compatible gateways", () => {
+  it("normalizes hostnames, trailing slashes, and missing protocols", () => {
+    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe(
+      "http://localhost:11434/v1",
+    );
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/")).toBe(
+      "https://api.example.com/v1",
+    );
+  });
+
+  it("rejects non-http URLs", () => {
+    expect(() => normalizeOpenAICompatibleBaseUrl("ftp://example.com")).toThrow(/http/);
+  });
+
+  it("round-trips model lists and recognizes gateway provider ids", () => {
+    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual([
+      "gpt-4o",
+      "llama3",
+      "mistral",
+    ]);
+    expect(serializeAvailableModels(["gpt-4o", "gpt-4o", "llama3"])).toBe("gpt-4o\nllama3");
+    expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
+    expect(isGatewayProvider("openai-compatible")).toBe(true);
+    expect(isGatewayProvider("openrouter")).toBe(false);
+  });
+
+  it("does not require streamed finish_reason on custom endpoints", () => {
+    const model = openaiCompatibleModel(
+      `${GATEWAY_PROVIDER_PREFIX}abc`,
+      "gemini-2.5-flash",
+      "https://generativelanguage.googleapis.com/v1beta/openai",
+    );
+    expect(model.compat).toMatchObject({
+      supportsFinishReason: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    });
+    expect(model.reasoning).toBe(false);
+  });
+
+  it("picks the key whose discovered models include the requested model", () => {
+    const credential = {
+      secretId: "active-secret",
+      keys: [
+        {
+          secretId: "gemini-secret",
+          isActive: false,
+          availableModels: "gemini-2.5-pro\ngemini-2.5-flash",
+        },
+        {
+          secretId: "active-secret",
+          isActive: true,
+          availableModels: "gpt-4o\no4-mini",
+        },
+      ],
+    };
+    expect(secretIdForGatewayModel(credential, "gemini-2.5-flash")).toBe("gemini-secret");
+    expect(secretIdForGatewayModel(credential, "gpt-4o")).toBe("active-secret");
+    expect(secretIdForGatewayModel(credential, "unknown-model")).toBe("active-secret");
+    expect(secretIdForGatewayModel(credential, undefined)).toBe("active-secret");
+    expect(unionAvailableModels(credential.keys)).toEqual([
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gpt-4o",
+      "o4-mini",
+    ]);
+    expect(labelForDiscoveredModels(["gemini-2.5-pro", "gemini-2.0-flash"])).toBe("Gemini");
+    expect(labelForDiscoveredModels(["gpt-4o", "gpt-4.1"])).toBe("GPT");
+    expect(labelForDiscoveredModels(["o4-mini"])).toBe("OpenAI");
+    expect(labelForDiscoveredModels(["gemini-2.5-pro", "gpt-4o"])).toBe("API key");
+  });
+
+  it("reads string, array, and SSE chat completion bodies", () => {
+    expect(
+      extractChatMessageText({
+        choices: [{ message: { content: "Hello from JSON" } }],
+      }),
+    ).toBe("Hello from JSON");
+    expect(
+      extractChatMessageText({
+        choices: [
+          {
+            delta: {
+              content: [
+                { type: "text", text: "Hel" },
+                { type: "text", text: "lo" },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toBe("Hello");
+    expect(
+      textFromOpenAICompatibleBody(
+        'data: {"choices":[{"delta":{"content":"Hi"}}]}\ndata: [DONE]\n',
+        "text/event-stream",
+      ),
+    ).toBe("Hi");
+  });
+
+  it("surfaces the gateway error body, not a generic status", () => {
+    expect(
+      errorFromOpenAICompatibleBody(
+        JSON.stringify({
+          error: { message: "Invalid API key provided", type: "invalid_request_error" },
+        }),
+        401,
+      ),
+    ).toBe("401: Invalid API key provided");
+    expect(
+      errorFromOpenAICompatibleBody(
+        JSON.stringify({
+          error: { errors: [{ message: "Model gemini-2.5-pro is not found" }] },
+        }),
+        404,
+      ),
+    ).toBe("404: Model gemini-2.5-pro is not found");
+    expect(errorFromOpenAICompatibleBody("upstream refused the stream", 502)).toBe(
+      "502: upstream refused the stream",
+    );
+  });
+});

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -9,7 +9,9 @@ import {
 
 describe("openai-compatible gateways", () => {
   it("normalizes hostnames, trailing slashes, and missing protocols", () => {
-    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe("http://localhost:11434/v1");
+    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe(
+      "http://localhost:11434/v1",
+    );
     expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/")).toBe(
       "https://api.example.com/v1",
     );
@@ -20,7 +22,11 @@ describe("openai-compatible gateways", () => {
   });
 
   it("round-trips model lists and recognizes gateway provider ids", () => {
-    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual(["gpt-4o", "llama3", "mistral"]);
+    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual([
+      "gpt-4o",
+      "llama3",
+      "mistral",
+    ]);
     expect(serializeAvailableModels(["gpt-4o", "gpt-4o", "llama3"])).toBe("gpt-4o\nllama3");
     expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
     expect(isGatewayProvider("openai-compatible")).toBe(true);

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -135,5 +135,8 @@ describe("openai-compatible gateways", () => {
     expect(errorFromOpenAICompatibleBody("upstream refused the stream", 502)).toBe(
       "502: upstream refused the stream",
     );
+    expect(errorFromOpenAICompatibleBody('{"choices":[{"message":{"content":""}}]}', 200)).toBe(
+      "The gateway returned an empty reply",
+    );
   });
 });

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,11 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  assertOpenAICompatibleBaseUrlAllowed,
+  createOpenAICompatibleFetch,
+  fetchOpenAICompatibleModels,
   GATEWAY_PROVIDER_PREFIX,
   isGatewayProvider,
+  isGloballyRoutableAddress,
   normalizeOpenAICompatibleBaseUrl,
   parseAvailableModels,
   serializeAvailableModels,
 } from "./openai-compatible.js";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve, reject) =>
+            server.close((error) => (error ? reject(error) : resolve())),
+          ),
+      ),
+  );
+});
 
 describe("openai-compatible gateways", () => {
   it("normalizes hostnames, trailing slashes, and missing protocols", () => {
@@ -19,6 +39,81 @@ describe("openai-compatible gateways", () => {
 
   it("rejects non-http URLs", () => {
     expect(() => normalizeOpenAICompatibleBaseUrl("ftp://example.com")).toThrow(/http/);
+    expect(() => normalizeOpenAICompatibleBaseUrl("http://user:pass@example.com/v1")).toThrow(
+      /credentials/,
+    );
+  });
+
+  it("classifies private, metadata, documentation, and public addresses", () => {
+    expect(isGloballyRoutableAddress("127.0.0.1")).toBe(false);
+    expect(isGloballyRoutableAddress("169.254.169.254")).toBe(false);
+    expect(isGloballyRoutableAddress("203.0.113.4")).toBe(false);
+    expect(isGloballyRoutableAddress("8.8.8.8")).toBe(true);
+    expect(isGloballyRoutableAddress("::1")).toBe(false);
+    expect(isGloballyRoutableAddress("2606:4700:4700::1111")).toBe(true);
+  });
+
+  it("allows owner loopback endpoints but blocks them for other users and always blocks metadata", async () => {
+    await expect(
+      assertOpenAICompatibleBaseUrlAllowed("http://127.0.0.1:11434/v1", {
+        allowPrivateNetwork: true,
+      }),
+    ).resolves.toBe("http://127.0.0.1:11434/v1");
+    await expect(assertOpenAICompatibleBaseUrlAllowed("http://127.0.0.1:11434/v1")).rejects.toThrow(
+      /private or local/,
+    );
+    await expect(
+      assertOpenAICompatibleBaseUrlAllowed("http://169.254.169.254/v1", {
+        allowPrivateNetwork: true,
+      }),
+    ).rejects.toThrow(/prohibited/);
+    await expect(
+      assertOpenAICompatibleBaseUrlAllowed("http://10.0.0.8/v1", {
+        allowPrivateNetwork: true,
+        hasCredentials: true,
+      }),
+    ).rejects.toThrow(/credentials require HTTPS/);
+  });
+
+  it("lists models from a bounded local fake gateway without requiring a key", async () => {
+    const server = createServer((request, response) => {
+      expect(request.url).toBe("/v1/models");
+      expect(request.headers.authorization).toBeUndefined();
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ data: [{ id: "fake-model" }, { id: "fake-model" }] }));
+    });
+    servers.push(server);
+    const baseUrl = await listen(server);
+
+    await expect(
+      fetchOpenAICompatibleModels(`${baseUrl}/v1`, undefined, undefined, {
+        allowPrivateNetwork: true,
+      }),
+    ).resolves.toEqual(["fake-model"]);
+  });
+
+  it("removes credentials before following a cross-origin redirect", async () => {
+    let redirectedAuthorization: string | undefined;
+    const destination = createServer((request, response) => {
+      redirectedAuthorization = request.headers.authorization;
+      response.end("ok");
+    });
+    servers.push(destination);
+    const destinationUrl = await listen(destination);
+    const source = createServer((_request, response) => {
+      response.statusCode = 307;
+      response.setHeader("location", destinationUrl);
+      response.end();
+    });
+    servers.push(source);
+    const sourceUrl = await listen(source);
+
+    const response = await createOpenAICompatibleFetch({ allowPrivateNetwork: true })(sourceUrl, {
+      headers: { authorization: "Bearer fake-gateway-key" },
+    });
+
+    expect(await response.text()).toBe("ok");
+    expect(redirectedAuthorization).toBeUndefined();
   });
 
   it("round-trips model lists and recognizes gateway provider ids", () => {
@@ -33,3 +128,15 @@ describe("openai-compatible gateways", () => {
     expect(isGatewayProvider("openrouter")).toBe(false);
   });
 });
+
+function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") return reject(new Error("Missing test port"));
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  GATEWAY_PROVIDER_PREFIX,
+  isGatewayProvider,
+  labelForDiscoveredModels,
+  normalizeOpenAICompatibleBaseUrl,
+  parseAvailableModels,
+  secretIdForGatewayModel,
+  serializeAvailableModels,
+  unionAvailableModels,
+} from "./openai-compatible.js";
+
+describe("openai-compatible gateways", () => {
+  it("normalizes hostnames, trailing slashes, and missing protocols", () => {
+    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe(
+      "http://localhost:11434/v1",
+    );
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/")).toBe(
+      "https://api.example.com/v1",
+    );
+  });
+
+  it("rejects non-http URLs", () => {
+    expect(() => normalizeOpenAICompatibleBaseUrl("ftp://example.com")).toThrow(/http/);
+  });
+
+  it("round-trips model lists and recognizes gateway provider ids", () => {
+    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual([
+      "gpt-4o",
+      "llama3",
+      "mistral",
+    ]);
+    expect(serializeAvailableModels(["gpt-4o", "gpt-4o", "llama3"])).toBe("gpt-4o\nllama3");
+    expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
+    expect(isGatewayProvider("openai-compatible")).toBe(true);
+    expect(isGatewayProvider("openrouter")).toBe(false);
+  });
+
+  it("picks the key whose discovered models include the requested model", () => {
+    const credential = {
+      secretId: "active-secret",
+      keys: [
+        {
+          secretId: "gemini-secret",
+          isActive: false,
+          availableModels: "gemini-2.5-pro\ngemini-2.5-flash",
+        },
+        {
+          secretId: "active-secret",
+          isActive: true,
+          availableModels: "gpt-4o\no4-mini",
+        },
+      ],
+    };
+    expect(secretIdForGatewayModel(credential, "gemini-2.5-flash")).toBe("gemini-secret");
+    expect(secretIdForGatewayModel(credential, "gpt-4o")).toBe("active-secret");
+    expect(secretIdForGatewayModel(credential, "unknown-model")).toBe("active-secret");
+    expect(secretIdForGatewayModel(credential, undefined)).toBe("active-secret");
+    expect(unionAvailableModels(credential.keys)).toEqual([
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gpt-4o",
+      "o4-mini",
+    ]);
+    expect(labelForDiscoveredModels(["gemini-2.5-pro", "gemini-2.0-flash"])).toBe("Gemini");
+    expect(labelForDiscoveredModels(["gpt-4o", "gpt-4.1"])).toBe("GPT");
+    expect(labelForDiscoveredModels(["o4-mini"])).toBe("OpenAI");
+    expect(labelForDiscoveredModels(["gemini-2.5-pro", "gpt-4o"])).toBe("API key");
+  });
+});

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -15,6 +15,9 @@ export function mintGatewayProviderId(): string {
 export function normalizeOpenAICompatibleBaseUrl(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error("Enter a base URL");
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed) && !/^https?:\/\//i.test(trimmed)) {
+    throw new Error("Base URL must be http or https");
+  }
   const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
   let parsed: URL;
   try {
@@ -61,11 +64,7 @@ export async function fetchOpenAICompatibleModels(
     throw new Error(`Could not list models (${response.status})`);
   }
   const body = (await response.json()) as { data?: unknown; models?: unknown };
-  const rows = Array.isArray(body.data)
-    ? body.data
-    : Array.isArray(body.models)
-      ? body.models
-      : [];
+  const rows = Array.isArray(body.data) ? body.data : Array.isArray(body.models) ? body.models : [];
   const ids = rows.flatMap((row) => {
     if (typeof row === "string") return [row];
     if (row && typeof row === "object" && "id" in row) return [String((row as { id: unknown }).id)];
@@ -119,7 +118,9 @@ export function attachOpenAICompatibleProvider(
       auth: {
         apiKey: {
           name: "Custom endpoint",
-          resolve: async () => ({ auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {} }),
+          resolve: async () => ({
+            auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {},
+          }),
         },
       },
       models: ids.map((id) => openaiCompatibleModel(input.provider, id, baseUrl)),

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -1,0 +1,129 @@
+import { createProvider, type Model, type MutableModels } from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+export const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
+export const GATEWAY_PROVIDER_PREFIX = "gateway:";
+
+export function isGatewayProvider(provider: string): boolean {
+  return provider === OPENAI_COMPATIBLE_PROVIDER || provider.startsWith(GATEWAY_PROVIDER_PREFIX);
+}
+
+export function mintGatewayProviderId(): string {
+  return `${GATEWAY_PROVIDER_PREFIX}${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
+}
+
+export function normalizeOpenAICompatibleBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("Enter a base URL");
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(withProtocol);
+  } catch {
+    throw new Error("Enter a valid http(s) base URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Base URL must be http or https");
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  const path = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = path || "/";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+export function parseAvailableModels(value: string | null | undefined): string[] {
+  if (!value?.trim()) return [];
+  return [
+    ...new Set(
+      value
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+export function serializeAvailableModels(models: string[]): string {
+  return [...new Set(models.map((entry) => entry.trim()).filter(Boolean))].join("\n");
+}
+
+export async function fetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const endpoint = `${normalizeOpenAICompatibleBaseUrl(baseUrl)}/models`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (apiKey?.trim()) headers.authorization = `Bearer ${apiKey.trim()}`;
+  const response = await fetch(endpoint, { headers, signal });
+  if (!response.ok) {
+    throw new Error(`Could not list models (${response.status})`);
+  }
+  const body = (await response.json()) as { data?: unknown; models?: unknown };
+  const rows = Array.isArray(body.data)
+    ? body.data
+    : Array.isArray(body.models)
+      ? body.models
+      : [];
+  const ids = rows.flatMap((row) => {
+    if (typeof row === "string") return [row];
+    if (row && typeof row === "object" && "id" in row) return [String((row as { id: unknown }).id)];
+    return [];
+  });
+  if (!ids.length) throw new Error("That endpoint did not return any models");
+  return [...new Set(ids)];
+}
+
+export function openaiCompatibleModel(
+  provider: string,
+  modelId: string,
+  baseUrl: string,
+): Model<"openai-completions"> {
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    provider,
+    baseUrl,
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStore: false,
+    },
+  };
+}
+
+export function attachOpenAICompatibleProvider(
+  models: MutableModels,
+  input: {
+    provider: string;
+    baseUrl: string;
+    modelId: string;
+    apiKey?: string;
+    extraModelIds?: string[];
+  },
+): void {
+  const baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl);
+  const ids = [...new Set([input.modelId, ...(input.extraModelIds ?? [])].filter(Boolean))];
+  models.setProvider(
+    createProvider({
+      id: input.provider,
+      name: input.provider,
+      baseUrl,
+      auth: {
+        apiKey: {
+          name: "Custom endpoint",
+          resolve: async () => ({ auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {} }),
+        },
+      },
+      models: ids.map((id) => openaiCompatibleModel(input.provider, id, baseUrl)),
+      api: openAICompletionsApi(),
+    }),
+  );
+}

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -1,0 +1,376 @@
+import { createProvider, type Model, type MutableModels } from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+export const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
+export const GATEWAY_PROVIDER_PREFIX = "gateway:";
+
+export function isGatewayProvider(provider: string): boolean {
+  return provider === OPENAI_COMPATIBLE_PROVIDER || provider.startsWith(GATEWAY_PROVIDER_PREFIX);
+}
+
+export function mintGatewayProviderId(): string {
+  return `${GATEWAY_PROVIDER_PREFIX}${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
+}
+
+export function normalizeOpenAICompatibleBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("Enter a base URL");
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed) && !/^https?:\/\//i.test(trimmed)) {
+    throw new Error("Base URL must be http or https");
+  }
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(withProtocol);
+  } catch {
+    throw new Error("Enter a valid http(s) base URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Base URL must be http or https");
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  const path = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = path || "/";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+export function parseAvailableModels(value: string | null | undefined): string[] {
+  if (!value?.trim()) return [];
+  return [
+    ...new Set(
+      value
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+export function serializeAvailableModels(models: string[]): string {
+  return [...new Set(models.map((entry) => entry.trim()).filter(Boolean))].join("\n");
+}
+
+export function modelsFromKeyCoverage(value: string | string[] | null | undefined): string[] {
+  return Array.isArray(value)
+    ? [...new Set(value.map((entry) => entry.trim()).filter(Boolean))]
+    : parseAvailableModels(value);
+}
+
+export function unionAvailableModels(
+  keys: Array<{ availableModels?: string | string[] | null }>,
+): string[] {
+  return [...new Set(keys.flatMap((key) => modelsFromKeyCoverage(key.availableModels)))];
+}
+
+export function secretIdForGatewayModel(
+  credential: {
+    secretId: string;
+    keys: Array<{
+      secretId: string;
+      isActive: boolean;
+      availableModels?: string | string[] | null;
+    }>;
+  },
+  modelId?: string | null,
+): string {
+  const fallback = credential.keys.find((key) => key.isActive)?.secretId ?? credential.secretId;
+  if (!modelId?.trim() || !credential.keys.length) return fallback;
+  const matching = credential.keys.filter((key) =>
+    modelsFromKeyCoverage(key.availableModels).includes(modelId),
+  );
+  if (!matching.length) return fallback;
+  return matching.find((key) => key.isActive)?.secretId ?? matching[0]!.secretId;
+}
+
+const MODEL_FAMILY_LABELS: Array<[string, string]> = [
+  ["gemini", "Gemini"],
+  ["claude", "Claude"],
+  ["gpt", "GPT"],
+  ["o1", "OpenAI"],
+  ["o3", "OpenAI"],
+  ["o4", "OpenAI"],
+  ["llama", "Llama"],
+  ["mistral", "Mistral"],
+  ["grok", "Grok"],
+  ["deepseek", "DeepSeek"],
+  ["qwen", "Qwen"],
+  ["command", "Command"],
+];
+
+export function labelForDiscoveredModels(models: string[], fallback = "API key"): string {
+  if (!models.length) return fallback;
+  const lower = models.map((id) => id.toLowerCase());
+  for (const [needle, label] of MODEL_FAMILY_LABELS) {
+    const hits = lower.filter((id) => id.includes(needle)).length;
+    if (hits === models.length || hits >= Math.max(1, Math.ceil(models.length * 0.7))) {
+      return label;
+    }
+  }
+  return fallback;
+}
+
+export async function tryFetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<{ models: string[]; error: string }> {
+  try {
+    return { models: await fetchOpenAICompatibleModels(baseUrl, apiKey, signal), error: "" };
+  } catch (error) {
+    return {
+      models: [],
+      error: error instanceof Error ? error.message : "Could not list models",
+    };
+  }
+}
+
+export async function fetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const endpoint = `${normalizeOpenAICompatibleBaseUrl(baseUrl)}/models`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (apiKey?.trim()) headers.authorization = `Bearer ${apiKey.trim()}`;
+  const response = await fetch(endpoint, { headers, signal });
+  if (!response.ok) {
+    throw new Error(`Could not list models (${response.status})`);
+  }
+  const body = (await response.json()) as { data?: unknown; models?: unknown };
+  const rows = Array.isArray(body.data) ? body.data : Array.isArray(body.models) ? body.models : [];
+  const ids = rows.flatMap((row) => {
+    if (typeof row === "string") return [row];
+    if (row && typeof row === "object" && "id" in row) return [String((row as { id: unknown }).id)];
+    return [];
+  });
+  if (!ids.length) throw new Error("That endpoint did not return any models");
+  return [...new Set(ids)];
+}
+
+export function openaiCompatibleModel(
+  provider: string,
+  modelId: string,
+  baseUrl: string,
+): Model<"openai-completions"> {
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    provider,
+    baseUrl,
+    reasoning: false,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStore: false,
+      // Custom OpenAI-compatible proxies (Gemini, Ollama, LiteLLM, Groq, …) often
+      // close the SSE stream after tokens without a terminal finish_reason chunk.
+      // Pi treats that as a hard error unless this is off.
+      supportsFinishReason: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    },
+  };
+}
+
+export function attachOpenAICompatibleProvider(
+  models: MutableModels,
+  input: {
+    provider: string;
+    baseUrl: string;
+    modelId: string;
+    apiKey?: string;
+    extraModelIds?: string[];
+  },
+): void {
+  const baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl);
+  const ids = [...new Set([input.modelId, ...(input.extraModelIds ?? [])].filter(Boolean))];
+  models.setProvider(
+    createProvider({
+      id: input.provider,
+      name: input.provider,
+      baseUrl,
+      auth: {
+        apiKey: {
+          name: "Custom endpoint",
+          resolve: async () => ({
+            auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {},
+          }),
+        },
+      },
+      models: ids.map((id) => openaiCompatibleModel(input.provider, id, baseUrl)),
+      api: openAICompletionsApi(),
+    }),
+  );
+}
+
+export async function completeOpenAICompatibleChat(input: {
+  baseUrl: string;
+  apiKey?: string;
+  modelId: string;
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const endpoint = `${normalizeOpenAICompatibleBaseUrl(input.baseUrl)}/chat/completions`;
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "content-type": "application/json",
+  };
+  if (input.apiKey?.trim()) headers.authorization = `Bearer ${input.apiKey.trim()}`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    signal: input.signal,
+    body: JSON.stringify({
+      model: input.modelId,
+      messages: input.messages,
+      stream: false,
+    }),
+  });
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(errorFromOpenAICompatibleBody(raw, response.status));
+  }
+  const text = textFromOpenAICompatibleBody(raw, response.headers.get("content-type") ?? "");
+  if (!text.trim()) {
+    throw new Error(errorFromOpenAICompatibleBody(raw, response.status));
+  }
+  return text;
+}
+
+const MAX_GATEWAY_ERROR_CHARS = 4000;
+
+export function errorFromOpenAICompatibleBody(raw: string, status?: number): string {
+  const trimmed = raw.trim();
+  const extracted = extractGatewayErrorMessage(trimmed) || trimmed;
+  const clipped =
+    extracted.length > MAX_GATEWAY_ERROR_CHARS
+      ? `${extracted.slice(0, MAX_GATEWAY_ERROR_CHARS)}…`
+      : extracted;
+  if (status && status >= 400) {
+    if (!clipped) return `Gateway request failed (${status})`;
+    return /^\d{3}\b/.test(clipped) ? clipped : `${status}: ${clipped}`;
+  }
+  return clipped || "The gateway returned an empty reply";
+}
+
+function extractGatewayErrorMessage(raw: string): string {
+  if (!raw) return "";
+  try {
+    const fromJson = errorMessageFromValue(JSON.parse(raw) as unknown);
+    if (fromJson) return fromJson;
+  } catch {
+    // Fall through to SSE / plain text.
+  }
+  if (raw.includes("data:")) {
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const fromEvent = errorMessageFromValue(JSON.parse(payload) as unknown);
+        if (fromEvent) return fromEvent;
+      } catch {
+        // Ignore malformed SSE lines.
+      }
+    }
+  }
+  return "";
+}
+
+function errorMessageFromValue(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (!value || typeof value !== "object") return "";
+  const record = value as Record<string, unknown>;
+  const nested = record.error;
+  if (typeof nested === "string" && nested.trim()) return nested.trim();
+  if (nested && typeof nested === "object") {
+    const inner = nested as Record<string, unknown>;
+    if (typeof inner.message === "string" && inner.message.trim()) return inner.message.trim();
+    if (typeof inner.msg === "string" && inner.msg.trim()) return inner.msg.trim();
+    if (typeof inner.error === "string" && inner.error.trim()) return inner.error.trim();
+    const errors = inner.errors;
+    if (Array.isArray(errors)) {
+      const first = errors.find(
+        (entry) =>
+          entry &&
+          typeof entry === "object" &&
+          typeof (entry as { message?: unknown }).message === "string",
+      ) as { message: string } | undefined;
+      if (first?.message.trim()) return first.message.trim();
+    }
+  }
+  if (typeof record.message === "string" && record.message.trim()) return record.message.trim();
+  if (typeof record.msg === "string" && record.msg.trim()) return record.msg.trim();
+  if (typeof record.detail === "string" && record.detail.trim()) return record.detail.trim();
+  return "";
+}
+
+export function textFromOpenAICompatibleBody(raw: string, contentType = ""): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (contentType.includes("text/event-stream") || trimmed.startsWith("data:")) {
+    return textFromChatCompletionSse(trimmed);
+  }
+  try {
+    return extractChatMessageText(JSON.parse(trimmed) as unknown);
+  } catch {
+    return trimmed.includes("data:") ? textFromChatCompletionSse(trimmed) : "";
+  }
+}
+
+export function extractChatMessageText(body: unknown): string {
+  if (!body || typeof body !== "object") return "";
+  const record = body as Record<string, unknown>;
+  const choices = Array.isArray(record.choices) ? record.choices : [];
+  const choice = choices[0];
+  if (!choice || typeof choice !== "object") return extractContent(record.content);
+  const row = choice as Record<string, unknown>;
+  const message =
+    row.message && typeof row.message === "object"
+      ? (row.message as Record<string, unknown>)
+      : undefined;
+  const delta =
+    row.delta && typeof row.delta === "object" ? (row.delta as Record<string, unknown>) : undefined;
+  return (
+    extractContent(message?.content) ||
+    extractContent(delta?.content) ||
+    extractContent(row.content)
+  );
+}
+
+function textFromChatCompletionSse(raw: string): string {
+  let text = "";
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    try {
+      text += extractChatMessageText(JSON.parse(payload) as unknown);
+    } catch {
+      // Ignore malformed SSE lines from non-standard proxies.
+    }
+  }
+  return text;
+}
+
+function extractContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (!part || typeof part !== "object") return "";
+      const record = part as Record<string, unknown>;
+      if (typeof record.text === "string") return record.text;
+      if (typeof record.content === "string") return record.content;
+      return "";
+    })
+    .join("");
+}

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -248,7 +248,7 @@ const MAX_GATEWAY_ERROR_CHARS = 4000;
 
 export function errorFromOpenAICompatibleBody(raw: string, status?: number): string {
   const trimmed = raw.trim();
-  const extracted = extractGatewayErrorMessage(trimmed) || trimmed;
+  const extracted = extractGatewayErrorMessage(trimmed) || (isJson(trimmed) ? "" : trimmed);
   const clipped =
     extracted.length > MAX_GATEWAY_ERROR_CHARS
       ? `${extracted.slice(0, MAX_GATEWAY_ERROR_CHARS)}…`
@@ -258,6 +258,16 @@ export function errorFromOpenAICompatibleBody(raw: string, status?: number): str
     return /^\d{3}\b/.test(clipped) ? clipped : `${status}: ${clipped}`;
   }
   return clipped || "The gateway returned an empty reply";
+}
+
+function isJson(value: string): boolean {
+  if (!value) return false;
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function extractGatewayErrorMessage(raw: string): string {

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -1,0 +1,204 @@
+import { createProvider, type Model, type MutableModels } from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+export const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
+export const GATEWAY_PROVIDER_PREFIX = "gateway:";
+
+export function isGatewayProvider(provider: string): boolean {
+  return provider === OPENAI_COMPATIBLE_PROVIDER || provider.startsWith(GATEWAY_PROVIDER_PREFIX);
+}
+
+export function mintGatewayProviderId(): string {
+  return `${GATEWAY_PROVIDER_PREFIX}${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
+}
+
+export function normalizeOpenAICompatibleBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("Enter a base URL");
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed) && !/^https?:\/\//i.test(trimmed)) {
+    throw new Error("Base URL must be http or https");
+  }
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(withProtocol);
+  } catch {
+    throw new Error("Enter a valid http(s) base URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Base URL must be http or https");
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  const path = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = path || "/";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+export function parseAvailableModels(value: string | null | undefined): string[] {
+  if (!value?.trim()) return [];
+  return [
+    ...new Set(
+      value
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+export function serializeAvailableModels(models: string[]): string {
+  return [...new Set(models.map((entry) => entry.trim()).filter(Boolean))].join("\n");
+}
+
+export function modelsFromKeyCoverage(value: string | string[] | null | undefined): string[] {
+  return Array.isArray(value)
+    ? [...new Set(value.map((entry) => entry.trim()).filter(Boolean))]
+    : parseAvailableModels(value);
+}
+
+export function unionAvailableModels(
+  keys: Array<{ availableModels?: string | string[] | null }>,
+): string[] {
+  return [...new Set(keys.flatMap((key) => modelsFromKeyCoverage(key.availableModels)))];
+}
+
+export function secretIdForGatewayModel(
+  credential: {
+    secretId: string;
+    keys: Array<{
+      secretId: string;
+      isActive: boolean;
+      availableModels?: string | string[] | null;
+    }>;
+  },
+  modelId?: string | null,
+): string {
+  const fallback = credential.keys.find((key) => key.isActive)?.secretId ?? credential.secretId;
+  if (!modelId?.trim() || !credential.keys.length) return fallback;
+  const matching = credential.keys.filter((key) =>
+    modelsFromKeyCoverage(key.availableModels).includes(modelId),
+  );
+  if (!matching.length) return fallback;
+  return matching.find((key) => key.isActive)?.secretId ?? matching[0]!.secretId;
+}
+
+const MODEL_FAMILY_LABELS: Array<[string, string]> = [
+  ["gemini", "Gemini"],
+  ["claude", "Claude"],
+  ["gpt", "GPT"],
+  ["o1", "OpenAI"],
+  ["o3", "OpenAI"],
+  ["o4", "OpenAI"],
+  ["llama", "Llama"],
+  ["mistral", "Mistral"],
+  ["grok", "Grok"],
+  ["deepseek", "DeepSeek"],
+  ["qwen", "Qwen"],
+  ["command", "Command"],
+];
+
+export function labelForDiscoveredModels(models: string[], fallback = "API key"): string {
+  if (!models.length) return fallback;
+  const lower = models.map((id) => id.toLowerCase());
+  for (const [needle, label] of MODEL_FAMILY_LABELS) {
+    const hits = lower.filter((id) => id.includes(needle)).length;
+    if (hits === models.length || hits >= Math.max(1, Math.ceil(models.length * 0.7))) {
+      return label;
+    }
+  }
+  return fallback;
+}
+
+export async function tryFetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<{ models: string[]; error: string }> {
+  try {
+    return { models: await fetchOpenAICompatibleModels(baseUrl, apiKey, signal), error: "" };
+  } catch (error) {
+    return {
+      models: [],
+      error: error instanceof Error ? error.message : "Could not list models",
+    };
+  }
+}
+
+export async function fetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const endpoint = `${normalizeOpenAICompatibleBaseUrl(baseUrl)}/models`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (apiKey?.trim()) headers.authorization = `Bearer ${apiKey.trim()}`;
+  const response = await fetch(endpoint, { headers, signal });
+  if (!response.ok) {
+    throw new Error(`Could not list models (${response.status})`);
+  }
+  const body = (await response.json()) as { data?: unknown; models?: unknown };
+  const rows = Array.isArray(body.data) ? body.data : Array.isArray(body.models) ? body.models : [];
+  const ids = rows.flatMap((row) => {
+    if (typeof row === "string") return [row];
+    if (row && typeof row === "object" && "id" in row) return [String((row as { id: unknown }).id)];
+    return [];
+  });
+  if (!ids.length) throw new Error("That endpoint did not return any models");
+  return [...new Set(ids)];
+}
+
+export function openaiCompatibleModel(
+  provider: string,
+  modelId: string,
+  baseUrl: string,
+): Model<"openai-completions"> {
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    provider,
+    baseUrl,
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStore: false,
+    },
+  };
+}
+
+export function attachOpenAICompatibleProvider(
+  models: MutableModels,
+  input: {
+    provider: string;
+    baseUrl: string;
+    modelId: string;
+    apiKey?: string;
+    extraModelIds?: string[];
+  },
+): void {
+  const baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl);
+  const ids = [...new Set([input.modelId, ...(input.extraModelIds ?? [])].filter(Boolean))];
+  models.setProvider(
+    createProvider({
+      id: input.provider,
+      name: input.provider,
+      baseUrl,
+      auth: {
+        apiKey: {
+          name: "Custom endpoint",
+          resolve: async () => ({
+            auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {},
+          }),
+        },
+      },
+      models: ids.map((id) => openaiCompatibleModel(input.provider, id, baseUrl)),
+      api: openAICompletionsApi(),
+    }),
+  );
+}

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -248,7 +248,8 @@ const MAX_GATEWAY_ERROR_CHARS = 4000;
 
 export function errorFromOpenAICompatibleBody(raw: string, status?: number): string {
   const trimmed = raw.trim();
-  const extracted = extractGatewayErrorMessage(trimmed) || (isJson(trimmed) ? "" : trimmed);
+  const parsed = parseGatewayError(trimmed);
+  const extracted = parsed.message || (parsed.isJson ? "" : trimmed);
   const clipped =
     extracted.length > MAX_GATEWAY_ERROR_CHARS
       ? `${extracted.slice(0, MAX_GATEWAY_ERROR_CHARS)}…`
@@ -260,21 +261,11 @@ export function errorFromOpenAICompatibleBody(raw: string, status?: number): str
   return clipped || "The gateway returned an empty reply";
 }
 
-function isJson(value: string): boolean {
-  if (!value) return false;
-  try {
-    JSON.parse(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function extractGatewayErrorMessage(raw: string): string {
-  if (!raw) return "";
+function parseGatewayError(raw: string): { message: string; isJson: boolean } {
+  if (!raw) return { message: "", isJson: false };
   try {
     const fromJson = errorMessageFromValue(JSON.parse(raw) as unknown);
-    if (fromJson) return fromJson;
+    return { message: fromJson, isJson: true };
   } catch {
     // Fall through to SSE / plain text.
   }
@@ -285,13 +276,13 @@ function extractGatewayErrorMessage(raw: string): string {
       if (!payload || payload === "[DONE]") continue;
       try {
         const fromEvent = errorMessageFromValue(JSON.parse(payload) as unknown);
-        if (fromEvent) return fromEvent;
+        if (fromEvent) return { message: fromEvent, isJson: false };
       } catch {
         // Ignore malformed SSE lines.
       }
     }
   }
-  return "";
+  return { message: "", isJson: false };
 }
 
 function errorMessageFromValue(value: unknown): string {

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -1,8 +1,51 @@
+import { lookup } from "node:dns/promises";
+import { request as httpRequest, type IncomingHttpHeaders } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { BlockList, isIP } from "node:net";
 import { createProvider, type Model, type MutableModels } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 
 export const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
 export const GATEWAY_PROVIDER_PREFIX = "gateway:";
+const MODEL_DISCOVERY_TIMEOUT_MS = 10_000;
+const MODEL_DISCOVERY_MAX_BYTES = 1_000_000;
+const MODEL_DISCOVERY_MAX_REDIRECTS = 3;
+
+const blockedModelEndpointAddresses = new BlockList();
+for (const [network, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+] as const) {
+  blockedModelEndpointAddresses.addSubnet(network, prefix, "ipv4");
+}
+for (const [network, prefix] of [
+  ["::", 128],
+  ["::1", 128],
+  ["::ffff:0:0", 96],
+  ["100::", 64],
+  ["2001:db8::", 32],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["ff00::", 8],
+] as const) {
+  blockedModelEndpointAddresses.addSubnet(network, prefix, "ipv6");
+}
+
+export interface ModelDiscoveryOptions {
+  allowPrivateNetwork?: boolean;
+}
 
 export function isGatewayProvider(provider: string): boolean {
   return provider === OPENAI_COMPATIBLE_PROVIDER || provider.startsWith(GATEWAY_PROVIDER_PREFIX);
@@ -27,6 +70,9 @@ export function normalizeOpenAICompatibleBaseUrl(value: string): string {
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error("Base URL must be http or https");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("Base URL must not contain credentials");
   }
   parsed.hash = "";
   parsed.search = "";
@@ -114,9 +160,13 @@ export async function tryFetchOpenAICompatibleModels(
   baseUrl: string,
   apiKey?: string,
   signal?: AbortSignal,
+  options?: ModelDiscoveryOptions,
 ): Promise<{ models: string[]; error: string }> {
   try {
-    return { models: await fetchOpenAICompatibleModels(baseUrl, apiKey, signal), error: "" };
+    return {
+      models: await fetchOpenAICompatibleModels(baseUrl, apiKey, signal, options),
+      error: "",
+    };
   } catch (error) {
     return {
       models: [],
@@ -129,15 +179,34 @@ export async function fetchOpenAICompatibleModels(
   baseUrl: string,
   apiKey?: string,
   signal?: AbortSignal,
+  options?: ModelDiscoveryOptions,
 ): Promise<string[]> {
-  const endpoint = `${normalizeOpenAICompatibleBaseUrl(baseUrl)}/models`;
-  const headers: Record<string, string> = { accept: "application/json" };
-  if (apiKey?.trim()) headers.authorization = `Bearer ${apiKey.trim()}`;
-  const response = await fetch(endpoint, { headers, signal });
-  if (!response.ok) {
+  let endpoint = new URL(`${normalizeOpenAICompatibleBaseUrl(baseUrl)}/models`);
+  let authorization = apiKey?.trim() ? `Bearer ${apiKey.trim()}` : undefined;
+  let response: Awaited<ReturnType<typeof requestModelEndpoint>> | undefined;
+  for (let redirects = 0; ; redirects += 1) {
+    response = await requestModelEndpoint(endpoint, authorization, signal, options);
+    const location = response.headers.location;
+    if (![301, 302, 303, 307, 308].includes(response.status) || !location) break;
+    if (redirects >= MODEL_DISCOVERY_MAX_REDIRECTS) {
+      throw new Error("Model endpoint redirected too many times");
+    }
+    const next = new URL(location, endpoint);
+    if (next.protocol !== "http:" && next.protocol !== "https:") {
+      throw new Error("Model endpoint redirected to a non-http URL");
+    }
+    if (next.origin !== endpoint.origin) authorization = undefined;
+    endpoint = next;
+  }
+  if (response.status < 200 || response.status >= 300) {
     throw new Error(`Could not list models (${response.status})`);
   }
-  const body = (await response.json()) as { data?: unknown; models?: unknown };
+  let body: { data?: unknown; models?: unknown };
+  try {
+    body = JSON.parse(response.body) as { data?: unknown; models?: unknown };
+  } catch {
+    throw new Error("Model endpoint returned invalid JSON");
+  }
   const rows = Array.isArray(body.data) ? body.data : Array.isArray(body.models) ? body.models : [];
   const ids = rows.flatMap((row) => {
     if (typeof row === "string") return [row];
@@ -146,6 +215,88 @@ export async function fetchOpenAICompatibleModels(
   });
   if (!ids.length) throw new Error("That endpoint did not return any models");
   return [...new Set(ids)];
+}
+
+export async function assertOpenAICompatibleEndpointAllowed(
+  baseUrl: string,
+  options?: ModelDiscoveryOptions,
+): Promise<string> {
+  const normalized = normalizeOpenAICompatibleBaseUrl(baseUrl);
+  await resolveModelEndpointAddress(new URL(normalized), options);
+  return normalized;
+}
+
+async function resolveModelEndpointAddress(url: URL, options?: ModelDiscoveryOptions) {
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  const family = isIP(hostname);
+  const addresses = family
+    ? [{ address: hostname, family }]
+    : await lookup(hostname, { all: true, verbatim: true });
+  if (!addresses.length) throw new Error("Model endpoint hostname did not resolve");
+  if (
+    !options?.allowPrivateNetwork &&
+    addresses.some(({ address, family: addressFamily }) =>
+      blockedModelEndpointAddresses.check(address, addressFamily === 6 ? "ipv6" : "ipv4"),
+    )
+  ) {
+    throw new Error("Private-network model endpoints require deployment-owner access");
+  }
+  return addresses[0]!;
+}
+
+async function requestModelEndpoint(
+  url: URL,
+  authorization: string | undefined,
+  signal?: AbortSignal,
+  options?: ModelDiscoveryOptions,
+): Promise<{ status: number; headers: IncomingHttpHeaders; body: string }> {
+  const resolved = await resolveModelEndpointAddress(url, options);
+  if (signal?.aborted) throw signal.reason ?? new Error("Request cancelled");
+  return new Promise((resolve, reject) => {
+    const servername = url.hostname.replace(/^\[|\]$/g, "");
+    const request = (url.protocol === "https:" ? httpsRequest : httpRequest)(
+      {
+        protocol: url.protocol,
+        hostname: resolved.address,
+        port: url.port || undefined,
+        path: `${url.pathname}${url.search}`,
+        method: "GET",
+        servername,
+        headers: {
+          accept: "application/json",
+          host: url.host,
+          ...(authorization ? { authorization } : {}),
+        },
+      },
+      (incoming) => {
+        const chunks: Buffer[] = [];
+        let bytes = 0;
+        incoming.on("data", (chunk: Buffer) => {
+          bytes += chunk.length;
+          if (bytes > MODEL_DISCOVERY_MAX_BYTES) {
+            request.destroy(new Error("Model endpoint response is too large"));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        incoming.on("end", () => {
+          resolve({
+            status: incoming.statusCode ?? 0,
+            headers: incoming.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    const abort = () => request.destroy(signal?.reason ?? new Error("Request cancelled"));
+    signal?.addEventListener("abort", abort, { once: true });
+    request.setTimeout(MODEL_DISCOVERY_TIMEOUT_MS, () => {
+      request.destroy(new Error("Model endpoint timed out"));
+    });
+    request.on("error", reject);
+    request.on("close", () => signal?.removeEventListener("abort", abort));
+    request.end();
+  });
 }
 
 export function openaiCompatibleModel(

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -1,8 +1,30 @@
+import { lookup } from "node:dns/promises";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { isIP, type LookupFunction } from "node:net";
+import { Readable } from "node:stream";
 import { createProvider, type Model, type MutableModels } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 
 export const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
 export const GATEWAY_PROVIDER_PREFIX = "gateway:";
+export const OPENAI_COMPATIBLE_KEYLESS_API_KEY = "rakazo-keyless-no-auth-placeholder";
+const MODEL_LIST_TIMEOUT_MS = 10_000;
+const MODEL_LIST_MAX_BYTES = 1_000_000;
+const MODEL_LIST_MAX_ENTRIES = 200;
+const MODEL_ID_MAX_LENGTH = 200;
+const MAX_REDIRECTS = 5;
+
+export interface GatewayNetworkOptions {
+  allowPrivateNetwork?: boolean;
+  hasCredentials?: boolean;
+  timeoutMs?: number;
+}
+
+interface ResolvedAddress {
+  address: string;
+  family: 4 | 6;
+}
 
 export function isGatewayProvider(provider: string): boolean {
   return provider === OPENAI_COMPATIBLE_PROVIDER || provider.startsWith(GATEWAY_PROVIDER_PREFIX);
@@ -27,6 +49,9 @@ export function normalizeOpenAICompatibleBaseUrl(value: string): string {
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error("Base URL must be http or https");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("Base URL must not include credentials");
   }
   parsed.hash = "";
   parsed.search = "";
@@ -55,23 +80,324 @@ export async function fetchOpenAICompatibleModels(
   baseUrl: string,
   apiKey?: string,
   signal?: AbortSignal,
+  options: GatewayNetworkOptions = {},
 ): Promise<string[]> {
   const endpoint = `${normalizeOpenAICompatibleBaseUrl(baseUrl)}/models`;
   const headers: Record<string, string> = { accept: "application/json" };
   if (apiKey?.trim()) headers.authorization = `Bearer ${apiKey.trim()}`;
-  const response = await fetch(endpoint, { headers, signal });
+  const response = await createOpenAICompatibleFetch({
+    ...options,
+    timeoutMs: options.timeoutMs ?? MODEL_LIST_TIMEOUT_MS,
+  })(endpoint, { headers, signal });
   if (!response.ok) {
     throw new Error(`Could not list models (${response.status})`);
   }
-  const body = (await response.json()) as { data?: unknown; models?: unknown };
+  const body = JSON.parse(await readLimitedText(response, MODEL_LIST_MAX_BYTES)) as {
+    data?: unknown;
+    models?: unknown;
+  };
   const rows = Array.isArray(body.data) ? body.data : Array.isArray(body.models) ? body.models : [];
-  const ids = rows.flatMap((row) => {
-    if (typeof row === "string") return [row];
-    if (row && typeof row === "object" && "id" in row) return [String((row as { id: unknown }).id)];
-    return [];
+  const ids = rows.slice(0, MODEL_LIST_MAX_ENTRIES).flatMap((row) => {
+    const id =
+      typeof row === "string"
+        ? row
+        : row && typeof row === "object" && "id" in row && typeof row.id === "string"
+          ? row.id
+          : "";
+    const normalized = id.trim();
+    return normalized && normalized.length <= MODEL_ID_MAX_LENGTH ? [normalized] : [];
   });
   if (!ids.length) throw new Error("That endpoint did not return any models");
   return [...new Set(ids)];
+}
+
+/**
+ * Build a fetch implementation that validates and pins DNS for every gateway
+ * request and redirect. Private endpoints are reserved for the deployment
+ * owner; public endpoints must use TLS.
+ */
+export function createOpenAICompatibleFetch(options: GatewayNetworkOptions = {}): typeof fetch {
+  return async (input, init) => {
+    const initial = new Request(input, init);
+    let url = new URL(initial.url);
+    let method = initial.method;
+    const headers = new Headers(initial.headers);
+    if (headers.get("authorization") === `Bearer ${OPENAI_COMPATIBLE_KEYLESS_API_KEY}`) {
+      headers.delete("authorization");
+    }
+    headers.set("accept-encoding", "identity");
+    let body = method === "GET" || method === "HEAD" ? undefined : await initial.arrayBuffer();
+    const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? 300_000);
+    const signal = AbortSignal.any([initial.signal, timeoutSignal]);
+
+    for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+      const addresses = await resolveAllowedAddresses(url, options.allowPrivateNetwork === true);
+      assertCredentialTransport(url, addresses, headers.has("authorization"));
+      const response = await requestPinned(url, { method, headers, body, signal }, addresses);
+      const location = response.headers.get("location");
+      if (!location || ![301, 302, 303, 307, 308].includes(response.status)) return response;
+      if (redirects === MAX_REDIRECTS) {
+        await response.body?.cancel();
+        throw new Error("Gateway redirected too many times");
+      }
+
+      const nextUrl = new URL(location, url);
+      if (nextUrl.origin !== url.origin) {
+        headers.delete("authorization");
+        headers.delete("cookie");
+        headers.delete("proxy-authorization");
+      }
+      if (
+        response.status === 303 ||
+        ((response.status === 301 || response.status === 302) && method === "POST")
+      ) {
+        method = "GET";
+        body = undefined;
+        headers.delete("content-length");
+        headers.delete("content-type");
+      }
+      await response.body?.cancel();
+      url = nextUrl;
+    }
+    throw new Error("Gateway redirected too many times");
+  };
+}
+
+export async function assertOpenAICompatibleBaseUrlAllowed(
+  baseUrl: string,
+  options: GatewayNetworkOptions = {},
+): Promise<string> {
+  const normalized = normalizeOpenAICompatibleBaseUrl(baseUrl);
+  const url = new URL(normalized);
+  const addresses = await resolveAllowedAddresses(url, options.allowPrivateNetwork === true);
+  assertCredentialTransport(url, addresses, options.hasCredentials === true);
+  return normalized;
+}
+
+export function isGloballyRoutableAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) {
+    const octets = address.split(".").map(Number);
+    const [a, b, c] = octets;
+    if (a === undefined || b === undefined || c === undefined || octets.length !== 4) return false;
+    return !(
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      a >= 224 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 0 && c === 0) ||
+      (a === 192 && b === 0 && c === 2) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      (a === 198 && b === 51 && c === 100) ||
+      (a === 203 && b === 0 && c === 113)
+    );
+  }
+  if (family !== 6) return false;
+  const value = parseIpv6(address);
+  if (value === null) return false;
+  // Currently allocated globally routable unicast space is 2000::/3. Keep the
+  // documentation prefix non-routable even though it sits inside that range.
+  return inIpv6Cidr(value, 0x2000n << 112n, 3) && !inIpv6Cidr(value, 0x20010db8n << 96n, 32);
+}
+
+async function resolveAllowedAddresses(url: URL, allowPrivateNetwork: boolean) {
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Gateway URL must use http or https");
+  }
+  if (url.username || url.password) throw new Error("Gateway URL must not include credentials");
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  const literalFamily = isIP(hostname);
+  const addresses: ResolvedAddress[] = literalFamily
+    ? [{ address: hostname, family: literalFamily as 4 | 6 }]
+    : ((await lookup(hostname, { all: true, verbatim: true })) as ResolvedAddress[]);
+  if (!addresses.length) throw new Error("Gateway host did not resolve");
+  if (
+    addresses.some(
+      (entry) =>
+        !isGloballyRoutableAddress(entry.address) && !isAllowedPrivateAddress(entry.address),
+    )
+  ) {
+    throw new Error("Gateway host resolves to a prohibited network address");
+  }
+  const hasPrivateAddress = addresses.some((entry) => isAllowedPrivateAddress(entry.address));
+  if (hasPrivateAddress && !allowPrivateNetwork) {
+    throw new Error("Gateway host resolves to a private or local network address");
+  }
+  if (
+    url.protocol !== "https:" &&
+    addresses.some((entry) => isGloballyRoutableAddress(entry.address))
+  ) {
+    throw new Error("Public gateway URLs must use HTTPS");
+  }
+  return addresses;
+}
+
+function isAllowedPrivateAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) {
+    const [a, b] = address.split(".").map(Number);
+    return (
+      a === 10 ||
+      a === 127 ||
+      (a === 172 && b !== undefined && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168)
+    );
+  }
+  if (family !== 6) return false;
+  const value = parseIpv6(address);
+  return value === 1n || (value !== null && inIpv6Cidr(value, 0xfcn << 120n, 7));
+}
+
+function assertCredentialTransport(
+  url: URL,
+  addresses: ResolvedAddress[],
+  hasCredentials: boolean,
+): void {
+  if (
+    hasCredentials &&
+    url.protocol !== "https:" &&
+    addresses.some((entry) => !isLoopbackAddress(entry.address))
+  ) {
+    throw new Error("Gateway credentials require HTTPS unless the endpoint is loopback");
+  }
+}
+
+function isLoopbackAddress(address: string): boolean {
+  if (isIP(address) === 4) return address.startsWith("127.");
+  return parseIpv6(address) === 1n;
+}
+
+async function requestPinned(
+  url: URL,
+  input: {
+    method: string;
+    headers: Headers;
+    body?: ArrayBuffer;
+    signal: AbortSignal;
+  },
+  addresses: ResolvedAddress[],
+): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const request = (url.protocol === "https:" ? httpsRequest : httpRequest)(
+      url,
+      {
+        method: input.method,
+        headers: Object.fromEntries(input.headers.entries()),
+        signal: input.signal,
+        lookup: pinnedLookup(addresses),
+        // Never reuse a socket validated under a different user's network policy.
+        agent: false,
+      },
+      (incoming) => {
+        const responseHeaders = new Headers();
+        for (let index = 0; index < incoming.rawHeaders.length; index += 2) {
+          responseHeaders.append(incoming.rawHeaders[index]!, incoming.rawHeaders[index + 1]!);
+        }
+        const mayHaveBody =
+          input.method !== "HEAD" && ![204, 205, 304].includes(incoming.statusCode ?? 0);
+        if (!mayHaveBody) incoming.resume();
+        resolve(
+          new Response(
+            mayHaveBody ? (Readable.toWeb(incoming) as ReadableStream<Uint8Array>) : null,
+            {
+              status: incoming.statusCode ?? 500,
+              statusText: incoming.statusMessage,
+              headers: responseHeaders,
+            },
+          ),
+        );
+      },
+    );
+    request.once("error", reject);
+    if (input.body?.byteLength) request.write(Buffer.from(input.body));
+    request.end();
+  });
+}
+
+function pinnedLookup(addresses: ResolvedAddress[]): LookupFunction {
+  return (_hostname, options, callback) => {
+    const family = options.family === "IPv4" ? 4 : options.family === "IPv6" ? 6 : options.family;
+    const matching = family ? addresses.filter((entry) => entry.family === family) : addresses;
+    if (!matching.length) {
+      const error = Object.assign(new Error("Gateway address family did not resolve"), {
+        code: "ENOTFOUND",
+      });
+      callback(error, "");
+      return;
+    }
+    if (typeof options === "object" && options.all) callback(null, matching);
+    else callback(null, matching[0]!.address, matching[0]!.family);
+  };
+}
+
+async function readLimitedText(response: Response, maxBytes: number): Promise<string> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) throw new Error("Model list is too large");
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    total += chunk.value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      throw new Error("Model list is too large");
+    }
+    chunks.push(chunk.value);
+  }
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}
+
+function parseIpv6(address: string): bigint | null {
+  const withoutZone = address.split("%")[0]!;
+  const pieces = withoutZone.split("::");
+  if (pieces.length > 2) return null;
+  const expandSide = (side: string): number[] | null => {
+    if (!side) return [];
+    const output: number[] = [];
+    for (const part of side.split(":")) {
+      if (part.includes(".")) {
+        const bytes = part.split(".").map(Number);
+        if (
+          bytes.length !== 4 ||
+          bytes.some((byte) => !Number.isInteger(byte) || byte < 0 || byte > 255)
+        ) {
+          return null;
+        }
+        output.push(bytes[0]! * 256 + bytes[1]!, bytes[2]! * 256 + bytes[3]!);
+      } else {
+        const value = Number.parseInt(part, 16);
+        if (!/^[0-9a-f]{1,4}$/i.test(part) || !Number.isFinite(value)) return null;
+        output.push(value);
+      }
+    }
+    return output;
+  };
+  const left = expandSide(pieces[0]!);
+  const right = expandSide(pieces[1] ?? "");
+  if (!left || !right) return null;
+  const missing = 8 - left.length - right.length;
+  if (missing < 0 || (pieces.length === 1 && missing !== 0)) return null;
+  const hextets = [...left, ...Array.from({ length: missing }, () => 0), ...right];
+  if (hextets.length !== 8) return null;
+  return hextets.reduce((result, hextet) => (result << 16n) | BigInt(hextet), 0n);
+}
+
+function inIpv6Cidr(address: bigint, prefix: bigint, bits: number): boolean {
+  const shift = BigInt(128 - bits);
+  return address >> shift === prefix >> shift;
 }
 
 export function openaiCompatibleModel(

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -15,6 +15,8 @@ export type PiCatalogEntry = {
   oauthLabel?: string;
   subscription: boolean;
   signIn?: PiCatalogSignIn;
+  custom?: boolean;
+  baseUrl?: string;
 };
 
 export function listPiCatalog(): PiCatalogEntry[] {
@@ -85,3 +87,50 @@ export const scriptedCatalogEntry: PiCatalogEntry = {
   auth: "api-key",
   subscription: false,
 };
+
+export const customEndpointCatalogEntry: PiCatalogEntry = {
+  provider: "openai-compatible",
+  providerName: "Custom endpoint",
+  id: "custom",
+  label: "OpenAI-compatible",
+  billing:
+    "Any OpenAI-compatible server. Paste a base URL — Ollama, vLLM, LiteLLM, OpenAI, Azure-compatible proxies, or your own gateway.",
+  auth: "api-key",
+  subscription: false,
+  custom: true,
+};
+
+export function gatewayCatalogEntries(
+  credentials: Array<{
+    provider: string;
+    label: string;
+    baseUrl?: string | null;
+    defaultModel?: string | null;
+    availableModels?: string[];
+  }>,
+): PiCatalogEntry[] {
+  return credentials.flatMap((credential) => {
+    if (!credential.baseUrl && !credential.provider.startsWith("gateway:")) return [];
+    const models = [
+      ...new Set(
+        [credential.defaultModel, ...(credential.availableModels ?? [])].filter(
+          (id): id is string => Boolean(id),
+        ),
+      ),
+    ];
+    const ids = models.length ? models : ["custom"];
+    return ids.map((id) => ({
+      provider: credential.provider,
+      providerName: credential.label || "Custom endpoint",
+      id,
+      label: id,
+      billing: credential.baseUrl
+        ? `Uses ${credential.baseUrl}. Rakazo does not pay for model usage.`
+        : "Custom OpenAI-compatible endpoint.",
+      auth: "api-key" as const,
+      subscription: false,
+      custom: true,
+      baseUrl: credential.baseUrl ?? undefined,
+    }));
+  });
+}

--- a/packages/adapters/src/pi-runtime-computer.test.ts
+++ b/packages/adapters/src/pi-runtime-computer.test.ts
@@ -9,6 +9,7 @@ const fakeAgentState = vi.hoisted(() => ({
 vi.mock("@earendil-works/pi-agent-core", () => ({
   Agent: class {
     state = { errorMessage: undefined, messages: [] };
+    private subscriber?: (event: Record<string, unknown>) => void;
     private readonly tool: {
       execute: (toolCallId: string, params: unknown) => Promise<unknown>;
     };
@@ -30,10 +31,19 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
       this.tool = tool;
     }
 
-    subscribe(_listener: unknown) {}
+    subscribe(listener: (event: Record<string, unknown>) => void) {
+      this.subscriber = listener;
+    }
 
     async prompt() {
       fakeAgentState.result = await this.tool.execute("observe-1", {});
+      this.subscriber?.({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "I can continue with the available tools." }],
+        },
+      });
     }
 
     async waitForIdle() {}

--- a/packages/adapters/src/pi-runtime-stream-close.test.ts
+++ b/packages/adapters/src/pi-runtime-stream-close.test.ts
@@ -1,0 +1,72 @@
+import type { ConnectorTool } from "@rakazo/adapter-kit";
+import { describe, expect, it, vi } from "vitest";
+import { isMissingFinishReasonError, PiAgentRuntime } from "./pi-runtime.js";
+
+vi.mock("@earendil-works/pi-agent-core", () => ({
+  Agent: class {
+    state = {
+      errorMessage: "Stream ended without finish_reason",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "The gateway already sent this reply." }],
+        },
+      ],
+    };
+    subscribe() {}
+    async prompt() {}
+    async waitForIdle() {}
+    abort() {}
+  },
+}));
+
+vi.mock("@earendil-works/pi-ai/providers/all", () => ({
+  builtinModels: () => ({
+    getModel: (_provider: string, modelId: string) =>
+      modelId === "flash" ? { provider: "gateway:test", id: modelId } : undefined,
+    streamSimple: () => {
+      throw new Error("provider should not be called");
+    },
+  }),
+}));
+
+const tools: ConnectorTool[] = [];
+
+describe("missing streamed finish_reason", () => {
+  it("recognizes the Pi protocol error", () => {
+    expect(isMissingFinishReasonError("Stream ended without finish_reason")).toBe(true);
+    expect(isMissingFinishReasonError("Provider finish_reason: length")).toBe(false);
+  });
+
+  it("keeps the model reply instead of posting I hit a problem", async () => {
+    const runtime = new PiAgentRuntime();
+    const events: Array<{ type?: string; text?: string }> = [];
+    for await (const event of runtime.run(
+      {
+        botId: "bot",
+        threadId: "thread",
+        runId: "run",
+        prompt: "hello",
+        instructions: "Be concise.",
+        history: [],
+        tools,
+        model: { provider: "gateway:test", id: "flash" },
+      },
+      {
+        operationId: "stream-close",
+        traceId: "stream-close",
+        workspaceId: "workspace",
+        userId: "user",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(events.some((event) => event.text?.includes("I hit a problem"))).toBe(false);
+    expect(events.some((event) => event.text === "The gateway already sent this reply.")).toBe(
+      true,
+    );
+    expect(events.at(-1)?.type).toBe("done");
+  });
+});

--- a/packages/adapters/src/pi-runtime-stream-close.test.ts
+++ b/packages/adapters/src/pi-runtime-stream-close.test.ts
@@ -1,72 +1,312 @@
-import type { ConnectorTool } from "@rakazo/adapter-kit";
-import { describe, expect, it, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { AgentRunRequest, AgentRuntimeEvent } from "@rakazo/adapter-kit";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { isMissingFinishReasonError, PiAgentRuntime } from "./pi-runtime.js";
+
+const gatewayCalls = new Map<string, number>();
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
   Agent: class {
-    state = {
-      errorMessage: "Stream ended without finish_reason",
-      messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "The gateway already sent this reply." }],
-        },
-      ],
-    };
-    subscribe() {}
-    async prompt() {}
+    state: { errorMessage?: string; messages: unknown[] } = { messages: [] };
+    readonly scenario: string;
+    private subscriber?: (event: Record<string, unknown>) => void;
+    private releasePrompt?: () => void;
+
+    constructor(input: { initialState: { model: { id: string } } }) {
+      this.scenario = input.initialState.model.id;
+    }
+
+    subscribe(subscriber: (event: Record<string, unknown>) => void) {
+      this.subscriber = subscriber;
+    }
+
+    async prompt() {
+      const assistant = (text: string) => ({
+        role: "assistant",
+        content: [{ type: "text", text }],
+      });
+      const textDelta = (delta: string) =>
+        this.subscriber?.({
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta },
+        });
+
+      if (this.scenario === "normal") {
+        textDelta("Normal reply");
+        this.state.messages = [assistant("Normal reply")];
+        this.subscriber?.({ type: "message_end", message: assistant("Normal reply") });
+        return;
+      }
+      if (this.scenario === "state-only") {
+        this.state.errorMessage = "Stream ended without finish_reason";
+        this.state.messages = [assistant("Reply retained in agent state")];
+        return;
+      }
+      if (this.scenario === "partial-missing") {
+        textDelta("Partial reply");
+        this.state.messages = [assistant("Partial reply")];
+        throw new Error("Stream ended without finish_reason");
+      }
+      if (this.scenario === "partial-failure") {
+        textDelta("Unfinished reply");
+        this.state.errorMessage = "upstream disconnected";
+        this.state.messages = [assistant("Unfinished reply")];
+        return;
+      }
+      if (this.scenario === "tool-only") {
+        this.subscriber?.({
+          type: "tool_execution_start",
+          toolCallId: "tool-1",
+          toolName: "read_file",
+          args: { path: "fixture.txt" },
+        });
+        this.subscriber?.({
+          type: "tool_execution_end",
+          toolCallId: "tool-1",
+          toolName: "read_file",
+          isError: false,
+        });
+        this.state.errorMessage = "Stream ended without finish_reason";
+        this.state.messages = [{ role: "toolResult", content: [] }];
+        return;
+      }
+      if (this.scenario === "abort") {
+        await new Promise<void>((resolve) => {
+          this.releasePrompt = resolve;
+        });
+        return;
+      }
+      this.state.errorMessage = "Stream ended without finish_reason";
+    }
+
     async waitForIdle() {}
-    abort() {}
+    abort() {
+      this.state.errorMessage = "aborted";
+      this.releasePrompt?.();
+    }
   },
 }));
 
 vi.mock("@earendil-works/pi-ai/providers/all", () => ({
   builtinModels: () => ({
-    getModel: (_provider: string, modelId: string) =>
-      modelId === "flash" ? { provider: "gateway:test", id: modelId } : undefined,
+    getModel: (provider: string, modelId: string) =>
+      provider === "gateway:test" ? { provider, id: modelId } : undefined,
+    setProvider() {},
     streamSimple: () => {
-      throw new Error("provider should not be called");
+      throw new Error("the mocked agent owns the deterministic stream");
     },
   }),
 }));
 
-const tools: ConnectorTool[] = [];
+let gateway: Server;
+let gatewayBaseUrl = "";
 
-describe("missing streamed finish_reason", () => {
-  it("recognizes the Pi protocol error", () => {
+beforeAll(async () => {
+  gateway = createServer(async (request, response) => {
+    const body = await readRequestBody(request);
+    const model = String((JSON.parse(body) as { model?: unknown }).model ?? "");
+    gatewayCalls.set(model, (gatewayCalls.get(model) ?? 0) + 1);
+
+    if (model === "empty-recovery") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ choices: [{ message: { content: "Recovered once" } }] }));
+      return;
+    }
+    if (model === "malformed-recovery") {
+      response.setHeader("content-type", "text/event-stream");
+      response.end(
+        'data: {"choices":[{"delta":{"content":"Recovered "}}]}\n\ndata: malformed\n\ndata: {"choices":[{"delta":{"content":"partially"}}]}\n\n',
+      );
+      return;
+    }
+    if (model === "failed-recovery") {
+      response.statusCode = 502;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: { message: "fake upstream failed" } }));
+      return;
+    }
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({ choices: [{ message: { content: "" } }] }));
+  });
+  await new Promise<void>((resolve) => gateway.listen(0, "127.0.0.1", resolve));
+  const address = gateway.address() as AddressInfo;
+  gatewayBaseUrl = `http://127.0.0.1:${address.port}/v1`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    gateway.close((error) => (error ? reject(error) : resolve())),
+  );
+});
+
+beforeEach(() => gatewayCalls.clear());
+
+describe("gateway stream termination", () => {
+  it("recognizes only the Pi missing-finish marker", () => {
     expect(isMissingFinishReasonError("Stream ended without finish_reason")).toBe(true);
     expect(isMissingFinishReasonError("Provider finish_reason: length")).toBe(false);
   });
 
-  it("keeps the model reply instead of posting I hit a problem", async () => {
+  it("completes a normal stream without a recovery request", async () => {
+    const events = await runScenario("normal");
+
+    expect(texts(events)).toEqual(["Normal reply"]);
+    expect(events.at(-1)).toEqual({ type: "done", text: "Normal reply" });
+    expect(gatewayCalls.get("normal") ?? 0).toBe(0);
+  });
+
+  it("uses assistant state before retrying a missing-finish stream", async () => {
+    const events = await runScenario("state-only");
+
+    expect(texts(events)).toEqual(["Reply retained in agent state"]);
+    expect(events.at(-1)?.type).toBe("done");
+    expect(gatewayCalls.get("state-only") ?? 0).toBe(0);
+  });
+
+  it("makes at most one recovery request for a genuinely empty stream", async () => {
+    const events = await runScenario("empty-recovery");
+
+    expect(texts(events)).toEqual(["Recovered once"]);
+    expect(events.at(-1)).toEqual({ type: "done", text: "Recovered once" });
+    expect(gatewayCalls.get("empty-recovery")).toBe(1);
+  });
+
+  it("fails after one recovery when both gateway replies are empty", async () => {
+    const events = await runScenario("empty-failure");
+
+    expect(events.some((event) => event.type === "done")).toBe(false);
+    expect(events.at(-1)).toEqual({
+      type: "error",
+      message: "The gateway returned an empty reply",
+    });
+    expect(gatewayCalls.get("empty-failure")).toBe(1);
+  });
+
+  it("keeps valid partial SSE recovery content around malformed events", async () => {
+    const events = await runScenario("malformed-recovery");
+
+    expect(texts(events)).toEqual(["Recovered partially"]);
+    expect(events.at(-1)?.type).toBe("done");
+    expect(gatewayCalls.get("malformed-recovery")).toBe(1);
+  });
+
+  it("does not retry after tools have already executed", async () => {
+    const events = await runScenario("tool-only");
+
+    expect(events.some((event) => event.type === "done")).toBe(false);
+    expect(events.at(-1)).toEqual({
+      type: "error",
+      message: "The model returned no final reply after running tools",
+    });
+    expect(gatewayCalls.get("tool-only") ?? 0).toBe(0);
+  });
+
+  it("accepts partial text when only finish_reason is missing", async () => {
+    const events = await runScenario("partial-missing");
+
+    expect(texts(events)).toEqual(["Partial reply"]);
+    expect(events.at(-1)).toEqual({ type: "done", text: "Partial reply" });
+    expect(gatewayCalls.get("partial-missing") ?? 0).toBe(0);
+  });
+
+  it("fails a partial stream on a real transport error without completing it", async () => {
+    const events = await runScenario("partial-failure");
+
+    expect(texts(events)).toEqual(["Unfinished reply"]);
+    expect(events.some((event) => event.type === "done")).toBe(false);
+    expect(events.at(-1)).toEqual({ type: "error", message: "upstream disconnected" });
+  });
+
+  it("surfaces a failing recovery once and does not emit a duplicate completion", async () => {
+    const events = await runScenario("failed-recovery");
+
+    expect(events.some((event) => event.type === "done")).toBe(false);
+    expect(events.at(-1)).toEqual({ type: "error", message: "502: fake upstream failed" });
+    expect(gatewayCalls.get("failed-recovery")).toBe(1);
+  });
+
+  it("terminates the active request when runtime.abort is called", async () => {
     const runtime = new PiAgentRuntime();
-    const events: Array<{ type?: string; text?: string }> = [];
-    for await (const event of runtime.run(
-      {
-        botId: "bot",
-        threadId: "thread",
-        runId: "run",
-        prompt: "hello",
-        instructions: "Be concise.",
-        history: [],
-        tools,
-        model: { provider: "gateway:test", id: "flash" },
-      },
-      {
-        operationId: "stream-close",
-        traceId: "stream-close",
+    const contextAbort = new AbortController();
+    const iterator = runtime
+      .run(requestFor("abort", false), {
+        operationId: "stream-abort",
+        traceId: "stream-abort",
         workspaceId: "workspace",
         userId: "user",
-        signal: new AbortController().signal,
-      },
-    )) {
-      events.push(event);
-    }
+        signal: contextAbort.signal,
+      })
+      [Symbol.asyncIterator]();
 
-    expect(events.some((event) => event.text?.includes("I hit a problem"))).toBe(false);
-    expect(events.some((event) => event.text === "The gateway already sent this reply.")).toBe(
-      true,
-    );
-    expect(events.at(-1)?.type).toBe("done");
+    const started = await iterator.next();
+    expect(started.done).toBe(false);
+    expect(started.value?.type === "progress" || started.value?.type === "reasoning").toBe(true);
+    await runtime.abort("run-abort");
+    const remaining = await collectWithTimeout(iterator, 1_000).finally(() => contextAbort.abort());
+
+    expect(remaining.at(-1)).toEqual({ type: "error", message: "aborted" });
   });
 });
+
+async function runScenario(modelId: string): Promise<AgentRuntimeEvent[]> {
+  const runtime = new PiAgentRuntime();
+  const events: AgentRuntimeEvent[] = [];
+  for await (const event of runtime.run(requestFor(modelId), {
+    operationId: `stream-${modelId}`,
+    traceId: `stream-${modelId}`,
+    workspaceId: "workspace",
+    userId: "user",
+    signal: new AbortController().signal,
+  })) {
+    events.push(event);
+  }
+  return events;
+}
+
+function requestFor(modelId: string, withGateway = true): AgentRunRequest {
+  const model: AgentRunRequest["model"] & { baseUrl?: string } = {
+    provider: "gateway:test",
+    id: modelId,
+    baseUrl: withGateway ? gatewayBaseUrl : undefined,
+  };
+  return {
+    botId: "bot",
+    threadId: "thread",
+    runId: `run-${modelId}`,
+    prompt: "hello",
+    instructions: "Be concise.",
+    history: [],
+    tools: [],
+    model,
+  };
+}
+
+async function collectWithTimeout(
+  iterator: AsyncIterator<AgentRuntimeEvent>,
+  timeoutMs: number,
+): Promise<AgentRuntimeEvent[]> {
+  return Promise.race([
+    (async () => {
+      const events: AgentRuntimeEvent[] = [];
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) return events;
+        events.push(next.value);
+      }
+    })(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("runtime did not abort")), timeoutMs),
+    ),
+  ]);
+}
+
+function texts(events: AgentRuntimeEvent[]): string[] {
+  return events.flatMap((event) => (event.type === "text" ? [event.text] : []));
+}
+
+async function readRequestBody(request: AsyncIterable<Uint8Array>): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/packages/adapters/src/pi-runtime.test.ts
+++ b/packages/adapters/src/pi-runtime.test.ts
@@ -1,6 +1,22 @@
+import { createServer } from "node:http";
 import type { ConnectorTool } from "@rakazo/adapter-kit";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { normalizeAgentToolName, normalizeAgentToolNames, PiAgentRuntime } from "./pi-runtime.js";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve, reject) =>
+            server.close((error) => (error ? reject(error) : resolve())),
+          ),
+      ),
+  );
+});
 
 function tool(name: string): ConnectorTool {
   return { name, description: name, inputSchema: { type: "object" } };
@@ -32,6 +48,114 @@ describe("Pi agent runtime", () => {
       if (event.type === "text") events.push(event.text);
     }
     expect(events.join(" ")).toMatch(/Unknown model/i);
+  });
+
+  it("streams reasoning and text from a keyless local fake gateway without leaking the deployment key", async () => {
+    const requests: Array<{ authorization?: string; body: string }> = [];
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+      request.on("end", () => {
+        requests.push({
+          authorization: request.headers.authorization,
+          body: Buffer.concat(chunks).toString("utf8"),
+        });
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.write(
+          `data: ${JSON.stringify({
+            id: "fake-chunk-1",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "fake-model",
+            choices: [{ index: 0, delta: { role: "assistant", reasoning_content: "checking" } }],
+          })}\n\n`,
+        );
+        response.write(
+          `data: ${JSON.stringify({
+            id: "fake-chunk-2",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "fake-model",
+            choices: [{ index: 0, delta: { content: "hello from fake gateway" } }],
+          })}\n\n`,
+        );
+        response.write(
+          `data: ${JSON.stringify({
+            id: "fake-chunk-3",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "fake-model",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          })}\n\n`,
+        );
+        response.end("data: [DONE]\n\n");
+      });
+    });
+    servers.push(server);
+    const baseUrl = await listen(server);
+    const oldDeploymentKey = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "fake-openrouter-deployment-key";
+    try {
+      const runtime = new PiAgentRuntime();
+      const events = [];
+      for await (const event of runtime.run(
+        {
+          botId: "b",
+          threadId: "t",
+          runId: "fake-gateway-run",
+          prompt: "say hello",
+          instructions: "test",
+          history: [],
+          tools: [],
+          model: {
+            provider: "gateway:fake",
+            id: "fake-model",
+            baseUrl: `${baseUrl}/v1`,
+            allowPrivateNetwork: true,
+          },
+        },
+        {
+          operationId: "1",
+          traceId: "1",
+          workspaceId: "w",
+          userId: "u",
+          signal: new AbortController().signal,
+        },
+      )) {
+        events.push(event);
+      }
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.authorization).toBeUndefined();
+      expect(requests[0]?.authorization ?? "").not.toContain("fake-openrouter-deployment-key");
+      expect(JSON.parse(requests[0]!.body)).toMatchObject({ model: "fake-model" });
+      expect(
+        events
+          .filter((event) => event.type === "text")
+          .map((event) => event.text)
+          .join(""),
+      ).toContain("hello from fake gateway");
+      const finalReasoning = events.findIndex(
+        (event) =>
+          event.type === "reasoning" &&
+          event.step.id === "status:done" &&
+          event.step.status === "done",
+      );
+      const thought = events.findIndex(
+        (event) =>
+          event.type === "reasoning" && event.step.kind === "think" && event.step.status === "done",
+      );
+      const done = events.findIndex((event) => event.type === "done");
+      expect(
+        events.some((event) => event.type === "reasoning" && event.step.kind === "think"),
+      ).toBe(true);
+      expect(finalReasoning).toBeGreaterThanOrEqual(0);
+      expect(finalReasoning).toBeGreaterThan(thought);
+      expect(done).toBeGreaterThan(finalReasoning);
+    } finally {
+      if (oldDeploymentKey === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = oldDeploymentKey;
+    }
   });
 });
 
@@ -76,3 +200,15 @@ describe("Pi model-facing connector tool names", () => {
     expect(first.every((name) => /^[a-zA-Z0-9_-]+$/.test(name))).toBe(true);
   });
 });
+
+function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") return reject(new Error("Missing test port"));
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}

--- a/packages/adapters/src/pi-runtime.test.ts
+++ b/packages/adapters/src/pi-runtime.test.ts
@@ -30,6 +30,7 @@ describe("Pi agent runtime", () => {
       },
     )) {
       if (event.type === "text") events.push(event.text);
+      if (event.type === "error") events.push(event.message);
     }
     expect(events.join(" ")).toMatch(/Unknown model/i);
   });

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -12,7 +12,11 @@ import type {
 import type { ReasoningStep } from "@rakazo/contracts";
 import { reasoningToolDetail, reasoningToolTitle } from "@rakazo/core";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
-import { attachOpenAICompatibleProvider } from "./openai-compatible.js";
+import {
+  attachOpenAICompatibleProvider,
+  createOpenAICompatibleFetch,
+  OPENAI_COMPATIBLE_KEYLESS_API_KEY,
+} from "./openai-compatible.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
 import { registerLocalProvider } from "./pi-local-provider.js";
 
@@ -72,7 +76,14 @@ export class PiAgentRuntime implements AgentRuntime {
 
         const apiKey = request.model.oauth
           ? undefined
-          : (request.model.apiKey ?? process.env.OPENROUTER_API_KEY);
+          : request.model.baseUrl
+            ? request.model.apiKey?.trim() || OPENAI_COMPATIBLE_KEYLESS_API_KEY
+            : (request.model.apiKey ?? process.env.OPENROUTER_API_KEY);
+        const providerFetch = request.model.baseUrl
+          ? createOpenAICompatibleFetch({
+              allowPrivateNetwork: request.model.allowPrivateNetwork,
+            })
+          : undefined;
         const toolDefs = request.tools.length ? request.tools : builtinAgentTools;
         const nestedAgents = new Set<Agent>();
         const host: ToolHost = {
@@ -81,6 +92,7 @@ export class PiAgentRuntime implements AgentRuntime {
           models,
           model,
           apiKey,
+          providerFetch,
           nestedAgents,
           subagentGate: createGate(MAX_PARALLEL_SUBAGENTS),
           signal,
@@ -90,7 +102,8 @@ export class PiAgentRuntime implements AgentRuntime {
         const history = toHistory(request.history, request.prompt);
 
         const agent = new Agent({
-          streamFn: (m, ctx, options) => models.streamSimple(m, ctx, options),
+          streamFn: (m, ctx, options) =>
+            models.streamSimple(m, ctx, { ...options, fetch: providerFetch ?? options?.fetch }),
           getApiKey: async () => apiKey,
           transformContext: async (messages) => pruneComputerScreenshotContext(messages),
           initialState: {
@@ -235,7 +248,7 @@ export class PiAgentRuntime implements AgentRuntime {
           streamed = fallback;
         }
         emitReasoning({
-          id: "status",
+          id: "status:done",
           kind: "status",
           title: "Finished",
           status: "done",
@@ -259,11 +272,9 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
-function modelsForRequest(
-  request: AgentRunRequest,
-  provider: string,
-): ReturnType<typeof builtinModels> {
+function modelsForRequest(request: AgentRunRequest, provider: string): Models {
   const oauth = request.model.oauth;
+  if (!oauth && !request.model.baseUrl) return catalogModels();
   const models = oauth
     ? registerLocalProvider(
         builtinModels({
@@ -274,7 +285,7 @@ function modelsForRequest(
           ),
         }),
       )
-    : catalogModels();
+    : registerLocalProvider(builtinModels());
   if (request.model.baseUrl) {
     attachOpenAICompatibleProvider(models as MutableModels, {
       provider,
@@ -499,7 +510,11 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
   );
   const nestedHost: ToolHost = { ...host, depth: 1 };
   const nested = new Agent({
-    streamFn: (m, ctx, options) => host.models.streamSimple(m, ctx, options),
+    streamFn: (m, ctx, options) =>
+      host.models.streamSimple(m, ctx, {
+        ...options,
+        fetch: host.providerFetch ?? options?.fetch,
+      }),
     getApiKey: async () => host.apiKey,
     transformContext: async (messages) => pruneComputerScreenshotContext(messages),
     initialState: {
@@ -788,6 +803,7 @@ interface ToolHost {
   models: Models;
   model: Model<Api>;
   apiKey: string | undefined;
+  providerFetch: typeof fetch | undefined;
   nestedAgents: Set<Agent>;
   subagentGate: { acquire(): Promise<void>; release(): void };
   signal: AbortSignal;

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -50,10 +50,14 @@ export class PiAgentRuntime implements AgentRuntime {
   async *run(request: AgentRunRequest, context: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
-    const signal = context.signal ?? controller.signal;
+    const signal = AbortSignal.any([controller.signal, context.signal]);
     const queue = createQueue();
 
     const work = (async () => {
+      let agent: Agent | undefined;
+      let onAbort: (() => void) | undefined;
+      let streamed = "";
+      let sawToolExecution = false;
       try {
         const provider =
           request.model.provider === "scripted" ? "openrouter" : request.model.provider;
@@ -64,8 +68,11 @@ export class PiAgentRuntime implements AgentRuntime {
         const models = modelsForRequest(request, provider);
         const model = models.getModel(provider, modelId) ?? models.getModel("openrouter", modelId);
         if (!model) {
-          queue.push({ type: "text", text: `Unknown model ${provider}/${modelId}` });
-          queue.push({ type: "done" });
+          pushRunError(
+            queue,
+            `Unknown model ${provider}/${modelId}`,
+            Boolean(request.model.baseUrl),
+          );
           return;
         }
 
@@ -88,7 +95,7 @@ export class PiAgentRuntime implements AgentRuntime {
         const tools = toAgentTools(toolDefs, host);
         const history = toHistory(request.history, request.prompt);
 
-        const agent = new Agent({
+        agent = new Agent({
           streamFn: (m, ctx, options) => models.streamSimple(m, ctx, options),
           getApiKey: async () => apiKey,
           transformContext: async (messages) => pruneComputerScreenshotContext(messages),
@@ -109,14 +116,16 @@ export class PiAgentRuntime implements AgentRuntime {
           queue.push({ type: "done", text: "stopped" });
           return;
         }
-        const onAbort = () => {
-          agent.abort();
+        onAbort = () => {
+          agent?.abort();
           for (const nested of nestedAgents) nested.abort();
         };
         signal.addEventListener("abort", onAbort);
 
-        let streamed = "";
         agent.subscribe((event) => {
+          if (event.type === "tool_execution_start") {
+            sawToolExecution = true;
+          }
           if (
             event.type === "message_update" &&
             event.assistantMessageEvent.type === "text_delta"
@@ -154,6 +163,7 @@ export class PiAgentRuntime implements AgentRuntime {
         await agent.prompt(request.prompt, images?.length ? images : undefined);
         await agent.waitForIdle();
         signal.removeEventListener("abort", onAbort);
+        onAbort = undefined;
 
         const error = agent.state.errorMessage;
         if (error && !isMissingFinishReasonError(error)) {
@@ -162,16 +172,18 @@ export class PiAgentRuntime implements AgentRuntime {
         }
         if (!streamed) {
           try {
+            const existing = assistantText(agent.state.messages.at(-1));
             const recovered =
-              (await recoverGatewayReply(request, signal)) ||
-              assistantText(agent.state.messages.at(-1));
+              existing || (sawToolExecution ? "" : await recoverGatewayReply(request, signal));
             if (recovered) {
               queue.push({ type: "text", text: recovered });
               streamed = recovered;
             } else {
               pushRunError(
                 queue,
-                error || "The gateway returned an empty reply",
+                sawToolExecution
+                  ? "The model returned no final reply after running tools"
+                  : error || "The gateway returned an empty reply",
                 Boolean(request.model.baseUrl),
               );
               return;
@@ -188,7 +200,15 @@ export class PiAgentRuntime implements AgentRuntime {
         queue.push({ type: "done", text: streamed });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
-        if (isMissingFinishReasonError(message) && request.model.baseUrl) {
+        if (isMissingFinishReasonError(message)) {
+          const existing = streamed || assistantText(agent?.state.messages.at(-1));
+          if (existing) {
+            if (!streamed) queue.push({ type: "text", text: existing });
+            queue.push({ type: "done", text: existing });
+            return;
+          }
+        }
+        if (isMissingFinishReasonError(message) && request.model.baseUrl && !sawToolExecution) {
           try {
             const recovered = await recoverGatewayReply(request, signal);
             if (recovered) {
@@ -205,8 +225,15 @@ export class PiAgentRuntime implements AgentRuntime {
             return;
           }
         }
-        pushRunError(queue, message, Boolean(request.model.baseUrl));
+        pushRunError(
+          queue,
+          isMissingFinishReasonError(message) && sawToolExecution
+            ? "The model returned no final reply after running tools"
+            : message,
+          Boolean(request.model.baseUrl),
+        );
       } finally {
+        if (onAbort) signal.removeEventListener("abort", onAbort);
         queue.close();
       }
     })();
@@ -724,10 +751,9 @@ function pushRunError(
     },
   });
   queue.push({
-    type: "text",
-    text: message,
+    type: "error",
+    message,
   });
-  queue.push({ type: "done", text: message });
 }
 
 async function recoverGatewayReply(request: AgentRunRequest, signal: AbortSignal): Promise<string> {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -1,5 +1,5 @@
 import { Agent, type AgentMessage, type AgentTool } from "@earendil-works/pi-agent-core";
-import { type Api, type Model, type Models, Type } from "@earendil-works/pi-ai";
+import { type Api, type Model, type Models, type MutableModels, Type } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import type {
   AdapterContext,
@@ -9,7 +9,10 @@ import type {
   AgentToolExecutionResult,
   ConnectorTool,
 } from "@rakazo/adapter-kit";
+import type { ReasoningStep } from "@rakazo/contracts";
+import { reasoningToolDetail, reasoningToolTitle } from "@rakazo/core";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
+import { attachOpenAICompatibleProvider } from "./openai-compatible.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
 import { registerLocalProvider } from "./pi-local-provider.js";
 
@@ -58,7 +61,9 @@ export class PiAgentRuntime implements AgentRuntime {
             ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731")
             : request.model.id;
         const models = modelsForRequest(request, provider);
-        const model = models.getModel(provider, modelId) ?? models.getModel("openrouter", modelId);
+        const model =
+          models.getModel(provider, modelId) ??
+          (request.model.baseUrl ? undefined : models.getModel("openrouter", modelId));
         if (!model) {
           queue.push({ type: "text", text: `Unknown model ${provider}/${modelId}` });
           queue.push({ type: "done" });
@@ -95,7 +100,7 @@ export class PiAgentRuntime implements AgentRuntime {
                 ? "You are a Rakazo bot with a real computer. Use computer_observe and computer_act to operate its visible desktop, including browsers and installed applications. Use shell and the file tools for precise terminal and filesystem work. The user may interact with the same desktop while you run, so re-observe when the screen may have changed. Be concise."
                 : "You are a Rakazo bot with a persistent sandbox filesystem and shell. Be concise."),
             model,
-            thinkingLevel: "off",
+            thinkingLevel: model.reasoning ? "medium" : "off",
             tools,
             messages: history,
           },
@@ -112,7 +117,72 @@ export class PiAgentRuntime implements AgentRuntime {
         signal.addEventListener("abort", onAbort);
 
         let streamed = "";
+        let thinking = "";
+        let lastThinkPush = 0;
+        const emitReasoning = (step: ReasoningStep) => {
+          queue.push({ type: "reasoning", step });
+        };
+        emitReasoning({
+          id: "status",
+          kind: "status",
+          title: "Working through the request",
+          status: "running",
+        });
         agent.subscribe((event) => {
+          if (
+            event.type === "message_update" &&
+            event.assistantMessageEvent.type === "thinking_delta"
+          ) {
+            const delta = event.assistantMessageEvent.delta;
+            if (delta) {
+              thinking += delta;
+              const now = Date.now();
+              if (now - lastThinkPush >= 80) {
+                lastThinkPush = now;
+                emitReasoning({
+                  id: "think",
+                  kind: "think",
+                  title: "Thinking",
+                  detail: thinking.slice(-4000),
+                  status: "running",
+                });
+              }
+            }
+          }
+          if (
+            event.type === "message_update" &&
+            event.assistantMessageEvent.type === "thinking_end"
+          ) {
+            const content = event.assistantMessageEvent.content || thinking;
+            if (content) {
+              thinking = content;
+              emitReasoning({
+                id: "think",
+                kind: "think",
+                title: "Thought",
+                detail: content.slice(-8000),
+                status: "done",
+              });
+            }
+          }
+          if (event.type === "tool_execution_start") {
+            emitReasoning({
+              id: event.toolCallId,
+              kind: "tool",
+              title: reasoningToolTitle(event.toolName, event.args ?? {}),
+              detail: reasoningToolDetail(event.toolName, event.args ?? {}),
+              status: "running",
+            });
+          }
+          if (event.type === "tool_execution_end") {
+            emitReasoning({
+              id: event.toolCallId,
+              kind: "tool",
+              title: reasoningToolTitle(event.toolName, event.args ?? {}),
+              detail: event.isError ? "failed" : "done",
+              status: "done",
+            });
+          }
           if (
             event.type === "message_update" &&
             event.assistantMessageEvent.type === "text_delta"
@@ -141,7 +211,6 @@ export class PiAgentRuntime implements AgentRuntime {
           }
         });
 
-        queue.push({ type: "progress", text: "working…" });
         const images = request.currentTurnImages?.map((image) => ({
           type: "image" as const,
           data: Buffer.from(image.data).toString("base64"),
@@ -163,6 +232,12 @@ export class PiAgentRuntime implements AgentRuntime {
           streamed = fallback;
         }
         queue.push({ type: "done", text: streamed });
+        emitReasoning({
+          id: "status",
+          kind: "status",
+          title: "Finished",
+          status: "done",
+        });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
         queue.push({ type: "text", text: `I hit a problem: ${message}` });
@@ -181,20 +256,28 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
-function modelsForRequest(request: AgentRunRequest, provider: string): Models {
+function modelsForRequest(request: AgentRunRequest, provider: string): ReturnType<typeof builtinModels> {
   const oauth = request.model.oauth;
-  if (!oauth) return catalogModels();
-
-  const persist = oauth.persist;
-  return registerLocalProvider(
-    builtinModels({
-      credentials: new PiRuntimeCredentialStore(
-        provider,
-        toOAuthCredential(oauth.credential),
-        persist ? (next) => persist(next) : undefined,
-      ),
-    }),
-  );
+  const models = oauth
+    ? registerLocalProvider(
+        builtinModels({
+          credentials: new PiRuntimeCredentialStore(
+            provider,
+            toOAuthCredential(oauth.credential),
+            oauth.persist ? (next) => oauth.persist!(next) : undefined,
+          ),
+        }),
+      )
+    : catalogModels();
+  if (request.model.baseUrl) {
+    attachOpenAICompatibleProvider(models as MutableModels, {
+      provider,
+      baseUrl: request.model.baseUrl,
+      modelId: request.model.id,
+      apiKey: request.model.apiKey,
+    });
+  }
+  return models;
 }
 
 function toAgentTools(toolDefs: readonly ConnectorTool[], host: ToolHost): AgentTool[] {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -119,6 +119,7 @@ export class PiAgentRuntime implements AgentRuntime {
         let streamed = "";
         let thinking = "";
         let lastThinkPush = 0;
+        const toolArgs = new Map<string, Record<string, unknown>>();
         const emitReasoning = (step: ReasoningStep) => {
           queue.push({ type: "reasoning", step });
         };
@@ -166,6 +167,7 @@ export class PiAgentRuntime implements AgentRuntime {
             }
           }
           if (event.type === "tool_execution_start") {
+            toolArgs.set(event.toolCallId, event.args ?? {});
             emitReasoning({
               id: event.toolCallId,
               kind: "tool",
@@ -175,10 +177,11 @@ export class PiAgentRuntime implements AgentRuntime {
             });
           }
           if (event.type === "tool_execution_end") {
+            const args = toolArgs.get(event.toolCallId) ?? {};
             emitReasoning({
               id: event.toolCallId,
               kind: "tool",
-              title: reasoningToolTitle(event.toolName, event.args ?? {}),
+              title: reasoningToolTitle(event.toolName, args),
               detail: event.isError ? "failed" : "done",
               status: "done",
             });
@@ -231,13 +234,13 @@ export class PiAgentRuntime implements AgentRuntime {
           queue.push({ type: "text", text: fallback });
           streamed = fallback;
         }
-        queue.push({ type: "done", text: streamed });
         emitReasoning({
           id: "status",
           kind: "status",
           title: "Finished",
           status: "done",
         });
+        queue.push({ type: "done", text: streamed });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
         queue.push({ type: "text", text: `I hit a problem: ${message}` });
@@ -256,7 +259,10 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
-function modelsForRequest(request: AgentRunRequest, provider: string): ReturnType<typeof builtinModels> {
+function modelsForRequest(
+  request: AgentRunRequest,
+  provider: string,
+): ReturnType<typeof builtinModels> {
   const oauth = request.model.oauth;
   const models = oauth
     ? registerLocalProvider(

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -10,6 +10,10 @@ import type {
   ConnectorTool,
 } from "@rakazo/adapter-kit";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
+import {
+  attachOpenAICompatibleProvider,
+  completeOpenAICompatibleChat,
+} from "./openai-compatible.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
 import { registerLocalProvider } from "./pi-local-provider.js";
 
@@ -152,21 +156,56 @@ export class PiAgentRuntime implements AgentRuntime {
         signal.removeEventListener("abort", onAbort);
 
         const error = agent.state.errorMessage;
-        if (error) {
-          queue.push({ type: "text", text: `I hit a problem: ${sanitizeError(error)}` });
-          queue.push({ type: "done", text: sanitizeError(error) });
+        if (error && !isMissingFinishReasonError(error)) {
+          pushRunError(queue, error, Boolean(request.model.baseUrl));
           return;
         }
         if (!streamed) {
-          const fallback = assistantText(agent.state.messages.at(-1)) || "I finished the work.";
-          queue.push({ type: "text", text: fallback });
-          streamed = fallback;
+          try {
+            const recovered =
+              (await recoverGatewayReply(request, signal)) ||
+              assistantText(agent.state.messages.at(-1));
+            if (recovered) {
+              queue.push({ type: "text", text: recovered });
+              streamed = recovered;
+            } else {
+              pushRunError(
+                queue,
+                error || "The gateway returned an empty reply",
+                Boolean(request.model.baseUrl),
+              );
+              return;
+            }
+          } catch (recoveryError) {
+            pushRunError(
+              queue,
+              recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+              Boolean(request.model.baseUrl),
+            );
+            return;
+          }
         }
         queue.push({ type: "done", text: streamed });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
-        queue.push({ type: "text", text: `I hit a problem: ${message}` });
-        queue.push({ type: "done", text: message });
+        if (isMissingFinishReasonError(message) && request.model.baseUrl) {
+          try {
+            const recovered = await recoverGatewayReply(request, signal);
+            if (recovered) {
+              queue.push({ type: "text", text: recovered });
+              queue.push({ type: "done", text: recovered });
+              return;
+            }
+          } catch (recoveryError) {
+            pushRunError(
+              queue,
+              recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+              true,
+            );
+            return;
+          }
+        }
+        pushRunError(queue, message, Boolean(request.model.baseUrl));
       } finally {
         queue.close();
       }
@@ -495,7 +534,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
     await nested.waitForIdle();
     host.signal.removeEventListener("abort", onAbort);
     const error = nested.state.errorMessage;
-    if (error) {
+    if (error && !isMissingFinishReasonError(error)) {
       const message = sanitizeError(error);
       host.queue.push({ type: "subagent", agentId, name, task, status: "failed", result: message });
       return `Subagent failed: ${message}`;
@@ -662,6 +701,62 @@ function summarizeToolResult(result: unknown) {
   } catch {
     return "ok";
   }
+}
+
+export function isMissingFinishReasonError(error: string): boolean {
+  return /stream ended without finish_reason/i.test(error);
+}
+
+function pushRunError(
+  queue: { push(event: AgentRuntimeEvent): void },
+  error: string,
+  fromGateway: boolean,
+) {
+  const message = sanitizeError(error);
+  queue.push({
+    type: "reasoning",
+    step: {
+      id: "status",
+      kind: "status",
+      title: fromGateway ? "Gateway error" : "Failed",
+      detail: message,
+      status: "done",
+    },
+  });
+  queue.push({
+    type: "text",
+    text: message,
+  });
+  queue.push({ type: "done", text: message });
+}
+
+async function recoverGatewayReply(request: AgentRunRequest, signal: AbortSignal): Promise<string> {
+  if (!request.model.baseUrl) return "";
+  return completeOpenAICompatibleChat({
+    baseUrl: request.model.baseUrl,
+    apiKey: request.model.apiKey,
+    modelId: request.model.id,
+    messages: gatewayChatMessages(request),
+    signal,
+  });
+}
+
+function gatewayChatMessages(
+  request: AgentRunRequest,
+): Array<{ role: "system" | "user" | "assistant"; content: string }> {
+  const messages: Array<{ role: "system" | "user" | "assistant"; content: string }> = [];
+  if (request.instructions?.trim()) {
+    messages.push({ role: "system", content: request.instructions });
+  }
+  for (const item of request.history) {
+    if (item.role === "user" || item.role === "assistant") {
+      messages.push({ role: item.role, content: item.content });
+    }
+  }
+  if (messages.at(-1)?.role !== "user" || messages.at(-1)?.content !== request.prompt) {
+    messages.push({ role: "user", content: request.prompt });
+  }
+  return messages;
 }
 
 function assistantText(message: unknown): string {

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -44,7 +44,15 @@ export class ScriptedAgentRuntime implements AgentRuntime {
           return;
         }
         if (turn.assistant) {
-          yield { type: "progress", text: "working…" };
+          yield {
+            type: "reasoning",
+            step: {
+              id: "status",
+              kind: "status",
+              title: "Writing a reply",
+              status: "running",
+            },
+          };
           yield { type: "text", text: turn.assistant };
         }
         for (const call of turn.toolCalls ?? []) {
@@ -81,6 +89,7 @@ export class ScriptedAgentRuntime implements AgentRuntime {
             name: call.name,
             args: call.args,
             executionId: `${request.runId}:${call.name}`,
+            status: "running",
           };
         }
         if (turn.ask) {

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -27,6 +27,8 @@ export const BotSchema = z.object({
   createdAt: z.string(),
   voiceId: z.string().nullable(),
   autoSpeak: z.boolean(),
+  modelProvider: z.string().nullable(),
+  modelId: z.string().nullable(),
 });
 export type Bot = z.infer<typeof BotSchema>;
 
@@ -47,6 +49,8 @@ export const CreateBotInput = z.object({
   notifyOnFinish: z.boolean().default(true),
   color: z.string().optional(),
   computerMode: ComputerModeSchema.default("team"),
+  modelProvider: z.string().max(120).nullable().optional(),
+  modelId: z.string().max(200).nullable().optional(),
 });
 export type CreateBotInput = z.infer<typeof CreateBotInput>;
 
@@ -62,6 +66,8 @@ export const UpdateBotInput = z.object({
   sectionId: Id.nullable().optional(),
   voiceId: z.string().max(120).nullable().optional(),
   autoSpeak: z.boolean().optional(),
+  modelProvider: z.string().max(120).nullable().optional(),
+  modelId: z.string().max(200).nullable().optional(),
 });
 
 export const RoutineSchema = z.object({
@@ -268,6 +274,9 @@ export const ModelCredentialSchema = z.object({
   label: z.string(),
   hasKey: z.boolean(),
   isDefault: z.boolean(),
+  baseUrl: z.string().nullable().optional(),
+  defaultModel: z.string().nullable().optional(),
+  availableModels: z.array(z.string()).optional(),
 });
 export type ModelCredential = z.infer<typeof ModelCredentialSchema>;
 
@@ -281,6 +290,8 @@ export const ModelCatalogEntrySchema = z.object({
   oauthLabel: z.string().optional(),
   subscription: z.boolean().optional(),
   signIn: z.enum(["device-code"]).optional(),
+  custom: z.boolean().optional(),
+  baseUrl: z.string().optional(),
 });
 export type ModelCatalogEntry = z.infer<typeof ModelCatalogEntrySchema>;
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -262,12 +262,27 @@ export const ThreadSnapshotSchema = z.object({
 });
 export type ThreadSnapshot = z.infer<typeof ThreadSnapshotSchema>;
 
+export const ModelCredentialKeySchema = z.object({
+  id: Id,
+  label: z.string(),
+  isActive: z.boolean(),
+  createdAt: z.string(),
+  availableModels: z.array(z.string()).optional(),
+  probedAt: z.string().nullable().optional(),
+  probeError: z.string().optional(),
+});
+export type ModelCredentialKey = z.infer<typeof ModelCredentialKeySchema>;
+
 export const ModelCredentialSchema = z.object({
   id: Id,
   provider: z.string(),
   label: z.string(),
   hasKey: z.boolean(),
   isDefault: z.boolean(),
+  baseUrl: z.string().nullable().optional(),
+  defaultModel: z.string().nullable().optional(),
+  availableModels: z.array(z.string()).optional(),
+  keys: z.array(ModelCredentialKeySchema),
 });
 export type ModelCredential = z.infer<typeof ModelCredentialSchema>;
 

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -6,6 +6,7 @@ export const ProductEventType = z.enum([
   "thread.cleared",
   "thread.message.updated",
   "thread.progress",
+  "thread.reasoning",
   "thread.artifact",
   "thread.ask",
   "thread.choice",
@@ -42,6 +43,15 @@ export type ProductEventType = z.infer<typeof ProductEventType>;
 
 export const MessageRole = z.enum(["user", "bot", "system"]);
 
+export const ReasoningStepSchema = z.object({
+  id: z.string(),
+  kind: z.enum(["status", "think", "tool"]),
+  title: z.string(),
+  detail: z.string().optional(),
+  status: z.enum(["running", "done"]),
+});
+export type ReasoningStep = z.infer<typeof ReasoningStepSchema>;
+
 export const MessageBlock = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("text"), text: z.string() }),
   z.object({
@@ -76,6 +86,10 @@ export const MessageBlock = z.discriminatedUnion("kind", [
   }),
   z.object({ kind: z.literal("meta"), text: z.string() }),
   z.object({ kind: z.literal("progress"), text: z.string() }),
+  z.object({
+    kind: z.literal("reasoning"),
+    steps: z.array(ReasoningStepSchema),
+  }),
   z.object({
     kind: z.literal("subagent"),
     agentId: z.string(),

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -25,6 +25,7 @@ describe("contracts", () => {
     expect(ProductEventType.options).toContain("thread.message.created");
     expect(ProductEventType.options).toContain("thread.cleared");
     expect(ProductEventType.options).toContain("thread.subagent");
+    expect(ProductEventType.options).toContain("thread.reasoning");
     expect(ProductEventType.options).toContain("bot.spawned");
   });
 });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -62,12 +62,22 @@ export const appContract = {
       .input(
         z.object({
           provider: z.string(),
-          apiKey: z.string().min(8),
+          apiKey: z.string().max(4000).optional().default(""),
           label: z.string().optional(),
           modelId: z.string().optional(),
+          baseUrl: z.string().max(500).optional(),
+          availableModels: z.array(z.string().min(1).max(200)).max(200).optional(),
         }),
       )
       .output(ModelCredentialSchema),
+    probe: oc
+      .input(
+        z.object({
+          baseUrl: z.string().min(1).max(500),
+          apiKey: z.string().max(4000).optional(),
+        }),
+      )
+      .output(z.object({ models: z.array(z.string()) })),
     beginOAuth: oc
       .input(
         z.object({

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -61,10 +61,10 @@ export const appContract = {
     connect: oc
       .input(
         z.object({
-          provider: z.string(),
+          provider: z.string().min(1).max(120),
           apiKey: z.string().max(4000).optional().default(""),
-          label: z.string().optional(),
-          modelId: z.string().optional(),
+          label: z.string().max(200).optional(),
+          modelId: z.string().max(200).optional(),
           baseUrl: z.string().max(500).optional(),
           availableModels: z.array(z.string().min(1).max(200)).max(200).optional(),
         }),
@@ -81,9 +81,9 @@ export const appContract = {
     beginOAuth: oc
       .input(
         z.object({
-          provider: z.string(),
-          label: z.string().optional(),
-          modelId: z.string().optional(),
+          provider: z.string().min(1).max(120),
+          label: z.string().max(200).optional(),
+          modelId: z.string().max(200).optional(),
         }),
       )
       .output(
@@ -108,7 +108,9 @@ export const appContract = {
       .input(z.object({ loginId: z.string() }))
       .output(z.object({ ok: z.literal(true) })),
     setDefault: oc
-      .input(z.object({ provider: z.string(), modelId: z.string() }))
+      .input(
+        z.object({ provider: z.string().min(1).max(120), modelId: z.string().min(1).max(200) }),
+      )
       .output(z.object({ ok: z.literal(true) })),
   },
   bots: {

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -100,6 +100,22 @@ export const appContract = {
     setDefault: oc
       .input(z.object({ provider: z.string(), modelId: z.string() }))
       .output(z.object({ ok: z.literal(true) })),
+    addKey: oc
+      .input(
+        z.object({
+          provider: z.string(),
+          apiKey: z.string().min(1).max(4000),
+          label: z.string().trim().min(1).max(80).optional(),
+        }),
+      )
+      .output(ModelCredentialSchema),
+    removeKey: oc
+      .input(z.object({ provider: z.string(), keyId: Id }))
+      .output(ModelCredentialSchema),
+    setActiveKey: oc
+      .input(z.object({ provider: z.string(), keyId: Id }))
+      .output(ModelCredentialSchema),
+    refreshKeys: oc.input(z.object({ provider: z.string() })).output(ModelCredentialSchema),
   },
   bots: {
     list: oc.output(z.array(BotSchema)),

--- a/packages/core/src/attachments.test.ts
+++ b/packages/core/src/attachments.test.ts
@@ -42,6 +42,18 @@ describe("attachment helpers", () => {
           name: "brief.pdf",
           size: 99,
         },
+        {
+          kind: "reasoning",
+          steps: [
+            {
+              id: "tool-1",
+              kind: "tool",
+              title: "Read private command",
+              detail: "fake-sensitive-tool-argument",
+              status: "done",
+            },
+          ],
+        },
       ]),
     ).toBe("hello\n[image: shot.png]\n[file: brief.pdf (application/pdf, 99 bytes)]");
   });

--- a/packages/core/src/attachments.ts
+++ b/packages/core/src/attachments.ts
@@ -90,6 +90,12 @@ export function blocksToAgentHistoryText(blocks: MessageBlock[]): string {
   return blocks
     .map((block) => {
       if (block.kind === "text") return block.text;
+      if (block.kind === "reasoning") {
+        return block.steps
+          .map((step) => [step.title, step.detail].filter(Boolean).join(": "))
+          .filter(Boolean)
+          .join("\n");
+      }
       if (block.kind === "image") return `[image: ${block.name}]`;
       if (block.kind === "file") {
         return `[file: ${block.name} (${block.mimeType}, ${block.size} bytes)]`;

--- a/packages/core/src/attachments.ts
+++ b/packages/core/src/attachments.ts
@@ -90,12 +90,9 @@ export function blocksToAgentHistoryText(blocks: MessageBlock[]): string {
   return blocks
     .map((block) => {
       if (block.kind === "text") return block.text;
-      if (block.kind === "reasoning") {
-        return block.steps
-          .map((step) => [step.title, step.detail].filter(Boolean).join(": "))
-          .filter(Boolean)
-          .join("\n");
-      }
+      // Reasoning is user-visible trace data, not conversation input. Replaying
+      // it would leak internal thinking and tool arguments into later prompts.
+      if (block.kind === "reasoning") return "";
       if (block.kind === "image") return `[image: ${block.name}]`;
       if (block.kind === "file") {
         return `[file: ${block.name} (${block.mimeType}, ${block.size} bytes)]`;

--- a/packages/core/src/events.test.ts
+++ b/packages/core/src/events.test.ts
@@ -128,6 +128,70 @@ describe("projectMessages", () => {
     expect(durable[0]?.blocks[0]).toMatchObject({ status: "completed", result: "ok" });
   });
 
+  it("keeps a live reasoning trace until the completed message is durable", () => {
+    const live = projectMessages([
+      {
+        id: "e1",
+        threadId: "t1",
+        seq: 0,
+        type: "thread.reasoning",
+        runId: "r1",
+        payload: {
+          steps: [
+            {
+              id: "think",
+              kind: "think",
+              title: "Thinking",
+              detail: "checking the inbox",
+              status: "running",
+            },
+          ],
+        },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+    ]);
+    expect(live[0]?.id).toBe("reasoning:r1");
+    expect(live[0]?.blocks[0]).toMatchObject({
+      kind: "reasoning",
+      steps: [expect.objectContaining({ title: "Thinking", detail: "checking the inbox" })],
+    });
+
+    const durable = projectMessages([
+      {
+        id: "e1",
+        threadId: "t1",
+        seq: 0,
+        type: "thread.reasoning",
+        runId: "r1",
+        payload: {
+          steps: [{ id: "think", kind: "think", title: "Thinking", status: "done" }],
+        },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+      {
+        id: "e2",
+        threadId: "t1",
+        seq: 1,
+        type: "thread.message.created",
+        runId: "r1",
+        payload: {
+          messageId: "m2",
+          role: "bot",
+          blocks: [
+            {
+              kind: "reasoning",
+              steps: [{ id: "think", kind: "think", title: "Thinking", status: "done" }],
+            },
+            { kind: "text", text: "Done." },
+          ],
+        },
+        createdAt: "2026-01-01T00:00:03.000Z",
+      },
+    ]);
+    expect(durable).toHaveLength(1);
+    expect(durable[0]?.blocks.map((block) => block.kind)).toEqual(["reasoning", "text"]);
+  });
+
   it("drops prior history when a later clear event is replayed", () => {
     const messages = projectMessages([
       {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,4 +1,5 @@
 import type { MessageBlock, ThreadMessage } from "@rakazo/contracts";
+import { reasoningMessageId, reasoningStepsFromPayload } from "./reasoning.js";
 
 export function projectMessages(
   events: Array<{
@@ -13,6 +14,7 @@ export function projectMessages(
 ): ThreadMessage[] {
   const messages: ThreadMessage[] = [];
   let streaming: ThreadMessage | null = null;
+  let reasoning: ThreadMessage | null = null;
   const liveSubagents = new Map<string, ThreadMessage>();
   const durableSubagents = new Set<string>();
   for (const event of events) {
@@ -21,6 +23,7 @@ export function projectMessages(
       typeof event.createdAt === "string" ? event.createdAt : event.createdAt.toISOString();
     if (event.type === "thread.message.created") {
       streaming = null;
+      reasoning = null;
       const role = (payload.role as ThreadMessage["role"]) ?? "bot";
       const blocks = (payload.blocks as MessageBlock[]) ?? [];
       for (const block of blocks) {
@@ -58,9 +61,23 @@ export function projectMessages(
       };
       continue;
     }
+    if (event.type === "thread.reasoning") {
+      const steps = reasoningStepsFromPayload(payload);
+      reasoning = {
+        id: reasoningMessageId(event),
+        threadId: event.threadId,
+        seq: event.seq,
+        role: "bot",
+        blocks: [{ kind: "reasoning", steps }],
+        runId: event.runId ?? undefined,
+        createdAt,
+      };
+      continue;
+    }
     if (event.type === "thread.cleared") {
       messages.length = 0;
       streaming = null;
+      reasoning = null;
       liveSubagents.clear();
       durableSubagents.clear();
       continue;
@@ -85,9 +102,11 @@ export function projectMessages(
       event.type === "run.cancelled"
     ) {
       streaming = null;
+      reasoning = null;
     }
   }
   for (const live of liveSubagents.values()) messages.push(live);
+  if (reasoning) messages.push(reasoning);
   if (streaming) messages.push(streaming);
   return messages;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@ export * from "./cron.js";
 export * from "./events.js";
 export * from "./message-pages.js";
 export * from "./model-oauth.js";
-export * from "./run-state.js";
+export * from "./reasoning.js";
 export * from "./sandbox-command.js";
 export * from "./screen-lease.js";
 export * from "./search.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./events.js";
 export * from "./message-pages.js";
 export * from "./model-oauth.js";
 export * from "./reasoning.js";
+export * from "./run-state.js";
 export * from "./sandbox-command.js";
 export * from "./screen-lease.js";
 export * from "./search.js";

--- a/packages/core/src/message-pages.ts
+++ b/packages/core/src/message-pages.ts
@@ -1,3 +1,5 @@
+import { isEphemeralThreadMessageId } from "./reasoning.js";
+
 interface MessageIdentity {
   id: string;
   seq?: number;
@@ -68,5 +70,5 @@ export function mergeMessagesById<T extends { id: string }>(
 }
 
 function isDurableMessage(message: { id: string }): boolean {
-  return !message.id.startsWith("progress:") && !message.id.startsWith("subagent:");
+  return !isEphemeralThreadMessageId(message.id) && !message.id.startsWith("subagent:");
 }

--- a/packages/core/src/reasoning.test.ts
+++ b/packages/core/src/reasoning.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  isEphemeralThreadMessageId,
+  reasoningMessageId,
+  reasoningToolTitle,
+  upsertReasoningStep,
+} from "./reasoning.js";
+
+describe("reasoning helpers", () => {
+  it("identifies live progress, reasoning, and pending ids", () => {
+    expect(isEphemeralThreadMessageId("progress:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("reasoning:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("pending:abc")).toBe(true);
+    expect(isEphemeralThreadMessageId("m-1")).toBe(false);
+  });
+
+  it("upserts reasoning steps by id", () => {
+    const first = upsertReasoningStep([], {
+      id: "think",
+      kind: "think",
+      title: "Thinking",
+      status: "running",
+    });
+    const second = upsertReasoningStep(first, {
+      id: "think",
+      kind: "think",
+      title: "Thinking",
+      detail: "considering files",
+      status: "running",
+    });
+    expect(second).toHaveLength(1);
+    expect(second[0]?.detail).toBe("considering files");
+    expect(reasoningMessageId({ runId: "r1" })).toBe("reasoning:r1");
+  });
+
+  it("names common tools in the trace", () => {
+    expect(reasoningToolTitle("shell")).toBe("Running a command");
+    expect(reasoningToolTitle("write_file", { path: "notes/result.txt" })).toBe(
+      "Writing result.txt",
+    );
+  });
+});

--- a/packages/core/src/reasoning.test.ts
+++ b/packages/core/src/reasoning.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  isEphemeralThreadMessageId,
+  reasoningMessageId,
+  reasoningToolTitle,
+  upsertReasoningStep,
+} from "./reasoning.js";
+
+describe("reasoning helpers", () => {
+  it("identifies live progress and reasoning ids", () => {
+    expect(isEphemeralThreadMessageId("progress:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("reasoning:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("m-1")).toBe(false);
+  });
+
+  it("upserts reasoning steps by id", () => {
+    const first = upsertReasoningStep([], {
+      id: "think",
+      kind: "think",
+      title: "Thinking",
+      status: "running",
+    });
+    const second = upsertReasoningStep(first, {
+      id: "think",
+      kind: "think",
+      title: "Thinking",
+      detail: "considering files",
+      status: "running",
+    });
+    expect(second).toHaveLength(1);
+    expect(second[0]?.detail).toBe("considering files");
+    expect(reasoningMessageId({ runId: "r1" })).toBe("reasoning:r1");
+  });
+
+  it("names common tools in the trace", () => {
+    expect(reasoningToolTitle("shell")).toBe("Running a command");
+    expect(reasoningToolTitle("write_file", { path: "notes/result.txt" })).toBe(
+      "Writing result.txt",
+    );
+  });
+});

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -1,0 +1,96 @@
+import type { ReasoningStep } from "@rakazo/contracts";
+
+export function isEphemeralThreadMessageId(id: string): boolean {
+  return id.startsWith("progress:") || id.startsWith("reasoning:");
+}
+
+export function reasoningMessageId(event: { runId?: string | null; id?: string }): string {
+  return `reasoning:${event.runId ?? event.id ?? "live"}`;
+}
+
+export function upsertReasoningStep(
+  steps: ReasoningStep[],
+  step: ReasoningStep,
+): ReasoningStep[] {
+  const next = steps.map((entry) => (entry.id === step.id ? { ...entry, ...step } : entry));
+  if (next.some((entry) => entry.id === step.id)) return next;
+  return [...next, step];
+}
+
+export function reasoningStepsFromPayload(payload: Record<string, unknown> | undefined): ReasoningStep[] {
+  const raw = payload?.steps;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const record = entry as Record<string, unknown>;
+    const kind = record.kind;
+    const status = record.status;
+    if (kind !== "status" && kind !== "think" && kind !== "tool") return [];
+    if (status !== "running" && status !== "done") return [];
+    return [
+      {
+        id: String(record.id ?? ""),
+        kind,
+        title: String(record.title ?? ""),
+        detail: record.detail ? String(record.detail) : undefined,
+        status,
+      },
+    ];
+  });
+}
+
+export function reasoningToolTitle(name: string, args: Record<string, unknown> = {}): string {
+  switch (name) {
+    case "shell":
+      return "Running a command";
+    case "write_file":
+      return args.path ? `Writing ${shortPath(String(args.path))}` : "Writing a file";
+    case "read_file":
+      return args.path ? `Reading ${shortPath(String(args.path))}` : "Reading a file";
+    case "list_files":
+      return "Listing files";
+    case "open_path":
+      return args.path ? `Opening ${shortPath(String(args.path))}` : "Opening a path";
+    case "computer_observe":
+      return "Looking at the screen";
+    case "computer_act":
+      return "Using the computer";
+    case "launch_app":
+      return args.application ? `Opening ${String(args.application)}` : "Opening an app";
+    case "remember":
+      return "Saving a memory";
+    case "request_takeover":
+      return "Asking you to take over";
+    case "run_subagent":
+      return args.name ? `Starting ${String(args.name)}` : "Starting a subagent";
+    case "spawn_bot":
+      return args.name ? `Creating ${String(args.name)}` : "Creating a bot";
+    case "destination.write":
+      return "Writing to a destination";
+    default:
+      return `Using ${name.replaceAll("_", " ").replaceAll(".", " ")}`;
+  }
+}
+
+export function reasoningToolDetail(
+  name: string,
+  args: Record<string, unknown> = {},
+): string | undefined {
+  if (name === "shell") return clip(String(args.command ?? ""));
+  if (name === "write_file") return clip(String(args.content ?? ""));
+  if (name === "remember") return clip(String(args.content ?? args.path ?? ""));
+  if (name === "run_subagent") return clip(String(args.task ?? ""));
+  if (name === "request_takeover") return clip(String(args.reason ?? ""));
+  return undefined;
+}
+
+function shortPath(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts.at(-1) || path;
+}
+
+function clip(value: string, max = 400): string | undefined {
+  const text = value.trim();
+  if (!text) return undefined;
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -8,16 +8,15 @@ export function reasoningMessageId(event: { runId?: string | null; id?: string }
   return `reasoning:${event.runId ?? event.id ?? "live"}`;
 }
 
-export function upsertReasoningStep(
-  steps: ReasoningStep[],
-  step: ReasoningStep,
-): ReasoningStep[] {
+export function upsertReasoningStep(steps: ReasoningStep[], step: ReasoningStep): ReasoningStep[] {
   const next = steps.map((entry) => (entry.id === step.id ? { ...entry, ...step } : entry));
   if (next.some((entry) => entry.id === step.id)) return next;
   return [...next, step];
 }
 
-export function reasoningStepsFromPayload(payload: Record<string, unknown> | undefined): ReasoningStep[] {
+export function reasoningStepsFromPayload(
+  payload: Record<string, unknown> | undefined,
+): ReasoningStep[] {
   const raw = payload?.steps;
   if (!Array.isArray(raw)) return [];
   return raw.flatMap((entry) => {

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -1,0 +1,109 @@
+import type { ReasoningStep } from "@rakazo/contracts";
+
+export const PENDING_USER_MESSAGE_PREFIX = "pending:";
+
+export function isPendingUserMessageId(id: string): boolean {
+  return id.startsWith(PENDING_USER_MESSAGE_PREFIX);
+}
+
+export function createPendingUserMessageId(): string {
+  return `${PENDING_USER_MESSAGE_PREFIX}${crypto.randomUUID()}`;
+}
+
+export function isEphemeralThreadMessageId(id: string): boolean {
+  return id.startsWith("progress:") || id.startsWith("reasoning:") || isPendingUserMessageId(id);
+}
+
+export function pendingUserMessageTextKey(text: string): string {
+  return `pending-text:${text}`;
+}
+
+export function reasoningMessageId(event: { runId?: string | null; id?: string }): string {
+  return `reasoning:${event.runId ?? event.id ?? "live"}`;
+}
+
+export function upsertReasoningStep(steps: ReasoningStep[], step: ReasoningStep): ReasoningStep[] {
+  const next = steps.map((entry) => (entry.id === step.id ? { ...entry, ...step } : entry));
+  if (next.some((entry) => entry.id === step.id)) return next;
+  return [...next, step];
+}
+
+export function reasoningStepsFromPayload(
+  payload: Record<string, unknown> | undefined,
+): ReasoningStep[] {
+  const raw = payload?.steps;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const record = entry as Record<string, unknown>;
+    const kind = record.kind;
+    const status = record.status;
+    if (kind !== "status" && kind !== "think" && kind !== "tool") return [];
+    if (status !== "running" && status !== "done") return [];
+    return [
+      {
+        id: String(record.id ?? ""),
+        kind,
+        title: String(record.title ?? ""),
+        detail: record.detail ? String(record.detail) : undefined,
+        status,
+      },
+    ];
+  });
+}
+
+export function reasoningToolTitle(name: string, args: Record<string, unknown> = {}): string {
+  switch (name) {
+    case "shell":
+      return "Running a command";
+    case "write_file":
+      return args.path ? `Writing ${shortPath(String(args.path))}` : "Writing a file";
+    case "read_file":
+      return args.path ? `Reading ${shortPath(String(args.path))}` : "Reading a file";
+    case "list_files":
+      return "Listing files";
+    case "open_path":
+      return args.path ? `Opening ${shortPath(String(args.path))}` : "Opening a path";
+    case "computer_observe":
+      return "Looking at the screen";
+    case "computer_act":
+      return "Using the computer";
+    case "launch_app":
+      return args.application ? `Opening ${String(args.application)}` : "Opening an app";
+    case "remember":
+      return "Saving a memory";
+    case "request_takeover":
+      return "Asking you to take over";
+    case "run_subagent":
+      return args.name ? `Starting ${String(args.name)}` : "Starting a subagent";
+    case "spawn_bot":
+      return args.name ? `Creating ${String(args.name)}` : "Creating a bot";
+    case "destination.write":
+      return "Writing to a destination";
+    default:
+      return `Using ${name.replaceAll("_", " ").replaceAll(".", " ")}`;
+  }
+}
+
+export function reasoningToolDetail(
+  name: string,
+  args: Record<string, unknown> = {},
+): string | undefined {
+  if (name === "shell") return clip(String(args.command ?? ""));
+  if (name === "write_file") return clip(String(args.content ?? ""));
+  if (name === "remember") return clip(String(args.content ?? args.path ?? ""));
+  if (name === "run_subagent") return clip(String(args.task ?? ""));
+  if (name === "request_takeover") return clip(String(args.reason ?? ""));
+  return undefined;
+}
+
+function shortPath(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts.at(-1) || path;
+}
+
+function clip(value: string, max = 400): string | undefined {
+  const text = value.trim();
+  if (!text) return undefined;
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}

--- a/packages/core/src/speech-text.ts
+++ b/packages/core/src/speech-text.ts
@@ -198,6 +198,12 @@ export function speechFromBlocks(blocks: MessageBlock[]): string {
     .map((block) => {
       if (block.kind === "text" || block.kind === "progress" || block.kind === "meta")
         return block.text;
+      if (block.kind === "reasoning") {
+        return block.steps
+          .filter((step) => step.kind !== "think")
+          .map((step) => step.title)
+          .join(". ");
+      }
       if (block.kind === "ask") return block.text;
       if (block.kind === "computer") return block.text;
       if (block.kind === "subagent") {

--- a/packages/db/prisma/migrations/0013_gateway_and_bot_model/migration.sql
+++ b/packages/db/prisma/migrations/0013_gateway_and_bot_model/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "user_model_credentials" ADD COLUMN "baseUrl" TEXT;
+ALTER TABLE "user_model_credentials" ADD COLUMN "availableModels" TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE "bots" ADD COLUMN "modelProvider" TEXT;
+ALTER TABLE "bots" ADD COLUMN "modelId" TEXT;

--- a/packages/db/prisma/migrations/0014_model_credential_keys/migration.sql
+++ b/packages/db/prisma/migrations/0014_model_credential_keys/migration.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "user_model_credential_keys" (
+  "id" TEXT NOT NULL,
+  "credentialId" TEXT NOT NULL,
+  "secretId" TEXT NOT NULL,
+  "label" TEXT NOT NULL DEFAULT 'API key',
+  "isActive" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "user_model_credential_keys_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "user_model_credential_keys_credentialId_createdAt_id_idx"
+ON "user_model_credential_keys"("credentialId", "createdAt", "id");
+
+ALTER TABLE "user_model_credential_keys"
+ADD CONSTRAINT "user_model_credential_keys_credentialId_fkey"
+FOREIGN KEY ("credentialId") REFERENCES "user_model_credentials"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+INSERT INTO "user_model_credential_keys" ("id", "credentialId", "secretId", "label", "isActive", "createdAt")
+SELECT
+  "id",
+  "id",
+  "secretId",
+  'API key',
+  TRUE,
+  "createdAt"
+FROM "user_model_credentials";

--- a/packages/db/prisma/migrations/0014_model_credential_keys/migration.sql
+++ b/packages/db/prisma/migrations/0014_model_credential_keys/migration.sql
@@ -11,6 +11,10 @@ CREATE TABLE "user_model_credential_keys" (
 CREATE INDEX "user_model_credential_keys_credentialId_createdAt_id_idx"
 ON "user_model_credential_keys"("credentialId", "createdAt", "id");
 
+CREATE UNIQUE INDEX "user_model_credential_keys_one_active_idx"
+ON "user_model_credential_keys"("credentialId")
+WHERE "isActive" = TRUE;
+
 ALTER TABLE "user_model_credential_keys"
 ADD CONSTRAINT "user_model_credential_keys_credentialId_fkey"
 FOREIGN KEY ("credentialId") REFERENCES "user_model_credentials"("id")

--- a/packages/db/prisma/migrations/0015_key_model_coverage/migration.sql
+++ b/packages/db/prisma/migrations/0015_key_model_coverage/migration.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "user_model_credential_keys"
+ADD COLUMN "availableModels" TEXT NOT NULL DEFAULT '',
+ADD COLUMN "probedAt" TIMESTAMP(3),
+ADD COLUMN "probeError" TEXT NOT NULL DEFAULT '';
+
+UPDATE "user_model_credential_keys" AS k
+SET "availableModels" = c."availableModels"
+FROM "user_model_credentials" AS c
+WHERE k."credentialId" = c."id"
+  AND k."isActive" = TRUE
+  AND c."availableModels" <> '';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -166,6 +166,8 @@ model UserModelCredential {
   secretId     String
   isDefault    Boolean  @default(false)
   defaultModel String?
+  baseUrl      String?
+  availableModels String @default("")
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
@@ -216,6 +218,8 @@ model Bot {
   computerSwitching Boolean @default(false)
   voiceId        String?
   autoSpeak      Boolean  @default(false)
+  modelProvider  String?
+  modelId        String?
   routines       Routine[]
   taughtSkills   TaughtSkill[]
   memoryDocuments MemoryDocument[]

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -168,9 +168,26 @@ model UserModelCredential {
   defaultModel String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  keys         UserModelCredentialKey[]
 
   @@index([userId, workspaceId])
   @@map("user_model_credentials")
+}
+
+model UserModelCredentialKey {
+  id           String   @id @default(cuid())
+  credentialId String
+  credential   UserModelCredential @relation(fields: [credentialId], references: [id], onDelete: Cascade)
+  secretId     String
+  label        String   @default("API key")
+  isActive     Boolean  @default(false)
+  availableModels String @default("")
+  probedAt     DateTime?
+  probeError   String   @default("")
+  createdAt    DateTime @default(now())
+
+  @@index([credentialId, createdAt, id])
+  @@map("user_model_credential_keys")
 }
 
 model UserVoiceCredential {

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -243,6 +243,12 @@ describe("pauseRunForInput", () => {
       "thread.message.created",
       "run.waiting_input",
     ]);
+    expect(tx.event.deleteMany).toHaveBeenCalledWith({
+      where: {
+        runId: "run-1",
+        type: { in: ["thread.progress", "thread.reasoning"] },
+      },
+    });
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 8 }));
   });
 });

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -543,6 +543,22 @@ export async function finalizeRun(
         runId: input.runId,
         payload: { messageId: message.id, role: "bot", blocks: input.blocks },
       });
+    } else {
+      const blocks = [{ kind: "text" as const, text: input.error }];
+      const message = await createThreadMessageInTransaction(tx, {
+        threadId: input.threadId,
+        role: "bot",
+        blocks,
+        runId: input.runId,
+      });
+      await appendEventInTransaction(tx, {
+        workspaceId: input.workspaceId,
+        threadId: input.threadId,
+        botId: input.botId,
+        type: "thread.message.created",
+        runId: input.runId,
+        payload: { messageId: message.id, role: "bot", blocks },
+      });
     }
     const lastEvent = await appendEventInTransaction(tx, {
       workspaceId: input.workspaceId,

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -423,7 +423,9 @@ export async function pauseRunForInput(
       runId: input.runId,
       payload: {},
     });
-    await tx.event.deleteMany({ where: { runId: input.runId, type: "thread.progress" } });
+    await tx.event.deleteMany({
+      where: { runId: input.runId, type: { in: ["thread.progress", "thread.reasoning"] } },
+    });
     return { threadId: waitingEvent.threadId, seq: waitingEvent.seq };
   });
 
@@ -578,7 +580,9 @@ export async function finalizeRun(
       runId: input.runId,
       payload: input.outcome === "completed" ? {} : { error: input.error },
     });
-    await tx.event.deleteMany({ where: { runId: input.runId, type: "thread.progress" } });
+    await tx.event.deleteMany({
+      where: { runId: input.runId, type: { in: ["thread.progress", "thread.reasoning"] } },
+    });
     await tx.bot.update({ where: { id: input.botId }, data: { updatedAt: now } });
     return { threadId: lastEvent.threadId, seq: lastEvent.seq };
   });

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -30,6 +30,8 @@ function mapBot(
     computer: { scope: string } | null;
     voiceId?: string | null;
     autoSpeak?: boolean;
+    modelProvider?: string | null;
+    modelId?: string | null;
   },
   preview = "",
   status = "idle",
@@ -59,6 +61,8 @@ function mapBot(
     updatedAt: bot.updatedAt.toISOString(),
     voiceId: bot.voiceId ?? null,
     autoSpeak: bot.autoSpeak ?? false,
+    modelProvider: bot.modelProvider ?? null,
+    modelId: bot.modelId ?? null,
   };
 }
 
@@ -185,6 +189,8 @@ export function createRepos(prisma: PrismaClient) {
         parentBotId?: string | null;
         computerMode?: ComputerMode;
         spawnKey?: string;
+        modelProvider?: string | null;
+        modelId?: string | null;
         initialMessage?: {
           role: "user" | "bot" | "system";
           blocks: MessageBlock[];
@@ -233,6 +239,8 @@ export function createRepos(prisma: PrismaClient) {
             parentBotId: input.parentBotId ?? null,
             computerId: teamComputer.id,
             spawnKey: input.spawnKey,
+            modelProvider: input.modelProvider ?? null,
+            modelId: input.modelId ?? null,
           },
         });
         const thread = await tx.thread.create({

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -27,6 +27,7 @@ const describeWithDatabase = hasDb ? describe : describe.skip;
 describeWithDatabase("API authorization and resource isolation", () => {
   let handles: AppHandles;
   let app: App;
+  let deploymentOwnerCookie: string;
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const dataDir = mkdtempSync(path.join(tmpdir(), "rakazo-authz-"));
 
@@ -41,6 +42,11 @@ describeWithDatabase("API authorization and resource isolation", () => {
       signupsEnabled: "true",
     });
     app = handles.app;
+    deploymentOwnerCookie = await signup(
+      app,
+      `deployment-owner-fixture-${stamp}@rakazo.test`,
+      "Deployment Owner Fixture",
+    );
   });
 
   afterAll(async () => {
@@ -521,7 +527,7 @@ describeWithDatabase("API authorization and resource isolation", () => {
   });
 
   it("lets a custom endpoint keep multiple labeled API keys", async () => {
-    const cookie = await signup(app, `model-keys-${stamp}@rakazo.test`, "Model Keys");
+    const cookie = deploymentOwnerCookie;
     const actor = await rpc<Actor>(app, cookie, "me");
     const connected = await rpc<ModelCredential>(app, cookie, "models/connect", {
       provider: "openai-compatible",
@@ -644,7 +650,7 @@ describeWithDatabase("API authorization and resource isolation", () => {
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : 0;
     try {
-      const cookie = await signup(app, `model-coverage-${stamp}@rakazo.test`, "Model Coverage");
+      const cookie = deploymentOwnerCookie;
       const connected = await rpc<ModelCredential>(app, cookie, "models/connect", {
         provider: "openai-compatible",
         apiKey: "gemini-key-xxxx-xxxx",
@@ -687,6 +693,152 @@ describeWithDatabase("API authorization and resource isolation", () => {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
       });
+    }
+  });
+
+  it("keeps concurrent key probes attached to the key that supplied them", async () => {
+    let releaseSlow = () => undefined;
+    let markSlowStarted = () => undefined;
+    const slowRelease = new Promise<void>((resolve) => {
+      releaseSlow = resolve;
+    });
+    const slowStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve;
+    });
+    const server = createServer(async (req, res) => {
+      const auth = String(req.headers.authorization ?? "");
+      const slow = auth.includes("slow-probe-key");
+      if (slow) {
+        markSlowStarted();
+        await slowRelease;
+      }
+      const id = slow ? "slow-model" : "fast-model";
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id }] }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    try {
+      const connected = await rpc<ModelCredential>(app, deploymentOwnerCookie, "models/connect", {
+        provider: "openai-compatible",
+        apiKey: "",
+        label: "Concurrent key router",
+        modelId: "slow-model",
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+      });
+      const slowRequest = rpc<ModelCredential>(app, deploymentOwnerCookie, "models/addKey", {
+        provider: connected.provider,
+        apiKey: "slow-probe-key-xxxx",
+        label: "Slow key",
+      });
+      await slowStarted;
+      await rpc<ModelCredential>(app, deploymentOwnerCookie, "models/addKey", {
+        provider: connected.provider,
+        apiKey: "fast-probe-key-xxxx",
+        label: "Fast key",
+      });
+      releaseSlow();
+      await slowRequest;
+
+      const listed = await rpc<ModelCredential[]>(app, deploymentOwnerCookie, "models/credentials");
+      const updated = listed.find((credential) => credential.provider === connected.provider)!;
+      expect(updated.keys.find((key) => key.label === "Slow key")?.availableModels).toEqual([
+        "slow-model",
+      ]);
+      expect(updated.keys.find((key) => key.label === "Fast key")?.availableModels).toEqual([
+        "fast-model",
+      ]);
+    } finally {
+      releaseSlow();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("blocks non-owner users from probing or saving private-network endpoints", async () => {
+    let requests = 0;
+    const server = createServer((_req, res) => {
+      requests += 1;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "private-model" }] }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const baseUrl = `http://127.0.0.1:${port}/v1`;
+    try {
+      const cookie = await signup(app, `private-probe-${stamp}@rakazo.test`, "Private Probe");
+      const probe = await raw(app, cookie, "models/probe", {
+        baseUrl,
+        apiKey: "fake-private-probe-key",
+      });
+      expect(probe.status).toBeGreaterThanOrEqual(400);
+      expect(await probe.text()).toMatch(/private.network|deployment.owner/i);
+
+      const connect = await raw(app, cookie, "models/connect", {
+        provider: "openai-compatible",
+        apiKey: "fake-private-connect-key",
+        label: "Private endpoint",
+        modelId: "private-model",
+        baseUrl,
+      });
+      expect(connect.status).toBeGreaterThanOrEqual(400);
+      expect(await connect.text()).toMatch(/private.network|deployment.owner/i);
+      expect(requests).toBe(0);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("does not let another user inspect or mutate endpoint keys", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "owner-model" }] }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    try {
+      const ownerCredential = await rpc<ModelCredential>(
+        app,
+        deploymentOwnerCookie,
+        "models/connect",
+        {
+          provider: "openai-compatible",
+          apiKey: "fake-owner-endpoint-key",
+          label: "Owner endpoint",
+          modelId: "owner-model",
+          baseUrl: `http://127.0.0.1:${port}/v1`,
+        },
+      );
+      const ownerKey = ownerCredential.keys[0]!;
+      const intruder = await signup(app, `model-key-intruder-${stamp}@rakazo.test`, "Intruder");
+      const secretCount = await handles.prisma.secret.count();
+
+      for (const [procedure, input] of [
+        ["models/addKey", { provider: ownerCredential.provider, apiKey: "fake-intruder-key" }],
+        ["models/removeKey", { provider: ownerCredential.provider, keyId: ownerKey.id }],
+        ["models/setActiveKey", { provider: ownerCredential.provider, keyId: ownerKey.id }],
+        ["models/refreshKeys", { provider: ownerCredential.provider }],
+      ] satisfies Array<[string, unknown]>) {
+        await expectDenied(app, intruder, procedure, input);
+      }
+
+      expect(
+        await handles.prisma.userModelCredentialKey.findUnique({ where: { id: ownerKey.id } }),
+      ).toMatchObject({ credentialId: ownerCredential.id, isActive: true });
+      expect(await handles.prisma.secret.count()).toBe(secretCount);
+      expect(await rpc<ModelCredential[]>(app, intruder, "models/credentials")).not.toContainEqual(
+        expect.objectContaining({ provider: ownerCredential.provider }),
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
     }
   });
 

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { appContract } from "@rakazo/contracts";
@@ -50,22 +51,29 @@ describeWithDatabase("API authorization and resource isolation", () => {
   it("rejects unauthenticated calls to every protected RPC family", async () => {
     const calls = exhaustiveProtectedCalls([
       ["me"],
+      ["bootstrap", {}],
       ["deployment/get"],
       ["deployment/update", { signupsEnabled: true }],
       ["models/list"],
       ["models/credentials"],
       ["models/connect", { provider: "test", apiKey: "not-a-real-key" }],
+      ["models/probe", { baseUrl: "http://127.0.0.1:9/v1" }],
       ["models/beginOAuth", { provider: "openai-codex" }],
       ["models/completeOAuth", { loginId: "missing-login" }],
       ["models/finishOAuth", { loginId: "missing-login" }],
       ["models/cancelOAuth", { loginId: "missing-login" }],
       ["models/setDefault", { provider: "test", modelId: "test/model" }],
+      ["models/addKey", { provider: "test", apiKey: "not-a-real-key" }],
+      ["models/removeKey", { provider: "test", keyId: "missing-key" }],
+      ["models/setActiveKey", { provider: "test", keyId: "missing-key" }],
+      ["models/refreshKeys", { provider: "test" }],
       ["bots/list"],
       ["bots/listArchived"],
       ["bots/get", { botId: "missing-bot" }],
       ["bots/create", botInput("Unauthenticated")],
       ["bots/duplicate", { botId: "missing-bot" }],
       ["bots/update", { botId: "missing-bot", name: "Nope" }],
+      ["bots/setComputer", { botId: "missing-bot", mode: "team" }],
       ["bots/archive", { botId: "missing-bot" }],
       ["bots/restore", { botId: "missing-bot" }],
       ["bots/remove", { botId: "missing-bot" }],
@@ -132,6 +140,15 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["connections/complete", { connectionId: "missing-connection" }],
       ["connections/revoke", { connectionId: "missing-connection" }],
       ["artifacts/list", { botId: "missing-bot" }],
+      [
+        "artifacts/create",
+        {
+          botId: "missing-bot",
+          name: "nope.txt",
+          mimeType: "text/plain",
+          contentBase64: "Tm9wZQ==",
+        },
+      ],
       ["usage/list"],
       ["usage/summary"],
       ["export/bot", { botId: "missing-bot" }],
@@ -494,6 +511,183 @@ describeWithDatabase("API authorization and resource isolation", () => {
     });
     expect(missing.status).toBeGreaterThanOrEqual(400);
     expect(await missing.text()).toMatch(/credential/i);
+
+    const addKeyDenied = await raw(app, cookie, "models/addKey", {
+      provider: "provider-a",
+      apiKey: "another-provider-a-key",
+      label: "Spare",
+    });
+    expect(addKeyDenied.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it("lets a custom endpoint keep multiple labeled API keys", async () => {
+    const cookie = await signup(app, `model-keys-${stamp}@rakazo.test`, "Model Keys");
+    const actor = await rpc<Actor>(app, cookie, "me");
+    const connected = await rpc<ModelCredential>(app, cookie, "models/connect", {
+      provider: "openai-compatible",
+      apiKey: "custom-endpoint-key-one-xxxx",
+      label: "Office vLLM",
+      modelId: "llama3.1",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    });
+    expect(connected.provider).toMatch(/^gateway:/);
+    expect(connected.hasKey).toBe(true);
+    expect(connected.keys).toHaveLength(1);
+    expect(connected.keys[0]).toMatchObject({ label: "API key", isActive: true });
+    expect(JSON.stringify(connected)).not.toContain("custom-endpoint-key");
+
+    const withSecond = await rpc<ModelCredential>(app, cookie, "models/addKey", {
+      provider: connected.provider,
+      apiKey: "custom-endpoint-key-two-xxxx",
+      label: "Pool key 2",
+    });
+    expect(withSecond.id).toBe(connected.id);
+    expect(withSecond.isDefault).toBe(true);
+    expect(withSecond.keys).toHaveLength(2);
+    const originalKey = withSecond.keys.find((key) => key.label === "API key");
+    const poolKey = withSecond.keys.find((key) => key.label === "Pool key 2");
+    expect(originalKey?.isActive).toBe(false);
+    expect(poolKey?.isActive).toBe(true);
+
+    const storedKeys = await handles.prisma.userModelCredentialKey.findMany({
+      where: { credentialId: connected.id },
+    });
+    expect(new Set(storedKeys.map((key) => key.secretId)).size).toBe(2);
+
+    const activated = await rpc<ModelCredential>(app, cookie, "models/setActiveKey", {
+      provider: connected.provider,
+      keyId: originalKey!.id,
+    });
+    expect(activated.keys.find((key) => key.id === originalKey?.id)?.isActive).toBe(true);
+    expect(activated.keys.find((key) => key.id === poolKey?.id)?.isActive).toBe(false);
+    const originalSecretId = storedKeys.find((key) => key.id === originalKey?.id)?.secretId;
+    expect(originalSecretId).toBeTruthy();
+    const afterSwitch = await handles.prisma.userModelCredential.findUniqueOrThrow({
+      where: { id: connected.id },
+    });
+    expect(afterSwitch.secretId).toBe(originalSecretId);
+
+    const removed = await rpc<ModelCredential>(app, cookie, "models/removeKey", {
+      provider: connected.provider,
+      keyId: originalKey!.id,
+    });
+    expect(removed.keys).toHaveLength(1);
+    expect(removed.keys[0]?.id).toBe(poolKey?.id);
+    expect(removed.keys[0]?.isActive).toBe(true);
+    expect(await handles.prisma.secret.findUnique({ where: { id: originalSecretId! } })).toBeNull();
+
+    const lastRemove = await raw(app, cookie, "models/removeKey", {
+      provider: connected.provider,
+      keyId: poolKey!.id,
+    });
+    expect(lastRemove.status).toBeGreaterThanOrEqual(400);
+
+    const renamed = await rpc<ModelCredential>(app, cookie, "models/connect", {
+      provider: connected.provider,
+      apiKey: "",
+      label: "Office vLLM renamed",
+      modelId: "llama3.1",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    });
+    expect(renamed.keys).toHaveLength(1);
+    expect(renamed.label).toBe("Office vLLM renamed");
+
+    const empty = await rpc<ModelCredential>(app, cookie, "models/connect", {
+      provider: "openai-compatible",
+      apiKey: "",
+      label: "Local Ollama",
+      modelId: "llama3.1",
+      baseUrl: "http://127.0.0.1:22434/v1",
+    });
+    expect(empty.provider).not.toBe(connected.provider);
+    expect(empty.hasKey).toBe(false);
+    expect(empty.keys).toEqual([]);
+    const secretsBeforeAdd = await handles.prisma.secret.count({
+      where: { userId: actor.userId, kind: "model" },
+    });
+    const added = await rpc<ModelCredential>(app, cookie, "models/addKey", {
+      provider: empty.provider,
+      apiKey: "ollama-optional-key-xxxx",
+      label: "Spare",
+    });
+    expect(added.keys).toHaveLength(1);
+    expect(added.keys[0]).toMatchObject({ label: "Spare", isActive: true });
+    expect(added.hasKey).toBe(true);
+    expect(
+      await handles.prisma.secret.count({ where: { userId: actor.userId, kind: "model" } }),
+    ).toBe(secretsBeforeAdd);
+
+    const listed = await rpc<ModelCredential[]>(app, cookie, "models/credentials");
+    expect(JSON.stringify(listed)).not.toContain("custom-endpoint-key");
+    expect(JSON.stringify(listed)).not.toContain("ollama-optional-key");
+  });
+
+  it("discovers which models each custom endpoint key can use", async () => {
+    const server = createServer((req, res) => {
+      if (!req.url?.endsWith("/models")) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      const auth = String(req.headers.authorization ?? "");
+      const ids = auth.includes("gemini-key")
+        ? ["gemini-2.5-pro", "gemini-2.5-flash"]
+        : auth.includes("openai-key")
+          ? ["gpt-4o", "gpt-4.1"]
+          : [];
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: ids.map((id) => ({ id })) }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    try {
+      const cookie = await signup(app, `model-coverage-${stamp}@rakazo.test`, "Model Coverage");
+      const connected = await rpc<ModelCredential>(app, cookie, "models/connect", {
+        provider: "openai-compatible",
+        apiKey: "gemini-key-xxxx-xxxx",
+        label: "Inference router",
+        modelId: "gemini-2.5-flash",
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+      });
+      expect(connected.keys).toHaveLength(1);
+      expect(connected.keys[0]).toMatchObject({
+        label: "Gemini",
+        availableModels: ["gemini-2.5-pro", "gemini-2.5-flash"],
+      });
+      expect(connected.availableModels).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
+
+      const withSecond = await rpc<ModelCredential>(app, cookie, "models/addKey", {
+        provider: connected.provider,
+        apiKey: "openai-key-xxxx-xxxx",
+      });
+      expect(withSecond.keys).toHaveLength(2);
+      const gemini = withSecond.keys.find((key) =>
+        key.availableModels?.includes("gemini-2.5-flash"),
+      );
+      const openai = withSecond.keys.find((key) => key.availableModels?.includes("gpt-4o"));
+      expect(gemini).toMatchObject({ label: "Gemini" });
+      expect(openai).toMatchObject({ label: "GPT" });
+      expect(withSecond.availableModels).toEqual(
+        expect.arrayContaining(["gemini-2.5-pro", "gemini-2.5-flash", "gpt-4o", "gpt-4.1"]),
+      );
+
+      const refreshed = await rpc<ModelCredential>(app, cookie, "models/refreshKeys", {
+        provider: connected.provider,
+      });
+      expect(refreshed.keys.find((key) => key.id === openai?.id)?.availableModels).toEqual([
+        "gpt-4o",
+        "gpt-4.1",
+      ]);
+      expect(JSON.stringify(refreshed)).not.toContain("gemini-key");
+      expect(JSON.stringify(refreshed)).not.toContain("openai-key");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("chooses the newest duplicate provider credential when selecting a default", async () => {
@@ -699,6 +893,14 @@ interface ModelCredential {
   label: string;
   hasKey: boolean;
   isDefault: boolean;
+  keys: Array<{
+    id: string;
+    label: string;
+    isActive: boolean;
+    createdAt: string;
+    availableModels?: string[];
+  }>;
+  availableModels?: string[];
 }
 
 interface Bot {

--- a/packages/testkit/src/executor-lifecycle.test.ts
+++ b/packages/testkit/src/executor-lifecycle.test.ts
@@ -139,6 +139,24 @@ describeIntegration("run executor lifecycle", () => {
       data: { runId: seeded.run.id, fence: 4, status: "running" },
     });
     const events = createThreadEvents(handles.prisma);
+    await events.append({
+      workspaceId: seeded.me.workspaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      runId: seeded.run.id,
+      type: "thread.progress",
+      payload: { text: "temporary" },
+    });
+    await events.append({
+      workspaceId: seeded.me.workspaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      runId: seeded.run.id,
+      type: "thread.reasoning",
+      payload: {
+        steps: [{ id: "status", kind: "status", title: "Working", status: "running" }],
+      },
+    });
     const input = {
       workspaceId: seeded.me.workspaceId,
       threadId: seeded.thread.id,
@@ -172,6 +190,14 @@ describeIntegration("run executor lifecycle", () => {
     expect(storedAttempt.status).toBe("completed");
     expect(task.status).toBe("completed");
     expect(messages).toHaveLength(1);
+    expect(
+      await handles.prisma.event.count({
+        where: {
+          runId: seeded.run.id,
+          type: { in: ["thread.progress", "thread.reasoning"] },
+        },
+      }),
+    ).toBe(0);
     expect(terminalEvents.map((event) => event.type)).toEqual([
       "thread.message.created",
       "run.completed",

--- a/packages/testkit/src/executor-lifecycle.test.ts
+++ b/packages/testkit/src/executor-lifecycle.test.ts
@@ -178,6 +178,66 @@ describeIntegration("run executor lifecycle", () => {
     ]);
   });
 
+  it("persists one visible error before the failed-run event under concurrent finalization", async () => {
+    const seeded = await seedRun("failed-terminal-fence", "exercise the fake gateway", {
+      status: "running",
+      leaseOwner: "failed-terminal-worker",
+      leaseFence: 5,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+    const attempt = await handles.prisma.attempt.create({
+      data: { runId: seeded.run.id, fence: 5, status: "running" },
+    });
+    const events = createThreadEvents(handles.prisma);
+    const input = {
+      workspaceId: seeded.me.workspaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      runId: seeded.run.id,
+      taskId: seeded.task.id,
+      attemptId: attempt.id,
+      leaseOwner: "failed-terminal-worker",
+      leaseFence: 5,
+      outcome: "failed" as const,
+      error: "Fake gateway unavailable",
+    };
+
+    const results = await Promise.all([events.finalizeRun(input), events.finalizeRun(input)]);
+
+    expect(results.sort()).toEqual([false, true]);
+    const [run, storedAttempt, task, messages, terminalEvents] = await Promise.all([
+      handles.prisma.run.findUniqueOrThrow({ where: { id: seeded.run.id } }),
+      handles.prisma.attempt.findUniqueOrThrow({ where: { id: attempt.id } }),
+      handles.prisma.task.findUniqueOrThrow({ where: { id: seeded.task.id } }),
+      handles.prisma.message.findMany({ where: { runId: seeded.run.id } }),
+      handles.prisma.event.findMany({
+        where: {
+          runId: seeded.run.id,
+          type: { in: ["thread.message.created", "run.failed"] },
+        },
+        orderBy: { seq: "asc" },
+      }),
+    ]);
+    expect(run).toMatchObject({
+      status: "failed",
+      error: "Fake gateway unavailable",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+    expect(storedAttempt).toMatchObject({
+      status: "failed",
+      error: "Fake gateway unavailable",
+    });
+    expect(task.status).toBe("failed");
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.blocks).toEqual([{ kind: "text", text: "Fake gateway unavailable" }]);
+    expect(terminalEvents.map((event) => event.type)).toEqual([
+      "thread.message.created",
+      "run.failed",
+    ]);
+  });
+
   it("rolls back every terminal write when the atomic commit fails", async () => {
     const seeded = await seedRun("terminal-rollback", "do not partially finish", {
       status: "running",


### PR DESCRIPTION
## Summary
- Missing `finish_reason` is a normal stop; empty streams retry; gateway errors persist instead of completing empty runs.
- Independent onto `elie222:main` for review. Landing order remains 1→13.

## Test plan
- [ ] `pi-runtime-stream-close` and openai-compatible error tests
- [ ] A failing custom endpoint shows its own error in chat
- [ ] Prefix is deployable with no new migrations

## Limitations
- Custom-gateway adapter and reasoning helpers that this slice also edits appear as additions because they are not on `main` yet (slices 1–2).
