### PR TITLE
Speed up chat: optimistic sends, working states, avatars, and autoscroll

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -499,7 +499,12 @@ export function createRouter(deps: RouterDeps) {
         await assertTeachingSendAllowed(deps.prisma, context.actor.workspaceId, bot.id);
         if (input.clientNonce) {
           const dup = await deps.prisma.run.findFirst({
-            where: { workspaceId: context.actor.workspaceId, clientNonce: input.clientNonce },
+            where: {
+              workspaceId: context.actor.workspaceId,
+              userId: context.actor.userId,
+              botId: bot.id,
+              clientNonce: input.clientNonce,
+            },
           });
           if (dup) return { taskId: dup.taskId, runId: dup.id, seq: 0 };
         }
@@ -514,17 +519,33 @@ export function createRouter(deps: RouterDeps) {
         // One transaction for message, run, and event: serialized against clearThread by the
         // thread-row lock, so a concurrent clear either sees the committed run and cancels it
         // or strictly precedes the whole send.
-        const sent = await deps.events.sendUserMessage({
-          workspaceId: context.actor.workspaceId,
-          threadId: bot.thread.id,
-          botId: bot.id,
-          userId: context.actor.userId,
-          blocks,
-          prompt,
-          trigger: "user",
-          clientNonce: input.clientNonce,
-          linkMessageToRun: true,
-        });
+        let sent: Awaited<ReturnType<typeof deps.events.sendUserMessage>>;
+        try {
+          sent = await deps.events.sendUserMessage({
+            workspaceId: context.actor.workspaceId,
+            threadId: bot.thread.id,
+            botId: bot.id,
+            userId: context.actor.userId,
+            blocks,
+            prompt,
+            trigger: "user",
+            clientNonce: input.clientNonce,
+            linkMessageToRun: true,
+          });
+        } catch (error) {
+          const dup = input.clientNonce
+            ? await deps.prisma.run.findFirst({
+                where: {
+                  workspaceId: context.actor.workspaceId,
+                  userId: context.actor.userId,
+                  botId: bot.id,
+                  clientNonce: input.clientNonce,
+                },
+              })
+            : null;
+          if (dup) return { taskId: dup.taskId, runId: dup.id, seq: 0 };
+          throw error;
+        }
         const runId = sent.runId!;
         await deps.prisma.run.updateMany({
           where: {

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -318,7 +318,10 @@ function BotRow({ bot, onLongPress }: { bot: MobileBot; onLongPress: () => void 
       accessibilityLabel={label}
       accessibilityHint="Long press to pin or move to a section"
       onPress={() =>
-        router.push({ pathname: "/thread", params: { botId: bot.id, name: bot.name } })
+        router.push({
+          pathname: "/thread",
+          params: { botId: bot.id, name: bot.name, color: bot.color },
+        })
       }
       onLongPress={onLongPress}
       style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -39,7 +39,10 @@ export default function NewBot() {
         notifyOnFinish: true,
         computerMode,
       });
-      router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
+      router.replace({
+        pathname: "/thread",
+        params: { botId: bot.id, name: bot.name, color: bot.color },
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not create bot");
     } finally {

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1,8 +1,24 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/native";
-import { abortableDelay, attachmentsForBot } from "@rakazo/core";
+import {
+  abortableDelay,
+  attachmentsForBot,
+  createPendingUserMessageId,
+  pendingUserMessageTextKey,
+  visibleReasoningSteps,
+} from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Alert, AppState, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Animated,
+  AppState,
+  Image,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 import { NativeSymbol } from "../components/native-symbol";
 import {
   applyMobileThreadEvent,
@@ -47,6 +63,7 @@ export default function Thread() {
     olderCursor: number | null;
   } | null>(null);
   const jumpScrollTarget = useRef<string | null>(null);
+  const enterState = useRef({ botId: "", seen: new Set<string>(), primed: false });
   const activeBotId = useRef(botId);
   activeBotId.current = botId;
   const [snap, setSnap] = useState<MobileSnapshot | null>(null);
@@ -56,7 +73,25 @@ export default function Thread() {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const [enteringIds, setEnteringIds] = useState<Set<string>>(() => new Set());
   const activePendingAttachments = attachmentsForBot(pendingAttachments, botId);
+  const botWorking = Boolean(
+    snap?.run && ["running", "queued", "leased"].includes(snap.run.status),
+  );
+  const hasLiveReasoning = (snap?.messages ?? []).some((message) =>
+    message.id.startsWith("reasoning:"),
+  );
+
+  useLayoutEffect(() => {
+    const nextBotId = botId ?? "";
+    const switchedBot = enterState.current.botId !== nextBotId;
+    const next = collectEnteringUserMessageIds(nextBotId, snap?.messages ?? [], enterState.current);
+    if (switchedBot) {
+      setEnteringIds(new Set());
+      return;
+    }
+    if (next.size > 0) setEnteringIds(next);
+  }, [botId, snap?.messages]);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -304,6 +339,20 @@ export default function Thread() {
     const attachments = attachmentsForBot(pendingAttachments, targetBotId);
     const text = draft.trim();
     if (!text && attachments.length === 0) return;
+    const pendingId = createPendingUserMessageId();
+    if (text) {
+      setDraft("");
+      setSnap((current) => {
+        if (!current) return current;
+        return {
+          ...current,
+          messages: [
+            ...current.messages,
+            { id: pendingId, role: "user", blocks: [{ kind: "text", text }] },
+          ],
+        };
+      });
+    }
     setSending(true);
     setError(null);
     try {
@@ -326,12 +375,20 @@ export default function Thread() {
         current.filter((attachment) => attachment.botId !== targetBotId),
       );
       if (activeBotId.current === targetBotId) {
-        setDraft("");
+        if (!text) setDraft("");
         setAttachmentNotice(null);
-        await refresh();
       }
     } catch (err) {
       if (activeBotId.current === targetBotId) {
+        setSnap((current) =>
+          current
+            ? {
+                ...current,
+                messages: current.messages.filter((message) => message.id !== pendingId),
+              }
+            : current,
+        );
+        if (text) setDraft(text);
         setError(err instanceof Error ? err.message : "Failed to send message");
       }
     } finally {
@@ -403,43 +460,45 @@ export default function Thread() {
           </Pressable>
         ) : null}
         {(snap?.messages ?? []).map((message) => (
-          <View
-            key={message.id}
-            onLayout={(event) => {
-              if (jumpScrollTarget.current !== message.id) return;
-              scroll.current?.scrollTo({
-                y: Math.max(0, event.nativeEvent.layout.y - 24),
-                animated: true,
-              });
-              jumpScrollTarget.current = null;
-            }}
-            style={{
-              marginTop: 12,
-              width: "100%",
-              flexDirection: "row",
-              justifyContent: message.role === "user" ? "flex-end" : "flex-start",
-            }}
-          >
-            <MessageBubble
-              botId={botId ?? ""}
-              message={message}
-              onOpenBot={(id, botName) =>
-                router.push({ pathname: "/thread", params: { botId: id, name: botName } })
-              }
-              onSpeak={
-                message.role === "bot"
-                  ? () =>
-                      void speakMessage(botId ?? "", message).catch((err) =>
-                        Alert.alert(
-                          "Could not speak",
-                          err instanceof Error ? err.message : "Try again.",
-                        ),
-                      )
-                  : undefined
-              }
-            />
-          </View>
+          <DropInMessage key={message.id} active={enteringIds.has(message.id)}>
+            <View
+              onLayout={(event) => {
+                if (jumpScrollTarget.current !== message.id) return;
+                scroll.current?.scrollTo({
+                  y: Math.max(0, event.nativeEvent.layout.y - 24),
+                  animated: true,
+                });
+                jumpScrollTarget.current = null;
+              }}
+              style={{
+                marginTop: 12,
+                width: "100%",
+                flexDirection: "row",
+                justifyContent: message.role === "user" ? "flex-end" : "flex-start",
+              }}
+            >
+              <MessageBubble
+                botId={botId ?? ""}
+                message={message}
+                onOpenBot={(id, botName) =>
+                  router.push({ pathname: "/thread", params: { botId: id, name: botName } })
+                }
+                onSpeak={
+                  message.role === "bot"
+                    ? () =>
+                        void speakMessage(botId ?? "", message).catch((err) =>
+                          Alert.alert(
+                            "Could not speak",
+                            err instanceof Error ? err.message : "Try again.",
+                          ),
+                        )
+                    : undefined
+                }
+              />
+            </View>
+          </DropInMessage>
         ))}
+        {botWorking && !hasLiveReasoning ? <BotWorkingStatus /> : null}
       </ScrollView>
       {attachmentNotice ? (
         <Text style={{ color: "#D6CFA0", marginTop: 12, fontSize: 13 }}>{attachmentNotice}</Text>
@@ -547,6 +606,108 @@ export default function Thread() {
   );
 }
 
+function collectEnteringUserMessageIds(
+  botId: string,
+  messages: MobileMessage[],
+  state: { botId: string; seen: Set<string>; primed: boolean },
+) {
+  if (state.botId !== botId) {
+    state.botId = botId;
+    state.seen = new Set(messages.map((message) => message.id));
+    state.primed = messages.length > 0;
+    return new Set<string>();
+  }
+  if (!state.primed) {
+    if (!messages.length) return new Set<string>();
+    for (const message of messages) state.seen.add(message.id);
+    state.primed = true;
+    return new Set<string>();
+  }
+  const recent = new Set(messages.slice(-4).map((message) => message.id));
+  const entering = new Set<string>();
+  for (const message of messages) {
+    const text = userMessagePlainText(message);
+    const pendingKey = pendingUserMessageTextKey(text);
+    if (!state.seen.has(message.id) && message.role === "user" && recent.has(message.id)) {
+      const replacingPending = !message.id.startsWith("pending:") && state.seen.has(pendingKey);
+      if (!replacingPending) entering.add(message.id);
+    }
+    state.seen.add(message.id);
+    if (message.role === "user") {
+      if (message.id.startsWith("pending:")) state.seen.add(pendingKey);
+      else state.seen.delete(pendingKey);
+    }
+  }
+  return entering;
+}
+
+function userMessagePlainText(message: MobileMessage): string {
+  return message.blocks
+    .flatMap((block) => (block.kind === "text" ? [block.text ?? ""] : []))
+    .join("\n");
+}
+
+function DropInMessage({ active, children }: { active: boolean; children: ReactNode }) {
+  const progress = useRef(new Animated.Value(active ? 0 : 1)).current;
+  useEffect(() => {
+    if (!active) return;
+    progress.setValue(0);
+    Animated.spring(progress, {
+      toValue: 1,
+      friction: 6.4,
+      tension: 148,
+      useNativeDriver: true,
+    }).start();
+  }, [active, progress]);
+  if (!active) return <>{children}</>;
+  return (
+    <Animated.View
+      style={{
+        opacity: progress,
+        transform: [
+          {
+            translateY: progress.interpolate({ inputRange: [0, 1], outputRange: [-14, 0] }),
+          },
+          {
+            scale: progress.interpolate({ inputRange: [0, 1], outputRange: [0.96, 1] }),
+          },
+        ],
+      }}
+    >
+      {children}
+    </Animated.View>
+  );
+}
+
+function WorkingShimmerText({ text }: { text: string }) {
+  const shine = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.timing(shine, { toValue: 1, duration: 980, useNativeDriver: true }),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [shine]);
+  const opacity = shine.interpolate({
+    inputRange: [0, 0.5, 1],
+    outputRange: [0.42, 1, 0.42],
+  });
+  return (
+    <Animated.Text style={{ color: "#E8E8EC", fontSize: 15, fontWeight: "600", opacity }}>
+      {text}
+    </Animated.Text>
+  );
+}
+
+function BotWorkingStatus() {
+  return (
+    <View style={{ flexDirection: "row", alignItems: "center", gap: 6, marginTop: 8 }}>
+      <NativeSymbol ios="chevron.right" android="chevron-forward" size={14} color="#8E8EA0" />
+      <WorkingShimmerText text="Thinking" />
+    </View>
+  );
+}
+
 async function speakMessage(botId: string, message: MobileMessage) {
   const text = blockText(message);
   if (!text.trim()) return;
@@ -558,6 +719,108 @@ async function speakMessage(botId: string, message: MobileMessage) {
   for (const utterance of prepared.utterances) {
     await playMpeg(await speakUtterance(utterance, { botId }));
   }
+}
+
+function ReasoningCard({
+  steps,
+}: {
+  steps: Array<{
+    id?: string;
+    kind?: "status" | "think" | "tool";
+    title?: string;
+    detail?: string;
+    status?: "running" | "done";
+  }>;
+}) {
+  const running = steps.some((step) => step.status === "running");
+  const [open, setOpen] = useState(running);
+  const rotation = useRef(new Animated.Value(running ? 1 : 0)).current;
+  const visible = visibleReasoningSteps(
+    steps.flatMap((step, index) => {
+      if (step.kind !== "status" && step.kind !== "think" && step.kind !== "tool") return [];
+      if (step.status !== "running" && step.status !== "done") return [];
+      return [
+        {
+          id: step.id || String(index),
+          kind: step.kind,
+          title: step.title ?? "",
+          detail: step.detail,
+          status: step.status,
+        },
+      ];
+    }),
+  );
+  useEffect(() => {
+    setOpen(running);
+  }, [running]);
+  useEffect(() => {
+    Animated.timing(rotation, {
+      toValue: open ? 1 : 0,
+      duration: 180,
+      useNativeDriver: true,
+    }).start();
+  }, [open, rotation]);
+  return (
+    <View>
+      <Pressable
+        onPress={() => setOpen((current) => !current)}
+        style={{ flexDirection: "row", alignItems: "center", gap: 6, paddingVertical: 2 }}
+      >
+        <Animated.View
+          style={{
+            transform: [
+              {
+                rotate: rotation.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: ["0deg", "90deg"],
+                }),
+              },
+            ],
+          }}
+        >
+          <NativeSymbol ios="chevron.right" android="chevron-forward" size={14} color="#8E8EA0" />
+        </Animated.View>
+        {running ? (
+          <WorkingShimmerText text="Thinking" />
+        ) : (
+          <Text style={{ color: "#B4B4B8", fontSize: 15, fontWeight: "600" }}>Thought</Text>
+        )}
+      </Pressable>
+      {open && visible.length ? (
+        <View
+          style={{
+            marginLeft: 7,
+            marginTop: 8,
+            borderLeftWidth: 1,
+            borderLeftColor: "#3A3A40",
+            paddingLeft: 14,
+            gap: 10,
+          }}
+        >
+          {visible.map((step) => (
+            <View key={step.id}>
+              {step.kind === "tool" || !step.detail ? (
+                <Text
+                  style={{
+                    color: step.status === "running" ? "#D0D0D4" : "#8E8EA0",
+                    fontSize: 14,
+                    lineHeight: 21,
+                  }}
+                >
+                  {step.title}
+                </Text>
+              ) : null}
+              {step.detail ? (
+                <Text style={{ color: "#8E8EA0", fontSize: 14, lineHeight: 21 }}>
+                  {step.detail}
+                </Text>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
 }
 
 function MessageBubble({

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1,4 +1,5 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/native";
+import type { ReasoningStep } from "@rakazo/contracts";
 import {
   abortableDelay,
   attachmentsForBot,
@@ -19,6 +20,7 @@ import {
   TextInput,
   View,
 } from "react-native";
+import { BotAvatar } from "../components/bot-avatar";
 import { NativeSymbol } from "../components/native-symbol";
 import {
   applyMobileThreadEvent,
@@ -39,17 +41,29 @@ import {
   pickFromLibrary,
   takePhoto,
 } from "../lib/pick-attachments";
+import { useReducedMotion } from "../lib/use-reduced-motion";
 import { playMpeg, speakUtterance } from "../lib/voice";
 
 type PendingAttachment = PickedAttachment & { botId: string };
 
+type PendingSendAttempt = {
+  botId: string;
+  text: string;
+  attachmentIds: string[];
+  clientNonce: string;
+  artifactIds: Map<string, string>;
+};
+
+const FALLBACK_BOT_COLOR = "#9B5CF6";
+
 export default function Thread() {
   const navigation = useNavigation();
   const router = useRouter();
-  const { botId, name, messageId } = useLocalSearchParams<{
+  const { botId, name, messageId, color } = useLocalSearchParams<{
     botId?: string;
     name?: string;
     messageId?: string;
+    color?: string;
   }>();
   const scroll = useRef<ScrollView>(null);
   const loadingOlderContent = useRef(false);
@@ -64,6 +78,7 @@ export default function Thread() {
   } | null>(null);
   const jumpScrollTarget = useRef<string | null>(null);
   const enterState = useRef({ botId: "", seen: new Set<string>(), primed: false });
+  const retrySend = useRef<PendingSendAttempt | null>(null);
   const activeBotId = useRef(botId);
   activeBotId.current = botId;
   const [snap, setSnap] = useState<MobileSnapshot | null>(null);
@@ -71,12 +86,15 @@ export default function Thread() {
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
+  const [sendingBotId, setSendingBotId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [enteringIds, setEnteringIds] = useState<Set<string>>(() => new Set());
   const activePendingAttachments = attachmentsForBot(pendingAttachments, botId);
   const botWorking = Boolean(
-    snap?.run && ["running", "queued", "leased"].includes(snap.run.status),
+    (snap?.run && ["running", "queued", "leased"].includes(snap.run.status)) ||
+      sendingBotId === botId ||
+      snap?.messages.some((message) => message.id.startsWith("pending:")),
   );
   const hasLiveReasoning = (snap?.messages ?? []).some((message) =>
     message.id.startsWith("reasoning:"),
@@ -96,13 +114,21 @@ export default function Thread() {
   useLayoutEffect(() => {
     navigation.setOptions({
       title: name || "Thread",
+      headerTitle: () => (
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
+          <BotAvatar color={color || FALLBACK_BOT_COLOR} size={26} thinking={botWorking} />
+          <Text style={{ color: "#ECECEE", fontSize: 17, fontWeight: "600" }} numberOfLines={1}>
+            {name || "Thread"}
+          </Text>
+        </View>
+      ),
       headerRight: () => (
         <Pressable accessibilityLabel="Bot actions" hitSlop={8} onPress={showBotActions}>
           <NativeSymbol ios="ellipsis" android="ellipsis-horizontal" size={21} color="#ECECEE" />
         </Pressable>
       ),
     });
-  }, [botId, name, navigation]);
+  }, [botId, botWorking, color, name, navigation]);
 
   function leaveBot() {
     router.dismissAll();
@@ -299,7 +325,11 @@ export default function Thread() {
               if (event.type === "thread.message.created" && event.payload?.role === "bot") {
                 markReadIfVisible();
               }
-              if (event.type === "run.completed") {
+              if (
+                event.type === "run.completed" ||
+                event.type === "run.failed" ||
+                event.type === "run.cancelled"
+              ) {
                 void refresh().catch(() => undefined);
               }
             },
@@ -339,7 +369,23 @@ export default function Thread() {
     const attachments = attachmentsForBot(pendingAttachments, targetBotId);
     const text = draft.trim();
     if (!text && attachments.length === 0) return;
-    const pendingId = createPendingUserMessageId();
+    const attachmentIds = attachments.map((attachment) => attachment.id);
+    const previousAttempt = retrySend.current;
+    const attempt =
+      previousAttempt &&
+      previousAttempt.botId === targetBotId &&
+      previousAttempt.text === text &&
+      sameStringList(previousAttempt.attachmentIds, attachmentIds)
+        ? previousAttempt
+        : {
+            botId: targetBotId,
+            text,
+            attachmentIds,
+            clientNonce: createPendingUserMessageId(),
+            artifactIds: new Map<string, string>(),
+          };
+    retrySend.current = attempt;
+    const pendingId = attempt.clientNonce;
     if (text) {
       setDraft("");
       setSnap((current) => {
@@ -354,23 +400,33 @@ export default function Thread() {
       });
     }
     setSending(true);
+    setSendingBotId(targetBotId);
     setError(null);
     try {
       const artifactIds: string[] = [];
       for (const pending of attachments) {
+        const existingArtifactId = attempt.artifactIds.get(pending.id);
+        if (existingArtifactId) {
+          artifactIds.push(existingArtifactId);
+          continue;
+        }
         const artifact = await rpc<{ id: string }>("artifacts/create", {
           botId: targetBotId,
           name: pending.name,
           mimeType: pending.mimeType,
           contentBase64: pending.contentBase64,
         });
+        attempt.artifactIds.set(pending.id, artifact.id);
         artifactIds.push(artifact.id);
       }
       await rpc("threads/send", {
         botId: targetBotId,
         text: text || undefined,
         artifactIds: artifactIds.length ? artifactIds : undefined,
+        clientNonce: attempt.clientNonce,
       });
+      if (activeBotId.current === targetBotId) await refresh();
+      if (retrySend.current === attempt) retrySend.current = null;
       setPendingAttachments((current) =>
         current.filter((attachment) => attachment.botId !== targetBotId),
       );
@@ -393,6 +449,7 @@ export default function Thread() {
       }
     } finally {
       setSending(false);
+      setSendingBotId((current) => (current === targetBotId ? null : current));
     }
   }
 
@@ -649,8 +706,12 @@ function userMessagePlainText(message: MobileMessage): string {
 
 function DropInMessage({ active, children }: { active: boolean; children: ReactNode }) {
   const progress = useRef(new Animated.Value(active ? 0 : 1)).current;
+  const reducedMotion = useReducedMotion();
   useEffect(() => {
-    if (!active) return;
+    if (!active || reducedMotion) {
+      progress.setValue(1);
+      return;
+    }
     progress.setValue(0);
     Animated.spring(progress, {
       toValue: 1,
@@ -658,8 +719,8 @@ function DropInMessage({ active, children }: { active: boolean; children: ReactN
       tension: 148,
       useNativeDriver: true,
     }).start();
-  }, [active, progress]);
-  if (!active) return <>{children}</>;
+  }, [active, progress, reducedMotion]);
+  if (!active || reducedMotion) return <>{children}</>;
   return (
     <Animated.View
       style={{
@@ -681,13 +742,18 @@ function DropInMessage({ active, children }: { active: boolean; children: ReactN
 
 function WorkingShimmerText({ text }: { text: string }) {
   const shine = useRef(new Animated.Value(0)).current;
+  const reducedMotion = useReducedMotion();
   useEffect(() => {
+    if (reducedMotion) return;
     const loop = Animated.loop(
       Animated.timing(shine, { toValue: 1, duration: 980, useNativeDriver: true }),
     );
     loop.start();
     return () => loop.stop();
-  }, [shine]);
+  }, [reducedMotion, shine]);
+  if (reducedMotion) {
+    return <Text style={{ color: "#A8A8AD", fontSize: 15, fontWeight: "600" }}>{text}</Text>;
+  }
   const opacity = shine.interpolate({
     inputRange: [0, 0.5, 1],
     outputRange: [0.42, 1, 0.42],
@@ -701,7 +767,12 @@ function WorkingShimmerText({ text }: { text: string }) {
 
 function BotWorkingStatus() {
   return (
-    <View style={{ flexDirection: "row", alignItems: "center", gap: 6, marginTop: 8 }}>
+    <View
+      accessible
+      accessibilityLabel="Bot is thinking"
+      accessibilityLiveRegion="polite"
+      style={{ flexDirection: "row", alignItems: "center", gap: 6, marginTop: 8 }}
+    >
       <NativeSymbol ios="chevron.right" android="chevron-forward" size={14} color="#8E8EA0" />
       <WorkingShimmerText text="Thinking" />
     </View>
@@ -721,48 +792,32 @@ async function speakMessage(botId: string, message: MobileMessage) {
   }
 }
 
-function ReasoningCard({
-  steps,
-}: {
-  steps: Array<{
-    id?: string;
-    kind?: "status" | "think" | "tool";
-    title?: string;
-    detail?: string;
-    status?: "running" | "done";
-  }>;
-}) {
+function ReasoningCard({ steps }: { steps: ReasoningStep[] }) {
   const running = steps.some((step) => step.status === "running");
   const [open, setOpen] = useState(running);
   const rotation = useRef(new Animated.Value(running ? 1 : 0)).current;
-  const visible = visibleReasoningSteps(
-    steps.flatMap((step, index) => {
-      if (step.kind !== "status" && step.kind !== "think" && step.kind !== "tool") return [];
-      if (step.status !== "running" && step.status !== "done") return [];
-      return [
-        {
-          id: step.id || String(index),
-          kind: step.kind,
-          title: step.title ?? "",
-          detail: step.detail,
-          status: step.status,
-        },
-      ];
-    }),
-  );
+  const reducedMotion = useReducedMotion();
+  const visible = visibleReasoningSteps(steps);
   useEffect(() => {
     setOpen(running);
   }, [running]);
   useEffect(() => {
+    if (reducedMotion) {
+      rotation.setValue(open ? 1 : 0);
+      return;
+    }
     Animated.timing(rotation, {
       toValue: open ? 1 : 0,
       duration: 180,
       useNativeDriver: true,
     }).start();
-  }, [open, rotation]);
+  }, [open, reducedMotion, rotation]);
   return (
     <View>
       <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={running ? "Thinking details" : "Thought details"}
+        accessibilityState={{ expanded: open }}
         onPress={() => setOpen((current) => !current)}
         style={{ flexDirection: "row", alignItems: "center", gap: 6, paddingVertical: 2 }}
       >
@@ -834,9 +889,38 @@ function MessageBubble({
   onOpenBot: (botId: string, name: string) => void;
   onSpeak?: () => void;
 }) {
+  const reasoning = message.blocks.find((block) => block.kind === "reasoning");
   const special = message.blocks.find(
     (block) => block.kind === "subagent" || block.kind === "child_bot",
   );
+  if (reasoning?.steps?.length && !special) {
+    const textBlocks = message.blocks.filter(
+      (block) => (block.kind === "text" || block.kind === "progress") && block.text,
+    );
+    return (
+      <View style={{ gap: 8, maxWidth: "90%" }}>
+        <ReasoningCard steps={reasoning.steps} />
+        {textBlocks.length ? (
+          <View style={{ backgroundColor: "#1A1A1D", padding: 12, borderRadius: 20 }}>
+            <ChatMarkdown streaming={message.id.startsWith("progress:")}>
+              {textBlocks.map((block) => block.text).join("\n")}
+            </ChatMarkdown>
+            {onSpeak ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Speak this reply"
+                onPress={onSpeak}
+                hitSlop={8}
+                style={{ marginTop: 8 }}
+              >
+                <Text style={{ color: "#85858A", fontSize: 13 }}>Speak</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        ) : null}
+      </View>
+    );
+  }
   if (special?.kind === "subagent") {
     const running = special.status === "running";
     const failed = special.status === "failed";
@@ -1022,7 +1106,13 @@ function MessageBubble({
             {blockText(message)}
           </ChatMarkdown>
           {onSpeak ? (
-            <Pressable onPress={onSpeak} hitSlop={8} style={{ marginTop: 8 }}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Speak this reply"
+              onPress={onSpeak}
+              hitSlop={8}
+              style={{ marginTop: 8 }}
+            >
               <Text style={{ color: "#85858A", fontSize: 13 }}>Speak</Text>
             </Pressable>
           ) : null}
@@ -1030,4 +1120,8 @@ function MessageBubble({
       )}
     </View>
   );
+}
+
+function sameStringList(first: readonly string[], second: readonly string[]): boolean {
+  return first.length === second.length && first.every((value, index) => value === second[index]);
 }

--- a/apps/mobile/components/bot-avatar.tsx
+++ b/apps/mobile/components/bot-avatar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { Animated, View } from "react-native";
+import { useReducedMotion } from "../lib/use-reduced-motion";
 
 export function BotAvatar({
   color,
@@ -16,9 +17,10 @@ export function BotAvatar({
   const gap = Math.max(4, Math.round(size * 0.13));
   const bob = useRef(new Animated.Value(0)).current;
   const blink = useRef(new Animated.Value(1)).current;
+  const reducedMotion = useReducedMotion();
 
   useEffect(() => {
-    if (!thinking) {
+    if (!thinking || reducedMotion) {
       bob.setValue(0);
       blink.setValue(1);
       return;
@@ -38,10 +40,12 @@ export function BotAvatar({
     );
     motion.start();
     return () => motion.stop();
-  }, [thinking, bob, blink]);
+  }, [thinking, reducedMotion, bob, blink]);
 
   return (
     <Animated.View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
       style={{
         width: size,
         height: size,

--- a/apps/mobile/components/bot-avatar.tsx
+++ b/apps/mobile/components/bot-avatar.tsx
@@ -1,12 +1,47 @@
-import { View } from "react-native";
+import { useEffect, useRef } from "react";
+import { Animated, View } from "react-native";
 
-export function BotAvatar({ color, size = 54 }: { color: string; size?: number }) {
+export function BotAvatar({
+  color,
+  size = 54,
+  thinking = false,
+}: {
+  color: string;
+  size?: number;
+  thinking?: boolean;
+}) {
   const visorW = Math.round(size * 0.68);
   const visorH = Math.round(size * 0.4);
   const dot = Math.max(3, Math.round(size * 0.1));
   const gap = Math.max(4, Math.round(size * 0.13));
+  const bob = useRef(new Animated.Value(0)).current;
+  const blink = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (!thinking) {
+      bob.setValue(0);
+      blink.setValue(1);
+      return;
+    }
+    const motion = Animated.loop(
+      Animated.parallel([
+        Animated.sequence([
+          Animated.timing(bob, { toValue: 1, duration: 380, useNativeDriver: true }),
+          Animated.timing(bob, { toValue: 0, duration: 380, useNativeDriver: true }),
+        ]),
+        Animated.sequence([
+          Animated.delay(900),
+          Animated.timing(blink, { toValue: 0.2, duration: 90, useNativeDriver: true }),
+          Animated.timing(blink, { toValue: 1, duration: 90, useNativeDriver: true }),
+        ]),
+      ]),
+    );
+    motion.start();
+    return () => motion.stop();
+  }, [thinking, bob, blink]);
+
   return (
-    <View
+    <Animated.View
       style={{
         width: size,
         height: size,
@@ -14,6 +49,11 @@ export function BotAvatar({ color, size = 54 }: { color: string; size?: number }
         backgroundColor: color,
         alignItems: "center",
         justifyContent: "center",
+        transform: [
+          {
+            translateY: bob.interpolate({ inputRange: [0, 1], outputRange: [0, -4] }),
+          },
+        ],
       }}
     >
       <View
@@ -28,9 +68,27 @@ export function BotAvatar({ color, size = 54 }: { color: string; size?: number }
           gap,
         }}
       >
-        <View style={{ width: dot, height: dot, borderRadius: dot / 2, backgroundColor: "#fff" }} />
-        <View style={{ width: dot, height: dot, borderRadius: dot / 2, backgroundColor: "#fff" }} />
+        <Animated.View
+          style={{
+            width: dot,
+            height: dot,
+            borderRadius: dot / 2,
+            backgroundColor: "#fff",
+            opacity: blink,
+            transform: [{ scaleY: blink }],
+          }}
+        />
+        <Animated.View
+          style={{
+            width: dot,
+            height: dot,
+            borderRadius: dot / 2,
+            backgroundColor: "#fff",
+            opacity: blink,
+            transform: [{ scaleY: blink }],
+          }}
+        />
       </View>
-    </View>
+    </Animated.View>
   );
 }

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -241,6 +241,27 @@ describe("mobile thread event reduction", () => {
     expect(next?.messages[1]?.blocks).toEqual([completed]);
   });
 
+  it("reconciles only the optimistic message named by the durable client nonce", () => {
+    const initial = snapshot([
+      mobileMessage("pending:first", [{ kind: "text", text: "first" }]),
+      mobileMessage("pending:second", [{ kind: "text", text: "second" }]),
+      mobileMessage("progress:run-1", [{ kind: "progress", text: "draft" }]),
+    ]);
+
+    const next = applyMobileThreadEvent(initial, {
+      type: "thread.message.created",
+      seq: 9,
+      payload: {
+        messageId: "message-first",
+        role: "user",
+        blocks: [{ kind: "text", text: "first" }],
+        clientNonce: "pending:first",
+      },
+    });
+
+    expect(next?.messages.map((item) => item.id)).toEqual(["pending:second", "message-first"]);
+  });
+
   it("clears loaded history and active state when another client clears the thread", () => {
     const initial = snapshot([mobileMessage("message-1", [{ kind: "text", text: "old" }])], 1);
     initial.run = { status: "running" };

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -5,12 +5,14 @@ import type {
   Me,
   ModelCatalogEntry,
   ModelCredential,
+  ReasoningStep,
 } from "@rakazo/contracts";
 import {
   mergeThreadHistory,
   prependThreadHistoryPage,
   progressMessageId,
   progressMessageText,
+  shouldReplaceTransientMessageId,
   type ThreadHistory,
 } from "@rakazo/core";
 import * as SecureStore from "expo-secure-store";
@@ -187,6 +189,7 @@ export type MobileMessage = {
     artifactId?: string;
     mimeType?: string;
     size?: number;
+    steps?: ReasoningStep[];
   }>;
 };
 
@@ -358,13 +361,15 @@ export function applyMobileThreadEvent(
       role: (event.payload?.role as MobileMessage["role"]) ?? "bot",
       blocks: (event.payload?.blocks as MobileMessage["blocks"]) ?? [],
     };
+    const clientNonce =
+      typeof event.payload?.clientNonce === "string" ? event.payload.clientNonce : undefined;
     return {
       ...prev,
       messages: [
         ...prev.messages.filter(
           (message) =>
             message.id !== next.id &&
-            !message.id.startsWith("progress:") &&
+            !shouldReplaceTransientMessageId(message.id, clientNonce) &&
             !(
               message.id.startsWith("subagent:") &&
               next.blocks.some(

--- a/apps/mobile/lib/use-reduced-motion.ts
+++ b/apps/mobile/lib/use-reduced-motion.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { AccessibilityInfo } from "react-native";
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
+      if (active) setReduced(enabled);
+    });
+    const subscription = AccessibilityInfo.addEventListener("reduceMotionChanged", setReduced);
+    return () => {
+      active = false;
+      subscription.remove();
+    };
+  }, []);
+
+  return reduced;
+}

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -162,6 +162,30 @@ describe("thread event reduction", () => {
     expect(next?.messages[1]?.blocks).toEqual([completedBlock]);
   });
 
+  it("reconciles only the optimistic message named by the durable client nonce", () => {
+    const initial = snapshot([
+      message("pending:first", [{ kind: "text", text: "first" }]),
+      message("pending:second", [{ kind: "text", text: "second" }]),
+      message("progress:run-1", [{ kind: "progress", text: "draft" }]),
+    ]);
+
+    const next = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.message.created",
+        seq: 9,
+        payload: {
+          messageId: "message-first",
+          role: "user",
+          blocks: [{ kind: "text", text: "first" }],
+          clientNonce: "pending:first",
+        },
+      }),
+    );
+
+    expect(next?.messages.map((item) => item.id)).toEqual(["pending:second", "message-first"]);
+  });
+
   it("clears durable and transient history when another client clears the thread", () => {
     const initial = snapshot(
       [

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -10,6 +10,7 @@ import {
   prependThreadHistoryPage,
   progressMessageId,
   progressMessageText,
+  shouldReplaceTransientMessageId,
   subagentBlockFromPayload,
 } from "@rakazo/core";
 
@@ -113,10 +114,12 @@ export function reduceThreadSnapshot(
     const replacedSubagentIds = new Set(
       blocks.filter((block) => block.kind === "subagent").map((block) => block.agentId),
     );
+    const clientNonce =
+      typeof event.payload.clientNonce === "string" ? event.payload.clientNonce : undefined;
     const without = prev.messages.filter(
       (message) =>
         message.id !== next.id &&
-        !message.id.startsWith("progress:") &&
+        !shouldReplaceTransientMessageId(message.id, clientNonce) &&
         !replacedSubagent(message, replacedSubagentIds),
     );
     return { ...prev, cursor: event.seq, messages: [...without, next] };

--- a/apps/web/src/pages/CallView.tsx
+++ b/apps/web/src/pages/CallView.tsx
@@ -20,7 +20,7 @@ export function CallView({
   botName: string;
   transcribe: boolean;
   snapshot: ThreadSnapshot | null;
-  onSend: (text: string) => Promise<void>;
+  onSend: (text: string) => Promise<boolean>;
   onFollowUp: (text: string) => Promise<void>;
   onAnswer: (message: ThreadMessage, text: string) => Promise<void>;
   onClose: () => void;
@@ -88,7 +88,7 @@ export function CallView({
       } else if (current?.run && ["running", "queued", "leased"].includes(current.run.status)) {
         await onFollowUp(text);
       } else {
-        await onSend(text);
+        if (!(await onSend(text))) throw new Error("Could not send that");
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not send that");

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -22,19 +22,23 @@ import {
 import {
   abortableDelay,
   attachmentsForBot,
+  createPendingUserMessageId,
   cronFromPreset,
   defaultCronPreset,
   formatCron,
   groupBotsForSidebar,
   inferAttachmentMimeType,
   isActive,
+  pendingUserMessageTextKey,
   presetFromCron,
   speechFromBlocks,
+  visibleReasoningSteps,
 } from "@rakazo/core";
 import { BotAvatar, Button } from "@rakazo/ui-web";
 import {
   ArrowUp,
   ChevronLeft,
+  ChevronRight,
   Cpu,
   Gauge,
   LogOut,
@@ -186,7 +190,6 @@ export function ShellPage() {
   const bootstrappedThread = useRef<ThreadSnapshot | null>(null);
   const expandedHistoryThread = useRef<string | null>(null);
   const historyEpoch = useRef(0);
-  const initiallyScrolledThread = useRef<string | null>(null);
   const messageScroll = useRef<HTMLDivElement>(null);
   const pinnedAroundRef = useRef<{
     botId: string;
@@ -202,6 +205,9 @@ export function ShellPage() {
   const autoSpokenBotId = useRef<string | null>(null);
 
   const active = bots.find((b) => b.id === botId) ?? bots[0];
+  const botWorking = Boolean(
+    snapshot?.run && ["running", "queued", "leased"].includes(snapshot.run.status),
+  );
   const activePendingAttachments = useMemo(
     () => attachmentsForBot(pendingAttachments, active?.id),
     [active?.id, pendingAttachments],
@@ -281,10 +287,6 @@ export function ShellPage() {
   }
 
   async function refreshThread(id: string) {
-    const scrollElement = messageScroll.current;
-    const stickToEnd =
-      !scrollElement ||
-      scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight < 80;
     markOnce("rk:renderer:thread-request-start");
     const pin = pinnedAroundRef.current;
     const keepPin = pin?.botId === id;
@@ -315,12 +317,6 @@ export function ShellPage() {
     setRoutinesBotId(id);
     setTaughtSkills(skills);
     setTaughtSkillsBotId(id);
-    if (!keepPin && stickToEnd) {
-      window.requestAnimationFrame(() => {
-        const element = messageScroll.current;
-        if (element) element.scrollTop = element.scrollHeight;
-      });
-    }
     return snap;
   }
 
@@ -679,16 +675,6 @@ export function ShellPage() {
     }
   }, [active, initialBotsLoaded, shellReady, snapshot?.botId]);
 
-  useLayoutEffect(() => {
-    if (!active || snapshot?.botId !== active.id) return;
-    if (initiallyScrolledThread.current === snapshot.threadId) return;
-    if (pinnedAroundRef.current?.botId === active.id) return;
-    const element = messageScroll.current;
-    if (!element) return;
-    element.scrollTop = element.scrollHeight;
-    initiallyScrolledThread.current = snapshot.threadId;
-  }, [active, snapshot?.botId, snapshot?.threadId]);
-
   const openBot = useCallback((id: string) => navigate(`/app/${id}`), [navigate]);
   const loadOlder = useCallback(() => loadOlderMessagesRef.current(), []);
   const answerMessage = useCallback(async (message: ThreadMessage, text: string) => {
@@ -747,6 +733,27 @@ export function ShellPage() {
       const attachments = attachmentsForBot(pendingAttachments, id);
       const trimmed = text.trim();
       if (!trimmed && attachments.length === 0) return;
+      const pendingId = createPendingUserMessageId();
+      pinnedAroundRef.current = null;
+      if (trimmed) {
+        setSnapshot((current) => {
+          if (!current || current.botId !== id) return current;
+          return {
+            ...current,
+            messages: [
+              ...current.messages.filter((message) => message.id !== pendingId),
+              {
+                id: pendingId,
+                threadId: current.threadId,
+                seq: (current.messages.at(-1)?.seq ?? 0) + 1,
+                role: "user",
+                blocks: [{ kind: "text", text: trimmed }],
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          };
+        });
+      }
       setSending(true);
       setSendError(null);
       try {
@@ -773,9 +780,16 @@ export function ShellPage() {
         revokePendingAttachmentPreviews(attachments);
         setPendingAttachments((current) => current.filter((attachment) => attachment.botId !== id));
         if (activeBotId.current === id) setAttachmentNotice(null);
-        await refreshThreadRef.current(id);
       } catch (error) {
         if (activeBotId.current === id) {
+          setSnapshot((current) =>
+            current
+              ? {
+                  ...current,
+                  messages: current.messages.filter((message) => message.id !== pendingId),
+                }
+              : current,
+          );
           setSendError(error instanceof Error ? error.message : "Failed to send message");
         }
       } finally {
@@ -1189,7 +1203,7 @@ export function ShellPage() {
         </div>
       </aside>
 
-      <main className="flex min-w-0 flex-1 flex-col bg-[#0D0D0E]">
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col bg-[#0D0D0E]">
         <div className="flex items-center justify-between border-b border-[#141416] px-[22px] py-[17px]">
           <button
             type="button"
@@ -1197,7 +1211,7 @@ export function ShellPage() {
             onClick={() => setPanel("settings")}
             className="flex min-w-0 items-center gap-3"
           >
-            {active ? <BotAvatar color={active.color} size={26} /> : null}
+            {active ? <BotAvatar color={active.color} size={26} thinking={botWorking} /> : null}
             <span className="min-w-0">
               <span className="block truncate text-[16px] font-medium text-[#ECECEE]">
                 {active?.name ?? "Select a bot"}
@@ -1241,9 +1255,16 @@ export function ShellPage() {
           olderCursor={snapshot?.olderCursor ?? null}
           loadingOlder={loadingOlder}
           answerableAskMessageId={answerableAskMessageId}
-          running={Boolean(
-            snapshot?.run && ["running", "queued", "leased"].includes(snapshot.run.status),
-          )}
+          running={botWorking}
+          followOutput={
+            !loadingOlder &&
+            !(
+              pinnedAroundRef.current &&
+              active &&
+              pinnedAroundRef.current.botId === active.id &&
+              pinnedAroundRef.current.threadId === snapshot?.threadId
+            )
+          }
           onLoadOlder={loadOlder}
           onOpenBot={openBot}
           onAnswer={answerMessage}
@@ -1846,6 +1867,16 @@ export function ShellPage() {
   );
 }
 
+const STICK_TO_BOTTOM_PX = 96;
+
+function isNearTranscriptEnd(element: HTMLElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= STICK_TO_BOTTOM_PX;
+}
+
+function scrollTranscriptToEnd(element: HTMLElement): void {
+  element.scrollTop = element.scrollHeight;
+}
+
 const Transcript = memo(function Transcript({
   scrollRef,
   botId,
@@ -1854,6 +1885,7 @@ const Transcript = memo(function Transcript({
   loadingOlder,
   answerableAskMessageId,
   running,
+  followOutput,
   onLoadOlder,
   onOpenBot,
   onAnswer,
@@ -1870,6 +1902,7 @@ const Transcript = memo(function Transcript({
   loadingOlder: boolean;
   answerableAskMessageId: string | null;
   running: boolean;
+  followOutput: boolean;
   onLoadOlder: () => void | Promise<void>;
   onOpenBot: (botId: string) => void;
   onAnswer: (message: ThreadMessage, text: string) => Promise<void>;
@@ -1879,48 +1912,99 @@ const Transcript = memo(function Transcript({
   speakingMessageId: string | null;
   onSpeak: (message: ThreadMessage) => void;
 }) {
+  const enterState = useRef({ botId: "", seen: new Set<string>(), primed: false });
+  const [enteringIds, setEnteringIds] = useState<Set<string>>(() => new Set());
+  const contentRef = useRef<HTMLDivElement>(null);
+  const stickToBottom = useRef(true);
+  const followOutputRef = useRef(followOutput);
+  followOutputRef.current = followOutput;
+  const lastBotId = useRef(botId);
+  useLayoutEffect(() => {
+    const switchedBot = enterState.current.botId !== botId;
+    const next = collectEnteringUserMessageIds(botId, messages, enterState.current);
+    if (switchedBot) {
+      setEnteringIds(new Set());
+      return;
+    }
+    if (next.size > 0) setEnteringIds(next);
+  }, [botId, messages]);
+  useLayoutEffect(() => {
+    if (lastBotId.current !== botId) {
+      stickToBottom.current = true;
+      lastBotId.current = botId;
+    }
+    if (loadingOlder) {
+      stickToBottom.current = false;
+      return;
+    }
+    if (messages.at(-1)?.id.startsWith("pending:")) stickToBottom.current = true;
+    const element = scrollRef.current;
+    if (!element || !followOutput || !stickToBottom.current) return;
+    scrollTranscriptToEnd(element);
+  }, [botId, followOutput, loadingOlder, messages, running, scrollRef]);
+  useEffect(() => {
+    const element = scrollRef.current;
+    const content = contentRef.current;
+    if (!element || !content) return;
+    const onScroll = () => {
+      stickToBottom.current = isNearTranscriptEnd(element);
+    };
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) stickToBottom.current = false;
+    };
+    element.addEventListener("scroll", onScroll, { passive: true });
+    element.addEventListener("wheel", onWheel, { passive: true });
+    const observer = new ResizeObserver(() => {
+      if (!followOutputRef.current || !stickToBottom.current) return;
+      scrollTranscriptToEnd(element);
+    });
+    observer.observe(content);
+    return () => {
+      element.removeEventListener("scroll", onScroll);
+      element.removeEventListener("wheel", onWheel);
+      observer.disconnect();
+    };
+  }, [botId, scrollRef]);
+  const hasLiveReasoning = messages.some((message) => message.id.startsWith("reasoning:"));
   return (
     <div
       ref={scrollRef}
       data-testid="transcript"
-      className="rk-scroll flex flex-1 flex-col gap-[13px] overflow-y-auto px-7 py-6"
+      className="rk-transcript rk-scroll flex min-h-0 flex-1 flex-col overflow-y-auto px-7 py-6"
     >
-      {olderCursor != null ? (
-        <button
-          type="button"
-          disabled={loadingOlder}
-          onClick={() => void onLoadOlder()}
-          className="self-center rounded-lg px-3 py-1.5 text-[13px] text-[#85858A] hover:bg-[#1A1A1D] hover:text-[#C9C9CE] disabled:opacity-50"
-        >
-          {loadingOlder ? "Loading…" : "Load earlier messages"}
-        </button>
-      ) : null}
-      {messages.map((message) => (
-        <div key={message.id} data-message-id={message.id}>
-          <MessageView
-            botId={botId}
-            message={message}
-            canAnswer={message.id === answerableAskMessageId}
-            onOpenBot={onOpenBot}
-            onAnswer={onAnswer}
-            onRefresh={onRefresh}
-            onAddRoutine={onAddRoutine}
-            voiceReady={voiceReady}
-            speaking={speakingMessageId === message.id}
-            onSpeak={() => onSpeak(message)}
-          />
-        </div>
-      ))}
-      {running ? (
-        <div className="flex justify-start">
-          <div
-            className="rounded-[20px] bg-[#1A1A1D] px-[18px] py-[13px] text-[14.5px] text-[#85858A]"
-            style={{ animation: "rkPulse 1.2s ease-in-out infinite" }}
+      <div ref={contentRef} className="flex flex-col gap-[13px]">
+        {olderCursor != null ? (
+          <button
+            type="button"
+            disabled={loadingOlder}
+            onClick={() => void onLoadOlder()}
+            className="self-center rounded-lg px-3 py-1.5 text-[13px] text-[#85858A] hover:bg-[#1A1A1D] hover:text-[#C9C9CE] disabled:opacity-50"
           >
-            working…
+            {loadingOlder ? "Loading…" : "Load earlier messages"}
+          </button>
+        ) : null}
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            data-message-id={message.id}
+            className={enteringIds.has(message.id) ? "rk-drop-in" : undefined}
+          >
+            <MessageView
+              botId={botId}
+              message={message}
+              canAnswer={message.id === answerableAskMessageId}
+              onOpenBot={onOpenBot}
+              onAnswer={onAnswer}
+              onRefresh={onRefresh}
+              onAddRoutine={onAddRoutine}
+              voiceReady={voiceReady}
+              speaking={speakingMessageId === message.id}
+              onSpeak={() => onSpeak(message)}
+            />
           </div>
-        </div>
-      ) : null}
+        ))}
+        {running && !hasLiveReasoning ? <BotWorkingStatus /> : null}
+      </div>
     </div>
   );
 });
@@ -2552,6 +2636,103 @@ function CreateBotForm({
         Create
       </button>
     </div>
+  );
+}
+
+function collectEnteringUserMessageIds(
+  botId: string,
+  messages: ThreadMessage[],
+  state: { botId: string; seen: Set<string>; primed: boolean },
+) {
+  if (state.botId !== botId) {
+    state.botId = botId;
+    state.seen = new Set(messages.map((message) => message.id));
+    state.primed = messages.length > 0;
+    return new Set<string>();
+  }
+  if (!state.primed) {
+    if (!messages.length) return new Set<string>();
+    for (const message of messages) state.seen.add(message.id);
+    state.primed = true;
+    return new Set<string>();
+  }
+  const recent = new Set(messages.slice(-4).map((message) => message.id));
+  const entering = new Set<string>();
+  for (const message of messages) {
+    const text = userMessagePlainText(message);
+    const pendingKey = pendingUserMessageTextKey(text);
+    if (!state.seen.has(message.id) && message.role === "user" && recent.has(message.id)) {
+      const replacingPending = !message.id.startsWith("pending:") && state.seen.has(pendingKey);
+      if (!replacingPending) entering.add(message.id);
+    }
+    state.seen.add(message.id);
+    if (message.role === "user") {
+      if (message.id.startsWith("pending:")) state.seen.add(pendingKey);
+      else state.seen.delete(pendingKey);
+    }
+  }
+  return entering;
+}
+
+function userMessagePlainText(message: ThreadMessage): string {
+  return message.blocks.flatMap((block) => (block.kind === "text" ? [block.text] : [])).join("\n");
+}
+
+function BotWorkingStatus() {
+  return (
+    <div className="rk-thought flex items-center gap-1.5 py-0.5" data-testid="bot-working">
+      <ChevronRight size={16} strokeWidth={2} className="rk-thought-caret text-[#8E8EA0]" />
+      <span className="rk-working-text text-[15px] font-medium">Thinking</span>
+    </div>
+  );
+}
+
+function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+  const running = steps.some((step) => step.status === "running");
+  const visible = visibleReasoningSteps(steps);
+  useEffect(() => {
+    const el = detailsRef.current;
+    if (!el) return;
+    el.open = running;
+  }, [running]);
+  if (!steps.length) return null;
+  return (
+    <details ref={detailsRef} className="rk-thought w-[min(560px,100%)]">
+      <summary className="rk-thought-summary flex cursor-pointer list-none items-center gap-1.5 [&::-webkit-details-marker]:hidden">
+        <ChevronRight
+          size={16}
+          strokeWidth={2}
+          className="rk-thought-caret shrink-0 text-[#8E8EA0]"
+        />
+        {running ? (
+          <span className="rk-working-text text-[15px] font-medium">Thinking</span>
+        ) : (
+          <span className="text-[15px] font-medium text-[#B4B4B8]">Thought</span>
+        )}
+      </summary>
+      {visible.length ? (
+        <div className="rk-thought-body ml-[7px] mt-2 space-y-2.5 border-l border-[#3A3A40] pl-3.5">
+          {visible.map((step) => (
+            <div key={step.id} className="text-[14px] leading-[1.55] text-[#8E8EA0]">
+              {step.kind === "tool" || !step.detail ? (
+                <div className={step.status === "running" ? "text-[#D0D0D4]" : undefined}>
+                  {step.title}
+                </div>
+              ) : null}
+              {step.detail ? (
+                <pre className="rk-scroll max-h-72 overflow-y-auto whitespace-pre-wrap break-words font-sans text-[14px] leading-[1.55] text-[#8E8EA0]">
+                  {step.detail}
+                  {running && step.status === "running" ? (
+                    <span className="rk-thought-cursor">▍</span>
+                  ) : null}
+                </pre>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </details>
   );
 }
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -6,6 +6,7 @@ import type {
   ComputerStatus,
   Me,
   ProductEvent,
+  ReasoningStep,
   Routine,
   SearchHit,
   TaughtSkill,
@@ -29,6 +30,7 @@ import {
   groupBotsForSidebar,
   inferAttachmentMimeType,
   isActive,
+  isPendingUserMessageId,
   pendingUserMessageTextKey,
   presetFromCron,
   speechFromBlocks,
@@ -121,6 +123,14 @@ type PendingAttachment = {
   previewUrl?: string;
 };
 
+type PendingSendAttempt = {
+  botId: string;
+  text: string;
+  attachmentIds: string[];
+  clientNonce: string;
+  artifactIds: Map<string, string>;
+};
+
 const ATTACHMENT_ACCEPT = ATTACHMENT_ALLOWED_MIME_TYPES.join(",");
 
 export function ShellPage() {
@@ -138,6 +148,7 @@ export function ShellPage() {
   const [snapshot, setSnapshot] = useState<ThreadSnapshot | null>(null);
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [sending, setSending] = useState(false);
+  const [sendingBotId, setSendingBotId] = useState<string | null>(null);
   const [sendError, setSendError] = useState<string | null>(null);
   const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -203,10 +214,13 @@ export function ShellPage() {
   computerVisible.current = panel === "computer" || computerOpen;
   const autoSpoken = useRef<string | null>(null);
   const autoSpokenBotId = useRef<string | null>(null);
+  const retrySend = useRef<PendingSendAttempt | null>(null);
 
   const active = bots.find((b) => b.id === botId) ?? bots[0];
   const botWorking = Boolean(
-    snapshot?.run && ["running", "queued", "leased"].includes(snapshot.run.status),
+    (snapshot?.run && ["running", "queued", "leased"].includes(snapshot.run.status)) ||
+      (active && sendingBotId === active.id) ||
+      snapshot?.messages.some((message) => isPendingUserMessageId(message.id)),
   );
   const activePendingAttachments = useMemo(
     () => attachmentsForBot(pendingAttachments, active?.id),
@@ -729,11 +743,27 @@ export function ShellPage() {
   const sendMessage = useCallback(
     async (text: string) => {
       const id = activeBotId.current;
-      if (!id || sending) return;
+      if (!id || sending) return false;
       const attachments = attachmentsForBot(pendingAttachments, id);
       const trimmed = text.trim();
-      if (!trimmed && attachments.length === 0) return;
-      const pendingId = createPendingUserMessageId();
+      if (!trimmed && attachments.length === 0) return false;
+      const attachmentIds = attachments.map((attachment) => attachment.id);
+      const previousAttempt = retrySend.current;
+      const attempt =
+        previousAttempt &&
+        previousAttempt.botId === id &&
+        previousAttempt.text === trimmed &&
+        sameStringList(previousAttempt.attachmentIds, attachmentIds)
+          ? previousAttempt
+          : {
+              botId: id,
+              text: trimmed,
+              attachmentIds,
+              clientNonce: createPendingUserMessageId(),
+              artifactIds: new Map<string, string>(),
+            };
+      retrySend.current = attempt;
+      const pendingId = attempt.clientNonce;
       pinnedAroundRef.current = null;
       if (trimmed) {
         setSnapshot((current) => {
@@ -755,10 +785,16 @@ export function ShellPage() {
         });
       }
       setSending(true);
+      setSendingBotId(id);
       setSendError(null);
       try {
         const artifactIds: string[] = [];
         for (const pending of attachments) {
+          const existingArtifactId = attempt.artifactIds.get(pending.id);
+          if (existingArtifactId) {
+            artifactIds.push(existingArtifactId);
+            continue;
+          }
           const mimeType = inferAttachmentMimeType(pending.file.name, pending.file.type);
           if (!mimeType) {
             throw new Error(`Unsupported file type: ${pending.file.name}`);
@@ -770,16 +806,21 @@ export function ShellPage() {
             mimeType,
             contentBase64,
           });
+          attempt.artifactIds.set(pending.id, artifact.id);
           artifactIds.push(artifact.id);
         }
         await rpc.threads.send({
           botId: id,
           text: trimmed || undefined,
           artifactIds: artifactIds.length ? artifactIds : undefined,
+          clientNonce: attempt.clientNonce,
         });
+        await refreshThreadRef.current(id);
+        if (retrySend.current === attempt) retrySend.current = null;
         revokePendingAttachmentPreviews(attachments);
         setPendingAttachments((current) => current.filter((attachment) => attachment.botId !== id));
         if (activeBotId.current === id) setAttachmentNotice(null);
+        return true;
       } catch (error) {
         if (activeBotId.current === id) {
           setSnapshot((current) =>
@@ -792,8 +833,10 @@ export function ShellPage() {
           );
           setSendError(error instanceof Error ? error.message : "Failed to send message");
         }
+        return false;
       } finally {
         setSending(false);
+        setSendingBotId((current) => (current === id ? null : current));
       }
     },
     [pendingAttachments, sending],
@@ -2039,7 +2082,7 @@ const Composer = memo(function Composer({
   fileInputRef: RefObject<HTMLInputElement | null>;
   onAttachmentPick: (files: FileList | null) => void | Promise<void>;
   onRemoveAttachment: (attachment: PendingAttachment) => void;
-  onSend: (text: string) => Promise<void>;
+  onSend: (text: string) => Promise<boolean>;
   onStop: () => Promise<void>;
   dictating: boolean;
   transcribe: boolean;
@@ -2049,11 +2092,13 @@ const Composer = memo(function Composer({
   const [draft, setDraft] = useState("");
   const canSend = draft.trim().length > 0 || pendingAttachments.length > 0;
 
-  function send() {
+  async function send() {
     if (!canSend || sending || disabled) return;
     const text = draft;
     setDraft("");
-    void onSend(text);
+    if (!(await onSend(text))) {
+      setDraft((current) => current || text);
+    }
   }
 
   return (
@@ -2146,7 +2191,7 @@ const Composer = memo(function Composer({
           onKeyDown={(event) => {
             if (event.key === "Enter" && !event.shiftKey) {
               event.preventDefault();
-              send();
+              void send();
             }
           }}
           disabled={disabled}
@@ -2170,7 +2215,7 @@ const Composer = memo(function Composer({
             type="button"
             aria-label="Send"
             disabled={sending || !canSend || disabled}
-            onClick={send}
+            onClick={() => void send()}
             className="grid h-9 w-9 place-items-center rounded-full bg-[#F1F1EF] text-[#17171A] disabled:opacity-50"
           >
             <ArrowUp size={18} strokeWidth={2} />
@@ -2251,6 +2296,9 @@ const MessageView = memo(function MessageView({
               </div>
             </div>
           );
+        }
+        if (block.kind === "reasoning") {
+          return <ReasoningTrace key={i} steps={block.steps} />;
         }
         if (block.kind === "subagent") {
           const running = block.status === "running";
@@ -2680,7 +2728,12 @@ function userMessagePlainText(message: ThreadMessage): string {
 
 function BotWorkingStatus() {
   return (
-    <div className="rk-thought flex items-center gap-1.5 py-0.5" data-testid="bot-working">
+    <div
+      className="rk-thought flex items-center gap-1.5 py-0.5"
+      data-testid="bot-working"
+      role="status"
+      aria-live="polite"
+    >
       <ChevronRight size={16} strokeWidth={2} className="rk-thought-caret text-[#8E8EA0]" />
       <span className="rk-working-text text-[15px] font-medium">Thinking</span>
     </div>
@@ -2699,7 +2752,7 @@ function ReasoningTrace({ steps }: { steps: ReasoningStep[] }) {
   if (!steps.length) return null;
   return (
     <details ref={detailsRef} className="rk-thought w-[min(560px,100%)]">
-      <summary className="rk-thought-summary flex cursor-pointer list-none items-center gap-1.5 [&::-webkit-details-marker]:hidden">
+      <summary className="rk-thought-summary flex cursor-pointer list-none items-center gap-1.5 rounded-sm [&::-webkit-details-marker]:hidden">
         <ChevronRight
           size={16}
           strokeWidth={2}
@@ -3350,6 +3403,10 @@ function readFileAsBase64(file: File): Promise<string> {
     reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
     reader.readAsDataURL(file);
   });
+}
+
+function sameStringList(first: readonly string[], second: readonly string[]): boolean {
+  return first.length === second.length && first.every((value, index) => value === second[index]);
 }
 
 function formatBytes(size: number) {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -15,6 +15,10 @@ body,
   font-family: "Geist Variable", ui-sans-serif, system-ui, sans-serif;
 }
 
+.rk-transcript {
+  overflow-anchor: none;
+}
+
 .rk-scroll::-webkit-scrollbar {
   width: 6px;
 }
@@ -64,5 +68,155 @@ body,
   }
   50% {
     opacity: 0.3;
+  }
+}
+
+@keyframes rkDropIn {
+  0% {
+    opacity: 0;
+    transform: translateY(-16px) scale(0.94);
+  }
+  62% {
+    opacity: 1;
+    transform: translateY(4px) scale(1.03);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes rkAvatarBob {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+    filter: brightness(1);
+  }
+  50% {
+    transform: translateY(-5px) scale(1.06);
+    filter: brightness(1.22);
+  }
+}
+
+@keyframes rkAvatarEyes {
+  0%,
+  70%,
+  100% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  80% {
+    opacity: 0.35;
+    transform: scaleY(0.2);
+  }
+}
+
+@keyframes rkWorkingShimmer {
+  0% {
+    background-position: 140% 0;
+  }
+  100% {
+    background-position: -140% 0;
+  }
+}
+
+@keyframes rkThoughtReveal {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes rkCaretBlink {
+  0%,
+  45% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+.rk-drop-in {
+  animation: rkDropIn 0.34s cubic-bezier(0.22, 1.18, 0.32, 1) both;
+  transform-origin: right top;
+  will-change: transform, opacity;
+}
+
+.rk-avatar-think {
+  animation: rkAvatarBob 0.85s ease-in-out infinite;
+  will-change: transform, filter;
+}
+
+.rk-avatar-think .rk-avatar-eye {
+  transform-origin: center;
+  animation: rkAvatarEyes 1.35s ease-in-out infinite;
+}
+
+.rk-working-text {
+  background-image: linear-gradient(
+    90deg,
+    #6c6c70 0%,
+    #6c6c70 28%,
+    #f7f7f8 50%,
+    #6c6c70 72%,
+    #6c6c70 100%
+  );
+  background-size: 180% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: rkWorkingShimmer 1.05s linear infinite;
+}
+
+.rk-thought-summary {
+  outline: none;
+}
+
+.rk-thought-caret {
+  display: block;
+  transform-origin: center;
+  transition: transform 0.18s cubic-bezier(0.22, 1.2, 0.36, 1);
+}
+
+.rk-thought[open] .rk-thought-caret {
+  transform: rotate(90deg);
+}
+
+.rk-thought-body {
+  animation: rkThoughtReveal 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.rk-thought-cursor {
+  display: inline-block;
+  margin-left: 1px;
+  color: #c9c9ce;
+  animation: rkCaretBlink 0.9s steps(1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rk-drop-in,
+  .rk-avatar-think,
+  .rk-avatar-think .rk-avatar-eye,
+  .rk-working-text,
+  .rk-thought-body,
+  .rk-thought-cursor {
+    animation: none;
+  }
+
+  .rk-thought-caret {
+    transition: none;
+  }
+
+  .rk-working-text {
+    background: none;
+    color: #a8a8ad;
+    -webkit-text-fill-color: #a8a8ad;
   }
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -179,6 +179,11 @@ body,
   outline: none;
 }
 
+.rk-thought-summary:focus-visible {
+  outline: 2px solid #8e8ea0;
+  outline-offset: 3px;
+}
+
 .rk-thought-caret {
   display: block;
   transform-origin: center;

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -105,6 +105,7 @@ const READ_ONLY_AGENT_TOOLS = new Set([
   "run_subagent",
 ]);
 const MAX_MODEL_FILE_BYTES = 250_000;
+const STREAM_FLUSH_MS = 32;
 const GRAPHICAL_AGENT_TOOLS = new Set([
   "computer_observe",
   "computer_act",
@@ -485,6 +486,20 @@ export function createRunExecutor(deps: ExecutorDeps) {
         let lastComputerFrameId: string | undefined;
         let terminalCheckpointComplete = false;
         const progressRedactor = createStreamingRedactor(runSecrets);
+        const publishReasoning = async (force = false) => {
+          if (!reasoningSteps.length) return;
+          const now = Date.now();
+          if (!force && now - lastReasoningAt < STREAM_FLUSH_MS) return;
+          lastReasoningAt = now;
+          await deps.events.append({
+            workspaceId: run.workspaceId,
+            threadId: thread.id,
+            botId: bot.id,
+            type: "thread.reasoning",
+            runId,
+            payload: { steps: reasoningSteps },
+          });
+        };
         const scripted = deps.runtime.describe().capabilities.scripted;
         const script = scripted
           ? inferScript(task.prompt, resumeFromTakeover ? "takeover" : undefined)
@@ -934,7 +949,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               assembled += event.text;
               pendingProgress += progressRedactor.push(event.text);
               const now = Date.now();
-              if (!scripted && pendingProgress && now - lastProgressAt >= 250) {
+              if (!scripted && pendingProgress && now - lastProgressAt >= STREAM_FLUSH_MS) {
                 lastProgressAt = now;
                 await deps.events.append({
                   workspaceId: run.workspaceId,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -105,7 +105,9 @@ const READ_ONLY_AGENT_TOOLS = new Set([
   "run_subagent",
 ]);
 const MAX_MODEL_FILE_BYTES = 250_000;
-const STREAM_FLUSH_MS = 32;
+// Keep streaming responsive without turning fast token/thought streams into one durable event
+// write per token. At 80 ms, each active run emits at most about 12 batched updates per second.
+const STREAM_FLUSH_MS = 80;
 const GRAPHICAL_AGENT_TOOLS = new Set([
   "computer_observe",
   "computer_act",

--- a/packages/adapters/src/openai-compatible.test.ts
+++ b/packages/adapters/src/openai-compatible.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  errorFromOpenAICompatibleBody,
+  extractChatMessageText,
+  GATEWAY_PROVIDER_PREFIX,
+  isGatewayProvider,
+  labelForDiscoveredModels,
+  normalizeOpenAICompatibleBaseUrl,
+  openaiCompatibleModel,
+  parseAvailableModels,
+  secretIdForGatewayModel,
+  serializeAvailableModels,
+  textFromOpenAICompatibleBody,
+  unionAvailableModels,
+} from "./openai-compatible.js";
+
+describe("openai-compatible gateways", () => {
+  it("normalizes hostnames, trailing slashes, and missing protocols", () => {
+    expect(normalizeOpenAICompatibleBaseUrl("localhost:11434/v1")).toBe(
+      "http://localhost:11434/v1",
+    );
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/")).toBe(
+      "https://api.example.com/v1",
+    );
+  });
+
+  it("appends /v1 when the pasted URL is a host or a completions path", () => {
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com")).toBe(
+      "https://api.example.com/v1",
+    );
+    expect(normalizeOpenAICompatibleBaseUrl("https://api.example.com/v1/chat/completions")).toBe(
+      "https://api.example.com/v1",
+    );
+    expect(normalizeOpenAICompatibleBaseUrl("https://openrouter.ai/api")).toBe(
+      "https://openrouter.ai/api/v1",
+    );
+    expect(
+      normalizeOpenAICompatibleBaseUrl("https://generativelanguage.googleapis.com/v1beta/openai"),
+    ).toBe("https://generativelanguage.googleapis.com/v1beta/openai");
+  });
+
+  it("rejects non-http URLs", () => {
+    expect(() => normalizeOpenAICompatibleBaseUrl("ftp://example.com")).toThrow(/http/);
+  });
+
+  it("round-trips model lists and recognizes gateway provider ids", () => {
+    expect(parseAvailableModels("gpt-4o\nllama3, mistral")).toEqual([
+      "gpt-4o",
+      "llama3",
+      "mistral",
+    ]);
+    expect(serializeAvailableModels(["gpt-4o", "gpt-4o", "llama3"])).toBe("gpt-4o\nllama3");
+    expect(isGatewayProvider(`${GATEWAY_PROVIDER_PREFIX}abc`)).toBe(true);
+    expect(isGatewayProvider("openai-compatible")).toBe(true);
+    expect(isGatewayProvider("openrouter")).toBe(false);
+  });
+
+  it("does not require streamed finish_reason on custom endpoints", () => {
+    const model = openaiCompatibleModel(
+      `${GATEWAY_PROVIDER_PREFIX}abc`,
+      "gemini-2.5-flash",
+      "https://generativelanguage.googleapis.com/v1beta/openai",
+    );
+    expect(model.compat).toMatchObject({
+      supportsFinishReason: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    });
+    expect(model.reasoning).toBe(false);
+  });
+
+  it("picks the key whose discovered models include the requested model", () => {
+    const credential = {
+      secretId: "active-secret",
+      keys: [
+        {
+          secretId: "gemini-secret",
+          isActive: false,
+          availableModels: "gemini-2.5-pro\ngemini-2.5-flash",
+        },
+        {
+          secretId: "active-secret",
+          isActive: true,
+          availableModels: "gpt-4o\no4-mini",
+        },
+      ],
+    };
+    expect(secretIdForGatewayModel(credential, "gemini-2.5-flash")).toBe("gemini-secret");
+    expect(secretIdForGatewayModel(credential, "gpt-4o")).toBe("active-secret");
+    expect(secretIdForGatewayModel(credential, "unknown-model")).toBe("active-secret");
+    expect(secretIdForGatewayModel(credential, undefined)).toBe("active-secret");
+    expect(unionAvailableModels(credential.keys)).toEqual([
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      "gpt-4o",
+      "o4-mini",
+    ]);
+    expect(labelForDiscoveredModels(["gemini-2.5-pro", "gemini-2.0-flash"])).toBe("Gemini");
+    expect(labelForDiscoveredModels(["gpt-4o", "gpt-4.1"])).toBe("GPT");
+    expect(labelForDiscoveredModels(["o4-mini"])).toBe("OpenAI");
+    expect(labelForDiscoveredModels(["gemini-2.5-pro", "gpt-4o"])).toBe("API key");
+  });
+
+  it("reads string, array, and SSE chat completion bodies", () => {
+    expect(
+      extractChatMessageText({
+        choices: [{ message: { content: "Hello from JSON" } }],
+      }),
+    ).toBe("Hello from JSON");
+    expect(
+      extractChatMessageText({
+        choices: [
+          {
+            delta: {
+              content: [
+                { type: "text", text: "Hel" },
+                { type: "text", text: "lo" },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toBe("Hello");
+    expect(
+      textFromOpenAICompatibleBody(
+        'data: {"choices":[{"delta":{"content":"Hi"}}]}\ndata: [DONE]\n',
+        "text/event-stream",
+      ),
+    ).toBe("Hi");
+  });
+
+  it("surfaces the gateway error body, not a generic status", () => {
+    expect(
+      errorFromOpenAICompatibleBody(
+        JSON.stringify({
+          error: { message: "Invalid API key provided", type: "invalid_request_error" },
+        }),
+        401,
+      ),
+    ).toBe("401: Invalid API key provided");
+    expect(
+      errorFromOpenAICompatibleBody(
+        JSON.stringify({
+          error: { errors: [{ message: "Model gemini-2.5-pro is not found" }] },
+        }),
+        404,
+      ),
+    ).toBe("404: Model gemini-2.5-pro is not found");
+    expect(errorFromOpenAICompatibleBody("upstream refused the stream", 502)).toBe(
+      "502: upstream refused the stream",
+    );
+    expect(
+      errorFromOpenAICompatibleBody("<!DOCTYPE html><html><head><title>Home</title></head>", 200),
+    ).toMatch(/HTML page instead of the OpenAI-compatible API/);
+  });
+});

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -1,0 +1,395 @@
+import { createProvider, type Model, type MutableModels } from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+export const OPENAI_COMPATIBLE_PROVIDER = "openai-compatible";
+export const GATEWAY_PROVIDER_PREFIX = "gateway:";
+
+export function isGatewayProvider(provider: string): boolean {
+  return provider === OPENAI_COMPATIBLE_PROVIDER || provider.startsWith(GATEWAY_PROVIDER_PREFIX);
+}
+
+export function mintGatewayProviderId(): string {
+  return `${GATEWAY_PROVIDER_PREFIX}${crypto.randomUUID().replaceAll("-", "").slice(0, 12)}`;
+}
+
+export function normalizeOpenAICompatibleBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("Enter a base URL");
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed) && !/^https?:\/\//i.test(trimmed)) {
+    throw new Error("Base URL must be http or https");
+  }
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(withProtocol);
+  } catch {
+    throw new Error("Enter a valid http(s) base URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Base URL must be http or https");
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  let path = parsed.pathname.replace(/\/+$/, "") || "/";
+  path = path.replace(/\/(chat\/completions|completions|models|responses)$/i, "");
+  path = path.replace(/\/+$/, "") || "/";
+  if (!/\/v\d+[a-z0-9]*(\/|$)/i.test(path)) {
+    path = path === "/" ? "/v1" : `${path}/v1`;
+  }
+  parsed.pathname = path;
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+export function parseAvailableModels(value: string | null | undefined): string[] {
+  if (!value?.trim()) return [];
+  return [
+    ...new Set(
+      value
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+export function serializeAvailableModels(models: string[]): string {
+  return [...new Set(models.map((entry) => entry.trim()).filter(Boolean))].join("\n");
+}
+
+export function modelsFromKeyCoverage(value: string | string[] | null | undefined): string[] {
+  return Array.isArray(value)
+    ? [...new Set(value.map((entry) => entry.trim()).filter(Boolean))]
+    : parseAvailableModels(value);
+}
+
+export function unionAvailableModels(
+  keys: Array<{ availableModels?: string | string[] | null }>,
+): string[] {
+  return [...new Set(keys.flatMap((key) => modelsFromKeyCoverage(key.availableModels)))];
+}
+
+export function secretIdForGatewayModel(
+  credential: {
+    secretId: string;
+    keys: Array<{
+      secretId: string;
+      isActive: boolean;
+      availableModels?: string | string[] | null;
+    }>;
+  },
+  modelId?: string | null,
+): string {
+  const fallback = credential.keys.find((key) => key.isActive)?.secretId ?? credential.secretId;
+  if (!modelId?.trim() || !credential.keys.length) return fallback;
+  const matching = credential.keys.filter((key) =>
+    modelsFromKeyCoverage(key.availableModels).includes(modelId),
+  );
+  if (!matching.length) return fallback;
+  return matching.find((key) => key.isActive)?.secretId ?? matching[0]!.secretId;
+}
+
+const MODEL_FAMILY_LABELS: Array<[string, string]> = [
+  ["gemini", "Gemini"],
+  ["claude", "Claude"],
+  ["gpt", "GPT"],
+  ["o1", "OpenAI"],
+  ["o3", "OpenAI"],
+  ["o4", "OpenAI"],
+  ["llama", "Llama"],
+  ["mistral", "Mistral"],
+  ["grok", "Grok"],
+  ["deepseek", "DeepSeek"],
+  ["qwen", "Qwen"],
+  ["command", "Command"],
+];
+
+export function labelForDiscoveredModels(models: string[], fallback = "API key"): string {
+  if (!models.length) return fallback;
+  const lower = models.map((id) => id.toLowerCase());
+  for (const [needle, label] of MODEL_FAMILY_LABELS) {
+    const hits = lower.filter((id) => id.includes(needle)).length;
+    if (hits === models.length || hits >= Math.max(1, Math.ceil(models.length * 0.7))) {
+      return label;
+    }
+  }
+  return fallback;
+}
+
+export async function tryFetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<{ models: string[]; error: string }> {
+  try {
+    return { models: await fetchOpenAICompatibleModels(baseUrl, apiKey, signal), error: "" };
+  } catch (error) {
+    return {
+      models: [],
+      error: error instanceof Error ? error.message : "Could not list models",
+    };
+  }
+}
+
+export async function fetchOpenAICompatibleModels(
+  baseUrl: string,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const endpoint = `${normalizeOpenAICompatibleBaseUrl(baseUrl)}/models`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (apiKey?.trim()) headers.authorization = `Bearer ${apiKey.trim()}`;
+  const response = await fetch(endpoint, { headers, signal });
+  if (!response.ok) {
+    throw new Error(`Could not list models (${response.status})`);
+  }
+  const body = (await response.json()) as { data?: unknown; models?: unknown };
+  const rows = Array.isArray(body.data) ? body.data : Array.isArray(body.models) ? body.models : [];
+  const ids = rows.flatMap((row) => {
+    if (typeof row === "string") return [row];
+    if (row && typeof row === "object" && "id" in row) return [String((row as { id: unknown }).id)];
+    return [];
+  });
+  if (!ids.length) throw new Error("That endpoint did not return any models");
+  return [...new Set(ids)];
+}
+
+export function openaiCompatibleModel(
+  provider: string,
+  modelId: string,
+  baseUrl: string,
+): Model<"openai-completions"> {
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    provider,
+    baseUrl,
+    reasoning: false,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStore: false,
+      // Custom OpenAI-compatible proxies (Gemini, Ollama, LiteLLM, Groq, …) often
+      // close the SSE stream after tokens without a terminal finish_reason chunk.
+      // Pi treats that as a hard error unless this is off.
+      supportsFinishReason: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    },
+  };
+}
+
+export function attachOpenAICompatibleProvider(
+  models: MutableModels,
+  input: {
+    provider: string;
+    baseUrl: string;
+    modelId: string;
+    apiKey?: string;
+    extraModelIds?: string[];
+  },
+): void {
+  const baseUrl = normalizeOpenAICompatibleBaseUrl(input.baseUrl);
+  const ids = [...new Set([input.modelId, ...(input.extraModelIds ?? [])].filter(Boolean))];
+  models.setProvider(
+    createProvider({
+      id: input.provider,
+      name: input.provider,
+      baseUrl,
+      auth: {
+        apiKey: {
+          name: "Custom endpoint",
+          resolve: async () => ({
+            auth: input.apiKey?.trim() ? { apiKey: input.apiKey.trim() } : {},
+          }),
+        },
+      },
+      models: ids.map((id) => openaiCompatibleModel(input.provider, id, baseUrl)),
+      api: openAICompletionsApi(),
+    }),
+  );
+}
+
+export async function completeOpenAICompatibleChat(input: {
+  baseUrl: string;
+  apiKey?: string;
+  modelId: string;
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const endpoint = `${normalizeOpenAICompatibleBaseUrl(input.baseUrl)}/chat/completions`;
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "content-type": "application/json",
+  };
+  if (input.apiKey?.trim()) headers.authorization = `Bearer ${input.apiKey.trim()}`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    signal: input.signal,
+    body: JSON.stringify({
+      model: input.modelId,
+      messages: input.messages,
+      stream: false,
+    }),
+  });
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(errorFromOpenAICompatibleBody(raw, response.status));
+  }
+  const text = textFromOpenAICompatibleBody(raw, response.headers.get("content-type") ?? "");
+  if (!text.trim()) {
+    throw new Error(errorFromOpenAICompatibleBody(raw, response.status));
+  }
+  return text;
+}
+
+const MAX_GATEWAY_ERROR_CHARS = 4000;
+
+export function errorFromOpenAICompatibleBody(raw: string, status?: number): string {
+  const trimmed = raw.trim();
+  if (looksLikeHtmlDocument(trimmed)) {
+    const hint =
+      "The endpoint returned an HTML page instead of the OpenAI-compatible API. Use a base URL that ends in /v1 (for example https://api.example.com/v1) and confirm the API key is saved.";
+    return status && status >= 400 ? `${status}: ${hint}` : hint;
+  }
+  const extracted = extractGatewayErrorMessage(trimmed) || trimmed;
+  const clipped =
+    extracted.length > MAX_GATEWAY_ERROR_CHARS
+      ? `${extracted.slice(0, MAX_GATEWAY_ERROR_CHARS)}…`
+      : extracted;
+  if (status && status >= 400) {
+    if (!clipped) return `Gateway request failed (${status})`;
+    return /^\d{3}\b/.test(clipped) ? clipped : `${status}: ${clipped}`;
+  }
+  return clipped || "The gateway returned an empty reply";
+}
+
+function looksLikeHtmlDocument(raw: string): boolean {
+  const head = raw.slice(0, 256).toLowerCase();
+  return (
+    head.startsWith("<!doctype html") ||
+    head.startsWith("<html") ||
+    (head.startsWith("<") && (head.includes("<head") || head.includes("<title")))
+  );
+}
+
+function extractGatewayErrorMessage(raw: string): string {
+  if (!raw) return "";
+  try {
+    const fromJson = errorMessageFromValue(JSON.parse(raw) as unknown);
+    if (fromJson) return fromJson;
+  } catch {
+    // Fall through to SSE / plain text.
+  }
+  if (raw.includes("data:")) {
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const fromEvent = errorMessageFromValue(JSON.parse(payload) as unknown);
+        if (fromEvent) return fromEvent;
+      } catch {
+        // Ignore malformed SSE lines.
+      }
+    }
+  }
+  return "";
+}
+
+function errorMessageFromValue(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (!value || typeof value !== "object") return "";
+  const record = value as Record<string, unknown>;
+  const nested = record.error;
+  if (typeof nested === "string" && nested.trim()) return nested.trim();
+  if (nested && typeof nested === "object") {
+    const inner = nested as Record<string, unknown>;
+    if (typeof inner.message === "string" && inner.message.trim()) return inner.message.trim();
+    if (typeof inner.msg === "string" && inner.msg.trim()) return inner.msg.trim();
+    if (typeof inner.error === "string" && inner.error.trim()) return inner.error.trim();
+    const errors = inner.errors;
+    if (Array.isArray(errors)) {
+      const first = errors.find(
+        (entry) =>
+          entry &&
+          typeof entry === "object" &&
+          typeof (entry as { message?: unknown }).message === "string",
+      ) as { message: string } | undefined;
+      if (first?.message.trim()) return first.message.trim();
+    }
+  }
+  if (typeof record.message === "string" && record.message.trim()) return record.message.trim();
+  if (typeof record.msg === "string" && record.msg.trim()) return record.msg.trim();
+  if (typeof record.detail === "string" && record.detail.trim()) return record.detail.trim();
+  return "";
+}
+
+export function textFromOpenAICompatibleBody(raw: string, contentType = ""): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (contentType.includes("text/event-stream") || trimmed.startsWith("data:")) {
+    return textFromChatCompletionSse(trimmed);
+  }
+  try {
+    return extractChatMessageText(JSON.parse(trimmed) as unknown);
+  } catch {
+    return trimmed.includes("data:") ? textFromChatCompletionSse(trimmed) : "";
+  }
+}
+
+export function extractChatMessageText(body: unknown): string {
+  if (!body || typeof body !== "object") return "";
+  const record = body as Record<string, unknown>;
+  const choices = Array.isArray(record.choices) ? record.choices : [];
+  const choice = choices[0];
+  if (!choice || typeof choice !== "object") return extractContent(record.content);
+  const row = choice as Record<string, unknown>;
+  const message =
+    row.message && typeof row.message === "object"
+      ? (row.message as Record<string, unknown>)
+      : undefined;
+  const delta =
+    row.delta && typeof row.delta === "object" ? (row.delta as Record<string, unknown>) : undefined;
+  return (
+    extractContent(message?.content) ||
+    extractContent(delta?.content) ||
+    extractContent(row.content)
+  );
+}
+
+function textFromChatCompletionSse(raw: string): string {
+  let text = "";
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    try {
+      text += extractChatMessageText(JSON.parse(payload) as unknown);
+    } catch {
+      // Ignore malformed SSE lines from non-standard proxies.
+    }
+  }
+  return text;
+}
+
+function extractContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (!part || typeof part !== "object") return "";
+      const record = part as Record<string, unknown>;
+      if (typeof record.text === "string") return record.text;
+      if (typeof record.content === "string") return record.content;
+      return "";
+    })
+    .join("");
+}

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -115,6 +115,62 @@ export class PiAgentRuntime implements AgentRuntime {
         agent.subscribe((event) => {
           if (
             event.type === "message_update" &&
+            event.assistantMessageEvent.type === "thinking_delta"
+          ) {
+            const delta = event.assistantMessageEvent.delta;
+            if (delta) {
+              thinking += delta;
+              const now = Date.now();
+              if (now - lastThinkPush >= 24) {
+                lastThinkPush = now;
+                emitReasoning({
+                  id: "think",
+                  kind: "think",
+                  title: "Thinking",
+                  detail: thinking.slice(-4000),
+                  status: "running",
+                });
+              }
+            }
+          }
+          if (
+            event.type === "message_update" &&
+            event.assistantMessageEvent.type === "thinking_end"
+          ) {
+            const content = event.assistantMessageEvent.content || thinking;
+            if (content) {
+              thinking = content;
+              emitReasoning({
+                id: "think",
+                kind: "think",
+                title: "Thought",
+                detail: content.slice(-8000),
+                status: "done",
+              });
+            }
+          }
+          if (event.type === "tool_execution_start") {
+            toolArgs.set(event.toolCallId, event.args ?? {});
+            emitReasoning({
+              id: event.toolCallId,
+              kind: "tool",
+              title: reasoningToolTitle(event.toolName, event.args ?? {}),
+              detail: reasoningToolDetail(event.toolName, event.args ?? {}),
+              status: "running",
+            });
+          }
+          if (event.type === "tool_execution_end") {
+            const args = toolArgs.get(event.toolCallId) ?? {};
+            emitReasoning({
+              id: event.toolCallId,
+              kind: "tool",
+              title: reasoningToolTitle(event.toolName, args),
+              detail: event.isError ? "failed" : "done",
+              status: "done",
+            });
+          }
+          if (
+            event.type === "message_update" &&
             event.assistantMessageEvent.type === "text_delta"
           ) {
             const delta = event.assistantMessageEvent.delta;

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -121,7 +121,7 @@ export class PiAgentRuntime implements AgentRuntime {
             if (delta) {
               thinking += delta;
               const now = Date.now();
-              if (now - lastThinkPush >= 24) {
+              if (now - lastThinkPush >= 80) {
                 lastThinkPush = now;
                 emitReasoning({
                   id: "think",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export * from "./cron.js";
 export * from "./events.js";
 export * from "./message-pages.js";
 export * from "./model-oauth.js";
+export * from "./reasoning.js";
 export * from "./run-state.js";
 export * from "./sandbox-command.js";
 export * from "./screen-lease.js";

--- a/packages/core/src/reasoning.test.ts
+++ b/packages/core/src/reasoning.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  isEphemeralThreadMessageId,
+  reasoningMessageId,
+  reasoningToolTitle,
+  upsertReasoningStep,
+  visibleReasoningSteps,
+} from "./reasoning.js";
+
+describe("reasoning helpers", () => {
+  it("identifies live progress, reasoning, and pending ids", () => {
+    expect(isEphemeralThreadMessageId("progress:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("reasoning:run-1")).toBe(true);
+    expect(isEphemeralThreadMessageId("pending:abc")).toBe(true);
+    expect(isEphemeralThreadMessageId("m-1")).toBe(false);
+  });
+
+  it("upserts reasoning steps by id", () => {
+    const first = upsertReasoningStep([], {
+      id: "think",
+      kind: "think",
+      title: "Thinking",
+      status: "running",
+    });
+    const second = upsertReasoningStep(first, {
+      id: "think",
+      kind: "think",
+      title: "Thinking",
+      detail: "considering files",
+      status: "running",
+    });
+    expect(second).toHaveLength(1);
+    expect(second[0]?.detail).toBe("considering files");
+    expect(reasoningMessageId({ runId: "r1" })).toBe("reasoning:r1");
+  });
+
+  it("hides filler status steps from the ChatGPT-style thought body", () => {
+    expect(
+      visibleReasoningSteps([
+        { id: "status", kind: "status", title: "Working through the request", status: "running" },
+        { id: "think", kind: "think", title: "Thinking", detail: "checking files", status: "done" },
+        { id: "status-done", kind: "status", title: "Finished", status: "done" },
+        {
+          id: "err",
+          kind: "status",
+          title: "Gateway error",
+          detail: "401: bad key",
+          status: "done",
+        },
+      ]).map((step) => step.id),
+    ).toEqual(["think", "err"]);
+  });
+
+  it("names common tools in the trace", () => {
+    expect(reasoningToolTitle("shell")).toBe("Running a command");
+    expect(reasoningToolTitle("write_file", { path: "notes/result.txt" })).toBe(
+      "Writing result.txt",
+    );
+  });
+});

--- a/packages/core/src/reasoning.test.ts
+++ b/packages/core/src/reasoning.test.ts
@@ -3,6 +3,7 @@ import {
   isEphemeralThreadMessageId,
   reasoningMessageId,
   reasoningToolTitle,
+  shouldReplaceTransientMessageId,
   upsertReasoningStep,
   visibleReasoningSteps,
 } from "./reasoning.js";
@@ -13,6 +14,14 @@ describe("reasoning helpers", () => {
     expect(isEphemeralThreadMessageId("reasoning:run-1")).toBe(true);
     expect(isEphemeralThreadMessageId("pending:abc")).toBe(true);
     expect(isEphemeralThreadMessageId("m-1")).toBe(false);
+  });
+
+  it("reconciles only the pending message named by the durable event nonce", () => {
+    expect(shouldReplaceTransientMessageId("pending:first", "pending:first")).toBe(true);
+    expect(shouldReplaceTransientMessageId("pending:second", "pending:first")).toBe(false);
+    expect(shouldReplaceTransientMessageId("pending:first")).toBe(false);
+    expect(shouldReplaceTransientMessageId("progress:run-1")).toBe(true);
+    expect(shouldReplaceTransientMessageId("reasoning:run-1")).toBe(true);
   });
 
   it("upserts reasoning steps by id", () => {

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -1,0 +1,122 @@
+import type { ReasoningStep } from "@rakazo/contracts";
+
+export const PENDING_USER_MESSAGE_PREFIX = "pending:";
+
+export function isPendingUserMessageId(id: string): boolean {
+  return id.startsWith(PENDING_USER_MESSAGE_PREFIX);
+}
+
+export function createPendingUserMessageId(): string {
+  return `${PENDING_USER_MESSAGE_PREFIX}${crypto.randomUUID()}`;
+}
+
+export function isEphemeralThreadMessageId(id: string): boolean {
+  return id.startsWith("progress:") || id.startsWith("reasoning:") || isPendingUserMessageId(id);
+}
+
+export function pendingUserMessageTextKey(text: string): string {
+  return `pending-text:${text}`;
+}
+
+export function reasoningMessageId(event: { runId?: string | null; id?: string }): string {
+  return `reasoning:${event.runId ?? event.id ?? "live"}`;
+}
+
+const FILLER_REASONING_TITLES = new Set(["working through the request", "finished"]);
+
+export function visibleReasoningSteps(steps: ReasoningStep[]): ReasoningStep[] {
+  return steps.filter((step) => {
+    if (step.detail?.trim()) return true;
+    if (step.kind === "tool" || step.kind === "think") return true;
+    if (step.kind === "status") {
+      return !FILLER_REASONING_TITLES.has(step.title.trim().toLowerCase());
+    }
+    return Boolean(step.title.trim());
+  });
+}
+
+export function upsertReasoningStep(steps: ReasoningStep[], step: ReasoningStep): ReasoningStep[] {
+  const next = steps.map((entry) => (entry.id === step.id ? { ...entry, ...step } : entry));
+  if (next.some((entry) => entry.id === step.id)) return next;
+  return [...next, step];
+}
+
+export function reasoningStepsFromPayload(
+  payload: Record<string, unknown> | undefined,
+): ReasoningStep[] {
+  const raw = payload?.steps;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const record = entry as Record<string, unknown>;
+    const kind = record.kind;
+    const status = record.status;
+    if (kind !== "status" && kind !== "think" && kind !== "tool") return [];
+    if (status !== "running" && status !== "done") return [];
+    return [
+      {
+        id: String(record.id ?? ""),
+        kind,
+        title: String(record.title ?? ""),
+        detail: record.detail ? String(record.detail) : undefined,
+        status,
+      },
+    ];
+  });
+}
+
+export function reasoningToolTitle(name: string, args: Record<string, unknown> = {}): string {
+  switch (name) {
+    case "shell":
+      return "Running a command";
+    case "write_file":
+      return args.path ? `Writing ${shortPath(String(args.path))}` : "Writing a file";
+    case "read_file":
+      return args.path ? `Reading ${shortPath(String(args.path))}` : "Reading a file";
+    case "list_files":
+      return "Listing files";
+    case "open_path":
+      return args.path ? `Opening ${shortPath(String(args.path))}` : "Opening a path";
+    case "computer_observe":
+      return "Looking at the screen";
+    case "computer_act":
+      return "Using the computer";
+    case "launch_app":
+      return args.application ? `Opening ${String(args.application)}` : "Opening an app";
+    case "remember":
+      return "Saving a memory";
+    case "request_takeover":
+      return "Asking you to take over";
+    case "run_subagent":
+      return args.name ? `Starting ${String(args.name)}` : "Starting a subagent";
+    case "spawn_bot":
+      return args.name ? `Creating ${String(args.name)}` : "Creating a bot";
+    case "destination.write":
+      return "Writing to a destination";
+    default:
+      return `Using ${name.replaceAll("_", " ").replaceAll(".", " ")}`;
+  }
+}
+
+export function reasoningToolDetail(
+  name: string,
+  args: Record<string, unknown> = {},
+): string | undefined {
+  if (name === "shell") return clip(String(args.command ?? ""));
+  if (name === "write_file") return clip(String(args.content ?? ""));
+  if (name === "remember") return clip(String(args.content ?? args.path ?? ""));
+  if (name === "run_subagent") return clip(String(args.task ?? ""));
+  if (name === "request_takeover") return clip(String(args.reason ?? ""));
+  return undefined;
+}
+
+function shortPath(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  return parts.at(-1) || path;
+}
+
+function clip(value: string, max = 400): string | undefined {
+  const text = value.trim();
+  if (!text) return undefined;
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}

--- a/packages/core/src/reasoning.ts
+++ b/packages/core/src/reasoning.ts
@@ -14,6 +14,11 @@ export function isEphemeralThreadMessageId(id: string): boolean {
   return id.startsWith("progress:") || id.startsWith("reasoning:") || isPendingUserMessageId(id);
 }
 
+export function shouldReplaceTransientMessageId(id: string, clientNonce?: string): boolean {
+  if (isPendingUserMessageId(id)) return Boolean(clientNonce) && id === clientNonce;
+  return id.startsWith("progress:") || id.startsWith("reasoning:");
+}
+
 export function pendingUserMessageTextKey(text: string): string {
   return `pending-text:${text}`;
 }

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -402,7 +402,11 @@ describe("sendUserMessage", () => {
     });
     expect(tx.event.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ type: "thread.message.created", runId: "run-1" }),
+        data: expect.objectContaining({
+          type: "thread.message.created",
+          runId: "run-1",
+          payload: expect.objectContaining({ clientNonce: "nonce-1" }),
+        }),
       }),
     );
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 8 }));

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -269,7 +269,12 @@ export async function sendUserMessage(
       botId: input.botId,
       type: "thread.message.created",
       runId: run?.id,
-      payload: { messageId: message.id, role: "user", blocks: input.blocks },
+      payload: {
+        messageId: message.id,
+        role: "user",
+        blocks: input.blocks,
+        ...(input.clientNonce ? { clientNonce: input.clientNonce } : {}),
+      },
     });
     return { message, task, run, event };
   });

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -1080,6 +1080,32 @@ describeJourneys("required product journeys", () => {
     });
     expect(file.content).toContain("nonce-ok");
     expect(file.content).not.toContain("nonce-dup");
+
+    const concurrentNonce = `concurrent-nonce-${stamp}`;
+    const [concurrentFirst, concurrentSecond] = await Promise.all([
+      rpc<{ runId: string }>(app, cookie, "threads/send", {
+        botId: bot.id,
+        text: "write concurrent-nonce-ok to notes/concurrent.txt",
+        clientNonce: concurrentNonce,
+      }),
+      rpc<{ runId: string }>(app, cookie, "threads/send", {
+        botId: bot.id,
+        text: "write concurrent-nonce-ok to notes/concurrent.txt",
+        clientNonce: concurrentNonce,
+      }),
+    ]);
+    expect(concurrentSecond.runId).toBe(concurrentFirst.runId);
+    await waitFor(
+      app,
+      cookie,
+      bot.id,
+      (s) => !s.run || ["completed", "failed", "cancelled"].includes(s.run.status),
+    );
+    expect(
+      await prisma.run.count({
+        where: { botId: bot.id, clientNonce: concurrentNonce },
+      }),
+    ).toBe(1);
   });
 
   it("16: routine test-run and plugin connect/revoke", async () => {

--- a/packages/ui-web/src/bot-avatar.tsx
+++ b/packages/ui-web/src/bot-avatar.tsx
@@ -3,10 +3,12 @@ import { cn } from "./lib/utils.js";
 export function BotAvatar({
   color,
   size = 38,
+  thinking = false,
   className,
 }: {
   color: string;
   size?: number;
+  thinking?: boolean;
   className?: string;
 }) {
   const visorW = Math.round(size * 0.68);
@@ -14,7 +16,11 @@ export function BotAvatar({
   const dot = Math.max(3, Math.round(size * 0.1));
   return (
     <div
-      className={cn("flex items-center justify-center rounded-full", className)}
+      className={cn(
+        "flex items-center justify-center rounded-full",
+        thinking && "rk-avatar-think",
+        className,
+      )}
       style={{ width: size, height: size, background: color, flex: "none" }}
     >
       <div
@@ -27,8 +33,8 @@ export function BotAvatar({
           gap: Math.max(4, Math.round(size * 0.13)),
         }}
       >
-        <span className="rounded-full bg-white" style={{ width: dot, height: dot }} />
-        <span className="rounded-full bg-white" style={{ width: dot, height: dot }} />
+        <span className="rk-avatar-eye rounded-full bg-white" style={{ width: dot, height: dot }} />
+        <span className="rk-avatar-eye rounded-full bg-white" style={{ width: dot, height: dot }} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Sent messages appear immediately; thinking avatars and working status; thought UI; desktop autoscroll.
- Independent onto `elie222:main` for review. Landing order remains 1→13.

## Test plan
- [ ] Send a message and confirm the bubble appears before the round trip
- [ ] Live reply autoscrolls the desktop transcript
- [ ] Prefix is deployable with no new migrations

## Limitations
- Reasoning/custom-gateway files that this slice also edits appear as additions because they are not on `main` yet.
