### PR TITLE
Add desktop auto-update and signed release workflow

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -9,7 +9,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-desktop-${{ github.ref }}
+  # Stable releases must validate and publish serially. Per-tag concurrency would let an older
+  # release validate before a newer one publishes, then overwrite GitHub's "latest" pointer.
+  group: release-desktop-stable
   cancel-in-progress: false
 
 jobs:
@@ -117,8 +119,8 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         env:
-          CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.DESKTOP_MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_MAC_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -132,8 +134,8 @@ jobs:
       - name: Package signed and notarized universal macOS app
         if: runner.os == 'macOS'
         env:
-          CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.DESKTOP_MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_MAC_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -155,8 +157,8 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         env:
-          WIN_CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+          WIN_CSC_LINK: ${{ secrets.DESKTOP_WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_WIN_CSC_KEY_PASSWORD }}
         run: |
           set -euo pipefail
           test -n "$WIN_CSC_LINK"
@@ -164,8 +166,8 @@ jobs:
       - name: Package signed x64 Windows app
         if: runner.os == 'Windows'
         env:
-          WIN_CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+          WIN_CSC_LINK: ${{ secrets.DESKTOP_WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_WIN_CSC_KEY_PASSWORD }}
         run: >-
           pnpm --filter @rakazo/desktop exec electron-builder
           --win --x64 --publish never -c.forceCodeSigning=true
@@ -174,11 +176,16 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
-          $installer = Get-ChildItem "apps/desktop/out/*.exe" | Select-Object -First 1
-          if (-not $installer) { throw "Windows installer was not created." }
-          $signature = Get-AuthenticodeSignature $installer.FullName
-          if ($signature.Status -ne "Valid") {
-            throw "Windows installer signature is $($signature.Status)."
+          $executables = @(
+            Get-ChildItem "apps/desktop/out/*.exe"
+            Get-ChildItem "apps/desktop/out/win-unpacked/*.exe"
+          )
+          if ($executables.Count -lt 2) { throw "Windows installer or application was not created." }
+          foreach ($executable in $executables) {
+            $signature = Get-AuthenticodeSignature $executable.FullName
+            if ($signature.Status -ne "Valid") {
+              throw "$($executable.Name) signature is $($signature.Status)."
+            }
           }
           $config = "apps/desktop/out/win-unpacked/resources/app-update.yml"
           if (-not (Select-String -Path $config -Pattern '^publisherName:' -Quiet)) {

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,46 +1,292 @@
 name: release-desktop
+
 on:
   push:
     tags: ["v*"]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-desktop-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish ${{ matrix.os }} installers
+  validate:
+    name: Validate stable release
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+      sha: ${{ steps.release.outputs.sha }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate tag, version, ancestry, and monotonicity
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_REF_TYPE" != "tag" ]]; then
+            echo "Desktop releases must run from a tag, including manual dispatches." >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Desktop releases use the stable vMAJOR.MINOR.PATCH channel." >&2
+            exit 1
+          fi
+
+          version="$(node -p "require('./apps/desktop/package.json').version")"
+          if [[ "$RELEASE_TAG" != "v$version" ]]; then
+            echo "Tag $RELEASE_TAG does not match desktop version $version." >&2
+            exit 1
+          fi
+
+          tag_sha="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
+            echo "The workflow revision does not match the tagged commit." >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$tag_sha" origin/main; then
+            echo "Desktop releases must point to a commit already on main." >&2
+            exit 1
+          fi
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "A release already exists for $RELEASE_TAG; refusing to replace it." >&2
+            exit 1
+          fi
+
+          latest_tag="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' |
+              sed -nE '/^v[0-9]+\.[0-9]+\.[0-9]+$/p' |
+              sort -V |
+              tail -n 1
+          )"
+          if [[ -n "$latest_tag" ]]; then
+            highest="$(printf '%s\n%s\n' "$latest_tag" "$RELEASE_TAG" | sort -V | tail -n 1)"
+            if [[ "$highest" != "$RELEASE_TAG" || "$latest_tag" == "$RELEASE_TAG" ]]; then
+              echo "$RELEASE_TAG must be newer than published release $latest_tag." >&2
+              exit 1
+            fi
+          fi
+
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sha=$tag_sha" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build signed ${{ matrix.artifact }} artifacts
+    needs: validate
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        include:
+          - os: macos-14
+            artifact: macos
+          - os: windows-2022
+            artifact: windows
+          - os: ubuntu-24.04
+            artifact: linux
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Build and publish
-        # electron-builder writes latest.yml / latest-mac.yml next to the installers; that file is
-        # the feed electron-updater reads, so a release without it cannot be picked up by clients.
-        run: pnpm --filter @rakazo/desktop run release
+      - name: Build renderer and Electron main process
+        run: pnpm --filter @rakazo/web build && pnpm --filter @rakazo/desktop build
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # The bundled renderer is static assets; the secrets it would otherwise demand only
-          # matter to the server the app connects to, so the build uses the dev placeholders.
           RAKAZO_ALLOW_DEV_SECRETS: "1"
-          # Signing is what makes an update installable without a security prompt. Leave these
-          # unset and the job still publishes, but macOS and Windows clients will refuse the update.
+
+      - name: Require macOS signing and notarization credentials
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
           CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          test -n "$CSC_LINK"
+          test -n "$CSC_KEY_PASSWORD"
+          test -n "$APPLE_ID"
+          test -n "$APPLE_APP_SPECIFIC_PASSWORD"
+          test -n "$APPLE_TEAM_ID"
+      - name: Package signed and notarized universal macOS app
+        if: runner.os == 'macOS'
+        env:
+          CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: >-
+          pnpm --filter @rakazo/desktop exec electron-builder
+          --mac --universal --publish never -c.forceCodeSigning=true
+      - name: Verify macOS signature, notarization ticket, and update feed
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          app="apps/desktop/out/mac-universal/Rakazo.app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          xcrun stapler validate "$app"
+          spctl --assess --type execute --verbose=2 "$app"
+          grep -Fqx "provider: github" "$app/Contents/Resources/app-update.yml"
+
+      - name: Require Windows signing credentials
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          WIN_CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$WIN_CSC_LINK"
+          test -n "$WIN_CSC_KEY_PASSWORD"
+      - name: Package signed x64 Windows app
+        if: runner.os == 'Windows'
+        env:
+          WIN_CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+        run: >-
+          pnpm --filter @rakazo/desktop exec electron-builder
+          --win --x64 --publish never -c.forceCodeSigning=true
+      - name: Verify Windows Authenticode signature and publisher-bound update feed
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installer = Get-ChildItem "apps/desktop/out/*.exe" | Select-Object -First 1
+          if (-not $installer) { throw "Windows installer was not created." }
+          $signature = Get-AuthenticodeSignature $installer.FullName
+          if ($signature.Status -ne "Valid") {
+            throw "Windows installer signature is $($signature.Status)."
+          }
+          $config = "apps/desktop/out/win-unpacked/resources/app-update.yml"
+          if (-not (Select-String -Path $config -Pattern '^publisherName:' -Quiet)) {
+            throw "Windows update config is not bound to the signing publisher."
+          }
+
+      - name: Package x64 Linux AppImage
+        if: runner.os == 'Linux'
+        run: >-
+          pnpm --filter @rakazo/desktop exec electron-builder
+          --linux --x64 --publish never
+
+      - name: Retain installers and updater metadata
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: desktop-${{ matrix.artifact }}-${{ needs.validate.outputs.sha }}
+          path: |
+            apps/desktop/out/*.AppImage
+            apps/desktop/out/*.blockmap
+            apps/desktop/out/*.dmg
+            apps/desktop/out/*.exe
+            apps/desktop/out/*.yml
+            apps/desktop/out/*.zip
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  publish:
+    name: Attest and publish complete release
+    needs: [validate, build]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.sha }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: desktop-*-${{ needs.validate.outputs.sha }}
+          path: release-artifacts
+          merge-multiple: true
+      - name: Verify the complete stable update feed
+        env:
+          RELEASE_SHA: ${{ needs.validate.outputs.sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          if [[ "$(git rev-parse "${RELEASE_TAG}^{commit}")" != "$RELEASE_SHA" ]]; then
+            echo "The release tag moved after the build started." >&2
+            exit 1
+          fi
+
+          test -f release-artifacts/latest.yml
+          test -f release-artifacts/latest-mac.yml
+          test -f release-artifacts/latest-linux.yml
+          compgen -G 'release-artifacts/*.dmg' >/dev/null
+          compgen -G 'release-artifacts/*.zip' >/dev/null
+          compgen -G 'release-artifacts/*.exe' >/dev/null
+          compgen -G 'release-artifacts/*.AppImage' >/dev/null
+          feeds=(
+            release-artifacts/latest.yml
+            release-artifacts/latest-mac.yml
+            release-artifacts/latest-linux.yml
+          )
+          for feed in "${feeds[@]}"; do
+            grep -Fqx "version: $RELEASE_VERSION" "$feed"
+          done
+
+          (
+            cd release-artifacts
+            find . -maxdepth 1 -type f ! -name SHA256SUMS -print0 |
+              sort -z |
+              xargs -0 sha256sum > SHA256SUMS
+          )
+      - name: Attest release provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: release-artifacts/*
+      - name: Create draft and upload every platform
+        id: create_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: >-
+          gh release create "$RELEASE_TAG" release-artifacts/*
+          --draft --generate-notes --title "Rakazo $RELEASE_TAG" --verify-tag
+      - name: Publish the completed release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --latest
+      - name: Remove an incomplete draft
+        if: failure() && steps.create_release.outcome != 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        shell: bash
+        run: |
+          if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq .draft 2>/dev/null)" == "true" ]]; then
+            gh release delete "$RELEASE_TAG" --yes
+          fi

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,46 @@
+name: release-desktop
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-desktop-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.os }} installers
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build and publish
+        # electron-builder writes latest.yml / latest-mac.yml next to the installers; that file is
+        # the feed electron-updater reads, so a release without it cannot be picked up by clients.
+        run: pnpm --filter @rakazo/desktop run release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The bundled renderer is static assets; the secrets it would otherwise demand only
+          # matter to the server the app connects to, so the build uses the dev placeholders.
+          RAKAZO_ALLOW_DEV_SECRETS: "1"
+          # Signing is what makes an update installable without a security prompt. Leave these
+          # unset and the job still publishes, but macOS and Windows clients will refuse the update.
+          CSC_LINK: ${{ secrets.DESKTOP_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/apps/desktop/e2e/smoke.spec.ts
+++ b/apps/desktop/e2e/smoke.spec.ts
@@ -29,8 +29,10 @@ test("launches with a narrow preload bridge and an isolated renderer", async () 
       return {
         bridgeKeys: desktop ? Object.keys(desktop).sort() : [],
         windowKeys: desktop ? Object.keys(desktop.window).sort() : [],
+        updateKeys: desktop ? Object.keys(desktop.update).sort() : [],
         platform: desktop?.platform,
         state: await desktop?.window.state(),
+        update: await desktop?.update.state(),
         nodeGlobals: {
           require: typeof (window as unknown as { require?: unknown }).require,
           process: typeof (window as unknown as { process?: unknown }).process,
@@ -39,10 +41,13 @@ test("launches with a narrow preload bridge and an isolated renderer", async () 
       };
     });
 
-    expect(renderer.bridgeKeys).toEqual(["platform", "window"]);
+    expect(renderer.bridgeKeys).toEqual(["platform", "update", "window"]);
     expect(renderer.windowKeys).toEqual(["close", "minimize", "state", "toggleMaximize"]);
+    expect(renderer.updateKeys).toEqual(["check", "download", "install", "state"]);
     expect(renderer.platform).toBe(process.platform);
     expect(renderer.state).toEqual({ minimized: false, maximized: false, fullScreen: false });
+    // An unpackaged run has no update feed, and that is reported as a state rather than an error.
+    expect(renderer.update).toMatchObject({ phase: "unsupported", availableVersion: null });
     expect(renderer.nodeGlobals).toEqual({
       require: "undefined",
       process: "undefined",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p tsconfig.json && cp src/preload.cjs dist/preload.cjs",
     "pack": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --mac --win --linux",
     "pack:dir": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --dir",
-    "release": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --publish always",
+    "release": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --publish never",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --root ../.. apps/desktop/src",
     "test:e2e": "pnpm build && playwright test --config e2e/playwright.config.ts"
@@ -55,6 +55,7 @@
     "mac": {
       "icon": "assets/icon.icns",
       "category": "public.app-category.productivity",
+      "notarize": true,
       "target": [
         "dmg",
         "zip"
@@ -62,6 +63,7 @@
     },
     "win": {
       "icon": "assets/icon.ico",
+      "verifyUpdateCodeSignature": true,
       "target": [
         "nsis"
       ]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,12 +9,14 @@
     "build": "tsc -p tsconfig.json && cp src/preload.cjs dist/preload.cjs",
     "pack": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --mac --win --linux",
     "pack:dir": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --dir",
+    "release": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --publish always",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --root ../.. apps/desktop/src",
     "test:e2e": "pnpm build && playwright test --config e2e/playwright.config.ts"
   },
   "dependencies": {
-    "@rakazo/contracts": "workspace:*"
+    "@rakazo/contracts": "workspace:*",
+    "electron-updater": "^6.8.9"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
@@ -26,6 +28,13 @@
   "build": {
     "appId": "dev.rakazo.desktop",
     "productName": "Rakazo",
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "elie222",
+        "repo": "rakazo"
+      }
+    ],
     "directories": {
       "output": "out",
       "buildResources": "assets"

--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   classifyUpdaterFailure,
+  DesktopUpdateController,
+  type ElectronAutoUpdater,
   initialUpdateState,
   MIN_CHECK_INTERVAL_MS,
   reduceUpdateState,
@@ -11,12 +13,46 @@ import {
 
 const NOW = "2026-08-22T12:00:00.000Z";
 const packaged = { packaged: true, version: "0.1.0" };
+const clock = { now: () => 1_000, iso: () => NOW };
 
 function apply(events: UpdaterEvent[], env = packaged) {
   return events.reduce(
     (state, event) => reduceUpdateState(state, event, NOW),
     initialUpdateState(env),
   );
+}
+
+function fakeUpdater(overrides: Partial<ElectronAutoUpdater> = {}) {
+  const listeners = new Map<string, (payload: unknown) => void>();
+  const updater: ElectronAutoUpdater = {
+    autoDownload: true,
+    autoInstallOnAppQuit: false,
+    allowDowngrade: true,
+    allowPrerelease: true,
+    disableWebInstaller: false,
+    on: vi.fn((event, listener) => {
+      listeners.set(event, listener);
+      return updater;
+    }),
+    checkForUpdates: vi.fn(async () => undefined),
+    downloadUpdate: vi.fn(async () => undefined),
+    quitAndInstall: vi.fn(),
+    ...overrides,
+  };
+  return {
+    updater,
+    emit(event: string, payload?: unknown) {
+      listeners.get(event)?.(payload);
+    },
+  };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 describe("updaterSupport", () => {
@@ -53,20 +89,21 @@ describe("classifyUpdaterFailure", () => {
     }
   });
 
-  it("always surfaces a signing problem with the original detail", () => {
+  it("surfaces signing failures without leaking the updater's raw URL or path", () => {
     const failure = classifyUpdaterFailure(
-      new Error("Code signature at URL did not pass validation"),
+      new Error("Code signature at https://private.invalid/update.zip did not pass validation"),
     );
     expect(failure.kind).toBe("signature");
-    expect(failure.message).toContain("did not pass validation");
+    expect(failure.message).toContain("could not be verified");
+    expect(failure.message).not.toContain("private.invalid");
   });
 
-  it("keeps anything else as a plain message", () => {
-    expect(classifyUpdaterFailure(new Error("disk full"))).toEqual({
+  it("keeps unclassified updater detail out of the renderer bridge", () => {
+    const failure = classifyUpdaterFailure(new Error("disk full at /Users/example/private"));
+    expect(failure).toEqual({
       kind: "other",
-      message: "disk full",
+      message: "The update could not be completed. Try again later.",
     });
-    expect(classifyUpdaterFailure("")).toMatchObject({ kind: "other" });
   });
 });
 
@@ -92,7 +129,7 @@ describe("reduceUpdateState", () => {
     expect(apply([{ type: "progress", percent: 250 }]).percent).toBe(100);
   });
 
-  it("clears an offer when a later check finds nothing", () => {
+  it("clears an offer when a completed check finds nothing", () => {
     const state = apply([
       { type: "available", version: "0.2.0" },
       { type: "check-start" },
@@ -104,11 +141,10 @@ describe("reduceUpdateState", () => {
   it("goes quiet on a missing feed instead of nagging every launch", () => {
     const state = apply([
       { type: "check-start" },
-      { type: "failed", error: new Error("HttpError: 404"), userInitiated: false },
+      { type: "failed", error: new Error("HttpError: 404 Not Found"), userInitiated: false },
     ]);
     expect(state.phase).toBe("unsupported");
     expect(state.message).toContain("No desktop releases");
-    // An unsupported install stops reacting, so later launches cannot re-raise the same notice.
     expect(reduceUpdateState(state, { type: "check-start" }, NOW)).toBe(state);
     expect(shouldCheck(state, 10_000_000, 0)).toBe(false);
   });
@@ -121,9 +157,12 @@ describe("reduceUpdateState", () => {
     );
   });
 
-  it("reports a real failure either way", () => {
+  it("reports other failures with a safe generic message", () => {
     const state = apply([{ type: "failed", error: new Error("disk full"), userInitiated: false }]);
-    expect(state).toMatchObject({ phase: "error", message: "disk full" });
+    expect(state).toMatchObject({
+      phase: "error",
+      message: "The update could not be completed. Try again later.",
+    });
   });
 });
 
@@ -135,10 +174,107 @@ describe("shouldCheck", () => {
     expect(shouldCheck(idle, MIN_CHECK_INTERVAL_MS + 1_000, 1_000)).toBe(true);
   });
 
-  it("never starts a second check on top of work already running", () => {
-    const busy = apply([{ type: "check-start" }]);
-    expect(shouldCheck(busy, 10_000_000, 0)).toBe(false);
-    const downloading = apply([{ type: "download-start" }]);
-    expect(shouldCheck(downloading, 10_000_000, 0)).toBe(false);
+  it("does not replace work, an available update, or a downloaded update", () => {
+    for (const state of [
+      apply([{ type: "check-start" }]),
+      apply([{ type: "available", version: "0.2.0" }]),
+      apply([{ type: "download-start" }]),
+      apply([{ type: "downloaded", version: "0.2.0" }]),
+    ]) {
+      expect(shouldCheck(state, 10_000_000, 0)).toBe(false);
+    }
+  });
+});
+
+describe("DesktopUpdateController", () => {
+  it("locks the updater to stable, upgrade-only, signed installer behavior", async () => {
+    const fake = fakeUpdater();
+    const controller = new DesktopUpdateController(packaged, async () => fake.updater, clock);
+
+    await controller.check(false);
+
+    expect(fake.updater).toMatchObject({
+      autoDownload: false,
+      autoInstallOnAppQuit: true,
+      allowPrerelease: false,
+      allowDowngrade: false,
+      disableWebInstaller: true,
+    });
+  });
+
+  it("serializes concurrent checks across the asynchronous updater load", async () => {
+    const check = deferred();
+    const fake = fakeUpdater({ checkForUpdates: vi.fn(() => check.promise) });
+    const controller = new DesktopUpdateController(packaged, async () => fake.updater, clock);
+
+    const first = controller.check(false);
+    const second = controller.check(true);
+    await vi.waitFor(() => expect(fake.updater.checkForUpdates).toHaveBeenCalledTimes(1));
+    expect(second).toBe(first);
+    check.resolve();
+    await first;
+  });
+
+  it("automatically downloads one verified stable update and tracks progress", async () => {
+    let fake: ReturnType<typeof fakeUpdater>;
+    fake = fakeUpdater({
+      checkForUpdates: vi.fn(async () => {
+        fake.emit("checking-for-update");
+        fake.emit("update-available", { version: "0.2.0" });
+      }),
+      downloadUpdate: vi.fn(async () => {
+        fake.emit("download-progress", { percent: 48.8 });
+        fake.emit("update-downloaded", { version: "0.2.0" });
+      }),
+    });
+    const controller = new DesktopUpdateController(packaged, async () => fake.updater, clock);
+
+    await controller.check(false);
+    await vi.waitFor(() => expect(fake.updater.downloadUpdate).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(controller.state().phase).toBe("ready"));
+    expect(controller.state()).toMatchObject({
+      availableVersion: "0.2.0",
+      percent: 100,
+    });
+  });
+
+  it("joins manual downloads to the automatic download already in flight", async () => {
+    const download = deferred();
+    let fake: ReturnType<typeof fakeUpdater>;
+    fake = fakeUpdater({
+      checkForUpdates: vi.fn(async () => {
+        fake.emit("checking-for-update");
+        fake.emit("update-available", { version: "0.2.0" });
+      }),
+      downloadUpdate: vi.fn(() => download.promise),
+    });
+    const controller = new DesktopUpdateController(packaged, async () => fake.updater, clock);
+
+    await controller.check(false);
+    const first = controller.download();
+    const second = controller.download();
+    expect(second).toBe(first);
+    expect(fake.updater.downloadUpdate).toHaveBeenCalledTimes(1);
+    download.resolve();
+    await first;
+  });
+
+  it("runs installation at most once", async () => {
+    let fake: ReturnType<typeof fakeUpdater>;
+    fake = fakeUpdater({
+      checkForUpdates: vi.fn(async () => {
+        fake.emit("checking-for-update");
+        fake.emit("update-available", { version: "0.2.0" });
+      }),
+      downloadUpdate: vi.fn(async () => {
+        fake.emit("update-downloaded", { version: "0.2.0" });
+      }),
+    });
+    const controller = new DesktopUpdateController(packaged, async () => fake.updater, clock);
+    await controller.check(false);
+    await vi.waitFor(() => expect(controller.state().phase).toBe("ready"));
+
+    await Promise.all([controller.install(), controller.install()]);
+    expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -259,6 +259,31 @@ describe("DesktopUpdateController", () => {
     await first;
   });
 
+  it("does not treat later background failures as user-requested", async () => {
+    let now = 1_000;
+    let fake: ReturnType<typeof fakeUpdater>;
+    fake = fakeUpdater({
+      checkForUpdates: vi.fn(async () => {
+        fake.emit("checking-for-update");
+        if (fake.updater.checkForUpdates.mock.calls.length === 1) {
+          fake.emit("update-not-available");
+        } else {
+          fake.emit("error", new Error("getaddrinfo ENOTFOUND github.com"));
+        }
+      }),
+    });
+    const controller = new DesktopUpdateController(packaged, async () => fake.updater, {
+      now: () => now,
+      iso: () => NOW,
+    });
+
+    await controller.check(true);
+    now += MIN_CHECK_INTERVAL_MS;
+    await controller.check(false);
+
+    expect(controller.state()).toMatchObject({ phase: "idle", message: null });
+  });
+
   it("runs installation at most once", async () => {
     let fake: ReturnType<typeof fakeUpdater>;
     fake = fakeUpdater({

--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyUpdaterFailure,
+  initialUpdateState,
+  MIN_CHECK_INTERVAL_MS,
+  reduceUpdateState,
+  shouldCheck,
+  type UpdaterEvent,
+  updaterSupport,
+} from "./auto-update.js";
+
+const NOW = "2026-08-22T12:00:00.000Z";
+const packaged = { packaged: true, version: "0.1.0" };
+
+function apply(events: UpdaterEvent[], env = packaged) {
+  return events.reduce(
+    (state, event) => reduceUpdateState(state, event, NOW),
+    initialUpdateState(env),
+  );
+}
+
+describe("updaterSupport", () => {
+  it("only runs in an installed build that has not opted out", () => {
+    expect(updaterSupport(packaged).supported).toBe(true);
+    expect(updaterSupport({ packaged: false, version: "0.1.0" }).supported).toBe(false);
+    expect(updaterSupport({ ...packaged, disabled: true }).supported).toBe(false);
+  });
+
+  it("starts unsupported builds in a state that explains itself", () => {
+    const state = initialUpdateState({ packaged: false, version: "0.1.0" });
+    expect(state).toMatchObject({ phase: "unsupported", currentVersion: "0.1.0" });
+    expect(state.message).toContain("installed build");
+  });
+});
+
+describe("classifyUpdaterFailure", () => {
+  it("treats a repository with no releases as an absent feed, not a fault", () => {
+    for (const message of [
+      "HttpError: 404 Not Found",
+      "Cannot find latest.yml in the latest release",
+      "No published versions on GitHub",
+    ]) {
+      expect(classifyUpdaterFailure(new Error(message)).kind, message).toBe("no-releases");
+    }
+  });
+
+  it("stays silent when the machine is simply offline", () => {
+    for (const message of ["getaddrinfo ENOTFOUND github.com", "net::ERR_INTERNET_DISCONNECTED"]) {
+      expect(classifyUpdaterFailure(new Error(message))).toEqual({
+        kind: "offline",
+        message: null,
+      });
+    }
+  });
+
+  it("always surfaces a signing problem with the original detail", () => {
+    const failure = classifyUpdaterFailure(
+      new Error("Code signature at URL did not pass validation"),
+    );
+    expect(failure.kind).toBe("signature");
+    expect(failure.message).toContain("did not pass validation");
+  });
+
+  it("keeps anything else as a plain message", () => {
+    expect(classifyUpdaterFailure(new Error("disk full"))).toEqual({
+      kind: "other",
+      message: "disk full",
+    });
+    expect(classifyUpdaterFailure("")).toMatchObject({ kind: "other" });
+  });
+});
+
+describe("reduceUpdateState", () => {
+  it("walks from a check to a downloaded release", () => {
+    const state = apply([
+      { type: "check-start" },
+      { type: "available", version: "0.2.0" },
+      { type: "download-start" },
+      { type: "progress", percent: 42.6 },
+      { type: "downloaded", version: "0.2.0" },
+    ]);
+    expect(state).toMatchObject({
+      phase: "ready",
+      availableVersion: "0.2.0",
+      percent: 100,
+    });
+    expect(state.message).toContain("Restart Rakazo");
+  });
+
+  it("clamps progress to a percentage", () => {
+    expect(apply([{ type: "progress", percent: -5 }]).percent).toBe(0);
+    expect(apply([{ type: "progress", percent: 250 }]).percent).toBe(100);
+  });
+
+  it("clears an offer when a later check finds nothing", () => {
+    const state = apply([
+      { type: "available", version: "0.2.0" },
+      { type: "check-start" },
+      { type: "not-available" },
+    ]);
+    expect(state).toMatchObject({ phase: "idle", availableVersion: null, checkedAt: NOW });
+  });
+
+  it("goes quiet on a missing feed instead of nagging every launch", () => {
+    const state = apply([
+      { type: "check-start" },
+      { type: "failed", error: new Error("HttpError: 404"), userInitiated: false },
+    ]);
+    expect(state.phase).toBe("unsupported");
+    expect(state.message).toContain("No desktop releases");
+    // An unsupported install stops reacting, so later launches cannot re-raise the same notice.
+    expect(reduceUpdateState(state, { type: "check-start" }, NOW)).toBe(state);
+    expect(shouldCheck(state, 10_000_000, 0)).toBe(false);
+  });
+
+  it("says nothing about being offline unless the user asked", () => {
+    const offline = new Error("getaddrinfo ENOTFOUND github.com");
+    expect(apply([{ type: "failed", error: offline, userInitiated: false }]).message).toBeNull();
+    expect(apply([{ type: "failed", error: offline, userInitiated: true }]).message).toContain(
+      "Could not reach",
+    );
+  });
+
+  it("reports a real failure either way", () => {
+    const state = apply([{ type: "failed", error: new Error("disk full"), userInitiated: false }]);
+    expect(state).toMatchObject({ phase: "error", message: "disk full" });
+  });
+});
+
+describe("shouldCheck", () => {
+  it("allows the first check and then rate-limits", () => {
+    const idle = initialUpdateState(packaged);
+    expect(shouldCheck(idle, 1_000, 0)).toBe(true);
+    expect(shouldCheck(idle, 1_000, 900)).toBe(false);
+    expect(shouldCheck(idle, MIN_CHECK_INTERVAL_MS + 1_000, 1_000)).toBe(true);
+  });
+
+  it("never starts a second check on top of work already running", () => {
+    const busy = apply([{ type: "check-start" }]);
+    expect(shouldCheck(busy, 10_000_000, 0)).toBe(false);
+    const downloading = apply([{ type: "download-start" }]);
+    expect(shouldCheck(downloading, 10_000_000, 0)).toBe(false);
+  });
+});

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -1,0 +1,169 @@
+import type { DesktopUpdateState } from "@rakazo/contracts";
+
+/** Long enough that a cold launch is never competing with the update feed for bandwidth. */
+export const LAUNCH_CHECK_DELAY_MS = 8_000;
+/** A connected server drives the renderer, so a manual check cannot become a request loop. */
+export const MIN_CHECK_INTERVAL_MS = 60_000;
+
+export interface UpdaterEnvironment {
+  packaged: boolean;
+  version: string;
+  disabled?: boolean;
+}
+
+export function updaterSupport(env: UpdaterEnvironment): { supported: boolean; reason: string } {
+  if (env.disabled === true) {
+    return { supported: false, reason: "Automatic updates are turned off for this install." };
+  }
+  if (!env.packaged) {
+    return { supported: false, reason: "Automatic updates only run in an installed build." };
+  }
+  return { supported: true, reason: "" };
+}
+
+export function initialUpdateState(env: UpdaterEnvironment): DesktopUpdateState {
+  const support = updaterSupport(env);
+  return {
+    phase: support.supported ? "idle" : "unsupported",
+    currentVersion: env.version,
+    availableVersion: null,
+    percent: null,
+    message: support.supported ? null : support.reason,
+    checkedAt: null,
+  };
+}
+
+export type UpdaterFailure =
+  | { kind: "no-releases"; message: string }
+  | { kind: "offline"; message: null }
+  | { kind: "signature"; message: string }
+  | { kind: "other"; message: string };
+
+const NO_RELEASES = [
+  "404",
+  "no published versions",
+  "cannot find latest",
+  "latest.yml",
+  "latest-mac.yml",
+  "unable to find latest version",
+];
+const OFFLINE = [
+  "enotfound",
+  "econnrefused",
+  "econnreset",
+  "etimedout",
+  "eai_again",
+  "enetunreach",
+  "net::err_",
+  "getaddrinfo",
+];
+const SIGNATURE = ["code sign", "signature", "not signed", "notariz"];
+
+/**
+ * A fork usually has no published releases and a laptop is often offline, so neither is worth
+ * telling the user about more than once. Signing problems are the opposite: they always need a fix.
+ */
+export function classifyUpdaterFailure(error: unknown): UpdaterFailure {
+  const text = (error instanceof Error ? error.message : String(error)).trim();
+  const haystack = text.toLowerCase();
+  if (NO_RELEASES.some((needle) => haystack.includes(needle))) {
+    return {
+      kind: "no-releases",
+      message: "No desktop releases are published for this build yet.",
+    };
+  }
+  if (OFFLINE.some((needle) => haystack.includes(needle))) {
+    return { kind: "offline", message: null };
+  }
+  if (SIGNATURE.some((needle) => haystack.includes(needle))) {
+    return {
+      kind: "signature",
+      message: `This update could not be verified: ${text}. Reinstall Rakazo from a trusted download.`,
+    };
+  }
+  return { kind: "other", message: text === "" ? "The update check failed." : text };
+}
+
+export type UpdaterEvent =
+  | { type: "check-start" }
+  | { type: "available"; version: string }
+  | { type: "not-available" }
+  | { type: "download-start" }
+  | { type: "progress"; percent: number }
+  | { type: "downloaded"; version: string }
+  | { type: "failed"; error: unknown; userInitiated: boolean };
+
+export function reduceUpdateState(
+  state: DesktopUpdateState,
+  event: UpdaterEvent,
+  now: string,
+): DesktopUpdateState {
+  if (state.phase === "unsupported") return state;
+  switch (event.type) {
+    case "check-start":
+      return { ...state, phase: "checking", percent: null, message: null };
+    case "available":
+      return {
+        ...state,
+        phase: "available",
+        availableVersion: event.version,
+        percent: null,
+        message: null,
+        checkedAt: now,
+      };
+    case "not-available":
+      return {
+        ...state,
+        phase: "idle",
+        availableVersion: null,
+        percent: null,
+        message: null,
+        checkedAt: now,
+      };
+    case "download-start":
+      return { ...state, phase: "downloading", percent: 0, message: null };
+    case "progress":
+      return {
+        ...state,
+        phase: "downloading",
+        percent: Math.max(0, Math.min(100, Math.round(event.percent))),
+      };
+    case "downloaded":
+      return {
+        ...state,
+        phase: "ready",
+        availableVersion: event.version,
+        percent: 100,
+        message: "Restart Rakazo to finish the update.",
+      };
+    case "failed": {
+      const failure = classifyUpdaterFailure(event.error);
+      if (failure.kind === "no-releases") {
+        return {
+          ...state,
+          phase: "unsupported",
+          percent: null,
+          message: failure.message,
+          checkedAt: now,
+        };
+      }
+      if (failure.kind === "offline") {
+        return {
+          ...state,
+          phase: "idle",
+          percent: null,
+          message: event.userInitiated ? "Could not reach the update server." : null,
+          checkedAt: now,
+        };
+      }
+      return { ...state, phase: "error", percent: null, message: failure.message, checkedAt: now };
+    }
+  }
+}
+
+/** Guards both the launch check and anything the renderer asks for. */
+export function shouldCheck(state: DesktopUpdateState, now: number, lastCheck: number): boolean {
+  if (state.phase === "unsupported") return false;
+  if (state.phase === "checking" || state.phase === "downloading") return false;
+  return now - lastCheck >= MIN_CHECK_INTERVAL_MS || lastCheck === 0;
+}

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -235,6 +235,9 @@ export class DesktopUpdateController {
 
   private push(event: UpdaterEvent) {
     this.current = reduceUpdateState(this.current, event, this.clock.iso());
+    if (event.type === "not-available" || event.type === "downloaded" || event.type === "failed") {
+      this.checkWasRequested = false;
+    }
   }
 
   private async updater(): Promise<ElectronAutoUpdater | null> {

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -40,11 +40,10 @@ export type UpdaterFailure =
   | { kind: "other"; message: string };
 
 const NO_RELEASES = [
-  "404",
+  "404 not found",
   "no published versions",
-  "cannot find latest",
-  "latest.yml",
-  "latest-mac.yml",
+  "cannot find latest.yml",
+  "cannot find latest-mac.yml",
   "unable to find latest version",
 ];
 const OFFLINE = [
@@ -59,29 +58,28 @@ const OFFLINE = [
 ];
 const SIGNATURE = ["code sign", "signature", "not signed", "notariz"];
 
-/**
- * A fork usually has no published releases and a laptop is often offline, so neither is worth
- * telling the user about more than once. Signing problems are the opposite: they always need a fix.
- */
+/** Error text can contain local paths or URLs, so renderer-visible messages stay generic. */
 export function classifyUpdaterFailure(error: unknown): UpdaterFailure {
-  const text = (error instanceof Error ? error.message : String(error)).trim();
-  const haystack = text.toLowerCase();
-  if (NO_RELEASES.some((needle) => haystack.includes(needle))) {
+  const text = (error instanceof Error ? error.message : String(error)).trim().toLowerCase();
+  if (NO_RELEASES.some((needle) => text.includes(needle))) {
     return {
       kind: "no-releases",
       message: "No desktop releases are published for this build yet.",
     };
   }
-  if (OFFLINE.some((needle) => haystack.includes(needle))) {
+  if (OFFLINE.some((needle) => text.includes(needle))) {
     return { kind: "offline", message: null };
   }
-  if (SIGNATURE.some((needle) => haystack.includes(needle))) {
+  if (SIGNATURE.some((needle) => text.includes(needle))) {
     return {
       kind: "signature",
-      message: `This update could not be verified: ${text}. Reinstall Rakazo from a trusted download.`,
+      message: "This update could not be verified. Reinstall Rakazo from a trusted download.",
     };
   }
-  return { kind: "other", message: text === "" ? "The update check failed." : text };
+  return {
+    kind: "other",
+    message: "The update could not be completed. Try again later.",
+  };
 }
 
 export type UpdaterEvent =
@@ -138,12 +136,22 @@ export function reduceUpdateState(
       };
     case "failed": {
       const failure = classifyUpdaterFailure(event.error);
-      if (failure.kind === "no-releases") {
+      if (failure.kind === "no-releases" && state.phase === "checking") {
         return {
           ...state,
           phase: "unsupported",
+          availableVersion: null,
           percent: null,
           message: failure.message,
+          checkedAt: now,
+        };
+      }
+      if (failure.kind === "no-releases") {
+        return {
+          ...state,
+          phase: "error",
+          percent: null,
+          message: "The update could not be completed. Try again later.",
           checkedAt: now,
         };
       }
@@ -161,9 +169,195 @@ export function reduceUpdateState(
   }
 }
 
-/** Guards both the launch check and anything the renderer asks for. */
+/** Checks never replace an offer that is already downloading or ready to install. */
 export function shouldCheck(state: DesktopUpdateState, now: number, lastCheck: number): boolean {
-  if (state.phase === "unsupported") return false;
-  if (state.phase === "checking" || state.phase === "downloading") return false;
+  if (state.phase !== "idle" && state.phase !== "error") return false;
   return now - lastCheck >= MIN_CHECK_INTERVAL_MS || lastCheck === 0;
+}
+
+export interface ElectronAutoUpdater {
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  allowDowngrade: boolean;
+  allowPrerelease: boolean;
+  disableWebInstaller: boolean;
+  on: (event: string, listener: (payload: unknown) => void) => unknown;
+  checkForUpdates: () => Promise<unknown>;
+  downloadUpdate: () => Promise<unknown>;
+  quitAndInstall: () => void;
+}
+
+interface UpdateClock {
+  now: () => number;
+  iso: () => string;
+}
+
+const systemClock: UpdateClock = {
+  now: Date.now,
+  iso: () => new Date().toISOString(),
+};
+
+function versionFrom(payload: unknown): string | null {
+  if (typeof payload !== "object" || payload === null || !("version" in payload)) return null;
+  return typeof payload.version === "string" && payload.version.trim() !== ""
+    ? payload.version
+    : null;
+}
+
+function percentFrom(payload: unknown): number | null {
+  if (typeof payload !== "object" || payload === null || !("percent" in payload)) return null;
+  return typeof payload.percent === "number" && Number.isFinite(payload.percent)
+    ? payload.percent
+    : null;
+}
+
+/** Owns updater configuration and serializes renderer and launch-time operations. */
+export class DesktopUpdateController {
+  private current: DesktopUpdateState;
+  private lastCheck = 0;
+  private updaterPromise: Promise<ElectronAutoUpdater | null> | null = null;
+  private checkPromise: Promise<DesktopUpdateState> | null = null;
+  private downloadPromise: Promise<DesktopUpdateState> | null = null;
+  private checkWasRequested = false;
+  private installStarted = false;
+
+  constructor(
+    private readonly environment: UpdaterEnvironment,
+    private readonly loadUpdater: () => Promise<ElectronAutoUpdater>,
+    private readonly clock: UpdateClock = systemClock,
+  ) {
+    this.current = initialUpdateState(environment);
+  }
+
+  state() {
+    return this.current;
+  }
+
+  private push(event: UpdaterEvent) {
+    this.current = reduceUpdateState(this.current, event, this.clock.iso());
+  }
+
+  private async updater(): Promise<ElectronAutoUpdater | null> {
+    if (!updaterSupport(this.environment).supported) return null;
+    if (this.updaterPromise !== null) return this.updaterPromise;
+
+    const loading = this.loadUpdater()
+      .then((updater) => {
+        updater.autoDownload = false;
+        updater.autoInstallOnAppQuit = true;
+        updater.allowPrerelease = false;
+        updater.allowDowngrade = false;
+        updater.disableWebInstaller = true;
+        updater.on("checking-for-update", () => this.push({ type: "check-start" }));
+        updater.on("update-available", (payload) => {
+          const version = versionFrom(payload);
+          if (version === null) {
+            this.push({
+              type: "failed",
+              error: new Error("The update feed did not include a version."),
+              userInitiated: this.checkWasRequested,
+            });
+            return;
+          }
+          this.push({ type: "available", version });
+          void this.download();
+        });
+        updater.on("update-not-available", () => this.push({ type: "not-available" }));
+        updater.on("download-progress", (payload) => {
+          const percent = percentFrom(payload);
+          if (percent !== null) this.push({ type: "progress", percent });
+        });
+        updater.on("update-downloaded", (payload) => {
+          const version = versionFrom(payload);
+          if (version !== null) {
+            this.push({ type: "downloaded", version });
+          } else {
+            this.push({
+              type: "failed",
+              error: new Error("The downloaded update did not include a version."),
+              userInitiated: this.checkWasRequested,
+            });
+          }
+        });
+        updater.on("error", (error) =>
+          this.push({ type: "failed", error, userInitiated: this.checkWasRequested }),
+        );
+        return updater;
+      })
+      .catch((error: unknown) => {
+        this.push({ type: "failed", error, userInitiated: this.checkWasRequested });
+        if (this.updaterPromise === loading) this.updaterPromise = null;
+        return null;
+      });
+    this.updaterPromise = loading;
+    return loading;
+  }
+
+  check(userInitiated: boolean) {
+    if (userInitiated) this.checkWasRequested = true;
+    if (this.checkPromise !== null) return this.checkPromise;
+    const checking = this.runCheck().finally(() => {
+      if (this.checkPromise === checking) this.checkPromise = null;
+    });
+    this.checkPromise = checking;
+    return checking;
+  }
+
+  private async runCheck() {
+    let now = this.clock.now();
+    if (!shouldCheck(this.current, now, this.lastCheck)) return this.current;
+    const updater = await this.updater();
+    if (updater === null) return this.current;
+    now = this.clock.now();
+    if (!shouldCheck(this.current, now, this.lastCheck)) return this.current;
+    this.lastCheck = now;
+    try {
+      await updater.checkForUpdates();
+    } catch (error) {
+      if (this.current.phase === "idle" || this.current.phase === "checking") {
+        this.push({ type: "failed", error, userInitiated: this.checkWasRequested });
+      }
+    }
+    return this.current;
+  }
+
+  download() {
+    if (this.downloadPromise !== null) return this.downloadPromise;
+    const downloading = this.runDownload().finally(() => {
+      if (this.downloadPromise === downloading) this.downloadPromise = null;
+    });
+    this.downloadPromise = downloading;
+    return downloading;
+  }
+
+  private async runDownload() {
+    if (this.current.phase !== "available") return this.current;
+    const updater = await this.updater();
+    if (updater === null || this.current.phase !== "available") return this.current;
+    this.push({ type: "download-start" });
+    try {
+      await updater.downloadUpdate();
+    } catch (error) {
+      if (this.state().phase === "downloading") {
+        this.push({ type: "failed", error, userInitiated: this.checkWasRequested });
+      }
+    }
+    return this.current;
+  }
+
+  async install() {
+    if (this.installStarted || this.current.phase !== "ready") return this.current;
+    const updater = await this.updater();
+    if (updater === null || this.installStarted || this.current.phase !== "ready") {
+      return this.current;
+    }
+    this.installStarted = true;
+    try {
+      updater.quitAndInstall();
+    } catch (error) {
+      this.installStarted = false;
+      this.push({ type: "failed", error, userInitiated: true });
+    }
+    return this.current;
+  }
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,7 +1,16 @@
 import { existsSync } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
+import type { DesktopReachability, DesktopSetup, DesktopUpdateState } from "@rakazo/contracts";
 import { app, BrowserWindow, ipcMain, net, session } from "electron";
+import {
+  initialUpdateState,
+  LAUNCH_CHECK_DELAY_MS,
+  reduceUpdateState,
+  shouldCheck,
+  type UpdaterEvent,
+  updaterSupport,
+} from "./auto-update.js";
 import {
   bundledRendererCandidates,
   contentType,
@@ -18,6 +27,15 @@ let quitting = false;
 let warmWindowTimer: NodeJS.Timeout | undefined;
 const WARM_WINDOW_TTL_MS = warmWindowTtlMs(process.env.RAKAZO_WARM_WINDOW_TTL_MS);
 
+const updaterEnvironment = {
+  packaged: app.isPackaged,
+  version: app.getVersion(),
+  disabled: process.env.RAKAZO_DISABLE_AUTO_UPDATE === "1",
+};
+let updateState: DesktopUpdateState = initialUpdateState(updaterEnvironment);
+let lastUpdateCheck = 0;
+let updaterWired = false;
+
 markOnce("rk:main:module-evaluated");
 if (PERFORMANCE_USER_DATA) {
   app.setPath("userData", PERFORMANCE_USER_DATA);
@@ -32,6 +50,95 @@ function markOnce(name: string) {
 
 function windowFrom(event: Electron.IpcMainInvokeEvent) {
   return BrowserWindow.fromWebContents(event.sender);
+}
+
+interface ElectronAutoUpdater {
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+  on: (event: string, listener: (payload: never) => void) => unknown;
+  checkForUpdates: () => Promise<unknown>;
+  downloadUpdate: () => Promise<unknown>;
+  quitAndInstall: () => void;
+}
+
+/** The updater reports failures on an event, not a rejection, so the caller's intent is kept here. */
+let updateCheckWasRequested = false;
+
+function pushUpdateEvent(event: UpdaterEvent) {
+  updateState = reduceUpdateState(updateState, event, new Date().toISOString());
+}
+
+/**
+ * Loaded on demand: an unpackaged run has no `app-update.yml`, and importing the updater there
+ * only produces a failure the developer cannot act on.
+ */
+async function loadAutoUpdater(): Promise<ElectronAutoUpdater | null> {
+  if (!updaterSupport(updaterEnvironment).supported) return null;
+  let updater: ElectronAutoUpdater;
+  try {
+    const module = await import("electron-updater");
+    updater = (module.default ?? module).autoUpdater as unknown as ElectronAutoUpdater;
+  } catch (error) {
+    pushUpdateEvent({ type: "failed", error, userInitiated: false });
+    return null;
+  }
+  if (!updaterWired) {
+    updaterWired = true;
+    updater.autoDownload = false;
+    updater.autoInstallOnAppQuit = true;
+    updater.on("checking-for-update", () => pushUpdateEvent({ type: "check-start" }));
+    updater.on("update-available", (info: { version: string }) =>
+      pushUpdateEvent({ type: "available", version: info.version }),
+    );
+    updater.on("update-not-available", () => pushUpdateEvent({ type: "not-available" }));
+    updater.on("download-progress", (progress: { percent: number }) =>
+      pushUpdateEvent({ type: "progress", percent: progress.percent }),
+    );
+    updater.on("update-downloaded", (info: { version: string }) =>
+      pushUpdateEvent({ type: "downloaded", version: info.version }),
+    );
+    updater.on("error", (error: Error) =>
+      pushUpdateEvent({ type: "failed", error, userInitiated: updateCheckWasRequested }),
+    );
+  }
+  return updater;
+}
+
+async function checkForDesktopUpdate(userInitiated: boolean) {
+  const now = Date.now();
+  if (!shouldCheck(updateState, now, lastUpdateCheck)) return updateState;
+  const updater = await loadAutoUpdater();
+  if (updater === null) return updateState;
+  lastUpdateCheck = now;
+  updateCheckWasRequested = userInitiated;
+  try {
+    await updater.checkForUpdates();
+  } catch (error) {
+    pushUpdateEvent({ type: "failed", error, userInitiated });
+  }
+  return updateState;
+}
+
+async function downloadDesktopUpdate() {
+  if (updateState.phase !== "available") return updateState;
+  const updater = await loadAutoUpdater();
+  if (updater === null) return updateState;
+  pushUpdateEvent({ type: "download-start" });
+  try {
+    await updater.downloadUpdate();
+  } catch (error) {
+    pushUpdateEvent({ type: "failed", error, userInitiated: true });
+  }
+  return updateState;
+}
+
+async function installDesktopUpdate() {
+  if (updateState.phase !== "ready") return updateState;
+  const updater = await loadAutoUpdater();
+  if (updater === null) return updateState;
+  quitting = true;
+  updater.quitAndInstall();
+  return updateState;
 }
 
 function developmentIcon() {
@@ -166,7 +273,49 @@ app.whenReady().then(async () => {
       fullScreen: win?.isFullScreen() ?? false,
     };
   });
-  createWindow();
+  ipcMain.handle("desktop.update.state", () => updateState);
+  ipcMain.handle("desktop.update.check", () => checkForDesktopUpdate(true));
+  ipcMain.handle("desktop.update.download", () => downloadDesktopUpdate());
+  ipcMain.handle("desktop.update.install", () => installDesktopUpdate());
+  ipcMain.handle("desktop.setup.state", (event) => {
+    if (!fromSetupWindow(event)) return null;
+    return {
+      defaultLocalUrl: DEFAULT_LOCAL_WEB_URL,
+      platform: process.platform,
+      saved: currentSetup,
+    };
+  });
+
+  ipcMain.handle("desktop.setup.test", async (event, url: unknown) => {
+    if (!fromSetupWindow(event)) return { ok: false, error: "Setup is not active." };
+    if (typeof url !== "string") return { ok: false, error: "Enter a server address." };
+    return probeServer(url);
+  });
+
+  ipcMain.handle("desktop.setup.save", async (event, payload: unknown) => {
+    if (!fromSetupWindow(event)) return { ok: false, error: "Setup is not active." };
+    const setup = parseSetupInput(payload);
+    if (setup === null) return { ok: false, error: "Enter a valid http:// or https:// address." };
+
+    await writeSetup(userDataDir, setup);
+    currentSetup = setup;
+    // Answer the setup window before tearing it down, otherwise the reply is lost.
+    setImmediate(() => void openApp(setup.serverUrl));
+    return { ok: true };
+  });
+
+  ipcMain.handle("desktop.setup.quit", (event) => {
+    if (fromSetupWindow(event)) app.quit();
+  });
+
+  if (currentTargetUrl === null) {
+    createSetupWindow();
+  } else {
+    await installBundledRenderer(currentTargetUrl);
+    createWindow(currentTargetUrl);
+    setTimeout(() => void checkForDesktopUpdate(false), LAUNCH_CHECK_DELAY_MS).unref();
+  }
+
   app.on("activate", () => {
     if (!mainWindow || mainWindow.isDestroyed()) createWindow();
     else {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,15 +1,11 @@
 import { existsSync } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import type { DesktopReachability, DesktopSetup, DesktopUpdateState } from "@rakazo/contracts";
 import { app, BrowserWindow, ipcMain, net, session } from "electron";
 import {
-  initialUpdateState,
+  DesktopUpdateController,
+  type ElectronAutoUpdater,
   LAUNCH_CHECK_DELAY_MS,
-  reduceUpdateState,
-  shouldCheck,
-  type UpdaterEvent,
-  updaterSupport,
 } from "./auto-update.js";
 import {
   bundledRendererCandidates,
@@ -32,9 +28,11 @@ const updaterEnvironment = {
   version: app.getVersion(),
   disabled: process.env.RAKAZO_DISABLE_AUTO_UPDATE === "1",
 };
-let updateState: DesktopUpdateState = initialUpdateState(updaterEnvironment);
-let lastUpdateCheck = 0;
-let updaterWired = false;
+const desktopUpdater = new DesktopUpdateController(updaterEnvironment, async () => {
+  const module = await import("electron-updater");
+  return (module.default ?? module).autoUpdater as unknown as ElectronAutoUpdater;
+});
+let launchUpdateCheckScheduled = false;
 
 markOnce("rk:main:module-evaluated");
 if (PERFORMANCE_USER_DATA) {
@@ -52,93 +50,8 @@ function windowFrom(event: Electron.IpcMainInvokeEvent) {
   return BrowserWindow.fromWebContents(event.sender);
 }
 
-interface ElectronAutoUpdater {
-  autoDownload: boolean;
-  autoInstallOnAppQuit: boolean;
-  on: (event: string, listener: (payload: never) => void) => unknown;
-  checkForUpdates: () => Promise<unknown>;
-  downloadUpdate: () => Promise<unknown>;
-  quitAndInstall: () => void;
-}
-
-/** The updater reports failures on an event, not a rejection, so the caller's intent is kept here. */
-let updateCheckWasRequested = false;
-
-function pushUpdateEvent(event: UpdaterEvent) {
-  updateState = reduceUpdateState(updateState, event, new Date().toISOString());
-}
-
-/**
- * Loaded on demand: an unpackaged run has no `app-update.yml`, and importing the updater there
- * only produces a failure the developer cannot act on.
- */
-async function loadAutoUpdater(): Promise<ElectronAutoUpdater | null> {
-  if (!updaterSupport(updaterEnvironment).supported) return null;
-  let updater: ElectronAutoUpdater;
-  try {
-    const module = await import("electron-updater");
-    updater = (module.default ?? module).autoUpdater as unknown as ElectronAutoUpdater;
-  } catch (error) {
-    pushUpdateEvent({ type: "failed", error, userInitiated: false });
-    return null;
-  }
-  if (!updaterWired) {
-    updaterWired = true;
-    updater.autoDownload = false;
-    updater.autoInstallOnAppQuit = true;
-    updater.on("checking-for-update", () => pushUpdateEvent({ type: "check-start" }));
-    updater.on("update-available", (info: { version: string }) =>
-      pushUpdateEvent({ type: "available", version: info.version }),
-    );
-    updater.on("update-not-available", () => pushUpdateEvent({ type: "not-available" }));
-    updater.on("download-progress", (progress: { percent: number }) =>
-      pushUpdateEvent({ type: "progress", percent: progress.percent }),
-    );
-    updater.on("update-downloaded", (info: { version: string }) =>
-      pushUpdateEvent({ type: "downloaded", version: info.version }),
-    );
-    updater.on("error", (error: Error) =>
-      pushUpdateEvent({ type: "failed", error, userInitiated: updateCheckWasRequested }),
-    );
-  }
-  return updater;
-}
-
-async function checkForDesktopUpdate(userInitiated: boolean) {
-  const now = Date.now();
-  if (!shouldCheck(updateState, now, lastUpdateCheck)) return updateState;
-  const updater = await loadAutoUpdater();
-  if (updater === null) return updateState;
-  lastUpdateCheck = now;
-  updateCheckWasRequested = userInitiated;
-  try {
-    await updater.checkForUpdates();
-  } catch (error) {
-    pushUpdateEvent({ type: "failed", error, userInitiated });
-  }
-  return updateState;
-}
-
-async function downloadDesktopUpdate() {
-  if (updateState.phase !== "available") return updateState;
-  const updater = await loadAutoUpdater();
-  if (updater === null) return updateState;
-  pushUpdateEvent({ type: "download-start" });
-  try {
-    await updater.downloadUpdate();
-  } catch (error) {
-    pushUpdateEvent({ type: "failed", error, userInitiated: true });
-  }
-  return updateState;
-}
-
-async function installDesktopUpdate() {
-  if (updateState.phase !== "ready") return updateState;
-  const updater = await loadAutoUpdater();
-  if (updater === null) return updateState;
-  quitting = true;
-  updater.quitAndInstall();
-  return updateState;
+function fromMainWindow(event: Electron.IpcMainInvokeEvent) {
+  return mainWindow !== null && windowFrom(event) === mainWindow;
 }
 
 function developmentIcon() {
@@ -191,6 +104,10 @@ function createWindow() {
     () => markOnce("rk:main:load-url-resolved"),
     () => markOnce("rk:main:load-url-rejected"),
   );
+  if (!launchUpdateCheckScheduled) {
+    launchUpdateCheckScheduled = true;
+    setTimeout(() => void desktopUpdater.check(false), LAUNCH_CHECK_DELAY_MS).unref();
+  }
   return win;
 }
 
@@ -273,48 +190,23 @@ app.whenReady().then(async () => {
       fullScreen: win?.isFullScreen() ?? false,
     };
   });
-  ipcMain.handle("desktop.update.state", () => updateState);
-  ipcMain.handle("desktop.update.check", () => checkForDesktopUpdate(true));
-  ipcMain.handle("desktop.update.download", () => downloadDesktopUpdate());
-  ipcMain.handle("desktop.update.install", () => installDesktopUpdate());
-  ipcMain.handle("desktop.setup.state", (event) => {
-    if (!fromSetupWindow(event)) return null;
-    return {
-      defaultLocalUrl: DEFAULT_LOCAL_WEB_URL,
-      platform: process.platform,
-      saved: currentSetup,
-    };
+  ipcMain.handle("desktop.update.state", () => desktopUpdater.state());
+  ipcMain.handle("desktop.update.check", (event) =>
+    fromMainWindow(event) ? desktopUpdater.check(true) : desktopUpdater.state(),
+  );
+  ipcMain.handle("desktop.update.download", (event) =>
+    fromMainWindow(event) ? desktopUpdater.download() : desktopUpdater.state(),
+  );
+  ipcMain.handle("desktop.update.install", async (event) => {
+    if (!fromMainWindow(event) || desktopUpdater.state().phase !== "ready") {
+      return desktopUpdater.state();
+    }
+    quitting = true;
+    const state = await desktopUpdater.install();
+    if (state.phase === "error") quitting = false;
+    return state;
   });
-
-  ipcMain.handle("desktop.setup.test", async (event, url: unknown) => {
-    if (!fromSetupWindow(event)) return { ok: false, error: "Setup is not active." };
-    if (typeof url !== "string") return { ok: false, error: "Enter a server address." };
-    return probeServer(url);
-  });
-
-  ipcMain.handle("desktop.setup.save", async (event, payload: unknown) => {
-    if (!fromSetupWindow(event)) return { ok: false, error: "Setup is not active." };
-    const setup = parseSetupInput(payload);
-    if (setup === null) return { ok: false, error: "Enter a valid http:// or https:// address." };
-
-    await writeSetup(userDataDir, setup);
-    currentSetup = setup;
-    // Answer the setup window before tearing it down, otherwise the reply is lost.
-    setImmediate(() => void openApp(setup.serverUrl));
-    return { ok: true };
-  });
-
-  ipcMain.handle("desktop.setup.quit", (event) => {
-    if (fromSetupWindow(event)) app.quit();
-  });
-
-  if (currentTargetUrl === null) {
-    createSetupWindow();
-  } else {
-    await installBundledRenderer(currentTargetUrl);
-    createWindow(currentTargetUrl);
-    setTimeout(() => void checkForDesktopUpdate(false), LAUNCH_CHECK_DELAY_MS).unref();
-  }
+  createWindow();
 
   app.on("activate", () => {
     if (!mainWindow || mainWindow.isDestroyed()) createWindow();

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -8,4 +8,10 @@ contextBridge.exposeInMainWorld("rakazoDesktop", {
     toggleMaximize: () => ipcRenderer.invoke("desktop.window.toggleMaximize"),
     state: () => ipcRenderer.invoke("desktop.window.state"),
   },
+  update: {
+    state: () => ipcRenderer.invoke("desktop.update.state"),
+    check: () => ipcRenderer.invoke("desktop.update.check"),
+    download: () => ipcRenderer.invoke("desktop.update.download"),
+    install: () => ipcRenderer.invoke("desktop.update.install"),
+  },
 });

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -5,18 +5,8 @@ import type { RakazoDesktop } from "@rakazo/contracts";
 import { describe, expect, it, vi } from "vitest";
 
 describe("desktop preload bridge", () => {
-  it("exposes only the platform and the four window operations", async () => {
-    const invoke = vi.fn(async (channel: string) => ({ channel }));
-    const exposeInMainWorld = vi.fn();
-    const source = readFileSync(path.join(import.meta.dirname, "preload.cjs"), "utf8");
-
-    vm.runInNewContext(source, {
-      process: { platform: "linux" },
-      require(moduleName: string) {
-        if (moduleName !== "electron") throw new Error(`Unexpected preload import: ${moduleName}`);
-        return { contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke } };
-      },
-    });
+  it("exposes only the platform, the four window operations, and the updater", async () => {
+    const { invoke, exposeInMainWorld } = runPreload("preload.cjs");
 
     expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
     const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoDesktop];
@@ -28,16 +18,53 @@ describe("desktop preload bridge", () => {
       "state",
       "toggleMaximize",
     ]);
+    expect(Object.keys(bridge.update).sort()).toEqual(["check", "download", "install", "state"]);
 
     await bridge.window.close();
     await bridge.window.minimize();
     await bridge.window.toggleMaximize();
     await bridge.window.state();
+    await bridge.update.state();
+    await bridge.update.check();
+    await bridge.update.download();
+    await bridge.update.install();
     expect(invoke.mock.calls.map(([channel]) => channel)).toEqual([
       "desktop.window.close",
       "desktop.window.minimize",
       "desktop.window.toggleMaximize",
       "desktop.window.state",
+      "desktop.update.state",
+      "desktop.update.check",
+      "desktop.update.download",
+      "desktop.update.install",
+    ]);
+  });
+
+  it("keeps setup off the app bridge so a connected server cannot re-point the app", () => {
+    const { exposeInMainWorld } = runPreload("preload.cjs");
+    const [, bridge] = exposeInMainWorld.mock.calls[0] as [string, Record<string, unknown>];
+    expect(Object.keys(bridge).sort()).toEqual(["platform", "update", "window"]);
+  });
+});
+
+describe("setup preload bridge", () => {
+  it("exposes only the first-run setup operations", async () => {
+    const { invoke, exposeInMainWorld } = runPreload("setup-preload.cjs");
+
+    expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
+    const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoSetup];
+    expect(globalName).toBe("rakazoSetup");
+    expect(Object.keys(bridge).sort()).toEqual(["quit", "save", "state", "test"]);
+
+    await bridge.state();
+    await bridge.test("http://127.0.0.1:5173");
+    await bridge.save({ mode: "local", serverUrl: "http://127.0.0.1:5173" });
+    await bridge.quit();
+    expect(invoke.mock.calls.map(([channel]) => channel)).toEqual([
+      "desktop.setup.state",
+      "desktop.setup.test",
+      "desktop.setup.save",
+      "desktop.setup.quit",
     ]);
   });
 });

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -4,6 +4,22 @@ import vm from "node:vm";
 import type { RakazoDesktop } from "@rakazo/contracts";
 import { describe, expect, it, vi } from "vitest";
 
+function runPreload(file: string) {
+  const invoke = vi.fn(async (channel: string) => ({ channel }));
+  const exposeInMainWorld = vi.fn();
+  const source = readFileSync(path.join(import.meta.dirname, file), "utf8");
+
+  vm.runInNewContext(source, {
+    process: { platform: "linux" },
+    require(moduleName: string) {
+      if (moduleName !== "electron") throw new Error(`Unexpected preload import: ${moduleName}`);
+      return { contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke } };
+    },
+  });
+
+  return { invoke, exposeInMainWorld };
+}
+
 describe("desktop preload bridge", () => {
   it("exposes only the platform, the four window operations, and the updater", async () => {
     const { invoke, exposeInMainWorld } = runPreload("preload.cjs");
@@ -37,34 +53,6 @@ describe("desktop preload bridge", () => {
       "desktop.update.check",
       "desktop.update.download",
       "desktop.update.install",
-    ]);
-  });
-
-  it("keeps setup off the app bridge so a connected server cannot re-point the app", () => {
-    const { exposeInMainWorld } = runPreload("preload.cjs");
-    const [, bridge] = exposeInMainWorld.mock.calls[0] as [string, Record<string, unknown>];
-    expect(Object.keys(bridge).sort()).toEqual(["platform", "update", "window"]);
-  });
-});
-
-describe("setup preload bridge", () => {
-  it("exposes only the first-run setup operations", async () => {
-    const { invoke, exposeInMainWorld } = runPreload("setup-preload.cjs");
-
-    expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
-    const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoSetup];
-    expect(globalName).toBe("rakazoSetup");
-    expect(Object.keys(bridge).sort()).toEqual(["quit", "save", "state", "test"]);
-
-    await bridge.state();
-    await bridge.test("http://127.0.0.1:5173");
-    await bridge.save({ mode: "local", serverUrl: "http://127.0.0.1:5173" });
-    await bridge.quit();
-    expect(invoke.mock.calls.map(([channel]) => channel)).toEqual([
-      "desktop.setup.state",
-      "desktop.setup.test",
-      "desktop.setup.save",
-      "desktop.setup.quit",
     ]);
   });
 });

--- a/apps/desktop/src/release-workflow.test.ts
+++ b/apps/desktop/src/release-workflow.test.ts
@@ -30,11 +30,15 @@ describe("desktop release workflow", () => {
     expect(workflow).toContain("attestations: write");
     expect(workflow).toContain("actions/attest-build-provenance@");
     expect(workflow).not.toContain("--publish always");
+    expect(workflow).toContain("DESKTOP_MAC_CSC_LINK");
+    expect(workflow).toContain("DESKTOP_WIN_CSC_LINK");
+    expect(workflow).not.toMatch(/secrets\.DESKTOP_CSC_(?:LINK|KEY_PASSWORD)/);
   });
 
   it("publishes only a complete stable, upgrade-only feed", () => {
     expect(workflow).toContain("^v([0-9]+)\\.([0-9]+)\\.([0-9]+)$");
     expect(workflow).toContain("must be newer than published release");
+    expect(workflow).toContain("group: release-desktop-stable");
     expect(workflow).toContain("latest.yml");
     expect(workflow).toContain("latest-mac.yml");
     expect(workflow).toContain("latest-linux.yml");

--- a/apps/desktop/src/release-workflow.test.ts
+++ b/apps/desktop/src/release-workflow.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  path.resolve(import.meta.dirname, "../../../.github/workflows/release-desktop.yml"),
+  "utf8",
+);
+
+describe("desktop release workflow", () => {
+  it("cannot execute contributor pull-request code with release credentials", () => {
+    expect(workflow).not.toMatch(/^\s*pull_request:/m);
+    expect(workflow).toContain("permissions:\n  contents: read");
+    expect(workflow.match(/persist-credentials: false/g)).toHaveLength(3);
+  });
+
+  it("pins every third-party action to an immutable commit", () => {
+    const actionReferences = [...workflow.matchAll(/uses:\s+([^\s#]+)/g)].map((match) => match[1]);
+    expect(actionReferences.length).toBeGreaterThan(0);
+    for (const reference of actionReferences) {
+      expect(reference, reference).toMatch(/@[0-9a-f]{40}$/);
+    }
+  });
+
+  it("requires signed platform builds before a single publication job", () => {
+    expect(workflow).toContain("-c.forceCodeSigning=true");
+    expect(workflow).toContain("codesign --verify --deep --strict");
+    expect(workflow).toContain("Get-AuthenticodeSignature");
+    expect(workflow).toContain("needs: [validate, build]");
+    expect(workflow).toContain("attestations: write");
+    expect(workflow).toContain("actions/attest-build-provenance@");
+    expect(workflow).not.toContain("--publish always");
+  });
+
+  it("publishes only a complete stable, upgrade-only feed", () => {
+    expect(workflow).toContain("^v([0-9]+)\\.([0-9]+)\\.([0-9]+)$");
+    expect(workflow).toContain("must be newer than published release");
+    expect(workflow).toContain("latest.yml");
+    expect(workflow).toContain("latest-mac.yml");
+    expect(workflow).toContain("latest-linux.yml");
+    expect(workflow).toContain("--draft --generate-notes");
+    expect(workflow).toContain("--draft=false --latest");
+  });
+});

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -5,6 +5,14 @@ import { describe, expect, it } from "vitest";
 import { type RakazoDesktop, windowChromeKind } from "./desktop.js";
 
 function desktop(platform: string): RakazoDesktop {
+  const updateState = {
+    phase: "unsupported" as const,
+    currentVersion: "0.1.0",
+    availableVersion: null,
+    percent: null,
+    message: "Automatic updates only run in an installed build.",
+    checkedAt: null,
+  };
   return {
     platform,
     window: {
@@ -12,6 +20,12 @@ function desktop(platform: string): RakazoDesktop {
       minimize: async () => undefined,
       toggleMaximize: async () => undefined,
       state: async () => ({ minimized: false, maximized: false, fullScreen: false }),
+    },
+    update: {
+      state: async () => updateState,
+      check: async () => updateState,
+      download: async () => updateState,
+      install: async () => updateState,
     },
   };
 }

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -1,3 +1,35 @@
+/**
+ * `unsupported` covers an unpackaged build and a repository with no published releases, which is
+ * the normal state for a fork. It is not an error the user needs to act on.
+ */
+export type DesktopUpdatePhase =
+  | "idle"
+  | "checking"
+  | "available"
+  | "downloading"
+  | "ready"
+  | "unsupported"
+  | "error";
+
+export interface DesktopUpdateState {
+  phase: DesktopUpdatePhase;
+  /** The installed desktop release, which can drift from the server this app points at. */
+  currentVersion: string;
+  availableVersion: string | null;
+  /** Download progress 0-100, only while `downloading`. */
+  percent: number | null;
+  message: string | null;
+  checkedAt: string | null;
+}
+
+export interface RakazoDesktopUpdate {
+  state: () => Promise<DesktopUpdateState>;
+  check: () => Promise<DesktopUpdateState>;
+  download: () => Promise<DesktopUpdateState>;
+  /** Quits and relaunches into the downloaded release; only useful once `phase` is `ready`. */
+  install: () => Promise<DesktopUpdateState>;
+}
+
 export interface RakazoDesktop {
   platform: string;
   window: {
@@ -6,4 +38,5 @@ export interface RakazoDesktop {
     toggleMaximize: () => Promise<void>;
     state: () => Promise<{ minimized: boolean; maximized: boolean; fullScreen: boolean }>;
   };
+  update: RakazoDesktopUpdate;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@rakazo/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
+      electron-updater:
+        specifier: ^6.8.9
+        version: 6.8.9
     devDependencies:
       '@playwright/test':
         specifier: ^1.55.0
@@ -4870,6 +4873,9 @@ packages:
   electron-to-chromium@1.5.405:
     resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
@@ -6074,6 +6080,13 @@ packages:
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
@@ -7795,6 +7808,9 @@ packages:
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -13835,6 +13851,19 @@ snapshots:
 
   electron-to-chromium@1.5.405: {}
 
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.3.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
@@ -15151,6 +15180,10 @@ snapshots:
   lodash.camelcase@4.3.0: {}
 
   lodash.debounce@4.0.8: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.throttle@4.1.1: {}
 
@@ -17368,6 +17401,8 @@ snapshots:
       semver: 5.7.2
 
   tiny-inflate@1.0.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Summary
- Electron auto-update and the signed `release-desktop` workflow.
- Independent onto `elie222:main` for review. Landing order remains 1→13.

## Test plan
- [ ] `auto-update` unit tests and preload contract
- [ ] Smoke test still exposes the desktop bridge
