### PR TITLE
Add Markdown artifact previews

### DIFF
--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -3,6 +3,10 @@ import { abortableDelay, attachmentsForBot } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Alert, AppState, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import {
+  MarkdownArtifactPreview,
+  type MarkdownArtifactPreviewTarget,
+} from "../components/markdown-artifact-preview";
 import { NativeSymbol } from "../components/native-symbol";
 import {
   applyMobileThreadEvent,
@@ -56,6 +60,9 @@ export default function Thread() {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const [markdownPreview, setMarkdownPreview] = useState<MarkdownArtifactPreviewTarget | null>(
+    null,
+  );
   const activePendingAttachments = attachmentsForBot(pendingAttachments, botId);
 
   useLayoutEffect(() => {
@@ -426,6 +433,7 @@ export default function Thread() {
               onOpenBot={(id, botName) =>
                 router.push({ pathname: "/thread", params: { botId: id, name: botName } })
               }
+              onPreviewMarkdown={setMarkdownPreview}
               onSpeak={
                 message.role === "bot"
                   ? () =>
@@ -543,6 +551,13 @@ export default function Thread() {
           <Text style={{ color: "#C9C9CE" }}>Open computer →</Text>
         </Pressable>
       </Link>
+      {markdownPreview ? (
+        <MarkdownArtifactPreview
+          botId={botId ?? ""}
+          target={markdownPreview}
+          onClose={() => setMarkdownPreview(null)}
+        />
+      ) : null}
     </View>
   );
 }
@@ -564,11 +579,13 @@ function MessageBubble({
   botId,
   message,
   onOpenBot,
+  onPreviewMarkdown,
   onSpeak,
 }: {
   botId: string;
   message: MobileMessage;
   onOpenBot: (botId: string, name: string) => void;
+  onPreviewMarkdown: (target: MarkdownArtifactPreviewTarget) => void;
   onSpeak?: () => void;
 }) {
   const special = message.blocks.find(
@@ -708,17 +725,23 @@ function MessageBubble({
               key={`${attachment.artifactId ?? attachment.name ?? "file"}-${index}`}
               onPress={() =>
                 attachment.artifactId
-                  ? void openMobileArtifact(
-                      botId,
-                      attachment.artifactId,
-                      attachment.name ?? "File",
-                      attachment.mimeType ?? "text/plain",
-                    ).catch((err) =>
-                      Alert.alert(
-                        "Could not open file",
-                        err instanceof Error ? err.message : "Try again.",
-                      ),
-                    )
+                  ? attachment.mimeType === "text/markdown"
+                    ? onPreviewMarkdown({
+                        artifactId: attachment.artifactId,
+                        name: attachment.name ?? "Markdown file",
+                        mimeType: attachment.mimeType,
+                      })
+                    : void openMobileArtifact(
+                        botId,
+                        attachment.artifactId,
+                        attachment.name ?? "File",
+                        attachment.mimeType ?? "text/plain",
+                      ).catch((err) =>
+                        Alert.alert(
+                          "Could not open file",
+                          err instanceof Error ? err.message : "Try again.",
+                        ),
+                      )
                   : undefined
               }
             >

--- a/apps/mobile/components/markdown-artifact-preview.tsx
+++ b/apps/mobile/components/markdown-artifact-preview.tsx
@@ -1,0 +1,117 @@
+import { ChatMarkdown } from "@rakazo/chat-ui/native";
+import { useEffect, useState } from "react";
+import { Alert, Modal, Pressable, SafeAreaView, ScrollView, Text, View } from "react-native";
+import { openMobileArtifact, readMobileArtifactText } from "../lib/artifact-open";
+import { NativeSymbol } from "./native-symbol";
+
+export type MarkdownArtifactPreviewTarget = {
+  artifactId: string;
+  name: string;
+  mimeType: string;
+};
+
+export function MarkdownArtifactPreview({
+  botId,
+  target,
+  onClose,
+}: {
+  botId: string;
+  target: MarkdownArtifactPreviewTarget;
+  onClose: () => void;
+}) {
+  const [state, setState] = useState<
+    | { status: "loading" }
+    | { status: "ready"; markdown: string }
+    | { status: "error"; message: string }
+  >({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    void readMobileArtifactText(botId, target.artifactId, target.mimeType)
+      .then((markdown) => {
+        if (!cancelled) setState({ status: "ready", markdown });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setState({
+          status: "error",
+          message: error instanceof Error ? error.message : "Could not load this file.",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [botId, target.artifactId, target.mimeType]);
+
+  return (
+    <Modal animationType="fade" presentationStyle="fullScreen" onRequestClose={onClose}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: "#0D0D0F" }}>
+        <View
+          style={{
+            height: 54,
+            flexDirection: "row",
+            alignItems: "center",
+            borderBottomWidth: 1,
+            borderBottomColor: "#27272B",
+            paddingHorizontal: 12,
+          }}
+        >
+          <Text
+            numberOfLines={1}
+            style={{ flex: 1, color: "#E7E7E9", fontSize: 15, fontWeight: "500" }}
+          >
+            {target.name}
+          </Text>
+          <Pressable
+            accessibilityLabel={`Share ${target.name}`}
+            hitSlop={8}
+            onPress={() =>
+              void openMobileArtifact(botId, target.artifactId, target.name, target.mimeType).catch(
+                (error) =>
+                  Alert.alert(
+                    "Could not share file",
+                    error instanceof Error ? error.message : "Try again.",
+                  ),
+              )
+            }
+            style={{ padding: 10 }}
+          >
+            <NativeSymbol
+              ios="square.and.arrow.up"
+              android="share-social-outline"
+              size={19}
+              color="#A8A8AD"
+            />
+          </Pressable>
+          <Pressable
+            accessibilityLabel="Close preview"
+            hitSlop={8}
+            onPress={onClose}
+            style={{ padding: 10 }}
+          >
+            <NativeSymbol ios="xmark" android="close" size={19} color="#A8A8AD" />
+          </Pressable>
+        </View>
+        <ScrollView contentContainerStyle={{ paddingHorizontal: 24, paddingVertical: 28 }}>
+          {state.status === "loading" ? (
+            <Text style={{ color: "#85858A", fontSize: 15 }}>Loading preview…</Text>
+          ) : state.status === "error" ? (
+            <View
+              style={{
+                borderRadius: 14,
+                borderWidth: 1,
+                borderColor: "#5A2A2A",
+                backgroundColor: "#2A1717",
+                padding: 14,
+              }}
+            >
+              <Text style={{ color: "#F1A8A8", fontSize: 15 }}>{state.message}</Text>
+            </View>
+          ) : (
+            <ChatMarkdown>{state.markdown}</ChatMarkdown>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    </Modal>
+  );
+}

--- a/apps/mobile/lib/artifact-file.test.ts
+++ b/apps/mobile/lib/artifact-file.test.ts
@@ -4,5 +4,6 @@ import { artifactCacheFileName } from "./artifact-file.js";
 describe("artifactCacheFileName", () => {
   it("uses the server id instead of an untrusted display name", () => {
     expect(artifactCacheFileName("../artifact/one", "application/pdf")).toBe("___artifact_one.pdf");
+    expect(artifactCacheFileName("markdown-one", "text/markdown")).toBe("markdown-one.md");
   });
 });

--- a/apps/mobile/lib/artifact-open.ts
+++ b/apps/mobile/lib/artifact-open.ts
@@ -3,16 +3,34 @@ import * as Sharing from "expo-sharing";
 import { rpc } from "./api";
 import { artifactCacheFileName } from "./artifact-file";
 
+async function cacheMobileArtifact(
+  botId: string,
+  artifactId: string,
+  mimeType: string,
+): Promise<File> {
+  const artifact = await rpc<{ contentBase64: string }>("artifacts/get", { botId, artifactId });
+  const file = new File(Paths.cache, artifactCacheFileName(artifactId, mimeType));
+  file.create({ overwrite: true });
+  file.write(artifact.contentBase64, { encoding: "base64" });
+  return file;
+}
+
+export async function readMobileArtifactText(
+  botId: string,
+  artifactId: string,
+  mimeType: string,
+): Promise<string> {
+  const file = await cacheMobileArtifact(botId, artifactId, mimeType);
+  return file.text();
+}
+
 export async function openMobileArtifact(
   botId: string,
   artifactId: string,
   name: string,
   mimeType: string,
 ): Promise<void> {
-  const artifact = await rpc<{ contentBase64: string }>("artifacts/get", { botId, artifactId });
-  const file = new File(Paths.cache, artifactCacheFileName(artifactId, mimeType));
-  file.create({ overwrite: true });
-  file.write(artifact.contentBase64, { encoding: "base64" });
+  const file = await cacheMobileArtifact(botId, artifactId, mimeType);
   if (await Sharing.isAvailableAsync()) {
     await Sharing.shareAsync(file.uri, { mimeType });
     return;

--- a/apps/web/e2e/artifact-preview.spec.ts
+++ b/apps/web/e2e/artifact-preview.spec.ts
@@ -43,13 +43,21 @@ test("agent-attached Markdown opens a rendered preview and can be downloaded", a
   const dialog = page.getByRole("dialog", { name: "preview.md" });
   await expect(dialog).toBeVisible();
   await expect(dialog.getByRole("heading", { name: "Project preview" })).toBeVisible();
+  const closeButton = dialog.getByRole("button", { name: "Close preview" });
+  const downloadButton = dialog.getByRole("button", { name: "Download preview.md" });
+  await expect(closeButton).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(downloadButton).toBeFocused();
+  await page.keyboard.press("Shift+Tab");
+  await expect(closeButton).toBeFocused();
   await captureScreenshot(page, testInfo, "markdown-preview-open");
 
   const downloadPromise = page.waitForEvent("download");
-  await dialog.getByRole("button", { name: "Download preview.md" }).click();
+  await downloadButton.click();
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toBe("preview.md");
 
   await page.keyboard.press("Escape");
   await expect(dialog).toHaveCount(0);
+  await expect(previewButton).toBeFocused();
 });

--- a/apps/web/e2e/artifact-preview.spec.ts
+++ b/apps/web/e2e/artifact-preview.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+test.describe.configure({ mode: "serial" });
+
+test("agent-attached files appear as downloadable cards", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `artifact-card-${stamp}@rakazo.test`, "password12", "Artifact Card");
+  await completeOnboarding(page, ["A bit of everything", "Clear and tight"]);
+
+  const composer = page.getByPlaceholder(/Message/);
+  await composer.fill("write notes/result.txt and attach it to the thread");
+  await page.keyboard.press("Enter");
+
+  const fileCard = page.getByRole("button", { name: /result\.txt/ });
+  await expect(fileCard).toBeVisible({ timeout: 30_000 });
+  await captureScreenshot(page, testInfo, "current-file-card");
+
+  const downloadPromise = page.waitForEvent("download");
+  await fileCard.click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("result.txt");
+});
+
+test("agent-attached Markdown opens a rendered preview and can be downloaded", async ({
+  page,
+}, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `markdown-preview-${stamp}@rakazo.test`, "password12", "Markdown Preview");
+  await completeOnboarding(page, ["A bit of everything", "Clear and tight"]);
+
+  const composer = page.getByPlaceholder(/Message/);
+  await composer.fill(
+    "write path notes/preview.md and attach it to the thread says # Project preview",
+  );
+  await page.keyboard.press("Enter");
+
+  const previewButton = page.getByRole("button", { name: "Preview preview.md" });
+  await expect(previewButton).toBeVisible({ timeout: 30_000 });
+  await captureScreenshot(page, testInfo, "markdown-file-card");
+  await previewButton.click();
+
+  const dialog = page.getByRole("dialog", { name: "preview.md" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("heading", { name: "Project preview" })).toBeVisible();
+  await captureScreenshot(page, testInfo, "markdown-preview-open");
+
+  const downloadPromise = page.waitForEvent("download");
+  await dialog.getByRole("button", { name: "Download preview.md" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("preview.md");
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+});

--- a/apps/web/src/components/ArtifactFileCard.tsx
+++ b/apps/web/src/components/ArtifactFileCard.tsx
@@ -1,0 +1,184 @@
+import { ChatMarkdown } from "@rakazo/chat-ui/web";
+import { Download, FileText, X } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { downloadArtifact, downloadArtifactBytes, fetchArtifactBytes } from "../lib/artifact-open";
+
+type ArtifactFileCardProps = {
+  botId: string;
+  artifactId: string;
+  name: string;
+  mimeType: string;
+  size: number;
+};
+
+export function ArtifactFileCard(props: ArtifactFileCardProps) {
+  const markdown = props.mimeType === "text/markdown";
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  if (!markdown) {
+    return (
+      <button
+        type="button"
+        onClick={() =>
+          void downloadArtifact(props.botId, props.artifactId, props.name, props.mimeType)
+        }
+        className="rounded-[20px] border border-[#26262A] bg-[#17171A] px-4 py-3 text-left text-[14px] text-[#DFDFE2] hover:bg-[#1F1F22]"
+      >
+        <div className="font-medium">{props.name}</div>
+        <div className="mt-1 text-[#85858A]">
+          {props.mimeType} · {formatBytes(props.size)}
+        </div>
+      </button>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex min-w-[280px] overflow-hidden rounded-[20px] border border-[#343438] bg-[#1B1B1E] text-left text-[#DFDFE2]">
+        <button
+          type="button"
+          aria-label={`Preview ${props.name}`}
+          onClick={() => setPreviewOpen(true)}
+          className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left hover:bg-[#222226]"
+        >
+          <span className="grid h-10 w-10 shrink-0 place-items-center rounded-[10px] bg-[#24344A] text-[#68A7FF]">
+            <FileText size={21} strokeWidth={1.8} />
+          </span>
+          <span className="min-w-0">
+            <span className="block truncate text-[14px] font-medium">{props.name}</span>
+            <span className="mt-0.5 block text-[13px] text-[#85858A]">
+              {formatBytes(props.size)}
+            </span>
+          </span>
+        </button>
+        <button
+          type="button"
+          aria-label={`Download ${props.name}`}
+          title={`Download ${props.name}`}
+          onClick={() =>
+            void downloadArtifact(props.botId, props.artifactId, props.name, props.mimeType)
+          }
+          className="grid w-14 shrink-0 place-items-center border-l border-[#343438] text-[#9A9AA0] hover:bg-[#222226] hover:text-[#ECECEE]"
+        >
+          <Download size={19} strokeWidth={1.8} />
+        </button>
+      </div>
+      {previewOpen ? <MarkdownPreview {...props} onClose={() => setPreviewOpen(false)} /> : null}
+    </>
+  );
+}
+
+function MarkdownPreview({
+  botId,
+  artifactId,
+  name,
+  mimeType,
+  onClose,
+}: ArtifactFileCardProps & { onClose: () => void }) {
+  const titleId = useId();
+  const closeButton = useRef<HTMLButtonElement>(null);
+  const [state, setState] = useState<
+    | { status: "loading" }
+    | { status: "ready"; bytes: Uint8Array; markdown: string }
+    | { status: "error"; message: string }
+  >({ status: "loading" });
+
+  useEffect(() => {
+    closeButton.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchArtifactBytes(botId, artifactId)
+      .then((bytes) => {
+        if (cancelled) return;
+        try {
+          const markdown = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+          setState({ status: "ready", bytes, markdown });
+        } catch {
+          setState({ status: "error", message: "This file is not valid UTF-8 Markdown." });
+        }
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setState({
+          status: "error",
+          message: error instanceof Error ? error.message : "Could not load this file.",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [artifactId, botId]);
+
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-5 backdrop-blur-sm">
+      <button
+        type="button"
+        aria-label="Close preview"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default"
+      />
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative flex h-[min(88vh,900px)] w-[min(960px,94vw)] flex-col overflow-hidden rounded-[18px] border border-[#2B2B2F] bg-[#0D0D0F] shadow-2xl"
+      >
+        <header className="flex h-14 shrink-0 items-center border-b border-[#27272B] px-5">
+          <h2
+            id={titleId}
+            className="min-w-0 flex-1 truncate text-[14px] font-medium text-[#E7E7E9]"
+          >
+            {name}
+          </h2>
+          <button
+            type="button"
+            aria-label={`Download ${name}`}
+            title={`Download ${name}`}
+            onClick={() => {
+              if (state.status === "ready") downloadArtifactBytes(name, mimeType, state.bytes);
+              else void downloadArtifact(botId, artifactId, name, mimeType);
+            }}
+            className="grid h-9 w-9 place-items-center rounded-full text-[#929298] hover:bg-[#1D1D20] hover:text-[#ECECEE]"
+          >
+            <Download size={18} strokeWidth={1.8} />
+          </button>
+          <button
+            ref={closeButton}
+            type="button"
+            aria-label="Close preview"
+            onClick={onClose}
+            className="grid h-9 w-9 place-items-center rounded-full text-[#929298] hover:bg-[#1D1D20] hover:text-[#ECECEE]"
+          >
+            <X size={19} strokeWidth={1.8} />
+          </button>
+        </header>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <article className="mx-auto w-full max-w-[760px] px-8 py-10 text-[16px] leading-7 text-[#D5D5D8] sm:px-12 sm:py-12">
+            {state.status === "loading" ? (
+              <div className="text-[#85858A]">Loading preview…</div>
+            ) : state.status === "error" ? (
+              <div className="rounded-[14px] border border-[#5A2A2A] bg-[#2A1717] px-4 py-3 text-[#F1A8A8]">
+                {state.message}
+              </div>
+            ) : (
+              <ChatMarkdown>{state.markdown}</ChatMarkdown>
+            )}
+          </article>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function formatBytes(size: number) {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web/src/components/ArtifactFileCard.tsx
+++ b/apps/web/src/components/ArtifactFileCard.tsx
@@ -13,57 +13,76 @@ type ArtifactFileCardProps = {
 
 export function ArtifactFileCard(props: ArtifactFileCardProps) {
   const markdown = props.mimeType === "text/markdown";
+  const previewButton = useRef<HTMLButtonElement>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+
+  async function startDownload() {
+    setDownloadError(null);
+    try {
+      await downloadArtifact(props.botId, props.artifactId, props.name, props.mimeType);
+    } catch {
+      setDownloadError(`Could not download ${props.name}. Try again.`);
+    }
+  }
+
+  function closePreview() {
+    setPreviewOpen(false);
+    window.requestAnimationFrame(() => previewButton.current?.focus());
+  }
 
   if (!markdown) {
     return (
-      <button
-        type="button"
-        onClick={() =>
-          void downloadArtifact(props.botId, props.artifactId, props.name, props.mimeType)
-        }
-        className="rounded-[20px] border border-[#26262A] bg-[#17171A] px-4 py-3 text-left text-[14px] text-[#DFDFE2] hover:bg-[#1F1F22]"
-      >
-        <div className="font-medium">{props.name}</div>
-        <div className="mt-1 text-[#85858A]">
-          {props.mimeType} · {formatBytes(props.size)}
-        </div>
-      </button>
+      <div>
+        <button
+          type="button"
+          onClick={() => void startDownload()}
+          className="rounded-[20px] border border-[#26262A] bg-[#17171A] px-4 py-3 text-left text-[14px] text-[#DFDFE2] hover:bg-[#1F1F22]"
+        >
+          <div className="font-medium">{props.name}</div>
+          <div className="mt-1 text-[#85858A]">
+            {props.mimeType} · {formatBytes(props.size)}
+          </div>
+        </button>
+        {downloadError ? <DownloadError message={downloadError} /> : null}
+      </div>
     );
   }
 
   return (
     <>
-      <div className="flex min-w-[280px] overflow-hidden rounded-[20px] border border-[#343438] bg-[#1B1B1E] text-left text-[#DFDFE2]">
-        <button
-          type="button"
-          aria-label={`Preview ${props.name}`}
-          onClick={() => setPreviewOpen(true)}
-          className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left hover:bg-[#222226]"
-        >
-          <span className="grid h-10 w-10 shrink-0 place-items-center rounded-[10px] bg-[#24344A] text-[#68A7FF]">
-            <FileText size={21} strokeWidth={1.8} />
-          </span>
-          <span className="min-w-0">
-            <span className="block truncate text-[14px] font-medium">{props.name}</span>
-            <span className="mt-0.5 block text-[13px] text-[#85858A]">
-              {formatBytes(props.size)}
+      <div>
+        <div className="flex min-w-[280px] overflow-hidden rounded-[20px] border border-[#343438] bg-[#1B1B1E] text-left text-[#DFDFE2]">
+          <button
+            ref={previewButton}
+            type="button"
+            aria-label={`Preview ${props.name}`}
+            onClick={() => setPreviewOpen(true)}
+            className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left hover:bg-[#222226]"
+          >
+            <span className="grid h-10 w-10 shrink-0 place-items-center rounded-[10px] bg-[#24344A] text-[#68A7FF]">
+              <FileText size={21} strokeWidth={1.8} />
             </span>
-          </span>
-        </button>
-        <button
-          type="button"
-          aria-label={`Download ${props.name}`}
-          title={`Download ${props.name}`}
-          onClick={() =>
-            void downloadArtifact(props.botId, props.artifactId, props.name, props.mimeType)
-          }
-          className="grid w-14 shrink-0 place-items-center border-l border-[#343438] text-[#9A9AA0] hover:bg-[#222226] hover:text-[#ECECEE]"
-        >
-          <Download size={19} strokeWidth={1.8} />
-        </button>
+            <span className="min-w-0">
+              <span className="block truncate text-[14px] font-medium">{props.name}</span>
+              <span className="mt-0.5 block text-[13px] text-[#85858A]">
+                {formatBytes(props.size)}
+              </span>
+            </span>
+          </button>
+          <button
+            type="button"
+            aria-label={`Download ${props.name}`}
+            title={`Download ${props.name}`}
+            onClick={() => void startDownload()}
+            className="grid w-14 shrink-0 place-items-center border-l border-[#343438] text-[#9A9AA0] hover:bg-[#222226] hover:text-[#ECECEE]"
+          >
+            <Download size={19} strokeWidth={1.8} />
+          </button>
+        </div>
+        {downloadError ? <DownloadError message={downloadError} /> : null}
       </div>
-      {previewOpen ? <MarkdownPreview {...props} onClose={() => setPreviewOpen(false)} /> : null}
+      {previewOpen ? <MarkdownPreview {...props} onClose={closePreview} /> : null}
     </>
   );
 }
@@ -76,7 +95,9 @@ function MarkdownPreview({
   onClose,
 }: ArtifactFileCardProps & { onClose: () => void }) {
   const titleId = useId();
+  const dialog = useRef<HTMLElement>(null);
   const closeButton = useRef<HTMLButtonElement>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
   const [state, setState] = useState<
     | { status: "loading" }
     | { status: "ready"; bytes: Uint8Array; markdown: string }
@@ -86,7 +107,30 @@ function MarkdownPreview({
   useEffect(() => {
     closeButton.current?.focus();
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = Array.from(
+        dialog.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      if (!first || !last) {
+        event.preventDefault();
+        return;
+      }
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
@@ -120,11 +164,13 @@ function MarkdownPreview({
     <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-5 backdrop-blur-sm">
       <button
         type="button"
+        tabIndex={-1}
         aria-label="Close preview"
         onClick={onClose}
         className="absolute inset-0 cursor-default"
       />
       <section
+        ref={dialog}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
@@ -141,10 +187,17 @@ function MarkdownPreview({
             type="button"
             aria-label={`Download ${name}`}
             title={`Download ${name}`}
-            onClick={() => {
-              if (state.status === "ready") downloadArtifactBytes(name, mimeType, state.bytes);
-              else void downloadArtifact(botId, artifactId, name, mimeType);
-            }}
+            onClick={() =>
+              void (async () => {
+                setDownloadError(null);
+                try {
+                  if (state.status === "ready") downloadArtifactBytes(name, mimeType, state.bytes);
+                  else await downloadArtifact(botId, artifactId, name, mimeType);
+                } catch {
+                  setDownloadError(`Could not download ${name}. Try again.`);
+                }
+              })()
+            }
             className="grid h-9 w-9 place-items-center rounded-full text-[#929298] hover:bg-[#1D1D20] hover:text-[#ECECEE]"
           >
             <Download size={18} strokeWidth={1.8} />
@@ -159,6 +212,11 @@ function MarkdownPreview({
             <X size={19} strokeWidth={1.8} />
           </button>
         </header>
+        {downloadError ? (
+          <div className="shrink-0 px-5 pt-4">
+            <DownloadError message={downloadError} />
+          </div>
+        ) : null}
         <div className="min-h-0 flex-1 overflow-y-auto">
           <article className="mx-auto w-full max-w-[760px] px-8 py-10 text-[16px] leading-7 text-[#D5D5D8] sm:px-12 sm:py-12">
             {state.status === "loading" ? (
@@ -173,6 +231,14 @@ function MarkdownPreview({
           </article>
         </div>
       </section>
+    </div>
+  );
+}
+
+function DownloadError({ message }: { message: string }) {
+  return (
+    <div role="alert" className="mt-2 text-left text-[13px] text-[#F1A8A8]">
+      {message}
     </div>
   );
 }

--- a/apps/web/src/lib/artifact-open.ts
+++ b/apps/web/src/lib/artifact-open.ts
@@ -1,4 +1,3 @@
-import { isAttachmentImageMimeType } from "@rakazo/contracts";
 import { rpc } from "./rpc";
 
 export function decodeArtifactBase64(contentBase64: string): Uint8Array {
@@ -10,23 +9,27 @@ export function decodeArtifactBase64(contentBase64: string): Uint8Array {
   return bytes;
 }
 
-export async function openArtifact(
+export async function fetchArtifactBytes(botId: string, artifactId: string): Promise<Uint8Array> {
+  const artifact = await rpc.artifacts.get({ botId, artifactId });
+  return decodeArtifactBase64(artifact.contentBase64);
+}
+
+export function downloadArtifactBytes(name: string, mimeType: string, bytes: Uint8Array): void {
+  const blob = new Blob([new Uint8Array(bytes)], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = name;
+  anchor.click();
+  window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
+export async function downloadArtifact(
   botId: string,
   artifactId: string,
   name: string,
   mimeType: string,
 ): Promise<void> {
-  const artifact = await rpc.artifacts.get({ botId, artifactId });
-  const bytes = decodeArtifactBase64(artifact.contentBase64);
-  const blob = new Blob([new Uint8Array(bytes)], { type: mimeType });
-  const url = URL.createObjectURL(blob);
-  if (isAttachmentImageMimeType(mimeType)) {
-    window.open(url, "_blank", "noopener,noreferrer");
-  } else {
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = name;
-    anchor.click();
-  }
-  window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  const bytes = await fetchArtifactBytes(botId, artifactId);
+  downloadArtifactBytes(name, mimeType, bytes);
 }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -64,11 +64,12 @@ import {
   useState,
 } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { ArtifactFileCard } from "../components/ArtifactFileCard";
 import { SkillDraftCard } from "../components/teach/SkillDraftCard";
 import { TeachCaptureOverlay } from "../components/teach/TeachCaptureOverlay";
 import { TeachComputerSection } from "../components/teach/TeachComputerSection";
 import { TeachRecordingChrome, TeachStopButton } from "../components/teach/TeachRecordingChrome";
-import { decodeArtifactBase64, openArtifact } from "../lib/artifact-open";
+import { decodeArtifactBase64 } from "../lib/artifact-open";
 import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
 import { dictation } from "../lib/dictation";
@@ -2256,18 +2257,13 @@ const MessageView = memo(function MessageView({
               key={i}
               className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}
             >
-              <button
-                type="button"
-                onClick={() =>
-                  void openArtifact(botId, block.artifactId, block.name, block.mimeType)
-                }
-                className="rounded-[20px] border border-[#26262A] bg-[#17171A] px-4 py-3 text-left text-[14px] text-[#DFDFE2] hover:bg-[#1F1F22]"
-              >
-                <div className="font-medium">{block.name}</div>
-                <div className="mt-1 text-[#85858A]">
-                  {block.mimeType} · {formatBytes(block.size)}
-                </div>
-              </button>
+              <ArtifactFileCard
+                botId={botId}
+                artifactId={block.artifactId}
+                name={block.name}
+                mimeType={block.mimeType}
+                size={block.size}
+              />
             </div>
           );
         }
@@ -3169,10 +3165,4 @@ function readFileAsBase64(file: File): Promise<string> {
     reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
     reader.readAsDataURL(file);
   });
-}
-
-function formatBytes(size: number) {
-  if (size < 1024) return `${size} B`;
-  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
-  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/packages/contracts/src/attachments.ts
+++ b/packages/contracts/src/attachments.ts
@@ -13,6 +13,7 @@ export const ATTACHMENT_IMAGE_MIME_TYPES = [
 export const ATTACHMENT_FILE_MIME_TYPES = [
   "application/pdf",
   "text/plain",
+  "text/markdown",
   "text/csv",
   "application/json",
 ] as const;

--- a/packages/core/src/attachments.test.ts
+++ b/packages/core/src/attachments.test.ts
@@ -51,6 +51,7 @@ describe("attachment helpers", () => {
     expect(inferAttachmentMimeType("notes.pdf", "")).toBe("application/pdf");
     expect(inferAttachmentMimeType("notes.md", "")).toBe("text/markdown");
     expect(inferAttachmentMimeType("notes.markdown", "text/plain")).toBe("text/markdown");
+    expect(inferAttachmentMimeType("notes.md", "application/pdf")).toBe("application/pdf");
     expect(inferAttachmentMimeType("archive.zip", "")).toBeNull();
   });
 

--- a/packages/core/src/attachments.test.ts
+++ b/packages/core/src/attachments.test.ts
@@ -49,6 +49,8 @@ describe("attachment helpers", () => {
   it("infers attachment mime types from extensions", () => {
     expect(inferAttachmentMimeType("photo.JPG", "")).toBe("image/jpeg");
     expect(inferAttachmentMimeType("notes.pdf", "")).toBe("application/pdf");
+    expect(inferAttachmentMimeType("notes.md", "")).toBe("text/markdown");
+    expect(inferAttachmentMimeType("notes.markdown", "text/plain")).toBe("text/markdown");
     expect(inferAttachmentMimeType("archive.zip", "")).toBeNull();
   });
 

--- a/packages/core/src/attachments.ts
+++ b/packages/core/src/attachments.ts
@@ -109,6 +109,8 @@ const EXTENSION_MIME_TYPES: Record<string, AttachmentMimeType> = {
   ".gif": "image/gif",
   ".pdf": "application/pdf",
   ".txt": "text/plain",
+  ".md": "text/markdown",
+  ".markdown": "text/markdown",
   ".csv": "text/csv",
   ".json": "application/json",
 };
@@ -120,6 +122,7 @@ const MIME_TYPE_EXTENSIONS: Record<AttachmentMimeType, string> = {
   "image/gif": ".gif",
   "application/pdf": ".pdf",
   "text/plain": ".txt",
+  "text/markdown": ".md",
   "text/csv": ".csv",
   "application/json": ".json",
 };
@@ -128,10 +131,12 @@ export function inferAttachmentMimeType(
   name: string,
   reportedType?: string,
 ): AttachmentMimeType | null {
-  if (reportedType && isAllowedAttachmentMimeType(reportedType)) return reportedType;
   const dot = name.lastIndexOf(".");
-  if (dot < 0) return null;
-  return EXTENSION_MIME_TYPES[name.slice(dot).toLowerCase()] ?? null;
+  const extensionType = dot < 0 ? undefined : EXTENSION_MIME_TYPES[name.slice(dot).toLowerCase()];
+  // Some browsers and native document pickers report Markdown as text/plain.
+  if (extensionType === "text/markdown") return extensionType;
+  if (reportedType && isAllowedAttachmentMimeType(reportedType)) return reportedType;
+  return extensionType ?? null;
 }
 
 export function attachmentExtensionForMimeType(mimeType: string): string {

--- a/packages/core/src/attachments.ts
+++ b/packages/core/src/attachments.ts
@@ -134,7 +134,9 @@ export function inferAttachmentMimeType(
   const dot = name.lastIndexOf(".");
   const extensionType = dot < 0 ? undefined : EXTENSION_MIME_TYPES[name.slice(dot).toLowerCase()];
   // Some browsers and native document pickers report Markdown as text/plain.
-  if (extensionType === "text/markdown") return extensionType;
+  if (extensionType === "text/markdown" && (!reportedType || reportedType === "text/plain")) {
+    return extensionType;
+  }
   if (reportedType && isAllowedAttachmentMimeType(reportedType)) return reportedType;
   return extensionType ?? null;
 }


### PR DESCRIPTION
## Summary

- support `.md` and `.markdown` files throughout the shared attachment pipeline
- render downloadable Markdown cards and an in-app preview dialog on web and Electron
- add a full-screen Markdown preview with native sharing on Expo mobile
- cover agent-created file downloads and Markdown preview behavior with browser tests

## Testing

- `pnpm check`
- `pnpm --filter @rakazo/contracts --filter @rakazo/core --filter @rakazo/web --filter @rakazo/mobile test`
- `pnpm test:e2e --spec=artifact-preview.spec.ts`
- `pnpm exec biome check` on all changed files

The user-provided reference screenshots and their private text are not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown artifact previews in mobile threads and web conversations.
  * Markdown files now render with loading and error states, plus close and download controls; mobile also supports sharing.
  * Added support for `.md` and `.markdown` attachments.
  * Non-Markdown artifacts remain downloadable through existing file controls.

* **Bug Fixes**
  * Improved Markdown type detection and artifact downloading across supported file types.
  * Added keyboard focus handling for accessible web previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->