### PR TITLE
Fix landing waitlist and demo interactions

### DIFF
--- a/apps/www/api/waitlist.ts
+++ b/apps/www/api/waitlist.ts
@@ -1,0 +1,55 @@
+import {
+  captureWaitlistSignup,
+  normalizeWaitlistEmail,
+  parseWaitlistBody,
+} from "../src/waitlist.js";
+
+const MAX_BODY_BYTES = 2_048;
+
+type WaitlistRequest = {
+  body?: unknown;
+  headers: Record<string, string | string[] | undefined>;
+  method?: string;
+};
+
+type WaitlistResponse = {
+  json: (body: unknown) => WaitlistResponse;
+  setHeader: (name: string, value: string) => void;
+  status: (code: number) => WaitlistResponse;
+};
+
+export default async function handler(request: WaitlistRequest, response: WaitlistResponse) {
+  response.setHeader("Cache-Control", "no-store");
+  response.setHeader("Allow", "POST");
+
+  if (request.method !== "POST") {
+    return response.status(405).json({ error: "Method not allowed" });
+  }
+
+  const contentLength = Number(request.headers["content-length"] ?? 0);
+  if (contentLength > MAX_BODY_BYTES) {
+    return response.status(400).json({ error: "Invalid request" });
+  }
+
+  const body = parseWaitlistBody(request.body);
+  if (!body) {
+    return response.status(400).json({ error: "Enter a valid email address" });
+  }
+
+  // A hidden field catches basic form spam without confirming the trap to bots.
+  if (body.company?.trim()) {
+    return response.status(200).json({ ok: true });
+  }
+
+  const email = normalizeWaitlistEmail(body.email);
+  if (!email) {
+    return response.status(400).json({ error: "Enter a valid email address" });
+  }
+
+  const captured = await captureWaitlistSignup(email, process.env).catch(() => false);
+  if (!captured) {
+    return response.status(503).json({ error: "Waitlist is temporarily unavailable" });
+  }
+
+  return response.status(200).json({ ok: true });
+}

--- a/apps/www/api/waitlist.ts
+++ b/apps/www/api/waitlist.ts
@@ -6,50 +6,73 @@ import {
 
 const MAX_BODY_BYTES = 2_048;
 
-type WaitlistRequest = {
-  body?: unknown;
-  headers: Record<string, string | string[] | undefined>;
-  method?: string;
-};
+function json(status: number, body: unknown) {
+  return Response.json(body, {
+    status,
+    headers: { Allow: "POST", "Cache-Control": "no-store" },
+  });
+}
 
-type WaitlistResponse = {
-  json: (body: unknown) => WaitlistResponse;
-  setHeader: (name: string, value: string) => void;
-  status: (code: number) => WaitlistResponse;
-};
+async function readBody(request: Request): Promise<string | null> {
+  if (!request.body) return "";
 
-export default async function handler(request: WaitlistRequest, response: WaitlistResponse) {
-  response.setHeader("Cache-Control", "no-store");
-  response.setHeader("Allow", "POST");
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let body = "";
 
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > MAX_BODY_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      body += decoder.decode(value, { stream: true });
+    }
+    return body + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function fetchWaitlist(request: Request) {
   if (request.method !== "POST") {
-    return response.status(405).json({ error: "Method not allowed" });
+    return json(405, { error: "Method not allowed" });
   }
 
-  const contentLength = Number(request.headers["content-length"] ?? 0);
-  if (contentLength > MAX_BODY_BYTES) {
-    return response.status(400).json({ error: "Invalid request" });
+  const contentLengthHeader = request.headers.get("content-length");
+  if (contentLengthHeader !== null) {
+    const contentLength = Number(contentLengthHeader);
+    if (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > MAX_BODY_BYTES) {
+      return json(400, { error: "Invalid request" });
+    }
   }
 
-  const body = parseWaitlistBody(request.body);
+  const rawBody = await readBody(request).catch(() => null);
+  const body = rawBody === null ? null : parseWaitlistBody(rawBody);
   if (!body) {
-    return response.status(400).json({ error: "Enter a valid email address" });
+    return json(400, { error: "Enter a valid email address" });
   }
 
   // A hidden field catches basic form spam without confirming the trap to bots.
   if (body.company?.trim()) {
-    return response.status(200).json({ ok: true });
+    return json(200, { ok: true });
   }
 
   const email = normalizeWaitlistEmail(body.email);
   if (!email) {
-    return response.status(400).json({ error: "Enter a valid email address" });
+    return json(400, { error: "Enter a valid email address" });
   }
 
   const captured = await captureWaitlistSignup(email, process.env).catch(() => false);
   if (!captured) {
-    return response.status(503).json({ error: "Waitlist is temporarily unavailable" });
+    return json(503, { error: "Waitlist is temporarily unavailable" });
   }
 
-  return response.status(200).json({ ok: true });
+  return json(200, { ok: true });
 }
+
+export default { fetch: fetchWaitlist };

--- a/apps/www/src/components/ProductDemo.tsx
+++ b/apps/www/src/components/ProductDemo.tsx
@@ -477,19 +477,13 @@ export function ProductDemo() {
   }
 
   function openRoutine(routine: DemoRoutine | null, index: number | null) {
-    const nextIndex = index === null ? active.routines.length : index;
-    if (index === null) {
-      patchActive({
-        routines: [...active.routines, { name: "", when: "Unscheduled", instruction: "" }],
-      });
-    }
     setPanelOpen(true);
     setPanelMode("routine");
     setRoutineDraft({
-      index: nextIndex,
+      index,
       name: routine?.name ?? "",
       instruction: routine?.instruction ?? "",
-      active: true,
+      active: routine?.active ?? true,
       triggers: routine ? [parseWhen(routine.when)] : [],
       runs: [],
     });
@@ -500,40 +494,16 @@ export function ProductDemo() {
   }
 
   function changeRoutine(patch: Partial<RoutineDraft>) {
-    setRoutineDraft((current) => {
-      if (!current) {
-        return current;
-      }
-      const next = { ...current, ...patch };
-      setBots((bots) =>
-        bots.map((bot) => {
-          if (bot.id !== activeId) {
-            return bot;
-          }
-          const routines = [...bot.routines];
-          const item: DemoRoutine = {
-            name: next.name.trim() || "Untitled routine",
-            when: whenLabel(next.triggers),
-            instruction: next.instruction,
-          };
-          if (next.index === null) {
-            next.index = routines.length;
-            routines.push(item);
-          } else {
-            routines[next.index] = item;
-          }
-          return { ...bot, routines };
-        }),
-      );
-      return next;
-    });
+    setRoutineDraft((current) => (current ? { ...current, ...patch } : current));
   }
 
   function persistRoutine(draftState: RoutineDraft) {
+    const index = draftState.index ?? active.routines.length;
     const next: DemoRoutine = {
       name: draftState.name.trim() || "Untitled routine",
       when: whenLabel(draftState.triggers),
       instruction: draftState.instruction,
+      active: draftState.active,
     };
     setBots((current) =>
       current.map((bot) => {
@@ -541,14 +511,15 @@ export function ProductDemo() {
           return bot;
         }
         const routines = [...bot.routines];
-        if (draftState.index === null) {
+        if (index === routines.length) {
           routines.push(next);
         } else {
-          routines[draftState.index] = next;
+          routines[index] = next;
         }
         return { ...bot, routines };
       }),
     );
+    return index;
   }
 
   function saveRoutine() {
@@ -570,7 +541,7 @@ export function ProductDemo() {
     const color = BOT_COLORS[bots.length % BOT_COLORS.length] ?? "#3EC5A8";
     const bot: LiveBot = {
       id: `bot-${Date.now()}`,
-      name: "",
+      name: "New bot",
       color,
       time: "Now",
       preview: "Say what you want this bot doing",
@@ -682,13 +653,19 @@ export function ProductDemo() {
     if (!routineDraft?.name.trim()) {
       return;
     }
-    persistRoutine(routineDraft);
-    changeRoutine({
-      runs: [
-        ...routineDraft.runs,
-        { mark: "●", color: "#4ECB71", text: "Completed", time: "Just now" },
-      ],
-    });
+    const index = persistRoutine(routineDraft);
+    setRoutineDraft((current) =>
+      current
+        ? {
+            ...current,
+            index,
+            runs: [
+              ...current.runs,
+              { mark: "●", color: "#4ECB71", text: "Completed", time: "Just now" },
+            ],
+          }
+        : current,
+    );
     appendMessage(active.id, { type: "meta", text: `Routine ran · ${routineDraft.name}` });
   }
 
@@ -699,6 +676,7 @@ export function ProductDemo() {
           id="product-demo-bots"
           className={`product-demo__sidebar${menuOpen ? " is-open" : ""}`}
           aria-hidden={compact && !menuOpen}
+          inert={compact && !menuOpen}
         >
           <div className="product-demo__chrome">
             <div className="product-demo__traffic" aria-hidden="true">

--- a/apps/www/src/components/ProductDemo.tsx
+++ b/apps/www/src/components/ProductDemo.tsx
@@ -5,6 +5,7 @@ import {
   type DemoBot,
   type DemoMessage,
   type DemoRoutine,
+  type DemoRoutineRun,
   type DemoScreen,
 } from "../demo";
 import { LandingBotAvatar } from "./LandingBotAvatar";
@@ -73,20 +74,22 @@ type LiveBot = DemoBot & {
   answers: string[];
 };
 type Trigger = { freq: string; n: number; unit: string; time: string; cron: string };
-type Run = { mark: string; color: string; text: string; time: string };
 type RoutineDraft = {
   index: number | null;
   name: string;
   instruction: string;
   active: boolean;
   triggers: Trigger[];
-  runs: Run[];
+  runs: DemoRoutineRun[];
 };
 
 function cloneBots(): LiveBot[] {
   return DEMO_BOTS.map((bot) => ({
     ...bot,
-    routines: bot.routines.map((routine) => ({ ...routine })),
+    routines: bot.routines.map((routine) => ({
+      ...routine,
+      runs: routine.runs?.map((run) => ({ ...run })),
+    })),
     title: "",
     description: "",
     onboarding: false,
@@ -485,7 +488,7 @@ export function ProductDemo() {
       instruction: routine?.instruction ?? "",
       active: routine?.active ?? true,
       triggers: routine ? [parseWhen(routine.when)] : [],
-      runs: [],
+      runs: routine?.runs?.map((run) => ({ ...run })) ?? [],
     });
   }
 
@@ -504,6 +507,7 @@ export function ProductDemo() {
       when: whenLabel(draftState.triggers),
       instruction: draftState.instruction,
       active: draftState.active,
+      runs: draftState.runs,
     };
     setBots((current) =>
       current.map((bot) => {
@@ -653,16 +657,22 @@ export function ProductDemo() {
     if (!routineDraft?.name.trim()) {
       return;
     }
-    const index = persistRoutine(routineDraft);
+    const completedRun: DemoRoutineRun = {
+      mark: "●",
+      color: "#4ECB71",
+      text: "Completed",
+      time: "Just now",
+    };
+    const index = persistRoutine({
+      ...routineDraft,
+      runs: [...routineDraft.runs, completedRun],
+    });
     setRoutineDraft((current) =>
       current
         ? {
             ...current,
             index,
-            runs: [
-              ...current.runs,
-              { mark: "●", color: "#4ECB71", text: "Completed", time: "Just now" },
-            ],
+            runs: [...current.runs, completedRun],
           }
         : current,
     );

--- a/apps/www/src/components/WaitlistForm.astro
+++ b/apps/www/src/components/WaitlistForm.astro
@@ -1,0 +1,70 @@
+<form class="waitlist-form" data-waitlist-form data-endpoint="/api/waitlist" novalidate>
+  <label class="sr-only" for="waitlist-email">Email address</label>
+  <input
+    id="waitlist-email"
+    name="email"
+    type="email"
+    inputmode="email"
+    autocomplete="email"
+    autocapitalize="none"
+    spellcheck="false"
+    maxlength="254"
+    placeholder="you@company.com"
+    required
+  />
+  <label class="waitlist-form__trap" aria-hidden="true">
+    Company
+    <input name="company" type="text" autocomplete="off" tabindex="-1" />
+  </label>
+  <button class="button button--secondary button--small" type="submit">Join the waitlist</button>
+  <p class="waitlist-form__status" data-waitlist-status aria-live="polite"></p>
+</form>
+
+<script>
+  document.querySelectorAll<HTMLFormElement>("[data-waitlist-form]").forEach((form) => {
+    const email = form.elements.namedItem("email");
+    const company = form.elements.namedItem("company");
+    const submit = form.querySelector<HTMLButtonElement>("button[type='submit']");
+    const status = form.querySelector<HTMLElement>("[data-waitlist-status]");
+
+    if (!(email instanceof HTMLInputElement) || !(company instanceof HTMLInputElement) || !submit || !status) {
+      return;
+    }
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      status.classList.remove("is-error", "is-success");
+
+      if (!email.checkValidity()) {
+        email.reportValidity();
+        return;
+      }
+
+      const endpoint = form.dataset.endpoint;
+      if (!endpoint) return;
+
+      submit.disabled = true;
+      submit.textContent = "Joining…";
+
+      try {
+        const response = await fetch(endpoint, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email: email.value, company: company.value }),
+        });
+
+        if (!response.ok) throw new Error("Waitlist request failed");
+
+        form.reset();
+        status.textContent = "You’re on the list.";
+        status.classList.add("is-success");
+        submit.textContent = "Joined";
+      } catch {
+        status.textContent = "Couldn’t join. Try again.";
+        status.classList.add("is-error");
+        submit.disabled = false;
+        submit.textContent = "Join the waitlist";
+      }
+    });
+  });
+</script>

--- a/apps/www/src/demo.ts
+++ b/apps/www/src/demo.ts
@@ -16,6 +16,14 @@ export type DemoRoutine = {
   when: string;
   instruction?: string;
   active?: boolean;
+  runs?: DemoRoutineRun[];
+};
+
+export type DemoRoutineRun = {
+  mark: string;
+  color: string;
+  text: string;
+  time: string;
 };
 
 export type DemoScreen = {

--- a/apps/www/src/demo.ts
+++ b/apps/www/src/demo.ts
@@ -15,6 +15,7 @@ export type DemoRoutine = {
   name: string;
   when: string;
   instruction?: string;
+  active?: boolean;
 };
 
 export type DemoScreen = {

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -4,6 +4,7 @@ import Footer from "../components/Footer.astro";
 import Header from "../components/Header.astro";
 import { ProductDemo } from "../components/ProductDemo";
 import RosterBotAvatar from "../components/RosterBotAvatar.astro";
+import WaitlistForm from "../components/WaitlistForm.astro";
 import { DEMO_ROSTER } from "../demo";
 import { fetchGithubStars, formatStarCount } from "../github";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -14,7 +15,6 @@ import {
   SITE_DESCRIPTION,
   SITE_NAME,
   SITE_URL,
-  WAITLIST_HREF,
 } from "../site";
 
 const stars = await fetchGithubStars();
@@ -170,7 +170,7 @@ const structuredData = {
               <div>Same bots, same routines, no migration</div>
             </div>
             <div class="comparison-actions">
-              <Button href={WAITLIST_HREF} variant="secondary" size="sm">Join the waitlist</Button>
+              <WaitlistForm />
             </div>
           </article>
         </div>

--- a/apps/www/src/pages/privacy.astro
+++ b/apps/www/src/pages/privacy.astro
@@ -26,10 +26,7 @@ const starsLabel = stars === null ? "Star" : formatStarCount(stars);
       <h2>Information we collect</h2>
       <p>Depending on how you use Rakazo, we collect:</p>
       <ul>
-        <li>
-          Account and contact information, including your name, email address, waitlist signup, and
-          authentication records.
-        </li>
+        <li>Contact and account information, such as your name, email address, and authentication records.</li>
         <li>
           Content you provide to the service, including bot instructions, messages, tasks, memories, files,
           routines, and support communications.

--- a/apps/www/src/pages/privacy.astro
+++ b/apps/www/src/pages/privacy.astro
@@ -26,7 +26,10 @@ const starsLabel = stars === null ? "Star" : formatStarCount(stars);
       <h2>Information we collect</h2>
       <p>Depending on how you use Rakazo, we collect:</p>
       <ul>
-        <li>Account information, including your name, email address, and authentication records.</li>
+        <li>
+          Account and contact information, including your name, email address, waitlist signup, and
+          authentication records.
+        </li>
         <li>
           Content you provide to the service, including bot instructions, messages, tasks, memories, files,
           routines, and support communications.

--- a/apps/www/src/site.ts
+++ b/apps/www/src/site.ts
@@ -8,6 +8,5 @@ export const GITHUB_API_REPO = "https://api.github.com/repos/elie222/rakazo";
 export const DOCS_URL = "https://github.com/elie222/rakazo/blob/main/docs/self-host.md";
 export const SETUP_PROMPT_URL = "https://github.com/elie222/rakazo/blob/main/SETUP_PROMPT.md";
 export const CHANGELOG_URL = "https://github.com/elie222/rakazo/releases";
-export const WAITLIST_HREF = "mailto:hello@rakazo.com?subject=Rakazo%20Cloud%20waitlist";
 export const INBOX_ZERO_URL =
   "https://www.getinboxzero.com/?utm_source=rakazo&utm_medium=website&utm_campaign=footer";

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -96,6 +96,18 @@ input {
   font: inherit;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 button {
   cursor: pointer;
 }
@@ -572,6 +584,65 @@ button {
   gap: 12px;
   margin-top: auto;
   padding-top: 26px;
+}
+
+.waitlist-form {
+  position: relative;
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.waitlist-form > input {
+  min-width: 0;
+  height: 42px;
+  border: 1px solid var(--line-2);
+  border-radius: 12px;
+  background: #fff;
+  padding: 0 13px;
+  color: var(--ink);
+  font-size: 14px;
+  outline: none;
+}
+
+.waitlist-form > input::placeholder {
+  color: var(--muted);
+}
+
+.waitlist-form > input:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--blue-soft-2);
+}
+
+.waitlist-form button:disabled {
+  cursor: default;
+  opacity: 0.7;
+  transform: none;
+}
+
+.waitlist-form__trap {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.waitlist-form__status {
+  grid-column: 1 / -1;
+  min-height: 18px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.waitlist-form__status.is-success {
+  color: var(--success);
+}
+
+.waitlist-form__status.is-error {
+  color: #b42318;
 }
 
 .comparison-kicker {
@@ -2016,6 +2087,10 @@ button {
   .comparison-actions {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .waitlist-form {
+    grid-template-columns: 1fr;
   }
 
   .button,

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -103,7 +103,7 @@ input {
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/apps/www/src/waitlist.test.ts
+++ b/apps/www/src/waitlist.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  captureWaitlistSignup,
+  normalizeWaitlistEmail,
+  parseWaitlistBody,
+} from "./waitlist";
+
+describe("waitlist", () => {
+  it("parses JSON and normalizes email addresses", () => {
+    expect(parseWaitlistBody('{"email":" Person@Example.COM "}')).toEqual({
+      email: " Person@Example.COM ",
+    });
+    expect(normalizeWaitlistEmail(" Person@Example.COM ")).toBe("person@example.com");
+  });
+
+  it("rejects malformed and oversized email addresses", () => {
+    expect(normalizeWaitlistEmail("person@example")).toBeNull();
+    expect(normalizeWaitlistEmail(`${"a".repeat(250)}@example.com`)).toBeNull();
+    expect(parseWaitlistBody({ email: "person@example.com", company: 42 })).toBeNull();
+  });
+
+  it("captures a deduplicated person in the marketing analytics project", async () => {
+    const fetchImpl = vi.fn(async (..._args: Parameters<typeof fetch>) =>
+      new Response(null, { status: 200 }),
+    );
+    await expect(
+      captureWaitlistSignup(
+        "person@example.com",
+        { PUBLIC_POSTHOG_KEY: "public-project-token" },
+        fetchImpl,
+      ),
+    ).resolves.toBe(true);
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const call = fetchImpl.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, init] = call!;
+    expect(String(url)).toBe("https://us.i.posthog.com/i/v0/e/");
+    const payload = JSON.parse(String(init?.body));
+    expect(payload).toMatchObject({
+      api_key: "public-project-token",
+      event: "waitlist_joined",
+      properties: {
+        $process_person_profile: true,
+        $set: { email: "person@example.com", waitlist_status: "joined" },
+        $set_once: { waitlist_source: "rakazo.com" },
+      },
+    });
+    expect(payload.distinct_id).toMatch(/^waitlist:[a-f0-9]{64}$/);
+  });
+
+  it("fails closed when the marketing project is not configured", async () => {
+    const fetchImpl = vi.fn();
+    await expect(captureWaitlistSignup("person@example.com", {}, fetchImpl)).resolves.toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/www/src/waitlist.test.ts
+++ b/apps/www/src/waitlist.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import waitlistFunction from "../api/waitlist";
 import {
   captureWaitlistSignup,
   normalizeWaitlistEmail,
@@ -36,6 +37,7 @@ describe("waitlist", () => {
     expect(call).toBeDefined();
     const [url, init] = call!;
     expect(String(url)).toBe("https://us.i.posthog.com/i/v0/e/");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
     const payload = JSON.parse(String(init?.body));
     expect(payload).toMatchObject({
       api_key: "public-project-token",
@@ -53,5 +55,17 @@ describe("waitlist", () => {
     const fetchImpl = vi.fn();
     await expect(captureWaitlistSignup("person@example.com", {}, fetchImpl)).resolves.toBe(false);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized body when content-length is missing", async () => {
+    const request = new Request("https://rakazo.com/api/waitlist", {
+      method: "POST",
+      body: JSON.stringify({ email: `${"a".repeat(2_048)}@example.com` }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await waitlistFunction.fetch(request);
+
+    expect(response.status).toBe(400);
   });
 });

--- a/apps/www/src/waitlist.ts
+++ b/apps/www/src/waitlist.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 const MAX_EMAIL_LENGTH = 254;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const CAPTURE_TIMEOUT_MS = 5_000;
 
 export type WaitlistBody = {
   email: string;
@@ -49,21 +50,29 @@ export async function captureWaitlistSignup(
   const host = env.PUBLIC_POSTHOG_HOST?.trim() || "https://us.i.posthog.com";
   const joinedAt = new Date().toISOString();
   const distinctId = `waitlist:${createHash("sha256").update(email).digest("hex")}`;
-  const response = await fetchImpl(new URL("/i/v0/e/", host), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      api_key: apiKey,
-      event: "waitlist_joined",
-      distinct_id: distinctId,
-      properties: {
-        $process_person_profile: true,
-        $set: { email, waitlist_status: "joined" },
-        $set_once: { waitlist_joined_at: joinedAt, waitlist_source: "rakazo.com" },
-      },
-      timestamp: joinedAt,
-    }),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CAPTURE_TIMEOUT_MS);
 
-  return response.ok;
+  try {
+    const response = await fetchImpl(new URL("/i/v0/e/", host), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        api_key: apiKey,
+        event: "waitlist_joined",
+        distinct_id: distinctId,
+        properties: {
+          $process_person_profile: true,
+          $set: { email, waitlist_status: "joined" },
+          $set_once: { waitlist_joined_at: joinedAt, waitlist_source: "rakazo.com" },
+        },
+        timestamp: joinedAt,
+      }),
+      signal: controller.signal,
+    });
+
+    return response.ok;
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/apps/www/src/waitlist.ts
+++ b/apps/www/src/waitlist.ts
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto";
+
+const MAX_EMAIL_LENGTH = 254;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type WaitlistBody = {
+  email: string;
+  company?: string;
+};
+
+type CaptureEnv = {
+  PUBLIC_POSTHOG_HOST?: string;
+  PUBLIC_POSTHOG_KEY?: string;
+};
+
+export function parseWaitlistBody(value: unknown): WaitlistBody | null {
+  if (typeof value === "string") {
+    try {
+      return parseWaitlistBody(JSON.parse(value));
+    } catch {
+      return null;
+    }
+  }
+
+  if (!value || typeof value !== "object") return null;
+  const body = value as Record<string, unknown>;
+  const email = body.email;
+  const company = body.company;
+  if (typeof email !== "string") return null;
+  if (company === undefined) return { email };
+  if (typeof company === "string") return { email, company };
+  return null;
+}
+
+export function normalizeWaitlistEmail(value: string): string | null {
+  const email = value.trim().toLowerCase();
+  if (!email || email.length > MAX_EMAIL_LENGTH || !EMAIL_PATTERN.test(email)) return null;
+  return email;
+}
+
+export async function captureWaitlistSignup(
+  email: string,
+  env: CaptureEnv,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  const apiKey = env.PUBLIC_POSTHOG_KEY?.trim();
+  if (!apiKey) return false;
+
+  const host = env.PUBLIC_POSTHOG_HOST?.trim() || "https://us.i.posthog.com";
+  const joinedAt = new Date().toISOString();
+  const distinctId = `waitlist:${createHash("sha256").update(email).digest("hex")}`;
+  const response = await fetchImpl(new URL("/i/v0/e/", host), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      api_key: apiKey,
+      event: "waitlist_joined",
+      distinct_id: distinctId,
+      properties: {
+        $process_person_profile: true,
+        $set: { email, waitlist_status: "joined" },
+        $set_once: { waitlist_joined_at: joinedAt, waitlist_source: "rakazo.com" },
+      },
+      timestamp: joinedAt,
+    }),
+  });
+
+  return response.ok;
+}

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -159,7 +159,7 @@ Pull the new source, rebuild with `GIT_SHA=$(git rev-parse HEAD)`, run `pnpm --f
 
 ## What “Rakazo Cloud” still needs
 
-`apps/www` (Astro, `output: "static"`, `site: https://rakazo.com`) can go live today on Vercel, Cloudflare Pages, or any static host. The waitlist link is `mailto:hello@rakazo.com`. That is the marketing site, not the product.
+`apps/www` owns the marketing site and its waitlist end to end. Astro builds the static pages, and the colocated Vercel function at `apps/www/api/waitlist.ts` records signups in the marketing PostHog project using its write-only `PUBLIC_POSTHOG_KEY`. It never calls the Rakazo product API. Another static host needs an equivalent same-origin function for `/api/waitlist`.
 
 The product cannot be “pushed live” as a Vercel serverless app. Graphile Worker, Postgres `LISTEN`, Pi runs, and Docker computers need durable processes and a sandbox host.
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -159,8 +159,6 @@ Pull the new source, rebuild with `GIT_SHA=$(git rev-parse HEAD)`, run `pnpm --f
 
 ## What “Rakazo Cloud” still needs
 
-`apps/www` owns the marketing site and its waitlist end to end. Astro builds the static pages, and the colocated Vercel function at `apps/www/api/waitlist.ts` records signups in the marketing PostHog project using its write-only `PUBLIC_POSTHOG_KEY`. It never calls the Rakazo product API. Another static host needs an equivalent same-origin function for `/api/waitlist`.
-
 The product cannot be “pushed live” as a Vercel serverless app. Graphile Worker, Postgres `LISTEN`, Pi runs, and Docker computers need durable processes and a sandbox host.
 
 To run a hosted product (same codebase):

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "apps/web/src/**/*.test.{ts,tsx}",
       "apps/mobile/lib/**/*.test.ts",
       "apps/api/src/**/*.test.ts",
+      "apps/www/src/**/*.test.ts",
     ],
     testTimeout: 30_000,
     hookTimeout: 60_000,


### PR DESCRIPTION
## Summary

- add a real, accessible waitlist form backed by a same-origin marketing-only Vercel function
- capture deduplicated signups in the existing marketing PostHog project without calling the product API
- fix routine cancellation, repeated test runs, blank bot names, and hidden mobile demo controls
- document the marketing/product boundary and update privacy coverage

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm --filter @rakazo/www build`
- `vercel build --prod --yes`
- desktop and mobile browser interaction checks against the local same-origin preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a waitlist signup form with email validation, spam protection, status feedback, and a mobile-friendly layout.
  * Routine run history is now preserved when routines are opened, tested, cloned, and saved.

* **Bug Fixes**
  * Improved waitlist submission reliability with request-size validation, duplicate signup handling, timeout protection, and safe failure behavior.
  * Added accessible form status messaging and disabled-submit feedback.

* **Documentation**
  * Updated privacy and self-hosting documentation to reflect current waitlist and site behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->