### PR TITLE
Add get started dialog to landing page

### DIFF
--- a/apps/www/api/waitlist.ts
+++ b/apps/www/api/waitlist.ts
@@ -58,7 +58,7 @@ async function fetchWaitlist(request: Request) {
   }
 
   // A hidden field catches basic form spam without confirming the trap to bots.
-  if (body.company?.trim()) {
+  if (body.contactNote?.trim()) {
     return json(200, { ok: true });
   }
 

--- a/apps/www/src/components/GetStartedDialog.astro
+++ b/apps/www/src/components/GetStartedDialog.astro
@@ -26,7 +26,6 @@ import WaitlistForm from "./WaitlistForm.astro";
       <div class="get-started-dialog__form">
         <WaitlistForm emailId="get-started-email" />
       </div>
-      <p class="get-started-dialog__note">We’ll only use your email to contact you about Rakazo.</p>
     </div>
 
     <div class="get-started-dialog__success" data-get-started-success hidden>

--- a/apps/www/src/components/GetStartedDialog.astro
+++ b/apps/www/src/components/GetStartedDialog.astro
@@ -1,0 +1,82 @@
+---
+import { GITHUB_URL } from "../site";
+import Button from "./Button.astro";
+import WaitlistForm from "./WaitlistForm.astro";
+---
+
+<dialog class="get-started-dialog" data-get-started-dialog aria-labelledby="get-started-title">
+  <div class="get-started-dialog__panel">
+    <button
+      class="get-started-dialog__close"
+      type="button"
+      data-get-started-close
+      aria-label="Close get started dialog"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="m6 6 12 12M18 6 6 18"></path>
+      </svg>
+    </button>
+
+    <div data-get-started-signup>
+      <div class="eyebrow">Rakazo Cloud</div>
+      <h2 id="get-started-title">Get started with Rakazo</h2>
+      <p class="get-started-dialog__copy">
+        Leave your email and we’ll let you know when your hosted workspace is ready.
+      </p>
+      <div class="get-started-dialog__form">
+        <WaitlistForm emailId="get-started-email" />
+      </div>
+      <p class="get-started-dialog__note">We’ll only use your email to contact you about Rakazo.</p>
+    </div>
+
+    <div class="get-started-dialog__success" data-get-started-success hidden>
+      <div class="get-started-dialog__success-mark" aria-hidden="true">
+        <svg viewBox="0 0 24 24">
+          <path d="m5 12 4 4L19 6"></path>
+        </svg>
+      </div>
+      <h2 id="get-started-success-title" tabindex="-1" data-get-started-success-title>You’re in.</h2>
+      <p class="get-started-dialog__copy">
+        We’ll email you when hosted Rakazo is ready. Want to start today? Rakazo is already available on GitHub.
+      </p>
+      <div class="get-started-dialog__actions">
+        <Button href={GITHUB_URL} external>View on GitHub</Button>
+        <button class="button button--secondary" type="button" data-get-started-close>Done</button>
+      </div>
+    </div>
+  </div>
+</dialog>
+
+<script>
+  const dialog = document.querySelector<HTMLDialogElement>("[data-get-started-dialog]");
+  const openers = document.querySelectorAll<HTMLButtonElement>("[data-get-started-open]");
+  const closeButtons = dialog?.querySelectorAll<HTMLButtonElement>("[data-get-started-close]");
+  const signup = dialog?.querySelector<HTMLElement>("[data-get-started-signup]");
+  const success = dialog?.querySelector<HTMLElement>("[data-get-started-success]");
+  const successTitle = dialog?.querySelector<HTMLElement>("[data-get-started-success-title]");
+  const email = dialog?.querySelector<HTMLInputElement>("input[type='email']");
+
+  openers.forEach((opener) => {
+    opener.addEventListener("click", () => {
+      if (!dialog || dialog.open) return;
+      dialog.showModal();
+      window.requestAnimationFrame(() => email?.focus());
+    });
+  });
+
+  closeButtons?.forEach((button) => {
+    button.addEventListener("click", () => dialog?.close());
+  });
+
+  dialog?.addEventListener("click", (event) => {
+    if (event.target === dialog) dialog.close();
+  });
+
+  dialog?.addEventListener("waitlist:joined", () => {
+    if (!signup || !success) return;
+    signup.hidden = true;
+    success.hidden = false;
+    dialog.setAttribute("aria-labelledby", "get-started-success-title");
+    successTitle?.focus();
+  });
+</script>

--- a/apps/www/src/components/WaitlistForm.astro
+++ b/apps/www/src/components/WaitlistForm.astro
@@ -1,7 +1,16 @@
+---
+type Props = {
+  emailId?: string;
+  submitLabel?: string;
+};
+
+const { emailId = "waitlist-email", submitLabel = "Continue" } = Astro.props;
+---
+
 <form class="waitlist-form" data-waitlist-form data-endpoint="/api/waitlist" novalidate>
-  <label class="sr-only" for="waitlist-email">Email address</label>
+  <label class="sr-only" for={emailId}>Email address</label>
   <input
-    id="waitlist-email"
+    id={emailId}
     name="email"
     type="email"
     inputmode="email"
@@ -12,24 +21,27 @@
     placeholder="you@company.com"
     required
   />
-  <label class="waitlist-form__trap" aria-hidden="true">
-    Company
-    <input name="company" type="text" autocomplete="off" tabindex="-1" />
-  </label>
-  <button class="button button--secondary button--small" type="submit">Join the waitlist</button>
+  <div class="waitlist-form__trap" hidden>
+    <input name="contact-note" type="text" autocomplete="off" tabindex="-1" />
+  </div>
+  <button class="button button--primary button--small" type="submit" data-submit-label={submitLabel}>
+    {submitLabel}
+  </button>
   <p class="waitlist-form__status" data-waitlist-status aria-live="polite"></p>
 </form>
 
 <script>
   document.querySelectorAll<HTMLFormElement>("[data-waitlist-form]").forEach((form) => {
     const email = form.elements.namedItem("email");
-    const company = form.elements.namedItem("company");
+    const contactNote = form.elements.namedItem("contact-note");
     const submit = form.querySelector<HTMLButtonElement>("button[type='submit']");
     const status = form.querySelector<HTMLElement>("[data-waitlist-status]");
 
-    if (!(email instanceof HTMLInputElement) || !(company instanceof HTMLInputElement) || !submit || !status) {
+    if (!(email instanceof HTMLInputElement) || !(contactNote instanceof HTMLInputElement) || !submit || !status) {
       return;
     }
+
+    const submitLabel = submit.dataset.submitLabel || "Continue";
 
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
@@ -50,20 +62,21 @@
         const response = await fetch(endpoint, {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ email: email.value, company: company.value }),
+          body: JSON.stringify({ email: email.value, contactNote: contactNote.value }),
         });
 
         if (!response.ok) throw new Error("Waitlist request failed");
 
         form.reset();
-        status.textContent = "You’re on the list.";
+        status.textContent = "You’re in.";
         status.classList.add("is-success");
-        submit.textContent = "Joined";
+        submit.textContent = "Added";
+        form.dispatchEvent(new CustomEvent("waitlist:joined", { bubbles: true }));
       } catch {
-        status.textContent = "Couldn’t join. Try again.";
+        status.textContent = "Couldn’t add you. Try again.";
         status.classList.add("is-error");
         submit.disabled = false;
-        submit.textContent = "Join the waitlist";
+        submit.textContent = submitLabel;
       }
     });
   });

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -69,8 +69,8 @@ const structuredData = {
           needs you. Your keys, your model, your machine.
         </p>
         <div class="hero__actions">
-          <Button href={GITHUB_URL} external>View on GitHub</Button>
-          <Button href="#demo" variant="secondary">See it in action</Button>
+          <button class="button button--primary" type="button" data-get-started-open>Get started</button>
+          <Button href={GITHUB_URL} variant="secondary" external>View on GitHub</Button>
         </div>
         <div class="hero__agent-setup">
           <button class="setup-copy" type="button" data-setup-copy={setupAgentPrompt}>

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -1,10 +1,10 @@
 ---
 import Button from "../components/Button.astro";
 import Footer from "../components/Footer.astro";
+import GetStartedDialog from "../components/GetStartedDialog.astro";
 import Header from "../components/Header.astro";
 import { ProductDemo } from "../components/ProductDemo";
 import RosterBotAvatar from "../components/RosterBotAvatar.astro";
-import WaitlistForm from "../components/WaitlistForm.astro";
 import { DEMO_ROSTER } from "../demo";
 import { fetchGithubStars, formatStarCount } from "../github";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -170,7 +170,9 @@ const structuredData = {
               <div>Same bots, same routines, no migration</div>
             </div>
             <div class="comparison-actions">
-              <WaitlistForm />
+              <button class="button button--primary button--small" type="button" data-get-started-open>
+                Get started
+              </button>
             </div>
           </article>
         </div>
@@ -179,9 +181,10 @@ const structuredData = {
       <section class="stats-band">
         <div>
           <h2>Meet your first bot</h2>
-          <p>Clone the repo, add a model key, and hand it something you have been putting off.</p>
+          <p>Give Rakazo something you have been putting off and let it handle the follow-through.</p>
           <div class="cta-actions">
-            <Button href={GITHUB_URL} external>View on GitHub</Button>
+            <button class="button button--primary" type="button" data-get-started-open>Get started</button>
+            <Button href={GITHUB_URL} variant="secondary" external>View on GitHub</Button>
           </div>
         </div>
         <div class="stats-grid">
@@ -203,6 +206,8 @@ const structuredData = {
           </div>
         </div>
       </section>
+
+      <GetStartedDialog />
     </main>
 
     <Footer />

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -721,13 +721,6 @@ button {
   margin-top: 26px;
 }
 
-.get-started-dialog__note {
-  margin: 10px 0 0;
-  color: var(--muted);
-  font-size: 12.5px;
-  line-height: 1.45;
-}
-
 .get-started-dialog__success-mark {
   display: flex;
   width: 44px;

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -645,6 +645,118 @@ button {
   color: #b42318;
 }
 
+.get-started-dialog {
+  width: min(520px, calc(100% - 32px));
+  max-width: none;
+  max-height: calc(100dvh - 32px);
+  margin: auto;
+  overflow: auto;
+  border: 1px solid var(--line-2);
+  border-radius: 24px;
+  background: var(--surface);
+  padding: 0;
+  color: var(--body);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.2);
+}
+
+.get-started-dialog::backdrop {
+  background: rgba(20, 20, 22, 0.48);
+  backdrop-filter: blur(4px);
+}
+
+.get-started-dialog__panel {
+  position: relative;
+  padding: 38px;
+}
+
+.get-started-dialog__close {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted-2);
+}
+
+.get-started-dialog__close:hover,
+.get-started-dialog__close:focus-visible {
+  background: var(--surface-soft);
+  color: var(--ink);
+}
+
+.get-started-dialog__close svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.8;
+}
+
+.get-started-dialog h2 {
+  max-width: 390px;
+  margin: 0;
+  color: var(--ink);
+  font-family: Aeonik, Geist, ui-sans-serif, system-ui, sans-serif;
+  font-size: 30px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+.get-started-dialog__copy {
+  margin: 14px 0 0;
+  color: var(--muted-2);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+.get-started-dialog__form {
+  margin-top: 26px;
+}
+
+.get-started-dialog__note {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.get-started-dialog__success-mark {
+  display: flex;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+  border-radius: 14px;
+  background: #edf9ef;
+  color: var(--success);
+}
+
+.get-started-dialog__success-mark svg {
+  width: 24px;
+  height: 24px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.get-started-dialog__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 26px;
+}
+
 .comparison-kicker {
   display: flex;
   align-items: center;
@@ -2091,6 +2203,14 @@ button {
 
   .waitlist-form {
     grid-template-columns: 1fr;
+  }
+
+  .get-started-dialog__panel {
+    padding: 32px 24px 24px;
+  }
+
+  .get-started-dialog__actions {
+    flex-direction: column;
   }
 
   .button,

--- a/apps/www/src/waitlist.test.ts
+++ b/apps/www/src/waitlist.test.ts
@@ -17,7 +17,7 @@ describe("waitlist", () => {
   it("rejects malformed and oversized email addresses", () => {
     expect(normalizeWaitlistEmail("person@example")).toBeNull();
     expect(normalizeWaitlistEmail(`${"a".repeat(250)}@example.com`)).toBeNull();
-    expect(parseWaitlistBody({ email: "person@example.com", company: 42 })).toBeNull();
+    expect(parseWaitlistBody({ email: "person@example.com", contactNote: 42 })).toBeNull();
   });
 
   it("captures a deduplicated person in the marketing analytics project", async () => {
@@ -67,5 +67,18 @@ describe("waitlist", () => {
     const response = await waitlistFunction.fetch(request);
 
     expect(response.status).toBe(400);
+  });
+
+  it("silently accepts submissions that fill the bot trap", async () => {
+    const request = new Request("https://rakazo.com/api/waitlist", {
+      method: "POST",
+      body: JSON.stringify({ email: "person@example.com", contactNote: "filled by a bot" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await waitlistFunction.fetch(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
   });
 });

--- a/apps/www/src/waitlist.ts
+++ b/apps/www/src/waitlist.ts
@@ -6,7 +6,7 @@ const CAPTURE_TIMEOUT_MS = 5_000;
 
 export type WaitlistBody = {
   email: string;
-  company?: string;
+  contactNote?: string;
 };
 
 type CaptureEnv = {
@@ -26,10 +26,10 @@ export function parseWaitlistBody(value: unknown): WaitlistBody | null {
   if (!value || typeof value !== "object") return null;
   const body = value as Record<string, unknown>;
   const email = body.email;
-  const company = body.company;
+  const contactNote = body.contactNote;
   if (typeof email !== "string") return null;
-  if (company === undefined) return { email };
-  if (typeof company === "string") return { email, company };
+  if (contactNote === undefined) return { email };
+  if (typeof contactNote === "string") return { email, contactNote };
   return null;
 }
 


### PR DESCRIPTION
## Summary
- replace the visible waitlist form with a reusable Get started dialog
- add Get started and View on GitHub actions to the final CTA
- show GitHub availability after signup and keep Cloud status clear
- replace the autofill-prone Company spam field with a hidden non-semantic trap

## Verification
- `pnpm --filter @rakazo/www check`
- `pnpm exec vitest run apps/www/src/waitlist.test.ts`
- `pnpm --filter @rakazo/www build`
- manually verified desktop and mobile dialog layout, focus, and close behavior locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Get started” modal with email signup and a success state linking to GitHub.
  * Updated homepage calls to action to open the new signup experience.
  * Added responsive styling for the modal on mobile devices.

* **Bug Fixes**
  * Improved waitlist spam protection while preserving valid signup responses.
  * Updated waitlist form messaging, submission states, and accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->