### PR TITLE
Fix Windows CRLF breaking sandbox shebangs (#135)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.sh text eol=lf
+infra/sandboxes/computer/rakazo-browser text eol=lf
+infra/sandboxes/computer/fluxbox.* text eol=lf
+*.png binary
+*.jpg binary
+*.ico binary

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -14,6 +14,8 @@ Same as the README quick start: `.env` from `.env.example`, Postgres via Compose
 4. `docker compose --env-file .env -f infra/compose/docker-compose.yml up --build`
 5. Open the web origin (`http://127.0.0.1:5173` by default). The first registered user becomes the deployment owner.
 
+On Windows, if you previously cloned with `core.autocrlf=true` and the computer pane hangs on boot (`bash\r` in sandbox logs), set `git config core.autocrlf false`, run `git add --renormalize . && git checkout -- .`, then rebuild with `pnpm sandbox:build`.
+
 Compose runs Postgres, the sandbox supervisor (Docker socket), API, worker, and a Vite preview of the web app. Bot computers are sibling containers (`rakazo/computer:local`). The API process does not get an unrestricted Docker socket; the supervisor owns the lifecycle.
 
 Postgres is published on **loopback only** (`127.0.0.1:5433` on the host). Do not expose that port on a public VPS. Change `POSTGRES_PASSWORD` and keep Postgres on an internal network when you deploy remotely.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -14,7 +14,7 @@ Same as the README quick start: `.env` from `.env.example`, Postgres via Compose
 4. `docker compose --env-file .env -f infra/compose/docker-compose.yml up --build`
 5. Open the web origin (`http://127.0.0.1:5173` by default). The first registered user becomes the deployment owner.
 
-On Windows, if you previously cloned with `core.autocrlf=true` and the computer pane hangs on boot (`bash\r` in sandbox logs), set `git config core.autocrlf false`, run `git add --renormalize . && git checkout -- .`, then rebuild with `pnpm sandbox:build`.
+On Windows, if an older clone with `core.autocrlf=true` leaves the computer pane hung on boot (`bash\r` in sandbox logs): from a clean worktree, set `git config core.autocrlf false`, run `git add --renormalize . && git checkout -- .`, then rebuild with `pnpm sandbox:build`.
 
 Compose runs Postgres, the sandbox supervisor (Docker socket), API, worker, and a Vite preview of the web app. Bot computers are sibling containers (`rakazo/computer:local`). The API process does not get an unrestricted Docker socket; the supervisor owns the lifecycle.
 

--- a/infra/sandboxes/computer/Dockerfile
+++ b/infra/sandboxes/computer/Dockerfile
@@ -32,6 +32,9 @@ COPY fluxbox.init /etc/rakazo/fluxbox/init
 COPY fluxbox.apps /etc/rakazo/fluxbox/apps
 COPY fluxbox.menu /etc/rakazo/fluxbox/menu
 COPY embed.html /usr/share/novnc/embed.html
-RUN chmod +x /usr/local/bin/rakazo-computer /usr/local/bin/rakazo-browser
+# Strip CR so shebangs work even if the build context came from a CRLF checkout.
+RUN sed -i 's/\r$//' /usr/local/bin/rakazo-computer /usr/local/bin/rakazo-browser \
+    /etc/rakazo/fluxbox/init /etc/rakazo/fluxbox/apps /etc/rakazo/fluxbox/menu \
+  && chmod +x /usr/local/bin/rakazo-computer /usr/local/bin/rakazo-browser
 EXPOSE 6080 6081 6082 6083 6084 6085 6086 6087 6088 6089 6090 6091 6092 6093 6094 6095
 CMD ["/usr/local/bin/rakazo-computer"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On Windows clones with `core.autocrlf=true`, sandbox shell scripts are checked out as CRLF and `COPY`d into the Linux `rakazo/computer:local` image. The shebang becomes `bash\r`, so containers exit immediately and the computer pane hangs on boot.

## Changes

- Add root `.gitattributes` so `*.sh`, `rakazo-browser`, and `fluxbox.*` stay LF (plus `* text=auto eol=lf` and common image binaries).
- Strip trailing CR in the computer Dockerfile after `COPY` so builds remain robust from dirty checkouts.
- Note in `docs/self-host.md`: existing Windows clones need a one-time renormalize + `pnpm sandbox:build`.

Closes #135.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf5d602b-6614-4407-bd9d-606623797566?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf5d602b-6614-4407-bd9d-606623797566&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox startup reliability on Windows by preventing script and desktop configuration line-ending issues from causing boot hangs.
  * Added cross-platform compatibility improvements for sandbox scripts and configuration files.

* **Documentation**
  * Expanded Windows Compose troubleshooting guidance for older clones, clean worktrees, Git line-ending normalization, and sandbox image rebuilding.

* **Chores**
  * Standardized text files to use LF line endings and marked common image formats as binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->