### PR TITLE
docs: document DOCKER_SOCKET override (closes #134)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ SANDBOX_SUPERVISOR_TOKEN=
 SANDBOX_PROVIDER=docker
 # Optional Docker daemon socket. Defaults to /var/run/docker.sock (Unix) or
 # //./pipe/docker_engine (Windows). Set for rootless Docker, Colima, or custom paths.
+# DOCKER_HOST takes precedence over DOCKER_SOCKET when both are set.
 # DOCKER_SOCKET=
 DAYTONA_API_KEY=
 DAYTONA_API_URL=

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ SANDBOX_SUPERVISOR_URL=http://127.0.0.1:7091
 # Optional separate service credential; defaults to BETTER_AUTH_SECRET when empty.
 SANDBOX_SUPERVISOR_TOKEN=
 SANDBOX_PROVIDER=docker
+# Optional Docker daemon socket. Defaults to /var/run/docker.sock (Unix) or
+# //./pipe/docker_engine (Windows). Set for rootless Docker, Colima, or custom paths.
+# DOCKER_SOCKET=
 DAYTONA_API_KEY=
 DAYTONA_API_URL=
 DAYTONA_TARGET=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Document optional `DOCKER_SOCKET` in `.env.example` for rootless Docker, Colima, and other non-default daemon paths.
- The Windows named-pipe default (`//./pipe/docker_engine`) already landed in #143 via `resolveDockerSocketPath` in `infra/sandboxes/supervisor/src/index.ts`; this completes the discoverability half of #134.

## Context
Issue #134 reported sandbox provision failures on Docker Desktop for Windows (`connect ENOENT /var/run/docker.sock`). Platform defaults and `DOCKER_SOCKET` / `DOCKER_HOST` handling are already in main; the remaining gap was that `DOCKER_SOCKET` was undocumented.

Closes #134.

## Test plan
- [x] Confirmed `resolveDockerSocketPath` on main returns `//./pipe/docker_engine` on `win32`, `/var/run/docker.sock` otherwise, and respects `DOCKER_SOCKET` / `DOCKER_HOST`
- [x] Confirmed existing unit coverage in `infra/sandboxes/supervisor/src/index.test.ts`
- [ ] Spot-check `.env.example` comment is clear for custom socket paths

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35da2e65-c1eb-42a0-b05a-744dea868803?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35da2e65-c1eb-42a0-b05a-744dea868803&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the optional `DOCKER_SOCKET` environment variable.
  * Added setup guidance for Unix, Windows, rootless Docker, Colima, and custom socket paths.
  * Clarified that `DOCKER_HOST` takes precedence when both variables are configured.
  * Noted that the variable remains commented out by default, so existing configurations are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->