### PR TITLE
Prevent OpenRouter mandatory-reasoning 400 from thinkingLevel "off" (#114)

### DIFF
--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -104,7 +104,11 @@ describe("Pi agent thinking level", () => {
   });
 
   it("uses medium reasoning for the main agent and subagent", async () => {
-    expect(await runWithModel("reasoning-model")).toEqual(["medium", "medium"]);
+    // Regression for OpenRouter mandatory-reasoning models (#114): forcing
+    // thinkingLevel "off" becomes effort "none" and the provider returns 400.
+    const levels = await runWithModel("reasoning-model");
+    expect(levels).toEqual(["medium", "medium"]);
+    expect(levels.every((level) => level !== "off")).toBe(true);
   });
 
   it("keeps reasoning off for the main agent and subagent", async () => {

--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -119,16 +119,19 @@ describe("Pi agent thinking level", () => {
     vi.stubEnv("PI_DEFAULT_PROVIDER", " openrouter ");
     vi.stubEnv("PI_DEFAULT_MODEL", "  stealth/ox-alpha  ");
 
-    await runWithModel("  stealth/ox-alpha  ", "openrouter");
+    const levels = await runWithModel("  stealth/ox-alpha  ", "openrouter");
 
     expect(fakeAgentState.models).toHaveLength(2);
     expect(fakeAgentState.models[0]).toMatchObject({
       id: "stealth/ox-alpha",
       provider: "openrouter",
-      reasoning: false,
+      reasoning: true,
       contextWindow: 16_384,
       maxTokens: 4_096,
     });
+    // Unknown OpenRouter PI_DEFAULT_MODEL must not force thinking off (#114).
+    expect(levels).toEqual(["medium", "medium"]);
+    expect(levels.every((level) => level !== "off")).toBe(true);
   });
 
   it("uses the trimmed configured default for scripted requests", async () => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -228,15 +228,17 @@ export class PiAgentRuntime implements AgentRuntime {
 }
 
 function configuredOpenRouterModel(id: string): Model<"openai-completions"> {
-  // A configured model can intentionally be newer than Pi's static catalog. Keep unknown
-  // capabilities and pricing conservative instead of inheriting them from an unrelated model.
+  // A configured model can intentionally be newer than Pi's static catalog. Keep
+  // pricing conservative, but enable reasoning: unknown OpenRouter endpoints
+  // (e.g. gemini-3.7-flash before the snapshot catches up) often mandate it, and
+  // thinkingLevel "off" becomes effort "none" which those endpoints reject.
   return {
     id,
     name: id,
     api: "openai-completions",
     provider: "openrouter",
     baseUrl: "https://openrouter.ai/api/v1",
-    reasoning: false,
+    reasoning: true,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 16_384,

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -23,6 +23,10 @@ function catalogModels(): Models {
   return catalogModelsCache;
 }
 const MAX_PARALLEL_SUBAGENTS = 4;
+// Reasoning-capable models must not start at "off": for OpenRouter, pi-ai maps
+// that to reasoning.effort "none", which 400s on endpoints that mandate
+// reasoning (e.g. google/gemini-3.7-flash). Keep a real level when model.reasoning
+// is set; plain models stay off.
 const REASONING_MODEL_THINKING_LEVEL = "medium";
 function thinkingLevelFor(model: { reasoning?: boolean }) {
   return model.reasoning ? REASONING_MODEL_THINKING_LEVEL : "off";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #114.

OpenRouter models with mandatory reasoning (e.g. `google/gemini-3.7-flash`) return 400 when Pi sends `reasoning: { effort: "none" }`. That payload comes from agent `thinkingLevel: "off"` on models with `reasoning: true` (or OpenRouter defaults that behave that way).

## Fix

- Keep #95's `thinkingLevelFor(model)` mapping on both agent-creation sites (`model.reasoning ? "medium" : "off"`) — no regression.
- Set `reasoning: true` on `configuredOpenRouterModel` so unknown `PI_DEFAULT_MODEL` OpenRouter fallbacks (catalog lag) also get a real thinking level instead of `"off"`.
- Lock both paths in `pi-runtime-thinking-level.test.ts`.

Catalog papercut left alone beyond the runtime fallback; no pi-ai bump.

## Test plan

- [x] `pnpm exec vitest run packages/adapters/src/pi-runtime-thinking-level.test.ts packages/adapters/src/pi-models.test.ts` — 8 passed
- [x] Both agent sites still call `thinkingLevelFor` (main + subagent)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81cad4c7-e89f-4523-aaa1-fb129c6addf8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81cad4c7-e89f-4523-aaa1-fb129c6addf8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning-level handling for supported AI models.
  * Ensured reasoning-capable models use the appropriate medium reasoning setting instead of disabling reasoning where unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->