### PR TITLE
fix(core): honor day-of-week and timezone in nextCronDate

### DIFF
--- a/packages/core/src/cron.test.ts
+++ b/packages/core/src/cron.test.ts
@@ -4,6 +4,7 @@ import {
   cronFromPreset,
   describeCronPreset,
   formatCron,
+  nextCronDate,
   presetFromCron,
 } from "./cron.js";
 
@@ -97,5 +98,40 @@ describe("formatCron", () => {
       lead: "Every hour",
       detail: "",
     });
+  });
+});
+
+describe("nextCronDate", () => {
+  it("returns the next matching time today for a daily cron", () => {
+    const from = new Date("2026-08-24T10:30:00.000Z");
+    expect(nextCronDate("0 11 * * *", from)).toEqual(new Date("2026-08-24T11:00:00.000Z"));
+  });
+
+  it("honors day-of-week instead of matching the same hour tomorrow", () => {
+    // Monday 13:52 UTC; the weekly slot is Monday 13:00, so the next fire is
+    // the following Monday, not Tuesday.
+    const from = new Date("2026-08-24T13:52:00.000Z");
+    expect(nextCronDate("0 13 * * 1", from)).toEqual(new Date("2026-08-31T13:00:00.000Z"));
+  });
+
+  it("maps cron day 7 to Sunday", () => {
+    const from = new Date("2026-08-26T12:00:00.000Z"); // Wednesday
+    expect(nextCronDate("0 9 * * 7", from)).toEqual(new Date("2026-08-30T09:00:00.000Z"));
+  });
+
+  it("evaluates the schedule in the routine timezone", () => {
+    // 10:00 UTC is 06:00 in New York on the same day, so a 7 AM America/New_York
+    // daily slot still fires later the same UTC day.
+    const from = new Date("2026-08-24T10:00:00.000Z");
+    expect(nextCronDate("0 7 * * *", from, "America/New_York")).toEqual(
+      new Date("2026-08-24T11:00:00.000Z"),
+    );
+  });
+
+  it("falls back to UTC for an unknown timezone", () => {
+    const from = new Date("2026-08-24T10:00:00.000Z");
+    expect(nextCronDate("0 7 * * *", from, "Mars/Olympus")).toEqual(
+      new Date("2026-08-25T07:00:00.000Z"),
+    );
   });
 });

--- a/packages/core/src/cron.test.ts
+++ b/packages/core/src/cron.test.ts
@@ -119,6 +119,14 @@ describe("nextCronDate", () => {
     expect(nextCronDate("0 9 * * 7", from)).toEqual(new Date("2026-08-30T09:00:00.000Z"));
   });
 
+  it("supports day 7 inside composite day expressions", () => {
+    const from = new Date("2026-08-26T12:00:00.000Z"); // Wednesday
+    // 1,7 = Monday and Sunday -> next is Sunday Aug 30.
+    expect(nextCronDate("0 9 * * 1,7", from)).toEqual(new Date("2026-08-30T09:00:00.000Z"));
+    // 5-7 = Friday, Saturday, Sunday -> next is Friday Aug 28.
+    expect(nextCronDate("0 9 * * 5-7", from)).toEqual(new Date("2026-08-28T09:00:00.000Z"));
+  });
+
   it("evaluates the schedule in the routine timezone", () => {
     // 10:00 UTC is 06:00 in New York on the same day, so a 7 AM America/New_York
     // daily slot still fires later the same UTC day.

--- a/packages/core/src/cron.ts
+++ b/packages/core/src/cron.ts
@@ -169,7 +169,6 @@ export function nextCronDate(cron: string, from: Date, timezone = "UTC"): Date {
     Fri: 5,
     Sat: 6,
   };
-  const dowExprSunday = dowExpr === undefined ? "*" : dowExpr.replace(/(^|\s)7(?=\s|$)/g, "$10");
   for (let i = 0; i < 8 * 24 * 60 + 2; i += 1) {
     const fields = formatter.formatToParts(candidate);
     const num = (type: string) => Number(fields.find((part) => part.type === type)?.value ?? "0");
@@ -180,13 +179,39 @@ export function nextCronDate(cron: string, from: Date, timezone = "UTC"): Date {
     if (
       matchField(minuteExpr ?? "*", minute, 0, 59) &&
       matchField(hourExpr ?? "*", hour, 0, 23) &&
-      matchField(dowExprSunday, weekday, 0, 6)
+      matchDayOfWeek(dowExpr ?? "*", weekday)
     ) {
       return candidate;
     }
     candidate.setUTCMinutes(candidate.getUTCMinutes() + 1);
   }
   return new Date(from.getTime() + 60_000);
+}
+
+// Day-of-week matching where 7 is a Sunday alias for 0. Supported inside
+// plain values, comma lists, and ranges (a range ending in 7 wraps: 5-7
+// means Fri, Sat, Sun).
+function matchDayOfWeek(expr: string, weekday: number): boolean {
+  if (expr === "*") return true;
+  return expr.split(",").some((item) => {
+    const token = item.trim();
+    if (token === "*") return true;
+    if (token.includes("-")) {
+      const [rawStart, rawEnd] = token.split("-");
+      let start = Number(rawStart);
+      let end = Number(rawEnd);
+      if (start === 7) start = 0;
+      if (end === 7) end = 0;
+      if (!Number.isFinite(start) || !Number.isFinite(end)) return false;
+      return start <= end ? weekday >= start && weekday <= end : weekday >= start || weekday <= end;
+    }
+    if (token.startsWith("*/")) {
+      const step = Number(token.slice(2));
+      return Number.isFinite(step) && step > 0 && weekday % step === 0;
+    }
+    const value = Number(token);
+    return value === weekday || (value === 7 && weekday === 0);
+  });
 }
 
 function parseClock(time: string): { hour: number; minute: number } {

--- a/packages/core/src/cron.ts
+++ b/packages/core/src/cron.ts
@@ -137,14 +137,51 @@ export function nextCronDate(cron: string, from: Date, timezone = "UTC"): Date {
   if (parts.length < 5) {
     return new Date(from.getTime() + 60_000);
   }
-  const [minuteExpr, hourExpr] = parts;
+  const [minuteExpr, hourExpr, , , dowExpr] = parts;
   const candidate = new Date(from.getTime() + 60_000);
   candidate.setSeconds(0, 0);
-  for (let i = 0; i < 24 * 60 + 2; i += 1) {
-    const minute = candidate.getUTCMinutes();
-    const hour = candidate.getUTCHours();
-    if (matchField(minuteExpr ?? "*", minute, 0, 59) && matchField(hourExpr ?? "*", hour, 0, 23)) {
-      void timezone;
+  // Scan up to 8 days so any weekly day-of-week is reachable; evaluate the
+  // cron fields in the routine's timezone instead of silently using UTC.
+  let formatter: Intl.DateTimeFormat;
+  try {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      minute: "numeric",
+      hour: "numeric",
+      weekday: "short",
+      hour12: false,
+    });
+  } catch {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: "UTC",
+      minute: "numeric",
+      hour: "numeric",
+      weekday: "short",
+      hour12: false,
+    });
+  }
+  const weekdayIndex: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  const dowExprSunday = dowExpr === undefined ? "*" : dowExpr.replace(/(^|\s)7(?=\s|$)/g, "$10");
+  for (let i = 0; i < 8 * 24 * 60 + 2; i += 1) {
+    const fields = formatter.formatToParts(candidate);
+    const num = (type: string) => Number(fields.find((part) => part.type === type)?.value ?? "0");
+    const weekdayPart = fields.find((part) => part.type === "weekday")?.value ?? "Sun";
+    const minute = num("minute");
+    const hour = num("hour") % 24;
+    const weekday = weekdayIndex[weekdayPart] ?? 0;
+    if (
+      matchField(minuteExpr ?? "*", minute, 0, 59) &&
+      matchField(hourExpr ?? "*", hour, 0, 23) &&
+      matchField(dowExprSunday, weekday, 0, 6)
+    ) {
       return candidate;
     }
     candidate.setUTCMinutes(candidate.getUTCMinutes() + 1);


### PR DESCRIPTION
## Problem

`nextCronDate` only matched the cron **minute and hour** fields and scanned forward ~24 hours, so the day-of-week field was silently ignored and the `timezone` argument was discarded (`void timezone`):

```ts
const [minuteExpr, hourExpr] = parts;   // dow never read
...
if (matchField(minuteExpr...) && matchField(hourExpr...)) {
  void timezone;                         // accepted but unused
  return candidate;
}
```

Effect on routines with weekly/weekday schedules: they re-queue **daily**. Observed on a live instance:

- A `0 15 * * 5` routine (Friday 3 PM) that fired Friday 15:00 re-queued for **Saturday** 15:00.
- A `0 9 * * 1` routine (Monday 9 AM) that fired Monday 13:52 re-queued for **Tuesday** 13:00.
- A `0 7 * * 6` routine (Saturday 7 AM) re-queued for **Sunday**.

Additionally, cron hours were always evaluated as UTC, so a routine configured at 7:00 with timezone `America/New_York` fired at 3 AM Eastern.

## Fix

- Match the **day-of-week** field, mapping `7` to Sunday so both spellings work.
- Evaluate minute, hour, and weekday **in the routine's timezone** using `Intl.DateTimeFormat`, with a fallback to UTC for unknown identifiers.
- Extend the scan window from 24 hours to 8 days so any weekly slot is reachable (minute granularity retained; worst case ~11.5k formatter calls, well under 100 ms).

## Tests

Five new cases in `packages/core/src/cron.test.ts` covering: same-day daily slots, weekly day-of-week selection (the exact Monday→next-Monday case above), day 7 as Sunday, timezone-aware hour evaluation, and the UTC fallback. All 12 tests in the file and the full `@rakazo/core` suite pass locally.

Found while operating a self-hosted instance with six routines across five bots — happy to adjust anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled task timing across time zones.
  * Added support for complex weekly schedules, including lists, ranges, stepped intervals, and Sunday aliases.
  * Invalid time zones now safely fall back to UTC.
  * Expanded scheduling calculations to reliably find the next occurrence over longer intervals.

* **Tests**
  * Added coverage for daily and weekly schedules, Sunday handling, time zones, and UTC fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->