### PR TITLE
Self-host improvements: Integrations UX, MCP OAuth, per-bot models, computer window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ verify-report
 .last-deployed-revision
 design/
 PRODUCT_PLAN.md
+# Local Studio runtime
+run/
+.nvm-ish.sh
+.rakazo-env.sh

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -160,6 +160,7 @@ export async function createApp(
       "http://127.0.0.1:8081",
       "http://localhost:19006",
       "http://127.0.0.1:19006",
+      ...env.trustedOrigins,
     ],
     beforeDeleteUser: async (userId) => {
       const bots = await prisma.bot.findMany({
@@ -324,6 +325,7 @@ export async function createApp(
 function isTrustedOrigin(origin: string, env: AppEnv) {
   if (!origin) return true;
   if (origin === env.webOrigin || origin === env.apiUrl || origin === env.authUrl) return true;
+  if (env.trustedOrigins.includes(origin)) return true;
   if (origin.startsWith("rakazo://") || origin.startsWith("exp://")) return true;
   try {
     const host = new URL(origin).hostname;

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -68,7 +68,7 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     pipedreamEnvironment:
       source.PIPEDREAM_ENVIRONMENT === "production" ? "production" : "development",
     defaultProvider: source.PI_DEFAULT_PROVIDER ?? "openrouter",
-    defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-vision-exp",
+    defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731",
     wakeupDriver: source.WAKEUP_DRIVER ?? "graphile",
     mcpStdioEnabled: source.MCP_STDIO_ENABLED === "true",
     mcpStdioAllowedCommands: (source.MCP_STDIO_ALLOWED_COMMANDS ?? "")

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -68,7 +68,7 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     pipedreamEnvironment:
       source.PIPEDREAM_ENVIRONMENT === "production" ? "production" : "development",
     defaultProvider: source.PI_DEFAULT_PROVIDER ?? "openrouter",
-    defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731",
+    defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-vision-exp",
     wakeupDriver: source.WAKEUP_DRIVER ?? "graphile",
     mcpStdioEnabled: source.MCP_STDIO_ENABLED === "true",
     mcpStdioAllowedCommands: (source.MCP_STDIO_ALLOWED_COMMANDS ?? "")

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -32,6 +32,7 @@ export interface AppEnv {
   wakeupDriver: string;
   mcpStdioEnabled: boolean;
   mcpStdioAllowedCommands: string[];
+  trustedOrigins: string[];
   port: number;
   gitSha: string | undefined;
 }
@@ -67,10 +68,14 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     pipedreamEnvironment:
       source.PIPEDREAM_ENVIRONMENT === "production" ? "production" : "development",
     defaultProvider: source.PI_DEFAULT_PROVIDER ?? "openrouter",
-    defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731",
+    defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-vision-exp",
     wakeupDriver: source.WAKEUP_DRIVER ?? "graphile",
     mcpStdioEnabled: source.MCP_STDIO_ENABLED === "true",
     mcpStdioAllowedCommands: (source.MCP_STDIO_ALLOWED_COMMANDS ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+    trustedOrigins: (source.TRUSTED_ORIGINS ?? "")
       .split(",")
       .map((value) => value.trim())
       .filter(Boolean),

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -2951,8 +2951,8 @@ function duplicateBotName(name: string) {
   return `${name.slice(0, 75)} copy`;
 }
 
-/** Superhuman/Krisp reject non-localhost HTTP redirects. Allow the app origin
- * plus loopback so MCP OAuth can complete through an SSH tunnel to Vite. */
+/** Some MCP OAuth providers reject non-localhost HTTP redirects. Allow the app origin
+ * plus loopback so a tunnelled Vite callback can complete. */
 function isAllowedMcpOauthRedirect(redirectUri: string, webOrigin: string) {
   try {
     const url = new URL(redirectUri);

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -493,6 +493,8 @@ export function createRouter(deps: RouterDeps) {
           notifyOnFinish: source.notifyOnFinish,
           color: source.color,
           computerMode: source.computer?.scope === "dedicated" ? "dedicated" : "team",
+          modelProvider: source.modelProvider,
+          modelId: source.modelId,
         });
         const assignments = await deps.prisma.botMcpServer.findMany({
           where: {
@@ -542,6 +544,8 @@ export function createRouter(deps: RouterDeps) {
             sectionId: input.sectionId,
             voiceId: input.voiceId,
             autoSpeak: input.autoSpeak,
+            modelProvider: input.modelProvider,
+            modelId: input.modelId,
           },
         });
         const bots = await repos.listBots(context.actor);
@@ -2072,8 +2076,7 @@ export function createRouter(deps: RouterDeps) {
       oauth: {
         begin: authed.mcp.oauth.begin.handler(async ({ context, input }) => {
           try {
-            const expectedRedirect = new URL("/mcp/oauth/callback", deps.env.webOrigin).toString();
-            if (new URL(input.redirectUri).toString() !== expectedRedirect) {
+            if (!isAllowedMcpOauthRedirect(input.redirectUri, deps.env.webOrigin)) {
               throw new Error("MCP OAuth redirect URI is not allowed");
             }
             return await mcpOAuth.begin({
@@ -2087,12 +2090,16 @@ export function createRouter(deps: RouterDeps) {
             });
           }
         }),
-        complete: authed.mcp.oauth.complete.handler(async ({ context, input }) => {
+        complete: os.mcp.oauth.complete.handler(async ({ input }) => {
           try {
+            const session = await deps.prisma.mcpOAuthSession.findFirst({
+              where: { id: input.sessionId },
+            });
+            if (!session) throw new Error("MCP OAuth session is invalid or expired");
             await mcpOAuth.complete({
               ...input,
-              workspaceId: context.actor.workspaceId,
-              userId: context.actor.userId,
+              workspaceId: session.workspaceId,
+              userId: session.userId,
             });
             return { ok: true as const };
           } catch (error) {
@@ -2942,4 +2949,25 @@ function withViewOnly(url: string, viewOnly: boolean) {
 
 function duplicateBotName(name: string) {
   return `${name.slice(0, 75)} copy`;
+}
+
+/** Superhuman/Krisp reject non-localhost HTTP redirects. Allow the app origin
+ * plus loopback so MCP OAuth can complete through an SSH tunnel to Vite. */
+function isAllowedMcpOauthRedirect(redirectUri: string, webOrigin: string) {
+  try {
+    const url = new URL(redirectUri);
+    if (url.pathname !== "/mcp/oauth/callback") return false;
+    if (url.protocol === "http:") {
+      return url.hostname === "127.0.0.1" || url.hostname === "localhost";
+    }
+    if (url.toString() === new URL("/mcp/oauth/callback", webOrigin).toString()) return true;
+    // Public HTTPS callback via Tailscale Funnel on :443 (no custom port).
+    return (
+      url.protocol === "https:" &&
+      url.port === "" &&
+      (url.hostname === "macstudio.lenok-truck.ts.net" || url.hostname.endsWith(".ts.net"))
+    );
+  } catch {
+    return false;
+  }
 }

--- a/apps/web/src/lib/mcp-connect.ts
+++ b/apps/web/src/lib/mcp-connect.ts
@@ -19,8 +19,8 @@ export type McpOauthResult =
 export async function connectMcpOauth(serverId: string): Promise<McpOauthResult> {
   const started = await rpc.mcp.oauth.begin({
     serverId,
-    // Superhuman/Krisp reject non-loopback HTTP and most custom HTTPS URIs.
-    // A local catcher on this machine receives the code and posts it to Rakazo.
+    // Some providers reject non-loopback HTTP and most custom HTTPS URIs.
+    // A local catcher receives the code and posts it to Rakazo.
     redirectUri: "https://macstudio.lenok-truck.ts.net/mcp/oauth/callback",
   });
   if (started.status !== "authorization_required") return started.status;

--- a/apps/web/src/lib/mcp-connect.ts
+++ b/apps/web/src/lib/mcp-connect.ts
@@ -14,11 +14,14 @@ export type McpOauthResult =
  * broadcasts completion or the popup is closed without finishing.
  *
  * The BroadcastChannel (not window.opener) is the completion signal because
- * provider login pages with COOP sever the opener link. */
+ * provider login pages with COOP sever the opener link. Loopback callbacks
+ * are a different origin, so we also poll oauthStatus. */
 export async function connectMcpOauth(serverId: string): Promise<McpOauthResult> {
   const started = await rpc.mcp.oauth.begin({
     serverId,
-    redirectUri: `${window.location.origin}/mcp/oauth/callback`,
+    // Superhuman/Krisp reject non-loopback HTTP and most custom HTTPS URIs.
+    // A local catcher on this machine receives the code and posts it to Rakazo.
+    redirectUri: "https://macstudio.lenok-truck.ts.net/mcp/oauth/callback",
   });
   if (started.status !== "authorization_required") return started.status;
   const popup = window.open(
@@ -35,19 +38,36 @@ export async function connectMcpOauth(serverId: string): Promise<McpOauthResult>
     const channel = new BroadcastChannel(MCP_OAUTH_CHANNEL);
     let settled = false;
     let pollTimer = 0;
+    let statusTimer = 0;
     let timeoutTimer = 0;
     const finish = (result: McpOauthResult) => {
       if (settled) return;
       settled = true;
       window.clearInterval(pollTimer);
+      window.clearInterval(statusTimer);
       window.clearTimeout(timeoutTimer);
       channel.close();
       resolve(result);
     };
     pollTimer = window.setInterval(() => {
       if (!popup.closed) return;
-      finish("cancelled");
+      void rpc.mcp.servers
+        .list()
+        .then((servers) => {
+          const server = servers.find((entry) => entry.id === serverId);
+          finish(server?.oauthStatus === "connected" ? "connected" : "cancelled");
+        })
+        .catch(() => finish("cancelled"));
     }, 500);
+    statusTimer = window.setInterval(() => {
+      void rpc.mcp.servers
+        .list()
+        .then((servers) => {
+          const server = servers.find((entry) => entry.id === serverId);
+          if (server?.oauthStatus === "connected") finish("connected");
+        })
+        .catch(() => undefined);
+    }, 1500);
     timeoutTimer = window.setTimeout(() => {
       popup.close();
       finish("cancelled");

--- a/apps/web/src/pages/McpServersOverlay.tsx
+++ b/apps/web/src/pages/McpServersOverlay.tsx
@@ -5,9 +5,15 @@ import { connectMcpOauth, MCP_OAUTH_CHANNEL } from "../lib/mcp-connect";
 import { rpc } from "../lib/rpc";
 
 function oauthStatusText(server: McpServer): string {
-  if (server.oauthStatus === "connected") return "OAuth connected";
-  if (server.oauthStatus === "reconnect") return "Authorization expired — reconnect required";
-  return server.hasSecret ? "Encrypted static credential saved" : "No credential saved";
+  if (server.oauthStatus === "connected" || server.transport === "stdio") return "Connected";
+  if (server.oauthStatus === "reconnect") return "Disconnected";
+  return "Disconnected";
+}
+
+function oauthStatusClass(server: McpServer): string {
+  return server.oauthStatus === "connected" || server.transport === "stdio"
+    ? "text-[#3DDC84]"
+    : "text-[#F05252]";
 }
 
 function oauthActionLabel(server: McpServer, pending: boolean): string {
@@ -406,9 +412,7 @@ export function McpServersOverlay({ onClose }: { onClose: () => void }) {
                       <p className="mt-1 text-xs text-[#77777F]">
                         {server.endpoint ?? server.command ?? server.slug}
                       </p>
-                      <p
-                        className={`mt-2 text-[11px] ${server.oauthStatus === "reconnect" ? "text-[#F0A15A]" : "text-[#6E778A]"}`}
-                      >
+                      <p className={`mt-2 text-[11px] ${oauthStatusClass(server)}`}>
                         {oauthStatusText(server)}
                       </p>
                       <div className="mt-3 flex flex-wrap items-center gap-1.5">

--- a/apps/web/src/pages/McpServersOverlay.tsx
+++ b/apps/web/src/pages/McpServersOverlay.tsx
@@ -236,100 +236,12 @@ export function McpServersOverlay({ onClose }: { onClose: () => void }) {
             ✕
           </button>
         </header>
-        <div className="border-b border-[#27272C] px-8 py-3 text-sm text-[#C9C9CE]">
-          {servers.length === 0
-            ? "No MCP servers configured."
-            : servers.map((server) => server.name).join(" · ")}
-        </div>
         {error ? (
           <p className="mx-8 mt-5 rounded-xl border border-[#6A2C37] bg-[#2A151A] p-3 text-xs text-[#F3A2AA]">
             {error}
           </p>
         ) : null}
-        <div className="rk-scroll min-h-0 space-y-6 overflow-y-auto p-8">
-          <div>
-            <h2 className="text-[15px] font-medium text-[#ECECEE]">Configured servers</h2>
-            <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-3">
-              {servers.length === 0 ? (
-                <p className="rounded-xl border border-dashed border-[#34343B] p-5 text-sm text-[#77777F] lg:col-span-3">
-                  No MCP servers yet.
-                </p>
-              ) : (
-                servers.map((server) => (
-                  <div
-                    key={server.id}
-                    className="rounded-xl border border-[#292930] bg-[#101012] p-4"
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="font-medium text-[#ECECEE]">{server.name}</span>
-                      <span className="rounded-full bg-[#202536] px-2 py-1 text-[10px] uppercase text-[#AEB7FF]">
-                        {server.transport.replace("_", " ")}
-                      </span>
-                    </div>
-                    <p className="mt-1 truncate text-xs text-[#77777F]">
-                      {server.endpoint ?? server.command ?? server.slug}
-                    </p>
-                    <p
-                      className={`mt-2 text-[11px] ${server.oauthStatus === "reconnect" ? "text-[#F0A15A]" : "text-[#6E778A]"}`}
-                    >
-                      {oauthStatusText(server)}
-                    </p>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      {server.transport !== "stdio" ? (
-                        <>
-                          <button
-                            type="button"
-                            disabled={oauthPending === server.id}
-                            onClick={() => void connectOAuth(server)}
-                            className="rounded-lg bg-[#7785FF] px-3 py-2 text-xs font-semibold text-[#090A12] disabled:opacity-50"
-                          >
-                            {oauthActionLabel(server, oauthPending === server.id)}
-                          </button>
-                          {server.oauthStatus !== "none" ? (
-                            <button
-                              type="button"
-                              disabled={oauthPending === server.id}
-                              onClick={() => void disconnectOAuth(server)}
-                              className="rounded-lg border border-[#34343B] px-3 py-2 text-xs text-[#B9B9C0]"
-                            >
-                              Disconnect
-                            </button>
-                          ) : null}
-                        </>
-                      ) : null}
-                      <button
-                        type="button"
-                        onClick={() => void deleteServer(server)}
-                        className={`ml-auto rounded-lg border px-3 py-2 text-xs ${confirmingDelete === server.id ? "border-[#B4434F] bg-[#3A1A20] text-[#F3A2AA]" : "border-[#34343B] text-[#B9B9C0]"}`}
-                      >
-                        {confirmingDelete === server.id ? "Confirm delete" : "Delete"}
-                      </button>
-                    </div>
-                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
-                      <span className="text-[11px] text-[#77777F]">Agents:</span>
-                      {bots.map((bot) => {
-                        const assigned = (botAssignments[bot.id] ?? []).some(
-                          (entry) => entry.serverId === server.id,
-                        );
-                        return (
-                          <button
-                            key={bot.id}
-                            type="button"
-                            onClick={() => void toggleAssignment(server, bot.id)}
-                            className={`rounded-full border px-2.5 py-1 text-[11px] ${assigned ? "border-[#7785FF] bg-[#30356A] text-[#E2E4FF]" : "border-[#34343B] text-[#85858B]"}`}
-                          >
-                            {assigned ? "✓ " : ""}
-                            {bot.name}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ))
-              )}
-            </div>
-          </div>
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_1.08fr]">
+        <div className="rk-scroll grid min-h-0 grid-cols-1 gap-6 overflow-y-auto p-8 lg:grid-cols-[1fr_1.08fr]">
           <div className="rounded-2xl border border-[#292930] bg-[#101012] p-5">
             <h2 className="text-[15px] font-medium text-[#ECECEE]">Add a server</h2>
             <p className="mb-5 mt-1 text-xs text-[#77777F]">
@@ -449,7 +361,7 @@ export function McpServersOverlay({ onClose }: { onClose: () => void }) {
                 Applies when you click Add server. Use the agent chips on each server card to change
                 access at any time — the agent picks it up on its next message.
               </p>
-              <div className="rk-scroll mt-3 max-h-[280px] space-y-2 overflow-y-auto pr-1">
+              <div className="mt-3 space-y-2">
                 {bots.map((bot) => (
                   <label
                     key={bot.id}
@@ -472,7 +384,88 @@ export function McpServersOverlay({ onClose }: { onClose: () => void }) {
                 ))}
               </div>
             </div>
-          </div>
+            <div>
+              <h2 className="text-[15px] font-medium text-[#ECECEE]">Configured servers</h2>
+              <div className="mt-3 space-y-2">
+                {servers.length === 0 ? (
+                  <p className="rounded-xl border border-dashed border-[#34343B] p-5 text-sm text-[#77777F]">
+                    No MCP servers yet.
+                  </p>
+                ) : (
+                  servers.map((server) => (
+                    <div
+                      key={server.id}
+                      className="rounded-xl border border-[#292930] bg-[#101012] p-4"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-[#ECECEE]">{server.name}</span>
+                        <span className="rounded-full bg-[#202536] px-2 py-1 text-[10px] uppercase text-[#AEB7FF]">
+                          {server.transport.replace("_", " ")}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-[#77777F]">
+                        {server.endpoint ?? server.command ?? server.slug}
+                      </p>
+                      <p
+                        className={`mt-2 text-[11px] ${server.oauthStatus === "reconnect" ? "text-[#F0A15A]" : "text-[#6E778A]"}`}
+                      >
+                        {oauthStatusText(server)}
+                      </p>
+                      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                        <span className="text-[11px] text-[#77777F]">Agents:</span>
+                        {bots.map((bot) => {
+                          const assigned = (botAssignments[bot.id] ?? []).some(
+                            (entry) => entry.serverId === server.id,
+                          );
+                          return (
+                            <button
+                              key={bot.id}
+                              type="button"
+                              onClick={() => void toggleAssignment(server, bot.id)}
+                              className={`rounded-full border px-2.5 py-1 text-[11px] ${assigned ? "border-[#7785FF] bg-[#30356A] text-[#E2E4FF]" : "border-[#34343B] text-[#85858B]"}`}
+                            >
+                              {assigned ? "✓ " : ""}
+                              {bot.name}
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {server.transport !== "stdio" ? (
+                          <>
+                            <button
+                              type="button"
+                              disabled={oauthPending === server.id}
+                              onClick={() => void connectOAuth(server)}
+                              className="rounded-lg bg-[#7785FF] px-3 py-2 text-xs font-semibold text-[#090A12] disabled:opacity-50"
+                            >
+                              {oauthActionLabel(server, oauthPending === server.id)}
+                            </button>
+                            {server.oauthStatus !== "none" ? (
+                              <button
+                                type="button"
+                                disabled={oauthPending === server.id}
+                                onClick={() => void disconnectOAuth(server)}
+                                className="rounded-lg border border-[#34343B] px-3 py-2 text-xs text-[#B9B9C0]"
+                              >
+                                Disconnect
+                              </button>
+                            ) : null}
+                          </>
+                        ) : null}
+                        <button
+                          type="button"
+                          onClick={() => void deleteServer(server)}
+                          className={`ml-auto rounded-lg border px-3 py-2 text-xs ${confirmingDelete === server.id ? "border-[#B4434F] bg-[#3A1A20] text-[#F3A2AA]" : "border-[#34343B] text-[#B9B9C0]"}`}
+                        >
+                          {confirmingDelete === server.id ? "Confirm delete" : "Delete"}
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/apps/web/src/pages/McpServersOverlay.tsx
+++ b/apps/web/src/pages/McpServersOverlay.tsx
@@ -236,12 +236,100 @@ export function McpServersOverlay({ onClose }: { onClose: () => void }) {
             ✕
           </button>
         </header>
+        <div className="border-b border-[#27272C] px-8 py-3 text-sm text-[#C9C9CE]">
+          {servers.length === 0
+            ? "No MCP servers configured."
+            : servers.map((server) => server.name).join(" · ")}
+        </div>
         {error ? (
           <p className="mx-8 mt-5 rounded-xl border border-[#6A2C37] bg-[#2A151A] p-3 text-xs text-[#F3A2AA]">
             {error}
           </p>
         ) : null}
-        <div className="rk-scroll grid min-h-0 grid-cols-1 gap-6 overflow-y-auto p-8 lg:grid-cols-[1fr_1.08fr]">
+        <div className="rk-scroll min-h-0 space-y-6 overflow-y-auto p-8">
+          <div>
+            <h2 className="text-[15px] font-medium text-[#ECECEE]">Configured servers</h2>
+            <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-3">
+              {servers.length === 0 ? (
+                <p className="rounded-xl border border-dashed border-[#34343B] p-5 text-sm text-[#77777F] lg:col-span-3">
+                  No MCP servers yet.
+                </p>
+              ) : (
+                servers.map((server) => (
+                  <div
+                    key={server.id}
+                    className="rounded-xl border border-[#292930] bg-[#101012] p-4"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium text-[#ECECEE]">{server.name}</span>
+                      <span className="rounded-full bg-[#202536] px-2 py-1 text-[10px] uppercase text-[#AEB7FF]">
+                        {server.transport.replace("_", " ")}
+                      </span>
+                    </div>
+                    <p className="mt-1 truncate text-xs text-[#77777F]">
+                      {server.endpoint ?? server.command ?? server.slug}
+                    </p>
+                    <p
+                      className={`mt-2 text-[11px] ${server.oauthStatus === "reconnect" ? "text-[#F0A15A]" : "text-[#6E778A]"}`}
+                    >
+                      {oauthStatusText(server)}
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {server.transport !== "stdio" ? (
+                        <>
+                          <button
+                            type="button"
+                            disabled={oauthPending === server.id}
+                            onClick={() => void connectOAuth(server)}
+                            className="rounded-lg bg-[#7785FF] px-3 py-2 text-xs font-semibold text-[#090A12] disabled:opacity-50"
+                          >
+                            {oauthActionLabel(server, oauthPending === server.id)}
+                          </button>
+                          {server.oauthStatus !== "none" ? (
+                            <button
+                              type="button"
+                              disabled={oauthPending === server.id}
+                              onClick={() => void disconnectOAuth(server)}
+                              className="rounded-lg border border-[#34343B] px-3 py-2 text-xs text-[#B9B9C0]"
+                            >
+                              Disconnect
+                            </button>
+                          ) : null}
+                        </>
+                      ) : null}
+                      <button
+                        type="button"
+                        onClick={() => void deleteServer(server)}
+                        className={`ml-auto rounded-lg border px-3 py-2 text-xs ${confirmingDelete === server.id ? "border-[#B4434F] bg-[#3A1A20] text-[#F3A2AA]" : "border-[#34343B] text-[#B9B9C0]"}`}
+                      >
+                        {confirmingDelete === server.id ? "Confirm delete" : "Delete"}
+                      </button>
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                      <span className="text-[11px] text-[#77777F]">Agents:</span>
+                      {bots.map((bot) => {
+                        const assigned = (botAssignments[bot.id] ?? []).some(
+                          (entry) => entry.serverId === server.id,
+                        );
+                        return (
+                          <button
+                            key={bot.id}
+                            type="button"
+                            onClick={() => void toggleAssignment(server, bot.id)}
+                            className={`rounded-full border px-2.5 py-1 text-[11px] ${assigned ? "border-[#7785FF] bg-[#30356A] text-[#E2E4FF]" : "border-[#34343B] text-[#85858B]"}`}
+                          >
+                            {assigned ? "✓ " : ""}
+                            {bot.name}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_1.08fr]">
           <div className="rounded-2xl border border-[#292930] bg-[#101012] p-5">
             <h2 className="text-[15px] font-medium text-[#ECECEE]">Add a server</h2>
             <p className="mb-5 mt-1 text-xs text-[#77777F]">
@@ -361,7 +449,7 @@ export function McpServersOverlay({ onClose }: { onClose: () => void }) {
                 Applies when you click Add server. Use the agent chips on each server card to change
                 access at any time — the agent picks it up on its next message.
               </p>
-              <div className="mt-3 space-y-2">
+              <div className="rk-scroll mt-3 max-h-[280px] space-y-2 overflow-y-auto pr-1">
                 {bots.map((bot) => (
                   <label
                     key={bot.id}
@@ -384,88 +472,7 @@ export function McpServersOverlay({ onClose }: { onClose: () => void }) {
                 ))}
               </div>
             </div>
-            <div>
-              <h2 className="text-[15px] font-medium text-[#ECECEE]">Configured servers</h2>
-              <div className="mt-3 space-y-2">
-                {servers.length === 0 ? (
-                  <p className="rounded-xl border border-dashed border-[#34343B] p-5 text-sm text-[#77777F]">
-                    No MCP servers yet.
-                  </p>
-                ) : (
-                  servers.map((server) => (
-                    <div
-                      key={server.id}
-                      className="rounded-xl border border-[#292930] bg-[#101012] p-4"
-                    >
-                      <div className="flex items-center justify-between">
-                        <span className="font-medium text-[#ECECEE]">{server.name}</span>
-                        <span className="rounded-full bg-[#202536] px-2 py-1 text-[10px] uppercase text-[#AEB7FF]">
-                          {server.transport.replace("_", " ")}
-                        </span>
-                      </div>
-                      <p className="mt-1 text-xs text-[#77777F]">
-                        {server.endpoint ?? server.command ?? server.slug}
-                      </p>
-                      <p
-                        className={`mt-2 text-[11px] ${server.oauthStatus === "reconnect" ? "text-[#F0A15A]" : "text-[#6E778A]"}`}
-                      >
-                        {oauthStatusText(server)}
-                      </p>
-                      <div className="mt-3 flex flex-wrap items-center gap-1.5">
-                        <span className="text-[11px] text-[#77777F]">Agents:</span>
-                        {bots.map((bot) => {
-                          const assigned = (botAssignments[bot.id] ?? []).some(
-                            (entry) => entry.serverId === server.id,
-                          );
-                          return (
-                            <button
-                              key={bot.id}
-                              type="button"
-                              onClick={() => void toggleAssignment(server, bot.id)}
-                              className={`rounded-full border px-2.5 py-1 text-[11px] ${assigned ? "border-[#7785FF] bg-[#30356A] text-[#E2E4FF]" : "border-[#34343B] text-[#85858B]"}`}
-                            >
-                              {assigned ? "✓ " : ""}
-                              {bot.name}
-                            </button>
-                          );
-                        })}
-                      </div>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {server.transport !== "stdio" ? (
-                          <>
-                            <button
-                              type="button"
-                              disabled={oauthPending === server.id}
-                              onClick={() => void connectOAuth(server)}
-                              className="rounded-lg bg-[#7785FF] px-3 py-2 text-xs font-semibold text-[#090A12] disabled:opacity-50"
-                            >
-                              {oauthActionLabel(server, oauthPending === server.id)}
-                            </button>
-                            {server.oauthStatus !== "none" ? (
-                              <button
-                                type="button"
-                                disabled={oauthPending === server.id}
-                                onClick={() => void disconnectOAuth(server)}
-                                className="rounded-lg border border-[#34343B] px-3 py-2 text-xs text-[#B9B9C0]"
-                              >
-                                Disconnect
-                              </button>
-                            ) : null}
-                          </>
-                        ) : null}
-                        <button
-                          type="button"
-                          onClick={() => void deleteServer(server)}
-                          className={`ml-auto rounded-lg border px-3 py-2 text-xs ${confirmingDelete === server.id ? "border-[#B4434F] bg-[#3A1A20] text-[#F3A2AA]" : "border-[#34343B] text-[#B9B9C0]"}`}
-                        >
-                          {confirmingDelete === server.id ? "Confirm delete" : "Delete"}
-                        </button>
-                      </div>
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
+          </div>
           </div>
         </div>
       </section>

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -292,33 +292,28 @@ export function PluginsOverlay({
           {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
           {loading ? <p className="text-[#6C6C70]">Loading integrations…</p> : null}
 
-          {!loading && mcpServers.length > 0 ? (
-            <div className="mb-6">
-              <div className="mb-2 flex items-center justify-between">
-                <h2 className="text-[15px] font-medium text-[#ECECEE]">Installed</h2>
-                {onOpenMcp ? (
-                  <button
-                    type="button"
-                    onClick={onOpenMcp}
-                    className="text-[12.5px] text-[#C9C9CE] hover:text-[#ECECEE]"
-                  >
-                    Manage
-                  </button>
-                ) : null}
-              </div>
+          {view === "sources" ? (
+            <div className="space-y-4">
               {mcpServers.map((server) => (
                 <div key={server.id} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">
                   <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold uppercase text-[#ECECEE]">
                     {server.name[0]}
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="text-[15.5px] font-medium text-[#ECECEE]">{server.name}</div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-[15.5px] font-medium text-[#ECECEE]">{server.name}</span>
+                      <span className="rounded-full bg-[#202536] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[#AEB7FF]">
+                        MCP
+                      </span>
+                    </div>
                     <div className="truncate text-[13.5px] text-[#7A7A80]">
                       {server.oauthStatus === "connected"
                         ? "Connected"
                         : server.oauthStatus === "reconnect"
                           ? "Needs reconnection"
-                          : server.endpoint ?? server.command ?? server.slug}
+                          : "Needs authorization"}
+                      {" · "}
+                      {server.endpoint ?? server.command ?? server.slug}
                     </div>
                   </div>
                   {server.transport !== "stdio" && server.oauthStatus !== "connected" ? (
@@ -331,7 +326,9 @@ export function PluginsOverlay({
                         setOauthPending(server.id);
                         void connectMcpOauth(server.id)
                           .then((result) => {
-                            if (result === "connected") void refresh();
+                            if (result === "connected" || result === "already_connected") {
+                              void refresh();
+                            }
                           })
                           .catch((err: unknown) =>
                             setError(err instanceof Error ? err.message : "OAuth failed"),
@@ -341,14 +338,13 @@ export function PluginsOverlay({
                     >
                       {oauthPending === server.id ? "Connecting…" : "Connect"}
                     </Button>
+                  ) : onOpenMcp ? (
+                    <Button type="button" variant="pill" size="sm" onClick={onOpenMcp}>
+                      Manage
+                    </Button>
                   ) : null}
                 </div>
               ))}
-            </div>
-          ) : null}
-
-          {view === "sources" ? (
-            <div className="space-y-4">
               {sourceKind ? (
                 <div className="space-y-3 rounded-[16px] border border-[#2C2C30] bg-[#101012] p-5">
                   <div className="text-base font-medium text-[#ECECEE]">
@@ -431,7 +427,7 @@ export function PluginsOverlay({
                 </div>
               ) : null}
 
-              {sources.length === 0 && !sourceKind ? (
+              {sources.length === 0 && mcpServers.length === 0 && !sourceKind ? (
                 <p className="text-[#6C6C70]">No MCP or API tool sources installed yet.</p>
               ) : null}
               {sources.map((source) => (
@@ -440,10 +436,14 @@ export function PluginsOverlay({
                     {source.kind === "mcp" ? "M" : "A"}
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="text-[15.5px] font-medium text-[#ECECEE]">{source.name}</div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-[15.5px] font-medium text-[#ECECEE]">{source.name}</span>
+                      <span className="rounded-full bg-[#202536] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[#AEB7FF]">
+                        {source.kind === "mcp" ? "MCP" : "API"}
+                      </span>
+                    </div>
                     <div className="truncate text-[13.5px] text-[#7A7A80]">
-                      {source.kind.toUpperCase()} · {source.source} ·{" "}
-                      {source.secretConfigured ? "credential saved" : "no auth"}
+                      {source.source} · {source.secretConfigured ? "credential saved" : "no auth"}
                     </div>
                   </div>
                   <Button
@@ -460,10 +460,10 @@ export function PluginsOverlay({
             </div>
           ) : (
             <>
-              {!loading && catalog.length === 0 && mcpServers.length === 0 ? (
+              {!loading && catalog.length === 0 ? (
                 <p className="text-[#6C6C70]">
-                  No managed app catalog is configured on this deployment. You can still add Treg,
-                  MCP, or OpenAPI sources.
+                  No managed app catalog is configured on this deployment. MCP servers like Krisp
+                  and Superhuman are under Tool sources.
                 </p>
               ) : null}
               {!loading && catalog.length > 0 && visible.length === 0 ? (

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -8,6 +8,15 @@ import { rpc } from "../lib/rpc";
 type CatalogView = "all" | "connected" | "sources";
 type SourceKind = "treg" | "mcp" | "api";
 
+function mcpConnectionStatus(server: McpServer) {
+  const ok = server.oauthStatus === "connected" || server.transport === "stdio";
+  return {
+    ok,
+    label: ok ? "Connected" : "Disconnected",
+    className: ok ? "text-[#3DDC84]" : "text-[#F05252]",
+  };
+}
+
 function itemKey(item: Pick<ConnectionCatalogItem, "connectorId" | "slug">) {
   return `${item.connectorId}:${item.slug}`;
 }
@@ -355,11 +364,9 @@ export function PluginsOverlay({
                       </span>
                     </div>
                     <div className="truncate text-[13.5px] text-[#7A7A80]">
-                      {server.oauthStatus === "connected"
-                        ? "Connected"
-                        : server.oauthStatus === "reconnect"
-                          ? "Needs reconnection"
-                          : "Needs authorization"}
+                      <span className={mcpConnectionStatus(server).className}>
+                        {mcpConnectionStatus(server).label}
+                      </span>
                       {" · "}
                       {server.endpoint ?? server.command ?? server.slug}
                     </div>

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -459,8 +459,8 @@ export function PluginsOverlay({
             <>
               {!loading && catalog.length === 0 ? (
                 <p className="text-[#6C6C70]">
-                  No managed app catalog is configured on this deployment. MCP servers like Krisp
-                  and Superhuman are under Tool sources.
+                  No managed app catalog is configured on this deployment. Added MCP servers appear
+                  under Tool sources.
                 </p>
               ) : null}
               {!loading && catalog.length > 0 && visible.length === 0 ? (

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -49,9 +49,9 @@ export function PluginsOverlay({
 
   async function refresh() {
     const [items, installs, servers] = await Promise.all([
-      rpc.connections.catalog({}),
-      rpc.capabilities.list(),
-      rpc.mcp.servers.list().catch(() => [] as McpServer[]),
+      rpc.connections.catalog({}).catch(() => [] as ConnectionCatalogItem[]),
+      rpc.capabilities.list().catch(() => [] as CapabilityInstall[]),
+      rpc.mcp.servers.list(),
     ]);
     setCatalog(items);
     setSources(installs.filter((install) => install.kind === "mcp" || install.kind === "api"));
@@ -427,9 +427,6 @@ export function PluginsOverlay({
                 </div>
               ) : null}
 
-              {sources.length === 0 && mcpServers.length === 0 && !sourceKind ? (
-                <p className="text-[#6C6C70]">No MCP or API tool sources installed yet.</p>
-              ) : null}
               {sources.map((source) => (
                 <div key={source.id} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">
                   <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold uppercase text-[#ECECEE]">

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -31,7 +31,8 @@ export function PluginsOverlay({
   onOpenMcp?: () => void;
 }) {
   const [query, setQuery] = useState("");
-  const [view, setView] = useState<CatalogView>("all");
+  const [view, setView] = useState<CatalogView>("sources");
+  const [tregInfoOpen, setTregInfoOpen] = useState(false);
   const [catalog, setCatalog] = useState<ConnectionCatalogItem[]>([]);
   const [sources, setSources] = useState<CapabilityInstall[]>([]);
   const [sourceKind, setSourceKind] = useState<SourceKind | null>(null);
@@ -214,43 +215,66 @@ export function PluginsOverlay({
           <div>
             <div className="text-2xl font-medium text-[#F1F1F2]">Integrations</div>
             <p className="mt-1 text-[13.5px] text-[#7A7A80]">
-              Connect apps or add Treg, MCP, and OpenAPI tool sources.
+              Tool servers for your agents. App catalog is optional.
             </p>
           </div>
-          <div className="flex items-center gap-3">
-            {onOpenMcp ? (
-              <button
-                type="button"
-                onClick={onOpenMcp}
-                className="rounded-full border border-[#383844] px-3 py-1.5 text-xs text-[#C9C9CE] hover:bg-[#232327]"
-              >
-                MCP servers
-              </button>
-            ) : null}
-            <button
-              type="button"
-              aria-label="Close integrations"
-              onClick={onClose}
-              className="text-[#85858A]"
-            >
-              ✕
-            </button>
-          </div>
+          <button
+            type="button"
+            aria-label="Close integrations"
+            onClick={onClose}
+            className="text-[#85858A]"
+          >
+            ✕
+          </button>
         </div>
 
-        <div className="flex flex-wrap gap-2 px-8 pt-4">
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("treg")}>
-            Add Treg
-          </Button>
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("mcp")}>
+        <div className="flex flex-wrap items-center gap-2 px-8 pt-4">
+          <Button
+            type="button"
+            variant="pill"
+            size="sm"
+            onClick={() => (onOpenMcp ? onOpenMcp() : beginSource("mcp"))}
+          >
             Add MCP server
           </Button>
           <Button type="button" variant="pill" size="sm" onClick={() => beginSource("api")}>
             Add OpenAPI
           </Button>
+          <span className="relative inline-flex items-center gap-1">
+            <Button type="button" variant="pill" size="sm" onClick={() => beginSource("treg")}>
+              Add Treg
+            </Button>
+            <button
+              type="button"
+              aria-label="What is Treg?"
+              aria-expanded={tregInfoOpen}
+              onClick={() => setTregInfoOpen((open) => !open)}
+              className="grid h-7 w-7 place-items-center rounded-full border border-[#383844] text-[11px] font-medium text-[#C9C9CE] hover:bg-[#232327]"
+            >
+              i
+            </button>
+            {tregInfoOpen ? (
+              <div
+                role="dialog"
+                aria-label="About Treg"
+                className="absolute left-0 top-9 z-10 w-[320px] rounded-2xl border border-[#2C2C30] bg-[#1A1A1D] p-3.5 text-[13px] leading-5 text-[#C9C9CE] shadow-[0_18px_40px_rgba(0,0,0,.45)]"
+              >
+                Treg is a paid catalog of extra agent tools (SEO, ads, outreach) behind one API
+                key. You do not need it for MCP servers you already added.
+                <a
+                  href="https://treg.to"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-2 block text-[#AEB7FF] hover:underline"
+                >
+                  treg.to
+                </a>
+              </div>
+            ) : null}
+          </span>
         </div>
 
-        {view !== "sources" ? (
+        {catalog.length > 0 && view !== "sources" ? (
           <div className="px-8 pt-4">
             <input
               value={query}
@@ -261,28 +285,30 @@ export function PluginsOverlay({
           </div>
         ) : null}
 
-        <div role="tablist" aria-label="Integration views" className="flex gap-1 px-8 pt-4">
-          {(["all", "connected", "sources"] as const).map((option) => (
-            <button
-              key={option}
-              type="button"
-              role="tab"
-              aria-selected={view === option}
-              aria-controls="integration-list"
-              onClick={() => {
-                setView(option);
-                if (option !== "sources") setSourceKind(null);
-              }}
-              className={`rounded-full px-3.5 py-1.5 text-sm transition-colors ${
-                view === option
-                  ? "bg-[#2C2C30] text-[#F1F1F2]"
-                  : "text-[#7A7A80] hover:text-[#C8C8CC]"
-              }`}
-            >
-              {option === "all" ? "Apps" : option === "connected" ? "Connected" : "Tool sources"}
-            </button>
-          ))}
-        </div>
+        {catalog.length > 0 ? (
+          <div role="tablist" aria-label="Integration views" className="flex gap-1 px-8 pt-4">
+            {(["sources", "all", "connected"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                role="tab"
+                aria-selected={view === option}
+                aria-controls="integration-list"
+                onClick={() => {
+                  setView(option);
+                  if (option !== "sources") setSourceKind(null);
+                }}
+                className={`rounded-full px-3.5 py-1.5 text-sm transition-colors ${
+                  view === option
+                    ? "bg-[#2C2C30] text-[#F1F1F2]"
+                    : "text-[#7A7A80] hover:text-[#C8C8CC]"
+                }`}
+              >
+                {option === "sources" ? "Tool servers" : option === "all" ? "Apps" : "Connected apps"}
+              </button>
+            ))}
+          </div>
+        ) : null}
 
         <div
           id="integration-list"
@@ -292,7 +318,7 @@ export function PluginsOverlay({
           {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
           {loading ? <p className="text-[#6C6C70]">Loading integrations…</p> : null}
 
-          {view === "sources" ? (
+          {view === "sources" || catalog.length === 0 ? (
             <div className="space-y-4">
               {mcpServers.map((server) => (
                 <div key={server.id} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -32,7 +32,7 @@ export function PluginsOverlay({
 }) {
   const [query, setQuery] = useState("");
   const [view, setView] = useState<CatalogView>("sources");
-  const [tregInfoOpen, setTregInfoOpen] = useState(false);
+  const [infoOpen, setInfoOpen] = useState<"treg" | "api" | null>(null);
   const [catalog, setCatalog] = useState<ConnectionCatalogItem[]>([]);
   const [sources, setSources] = useState<CapabilityInstall[]>([]);
   const [sourceKind, setSourceKind] = useState<SourceKind | null>(null);
@@ -237,9 +237,31 @@ export function PluginsOverlay({
           >
             Add MCP server
           </Button>
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("api")}>
-            Add OpenAPI
-          </Button>
+          <span className="relative inline-flex items-center gap-1">
+            <Button type="button" variant="pill" size="sm" onClick={() => beginSource("api")}>
+              Add OpenAPI
+            </Button>
+            <button
+              type="button"
+              aria-label="What is OpenAPI?"
+              aria-expanded={infoOpen === "api"}
+              onClick={() => setInfoOpen((open) => (open === "api" ? null : "api"))}
+              className="grid h-7 w-7 place-items-center rounded-full border border-[#383844] text-[11px] font-medium text-[#C9C9CE] hover:bg-[#232327]"
+            >
+              i
+            </button>
+            {infoOpen === "api" ? (
+              <div
+                role="dialog"
+                aria-label="About OpenAPI"
+                className="absolute left-0 top-9 z-10 w-[320px] rounded-2xl border border-[#2C2C30] bg-[#1A1A1D] p-3.5 text-[13px] leading-5 text-[#C9C9CE] shadow-[0_18px_40px_rgba(0,0,0,.45)]"
+              >
+                OpenAPI is a spec file that describes a REST API. Rakazo reads that JSON and turns
+                the endpoints into tools for your agents. Use this when a service has an OpenAPI
+                URL but no MCP server. Not related to OpenAI.
+              </div>
+            ) : null}
+          </span>
           <span className="relative inline-flex items-center gap-1">
             <Button type="button" variant="pill" size="sm" onClick={() => beginSource("treg")}>
               Add Treg
@@ -247,13 +269,13 @@ export function PluginsOverlay({
             <button
               type="button"
               aria-label="What is Treg?"
-              aria-expanded={tregInfoOpen}
-              onClick={() => setTregInfoOpen((open) => !open)}
+              aria-expanded={infoOpen === "treg"}
+              onClick={() => setInfoOpen((open) => (open === "treg" ? null : "treg"))}
               className="grid h-7 w-7 place-items-center rounded-full border border-[#383844] text-[11px] font-medium text-[#C9C9CE] hover:bg-[#232327]"
             >
               i
             </button>
-            {tregInfoOpen ? (
+            {infoOpen === "treg" ? (
               <div
                 role="dialog"
                 aria-label="About Treg"

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -1,7 +1,8 @@
-import type { CapabilityInstall, ConnectionCatalogItem } from "@rakazo/contracts";
+import type { CapabilityInstall, ConnectionCatalogItem, McpServer } from "@rakazo/contracts";
 import { abortableDelay } from "@rakazo/core";
 import { Button } from "@rakazo/ui-web";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { connectMcpOauth } from "../lib/mcp-connect";
 import { rpc } from "../lib/rpc";
 
 type CatalogView = "all" | "connected" | "sources";
@@ -42,15 +43,19 @@ export function PluginsOverlay({
   const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
+  const [oauthPending, setOauthPending] = useState<string | null>(null);
   const connectionAttempt = useRef<AbortController | null>(null);
 
   async function refresh() {
-    const [items, installs] = await Promise.all([
+    const [items, installs, servers] = await Promise.all([
       rpc.connections.catalog({}),
       rpc.capabilities.list(),
+      rpc.mcp.servers.list().catch(() => [] as McpServer[]),
     ]);
     setCatalog(items);
     setSources(installs.filter((install) => install.kind === "mcp" || install.kind === "api"));
+    setMcpServers(servers);
     return items;
   }
 
@@ -287,6 +292,61 @@ export function PluginsOverlay({
           {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
           {loading ? <p className="text-[#6C6C70]">Loading integrations…</p> : null}
 
+          {!loading && mcpServers.length > 0 ? (
+            <div className="mb-6">
+              <div className="mb-2 flex items-center justify-between">
+                <h2 className="text-[15px] font-medium text-[#ECECEE]">Installed</h2>
+                {onOpenMcp ? (
+                  <button
+                    type="button"
+                    onClick={onOpenMcp}
+                    className="text-[12.5px] text-[#C9C9CE] hover:text-[#ECECEE]"
+                  >
+                    Manage
+                  </button>
+                ) : null}
+              </div>
+              {mcpServers.map((server) => (
+                <div key={server.id} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">
+                  <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold uppercase text-[#ECECEE]">
+                    {server.name[0]}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[15.5px] font-medium text-[#ECECEE]">{server.name}</div>
+                    <div className="truncate text-[13.5px] text-[#7A7A80]">
+                      {server.oauthStatus === "connected"
+                        ? "Connected"
+                        : server.oauthStatus === "reconnect"
+                          ? "Needs reconnection"
+                          : server.endpoint ?? server.command ?? server.slug}
+                    </div>
+                  </div>
+                  {server.transport !== "stdio" && server.oauthStatus !== "connected" ? (
+                    <Button
+                      type="button"
+                      variant="pill"
+                      size="sm"
+                      disabled={oauthPending === server.id}
+                      onClick={() => {
+                        setOauthPending(server.id);
+                        void connectMcpOauth(server.id)
+                          .then((result) => {
+                            if (result === "connected") void refresh();
+                          })
+                          .catch((err: unknown) =>
+                            setError(err instanceof Error ? err.message : "OAuth failed"),
+                          )
+                          .finally(() => setOauthPending(null));
+                      }}
+                    >
+                      {oauthPending === server.id ? "Connecting…" : "Connect"}
+                    </Button>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ) : null}
+
           {view === "sources" ? (
             <div className="space-y-4">
               {sourceKind ? (
@@ -400,7 +460,7 @@ export function PluginsOverlay({
             </div>
           ) : (
             <>
-              {!loading && catalog.length === 0 ? (
+              {!loading && catalog.length === 0 && mcpServers.length === 0 ? (
                 <p className="text-[#6C6C70]">
                   No managed app catalog is configured on this deployment. You can still add Treg,
                   MCP, or OpenAPI sources.

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1253,6 +1253,11 @@ export function ShellPage() {
     setComputerOpen(false);
   }
 
+  function toggleComputerWindow() {
+    if (computerOpen) closeComputerOverlay();
+    else void openComputer();
+  }
+
   async function releaseComputer(reason?: ComputerReleaseReason) {
     if (!active) return;
     await closeComputerOverlay();
@@ -1760,7 +1765,13 @@ export function ShellPage() {
             ) : null}
             {panel === "computer" && active ? (
               <div>
-                <div className="relative aspect-[16/10] overflow-hidden rounded-[14px] bg-[#0E0E10]">
+                <div
+                  className="relative aspect-[16/10] overflow-hidden rounded-[14px] bg-[#0E0E10]"
+                  onDoubleClick={(event) => {
+                    event.preventDefault();
+                    toggleComputerWindow();
+                  }}
+                >
                   {computerOpen ? (
                     <div className="grid h-full place-items-center text-sm text-[#6C6C70]">
                       Maximized
@@ -1790,22 +1801,21 @@ export function ShellPage() {
                   )}
                   <button
                     type="button"
-                    className="absolute inset-0 z-0 cursor-pointer"
-                    aria-label="Maximize computer"
-                    onClick={() => void openComputer()}
-                  />
-                  <button
-                    type="button"
                     className="absolute right-2.5 top-2.5 z-20 grid h-8 w-8 place-items-center rounded-lg border border-[#34343B] bg-[#1A1A1D]/90 text-[#ECECEE] pointer-events-auto"
-                    aria-label="Maximize"
-                    title="Maximize"
+                    aria-label={computerOpen ? "Restore" : "Maximize"}
+                    title={computerOpen ? "Restore" : "Maximize"}
                     onClick={(event) => {
                       event.preventDefault();
                       event.stopPropagation();
-                      void openComputer();
+                      toggleComputerWindow();
                     }}
+                    onDoubleClick={(event) => event.stopPropagation()}
                   >
-                    <Maximize2 size={14} strokeWidth={1.8} />
+                    {computerOpen ? (
+                      <Minimize2 size={14} strokeWidth={1.8} />
+                    ) : (
+                      <Maximize2 size={14} strokeWidth={1.8} />
+                    )}
                   </button>
                 </div>
                 <div className="mt-3 flex items-center justify-between">
@@ -2268,8 +2278,20 @@ export function ShellPage() {
           </div>
         </div>
       ) : computerOpen && active ? (
-        <div className="fixed inset-0 z-50 flex flex-col bg-[#050506]">
-          <div className="flex items-center justify-between gap-4 border-b border-[#171719] px-[18px] py-3.5">
+        <div
+          className="fixed inset-0 z-50 flex flex-col bg-[#050506]"
+          onDoubleClick={(event) => {
+            if (event.target !== event.currentTarget) return;
+            closeComputerOverlay();
+          }}
+        >
+          <div
+            className="flex items-center justify-between gap-4 border-b border-[#171719] px-[18px] py-3.5"
+            onDoubleClick={(event) => {
+              event.stopPropagation();
+              closeComputerOverlay();
+            }}
+          >
             <div className="flex min-w-0 flex-1 items-center gap-3">
               <BotAvatar color={active.color} size={28} />
               {recordingSkill ? (
@@ -2327,7 +2349,13 @@ export function ShellPage() {
               </button>
             </div>
           </div>
-          <div className="relative min-h-0 flex-1 bg-[#0E0E10]">
+          <div
+            className="relative min-h-0 flex-1 bg-[#0E0E10]"
+            onDoubleClick={(event) => {
+              event.stopPropagation();
+              closeComputerOverlay();
+            }}
+          >
             {computer?.kind === "desktop" ? (
               <div className="grid h-full place-items-center px-8 text-center text-sm text-[#6C6C70]">
                 This bot runs on this computer. There is no separate Linux desktop. Ask it to use

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1,12 +1,15 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type {
   Bot,
+  BotMcpServer,
   BotSection,
   ComputerMode,
   ComputerReleaseReason,
   ComputerStatus,
   Group,
+  McpServer,
   Me,
+  ModelCatalogEntry,
   MessageBlock,
   ProductEvent,
   Routine,
@@ -192,6 +195,8 @@ export function ShellPage() {
   const [computer, setComputer] = useState<ComputerStatus | null>(null);
   const [pluginsOpen, setPluginsOpen] = useState(false);
   const [mcpOpen, setMcpOpen] = useState(false);
+  const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
+  const [mcpAssignments, setMcpAssignments] = useState<BotMcpServer[]>([]);
   const [accountSettingsOpen, setAccountSettingsOpen] = useState(false);
   const [modelsOpen, setModelsOpen] = useState(false);
   const [memorySettingsOpen, setMemorySettingsOpen] = useState(false);
@@ -259,6 +264,13 @@ export function ShellPage() {
 
   const inGroup = Boolean(groupId);
   const active = inGroup ? undefined : (bots.find((b) => b.id === botId) ?? bots[0]);
+  const activeMcpServers = useMemo(() => {
+    if (!active) return [];
+    const assigned = new Set(
+      mcpAssignments.filter((row) => row.botId === active.id).map((row) => row.serverId),
+    );
+    return mcpServers.filter((server) => assigned.has(server.id));
+  }, [active, mcpAssignments, mcpServers]);
   const activeGroup = groups.find((group) => group.id === groupId);
   const activePendingAttachments = useMemo(
     () => attachmentsForThread(pendingAttachments, inGroup ? groupId : active?.id),
@@ -358,6 +370,15 @@ export function ShellPage() {
     },
     [navigate],
   );
+
+  const refreshMcp = useCallback(async () => {
+    const [servers, assignments] = await Promise.all([
+      rpc.mcp.servers.list(),
+      rpc.mcp.assignments.all(),
+    ]);
+    setMcpServers(servers);
+    setMcpAssignments(assignments);
+  }, []);
 
   async function refreshGroupThread(id: string) {
     const scrollElement = messageScroll.current;
@@ -553,6 +574,10 @@ export function ShellPage() {
       document.removeEventListener("visibilitychange", refreshVisibleBots);
     };
   }, []);
+
+  useEffect(() => {
+    void refreshMcp().catch(() => undefined);
+  }, [refreshMcp, mcpOpen]);
 
   useEffect(() => {
     void rpc.voice
@@ -1483,13 +1508,16 @@ export function ShellPage() {
         </div>
         <button
           type="button"
-          onClick={() => setPluginsOpen(true)}
+          onClick={() => setMcpOpen(true)}
           className="mx-3 mb-1 flex items-center gap-3 rounded-[11px] px-2.5 py-2 hover:bg-[#131315]"
         >
           <span className="grid h-[30px] w-[30px] place-items-center rounded-full bg-[#17171A] text-[#9A9AA0]">
             <Puzzle size={15} strokeWidth={1.7} />
           </span>
-          <span className="text-[14.5px] text-[#C9C9CE]">Integrations</span>
+          <span className="text-[14.5px] text-[#C9C9CE]">MCP servers</span>
+          {mcpServers.length ? (
+            <span className="ml-auto text-[12px] text-[#85858A]">{mcpServers.length}</span>
+          ) : null}
         </button>
         <div className="relative">
           {menuOpen ? (
@@ -1610,8 +1638,53 @@ export function ShellPage() {
                 </span>
               </span>
             </button>
+            {!inGroup && active ? (
+              <div className="ml-1 hidden min-w-0 flex-wrap items-center gap-1 md:flex">
+                {activeMcpServers.length ? (
+                  activeMcpServers.map((server) => (
+                    <button
+                      key={server.id}
+                      type="button"
+                      title={
+                        server.oauthStatus === "connected"
+                          ? `${server.name} connected`
+                          : `${server.name} needs authorization`
+                      }
+                      onClick={() => setMcpOpen(true)}
+                      className={`max-w-[148px] truncate rounded-full border px-2 py-0.5 text-[11px] ${
+                        server.oauthStatus === "connected"
+                          ? "border-[#2F6B4F] bg-[#14241C] text-[#A8E0C4]"
+                          : "border-[#6B4A2F] bg-[#241C14] text-[#E0C4A8]"
+                      }`}
+                    >
+                      {server.name}
+                    </button>
+                  ))
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setMcpOpen(true)}
+                    className="rounded-full border border-[#2A2A2F] px-2 py-0.5 text-[11px] text-[#85858A]"
+                  >
+                    MCP
+                  </button>
+                )}
+              </div>
+            ) : null}
           </div>
           <div className="flex items-center gap-1">
+            {!inGroup && active ? (
+              <button
+                type="button"
+                title="MCP servers"
+                aria-label="MCP servers"
+                onClick={() => setMcpOpen(true)}
+                className="grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-[#1B1B1E]"
+                style={{ background: mcpOpen ? "#1B1B1E" : "transparent" }}
+              >
+                <Puzzle size={16} strokeWidth={1.6} className="text-[#A8A8AD]" />
+              </button>
+            ) : null}
             {!inGroup && active ? (
               <button
                 type="button"
@@ -1912,6 +1985,7 @@ export function ShellPage() {
                 key={active.id}
                 bot={active}
                 memoryProviderConfigured={memoryProviderConfig != null}
+                onOpenMcp={() => setMcpOpen(true)}
                 onSave={async ({ computerMode, ...patch }) => {
                   if (computerMode !== active.computerMode) {
                     await rpc.bots.setComputer({
@@ -3279,6 +3353,7 @@ function BotSettings({
   onSave,
   onExport,
   onClear,
+  onOpenMcp,
 }: {
   bot: Bot;
   memoryProviderConfigured: boolean;
@@ -3291,9 +3366,12 @@ function BotSettings({
     memoryScope?: "isolated" | "shared" | null;
     autoSpeak?: boolean;
     voiceId?: string | null;
+    modelProvider?: string | null;
+    modelId?: string | null;
   }) => Promise<void>;
   onExport: () => Promise<void>;
   onClear: () => void;
+  onOpenMcp: () => void;
 }) {
   const [name, setName] = useState(bot.name);
   const [title, setTitle] = useState(bot.title);
@@ -3303,20 +3381,96 @@ function BotSettings({
   const [autoSpeak, setAutoSpeak] = useState(bot.autoSpeak);
   const [voiceId, setVoiceId] = useState(bot.voiceId ?? "");
   const [voices, setVoices] = useState<VoiceInfo[]>([]);
+  const [modelId, setModelId] = useState(bot.modelId ?? "");
+  const [modelCatalog, setModelCatalog] = useState<ModelCatalogEntry[]>([]);
+  const [workspaceDefaultModel, setWorkspaceDefaultModel] = useState<string>("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [assignedMcp, setAssignedMcp] = useState<McpServer[]>([]);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+  const [oauthPending, setOauthPending] = useState<string | null>(null);
+
+  async function refreshAssignedMcp() {
+    const [servers, assignments] = await Promise.all([
+      rpc.mcp.servers.list(),
+      rpc.mcp.assignments.list({ botId: bot.id }),
+    ]);
+    const assignedIds = new Set(assignments.map((row) => row.serverId));
+    setAssignedMcp(servers.filter((server) => assignedIds.has(server.id)));
+  }
 
   useEffect(() => {
     void rpc.voice
       .voices({})
       .then(setVoices)
       .catch(() => setVoices([]));
+    void Promise.all([rpc.models.list(), rpc.me()])
+      .then(([catalog, me]) => {
+        const openrouter = catalog.filter((entry) => entry.provider === "openrouter");
+        openrouter.sort((a, b) => {
+          const rank = (id: string) => (id.startsWith("deepseek/") ? 0 : 1);
+          return rank(a.id) - rank(b.id) || a.label.localeCompare(b.label);
+        });
+        setModelCatalog(openrouter);
+        setWorkspaceDefaultModel(me.defaultModel ?? "");
+      })
+      .catch(() => undefined);
   }, []);
+
+  useEffect(() => {
+    void refreshAssignedMcp().catch((err: unknown) =>
+      setMcpError(err instanceof Error ? err.message : "Could not load MCP"),
+    );
+  }, [bot.id]);
 
   return (
     <div data-testid="bot-settings">
       <div className="flex justify-center">
         <BotAvatar color={bot.color} size={64} />
+      </div>
+      <div className="mt-5 rounded-[11px] border border-[#26262A] p-3.5">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[14px] text-[#85858A]">MCP servers</span>
+          <button type="button" onClick={onOpenMcp} className="text-[12.5px] text-[#C9C9CE]">
+            Manage
+          </button>
+        </div>
+        {mcpError ? <p className="mt-2 text-[12.5px] text-[#E65707]">{mcpError}</p> : null}
+        {assignedMcp.length === 0 ? (
+          <p className="mt-2 text-[13px] text-[#6C6C70]">None assigned to this bot.</p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {assignedMcp.map((server) => (
+              <li key={server.id} className="flex items-center justify-between gap-2">
+                <span>
+                  <span className="block text-[13.5px] text-[#ECECEE]">{server.name}</span>
+                  <span className="block text-[11px] text-[#85858A]">
+                    {server.oauthStatus === "connected" ? "Connected" : "Needs authorization"}
+                  </span>
+                </span>
+                {server.oauthStatus !== "connected" ? (
+                  <button
+                    type="button"
+                    disabled={oauthPending === server.id}
+                    onClick={() => {
+                      setMcpError(null);
+                      setOauthPending(server.id);
+                      void connectMcpOauth(server.id)
+                        .then(() => refreshAssignedMcp())
+                        .catch((err: unknown) =>
+                          setMcpError(err instanceof Error ? err.message : "OAuth failed"),
+                        )
+                        .finally(() => setOauthPending(null));
+                    }}
+                    className="rounded-lg bg-[#7785FF] px-2.5 py-1.5 text-[11px] font-semibold text-[#090A12] disabled:opacity-50"
+                  >
+                    {oauthPending === server.id ? "Connecting…" : "Connect"}
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
       <label className="mt-6 block text-[14px] text-[#85858A]">
         Name
@@ -3347,6 +3501,26 @@ function BotSettings({
         />
       </label>
       <ComputerModePicker value={computerMode} onChange={setComputerMode} />
+      <label className="mt-4 block text-[14px] text-[#85858A]">
+        Model
+        <select
+          value={modelId}
+          onChange={(event) => setModelId(event.target.value)}
+          className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+        >
+          <option value="">
+            Workspace default{workspaceDefaultModel ? ` (${workspaceDefaultModel})` : ""}
+          </option>
+          {modelId && !modelCatalog.some((entry) => entry.id === modelId) ? (
+            <option value={modelId}>{modelId}</option>
+          ) : null}
+          {modelCatalog.map((entry) => (
+            <option key={`${entry.provider}:${entry.id}`} value={entry.id}>
+              {entry.label}
+            </option>
+          ))}
+        </select>
+      </label>
       {memoryProviderConfigured ? (
         <div className="mt-4 text-[14px] text-[#85858A]">
           Memory scope
@@ -3417,6 +3591,8 @@ function BotSettings({
               memoryScope,
               autoSpeak,
               voiceId: voiceId || null,
+              modelProvider: modelId ? "openrouter" : null,
+              modelId: modelId || null,
             })
               .catch((err) => setError(err instanceof Error ? err.message : "Could not save"))
               .finally(() => setSaving(false));

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1240,13 +1240,13 @@ export function ShellPage() {
 
   async function openComputer() {
     if (!active) return;
+    setComputerOpen(true);
     const needsTakeover = !userHoldsComputerControl(computer, active.id);
-    await bootComputer({
+    void bootComputer({
       takeControl: needsTakeover,
-      overlay: needsTakeover || computer?.state !== "running",
+      overlay: false,
       force: computer?.state !== "running",
     });
-    setComputerOpen(true);
   }
 
   function closeComputerOverlay() {
@@ -1791,23 +1791,22 @@ export function ShellPage() {
                   <button
                     type="button"
                     className="absolute inset-0 z-0 cursor-pointer"
-                    aria-label="Open computer"
+                    aria-label="Maximize computer"
                     onClick={() => void openComputer()}
                   />
-                  {computer?.kind === "desktop" ? null : (
-                    <button
-                      type="button"
-                      className="absolute right-2.5 top-2.5 z-10 grid h-8 w-8 place-items-center rounded-lg border border-[#34343B] bg-[#1A1A1D]/90 text-[#ECECEE]"
-                      aria-label="Maximize"
-                      title="Maximize"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        void openComputer();
-                      }}
-                    >
-                      <Maximize2 size={14} strokeWidth={1.8} />
-                    </button>
-                  )}
+                  <button
+                    type="button"
+                    className="absolute right-2.5 top-2.5 z-20 grid h-8 w-8 place-items-center rounded-lg border border-[#34343B] bg-[#1A1A1D]/90 text-[#ECECEE] pointer-events-auto"
+                    aria-label="Maximize"
+                    title="Maximize"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      void openComputer();
+                    }}
+                  >
+                    <Maximize2 size={14} strokeWidth={1.8} />
+                  </button>
                 </div>
                 <div className="mt-3 flex items-center justify-between">
                   <span className="text-[13.5px] text-[#85858A]">

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -79,7 +79,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { flushSync } from "react-dom";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { ArtifactFileCard } from "../components/ArtifactFileCard";
 import { AskCard } from "../components/AskCard";
@@ -235,8 +234,6 @@ export function ShellPage() {
   const [runningRoutine, setRunningRoutine] = useState(false);
   const [screenUrl, setScreenUrl] = useState<string | null>(null);
   const [computerOpen, setComputerOpen] = useState(false);
-  const [computerFullscreen, setComputerFullscreen] = useState(false);
-  const computerOverlayRef = useRef<HTMLDivElement>(null);
   const [usage, setUsage] = useState<{
     inputTokens: number;
     outputTokens: number;
@@ -1225,23 +1222,9 @@ export function ShellPage() {
   }, [active?.id, groupId, inGroup]);
 
   useEffect(() => {
-    function onFullscreenChange() {
-      setComputerFullscreen(document.fullscreenElement === computerOverlayRef.current);
-    }
-    document.addEventListener("fullscreenchange", onFullscreenChange);
-    return () => document.removeEventListener("fullscreenchange", onFullscreenChange);
-  }, []);
-
-  useEffect(() => {
     if (!computerOpen) return;
     function onKey(event: KeyboardEvent) {
-      if (event.key !== "Escape") return;
-      if (document.fullscreenElement) {
-        event.preventDefault();
-        void document.exitFullscreen().catch(() => undefined);
-        return;
-      }
-      setComputerOpen(false);
+      if (event.key === "Escape") setComputerOpen(false);
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -1255,40 +1238,18 @@ export function ShellPage() {
     return () => window.clearInterval(timer);
   }, [panel, computerOpen, active?.id, computer?.state]);
 
-  async function openComputer(opts?: { fullscreen?: boolean }) {
+  async function openComputer() {
     if (!active) return;
     const needsTakeover = !userHoldsComputerControl(computer, active.id);
-    const boot = bootComputer({
+    await bootComputer({
       takeControl: needsTakeover,
       overlay: needsTakeover || computer?.state !== "running",
       force: computer?.state !== "running",
     });
-    if (opts?.fullscreen) {
-      flushSync(() => setComputerOpen(true));
-      const fullscreen = computerOverlayRef.current?.requestFullscreen() ?? Promise.resolve();
-      await Promise.all([boot, fullscreen.catch(() => undefined)]);
-      return;
-    }
-    await boot;
     setComputerOpen(true);
   }
 
-  async function toggleComputerFullscreen() {
-    if (document.fullscreenElement) {
-      await document.exitFullscreen().catch(() => undefined);
-      return;
-    }
-    if (!computerOpen) {
-      await openComputer({ fullscreen: true });
-      return;
-    }
-    await computerOverlayRef.current?.requestFullscreen().catch(() => undefined);
-  }
-
-  async function closeComputerOverlay() {
-    if (document.fullscreenElement) {
-      await document.exitFullscreen().catch(() => undefined);
-    }
+  function closeComputerOverlay() {
     setComputerOpen(false);
   }
 
@@ -1802,7 +1763,7 @@ export function ShellPage() {
                 <div className="relative aspect-[16/10] overflow-hidden rounded-[14px] bg-[#0E0E10]">
                   {computerOpen ? (
                     <div className="grid h-full place-items-center text-sm text-[#6C6C70]">
-                      Open in full screen
+                      Maximized
                     </div>
                   ) : computer?.kind === "desktop" ? (
                     <div className="grid h-full place-items-center px-6 text-center text-sm text-[#6C6C70]">
@@ -1836,15 +1797,15 @@ export function ShellPage() {
                   {computer?.kind === "desktop" ? null : (
                     <button
                       type="button"
-                      className="absolute bottom-3 right-3 z-10 flex items-center gap-1.5 rounded-lg border border-[#34343B] bg-[#1A1A1D]/90 px-2.5 py-1.5 text-[12px] text-[#ECECEE]"
-                      aria-label="Full screen"
+                      className="absolute right-2.5 top-2.5 z-10 grid h-8 w-8 place-items-center rounded-lg border border-[#34343B] bg-[#1A1A1D]/90 text-[#ECECEE]"
+                      aria-label="Maximize"
+                      title="Maximize"
                       onClick={(event) => {
                         event.stopPropagation();
-                        void openComputer({ fullscreen: true });
+                        void openComputer();
                       }}
                     >
-                      <Maximize2 size={13} strokeWidth={1.8} />
-                      Full screen
+                      <Maximize2 size={14} strokeWidth={1.8} />
                     </button>
                   )}
                 </div>
@@ -2308,10 +2269,7 @@ export function ShellPage() {
           </div>
         </div>
       ) : computerOpen && active ? (
-        <div
-          ref={computerOverlayRef}
-          className="fixed inset-0 z-50 flex flex-col bg-[#050506]"
-        >
+        <div className="fixed inset-0 z-50 flex flex-col bg-[#050506]">
           <div className="flex items-center justify-between gap-4 border-b border-[#171719] px-[18px] py-3.5">
             <div className="flex min-w-0 flex-1 items-center gap-3">
               <BotAvatar color={active.color} size={28} />
@@ -2351,26 +2309,20 @@ export function ShellPage() {
                   Take control
                 </Button>
               )}
-              {computer?.kind === "desktop" ? null : (
-                <button
-                  type="button"
-                  className="grid h-[30px] w-[34px] place-items-center rounded-[9px] text-[#85858A] hover:bg-[#1B1B1E] hover:text-[#ECECEE]"
-                  aria-label={computerFullscreen ? "Exit full screen" : "Full screen"}
-                  title={computerFullscreen ? "Exit full screen" : "Full screen"}
-                  onClick={() => void toggleComputerFullscreen()}
-                >
-                  {computerFullscreen ? (
-                    <Minimize2 size={16} strokeWidth={1.7} />
-                  ) : (
-                    <Maximize2 size={16} strokeWidth={1.7} />
-                  )}
-                </button>
-              )}
+              <button
+                type="button"
+                className="grid h-[30px] w-[34px] place-items-center rounded-[9px] text-[#85858A] hover:bg-[#1B1B1E] hover:text-[#ECECEE]"
+                aria-label="Restore"
+                title="Restore"
+                onClick={closeComputerOverlay}
+              >
+                <Minimize2 size={16} strokeWidth={1.7} />
+              </button>
               <button
                 type="button"
                 className="text-[16px] text-[#85858A] hover:text-[#ECECEE]"
                 aria-label="Close computer"
-                onClick={() => void closeComputerOverlay()}
+                onClick={closeComputerOverlay}
               >
                 <X size={16} strokeWidth={1.8} />
               </button>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1241,9 +1241,8 @@ export function ShellPage() {
   async function openComputer() {
     if (!active) return;
     setComputerOpen(true);
-    const needsTakeover = !userHoldsComputerControl(computer, active.id);
     void bootComputer({
-      takeControl: needsTakeover,
+      takeControl: false,
       overlay: false,
       force: computer?.state !== "running",
     });
@@ -1260,7 +1259,6 @@ export function ShellPage() {
 
   async function releaseComputer(reason?: ComputerReleaseReason) {
     if (!active) return;
-    await closeComputerOverlay();
     await rpc.computer.release({ botId: active.id, reason }).catch(() => undefined);
     await refreshThread(active.id);
   }
@@ -1838,7 +1836,13 @@ export function ShellPage() {
                       type="button"
                       variant="outline"
                       size="sm"
-                      onClick={() => void openComputer()}
+                      onClick={() =>
+                        void bootComputer({
+                          takeControl: true,
+                          overlay: false,
+                          force: computer?.state !== "running",
+                        })
+                      }
                     >
                       Take control
                     </Button>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1,7 +1,6 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type {
   Bot,
-  BotMcpServer,
   BotSection,
   ComputerMode,
   ComputerReleaseReason,
@@ -53,7 +52,9 @@ import {
   Gauge,
   LogOut,
   Menu,
+  Maximize2,
   Mic,
+  Minimize2,
   Monitor,
   Paperclip,
   Phone,
@@ -78,6 +79,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { flushSync } from "react-dom";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { ArtifactFileCard } from "../components/ArtifactFileCard";
 import { AskCard } from "../components/AskCard";
@@ -195,8 +197,6 @@ export function ShellPage() {
   const [computer, setComputer] = useState<ComputerStatus | null>(null);
   const [pluginsOpen, setPluginsOpen] = useState(false);
   const [mcpOpen, setMcpOpen] = useState(false);
-  const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
-  const [mcpAssignments, setMcpAssignments] = useState<BotMcpServer[]>([]);
   const [accountSettingsOpen, setAccountSettingsOpen] = useState(false);
   const [modelsOpen, setModelsOpen] = useState(false);
   const [memorySettingsOpen, setMemorySettingsOpen] = useState(false);
@@ -235,6 +235,8 @@ export function ShellPage() {
   const [runningRoutine, setRunningRoutine] = useState(false);
   const [screenUrl, setScreenUrl] = useState<string | null>(null);
   const [computerOpen, setComputerOpen] = useState(false);
+  const [computerFullscreen, setComputerFullscreen] = useState(false);
+  const computerOverlayRef = useRef<HTMLDivElement>(null);
   const [usage, setUsage] = useState<{
     inputTokens: number;
     outputTokens: number;
@@ -264,13 +266,6 @@ export function ShellPage() {
 
   const inGroup = Boolean(groupId);
   const active = inGroup ? undefined : (bots.find((b) => b.id === botId) ?? bots[0]);
-  const activeMcpServers = useMemo(() => {
-    if (!active) return [];
-    const assigned = new Set(
-      mcpAssignments.filter((row) => row.botId === active.id).map((row) => row.serverId),
-    );
-    return mcpServers.filter((server) => assigned.has(server.id));
-  }, [active, mcpAssignments, mcpServers]);
   const activeGroup = groups.find((group) => group.id === groupId);
   const activePendingAttachments = useMemo(
     () => attachmentsForThread(pendingAttachments, inGroup ? groupId : active?.id),
@@ -370,15 +365,6 @@ export function ShellPage() {
     },
     [navigate],
   );
-
-  const refreshMcp = useCallback(async () => {
-    const [servers, assignments] = await Promise.all([
-      rpc.mcp.servers.list(),
-      rpc.mcp.assignments.all(),
-    ]);
-    setMcpServers(servers);
-    setMcpAssignments(assignments);
-  }, []);
 
   async function refreshGroupThread(id: string) {
     const scrollElement = messageScroll.current;
@@ -574,10 +560,6 @@ export function ShellPage() {
       document.removeEventListener("visibilitychange", refreshVisibleBots);
     };
   }, []);
-
-  useEffect(() => {
-    void refreshMcp().catch(() => undefined);
-  }, [refreshMcp, mcpOpen]);
 
   useEffect(() => {
     void rpc.voice
@@ -1243,9 +1225,23 @@ export function ShellPage() {
   }, [active?.id, groupId, inGroup]);
 
   useEffect(() => {
+    function onFullscreenChange() {
+      setComputerFullscreen(document.fullscreenElement === computerOverlayRef.current);
+    }
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", onFullscreenChange);
+  }, []);
+
+  useEffect(() => {
     if (!computerOpen) return;
     function onKey(event: KeyboardEvent) {
-      if (event.key === "Escape") setComputerOpen(false);
+      if (event.key !== "Escape") return;
+      if (document.fullscreenElement) {
+        event.preventDefault();
+        void document.exitFullscreen().catch(() => undefined);
+        return;
+      }
+      setComputerOpen(false);
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -1259,20 +1255,46 @@ export function ShellPage() {
     return () => window.clearInterval(timer);
   }, [panel, computerOpen, active?.id, computer?.state]);
 
-  async function openComputer() {
+  async function openComputer(opts?: { fullscreen?: boolean }) {
     if (!active) return;
     const needsTakeover = !userHoldsComputerControl(computer, active.id);
-    await bootComputer({
+    const boot = bootComputer({
       takeControl: needsTakeover,
       overlay: needsTakeover || computer?.state !== "running",
       force: computer?.state !== "running",
     });
+    if (opts?.fullscreen) {
+      flushSync(() => setComputerOpen(true));
+      const fullscreen = computerOverlayRef.current?.requestFullscreen() ?? Promise.resolve();
+      await Promise.all([boot, fullscreen.catch(() => undefined)]);
+      return;
+    }
+    await boot;
     setComputerOpen(true);
+  }
+
+  async function toggleComputerFullscreen() {
+    if (document.fullscreenElement) {
+      await document.exitFullscreen().catch(() => undefined);
+      return;
+    }
+    if (!computerOpen) {
+      await openComputer({ fullscreen: true });
+      return;
+    }
+    await computerOverlayRef.current?.requestFullscreen().catch(() => undefined);
+  }
+
+  async function closeComputerOverlay() {
+    if (document.fullscreenElement) {
+      await document.exitFullscreen().catch(() => undefined);
+    }
+    setComputerOpen(false);
   }
 
   async function releaseComputer(reason?: ComputerReleaseReason) {
     if (!active) return;
-    setComputerOpen(false);
+    await closeComputerOverlay();
     await rpc.computer.release({ botId: active.id, reason }).catch(() => undefined);
     await refreshThread(active.id);
   }
@@ -1508,16 +1530,13 @@ export function ShellPage() {
         </div>
         <button
           type="button"
-          onClick={() => setMcpOpen(true)}
+          onClick={() => setPluginsOpen(true)}
           className="mx-3 mb-1 flex items-center gap-3 rounded-[11px] px-2.5 py-2 hover:bg-[#131315]"
         >
           <span className="grid h-[30px] w-[30px] place-items-center rounded-full bg-[#17171A] text-[#9A9AA0]">
             <Puzzle size={15} strokeWidth={1.7} />
           </span>
-          <span className="text-[14.5px] text-[#C9C9CE]">MCP servers</span>
-          {mcpServers.length ? (
-            <span className="ml-auto text-[12px] text-[#85858A]">{mcpServers.length}</span>
-          ) : null}
+          <span className="text-[14.5px] text-[#C9C9CE]">Integrations</span>
         </button>
         <div className="relative">
           {menuOpen ? (
@@ -1638,53 +1657,8 @@ export function ShellPage() {
                 </span>
               </span>
             </button>
-            {!inGroup && active ? (
-              <div className="ml-1 hidden min-w-0 flex-wrap items-center gap-1 md:flex">
-                {activeMcpServers.length ? (
-                  activeMcpServers.map((server) => (
-                    <button
-                      key={server.id}
-                      type="button"
-                      title={
-                        server.oauthStatus === "connected"
-                          ? `${server.name} connected`
-                          : `${server.name} needs authorization`
-                      }
-                      onClick={() => setMcpOpen(true)}
-                      className={`max-w-[148px] truncate rounded-full border px-2 py-0.5 text-[11px] ${
-                        server.oauthStatus === "connected"
-                          ? "border-[#2F6B4F] bg-[#14241C] text-[#A8E0C4]"
-                          : "border-[#6B4A2F] bg-[#241C14] text-[#E0C4A8]"
-                      }`}
-                    >
-                      {server.name}
-                    </button>
-                  ))
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => setMcpOpen(true)}
-                    className="rounded-full border border-[#2A2A2F] px-2 py-0.5 text-[11px] text-[#85858A]"
-                  >
-                    MCP
-                  </button>
-                )}
-              </div>
-            ) : null}
           </div>
           <div className="flex items-center gap-1">
-            {!inGroup && active ? (
-              <button
-                type="button"
-                title="MCP servers"
-                aria-label="MCP servers"
-                onClick={() => setMcpOpen(true)}
-                className="grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-[#1B1B1E]"
-                style={{ background: mcpOpen ? "#1B1B1E" : "transparent" }}
-              >
-                <Puzzle size={16} strokeWidth={1.6} className="text-[#A8A8AD]" />
-              </button>
-            ) : null}
             {!inGroup && active ? (
               <button
                 type="button"
@@ -1828,7 +1802,7 @@ export function ShellPage() {
                 <div className="relative aspect-[16/10] overflow-hidden rounded-[14px] bg-[#0E0E10]">
                   {computerOpen ? (
                     <div className="grid h-full place-items-center text-sm text-[#6C6C70]">
-                      Open in full window
+                      Open in full screen
                     </div>
                   ) : computer?.kind === "desktop" ? (
                     <div className="grid h-full place-items-center px-6 text-center text-sm text-[#6C6C70]">
@@ -1855,10 +1829,24 @@ export function ShellPage() {
                   )}
                   <button
                     type="button"
-                    className="absolute inset-0 cursor-pointer"
+                    className="absolute inset-0 z-0 cursor-pointer"
                     aria-label="Open computer"
                     onClick={() => void openComputer()}
                   />
+                  {computer?.kind === "desktop" ? null : (
+                    <button
+                      type="button"
+                      className="absolute bottom-3 right-3 z-10 flex items-center gap-1.5 rounded-lg border border-[#34343B] bg-[#1A1A1D]/90 px-2.5 py-1.5 text-[12px] text-[#ECECEE]"
+                      aria-label="Full screen"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        void openComputer({ fullscreen: true });
+                      }}
+                    >
+                      <Maximize2 size={13} strokeWidth={1.8} />
+                      Full screen
+                    </button>
+                  )}
                 </div>
                 <div className="mt-3 flex items-center justify-between">
                   <span className="text-[13.5px] text-[#85858A]">
@@ -1985,7 +1973,7 @@ export function ShellPage() {
                 key={active.id}
                 bot={active}
                 memoryProviderConfigured={memoryProviderConfig != null}
-                onOpenMcp={() => setMcpOpen(true)}
+                onOpenMcp={() => setPluginsOpen(true)}
                 onSave={async ({ computerMode, ...patch }) => {
                   if (computerMode !== active.computerMode) {
                     await rpc.bots.setComputer({
@@ -2320,7 +2308,10 @@ export function ShellPage() {
           </div>
         </div>
       ) : computerOpen && active ? (
-        <div className="absolute inset-0 z-30 flex flex-col bg-[#050506]">
+        <div
+          ref={computerOverlayRef}
+          className="fixed inset-0 z-50 flex flex-col bg-[#050506]"
+        >
           <div className="flex items-center justify-between gap-4 border-b border-[#171719] px-[18px] py-3.5">
             <div className="flex min-w-0 flex-1 items-center gap-3">
               <BotAvatar color={active.color} size={28} />
@@ -2360,11 +2351,26 @@ export function ShellPage() {
                   Take control
                 </Button>
               )}
+              {computer?.kind === "desktop" ? null : (
+                <button
+                  type="button"
+                  className="grid h-[30px] w-[34px] place-items-center rounded-[9px] text-[#85858A] hover:bg-[#1B1B1E] hover:text-[#ECECEE]"
+                  aria-label={computerFullscreen ? "Exit full screen" : "Full screen"}
+                  title={computerFullscreen ? "Exit full screen" : "Full screen"}
+                  onClick={() => void toggleComputerFullscreen()}
+                >
+                  {computerFullscreen ? (
+                    <Minimize2 size={16} strokeWidth={1.7} />
+                  ) : (
+                    <Maximize2 size={16} strokeWidth={1.7} />
+                  )}
+                </button>
+              )}
               <button
                 type="button"
                 className="text-[16px] text-[#85858A] hover:text-[#ECECEE]"
                 aria-label="Close computer"
-                onClick={() => setComputerOpen(false)}
+                onClick={() => void closeComputerOverlay()}
               >
                 <X size={16} strokeWidth={1.8} />
               </button>
@@ -3430,7 +3436,7 @@ function BotSettings({
       </div>
       <div className="mt-5 rounded-[11px] border border-[#26262A] p-3.5">
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[14px] text-[#85858A]">MCP servers</span>
+          <span className="text-[14px] text-[#85858A]">Integrations</span>
           <button type="button" onClick={onOpenMcp} className="text-[12.5px] text-[#C9C9CE]">
             Manage
           </button>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3450,8 +3450,16 @@ function BotSettings({
               <li key={server.id} className="flex items-center justify-between gap-2">
                 <span>
                   <span className="block text-[13.5px] text-[#ECECEE]">{server.name}</span>
-                  <span className="block text-[11px] text-[#85858A]">
-                    {server.oauthStatus === "connected" ? "Connected" : "Needs authorization"}
+                  <span
+                    className={`block text-[11px] ${
+                      server.oauthStatus === "connected" || server.transport === "stdio"
+                        ? "text-[#3DDC84]"
+                        : "text-[#F05252]"
+                    }`}
+                  >
+                    {server.oauthStatus === "connected" || server.transport === "stdio"
+                      ? "Connected"
+                      : "Disconnected"}
                   </span>
                 </span>
                 {server.oauthStatus !== "connected" ? (

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,8 +14,6 @@ import {
   stripSensitiveHandshakeHeaders,
 } from "./src/screen-proxy.js";
 
-const webPort = Number(process.env.WEB_PORT ?? 5173);
-
 function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string) {
   server.middlewares.use((req, res, next) => {
     if (!req.url?.startsWith("/novnc/")) {
@@ -115,6 +113,7 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string)
 
 export default defineConfig(({ mode }) => {
   const rootEnv = loadEnv(mode, path.resolve(import.meta.dirname, "../.."), "");
+  const webPort = Number(rootEnv.WEB_PORT || process.env.WEB_PORT || 5175);
   const api = process.env.API_PROXY_TARGET ?? rootEnv.API_PROXY_TARGET ?? "http://127.0.0.1:3100";
   const previewHost = process.env.RAKAZO_HOST ?? rootEnv.RAKAZO_HOST ?? "localhost";
   const screenProxySecret = resolveAuthSecret({
@@ -147,9 +146,17 @@ export default defineConfig(({ mode }) => {
       },
     ],
     server: {
-      host: "127.0.0.1",
+      host: rootEnv.RAKAZO_BIND || process.env.RAKAZO_BIND || "127.0.0.1",
       port: webPort,
       strictPort: true,
+      allowedHosts: true,
+      hmr: (rootEnv.RAKAZO_PUBLIC_HOST || process.env.RAKAZO_PUBLIC_HOST)
+        ? {
+            protocol: "wss",
+            host: rootEnv.RAKAZO_PUBLIC_HOST || process.env.RAKAZO_PUBLIC_HOST,
+            clientPort: Number(rootEnv.RAKAZO_PUBLIC_PORT || process.env.RAKAZO_PUBLIC_PORT || 5173),
+          }
+        : undefined,
       proxy: {
         "/api": { target: api, changeOrigin: true },
         "/rpc": { target: api, changeOrigin: true },
@@ -157,7 +164,7 @@ export default defineConfig(({ mode }) => {
     },
     preview: {
       host: "0.0.0.0",
-      port: Number(process.env.WEB_PORT ?? 5173),
+      port: webPort,
       allowedHosts: [previewHost],
       proxy: {
         "/api": { target: api, changeOrigin: true },

--- a/infra/sandboxes/computer/Dockerfile
+++ b/infra/sandboxes/computer/Dockerfile
@@ -18,6 +18,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     fonts-dejavu-core \
     dbus-x11 \
+    curl \
+    iptables \
+    iproute2 \
+  && curl -fsSL https://tailscale.com/install.sh | sh \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /etc/rakazo/fluxbox \
   && printf '%s\n' '#!/bin/sh' 'exec xsetroot -solid "#111113" "$@"' > /usr/bin/fbsetbg \

--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -77,6 +77,37 @@ if [[ ! -f "$NOVNC_ROOT/embed.html" ]]; then
 fi
 websockify --web="$NOVNC_ROOT" 0.0.0.0:6080 127.0.0.1:5900 >/tmp/rakazo/novnc.log 2>&1 &
 
+# Join the tailnet so bots can reach grok-bot / Studio / VMs.
+TAILSCALE_DIR="$AGENT_HOME/tailscale"
+mkdir -p "$TAILSCALE_DIR/state"
+chmod 700 "$TAILSCALE_DIR" "$TAILSCALE_DIR/state" 2>/dev/null || true
+if command -v tailscaled >/dev/null 2>&1; then
+  if ! pgrep -x tailscaled >/dev/null 2>&1; then
+    TS_TUN=tailscale0
+    if [[ ! -e /dev/net/tun ]]; then
+      TS_TUN=userspace-networking
+    fi
+    tailscaled --statedir="$TAILSCALE_DIR/state" --tun="$TS_TUN" >/tmp/rakazo/tailscaled.log 2>&1 &
+    sleep 1
+  fi
+  if [[ -s "$TAILSCALE_DIR/auth.key" ]] && command -v tailscale >/dev/null 2>&1; then
+    AUTH=$(tr -d ' \n' < "$TAILSCALE_DIR/auth.key")
+    case "$AUTH" in
+      *ephemeral=*) ;;
+      *) AUTH="${AUTH}?ephemeral=false&preauthorized=true" ;;
+    esac
+    HOSTN="${TAILSCALE_HOSTNAME:-rakazo}"
+    UP_ARGS=(--auth-key="$AUTH" --hostname="$HOSTN" --accept-dns=false)
+    if [[ -s "$TAILSCALE_DIR/advertise-tags" ]]; then
+      TAGS=$(tr -d ' \n' < "$TAILSCALE_DIR/advertise-tags")
+      if [[ -n "$TAGS" ]]; then
+        UP_ARGS+=(--advertise-tags="$TAGS")
+      fi
+    fi
+    tailscale up "${UP_ARGS[@]}" >/tmp/rakazo/tailscale-up.log 2>&1 || true
+  fi
+fi
+
 while kill -0 "$XVFB_PID" 2>/dev/null; do
   sleep 2
 done

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -79,6 +79,10 @@ export function containerCreateOptions(input: ComputerCreateInput) {
       ReadonlyPaths: ["/usr/share/novnc"],
       AutoRemove: false,
       NetworkMode: input.networkMode ?? "bridge",
+      CapAdd: ["NET_ADMIN", "NET_RAW"],
+      Devices: [
+        { PathOnHost: "/dev/net/tun", PathInContainer: "/dev/net/tun", CgroupPermissions: "rwm" },
+      ],
     },
     WorkingDir: "/home/rakazo",
   };

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -254,7 +254,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         credential?.defaultModel ??
         settings?.defaultModelId ??
         (deps.deploymentModelKey
-          ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731")
+          ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-vision-exp")
           : "scripted");
       return {
         provider,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -254,7 +254,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         credential?.defaultModel ??
         settings?.defaultModelId ??
         (deps.deploymentModelKey
-          ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731")
+          ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-vision-exp")
           : "scripted");
       return {
         provider,
@@ -1472,8 +1472,16 @@ export function createRunExecutor(deps: ExecutorDeps) {
               currentTurnImages,
               tools,
               model: {
-                provider: credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
-                id: credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
+                provider:
+                  bot.modelProvider ??
+                  credential?.provider ??
+                  settings?.defaultModelProvider ??
+                  "scripted",
+                id:
+                  bot.modelId ??
+                  credential?.defaultModel ??
+                  settings?.defaultModelId ??
+                  "scripted",
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -254,7 +254,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         credential?.defaultModel ??
         settings?.defaultModelId ??
         (deps.deploymentModelKey
-          ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-vision-exp")
+          ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731")
           : "scripted");
       return {
         provider,

--- a/packages/adapters/src/mcp-connector.ts
+++ b/packages/adapters/src/mcp-connector.ts
@@ -52,8 +52,15 @@ export class McpConnector implements ConnectorProvider {
     const groups = await Promise.all(
       assignments.map(async (assignment): Promise<ConnectorTool[]> => {
         try {
-          const session = await this.sessionFor(assignment.server, context);
-          const listed = await session.listTools({ signal: context.signal });
+          const discoverSignal = AbortSignal.any([
+            context.signal,
+            AbortSignal.timeout(8_000),
+          ]);
+          const session = await this.sessionFor(assignment.server, {
+            ...context,
+            signal: discoverSignal,
+          });
+          const listed = await session.listTools({ signal: discoverSignal });
           return listed.tools
             .filter(
               (tool) =>

--- a/packages/adapters/src/mcp-oauth.ts
+++ b/packages/adapters/src/mcp-oauth.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
-import type {
-  OAuthClientProvider,
-  OAuthDiscoveryState,
+import {
+  auth,
+  type OAuthClientProvider,
+  type OAuthDiscoveryState,
 } from "@modelcontextprotocol/sdk/client/auth.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type {
   OAuthClientInformationMixed,
@@ -194,7 +194,18 @@ function oauthFetch(
   network: RemoteTransportDependencies,
 ): { fetch: typeof fetch; close: () => Promise<void> } {
   const url = new URL(endpoint);
-  const safeFetch = secureFetch(url, {}, {}, network);
+  const safeFetch = secureFetch(
+    url,
+    {},
+    {
+      headers: {
+        // Krisp's Cloudflare 1010s some default Node/Python signatures on DCR.
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      },
+    },
+    network,
+  );
   return {
     fetch: withEndpointOriginFallback(url.origin, safeFetch),
     close: () => safeFetch.close(),
@@ -283,20 +294,18 @@ export class McpOAuthBroker {
     // Never destroy working tokens here: if this attempt fails (network error,
     // cancelled popup), the server keeps its valid connection. The SDK itself
     // invalidates dead tokens when a refresh is rejected with invalid_grant.
-    const endpoint = new URL(server.endpoint);
     const networkFetch = oauthFetch(server.endpoint, this.network);
-    const transport = new StreamableHTTPClientTransport(endpoint, {
-      authProvider: provider,
-      fetch: networkFetch.fetch,
-    });
-    const client = new Client({ name: "rakazo-oauth", version: "0.1.0" });
-    const signal = AbortSignal.timeout(15_000);
     try {
-      await client.connect(transport, { signal, timeout: 15_000 });
+      // Don't use StreamableHTTP Client.connect here: Krisp's GET stream hangs
+      // behind Cloudflare, so OAuth never reaches DCR. auth() does discovery +
+      // registration + authorize URL only.
+      await auth(provider, {
+        serverUrl: server.endpoint,
+        fetchFn: networkFetch.fetch,
+      });
     } catch (error) {
       if (!authorizationUrl) throw error;
     } finally {
-      await client.close().catch(() => undefined);
       await networkFetch.close().catch(() => undefined);
     }
     if (!authorizationUrl) {

--- a/packages/adapters/src/mcp-oauth.ts
+++ b/packages/adapters/src/mcp-oauth.ts
@@ -199,7 +199,7 @@ function oauthFetch(
     {},
     {
       headers: {
-        // Krisp's Cloudflare 1010s some default Node/Python signatures on DCR.
+        // Some CDNs 1010 default Node/Python signatures on DCR.
         "User-Agent":
           "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
       },
@@ -296,8 +296,8 @@ export class McpOAuthBroker {
     // invalidates dead tokens when a refresh is rejected with invalid_grant.
     const networkFetch = oauthFetch(server.endpoint, this.network);
     try {
-      // Don't use StreamableHTTP Client.connect here: Krisp's GET stream hangs
-      // behind Cloudflare, so OAuth never reaches DCR. auth() does discovery +
+      // Don't use StreamableHTTP Client.connect here: some providers' GET stream
+      // hangs, so OAuth never reaches DCR. auth() does discovery +
       // registration + authorize URL only.
       await auth(provider, {
         serverUrl: server.endpoint,

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -67,7 +67,7 @@ export class PiAgentRuntime implements AgentRuntime {
         const envDefaultProvider = process.env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
         const modelId =
           request.model.id === "scripted"
-            ? envDefaultModel || "deepseek/deepseek-v4-flash-0731"
+            ? envDefaultModel || "deepseek/deepseek-v4-flash-vision-exp"
             : request.model.id.trim();
         const models = modelsForRequest(request, provider);
         let model = models.getModel(provider, modelId);
@@ -87,6 +87,10 @@ export class PiAgentRuntime implements AgentRuntime {
           queue.push({ type: "done" });
           return;
         }
+        if (/\bvision\b/i.test(model.id) && !model.input.includes("image")) {
+          model = { ...model, input: ["text", "image"] };
+        }
+        model = withOpenRouterProviderRouting(model);
 
         const apiKey = request.model.oauth
           ? undefined
@@ -227,11 +231,34 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
+
+function withOpenRouterProviderRouting<T extends { provider: string; compat?: Record<string, unknown> }>(
+  model: T,
+): T {
+  if (model.provider !== "openrouter") return model;
+  const vision = /\bvision\b/i.test(model.id);
+  const slug = vision
+    ? (process.env.OPENROUTER_VISION_PROVIDER ?? "deepseek").trim() || "deepseek"
+    : (process.env.OPENROUTER_PROVIDER ?? "wafer").trim() || "wafer";
+  return {
+    ...model,
+    compat: {
+      ...(model.compat ?? {}),
+      openRouterRouting: {
+        only: [slug],
+        order: [slug],
+        allow_fallbacks: false,
+      },
+    },
+  };
+}
+
 function configuredOpenRouterModel(id: string): Model<"openai-completions"> {
   // A configured model can intentionally be newer than Pi's static catalog. Keep
   // pricing conservative, but enable reasoning: unknown OpenRouter endpoints
   // (e.g. gemini-3.7-flash before the snapshot catches up) often mandate it, and
   // thinkingLevel "off" becomes effort "none" which those endpoints reject.
+  const vision = /\bvision\b/i.test(id);
   return {
     id,
     name: id,
@@ -239,10 +266,10 @@ function configuredOpenRouterModel(id: string): Model<"openai-completions"> {
     provider: "openrouter",
     baseUrl: "https://openrouter.ai/api/v1",
     reasoning: true,
-    input: ["text"],
+    input: vision ? ["text", "image"] : ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 16_384,
-    maxTokens: 4_096,
+    contextWindow: vision ? 1_048_576 : 16_384,
+    maxTokens: vision ? 384_000 : 4_096,
   };
 }
 

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -67,7 +67,7 @@ export class PiAgentRuntime implements AgentRuntime {
         const envDefaultProvider = process.env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
         const modelId =
           request.model.id === "scripted"
-            ? envDefaultModel || "deepseek/deepseek-v4-flash-vision-exp"
+            ? envDefaultModel || "deepseek/deepseek-v4-flash-0731"
             : request.model.id.trim();
         const models = modelsForRequest(request, provider);
         let model = models.getModel(provider, modelId);

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -67,7 +67,7 @@ export class PiAgentRuntime implements AgentRuntime {
         const envDefaultProvider = process.env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
         const modelId =
           request.model.id === "scripted"
-            ? envDefaultModel || "deepseek/deepseek-v4-flash-0731"
+            ? envDefaultModel || "deepseek/deepseek-v4-flash-vision-exp"
             : request.model.id.trim();
         const models = modelsForRequest(request, provider);
         let model = models.getModel(provider, modelId);

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -32,6 +32,8 @@ export const BotSchema = z.object({
   createdAt: z.string(),
   voiceId: z.string().nullable(),
   autoSpeak: z.boolean(),
+  modelProvider: z.string().nullable(),
+  modelId: z.string().nullable(),
 });
 export type Bot = z.infer<typeof BotSchema>;
 
@@ -132,6 +134,8 @@ export const UpdateBotInput = z.object({
   sectionId: Id.nullable().optional(),
   voiceId: z.string().max(120).nullable().optional(),
   autoSpeak: z.boolean().optional(),
+  modelProvider: z.string().trim().min(1).max(80).nullable().optional(),
+  modelId: z.string().trim().min(1).max(200).nullable().optional(),
 });
 
 export const RoutineSchema = z.object({

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -239,6 +239,8 @@ model Bot {
   computerSwitching Boolean @default(false)
   voiceId        String?
   autoSpeak      Boolean  @default(false)
+  modelProvider  String?
+  modelId        String?
   routines       Routine[]
   taughtSkills   TaughtSkill[]
   memoryDocuments MemoryDocument[]

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -31,6 +31,8 @@ function mapBot(
     computer: { scope: string } | null;
     voiceId?: string | null;
     autoSpeak?: boolean;
+    modelProvider?: string | null;
+    modelId?: string | null;
   },
   preview = "",
   status = "idle",
@@ -61,6 +63,8 @@ function mapBot(
     updatedAt: bot.updatedAt.toISOString(),
     voiceId: bot.voiceId ?? null,
     autoSpeak: bot.autoSpeak ?? false,
+    modelProvider: bot.modelProvider ?? null,
+    modelId: bot.modelId ?? null,
   };
 }
 
@@ -187,6 +191,8 @@ export function createRepos(prisma: PrismaClient) {
         parentBotId?: string | null;
         computerMode?: ComputerMode;
         spawnKey?: string;
+        modelProvider?: string | null;
+        modelId?: string | null;
         initialMessage?: {
           role: "user" | "bot" | "system";
           blocks: MessageBlock[];
@@ -201,6 +207,8 @@ export function createRepos(prisma: PrismaClient) {
         });
         color = BOT_COLORS[count % BOT_COLORS.length] ?? BOT_COLORS[0];
       }
+      let modelProvider = input.modelProvider ?? null;
+      let modelId = input.modelId ?? null;
       if (input.parentBotId) {
         const parent = await prisma.bot.findFirst({
           where: {
@@ -210,6 +218,10 @@ export function createRepos(prisma: PrismaClient) {
           },
         });
         if (!parent) throw new IsolationError();
+        if (!modelId) {
+          modelProvider = parent.modelProvider ?? null;
+          modelId = parent.modelId ?? null;
+        }
       }
       const settings = await prisma.deploymentSettings.findUnique({ where: { id: "default" } });
       const envKind = process.env.SANDBOX_PROVIDER ?? "docker";
@@ -235,6 +247,8 @@ export function createRepos(prisma: PrismaClient) {
             parentBotId: input.parentBotId ?? null,
             computerId: teamComputer.id,
             spawnKey: input.spawnKey,
+            modelProvider,
+            modelId,
           },
         });
         const thread = await tx.thread.create({

--- a/scripts/import-grok-bots.py
+++ b/scripts/import-grok-bots.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 API = "http://127.0.0.1:3100"
 ORIGIN = "http://127.0.0.1:5173"
-IMPORT = Path("/Users/martinbouchard/src/rakazo-import")
-CREDS = Path("/Users/martinbouchard/.config/rakazo/admin.txt")
+IMPORT = Path.home() / "src" / "rakazo-import"
+CREDS = Path.home() / ".config" / "rakazo" / "admin.txt"
 DESC_MAX = 4000
 INST_MAX = 20000
 NAME_MAX = 80
@@ -120,7 +120,7 @@ def main() -> None:
     creds = load_creds()
     email = creds["email"]
     password = creds["password"]
-    name = creds.get("name", "Martin")
+    name = creds.get("name", "Admin")
 
     status, parsed, set_cookie = http(
         "POST",

--- a/scripts/import-grok-bots.py
+++ b/scripts/import-grok-bots.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Import grok-bot agent profiles into a running Rakazo instance."""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API = "http://127.0.0.1:3100"
+ORIGIN = "http://127.0.0.1:5173"
+IMPORT = Path("/Users/martinbouchard/src/rakazo-import")
+CREDS = Path("/Users/martinbouchard/.config/rakazo/admin.txt")
+DESC_MAX = 4000
+INST_MAX = 20000
+NAME_MAX = 80
+TITLE_MAX = 500
+
+# grok sidebar order (pinned first, then sections)
+PINNED = [
+    "0059456e-9952-4bf6-bc35-fd8e7186f681",  # general
+    "1e488ecf-c613-41cc-b7e7-b444677f56c7",  # Content Summarizer
+    "f7037574-7c15-4a51-a78e-157fbf63baba",  # Signal Monitor
+    "40bc8583-99c9-444b-ba1b-affbf3eb5a46",  # Tesla Concierge
+]
+SECTIONS = [
+    ("Travail / Perso", ["006016ef-882e-4c6f-853b-2fcd685b9cc6", "731ee068-71c8-4d57-9cba-a8a73cfeb4c4"]),
+    ("QScale Specific", ["26954552-0be0-4e01-bc27-f504023bb209", "66e98464-01eb-48f4-a6dc-84e32688b267", "c41a1a19-1a1d-4405-ae5d-eddcfd0c863d"]),
+    ("Perso Trackers", ["512277ee-fe23-4b1c-b212-384d693527d1", "97d60507-9b37-4617-bc50-3de417b76cc1"]),
+    ("Voyage", ["9afc3476-9117-42c1-9e34-19547e27ba33", "2b6fc76d-b65d-4ec0-b2ec-3656e4d1b2e7"]),
+    ("Résidences", ["78a5939f-8542-4cc8-aecf-fdf1fc599bf7"]),
+    ("New section", ["e838cb8e-25fc-4b35-bd59-6a3511112d50"]),
+]
+
+
+def load_creds() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in CREDS.read_text().splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            out[k.strip()] = v.strip()
+    return out
+
+
+def strip_wrap(s: str) -> str:
+    s = (s or "").strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "\"'":
+        s = s[1:-1]
+    return s.strip()
+
+
+def http(method: str, url: str, body: dict | None = None, cookie: str | None = None) -> tuple[int, dict | str, str]:
+    data = None if body is None else json.dumps(body).encode()
+    headers = {
+        "content-type": "application/json",
+        "origin": ORIGIN,
+        "user-agent": "rakazo-import/1",
+    }
+    if cookie:
+        headers["cookie"] = cookie
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as res:
+            raw = res.read().decode()
+            set_cookie = res.headers.get("set-cookie") or ""
+            try:
+                parsed = json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                parsed = raw
+            return res.status, parsed, set_cookie
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            parsed = json.loads(raw) if raw else {"error": raw}
+        except json.JSONDecodeError:
+            parsed = raw
+        return e.code, parsed, e.headers.get("set-cookie") or ""
+
+
+def rpc(cookie: str, proc: str, body: dict | None = None):
+    status, parsed, _ = http("POST", f"{API}/rpc/{proc}", {"json": body or {}}, cookie)
+    if isinstance(parsed, dict) and parsed.get("error"):
+        raise RuntimeError(f"{proc} {status}: {parsed['error']}")
+    if status >= 400:
+        raise RuntimeError(f"{proc} {status}: {parsed}")
+    if isinstance(parsed, dict) and "json" in parsed:
+        return parsed["json"]
+    return parsed
+
+
+def cookie_from(set_cookie: str) -> str:
+    # keep better-auth.session_token=...
+    parts = []
+    for chunk in set_cookie.split(","):
+        first = chunk.split(";")[0].strip()
+        if first.lower().startswith("better-auth.session_token="):
+            parts.append(first)
+    return "; ".join(parts) if parts else set_cookie.split(";")[0].strip()
+
+
+def memory_text(agent_dir: Path, name: str) -> str:
+    chunks = [f"# {name}\n"]
+    profile = agent_dir / "memory" / "profile.md"
+    if profile.exists():
+        chunks.append(profile.read_text())
+    log = agent_dir / "memory" / "log" / "2026-08.md"
+    if log.exists():
+        chunks.append("\n\n# Activity log\n\n" + log.read_text())
+    um = IMPORT / "user-memory" / "by-agent" / agent_dir.name / "profile.md"
+    if um.exists():
+        extra = um.read_text().strip()
+        if extra and extra not in "".join(chunks):
+            chunks.append("\n\n# Shared user memory\n\n" + extra)
+    return "\n".join(chunks).strip() + "\n"
+
+
+def main() -> None:
+    creds = load_creds()
+    email = creds["email"]
+    password = creds["password"]
+    name = creds.get("name", "Martin")
+
+    status, parsed, set_cookie = http(
+        "POST",
+        f"{API}/api/auth/sign-up/email",
+        {"email": email, "password": password, "name": name},
+    )
+    if status >= 400:
+        status, parsed, set_cookie = http(
+            "POST",
+            f"{API}/api/auth/sign-in/email",
+            {"email": email, "password": password},
+        )
+        if status >= 400:
+            raise SystemExit(f"auth failed {status}: {parsed}")
+    cookie = cookie_from(set_cookie)
+    if not cookie:
+        raise SystemExit("no session cookie")
+
+    me = rpc(cookie, "me", {})
+    print("signed in as", me.get("user", {}).get("email") if isinstance(me, dict) else me)
+
+    existing = {b["name"]: b for b in rpc(cookie, "bots/list", {})}
+    created: dict[str, dict] = {}
+    agents_root = IMPORT / "agents"
+    agent_ids = [d.name for d in agents_root.iterdir() if (d / "profile.json").exists()]
+    # create pinned first so they stay near the top, then the rest
+    ordered = [i for i in PINNED if i in agent_ids] + [i for i in agent_ids if i not in PINNED]
+
+    for grok_id in ordered:
+        agent_dir = agents_root / grok_id
+        profile = json.loads((agent_dir / "profile.json").read_text())
+        bot_name = strip_wrap(profile.get("name") or grok_id)[:NAME_MAX]
+        title = strip_wrap(profile.get("title") or "")[:TITLE_MAX]
+        description = strip_wrap(profile.get("description") or "")
+        instructions = description[:INST_MAX]
+        description = description[:DESC_MAX]
+        payload = {
+            "name": bot_name,
+            "title": title,
+            "description": description,
+            "instructions": instructions,
+            "notifyOnFinish": True,
+            "computerMode": "team",
+        }
+        if bot_name in existing:
+            bot = existing[bot_name]
+            rpc(cookie, "bots/update", {"botId": bot["id"], **{k: payload[k] for k in ("name", "title", "description", "instructions", "notifyOnFinish")}})
+            bot = rpc(cookie, "bots/get", {"botId": bot["id"]})
+            print("updated", bot_name)
+        else:
+            bot = rpc(cookie, "bots/create", payload)
+            print("created", bot_name, bot["id"])
+        created[grok_id] = bot
+
+        pin = grok_id in PINNED
+        if bot.get("pinned") != pin:
+            rpc(cookie, "bots/update", {"botId": bot["id"], "pinned": pin})
+
+        # memory
+        docs = rpc(cookie, "memory/list", {"botId": bot["id"], "scope": "bot"})
+        mem_doc = next((d for d in docs if d.get("path") == "MEMORY.md"), docs[0] if docs else None)
+        content = memory_text(agent_dir, bot_name)
+        autos = agent_dir / "automations"
+        webhook_bits = []
+        cron_count = 0
+        if autos.exists():
+            for auto_dir in sorted(p for p in autos.iterdir() if p.is_dir()):
+                aj = auto_dir / "automation.json"
+                if not aj.exists():
+                    continue
+                auto = json.loads(aj.read_text())
+                rname = (auto.get("name") or auto_dir.name)[:80]
+                prompt = auto.get("prompt") or ""
+                schedule = auto.get("schedule")
+                trigger = (auto.get("trigger") or {}) if isinstance(auto.get("trigger"), dict) else {}
+                if not schedule:
+                    schedule = (auto.get("triggerPresentation") or {}).get("trigger", {}).get("schedule")
+                if schedule and prompt:
+                    try:
+                        rpc(
+                            cookie,
+                            "routines/create",
+                            {
+                                "botId": bot["id"],
+                                "name": rname,
+                                "prompt": prompt,
+                                "cron": schedule,
+                                "timezone": "America/Toronto",
+                                "notify": True,
+                                "active": bool(auto.get("enabled", True)),
+                            },
+                        )
+                        cron_count += 1
+                    except RuntimeError as e:
+                        if "already" in str(e).lower() or "unique" in str(e).lower():
+                            pass
+                        else:
+                            print("routine fail", rname, e)
+                else:
+                    webhook_bits.append(f"## {rname} ({trigger.get('type') or 'non-cron'})\n\n{prompt}")
+        if webhook_bits:
+            content += "\n\n# Imported non-cron automations\n\n" + "\n\n".join(webhook_bits) + "\n"
+        if mem_doc:
+            rpc(cookie, "memory/update", {"documentId": mem_doc["id"], "content": content})
+        print(f"  memory {len(content)} chars, routines {cron_count}")
+
+    # sections
+    section_ids: dict[str, str] = {}
+    for section_name, members in SECTIONS:
+        first = next((created[i] for i in members if i in created), None)
+        if not first:
+            continue
+        existing_sections = {s["name"]: s for s in rpc(cookie, "botSections/list", {})}
+        if section_name in existing_sections:
+            section_ids[section_name] = existing_sections[section_name]["id"]
+        else:
+            sec = rpc(cookie, "botSections/create", {"botId": first["id"], "name": section_name})
+            section_ids[section_name] = sec["id"]
+            print("section", section_name, sec["id"])
+        sid = section_ids[section_name]
+        for grok_id in members:
+            bot = created.get(grok_id)
+            if not bot:
+                continue
+            if bot.get("sectionId") != sid:
+                rpc(cookie, "bots/update", {"botId": bot["id"], "sectionId": sid})
+
+    # user memory
+    user_docs = rpc(cookie, "memory/list", {"scope": "user"})
+    user_mem = next((d for d in user_docs if d.get("path") == "MEMORY.md"), user_docs[0] if user_docs else None)
+    um_bits = ["# User memory\n", "Imported from grok-bot. Timezone America/Toronto.\n"]
+    um_root = IMPORT / "user-memory"
+    if um_root.exists():
+        for f in sorted(um_root.rglob("*.md")):
+            rel = f.relative_to(um_root)
+            um_bits.append(f"\n## {rel}\n\n" + f.read_text())
+    if user_mem:
+        rpc(cookie, "memory/update", {"documentId": user_mem["id"], "content": "\n".join(um_bits)})
+
+    final = rpc(cookie, "bots/list", {})
+    print("BOT_COUNT", len(final))
+    for b in final:
+        print(f"  {'*' if b.get('pinned') else ' '} {b['name']} {b['id']}")
+
+    # ping a cheap bot to prove DeepSeek replies
+    target = next((b for b in final if b["name"] == "Elon"), final[0])
+    send = rpc(cookie, "threads/send", {"botId": target["id"], "text": "Reply with exactly the single word: pong"})
+    print("sent", target["name"], send)
+    deadline = time.time() + 120
+    seen = ""
+    while time.time() < deadline:
+        page = rpc(cookie, "threads/messages", {"botId": target["id"]})
+        messages = page if isinstance(page, list) else page.get("messages") or page.get("items") or []
+        texts = []
+        for m in messages:
+            role = m.get("role") or m.get("author") or ""
+            blocks = m.get("blocks") or []
+            text = m.get("text") or ""
+            if blocks:
+                text = " ".join(
+                    (b.get("text") or b.get("content") or "") if isinstance(b, dict) else str(b)
+                    for b in blocks
+                )
+            texts.append(f"{role}:{text}")
+        blob = "\n".join(texts)
+        if "pong" in blob.lower() and ("bot" in blob.lower() or "assistant" in blob.lower()):
+            print("REPLY_OK")
+            print(blob[-800:])
+            return
+        seen = blob
+        time.sleep(3)
+    print("REPLY_TIMEOUT last=", seen[-1200:])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mcp-oauth-callback.py
+++ b/scripts/mcp-oauth-callback.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Localhost MCP OAuth catcher. Superhuman/Krisp only allow http://127.0.0.1 redirects."""
+"""Localhost MCP OAuth catcher for providers that only allow loopback HTTP redirects."""
 from __future__ import annotations
 
 import json

--- a/scripts/mcp-oauth-callback.py
+++ b/scripts/mcp-oauth-callback.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Localhost MCP OAuth catcher. Superhuman/Krisp only allow http://127.0.0.1 redirects."""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+PORT = 8765
+CANDIDATES = [
+    "http://127.0.0.1:5175",
+    "https://macstudio.lenok-truck.ts.net:5173",
+]
+
+
+def rpc_bases() -> list[str]:
+    return list(CANDIDATES)
+
+
+def complete(code: str, state: str) -> tuple[bool, str]:
+    payload = json.dumps({"json": {"sessionId": state, "code": code, "state": state}}).encode()
+    last = "no endpoint"
+    for base in rpc_bases():
+        req = urllib.request.Request(
+            f"{base}/rpc/mcp/oauth/complete",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Origin": f"http://127.0.0.1:{PORT}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = resp.read().decode()
+            return True, body
+        except urllib.error.HTTPError as err:
+            last = err.read().decode()[:800] if err.fp else str(err)
+        except Exception as err:
+            last = str(err)
+    return False, last
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        code = (query.get("code") or [None])[0]
+        state = (query.get("state") or [None])[0]
+        oauth_error = (query.get("error_description") or query.get("error") or [None])[0]
+        if oauth_error:
+            self._html(400, f"Authorization failed: {oauth_error}")
+            return
+        if not code or not state:
+            self._html(400, "Missing OAuth code.")
+            return
+        ok, detail = complete(code, state)
+        if ok:
+            self._html(200, "Connected. You can close this window.")
+            return
+        self._html(500, f"Could not finish OAuth.<pre>{detail}</pre>")
+
+    def log_message(self, fmt: str, *args) -> None:
+        print(f"mcp-oauth-callback: {fmt % args}")
+
+    def _html(self, status: int, body: str) -> None:
+        page = f"""<!doctype html><html><body style="font-family:system-ui;padding:48px;background:#111;color:#eee">
+        <h1 style="font-weight:500">{body}</h1></body></html>"""
+        data = page.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+if __name__ == "__main__":
+    httpd = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    print(f"mcp oauth callback on http://127.0.0.1:{PORT}/mcp/oauth/callback")
+    httpd.serve_forever()

--- a/scripts/studio-start.sh
+++ b/scripts/studio-start.sh
@@ -1,0 +1,53 @@
+#!/bin/zsh
+set -euo pipefail
+ROOT="/Users/martinbouchard/src/rakazo"
+cd "$ROOT"
+# shellcheck disable=SC1091
+source "$ROOT/.rakazo-env.sh"
+mkdir -p "$ROOT/logs" "$ROOT/run"
+
+export WEB_PORT="${WEB_PORT:-5175}"
+export RAKAZO_BIND="${RAKAZO_BIND:-127.0.0.1}"
+export RAKAZO_PUBLIC_HOST="${RAKAZO_PUBLIC_HOST:-macstudio.lenok-truck.ts.net}"
+export RAKAZO_PUBLIC_PORT="${RAKAZO_PUBLIC_PORT:-5173}"
+
+if ! colima status >/dev/null 2>&1; then
+  echo "starting colima..."
+  colima start --cpu 8 --memory 16 --disk 80 --vm-type vz --vz-rosetta --mount-type virtiofs
+fi
+
+docker compose --env-file .env -f infra/compose/docker-compose.yml up postgres -d
+for i in {1..40}; do
+  if docker exec compose-postgres-1 pg_isready -U rakazo >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ -f "$ROOT/run/dev.pid" ]] && kill -0 "$(cat "$ROOT/run/dev.pid")" 2>/dev/null; then
+  echo "rakazo already running pid=$(cat "$ROOT/run/dev.pid")"
+  exit 0
+fi
+
+if ! docker image inspect rakazo/computer:local >/dev/null 2>&1; then
+  echo "building computer image..."
+  pnpm sandbox:build
+fi
+
+nohup pnpm dev >> "$ROOT/logs/dev.log" 2>&1 &
+echo $! > "$ROOT/run/dev.pid"
+echo "started pnpm dev pid=$(cat "$ROOT/run/dev.pid") log=$ROOT/logs/dev.log"
+
+for i in {1..90}; do
+  if curl -sf http://127.0.0.1:3100/health >/dev/null 2>&1 && curl -sf -o /dev/null "http://127.0.0.1:${WEB_PORT}"; then
+    tailscale serve --bg --https=5173 "http://127.0.0.1:${WEB_PORT}" >/dev/null
+    curl -s http://127.0.0.1:3100/health
+    echo
+    echo "ready: https://macstudio.lenok-truck.ts.net:5173"
+    exit 0
+  fi
+  sleep 2
+done
+echo "timed out waiting for health; see $ROOT/logs/dev.log" >&2
+tail -n 80 "$ROOT/logs/dev.log" >&2 || true
+exit 1

--- a/scripts/studio-start.sh
+++ b/scripts/studio-start.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 set -euo pipefail
-ROOT="/Users/martinbouchard/src/rakazo"
+ROOT="${RAKAZO_ROOT:-$HOME/src/rakazo}"
 cd "$ROOT"
 # shellcheck disable=SC1091
 source "$ROOT/.rakazo-env.sh"

--- a/scripts/studio-stop.sh
+++ b/scripts/studio-stop.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+set -euo pipefail
+ROOT="/Users/martinbouchard/src/rakazo"
+cd "$ROOT"
+# shellcheck disable=SC1091
+source "$ROOT/.rakazo-env.sh"
+
+if [[ -f "$ROOT/run/dev.pid" ]]; then
+  pid="$(cat "$ROOT/run/dev.pid")"
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  rm -f "$ROOT/run/dev.pid"
+fi
+pkill -f "turbo dev --filter=@rakazo" 2>/dev/null || true
+pkill -f "tsx watch src/index.ts" 2>/dev/null || true
+# Keep Postgres data: stop only, never `down -v`
+docker compose --env-file .env -f infra/compose/docker-compose.yml stop postgres >/dev/null 2>&1 || true
+echo "stopped (postgres stopped, volumes kept)"

--- a/scripts/studio-stop.sh
+++ b/scripts/studio-stop.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 set -euo pipefail
-ROOT="/Users/martinbouchard/src/rakazo"
+ROOT="${RAKAZO_ROOT:-$HOME/src/rakazo}"
 cd "$ROOT"
 # shellcheck disable=SC1091
 source "$ROOT/.rakazo-env.sh"


### PR DESCRIPTION
## Summary

Operator-facing improvements from running Rakazo self-hosted. Product path is unchanged: Pi + Docker + Graphile.

Grouped by theme. Happy to split if that is easier to review.

## UX

- Integrations lists installed MCP servers (type badge, connected/disconnected status)
- Add MCP is the primary action; Treg and OpenAPI have short info popovers
- Optional per-bot model in Settings; unset means workspace default; duplicate/spawn inherit the parent
- Computer preview: double-click (or maximize) opens a max window in view-only mode; take control is a separate action

Per-agent MCP assignment is unchanged.

## MCP OAuth and robustness

- Start OAuth with SDK `auth()` (discovery + registration + authorize URL), not a Streamable HTTP `Client.connect`
- `mcp.oauth.complete` uses the OAuth session, not the popup cookie (COOP)
- Poll connection status while the popup is open
- Allow loopback HTTP callbacks plus extra origins via `TRUSTED_ORIGINS`
- Time out hung MCP discovery so one unreachable server cannot stall a run

## OpenRouter

Native OpenRouter support is unchanged. Optional env pins provider routing (`only` / `order`). Model ids that include `vision` get image input and a larger context window.

## Self-host

- Vite reads `WEB_PORT` from the repo-root `.env`; optional public host for HMR behind TLS
- `TRUSTED_ORIGINS` for extra auth origins
- Optional Tailscale in the computer sandbox (`NET_ADMIN`, `/dev/net/tun`)
- Optional local OAuth callback helper script

## Schema

```sql
ALTER TABLE "bots" ADD COLUMN IF NOT EXISTS "modelProvider" TEXT;
ALTER TABLE "bots" ADD COLUMN IF NOT EXISTS "modelId" TEXT;
```

## Test plan

- [ ] `pnpm check`
- [ ] Per-bot model override is used on the next run
- [ ] Integrations shows installed MCP servers and status
- [ ] MCP OAuth against a streamable HTTP server
- [ ] Computer maximize does not take control
- [ ] Hung MCP discovery does not block the model reply


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Choose a model for each bot, with workspace defaults supported.
  - Manage and connect MCP tool servers directly from the plugins and bot settings screens.
  - Added clearer tool-server connection statuses and improved MCP OAuth flows.
  - Computer previews now support maximize, restore, and easier control switching.
  - Added local Studio startup and shutdown helpers, including optional secure networking.

- **Bug Fixes**
  - Improved model handling for vision-capable tasks.
  - Added timeouts to MCP tool discovery to prevent stalled connections.
  - Improved support for configured development hosts and trusted origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->