### PR TITLE
Add a copy button to code blocks in chat messages

### DIFF
--- a/apps/web/src/lib/chat-markdown.test.tsx
+++ b/apps/web/src/lib/chat-markdown.test.tsx
@@ -32,4 +32,14 @@ describe("ChatMarkdown", () => {
     expect(html).toContain("const live = true;");
     expect(html).toContain("rk-chat-markdown-cursor");
   });
+
+  it("renders a copy button alongside each code block", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown>{"```ts\nconst value = 1;\n```"}</ChatMarkdown>,
+    );
+
+    expect(html).toContain("rk-chat-markdown-pre-wrap");
+    expect(html).toContain('aria-label="Copy code"');
+    expect(html).toContain("rk-chat-markdown-copy");
+  });
 });

--- a/packages/chat-ui/src/markdown.web.css
+++ b/packages/chat-ui/src/markdown.web.css
@@ -112,6 +112,43 @@
   white-space: pre;
 }
 
+.rk-chat-markdown-pre-wrap {
+  position: relative;
+  margin: 0.65em 0;
+}
+
+.rk-chat-markdown .rk-chat-markdown-pre-wrap pre {
+  margin: 0;
+}
+
+.rk-chat-markdown-copy {
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75em;
+  height: 1.75em;
+  border: 1px solid #34343a;
+  border-radius: 0.4em;
+  background: #17171a;
+  color: #b8b8bd;
+  opacity: 0;
+  transition: opacity 0.12s;
+  cursor: pointer;
+}
+
+.rk-chat-markdown-pre-wrap:hover .rk-chat-markdown-copy,
+.rk-chat-markdown-copy:focus-visible {
+  opacity: 1;
+}
+
+.rk-chat-markdown-copy:hover {
+  background: #202024;
+  color: #f3f3f4;
+}
+
 .rk-chat-markdown blockquote {
   border-left: 3px solid #55555c;
   padding-left: 0.85em;

--- a/packages/chat-ui/src/markdown.web.tsx
+++ b/packages/chat-ui/src/markdown.web.tsx
@@ -44,15 +44,18 @@ function CheckIcon() {
 
 function CodeBlock(props: React.ComponentPropsWithoutRef<"pre">) {
   const preRef = useRef<HTMLPreElement>(null);
+  const resetTimerRef = useRef<number | undefined>(undefined);
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
+    if (!navigator.clipboard) return;
     const text = preRef.current?.textContent ?? "";
     navigator.clipboard
       .writeText(text)
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        window.clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = window.setTimeout(() => setCopied(false), 1500);
       })
       .catch(() => {});
   }, []);

--- a/packages/chat-ui/src/markdown.web.tsx
+++ b/packages/chat-ui/src/markdown.web.tsx
@@ -1,8 +1,76 @@
-import { memo } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import "./markdown.web.css";
 import { type ChatMarkdownProps, closeUnterminatedFence, sanitizeMarkdownUrl } from "./markdown";
+
+function CopyIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect
+        x="9"
+        y="9"
+        width="12"
+        height="12"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M4 12.5 9.5 18 20 6"
+        stroke="currentColor"
+        strokeWidth="2.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CodeBlock(props: React.ComponentPropsWithoutRef<"pre">) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    const text = preRef.current?.textContent ?? "";
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="rk-chat-markdown-pre-wrap">
+      <pre {...props} ref={preRef} />
+      <button
+        type="button"
+        className="rk-chat-markdown-copy"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : "Copy code"}
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </button>
+    </div>
+  );
+}
 
 const components: Components = {
   a({ node: _node, ...props }) {
@@ -10,6 +78,9 @@ const components: Components = {
   },
   img({ node: _node, ...props }) {
     return <img {...props} alt={props.alt ?? ""} loading="lazy" />;
+  },
+  pre({ node: _node, ...props }) {
+    return <CodeBlock {...props} />;
   },
 };
 


### PR DESCRIPTION
## Summary

Bot replies render code through the shared `ChatMarkdown` component (`packages/chat-ui`), but there's no way to copy that code out - I kept wanting to grab a snippet from a reply and had to select-and-copy manually every time, which gets finicky once the block scrolls. There's no `navigator.clipboard` usage anywhere in the app today, and it's a pretty standard affordance in any chat product.

- Small icon-only copy button, shown on hover/focus over a code block
- Native Clipboard API - no new dependency
- Brief "copied" state (icon swap) for feedback, `aria-label` on the button for accessibility
- Lives in `packages/chat-ui/src/markdown.web.tsx`, so it covers both the web app and Electron (which hosts the same web UI) with one change
- Left `markdown.native.tsx` (mobile) alone on purpose - copy-on-mobile is normally a long-press gesture rather than a button, and would need its own dependency (`expo-clipboard`); happy to follow up separately if that's wanted

No schema, API, or auth/security-surface changes.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm --filter @rakazo/chat-ui check`, `pnpm --filter @rakazo/web check`
- [x] `pnpm test` - `chat-markdown.test.tsx` and the full `@rakazo/chat-ui` suite pass (8/8, including the new test)
- [x] `pnpm test` (full monorepo) - 823 passed; the 25 suites that failed all fail identically on a missing generated Prisma client (no `db:generate`/Postgres set up in this environment) - none touch the changed files
- [ ] `pnpm test:integration` / `pnpm test:e2e` - not run locally (needs Docker); this only touches a leaf presentational component so I don't expect it to affect these, but will watch CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copy button to Markdown code blocks.
  * Added visual feedback confirming when code has been copied.
  * Improved code-block layout and button visibility on hover or focus.
* **Tests**
  * Added coverage verifying accessible copy controls and code-block wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->