### PR TITLE
Add a workspace Now/Recent run list on web and mobile

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -106,6 +106,7 @@ import {
 import { buildMcpUpdateMaterial } from "./mcp-material.js";
 import { chooseFocus, markAppConnected, startOnboarding } from "./onboarding.js";
 import { addScreenProxyCapability } from "./screen-proxy.js";
+import { listWorkspaceRuns } from "./runs.js";
 import { queryWorkspaceSearch } from "./search.js";
 import { withSerializableRetry } from "./serializable-retry.js";
 import { assertTeachingSendAllowed, createTaughtSkillsService } from "./taught-skills.js";
@@ -2731,6 +2732,11 @@ export function createRouter(deps: RouterDeps) {
     search: {
       query: authed.search.query.handler(async ({ context, input }) => ({
         hits: await queryWorkspaceSearch(deps.prisma, context.actor, input.q),
+      })),
+    },
+    runs: {
+      list: authed.runs.list.handler(async ({ context, input }) => ({
+        runs: await listWorkspaceRuns(deps.prisma, context.actor, input.filter),
       })),
     },
     voice: {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -105,8 +105,8 @@ import {
 } from "./computer-status.js";
 import { buildMcpUpdateMaterial } from "./mcp-material.js";
 import { chooseFocus, markAppConnected, startOnboarding } from "./onboarding.js";
-import { addScreenProxyCapability } from "./screen-proxy.js";
 import { listWorkspaceRuns } from "./runs.js";
+import { addScreenProxyCapability } from "./screen-proxy.js";
 import { queryWorkspaceSearch } from "./search.js";
 import { withSerializableRetry } from "./serializable-retry.js";
 import { assertTeachingSendAllowed, createTaughtSkillsService } from "./taught-skills.js";

--- a/apps/api/src/runs.ts
+++ b/apps/api/src/runs.ts
@@ -1,0 +1,58 @@
+import type { Actor, RunActivityRow } from "@rakazo/contracts";
+import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
+import type { PrismaClient } from "@rakazo/db";
+
+const RECENT_LIMIT = 20;
+const TERMINAL_STATUSES = ["completed", "failed", "cancelled"] as const;
+
+function promptSnippet(prompt: string, max = 120): string {
+  const oneLine = prompt.replace(/\s+/g, " ").trim();
+  if (oneLine.length <= max) return oneLine;
+  return `${oneLine.slice(0, max - 1)}…`;
+}
+
+export async function listWorkspaceRuns(
+  prisma: PrismaClient,
+  actor: Actor,
+  filter: "active" | "recent",
+): Promise<RunActivityRow[]> {
+  const rows = await prisma.run.findMany({
+    where: {
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      ...(filter === "active"
+        ? { status: { in: [...ACTIVE_RUN_STATUSES] } }
+        : { status: { in: [...TERMINAL_STATUSES] } }),
+    },
+    include: {
+      bot: { select: { name: true, archivedAt: true } },
+      task: { select: { prompt: true } },
+      thread: {
+        select: {
+          groupId: true,
+          group: { select: { name: true } },
+        },
+      },
+    },
+    orderBy:
+      filter === "active"
+        ? [{ updatedAt: "desc" }, { id: "desc" }]
+        : [{ completedAt: "desc" }, { updatedAt: "desc" }, { id: "desc" }],
+    take: filter === "recent" ? RECENT_LIMIT : undefined,
+  });
+
+  return rows
+    .filter((row) => !row.bot.archivedAt)
+    .map((row) => ({
+      runId: row.id,
+      botId: row.botId,
+      botName: row.bot.name,
+      groupId: row.thread.groupId,
+      groupName: row.thread.group?.name ?? null,
+      threadId: row.threadId,
+      status: row.status as RunActivityRow["status"],
+      trigger: row.trigger as RunActivityRow["trigger"],
+      promptSnippet: promptSnippet(row.task.prompt),
+      updatedAt: (filter === "recent" && row.completedAt ? row.completedAt : row.updatedAt).toISOString(),
+    }));
+}

--- a/apps/api/src/runs.ts
+++ b/apps/api/src/runs.ts
@@ -20,6 +20,7 @@ export async function listWorkspaceRuns(
     where: {
       workspaceId: actor.workspaceId,
       userId: actor.userId,
+      bot: { archivedAt: null },
       ...(filter === "active"
         ? { status: { in: [...ACTIVE_RUN_STATUSES] } }
         : { status: { in: [...TERMINAL_STATUSES] } }),
@@ -41,18 +42,19 @@ export async function listWorkspaceRuns(
     take: filter === "recent" ? RECENT_LIMIT : undefined,
   });
 
-  return rows
-    .filter((row) => !row.bot.archivedAt)
-    .map((row) => ({
-      runId: row.id,
-      botId: row.botId,
-      botName: row.bot.name,
-      groupId: row.thread.groupId,
-      groupName: row.thread.group?.name ?? null,
-      threadId: row.threadId,
-      status: row.status as RunActivityRow["status"],
-      trigger: row.trigger as RunActivityRow["trigger"],
-      promptSnippet: promptSnippet(row.task.prompt),
-      updatedAt: (filter === "recent" && row.completedAt ? row.completedAt : row.updatedAt).toISOString(),
-    }));
+  return rows.map((row) => ({
+    runId: row.id,
+    botId: row.botId,
+    botName: row.bot.name,
+    groupId: row.thread.groupId,
+    groupName: row.thread.group?.name ?? null,
+    threadId: row.threadId,
+    status: row.status as RunActivityRow["status"],
+    trigger: row.trigger as RunActivityRow["trigger"],
+    promptSnippet: promptSnippet(row.task.prompt),
+    updatedAt: (filter === "recent" && row.completedAt
+      ? row.completedAt
+      : row.updatedAt
+    ).toISOString(),
+  }));
 }

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,4 +1,4 @@
-import type { SearchHit } from "@rakazo/contracts";
+import type { RunActivityRow, SearchHit } from "@rakazo/contracts";
 import { groupBotsForSidebar } from "@rakazo/core";
 import { Redirect, useFocusEffect, useRouter } from "expo-router";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
@@ -30,8 +30,13 @@ import { botTag, filterBots, formatThreadTime, userInitials } from "../lib/inbox
 import { native } from "../lib/native";
 import { previewSnippet } from "../lib/preview";
 import { registerPushToken } from "../lib/push";
-import { queryWorkspaceSearch } from "../lib/search";
+import {
+  activityStatusLabel,
+  fetchWorkspaceActivity,
+  formatActivityRelativeTime,
+} from "../lib/activity";
 import { mobileSearchDestination } from "../lib/search-destination";
+import { queryWorkspaceSearch } from "../lib/search";
 
 const FALLBACK_COLOR = "#9B5CF6";
 
@@ -55,6 +60,10 @@ export default function Home() {
   const [searchHits, setSearchHits] = useState<SearchHit[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [organizeBotId, setOrganizeBotId] = useState<string | null>(null);
+  const [activity, setActivity] = useState<{ active: RunActivityRow[]; recent: RunActivityRow[] }>({
+    active: [],
+    recent: [],
+  });
 
   const loadBots = useCallback(async () => {
     setError(null);
@@ -100,6 +109,24 @@ export default function Home() {
     useCallback(() => {
       if (hasSession) void loadBots();
     }, [hasSession, loadBots]),
+  );
+
+  const loadActivity = useCallback(async () => {
+    if (!hasSession || searching || query.trim()) {
+      setActivity({ active: [], recent: [] });
+      return;
+    }
+    try {
+      setActivity(await fetchWorkspaceActivity());
+    } catch {
+      setActivity({ active: [], recent: [] });
+    }
+  }, [hasSession, query, searching]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadActivity();
+    }, [loadActivity]),
   );
 
   useEffect(() => {
@@ -225,11 +252,19 @@ export default function Home() {
         refreshControl={
           <RefreshControl
             refreshing={refreshing}
-            onRefresh={() => void refreshBots()}
+            onRefresh={() => {
+              void refreshBots();
+              void loadActivity();
+            }}
             tintColor={native.secondaryLabel}
             colors={["#8E8E93"]}
             progressBackgroundColor="#1C1C1E"
           />
+        }
+        ListHeaderComponent={
+          !searching && !query.trim() && (activity.active.length > 0 || activity.recent.length > 0) ? (
+            <ActivitySection activity={activity} />
+          ) : null
         }
         ListEmptyComponent={
           <Text style={styles.empty}>
@@ -279,6 +314,64 @@ export default function Home() {
         />
       ) : null}
     </View>
+  );
+}
+
+function ActivitySection({
+  activity,
+}: {
+  activity: { active: RunActivityRow[]; recent: RunActivityRow[] };
+}) {
+  const router = useRouter();
+  const openRun = (run: RunActivityRow) => {
+    if (run.groupId) {
+      router.push({ pathname: "/group-thread", params: { groupId: run.groupId, name: run.groupName ?? "Group" } });
+      return;
+    }
+    router.push({ pathname: "/thread", params: { botId: run.botId, name: run.botName } });
+  };
+
+  return (
+    <View style={styles.activitySection}>
+      {activity.active.length > 0 ? (
+        <>
+          <Text style={styles.sectionHeading}>Now</Text>
+          {activity.active.map((run) => (
+            <ActivityRow key={run.runId} run={run} onPress={() => openRun(run)} />
+          ))}
+        </>
+      ) : null}
+      {activity.recent.length > 0 ? (
+        <>
+          <Text style={[styles.sectionHeading, activity.active.length > 0 && styles.activityGap]}>
+            Recent
+          </Text>
+          {activity.recent.map((run) => (
+            <ActivityRow key={run.runId} run={run} onPress={() => openRun(run)} />
+          ))}
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+function ActivityRow({ run, onPress }: { run: RunActivityRow; onPress: () => void }) {
+  const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}>
+      <View style={styles.activityDot} />
+      <View style={styles.rowBody}>
+        <View style={styles.rowTop}>
+          <Text style={styles.name} numberOfLines={1}>
+            {title}
+          </Text>
+          <Text style={styles.time}>{formatActivityRelativeTime(run.updatedAt)}</Text>
+        </View>
+        <Text style={styles.preview} numberOfLines={1}>
+          {run.promptSnippet || activityStatusLabel(run.status)} · {activityStatusLabel(run.status)}
+        </Text>
+      </View>
+    </Pressable>
   );
 }
 
@@ -556,6 +649,22 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
     paddingBottom: 4,
+  },
+  activitySection: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#2C2C2E",
+    marginBottom: 4,
+    paddingBottom: 4,
+  },
+  activityGap: {
+    paddingTop: 16,
+  },
+  activityDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: "#8B5CF6",
+    marginTop: 6,
   },
   groupAvatar: {
     width: 48,

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -376,10 +376,13 @@ function ActivityRow({ run, onPress }: { run: RunActivityRow; onPress: () => voi
   const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
   const status = activityStatusLabel(run.status);
   const preview = run.promptSnippet ? `${run.promptSnippet} · ${status}` : status;
+  const activityLabel = run.groupName
+    ? `${status} activity run in ${run.groupName}`
+    : `${status} activity run`;
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={`Activity for ${title}, ${status}`}
+      accessibilityLabel={activityLabel}
       onPress={onPress}
       style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
     >

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -146,11 +146,21 @@ export default function Home() {
   useFocusEffect(
     useCallback(() => {
       if (!hasSession || !activityMode || searching || query.trim()) return;
-      void loadActivity();
-      const timer = setInterval(() => void loadActivity(), 15_000);
+      let cancelled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      const tick = async () => {
+        await loadActivity();
+        if (!cancelled) {
+          timer = setTimeout(() => void tick(), 15_000);
+        }
+      };
+
+      void tick();
       return () => {
+        cancelled = true;
         activityRequestId.current += 1;
-        clearInterval(timer);
+        if (timer !== undefined) clearTimeout(timer);
       };
     }, [activityMode, hasSession, loadActivity, query, searching]),
   );

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,7 +1,7 @@
 import type { RunActivityRow, SearchHit } from "@rakazo/contracts";
 import { groupBotsForSidebar } from "@rakazo/core";
 import { Redirect, useFocusEffect, useRouter } from "expo-router";
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -19,6 +19,11 @@ import { BotOrganizeModal } from "../components/bot-organize-modal";
 import { GroupAvatar } from "../components/group-avatar";
 import { NativeSymbol } from "../components/native-symbol";
 import {
+  activityStatusLabel,
+  fetchWorkspaceActivity,
+  formatActivityRelativeTime,
+} from "../lib/activity";
+import {
   loadSessionToken,
   type MobileBot,
   type MobileBotSection,
@@ -30,13 +35,8 @@ import { botTag, filterBots, formatThreadTime, userInitials } from "../lib/inbox
 import { native } from "../lib/native";
 import { previewSnippet } from "../lib/preview";
 import { registerPushToken } from "../lib/push";
-import {
-  activityStatusLabel,
-  fetchWorkspaceActivity,
-  formatActivityRelativeTime,
-} from "../lib/activity";
-import { mobileSearchDestination } from "../lib/search-destination";
 import { queryWorkspaceSearch } from "../lib/search";
+import { mobileSearchDestination } from "../lib/search-destination";
 
 const FALLBACK_COLOR = "#9B5CF6";
 
@@ -64,6 +64,7 @@ export default function Home() {
     active: [],
     recent: [],
   });
+  const activityGeneration = useRef(0);
 
   const loadBots = useCallback(async () => {
     setError(null);
@@ -113,20 +114,31 @@ export default function Home() {
 
   const loadActivity = useCallback(async () => {
     if (!hasSession || searching || query.trim()) {
+      activityGeneration.current += 1;
       setActivity({ active: [], recent: [] });
       return;
     }
+    const generation = ++activityGeneration.current;
     try {
-      setActivity(await fetchWorkspaceActivity());
+      const next = await fetchWorkspaceActivity();
+      if (generation !== activityGeneration.current) return;
+      setActivity(next);
     } catch {
+      if (generation !== activityGeneration.current) return;
       setActivity({ active: [], recent: [] });
     }
   }, [hasSession, query, searching]);
 
   useFocusEffect(
     useCallback(() => {
+      if (!hasSession || searching || query.trim()) return;
       void loadActivity();
-    }, [loadActivity]),
+      const timer = setInterval(() => void loadActivity(), 15_000);
+      return () => {
+        activityGeneration.current += 1;
+        clearInterval(timer);
+      };
+    }, [hasSession, loadActivity, query, searching]),
   );
 
   useEffect(() => {
@@ -262,7 +274,9 @@ export default function Home() {
           />
         }
         ListHeaderComponent={
-          !searching && !query.trim() && (activity.active.length > 0 || activity.recent.length > 0) ? (
+          !searching &&
+          !query.trim() &&
+          (activity.active.length > 0 || activity.recent.length > 0) ? (
             <ActivitySection activity={activity} />
           ) : null
         }
@@ -325,7 +339,10 @@ function ActivitySection({
   const router = useRouter();
   const openRun = (run: RunActivityRow) => {
     if (run.groupId) {
-      router.push({ pathname: "/group-thread", params: { groupId: run.groupId, name: run.groupName ?? "Group" } });
+      router.push({
+        pathname: "/group-thread",
+        params: { groupId: run.groupId, name: run.groupName ?? "Group" },
+      });
       return;
     }
     router.push({ pathname: "/thread", params: { botId: run.botId, name: run.botName } });
@@ -357,8 +374,15 @@ function ActivitySection({
 
 function ActivityRow({ run, onPress }: { run: RunActivityRow; onPress: () => void }) {
   const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
+  const status = activityStatusLabel(run.status);
+  const preview = run.promptSnippet ? `${run.promptSnippet} · ${status}` : status;
   return (
-    <Pressable onPress={onPress} style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}>
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Activity for ${title}, ${status}`}
+      onPress={onPress}
+      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+    >
       <View style={styles.activityDot} />
       <View style={styles.rowBody}>
         <View style={styles.rowTop}>
@@ -368,7 +392,7 @@ function ActivityRow({ run, onPress }: { run: RunActivityRow; onPress: () => voi
           <Text style={styles.time}>{formatActivityRelativeTime(run.updatedAt)}</Text>
         </View>
         <Text style={styles.preview} numberOfLines={1}>
-          {run.promptSnippet || activityStatusLabel(run.status)} · {activityStatusLabel(run.status)}
+          {preview}
         </Text>
       </View>
     </Pressable>

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -118,7 +118,7 @@ export default function Home() {
       setActivity({ active: [], recent: [] });
       return;
     }
-    const generation = ++activityGeneration.current;
+    const generation = activityGeneration.current;
     try {
       const next = await fetchWorkspaceActivity();
       if (generation !== activityGeneration.current) return;

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -124,8 +124,8 @@ export default function Home() {
       if (requestId !== activityRequestId.current) return;
       setActivity(next);
     } catch {
+      // Keep the last good snapshot on transient RPC failures; only drop stale responses.
       if (requestId !== activityRequestId.current) return;
-      setActivity({ active: [], recent: [] });
     }
   }, [hasSession, query, searching]);
 

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -23,6 +23,7 @@ import {
   fetchWorkspaceActivity,
   formatActivityRelativeTime,
 } from "../lib/activity";
+import { loadActivityMode, saveActivityMode } from "../lib/activity-mode";
 import {
   loadSessionToken,
   type MobileBot,
@@ -60,11 +61,24 @@ export default function Home() {
   const [searchHits, setSearchHits] = useState<SearchHit[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [organizeBotId, setOrganizeBotId] = useState<string | null>(null);
+  const [activityMode, setActivityMode] = useState(false);
   const [activity, setActivity] = useState<{ active: RunActivityRow[]; recent: RunActivityRow[] }>({
     active: [],
     recent: [],
   });
   const activityRequestId = useRef(0);
+
+  useEffect(() => {
+    void loadActivityMode().then(setActivityMode);
+  }, []);
+
+  const toggleActivityMode = useCallback(() => {
+    setActivityMode((on) => {
+      const next = !on;
+      void saveActivityMode(next);
+      return next;
+    });
+  }, []);
 
   const loadBots = useCallback(async () => {
     setError(null);
@@ -113,7 +127,7 @@ export default function Home() {
   );
 
   const loadActivity = useCallback(async () => {
-    if (!hasSession || searching || query.trim()) {
+    if (!hasSession || !activityMode || searching || query.trim()) {
       activityRequestId.current += 1;
       setActivity({ active: [], recent: [] });
       return;
@@ -127,18 +141,18 @@ export default function Home() {
       // Keep the last good snapshot on transient RPC failures; only drop stale responses.
       if (requestId !== activityRequestId.current) return;
     }
-  }, [hasSession, query, searching]);
+  }, [activityMode, hasSession, query, searching]);
 
   useFocusEffect(
     useCallback(() => {
-      if (!hasSession || searching || query.trim()) return;
+      if (!hasSession || !activityMode || searching || query.trim()) return;
       void loadActivity();
       const timer = setInterval(() => void loadActivity(), 15_000);
       return () => {
         activityRequestId.current += 1;
         clearInterval(timer);
       };
-    }, [hasSession, loadActivity, query, searching]),
+    }, [activityMode, hasSession, loadActivity, query, searching]),
   );
 
   useEffect(() => {
@@ -203,6 +217,18 @@ export default function Home() {
           <Text style={styles.profileInitials}>{initials}</Text>
         </CircleButton>
         <View style={styles.headerActions}>
+          <CircleButton
+            accessibilityLabel="Activity"
+            active={activityMode}
+            onPress={toggleActivityMode}
+          >
+            <NativeSymbol
+              ios={activityMode ? "bell.fill" : "bell"}
+              android={activityMode ? "notifications" : "notifications-outline"}
+              size={17}
+              color={activityMode ? "#ECECEE" : "#fff"}
+            />
+          </CircleButton>
           <CircleButton
             accessibilityLabel="Search"
             active={searching}
@@ -274,6 +300,7 @@ export default function Home() {
           />
         }
         ListHeaderComponent={
+          activityMode &&
           !searching &&
           !query.trim() &&
           (activity.active.length > 0 || activity.recent.length > 0) ? (
@@ -415,6 +442,7 @@ function CircleButton({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ selected: active }}
       onPress={onPress}
       hitSlop={4}
       style={({ pressed }) => [styles.circleButton, (active || pressed) && styles.circlePressed]}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -64,7 +64,7 @@ export default function Home() {
     active: [],
     recent: [],
   });
-  const activityGeneration = useRef(0);
+  const activityRequestId = useRef(0);
 
   const loadBots = useCallback(async () => {
     setError(null);
@@ -114,17 +114,17 @@ export default function Home() {
 
   const loadActivity = useCallback(async () => {
     if (!hasSession || searching || query.trim()) {
-      activityGeneration.current += 1;
+      activityRequestId.current += 1;
       setActivity({ active: [], recent: [] });
       return;
     }
-    const generation = activityGeneration.current;
+    const requestId = ++activityRequestId.current;
     try {
       const next = await fetchWorkspaceActivity();
-      if (generation !== activityGeneration.current) return;
+      if (requestId !== activityRequestId.current) return;
       setActivity(next);
     } catch {
-      if (generation !== activityGeneration.current) return;
+      if (requestId !== activityRequestId.current) return;
       setActivity({ active: [], recent: [] });
     }
   }, [hasSession, query, searching]);
@@ -135,7 +135,7 @@ export default function Home() {
       void loadActivity();
       const timer = setInterval(() => void loadActivity(), 15_000);
       return () => {
-        activityGeneration.current += 1;
+        activityRequestId.current += 1;
         clearInterval(timer);
       };
     }, [hasSession, loadActivity, query, searching]),

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -376,9 +376,7 @@ function ActivityRow({ run, onPress }: { run: RunActivityRow; onPress: () => voi
   const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
   const status = activityStatusLabel(run.status);
   const preview = run.promptSnippet ? `${run.promptSnippet} · ${status}` : status;
-  const activityLabel = run.groupName
-    ? `${status} activity run in ${run.groupName}`
-    : `${status} activity run`;
+  const activityLabel = `${title}, ${status}`;
   return (
     <Pressable
       accessibilityRole="button"

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -220,13 +220,14 @@ export default function Home() {
           <CircleButton
             accessibilityLabel="Activity"
             active={activityMode}
+            accent
             onPress={toggleActivityMode}
           >
             <NativeSymbol
               ios={activityMode ? "bell.fill" : "bell"}
               android={activityMode ? "notifications" : "notifications-outline"}
               size={17}
-              color={activityMode ? "#ECECEE" : "#fff"}
+              color={activityMode ? "#FFFFFF" : "#8E8E93"}
             />
           </CircleButton>
           <CircleButton
@@ -432,11 +433,13 @@ function CircleButton({
   onPress,
   accessibilityLabel,
   active = false,
+  accent = false,
 }: {
   children: ReactNode;
   onPress: () => void;
   accessibilityLabel: string;
   active?: boolean;
+  accent?: boolean;
 }) {
   return (
     <Pressable
@@ -445,7 +448,10 @@ function CircleButton({
       accessibilityState={{ selected: active }}
       onPress={onPress}
       hitSlop={4}
-      style={({ pressed }) => [styles.circleButton, (active || pressed) && styles.circlePressed]}
+      style={({ pressed }) => [
+        styles.circleButton,
+        accent && active ? styles.circleAccent : (active || pressed) && styles.circlePressed,
+      ]}
     >
       {children}
     </Pressable>
@@ -591,6 +597,9 @@ const styles = StyleSheet.create({
   },
   circlePressed: {
     backgroundColor: "#3A3A3C",
+  },
+  circleAccent: {
+    backgroundColor: "#4C8DFF",
   },
   profileInitials: {
     color: native.label,

--- a/apps/mobile/lib/activity-mode.ts
+++ b/apps/mobile/lib/activity-mode.ts
@@ -1,0 +1,21 @@
+import * as SecureStore from "expo-secure-store";
+
+/** Persisted Codex-style recency mode for home Now/Recent. Default off. */
+export const ACTIVITY_MODE_KEY = "rakazo.activity-mode";
+
+export async function loadActivityMode(): Promise<boolean> {
+  try {
+    return (await SecureStore.getItemAsync(ACTIVITY_MODE_KEY)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export async function saveActivityMode(on: boolean): Promise<void> {
+  try {
+    if (on) await SecureStore.setItemAsync(ACTIVITY_MODE_KEY, "1");
+    else await SecureStore.deleteItemAsync(ACTIVITY_MODE_KEY);
+  } catch {
+    // SecureStore unavailable in some test / web hosts.
+  }
+}

--- a/apps/mobile/lib/activity.ts
+++ b/apps/mobile/lib/activity.ts
@@ -1,0 +1,50 @@
+import type { RunActivityRow } from "@rakazo/contracts";
+import { rpc } from "../lib/api";
+
+export async function fetchWorkspaceActivity(): Promise<{
+  active: RunActivityRow[];
+  recent: RunActivityRow[];
+}> {
+  const [active, recent] = await Promise.all([
+    rpc<{ runs: RunActivityRow[] }>("runs/list", { filter: "active" }),
+    rpc<{ runs: RunActivityRow[] }>("runs/list", { filter: "recent" }),
+  ]);
+  return { active: active.runs, recent: recent.runs };
+}
+
+export function formatActivityRelativeTime(iso: string, now = new Date()): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  if (seconds < 45) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export function activityStatusLabel(status: RunActivityRow["status"]): string {
+  switch (status) {
+    case "queued":
+      return "Queued";
+    case "leased":
+      return "Starting";
+    case "running":
+      return "Running";
+    case "waiting_input":
+      return "Needs input";
+    case "waiting_takeover":
+      return "Needs takeover";
+    case "completed":
+      return "Done";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return status;
+  }
+}

--- a/apps/web/e2e/activity-list.spec.ts
+++ b/apps/web/e2e/activity-list.spec.ts
@@ -1,0 +1,53 @@
+import { expect, type Page, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+/** Activity rows sit above `[data-sidebar-group]` bots; match their aria-label. */
+function activityRow(page: Page, botName: string) {
+  return page.locator("aside").getByRole("button", {
+    name: new RegExp(`^${botName}, `),
+  });
+}
+
+test("sidebar Now and Recent surface active and terminal runs", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `activity-${stamp}@rakazo.test`, "password12", "Activity");
+  await completeOnboarding(page);
+
+  const composer = page.getByPlaceholder(/Message/);
+  await composer.fill("keep working until I stop you");
+  await page.keyboard.press("Enter");
+  await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
+
+  // Remount ActivityList so the first poll sees the in-flight run (15s interval otherwise).
+  await page.reload();
+  await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByText("Loading activity…")).toBeHidden({ timeout: 20_000 });
+  const aside = page.locator("aside").first();
+  await expect(aside.getByText("Now", { exact: true })).toBeVisible({ timeout: 20_000 });
+  await expect(activityRow(page, "Chief")).toBeVisible();
+  await expect(activityRow(page, "Chief")).toContainText(/keep working|Running|Queued|Starting/i);
+  await captureScreenshot(page, testInfo, "57-activity-now");
+
+  await page.getByRole("button", { name: "Stop", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
+
+  await page.reload();
+  await expect(page.getByText("Loading activity…")).toBeHidden({ timeout: 20_000 });
+  await expect(aside.getByText("Recent", { exact: true })).toBeVisible({ timeout: 20_000 });
+  await expect(activityRow(page, "Chief")).toBeVisible();
+  await expect(activityRow(page, "Chief")).toContainText(/Cancelled|keep working/i);
+  await expect(aside.getByText("Now", { exact: true })).toHaveCount(0);
+  await captureScreenshot(page, testInfo, "58-activity-recent");
+
+  await page.getByPlaceholder("Search").fill("Chief");
+  await expect(aside.getByText("Recent", { exact: true })).toHaveCount(0);
+  await expect(activityRow(page, "Chief")).toHaveCount(0);
+
+  await page.getByPlaceholder("Search").fill("");
+  await expect(aside.getByText("Recent", { exact: true })).toBeVisible({ timeout: 20_000 });
+  await expect(activityRow(page, "Chief")).toBeVisible();
+});

--- a/apps/web/e2e/activity-list.spec.ts
+++ b/apps/web/e2e/activity-list.spec.ts
@@ -8,6 +8,35 @@ function activityRow(page: Page, botName: string) {
   });
 }
 
+async function captureActivitySidebar(
+  page: Page,
+  testInfo: Parameters<typeof captureScreenshot>[1],
+  name: string,
+) {
+  const aside = page.locator("aside").first();
+  const toggle = page.getByRole("button", { name: "Activity", exact: true });
+  await toggle.scrollIntoViewIfNeeded();
+  // Keep the header (bell + Create) in frame with the Now/Recent list.
+  const box = await aside.boundingBox();
+  if (box) {
+    const screenshotPath = testInfo.outputPath(`${name}.png`);
+    await page.screenshot({
+      animations: "disabled",
+      caret: "hide",
+      path: screenshotPath,
+      clip: {
+        x: Math.max(0, box.x),
+        y: Math.max(0, box.y),
+        width: Math.min(box.width + 24, 360),
+        height: Math.min(Math.max(box.height, 420), 720),
+      },
+    });
+    await testInfo.attach(name, { contentType: "image/png", path: screenshotPath });
+    return;
+  }
+  await captureScreenshot(page, testInfo, name);
+}
+
 test("sidebar Now and Recent surface active and terminal runs", async ({ page }, testInfo) => {
   const stamp = Date.now();
   await signup(page, `activity-${stamp}@rakazo.test`, "password12", "Activity");
@@ -16,11 +45,12 @@ test("sidebar Now and Recent surface active and terminal runs", async ({ page },
   const aside = page.locator("aside").first();
   const activityToggle = page.getByRole("button", { name: "Activity", exact: true });
   await expect(activityToggle).toHaveAttribute("aria-pressed", "false");
+  await expect(activityToggle).toHaveAttribute("data-activity-mode", "off");
   await expect(aside.getByText("Now", { exact: true })).toHaveCount(0);
   await expect(aside.getByText("Recent", { exact: true })).toHaveCount(0);
   await expect(aside.getByText("Loading activity…")).toHaveCount(0);
   await expect(aside.locator("[data-sidebar-group]").getByText("Chief").first()).toBeVisible();
-  await captureScreenshot(page, testInfo, "57-activity-mode-off");
+  await captureActivitySidebar(page, testInfo, "57-activity-mode-off");
 
   const composer = page.getByPlaceholder(/Message/);
   await composer.fill("keep working until I stop you");
@@ -30,10 +60,12 @@ test("sidebar Now and Recent surface active and terminal runs", async ({ page },
 
   await activityToggle.click();
   await expect(activityToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(activityToggle).toHaveAttribute("data-activity-mode", "on");
 
   // Remount ActivityList so the first poll sees the in-flight run (15s interval otherwise).
   await page.reload();
   await expect(activityToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(activityToggle).toHaveAttribute("data-activity-mode", "on");
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible({
     timeout: 30_000,
@@ -42,19 +74,20 @@ test("sidebar Now and Recent surface active and terminal runs", async ({ page },
   await expect(aside.getByText("Now", { exact: true })).toBeVisible({ timeout: 20_000 });
   await expect(activityRow(page, "Chief")).toBeVisible();
   await expect(activityRow(page, "Chief")).toContainText(/keep working|Running|Queued|Starting/i);
-  await captureScreenshot(page, testInfo, "58-activity-now");
+  await captureActivitySidebar(page, testInfo, "58-activity-now");
 
   await page.getByRole("button", { name: "Stop", exact: true }).click();
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
 
   await page.reload();
   await expect(activityToggle).toHaveAttribute("aria-pressed", "true");
+  await expect(activityToggle).toHaveAttribute("data-activity-mode", "on");
   await expect(page.getByText("Loading activity…")).toBeHidden({ timeout: 20_000 });
   await expect(aside.getByText("Recent", { exact: true })).toBeVisible({ timeout: 20_000 });
   await expect(activityRow(page, "Chief")).toBeVisible();
   await expect(activityRow(page, "Chief")).toContainText(/Cancelled|keep working/i);
   await expect(aside.getByText("Now", { exact: true })).toHaveCount(0);
-  await captureScreenshot(page, testInfo, "59-activity-recent");
+  await captureActivitySidebar(page, testInfo, "59-activity-recent");
 
   await page.getByPlaceholder("Search").fill("Chief");
   await expect(aside.getByText("Recent", { exact: true })).toHaveCount(0);

--- a/apps/web/e2e/activity-list.spec.ts
+++ b/apps/web/e2e/activity-list.spec.ts
@@ -13,35 +13,48 @@ test("sidebar Now and Recent surface active and terminal runs", async ({ page },
   await signup(page, `activity-${stamp}@rakazo.test`, "password12", "Activity");
   await completeOnboarding(page);
 
+  const aside = page.locator("aside").first();
+  const activityToggle = page.getByRole("button", { name: "Activity", exact: true });
+  await expect(activityToggle).toHaveAttribute("aria-pressed", "false");
+  await expect(aside.getByText("Now", { exact: true })).toHaveCount(0);
+  await expect(aside.getByText("Recent", { exact: true })).toHaveCount(0);
+  await expect(aside.getByText("Loading activity…")).toHaveCount(0);
+  await expect(aside.locator("[data-sidebar-group]").getByText("Chief").first()).toBeVisible();
+  await captureScreenshot(page, testInfo, "57-activity-mode-off");
+
   const composer = page.getByPlaceholder(/Message/);
   await composer.fill("keep working until I stop you");
   await page.keyboard.press("Enter");
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
 
+  await activityToggle.click();
+  await expect(activityToggle).toHaveAttribute("aria-pressed", "true");
+
   // Remount ActivityList so the first poll sees the in-flight run (15s interval otherwise).
   await page.reload();
+  await expect(activityToggle).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible({
     timeout: 30_000,
   });
   await expect(page.getByText("Loading activity…")).toBeHidden({ timeout: 20_000 });
-  const aside = page.locator("aside").first();
   await expect(aside.getByText("Now", { exact: true })).toBeVisible({ timeout: 20_000 });
   await expect(activityRow(page, "Chief")).toBeVisible();
   await expect(activityRow(page, "Chief")).toContainText(/keep working|Running|Queued|Starting/i);
-  await captureScreenshot(page, testInfo, "57-activity-now");
+  await captureScreenshot(page, testInfo, "58-activity-now");
 
   await page.getByRole("button", { name: "Stop", exact: true }).click();
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
 
   await page.reload();
+  await expect(activityToggle).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByText("Loading activity…")).toBeHidden({ timeout: 20_000 });
   await expect(aside.getByText("Recent", { exact: true })).toBeVisible({ timeout: 20_000 });
   await expect(activityRow(page, "Chief")).toBeVisible();
   await expect(activityRow(page, "Chief")).toContainText(/Cancelled|keep working/i);
   await expect(aside.getByText("Now", { exact: true })).toHaveCount(0);
-  await captureScreenshot(page, testInfo, "58-activity-recent");
+  await captureScreenshot(page, testInfo, "59-activity-recent");
 
   await page.getByPlaceholder("Search").fill("Chief");
   await expect(aside.getByText("Recent", { exact: true })).toHaveCount(0);

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -8,6 +8,10 @@ import {
   signup,
 } from "./helpers";
 
+function sidebarBotButton(page: Page, name: RegExp | string) {
+  return page.locator("[data-sidebar-group]").getByRole("button", { name });
+}
+
 test.describe.configure({ mode: "serial" });
 
 test("two users are isolated and a bot completes durable work", async ({ browser }, testInfo) => {
@@ -213,13 +217,13 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   const composer = page.getByPlaceholder(/Message/);
   await composer.fill("spawn a bot named Scout to research venues");
   await page.keyboard.press("Enter");
-  await expect(page.getByRole("complementary").getByRole("button", { name: /Scout/ })).toBeVisible({
+  await expect(sidebarBotButton(page, /Scout/)).toBeVisible({
     timeout: 30_000,
   });
   await captureScreenshot(page, testInfo, "13-spawned-bot");
 
   await page
-    .getByRole("complementary")
+    .locator("[data-sidebar-group]")
     .getByRole("button", { name: /^Chief/ })
     .click();
   await composer.fill("keep working until I stop you");
@@ -235,12 +239,8 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await page.getByPlaceholder("Password").fill("password12");
   await page.getByRole("button", { name: "Continue with email" }).click();
   await page.waitForURL(/\/app/, { timeout: 20_000 });
-  await expect(
-    page.getByRole("complementary").getByRole("button", { name: /^Chief/ }),
-  ).toBeVisible();
-  await expect(
-    page.getByRole("complementary").getByRole("button", { name: /Scout/ }),
-  ).toBeVisible();
+  await expect(sidebarBotButton(page, /^Chief/)).toBeVisible();
+  await expect(sidebarBotButton(page, /Scout/)).toBeVisible();
   await captureScreenshot(page, testInfo, "15-restored-session");
 });
 

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -96,10 +96,11 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
     });
   });
   await page.reload();
+  // Anchor ^ so Now/Recent activity rows ("Bot · Draft team, …") do not match.
   const groupAvatar = page
     .locator("aside")
     .first()
-    .getByRole("button", { name: /Draft team/ })
+    .getByRole("button", { name: /^Draft team/ })
     .locator(".rakazo-group-avatar");
   await expect(groupAvatar).toBeVisible();
   await expect(groupAvatar.locator(".rakazo-bot-avatar")).toHaveCount(2);
@@ -116,9 +117,9 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   const groupName = desktopSettings.locator("label:has-text('Name') input");
   await groupName.fill("Unsaved Draft team name");
   const sidebar = page.locator("aside").first();
-  await sidebar.getByRole("button", { name: /Review team/ }).click();
+  await sidebar.getByRole("button", { name: /^Review team/ }).click();
   await expect(groupName).toHaveValue("Review team");
-  await sidebar.getByRole("button", { name: /Draft team/ }).click();
+  await sidebar.getByRole("button", { name: /^Draft team/ }).click();
   await expect(groupName).toHaveValue("Draft team");
   await page.route("**/rpc/groups/update", async (route) => route.abort("failed"));
   await desktopSettings.getByRole("button", { name: "Save", exact: true }).click();
@@ -130,9 +131,9 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await page
     .getByRole("textbox", { name: "Message Draft team" })
     .fill("@Researcher unfinished draft");
-  await sidebar.getByRole("button", { name: /Review team/ }).click();
+  await sidebar.getByRole("button", { name: /^Review team/ }).click();
   await expect(page.getByRole("textbox", { name: "Message Review team" })).toHaveValue("");
-  await sidebar.getByRole("button", { name: /Draft team/ }).click();
+  await sidebar.getByRole("button", { name: /^Draft team/ }).click();
   await expect(page.getByRole("textbox", { name: "Message Draft team" })).toHaveValue("");
 
   const composer = page.getByRole("textbox", { name: "Message Draft team" });
@@ -212,14 +213,14 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
     await reviewSnapshotReleased;
     await route.continue();
   });
-  await sidebar.getByRole("button", { name: /Review team/ }).click();
+  await sidebar.getByRole("button", { name: /^Review team/ }).click();
   await reviewSnapshotIntercepted;
   await expect(page).toHaveURL(new RegExp(`/app/g/${reviewGroup.id}$`));
   await expect(page.getByTestId("transcript")).not.toContainText("Answered: Paris");
   releaseReviewSnapshot();
   await expect(page.getByRole("textbox", { name: "Message Review team" })).toBeVisible();
   await page.unroute("**/rpc/threads/get");
-  await sidebar.getByRole("button", { name: /Draft team/ }).click();
+  await sidebar.getByRole("button", { name: /^Draft team/ }).click();
   await expect(page.getByText("Answered: Paris", { exact: true })).toBeVisible();
 
   await composer.fill(

--- a/apps/web/src/lib/activity-mode.ts
+++ b/apps/web/src/lib/activity-mode.ts
@@ -1,0 +1,19 @@
+/** Persisted Codex-style recency mode for the sidebar Now/Recent list. Default off. */
+export const ACTIVITY_MODE_KEY = "rakazo.activity-mode";
+
+export function readActivityMode(): boolean {
+  try {
+    return window.localStorage.getItem(ACTIVITY_MODE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeActivityMode(on: boolean): void {
+  try {
+    if (on) window.localStorage.setItem(ACTIVITY_MODE_KEY, "1");
+    else window.localStorage.removeItem(ACTIVITY_MODE_KEY);
+  } catch {
+    // Private mode / blocked storage — keep in-memory only.
+  }
+}

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -139,9 +139,13 @@ function ActivityRow({ run, onOpen }: { run: RunActivityRow; onOpen: () => void 
             {formatRelativeTime(run.updatedAt)}
           </span>
         </div>
-        <div className="mt-0.5 flex items-baseline justify-between gap-2">
-          <span className="truncate text-[13px] text-[#85858A]">{run.promptSnippet || label}</span>
-          <span className="shrink-0 text-[12px]" style={{ color: statusColor(run.status) }}>
+        <div className="mt-0.5 flex items-baseline gap-2">
+          {run.promptSnippet ? (
+            <span className="min-w-0 flex-1 truncate text-[13px] text-[#85858A]">
+              {run.promptSnippet}
+            </span>
+          ) : null}
+          <span className="ms-auto shrink-0 text-[12px]" style={{ color: statusColor(run.status) }}>
             {label}
           </span>
         </div>

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -1,5 +1,5 @@
 import type { RunActivityRow } from "@rakazo/contracts";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { rpc } from "../lib/rpc";
 
 function formatRelativeTime(iso: string, now = new Date()): string {
@@ -55,33 +55,38 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
   const [activeRuns, setActiveRuns] = useState<RunActivityRow[]>([]);
   const [recentRuns, setRecentRuns] = useState<RunActivityRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const refreshGeneration = useRef(0);
 
   const refresh = useCallback(async () => {
+    const generation = ++refreshGeneration.current;
     try {
       const [active, recent] = await Promise.all([
         rpc.runs.list({ filter: "active" }),
         rpc.runs.list({ filter: "recent" }),
       ]);
+      if (generation !== refreshGeneration.current) return;
       setActiveRuns(active.runs);
       setRecentRuns(recent.runs);
     } catch {
+      if (generation !== refreshGeneration.current) return;
       setActiveRuns([]);
       setRecentRuns([]);
     } finally {
-      setLoading(false);
+      if (generation === refreshGeneration.current) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
     void refresh();
     const timer = window.setInterval(() => void refresh(), 15_000);
-    return () => window.clearInterval(timer);
+    return () => {
+      refreshGeneration.current += 1;
+      window.clearInterval(timer);
+    };
   }, [refresh]);
 
   if (loading) {
-    return (
-      <div className="px-2.5 py-2 text-[13px] text-[#6C6C70]">Loading activity…</div>
-    );
+    return <div className="px-2.5 py-2 text-[13px] text-[#6C6C70]">Loading activity…</div>;
   }
 
   if (activeRuns.length === 0 && recentRuns.length === 0) return null;
@@ -110,9 +115,11 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
 
 function ActivityRow({ run, onOpen }: { run: RunActivityRow; onOpen: () => void }) {
   const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
+  const label = statusLabel(run.status);
   return (
     <button
       type="button"
+      aria-label={`Activity for ${title}, ${label}`}
       onClick={onOpen}
       className="flex w-full gap-3 rounded-xl px-2.5 py-[9px] text-left hover:bg-[#131315]"
     >
@@ -129,11 +136,9 @@ function ActivityRow({ run, onOpen }: { run: RunActivityRow; onOpen: () => void 
           </span>
         </div>
         <div className="mt-0.5 flex items-baseline justify-between gap-2">
-          <span className="truncate text-[13px] text-[#85858A]">
-            {run.promptSnippet || statusLabel(run.status)}
-          </span>
+          <span className="truncate text-[13px] text-[#85858A]">{run.promptSnippet || label}</span>
           <span className="shrink-0 text-[12px]" style={{ color: statusColor(run.status) }}>
-            {statusLabel(run.status)}
+            {label}
           </span>
         </div>
       </div>

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -116,10 +116,13 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
 function ActivityRow({ run, onOpen }: { run: RunActivityRow; onOpen: () => void }) {
   const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
   const label = statusLabel(run.status);
+  const activityLabel = run.groupName
+    ? `${label} activity run in ${run.groupName}`
+    : `${label} activity run`;
   return (
     <button
       type="button"
-      aria-label={`Activity for ${title}, ${label}`}
+      aria-label={activityLabel}
       onClick={onOpen}
       className="flex w-full gap-3 rounded-xl px-2.5 py-[9px] text-left hover:bg-[#131315]"
     >

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -1,0 +1,142 @@
+import type { RunActivityRow } from "@rakazo/contracts";
+import { useCallback, useEffect, useState } from "react";
+import { rpc } from "../lib/rpc";
+
+function formatRelativeTime(iso: string, now = new Date()): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  if (seconds < 45) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function statusLabel(status: RunActivityRow["status"]): string {
+  switch (status) {
+    case "queued":
+      return "Queued";
+    case "leased":
+      return "Starting";
+    case "running":
+      return "Running";
+    case "waiting_input":
+      return "Needs input";
+    case "waiting_takeover":
+      return "Needs takeover";
+    case "completed":
+      return "Done";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    default:
+      return status;
+  }
+}
+
+function statusColor(status: RunActivityRow["status"]): string {
+  if (status === "failed") return "#FF5364";
+  if (status === "cancelled") return "#85858A";
+  if (status === "completed") return "#4ECB71";
+  if (status === "waiting_input" || status === "waiting_takeover") return "#F5A03C";
+  return "#8B5CF6";
+}
+
+type ActivityListProps = {
+  onOpenRun: (run: RunActivityRow) => void;
+};
+
+export function ActivityList({ onOpenRun }: ActivityListProps) {
+  const [activeRuns, setActiveRuns] = useState<RunActivityRow[]>([]);
+  const [recentRuns, setRecentRuns] = useState<RunActivityRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [active, recent] = await Promise.all([
+        rpc.runs.list({ filter: "active" }),
+        rpc.runs.list({ filter: "recent" }),
+      ]);
+      setActiveRuns(active.runs);
+      setRecentRuns(recent.runs);
+    } catch {
+      setActiveRuns([]);
+      setRecentRuns([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 15_000);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  if (loading) {
+    return (
+      <div className="px-2.5 py-2 text-[13px] text-[#6C6C70]">Loading activity…</div>
+    );
+  }
+
+  if (activeRuns.length === 0 && recentRuns.length === 0) return null;
+
+  return (
+    <div className="mb-2 border-b border-[#202023] pb-2">
+      {activeRuns.length > 0 ? (
+        <section>
+          <div className="px-2.5 pb-1 pt-1 text-[12.5px] font-medium text-[#6C6C70]">Now</div>
+          {activeRuns.map((run) => (
+            <ActivityRow key={run.runId} run={run} onOpen={() => onOpenRun(run)} />
+          ))}
+        </section>
+      ) : null}
+      {recentRuns.length > 0 ? (
+        <section className={activeRuns.length > 0 ? "mt-2" : undefined}>
+          <div className="px-2.5 pb-1 pt-1 text-[12.5px] font-medium text-[#6C6C70]">Recent</div>
+          {recentRuns.map((run) => (
+            <ActivityRow key={run.runId} run={run} onOpen={() => onOpenRun(run)} />
+          ))}
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function ActivityRow({ run, onOpen }: { run: RunActivityRow; onOpen: () => void }) {
+  const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full gap-3 rounded-xl px-2.5 py-[9px] text-left hover:bg-[#131315]"
+    >
+      <span
+        className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+        style={{ backgroundColor: statusColor(run.status) }}
+        aria-hidden="true"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="truncate text-[14px] font-medium text-[#ECECEE]">{title}</span>
+          <span className="shrink-0 text-[12px] text-[#6C6C70]">
+            {formatRelativeTime(run.updatedAt)}
+          </span>
+        </div>
+        <div className="mt-0.5 flex items-baseline justify-between gap-2">
+          <span className="truncate text-[13px] text-[#85858A]">
+            {run.promptSnippet || statusLabel(run.status)}
+          </span>
+          <span className="shrink-0 text-[12px]" style={{ color: statusColor(run.status) }}>
+            {statusLabel(run.status)}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -56,9 +56,14 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
   const [recentRuns, setRecentRuns] = useState<RunActivityRow[]>([]);
   const [loading, setLoading] = useState(true);
   const refreshGeneration = useRef(0);
+  const inFlight = useRef(false);
 
   const refresh = useCallback(async () => {
-    const generation = ++refreshGeneration.current;
+    // Skip overlapping ticks so a slow poll cannot be invalidated (stuck Loading)
+    // or finish after a newer start and clear loading early (empty flash).
+    if (inFlight.current) return;
+    inFlight.current = true;
+    const generation = refreshGeneration.current;
     try {
       const [active, recent] = await Promise.all([
         rpc.runs.list({ filter: "active" }),
@@ -72,8 +77,8 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
       setActiveRuns([]);
       setRecentRuns([]);
     } finally {
-      // Clear loading even for stale polls so >15s RPCs cannot stick on "Loading…".
-      setLoading(false);
+      inFlight.current = false;
+      if (generation === refreshGeneration.current) setLoading(false);
     }
   }, []);
 

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -74,10 +74,11 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
         setActiveRuns([]);
         setRecentRuns([]);
       } finally {
-        if (cancelled) return;
-        setLoading(false);
-        // Schedule the next poll after the previous settles — no overlap.
-        timer = window.setTimeout(() => void tick(), 15_000);
+        if (!cancelled) {
+          setLoading(false);
+          // Schedule the next poll after the previous settles — no overlap.
+          timer = window.setTimeout(() => void tick(), 15_000);
+        }
       }
     };
 

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -72,7 +72,8 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
       setActiveRuns([]);
       setRecentRuns([]);
     } finally {
-      if (generation === refreshGeneration.current) setLoading(false);
+      // Clear loading even for stale polls so >15s RPCs cannot stick on "Loading…".
+      setLoading(false);
     }
   }, []);
 

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -1,5 +1,5 @@
 import type { RunActivityRow } from "@rakazo/contracts";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { rpc } from "../lib/rpc";
 
 function formatRelativeTime(iso: string, now = new Date()): string {
@@ -55,41 +55,38 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
   const [activeRuns, setActiveRuns] = useState<RunActivityRow[]>([]);
   const [recentRuns, setRecentRuns] = useState<RunActivityRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const refreshGeneration = useRef(0);
-  const inFlight = useRef(false);
-
-  const refresh = useCallback(async () => {
-    // Skip overlapping ticks so a slow poll cannot be invalidated (stuck Loading)
-    // or finish after a newer start and clear loading early (empty flash).
-    if (inFlight.current) return;
-    inFlight.current = true;
-    const generation = refreshGeneration.current;
-    try {
-      const [active, recent] = await Promise.all([
-        rpc.runs.list({ filter: "active" }),
-        rpc.runs.list({ filter: "recent" }),
-      ]);
-      if (generation !== refreshGeneration.current) return;
-      setActiveRuns(active.runs);
-      setRecentRuns(recent.runs);
-    } catch {
-      if (generation !== refreshGeneration.current) return;
-      setActiveRuns([]);
-      setRecentRuns([]);
-    } finally {
-      inFlight.current = false;
-      if (generation === refreshGeneration.current) setLoading(false);
-    }
-  }, []);
 
   useEffect(() => {
-    void refresh();
-    const timer = window.setInterval(() => void refresh(), 15_000);
-    return () => {
-      refreshGeneration.current += 1;
-      window.clearInterval(timer);
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const tick = async () => {
+      try {
+        const [active, recent] = await Promise.all([
+          rpc.runs.list({ filter: "active" }),
+          rpc.runs.list({ filter: "recent" }),
+        ]);
+        if (cancelled) return;
+        setActiveRuns(active.runs);
+        setRecentRuns(recent.runs);
+      } catch {
+        if (cancelled) return;
+        setActiveRuns([]);
+        setRecentRuns([]);
+      } finally {
+        if (cancelled) return;
+        setLoading(false);
+        // Schedule the next poll after the previous settles — no overlap.
+        timer = window.setTimeout(() => void tick(), 15_000);
+      }
     };
-  }, [refresh]);
+
+    void tick();
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, []);
 
   if (loading) {
     return <div className="px-2.5 py-2 text-[13px] text-[#6C6C70]">Loading activity…</div>;

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -70,9 +70,8 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
         setActiveRuns(active.runs);
         setRecentRuns(recent.runs);
       } catch {
+        // Keep the last good snapshot on transient RPC failures.
         if (cancelled) return;
-        setActiveRuns([]);
-        setRecentRuns([]);
       } finally {
         if (!cancelled) {
           setLoading(false);

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -116,9 +116,7 @@ export function ActivityList({ onOpenRun }: ActivityListProps) {
 function ActivityRow({ run, onOpen }: { run: RunActivityRow; onOpen: () => void }) {
   const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
   const label = statusLabel(run.status);
-  const activityLabel = run.groupName
-    ? `${label} activity run in ${run.groupName}`
-    : `${label} activity run`;
+  const activityLabel = `${title}, ${label}`;
   return (
     <button
       type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -118,11 +118,11 @@ import {
   userHoldsComputerControl,
 } from "../lib/thread-events";
 import { speaker } from "../lib/tts";
+import { ActivityList } from "./ActivityList";
 import type { ContextMenuPosition } from "./BotContextMenu";
 import { CreateGroupForm, GroupSettings, memberName } from "./GroupPanel";
 import { HostComputerPrompt } from "./HostComputerPrompt";
 import { WindowChrome } from "./WindowChrome";
-import { ActivityList } from "./ActivityList";
 import { WorkspaceSearchResults } from "./WorkspaceSearch";
 
 const BotContextMenu = lazy(() =>
@@ -1494,67 +1494,67 @@ export function ShellPage() {
                 }}
               />
               {sidebarGroups.map((group) => (
-              <div key={group.key} data-sidebar-group={group.key}>
-                {group.title ? (
-                  <div className="px-2.5 pb-1 pt-3 text-[12.5px] font-medium text-[#6C6C70]">
-                    {group.title}
-                  </div>
-                ) : null}
-                {group.bots.map((bot) => (
-                  <button
-                    key={bot.id}
-                    type="button"
-                    onClick={() => {
-                      setMobileSidebarOpen(false);
-                      navigate(`/app/${bot.id}`);
-                    }}
-                    onContextMenu={(event) => {
-                      event.preventDefault();
-                      setBotMenu({
-                        botId: bot.id,
-                        position: { x: event.clientX, y: event.clientY },
-                      });
-                    }}
-                    className="flex w-full gap-3 rounded-xl px-2.5 py-[11px] text-start"
-                    style={{
-                      background: !inGroup && active?.id === bot.id ? "#161618" : "transparent",
-                    }}
-                  >
-                    <BotAvatar color={bot.color} size={38} status={bot.status} />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-baseline justify-between gap-2">
-                        <span
+                <div key={group.key} data-sidebar-group={group.key}>
+                  {group.title ? (
+                    <div className="px-2.5 pb-1 pt-3 text-[12.5px] font-medium text-[#6C6C70]">
+                      {group.title}
+                    </div>
+                  ) : null}
+                  {group.bots.map((bot) => (
+                    <button
+                      key={bot.id}
+                      type="button"
+                      onClick={() => {
+                        setMobileSidebarOpen(false);
+                        navigate(`/app/${bot.id}`);
+                      }}
+                      onContextMenu={(event) => {
+                        event.preventDefault();
+                        setBotMenu({
+                          botId: bot.id,
+                          position: { x: event.clientX, y: event.clientY },
+                        });
+                      }}
+                      className="flex w-full gap-3 rounded-xl px-2.5 py-[11px] text-start"
+                      style={{
+                        background: !inGroup && active?.id === bot.id ? "#161618" : "transparent",
+                      }}
+                    >
+                      <BotAvatar color={bot.color} size={38} status={bot.status} />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-baseline justify-between gap-2">
+                          <span
+                            dir="auto"
+                            className={`truncate text-[15px] text-[#ECECEE] ${
+                              bot.unread ? "font-semibold" : "font-medium"
+                            }`}
+                          >
+                            {bot.name}
+                            {bot.unread ? <span className="sr-only"> (unread)</span> : null}
+                          </span>
+                          <span className="flex shrink-0 items-center gap-1.5 text-[12.5px] text-[#6C6C70]">
+                            {bot.status === "idle" ? "" : bot.status}
+                            {bot.unread ? (
+                              <span
+                                aria-hidden="true"
+                                className="inline-block h-2 w-2 rounded-full bg-[#8B5CF6]"
+                              />
+                            ) : null}
+                          </span>
+                        </div>
+                        <div
                           dir="auto"
-                          className={`truncate text-[15px] text-[#ECECEE] ${
-                            bot.unread ? "font-semibold" : "font-medium"
+                          className={`mt-0.5 truncate text-[13.5px] ${
+                            bot.unread ? "font-medium text-[#C9C9CE]" : "text-[#85858A]"
                           }`}
                         >
-                          {bot.name}
-                          {bot.unread ? <span className="sr-only"> (unread)</span> : null}
-                        </span>
-                        <span className="flex shrink-0 items-center gap-1.5 text-[12.5px] text-[#6C6C70]">
-                          {bot.status === "idle" ? "" : bot.status}
-                          {bot.unread ? (
-                            <span
-                              aria-hidden="true"
-                              className="inline-block h-2 w-2 rounded-full bg-[#8B5CF6]"
-                            />
-                          ) : null}
-                        </span>
+                          {bot.preview || bot.title}
+                        </div>
                       </div>
-                      <div
-                        dir="auto"
-                        className={`mt-0.5 truncate text-[13.5px] ${
-                          bot.unread ? "font-medium text-[#C9C9CE]" : "text-[#85858A]"
-                        }`}
-                      >
-                        {bot.preview || bot.title}
-                      </div>
-                    </div>
-                  </button>
-                ))}
-              </div>
-            ))}
+                    </button>
+                  ))}
+                </div>
+              ))}
             </>
           )}
           {!showWorkspaceSearch

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1449,12 +1449,18 @@ export function ShellPage() {
               aria-label="Activity"
               aria-pressed={activityMode}
               title="Activity"
+              data-activity-mode={activityMode ? "on" : "off"}
               onClick={toggleActivityMode}
-              className={`app-no-drag flex items-center justify-center ${
-                activityMode ? "text-[#ECECEE]" : "text-[#7A7A80] hover:text-[#C9C9CE]"
+              className={`app-no-drag flex h-7 w-7 items-center justify-center rounded-full ${
+                activityMode ? "bg-[#4C8DFF] text-white" : "text-[#7A7A80] hover:text-[#C9C9CE]"
               }`}
             >
-              <Bell size={16} strokeWidth={1.8} aria-hidden="true" />
+              <Bell
+                size={15}
+                strokeWidth={1.8}
+                fill={activityMode ? "currentColor" : "none"}
+                aria-hidden="true"
+              />
             </button>
             <button
               type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -122,6 +122,7 @@ import type { ContextMenuPosition } from "./BotContextMenu";
 import { CreateGroupForm, GroupSettings, memberName } from "./GroupPanel";
 import { HostComputerPrompt } from "./HostComputerPrompt";
 import { WindowChrome } from "./WindowChrome";
+import { ActivityList } from "./ActivityList";
 import { WorkspaceSearchResults } from "./WorkspaceSearch";
 
 const BotContextMenu = lazy(() =>
@@ -1484,7 +1485,15 @@ export function ShellPage() {
               onSelect={(hit) => void jumpToSearchHit(hit)}
             />
           ) : (
-            sidebarGroups.map((group) => (
+            <>
+              <ActivityList
+                onOpenRun={(run) => {
+                  setMobileSidebarOpen(false);
+                  if (run.groupId) navigate(`/app/g/${run.groupId}`);
+                  else navigate(`/app/${run.botId}`);
+                }}
+              />
+              {sidebarGroups.map((group) => (
               <div key={group.key} data-sidebar-group={group.key}>
                 {group.title ? (
                   <div className="px-2.5 pb-1 pt-3 text-[12.5px] font-medium text-[#6C6C70]">
@@ -1545,7 +1554,8 @@ export function ShellPage() {
                   </button>
                 ))}
               </div>
-            ))
+            ))}
+            </>
           )}
           {!showWorkspaceSearch
             ? groups.map((group) => (

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -52,6 +52,7 @@ import {
 import { BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
 import {
   ArrowUp,
+  Bell,
   Box,
   ChevronLeft,
   Cpu,
@@ -95,6 +96,7 @@ import { SkillDraftCard } from "../components/teach/SkillDraftCard";
 import { TeachCaptureOverlay } from "../components/teach/TeachCaptureOverlay";
 import { TeachComputerSection } from "../components/teach/TeachComputerSection";
 import { TeachRecordingChrome, TeachStopButton } from "../components/teach/TeachRecordingChrome";
+import { readActivityMode, writeActivityMode } from "../lib/activity-mode";
 import { type ArtifactTarget, decodeArtifactBase64 } from "../lib/artifact-open";
 import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
@@ -241,6 +243,14 @@ export function ShellPage() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
+  const [activityMode, setActivityMode] = useState(readActivityMode);
+  const toggleActivityMode = useCallback(() => {
+    setActivityMode((on) => {
+      const next = !on;
+      writeActivityMode(next);
+      return next;
+    });
+  }, []);
   const [botMenu, setBotMenu] = useState<{
     botId: string;
     position: ContextMenuPosition;
@@ -1433,7 +1443,19 @@ export function ShellPage() {
       >
         <div className="app-drag flex items-center justify-between px-[18px] pb-3 pt-4">
           <WindowChrome />
-          <div className="relative">
+          <div className="relative flex items-center gap-2.5">
+            <button
+              type="button"
+              aria-label="Activity"
+              aria-pressed={activityMode}
+              title="Activity"
+              onClick={toggleActivityMode}
+              className={`app-no-drag flex items-center justify-center ${
+                activityMode ? "text-[#ECECEE]" : "text-[#7A7A80] hover:text-[#C9C9CE]"
+              }`}
+            >
+              <Bell size={16} strokeWidth={1.8} aria-hidden="true" />
+            </button>
             <button
               type="button"
               onClick={() => setCreateMenuOpen((open) => !open)}
@@ -1486,13 +1508,15 @@ export function ShellPage() {
             />
           ) : (
             <>
-              <ActivityList
-                onOpenRun={(run) => {
-                  setMobileSidebarOpen(false);
-                  if (run.groupId) navigate(`/app/g/${run.groupId}`);
-                  else navigate(`/app/${run.botId}`);
-                }}
-              />
+              {activityMode ? (
+                <ActivityList
+                  onOpenRun={(run) => {
+                    setMobileSidebarOpen(false);
+                    if (run.groupId) navigate(`/app/g/${run.groupId}`);
+                    else navigate(`/app/${run.botId}`);
+                  }}
+                />
+              ) : null}
               {sidebarGroups.map((group) => (
                 <div key={group.key} data-sidebar-group={group.key}>
                   {group.title ? (

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6,4 +6,5 @@ export * from "./ids.js";
 export * from "./mcp.js";
 export * from "./openai-compatible-ui.js";
 export * from "./rpc.js";
+export * from "./runs.js";
 export * from "./search.js";

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -516,9 +516,7 @@ export const appContract = {
     query: oc.input(z.object({ q: z.string().max(200) })).output(SearchQueryOutputSchema),
   },
   runs: {
-    list: oc
-      .input(z.object({ filter: z.enum(["active", "recent"]) }))
-      .output(RunsListOutputSchema),
+    list: oc.input(z.object({ filter: z.enum(["active", "recent"]) })).output(RunsListOutputSchema),
   },
   voice: {
     catalog: oc.output(z.array(VoiceCatalogEntrySchema)),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -56,6 +56,7 @@ import {
 } from "./domain.js";
 import { ProductEventSchema } from "./events.js";
 import { Id } from "./ids.js";
+import { RunsListOutputSchema } from "./runs.js";
 import { SearchQueryOutputSchema } from "./search.js";
 
 const botId = z.object({ botId: Id });
@@ -513,6 +514,11 @@ export const appContract = {
   },
   search: {
     query: oc.input(z.object({ q: z.string().max(200) })).output(SearchQueryOutputSchema),
+  },
+  runs: {
+    list: oc
+      .input(z.object({ filter: z.enum(["active", "recent"]) }))
+      .output(RunsListOutputSchema),
   },
   voice: {
     catalog: oc.output(z.array(VoiceCatalogEntrySchema)),

--- a/packages/contracts/src/runs.ts
+++ b/packages/contracts/src/runs.ts
@@ -1,0 +1,21 @@
+import * as z from "zod";
+import { Id, RunStatus } from "./ids.js";
+
+export const RunActivityRowSchema = z.object({
+  runId: Id,
+  botId: Id,
+  botName: z.string(),
+  groupId: Id.nullable(),
+  groupName: z.string().nullable(),
+  threadId: Id,
+  status: RunStatus,
+  trigger: z.enum(["user", "routine", "resume", "follow_up", "spawn", "skill"]),
+  promptSnippet: z.string(),
+  updatedAt: z.string(),
+});
+export type RunActivityRow = z.infer<typeof RunActivityRowSchema>;
+
+export const RunsListOutputSchema = z.object({
+  runs: z.array(RunActivityRowSchema),
+});
+export type RunsListOutput = z.infer<typeof RunsListOutputSchema>;

--- a/packages/testkit/src/runs-list.test.ts
+++ b/packages/testkit/src/runs-list.test.ts
@@ -1,0 +1,210 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { PrismaClient } from "@rakazo/db";
+import type { RunActivityRow } from "@rakazo/contracts";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { sessionCookieHeader } from "./index.js";
+
+type App = { request: (input: string, init?: RequestInit) => Promise<Response> };
+
+process.env.WAKEUP_DRIVER = "memory";
+process.env.SANDBOX_PROVIDER = "fake";
+process.env.AGENT_RUNTIME = "scripted";
+
+const hasDb = process.env.VERIFY_DATABASE === "1" && Boolean(process.env.DATABASE_URL);
+const describeRunsList = hasDb ? describe : describe.skip;
+
+describeRunsList("runs.list activity tracker", () => {
+  let app: App;
+  let prisma: PrismaClient;
+  let stop: () => Promise<void>;
+  const stamp = Date.now();
+  const dataDir = mkdtempSync(path.join(tmpdir(), "rakazo-runs-list-"));
+
+  beforeAll(async () => {
+    const { createApp } = await import("../../../apps/api/src/app.ts");
+    const handles = await createApp({
+      databaseUrl: process.env.DATABASE_URL!,
+      dataDir,
+      sandboxProvider: "fake",
+      agentRuntime: "scripted",
+    });
+    app = handles.app;
+    prisma = handles.prisma;
+    stop = handles.stop;
+  });
+
+  afterAll(async () => {
+    await stop?.();
+  });
+
+  it("lists active runs from two bots and keeps completed runs under recent", async () => {
+    const cookie = await signup(app, `runs-${stamp}@rakazo.test`, "Runs User");
+    const alpha = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Alpha",
+      title: "Alpha",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const beta = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Beta",
+      title: "Beta",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+
+    await seedRun(prisma, alpha.id, "running", "alpha in flight");
+    await seedRun(prisma, beta.id, "queued", "beta in flight");
+    await seedRun(prisma, alpha.id, "completed", "alpha done");
+
+    const active = await rpc<{ runs: RunActivityRow[] }>(app, cookie, "runs/list", {
+      filter: "active",
+    });
+    expect(active.runs.map((run) => run.botName).sort()).toEqual(["Alpha", "Beta"]);
+    expect(active.runs.some((run) => run.status === "completed")).toBe(false);
+
+    const recent = await rpc<{ runs: RunActivityRow[] }>(app, cookie, "runs/list", {
+      filter: "recent",
+    });
+    expect(recent.runs.some((run) => run.botName === "Alpha" && run.status === "completed")).toBe(
+      true,
+    );
+    expect(recent.runs.some((run) => run.botName === "Beta")).toBe(false);
+  });
+
+  it("never returns runs from another workspace", async () => {
+    const ownerCookie = await signup(app, `runs-owner-${stamp}@rakazo.test`, "Owner");
+    const ownerBot = await rpc<{ id: string }>(app, ownerCookie, "bots/create", {
+      name: "OwnerBot",
+      title: "OwnerBot",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    await seedRun(prisma, ownerBot.id, "running", "owner active run");
+
+    const intruderCookie = await signup(app, `runs-intruder-${stamp}@rakazo.test`, "Intruder");
+    const active = await rpc<{ runs: RunActivityRow[] }>(app, intruderCookie, "runs/list", {
+      filter: "active",
+    });
+    expect(active.runs).toEqual([]);
+  });
+
+  it("returns group runs with groupId for navigation", async () => {
+    const cookie = await signup(app, `runs-group-${stamp}@rakazo.test`, "Group User");
+    const botA = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Worker",
+      title: "Worker",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const botB = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Helper",
+      title: "Helper",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const group = await rpc<{ id: string }>(app, cookie, "groups/create", {
+      name: "Ops",
+      botIds: [botA.id, botB.id],
+    });
+    const groupThread = await prisma.thread.findUniqueOrThrow({ where: { groupId: group.id } });
+    const task = await prisma.task.create({
+      data: {
+        workspaceId: groupThread.workspaceId,
+        userId: groupThread.userId,
+        botId: botA.id,
+        threadId: groupThread.id,
+        prompt: "group task in flight",
+        status: "running",
+      },
+    });
+    await prisma.run.create({
+      data: {
+        workspaceId: groupThread.workspaceId,
+        userId: groupThread.userId,
+        botId: botA.id,
+        threadId: groupThread.id,
+        taskId: task.id,
+        status: "running",
+        trigger: "user",
+      },
+    });
+
+    const active = await rpc<{ runs: RunActivityRow[] }>(app, cookie, "runs/list", {
+      filter: "active",
+    });
+    const groupRun = active.runs.find((run) => run.groupId === group.id);
+    expect(groupRun).toBeTruthy();
+    expect(groupRun?.groupName).toBe("Ops");
+    expect(groupRun?.botId).toBe(botA.id);
+  });
+});
+
+async function seedRun(
+  prisma: PrismaClient,
+  botId: string,
+  status: "queued" | "running" | "completed",
+  prompt: string,
+) {
+  const thread = await prisma.thread.findUniqueOrThrow({ where: { botId } });
+  const task = await prisma.task.create({
+    data: {
+      workspaceId: thread.workspaceId,
+      userId: thread.userId,
+      botId,
+      threadId: thread.id,
+      prompt,
+      status,
+    },
+  });
+  return prisma.run.create({
+    data: {
+      workspaceId: thread.workspaceId,
+      userId: thread.userId,
+      botId,
+      threadId: thread.id,
+      taskId: task.id,
+      status,
+      trigger: "user",
+      completedAt: status === "completed" ? new Date() : null,
+    },
+  });
+}
+
+async function signup(app: App, email: string, name: string) {
+  const response = await app.request("/api/auth/sign-up/email", {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: "http://127.0.0.1:5173" },
+    body: JSON.stringify({ email, password: "test-password-123", name }),
+  });
+  expect(response.status).toBeLessThan(400);
+  return sessionCookieHeader(response);
+}
+
+async function rpc<T>(app: App, cookie: string, proc: string, body: unknown = {}): Promise<T> {
+  const res = await raw(app, cookie, proc, body);
+  const text = await res.text();
+  const parsed = JSON.parse(text) as { json?: T; error?: { message?: string } };
+  if (res.status >= 400 || parsed.error) {
+    throw new Error(`${proc} ${res.status}: ${parsed.error?.message ?? text}`);
+  }
+  return parsed.json as T;
+}
+
+async function raw(app: App, cookie: string, proc: string, body: unknown) {
+  return app.request(`/rpc/${proc}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie,
+      origin: "http://127.0.0.1:5173",
+    },
+    body: JSON.stringify({ json: body }),
+  });
+}

--- a/packages/testkit/src/runs-list.test.ts
+++ b/packages/testkit/src/runs-list.test.ts
@@ -109,15 +109,25 @@ describeRunsList("runs.list activity tracker", () => {
       instructions: "",
       notifyOnFinish: true,
     });
-    await seedRun(prisma, archivedBot.id, "completed", "archived run");
     await rpc(app, cookie, "bots/archive", { botId: archivedBot.id });
-    await seedRun(prisma, visibleBot.id, "completed", "visible run");
+    const olderVisibleAt = new Date(Date.now() - 86_400_000);
+    for (let i = 0; i < 21; i += 1) {
+      await seedRun(
+        prisma,
+        archivedBot.id,
+        "completed",
+        `archived filler ${i}`,
+        new Date(Date.now() - i * 1_000),
+      );
+    }
+    await seedRun(prisma, visibleBot.id, "completed", "visible run", olderVisibleAt);
 
     const recent = await rpc<{ runs: RunActivityRow[] }>(app, cookie, "runs/list", {
       filter: "recent",
     });
     expect(recent.runs.some((run) => run.botName === "Archived")).toBe(false);
     expect(recent.runs.some((run) => run.botName === "Visible")).toBe(true);
+    expect(recent.runs.length).toBe(1);
   });
 
   it("returns group runs with groupId for navigation", async () => {
@@ -178,6 +188,7 @@ async function seedRun(
   botId: string,
   status: "queued" | "running" | "completed",
   prompt: string,
+  completedAt?: Date | null,
 ) {
   const thread = await prisma.thread.findUniqueOrThrow({ where: { botId } });
   const task = await prisma.task.create({
@@ -199,7 +210,7 @@ async function seedRun(
       taskId: task.id,
       status,
       trigger: "user",
-      completedAt: status === "completed" ? new Date() : null,
+      completedAt: status === "completed" ? (completedAt ?? new Date()) : null,
     },
   });
 }

--- a/packages/testkit/src/runs-list.test.ts
+++ b/packages/testkit/src/runs-list.test.ts
@@ -1,8 +1,8 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { PrismaClient } from "@rakazo/db";
 import type { RunActivityRow } from "@rakazo/contracts";
+import type { PrismaClient } from "@rakazo/db";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { sessionCookieHeader } from "./index.js";
 
@@ -91,6 +91,33 @@ describeRunsList("runs.list activity tracker", () => {
       filter: "active",
     });
     expect(active.runs).toEqual([]);
+  });
+
+  it("excludes archived bots from recent before applying the limit", async () => {
+    const cookie = await signup(app, `runs-archived-${stamp}@rakazo.test`, "Archive User");
+    const archivedBot = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Archived",
+      title: "Archived",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const visibleBot = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Visible",
+      title: "Visible",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    await seedRun(prisma, archivedBot.id, "completed", "archived run");
+    await rpc(app, cookie, "bots/archive", { botId: archivedBot.id });
+    await seedRun(prisma, visibleBot.id, "completed", "visible run");
+
+    const recent = await rpc<{ runs: RunActivityRow[] }>(app, cookie, "runs/list", {
+      filter: "recent",
+    });
+    expect(recent.runs.some((run) => run.botName === "Archived")).toBe(false);
+    expect(recent.runs.some((run) => run.botName === "Visible")).toBe(true);
   });
 
   it("returns group runs with groupId for navigation", async () => {


### PR DESCRIPTION
## Summary
- Adds `runs.list` `{ filter: "active" | "recent" }` so a signed-in user can see in-flight bot work (`queued|leased|running|waiting_input|waiting_takeover`) and the last 20 terminal runs without opening every thread.
- Web sidebar **Now / Recent** (hidden while searching) and mobile home list open the matching 1:1 or group thread.
- Tenant-scoped; tests cover two active bots, completed → recent, workspace isolation, and group `groupId`.

This is the Grok-shaped “follow the work” surface. Official Grok Bot keeps activity in search + the open conversation; Rakazo still needs a home list because it has many 1:1 threads.

Closes #161

## Test plan
- [ ] `pnpm --filter @rakazo/contracts --filter @rakazo/api --filter @rakazo/web check`
- [ ] `VERIFY_DATABASE=1 DATABASE_URL=… pnpm exec vitest run packages/testkit/src/runs-list.test.ts --root .`
- [ ] Web: start a run on two bots → both appear under **Now**; click a row → that thread opens
- [ ] Let a run finish → it moves to **Recent** (max 20)
- [ ] Group run row shows `Bot · Group` and opens `/app/g/:groupId`
- [ ] Type in Search → activity list hides; clear Search → it returns
- [ ] Mobile home: same Now/Recent list; hidden while searching; row opens 1:1 or group thread
- [ ] Another workspace’s runs never appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Activity views for active and recent runs on web and mobile.
  * Activity entries show statuses, relative timestamps, prompt previews, and navigation to runs.
  * Added persistent Activity mode toggles with automatic refresh and controls for stopping active runs.
  * Added agent skill management and skill expansion during test runs.
* **Bug Fixes**
  * Archived bots are excluded before recent-activity limits are applied.
  * Improved loading, empty, error, search, and refresh-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->