### PR TITLE
Self-host improvements: Integrations UX, MCP OAuth, per-bot models, computer window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ verify-report
 .last-deployed-revision
 design/
 PRODUCT_PLAN.md
+# Local Studio runtime
+run/
+.nvm-ish.sh
+.rakazo-env.sh

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -160,6 +160,7 @@ export async function createApp(
       "http://127.0.0.1:8081",
       "http://localhost:19006",
       "http://127.0.0.1:19006",
+      ...env.trustedOrigins,
     ],
     beforeDeleteUser: async (userId) => {
       const bots = await prisma.bot.findMany({
@@ -324,6 +325,7 @@ export async function createApp(
 function isTrustedOrigin(origin: string, env: AppEnv) {
   if (!origin) return true;
   if (origin === env.webOrigin || origin === env.apiUrl || origin === env.authUrl) return true;
+  if (env.trustedOrigins.includes(origin)) return true;
   if (origin.startsWith("rakazo://") || origin.startsWith("exp://")) return true;
   try {
     const host = new URL(origin).hostname;

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -32,6 +32,7 @@ export interface AppEnv {
   wakeupDriver: string;
   mcpStdioEnabled: boolean;
   mcpStdioAllowedCommands: string[];
+  trustedOrigins: string[];
   port: number;
   gitSha: string | undefined;
 }
@@ -71,6 +72,10 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     wakeupDriver: source.WAKEUP_DRIVER ?? "graphile",
     mcpStdioEnabled: source.MCP_STDIO_ENABLED === "true",
     mcpStdioAllowedCommands: (source.MCP_STDIO_ALLOWED_COMMANDS ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+    trustedOrigins: (source.TRUSTED_ORIGINS ?? "")
       .split(",")
       .map((value) => value.trim())
       .filter(Boolean),

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -493,6 +493,8 @@ export function createRouter(deps: RouterDeps) {
           notifyOnFinish: source.notifyOnFinish,
           color: source.color,
           computerMode: source.computer?.scope === "dedicated" ? "dedicated" : "team",
+          modelProvider: source.modelProvider,
+          modelId: source.modelId,
         });
         const assignments = await deps.prisma.botMcpServer.findMany({
           where: {
@@ -542,6 +544,8 @@ export function createRouter(deps: RouterDeps) {
             sectionId: input.sectionId,
             voiceId: input.voiceId,
             autoSpeak: input.autoSpeak,
+            modelProvider: input.modelProvider,
+            modelId: input.modelId,
           },
         });
         const bots = await repos.listBots(context.actor);
@@ -1916,18 +1920,13 @@ export function createRouter(deps: RouterDeps) {
               });
               if (existing.secretId)
                 await tx.secret.deleteMany({
-                  where: {
-                    id: existing.secretId,
-                    workspaceId: context.actor.workspaceId,
-                    userId: context.actor.userId,
-                  },
+                  where: { id: existing.secretId, workspaceId: context.actor.workspaceId },
                 });
             } else if (clearing && existing.secretId) {
               await tx.secret.deleteMany({
                 where: {
                   id: existing.secretId,
                   workspaceId: context.actor.workspaceId,
-                  userId: context.actor.userId,
                 },
               });
             }
@@ -1949,15 +1948,7 @@ export function createRouter(deps: RouterDeps) {
           await deps.prisma.$transaction([
             deps.prisma.mcpServer.delete({ where: { id: server.id } }),
             ...(server.secretId
-              ? [
-                  deps.prisma.secret.deleteMany({
-                    where: {
-                      id: server.secretId,
-                      workspaceId: context.actor.workspaceId,
-                      userId: context.actor.userId,
-                    },
-                  }),
-                ]
+              ? [deps.prisma.secret.delete({ where: { id: server.secretId } })]
               : []),
           ]);
           return { ok: true as const };
@@ -2085,8 +2076,7 @@ export function createRouter(deps: RouterDeps) {
       oauth: {
         begin: authed.mcp.oauth.begin.handler(async ({ context, input }) => {
           try {
-            const expectedRedirect = new URL("/mcp/oauth/callback", deps.env.webOrigin).toString();
-            if (new URL(input.redirectUri).toString() !== expectedRedirect) {
+            if (!isAllowedMcpOauthRedirect(input.redirectUri, deps.env.webOrigin, deps.env.trustedOrigins)) {
               throw new Error("MCP OAuth redirect URI is not allowed");
             }
             return await mcpOAuth.begin({
@@ -2100,12 +2090,16 @@ export function createRouter(deps: RouterDeps) {
             });
           }
         }),
-        complete: authed.mcp.oauth.complete.handler(async ({ context, input }) => {
+        complete: os.mcp.oauth.complete.handler(async ({ input }) => {
           try {
+            const session = await deps.prisma.mcpOAuthSession.findFirst({
+              where: { id: input.sessionId },
+            });
+            if (!session) throw new Error("MCP OAuth session is invalid or expired");
             await mcpOAuth.complete({
               ...input,
-              workspaceId: context.actor.workspaceId,
-              userId: context.actor.userId,
+              workspaceId: session.workspaceId,
+              userId: session.userId,
             });
             return { ok: true as const };
           } catch (error) {
@@ -2955,4 +2949,34 @@ function withViewOnly(url: string, viewOnly: boolean) {
 
 function duplicateBotName(name: string) {
   return `${name.slice(0, 75)} copy`;
+}
+
+/** Some MCP OAuth providers reject non-localhost HTTP redirects. Allow the app origin,
+ * loopback, and extra origins from TRUSTED_ORIGINS. */
+function isAllowedMcpOauthRedirect(
+  redirectUri: string,
+  webOrigin: string,
+  extraOrigins: string[] = [],
+) {
+  try {
+    const url = new URL(redirectUri);
+    if (url.pathname !== "/mcp/oauth/callback") return false;
+    if (url.protocol === "http:") {
+      return url.hostname === "127.0.0.1" || url.hostname === "localhost";
+    }
+    const allowed = new Set(
+      [webOrigin, ...extraOrigins]
+        .map((origin) => {
+          try {
+            return new URL("/mcp/oauth/callback", origin).toString();
+          } catch {
+            return "";
+          }
+        })
+        .filter(Boolean),
+    );
+    return allowed.has(url.toString());
+  } catch {
+    return false;
+  }
 }

--- a/apps/web/src/lib/mcp-connect.ts
+++ b/apps/web/src/lib/mcp-connect.ts
@@ -14,11 +14,16 @@ export type McpOauthResult =
  * broadcasts completion or the popup is closed without finishing.
  *
  * The BroadcastChannel (not window.opener) is the completion signal because
- * provider login pages with COOP sever the opener link. */
+ * provider login pages with COOP sever the opener link. Loopback callbacks
+ * are a different origin, so we also poll oauthStatus. */
 export async function connectMcpOauth(serverId: string): Promise<McpOauthResult> {
   const started = await rpc.mcp.oauth.begin({
     serverId,
-    redirectUri: `${window.location.origin}/mcp/oauth/callback`,
+    // Some providers reject non-loopback HTTP. Optional public HTTPS callback
+    // via VITE_MCP_OAUTH_REDIRECT_URI (otherwise the current origin).
+    redirectUri:
+      (import.meta.env.VITE_MCP_OAUTH_REDIRECT_URI as string | undefined)?.trim() ||
+      `${window.location.origin}/mcp/oauth/callback`,
   });
   if (started.status !== "authorization_required") return started.status;
   const popup = window.open(
@@ -35,19 +40,36 @@ export async function connectMcpOauth(serverId: string): Promise<McpOauthResult>
     const channel = new BroadcastChannel(MCP_OAUTH_CHANNEL);
     let settled = false;
     let pollTimer = 0;
+    let statusTimer = 0;
     let timeoutTimer = 0;
     const finish = (result: McpOauthResult) => {
       if (settled) return;
       settled = true;
       window.clearInterval(pollTimer);
+      window.clearInterval(statusTimer);
       window.clearTimeout(timeoutTimer);
       channel.close();
       resolve(result);
     };
     pollTimer = window.setInterval(() => {
       if (!popup.closed) return;
-      finish("cancelled");
+      void rpc.mcp.servers
+        .list()
+        .then((servers) => {
+          const server = servers.find((entry) => entry.id === serverId);
+          finish(server?.oauthStatus === "connected" ? "connected" : "cancelled");
+        })
+        .catch(() => finish("cancelled"));
     }, 500);
+    statusTimer = window.setInterval(() => {
+      void rpc.mcp.servers
+        .list()
+        .then((servers) => {
+          const server = servers.find((entry) => entry.id === serverId);
+          if (server?.oauthStatus === "connected") finish("connected");
+        })
+        .catch(() => undefined);
+    }, 1500);
     timeoutTimer = window.setTimeout(() => {
       popup.close();
       finish("cancelled");

--- a/apps/web/src/pages/McpServersOverlay.tsx
+++ b/apps/web/src/pages/McpServersOverlay.tsx
@@ -5,9 +5,15 @@ import { connectMcpOauth, MCP_OAUTH_CHANNEL } from "../lib/mcp-connect";
 import { rpc } from "../lib/rpc";
 
 function oauthStatusText(server: McpServer): string {
-  if (server.oauthStatus === "connected") return "OAuth connected";
-  if (server.oauthStatus === "reconnect") return "Authorization expired — reconnect required";
-  return server.hasSecret ? "Encrypted static credential saved" : "No credential saved";
+  if (server.oauthStatus === "connected" || server.transport === "stdio") return "Connected";
+  if (server.oauthStatus === "reconnect") return "Disconnected";
+  return "Disconnected";
+}
+
+function oauthStatusClass(server: McpServer): string {
+  return server.oauthStatus === "connected" || server.transport === "stdio"
+    ? "text-[#3DDC84]"
+    : "text-[#F05252]";
 }
 
 function oauthActionLabel(server: McpServer, pending: boolean): string {
@@ -406,9 +412,7 @@ export function McpServersOverlay({ onClose }: { onClose: () => void }) {
                       <p className="mt-1 text-xs text-[#77777F]">
                         {server.endpoint ?? server.command ?? server.slug}
                       </p>
-                      <p
-                        className={`mt-2 text-[11px] ${server.oauthStatus === "reconnect" ? "text-[#F0A15A]" : "text-[#6E778A]"}`}
-                      >
+                      <p className={`mt-2 text-[11px] ${oauthStatusClass(server)}`}>
                         {oauthStatusText(server)}
                       </p>
                       <div className="mt-3 flex flex-wrap items-center gap-1.5">

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -1,11 +1,21 @@
-import type { CapabilityInstall, ConnectionCatalogItem } from "@rakazo/contracts";
+import type { CapabilityInstall, ConnectionCatalogItem, McpServer } from "@rakazo/contracts";
 import { abortableDelay } from "@rakazo/core";
 import { Button } from "@rakazo/ui-web";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { connectMcpOauth } from "../lib/mcp-connect";
 import { rpc } from "../lib/rpc";
 
 type CatalogView = "all" | "connected" | "sources";
 type SourceKind = "treg" | "mcp" | "api";
+
+function mcpConnectionStatus(server: McpServer) {
+  const ok = server.oauthStatus === "connected" || server.transport === "stdio";
+  return {
+    ok,
+    label: ok ? "Connected" : "Disconnected",
+    className: ok ? "text-[#3DDC84]" : "text-[#F05252]",
+  };
+}
 
 function itemKey(item: Pick<ConnectionCatalogItem, "connectorId" | "slug">) {
   return `${item.connectorId}:${item.slug}`;
@@ -30,7 +40,8 @@ export function PluginsOverlay({
   onOpenMcp?: () => void;
 }) {
   const [query, setQuery] = useState("");
-  const [view, setView] = useState<CatalogView>("all");
+  const [view, setView] = useState<CatalogView>("sources");
+  const [infoOpen, setInfoOpen] = useState<"treg" | "api" | null>(null);
   const [catalog, setCatalog] = useState<ConnectionCatalogItem[]>([]);
   const [sources, setSources] = useState<CapabilityInstall[]>([]);
   const [sourceKind, setSourceKind] = useState<SourceKind | null>(null);
@@ -42,15 +53,19 @@ export function PluginsOverlay({
   const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
+  const [oauthPending, setOauthPending] = useState<string | null>(null);
   const connectionAttempt = useRef<AbortController | null>(null);
 
   async function refresh() {
-    const [items, installs] = await Promise.all([
-      rpc.connections.catalog({}),
-      rpc.capabilities.list(),
+    const [items, installs, servers] = await Promise.all([
+      rpc.connections.catalog({}).catch(() => [] as ConnectionCatalogItem[]),
+      rpc.capabilities.list().catch(() => [] as CapabilityInstall[]),
+      rpc.mcp.servers.list(),
     ]);
     setCatalog(items);
     setSources(installs.filter((install) => install.kind === "mcp" || install.kind === "api"));
+    setMcpServers(servers);
     return items;
   }
 
@@ -209,43 +224,88 @@ export function PluginsOverlay({
           <div>
             <div className="text-2xl font-medium text-[#F1F1F2]">Integrations</div>
             <p className="mt-1 text-[13.5px] text-[#7A7A80]">
-              Connect apps or add Treg, MCP, and OpenAPI tool sources.
+              Tool servers for your agents. App catalog is optional.
             </p>
           </div>
-          <div className="flex items-center gap-3">
-            {onOpenMcp ? (
-              <button
-                type="button"
-                onClick={onOpenMcp}
-                className="rounded-full border border-[#383844] px-3 py-1.5 text-xs text-[#C9C9CE] hover:bg-[#232327]"
-              >
-                MCP servers
-              </button>
-            ) : null}
-            <button
-              type="button"
-              aria-label="Close integrations"
-              onClick={onClose}
-              className="text-[#85858A]"
-            >
-              ✕
-            </button>
-          </div>
+          <button
+            type="button"
+            aria-label="Close integrations"
+            onClick={onClose}
+            className="text-[#85858A]"
+          >
+            ✕
+          </button>
         </div>
 
-        <div className="flex flex-wrap gap-2 px-8 pt-4">
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("treg")}>
-            Add Treg
-          </Button>
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("mcp")}>
+        <div className="flex flex-wrap items-center gap-2 px-8 pt-4">
+          <Button
+            type="button"
+            variant="pill"
+            size="sm"
+            onClick={() => (onOpenMcp ? onOpenMcp() : beginSource("mcp"))}
+          >
             Add MCP server
           </Button>
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("api")}>
-            Add OpenAPI
-          </Button>
+          <span className="relative inline-flex items-center gap-1">
+            <Button type="button" variant="pill" size="sm" onClick={() => beginSource("api")}>
+              Add OpenAPI
+            </Button>
+            <button
+              type="button"
+              aria-label="What is OpenAPI?"
+              aria-expanded={infoOpen === "api"}
+              onClick={() => setInfoOpen((open) => (open === "api" ? null : "api"))}
+              className="grid h-7 w-7 place-items-center rounded-full border border-[#383844] text-[11px] font-medium text-[#C9C9CE] hover:bg-[#232327]"
+            >
+              i
+            </button>
+            {infoOpen === "api" ? (
+              <div
+                role="dialog"
+                aria-label="About OpenAPI"
+                className="absolute left-0 top-9 z-10 w-[320px] rounded-2xl border border-[#2C2C30] bg-[#1A1A1D] p-3.5 text-[13px] leading-5 text-[#C9C9CE] shadow-[0_18px_40px_rgba(0,0,0,.45)]"
+              >
+                OpenAPI is a spec file that describes a REST API. Rakazo reads that JSON and turns
+                the endpoints into tools for your agents. Use this when a service has an OpenAPI
+                URL but no MCP server. Not related to OpenAI.
+              </div>
+            ) : null}
+          </span>
+          <span className="relative inline-flex items-center gap-1">
+            <Button type="button" variant="pill" size="sm" onClick={() => beginSource("treg")}>
+              Add Treg
+            </Button>
+            <button
+              type="button"
+              aria-label="What is Treg?"
+              aria-expanded={infoOpen === "treg"}
+              onClick={() => setInfoOpen((open) => (open === "treg" ? null : "treg"))}
+              className="grid h-7 w-7 place-items-center rounded-full border border-[#383844] text-[11px] font-medium text-[#C9C9CE] hover:bg-[#232327]"
+            >
+              i
+            </button>
+            {infoOpen === "treg" ? (
+              <div
+                role="dialog"
+                aria-label="About Treg"
+                className="absolute left-0 top-9 z-10 w-[320px] rounded-2xl border border-[#2C2C30] bg-[#1A1A1D] p-3.5 text-[13px] leading-5 text-[#C9C9CE] shadow-[0_18px_40px_rgba(0,0,0,.45)]"
+              >
+                Treg is a paid catalog of extra agent tools (SEO, ads, outreach) behind one API
+                key. You do not need it for MCP servers you already added.
+                <a
+                  href="https://treg.to"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-2 block text-[#AEB7FF] hover:underline"
+                >
+                  treg.to
+                </a>
+              </div>
+            ) : null}
+          </span>
         </div>
 
-        {view !== "sources" ? (
+        {catalog.length > 0 && view !== "sources" ? (
           <div className="px-8 pt-4">
             <input
               value={query}
@@ -256,28 +316,30 @@ export function PluginsOverlay({
           </div>
         ) : null}
 
-        <div role="tablist" aria-label="Integration views" className="flex gap-1 px-8 pt-4">
-          {(["all", "connected", "sources"] as const).map((option) => (
-            <button
-              key={option}
-              type="button"
-              role="tab"
-              aria-selected={view === option}
-              aria-controls="integration-list"
-              onClick={() => {
-                setView(option);
-                if (option !== "sources") setSourceKind(null);
-              }}
-              className={`rounded-full px-3.5 py-1.5 text-sm transition-colors ${
-                view === option
-                  ? "bg-[#2C2C30] text-[#F1F1F2]"
-                  : "text-[#7A7A80] hover:text-[#C8C8CC]"
-              }`}
-            >
-              {option === "all" ? "Apps" : option === "connected" ? "Connected" : "Tool sources"}
-            </button>
-          ))}
-        </div>
+        {catalog.length > 0 ? (
+          <div role="tablist" aria-label="Integration views" className="flex gap-1 px-8 pt-4">
+            {(["sources", "all", "connected"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                role="tab"
+                aria-selected={view === option}
+                aria-controls="integration-list"
+                onClick={() => {
+                  setView(option);
+                  if (option !== "sources") setSourceKind(null);
+                }}
+                className={`rounded-full px-3.5 py-1.5 text-sm transition-colors ${
+                  view === option
+                    ? "bg-[#2C2C30] text-[#F1F1F2]"
+                    : "text-[#7A7A80] hover:text-[#C8C8CC]"
+                }`}
+              >
+                {option === "sources" ? "Tool servers" : option === "all" ? "Apps" : "Connected apps"}
+              </button>
+            ))}
+          </div>
+        ) : null}
 
         <div
           id="integration-list"
@@ -287,8 +349,57 @@ export function PluginsOverlay({
           {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
           {loading ? <p className="text-[#6C6C70]">Loading integrations…</p> : null}
 
-          {view === "sources" ? (
+          {view === "sources" || catalog.length === 0 ? (
             <div className="space-y-4">
+              {mcpServers.map((server) => (
+                <div key={server.id} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">
+                  <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold uppercase text-[#ECECEE]">
+                    {server.name[0]}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[15.5px] font-medium text-[#ECECEE]">{server.name}</span>
+                      <span className="rounded-full bg-[#202536] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[#AEB7FF]">
+                        MCP
+                      </span>
+                    </div>
+                    <div className="truncate text-[13.5px] text-[#7A7A80]">
+                      <span className={mcpConnectionStatus(server).className}>
+                        {mcpConnectionStatus(server).label}
+                      </span>
+                      {" · "}
+                      {server.endpoint ?? server.command ?? server.slug}
+                    </div>
+                  </div>
+                  {server.transport !== "stdio" && server.oauthStatus !== "connected" ? (
+                    <Button
+                      type="button"
+                      variant="pill"
+                      size="sm"
+                      disabled={oauthPending === server.id}
+                      onClick={() => {
+                        setOauthPending(server.id);
+                        void connectMcpOauth(server.id)
+                          .then((result) => {
+                            if (result === "connected" || result === "already_connected") {
+                              void refresh();
+                            }
+                          })
+                          .catch((err: unknown) =>
+                            setError(err instanceof Error ? err.message : "OAuth failed"),
+                          )
+                          .finally(() => setOauthPending(null));
+                      }}
+                    >
+                      {oauthPending === server.id ? "Connecting…" : "Connect"}
+                    </Button>
+                  ) : onOpenMcp ? (
+                    <Button type="button" variant="pill" size="sm" onClick={onOpenMcp}>
+                      Manage
+                    </Button>
+                  ) : null}
+                </div>
+              ))}
               {sourceKind ? (
                 <div className="space-y-3 rounded-[16px] border border-[#2C2C30] bg-[#101012] p-5">
                   <div className="text-base font-medium text-[#ECECEE]">
@@ -371,19 +482,20 @@ export function PluginsOverlay({
                 </div>
               ) : null}
 
-              {sources.length === 0 && !sourceKind ? (
-                <p className="text-[#6C6C70]">No MCP or API tool sources installed yet.</p>
-              ) : null}
               {sources.map((source) => (
                 <div key={source.id} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">
                   <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold uppercase text-[#ECECEE]">
                     {source.kind === "mcp" ? "M" : "A"}
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="text-[15.5px] font-medium text-[#ECECEE]">{source.name}</div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-[15.5px] font-medium text-[#ECECEE]">{source.name}</span>
+                      <span className="rounded-full bg-[#202536] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[#AEB7FF]">
+                        {source.kind === "mcp" ? "MCP" : "API"}
+                      </span>
+                    </div>
                     <div className="truncate text-[13.5px] text-[#7A7A80]">
-                      {source.kind.toUpperCase()} · {source.source} ·{" "}
-                      {source.secretConfigured ? "credential saved" : "no auth"}
+                      {source.source} · {source.secretConfigured ? "credential saved" : "no auth"}
                     </div>
                   </div>
                   <Button
@@ -402,8 +514,8 @@ export function PluginsOverlay({
             <>
               {!loading && catalog.length === 0 ? (
                 <p className="text-[#6C6C70]">
-                  No managed app catalog is configured on this deployment. You can still add Treg,
-                  MCP, or OpenAPI sources.
+                  No managed app catalog is configured on this deployment. Added MCP servers appear
+                  under Tool sources.
                 </p>
               ) : null}
               {!loading && catalog.length > 0 && visible.length === 0 ? (

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -6,7 +6,9 @@ import type {
   ComputerReleaseReason,
   ComputerStatus,
   Group,
+  McpServer,
   Me,
+  ModelCatalogEntry,
   MessageBlock,
   ProductEvent,
   Routine,
@@ -50,7 +52,9 @@ import {
   Gauge,
   LogOut,
   Menu,
+  Maximize2,
   Mic,
+  Minimize2,
   Monitor,
   Paperclip,
   Phone,
@@ -1236,18 +1240,25 @@ export function ShellPage() {
 
   async function openComputer() {
     if (!active) return;
-    const needsTakeover = !userHoldsComputerControl(computer, active.id);
-    await bootComputer({
-      takeControl: needsTakeover,
-      overlay: needsTakeover || computer?.state !== "running",
+    setComputerOpen(true);
+    void bootComputer({
+      takeControl: false,
+      overlay: false,
       force: computer?.state !== "running",
     });
-    setComputerOpen(true);
+  }
+
+  function closeComputerOverlay() {
+    setComputerOpen(false);
+  }
+
+  function toggleComputerWindow() {
+    if (computerOpen) closeComputerOverlay();
+    else void openComputer();
   }
 
   async function releaseComputer(reason?: ComputerReleaseReason) {
     if (!active) return;
-    setComputerOpen(false);
     await rpc.computer.release({ botId: active.id, reason }).catch(() => undefined);
     await refreshThread(active.id);
   }
@@ -1752,10 +1763,16 @@ export function ShellPage() {
             ) : null}
             {panel === "computer" && active ? (
               <div>
-                <div className="relative aspect-[16/10] overflow-hidden rounded-[14px] bg-[#0E0E10]">
+                <div
+                  className="relative aspect-[16/10] overflow-hidden rounded-[14px] bg-[#0E0E10]"
+                  onDoubleClick={(event) => {
+                    event.preventDefault();
+                    toggleComputerWindow();
+                  }}
+                >
                   {computerOpen ? (
                     <div className="grid h-full place-items-center text-sm text-[#6C6C70]">
-                      Open in full window
+                      Maximized
                     </div>
                   ) : computer?.kind === "desktop" ? (
                     <div className="grid h-full place-items-center px-6 text-center text-sm text-[#6C6C70]">
@@ -1782,10 +1799,22 @@ export function ShellPage() {
                   )}
                   <button
                     type="button"
-                    className="absolute inset-0 cursor-pointer"
-                    aria-label="Open computer"
-                    onClick={() => void openComputer()}
-                  />
+                    className="absolute right-2.5 top-2.5 z-20 grid h-8 w-8 place-items-center rounded-lg border border-[#34343B] bg-[#1A1A1D]/90 text-[#ECECEE] pointer-events-auto"
+                    aria-label={computerOpen ? "Restore" : "Maximize"}
+                    title={computerOpen ? "Restore" : "Maximize"}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      toggleComputerWindow();
+                    }}
+                    onDoubleClick={(event) => event.stopPropagation()}
+                  >
+                    {computerOpen ? (
+                      <Minimize2 size={14} strokeWidth={1.8} />
+                    ) : (
+                      <Maximize2 size={14} strokeWidth={1.8} />
+                    )}
+                  </button>
                 </div>
                 <div className="mt-3 flex items-center justify-between">
                   <span className="text-[13.5px] text-[#85858A]">
@@ -1807,7 +1836,13 @@ export function ShellPage() {
                       type="button"
                       variant="outline"
                       size="sm"
-                      onClick={() => void openComputer()}
+                      onClick={() =>
+                        void bootComputer({
+                          takeControl: true,
+                          overlay: false,
+                          force: computer?.state !== "running",
+                        })
+                      }
                     >
                       Take control
                     </Button>
@@ -1912,6 +1947,7 @@ export function ShellPage() {
                 key={active.id}
                 bot={active}
                 memoryProviderConfigured={memoryProviderConfig != null}
+                onOpenMcp={() => setPluginsOpen(true)}
                 onSave={async ({ computerMode, ...patch }) => {
                   if (computerMode !== active.computerMode) {
                     await rpc.bots.setComputer({
@@ -2246,8 +2282,20 @@ export function ShellPage() {
           </div>
         </div>
       ) : computerOpen && active ? (
-        <div className="absolute inset-0 z-30 flex flex-col bg-[#050506]">
-          <div className="flex items-center justify-between gap-4 border-b border-[#171719] px-[18px] py-3.5">
+        <div
+          className="fixed inset-0 z-50 flex flex-col bg-[#050506]"
+          onDoubleClick={(event) => {
+            if (event.target !== event.currentTarget) return;
+            closeComputerOverlay();
+          }}
+        >
+          <div
+            className="flex items-center justify-between gap-4 border-b border-[#171719] px-[18px] py-3.5"
+            onDoubleClick={(event) => {
+              event.stopPropagation();
+              closeComputerOverlay();
+            }}
+          >
             <div className="flex min-w-0 flex-1 items-center gap-3">
               <BotAvatar color={active.color} size={28} />
               {recordingSkill ? (
@@ -2288,15 +2336,30 @@ export function ShellPage() {
               )}
               <button
                 type="button"
+                className="grid h-[30px] w-[34px] place-items-center rounded-[9px] text-[#85858A] hover:bg-[#1B1B1E] hover:text-[#ECECEE]"
+                aria-label="Restore"
+                title="Restore"
+                onClick={closeComputerOverlay}
+              >
+                <Minimize2 size={16} strokeWidth={1.7} />
+              </button>
+              <button
+                type="button"
                 className="text-[16px] text-[#85858A] hover:text-[#ECECEE]"
                 aria-label="Close computer"
-                onClick={() => setComputerOpen(false)}
+                onClick={closeComputerOverlay}
               >
                 <X size={16} strokeWidth={1.8} />
               </button>
             </div>
           </div>
-          <div className="relative min-h-0 flex-1 bg-[#0E0E10]">
+          <div
+            className="relative min-h-0 flex-1 bg-[#0E0E10]"
+            onDoubleClick={(event) => {
+              event.stopPropagation();
+              closeComputerOverlay();
+            }}
+          >
             {computer?.kind === "desktop" ? (
               <div className="grid h-full place-items-center px-8 text-center text-sm text-[#6C6C70]">
                 This bot runs on this computer. There is no separate Linux desktop. Ask it to use
@@ -3279,6 +3342,7 @@ function BotSettings({
   onSave,
   onExport,
   onClear,
+  onOpenMcp,
 }: {
   bot: Bot;
   memoryProviderConfigured: boolean;
@@ -3291,9 +3355,12 @@ function BotSettings({
     memoryScope?: "isolated" | "shared" | null;
     autoSpeak?: boolean;
     voiceId?: string | null;
+    modelProvider?: string | null;
+    modelId?: string | null;
   }) => Promise<void>;
   onExport: () => Promise<void>;
   onClear: () => void;
+  onOpenMcp: () => void;
 }) {
   const [name, setName] = useState(bot.name);
   const [title, setTitle] = useState(bot.title);
@@ -3303,20 +3370,104 @@ function BotSettings({
   const [autoSpeak, setAutoSpeak] = useState(bot.autoSpeak);
   const [voiceId, setVoiceId] = useState(bot.voiceId ?? "");
   const [voices, setVoices] = useState<VoiceInfo[]>([]);
+  const [modelId, setModelId] = useState(bot.modelId ?? "");
+  const [modelCatalog, setModelCatalog] = useState<ModelCatalogEntry[]>([]);
+  const [workspaceDefaultModel, setWorkspaceDefaultModel] = useState<string>("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [assignedMcp, setAssignedMcp] = useState<McpServer[]>([]);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+  const [oauthPending, setOauthPending] = useState<string | null>(null);
+
+  async function refreshAssignedMcp() {
+    const [servers, assignments] = await Promise.all([
+      rpc.mcp.servers.list(),
+      rpc.mcp.assignments.list({ botId: bot.id }),
+    ]);
+    const assignedIds = new Set(assignments.map((row) => row.serverId));
+    setAssignedMcp(servers.filter((server) => assignedIds.has(server.id)));
+  }
 
   useEffect(() => {
     void rpc.voice
       .voices({})
       .then(setVoices)
       .catch(() => setVoices([]));
+    void Promise.all([rpc.models.list(), rpc.me()])
+      .then(([catalog, me]) => {
+        const openrouter = catalog.filter((entry) => entry.provider === "openrouter");
+        openrouter.sort((a, b) => {
+          const rank = (id: string) => (id.startsWith("deepseek/") ? 0 : 1);
+          return rank(a.id) - rank(b.id) || a.label.localeCompare(b.label);
+        });
+        setModelCatalog(openrouter);
+        setWorkspaceDefaultModel(me.defaultModel ?? "");
+      })
+      .catch(() => undefined);
   }, []);
+
+  useEffect(() => {
+    void refreshAssignedMcp().catch((err: unknown) =>
+      setMcpError(err instanceof Error ? err.message : "Could not load MCP"),
+    );
+  }, [bot.id]);
 
   return (
     <div data-testid="bot-settings">
       <div className="flex justify-center">
         <BotAvatar color={bot.color} size={64} />
+      </div>
+      <div className="mt-5 rounded-[11px] border border-[#26262A] p-3.5">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[14px] text-[#85858A]">Integrations</span>
+          <button type="button" onClick={onOpenMcp} className="text-[12.5px] text-[#C9C9CE]">
+            Manage
+          </button>
+        </div>
+        {mcpError ? <p className="mt-2 text-[12.5px] text-[#E65707]">{mcpError}</p> : null}
+        {assignedMcp.length === 0 ? (
+          <p className="mt-2 text-[13px] text-[#6C6C70]">None assigned to this bot.</p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {assignedMcp.map((server) => (
+              <li key={server.id} className="flex items-center justify-between gap-2">
+                <span>
+                  <span className="block text-[13.5px] text-[#ECECEE]">{server.name}</span>
+                  <span
+                    className={`block text-[11px] ${
+                      server.oauthStatus === "connected" || server.transport === "stdio"
+                        ? "text-[#3DDC84]"
+                        : "text-[#F05252]"
+                    }`}
+                  >
+                    {server.oauthStatus === "connected" || server.transport === "stdio"
+                      ? "Connected"
+                      : "Disconnected"}
+                  </span>
+                </span>
+                {server.oauthStatus !== "connected" ? (
+                  <button
+                    type="button"
+                    disabled={oauthPending === server.id}
+                    onClick={() => {
+                      setMcpError(null);
+                      setOauthPending(server.id);
+                      void connectMcpOauth(server.id)
+                        .then(() => refreshAssignedMcp())
+                        .catch((err: unknown) =>
+                          setMcpError(err instanceof Error ? err.message : "OAuth failed"),
+                        )
+                        .finally(() => setOauthPending(null));
+                    }}
+                    className="rounded-lg bg-[#7785FF] px-2.5 py-1.5 text-[11px] font-semibold text-[#090A12] disabled:opacity-50"
+                  >
+                    {oauthPending === server.id ? "Connecting…" : "Connect"}
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
       <label className="mt-6 block text-[14px] text-[#85858A]">
         Name
@@ -3347,6 +3498,26 @@ function BotSettings({
         />
       </label>
       <ComputerModePicker value={computerMode} onChange={setComputerMode} />
+      <label className="mt-4 block text-[14px] text-[#85858A]">
+        Model
+        <select
+          value={modelId}
+          onChange={(event) => setModelId(event.target.value)}
+          className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
+        >
+          <option value="">
+            Workspace default{workspaceDefaultModel ? ` (${workspaceDefaultModel})` : ""}
+          </option>
+          {modelId && !modelCatalog.some((entry) => entry.id === modelId) ? (
+            <option value={modelId}>{modelId}</option>
+          ) : null}
+          {modelCatalog.map((entry) => (
+            <option key={`${entry.provider}:${entry.id}`} value={entry.id}>
+              {entry.label}
+            </option>
+          ))}
+        </select>
+      </label>
       {memoryProviderConfigured ? (
         <div className="mt-4 text-[14px] text-[#85858A]">
           Memory scope
@@ -3417,6 +3588,8 @@ function BotSettings({
               memoryScope,
               autoSpeak,
               voiceId: voiceId || null,
+              modelProvider: modelId ? "openrouter" : null,
+              modelId: modelId || null,
             })
               .catch((err) => setError(err instanceof Error ? err.message : "Could not save"))
               .finally(() => setSaving(false));

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,8 +14,6 @@ import {
   stripSensitiveHandshakeHeaders,
 } from "./src/screen-proxy.js";
 
-const webPort = Number(process.env.WEB_PORT ?? 5173);
-
 function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string) {
   server.middlewares.use((req, res, next) => {
     if (!req.url?.startsWith("/novnc/")) {
@@ -115,6 +113,7 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string)
 
 export default defineConfig(({ mode }) => {
   const rootEnv = loadEnv(mode, path.resolve(import.meta.dirname, "../.."), "");
+  const webPort = Number(rootEnv.WEB_PORT || process.env.WEB_PORT || 5173);
   const api = process.env.API_PROXY_TARGET ?? rootEnv.API_PROXY_TARGET ?? "http://127.0.0.1:3100";
   const previewHost = process.env.RAKAZO_HOST ?? rootEnv.RAKAZO_HOST ?? "localhost";
   const screenProxySecret = resolveAuthSecret({
@@ -147,9 +146,17 @@ export default defineConfig(({ mode }) => {
       },
     ],
     server: {
-      host: "127.0.0.1",
+      host: rootEnv.RAKAZO_BIND || process.env.RAKAZO_BIND || "127.0.0.1",
       port: webPort,
       strictPort: true,
+      allowedHosts: true,
+      hmr: (rootEnv.RAKAZO_PUBLIC_HOST || process.env.RAKAZO_PUBLIC_HOST)
+        ? {
+            protocol: "wss",
+            host: rootEnv.RAKAZO_PUBLIC_HOST || process.env.RAKAZO_PUBLIC_HOST,
+            clientPort: Number(rootEnv.RAKAZO_PUBLIC_PORT || process.env.RAKAZO_PUBLIC_PORT || 5173),
+          }
+        : undefined,
       proxy: {
         "/api": { target: api, changeOrigin: true },
         "/rpc": { target: api, changeOrigin: true },
@@ -157,7 +164,7 @@ export default defineConfig(({ mode }) => {
     },
     preview: {
       host: "0.0.0.0",
-      port: Number(process.env.WEB_PORT ?? 5173),
+      port: webPort,
       allowedHosts: [previewHost],
       proxy: {
         "/api": { target: api, changeOrigin: true },

--- a/infra/sandboxes/computer/Dockerfile
+++ b/infra/sandboxes/computer/Dockerfile
@@ -18,6 +18,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     fonts-dejavu-core \
     dbus-x11 \
+    curl \
+    iptables \
+    iproute2 \
+  && curl -fsSL https://tailscale.com/install.sh | sh \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /etc/rakazo/fluxbox \
   && printf '%s\n' '#!/bin/sh' 'exec xsetroot -solid "#111113" "$@"' > /usr/bin/fbsetbg \

--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -77,6 +77,37 @@ if [[ ! -f "$NOVNC_ROOT/embed.html" ]]; then
 fi
 websockify --web="$NOVNC_ROOT" 0.0.0.0:6080 127.0.0.1:5900 >/tmp/rakazo/novnc.log 2>&1 &
 
+# Join the tailnet so bots can reach grok-bot / Studio / VMs.
+TAILSCALE_DIR="$AGENT_HOME/tailscale"
+mkdir -p "$TAILSCALE_DIR/state"
+chmod 700 "$TAILSCALE_DIR" "$TAILSCALE_DIR/state" 2>/dev/null || true
+if command -v tailscaled >/dev/null 2>&1; then
+  if ! pgrep -x tailscaled >/dev/null 2>&1; then
+    TS_TUN=tailscale0
+    if [[ ! -e /dev/net/tun ]]; then
+      TS_TUN=userspace-networking
+    fi
+    tailscaled --statedir="$TAILSCALE_DIR/state" --tun="$TS_TUN" >/tmp/rakazo/tailscaled.log 2>&1 &
+    sleep 1
+  fi
+  if [[ -s "$TAILSCALE_DIR/auth.key" ]] && command -v tailscale >/dev/null 2>&1; then
+    AUTH=$(tr -d ' \n' < "$TAILSCALE_DIR/auth.key")
+    case "$AUTH" in
+      *ephemeral=*) ;;
+      *) AUTH="${AUTH}?ephemeral=false&preauthorized=true" ;;
+    esac
+    HOSTN="${TAILSCALE_HOSTNAME:-rakazo}"
+    UP_ARGS=(--auth-key="$AUTH" --hostname="$HOSTN" --accept-dns=false)
+    if [[ -s "$TAILSCALE_DIR/advertise-tags" ]]; then
+      TAGS=$(tr -d ' \n' < "$TAILSCALE_DIR/advertise-tags")
+      if [[ -n "$TAGS" ]]; then
+        UP_ARGS+=(--advertise-tags="$TAGS")
+      fi
+    fi
+    tailscale up "${UP_ARGS[@]}" >/tmp/rakazo/tailscale-up.log 2>&1 || true
+  fi
+fi
+
 while kill -0 "$XVFB_PID" 2>/dev/null; do
   sleep 2
 done

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -79,6 +79,10 @@ export function containerCreateOptions(input: ComputerCreateInput) {
       ReadonlyPaths: ["/usr/share/novnc"],
       AutoRemove: false,
       NetworkMode: input.networkMode ?? "bridge",
+      CapAdd: ["NET_ADMIN", "NET_RAW"],
+      Devices: [
+        { PathOnHost: "/dev/net/tun", PathInContainer: "/dev/net/tun", CgroupPermissions: "rwm" },
+      ],
     },
     WorkingDir: "/home/rakazo",
   };

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1472,8 +1472,16 @@ export function createRunExecutor(deps: ExecutorDeps) {
               currentTurnImages,
               tools,
               model: {
-                provider: credential?.provider ?? settings?.defaultModelProvider ?? "scripted",
-                id: credential?.defaultModel ?? settings?.defaultModelId ?? "scripted",
+                provider:
+                  bot.modelProvider ??
+                  credential?.provider ??
+                  settings?.defaultModelProvider ??
+                  "scripted",
+                id:
+                  bot.modelId ??
+                  credential?.defaultModel ??
+                  settings?.defaultModelId ??
+                  "scripted",
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }

--- a/packages/adapters/src/mcp-connector.ts
+++ b/packages/adapters/src/mcp-connector.ts
@@ -52,8 +52,15 @@ export class McpConnector implements ConnectorProvider {
     const groups = await Promise.all(
       assignments.map(async (assignment): Promise<ConnectorTool[]> => {
         try {
-          const session = await this.sessionFor(assignment.server, context);
-          const listed = await session.listTools({ signal: context.signal });
+          const discoverSignal = AbortSignal.any([
+            context.signal,
+            AbortSignal.timeout(8_000),
+          ]);
+          const session = await this.sessionFor(assignment.server, {
+            ...context,
+            signal: discoverSignal,
+          });
+          const listed = await session.listTools({ signal: discoverSignal });
           return listed.tools
             .filter(
               (tool) =>

--- a/packages/adapters/src/mcp-oauth.ts
+++ b/packages/adapters/src/mcp-oauth.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
-import type {
-  OAuthClientProvider,
-  OAuthDiscoveryState,
+import {
+  auth,
+  type OAuthClientProvider,
+  type OAuthDiscoveryState,
 } from "@modelcontextprotocol/sdk/client/auth.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type {
   OAuthClientInformationMixed,
@@ -194,7 +194,18 @@ function oauthFetch(
   network: RemoteTransportDependencies,
 ): { fetch: typeof fetch; close: () => Promise<void> } {
   const url = new URL(endpoint);
-  const safeFetch = secureFetch(url, {}, {}, network);
+  const safeFetch = secureFetch(
+    url,
+    {},
+    {
+      headers: {
+        // Some CDNs 1010 default Node/Python signatures on DCR.
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      },
+    },
+    network,
+  );
   return {
     fetch: withEndpointOriginFallback(url.origin, safeFetch),
     close: () => safeFetch.close(),
@@ -283,20 +294,18 @@ export class McpOAuthBroker {
     // Never destroy working tokens here: if this attempt fails (network error,
     // cancelled popup), the server keeps its valid connection. The SDK itself
     // invalidates dead tokens when a refresh is rejected with invalid_grant.
-    const endpoint = new URL(server.endpoint);
     const networkFetch = oauthFetch(server.endpoint, this.network);
-    const transport = new StreamableHTTPClientTransport(endpoint, {
-      authProvider: provider,
-      fetch: networkFetch.fetch,
-    });
-    const client = new Client({ name: "rakazo-oauth", version: "0.1.0" });
-    const signal = AbortSignal.timeout(15_000);
     try {
-      await client.connect(transport, { signal, timeout: 15_000 });
+      // Don't use StreamableHTTP Client.connect here: some providers' GET stream
+      // hangs, so OAuth never reaches DCR. auth() does discovery +
+      // registration + authorize URL only.
+      await auth(provider, {
+        serverUrl: server.endpoint,
+        fetchFn: networkFetch.fetch,
+      });
     } catch (error) {
       if (!authorizationUrl) throw error;
     } finally {
-      await client.close().catch(() => undefined);
       await networkFetch.close().catch(() => undefined);
     }
     if (!authorizationUrl) {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -87,6 +87,10 @@ export class PiAgentRuntime implements AgentRuntime {
           queue.push({ type: "done" });
           return;
         }
+        if (/\bvision\b/i.test(model.id) && !model.input.includes("image")) {
+          model = { ...model, input: ["text", "image"] };
+        }
+        model = withOpenRouterProviderRouting(model);
 
         const apiKey = request.model.oauth
           ? undefined
@@ -227,11 +231,35 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
+
+function withOpenRouterProviderRouting<T extends { provider: string; compat?: Record<string, unknown> }>(
+  model: T,
+): T {
+  if (model.provider !== "openrouter") return model;
+  const vision = /\bvision\b/i.test(model.id);
+  const slug = (
+    vision ? process.env.OPENROUTER_VISION_PROVIDER : process.env.OPENROUTER_PROVIDER
+  )?.trim();
+  if (!slug) return model;
+  return {
+    ...model,
+    compat: {
+      ...(model.compat ?? {}),
+      openRouterRouting: {
+        only: [slug],
+        order: [slug],
+        allow_fallbacks: false,
+      },
+    },
+  };
+}
+
 function configuredOpenRouterModel(id: string): Model<"openai-completions"> {
   // A configured model can intentionally be newer than Pi's static catalog. Keep
   // pricing conservative, but enable reasoning: unknown OpenRouter endpoints
   // (e.g. gemini-3.7-flash before the snapshot catches up) often mandate it, and
   // thinkingLevel "off" becomes effort "none" which those endpoints reject.
+  const vision = /\bvision\b/i.test(id);
   return {
     id,
     name: id,
@@ -239,10 +267,10 @@ function configuredOpenRouterModel(id: string): Model<"openai-completions"> {
     provider: "openrouter",
     baseUrl: "https://openrouter.ai/api/v1",
     reasoning: true,
-    input: ["text"],
+    input: vision ? ["text", "image"] : ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 16_384,
-    maxTokens: 4_096,
+    contextWindow: vision ? 1_048_576 : 16_384,
+    maxTokens: vision ? 384_000 : 4_096,
   };
 }
 

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -32,6 +32,8 @@ export const BotSchema = z.object({
   createdAt: z.string(),
   voiceId: z.string().nullable(),
   autoSpeak: z.boolean(),
+  modelProvider: z.string().nullable(),
+  modelId: z.string().nullable(),
 });
 export type Bot = z.infer<typeof BotSchema>;
 
@@ -132,6 +134,8 @@ export const UpdateBotInput = z.object({
   sectionId: Id.nullable().optional(),
   voiceId: z.string().max(120).nullable().optional(),
   autoSpeak: z.boolean().optional(),
+  modelProvider: z.string().trim().min(1).max(80).nullable().optional(),
+  modelId: z.string().trim().min(1).max(200).nullable().optional(),
 });
 
 export const RoutineSchema = z.object({

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -239,6 +239,8 @@ model Bot {
   computerSwitching Boolean @default(false)
   voiceId        String?
   autoSpeak      Boolean  @default(false)
+  modelProvider  String?
+  modelId        String?
   routines       Routine[]
   taughtSkills   TaughtSkill[]
   memoryDocuments MemoryDocument[]

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -31,6 +31,8 @@ function mapBot(
     computer: { scope: string } | null;
     voiceId?: string | null;
     autoSpeak?: boolean;
+    modelProvider?: string | null;
+    modelId?: string | null;
   },
   preview = "",
   status = "idle",
@@ -61,6 +63,8 @@ function mapBot(
     updatedAt: bot.updatedAt.toISOString(),
     voiceId: bot.voiceId ?? null,
     autoSpeak: bot.autoSpeak ?? false,
+    modelProvider: bot.modelProvider ?? null,
+    modelId: bot.modelId ?? null,
   };
 }
 
@@ -187,6 +191,8 @@ export function createRepos(prisma: PrismaClient) {
         parentBotId?: string | null;
         computerMode?: ComputerMode;
         spawnKey?: string;
+        modelProvider?: string | null;
+        modelId?: string | null;
         initialMessage?: {
           role: "user" | "bot" | "system";
           blocks: MessageBlock[];
@@ -201,6 +207,8 @@ export function createRepos(prisma: PrismaClient) {
         });
         color = BOT_COLORS[count % BOT_COLORS.length] ?? BOT_COLORS[0];
       }
+      let modelProvider = input.modelProvider ?? null;
+      let modelId = input.modelId ?? null;
       if (input.parentBotId) {
         const parent = await prisma.bot.findFirst({
           where: {
@@ -210,6 +218,10 @@ export function createRepos(prisma: PrismaClient) {
           },
         });
         if (!parent) throw new IsolationError();
+        if (!modelId) {
+          modelProvider = parent.modelProvider ?? null;
+          modelId = parent.modelId ?? null;
+        }
       }
       const settings = await prisma.deploymentSettings.findUnique({ where: { id: "default" } });
       const envKind = process.env.SANDBOX_PROVIDER ?? "docker";
@@ -235,6 +247,8 @@ export function createRepos(prisma: PrismaClient) {
             parentBotId: input.parentBotId ?? null,
             computerId: teamComputer.id,
             spawnKey: input.spawnKey,
+            modelProvider,
+            modelId,
           },
         });
         const thread = await tx.thread.create({

--- a/scripts/mcp-oauth-callback.py
+++ b/scripts/mcp-oauth-callback.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Localhost MCP OAuth catcher for providers that only allow loopback HTTP redirects."""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+PORT = int(__import__("os").environ.get("MCP_OAUTH_CALLBACK_PORT", "8765"))
+CANDIDATES = [
+    origin.strip()
+    for origin in __import__("os").environ.get(
+        "MCP_OAUTH_COMPLETE_ORIGINS",
+        "http://127.0.0.1:5173,http://127.0.0.1:5175",
+    ).split(",")
+    if origin.strip()
+]
+
+
+def rpc_bases() -> list[str]:
+    return list(CANDIDATES)
+
+
+def complete(code: str, state: str) -> tuple[bool, str]:
+    payload = json.dumps({"json": {"sessionId": state, "code": code, "state": state}}).encode()
+    last = "no endpoint"
+    for base in rpc_bases():
+        req = urllib.request.Request(
+            f"{base}/rpc/mcp/oauth/complete",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Origin": f"http://127.0.0.1:{PORT}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = resp.read().decode()
+            return True, body
+        except urllib.error.HTTPError as err:
+            last = err.read().decode()[:800] if err.fp else str(err)
+        except Exception as err:
+            last = str(err)
+    return False, last
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        code = (query.get("code") or [None])[0]
+        state = (query.get("state") or [None])[0]
+        oauth_error = (query.get("error_description") or query.get("error") or [None])[0]
+        if oauth_error:
+            self._html(400, f"Authorization failed: {oauth_error}")
+            return
+        if not code or not state:
+            self._html(400, "Missing OAuth code.")
+            return
+        ok, detail = complete(code, state)
+        if ok:
+            self._html(200, "Connected. You can close this window.")
+            return
+        self._html(500, f"Could not finish OAuth.<pre>{detail}</pre>")
+
+    def log_message(self, fmt: str, *args) -> None:
+        print(f"mcp-oauth-callback: {fmt % args}")
+
+    def _html(self, status: int, body: str) -> None:
+        page = f"""<!doctype html><html><body style="font-family:system-ui;padding:48px;background:#111;color:#eee">
+        <h1 style="font-weight:500">{body}</h1></body></html>"""
+        data = page.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+if __name__ == "__main__":
+    httpd = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    print(f"mcp oauth callback on http://127.0.0.1:{PORT}/mcp/oauth/callback")
+    httpd.serve_forever()


### PR DESCRIPTION
## Summary

Self-host improvements. Product path is unchanged: Pi + Docker + Graphile.

Six commits, one per theme. Happy to split further if that is easier to review.

1. **bots** — optional per-bot model override  
2. **api** — persist that model; MCP OAuth complete uses the OAuth session, not the popup cookie  
3. **web** — Integrations lists installed MCP servers; computer maximize is view-only  
4. **mcp** — OAuth via `auth()` instead of a hanging Streamable GET; 8s discovery timeout  
5. **openrouter** — optional provider routing; vision model ids accept images  
6. **self-host** — Vite env/TLS bind; optional Tailscale in the computer sandbox  

Per-agent MCP assignment is unchanged.

## Schema

```sql
ALTER TABLE "bots" ADD COLUMN IF NOT EXISTS "modelProvider" TEXT;
ALTER TABLE "bots" ADD COLUMN IF NOT EXISTS "modelId" TEXT;
```

## Test plan

- [ ] `pnpm check`
- [ ] Per-bot model override is used on the next run
- [ ] Integrations shows installed MCP servers and status
- [ ] MCP OAuth against a streamable HTTP server
- [ ] Computer maximize does not take control
- [ ] Hung MCP discovery does not block the model reply
- [ ] With OpenRouter provider env unset, routing is unmodified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configure bot-specific model providers and models, including OpenRouter vision support.
  - Manage MCP tool servers directly from Plugins and bot settings.
  - Connect MCP servers through OAuth, including localhost callback support.
  - View clearer MCP connection statuses and access integration actions.
  - Restore, maximize, and control computer sessions more flexibly.
  - Support optional secure network connectivity for computer environments.

- **Improvements**
  - Expanded trusted-origin support for authentication and OAuth.
  - MCP discovery now times out gracefully instead of hanging indefinitely.
  - Configurable web server ports and public hosts are supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->