### PR TITLE
Contain Windows desktop-sandbox writes through final symlinks

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -26,9 +26,10 @@
     "d3-dsv": "^3.0.1",
     "graphile-worker": "^0.17.3",
     "jsdom": "^30.0.1",
+    "koffi": "^2.9.0",
     "pg": "^8.16.3",
-    "undici": "^7.22.0",
     "sharp": "^0.35.3",
+    "undici": "^7.22.0",
     "zod": "^4.1.5"
   },
   "devDependencies": {

--- a/packages/adapters/src/desktop-sandbox-paths.test.ts
+++ b/packages/adapters/src/desktop-sandbox-paths.test.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isAllowedDesktopPath, normalizeDesktopWorkspacePath } from "./desktop-sandbox-paths.js";
+
+describe("desktop sandbox path rules", () => {
+  it("compares Windows roots case-insensitively without accepting siblings or other drives", () => {
+    const roots = ["C:\\Users\\Owner\\Rakazo\\bot"];
+
+    expect(
+      isAllowedDesktopPath("c:\\users\\owner\\rakazo\\BOT\\notes.txt", roots, path.win32),
+    ).toBe(true);
+    expect(
+      isAllowedDesktopPath("C:\\Users\\Owner\\Rakazo\\bot-other\\notes.txt", roots, path.win32),
+    ).toBe(false);
+    expect(isAllowedDesktopPath("D:\\notes.txt", roots, path.win32)).toBe(false);
+  });
+
+  it("handles explicitly allowed UNC roots without accepting sibling shares", () => {
+    const roots = ["\\\\server\\share\\rakazo\\bot"];
+
+    expect(
+      isAllowedDesktopPath("\\\\SERVER\\share\\rakazo\\BOT\\notes.txt", roots, path.win32),
+    ).toBe(true);
+    expect(
+      isAllowedDesktopPath("\\\\server\\share-other\\rakazo\\bot\\notes.txt", roots, path.win32),
+    ).toBe(false);
+  });
+
+  it.each([
+    "C:\\outside.txt",
+    "C:outside.txt",
+    "\\\\server\\share\\outside.txt",
+    "\\\\?\\C:\\outside.txt",
+    "notes.txt:secret",
+    "NUL.txt",
+    "COM1.log",
+    "trailing-dot.",
+    "trailing-space ",
+  ])("rejects ambiguous or special Windows path %s", (requested) => {
+    expect(() => normalizeDesktopWorkspacePath(requested, "win32")).toThrow(/escapes/i);
+  });
+
+  it("keeps ordinary portable paths and the virtual root syntax", () => {
+    expect(normalizeDesktopWorkspacePath("/notes/result.txt", "win32")).toBe("notes/result.txt");
+    expect(normalizeDesktopWorkspacePath("notes/result.txt", "linux")).toBe("notes/result.txt");
+  });
+});

--- a/packages/adapters/src/desktop-sandbox-paths.ts
+++ b/packages/adapters/src/desktop-sandbox-paths.ts
@@ -1,0 +1,50 @@
+import path from "node:path";
+import { normalizeWorkspacePath } from "./computer-support.js";
+
+type PathOperations = Pick<typeof path, "isAbsolute" | "relative" | "resolve" | "sep">;
+
+const WINDOWS_RESERVED_NAME = /^(?:CON|PRN|AUX|NUL|COM[1-9¹²³]|LPT[1-9¹²³])$/iu;
+
+export function normalizeDesktopWorkspacePath(value: string, platform = process.platform) {
+  if (platform === "win32") assertPortableWindowsPath(value);
+  return normalizeWorkspacePath(value);
+}
+
+export function isAllowedDesktopPath(
+  target: string,
+  roots: string[],
+  pathOperations: PathOperations = path,
+) {
+  const resolved = pathOperations.resolve(target);
+  return roots.some((root) => {
+    const relative = pathOperations.relative(pathOperations.resolve(root), resolved);
+    return (
+      relative === "" ||
+      (relative !== ".." &&
+        !relative.startsWith(`..${pathOperations.sep}`) &&
+        !pathOperations.isAbsolute(relative))
+    );
+  });
+}
+
+function assertPortableWindowsPath(value: string) {
+  const portable = value.replace(/\\/g, "/");
+  if (portable.startsWith("//")) throw new Error("Path escapes the computer workspace");
+  const withoutVirtualRoot = portable.replace(/^\/+/, "");
+  for (const segment of withoutVirtualRoot.split("/").filter(Boolean)) {
+    const deviceName = segment.split(".", 1)[0] ?? "";
+    if (
+      hasWindowsReservedCharacter(segment) ||
+      /[ .]$/u.test(segment) ||
+      WINDOWS_RESERVED_NAME.test(deviceName)
+    ) {
+      throw new Error("Path escapes the computer workspace");
+    }
+  }
+}
+
+function hasWindowsReservedCharacter(segment: string) {
+  return [...segment].some(
+    (character) => character.charCodeAt(0) <= 31 || '<>:"|?*'.includes(character),
+  );
+}

--- a/packages/adapters/src/desktop-sandbox-win32-path.ts
+++ b/packages/adapters/src/desktop-sandbox-win32-path.ts
@@ -1,36 +1,277 @@
+import {
+  close as closeCb,
+  fchmod as fchmodCb,
+  fstat as fstatCb,
+  ftruncate as ftruncateCb,
+  writeFile as writeFileCb,
+  closeSync,
+} from "node:fs";
+import { promisify } from "node:util";
 import koffi from "koffi";
 
-/**
- * Resolve the current filesystem path of an open Windows directory handle.
- * After a rename/junction swap of the original pathname, this still returns the
- * path of the held inode, so subsequent mkdir/open under it stay contained.
- */
-export function pathFromDirectoryFd(fd: number): string {
+const closeFd = promisify(closeCb);
+const fchmodFd = promisify(fchmodCb);
+const fstatFd = promisify(fstatCb);
+const ftruncateFd = promisify(ftruncateCb);
+const writeFileFd = promisify(writeFileCb) as (
+  fd: number,
+  data: string | Uint8Array,
+) => Promise<void>;
+
+const FILE_OPEN = 1;
+const FILE_CREATE = 2;
+const FILE_DIRECTORY_FILE = 0x00000001;
+const FILE_NON_DIRECTORY_FILE = 0x00000040;
+const FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020;
+const FILE_OPEN_REPARSE_POINT = 0x00200000;
+const OBJ_CASE_INSENSITIVE = 0x00000040;
+const GENERIC_READ = 0x80000000;
+const GENERIC_WRITE = 0x40000000;
+const SYNCHRONIZE = 0x00100000;
+const FILE_SHARE_ALL = 0x00000007;
+const FILE_ATTRIBUTE_NORMAL = 0x00000080;
+const FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
+const O_RDWR_BINARY = 0x8002;
+/** NTSTATUS 0xC0000035 as signed int32 */
+const STATUS_OBJECT_NAME_COLLISION = -1073741771;
+/** NTSTATUS 0xC0000034 as signed int32 */
+const STATUS_OBJECT_NAME_NOT_FOUND = -1073741772;
+/** NTSTATUS 0xC000003A as signed int32 */
+const STATUS_OBJECT_PATH_NOT_FOUND = -1073741763;
+
+function escapeWorkspace(): never {
+  throw new Error("Path escapes the computer workspace");
+}
+
+type NtFns = {
+  NtCreateFile: koffi.KoffiFunction;
+  RtlInitUnicodeString: koffi.KoffiFunction;
+  getOsFhandle: koffi.KoffiFunction;
+  openOsFhandle: koffi.KoffiFunction;
+  CloseHandle: koffi.KoffiFunction;
+  GetFinalPathNameByHandleW: koffi.KoffiFunction;
+  objectAttributesSize: number;
+};
+
+let cached: NtFns | undefined | null;
+
+/** True when real Win32 NT APIs loaded (false on Linux hosts that only mock win32). */
+export function win32NtRelativeAvailable(): boolean {
+  if (process.platform !== "win32") return false;
+  try {
+    nt();
+    return true;
+  } catch {
+    cached = null;
+    return false;
+  }
+}
+
+function nt(): NtFns {
+  if (cached === null) throw new Error("Win32 NT APIs unavailable");
+  if (cached) return cached;
+  const ntdll = koffi.load("ntdll.dll");
   const kernel32 = koffi.load("kernel32.dll");
   const msvcrt = koffi.load("msvcrt.dll");
 
-  const GetFinalPathNameByHandleW = kernel32.func(
-    "uint32_t __stdcall GetFinalPathNameByHandleW(void *hFile, void *lpszFilePath, uint32_t cchFilePath, uint32_t dwFlags)",
-  );
-  const getOsFhandle = msvcrt.func("intptr_t __cdecl _get_osfhandle(int fd)");
+  koffi.struct("UNICODE_STRING", {
+    Length: "uint16_t",
+    MaximumLength: "uint16_t",
+    Buffer: "void *",
+  });
+  const OBJECT_ATTRIBUTES = koffi.struct("OBJECT_ATTRIBUTES", {
+    Length: "uint32_t",
+    RootDirectory: "void *",
+    ObjectName: "UNICODE_STRING *",
+    Attributes: "uint32_t",
+    SecurityDescriptor: "void *",
+    SecurityQualityOfService: "void *",
+  });
+  koffi.struct("IO_STATUS_BLOCK", {
+    Status: "intptr_t",
+    Information: "uintptr_t",
+  });
 
-  const handle = getOsFhandle(fd);
-  if (handle === -1n || handle === -1) {
-    throw new Error("Path escapes the computer workspace");
-  }
+  cached = {
+    NtCreateFile: ntdll.func(
+      "int32_t __stdcall NtCreateFile(_Out_ void **FileHandle, uint32_t DesiredAccess, OBJECT_ATTRIBUTES *ObjectAttributes, IO_STATUS_BLOCK *IoStatusBlock, void *AllocationSize, uint32_t FileAttributes, uint32_t ShareAccess, uint32_t CreateDisposition, uint32_t CreateOptions, void *EaBuffer, uint32_t EaLength)",
+    ),
+    RtlInitUnicodeString: ntdll.func(
+      "void __stdcall RtlInitUnicodeString(_Out_ UNICODE_STRING *DestinationString, void *SourceString)",
+    ),
+    getOsFhandle: msvcrt.func("intptr_t __cdecl _get_osfhandle(int fd)"),
+    openOsFhandle: msvcrt.func("int __cdecl _open_osfhandle(intptr_t handle, int flags)"),
+    CloseHandle: kernel32.func("int __stdcall CloseHandle(void *hObject)"),
+    GetFinalPathNameByHandleW: kernel32.func(
+      "uint32_t __stdcall GetFinalPathNameByHandleW(void *hFile, void *lpszFilePath, uint32_t cchFilePath, uint32_t dwFlags)",
+    ),
+    objectAttributesSize: koffi.sizeof(OBJECT_ATTRIBUTES),
+  };
+  return cached;
+}
+
+/**
+ * Resolve the current filesystem path of an open Windows file/directory handle.
+ * After a rename/junction swap of the original pathname, this still returns the
+ * path of the held inode.
+ */
+export function pathFromDirectoryFd(fd: number): string {
+  const api = nt();
+  const handle = api.getOsFhandle(fd) as number | bigint;
+  if (handle === -1n || handle === -1) escapeWorkspace();
 
   const flags = 0; // VOLUME_NAME_DOS
-  const size = GetFinalPathNameByHandleW(handle, null, 0, flags);
-  if (size === 0) throw new Error("Path escapes the computer workspace");
+  const size = api.GetFinalPathNameByHandleW(handle, null, 0, flags) as number;
+  if (size === 0) escapeWorkspace();
 
   const buf = Buffer.alloc((size + 1) * 2);
-  const written = GetFinalPathNameByHandleW(handle, buf, size + 1, flags);
-  if (written === 0) throw new Error("Path escapes the computer workspace");
+  const written = api.GetFinalPathNameByHandleW(handle, buf, size + 1, flags) as number;
+  if (written === 0) escapeWorkspace();
 
   let resolved = buf.toString("utf16le", 0, written * 2);
-  // GetFinalPathNameByHandle returns \\?\C:\... or \\?\UNC\...
   if (resolved.startsWith("\\\\?\\UNC\\"))
     resolved = `\\\\${resolved.slice("\\\\?\\UNC\\".length)}`;
   else if (resolved.startsWith("\\\\?\\")) resolved = resolved.slice("\\\\?\\".length);
   return resolved;
+}
+
+function assertLeafName(name: string) {
+  if (!name || name === "." || name === ".." || /[\\/]/.test(name)) escapeWorkspace();
+}
+
+function ntCreateRelative(
+  parentFd: number,
+  name: string,
+  createDisposition: number,
+  createOptions: number,
+  fileAttributes: number,
+): { fd: number; status: number } {
+  assertLeafName(name);
+  const api = nt();
+  const root = api.getOsFhandle(parentFd) as number | bigint;
+  if (root === -1 || root === -1n) escapeWorkspace();
+
+  const nameBuf = Buffer.from(`${name}\0`, "utf16le");
+  const uni = {};
+  api.RtlInitUnicodeString(uni, nameBuf);
+
+  const objectAttributes = {
+    Length: api.objectAttributesSize,
+    RootDirectory: root,
+    ObjectName: uni,
+    Attributes: OBJ_CASE_INSENSITIVE,
+    SecurityDescriptor: null,
+    SecurityQualityOfService: null,
+  };
+  const ioStatus = {};
+  const handleOut: Array<unknown> = [null];
+  const status = api.NtCreateFile(
+    handleOut,
+    GENERIC_READ | GENERIC_WRITE | SYNCHRONIZE,
+    objectAttributes,
+    ioStatus,
+    null,
+    fileAttributes,
+    FILE_SHARE_ALL,
+    createDisposition,
+    createOptions,
+    null,
+    0,
+  ) as number;
+
+  if (status !== 0) return { fd: -1, status };
+
+  const handle = handleOut[0];
+  if (handle == null) escapeWorkspace();
+  const fd = api.openOsFhandle(handle as number | bigint, O_RDWR_BINARY) as number;
+  if (fd < 0) {
+    api.CloseHandle(handle as number | bigint);
+    escapeWorkspace();
+  }
+  return { fd, status: 0 };
+}
+
+/** Duck-typed FileHandle surface used by desktop-sandbox writes. */
+export function fileHandleFromFd(fd: number) {
+  return {
+    fd,
+    stat: (opts?: { bigint?: boolean }) => fstatFd(fd, opts as never),
+    truncate: (len = 0) => ftruncateFd(fd, len),
+    writeFile: (data: string | Uint8Array) => writeFileFd(fd, data),
+    chmod: (mode: number) => fchmodFd(fd, mode),
+    close: () => closeFd(fd),
+  };
+}
+
+export type Win32FileHandle = ReturnType<typeof fileHandleFromFd>;
+
+export function openExistingChildViaDirectoryFdWin32(parentFd: number, name: string) {
+  const { fd, status } = ntCreateRelative(
+    parentFd,
+    name,
+    FILE_OPEN,
+    FILE_NON_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
+    FILE_ATTRIBUTE_NORMAL,
+  );
+  if (status === STATUS_OBJECT_NAME_NOT_FOUND || status === STATUS_OBJECT_PATH_NOT_FOUND) {
+    const err = new Error("ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    throw err;
+  }
+  if (status !== 0) escapeWorkspace();
+  return fileHandleFromFd(fd);
+}
+
+export function createExclusiveChildViaDirectoryFdWin32(parentFd: number, name: string) {
+  const { fd, status } = ntCreateRelative(
+    parentFd,
+    name,
+    FILE_CREATE,
+    FILE_NON_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
+    FILE_ATTRIBUTE_NORMAL,
+  );
+  if (status === STATUS_OBJECT_NAME_COLLISION) {
+    const err = new Error("EEXIST") as NodeJS.ErrnoException;
+    err.code = "EEXIST";
+    throw err;
+  }
+  if (status !== 0) escapeWorkspace();
+  return fileHandleFromFd(fd);
+}
+
+/** Creates a child directory relative to the parent fd. Returns a path for cleanup when available. */
+export function mkdirChildViaDirectoryFdWin32(parentFd: number, name: string): string | undefined {
+  const { fd, status } = ntCreateRelative(
+    parentFd,
+    name,
+    FILE_CREATE,
+    FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
+    FILE_ATTRIBUTE_DIRECTORY,
+  );
+  if (status === STATUS_OBJECT_NAME_COLLISION) {
+    const err = new Error("EEXIST") as NodeJS.ErrnoException;
+    err.code = "EEXIST";
+    throw err;
+  }
+  if (status !== 0) escapeWorkspace();
+  let createdPath: string | undefined;
+  try {
+    createdPath = pathFromDirectoryFd(fd);
+  } catch {
+    createdPath = undefined;
+  }
+  closeSync(fd);
+  return createdPath;
+}
+
+export function openChildDirectoryViaDirectoryFdWin32(parentFd: number, name: string) {
+  const { fd, status } = ntCreateRelative(
+    parentFd,
+    name,
+    FILE_OPEN,
+    FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
+    FILE_ATTRIBUTE_DIRECTORY,
+  );
+  if (status !== 0) escapeWorkspace();
+  return fileHandleFromFd(fd);
 }

--- a/packages/adapters/src/desktop-sandbox-win32-path.ts
+++ b/packages/adapters/src/desktop-sandbox-win32-path.ts
@@ -1,10 +1,10 @@
 import {
   close as closeCb,
+  closeSync,
   fchmod as fchmodCb,
   fstat as fstatCb,
   ftruncate as ftruncateCb,
   writeFile as writeFileCb,
-  closeSync,
 } from "node:fs";
 import { promisify } from "node:util";
 import koffi from "koffi";

--- a/packages/adapters/src/desktop-sandbox-win32-path.ts
+++ b/packages/adapters/src/desktop-sandbox-win32-path.ts
@@ -1,0 +1,36 @@
+import koffi from "koffi";
+
+/**
+ * Resolve the current filesystem path of an open Windows directory handle.
+ * After a rename/junction swap of the original pathname, this still returns the
+ * path of the held inode, so subsequent mkdir/open under it stay contained.
+ */
+export function pathFromDirectoryFd(fd: number): string {
+  const kernel32 = koffi.load("kernel32.dll");
+  const msvcrt = koffi.load("msvcrt.dll");
+
+  const GetFinalPathNameByHandleW = kernel32.func(
+    "uint32_t __stdcall GetFinalPathNameByHandleW(void *hFile, void *lpszFilePath, uint32_t cchFilePath, uint32_t dwFlags)",
+  );
+  const getOsFhandle = msvcrt.func("intptr_t __cdecl _get_osfhandle(int fd)");
+
+  const handle = getOsFhandle(fd);
+  if (handle === -1n || handle === -1) {
+    throw new Error("Path escapes the computer workspace");
+  }
+
+  const flags = 0; // VOLUME_NAME_DOS
+  const size = GetFinalPathNameByHandleW(handle, null, 0, flags);
+  if (size === 0) throw new Error("Path escapes the computer workspace");
+
+  const buf = Buffer.alloc((size + 1) * 2);
+  const written = GetFinalPathNameByHandleW(handle, buf, size + 1, flags);
+  if (written === 0) throw new Error("Path escapes the computer workspace");
+
+  let resolved = buf.toString("utf16le", 0, written * 2);
+  // GetFinalPathNameByHandle returns \\?\C:\... or \\?\UNC\...
+  if (resolved.startsWith("\\\\?\\UNC\\"))
+    resolved = `\\\\${resolved.slice("\\\\?\\UNC\\".length)}`;
+  else if (resolved.startsWith("\\\\?\\")) resolved = resolved.slice("\\\\?\\".length);
+  return resolved;
+}

--- a/packages/adapters/src/desktop-sandbox-write-containment.test.ts
+++ b/packages/adapters/src/desktop-sandbox-write-containment.test.ts
@@ -68,6 +68,15 @@ async function fixture(botId: string) {
   return { root, desktop, computer };
 }
 
+async function pathExists(target: string) {
+  try {
+    await realpath(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("desktop sandbox write containment without O_NOFOLLOW", () => {
   it("rejects an existing final symlink without changing its outside target", async () => {
     const { root, desktop, computer } = await fixture("static-link");
@@ -228,6 +237,57 @@ describe("desktop sandbox write containment without O_NOFOLLOW", () => {
     await expect(readFile(path.join(outside, "nested"), "utf8")).rejects.toMatchObject({
       code: "ENOENT",
     });
+  });
+
+  it("rejects when path containment and the opened inode diverge after a parent swap", async () => {
+    const { root, desktop, computer } = await fixture("inode-diverge");
+    const parent = path.join(computer.providerRef, "notes");
+    const displaced = path.join(computer.providerRef, "notes-original");
+    const outside = path.join(root, "outside-directory");
+    await mkdir(parent);
+    await mkdir(outside);
+    await writeFile(path.join(parent, "result.txt"), "inside-before");
+    await writeFile(path.join(outside, "result.txt"), "outside-before");
+
+    // Force pathname opens so containment must bind directory/file inodes (Windows path).
+    const platform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    try {
+      let notesRealpaths = 0;
+      lstatRace.afterRealpath = async (inspected) => {
+        if (path.basename(inspected) !== "notes") return;
+        notesRealpaths += 1;
+        // After openContainedWorkspaceFile's parent realpath, point the pathname at an
+        // outside directory. Without binding the opened parent inode to a fresh
+        // contained realpath, later checks could validate a restored inside path
+        // while the handle still referred outside.
+        if (notesRealpaths !== 2) return;
+        await rename(parent, displaced);
+        await symlink(outside, parent, "junction");
+      };
+      lstatRace.after = async (inspected) => {
+        if (path.basename(inspected) !== "result.txt") return;
+        // If a child open happened, restore an inside pathname so realpath-only
+        // containment would incorrectly pass without an inode bind.
+        if (!(await pathExists(parent))) return;
+        await rm(parent, { force: true });
+        if (await pathExists(displaced)) await rename(displaced, parent);
+      };
+
+      await expect(
+        desktop.writeFile(computer, {
+          path: "notes/result.txt",
+          content: new TextEncoder().encode("after"),
+        }),
+      ).rejects.toThrow();
+      expect(notesRealpaths).toBeGreaterThanOrEqual(2);
+      expect(await readFile(path.join(outside, "result.txt"), "utf8")).toBe("outside-before");
+      // Inside content lives under the displaced original parent after the race.
+      expect(await readFile(path.join(displaced, "result.txt"), "utf8")).toBe("inside-before");
+    } finally {
+      if (platform) Object.defineProperty(process, "platform", platform);
+      else Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+    }
   });
 
   it("rejects a hard link whose other name is outside the workspace", async () => {

--- a/packages/adapters/src/desktop-sandbox-write-containment.test.ts
+++ b/packages/adapters/src/desktop-sandbox-write-containment.test.ts
@@ -127,6 +127,26 @@ describe("desktop sandbox write containment without O_NOFOLLOW", () => {
     });
   });
 
+  it("does not create outside directories through a parent symlink", async () => {
+    const { root, desktop, computer } = await fixture("parent-link-nested");
+    const outside = path.join(root, "outside-directory");
+    await mkdir(outside);
+    await symlink(outside, path.join(computer.providerRef, "escape-directory"), "junction");
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "escape-directory/nested/outside.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    await expect(readFile(path.join(outside, "nested/outside.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(path.join(outside, "nested"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
   it("does not write outside when a validated parent is replaced before open", async () => {
     const { root, desktop, computer } = await fixture("parent-swap");
     const parent = path.join(computer.providerRef, "notes");
@@ -153,6 +173,33 @@ describe("desktop sandbox write containment without O_NOFOLLOW", () => {
     expect(swapped).toBe(true);
     expect(await readFile(path.join(outside, "result.txt"), "utf8")).toBe("outside-before");
     expect(await readFile(path.join(displaced, "result.txt"), "utf8")).toBe("inside-before");
+  });
+
+  it("does not leave an outside file when exclusive create races through a swapped parent", async () => {
+    const { root, desktop, computer } = await fixture("parent-swap-create");
+    const parent = path.join(computer.providerRef, "notes");
+    const displaced = path.join(computer.providerRef, "notes-original");
+    const outside = path.join(root, "outside-directory");
+    await mkdir(parent);
+    await mkdir(outside);
+    let swapped = false;
+    lstatRace.afterRealpath = async (inspected) => {
+      if (swapped || path.resolve(inspected) !== parent) return;
+      swapped = true;
+      await rename(parent, displaced);
+      await symlink(outside, parent, "junction");
+    };
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "notes/result.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    expect(swapped).toBe(true);
+    await expect(readFile(path.join(outside, "result.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("rejects a hard link whose other name is outside the workspace", async () => {

--- a/packages/adapters/src/desktop-sandbox-write-containment.test.ts
+++ b/packages/adapters/src/desktop-sandbox-write-containment.test.ts
@@ -84,7 +84,7 @@ describe("desktop sandbox write containment without O_NOFOLLOW", () => {
     expect(await readFile(outside, "utf8")).toBe("before");
   });
 
-  it("does not write outside when the final file is replaced after lstat", async () => {
+  it("keeps writes on the opened inode when the final name is replaced after lstat", async () => {
     const { root, desktop, computer } = await fixture("swap-link");
     const target = path.join(computer.providerRef, "result.txt");
     const displaced = path.join(computer.providerRef, "result-original.txt");
@@ -93,21 +93,19 @@ describe("desktop sandbox write containment without O_NOFOLLOW", () => {
     await writeFile(outside, "outside-before");
     let swapped = false;
     lstatRace.after = async (inspected) => {
-      if (swapped || path.resolve(inspected) !== target) return;
+      if (swapped || path.basename(inspected) !== "result.txt") return;
       swapped = true;
       await rename(target, displaced);
       await symlink(outside, target);
     };
 
-    await expect(
-      desktop.writeFile(computer, {
-        path: "result.txt",
-        content: new TextEncoder().encode("after"),
-      }),
-    ).rejects.toThrow();
+    await desktop.writeFile(computer, {
+      path: "result.txt",
+      content: new TextEncoder().encode("after"),
+    });
     expect(swapped).toBe(true);
     expect(await readFile(outside, "utf8")).toBe("outside-before");
-    expect(await readFile(displaced, "utf8")).toBe("inside-before");
+    expect(await readFile(displaced, "utf8")).toBe("after");
   });
 
   it("rejects a parent symlink that resolves outside the workspace", async () => {

--- a/packages/adapters/src/desktop-sandbox-write-containment.test.ts
+++ b/packages/adapters/src/desktop-sandbox-write-containment.test.ts
@@ -1,0 +1,189 @@
+import {
+  link,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const lstatRace = vi.hoisted(() => ({
+  after: undefined as undefined | ((target: string) => Promise<void>),
+  afterRealpath: undefined as undefined | ((target: string) => Promise<void>),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    constants: { ...actual.constants, O_NOFOLLOW: 0 },
+  };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    lstat: async (target: string, options?: { bigint?: boolean }) => {
+      const result = await actual.lstat(target, options as never);
+      await lstatRace.after?.(target);
+      return result;
+    },
+    realpath: async (target: string) => {
+      const result = await actual.realpath(target);
+      await lstatRace.afterRealpath?.(target);
+      return result;
+    },
+  };
+});
+
+const { DesktopSandboxProvider } = await import("./desktop-sandbox.js");
+
+const ctx = {
+  operationId: "operation",
+  traceId: "trace",
+  workspaceId: "workspace",
+  userId: "user",
+  signal: new AbortController().signal,
+};
+const roots: string[] = [];
+
+afterEach(async () => {
+  lstatRace.after = undefined;
+  lstatRace.afterRealpath = undefined;
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(botId: string) {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), "rakazo-desktop-containment-")));
+  roots.push(root);
+  const desktop = new DesktopSandboxProvider({ root });
+  const computer = await desktop.provision({ botId, homePath: "/unused" }, ctx);
+  return { root, desktop, computer };
+}
+
+describe("desktop sandbox write containment without O_NOFOLLOW", () => {
+  it("rejects an existing final symlink without changing its outside target", async () => {
+    const { root, desktop, computer } = await fixture("static-link");
+    const outside = path.join(root, "outside.txt");
+    await writeFile(outside, "before");
+    await symlink(outside, path.join(computer.providerRef, "escape.txt"));
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "escape.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    expect(await readFile(outside, "utf8")).toBe("before");
+  });
+
+  it("does not write outside when the final file is replaced after lstat", async () => {
+    const { root, desktop, computer } = await fixture("swap-link");
+    const target = path.join(computer.providerRef, "result.txt");
+    const displaced = path.join(computer.providerRef, "result-original.txt");
+    const outside = path.join(root, "outside.txt");
+    await writeFile(target, "inside-before");
+    await writeFile(outside, "outside-before");
+    let swapped = false;
+    lstatRace.after = async (inspected) => {
+      if (swapped || path.resolve(inspected) !== target) return;
+      swapped = true;
+      await rename(target, displaced);
+      await symlink(outside, target);
+    };
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "result.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    expect(swapped).toBe(true);
+    expect(await readFile(outside, "utf8")).toBe("outside-before");
+    expect(await readFile(displaced, "utf8")).toBe("inside-before");
+  });
+
+  it("rejects a parent symlink that resolves outside the workspace", async () => {
+    const { root, desktop, computer } = await fixture("parent-link");
+    const outside = path.join(root, "outside-directory");
+    await mkdir(outside);
+    await symlink(outside, path.join(computer.providerRef, "escape-directory"), "junction");
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "escape-directory/outside.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    await expect(readFile(path.join(outside, "outside.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not write outside when a validated parent is replaced before open", async () => {
+    const { root, desktop, computer } = await fixture("parent-swap");
+    const parent = path.join(computer.providerRef, "notes");
+    const displaced = path.join(computer.providerRef, "notes-original");
+    const outside = path.join(root, "outside-directory");
+    await mkdir(parent);
+    await mkdir(outside);
+    await writeFile(path.join(parent, "result.txt"), "inside-before");
+    await writeFile(path.join(outside, "result.txt"), "outside-before");
+    let swapped = false;
+    lstatRace.afterRealpath = async (inspected) => {
+      if (swapped || path.resolve(inspected) !== parent) return;
+      swapped = true;
+      await rename(parent, displaced);
+      await symlink(outside, parent, "junction");
+    };
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "notes/result.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    expect(swapped).toBe(true);
+    expect(await readFile(path.join(outside, "result.txt"), "utf8")).toBe("outside-before");
+    expect(await readFile(path.join(displaced, "result.txt"), "utf8")).toBe("inside-before");
+  });
+
+  it("rejects a hard link whose other name is outside the workspace", async () => {
+    const { root, desktop, computer } = await fixture("hard-link");
+    const outside = path.join(root, "outside.txt");
+    await writeFile(outside, "outside-before");
+    await link(outside, path.join(computer.providerRef, "escape.txt"));
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "escape.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    expect(await readFile(outside, "utf8")).toBe("outside-before");
+  });
+
+  it("still creates and replaces ordinary workspace files", async () => {
+    const { desktop, computer } = await fixture("ordinary-files");
+
+    await desktop.writeFile(computer, {
+      path: "notes/result.txt",
+      content: new TextEncoder().encode("first"),
+    });
+    await desktop.writeFile(computer, {
+      path: "notes/result.txt",
+      content: new TextEncoder().encode("second"),
+    });
+
+    expect(await readFile(path.join(computer.providerRef, "notes/result.txt"), "utf8")).toBe(
+      "second",
+    );
+  });
+});

--- a/packages/adapters/src/desktop-sandbox-write-containment.test.ts
+++ b/packages/adapters/src/desktop-sandbox-write-containment.test.ts
@@ -156,7 +156,7 @@ describe("desktop sandbox write containment without O_NOFOLLOW", () => {
     await writeFile(path.join(outside, "result.txt"), "outside-before");
     let swapped = false;
     lstatRace.afterRealpath = async (inspected) => {
-      if (swapped || path.resolve(inspected) !== parent) return;
+      if (swapped || path.basename(inspected) !== "notes") return;
       swapped = true;
       await rename(parent, displaced);
       await symlink(outside, parent, "junction");
@@ -182,7 +182,7 @@ describe("desktop sandbox write containment without O_NOFOLLOW", () => {
     await mkdir(outside);
     let swapped = false;
     lstatRace.afterRealpath = async (inspected) => {
-      if (swapped || path.resolve(inspected) !== parent) return;
+      if (swapped || path.basename(inspected) !== "notes") return;
       swapped = true;
       await rename(parent, displaced);
       await symlink(outside, parent, "junction");
@@ -196,6 +196,36 @@ describe("desktop sandbox write containment without O_NOFOLLOW", () => {
     ).rejects.toThrow();
     expect(swapped).toBe(true);
     await expect(readFile(path.join(outside, "result.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not create outside directories when a parent is swapped during mkdir", async () => {
+    const { root, desktop, computer } = await fixture("mkdir-swap");
+    const parent = path.join(computer.providerRef, "notes");
+    const displaced = path.join(computer.providerRef, "notes-original");
+    const outside = path.join(root, "outside-directory");
+    await mkdir(parent);
+    await mkdir(outside);
+    let swapped = false;
+    lstatRace.afterRealpath = async (inspected) => {
+      if (swapped || path.basename(inspected) !== "notes") return;
+      swapped = true;
+      await rename(parent, displaced);
+      await symlink(outside, parent, "junction");
+    };
+
+    await expect(
+      desktop.writeFile(computer, {
+        path: "notes/nested/result.txt",
+        content: new TextEncoder().encode("after"),
+      }),
+    ).rejects.toThrow();
+    expect(swapped).toBe(true);
+    await expect(readFile(path.join(outside, "nested/result.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(path.join(outside, "nested"), "utf8")).rejects.toMatchObject({
       code: "ENOENT",
     });
   });

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -8,6 +8,7 @@ import {
   readFile,
   realpath,
   rm,
+  rmdir,
   stat,
   unlink,
   writeFile,
@@ -341,7 +342,7 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
           await parentHandle.close().catch(() => undefined);
           parentHandle = nextHandle;
         } catch (error) {
-          if (created) await rm(next, { recursive: true, force: true }).catch(() => undefined);
+          if (created) await rmdir(next).catch(() => undefined);
           throw error;
         }
       }
@@ -417,18 +418,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
     ) {
       throw new Error("Path escapes the computer workspace");
     }
-    if (!viaDirFd) {
-      // Bind containment to the opened inode so a path swap cannot validate a
-      // different inside path while the handle still refers outside.
-      const resolved = await realpath(path.join(containedParent, name));
-      if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
-        throw new Error("Path escapes the computer workspace");
-      }
-      const resolvedStat = await stat(resolved, { bigint: true });
-      if (resolvedStat.dev !== opened.dev || resolvedStat.ino !== opened.ino) {
-        throw new Error("Path escapes the computer workspace");
-      }
-    }
+    await assertContainedFileHandle(handle, resolvedHome, parentHandle, containedParent);
     return handle;
   } catch (error) {
     if (created && handle) {
@@ -464,24 +454,70 @@ async function assertContainedDirectoryHandle(
   ) {
     throw new Error("Path escapes the computer workspace");
   }
-  const resolved = await realpath(pathToRecheck);
-  if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
+  // Prefer fd-bound realpath so containment cannot diverge from the open handle.
+  const resolved = await realpathFromFd(handle.fd);
+  if (resolved) {
+    if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
+      throw new Error("Path escapes the computer workspace");
+    }
+    return resolved;
+  }
+  // Pathname platforms: re-open the realpath immediately and require the same inode.
+  const byPath = await realpath(pathToRecheck);
+  if (!isAllowedDesktopPath(byPath, [resolvedHome])) {
     throw new Error("Path escapes the computer workspace");
   }
-  const resolvedStat = await stat(resolved);
+  const verify = await open(byPath, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0));
+  try {
+    const verified = await verify.stat();
+    if (!verified.isDirectory() || verified.dev !== after.dev || verified.ino !== after.ino) {
+      throw new Error("Path escapes the computer workspace");
+    }
+  } finally {
+    await verify.close().catch(() => undefined);
+  }
+  return byPath;
+}
+
+async function assertContainedFileHandle(
+  handle: Awaited<ReturnType<typeof open>>,
+  resolvedHome: string,
+  parentHandle: Awaited<ReturnType<typeof open>>,
+  parentPath: string,
+) {
+  const opened = await handle.stat({ bigint: true });
+  if (!opened.isFile() || opened.nlink !== 1n) {
+    throw new Error("Path escapes the computer workspace");
+  }
+  const resolved = await realpathFromFd(handle.fd);
+  if (resolved) {
+    if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
+      throw new Error("Path escapes the computer workspace");
+    }
+    return;
+  }
+  // Pathname platforms: ensure the parent path still names the held parent inode.
+  // If it was swapped to a junction, the path inode diverges and we fail closed.
+  const parentOpened = await parentHandle.stat();
+  const parentNow = await stat(parentPath);
   if (
-    !resolvedStat.isDirectory() ||
-    resolvedStat.dev !== after.dev ||
-    resolvedStat.ino !== after.ino
+    !parentNow.isDirectory() ||
+    parentNow.dev !== parentOpened.dev ||
+    parentNow.ino !== parentOpened.ino ||
+    !isAllowedDesktopPath(await realpath(parentPath), [resolvedHome])
   ) {
     throw new Error("Path escapes the computer workspace");
   }
-  return resolved;
 }
 
 function childPathViaDirFd(fd: number, name: string) {
   if (process.platform === "linux") return `/proc/self/fd/${fd}/${name}`;
   return undefined;
+}
+
+async function realpathFromFd(fd: number) {
+  if (process.platform !== "linux") return undefined;
+  return realpath(`/proc/self/fd/${fd}`);
 }
 
 function hasErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -9,6 +9,7 @@ import {
   realpath,
   rm,
   stat,
+  unlink,
   writeFile,
 } from "node:fs/promises";
 import path from "node:path";
@@ -213,7 +214,6 @@ export class DesktopSandboxProvider implements SandboxProvider {
   async writeFile(computer: ComputerRef, file: PortableFile) {
     const box = this.requiredBox(computer);
     const target = await localWorkspaceTarget(box.home, file.path, false);
-    await mkdir(path.dirname(target), { recursive: true });
     const handle = await openContainedWorkspaceFile(
       box.home,
       target,
@@ -298,12 +298,26 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
   if (!isAllowedDesktopPath(candidate, [home]))
     throw new Error("Path escapes the computer workspace");
   if (!mustExist) {
-    const parent = path.dirname(candidate);
-    await mkdir(parent, { recursive: true });
-    const resolvedParent = await realpath(parent);
-    if (!isAllowedDesktopPath(resolvedParent, [home]))
+    // Create each parent component under a realpath-checked path so a concurrent
+    // symlink/junction swap cannot mkdir outside the workspace before we notice.
+    const resolvedHome = await realpath(home);
+    if (!isAllowedDesktopPath(resolvedHome, [home]))
       throw new Error("Path escapes the computer workspace");
-    return path.join(resolvedParent, path.basename(candidate));
+    const segments = normalized.split(/[/\\]/u).filter(Boolean);
+    let current = resolvedHome;
+    for (const segment of segments.slice(0, -1)) {
+      const next = path.join(current, segment);
+      try {
+        await mkdir(next);
+      } catch (error) {
+        if (!hasErrorCode(error, "EEXIST")) throw error;
+      }
+      const resolved = await realpath(next);
+      if (!isAllowedDesktopPath(resolved, [resolvedHome]))
+        throw new Error("Path escapes the computer workspace");
+      current = resolved;
+    }
+    return path.join(current, segments.at(-1) ?? "");
   }
   const resolved = await realpath(candidate);
   if (!isAllowedDesktopPath(resolved, [home]))
@@ -313,6 +327,7 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
 
 async function openContainedWorkspaceFile(home: string, target: string, mode: number) {
   let handle: Awaited<ReturnType<typeof open>>;
+  let created = false;
   try {
     // Opening without O_TRUNC makes following a Windows reparse point non-destructive.
     // Validation below binds the write to this handle before any content is changed.
@@ -325,6 +340,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
       constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | O_NOFOLLOW,
       mode,
     );
+    created = true;
   }
 
   try {
@@ -346,6 +362,8 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
     return handle;
   } catch (error) {
     await handle.close().catch(() => undefined);
+    // If exclusive create followed a swapped parent link, remove the empty outside file.
+    if (created) await unlink(target).catch(() => undefined);
     throw error;
   }
 }

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -299,34 +299,54 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
     throw new Error("Path escapes the computer workspace");
   const resolvedHome = await realpath(home);
   if (!mustExist) {
-    // Create each parent under a realpath-checked prefix so a symlink/junction
-    // swap cannot mkdir outside the workspace before containment is checked.
+    // Walk/create parents from a held directory fd so a junction swap cannot
+    // redirect mkdir outside the workspace between validation and creation.
     const segments = normalized.split(/[/\\]/u).filter(Boolean);
     let current = resolvedHome;
-    for (const segment of segments.slice(0, -1)) {
-      const next = path.join(current, segment);
-      let created = false;
-      try {
-        await mkdir(next);
-        created = true;
-      } catch (error) {
-        if (!hasErrorCode(error, "EEXIST")) throw error;
-      }
-      try {
-        const resolved = await realpath(next);
-        if (
-          !isAllowedDesktopPath(resolved, [resolvedHome]) ||
-          !(await stat(resolved)).isDirectory()
-        ) {
-          throw new Error("Path escapes the computer workspace");
+    let parentHandle = await open(current, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0));
+    try {
+      for (const segment of segments.slice(0, -1)) {
+        const viaDirFd = childPathViaDirFd(parentHandle.fd, segment);
+        const next = viaDirFd ?? path.join(current, segment);
+        let created = false;
+        try {
+          await mkdir(next);
+          created = true;
+        } catch (error) {
+          if (!hasErrorCode(error, "EEXIST")) throw error;
         }
-        current = resolved;
-      } catch (error) {
-        if (created) await rm(next, { recursive: true, force: true }).catch(() => undefined);
-        throw error;
+        try {
+          const resolved = await realpath(next);
+          const before = await stat(resolved);
+          if (!isAllowedDesktopPath(resolved, [resolvedHome]) || !before.isDirectory()) {
+            throw new Error("Path escapes the computer workspace");
+          }
+          const nextHandle = await open(
+            resolved,
+            constants.O_RDONLY | (constants.O_DIRECTORY ?? 0),
+          );
+          const after = await nextHandle.stat();
+          if (
+            !after.isDirectory() ||
+            after.dev !== before.dev ||
+            after.ino !== before.ino ||
+            !isAllowedDesktopPath(resolved, [resolvedHome])
+          ) {
+            await nextHandle.close().catch(() => undefined);
+            throw new Error("Path escapes the computer workspace");
+          }
+          await parentHandle.close().catch(() => undefined);
+          parentHandle = nextHandle;
+          current = resolved;
+        } catch (error) {
+          if (created) await rm(next, { recursive: true, force: true }).catch(() => undefined);
+          throw error;
+        }
       }
+      return path.join(current, segments.at(-1) ?? "");
+    } finally {
+      await parentHandle.close().catch(() => undefined);
     }
-    return path.join(current, segments.at(-1) ?? "");
   }
   const resolved = await realpath(candidate);
   if (!isAllowedDesktopPath(resolved, [resolvedHome]))
@@ -352,6 +372,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
   let handle: Awaited<ReturnType<typeof open>> | undefined;
   let created = false;
   let openedPath = path.join(parentReal, name);
+  let viaDirFd: string | undefined;
   try {
     const parentAfter = await parentHandle.stat();
     if (
@@ -363,7 +384,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
     }
 
     // Prefer directory-fd relative opens so a parent path swap cannot redirect creates.
-    const viaDirFd = childPathViaDirFd(parentHandle.fd, name);
+    viaDirFd = childPathViaDirFd(parentHandle.fd, name);
     openedPath = viaDirFd ?? path.join(parentReal, name);
 
     try {
@@ -394,16 +415,33 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
       throw new Error("Path escapes the computer workspace");
     }
     if (!viaDirFd) {
+      // Bind containment to the opened inode so a path swap cannot validate a
+      // different inside path while the handle still refers outside.
       const resolved = await realpath(path.join(parentReal, name));
       if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
+        throw new Error("Path escapes the computer workspace");
+      }
+      const resolvedStat = await stat(resolved, { bigint: true });
+      if (resolvedStat.dev !== opened.dev || resolvedStat.ino !== opened.ino) {
         throw new Error("Path escapes the computer workspace");
       }
     }
     return handle;
   } catch (error) {
-    await handle?.close().catch(() => undefined);
-    // Path-based exclusive create may have landed outside through a swapped parent.
-    if (created) await unlink(openedPath).catch(() => undefined);
+    if (created && handle) {
+      const createdStat = await handle.stat({ bigint: true }).catch(() => undefined);
+      await handle.close().catch(() => undefined);
+      handle = undefined;
+      // Only unlink if the path still names the inode we created.
+      if (createdStat) {
+        const present = await lstat(openedPath, { bigint: true }).catch(() => undefined);
+        if (present && present.dev === createdStat.dev && present.ino === createdStat.ino) {
+          await unlink(openedPath).catch(() => undefined);
+        }
+      }
+    } else {
+      await handle?.close().catch(() => undefined);
+    }
     throw error;
   } finally {
     await parentHandle.close().catch(() => undefined);

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -451,6 +451,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
         if (!hasErrorCode(error, "ENOENT")) throw error;
         handle = createExclusiveChildViaDirectoryFdWin32(parentHandle.fd, name);
         created = true;
+        await handle.chmod(mode).catch(() => undefined);
       }
       try {
         openedPath = pathFromDirectoryFd(handle.fd);

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -42,8 +42,8 @@ import {
   openChildDirectoryViaDirectoryFdWin32,
   openExistingChildViaDirectoryFdWin32,
   pathFromDirectoryFd,
-  win32NtRelativeAvailable,
   type Win32FileHandle,
+  win32NtRelativeAvailable,
 } from "./desktop-sandbox-win32-path.js";
 
 const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -305,19 +305,26 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
     let current = resolvedHome;
     for (const segment of segments.slice(0, -1)) {
       const next = path.join(current, segment);
+      let created = false;
       try {
         await mkdir(next);
+        created = true;
       } catch (error) {
         if (!hasErrorCode(error, "EEXIST")) throw error;
       }
-      const resolved = await realpath(next);
-      if (
-        !isAllowedDesktopPath(resolved, [resolvedHome]) ||
-        !(await stat(resolved)).isDirectory()
-      ) {
-        throw new Error("Path escapes the computer workspace");
+      try {
+        const resolved = await realpath(next);
+        if (
+          !isAllowedDesktopPath(resolved, [resolvedHome]) ||
+          !(await stat(resolved)).isDirectory()
+        ) {
+          throw new Error("Path escapes the computer workspace");
+        }
+        current = resolved;
+      } catch (error) {
+        if (created) await rm(next, { recursive: true, force: true }).catch(() => undefined);
+        throw error;
       }
-      current = resolved;
     }
     return path.join(current, segments.at(-1) ?? "");
   }
@@ -328,28 +335,53 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
 }
 
 async function openContainedWorkspaceFile(home: string, target: string, mode: number) {
-  let handle: Awaited<ReturnType<typeof open>>;
-  let created = false;
-  try {
-    // Opening without O_TRUNC makes following a Windows reparse point non-destructive.
-    // Validation below binds the write to this handle before any content is changed.
-    handle = await open(target, constants.O_WRONLY | O_NOFOLLOW);
-  } catch (error) {
-    if (!hasErrorCode(error, "ENOENT")) throw error;
-    // Exclusive creation fails closed if a final link or file appears concurrently.
-    handle = await open(
-      target,
-      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | O_NOFOLLOW,
-      mode,
-    );
-    created = true;
+  const resolvedHome = await realpath(home);
+  const parentPath = path.dirname(target);
+  const name = path.basename(target);
+  if (!name || name === "." || name === "..") {
+    throw new Error("Path escapes the computer workspace");
   }
 
+  const parentReal = await realpath(parentPath);
+  if (!isAllowedDesktopPath(parentReal, [resolvedHome])) {
+    throw new Error("Path escapes the computer workspace");
+  }
+  const parentBefore = await stat(parentReal);
+  const parentHandle = await open(parentReal, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0));
+
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let created = false;
+  let openedPath = path.join(parentReal, name);
   try {
+    const parentAfter = await parentHandle.stat();
+    if (
+      !parentAfter.isDirectory() ||
+      parentAfter.dev !== parentBefore.dev ||
+      parentAfter.ino !== parentBefore.ino
+    ) {
+      throw new Error("Path escapes the computer workspace");
+    }
+
+    // Prefer directory-fd relative opens so a parent path swap cannot redirect creates.
+    const viaDirFd = childPathViaDirFd(parentHandle.fd, name);
+    openedPath = viaDirFd ?? path.join(parentReal, name);
+
+    try {
+      // Opening without O_TRUNC makes following a Windows reparse point non-destructive.
+      handle = await open(openedPath, constants.O_WRONLY | O_NOFOLLOW);
+    } catch (error) {
+      if (!hasErrorCode(error, "ENOENT")) throw error;
+      handle = await open(
+        openedPath,
+        constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | O_NOFOLLOW,
+        mode,
+      );
+      created = true;
+    }
+
     const opened = await handle.stat({ bigint: true });
-    const named = await lstat(target, { bigint: true });
-    const resolved = await realpath(target);
-    const resolvedHome = await realpath(home);
+    // lstat the same child path we opened so a followed final symlink cannot match.
+    const named = await lstat(openedPath, { bigint: true });
     if (
       !opened.isFile() ||
       !named.isFile() ||
@@ -357,18 +389,30 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
       opened.dev !== named.dev ||
       opened.ino !== named.ino ||
       opened.nlink !== 1n ||
-      named.nlink !== 1n ||
-      !isAllowedDesktopPath(resolved, [resolvedHome])
+      named.nlink !== 1n
     ) {
       throw new Error("Path escapes the computer workspace");
     }
+    if (!viaDirFd) {
+      const resolved = await realpath(path.join(parentReal, name));
+      if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
+        throw new Error("Path escapes the computer workspace");
+      }
+    }
     return handle;
   } catch (error) {
-    await handle.close().catch(() => undefined);
-    // If exclusive create followed a swapped parent link, remove the empty outside file.
-    if (created) await unlink(target).catch(() => undefined);
+    await handle?.close().catch(() => undefined);
+    // Path-based exclusive create may have landed outside through a swapped parent.
+    if (created) await unlink(openedPath).catch(() => undefined);
     throw error;
+  } finally {
+    await parentHandle.close().catch(() => undefined);
   }
+}
+
+function childPathViaDirFd(fd: number, name: string) {
+  if (process.platform === "linux") return `/proc/self/fd/${fd}/${name}`;
+  return undefined;
 }
 
 function hasErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -530,6 +530,9 @@ async function assertContainedFileHandle(
   try {
     const verified = await verify.stat({ bigint: true });
     const named = await lstat(verifyPath, { bigint: true });
+    // Re-stat the write handle last so a hardlink planted during verify cannot
+    // make an outside inode appear to live under the restored parent.
+    const again = await handle.stat({ bigint: true });
     if (
       !verified.isFile() ||
       !named.isFile() ||
@@ -537,7 +540,12 @@ async function assertContainedFileHandle(
       verified.dev !== opened.dev ||
       verified.ino !== opened.ino ||
       named.dev !== opened.dev ||
-      named.ino !== opened.ino
+      named.ino !== opened.ino ||
+      verified.nlink !== 1n ||
+      named.nlink !== 1n ||
+      again.dev !== opened.dev ||
+      again.ino !== opened.ino ||
+      again.nlink !== 1n
     ) {
       throw new Error("Path escapes the computer workspace");
     }

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -1,6 +1,16 @@
 import { spawn } from "node:child_process";
 import { constants } from "node:fs";
-import { mkdir, open, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import type {
   AdapterContext,
@@ -23,6 +33,9 @@ import {
   normalizeWorkspacePath,
   placeholderObservation,
 } from "./computer-support.js";
+import { isAllowedDesktopPath, normalizeDesktopWorkspacePath } from "./desktop-sandbox-paths.js";
+
+const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
 
 interface DesktopBox {
   ref: ComputerRef;
@@ -100,7 +113,7 @@ export class DesktopSandboxProvider implements SandboxProvider {
       return;
     }
     const cwd = resolveExecuteCwd(request.cwd, box.home);
-    if (!allowedPath(cwd, this.allowedRoots(box.home))) {
+    if (!isAllowedDesktopPath(cwd, this.allowedRoots(box.home))) {
       yield { type: "stderr", data: "path is outside this computer's home" };
       yield { type: "exit", code: 1 };
       return;
@@ -201,12 +214,13 @@ export class DesktopSandboxProvider implements SandboxProvider {
     const box = this.requiredBox(computer);
     const target = await localWorkspaceTarget(box.home, file.path, false);
     await mkdir(path.dirname(target), { recursive: true });
-    const handle = await open(
+    const handle = await openContainedWorkspaceFile(
+      box.home,
       target,
-      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW,
       file.executable ? 0o700 : 0o600,
     );
     try {
+      await handle.truncate(0);
       await handle.writeFile(file.content);
       if (file.executable) await handle.chmod(0o700);
     } finally {
@@ -279,20 +293,65 @@ export class DesktopSandboxProvider implements SandboxProvider {
 }
 
 async function localWorkspaceTarget(home: string, relative: string, mustExist: boolean) {
-  const normalized = normalizeWorkspacePath(relative);
+  const normalized = normalizeDesktopWorkspacePath(relative);
   const candidate = path.resolve(home, normalized);
-  if (!allowedPath(candidate, [home])) throw new Error("Path escapes the computer workspace");
+  if (!isAllowedDesktopPath(candidate, [home]))
+    throw new Error("Path escapes the computer workspace");
   if (!mustExist) {
     const parent = path.dirname(candidate);
     await mkdir(parent, { recursive: true });
     const resolvedParent = await realpath(parent);
-    if (!allowedPath(resolvedParent, [home]))
+    if (!isAllowedDesktopPath(resolvedParent, [home]))
       throw new Error("Path escapes the computer workspace");
     return path.join(resolvedParent, path.basename(candidate));
   }
   const resolved = await realpath(candidate);
-  if (!allowedPath(resolved, [home])) throw new Error("Path escapes the computer workspace");
+  if (!isAllowedDesktopPath(resolved, [home]))
+    throw new Error("Path escapes the computer workspace");
   return resolved;
+}
+
+async function openContainedWorkspaceFile(home: string, target: string, mode: number) {
+  let handle: Awaited<ReturnType<typeof open>>;
+  try {
+    // Opening without O_TRUNC makes following a Windows reparse point non-destructive.
+    // Validation below binds the write to this handle before any content is changed.
+    handle = await open(target, constants.O_WRONLY | O_NOFOLLOW);
+  } catch (error) {
+    if (!hasErrorCode(error, "ENOENT")) throw error;
+    // Exclusive creation fails closed if a final link or file appears concurrently.
+    handle = await open(
+      target,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | O_NOFOLLOW,
+      mode,
+    );
+  }
+
+  try {
+    const opened = await handle.stat({ bigint: true });
+    const named = await lstat(target, { bigint: true });
+    const resolved = await realpath(target);
+    if (
+      !opened.isFile() ||
+      !named.isFile() ||
+      named.isSymbolicLink() ||
+      opened.dev !== named.dev ||
+      opened.ino !== named.ino ||
+      opened.nlink !== 1n ||
+      named.nlink !== 1n ||
+      !isAllowedDesktopPath(resolved, [home])
+    ) {
+      throw new Error("Path escapes the computer workspace");
+    }
+    return handle;
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code;
 }
 
 async function* walkDesktopWorkspace(home: string, directory: string): AsyncIterable<PortableFile> {
@@ -316,14 +375,6 @@ async function* walkDesktopWorkspace(home: string, directory: string): AsyncIter
 function resolveExecuteCwd(requestCwd: string | undefined, home: string) {
   if (!requestCwd || requestCwd === "/home/rakazo" || requestCwd === "/home/user") return home;
   return path.resolve(home, requestCwd);
-}
-
-function allowedPath(target: string, roots: string[]) {
-  const resolved = path.resolve(target);
-  return roots.some((root) => {
-    const base = path.resolve(root);
-    return resolved === base || resolved.startsWith(base + path.sep);
-  });
 }
 
 function runCommand(

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -297,12 +297,10 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
   const candidate = path.resolve(home, normalized);
   if (!isAllowedDesktopPath(candidate, [home]))
     throw new Error("Path escapes the computer workspace");
+  const resolvedHome = await realpath(home);
   if (!mustExist) {
-    // Create each parent component under a realpath-checked path so a concurrent
-    // symlink/junction swap cannot mkdir outside the workspace before we notice.
-    const resolvedHome = await realpath(home);
-    if (!isAllowedDesktopPath(resolvedHome, [home]))
-      throw new Error("Path escapes the computer workspace");
+    // Create each parent under a realpath-checked prefix so a symlink/junction
+    // swap cannot mkdir outside the workspace before containment is checked.
     const segments = normalized.split(/[/\\]/u).filter(Boolean);
     let current = resolvedHome;
     for (const segment of segments.slice(0, -1)) {
@@ -313,14 +311,18 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
         if (!hasErrorCode(error, "EEXIST")) throw error;
       }
       const resolved = await realpath(next);
-      if (!isAllowedDesktopPath(resolved, [resolvedHome]))
+      if (
+        !isAllowedDesktopPath(resolved, [resolvedHome]) ||
+        !(await stat(resolved)).isDirectory()
+      ) {
         throw new Error("Path escapes the computer workspace");
+      }
       current = resolved;
     }
     return path.join(current, segments.at(-1) ?? "");
   }
   const resolved = await realpath(candidate);
-  if (!isAllowedDesktopPath(resolved, [home]))
+  if (!isAllowedDesktopPath(resolved, [resolvedHome]))
     throw new Error("Path escapes the computer workspace");
   return resolved;
 }
@@ -347,6 +349,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
     const opened = await handle.stat({ bigint: true });
     const named = await lstat(target, { bigint: true });
     const resolved = await realpath(target);
+    const resolvedHome = await realpath(home);
     if (
       !opened.isFile() ||
       !named.isFile() ||
@@ -355,7 +358,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
       opened.ino !== named.ino ||
       opened.nlink !== 1n ||
       named.nlink !== 1n ||
-      !isAllowedDesktopPath(resolved, [home])
+      !isAllowedDesktopPath(resolved, [resolvedHome])
     ) {
       throw new Error("Path escapes the computer workspace");
     }

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -36,6 +36,7 @@ import {
   placeholderObservation,
 } from "./computer-support.js";
 import { isAllowedDesktopPath, normalizeDesktopWorkspacePath } from "./desktop-sandbox-paths.js";
+import { pathFromDirectoryFd } from "./desktop-sandbox-win32-path.js";
 
 const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
 
@@ -556,6 +557,16 @@ async function assertContainedFileHandle(
 
 function childPathViaDirFd(fd: number, name: string) {
   if (process.platform === "linux") return `/proc/self/fd/${fd}/${name}`;
+  if (process.platform === "win32") {
+    try {
+      // Resolve the held directory inode's current path so mkdir/open do not go
+      // through a junction that replaced the original pathname.
+      return path.join(pathFromDirectoryFd(fd), name);
+    } catch {
+      // Hosts that only pretend to be win32 (unit tests) lack the Win32 APIs.
+      return undefined;
+    }
+  }
   return undefined;
 }
 

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -312,10 +312,11 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
         current = await assertContainedDirectoryHandle(parentHandle, current, resolvedHome);
         const viaDirFd = childPathViaDirFd(parentHandle.fd, segment);
         const next = viaDirFd ?? path.join(current, segment);
-        let created = false;
+        let created: { path: string; dev: number; ino: number } | undefined;
         try {
           await mkdir(next);
-          created = true;
+          const createdStat = await stat(next);
+          created = { path: next, dev: createdStat.dev, ino: createdStat.ino };
         } catch (error) {
           if (!hasErrorCode(error, "EEXIST")) throw error;
         }
@@ -345,7 +346,14 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
           await parentHandle.close().catch(() => undefined);
           parentHandle = nextHandle;
         } catch (error) {
-          if (created) await rmdir(next).catch(() => undefined);
+          // Only remove the directory inode we created; a swapped pathname must not
+          // rmdir a different empty directory.
+          if (created) {
+            const present = await stat(created.path).catch(() => undefined);
+            if (present && present.dev === created.dev && present.ino === created.ino) {
+              await rmdir(created.path).catch(() => undefined);
+            }
+          }
           throw error;
         }
       }

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -307,6 +307,9 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
     let parentHandle = await open(current, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0));
     try {
       for (const segment of segments.slice(0, -1)) {
+        // Re-bind the held parent immediately before create so a junction swap cannot
+        // redirect pathname mkdir outside the workspace.
+        current = await assertContainedDirectoryHandle(parentHandle, current, resolvedHome);
         const viaDirFd = childPathViaDirFd(parentHandle.fd, segment);
         const next = viaDirFd ?? path.join(current, segment);
         let created = false;
@@ -418,7 +421,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
     ) {
       throw new Error("Path escapes the computer workspace");
     }
-    await assertContainedFileHandle(handle, resolvedHome, parentHandle, containedParent);
+    await assertContainedFileHandle(handle, resolvedHome, parentHandle, containedParent, name);
     return handle;
   } catch (error) {
     if (created && handle) {
@@ -484,6 +487,7 @@ async function assertContainedFileHandle(
   resolvedHome: string,
   parentHandle: Awaited<ReturnType<typeof open>>,
   parentPath: string,
+  childName: string,
 ) {
   const opened = await handle.stat({ bigint: true });
   if (!opened.isFile() || opened.nlink !== 1n) {
@@ -496,17 +500,41 @@ async function assertContainedFileHandle(
     }
     return;
   }
-  // Pathname platforms: ensure the parent path still names the held parent inode.
-  // If it was swapped to a junction, the path inode diverges and we fail closed.
+  // Pathname platforms: the parent path must still name the held parent inode,
+  // and re-opening the child through that path must yield the same file. A
+  // junction swap for open + restore before the parent check would otherwise
+  // leave an outside handle while the parent path looks inside again.
   const parentOpened = await parentHandle.stat();
   const parentNow = await stat(parentPath);
   if (
     !parentNow.isDirectory() ||
     parentNow.dev !== parentOpened.dev ||
-    parentNow.ino !== parentOpened.ino ||
-    !isAllowedDesktopPath(await realpath(parentPath), [resolvedHome])
+    parentNow.ino !== parentOpened.ino
   ) {
     throw new Error("Path escapes the computer workspace");
+  }
+  const parentReal = await realpath(parentPath);
+  if (!isAllowedDesktopPath(parentReal, [resolvedHome])) {
+    throw new Error("Path escapes the computer workspace");
+  }
+  const verifyPath = path.join(parentReal, childName);
+  const verify = await open(verifyPath, constants.O_RDONLY | O_NOFOLLOW);
+  try {
+    const verified = await verify.stat({ bigint: true });
+    const named = await lstat(verifyPath, { bigint: true });
+    if (
+      !verified.isFile() ||
+      !named.isFile() ||
+      named.isSymbolicLink() ||
+      verified.dev !== opened.dev ||
+      verified.ino !== opened.ino ||
+      named.dev !== opened.dev ||
+      named.ino !== opened.ino
+    ) {
+      throw new Error("Path escapes the computer workspace");
+    }
+  } finally {
+    await verify.close().catch(() => undefined);
   }
 }
 

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -36,9 +36,20 @@ import {
   placeholderObservation,
 } from "./computer-support.js";
 import { isAllowedDesktopPath, normalizeDesktopWorkspacePath } from "./desktop-sandbox-paths.js";
-import { pathFromDirectoryFd } from "./desktop-sandbox-win32-path.js";
+import {
+  createExclusiveChildViaDirectoryFdWin32,
+  mkdirChildViaDirectoryFdWin32,
+  openChildDirectoryViaDirectoryFdWin32,
+  openExistingChildViaDirectoryFdWin32,
+  pathFromDirectoryFd,
+  win32NtRelativeAvailable,
+  type Win32FileHandle,
+} from "./desktop-sandbox-win32-path.js";
 
 const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
+
+/** Node FileHandle or Win32 duck-typed handle opened relative to a parent directory. */
+type ContainedHandle = Awaited<ReturnType<typeof open>> | Win32FileHandle;
 
 interface DesktopBox {
   ref: ComputerRef;
@@ -305,45 +316,77 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
     // redirect mkdir outside the workspace between validation and creation.
     const segments = normalized.split(/[/\\]/u).filter(Boolean);
     let current = resolvedHome;
-    let parentHandle = await open(current, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0));
+    let parentHandle: ContainedHandle = await open(
+      current,
+      constants.O_RDONLY | (constants.O_DIRECTORY ?? 0),
+    );
+    const useWin32Relative = win32NtRelativeAvailable();
     try {
       for (const segment of segments.slice(0, -1)) {
         // Re-bind the held parent immediately before create so a junction swap cannot
         // redirect pathname mkdir outside the workspace.
         current = await assertContainedDirectoryHandle(parentHandle, current, resolvedHome);
-        const viaDirFd = childPathViaDirFd(parentHandle.fd, segment);
-        const next = viaDirFd ?? path.join(current, segment);
         let created: { path: string; dev: number; ino: number } | undefined;
         try {
-          await mkdir(next);
-          const createdStat = await stat(next);
-          created = { path: next, dev: createdStat.dev, ino: createdStat.ino };
+          if (useWin32Relative) {
+            const createdPath = mkdirChildViaDirectoryFdWin32(parentHandle.fd, segment);
+            if (createdPath) {
+              const createdStat = await stat(createdPath).catch(() => undefined);
+              if (createdStat?.isDirectory()) {
+                created = { path: createdPath, dev: createdStat.dev, ino: createdStat.ino };
+              }
+            }
+          } else {
+            const viaDirFd = childPathViaDirFd(parentHandle.fd, segment);
+            const next = viaDirFd ?? path.join(current, segment);
+            await mkdir(next);
+            const createdStat = await stat(next);
+            created = { path: next, dev: createdStat.dev, ino: createdStat.ino };
+          }
         } catch (error) {
           if (!hasErrorCode(error, "EEXIST")) throw error;
         }
         try {
-          const resolved = await realpath(next);
-          const before = await stat(resolved);
-          if (!isAllowedDesktopPath(resolved, [resolvedHome]) || !before.isDirectory()) {
-            throw new Error("Path escapes the computer workspace");
-          }
-          const nextHandle = await open(
-            resolved,
-            constants.O_RDONLY | (constants.O_DIRECTORY ?? 0),
-          );
-          try {
-            // Re-resolve after open so a junction swap cannot leave us holding an
-            // outside directory while still trusting the earlier inside pathname.
-            current = await assertContainedDirectoryHandle(
+          let nextHandle: ContainedHandle;
+          let before: { dev: number; ino: number; isDirectory(): boolean };
+          let resolved: string;
+          if (useWin32Relative) {
+            nextHandle = openChildDirectoryViaDirectoryFdWin32(parentHandle.fd, segment);
+            before = await nextHandle.stat();
+            if (!before.isDirectory()) {
+              await nextHandle.close().catch(() => undefined);
+              throw new Error("Path escapes the computer workspace");
+            }
+            resolved = await assertContainedDirectoryHandle(
               nextHandle,
-              resolved,
+              path.join(current, segment),
               resolvedHome,
               before,
             );
-          } catch (error) {
-            await nextHandle.close().catch(() => undefined);
-            throw error;
+          } else {
+            const viaDirFd = childPathViaDirFd(parentHandle.fd, segment);
+            const next = viaDirFd ?? path.join(current, segment);
+            resolved = await realpath(next);
+            before = await stat(resolved);
+            if (!isAllowedDesktopPath(resolved, [resolvedHome]) || !before.isDirectory()) {
+              throw new Error("Path escapes the computer workspace");
+            }
+            nextHandle = await open(resolved, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0));
+            try {
+              // Re-resolve after open so a junction swap cannot leave us holding an
+              // outside directory while still trusting the earlier inside pathname.
+              resolved = await assertContainedDirectoryHandle(
+                nextHandle,
+                resolved,
+                resolvedHome,
+                before,
+              );
+            } catch (error) {
+              await nextHandle.close().catch(() => undefined);
+              throw error;
+            }
           }
+          current = resolved;
           await parentHandle.close().catch(() => undefined);
           parentHandle = nextHandle;
         } catch (error) {
@@ -383,11 +426,11 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
   }
   const parentBefore = await stat(parentReal);
   const parentHandle = await open(parentReal, constants.O_RDONLY | (constants.O_DIRECTORY ?? 0));
+  const useWin32Relative = win32NtRelativeAvailable();
 
-  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let handle: ContainedHandle | undefined;
   let created = false;
   let openedPath = path.join(parentReal, name);
-  let viaDirFd: string | undefined;
   try {
     // Bind the parent handle to a still-contained realpath. Otherwise a swap
     // after the first realpath can make inode checks agree on an outside dir
@@ -399,21 +442,38 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
       parentBefore,
     );
 
-    // Prefer directory-fd relative opens so a parent path swap cannot redirect creates.
-    viaDirFd = childPathViaDirFd(parentHandle.fd, name);
-    openedPath = viaDirFd ?? path.join(containedParent, name);
+    if (useWin32Relative) {
+      // Open/create relative to the held parent HANDLE so a junction swap of the
+      // parent pathname cannot redirect the write (true openat-style on Windows).
+      try {
+        handle = openExistingChildViaDirectoryFdWin32(parentHandle.fd, name);
+      } catch (error) {
+        if (!hasErrorCode(error, "ENOENT")) throw error;
+        handle = createExclusiveChildViaDirectoryFdWin32(parentHandle.fd, name);
+        created = true;
+      }
+      try {
+        openedPath = pathFromDirectoryFd(handle.fd);
+      } catch {
+        openedPath = path.join(containedParent, name);
+      }
+    } else {
+      // Prefer directory-fd relative opens so a parent path swap cannot redirect creates.
+      const viaDirFd = childPathViaDirFd(parentHandle.fd, name);
+      openedPath = viaDirFd ?? path.join(containedParent, name);
 
-    try {
-      // Opening without O_TRUNC makes following a Windows reparse point non-destructive.
-      handle = await open(openedPath, constants.O_WRONLY | O_NOFOLLOW);
-    } catch (error) {
-      if (!hasErrorCode(error, "ENOENT")) throw error;
-      handle = await open(
-        openedPath,
-        constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | O_NOFOLLOW,
-        mode,
-      );
-      created = true;
+      try {
+        // Opening without O_TRUNC makes following a Windows reparse point non-destructive.
+        handle = await open(openedPath, constants.O_WRONLY | O_NOFOLLOW);
+      } catch (error) {
+        if (!hasErrorCode(error, "ENOENT")) throw error;
+        handle = await open(
+          openedPath,
+          constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | O_NOFOLLOW,
+          mode,
+        );
+        created = true;
+      }
     }
 
     const opened = await handle.stat({ bigint: true });
@@ -435,13 +495,21 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
   } catch (error) {
     if (created && handle) {
       const createdStat = await handle.stat({ bigint: true }).catch(() => undefined);
+      let cleanupPath = openedPath;
+      if (useWin32Relative) {
+        try {
+          cleanupPath = pathFromDirectoryFd(handle.fd);
+        } catch {
+          // Keep openedPath when GetFinalPathName is unavailable.
+        }
+      }
       await handle.close().catch(() => undefined);
       handle = undefined;
       // Only unlink if the path still names the inode we created.
       if (createdStat) {
-        const present = await lstat(openedPath, { bigint: true }).catch(() => undefined);
+        const present = await lstat(cleanupPath, { bigint: true }).catch(() => undefined);
         if (present && present.dev === createdStat.dev && present.ino === createdStat.ino) {
-          await unlink(openedPath).catch(() => undefined);
+          await unlink(cleanupPath).catch(() => undefined);
         }
       }
     } else {
@@ -454,7 +522,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
 }
 
 async function assertContainedDirectoryHandle(
-  handle: Awaited<ReturnType<typeof open>>,
+  handle: ContainedHandle,
   pathToRecheck: string,
   resolvedHome: string,
   expected?: { dev: number; ino: number },
@@ -469,10 +537,15 @@ async function assertContainedDirectoryHandle(
   // Prefer fd-bound realpath so containment cannot diverge from the open handle.
   const resolved = await realpathFromFd(handle.fd);
   if (resolved) {
-    if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
+    const named = await lstat(resolved).catch(() => undefined);
+    if (named?.isSymbolicLink() || !isAllowedDesktopPath(resolved, [resolvedHome])) {
       throw new Error("Path escapes the computer workspace");
     }
-    return resolved;
+    const fully = await realpath(resolved);
+    if (!isAllowedDesktopPath(fully, [resolvedHome])) {
+      throw new Error("Path escapes the computer workspace");
+    }
+    return fully;
   }
   // Pathname platforms: re-open the realpath immediately and require the same inode.
   const byPath = await realpath(pathToRecheck);
@@ -492,9 +565,9 @@ async function assertContainedDirectoryHandle(
 }
 
 async function assertContainedFileHandle(
-  handle: Awaited<ReturnType<typeof open>>,
+  handle: ContainedHandle,
   resolvedHome: string,
-  parentHandle: Awaited<ReturnType<typeof open>>,
+  parentHandle: ContainedHandle,
   parentPath: string,
   childName: string,
 ) {
@@ -504,7 +577,19 @@ async function assertContainedFileHandle(
   }
   const resolved = await realpathFromFd(handle.fd);
   if (resolved) {
-    if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
+    const named = await lstat(resolved, { bigint: true });
+    if (
+      named.isSymbolicLink() ||
+      !named.isFile() ||
+      named.dev !== opened.dev ||
+      named.ino !== opened.ino ||
+      named.nlink !== 1n ||
+      !isAllowedDesktopPath(resolved, [resolvedHome])
+    ) {
+      throw new Error("Path escapes the computer workspace");
+    }
+    const fully = await realpath(resolved);
+    if (!isAllowedDesktopPath(fully, [resolvedHome])) {
       throw new Error("Path escapes the computer workspace");
     }
     return;
@@ -557,22 +642,20 @@ async function assertContainedFileHandle(
 
 function childPathViaDirFd(fd: number, name: string) {
   if (process.platform === "linux") return `/proc/self/fd/${fd}/${name}`;
+  return undefined;
+}
+
+async function realpathFromFd(fd: number) {
+  if (process.platform === "linux") return realpath(`/proc/self/fd/${fd}`);
   if (process.platform === "win32") {
     try {
-      // Resolve the held directory inode's current path so mkdir/open do not go
-      // through a junction that replaced the original pathname.
-      return path.join(pathFromDirectoryFd(fd), name);
+      return pathFromDirectoryFd(fd);
     } catch {
       // Hosts that only pretend to be win32 (unit tests) lack the Win32 APIs.
       return undefined;
     }
   }
   return undefined;
-}
-
-async function realpathFromFd(fd: number) {
-  if (process.platform !== "linux") return undefined;
-  return realpath(`/proc/self/fd/${fd}`);
 }
 
 function hasErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -325,19 +325,21 @@ async function localWorkspaceTarget(home: string, relative: string, mustExist: b
             resolved,
             constants.O_RDONLY | (constants.O_DIRECTORY ?? 0),
           );
-          const after = await nextHandle.stat();
-          if (
-            !after.isDirectory() ||
-            after.dev !== before.dev ||
-            after.ino !== before.ino ||
-            !isAllowedDesktopPath(resolved, [resolvedHome])
-          ) {
+          try {
+            // Re-resolve after open so a junction swap cannot leave us holding an
+            // outside directory while still trusting the earlier inside pathname.
+            current = await assertContainedDirectoryHandle(
+              nextHandle,
+              resolved,
+              resolvedHome,
+              before,
+            );
+          } catch (error) {
             await nextHandle.close().catch(() => undefined);
-            throw new Error("Path escapes the computer workspace");
+            throw error;
           }
           await parentHandle.close().catch(() => undefined);
           parentHandle = nextHandle;
-          current = resolved;
         } catch (error) {
           if (created) await rm(next, { recursive: true, force: true }).catch(() => undefined);
           throw error;
@@ -374,18 +376,19 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
   let openedPath = path.join(parentReal, name);
   let viaDirFd: string | undefined;
   try {
-    const parentAfter = await parentHandle.stat();
-    if (
-      !parentAfter.isDirectory() ||
-      parentAfter.dev !== parentBefore.dev ||
-      parentAfter.ino !== parentBefore.ino
-    ) {
-      throw new Error("Path escapes the computer workspace");
-    }
+    // Bind the parent handle to a still-contained realpath. Otherwise a swap
+    // after the first realpath can make inode checks agree on an outside dir
+    // while pathname containment still sees the stale inside path.
+    const containedParent = await assertContainedDirectoryHandle(
+      parentHandle,
+      parentReal,
+      resolvedHome,
+      parentBefore,
+    );
 
     // Prefer directory-fd relative opens so a parent path swap cannot redirect creates.
     viaDirFd = childPathViaDirFd(parentHandle.fd, name);
-    openedPath = viaDirFd ?? path.join(parentReal, name);
+    openedPath = viaDirFd ?? path.join(containedParent, name);
 
     try {
       // Opening without O_TRUNC makes following a Windows reparse point non-destructive.
@@ -417,7 +420,7 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
     if (!viaDirFd) {
       // Bind containment to the opened inode so a path swap cannot validate a
       // different inside path while the handle still refers outside.
-      const resolved = await realpath(path.join(parentReal, name));
+      const resolved = await realpath(path.join(containedParent, name));
       if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
         throw new Error("Path escapes the computer workspace");
       }
@@ -446,6 +449,34 @@ async function openContainedWorkspaceFile(home: string, target: string, mode: nu
   } finally {
     await parentHandle.close().catch(() => undefined);
   }
+}
+
+async function assertContainedDirectoryHandle(
+  handle: Awaited<ReturnType<typeof open>>,
+  pathToRecheck: string,
+  resolvedHome: string,
+  expected?: { dev: number; ino: number },
+) {
+  const after = await handle.stat();
+  if (
+    !after.isDirectory() ||
+    (expected && (after.dev !== expected.dev || after.ino !== expected.ino))
+  ) {
+    throw new Error("Path escapes the computer workspace");
+  }
+  const resolved = await realpath(pathToRecheck);
+  if (!isAllowedDesktopPath(resolved, [resolvedHome])) {
+    throw new Error("Path escapes the computer workspace");
+  }
+  const resolvedStat = await stat(resolved);
+  if (
+    !resolvedStat.isDirectory() ||
+    resolvedStat.dev !== after.dev ||
+    resolvedStat.ino !== after.ino
+  ) {
+    throw new Error("Path escapes the computer workspace");
+  }
+  return resolved;
 }
 
 function childPathViaDirFd(fd: number, name: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,9 @@ importers:
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1(@noble/hashes@2.3.0)
+      koffi:
+        specifier: ^2.9.0
+        version: 2.16.3
       pg:
         specifier: ^8.16.3
         version: 8.23.0
@@ -6182,6 +6185,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  koffi@2.16.3:
+    resolution: {integrity: sha512-E9y1AsgYGlaxMhcZzHr8y96QF2U5XzA12GGVAfbWqIubTwPNMXQarfBzePNXHe0xtIEtNd6ifAv3GAKYGUeBAQ==}
 
   kysely@0.29.5:
     resolution: {integrity: sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==}
@@ -12174,9 +12180,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -15723,6 +15727,8 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  koffi@2.16.3: {}
 
   kysely@0.29.5: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens Windows desktop-sandbox writes so a final symlink/junction (or a parent junction swap) cannot redirect workspace writes outside the computer home.

### Approach

1. **Open without truncate-first** — following a Windows reparse point is non-destructive; identity checks run before any write.
2. **Bind writes to the open handle** — require file identity (`lstat` match, `nlink === 1`) and realpath containment under the sandbox home.
3. **Exclusive create** — missing files use `O_EXCL` / `NtCreateFile(FILE_CREATE)`; reject final symlinks/junctions and Windows-unsafe path forms.
4. **Parent creation without blind recursive mkdir** — walk segments under a held directory handle with containment checks.
5. **Windows openat-style creates** — when Win32 NT APIs are available, mkdir/open/create go through `NtCreateFile` **relative to the parent directory HANDLE** (not a mutable path string after `GetFinalPathName`). `GetFinalPathNameByHandle` is used for fd-bound containment checks and inode-gated cleanup only.
6. **Linux** — mkdir/open via `/proc/self/fd/<parentFd>/…`.

### Tests

- `desktop-sandbox-paths` + `desktop-sandbox-write-containment` (symlink/junction races, hard links, ordinary writes).

### Leftover risk

- Cleanup of failed exclusive creates still uses an inode-gated pathname `unlink`/`rmdir` after resolving the held handle’s path (narrow race if the name is swapped for the same inode — unlikely — or a different inode is left behind).
- Hosts that mock `process.platform === "win32"` without real `ntdll` fall back to the pathname path (unit tests on Linux).

Do not merge until review bots are clear.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-966a117e-19c9-4444-b567-ac76bea7b91f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-966a117e-19c9-4444-b567-ac76bea7b91f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop sandbox validation for Windows paths, including UNC paths, reserved names, trailing spaces, and ambiguous formats.
  * Prevented workspace file writes from escaping permitted locations through symlinks, hard links, or timing-related filesystem changes.
  * Strengthened protection when creating, replacing, or updating workspace files, including safer handling of newly created files and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->