### PR TITLE
Ask which Rakazo instance the desktop app should use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ apps/**/data
 apps/web/dist
 apps/desktop/dist
 apps/desktop/out
+apps/desktop/e2e/screenshots
 apps/mobile/.expo
 apps/mobile/dist
 apps/mobile/ios

--- a/README.md
+++ b/README.md
@@ -89,12 +89,13 @@ pnpm --filter @rakazo/desktop dev
 
 On first run the desktop app asks whether to use the Rakazo stack on this computer
 (`http://127.0.0.1:5173`) or connect to an existing server. Public servers must use HTTPS; HTTP is
-accepted only for loopback and private-network addresses. The app verifies Rakazo's health endpoint
-before saving, and later launches go straight to that instance.
+accepted only for loopback and private LAN addresses (not link-local). The app verifies Rakazo's
+health endpoint before saving, and later launches go straight to that instance.
 
-Use **Change Rakazo Server…** in the application menu to reconnect. For development automation, set
-`RAKAZO_WEB_URL` to point the shell somewhere else without changing the saved instance, or
-`RAKAZO_FORCE_SETUP=1` to run setup again.
+Use **Change Rakazo Server…** in the application menu to reconnect. Closing that window without
+saving returns to the previous instance. For development automation, set `RAKAZO_WEB_URL` to point
+the shell somewhere else without changing the saved instance, or `RAKAZO_FORCE_SETUP=1` to run
+setup again.
 
 Mobile build and release instructions live in [docs/mobile-release.md](./docs/mobile-release.md).
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ With the development stack running, launch Electron with:
 pnpm --filter @rakazo/desktop dev
 ```
 
+On first run the desktop app asks whether to use the Rakazo stack on this computer
+(`http://127.0.0.1:5173`) or connect to an existing server. Public servers must use HTTPS; HTTP is
+accepted only for loopback and private-network addresses. The app verifies Rakazo's health endpoint
+before saving, and later launches go straight to that instance.
+
+Use **Change Rakazo Server…** in the application menu to reconnect. For development automation, set
+`RAKAZO_WEB_URL` to point the shell somewhere else without changing the saved instance, or
+`RAKAZO_FORCE_SETUP=1` to run setup again.
+
 Mobile build and release instructions live in [docs/mobile-release.md](./docs/mobile-release.md).
 
 ## Development

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -227,8 +227,10 @@ test("a session-pending shell skeleton is not accepted as a ready app", async ()
 });
 
 test("a post-session ready app mount is accepted", async () => {
-  const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head>
-<body><div id="root"><div data-rakazo-app-state="ready"><div data-testid="shell-root" data-ready="false">Workspace</div></div></div></body></html>`;
+  const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title>
+<script>performance.mark("rk:renderer:session-committed");performance.mark("rk:renderer:shell-ready");</script>
+</head>
+<body><div id="root"><div data-rakazo-app-state="ready"><div data-testid="shell-root" data-ready="true">Workspace</div></div></div></body></html>`;
   const ready = createServer((request, response) => {
     if (request.url === "/rpc/health" && request.method === "POST") {
       response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
@@ -261,6 +263,43 @@ test("a post-session ready app mount is accepted", async () => {
   } finally {
     await new Promise<void>((resolve, reject) => {
       ready.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("a shell mount before workspace bootstrap is not accepted", async () => {
+  const preBootstrapHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head>
+<body><div id="root"><div data-rakazo-app-state="ready"><div data-testid="shell-root" data-ready="false">Workspace</div></div></div></body></html>`;
+  const preBootstrap = createServer((request, response) => {
+    if (request.url === "/rpc/health" && request.method === "POST") {
+      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(preBootstrapHtml);
+  });
+  await new Promise<void>((resolve) => preBootstrap.listen(0, "127.0.0.1", resolve));
+  const address = preBootstrap.address();
+  if (address === null || typeof address === "string")
+    throw new Error("pre-bootstrap server has no port");
+
+  try {
+    app = await launch();
+    const setup = await app.firstWindow();
+    await setup.getByRole("radio", { name: /Existing instance/ }).check();
+    await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
+    await setup.getByRole("button", { name: "Continue" }).click();
+
+    await expect(setup.locator("#status")).toContainText("Could not open that server.", {
+      timeout: 15_000,
+    });
+    await expect(async () => {
+      await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
+    }).toPass();
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      preBootstrap.close((error) => (error ? reject(error) : resolve()));
     });
   }
 });

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -189,6 +189,81 @@ test("an HTTP error document is not accepted after a healthy probe", async () =>
   }
 });
 
+test("a session-pending shell skeleton is not accepted as a ready app", async () => {
+  const skeletonHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head>
+<body><div id="root"><div data-rakazo-app-state="session-pending"><aside></aside><main><div>Opening your workspace…</div></main></div></div></body></html>`;
+  const skeleton = createServer((request, response) => {
+    if (request.url === "/rpc/health" && request.method === "POST") {
+      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(skeletonHtml);
+  });
+  await new Promise<void>((resolve) => skeleton.listen(0, "127.0.0.1", resolve));
+  const address = skeleton.address();
+  if (address === null || typeof address === "string") throw new Error("skeleton server has no port");
+
+  try {
+    app = await launch();
+    const setup = await app.firstWindow();
+    await setup.getByRole("radio", { name: /Existing instance/ }).check();
+    await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
+    await setup.getByRole("button", { name: "Continue" }).click();
+
+    await expect(setup.locator("#status")).toContainText("Could not open that server.", {
+      timeout: 15_000,
+    });
+    await expect(async () => {
+      await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
+    }).toPass();
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      skeleton.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("a post-session ready app mount is accepted", async () => {
+  const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head>
+<body><div id="root"><div data-rakazo-app-state="ready"><div data-testid="shell-root" data-ready="false">Workspace</div></div></div></body></html>`;
+  const ready = createServer((request, response) => {
+    if (request.url === "/rpc/health" && request.method === "POST") {
+      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(readyHtml);
+  });
+  await new Promise<void>((resolve) => ready.listen(0, "127.0.0.1", resolve));
+  const address = ready.address();
+  if (address === null || typeof address === "string") throw new Error("ready server has no port");
+
+  try {
+    app = await launch();
+    const setup = await app.firstWindow();
+    await setup.getByRole("radio", { name: /Existing instance/ }).check();
+    await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
+    const appWindow = await Promise.all([
+      app.waitForEvent("window"),
+      setup.getByRole("button", { name: "Continue" }).click(),
+    ]).then(([window]) => window);
+
+    await expect(appWindow.getByTestId("shell-root")).toBeVisible();
+    const saved = JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
+    expect(saved).toEqual({
+      mode: "existing",
+      serverUrl: `http://127.0.0.1:${address.port}`,
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      ready.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test("a malformed address is rejected before anything is written", async () => {
   app = await launch();
   const setup = await app.firstWindow();

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { type ElectronApplication, _electron as electron, expect, test } from "@playwright/test";
+
+const APP_MARKER = "Existing Rakazo instance ready";
+
+let server: Server;
+let serverUrl: string;
+let closedUrl: string;
+let userData: string;
+let app: ElectronApplication | undefined;
+
+/** A port nothing listens on, so a connection attempt is refused rather than blocked. */
+async function reserveClosedPort() {
+  const probe = createServer();
+  await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+  const address = probe.address();
+  if (address === null || typeof address === "string") throw new Error("probe has no port");
+  const { port } = address;
+  await new Promise<void>((resolve, reject) => {
+    probe.close((error) => (error ? reject(error) : resolve()));
+  });
+  return `http://127.0.0.1:${port}`;
+}
+
+test.beforeAll(async () => {
+  server = createServer((request, response) => {
+    if (request.url === "/rpc/health" && request.method === "POST") {
+      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(
+      `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head><body><main>${APP_MARKER}</main></body></html>`,
+    );
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("stub server has no port");
+  serverUrl = `http://127.0.0.1:${address.port}`;
+  closedUrl = await reserveClosedPort();
+});
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test.beforeEach(async () => {
+  userData = await mkdtemp(path.join(tmpdir(), "rakazo-desktop-e2e-"));
+});
+
+test.afterEach(async () => {
+  await app?.close();
+  app = undefined;
+  await rm(userData, { recursive: true, force: true });
+});
+
+function launch(extraEnv: Record<string, string> = {}) {
+  const env = { ...process.env, RAKAZO_PERFORMANCE_USER_DATA: userData };
+  // A stale RAKAZO_WEB_URL from the developer's shell would bypass setup entirely.
+  delete env.RAKAZO_WEB_URL;
+  return electron.launch({
+    args: ["."],
+    cwd: path.resolve(import.meta.dirname, ".."),
+    env: { ...env, ...extraEnv },
+  });
+}
+
+test("first run asks whether to use a local or existing instance", async () => {
+  app = await launch();
+  const setup = await app.firstWindow();
+
+  await expect(setup.getByRole("heading", { name: "Welcome to Rakazo" })).toBeVisible();
+  await expect(setup.getByText("Use an instance on this computer")).toBeVisible();
+  await expect(setup.getByText("Connect to an existing instance")).toBeVisible();
+
+  // A new instance is the default and points at the local development stack.
+  await expect(
+    setup.getByRole("radio", { name: /Use an instance on this computer/ }),
+  ).toBeChecked();
+  await expect(setup.locator("#local-url")).toHaveValue("http://127.0.0.1:5173");
+  await expect(setup.locator("#panel-existing")).toBeHidden();
+
+  await setup.screenshot({ path: "e2e/screenshots/01-setup-new-instance.png" });
+});
+
+test("connecting to an existing instance verifies, saves, and opens it", async () => {
+  app = await launch();
+  const setup = await app.firstWindow();
+
+  await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+  await expect(setup.locator("#panel-new")).toBeHidden();
+
+  await setup.locator("#server-url").fill(serverUrl);
+  await setup.getByRole("button", { name: "Check connection" }).click();
+  await expect(setup.locator("#status")).toHaveText(`Rakazo answered at ${serverUrl}.`);
+  await expect(setup.locator("#status")).toHaveAttribute("data-tone", "ok");
+
+  await setup.screenshot({ path: "e2e/screenshots/02-setup-existing-verified.png" });
+
+  const appWindow = await Promise.all([
+    app.waitForEvent("window"),
+    setup.getByRole("button", { name: "Continue" }).click(),
+  ]).then(([window]) => window);
+
+  await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
+  await appWindow.screenshot({ path: "e2e/screenshots/03-connected-instance.png" });
+
+  const saved = JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
+  expect(saved).toEqual({ mode: "existing", serverUrl });
+});
+
+test("Continue verifies and remembers the instance so setup does not run again", async () => {
+  app = await launch();
+  const setup = await app.firstWindow();
+  await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+  await setup.locator("#server-url").fill(serverUrl);
+  const firstRun = await Promise.all([
+    app.waitForEvent("window"),
+    setup.getByRole("button", { name: "Continue" }).click(),
+  ]).then(([window]) => window);
+  await expect(firstRun.getByText(APP_MARKER)).toBeVisible();
+  await app.close();
+
+  app = await launch();
+  const relaunched = await app.firstWindow();
+  await expect(relaunched.getByText(APP_MARKER)).toBeVisible();
+  await expect(relaunched.locator("#setup")).toHaveCount(0);
+});
+
+test("an unreachable address is reported instead of being saved", async () => {
+  app = await launch();
+  const setup = await app.firstWindow();
+
+  await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+  await setup.locator("#server-url").fill(closedUrl);
+  await setup.getByRole("button", { name: "Check connection" }).click();
+
+  await expect(setup.locator("#status")).toHaveAttribute("data-tone", "error");
+  await expect(setup.locator("#status")).toHaveText("Nothing is listening at that address yet.");
+  await setup.getByRole("button", { name: "Continue" }).click();
+  await expect(setup.locator("#status")).toHaveText("Nothing is listening at that address yet.");
+  await expect(async () => {
+    await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
+  }).toPass();
+  await setup.screenshot({ path: "e2e/screenshots/04-setup-unreachable.png" });
+});
+
+test("a malformed address is rejected before anything is written", async () => {
+  app = await launch();
+  const setup = await app.firstWindow();
+
+  await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+  await setup.locator("#server-url").fill("not a server");
+  await setup.getByRole("button", { name: "Continue" }).click();
+
+  await expect(setup.locator("#status")).toContainText("Enter a valid server address.");
+  await expect(async () => {
+    await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
+  }).toPass();
+});
+
+test("a generic web page is not accepted as a Rakazo server", async () => {
+  const plain = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end("<!doctype html><p>not Rakazo</p>");
+  });
+  await new Promise<void>((resolve) => plain.listen(0, "127.0.0.1", resolve));
+  const address = plain.address();
+  if (address === null || typeof address === "string") throw new Error("plain server has no port");
+
+  try {
+    app = await launch();
+    const setup = await app.firstWindow();
+    await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+    await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
+    await setup.getByRole("button", { name: "Continue" }).click();
+
+    await expect(setup.locator("#status")).toHaveText(
+      "That address did not respond like a Rakazo server.",
+    );
+    await expect(async () => {
+      await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
+    }).toPass();
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      plain.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("the setup probe refuses redirects instead of following them", async () => {
+  const redirect = createServer((_request, response) => {
+    response.writeHead(302, { location: `${serverUrl}/rpc/health` });
+    response.end();
+  });
+  await new Promise<void>((resolve) => redirect.listen(0, "127.0.0.1", resolve));
+  const address = redirect.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("redirect server has no port");
+  }
+
+  try {
+    app = await launch();
+    const setup = await app.firstWindow();
+    await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+    await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
+    await setup.getByRole("button", { name: "Continue" }).click();
+
+    await expect(setup.locator("#status")).toHaveText("Could not reach that address.");
+    await expect(async () => {
+      await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
+    }).toPass();
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      redirect.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("an unreachable saved server falls back to setup with a recovery message", async () => {
+  await writeFile(
+    path.join(userData, "setup.json"),
+    `${JSON.stringify({ mode: "existing", serverUrl: closedUrl }, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+
+  app = await launch();
+  const setup = await app.firstWindow();
+
+  await expect(setup.getByRole("heading", { name: "Welcome to Rakazo" })).toBeVisible();
+  await expect(setup.getByRole("radio", { name: /Connect to an existing instance/ })).toBeChecked();
+  await expect(setup.locator("#server-url")).toHaveValue(closedUrl);
+  await expect(setup.locator("#status")).toContainText("Could not reconnect to the saved server.");
+  await setup.screenshot({ path: "e2e/screenshots/05-saved-server-recovery.png" });
+});
+
+test("the native application menu can reopen setup without exposing setup IPC to the server", async () => {
+  app = await launch({ RAKAZO_WEB_URL: serverUrl });
+  const appWindow = await app.firstWindow();
+  await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
+
+  const setupPromise = app.waitForEvent("window");
+  await app.evaluate(({ Menu }) => {
+    const item = Menu.getApplicationMenu()?.getMenuItemById("change-rakazo-server");
+    if (!item) throw new Error("Change server menu item is missing");
+    item.click();
+  });
+  const setup = await setupPromise;
+
+  await expect(setup.getByRole("heading", { name: "Welcome to Rakazo" })).toBeVisible();
+  await expect(setup.locator("#status")).toBeEmpty();
+});
+
+test("servers on the same host but different ports do not share login cookies", async () => {
+  const first = createServer((_request, response) => {
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "set-cookie": "rakazo_session=fake-one; Path=/; SameSite=Lax",
+    });
+    response.end("<!doctype html><main>Cookie stored</main>");
+  });
+  const second = createServer((request, response) => {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html><main>Cookies: ${request.headers.cookie ?? "none"}</main>`);
+  });
+  await Promise.all([
+    new Promise<void>((resolve) => first.listen(0, "127.0.0.1", resolve)),
+    new Promise<void>((resolve) => second.listen(0, "127.0.0.1", resolve)),
+  ]);
+  const firstAddress = first.address();
+  const secondAddress = second.address();
+  if (
+    firstAddress === null ||
+    typeof firstAddress === "string" ||
+    secondAddress === null ||
+    typeof secondAddress === "string"
+  ) {
+    throw new Error("cookie fixture server has no port");
+  }
+
+  try {
+    app = await launch({ RAKAZO_WEB_URL: `http://127.0.0.1:${firstAddress.port}` });
+    const firstWindow = await app.firstWindow();
+    await expect(firstWindow.getByText("Cookie stored")).toBeVisible();
+    await expect.poll(() => firstWindow.evaluate(() => document.cookie)).toContain("fake-one");
+    await app.close();
+
+    app = await launch({ RAKAZO_WEB_URL: `http://127.0.0.1:${secondAddress.port}` });
+    const secondWindow = await app.firstWindow();
+    await expect(secondWindow.getByText("Cookies: none")).toBeVisible();
+  } finally {
+    await Promise.all([
+      new Promise<void>((resolve, reject) =>
+        first.close((error) => (error ? reject(error) : resolve())),
+      ),
+      new Promise<void>((resolve, reject) =>
+        second.close((error) => (error ? reject(error) : resolve())),
+      ),
+    ]);
+  }
+});
+
+test("setup IPC is not reachable from the connected app window", async () => {
+  app = await launch({ RAKAZO_WEB_URL: serverUrl });
+  const appWindow = await app.firstWindow();
+  await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
+
+  const exposed = await appWindow.evaluate(() =>
+    Object.keys((window as typeof window & { rakazoSetup?: unknown }).rakazoSetup ?? {}),
+  );
+  expect(exposed).toEqual([]);
+});

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -80,9 +80,7 @@ test("first run asks whether to use a local or existing instance", async () => {
   await expect(setup.getByText("Existing instance")).toBeVisible();
 
   // A new instance is the default and points at the local development stack.
-  await expect(
-    setup.getByRole("radio", { name: /This computer/ }),
-  ).toBeChecked();
+  await expect(setup.getByRole("radio", { name: /This computer/ })).toBeChecked();
   await expect(setup.locator("#local-url")).toHaveValue("http://127.0.0.1:5173");
   await expect(setup.locator("#panel-existing")).toBeHidden();
 
@@ -212,9 +210,9 @@ test("the setup probe refuses redirects instead of following them", async () => 
     await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
     await setup.getByRole("button", { name: "Continue" }).click();
 
-    await expect(setup.locator("#status")).toHaveText(
-      "That address redirects elsewhere. Enter the final Rakazo server address.",
-    );
+    // Electron's net.fetch with redirect:"manual" surfaces redirects as a
+    // network failure rather than an HTTP 3xx body we can classify.
+    await expect(setup.locator("#status")).toHaveText("Could not reach that address.");
     await expect(async () => {
       await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
     }).toPass();

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -76,12 +76,12 @@ test("first run asks whether to use a local or existing instance", async () => {
   const setup = await app.firstWindow();
 
   await expect(setup.getByRole("heading", { name: "Welcome to Rakazo" })).toBeVisible();
-  await expect(setup.getByText("Use an instance on this computer")).toBeVisible();
-  await expect(setup.getByText("Connect to an existing instance")).toBeVisible();
+  await expect(setup.getByText("This computer")).toBeVisible();
+  await expect(setup.getByText("Existing instance")).toBeVisible();
 
   // A new instance is the default and points at the local development stack.
   await expect(
-    setup.getByRole("radio", { name: /Use an instance on this computer/ }),
+    setup.getByRole("radio", { name: /This computer/ }),
   ).toBeChecked();
   await expect(setup.locator("#local-url")).toHaveValue("http://127.0.0.1:5173");
   await expect(setup.locator("#panel-existing")).toBeHidden();
@@ -93,7 +93,7 @@ test("connecting to an existing instance verifies, saves, and opens it", async (
   app = await launch();
   const setup = await app.firstWindow();
 
-  await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+  await setup.getByRole("radio", { name: /Existing instance/ }).check();
   await expect(setup.locator("#panel-new")).toBeHidden();
 
   await setup.locator("#server-url").fill(serverUrl);
@@ -118,7 +118,7 @@ test("connecting to an existing instance verifies, saves, and opens it", async (
 test("Continue verifies and remembers the instance so setup does not run again", async () => {
   app = await launch();
   const setup = await app.firstWindow();
-  await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+  await setup.getByRole("radio", { name: /Existing instance/ }).check();
   await setup.locator("#server-url").fill(serverUrl);
   const firstRun = await Promise.all([
     app.waitForEvent("window"),
@@ -137,7 +137,7 @@ test("an unreachable address is reported instead of being saved", async () => {
   app = await launch();
   const setup = await app.firstWindow();
 
-  await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+  await setup.getByRole("radio", { name: /Existing instance/ }).check();
   await setup.locator("#server-url").fill(closedUrl);
   await setup.getByRole("button", { name: "Check connection" }).click();
 
@@ -155,7 +155,7 @@ test("a malformed address is rejected before anything is written", async () => {
   app = await launch();
   const setup = await app.firstWindow();
 
-  await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+  await setup.getByRole("radio", { name: /Existing instance/ }).check();
   await setup.locator("#server-url").fill("not a server");
   await setup.getByRole("button", { name: "Continue" }).click();
 
@@ -177,7 +177,7 @@ test("a generic web page is not accepted as a Rakazo server", async () => {
   try {
     app = await launch();
     const setup = await app.firstWindow();
-    await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+    await setup.getByRole("radio", { name: /Existing instance/ }).check();
     await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
     await setup.getByRole("button", { name: "Continue" }).click();
 
@@ -208,11 +208,13 @@ test("the setup probe refuses redirects instead of following them", async () => 
   try {
     app = await launch();
     const setup = await app.firstWindow();
-    await setup.getByRole("radio", { name: /Connect to an existing instance/ }).check();
+    await setup.getByRole("radio", { name: /Existing instance/ }).check();
     await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
     await setup.getByRole("button", { name: "Continue" }).click();
 
-    await expect(setup.locator("#status")).toHaveText("Could not reach that address.");
+    await expect(setup.locator("#status")).toHaveText(
+      "That address redirects elsewhere. Enter the final Rakazo server address.",
+    );
     await expect(async () => {
       await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
     }).toPass();
@@ -234,7 +236,7 @@ test("an unreachable saved server falls back to setup with a recovery message", 
   const setup = await app.firstWindow();
 
   await expect(setup.getByRole("heading", { name: "Welcome to Rakazo" })).toBeVisible();
-  await expect(setup.getByRole("radio", { name: /Connect to an existing instance/ })).toBeChecked();
+  await expect(setup.getByRole("radio", { name: /Existing instance/ })).toBeChecked();
   await expect(setup.locator("#server-url")).toHaveValue(closedUrl);
   await expect(setup.locator("#status")).toContainText("Could not reconnect to the saved server.");
   await setup.screenshot({ path: "e2e/screenshots/05-saved-server-recovery.png" });
@@ -255,6 +257,10 @@ test("the native application menu can reopen setup without exposing setup IPC to
 
   await expect(setup.getByRole("heading", { name: "Welcome to Rakazo" })).toBeVisible();
   await expect(setup.locator("#status")).toBeEmpty();
+
+  // Closing setup without saving restores the connected instance.
+  await setup.close();
+  await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
 });
 
 test("servers on the same host but different ports do not share login cookies", async () => {

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -157,6 +157,38 @@ test("an unreachable address is reported instead of being saved", async () => {
   });
 });
 
+test("an HTTP error document is not accepted after a healthy probe", async () => {
+  const broken = createServer((request, response) => {
+    if (request.url === "/rpc/health" && request.method === "POST") {
+      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
+      return;
+    }
+    response.writeHead(503, { "content-type": "text/html; charset=utf-8" });
+    response.end("<!doctype html><html><body><h1>Unavailable</h1></body></html>");
+  });
+  await new Promise<void>((resolve) => broken.listen(0, "127.0.0.1", resolve));
+  const address = broken.address();
+  if (address === null || typeof address === "string") throw new Error("broken server has no port");
+
+  try {
+    app = await launch();
+    const setup = await app.firstWindow();
+    await setup.getByRole("radio", { name: /Existing instance/ }).check();
+    await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
+    await setup.getByRole("button", { name: "Continue" }).click();
+
+    await expect(setup.locator("#status")).toContainText("Could not open that server.");
+    await expect(async () => {
+      await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
+    }).toPass();
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      broken.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test("a malformed address is rejected before anything is written", async () => {
   app = await launch();
   const setup = await app.firstWindow();

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -84,7 +84,7 @@ test("first run asks whether to use a local or existing instance", async () => {
   await expect(setup.locator("#local-url")).toHaveValue("http://127.0.0.1:5173");
   await expect(setup.locator("#panel-existing")).toBeHidden();
 
-  await setup.screenshot({ path: "e2e/screenshots/01-setup-new-instance.png" });
+  await setup.screenshot({ path: path.join(import.meta.dirname, "screenshots", "01-setup-new-instance.png") });
 });
 
 test("connecting to an existing instance verifies, saves, and opens it", async () => {
@@ -99,7 +99,7 @@ test("connecting to an existing instance verifies, saves, and opens it", async (
   await expect(setup.locator("#status")).toHaveText(`Rakazo answered at ${serverUrl}.`);
   await expect(setup.locator("#status")).toHaveAttribute("data-tone", "ok");
 
-  await setup.screenshot({ path: "e2e/screenshots/02-setup-existing-verified.png" });
+  await setup.screenshot({ path: path.join(import.meta.dirname, "screenshots", "02-setup-existing-verified.png") });
 
   const appWindow = await Promise.all([
     app.waitForEvent("window"),
@@ -107,7 +107,7 @@ test("connecting to an existing instance verifies, saves, and opens it", async (
   ]).then(([window]) => window);
 
   await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
-  await appWindow.screenshot({ path: "e2e/screenshots/03-connected-instance.png" });
+  await appWindow.screenshot({ path: path.join(import.meta.dirname, "screenshots", "03-connected-instance.png") });
 
   const saved = JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
   expect(saved).toEqual({ mode: "existing", serverUrl });
@@ -146,7 +146,7 @@ test("an unreachable address is reported instead of being saved", async () => {
   await expect(async () => {
     await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
   }).toPass();
-  await setup.screenshot({ path: "e2e/screenshots/04-setup-unreachable.png" });
+  await setup.screenshot({ path: path.join(import.meta.dirname, "screenshots", "04-setup-unreachable.png") });
 });
 
 test("a malformed address is rejected before anything is written", async () => {
@@ -237,7 +237,7 @@ test("an unreachable saved server falls back to setup with a recovery message", 
   await expect(setup.getByRole("radio", { name: /Existing instance/ })).toBeChecked();
   await expect(setup.locator("#server-url")).toHaveValue(closedUrl);
   await expect(setup.locator("#status")).toContainText("Could not reconnect to the saved server.");
-  await setup.screenshot({ path: "e2e/screenshots/05-saved-server-recovery.png" });
+  await setup.screenshot({ path: path.join(import.meta.dirname, "screenshots", "05-saved-server-recovery.png") });
 });
 
 test("the native application menu can reopen setup without exposing setup IPC to the server", async () => {

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -203,7 +203,8 @@ test("a session-pending shell skeleton is not accepted as a ready app", async ()
   });
   await new Promise<void>((resolve) => skeleton.listen(0, "127.0.0.1", resolve));
   const address = skeleton.address();
-  if (address === null || typeof address === "string") throw new Error("skeleton server has no port");
+  if (address === null || typeof address === "string")
+    throw new Error("skeleton server has no port");
 
   try {
     app = await launch();

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -84,7 +84,9 @@ test("first run asks whether to use a local or existing instance", async () => {
   await expect(setup.locator("#local-url")).toHaveValue("http://127.0.0.1:5173");
   await expect(setup.locator("#panel-existing")).toBeHidden();
 
-  await setup.screenshot({ path: path.join(import.meta.dirname, "screenshots", "01-setup-new-instance.png") });
+  await setup.screenshot({
+    path: path.join(import.meta.dirname, "screenshots", "01-setup-new-instance.png"),
+  });
 });
 
 test("connecting to an existing instance verifies, saves, and opens it", async () => {
@@ -99,7 +101,9 @@ test("connecting to an existing instance verifies, saves, and opens it", async (
   await expect(setup.locator("#status")).toHaveText(`Rakazo answered at ${serverUrl}.`);
   await expect(setup.locator("#status")).toHaveAttribute("data-tone", "ok");
 
-  await setup.screenshot({ path: path.join(import.meta.dirname, "screenshots", "02-setup-existing-verified.png") });
+  await setup.screenshot({
+    path: path.join(import.meta.dirname, "screenshots", "02-setup-existing-verified.png"),
+  });
 
   const appWindow = await Promise.all([
     app.waitForEvent("window"),
@@ -107,7 +111,9 @@ test("connecting to an existing instance verifies, saves, and opens it", async (
   ]).then(([window]) => window);
 
   await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
-  await appWindow.screenshot({ path: path.join(import.meta.dirname, "screenshots", "03-connected-instance.png") });
+  await appWindow.screenshot({
+    path: path.join(import.meta.dirname, "screenshots", "03-connected-instance.png"),
+  });
 
   const saved = JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
   expect(saved).toEqual({ mode: "existing", serverUrl });
@@ -146,7 +152,9 @@ test("an unreachable address is reported instead of being saved", async () => {
   await expect(async () => {
     await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
   }).toPass();
-  await setup.screenshot({ path: path.join(import.meta.dirname, "screenshots", "04-setup-unreachable.png") });
+  await setup.screenshot({
+    path: path.join(import.meta.dirname, "screenshots", "04-setup-unreachable.png"),
+  });
 });
 
 test("a malformed address is rejected before anything is written", async () => {
@@ -237,7 +245,9 @@ test("an unreachable saved server falls back to setup with a recovery message", 
   await expect(setup.getByRole("radio", { name: /Existing instance/ })).toBeChecked();
   await expect(setup.locator("#server-url")).toHaveValue(closedUrl);
   await expect(setup.locator("#status")).toContainText("Could not reconnect to the saved server.");
-  await setup.screenshot({ path: path.join(import.meta.dirname, "screenshots", "05-saved-server-recovery.png") });
+  await setup.screenshot({
+    path: path.join(import.meta.dirname, "screenshots", "05-saved-server-recovery.png"),
+  });
 });
 
 test("the native application menu can reopen setup without exposing setup IPC to the server", async () => {

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -227,7 +227,9 @@ test("a session-pending shell skeleton is not accepted as a ready app", async ()
 });
 
 test("a post-session ready app mount is accepted", async () => {
-  const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head>
+  const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title>
+<script>performance.mark("rk:renderer:session-committed");performance.mark("rk:renderer:shell-ready");</script>
+</head>
 <body><div id="root"><div data-rakazo-app-state="ready"><div data-testid="shell-root" data-ready="false">Workspace</div></div></div></body></html>`;
   const ready = createServer((request, response) => {
     if (request.url === "/rpc/health" && request.method === "POST") {

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -227,9 +227,7 @@ test("a session-pending shell skeleton is not accepted as a ready app", async ()
 });
 
 test("a post-session ready app mount is accepted", async () => {
-  const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title>
-<script>performance.mark("rk:renderer:session-committed");performance.mark("rk:renderer:shell-ready");</script>
-</head>
+  const readyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head>
 <body><div id="root"><div data-rakazo-app-state="ready"><div data-testid="shell-root" data-ready="false">Workspace</div></div></div></body></html>`;
   const ready = createServer((request, response) => {
     if (request.url === "/rpc/health" && request.method === "POST") {
@@ -263,6 +261,43 @@ test("a post-session ready app mount is accepted", async () => {
   } finally {
     await new Promise<void>((resolve, reject) => {
       ready.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("a session-ready marker without a route surface is not accepted", async () => {
+  const emptyReadyHtml = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Rakazo</title></head>
+<body><div id="root"><div data-rakazo-app-state="ready" class="h-full"></div></div></body></html>`;
+  const emptyReady = createServer((request, response) => {
+    if (request.url === "/rpc/health" && request.method === "POST") {
+      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(emptyReadyHtml);
+  });
+  await new Promise<void>((resolve) => emptyReady.listen(0, "127.0.0.1", resolve));
+  const address = emptyReady.address();
+  if (address === null || typeof address === "string")
+    throw new Error("empty-ready server has no port");
+
+  try {
+    app = await launch();
+    const setup = await app.firstWindow();
+    await setup.getByRole("radio", { name: /Existing instance/ }).check();
+    await setup.locator("#server-url").fill(`http://127.0.0.1:${address.port}`);
+    await setup.getByRole("button", { name: "Continue" }).click();
+
+    await expect(setup.locator("#status")).toContainText("Could not open that server.", {
+      timeout: 15_000,
+    });
+    await expect(async () => {
+      await expect(readFile(path.join(userData, "setup.json"), "utf8")).rejects.toThrow();
+    }).toPass();
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      emptyReady.close((error) => (error ? reject(error) : resolve()));
     });
   }
 });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "main": "dist/main.js",
   "scripts": {
     "dev": "pnpm build && electron .",
-    "build": "tsc -p tsconfig.json && cp src/preload.cjs dist/preload.cjs",
+    "build": "tsc -p tsconfig.json && node scripts/copy-static.mjs",
     "pack": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --mac --win --linux",
     "pack:dir": "pnpm --filter @rakazo/web build && pnpm build && electron-builder --dir",
     "check": "tsc --noEmit -p tsconfig.json",

--- a/apps/desktop/scripts/copy-static.mjs
+++ b/apps/desktop/scripts/copy-static.mjs
@@ -1,0 +1,15 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// tsc only emits the TypeScript sources; the preload bridges and the setup
+// window's static assets have to be copied into dist alongside them.
+const STATIC_FILES = ["preload.cjs", "setup-preload.cjs", "setup.html", "setup.css", "setup.js"];
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const dist = path.join(root, "dist");
+
+await mkdir(dist, { recursive: true });
+await Promise.all(
+  STATIC_FILES.map((file) => copyFile(path.join(root, "src", file), path.join(dist, file))),
+);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -21,7 +21,7 @@ import {
   servesBundledRenderer,
   sessionPartitionForServerUrl,
 } from "./setup-config.js";
-import { readSetup, writeSetup } from "./setup-store.js";
+import { clearSetup, readSetup, writeSetup } from "./setup-store.js";
 import { browserWindowOptions, setupWindowOptions, warmWindowTtlMs } from "./window-options.js";
 
 const PERFORMANCE_USER_DATA = process.env.RAKAZO_PERFORMANCE_USER_DATA;
@@ -761,6 +761,12 @@ app.whenReady().then(async () => {
         await writeSetup(userDataDir, setup);
         if (rendererWatch?.crashed()) {
           abandonPendingAppSwitch(previousSetup, previousUrl);
+          try {
+            if (previousSetup !== null) await writeSetup(userDataDir, previousSetup);
+            else await clearSetup(userDataDir);
+          } catch {
+            // Best-effort disk rollback; in-memory session already restored.
+          }
           return {
             ok: false,
             error: "Could not open that server. Renderer stopped.",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -780,11 +780,19 @@ app.whenReady().then(async () => {
         // Commit while the crash listener is still armed, then dispose.
         commitPendingAppSwitch();
         if (rendererWatch?.crashed()) {
-          // Previous window is already gone; still roll back disk for next launch.
+          // Previous window is already gone; roll back disk and drop the dead window
+          // so setup can reconnect to the restored saved instance.
           await rollbackSetupFile(userDataDir, previousSetup);
+          currentSetup = previousSetup;
+          currentTargetUrl = previousUrl;
+          if (mainWindow !== null && !mainWindow.isDestroyed()) mainWindow.destroy();
+          mainWindow = null;
           return {
             ok: false,
-            error: "Could not open that server. Renderer stopped.",
+            error:
+              previousSetup !== null
+                ? "Could not open that server. Renderer stopped. The previous instance was restored for the next launch."
+                : "Could not open that server. Renderer stopped.",
           };
         }
       } catch {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -75,8 +75,9 @@ function legacyDefaultSessionFlag(partition: string) {
 }
 
 /**
- * Prefer the default session for origins that already have cookies there so
- * upgrades keep localStorage/IndexedDB. New origins get an isolated partition.
+ * Prefer the default session when that origin already has cookies or site
+ * storage there, so upgrades keep localStorage/IndexedDB. Fresh origins get
+ * an isolated partition.
  */
 async function resolveSessionForTarget(targetUrl: string) {
   const partition = sessionPartitionKey(targetUrl);
@@ -95,10 +96,66 @@ async function resolveSessionForTarget(targetUrl: string) {
         return { partition: null, value: session.defaultSession };
       }
     } catch {
-      // Fall through to an isolated partition.
+      // Continue with a storage probe when the profile looks pre-partition.
+    }
+    if (defaultSessionProfileExists() && (await defaultSessionHasOriginData(origin))) {
+      try {
+        await writeFile(legacyDefaultSessionFlag(partition), new Date().toISOString(), "utf8");
+      } catch {
+        // Flag is best-effort; still stay on the default session this launch.
+      }
+      return { partition: null, value: session.defaultSession };
     }
   }
   return { partition, value: session.fromPartition(partition) };
+}
+
+function defaultSessionProfileExists() {
+  const root = app.getPath("userData");
+  return (
+    existsSync(path.join(root, "Local Storage")) ||
+    existsSync(path.join(root, "IndexedDB")) ||
+    existsSync(path.join(root, "Cookies")) ||
+    existsSync(path.join(root, "Network", "Cookies")) ||
+    existsSync(path.join(root, "Cache Storage"))
+  );
+}
+
+/** Page storage in the default session means a pre-partition install for this origin. */
+async function defaultSessionHasOriginData(origin: string): Promise<boolean> {
+  const probe = new BrowserWindow({
+    show: false,
+    width: 1,
+    height: 1,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+    },
+  });
+  try {
+    await probe.loadURL(origin);
+    return (await probe.webContents.executeJavaScript(`(async () => {
+      if (localStorage.length > 0 || sessionStorage.length > 0) return true;
+      if (typeof indexedDB !== "undefined" && indexedDB.databases) {
+        try {
+          const databases = await indexedDB.databases();
+          if (databases.length > 0) return true;
+        } catch {}
+      }
+      if (typeof caches !== "undefined") {
+        try {
+          const keys = await caches.keys();
+          if (keys.length > 0) return true;
+        } catch {}
+      }
+      return false;
+    })()`)) as boolean;
+  } catch {
+    return false;
+  } finally {
+    if (!probe.isDestroyed()) probe.destroy();
+  }
 }
 
 function createWindow(url: string, partition: string | null) {
@@ -787,13 +844,13 @@ app.whenReady().then(async () => {
           currentTargetUrl = previousUrl;
           if (mainWindow !== null && !mainWindow.isDestroyed()) mainWindow.destroy();
           mainWindow = null;
-          return {
-            ok: false,
-            error:
-              previousSetup !== null
-                ? "Could not open that server. Renderer stopped. The previous instance was restored for the next launch."
-                : "Could not open that server. Renderer stopped.",
-          };
+          const message =
+            previousSetup !== null
+              ? "Could not open that server. Renderer stopped. The previous instance was restored for the next launch."
+              : "Could not open that server. Renderer stopped.";
+          // Setup may already be closed (user dismissed it during write); reopen it.
+          showSetupWindow(message);
+          return { ok: false, error: message };
         }
       } catch {
         const outcome = abandonPendingAppSwitch(previousSetup, previousUrl);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -344,9 +344,10 @@ function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
 
 /**
  * Empty `#root` shells and session-pending skeletons count as loaded HTML but are
- * not a usable app. After session resolves, also wait for a real route surface
- * (shell / auth / welcome / onboarding) so a bare Suspense fallback cannot pass.
- * Plain e2e fixtures omit the Rakazo app-state marker.
+ * not a usable app. After session resolves, wait for a bootstrapped shell
+ * (`data-ready` / shell-ready mark) or an auth/welcome/onboarding surface so a
+ * bare Suspense fallback or pre-bootstrap ShellPage cannot pass. Plain e2e
+ * fixtures omit the Rakazo app-state marker.
  */
 async function waitForMountedAppDocument(contents: Electron.WebContents) {
   const deadline = Date.now() + 8_000;
@@ -358,11 +359,15 @@ async function waitForMountedAppDocument(contents: Electron.WebContents) {
         null;
       if (appState === "session-pending") return false;
 
-      const surfaceReady = Boolean(
-        document.querySelector('[data-testid="shell-root"]') ||
-          document.querySelector(
-            'form input[type="email"], form input[name="email"], form input#email',
-          ) ||
+      const shell = document.querySelector('[data-testid="shell-root"]');
+      const shellBootstrapped = Boolean(
+        (shell && shell.getAttribute("data-ready") === "true") ||
+          performance.getEntriesByName("rk:renderer:shell-ready").length > 0,
+      );
+      const authOrWelcomeSurface = Boolean(
+        document.querySelector(
+          'form input[type="email"], form input[name="email"], form input#email',
+        ) ||
           Array.from(document.querySelectorAll("button")).some((button) =>
             /sign\\s*in/i.test((button.textContent || "").trim()),
           ) ||
@@ -370,6 +375,7 @@ async function waitForMountedAppDocument(contents: Electron.WebContents) {
             '[aria-label="Model"], [aria-label="Model id"], [aria-label="Models from server"]',
           ),
       );
+      const surfaceReady = shellBootstrapped || authOrWelcomeSurface;
       const sessionReady =
         appState === "ready" ||
         performance.getEntriesByName("rk:renderer:session-committed").length > 0;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import { app, BrowserWindow, ipcMain, net, session } from "electron";
+import type { DesktopReachability, DesktopSetup } from "@rakazo/contracts";
+import { app, BrowserWindow, ipcMain, Menu, net, type Session, session, shell } from "electron";
 import {
   bundledRendererCandidates,
   contentType,
@@ -9,11 +10,31 @@ import {
   immutableRendererAsset,
   isRendererAssetMiss,
 } from "./renderer-assets.js";
-import { browserWindowOptions, warmWindowTtlMs } from "./window-options.js";
+import {
+  DEFAULT_LOCAL_WEB_URL,
+  isRakazoHealth,
+  normalizeServerUrl,
+  parseSetupInput,
+  probeFailureMessage,
+  resolveStartupTarget,
+  safeExternalUrl,
+  servesBundledRenderer,
+  sessionPartitionForServerUrl,
+} from "./setup-config.js";
+import { readSetup, writeSetup } from "./setup-store.js";
+import { browserWindowOptions, setupWindowOptions, warmWindowTtlMs } from "./window-options.js";
 
-const WEB_URL = process.env.RAKAZO_WEB_URL ?? "http://127.0.0.1:5173";
 const PERFORMANCE_USER_DATA = process.env.RAKAZO_PERFORMANCE_USER_DATA;
+const PROBE_TIMEOUT_MS = 8_000;
+const PROBE_RESPONSE_LIMIT_BYTES = 64 * 1024;
 let mainWindow: BrowserWindow | null = null;
+let setupWindow: BrowserWindow | null = null;
+const bundledRendererInstallations = new Set<string>();
+let currentSetup: DesktopSetup | null = null;
+let currentTargetUrl: string | null = null;
+let setupError: string | null = null;
+let setupSaveInProgress = false;
+let openAppPromise: Promise<boolean> | null = null;
 let quitting = false;
 let warmWindowTimer: NodeJS.Timeout | undefined;
 const WARM_WINDOW_TTL_MS = warmWindowTtlMs(process.env.RAKAZO_WARM_WINDOW_TTL_MS);
@@ -40,7 +61,15 @@ function developmentIcon() {
   return existsSync(icon) ? icon : undefined;
 }
 
-function createWindow() {
+function sessionForTarget(targetUrl: string) {
+  const partition = sessionPartitionForServerUrl(targetUrl);
+  return {
+    partition,
+    value: partition === null ? session.defaultSession : session.fromPartition(partition),
+  };
+}
+
+function createWindow(url: string, partition: string | null) {
   markOnce("rk:main:window-create-start");
   const icon = developmentIcon();
   const win = new BrowserWindow({
@@ -51,41 +80,73 @@ function createWindow() {
       nodeIntegration: false,
       contextIsolation: true,
       sandbox: true,
+      ...(partition === null ? {} : { partition }),
     },
   });
   mainWindow = win;
+  const targetOrigin = safeOrigin(url);
   // OAuth flows open the provider's authorize page via window.open; give that
-  // popup a normal framed window and keep every non-http target closed.
-  win.webContents.setWindowOpenHandler(({ url }) => {
+  // popup a normal framed window. Non-http(s) targets stay closed; other http(s)
+  // origins open in the system browser so a connected server cannot navigate us away.
+  win.webContents.setWindowOpenHandler(({ url: childUrl }) => {
     let target: URL;
     try {
-      target = new URL(url);
+      target = new URL(childUrl);
     } catch {
       return { action: "deny" };
     }
-    const appOrigin = new URL(WEB_URL).origin;
+    const appOrigin = targetOrigin ?? safeOrigin(url);
     if (
-      target.protocol !== "https:" &&
-      !(target.protocol === "http:" && target.origin === appOrigin)
-    )
-      return { action: "deny" };
-    return {
-      action: "allow",
-      overrideBrowserWindowOptions: {
-        width: 560,
-        height: 720,
-        frame: true,
-        titleBarStyle: "default",
-        autoHideMenuBar: true,
-        backgroundColor: "#050506",
-        webPreferences: {
-          preload: "",
-          nodeIntegration: false,
-          contextIsolation: true,
-          sandbox: true,
-        },
-      },
-    };
+      target.protocol === "https:" ||
+      (target.protocol === "http:" && appOrigin !== null && target.origin === appOrigin)
+    ) {
+      if (appOrigin !== null && target.origin === appOrigin) {
+        return {
+          action: "allow",
+          overrideBrowserWindowOptions: {
+            width: 560,
+            height: 720,
+            frame: true,
+            titleBarStyle: "default",
+            autoHideMenuBar: true,
+            backgroundColor: "#050506",
+            webPreferences: {
+              preload: "",
+              nodeIntegration: false,
+              contextIsolation: true,
+              sandbox: true,
+            },
+          },
+        };
+      }
+      // Third-party https (OAuth providers): allow a framed popup.
+      if (target.protocol === "https:") {
+        return {
+          action: "allow",
+          overrideBrowserWindowOptions: {
+            width: 560,
+            height: 720,
+            frame: true,
+            titleBarStyle: "default",
+            autoHideMenuBar: true,
+            backgroundColor: "#050506",
+            webPreferences: {
+              preload: "",
+              nodeIntegration: false,
+              contextIsolation: true,
+              sandbox: true,
+            },
+          },
+        };
+      }
+    }
+    const external = safeExternalUrl(childUrl);
+    if (external !== null) void shell.openExternal(external);
+    return { action: "deny" };
+  });
+  win.webContents.on("will-navigate", (event, navigationUrl) => {
+    if (targetOrigin !== null && safeOrigin(navigationUrl) === targetOrigin) return;
+    event.preventDefault();
   });
   win.on("close", (event) => {
     if (
@@ -113,23 +174,31 @@ function createWindow() {
   win.webContents.once("did-finish-load", () => markOnce("rk:main:did-finish-load"));
   win.webContents.once("did-stop-loading", () => markOnce("rk:main:did-stop-loading"));
   markOnce("rk:main:load-url-start");
-  void win.loadURL(WEB_URL).then(
+  const loaded = win.loadURL(url).then(
     () => markOnce("rk:main:load-url-resolved"),
-    () => markOnce("rk:main:load-url-rejected"),
+    (error: unknown) => {
+      markOnce("rk:main:load-url-rejected");
+      throw error;
+    },
   );
-  return win;
+  return { loaded, win };
 }
 
-async function installBundledRenderer() {
+async function installBundledRenderer(
+  targetUrl: string,
+  targetSession: Session,
+  partition: string | null,
+) {
   if (!app.isPackaged || process.env.RAKAZO_DISABLE_BUNDLED_RENDERER === "1") return;
-  const webUrl = new URL(WEB_URL);
-  if (webUrl.protocol !== "http:" && webUrl.protocol !== "https:") return;
+  if (!servesBundledRenderer(targetUrl)) return;
+  const webUrl = new URL(targetUrl);
+  const installationKey = `${partition ?? "default"}:${webUrl.protocol}`;
+  if (bundledRendererInstallations.has(installationKey)) return;
   const root = path.join(process.resourcesPath, "web");
-  if (!existsSync(path.join(root, "index.html"))) return;
 
-  await session.defaultSession.protocol.handle(webUrl.protocol.slice(0, -1), async (request) => {
+  await targetSession.protocol.handle(webUrl.protocol.slice(0, -1), async (request) => {
     const forward = () => {
-      return net.fetch(request, forwardedRendererRequestInit(request, webUrl.origin));
+      return targetSession.fetch(request, forwardedRendererRequestInit(request, webUrl.origin));
     };
     if (request.method !== "GET" && request.method !== "HEAD") {
       return forward();
@@ -160,20 +229,230 @@ async function installBundledRenderer() {
     }
     return forward();
   });
+  bundledRendererInstallations.add(installationKey);
   markOnce("rk:main:bundled-renderer-ready");
 }
 
+function createSetupWindow() {
+  const icon = developmentIcon();
+  const win = new BrowserWindow({
+    ...setupWindowOptions(process.platform),
+    ...(icon ? { icon } : {}),
+    webPreferences: {
+      preload: path.join(import.meta.dirname, "setup-preload.cjs"),
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+    },
+  });
+  setupWindow = win;
+  win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  win.once("closed", () => {
+    if (setupWindow === win) setupWindow = null;
+  });
+  void win.loadFile(path.join(import.meta.dirname, "setup.html"));
+  markOnce("rk:main:setup-window-created");
+  return win;
+}
+
+function showSetupWindow(error: string | null = null) {
+  currentTargetUrl = null;
+  setupError = error;
+  const appWindow = mainWindow;
+  mainWindow = null;
+
+  let win: BrowserWindow;
+  if (setupWindow !== null && !setupWindow.isDestroyed()) {
+    if (error !== null) setupWindow.reload();
+    win = setupWindow;
+  } else {
+    win = createSetupWindow();
+  }
+  if (appWindow !== null && !appWindow.isDestroyed()) appWindow.destroy();
+  win.show();
+  win.focus();
+  return win;
+}
+
+function installApplicationMenu() {
+  const changeServer: Electron.MenuItemConstructorOptions = {
+    id: "change-rakazo-server",
+    label: "Change Rakazo Server…",
+    accelerator: "CmdOrCtrl+Shift+K",
+    click: () => showSetupWindow(),
+  };
+  const template: Electron.MenuItemConstructorOptions[] =
+    process.platform === "darwin"
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: "about" },
+              { type: "separator" },
+              changeServer,
+              { type: "separator" },
+              { role: "hide" },
+              { role: "hideOthers" },
+              { role: "unhide" },
+              { type: "separator" },
+              { role: "quit" },
+            ],
+          },
+          { role: "editMenu" },
+          { role: "windowMenu" },
+        ]
+      : [
+          {
+            label: "File",
+            submenu: [changeServer, { type: "separator" }, { role: "quit" }],
+          },
+          { role: "editMenu" },
+          { role: "windowMenu" },
+        ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+/** Setup IPC must only answer the setup window, never a connected Rakazo server. */
+function fromSetupWindow(event: Electron.IpcMainInvokeEvent) {
+  return (
+    setupWindow !== null && !setupWindow.isDestroyed() && event.sender === setupWindow.webContents
+  );
+}
+
+async function probeServer(rawUrl: string): Promise<DesktopReachability> {
+  const url = normalizeServerUrl(rawUrl);
+  if (url === null) return { ok: false, error: "Enter a valid http:// or https:// address." };
+
+  try {
+    const response = await net.fetch(`${url}/rpc/health`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ json: {} }),
+      cache: "no-store",
+      credentials: "omit",
+      redirect: "manual",
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    if (response.status >= 300 && response.status < 400) {
+      return {
+        ok: false,
+        status: response.status,
+        url,
+        error: "That address redirects elsewhere. Enter the final Rakazo server address.",
+      };
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        url,
+        error: `The server answered with HTTP ${response.status}.`,
+      };
+    }
+    const health = await limitedJson(response);
+    if (!isRakazoHealth(health)) {
+      return {
+        ok: false,
+        status: response.status,
+        url,
+        error: "That address did not respond like a Rakazo server.",
+      };
+    }
+    return {
+      ok: true,
+      status: response.status,
+      url,
+    };
+  } catch (error) {
+    return { ok: false, url, error: probeFailureMessage(error) };
+  }
+}
+
+async function limitedJson(response: Response): Promise<unknown> {
+  if (response.body === null) return null;
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > PROBE_RESPONSE_LIMIT_BYTES) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(body));
+  } catch {
+    return null;
+  }
+}
+
+function openApp(targetUrl: string) {
+  if (openAppPromise !== null) return openAppPromise;
+  openAppPromise = openAppOnce(targetUrl).finally(() => {
+    openAppPromise = null;
+  });
+  return openAppPromise;
+}
+
+async function openAppOnce(targetUrl: string) {
+  const target = sessionForTarget(targetUrl);
+  let win: BrowserWindow | null = null;
+  try {
+    await installBundledRenderer(targetUrl, target.value, target.partition);
+    const created = createWindow(targetUrl, target.partition);
+    win = created.win;
+    await created.loaded;
+    currentTargetUrl = targetUrl;
+    setupError = null;
+    const setup = setupWindow;
+    setupWindow = null;
+    if (setup !== null && !setup.isDestroyed()) setup.destroy();
+    return true;
+  } catch (error) {
+    if (win !== null && !win.isDestroyed()) win.destroy();
+    showSetupWindow(`Could not open that server. ${probeFailureMessage(error)}`);
+    return false;
+  }
+}
+
+function safeOrigin(targetUrl: string) {
+  try {
+    return new URL(targetUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
 app.whenReady().then(async () => {
+  const userDataDir = app.getPath("userData");
+  currentSetup = await readSetup(userDataDir);
+  const target = resolveStartupTarget({
+    envUrl: process.env.RAKAZO_WEB_URL,
+    saved: currentSetup,
+    forceSetup: process.env.RAKAZO_FORCE_SETUP === "1",
+  });
   if (process.env.RAKAZO_PERFORMANCE_CLEAR_CACHE === "1") {
-    await Promise.all([
-      session.defaultSession.clearCache(),
-      session.defaultSession.clearCodeCaches({}),
-    ]);
+    const cacheSessions = new Set<Session>([session.defaultSession]);
+    if (target.kind === "app") cacheSessions.add(sessionForTarget(target.url).value);
+    await Promise.all(
+      [...cacheSessions].flatMap((value) => [value.clearCache(), value.clearCodeCaches({})]),
+    );
     markOnce("rk:main:caches-cleared");
   }
-  await installBundledRenderer();
+
   const icon = developmentIcon();
   if (process.platform === "darwin" && icon) app.dock?.setIcon(icon);
+  installApplicationMenu();
   ipcMain.handle("desktop.platform", () => process.platform);
   ipcMain.handle("desktop.window.close", (event) => {
     windowFrom(event)?.close();
@@ -199,14 +478,88 @@ app.whenReady().then(async () => {
       fullScreen: win?.isFullScreen() ?? false,
     };
   });
-  createWindow();
+  ipcMain.handle("desktop.setup.state", (event) => {
+    if (!fromSetupWindow(event)) return null;
+    return {
+      defaultLocalUrl: DEFAULT_LOCAL_WEB_URL,
+      saved: currentSetup,
+      error: setupError ?? undefined,
+    };
+  });
+
+  ipcMain.handle("desktop.setup.test", async (event, url: unknown) => {
+    if (!fromSetupWindow(event)) return { ok: false, error: "Setup is not active." };
+    if (typeof url !== "string") return { ok: false, error: "Enter a server address." };
+    return probeServer(url);
+  });
+
+  ipcMain.handle("desktop.setup.save", async (event, payload: unknown) => {
+    if (!fromSetupWindow(event)) return { ok: false, error: "Setup is not active." };
+    if (setupSaveInProgress)
+      return { ok: false, error: "A connection attempt is already running." };
+    setupSaveInProgress = true;
+    try {
+      const setup = parseSetupInput(payload);
+      if (setup === null) {
+        return {
+          ok: false,
+          error:
+            "Enter a valid server address. Public servers require HTTPS; a new local instance must use localhost.",
+        };
+      }
+
+      const reachability = await probeServer(setup.serverUrl);
+      if (!reachability.ok) return { ok: false, error: reachability.error };
+
+      try {
+        await writeSetup(userDataDir, setup);
+      } catch {
+        return {
+          ok: false,
+          error: "Could not save setup. Check that Rakazo can write to its app-data directory.",
+        };
+      }
+      currentSetup = setup;
+      // Answer the setup window before tearing it down, otherwise the reply is lost.
+      setImmediate(() => void openApp(setup.serverUrl));
+      return { ok: true };
+    } finally {
+      setupSaveInProgress = false;
+    }
+  });
+
+  ipcMain.handle("desktop.setup.quit", (event) => {
+    if (fromSetupWindow(event)) app.quit();
+  });
+
+  if (target.kind === "setup") {
+    showSetupWindow();
+  } else if (target.source === "saved") {
+    const reachability = await probeServer(target.url);
+    if (reachability.ok) {
+      await openApp(target.url);
+    } else {
+      showSetupWindow(`Could not reconnect to the saved server. ${reachability.error}`);
+    }
+  } else {
+    await openApp(target.url);
+  }
+
   app.on("activate", () => {
-    if (!mainWindow || mainWindow.isDestroyed()) createWindow();
-    else {
+    if (setupWindow !== null && !setupWindow.isDestroyed()) {
+      setupWindow.show();
+      setupWindow.focus();
+      return;
+    }
+    if (mainWindow !== null && !mainWindow.isDestroyed()) {
       clearTimeout(warmWindowTimer);
       mainWindow.show();
       mainWindow.focus();
+      return;
     }
+    if (openAppPromise !== null) return;
+    if (currentTargetUrl === null) showSetupWindow(setupError);
+    else void openApp(currentTargetUrl);
   });
 });
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -893,12 +893,19 @@ app.whenReady().then(async () => {
           const message = await recoverFromCrashedSave(userDataDir, previousSetup, previousUrl);
           return { ok: false, error: message };
         }
-        // Commit while the crash listener is still armed, then dispose.
+        // Commit while the crash listener is still armed.
         commitPendingAppSwitch();
         if (rendererWatch?.crashed()) {
           const message = await recoverFromCrashedSave(userDataDir, previousSetup, previousUrl);
           return { ok: false, error: message };
         }
+        destroySetupWindow();
+        // Final check after setup closes — a crash in this gap still rolls back.
+        if (rendererWatch?.crashed()) {
+          const message = await recoverFromCrashedSave(userDataDir, previousSetup, previousUrl);
+          return { ok: false, error: message };
+        }
+        return { ok: true };
       } catch {
         const outcome = abandonPendingAppSwitch(previousSetup, previousUrl);
         return {
@@ -911,8 +918,6 @@ app.whenReady().then(async () => {
       } finally {
         rendererWatch?.dispose();
       }
-      destroySetupWindow();
-      return { ok: true };
     } finally {
       setupSaveInProgress = false;
     }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -143,7 +143,7 @@ function createWindow(url: string, partition: string | null) {
   win.webContents.once("did-finish-load", () => markOnce("rk:main:did-finish-load"));
   win.webContents.once("did-stop-loading", () => markOnce("rk:main:did-stop-loading"));
   markOnce("rk:main:load-url-start");
-  const loaded = win.loadURL(url).then(
+  const loaded = loadAppUrl(win, url).then(
     () => markOnce("rk:main:load-url-resolved"),
     (error: unknown) => {
       markOnce("rk:main:load-url-rejected");
@@ -151,6 +151,67 @@ function createWindow(url: string, partition: string | null) {
     },
   );
   return { loaded, win };
+}
+
+/**
+ * loadURL alone treats many HTTP error documents as success. Reject main-frame
+ * failures, renderer crashes during load, and HTTP 4xx/5xx main-frame responses.
+ */
+function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
+  const contents = win.webContents;
+  const targetSession = contents.session;
+  let mainStatus: number | undefined;
+
+  targetSession.webRequest.onCompleted({ urls: ["*://*/*"] }, (details) => {
+    if (details.webContentsId === contents.id && details.resourceType === "mainFrame") {
+      mainStatus = details.statusCode;
+    }
+  });
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      contents.removeListener("did-fail-load", onFail);
+      contents.removeListener("render-process-gone", onGone);
+      targetSession.webRequest.onCompleted(null);
+      if (error) {
+        reject(error);
+        return;
+      }
+      if (mainStatus !== undefined && mainStatus >= 400) {
+        reject(new Error(`The server answered with HTTP ${mainStatus}.`));
+        return;
+      }
+      resolve();
+    };
+
+    const onFail = (
+      _event: Electron.Event,
+      _errorCode: number,
+      errorDescription: string,
+      _validatedURL: string,
+      isMainFrame: boolean,
+    ) => {
+      if (isMainFrame) settle(new Error(errorDescription || "Page failed to load."));
+    };
+    const onGone = (_event: Electron.Event, details: Electron.RenderProcessGoneDetails) => {
+      settle(new Error(`Renderer stopped (${details.reason}).`));
+    };
+
+    contents.on("did-fail-load", onFail);
+    contents.on("render-process-gone", onGone);
+    void contents.loadURL(url).then(
+      () => {
+        // onCompleted can lag loadURL's resolve by a tick.
+        setImmediate(() => settle());
+      },
+      (error: unknown) => {
+        settle(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
 }
 
 async function installBundledRenderer(
@@ -434,18 +495,24 @@ function commitPendingAppSwitch() {
 }
 
 /**
- * Undo an open that could not be persisted: destroy the new window, restore the
- * prior session, and leave setup up so the error reply can be shown.
+ * Undo an open that could not be persisted. When a prior session exists, restore
+ * it. On first run keep the connected window so the user can retry save.
  */
-function abandonPendingAppSwitch(previousSetup: DesktopSetup | null, previousUrl: string | null) {
+function abandonPendingAppSwitch(
+  previousSetup: DesktopSetup | null,
+  previousUrl: string | null,
+): "restored" | "kept" {
   const previous = pendingPreviousWindow;
   pendingPreviousWindow = null;
-  const failed = mainWindow;
-  if (failed !== null && !failed.isDestroyed() && failed !== previous) failed.destroy();
-  if (previous !== null && !previous.isDestroyed()) mainWindow = previous;
-  else mainWindow = null;
-  currentSetup = previousSetup;
-  currentTargetUrl = previousUrl;
+  if (previous !== null && !previous.isDestroyed()) {
+    const failed = mainWindow;
+    if (failed !== null && !failed.isDestroyed() && failed !== previous) failed.destroy();
+    mainWindow = previous;
+    currentSetup = previousSetup;
+    currentTargetUrl = previousUrl;
+    return "restored";
+  }
+  return "kept";
 }
 
 function destroySetupWindow() {
@@ -594,10 +661,13 @@ app.whenReady().then(async () => {
       try {
         await writeSetup(userDataDir, setup);
       } catch {
-        abandonPendingAppSwitch(previousSetup, previousUrl);
+        const outcome = abandonPendingAppSwitch(previousSetup, previousUrl);
         return {
           ok: false,
-          error: "Could not save setup. The previous instance was restored.",
+          error:
+            outcome === "restored"
+              ? "Could not save setup. The previous instance was restored."
+              : "Connected, but could not save setup for the next launch. Try Continue again.",
         };
       }
       commitPendingAppSwitch();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -344,8 +344,8 @@ function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
 
 /**
  * Empty `#root` shells and session-pending skeletons count as loaded HTML but are
- * not a usable app. Wait until auth session resolves (or an e2e `<main>` fixture
- * mounts without the pending marker).
+ * not a usable app. Wait until the shell is ready (or a non-app auth/welcome route
+ * finishes session), or an e2e fixture mounts without app markers.
  */
 async function waitForMountedAppDocument(contents: Electron.WebContents) {
   const deadline = Date.now() + 8_000;
@@ -353,20 +353,29 @@ async function waitForMountedAppDocument(contents: Electron.WebContents) {
     if (contents.isCrashed()) throw new Error("Renderer stopped after load.");
     const state = (await contents.executeJavaScript(`({
       appState: document.querySelector("[data-rakazo-app-state]")?.getAttribute("data-rakazo-app-state") ?? null,
+      path: location.pathname,
       rootChildren: document.getElementById("root")?.childElementCount ?? 0,
       mainText: (document.querySelector("main")?.textContent ?? "").trim().length,
-      sessionCommitted: performance.getEntriesByName("rk:renderer:session-committed").length > 0
+      sessionCommitted: performance.getEntriesByName("rk:renderer:session-committed").length > 0,
+      shellReady: performance.getEntriesByName("rk:renderer:shell-ready").length > 0
     })`)) as {
       appState: string | null;
+      path: string;
       rootChildren: number;
       mainText: number;
       sessionCommitted: boolean;
+      shellReady: boolean;
     };
     if (state.appState === "session-pending") {
       await new Promise((r) => setTimeout(r, 50));
       continue;
     }
-    if (state.appState === "ready" || state.sessionCommitted) return;
+    // Logged-in `/` redirects into `/app`; require the shell, not just session.
+    const needsShell =
+      state.path === "/" || state.path === "/app" || state.path.startsWith("/app/");
+    if (state.shellReady) return;
+    const sessionReady = state.appState === "ready" || state.sessionCommitted;
+    if (sessionReady && !needsShell) return;
     // Desktop e2e fixtures mount a plain `<main>` without the web app markers.
     if (state.appState === null && (state.rootChildren > 0 || state.mainText > 0)) return;
     await new Promise((r) => setTimeout(r, 50));
@@ -732,6 +741,31 @@ async function rollbackSetupFile(userDataDir: string, previousSetup: DesktopSetu
   }
 }
 
+/**
+ * After a renderer crash around save: restore prior setup when possible, otherwise
+ * drop the crashed first-run window so setup remains the only recovery surface.
+ */
+async function recoverFromCrashedSave(
+  userDataDir: string,
+  previousSetup: DesktopSetup | null,
+  previousUrl: string | null,
+): Promise<string> {
+  const outcome = abandonPendingAppSwitch(previousSetup, previousUrl);
+  await rollbackSetupFile(userDataDir, previousSetup);
+  if (outcome === "kept") {
+    if (mainWindow !== null && !mainWindow.isDestroyed()) mainWindow.destroy();
+    mainWindow = null;
+    currentSetup = previousSetup;
+    currentTargetUrl = previousUrl;
+  }
+  const message =
+    previousSetup !== null
+      ? "Could not open that server. Renderer stopped. The previous instance was restored for the next launch."
+      : "Could not open that server. Renderer stopped.";
+  showSetupWindow(message);
+  return message;
+}
+
 function safeOrigin(targetUrl: string) {
   try {
     return new URL(targetUrl).origin;
@@ -841,12 +875,8 @@ app.whenReady().then(async () => {
       try {
         await writeSetup(userDataDir, setup);
         if (rendererWatch?.crashed()) {
-          abandonPendingAppSwitch(previousSetup, previousUrl);
-          await rollbackSetupFile(userDataDir, previousSetup);
-          return {
-            ok: false,
-            error: "Could not open that server. Renderer stopped.",
-          };
+          const message = await recoverFromCrashedSave(userDataDir, previousSetup, previousUrl);
+          return { ok: false, error: message };
         }
         // Commit while the crash listener is still armed, then dispose.
         commitPendingAppSwitch();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -153,9 +153,29 @@ function createWindow(url: string, partition: string | null) {
   return { loaded, win };
 }
 
+async function probeDocument(url: string): Promise<string | null> {
+  try {
+    const response = await net.fetch(url, {
+      method: "GET",
+      redirect: "manual",
+      cache: "no-store",
+      credentials: "omit",
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    // Allow 3xx (e.g. / → /login); reject hard HTTP errors before opening a window.
+    if (response.status >= 400) {
+      return `The server answered with HTTP ${response.status}.`;
+    }
+    return null;
+  } catch (error) {
+    return probeFailureMessage(error);
+  }
+}
+
 /**
  * loadURL alone treats many HTTP error documents as success. Reject main-frame
- * failures, renderer crashes during load, and HTTP 4xx/5xx main-frame responses.
+ * failures, renderer crashes during load, HTTP 4xx/5xx main-frame responses, and
+ * empty documents.
  */
 function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
   const contents = win.webContents;
@@ -220,9 +240,13 @@ function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
     contents.on("did-fail-load", onFail);
     contents.on("render-process-gone", onGone);
     void contents.loadURL(url).then(
-      () => {
-        // onCompleted can lag loadURL's resolve by a tick.
-        setImmediate(() => settle());
+      async () => {
+        // onCompleted can lag loadURL; wait briefly for the main-frame status.
+        const deadline = Date.now() + 500;
+        while (mainStatus === undefined && Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 10));
+        }
+        settle();
       },
       (error: unknown) => {
         settle(error instanceof Error ? error : new Error(String(error)));
@@ -477,11 +501,30 @@ function openApp(targetUrl: string) {
   return openAppPromise;
 }
 
+function openFailureDetail(error: unknown): string {
+  if (error instanceof Error) {
+    const { message } = error;
+    if (
+      message.startsWith("The server answered with HTTP") ||
+      message.startsWith("The server page loaded empty") ||
+      message.startsWith("Renderer stopped") ||
+      message.startsWith("Page failed to load")
+    ) {
+      return message;
+    }
+  }
+  return probeFailureMessage(error);
+}
+
 async function openAppOnce(targetUrl: string) {
   const target = sessionForTarget(targetUrl);
   const previous = mainWindow;
   let win: BrowserWindow | null = null;
   try {
+    const documentError = await probeDocument(targetUrl);
+    if (documentError !== null) {
+      throw new Error(documentError);
+    }
     await migrateDefaultSessionCookies(targetUrl, target.value, target.partition);
     await installBundledRenderer(targetUrl, target.value, target.partition);
     const created = createWindow(targetUrl, target.partition);
@@ -499,7 +542,7 @@ async function openAppOnce(targetUrl: string) {
     if (win !== null && !win.isDestroyed()) win.destroy();
     // Keep the previous app window so Cancel / close can restore it.
     if (previous !== null && !previous.isDestroyed()) mainWindow = previous;
-    showSetupWindow(`Could not open that server. ${probeFailureMessage(error)}`);
+    showSetupWindow(`Could not open that server. ${openFailureDetail(error)}`);
     return false;
   }
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -344,40 +344,49 @@ function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
 
 /**
  * Empty `#root` shells and session-pending skeletons count as loaded HTML but are
- * not a usable app. Wait until the shell is ready (or a non-app auth/welcome route
- * finishes session), or an e2e fixture mounts without app markers.
+ * not a usable app. After session resolves, also wait for a real route surface
+ * (shell / auth / welcome / onboarding) so a bare Suspense fallback cannot pass.
+ * Plain e2e fixtures omit the Rakazo app-state marker.
  */
 async function waitForMountedAppDocument(contents: Electron.WebContents) {
   const deadline = Date.now() + 8_000;
   while (Date.now() < deadline) {
     if (contents.isCrashed()) throw new Error("Renderer stopped after load.");
-    const state = (await contents.executeJavaScript(`({
-      appState: document.querySelector("[data-rakazo-app-state]")?.getAttribute("data-rakazo-app-state") ?? null,
-      path: location.pathname,
-      rootChildren: document.getElementById("root")?.childElementCount ?? 0,
-      mainText: (document.querySelector("main")?.textContent ?? "").trim().length,
-      sessionCommitted: performance.getEntriesByName("rk:renderer:session-committed").length > 0,
-      shellReady: performance.getEntriesByName("rk:renderer:shell-ready").length > 0
-    })`)) as {
-      appState: string | null;
-      path: string;
-      rootChildren: number;
-      mainText: number;
-      sessionCommitted: boolean;
-      shellReady: boolean;
-    };
-    if (state.appState === "session-pending") {
-      await new Promise((r) => setTimeout(r, 50));
-      continue;
-    }
-    // Logged-in `/` redirects into `/app`; require the shell, not just session.
-    const needsShell =
-      state.path === "/" || state.path === "/app" || state.path.startsWith("/app/");
-    if (state.shellReady) return;
-    const sessionReady = state.appState === "ready" || state.sessionCommitted;
-    if (sessionReady && !needsShell) return;
-    // Desktop e2e fixtures mount a plain `<main>` without the web app markers.
-    if (state.appState === null && (state.rootChildren > 0 || state.mainText > 0)) return;
+    const ready = (await contents.executeJavaScript(`(() => {
+      const appState =
+        document.querySelector("[data-rakazo-app-state]")?.getAttribute("data-rakazo-app-state") ??
+        null;
+      if (appState === "session-pending") return false;
+
+      const surfaceReady = Boolean(
+        document.querySelector('[data-testid="shell-root"]') ||
+          document.querySelector(
+            'form input[type="email"], form input[name="email"], form input#email',
+          ) ||
+          Array.from(document.querySelectorAll("button")).some((button) =>
+            /sign\\s*in/i.test((button.textContent || "").trim()),
+          ) ||
+          document.querySelector(
+            '[aria-label="Model"], [aria-label="Model id"], [aria-label="Models from server"]',
+          ),
+      );
+      const sessionReady =
+        appState === "ready" ||
+        performance.getEntriesByName("rk:renderer:session-committed").length > 0;
+      if (sessionReady && surfaceReady) return true;
+
+      // Desktop e2e fixtures mount a plain page without Rakazo app-state markers.
+      if (appState === null) {
+        const bodyText = (document.body?.innerText || "").trim();
+        if (bodyText.includes("Opening your workspace")) return false;
+        if (bodyText === "Loading…" || bodyText === "Loading...") return false;
+        const mainText = (document.querySelector("main")?.textContent || "").trim();
+        const rootChildren = document.getElementById("root")?.childElementCount ?? 0;
+        return mainText.length > 0 || rootChildren > 0;
+      }
+      return false;
+    })()`)) as boolean;
+    if (ready) return;
     await new Promise((r) => setTimeout(r, 50));
   }
   throw new Error("The server page did not become ready.");
@@ -881,19 +890,7 @@ app.whenReady().then(async () => {
         // Commit while the crash listener is still armed, then dispose.
         commitPendingAppSwitch();
         if (rendererWatch?.crashed()) {
-          // Previous window is already gone; roll back disk and drop the dead window
-          // so setup can reconnect to the restored saved instance.
-          await rollbackSetupFile(userDataDir, previousSetup);
-          currentSetup = previousSetup;
-          currentTargetUrl = previousUrl;
-          if (mainWindow !== null && !mainWindow.isDestroyed()) mainWindow.destroy();
-          mainWindow = null;
-          const message =
-            previousSetup !== null
-              ? "Could not open that server. Renderer stopped. The previous instance was restored for the next launch."
-              : "Could not open that server. Renderer stopped.";
-          // Setup may already be closed (user dismissed it during write); reopen it.
-          showSetupWindow(message);
+          const message = await recoverFromCrashedSave(userDataDir, previousSetup, previousUrl);
           return { ok: false, error: message };
         }
       } catch {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -96,49 +96,16 @@ function createWindow(url: string, partition: string | null) {
       return { action: "deny" };
     }
     const appOrigin = targetOrigin ?? safeOrigin(url);
+    const sameOrigin = appOrigin !== null && target.origin === appOrigin;
+    // Same-origin http(s) and third-party https (OAuth) get a framed popup.
     if (
-      target.protocol === "https:" ||
-      (target.protocol === "http:" && appOrigin !== null && target.origin === appOrigin)
+      (sameOrigin && (target.protocol === "http:" || target.protocol === "https:")) ||
+      (!sameOrigin && target.protocol === "https:")
     ) {
-      if (appOrigin !== null && target.origin === appOrigin) {
-        return {
-          action: "allow",
-          overrideBrowserWindowOptions: {
-            width: 560,
-            height: 720,
-            frame: true,
-            titleBarStyle: "default",
-            autoHideMenuBar: true,
-            backgroundColor: "#050506",
-            webPreferences: {
-              preload: "",
-              nodeIntegration: false,
-              contextIsolation: true,
-              sandbox: true,
-            },
-          },
-        };
-      }
-      // Third-party https (OAuth providers): allow a framed popup.
-      if (target.protocol === "https:") {
-        return {
-          action: "allow",
-          overrideBrowserWindowOptions: {
-            width: 560,
-            height: 720,
-            frame: true,
-            titleBarStyle: "default",
-            autoHideMenuBar: true,
-            backgroundColor: "#050506",
-            webPreferences: {
-              preload: "",
-              nodeIntegration: false,
-              contextIsolation: true,
-              sandbox: true,
-            },
-          },
-        };
-      }
+      return {
+        action: "allow",
+        overrideBrowserWindowOptions: oauthPopupWindowOptions(),
+      };
     }
     const external = safeExternalUrl(childUrl);
     if (external !== null) void shell.openExternal(external);
@@ -233,6 +200,23 @@ async function installBundledRenderer(
   markOnce("rk:main:bundled-renderer-ready");
 }
 
+function oauthPopupWindowOptions() {
+  return {
+    width: 560,
+    height: 720,
+    frame: true,
+    titleBarStyle: "default" as const,
+    autoHideMenuBar: true,
+    backgroundColor: "#050506",
+    webPreferences: {
+      preload: "",
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+    },
+  };
+}
+
 function createSetupWindow() {
   const icon = developmentIcon();
   const win = new BrowserWindow({
@@ -249,17 +233,17 @@ function createSetupWindow() {
   win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
   win.once("closed", () => {
     if (setupWindow === win) setupWindow = null;
+    // Closing setup without saving restores a connected session (Change Server cancel).
+    restoreAppWindowAfterSetup();
   });
   void win.loadFile(path.join(import.meta.dirname, "setup.html"));
   markOnce("rk:main:setup-window-created");
   return win;
 }
 
+/** Hide the app while setup is open; do not clear the saved target until a new one opens. */
 function showSetupWindow(error: string | null = null) {
-  currentTargetUrl = null;
   setupError = error;
-  const appWindow = mainWindow;
-  mainWindow = null;
 
   let win: BrowserWindow;
   if (setupWindow !== null && !setupWindow.isDestroyed()) {
@@ -268,10 +252,19 @@ function showSetupWindow(error: string | null = null) {
   } else {
     win = createSetupWindow();
   }
-  if (appWindow !== null && !appWindow.isDestroyed()) appWindow.destroy();
+  if (mainWindow !== null && !mainWindow.isDestroyed()) mainWindow.hide();
   win.show();
   win.focus();
   return win;
+}
+
+function restoreAppWindowAfterSetup() {
+  if (quitting) return;
+  if (setupWindow !== null && !setupWindow.isDestroyed()) return;
+  if (mainWindow === null || mainWindow.isDestroyed() || currentTargetUrl === null) return;
+  clearTimeout(warmWindowTimer);
+  mainWindow.show();
+  mainWindow.focus();
 }
 
 function installApplicationMenu() {
@@ -406,6 +399,7 @@ function openApp(targetUrl: string) {
 
 async function openAppOnce(targetUrl: string) {
   const target = sessionForTarget(targetUrl);
+  const previous = mainWindow;
   let win: BrowserWindow | null = null;
   try {
     await migrateDefaultSessionCookies(targetUrl, target.value, target.partition);
@@ -415,9 +409,12 @@ async function openAppOnce(targetUrl: string) {
     await created.loaded;
     currentTargetUrl = targetUrl;
     setupError = null;
+    if (previous !== null && !previous.isDestroyed() && previous !== win) previous.destroy();
     return true;
   } catch (error) {
     if (win !== null && !win.isDestroyed()) win.destroy();
+    // Keep the previous app window so Cancel / close can restore it.
+    if (previous !== null && !previous.isDestroyed()) mainWindow = previous;
     showSetupWindow(`Could not open that server. ${probeFailureMessage(error)}`);
     return false;
   }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -570,13 +570,30 @@ function abandonPendingAppSwitch(
     const failed = mainWindow;
     if (failed !== null && !failed.isDestroyed() && failed !== previous) failed.destroy();
     mainWindow = previous;
-    // Keep the prior window hidden so setup stays focused with the save error;
-    // closing setup restores it via restoreAppWindowAfterSetup.
     currentSetup = previousSetup;
     currentTargetUrl = previousUrl;
+    // If setup was already closed (e.g. during a slow write), make the restored
+    // session visible — otherwise macOS can be left with no shown window.
+    if (setupWindow === null || setupWindow.isDestroyed()) {
+      previous.show();
+      previous.focus();
+    }
     return "restored";
   }
   return "kept";
+}
+
+/** Watch for a renderer crash until setup is persisted (or the switch is abandoned). */
+function watchRendererUntilCommitted(win: BrowserWindow): () => boolean {
+  let crashed = false;
+  const onGone = () => {
+    crashed = true;
+  };
+  win.webContents.once("render-process-gone", onGone);
+  return () => {
+    if (!win.isDestroyed()) win.webContents.removeListener("render-process-gone", onGone);
+    return crashed;
+  };
 }
 
 function destroySetupWindow() {
@@ -722,9 +739,22 @@ app.whenReady().then(async () => {
         };
       }
 
+      const appWindow = mainWindow;
+      const finishRendererWatch =
+        appWindow !== null && !appWindow.isDestroyed()
+          ? watchRendererUntilCommitted(appWindow)
+          : () => false;
       try {
         await writeSetup(userDataDir, setup);
+        if (finishRendererWatch()) {
+          abandonPendingAppSwitch(previousSetup, previousUrl);
+          return {
+            ok: false,
+            error: "Could not open that server. Renderer stopped.",
+          };
+        }
       } catch {
+        finishRendererWatch();
         const outcome = abandonPendingAppSwitch(previousSetup, previousUrl);
         return {
           ok: false,
@@ -734,6 +764,7 @@ app.whenReady().then(async () => {
               : "Connected, but could not save setup for the next launch. Try Continue again.",
         };
       }
+      finishRendererWatch();
       commitPendingAppSwitch();
       destroySetupWindow();
       return { ok: true };

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -525,8 +525,8 @@ function abandonPendingAppSwitch(
     const failed = mainWindow;
     if (failed !== null && !failed.isDestroyed() && failed !== previous) failed.destroy();
     mainWindow = previous;
-    previous.show();
-    previous.focus();
+    // Keep the prior window hidden so setup stays focused with the save error;
+    // closing setup restores it via restoreAppWindowAfterSetup.
     currentSetup = previousSetup;
     currentTargetUrl = previousUrl;
     return "restored";

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -63,12 +63,42 @@ function developmentIcon() {
   return existsSync(icon) ? icon : undefined;
 }
 
-function sessionForTarget(targetUrl: string) {
-  const partition = sessionPartitionForServerUrl(targetUrl);
-  return {
-    partition,
-    value: partition === null ? session.defaultSession : session.fromPartition(partition),
-  };
+function sessionPartitionKey(targetUrl: string) {
+  return sessionPartitionForServerUrl(targetUrl);
+}
+
+function legacyDefaultSessionFlag(partition: string) {
+  return path.join(
+    app.getPath("userData"),
+    `legacy-default-${partition.replace(/[^a-zA-Z0-9_-]/g, "_")}.flag`,
+  );
+}
+
+/**
+ * Prefer the default session for origins that already have cookies there so
+ * upgrades keep localStorage/IndexedDB. New origins get an isolated partition.
+ */
+async function resolveSessionForTarget(targetUrl: string) {
+  const partition = sessionPartitionKey(targetUrl);
+  if (partition === null) {
+    return { partition: null, value: session.defaultSession };
+  }
+  if (existsSync(legacyDefaultSessionFlag(partition))) {
+    return { partition: null, value: session.defaultSession };
+  }
+  const origin = safeOrigin(targetUrl);
+  if (origin !== null) {
+    try {
+      const defaultCookies = await session.defaultSession.cookies.get({ url: origin });
+      if (defaultCookies.length > 0) {
+        await writeFile(legacyDefaultSessionFlag(partition), new Date().toISOString(), "utf8");
+        return { partition: null, value: session.defaultSession };
+      }
+    } catch {
+      // Fall through to an isolated partition.
+    }
+  }
+  return { partition, value: session.fromPartition(partition) };
 }
 
 function createWindow(url: string, partition: string | null) {
@@ -536,7 +566,7 @@ function openFailureDetail(error: unknown): string {
 }
 
 async function openAppOnce(targetUrl: string) {
-  const target = sessionForTarget(targetUrl);
+  const target = await resolveSessionForTarget(targetUrl);
   const previous = mainWindow;
   let win: BrowserWindow | null = null;
   try {
@@ -544,7 +574,6 @@ async function openAppOnce(targetUrl: string) {
     if (documentError !== null) {
       throw new Error(documentError);
     }
-    await migrateDefaultSessionCookies(targetUrl, target.value, target.partition);
     await installBundledRenderer(targetUrl, target.value, target.partition);
     const created = createWindow(targetUrl, target.partition);
     win = created.win;
@@ -602,15 +631,17 @@ function abandonPendingAppSwitch(
 }
 
 /** Watch for a renderer crash until setup is persisted (or the switch is abandoned). */
-function watchRendererUntilCommitted(win: BrowserWindow): () => boolean {
+function watchRendererUntilCommitted(win: BrowserWindow) {
   let crashed = false;
   const onGone = () => {
     crashed = true;
   };
   win.webContents.once("render-process-gone", onGone);
-  return () => {
-    if (!win.isDestroyed()) win.webContents.removeListener("render-process-gone", onGone);
-    return crashed;
+  return {
+    crashed: () => crashed || (!win.isDestroyed() && win.webContents.isCrashed()),
+    dispose: () => {
+      if (!win.isDestroyed()) win.webContents.removeListener("render-process-gone", onGone);
+    },
   };
 }
 
@@ -618,44 +649,6 @@ function destroySetupWindow() {
   const setup = setupWindow;
   setupWindow = null;
   if (setup !== null && !setup.isDestroyed()) setup.destroy();
-}
-
-/**
- * First launch after this feature may still have auth cookies in the default session
- * (pre-partition installs). Copy matching origin cookies into the per-origin partition once.
- */
-async function migrateDefaultSessionCookies(
-  targetUrl: string,
-  targetSession: Session,
-  partition: string | null,
-) {
-  if (partition === null || targetSession === session.defaultSession) return;
-  const origin = safeOrigin(targetUrl);
-  if (origin === null) return;
-  const marker = path.join(
-    app.getPath("userData"),
-    `session-migrated-${partition.replace(/[^a-zA-Z0-9_-]/g, "_")}.flag`,
-  );
-  if (existsSync(marker)) return;
-  try {
-    const cookies = await session.defaultSession.cookies.get({ url: origin });
-    for (const cookie of cookies) {
-      await targetSession.cookies.set({
-        url: origin,
-        name: cookie.name,
-        value: cookie.value,
-        domain: cookie.domain,
-        path: cookie.path,
-        secure: cookie.secure,
-        httpOnly: cookie.httpOnly,
-        expirationDate: cookie.expirationDate,
-        sameSite: cookie.sameSite,
-      });
-    }
-    await writeFile(marker, new Date().toISOString(), "utf8");
-  } catch {
-    // Migration is best-effort; a failed copy must not block opening the app.
-  }
 }
 
 function safeOrigin(targetUrl: string) {
@@ -676,7 +669,9 @@ app.whenReady().then(async () => {
   });
   if (process.env.RAKAZO_PERFORMANCE_CLEAR_CACHE === "1") {
     const cacheSessions = new Set<Session>([session.defaultSession]);
-    if (target.kind === "app") cacheSessions.add(sessionForTarget(target.url).value);
+    if (target.kind === "app") {
+      cacheSessions.add((await resolveSessionForTarget(target.url)).value);
+    }
     await Promise.all(
       [...cacheSessions].flatMap((value) => [value.clearCache(), value.clearCodeCaches({})]),
     );
@@ -758,21 +753,22 @@ app.whenReady().then(async () => {
       }
 
       const appWindow = mainWindow;
-      const finishRendererWatch =
+      const rendererWatch =
         appWindow !== null && !appWindow.isDestroyed()
           ? watchRendererUntilCommitted(appWindow)
-          : () => false;
+          : null;
       try {
         await writeSetup(userDataDir, setup);
-        if (finishRendererWatch()) {
+        if (rendererWatch?.crashed()) {
           abandonPendingAppSwitch(previousSetup, previousUrl);
           return {
             ok: false,
             error: "Could not open that server. Renderer stopped.",
           };
         }
+        // Commit while the crash listener is still armed, then dispose.
+        commitPendingAppSwitch();
       } catch {
-        finishRendererWatch();
         const outcome = abandonPendingAppSwitch(previousSetup, previousUrl);
         return {
           ok: false,
@@ -781,9 +777,9 @@ app.whenReady().then(async () => {
               ? "Could not save setup. The previous instance was restored."
               : "Connected, but could not save setup for the next launch. Try Continue again.",
         };
+      } finally {
+        rendererWatch?.dispose();
       }
-      finishRendererWatch();
-      commitPendingAppSwitch();
       destroySetupWindow();
       return { ok: true };
     } finally {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -35,6 +35,8 @@ let currentTargetUrl: string | null = null;
 let setupError: string | null = null;
 let setupSaveInProgress = false;
 let openAppPromise: Promise<boolean> | null = null;
+/** Prior app window kept until setup is persisted (or the switch is abandoned). */
+let pendingPreviousWindow: BrowserWindow | null = null;
 let quitting = false;
 let warmWindowTimer: NodeJS.Timeout | undefined;
 const WARM_WINDOW_TTL_MS = warmWindowTtlMs(process.env.RAKAZO_WARM_WINDOW_TTL_MS);
@@ -409,15 +411,41 @@ async function openAppOnce(targetUrl: string) {
     await created.loaded;
     currentTargetUrl = targetUrl;
     setupError = null;
-    if (previous !== null && !previous.isDestroyed() && previous !== win) previous.destroy();
+    // Keep the previous window until the caller commits (after setup.json is written).
+    pendingPreviousWindow =
+      previous !== null && !previous.isDestroyed() && previous !== win ? previous : null;
+    if (pendingPreviousWindow !== null) pendingPreviousWindow.hide();
     return true;
   } catch (error) {
+    pendingPreviousWindow = null;
     if (win !== null && !win.isDestroyed()) win.destroy();
     // Keep the previous app window so Cancel / close can restore it.
     if (previous !== null && !previous.isDestroyed()) mainWindow = previous;
     showSetupWindow(`Could not open that server. ${probeFailureMessage(error)}`);
     return false;
   }
+}
+
+/** Drop the previous app window after the new server is opened and persisted. */
+function commitPendingAppSwitch() {
+  const previous = pendingPreviousWindow;
+  pendingPreviousWindow = null;
+  if (previous !== null && !previous.isDestroyed() && previous !== mainWindow) previous.destroy();
+}
+
+/**
+ * Undo an open that could not be persisted: destroy the new window, restore the
+ * prior session, and leave setup up so the error reply can be shown.
+ */
+function abandonPendingAppSwitch(previousSetup: DesktopSetup | null, previousUrl: string | null) {
+  const previous = pendingPreviousWindow;
+  pendingPreviousWindow = null;
+  const failed = mainWindow;
+  if (failed !== null && !failed.isDestroyed() && failed !== previous) failed.destroy();
+  if (previous !== null && !previous.isDestroyed()) mainWindow = previous;
+  else mainWindow = null;
+  currentSetup = previousSetup;
+  currentTargetUrl = previousUrl;
 }
 
 function destroySetupWindow() {
@@ -538,6 +566,7 @@ app.whenReady().then(async () => {
       return { ok: false, error: "A connection attempt is already running." };
     setupSaveInProgress = true;
     const previousSetup = currentSetup;
+    const previousUrl = currentTargetUrl;
     try {
       const setup = parseSetupInput(payload);
       if (setup === null) {
@@ -565,13 +594,13 @@ app.whenReady().then(async () => {
       try {
         await writeSetup(userDataDir, setup);
       } catch {
-        // The app window is already on the new server; keep currentSetup aligned with it.
-        destroySetupWindow();
+        abandonPendingAppSwitch(previousSetup, previousUrl);
         return {
           ok: false,
-          error: "Connected, but could not save setup for the next launch.",
+          error: "Could not save setup. The previous instance was restored.",
         };
       }
+      commitPendingAppSwitch();
       destroySetupWindow();
       return { ok: true };
     } finally {
@@ -583,6 +612,7 @@ app.whenReady().then(async () => {
     if (fromSetupWindow(event)) app.quit();
   });
 
+  // Register before startup awaits so macOS dock clicks during probe/open are handled.
   app.on("activate", () => {
     if (setupWindow !== null && !setupWindow.isDestroyed()) {
       setupWindow.show();
@@ -597,7 +627,10 @@ app.whenReady().then(async () => {
     }
     if (openAppPromise !== null) return;
     if (currentTargetUrl === null) showSetupWindow(setupError);
-    else void openApp(currentTargetUrl);
+    else
+      void openApp(currentTargetUrl).then((opened) => {
+        if (opened) commitPendingAppSwitch();
+      });
   });
 
   if (target.kind === "setup") {
@@ -605,12 +638,18 @@ app.whenReady().then(async () => {
   } else if (target.source === "saved") {
     const reachability = await probeServer(target.url);
     if (reachability.ok) {
-      if (await openApp(target.url)) destroySetupWindow();
+      if (await openApp(target.url)) {
+        commitPendingAppSwitch();
+        destroySetupWindow();
+      }
     } else {
       showSetupWindow(`Could not reconnect to the saved server. ${reachability.error}`);
     }
   } else {
-    if (await openApp(target.url)) destroySetupWindow();
+    if (await openApp(target.url)) {
+      commitPendingAppSwitch();
+      destroySetupWindow();
+    }
   }
 });
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -184,7 +184,24 @@ function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
         reject(new Error(`The server answered with HTTP ${mainStatus}.`));
         return;
       }
-      resolve();
+      void contents
+        .executeJavaScript(
+          `Boolean(document.body && (document.getElementById("root") || document.querySelector("main") || document.body.children.length > 0))`,
+        )
+        .then((usable: unknown) => {
+          if (contents.isCrashed()) {
+            reject(new Error("Renderer stopped after load."));
+            return;
+          }
+          if (!usable) {
+            reject(new Error("The server page loaded empty."));
+            return;
+          }
+          resolve();
+        })
+        .catch((inspectError: unknown) => {
+          reject(inspectError instanceof Error ? inspectError : new Error(String(inspectError)));
+        });
     };
 
     const onFail = (
@@ -508,6 +525,8 @@ function abandonPendingAppSwitch(
     const failed = mainWindow;
     if (failed !== null && !failed.isDestroyed() && failed !== previous) failed.destroy();
     mainWindow = previous;
+    previous.show();
+    previous.focus();
     currentSetup = previousSetup;
     currentTargetUrl = previousUrl;
     return "restored";

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -177,7 +177,7 @@ async function probeDocument(url: string): Promise<string | null> {
 /**
  * loadURL alone treats many HTTP error documents as success. Reject main-frame
  * failures, renderer crashes during load, HTTP 4xx/5xx main-frame responses, and
- * empty documents.
+ * shells that never mount application content.
  */
 function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
   const contents = win.webContents;
@@ -196,32 +196,30 @@ function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
       if (settled) return;
       settled = true;
       contents.removeListener("did-fail-load", onFail);
-      contents.removeListener("render-process-gone", onGone);
+      // Keep render-process-gone until document readiness finishes so a crash
+      // during mount still fails the switch.
       targetSession.webRequest.onCompleted(null);
       if (error) {
+        contents.removeListener("render-process-gone", onGone);
         reject(error);
         return;
       }
       if (mainStatus !== undefined && mainStatus >= 400) {
+        contents.removeListener("render-process-gone", onGone);
         reject(new Error(`The server answered with HTTP ${mainStatus}.`));
         return;
       }
-      void contents
-        .executeJavaScript(
-          `Boolean(document.body && (document.getElementById("root") || document.querySelector("main") || document.body.children.length > 0))`,
-        )
-        .then((usable: unknown) => {
+      void waitForMountedAppDocument(contents)
+        .then(() => {
+          contents.removeListener("render-process-gone", onGone);
           if (contents.isCrashed()) {
             reject(new Error("Renderer stopped after load."));
-            return;
-          }
-          if (!usable) {
-            reject(new Error("The server page loaded empty."));
             return;
           }
           resolve();
         })
         .catch((inspectError: unknown) => {
+          contents.removeListener("render-process-gone", onGone);
           reject(inspectError instanceof Error ? inspectError : new Error(String(inspectError)));
         });
     };
@@ -255,6 +253,24 @@ function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
       },
     );
   });
+}
+
+/**
+ * Empty `#root` shells count as loaded HTML but are not a usable app. Wait until
+ * React (or an e2e `<main>` fixture) mounts visible content.
+ */
+async function waitForMountedAppDocument(contents: Electron.WebContents) {
+  const deadline = Date.now() + 8_000;
+  while (Date.now() < deadline) {
+    if (contents.isCrashed()) throw new Error("Renderer stopped after load.");
+    const state = (await contents.executeJavaScript(`({
+      rootChildren: document.getElementById("root")?.childElementCount ?? 0,
+      mainText: (document.querySelector("main")?.textContent ?? "").trim().length
+    })`)) as { rootChildren: number; mainText: number };
+    if (state.rootChildren > 0 || state.mainText > 0) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error("The server page did not become ready.");
 }
 
 async function installBundledRenderer(
@@ -509,6 +525,7 @@ function openFailureDetail(error: unknown): string {
     if (
       message.startsWith("The server answered with HTTP") ||
       message.startsWith("The server page loaded empty") ||
+      message.startsWith("The server page did not become ready") ||
       message.startsWith("Renderer stopped") ||
       message.startsWith("Page failed to load")
     ) {
@@ -575,6 +592,7 @@ function abandonPendingAppSwitch(
     // If setup was already closed (e.g. during a slow write), make the restored
     // session visible — otherwise macOS can be left with no shown window.
     if (setupWindow === null || setupWindow.isDestroyed()) {
+      clearTimeout(warmWindowTimer);
       previous.show();
       previous.focus();
     }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -343,18 +343,32 @@ function loadAppUrl(win: BrowserWindow, url: string): Promise<void> {
 }
 
 /**
- * Empty `#root` shells count as loaded HTML but are not a usable app. Wait until
- * React (or an e2e `<main>` fixture) mounts visible content.
+ * Empty `#root` shells and session-pending skeletons count as loaded HTML but are
+ * not a usable app. Wait until auth session resolves (or an e2e `<main>` fixture
+ * mounts without the pending marker).
  */
 async function waitForMountedAppDocument(contents: Electron.WebContents) {
   const deadline = Date.now() + 8_000;
   while (Date.now() < deadline) {
     if (contents.isCrashed()) throw new Error("Renderer stopped after load.");
     const state = (await contents.executeJavaScript(`({
+      appState: document.querySelector("[data-rakazo-app-state]")?.getAttribute("data-rakazo-app-state") ?? null,
       rootChildren: document.getElementById("root")?.childElementCount ?? 0,
-      mainText: (document.querySelector("main")?.textContent ?? "").trim().length
-    })`)) as { rootChildren: number; mainText: number };
-    if (state.rootChildren > 0 || state.mainText > 0) return;
+      mainText: (document.querySelector("main")?.textContent ?? "").trim().length,
+      sessionCommitted: performance.getEntriesByName("rk:renderer:session-committed").length > 0
+    })`)) as {
+      appState: string | null;
+      rootChildren: number;
+      mainText: number;
+      sessionCommitted: boolean;
+    };
+    if (state.appState === "session-pending") {
+      await new Promise((r) => setTimeout(r, 50));
+      continue;
+    }
+    if (state.appState === "ready" || state.sessionCommitted) return;
+    // Desktop e2e fixtures mount a plain `<main>` without the web app markers.
+    if (state.appState === null && (state.rootChildren > 0 || state.mainText > 0)) return;
     await new Promise((r) => setTimeout(r, 50));
   }
   throw new Error("The server page did not become ready.");

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -583,19 +583,6 @@ app.whenReady().then(async () => {
     if (fromSetupWindow(event)) app.quit();
   });
 
-  if (target.kind === "setup") {
-    showSetupWindow();
-  } else if (target.source === "saved") {
-    const reachability = await probeServer(target.url);
-    if (reachability.ok) {
-      if (await openApp(target.url)) destroySetupWindow();
-    } else {
-      showSetupWindow(`Could not reconnect to the saved server. ${reachability.error}`);
-    }
-  } else {
-    if (await openApp(target.url)) destroySetupWindow();
-  }
-
   app.on("activate", () => {
     if (setupWindow !== null && !setupWindow.isDestroyed()) {
       setupWindow.show();
@@ -612,6 +599,19 @@ app.whenReady().then(async () => {
     if (currentTargetUrl === null) showSetupWindow(setupError);
     else void openApp(currentTargetUrl);
   });
+
+  if (target.kind === "setup") {
+    showSetupWindow();
+  } else if (target.source === "saved") {
+    const reachability = await probeServer(target.url);
+    if (reachability.ok) {
+      if (await openApp(target.url)) destroySetupWindow();
+    } else {
+      showSetupWindow(`Could not reconnect to the saved server. ${reachability.error}`);
+    }
+  } else {
+    if (await openApp(target.url)) destroySetupWindow();
+  }
 });
 
 app.on("window-all-closed", () => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -651,6 +651,16 @@ function destroySetupWindow() {
   if (setup !== null && !setup.isDestroyed()) setup.destroy();
 }
 
+/** Best-effort restore of setup.json after a failed save that already wrote disk. */
+async function rollbackSetupFile(userDataDir: string, previousSetup: DesktopSetup | null) {
+  try {
+    if (previousSetup !== null) await writeSetup(userDataDir, previousSetup);
+    else await clearSetup(userDataDir);
+  } catch {
+    // Disk rollback is best-effort; callers already restored in-memory state when possible.
+  }
+}
+
 function safeOrigin(targetUrl: string) {
   try {
     return new URL(targetUrl).origin;
@@ -761,12 +771,7 @@ app.whenReady().then(async () => {
         await writeSetup(userDataDir, setup);
         if (rendererWatch?.crashed()) {
           abandonPendingAppSwitch(previousSetup, previousUrl);
-          try {
-            if (previousSetup !== null) await writeSetup(userDataDir, previousSetup);
-            else await clearSetup(userDataDir);
-          } catch {
-            // Best-effort disk rollback; in-memory session already restored.
-          }
+          await rollbackSetupFile(userDataDir, previousSetup);
           return {
             ok: false,
             error: "Could not open that server. Renderer stopped.",
@@ -774,6 +779,14 @@ app.whenReady().then(async () => {
         }
         // Commit while the crash listener is still armed, then dispose.
         commitPendingAppSwitch();
+        if (rendererWatch?.crashed()) {
+          // Previous window is already gone; still roll back disk for next launch.
+          await rollbackSetupFile(userDataDir, previousSetup);
+          return {
+            ok: false,
+            error: "Could not open that server. Renderer stopped.",
+          };
+        }
       } catch {
         const outcome = abandonPendingAppSwitch(previousSetup, previousUrl);
         return {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -154,6 +154,8 @@ function createWindow(url: string, partition: string | null) {
 }
 
 async function probeDocument(url: string): Promise<string | null> {
+  // Test/dev harnesses may load data: or file: documents; only probe real servers.
+  if (!url.startsWith("http://") && !url.startsWith("https://")) return null;
   try {
     const response = await net.fetch(url, {
       method: "GET",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { readFile, stat } from "node:fs/promises";
+import { readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { DesktopReachability, DesktopSetup } from "@rakazo/contracts";
 import { app, BrowserWindow, ipcMain, Menu, net, type Session, session, shell } from "electron";
@@ -408,20 +408,62 @@ async function openAppOnce(targetUrl: string) {
   const target = sessionForTarget(targetUrl);
   let win: BrowserWindow | null = null;
   try {
+    await migrateDefaultSessionCookies(targetUrl, target.value, target.partition);
     await installBundledRenderer(targetUrl, target.value, target.partition);
     const created = createWindow(targetUrl, target.partition);
     win = created.win;
     await created.loaded;
     currentTargetUrl = targetUrl;
     setupError = null;
-    const setup = setupWindow;
-    setupWindow = null;
-    if (setup !== null && !setup.isDestroyed()) setup.destroy();
     return true;
   } catch (error) {
     if (win !== null && !win.isDestroyed()) win.destroy();
     showSetupWindow(`Could not open that server. ${probeFailureMessage(error)}`);
     return false;
+  }
+}
+
+function destroySetupWindow() {
+  const setup = setupWindow;
+  setupWindow = null;
+  if (setup !== null && !setup.isDestroyed()) setup.destroy();
+}
+
+/**
+ * First launch after this feature may still have auth cookies in the default session
+ * (pre-partition installs). Copy matching origin cookies into the per-origin partition once.
+ */
+async function migrateDefaultSessionCookies(
+  targetUrl: string,
+  targetSession: Session,
+  partition: string | null,
+) {
+  if (partition === null || targetSession === session.defaultSession) return;
+  const origin = safeOrigin(targetUrl);
+  if (origin === null) return;
+  const marker = path.join(
+    app.getPath("userData"),
+    `session-migrated-${partition.replace(/[^a-zA-Z0-9_-]/g, "_")}.flag`,
+  );
+  if (existsSync(marker)) return;
+  try {
+    const cookies = await session.defaultSession.cookies.get({ url: origin });
+    for (const cookie of cookies) {
+      await targetSession.cookies.set({
+        url: origin,
+        name: cookie.name,
+        value: cookie.value,
+        domain: cookie.domain,
+        path: cookie.path,
+        secure: cookie.secure,
+        httpOnly: cookie.httpOnly,
+        expirationDate: cookie.expirationDate,
+        sameSite: cookie.sameSite,
+      });
+    }
+    await writeFile(marker, new Date().toISOString(), "utf8");
+  } catch {
+    // Migration is best-effort; a failed copy must not block opening the app.
   }
 }
 
@@ -498,6 +540,7 @@ app.whenReady().then(async () => {
     if (setupSaveInProgress)
       return { ok: false, error: "A connection attempt is already running." };
     setupSaveInProgress = true;
+    const previousSetup = currentSetup;
     try {
       const setup = parseSetupInput(payload);
       if (setup === null) {
@@ -511,17 +554,28 @@ app.whenReady().then(async () => {
       const reachability = await probeServer(setup.serverUrl);
       if (!reachability.ok) return { ok: false, error: reachability.error };
 
+      // Open before persisting so a failed renderer load keeps the last working setup.
+      currentSetup = setup;
+      const opened = await openApp(setup.serverUrl);
+      if (!opened) {
+        currentSetup = previousSetup;
+        return {
+          ok: false,
+          error: "Could not open that server. The previous instance was left unchanged.",
+        };
+      }
+
       try {
         await writeSetup(userDataDir, setup);
       } catch {
+        // The app window is already on the new server; keep currentSetup aligned with it.
+        destroySetupWindow();
         return {
           ok: false,
-          error: "Could not save setup. Check that Rakazo can write to its app-data directory.",
+          error: "Connected, but could not save setup for the next launch.",
         };
       }
-      currentSetup = setup;
-      // Answer the setup window before tearing it down, otherwise the reply is lost.
-      setImmediate(() => void openApp(setup.serverUrl));
+      destroySetupWindow();
       return { ok: true };
     } finally {
       setupSaveInProgress = false;
@@ -537,12 +591,12 @@ app.whenReady().then(async () => {
   } else if (target.source === "saved") {
     const reachability = await probeServer(target.url);
     if (reachability.ok) {
-      await openApp(target.url);
+      if (await openApp(target.url)) destroySetupWindow();
     } else {
       showSetupWindow(`Could not reconnect to the saved server. ${reachability.error}`);
     }
   } else {
-    await openApp(target.url);
+    if (await openApp(target.url)) destroySetupWindow();
   }
 
   app.on("activate", () => {

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -1,22 +1,28 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
-import type { RakazoDesktop } from "@rakazo/contracts";
+import type { RakazoDesktop, RakazoSetup } from "@rakazo/contracts";
 import { describe, expect, it, vi } from "vitest";
+
+function runPreload(file: string) {
+  const invoke = vi.fn(async (channel: string) => ({ channel }));
+  const exposeInMainWorld = vi.fn();
+  const source = readFileSync(path.join(import.meta.dirname, file), "utf8");
+
+  vm.runInNewContext(source, {
+    process: { platform: "linux" },
+    require(moduleName: string) {
+      if (moduleName !== "electron") throw new Error(`Unexpected preload import: ${moduleName}`);
+      return { contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke } };
+    },
+  });
+
+  return { invoke, exposeInMainWorld };
+}
 
 describe("desktop preload bridge", () => {
   it("exposes only the platform and the four window operations", async () => {
-    const invoke = vi.fn(async (channel: string) => ({ channel }));
-    const exposeInMainWorld = vi.fn();
-    const source = readFileSync(path.join(import.meta.dirname, "preload.cjs"), "utf8");
-
-    vm.runInNewContext(source, {
-      process: { platform: "linux" },
-      require(moduleName: string) {
-        if (moduleName !== "electron") throw new Error(`Unexpected preload import: ${moduleName}`);
-        return { contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke } };
-      },
-    });
+    const { invoke, exposeInMainWorld } = runPreload("preload.cjs");
 
     expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
     const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoDesktop];
@@ -38,6 +44,34 @@ describe("desktop preload bridge", () => {
       "desktop.window.minimize",
       "desktop.window.toggleMaximize",
       "desktop.window.state",
+    ]);
+  });
+
+  it("keeps setup off the app bridge so a connected server cannot re-point the app", () => {
+    const { exposeInMainWorld } = runPreload("preload.cjs");
+    const [, bridge] = exposeInMainWorld.mock.calls[0] as [string, Record<string, unknown>];
+    expect(Object.keys(bridge).sort()).toEqual(["platform", "window"]);
+  });
+});
+
+describe("setup preload bridge", () => {
+  it("exposes only the first-run setup operations", async () => {
+    const { invoke, exposeInMainWorld } = runPreload("setup-preload.cjs");
+
+    expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
+    const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoSetup];
+    expect(globalName).toBe("rakazoSetup");
+    expect(Object.keys(bridge).sort()).toEqual(["quit", "save", "state", "test"]);
+
+    await bridge.state();
+    await bridge.test("http://127.0.0.1:5173");
+    await bridge.save({ mode: "new", serverUrl: "http://127.0.0.1:5173" });
+    await bridge.quit();
+    expect(invoke.mock.calls.map(([channel]) => channel)).toEqual([
+      "desktop.setup.state",
+      "desktop.setup.test",
+      "desktop.setup.save",
+      "desktop.setup.quit",
     ]);
   });
 });

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -42,6 +42,14 @@ describe("server address normalization", () => {
     expect(normalizeServerUrl("http://[fd00::1]:3100")).toBe("http://[fd00::1]:3100");
   });
 
+  it("rejects cleartext link-local addresses used by cloud metadata endpoints", () => {
+    expect(normalizeServerUrl("http://169.254.169.254")).toBeNull();
+    expect(normalizeServerUrl("http://169.254.1.1:80")).toBeNull();
+    expect(normalizeServerUrl("http://[fe80::1]:3100")).toBeNull();
+    // HTTPS to link-local still normalizes; the health probe must match Rakazo.
+    expect(normalizeServerUrl("https://169.254.169.254")).toBe("https://169.254.169.254");
+  });
+
   it.each(["", "   ", "not a url", "ftp://example.com", "file:///etc/passwd", "http://"])(
     "rejects an address that cannot reach a Rakazo server (%s)",
     (value) => {

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LOCAL_WEB_URL,
+  isRakazoHealth,
+  normalizeServerUrl,
+  parseSetupInput,
+  parseStoredSetup,
+  probeFailureMessage,
+  resolveStartupTarget,
+  safeExternalUrl,
+  serializeSetup,
+  servesBundledRenderer,
+  sessionPartitionForServerUrl,
+} from "./setup-config.js";
+
+describe("server address normalization", () => {
+  it("assumes http locally and https for a bare public host", () => {
+    expect(normalizeServerUrl("127.0.0.1:5173")).toBe("http://127.0.0.1:5173");
+    expect(normalizeServerUrl("localhost:5173")).toBe("http://localhost:5173");
+    expect(normalizeServerUrl("192.168.1.20:3100")).toBe("http://192.168.1.20:3100");
+    expect(normalizeServerUrl("rakazo.example.com")).toBe("https://rakazo.example.com");
+  });
+
+  it("keeps an explicit secure scheme and port but stores only the origin", () => {
+    expect(normalizeServerUrl("https://rakazo.example.com")).toBe("https://rakazo.example.com");
+    expect(normalizeServerUrl("https://rakazo.example.com:8443/team")).toBe(
+      "https://rakazo.example.com:8443",
+    );
+  });
+
+  it("trims surrounding space, trailing slashes, queries, and fragments", () => {
+    expect(normalizeServerUrl("  http://127.0.0.1:5173/  ")).toBe("http://127.0.0.1:5173");
+    expect(normalizeServerUrl("http://127.0.0.1:5173///")).toBe("http://127.0.0.1:5173");
+    expect(normalizeServerUrl("http://127.0.0.1:5173/?next=/bots#top")).toBe(
+      "http://127.0.0.1:5173",
+    );
+  });
+
+  it("rejects cleartext public servers but permits private-network development", () => {
+    expect(normalizeServerUrl("http://rakazo.example.com")).toBeNull();
+    expect(normalizeServerUrl("http://10.0.0.8:3100")).toBe("http://10.0.0.8:3100");
+    expect(normalizeServerUrl("http://[fd00::1]:3100")).toBe("http://[fd00::1]:3100");
+  });
+
+  it.each(["", "   ", "not a url", "ftp://example.com", "file:///etc/passwd", "http://"])(
+    "rejects an address that cannot reach a Rakazo server (%s)",
+    (value) => {
+      expect(normalizeServerUrl(value)).toBeNull();
+    },
+  );
+
+  it("rejects embedded credentials rather than writing them to disk", () => {
+    expect(normalizeServerUrl("https://user:secret@rakazo.example.com")).toBeNull();
+  });
+});
+
+describe("saved setup", () => {
+  it("round-trips through the on-disk format", () => {
+    const setup = { mode: "existing", serverUrl: "https://rakazo.example.com" } as const;
+    expect(parseStoredSetup(serializeSetup(setup))).toEqual(setup);
+  });
+
+  it("normalizes the address it reads back", () => {
+    expect(parseStoredSetup('{"mode":"new","serverUrl":"127.0.0.1:5173/"}')).toEqual({
+      mode: "new",
+      serverUrl: "http://127.0.0.1:5173",
+    });
+  });
+
+  it.each([
+    ["not json", "{oops"],
+    ["a non-object", '"nope"'],
+    ["an unknown mode", '{"mode":"other","serverUrl":"http://127.0.0.1:5173"}'],
+    ["a missing address", '{"mode":"new"}'],
+    ["an unusable address", '{"mode":"new","serverUrl":"ftp://example.com"}'],
+  ])("discards %s so setup runs again", (_label, raw) => {
+    expect(parseStoredSetup(raw)).toBeNull();
+  });
+
+  it("rejects an untrusted payload that is not a setup", () => {
+    expect(parseSetupInput(null)).toBeNull();
+    expect(parseSetupInput({ mode: "new", serverUrl: 5173 })).toBeNull();
+  });
+
+  it("keeps the new-instance choice on this computer", () => {
+    expect(parseSetupInput({ mode: "new", serverUrl: "http://192.168.1.20:3100" })).toBeNull();
+    expect(parseSetupInput({ mode: "existing", serverUrl: "http://192.168.1.20:3100" })).toEqual({
+      mode: "existing",
+      serverUrl: "http://192.168.1.20:3100",
+    });
+  });
+});
+
+describe("startup target", () => {
+  const saved = { mode: "existing", serverUrl: "https://rakazo.example.com" } as const;
+
+  it("runs setup on a first launch", () => {
+    expect(resolveStartupTarget({})).toEqual({ kind: "setup" });
+  });
+
+  it("opens the saved instance on later launches", () => {
+    expect(resolveStartupTarget({ saved })).toEqual({
+      kind: "app",
+      url: "https://rakazo.example.com",
+      source: "saved",
+    });
+  });
+
+  it("lets RAKAZO_WEB_URL point the shell anywhere without touching saved setup", () => {
+    expect(resolveStartupTarget({ envUrl: "http://127.0.0.1:4321", saved })).toEqual({
+      kind: "app",
+      url: "http://127.0.0.1:4321",
+      source: "env",
+    });
+  });
+
+  it("ignores an empty RAKAZO_WEB_URL", () => {
+    expect(resolveStartupTarget({ envUrl: "   ", saved }).kind).toBe("app");
+    expect(resolveStartupTarget({ envUrl: "   ", saved })).toMatchObject({ source: "saved" });
+  });
+
+  it("re-runs setup when forced, even with saved configuration", () => {
+    expect(resolveStartupTarget({ saved, forceSetup: true })).toEqual({ kind: "setup" });
+  });
+
+  it("re-runs setup when the saved address is unusable", () => {
+    expect(resolveStartupTarget({ saved: { mode: "new", serverUrl: "nope://x" } })).toEqual({
+      kind: "setup",
+    });
+    expect(
+      resolveStartupTarget({
+        saved: { mode: "new", serverUrl: "http://192.168.1.20:3100" },
+      }),
+    ).toEqual({ kind: "setup" });
+  });
+});
+
+describe("bundled renderer eligibility", () => {
+  it("stands in for http(s) origins only", () => {
+    expect(servesBundledRenderer(DEFAULT_LOCAL_WEB_URL)).toBe(true);
+    expect(servesBundledRenderer("https://rakazo.example.com")).toBe(true);
+    expect(servesBundledRenderer("data:text/html,<p>fixture</p>")).toBe(false);
+    expect(servesBundledRenderer("nonsense")).toBe(false);
+  });
+});
+
+describe("remote-content isolation", () => {
+  it("uses a stable, opaque session partition per server origin", () => {
+    const first = sessionPartitionForServerUrl("https://one.example.com/path");
+    expect(first).toBe(sessionPartitionForServerUrl("https://one.example.com/other"));
+    expect(first).not.toBe(sessionPartitionForServerUrl("https://one.example.com:8443"));
+    expect(first).toMatch(/^persist:rakazo-[a-f0-9]{24}$/);
+    expect(first).not.toContain("one.example.com");
+    expect(sessionPartitionForServerUrl("data:text/html,fixture")).toBeNull();
+  });
+
+  it("opens only web URLs outside Electron", () => {
+    expect(safeExternalUrl("https://example.com/docs")).toBe("https://example.com/docs");
+    expect(safeExternalUrl("mailto:person@example.com")).toBeNull();
+    expect(safeExternalUrl("file:///etc/passwd")).toBeNull();
+  });
+});
+
+describe("Rakazo health response", () => {
+  it("requires the public RPC health contract", () => {
+    expect(isRakazoHealth({ json: { ok: true, version: "0.1.0" } })).toBe(true);
+    expect(isRakazoHealth({ json: { ok: true } })).toBe(false);
+    expect(isRakazoHealth({ ok: true, version: "0.1.0" })).toBe(false);
+  });
+});
+
+describe("probe failures", () => {
+  it.each([
+    ["TimeoutError", "Timed out reaching that address."],
+    ["AbortError", "Timed out reaching that address."],
+  ])("explains %s", (name, expected) => {
+    const error = new Error("stopped");
+    error.name = name;
+    expect(probeFailureMessage(error)).toBe(expected);
+  });
+
+  it.each([
+    ["net::ERR_CONNECTION_REFUSED", "Nothing is listening at that address yet."],
+    ["net::ERR_NAME_NOT_RESOLVED", "That host could not be found."],
+    ["net::ERR_CERT_AUTHORITY_INVALID", "The server's HTTPS certificate was rejected."],
+    ["something else entirely", "Could not reach that address."],
+  ])("explains %s", (message, expected) => {
+    expect(probeFailureMessage(new Error(message))).toBe(expected);
+  });
+});

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -160,23 +160,42 @@ function isLoopbackHost(hostname: string) {
   return isIP(host) === 6 && host === "::1";
 }
 
+/**
+ * Link-local addresses (IPv4 169.254/16, IPv6 fe80::/10) often host cloud
+ * metadata endpoints. Cleartext HTTP to them is never a legitimate Rakazo
+ * deploy target, so they stay out of the private-network HTTP allowlist.
+ */
+function isLinkLocalHost(hostname: string) {
+  const host = unbracketedHost(hostname);
+  if (isIP(host) === 4) {
+    const [first, second] = host.split(".").map(Number);
+    return first === 169 && second === 254;
+  }
+  if (isIP(host) === 6) {
+    const first = host.split(":", 1)[0] ?? "";
+    return /^fe[89ab]/.test(first);
+  }
+  return false;
+}
+
 function isLocalNetworkHost(hostname: string) {
   const host = unbracketedHost(hostname);
   if (isLoopbackHost(host) || host.endsWith(".local")) return true;
+  if (isLinkLocalHost(host)) return false;
 
   if (isIP(host) === 4) {
     const [first, second] = host.split(".").map(Number);
     return (
       first === 10 ||
       (first === 172 && second !== undefined && second >= 16 && second <= 31) ||
-      (first === 192 && second === 168) ||
-      (first === 169 && second === 254)
+      (first === 192 && second === 168)
     );
   }
 
   if (isIP(host) === 6) {
     const first = host.split(":", 1)[0] ?? "";
-    return /^f[cd]/.test(first) || /^fe[89ab]/.test(first);
+    // Unique-local only (fc00::/7). Link-local is rejected above.
+    return /^f[cd]/.test(first);
   }
   return false;
 }

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import { isIP } from "node:net";
+import type { DesktopSetup } from "@rakazo/contracts";
+
+/** Where `pnpm dev` serves the Rakazo web app on this machine. */
+export const DEFAULT_LOCAL_WEB_URL = "http://127.0.0.1:5173";
+
+export const SETUP_FILE_NAME = "setup.json";
+
+export type StartupTarget =
+  | { kind: "app"; url: string; source: "env" | "saved" }
+  | { kind: "setup" };
+
+const SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+
+/**
+ * Accepts what a person would actually type ("localhost:5173", "rakazo.example.com")
+ * and returns a canonical http(s) origin, or null when the input can never
+ * securely address a Rakazo server.
+ */
+export function normalizeServerUrl(input: string): string | null {
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+
+  let url: URL;
+  try {
+    if (SCHEME.test(trimmed)) {
+      url = new URL(trimmed);
+    } else {
+      const candidate = new URL(`http://${trimmed}`);
+      url = isLocalNetworkHost(candidate.hostname) ? candidate : new URL(`https://${trimmed}`);
+    }
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  if (url.hostname === "") return null;
+  // Embedded credentials would be written to disk in cleartext.
+  if (url.username !== "" || url.password !== "") return null;
+  // Public login cookies and API traffic must never cross a cleartext connection.
+  if (url.protocol === "http:" && !isLocalNetworkHost(url.hostname)) return null;
+
+  // Rakazo serves its renderer, RPC, and auth routes from one origin. Keeping a
+  // user-supplied path would make the setup probe and the loaded app disagree.
+  return url.origin;
+}
+
+/** Validates an untrusted value (saved file or IPC payload) into a usable setup. */
+export function parseSetupInput(value: unknown): DesktopSetup | null {
+  if (typeof value !== "object" || value === null) return null;
+
+  const { mode, serverUrl } = value as Record<string, unknown>;
+  if (mode !== "new" && mode !== "existing") return null;
+  if (typeof serverUrl !== "string") return null;
+
+  const normalized = normalizeServerUrl(serverUrl);
+  if (normalized === null) return null;
+  if (mode === "new" && !isLoopbackHost(new URL(normalized).hostname)) return null;
+  return { mode, serverUrl: normalized };
+}
+
+export function parseStoredSetup(raw: string): DesktopSetup | null {
+  try {
+    return parseSetupInput(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function serializeSetup(setup: DesktopSetup): string {
+  return `${JSON.stringify(setup, null, 2)}\n`;
+}
+
+/**
+ * Decides between the first-run setup window and the app window. An explicit
+ * `RAKAZO_WEB_URL` still wins over saved configuration so test and performance
+ * harnesses can point the shell anywhere without touching a user's real setup.
+ */
+export function resolveStartupTarget(input: {
+  envUrl?: string;
+  saved?: DesktopSetup | null;
+  forceSetup?: boolean;
+}): StartupTarget {
+  if (input.forceSetup === true) return { kind: "setup" };
+
+  const envUrl = input.envUrl?.trim();
+  if (envUrl !== undefined && envUrl !== "") return { kind: "app", url: envUrl, source: "env" };
+
+  if (input.saved != null) {
+    const saved = parseSetupInput(input.saved);
+    if (saved !== null) return { kind: "app", url: saved.serverUrl, source: "saved" };
+  }
+  return { kind: "setup" };
+}
+
+/** Turns a network failure into something a person can act on. */
+export function probeFailureMessage(error: unknown): string {
+  const name = error instanceof Error ? error.name : "";
+  if (name === "TimeoutError" || name === "AbortError") {
+    return "Timed out reaching that address.";
+  }
+
+  const detail = error instanceof Error ? error.message : String(error);
+  if (detail.includes("CONNECTION_REFUSED") || detail.includes("ECONNREFUSED")) {
+    return "Nothing is listening at that address yet.";
+  }
+  if (detail.includes("NAME_NOT_RESOLVED") || detail.includes("ENOTFOUND")) {
+    return "That host could not be found.";
+  }
+  if (detail.includes("CERT_") || detail.includes("SSL")) {
+    return "The server's HTTPS certificate was rejected.";
+  }
+  return "Could not reach that address.";
+}
+
+/** The bundled renderer only stands in for a real http(s) origin. */
+export function servesBundledRenderer(targetUrl: string): boolean {
+  try {
+    const { protocol } = new URL(targetUrl);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** Each Rakazo origin gets its own persistent cookie and storage partition. */
+export function sessionPartitionForServerUrl(targetUrl: string): string | null {
+  try {
+    const url = new URL(targetUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    const digest = createHash("sha256").update(url.origin).digest("hex").slice(0, 24);
+    return `persist:rakazo-${digest}`;
+  } catch {
+    return null;
+  }
+}
+
+/** External pages are opened by the OS, never in a privileged Electron child window. */
+export function safeExternalUrl(targetUrl: string): string | null {
+  if (!servesBundledRenderer(targetUrl)) return null;
+  return new URL(targetUrl).toString();
+}
+
+export function isRakazoHealth(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const json = (value as { json?: unknown }).json;
+  return (
+    typeof json === "object" &&
+    json !== null &&
+    (json as { ok?: unknown }).ok === true &&
+    typeof (json as { version?: unknown }).version === "string"
+  );
+}
+
+function isLoopbackHost(hostname: string) {
+  const host = unbracketedHost(hostname);
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (isIP(host) === 4) return host.startsWith("127.");
+  return isIP(host) === 6 && host === "::1";
+}
+
+function isLocalNetworkHost(hostname: string) {
+  const host = unbracketedHost(hostname);
+  if (isLoopbackHost(host) || host.endsWith(".local")) return true;
+
+  if (isIP(host) === 4) {
+    const [first, second] = host.split(".").map(Number);
+    return (
+      first === 10 ||
+      (first === 172 && second !== undefined && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168) ||
+      (first === 169 && second === 254)
+    );
+  }
+
+  if (isIP(host) === 6) {
+    const first = host.split(":", 1)[0] ?? "";
+    return /^f[cd]/.test(first) || /^fe[89ab]/.test(first);
+  }
+  return false;
+}
+
+function unbracketedHost(hostname: string) {
+  return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+}

--- a/apps/desktop/src/setup-preload.cjs
+++ b/apps/desktop/src/setup-preload.cjs
@@ -1,0 +1,8 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("rakazoSetup", {
+  state: () => ipcRenderer.invoke("desktop.setup.state"),
+  test: (url) => ipcRenderer.invoke("desktop.setup.test", url),
+  save: (setup) => ipcRenderer.invoke("desktop.setup.save", setup),
+  quit: () => ipcRenderer.invoke("desktop.setup.quit"),
+});

--- a/apps/desktop/src/setup-store.test.ts
+++ b/apps/desktop/src/setup-store.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promise
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readSetup, setupFilePath, writeSetup } from "./setup-store.js";
+import { clearSetup, readSetup, setupFilePath, writeSetup } from "./setup-store.js";
 
 let userData: string;
 
@@ -25,6 +25,12 @@ describe("setup store", () => {
       mode: "existing",
       serverUrl: "https://rakazo.example.com",
     });
+  });
+
+  it("clears saved setup so first-run runs again", async () => {
+    await writeSetup(userData, { mode: "existing", serverUrl: "https://rakazo.example.com" });
+    await clearSetup(userData);
+    await expect(readSetup(userData)).resolves.toBeNull();
   });
 
   it("creates the user data directory when it does not exist yet", async () => {

--- a/apps/desktop/src/setup-store.test.ts
+++ b/apps/desktop/src/setup-store.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readSetup, setupFilePath, writeSetup } from "./setup-store.js";
+
+let userData: string;
+
+beforeEach(async () => {
+  userData = await mkdtemp(path.join(tmpdir(), "rakazo-setup-"));
+});
+
+afterEach(async () => {
+  await rm(userData, { recursive: true, force: true });
+});
+
+describe("setup store", () => {
+  it("reports no setup before the first run", async () => {
+    await expect(readSetup(userData)).resolves.toBeNull();
+  });
+
+  it("keeps the chosen instance across launches", async () => {
+    await writeSetup(userData, { mode: "existing", serverUrl: "https://rakazo.example.com" });
+    await expect(readSetup(userData)).resolves.toEqual({
+      mode: "existing",
+      serverUrl: "https://rakazo.example.com",
+    });
+  });
+
+  it("creates the user data directory when it does not exist yet", async () => {
+    const nested = path.join(userData, "nested", "profile");
+    await writeSetup(nested, { mode: "new", serverUrl: "http://127.0.0.1:5173" });
+    await expect(readSetup(nested)).resolves.toEqual({
+      mode: "new",
+      serverUrl: "http://127.0.0.1:5173",
+    });
+  });
+
+  it.runIf(process.platform !== "win32")("keeps the saved address private", async () => {
+    await writeSetup(userData, { mode: "existing", serverUrl: "https://rakazo.example.com" });
+    const info = await stat(setupFilePath(userData));
+    expect(info.mode & 0o777).toBe(0o600);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "replaces a final symlink instead of overwriting its target",
+    async () => {
+      const victim = path.join(userData, "victim.txt");
+      await writeFile(victim, "untouched", "utf8");
+      await symlink(victim, setupFilePath(userData));
+
+      await writeSetup(userData, { mode: "existing", serverUrl: "https://rakazo.example.com" });
+
+      await expect(readSetup(userData)).resolves.toEqual({
+        mode: "existing",
+        serverUrl: "https://rakazo.example.com",
+      });
+      await expect(readFile(victim, "utf8")).resolves.toBe("untouched");
+    },
+  );
+
+  it("falls back to setup when the saved file is corrupt", async () => {
+    await writeFile(setupFilePath(userData), "{ not json", "utf8");
+    await expect(readSetup(userData)).resolves.toBeNull();
+  });
+});

--- a/apps/desktop/src/setup-store.ts
+++ b/apps/desktop/src/setup-store.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import type { DesktopSetup } from "@rakazo/contracts";
+import { parseStoredSetup, SETUP_FILE_NAME, serializeSetup } from "./setup-config.js";
+
+export function setupFilePath(userDataDir: string): string {
+  return path.join(userDataDir, SETUP_FILE_NAME);
+}
+
+/** Returns null when setup has not run yet, or when the saved file is unusable. */
+export async function readSetup(userDataDir: string): Promise<DesktopSetup | null> {
+  let raw: string;
+  try {
+    raw = await readFile(setupFilePath(userDataDir), "utf8");
+  } catch {
+    return null;
+  }
+  return parseStoredSetup(raw);
+}
+
+export async function writeSetup(userDataDir: string, setup: DesktopSetup): Promise<void> {
+  await mkdir(userDataDir, { recursive: true });
+  const destination = setupFilePath(userDataDir);
+  const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+  let file: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    file = await open(temporary, "wx", 0o600);
+    await file.writeFile(serializeSetup(setup), "utf8");
+    await file.sync();
+    await file.close();
+    file = undefined;
+    // Replacing the complete file avoids following a malicious final symlink and
+    // leaves either the old or new valid JSON after an interrupted write.
+    await rename(temporary, destination);
+  } finally {
+    await file?.close().catch(() => undefined);
+    await rm(temporary, { force: true }).catch(() => undefined);
+  }
+}

--- a/apps/desktop/src/setup-store.ts
+++ b/apps/desktop/src/setup-store.ts
@@ -38,3 +38,8 @@ export async function writeSetup(userDataDir: string, setup: DesktopSetup): Prom
     await rm(temporary, { force: true }).catch(() => undefined);
   }
 }
+
+/** Removes saved setup so the next launch runs first-run again. */
+export async function clearSetup(userDataDir: string): Promise<void> {
+  await rm(setupFilePath(userDataDir), { force: true });
+}

--- a/apps/desktop/src/setup.css
+++ b/apps/desktop/src/setup.css
@@ -1,0 +1,277 @@
+:root {
+  color-scheme: dark;
+  --bg: #050506;
+  --panel: #0f0f12;
+  --panel-raised: #17171c;
+  --border: #26262e;
+  --border-strong: #3a3a46;
+  --text: #f4f4f6;
+  --text-muted: #9a9aa8;
+  --accent: #2563eb;
+  --accent-hover: #3b76f2;
+  --danger: #f87171;
+  --ok: #4ade80;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    "Segoe UI", -apple-system, BlinkMacSystemFont, Inter, Roboto, Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.titlebar {
+  -webkit-app-region: drag;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  flex: none;
+}
+
+.titlebar-name {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.titlebar-quit {
+  -webkit-app-region: no-drag;
+  background: none;
+  border: 0;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+
+.titlebar-quit:hover {
+  color: var(--text);
+  background: var(--panel-raised);
+}
+
+.shell {
+  flex: 1;
+  width: 100%;
+  max-width: 620px;
+  margin: 0 auto;
+  padding: 24px 28px 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.heading {
+  margin: 0 0 8px;
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.subheading {
+  margin: 0 0 24px;
+  color: var(--text-muted);
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px;
+}
+
+.choices {
+  border: 0;
+  margin: 0 0 18px;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.choice {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel-raised);
+  cursor: pointer;
+}
+
+.choice:hover {
+  border-color: var(--border-strong);
+}
+
+.choice:has(input:checked) {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, var(--panel-raised));
+}
+
+.choice:has(input:focus-visible) {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.choice input {
+  margin: 2px 0 0;
+  accent-color: var(--accent);
+  flex: none;
+}
+
+.choice-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.choice-title {
+  font-weight: 600;
+}
+
+.choice-note {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.panel {
+  margin-bottom: 4px;
+}
+
+.field-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.field {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 9px;
+  border: 1px solid var(--border-strong);
+  background: #08080a;
+  color: var(--text);
+  font: inherit;
+  font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
+  font-size: 13px;
+}
+
+.field:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-color: var(--accent);
+}
+
+.hint {
+  margin: 8px 0 0;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+.hint code {
+  background: var(--panel-raised);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 1px 5px;
+  font-size: 12px;
+}
+
+.status {
+  margin: 14px 0 0;
+  min-height: 20px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.status[data-tone="ok"] {
+  color: var(--ok);
+}
+
+.status[data-tone="error"] {
+  color: var(--danger);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.button {
+  font: inherit;
+  font-weight: 600;
+  padding: 9px 18px;
+  border-radius: 9px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.button-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.button-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.button-secondary {
+  background: var(--panel-raised);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+.button-secondary:hover:not(:disabled) {
+  border-color: var(--text-muted);
+}
+
+.footnote {
+  margin: 16px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}

--- a/apps/desktop/src/setup.html
+++ b/apps/desktop/src/setup.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; form-action 'none'; base-uri 'none'"
+    />
+    <title>Set up Rakazo</title>
+    <link rel="stylesheet" href="setup.css" />
+  </head>
+  <body>
+    <header class="titlebar">
+      <span class="titlebar-name">Rakazo</span>
+      <button id="quit" class="titlebar-quit" type="button" title="Quit Rakazo">Quit</button>
+    </header>
+
+    <main class="shell">
+      <h1 class="heading">Welcome to Rakazo</h1>
+      <p class="subheading">
+        Rakazo runs on a server that hosts your bots, memory, and computers. Choose how this desktop
+        app should connect.
+      </p>
+
+      <form id="setup" class="card" novalidate>
+        <fieldset class="choices">
+          <legend class="sr-only">Instance</legend>
+
+          <label class="choice" for="mode-new">
+            <input id="mode-new" type="radio" name="mode" value="new" checked />
+            <span class="choice-body">
+              <span class="choice-title">Use an instance on this computer</span>
+              <span class="choice-note">
+                Use a Rakazo stack running on this computer. Best if you are self-hosting locally.
+              </span>
+            </span>
+          </label>
+
+          <label class="choice" for="mode-existing">
+            <input id="mode-existing" type="radio" name="mode" value="existing" />
+            <span class="choice-body">
+              <span class="choice-title">Connect to an existing instance</span>
+              <span class="choice-note">
+                Point at a Rakazo server you or your team already runs.
+              </span>
+            </span>
+          </label>
+        </fieldset>
+
+        <section id="panel-new" class="panel">
+          <label class="field-label" for="local-url">Local server address</label>
+          <input id="local-url" class="field" type="text" spellcheck="false" autocomplete="off" />
+          <p class="hint">
+            Not running yet? Start the stack from your Rakazo checkout with
+            <code>pnpm dev</code>, then check again.
+          </p>
+        </section>
+
+        <section id="panel-existing" class="panel" hidden>
+          <label class="field-label" for="server-url">Server address</label>
+          <input
+            id="server-url"
+            class="field"
+            type="text"
+            spellcheck="false"
+            autocomplete="off"
+            placeholder="https://rakazo.example.com"
+          />
+          <p class="hint">Use the address you open Rakazo with in a browser.</p>
+        </section>
+
+        <p id="status" class="status" role="status" aria-live="polite"></p>
+
+        <div class="actions">
+          <button id="check" class="button button-secondary" type="button">Check connection</button>
+          <button id="continue" class="button button-primary" type="submit">Continue</button>
+        </div>
+      </form>
+
+      <p class="footnote">
+        You can change this later from the Rakazo application menu (Command/Ctrl + Shift + K).
+      </p>
+    </main>
+
+    <script src="setup.js"></script>
+  </body>
+</html>

--- a/apps/desktop/src/setup.html
+++ b/apps/desktop/src/setup.html
@@ -17,10 +17,7 @@
 
     <main class="shell">
       <h1 class="heading">Welcome to Rakazo</h1>
-      <p class="subheading">
-        Rakazo runs on a server that hosts your bots, memory, and computers. Choose how this desktop
-        app should connect.
-      </p>
+      <p class="subheading">Choose which server this app should use.</p>
 
       <form id="setup" class="card" novalidate>
         <fieldset class="choices">
@@ -29,31 +26,24 @@
           <label class="choice" for="mode-new">
             <input id="mode-new" type="radio" name="mode" value="new" checked />
             <span class="choice-body">
-              <span class="choice-title">Use an instance on this computer</span>
-              <span class="choice-note">
-                Use a Rakazo stack running on this computer. Best if you are self-hosting locally.
-              </span>
+              <span class="choice-title">This computer</span>
+              <span class="choice-note">Local Rakazo stack.</span>
             </span>
           </label>
 
           <label class="choice" for="mode-existing">
             <input id="mode-existing" type="radio" name="mode" value="existing" />
             <span class="choice-body">
-              <span class="choice-title">Connect to an existing instance</span>
-              <span class="choice-note">
-                Point at a Rakazo server you or your team already runs.
-              </span>
+              <span class="choice-title">Existing instance</span>
+              <span class="choice-note">A server you already run.</span>
             </span>
           </label>
         </fieldset>
 
         <section id="panel-new" class="panel">
-          <label class="field-label" for="local-url">Local server address</label>
+          <label class="field-label" for="local-url">Local address</label>
           <input id="local-url" class="field" type="text" spellcheck="false" autocomplete="off" />
-          <p class="hint">
-            Not running yet? Start the stack from your Rakazo checkout with
-            <code>pnpm dev</code>, then check again.
-          </p>
+          <p class="hint">If it isn’t running yet, start with <code>pnpm dev</code>.</p>
         </section>
 
         <section id="panel-existing" class="panel" hidden>
@@ -66,7 +56,7 @@
             autocomplete="off"
             placeholder="https://rakazo.example.com"
           />
-          <p class="hint">Use the address you open Rakazo with in a browser.</p>
+          <p class="hint">Same address you open in a browser.</p>
         </section>
 
         <p id="status" class="status" role="status" aria-live="polite"></p>
@@ -77,9 +67,7 @@
         </div>
       </form>
 
-      <p class="footnote">
-        You can change this later from the Rakazo application menu (Command/Ctrl + Shift + K).
-      </p>
+      <p class="footnote">Change later from the Rakazo menu (⌘/Ctrl+Shift+K).</p>
     </main>
 
     <script src="setup.js"></script>

--- a/apps/desktop/src/setup.js
+++ b/apps/desktop/src/setup.js
@@ -1,0 +1,123 @@
+(() => {
+  const bridge = window.rakazoSetup;
+
+  const form = document.getElementById("setup");
+  const localUrl = document.getElementById("local-url");
+  const serverUrl = document.getElementById("server-url");
+  const panelNew = document.getElementById("panel-new");
+  const panelExisting = document.getElementById("panel-existing");
+  const status = document.getElementById("status");
+  const checkButton = document.getElementById("check");
+  const continueButton = document.getElementById("continue");
+  const quitButton = document.getElementById("quit");
+
+  function selectedMode() {
+    const checked = form.querySelector('input[name="mode"]:checked');
+    return checked === null ? "new" : checked.value;
+  }
+
+  function activeField() {
+    return selectedMode() === "new" ? localUrl : serverUrl;
+  }
+
+  function setStatus(message, tone) {
+    status.textContent = message;
+    if (tone === undefined) status.removeAttribute("data-tone");
+    else status.setAttribute("data-tone", tone);
+  }
+
+  function setBusy(busy) {
+    checkButton.disabled = busy;
+    continueButton.disabled = busy;
+  }
+
+  function syncPanels() {
+    const mode = selectedMode();
+    panelNew.hidden = mode !== "new";
+    panelExisting.hidden = mode === "new";
+    setStatus("");
+  }
+
+  async function check() {
+    const value = activeField().value;
+    if (value.trim() === "") {
+      setStatus("Enter a server address first.", "error");
+      return null;
+    }
+
+    setBusy(true);
+    setStatus("Checking…");
+    try {
+      const result = await bridge.test(value);
+      if (result.ok) {
+        activeField().value = result.url;
+        setStatus(`Rakazo answered at ${result.url}.`, "ok");
+      } else {
+        setStatus(result.error ?? "Could not reach that address.", "error");
+      }
+      return result;
+    } catch {
+      setStatus("Could not run the connection check. Try again.", "error");
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  form.addEventListener("change", (event) => {
+    if (event.target instanceof HTMLInputElement && event.target.name === "mode") syncPanels();
+  });
+
+  checkButton.addEventListener("click", () => {
+    void check();
+  });
+
+  quitButton.addEventListener("click", () => {
+    void bridge.quit();
+  });
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const mode = selectedMode();
+    const value = activeField().value;
+
+    setBusy(true);
+    setStatus("Connecting…");
+    try {
+      const saved = await bridge.save({ mode, serverUrl: value });
+      if (!saved.ok) setStatus(saved.error ?? "Could not save that address.", "error");
+    } catch {
+      setStatus("Could not save that address. Try again.", "error");
+    } finally {
+      setBusy(false);
+    }
+  });
+
+  async function init() {
+    if (bridge === undefined) {
+      setStatus("Setup bridge unavailable.", "error");
+      setBusy(true);
+      return;
+    }
+
+    try {
+      const state = await bridge.state();
+      if (state === null) throw new Error("Setup is not active");
+      localUrl.value = state.defaultLocalUrl;
+      if (state.saved !== null) {
+        const modeInput = document.querySelector(`input[name="mode"][value="${state.saved.mode}"]`);
+        if (modeInput !== null) modeInput.checked = true;
+        if (state.saved.mode === "existing") serverUrl.value = state.saved.serverUrl;
+        else localUrl.value = state.saved.serverUrl;
+      }
+      syncPanels();
+      if (state.error) setStatus(state.error, "error");
+      activeField().focus();
+    } catch {
+      setStatus("Setup could not start. Quit Rakazo and try again.", "error");
+      setBusy(true);
+    }
+  }
+
+  void init();
+})();

--- a/apps/desktop/src/setup.js
+++ b/apps/desktop/src/setup.js
@@ -73,6 +73,10 @@
   });
 
   quitButton.addEventListener("click", () => {
+    if (bridge === undefined) {
+      window.close();
+      return;
+    }
     void bridge.quit();
   });
 

--- a/apps/desktop/src/window-options.test.ts
+++ b/apps/desktop/src/window-options.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   browserWindowOptions,
   DEFAULT_WARM_WINDOW_TTL_MS,
+  setupWindowOptions,
   warmWindowTtlMs,
 } from "./window-options.js";
 
@@ -19,6 +20,25 @@ describe("desktop window chrome", () => {
       expect(opts.frame).toBe(false);
       expect(opts.titleBarStyle).toBeUndefined();
     }
+  });
+});
+
+describe("setup window chrome", () => {
+  it("matches the app window chrome so first run looks like the product", () => {
+    for (const platform of ["darwin", "win32", "linux"] as const) {
+      const setup = setupWindowOptions(platform);
+      const app = browserWindowOptions(platform);
+      expect(setup.frame).toBe(app.frame);
+      expect(setup.titleBarStyle).toBe(app.titleBarStyle);
+      expect(setup.backgroundColor).toBe(app.backgroundColor);
+    }
+  });
+
+  it("opens smaller than the app window and stays usable when resized down", () => {
+    const setup = setupWindowOptions("win32");
+    expect(setup.width).toBeLessThan(browserWindowOptions("win32").width);
+    expect(setup.minWidth).toBeLessThanOrEqual(setup.width);
+    expect(setup.minHeight).toBeLessThanOrEqual(setup.height);
   });
 });
 

--- a/apps/desktop/src/window-options.ts
+++ b/apps/desktop/src/window-options.ts
@@ -9,11 +9,9 @@ export function warmWindowTtlMs(value: string | undefined) {
     : DEFAULT_WARM_WINDOW_TTL_MS;
 }
 
-export function browserWindowOptions(platform: NodeJS.Platform) {
+function windowChrome(platform: NodeJS.Platform) {
   const mac = platform === "darwin";
   return {
-    width: 1440,
-    height: 900,
     backgroundColor: "#050506",
     show: true,
     autoHideMenuBar: true,
@@ -21,4 +19,13 @@ export function browserWindowOptions(platform: NodeJS.Platform) {
     titleBarStyle: mac ? ("hiddenInset" as const) : undefined,
     trafficLightPosition: mac ? { x: 16, y: 16 } : undefined,
   };
+}
+
+export function browserWindowOptions(platform: NodeJS.Platform) {
+  return { width: 1440, height: 900, ...windowChrome(platform) };
+}
+
+/** The first-run setup window is smaller and keeps the same frameless chrome. */
+export function setupWindowOptions(platform: NodeJS.Platform) {
+  return { width: 720, height: 700, minWidth: 480, minHeight: 560, ...windowChrome(platform) };
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,47 +26,57 @@ export function App() {
     return window.location.pathname.startsWith("/app") ? (
       <ShellSkeleton />
     ) : (
-      <div className="grid h-full place-items-center text-[#6C6C70]">Loading…</div>
+      <div
+        className="grid h-full place-items-center text-[#6C6C70]"
+        data-rakazo-app-state="session-pending"
+      >
+        Loading…
+      </div>
     );
   }
   const user = session.data?.user;
   return (
-    <Suspense fallback={<div className="h-full bg-[#050506]" />}>
-      <Routes>
-        <Route path="/" element={user ? <Navigate to="/app" replace /> : <WelcomePage />} />
-        <Route
-          path="/sign-in"
-          element={user ? <Navigate to="/app" replace /> : <AuthPage mode="in" />}
-        />
-        <Route
-          path="/sign-up"
-          element={user ? <Navigate to="/onboarding" replace /> : <AuthPage mode="up" />}
-        />
-        <Route
-          path="/onboarding"
-          element={user ? <OnboardingPage /> : <Navigate to="/sign-in" replace />}
-        />
-        <Route
-          path="/mcp/oauth/callback"
-          element={user ? <McpOAuthCallbackPage /> : <Navigate to="/sign-in" replace />}
-        />
-        <Route path="/app" element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />} />
-        <Route
-          path="/app/g/:groupId"
-          element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
-        />
-        <Route
-          path="/app/:botId"
-          element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
-        />
-      </Routes>
-    </Suspense>
+    <div className="h-full" data-rakazo-app-state="ready">
+      <Suspense fallback={<div className="h-full bg-[#050506]" />}>
+        <Routes>
+          <Route path="/" element={user ? <Navigate to="/app" replace /> : <WelcomePage />} />
+          <Route
+            path="/sign-in"
+            element={user ? <Navigate to="/app" replace /> : <AuthPage mode="in" />}
+          />
+          <Route
+            path="/sign-up"
+            element={user ? <Navigate to="/onboarding" replace /> : <AuthPage mode="up" />}
+          />
+          <Route
+            path="/onboarding"
+            element={user ? <OnboardingPage /> : <Navigate to="/sign-in" replace />}
+          />
+          <Route
+            path="/mcp/oauth/callback"
+            element={user ? <McpOAuthCallbackPage /> : <Navigate to="/sign-in" replace />}
+          />
+          <Route path="/app" element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />} />
+          <Route
+            path="/app/g/:groupId"
+            element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
+          />
+          <Route
+            path="/app/:botId"
+            element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
+          />
+        </Routes>
+      </Suspense>
+    </div>
   );
 }
 
 function ShellSkeleton() {
   return (
-    <div className="flex h-full overflow-hidden bg-[#050506]">
+    <div
+      className="flex h-full overflow-hidden bg-[#050506]"
+      data-rakazo-app-state="session-pending"
+    >
       <aside className="hidden w-[316px] shrink-0 border-e border-[#171719] bg-[#0B0B0C] px-3.5 pt-16 md:block">
         <div className="h-10 rounded-xl bg-[#141416]" />
         <div className="mt-5 space-y-2 px-1">

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -896,7 +896,9 @@ export function ShellPage() {
   );
   const shellReady =
     initialBotsLoaded &&
-    (inGroup ? Boolean(activeGroup && activeSnapshot) : Boolean(active && activeSnapshot));
+    (inGroup
+      ? Boolean(activeGroup && activeSnapshot)
+      : bots.length === 0 || Boolean(active && activeSnapshot));
   const refreshThreadRef = useRef(refreshThread);
   refreshThreadRef.current = refreshThread;
   const refreshGroupThreadRef = useRef(refreshGroupThread);

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -7,3 +7,38 @@ export interface RakazoDesktop {
     state: () => Promise<{ minimized: boolean; maximized: boolean; fullScreen: boolean }>;
   };
 }
+
+/** How the desktop app was pointed at a Rakazo server during first-run setup. */
+export type DesktopInstanceMode = "new" | "existing";
+
+export interface DesktopSetup {
+  mode: DesktopInstanceMode;
+  serverUrl: string;
+}
+
+export interface DesktopSetupState {
+  defaultLocalUrl: string;
+  saved: DesktopSetup | null;
+  /** Present when a saved or newly selected server could not be reopened. */
+  error?: string;
+}
+
+export interface DesktopReachability {
+  ok: boolean;
+  /** HTTP status when the server answered, absent when it could not be reached. */
+  status?: number;
+  /** Normalized URL that was probed, absent when the input was not a usable URL. */
+  url?: string;
+  error?: string;
+}
+
+/**
+ * Bridge exposed only to the first-run setup window. The app window keeps the
+ * narrower `rakazoDesktop` bridge so a connected server can never re-point the app.
+ */
+export interface RakazoSetup {
+  state: () => Promise<DesktopSetupState>;
+  test: (url: string) => Promise<DesktopReachability>;
+  save: (setup: DesktopSetup) => Promise<{ ok: boolean; error?: string }>;
+  quit: () => Promise<void>;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Desktop first-run picker for which Rakazo instance to use (local vs existing server), with health probe, `setup.json` persistence, Change Server flow, and per-origin session partitions.

## Latest review fixes
- Open gate requires session-ready **and** a bootstrapped shell (`data-ready` / shell-ready) or auth/welcome/onboarding UI.
- Empty workspaces set `shellReady` once bots have loaded.
- Renderer crash during/after save recovers via `recoverFromCrashedSave`; crash watch stays armed through setup close.
- Desktop e2e covers pending skeleton, pre-bootstrap rejection, and ready surface acceptance.

## Test plan
- [x] `apps/desktop` unit (65) + e2e (17)
- [ ] CI on this PR

Do not merge until review bots finish and actionable feedback is cleared.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-966a117e-19c9-4444-b567-ac76bea7b91f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-966a117e-19c9-4444-b567-ac76bea7b91f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a first-run desktop setup flow for choosing a local Rakazo stack or an existing server.
  * Added server validation, secure connection guidance, saved connection recovery, and a “Change Rakazo Server…” option.
  * Added per-server session isolation and safer handling for navigation and authentication popups.
  * Added environment-variable options for development and automation.

* **Documentation**
  * Updated the README with desktop setup and reconnection instructions.

* **Tests**
  * Added comprehensive coverage for setup, validation, persistence, recovery, and desktop connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->