### PR TITLE
fix(desktop): capture loopback OAuth codes from the sign-in popup

### DIFF
--- a/apps/desktop/e2e/smoke.spec.ts
+++ b/apps/desktop/e2e/smoke.spec.ts
@@ -39,7 +39,7 @@ test("launches with a narrow preload bridge and an isolated renderer", async () 
       };
     });
 
-    expect(renderer.bridgeKeys).toEqual(["platform", "window"]);
+    expect(renderer.bridgeKeys).toEqual(["oauth", "platform", "window"]);
     expect(renderer.windowKeys).toEqual(["close", "minimize", "state", "toggleMaximize"]);
     expect(renderer.platform).toBe(process.platform);
     expect(renderer.state).toEqual({ minimized: false, maximized: false, fullScreen: false });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -57,6 +57,7 @@ function createWindow() {
   mainWindow = win;
   // OAuth flows open the provider's authorize page via window.open; give that
   // popup a normal framed window and keep every non-http target closed.
+  const appOrigin = new URL(WEB_URL).origin;
   win.webContents.setWindowOpenHandler(({ url }) => {
     let target: URL;
     try {
@@ -64,7 +65,6 @@ function createWindow() {
     } catch {
       return { action: "deny" };
     }
-    const appOrigin = new URL(WEB_URL).origin;
     if (
       target.protocol !== "https:" &&
       !(target.protocol === "http:" && target.origin === appOrigin)
@@ -92,15 +92,21 @@ function createWindow() {
   // the user on a blank window holding the authorization code in a URL they
   // cannot read. Capture it here and hand it to the app instead.
   win.webContents.on("did-create-window", (popup) => {
-    const capture = (details: Electron.Event, url: string) => {
-      const callback = oauthCallbackFrom(url);
+    const capture = (details: {
+      preventDefault: () => void;
+      url: string;
+      isMainFrame?: boolean;
+    }) => {
+      // will-redirect can fire for iframes; only the top-level callback counts.
+      if (details.isMainFrame === false) return;
+      const callback = oauthCallbackFrom(details.url, { excludeOrigins: [appOrigin] });
       if (!callback) return;
       details.preventDefault();
       if (!win.isDestroyed()) win.webContents.send("desktop.oauth.callback", callback);
       if (!popup.isDestroyed()) popup.close();
     };
-    popup.webContents.on("will-redirect", (details) => capture(details, details.url));
-    popup.webContents.on("will-navigate", (details) => capture(details, details.url));
+    popup.webContents.on("will-redirect", (details) => capture(details));
+    popup.webContents.on("will-navigate", (details) => capture(details));
   });
   win.on("close", (event) => {
     if (

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { app, BrowserWindow, ipcMain, net, session } from "electron";
+import { oauthCallbackFrom } from "./oauth-callback.js";
 import {
   bundledRendererCandidates,
   contentType,
@@ -86,6 +87,20 @@ function createWindow() {
         },
       },
     };
+  });
+  // The popup has no address bar, so a loopback redirect would otherwise strand
+  // the user on a blank window holding the authorization code in a URL they
+  // cannot read. Capture it here and hand it to the app instead.
+  win.webContents.on("did-create-window", (popup) => {
+    const capture = (details: Electron.Event, url: string) => {
+      const callback = oauthCallbackFrom(url);
+      if (!callback) return;
+      details.preventDefault();
+      if (!win.isDestroyed()) win.webContents.send("desktop.oauth.callback", callback);
+      if (!popup.isDestroyed()) popup.close();
+    };
+    popup.webContents.on("will-redirect", (details) => capture(details, details.url));
+    popup.webContents.on("will-navigate", (details) => capture(details, details.url));
   });
   win.on("close", (event) => {
     if (

--- a/apps/desktop/src/oauth-callback.test.ts
+++ b/apps/desktop/src/oauth-callback.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { oauthCallbackFrom } from "./oauth-callback.js";
+
+describe("loopback OAuth callbacks", () => {
+  it("reads the code and state Anthropic redirects with", () => {
+    expect(
+      oauthCallbackFrom("http://localhost:53692/callback?code=ac_123&state=verifier_456"),
+    ).toEqual({ code: "ac_123", state: "verifier_456" });
+  });
+
+  it("accepts the loopback addresses a provider may redirect to", () => {
+    expect(oauthCallbackFrom("http://127.0.0.1:53692/callback?code=ac_123")).toEqual({
+      code: "ac_123",
+    });
+    expect(oauthCallbackFrom("http://[::1]:53692/callback?code=ac_123")).toEqual({
+      code: "ac_123",
+    });
+  });
+
+  it("omits state when the provider redirects without one", () => {
+    expect(oauthCallbackFrom("http://localhost:53692/callback?code=ac_123")).toEqual({
+      code: "ac_123",
+    });
+  });
+
+  it("ignores the authorize page and other steps of the flow", () => {
+    expect(oauthCallbackFrom("https://claude.ai/oauth/authorize?code=true")).toBeUndefined();
+    expect(oauthCallbackFrom("http://localhost:53692/callback")).toBeUndefined();
+    expect(oauthCallbackFrom("http://localhost:5173/")).toBeUndefined();
+  });
+
+  it("does not treat a remote host as a loopback callback", () => {
+    expect(oauthCallbackFrom("https://example.com/callback?code=ac_123")).toBeUndefined();
+    expect(oauthCallbackFrom("https://localhost.example.com/callback?code=ac_123")).toBeUndefined();
+  });
+
+  it("ignores non-http schemes and unparseable targets", () => {
+    expect(oauthCallbackFrom("file:///callback?code=ac_123")).toBeUndefined();
+    expect(oauthCallbackFrom("rakazo://localhost/callback?code=ac_123")).toBeUndefined();
+    expect(oauthCallbackFrom("not a url")).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/oauth-callback.test.ts
+++ b/apps/desktop/src/oauth-callback.test.ts
@@ -39,4 +39,28 @@ describe("loopback OAuth callbacks", () => {
     expect(oauthCallbackFrom("rakazo://localhost/callback?code=ac_123")).toBeUndefined();
     expect(oauthCallbackFrom("not a url")).toBeUndefined();
   });
+
+  it("does not treat all-interfaces or mapped loopback forms as callbacks", () => {
+    expect(oauthCallbackFrom("http://0.0.0.0:53692/callback?code=ac_123")).toBeUndefined();
+    expect(
+      oauthCallbackFrom("http://[::ffff:127.0.0.1]:53692/callback?code=ac_123"),
+    ).toBeUndefined();
+  });
+
+  it("ignores whitespace-only codes", () => {
+    expect(oauthCallbackFrom("http://localhost:53692/callback?code=%20%20")).toBeUndefined();
+  });
+
+  it("does not capture the app renderer origin used by MCP and other in-app callbacks", () => {
+    expect(
+      oauthCallbackFrom("http://127.0.0.1:5173/mcp/oauth/callback?code=mcp_123&state=s", {
+        excludeOrigins: ["http://127.0.0.1:5173"],
+      }),
+    ).toBeUndefined();
+    expect(
+      oauthCallbackFrom("http://localhost:53692/callback?code=ac_123", {
+        excludeOrigins: ["http://127.0.0.1:5173"],
+      }),
+    ).toEqual({ code: "ac_123" });
+  });
 });

--- a/apps/desktop/src/oauth-callback.ts
+++ b/apps/desktop/src/oauth-callback.ts
@@ -1,0 +1,26 @@
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+export type OAuthCallback = { code: string; state?: string };
+
+/**
+ * Providers that sign in through a loopback redirect — Anthropic sends the
+ * browser to `http://localhost:53692/callback` — return the authorization code
+ * in the redirect URL. Rakazo runs no listener on that port and asks for the
+ * code to be pasted instead, which the sign-in popup cannot show because an
+ * Electron window has no address bar. The main process still sees the
+ * navigation, so it reads the code from there.
+ */
+export function oauthCallbackFrom(url: string): OAuthCallback | undefined {
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return undefined;
+  }
+  if (target.protocol !== "http:" && target.protocol !== "https:") return undefined;
+  if (!LOOPBACK_HOSTS.has(target.hostname)) return undefined;
+  const code = target.searchParams.get("code");
+  if (!code) return undefined;
+  const state = target.searchParams.get("state");
+  return state === null ? { code } : { code, state };
+}

--- a/apps/desktop/src/oauth-callback.ts
+++ b/apps/desktop/src/oauth-callback.ts
@@ -2,6 +2,11 @@ const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 export type OAuthCallback = { code: string; state?: string };
 
+export type OAuthCallbackFromOptions = {
+  /** App renderer origins — their `/callback` routes must not be treated as paste-flow codes. */
+  excludeOrigins?: readonly string[];
+};
+
 /**
  * Providers that sign in through a loopback redirect — Anthropic sends the
  * browser to `http://localhost:53692/callback` — return the authorization code
@@ -10,7 +15,10 @@ export type OAuthCallback = { code: string; state?: string };
  * Electron window has no address bar. The main process still sees the
  * navigation, so it reads the code from there.
  */
-export function oauthCallbackFrom(url: string): OAuthCallback | undefined {
+export function oauthCallbackFrom(
+  url: string,
+  options: OAuthCallbackFromOptions = {},
+): OAuthCallback | undefined {
   let target: URL;
   try {
     target = new URL(url);
@@ -19,8 +27,9 @@ export function oauthCallbackFrom(url: string): OAuthCallback | undefined {
   }
   if (target.protocol !== "http:" && target.protocol !== "https:") return undefined;
   if (!LOOPBACK_HOSTS.has(target.hostname)) return undefined;
-  const code = target.searchParams.get("code");
+  if (options.excludeOrigins?.includes(target.origin)) return undefined;
+  const code = target.searchParams.get("code")?.trim();
   if (!code) return undefined;
-  const state = target.searchParams.get("state");
-  return state === null ? { code } : { code, state };
+  const state = target.searchParams.get("state")?.trim();
+  return state ? { code, state } : { code };
 }

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -8,4 +8,12 @@ contextBridge.exposeInMainWorld("rakazoDesktop", {
     toggleMaximize: () => ipcRenderer.invoke("desktop.window.toggleMaximize"),
     state: () => ipcRenderer.invoke("desktop.window.state"),
   },
+  oauth: {
+    onCallback: (listener) => {
+      // The IpcRendererEvent stays in the preload: the renderer only sees the code.
+      const handler = (_event, callback) => listener(callback);
+      ipcRenderer.on("desktop.oauth.callback", handler);
+      return () => ipcRenderer.off("desktop.oauth.callback", handler);
+    },
+  },
 });

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -5,16 +5,18 @@ import type { RakazoDesktop } from "@rakazo/contracts";
 import { describe, expect, it, vi } from "vitest";
 
 describe("desktop preload bridge", () => {
-  it("exposes only the platform and the four window operations", async () => {
+  it("exposes only the platform, the four window operations, and the OAuth bridge", async () => {
     const invoke = vi.fn(async (channel: string) => ({ channel }));
     const exposeInMainWorld = vi.fn();
+    const on = vi.fn();
+    const off = vi.fn();
     const source = readFileSync(path.join(import.meta.dirname, "preload.cjs"), "utf8");
 
     vm.runInNewContext(source, {
       process: { platform: "linux" },
       require(moduleName: string) {
         if (moduleName !== "electron") throw new Error(`Unexpected preload import: ${moduleName}`);
-        return { contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke } };
+        return { contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke, on, off } };
       },
     });
 
@@ -22,6 +24,7 @@ describe("desktop preload bridge", () => {
     const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoDesktop];
     expect(globalName).toBe("rakazoDesktop");
     expect(bridge.platform).toBe("linux");
+    expect(Object.keys(bridge).sort()).toEqual(["oauth", "platform", "window"]);
     expect(Object.keys(bridge.window).sort()).toEqual([
       "close",
       "minimize",
@@ -39,5 +42,34 @@ describe("desktop preload bridge", () => {
       "desktop.window.toggleMaximize",
       "desktop.window.state",
     ]);
+  });
+
+  it("forwards captured codes without leaking the IPC event to the renderer", () => {
+    const listeners: Array<(event: unknown, callback: unknown) => void> = [];
+    const on = vi.fn((_channel: string, handler: (event: unknown, callback: unknown) => void) => {
+      listeners.push(handler);
+    });
+    const off = vi.fn();
+    const exposeInMainWorld = vi.fn();
+    const source = readFileSync(path.join(import.meta.dirname, "preload.cjs"), "utf8");
+
+    vm.runInNewContext(source, {
+      process: { platform: "linux" },
+      require: () => ({
+        contextBridge: { exposeInMainWorld },
+        ipcRenderer: { invoke: vi.fn(), on, off },
+      }),
+    });
+
+    const [, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoDesktop];
+    const received: unknown[] = [];
+    const unsubscribe = bridge.oauth.onCallback((callback) => received.push(callback));
+
+    expect(on).toHaveBeenCalledWith("desktop.oauth.callback", expect.any(Function));
+    listeners[0]?.({ sender: "ipc-event" }, { code: "ac_123", state: "verifier_456" });
+    expect(received).toEqual([{ code: "ac_123", state: "verifier_456" }]);
+
+    unsubscribe();
+    expect(off).toHaveBeenCalledWith("desktop.oauth.callback", expect.any(Function));
   });
 });

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { type RakazoDesktop, windowChromeKind } from "./desktop.js";
+import { desktopOAuthCode, type RakazoDesktop, windowChromeKind } from "./desktop.js";
 
 function desktop(platform: string): RakazoDesktop {
   return {
@@ -13,6 +13,7 @@ function desktop(platform: string): RakazoDesktop {
       toggleMaximize: async () => undefined,
       state: async () => ({ minimized: false, maximized: false, fullScreen: false }),
     },
+    oauth: { onCallback: () => () => undefined },
   };
 }
 
@@ -36,5 +37,15 @@ describe("window chrome", () => {
     const welcome = readFileSync(path.join(root, "Welcome.tsx"), "utf8");
     expect(shell).not.toContain("FF5F57");
     expect(welcome).not.toContain("FF5F57");
+  });
+});
+
+describe("captured OAuth callbacks", () => {
+  it("sends the code and state as the compact form the paste flow accepts", () => {
+    expect(desktopOAuthCode({ code: "ac_123", state: "verifier_456" })).toBe("ac_123#verifier_456");
+  });
+
+  it("sends a bare code when the provider redirects without state", () => {
+    expect(desktopOAuthCode({ code: "ac_123" })).toBe("ac_123");
   });
 });

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -2,7 +2,14 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { desktopOAuthCode, type RakazoDesktop, windowChromeKind } from "./desktop.js";
+import {
+  desktopOAuthCaptureMatches,
+  desktopOAuthCode,
+  desktopOAuthCodeParts,
+  oauthStateFromAuthorizeUrl,
+  type RakazoDesktop,
+  windowChromeKind,
+} from "./desktop.js";
 
 function desktop(platform: string): RakazoDesktop {
   return {
@@ -47,5 +54,30 @@ describe("captured OAuth callbacks", () => {
 
   it("sends a bare code when the provider redirects without state", () => {
     expect(desktopOAuthCode({ code: "ac_123" })).toBe("ac_123");
+  });
+
+  it("splits the compact form back into code and state", () => {
+    expect(desktopOAuthCodeParts("ac_123#verifier_456")).toEqual({
+      code: "ac_123",
+      state: "verifier_456",
+    });
+    expect(desktopOAuthCodeParts("ac_123")).toEqual({ code: "ac_123" });
+  });
+
+  it("reads state from the authorize URL when the provider embeds it", () => {
+    expect(
+      oauthStateFromAuthorizeUrl("https://claude.ai/oauth/authorize?state=verifier_456&code=true"),
+    ).toBe("verifier_456");
+    expect(oauthStateFromAuthorizeUrl("https://claude.ai/oauth/authorize")).toBeUndefined();
+  });
+
+  it("ignores captured codes whose state does not match the active authorize URL", () => {
+    const uri = "https://claude.ai/oauth/authorize?state=active";
+    expect(desktopOAuthCaptureMatches("ac_123#active", uri)).toBe(true);
+    expect(desktopOAuthCaptureMatches("ac_123#stale", uri)).toBe(false);
+    expect(desktopOAuthCaptureMatches("ac_123", uri)).toBe(false);
+    expect(desktopOAuthCaptureMatches("ac_123#any", "https://claude.ai/oauth/authorize")).toBe(
+      true,
+    );
   });
 });

--- a/apps/web/src/lib/desktop.ts
+++ b/apps/web/src/lib/desktop.ts
@@ -1,6 +1,6 @@
-import type { RakazoDesktop } from "@rakazo/contracts";
+import type { RakazoDesktop, RakazoDesktopOAuthCallback } from "@rakazo/contracts";
 
-export type { RakazoDesktop } from "@rakazo/contracts";
+export type { RakazoDesktop, RakazoDesktopOAuthCallback } from "@rakazo/contracts";
 
 declare global {
   interface Window {
@@ -10,6 +10,22 @@ declare global {
 
 export function desktopBridge(): RakazoDesktop | undefined {
   return typeof window === "undefined" ? undefined : window.rakazoDesktop;
+}
+
+/** The compact `code#state` form the manual paste flow already accepts. */
+export function desktopOAuthCode(callback: RakazoDesktopOAuthCallback) {
+  return callback.state === undefined ? callback.code : `${callback.code}#${callback.state}`;
+}
+
+/**
+ * Sign-in popups in the desktop app redirect to a loopback URL the renderer
+ * never sees. The main process captures the code there so the browser flow's
+ * copy-and-paste step can be skipped. No-ops in a browser.
+ */
+export function onDesktopOAuthCallback(listener: (code: string) => void): () => void {
+  const oauth = desktopBridge()?.oauth;
+  if (!oauth) return () => undefined;
+  return oauth.onCallback((callback) => listener(desktopOAuthCode(callback)));
 }
 
 export function windowChromeKind(desktop?: RakazoDesktop): "spacer" | "darwin" | "controls" {

--- a/apps/web/src/lib/desktop.ts
+++ b/apps/web/src/lib/desktop.ts
@@ -17,6 +17,36 @@ export function desktopOAuthCode(callback: RakazoDesktopOAuthCallback) {
   return callback.state === undefined ? callback.code : `${callback.code}#${callback.state}`;
 }
 
+/** Split the compact form produced by {@link desktopOAuthCode}. */
+export function desktopOAuthCodeParts(value: string): { code: string; state?: string } {
+  const hash = value.indexOf("#");
+  if (hash === -1) return { code: value };
+  return { code: value.slice(0, hash), state: value.slice(hash + 1) };
+}
+
+/**
+ * Providers that put `state` on the authorize URL (Anthropic) let the renderer
+ * ignore a captured callback from a cancelled popup when a newer attempt is active.
+ */
+export function oauthStateFromAuthorizeUrl(verificationUri: string): string | undefined {
+  try {
+    return new URL(verificationUri).searchParams.get("state")?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** True when a desktop-captured code belongs to the in-flight authorize attempt. */
+export function desktopOAuthCaptureMatches(
+  captured: string,
+  verificationUri: string | undefined,
+): boolean {
+  if (!verificationUri) return false;
+  const expected = oauthStateFromAuthorizeUrl(verificationUri);
+  if (!expected) return true;
+  return desktopOAuthCodeParts(captured).state === expected;
+}
+
 /**
  * Sign-in popups in the desktop app redirect to a loopback URL the renderer
  * never sees. The main process captures the code there so the browser flow's

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -15,6 +15,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { onDesktopOAuthCallback } from "../lib/desktop";
 import {
   cancelModelOAuthAttempt,
   finishModelOAuthAttempt,
@@ -333,10 +334,15 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     }
   }
 
-  async function submitOAuthCode() {
+  useEffect(() => {
+    if (oauth?.mode !== "auth-url") return;
+    return onDesktopOAuthCallback((code) => void submitOAuthCode(code));
+  }, [oauth]);
+
+  async function submitOAuthCode(captured?: string) {
     if (oauth?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
     const controller = oauthAbortRef.current;
-    const code = pasteCode.trim();
+    const code = (captured ?? pasteCode).trim();
     if (!controller || !code) return;
     oauthCodeSubmittingRef.current = true;
     setPasteCode("");

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -15,7 +15,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { onDesktopOAuthCallback } from "../lib/desktop";
+import { desktopOAuthCaptureMatches, onDesktopOAuthCallback } from "../lib/desktop";
 import {
   cancelModelOAuthAttempt,
   finishModelOAuthAttempt,
@@ -50,13 +50,19 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const oauthAbortRef = useRef<AbortController | null>(null);
   const oauthLoginIdRef = useRef<string | null>(null);
   const oauthCodeSubmittingRef = useRef(false);
+  const oauthRef = useRef<ModelOAuthBegin | null>(null);
+  const pasteCodeRef = useRef("");
   const refreshRevisionRef = useRef(0);
   const selectionRevisionRef = useRef(0);
   const probeRequestIdRef = useRef(0);
 
+  oauthRef.current = oauth;
+  pasteCodeRef.current = pasteCode;
+
   function cancelOAuthAttempt(resetState = true) {
     const loginId = oauthLoginIdRef.current;
     oauthLoginIdRef.current = null;
+    oauthRef.current = null;
     cancelModelOAuthAttempt(oauthAbortRef, () => {
       if (resetState) {
         setOauth(null);
@@ -290,6 +296,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     await rpc.models.finishOAuth({ loginId }, { signal: controller.signal });
     if (controller.signal.aborted) return;
     oauthLoginIdRef.current = null;
+    oauthRef.current = null;
     setOauth(null);
     await refresh();
     if (controller.signal.aborted) return;
@@ -316,6 +323,9 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       if (controller.signal.aborted) return;
       oauthLoginIdRef.current = started.loginId;
       setPasteCode("");
+      // Eagerly publish before window.open so a fast redirect can submit
+      // before React re-renders with the oauth state.
+      oauthRef.current = started;
       setOauth(started);
       window.open(started.verificationUri, "_blank", "noopener,noreferrer");
       waitingForCode = started.mode === "auth-url";
@@ -324,6 +334,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       if (controller.signal.aborted) return;
       const loginId = oauthLoginIdRef.current;
       oauthLoginIdRef.current = null;
+      oauthRef.current = null;
       if (loginId) void rpc.models.cancelOAuth({ loginId }).catch(() => undefined);
       setError(err instanceof Error ? err.message : "Could not start sign-in");
       setOauth(null);
@@ -334,15 +345,19 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     }
   }
 
+  // Subscribe while beginOAuth is in flight (oauthPending), not after oauth
+  // state commits — a cached provider session can redirect before that paint.
   useEffect(() => {
-    if (oauth?.mode !== "auth-url") return;
+    if (!oauthPending) return;
     return onDesktopOAuthCallback((code) => void submitOAuthCode(code));
-  }, [oauth]);
+  }, [oauthPending]);
 
   async function submitOAuthCode(captured?: string) {
-    if (oauth?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
+    const current = oauthRef.current;
+    if (current?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
+    if (captured && !desktopOAuthCaptureMatches(captured, current.verificationUri)) return;
     const controller = oauthAbortRef.current;
-    const code = (captured ?? pasteCode).trim();
+    const code = (captured ?? pasteCodeRef.current).trim();
     if (!controller || !code) return;
     oauthCodeSubmittingRef.current = true;
     setPasteCode("");
@@ -351,17 +366,18 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     let retryable = false;
     try {
       await rpc.models.submitOAuthCode(
-        { loginId: oauth.loginId, code },
+        { loginId: current.loginId, code },
         { signal: controller.signal },
       );
       submitted = true;
-      await finishSubscriptionSignIn(oauth.loginId, controller);
+      await finishSubscriptionSignIn(current.loginId, controller);
     } catch (err) {
       if (controller.signal.aborted) return;
       if (submitted) {
         oauthLoginIdRef.current = null;
+        oauthRef.current = null;
         setOauth(null);
-        void rpc.models.cancelOAuth({ loginId: oauth.loginId }).catch(() => undefined);
+        void rpc.models.cancelOAuth({ loginId: current.loginId }).catch(() => undefined);
       } else {
         retryable = true;
         setPasteCode(code);

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -7,6 +7,7 @@ import {
 import { ChevronDown } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { onDesktopOAuthCallback } from "../lib/desktop";
 import {
   cancelModelOAuthAttempt,
   finishModelOAuthAttempt,
@@ -232,10 +233,15 @@ export function OnboardingPage() {
     }
   }
 
-  async function submitOAuthCode() {
+  useEffect(() => {
+    if (oauth?.mode !== "auth-url") return;
+    return onDesktopOAuthCallback((code) => void submitOAuthCode(code));
+  }, [oauth]);
+
+  async function submitOAuthCode(captured?: string) {
     if (oauth?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
     const controller = oauthAbortRef.current;
-    const code = pasteCode.trim();
+    const code = (captured ?? pasteCode).trim();
     if (!controller || !code) return;
     oauthCodeSubmittingRef.current = true;
     setPasteCode("");

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -7,7 +7,7 @@ import {
 import { ChevronDown } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { onDesktopOAuthCallback } from "../lib/desktop";
+import { desktopOAuthCaptureMatches, onDesktopOAuthCallback } from "../lib/desktop";
 import {
   cancelModelOAuthAttempt,
   finishModelOAuthAttempt,
@@ -41,11 +41,17 @@ export function OnboardingPage() {
   const oauthAbortRef = useRef<AbortController | null>(null);
   const oauthLoginIdRef = useRef<string | null>(null);
   const oauthCodeSubmittingRef = useRef(false);
+  const oauthRef = useRef<ModelOAuthBegin | null>(null);
+  const pasteCodeRef = useRef("");
   const probeRequestIdRef = useRef(0);
+
+  oauthRef.current = oauth;
+  pasteCodeRef.current = pasteCode;
 
   function cancelOAuthAttempt(resetState = true) {
     const loginId = oauthLoginIdRef.current;
     oauthLoginIdRef.current = null;
+    oauthRef.current = null;
     cancelModelOAuthAttempt(oauthAbortRef, () => {
       if (resetState) {
         setOauth(null);
@@ -193,6 +199,7 @@ export function OnboardingPage() {
     await rpc.models.finishOAuth({ loginId }, { signal: controller.signal });
     if (controller.signal.aborted) return;
     oauthLoginIdRef.current = null;
+    oauthRef.current = null;
     setOauth(null);
     setStep("bot");
   }
@@ -215,6 +222,9 @@ export function OnboardingPage() {
       if (controller.signal.aborted) return;
       oauthLoginIdRef.current = started.loginId;
       setPasteCode("");
+      // Eagerly publish before window.open so a fast redirect can submit
+      // before React re-renders with the oauth state.
+      oauthRef.current = started;
       setOauth(started);
       window.open(started.verificationUri, "_blank", "noopener,noreferrer");
       waitingForCode = started.mode === "auth-url";
@@ -223,6 +233,7 @@ export function OnboardingPage() {
       if (controller.signal.aborted) return;
       const loginId = oauthLoginIdRef.current;
       oauthLoginIdRef.current = null;
+      oauthRef.current = null;
       if (loginId) void rpc.models.cancelOAuth({ loginId }).catch(() => undefined);
       setError(err instanceof Error ? err.message : "Could not start sign-in");
       setOauth(null);
@@ -233,15 +244,19 @@ export function OnboardingPage() {
     }
   }
 
+  // Subscribe while beginOAuth is in flight (oauthPending), not after oauth
+  // state commits — a cached provider session can redirect before that paint.
   useEffect(() => {
-    if (oauth?.mode !== "auth-url") return;
+    if (!oauthPending) return;
     return onDesktopOAuthCallback((code) => void submitOAuthCode(code));
-  }, [oauth]);
+  }, [oauthPending]);
 
   async function submitOAuthCode(captured?: string) {
-    if (oauth?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
+    const current = oauthRef.current;
+    if (current?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
+    if (captured && !desktopOAuthCaptureMatches(captured, current.verificationUri)) return;
     const controller = oauthAbortRef.current;
-    const code = (captured ?? pasteCode).trim();
+    const code = (captured ?? pasteCodeRef.current).trim();
     if (!controller || !code) return;
     oauthCodeSubmittingRef.current = true;
     setPasteCode("");
@@ -250,17 +265,18 @@ export function OnboardingPage() {
     let retryable = false;
     try {
       await rpc.models.submitOAuthCode(
-        { loginId: oauth.loginId, code },
+        { loginId: current.loginId, code },
         { signal: controller.signal },
       );
       submitted = true;
-      await finishSubscriptionSignIn(oauth.loginId, controller);
+      await finishSubscriptionSignIn(current.loginId, controller);
     } catch (err) {
       if (controller.signal.aborted) return;
       if (submitted) {
         oauthLoginIdRef.current = null;
+        oauthRef.current = null;
         setOauth(null);
-        void rpc.models.cancelOAuth({ loginId: oauth.loginId }).catch(() => undefined);
+        void rpc.models.cancelOAuth({ loginId: current.loginId }).catch(() => undefined);
       } else {
         retryable = true;
         setPasteCode(code);

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -1,3 +1,8 @@
+export interface RakazoDesktopOAuthCallback {
+  code: string;
+  state?: string;
+}
+
 export interface RakazoDesktop {
   platform: string;
   window: {
@@ -5,5 +10,12 @@ export interface RakazoDesktop {
     minimize: () => Promise<void>;
     toggleMaximize: () => Promise<void>;
     state: () => Promise<{ minimized: boolean; maximized: boolean; fullScreen: boolean }>;
+  };
+  oauth: {
+    /**
+     * Authorization codes captured from a sign-in popup's loopback redirect.
+     * Returns an unsubscribe function.
+     */
+    onCallback: (listener: (callback: RakazoDesktopOAuthCallback) => void) => () => void;
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closed as leftover / duplicate of [#183](https://github.com/elie222/rakazo/pull/183).

Review hardening from this branch (skip app renderer origin for MCP/in-app OAuth; ignore non-main-frame `will-redirect`) was folded into #183. Race + state correlation was already landed there by the author.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6dd5200-274e-4164-8dbd-80e3da327520?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6dd5200-274e-4164-8dbd-80e3da327520&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop OAuth callback capture from sign-in popups.
  * OAuth sign-in now automatically detects valid callbacks, verifies their state, and completes authentication in supported desktop flows.
  * Added OAuth callback support to the desktop bridge, including listener cleanup.
* **Bug Fixes**
  * Improved handling of OAuth callbacks during asynchronous sign-in startup and error recovery.
  * Invalid, unsupported, or unrelated callback URLs are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->