### PR TITLE
fix(web): stop signing out a user the session lookup could not reach

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,8 @@
-import { lazy, Suspense, useLayoutEffect } from "react";
+import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { authClient } from "./lib/auth";
 import { markAfterPaint, markOnce } from "./lib/performance";
+import { sessionGate, sessionRetryDelayMs } from "./lib/session-gate";
 import { McpOAuthCallbackPage } from "./pages/McpOAuthCallback";
 import { ShellPage } from "./pages/Shell";
 
@@ -22,13 +23,15 @@ export function App() {
     markOnce("rk:renderer:session-committed");
     markAfterPaint("rk:renderer:session-painted");
   }, [session.isPending]);
-  if (session.isPending) {
+  if (session.isPending && !session.data) {
     return window.location.pathname.startsWith("/app") ? (
       <ShellSkeleton />
     ) : (
       <div className="grid h-full place-items-center text-[#6C6C70]">Loading…</div>
     );
   }
+  const gate = sessionGate(session);
+  if (gate === "unreachable") return <SessionUnavailable refetch={session.refetch} />;
   const user = session.data?.user;
   return (
     <Suspense fallback={<div className="h-full bg-[#050506]" />}>
@@ -61,6 +64,42 @@ export function App() {
         />
       </Routes>
     </Suspense>
+  );
+}
+
+/**
+ * A session lookup that never reached the server is not a sign-out, so the app
+ * waits and retries here instead of routing to sign-in and stranding a signed-in
+ * user. Better Auth only polls once a session exists, so the retry lives here.
+ */
+function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
+  const [attempt, setAttempt] = useState(0);
+  const refetchRef = useRef(refetch);
+  refetchRef.current = refetch;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      void refetchRef.current().finally(() => setAttempt((value) => value + 1));
+    }, sessionRetryDelayMs(attempt));
+    return () => clearTimeout(timer);
+  }, [attempt]);
+
+  return (
+    <div className="grid h-full place-items-center bg-[#050506] px-6 text-center">
+      <div>
+        <div className="text-[15px] text-[#ECECEE]">Reconnecting…</div>
+        <p className="mt-2 text-[13.5px] text-[#6C6C70]">
+          Rakazo can&apos;t reach the server. You are still signed in.
+        </p>
+        <button
+          type="button"
+          onClick={() => setAttempt(0)}
+          className="mt-4 rounded-[11px] border border-[#26262A] px-4 py-2 text-[13px] text-[#ECECEE]"
+        >
+          Retry now
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,12 @@ import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from "re
 import { Navigate, Route, Routes } from "react-router-dom";
 import { authClient } from "./lib/auth";
 import { markAfterPaint, markOnce } from "./lib/performance";
-import { sessionGate, sessionRetryDelayMs } from "./lib/session-gate";
+import {
+  holdUnreachableGate,
+  sessionGate,
+  sessionRetryDelayMs,
+  showSessionUnavailable,
+} from "./lib/session-gate";
 import { McpOAuthCallbackPage } from "./pages/McpOAuthCallback";
 import { ShellPage } from "./pages/Shell";
 
@@ -18,20 +23,28 @@ const WelcomePage = lazy(() =>
 
 export function App() {
   const session = authClient.useSession();
+  const gate = sessionGate(session);
+  const [holdingUnreachable, setHoldingUnreachable] = useState(false);
+  const nextHolding = holdUnreachableGate(gate, holdingUnreachable);
+  if (nextHolding !== holdingUnreachable) setHoldingUnreachable(nextHolding);
+
   useLayoutEffect(() => {
     if (session.isPending) return;
     markOnce("rk:renderer:session-committed");
     markAfterPaint("rk:renderer:session-painted");
   }, [session.isPending]);
-  if (session.isPending && !session.data) {
+
+  if (showSessionUnavailable(gate, nextHolding)) {
+    return <SessionUnavailable refetch={session.refetch} />;
+  }
+  if (gate === "loading") {
     return window.location.pathname.startsWith("/app") ? (
       <ShellSkeleton />
     ) : (
       <div className="grid h-full place-items-center text-[#6C6C70]">Loading…</div>
     );
   }
-  const gate = sessionGate(session);
-  if (gate === "unreachable") return <SessionUnavailable refetch={session.refetch} />;
+
   const user = session.data?.user;
   return (
     <Suspense fallback={<div className="h-full bg-[#050506]" />}>
@@ -74,26 +87,39 @@ export function App() {
  */
 function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
   const [attempt, setAttempt] = useState(0);
+  const [retryKey, setRetryKey] = useState(0);
+  const retryImmediately = useRef(false);
   const refetchRef = useRef(refetch);
   refetchRef.current = refetch;
 
   useEffect(() => {
+    let cancelled = false;
+    const delay = retryImmediately.current ? 0 : sessionRetryDelayMs(attempt);
+    retryImmediately.current = false;
     const timer = setTimeout(() => {
-      void refetchRef.current().finally(() => setAttempt((value) => value + 1));
-    }, sessionRetryDelayMs(attempt));
-    return () => clearTimeout(timer);
-  }, [attempt]);
+      void refetchRef.current().finally(() => {
+        if (!cancelled) setAttempt((value) => value + 1);
+      });
+    }, delay);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [attempt, retryKey]);
 
   return (
     <div className="grid h-full place-items-center bg-[#050506] px-6 text-center">
       <div>
         <div className="text-[15px] text-[#ECECEE]">Reconnecting…</div>
-        <p className="mt-2 text-[13.5px] text-[#6C6C70]">
-          Rakazo can&apos;t reach the server. You are still signed in.
-        </p>
+        <p className="mt-2 text-[13.5px] text-[#6C6C70]">Can&apos;t reach the server.</p>
         <button
           type="button"
-          onClick={() => setAttempt(0)}
+          aria-label="Retry now"
+          onClick={() => {
+            retryImmediately.current = true;
+            setAttempt(0);
+            setRetryKey((key) => key + 1);
+          }}
           className="mt-4 rounded-[11px] border border-[#26262A] px-4 py-2 text-[13px] text-[#ECECEE]"
         >
           Retry now

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
+import { BuiButton, LoadingState } from "./components/beautiful-ui/primitives";
 import { authClient } from "./lib/auth";
 import { markAfterPaint, markOnce } from "./lib/performance";
 import {
@@ -109,21 +110,20 @@ function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
 
   return (
     <div className="grid h-full place-items-center bg-[#050506] px-6 text-center">
-      <div>
-        <div className="text-[15px] text-[#ECECEE]">Reconnecting…</div>
-        <p className="mt-2 text-[13.5px] text-[#6C6C70]">Can&apos;t reach the server.</p>
-        <button
-          type="button"
-          aria-label="Retry now"
-          onClick={() => {
-            retryImmediately.current = true;
-            setAttempt(0);
-            setRetryKey((key) => key + 1);
-          }}
-          className="mt-4 rounded-[11px] border border-[#26262A] px-4 py-2 text-[13px] text-[#ECECEE]"
-        >
-          Retry now
-        </button>
+      <div className="flex flex-col items-center">
+        <LoadingState label="Reconnecting" />
+        <p className="mt-3 text-[13.5px] text-[#6C6C70]">Can&apos;t reach the server.</p>
+        <div className="mt-4">
+          <BuiButton
+            onClick={() => {
+              retryImmediately.current = true;
+              setAttempt(0);
+              setRetryKey((key) => key + 1);
+            }}
+          >
+            Retry now
+          </BuiButton>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/lib/session-gate.test.ts
+++ b/apps/web/src/lib/session-gate.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { sessionGate, sessionRetryDelayMs } from "./session-gate.js";
+
+const user = { user: { id: "u_1" } };
+
+describe("session gate", () => {
+  it("shows the app once a session resolves", () => {
+    expect(sessionGate({ data: user, isPending: false, error: null })).toBe("authenticated");
+  });
+
+  it("waits while the first lookup is in flight", () => {
+    expect(sessionGate({ data: null, isPending: true, error: null })).toBe("loading");
+  });
+
+  it("sends a signed-out visitor to sign-in", () => {
+    expect(sessionGate({ data: null, isPending: false, error: null })).toBe("anonymous");
+  });
+
+  it("treats 401 as a real sign-out", () => {
+    expect(sessionGate({ data: null, isPending: false, error: { status: 401 } })).toBe("anonymous");
+  });
+
+  it("does not sign out a cold load that could not reach the server", () => {
+    expect(sessionGate({ data: null, isPending: false, error: { status: 503 } })).toBe(
+      "unreachable",
+    );
+    // A thrown fetch has no status at all.
+    expect(sessionGate({ data: null, isPending: false, error: {} })).toBe("unreachable");
+  });
+
+  it("keeps showing the app when a refresh fails for an established session", () => {
+    expect(sessionGate({ data: user, isPending: false, error: { status: 500 } })).toBe(
+      "authenticated",
+    );
+  });
+
+  it("backs off between retries and stops growing", () => {
+    expect(sessionRetryDelayMs(0)).toBe(1_000);
+    expect(sessionRetryDelayMs(1)).toBe(2_000);
+    expect(sessionRetryDelayMs(3)).toBe(8_000);
+    expect(sessionRetryDelayMs(20)).toBe(15_000);
+  });
+});

--- a/apps/web/src/lib/session-gate.test.ts
+++ b/apps/web/src/lib/session-gate.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { sessionGate, sessionRetryDelayMs } from "./session-gate.js";
+import {
+  holdUnreachableGate,
+  sessionGate,
+  sessionRetryDelayMs,
+  showSessionUnavailable,
+} from "./session-gate.js";
 
 const user = { user: { id: "u_1" } };
 
@@ -32,6 +37,15 @@ describe("session gate", () => {
     expect(sessionGate({ data: user, isPending: false, error: { status: 500 } })).toBe(
       "authenticated",
     );
+  });
+
+  it("holds the reconnect screen across a null-session refetch", () => {
+    expect(holdUnreachableGate("unreachable", false)).toBe(true);
+    expect(holdUnreachableGate("loading", true)).toBe(true);
+    expect(holdUnreachableGate("authenticated", true)).toBe(false);
+    expect(holdUnreachableGate("anonymous", true)).toBe(false);
+    expect(showSessionUnavailable("loading", true)).toBe(true);
+    expect(showSessionUnavailable("loading", false)).toBe(false);
   });
 
   it("backs off between retries and stops growing", () => {

--- a/apps/web/src/lib/session-gate.ts
+++ b/apps/web/src/lib/session-gate.ts
@@ -1,0 +1,31 @@
+export interface SessionGateInput {
+  data: { user?: unknown } | null | undefined;
+  isPending: boolean;
+  error: { status?: number } | null;
+}
+
+export type SessionGate = "loading" | "unreachable" | "authenticated" | "anonymous";
+
+/**
+ * A failed session fetch is not a sign-out. Better Auth keeps the last known
+ * session on a network error, but a cold load has nothing to keep, and its
+ * refresh manager only polls once a session exists — so a request that fails
+ * before the first success never retries. Routing that state to sign-in signs
+ * out a user whose cookie is still valid, so it is reported separately.
+ */
+export function sessionGate(session: SessionGateInput): SessionGate {
+  if (session.data?.user) return "authenticated";
+  if (session.isPending) return "loading";
+  // 401 is the server answering: there is genuinely no session.
+  if (session.error && session.error.status !== 401) return "unreachable";
+  return "anonymous";
+}
+
+const RETRY_BASE_MS = 1_000;
+const RETRY_MAX_MS = 15_000;
+
+/** Exponential backoff for retrying an unreachable session lookup. */
+export function sessionRetryDelayMs(attempt: number): number {
+  const exponent = Math.max(0, attempt);
+  return Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** exponent);
+}

--- a/apps/web/src/lib/session-gate.ts
+++ b/apps/web/src/lib/session-gate.ts
@@ -21,6 +21,22 @@ export function sessionGate(session: SessionGateInput): SessionGate {
   return "anonymous";
 }
 
+/**
+ * Better Auth clears `error` and sets `isPending` while a null-session refetch
+ * runs, which would otherwise look like a cold "loading" and unmount the
+ * reconnect UI (resetting backoff). Hold the unreachable screen across that
+ * refetch until the gate resolves to authenticated or anonymous.
+ */
+export function holdUnreachableGate(gate: SessionGate, holding: boolean): boolean {
+  if (gate === "unreachable") return true;
+  if (gate === "authenticated" || gate === "anonymous") return false;
+  return holding;
+}
+
+export function showSessionUnavailable(gate: SessionGate, holding: boolean): boolean {
+  return gate === "unreachable" || (holding && gate === "loading");
+}
+
 const RETRY_BASE_MS = 1_000;
 const RETRY_MAX_MS = 15_000;
 


### PR DESCRIPTION
## The problem

The app signs out users whose session is perfectly valid.

`App.tsx` reads only `session.data?.user`, so every state without a user — including "the lookup failed" — falls through to `<Navigate to="/sign-in" replace />`.

Better Auth already handles this for an *established* session: on an error it keeps the last known session and clears it only on a 401. But a cold load has nothing to keep. If the first `/get-session` fails, `data` stays `null` and `isPending` flips to `false`, so the app redirects. Worse, the refresh manager polls only while a session already exists:

```js
// better-auth/dist/client/session-atom.mjs
const refreshManager = createSessionRefreshManager({
  shouldPollSession: () => session.value.data != null,
  ...
});
```

So after a failed initial lookup nothing ever retries, and the user sits on the sign-in page until they reload by hand.

This is easy to hit whenever the API is briefly unavailable while the renderer boots — `tsx watch` restarting after a save, the desktop app launching before the API is listening, a machine waking from sleep.

## The fix

Report "could not reach the server" separately from "signed out".

`sessionGate` (pure, unit-tested) distinguishes a real sign-out — a 401, or a clean response with no user — from a lookup that never landed. The unreachable case renders a reconnecting screen that retries with exponential backoff instead of navigating away, since Better Auth will not retry on its own.

An established session that hits a failing refresh is unaffected: Better Auth keeps `data`, so the gate still returns `authenticated`.

## How I tested

Ran a web build proxying `/api` to a dead port, so the auth lookup fails exactly as it does when the API is down, and loaded `/app` cold in headless Chromium:

| | Final URL | Rendered |
|---|---|---|
| before | `/sign-in` | "Sign in to Rakazo" |
| after | `/app` | "Reconnecting… You are still signed in." |

Also: 7 unit tests covering the gate and the backoff, `pnpm lint`, `pnpm check` (19/19), and `pnpm vitest run apps/web/src` (13 files, 70 tests).

Unrelated pre-existing failures on my machine, confirmed on a clean checkout: `sandbox-conformance` (EACCES on `/tmp` in my sandbox) and a `voice-http` 1 ms deadline flake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer session status handling for loading, signed-in, signed-out, and unavailable states.
  * Added a reconnecting screen when the session service cannot be reached.
  * Added automatic session retries with increasing delays and a manual retry option.

* **Bug Fixes**
  * Prevented temporary session-fetching failures from being treated as signed-out states.
  * Improved handling of expired or invalid sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->