### PR TITLE
fix: disable Take control while a Team bot run blocks takeover

### DIFF
--- a/apps/api/src/computer-status.test.ts
+++ b/apps/api/src/computer-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toComputerStatus } from "./computer-status.js";
+import { executionBlocksUserTakeover, toComputerStatus } from "./computer-status.js";
 
 describe("toComputerStatus", () => {
   it("only marks control that is bound to a waiting run as a requested takeover", () => {
@@ -17,5 +17,81 @@ describe("toComputerStatus", () => {
     expect(toComputerStatus("bot-1", { ...computer, controlRunId: null }).takeoverRequested).toBe(
       false,
     );
+  });
+
+  it("passes through the busy bot name when takeover is blocked", () => {
+    const computer = {
+      kind: "fake",
+      state: "running",
+      scope: "team",
+      controlHolder: "none",
+      homeRevision: "revision-1",
+    };
+    expect(toComputerStatus("bot-1", computer).busyBotName).toBeNull();
+    expect(toComputerStatus("bot-1", computer, "Writer").busyBotName).toBe("Writer");
+  });
+});
+
+describe("executionBlocksUserTakeover", () => {
+  const now = Date.parse("2026-08-25T12:00:00.000Z");
+
+  it("allows takeover when there is no execution lease", () => {
+    expect(
+      executionBlocksUserTakeover({
+        hasLease: false,
+        leaseExpiresAt: new Date(now + 60_000),
+        runStatus: "running",
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows takeover while the run is waiting for the user", () => {
+    expect(
+      executionBlocksUserTakeover({
+        hasLease: true,
+        leaseExpiresAt: new Date(now + 60_000),
+        runStatus: "waiting_takeover",
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks takeover for an active lease or active run", () => {
+    expect(
+      executionBlocksUserTakeover({
+        hasLease: true,
+        leaseExpiresAt: new Date(now + 60_000),
+        runStatus: "running",
+        now,
+      }),
+    ).toBe(true);
+    expect(
+      executionBlocksUserTakeover({
+        hasLease: true,
+        leaseExpiresAt: new Date(now - 1),
+        runStatus: "running",
+        now,
+      }),
+    ).toBe(true);
+    expect(
+      executionBlocksUserTakeover({
+        hasLease: true,
+        leaseExpiresAt: new Date(now + 60_000),
+        runStatus: "completed",
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows takeover when both the lease and run are inactive", () => {
+    expect(
+      executionBlocksUserTakeover({
+        hasLease: true,
+        leaseExpiresAt: new Date(now - 1),
+        runStatus: "completed",
+        now,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/computer-status.ts
+++ b/apps/api/src/computer-status.ts
@@ -1,5 +1,50 @@
 import type { ComputerStatus } from "@rakazo/contracts";
-import { computerScreenSize } from "@rakazo/core";
+import { ACTIVE_RUN_STATUSES, computerScreenSize } from "@rakazo/core";
+import type { PrismaClient } from "@rakazo/db";
+
+/** Mirrors computer.takeover: an execution lease blocks user control unless waiting_takeover. */
+export function executionBlocksUserTakeover(input: {
+  hasLease: boolean;
+  leaseExpiresAt: Date | null | undefined;
+  runStatus: string | null | undefined;
+  now?: number;
+}): boolean {
+  if (!input.hasLease) return false;
+  if (input.runStatus === "waiting_takeover") return false;
+  const now = input.now ?? Date.now();
+  const leaseActive = Boolean(input.leaseExpiresAt && input.leaseExpiresAt.getTime() > now);
+  const runActive = Boolean(
+    input.runStatus && (ACTIVE_RUN_STATUSES as readonly string[]).includes(input.runStatus),
+  );
+  return leaseActive || runActive;
+}
+
+export async function resolveBusyBotName(
+  prisma: PrismaClient,
+  input: {
+    computerId: string | null | undefined;
+    botId: string;
+    botName: string;
+  },
+): Promise<string | null> {
+  if (!input.computerId) return null;
+  const lease = await prisma.computerExecutionLease.findUnique({
+    where: { computerId_botId: { computerId: input.computerId, botId: input.botId } },
+    select: { expiresAt: true, runId: true },
+  });
+  if (!lease) return null;
+  const run = await prisma.run.findUnique({
+    where: { id: lease.runId },
+    select: { status: true },
+  });
+  return executionBlocksUserTakeover({
+    hasLease: true,
+    leaseExpiresAt: lease.expiresAt,
+    runStatus: run?.status,
+  })
+    ? input.botName
+    : null;
+}
 
 export function toComputerStatus(
   botId: string,
@@ -12,6 +57,7 @@ export function toComputerStatus(
     controlRunId?: string | null;
     homeRevision: string;
   } | null,
+  busyBotName: string | null = null,
 ): ComputerStatus {
   const state =
     computer?.state === "suspending"
@@ -36,6 +82,6 @@ export function toComputerStatus(
     screenWidth: screen.width,
     screenHeight: screen.height,
     homeRevision: computer?.homeRevision ?? null,
-    busyBotName: null,
+    busyBotName,
   };
 }

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -93,7 +93,11 @@ import {
   touchGroupUpdatedAt,
 } from "@rakazo/db";
 import { createOwnedArtifact, getOwnedArtifact, getWorkspaceArtifact } from "./artifacts.js";
-import { toComputerStatus } from "./computer-status.js";
+import {
+  executionBlocksUserTakeover,
+  resolveBusyBotName,
+  toComputerStatus,
+} from "./computer-status.js";
 import { buildMcpUpdateMaterial } from "./mcp-material.js";
 import { chooseFocus, markAppConnected, startOnboarding } from "./onboarding.js";
 import { addScreenProxyCapability } from "./screen-proxy.js";
@@ -1102,23 +1106,29 @@ export function createRouter(deps: RouterDeps) {
         const executionLease = await deps.prisma.computerExecutionLease.findUnique({
           where: { computerId_botId: { computerId: bot.computer.id, botId: bot.id } },
         });
-        const executionLeaseActive = Boolean(
-          executionLease && executionLease.expiresAt.getTime() > Date.now(),
-        );
         const executionRun = executionLease
           ? await deps.prisma.run.findUnique({
               where: { id: executionLease.runId },
               select: { botId: true, status: true },
             })
           : null;
+        const waitingForTakeover =
+          executionRun?.botId === bot.id && executionRun.status === "waiting_takeover";
+        if (
+          executionBlocksUserTakeover({
+            hasLease: Boolean(executionLease),
+            leaseExpiresAt: executionLease?.expiresAt,
+            runStatus: executionRun?.status,
+          })
+        ) {
+          throw new ORPCError("CONFLICT", { message: "Stop the bot first" });
+        }
+        const executionLeaseActive = Boolean(
+          executionLease && executionLease.expiresAt.getTime() > Date.now(),
+        );
         const executionRunActive = Boolean(
           executionRun && ACTIVE_RUN_STATUSES.some((status) => status === executionRun.status),
         );
-        const waitingForTakeover =
-          executionRun?.botId === bot.id && executionRun.status === "waiting_takeover";
-        if (executionLease && !waitingForTakeover && (executionLeaseActive || executionRunActive)) {
-          throw new ORPCError("CONFLICT", { message: "Stop the bot first" });
-        }
         if (executionLease && !executionLeaseActive && !executionRunActive) {
           await deps.prisma.computerExecutionLease.deleteMany({
             where: { id: executionLease.id },
@@ -2710,7 +2720,12 @@ async function computerStatus(
   if (await expireStaleComputerControl(deps, bot.computer)) {
     bot = await repos.getBot(actor, botId);
   }
-  return toComputerStatus(botId, bot.computer);
+  const busyBotName = await resolveBusyBotName(deps.prisma, {
+    computerId: bot.computer?.id,
+    botId,
+    botName: bot.name,
+  });
+  return toComputerStatus(botId, bot.computer, busyBotName);
 }
 
 async function expireStaleComputerControl(

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -25,7 +25,7 @@ import {
   resolveGroupSendAttachments,
   resolveSendAttachments,
 } from "./artifacts.js";
-import { toComputerStatus } from "./computer-status.js";
+import { resolveBusyBotName, toComputerStatus } from "./computer-status.js";
 import { withSerializableRetry } from "./serializable-retry.js";
 import { loadMessagePage } from "./thread-message-pages.js";
 
@@ -211,7 +211,7 @@ export async function threadSnapshot(
   target: ThreadTarget,
 ): Promise<ThreadSnapshot> {
   if (target.kind === "bot") {
-    const [messagePage, last, run] = await Promise.all([
+    const [messagePage, last, run, busyBotName] = await Promise.all([
       loadMessagePage(deps.prisma, target.threadId, undefined, THREAD_MESSAGE_PAGE_SIZE),
       deps.prisma.event.findFirst({
         where: { threadId: target.threadId },
@@ -224,6 +224,11 @@ export async function threadSnapshot(
           status: { in: [...ACTIVE_RUN_STATUSES] },
         },
         orderBy: { createdAt: "desc" },
+      }),
+      resolveBusyBotName(deps.prisma, {
+        computerId: target.bot.computer?.id,
+        botId: target.botId,
+        botName: target.bot.name,
       }),
     ]);
     const liveEvents = run
@@ -243,7 +248,7 @@ export async function threadSnapshot(
       messages: messagesWithLiveEvents(messagePage.messages, liveEvents),
       olderCursor: messagePage.olderCursor,
       run: run ? mapRun(run) : null,
-      computer: toComputerStatus(target.botId, target.bot.computer),
+      computer: toComputerStatus(target.botId, target.bot.computer, busyBotName),
     };
   }
 

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -181,9 +181,8 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
         ).busyBotName,
     )
     .toBeNull();
-  await expect
-    .poll(async () => (await rpcResponse(page, "computer/takeover", { botId: chiefId })).ok)
-    .toBe(true);
+  await expect(takeControl).toBeEnabled();
+  await takeControl.click();
   await expect(page.getByText("You have control", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "49-team-computer-takeover-after-stop");
   await rpc(page, "computer/release", { botId: chiefId });

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -168,6 +168,7 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
   const takeControl = page.getByRole("button", { name: /Take control/i }).first();
   await expect(takeControl).toBeDisabled();
   await expect(page.getByText(/is using it/i).first()).toBeVisible();
+  await captureScreenshot(page, testInfo, "48b-take-control-blocked-while-busy");
 
   await rpc(page, "threads/stop", { botId: chiefId });
   await waitForIdle(page, chiefId);

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -146,6 +146,16 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
       async () => (await rpc<{ state: string }>(page, "computer/status", { botId: chiefId })).state,
     )
     .toBe("running");
+  await expect
+    .poll(
+      async () =>
+        (
+          await rpc<{ busyBotName: string | null }>(page, "computer/status", {
+            botId: chiefId,
+          })
+        ).busyBotName,
+    )
+    .not.toBeNull();
 
   const takeover = await rpcResponse(page, "computer/takeover", { botId: chiefId });
   expect(takeover.ok).toBe(false);
@@ -154,12 +164,26 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
     .poll(async () => (await threadSnapshot(page, chiefId)).run?.status ?? "idle")
     .toBe("running");
 
+  await page.getByTitle("Agent computer").click();
+  const takeControl = page.getByRole("button", { name: /Take control/i }).first();
+  await expect(takeControl).toBeDisabled();
+  await expect(page.getByText(/is using it/i).first()).toBeVisible();
+
   await rpc(page, "threads/stop", { botId: chiefId });
   await waitForIdle(page, chiefId);
   await expect
+    .poll(
+      async () =>
+        (
+          await rpc<{ busyBotName: string | null }>(page, "computer/status", {
+            botId: chiefId,
+          })
+        ).busyBotName,
+    )
+    .toBeNull();
+  await expect
     .poll(async () => (await rpcResponse(page, "computer/takeover", { botId: chiefId })).ok)
     .toBe(true);
-  await page.getByTitle("Agent computer").click();
   await expect(page.getByText("You have control", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "49-team-computer-takeover-after-stop");
   await rpc(page, "computer/release", { botId: chiefId });

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -170,7 +170,9 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
   await expect(page.getByText(/is using it/i).first()).toBeVisible();
   await captureScreenshot(page, testInfo, "48b-take-control-blocked-while-busy");
 
-  await rpc(page, "threads/stop", { botId: chiefId });
+  // Stop through the shell so the client refreshes computer status (API stop alone
+  // does not emit a terminal thread event).
+  await page.getByRole("button", { name: "Stop", exact: true }).click();
   await waitForIdle(page, chiefId);
   await expect
     .poll(

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -839,6 +839,26 @@ describe("computer event reduction", () => {
     expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }))).toBe(true);
     expect(computerTakeoverBlocked(computer({ busyBotName: null }))).toBe(false);
     expect(computerTakeoverBlocked(null)).toBe(false);
+    expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }), "waiting_takeover")).toBe(
+      false,
+    );
+  });
+
+  it("clears the busy bot when takeover is requested or granted", () => {
+    const busy = computer({ state: "running", busyBotName: "Writer" });
+    expect(
+      reduceComputerStatus(busy, event({ type: "computer.takeover.requested", payload: {} })),
+    ).toMatchObject({ busyBotName: null });
+    expect(
+      reduceComputerStatus(
+        busy,
+        event({ type: "computer.takeover.granted", payload: { takeoverRequested: true } }),
+      ),
+    ).toMatchObject({
+      controlHolder: "user",
+      busyBotName: null,
+      takeoverRequested: true,
+    });
   });
 
   it("auto-boots stopped computers and recovers a running screen that has no URL", () => {

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -836,12 +836,14 @@ describe("computer event reduction", () => {
   });
 
   it("treats a busy bot name as a blocked takeover", () => {
-    expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }))).toBe(true);
-    expect(computerTakeoverBlocked(computer({ busyBotName: null }))).toBe(false);
-    expect(computerTakeoverBlocked(null)).toBe(false);
+    expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }), "running")).toBe(true);
+    expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }))).toBe(false);
+    expect(computerTakeoverBlocked(computer({ busyBotName: null }), "running")).toBe(false);
+    expect(computerTakeoverBlocked(null, "running")).toBe(false);
     expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }), "waiting_takeover")).toBe(
       false,
     );
+    expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }), "completed")).toBe(false);
   });
 
   it("clears the busy bot when takeover is requested or granted", () => {

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   activeThreadRuns,
   computerPanelAutoBoot,
+  computerTakeoverBlocked,
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
   prependThreadMessagePage,
@@ -832,6 +833,12 @@ describe("computer event reduction", () => {
     });
     expect(userHoldsComputerControl(granted, "bot-1")).toBe(true);
     expect(userHoldsComputerControl(granted, "bot-2")).toBe(false);
+  });
+
+  it("treats a busy bot name as a blocked takeover", () => {
+    expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }))).toBe(true);
+    expect(computerTakeoverBlocked(computer({ busyBotName: null }))).toBe(false);
+    expect(computerTakeoverBlocked(null)).toBe(false);
   });
 
   it("auto-boots stopped computers and recovers a running screen that has no URL", () => {

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -235,6 +235,13 @@ export function userHoldsComputerControl(
   return Boolean(botId && computer?.controlHolder === "user" && computer.controlBotId === botId);
 }
 
+/** True when status says a bot run/lease blocks Take control (API would return 409). */
+export function computerTakeoverBlocked(
+  computer: Pick<ComputerStatus, "busyBotName"> | null | undefined,
+): boolean {
+  return Boolean(computer?.busyBotName);
+}
+
 export function computerPanelAutoBoot(
   state: ComputerStatus["state"] | undefined,
   screenUrl?: string | null,

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -238,7 +238,9 @@ export function userHoldsComputerControl(
 /** True when status says a bot run/lease blocks Take control (API would return 409). */
 export function computerTakeoverBlocked(
   computer: Pick<ComputerStatus, "busyBotName"> | null | undefined,
+  runStatus?: string | null,
 ): boolean {
+  if (runStatus === "waiting_takeover") return false;
   return Boolean(computer?.busyBotName);
 }
 
@@ -257,20 +259,39 @@ export function reduceComputerStatus(
 ): ComputerStatus | null {
   if (!prev) return prev;
   if (!isComputerStatusEvent(event)) return prev;
+  if (event.type === "computer.takeover.requested") {
+    return prev.busyBotName === null ? prev : { ...prev, busyBotName: null };
+  }
   if (event.type === "computer.takeover.granted") {
     const takeoverRequested = event.payload.takeoverRequested === true;
     return prev.controlHolder === "user" &&
       prev.controlBotId === event.botId &&
-      prev.takeoverRequested === takeoverRequested
+      prev.takeoverRequested === takeoverRequested &&
+      prev.busyBotName === null
       ? prev
-      : { ...prev, controlHolder: "user", controlBotId: event.botId, takeoverRequested };
+      : {
+          ...prev,
+          controlHolder: "user",
+          controlBotId: event.botId,
+          takeoverRequested,
+          busyBotName: null,
+        };
   }
   if (event.type === "computer.takeover.released") {
     const holder = event.payload.holder;
     if (holder !== "bot" && holder !== "none") return prev;
-    return prev.controlHolder === holder && prev.controlBotId === null && !prev.takeoverRequested
+    return prev.controlHolder === holder &&
+      prev.controlBotId === null &&
+      !prev.takeoverRequested &&
+      prev.busyBotName === null
       ? prev
-      : { ...prev, controlHolder: holder, controlBotId: null, takeoverRequested: false };
+      : {
+          ...prev,
+          controlHolder: holder,
+          controlBotId: null,
+          takeoverRequested: false,
+          busyBotName: null,
+        };
   }
   const status = event.payload.status;
   if (!isComputerState(status)) return prev;
@@ -286,6 +307,7 @@ export function reduceComputerStatus(
 export function isComputerStatusEvent(event: ProductEvent): boolean {
   return (
     event.type === "computer.status" ||
+    event.type === "computer.takeover.requested" ||
     event.type === "computer.takeover.granted" ||
     event.type === "computer.takeover.released"
   );

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -1,11 +1,13 @@
 import type {
   ComputerStatus,
   ProductEvent,
+  RunStatus,
   ThreadMessage,
   ThreadMessagePage,
   ThreadSnapshot,
 } from "@rakazo/contracts";
 import {
+  isActive,
   isRunTerminalEvent,
   mergeThreadHistory,
   prependThreadHistoryPage,
@@ -235,13 +237,16 @@ export function userHoldsComputerControl(
   return Boolean(botId && computer?.controlHolder === "user" && computer.controlBotId === botId);
 }
 
-/** True when status says a bot run/lease blocks Take control (API would return 409). */
+/** True when a live bot run is blocking Take control (API would return 409). */
 export function computerTakeoverBlocked(
   computer: Pick<ComputerStatus, "busyBotName"> | null | undefined,
   runStatus?: string | null,
 ): boolean {
-  if (runStatus === "waiting_takeover") return false;
-  return Boolean(computer?.busyBotName);
+  if (!computer?.busyBotName) return false;
+  // waiting_takeover is the bot asking for control; terminal/idle clears the block even if
+  // busyBotName is briefly stale while the executor still holds the lease in finally.
+  if (!runStatus || runStatus === "waiting_takeover") return false;
+  return isActive(runStatus as RunStatus);
 }
 
 export function computerPanelAutoBoot(

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -100,6 +100,7 @@ import { rpc } from "../lib/rpc";
 import {
   activeThreadRuns,
   computerPanelAutoBoot,
+  computerTakeoverBlocked,
   isComputerStatusEvent,
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
@@ -231,6 +232,7 @@ export function ShellPage() {
   const [routineError, setRoutineError] = useState<string | null>(null);
   const [screenUrl, setScreenUrl] = useState<string | null>(null);
   const [computerOpen, setComputerOpen] = useState(false);
+  const [computerError, setComputerError] = useState<string | null>(null);
   const [usage, setUsage] = useState<{
     inputTokens: number;
     outputTokens: number;
@@ -1155,6 +1157,10 @@ export function ShellPage() {
       if (needsBoot) await rpc.computer.boot({ botId: active.id });
       if (takeControl) await rpc.computer.takeover({ botId: active.id });
       await refreshThread(active.id);
+      setComputerError(null);
+    } catch (error) {
+      setComputerError(error instanceof Error ? error.message : "Could not take control");
+      throw error;
     } finally {
       setBooting(false);
     }
@@ -1187,7 +1193,7 @@ export function ShellPage() {
         takeControl: false,
         overlay: action === "boot",
         force: true,
-      });
+      }).catch(() => undefined);
     })();
     return () => {
       cancelled = true;
@@ -1196,7 +1202,12 @@ export function ShellPage() {
 
   useEffect(() => {
     setComputerOpen(false);
+    setComputerError(null);
   }, [active?.id]);
+
+  useEffect(() => {
+    if (!computer?.busyBotName) setComputerError(null);
+  }, [computer?.busyBotName]);
 
   useEffect(() => {
     if (panel !== "routine") {
@@ -1246,12 +1257,20 @@ export function ShellPage() {
   async function openComputer() {
     if (!active) return;
     const needsTakeover = !userHoldsComputerControl(computer, active.id);
-    await bootComputer({
-      takeControl: needsTakeover,
-      overlay: needsTakeover || computer?.state !== "running",
-      force: computer?.state !== "running",
-    });
-    setComputerOpen(true);
+    const blocked = computerTakeoverBlocked(computer);
+    try {
+      await bootComputer({
+        takeControl: needsTakeover && !blocked,
+        overlay: (needsTakeover && !blocked) || computer?.state !== "running",
+        force: computer?.state !== "running",
+      });
+      setComputerOpen(true);
+      if (needsTakeover && blocked) {
+        setComputerError("Stop the bot first");
+      }
+    } catch {
+      // computerError already set in bootComputer
+    }
   }
 
   async function releaseComputer(reason?: ComputerReleaseReason) {
@@ -1263,6 +1282,7 @@ export function ShellPage() {
 
   const embeddedScreenUrl = embeddableScreenUrl(screenUrl);
   const hasControl = userHoldsComputerControl(computer, active?.id);
+  const takeoverBlocked = computerTakeoverBlocked(computer);
 
   const userName = session.data?.user.name ?? "You";
   const initials = userName
@@ -1808,15 +1828,17 @@ export function ShellPage() {
                     onClick={() => void openComputer()}
                   />
                 </div>
-                <div className="mt-3 flex items-center justify-between">
-                  <span className="text-[13.5px] text-[#85858A]">
-                    {computer?.busyBotName
-                      ? `${computer.busyBotName} is using it`
-                      : hasControl
-                        ? "You have control"
-                        : computer?.state === "suspended"
-                          ? "Asleep"
-                          : computerLabel(computer?.mode, active.name)}
+                <div className="mt-3 flex items-center justify-between gap-3">
+                  <span className="min-w-0 text-[13.5px] text-[#85858A]">
+                    {computerError
+                      ? computerError
+                      : computer?.busyBotName
+                        ? `${computer.busyBotName} is using it`
+                        : hasControl
+                          ? "You have control"
+                          : computer?.state === "suspended"
+                            ? "Asleep"
+                            : computerLabel(computer?.mode, active.name)}
                   </span>
                   {hasControl ? (
                     <ComputerReleaseActions
@@ -1828,6 +1850,11 @@ export function ShellPage() {
                       type="button"
                       variant="outline"
                       size="sm"
+                      disabled={takeoverBlocked}
+                      title={takeoverBlocked ? "Stop the bot first" : undefined}
+                      aria-label={
+                        takeoverBlocked ? "Take control — stop the bot first" : "Take control"
+                      }
                       onClick={() => void openComputer()}
                     >
                       Take control
@@ -2330,7 +2357,14 @@ export function ShellPage() {
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => void bootComputer({ takeControl: true, overlay: false })}
+                  disabled={takeoverBlocked}
+                  title={takeoverBlocked ? "Stop the bot first" : undefined}
+                  aria-label={
+                    takeoverBlocked ? "Take control — stop the bot first" : "Take control"
+                  }
+                  onClick={() =>
+                    void bootComputer({ takeControl: true, overlay: false }).catch(() => undefined)
+                  }
                 >
                   Take control
                 </Button>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -673,6 +673,8 @@ export function ShellPage() {
             }
             if (isRunTerminalEvent(event) || event.type === "skill.teaching.stopped") {
               void refreshThread(active.id).catch(() => undefined);
+            } else if (event.type === "computer.takeover.requested") {
+              void refreshThread(active.id).catch(() => undefined);
             } else if (isComputerStatusEvent(event)) {
               void refreshComputerScreen(active.id).catch(() => undefined);
             }
@@ -1257,7 +1259,7 @@ export function ShellPage() {
   async function openComputer() {
     if (!active) return;
     const needsTakeover = !userHoldsComputerControl(computer, active.id);
-    const blocked = computerTakeoverBlocked(computer);
+    const blocked = computerTakeoverBlocked(computer, snapshot?.run?.status);
     try {
       await bootComputer({
         takeControl: needsTakeover && !blocked,
@@ -1282,7 +1284,7 @@ export function ShellPage() {
 
   const embeddedScreenUrl = embeddableScreenUrl(screenUrl);
   const hasControl = userHoldsComputerControl(computer, active?.id);
-  const takeoverBlocked = computerTakeoverBlocked(computer);
+  const takeoverBlocked = computerTakeoverBlocked(computer, snapshot?.run?.status);
 
   const userName = session.data?.user.name ?? "You";
   const initials = userName
@@ -1830,12 +1832,12 @@ export function ShellPage() {
                 </div>
                 <div className="mt-3 flex items-center justify-between gap-3">
                   <span className="min-w-0 text-[13.5px] text-[#85858A]">
-                    {computerError
-                      ? computerError
-                      : computer?.busyBotName
-                        ? `${computer.busyBotName} is using it`
-                        : hasControl
-                          ? "You have control"
+                    {hasControl
+                      ? "You have control"
+                      : computerError
+                        ? computerError
+                        : computer?.busyBotName
+                          ? `${computer.busyBotName} is using it`
                           : computer?.state === "suspended"
                             ? "Asleep"
                             : computerLabel(computer?.mode, active.name)}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2807,9 +2807,6 @@ function applyThreadEvent(
   if (isComputerStatusEvent(event)) {
     setComputer((prev) => reduceComputerStatus(prev, event));
   }
-  if (isRunTerminalEvent(event)) {
-    setComputer((prev) => (prev?.busyBotName ? { ...prev, busyBotName: null } : prev));
-  }
 }
 
 function ComputerReleaseActions({

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -672,7 +672,15 @@ export function ShellPage() {
               if (event.payload.role === "bot") markBotReadIfVisible(active.id);
             }
             if (isRunTerminalEvent(event) || event.type === "skill.teaching.stopped") {
-              void refreshThread(active.id).catch(() => undefined);
+              // Lease release happens in the executor finally after the terminal event.
+              // Refresh once, then again shortly if status still shows a busy bot.
+              void (async () => {
+                const snap = await refreshThread(active.id).catch(() => null);
+                if (!snap?.computer?.busyBotName) return;
+                await abortableDelay(300);
+                if (activeBotId.current !== active.id) return;
+                await refreshThread(active.id).catch(() => undefined);
+              })();
             } else if (event.type === "computer.takeover.requested") {
               // Clears busyBotName so Take control stays enabled for waiting_takeover.
               void refreshThread(active.id).catch(() => undefined);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2811,6 +2811,9 @@ function applyThreadEvent(
   if (isComputerStatusEvent(event)) {
     setComputer((prev) => reduceComputerStatus(prev, event));
   }
+  if (isRunTerminalEvent(event)) {
+    setComputer((prev) => (prev?.busyBotName ? { ...prev, busyBotName: null } : prev));
+  }
 }
 
 function ComputerReleaseActions({

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -672,15 +672,7 @@ export function ShellPage() {
               if (event.payload.role === "bot") markBotReadIfVisible(active.id);
             }
             if (isRunTerminalEvent(event) || event.type === "skill.teaching.stopped") {
-              // Lease release happens in the executor finally after the terminal event.
-              // Refresh once, then again shortly if status still shows a busy bot.
-              void (async () => {
-                const snap = await refreshThread(active.id).catch(() => null);
-                if (!snap?.computer?.busyBotName) return;
-                await abortableDelay(300);
-                if (activeBotId.current !== active.id) return;
-                await refreshThread(active.id).catch(() => undefined);
-              })();
+              void refreshThread(active.id).catch(() => undefined);
             } else if (event.type === "computer.takeover.requested") {
               // Clears busyBotName so Take control stays enabled for waiting_takeover.
               void refreshThread(active.id).catch(() => undefined);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -671,14 +671,10 @@ export function ShellPage() {
               }
               if (event.payload.role === "bot") markBotReadIfVisible(active.id);
             }
-            if (
-              isRunTerminalEvent(event) ||
-              event.type === "run.waiting_takeover" ||
-              event.type === "skill.teaching.stopped"
-            ) {
-              // waiting_takeover clears busyBotName (same rule as computer.takeover 409).
+            if (isRunTerminalEvent(event) || event.type === "skill.teaching.stopped") {
               void refreshThread(active.id).catch(() => undefined);
             } else if (event.type === "computer.takeover.requested") {
+              // Clears busyBotName so Take control stays enabled for waiting_takeover.
               void refreshThread(active.id).catch(() => undefined);
             } else if (isComputerStatusEvent(event)) {
               void refreshComputerScreen(active.id).catch(() => undefined);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -671,7 +671,12 @@ export function ShellPage() {
               }
               if (event.payload.role === "bot") markBotReadIfVisible(active.id);
             }
-            if (isRunTerminalEvent(event) || event.type === "skill.teaching.stopped") {
+            if (
+              isRunTerminalEvent(event) ||
+              event.type === "run.waiting_takeover" ||
+              event.type === "skill.teaching.stopped"
+            ) {
+              // waiting_takeover clears busyBotName (same rule as computer.takeover 409).
               void refreshThread(active.id).catch(() => undefined);
             } else if (event.type === "computer.takeover.requested") {
               void refreshThread(active.id).catch(() => undefined);
@@ -1267,9 +1272,6 @@ export function ShellPage() {
         force: computer?.state !== "running",
       });
       setComputerOpen(true);
-      if (needsTakeover && blocked) {
-        setComputerError("Stop the bot first");
-      }
     } catch {
       // computerError already set in bootComputer
     }
@@ -1854,9 +1856,6 @@ export function ShellPage() {
                       size="sm"
                       disabled={takeoverBlocked}
                       title={takeoverBlocked ? "Stop the bot first" : undefined}
-                      aria-label={
-                        takeoverBlocked ? "Take control — stop the bot first" : "Take control"
-                      }
                       onClick={() => void openComputer()}
                     >
                       Take control
@@ -2361,9 +2360,6 @@ export function ShellPage() {
                   size="sm"
                   disabled={takeoverBlocked}
                   title={takeoverBlocked ? "Stop the bot first" : undefined}
-                  aria-label={
-                    takeoverBlocked ? "Take control — stop the bot first" : "Take control"
-                  }
                   onClick={() =>
                     void bootComputer({ takeControl: true, overlay: false }).catch(() => undefined)
                   }

--- a/docs/computer-runtime.md
+++ b/docs/computer-runtime.md
@@ -27,7 +27,7 @@ Each workspace gets one Team Computer by default, so bots share its browser sess
 
 The model gets `computer_observe`, batched `computer_act`, `open_path`, `launch_app`, `shell`, and file tools. An action can settle and return the resulting screenshot in one call. Identical consecutive frames keep their metadata but omit duplicate image bytes from model context.
 
-Human input and agent input may coexist. “Take control” changes whether the embedded viewer accepts user input; it does not create an exclusive machine lock or automatically pause an active run. `request_takeover` remains available when the model explicitly needs protected input or human judgment.
+Human input and agent input may coexist on distinct Team screens. “Take control” grants the user an exclusive control lease on that bot’s screen so the embedded viewer accepts input. For a Team bot, takeover is refused with HTTP 409 (“Stop the bot first”) while that bot holds a live computer execution lease or an active run, unless the run is `waiting_takeover` (the bot asked for protected input). Stop the bot first, then take control; after release, the agent may continue. `request_takeover` remains available when the model explicitly needs protected input or human judgment.
 
 ## E2B backend
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #181

When a Team bot is mid-run, `computer.takeover` correctly returns HTTP 409 (`Stop the bot first`), but the web UI still looked clickable and ignored the conflict. Status also left `busyBotName` hardcoded to `null`.

### Changes
- Resolve `busyBotName` from the bot’s live computer execution lease/run (same rule as the 409 path; still allows `waiting_takeover`)
- Disable **Take control** while blocked, catch takeover failures, and show the busy-bot status hint
- Align `docs/computer-runtime.md` with the exclusive control lease / stop-first API behavior
- Extend unit coverage and the existing Team Computer e2e for busy status + disabled control

After stop, takeover still works as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b7f91ea-e04b-485f-8ba0-fee004aa221c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b7f91ea-e04b-485f-8ba0-fee004aa221c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

