### PR TITLE
Fix takeover state race in web E2E

### DIFF
--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -186,7 +186,9 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
     .toBeNull();
   await expect(takeControl).toBeEnabled();
   await takeControl.click();
-  await expect(page.getByText("You have control", { exact: true })).toBeVisible();
+  await expect(
+    page.getByTestId("side-panel").getByText("You have control", { exact: true }),
+  ).toBeVisible();
   await captureScreenshot(page, testInfo, "49-team-computer-takeover-after-stop");
   await rpc(page, "computer/release", { botId: chiefId });
 });

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -279,6 +279,36 @@ describe("thread event reduction", () => {
     expect(reconciled.computer).toBe(prevComputer);
   });
 
+  it("applies a stop refresh that clears the run even when progress advanced the cursor", () => {
+    const run = threadRun("run-1");
+    const localWithProgress: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 14,
+      run,
+      computer: computer({ state: "running", busyBotName: "Chief" }),
+    };
+    const stopRefresh: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 11,
+      run: null,
+      activeRuns: [],
+      computer: computer({ state: "running", busyBotName: null }),
+    };
+
+    const reconciled = reconcileRefreshedThread(
+      localWithProgress,
+      stopRefresh,
+      computer({ state: "running", busyBotName: "Chief" }),
+    );
+
+    expect(reconciled.snapshot.run).toBeNull();
+    expect(reconciled.snapshot.cursor).toBe(14);
+    expect(reconciled.computer?.busyBotName).toBeNull();
+    expect(computerTakeoverBlocked(reconciled.computer, reconciled.snapshot.run?.status)).toBe(
+      false,
+    );
+  });
+
   it("keeps group member status in sync with run lifecycle events", () => {
     const run = threadRun("run-1", "bot-member");
     const initial: ThreadSnapshot = {

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -212,6 +212,39 @@ describe("thread event reduction", () => {
     expect(isThreadSnapshotEvent(event({ type: "computer.takeover.requested" }))).toBe(true);
   });
 
+  it("event-sources the active run on run.started so Stop does not wait on threads.get", () => {
+    const initial = snapshot([]);
+    const started = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "run.started",
+        seq: 3,
+        runId: "run-1",
+        payload: { trigger: "user" },
+      }),
+    );
+
+    expect(started?.run).toMatchObject({
+      id: "run-1",
+      botId: "bot-1",
+      status: "running",
+      trigger: "user",
+    });
+    expect(started?.activeRuns).toEqual([started?.run]);
+
+    const progressed = reduceThreadSnapshot(
+      started,
+      event({
+        type: "thread.progress",
+        seq: 4,
+        runId: "run-1",
+        payload: { delta: "still working" },
+      }),
+    );
+    expect(progressed?.run?.id).toBe("run-1");
+    expect(progressed?.cursor).toBe(4);
+  });
+
   it("marks the run as waiting when computer takeover is requested", () => {
     const run = threadRun("run-1");
     const initial: ThreadSnapshot = {
@@ -364,9 +397,12 @@ describe("thread event reduction", () => {
       event({ type: "run.started", botId: "bot-member", runId: run.id }),
     );
     expect(started?.members?.[0]?.status).toBe("running");
+    expect(started?.run?.id).toBe(run.id);
+    expect(started?.run?.status).toBe("running");
+    expect(started?.activeRuns?.map((item) => item.id)).toEqual([run.id]);
 
     const waiting = reduceThreadSnapshot(
-      { ...started!, run, activeRuns: [run] },
+      started!,
       event({
         type: "run.waiting_input",
         seq: 5,

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -12,6 +12,7 @@ import {
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
   prependThreadMessagePage,
+  reconcileRefreshedThread,
   reduceComputerStatus,
   reduceThreadSnapshot,
   userHoldsComputerControl,
@@ -226,6 +227,56 @@ describe("thread event reduction", () => {
 
     expect(waiting?.run?.status).toBe("waiting_takeover");
     expect(waiting?.activeRuns?.[0]?.status).toBe("waiting_takeover");
+  });
+
+  it("keeps event-sourced waiting_takeover when a stale refresh still shows the bot busy", () => {
+    const run = threadRun("run-1");
+    const waitingLocal: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 10,
+      run: { ...run, status: "waiting_takeover" },
+      activeRuns: [{ ...run, status: "waiting_takeover" }],
+    };
+    const staleRefresh: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 10,
+      run,
+      activeRuns: [run],
+      computer: computer({ state: "running", busyBotName: "Chief" }),
+    };
+
+    const reconciled = reconcileRefreshedThread(
+      waitingLocal,
+      staleRefresh,
+      computer({ state: "running", busyBotName: null }),
+    );
+
+    expect(reconciled.snapshot.run?.status).toBe("waiting_takeover");
+    expect(reconciled.computer?.busyBotName).toBeNull();
+    expect(computerTakeoverBlocked(reconciled.computer, reconciled.snapshot.run?.status)).toBe(
+      false,
+    );
+  });
+
+  it("ignores a refresh whose cursor is behind the event-sourced snapshot", () => {
+    const run = threadRun("run-1");
+    const newer: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 12,
+      run: { ...run, status: "waiting_takeover" },
+    };
+    const older: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 9,
+      run,
+      computer: computer({ busyBotName: "Chief" }),
+    };
+    const prevComputer = computer({ busyBotName: null });
+
+    const reconciled = reconcileRefreshedThread(newer, older, prevComputer);
+
+    expect(reconciled.snapshot).toBe(newer);
+    expect(reconciled.computer).toBe(prevComputer);
   });
 
   it("keeps group member status in sync with run lifecycle events", () => {

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -298,6 +298,37 @@ describe("thread event reduction", () => {
     expect(reconciled.snapshot).toBe(newer);
     expect(reconciled.computer?.busyBotName).toBe("Chief");
   });
+
+  it("keeps an optimistic stop clear when an older cursor refresh still looks busy", () => {
+    // Stop has no terminal event, so progress can leave the local cursor ahead of threads.get.
+    // After the shell clears run/busy locally, that older get must not restore Stop / Take control block.
+    const run = threadRun("run-1");
+    const stoppedLocal: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 15,
+      run: null,
+      activeRuns: [],
+      computer: computer({ state: "running", busyBotName: null }),
+    };
+    const staleBusyRefresh: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 10,
+      run,
+      activeRuns: [run],
+      computer: computer({ state: "running", busyBotName: "Chief" }),
+    };
+    const clearedComputer = computer({ state: "running", busyBotName: null });
+
+    const reconciled = reconcileRefreshedThread(stoppedLocal, staleBusyRefresh, clearedComputer);
+
+    expect(reconciled.snapshot.run).toBeNull();
+    expect(reconciled.snapshot.activeRuns).toEqual([]);
+    expect(reconciled.computer?.busyBotName).toBeNull();
+    expect(computerTakeoverBlocked(reconciled.computer, reconciled.snapshot.run?.status)).toBe(
+      false,
+    );
+  });
+
   it("always replaces the snapshot when switching to a different thread", () => {
     const previous: ThreadSnapshot = {
       ...snapshot([]),

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -309,6 +309,27 @@ describe("thread event reduction", () => {
     );
   });
 
+  it("always replaces the snapshot when switching to a different thread", () => {
+    const previous: ThreadSnapshot = {
+      ...snapshot([]),
+      threadId: "thread-writer",
+      cursor: 40,
+      computer: computer({ mode: "team", busyBotName: null }),
+    };
+    const next: ThreadSnapshot = {
+      ...snapshot([]),
+      botId: "bot-private",
+      threadId: "thread-private",
+      cursor: 0,
+      computer: computer({ mode: "dedicated", state: "running" }),
+    };
+
+    const reconciled = reconcileRefreshedThread(previous, next, previous.computer);
+
+    expect(reconciled.snapshot.threadId).toBe("thread-private");
+    expect(reconciled.computer?.mode).toBe("dedicated");
+  });
+
   it("keeps group member status in sync with run lifecycle events", () => {
     const run = threadRun("run-1", "bot-member");
     const initial: ThreadSnapshot = {

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -7,6 +7,7 @@ import type {
 import { describe, expect, it } from "vitest";
 import {
   activeThreadRuns,
+  clearActiveThreadRuns,
   computerPanelAutoBoot,
   computerTakeoverBlocked,
   isThreadSnapshotEvent,
@@ -330,6 +331,48 @@ describe("thread event reduction", () => {
 
     expect(reconciled.snapshot).toBe(newer);
     expect(reconciled.computer?.busyBotName).toBe("Chief");
+  });
+
+  it("hydrates a live run from a refresh without rolling back newer progress", () => {
+    const run = threadRun("run-1");
+    const liveProgress = {
+      ...message("progress:run-1", [{ kind: "progress" as const, text: "Still working" }]),
+      runId: run.id,
+    };
+    const newer: ThreadSnapshot = { ...snapshot([liveProgress]), cursor: 12, run: null };
+    const older: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 11,
+      run,
+      computer: computer({ state: "running", controlHolder: "bot", busyBotName: "Chief" }),
+    };
+
+    const reconciled = reconcileRefreshedThread(newer, older, computer());
+
+    expect(reconciled.snapshot.cursor).toBe(12);
+    expect(reconciled.snapshot.messages).toEqual([liveProgress]);
+    expect(reconciled.snapshot.run).toBe(run);
+    expect(reconciled.computer?.busyBotName).toBe("Chief");
+  });
+
+  it("clears active runs and their transient progress after stop", () => {
+    const run = threadRun("run-1");
+    const durable = message("message-1", [{ kind: "text", text: "Keep me" }]);
+    const progress = {
+      ...message("progress:run-1", [{ kind: "progress" as const, text: "Still working" }]),
+      runId: run.id,
+    };
+    const stopped = clearActiveThreadRuns({
+      ...snapshot([durable, progress]),
+      run,
+      activeRuns: [run],
+      computer: computer({ state: "running", busyBotName: "Chief" }),
+    });
+
+    expect(stopped.run).toBeNull();
+    expect(stopped.activeRuns).toEqual([]);
+    expect(stopped.messages).toEqual([durable]);
+    expect(stopped.computer?.busyBotName).toBeNull();
   });
 
   it("keeps an optimistic stop clear when an older cursor refresh still looks busy", () => {

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -208,6 +208,24 @@ describe("thread event reduction", () => {
     ).toBe(true);
     expect(isThreadSnapshotEvent(event({ type: "run.started" }))).toBe(true);
     expect(isThreadSnapshotEvent(event({ type: "run.completed" }))).toBe(true);
+    expect(isThreadSnapshotEvent(event({ type: "computer.takeover.requested" }))).toBe(true);
+  });
+
+  it("marks the run as waiting when computer takeover is requested", () => {
+    const run = threadRun("run-1");
+    const initial: ThreadSnapshot = {
+      ...snapshot([]),
+      run,
+      activeRuns: [run],
+    };
+
+    const waiting = reduceThreadSnapshot(
+      initial,
+      event({ type: "computer.takeover.requested", seq: 5, runId: run.id }),
+    );
+
+    expect(waiting?.run?.status).toBe("waiting_takeover");
+    expect(waiting?.activeRuns?.[0]?.status).toBe("waiting_takeover");
   });
 
   it("keeps group member status in sync with run lifecycle events", () => {

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -279,6 +279,25 @@ describe("thread event reduction", () => {
     expect(reconciled.computer).toBe(prevComputer);
   });
 
+  it("refreshes busy status when only transient thread events are ahead", () => {
+    const run = threadRun("run-1");
+    const newer: ThreadSnapshot = { ...snapshot([]), cursor: 12, run };
+    const older: ThreadSnapshot = {
+      ...snapshot([]),
+      cursor: 9,
+      run,
+      computer: computer({ state: "running", controlHolder: "bot", busyBotName: "Chief" }),
+    };
+
+    const reconciled = reconcileRefreshedThread(
+      newer,
+      older,
+      computer({ state: "running", controlHolder: "bot", busyBotName: null }),
+    );
+
+    expect(reconciled.snapshot).toBe(newer);
+    expect(reconciled.computer?.busyBotName).toBe("Chief");
+  });
   it("always replaces the snapshot when switching to a different thread", () => {
     const previous: ThreadSnapshot = {
       ...snapshot([]),

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -279,36 +279,6 @@ describe("thread event reduction", () => {
     expect(reconciled.computer).toBe(prevComputer);
   });
 
-  it("applies a stop refresh that clears the run even when progress advanced the cursor", () => {
-    const run = threadRun("run-1");
-    const localWithProgress: ThreadSnapshot = {
-      ...snapshot([]),
-      cursor: 14,
-      run,
-      computer: computer({ state: "running", busyBotName: "Chief" }),
-    };
-    const stopRefresh: ThreadSnapshot = {
-      ...snapshot([]),
-      cursor: 11,
-      run: null,
-      activeRuns: [],
-      computer: computer({ state: "running", busyBotName: null }),
-    };
-
-    const reconciled = reconcileRefreshedThread(
-      localWithProgress,
-      stopRefresh,
-      computer({ state: "running", busyBotName: "Chief" }),
-    );
-
-    expect(reconciled.snapshot.run).toBeNull();
-    expect(reconciled.snapshot.cursor).toBe(14);
-    expect(reconciled.computer?.busyBotName).toBeNull();
-    expect(computerTakeoverBlocked(reconciled.computer, reconciled.snapshot.run?.status)).toBe(
-      false,
-    );
-  });
-
   it("always replaces the snapshot when switching to a different thread", () => {
     const previous: ThreadSnapshot = {
       ...snapshot([]),
@@ -324,7 +294,7 @@ describe("thread event reduction", () => {
       computer: computer({ mode: "dedicated", state: "running" }),
     };
 
-    const reconciled = reconcileRefreshedThread(previous, next, previous.computer);
+    const reconciled = reconcileRefreshedThread(previous, next, previous.computer ?? null);
 
     expect(reconciled.snapshot.threadId).toBe("thread-private");
     expect(reconciled.computer?.mode).toBe("dedicated");

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -57,13 +57,8 @@ export function mergeThreadSnapshot(
 /**
  * Apply a threads.get refresh without clobbering newer event-sourced takeover state.
  *
- * Takeover events are published with the waiting_takeover row, but a refresh that started
- * earlier can still return running+busyBotName. Stop does not emit a terminal event, so a
- * refresh that clears the active run must win even when progress events advanced the local
- * cursor while a slow screen URL fetch kept Promise.all open.
- *
- * Cursor comparisons only apply within the same thread — a new bot/group thread must always
- * replace the previous snapshot (its cursor is not comparable).
+ * A refresh that started earlier can still return running+busyBotName after the client
+ * already applied waiting_takeover. Cursor comparisons only apply within the same thread.
  */
 export function reconcileRefreshedThread(
   prev: ThreadSnapshot | null,
@@ -72,24 +67,9 @@ export function reconcileRefreshedThread(
   preserveLoadedHistory = false,
 ): { snapshot: ThreadSnapshot; computer: ComputerStatus | null } {
   const sameThread = Boolean(prev && prev.threadId === snap.threadId);
-  const snapClearsActiveRun =
-    Boolean(prev?.run && isActive(prev.run.status as RunStatus)) &&
-    (snap.run == null || !isActive(snap.run.status as RunStatus));
 
   if (sameThread && prev && snap.cursor < prev.cursor) {
-    if (!snapClearsActiveRun) {
-      return { snapshot: prev, computer: prevComputer };
-    }
-    // Keep newer event-sourced messages; adopt the cleared run/computer from stop refresh.
-    return {
-      snapshot: {
-        ...prev,
-        run: snap.run,
-        activeRuns: snap.activeRuns,
-        computer: snap.computer ?? prev.computer,
-      },
-      computer: snap.computer ?? null,
-    };
+    return { snapshot: prev, computer: prevComputer };
   }
 
   let snapshot = mergeThreadSnapshot(prev, snap, preserveLoadedHistory);

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -34,9 +34,10 @@ function runFromStartedEvent(event: ProductEvent, previous: Run | undefined): Ru
     threadId: event.threadId,
     taskId: previous?.taskId ?? event.runId ?? event.id,
     status: "running",
-    trigger: typeof trigger === "string" && runTriggers.has(trigger as Run["trigger"])
-      ? (trigger as Run["trigger"])
-      : (previous?.trigger ?? "user"),
+    trigger:
+      typeof trigger === "string" && runTriggers.has(trigger as Run["trigger"])
+        ? (trigger as Run["trigger"])
+        : (previous?.trigger ?? "user"),
     modelProvider: previous?.modelProvider ?? null,
     modelId: previous?.modelId ?? null,
     error: null,

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -57,11 +57,10 @@ export function mergeThreadSnapshot(
 /**
  * Apply a threads.get refresh without clobbering newer event-sourced takeover state.
  *
- * `computer.takeover.requested` is published before the run row flips to waiting_takeover.
- * A refresh started earlier (e.g. after send, while the computer panel keeps screen URL
- * fetch slow) can return running+busyBotName after the client already applied the event.
- * The subscribe cursor has already advanced past that event, so overwriting would leave
- * Take control disabled until another refresh happens to land after the status flip.
+ * Takeover events are published with the waiting_takeover row, but a refresh that started
+ * earlier can still return running+busyBotName. Stop does not emit a terminal event, so a
+ * refresh that clears the active run must win even when progress events advanced the local
+ * cursor while a slow screen URL fetch kept Promise.all open.
  */
 export function reconcileRefreshedThread(
   prev: ThreadSnapshot | null,
@@ -69,8 +68,24 @@ export function reconcileRefreshedThread(
   prevComputer: ComputerStatus | null,
   preserveLoadedHistory = false,
 ): { snapshot: ThreadSnapshot; computer: ComputerStatus | null } {
+  const snapClearsActiveRun =
+    Boolean(prev?.run && isActive(prev.run.status as RunStatus)) &&
+    (snap.run == null || !isActive(snap.run.status as RunStatus));
+
   if (prev && snap.cursor < prev.cursor) {
-    return { snapshot: prev, computer: prevComputer };
+    if (!snapClearsActiveRun) {
+      return { snapshot: prev, computer: prevComputer };
+    }
+    // Keep newer event-sourced messages; adopt the cleared run/computer from stop refresh.
+    return {
+      snapshot: {
+        ...prev,
+        run: snap.run,
+        activeRuns: snap.activeRuns,
+        computer: snap.computer ?? prev.computer,
+      },
+      computer: snap.computer ?? null,
+    };
   }
 
   let snapshot = mergeThreadSnapshot(prev, snap, preserveLoadedHistory);

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -69,7 +69,12 @@ export function reconcileRefreshedThread(
   const sameThread = Boolean(prev && prev.threadId === snap.threadId);
 
   if (sameThread && prev && snap.cursor < prev.cursor) {
-    return { snapshot: prev, computer: prevComputer };
+    // Progress can advance the thread cursor while the embedded computer status remains
+    // authoritative. Preserve only the event-sourced takeover transition itself.
+    return {
+      snapshot: prev,
+      computer: prev.run?.status === "waiting_takeover" ? prevComputer : (snap.computer ?? null),
+    };
   }
 
   let snapshot = mergeThreadSnapshot(prev, snap, preserveLoadedHistory);

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -76,6 +76,23 @@ export function activeThreadRuns(
   return snapshot?.activeRuns ?? (snapshot?.run ? [snapshot.run] : []);
 }
 
+export function clearActiveThreadRuns(snapshot: ThreadSnapshot): ThreadSnapshot {
+  const runIds = new Set(activeThreadRuns(snapshot).map((run) => run.id));
+  const computer = snapshot.computer?.busyBotName
+    ? { ...snapshot.computer, busyBotName: null }
+    : snapshot.computer;
+  return {
+    ...snapshot,
+    run: null,
+    activeRuns: [],
+    messages: snapshot.messages.filter(
+      (message) =>
+        !message.runId || !runIds.has(message.runId) || !message.id.startsWith("progress:"),
+    ),
+    computer,
+  };
+}
+
 export function mergeThreadSnapshot(
   prev: ThreadSnapshot | null,
   next: ThreadSnapshot,
@@ -101,6 +118,28 @@ export function reconcileRefreshedThread(
   const sameThread = Boolean(prev && prev.threadId === snap.threadId);
 
   if (sameThread && prev && snap.cursor < prev.cursor) {
+    // A subscription can advance the cursor with progress before the send-triggered refresh
+    // returns the new run record. Hydrate that matching run without rolling the transcript back.
+    // Optimistic stop removes the matching progress message, so an older refresh cannot revive it.
+    const refreshedRun = snap.run;
+    const hasMatchingLiveProgress = Boolean(
+      refreshedRun &&
+        prev.messages.some(
+          (message) =>
+            message.runId === refreshedRun.id && message.id === `progress:${refreshedRun.id}`,
+        ),
+    );
+    if (!prev.run && refreshedRun && hasMatchingLiveProgress) {
+      return {
+        snapshot: {
+          ...prev,
+          run: refreshedRun,
+          activeRuns: snap.activeRuns,
+          computer: snap.computer,
+        },
+        computer: snap.computer ?? null,
+      };
+    }
     // Progress can advance the thread cursor while embedded computer status from threads.get
     // is still useful — but only while a live run remains. Preserve event-sourced
     // waiting_takeover clears and optimistic stop clears.

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -61,6 +61,9 @@ export function mergeThreadSnapshot(
  * earlier can still return running+busyBotName. Stop does not emit a terminal event, so a
  * refresh that clears the active run must win even when progress events advanced the local
  * cursor while a slow screen URL fetch kept Promise.all open.
+ *
+ * Cursor comparisons only apply within the same thread — a new bot/group thread must always
+ * replace the previous snapshot (its cursor is not comparable).
  */
 export function reconcileRefreshedThread(
   prev: ThreadSnapshot | null,
@@ -68,11 +71,12 @@ export function reconcileRefreshedThread(
   prevComputer: ComputerStatus | null,
   preserveLoadedHistory = false,
 ): { snapshot: ThreadSnapshot; computer: ComputerStatus | null } {
+  const sameThread = Boolean(prev && prev.threadId === snap.threadId);
   const snapClearsActiveRun =
     Boolean(prev?.run && isActive(prev.run.status as RunStatus)) &&
     (snap.run == null || !isActive(snap.run.status as RunStatus));
 
-  if (prev && snap.cursor < prev.cursor) {
+  if (sameThread && prev && snap.cursor < prev.cursor) {
     if (!snapClearsActiveRun) {
       return { snapshot: prev, computer: prevComputer };
     }
@@ -92,6 +96,7 @@ export function reconcileRefreshedThread(
   let computer = snap.computer ?? null;
 
   const localWaiting =
+    sameThread &&
     prev?.run?.status === "waiting_takeover" &&
     snapshot.run?.id === prev.run.id &&
     snapshot.run.status !== "waiting_takeover" &&

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -54,6 +54,51 @@ export function mergeThreadSnapshot(
   return mergeThreadHistory(prev, next, preserveLoadedHistory);
 }
 
+/**
+ * Apply a threads.get refresh without clobbering newer event-sourced takeover state.
+ *
+ * `computer.takeover.requested` is published before the run row flips to waiting_takeover.
+ * A refresh started earlier (e.g. after send, while the computer panel keeps screen URL
+ * fetch slow) can return running+busyBotName after the client already applied the event.
+ * The subscribe cursor has already advanced past that event, so overwriting would leave
+ * Take control disabled until another refresh happens to land after the status flip.
+ */
+export function reconcileRefreshedThread(
+  prev: ThreadSnapshot | null,
+  snap: ThreadSnapshot,
+  prevComputer: ComputerStatus | null,
+  preserveLoadedHistory = false,
+): { snapshot: ThreadSnapshot; computer: ComputerStatus | null } {
+  if (prev && snap.cursor < prev.cursor) {
+    return { snapshot: prev, computer: prevComputer };
+  }
+
+  let snapshot = mergeThreadSnapshot(prev, snap, preserveLoadedHistory);
+  let computer = snap.computer ?? null;
+
+  const localWaiting =
+    prev?.run?.status === "waiting_takeover" &&
+    snapshot.run?.id === prev.run.id &&
+    snapshot.run.status !== "waiting_takeover" &&
+    isActive(snapshot.run.status as RunStatus);
+
+  if (localWaiting && snapshot.run) {
+    const runId = snapshot.run.id;
+    snapshot = {
+      ...snapshot,
+      run: { ...snapshot.run, status: "waiting_takeover" },
+      activeRuns: snapshot.activeRuns?.map((run) =>
+        run.id === runId ? { ...run, status: "waiting_takeover" } : run,
+      ),
+    };
+    if (computer?.busyBotName) computer = { ...computer, busyBotName: null };
+  } else if (snapshot.run?.status === "waiting_takeover" && computer?.busyBotName) {
+    computer = { ...computer, busyBotName: null };
+  }
+
+  return { snapshot, computer };
+}
+
 export function prependThreadMessagePage(
   prev: ThreadSnapshot | null,
   page: ThreadMessagePage,

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -1,6 +1,7 @@
 import type {
   ComputerStatus,
   ProductEvent,
+  Run,
   RunStatus,
   ThreadMessage,
   ThreadMessagePage,
@@ -15,6 +16,34 @@ import {
   reduceLiveMessageBlocks,
   subagentBlockFromPayload,
 } from "@rakazo/core";
+
+const runTriggers = new Set<Run["trigger"]>([
+  "user",
+  "routine",
+  "resume",
+  "follow_up",
+  "spawn",
+  "skill",
+]);
+
+function runFromStartedEvent(event: ProductEvent, previous: Run | undefined): Run {
+  const trigger = event.payload.trigger;
+  return {
+    id: event.runId ?? previous?.id ?? event.id,
+    botId: event.botId,
+    threadId: event.threadId,
+    taskId: previous?.taskId ?? event.runId ?? event.id,
+    status: "running",
+    trigger: typeof trigger === "string" && runTriggers.has(trigger as Run["trigger"])
+      ? (trigger as Run["trigger"])
+      : (previous?.trigger ?? "user"),
+    modelProvider: previous?.modelProvider ?? null,
+    modelId: previous?.modelId ?? null,
+    error: null,
+    startedAt: previous?.startedAt ?? event.createdAt,
+    completedAt: null,
+  };
+}
 
 function takeLiveMessage(
   messages: readonly ThreadMessage[],
@@ -149,10 +178,28 @@ export function reduceThreadSnapshot(
     };
   }
   if (event.type === "run.started") {
+    if (!event.runId) {
+      return {
+        ...prev,
+        cursor: event.seq,
+        members: updateMemberStatus(prev.members, event.botId, "running"),
+      };
+    }
+    const previousRun =
+      prev.activeRuns?.find((candidate) => candidate.id === event.runId) ??
+      (prev.run?.id === event.runId ? prev.run : undefined);
+    const run = runFromStartedEvent(event, previousRun);
+    const without = (prev.activeRuns ?? (prev.run ? [prev.run] : [])).filter(
+      (candidate) => candidate.id !== run.id,
+    );
+    // Bot threads keep a single primary run; groups accumulate concurrent member runs.
+    const activeRuns = prev.groupId ? [...without, run] : [run];
     return {
       ...prev,
       cursor: event.seq,
       members: updateMemberStatus(prev.members, event.botId, "running"),
+      run,
+      activeRuns,
     };
   }
   if (event.type === "run.waiting_input" || event.type === "computer.takeover.requested") {

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -71,6 +71,7 @@ export function isThreadSnapshotEvent(event: ProductEvent): boolean {
     event.type === "thread.message.updated" ||
     event.type === "run.started" ||
     event.type === "run.waiting_input" ||
+    event.type === "computer.takeover.requested" ||
     isRunTerminalEvent(event)
   );
 }
@@ -97,23 +98,24 @@ export function reduceThreadSnapshot(
       members: updateMemberStatus(prev.members, event.botId, "running"),
     };
   }
-  if (event.type === "run.waiting_input") {
+  if (event.type === "run.waiting_input" || event.type === "computer.takeover.requested") {
+    const status = event.type === "run.waiting_input" ? "waiting_input" : "waiting_takeover";
     const runChanged = Boolean(
-      prev.run && prev.run.id === event.runId && prev.run.status !== "waiting_input",
+      prev.run && prev.run.id === event.runId && prev.run.status !== status,
     );
     const activeRunChanged = prev.activeRuns?.some(
-      (candidate) => candidate.id === event.runId && candidate.status !== "waiting_input",
+      (candidate) => candidate.id === event.runId && candidate.status !== status,
     );
-    const members = updateMemberStatus(prev.members, event.botId, "waiting_input");
+    const members = updateMemberStatus(prev.members, event.botId, status);
     if (!runChanged && !activeRunChanged && members === prev.members) return prev;
     return {
       ...prev,
       cursor: event.seq,
       members,
-      run: runChanged && prev.run ? { ...prev.run, status: "waiting_input" } : prev.run,
+      run: runChanged && prev.run ? { ...prev.run, status } : prev.run,
       activeRuns: activeRunChanged
         ? prev.activeRuns?.map((candidate) =>
-            candidate.id === event.runId ? { ...candidate, status: "waiting_input" } : candidate,
+            candidate.id === event.runId ? { ...candidate, status } : candidate,
           )
         : prev.activeRuns,
     };

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -59,6 +59,8 @@ export function mergeThreadSnapshot(
  *
  * A refresh that started earlier can still return running+busyBotName after the client
  * already applied waiting_takeover. Cursor comparisons only apply within the same thread.
+ * Stop clears run/busy optimistically in the shell because it has no terminal event; an
+ * older-cursor refresh must keep that cleared local state (see Shell stopRun).
  */
 export function reconcileRefreshedThread(
   prev: ThreadSnapshot | null,
@@ -69,11 +71,16 @@ export function reconcileRefreshedThread(
   const sameThread = Boolean(prev && prev.threadId === snap.threadId);
 
   if (sameThread && prev && snap.cursor < prev.cursor) {
-    // Progress can advance the thread cursor while the embedded computer status remains
-    // authoritative. Preserve only the event-sourced takeover transition itself.
+    // Progress can advance the thread cursor while embedded computer status from threads.get
+    // is still useful — but only while a live run remains. Preserve event-sourced
+    // waiting_takeover clears and optimistic stop clears.
+    const preserveLocalComputer =
+      prev.run?.status === "waiting_takeover" ||
+      !prev.run ||
+      !isActive(prev.run.status as RunStatus);
     return {
       snapshot: prev,
-      computer: prev.run?.status === "waiting_takeover" ? prevComputer : (snap.computer ?? null),
+      computer: preserveLocalComputer ? prevComputer : (snap.computer ?? null),
     };
   }
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -62,12 +62,10 @@ import {
   X,
 } from "lucide-react";
 import {
-  type Dispatch,
   lazy,
   type MutableRefObject,
   memo,
   type RefObject,
-  type SetStateAction,
   Suspense,
   useCallback,
   useEffect,
@@ -181,7 +179,6 @@ export function ShellPage() {
   const [searchLoading, setSearchLoading] = useState(false);
   const [snapshot, setSnapshot] = useState<ThreadSnapshot | null>(null);
   const snapshotRef = useRef<ThreadSnapshot | null>(null);
-  snapshotRef.current = snapshot;
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [replyTarget, setReplyTarget] = useState<ThreadMessage | null>(null);
   const [sending, setSending] = useState(false);
@@ -196,7 +193,22 @@ export function ShellPage() {
   const [teachBusy, setTeachBusy] = useState(false);
   const [computer, setComputer] = useState<ComputerStatus | null>(null);
   const computerRef = useRef<ComputerStatus | null>(null);
-  computerRef.current = computer;
+  const threadRefreshEpoch = useRef(0);
+  const groupRefreshEpoch = useRef(0);
+
+  function commitSnapshot(next: ThreadSnapshot | null) {
+    snapshotRef.current = next;
+    setSnapshot(next);
+  }
+
+  function commitComputer(next: ComputerStatus | null) {
+    computerRef.current = next;
+    setComputer(next);
+  }
+
+  function updateSnapshot(update: (prev: ThreadSnapshot | null) => ThreadSnapshot | null) {
+    commitSnapshot(update(snapshotRef.current));
+  }
   const [pluginsOpen, setPluginsOpen] = useState(false);
   const [mcpOpen, setMcpOpen] = useState(false);
   const [accountSettingsOpen, setAccountSettingsOpen] = useState(false);
@@ -375,13 +387,14 @@ export function ShellPage() {
       !scrollElement ||
       scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight < 80;
     markOnce("rk:renderer:thread-request-start");
+    const request = ++groupRefreshEpoch.current;
     const snap = await rpc.threads.get({ groupId: id });
     markOnce("rk:renderer:thread-response");
-    if (activeGroupId.current !== id) return snap;
-    setSnapshot((prev) =>
+    if (activeGroupId.current !== id || request !== groupRefreshEpoch.current) return snap;
+    updateSnapshot((prev) =>
       mergeThreadSnapshot(prev, snap, expandedHistoryThread.current === snap.threadId),
     );
-    setComputer(null);
+    commitComputer(null);
     setRoutines([]);
     setRoutinesBotId(null);
     if (stickToEnd) {
@@ -402,6 +415,7 @@ export function ShellPage() {
     const pin = pinnedAroundRef.current;
     const keepPin = pin?.botId === id;
     const epoch = historyEpoch.current;
+    const request = ++threadRefreshEpoch.current;
     const [snap, routines, skills] = await Promise.all([
       rpc.threads.get({ botId: id }),
       rpc.routines.list({ botId: id }),
@@ -411,7 +425,13 @@ export function ShellPage() {
     markOnce("rk:renderer:thread-response");
     // The epoch check drops a response that raced a conversation clear, which would otherwise
     // re-apply the deleted messages and cursor over the emptied snapshot.
-    if (activeBotId.current !== id || epoch !== historyEpoch.current) return snap;
+    if (
+      activeBotId.current !== id ||
+      epoch !== historyEpoch.current ||
+      request !== threadRefreshEpoch.current
+    ) {
+      return snap;
+    }
     // Reconcile against the latest event-sourced state before setState. A refresh started
     // after send (especially with the computer panel open) can return after takeover.requested
     // was applied; overwriting would re-disable Take control with no event left to replay.
@@ -429,10 +449,8 @@ export function ShellPage() {
         olderCursor: pin.olderCursor,
       };
     }
-    snapshotRef.current = merged;
-    computerRef.current = reconciled.computer;
-    setSnapshot(merged);
-    setComputer(reconciled.computer);
+    commitSnapshot(merged);
+    commitComputer(reconciled.computer);
     setRoutines(routines);
     setRoutinesBotId(id);
     setTaughtSkills(skills);
@@ -492,7 +510,7 @@ export function ShellPage() {
       )
         return;
       expandedHistoryThread.current = page.threadId;
-      setSnapshot((prev) => prependThreadMessagePage(prev, page));
+      updateSnapshot((prev) => prependThreadMessagePage(prev, page));
       window.requestAnimationFrame(() => {
         const element = messageScroll.current;
         if (element) element.scrollTop += element.scrollHeight - previousHeight;
@@ -528,8 +546,8 @@ export function ShellPage() {
         setInitialBotsLoaded(true);
         if (!groupId && bootstrap.thread) {
           bootstrappedThread.current = bootstrap.thread;
-          setSnapshot(bootstrap.thread);
-          setComputer(bootstrap.thread.computer ?? null);
+          commitSnapshot(bootstrap.thread);
+          commitComputer(bootstrap.thread.computer ?? null);
           setRoutines(bootstrap.routines);
           setRoutinesBotId(bootstrap.thread.botId ?? null);
           markOnce("rk:renderer:bots-response");
@@ -663,7 +681,7 @@ export function ShellPage() {
             if (abort.signal.aborted) break;
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
-            applyThreadEvent(event, setSnapshot, setComputer, snapshotRef, computerRef);
+            applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
             if (event.type === "thread.cleared") {
               expandedHistoryThread.current = null;
               pinnedAroundRef.current = null;
@@ -750,7 +768,7 @@ export function ShellPage() {
             if (abort.signal.aborted) break;
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
-            applyThreadEvent(event, setSnapshot, setComputer, snapshotRef, computerRef);
+            applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
             if (event.type === "thread.message.created" && event.payload.role === "bot") {
               readVisibleGroups.current.delete(groupId);
               markVisibleGroupRead();
@@ -842,12 +860,12 @@ export function ShellPage() {
       messages: page.messages,
       olderCursor: page.olderCursor,
     };
-    setSnapshot({
+    commitSnapshot({
       ...snap,
       messages: page.messages,
       olderCursor: page.olderCursor,
     });
-    setComputer(snap.computer ?? null);
+    commitComputer(snap.computer ?? null);
     setRoutines(await rpc.routines.list({ botId }));
     setRoutinesBotId(botId);
     window.requestAnimationFrame(() => {
@@ -2254,7 +2272,7 @@ export function ShellPage() {
                 expandedHistoryThread.current = null;
                 pinnedAroundRef.current = null;
                 historyEpoch.current += 1;
-                setSnapshot((current) =>
+                updateSnapshot((current) =>
                   current ? { ...current, messages: [], olderCursor: null, run: null } : current,
                 );
               }
@@ -2848,28 +2866,18 @@ function firstThreadRoute(
 
 function applyThreadEvent(
   event: ProductEvent,
-  setSnapshot: Dispatch<SetStateAction<ThreadSnapshot | null>>,
-  setComputer: Dispatch<SetStateAction<ComputerStatus | null>>,
-  snapshotRef?: MutableRefObject<ThreadSnapshot | null>,
-  computerRef?: MutableRefObject<ComputerStatus | null>,
+  commitSnapshot: (next: ThreadSnapshot | null) => void,
+  commitComputer: (next: ComputerStatus | null) => void,
+  snapshotRef: MutableRefObject<ThreadSnapshot | null>,
+  computerRef: MutableRefObject<ComputerStatus | null>,
 ) {
   if (isThreadSnapshotEvent(event)) {
-    if (snapshotRef) {
-      const next = reduceThreadSnapshot(snapshotRef.current, event);
-      snapshotRef.current = next;
-      setSnapshot(next);
-    } else {
-      setSnapshot((prev) => reduceThreadSnapshot(prev, event));
-    }
+    const next = reduceThreadSnapshot(snapshotRef.current, event);
+    commitSnapshot(next);
   }
   if (isComputerStatusEvent(event)) {
-    if (computerRef) {
-      const next = reduceComputerStatus(computerRef.current, event);
-      computerRef.current = next;
-      setComputer(next);
-    } else {
-      setComputer((prev) => reduceComputerStatus(prev, event));
-    }
+    const next = reduceComputerStatus(computerRef.current, event);
+    commitComputer(next);
   }
 }
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -98,6 +98,7 @@ import { markAfterPaint, markOnce } from "../lib/performance";
 import { rpc } from "../lib/rpc";
 import {
   activeThreadRuns,
+  clearActiveThreadRuns,
   computerPanelAutoBoot,
   computerTakeoverBlocked,
   isComputerStatusEvent,
@@ -1110,7 +1111,7 @@ export function ShellPage() {
       // Stop has no terminal event; clear run UI before refresh races with in-flight gets.
       if (activeGroupId.current === groupTarget) {
         updateSnapshot((prev) =>
-          prev && prev.groupId === groupTarget ? { ...prev, run: null, activeRuns: [] } : prev,
+          prev && prev.groupId === groupTarget ? clearActiveThreadRuns(prev) : prev,
         );
       }
       await refreshGroupThreadRef.current(groupTarget).catch(() => undefined);
@@ -1132,10 +1133,7 @@ export function ShellPage() {
     if (activeBotId.current === botTarget) {
       updateSnapshot((prev) => {
         if (!prev || (prev.botId !== botTarget && prev.botId)) return prev;
-        const computer = prev.computer?.busyBotName
-          ? { ...prev.computer, busyBotName: null }
-          : prev.computer;
-        return { ...prev, run: null, activeRuns: [], computer };
+        return clearActiveThreadRuns(prev);
       });
       const currentComputer = computerRef.current;
       if (currentComputer?.busyBotName) {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1107,6 +1107,12 @@ export function ShellPage() {
         }
         return;
       }
+      // Stop has no terminal event; clear run UI before refresh races with in-flight gets.
+      if (activeGroupId.current === groupTarget) {
+        updateSnapshot((prev) =>
+          prev && prev.groupId === groupTarget ? { ...prev, run: null, activeRuns: [] } : prev,
+        );
+      }
       await refreshGroupThreadRef.current(groupTarget).catch(() => undefined);
       return;
     }
@@ -1119,6 +1125,22 @@ export function ShellPage() {
         setSendError(error instanceof Error ? error.message : "Failed to stop");
       }
       return;
+    }
+    // Stop does not emit a terminal thread event. Clear local run/busy immediately so a
+    // superseded in-flight refresh (older cursor) cannot leave Stop enabled / Take control
+    // blocked while the API is already idle.
+    if (activeBotId.current === botTarget) {
+      updateSnapshot((prev) => {
+        if (!prev || (prev.botId !== botTarget && prev.botId)) return prev;
+        const computer = prev.computer?.busyBotName
+          ? { ...prev.computer, busyBotName: null }
+          : prev.computer;
+        return { ...prev, run: null, activeRuns: [], computer };
+      });
+      const currentComputer = computerRef.current;
+      if (currentComputer?.busyBotName) {
+        commitComputer({ ...currentComputer, busyBotName: null });
+      }
     }
     await refreshThreadRef.current(botTarget).catch(() => undefined);
   }, []);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -65,6 +65,7 @@ import {
   type Dispatch,
   lazy,
   memo,
+  type MutableRefObject,
   type RefObject,
   type SetStateAction,
   Suspense,
@@ -105,6 +106,7 @@ import {
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
   prependThreadMessagePage,
+  reconcileRefreshedThread,
   reduceComputerStatus,
   reduceThreadSnapshot,
   userHoldsComputerControl,
@@ -178,6 +180,8 @@ export function ShellPage() {
   const [searchHits, setSearchHits] = useState<SearchHit[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [snapshot, setSnapshot] = useState<ThreadSnapshot | null>(null);
+  const snapshotRef = useRef<ThreadSnapshot | null>(null);
+  snapshotRef.current = snapshot;
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [replyTarget, setReplyTarget] = useState<ThreadMessage | null>(null);
   const [sending, setSending] = useState(false);
@@ -191,6 +195,8 @@ export function ShellPage() {
   const [taughtSkillsBotId, setTaughtSkillsBotId] = useState<string | null>(null);
   const [teachBusy, setTeachBusy] = useState(false);
   const [computer, setComputer] = useState<ComputerStatus | null>(null);
+  const computerRef = useRef<ComputerStatus | null>(null);
+  computerRef.current = computer;
   const [pluginsOpen, setPluginsOpen] = useState(false);
   const [mcpOpen, setMcpOpen] = useState(false);
   const [accountSettingsOpen, setAccountSettingsOpen] = useState(false);
@@ -406,18 +412,27 @@ export function ShellPage() {
     // The epoch check drops a response that raced a conversation clear, which would otherwise
     // re-apply the deleted messages and cursor over the emptied snapshot.
     if (activeBotId.current !== id || epoch !== historyEpoch.current) return snap;
-    setSnapshot((prev) => {
-      let merged = mergeThreadSnapshot(prev, snap, expandedHistoryThread.current === snap.threadId);
-      if (keepPin && merged) {
-        merged = {
-          ...merged,
-          messages: pin.messages,
-          olderCursor: pin.olderCursor,
-        };
-      }
-      return merged;
-    });
-    setComputer(snap.computer ?? null);
+    // Reconcile against the latest event-sourced state before setState. A refresh started
+    // after send (especially with the computer panel open) can return after takeover.requested
+    // was applied; overwriting would re-disable Take control with no event left to replay.
+    const reconciled = reconcileRefreshedThread(
+      snapshotRef.current,
+      snap,
+      computerRef.current,
+      expandedHistoryThread.current === snap.threadId,
+    );
+    let merged = reconciled.snapshot;
+    if (keepPin && merged) {
+      merged = {
+        ...merged,
+        messages: pin.messages,
+        olderCursor: pin.olderCursor,
+      };
+    }
+    snapshotRef.current = merged;
+    computerRef.current = reconciled.computer;
+    setSnapshot(merged);
+    setComputer(reconciled.computer);
     setRoutines(routines);
     setRoutinesBotId(id);
     setTaughtSkills(skills);
@@ -648,7 +663,7 @@ export function ShellPage() {
             if (abort.signal.aborted) break;
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
-            applyThreadEvent(event, setSnapshot, setComputer);
+            applyThreadEvent(event, setSnapshot, setComputer, snapshotRef, computerRef);
             if (event.type === "thread.cleared") {
               expandedHistoryThread.current = null;
               pinnedAroundRef.current = null;
@@ -735,7 +750,7 @@ export function ShellPage() {
             if (abort.signal.aborted) break;
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
-            applyThreadEvent(event, setSnapshot, setComputer);
+            applyThreadEvent(event, setSnapshot, setComputer, snapshotRef, computerRef);
             if (event.type === "thread.message.created" && event.payload.role === "bot") {
               readVisibleGroups.current.delete(groupId);
               markVisibleGroupRead();
@@ -2835,12 +2850,26 @@ function applyThreadEvent(
   event: ProductEvent,
   setSnapshot: Dispatch<SetStateAction<ThreadSnapshot | null>>,
   setComputer: Dispatch<SetStateAction<ComputerStatus | null>>,
+  snapshotRef?: MutableRefObject<ThreadSnapshot | null>,
+  computerRef?: MutableRefObject<ComputerStatus | null>,
 ) {
   if (isThreadSnapshotEvent(event)) {
-    setSnapshot((prev) => reduceThreadSnapshot(prev, event));
+    if (snapshotRef) {
+      const next = reduceThreadSnapshot(snapshotRef.current, event);
+      snapshotRef.current = next;
+      setSnapshot(next);
+    } else {
+      setSnapshot((prev) => reduceThreadSnapshot(prev, event));
+    }
   }
   if (isComputerStatusEvent(event)) {
-    setComputer((prev) => reduceComputerStatus(prev, event));
+    if (computerRef) {
+      const next = reduceComputerStatus(computerRef.current, event);
+      computerRef.current = next;
+      setComputer(next);
+    } else {
+      setComputer((prev) => reduceComputerStatus(prev, event));
+    }
   }
 }
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -673,9 +673,6 @@ export function ShellPage() {
             }
             if (isRunTerminalEvent(event) || event.type === "skill.teaching.stopped") {
               void refreshThread(active.id).catch(() => undefined);
-            } else if (event.type === "computer.takeover.requested") {
-              // Clears busyBotName so Take control stays enabled for waiting_takeover.
-              void refreshThread(active.id).catch(() => undefined);
             } else if (isComputerStatusEvent(event)) {
               void refreshComputerScreen(active.id).catch(() => undefined);
             }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -416,15 +416,10 @@ export function ShellPage() {
     const keepPin = pin?.botId === id;
     const epoch = historyEpoch.current;
     const request = ++threadRefreshEpoch.current;
-    const [snap, routines, skills] = await Promise.all([
-      rpc.threads.get({ botId: id }),
-      rpc.routines.list({ botId: id }),
-      rpc.skills.list({ botId: id }),
-      refreshComputerScreen(id),
-    ]);
+    // Apply threads.get as soon as it returns so stop/takeover status is not held behind
+    // routines/skills/screen fetches (progress can advance the cursor meanwhile).
+    const snap = await rpc.threads.get({ botId: id });
     markOnce("rk:renderer:thread-response");
-    // The epoch check drops a response that raced a conversation clear, which would otherwise
-    // re-apply the deleted messages and cursor over the emptied snapshot.
     if (
       activeBotId.current !== id ||
       epoch !== historyEpoch.current ||
@@ -432,9 +427,6 @@ export function ShellPage() {
     ) {
       return snap;
     }
-    // Reconcile against the latest event-sourced state before setState. A refresh started
-    // after send (especially with the computer panel open) can return after takeover.requested
-    // was applied; overwriting would re-disable Take control with no event left to replay.
     const reconciled = reconcileRefreshedThread(
       snapshotRef.current,
       snap,
@@ -451,16 +443,28 @@ export function ShellPage() {
     }
     commitSnapshot(merged);
     commitComputer(reconciled.computer);
-    setRoutines(routines);
-    setRoutinesBotId(id);
-    setTaughtSkills(skills);
-    setTaughtSkillsBotId(id);
     if (!keepPin && stickToEnd) {
       window.requestAnimationFrame(() => {
         const element = messageScroll.current;
         if (element) element.scrollTop = element.scrollHeight;
       });
     }
+    const [routines, skills] = await Promise.all([
+      rpc.routines.list({ botId: id }),
+      rpc.skills.list({ botId: id }),
+      refreshComputerScreen(id),
+    ]);
+    if (
+      activeBotId.current !== id ||
+      epoch !== historyEpoch.current ||
+      request !== threadRefreshEpoch.current
+    ) {
+      return snap;
+    }
+    setRoutines(routines);
+    setRoutinesBotId(id);
+    setTaughtSkills(skills);
+    setTaughtSkillsBotId(id);
     return snap;
   }
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -64,8 +64,8 @@ import {
 import {
   type Dispatch,
   lazy,
-  memo,
   type MutableRefObject,
+  memo,
   type RefObject,
   type SetStateAction,
   Suspense,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1680,14 +1680,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
               await publishMessage(deps, run, "bot", [
                 { kind: "computer", state: "Ready", text: safeReason },
               ]);
-              await deps.events.append({
-                workspaceId: run.workspaceId,
-                threadId: thread.id,
-                botId: bot.id,
-                type: "computer.takeover.requested",
-                runId,
-                payload: { reason: safeReason },
-              });
               await deps.prisma.computer.updateMany({
                 where: { id: storedComputer.id },
                 data: {
@@ -1703,22 +1695,18 @@ export function createRunExecutor(deps: ExecutorDeps) {
               if (!(await holdComputerExecutionLeaseForTakeover(deps.prisma, computerLease))) {
                 throw new Error("Computer lease expired before takeover");
               }
-              const paused = await deps.prisma.run.updateMany({
-                where: { id: runId, status: "running", leaseOwner: workerId, leaseFence: fence },
-                data: {
-                  status: "waiting_takeover",
-                  leaseOwner: null,
-                  leaseExpiresAt: null,
-                  checkpoint: null,
-                },
+              const paused = await deps.events.pauseRunForTakeover({
+                workspaceId: run.workspaceId,
+                threadId: run.threadId,
+                botId: run.botId,
+                runId,
+                attemptId: attempt.id,
+                leaseOwner: workerId,
+                leaseFence: fence,
+                reason: safeReason,
               });
-              if (paused.count !== 1) return;
+              if (!paused) return;
               retainComputerLease = true;
-              await deps.prisma.attempt.update({
-                where: { id: attempt.id },
-                data: { status: "waiting_takeover", finishedAt: new Date() },
-              });
-              await clearRunProgress(deps, runId);
               await notifyRun(deps, run, {
                 kind: "takeover",
                 title: `${bot.name} needs you on the screen`,
@@ -2095,10 +2083,6 @@ async function requeueComputerRun(
     ...runContinueJob(runId),
     availableAt: new Date(Date.now() + computerRetryDelay(fence)),
   });
-}
-
-async function clearRunProgress(deps: ExecutorDeps, runId: string): Promise<void> {
-  await deps.prisma.event.deleteMany({ where: { runId, type: "thread.progress" } });
 }
 
 function redactBlocks(blocks: MessageBlock[], secrets: string[]): MessageBlock[] {

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -8,6 +8,7 @@ import {
   finalizeComputerControlRelease,
   followThreadEvents,
   pauseRunForInput,
+  pauseRunForTakeover,
   sendUserMessage,
 } from "./events.js";
 import { RunHistoryWriteError } from "./messages.js";
@@ -264,6 +265,73 @@ describe("pauseRunForInput", () => {
       "run.waiting_input",
     ]);
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 8 }));
+  });
+});
+
+describe("pauseRunForTakeover", () => {
+  it("stores the paused run, attempt, and takeover event in one transaction", async () => {
+    const fanout = new TestFanout();
+    const publish = vi.spyOn(fanout, "publish");
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      run: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUnique: vi.fn().mockResolvedValue({ status: "waiting_takeover" }),
+      },
+      attempt: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      thread: { update: vi.fn().mockResolvedValue({ nextEventSeq: 8 }) },
+      event: {
+        create: vi.fn(async ({ data }: { data: { seq: number; type: string } }) => ({
+          ...event(data.seq),
+          type: data.type,
+        })),
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      pauseRunForTakeover(
+        prisma,
+        {
+          workspaceId: "workspace-1",
+          threadId: "thread-1",
+          botId: "bot-1",
+          runId: "run-1",
+          attemptId: "attempt-1",
+          leaseOwner: "worker-1",
+          leaseFence: 3,
+          reason: "Sign in",
+        },
+        fanout,
+      ),
+    ).resolves.toBe(true);
+
+    expect(tx.run.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "running", leaseFence: 3 }),
+        data: {
+          status: "waiting_takeover",
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          checkpoint: null,
+        },
+      }),
+    );
+    expect(tx.attempt.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: "waiting_takeover" }) }),
+    );
+    expect(tx.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "computer.takeover.requested",
+          payload: { reason: "Sign in" },
+        }),
+      }),
+    );
+    expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 7 }));
   });
 });
 

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -35,6 +35,7 @@ export interface ThreadEvents {
   finalizeRun(input: FinalizeRunInput): Promise<boolean>;
   notify(threadId: string, seq: number): Promise<void>;
   pauseRunForInput(input: PauseRunForInput): Promise<boolean>;
+  pauseRunForTakeover(input: PauseRunForTakeover): Promise<boolean>;
   sendUserMessage(input: SendUserMessageInput): Promise<SendUserMessageResult>;
   follow(threadId: string, cursor: number, signal?: AbortSignal): AsyncGenerator<ProductEvent>;
 }
@@ -90,6 +91,17 @@ export interface PauseRunForInput {
   blocks: MessageBlock[];
 }
 
+export interface PauseRunForTakeover {
+  workspaceId: string;
+  threadId: string;
+  botId: string;
+  runId: string;
+  attemptId: string;
+  leaseOwner: string;
+  leaseFence: number;
+  reason: string;
+}
+
 export interface AnswerRunInput {
   workspaceId: string;
   threadId: string;
@@ -134,6 +146,7 @@ export function createThreadEvents(
     finalizeRun: (input) => finalizeRun(prisma, input, realtime),
     notify: (threadId, seq) => notifyRealtime(realtime, threadId, seq),
     pauseRunForInput: (input) => pauseRunForInput(prisma, input, realtime),
+    pauseRunForTakeover: (input) => pauseRunForTakeover(prisma, input, realtime),
     sendUserMessage: (input) => sendUserMessage(prisma, input, realtime),
     follow: (threadId, cursor, signal) =>
       followThreadEvents(prisma, threadId, cursor, realtime, signal, options.catchUpMs),
@@ -523,6 +536,60 @@ export async function pauseRunForInput(
       type: "run.waiting_input",
       runId: input.runId,
       payload: {},
+    });
+    await tx.event.deleteMany({ where: { runId: input.runId, type: "thread.progress" } });
+    return { threadId: waitingEvent.threadId, seq: waitingEvent.seq };
+  });
+
+  if (!committed) return false;
+  await notifyRealtime(realtime, committed.threadId, committed.seq);
+  return true;
+}
+
+export async function pauseRunForTakeover(
+  prisma: PrismaClient,
+  input: PauseRunForTakeover,
+  realtime?: RealtimeFanout,
+): Promise<boolean> {
+  const committed = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.$queryRaw`SELECT id FROM threads WHERE id = ${input.threadId} FOR UPDATE`;
+    const paused = await tx.run.updateMany({
+      where: {
+        id: input.runId,
+        workspaceId: input.workspaceId,
+        threadId: input.threadId,
+        botId: input.botId,
+        status: "running",
+        leaseOwner: input.leaseOwner,
+        leaseFence: input.leaseFence,
+      },
+      data: {
+        status: "waiting_takeover",
+        leaseOwner: null,
+        leaseExpiresAt: null,
+        checkpoint: null,
+      },
+    });
+    if (paused.count !== 1) return null;
+
+    const attempt = await tx.attempt.updateMany({
+      where: {
+        id: input.attemptId,
+        runId: input.runId,
+        fence: input.leaseFence,
+        status: "running",
+      },
+      data: { status: "waiting_takeover", finishedAt: new Date() },
+    });
+    if (attempt.count !== 1) throw new Error("Active run attempt was not available to pause");
+
+    const waitingEvent = await appendEventInTransaction(tx, {
+      workspaceId: input.workspaceId,
+      threadId: input.threadId,
+      botId: input.botId,
+      type: "computer.takeover.requested",
+      runId: input.runId,
+      payload: { reason: input.reason },
     });
     await tx.event.deleteMany({ where: { runId: input.runId, type: "thread.progress" } });
     return { threadId: waitingEvent.threadId, seq: waitingEvent.seq };


### PR DESCRIPTION
Treats `computer.takeover.requested` as an authoritative transition to `waiting_takeover`, reconciles stale thread refreshes, and keeps the client snapshot/computer refs synchronized. Publishes the run, attempt, and takeover event atomically so subscribers cannot observe an event with old run state. Adds reducer and transaction regression coverage. Verified with affected unit/typecheck/Biome checks and the previously failing golden Playwright scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved computer takeover handling with clearer run status updates and realtime notifications.
  * Preserved takeover state during thread refreshes and restored active run progress when available.
  * Added safeguards to ignore outdated refresh results when loading threads or bot data.

* **Bug Fixes**
  * Prevented takeover requests from incorrectly appearing as active runs.
  * Cleared busy indicators and temporary progress immediately when stopping a run.
  * Ensured switching threads displays the correct thread snapshot and computer state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->