### PR TITLE
fix(desktop): capture loopback OAuth codes from the sign-in popup

### DIFF
--- a/apps/desktop/e2e/smoke.spec.ts
+++ b/apps/desktop/e2e/smoke.spec.ts
@@ -41,7 +41,7 @@ test("launches with a narrow preload bridge and an isolated renderer", async () 
       };
     });
 
-    expect(renderer.bridgeKeys).toEqual(["platform", "update", "window"]);
+    expect(renderer.bridgeKeys).toEqual(["oauth", "platform", "update", "window"]);
     expect(renderer.windowKeys).toEqual(["close", "minimize", "state", "toggleMaximize"]);
     expect(renderer.updateKeys).toEqual(["check", "download", "install", "state"]);
     expect(renderer.platform).toBe(process.platform);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -8,6 +8,7 @@ import {
   type ElectronAutoUpdater,
   LAUNCH_CHECK_DELAY_MS,
 } from "./auto-update.js";
+import { oauthCallbackFrom } from "./oauth-callback.js";
 import {
   bundledRendererCandidates,
   contentType,
@@ -223,6 +224,20 @@ function createWindow(url: string, partition: string | null) {
   win.webContents.on("will-navigate", (event, navigationUrl) => {
     if (targetOrigin !== null && safeOrigin(navigationUrl) === targetOrigin) return;
     event.preventDefault();
+  });
+  // The popup has no address bar, so a loopback redirect would otherwise strand
+  // the user on a blank window holding the authorization code in a URL they
+  // cannot read. Capture it here and hand it to the app instead.
+  win.webContents.on("did-create-window", (popup) => {
+    const capture = (details: Electron.Event, url: string) => {
+      const callback = oauthCallbackFrom(url);
+      if (!callback) return;
+      details.preventDefault();
+      if (!win.isDestroyed()) win.webContents.send("desktop.oauth.callback", callback);
+      if (!popup.isDestroyed()) popup.close();
+    };
+    popup.webContents.on("will-redirect", (details) => capture(details, details.url));
+    popup.webContents.on("will-navigate", (details) => capture(details, details.url));
   });
   win.on("close", (event) => {
     if (

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -198,6 +198,8 @@ function createWindow(url: string, partition: string | null) {
   // OAuth flows open the provider's authorize page via window.open; give that
   // popup a normal framed window. Non-http(s) targets stay closed; other http(s)
   // origins open in the system browser so a connected server cannot navigate us away.
+  // Hoisted for loopback OAuth capture so MCP/in-app localhost callbacks are skipped.
+  const appOrigin = targetOrigin ?? safeOrigin(url);
   win.webContents.setWindowOpenHandler(({ url: childUrl }) => {
     let target: URL;
     try {
@@ -205,7 +207,6 @@ function createWindow(url: string, partition: string | null) {
     } catch {
       return { action: "deny" };
     }
-    const appOrigin = targetOrigin ?? safeOrigin(url);
     const sameOrigin = appOrigin !== null && target.origin === appOrigin;
     // Same-origin http(s) and third-party https (OAuth) get a framed popup.
     if (
@@ -229,15 +230,23 @@ function createWindow(url: string, partition: string | null) {
   // the user on a blank window holding the authorization code in a URL they
   // cannot read. Capture it here and hand it to the app instead.
   win.webContents.on("did-create-window", (popup) => {
-    const capture = (details: Electron.Event, url: string) => {
-      const callback = oauthCallbackFrom(url);
+    const capture = (details: {
+      preventDefault: () => void;
+      url: string;
+      isMainFrame?: boolean;
+    }) => {
+      // will-redirect can fire for iframes; only the top-level callback counts.
+      if (details.isMainFrame === false) return;
+      const callback = oauthCallbackFrom(details.url, {
+        excludeOrigins: appOrigin !== null ? [appOrigin] : [],
+      });
       if (!callback) return;
       details.preventDefault();
       if (!win.isDestroyed()) win.webContents.send("desktop.oauth.callback", callback);
       if (!popup.isDestroyed()) popup.close();
     };
-    popup.webContents.on("will-redirect", (details) => capture(details, details.url));
-    popup.webContents.on("will-navigate", (details) => capture(details, details.url));
+    popup.webContents.on("will-redirect", (details) => capture(details));
+    popup.webContents.on("will-navigate", (details) => capture(details));
   });
   win.on("close", (event) => {
     if (

--- a/apps/desktop/src/oauth-callback.test.ts
+++ b/apps/desktop/src/oauth-callback.test.ts
@@ -39,4 +39,21 @@ describe("loopback OAuth callbacks", () => {
     expect(oauthCallbackFrom("rakazo://localhost/callback?code=ac_123")).toBeUndefined();
     expect(oauthCallbackFrom("not a url")).toBeUndefined();
   });
+
+  it("ignores whitespace-only codes", () => {
+    expect(oauthCallbackFrom("http://localhost:53692/callback?code=%20%20")).toBeUndefined();
+  });
+
+  it("does not capture the app renderer origin used by MCP and other in-app callbacks", () => {
+    expect(
+      oauthCallbackFrom("http://127.0.0.1:5173/mcp/oauth/callback?code=mcp_123&state=s", {
+        excludeOrigins: ["http://127.0.0.1:5173"],
+      }),
+    ).toBeUndefined();
+    expect(
+      oauthCallbackFrom("http://localhost:53692/callback?code=ac_123", {
+        excludeOrigins: ["http://127.0.0.1:5173"],
+      }),
+    ).toEqual({ code: "ac_123" });
+  });
 });

--- a/apps/desktop/src/oauth-callback.test.ts
+++ b/apps/desktop/src/oauth-callback.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { oauthCallbackFrom } from "./oauth-callback.js";
+
+describe("loopback OAuth callbacks", () => {
+  it("reads the code and state Anthropic redirects with", () => {
+    expect(
+      oauthCallbackFrom("http://localhost:53692/callback?code=ac_123&state=verifier_456"),
+    ).toEqual({ code: "ac_123", state: "verifier_456" });
+  });
+
+  it("accepts the loopback addresses a provider may redirect to", () => {
+    expect(oauthCallbackFrom("http://127.0.0.1:53692/callback?code=ac_123")).toEqual({
+      code: "ac_123",
+    });
+    expect(oauthCallbackFrom("http://[::1]:53692/callback?code=ac_123")).toEqual({
+      code: "ac_123",
+    });
+  });
+
+  it("omits state when the provider redirects without one", () => {
+    expect(oauthCallbackFrom("http://localhost:53692/callback?code=ac_123")).toEqual({
+      code: "ac_123",
+    });
+  });
+
+  it("ignores the authorize page and other steps of the flow", () => {
+    expect(oauthCallbackFrom("https://claude.ai/oauth/authorize?code=true")).toBeUndefined();
+    expect(oauthCallbackFrom("http://localhost:53692/callback")).toBeUndefined();
+    expect(oauthCallbackFrom("http://localhost:5173/")).toBeUndefined();
+  });
+
+  it("does not treat a remote host as a loopback callback", () => {
+    expect(oauthCallbackFrom("https://example.com/callback?code=ac_123")).toBeUndefined();
+    expect(oauthCallbackFrom("https://localhost.example.com/callback?code=ac_123")).toBeUndefined();
+  });
+
+  it("ignores non-http schemes and unparseable targets", () => {
+    expect(oauthCallbackFrom("file:///callback?code=ac_123")).toBeUndefined();
+    expect(oauthCallbackFrom("rakazo://localhost/callback?code=ac_123")).toBeUndefined();
+    expect(oauthCallbackFrom("not a url")).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/oauth-callback.ts
+++ b/apps/desktop/src/oauth-callback.ts
@@ -1,0 +1,26 @@
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+export type OAuthCallback = { code: string; state?: string };
+
+/**
+ * Providers that sign in through a loopback redirect — Anthropic sends the
+ * browser to `http://localhost:53692/callback` — return the authorization code
+ * in the redirect URL. Rakazo runs no listener on that port and asks for the
+ * code to be pasted instead, which the sign-in popup cannot show because an
+ * Electron window has no address bar. The main process still sees the
+ * navigation, so it reads the code from there.
+ */
+export function oauthCallbackFrom(url: string): OAuthCallback | undefined {
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return undefined;
+  }
+  if (target.protocol !== "http:" && target.protocol !== "https:") return undefined;
+  if (!LOOPBACK_HOSTS.has(target.hostname)) return undefined;
+  const code = target.searchParams.get("code");
+  if (!code) return undefined;
+  const state = target.searchParams.get("state");
+  return state === null ? { code } : { code, state };
+}

--- a/apps/desktop/src/oauth-callback.ts
+++ b/apps/desktop/src/oauth-callback.ts
@@ -2,6 +2,11 @@ const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 export type OAuthCallback = { code: string; state?: string };
 
+export type OAuthCallbackFromOptions = {
+  /** App renderer origins — their `/callback` routes must not be treated as paste-flow codes. */
+  excludeOrigins?: readonly string[];
+};
+
 /**
  * Providers that sign in through a loopback redirect — Anthropic sends the
  * browser to `http://localhost:53692/callback` — return the authorization code
@@ -10,7 +15,10 @@ export type OAuthCallback = { code: string; state?: string };
  * Electron window has no address bar. The main process still sees the
  * navigation, so it reads the code from there.
  */
-export function oauthCallbackFrom(url: string): OAuthCallback | undefined {
+export function oauthCallbackFrom(
+  url: string,
+  options: OAuthCallbackFromOptions = {},
+): OAuthCallback | undefined {
   let target: URL;
   try {
     target = new URL(url);
@@ -19,8 +27,9 @@ export function oauthCallbackFrom(url: string): OAuthCallback | undefined {
   }
   if (target.protocol !== "http:" && target.protocol !== "https:") return undefined;
   if (!LOOPBACK_HOSTS.has(target.hostname)) return undefined;
-  const code = target.searchParams.get("code");
+  if (options.excludeOrigins?.includes(target.origin)) return undefined;
+  const code = target.searchParams.get("code")?.trim();
   if (!code) return undefined;
-  const state = target.searchParams.get("state");
-  return state === null ? { code } : { code, state };
+  const state = target.searchParams.get("state")?.trim();
+  return state ? { code, state } : { code };
 }

--- a/apps/desktop/src/oauth-callback.ts
+++ b/apps/desktop/src/oauth-callback.ts
@@ -1,11 +1,11 @@
-const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
-
-export type OAuthCallback = { code: string; state?: string };
+import type { RakazoDesktopOAuthCallback } from "@rakazo/contracts";
 
 export type OAuthCallbackFromOptions = {
   /** App renderer origins — their `/callback` routes must not be treated as paste-flow codes. */
   excludeOrigins?: readonly string[];
 };
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
 /**
  * Providers that sign in through a loopback redirect — Anthropic sends the
@@ -18,7 +18,7 @@ export type OAuthCallbackFromOptions = {
 export function oauthCallbackFrom(
   url: string,
   options: OAuthCallbackFromOptions = {},
-): OAuthCallback | undefined {
+): RakazoDesktopOAuthCallback | undefined {
   let target: URL;
   try {
     target = new URL(url);

--- a/apps/desktop/src/preload.cjs
+++ b/apps/desktop/src/preload.cjs
@@ -14,4 +14,12 @@ contextBridge.exposeInMainWorld("rakazoDesktop", {
     download: () => ipcRenderer.invoke("desktop.update.download"),
     install: () => ipcRenderer.invoke("desktop.update.install"),
   },
+  oauth: {
+    onCallback: (listener) => {
+      // The IpcRendererEvent stays in the preload: the renderer only sees the code.
+      const handler = (_event, callback) => listener(callback);
+      ipcRenderer.on("desktop.oauth.callback", handler);
+      return () => ipcRenderer.off("desktop.oauth.callback", handler);
+    },
+  },
 });

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -4,11 +4,9 @@ import vm from "node:vm";
 import type { RakazoDesktop, RakazoSetup } from "@rakazo/contracts";
 import { describe, expect, it, vi } from "vitest";
 
-function runPreload(
-  file: string,
-  ipc: { invoke?: unknown; on?: unknown; off?: unknown } = {},
-) {
-  const invoke = (ipc.invoke as ReturnType<typeof vi.fn>) ?? vi.fn(async (channel: string) => ({ channel }));
+function runPreload(file: string, ipc: { invoke?: unknown; on?: unknown; off?: unknown } = {}) {
+  const invoke =
+    (ipc.invoke as ReturnType<typeof vi.fn>) ?? vi.fn(async (channel: string) => ({ channel }));
   const on = (ipc.on as ReturnType<typeof vi.fn>) ?? vi.fn();
   const off = (ipc.off as ReturnType<typeof vi.fn>) ?? vi.fn();
   const exposeInMainWorld = vi.fn();

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -4,8 +4,13 @@ import vm from "node:vm";
 import type { RakazoDesktop, RakazoSetup } from "@rakazo/contracts";
 import { describe, expect, it, vi } from "vitest";
 
-function runPreload(file: string) {
-  const invoke = vi.fn(async (channel: string) => ({ channel }));
+function runPreload(
+  file: string,
+  ipc: { invoke?: unknown; on?: unknown; off?: unknown } = {},
+) {
+  const invoke = (ipc.invoke as ReturnType<typeof vi.fn>) ?? vi.fn(async (channel: string) => ({ channel }));
+  const on = (ipc.on as ReturnType<typeof vi.fn>) ?? vi.fn();
+  const off = (ipc.off as ReturnType<typeof vi.fn>) ?? vi.fn();
   const exposeInMainWorld = vi.fn();
   const source = readFileSync(path.join(import.meta.dirname, file), "utf8");
 
@@ -13,21 +18,22 @@ function runPreload(file: string) {
     process: { platform: "linux" },
     require(moduleName: string) {
       if (moduleName !== "electron") throw new Error(`Unexpected preload import: ${moduleName}`);
-      return { contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke } };
+      return { contextBridge: { exposeInMainWorld }, ipcRenderer: { invoke, on, off } };
     },
   });
 
-  return { invoke, exposeInMainWorld };
+  return { invoke, on, off, exposeInMainWorld };
 }
 
 describe("desktop preload bridge", () => {
-  it("exposes only the platform, the four window operations, and the updater", async () => {
+  it("exposes only the platform, the four window operations, the updater, and the OAuth bridge", async () => {
     const { invoke, exposeInMainWorld } = runPreload("preload.cjs");
 
     expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
     const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoDesktop];
     expect(globalName).toBe("rakazoDesktop");
     expect(bridge.platform).toBe("linux");
+    expect(Object.keys(bridge).sort()).toEqual(["oauth", "platform", "update", "window"]);
     expect(Object.keys(bridge.window).sort()).toEqual([
       "close",
       "minimize",
@@ -59,7 +65,27 @@ describe("desktop preload bridge", () => {
   it("keeps setup off the app bridge so a connected server cannot re-point the app", () => {
     const { exposeInMainWorld } = runPreload("preload.cjs");
     const [, bridge] = exposeInMainWorld.mock.calls[0] as [string, Record<string, unknown>];
-    expect(Object.keys(bridge).sort()).toEqual(["platform", "update", "window"]);
+    expect(Object.keys(bridge).sort()).toEqual(["oauth", "platform", "update", "window"]);
+  });
+
+  it("forwards captured codes without leaking the IPC event to the renderer", () => {
+    const listeners: Array<(event: unknown, callback: unknown) => void> = [];
+    const on = vi.fn((_channel: string, handler: (event: unknown, callback: unknown) => void) => {
+      listeners.push(handler);
+    });
+    const off = vi.fn();
+    const { exposeInMainWorld } = runPreload("preload.cjs", { on, off });
+
+    const [, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoDesktop];
+    const received: unknown[] = [];
+    const unsubscribe = bridge.oauth.onCallback((callback) => received.push(callback));
+
+    expect(on).toHaveBeenCalledWith("desktop.oauth.callback", expect.any(Function));
+    listeners[0]?.({ sender: "ipc-event" }, { code: "ac_123", state: "verifier_456" });
+    expect(received).toEqual([{ code: "ac_123", state: "verifier_456" }]);
+
+    unsubscribe();
+    expect(off).toHaveBeenCalledWith("desktop.oauth.callback", expect.any(Function));
   });
 });
 

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -1,8 +1,15 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
-import { desktopOAuthCode, type RakazoDesktop, windowChromeKind } from "./desktop.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  desktopOAuthCode,
+  oauthStateOf,
+  onDesktopOAuthCallback,
+  type RakazoDesktop,
+  type RakazoDesktopOAuthCallback,
+  windowChromeKind,
+} from "./desktop.js";
 
 function desktop(platform: string): RakazoDesktop {
   const updateState = {
@@ -61,5 +68,62 @@ describe("captured OAuth callbacks", () => {
 
   it("sends a bare code when the provider redirects without state", () => {
     expect(desktopOAuthCode({ code: "ac_123" })).toBe("ac_123");
+  });
+});
+
+describe("attempt correlation", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function bridgeEmitting() {
+    let emit: (callback: RakazoDesktopOAuthCallback) => void = () => undefined;
+    const unsubscribe = vi.fn();
+    vi.stubGlobal("window", {
+      rakazoDesktop: {
+        ...desktop("linux"),
+        oauth: {
+          onCallback: (listener: (callback: RakazoDesktopOAuthCallback) => void) => {
+            emit = listener;
+            return unsubscribe;
+          },
+        },
+      },
+    });
+    return { emit: (c: RakazoDesktopOAuthCallback) => emit(c), unsubscribe };
+  }
+
+  it("reads the attempt state out of the authorize URL", () => {
+    expect(oauthStateOf("https://claude.ai/oauth/authorize?code=true&state=verifier_456")).toBe(
+      "verifier_456",
+    );
+    expect(oauthStateOf("https://claude.ai/oauth/authorize?code=true")).toBeUndefined();
+    expect(oauthStateOf("not a url")).toBeUndefined();
+  });
+
+  it("ignores a code captured for a different attempt", () => {
+    const { emit } = bridgeEmitting();
+    const received: string[] = [];
+    onDesktopOAuthCallback((code) => received.push(code), "verifier_456");
+
+    emit({ code: "stale", state: "verifier_000" });
+    expect(received).toEqual([]);
+
+    emit({ code: "ac_123", state: "verifier_456" });
+    expect(received).toEqual(["ac_123#verifier_456"]);
+  });
+
+  it("accepts any code when the provider carries no state to correlate on", () => {
+    const { emit } = bridgeEmitting();
+    const received: string[] = [];
+    onDesktopOAuthCallback((code) => received.push(code));
+
+    emit({ code: "ac_123" });
+    expect(received).toEqual(["ac_123"]);
+  });
+
+  it("no-ops in a browser without the desktop bridge", () => {
+    vi.stubGlobal("window", {});
+    const received: string[] = [];
+    expect(() => onDesktopOAuthCallback((code) => received.push(code))()).not.toThrow();
+    expect(received).toEqual([]);
   });
 });

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { type RakazoDesktop, windowChromeKind } from "./desktop.js";
+import { desktopOAuthCode, type RakazoDesktop, windowChromeKind } from "./desktop.js";
 
 function desktop(platform: string): RakazoDesktop {
   const updateState = {
@@ -27,6 +27,7 @@ function desktop(platform: string): RakazoDesktop {
       download: async () => updateState,
       install: async () => updateState,
     },
+    oauth: { onCallback: () => () => undefined },
   };
 }
 
@@ -50,5 +51,15 @@ describe("window chrome", () => {
     const welcome = readFileSync(path.join(root, "Welcome.tsx"), "utf8");
     expect(shell).not.toContain("FF5F57");
     expect(welcome).not.toContain("FF5F57");
+  });
+});
+
+describe("captured OAuth callbacks", () => {
+  it("sends the code and state as the compact form the paste flow accepts", () => {
+    expect(desktopOAuthCode({ code: "ac_123", state: "verifier_456" })).toBe("ac_123#verifier_456");
+  });
+
+  it("sends a bare code when the provider redirects without state", () => {
+    expect(desktopOAuthCode({ code: "ac_123" })).toBe("ac_123");
   });
 });

--- a/apps/web/src/lib/desktop.ts
+++ b/apps/web/src/lib/desktop.ts
@@ -18,14 +18,37 @@ export function desktopOAuthCode(callback: RakazoDesktopOAuthCallback) {
 }
 
 /**
+ * The authorize URL carries the attempt's PKCE state, so a captured code whose
+ * state differs belongs to a different attempt — a popup left open by a
+ * cancelled sign-in, say — and must not be spent on the current one.
+ */
+export function oauthStateOf(verificationUri: string): string | undefined {
+  try {
+    return new URL(verificationUri).searchParams.get("state") ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Sign-in popups in the desktop app redirect to a loopback URL the renderer
  * never sees. The main process captures the code there so the browser flow's
  * copy-and-paste step can be skipped. No-ops in a browser.
+ *
+ * Pass the attempt's state to ignore codes captured for any other attempt.
+ * Providers whose authorize URL carries no state cannot be correlated, so
+ * their codes are accepted as before.
  */
-export function onDesktopOAuthCallback(listener: (code: string) => void): () => void {
+export function onDesktopOAuthCallback(
+  listener: (code: string) => void,
+  expectedState?: string,
+): () => void {
   const oauth = desktopBridge()?.oauth;
   if (!oauth) return () => undefined;
-  return oauth.onCallback((callback) => listener(desktopOAuthCode(callback)));
+  return oauth.onCallback((callback) => {
+    if (expectedState !== undefined && callback.state !== expectedState) return;
+    listener(desktopOAuthCode(callback));
+  });
 }
 
 export function windowChromeKind(desktop?: RakazoDesktop): "spacer" | "darwin" | "controls" {

--- a/apps/web/src/lib/desktop.ts
+++ b/apps/web/src/lib/desktop.ts
@@ -1,6 +1,6 @@
-import type { RakazoDesktop } from "@rakazo/contracts";
+import type { RakazoDesktop, RakazoDesktopOAuthCallback } from "@rakazo/contracts";
 
-export type { RakazoDesktop } from "@rakazo/contracts";
+export type { RakazoDesktop, RakazoDesktopOAuthCallback } from "@rakazo/contracts";
 
 declare global {
   interface Window {
@@ -10,6 +10,22 @@ declare global {
 
 export function desktopBridge(): RakazoDesktop | undefined {
   return typeof window === "undefined" ? undefined : window.rakazoDesktop;
+}
+
+/** The compact `code#state` form the manual paste flow already accepts. */
+export function desktopOAuthCode(callback: RakazoDesktopOAuthCallback) {
+  return callback.state === undefined ? callback.code : `${callback.code}#${callback.state}`;
+}
+
+/**
+ * Sign-in popups in the desktop app redirect to a loopback URL the renderer
+ * never sees. The main process captures the code there so the browser flow's
+ * copy-and-paste step can be skipped. No-ops in a browser.
+ */
+export function onDesktopOAuthCallback(listener: (code: string) => void): () => void {
+  const oauth = desktopBridge()?.oauth;
+  if (!oauth) return () => undefined;
+  return oauth.onCallback((callback) => listener(desktopOAuthCode(callback)));
 }
 
 export function windowChromeKind(desktop?: RakazoDesktop): "spacer" | "darwin" | "controls" {

--- a/apps/web/src/lib/use-model-oauth-signin.ts
+++ b/apps/web/src/lib/use-model-oauth-signin.ts
@@ -63,7 +63,14 @@ export function useModelOAuthSignIn(options: {
     if (controller.signal.aborted) return;
     oauthLoginIdRef.current = null;
     setOauth(null);
-    await onFinishedRef.current(controller);
+    // Keep post-connect UI work outside the OAuth try/catch so a refresh failure
+    // is not reported as a failed sign-in (finishOAuth already persisted).
+    try {
+      await onFinishedRef.current(controller);
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      onErrorRef.current(err instanceof Error ? err.message : "Connected, but could not refresh");
+    }
   }
 
   async function submitOAuthCode(captured?: string, login?: ModelOAuthBegin) {

--- a/apps/web/src/lib/use-model-oauth-signin.ts
+++ b/apps/web/src/lib/use-model-oauth-signin.ts
@@ -162,7 +162,7 @@ export function useModelOAuthSignIn(options: {
     }
   }
 
-  useEffect(() => releaseOAuthCapture, []);
+  useEffect(() => () => cancelOAuthAttempt(false), []);
 
   return {
     oauth,

--- a/apps/web/src/lib/use-model-oauth-signin.ts
+++ b/apps/web/src/lib/use-model-oauth-signin.ts
@@ -1,0 +1,169 @@
+import type { ModelOAuthBegin } from "@rakazo/contracts";
+import { cancelModelOAuthAttempt, finishModelOAuthAttempt } from "@rakazo/core";
+import { useEffect, useRef, useState } from "react";
+import { oauthStateOf, onDesktopOAuthCallback } from "./desktop";
+import { waitForModelOAuth } from "./model-auth";
+import { rpc } from "./rpc";
+
+export type ModelOAuthSignInBegin = {
+  provider: string;
+  modelId?: string;
+  label?: string;
+};
+
+/**
+ * Shared subscription sign-in lifecycle for desktop loopback capture and the
+ * paste fallback. Preserves attempt-owned capture unsubscribe and submitting
+ * guards so cancel-and-retry cannot drop a newer callback.
+ */
+export function useModelOAuthSignIn(options: {
+  onFinished: (controller: AbortController) => void | Promise<void>;
+  onError: (message: string) => void;
+  onClearError?: () => void;
+}) {
+  const { onFinished, onError, onClearError } = options;
+  const [oauth, setOauth] = useState<ModelOAuthBegin | null>(null);
+  const [pasteCode, setPasteCode] = useState("");
+  const [oauthPending, setOauthPending] = useState(false);
+  const oauthAbortRef = useRef<AbortController | null>(null);
+  const oauthLoginIdRef = useRef<string | null>(null);
+  const oauthCodeSubmittingRef = useRef(false);
+  const oauthCaptureRef = useRef<(() => void) | null>(null);
+  const onFinishedRef = useRef(onFinished);
+  const onErrorRef = useRef(onError);
+  const onClearErrorRef = useRef(onClearError);
+  onFinishedRef.current = onFinished;
+  onErrorRef.current = onError;
+  onClearErrorRef.current = onClearError;
+
+  function releaseOAuthCapture(expected?: (() => void) | null) {
+    if (expected !== undefined && oauthCaptureRef.current !== expected) return;
+    oauthCaptureRef.current?.();
+    oauthCaptureRef.current = null;
+  }
+
+  function cancelOAuthAttempt(resetState = true) {
+    releaseOAuthCapture();
+    oauthCodeSubmittingRef.current = false;
+    const loginId = oauthLoginIdRef.current;
+    oauthLoginIdRef.current = null;
+    cancelModelOAuthAttempt(oauthAbortRef, () => {
+      if (resetState) {
+        setOauth(null);
+        setOauthPending(false);
+      }
+    });
+    if (loginId) void rpc.models.cancelOAuth({ loginId }).catch(() => undefined);
+  }
+
+  async function finishSubscriptionSignIn(loginId: string, controller: AbortController) {
+    await waitForModelOAuth(loginId, controller.signal);
+    if (controller.signal.aborted) return;
+    await rpc.models.finishOAuth({ loginId }, { signal: controller.signal });
+    if (controller.signal.aborted) return;
+    oauthLoginIdRef.current = null;
+    setOauth(null);
+    await onFinishedRef.current(controller);
+  }
+
+  async function submitOAuthCode(captured?: string, login?: ModelOAuthBegin) {
+    const attempt = login ?? oauth;
+    if (attempt?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
+    const controller = oauthAbortRef.current;
+    const capture = oauthCaptureRef.current;
+    const code = (captured ?? pasteCode).trim();
+    if (!controller || !code) return;
+    oauthCodeSubmittingRef.current = true;
+    setPasteCode("");
+    onClearErrorRef.current?.();
+    let submitted = false;
+    let retryable = false;
+    try {
+      await rpc.models.submitOAuthCode(
+        { loginId: attempt.loginId, code },
+        { signal: controller.signal },
+      );
+      submitted = true;
+      await finishSubscriptionSignIn(attempt.loginId, controller);
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      if (submitted) {
+        oauthLoginIdRef.current = null;
+        setOauth(null);
+        void rpc.models.cancelOAuth({ loginId: attempt.loginId }).catch(() => undefined);
+      } else {
+        retryable = true;
+        setPasteCode(code);
+      }
+      onErrorRef.current(err instanceof Error ? err.message : "Could not finish sign-in");
+    } finally {
+      // A cancelled attempt may already have started another sign-in; do not clear
+      // its submitting guard or the newer desktop callback is dropped.
+      if (oauthAbortRef.current === controller) {
+        oauthCodeSubmittingRef.current = false;
+      }
+      if (!retryable) {
+        // Only drop this attempt's listener — a newer sign-in may already own the ref.
+        releaseOAuthCapture(capture);
+        finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
+      }
+    }
+  }
+
+  async function startSubscriptionSignIn(begin: ModelOAuthSignInBegin) {
+    onClearErrorRef.current?.();
+    setOauthPending(true);
+    const controller = new AbortController();
+    oauthAbortRef.current = controller;
+    let waitingForCode = false;
+    try {
+      const started = await rpc.models.beginOAuth(
+        {
+          provider: begin.provider,
+          modelId: begin.modelId,
+          label: begin.label,
+        },
+        { signal: controller.signal },
+      );
+      if (controller.signal.aborted) return;
+      oauthLoginIdRef.current = started.loginId;
+      setPasteCode("");
+      setOauth(started);
+      if (started.mode === "auth-url") {
+        // Subscribe before the popup exists: a provider that is already
+        // authorized can redirect before React commits the state above.
+        releaseOAuthCapture();
+        oauthCaptureRef.current = onDesktopOAuthCallback(
+          (code) => void submitOAuthCode(code, started),
+          oauthStateOf(started.verificationUri),
+        );
+      }
+      window.open(started.verificationUri, "_blank", "noopener,noreferrer");
+      waitingForCode = started.mode === "auth-url";
+      if (!waitingForCode) await finishSubscriptionSignIn(started.loginId, controller);
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      const loginId = oauthLoginIdRef.current;
+      oauthLoginIdRef.current = null;
+      if (loginId) void rpc.models.cancelOAuth({ loginId }).catch(() => undefined);
+      onErrorRef.current(err instanceof Error ? err.message : "Could not start sign-in");
+      setOauth(null);
+    } finally {
+      if (!waitingForCode) {
+        finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
+      }
+    }
+  }
+
+  useEffect(() => releaseOAuthCapture, []);
+
+  return {
+    oauth,
+    pasteCode,
+    setPasteCode,
+    oauthPending,
+    cancelOAuthAttempt,
+    startSubscriptionSignIn,
+    submitOAuthCode,
+  };
+}

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -63,6 +63,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
 
   function cancelOAuthAttempt(resetState = true) {
     releaseOAuthCapture();
+    oauthCodeSubmittingRef.current = false;
     const loginId = oauthLoginIdRef.current;
     oauthLoginIdRef.current = null;
     cancelModelOAuthAttempt(oauthAbortRef, () => {
@@ -384,7 +385,11 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       }
       setError(err instanceof Error ? err.message : "Could not finish sign-in");
     } finally {
-      oauthCodeSubmittingRef.current = false;
+      // A cancelled attempt may already have started another sign-in; do not clear
+      // its submitting guard or the newer desktop callback is dropped.
+      if (oauthAbortRef.current === controller) {
+        oauthCodeSubmittingRef.current = false;
+      }
       if (!retryable) {
         // Only drop this attempt's listener — a newer sign-in may already own the ref.
         releaseOAuthCapture(capture);

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -107,7 +107,6 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     return () => {
       refreshRevisionRef.current += 1;
       probeRequestIdRef.current += 1;
-      cancelOAuthAttempt(false);
     };
   }, []);
 

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -55,7 +55,8 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const selectionRevisionRef = useRef(0);
   const probeRequestIdRef = useRef(0);
 
-  function releaseOAuthCapture() {
+  function releaseOAuthCapture(expected?: (() => void) | null) {
+    if (expected !== undefined && oauthCaptureRef.current !== expected) return;
     oauthCaptureRef.current?.();
     oauthCaptureRef.current = null;
   }
@@ -356,6 +357,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     const attempt = login ?? oauth;
     if (attempt?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
     const controller = oauthAbortRef.current;
+    const capture = oauthCaptureRef.current;
     const code = (captured ?? pasteCode).trim();
     if (!controller || !code) return;
     oauthCodeSubmittingRef.current = true;
@@ -384,7 +386,8 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     } finally {
       oauthCodeSubmittingRef.current = false;
       if (!retryable) {
-        releaseOAuthCapture();
+        // Only drop this attempt's listener — a newer sign-in may already own the ref.
+        releaseOAuthCapture(capture);
         finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
       }
     }

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -15,6 +15,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { onDesktopOAuthCallback } from "../lib/desktop";
 import {
   cancelModelOAuthAttempt,
   finishModelOAuthAttempt,
@@ -333,10 +334,15 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     }
   }
 
-  async function submitOAuthCode() {
+  useEffect(() => {
+    if (oauth?.mode !== "auth-url") return;
+    return onDesktopOAuthCallback((code) => void submitOAuthCode(code));
+  }, [oauth]);
+
+  async function submitOAuthCode(captured?: string) {
     if (oauth?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
     const controller = oauthAbortRef.current;
-    const code = pasteCode.trim();
+    const code = (captured ?? pasteCode).trim();
     if (!controller || !code) return;
     oauthCodeSubmittingRef.current = true;
     setPasteCode("");

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -15,7 +15,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { onDesktopOAuthCallback } from "../lib/desktop";
+import { oauthStateOf, onDesktopOAuthCallback } from "../lib/desktop";
 import {
   cancelModelOAuthAttempt,
   finishModelOAuthAttempt,
@@ -50,11 +50,18 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const oauthAbortRef = useRef<AbortController | null>(null);
   const oauthLoginIdRef = useRef<string | null>(null);
   const oauthCodeSubmittingRef = useRef(false);
+  const oauthCaptureRef = useRef<(() => void) | null>(null);
   const refreshRevisionRef = useRef(0);
   const selectionRevisionRef = useRef(0);
   const probeRequestIdRef = useRef(0);
 
+  function releaseOAuthCapture() {
+    oauthCaptureRef.current?.();
+    oauthCaptureRef.current = null;
+  }
+
   function cancelOAuthAttempt(resetState = true) {
+    releaseOAuthCapture();
     const loginId = oauthLoginIdRef.current;
     oauthLoginIdRef.current = null;
     cancelModelOAuthAttempt(oauthAbortRef, () => {
@@ -317,6 +324,15 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       oauthLoginIdRef.current = started.loginId;
       setPasteCode("");
       setOauth(started);
+      if (started.mode === "auth-url") {
+        // Subscribe before the popup exists: a provider that is already
+        // authorized can redirect before React commits the state above.
+        releaseOAuthCapture();
+        oauthCaptureRef.current = onDesktopOAuthCallback(
+          (code) => void submitOAuthCode(code, started),
+          oauthStateOf(started.verificationUri),
+        );
+      }
       window.open(started.verificationUri, "_blank", "noopener,noreferrer");
       waitingForCode = started.mode === "auth-url";
       if (!waitingForCode) await finishSubscriptionSignIn(started.loginId, controller);
@@ -334,13 +350,11 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     }
   }
 
-  useEffect(() => {
-    if (oauth?.mode !== "auth-url") return;
-    return onDesktopOAuthCallback((code) => void submitOAuthCode(code));
-  }, [oauth]);
+  useEffect(() => releaseOAuthCapture, []);
 
-  async function submitOAuthCode(captured?: string) {
-    if (oauth?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
+  async function submitOAuthCode(captured?: string, login?: ModelOAuthBegin) {
+    const attempt = login ?? oauth;
+    if (attempt?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
     const controller = oauthAbortRef.current;
     const code = (captured ?? pasteCode).trim();
     if (!controller || !code) return;
@@ -351,17 +365,17 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     let retryable = false;
     try {
       await rpc.models.submitOAuthCode(
-        { loginId: oauth.loginId, code },
+        { loginId: attempt.loginId, code },
         { signal: controller.signal },
       );
       submitted = true;
-      await finishSubscriptionSignIn(oauth.loginId, controller);
+      await finishSubscriptionSignIn(attempt.loginId, controller);
     } catch (err) {
       if (controller.signal.aborted) return;
       if (submitted) {
         oauthLoginIdRef.current = null;
         setOauth(null);
-        void rpc.models.cancelOAuth({ loginId: oauth.loginId }).catch(() => undefined);
+        void rpc.models.cancelOAuth({ loginId: attempt.loginId }).catch(() => undefined);
       } else {
         retryable = true;
         setPasteCode(code);
@@ -370,6 +384,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     } finally {
       oauthCodeSubmittingRef.current = false;
       if (!retryable) {
+        releaseOAuthCapture();
         finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
       }
     }

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -15,17 +15,9 @@ import {
   useRef,
   useState,
 } from "react";
-import { oauthStateOf, onDesktopOAuthCallback } from "../lib/desktop";
-import {
-  cancelModelOAuthAttempt,
-  finishModelOAuthAttempt,
-  type ModelCatalogEntry,
-  type ModelCredential,
-  type ModelOAuthBegin,
-  providerHint,
-  waitForModelOAuth,
-} from "../lib/model-auth";
+import { type ModelCatalogEntry, type ModelCredential, providerHint } from "../lib/model-auth";
 import { rpc } from "../lib/rpc";
+import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 
 export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
@@ -39,41 +31,33 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [probeModels, setProbeModels] = useState<string[]>([]);
   const [probedBaseUrl, setProbedBaseUrl] = useState<string | null>(null);
   const [probing, setProbing] = useState(false);
-  const [oauth, setOauth] = useState<ModelOAuthBegin | null>(null);
-  const [pasteCode, setPasteCode] = useState("");
   const [loading, setLoading] = useState(true);
   const [pending, setPending] = useState<"connect" | "default" | null>(null);
-  const [oauthPending, setOauthPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const detailScrollRef = useRef<HTMLDivElement>(null);
-  const oauthAbortRef = useRef<AbortController | null>(null);
-  const oauthLoginIdRef = useRef<string | null>(null);
-  const oauthCodeSubmittingRef = useRef(false);
-  const oauthCaptureRef = useRef<(() => void) | null>(null);
   const refreshRevisionRef = useRef(0);
   const selectionRevisionRef = useRef(0);
   const probeRequestIdRef = useRef(0);
+  const selectedLabelRef = useRef<string | undefined>(undefined);
 
-  function releaseOAuthCapture(expected?: (() => void) | null) {
-    if (expected !== undefined && oauthCaptureRef.current !== expected) return;
-    oauthCaptureRef.current?.();
-    oauthCaptureRef.current = null;
-  }
-
-  function cancelOAuthAttempt(resetState = true) {
-    releaseOAuthCapture();
-    oauthCodeSubmittingRef.current = false;
-    const loginId = oauthLoginIdRef.current;
-    oauthLoginIdRef.current = null;
-    cancelModelOAuthAttempt(oauthAbortRef, () => {
-      if (resetState) {
-        setOauth(null);
-        setOauthPending(false);
-      }
-    });
-    if (loginId) void rpc.models.cancelOAuth({ loginId }).catch(() => undefined);
-  }
+  const {
+    oauth,
+    pasteCode,
+    setPasteCode,
+    oauthPending,
+    cancelOAuthAttempt,
+    startSubscriptionSignIn,
+    submitOAuthCode,
+  } = useModelOAuthSignIn({
+    onClearError: () => setError(null),
+    onError: setError,
+    onFinished: async (controller) => {
+      await refresh();
+      if (controller.signal.aborted) return;
+      setNotice(`Connected and using ${selectedLabelRef.current ?? "this model"}.`);
+    },
+  });
 
   async function refresh() {
     const refreshRevision = ++refreshRevisionRef.current;
@@ -152,6 +136,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   }, [groups, providerQuery]);
   const modelsForProvider = catalog.filter((entry) => entry.provider === provider);
   const selected = modelsForProvider.find((entry) => entry.id === modelId) ?? modelsForProvider[0];
+  selectedLabelRef.current = selected?.label;
   const isOpenAiCompatible = provider === OPENAI_COMPATIBLE_PROVIDER_ID;
   const credential = credentials.find((entry) => entry.provider === provider);
   const currentEntry = catalog.find(
@@ -293,114 +278,19 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     }
   }
 
-  async function finishSubscriptionSignIn(loginId: string, controller: AbortController) {
-    await waitForModelOAuth(loginId, controller.signal);
-    if (controller.signal.aborted) return;
-    await rpc.models.finishOAuth({ loginId }, { signal: controller.signal });
-    if (controller.signal.aborted) return;
-    oauthLoginIdRef.current = null;
-    setOauth(null);
-    await refresh();
-    if (controller.signal.aborted) return;
-    setNotice(`Connected and using ${selected?.label ?? "this model"}.`);
-  }
-
-  async function startSubscriptionSignIn() {
-    if (!selected) return;
-    setError(null);
-    setNotice(null);
-    setOauthPending(true);
-    const controller = new AbortController();
-    oauthAbortRef.current = controller;
-    let waitingForCode = false;
-    try {
-      const started = await rpc.models.beginOAuth(
-        {
-          provider: selected.provider,
-          modelId: selected.id,
-          label: selected.providerName ?? selected.provider,
-        },
-        { signal: controller.signal },
-      );
-      if (controller.signal.aborted) return;
-      oauthLoginIdRef.current = started.loginId;
-      setPasteCode("");
-      setOauth(started);
-      if (started.mode === "auth-url") {
-        // Subscribe before the popup exists: a provider that is already
-        // authorized can redirect before React commits the state above.
-        releaseOAuthCapture();
-        oauthCaptureRef.current = onDesktopOAuthCallback(
-          (code) => void submitOAuthCode(code, started),
-          oauthStateOf(started.verificationUri),
-        );
-      }
-      window.open(started.verificationUri, "_blank", "noopener,noreferrer");
-      waitingForCode = started.mode === "auth-url";
-      if (!waitingForCode) await finishSubscriptionSignIn(started.loginId, controller);
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      const loginId = oauthLoginIdRef.current;
-      oauthLoginIdRef.current = null;
-      if (loginId) void rpc.models.cancelOAuth({ loginId }).catch(() => undefined);
-      setError(err instanceof Error ? err.message : "Could not start sign-in");
-      setOauth(null);
-    } finally {
-      if (!waitingForCode) {
-        finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
-      }
-    }
-  }
-
-  useEffect(() => releaseOAuthCapture, []);
-
-  async function submitOAuthCode(captured?: string, login?: ModelOAuthBegin) {
-    const attempt = login ?? oauth;
-    if (attempt?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
-    const controller = oauthAbortRef.current;
-    const capture = oauthCaptureRef.current;
-    const code = (captured ?? pasteCode).trim();
-    if (!controller || !code) return;
-    oauthCodeSubmittingRef.current = true;
-    setPasteCode("");
-    setError(null);
-    let submitted = false;
-    let retryable = false;
-    try {
-      await rpc.models.submitOAuthCode(
-        { loginId: attempt.loginId, code },
-        { signal: controller.signal },
-      );
-      submitted = true;
-      await finishSubscriptionSignIn(attempt.loginId, controller);
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      if (submitted) {
-        oauthLoginIdRef.current = null;
-        setOauth(null);
-        void rpc.models.cancelOAuth({ loginId: attempt.loginId }).catch(() => undefined);
-      } else {
-        retryable = true;
-        setPasteCode(code);
-      }
-      setError(err instanceof Error ? err.message : "Could not finish sign-in");
-    } finally {
-      // A cancelled attempt may already have started another sign-in; do not clear
-      // its submitting guard or the newer desktop callback is dropped.
-      if (oauthAbortRef.current === controller) {
-        oauthCodeSubmittingRef.current = false;
-      }
-      if (!retryable) {
-        // Only drop this attempt's listener — a newer sign-in may already own the ref.
-        releaseOAuthCapture(capture);
-        finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
-      }
-    }
-  }
-
   function handleClose() {
     cancelOAuthAttempt(false);
     onClose();
+  }
+
+  function beginSelectedSubscriptionSignIn() {
+    if (!selected) return;
+    setNotice(null);
+    void startSubscriptionSignIn({
+      provider: selected.provider,
+      modelId: selected.id,
+      label: selected.providerName ?? selected.provider,
+    });
   }
 
   return (
@@ -677,7 +567,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         variant="outline"
                         size="sm"
                         disabled={busy}
-                        onClick={() => void startSubscriptionSignIn()}
+                        onClick={() => beginSelectedSubscriptionSignIn()}
                       >
                         {oauthPending ? "Starting…" : (selected.oauthLabel ?? "Sign in")}
                       </Button>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -44,7 +44,8 @@ export function OnboardingPage() {
   const oauthCaptureRef = useRef<(() => void) | null>(null);
   const probeRequestIdRef = useRef(0);
 
-  function releaseOAuthCapture() {
+  function releaseOAuthCapture(expected?: (() => void) | null) {
+    if (expected !== undefined && oauthCaptureRef.current !== expected) return;
     oauthCaptureRef.current?.();
     oauthCaptureRef.current = null;
   }
@@ -255,6 +256,7 @@ export function OnboardingPage() {
     const attempt = login ?? oauth;
     if (attempt?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
     const controller = oauthAbortRef.current;
+    const capture = oauthCaptureRef.current;
     const code = (captured ?? pasteCode).trim();
     if (!controller || !code) return;
     oauthCodeSubmittingRef.current = true;
@@ -283,7 +285,8 @@ export function OnboardingPage() {
     } finally {
       oauthCodeSubmittingRef.current = false;
       if (!retryable) {
-        releaseOAuthCapture();
+        // Only drop this attempt's listener — a newer sign-in may already own the ref.
+        releaseOAuthCapture(capture);
         finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
       }
     }

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -7,16 +7,9 @@ import {
 import { ChevronDown } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { oauthStateOf, onDesktopOAuthCallback } from "../lib/desktop";
-import {
-  cancelModelOAuthAttempt,
-  finishModelOAuthAttempt,
-  type ModelCatalogEntry,
-  type ModelOAuthBegin,
-  providerHint,
-  waitForModelOAuth,
-} from "../lib/model-auth";
+import { type ModelCatalogEntry, providerHint } from "../lib/model-auth";
 import { rpc } from "../lib/rpc";
+import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 
 export function OnboardingPage() {
   const navigate = useNavigate();
@@ -35,34 +28,23 @@ export function OnboardingPage() {
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
-  const [oauth, setOauth] = useState<ModelOAuthBegin | null>(null);
-  const [pasteCode, setPasteCode] = useState("");
-  const [oauthPending, setOauthPending] = useState(false);
-  const oauthAbortRef = useRef<AbortController | null>(null);
-  const oauthLoginIdRef = useRef<string | null>(null);
-  const oauthCodeSubmittingRef = useRef(false);
-  const oauthCaptureRef = useRef<(() => void) | null>(null);
   const probeRequestIdRef = useRef(0);
 
-  function releaseOAuthCapture(expected?: (() => void) | null) {
-    if (expected !== undefined && oauthCaptureRef.current !== expected) return;
-    oauthCaptureRef.current?.();
-    oauthCaptureRef.current = null;
-  }
-
-  function cancelOAuthAttempt(resetState = true) {
-    releaseOAuthCapture();
-    oauthCodeSubmittingRef.current = false;
-    const loginId = oauthLoginIdRef.current;
-    oauthLoginIdRef.current = null;
-    cancelModelOAuthAttempt(oauthAbortRef, () => {
-      if (resetState) {
-        setOauth(null);
-        setOauthPending(false);
-      }
-    });
-    if (loginId) void rpc.models.cancelOAuth({ loginId }).catch(() => undefined);
-  }
+  const {
+    oauth,
+    pasteCode,
+    setPasteCode,
+    oauthPending,
+    cancelOAuthAttempt,
+    startSubscriptionSignIn,
+    submitOAuthCode,
+  } = useModelOAuthSignIn({
+    onClearError: () => setError(null),
+    onError: setError,
+    onFinished: () => {
+      setStep("bot");
+    },
+  });
 
   useEffect(() => {
     void Promise.all([rpc.me(), rpc.models.list().catch(() => [])])
@@ -196,105 +178,12 @@ export function OnboardingPage() {
     }
   }
 
-  async function finishSubscriptionSignIn(loginId: string, controller: AbortController) {
-    await waitForModelOAuth(loginId, controller.signal);
-    if (controller.signal.aborted) return;
-    await rpc.models.finishOAuth({ loginId }, { signal: controller.signal });
-    if (controller.signal.aborted) return;
-    oauthLoginIdRef.current = null;
-    setOauth(null);
-    setStep("bot");
-  }
-
-  async function startSubscriptionSignIn() {
-    setError(null);
-    setOauthPending(true);
-    const controller = new AbortController();
-    oauthAbortRef.current = controller;
-    let waitingForCode = false;
-    try {
-      const started = await rpc.models.beginOAuth(
-        {
-          provider,
-          modelId,
-          label: selected?.providerName ?? provider,
-        },
-        { signal: controller.signal },
-      );
-      if (controller.signal.aborted) return;
-      oauthLoginIdRef.current = started.loginId;
-      setPasteCode("");
-      setOauth(started);
-      if (started.mode === "auth-url") {
-        // Subscribe before the popup exists: a provider that is already
-        // authorized can redirect before React commits the state above.
-        releaseOAuthCapture();
-        oauthCaptureRef.current = onDesktopOAuthCallback(
-          (code) => void submitOAuthCode(code, started),
-          oauthStateOf(started.verificationUri),
-        );
-      }
-      window.open(started.verificationUri, "_blank", "noopener,noreferrer");
-      waitingForCode = started.mode === "auth-url";
-      if (!waitingForCode) await finishSubscriptionSignIn(started.loginId, controller);
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      const loginId = oauthLoginIdRef.current;
-      oauthLoginIdRef.current = null;
-      if (loginId) void rpc.models.cancelOAuth({ loginId }).catch(() => undefined);
-      setError(err instanceof Error ? err.message : "Could not start sign-in");
-      setOauth(null);
-    } finally {
-      if (!waitingForCode) {
-        finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
-      }
-    }
-  }
-
-  useEffect(() => releaseOAuthCapture, []);
-
-  async function submitOAuthCode(captured?: string, login?: ModelOAuthBegin) {
-    const attempt = login ?? oauth;
-    if (attempt?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
-    const controller = oauthAbortRef.current;
-    const capture = oauthCaptureRef.current;
-    const code = (captured ?? pasteCode).trim();
-    if (!controller || !code) return;
-    oauthCodeSubmittingRef.current = true;
-    setPasteCode("");
-    setError(null);
-    let submitted = false;
-    let retryable = false;
-    try {
-      await rpc.models.submitOAuthCode(
-        { loginId: attempt.loginId, code },
-        { signal: controller.signal },
-      );
-      submitted = true;
-      await finishSubscriptionSignIn(attempt.loginId, controller);
-    } catch (err) {
-      if (controller.signal.aborted) return;
-      if (submitted) {
-        oauthLoginIdRef.current = null;
-        setOauth(null);
-        void rpc.models.cancelOAuth({ loginId: attempt.loginId }).catch(() => undefined);
-      } else {
-        retryable = true;
-        setPasteCode(code);
-      }
-      setError(err instanceof Error ? err.message : "Could not finish sign-in");
-    } finally {
-      // A cancelled attempt may already have started another sign-in; do not clear
-      // its submitting guard or the newer desktop callback is dropped.
-      if (oauthAbortRef.current === controller) {
-        oauthCodeSubmittingRef.current = false;
-      }
-      if (!retryable) {
-        // Only drop this attempt's listener — a newer sign-in may already own the ref.
-        releaseOAuthCapture(capture);
-        finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
-      }
-    }
+  function beginSelectedSubscriptionSignIn() {
+    void startSubscriptionSignIn({
+      provider,
+      modelId,
+      label: selected?.providerName ?? provider,
+    });
   }
 
   async function createBot() {
@@ -518,7 +407,7 @@ export function OnboardingPage() {
                   <button
                     type="button"
                     disabled={oauthPending}
-                    onClick={() => void startSubscriptionSignIn()}
+                    onClick={() => beginSelectedSubscriptionSignIn()}
                     className="rounded-[11px] bg-[#F1F1EF] px-5 py-2.5 text-[#17171A] disabled:opacity-40"
                   >
                     {oauthPending ? "Starting…" : signInLabel}

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -7,7 +7,7 @@ import {
 import { ChevronDown } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { onDesktopOAuthCallback } from "../lib/desktop";
+import { oauthStateOf, onDesktopOAuthCallback } from "../lib/desktop";
 import {
   cancelModelOAuthAttempt,
   finishModelOAuthAttempt,
@@ -41,9 +41,16 @@ export function OnboardingPage() {
   const oauthAbortRef = useRef<AbortController | null>(null);
   const oauthLoginIdRef = useRef<string | null>(null);
   const oauthCodeSubmittingRef = useRef(false);
+  const oauthCaptureRef = useRef<(() => void) | null>(null);
   const probeRequestIdRef = useRef(0);
 
+  function releaseOAuthCapture() {
+    oauthCaptureRef.current?.();
+    oauthCaptureRef.current = null;
+  }
+
   function cancelOAuthAttempt(resetState = true) {
+    releaseOAuthCapture();
     const loginId = oauthLoginIdRef.current;
     oauthLoginIdRef.current = null;
     cancelModelOAuthAttempt(oauthAbortRef, () => {
@@ -216,6 +223,15 @@ export function OnboardingPage() {
       oauthLoginIdRef.current = started.loginId;
       setPasteCode("");
       setOauth(started);
+      if (started.mode === "auth-url") {
+        // Subscribe before the popup exists: a provider that is already
+        // authorized can redirect before React commits the state above.
+        releaseOAuthCapture();
+        oauthCaptureRef.current = onDesktopOAuthCallback(
+          (code) => void submitOAuthCode(code, started),
+          oauthStateOf(started.verificationUri),
+        );
+      }
       window.open(started.verificationUri, "_blank", "noopener,noreferrer");
       waitingForCode = started.mode === "auth-url";
       if (!waitingForCode) await finishSubscriptionSignIn(started.loginId, controller);
@@ -233,13 +249,11 @@ export function OnboardingPage() {
     }
   }
 
-  useEffect(() => {
-    if (oauth?.mode !== "auth-url") return;
-    return onDesktopOAuthCallback((code) => void submitOAuthCode(code));
-  }, [oauth]);
+  useEffect(() => releaseOAuthCapture, []);
 
-  async function submitOAuthCode(captured?: string) {
-    if (oauth?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
+  async function submitOAuthCode(captured?: string, login?: ModelOAuthBegin) {
+    const attempt = login ?? oauth;
+    if (attempt?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
     const controller = oauthAbortRef.current;
     const code = (captured ?? pasteCode).trim();
     if (!controller || !code) return;
@@ -250,17 +264,17 @@ export function OnboardingPage() {
     let retryable = false;
     try {
       await rpc.models.submitOAuthCode(
-        { loginId: oauth.loginId, code },
+        { loginId: attempt.loginId, code },
         { signal: controller.signal },
       );
       submitted = true;
-      await finishSubscriptionSignIn(oauth.loginId, controller);
+      await finishSubscriptionSignIn(attempt.loginId, controller);
     } catch (err) {
       if (controller.signal.aborted) return;
       if (submitted) {
         oauthLoginIdRef.current = null;
         setOauth(null);
-        void rpc.models.cancelOAuth({ loginId: oauth.loginId }).catch(() => undefined);
+        void rpc.models.cancelOAuth({ loginId: attempt.loginId }).catch(() => undefined);
       } else {
         retryable = true;
         setPasteCode(code);
@@ -269,6 +283,7 @@ export function OnboardingPage() {
     } finally {
       oauthCodeSubmittingRef.current = false;
       if (!retryable) {
+        releaseOAuthCapture();
         finishModelOAuthAttempt(oauthAbortRef, controller, () => setOauthPending(false));
       }
     }

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -52,6 +52,7 @@ export function OnboardingPage() {
 
   function cancelOAuthAttempt(resetState = true) {
     releaseOAuthCapture();
+    oauthCodeSubmittingRef.current = false;
     const loginId = oauthLoginIdRef.current;
     oauthLoginIdRef.current = null;
     cancelModelOAuthAttempt(oauthAbortRef, () => {
@@ -283,7 +284,11 @@ export function OnboardingPage() {
       }
       setError(err instanceof Error ? err.message : "Could not finish sign-in");
     } finally {
-      oauthCodeSubmittingRef.current = false;
+      // A cancelled attempt may already have started another sign-in; do not clear
+      // its submitting guard or the newer desktop callback is dropped.
+      if (oauthAbortRef.current === controller) {
+        oauthCodeSubmittingRef.current = false;
+      }
       if (!retryable) {
         // Only drop this attempt's listener — a newer sign-in may already own the ref.
         releaseOAuthCapture(capture);

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -7,6 +7,7 @@ import {
 import { ChevronDown } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { onDesktopOAuthCallback } from "../lib/desktop";
 import {
   cancelModelOAuthAttempt,
   finishModelOAuthAttempt,
@@ -232,10 +233,15 @@ export function OnboardingPage() {
     }
   }
 
-  async function submitOAuthCode() {
+  useEffect(() => {
+    if (oauth?.mode !== "auth-url") return;
+    return onDesktopOAuthCallback((code) => void submitOAuthCode(code));
+  }, [oauth]);
+
+  async function submitOAuthCode(captured?: string) {
     if (oauth?.mode !== "auth-url" || oauthCodeSubmittingRef.current) return;
     const controller = oauthAbortRef.current;
-    const code = pasteCode.trim();
+    const code = (captured ?? pasteCode).trim();
     if (!controller || !code) return;
     oauthCodeSubmittingRef.current = true;
     setPasteCode("");

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -65,7 +65,6 @@ export function OnboardingPage() {
       .catch(() => setStep("bot"));
     return () => {
       probeRequestIdRef.current += 1;
-      cancelOAuthAttempt(false);
     };
   }, []);
 

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -31,6 +31,11 @@ export interface RakazoDesktopUpdate {
   install: () => Promise<DesktopUpdateState>;
 }
 
+export interface RakazoDesktopOAuthCallback {
+  code: string;
+  state?: string;
+}
+
 export interface RakazoDesktop {
   platform: string;
   window: {
@@ -40,6 +45,13 @@ export interface RakazoDesktop {
     state: () => Promise<{ minimized: boolean; maximized: boolean; fullScreen: boolean }>;
   };
   update: RakazoDesktopUpdate;
+  oauth: {
+    /**
+     * Authorization codes captured from a sign-in popup's loopback redirect.
+     * Returns an unsubscribe function.
+     */
+    onCallback: (listener: (callback: RakazoDesktopOAuthCallback) => void) => () => void;
+  };
 }
 
 /** How the desktop app was pointed at a Rakazo server during first-run setup. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebase of [#183](https://github.com/elie222/rakazo/pull/183) onto current `main` after `#177` (desktop auto-update) and `#185` (session lookup sign-out) landed and conflicted.

**Could not update the original fork branch** (`adam91holt:fix/desktop-oauth-loopback-callback`): push was rejected because the GitHub App token lacks `workflows` permission when the rebased tip includes workflow changes from `main`. This PR carries the same product change on a writable branch in this repo.

## Product change (from adam91holt)

Desktop main process captures loopback OAuth codes from the sign-in popup and forwards `{ code, state }` to the renderer over `desktop.oauth.callback`, so subscription sign-in can finish without an address bar. Browser behavior unchanged; paste remains a fallback.

Preserves Adam Holt authorship on the original capture/correlation commits (`Co-Authored-By` trailers kept through rebase).

## Conflict resolution

Overlaps were in `apps/desktop/src/main.ts`, preload, smoke e2e, `packages/contracts/src/desktop.ts`, and web desktop tests:

- Kept auto-update bridge (`update`) and OAuth bridge (`oauth`) together.
- Kept current main's `setWindowOpenHandler` / setup / shell-external behavior.
- Re-applied `#184` hardening on the rebased tip: skip app-origin loopback, ignore non-main-frame redirects (`excludeOrigins` from `targetOrigin` / server URL, not the old `WEB_URL` constant).

## Verification

- `@rakazo/contracts` / `@rakazo/desktop` / `@rakazo/web` `check` (tsc) clean
- Desktop unit tests including `oauth-callback` + preload: 106 passed
- `apps/web/src/lib/desktop.test.ts`: 10 passed

Original PR: https://github.com/elie222/rakazo/pull/183

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa88888c-42fa-41a2-872e-ffe04d7fda45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa88888c-42fa-41a2-872e-ffe04d7fda45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added desktop OAuth sign-in support by capturing secure loopback callbacks from authorization popups.
  - Added automatic callback handling with authorization state validation.
  - Added paste-code fallback for completing sign-in when automatic capture is unavailable.
  - Added cancellation, retry, and improved error handling across onboarding and model settings sign-in flows.
  - Added support for OAuth callback notifications through the desktop application bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->