### PR TITLE
Add composer / picker for skills above Actions

### DIFF
--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -1,8 +1,10 @@
 import type { ThreadMessage, ThreadMessagePage } from "@rakazo/contracts";
 import type { Prisma, PrismaClient } from "@rakazo/db";
 
+type MessageDb = PrismaClient | Prisma.TransactionClient;
+
 export async function loadMessagePage(
-  prisma: PrismaClient,
+  prisma: MessageDb,
   threadId: string,
   before: number | undefined,
   pageSize: number,

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -31,13 +31,17 @@ describe("threadSnapshot", () => {
         createdAt: new Date("2026-08-23T00:00:00.000Z"),
       },
     ]);
-    const prisma = {
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
       message: { findMany: vi.fn().mockResolvedValue([]) },
       event: {
         findFirst: vi.fn().mockResolvedValue({ seq: 4 }),
         findMany: findManyEvents,
       },
       run: { findFirst: vi.fn().mockResolvedValue(run) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
     } as unknown as PrismaClient;
     const target = {
       kind: "bot",
@@ -48,6 +52,7 @@ describe("threadSnapshot", () => {
 
     const snapshot = await threadSnapshot({ prisma }, target);
 
+    expect(tx.$queryRaw).toHaveBeenCalledOnce();
     expect(findManyEvents).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -210,84 +210,98 @@ export async function threadSnapshot(
   deps: { prisma: PrismaClient },
   target: ThreadTarget,
 ): Promise<ThreadSnapshot> {
+  // Lock the thread row so messages, the event cursor, active runs, and live
+  // progress are read from one consistent commit. A torn Promise.all can
+  // otherwise advance the client cursor past thread.message.created while the
+  // ask message page still omits it — leaving waiting_input with no AskCard.
   if (target.kind === "bot") {
-    const [messagePage, last, run, busyBotName] = await Promise.all([
-      loadMessagePage(deps.prisma, target.threadId, undefined, THREAD_MESSAGE_PAGE_SIZE),
-      deps.prisma.event.findFirst({
-        where: { threadId: target.threadId },
-        orderBy: { seq: "desc" },
-        select: { seq: true },
-      }),
-      deps.prisma.run.findFirst({
-        where: {
-          botId: target.botId,
-          status: { in: [...ACTIVE_RUN_STATUSES] },
-        },
-        orderBy: { createdAt: "desc" },
-      }),
+    const [busyBotName, core] = await Promise.all([
       resolveBusyBotName(deps.prisma, {
         computerId: target.bot.computer?.id,
         botId: target.botId,
         botName: target.bot.name,
       }),
+      deps.prisma.$transaction(async (tx) => {
+        await tx.$queryRaw`SELECT id FROM threads WHERE id = ${target.threadId} FOR SHARE`;
+        const [messagePage, last, run] = await Promise.all([
+          loadMessagePage(tx, target.threadId, undefined, THREAD_MESSAGE_PAGE_SIZE),
+          tx.event.findFirst({
+            where: { threadId: target.threadId },
+            orderBy: { seq: "desc" },
+            select: { seq: true },
+          }),
+          tx.run.findFirst({
+            where: {
+              botId: target.botId,
+              status: { in: [...ACTIVE_RUN_STATUSES] },
+            },
+            orderBy: { createdAt: "desc" },
+          }),
+        ]);
+        const liveEvents = run
+          ? await tx.event.findMany({
+              where: {
+                threadId: target.threadId,
+                runId: run.id,
+                type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
+              },
+              orderBy: { seq: "asc" },
+            })
+          : [];
+        return { messagePage, last, run, liveEvents };
+      }),
     ]);
-    const liveEvents = run
-      ? await deps.prisma.event.findMany({
-          where: {
-            threadId: target.threadId,
-            runId: run.id,
-            type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
-          },
-          orderBy: { seq: "asc" },
-        })
-      : [];
     return {
       botId: target.botId,
       threadId: target.threadId,
-      cursor: last?.seq ?? -1,
-      messages: messagesWithLiveEvents(messagePage.messages, liveEvents),
-      olderCursor: messagePage.olderCursor,
-      run: run ? mapRun(run) : null,
+      cursor: core.last?.seq ?? -1,
+      messages: messagesWithLiveEvents(core.messagePage.messages, core.liveEvents),
+      olderCursor: core.messagePage.olderCursor,
+      run: core.run ? mapRun(core.run) : null,
       computer: toComputerStatus(target.botId, target.bot.computer, busyBotName),
     };
   }
 
-  const [messagePage, last, activeRuns] = await Promise.all([
-    loadMessagePage(deps.prisma, target.threadId, undefined, THREAD_MESSAGE_PAGE_SIZE),
-    deps.prisma.event.findFirst({
-      where: { threadId: target.threadId },
-      orderBy: { seq: "desc" },
-      select: { seq: true },
-    }),
-    deps.prisma.run.findMany({
-      where: {
-        threadId: target.threadId,
-        status: { in: [...ACTIVE_RUN_STATUSES] },
-      },
-      orderBy: { createdAt: "desc" },
-    }),
-  ]);
-  const liveEvents =
-    activeRuns.length > 0
-      ? await deps.prisma.event.findMany({
-          where: {
-            threadId: target.threadId,
-            runId: { in: activeRuns.map((run) => run.id) },
-            type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
-          },
-          orderBy: { seq: "asc" },
-        })
-      : [];
+  const core = await deps.prisma.$transaction(async (tx) => {
+    await tx.$queryRaw`SELECT id FROM threads WHERE id = ${target.threadId} FOR SHARE`;
+    const [messagePage, last, activeRuns] = await Promise.all([
+      loadMessagePage(tx, target.threadId, undefined, THREAD_MESSAGE_PAGE_SIZE),
+      tx.event.findFirst({
+        where: { threadId: target.threadId },
+        orderBy: { seq: "desc" },
+        select: { seq: true },
+      }),
+      tx.run.findMany({
+        where: {
+          threadId: target.threadId,
+          status: { in: [...ACTIVE_RUN_STATUSES] },
+        },
+        orderBy: { createdAt: "desc" },
+      }),
+    ]);
+    const liveEvents =
+      activeRuns.length > 0
+        ? await tx.event.findMany({
+            where: {
+              threadId: target.threadId,
+              runId: { in: activeRuns.map((run) => run.id) },
+              type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
+            },
+            orderBy: { seq: "asc" },
+          })
+        : [];
+    return { messagePage, last, activeRuns, liveEvents };
+  });
   return {
     groupId: target.groupId,
     groupName: target.groupName,
     members: target.members,
     threadId: target.threadId,
-    cursor: last?.seq ?? -1,
-    messages: messagesWithLiveEvents(messagePage.messages, liveEvents),
-    olderCursor: messagePage.olderCursor,
-    run: activeRuns[0] ? mapRun(activeRuns[0]) : null,
-    activeRuns: activeRuns.map(mapRun),
+    cursor: core.last?.seq ?? -1,
+    messages: messagesWithLiveEvents(core.messagePage.messages, core.liveEvents),
+    olderCursor: core.messagePage.olderCursor,
+    run: core.activeRuns[0] ? mapRun(core.activeRuns[0]) : null,
+    activeRuns: core.activeRuns.map(mapRun),
   };
 }
 

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -115,8 +115,16 @@ test("connecting to an existing instance verifies, saves, and opens it", async (
     path: path.join(import.meta.dirname, "screenshots", "03-connected-instance.png"),
   });
 
-  const saved = JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
-  expect(saved).toEqual({ mode: "existing", serverUrl });
+  // Continue can paint the app window before setup.json finishes flushing to disk.
+  await expect
+    .poll(async () => {
+      try {
+        return JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
+      } catch {
+        return null;
+      }
+    })
+    .toEqual({ mode: "existing", serverUrl });
 });
 
 test("Continue verifies and remembers the instance so setup does not run again", async () => {
@@ -255,11 +263,18 @@ test("a post-session ready app mount is accepted", async () => {
     ]).then(([window]) => window);
 
     await expect(appWindow.getByTestId("shell-root")).toBeVisible();
-    const saved = JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
-    expect(saved).toEqual({
-      mode: "existing",
-      serverUrl: `http://127.0.0.1:${address.port}`,
-    });
+    await expect
+      .poll(async () => {
+        try {
+          return JSON.parse(await readFile(path.join(userData, "setup.json"), "utf8"));
+        } catch {
+          return null;
+        }
+      })
+      .toEqual({
+        mode: "existing",
+        serverUrl: `http://127.0.0.1:${address.port}`,
+      });
   } finally {
     await new Promise<void>((resolve, reject) => {
       ready.close((error) => (error ? reject(error) : resolve()));

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -54,6 +54,7 @@ export default function Layout() {
             />
             <Stack.Screen name="group-thread" options={{ title: "Group" }} />
             <Stack.Screen name="group-settings" options={{ title: "Group settings" }} />
+            <Stack.Screen name="bot-settings" options={{ title: "Chat settings" }} />
             <Stack.Screen name="thread" options={{ title: "Thread" }} />
             <Stack.Screen name="routine" options={{ title: "Routine" }} />
             <Stack.Screen name="computer" options={{ title: "Computer" }} />

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
@@ -18,11 +18,17 @@ import { native } from "../lib/native";
 
 export default function Account() {
   const router = useRouter();
+  const { focus } = useLocalSearchParams<{ focus?: string }>();
   const [me, setMe] = useState<MobileMe | null>(null);
   const [password, setPassword] = useState("");
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [archivedBots, setArchivedBots] = useState<MobileBot[]>([]);
+  const [usage, setUsage] = useState<{
+    runs: number;
+    inputTokens: number;
+    outputTokens: number;
+  } | null>(null);
 
   useEffect(() => {
     void rpc<MobileMe>("me")
@@ -31,7 +37,22 @@ export default function Account() {
     void rpc<MobileBot[]>("bots/listArchived")
       .then(setArchivedBots)
       .catch(() => undefined);
+    void rpc<{ runs: number; inputTokens: number; outputTokens: number }>("usage/summary")
+      .then(setUsage)
+      .catch(() => undefined);
   }, []);
+
+  const usageBlock = (
+    <View accessibilityLabel="Usage and billing" style={styles.profile}>
+      <Text style={styles.settingsTitle}>Usage & Billing</Text>
+      {usage ? (
+        <Text style={styles.email}>
+          {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens this week
+        </Text>
+      ) : null}
+      <Text style={styles.settingsExplanation}>Model spend uses your provider keys.</Text>
+    </View>
+  );
 
   async function restoreBot(botId: string) {
     try {
@@ -85,10 +106,12 @@ export default function Account() {
   return (
     <SafeAreaView edges={["bottom"]} style={styles.screen}>
       <ScrollView contentContainerStyle={styles.content}>
+        {focus === "usage" ? usageBlock : null}
         <View style={styles.profile}>
           <Text style={styles.name}>{me?.name || "Your account"}</Text>
           {me?.email ? <Text style={styles.email}>{me.email}</Text> : null}
         </View>
+        {focus !== "usage" ? usageBlock : null}
 
         <Pressable
           accessibilityRole="button"

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -43,24 +43,14 @@ export default function Account() {
   }, []);
 
   const usageBlock = (
-    <View accessibilityLabel="Usage and billing" style={styles.profile}>
-      <Text style={styles.settingsTitle}>Usage & Billing</Text>
+    <View accessibilityLabel="Usage" style={styles.profile}>
+      <Text style={styles.settingsTitle}>Usage</Text>
       {usage ? (
         <Text style={styles.email}>
           {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens
         </Text>
       ) : null}
       <Text style={styles.settingsExplanation}>Model spend uses your provider keys.</Text>
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel="Open models and billing"
-        disabled={pending}
-        onPress={() => router.push("/models")}
-        hitSlop={8}
-        style={{ marginTop: 10 }}
-      >
-        <Text style={styles.restoreLabel}>Models & billing</Text>
-      </Pressable>
     </View>
   );
 

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -51,6 +51,16 @@ export default function Account() {
         </Text>
       ) : null}
       <Text style={styles.settingsExplanation}>Model spend uses your provider keys.</Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Open models and billing"
+        disabled={pending}
+        onPress={() => router.push("/models")}
+        hitSlop={8}
+        style={{ marginTop: 10 }}
+      >
+        <Text style={styles.restoreLabel}>Models & billing</Text>
+      </Pressable>
     </View>
   );
 

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -47,7 +47,7 @@ export default function Account() {
       <Text style={styles.settingsTitle}>Usage & Billing</Text>
       {usage ? (
         <Text style={styles.email}>
-          {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens this week
+          {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens
         </Text>
       ) : null}
       <Text style={styles.settingsExplanation}>Model spend uses your provider keys.</Text>

--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -50,14 +50,20 @@ export default function BotSettingsScreen() {
         name?: string;
         title?: string;
         description?: string;
+        instructions?: string;
       } = { botId };
       if (profile.name !== bot.name) input.name = profile.name;
       if (profile.title !== bot.title) input.title = profile.title;
-      if (profile.description !== (bot.description ?? "")) input.description = profile.description;
+      if (profile.description !== (bot.description ?? "")) {
+        input.description = profile.description;
+        // Keep instructions in sync with description (same as web BotSettings).
+        input.instructions = profile.instructions;
+      }
       if (computerMode !== bot.computerMode) {
         await rpc("bots/setComputer", { botId, mode: computerMode });
       }
-      if (input.name || input.title || input.description) {
+      // Use key presence so clearing title/description to "" still persists.
+      if (Object.keys(input).length > 1) {
         await rpc("bots/update", input);
       }
       router.back();

--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -1,0 +1,147 @@
+import {
+  BOT_DESCRIPTION_MAX_LENGTH,
+  BOT_NAME_MAX_LENGTH,
+  BOT_TITLE_MAX_LENGTH,
+  type ComputerMode,
+  normalizeCreateBotProfile,
+} from "@rakazo/contracts";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import { Pressable, ScrollView, Text, TextInput } from "react-native";
+import { ComputerModePicker } from "../components/computer-mode-picker";
+import { type MobileBot, rpc } from "../lib/api";
+
+type BotSettingsRecord = MobileBot & {
+  description?: string;
+};
+
+export default function BotSettingsScreen() {
+  const router = useRouter();
+  const { botId } = useLocalSearchParams<{ botId: string }>();
+  const [bot, setBot] = useState<BotSettingsRecord | null>(null);
+  const [name, setName] = useState("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [computerMode, setComputerMode] = useState<ComputerMode>("team");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    if (!botId) return;
+    void rpc<BotSettingsRecord>("bots/get", { botId })
+      .then((next) => {
+        setBot(next);
+        setName(next.name);
+        setTitle(next.title);
+        setDescription(next.description ?? "");
+        setComputerMode(next.computerMode);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : "Could not load bot"));
+  }, [botId]);
+
+  async function save() {
+    if (!botId || !bot || pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const profile = normalizeCreateBotProfile({ name, title, description });
+      const input: {
+        botId: string;
+        name?: string;
+        title?: string;
+        description?: string;
+      } = { botId };
+      if (profile.name !== bot.name) input.name = profile.name;
+      if (profile.title !== bot.title) input.title = profile.title;
+      if (profile.description !== (bot.description ?? "")) input.description = profile.description;
+      if (computerMode !== bot.computerMode) {
+        await rpc("bots/setComputer", { botId, mode: computerMode });
+      }
+      if (input.name || input.title || input.description) {
+        await rpc("bots/update", input);
+      }
+      router.back();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not save bot");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Chat settings" }} />
+      <ScrollView
+        style={{ flex: 1, backgroundColor: "#050506" }}
+        contentContainerStyle={{ padding: 24 }}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+      >
+        <Text style={{ color: "#85858A", fontSize: 14 }}>Name</Text>
+        <TextInput
+          value={name}
+          maxLength={BOT_NAME_MAX_LENGTH}
+          onChangeText={setName}
+          placeholder="Name this bot"
+          placeholderTextColor="#6C6C70"
+          style={{
+            marginTop: 8,
+            backgroundColor: "#1A1A1D",
+            borderRadius: 11,
+            padding: 16,
+            color: "#ECECEE",
+          }}
+        />
+        <Text style={{ color: "#85858A", marginTop: 16, fontSize: 14 }}>Title</Text>
+        <TextInput
+          value={title}
+          maxLength={BOT_TITLE_MAX_LENGTH}
+          onChangeText={setTitle}
+          placeholder="Describe what this bot does"
+          placeholderTextColor="#6C6C70"
+          style={{
+            marginTop: 8,
+            backgroundColor: "#1A1A1D",
+            borderRadius: 11,
+            padding: 16,
+            color: "#ECECEE",
+          }}
+        />
+        <Text style={{ color: "#85858A", marginTop: 16, fontSize: 14 }}>Description</Text>
+        <TextInput
+          value={description}
+          maxLength={BOT_DESCRIPTION_MAX_LENGTH}
+          onChangeText={setDescription}
+          placeholder="What this bot is for"
+          placeholderTextColor="#6C6C70"
+          multiline
+          style={{
+            marginTop: 8,
+            backgroundColor: "#1A1A1D",
+            borderRadius: 11,
+            padding: 16,
+            color: "#ECECEE",
+            minHeight: 120,
+            textAlignVertical: "top",
+          }}
+        />
+        <ComputerModePicker value={computerMode} onChange={setComputerMode} />
+        {error ? <Text style={{ color: "#E65707", marginTop: 16 }}>{error}</Text> : null}
+        <Pressable
+          onPress={() => void save()}
+          disabled={!name.trim() || pending || !bot}
+          style={{
+            marginTop: 24,
+            backgroundColor: "#F1F1EF",
+            borderRadius: 11,
+            padding: 16,
+            alignItems: "center",
+            opacity: !name.trim() || pending || !bot ? 0.4 : 1,
+          }}
+        >
+          <Text style={{ color: "#17171A", fontSize: 16 }}>{pending ? "Saving…" : "Save"}</Text>
+        </Pressable>
+      </ScrollView>
+    </>
+  );
+}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -478,8 +478,9 @@ export default function Thread() {
       void rpc<{ runs: number; inputTokens: number; outputTokens: number }>("usage/summary")
         .then((summary) => {
           Alert.alert(
-            "Usage",
-            `${summary.runs} runs · ${summary.inputTokens + summary.outputTokens} tokens`,
+            "Usage & Billing",
+            `${summary.runs} runs · ${summary.inputTokens + summary.outputTokens} tokens this week.\nModel spend follows your connected provider accounts.`,
+            [{ text: "Account", onPress: () => router.push("/account") }, { text: "OK" }],
           );
         })
         .catch(() => router.push("/account"));

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -442,7 +442,7 @@ export default function Thread() {
     );
     const match = /(?:^|\s)@([\w-]*)$/.exec(value);
     setMentionQuery(match ? (match[1] ?? "") : null);
-    const slashMatch = /(?:^|\s)\/([^\n]*)$/.exec(value);
+    const slashMatch = /^\/([^\n]*)$/.exec(value);
     setSlashQuery(slashMatch ? (slashMatch[1] ?? "") : null);
   }
 
@@ -459,12 +459,12 @@ export default function Thread() {
   }
 
   function insertSkill(skill: { name: string }) {
-    setDraft((current) => current.replace(/\/([^\n]*)$/, `/${skill.name} `));
+    setDraft(`/${skill.name} `);
     setSlashQuery(null);
   }
 
   function runSlashAction(action: "chat-settings" | "settings-general" | "settings-usage") {
-    setDraft((current) => current.replace(/(^|\s)\/([^\n]*)$/, "$1").replace(/\s+$/, ""));
+    setDraft("");
     setSlashQuery(null);
     if (action === "chat-settings") {
       if (inGroup && groupId) {
@@ -472,6 +472,17 @@ export default function Thread() {
       } else {
         showBotActions();
       }
+      return;
+    }
+    if (action === "settings-usage") {
+      void rpc<{ runs: number; inputTokens: number; outputTokens: number }>("usage/summary")
+        .then((summary) => {
+          Alert.alert(
+            "Usage",
+            `${summary.runs} runs · ${summary.inputTokens + summary.outputTokens} tokens`,
+          );
+        })
+        .catch(() => router.push("/account"));
       return;
     }
     router.push("/account");

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -459,7 +459,7 @@ export default function Thread() {
   }
 
   function insertSkill(skill: { name: string }) {
-    setDraft(`/${skill.name} `);
+    setDraft(`/${skill.name}\n`);
     setSlashQuery(null);
   }
 
@@ -474,19 +474,10 @@ export default function Thread() {
       }
       return;
     }
-    if (action === "settings-usage") {
-      void rpc<{ runs: number; inputTokens: number; outputTokens: number }>("usage/summary")
-        .then((summary) => {
-          Alert.alert(
-            "Usage & Billing",
-            `${summary.runs} runs · ${summary.inputTokens + summary.outputTokens} tokens this week.\nModel spend follows your connected provider accounts.`,
-            [{ text: "Account", onPress: () => router.push("/account") }, { text: "OK" }],
-          );
-        })
-        .catch(() => router.push("/account"));
-      return;
-    }
-    router.push("/account");
+    router.push({
+      pathname: "/account",
+      params: action === "settings-usage" ? { focus: "usage" } : undefined,
+    });
   }
 
   async function send() {
@@ -802,12 +793,21 @@ export default function Thread() {
               key={skill.id}
               accessibilityLabel={`Skill ${skill.name}`}
               onPress={() => insertSkill(skill)}
-              style={{ paddingHorizontal: 14, paddingVertical: 10 }}
+              style={{
+                flexDirection: "row",
+                alignItems: "flex-start",
+                gap: 10,
+                paddingHorizontal: 14,
+                paddingVertical: 10,
+              }}
             >
-              <Text style={{ color: "#ECECEE", fontSize: 14 }}>{skill.name}</Text>
-              <Text numberOfLines={1} style={{ color: "#85858A", fontSize: 12.5, marginTop: 2 }}>
-                {skill.description}
-              </Text>
+              <NativeSymbol ios="cube" android="cube-outline" size={16} color="#9A9AA0" />
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={{ color: "#ECECEE", fontSize: 14 }}>{skill.name}</Text>
+                <Text numberOfLines={1} style={{ color: "#85858A", fontSize: 12.5, marginTop: 2 }}>
+                  {skill.description}
+                </Text>
+              </View>
             </Pressable>
           ))}
           {slashActionOptions.map((action) => (
@@ -815,8 +815,15 @@ export default function Thread() {
               key={action.id}
               accessibilityLabel={action.label}
               onPress={() => runSlashAction(action.id)}
-              style={{ paddingHorizontal: 14, paddingVertical: 10 }}
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 10,
+                paddingHorizontal: 14,
+                paddingVertical: 10,
+              }}
             >
+              <NativeSymbol ios="gearshape" android="settings-outline" size={16} color="#9A9AA0" />
               <Text style={{ color: "#ECECEE", fontSize: 14 }}>{action.label}</Text>
             </Pressable>
           ))}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -887,9 +887,16 @@ export default function Thread() {
               }}
             >
               <NativeSymbol ios="cube" android="cube-outline" size={13} color="#B0B0B6" />
-              <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13 }}>
+              <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13, flexShrink: 1 }}>
                 {selectedSkill.name}
               </Text>
+              <Pressable
+                accessibilityLabel={`Remove ${selectedSkill.name}`}
+                hitSlop={8}
+                onPress={() => setSelectedSkill(null)}
+              >
+                <NativeSymbol ios="xmark" android="close" size={12} color="#85858A" />
+              </Pressable>
             </View>
           ) : null}
           {selectedMentions.map((member) => (
@@ -915,9 +922,20 @@ export default function Thread() {
                   backgroundColor: member.color ?? "#85858A",
                 }}
               />
-              <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13 }}>
+              <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13, flexShrink: 1 }}>
                 {member.name}
               </Text>
+              <Pressable
+                accessibilityLabel={`Remove ${member.name}`}
+                hitSlop={8}
+                onPress={() =>
+                  setSelectedMentions((current) =>
+                    current.filter((selected) => selected.botId !== member.botId),
+                  )
+                }
+              >
+                <NativeSymbol ios="xmark" android="close" size={12} color="#85858A" />
+              </Pressable>
             </View>
           ))}
           <TextInput

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -851,15 +851,18 @@ export default function Thread() {
           placeholder="Message…"
           placeholderTextColor="#6C6C70"
           keyboardAppearance="dark"
-          returnKeyType="send"
-          onSubmitEditing={() => void send()}
+          multiline
+          textAlignVertical="center"
+          blurOnSubmit={false}
           style={{
             flex: 1,
             color: "#ECECEE",
             backgroundColor: "#131315",
             borderRadius: 20,
             paddingHorizontal: 14,
-            height: 44,
+            paddingVertical: 10,
+            minHeight: 44,
+            maxHeight: 120,
             writingDirection: "auto",
           }}
         />

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -6,6 +6,9 @@ import {
   isApprovalAskBlock,
   isRunTerminalEvent,
   latestAnswerableAskMessageId,
+  SLASH_ACTIONS,
+  type SlashActionId,
+  serializeComposerPrompt,
 } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -132,13 +135,7 @@ export default function Thread() {
       : [];
   const slashActionOptions =
     slashQuery !== null && mentionQuery === null
-      ? (
-          [
-            { id: "chat-settings", label: "Chat Settings" },
-            { id: "settings-general", label: "Settings: General" },
-            { id: "settings-usage", label: "Settings: Usage" },
-          ] as const
-        ).filter(
+      ? SLASH_ACTIONS.filter(
           (action) =>
             !slashQueryNormalized || action.label.toLowerCase().includes(slashQueryNormalized),
         )
@@ -474,24 +471,18 @@ export default function Thread() {
     if (selectedSkill) setSelectedSkill(null);
   }
 
-  function serializeComposerPrompt(): string {
-    const body = draft.replace(/^\s+/, "");
-    const mentionPrefix = selectedMentions.map((member) => `@${member.name}`).join(" ");
-    const afterSkill = [mentionPrefix, body].filter((part) => part.trim().length > 0).join(" ");
-    if (!selectedSkill) return afterSkill.trimEnd();
-    return afterSkill.trim().length > 0
-      ? `/${selectedSkill.name}\n${afterSkill}`
-      : `/${selectedSkill.name}`;
+  function serializeComposerPromptText(): string {
+    return serializeComposerPrompt(draft, selectedSkill, selectedMentions);
   }
 
-  function runSlashAction(action: "chat-settings" | "settings-general" | "settings-usage") {
+  function runSlashAction(action: SlashActionId) {
     setDraft("");
     setSlashQuery(null);
     if (action === "chat-settings") {
       if (inGroup && groupId) {
         router.push({ pathname: "/group-settings", params: { groupId } });
-      } else {
-        showBotActions();
+      } else if (botId) {
+        router.push({ pathname: "/bot-settings", params: { botId } });
       }
       return;
     }
@@ -506,7 +497,7 @@ export default function Thread() {
     const targetGroupId = groupId;
     if ((!targetBotId && !targetGroupId) || sending) return;
     const attachments = attachmentsForThread(pendingAttachments, threadKey);
-    const text = serializeComposerPrompt().trim();
+    const text = serializeComposerPromptText().trim();
     if (!text && attachments.length === 0) return;
     setSending(true);
     setError(null);

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1,5 +1,5 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/native";
-import type { MessageBlock } from "@rakazo/contracts";
+import type { AgentSkillCatalogEntry, MessageBlock } from "@rakazo/contracts";
 import {
   abortableDelay,
   attachmentsForThread,
@@ -9,6 +9,7 @@ import {
   SLASH_ACTIONS,
   type SlashActionId,
   serializeComposerPrompt,
+  truncateSlashDescription,
 } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -88,17 +89,11 @@ export default function Thread() {
   const [draft, setDraft] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [slashQuery, setSlashQuery] = useState<string | null>(null);
-  const [agentSkills, setAgentSkills] = useState<
-    Array<{ id: string; name: string; description: string }>
-  >([]);
+  const [agentSkills, setAgentSkills] = useState<AgentSkillCatalogEntry[]>([]);
   const [selectedMentions, setSelectedMentions] = useState<
     Array<{ botId: string; name: string; color?: string }>
   >([]);
-  const [selectedSkill, setSelectedSkill] = useState<{
-    id: string;
-    name: string;
-    description: string;
-  } | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<AgentSkillCatalogEntry | null>(null);
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [replyTarget, setReplyTarget] = useState<MobileMessage | null>(null);
   const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
@@ -142,7 +137,7 @@ export default function Thread() {
       : [];
 
   useEffect(() => {
-    void rpc<Array<{ id: string; name: string; description: string }>>("agentSkills/list")
+    void rpc<AgentSkillCatalogEntry[]>("agentSkills/list")
       .then(setAgentSkills)
       .catch(() => setAgentSkills([]));
   }, []);
@@ -457,7 +452,7 @@ export default function Thread() {
     );
   }
 
-  function insertSkill(skill: { id: string; name: string; description: string }) {
+  function insertSkill(skill: AgentSkillCatalogEntry) {
     setSelectedSkill(skill);
     setDraft("");
     setSlashQuery(null);
@@ -491,6 +486,12 @@ export default function Thread() {
       params: action === "settings-usage" ? { focus: "usage" } : undefined,
     });
   }
+
+  const canSend =
+    Boolean(draft.trim()) ||
+    selectedSkill !== null ||
+    selectedMentions.length > 0 ||
+    activePendingAttachments.length > 0;
 
   async function send() {
     const targetBotId = botId;
@@ -818,7 +819,7 @@ export default function Thread() {
               <View style={{ flex: 1, minWidth: 0 }}>
                 <Text style={{ color: "#ECECEE", fontSize: 14 }}>{skill.name}</Text>
                 <Text numberOfLines={1} style={{ color: "#85858A", fontSize: 12.5, marginTop: 2 }}>
-                  {skill.description}
+                  {truncateSlashDescription(skill.description)}
                 </Text>
               </View>
             </Pressable>
@@ -891,7 +892,7 @@ export default function Thread() {
                 {selectedSkill.name}
               </Text>
               <Pressable
-                accessibilityLabel={`Remove ${selectedSkill.name}`}
+                accessibilityLabel={`Remove skill ${selectedSkill.name}`}
                 hitSlop={8}
                 onPress={() => setSelectedSkill(null)}
               >
@@ -926,7 +927,7 @@ export default function Thread() {
                 {member.name}
               </Text>
               <Pressable
-                accessibilityLabel={`Remove ${member.name}`}
+                accessibilityLabel={`Remove mention ${member.name}`}
                 hitSlop={8}
                 onPress={() =>
                   setSelectedMentions((current) =>
@@ -968,13 +969,7 @@ export default function Thread() {
           />
         </View>
         <Pressable
-          disabled={
-            sending ||
-            (!draft.trim() &&
-              !selectedSkill &&
-              selectedMentions.length === 0 &&
-              activePendingAttachments.length === 0)
-          }
+          disabled={sending || !canSend}
           onPress={() => void send()}
           style={{
             backgroundColor: "#F1F1EF",
@@ -983,14 +978,7 @@ export default function Thread() {
             height: 44,
             alignItems: "center",
             justifyContent: "center",
-            opacity:
-              sending ||
-              (!draft.trim() &&
-                !selectedSkill &&
-                selectedMentions.length === 0 &&
-                activePendingAttachments.length === 0)
-                ? 0.5
-                : 1,
+            opacity: sending || !canSend ? 0.5 : 1,
           }}
         >
           <NativeSymbol ios="arrow.up" android="arrow-up" size={18} color="#17171A" />

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -3,7 +3,6 @@ import type { MessageBlock } from "@rakazo/contracts";
 import {
   abortableDelay,
   attachmentsForThread,
-  hasMentionToken,
   isApprovalAskBlock,
   isRunTerminalEvent,
   latestAnswerableAskMessageId,
@@ -89,9 +88,14 @@ export default function Thread() {
   const [agentSkills, setAgentSkills] = useState<
     Array<{ id: string; name: string; description: string }>
   >([]);
-  const [selectedMentions, setSelectedMentions] = useState<Array<{ botId: string; name: string }>>(
-    [],
-  );
+  const [selectedMentions, setSelectedMentions] = useState<
+    Array<{ botId: string; name: string; color?: string }>
+  >([]);
+  const [selectedSkill, setSelectedSkill] = useState<{
+    id: string;
+    name: string;
+    description: string;
+  } | null>(null);
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [replyTarget, setReplyTarget] = useState<MobileMessage | null>(null);
   const [attachmentNotice, setAttachmentNotice] = useState<string | null>(null);
@@ -132,7 +136,7 @@ export default function Thread() {
           [
             { id: "chat-settings", label: "Chat Settings" },
             { id: "settings-general", label: "Settings: General" },
-            { id: "settings-usage", label: "Settings: Usage & Billing" },
+            { id: "settings-usage", label: "Settings: Usage" },
           ] as const
         ).filter(
           (action) =>
@@ -429,6 +433,7 @@ export default function Thread() {
     setDraft("");
     setMentionQuery(null);
     setSlashQuery(null);
+    setSelectedSkill(null);
     setSelectedMentions([]);
     setReplyTarget(null);
     setAttachmentNotice(null);
@@ -437,30 +442,46 @@ export default function Thread() {
 
   function updateDraft(value: string) {
     setDraft(value);
-    setSelectedMentions((current) =>
-      current.filter((member) => hasMentionToken(value, member.name)),
-    );
     const match = /(?:^|\s)@([\w-]*)$/.exec(value);
     setMentionQuery(match ? (match[1] ?? "") : null);
-    const slashMatch = /^\/([^\n]*)$/.exec(value);
+    const slashMatch = selectedSkill === null ? /^\/([^\n]*)$/.exec(value) : null;
     setSlashQuery(slashMatch ? (slashMatch[1] ?? "") : null);
   }
 
-  function insertMention(member: { botId: string; name: string }) {
-    setDraft((current) => current.replace(/@([\w-]*)$/, `@${member.name} `));
-    if (member.botId !== "everyone") {
-      setSelectedMentions((current) =>
-        current.some((selected) => selected.botId === member.botId)
-          ? current
-          : [...current, member],
-      );
-    }
+  function insertMention(member: { botId: string; name: string; color?: string }) {
+    setDraft((current) => current.replace(/@([\w-]*)$/, ""));
     setMentionQuery(null);
+    if (member.botId === "everyone") {
+      setDraft((current) => `${current.replace(/\s+$/, "")} @everyone `.replace(/^\s+/, ""));
+      return;
+    }
+    setSelectedMentions((current) =>
+      current.some((selected) => selected.botId === member.botId) ? current : [...current, member],
+    );
   }
 
-  function insertSkill(skill: { name: string }) {
-    setDraft(`/${skill.name}\n`);
+  function insertSkill(skill: { id: string; name: string; description: string }) {
+    setSelectedSkill(skill);
+    setDraft("");
     setSlashQuery(null);
+  }
+
+  function removeLastChip() {
+    if (selectedMentions.length > 0) {
+      setSelectedMentions((current) => current.slice(0, -1));
+      return;
+    }
+    if (selectedSkill) setSelectedSkill(null);
+  }
+
+  function serializeComposerPrompt(): string {
+    const body = draft.replace(/^\s+/, "");
+    const mentionPrefix = selectedMentions.map((member) => `@${member.name}`).join(" ");
+    const afterSkill = [mentionPrefix, body].filter((part) => part.trim().length > 0).join(" ");
+    if (!selectedSkill) return afterSkill.trimEnd();
+    return afterSkill.trim().length > 0
+      ? `/${selectedSkill.name}\n${afterSkill}`
+      : `/${selectedSkill.name}`;
   }
 
   function runSlashAction(action: "chat-settings" | "settings-general" | "settings-usage") {
@@ -485,7 +506,7 @@ export default function Thread() {
     const targetGroupId = groupId;
     if ((!targetBotId && !targetGroupId) || sending) return;
     const attachments = attachmentsForThread(pendingAttachments, threadKey);
-    const text = draft.trim();
+    const text = serializeComposerPrompt().trim();
     if (!text && attachments.length === 0) return;
     setSending(true);
     setError(null);
@@ -526,6 +547,7 @@ export default function Thread() {
         setDraft("");
         setMentionQuery(null);
         setSlashQuery(null);
+        setSelectedSkill(null);
         setSelectedMentions([]);
         setReplyTarget(null);
         setAttachmentNotice(null);
@@ -829,7 +851,7 @@ export default function Thread() {
           ))}
         </View>
       ) : null}
-      <View style={{ flexDirection: "row", gap: 8, marginTop: 16 }}>
+      <View style={{ flexDirection: "row", gap: 8, marginTop: 16, alignItems: "flex-end" }}>
         <Pressable
           accessibilityLabel="Attach file"
           onPress={showAttachMenu}
@@ -845,29 +867,105 @@ export default function Thread() {
         >
           <NativeSymbol ios="plus" android="add" size={18} color="#9A9AA0" />
         </Pressable>
-        <TextInput
-          value={draft}
-          onChangeText={updateDraft}
-          placeholder="Message…"
-          placeholderTextColor="#6C6C70"
-          keyboardAppearance="dark"
-          multiline
-          textAlignVertical="center"
-          blurOnSubmit={false}
+        <View
           style={{
             flex: 1,
-            color: "#ECECEE",
+            flexDirection: "row",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 6,
             backgroundColor: "#131315",
             borderRadius: 20,
-            paddingHorizontal: 14,
-            paddingVertical: 10,
+            paddingHorizontal: 10,
+            paddingVertical: 8,
             minHeight: 44,
-            maxHeight: 120,
-            writingDirection: "auto",
           }}
-        />
+        >
+          {selectedSkill ? (
+            <View
+              testID="skill-chip"
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                backgroundColor: "#1C1C1F",
+                borderRadius: 999,
+                paddingHorizontal: 10,
+                paddingVertical: 5,
+                maxWidth: "100%",
+              }}
+            >
+              <NativeSymbol ios="cube" android="cube-outline" size={13} color="#B0B0B6" />
+              <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13 }}>
+                {selectedSkill.name}
+              </Text>
+            </View>
+          ) : null}
+          {selectedMentions.map((member) => (
+            <View
+              key={member.botId}
+              testID="mention-chip"
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                backgroundColor: "#1C1C1F",
+                borderRadius: 999,
+                paddingHorizontal: 10,
+                paddingVertical: 5,
+                maxWidth: "100%",
+              }}
+            >
+              <View
+                style={{
+                  width: 14,
+                  height: 14,
+                  borderRadius: 4,
+                  backgroundColor: member.color ?? "#85858A",
+                }}
+              />
+              <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13 }}>
+                {member.name}
+              </Text>
+            </View>
+          ))}
+          <TextInput
+            value={draft}
+            onChangeText={updateDraft}
+            onKeyPress={(event) => {
+              if (
+                event.nativeEvent.key === "Backspace" &&
+                draft.length === 0 &&
+                (selectedSkill !== null || selectedMentions.length > 0)
+              ) {
+                removeLastChip();
+              }
+            }}
+            placeholder={selectedSkill || selectedMentions.length ? undefined : "Message…"}
+            placeholderTextColor="#6C6C70"
+            keyboardAppearance="dark"
+            multiline
+            textAlignVertical="center"
+            blurOnSubmit={false}
+            style={{
+              flexGrow: 1,
+              flexShrink: 1,
+              minWidth: 96,
+              color: "#ECECEE",
+              paddingVertical: 2,
+              maxHeight: 100,
+              writingDirection: "auto",
+            }}
+          />
+        </View>
         <Pressable
-          disabled={sending || (!draft.trim() && activePendingAttachments.length === 0)}
+          disabled={
+            sending ||
+            (!draft.trim() &&
+              !selectedSkill &&
+              selectedMentions.length === 0 &&
+              activePendingAttachments.length === 0)
+          }
           onPress={() => void send()}
           style={{
             backgroundColor: "#F1F1EF",
@@ -876,7 +974,14 @@ export default function Thread() {
             height: 44,
             alignItems: "center",
             justifyContent: "center",
-            opacity: sending || (!draft.trim() && activePendingAttachments.length === 0) ? 0.5 : 1,
+            opacity:
+              sending ||
+              (!draft.trim() &&
+                !selectedSkill &&
+                selectedMentions.length === 0 &&
+                activePendingAttachments.length === 0)
+                ? 0.5
+                : 1,
           }}
         >
           <NativeSymbol ios="arrow.up" android="arrow-up" size={18} color="#17171A" />

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -85,6 +85,10 @@ export default function Thread() {
   const [snap, setSnap] = useState<MobileSnapshot | null>(null);
   const [draft, setDraft] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [slashQuery, setSlashQuery] = useState<string | null>(null);
+  const [agentSkills, setAgentSkills] = useState<
+    Array<{ id: string; name: string; description: string }>
+  >([]);
   const [selectedMentions, setSelectedMentions] = useState<Array<{ botId: string; name: string }>>(
     [],
   );
@@ -109,6 +113,38 @@ export default function Thread() {
             : []),
         ].slice(0, 8)
       : [];
+  const slashQueryNormalized = slashQuery?.trim().toLowerCase() ?? null;
+  const slashSkillOptions =
+    slashQuery !== null && mentionQuery === null
+      ? agentSkills
+          .filter((skill) => {
+            if (!slashQueryNormalized) return true;
+            return (
+              skill.name.toLowerCase().includes(slashQueryNormalized) ||
+              skill.description.toLowerCase().includes(slashQueryNormalized)
+            );
+          })
+          .slice(0, 8)
+      : [];
+  const slashActionOptions =
+    slashQuery !== null && mentionQuery === null
+      ? (
+          [
+            { id: "chat-settings", label: "Chat Settings" },
+            { id: "settings-general", label: "Settings: General" },
+            { id: "settings-usage", label: "Settings: Usage & Billing" },
+          ] as const
+        ).filter(
+          (action) =>
+            !slashQueryNormalized || action.label.toLowerCase().includes(slashQueryNormalized),
+        )
+      : [];
+
+  useEffect(() => {
+    void rpc<Array<{ id: string; name: string; description: string }>>("agentSkills/list")
+      .then(setAgentSkills)
+      .catch(() => setAgentSkills([]));
+  }, []);
 
   function isCurrentTarget(targetBotId: string | undefined, targetGroupId: string | undefined) {
     return activeBotId.current === targetBotId && activeGroupId.current === targetGroupId;
@@ -392,6 +428,7 @@ export default function Thread() {
     setPendingAttachments((current) => attachmentsForThread(current, threadKey));
     setDraft("");
     setMentionQuery(null);
+    setSlashQuery(null);
     setSelectedMentions([]);
     setReplyTarget(null);
     setAttachmentNotice(null);
@@ -405,6 +442,8 @@ export default function Thread() {
     );
     const match = /(?:^|\s)@([\w-]*)$/.exec(value);
     setMentionQuery(match ? (match[1] ?? "") : null);
+    const slashMatch = /(?:^|\s)\/([^\n]*)$/.exec(value);
+    setSlashQuery(slashMatch ? (slashMatch[1] ?? "") : null);
   }
 
   function insertMention(member: { botId: string; name: string }) {
@@ -417,6 +456,25 @@ export default function Thread() {
       );
     }
     setMentionQuery(null);
+  }
+
+  function insertSkill(skill: { name: string }) {
+    setDraft((current) => current.replace(/\/([^\n]*)$/, `/${skill.name} `));
+    setSlashQuery(null);
+  }
+
+  function runSlashAction(action: "chat-settings" | "settings-general" | "settings-usage") {
+    setDraft((current) => current.replace(/(^|\s)\/([^\n]*)$/, "$1").replace(/\s+$/, ""));
+    setSlashQuery(null);
+    if (action === "chat-settings") {
+      if (inGroup && groupId) {
+        router.push({ pathname: "/group-settings", params: { groupId } });
+      } else {
+        showBotActions();
+      }
+      return;
+    }
+    router.push("/account");
   }
 
   async function send() {
@@ -464,6 +522,7 @@ export default function Thread() {
       if (isCurrentTarget(targetBotId, targetGroupId)) {
         setDraft("");
         setMentionQuery(null);
+        setSlashQuery(null);
         setSelectedMentions([]);
         setReplyTarget(null);
         setAttachmentNotice(null);
@@ -710,6 +769,43 @@ export default function Thread() {
               style={{ paddingHorizontal: 14, paddingVertical: 10 }}
             >
               <Text style={{ color: "#ECECEE", fontSize: 14 }}>@{member.name}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+      {slashSkillOptions.length || slashActionOptions.length ? (
+        <View
+          testID="slash-picker"
+          style={{
+            marginTop: 12,
+            borderRadius: 14,
+            borderWidth: 1,
+            borderColor: "#26262A",
+            backgroundColor: "#17171A",
+            overflow: "hidden",
+          }}
+        >
+          {slashSkillOptions.map((skill) => (
+            <Pressable
+              key={skill.id}
+              accessibilityLabel={`Skill ${skill.name}`}
+              onPress={() => insertSkill(skill)}
+              style={{ paddingHorizontal: 14, paddingVertical: 10 }}
+            >
+              <Text style={{ color: "#ECECEE", fontSize: 14 }}>{skill.name}</Text>
+              <Text numberOfLines={1} style={{ color: "#85858A", fontSize: 12.5, marginTop: 2 }}>
+                {skill.description}
+              </Text>
+            </Pressable>
+          ))}
+          {slashActionOptions.map((action) => (
+            <Pressable
+              key={action.id}
+              accessibilityLabel={action.label}
+              onPress={() => runSlashAction(action.id)}
+              style={{ paddingHorizontal: 14, paddingVertical: 10 }}
+            >
+              <Text style={{ color: "#ECECEE", fontSize: 14 }}>{action.label}</Text>
             </Pressable>
           ))}
         </View>

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -942,6 +942,7 @@ export default function Thread() {
           <TextInput
             value={draft}
             onChangeText={updateDraft}
+            accessibilityLabel="Message"
             onKeyPress={(event) => {
               if (
                 event.nativeEvent.key === "Backspace" &&

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -348,6 +348,9 @@ export function applyMobileThreadEvent(
     };
   }
   if (event.type === "run.waiting_input") {
+    const progressId = progressMessageId(event);
+    const messages = prev.messages.filter((message) => message.id !== progressId);
+    const progressCleared = messages.length !== prev.messages.length;
     const runChanged = Boolean(
       prev.run && prev.run.id === event.runId && prev.run.status !== "waiting_input",
     );
@@ -355,7 +358,7 @@ export function applyMobileThreadEvent(
       (candidate) => candidate.id === event.runId && candidate.status !== "waiting_input",
     );
     const cursor = event.seq ?? prev.cursor;
-    if (!runChanged && !activeRunChanged) {
+    if (!runChanged && !activeRunChanged && !progressCleared) {
       return cursor === prev.cursor ? prev : { ...prev, cursor };
     }
     const run = runChanged && prev.run ? { ...prev.run, status: "waiting_input" } : prev.run;
@@ -364,7 +367,7 @@ export function applyMobileThreadEvent(
           candidate.id === event.runId ? { ...candidate, status: "waiting_input" } : candidate,
         )
       : prev.activeRuns;
-    return { ...prev, cursor, run, activeRuns };
+    return { ...prev, cursor, run, activeRuns, messages };
   }
   if (isRunTerminalEvent(event)) {
     const activeRuns = prev.activeRuns?.filter((candidate) => candidate.id !== event.runId);

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -15,7 +15,7 @@ async function createBot(page: import("@playwright/test").Page, name: string) {
   await page.locator("label:has-text('Name') input").fill(name);
   await page.getByRole("button", { name: "Create", exact: true }).click();
   await expect(botList.getByRole("button", { name: new RegExp(`^${name}`) })).toBeVisible();
-  await expect(page.getByPlaceholder(`Message ${name}`)).toBeVisible();
+  await expect(page.getByRole("textbox", { name: `Message ${name}` })).toBeVisible();
   await page.waitForURL(/\/app\/[^/]+$/);
   return activeBotId(page);
 }
@@ -56,7 +56,7 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   });
   await page.reload();
   await expect(page).toHaveURL(groupUrl);
-  await expect(page.getByPlaceholder("Message Draft team")).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Message Draft team" })).toBeVisible();
 
   const groups = await rpc<
     Array<{
@@ -201,7 +201,7 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await expect(page).toHaveURL(new RegExp(`/app/g/${reviewGroup.id}$`));
   await expect(page.getByTestId("transcript")).not.toContainText("Answered: Paris");
   releaseReviewSnapshot();
-  await expect(page.getByPlaceholder("Message Review team")).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Message Review team" })).toBeVisible();
   await page.unroute("**/rpc/threads/get");
   await sidebar.getByRole("button", { name: /Draft team/ }).click();
   await expect(page.getByText("Answered: Paris", { exact: true })).toBeVisible();
@@ -232,5 +232,5 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await rpc(page, "groups/remove", { groupId: reviewGroup.id });
   await page.goto(`/app/g/${reviewGroup.id}`);
   await page.waitForURL(/\/app\/(?!g\/)[^/]+$/);
-  await expect(page.getByPlaceholder(/Message/)).toBeVisible();
+  await expect(page.getByRole("textbox", { name: /Message/ })).toBeVisible();
 });

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -127,13 +127,13 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await page.unroute("**/rpc/groups/update");
   await desktopSettings.getByRole("button", { name: "Save", exact: true }).click();
 
-  await page.getByPlaceholder("Message Draft team").fill("@Researcher unfinished draft");
+  await page.getByRole("textbox", { name: "Message Draft team" }).fill("@Researcher unfinished draft");
   await sidebar.getByRole("button", { name: /Review team/ }).click();
-  await expect(page.getByPlaceholder("Message Review team")).toHaveValue("");
+  await expect(page.getByRole("textbox", { name: "Message Review team" })).toHaveValue("");
   await sidebar.getByRole("button", { name: /Draft team/ }).click();
-  await expect(page.getByPlaceholder("Message Draft team")).toHaveValue("");
+  await expect(page.getByRole("textbox", { name: "Message Draft team" })).toHaveValue("");
 
-  const composer = page.getByPlaceholder("Message Draft team");
+  const composer = page.getByRole("textbox", { name: "Message Draft team" });
   await composer.fill("@Res");
   await captureScreenshot(page, testInfo, "group-mention-picker");
   await page.getByRole("button", { name: "@Research Writer", exact: true }).click();

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -164,7 +164,12 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   expect(speechRequest.postDataJSON()).toMatchObject({ botId: researcherId });
   await captureScreenshot(page, testInfo, "group-transcript");
 
-  await composer.fill("@Research Writer ask me which city to use");
+  await composer.fill("@Res");
+  await page.getByRole("button", { name: "@Research Writer", exact: true }).click();
+  await expect(
+    page.getByTestId("mention-chip").filter({ hasText: "Research Writer" }),
+  ).toBeVisible();
+  await composer.fill("ask me which city to use");
   await composer.press("Enter");
   await expect(page.getByText("Which city should I use?", { exact: true })).toBeVisible({
     timeout: 60_000,

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -137,9 +137,13 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await composer.fill("@Res");
   await captureScreenshot(page, testInfo, "group-mention-picker");
   await page.getByRole("button", { name: "@Research Writer", exact: true }).click();
-  await composer.fill(`${await composer.inputValue()} turn the sources into a draft. @Res`);
+  await expect(
+    page.getByTestId("mention-chip").filter({ hasText: "Research Writer" }),
+  ).toBeVisible();
+  await composer.fill("turn the sources into a draft. @Res");
   await page.getByRole("button", { name: "@Researcher", exact: true }).click();
-  await composer.fill(`${await composer.inputValue()} gather sources.`);
+  await expect(page.getByTestId("mention-chip").filter({ hasText: "Researcher" })).toBeVisible();
+  await composer.fill(`${await composer.inputValue()}gather sources.`);
   await composer.press("Enter");
 
   await expect(page.getByTestId("transcript")).toContainText(/handled|on it|gather/i, {

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -171,9 +171,18 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   ).toBeVisible();
   await composer.fill("ask me which city to use");
   await composer.press("Enter");
-  await expect(page.getByText("Which city should I use?", { exact: true })).toBeVisible({
+  // threads/get / member status can observe waiting_input before realtime paints the ask card.
+  await expect(page.getByRole("button", { name: /Research Writer waiting_input/ })).toBeVisible({
     timeout: 60_000,
   });
+  const cityAsk = page.locator("p").filter({ hasText: /^Which city should I use\?$/ });
+  if ((await cityAsk.count()) === 0) {
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("textbox", { name: "Message Draft team" })).toBeVisible({
+      timeout: 15_000,
+    });
+  }
+  await expect(cityAsk).toBeVisible({ timeout: 15_000 });
   await page.getByRole("button", { name: "Edit first" }).click();
   await page.getByRole("textbox", { name: "Answer" }).fill("Paris");
   await page.getByRole("button", { name: "Send answer" }).click();

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -161,7 +161,7 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await composer.fill("@Research Writer ask me which city to use");
   await composer.press("Enter");
   await expect(page.getByText("Which city should I use?", { exact: true })).toBeVisible({
-    timeout: 30_000,
+    timeout: 60_000,
   });
   await page.getByRole("button", { name: "Edit first" }).click();
   await page.getByRole("textbox", { name: "Answer" }).fill("Paris");

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -127,7 +127,9 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await page.unroute("**/rpc/groups/update");
   await desktopSettings.getByRole("button", { name: "Save", exact: true }).click();
 
-  await page.getByRole("textbox", { name: "Message Draft team" }).fill("@Researcher unfinished draft");
+  await page
+    .getByRole("textbox", { name: "Message Draft team" })
+    .fill("@Researcher unfinished draft");
   await sidebar.getByRole("button", { name: /Review team/ }).click();
   await expect(page.getByRole("textbox", { name: "Message Review team" })).toHaveValue("");
   await sidebar.getByRole("button", { name: /Draft team/ }).click();

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -26,7 +26,7 @@ test("composer / picker lists skills above actions", async ({ page }, testInfo) 
   await expect(skillButton).toBeVisible();
   await expect(chatSettings).toBeVisible();
   await expect(picker.getByRole("button", { name: "Settings: General" })).toBeVisible();
-  await expect(picker.getByRole("button", { name: "Settings: Usage & Billing" })).toBeVisible();
+  await expect(picker.getByRole("button", { name: "Settings: Usage" })).toBeVisible();
 
   const skillBox = skillButton.boundingBox();
   const actionBox = chatSettings.boundingBox();
@@ -40,11 +40,20 @@ test("composer / picker lists skills above actions", async ({ page }, testInfo) 
   await captureScreenshot(page, testInfo, "slash-skills-picker");
 
   await skillButton.click();
-  await expect(composer).toHaveValue("/Daily standup\n");
+  await expect(page.getByTestId("slash-picker")).toHaveCount(0);
+  const skillChip = page.getByTestId("skill-chip");
+  await expect(skillChip).toBeVisible();
+  await expect(skillChip).toContainText("Daily standup");
+  await expect(composer).toHaveValue("");
+  await composer.fill("focus on blockers");
   await captureScreenshot(page, testInfo, "slash-skills-inserted");
 
   await composer.fill("hello /");
   await expect(page.getByTestId("slash-picker")).toHaveCount(0);
+
+  await composer.fill("");
+  await page.keyboard.press("Backspace");
+  await expect(page.getByTestId("skill-chip")).toHaveCount(0);
 
   await composer.fill("@");
   await expect(page.getByTestId("slash-picker")).toHaveCount(0);

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -39,7 +39,7 @@ test("composer / picker lists skills above actions", async ({ page }) => {
   await expect(skillButton).toContainText("Prepare a concise standup");
 
   await skillButton.click();
-  await expect(composer).toHaveValue("/Daily standup ");
+  await expect(composer).toHaveValue("/Daily standup\n");
 
   await composer.fill("hello /");
   await expect(page.getByTestId("slash-picker")).toHaveCount(0);

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { completeOnboarding, rpc, signup } from "./helpers";
+
+test("composer / picker lists skills above actions", async ({ page }) => {
+  const stamp = Date.now();
+  await signup(page, `slash-skills-${stamp}@rakazo.test`, "password12", "Slash Skills");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  await rpc(page, "agentSkills/create", {
+    name: "Daily standup",
+    description:
+      "Prepare a concise standup update from recent work. Use when the user asks for standup notes.",
+    body: "1. Summarize wins.\n2. List blockers.",
+  });
+
+  const composer = page.getByPlaceholder(/^Message /);
+  await expect(composer).toBeVisible();
+  await composer.fill("/");
+
+  const picker = page.getByTestId("slash-picker");
+  await expect(picker).toBeVisible();
+  const skillButton = picker.getByRole("button", { name: "Skill Daily standup" });
+  const chatSettings = picker.getByRole("button", { name: "Chat Settings" });
+  await expect(skillButton).toBeVisible();
+  await expect(chatSettings).toBeVisible();
+  await expect(picker.getByRole("button", { name: "Settings: General" })).toBeVisible();
+  await expect(picker.getByRole("button", { name: "Settings: Usage & Billing" })).toBeVisible();
+
+  const skillBox = skillButton.boundingBox();
+  const actionBox = chatSettings.boundingBox();
+  const skill = await skillBox;
+  const action = await actionBox;
+  expect(skill).toBeTruthy();
+  expect(action).toBeTruthy();
+  expect(skill!.y).toBeLessThan(action!.y);
+
+  await expect(skillButton).toContainText("Prepare a concise standup");
+
+  await skillButton.click();
+  await expect(composer).toHaveValue("/Daily standup ");
+
+  await composer.fill("@");
+  await expect(page.getByTestId("slash-picker")).toHaveCount(0);
+});

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -15,10 +15,7 @@ test("composer / picker lists skills above actions", async ({ page }, testInfo) 
     body: "1. Summarize wins.\n2. List blockers.",
   });
 
-<<<<<<< HEAD
   // aria-label stays available when skill/mention chips hide the placeholder.
-=======
->>>>>>> 9d0e4da (Locate composer by aria-label after skill/mention chips)
   const composer = page.getByRole("textbox", { name: /^Message/ });
   await expect(composer).toBeVisible();
   await composer.fill("/");

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -15,7 +15,10 @@ test("composer / picker lists skills above actions", async ({ page }, testInfo) 
     body: "1. Summarize wins.\n2. List blockers.",
   });
 
+<<<<<<< HEAD
   // aria-label stays available when skill/mention chips hide the placeholder.
+=======
+>>>>>>> 9d0e4da (Locate composer by aria-label after skill/mention chips)
   const composer = page.getByRole("textbox", { name: /^Message/ });
   await expect(composer).toBeVisible();
   await composer.fill("/");

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -29,13 +29,11 @@ test("composer / picker lists skills above actions", async ({ page }, testInfo) 
   await expect(picker.getByRole("button", { name: "Settings: General" })).toBeVisible();
   await expect(picker.getByRole("button", { name: "Settings: Usage" })).toBeVisible();
 
-  const skillBox = skillButton.boundingBox();
-  const actionBox = chatSettings.boundingBox();
-  const skill = await skillBox;
-  const action = await actionBox;
-  expect(skill).toBeTruthy();
-  expect(action).toBeTruthy();
-  expect(skill!.y).toBeLessThan(action!.y);
+  const skillBox = await skillButton.boundingBox();
+  const actionBox = await chatSettings.boundingBox();
+  expect(skillBox).toBeTruthy();
+  expect(actionBox).toBeTruthy();
+  expect(skillBox!.y).toBeLessThan(actionBox!.y);
 
   await expect(skillButton).toContainText("Prepare a concise standup");
   await captureScreenshot(page, testInfo, "slash-skills-picker");
@@ -52,8 +50,7 @@ test("composer / picker lists skills above actions", async ({ page }, testInfo) 
   await composer.fill("hello /");
   await expect(page.getByTestId("slash-picker")).toHaveCount(0);
 
-  await composer.fill("");
-  await page.keyboard.press("Backspace");
+  await page.getByRole("button", { name: "Remove skill Daily standup" }).click();
   await expect(page.getByTestId("skill-chip")).toHaveCount(0);
 
   await composer.fill("@");

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -15,7 +15,8 @@ test("composer / picker lists skills above actions", async ({ page }, testInfo) 
     body: "1. Summarize wins.\n2. List blockers.",
   });
 
-  const composer = page.getByPlaceholder(/^Message /);
+  // aria-label stays available when skill/mention chips hide the placeholder.
+  const composer = page.getByRole("textbox", { name: /^Message/ });
   await expect(composer).toBeVisible();
   await composer.fill("/");
 

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -41,6 +41,9 @@ test("composer / picker lists skills above actions", async ({ page }) => {
   await skillButton.click();
   await expect(composer).toHaveValue("/Daily standup ");
 
+  await composer.fill("hello /");
+  await expect(page.getByTestId("slash-picker")).toHaveCount(0);
+
   await composer.fill("@");
   await expect(page.getByTestId("slash-picker")).toHaveCount(0);
 });

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
-import { completeOnboarding, rpc, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, rpc, signup } from "./helpers";
 
-test("composer / picker lists skills above actions", async ({ page }) => {
+test("composer / picker lists skills above actions", async ({ page }, testInfo) => {
   const stamp = Date.now();
   await signup(page, `slash-skills-${stamp}@rakazo.test`, "password12", "Slash Skills");
   await completeOnboarding(page);
@@ -37,9 +37,11 @@ test("composer / picker lists skills above actions", async ({ page }) => {
   expect(skill!.y).toBeLessThan(action!.y);
 
   await expect(skillButton).toContainText("Prepare a concise standup");
+  await captureScreenshot(page, testInfo, "slash-skills-picker");
 
   await skillButton.click();
   await expect(composer).toHaveValue("/Daily standup\n");
+  await captureScreenshot(page, testInfo, "slash-skills-inserted");
 
   await composer.fill("hello /");
   await expect(page.getByTestId("slash-picker")).toHaveCount(0);

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -60,6 +60,22 @@ describe("thread event reduction", () => {
     expect(next.olderCursor).toBeNull();
   });
 
+  it("ignores a stale thread refresh that is behind the live cursor", () => {
+    const live: ThreadSnapshot = {
+      ...snapshot([
+        message("ask-1", [{ kind: "ask", text: "Which city?", status: "pending" }], 11),
+      ]),
+      cursor: 12,
+    };
+    const stale: ThreadSnapshot = {
+      ...snapshot([message("m-1", [{ kind: "text", text: "older" }], 1)]),
+      cursor: 8,
+    };
+
+    expect(mergeThreadSnapshot(live, stale)).toBe(live);
+    expect(mergeThreadSnapshot(live, stale, true)).toBe(live);
+  });
+
   it("accumulates progress deltas and keeps only the active progress message", () => {
     const stale = message("progress:older", [{ kind: "progress", text: "old run" }]);
     const initial = snapshot([stale]);
@@ -518,6 +534,29 @@ describe("thread event reduction", () => {
     expect(
       reduceThreadSnapshot(waiting, event({ type: "run.waiting_input", seq: 7, runId: "run-1" })),
     ).toBe(waiting);
+  });
+
+  it("clears live progress when a run waits for input", () => {
+    const run = threadRun("run-1");
+    const initial: ThreadSnapshot = {
+      ...snapshot([
+        {
+          ...message("progress:run-1", [{ kind: "progress", text: "working…" }]),
+          runId: run.id,
+        },
+      ]),
+      run,
+      activeRuns: [run],
+    };
+
+    const waiting = reduceThreadSnapshot(
+      initial,
+      event({ type: "run.waiting_input", seq: 6, runId: run.id }),
+    );
+
+    expect(waiting?.messages).toEqual([]);
+    expect(waiting?.run?.status).toBe("waiting_input");
+    expect(waiting?.activeRuns?.[0]?.status).toBe("waiting_input");
   });
 
   it("accumulates tool-call steps and collapses repeats into a count", () => {

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -261,7 +261,12 @@ export function reduceThreadSnapshot(
       event.type === "run.waiting_input" && prev.messages.some((message) => message.id === liveId)
         ? prev.messages.filter((message) => message.id !== liveId)
         : prev.messages;
-    if (!runChanged && !activeRunChanged && members === prev.members && messages === prev.messages) {
+    if (
+      !runChanged &&
+      !activeRunChanged &&
+      members === prev.members &&
+      messages === prev.messages
+    ) {
       return prev;
     }
     return {

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -98,6 +98,9 @@ export function mergeThreadSnapshot(
   next: ThreadSnapshot,
   preserveLoadedHistory = false,
 ): ThreadSnapshot {
+  // A threads.get started before SSE caught up must not wipe newer live state
+  // (e.g. ask cards applied after send's post-refresh request was already in flight).
+  if (prev && prev.threadId === next.threadId && prev.cursor > next.cursor) return prev;
   return mergeThreadHistory(prev, next, preserveLoadedHistory);
 }
 
@@ -251,11 +254,21 @@ export function reduceThreadSnapshot(
       (candidate) => candidate.id === event.runId && candidate.status !== status,
     );
     const members = updateMemberStatus(prev.members, event.botId, status);
-    if (!runChanged && !activeRunChanged && members === prev.members) return prev;
+    // Ask pauses delete progress events server-side; drop the live bubble so a missed
+    // message.created cannot leave "working…" stuck next to waiting_input.
+    const liveId = progressMessageId(event);
+    const messages =
+      event.type === "run.waiting_input" && prev.messages.some((message) => message.id === liveId)
+        ? prev.messages.filter((message) => message.id !== liveId)
+        : prev.messages;
+    if (!runChanged && !activeRunChanged && members === prev.members && messages === prev.messages) {
+      return prev;
+    }
     return {
       ...prev,
       cursor: event.seq,
       members,
+      messages,
       run: runChanged && prev.run ? { ...prev.run, status } : prev.run,
       activeRuns: activeRunChanged
         ? prev.activeRuns?.map((candidate) =>

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -4,13 +4,18 @@ import { ApprovalRulesSettings } from "../components/ApprovalRulesSettings";
 export function AccountSettingsOverlay({
   email,
   name,
+  usage,
+  focusUsage,
   onClose,
 }: {
   email?: string | null;
   name: string;
+  usage?: { runs: number; inputTokens: number; outputTokens: number } | null;
+  focusUsage?: boolean;
   onClose: () => void;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const usageRef = useRef<HTMLElement>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
@@ -21,12 +26,13 @@ export function AccountSettingsOverlay({
       if (event.key === "Escape") onCloseRef.current();
     }
     window.addEventListener("keydown", handleKeyDown);
-    panelRef.current?.focus();
+    if (focusUsage) usageRef.current?.focus();
+    else panelRef.current?.focus();
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
       previousFocus?.focus();
     };
-  }, []);
+  }, [focusUsage]);
 
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-[rgba(4,4,5,.62)] p-4 sm:p-10">
@@ -62,6 +68,27 @@ export function AccountSettingsOverlay({
           <h3 className="text-[15px] font-medium text-[#ECECEE]">Account</h3>
           <p className="mt-3 text-[14px] text-[#C9C9CE]">{name}</p>
           {email ? <p className="mt-1 text-[13px] text-[#7A7A80]">{email}</p> : null}
+        </section>
+
+        <section
+          ref={usageRef}
+          tabIndex={-1}
+          data-testid="usage-billing-settings"
+          className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4 outline-none"
+        >
+          <h3 className="text-[15px] font-medium text-[#ECECEE]">Usage & Billing</h3>
+          {usage ? (
+            <p className="mt-3 text-[14px] text-[#C9C9CE]">
+              {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens this week
+            </p>
+          ) : (
+            <p className="mt-3 text-[14px] text-[#7A7A80]">
+              {focusUsage ? "Loading usage…" : "Weekly usage appears here when loaded."}
+            </p>
+          )}
+          <p className="mt-2 text-[12.5px] text-[#6C6C70]">
+            Model spend follows your connected provider accounts.
+          </p>
         </section>
 
         <details

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -79,7 +79,7 @@ export function AccountSettingsOverlay({
           <h3 className="text-[15px] font-medium text-[#ECECEE]">Usage & Billing</h3>
           {usage ? (
             <p className="mt-3 text-[14px] text-[#C9C9CE]">
-              {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens this week
+              {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens
             </p>
           ) : null}
           <p className={`text-[12.5px] text-[#6C6C70] ${usage ? "mt-2" : "mt-3"}`}>

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -6,12 +6,14 @@ export function AccountSettingsOverlay({
   name,
   usage,
   focusUsage,
+  onOpenModels,
   onClose,
 }: {
   email?: string | null;
   name: string;
   usage?: { runs: number; inputTokens: number; outputTokens: number } | null;
   focusUsage?: boolean;
+  onOpenModels?: () => void;
   onClose: () => void;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
@@ -85,6 +87,16 @@ export function AccountSettingsOverlay({
           <p className={`text-[12.5px] text-[#6C6C70] ${usage ? "mt-2" : "mt-3"}`}>
             Model spend uses your provider keys.
           </p>
+          {onOpenModels ? (
+            <button
+              type="button"
+              aria-label="Open models and billing"
+              onClick={onOpenModels}
+              className="mt-3 text-[13.5px] text-[#C9C9CE] underline-offset-2 hover:underline"
+            >
+              Models & billing
+            </button>
+          ) : null}
         </div>
 
         <details

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -6,14 +6,12 @@ export function AccountSettingsOverlay({
   name,
   usage,
   focusUsage,
-  onOpenModels,
   onClose,
 }: {
   email?: string | null;
   name: string;
   usage?: { runs: number; inputTokens: number; outputTokens: number } | null;
   focusUsage?: boolean;
-  onOpenModels?: () => void;
   onClose: () => void;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
@@ -75,10 +73,10 @@ export function AccountSettingsOverlay({
         <div
           ref={usageRef}
           tabIndex={-1}
-          data-testid="usage-billing-settings"
+          data-testid="usage-settings"
           className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4 outline-none"
         >
-          <h3 className="text-[15px] font-medium text-[#ECECEE]">Usage & Billing</h3>
+          <h3 className="text-[15px] font-medium text-[#ECECEE]">Usage</h3>
           {usage ? (
             <p className="mt-3 text-[14px] text-[#C9C9CE]">
               {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens
@@ -87,16 +85,6 @@ export function AccountSettingsOverlay({
           <p className={`text-[12.5px] text-[#6C6C70] ${usage ? "mt-2" : "mt-3"}`}>
             Model spend uses your provider keys.
           </p>
-          {onOpenModels ? (
-            <button
-              type="button"
-              aria-label="Open models and billing"
-              onClick={onOpenModels}
-              className="mt-3 text-[13.5px] text-[#C9C9CE] underline-offset-2 hover:underline"
-            >
-              Models & billing
-            </button>
-          ) : null}
         </div>
 
         <details

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -15,7 +15,7 @@ export function AccountSettingsOverlay({
   onClose: () => void;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
-  const usageRef = useRef<HTMLElement>(null);
+  const usageRef = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
 
@@ -70,7 +70,7 @@ export function AccountSettingsOverlay({
           {email ? <p className="mt-1 text-[13px] text-[#7A7A80]">{email}</p> : null}
         </section>
 
-        <section
+        <div
           ref={usageRef}
           tabIndex={-1}
           data-testid="usage-billing-settings"
@@ -81,15 +81,11 @@ export function AccountSettingsOverlay({
             <p className="mt-3 text-[14px] text-[#C9C9CE]">
               {usage.runs} runs · {usage.inputTokens + usage.outputTokens} tokens this week
             </p>
-          ) : (
-            <p className="mt-3 text-[14px] text-[#7A7A80]">
-              {focusUsage ? "Loading usage…" : "Weekly usage appears here when loaded."}
-            </p>
-          )}
-          <p className="mt-2 text-[12.5px] text-[#6C6C70]">
-            Model spend follows your connected provider accounts.
+          ) : null}
+          <p className={`text-[12.5px] text-[#6C6C70] ${usage ? "mt-2" : "mt-3"}`}>
+            Model spend uses your provider keys.
           </p>
-        </section>
+        </div>
 
         <details
           data-testid="advanced-settings"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2404,6 +2404,11 @@ export function ShellPage() {
             email={session.data?.user.email}
             usage={usage}
             focusUsage={accountSettingsFocusUsage}
+            onOpenModels={() => {
+              setAccountSettingsOpen(false);
+              setAccountSettingsFocusUsage(false);
+              setModelsOpen(true);
+            }}
             onClose={() => {
               setAccountSettingsOpen(false);
               setAccountSettingsFocusUsage(false);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1858,7 +1858,7 @@ export function ShellPage() {
               return;
             }
             if (action === "settings-usage") {
-              setAccountSettingsOpen(true);
+              setMenuOpen(true);
               void rpc.usage
                 .summary()
                 .then(setUsage)
@@ -2738,8 +2738,8 @@ const Composer = memo(function Composer({
     );
     const mentionMatch = /(?:^|\s)@([\w-]*)$/.exec(value);
     setMentionQuery(mentionMatch ? (mentionMatch[1] ?? "") : null);
-    // `/` picker is separate from `@` mentions.
-    const slashMatch = /(?:^|\s)\/([^\n]*)$/.exec(value);
+    // `/` only at the start of the draft so forced skills expand (`Use skill:` / `/Name` prefix).
+    const slashMatch = /^\/([^\n]*)$/.exec(value);
     const nextSlash = slashMatch ? (slashMatch[1] ?? "") : null;
     if (nextSlash !== null && slashQuery === null) onSlashOpen?.();
     setSlashQuery(nextSlash);
@@ -2758,12 +2758,12 @@ const Composer = memo(function Composer({
   }
 
   function insertSkill(skill: AgentSkillCatalogEntry) {
-    setDraft((current) => current.replace(/\/([^\n]*)$/, `/${skill.name} `));
+    setDraft(`/${skill.name} `);
     setSlashQuery(null);
   }
 
   function runSlashAction(action: "chat-settings" | "settings-general" | "settings-usage") {
-    setDraft((current) => current.replace(/(^|\s)\/([^\n]*)$/, "$1").replace(/\s+$/, ""));
+    setDraft("");
     setSlashQuery(null);
     onSlashAction?.(action);
   }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -401,9 +401,13 @@ export function ShellPage() {
     const snap = await rpc.threads.get({ groupId: id });
     markOnce("rk:renderer:thread-response");
     if (activeGroupId.current !== id || request !== groupRefreshEpoch.current) return snap;
-    updateSnapshot((prev) =>
-      mergeThreadSnapshot(prev, snap, expandedHistoryThread.current === snap.threadId),
+    const reconciled = reconcileRefreshedThread(
+      snapshotRef.current,
+      snap,
+      computerRef.current,
+      expandedHistoryThread.current === snap.threadId,
     );
+    commitSnapshot(reconciled.snapshot);
     commitComputer(null);
     setRoutines([]);
     setRoutinesBotId(null);
@@ -740,7 +744,12 @@ export function ShellPage() {
               }
               if (event.payload.role === "bot") markBotReadIfVisible(active.id);
             }
-            if (isRunTerminalEvent(event) || event.type === "skill.teaching.stopped") {
+            if (
+              isRunTerminalEvent(event) ||
+              event.type === "run.waiting_input" ||
+              event.type === "skill.teaching.stopped"
+            ) {
+              // waiting_input: reconcile ask cards if a stale post-send refresh raced SSE.
               void refreshThread(active.id).catch(() => undefined);
             } else if (isComputerStatusEvent(event)) {
               void refreshComputerScreen(active.id).catch(() => undefined);
@@ -809,7 +818,8 @@ export function ShellPage() {
               readVisibleGroups.current.delete(groupId);
               markVisibleGroupRead();
             }
-            if (isRunTerminalEvent(event)) {
+            if (isRunTerminalEvent(event) || event.type === "run.waiting_input") {
+              // waiting_input: reconcile ask cards if a stale post-send refresh raced SSE.
               void refreshGroupThread(groupId).catch(() => undefined);
             }
           }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -38,7 +38,6 @@ import {
   defaultCronPreset,
   formatCron,
   groupBotsForSidebar,
-  hasMentionToken,
   inferAttachmentMimeType,
   isActive,
   isRunTerminalEvent,
@@ -1845,6 +1844,7 @@ export function ShellPage() {
               ? (activeSnapshot?.members ?? activeGroup?.members)?.map((member) => ({
                   botId: member.botId,
                   name: member.name,
+                  color: member.color,
                 }))
               : undefined
           }
@@ -2404,11 +2404,6 @@ export function ShellPage() {
             email={session.data?.user.email}
             usage={usage}
             focusUsage={accountSettingsFocusUsage}
-            onOpenModels={() => {
-              setAccountSettingsOpen(false);
-              setAccountSettingsFocusUsage(false);
-              setModelsOpen(true);
-            }}
             onClose={() => {
               setAccountSettingsOpen(false);
               setAccountSettingsFocusUsage(false);
@@ -2728,7 +2723,7 @@ const Composer = memo(function Composer({
   onStop: () => Promise<void>;
   replyTarget?: ThreadMessage | null;
   onClearReply?: () => void;
-  mentionMembers?: Array<{ botId: string; name: string }>;
+  mentionMembers?: Array<{ botId: string; name: string; color?: string }>;
   agentSkills?: AgentSkillCatalogEntry[];
   onSlashOpen?: () => void;
   onSlashAction?: (action: "chat-settings" | "settings-general" | "settings-usage") => void;
@@ -2740,40 +2735,42 @@ const Composer = memo(function Composer({
   const [draft, setDraft] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [slashQuery, setSlashQuery] = useState<string | null>(null);
-  const [selectedMentions, setSelectedMentions] = useState<Array<{ botId: string; name: string }>>(
-    [],
-  );
-  const canSend = draft.trim().length > 0 || pendingAttachments.length > 0;
+  const [selectedSkill, setSelectedSkill] = useState<AgentSkillCatalogEntry | null>(null);
+  const [selectedMentions, setSelectedMentions] = useState<
+    Array<{ botId: string; name: string; color?: string }>
+  >([]);
+  const canSend =
+    draft.trim().length > 0 ||
+    selectedSkill !== null ||
+    selectedMentions.length > 0 ||
+    pendingAttachments.length > 0;
 
   function updateDraft(value: string) {
     setDraft(value);
-    setSelectedMentions((current) =>
-      current.filter((member) => hasMentionToken(value, member.name)),
-    );
     const mentionMatch = /(?:^|\s)@([\w-]*)$/.exec(value);
     setMentionQuery(mentionMatch ? (mentionMatch[1] ?? "") : null);
     // `/` only at the start of the draft so forced skills expand (`Use skill:` / `/Name` prefix).
-    const slashMatch = /^\/([^\n]*)$/.exec(value);
+    const slashMatch = selectedSkill === null ? /^\/([^\n]*)$/.exec(value) : null;
     const nextSlash = slashMatch ? (slashMatch[1] ?? "") : null;
     if (nextSlash !== null && slashQuery === null) onSlashOpen?.();
     setSlashQuery(nextSlash);
   }
 
-  function insertMention(member: { botId: string; name: string }) {
-    setDraft((current) => current.replace(/@([\w-]*)$/, `@${member.name} `));
-    if (member.botId !== "everyone") {
-      setSelectedMentions((current) =>
-        current.some((selected) => selected.botId === member.botId)
-          ? current
-          : [...current, member],
-      );
-    }
+  function insertMention(member: { botId: string; name: string; color?: string }) {
+    setDraft((current) => current.replace(/@([\w-]*)$/, ""));
     setMentionQuery(null);
+    if (member.botId === "everyone") {
+      setDraft((current) => `${current.replace(/\s+$/, "")} @everyone `.replace(/^\s+/, ""));
+      return;
+    }
+    setSelectedMentions((current) =>
+      current.some((selected) => selected.botId === member.botId) ? current : [...current, member],
+    );
   }
 
   function insertSkill(skill: AgentSkillCatalogEntry) {
-    // Newline keeps trailing prompt text off the forced `/Name` line.
-    setDraft(`/${skill.name}\n`);
+    setSelectedSkill(skill);
+    setDraft("");
     setSlashQuery(null);
   }
 
@@ -2783,12 +2780,20 @@ const Composer = memo(function Composer({
     onSlashAction?.(action);
   }
 
+  function removeLastChip() {
+    if (selectedMentions.length > 0) {
+      setSelectedMentions((current) => current.slice(0, -1));
+      return;
+    }
+    if (selectedSkill) setSelectedSkill(null);
+  }
+
   const mentionOptions = useMemo(() => {
     if (mentionQuery === null || !mentionMembers?.length) return [];
     const query = mentionQuery.toLowerCase();
     const options = mentionMembers.filter((member) => member.name.toLowerCase().startsWith(query));
     if ("everyone".startsWith(query)) {
-      options.unshift({ botId: "everyone", name: "everyone" });
+      options.unshift({ botId: "everyone", name: "everyone", color: "#85858A" });
     }
     return options.slice(0, 8);
   }, [mentionMembers, mentionQuery]);
@@ -2821,14 +2826,18 @@ const Composer = memo(function Composer({
 
   function send() {
     if (!canSend || sending || disabled) return;
-    const text = draft;
+    const text = serializeComposerPrompt(draft, selectedSkill, selectedMentions);
     setDraft("");
     setMentionQuery(null);
     setSlashQuery(null);
+    setSelectedSkill(null);
     const mentions = selectedMentions.map((member) => member.botId);
     setSelectedMentions([]);
-    void onSend(text, mentions);
+    void onSend(text, mentions.length ? mentions : undefined);
   }
+
+  const showComposerPlaceholder =
+    draft.length === 0 && selectedSkill === null && selectedMentions.length === 0;
 
   return (
     <div className="relative z-30 px-3 pb-4 pt-3 md:px-6 md:pb-6">
@@ -2986,24 +2995,64 @@ const Composer = memo(function Composer({
         >
           <Mic size={16} strokeWidth={1.8} />
         </button>
-        <textarea
-          value={draft}
-          onChange={(event) => updateDraft(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" && !event.shiftKey) {
-              event.preventDefault();
-              send();
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+          {selectedSkill ? (
+            <span
+              data-testid="skill-chip"
+              className="inline-flex max-w-full items-center gap-1.5 rounded-full bg-[#1C1C1F] px-2.5 py-1 text-[13px] text-[#ECECEE]"
+            >
+              <Box size={13} strokeWidth={1.7} className="shrink-0 text-[#B0B0B6]" />
+              <span dir="auto" className="truncate">
+                {selectedSkill.name}
+              </span>
+            </span>
+          ) : null}
+          {selectedMentions.map((member) => (
+            <span
+              key={member.botId}
+              data-testid="mention-chip"
+              className="inline-flex max-w-full items-center gap-1.5 rounded-full bg-[#1C1C1F] px-2.5 py-1 text-[13px] text-[#ECECEE]"
+            >
+              <BotAvatar color={member.color ?? "#85858A"} size={16} />
+              <span dir="auto" className="truncate">
+                {member.name}
+              </span>
+            </span>
+          ))}
+          <textarea
+            value={draft}
+            onChange={(event) => updateDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (
+                event.key === "Backspace" &&
+                draft.length === 0 &&
+                (selectedSkill !== null || selectedMentions.length > 0)
+              ) {
+                event.preventDefault();
+                removeLastChip();
+                return;
+              }
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                send();
+              }
+            }}
+            disabled={disabled}
+            placeholder={
+              showComposerPlaceholder
+                ? activeName
+                  ? `Message ${activeName}`
+                  : "Message…"
+                : undefined
             }
-          }}
-          disabled={disabled}
-          placeholder={activeName ? `Message ${activeName}` : "Message…"}
-          aria-label={activeName ? `Message ${activeName}` : "Message"}
-          name="chat-message"
-          autoComplete="off"
-          dir="auto"
-          rows={1}
-          className="max-h-32 min-h-[24px] flex-1 resize-none overflow-y-auto bg-transparent py-0.5 text-[15.5px] leading-6 text-[#E9E9EA] outline-none disabled:opacity-40"
-        />
+            aria-label={activeName ? `Message ${activeName}` : "Message"}
+            name="chat-message"
+            autoComplete="off"
+            dir="auto"
+            rows={1}
+            className="max-h-32 min-h-[24px] min-w-[8rem] flex-1 resize-none overflow-y-auto bg-transparent py-0.5 text-[15.5px] leading-6 text-[#E9E9EA] outline-none disabled:opacity-40"
+          />
+        </div>
         {running ? (
           <button
             type="button"
@@ -3032,8 +3081,20 @@ const Composer = memo(function Composer({
 const SLASH_ACTIONS = [
   { id: "chat-settings" as const, label: "Chat Settings" },
   { id: "settings-general" as const, label: "Settings: General" },
-  { id: "settings-usage" as const, label: "Settings: Usage & Billing" },
+  { id: "settings-usage" as const, label: "Settings: Usage" },
 ];
+
+function serializeComposerPrompt(
+  draft: string,
+  skill: { name: string } | null,
+  mentions: Array<{ name: string }>,
+): string {
+  const body = draft.replace(/^\s+/, "");
+  const mentionPrefix = mentions.map((member) => `@${member.name}`).join(" ");
+  const afterSkill = [mentionPrefix, body].filter((part) => part.trim().length > 0).join(" ");
+  if (!skill) return afterSkill.trimEnd();
+  return afterSkill.trim().length > 0 ? `/${skill.name}\n${afterSkill}` : `/${skill.name}`;
+}
 
 function truncateSlashDescription(value: string, max = 72): string {
   const text = value.replace(/\s+/g, " ").trim();

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -107,7 +107,6 @@ import {
   computerTakeoverBlocked,
   isComputerStatusEvent,
   isThreadSnapshotEvent,
-  mergeThreadSnapshot,
   prependThreadMessagePage,
   reconcileRefreshedThread,
   reduceComputerStatus,

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1,5 +1,6 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type {
+  AgentSkillCatalogEntry,
   Bot,
   BotSection,
   ComputerMode,
@@ -48,6 +49,7 @@ import {
 import { BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
 import {
   ArrowUp,
+  Box,
   ChevronLeft,
   Cpu,
   Gauge,
@@ -197,6 +199,7 @@ export function ShellPage() {
   const [routinesBotId, setRoutinesBotId] = useState<string | null>(null);
   const [taughtSkills, setTaughtSkills] = useState<TaughtSkill[]>([]);
   const [taughtSkillsBotId, setTaughtSkillsBotId] = useState<string | null>(null);
+  const [agentSkills, setAgentSkills] = useState<AgentSkillCatalogEntry[]>([]);
   const [teachBusy, setTeachBusy] = useState(false);
   const [computer, setComputer] = useState<ComputerStatus | null>(null);
   const computerRef = useRef<ComputerStatus | null>(null);
@@ -600,6 +603,28 @@ export function ShellPage() {
       window.removeEventListener("focus", refreshVisibleBots);
       document.removeEventListener("visibilitychange", refreshVisibleBots);
     };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void rpc.agentSkills
+      .list()
+      .then((skills) => {
+        if (!cancelled) setAgentSkills(skills);
+      })
+      .catch(() => {
+        if (!cancelled) setAgentSkills([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const refreshAgentSkills = useCallback(() => {
+    void rpc.agentSkills
+      .list()
+      .then(setAgentSkills)
+      .catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -1821,6 +1846,25 @@ export function ShellPage() {
                 }))
               : undefined
           }
+          agentSkills={agentSkills}
+          onSlashOpen={refreshAgentSkills}
+          onSlashAction={(action) => {
+            if (action === "chat-settings") {
+              setPanel(inGroup ? "group-settings" : "settings");
+              return;
+            }
+            if (action === "settings-general") {
+              setAccountSettingsOpen(true);
+              return;
+            }
+            if (action === "settings-usage") {
+              setAccountSettingsOpen(true);
+              void rpc.usage
+                .summary()
+                .then(setUsage)
+                .catch(() => undefined);
+            }
+          }}
           dictating={dictating}
           transcribe={Boolean(voiceStatus?.transcribe)}
           onDictateStart={(onFinal) => {
@@ -2647,6 +2691,9 @@ const Composer = memo(function Composer({
   replyTarget,
   onClearReply,
   mentionMembers,
+  agentSkills,
+  onSlashOpen,
+  onSlashAction,
   dictating,
   transcribe,
   onDictateStart,
@@ -2668,6 +2715,9 @@ const Composer = memo(function Composer({
   replyTarget?: ThreadMessage | null;
   onClearReply?: () => void;
   mentionMembers?: Array<{ botId: string; name: string }>;
+  agentSkills?: AgentSkillCatalogEntry[];
+  onSlashOpen?: () => void;
+  onSlashAction?: (action: "chat-settings" | "settings-general" | "settings-usage") => void;
   dictating: boolean;
   transcribe: boolean;
   onDictateStart: (onFinal: (text: string) => void) => void;
@@ -2675,6 +2725,7 @@ const Composer = memo(function Composer({
 }) {
   const [draft, setDraft] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [slashQuery, setSlashQuery] = useState<string | null>(null);
   const [selectedMentions, setSelectedMentions] = useState<Array<{ botId: string; name: string }>>(
     [],
   );
@@ -2685,8 +2736,13 @@ const Composer = memo(function Composer({
     setSelectedMentions((current) =>
       current.filter((member) => hasMentionToken(value, member.name)),
     );
-    const match = /(?:^|\s)@([\w-]*)$/.exec(value);
-    setMentionQuery(match ? (match[1] ?? "") : null);
+    const mentionMatch = /(?:^|\s)@([\w-]*)$/.exec(value);
+    setMentionQuery(mentionMatch ? (mentionMatch[1] ?? "") : null);
+    // `/` picker is separate from `@` mentions.
+    const slashMatch = /(?:^|\s)\/([^\n]*)$/.exec(value);
+    const nextSlash = slashMatch ? (slashMatch[1] ?? "") : null;
+    if (nextSlash !== null && slashQuery === null) onSlashOpen?.();
+    setSlashQuery(nextSlash);
   }
 
   function insertMention(member: { botId: string; name: string }) {
@@ -2701,6 +2757,17 @@ const Composer = memo(function Composer({
     setMentionQuery(null);
   }
 
+  function insertSkill(skill: AgentSkillCatalogEntry) {
+    setDraft((current) => current.replace(/\/([^\n]*)$/, `/${skill.name} `));
+    setSlashQuery(null);
+  }
+
+  function runSlashAction(action: "chat-settings" | "settings-general" | "settings-usage") {
+    setDraft((current) => current.replace(/(^|\s)\/([^\n]*)$/, "$1").replace(/\s+$/, ""));
+    setSlashQuery(null);
+    onSlashAction?.(action);
+  }
+
   const mentionOptions = useMemo(() => {
     if (mentionQuery === null || !mentionMembers?.length) return [];
     const query = mentionQuery.toLowerCase();
@@ -2711,11 +2778,38 @@ const Composer = memo(function Composer({
     return options.slice(0, 8);
   }, [mentionMembers, mentionQuery]);
 
+  const slashSkillOptions = useMemo(() => {
+    if (slashQuery === null) return [];
+    const query = slashQuery.trim().toLowerCase();
+    const skills = agentSkills ?? [];
+    return skills
+      .filter((skill) => {
+        if (!query) return true;
+        return (
+          skill.name.toLowerCase().includes(query) ||
+          skill.description.toLowerCase().includes(query)
+        );
+      })
+      .slice(0, 8);
+  }, [agentSkills, slashQuery]);
+
+  const slashActionOptions = useMemo(() => {
+    if (slashQuery === null) return [];
+    const query = slashQuery.trim().toLowerCase();
+    return SLASH_ACTIONS.filter((action) => !query || action.label.toLowerCase().includes(query));
+  }, [slashQuery]);
+
+  const showSlashPicker =
+    slashQuery !== null &&
+    mentionQuery === null &&
+    (slashSkillOptions.length > 0 || slashActionOptions.length > 0);
+
   function send() {
     if (!canSend || sending || disabled) return;
     const text = draft;
     setDraft("");
     setMentionQuery(null);
+    setSlashQuery(null);
     const mentions = selectedMentions.map((member) => member.botId);
     setSelectedMentions([]);
     void onSend(text, mentions);
@@ -2792,6 +2886,44 @@ const Composer = memo(function Composer({
               className="block w-full px-4 py-2 text-start text-[14px] text-[#ECECEE] hover:bg-[#1F1F22]"
             >
               <span dir="auto">@{member.name}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {showSlashPicker ? (
+        <div
+          data-testid="slash-picker"
+          className="mb-2 overflow-hidden rounded-[14px] border border-[#26262A] bg-[#17171A]"
+        >
+          {slashSkillOptions.map((skill) => (
+            <button
+              key={skill.id}
+              type="button"
+              aria-label={`Skill ${skill.name}`}
+              onClick={() => insertSkill(skill)}
+              className="flex w-full items-start gap-3 px-4 py-2.5 text-start hover:bg-[#1F1F22]"
+            >
+              <Box size={16} strokeWidth={1.7} className="mt-0.5 shrink-0 text-[#9A9AA0]" />
+              <span className="min-w-0">
+                <span dir="auto" className="block text-[14px] text-[#ECECEE]">
+                  {skill.name}
+                </span>
+                <span dir="auto" className="block truncate text-[12.5px] text-[#85858A]">
+                  {truncateSlashDescription(skill.description)}
+                </span>
+              </span>
+            </button>
+          ))}
+          {slashActionOptions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              aria-label={action.label}
+              onClick={() => runSlashAction(action.id)}
+              className="flex w-full items-center gap-3 px-4 py-2.5 text-start hover:bg-[#1F1F22]"
+            >
+              <Settings size={16} strokeWidth={1.7} className="shrink-0 text-[#9A9AA0]" />
+              <span className="text-[14px] text-[#ECECEE]">{action.label}</span>
             </button>
           ))}
         </div>
@@ -2880,6 +3012,18 @@ const Composer = memo(function Composer({
     </div>
   );
 });
+
+const SLASH_ACTIONS = [
+  { id: "chat-settings" as const, label: "Chat Settings" },
+  { id: "settings-general" as const, label: "Settings: General" },
+  { id: "settings-usage" as const, label: "Settings: Usage & Billing" },
+];
+
+function truncateSlashDescription(value: string, max = 72): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}
 
 function previewMessageText(message: ThreadMessage): string {
   const text = message.blocks

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2981,7 +2981,7 @@ const Composer = memo(function Composer({
         >
           <Mic size={16} strokeWidth={1.8} />
         </button>
-        <input
+        <textarea
           value={draft}
           onChange={(event) => updateDraft(event.target.value)}
           onKeyDown={(event) => {
@@ -2996,7 +2996,8 @@ const Composer = memo(function Composer({
           name="chat-message"
           autoComplete="off"
           dir="auto"
-          className="flex-1 bg-transparent text-[15.5px] text-[#E9E9EA] outline-none disabled:opacity-40"
+          rows={1}
+          className="max-h-32 min-h-[24px] flex-1 resize-none overflow-y-auto bg-transparent py-0.5 text-[15.5px] leading-6 text-[#E9E9EA] outline-none disabled:opacity-40"
         />
         {running ? (
           <button

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -222,6 +222,7 @@ export function ShellPage() {
   const [pluginsOpen, setPluginsOpen] = useState(false);
   const [mcpOpen, setMcpOpen] = useState(false);
   const [accountSettingsOpen, setAccountSettingsOpen] = useState(false);
+  const [accountSettingsFocusUsage, setAccountSettingsFocusUsage] = useState(false);
   const [modelsOpen, setModelsOpen] = useState(false);
   const [memorySettingsOpen, setMemorySettingsOpen] = useState(false);
   const [memoryProviderConfig, setMemoryProviderConfig] = useState<
@@ -1642,6 +1643,7 @@ export function ShellPage() {
                 aria-label="Settings"
                 onClick={() => {
                   setMenuOpen(false);
+                  setAccountSettingsFocusUsage(false);
                   setAccountSettingsOpen(true);
                 }}
                 className="flex w-full items-center gap-3 rounded-[11px] px-3 py-2.5 hover:bg-[#232327]"
@@ -1854,11 +1856,13 @@ export function ShellPage() {
               return;
             }
             if (action === "settings-general") {
+              setAccountSettingsFocusUsage(false);
               setAccountSettingsOpen(true);
               return;
             }
             if (action === "settings-usage") {
-              setMenuOpen(true);
+              setAccountSettingsFocusUsage(true);
+              setAccountSettingsOpen(true);
               void rpc.usage
                 .summary()
                 .then(setUsage)
@@ -2398,7 +2402,12 @@ export function ShellPage() {
           <AccountSettingsOverlay
             name={userName}
             email={session.data?.user.email}
-            onClose={() => setAccountSettingsOpen(false)}
+            usage={usage}
+            focusUsage={accountSettingsFocusUsage}
+            onClose={() => {
+              setAccountSettingsOpen(false);
+              setAccountSettingsFocusUsage(false);
+            }}
           />
         ) : null}
         {modelsOpen ? <ModelSettingsOverlay onClose={() => setModelsOpen(false)} /> : null}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -43,7 +43,11 @@ import {
   isRunTerminalEvent,
   latestAnswerableAskMessageId,
   presetFromCron,
+  SLASH_ACTIONS,
+  type SlashActionId,
+  serializeComposerPrompt,
   speechFromBlocks,
+  truncateSlashDescription,
 } from "@rakazo/core";
 import { BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
 import {
@@ -2735,7 +2739,7 @@ const Composer = memo(function Composer({
   mentionMembers?: Array<{ botId: string; name: string; color?: string }>;
   agentSkills?: AgentSkillCatalogEntry[];
   onSlashOpen?: () => void;
-  onSlashAction?: (action: "chat-settings" | "settings-general" | "settings-usage") => void;
+  onSlashAction?: (action: SlashActionId) => void;
   dictating: boolean;
   transcribe: boolean;
   onDictateStart: (onFinal: (text: string) => void) => void;
@@ -2783,7 +2787,7 @@ const Composer = memo(function Composer({
     setSlashQuery(null);
   }
 
-  function runSlashAction(action: "chat-settings" | "settings-general" | "settings-usage") {
+  function runSlashAction(action: SlashActionId) {
     setDraft("");
     setSlashQuery(null);
     onSlashAction?.(action);
@@ -3014,6 +3018,14 @@ const Composer = memo(function Composer({
               <span dir="auto" className="truncate">
                 {selectedSkill.name}
               </span>
+              <button
+                type="button"
+                aria-label={`Remove ${selectedSkill.name}`}
+                onClick={() => setSelectedSkill(null)}
+                className="text-[#85858A] hover:text-[#ECECEE]"
+              >
+                <X size={12} strokeWidth={2} />
+              </button>
             </span>
           ) : null}
           {selectedMentions.map((member) => (
@@ -3026,6 +3038,18 @@ const Composer = memo(function Composer({
               <span dir="auto" className="truncate">
                 {member.name}
               </span>
+              <button
+                type="button"
+                aria-label={`Remove ${member.name}`}
+                onClick={() =>
+                  setSelectedMentions((current) =>
+                    current.filter((selected) => selected.botId !== member.botId),
+                  )
+                }
+                className="text-[#85858A] hover:text-[#ECECEE]"
+              >
+                <X size={12} strokeWidth={2} />
+              </button>
             </span>
           ))}
           <textarea
@@ -3086,30 +3110,6 @@ const Composer = memo(function Composer({
     </div>
   );
 });
-
-const SLASH_ACTIONS = [
-  { id: "chat-settings" as const, label: "Chat Settings" },
-  { id: "settings-general" as const, label: "Settings: General" },
-  { id: "settings-usage" as const, label: "Settings: Usage" },
-];
-
-function serializeComposerPrompt(
-  draft: string,
-  skill: { name: string } | null,
-  mentions: Array<{ name: string }>,
-): string {
-  const body = draft.replace(/^\s+/, "");
-  const mentionPrefix = mentions.map((member) => `@${member.name}`).join(" ");
-  const afterSkill = [mentionPrefix, body].filter((part) => part.trim().length > 0).join(" ");
-  if (!skill) return afterSkill.trimEnd();
-  return afterSkill.trim().length > 0 ? `/${skill.name}\n${afterSkill}` : `/${skill.name}`;
-}
-
-function truncateSlashDescription(value: string, max = 72): string {
-  const text = value.replace(/\s+/g, " ").trim();
-  if (text.length <= max) return text;
-  return `${text.slice(0, max - 1).trimEnd()}…`;
-}
 
 function previewMessageText(message: ThreadMessage): string {
   const text = message.blocks

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1793,14 +1793,12 @@ export function ShellPage() {
                 type="button"
                 title="Agent computer"
                 onClick={() => {
-                  setPanel((p) => {
-                    const next = p === "computer" ? null : "computer";
-                    if (next === "computer" && active) {
-                      // Refresh run/computer so Take control isn't stuck on a stale busyBotName.
-                      void refreshThread(active.id).catch(() => undefined);
-                    }
-                    return next;
-                  });
+                  const next = panel === "computer" ? null : "computer";
+                  setPanel(next);
+                  if (next === "computer" && active) {
+                    // Refresh run/computer so Take control isn't stuck on a stale busyBotName.
+                    void refreshThread(active.id).catch(() => undefined);
+                  }
                 }}
                 className="grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-[#1B1B1E]"
                 style={{ background: panel ? "#1B1B1E" : "transparent" }}
@@ -3020,7 +3018,7 @@ const Composer = memo(function Composer({
               </span>
               <button
                 type="button"
-                aria-label={`Remove ${selectedSkill.name}`}
+                aria-label={`Remove skill ${selectedSkill.name}`}
                 onClick={() => setSelectedSkill(null)}
                 className="text-[#85858A] hover:text-[#ECECEE]"
               >
@@ -3040,7 +3038,7 @@ const Composer = memo(function Composer({
               </span>
               <button
                 type="button"
-                aria-label={`Remove ${member.name}`}
+                aria-label={`Remove mention ${member.name}`}
                 onClick={() =>
                   setSelectedMentions((current) =>
                     current.filter((selected) => selected.botId !== member.botId),

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1691,7 +1691,7 @@ export function ShellPage() {
                 }}
               >
                 <Gauge size={16} strokeWidth={1.7} className="text-[#9A9AA0]" />
-                <span className="flex-1 text-start text-[14.5px] text-[#ECECEE]">Weekly usage</span>
+                <span className="flex-1 text-start text-[14.5px] text-[#ECECEE]">Usage</span>
               </button>
               {usage ? (
                 <p className="px-3 pb-2 text-[12.5px] text-[#85858A]">

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2767,7 +2767,8 @@ const Composer = memo(function Composer({
   }
 
   function insertSkill(skill: AgentSkillCatalogEntry) {
-    setDraft(`/${skill.name} `);
+    // Newline keeps trailing prompt text off the forced `/Name` line.
+    setDraft(`/${skill.name}\n`);
     setSlashQuery(null);
   }
 

--- a/packages/adapters/src/skill-tools.test.ts
+++ b/packages/adapters/src/skill-tools.test.ts
@@ -140,6 +140,27 @@ describe("skill tools", () => {
     expect(String(read.content)).toContain("Leave comments");
   });
 
+  it("renames only via newName, not the name lookup key", async () => {
+    const created = await skillCreateFromTool(prisma as never, owner, {
+      name: "Original",
+      description: "Keep name unless newName",
+      body: "body",
+    });
+    const skillId = String(created.id);
+    const mistyped = await skillUpdateFromTool(prisma as never, owner, {
+      skillId,
+      name: "Should not apply",
+      description: "still original name",
+    });
+    expect(mistyped).toMatchObject({ ok: true, name: "Original" });
+
+    const renamed = await skillUpdateFromTool(prisma as never, owner, {
+      skillId,
+      newName: "Renamed",
+    });
+    expect(renamed).toMatchObject({ ok: true, name: "Renamed" });
+  });
+
   it("scopes list to the owner workspace and injects catalog lines", async () => {
     prisma = makePrisma([
       {

--- a/packages/adapters/src/skill-tools.ts
+++ b/packages/adapters/src/skill-tools.ts
@@ -212,6 +212,7 @@ export async function skillUpdateFromTool(
   } else {
     const prior = parseSkillMd(existing.content);
     if ("error" in prior) return { error: prior.error };
+    // `name` is only a lookup key (see findOwnedSkill above); renames require `newName`.
     nextName = String(input.newName ?? existing.name).trim() || existing.name;
     nextDescription =
       input.description !== undefined ? String(input.description).trim() : existing.description;

--- a/packages/adapters/src/skill-tools.ts
+++ b/packages/adapters/src/skill-tools.ts
@@ -212,7 +212,7 @@ export async function skillUpdateFromTool(
   } else {
     const prior = parseSkillMd(existing.content);
     if ("error" in prior) return { error: prior.error };
-    nextName = String(input.newName ?? input.name ?? existing.name).trim() || existing.name;
+    nextName = String(input.newName ?? existing.name).trim() || existing.name;
     nextDescription =
       input.description !== undefined ? String(input.description).trim() : existing.description;
     const body = input.body !== undefined ? String(input.body) : prior.body;

--- a/packages/core/src/composer-slash.test.ts
+++ b/packages/core/src/composer-slash.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SLASH_ACTIONS,
+  serializeComposerPrompt,
+  truncateSlashDescription,
+} from "./composer-slash.js";
+
+describe("serializeComposerPrompt", () => {
+  it("returns draft when no skill or mentions", () => {
+    expect(serializeComposerPrompt("  hello", null, [])).toBe("hello");
+  });
+
+  it("prefixes skill slash name alone", () => {
+    expect(serializeComposerPrompt("", { name: "Daily standup" }, [])).toBe("/Daily standup");
+  });
+
+  it("combines skill, mentions, and draft", () => {
+    expect(
+      serializeComposerPrompt("check blockers", { name: "Daily standup" }, [
+        { name: "Research Writer" },
+      ]),
+    ).toBe("/Daily standup\n@Research Writer check blockers");
+  });
+
+  it("prefixes mentions without a skill", () => {
+    expect(serializeComposerPrompt("go", null, [{ name: "everyone" }])).toBe("@everyone go");
+  });
+});
+
+describe("truncateSlashDescription", () => {
+  it("leaves short text alone", () => {
+    expect(truncateSlashDescription("short")).toBe("short");
+  });
+
+  it("truncates long text with an ellipsis", () => {
+    const long = "a".repeat(80);
+    expect(truncateSlashDescription(long, 20)).toBe(`${"a".repeat(19)}…`);
+  });
+});
+
+describe("SLASH_ACTIONS", () => {
+  it("exposes chat and account destinations", () => {
+    expect(SLASH_ACTIONS.map((action) => action.id)).toEqual([
+      "chat-settings",
+      "settings-general",
+      "settings-usage",
+    ]);
+  });
+});

--- a/packages/core/src/composer-slash.ts
+++ b/packages/core/src/composer-slash.ts
@@ -1,0 +1,26 @@
+export const SLASH_ACTIONS = [
+  { id: "chat-settings" as const, label: "Chat Settings" },
+  { id: "settings-general" as const, label: "Settings: General" },
+  { id: "settings-usage" as const, label: "Settings: Usage" },
+] as const;
+
+export type SlashActionId = (typeof SLASH_ACTIONS)[number]["id"];
+
+/** Serialize composer chips + draft into the prompt text sent to the agent. */
+export function serializeComposerPrompt(
+  draft: string,
+  skill: { name: string } | null,
+  mentions: Array<{ name: string }>,
+): string {
+  const body = draft.replace(/^\s+/, "");
+  const mentionPrefix = mentions.map((member) => `@${member.name}`).join(" ");
+  const afterSkill = [mentionPrefix, body].filter((part) => part.trim().length > 0).join(" ");
+  if (!skill) return afterSkill.trimEnd();
+  return afterSkill.trim().length > 0 ? `/${skill.name}\n${afterSkill}` : `/${skill.name}`;
+}
+
+export function truncateSlashDescription(value: string, max = 72): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,9 @@ export * from "./async.js";
 export * from "./attachments.js";
 export * from "./bot-sections.js";
 export * from "./compose-update.js";
+export * from "./composer-slash.js";
 export * from "./cron.js";
+
 export * from "./events.js";
 export * from "./group-mentions.js";
 export * from "./mcp.js";

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -254,6 +254,15 @@ describe("pauseRunForInput", () => {
       ),
     ).resolves.toBe(true);
 
+    expect(tx.message.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          botId: "bot-1",
+          runId: "run-1",
+          role: "bot",
+        }),
+      }),
+    );
     expect(tx.run.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ status: "running", leaseFence: 3 }),

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -519,6 +519,7 @@ export async function pauseRunForInput(
       threadId: input.threadId,
       role: "bot",
       blocks: input.blocks,
+      botId: input.botId,
       runId: input.runId,
     });
     await appendEventInTransaction(tx, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Composer `/` picker for shared Skills (on top of current `main`, including merged #192 skill storage/API).

- Typing `/` at the **start** of the composer opens a picker with **skills above Actions**
- Skills use a cube (`Box`) icon; selecting one inserts a **skill chip** (not raw `/Name` text)
- Mentions from `@` insert an **avatar chip**; skills stay off `@`
- On send, chips serialize to `/Name` (forced skill) and `@Name` tokens so backend expansion/routing still work
- Actions: Chat Settings, Settings: General, Settings: Usage
- Web e2e (`slash-skills.spec.ts`, group mention path in `group-chats.spec.ts`) plus matching mobile picker

## Notes

Rebased onto current `main` after #192 merged. Skill storage/parser/tools come from main; this PR only adds composer/picker/chip/UI/e2e (plus a small `skill_update` rename-via-`newName` hardening from review).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9958e735-22fb-4f37-8f53-a5f35f6fe0b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9958e735-22fb-4f37-8f53-a5f35f6fe0b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added slash-command skill discovery, filtering, descriptions, selection, and removable skill or mention chips.
  * Added quick navigation actions for chat, bot, usage, and account settings.
  * Added mobile bot settings and usage views, including usage summaries and advanced model options.
  * Added skill management capabilities, including creating, editing, reading, and deleting eligible skills.
* **Bug Fixes**
  * Improved thread synchronization and prevented stale refreshes from replacing newer messages.
  * Cleared progress indicators correctly when runs request input.
  * Preserved bot information when pausing runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->