### PR TITLE
ci: publish server images for linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -36,7 +36,7 @@ jobs:
     name: Validate ${{ matrix.name }} image
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     permissions:
       contents: read
     strategy:
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
@@ -64,6 +65,7 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           build-args: GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=pr-${{ github.event.pull_request.number }}-${{ matrix.name }}
@@ -74,7 +76,7 @@ jobs:
     name: Publish ${{ matrix.name }} image
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     permissions:
       contents: read
       packages: write
@@ -93,6 +95,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -120,6 +123,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           # GET /health can report the exact source commit without a deployment-supplied override.
           build-args: GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.name }}


### PR DESCRIPTION
## Summary
- Build and publish the app and updater images as a multi-arch manifest (`linux/amd64,linux/arm64`) so Apple Silicon and other arm64 hosts can pull a native image.
- Register QEMU in both the PR validate job and the publish job (pinned `docker/setup-qemu-action` v4.2.0, same style as the other Docker actions).
- Raise those job timeouts from 90 to 180 minutes because the arm64 half is emulated on `ubuntu-latest`.

Base image digest pins already resolve to multi-arch indexes, so the Dockerfiles themselves did not need to change.

## Test plan
- [ ] Confirm `publish-server-image` on this PR validates both platforms for `app` and `updater`.
- [ ] After merge (or a `workflow_dispatch` / tag on a repo that publishes), `docker buildx imagetools inspect ghcr.io/<owner>/rakazo/app:<tag>` lists `linux/amd64` and `linux/arm64`.
- [ ] On an arm64 machine, `docker pull` of that tag gets the arm64 variant (no qemu warning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container images now support both `linux/amd64` and `linux/arm64` platforms.
  * Image validation and publishing workflows have extended time limits for more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->