### PR TITLE
fix(e2b): open http(s) URLs via named browser launcher

### DIFF
--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -123,11 +123,18 @@ describe("e2b create options", () => {
 
   it("opens a URL through the named browser launcher", async () => {
     const launched: Array<{ application: string; uri?: string }> = [];
+    const commands = {
+      run: async (cmd: string) => {
+        if (cmd.includes("google-chrome")) throw new Error("missing");
+        if (cmd.includes("firefox")) return { exitCode: 0 };
+        throw new Error("missing");
+      },
+    };
     await openDesktopUrl(
       {
+        commands,
         launch: async (application, uri) => {
           launched.push({ application, uri });
-          if (application !== "firefox") throw new Error("missing");
         },
         open: async () => {
           throw new Error("should not fall back");
@@ -135,10 +142,7 @@ describe("e2b create options", () => {
       },
       "https://example.com/page",
     );
-    expect(launched).toEqual([
-      { application: "google-chrome", uri: "https://example.com/page" },
-      { application: "firefox", uri: "https://example.com/page" },
-    ]);
+    expect(launched).toEqual([{ application: "firefox", uri: "https://example.com/page" }]);
   });
 });
 

--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -6,6 +6,7 @@ import {
   e2bCreateOptions,
   isUnrecoverableSandboxError,
   openDesktopBrowser,
+  openDesktopUrl,
 } from "./e2b-sandbox.js";
 
 describe("sandbox idle", () => {
@@ -118,6 +119,26 @@ describe("e2b create options", () => {
       },
     });
     expect(launched).toEqual(["google-chrome", "firefox"]);
+  });
+
+  it("opens a URL through the named browser launcher", async () => {
+    const launched: Array<{ application: string; uri?: string }> = [];
+    await openDesktopUrl(
+      {
+        launch: async (application, uri) => {
+          launched.push({ application, uri });
+          if (application !== "firefox") throw new Error("missing");
+        },
+        open: async () => {
+          throw new Error("should not fall back");
+        },
+      },
+      "https://example.com/page",
+    );
+    expect(launched).toEqual([
+      { application: "google-chrome", uri: "https://example.com/page" },
+      { application: "firefox", uri: "https://example.com/page" },
+    ]);
   });
 });
 

--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -122,9 +122,10 @@ describe("e2b create options", () => {
   });
 
   it("opens a URL through the named browser launcher", async () => {
-    const launched: Array<{ application: string; uri?: string }> = [];
+    const launched: string[] = [];
     const commands = {
       run: async (cmd: string) => {
+        launched.push(cmd);
         if (cmd.includes("google-chrome")) throw new Error("missing");
         if (cmd.includes("firefox")) return { exitCode: 0 };
         throw new Error("missing");
@@ -133,8 +134,8 @@ describe("e2b create options", () => {
     await openDesktopUrl(
       {
         commands,
-        launch: async (application, uri) => {
-          launched.push({ application, uri });
+        launch: async () => {
+          throw new Error("should use gtk-launch via commands");
         },
         open: async () => {
           throw new Error("should not fall back");
@@ -142,7 +143,10 @@ describe("e2b create options", () => {
       },
       "https://example.com/page",
     );
-    expect(launched).toEqual([{ application: "firefox", uri: "https://example.com/page" }]);
+    expect(launched).toEqual([
+      "gtk-launch 'google-chrome' 'https://example.com/page'",
+      "gtk-launch 'firefox' 'https://example.com/page'",
+    ]);
   });
 });
 

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -69,6 +69,10 @@ describe("E2B computer backend", () => {
       if (value.includes("RAKAZO_SCREEN_INDEX=")) {
         return { stdout: "RAKAZO_SCREEN_INDEX=0\n", stderr: "", exitCode: 0 };
       }
+      if (value.includes("command -v")) {
+        if (value.includes("google-chrome")) return { stdout: "", stderr: "", exitCode: 0 };
+        throw new Error("missing");
+      }
       return { stdout: "", stderr: "", exitCode: 0 };
     });
     const launch = vi.fn(async () => undefined);
@@ -95,6 +99,9 @@ describe("E2B computer backend", () => {
       computer,
       { actions: [{ kind: "open", path: "https://example.com/docs" }], observe: false },
       context,
+    );
+    expect(command).toHaveBeenCalledWith(
+      expect.stringMatching(/command -v ['"]?google-chrome['"]?/),
     );
     expect(launch).toHaveBeenCalledWith("google-chrome", "https://example.com/docs");
     expect(open).not.toHaveBeenCalled();

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -69,7 +69,7 @@ describe("E2B computer backend", () => {
       if (value.includes("RAKAZO_SCREEN_INDEX=")) {
         return { stdout: "RAKAZO_SCREEN_INDEX=0\n", stderr: "", exitCode: 0 };
       }
-      if (value.includes("command -v")) {
+      if (value.startsWith("gtk-launch")) {
         if (value.includes("google-chrome")) return { stdout: "", stderr: "", exitCode: 0 };
         throw new Error("missing");
       }
@@ -100,10 +100,8 @@ describe("E2B computer backend", () => {
       { actions: [{ kind: "open", path: "https://example.com/docs" }], observe: false },
       context,
     );
-    expect(command).toHaveBeenCalledWith(
-      expect.stringMatching(/command -v ['"]?google-chrome['"]?/),
-    );
-    expect(launch).toHaveBeenCalledWith("google-chrome", "https://example.com/docs");
+    expect(command).toHaveBeenCalledWith("gtk-launch 'google-chrome' 'https://example.com/docs'");
+    expect(launch).not.toHaveBeenCalled();
     expect(open).not.toHaveBeenCalled();
 
     await provider.act(

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -54,7 +54,57 @@ describe("E2B computer backend", () => {
     await provider.prepare(computer, context);
 
     expect(command.mock.calls.filter(([value]) => String(value).includes("ln -s"))).toHaveLength(1);
+    expect(
+      command.mock.calls.some(
+        ([value]) =>
+          String(value).includes("xdg-settings set default-web-browser google-chrome.desktop") &&
+          String(value).includes("WebBrowser=google-chrome"),
+      ),
+    ).toBe(true);
     expect(desktop.launch).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens http(s) URLs through the named browser launcher", async () => {
+    const command = vi.fn(async (value: string) => {
+      if (value.includes("RAKAZO_SCREEN_INDEX=")) {
+        return { stdout: "RAKAZO_SCREEN_INDEX=0\n", stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const launch = vi.fn(async () => undefined);
+    const open = vi.fn(async () => undefined);
+    const desktop = {
+      sandboxId: "e2b-open-url-box",
+      display: ":0",
+      commands: { run: command },
+      files: { makeDir: vi.fn(async () => undefined) },
+      launch,
+      open,
+    } as unknown as Sandbox;
+    const provider = new E2BSandboxProvider("test-key", {
+      create: vi.fn(async () => desktop),
+      connect: vi.fn(async () => desktop),
+      pause: vi.fn(async () => undefined),
+    });
+    const computer = await provider.provision(
+      { botId: "bot-1", homePath: "/unused", providerKind: "e2b" },
+      context,
+    );
+
+    await provider.act(
+      computer,
+      { actions: [{ kind: "open", path: "https://example.com/docs" }], observe: false },
+      context,
+    );
+    expect(launch).toHaveBeenCalledWith("google-chrome", "https://example.com/docs");
+    expect(open).not.toHaveBeenCalled();
+
+    await provider.act(
+      computer,
+      { actions: [{ kind: "open", path: "notes/readme.md" }], observe: false },
+      context,
+    );
+    expect(open).toHaveBeenCalledWith("/home/user/rakazo-home/notes/readme.md");
   });
 
   it("controls the desktop and exposes a portable workspace", async () => {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -79,10 +79,12 @@ export function isUnrecoverableSandboxError(error: unknown): boolean {
 
 export const E2B_BROWSER_APPS = ["google-chrome", "firefox", "chromium"] as const;
 
-export async function openDesktopBrowser(desktop: {
+type E2BDesktopBrowser = {
   launch: (application: string, uri?: string) => Promise<void>;
   open: (fileOrUrl: string) => Promise<void>;
-}): Promise<void> {
+};
+
+export async function openDesktopBrowser(desktop: E2BDesktopBrowser): Promise<void> {
   for (const app of E2B_BROWSER_APPS) {
     try {
       await desktop.launch(app);
@@ -92,6 +94,19 @@ export async function openDesktopBrowser(desktop: {
     }
   }
   await desktop.open("https://www.google.com").catch(() => undefined);
+}
+
+/** Open an http(s) URL via a named browser — avoids the broken default-browser association. */
+export async function openDesktopUrl(desktop: E2BDesktopBrowser, url: string): Promise<void> {
+  for (const app of E2B_BROWSER_APPS) {
+    try {
+      await desktop.launch(app, url);
+      return;
+    } catch {
+      // try the next installed browser
+    }
+  }
+  await desktop.open(url);
 }
 
 export class E2BSandboxProvider implements SandboxProvider {
@@ -221,6 +236,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     const desktop = await this.box(computer);
     if (computer.fresh) await desktop.files.makeDir(E2B_WORKSPACE);
     const profilesChanged = await configurePortableBrowserProfiles(desktop);
+    await configureDefaultWebBrowser(desktop);
     if (!computer.fresh && profilesChanged) await openDesktopBrowser(desktop);
   }
 
@@ -762,6 +778,20 @@ async function configurePortableBrowserProfiles(desktop: Sandbox): Promise<boole
   return true;
 }
 
+/** Point xdg-open / XFCE exo-open at Chrome. Lives outside the checkpointed workspace. */
+async function configureDefaultWebBrowser(desktop: Sandbox): Promise<void> {
+  await desktop.commands
+    .run(
+      [
+        "command -v google-chrome >/dev/null 2>&1 || exit 0",
+        'mkdir -p "$HOME/.config/xfce4"',
+        "printf 'WebBrowser=google-chrome\\n' > \"$HOME/.config/xfce4/helpers.rc\"",
+        "xdg-settings set default-web-browser google-chrome.desktop",
+      ].join(" && "),
+    )
+    .catch(() => undefined);
+}
+
 async function stopDesktopBrowsers(desktop: Sandbox): Promise<void> {
   await desktop.commands.run(PORTABLE_BROWSER_STOP_COMMAND).catch(() => undefined);
 }
@@ -799,10 +829,11 @@ async function applyE2BAction(desktop: Sandbox, action: ComputerAction): Promise
     return;
   }
   if (action.kind === "open") {
-    const value = /^https?:\/\//i.test(action.path)
-      ? action.path
-      : workspacePath(E2B_WORKSPACE, action.path);
-    await desktop.open(value);
+    if (/^https?:\/\//i.test(action.path)) {
+      await openDesktopUrl(desktop, action.path);
+      return;
+    }
+    await desktop.open(workspacePath(E2B_WORKSPACE, action.path));
     return;
   }
   await desktop.launch(action.application, action.uri);

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -84,6 +84,10 @@ type E2BDesktopBrowser = {
   open: (fileOrUrl: string) => Promise<void>;
 };
 
+type E2BDesktopCommands = {
+  run: (cmd: string) => Promise<{ exitCode?: number }>;
+};
+
 export async function openDesktopBrowser(desktop: E2BDesktopBrowser): Promise<void> {
   for (const app of E2B_BROWSER_APPS) {
     try {
@@ -97,14 +101,21 @@ export async function openDesktopBrowser(desktop: E2BDesktopBrowser): Promise<vo
 }
 
 /** Open an http(s) URL via a named browser — avoids the broken default-browser association. */
-export async function openDesktopUrl(desktop: E2BDesktopBrowser, url: string): Promise<void> {
+export async function openDesktopUrl(
+  desktop: E2BDesktopBrowser & { commands: E2BDesktopCommands },
+  url: string,
+): Promise<void> {
   for (const app of E2B_BROWSER_APPS) {
-    try {
-      await desktop.launch(app, url);
-      return;
-    } catch {
-      // try the next installed browser
-    }
+    // desktop.launch backgrounds gtk-launch and always resolves, so probe first.
+    const available = await desktop.commands
+      .run(`command -v ${shellQuote(app)} >/dev/null 2>&1`)
+      .then(
+        (result) => (result.exitCode ?? 0) === 0,
+        () => false,
+      );
+    if (!available) continue;
+    await desktop.launch(app, url);
+    return;
   }
   await desktop.open(url);
 }

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -106,16 +106,15 @@ export async function openDesktopUrl(
   url: string,
 ): Promise<void> {
   for (const app of E2B_BROWSER_APPS) {
-    // desktop.launch backgrounds gtk-launch and always resolves, so probe first.
-    const available = await desktop.commands
-      .run(`command -v ${shellQuote(app)} >/dev/null 2>&1`)
+    // Prefer a foreground gtk-launch so missing desktop entries / launch failures reject
+    // and we can try the next browser. desktop.launch backgrounds and always resolves.
+    const launched = await desktop.commands
+      .run(`gtk-launch ${shellQuote(app)} ${shellQuote(url)}`)
       .then(
         (result) => (result.exitCode ?? 0) === 0,
         () => false,
       );
-    if (!available) continue;
-    await desktop.launch(app, url);
-    return;
+    if (launched) return;
   }
   await desktop.open(url);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On E2B, `open` for http(s) URLs failed because the image’s default browser association (`debian-sensible-browser.desktop`) does not resolve, so `xdg-open` / XFCE `exo-open` never launch Chrome.

## Changes
- Route http(s) `open` actions through `openDesktopUrl`, which tries `gtk-launch` over `E2B_BROWSER_APPS` via `commands.run` (foreground, so missing desktop entries / launch failures can fall through) and only then `desktop.open`.
- During `prepare`, if Chrome is present, set the default web browser (`xdg-settings` + `~/.config/xfce4/helpers.rc`) so association-based opens also work. This runs per machine because those paths are outside the checkpointed workspace.
- Leave non-URL `open` paths unchanged (workspace files via `desktop.open`).
- Add unit coverage that URL opens hit the named-browser launcher.

Fixes #197

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-297fdc85-d9c3-42b8-9efa-ddb641c8ebca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-297fdc85-d9c3-42b8-9efa-ddb641c8ebca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

