### PR TITLE
fix: gate screenshot computer tools on model vision capability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ SANDBOX_IDLE_MS=600000
 SANDBOX_COMMAND_TIMEOUT_MS=300000
 OPENROUTER_API_KEY=
 PI_DEFAULT_PROVIDER=openrouter
+# Text-only by default. Computer use (screenshots via computer_observe / computer_act)
+# needs a vision-capable model — one whose catalog entry lists image input modalities
+# (e.g. openai/gpt-4o). Tests use COMPUTER_E2E_MODEL for that.
 PI_DEFAULT_MODEL=deepseek/deepseek-v4-flash-0731
 # Optional local OpenAI-compatible models. Leave blank to disable the provider.
 RAKAZO_LOCAL_MODELS=

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -121,6 +121,12 @@ import {
 import { loadAgentMemoryContext } from "./memory-context.js";
 import type { MemoryProviderResolver } from "./memory-provider-factory.js";
 import { selectMemoryTools } from "./memory-tools.js";
+import {
+  filterImageReturningComputerTools,
+  IMAGE_RETURNING_COMPUTER_TOOLS,
+  MODEL_CANNOT_SEE_MESSAGE,
+  modelAcceptsImageInput,
+} from "./model-vision.js";
 import { toOAuthCredential } from "./pi-credentials.js";
 import {
   parseModelSecret,
@@ -179,12 +185,6 @@ const MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 6;
 // Backstop for a stuck agent that varies its arguments each call (so the exact-match cap above
 // never trips) but keeps hammering the same tool without ever narrating progress in between.
 const MAX_CONSECUTIVE_SAME_TOOL_CALLS = 20;
-const GRAPHICAL_AGENT_TOOLS = new Set([
-  "computer_observe",
-  "computer_act",
-  "open_path",
-  "launch_app",
-]);
 const BUILTIN_AGENT_TOOL_NAMES = new Set(builtinAgentTools.map((tool) => tool.name));
 
 export interface ExecutorDeps {
@@ -695,13 +695,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const attachedFilesPrompt = currentTurnFilesInstruction(currentTurnFiles);
         const graphical =
           computer.kind !== "desktop" && deps.sandbox.describe().capabilities.graphical;
+        const modelProvider = credential?.provider ?? settings?.defaultModelProvider ?? "scripted";
+        const modelId = credential?.defaultModel ?? settings?.defaultModelId ?? "scripted";
+        const acceptsImages = modelAcceptsImageInput(modelProvider, modelId);
         const groupContext = thread.groupId
           ? await loadGroupContext(deps.prisma, thread.groupId)
           : undefined;
+        const graphicalToolsAllowed = graphical && acceptsImages;
         const availableBuiltins = filterBuiltinToolsForThread(
-          graphical
-            ? builtinAgentTools
-            : builtinAgentTools.filter((tool) => !GRAPHICAL_AGENT_TOOLS.has(tool.name)),
+          filterImageReturningComputerTools(builtinAgentTools, graphicalToolsAllowed),
           thread.groupId,
         );
         const builtins = selectMemoryTools(availableBuiltins, semanticMemoryEnabled);
@@ -727,9 +729,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
           return approvalRulesPromise;
         };
         const tools = [...builtins, ...exposedConnectorTools];
-        const computerInstruction = graphical
+        const computerInstruction = graphicalToolsAllowed
           ? "You have a persistent computer. Use computer_observe and computer_act for its visible desktop, including browsers and installed applications. Use open_path and launch_app to open graphical files, URLs, and applications. Use the file tools and shell for precise filesystem and terminal work. On a Team Computer you have your own screen; other Team bots may run at the same time on theirs. Another user may interact with your screen while you run, so re-observe when it may have changed."
-          : "You have a persistent sandbox filesystem and shell. This backend does not provide model-visible graphical control, so use the file tools and shell.";
+          : graphical
+            ? `You have a persistent computer filesystem and shell. ${MODEL_CANNOT_SEE_MESSAGE} Desktop observe and act tools are unavailable until a vision-capable model is selected. Use the file tools and shell.`
+            : "You have a persistent sandbox filesystem and shell. This backend does not provide model-visible graphical control, so use the file tools and shell.";
         const workspaceInstruction =
           computerMode === "team"
             ? `Your Team Computer home is ${teamBotWorkspaceDirectory(bot.id)}. Relative file paths and shell working directories start there. Put intentionally shared work under shared/. Other bots' folders are visible under bots/; treat them as their working areas.`
@@ -802,6 +806,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
           args: Record<string, unknown>,
           executionId: string,
         ) => {
+          if (IMAGE_RETURNING_COMPUTER_TOOLS.has(name) && !acceptsImages) {
+            return { error: MODEL_CANNOT_SEE_MESSAGE };
+          }
           const viaConnector = !BUILTIN_AGENT_TOOL_NAMES.has(name);
           const requiresApprovalByDefault = toolRequiresApproval(name, viaConnector);
           const approvalDecision = resolveActionApproval({

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -697,7 +697,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
           computer.kind !== "desktop" && deps.sandbox.describe().capabilities.graphical;
         const modelProvider = credential?.provider ?? settings?.defaultModelProvider ?? "scripted";
         const modelId = credential?.defaultModel ?? settings?.defaultModelId ?? "scripted";
-        const acceptsImages = modelAcceptsImageInput(modelProvider, modelId);
+        // Scripted runtime fixtures still need screenshot tools; for Pi, resolve
+        // the scripted placeholder the same way the runtime does before gating.
+        const acceptsImages =
+          deps.runtime.describe().capabilities.scripted ||
+          modelAcceptsImageInput(modelProvider, modelId);
         const groupContext = thread.groupId
           ? await loadGroupContext(deps.prisma, thread.groupId)
           : undefined;

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -38,6 +38,7 @@ export * from "./mcp-server-tool.js";
 export * from "./mcp-transport.js";
 export * from "./memory-provider-factory.js";
 export * from "./model-connect.js";
+export * from "./model-vision.js";
 export * from "./openai-compatible-url.js";
 export * from "./openai-voice.js";
 export * from "./pi-models.js";

--- a/packages/adapters/src/model-vision.test.ts
+++ b/packages/adapters/src/model-vision.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { builtinAgentTools } from "./builtin-tools.js";
 import {
   filterImageReturningComputerTools,
   IMAGE_RETURNING_COMPUTER_TOOLS,
   MODEL_CANNOT_SEE_MESSAGE,
   modelAcceptsImageInput,
+  resolveModelRefForVisionCheck,
 } from "./model-vision.js";
 
 describe("model vision gating for computer tools", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("treats catalog text-only models as unable to see", () => {
     expect(modelAcceptsImageInput("openrouter", "deepseek/deepseek-v4-flash-0731")).toBe(false);
     expect(modelAcceptsImageInput("openrouter", "deepseek/deepseek-v4-pro")).toBe(false);
@@ -20,9 +25,25 @@ describe("model vision gating for computer tools", () => {
     );
   });
 
-  it("treats unknown models as text-only and allows scripted fixtures", () => {
-    expect(modelAcceptsImageInput("openrouter", "rakazo-test/unknown-future-model")).toBe(false);
+  it("resolves the scripted placeholder like Pi before checking vision", () => {
+    expect(resolveModelRefForVisionCheck("scripted", "scripted")).toEqual({
+      provider: "openrouter",
+      id: "deepseek/deepseek-v4-flash-0731",
+    });
+    // Default PI_DEFAULT_MODEL is text-only, so the scripted fallback must not
+    // expose screenshot tools (reproduces the self-host default failure mode).
+    expect(modelAcceptsImageInput("scripted", "scripted")).toBe(false);
+
+    vi.stubEnv("PI_DEFAULT_MODEL", "openai/gpt-4o");
+    expect(resolveModelRefForVisionCheck("scripted", "scripted")).toEqual({
+      provider: "openrouter",
+      id: "openai/gpt-4o",
+    });
     expect(modelAcceptsImageInput("scripted", "scripted")).toBe(true);
+  });
+
+  it("treats unknown models as text-only", () => {
+    expect(modelAcceptsImageInput("openrouter", "rakazo-test/unknown-future-model")).toBe(false);
   });
 
   it("omits image-returning computer tools for text-only models", () => {

--- a/packages/adapters/src/model-vision.test.ts
+++ b/packages/adapters/src/model-vision.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { builtinAgentTools } from "./builtin-tools.js";
+import {
+  filterImageReturningComputerTools,
+  IMAGE_RETURNING_COMPUTER_TOOLS,
+  MODEL_CANNOT_SEE_MESSAGE,
+  modelAcceptsImageInput,
+} from "./model-vision.js";
+
+describe("model vision gating for computer tools", () => {
+  it("treats catalog text-only models as unable to see", () => {
+    expect(modelAcceptsImageInput("openrouter", "deepseek/deepseek-v4-flash-0731")).toBe(false);
+    expect(modelAcceptsImageInput("openrouter", "deepseek/deepseek-v4-pro")).toBe(false);
+  });
+
+  it("treats catalog vision models as able to see", () => {
+    expect(modelAcceptsImageInput("openrouter", "openai/gpt-4o")).toBe(true);
+    expect(modelAcceptsImageInput("openrouter", "deepseek/deepseek-v4-flash-vision-exp")).toBe(
+      true,
+    );
+  });
+
+  it("treats unknown models as text-only and allows scripted fixtures", () => {
+    expect(modelAcceptsImageInput("openrouter", "rakazo-test/unknown-future-model")).toBe(false);
+    expect(modelAcceptsImageInput("scripted", "scripted")).toBe(true);
+  });
+
+  it("omits image-returning computer tools for text-only models", () => {
+    const names = filterImageReturningComputerTools(builtinAgentTools, false).map(
+      (tool) => tool.name,
+    );
+    for (const name of IMAGE_RETURNING_COMPUTER_TOOLS) {
+      expect(names).not.toContain(name);
+    }
+    expect(names).toContain("shell");
+    expect(names).toContain("list_files");
+  });
+
+  it("keeps image-returning computer tools for vision models", () => {
+    const names = filterImageReturningComputerTools(builtinAgentTools, true).map(
+      (tool) => tool.name,
+    );
+    expect(names).toEqual(builtinAgentTools.map((tool) => tool.name));
+    expect(names).toContain("computer_observe");
+    expect(names).toContain("computer_act");
+  });
+
+  it("exposes a clear operator-facing cannot-see message", () => {
+    expect(MODEL_CANNOT_SEE_MESSAGE).toMatch(/cannot see/i);
+    expect(MODEL_CANNOT_SEE_MESSAGE).toMatch(/vision-capable model/i);
+  });
+});

--- a/packages/adapters/src/model-vision.ts
+++ b/packages/adapters/src/model-vision.ts
@@ -1,0 +1,56 @@
+import type { Models } from "@earendil-works/pi-ai";
+import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import { registerLocalProvider } from "./pi-local-provider.js";
+import {
+  OPENAI_COMPATIBLE_PROVIDER_ID,
+  registerOpenAiCompatibleCatalog,
+} from "./pi-openai-compatible-provider.js";
+
+/** Computer tools whose results include screenshots for the model. */
+export const IMAGE_RETURNING_COMPUTER_TOOLS = new Set([
+  "computer_observe",
+  "computer_act",
+  "open_path",
+  "launch_app",
+]);
+
+export const MODEL_CANNOT_SEE_MESSAGE = "This bot's model cannot see; pick a vision-capable model.";
+
+let catalogModelsCache: Models | undefined;
+
+function catalogModels(): Models {
+  catalogModelsCache ??= registerOpenAiCompatibleCatalog(registerLocalProvider(builtinModels()));
+  return catalogModelsCache;
+}
+
+/**
+ * Whether the selected model accepts image input, per the Pi model catalog's
+ * declared `input` modalities. Unknown models are treated as text-only.
+ * Scripted fixtures always allow images so local verification still covers
+ * computer tools.
+ */
+export function modelAcceptsImageInput(provider: string, modelId: string): boolean {
+  const normalizedProvider = provider.trim();
+  const normalizedId = modelId.trim();
+  if (!normalizedProvider || !normalizedId) return false;
+  if (normalizedProvider === "scripted" || normalizedId === "scripted") return true;
+
+  const models = catalogModels();
+  let model = models.getModel(normalizedProvider, normalizedId);
+  if (
+    !model &&
+    normalizedProvider !== "openrouter" &&
+    normalizedProvider !== OPENAI_COMPATIBLE_PROVIDER_ID
+  ) {
+    model = models.getModel("openrouter", normalizedId);
+  }
+  return Boolean(model?.input.includes("image"));
+}
+
+export function filterImageReturningComputerTools<T extends { name: string }>(
+  tools: T[],
+  acceptsImages: boolean,
+): T[] {
+  if (acceptsImages) return tools;
+  return tools.filter((tool) => !IMAGE_RETURNING_COMPUTER_TOOLS.has(tool.name));
+}

--- a/packages/adapters/src/model-vision.ts
+++ b/packages/adapters/src/model-vision.ts
@@ -16,6 +16,8 @@ export const IMAGE_RETURNING_COMPUTER_TOOLS = new Set([
 
 export const MODEL_CANNOT_SEE_MESSAGE = "This bot's model cannot see; pick a vision-capable model.";
 
+const SCRIPTED_DEFAULT_MODEL_ID = "deepseek/deepseek-v4-flash-0731";
+
 let catalogModelsCache: Models | undefined;
 
 function catalogModels(): Models {
@@ -24,25 +26,42 @@ function catalogModels(): Models {
 }
 
 /**
- * Whether the selected model accepts image input, per the Pi model catalog's
- * declared `input` modalities. Unknown models are treated as text-only.
- * Scripted fixtures always allow images so local verification still covers
- * computer tools.
+ * Mirror Pi's scripted placeholder resolution so vision checks use the same
+ * model the runtime will actually call.
  */
-export function modelAcceptsImageInput(provider: string, modelId: string): boolean {
+export function resolveModelRefForVisionCheck(
+  provider: string,
+  modelId: string,
+): { provider: string; id: string } {
   const normalizedProvider = provider.trim();
   const normalizedId = modelId.trim();
-  if (!normalizedProvider || !normalizedId) return false;
-  if (normalizedProvider === "scripted" || normalizedId === "scripted") return true;
+  if (normalizedProvider === "scripted" || normalizedId === "scripted") {
+    return {
+      provider: "openrouter",
+      id: process.env.PI_DEFAULT_MODEL?.trim() || SCRIPTED_DEFAULT_MODEL_ID,
+    };
+  }
+  return { provider: normalizedProvider, id: normalizedId };
+}
+
+/**
+ * Whether the selected model accepts image input, per the Pi model catalog's
+ * declared `input` modalities. Unknown models are treated as text-only.
+ * The `scripted` placeholder is resolved the same way Pi does (env default /
+ * DeepSeek fallback) before the catalog check.
+ */
+export function modelAcceptsImageInput(provider: string, modelId: string): boolean {
+  const resolved = resolveModelRefForVisionCheck(provider, modelId);
+  if (!resolved.provider || !resolved.id) return false;
 
   const models = catalogModels();
-  let model = models.getModel(normalizedProvider, normalizedId);
+  let model = models.getModel(resolved.provider, resolved.id);
   if (
     !model &&
-    normalizedProvider !== "openrouter" &&
-    normalizedProvider !== OPENAI_COMPATIBLE_PROVIDER_ID
+    resolved.provider !== "openrouter" &&
+    resolved.provider !== OPENAI_COMPATIBLE_PROVIDER_ID
   ) {
-    model = models.getModel("openrouter", normalizedId);
+    model = models.getModel("openrouter", resolved.id);
   }
   return Boolean(model?.input.includes("image"));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Computer tools that return screenshots (`computer_observe`, `computer_act`, `open_path`, `launch_app`) were attached whenever a bot had a graphical computer, even when the selected model only accepts text. Text-only models (including the default `PI_DEFAULT_MODEL`) then failed in a generic, confusing way.

## Changes

- Consult the Pi model catalog’s declared `input` modalities before exposing image-returning computer tools.
- If the model cannot take images, omit those tools and instruct the agent accordingly; if one is invoked anyway, return: `This bot's model cannot see; pick a vision-capable model.`
- Keep shell/file tools available for text-only models with a computer.
- Comment in `.env.example` that computer use needs a vision-capable model (default stays text-only).
- Unit tests cover text-only vs vision catalog models and tool filtering.

Refs #199

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03cc48b1-56f9-43ab-9e2a-a56972ab172e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03cc48b1-56f9-43ab-9e2a-a56972ab172e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved computer-use support by showing screenshot tools only to models capable of processing images.
  * Added clear guidance when a selected model cannot view screenshots.
  * Vision-capable model detection now supports known models and scripted test configurations.

* **Bug Fixes**
  * Prevented incompatible models from receiving or invoking image-based computer tools.

* **Documentation**
  * Clarified vision model requirements and test configuration in the environment template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->