### PR TITLE
Default the Linux production deploy directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,9 +58,9 @@ LOG_LEVEL=info
 GIT_SHA=
 
 # --- Compose production deployments ---
-# Absolute path of this checkout as the Docker *daemon* sees it. Required by
-# infra/compose/docker-compose.prod.yml so the updater sidecar bind-mount resolves.
-# Linux: RAKAZO_DEPLOY_DIR=/srv/rakazo
+# Absolute path of this checkout as the Docker *daemon* sees it. Production Compose defaults to
+# /srv/rakazo on Linux; override it for any other host path so the updater bind mount resolves.
+# Linux override: RAKAZO_DEPLOY_DIR=/opt/rakazo
 # Docker Desktop on Windows (C:\Users\you\rakazo):
 #   RAKAZO_DEPLOY_DIR=/run/desktop/mnt/host/c/Users/you/rakazo
 RAKAZO_DEPLOY_DIR=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,18 +127,11 @@ jobs:
 
       - name: Deploy successful main revision
         env:
-          PRODUCTION_DEPLOY_DIR: ${{ vars.PRODUCTION_DEPLOY_DIR }}
           SSH_HOST: ${{ secrets.PRODUCTION_SSH_HOST }}
           SSH_USER: ${{ secrets.PRODUCTION_SSH_USER }}
         run: |
-          test -n "$PRODUCTION_DEPLOY_DIR"
           test -n "$SSH_HOST"
           test -n "$SSH_USER"
-          case "$PRODUCTION_DEPLOY_DIR" in
-            /*) ;;
-            *) echo "PRODUCTION_DEPLOY_DIR must be an absolute path" >&2; exit 1 ;;
-          esac
-          printf -v remote_deploy_dir '%q' "$PRODUCTION_DEPLOY_DIR"
           ssh -F /dev/null \
             -i "$HOME/.ssh/rakazo-production" \
             -o BatchMode=yes \
@@ -146,4 +139,4 @@ jobs:
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
             -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
-            "$SSH_USER@$SSH_HOST" "RAKAZO_DEPLOY_DIR=$remote_deploy_dir deploy-main"
+            "$SSH_USER@$SSH_HOST" deploy-main

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -119,10 +119,11 @@ container logs, default no-new-privileges, and the kernel NAT path instead of Do
    whenever Cloudflare publishes a change. A Cloudflare Tunnel can replace the public web listeners.
 2. Clone the repository on the VM and create a root `.env` with production-only values. At minimum set
    `POSTGRES_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `E2B_API_KEY`, `OPENROUTER_API_KEY`,
-   `RAKAZO_HOST`, the three public origins, `RAKAZO_DEPLOY_DIR`, and `RAKAZO_UPDATER_TOKEN`. Use
-   URL-safe random values for database credentials. The updater token must be a dedicated random
-   string (at least 32 characters) that differs from `BETTER_AUTH_SECRET` and
-   `SANDBOX_SUPERVISOR_TOKEN`; without it `up --wait` fails because the sidecar refuses to start.
+   `RAKAZO_HOST`, the three public origins, and `RAKAZO_UPDATER_TOKEN`. Set `RAKAZO_DEPLOY_DIR` when
+   the checkout is not at the supported Linux default, `/srv/rakazo`. Use URL-safe random values for
+   database credentials. The updater token must be a dedicated random string (at least 32 characters)
+   that differs from `BETTER_AUTH_SECRET` and `SANDBOX_SUPERVISOR_TOKEN`; without it `up --wait`
+   fails because the sidecar refuses to start.
 3. Keep registration allowlisted while the service is private:
 
 ```env
@@ -139,9 +140,8 @@ SANDBOX_PROVIDER=e2b
 AGENT_RUNTIME=pi
 WAKEUP_DRIVER=graphile
 DATA_DIR=/data
-# Absolute path of this checkout as the Docker daemon sees it. Required: the updater sidecar is
-# bind-mounted at exactly this path so Compose resolves the same bind mounts inside the container
-# that it does from your shell. See "The deploy directory must be one path" below.
+# Absolute path of this checkout as the Docker daemon sees it. /srv/rakazo is the Linux default;
+# set this explicitly for every other layout. See "The deploy directory must be one path" below.
 RAKAZO_DEPLOY_DIR=/srv/rakazo
 RAKAZO_IMAGE_TAG=local
 # Dedicated updater credential (not BETTER_AUTH_SECRET / SANDBOX_SUPERVISOR_TOKEN).
@@ -299,7 +299,8 @@ untracked source tree fails closed before anything runs (the application Dockerf
 ### The deploy directory must be one path
 
 `RAKAZO_DEPLOY_DIR` is bind-mounted into the updater at the same path it is read from
-(`${RAKAZO_DEPLOY_DIR}:${RAKAZO_DEPLOY_DIR}`), and that is load-bearing rather than tidy. When the
+(`${RAKAZO_DEPLOY_DIR}:${RAKAZO_DEPLOY_DIR}`), and that is load-bearing rather than tidy. Production
+Compose defaults both sides to `/srv/rakazo`; set the variable for any other layout. When the
 updater runs `docker compose -p <project> --file $RAKAZO_DEPLOY_DIR/infra/compose/docker-compose.prod.yml up -d`,
 the Compose CLI *inside* the container expands this file's relative bind mounts — `../../.env`,
 `./Caddyfile.prod` — against that path and hands the results to the daemon. The daemon has to be
@@ -315,7 +316,8 @@ The value therefore has to be the path **the daemon** sees, which is not always 
 sees:
 
 - **Linux.** The daemon shares the host filesystem, so the checkout path is the answer:
-  `RAKAZO_DEPLOY_DIR=/srv/rakazo`. This is the supported production layout.
+  `/srv/rakazo` is the default and supported production layout. Set `RAKAZO_DEPLOY_DIR` explicitly
+  when the checkout is elsewhere.
 - **Docker Desktop (Windows/macOS).** The daemon runs in a VM that mounts your drive somewhere else.
   On Windows, `C:` appears at `/run/desktop/mnt/host/c`, so a checkout at `C:\Users\you\rakazo` is
   `RAKAZO_DEPLOY_DIR=/run/desktop/mnt/host/c/Users/you/rakazo`. Host Git may use `core.autocrlf=true`; the updater ignores CR-only diffs so that does not block `/apply`. Verify the mount before deploying:

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -175,13 +175,13 @@ services:
       # `-p` is available to Compose interpolation but is not injected into containers unless it is
       # declared here. The sidecar must target the project the operator actually started.
       COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-rakazo-prod}
-      # Must equal the host path it is mounted from, or Compose would derive a different project
-      # name and every relative bind mount in this file would resolve somewhere else.
-      RAKAZO_DEPLOY_DIR: ${RAKAZO_DEPLOY_DIR:?Set RAKAZO_DEPLOY_DIR to the absolute path of this checkout}
+      # Must equal the host path it is mounted from, or every relative bind mount in this file would
+      # resolve somewhere else. /srv/rakazo is the supported Linux production layout.
+      RAKAZO_DEPLOY_DIR: ${RAKAZO_DEPLOY_DIR:-/srv/rakazo}
       RAKAZO_COMPOSE_FILE: infra/compose/docker-compose.prod.yml
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ${RAKAZO_DEPLOY_DIR:?Set RAKAZO_DEPLOY_DIR to the absolute path of this checkout}:${RAKAZO_DEPLOY_DIR:?Set RAKAZO_DEPLOY_DIR to the absolute path of this checkout}
+      - ${RAKAZO_DEPLOY_DIR:-/srv/rakazo}:${RAKAZO_DEPLOY_DIR:-/srv/rakazo}
     networks:
       - control
     healthcheck:

--- a/infra/updater/src/compose-service.test.ts
+++ b/infra/updater/src/compose-service.test.ts
@@ -55,9 +55,13 @@ describe("the updater compose service", () => {
 
   it("is bind-mounted at the same path it has on the host", () => {
     const mount = (updater.volumes ?? []).find((volume) => volume.includes("RAKAZO_DEPLOY_DIR"));
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: this is the literal Compose expression
+    const deployDir = "${RAKAZO_DEPLOY_DIR:-/srv/rakazo}";
     const separatorIndex = mount?.indexOf("}:${") ?? -1;
     const source = separatorIndex < 0 ? undefined : mount?.slice(0, separatorIndex + 1);
     const destination = separatorIndex < 0 ? undefined : mount?.slice(separatorIndex + 2);
+    expect(updater.environment?.RAKAZO_DEPLOY_DIR).toBe(deployDir);
+    expect(mount).toBe(`${deployDir}:${deployDir}`);
     expect(source).toBe(destination);
   });
 


### PR DESCRIPTION
## Summary
- default the updater checkout mount to the documented Linux production layout, `/srv/rakazo`
- keep `RAKAZO_DEPLOY_DIR` as an explicit override for every nonstandard and Docker Desktop layout
- assert that Compose injects and bind-mounts the exact same path
- remove the ineffective workflow-level environment forwarding, which the restricted host wrapper sanitizes
- update `.env.example` and self-hosting documentation

## Validation
- `pnpm test -- infra/updater/src/compose-service.test.ts infra/updater/src/updater-logic.test.ts` (27 passed)
- default Compose config resolves `/srv/rakazo:/srv/rakazo`
- override Compose config resolves `/opt/rakazo:/opt/rakazo`
- `pnpm lint`
- workflow YAML parse
- `git diff --check`

## Production evidence
The merged workflow fix reached the restricted `deploy-main` wrapper, but the wrapper intentionally sanitized the remote assignment before invoking Compose. The host checkout is the documented `/srv/rakazo` layout, so making that the production Compose default fixes the migration without touching secrets or weakening override support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Improvements**
  - Production deployments now default to `/srv/rakazo` for the deployment directory.
  - Deployments no longer require explicitly setting the deployment directory when using the default checkout location.
  - Custom checkout locations remain supported by setting `RAKAZO_DEPLOY_DIR`.

- **Documentation**
  - Updated self-hosting and environment configuration guidance with default paths and override instructions.
  - Clarified Docker daemon path requirements for deployment-directory mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->