### PR TITLE
Make production updater sidecar opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,8 @@ RAKAZO_IMAGE_TAG=local
 RAKAZO_IMAGE_TAG_PREVIOUS=
 RAKAZO_UPDATER_IMAGE=ghcr.io/elie222/rakazo/updater
 RAKAZO_UPDATER_IMAGE_TAG=local
-# Required by infra/compose/docker-compose.prod.yml (sidecar refuses to start without it).
-# Dedicated random value, not BETTER_AUTH_SECRET / SANDBOX_SUPERVISOR_TOKEN; ≥32 chars in production.
-# Leave empty for source checkouts that do not run the sidecar.
+# Required only when starting the opt-in `updater` Compose profile; the sidecar refuses to start
+# without it. Use a dedicated random value, not BETTER_AUTH_SECRET / SANDBOX_SUPERVISOR_TOKEN;
+# ≥32 chars in production. Leave empty when the sidecar is disabled.
 RAKAZO_UPDATER_URL=
 RAKAZO_UPDATER_TOKEN=

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -158,10 +158,11 @@ curl --fail https://app.example.com/health
 ```
 
 **Build, do not pull, for a first deployment.** `RAKAZO_IMAGE_TAG` ships as `local`, a tag no
-registry serves, so the commands above build `api`, `worker`, `web`, and `updater` from the checkout
-you just cloned. Running `docker compose … pull` first — as earlier versions of this page told you
-to — fails outright with `error from registry: denied` whenever the tag you are on has not been
-published, and there is nothing to fall back to.
+registry serves, so the commands above build `api`, `worker`, and `web` from the checkout you just
+cloned. The opt-in command under [Updater sidecar](#updater-sidecar) builds `updater` when needed.
+Running `docker compose … pull` first — as earlier versions of this page told you to — fails outright
+with `error from registry: denied` whenever the tag you are on has not been published, and there is
+nothing to fall back to.
 
 Passing `GIT_SHA` is what makes `GET /health` report a `"revision"`; a locally built image has no
 other way to know its commit. Prebuilt images from the registry bake it in at publish time, so when

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -96,7 +96,7 @@ This dumps Postgres (`pg_dump`) and archives `data/` into `backups/<stamp>/`.
 
 `infra/compose/docker-compose.prod.yml` runs the hosted product with Postgres, the API, worker, web app,
 and automatic HTTPS through Caddy. It uses E2B for bot computers, so the VM never exposes a Docker
-supervisor or browser containers.
+supervisor or browser containers. The root-equivalent updater sidecar is an explicit opt-in profile.
 
 Before deploying to a new Ubuntu host, create and verify a key-only `deploy` account, then apply the
 idempotent host-hardening baseline. It disables SSH passwords and root login, rate-limits SSH, allows
@@ -119,11 +119,10 @@ container logs, default no-new-privileges, and the kernel NAT path instead of Do
    whenever Cloudflare publishes a change. A Cloudflare Tunnel can replace the public web listeners.
 2. Clone the repository on the VM and create a root `.env` with production-only values. At minimum set
    `POSTGRES_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `E2B_API_KEY`, `OPENROUTER_API_KEY`,
-   `RAKAZO_HOST`, the three public origins, and `RAKAZO_UPDATER_TOKEN`. Set `RAKAZO_DEPLOY_DIR` when
-   the checkout is not at the supported Linux default, `/srv/rakazo`. Use URL-safe random values for
-   database credentials. The updater token must be a dedicated random string (at least 32 characters)
-   that differs from `BETTER_AUTH_SECRET` and `SANDBOX_SUPERVISOR_TOKEN`; without it `up --wait`
-   fails because the sidecar refuses to start.
+   `RAKAZO_HOST`, and the three public origins. Set `RAKAZO_DEPLOY_DIR` when the checkout is not at
+   the supported Linux default, `/srv/rakazo`. Use URL-safe random values for database credentials.
+   If you enable the `updater` profile, also set a dedicated `RAKAZO_UPDATER_TOKEN` (at least 32
+   characters) that differs from `BETTER_AUTH_SECRET` and `SANDBOX_SUPERVISOR_TOKEN`.
 3. Keep registration allowlisted while the service is private:
 
 ```env
@@ -144,8 +143,8 @@ DATA_DIR=/data
 # set this explicitly for every other layout. See "The deploy directory must be one path" below.
 RAKAZO_DEPLOY_DIR=/srv/rakazo
 RAKAZO_IMAGE_TAG=local
-# Dedicated updater credential (not BETTER_AUTH_SECRET / SANDBOX_SUPERVISOR_TOKEN).
-RAKAZO_UPDATER_TOKEN=replace-with-32-plus-character-updater-token
+# Optional: required only with `--profile updater`.
+# RAKAZO_UPDATER_TOKEN=replace-with-32-plus-character-updater-token
 ```
 
 4. Build the images from your checkout and start the stack, then verify its public health endpoint:
@@ -269,8 +268,16 @@ and refuses the official path until a stable `vX.Y.Z` exists.
 
 ### Updater sidecar
 
-Compose production deployments include an `updater` service on a private `control` network. It
-exposes `/health`, `/state`, `/plan`, `/apply`, and `/rollback` at `http://updater:7092` with
+Compose production deployments offer an opt-in `updater` profile on a private `control` network.
+Normal deployments do not start it or require its credential. To enable it, set a dedicated
+`RAKAZO_UPDATER_TOKEN` and explicitly start the profile:
+
+```bash
+docker compose --env-file .env -f infra/compose/docker-compose.prod.yml \
+  --profile updater up -d --build updater
+```
+
+It exposes `/health`, `/state`, `/plan`, `/apply`, and `/rollback` at `http://updater:7092` with
 `RAKAZO_UPDATER_TOKEN`. Operator CLI upgrades above do not need it; the sidecar is for automated
 apply/rollback over that private HTTP API.
 
@@ -324,7 +331,7 @@ sees:
 
 ```bash
 docker compose --env-file .env -f infra/compose/docker-compose.prod.yml \
-  run --rm updater git -C "$RAKAZO_DEPLOY_DIR" log --oneline -1
+  --profile updater run --rm updater git -C "$RAKAZO_DEPLOY_DIR" log --oneline -1
 ```
 
   That must print your checkout's HEAD. The two tempting wrong answers both fail: a native Windows
@@ -347,9 +354,9 @@ as that allows:
 - The Docker CLI lives only in the updater image. The api, worker, and web containers keep
   `cap_drop: ALL` and no socket.
 
-Set `RAKAZO_UPDATER_TOKEN` to a dedicated random value (at least 32 characters in production). It
-must differ from `BETTER_AUTH_SECRET` and `SANDBOX_SUPERVISOR_TOKEN`. Drop the `updater` service if
-you would rather not have the capability at all.
+Enabling the `updater` profile requires `RAKAZO_UPDATER_TOKEN` to be a dedicated random value (at
+least 32 characters in production). It must differ from `BETTER_AUTH_SECRET` and
+`SANDBOX_SUPERVISOR_TOKEN`. Leave the profile disabled if you would rather not grant the capability.
 
 ## What “Rakazo Cloud” still needs
 

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -144,13 +144,14 @@ services:
       api:
         condition: service_healthy
 
-  # The updater holds the Docker socket, which is root-equivalent on the host, so it is deliberately
-  # the narrowest service here: no `ports` (nothing on the host), only the dedicated `control`
-  # network shared with the API, and no `env_file` — secrets stay in the bind-mounted `.env` that
-  # Compose reads for interpolation, not in this process. Caddy has no route to it. The API reaches
-  # it as http://updater:7092 with the shared token. It is also the one service the update never
-  # recreates, because it is the process performing the update.
+  # The updater holds the Docker socket, which is root-equivalent on the host, so it is opt-in and
+  # deliberately the narrowest service here: no `ports` (nothing on the host), only the dedicated
+  # `control` network shared with the API, and no `env_file` — secrets stay in the bind-mounted
+  # `.env` that Compose reads for interpolation, not in this process. Caddy has no route to it. The
+  # API reaches it as http://updater:7092 with the shared token. It is also the one service the
+  # update never recreates, because it is the process performing the update.
   updater:
+    profiles: [updater]
     # Pinned separately from the application image: the updater does not recreate itself, so moving
     # its own version is an operator action, not something an update can do underneath itself.
     image: ${RAKAZO_UPDATER_IMAGE:-ghcr.io/elie222/rakazo/updater}:${RAKAZO_UPDATER_IMAGE_TAG:-local}
@@ -168,7 +169,9 @@ services:
     mem_limit: 1g
     environment:
       NODE_ENV: production
-      RAKAZO_UPDATER_TOKEN: ${RAKAZO_UPDATER_TOKEN:?Set RAKAZO_UPDATER_TOKEN in .env}
+      # Keep interpolation optional so deployments that do not enable this profile need no token.
+      # resolveUpdaterConfig still refuses to start the sidecar without a dedicated secure value.
+      RAKAZO_UPDATER_TOKEN: ${RAKAZO_UPDATER_TOKEN:-}
       RAKAZO_UPDATER_HOST: "0.0.0.0"
       RAKAZO_UPDATER_PORT: "7092"
       RAKAZO_IMAGE: ${RAKAZO_IMAGE:-ghcr.io/elie222/rakazo/app}

--- a/infra/updater/src/compose-service.test.ts
+++ b/infra/updater/src/compose-service.test.ts
@@ -6,6 +6,7 @@ import { parse } from "yaml";
 
 interface ComposeService {
   image?: string;
+  profiles?: string[];
   ports?: unknown[];
   networks?: string[];
   volumes?: string[];
@@ -31,6 +32,10 @@ describe("the updater compose service", () => {
   it("exists and runs the updater image", () => {
     expect(updater).toBeDefined();
     expect(updater.image).toMatch(/updater/);
+  });
+
+  it("is opt-in because it grants root-equivalent Docker access", () => {
+    expect(updater.profiles).toEqual(["updater"]);
   });
 
   it("publishes nothing on the host", () => {
@@ -93,7 +98,8 @@ describe("the updater compose service", () => {
 
   it("does not load the application env_file into the root-equivalent process", () => {
     expect(updater.env_file).toBeUndefined();
-    expect(updater.environment?.RAKAZO_UPDATER_TOKEN).toContain("RAKAZO_UPDATER_TOKEN");
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: this is the literal Compose expression
+    expect(updater.environment?.RAKAZO_UPDATER_TOKEN).toBe("${RAKAZO_UPDATER_TOKEN:-}");
   });
 
   it("does not let the api container reach the Docker socket to update itself", () => {


### PR DESCRIPTION
## Summary
- put the root-equivalent Docker updater behind an explicit Compose profile
- allow the default production stack to resolve without an updater token
- keep runtime token validation intact whenever the updater is enabled
- document and test both deployment modes

## Production failure addressed
The restricted production deploy account cannot edit `.env`. After the deploy-directory migration fixed the first interpolation failure, main reached the next new requirement and rolled back because the existing host has no `RAKAZO_UPDATER_TOKEN`. The normal stack does not use the updater, so it should not require or start the Docker-socket sidecar implicitly.

## Validation
- `POSTGRES_PASSWORD=fake-review-password docker compose --env-file /dev/null -f infra/compose/docker-compose.prod.yml config --services` excludes `updater` and needs no updater token
- the same command with `--profile updater` and a fake 32+ character token includes `updater`
- `pnpm test -- infra/updater/src/compose-service.test.ts infra/updater/src/updater-logic.test.ts` (28 passed)
- `pnpm lint`
- `git diff --check`