### PR TITLE
Fix Codex stream reliability and surface provider failures

### DIFF
--- a/packages/adapters/src/pi-runtime-error.test.ts
+++ b/packages/adapters/src/pi-runtime-error.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@earendil-works/pi-agent-core", () => ({
+  Agent: class {
+    state = { errorMessage: "WebSocket closed 1006", messages: [] };
+
+    subscribe() {}
+    async prompt() {}
+    async waitForIdle() {}
+    abort() {}
+  },
+}));
+
+vi.mock("@earendil-works/pi-ai/providers/all", () => ({
+  builtinModels: () => ({
+    getModel: () => ({ provider: "openai-codex", id: "gpt-test" }),
+    streamSimple: vi.fn(),
+  }),
+}));
+
+vi.mock("./pi-local-provider.js", () => ({
+  registerLocalProvider: (models: unknown) => models,
+}));
+
+vi.mock("./pi-openai-compatible-provider.js", () => ({
+  OPENAI_COMPATIBLE_PROVIDER_ID: "openai-compatible",
+  registerOpenAiCompatibleCatalog: (models: unknown) => models,
+  registerOpenAiCompatibleRuntime: (models: unknown) => models,
+}));
+
+import { PiAgentRuntime } from "./pi-runtime.js";
+
+describe("Pi runtime errors", () => {
+  it("propagates provider failures instead of completing with error text", async () => {
+    const runtime = new PiAgentRuntime();
+    const consume = async () => {
+      for await (const _event of runtime.run(
+        {
+          botId: "bot",
+          threadId: "thread",
+          runId: "run",
+          prompt: "continue",
+          instructions: "test",
+          history: [],
+          tools: [],
+          model: { provider: "openai-codex", id: "gpt-test" },
+        },
+        {
+          operationId: "operation",
+          traceId: "trace",
+          workspaceId: "workspace",
+          userId: "user",
+          signal: new AbortController().signal,
+        },
+      )) {
+        // Consume the stream so terminal failures surface to the executor.
+      }
+    };
+
+    await expect(consume()).rejects.toThrow("WebSocket closed 1006");
+  });
+});

--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -175,7 +175,9 @@ describe("Pi agent thinking level", () => {
     const removeEventListener = vi.spyOn(controller.signal, "removeEventListener");
     fakeAgentState.failPrompt = true;
 
-    await runWithModel("plain-model", "test", controller.signal);
+    await expect(runWithModel("plain-model", "test", controller.signal)).rejects.toThrow(
+      "prompt failed",
+    );
 
     expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
   });

--- a/packages/adapters/src/pi-runtime-transport.test.ts
+++ b/packages/adapters/src/pi-runtime-transport.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 import { reliableStreamOptions } from "./pi-runtime.js";
 
 describe("Pi runtime transport", () => {
-  it("forces SSE for Codex OAuth models", () => {
-    const model = {
-      provider: "openai-codex",
-      api: "openai-codex-responses",
-    } as Model<Api>;
+  it.each([
+    { source: "provider", provider: "openai-codex", api: "openai-completions" },
+    { source: "API", provider: "custom-provider", api: "openai-codex-responses" },
+  ])("forces SSE when Codex is identified by $source", ({ provider, api }) => {
+    const model = { provider, api } as Model<Api>;
 
     expect(reliableStreamOptions(model, { transport: "auto", maxRetries: 4 })).toEqual({
       transport: "sse",

--- a/packages/adapters/src/pi-runtime-transport.test.ts
+++ b/packages/adapters/src/pi-runtime-transport.test.ts
@@ -1,0 +1,24 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { reliableStreamOptions } from "./pi-runtime.js";
+
+describe("Pi runtime transport", () => {
+  it("forces SSE for Codex OAuth models", () => {
+    const model = {
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+    } as Model<Api>;
+
+    expect(reliableStreamOptions(model, { transport: "auto", maxRetries: 4 })).toEqual({
+      transport: "sse",
+      maxRetries: 4,
+    });
+  });
+
+  it("leaves other provider transports unchanged", () => {
+    const model = { provider: "openrouter", api: "openai-completions" } as Model<Api>;
+    const options = { transport: "auto" as const, maxRetries: 2 };
+
+    expect(reliableStreamOptions(model, options)).toBe(options);
+  });
+});

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -5,6 +5,7 @@ import {
   type Model,
   type Models,
   type ModelThinkingLevel,
+  type SimpleStreamOptions,
   Type,
 } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
@@ -129,7 +130,8 @@ export class PiAgentRuntime implements AgentRuntime {
         const history = toHistory(request.history, request.prompt);
 
         const agent = new Agent({
-          streamFn: (m, ctx, options) => models.streamSimple(m, ctx, options),
+          streamFn: (m, ctx, options) =>
+            models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
           getApiKey: async () => apiKey,
           transformContext: async (messages) => pruneComputerScreenshotContext(messages),
           initialState: {
@@ -218,9 +220,7 @@ export class PiAgentRuntime implements AgentRuntime {
 
         const error = agent.state.errorMessage;
         if (error) {
-          queue.push({ type: "text", text: `I hit a problem: ${sanitizeError(error)}` });
-          queue.push({ type: "done", text: sanitizeError(error) });
-          return;
+          throw new Error(sanitizeError(error));
         }
         if (!streamed) {
           const fallback = assistantText(agent.state.messages.at(-1)) || "I finished the work.";
@@ -230,8 +230,7 @@ export class PiAgentRuntime implements AgentRuntime {
         queue.push({ type: "done", text: streamed });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
-        queue.push({ type: "text", text: `I hit a problem: ${message}` });
-        queue.push({ type: "done", text: message });
+        queue.fail(new Error(message));
       } finally {
         queue.close();
       }
@@ -547,7 +546,8 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
   );
   const nestedHost: ToolHost = { ...host, depth: 1 };
   const nested = new Agent({
-    streamFn: (m, ctx, options) => host.models.streamSimple(m, ctx, options),
+    streamFn: (m, ctx, options) =>
+      host.models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
     getApiKey: async () => host.apiKey,
     transformContext: async (messages) => pruneComputerScreenshotContext(messages),
     initialState: {
@@ -836,6 +836,7 @@ function sanitizeError(message: string) {
 
 interface EventQueue {
   push(event: AgentRuntimeEvent): void;
+  fail(error: Error): void;
   close(): void;
   iterate(): AsyncIterable<AgentRuntimeEvent>;
 }
@@ -891,9 +892,15 @@ function createQueue(): EventQueue {
   const items: AgentRuntimeEvent[] = [];
   let wake: (() => void) | undefined;
   let closed = false;
+  let failure: Error | undefined;
   return {
     push(event) {
       items.push(event);
+      wake?.();
+    },
+    fail(error) {
+      failure = error;
+      closed = true;
       wake?.();
     },
     close() {
@@ -901,15 +908,30 @@ function createQueue(): EventQueue {
       wake?.();
     },
     async *iterate() {
-      while (!closed || items.length) {
+      while (true) {
         if (items.length) {
           yield items.shift()!;
           continue;
         }
+        if (failure) throw failure;
+        if (closed) return;
         await new Promise<void>((resolve) => {
           wake = resolve;
         });
       }
     },
   };
+}
+
+export function reliableStreamOptions(
+  model: Pick<Model<Api>, "api" | "provider">,
+  options?: SimpleStreamOptions,
+): SimpleStreamOptions | undefined {
+  if (model.provider !== "openai-codex" && model.api !== "openai-codex-responses") {
+    return options;
+  }
+  // Pi cannot fall back after a WebSocket has emitted its start event. Long tool
+  // runs then surface abnormal close 1006 as a terminal model error. SSE has
+  // bounded network retries and no long-lived connection between tool turns.
+  return { ...options, transport: "sse" };
 }


### PR DESCRIPTION
## Summary

- Force SSE for OpenAI Codex OAuth models so mid-stream WebSocket closures cannot terminate runs with code 1006.
- Apply the same transport choice to nested agents.
- Propagate provider failures through the runtime iterator instead of emitting error text followed by a successful completion.
- Add regression coverage for transport selection and terminal error propagation.

## Verification

- Focused runtime tests: 9 passed.
- Adapter TypeScript check: passed after Prisma client generation.
- Biome: 4 files checked, no issues.
- Full adapter suite: 568 passed, 7 skipped, 3 unrelated failures. The unchanged upstream baseline reproduces the desktop sandbox inode-race failure and local shell startup stderr pollution in sandbox conformance tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider and agent failures now surface as actual errors instead of appearing as completed responses with error text.
  * Improved streaming reliability for OpenAI Codex Responses models by using SSE transport while preserving retry settings.

* **Tests**
  * Added regression coverage for error propagation, prompt failures, and streaming transport behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->