### PR TITLE
fix(web): auto-grow composer so Shift+Enter inserts newlines (#211)

### DIFF
--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -64,11 +64,12 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await expect(page.getByRole("button", { name: new RegExp(userName, "i") })).toBeVisible();
 
   await composer.fill("line one");
+  const heightBeforeNewline = await composer.evaluate((el) => el.getBoundingClientRect().height);
   await composer.press("Shift+Enter");
   await composer.type("line two");
   await expect(composer).toHaveValue("line one\nline two");
   const heightWithNewline = await composer.evaluate((el) => el.getBoundingClientRect().height);
-  expect(heightWithNewline).toBeGreaterThan(24);
+  expect(heightWithNewline).toBeGreaterThan(heightBeforeNewline);
 
   const message = "Fake composer regression check.";
   await composer.fill(message);

--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -62,6 +62,14 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await expect(composer).toHaveAttribute("autocomplete", "off");
   await expect(composer).toHaveAttribute("aria-label", "Message Chief");
   await expect(page.getByRole("button", { name: new RegExp(userName, "i") })).toBeVisible();
+
+  await composer.fill("line one");
+  await composer.press("Shift+Enter");
+  await composer.type("line two");
+  await expect(composer).toHaveValue("line one\nline two");
+  const heightWithNewline = await composer.evaluate((el) => el.getBoundingClientRect().height);
+  expect(heightWithNewline).toBeGreaterThan(24);
+
   const message = "Fake composer regression check.";
   await composer.fill(message);
   await captureScreenshot(page, testInfo, "40-restored-auth-session");

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2750,11 +2750,19 @@ const Composer = memo(function Composer({
   const [selectedMentions, setSelectedMentions] = useState<
     Array<{ botId: string; name: string; color?: string }>
   >([]);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const canSend =
     draft.trim().length > 0 ||
     selectedSkill !== null ||
     selectedMentions.length > 0 ||
     pendingAttachments.length > 0;
+
+  useLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "0px";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [draft]);
 
   function updateDraft(value: string) {
     setDraft(value);
@@ -2963,7 +2971,7 @@ const Composer = memo(function Composer({
           ))}
         </div>
       ) : null}
-      <div className="flex items-center gap-3.5 rounded-full border border-[#202023] bg-[#131315] py-[9px] pe-2.5 ps-3">
+      <div className="flex items-end gap-3.5 rounded-full border border-[#202023] bg-[#131315] py-[9px] pe-2.5 ps-3">
         <input
           ref={fileInputRef}
           type="file"
@@ -3006,7 +3014,7 @@ const Composer = memo(function Composer({
         >
           <Mic size={16} strokeWidth={1.8} />
         </button>
-        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+        <div className="flex min-w-0 flex-1 flex-wrap items-end gap-1.5">
           {selectedSkill ? (
             <span
               data-testid="skill-chip"
@@ -3051,6 +3059,7 @@ const Composer = memo(function Composer({
             </span>
           ))}
           <textarea
+            ref={textareaRef}
             value={draft}
             onChange={(event) => updateDraft(event.target.value)}
             onKeyDown={(event) => {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2760,8 +2760,22 @@ const Composer = memo(function Composer({
   useLayoutEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
-    el.style.height = "0px";
-    el.style.height = `${el.scrollHeight}px`;
+
+    function syncHeight() {
+      el.style.height = "0px";
+      el.style.height = `${el.scrollHeight}px`;
+    }
+
+    syncHeight();
+    let lastWidth = el.getBoundingClientRect().width;
+    const observer = new ResizeObserver(() => {
+      const width = el.getBoundingClientRect().width;
+      if (width === lastWidth) return;
+      lastWidth = width;
+      syncHeight();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [draft]);
 
   function updateDraft(value: string) {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2762,14 +2762,18 @@ const Composer = memo(function Composer({
     if (!el) return;
 
     function syncHeight() {
-      el.style.height = "0px";
-      el.style.height = `${el.scrollHeight}px`;
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.style.height = "0px";
+      textarea.style.height = `${textarea.scrollHeight}px`;
     }
 
     syncHeight();
     let lastWidth = el.getBoundingClientRect().width;
     const observer = new ResizeObserver(() => {
-      const width = el.getBoundingClientRect().width;
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      const width = textarea.getBoundingClientRect().width;
       if (width === lastWidth) return;
       lastWidth = width;
       syncHeight();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #211.

## Summary
The chat composer already used a `textarea` with Enter-to-send (ignoring Shift), but it did not grow with content and controls stayed vertically centered. This completes the intended multi-line behavior.

## Changes
- Auto-grow the composer `textarea` from `rows={1}` up to `max-h-32`, then scroll
- Bottom-align attach / dictate / send / stop with the growing field
- Extend `auth-lifecycle` e2e: Shift+Enter inserts a newline and height grows vs the single-line baseline; Enter still sends

Mobile already uses a multiline `TextInput` with `alignItems: "flex-end"`, so no mobile change.

## Test plan
- [x] `pnpm --filter @rakazo/web check`
- [x] `biome check` on touched files
- [x] `pnpm --filter @rakazo/web test` (91 passed)
- [x] Web E2E via CI (auth-lifecycle); height assertion tightened after Greptile feedback

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72342844-0ec3-45cd-ac9a-0d10aa218e0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72342844-0ec3-45cd-ac9a-0d10aa218e0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The chat composer now expands automatically as you type multiline messages.
  * Pressing `Shift+Enter` inserts a new line while preserving the draft content.
  * Composer content remains bottom-aligned for improved usability.

* **Tests**
  * Added coverage verifying multiline input behavior and dynamic composer resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->