### PR TITLE
ci: publish multi-arch server images (amd64+arm64)

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -74,7 +74,9 @@ jobs:
     name: Publish ${{ matrix.name }} image
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # QEMU arm64 is slow; keep everyday main→edge publishes at 90m. Multi-arch
+    # (v* tags + workflow_dispatch) needs the longer budget.
+    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')) && 180 || 90 }}
     permissions:
       contents: read
       packages: write
@@ -93,6 +95,9 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
+      # Emulated arm64 only for releases and manual runs — not the ~10x/day main merge train.
+      - if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -120,6 +125,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Main→edge stays native amd64. Tags and workflow_dispatch publish amd64+arm64.
+          platforms: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           # GET /health can report the exact source commit without a deployment-supplied override.
           build-args: GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.name }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Supersedes #200 ([nicolaeser](https://github.com/nicolaeser)/`ci/arm64-server-images`): same multi-arch publish goal (`linux/amd64` + `linux/arm64` via pinned `docker/setup-qemu-action` v4.2.0), but scoped so everyday CI stays fast.

| Trigger | Platforms | QEMU | Timeout |
|---|---|---|---|
| PR `validate` | native amd64 (unchanged) | no | 90m |
| `push` to `main` → `edge` | `linux/amd64` | no | 90m |
| `v*` tag or `workflow_dispatch` | `linux/amd64,linux/arm64` | yes | 180m |

QEMU-on-every-PR (and on every main merge) would slow the ~10×/day merge train; multi-arch is therefore **release/manual only**.

Only `.github/workflows/publish-server-image.yml` changes. Dockerfiles, cache scopes, tags, provenance, SBOM, permissions, and path filters are untouched. Credit to nicolaeser for the original approach in #200.

## Test plan

- [ ] On this PR, `publish-server-image` / `validate` runs without QEMU and without a `platforms:` multi-arch override (native amd64, 90m).
- [ ] After merge, a normal push to `main` still publishes `edge` as amd64-only (no QEMU step).
- [ ] A `v*` tag push (or `workflow_dispatch`) installs QEMU, builds `linux/amd64,linux/arm64`, and uses the 180m timeout.
- [ ] `docker buildx imagetools inspect ghcr.io/<owner>/rakazo/app:<semver>` lists both architectures after a release publish.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-155aebd8-a89a-42be-a4da-b224d1d3824c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-155aebd8-a89a-42be-a4da-b224d1d3824c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Multi-architecture image publishing is now supported for version-tagged and manually triggered builds.
  * Main-branch publishes continue to target AMD64 only for faster completion.
  * Extended build timeouts are applied to longer multi-architecture builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->