### PR TITLE
fix(api): close open SSE connections on graceful shutdown

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,4 @@
+import type { Socket } from "node:net";
 import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 
 loadRootEnv();
@@ -12,11 +13,26 @@ const server = serve({ fetch: app.fetch, port: env.port }, () => {
   console.log(`rakazo api on http://127.0.0.1:${env.port}`);
 });
 
+// Long-lived connections (threads.subscribe SSE streams) never end on their
+// own, so server.close() alone waits forever for them. Track sockets and
+// force-close any still open after a short grace period for in-flight
+// requests, or every restart/shutdown hangs until something force-kills it.
+const sockets = new Set<Socket>();
+server.on("connection", (socket) => {
+  sockets.add(socket);
+  socket.once("close", () => sockets.delete(socket));
+});
+
 let stopping = false;
 const shutdown = async () => {
   if (stopping) return;
   stopping = true;
-  server.close();
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  const grace = setTimeout(() => {
+    for (const socket of sockets) socket.destroy();
+  }, 2_000);
+  await closed;
+  clearTimeout(grace);
   await stop();
 };
 process.once("SIGTERM", () => void shutdown());


### PR DESCRIPTION
## Summary

`server.close()` alone waits forever for long-lived `threads.subscribe` SSE
streams to end on their own, so every dev restart or deploy hung until
something force-killed the process.

## Changes

- Track open sockets via `server.on("connection", ...)`
- On shutdown, wait for `server.close()`'s callback, but force-destroy any
  socket still open after a 2s grace period for in-flight requests

## Testing notes

- [x] `pnpm --filter @rakazo/api check`
- [x] `biome check` on the touched file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API shutdown handling to allow active connections to close gracefully.
  * Added a fallback to terminate lingering connections after a brief grace period, ensuring shutdown completes reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->