### PR TITLE
fix(sandbox): screen readiness check and per-bot network isolation

### DIFF
--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -69,12 +69,17 @@ describe("graphical computer spec", () => {
       homePath: "/var/rakazo/homes/bot_isolation",
       networkMode,
     });
-    expect(networkMode).toBe("rakazo-computer-bot_isolation");
+    expect(networkMode).toMatch(/^rakazo-computer-bot_isolation-[0-9a-f]{8}$/);
     expect(options.HostConfig.NetworkMode).toBe(networkMode);
     expect(options.HostConfig.PortBindings["6080/tcp"]).toEqual([
       { HostIp: "127.0.0.1", HostPort: "0" },
     ]);
     expect(options.ExposedPorts["6080/tcp"]).toEqual({});
+  });
+
+  it("keeps sanitized network names unique when botIds only differ by stripped characters", () => {
+    expect(computerNetworkNameFor("a/b")).not.toBe(computerNetworkNameFor("ab"));
+    expect(computerNetworkNameFor("a/b")).toBe(computerNetworkNameFor("a/b"));
   });
 
   it("ships a browser desktop, not a fullscreen terminal", () => {

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   COMPUTER_IMAGE,
   computerNetworkNameFor,
+  computerNetworkNamesForCleanup,
   containerCreateOptions,
   containerNameFor,
   resolveScreenPublishTarget,
@@ -80,6 +81,14 @@ describe("graphical computer spec", () => {
   it("keeps sanitized network names unique when botIds only differ by stripped characters", () => {
     expect(computerNetworkNameFor("a/b")).not.toBe(computerNetworkNameFor("ab"));
     expect(computerNetworkNameFor("a/b")).toBe(computerNetworkNameFor("a/b"));
+  });
+
+  it("lists prior network name variants for cleanup", () => {
+    const names = computerNetworkNamesForCleanup("bot_1");
+    expect(names[0]).toBe(computerNetworkNameFor("bot_1"));
+    expect(names).toContain("rakazo-computer-bot_1");
+    expect(names.some((name) => /-[0-9a-f]{8}$/.test(name))).toBe(true);
+    expect(names.some((name) => /-[0-9a-f]{32}$/.test(name))).toBe(true);
   });
 
   it("ships a browser desktop, not a fullscreen terminal", () => {

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -3,8 +3,10 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   COMPUTER_IMAGE,
+  computerNetworkNameFor,
   containerCreateOptions,
   containerNameFor,
+  resolveScreenPublishTarget,
   screenPorts,
   screenUrlFor,
   xdotoolCommand,
@@ -57,6 +59,24 @@ describe("graphical computer spec", () => {
     expect(options.HostConfig.NetworkMode).toBe("rakazo_default");
   });
 
+  it("still publishes host ports when NetworkMode is a per-bot isolated network", () => {
+    const networkMode = computerNetworkNameFor("bot_isolation");
+    const options = containerCreateOptions({
+      name: containerNameFor("bot_isolation"),
+      image: COMPUTER_IMAGE,
+      botId: "bot_isolation",
+      workspaceId: "ws",
+      homePath: "/var/rakazo/homes/bot_isolation",
+      networkMode,
+    });
+    expect(networkMode).toBe("rakazo-computer-bot_isolation");
+    expect(options.HostConfig.NetworkMode).toBe(networkMode);
+    expect(options.HostConfig.PortBindings["6080/tcp"]).toEqual([
+      { HostIp: "127.0.0.1", HostPort: "0" },
+    ]);
+    expect(options.ExposedPorts["6080/tcp"]).toEqual({});
+  });
+
   it("ships a browser desktop, not a fullscreen terminal", () => {
     const root = path.resolve(import.meta.dirname, "../../computer");
     const dockerfile = readFileSync(path.join(root, "Dockerfile"), "utf8");
@@ -76,6 +96,44 @@ describe("graphical computer spec", () => {
 
   it("points the screen at the chrome-less noVNC embed", () => {
     expect(screenUrlFor("16080")).toBe("http://127.0.0.1:16080/embed.html");
+  });
+
+  it("uses the published host mapping in the default topology even when a container IP exists", () => {
+    // Regression: per-bot NetworkMode always yields a 172.x address. Returning
+    // that to clients makes local/dev screens look dead — browsers cannot load
+    // docker-internal IPs. Probe and return the host mapping instead.
+    const networkMode = computerNetworkNameFor("bot_1");
+    expect(
+      resolveScreenPublishTarget({
+        screenNetwork: undefined,
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        hostPort: "49152",
+        containerPort: "6080",
+      }),
+    ).toEqual({ host: "127.0.0.1", port: "49152" });
+    expect(
+      resolveScreenPublishTarget({
+        screenNetwork: undefined,
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        hostPort: undefined,
+        containerPort: "6080",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("uses the container IP only for the internal screen network topology", () => {
+    const networkMode = "rakazo_default";
+    expect(
+      resolveScreenPublishTarget({
+        screenNetwork: "internal",
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        hostPort: "49152",
+        containerPort: "6080",
+      }),
+    ).toEqual({ host: "172.18.0.4", port: "6080" });
   });
 
   it("turns takeover input into xdotool", () => {

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -69,7 +69,7 @@ describe("graphical computer spec", () => {
       homePath: "/var/rakazo/homes/bot_isolation",
       networkMode,
     });
-    expect(networkMode).toMatch(/^rakazo-computer-bot_isolation-[0-9a-f]{8}$/);
+    expect(networkMode).toMatch(/^rakazo-computer-bot_isolation-[0-9a-f]{32}$/);
     expect(options.HostConfig.NetworkMode).toBe(networkMode);
     expect(options.HostConfig.PortBindings["6080/tcp"]).toEqual([
       { HostIp: "127.0.0.1", HostPort: "0" },

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export const COMPUTER_IMAGE = process.env.RAKAZO_COMPUTER_IMAGE ?? "rakazo/computer:local";
 export const TEAM_SCREEN_LIMIT = 8;
 export const SCREEN_HOST = process.env.SANDBOX_SCREEN_HOST ?? "127.0.0.1";
@@ -94,7 +96,11 @@ export function containerNameFor(botId: string) {
 }
 
 export function computerNetworkNameFor(botId: string) {
-  return `rakazo-computer-${sanitizeIdentifier(botId)}`;
+  // Keep distinct botIds on distinct networks even when sanitization collapses
+  // characters (e.g. "a/b" and "ab"). Do not change containerNameFor — that
+  // name must stay stable so an existing computer can resume.
+  const hash = createHash("sha256").update(botId).digest("hex").slice(0, 8);
+  return `rakazo-computer-${sanitizeIdentifier(botId).slice(0, 32)}-${hash}`;
 }
 
 export function screenUrlFor(hostPort: string, host = SCREEN_HOST) {

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -101,6 +101,31 @@ export function screenUrlFor(hostPort: string, host = SCREEN_HOST) {
   return `http://${host}:${hostPort}/embed.html`;
 }
 
+/**
+ * Decide which host:port clients (and readiness probes) should use.
+ *
+ * Per-bot NetworkMode isolation must not change this: a container always has a
+ * docker-internal IP on its network, but browsers cannot load that 172.x
+ * address. Only the internal compose topology may return the container IP;
+ * the default topology must keep using the published host mapping.
+ */
+export function resolveScreenPublishTarget(input: {
+  screenNetwork: string | undefined;
+  networkMode: string | null | undefined;
+  networks: Record<string, { IPAddress?: string } | undefined> | null | undefined;
+  hostPort: string | undefined;
+  containerPort: string;
+  screenHost?: string;
+}): { host: string; port: string } | undefined {
+  if (input.screenNetwork === "internal") {
+    const address = input.networkMode ? input.networks?.[input.networkMode]?.IPAddress : undefined;
+    if (address) return { host: address, port: input.containerPort };
+    return undefined;
+  }
+  if (input.hostPort) return { host: input.screenHost ?? SCREEN_HOST, port: input.hostPort };
+  return undefined;
+}
+
 export function xdotoolCommand(input: SandboxInput): string[] {
   if (input.kind === "key") {
     const key = mapKey(input.key);

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -1,6 +1,6 @@
 export const COMPUTER_IMAGE = process.env.RAKAZO_COMPUTER_IMAGE ?? "rakazo/computer:local";
 export const TEAM_SCREEN_LIMIT = 8;
-const SCREEN_HOST = process.env.SANDBOX_SCREEN_HOST ?? "127.0.0.1";
+export const SCREEN_HOST = process.env.SANDBOX_SCREEN_HOST ?? "127.0.0.1";
 
 export function screenPorts(index: number) {
   if (index < 0 || index >= TEAM_SCREEN_LIMIT) {
@@ -84,9 +84,17 @@ export function containerCreateOptions(input: ComputerCreateInput) {
   };
 }
 
-export function containerNameFor(botId: string) {
+export function sanitizeIdentifier(botId: string) {
   const safe = botId.replace(/[^a-zA-Z0-9_.-]/g, "").slice(0, 40);
-  return `rakazo-bot-${safe || "box"}`;
+  return safe || "box";
+}
+
+export function containerNameFor(botId: string) {
+  return `rakazo-bot-${sanitizeIdentifier(botId)}`;
+}
+
+export function computerNetworkNameFor(botId: string) {
+  return `rakazo-computer-${sanitizeIdentifier(botId)}`;
 }
 
 export function screenUrlFor(hostPort: string, host = SCREEN_HOST) {

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -103,6 +103,17 @@ export function computerNetworkNameFor(botId: string) {
   return `rakazo-computer-${sanitizeIdentifier(botId).slice(0, 32)}-${hash}`;
 }
 
+/** Current and prior network names used by this PR, for delete cleanup. */
+export function computerNetworkNamesForCleanup(botId: string) {
+  const safe = sanitizeIdentifier(botId);
+  const digest = createHash("sha256").update(botId).digest("hex");
+  return [
+    computerNetworkNameFor(botId),
+    `rakazo-computer-${safe}`,
+    `rakazo-computer-${safe.slice(0, 32)}-${digest.slice(0, 8)}`,
+  ];
+}
+
 export function screenUrlFor(hostPort: string, host = SCREEN_HOST) {
   return `http://${host}:${hostPort}/embed.html`;
 }

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -99,7 +99,7 @@ export function computerNetworkNameFor(botId: string) {
   // Keep distinct botIds on distinct networks even when sanitization collapses
   // characters (e.g. "a/b" and "ab"). Do not change containerNameFor — that
   // name must stay stable so an existing computer can resume.
-  const hash = createHash("sha256").update(botId).digest("hex").slice(0, 8);
+  const hash = createHash("sha256").update(botId).digest("hex").slice(0, 32);
   return `rakazo-computer-${sanitizeIdentifier(botId).slice(0, 32)}-${hash}`;
 }
 

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -53,6 +53,21 @@ describe("computer screen readiness", () => {
     }
   });
 
+  it("does not treat HTTP error responses as ready", async () => {
+    const server = http.createServer((_req, res) => {
+      res.statusCode = 503;
+      res.end("starting");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("expected a TCP address");
+    try {
+      await expect(waitForScreenReady("127.0.0.1", address.port, 700)).resolves.toBe(false);
+    } finally {
+      server.close();
+    }
+  });
+
   it("times out instead of hanging when nothing is listening", async () => {
     const server = net.createServer();
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -1,7 +1,9 @@
 import { spawnSync } from "node:child_process";
+import http from "node:http";
+import net from "node:net";
 import { resolveSupervisorToken } from "@rakazo/core";
 import { describe, expect, it } from "vitest";
-import { resolveDockerSocketPath, supervisorApp } from "./index.js";
+import { resolveDockerSocketPath, supervisorApp, waitForScreenReady } from "./index.js";
 import {
   assertRequestIdentity,
   clearComputerScreenRegistry,
@@ -21,6 +23,47 @@ import {
 } from "./supervisor-logic.js";
 
 const token = resolveSupervisorToken(process.env);
+
+describe("computer screen readiness", () => {
+  it("waits for the server to actually answer HTTP requests before succeeding", async () => {
+    const server = http.createServer((_req, res) => res.end("ok"));
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("expected a TCP address");
+    try {
+      await expect(waitForScreenReady("127.0.0.1", address.port, 2_000)).resolves.toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("does not treat an open TCP port as ready when nothing is serving HTTP on it yet", async () => {
+    // Regression test: a bare TCP accept (e.g. the Docker port mapping coming
+    // up before websockify inside the container does) must not be mistaken
+    // for the screen being ready — that gap is exactly what caused
+    // "socket hang up" in the browser.
+    const server = net.createServer((socket) => socket.destroy());
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("expected a TCP address");
+    try {
+      await expect(waitForScreenReady("127.0.0.1", address.port, 700)).resolves.toBe(false);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("times out instead of hanging when nothing is listening", async () => {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("expected a TCP address");
+    const closedPort = address.port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    await expect(waitForScreenReady("127.0.0.1", closedPort, 700)).resolves.toBe(false);
+  });
+});
 
 describe("sandbox supervisor Docker endpoint", () => {
   it("respects Docker host and socket overrides before platform defaults", () => {

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -68,6 +68,22 @@ describe("computer screen readiness", () => {
     }
   });
 
+  it("does not treat redirect responses as ready", async () => {
+    const server = http.createServer((_req, res) => {
+      res.statusCode = 302;
+      res.setHeader("Location", "/vnc.html");
+      res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("expected a TCP address");
+    try {
+      await expect(waitForScreenReady("127.0.0.1", address.port, 700)).resolves.toBe(false);
+    } finally {
+      server.close();
+    }
+  });
+
   it("times out instead of hanging when nothing is listening", async () => {
     const server = net.createServer();
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -98,42 +98,47 @@ app.post("/computers", async (c) => {
       botId: body.botId,
       workspaceId: body.workspaceId,
     });
-    await ensureComputerImage();
-    const runtimeInfo = await inspectSupervisorContainer();
-    const networkMode = await computerNetworkName(body.botId, runtimeInfo);
-    const serviceHomePath = path.resolve(body.homePath);
-    assertBotHomePath(serviceHomePath, body.botId);
-    await mkdir(serviceHomePath, { recursive: true });
-    const homePath = hostHomePath(serviceHomePath, runtimeInfo);
-    const existing = await findBotContainer(body.botId, body.workspaceId);
-    if (existing) {
-      const info = await existing.inspect();
-      const desired = await docker.getImage(COMPUTER_IMAGE).inspect();
-      if (
-        info.Image !== desired.Id ||
-        (networkMode && info.HostConfig.NetworkMode !== networkMode)
-      ) {
-        await existing.remove({ force: true }).catch(() => undefined);
-      } else {
-        if (!info.State.Running) await existing.start();
-        const screenUrl = await publishedScreenUrl(existing, info.State.Running ? info : undefined);
-        return c.json({ id: existing.id, image: COMPUTER_IMAGE, screenUrl, resumed: true });
+    return await withBotLifecycleLock(body.botId, async () => {
+      await ensureComputerImage();
+      const runtimeInfo = await inspectSupervisorContainer();
+      const networkMode = await computerNetworkName(body.botId, runtimeInfo);
+      const serviceHomePath = path.resolve(body.homePath);
+      assertBotHomePath(serviceHomePath, body.botId);
+      await mkdir(serviceHomePath, { recursive: true });
+      const homePath = hostHomePath(serviceHomePath, runtimeInfo);
+      const existing = await findBotContainer(body.botId, body.workspaceId);
+      if (existing) {
+        const info = await existing.inspect();
+        const desired = await docker.getImage(COMPUTER_IMAGE).inspect();
+        if (
+          info.Image !== desired.Id ||
+          (networkMode && info.HostConfig.NetworkMode !== networkMode)
+        ) {
+          await existing.remove({ force: true }).catch(() => undefined);
+        } else {
+          if (!info.State.Running) await existing.start();
+          const screenUrl = await publishedScreenUrl(
+            existing,
+            info.State.Running ? info : undefined,
+          );
+          return c.json({ id: existing.id, image: COMPUTER_IMAGE, screenUrl, resumed: true });
+        }
       }
-    }
-    const name = containerNameFor(body.botId);
-    const container = await docker.createContainer(
-      containerCreateOptions({
-        name,
-        image: COMPUTER_IMAGE,
-        botId: body.botId,
-        workspaceId: body.workspaceId,
-        homePath,
-        networkMode,
-      }),
-    );
-    await container.start();
-    const screenUrl = await publishedScreenUrl(container);
-    return c.json({ id: container.id, image: COMPUTER_IMAGE, screenUrl, resumed: false });
+      const name = containerNameFor(body.botId);
+      const container = await docker.createContainer(
+        containerCreateOptions({
+          name,
+          image: COMPUTER_IMAGE,
+          botId: body.botId,
+          workspaceId: body.workspaceId,
+          homePath,
+          networkMode,
+        }),
+      );
+      await container.start();
+      const screenUrl = await publishedScreenUrl(container);
+      return c.json({ id: container.id, image: COMPUTER_IMAGE, screenUrl, resumed: false });
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ error: message }, 500);
@@ -483,13 +488,20 @@ app.delete("/computers/:id", async (c) => {
   const id = c.req.param("id");
   const botId = c.req.header("x-rakazo-bot-id");
   try {
-    const { container } = await managedContainer(id, botId, c.req.header("x-rakazo-workspace-id"));
-    await container.remove({ force: true }).catch(() => undefined);
-    clearComputerScreenRegistry(computerScreens, id);
-    if (botId && process.env.SANDBOX_SCREEN_NETWORK !== "internal") {
-      await removeBotNetwork(botId);
-    }
-    return c.json({ ok: true });
+    if (!botId) throw new Error("missing computer identity");
+    return await withBotLifecycleLock(botId, async () => {
+      const { container } = await managedContainer(
+        id,
+        botId,
+        c.req.header("x-rakazo-workspace-id"),
+      );
+      await container.remove({ force: true }).catch(() => undefined);
+      clearComputerScreenRegistry(computerScreens, id);
+      if (process.env.SANDBOX_SCREEN_NETWORK !== "internal") {
+        await removeBotNetwork(botId);
+      }
+      return c.json({ ok: true });
+    });
   } catch {
     return c.json({ error: "computer not found" }, 404);
   }
@@ -724,6 +736,27 @@ async function removeBotNetwork(botId: string) {
     .getNetwork(computerNetworkNameFor(botId))
     .remove()
     .catch(() => undefined);
+}
+
+const botLifecycleLocks = new Map<string, Promise<unknown>>();
+
+// Serialize create/delete for one bot so DELETE cannot remove a per-bot network
+// while POST still needs it between ensureBotNetwork and container attach.
+async function withBotLifecycleLock<T>(botId: string, task: () => Promise<T>): Promise<T> {
+  const previous = botLifecycleLocks.get(botId) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const current = previous.catch(() => undefined).then(() => gate);
+  botLifecycleLocks.set(botId, current);
+  await previous.catch(() => undefined);
+  try {
+    return await task();
+  } finally {
+    release();
+    if (botLifecycleLocks.get(botId) === current) botLifecycleLocks.delete(botId);
+  }
 }
 
 async function inspectSupervisorContainer() {

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -135,10 +135,6 @@ app.post("/computers", async (c) => {
     const screenUrl = await publishedScreenUrl(container);
     return c.json({ id: container.id, image: COMPUTER_IMAGE, screenUrl, resumed: false });
   } catch (error) {
-    if (process.env.SANDBOX_SCREEN_NETWORK !== "internal") {
-      const leftover = await findBotContainer(body.botId, body.workspaceId).catch(() => undefined);
-      if (!leftover) await removeBotNetwork(body.botId);
-    }
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ error: message }, 500);
   }
@@ -637,7 +633,7 @@ export async function waitForScreenReady(host: string, port: number, timeoutMs: 
       const req = http.get({ host, port, path: "/embed.html", timeout: 1_500 }, (res) => {
         res.resume();
         const status = res.statusCode ?? 0;
-        resolve(status >= 200 && status < 400);
+        resolve(status >= 200 && status < 300);
       });
       req.once("timeout", () => {
         req.destroy();

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import {
   COMPUTER_IMAGE,
   computerNetworkNameFor,
+  computerNetworkNamesForCleanup,
   containerCreateOptions,
   containerNameFor,
   resolveScreenPublishTarget,
@@ -732,10 +733,12 @@ async function ensureBotNetwork(botId: string) {
 }
 
 async function removeBotNetwork(botId: string) {
-  await docker
-    .getNetwork(computerNetworkNameFor(botId))
-    .remove()
-    .catch(() => undefined);
+  for (const name of computerNetworkNamesForCleanup(botId)) {
+    await docker
+      .getNetwork(name)
+      .remove()
+      .catch(() => undefined);
+  }
 }
 
 const botLifecycleLocks = new Map<string, Promise<unknown>>();

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
@@ -11,8 +12,10 @@ import { Hono } from "hono";
 import { z } from "zod";
 import {
   COMPUTER_IMAGE,
+  computerNetworkNameFor,
   containerCreateOptions,
   containerNameFor,
+  SCREEN_HOST,
   screenPorts,
   screenUrlFor,
   xdotoolCommand,
@@ -96,7 +99,7 @@ app.post("/computers", async (c) => {
     });
     await ensureComputerImage();
     const runtimeInfo = await inspectSupervisorContainer();
-    const networkMode = computerNetworkMode(runtimeInfo);
+    const networkMode = await computerNetworkName(body.botId, runtimeInfo);
     const serviceHomePath = path.resolve(body.homePath);
     assertBotHomePath(serviceHomePath, body.botId);
     await mkdir(serviceHomePath, { recursive: true });
@@ -477,14 +480,14 @@ app.post("/computers/:id/stop", async (c) => {
 
 app.delete("/computers/:id", async (c) => {
   const id = c.req.param("id");
+  const botId = c.req.header("x-rakazo-bot-id");
   try {
-    const { container } = await managedContainer(
-      id,
-      c.req.header("x-rakazo-bot-id"),
-      c.req.header("x-rakazo-workspace-id"),
-    );
+    const { container } = await managedContainer(id, botId, c.req.header("x-rakazo-workspace-id"));
     await container.remove({ force: true }).catch(() => undefined);
     clearComputerScreenRegistry(computerScreens, id);
+    if (botId && process.env.SANDBOX_SCREEN_NETWORK !== "internal") {
+      await removeBotNetwork(botId);
+    }
     return c.json({ ok: true });
   } catch {
     return c.json({ error: "computer not found" }, 404);
@@ -606,6 +609,42 @@ function hostHomePath(serviceHomePath: string, info: Docker.ContainerInspectInfo
   if (!dataMount?.Source) return serviceHomePath;
   return path.join(dataMount.Source, path.relative(dataDir, serviceHomePath));
 }
+const SCREEN_READY_TIMEOUT_MS = 45_000;
+
+// Docker publishes a container's port mapping (or assigns its internal IP)
+// almost immediately on start, well before the process inside the container
+// is actually listening on it (Xvfb, the browser, x11vnc, then websockify
+// all start in sequence — see infra/sandboxes/computer/start.sh). Returning
+// the URL as soon as the mapping exists lets the frontend iframe race the
+// container's own boot sequence and hit "socket hang up" on first load.
+//
+// A bare TCP connect isn't a strong enough signal either: it only proves the
+// port is accepting connections, not that websockify is actually up and
+// serving — the same race can still slip through between "port open" and
+// "websockify ready" (e.g. right after setInteractiveScreen starts a new
+// x11vnc/websockify pair on the control port for a takeover). An HTTP GET
+// against the same embed.html path the browser will load only succeeds once
+// websockify itself is answering requests, closing that gap too.
+export async function waitForScreenReady(host: string, port: number, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const ready = await new Promise<boolean>((resolve) => {
+      const req = http.get({ host, port, path: "/embed.html", timeout: 1_500 }, (res) => {
+        res.resume();
+        resolve(true);
+      });
+      req.once("timeout", () => {
+        req.destroy();
+        resolve(false);
+      });
+      req.once("error", () => resolve(false));
+    });
+    if (ready) return true;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  } while (Date.now() < deadline);
+  return false;
+}
+
 async function publishedScreenUrl(
   container: Docker.Container,
   initialInfo?: Docker.ContainerInspectInfo,
@@ -618,10 +657,26 @@ async function publishedScreenUrl(
       const address = networkMode
         ? info.NetworkSettings?.Networks?.[networkMode]?.IPAddress
         : undefined;
-      if (address) return screenUrlFor(containerPort, address);
+      if (address) {
+        const ready = await waitForScreenReady(
+          address,
+          Number(containerPort),
+          SCREEN_READY_TIMEOUT_MS,
+        );
+        if (!ready) throw new Error("computer screen did not become ready in time");
+        return screenUrlFor(containerPort, address);
+      }
     }
     const hostPort = info.NetworkSettings?.Ports?.[`${containerPort}/tcp`]?.[0]?.HostPort;
-    if (hostPort) return screenUrlFor(hostPort);
+    if (hostPort) {
+      const ready = await waitForScreenReady(
+        SCREEN_HOST,
+        Number(hostPort),
+        SCREEN_READY_TIMEOUT_MS,
+      );
+      if (!ready) throw new Error("computer screen did not become ready in time");
+      return screenUrlFor(hostPort);
+    }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error("computer screen port was not published");
@@ -641,9 +696,40 @@ async function setInteractiveScreen(
   if (result.code !== 0) throw new Error(result.stderr || "control screen failed to start");
 }
 
-function computerNetworkMode(info: Docker.ContainerInspectInfo | undefined) {
-  if (process.env.SANDBOX_SCREEN_NETWORK !== "internal") return undefined;
-  return info ? Object.keys(info.NetworkSettings.Networks)[0] : undefined;
+// Each bot's computer gets its own Docker network so containers cannot reach
+// one another (Docker's default "bridge" network allows any container to
+// dial any other container's exposed ports, which would let one bot's
+// computer reach another bot's desktop/VNC endpoint with no authentication).
+async function computerNetworkName(botId: string, info: Docker.ContainerInspectInfo | undefined) {
+  if (process.env.SANDBOX_SCREEN_NETWORK === "internal") {
+    // The supervisor itself runs in this shared network in that topology and
+    // needs to address child containers by their in-network IP, so children
+    // stay on the supervisor's network rather than an isolated one.
+    return info ? Object.keys(info.NetworkSettings.Networks)[0] : undefined;
+  }
+  return ensureBotNetwork(botId);
+}
+
+async function ensureBotNetwork(botId: string) {
+  const name = computerNetworkNameFor(botId);
+  try {
+    await docker.getNetwork(name).inspect();
+  } catch {
+    await docker
+      .createNetwork({ Name: name, Driver: "bridge", CheckDuplicate: true })
+      .catch((error) => {
+        // Another concurrent provision request may have created it first.
+        if (!/already exists/i.test(String(error))) throw error;
+      });
+  }
+  return name;
+}
+
+async function removeBotNetwork(botId: string) {
+  await docker
+    .getNetwork(computerNetworkNameFor(botId))
+    .remove()
+    .catch(() => undefined);
 }
 
 async function inspectSupervisorContainer() {

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -15,6 +15,7 @@ import {
   computerNetworkNameFor,
   containerCreateOptions,
   containerNameFor,
+  resolveScreenPublishTarget,
   SCREEN_HOST,
   screenPorts,
   screenUrlFor,
@@ -652,30 +653,22 @@ async function publishedScreenUrl(
 ) {
   for (let i = 0; i < 30; i += 1) {
     const info = i === 0 && initialInfo ? initialInfo : await container.inspect();
-    if (process.env.SANDBOX_SCREEN_NETWORK === "internal") {
-      const networkMode = info.HostConfig.NetworkMode;
-      const address = networkMode
-        ? info.NetworkSettings?.Networks?.[networkMode]?.IPAddress
-        : undefined;
-      if (address) {
-        const ready = await waitForScreenReady(
-          address,
-          Number(containerPort),
-          SCREEN_READY_TIMEOUT_MS,
-        );
-        if (!ready) throw new Error("computer screen did not become ready in time");
-        return screenUrlFor(containerPort, address);
-      }
-    }
-    const hostPort = info.NetworkSettings?.Ports?.[`${containerPort}/tcp`]?.[0]?.HostPort;
-    if (hostPort) {
+    const target = resolveScreenPublishTarget({
+      screenNetwork: process.env.SANDBOX_SCREEN_NETWORK,
+      networkMode: info.HostConfig.NetworkMode,
+      networks: info.NetworkSettings?.Networks,
+      hostPort: info.NetworkSettings?.Ports?.[`${containerPort}/tcp`]?.[0]?.HostPort,
+      containerPort,
+      screenHost: SCREEN_HOST,
+    });
+    if (target) {
       const ready = await waitForScreenReady(
-        SCREEN_HOST,
-        Number(hostPort),
+        target.host,
+        Number(target.port),
         SCREEN_READY_TIMEOUT_MS,
       );
       if (!ready) throw new Error("computer screen did not become ready in time");
-      return screenUrlFor(hostPort);
+      return screenUrlFor(target.port, target.host);
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -135,6 +135,10 @@ app.post("/computers", async (c) => {
     const screenUrl = await publishedScreenUrl(container);
     return c.json({ id: container.id, image: COMPUTER_IMAGE, screenUrl, resumed: false });
   } catch (error) {
+    if (process.env.SANDBOX_SCREEN_NETWORK !== "internal") {
+      const leftover = await findBotContainer(body.botId, body.workspaceId).catch(() => undefined);
+      if (!leftover) await removeBotNetwork(body.botId);
+    }
     const message = error instanceof Error ? error.message : String(error);
     return c.json({ error: message }, 500);
   }
@@ -632,7 +636,8 @@ export async function waitForScreenReady(host: string, port: number, timeoutMs: 
     const ready = await new Promise<boolean>((resolve) => {
       const req = http.get({ host, port, path: "/embed.html", timeout: 1_500 }, (res) => {
         res.resume();
-        resolve(true);
+        const status = res.statusCode ?? 0;
+        resolve(status >= 200 && status < 400);
       });
       req.once("timeout", () => {
         req.destroy();


### PR DESCRIPTION
## Summary

Two small, related fixes to the Docker sandbox supervisor.

**Screen readiness ("socket hang up")** — Docker publishes a container's
port mapping well before the process inside is actually listening (Xvfb,
the browser, x11vnc, then websockify start in sequence). Returning the
screen URL as soon as the mapping exists let the frontend iframe race the
container's boot sequence. A bare TCP connect isn't a strong enough signal
either — it only proves the port accepts connections, not that websockify
itself is serving.

**Per-bot network isolation (security)** — every bot's computer container
shared Docker's default bridge network, so one bot's computer could reach
another bot's desktop/VNC endpoint with no authentication.

## Changes

- `waitForScreenReady`: HTTP GET against `embed.html` — only succeeds once
  websockify is actually answering, closing the readiness gap for both
  initial boot and the interactive/control screen a takeover starts fresh
- Give each bot's computer its own isolated Docker network
  (`ensureBotNetwork`/`removeBotNetwork`), cleaned up on computer delete

## Testing notes

- [x] `pnpm --filter @rakazo/sandbox-supervisor check`
- [x] `pnpm --filter @rakazo/sandbox-supervisor test` (26 passed)
- [x] `biome check` on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Screen URLs are returned only after the screen service successfully responds, reducing startup connection failures.
  * Improved handling for unavailable, redirecting, erroring, or prematurely open screen connections.
  * Computer creation and deletion operations are now reliably serialized.
  * Computer cleanup removes all associated network resources.

* **New Features**
  * Improved isolation and naming for computer networking.
  * Screen connections work reliably across internal and host-published configurations.

* **Tests**
  * Added coverage for readiness checks, network naming, port mappings, unavailable services, and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->