### PR TITLE
feat: cross-bot @mention delegation

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -111,6 +111,7 @@ import { withSerializableRetry } from "./serializable-retry.js";
 import { assertTeachingSendAllowed, createTaughtSkillsService } from "./taught-skills.js";
 import { loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
 import {
+  cancelRun,
   resolveThreadTarget,
   sendThreadMessage,
   setThreadUnreadState,
@@ -1001,6 +1002,12 @@ export function createRouter(deps: RouterDeps) {
         const target = await resolveThreadTarget(deps.prisma, context.actor, input);
         await setThreadUnreadState(deps.prisma, context.actor, target, true);
         return { ok: true as const };
+      }),
+    },
+    runs: {
+      cancel: authed.runs.cancel.handler(async ({ context, input }) => {
+        const result = await cancelRun(deps, context.actor, input.runId);
+        return result;
       }),
     },
     computer: {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1005,12 +1005,6 @@ export function createRouter(deps: RouterDeps) {
         return { ok: true as const };
       }),
     },
-    runs: {
-      cancel: authed.runs.cancel.handler(async ({ context, input }) => {
-        const result = await cancelRun(deps, context.actor, input.runId);
-        return result;
-      }),
-    },
     computer: {
       status: authed.computer.status.handler(async ({ context, input }) =>
         computerStatus(deps, context.actor, input.botId),
@@ -2745,6 +2739,10 @@ export function createRouter(deps: RouterDeps) {
       list: authed.runs.list.handler(async ({ context, input }) => ({
         runs: await listWorkspaceRuns(deps.prisma, context.actor, input.filter),
       })),
+      cancel: authed.runs.cancel.handler(async ({ context, input }) => {
+        const result = await cancelRun(deps, context.actor, input.runId);
+        return result;
+      }),
     },
     voice: {
       catalog: authed.voice.catalog.handler(async () => listVoiceCatalog()),

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -1,8 +1,13 @@
 import type { SandboxProvider } from "@rakazo/adapter-kit";
 import type { Actor } from "@rakazo/contracts";
-import type { PrismaClient } from "@rakazo/db";
+import type { Prisma, PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
-import { stopThreadRuns, type ThreadTarget, threadSnapshot } from "./thread-target.js";
+import {
+  resolveDelegationTarget,
+  stopThreadRuns,
+  type ThreadTarget,
+  threadSnapshot,
+} from "./thread-target.js";
 
 describe("threadSnapshot", () => {
   it("reloads tool-only live messages for an active run", async () => {
@@ -131,5 +136,88 @@ describe("stopThreadRuns", () => {
       expect.objectContaining({ providerRef: "computer-b" }),
       expect.objectContaining({ workspaceId: "workspace-1", userId: "user-1", botId: "bot-b" }),
     );
+  });
+});
+
+describe("resolveDelegationTarget", () => {
+  const actor = { workspaceId: "workspace-1", userId: "user-1" } as Actor;
+
+  function txWithBots(bots: Array<{ id: string; name: string; hasThread?: boolean }>) {
+    return {
+      bot: {
+        findMany: vi.fn().mockResolvedValue(
+          bots.map((bot) => ({
+            id: bot.id,
+            name: bot.name,
+            thread: bot.hasThread === false ? null : { id: `thread-${bot.id}` },
+          })),
+        ),
+      },
+    } as unknown as Prisma.TransactionClient;
+  }
+
+  it("matches an @mention at the start of the message", async () => {
+    const tx = txWithBots([{ id: "bot-sarah", name: "Sarah" }]);
+    const result = await resolveDelegationTarget(tx, actor, "bot-origin", "@Sarah check email");
+    expect(result).toEqual({
+      botId: "bot-sarah",
+      botName: "Sarah",
+      threadId: "thread-bot-sarah",
+      prompt: "Sarah check email",
+    });
+  });
+
+  it("matches an @mention in the middle of a sentence", async () => {
+    const tx = txWithBots([{ id: "bot-sarah", name: "Sarah" }]);
+    const result = await resolveDelegationTarget(
+      tx,
+      actor,
+      "bot-origin",
+      "Can you see what @Sarah is upto",
+    );
+    expect(result).toEqual({
+      botId: "bot-sarah",
+      botName: "Sarah",
+      threadId: "thread-bot-sarah",
+      prompt: "Can you see what Sarah is upto",
+    });
+  });
+
+  it("does not match @BotFoo when the bot is named Bot", async () => {
+    const tx = txWithBots([{ id: "bot-1", name: "Bot" }]);
+    const result = await resolveDelegationTarget(tx, actor, "bot-origin", "ping @BotFoo now");
+    expect(result).toBeNull();
+  });
+
+  it("prefers the longest matching name", async () => {
+    const tx = txWithBots([
+      { id: "bot-chief", name: "Chief" },
+      { id: "bot-chief-of-staff", name: "Chief of Staff" },
+    ]);
+    const result = await resolveDelegationTarget(
+      tx,
+      actor,
+      "bot-origin",
+      "@Chief of Staff please review this",
+    );
+    expect(result?.botId).toBe("bot-chief-of-staff");
+  });
+
+  it("returns null for a bare mention with no task text", async () => {
+    const tx = txWithBots([{ id: "bot-sarah", name: "Sarah" }]);
+    const result = await resolveDelegationTarget(tx, actor, "bot-origin", "@Sarah");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the mentioned bot has no thread", async () => {
+    const tx = txWithBots([{ id: "bot-sarah", name: "Sarah", hasThread: false }]);
+    const result = await resolveDelegationTarget(tx, actor, "bot-origin", "@Sarah check email");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the text has no @ at all", async () => {
+    const tx = txWithBots([{ id: "bot-sarah", name: "Sarah" }]);
+    const result = await resolveDelegationTarget(tx, actor, "bot-origin", "just a normal message");
+    expect(result).toBeNull();
   });
 });

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -220,4 +220,47 @@ describe("resolveDelegationTarget", () => {
     const result = await resolveDelegationTarget(tx, actor, "bot-origin", "just a normal message");
     expect(result).toBeNull();
   });
+
+  it("does not match a bot owned by a different userId in the same workspace", async () => {
+    // Same workspace, other member's bot named Sarah — Prisma would exclude it via userId.
+    const findMany = vi.fn().mockImplementation(async ({ where }) => {
+      const bots = [
+        {
+          id: "bot-sarah-other",
+          name: "Sarah",
+          userId: "user-2",
+          thread: { id: "thread-bot-sarah-other" },
+        },
+        {
+          id: "bot-sarah-own",
+          name: "Other",
+          userId: "user-1",
+          thread: { id: "thread-bot-sarah-own" },
+        },
+      ];
+      return bots
+        .filter(
+          (bot) =>
+            bot.userId === where.userId &&
+            where.workspaceId === actor.workspaceId &&
+            bot.id !== where.id.not,
+        )
+        .map(({ id, name, thread }) => ({ id, name, thread }));
+    });
+    const tx = { bot: { findMany } } as unknown as Prisma.TransactionClient;
+
+    const result = await resolveDelegationTarget(tx, actor, "bot-origin", "@Sarah check email");
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          workspaceId: "workspace-1",
+          userId: "user-1",
+          archivedAt: null,
+          id: { not: "bot-origin" },
+        }),
+      }),
+    );
+    expect(result).toBeNull();
+  });
 });

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -1,12 +1,18 @@
 import { type JobPublisher, runContinueJob } from "@rakazo/adapter-kit";
-import { toComputerRef } from "@rakazo/adapters";
+import { notifyDelegationOrigin, toComputerRef } from "@rakazo/adapters";
 import {
   type Actor,
   GROUP_MEMBER_MIN,
   type GroupMember,
+  type MessageBlock,
   type ThreadSnapshot,
 } from "@rakazo/contracts";
-import { ACTIVE_RUN_STATUSES, projectMessages, resolveGroupTargetBotIds } from "@rakazo/core";
+import {
+  ACTIVE_RUN_STATUSES,
+  blocksToAgentHistoryText,
+  projectMessages,
+  resolveGroupTargetBotIds,
+} from "@rakazo/core";
 import {
   appendEventInTransaction,
   createGroupRepos,
@@ -323,6 +329,143 @@ function messagesWithLiveEvents(
   return [...persisted, ...live];
 }
 
+const DELEGATION_CONTEXT_MESSAGES = 6;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * "@BotB" anywhere in Bot A's 1:1 chat, typed by the user, delegates the task
+ * to an existing peer bot rather than sending to Bot A — "@BotB do X" at the
+ * start, or "do X @BotB" / "can you ask @BotB to do X" mid-sentence, all
+ * match. Matched against every other bot's exact name (longest first, so
+ * "Chief of Staff" wins over a hypothetical "Chief") as a whole word: the
+ * mention must be preceded by start-of-string/whitespace and followed by
+ * end-of-string/whitespace/punctuation, so "@Bot" inside "@BotFoo" doesn't
+ * false-match. The matched "@BotB" token is replaced with the bare bot name
+ * so the remaining text still reads as a natural instruction; if nothing is
+ * left after that, it's not a delegation and falls through to a normal
+ * message.
+ */
+export async function resolveDelegationTarget(
+  tx: Prisma.TransactionClient,
+  actor: Actor,
+  originBotId: string,
+  text: string | undefined,
+): Promise<{ botId: string; botName: string; threadId: string; prompt: string } | null> {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed.includes("@")) return null;
+  const candidates = await tx.bot.findMany({
+    where: { workspaceId: actor.workspaceId, archivedAt: null, id: { not: originBotId } },
+    select: { id: true, name: true, thread: { select: { id: true } } },
+  });
+  const withThread = candidates
+    .filter((candidate) => candidate.thread)
+    .sort((a, b) => b.name.length - a.name.length);
+  for (const candidate of withThread) {
+    const pattern = new RegExp(`(^|\\s)@${escapeRegExp(candidate.name)}(?=$|[\\s.,!?;:])`, "i");
+    if (!pattern.test(trimmed)) continue;
+    const prompt = trimmed
+      .replace(pattern, (_match, lead) => `${lead}${candidate.name}`)
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!prompt || prompt.toLowerCase() === candidate.name.toLowerCase()) continue;
+    return { botId: candidate.id, botName: candidate.name, threadId: candidate.thread!.id, prompt };
+  }
+  return null;
+}
+
+async function buildDelegationContext(
+  tx: Prisma.TransactionClient,
+  threadId: string,
+): Promise<string> {
+  const recent = await tx.message.findMany({
+    where: { threadId },
+    orderBy: { seq: "desc" },
+    take: DELEGATION_CONTEXT_MESSAGES,
+    select: { role: true, blocks: true },
+  });
+  const lines = recent
+    .reverse()
+    .map((message) => {
+      const text = blocksToAgentHistoryText(message.blocks as MessageBlock[]);
+      return text ? `${message.role}: ${text}` : null;
+    })
+    .filter((line): line is string => Boolean(line));
+  return lines.join("\n");
+}
+
+/**
+ * Creates the delegated bot's own Task/Run (same create-then-enqueue shape as
+ * routine wakeups and group handoffs) plus a "delegated_task" card message in
+ * the origin thread that a later run.started/completed/failed hook mirrors
+ * live status into (see notifyDelegationOrigin in packages/adapters).
+ */
+async function createDelegatedRun(
+  tx: Prisma.TransactionClient,
+  params: {
+    actor: Actor;
+    originBotId: string;
+    originThreadId: string;
+    targetBotId: string;
+    targetBotName: string;
+    targetThreadId: string;
+    prompt: string;
+  },
+) {
+  const context = await buildDelegationContext(tx, params.originThreadId);
+  const enrichedPrompt = context
+    ? `${params.prompt}\n\n(Delegated from another bot's conversation. Recent context:\n${context})`
+    : params.prompt;
+
+  const task = await tx.task.create({
+    data: {
+      workspaceId: params.actor.workspaceId,
+      botId: params.targetBotId,
+      threadId: params.targetThreadId,
+      userId: params.actor.userId,
+      prompt: enrichedPrompt,
+      status: "queued",
+    },
+  });
+  const run = await tx.run.create({
+    data: {
+      workspaceId: params.actor.workspaceId,
+      botId: params.targetBotId,
+      threadId: params.targetThreadId,
+      taskId: task.id,
+      userId: params.actor.userId,
+      status: "queued",
+      trigger: "spawn",
+      delegatedFromThreadId: params.originThreadId,
+    },
+  });
+
+  const cardBlock: MessageBlock = {
+    kind: "delegated_task",
+    taskId: task.id,
+    runId: run.id,
+    botId: params.targetBotId,
+    botName: params.targetBotName,
+    prompt: params.prompt,
+    status: "queued",
+    summary: null,
+  };
+  const cardMessage = await createThreadMessageInTransaction(tx, {
+    threadId: params.originThreadId,
+    role: "bot",
+    botId: params.originBotId,
+    blocks: [cardBlock],
+  });
+  await tx.run.update({
+    where: { id: run.id },
+    data: { delegatedFromMessageId: cardMessage.id },
+  });
+
+  return { run, cardMessageId: cardMessage.id, cardBlocks: [cardBlock] as MessageBlock[] };
+}
+
 function mapRun(run: {
   id: string;
   botId: string;
@@ -397,6 +540,40 @@ export async function sendThreadMessage(
           replyToMessageId: input.replyToMessageId,
           clientNonce: input.clientNonce,
         });
+
+        const delegated = await resolveDelegationTarget(tx, actor, target.botId, input.text);
+        if (delegated) {
+          const userEvent = await appendEventInTransaction(tx, {
+            workspaceId: actor.workspaceId,
+            threadId: target.threadId,
+            botId: target.botId,
+            type: "thread.message.created",
+            payload: {
+              messageId: message.id,
+              role: "user",
+              blocks,
+              replyToMessageId: input.replyToMessageId,
+            },
+          });
+          const created = await createDelegatedRun(tx, {
+            actor,
+            originBotId: target.botId,
+            originThreadId: target.threadId,
+            targetBotId: delegated.botId,
+            targetBotName: delegated.botName,
+            targetThreadId: delegated.threadId,
+            prompt: delegated.prompt,
+          });
+          const cardEvent = await appendEventInTransaction(tx, {
+            workspaceId: actor.workspaceId,
+            threadId: target.threadId,
+            botId: target.botId,
+            type: "thread.message.created",
+            payload: { messageId: created.cardMessageId, role: "bot", blocks: created.cardBlocks },
+          });
+          return { message, runs: [created.run], eventSeq: Math.max(userEvent.seq, cardEvent.seq) };
+        }
+
         const task = await tx.task.create({
           data: {
             workspaceId: actor.workspaceId,
@@ -620,6 +797,79 @@ export async function stopThreadRuns(
       runId: { in: activeRuns.map((run) => run.id) },
     },
   });
+}
+
+/**
+ * Cancels a single run, leaving any other active run on the same thread
+ * untouched — unlike stopThreadRuns, which cancels every active run on the
+ * thread at once. Needed so an accidental duplicate @mention delegation
+ * (two Task/Run pairs queued on the same target bot) can be cleaned up
+ * without killing the run that's actually meant to keep going.
+ */
+export async function cancelRun(
+  deps: {
+    prisma: PrismaClient;
+    sandbox: import("@rakazo/adapter-kit").SandboxProvider;
+    events: ThreadEvents;
+  },
+  actor: Actor,
+  runId: string,
+): Promise<{ ok: true } | { ok: false; reason: "not_found" | "not_active" }> {
+  const run = await deps.prisma.run.findFirst({
+    where: { id: runId, bot: { workspaceId: actor.workspaceId, userId: actor.userId } },
+    select: {
+      id: true,
+      status: true,
+      botId: true,
+      workspaceId: true,
+      delegatedFromThreadId: true,
+      delegatedFromMessageId: true,
+      bot: {
+        select: {
+          computer: {
+            select: {
+              id: true,
+              homeKey: true,
+              kind: true,
+              providerRef: true,
+              executionRunId: true,
+            },
+          },
+        },
+      },
+    },
+  });
+  if (!run) return { ok: false, reason: "not_found" };
+  if (!ACTIVE_RUN_STATUSES.includes(run.status as (typeof ACTIVE_RUN_STATUSES)[number])) {
+    return { ok: false, reason: "not_active" };
+  }
+  await deps.prisma.run.update({
+    where: { id: run.id },
+    data: { status: "cancelled", completedAt: new Date() },
+  });
+  const computer = run.bot.computer;
+  if (computer && computer.executionRunId === run.id) {
+    await deps.prisma.computerExecutionLease.deleteMany({ where: { botId: run.botId } });
+    await deps.prisma.computer.update({
+      where: { id: computer.id },
+      data: { executionRunId: null, executionBotId: null, executionLeaseExpiresAt: null },
+    });
+    if (computer.providerRef) {
+      await deps.sandbox
+        .releaseScreen?.(toComputerRef(computer), {
+          operationId: "stop",
+          traceId: "stop",
+          workspaceId: actor.workspaceId,
+          userId: actor.userId,
+          botId: run.botId,
+          signal: new AbortController().signal,
+        })
+        .catch(() => undefined);
+    }
+  }
+  await deps.prisma.event.deleteMany({ where: { type: "thread.progress", runId: run.id } });
+  await notifyDelegationOrigin(deps, run, "cancelled");
+  return { ok: true };
 }
 
 export async function setThreadUnreadState(

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -357,7 +357,12 @@ export async function resolveDelegationTarget(
   const trimmed = (text ?? "").trim();
   if (!trimmed.includes("@")) return null;
   const candidates = await tx.bot.findMany({
-    where: { workspaceId: actor.workspaceId, archivedAt: null, id: { not: originBotId } },
+    where: {
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      archivedAt: null,
+      id: { not: originBotId },
+    },
     select: { id: true, name: true, thread: { select: { id: true } } },
   });
   const withThread = candidates

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3486,6 +3486,68 @@ const MessageView = memo(function MessageView({
             </button>
           );
         }
+        if (block.kind === "delegated_task") {
+          const failed = block.status === "failed" || block.status === "cancelled";
+          const done = block.status === "completed";
+          const running = !failed && !done;
+          return (
+            <div
+              key={i}
+              className="group relative w-[min(340px,90%)] rounded-[18px] border border-[#232326] bg-[#17171A]"
+            >
+              <button
+                type="button"
+                onClick={() => onOpenBot(block.botId)}
+                className="w-full px-[18px] py-4 text-start"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span
+                    className="min-w-0 truncate text-[15px] font-medium text-[#ECECEE]"
+                    dir="auto"
+                  >
+                    {block.botName}
+                  </span>
+                  <span
+                    className="shrink-0 rounded-full px-[11px] py-1 text-[13px]"
+                    style={{
+                      background: failed
+                        ? "rgba(230,87,7,.14)"
+                        : done
+                          ? "rgba(48,162,75,.14)"
+                          : "rgba(245,160,60,.14)",
+                      color: failed ? "#E65707" : done ? "#4ECB71" : "#F5A03C",
+                      animation: running ? "rkPulse 1.2s ease-in-out infinite" : undefined,
+                    }}
+                  >
+                    {block.status.replace("_", " ")}
+                  </span>
+                </div>
+                <div className="mt-2 text-[13.5px] text-[#85858A]" dir="auto">
+                  {block.prompt}
+                </div>
+                {block.summary ? (
+                  <div className="mt-2.5 text-[14.5px] leading-[1.5] text-[#A8A8AD]" dir="auto">
+                    <ChatMarkdown>{block.summary}</ChatMarkdown>
+                  </div>
+                ) : null}
+              </button>
+              {running ? (
+                <button
+                  type="button"
+                  aria-label={`Cancel ${block.botName}'s task`}
+                  title="Cancel this delegated task"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void rpc.runs.cancel({ runId: block.runId }).catch(() => undefined);
+                  }}
+                  className="absolute right-2 top-2 rounded-full p-1 text-[#55555A] opacity-0 hover:bg-[#232326] hover:text-[#EF6461] group-hover:opacity-100"
+                >
+                  <X size={13} strokeWidth={2} />
+                </button>
+              ) : null}
+            </div>
+          );
+        }
         if (block.kind === "choice") {
           const botId = "botId" in artifactTarget ? artifactTarget.botId : message.botId;
           if (!botId) return null;

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -268,6 +268,63 @@ async function persistLivePluginConnections(
   }
 }
 
+// A verbose agent's final text often front-loads step-by-step narration and
+// puts the actual outcome at the end, so a head-truncated summary can cut
+// off before the conclusion. Prefer the tail when the text is over the
+// limit — the last `limit` chars, trimmed to a whole word.
+function summarizeTail(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  const tail = text.slice(-limit);
+  const spaceIndex = tail.indexOf(" ");
+  const trimmed = spaceIndex === -1 ? tail : tail.slice(spaceIndex + 1);
+  return `…${trimmed}`;
+}
+
+/**
+ * Mirrors a delegated run's status into the "delegated_task" card left in the
+ * origin bot's thread by createDelegatedRun (apps/api/src/thread-target.ts),
+ * so that card updates live as Bot B's run progresses instead of staying
+ * frozen at "queued". A no-op for any run that wasn't a delegation.
+ */
+export async function notifyDelegationOrigin(
+  deps: Pick<ExecutorDeps, "prisma" | "events">,
+  run: {
+    workspaceId: string;
+    botId: string;
+    delegatedFromThreadId: string | null;
+    delegatedFromMessageId: string | null;
+  },
+  status: "running" | "completed" | "failed" | "cancelled",
+  summary?: string,
+) {
+  if (!run.delegatedFromThreadId || !run.delegatedFromMessageId) return;
+  try {
+    const existing = await deps.prisma.message.findUnique({
+      where: { id: run.delegatedFromMessageId },
+      select: { blocks: true },
+    });
+    const blocks = existing?.blocks as MessageBlock[] | undefined;
+    const existingBlock = blocks?.[0];
+    if (!existing || existingBlock?.kind !== "delegated_task") return;
+    const nextBlocks: MessageBlock[] = [
+      { ...existingBlock, status, summary: summary ?? existingBlock.summary },
+    ];
+    await deps.prisma.message.update({
+      where: { id: run.delegatedFromMessageId },
+      data: { blocks: nextBlocks as never },
+    });
+    await deps.events.append({
+      workspaceId: run.workspaceId,
+      threadId: run.delegatedFromThreadId,
+      botId: run.botId,
+      type: "thread.message.updated",
+      payload: { messageId: run.delegatedFromMessageId, role: "bot", blocks: nextBlocks },
+    });
+  } catch (error) {
+    console.error("delegation status update failed", error);
+  }
+}
+
 export function createRunExecutor(deps: ExecutorDeps) {
   return {
     async resolveModel(scope: {
@@ -655,6 +712,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           runId,
           payload: { trigger: run.trigger },
         });
+        await notifyDelegationOrigin(deps, run, "running");
 
         const discoveredPromise = deps.connector
           ? deps.connector.discoverTools(context)
@@ -1978,6 +2036,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                   outcome: "completed",
                   blocks: [{ kind: "text", text: stuckText }],
                 });
+                await notifyDelegationOrigin(deps, run, "completed", summarizeTail(stuckText, 240));
                 runAbortController?.abort();
                 return;
               }
@@ -2104,6 +2163,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             blocks,
           });
           if (!completed) return;
+          await notifyDelegationOrigin(deps, run, "completed", summarizeTail(text, 240));
           if (bot.notifyOnFinish) {
             await notifyRun(deps, run, {
               kind: "completion",
@@ -2163,6 +2223,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             error: message,
           });
           if (!failed) return;
+          await notifyDelegationOrigin(deps, run, "failed", message.slice(0, 240));
           if (bot.notifyOnFinish) {
             await notifyRun(deps, run, {
               kind: "failure",

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -150,6 +150,27 @@ export const MessageBlock = z.discriminatedUnion("kind", [
     status: z.enum(["created", "archived", "deleted"]),
   }),
   z.object({
+    /** An @mention delegation to an existing peer bot — its own Task/Run runs
+        in that bot's own thread; this card mirrors its live status back here. */
+    kind: z.literal("delegated_task"),
+    taskId: Id,
+    runId: Id,
+    botId: Id,
+    botName: z.string(),
+    prompt: z.string(),
+    status: z.enum([
+      "queued",
+      "leased",
+      "running",
+      "waiting_input",
+      "waiting_takeover",
+      "completed",
+      "failed",
+      "cancelled",
+    ]),
+    summary: z.string().nullable(),
+  }),
+  z.object({
     kind: z.literal("skill_draft"),
     skillId: Id,
     name: z.string(),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -225,6 +225,16 @@ export const appContract = {
     markRead: oc.input(threadTarget).output(z.object({ ok: z.literal(true) })),
     markUnread: oc.input(threadTarget).output(z.object({ ok: z.literal(true) })),
   },
+  runs: {
+    /** Cancels one run without touching any other active run on the same
+        thread — unlike threads.stop, which cancels every active run on a
+        thread at once. Used to clean up an accidental duplicate delegation. */
+    cancel: oc
+      .input(z.object({ runId: Id }))
+      .output(
+        z.object({ ok: z.boolean(), reason: z.enum(["not_found", "not_active"]).optional() }),
+      ),
+  },
   computer: {
     status: oc.input(botId).output(ComputerStatusSchema),
     boot: oc.input(botId).output(ComputerStatusSchema),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -226,16 +226,6 @@ export const appContract = {
     markRead: oc.input(threadTarget).output(z.object({ ok: z.literal(true) })),
     markUnread: oc.input(threadTarget).output(z.object({ ok: z.literal(true) })),
   },
-  runs: {
-    /** Cancels one run without touching any other active run on the same
-        thread — unlike threads.stop, which cancels every active run on a
-        thread at once. Used to clean up an accidental duplicate delegation. */
-    cancel: oc
-      .input(z.object({ runId: Id }))
-      .output(
-        z.object({ ok: z.boolean(), reason: z.enum(["not_found", "not_active"]).optional() }),
-      ),
-  },
   computer: {
     status: oc.input(botId).output(ComputerStatusSchema),
     boot: oc.input(botId).output(ComputerStatusSchema),
@@ -527,6 +517,14 @@ export const appContract = {
   },
   runs: {
     list: oc.input(z.object({ filter: z.enum(["active", "recent"]) })).output(RunsListOutputSchema),
+    /** Cancels one run without touching any other active run on the same
+        thread — unlike threads.stop, which cancels every active run on a
+        thread at once. Used to clean up an accidental duplicate delegation. */
+    cancel: oc
+      .input(z.object({ runId: Id }))
+      .output(
+        z.object({ ok: z.boolean(), reason: z.enum(["not_found", "not_active"]).optional() }),
+      ),
   },
   voice: {
     catalog: oc.output(z.array(VoiceCatalogEntrySchema)),

--- a/packages/core/src/attachments.test.ts
+++ b/packages/core/src/attachments.test.ts
@@ -44,6 +44,33 @@ describe("attachment helpers", () => {
         },
       ]),
     ).toBe("hello\n[image: shot.png]\n[file: brief.pdf (application/pdf, 99 bytes)]");
+    expect(
+      blocksToAgentHistoryText([
+        {
+          kind: "delegated_task",
+          taskId: "t1",
+          runId: "r1",
+          botId: "b1",
+          botName: "Researcher",
+          prompt: "find comps",
+          status: "completed",
+          summary: "found 3 comps",
+        },
+        {
+          kind: "delegated_task",
+          taskId: "t2",
+          runId: "r2",
+          botId: "b2",
+          botName: "Writer",
+          prompt: "draft the memo",
+          status: "running",
+          summary: null,
+        },
+      ]),
+    ).toBe(
+      '[delegated to Researcher: "find comps" — completed: found 3 comps]\n' +
+        '[delegated to Writer: "draft the memo" — running]',
+    );
   });
 
   it("infers attachment mime types from extensions", () => {

--- a/packages/core/src/attachments.ts
+++ b/packages/core/src/attachments.ts
@@ -95,6 +95,10 @@ export function blocksToAgentHistoryText(blocks: MessageBlock[]): string {
       if (block.kind === "file") {
         return `[file: ${block.name} (${block.mimeType}, ${block.size} bytes)]`;
       }
+      if (block.kind === "delegated_task") {
+        const outcome = block.summary ? `${block.status}: ${block.summary}` : block.status;
+        return `[delegated to ${block.botName}: "${block.prompt}" — ${outcome}]`;
+      }
       if ("text" in block && typeof block.text === "string") return block.text;
       return "";
     })

--- a/packages/db/prisma/migrations/20260825150000_run_delegation_fields/migration.sql
+++ b/packages/db/prisma/migrations/20260825150000_run_delegation_fields/migration.sql
@@ -1,0 +1,6 @@
+-- A run created by an @mention delegation from another bot's own thread
+-- tracks that origin so its status can be mirrored back into a live card
+-- there. Plain columns, no foreign key: the origin thread/message can
+-- belong to a different bot than this run's own.
+ALTER TABLE "runs" ADD COLUMN "delegatedFromThreadId" TEXT;
+ALTER TABLE "runs" ADD COLUMN "delegatedFromMessageId" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -434,6 +434,12 @@ model Run {
   clientNonce   String?
   sourceMessageId String?
   sourceMessage Message?  @relation("RunSourceMessage", fields: [sourceMessageId], references: [id], onDelete: SetNull)
+  // A run created by an @mention delegation from another bot's own thread
+  // tracks that origin so its status can be mirrored back into a live card
+  // there. Plain columns, no foreign key: the origin thread/message can
+  // belong to a different bot than this run's own.
+  delegatedFromThreadId  String?
+  delegatedFromMessageId String?
   startedAt     DateTime?
   completedAt   DateTime?
   createdAt     DateTime  @default(now())


### PR DESCRIPTION
## Summary

Typing `@BotB do X` in Bot A's 1:1 chat delegates the task to Bot B: it gets
its own Task/Run in its own thread, with the last 6 messages of Bot A's
conversation folded into the prompt as context. A live-updating
`delegated_task` card in Bot A's thread mirrors Bot B's status (queued →
running → completed/failed/cancelled).

## Changes

- `resolveDelegationTarget`: matches `@BotB` **anywhere** in the message
  (start, middle, or end — "can you ask @BotB to check this" works), not
  just as a prefix. Matched against every other bot's exact name (longest
  first, so "Chief of Staff" wins over "Chief"), as a whole word.
- `createDelegatedRun`: creates the Task/Run in Bot B's own thread inside
  the same transaction as the user's message, posts the `delegated_task`
  card in Bot A's thread
- `notifyDelegationOrigin`: mirrors Bot B's run status live into that card
  via the existing run.started/completed/failed hooks. The completion
  summary is tail-truncated rather than head-truncated — a verbose agent's
  actual conclusion is usually at the end of its response, not the start.
- New `runs.cancel` / `cancelRun`: cancels exactly one run, unlike the
  existing thread-wide `threads.stop` — needed so an accidental duplicate
  delegation (two Task/Run pairs queued on the same target bot) can be
  cleaned up without killing the run that's actually meant to keep going.
  The `delegated_task` card gets a hover Stop button wired to it.
- `Run.delegatedFromThreadId` / `delegatedFromMessageId`: plain columns, no
  FK (the origin thread/message can belong to a different bot than the run
  itself)

## Testing notes

- [x] `pnpm --filter @rakazo/api test` — new `resolveDelegationTarget`
      coverage (start/middle mention, longest-name-wins, bare mention with
      no task text, mentioned bot with no thread, no `@` at all)
- [x] `pnpm --filter @rakazo/adapters test`
- [x] `pnpm --filter @rakazo/api check`, `pnpm --filter @rakazo/web check`,
      `pnpm --filter @rakazo/adapters check`
- [x] `biome check` on touched files
- [x] Manually tested live against two real bots (Sarah/private) in a
      running instance — delegation triggers, the card mirrors status live,
      per-run cancel leaves the other bot's run untouched