### PR TITLE
fix(sandbox): Team Computer was one desktop per bot, not one shared

### DIFF
--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -75,7 +75,7 @@ if [[ ! -f "$NOVNC_ROOT/embed.html" ]]; then
   echo "noVNC embed.html is missing from the computer image" >&2
   exit 1
 fi
-websockify --web="$NOVNC_ROOT" 0.0.0.0:6080 127.0.0.1:5900 >/tmp/rakazo/novnc.log 2>&1 &
+websockify --heartbeat=30 --web="$NOVNC_ROOT" 0.0.0.0:6080 127.0.0.1:5900 >/tmp/rakazo/novnc.log 2>&1 &
 
 while kill -0 "$XVFB_PID" 2>/dev/null; do
   sleep 2

--- a/infra/sandboxes/supervisor/src/supervisor-logic.ts
+++ b/infra/sandboxes/supervisor/src/supervisor-logic.ts
@@ -177,7 +177,7 @@ export function ensureScreenCommand(index: number) {
     `if [ -d /home/rakazo/.browser-profiles/chromium ]; then cp -a /home/rakazo/.browser-profiles/chromium/. ${profile}/; rm -f ${profile}/SingletonLock ${profile}/SingletonCookie ${profile}/SingletonSocket; fi`,
     `DISPLAY=${layout.display} HOME=/home/rakazo rakazo-browser --user-data-dir=${profile} >${log}-browser.log 2>&1 &`,
     `x11vnc -display ${layout.display} -forever -shared -viewonly -nopw -listen 127.0.0.1 -rfbport ${layout.viewVncPort} -xkb -ncache 0 >${log}-x11vnc.log 2>&1 &`,
-    `websockify --web=/usr/share/novnc 0.0.0.0:${layout.viewPort} 127.0.0.1:${layout.viewVncPort} >${log}-novnc.log 2>&1 &`,
+    `websockify --heartbeat=30 --web=/usr/share/novnc 0.0.0.0:${layout.viewPort} 127.0.0.1:${layout.viewVncPort} >${log}-novnc.log 2>&1 &`,
     `for i in $(seq 1 50); do (echo >/dev/tcp/127.0.0.1/${layout.viewPort}) >/dev/null 2>&1 && exit 0; sleep 0.1; done`,
     "exit 1",
   ].join("\n");
@@ -268,7 +268,7 @@ export function interactiveScreenCommand(
     `printf %s ${shellQuote(controlToken)} > ${tokenFile}`,
     `export DISPLAY=${layout.display}`,
     `(x11vnc -display ${layout.display} -forever -shared -nopw -listen 127.0.0.1 -rfbport ${layout.controlVncPort} -xkb -ncache 0 >/tmp/rakazo/x11vnc-control-${layout.displayNumber}.log 2>&1 &)`,
-    `(websockify --web=/usr/share/novnc 0.0.0.0:${layout.controlPort} 127.0.0.1:${layout.controlVncPort} >/tmp/rakazo/novnc-control-${layout.displayNumber}.log 2>&1 &)`,
+    `(websockify --heartbeat=30 --web=/usr/share/novnc 0.0.0.0:${layout.controlPort} 127.0.0.1:${layout.controlVncPort} >/tmp/rakazo/novnc-control-${layout.displayNumber}.log 2>&1 &)`,
     `for i in $(seq 1 50); do (echo >/dev/tcp/127.0.0.1/${layout.controlPort}) >/dev/null 2>&1 && exit 0; sleep 0.1; done`,
     "exit 1",
   ].join("; ");

--- a/packages/adapters/src/docker-sandbox.test.ts
+++ b/packages/adapters/src/docker-sandbox.test.ts
@@ -45,9 +45,7 @@ describe("Docker sandbox", () => {
       { type: "stderr", data: "command timed out after 75 ms\n" },
       { type: "exit", code: 124 },
     ]);
-    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
-      "x-rakazo-screen-id": "bot",
-    });
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).not.toHaveProperty("x-rakazo-screen-id");
   });
 
   it("releases this bot's screen assignment through the supervisor", async () => {
@@ -67,7 +65,6 @@ describe("Docker sandbox", () => {
         headers: expect.objectContaining({
           authorization: "Bearer test-token",
           "x-rakazo-bot-id": "home-bot",
-          "x-rakazo-screen-id": "bot",
           "x-rakazo-screen-lease-id": "run-1:1",
           "x-rakazo-workspace-id": "workspace",
         }),

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -52,12 +52,22 @@ export class DockerSandboxProvider implements SandboxProvider {
     return `${this.supervisorUrl.replace(/\/$/, "")}${path}`;
   }
 
+  // No x-rakazo-screen-id here: the supervisor keys a screen off
+  // x-rakazo-bot-id alone (the ComputerRef's homeKey — shared across every
+  // bot on a Team Computer, distinct per bot on a dedicated one). Keying it
+  // off the calling bot's own id instead would give each bot on a shared
+  // Team Computer its own Xvfb/Chromium/x11vnc stack — several times the RAM
+  // for one container, and each stack fighting the same Chromium profile dir
+  // (homeKey is shared too) for its SingletonLock, so only the first bot to
+  // grab it gets the real logged-in session and the rest boot to a blank
+  // profile. Screen VIEWING is safely shared already (x11vnc -shared serves
+  // any number of simultaneous viewers of the one desktop); who gets to
+  // actually drive it is gated separately by the execution lease.
   private headers(context: AdapterContext, botId?: string) {
     return {
       authorization: `Bearer ${this.supervisorToken}`,
       "x-rakazo-workspace-id": context.workspaceId,
       ...(botId ? { "x-rakazo-bot-id": botId } : {}),
-      ...(context.botId ? { "x-rakazo-screen-id": context.botId } : {}),
       ...(context.screenLeaseId ? { "x-rakazo-screen-lease-id": context.screenLeaseId } : {}),
     };
   }


### PR DESCRIPTION
## Summary

Each bot's own real id was sent as the screen key (`x-rakazo-screen-id`),
so every bot sharing a Team Computer got its own Xvfb/Chromium/x11vnc/
websockify stack in the same container — several times the RAM for one
container, and each stack fighting the same Chromium profile dir (the
`homeKey` is shared too) for its `SingletonLock`, so only the first bot to
grab it got the real logged-in session and the rest booted to a blank
profile.

## Changes

- The supervisor already keys a screen off `x-rakazo-bot-id` alone (the
  `ComputerRef`'s `homeKey` — shared across every bot on a Team Computer,
  distinct per bot on a dedicated one); dropping the extra per-bot
  `x-rakazo-screen-id` header lets every bot on a shared computer land on
  the one screen that's actually there. Screen *viewing* was already safely
  shared (`x11vnc -shared` serves any number of simultaneous viewers); who
  gets to *drive* it is gated separately by the execution lease.
- `--heartbeat=30` on every `websockify` invocation, so a client that goes
  away without a clean WebSocket close (network drop, tab closed
  mid-session) gets reaped in tens of seconds instead of however long the
  OS takes to notice a dead TCP connection.

## Testing notes

- [x] `pnpm --filter @rakazo/adapters test`, `pnpm --filter @rakazo/sandbox-supervisor test`
- [x] `pnpm --filter @rakazo/adapters check`, `pnpm --filter @rakazo/sandbox-supervisor check`
- [x] `biome check` on touched files
- [x] Manually verified against two real bots sharing a Team Computer: only
      one Xvfb/Chromium/x11vnc/websockify stack running, both bots see the
      same live desktop