### PR TITLE
feat(web): view any other agent's computer, read only

### DIFF
--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -88,6 +88,7 @@ describe("computer.peek", () => {
       overrides.connectScreen ??
       vi.fn().mockResolvedValue({ url: "https://sandbox.test/vnc.html", close: async () => {} });
     const leaseFindUnique = overrides.leaseFindUnique ?? vi.fn();
+    const enqueue = vi.fn().mockResolvedValue(undefined);
     const prisma = {
       bot: { findFirst: overrides.botFindFirst ?? vi.fn().mockResolvedValue(null) },
       computerExecutionLease: { findUnique: leaseFindUnique },
@@ -95,6 +96,7 @@ describe("computer.peek", () => {
     const deps = {
       prisma,
       sandbox: { connectScreen },
+      jobs: { enqueue },
       env: {
         defaultProvider: "fake",
         defaultModel: "fake-model",
@@ -104,7 +106,13 @@ describe("computer.peek", () => {
       },
       dataDir: "/tmp/rakazo-router-test",
     } as unknown as RouterDeps;
-    return { deps, connectScreen, leaseFindUnique, handler: new RPCHandler(createRouter(deps)) };
+    return {
+      deps,
+      connectScreen,
+      leaseFindUnique,
+      enqueue,
+      handler: new RPCHandler(createRouter(deps)),
+    };
   }
 
   async function callPeek(

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -71,6 +71,123 @@ describe("thread answer delivery", () => {
   });
 });
 
+describe("computer.peek", () => {
+  const actor = {
+    workspaceId: "workspace-1",
+    userId: "user-1",
+    email: "user@rakazo.test",
+    isDeploymentOwner: true,
+  } satisfies Actor;
+
+  function peekDeps(overrides: {
+    botFindFirst?: ReturnType<typeof vi.fn>;
+    leaseFindUnique?: ReturnType<typeof vi.fn>;
+    connectScreen?: ReturnType<typeof vi.fn>;
+  }) {
+    const connectScreen =
+      overrides.connectScreen ??
+      vi.fn().mockResolvedValue({ url: "https://sandbox.test/vnc.html", close: async () => {} });
+    const leaseFindUnique = overrides.leaseFindUnique ?? vi.fn();
+    const prisma = {
+      bot: { findFirst: overrides.botFindFirst ?? vi.fn().mockResolvedValue(null) },
+      computerExecutionLease: { findUnique: leaseFindUnique },
+    } as unknown as PrismaClient;
+    const deps = {
+      prisma,
+      sandbox: { connectScreen },
+      env: {
+        defaultProvider: "fake",
+        defaultModel: "fake-model",
+        webOrigin: "http://127.0.0.1:5173",
+        screenProxySecret: "fake-test-secret",
+        sandboxProvider: "fake",
+      },
+      dataDir: "/tmp/rakazo-router-test",
+    } as unknown as RouterDeps;
+    return { deps, connectScreen, leaseFindUnique, handler: new RPCHandler(createRouter(deps)) };
+  }
+
+  async function callPeek(
+    handler: ReturnType<typeof peekDeps>["handler"],
+    targetBotId: string,
+    peekActor: Actor = actor,
+  ) {
+    return handler.handle(
+      new Request("http://127.0.0.1/rpc/computer/peek", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { targetBotId } }),
+      }),
+      { prefix: "/rpc", context: { actor: peekActor } },
+    );
+  }
+
+  it("fails closed for an unknown or foreign bot id", async () => {
+    const { handler, connectScreen, leaseFindUnique } = peekDeps({
+      botFindFirst: vi.fn().mockResolvedValue(null),
+    });
+    const { matched, response } = await callPeek(handler, "missing-bot");
+    expect(matched).toBe(true);
+    expect(response.status).not.toBe(200);
+    expect(connectScreen).not.toHaveBeenCalled();
+    expect(leaseFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("connects the target screen without an execution lease", async () => {
+    const target = {
+      id: "bot-other",
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      thread: { id: "thread-other" },
+      computer: {
+        id: "computer-1",
+        homeKey: "home-1",
+        kind: "fake",
+        scope: "team",
+        state: "running",
+        providerRef: "provider-1",
+        controlHolder: "none",
+        controlBotId: null,
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlRunId: null,
+      },
+    };
+    const { handler, connectScreen, leaseFindUnique } = peekDeps({
+      botFindFirst: vi.fn().mockResolvedValue(target),
+      // If peek incorrectly used computerScreenContext, this lease would be attached.
+      leaseFindUnique: vi.fn().mockResolvedValue({
+        runId: "run-1",
+        fence: 3,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    });
+
+    const { matched, response } = await callPeek(handler, target.id);
+    expect(matched).toBe(true);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      json: { mode: "team", exists: true, state: "running" },
+    });
+    expect(typeof body.json.url).toBe("string");
+    expect(connectScreen).toHaveBeenCalledOnce();
+    expect(connectScreen).toHaveBeenCalledWith(
+      expect.objectContaining({ providerRef: "provider-1" }),
+      { view: "stream", interactive: false },
+      expect.objectContaining({
+        botId: "bot-other",
+        operationId: "peek",
+        workspaceId: "workspace-1",
+        userId: "user-1",
+      }),
+    );
+    const context = connectScreen.mock.calls[0]?.[2] as { screenLeaseId?: string };
+    expect(context.screenLeaseId).toBeUndefined();
+    expect(leaseFindUnique).not.toHaveBeenCalled();
+  });
+});
+
 describe("MCP server deletion", () => {
   it("does not fail when a concurrent credential rotation already removed the old secret", async () => {
     const deleteServer = vi.fn().mockResolvedValue({ id: "server-1" });

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1468,6 +1468,7 @@ export function createRouter(deps: RouterDeps) {
         if (!session.url) {
           return { mode, exists: true, state: other.state as never, url: null };
         }
+        scheduleComputerSleep(deps.jobs, other.id);
         const viewUrl = withViewOnly(session.url, true);
         return {
           mode,

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1440,6 +1440,47 @@ export function createRouter(deps: RouterDeps) {
           ),
         };
       }),
+      /**
+       * Read-only look at ANY other bot's currently assigned computer — for
+       * the computer-pane picker, which is a view toggle, not a
+       * reassignment or takeover. Never boots, provisions, or mutates
+       * anything: a stopped/never-used computer just reports
+       * { exists, state } with a null screen.
+       */
+      peek: authed.computer.peek.handler(async ({ context, input }) => {
+        const target = await repos.getBot(context.actor, input.targetBotId);
+        const mode = target.computer?.scope === "dedicated" ? "dedicated" : "team";
+        const other = target.computer;
+        if (!other) return { mode, exists: false, state: null, url: null };
+        if (!other.providerRef || (other.state !== "running" && other.state !== "booting")) {
+          return { mode, exists: true, state: other.state as never, url: null };
+        }
+        const session = await deps.sandbox
+          .connectScreen(
+            toComputerRef(other),
+            { view: "stream", interactive: false },
+            await computerScreenContext(deps.prisma, context.actor, other.id, target.id, "peek"),
+          )
+          .catch(() => ({ url: null }));
+        if (!session.url) {
+          return { mode, exists: true, state: other.state as never, url: null };
+        }
+        const viewUrl = withViewOnly(session.url, true);
+        return {
+          mode,
+          exists: true,
+          state: other.state as never,
+          url: addScreenProxyCapability(
+            viewUrl,
+            deps.env.screenProxySecret,
+            deps.env.webOrigin,
+            undefined,
+            {
+              proxyExternal: other.kind === "box",
+            },
+          ),
+        };
+      }),
       heartbeat: authed.computer.heartbeat.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId);
         if (bot.computer?.state === "running" && bot.computer.providerRef) {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1455,11 +1455,14 @@ export function createRouter(deps: RouterDeps) {
         if (!other.providerRef || (other.state !== "running" && other.state !== "booting")) {
           return { mode, exists: true, state: other.state as never, url: null };
         }
+        // Peek is strictly view-only: never attach the target bot's execution
+        // lease. computerScreenContext would set screenLeaseId and let the
+        // supervisor overwrite or reject the shared screen assignment.
         const session = await deps.sandbox
           .connectScreen(
             toComputerRef(other),
             { view: "stream", interactive: false },
-            await computerScreenContext(deps.prisma, context.actor, other.id, target.id, "peek"),
+            computerContext(context.actor, target.id, "peek"),
           )
           .catch(() => ({ url: null }));
         if (!session.url) {

--- a/apps/web/e2e/computer-peek.spec.ts
+++ b/apps/web/e2e/computer-peek.spec.ts
@@ -1,0 +1,55 @@
+import { expect, type Page, test } from "@playwright/test";
+import { activeBotId, captureScreenshot, completeOnboarding, openNewBot, signup } from "./helpers";
+
+test("View… peeks another bot's computer read-only", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+
+  await signup(page, `computer-peek-${stamp}@rakazo.test`, "password12", "Computer Peek");
+  await completeOnboarding(page);
+  const chiefId = activeBotId(page);
+
+  await createBot(page, "Writer", "team");
+  await openBot(page, "Chief");
+  expect(activeBotId(page)).toBe(chiefId);
+
+  await openComputerPanel(page);
+  const panel = page.getByTestId("side-panel");
+  await panel.getByRole("button", { name: "View another computer" }).click();
+  const picker = panel.getByRole("button", { name: "Writer", exact: true });
+  await expect(picker).toBeVisible();
+  await captureScreenshot(page, testInfo, "computer-peek-picker");
+
+  await picker.click();
+  await expect(panel.getByRole("button", { name: "Back to your computer" })).toBeVisible();
+  await expect(panel.getByText("Viewing Writer (read only)", { exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "computer-peek-view");
+});
+
+async function createBot(page: Page, name: string, mode: "team" | "dedicated") {
+  await openNewBot(page);
+  await expect(page.getByText("New bot", { exact: true })).toBeVisible();
+  const team = page.getByRole("button", { name: "Team", exact: true });
+  const privateComputer = page.getByRole("button", { name: "Private", exact: true });
+  await expect(team).toHaveAttribute("aria-pressed", "true");
+  if (mode === "dedicated") await privateComputer.click();
+  await expect(mode === "team" ? team : privateComputer).toHaveAttribute("aria-pressed", "true");
+  await page.getByPlaceholder("Name this bot").fill(name);
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await expect(page.getByPlaceholder(`Message ${name}`)).toBeVisible();
+  return activeBotId(page);
+}
+
+async function openBot(page: Page, name: string) {
+  await page
+    .locator("aside")
+    .first()
+    .getByRole("button", { name: new RegExp(`^${name}`) })
+    .click();
+  await expect(page.getByPlaceholder(`Message ${name}`)).toBeVisible();
+}
+
+async function openComputerPanel(page: Page) {
+  await page.getByTitle("Agent computer").click();
+  await expect(page.getByRole("button", { name: "Take control", exact: true })).toBeVisible();
+}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4,6 +4,7 @@ import type {
   Bot,
   BotSection,
   ComputerMode,
+  ComputerPeek,
   ComputerReleaseReason,
   ComputerStatus,
   Group,
@@ -264,6 +265,15 @@ export function ShellPage() {
   const [screenUrl, setScreenUrl] = useState<string | null>(null);
   const [computerOpen, setComputerOpen] = useState(false);
   const [computerError, setComputerError] = useState<string | null>(null);
+  // Read-only look at any OTHER bot's currently assigned computer —
+  // reassigning this bot's own computer happens in Settings instead.
+  const [peek, setPeek] = useState<ComputerPeek | null>(null);
+  const [peekTarget, setPeekTarget] = useState<{ id: string; name: string; color: string } | null>(
+    null,
+  );
+  const [peekLoading, setPeekLoading] = useState(false);
+  const [peekMenuOpen, setPeekMenuOpen] = useState(false);
+  const peekRequest = useRef(0);
   const [usage, setUsage] = useState<{
     inputTokens: number;
     outputTokens: number;
@@ -701,6 +711,9 @@ export function ShellPage() {
     if (!searchParams.get("m")) {
       pinnedAroundRef.current = null;
     }
+    setPeek(null);
+    setPeekTarget(null);
+    setPeekMenuOpen(false);
     screenRequest.current += 1;
     setScreenUrl(null);
     expandedHistoryThread.current = null;
@@ -1409,6 +1422,32 @@ export function ShellPage() {
     await refreshThread(active.id);
   }
 
+  // Read-only: shows another bot's live screen without touching which
+  // computer this bot is actually assigned to, or that bot's own state.
+  async function peekBot(bot: { id: string; name: string; color: string }) {
+    setPeekMenuOpen(false);
+    const id = ++peekRequest.current;
+    setPeekTarget(bot);
+    setPeekLoading(true);
+    try {
+      const result = await rpc.computer.peek({ targetBotId: bot.id });
+      if (id !== peekRequest.current) return;
+      setPeek(result);
+    } catch {
+      if (id !== peekRequest.current) return;
+      setPeek({ mode: "team", exists: false, state: null, url: null });
+    } finally {
+      if (id === peekRequest.current) setPeekLoading(false);
+    }
+  }
+
+  function clearPeek() {
+    peekRequest.current += 1;
+    setPeek(null);
+    setPeekTarget(null);
+    setPeekLoading(false);
+  }
+
   const embeddedScreenUrl = embeddableScreenUrl(screenUrl);
   const hasControl = userHoldsComputerControl(computer, active?.id);
   const takeoverBlocked = computerTakeoverBlocked(computer, snapshot?.run?.status);
@@ -1930,7 +1969,58 @@ export function ShellPage() {
                       ? (computer?.state ?? active.status)
                       : "group"}
                 </span>
-                <div className="flex gap-3.5">
+                <div className="flex items-center gap-3.5">
+                  {active && panel === "computer" ? (
+                    peekTarget ? (
+                      <button
+                        type="button"
+                        aria-label="Back to your computer"
+                        title="Back to your computer"
+                        onClick={clearPeek}
+                        className="max-w-[120px] truncate rounded-full border border-[#26262A] px-2.5 py-1 text-[11px] leading-none text-[#85858A] transition-colors hover:text-[#ECECEE]"
+                      >
+                        {peekLoading ? "…" : peekTarget.name}
+                      </button>
+                    ) : (
+                      <div className="relative">
+                        <button
+                          type="button"
+                          aria-label="View another agent's computer"
+                          title="View another agent's computer (read only)"
+                          onClick={() => setPeekMenuOpen((open) => !open)}
+                          className="rounded-full border border-[#26262A] px-2.5 py-1 text-[11px] leading-none text-[#85858A] transition-colors hover:text-[#ECECEE]"
+                        >
+                          View…
+                        </button>
+                        {peekMenuOpen ? (
+                          <div className="app-no-drag absolute end-0 top-full z-20 mt-2 max-h-[240px] min-w-[180px] overflow-y-auto rounded-xl border border-[#26262A] bg-[#141416] py-1 shadow-lg">
+                            {bots.filter((bot) => !bot.archivedAt && bot.id !== active.id)
+                              .length === 0 ? (
+                              <div className="px-3.5 py-2 text-[13px] text-[#6C6C70]">
+                                No other agents yet
+                              </div>
+                            ) : (
+                              bots
+                                .filter((bot) => !bot.archivedAt && bot.id !== active.id)
+                                .map((bot) => (
+                                  <button
+                                    key={bot.id}
+                                    type="button"
+                                    onClick={() =>
+                                      void peekBot({ id: bot.id, name: bot.name, color: bot.color })
+                                    }
+                                    className="flex w-full items-center gap-2 px-3.5 py-2 text-start text-[14px] text-[#ECECEE] hover:bg-[#1F1F22]"
+                                  >
+                                    <BotAvatar color={bot.color} size={18} />
+                                    <span className="min-w-0 flex-1 truncate">{bot.name}</span>
+                                  </button>
+                                ))
+                            )}
+                          </div>
+                        ) : null}
+                      </div>
+                    )
+                  ) : null}
                   {active ? (
                     <button
                       type="button"
@@ -1954,7 +2044,27 @@ export function ShellPage() {
             {panel === "computer" && active ? (
               <div>
                 <div className="relative aspect-[16/10] overflow-hidden rounded-[14px] bg-[#0E0E10]">
-                  {computerOpen ? (
+                  {peek ? (
+                    embeddableScreenUrl(peek.url) ? (
+                      <iframe
+                        title="Other computer preview (view only)"
+                        src={embeddableScreenUrl(peek.url) ?? undefined}
+                        sandbox={screenIframeSandbox(peek.url)}
+                        className="h-full w-full border-0 bg-black"
+                        style={{ pointerEvents: "none" }}
+                      />
+                    ) : (
+                      <div className="grid h-full place-items-center text-sm text-[#6C6C70]">
+                        {peek.exists
+                          ? computerPlaceholder(
+                              peek.state ?? undefined,
+                              false,
+                              computerLabel(peek.mode, peekTarget?.name ?? active.name),
+                            )
+                          : "Never used yet"}
+                      </div>
+                    )
+                  ) : computerOpen ? (
                     <div className="grid h-full place-items-center text-sm text-[#6C6C70]">
                       Open in full window
                     </div>
@@ -1981,26 +2091,30 @@ export function ShellPage() {
                       )}
                     </div>
                   )}
-                  <button
-                    type="button"
-                    className="absolute inset-0 cursor-pointer"
-                    aria-label="Open computer"
-                    onClick={() => void openComputer()}
-                  />
+                  {peek ? null : (
+                    <button
+                      type="button"
+                      className="absolute inset-0 cursor-pointer"
+                      aria-label="Open computer"
+                      onClick={() => void openComputer()}
+                    />
+                  )}
                 </div>
                 <div className="mt-3 flex items-center justify-between gap-3">
                   <span className="min-w-0 text-[13.5px] text-[#85858A]">
-                    {hasControl
-                      ? "You have control"
-                      : computerError
-                        ? computerError
-                        : computer?.busyBotName
-                          ? `${computer.busyBotName} is using it`
-                          : computer?.state === "suspended"
-                            ? "Asleep"
-                            : computerLabel(computer?.mode, active.name)}
+                    {peek
+                      ? `Viewing ${computerLabel(peek.mode, peekTarget?.name ?? active.name)} — view only`
+                      : hasControl
+                        ? "You have control"
+                        : computerError
+                          ? computerError
+                          : computer?.busyBotName
+                            ? `${computer.busyBotName} is using it`
+                            : computer?.state === "suspended"
+                              ? "Asleep"
+                              : computerLabel(computer?.mode, active.name)}
                   </span>
-                  {hasControl ? (
+                  {peek ? null : hasControl ? (
                     <ComputerReleaseActions
                       takeoverRequested={computer?.takeoverRequested ?? false}
                       onRelease={releaseComputer}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1985,8 +1985,8 @@ export function ShellPage() {
                       <div className="relative">
                         <button
                           type="button"
-                          aria-label="View another agent's computer"
-                          title="View another agent's computer (read only)"
+                          aria-label="View another computer"
+                          title="View another computer"
                           onClick={() => setPeekMenuOpen((open) => !open)}
                           className="rounded-full border border-[#26262A] px-2.5 py-1 text-[11px] leading-none text-[#85858A] transition-colors hover:text-[#ECECEE]"
                         >
@@ -2103,7 +2103,7 @@ export function ShellPage() {
                 <div className="mt-3 flex items-center justify-between gap-3">
                   <span className="min-w-0 text-[13.5px] text-[#85858A]">
                     {peek
-                      ? `Viewing ${computerLabel(peek.mode, peekTarget?.name ?? active.name)} — view only`
+                      ? `Viewing ${peekTarget?.name ?? active.name} (read only)`
                       : hasControl
                         ? "You have control"
                         : computerError

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1392,12 +1392,19 @@ export function ShellPage() {
   }, [computerOpen]);
 
   useEffect(() => {
-    if ((panel !== "computer" && !computerOpen) || !active || computer?.state !== "running") return;
-    const ping = () => void rpc.computer.heartbeat({ botId: active.id }).catch(() => undefined);
+    if (panel !== "computer" && !computerOpen) return;
+    // While peeking, keep the *target* computer awake — heartbeats otherwise only
+    // touch the active bot, so a long-lived peek of an idle dedicated/team machine
+    // would still hit the sleep job and drop the preview.
+    const heartbeatBotId = peekTarget?.id ?? active?.id;
+    if (!heartbeatBotId) return;
+    if (!peekTarget && computer?.state !== "running") return;
+    const ping = () =>
+      void rpc.computer.heartbeat({ botId: heartbeatBotId }).catch(() => undefined);
     ping();
     const timer = window.setInterval(ping, 60_000);
     return () => window.clearInterval(timer);
-  }, [panel, computerOpen, active?.id, computer?.state]);
+  }, [panel, computerOpen, active?.id, computer?.state, peekTarget?.id]);
 
   async function openComputer() {
     if (!active) return;

--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -75,7 +75,7 @@ if [[ ! -f "$NOVNC_ROOT/embed.html" ]]; then
   echo "noVNC embed.html is missing from the computer image" >&2
   exit 1
 fi
-websockify --web="$NOVNC_ROOT" 0.0.0.0:6080 127.0.0.1:5900 >/tmp/rakazo/novnc.log 2>&1 &
+websockify --heartbeat=30 --web="$NOVNC_ROOT" 0.0.0.0:6080 127.0.0.1:5900 >/tmp/rakazo/novnc.log 2>&1 &
 
 while kill -0 "$XVFB_PID" 2>/dev/null; do
   sleep 2

--- a/infra/sandboxes/supervisor/src/supervisor-logic.ts
+++ b/infra/sandboxes/supervisor/src/supervisor-logic.ts
@@ -177,7 +177,7 @@ export function ensureScreenCommand(index: number) {
     `if [ -d /home/rakazo/.browser-profiles/chromium ]; then cp -a /home/rakazo/.browser-profiles/chromium/. ${profile}/; rm -f ${profile}/SingletonLock ${profile}/SingletonCookie ${profile}/SingletonSocket; fi`,
     `DISPLAY=${layout.display} HOME=/home/rakazo rakazo-browser --user-data-dir=${profile} >${log}-browser.log 2>&1 &`,
     `x11vnc -display ${layout.display} -forever -shared -viewonly -nopw -listen 127.0.0.1 -rfbport ${layout.viewVncPort} -xkb -ncache 0 >${log}-x11vnc.log 2>&1 &`,
-    `websockify --web=/usr/share/novnc 0.0.0.0:${layout.viewPort} 127.0.0.1:${layout.viewVncPort} >${log}-novnc.log 2>&1 &`,
+    `websockify --heartbeat=30 --web=/usr/share/novnc 0.0.0.0:${layout.viewPort} 127.0.0.1:${layout.viewVncPort} >${log}-novnc.log 2>&1 &`,
     `for i in $(seq 1 50); do (echo >/dev/tcp/127.0.0.1/${layout.viewPort}) >/dev/null 2>&1 && exit 0; sleep 0.1; done`,
     "exit 1",
   ].join("\n");
@@ -268,7 +268,7 @@ export function interactiveScreenCommand(
     `printf %s ${shellQuote(controlToken)} > ${tokenFile}`,
     `export DISPLAY=${layout.display}`,
     `(x11vnc -display ${layout.display} -forever -shared -nopw -listen 127.0.0.1 -rfbport ${layout.controlVncPort} -xkb -ncache 0 >/tmp/rakazo/x11vnc-control-${layout.displayNumber}.log 2>&1 &)`,
-    `(websockify --web=/usr/share/novnc 0.0.0.0:${layout.controlPort} 127.0.0.1:${layout.controlVncPort} >/tmp/rakazo/novnc-control-${layout.displayNumber}.log 2>&1 &)`,
+    `(websockify --heartbeat=30 --web=/usr/share/novnc 0.0.0.0:${layout.controlPort} 127.0.0.1:${layout.controlVncPort} >/tmp/rakazo/novnc-control-${layout.displayNumber}.log 2>&1 &)`,
     `for i in $(seq 1 50); do (echo >/dev/tcp/127.0.0.1/${layout.controlPort}) >/dev/null 2>&1 && exit 0; sleep 0.1; done`,
     "exit 1",
   ].join("; ");

--- a/packages/adapters/src/docker-sandbox.test.ts
+++ b/packages/adapters/src/docker-sandbox.test.ts
@@ -45,9 +45,7 @@ describe("Docker sandbox", () => {
       { type: "stderr", data: "command timed out after 75 ms\n" },
       { type: "exit", code: 124 },
     ]);
-    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
-      "x-rakazo-screen-id": "bot",
-    });
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).not.toHaveProperty("x-rakazo-screen-id");
   });
 
   it("releases this bot's screen assignment through the supervisor", async () => {
@@ -67,7 +65,6 @@ describe("Docker sandbox", () => {
         headers: expect.objectContaining({
           authorization: "Bearer test-token",
           "x-rakazo-bot-id": "home-bot",
-          "x-rakazo-screen-id": "bot",
           "x-rakazo-screen-lease-id": "run-1:1",
           "x-rakazo-workspace-id": "workspace",
         }),

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -52,12 +52,22 @@ export class DockerSandboxProvider implements SandboxProvider {
     return `${this.supervisorUrl.replace(/\/$/, "")}${path}`;
   }
 
+  // No x-rakazo-screen-id here: the supervisor keys a screen off
+  // x-rakazo-bot-id alone (the ComputerRef's homeKey — shared across every
+  // bot on a Team Computer, distinct per bot on a dedicated one). Keying it
+  // off the calling bot's own id instead would give each bot on a shared
+  // Team Computer its own Xvfb/Chromium/x11vnc stack — several times the RAM
+  // for one container, and each stack fighting the same Chromium profile dir
+  // (homeKey is shared too) for its SingletonLock, so only the first bot to
+  // grab it gets the real logged-in session and the rest boot to a blank
+  // profile. Screen VIEWING is safely shared already (x11vnc -shared serves
+  // any number of simultaneous viewers of the one desktop); who gets to
+  // actually drive it is gated separately by the execution lease.
   private headers(context: AdapterContext, botId?: string) {
     return {
       authorization: `Bearer ${this.supervisorToken}`,
       "x-rakazo-workspace-id": context.workspaceId,
       ...(botId ? { "x-rakazo-bot-id": botId } : {}),
-      ...(context.botId ? { "x-rakazo-screen-id": context.botId } : {}),
       ...(context.screenLeaseId ? { "x-rakazo-screen-lease-id": context.screenLeaseId } : {}),
     };
   }

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -515,6 +515,15 @@ export const ComputerStatusSchema = z.object({
 });
 export type ComputerStatus = z.infer<typeof ComputerStatusSchema>;
 
+export const ComputerPeekSchema = z.object({
+  mode: ComputerModeSchema,
+  /** False when that computer has never been provisioned for this bot/workspace. */
+  exists: z.boolean(),
+  state: z.enum(["stopped", "booting", "running", "suspended", "error"]).nullable(),
+  url: z.string().nullable(),
+});
+export type ComputerPeek = z.infer<typeof ComputerPeekSchema>;
+
 export const ComputerReleaseReasonSchema = z.enum(["done", "skipped"]);
 export type ComputerReleaseReason = z.infer<typeof ComputerReleaseReasonSchema>;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -13,6 +13,7 @@ import {
   BotSectionSchema,
   CapabilityInstallSchema,
   ComputerModeSchema,
+  ComputerPeekSchema,
   ComputerReleaseReasonSchema,
   ComputerStatusSchema,
   ConnectionCatalogItemSchema,
@@ -256,6 +257,9 @@ export const appContract = {
       .input(z.object({ botId: Id, path: z.string() }))
       .output(z.object({ path: z.string(), content: z.string() })),
     screenUrl: oc.input(botId).output(z.object({ url: z.string().nullable() })),
+    /** Read-only peek at ANY other bot's currently assigned computer — for
+        a view-only picker, never reassigns anything. */
+    peek: oc.input(z.object({ targetBotId: Id })).output(ComputerPeekSchema),
     heartbeat: oc.input(botId).output(z.object({ ok: z.literal(true) })),
   },
   memory: {


### PR DESCRIPTION
## Summary

The computer pane only ever showed the bot you had open. With multiple bots
working in parallel, there was no way to check on another one without
switching to its own thread.

**Stacked on #221** (Team Computer sharing fix) — peeking at a Team Computer
now shows the one real shared desktop, not a stray per-bot duplicate.

## Changes

- New "View…" picker in the computer pane header listing every other bot
- Picking one shows that bot's currently assigned computer live (Team or
  dedicated) — strictly view-only, no control affordances
- Never boots, provisions, or reassigns anything; never touches an active
  run on either side
- New `computer.peek` RPC: resolves the target bot's own assigned computer
  directly (not the caller's), read-only

## Testing notes

- [x] `pnpm --filter @rakazo/api check`, `pnpm --filter @rakazo/web check`
- [x] `biome check` on touched files
- [x] Manually tested against two real bots — picker lists the other bot,
      peek shows its live screen, toggling back restores the normal pane,
      neither bot's active run is affected