### PR TITLE
fix: bound computer cache and stop SSE reconnects on unrelated params

### DIFF
--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -179,6 +179,11 @@ export function ShellPage() {
   const { botId, groupId } = useParams();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  // Mirrors searchParams for effects that only need to read it once on run,
+  // not re-run on every unrelated query-param change (e.g. the SSE subscribe
+  // effect below, which should only restart when the active bot changes).
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
   const session = authClient.useSession();
   const [groups, setGroups] = useState<Group[]>([]);
   const [bots, setBots] = useState<Bot[]>([]);
@@ -207,6 +212,31 @@ export function ShellPage() {
   const computerRef = useRef<ComputerStatus | null>(null);
   const threadRefreshEpoch = useRef(0);
   const groupRefreshEpoch = useRef(0);
+  // Last-known computer/screen per bot, so switching back to an already-seen
+  // bot paints its computer pane instantly instead of blanking it while the
+  // thread + screen RPCs round-trip again (see refreshThread / refreshComputerScreen).
+  const computerCacheRef = useRef(
+    new Map<string, { computer: ComputerStatus | null; screenUrl: string | null }>(),
+  );
+  // Caps computerCacheRef so a long session that opens many distinct bots
+  // over time doesn't accumulate one entry per bot forever. Re-inserting on
+  // every update keeps Map iteration order as least-recently-used first, so
+  // eviction drops the bot that's been out of view longest.
+  const COMPUTER_CACHE_LIMIT = 20;
+
+  function cacheComputerFor(
+    botId: string,
+    patch: Partial<{ computer: ComputerStatus | null; screenUrl: string | null }>,
+  ) {
+    const cache = computerCacheRef.current;
+    const prev = cache.get(botId) ?? { computer: null, screenUrl: null };
+    cache.delete(botId);
+    cache.set(botId, { ...prev, ...patch });
+    if (cache.size > COMPUTER_CACHE_LIMIT) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
+  }
 
   function commitSnapshot(next: ThreadSnapshot | null) {
     snapshotRef.current = next;
@@ -460,6 +490,7 @@ export function ShellPage() {
     }
     commitSnapshot(merged);
     commitComputer(reconciled.computer);
+    cacheComputerFor(id, { computer: reconciled.computer });
     if (!keepPin && stickToEnd) {
       window.requestAnimationFrame(() => {
         const element = messageScroll.current;
@@ -497,6 +528,7 @@ export function ShellPage() {
       return null;
     }
     setScreenUrl(screen.url);
+    cacheComputerFor(id, { screenUrl: screen.url });
     return screen.url;
   }
 
@@ -698,11 +730,19 @@ export function ShellPage() {
 
   useEffect(() => {
     if (!active) return;
-    if (!searchParams.get("m")) {
+    if (!searchParamsRef.current.get("m")) {
       pinnedAroundRef.current = null;
     }
     screenRequest.current += 1;
-    setScreenUrl(null);
+    const cached = computerCacheRef.current.get(active.id);
+    if (cached) {
+      // Paint the last-known computer instantly; refreshThread/refreshComputerScreen
+      // below still run and reconcile with fresh data in the background.
+      setScreenUrl(cached.screenUrl);
+      commitComputer(cached.computer);
+    } else {
+      setScreenUrl(null);
+    }
     expandedHistoryThread.current = null;
     historyEpoch.current += 1;
     const abort = new AbortController();
@@ -770,7 +810,7 @@ export function ShellPage() {
     return () => {
       abort.abort();
     };
-  }, [active?.id, markBotReadIfVisible, searchParams]);
+  }, [active?.id, markBotReadIfVisible]);
 
   useEffect(() => {
     if (!groupId || !activeGroup) return;


### PR DESCRIPTION
## Summary

Two memory-leak / perf issues found while auditing `Shell.tsx`'s bot-switch
and SSE-subscribe paths:

## Changes

- **Bounded computer cache**: the bot-switch effect used to blank the
  computer pane (`setScreenUrl(null)`) on every switch, then wait for
  `refreshThread`/`refreshComputerScreen` to repaint it. Added
  `computerCacheRef`, a size-capped (20), LRU-evicted `Map<botId, {computer,
  screenUrl}>` populated wherever those two calls resolve. Switching back to
  an already-seen bot now paints its last-known computer instantly; the
  background refresh still runs and reconciles with fresh data.
- **SSE reconnect on unrelated params**: the thread-subscribe `useEffect`
  had `searchParams` (the whole object from `useSearchParams`) in its
  dependency array, so it tore down and reopened the SSE connection on
  *any* query-param change, not just an active-bot change. It only reads
  `searchParams.get("m")` once on run to decide whether to reset
  `pinnedAroundRef`, so that read now goes through a `searchParamsRef`
  mirror instead, and `searchParams` is dropped from the deps array.

## Testing notes

- [x] `pnpm --filter @rakazo/web check` (tsc)
- [x] `biome check` on touched file