### PR TITLE
Fix: define save_memory/recall_memory builtin tools

### DIFF
--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -241,6 +241,31 @@ export const builtinAgentTools: ConnectorTool[] = [
       required: ["content"],
     },
   },
+  // Semantic-memory tools: exposed by selectMemoryTools() only when a
+  // workspace memory provider is configured (which hides `remember`).
+  {
+    name: "save_memory",
+    description:
+      "Store a durable fact in this bot's semantic memory (preferences, decisions, recurring context). Use for anything worth recalling in future conversations.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        content: { type: "string" },
+      },
+      required: ["content"],
+    },
+  },
+  {
+    name: "recall_memory",
+    description: "Semantically search this bot's durable memory for facts relevant to a query.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+    },
+  },
   {
     name: "scratchpad_list",
     description:


### PR DESCRIPTION
## Problem

Configuring a workspace memory provider (Settings → Memory → Supermemory) currently leaves bots with **no memory tool at all**:

- `selectMemoryTools()` (packages/adapters/src/memory-tools.ts) removes `remember` when a semantic provider is configured, and is meant to expose `save_memory`/`recall_memory` instead.
- The executor has handlers for both tools (`executor.ts` — `recall_memory`/`save_memory` branches), and `recall_memory` is in the read-only list.
- But neither tool has a definition in `builtin-tools.ts`, so they are never offered to the model.

Net effect: connecting a memory provider silently *removes* memory capability. In testing, bots improvised by writing files into their sandbox home and reporting "saved to durable memory."

## Repro

1. Connect Supermemory (cloud or local) as the workspace memory provider.
2. Ask any bot to use `save_memory`.
3. The bot reports it has no such tool (and `remember` is gone too).

## Fix

Add the two missing tool definitions next to `remember` in `builtin-tools.ts`, mirroring its shape. The existing `selectMemoryTools()` gating and executor handlers then work as designed — verified end-to-end against a Supermemory-compatible local server: `save_memory` returns ok, the memory lands in the store, and `recall_memory` retrieves it semantically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tools for saving durable memories and recalling relevant information.
  * Memory tools are available when workspace memory is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->