### PR TITLE
Clarify homepage product positioning

### DIFF
--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -80,7 +80,7 @@ const structuredData = {
 };
 ---
 
-<BaseLayout title="Rakazo" description={SITE_DESCRIPTION} {structuredData}>
+<BaseLayout title="Rakazo | Open source Grok Bot alternative" description={SITE_DESCRIPTION} {structuredData}>
   <div class="container">
     <Header starsLabel={starsLabel} />
 
@@ -88,12 +88,12 @@ const structuredData = {
       <section class="hero">
         <a class="hero__pill" href="#selfhost">
           <span class="hero__badge">Apache-2.0</span>
-          <span>Open source alternative to Grok Bot<span class="hero__pill-tail"> — run it on your own machine</span></span>
+          <span>Self-hosted</span>
         </a>
         <h1>AI teammates you actually own</h1>
         <p class="lead">
-          Give a bot real work. It signs in to your tools, uses them the way you do, and comes back when it
-          needs you. Your keys, your model, your machine.
+          Rakazo is an open source Grok Bot alternative. Give a bot real work. It signs in to your tools, uses
+          them the way you do, and comes back when it needs you.
         </p>
         <div class="hero__actions">
           <button class="button button--primary" type="button" data-get-started-open>Get started</button>

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -2174,10 +2174,6 @@ button {
     font-size: 12.5px;
   }
 
-  .hero__pill-tail {
-    display: none;
-  }
-
   .lead {
     margin-top: 18px;
     font-size: 17px;


### PR DESCRIPTION
Updates the homepage title and hero copy to describe Rakazo more directly. Simplifies the self-hosted badge and removes its obsolete responsive style.

Tested with `pnpm --filter @rakazo/www check` and `pnpm --filter @rakazo/www build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the homepage hero messaging to highlight Rakazo as a self-hosted, open-source Grok Bot alternative.
  * Improved mobile visibility by keeping the full hero pill text visible on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->