### PR TITLE
Search groups and jump to the matching message

### DIFF
--- a/apps/api/src/search.ts
+++ b/apps/api/src/search.ts
@@ -3,6 +3,8 @@ import { extractLinksFromText, matchesSearchQuery, snippetAroundMatch } from "@r
 import type { Prisma, PrismaClient } from "@rakazo/db";
 
 const SEARCH_LIMIT = 25;
+/** Cap name matches so content hits (messages/files/links/routines) keep most of the budget. */
+const CONVERSATION_HIT_LIMIT = 5;
 
 export async function queryWorkspaceSearch(
   prisma: PrismaClient,
@@ -12,21 +14,23 @@ export async function queryWorkspaceSearch(
   const query = q.trim();
   if (!query) return [];
 
-  const hits: SearchHit[] = [];
+  const conversationHits: SearchHit[] = [];
+  const contentHits: SearchHit[] = [];
   const seen = new Set<string>();
 
-  function push(hit: SearchHit) {
+  function pushInto(bucket: SearchHit[], hit: SearchHit, limit: number) {
     const key = [
       hit.kind,
-      hit.botId,
+      hit.botId ?? "",
+      hit.groupId ?? "",
       hit.messageId ?? "",
       hit.artifactId ?? "",
       hit.routineId ?? "",
       hit.url ?? "",
     ].join(":");
-    if (seen.has(key) || hits.length >= SEARCH_LIMIT) return;
+    if (seen.has(key) || bucket.length >= limit) return;
     seen.add(key);
-    hits.push(hit);
+    bucket.push(hit);
   }
 
   const bots = await prisma.bot.findMany({
@@ -40,17 +44,45 @@ export async function queryWorkspaceSearch(
         { description: { contains: query, mode: "insensitive" } },
       ],
     },
-    take: SEARCH_LIMIT,
+    take: CONVERSATION_HIT_LIMIT,
   });
   for (const bot of bots) {
-    push({
-      kind: "conversation",
-      botId: bot.id,
-      botName: bot.name,
-      title: bot.name,
-      snippet: bot.title || bot.description || bot.name,
-    });
+    pushInto(
+      conversationHits,
+      {
+        kind: "conversation",
+        botId: bot.id,
+        botName: bot.name,
+        title: bot.name,
+        snippet: bot.title || bot.description || bot.name,
+      },
+      CONVERSATION_HIT_LIMIT * 2,
+    );
   }
+
+  const groups = await prisma.chatGroup.findMany({
+    where: {
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      name: { contains: query, mode: "insensitive" },
+    },
+    take: CONVERSATION_HIT_LIMIT,
+  });
+  for (const group of groups) {
+    pushInto(
+      conversationHits,
+      {
+        kind: "conversation",
+        groupId: group.id,
+        groupName: group.name,
+        title: group.name,
+        snippet: group.name,
+      },
+      CONVERSATION_HIT_LIMIT * 2,
+    );
+  }
+
+  const contentBudget = Math.max(0, SEARCH_LIMIT - conversationHits.length);
 
   const artifacts = await prisma.artifact.findMany({
     where: {
@@ -79,16 +111,61 @@ export async function queryWorkspaceSearch(
     `;
     const message = messageRows[0];
     if (!message) continue;
-    push({
-      kind: "file",
-      botId: artifact.botId,
-      botName: artifact.bot.name,
-      title: artifact.name,
-      snippet: `${artifact.mimeType} · ${artifact.size} bytes`,
-      artifactId: artifact.id,
-      messageId: message?.id,
-      seq: message?.seq,
-    });
+    pushInto(
+      contentHits,
+      {
+        kind: "file",
+        botId: artifact.botId,
+        botName: artifact.bot.name,
+        title: artifact.name,
+        snippet: `${artifact.mimeType} · ${artifact.size} bytes`,
+        artifactId: artifact.id,
+        messageId: message.id,
+        seq: message.seq,
+      },
+      contentBudget,
+    );
+  }
+
+  const groupArtifacts = await prisma.artifact.findMany({
+    where: {
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      groupId: { not: null },
+      name: { contains: query, mode: "insensitive" },
+    },
+    include: { group: { select: { name: true } } },
+    take: SEARCH_LIMIT,
+  });
+  for (const artifact of groupArtifacts) {
+    if (!artifact.groupId || !artifact.group) continue;
+    const messageRows = await prisma.$queryRaw<Array<{ id: string; seq: number }>>`
+      SELECT m.id, m.seq
+      FROM messages m
+      INNER JOIN threads t ON t.id = m."threadId"
+      WHERE t."workspaceId" = ${actor.workspaceId}
+        AND t."userId" = ${actor.userId}
+        AND t."groupId" = ${artifact.groupId}
+        AND m.blocks::text ILIKE ${`%${artifact.id}%`}
+      ORDER BY m."createdAt" DESC
+      LIMIT 1
+    `;
+    const message = messageRows[0];
+    if (!message) continue;
+    pushInto(
+      contentHits,
+      {
+        kind: "file",
+        groupId: artifact.groupId,
+        groupName: artifact.group.name,
+        title: artifact.name,
+        snippet: `${artifact.mimeType} · ${artifact.size} bytes`,
+        artifactId: artifact.id,
+        messageId: message.id,
+        seq: message.seq,
+      },
+      contentBudget,
+    );
   }
 
   const routines = await prisma.routine.findMany({
@@ -105,14 +182,18 @@ export async function queryWorkspaceSearch(
     take: SEARCH_LIMIT,
   });
   for (const routine of routines) {
-    push({
-      kind: "routine",
-      botId: routine.botId,
-      botName: routine.bot.name,
-      title: routine.name,
-      snippet: snippetAroundMatch(routine.prompt, query),
-      routineId: routine.id,
-    });
+    pushInto(
+      contentHits,
+      {
+        kind: "routine",
+        botId: routine.botId,
+        botName: routine.bot.name,
+        title: routine.name,
+        snippet: snippetAroundMatch(routine.prompt, query),
+        routineId: routine.id,
+      },
+      contentBudget,
+    );
   }
 
   const pattern = `%${query}%`;
@@ -139,50 +220,107 @@ export async function queryWorkspaceSearch(
   `;
 
   for (const row of messageRows) {
-    const blocks = row.blocks as MessageBlock[];
-    let messageHit = false;
-    for (const block of blocks) {
-      if (block.kind !== "text") continue;
-      const text = block.text;
-      if (matchesSearchQuery(query, text)) {
-        push({
-          kind: "message",
-          botId: row.botId,
-          botName: row.botName,
-          title: row.botName,
-          snippet: snippetAroundMatch(text, query),
-          messageId: row.id,
-          seq: row.seq,
-        });
-        messageHit = true;
-      }
-      for (const url of extractLinksFromText(text)) {
-        if (matchesSearchQuery(query, url)) {
-          push({
-            kind: "link",
-            botId: row.botId,
-            botName: row.botName,
-            title: url,
-            snippet: snippetAroundMatch(text, query),
-            messageId: row.id,
-            seq: row.seq,
-            url,
-          });
-        }
-      }
-    }
-    if (!messageHit && matchesSearchQuery(query, JSON.stringify(blocks))) {
-      push({
-        kind: "message",
-        botId: row.botId,
-        botName: row.botName,
-        title: row.botName,
-        snippet: query,
-        messageId: row.id,
-        seq: row.seq,
-      });
-    }
+    pushMessageHits(row.blocks as MessageBlock[], {
+      botId: row.botId,
+      botName: row.botName,
+      messageId: row.id,
+      seq: row.seq,
+      query,
+      push: (hit) => pushInto(contentHits, hit, contentBudget),
+    });
   }
 
-  return hits.slice(0, SEARCH_LIMIT);
+  const groupMessageRows = await prisma.$queryRaw<
+    Array<{
+      id: string;
+      threadId: string;
+      seq: number;
+      blocks: Prisma.JsonValue;
+      groupId: string;
+      groupName: string;
+    }>
+  >`
+    SELECT m.id, m."threadId", m.seq, m.blocks, g.id AS "groupId", g.name AS "groupName"
+    FROM messages m
+    INNER JOIN threads t ON t.id = m."threadId"
+    INNER JOIN chat_groups g ON g.id = t."groupId"
+    WHERE t."workspaceId" = ${actor.workspaceId}
+      AND t."userId" = ${actor.userId}
+      AND t."groupId" IS NOT NULL
+      AND m.blocks::text ILIKE ${pattern}
+    ORDER BY m."createdAt" DESC
+    LIMIT ${SEARCH_LIMIT}
+  `;
+
+  for (const row of groupMessageRows) {
+    pushMessageHits(row.blocks as MessageBlock[], {
+      groupId: row.groupId,
+      groupName: row.groupName,
+      messageId: row.id,
+      seq: row.seq,
+      query,
+      push: (hit) => pushInto(contentHits, hit, contentBudget),
+    });
+  }
+
+  return [...conversationHits, ...contentHits].slice(0, SEARCH_LIMIT);
+}
+
+function pushMessageHits(
+  blocks: MessageBlock[],
+  ctx: {
+    botId?: string;
+    botName?: string;
+    groupId?: string;
+    groupName?: string;
+    messageId: string;
+    seq: number;
+    query: string;
+    push: (hit: SearchHit) => void;
+  },
+) {
+  // Discriminate on groupId (not name): empty group names must still target the group.
+  const destination = ctx.groupId
+    ? { groupId: ctx.groupId, groupName: ctx.groupName ?? "" }
+    : { botId: ctx.botId!, botName: ctx.botName! };
+  const title = ctx.groupId ? (ctx.groupName ?? "") : (ctx.botName ?? "");
+  let messageHit = false;
+  for (const block of blocks) {
+    if (block.kind !== "text") continue;
+    const text = block.text;
+    if (matchesSearchQuery(ctx.query, text)) {
+      ctx.push({
+        kind: "message",
+        ...destination,
+        title,
+        snippet: snippetAroundMatch(text, ctx.query),
+        messageId: ctx.messageId,
+        seq: ctx.seq,
+      });
+      messageHit = true;
+    }
+    for (const url of extractLinksFromText(text)) {
+      if (matchesSearchQuery(ctx.query, url)) {
+        ctx.push({
+          kind: "link",
+          ...destination,
+          title: url,
+          snippet: snippetAroundMatch(text, ctx.query),
+          messageId: ctx.messageId,
+          seq: ctx.seq,
+          url,
+        });
+      }
+    }
+  }
+  if (!messageHit && matchesSearchQuery(ctx.query, JSON.stringify(blocks))) {
+    ctx.push({
+      kind: "message",
+      ...destination,
+      title,
+      snippet: ctx.query,
+      messageId: ctx.messageId,
+      seq: ctx.seq,
+    });
+  }
 }

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -292,7 +292,7 @@ export default function Home() {
           if (item.type === "bot") return item.bot.id;
           if (item.type === "group") return `group-${item.group.id}`;
           const hit = item.hit;
-          return `${hit.kind}-${hit.botId}-${hit.messageId ?? hit.artifactId ?? hit.routineId ?? hit.url}`;
+          return `${hit.kind}-${hit.botId ?? hit.groupId}-${hit.messageId ?? hit.artifactId ?? hit.routineId ?? hit.url}`;
         }}
         keyboardDismissMode="interactive"
         keyboardShouldPersistTaps="handled"
@@ -482,7 +482,7 @@ function SearchRow({ hit, onPress }: { hit: SearchHit; onPress: () => void }) {
           <Text style={styles.time}>{hit.kind}</Text>
         </View>
         <Text style={styles.preview} numberOfLines={2}>
-          {hit.botName} · {hit.snippet}
+          {hit.groupName ?? hit.botName} · {hit.snippet}
         </Text>
       </View>
     </Pressable>

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -67,7 +67,8 @@ export default function Thread() {
   const expandedHistoryThread = useRef<string | null>(null);
   const historyEpoch = useRef(0);
   const pinnedAroundRef = useRef<{
-    botId: string;
+    botId?: string;
+    groupId?: string;
     messageId: string;
     threadId: string;
     messages: readonly MobileMessage[];
@@ -248,42 +249,36 @@ export default function Thread() {
       })
     )
       return next;
-    const pin = pinnedAroundRef.current;
-    setSnap((prev) => {
-      let merged = mergeMobileSnapshot(prev, next, expandedHistoryThread.current === next.threadId);
-      if (pin && merged && pin.botId === targetBotId) {
-        merged = {
-          ...merged,
-          messages: [...pin.messages],
-          olderCursor: pin.olderCursor,
-        };
-      }
-      return merged;
-    });
+    setSnap((prev) =>
+      mergeMobileSnapshot(prev, next, expandedHistoryThread.current === next.threadId),
+    );
     return next;
   }
 
-  async function applyMessageJump(targetBotId: string, targetMessageId: string) {
+  async function applyMessageJump(target: { botId?: string; groupId?: string; messageId: string }) {
+    const threadTarget = target.groupId ? { groupId: target.groupId } : { botId: target.botId! };
     const epoch = historyEpoch.current;
     const [snap, page] = await Promise.all([
-      rpc<MobileSnapshot>("threads/get", { botId: targetBotId }),
+      rpc<MobileSnapshot>("threads/get", threadTarget),
       rpc<MobileMessagePage>("threads/messages", {
-        botId: targetBotId,
-        around: { messageId: targetMessageId },
+        ...threadTarget,
+        around: { messageId: target.messageId },
       }),
     ]);
     // The epoch check drops a jump that raced a conversation clear (or a bot switch): applying
     // the fetched page would pin deleted messages that every later refresh keeps restoring.
     if (epoch !== historyEpoch.current) return;
+    if (target.groupId && activeGroupId.current !== target.groupId) return;
+    if (target.botId && activeBotId.current !== target.botId) return;
     expandedHistoryThread.current = page.threadId;
     pinnedAroundRef.current = {
-      botId: targetBotId,
-      messageId: targetMessageId,
+      ...threadTarget,
+      messageId: target.messageId,
       threadId: page.threadId,
       messages: [...page.messages],
       olderCursor: page.olderCursor,
     };
-    jumpScrollTarget.current = targetMessageId;
+    jumpScrollTarget.current = target.messageId;
     setSnap({
       ...snap,
       messages: [...page.messages],
@@ -357,10 +352,18 @@ export default function Thread() {
     historyEpoch.current += 1;
     const abort = new AbortController();
     void (async () => {
-      const next = await refresh().catch((err: Error) => {
-        setError(err.message);
-        return null;
-      });
+      // Pending search jumps load the around-page separately; avoid replacing it with latest.
+      const next = messageId
+        ? await rpc<MobileSnapshot>("threads/get", groupId ? { groupId } : { botId: botId! }).catch(
+            (err: Error) => {
+              setError(err.message);
+              return null;
+            },
+          )
+        : await refresh().catch((err: Error) => {
+            setError(err.message);
+            return null;
+          });
       if (abort.signal.aborted) return;
       let cursor = next?.cursor ?? -1;
       let retryMs = 250;
@@ -394,7 +397,9 @@ export default function Thread() {
                 markReadIfVisible();
               }
               if (isRunTerminalEvent(event)) {
-                void refresh().catch(() => undefined);
+                if (!jumpScrollTarget.current && !expandedHistoryThread.current) {
+                  void refresh().catch(() => undefined);
+                }
               }
             },
             abort.signal,
@@ -403,7 +408,9 @@ export default function Thread() {
           // A full refresh reconciles visible state; the event cursor still resumes without gaps.
         }
         if (abort.signal.aborted) break;
-        await refresh().catch(() => undefined);
+        if (!jumpScrollTarget.current && !expandedHistoryThread.current) {
+          await refresh().catch(() => undefined);
+        }
         await abortableDelay(retryMs, abort.signal);
         retryMs = Math.min(retryMs * 2, 5_000);
       }
@@ -414,11 +421,13 @@ export default function Thread() {
   }, [botId, groupId, markReadIfVisible]);
 
   useEffect(() => {
-    if (!botId || !messageId) return;
-    void applyMessageJump(botId, messageId).catch((err) => {
-      setError(err instanceof Error ? err.message : "Could not open message");
-    });
-  }, [botId, messageId]);
+    if ((!botId && !groupId) || !messageId) return;
+    void applyMessageJump(groupId ? { groupId, messageId } : { botId: botId!, messageId }).catch(
+      (err) => {
+        setError(err instanceof Error ? err.message : "Could not open message");
+      },
+    );
+  }, [botId, groupId, messageId]);
 
   useEffect(() => {
     setPendingAttachments((current) => attachmentsForThread(current, threadKey));
@@ -615,7 +624,11 @@ export default function Thread() {
           }
           if (
             jumpScrollTarget.current ||
-            (pinnedAroundRef.current && pinnedAroundRef.current.botId === botId)
+            (pinnedAroundRef.current &&
+              ((pinnedAroundRef.current.botId && pinnedAroundRef.current.botId === botId) ||
+                (pinnedAroundRef.current.groupId &&
+                  pinnedAroundRef.current.groupId === groupId))) ||
+            expandedHistoryThread.current === snap?.threadId
           )
             return;
           scroll.current?.scrollToEnd({ animated: false });

--- a/apps/mobile/lib/search-destination.ts
+++ b/apps/mobile/lib/search-destination.ts
@@ -6,20 +6,34 @@ export function mobileSearchDestination(hit: SearchHit):
       params: { botId: string; botName: string; routineId: string };
     }
   | {
+      pathname: "/group-thread";
+      params: { groupId: string; name: string; messageId?: string };
+    }
+  | {
       pathname: "/thread";
       params: { botId: string; name: string; messageId?: string };
     } {
   if (hit.routineId) {
     return {
       pathname: "/routine",
-      params: { botId: hit.botId, botName: hit.botName, routineId: hit.routineId },
+      params: { botId: hit.botId!, botName: hit.botName!, routineId: hit.routineId },
+    };
+  }
+  if (hit.groupId) {
+    return {
+      pathname: "/group-thread",
+      params: {
+        groupId: hit.groupId,
+        name: hit.groupName ?? hit.title,
+        ...(hit.messageId ? { messageId: hit.messageId } : {}),
+      },
     };
   }
   return {
     pathname: "/thread",
     params: {
-      botId: hit.botId,
-      name: hit.botName,
+      botId: hit.botId!,
+      name: hit.botName ?? hit.title,
       ...(hit.messageId ? { messageId: hit.messageId } : {}),
     },
   };

--- a/apps/mobile/lib/search.test.ts
+++ b/apps/mobile/lib/search.test.ts
@@ -25,4 +25,20 @@ describe("mobileSearchDestination", () => {
       params: { botId: "bot-1", botName: "Scout", routineId: "routine-1" },
     });
   });
+
+  it("opens group matches in the group thread", () => {
+    const hit: SearchHit = {
+      kind: "message",
+      groupId: "group-1",
+      groupName: "Squad",
+      title: "Squad",
+      snippet: "match",
+      messageId: "message-1",
+      seq: 2,
+    };
+    expect(mobileSearchDestination(hit)).toEqual({
+      pathname: "/group-thread",
+      params: { groupId: "group-1", name: "Squad", messageId: "message-1" },
+    });
+  });
 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -45,6 +45,7 @@ import {
   presetFromCron,
   SLASH_ACTIONS,
   type SlashActionId,
+  searchHitThreadTarget,
   serializeComposerPrompt,
   speechFromBlocks,
   truncateSlashDescription,
@@ -325,7 +326,8 @@ export function ShellPage() {
   const initiallyScrolledThread = useRef<string | null>(null);
   const messageScroll = useRef<HTMLDivElement>(null);
   const pinnedAroundRef = useRef<{
-    botId: string;
+    botId?: string;
+    groupId?: string;
     messageId: string;
     threadId: string;
     messages: ThreadMessage[];
@@ -460,7 +462,8 @@ export function ShellPage() {
     commitComputer(null);
     setRoutines([]);
     setRoutinesBotId(null);
-    if (stickToEnd) {
+    // Keep the search-jump viewport; expandedHistoryThread merge still accepts live messages.
+    if (stickToEnd && expandedHistoryThread.current !== snap.threadId) {
       window.requestAnimationFrame(() => {
         const element = messageScroll.current;
         if (element) element.scrollTop = element.scrollHeight;
@@ -475,8 +478,6 @@ export function ShellPage() {
       !scrollElement ||
       scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight < 80;
     markOnce("rk:renderer:thread-request-start");
-    const pin = pinnedAroundRef.current;
-    const keepPin = pin?.botId === id;
     const epoch = historyEpoch.current;
     const request = ++threadRefreshEpoch.current;
     // Apply threads.get as soon as it returns so stop/takeover status is not held behind
@@ -496,18 +497,10 @@ export function ShellPage() {
       computerRef.current,
       expandedHistoryThread.current === snap.threadId,
     );
-    let merged = reconciled.snapshot;
-    if (keepPin && merged) {
-      merged = {
-        ...merged,
-        messages: pin.messages,
-        olderCursor: pin.olderCursor,
-      };
-    }
-    commitSnapshot(merged);
+    commitSnapshot(reconciled.snapshot);
     commitComputer(reconciled.computer);
     cacheComputerFor(id, { computer: reconciled.computer });
-    if (!keepPin && stickToEnd) {
+    if (stickToEnd && expandedHistoryThread.current !== snap.threadId) {
       window.requestAnimationFrame(() => {
         const element = messageScroll.current;
         if (element) element.scrollTop = element.scrollHeight;
@@ -746,7 +739,8 @@ export function ShellPage() {
 
   useEffect(() => {
     if (!active) return;
-    if (!searchParamsRef.current.get("m")) {
+    const pendingJump = searchParamsRef.current.get("m");
+    if (!pendingJump) {
       pinnedAroundRef.current = null;
     }
     screenRequest.current += 1;
@@ -765,8 +759,13 @@ export function ShellPage() {
     void (async () => {
       const primed = bootstrappedThread.current;
       bootstrappedThread.current = null;
+      // Pending search jumps load the around-page separately; avoid replacing it with latest.
       const snap =
-        primed?.botId === active.id ? primed : await refreshThread(active.id).catch(() => null);
+        primed?.botId === active.id
+          ? primed
+          : pendingJump
+            ? await rpc.threads.get({ botId: active.id }).catch(() => null)
+            : await refreshThread(active.id).catch(() => null);
       if (abort.signal.aborted) return;
       let cursor = snap?.cursor ?? -1;
       let retryMs = 250;
@@ -858,10 +857,17 @@ export function ShellPage() {
     markVisibleGroupRead();
     window.addEventListener("focus", markVisibleGroupRead);
     document.addEventListener("visibilitychange", markVisibleGroupRead);
-    pinnedAroundRef.current = null;
+    const pendingJump = searchParamsRef.current.get("m");
+    if (!pendingJump) {
+      pinnedAroundRef.current = null;
+      expandedHistoryThread.current = null;
+    }
+    historyEpoch.current += 1;
     const abort = new AbortController();
     void (async () => {
-      const snap = await refreshGroupThread(groupId).catch(() => null);
+      const snap = pendingJump
+        ? await rpc.threads.get({ groupId }).catch(() => null)
+        : await refreshGroupThread(groupId).catch(() => null);
       if (abort.signal.aborted) return;
       let cursor = snap?.cursor ?? -1;
       let retryMs = 250;
@@ -943,47 +949,66 @@ export function ShellPage() {
     if (hit.messageId) params.set("m", hit.messageId);
     if (hit.routineId) params.set("routine", hit.routineId);
     navigate({
-      pathname: `/app/${hit.botId}`,
+      pathname: hit.groupId ? `/app/g/${hit.groupId}` : `/app/${hit.botId}`,
       search: params.toString() ? `?${params.toString()}` : undefined,
     });
   }
 
-  async function jumpToMessage(botId: string, messageId: string) {
+  async function jumpToMessage(target: { botId?: string; groupId?: string; messageId: string }) {
+    const threadTarget = searchHitThreadTarget(target);
     const epoch = historyEpoch.current;
     const [snap, page] = await Promise.all([
-      rpc.threads.get({ botId }),
-      rpc.threads.messages({ botId, around: { messageId } }),
+      rpc.threads.get(threadTarget),
+      rpc.threads.messages({ ...threadTarget, around: { messageId: target.messageId } }),
     ]);
     // The epoch check drops a jump that raced a conversation clear (or a bot switch): applying
     // the fetched page would pin deleted messages that every later refresh keeps restoring.
     if (epoch !== historyEpoch.current) return;
+    if (target.groupId && activeGroupId.current !== target.groupId) return;
+    if (target.botId && activeBotId.current !== target.botId) return;
     expandedHistoryThread.current = page.threadId;
     pinnedAroundRef.current = {
-      botId,
-      messageId,
+      ...threadTarget,
+      messageId: target.messageId,
       threadId: page.threadId,
       messages: page.messages,
       olderCursor: page.olderCursor,
     };
+    initiallyScrolledThread.current = page.threadId;
     commitSnapshot({
       ...snap,
       messages: page.messages,
       olderCursor: page.olderCursor,
     });
-    commitComputer(snap.computer ?? null);
-    setRoutines(await rpc.routines.list({ botId }));
-    setRoutinesBotId(botId);
+    if (threadTarget.botId) {
+      commitComputer(snap.computer ?? null);
+      setRoutines(await rpc.routines.list({ botId: threadTarget.botId }));
+      setRoutinesBotId(threadTarget.botId);
+    } else {
+      commitComputer(null);
+      setRoutines([]);
+      setRoutinesBotId(null);
+    }
     window.requestAnimationFrame(() => {
       document
-        .querySelector(`[data-message-id="${messageId}"]`)
+        .querySelector(`[data-message-id="${target.messageId}"]`)
         ?.scrollIntoView({ behavior: "smooth", block: "center" });
     });
   }
 
   useEffect(() => {
-    if (!active) return;
     const messageId = searchParams.get("m");
     const routineId = searchParams.get("routine");
+    if (inGroup && groupId && messageId) {
+      void jumpToMessage({ groupId, messageId }).finally(() => {
+        // Keep expandedHistoryThread; only strip the jump URL so refresh does not remount.
+        const next = new URLSearchParams(searchParams);
+        next.delete("m");
+        setSearchParams(next, { replace: true });
+      });
+      return;
+    }
+    if (!active) return;
     if (routineId && routinesBotId === active.id) {
       const routine = routines.find((item) => item.id === routineId);
       if (routine) {
@@ -1001,13 +1026,13 @@ export function ShellPage() {
       setSearchParams(next, { replace: true });
     }
     if (messageId) {
-      void jumpToMessage(active.id, messageId).finally(() => {
+      void jumpToMessage({ botId: active.id, messageId }).finally(() => {
         const next = new URLSearchParams(searchParams);
         next.delete("m");
         setSearchParams(next, { replace: true });
       });
     }
-  }, [active?.id, routines, routinesBotId, searchParams, setSearchParams]);
+  }, [active?.id, groupId, inGroup, routines, routinesBotId, searchParams, setSearchParams]);
   const activeSnapshot = inGroup
     ? snapshot?.groupId === groupId
       ? snapshot
@@ -1075,14 +1100,23 @@ export function ShellPage() {
   }, [active, initialBotsLoaded, shellReady, snapshot?.botId]);
 
   useLayoutEffect(() => {
-    if (!active || !snapshot || snapshot.botId !== active.id) return;
-    if (initiallyScrolledThread.current === snapshot.threadId) return;
-    if (pinnedAroundRef.current?.botId === active.id) return;
+    const pin = pinnedAroundRef.current;
+    if (inGroup) {
+      if (!groupId || !snapshot || snapshot.groupId !== groupId) return;
+      if (initiallyScrolledThread.current === snapshot.threadId) return;
+      if (expandedHistoryThread.current === snapshot.threadId) return;
+      if (pin?.groupId === groupId) return;
+    } else {
+      if (!active || !snapshot || snapshot.botId !== active.id) return;
+      if (initiallyScrolledThread.current === snapshot.threadId) return;
+      if (expandedHistoryThread.current === snapshot.threadId) return;
+      if (pin?.botId === active.id) return;
+    }
     const element = messageScroll.current;
     if (!element) return;
     element.scrollTop = element.scrollHeight;
     initiallyScrolledThread.current = snapshot.threadId;
-  }, [active, snapshot?.botId, snapshot?.threadId]);
+  }, [active, groupId, inGroup, snapshot?.botId, snapshot?.groupId, snapshot?.threadId]);
 
   const openBot = useCallback((id: string) => navigate(`/app/${id}`), [navigate]);
   const loadOlder = useCallback(() => loadOlderMessagesRef.current(), []);

--- a/apps/web/src/pages/WorkspaceSearch.tsx
+++ b/apps/web/src/pages/WorkspaceSearch.tsx
@@ -19,7 +19,7 @@ export function WorkspaceSearchResults({
     <div className="flex flex-col gap-0.5">
       {hits.map((hit) => (
         <button
-          key={`${hit.kind}-${hit.botId}-${hit.messageId ?? hit.artifactId ?? hit.routineId ?? hit.url}`}
+          key={`${hit.kind}-${hit.botId ?? hit.groupId}-${hit.messageId ?? hit.artifactId ?? hit.routineId ?? hit.url}`}
           type="button"
           onClick={() => onSelect(hit)}
           className="rounded-xl px-2.5 py-[11px] text-start hover:bg-[#131315]"
@@ -33,7 +33,7 @@ export function WorkspaceSearchResults({
             </span>
           </div>
           <div className="mt-0.5 truncate text-[13px] text-[#85858A]" dir="auto">
-            {hit.botName} · {hit.snippet}
+            {hit.groupName ?? hit.botName} · {hit.snippet}
           </div>
         </button>
       ))}

--- a/packages/contracts/src/search.test.ts
+++ b/packages/contracts/src/search.test.ts
@@ -19,4 +19,43 @@ describe("search contracts", () => {
     expect(parsed.hits).toHaveLength(1);
     expect(SearchHitSchema.parse(parsed.hits[0]).kind).toBe("message");
   });
+
+  it("accepts group thread hits", () => {
+    const parsed = SearchQueryOutputSchema.parse({
+      hits: [
+        {
+          kind: "message",
+          groupId: "group-1",
+          groupName: "Squad",
+          title: "Squad",
+          snippet: "found it",
+          messageId: "msg-1",
+          seq: 3,
+        },
+      ],
+    });
+    expect(parsed.hits[0]?.groupId).toBe("group-1");
+    expect(parsed.hits[0]?.botId).toBeUndefined();
+  });
+
+  it("rejects hits with both or neither target id", () => {
+    expect(() =>
+      SearchHitSchema.parse({
+        kind: "message",
+        title: "x",
+        snippet: "y",
+      }),
+    ).toThrow();
+    expect(() =>
+      SearchHitSchema.parse({
+        kind: "message",
+        botId: "bot-1",
+        botName: "Scout",
+        groupId: "group-1",
+        groupName: "Squad",
+        title: "x",
+        snippet: "y",
+      }),
+    ).toThrow();
+  });
 });

--- a/packages/contracts/src/search.ts
+++ b/packages/contracts/src/search.ts
@@ -4,18 +4,32 @@ import { Id } from "./ids.js";
 export const SearchHitKindSchema = z.enum(["conversation", "message", "file", "link", "routine"]);
 export type SearchHitKind = z.infer<typeof SearchHitKindSchema>;
 
-export const SearchHitSchema = z.object({
-  kind: SearchHitKindSchema,
-  botId: Id,
-  botName: z.string(),
-  title: z.string(),
-  snippet: z.string(),
-  messageId: Id.optional(),
-  seq: z.number().int().nonnegative().optional(),
-  artifactId: Id.optional(),
-  routineId: Id.optional(),
-  url: z.string().optional(),
-});
+export const SearchHitSchema = z
+  .object({
+    kind: SearchHitKindSchema,
+    botId: Id.optional(),
+    botName: z.string().optional(),
+    groupId: Id.optional(),
+    groupName: z.string().optional(),
+    title: z.string(),
+    snippet: z.string(),
+    messageId: Id.optional(),
+    seq: z.number().int().nonnegative().optional(),
+    artifactId: Id.optional(),
+    routineId: Id.optional(),
+    url: z.string().optional(),
+  })
+  .superRefine((input, ctx) => {
+    const hasBot = Boolean(input.botId);
+    const hasGroup = Boolean(input.groupId);
+    if (hasBot === hasGroup) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Provide exactly one of botId or groupId",
+        path: ["botId"],
+      });
+    }
+  });
 export type SearchHit = z.infer<typeof SearchHitSchema>;
 
 export const SearchQueryOutputSchema = z.object({

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { extractLinksFromText, matchesSearchQuery, snippetAroundMatch } from "./search.js";
+import {
+  extractLinksFromText,
+  matchesSearchQuery,
+  searchHitThreadTarget,
+  snippetAroundMatch,
+} from "./search.js";
 
 describe("search helpers", () => {
   it("extracts http and https links from text", () => {
@@ -17,5 +22,15 @@ describe("search helpers", () => {
   it("builds a short snippet around the query", () => {
     const text = "alpha beta gamma delta epsilon zeta eta theta";
     expect(snippetAroundMatch(text, "gamma", 20)).toContain("gamma");
+  });
+
+  it("uses groupId for group search message jumps", () => {
+    expect(searchHitThreadTarget({ groupId: "group-1" })).toEqual({ groupId: "group-1" });
+    expect(searchHitThreadTarget({ botId: "bot-1" })).toEqual({ botId: "bot-1" });
+  });
+
+  it("rejects ambiguous search hit targets", () => {
+    expect(() => searchHitThreadTarget({})).toThrow();
+    expect(() => searchHitThreadTarget({ botId: "bot-1", groupId: "group-1" })).toThrow();
   });
 });

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -26,3 +26,17 @@ export function snippetAroundMatch(text: string, query: string, maxLen = 120): s
   const suffix = end < text.length ? "…" : "";
   return `${prefix}${text.slice(start, end)}${suffix}`;
 }
+
+export type SearchThreadTarget =
+  | { botId: string; groupId?: undefined }
+  | { groupId: string; botId?: undefined };
+
+export function searchHitThreadTarget(hit: {
+  botId?: string;
+  groupId?: string;
+}): SearchThreadTarget {
+  if (Boolean(hit.botId) === Boolean(hit.groupId)) {
+    throw new Error("Search hit must target exactly one of a bot or group");
+  }
+  return hit.groupId ? { groupId: hit.groupId } : { botId: hit.botId! };
+}

--- a/packages/testkit/src/search.test.ts
+++ b/packages/testkit/src/search.test.ts
@@ -94,6 +94,68 @@ describeSearch("workspace search", () => {
     });
     expect(hits.hits).toEqual([]);
   });
+
+  it("finds group conversations, messages, and files", async () => {
+    const cookie = await signup(app, `search-group-${stamp}@rakazo.test`, "Group Search User");
+    const botA = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Alpha",
+      title: "Alpha",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const botB = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Beta",
+      title: "Beta",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const group = await rpc<{ id: string }>(app, cookie, "groups/create", {
+      name: "Squad",
+      botIds: [botA.id, botB.id],
+    });
+    const groupToken = `squad-search-token-${stamp}`;
+    await rpc(app, cookie, "threads/send", { groupId: group.id, text: groupToken });
+    const artifact = await rpc<{ id: string }>(app, cookie, "artifacts/create", {
+      groupId: group.id,
+      name: `squad-notes-${stamp}.txt`,
+      mimeType: "text/plain",
+      contentBase64: Buffer.from("group fixture").toString("base64"),
+    });
+    await rpc(app, cookie, "threads/send", {
+      groupId: group.id,
+      text: "see attachment",
+      artifactIds: [artifact.id],
+    });
+
+    const squadHits = await rpc<{
+      hits: Array<{ kind: string; groupId?: string; botId?: string }>;
+    }>(app, cookie, "search/query", { q: "Squad" });
+    expect(
+      squadHits.hits.some((hit) => hit.kind === "conversation" && hit.groupId === group.id),
+    ).toBe(true);
+
+    const messageHits = await rpc<{
+      hits: Array<{ kind: string; groupId?: string; botId?: string; messageId?: string }>;
+    }>(app, cookie, "search/query", { q: groupToken });
+    const groupMessage = messageHits.hits.find((hit) => hit.kind === "message");
+    expect(groupMessage?.groupId).toBe(group.id);
+    expect(groupMessage?.botId).toBeUndefined();
+    expect(groupMessage?.messageId).toBeDefined();
+    const page = await rpc<{ messages: Array<{ id: string }> }>(app, cookie, "threads/messages", {
+      groupId: group.id,
+      around: { messageId: groupMessage!.messageId! },
+    });
+    expect(page.messages.some((message) => message.id === groupMessage!.messageId)).toBe(true);
+
+    const fileHits = await rpc<{
+      hits: Array<{ kind: string; groupId?: string; artifactId?: string }>;
+    }>(app, cookie, "search/query", { q: `squad-notes-${stamp}` });
+    const groupFile = fileHits.hits.find((hit) => hit.kind === "file");
+    expect(groupFile?.groupId).toBe(group.id);
+    expect(groupFile?.artifactId).toBe(artifact.id);
+  });
 });
 
 async function signup(app: App, email: string, name: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Closes #166

Port of community PR #164 by **bnsd55 (Ben)** onto current `main` (that PR is conflicting; this does not push to the fork).

- Workspace search returns **group** hits (names, messages, files, links) with exactly one of `botId` / `groupId`.
- Selecting a hit opens the 1:1 or group thread **on that message**. Web keeps the pin after `?m=` is stripped; mobile `/group-thread` jumps the same way.
- Tests cover group hit shape, `threads/messages` `{ groupId, around: { messageId } }`, and destination helpers.

### What changed vs #164 and why
- **Rebased onto current main** instead of merging the conflicting fork branch; left out unrelated Shell Advanced / scratchpad / settings churn from CodeRabbit’s #164 summary.
- **Search budget:** #164’s final reservation truncated already-collected content hits to make room for group names (Greptile P1). Here conversation name hits are capped (5 bot + 5 group), then content fills the remaining slots — names cannot crowd out messages, and content is never truncated for names.
- **Empty group names:** destination uses `groupId` (not `groupName`) so empty names still produce valid exclusive-target hits.
- **Jump / live updates:** drop frozen `keepPin` message replacement; rely on `expandedHistoryThread` + history merge so SSE refresh keeps the jumped page *and* accepts live messages. Skip scroll-to-end while expanded history is active; mark the thread as initially scrolled on jump so stripping `?m=` does not snap to latest. Group subscribe path bumps `historyEpoch` and skips the initial latest refresh when `?m=` is pending (same idea as the bot path).

Credit: original implementation by **bnsd55 (Ben)** in https://github.com/elie222/rakazo/pull/164.

## Test plan
- [x] `pnpm --filter @rakazo/contracts --filter @rakazo/core --filter @rakazo/api check`
- [x] `pnpm exec vitest run packages/contracts/src/search.test.ts packages/core/src/search.test.ts apps/mobile/lib/search.test.ts --root .`
- [ ] `VERIFY_DATABASE=1 DATABASE_URL=… pnpm exec vitest run packages/testkit/src/search.test.ts --root .`
- [ ] Search a unique token in a **long** group thread → select the hit → stay on that message after the URL loses `?m=`
- [ ] Same jump on mobile `/group-thread`
- [ ] 1:1 search jump still works; group names/files/links appear in results

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8710c1c8-91fe-4a70-9654-19a41947b49f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8710c1c8-91fe-4a70-9654-19a41947b49f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search now includes group conversations, messages, files, routines, and links alongside bot results.
  - Search results identify their associated group and provide clearer previews.
  - Selecting a group result opens the relevant group thread and message.
  - Mobile and web threads preserve message-history jumps and scroll position for group conversations.

- **Bug Fixes**
  - Improved result balancing and deduplication across search categories.
  - Prevented thread refreshes from overwriting pending search navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->