### PR TITLE
feat: Grok-style @ mentions on the chip composer

### DIFF
--- a/apps/api/src/artifacts.ts
+++ b/apps/api/src/artifacts.ts
@@ -240,6 +240,11 @@ export function buildUserMessageBlocks(
 export function buildSendPrompt(
   text: string | undefined,
   artifacts: Array<{ name: string; mimeType: string; size: number }>,
+  connectorNames: string[] = [],
 ) {
-  return promptTextForAttachments(text, artifacts);
+  const prompt = promptTextForAttachments(text, artifacts);
+  if (connectorNames.length === 0) return prompt;
+  const line = `Use these connectors if relevant: ${connectorNames.join(", ")}.`;
+  if (prompt.includes("Use these connectors if relevant:")) return prompt;
+  return prompt ? `${prompt}\n\n${line}` : line;
 }

--- a/apps/api/src/artifacts.ts
+++ b/apps/api/src/artifacts.ts
@@ -256,6 +256,6 @@ export function buildSendPrompt(
     ]),
   ];
   const line = `${marker} ${names.join(", ")}.`;
-  if (existing) return prompt.replace(existing[0], line);
+  if (existing) return prompt.replace(existing[0], () => line);
   return prompt ? `${prompt}\n\n${line}` : line;
 }

--- a/apps/api/src/artifacts.ts
+++ b/apps/api/src/artifacts.ts
@@ -244,7 +244,18 @@ export function buildSendPrompt(
 ) {
   const prompt = promptTextForAttachments(text, artifacts);
   if (connectorNames.length === 0) return prompt;
-  const line = `Use these connectors if relevant: ${connectorNames.join(", ")}.`;
-  if (prompt.includes("Use these connectors if relevant:")) return prompt;
+  const marker = "Use these connectors if relevant:";
+  const existing = new RegExp(`^${marker} (.*)\\.$`, "m").exec(prompt);
+  const names = [
+    ...new Set([
+      ...(existing?.[1]
+        ?.split(",")
+        .map((name) => name.trim())
+        .filter(Boolean) ?? []),
+      ...connectorNames.map((name) => name.trim()).filter(Boolean),
+    ]),
+  ];
+  const line = `${marker} ${names.join(", ")}.`;
+  if (existing) return prompt.replace(existing[0], line);
   return prompt ? `${prompt}\n\n${line}` : line;
 }

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1758,9 +1758,11 @@ export function createRouter(deps: RouterDeps) {
           }
           throw error;
         }
-        // Keep enqueue outside the nonce-collision catch so a failed enqueue is not
-        // reported as success by returning the run that this request just created.
-        await deps.jobs.enqueue(runContinueJob(run.id));
+        // Keep enqueue outside the nonce-collision catch. The queued run is durable;
+        // log enqueue failures and still return success — the reconciler repairs a missed wake.
+        await deps.jobs.enqueue(runContinueJob(run.id)).catch((error) => {
+          console.error("routine testRun enqueue", error);
+        });
         return { runId: run.id };
       }),
     },

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1712,9 +1712,10 @@ export function createRouter(deps: RouterDeps) {
         }
         const skillRecords = await agentSkills.listWithContent(context.actor);
         const prompt = expandSkillReferencesInPrompt(routine.prompt, skillRecords);
+        let run: { id: string };
         try {
           // Task + run must commit together so a nonce collision cannot leave an orphan queued Task.
-          const run = await deps.prisma.$transaction(async (tx) => {
+          run = await deps.prisma.$transaction(async (tx) => {
             if (nonce) {
               const existing = await tx.run.findFirst({
                 where: { threadId, clientNonce: nonce },
@@ -1747,8 +1748,6 @@ export function createRouter(deps: RouterDeps) {
               select: { id: true },
             });
           });
-          await deps.jobs.enqueue(runContinueJob(run.id));
-          return { runId: run.id };
         } catch (error) {
           if (nonce) {
             const existing = await deps.prisma.run.findFirst({
@@ -1759,6 +1758,10 @@ export function createRouter(deps: RouterDeps) {
           }
           throw error;
         }
+        // Keep enqueue outside the nonce-collision catch so a failed enqueue is not
+        // reported as success by returning the run that this request just created.
+        await deps.jobs.enqueue(runContinueJob(run.id));
+        return { runId: run.id };
       }),
     },
     scratchpad: {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1701,51 +1701,58 @@ export function createRouter(deps: RouterDeps) {
         if (!routine) throw new IsolationError();
         const bot = await repos.getBot(context.actor, routine.botId);
         if (!bot.thread) throw new IsolationError();
-        if (input.clientNonce) {
+        const threadId = bot.thread.id;
+        const nonce = input.clientNonce ? `routine-test:${input.clientNonce}` : undefined;
+        if (nonce) {
           const existing = await deps.prisma.run.findFirst({
-            where: {
-              threadId: bot.thread.id,
-              clientNonce: `routine-test:${input.clientNonce}`,
-            },
+            where: { threadId, clientNonce: nonce },
             select: { id: true },
           });
           if (existing) return { runId: existing.id };
         }
         const skillRecords = await agentSkills.listWithContent(context.actor);
         const prompt = expandSkillReferencesInPrompt(routine.prompt, skillRecords);
-        const task = await deps.prisma.task.create({
-          data: {
-            workspaceId: context.actor.workspaceId,
-            botId: bot.id,
-            threadId: bot.thread.id,
-            userId: context.actor.userId,
-            prompt,
-            status: "queued",
-          },
-        });
         try {
-          const run = await deps.prisma.run.create({
-            data: {
-              workspaceId: context.actor.workspaceId,
-              botId: bot.id,
-              threadId: bot.thread.id,
-              taskId: task.id,
-              userId: context.actor.userId,
-              status: "queued",
-              trigger: "routine",
-              routineId: routine.id,
-              clientNonce: input.clientNonce ? `routine-test:${input.clientNonce}` : undefined,
-            },
+          // Task + run must commit together so a nonce collision cannot leave an orphan queued Task.
+          const run = await deps.prisma.$transaction(async (tx) => {
+            if (nonce) {
+              const existing = await tx.run.findFirst({
+                where: { threadId, clientNonce: nonce },
+                select: { id: true },
+              });
+              if (existing) return existing;
+            }
+            const task = await tx.task.create({
+              data: {
+                workspaceId: context.actor.workspaceId,
+                botId: bot.id,
+                threadId,
+                userId: context.actor.userId,
+                prompt,
+                status: "queued",
+              },
+            });
+            return tx.run.create({
+              data: {
+                workspaceId: context.actor.workspaceId,
+                botId: bot.id,
+                threadId,
+                taskId: task.id,
+                userId: context.actor.userId,
+                status: "queued",
+                trigger: "routine",
+                routineId: routine.id,
+                clientNonce: nonce,
+              },
+              select: { id: true },
+            });
           });
           await deps.jobs.enqueue(runContinueJob(run.id));
           return { runId: run.id };
         } catch (error) {
-          if (input.clientNonce) {
+          if (nonce) {
             const existing = await deps.prisma.run.findFirst({
-              where: {
-                threadId: bot.thread.id,
-                clientNonce: `routine-test:${input.clientNonce}`,
-              },
+              where: { threadId, clientNonce: nonce },
               select: { id: true },
             });
             if (existing) return { runId: existing.id };

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1692,11 +1692,25 @@ export function createRouter(deps: RouterDeps) {
       }),
       testRun: authed.routines.testRun.handler(async ({ context, input }) => {
         const routine = await deps.prisma.routine.findFirst({
-          where: { id: input.routineId, workspaceId: context.actor.workspaceId },
+          where: {
+            id: input.routineId,
+            workspaceId: context.actor.workspaceId,
+            userId: context.actor.userId,
+          },
         });
         if (!routine) throw new IsolationError();
         const bot = await repos.getBot(context.actor, routine.botId);
         if (!bot.thread) throw new IsolationError();
+        if (input.clientNonce) {
+          const existing = await deps.prisma.run.findFirst({
+            where: {
+              threadId: bot.thread.id,
+              clientNonce: `routine-test:${input.clientNonce}`,
+            },
+            select: { id: true },
+          });
+          if (existing) return { runId: existing.id };
+        }
         const skillRecords = await agentSkills.listWithContent(context.actor);
         const prompt = expandSkillReferencesInPrompt(routine.prompt, skillRecords);
         const task = await deps.prisma.task.create({
@@ -1709,20 +1723,35 @@ export function createRouter(deps: RouterDeps) {
             status: "queued",
           },
         });
-        const run = await deps.prisma.run.create({
-          data: {
-            workspaceId: context.actor.workspaceId,
-            botId: bot.id,
-            threadId: bot.thread.id,
-            taskId: task.id,
-            userId: context.actor.userId,
-            status: "queued",
-            trigger: "routine",
-            routineId: routine.id,
-          },
-        });
-        await deps.jobs.enqueue(runContinueJob(run.id));
-        return { runId: run.id };
+        try {
+          const run = await deps.prisma.run.create({
+            data: {
+              workspaceId: context.actor.workspaceId,
+              botId: bot.id,
+              threadId: bot.thread.id,
+              taskId: task.id,
+              userId: context.actor.userId,
+              status: "queued",
+              trigger: "routine",
+              routineId: routine.id,
+              clientNonce: input.clientNonce ? `routine-test:${input.clientNonce}` : undefined,
+            },
+          });
+          await deps.jobs.enqueue(runContinueJob(run.id));
+          return { runId: run.id };
+        } catch (error) {
+          if (input.clientNonce) {
+            const existing = await deps.prisma.run.findFirst({
+              where: {
+                threadId: bot.thread.id,
+                clientNonce: `routine-test:${input.clientNonce}`,
+              },
+              select: { id: true },
+            });
+            if (existing) return { runId: existing.id };
+          }
+          throw error;
+        }
       }),
     },
     scratchpad: {

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -48,6 +48,51 @@ export type ThreadTarget =
 const THREAD_MESSAGE_PAGE_SIZE = 100;
 const RUNS_NEEDING_CONTINUE = new Set(["queued"]);
 
+type MentionTargetInput = string | { kind: "bot" | "group" | "routine" | "connector"; id: string };
+
+function splitMentionTargets(mentions: MentionTargetInput[] | undefined) {
+  const botMentionIds = new Set<string>();
+  const groupMentionIds = new Set<string>();
+  const routineMentionIds = new Set<string>();
+  const connectorMentionIds = new Set<string>();
+  for (const mention of mentions ?? []) {
+    if (typeof mention === "string") {
+      botMentionIds.add(mention);
+      continue;
+    }
+    if (mention.kind === "bot") botMentionIds.add(mention.id);
+    if (mention.kind === "group") groupMentionIds.add(mention.id);
+    if (mention.kind === "routine") routineMentionIds.add(mention.id);
+    if (mention.kind === "connector") connectorMentionIds.add(mention.id);
+  }
+  return {
+    botMentionIds: [...botMentionIds],
+    groupMentionIds: [...groupMentionIds],
+    routineMentionIds: [...routineMentionIds],
+    connectorMentionIds: [...connectorMentionIds],
+  };
+}
+
+async function resolveOwnedConnectorDisplayNames(
+  tx: Prisma.TransactionClient,
+  actor: Actor,
+  connectionIds: string[],
+) {
+  if (!connectionIds.length) return [];
+  const rows = await tx.connection.findMany({
+    where: {
+      id: { in: connectionIds },
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      status: "connected",
+    },
+    select: { id: true, displayName: true },
+  });
+  if (rows.length !== connectionIds.length) throw new IsolationError();
+  const byId = new Map(rows.map((row) => [row.id, row.displayName]));
+  return connectionIds.map((id) => byId.get(id) ?? "connector");
+}
+
 function sendRunClientNonce(
   clientNonce: string | undefined,
   messageId: string,
@@ -366,7 +411,7 @@ export async function sendThreadMessage(
   input: {
     text?: string;
     artifactIds?: string[];
-    mentions?: string[];
+    mentions?: MentionTargetInput[];
     replyToMessageId?: string;
     clientNonce?: string;
   },
@@ -385,11 +430,17 @@ export async function sendThreadMessage(
       }
 
       if (target.kind === "bot") {
+        const mentionTargets = splitMentionTargets(input.mentions);
         const { blocks: attachmentBlocks, artifacts } = await resolveSendAttachments(
           { prisma: tx },
           actor,
           target.botId,
           input.artifactIds,
+        );
+        const connectorNames = await resolveOwnedConnectorDisplayNames(
+          tx,
+          actor,
+          mentionTargets.connectorMentionIds,
         );
         const blocks = buildUserMessageBlocks(input.text, attachmentBlocks);
         const message = await createThreadMessageInTransaction(tx, {
@@ -405,7 +456,7 @@ export async function sendThreadMessage(
             botId: target.botId,
             threadId: target.threadId,
             userId: actor.userId,
-            prompt: buildSendPrompt(input.text, artifacts),
+            prompt: buildSendPrompt(input.text, artifacts, connectorNames),
             status: "queued",
           },
         });
@@ -446,10 +497,11 @@ export async function sendThreadMessage(
 
       const members = await lockAndLoadGroupMembers(tx, actor, target);
       const memberBotIds = members.map((member) => member.botId);
+      const mentionTargets = splitMentionTargets(input.mentions);
       const targetBotIds = resolveGroupTargetBotIds({
         text: input.text ?? "",
         members: members.map((member) => ({ id: member.botId, name: member.name })),
-        explicitMentions: input.mentions,
+        explicitMentions: mentionTargets.botMentionIds,
       });
       const { blocks: attachmentBlocks, artifacts } = await resolveGroupSendAttachments(
         { prisma: tx },
@@ -457,6 +509,11 @@ export async function sendThreadMessage(
         target.groupId,
         memberBotIds,
         input.artifactIds,
+      );
+      const connectorNames = await resolveOwnedConnectorDisplayNames(
+        tx,
+        actor,
+        mentionTargets.connectorMentionIds,
       );
       const blocks = buildUserMessageBlocks(input.text, attachmentBlocks);
       const message = await createThreadMessageInTransaction(tx, {
@@ -474,7 +531,7 @@ export async function sendThreadMessage(
             botId,
             threadId: target.threadId,
             userId: actor.userId,
-            prompt: buildSendPrompt(input.text, artifacts),
+            prompt: buildSendPrompt(input.text, artifacts, connectorNames),
             status: "queued",
           },
         });

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -640,10 +640,20 @@ export default function Thread() {
           ),
         );
       }
-      if (!plan.shouldSend) {
+      const clearOriginComposer = () => {
         setPendingAttachments((current) =>
           current.filter((attachment) => attachment.threadKey !== originThreadKey),
         );
+        setDraft("");
+        setMentionQuery(null);
+        setSlashQuery(null);
+        setSelectedSkill(null);
+        setSelectedMentions([]);
+        setReplyTarget(null);
+        setAttachmentNotice(null);
+      };
+      if (!plan.shouldSend) {
+        clearOriginComposer();
         if (plan.shouldOpenGroup && groupTarget) {
           router.push({
             pathname: "/group-thread",
@@ -655,13 +665,6 @@ export default function Thread() {
           return;
         }
         if (isCurrentTarget(botTarget, groupTarget)) {
-          setDraft("");
-          setMentionQuery(null);
-          setSlashQuery(null);
-          setSelectedSkill(null);
-          setSelectedMentions([]);
-          setReplyTarget(null);
-          setAttachmentNotice(null);
           await refresh();
         }
         return;
@@ -694,9 +697,7 @@ export default function Thread() {
               replyToMessageId: replyTarget?.id,
             },
       );
-      setPendingAttachments((current) =>
-        current.filter((attachment) => attachment.threadKey !== originThreadKey),
-      );
+      clearOriginComposer();
       if (plan.shouldOpenGroup && groupTarget) {
         router.push({
           pathname: "/group-thread",
@@ -708,13 +709,6 @@ export default function Thread() {
         return;
       }
       if (isCurrentTarget(botTarget, groupTarget)) {
-        setDraft("");
-        setMentionQuery(null);
-        setSlashQuery(null);
-        setSelectedSkill(null);
-        setSelectedMentions([]);
-        setReplyTarget(null);
-        setAttachmentNotice(null);
         await refresh();
       }
     } catch (err) {

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1,18 +1,32 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/native";
-import type { AgentSkillCatalogEntry, MessageBlock } from "@rakazo/contracts";
+import type {
+  AgentSkillCatalogEntry,
+  Connection,
+  ConnectionCatalogItem,
+  MessageBlock,
+  Routine,
+} from "@rakazo/contracts";
 import {
   abortableDelay,
+  appendConnectorIntent,
   attachmentsForThread,
+  buildComposerMentionOptions,
+  type ComposerMention,
   isApprovalAskBlock,
   isRunTerminalEvent,
   latestAnswerableAskMessageId,
+  mentionChipKey,
+  needsAuthConnectorNames,
+  partitionComposerMentions,
   SLASH_ACTIONS,
   type SlashActionId,
   serializeComposerPrompt,
+  stripMentionKinds,
+  toThreadMentionPayload,
   truncateSlashDescription,
 } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Alert, AppState, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { AskActions } from "../components/AskActions";
 import {
@@ -23,6 +37,8 @@ import { NativeSymbol } from "../components/native-symbol";
 import {
   applyMobileThreadEvent,
   blockText,
+  type MobileBot,
+  type MobileGroup,
   type MobileMessage,
   type MobileMessagePage,
   type MobileSnapshot,
@@ -90,9 +106,18 @@ export default function Thread() {
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [slashQuery, setSlashQuery] = useState<string | null>(null);
   const [agentSkills, setAgentSkills] = useState<AgentSkillCatalogEntry[]>([]);
-  const [selectedMentions, setSelectedMentions] = useState<
-    Array<{ botId: string; name: string; color?: string }>
+  const [mentionBots, setMentionBots] = useState<MobileBot[]>([]);
+  const [mentionGroups, setMentionGroups] = useState<MobileGroup[]>([]);
+  const [mentionRoutines, setMentionRoutines] = useState<Array<Routine & { botName?: string }>>([]);
+  const [mentionConnectors, setMentionConnectors] = useState<
+    Array<{
+      id: string;
+      name: string;
+      authStatus: "connected" | "needs_auth";
+      connectionId?: string;
+    }>
   >([]);
+  const [selectedMentions, setSelectedMentions] = useState<ComposerMention[]>([]);
   const [selectedSkill, setSelectedSkill] = useState<AgentSkillCatalogEntry | null>(null);
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [replyTarget, setReplyTarget] = useState<MobileMessage | null>(null);
@@ -104,17 +129,33 @@ export default function Thread() {
     null,
   );
   const activePendingAttachments = attachmentsForThread(pendingAttachments, threadKey);
-  const mentionOptions =
-    inGroup && mentionQuery !== null
-      ? [
-          ...((snap?.members ?? []).filter((member) =>
-            member.name.toLowerCase().startsWith(mentionQuery.toLowerCase()),
-          ) ?? []),
-          ...("everyone".startsWith(mentionQuery.toLowerCase())
-            ? [{ botId: "everyone", name: "everyone", color: "#85858A" }]
-            : []),
-        ].slice(0, 8)
-      : [];
+  const composerMentionTargets = useMemo(
+    () =>
+      buildComposerMentionOptions({
+        query: "",
+        includeEveryone: inGroup,
+        currentGroupId: groupId,
+        bots: mentionBots.map((bot) => ({ id: bot.id, name: bot.name, color: bot.color })),
+        groups: mentionGroups.map((group) => ({ id: group.id, name: group.name })),
+        routines: mentionRoutines.map((routine) => ({
+          id: routine.id,
+          name: routine.name,
+          crons: routine.crons,
+          botId: routine.botId,
+          botName: routine.botName,
+        })),
+        connectors: mentionConnectors,
+        limit: 64,
+      }),
+    [groupId, inGroup, mentionBots, mentionConnectors, mentionGroups, mentionRoutines],
+  );
+  const mentionOptions = useMemo(() => {
+    if (mentionQuery === null || composerMentionTargets.length === 0) return [];
+    const query = mentionQuery.trim().toLowerCase();
+    return composerMentionTargets
+      .filter((target) => !query || target.name.toLowerCase().startsWith(query))
+      .slice(0, 10);
+  }, [composerMentionTargets, mentionQuery]);
   const slashQueryNormalized = slashQuery?.trim().toLowerCase() ?? null;
   const slashSkillOptions =
     slashQuery !== null && mentionQuery === null
@@ -141,6 +182,80 @@ export default function Thread() {
       .then(setAgentSkills)
       .catch(() => setAgentSkills([]));
   }, []);
+
+  useEffect(() => {
+    void rpc<MobileBot[]>("bots/list")
+      .then(setMentionBots)
+      .catch(() => setMentionBots([]));
+    void rpc<MobileGroup[]>("groups/list")
+      .then(setMentionGroups)
+      .catch(() => setMentionGroups([]));
+  }, []);
+
+  useEffect(() => {
+    if (mentionBots.length === 0) {
+      setMentionRoutines([]);
+      setMentionConnectors([]);
+      return;
+    }
+    let cancelled = false;
+    const botNameById = new Map(mentionBots.map((bot) => [bot.id, bot.name]));
+    void Promise.all(
+      mentionBots.map((bot) =>
+        rpc<Routine[]>("routines/list", { botId: bot.id })
+          .then((rows) =>
+            rows.map((routine) => ({
+              ...routine,
+              botName: botNameById.get(bot.id) ?? bot.name,
+            })),
+          )
+          .catch(() => [] as Array<Routine & { botName?: string }>),
+      ),
+    ).then((lists) => {
+      if (!cancelled) setMentionRoutines(lists.flat());
+    });
+    void Promise.all([
+      rpc<Connection[]>("connections/list").catch(() => [] as Connection[]),
+      rpc<ConnectionCatalogItem[]>("connections/catalog", {}).catch(
+        () => [] as ConnectionCatalogItem[],
+      ),
+    ]).then(([connections, catalog]) => {
+      if (cancelled) return;
+      const connected = connections.filter((row) => row.status === "connected");
+      const options: Array<{
+        id: string;
+        name: string;
+        authStatus: "connected" | "needs_auth";
+        connectionId?: string;
+      }> = connected.map((row) => ({
+        id: row.id,
+        name: row.displayName,
+        authStatus: "connected" as const,
+        connectionId: row.id,
+      }));
+      for (const item of catalog) {
+        if (item.connected || item.noAuth) continue;
+        if (
+          connected.some(
+            (row) =>
+              row.provider.toLowerCase() === item.slug.toLowerCase() ||
+              row.displayName.toLowerCase() === item.name.toLowerCase(),
+          )
+        ) {
+          continue;
+        }
+        options.push({
+          id: `catalog:${item.connectorId}:${item.slug}`,
+          name: item.name,
+          authStatus: "needs_auth",
+        });
+      }
+      setMentionConnectors(options);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mentionBots]);
 
   function isCurrentTarget(targetBotId: string | undefined, targetGroupId: string | undefined) {
     return activeBotId.current === targetBotId && activeGroupId.current === targetGroupId;
@@ -440,15 +555,13 @@ export default function Thread() {
     setSlashQuery(slashMatch ? (slashMatch[1] ?? "") : null);
   }
 
-  function insertMention(member: { botId: string; name: string; color?: string }) {
+  function insertMention(mention: ComposerMention) {
     setDraft((current) => current.replace(/@([\w-]*)$/, ""));
     setMentionQuery(null);
-    if (member.botId === "everyone") {
-      setDraft((current) => `${current.replace(/\s+$/, "")} @everyone `.replace(/^\s+/, ""));
-      return;
-    }
     setSelectedMentions((current) =>
-      current.some((selected) => selected.botId === member.botId) ? current : [...current, member],
+      current.some((selected) => mentionChipKey(selected) === mentionChipKey(mention))
+        ? current
+        : [...current, mention],
     );
   }
 
@@ -494,48 +607,111 @@ export default function Thread() {
     activePendingAttachments.length > 0;
 
   async function send() {
-    const targetBotId = botId;
-    const targetGroupId = groupId;
-    if ((!targetBotId && !targetGroupId) || sending) return;
-    const attachments = attachmentsForThread(pendingAttachments, threadKey);
-    const text = serializeComposerPromptText().trim();
-    if (!text && attachments.length === 0) return;
+    const initialBotTarget = botId;
+    const initialGroupTarget = groupId;
+    if ((!initialBotTarget && !initialGroupTarget) || sending) return;
+    const originThreadKey = initialGroupTarget ?? initialBotTarget;
+    let botTarget = initialBotTarget;
+    let groupTarget = initialGroupTarget;
+    const mentions = selectedMentions;
+    const parts = partitionComposerMentions(mentions);
+    const mentionedGroup = parts.groups[0];
+    const reroutedToGroup = Boolean(!initialGroupTarget && mentionedGroup);
+    if (reroutedToGroup && mentionedGroup) {
+      groupTarget = mentionedGroup.id;
+      botTarget = undefined;
+    }
+    const attachments = attachmentsForThread(pendingAttachments, originThreadKey);
+    let trimmed = stripMentionKinds(serializeComposerPromptText().trim(), mentions, [
+      "group",
+      "routine",
+      "connector",
+    ]);
+    trimmed = appendConnectorIntent(trimmed, needsAuthConnectorNames(mentions));
+    if (!trimmed && parts.connectors.length) {
+      trimmed = parts.connectors.map((mention) => `@${mention.name}`).join(" ");
+    }
+    const routineIds = [...new Set(parts.routines.map((routine) => routine.id))];
+    if (!trimmed && attachments.length === 0 && routineIds.length === 0) return;
     setSending(true);
     setError(null);
     try {
+      if (routineIds.length) {
+        const sendNonce = crypto.randomUUID();
+        await Promise.all(
+          routineIds.map((routineId) =>
+            rpc("routines/testRun", {
+              routineId,
+              clientNonce: `routine-mention:${sendNonce}:${routineId}`,
+            }),
+          ),
+        );
+      }
+      if (!trimmed && attachments.length === 0) {
+        setPendingAttachments((current) =>
+          current.filter((attachment) => attachment.threadKey !== originThreadKey),
+        );
+        if (reroutedToGroup && groupTarget) {
+          router.push({
+            pathname: "/group-thread",
+            params: { groupId: groupTarget, name: mentionedGroup?.name ?? "Group" },
+          });
+          return;
+        }
+        if (isCurrentTarget(botTarget, groupTarget)) {
+          setDraft("");
+          setMentionQuery(null);
+          setSlashQuery(null);
+          setSelectedSkill(null);
+          setSelectedMentions([]);
+          setReplyTarget(null);
+          setAttachmentNotice(null);
+          await refresh();
+        }
+        return;
+      }
       const artifactIds: string[] = [];
       for (const pending of attachments) {
         const artifact = await rpc<{ id: string }>("artifacts/create", {
-          ...(targetGroupId ? { groupId: targetGroupId } : { botId: targetBotId! }),
+          ...(groupTarget ? { groupId: groupTarget } : { botId: botTarget! }),
           name: pending.name,
           mimeType: pending.mimeType,
           contentBase64: pending.contentBase64,
         });
         artifactIds.push(artifact.id);
       }
+      const mentionPayload = toThreadMentionPayload(
+        mentions.filter((mention) => mention.kind !== "group" && mention.kind !== "routine"),
+      );
       await rpc(
         "threads/send",
-        targetGroupId
+        groupTarget
           ? {
-              groupId: targetGroupId,
-              text: text || undefined,
-              mentions: selectedMentions.length
-                ? selectedMentions.map((member) => member.botId)
-                : undefined,
+              groupId: groupTarget,
+              text: trimmed || undefined,
+              mentions: mentionPayload.length ? mentionPayload : undefined,
               artifactIds: artifactIds.length ? artifactIds : undefined,
-              replyToMessageId: replyTarget?.id,
+              replyToMessageId: reroutedToGroup ? undefined : replyTarget?.id,
             }
           : {
-              botId: targetBotId!,
-              text: text || undefined,
+              botId: botTarget!,
+              text: trimmed || undefined,
+              mentions: mentionPayload.length ? mentionPayload : undefined,
               artifactIds: artifactIds.length ? artifactIds : undefined,
               replyToMessageId: replyTarget?.id,
             },
       );
       setPendingAttachments((current) =>
-        current.filter((attachment) => attachment.threadKey !== threadKey),
+        current.filter((attachment) => attachment.threadKey !== originThreadKey),
       );
-      if (isCurrentTarget(targetBotId, targetGroupId)) {
+      if (reroutedToGroup && groupTarget) {
+        router.push({
+          pathname: "/group-thread",
+          params: { groupId: groupTarget, name: mentionedGroup?.name ?? "Group" },
+        });
+        return;
+      }
+      if (isCurrentTarget(botTarget, groupTarget)) {
         setDraft("");
         setMentionQuery(null);
         setSlashQuery(null);
@@ -546,7 +722,9 @@ export default function Thread() {
         await refresh();
       }
     } catch (err) {
-      if (isCurrentTarget(targetBotId, targetGroupId)) {
+      if (reroutedToGroup && groupTarget) {
+        setError(err instanceof Error ? err.message : "Failed to send message");
+      } else if (isCurrentTarget(botTarget, groupTarget)) {
         setError(err instanceof Error ? err.message : "Failed to send message");
       }
     } finally {
@@ -769,6 +947,7 @@ export default function Thread() {
       ) : null}
       {mentionOptions.length ? (
         <View
+          testID="mention-picker"
           style={{
             marginTop: 12,
             borderRadius: 14,
@@ -778,14 +957,31 @@ export default function Thread() {
             overflow: "hidden",
           }}
         >
-          {mentionOptions.map((member) => (
+          {mentionOptions.map((mention) => (
             <Pressable
-              key={member.botId}
-              accessibilityLabel={`Mention ${member.name}`}
-              onPress={() => insertMention(member)}
-              style={{ paddingHorizontal: 14, paddingVertical: 10 }}
+              key={mentionChipKey(mention)}
+              accessibilityLabel={`@${mention.name}`}
+              onPress={() => insertMention(mention)}
+              style={{
+                flexDirection: "row",
+                alignItems: "flex-start",
+                gap: 10,
+                paddingHorizontal: 14,
+                paddingVertical: 10,
+              }}
             >
-              <Text style={{ color: "#ECECEE", fontSize: 14 }}>@{member.name}</Text>
+              <MentionOptionIcon mention={mention} />
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={{ color: "#ECECEE", fontSize: 14 }}>@{mention.name}</Text>
+                {mention.subtitle ? (
+                  <Text
+                    numberOfLines={1}
+                    style={{ color: "#85858A", fontSize: 12.5, marginTop: 2 }}
+                  >
+                    {mention.subtitle}
+                  </Text>
+                ) : null}
+              </View>
             </Pressable>
           ))}
         </View>
@@ -900,9 +1096,9 @@ export default function Thread() {
               </Pressable>
             </View>
           ) : null}
-          {selectedMentions.map((member) => (
+          {selectedMentions.map((mention) => (
             <View
-              key={member.botId}
+              key={mentionChipKey(mention)}
               testID="mention-chip"
               style={{
                 flexDirection: "row",
@@ -915,23 +1111,18 @@ export default function Thread() {
                 maxWidth: "100%",
               }}
             >
-              <View
-                style={{
-                  width: 14,
-                  height: 14,
-                  borderRadius: 4,
-                  backgroundColor: member.color ?? "#85858A",
-                }}
-              />
+              <MentionChipIcon mention={mention} />
               <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13, flexShrink: 1 }}>
-                {member.name}
+                {mention.name}
               </Text>
               <Pressable
-                accessibilityLabel={`Remove mention ${member.name}`}
+                accessibilityLabel={`Remove mention ${mention.name}`}
                 hitSlop={8}
                 onPress={() =>
                   setSelectedMentions((current) =>
-                    current.filter((selected) => selected.botId !== member.botId),
+                    current.filter(
+                      (selected) => mentionChipKey(selected) !== mentionChipKey(mention),
+                    ),
                   )
                 }
               >
@@ -1003,6 +1194,108 @@ export default function Thread() {
         />
       ) : null}
     </View>
+  );
+}
+
+function MentionOptionIcon({ mention }: { mention: ComposerMention }) {
+  if (mention.kind === "routine") {
+    return <NativeSymbol ios="clock" android="time-outline" size={16} color="#9A9AA0" />;
+  }
+  if (mention.kind === "connector") {
+    return (
+      <NativeSymbol
+        ios="puzzlepiece.extension"
+        android="extension-puzzle-outline"
+        size={16}
+        color="#9A9AA0"
+      />
+    );
+  }
+  if (mention.kind === "group") {
+    return (
+      <View
+        style={{
+          width: 16,
+          height: 16,
+          borderRadius: 8,
+          backgroundColor: "#2A2A2E",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Text style={{ color: "#C9C9CE", fontSize: 9 }}>G</Text>
+      </View>
+    );
+  }
+  if (mention.kind === "everyone") {
+    return (
+      <View
+        style={{
+          width: 16,
+          height: 16,
+          borderRadius: 8,
+          backgroundColor: "#2A2A2E",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Text style={{ color: "#C9C9CE", fontSize: 9 }}>@</Text>
+      </View>
+    );
+  }
+  return (
+    <View
+      style={{
+        width: 16,
+        height: 16,
+        borderRadius: 4,
+        backgroundColor: mention.color ?? "#85858A",
+      }}
+    />
+  );
+}
+
+function MentionChipIcon({ mention }: { mention: ComposerMention }) {
+  if (mention.kind === "routine") {
+    return <NativeSymbol ios="clock" android="time-outline" size={13} color="#B0B0B6" />;
+  }
+  if (mention.kind === "connector") {
+    return (
+      <NativeSymbol
+        ios="puzzlepiece.extension"
+        android="extension-puzzle-outline"
+        size={13}
+        color="#B0B0B6"
+      />
+    );
+  }
+  if (mention.kind === "group" || mention.kind === "everyone") {
+    return (
+      <View
+        style={{
+          width: 14,
+          height: 14,
+          borderRadius: 7,
+          backgroundColor: "#2A2A2E",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Text style={{ color: "#C9C9CE", fontSize: 9 }}>
+          {mention.kind === "group" ? "G" : "@"}
+        </Text>
+      </View>
+    );
+  }
+  return (
+    <View
+      style={{
+        width: 14,
+        height: 14,
+        borderRadius: 4,
+        backgroundColor: mention.color ?? "#85858A",
+      }}
+    />
   );
 }
 

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -619,10 +619,11 @@ export default function Thread() {
       text: serializeComposerPromptText(),
       mentions: selectedMentions,
       hasAttachments: attachments.length > 0,
-      alreadyInGroup: Boolean(initialGroupTarget),
     });
     if (plan.isNoOp) return;
-    const reroutedToGroup = Boolean(plan.rerouteGroupId);
+    const reroutedToGroup = Boolean(
+      plan.rerouteGroupId && plan.rerouteGroupId !== initialGroupTarget,
+    );
     const groupTarget = plan.rerouteGroupId ?? initialGroupTarget;
     const botTarget = reroutedToGroup ? undefined : initialBotTarget;
     const trimmed = plan.trimmed;
@@ -654,7 +655,7 @@ export default function Thread() {
       };
       if (!plan.shouldSend) {
         clearOriginComposer();
-        if (plan.shouldOpenGroup && groupTarget) {
+        if (reroutedToGroup && groupTarget) {
           router.push({
             pathname: "/group-thread",
             params: {
@@ -698,7 +699,7 @@ export default function Thread() {
             },
       );
       clearOriginComposer();
-      if (plan.shouldOpenGroup && groupTarget) {
+      if (reroutedToGroup && groupTarget) {
         router.push({
           pathname: "/group-thread",
           params: {

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -8,7 +8,6 @@ import type {
 } from "@rakazo/contracts";
 import {
   abortableDelay,
-  appendConnectorIntent,
   attachmentsForThread,
   buildComposerMentionOptions,
   type ComposerMention,
@@ -16,13 +15,10 @@ import {
   isRunTerminalEvent,
   latestAnswerableAskMessageId,
   mentionChipKey,
-  needsAuthConnectorNames,
-  partitionComposerMentions,
+  resolveComposerSendPlan,
   SLASH_ACTIONS,
   type SlashActionId,
   serializeComposerPrompt,
-  stripMentionKinds,
-  toThreadMentionPayload,
   truncateSlashDescription,
 } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
@@ -145,7 +141,6 @@ export default function Thread() {
           botName: routine.botName,
         })),
         connectors: mentionConnectors,
-        limit: 64,
       }),
     [groupId, inGroup, mentionBots, mentionConnectors, mentionGroups, mentionRoutines],
   );
@@ -611,35 +606,25 @@ export default function Thread() {
     const initialGroupTarget = groupId;
     if ((!initialBotTarget && !initialGroupTarget) || sending) return;
     const originThreadKey = initialGroupTarget ?? initialBotTarget;
-    let botTarget = initialBotTarget;
-    let groupTarget = initialGroupTarget;
-    const mentions = selectedMentions;
-    const parts = partitionComposerMentions(mentions);
-    const mentionedGroup = parts.groups[0];
-    const reroutedToGroup = Boolean(!initialGroupTarget && mentionedGroup);
-    if (reroutedToGroup && mentionedGroup) {
-      groupTarget = mentionedGroup.id;
-      botTarget = undefined;
-    }
     const attachments = attachmentsForThread(pendingAttachments, originThreadKey);
-    let trimmed = stripMentionKinds(serializeComposerPromptText().trim(), mentions, [
-      "group",
-      "routine",
-      "connector",
-    ]);
-    trimmed = appendConnectorIntent(trimmed, needsAuthConnectorNames(mentions));
-    if (!trimmed && parts.connectors.length) {
-      trimmed = parts.connectors.map((mention) => `@${mention.name}`).join(" ");
-    }
-    const routineIds = [...new Set(parts.routines.map((routine) => routine.id))];
-    if (!trimmed && attachments.length === 0 && routineIds.length === 0) return;
+    const plan = resolveComposerSendPlan({
+      text: serializeComposerPromptText(),
+      mentions: selectedMentions,
+      hasAttachments: attachments.length > 0,
+      alreadyInGroup: Boolean(initialGroupTarget),
+    });
+    if (plan.isNoOp) return;
+    const reroutedToGroup = Boolean(plan.rerouteGroupId);
+    const groupTarget = plan.rerouteGroupId ?? initialGroupTarget;
+    const botTarget = reroutedToGroup ? undefined : initialBotTarget;
+    const trimmed = plan.trimmed;
     setSending(true);
     setError(null);
     try {
-      if (routineIds.length) {
+      if (plan.shouldRunRoutines) {
         const sendNonce = crypto.randomUUID();
         await Promise.all(
-          routineIds.map((routineId) =>
+          plan.routineIds.map((routineId) =>
             rpc("routines/testRun", {
               routineId,
               clientNonce: `routine-mention:${sendNonce}:${routineId}`,
@@ -647,14 +632,17 @@ export default function Thread() {
           ),
         );
       }
-      if (!trimmed && attachments.length === 0) {
+      if (!plan.shouldSend) {
         setPendingAttachments((current) =>
           current.filter((attachment) => attachment.threadKey !== originThreadKey),
         );
-        if (reroutedToGroup && groupTarget) {
+        if (plan.shouldOpenGroup && groupTarget) {
           router.push({
             pathname: "/group-thread",
-            params: { groupId: groupTarget, name: mentionedGroup?.name ?? "Group" },
+            params: {
+              groupId: groupTarget,
+              name: plan.rerouteGroupName ?? "Group",
+            },
           });
           return;
         }
@@ -680,23 +668,20 @@ export default function Thread() {
         });
         artifactIds.push(artifact.id);
       }
-      const mentionPayload = toThreadMentionPayload(
-        mentions.filter((mention) => mention.kind !== "group" && mention.kind !== "routine"),
-      );
       await rpc(
         "threads/send",
         groupTarget
           ? {
               groupId: groupTarget,
               text: trimmed || undefined,
-              mentions: mentionPayload.length ? mentionPayload : undefined,
+              mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
               artifactIds: artifactIds.length ? artifactIds : undefined,
               replyToMessageId: reroutedToGroup ? undefined : replyTarget?.id,
             }
           : {
               botId: botTarget!,
               text: trimmed || undefined,
-              mentions: mentionPayload.length ? mentionPayload : undefined,
+              mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
               artifactIds: artifactIds.length ? artifactIds : undefined,
               replyToMessageId: replyTarget?.id,
             },
@@ -704,10 +689,13 @@ export default function Thread() {
       setPendingAttachments((current) =>
         current.filter((attachment) => attachment.threadKey !== originThreadKey),
       );
-      if (reroutedToGroup && groupTarget) {
+      if (plan.shouldOpenGroup && groupTarget) {
         router.push({
           pathname: "/group-thread",
-          params: { groupId: groupTarget, name: mentionedGroup?.name ?? "Group" },
+          params: {
+            groupId: groupTarget,
+            name: plan.rerouteGroupName ?? "Group",
+          },
         });
         return;
       }

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -56,6 +56,14 @@ import { playMpeg, speakUtterance } from "../lib/voice";
 
 type PendingAttachment = PickedAttachment & { threadKey: string };
 
+function newClientNonce(): string {
+  const webCrypto = globalThis.crypto;
+  if (webCrypto && typeof webCrypto.randomUUID === "function") {
+    return webCrypto.randomUUID();
+  }
+  return `m-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function formatApprovalAnswer(answer: string | undefined): string {
   if (!answer) return "Answered";
   if (answer === "allow") return "Allowed once";
@@ -622,7 +630,7 @@ export default function Thread() {
     setError(null);
     try {
       if (plan.shouldRunRoutines) {
-        const sendNonce = crypto.randomUUID();
+        const sendNonce = newClientNonce();
         await Promise.all(
           plan.routineIds.map((routineId) =>
             rpc("routines/testRun", {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1258,10 +1258,11 @@ export function ShellPage() {
         text,
         mentions,
         hasAttachments: attachments.length > 0,
-        alreadyInGroup: Boolean(initialGroupTarget),
       });
       if (plan.isNoOp) return;
-      const reroutedToGroup = Boolean(plan.rerouteGroupId);
+      const reroutedToGroup = Boolean(
+        plan.rerouteGroupId && plan.rerouteGroupId !== initialGroupTarget,
+      );
       const groupTarget = plan.rerouteGroupId ?? initialGroupTarget;
       const botTarget = reroutedToGroup ? undefined : initialBotTarget;
       const trimmed = plan.trimmed;
@@ -1286,7 +1287,7 @@ export function ShellPage() {
             current.filter((attachment) => attachment.threadKey !== originThreadKey),
           );
           setAttachmentNotice(null);
-          if (plan.shouldOpenGroup && groupTarget) {
+          if (reroutedToGroup && groupTarget) {
             navigate(`/app/g/${groupTarget}`);
             return;
           }
@@ -1333,7 +1334,7 @@ export function ShellPage() {
         setPendingAttachments((current) =>
           current.filter((attachment) => attachment.threadKey !== originThreadKey),
         );
-        if (plan.shouldOpenGroup && groupTarget) {
+        if (reroutedToGroup && groupTarget) {
           navigate(`/app/g/${groupTarget}`);
           return;
         }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -6,6 +6,8 @@ import type {
   ComputerMode,
   ComputerReleaseReason,
   ComputerStatus,
+  Connection,
+  ConnectionCatalogItem,
   Group,
   Me,
   MessageBlock,
@@ -33,7 +35,10 @@ import {
 } from "@rakazo/contracts";
 import {
   abortableDelay,
+  appendConnectorIntent,
   attachmentsForThread,
+  buildComposerMentionOptions,
+  type ComposerMention,
   cronFromPreset,
   defaultCronPreset,
   formatCron,
@@ -42,11 +47,16 @@ import {
   isActive,
   isRunTerminalEvent,
   latestAnswerableAskMessageId,
+  mentionChipKey,
+  needsAuthConnectorNames,
+  partitionComposerMentions,
   presetFromCron,
   SLASH_ACTIONS,
   type SlashActionId,
   serializeComposerPrompt,
   speechFromBlocks,
+  stripMentionKinds,
+  toThreadMentionPayload,
   truncateSlashDescription,
 } from "@rakazo/core";
 import { BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
@@ -55,6 +65,7 @@ import {
   Bell,
   Box,
   ChevronLeft,
+  Clock,
   Cpu,
   Gauge,
   LogOut,
@@ -215,6 +226,15 @@ export function ShellPage() {
   const [taughtSkills, setTaughtSkills] = useState<TaughtSkill[]>([]);
   const [taughtSkillsBotId, setTaughtSkillsBotId] = useState<string | null>(null);
   const [agentSkills, setAgentSkills] = useState<AgentSkillCatalogEntry[]>([]);
+  const [mentionRoutines, setMentionRoutines] = useState<Array<Routine & { botName?: string }>>([]);
+  const [mentionConnectors, setMentionConnectors] = useState<
+    Array<{
+      id: string;
+      name: string;
+      authStatus: "connected" | "needs_auth";
+      connectionId?: string;
+    }>
+  >([]);
   const [teachBusy, setTeachBusy] = useState(false);
   const [computer, setComputer] = useState<ComputerStatus | null>(null);
   const computerRef = useRef<ComputerStatus | null>(null);
@@ -1047,6 +1067,26 @@ export function ShellPage() {
     (botId: string | undefined) => memberName(transcriptMembers, botId),
     [transcriptMembers],
   );
+  const composerMentionTargets = useMemo(
+    () =>
+      buildComposerMentionOptions({
+        query: "",
+        includeEveryone: inGroup,
+        currentGroupId: groupId,
+        bots: bots.map((bot) => ({ id: bot.id, name: bot.name, color: bot.color })),
+        groups: groups.map((group) => ({ id: group.id, name: group.name })),
+        routines: mentionRoutines.map((routine) => ({
+          id: routine.id,
+          name: routine.name,
+          crons: routine.crons,
+          botId: routine.botId,
+          botName: routine.botName,
+        })),
+        connectors: mentionConnectors,
+        limit: 64,
+      }),
+    [bots, groupId, groups, inGroup, mentionConnectors, mentionRoutines],
+  );
   const shellReady =
     initialBotsLoaded &&
     (inGroup
@@ -1058,6 +1098,70 @@ export function ShellPage() {
   refreshGroupThreadRef.current = refreshGroupThread;
   const loadOlderMessagesRef = useRef(loadOlderMessages);
   loadOlderMessagesRef.current = loadOlderMessages;
+
+  useEffect(() => {
+    if (!initialBotsLoaded || bots.length === 0) {
+      setMentionRoutines([]);
+      setMentionConnectors([]);
+      return;
+    }
+    let cancelled = false;
+    const botNameById = new Map(bots.map((bot) => [bot.id, bot.name]));
+    void Promise.all(
+      bots.map((bot) =>
+        rpc.routines
+          .list({ botId: bot.id })
+          .then((rows) =>
+            rows.map((routine) => ({
+              ...routine,
+              botName: botNameById.get(bot.id) ?? bot.name,
+            })),
+          )
+          .catch(() => [] as Array<Routine & { botName?: string }>),
+      ),
+    ).then((lists) => {
+      if (!cancelled) setMentionRoutines(lists.flat());
+    });
+    void Promise.all([
+      rpc.connections.list().catch(() => [] as Connection[]),
+      rpc.connections.catalog({}).catch(() => [] as ConnectionCatalogItem[]),
+    ]).then(([connections, catalog]) => {
+      if (cancelled) return;
+      const connected = connections.filter((row) => row.status === "connected");
+      const options: Array<{
+        id: string;
+        name: string;
+        authStatus: "connected" | "needs_auth";
+        connectionId?: string;
+      }> = connected.map((row) => ({
+        id: row.id,
+        name: row.displayName,
+        authStatus: "connected" as const,
+        connectionId: row.id,
+      }));
+      for (const item of catalog) {
+        if (item.connected || item.noAuth) continue;
+        if (
+          connected.some(
+            (row) =>
+              row.provider.toLowerCase() === item.slug.toLowerCase() ||
+              row.displayName.toLowerCase() === item.name.toLowerCase(),
+          )
+        ) {
+          continue;
+        }
+        options.push({
+          id: `catalog:${item.connectorId}:${item.slug}`,
+          name: item.name,
+          authStatus: "needs_auth",
+        });
+      }
+      setMentionConnectors(options);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [bots, initialBotsLoaded]);
 
   useLayoutEffect(() => {
     if (initialBotsLoaded) {
@@ -1141,16 +1245,52 @@ export function ShellPage() {
     setPendingAttachments((current) => current.filter((item) => item.id !== attachment.id));
   }, []);
   const sendMessage = useCallback(
-    async (text: string, mentions?: string[]) => {
-      const botTarget = activeBotId.current;
-      const groupTarget = activeGroupId.current;
-      if ((!botTarget && !groupTarget) || sending) return;
-      const attachments = attachmentsForThread(pendingAttachments, groupTarget ?? botTarget);
-      const trimmed = text.trim();
-      if (!trimmed && attachments.length === 0) return;
+    async (text: string, mentions: ComposerMention[] = []) => {
+      const initialBotTarget = activeBotId.current;
+      const initialGroupTarget = activeGroupId.current;
+      if ((!initialBotTarget && !initialGroupTarget) || sending) return;
+      const originThreadKey = initialGroupTarget ?? initialBotTarget;
+      let botTarget = initialBotTarget;
+      let groupTarget = initialGroupTarget;
+      const parts = partitionComposerMentions(mentions);
+      const mentionedGroup = parts.groups[0];
+      const reroutedToGroup = Boolean(!initialGroupTarget && mentionedGroup);
+      // Capture destination ids before any navigate so refresh/send cannot use the old 1:1.
+      if (reroutedToGroup && mentionedGroup) {
+        groupTarget = mentionedGroup.id;
+        botTarget = undefined;
+      }
+      const attachments = attachmentsForThread(pendingAttachments, originThreadKey);
+      let trimmed = stripMentionKinds(text.trim(), mentions, ["group", "routine", "connector"]);
+      trimmed = appendConnectorIntent(trimmed, needsAuthConnectorNames(mentions));
+      if (!trimmed && parts.connectors.length) {
+        trimmed = parts.connectors.map((mention) => `@${mention.name}`).join(" ");
+      }
+      const routineIds = [...new Set(parts.routines.map((routine) => routine.id))];
+      if (!trimmed && attachments.length === 0 && routineIds.length === 0) return;
       setSending(true);
       setSendError(null);
       try {
+        if (routineIds.length) {
+          const sendNonce = crypto.randomUUID();
+          await Promise.all(
+            routineIds.map((routineId) =>
+              rpc.routines.testRun({
+                routineId,
+                clientNonce: `routine-mention:${sendNonce}:${routineId}`,
+              }),
+            ),
+          );
+        }
+        if (!trimmed && attachments.length === 0) {
+          setReplyTarget(null);
+          if (groupTarget && activeGroupId.current === groupTarget) {
+            await refreshGroupThreadRef.current(groupTarget);
+          } else if (botTarget && activeBotId.current === botTarget) {
+            await refreshThreadRef.current(botTarget);
+          }
+          return;
+        }
         const artifactIds: string[] = [];
         for (const pending of attachments) {
           const mimeType = inferAttachmentMimeType(pending.file.name, pending.file.type);
@@ -1165,18 +1305,22 @@ export function ShellPage() {
           );
           artifactIds.push(artifact.id);
         }
+        const mentionPayload = toThreadMentionPayload(
+          mentions.filter((mention) => mention.kind !== "group" && mention.kind !== "routine"),
+        );
         if (groupTarget) {
           await rpc.threads.send({
             groupId: groupTarget,
             text: trimmed || undefined,
-            mentions: mentions?.length ? mentions : undefined,
+            mentions: mentionPayload.length ? mentionPayload : undefined,
             artifactIds: artifactIds.length ? artifactIds : undefined,
-            replyToMessageId: activeReplyTarget?.id,
+            replyToMessageId: reroutedToGroup ? undefined : activeReplyTarget?.id,
           });
         } else if (botTarget) {
           await rpc.threads.send({
             botId: botTarget,
             text: trimmed || undefined,
+            mentions: mentionPayload.length ? mentionPayload : undefined,
             artifactIds: artifactIds.length ? artifactIds : undefined,
             replyToMessageId: activeReplyTarget?.id,
           });
@@ -1184,14 +1328,20 @@ export function ShellPage() {
         setReplyTarget(null);
         revokePendingAttachmentPreviews(attachments);
         setPendingAttachments((current) =>
-          current.filter((attachment) => attachment.threadKey !== (groupTarget ?? botTarget)),
+          current.filter((attachment) => attachment.threadKey !== originThreadKey),
         );
+        if (reroutedToGroup && groupTarget) {
+          navigate(`/app/g/${groupTarget}`);
+          return;
+        }
         if (groupTarget && activeGroupId.current === groupTarget) setAttachmentNotice(null);
         if (botTarget && activeBotId.current === botTarget) setAttachmentNotice(null);
         if (groupTarget) await refreshGroupThreadRef.current(groupTarget);
         else if (botTarget) await refreshThreadRef.current(botTarget);
       } catch (error) {
-        if (groupTarget && activeGroupId.current === groupTarget) {
+        if (reroutedToGroup && groupTarget) {
+          setSendError(error instanceof Error ? error.message : "Failed to send message");
+        } else if (groupTarget && activeGroupId.current === groupTarget) {
           setSendError(error instanceof Error ? error.message : "Failed to send message");
         } else if (botTarget && activeBotId.current === botTarget) {
           setSendError(error instanceof Error ? error.message : "Failed to send message");
@@ -1200,7 +1350,7 @@ export function ShellPage() {
         setSending(false);
       }
     },
-    [activeReplyTarget?.id, pendingAttachments, sending],
+    [activeReplyTarget?.id, navigate, pendingAttachments, sending],
   );
   const followUpMessage = useCallback(async (text: string) => {
     const id = activeBotId.current;
@@ -1953,15 +2103,7 @@ export function ShellPage() {
           onStop={stopRun}
           replyTarget={activeReplyTarget}
           onClearReply={() => setReplyTarget(null)}
-          mentionMembers={
-            inGroup
-              ? (activeSnapshot?.members ?? activeGroup?.members)?.map((member) => ({
-                  botId: member.botId,
-                  name: member.name,
-                  color: member.color,
-                }))
-              : undefined
-          }
+          mentionTargets={composerMentionTargets}
           agentSkills={agentSkills}
           onSlashOpen={refreshAgentSkills}
           onSlashAction={(action) => {
@@ -2854,7 +2996,7 @@ const Composer = memo(function Composer({
   onStop,
   replyTarget,
   onClearReply,
-  mentionMembers,
+  mentionTargets,
   agentSkills,
   onSlashOpen,
   onSlashAction,
@@ -2874,11 +3016,11 @@ const Composer = memo(function Composer({
   fileInputRef: RefObject<HTMLInputElement | null>;
   onAttachmentPick: (files: FileList | null) => void | Promise<void>;
   onRemoveAttachment: (attachment: PendingAttachment) => void;
-  onSend: (text: string, mentions?: string[]) => Promise<void>;
+  onSend: (text: string, mentions?: ComposerMention[]) => Promise<void>;
   onStop: () => Promise<void>;
   replyTarget?: ThreadMessage | null;
   onClearReply?: () => void;
-  mentionMembers?: Array<{ botId: string; name: string; color?: string }>;
+  mentionTargets?: ComposerMention[];
   agentSkills?: AgentSkillCatalogEntry[];
   onSlashOpen?: () => void;
   onSlashAction?: (action: SlashActionId) => void;
@@ -2891,9 +3033,7 @@ const Composer = memo(function Composer({
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [slashQuery, setSlashQuery] = useState<string | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<AgentSkillCatalogEntry | null>(null);
-  const [selectedMentions, setSelectedMentions] = useState<
-    Array<{ botId: string; name: string; color?: string }>
-  >([]);
+  const [selectedMentions, setSelectedMentions] = useState<ComposerMention[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const canSend =
     draft.trim().length > 0 ||
@@ -2937,15 +3077,13 @@ const Composer = memo(function Composer({
     setSlashQuery(nextSlash);
   }
 
-  function insertMention(member: { botId: string; name: string; color?: string }) {
+  function insertMention(mention: ComposerMention) {
     setDraft((current) => current.replace(/@([\w-]*)$/, ""));
     setMentionQuery(null);
-    if (member.botId === "everyone") {
-      setDraft((current) => `${current.replace(/\s+$/, "")} @everyone `.replace(/^\s+/, ""));
-      return;
-    }
     setSelectedMentions((current) =>
-      current.some((selected) => selected.botId === member.botId) ? current : [...current, member],
+      current.some((selected) => mentionChipKey(selected) === mentionChipKey(mention))
+        ? current
+        : [...current, mention],
     );
   }
 
@@ -2970,14 +3108,12 @@ const Composer = memo(function Composer({
   }
 
   const mentionOptions = useMemo(() => {
-    if (mentionQuery === null || !mentionMembers?.length) return [];
-    const query = mentionQuery.toLowerCase();
-    const options = mentionMembers.filter((member) => member.name.toLowerCase().startsWith(query));
-    if ("everyone".startsWith(query)) {
-      options.unshift({ botId: "everyone", name: "everyone", color: "#85858A" });
-    }
-    return options.slice(0, 8);
-  }, [mentionMembers, mentionQuery]);
+    if (mentionQuery === null || !mentionTargets?.length) return [];
+    const query = mentionQuery.trim().toLowerCase();
+    return mentionTargets
+      .filter((target) => !query || target.name.toLowerCase().startsWith(query))
+      .slice(0, 10);
+  }, [mentionQuery, mentionTargets]);
 
   const slashSkillOptions = useMemo(() => {
     if (slashQuery === null) return [];
@@ -3012,9 +3148,9 @@ const Composer = memo(function Composer({
     setMentionQuery(null);
     setSlashQuery(null);
     setSelectedSkill(null);
-    const mentions = selectedMentions.map((member) => member.botId);
+    const mentions = selectedMentions;
     setSelectedMentions([]);
-    void onSend(text, mentions.length ? mentions : undefined);
+    void onSend(text, mentions);
   }
 
   const showComposerPlaceholder =
@@ -3082,15 +3218,29 @@ const Composer = memo(function Composer({
         </div>
       ) : null}
       {mentionOptions.length ? (
-        <div className="mb-2 overflow-hidden rounded-[14px] border border-[#26262A] bg-[#17171A]">
-          {mentionOptions.map((member) => (
+        <div
+          data-testid="mention-picker"
+          className="mb-2 overflow-hidden rounded-[14px] border border-[#26262A] bg-[#17171A]"
+        >
+          {mentionOptions.map((mention) => (
             <button
-              key={member.botId}
+              key={mentionChipKey(mention)}
               type="button"
-              onClick={() => insertMention(member)}
-              className="block w-full px-4 py-2 text-start text-[14px] text-[#ECECEE] hover:bg-[#1F1F22]"
+              aria-label={`@${mention.name}`}
+              onClick={() => insertMention(mention)}
+              className="flex w-full items-start gap-3 px-4 py-2.5 text-start hover:bg-[#1F1F22]"
             >
-              <span dir="auto">@{member.name}</span>
+              <MentionOptionIcon mention={mention} />
+              <span className="min-w-0">
+                <span dir="auto" className="block text-[14px] text-[#ECECEE]">
+                  @{mention.name}
+                </span>
+                {mention.subtitle ? (
+                  <span dir="auto" className="block truncate text-[12.5px] text-[#85858A]">
+                    {mention.subtitle}
+                  </span>
+                ) : null}
+              </span>
             </button>
           ))}
         </div>
@@ -3196,22 +3346,25 @@ const Composer = memo(function Composer({
               </button>
             </span>
           ) : null}
-          {selectedMentions.map((member) => (
+          {selectedMentions.map((mention) => (
             <span
-              key={member.botId}
+              key={mentionChipKey(mention)}
               data-testid="mention-chip"
+              data-mention-kind={mention.kind}
               className="inline-flex max-w-full items-center gap-1.5 rounded-full bg-[#1C1C1F] px-2.5 py-1 text-[13px] text-[#ECECEE]"
             >
-              <BotAvatar color={member.color ?? "#85858A"} size={16} />
+              <MentionChipIcon mention={mention} />
               <span dir="auto" className="truncate">
-                {member.name}
+                {mention.name}
               </span>
               <button
                 type="button"
-                aria-label={`Remove mention ${member.name}`}
+                aria-label={`Remove mention ${mention.name}`}
                 onClick={() =>
                   setSelectedMentions((current) =>
-                    current.filter((selected) => selected.botId !== member.botId),
+                    current.filter(
+                      (selected) => mentionChipKey(selected) !== mentionChipKey(mention),
+                    ),
                   )
                 }
                 className="text-[#85858A] hover:text-[#ECECEE]"
@@ -3279,6 +3432,47 @@ const Composer = memo(function Composer({
     </div>
   );
 });
+
+function MentionOptionIcon({ mention }: { mention: ComposerMention }) {
+  if (mention.kind === "routine") {
+    return <Clock size={16} strokeWidth={1.7} className="mt-0.5 shrink-0 text-[#9A9AA0]" />;
+  }
+  if (mention.kind === "connector") {
+    return <Puzzle size={16} strokeWidth={1.7} className="mt-0.5 shrink-0 text-[#9A9AA0]" />;
+  }
+  if (mention.kind === "group") {
+    return (
+      <span className="mt-0.5 grid h-4 w-4 shrink-0 place-items-center rounded-full bg-[#2A2A2E] text-[9px] text-[#C9C9CE]">
+        G
+      </span>
+    );
+  }
+  if (mention.kind === "everyone") {
+    return (
+      <span className="mt-0.5 grid h-4 w-4 shrink-0 place-items-center rounded-full bg-[#2A2A2E] text-[9px] text-[#C9C9CE]">
+        @
+      </span>
+    );
+  }
+  return <BotAvatar color={mention.color ?? "#85858A"} size={16} />;
+}
+
+function MentionChipIcon({ mention }: { mention: ComposerMention }) {
+  if (mention.kind === "routine") {
+    return <Clock size={13} strokeWidth={1.7} className="shrink-0 text-[#B0B0B6]" />;
+  }
+  if (mention.kind === "connector") {
+    return <Puzzle size={13} strokeWidth={1.7} className="shrink-0 text-[#B0B0B6]" />;
+  }
+  if (mention.kind === "group" || mention.kind === "everyone") {
+    return (
+      <span className="grid h-4 w-4 shrink-0 place-items-center rounded-full bg-[#2A2A2E] text-[9px] text-[#C9C9CE]">
+        {mention.kind === "group" ? "G" : "@"}
+      </span>
+    );
+  }
+  return <BotAvatar color={mention.color ?? "#85858A"} size={16} />;
+}
 
 function previewMessageText(message: ThreadMessage): string {
   const text = message.blocks

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1094,7 +1094,15 @@ export function ShellPage() {
   const loadOlderMessagesRef = useRef(loadOlderMessages);
   loadOlderMessagesRef.current = loadOlderMessages;
 
+  const mentionBotsKey = useMemo(
+    () => bots.map((bot) => `${bot.id}:${bot.name}`).join(","),
+    [bots],
+  );
+  const botsForMentionsRef = useRef(bots);
+  botsForMentionsRef.current = bots;
+
   useEffect(() => {
+    const bots = botsForMentionsRef.current;
     if (!initialBotsLoaded || bots.length === 0) {
       setMentionRoutines([]);
       setMentionConnectors([]);
@@ -1156,7 +1164,7 @@ export function ShellPage() {
     return () => {
       cancelled = true;
     };
-  }, [bots, initialBotsLoaded]);
+  }, [initialBotsLoaded, mentionBotsKey]);
 
   useLayoutEffect(() => {
     if (initialBotsLoaded) {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1281,6 +1281,11 @@ export function ShellPage() {
         }
         if (!plan.shouldSend) {
           setReplyTarget(null);
+          revokePendingAttachmentPreviews(attachments);
+          setPendingAttachments((current) =>
+            current.filter((attachment) => attachment.threadKey !== originThreadKey),
+          );
+          setAttachmentNotice(null);
           if (plan.shouldOpenGroup && groupTarget) {
             navigate(`/app/g/${groupTarget}`);
             return;

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -35,7 +35,6 @@ import {
 } from "@rakazo/contracts";
 import {
   abortableDelay,
-  appendConnectorIntent,
   attachmentsForThread,
   buildComposerMentionOptions,
   type ComposerMention,
@@ -48,15 +47,12 @@ import {
   isRunTerminalEvent,
   latestAnswerableAskMessageId,
   mentionChipKey,
-  needsAuthConnectorNames,
-  partitionComposerMentions,
   presetFromCron,
+  resolveComposerSendPlan,
   SLASH_ACTIONS,
   type SlashActionId,
   serializeComposerPrompt,
   speechFromBlocks,
-  stripMentionKinds,
-  toThreadMentionPayload,
   truncateSlashDescription,
 } from "@rakazo/core";
 import { BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
@@ -1083,7 +1079,6 @@ export function ShellPage() {
           botName: routine.botName,
         })),
         connectors: mentionConnectors,
-        limit: 64,
       }),
     [bots, groupId, groups, inGroup, mentionConnectors, mentionRoutines],
   );
@@ -1250,31 +1245,25 @@ export function ShellPage() {
       const initialGroupTarget = activeGroupId.current;
       if ((!initialBotTarget && !initialGroupTarget) || sending) return;
       const originThreadKey = initialGroupTarget ?? initialBotTarget;
-      let botTarget = initialBotTarget;
-      let groupTarget = initialGroupTarget;
-      const parts = partitionComposerMentions(mentions);
-      const mentionedGroup = parts.groups[0];
-      const reroutedToGroup = Boolean(!initialGroupTarget && mentionedGroup);
-      // Capture destination ids before any navigate so refresh/send cannot use the old 1:1.
-      if (reroutedToGroup && mentionedGroup) {
-        groupTarget = mentionedGroup.id;
-        botTarget = undefined;
-      }
       const attachments = attachmentsForThread(pendingAttachments, originThreadKey);
-      let trimmed = stripMentionKinds(text.trim(), mentions, ["group", "routine", "connector"]);
-      trimmed = appendConnectorIntent(trimmed, needsAuthConnectorNames(mentions));
-      if (!trimmed && parts.connectors.length) {
-        trimmed = parts.connectors.map((mention) => `@${mention.name}`).join(" ");
-      }
-      const routineIds = [...new Set(parts.routines.map((routine) => routine.id))];
-      if (!trimmed && attachments.length === 0 && routineIds.length === 0) return;
+      const plan = resolveComposerSendPlan({
+        text,
+        mentions,
+        hasAttachments: attachments.length > 0,
+        alreadyInGroup: Boolean(initialGroupTarget),
+      });
+      if (plan.isNoOp) return;
+      const reroutedToGroup = Boolean(plan.rerouteGroupId);
+      const groupTarget = plan.rerouteGroupId ?? initialGroupTarget;
+      const botTarget = reroutedToGroup ? undefined : initialBotTarget;
+      const trimmed = plan.trimmed;
       setSending(true);
       setSendError(null);
       try {
-        if (routineIds.length) {
+        if (plan.shouldRunRoutines) {
           const sendNonce = crypto.randomUUID();
           await Promise.all(
-            routineIds.map((routineId) =>
+            plan.routineIds.map((routineId) =>
               rpc.routines.testRun({
                 routineId,
                 clientNonce: `routine-mention:${sendNonce}:${routineId}`,
@@ -1282,8 +1271,12 @@ export function ShellPage() {
             ),
           );
         }
-        if (!trimmed && attachments.length === 0) {
+        if (!plan.shouldSend) {
           setReplyTarget(null);
+          if (plan.shouldOpenGroup && groupTarget) {
+            navigate(`/app/g/${groupTarget}`);
+            return;
+          }
           if (groupTarget && activeGroupId.current === groupTarget) {
             await refreshGroupThreadRef.current(groupTarget);
           } else if (botTarget && activeBotId.current === botTarget) {
@@ -1305,14 +1298,11 @@ export function ShellPage() {
           );
           artifactIds.push(artifact.id);
         }
-        const mentionPayload = toThreadMentionPayload(
-          mentions.filter((mention) => mention.kind !== "group" && mention.kind !== "routine"),
-        );
         if (groupTarget) {
           await rpc.threads.send({
             groupId: groupTarget,
             text: trimmed || undefined,
-            mentions: mentionPayload.length ? mentionPayload : undefined,
+            mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
             artifactIds: artifactIds.length ? artifactIds : undefined,
             replyToMessageId: reroutedToGroup ? undefined : activeReplyTarget?.id,
           });
@@ -1320,7 +1310,7 @@ export function ShellPage() {
           await rpc.threads.send({
             botId: botTarget,
             text: trimmed || undefined,
-            mentions: mentionPayload.length ? mentionPayload : undefined,
+            mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
             artifactIds: artifactIds.length ? artifactIds : undefined,
             replyToMessageId: activeReplyTarget?.id,
           });
@@ -1330,7 +1320,7 @@ export function ShellPage() {
         setPendingAttachments((current) =>
           current.filter((attachment) => attachment.threadKey !== originThreadKey),
         );
-        if (reroutedToGroup && groupTarget) {
+        if (plan.shouldOpenGroup && groupTarget) {
           navigate(`/app/g/${groupTarget}`);
           return;
         }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -24,7 +24,6 @@ import {
   CreateScratchpadItemInput,
   DeploymentSettingsSchema,
   ExportManifestSchema,
-  GROUP_MEMBER_MAX,
   GroupDetailSchema,
   GroupSchema,
   McpServerConfigInput,
@@ -79,11 +78,22 @@ const threadTarget = z
     }
   });
 
+const structuredMentionTarget = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("bot"), id: Id }),
+  z.object({ kind: z.literal("group"), id: Id }),
+  z.object({ kind: z.literal("routine"), id: Id }),
+  z.object({ kind: z.literal("connector"), id: Id }),
+]);
+
 const threadSendInput = threadTarget
   .safeExtend({
     text: z.string().optional(),
     artifactIds: z.array(Id).max(ATTACHMENT_MAX_COUNT).optional(),
-    mentions: z.array(Id).max(GROUP_MEMBER_MAX).optional(),
+    /** Bare bot ids (legacy) or typed mention chips from the composer. */
+    mentions: z
+      .array(z.union([Id, structuredMentionTarget]))
+      .max(64)
+      .optional(),
     replyToMessageId: Id.optional(),
     clientNonce: z.string().min(1).max(200).optional(),
   })
@@ -300,7 +310,14 @@ export const appContract = {
       )
       .output(RoutineSchema),
     remove: oc.input(z.object({ routineId: Id })).output(z.object({ ok: z.literal(true) })),
-    testRun: oc.input(z.object({ routineId: Id })).output(z.object({ runId: Id })),
+    testRun: oc
+      .input(
+        z.object({
+          routineId: Id,
+          clientNonce: z.string().min(1).max(200).optional(),
+        }),
+      )
+      .output(z.object({ runId: Id })),
   },
   scratchpad: {
     list: oc

--- a/packages/core/src/composer-mentions.test.ts
+++ b/packages/core/src/composer-mentions.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  appendConnectorIntent,
+  buildComposerMentionOptions,
+  connectorIntentLine,
+  mentionChipKey,
+  partitionComposerMentions,
+  routineScheduleSubtitle,
+  stripMentionKinds,
+  stripMentionToken,
+  toThreadMentionPayload,
+} from "./composer-mentions.js";
+
+describe("buildComposerMentionOptions", () => {
+  it("lists bots groups routines connectors and everyone", () => {
+    const options = buildComposerMentionOptions({
+      query: "",
+      includeEveryone: true,
+      bots: [{ id: "b1", name: "Chief", color: "#111" }],
+      groups: [{ id: "g1", name: "Planning" }],
+      routines: [
+        { id: "r1", name: "Daily digest", crons: ["0 9 * * 1-5"], botId: "b1", botName: "Chief" },
+      ],
+      connectors: [
+        { id: "c1", name: "Gmail", authStatus: "connected", connectionId: "c1" },
+        { id: "catalog:stripe", name: "Stripe", authStatus: "needs_auth" },
+      ],
+    });
+    expect(options.map((option) => option.kind)).toEqual([
+      "everyone",
+      "bot",
+      "group",
+      "routine",
+      "connector",
+      "connector",
+    ]);
+    expect(options.find((option) => option.kind === "bot")?.subtitle).toBe("Bot");
+    expect(options.find((option) => option.name === "Gmail")?.subtitle).toBe("Connected");
+    expect(options.find((option) => option.name === "Stripe")?.subtitle).toBe("Needs auth");
+    expect(options.find((option) => option.kind === "routine")?.subtitle).toMatch(/Weekdays/i);
+  });
+
+  it("disambiguates same-name routines with bot name", () => {
+    const options = buildComposerMentionOptions({
+      query: "daily",
+      bots: [],
+      groups: [],
+      routines: [
+        { id: "r1", name: "Daily", crons: ["0 9 * * *"], botId: "b1", botName: "Chief" },
+        { id: "r2", name: "Daily", crons: ["0 10 * * *"], botId: "b2", botName: "Writer" },
+      ],
+      connectors: [],
+    });
+    expect(options).toHaveLength(2);
+    expect(options[0]?.subtitle).toContain("Chief");
+    expect(options[1]?.subtitle).toContain("Writer");
+    expect(mentionChipKey(options[0]!)).toBe("routine:r1");
+    expect(mentionChipKey(options[1]!)).toBe("routine:r2");
+  });
+
+  it("skips the current group", () => {
+    const options = buildComposerMentionOptions({
+      query: "",
+      currentGroupId: "g1",
+      bots: [],
+      groups: [
+        { id: "g1", name: "Here" },
+        { id: "g2", name: "Elsewhere" },
+      ],
+      routines: [],
+      connectors: [],
+    });
+    expect(options.map((option) => option.id)).toEqual(["g2"]);
+  });
+});
+
+describe("partition and payload", () => {
+  it("partitions typed mentions", () => {
+    const parts = partitionComposerMentions([
+      { kind: "bot", id: "b1", name: "Chief" },
+      { kind: "group", id: "g1", name: "Planning" },
+      { kind: "routine", id: "r1", name: "Digest" },
+      { kind: "connector", id: "c1", name: "Gmail", authStatus: "connected", connectionId: "c1" },
+      { kind: "everyone", id: "everyone", name: "everyone" },
+    ]);
+    expect(parts.bots).toHaveLength(1);
+    expect(parts.groups).toHaveLength(1);
+    expect(parts.routines).toHaveLength(1);
+    expect(parts.connectors).toHaveLength(1);
+    expect(parts.everyone).toBe(true);
+  });
+
+  it("omits needs-auth catalog connectors from API payload", () => {
+    expect(
+      toThreadMentionPayload([
+        { kind: "bot", id: "b1", name: "Chief" },
+        {
+          kind: "connector",
+          id: "catalog:stripe",
+          name: "Stripe",
+          authStatus: "needs_auth",
+        },
+        {
+          kind: "connector",
+          id: "c1",
+          name: "Gmail",
+          authStatus: "connected",
+          connectionId: "c1",
+        },
+      ]),
+    ).toEqual([
+      { kind: "bot", id: "b1" },
+      { kind: "connector", id: "c1" },
+    ]);
+  });
+});
+
+describe("strip and connector intent", () => {
+  it("strips selected mention kinds from prompt text", () => {
+    expect(
+      stripMentionKinds(
+        "@Planning @Chief check this",
+        [
+          { kind: "group", name: "Planning" },
+          { kind: "bot", name: "Chief" },
+        ],
+        ["group"],
+      ),
+    ).toBe("@Chief check this");
+  });
+
+  it("strips multi-word mention tokens", () => {
+    expect(stripMentionToken("Ask @Draft team please", "Draft team")).toBe("Ask please");
+  });
+
+  it("builds connector intent lines", () => {
+    expect(connectorIntentLine(["Gmail", "Stripe"])).toBe(
+      "Use these connectors if relevant: Gmail, Stripe.",
+    );
+    expect(appendConnectorIntent("check inbox", ["Gmail"])).toBe(
+      "check inbox\n\nUse these connectors if relevant: Gmail.",
+    );
+    expect(appendConnectorIntent("", ["Gmail"])).toBe("Use these connectors if relevant: Gmail.");
+  });
+
+  it("formats routine subtitles", () => {
+    expect(routineScheduleSubtitle(["0 9 * * 1-5"])).toMatch(/Weekdays/i);
+    expect(routineScheduleSubtitle(["0 9 * * 1-5"], "Chief")).toContain("Chief");
+  });
+});

--- a/packages/core/src/composer-mentions.test.ts
+++ b/packages/core/src/composer-mentions.test.ts
@@ -117,7 +117,6 @@ describe("resolveComposerSendPlan", () => {
       text: "@Planning",
       mentions: [{ kind: "group", id: "g1", name: "Planning" }],
       hasAttachments: false,
-      alreadyInGroup: false,
     });
     expect(plan.isNoOp).toBe(false);
     expect(plan.shouldSend).toBe(false);
@@ -131,7 +130,6 @@ describe("resolveComposerSendPlan", () => {
       text: "@Planning follow up",
       mentions: [{ kind: "group", id: "g1", name: "Planning" }],
       hasAttachments: false,
-      alreadyInGroup: false,
     });
     expect(plan.shouldSend).toBe(true);
     expect(plan.shouldOpenGroup).toBe(true);
@@ -146,7 +144,6 @@ describe("resolveComposerSendPlan", () => {
         { kind: "routine", id: "r1", name: "Digest" },
       ],
       hasAttachments: false,
-      alreadyInGroup: false,
     });
     expect(plan.shouldRunRoutines).toBe(true);
     expect(plan.routineIds).toEqual(["r1"]);
@@ -155,15 +152,16 @@ describe("resolveComposerSendPlan", () => {
     expect(plan.isNoOp).toBe(false);
   });
 
-  it("does not reroute when already in a group thread", () => {
+  it("opens another group from inside a group thread", () => {
     const plan = resolveComposerSendPlan({
       text: "@Other",
       mentions: [{ kind: "group", id: "g2", name: "Other" }],
       hasAttachments: false,
-      alreadyInGroup: true,
     });
-    expect(plan.shouldOpenGroup).toBe(false);
-    expect(plan.isNoOp).toBe(true);
+    expect(plan.shouldOpenGroup).toBe(true);
+    expect(plan.rerouteGroupId).toBe("g2");
+    expect(plan.shouldSend).toBe(false);
+    expect(plan.isNoOp).toBe(false);
   });
 });
 

--- a/packages/core/src/composer-mentions.test.ts
+++ b/packages/core/src/composer-mentions.test.ts
@@ -226,6 +226,11 @@ describe("strip and connector intent", () => {
     expect(stripMentionToken("Ask @Draft team please", "Draft team")).toBe("Ask please");
   });
 
+  it("preserves newlines when stripping mention tokens", () => {
+    expect(stripMentionToken("@Planning\n\nline two", "Planning")).toBe("line two");
+    expect(stripMentionToken("one\n@Planning\ntwo", "Planning")).toBe("one\n\ntwo");
+  });
+
   it("builds connector intent lines", () => {
     expect(connectorIntentLine(["Gmail", "Stripe"])).toBe(
       "Use these connectors if relevant: Gmail, Stripe.",

--- a/packages/core/src/composer-mentions.test.ts
+++ b/packages/core/src/composer-mentions.test.ts
@@ -6,6 +6,7 @@ import {
   connectorIntentLine,
   mentionChipKey,
   partitionComposerMentions,
+  resolveComposerSendPlan,
   routineScheduleSubtitle,
   stripMentionKinds,
   stripMentionToken,
@@ -72,6 +73,97 @@ describe("buildComposerMentionOptions", () => {
       connectors: [],
     });
     expect(options.map((option) => option.id)).toEqual(["g2"]);
+  });
+
+  it("filters by query before applying limit so later kinds stay reachable", () => {
+    const bots = Array.from({ length: 40 }, (_, index) => ({
+      id: `b${index}`,
+      name: `Bot${index}`,
+    }));
+    const options = buildComposerMentionOptions({
+      query: "gmail",
+      bots,
+      groups: [],
+      routines: [],
+      connectors: [
+        { id: "c1", name: "Gmail", authStatus: "connected", connectionId: "c1" },
+        { id: "c2", name: "Granola", authStatus: "needs_auth" },
+      ],
+      limit: 10,
+    });
+    expect(options.map((option) => option.name)).toEqual(["Gmail"]);
+  });
+
+  it("returns the full catalog when limit is omitted", () => {
+    const bots = Array.from({ length: 80 }, (_, index) => ({
+      id: `b${index}`,
+      name: `Bot${index}`,
+    }));
+    const options = buildComposerMentionOptions({
+      query: "",
+      bots,
+      groups: [],
+      routines: [],
+      connectors: [{ id: "c1", name: "Gmail", authStatus: "connected", connectionId: "c1" }],
+    });
+    expect(options).toHaveLength(81);
+    expect(options.at(-1)?.name).toBe("Gmail");
+  });
+});
+
+describe("resolveComposerSendPlan", () => {
+  it("opens a chip-only @Group from a 1:1 without sending", () => {
+    const plan = resolveComposerSendPlan({
+      text: "@Planning",
+      mentions: [{ kind: "group", id: "g1", name: "Planning" }],
+      hasAttachments: false,
+      alreadyInGroup: false,
+    });
+    expect(plan.isNoOp).toBe(false);
+    expect(plan.shouldSend).toBe(false);
+    expect(plan.shouldOpenGroup).toBe(true);
+    expect(plan.rerouteGroupId).toBe("g1");
+    expect(plan.trimmed).toBe("");
+  });
+
+  it("sends leftover text into the mentioned group", () => {
+    const plan = resolveComposerSendPlan({
+      text: "@Planning follow up",
+      mentions: [{ kind: "group", id: "g1", name: "Planning" }],
+      hasAttachments: false,
+      alreadyInGroup: false,
+    });
+    expect(plan.shouldSend).toBe(true);
+    expect(plan.shouldOpenGroup).toBe(true);
+    expect(plan.trimmed).toBe("follow up");
+  });
+
+  it("runs routines then opens the group when both chips have no text", () => {
+    const plan = resolveComposerSendPlan({
+      text: "@Planning @Digest",
+      mentions: [
+        { kind: "group", id: "g1", name: "Planning" },
+        { kind: "routine", id: "r1", name: "Digest" },
+      ],
+      hasAttachments: false,
+      alreadyInGroup: false,
+    });
+    expect(plan.shouldRunRoutines).toBe(true);
+    expect(plan.routineIds).toEqual(["r1"]);
+    expect(plan.shouldOpenGroup).toBe(true);
+    expect(plan.shouldSend).toBe(false);
+    expect(plan.isNoOp).toBe(false);
+  });
+
+  it("does not reroute when already in a group thread", () => {
+    const plan = resolveComposerSendPlan({
+      text: "@Other",
+      mentions: [{ kind: "group", id: "g2", name: "Other" }],
+      hasAttachments: false,
+      alreadyInGroup: true,
+    });
+    expect(plan.shouldOpenGroup).toBe(false);
+    expect(plan.isNoOp).toBe(true);
   });
 });
 

--- a/packages/core/src/composer-mentions.ts
+++ b/packages/core/src/composer-mentions.ts
@@ -1,0 +1,230 @@
+import { formatCron } from "./cron.js";
+import { hasMentionToken } from "./group-mentions.js";
+
+export const COMPOSER_MENTION_KINDS = ["bot", "group", "routine", "connector", "everyone"] as const;
+
+export type ComposerMentionKind = (typeof COMPOSER_MENTION_KINDS)[number];
+
+/** Chip selected in the composer `@` picker. */
+export type ComposerMention = {
+  kind: ComposerMentionKind;
+  id: string;
+  name: string;
+  subtitle?: string;
+  color?: string;
+  /** Owning bot for routine chips (test-run lands on that bot). */
+  botId?: string;
+  /** Connected connection row id when kind is connector + connected. */
+  connectionId?: string;
+  authStatus?: "connected" | "needs_auth";
+};
+
+export type MentionPickerBot = { id: string; name: string; color?: string };
+export type MentionPickerGroup = { id: string; name: string };
+export type MentionPickerRoutine = {
+  id: string;
+  name: string;
+  crons: string[];
+  botId: string;
+  botName?: string;
+};
+export type MentionPickerConnector = {
+  id: string;
+  name: string;
+  authStatus: "connected" | "needs_auth";
+  connectionId?: string;
+};
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function mentionChipKey(mention: Pick<ComposerMention, "kind" | "id">): string {
+  return `${mention.kind}:${mention.id}`;
+}
+
+export function stripMentionToken(text: string, mentionName: string): string {
+  const normalized = mentionName.trim();
+  if (!normalized) return text.trim();
+  const pattern = new RegExp(
+    `(^|[^\\p{L}\\p{N}_-])@${escapeRegExp(normalized)}(?![\\p{L}\\p{N}_-])`,
+    "giu",
+  );
+  return text
+    .replace(pattern, (_match, prefix: string) => prefix ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function stripMentionKinds(
+  text: string,
+  mentions: readonly Pick<ComposerMention, "kind" | "name">[],
+  kinds: readonly ComposerMentionKind[],
+): string {
+  let result = text;
+  for (const mention of mentions) {
+    if (kinds.includes(mention.kind)) {
+      result = stripMentionToken(result, mention.name);
+    }
+  }
+  return result.trim();
+}
+
+export function partitionComposerMentions(mentions: readonly ComposerMention[]) {
+  const bots: ComposerMention[] = [];
+  const groups: ComposerMention[] = [];
+  const routines: ComposerMention[] = [];
+  const connectors: ComposerMention[] = [];
+  let everyone = false;
+  for (const mention of mentions) {
+    if (mention.kind === "bot") bots.push(mention);
+    else if (mention.kind === "group") groups.push(mention);
+    else if (mention.kind === "routine") routines.push(mention);
+    else if (mention.kind === "connector") connectors.push(mention);
+    else if (mention.kind === "everyone") everyone = true;
+  }
+  return { bots, groups, routines, connectors, everyone };
+}
+
+/** Payload entries for `threads/send` mentions (legacy bare bot ids still accepted). */
+export function toThreadMentionPayload(
+  mentions: readonly ComposerMention[],
+): Array<string | { kind: "bot" | "group" | "routine" | "connector"; id: string }> {
+  const payload: Array<string | { kind: "bot" | "group" | "routine" | "connector"; id: string }> =
+    [];
+  for (const mention of mentions) {
+    if (mention.kind === "everyone") continue;
+    if (mention.kind === "bot") {
+      payload.push({ kind: "bot", id: mention.id });
+      continue;
+    }
+    if (mention.kind === "group") {
+      payload.push({ kind: "group", id: mention.id });
+      continue;
+    }
+    if (mention.kind === "routine") {
+      payload.push({ kind: "routine", id: mention.id });
+      continue;
+    }
+    if (mention.kind === "connector") {
+      const connectionId = mention.connectionId ?? mention.id;
+      if (mention.authStatus === "needs_auth" && !mention.connectionId) continue;
+      if (!connectionId || connectionId.startsWith("catalog:")) continue;
+      payload.push({ kind: "connector", id: connectionId });
+    }
+  }
+  return payload;
+}
+
+export function connectorIntentLine(names: readonly string[]): string {
+  const unique = [...new Set(names.map((name) => name.trim()).filter(Boolean))];
+  if (unique.length === 0) return "";
+  return `Use these connectors if relevant: ${unique.join(", ")}.`;
+}
+
+/** Names that need a client-side connector line (not yet a owned connection row). */
+export function needsAuthConnectorNames(mentions: readonly ComposerMention[]): string[] {
+  return mentions
+    .filter((mention) => mention.kind === "connector" && mention.authStatus === "needs_auth")
+    .map((mention) => mention.name);
+}
+
+export function appendConnectorIntent(text: string, names: readonly string[]): string {
+  const line = connectorIntentLine(names);
+  if (!line) return text.trim();
+  const trimmed = text.trim();
+  return trimmed ? `${trimmed}\n\n${line}` : line;
+}
+
+export function routineScheduleSubtitle(crons: readonly string[], botName?: string): string {
+  const schedule = crons.map((cron) => formatCron(cron)).join(" · ");
+  if (botName?.trim()) return `${schedule} · ${botName.trim()}`;
+  return schedule;
+}
+
+export function buildComposerMentionOptions(input: {
+  query: string;
+  bots: readonly MentionPickerBot[];
+  groups: readonly MentionPickerGroup[];
+  routines: readonly MentionPickerRoutine[];
+  connectors: readonly MentionPickerConnector[];
+  currentGroupId?: string | null;
+  includeEveryone?: boolean;
+  limit?: number;
+}): ComposerMention[] {
+  const query = input.query.trim().toLowerCase();
+  const limit = input.limit ?? 12;
+  const options: ComposerMention[] = [];
+
+  const matches = (name: string) => !query || name.toLowerCase().startsWith(query);
+
+  if (input.includeEveryone && matches("everyone")) {
+    options.push({
+      kind: "everyone",
+      id: "everyone",
+      name: "everyone",
+      subtitle: "Everyone in this group",
+      color: "#85858A",
+    });
+  }
+
+  for (const bot of input.bots) {
+    if (!matches(bot.name)) continue;
+    options.push({
+      kind: "bot",
+      id: bot.id,
+      name: bot.name,
+      subtitle: "Bot",
+      color: bot.color,
+    });
+  }
+
+  for (const group of input.groups) {
+    if (input.currentGroupId && group.id === input.currentGroupId) continue;
+    if (!matches(group.name)) continue;
+    options.push({
+      kind: "group",
+      id: group.id,
+      name: group.name,
+      subtitle: "Group",
+    });
+  }
+
+  const routineNameCounts = new Map<string, number>();
+  for (const routine of input.routines) {
+    const key = routine.name.toLowerCase();
+    routineNameCounts.set(key, (routineNameCounts.get(key) ?? 0) + 1);
+  }
+  for (const routine of input.routines) {
+    if (!matches(routine.name)) continue;
+    const duplicate = (routineNameCounts.get(routine.name.toLowerCase()) ?? 0) > 1;
+    options.push({
+      kind: "routine",
+      id: routine.id,
+      name: routine.name,
+      botId: routine.botId,
+      subtitle: routineScheduleSubtitle(routine.crons, duplicate ? routine.botName : undefined),
+    });
+  }
+
+  for (const connector of input.connectors) {
+    if (!matches(connector.name)) continue;
+    options.push({
+      kind: "connector",
+      id: connector.id,
+      name: connector.name,
+      connectionId: connector.connectionId,
+      authStatus: connector.authStatus,
+      subtitle: connector.authStatus === "connected" ? "Connected" : "Needs auth",
+    });
+  }
+
+  return options.slice(0, limit);
+}
+
+export function mentionStillInPrompt(
+  text: string,
+  mention: Pick<ComposerMention, "name">,
+): boolean {
+  return hasMentionToken(text, mention.name);
+}

--- a/packages/core/src/composer-mentions.ts
+++ b/packages/core/src/composer-mentions.ts
@@ -226,15 +226,14 @@ export function buildComposerMentionOptions(input: {
 
 /**
  * Shared send routing for web + mobile composers.
- * Chip-only `@Group` from a 1:1 opens that group (no fabricated body).
- * Routines always test-run; with a group chip, open the group after.
+ * Chip-only `@Group` opens that group (no fabricated body), including from
+ * another group thread. Routines always test-run; with a group chip, open after.
+ * Callers should omit the current group from the picker (`currentGroupId`).
  */
 export function resolveComposerSendPlan(input: {
   text: string;
   mentions: readonly ComposerMention[];
   hasAttachments: boolean;
-  /** True when the composer is already inside a group thread. */
-  alreadyInGroup: boolean;
 }): {
   trimmed: string;
   routineIds: string[];
@@ -247,7 +246,7 @@ export function resolveComposerSendPlan(input: {
   isNoOp: boolean;
 } {
   const parts = partitionComposerMentions(input.mentions);
-  const mentionedGroup = input.alreadyInGroup ? undefined : parts.groups[0];
+  const mentionedGroup = parts.groups[0];
   let trimmed = stripMentionKinds(input.text.trim(), input.mentions, [
     "group",
     "routine",

--- a/packages/core/src/composer-mentions.ts
+++ b/packages/core/src/composer-mentions.ts
@@ -52,7 +52,8 @@ export function stripMentionToken(text: string, mentionName: string): string {
   );
   return text
     .replace(pattern, (_match, prefix: string) => prefix ?? "")
-    .replace(/\s+/g, " ")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/[^\S\n]*\n/g, "\n")
     .trim();
 }
 

--- a/packages/core/src/composer-mentions.ts
+++ b/packages/core/src/composer-mentions.ts
@@ -150,10 +150,10 @@ export function buildComposerMentionOptions(input: {
   connectors: readonly MentionPickerConnector[];
   currentGroupId?: string | null;
   includeEveryone?: boolean;
+  /** When omitted, return every match (catalog build). When set, apply after query filter. */
   limit?: number;
 }): ComposerMention[] {
   const query = input.query.trim().toLowerCase();
-  const limit = input.limit ?? 12;
   const options: ComposerMention[] = [];
 
   const matches = (name: string) => !query || name.toLowerCase().startsWith(query);
@@ -219,7 +219,60 @@ export function buildComposerMentionOptions(input: {
     });
   }
 
-  return options.slice(0, limit);
+  if (input.limit == null) return options;
+  return options.slice(0, input.limit);
+}
+
+/**
+ * Shared send routing for web + mobile composers.
+ * Chip-only `@Group` from a 1:1 opens that group (no fabricated body).
+ * Routines always test-run; with a group chip, open the group after.
+ */
+export function resolveComposerSendPlan(input: {
+  text: string;
+  mentions: readonly ComposerMention[];
+  hasAttachments: boolean;
+  /** True when the composer is already inside a group thread. */
+  alreadyInGroup: boolean;
+}): {
+  trimmed: string;
+  routineIds: string[];
+  rerouteGroupId: string | null;
+  rerouteGroupName: string | null;
+  mentionPayload: ReturnType<typeof toThreadMentionPayload>;
+  shouldSend: boolean;
+  shouldOpenGroup: boolean;
+  shouldRunRoutines: boolean;
+  isNoOp: boolean;
+} {
+  const parts = partitionComposerMentions(input.mentions);
+  const mentionedGroup = input.alreadyInGroup ? undefined : parts.groups[0];
+  let trimmed = stripMentionKinds(input.text.trim(), input.mentions, [
+    "group",
+    "routine",
+    "connector",
+  ]);
+  trimmed = appendConnectorIntent(trimmed, needsAuthConnectorNames(input.mentions));
+  if (!trimmed && parts.connectors.length) {
+    trimmed = parts.connectors.map((mention) => `@${mention.name}`).join(" ");
+  }
+  const routineIds = [...new Set(parts.routines.map((routine) => routine.id))];
+  const shouldSend = Boolean(trimmed) || input.hasAttachments;
+  const shouldOpenGroup = Boolean(mentionedGroup);
+  const shouldRunRoutines = routineIds.length > 0;
+  return {
+    trimmed,
+    routineIds,
+    rerouteGroupId: mentionedGroup?.id ?? null,
+    rerouteGroupName: mentionedGroup?.name ?? null,
+    mentionPayload: toThreadMentionPayload(
+      input.mentions.filter((mention) => mention.kind !== "group" && mention.kind !== "routine"),
+    ),
+    shouldSend,
+    shouldOpenGroup,
+    shouldRunRoutines,
+    isNoOp: !shouldSend && !shouldOpenGroup && !shouldRunRoutines,
+  };
 }
 
 export function mentionStillInPrompt(

--- a/packages/core/src/group-mentions.test.ts
+++ b/packages/core/src/group-mentions.test.ts
@@ -71,6 +71,16 @@ describe("resolveGroupTargetBotIds", () => {
     ).toEqual(["research", "edit", "anna"]);
   });
 
+  it("ignores explicit mentions for bots that are not group members", () => {
+    expect(
+      resolveGroupTargetBotIds({
+        text: "hello",
+        members,
+        explicitMentions: ["b", "outsider"],
+      }),
+    ).toEqual(["b"]);
+  });
+
   it("picks the first member when unmentioned", () => {
     expect(
       resolveGroupTargetBotIds({

--- a/packages/core/src/group-mentions.ts
+++ b/packages/core/src/group-mentions.ts
@@ -30,12 +30,14 @@ export function parseMentionNames(text: string): string[] {
 export function resolveGroupTargetBotIds(input: {
   text: string;
   members: GroupMemberRef[];
+  /** Bot ids from typed mention chips (non-members are ignored for wake). */
   explicitMentions?: string[];
 }): string[] {
   const membersById = new Map(input.members.map((member) => [member.id, member]));
   const targetIds = new Set<string>();
 
   for (const mentionId of input.explicitMentions ?? []) {
+    // Out-of-chat bots stay as @Name in the prompt; only members are woken here.
     if (membersById.has(mentionId)) targetIds.add(mentionId);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./attachments.js";
 export * from "./bot-messages.js";
 export * from "./bot-sections.js";
 export * from "./compose-update.js";
+export * from "./composer-mentions.js";
 export * from "./composer-slash.js";
 export * from "./cron.js";
 

--- a/packages/testkit/src/mention-targets.test.ts
+++ b/packages/testkit/src/mention-targets.test.ts
@@ -1,0 +1,350 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ComposioEmulator } from "@rakazo/adapters";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { sessionCookieHeader } from "./index.js";
+
+type App = { request: (input: string, init?: RequestInit) => Promise<Response> };
+type AppHandles = Awaited<ReturnType<typeof import("../../../apps/api/src/app.ts").createApp>>;
+
+process.env.WAKEUP_DRIVER = "memory";
+process.env.SANDBOX_PROVIDER = "fake";
+process.env.AGENT_RUNTIME = "scripted";
+
+const hasDb = process.env.VERIFY_DATABASE === "1" && Boolean(process.env.DATABASE_URL);
+const describeWithDatabase = hasDb ? describe : describe.skip;
+
+describeWithDatabase("structured @ mention targets", () => {
+  let handles: AppHandles;
+  let app: App;
+  let prisma: AppHandles["prisma"];
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const dataDir = mkdtempSync(path.join(tmpdir(), "rakazo-mention-targets-"));
+
+  beforeAll(async () => {
+    const { createApp } = await import("../../../apps/api/src/app.ts");
+    handles = await createApp({
+      databaseUrl: process.env.DATABASE_URL!,
+      dataDir,
+      sandboxProvider: "fake",
+      agentRuntime: "scripted",
+      composio: new ComposioEmulator(),
+      signupsEnabled: "true",
+    });
+    app = handles.app;
+    prisma = handles.prisma;
+  });
+
+  afterAll(async () => {
+    await handles?.stop();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("starts a routine test run on the owning bot", async () => {
+    const cookie = await signup(app, `mention-routine-${stamp}@rakazo.test`, "Routine Owner");
+    const bot = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Chief",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const routine = await rpc<{ id: string }>(app, cookie, "routines/create", {
+      botId: bot.id,
+      name: "Daily digest",
+      prompt: "Summarize inbox",
+      crons: ["0 9 * * 1"],
+      timezone: "UTC",
+      notify: false,
+      active: false,
+    });
+    const tested = await rpc<{ runId: string }>(app, cookie, "routines/testRun", {
+      routineId: routine.id,
+    });
+    const run = await prisma.run.findUniqueOrThrow({ where: { id: tested.runId } });
+    expect(run.botId).toBe(bot.id);
+    expect(run.trigger).toBe("routine");
+  });
+
+  it("replays routine testRun with the same clientNonce", async () => {
+    const cookie = await signup(app, `mention-routine-replay-${stamp}@rakazo.test`, "Replay Owner");
+    const bot = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "ReplayBot",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const routine = await rpc<{ id: string }>(app, cookie, "routines/create", {
+      botId: bot.id,
+      name: "Replay digest",
+      prompt: "Replay inbox",
+      crons: ["0 9 * * 1"],
+      timezone: "UTC",
+      notify: false,
+      active: false,
+    });
+    const nonce = `routine-mention:${stamp}:replay`;
+    const first = await rpc<{ runId: string }>(app, cookie, "routines/testRun", {
+      routineId: routine.id,
+      clientNonce: nonce,
+    });
+    const second = await rpc<{ runId: string }>(app, cookie, "routines/testRun", {
+      routineId: routine.id,
+      clientNonce: nonce,
+    });
+    expect(second.runId).toBe(first.runId);
+    expect(
+      await prisma.run.count({
+        where: { clientNonce: `routine-test:${nonce}` },
+      }),
+    ).toBe(1);
+  });
+
+  it("includes connector intent on a 1:1 send prompt", async () => {
+    const cookie = await signup(app, `mention-connector-${stamp}@rakazo.test`, "Connector Owner");
+    const bot = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Chief",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const started = await rpc<{ connectionId: string }>(app, cookie, "connections/begin", {
+      provider: "gmail",
+      displayName: "Gmail",
+    });
+    await rpc(app, cookie, "connections/complete", { connectionId: started.connectionId });
+
+    const sent = await rpc<{ runId: string }>(app, cookie, "threads/send", {
+      botId: bot.id,
+      text: "check my email",
+      mentions: [{ kind: "connector", id: started.connectionId }],
+    });
+    const run = await prisma.run.findUniqueOrThrow({
+      where: { id: sent.runId },
+      include: { task: true },
+    });
+    expect(run.task.prompt).toContain("Use these connectors if relevant: Gmail");
+  });
+
+  it("lands a group-targeted send in the group transcript, not the 1:1 bot thread", async () => {
+    const cookie = await signup(app, `mention-group-${stamp}@rakazo.test`, "Group Owner");
+    const botA = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "BotA",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const botB = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "BotB",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const group = await rpc<{ id: string; threadId: string }>(app, cookie, "groups/create", {
+      name: "Planning",
+      botIds: [botA.id, botB.id],
+    });
+    const messageText = "follow up from 1:1 reroute";
+    await rpc(app, cookie, "threads/send", {
+      groupId: group.id,
+      text: messageText,
+    });
+    const groupSnap = await rpc<{
+      messages: Array<{ blocks: Array<{ kind: string; text?: string }> }>;
+    }>(app, cookie, "threads/get", { groupId: group.id });
+    const botSnap = await rpc<{
+      messages: Array<{ blocks: Array<{ kind: string; text?: string }> }>;
+    }>(app, cookie, "threads/get", { botId: botA.id });
+    const groupHasMessage = groupSnap.messages.some((message) =>
+      message.blocks.some((block) => block.kind === "text" && block.text?.includes(messageText)),
+    );
+    const botHasMessage = botSnap.messages.some((message) =>
+      message.blocks.some((block) => block.kind === "text" && block.text?.includes(messageText)),
+    );
+    expect(groupHasMessage).toBe(true);
+    expect(botHasMessage).toBe(false);
+  });
+
+  it("wakes exactly one bot on an unmentioned group send", async () => {
+    const cookie = await signup(app, `mention-group-default-${stamp}@rakazo.test`, "Group Default");
+    const botA = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "BotA",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const botB = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "BotB",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const group = await rpc<{ id: string; threadId: string }>(app, cookie, "groups/create", {
+      name: "Squad",
+      botIds: [botA.id, botB.id],
+    });
+    const before = await prisma.run.count({
+      where: { threadId: group.threadId, trigger: "user" },
+    });
+    await rpc(app, cookie, "threads/send", { groupId: group.id, text: "hello team" });
+    const after = await prisma.run.count({
+      where: { threadId: group.threadId, trigger: "user" },
+    });
+    expect(after - before).toBe(1);
+  });
+
+  it("wakes a mentioned group member from typed bot chips and ignores non-members", async () => {
+    const cookie = await signup(app, `mention-out-${stamp}@rakazo.test`, "Out Of Chat");
+    const botA = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "MemberA",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const botB = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "MemberB",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const outsider = await rpc<{ id: string }>(app, cookie, "bots/create", {
+      name: "Outsider",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const group = await rpc<{ id: string; threadId: string }>(app, cookie, "groups/create", {
+      name: "Core",
+      botIds: [botA.id, botB.id],
+    });
+    const sent = await rpc<{ runId: string; runIds?: string[] }>(app, cookie, "threads/send", {
+      groupId: group.id,
+      text: "@MemberB @Outsider please review",
+      mentions: [
+        { kind: "bot", id: botB.id },
+        { kind: "bot", id: outsider.id },
+      ],
+    });
+    const runIds = sent.runIds ?? [sent.runId];
+    const runs = await prisma.run.findMany({
+      where: { id: { in: runIds } },
+      select: { botId: true },
+    });
+    expect(runs.map((run) => run.botId).sort()).toEqual([botB.id].sort());
+  });
+
+  it("rejects another user's routine, connection, and group mentions", async () => {
+    const ada = await signup(app, `mention-auth-ada-${stamp}@rakazo.test`, "Ada Auth");
+    const bob = await signup(app, `mention-auth-bob-${stamp}@rakazo.test`, "Bob Auth");
+    const adaBot = await rpc<{ id: string }>(app, ada, "bots/create", {
+      name: "AdaBot",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const bobBot = await rpc<{ id: string }>(app, bob, "bots/create", {
+      name: "BobBot",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const adaBotB = await rpc<{ id: string }>(app, ada, "bots/create", {
+      name: "AdaBotB",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const routine = await rpc<{ id: string }>(app, ada, "routines/create", {
+      botId: adaBot.id,
+      name: "Private routine",
+      prompt: "do work",
+      crons: ["0 9 * * 1"],
+      timezone: "UTC",
+      notify: false,
+      active: false,
+    });
+    const started = await rpc<{ connectionId: string }>(app, ada, "connections/begin", {
+      provider: "gmail",
+      displayName: "Gmail",
+    });
+    await rpc(app, ada, "connections/complete", { connectionId: started.connectionId });
+    const group = await rpc<{ id: string }>(app, ada, "groups/create", {
+      name: "Ada group",
+      botIds: [adaBot.id, adaBotB.id],
+    });
+
+    const routineAttempt = await raw(app, bob, "routines/testRun", { routineId: routine.id });
+    expect(routineAttempt.status).toBeGreaterThanOrEqual(400);
+
+    const connectionAttempt = await raw(app, bob, "threads/send", {
+      botId: bobBot.id,
+      text: "use connector",
+      mentions: [{ kind: "connector", id: started.connectionId }],
+    });
+    expect(connectionAttempt.status).toBeGreaterThanOrEqual(400);
+
+    const groupAttempt = await raw(app, bob, "threads/send", {
+      groupId: group.id,
+      text: "intrude",
+    });
+    expect(groupAttempt.status).toBeGreaterThanOrEqual(400);
+
+    const routineRuns = await prisma.run.count({ where: { botId: adaBot.id, trigger: "routine" } });
+    expect(routineRuns).toBe(0);
+  });
+});
+
+async function signup(app: App, email: string, name: string) {
+  const res = await app.request("/api/auth/sign-up/email", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "http://127.0.0.1:5173",
+    },
+    body: JSON.stringify({ email, password: "password12", name }),
+  });
+  if (res.status >= 400) {
+    throw new Error(`signup failed ${res.status}: ${await res.text()}`);
+  }
+  return sessionCookieHeader(res);
+}
+
+async function raw(app: App, cookie: string, proc: string, body: unknown = {}) {
+  return app.request(`/rpc/${proc}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie,
+      origin: "http://127.0.0.1:5173",
+    },
+    body: JSON.stringify({ json: body }),
+  });
+}
+
+async function rpc<T>(app: App, cookie: string, proc: string, body: unknown = {}): Promise<T> {
+  const res = await raw(app, cookie, proc, body);
+  const text = await res.text();
+  let parsed: { json?: T; error?: { message?: string } };
+  try {
+    parsed = JSON.parse(text) as { json?: T; error?: { message?: string } };
+  } catch {
+    throw new Error(`${proc} ${res.status}: ${text}`);
+  }
+  if (res.status >= 400 || parsed.error) {
+    throw new Error(`${proc} ${res.status}: ${parsed.error?.message ?? text}`);
+  }
+  return parsed.json as T;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebuilds official Grok Bot–style `@` mentions on the chip composer that already shipped in #193 — not the conflicting regex/scratchpad approach in #165.

Credit to **@bnsd55** for the original attempt and for filing #167.

### What’s different from #165
- Starts from current `main` / chip composer (`selectedMentions` + `serializeComposerPrompt`), not `feat/mention-routines-connectors`.
- No second regex mention system, scratchpad, Board, or Advanced settings leftovers.
- Mentions are typed chips: `bot | group | routine | connector | everyone`, keyed by id (same-name routines no longer collide).
- `connections.list` / catalog failures are caught so the picker cannot blank the app.
- `@Group` from a 1:1 captures destination ids before navigate, then sends into the group and opens that thread (fixes the wrong-thread bug).

### Chip composer extension
- New `packages/core/src/composer-mentions.ts` builds picker options and partitions send behavior.
- Chips still serialize to `@Name` via existing `serializeComposerPrompt`.
- `threads/send` accepts legacy bare bot ids or `{ kind, id }` structured mentions.
- Connected connector mentions append `Use these connectors if relevant: …` on the run prompt (owned connections only).
- Routine chips call existing `routines/testRun` (optional `clientNonce` for replay).
- Out-of-chat bots: taggable from any chat; `@Name` stays in the prompt. In groups, only members are woken (existing `resolveGroupTargetBotIds`); non-members are not auto-added — the woken bot can use `message_bot` / handoff.

### Surfaces
- Web (`Shell` composer) and mobile (`thread`) pickers match: bots (including non-members, labeled Bot), groups, routines (schedule subtitle), connectors (Connected / Needs auth), `@everyone` in groups.

## Test plan
- [x] `pnpm --filter @rakazo/core --filter @rakazo/contracts --filter @rakazo/api --filter @rakazo/web --filter @rakazo/mobile check`
- [x] `pnpm exec vitest run packages/core/src/composer-mentions.test.ts packages/core/src/group-mentions.test.ts`
- [ ] `pnpm exec vitest run packages/testkit/src/mention-targets.test.ts` (needs `VERIFY_DATABASE=1`)
- [ ] Web: `@` in a 1:1 shows all bots / groups / routines / connectors; pick a group → land in that group transcript
- [ ] `@Routine` starts that routine’s test run; `@Connector` send includes connector intent on the prompt
- [ ] Groups: `@everyone` still works; unmentioned send still wakes exactly one bot
- [ ] Mobile composer matches web
- [ ] Cannot mention another user’s routine, connection, or group

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3decb35b-504c-4cf9-99ea-278f95695eec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3decb35b-504c-4cf9-99ea-278f95695eec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mention bots, groups, routines, connectors, and everyone directly from thread composers.
  * Route messages to selected groups and trigger routine test runs from mentions.
  * See clearer mention options with icons, descriptions, filtering, and duplicate disambiguation.
  * Connector mentions can include authorization requests when needed.
* **Bug Fixes**
  * Improved access controls for routines, groups, and connectors.
  * Prevented duplicate routine test runs when requests are retried.
  * Preserved attachment and reply behavior with structured mentions.
  * Normalized connector instructions to remove duplicates.
* **Tests**
  * Added coverage for mention handling, routing, authorization, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->