### PR TITLE
fix(web): ModelPicker keyboard nav with search (#227 follow-up)

### DIFF
--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -746,14 +746,30 @@ function ModelPicker({
   }
 
   function moveHighlight(index: number) {
-    setHighlightedIndex((index + filteredOptions.length) % filteredOptions.length);
+    const count = filteredOptions.length;
+    if (count === 0) return;
+    const next = ((index % count) + count) % count;
+    setHighlightedIndex(next);
+    optionRefs.current[next]?.focus();
   }
 
   function onSearchKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      setHighlightedIndex(0);
-      optionRefs.current[0]?.focus();
+      if (filteredOptions.length === 0) return;
+      const next =
+        highlightedIndex >= 0 && highlightedIndex < filteredOptions.length
+          ? highlightedIndex
+          : 0;
+      moveHighlight(next);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      if (filteredOptions.length === 0) return;
+      const index =
+        highlightedIndex >= 0 && highlightedIndex < filteredOptions.length
+          ? highlightedIndex
+          : 0;
+      choose(index);
     } else if (event.key === "Escape") {
       event.preventDefault();
       setOpen(false);
@@ -775,7 +791,7 @@ function ModelPicker({
     if (event.key === "ArrowUp") {
       event.preventDefault();
       setOpen(true);
-      setHighlightedIndex(filteredOptions.length - 1);
+      setHighlightedIndex(Math.max(0, filteredOptions.length - 1));
     }
   }
 
@@ -788,10 +804,10 @@ function ModelPicker({
       moveHighlight(index - 1);
     } else if (event.key === "Home") {
       event.preventDefault();
-      setHighlightedIndex(0);
+      moveHighlight(0);
     } else if (event.key === "End") {
       event.preventDefault();
-      setHighlightedIndex(filteredOptions.length - 1);
+      moveHighlight(filteredOptions.length - 1);
     } else if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       choose(index);

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -753,23 +753,21 @@ function ModelPicker({
     optionRefs.current[next]?.focus();
   }
 
+  function activeOptionIndex() {
+    return highlightedIndex >= 0 && highlightedIndex < filteredOptions.length
+      ? highlightedIndex
+      : 0;
+  }
+
   function onSearchKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
     if (event.key === "ArrowDown") {
       event.preventDefault();
       if (filteredOptions.length === 0) return;
-      const next =
-        highlightedIndex >= 0 && highlightedIndex < filteredOptions.length
-          ? highlightedIndex
-          : 0;
-      moveHighlight(next);
+      moveHighlight(activeOptionIndex());
     } else if (event.key === "Enter") {
       event.preventDefault();
       if (filteredOptions.length === 0) return;
-      const index =
-        highlightedIndex >= 0 && highlightedIndex < filteredOptions.length
-          ? highlightedIndex
-          : 0;
-      choose(index);
+      choose(activeOptionIndex());
     } else if (event.key === "Escape") {
       event.preventDefault();
       setOpen(false);

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -9,6 +9,7 @@ import { Button } from "@rakazo/ui-web";
 import { ChevronDown } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
   useEffect,
   useId,
   useMemo,
@@ -672,6 +673,7 @@ function ModelPicker({
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const listboxId = useId();
   const selectedIndex = Math.max(
@@ -679,7 +681,39 @@ function ModelPicker({
     options.findIndex((option) => option.id === value),
   );
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const [highlightedIndex, setHighlightedIndex] = useState(selectedIndex);
+  const trimmedQuery = query.trim().toLowerCase();
+  const filteredOptions = useMemo(
+    () =>
+      trimmedQuery
+        ? options.filter(
+            (option) =>
+              option.label.toLowerCase().includes(trimmedQuery) ||
+              option.id.toLowerCase().includes(trimmedQuery) ||
+              (option.providerName ?? option.provider).toLowerCase().includes(trimmedQuery),
+          )
+        : options,
+    [options, trimmedQuery],
+  );
+  const groups = useMemo(() => {
+    const grouped = new Map<string, ModelCatalogEntry[]>();
+    for (const option of filteredOptions) {
+      const key = option.providerName ?? option.provider;
+      const list = grouped.get(key);
+      if (list) list.push(option);
+      else grouped.set(key, [option]);
+    }
+    return [...grouped].map(([name, entries]) => ({ name, entries }));
+  }, [filteredOptions]);
+  const groupRanges = useMemo(() => {
+    let index = 0;
+    return groups.map((group) => {
+      const start = index;
+      index += group.entries.length;
+      return { name: group.name, start, entries: group.entries };
+    });
+  }, [groups]);
 
   useEffect(() => {
     setHighlightedIndex(selectedIndex);
@@ -687,9 +721,12 @@ function ModelPicker({
   }, [selectedIndex, value]);
 
   useEffect(() => {
-    if (!open) return;
-    optionRefs.current[highlightedIndex]?.focus();
-  }, [highlightedIndex, open]);
+    if (!open) {
+      setQuery("");
+      return;
+    }
+    searchRef.current?.focus();
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -701,7 +738,7 @@ function ModelPicker({
   }, [open]);
 
   function choose(index: number) {
-    const option = options[index];
+    const option = filteredOptions[index];
     if (!option) return;
     onChange(option.id);
     setOpen(false);
@@ -709,7 +746,19 @@ function ModelPicker({
   }
 
   function moveHighlight(index: number) {
-    setHighlightedIndex((index + options.length) % options.length);
+    setHighlightedIndex((index + filteredOptions.length) % filteredOptions.length);
+  }
+
+  function onSearchKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlightedIndex(0);
+      optionRefs.current[0]?.focus();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+      triggerRef.current?.focus();
+    }
   }
 
   function onTriggerKeyDown(event: ReactKeyboardEvent<HTMLButtonElement>) {
@@ -726,7 +775,7 @@ function ModelPicker({
     if (event.key === "ArrowUp") {
       event.preventDefault();
       setOpen(true);
-      setHighlightedIndex(options.length - 1);
+      setHighlightedIndex(filteredOptions.length - 1);
     }
   }
 
@@ -742,7 +791,7 @@ function ModelPicker({
       setHighlightedIndex(0);
     } else if (event.key === "End") {
       event.preventDefault();
-      setHighlightedIndex(options.length - 1);
+      setHighlightedIndex(filteredOptions.length - 1);
     } else if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       choose(index);
@@ -773,33 +822,94 @@ function ModelPicker({
         </span>
       </button>
       {open ? (
-        <div
-          id={listboxId}
-          role="listbox"
-          aria-label="Model options"
-          className="rk-scroll absolute left-0 right-0 top-full z-20 mt-2 max-h-60 overflow-y-auto rounded-[11px] border border-[#26262A] bg-[#101012] p-1 shadow-[0_20px_45px_rgba(0,0,0,.55)]"
-        >
-          {options.map((option, index) => (
-            <button
-              key={`${option.provider}:${option.id}`}
-              ref={(element) => {
-                optionRefs.current[index] = element;
-              }}
-              type="button"
-              role="option"
-              aria-selected={option.id === value}
-              tabIndex={index === highlightedIndex ? 0 : -1}
-              className={`w-full rounded-[8px] px-3 py-2 text-start text-[13.5px] text-[#ECECEE] outline-none hover:bg-[#1A1A1D] focus-visible:bg-[#1A1A1D] ${
-                option.id === value ? "bg-[#1A1A1D]" : ""
-              }`}
-              onClick={() => choose(index)}
-              onKeyDown={(event) => onOptionKeyDown(event, index)}
-            >
-              {option.label}
-            </button>
-          ))}
+        <div className="absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-[11px] border border-[#26262A] bg-[#101012] shadow-[0_20px_45px_rgba(0,0,0,.55)]">
+          <input
+            ref={searchRef}
+            type="text"
+            value={query}
+            aria-label="Search models"
+            placeholder="Search"
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setHighlightedIndex(0);
+            }}
+            onKeyDown={onSearchKeyDown}
+            className="w-full border-b border-[#26262A] bg-transparent px-3 py-2.5 text-[13.5px] text-[#ECECEE] outline-none placeholder:text-[#6C6C70]"
+          />
+          <div
+            id={listboxId}
+            role="listbox"
+            aria-label="Model options"
+            className="rk-scroll max-h-64 overflow-y-auto py-1"
+          >
+            {groupRanges.map((group) => (
+              <div key={group.name}>
+                <p className="px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-[0.08em] text-[#6C6C70]">
+                  {group.name}
+                </p>
+                {group.entries.map((option, groupIndex) => {
+                  const index = group.start + groupIndex;
+                  return (
+                    <ModelOption
+                      key={`${option.provider}:${option.id}`}
+                      option={option}
+                      index={index}
+                      value={value}
+                      highlighted={highlightedIndex === index}
+                      optionRefs={optionRefs}
+                      choose={choose}
+                      onOptionKeyDown={onOptionKeyDown}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+            {filteredOptions.length === 0 ? (
+              <p className="px-3 py-2 text-[13px] text-[#85858A]">No matching models</p>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>
+  );
+}
+
+function ModelOption({
+  option,
+  index,
+  value,
+  highlighted,
+  optionRefs,
+  choose,
+  onOptionKeyDown,
+}: {
+  option: ModelCatalogEntry;
+  index: number;
+  value: string;
+  highlighted: boolean;
+  optionRefs: RefObject<Array<HTMLButtonElement | null>>;
+  choose: (index: number) => void;
+  onOptionKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => void;
+}) {
+  return (
+    <button
+      ref={(element) => {
+        optionRefs.current[index] = element;
+      }}
+      type="button"
+      role="option"
+      aria-selected={option.id === value}
+      tabIndex={highlighted ? 0 : -1}
+      className={`flex w-full items-center justify-between gap-3 px-3 py-2 text-start text-[13.5px] text-[#ECECEE] outline-none hover:bg-[#1A1A1D] focus-visible:bg-[#1A1A1D] ${
+        option.id === value ? "bg-[#1A1A1D]" : ""
+      }`}
+      onClick={() => choose(index)}
+      onKeyDown={(event) => onOptionKeyDown(event, index)}
+    >
+      <span className="min-w-0 truncate">{option.label}</span>
+      {option.billing.toLowerCase().includes("free") ? (
+        <span className="shrink-0 text-[12px] text-[#85858A]">Free</span>
+      ) : null}
+    </button>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #227. Could not push onto `mtsogias/rakazo` (`model-picker-search`), so this branch starts from that PR head (`2a7526c`) and adds the keyboard-nav fix.

## Problem
Search was added to `ModelPicker`, and the old effect that focused `optionRefs.current[highlightedIndex]` on highlight/open was removed so the search input can keep focus. Arrow/Home/End on options then only updated highlight state, so keyboard list navigation broke. Also `moveHighlight` used `% filteredOptions.length`, which becomes `NaN` when the filter matches nothing.

## Fix
- `moveHighlight` no-ops when there are zero matches (no modulo-0 / NaN), updates highlight, and focuses the option.
- Option ArrowUp/Down/Home/End go through `moveHighlight` so focus moves with highlight and wraps only when there is at least one option.
- Opening still focuses search; ArrowDown from search moves focus to the highlighted (or first) option; Enter in search chooses the highlighted match when one exists; Escape still closes and returns focus to the trigger.
- Keeps search, provider grouping, Free badge, and empty-state copy unchanged.

## Note for maintainers
Prefer cherry-picking `8b43e82` onto #227 if that PR should remain the merge vehicle; otherwise this PR includes #227’s commit plus the fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53446d61-8e35-46ec-a9d9-7c8749679fbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53446d61-8e35-46ec-a9d9-7c8749679fbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added searchable model selection with options grouped by provider.
  * Added keyboard navigation, Home/End shortcuts, and improved handling when no models match the search.
  * Added clear labels for free models and automatically focuses the search field when opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->