### PR TITLE
fix(api): normalize run routineId to null in thread snapshot

### DIFF
--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -345,7 +345,7 @@ function mapRun(run: {
     taskId: run.taskId,
     status: run.status as never,
     trigger: run.trigger as never,
-    routineId: run.routineId,
+    routineId: run.routineId ?? null,
     modelProvider: run.modelProvider,
     modelId: run.modelId,
     error: run.error,


### PR DESCRIPTION
## Summary

`mapRun` in `apps/api/src/thread-target.ts` could emit `undefined` for `routineId`, but `RunSchema.routineId` requires `string | null`. This caused the `threads.get` output validation to fail with "Output validation failed" after sending a message (the snapshot is reloaded on every send).

## Change

```ts
routineId: run.routineId ?? null,
```

Normalizes `undefined` to `null` so the value matches the schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of runs without an associated routine, ensuring they are represented consistently as `null`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->