### PR TITLE
Reconcile stale pending Composio connections and keep catalog on write failure

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1374,15 +1374,21 @@ export function createRouter(deps: RouterDeps) {
             // A connection can finish on Composio's side after our own completion check gave
             // up (see PluginsOverlay's polling timeout) — reconcile stale "pending" rows here
             // so callers like the run executor, which trust our local status, stay in sync.
-            await deps.prisma.connection.updateMany({
-              where: {
-                workspaceId: context.actor.workspaceId,
-                userId: context.actor.userId,
-                status: "pending",
-                provider: { in: nowConnected },
-              },
-              data: { status: "connected" },
-            });
+            // Best effort: a failed reconciliation write shouldn't blank out an otherwise
+            // successful catalog fetch — the caller still gets accurate, if unreconciled, data.
+            await deps.prisma.connection
+              .updateMany({
+                where: {
+                  workspaceId: context.actor.workspaceId,
+                  userId: context.actor.userId,
+                  status: "pending",
+                  provider: { in: nowConnected },
+                },
+                data: { status: "connected" },
+              })
+              .catch((error) => {
+                console.error("composio pending-connection reconciliation failed", error);
+              });
           }
           return items;
         } catch {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1368,7 +1368,23 @@ export function createRouter(deps: RouterDeps) {
       catalog: authed.connections.catalog.handler(async ({ context, input }) => {
         if (!deps.composio) return [];
         try {
-          return await deps.composio.catalog(context.actor.userId, input.query);
+          const items = await deps.composio.catalog(context.actor.userId, input.query);
+          const nowConnected = items.filter((item) => item.connected).map((item) => item.slug);
+          if (nowConnected.length > 0) {
+            // A connection can finish on Composio's side after our own completion check gave
+            // up (see PluginsOverlay's polling timeout) — reconcile stale "pending" rows here
+            // so callers like the run executor, which trust our local status, stay in sync.
+            await deps.prisma.connection.updateMany({
+              where: {
+                workspaceId: context.actor.workspaceId,
+                userId: context.actor.userId,
+                status: "pending",
+                provider: { in: nowConnected },
+              },
+              data: { status: "connected" },
+            });
+          }
+          return items;
         } catch {
           return [];
         }


### PR DESCRIPTION
## Summary
- Reconcile stale pending Composio connections when the plugin catalog is fetched, so a half-finished connect attempt doesn't linger forever
- Don't blank the plugin catalog when the reconciliation write fails — serve the last good catalog instead

## Test plan
- pnpm vitest run apps/api (22 passed)
- tsc + biome clean for apps/api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Connection records are now automatically marked as connected when matching providers are detected in the catalog.
  - Catalog results remain available even if connection status updates cannot be completed.
  - Provider catalog errors continue to return an empty list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->