### PR TITLE
Interleave tool-call steps into live bot messages, plus streaming UX fixes

### DIFF
--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -327,6 +327,55 @@ describe("thread event reduction", () => {
     ]);
   });
 
+  it("survives a React StrictMode replay of the same event without double-counting", () => {
+    // StrictMode invokes a setState updater twice per event in development to catch impure
+    // updaters — reduceThreadSnapshot(prev, event) must return the same result both times
+    // rather than mutating its pending-tool-call bookkeeping a second time.
+    const initial = snapshot([]);
+    const afterNarration = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.progress",
+        seq: 4,
+        runId: "run-1",
+        payload: { text: "Let me check ", streaming: true },
+      }),
+    );
+    const toolEvent = event({
+      type: "agent.tool.called",
+      seq: 5,
+      runId: "run-1",
+      payload: { name: "SLACK_FIND_CHANNELS" },
+    });
+
+    // The tool call lands mid-sentence, so it's held back rather than flushed immediately —
+    // exactly the state a naive module-level mutation would double-push on replay.
+    const first = reduceThreadSnapshot(afterNarration, toolEvent);
+    const replay = reduceThreadSnapshot(afterNarration, toolEvent);
+    expect(replay).toEqual(first);
+
+    const sentenceEnd = reduceThreadSnapshot(
+      first,
+      event({
+        type: "thread.progress",
+        seq: 6,
+        runId: "run-1",
+        payload: { delta: "Done.", streaming: true },
+      }),
+    );
+
+    // A single tool call, not two — StrictMode's replay must not have pushed it twice.
+    expect(sentenceEnd?.messages).toEqual([
+      expect.objectContaining({
+        id: "progress:run-1",
+        blocks: [
+          { kind: "text", text: "Let me check Done." },
+          { kind: "steps", steps: [{ label: "Slack find channels", count: 1 }] },
+        ],
+      }),
+    ]);
+  });
+
   it("keeps deferring a tool call across several sentence-less deltas", () => {
     const initial = snapshot([]);
 

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -274,7 +274,60 @@ describe("thread event reduction", () => {
     ]);
   });
 
-  it("merges narration and tool calls into one live message in chronological order", () => {
+  it("holds a tool call that lands mid-sentence until the sentence completes", () => {
+    const initial = snapshot([]);
+
+    const afterNarration = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.progress",
+        seq: 4,
+        runId: "run-1",
+        payload: { text: "Let me check Slack ", streaming: true },
+      }),
+    );
+    const afterTool = reduceThreadSnapshot(
+      afterNarration,
+      event({
+        type: "agent.tool.called",
+        seq: 5,
+        runId: "run-1",
+        payload: { name: "SLACK_FIND_CHANNELS" },
+      }),
+    );
+
+    // Still mid-sentence — the tool call stays hidden, folded into the streaming text instead.
+    expect(afterTool?.messages).toEqual([
+      expect.objectContaining({
+        id: "progress:run-1",
+        blocks: [{ kind: "progress", text: "Let me check Slack " }],
+      }),
+    ]);
+
+    const afterMore = reduceThreadSnapshot(
+      afterTool,
+      event({
+        type: "thread.progress",
+        seq: 6,
+        runId: "run-1",
+        payload: { delta: "for a broad search.", streaming: true },
+      }),
+    );
+
+    // The sentence just finished — the completed sentence and the held-back tool call appear
+    // together, in that order.
+    expect(afterMore?.messages).toEqual([
+      expect.objectContaining({
+        id: "progress:run-1",
+        blocks: [
+          { kind: "text", text: "Let me check Slack for a broad search." },
+          { kind: "steps", steps: [{ label: "Slack find channels", count: 1 }] },
+        ],
+      }),
+    ]);
+  });
+
+  it("keeps deferring a tool call across several sentence-less deltas", () => {
     const initial = snapshot([]);
 
     const afterNarration = reduceThreadSnapshot(
@@ -305,57 +358,12 @@ describe("thread event reduction", () => {
       }),
     );
 
+    // No sentence terminator has streamed in yet, so the tool call is still hidden and
+    // everything so far renders as one continuous progress block.
     expect(afterMore?.messages).toEqual([
       expect.objectContaining({
         id: "progress:run-1",
-        blocks: [
-          { kind: "text", text: "Let me check Slack " },
-          { kind: "steps", steps: [{ label: "Slack find channels", count: 1 }] },
-          { kind: "progress", text: "Found it, now sanding" },
-        ],
-      }),
-    ]);
-  });
-
-  it("holds back a partial trailing word across a tool call instead of splitting it", () => {
-    const initial = snapshot([]);
-
-    const afterNarration = reduceThreadSnapshot(
-      initial,
-      event({
-        type: "thread.progress",
-        seq: 4,
-        runId: "run-1",
-        payload: { text: "Let me check what I have loca", streaming: true },
-      }),
-    );
-    const afterTool = reduceThreadSnapshot(
-      afterNarration,
-      event({
-        type: "agent.tool.called",
-        seq: 5,
-        runId: "run-1",
-        payload: { name: "shell" },
-      }),
-    );
-    const afterMore = reduceThreadSnapshot(
-      afterTool,
-      event({
-        type: "thread.progress",
-        seq: 6,
-        runId: "run-1",
-        payload: { delta: "lly and try the GitHub API.", streaming: true },
-      }),
-    );
-
-    expect(afterMore?.messages).toEqual([
-      expect.objectContaining({
-        id: "progress:run-1",
-        blocks: [
-          { kind: "text", text: "Let me check what I have " },
-          { kind: "steps", steps: [{ label: "Shell", count: 1 }] },
-          { kind: "progress", text: "locally and try the GitHub API." },
-        ],
+        blocks: [{ kind: "progress", text: "Let me check Slack Found it, now sanding" }],
       }),
     ]);
   });

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -227,6 +227,158 @@ describe("thread event reduction", () => {
     ).toBe(waiting);
   });
 
+  it("accumulates tool-call steps and collapses repeats into a count", () => {
+    const initial = snapshot([]);
+
+    const first = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "agent.tool.called",
+        seq: 4,
+        runId: "run-1",
+        payload: { name: "SLACK_FIND_CHANNELS" },
+      }),
+    );
+    const second = reduceThreadSnapshot(
+      first,
+      event({
+        type: "agent.tool.called",
+        seq: 5,
+        runId: "run-1",
+        payload: { name: "SLACK_FETCH_CONVERSATION_HISTORY" },
+      }),
+    );
+    const third = reduceThreadSnapshot(
+      second,
+      event({
+        type: "agent.tool.called",
+        seq: 6,
+        runId: "run-1",
+        payload: { name: "SLACK_FETCH_CONVERSATION_HISTORY" },
+      }),
+    );
+
+    expect(third?.messages).toEqual([
+      expect.objectContaining({
+        id: "progress:run-1",
+        blocks: [
+          {
+            kind: "steps",
+            steps: [
+              { label: "Slack find channels", count: 1 },
+              { label: "Slack fetch conversation history", count: 2 },
+            ],
+          },
+        ],
+      }),
+    ]);
+  });
+
+  it("merges narration and tool calls into one live message in chronological order", () => {
+    const initial = snapshot([]);
+
+    const afterNarration = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.progress",
+        seq: 4,
+        runId: "run-1",
+        payload: { text: "Let me check Slack ", streaming: true },
+      }),
+    );
+    const afterTool = reduceThreadSnapshot(
+      afterNarration,
+      event({
+        type: "agent.tool.called",
+        seq: 5,
+        runId: "run-1",
+        payload: { name: "SLACK_FIND_CHANNELS" },
+      }),
+    );
+    const afterMore = reduceThreadSnapshot(
+      afterTool,
+      event({
+        type: "thread.progress",
+        seq: 6,
+        runId: "run-1",
+        payload: { delta: "Found it, now sanding", streaming: true },
+      }),
+    );
+
+    expect(afterMore?.messages).toEqual([
+      expect.objectContaining({
+        id: "progress:run-1",
+        blocks: [
+          { kind: "text", text: "Let me check Slack " },
+          { kind: "steps", steps: [{ label: "Slack find channels", count: 1 }] },
+          { kind: "progress", text: "Found it, now sanding" },
+        ],
+      }),
+    ]);
+  });
+
+  it("holds back a partial trailing word across a tool call instead of splitting it", () => {
+    const initial = snapshot([]);
+
+    const afterNarration = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.progress",
+        seq: 4,
+        runId: "run-1",
+        payload: { text: "Let me check what I have loca", streaming: true },
+      }),
+    );
+    const afterTool = reduceThreadSnapshot(
+      afterNarration,
+      event({
+        type: "agent.tool.called",
+        seq: 5,
+        runId: "run-1",
+        payload: { name: "shell" },
+      }),
+    );
+    const afterMore = reduceThreadSnapshot(
+      afterTool,
+      event({
+        type: "thread.progress",
+        seq: 6,
+        runId: "run-1",
+        payload: { delta: "lly and try the GitHub API.", streaming: true },
+      }),
+    );
+
+    expect(afterMore?.messages).toEqual([
+      expect.objectContaining({
+        id: "progress:run-1",
+        blocks: [
+          { kind: "text", text: "Let me check what I have " },
+          { kind: "steps", steps: [{ label: "Shell", count: 1 }] },
+          { kind: "progress", text: "locally and try the GitHub API." },
+        ],
+      }),
+    ]);
+  });
+
+  it("clears the step trail once the durable answer arrives", () => {
+    const initial = snapshot([
+      message("steps:run-1", [
+        { kind: "steps", steps: [{ label: "Slack find channels", count: 1 }] },
+      ]),
+    ]);
+
+    const next = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.message.created",
+        seq: 9,
+        payload: { messageId: "final", role: "bot", blocks: [{ kind: "text", text: "Done" }] },
+      }),
+    );
+
+    expect(next?.messages.map((item) => item.id)).toEqual(["final"]);
+  });
+
   it("replaces an ask message when its durable prompt state changes", () => {
     const initial = snapshot([
       message("ask-1", [{ kind: "ask", text: "Which city?", status: "pending" }]),

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -82,7 +82,28 @@ export function isThreadSnapshotEvent(event: ProductEvent): boolean {
   );
 }
 
+// React StrictMode invokes a setState updater twice in development to surface impure updaters.
+// This reducer holds tool-call state pending a sentence boundary in a module-level Map
+// (pendingToolsByRun) rather than in the returned snapshot, so a naive replay would mutate it a
+// second time and corrupt the pending count. Memoize the last (prev, event) pair so a replay of
+// the exact same event returns the exact same result without touching pendingToolsByRun again.
+let lastReducedPrev: ThreadSnapshot | null = null;
+let lastReducedEventId: string | null = null;
+let lastReducedResult: ThreadSnapshot | null = null;
+
 export function reduceThreadSnapshot(
+  prev: ThreadSnapshot | null,
+  event: ProductEvent,
+): ThreadSnapshot | null {
+  if (prev === lastReducedPrev && event.id === lastReducedEventId) return lastReducedResult;
+  const result = reduceThreadSnapshotOnce(prev, event);
+  lastReducedPrev = prev;
+  lastReducedEventId = event.id;
+  lastReducedResult = result;
+  return result;
+}
+
+function reduceThreadSnapshotOnce(
   prev: ThreadSnapshot | null,
   event: ProductEvent,
 ): ThreadSnapshot | null {

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -1,17 +1,28 @@
 import type {
   ComputerStatus,
+  MessageBlock,
   ProductEvent,
   ThreadMessage,
   ThreadMessagePage,
   ThreadSnapshot,
 } from "@rakazo/contracts";
 import {
+  appendTextSegment,
+  appendToolCallSegment,
   mergeThreadHistory,
   prependThreadHistoryPage,
   progressMessageId,
   progressMessageText,
+  splitFlushableText,
   subagentBlockFromPayload,
 } from "@rakazo/core";
+
+function liveStreamTextSoFar(blocks: readonly MessageBlock[]): string {
+  return blocks
+    .filter((block) => block.kind === "text" || block.kind === "progress")
+    .map((block) => (block.kind === "text" || block.kind === "progress" ? block.text : ""))
+    .join("");
+}
 
 const computerStates: ReadonlySet<unknown> = new Set<ComputerStatus["state"]>([
   "stopped",
@@ -41,6 +52,7 @@ export function isThreadSnapshotEvent(event: ProductEvent): boolean {
     event.type === "thread.cleared" ||
     event.type === "thread.progress" ||
     event.type === "thread.subagent" ||
+    event.type === "agent.tool.called" ||
     event.type === "thread.message.created" ||
     event.type === "thread.message.updated" ||
     event.type === "run.waiting_input"
@@ -65,21 +77,55 @@ export function reduceThreadSnapshot(
     };
   }
   if (event.type === "thread.progress") {
-    const progressId = progressMessageId(event);
-    const previous = prev.messages.find((message) => message.id === progressId);
-    const previousText = previous?.blocks[0]?.kind === "progress" ? previous.blocks[0].text : "";
-    const text = progressMessageText(event.payload, previousText);
+    const liveId = progressMessageId(event);
+    const previous = prev.messages.find((message) => message.id === liveId);
+    const priorBlocks = previous?.blocks ?? [];
+    const flushedBlocks =
+      priorBlocks.at(-1)?.kind === "progress" ? priorBlocks.slice(0, -1) : priorBlocks;
+    // Deltas are relative to the whole stream so far, not just the unflushed tail — reconstruct
+    // the full text, then take only what's beyond what earlier segments already captured.
+    const flushedLength = liveStreamTextSoFar(flushedBlocks).length;
+    const fullText = progressMessageText(event.payload, liveStreamTextSoFar(priorBlocks));
+    const tailText = fullText.slice(flushedLength);
+    const blocks = tailText
+      ? [...flushedBlocks, { kind: "progress" as const, text: tailText }]
+      : flushedBlocks;
     const streaming: ThreadMessage = {
-      id: progressId,
+      id: liveId,
       threadId: event.threadId,
       seq: event.seq,
       role: "bot",
-      blocks: [{ kind: "progress", text }],
+      blocks,
       runId: event.runId,
       createdAt: event.createdAt,
     };
     const without = prev.messages.filter((message) => !message.id.startsWith("progress:"));
     return { ...prev, cursor: event.seq, messages: [...without, streaming] };
+  }
+  if (event.type === "agent.tool.called") {
+    const liveId = progressMessageId(event);
+    const previous = prev.messages.find((message) => message.id === liveId);
+    const priorBlocks = previous?.blocks ?? [];
+    const tail = priorBlocks.at(-1);
+    // Hold back a partial trailing word rather than splitting it across the tool call — it
+    // rejoins as the start of whatever text streams next.
+    const { flush, carry } =
+      tail?.kind === "progress" ? splitFlushableText(tail.text) : { flush: "", carry: "" };
+    const flushedBlocks =
+      tail?.kind === "progress" ? appendTextSegment(priorBlocks.slice(0, -1), flush) : priorBlocks;
+    const withTool = appendToolCallSegment(flushedBlocks, String(event.payload.name ?? ""));
+    const blocks = carry ? [...withTool, { kind: "progress" as const, text: carry }] : withTool;
+    const next: ThreadMessage = {
+      id: liveId,
+      threadId: event.threadId,
+      seq: event.seq,
+      role: "bot",
+      blocks,
+      runId: event.runId,
+      createdAt: event.createdAt,
+    };
+    const without = prev.messages.filter((message) => message.id !== liveId);
+    return { ...prev, cursor: event.seq, messages: [...without, next] };
   }
   if (event.type === "thread.subagent") {
     const block = subagentBlockFromPayload(event.payload);
@@ -93,10 +139,15 @@ export function reduceThreadSnapshot(
       createdAt: event.createdAt,
     };
     const without = prev.messages.filter(
-      (message) => message.id !== next.id && !message.id.startsWith("progress:"),
+      (message) =>
+        message.id !== next.id &&
+        !message.id.startsWith("progress:") &&
+        !message.id.startsWith("steps:"),
     );
-    const progress = prev.messages.filter((message) => message.id.startsWith("progress:"));
-    return { ...prev, cursor: event.seq, messages: [...without, next, ...progress] };
+    const kept = prev.messages.filter(
+      (message) => message.id.startsWith("progress:") || message.id.startsWith("steps:"),
+    );
+    return { ...prev, cursor: event.seq, messages: [...without, next, ...kept] };
   }
   if (event.type === "thread.message.created" || event.type === "thread.message.updated") {
     const role = (event.payload.role as ThreadMessage["role"]) ?? "bot";
@@ -117,6 +168,7 @@ export function reduceThreadSnapshot(
       (message) =>
         message.id !== next.id &&
         !message.id.startsWith("progress:") &&
+        !message.id.startsWith("steps:") &&
         !replacedSubagent(message, replacedSubagentIds),
     );
     return { ...prev, cursor: event.seq, messages: [...without, next] };

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -9,13 +9,36 @@ import type {
 import {
   appendTextSegment,
   appendToolCallSegment,
+  endsSentence,
   mergeThreadHistory,
   prependThreadHistoryPage,
   progressMessageId,
   progressMessageText,
-  splitFlushableText,
   subagentBlockFromPayload,
 } from "@rakazo/core";
+
+// reduceThreadSnapshot runs once per incoming event with no memory of its own beyond the
+// `prev`/`next` snapshots, so a tool call held back mid-sentence (see flushPendingTools below)
+// needs somewhere to live between calls. Keyed by run id; cleared once the run's durable
+// message arrives.
+const pendingToolsByRun = new Map<string, string[]>();
+
+// If `tailText` (the narration not yet folded into `segments`) now ends a sentence, fold it in
+// followed by every tool call held back since the sentence started, and return the result.
+// Returns null when there's nothing pending or the sentence hasn't finished yet — the caller
+// keeps waiting.
+function flushPendingTools(
+  liveId: string,
+  segments: readonly MessageBlock[],
+  tailText: string,
+): MessageBlock[] | null {
+  const pending = pendingToolsByRun.get(liveId);
+  if (!pending || pending.length === 0 || !endsSentence(tailText)) return null;
+  let next = appendTextSegment(segments, tailText);
+  for (const name of pending) next = appendToolCallSegment(next, name);
+  pendingToolsByRun.delete(liveId);
+  return next;
+}
 
 function liveStreamTextSoFar(blocks: readonly MessageBlock[]): string {
   return blocks
@@ -87,9 +110,11 @@ export function reduceThreadSnapshot(
     const flushedLength = liveStreamTextSoFar(flushedBlocks).length;
     const fullText = progressMessageText(event.payload, liveStreamTextSoFar(priorBlocks));
     const tailText = fullText.slice(flushedLength);
-    const blocks = tailText
-      ? [...flushedBlocks, { kind: "progress" as const, text: tailText }]
-      : flushedBlocks;
+    const blocks =
+      flushPendingTools(liveId, flushedBlocks, tailText) ??
+      (tailText
+        ? [...flushedBlocks, { kind: "progress" as const, text: tailText }]
+        : flushedBlocks);
     const streaming: ThreadMessage = {
       id: liveId,
       threadId: event.threadId,
@@ -107,14 +132,16 @@ export function reduceThreadSnapshot(
     const previous = prev.messages.find((message) => message.id === liveId);
     const priorBlocks = previous?.blocks ?? [];
     const tail = priorBlocks.at(-1);
-    // Hold back a partial trailing word rather than splitting it across the tool call — it
-    // rejoins as the start of whatever text streams next.
-    const { flush, carry } =
-      tail?.kind === "progress" ? splitFlushableText(tail.text) : { flush: "", carry: "" };
-    const flushedBlocks =
-      tail?.kind === "progress" ? appendTextSegment(priorBlocks.slice(0, -1), flush) : priorBlocks;
-    const withTool = appendToolCallSegment(flushedBlocks, String(event.payload.name ?? ""));
-    const blocks = carry ? [...withTool, { kind: "progress" as const, text: carry }] : withTool;
+    const tailText = tail?.kind === "progress" ? tail.text : "";
+    const flushedBlocks = tail?.kind === "progress" ? priorBlocks.slice(0, -1) : priorBlocks;
+    const pending = pendingToolsByRun.get(liveId) ?? [];
+    pending.push(String(event.payload.name ?? ""));
+    pendingToolsByRun.set(liveId, pending);
+    const blocks =
+      flushPendingTools(liveId, flushedBlocks, tailText) ??
+      (tailText
+        ? [...flushedBlocks, { kind: "progress" as const, text: tailText }]
+        : flushedBlocks);
     const next: ThreadMessage = {
       id: liveId,
       threadId: event.threadId,
@@ -150,6 +177,7 @@ export function reduceThreadSnapshot(
     return { ...prev, cursor: event.seq, messages: [...without, next, ...kept] };
   }
   if (event.type === "thread.message.created" || event.type === "thread.message.updated") {
+    pendingToolsByRun.delete(progressMessageId(event));
     const role = (event.payload.role as ThreadMessage["role"]) ?? "bot";
     const blocks = (event.payload.blocks as ThreadMessage["blocks"]) ?? [];
     const next: ThreadMessage = {

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -374,7 +374,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         onChange={(event) => setApiKey(event.target.value)}
                         placeholder="sk-…"
                         type="password"
-                        autoComplete="off"
+                        autoComplete="new-password"
                         className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-[#101012] px-3.5 py-3 text-[#ECECEE] outline-none"
                       />
                     </label>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2081,6 +2081,61 @@ const MessageView = memo(function MessageView({
   speaking: boolean;
   onSpeak: () => void;
 }) {
+  const isNarration =
+    message.role === "bot" &&
+    message.blocks.length > 0 &&
+    message.blocks.every(
+      (block) => block.kind === "text" || block.kind === "progress" || block.kind === "steps",
+    );
+  if (isNarration) {
+    const isLive = message.id.startsWith("progress:");
+    return (
+      <div className="flex justify-start">
+        <div className="max-w-[74%] space-y-2.5 rounded-[20px] bg-[#1A1A1D] px-[18px] py-3 text-[15.5px] leading-[1.5] text-[#DFDFE2]">
+          {message.blocks.map((block, i) => {
+            if (block.kind === "steps") {
+              const isCurrentBlock = isLive && i === message.blocks.length - 1;
+              return (
+                <div key={i} className="space-y-1.5">
+                  {block.steps.map((step, stepIndex) => {
+                    const isCurrent = isCurrentBlock && stepIndex === block.steps.length - 1;
+                    return (
+                      <div key={stepIndex} className="flex items-center gap-2">
+                        <span
+                          className="text-[13px]"
+                          style={{
+                            color: isCurrent ? "#F5A03C" : "#4ECB71",
+                            animation: isCurrent ? "rkPulse 1.2s ease-in-out infinite" : undefined,
+                          }}
+                        >
+                          {isCurrent ? "◷" : "✓"}
+                        </span>
+                        <span
+                          className="truncate text-[14px]"
+                          style={{ color: isCurrent ? "#DFDFE2" : "#85858A" }}
+                        >
+                          {step.label}
+                          {step.count > 1 ? ` ×${step.count}` : ""}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            }
+            if (block.kind === "text" || block.kind === "progress") {
+              return (
+                <ChatMarkdown key={i} streaming={block.kind === "progress"}>
+                  {block.text}
+                </ChatMarkdown>
+              );
+            }
+            return null;
+          })}
+        </div>
+      </div>
+    );
+  }
   return (
     <>
       {message.blocks.map((block, i) => {
@@ -2100,6 +2155,37 @@ const MessageView = memo(function MessageView({
             <div key={i} className="flex justify-start">
               <div className="max-w-[74%] rounded-[20px] bg-[#1A1A1D] px-[18px] py-3 text-[15.5px] leading-[1.5] text-[#DFDFE2]">
                 <ChatMarkdown streaming>{block.text}</ChatMarkdown>
+              </div>
+            </div>
+          );
+        }
+        if (block.kind === "steps") {
+          return (
+            <div key={i} className="flex justify-start">
+              <div className="max-w-[74%] space-y-1.5 rounded-[20px] bg-[#1A1A1D] px-[18px] py-3">
+                {block.steps.map((step, stepIndex) => {
+                  const isCurrent = stepIndex === block.steps.length - 1;
+                  return (
+                    <div key={stepIndex} className="flex items-center gap-2">
+                      <span
+                        className="text-[13px]"
+                        style={{
+                          color: isCurrent ? "#F5A03C" : "#4ECB71",
+                          animation: isCurrent ? "rkPulse 1.2s ease-in-out infinite" : undefined,
+                        }}
+                      >
+                        {isCurrent ? "◷" : "✓"}
+                      </span>
+                      <span
+                        className="truncate text-[14px]"
+                        style={{ color: isCurrent ? "#DFDFE2" : "#85858A" }}
+                      >
+                        {step.label}
+                        {step.count > 1 ? ` ×${step.count}` : ""}
+                      </span>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           );

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2125,9 +2125,19 @@ const MessageView = memo(function MessageView({
             }
             if (block.kind === "text" || block.kind === "progress") {
               return (
-                <ChatMarkdown key={i} streaming={block.kind === "progress"}>
-                  {block.text}
-                </ChatMarkdown>
+                <div key={i}>
+                  <ChatMarkdown streaming={block.kind === "progress"}>{block.text}</ChatMarkdown>
+                  {block.kind === "text" && voiceReady ? (
+                    <button
+                      type="button"
+                      aria-label={speaking ? "Stop speaking" : "Speak this reply"}
+                      onClick={onSpeak}
+                      className="mt-2 text-[12px] text-[#85858A] hover:text-[#ECECEE]"
+                    >
+                      {speaking ? "Stop" : "Speak"}
+                    </button>
+                  ) : null}
+                </div>
               );
             }
             return null;

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2006,6 +2006,8 @@ const Composer = memo(function Composer({
           }}
           disabled={disabled}
           placeholder={activeName ? `Message ${activeName}` : "Message…"}
+          name="chat-message"
+          autoComplete="off"
           className="flex-1 bg-transparent text-[15.5px] text-[#E9E9EA] outline-none disabled:opacity-40"
         />
         {running ? (

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -16,11 +16,14 @@ import { historyCompactJob, routineWakeupJob, runContinueJob } from "@rakazo/ada
 import type { MessageBlock, RunStatus } from "@rakazo/contracts";
 import { ATTACHMENT_MAX_BYTES, isAttachmentImageMimeType } from "@rakazo/contracts";
 import {
+  appendTextSegment,
+  appendToolCallSegment,
   assertTransition,
   blocksToAgentHistoryText,
   containsSecret,
   createStreamingRedactor,
   formatSkillRunPrompt,
+  humanizeToolName,
   inferAttachmentMimeType,
   isTerminal,
   nextCronDate,
@@ -28,6 +31,11 @@ import {
   promptInvokesSkill,
   redactSecrets,
   sandboxCommandTimeoutMs,
+  splitFlushableText,
+  type ToolCallStreak,
+  type ToolNameStreak,
+  trackToolCallStreak,
+  trackToolNameStreak,
   userTurnBlocksForRun,
 } from "@rakazo/core";
 import {
@@ -105,6 +113,12 @@ const READ_ONLY_AGENT_TOOLS = new Set([
   "run_subagent",
 ]);
 const MAX_MODEL_FILE_BYTES = 250_000;
+const MAX_AGENT_HISTORY_MESSAGES = 200;
+// Same tool, same arguments, this many times in a row means the agent is stuck, not paginating.
+const MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 6;
+// Backstop for a stuck agent that varies its arguments each call (so the exact-match cap above
+// never trips) but keeps hammering the same tool without ever narrating progress in between.
+const MAX_CONSECUTIVE_SAME_TOOL_CALLS = 20;
 const GRAPHICAL_AGENT_TOOLS = new Set([
   "computer_observe",
   "computer_act",
@@ -480,8 +494,13 @@ export function createRunExecutor(deps: ExecutorDeps) {
             : "This entire computer workspace is your private home. Relative file paths and shell working directories start at its root.";
 
         let assembled = "";
+        let currentTextSegment = "";
+        let messageSegments: MessageBlock[] = [];
         let pendingProgress = "";
         let lastProgressAt = 0;
+        let hasStreamedText = false;
+        let toolCallStreak: ToolCallStreak = { key: undefined, count: 0 };
+        let toolNameStreak: ToolNameStreak = { name: undefined, count: 0 };
         let lastComputerFrameId: string | undefined;
         let terminalCheckpointComplete = false;
         const progressRedactor = createStreamingRedactor(runSecrets);
@@ -932,6 +951,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
 
             if (event.type === "text") {
               assembled += event.text;
+              currentTextSegment += event.text;
               pendingProgress += progressRedactor.push(event.text);
               const now = Date.now();
               if (!scripted && pendingProgress && now - lastProgressAt >= 250) {
@@ -942,8 +962,13 @@ export function createRunExecutor(deps: ExecutorDeps) {
                   botId: bot.id,
                   type: "thread.progress",
                   runId,
-                  payload: { delta: pendingProgress, streaming: true },
+                  // The first flush replaces the "working…" placeholder outright — a delta
+                  // here would otherwise get appended straight onto it with no separator.
+                  payload: hasStreamedText
+                    ? { delta: pendingProgress, streaming: true }
+                    : { text: pendingProgress, streaming: true },
                 });
+                hasStreamedText = true;
                 pendingProgress = "";
               }
             } else if (event.type === "progress") {
@@ -1042,6 +1067,40 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 runId,
                 payload: { name: event.name, executionId: event.executionId },
               });
+              const { flush, carry } = splitFlushableText(currentTextSegment);
+              messageSegments = appendTextSegment(messageSegments, flush);
+              currentTextSegment = carry;
+              messageSegments = appendToolCallSegment(messageSegments, event.name);
+              toolCallStreak = trackToolCallStreak(toolCallStreak, event.name, event.args);
+              toolNameStreak = trackToolNameStreak(toolNameStreak, event.name);
+              const stuckOnExactRepeat =
+                toolCallStreak.count >= MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS;
+              const stuckOnSameTool = toolNameStreak.count >= MAX_CONSECUTIVE_SAME_TOOL_CALLS;
+              if (stuckOnExactRepeat || stuckOnSameTool) {
+                if (!(await renewRunLease(deps, runId, workerId, fence))) return;
+                if (messageSegments.length > 0) {
+                  await publishMessage(deps, run, "bot", redactBlocks(messageSegments, runSecrets));
+                }
+                await checkpointAndRecordComputerWorkspace(deps, storedComputer, computer, context);
+                terminalCheckpointComplete = true;
+                const stuckCount = stuckOnExactRepeat ? toolCallStreak.count : toolNameStreak.count;
+                const stuckDetail = stuckOnExactRepeat ? " with the same input" : "";
+                const stuckText = `I got stuck calling ${humanizeToolName(event.name)}${stuckDetail} ${stuckCount} times in a row without making progress, so I stopped early. Try rephrasing this, or ask me to try a different approach.`;
+                await deps.events.finalizeRun({
+                  workspaceId: run.workspaceId,
+                  threadId: thread.id,
+                  botId: bot.id,
+                  runId,
+                  taskId: run.taskId,
+                  attemptId: attempt.id,
+                  leaseOwner: workerId,
+                  leaseFence: fence,
+                  outcome: "completed",
+                  blocks: [{ kind: "text", text: stuckText }],
+                });
+                runAbortController?.abort();
+                return;
+              }
               if (scripted) await applyTool(event.name, event.args, event.executionId);
             } else if (event.type === "subagent") {
               const safeTask = redactSecrets(event.task, runSecrets);
@@ -1136,6 +1195,12 @@ export function createRunExecutor(deps: ExecutorDeps) {
           if (containsSecret(text, runSecrets)) {
             throw new Error("refusing to persist a secret in the thread");
           }
+          messageSegments = appendTextSegment(messageSegments, currentTextSegment);
+          currentTextSegment = "";
+          if (!assembled) {
+            messageSegments = appendTextSegment(messageSegments, "done.");
+          }
+          const blocks = redactBlocks(messageSegments, runSecrets);
           if (!(await renewRunLease(deps, runId, workerId, fence))) return;
           const completed = await deps.events.finalizeRun({
             workspaceId: run.workspaceId,
@@ -1147,7 +1212,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             leaseOwner: workerId,
             leaseFence: fence,
             outcome: "completed",
-            blocks: [{ kind: "text", text }],
+            blocks,
           });
           if (!completed) return;
           if (bot.notifyOnFinish) {
@@ -1341,6 +1406,14 @@ async function requeueComputerRun(
 
 async function clearRunProgress(deps: ExecutorDeps, runId: string): Promise<void> {
   await deps.prisma.event.deleteMany({ where: { runId, type: "thread.progress" } });
+}
+
+function redactBlocks(blocks: MessageBlock[], secrets: string[]): MessageBlock[] {
+  return blocks.map((block) =>
+    block.kind === "text"
+      ? { kind: "text" as const, text: redactSecrets(block.text, secrets) }
+      : block,
+  );
 }
 
 async function publishMessage(

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -22,6 +22,7 @@ import {
   blocksToAgentHistoryText,
   containsSecret,
   createStreamingRedactor,
+  endsSentence,
   formatSkillRunPrompt,
   humanizeToolName,
   inferAttachmentMimeType,
@@ -31,7 +32,6 @@ import {
   promptInvokesSkill,
   redactSecrets,
   sandboxCommandTimeoutMs,
-  splitFlushableText,
   type ToolCallStreak,
   type ToolNameStreak,
   trackToolCallStreak,
@@ -496,6 +496,22 @@ export function createRunExecutor(deps: ExecutorDeps) {
         let assembled = "";
         let currentTextSegment = "";
         let messageSegments: MessageBlock[] = [];
+        // Tool calls that land mid-sentence wait here until the narration catches up to a
+        // sentence boundary, so the step chips never render in the middle of a clause.
+        let pendingToolNames: string[] = [];
+        const flushPendingTools = () => {
+          if (currentTextSegment) {
+            messageSegments = appendTextSegment(messageSegments, currentTextSegment);
+            currentTextSegment = "";
+          }
+          for (const name of pendingToolNames) {
+            messageSegments = appendToolCallSegment(messageSegments, name);
+          }
+          pendingToolNames = [];
+        };
+        const tryFlushPendingTools = () => {
+          if (pendingToolNames.length > 0 && endsSentence(currentTextSegment)) flushPendingTools();
+        };
         let pendingProgress = "";
         let lastProgressAt = 0;
         let hasStreamedText = false;
@@ -952,6 +968,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             if (event.type === "text") {
               assembled += event.text;
               currentTextSegment += event.text;
+              tryFlushPendingTools();
               pendingProgress += progressRedactor.push(event.text);
               const now = Date.now();
               if (!scripted && pendingProgress && now - lastProgressAt >= 250) {
@@ -1067,16 +1084,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 runId,
                 payload: { name: event.name, executionId: event.executionId },
               });
-              const { flush, carry } = splitFlushableText(currentTextSegment);
-              messageSegments = appendTextSegment(messageSegments, flush);
-              currentTextSegment = carry;
-              messageSegments = appendToolCallSegment(messageSegments, event.name);
+              pendingToolNames.push(event.name);
+              tryFlushPendingTools();
               toolCallStreak = trackToolCallStreak(toolCallStreak, event.name, event.args);
               toolNameStreak = trackToolNameStreak(toolNameStreak, event.name);
               const stuckOnExactRepeat =
                 toolCallStreak.count >= MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS;
               const stuckOnSameTool = toolNameStreak.count >= MAX_CONSECUTIVE_SAME_TOOL_CALLS;
               if (stuckOnExactRepeat || stuckOnSameTool) {
+                flushPendingTools();
                 if (!(await renewRunLease(deps, runId, workerId, fence))) return;
                 if (messageSegments.length > 0) {
                   await publishMessage(deps, run, "bot", redactBlocks(messageSegments, runSecrets));
@@ -1195,8 +1211,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           if (containsSecret(text, runSecrets)) {
             throw new Error("refusing to persist a secret in the thread");
           }
-          messageSegments = appendTextSegment(messageSegments, currentTextSegment);
-          currentTextSegment = "";
+          flushPendingTools();
           if (!assembled) {
             messageSegments = appendTextSegment(messageSegments, "done.");
           }

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -77,6 +77,10 @@ export const MessageBlock = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("meta"), text: z.string() }),
   z.object({ kind: z.literal("progress"), text: z.string() }),
   z.object({
+    kind: z.literal("steps"),
+    steps: z.array(z.object({ label: z.string(), count: z.number().int().positive() })),
+  }),
+  z.object({
     kind: z.literal("subagent"),
     agentId: z.string(),
     name: z.string(),

--- a/packages/core/src/events.test.ts
+++ b/packages/core/src/events.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { createStreamingRedactor, projectMessages } from "./events.js";
+import {
+  appendTextSegment,
+  appendToolCallSegment,
+  appendToolStep,
+  createStreamingRedactor,
+  humanizeToolName,
+  projectMessages,
+  splitFlushableText,
+  trackToolCallStreak,
+  trackToolNameStreak,
+} from "./events.js";
 
 describe("projectMessages", () => {
   it("replays durable messages and trailing live tokens from progress events", () => {
@@ -128,6 +138,145 @@ describe("projectMessages", () => {
     expect(durable[0]?.blocks[0]).toMatchObject({ status: "completed", result: "ok" });
   });
 
+  it("collapses repeated tool calls into one step with a count", () => {
+    const messages = projectMessages([
+      {
+        id: "e1",
+        threadId: "t1",
+        seq: 0,
+        type: "agent.tool.called",
+        runId: "r1",
+        payload: { name: "SLACK_FETCH_CONVERSATION_HISTORY" },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "e2",
+        threadId: "t1",
+        seq: 1,
+        type: "agent.tool.called",
+        runId: "r1",
+        payload: { name: "SLACK_FETCH_CONVERSATION_HISTORY" },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+      {
+        id: "e3",
+        threadId: "t1",
+        seq: 2,
+        type: "agent.tool.called",
+        runId: "r1",
+        payload: { name: "SLACK_FIND_CHANNELS" },
+        createdAt: "2026-01-01T00:00:02.000Z",
+      },
+    ]);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.blocks[0]).toEqual({
+      kind: "steps",
+      steps: [
+        { label: "Slack fetch conversation history", count: 2 },
+        { label: "Slack find channels", count: 1 },
+      ],
+    });
+  });
+
+  it("merges narration and tool calls into one live message in chronological order", () => {
+    const messages = projectMessages([
+      {
+        id: "e1",
+        threadId: "t1",
+        seq: 0,
+        type: "thread.progress",
+        runId: "r1",
+        payload: { text: "Let me check Slack ", streaming: true },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "e2",
+        threadId: "t1",
+        seq: 1,
+        type: "agent.tool.called",
+        runId: "r1",
+        payload: { name: "SLACK_FIND_CHANNELS" },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+      {
+        id: "e3",
+        threadId: "t1",
+        seq: 2,
+        type: "thread.progress",
+        runId: "r1",
+        payload: { delta: "Found it, now sanding", streaming: true },
+        createdAt: "2026-01-01T00:00:02.000Z",
+      },
+    ]);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.blocks).toEqual([
+      { kind: "text", text: "Let me check Slack " },
+      { kind: "steps", steps: [{ label: "Slack find channels", count: 1 }] },
+      { kind: "progress", text: "Found it, now sanding" },
+    ]);
+  });
+
+  it("holds back a partial trailing word across a tool call instead of splitting it", () => {
+    const messages = projectMessages([
+      {
+        id: "e1",
+        threadId: "t1",
+        seq: 0,
+        type: "thread.progress",
+        runId: "r1",
+        payload: { text: "Let me check what I have loca", streaming: true },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "e2",
+        threadId: "t1",
+        seq: 1,
+        type: "agent.tool.called",
+        runId: "r1",
+        payload: { name: "shell" },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+      {
+        id: "e3",
+        threadId: "t1",
+        seq: 2,
+        type: "thread.progress",
+        runId: "r1",
+        payload: { delta: "lly and try the GitHub API.", streaming: true },
+        createdAt: "2026-01-01T00:00:02.000Z",
+      },
+    ]);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.blocks).toEqual([
+      { kind: "text", text: "Let me check what I have " },
+      { kind: "steps", steps: [{ label: "Shell", count: 1 }] },
+      { kind: "progress", text: "locally and try the GitHub API." },
+    ]);
+  });
+
+  it("clears the live step trail once the run ends", () => {
+    const messages = projectMessages([
+      {
+        id: "e1",
+        threadId: "t1",
+        seq: 0,
+        type: "agent.tool.called",
+        runId: "r1",
+        payload: { name: "SLACK_FIND_CHANNELS" },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "e2",
+        threadId: "t1",
+        seq: 1,
+        type: "run.cancelled",
+        runId: "r1",
+        payload: {},
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+    ]);
+    expect(messages).toHaveLength(0);
+  });
   it("drops prior history when a later clear event is replayed", () => {
     const messages = projectMessages([
       {
@@ -157,6 +306,182 @@ describe("projectMessages", () => {
       },
     ]);
     expect(messages).toEqual([]);
+  });
+});
+
+describe("humanizeToolName", () => {
+  it("turns a Composio-style constant into a readable label", () => {
+    expect(humanizeToolName("SLACK_FIND_CHANNELS")).toBe("Slack find channels");
+  });
+
+  it("turns a lowercase builtin tool name into a readable label", () => {
+    expect(humanizeToolName("request_takeover")).toBe("Request takeover");
+  });
+});
+
+describe("appendToolStep", () => {
+  it("starts a new step for the first call", () => {
+    expect(appendToolStep([], "SLACK_FIND_CHANNELS")).toEqual([
+      { label: "Slack find channels", count: 1 },
+    ]);
+  });
+
+  it("increments the count when the same tool fires again in a row", () => {
+    const first = appendToolStep([], "SLACK_FIND_CHANNELS");
+    expect(appendToolStep(first, "SLACK_FIND_CHANNELS")).toEqual([
+      { label: "Slack find channels", count: 2 },
+    ]);
+  });
+
+  it("appends a new step when a different tool fires", () => {
+    const first = appendToolStep([], "SLACK_FIND_CHANNELS");
+    expect(appendToolStep(first, "SLACK_FETCH_CONVERSATION_HISTORY")).toEqual([
+      { label: "Slack find channels", count: 1 },
+      { label: "Slack fetch conversation history", count: 1 },
+    ]);
+  });
+});
+
+describe("trackToolCallStreak", () => {
+  it("starts a streak of 1 for the first call", () => {
+    expect(
+      trackToolCallStreak({ key: undefined, count: 0 }, "SLACK_FIND_CHANNELS", { cursor: "a" }),
+    ).toEqual({ key: 'SLACK_FIND_CHANNELS:{"cursor":"a"}', count: 1 });
+  });
+
+  it("increments the count when the same tool and args repeat", () => {
+    const first = trackToolCallStreak({ key: undefined, count: 0 }, "SLACK_FIND_CHANNELS", {
+      cursor: "a",
+    });
+    expect(trackToolCallStreak(first, "SLACK_FIND_CHANNELS", { cursor: "a" })).toEqual({
+      key: 'SLACK_FIND_CHANNELS:{"cursor":"a"}',
+      count: 2,
+    });
+  });
+
+  it("resets the streak when the same tool is called with different args", () => {
+    const first = trackToolCallStreak({ key: undefined, count: 0 }, "SLACK_FIND_CHANNELS", {
+      cursor: "a",
+    });
+    expect(trackToolCallStreak(first, "SLACK_FIND_CHANNELS", { cursor: "b" })).toEqual({
+      key: 'SLACK_FIND_CHANNELS:{"cursor":"b"}',
+      count: 1,
+    });
+  });
+
+  it("resets the streak when a different tool is called", () => {
+    const first = trackToolCallStreak({ key: undefined, count: 0 }, "SLACK_FIND_CHANNELS", {
+      cursor: "a",
+    });
+    expect(trackToolCallStreak(first, "SLACK_FETCH_CONVERSATION_HISTORY", { cursor: "a" })).toEqual(
+      { key: 'SLACK_FETCH_CONVERSATION_HISTORY:{"cursor":"a"}', count: 1 },
+    );
+  });
+});
+
+describe("trackToolNameStreak", () => {
+  it("starts a streak of 1 for the first call", () => {
+    expect(trackToolNameStreak({ name: undefined, count: 0 }, "shell")).toEqual({
+      name: "shell",
+      count: 1,
+    });
+  });
+
+  it("increments the count when the same tool name repeats, even with different arguments", () => {
+    const first = trackToolNameStreak({ name: undefined, count: 0 }, "shell");
+    expect(trackToolNameStreak(first, "shell")).toEqual({ name: "shell", count: 2 });
+  });
+
+  it("resets the streak when a different tool is called", () => {
+    const first = trackToolNameStreak({ name: undefined, count: 0 }, "shell");
+    expect(trackToolNameStreak(first, "recall_memory")).toEqual({
+      name: "recall_memory",
+      count: 1,
+    });
+  });
+});
+
+describe("splitFlushableText", () => {
+  it("flushes everything up to and including the last whitespace", () => {
+    expect(splitFlushableText("Let me check what I have loca")).toEqual({
+      flush: "Let me check what I have ",
+      carry: "loca",
+    });
+  });
+
+  it("holds back the whole string when there is no whitespace at all", () => {
+    expect(splitFlushableText("loca")).toEqual({ flush: "", carry: "loca" });
+  });
+
+  it("flushes everything and carries nothing when the text ends on whitespace", () => {
+    expect(splitFlushableText("Let me check. ")).toEqual({
+      flush: "Let me check. ",
+      carry: "",
+    });
+  });
+
+  it("flushes everything and carries nothing for an empty string", () => {
+    expect(splitFlushableText("")).toEqual({ flush: "", carry: "" });
+  });
+});
+
+describe("appendTextSegment", () => {
+  it("starts a new text segment when there are none", () => {
+    expect(appendTextSegment([], "hello")).toEqual([{ kind: "text", text: "hello" }]);
+  });
+
+  it("does nothing when the text is empty", () => {
+    const segments = [{ kind: "steps" as const, steps: [{ label: "Shell", count: 1 }] }];
+    expect(appendTextSegment(segments, "")).toEqual(segments);
+  });
+
+  it("merges into the last segment when it is already text", () => {
+    const segments = appendTextSegment([], "a");
+    expect(appendTextSegment(segments, "b")).toEqual([{ kind: "text", text: "ab" }]);
+  });
+
+  it("starts a new text segment after a steps segment", () => {
+    const segments = [{ kind: "steps" as const, steps: [{ label: "Shell", count: 1 }] }];
+    expect(appendTextSegment(segments, "done")).toEqual([
+      { kind: "steps", steps: [{ label: "Shell", count: 1 }] },
+      { kind: "text", text: "done" },
+    ]);
+  });
+});
+
+describe("appendToolCallSegment", () => {
+  it("starts a new steps segment when there are none", () => {
+    expect(appendToolCallSegment([], "SLACK_FIND_CHANNELS")).toEqual([
+      { kind: "steps", steps: [{ label: "Slack find channels", count: 1 }] },
+    ]);
+  });
+
+  it("collapses into the last steps segment for the same tool", () => {
+    const segments = appendToolCallSegment([], "SLACK_FIND_CHANNELS");
+    expect(appendToolCallSegment(segments, "SLACK_FIND_CHANNELS")).toEqual([
+      { kind: "steps", steps: [{ label: "Slack find channels", count: 2 }] },
+    ]);
+  });
+
+  it("starts a new steps segment after a text segment", () => {
+    const segments = [{ kind: "text" as const, text: "hi" }];
+    expect(appendToolCallSegment(segments, "shell")).toEqual([
+      { kind: "text", text: "hi" },
+      { kind: "steps", steps: [{ label: "Shell", count: 1 }] },
+    ]);
+  });
+
+  it("adds a new step entry within the same steps segment for a different tool", () => {
+    const segments = appendToolCallSegment([], "SLACK_FIND_CHANNELS");
+    expect(appendToolCallSegment(segments, "shell")).toEqual([
+      {
+        kind: "steps",
+        steps: [
+          { label: "Slack find channels", count: 1 },
+          { label: "Shell", count: 1 },
+        ],
+      },
+    ]);
   });
 });
 

--- a/packages/core/src/events.test.ts
+++ b/packages/core/src/events.test.ts
@@ -4,9 +4,9 @@ import {
   appendToolCallSegment,
   appendToolStep,
   createStreamingRedactor,
+  endsSentence,
   humanizeToolName,
   projectMessages,
-  splitFlushableText,
   trackToolCallStreak,
   trackToolNameStreak,
 } from "./events.js";
@@ -178,7 +178,7 @@ describe("projectMessages", () => {
     });
   });
 
-  it("merges narration and tool calls into one live message in chronological order", () => {
+  it("holds a tool call that lands mid-sentence until the sentence completes", () => {
     const messages = projectMessages([
       {
         id: "e1",
@@ -204,19 +204,20 @@ describe("projectMessages", () => {
         seq: 2,
         type: "thread.progress",
         runId: "r1",
-        payload: { delta: "Found it, now sanding", streaming: true },
+        payload: { delta: "for a broad search.", streaming: true },
         createdAt: "2026-01-01T00:00:02.000Z",
       },
     ]);
     expect(messages).toHaveLength(1);
+    // The sentence only finishes once "for a broad search." streams in, so the completed
+    // sentence and the held-back tool call appear together, in that order.
     expect(messages[0]?.blocks).toEqual([
-      { kind: "text", text: "Let me check Slack " },
+      { kind: "text", text: "Let me check Slack for a broad search." },
       { kind: "steps", steps: [{ label: "Slack find channels", count: 1 }] },
-      { kind: "progress", text: "Found it, now sanding" },
     ]);
   });
 
-  it("holds back a partial trailing word across a tool call instead of splitting it", () => {
+  it("keeps a tool call hidden while narration keeps streaming with no sentence end", () => {
     const messages = projectMessages([
       {
         id: "e1",
@@ -224,7 +225,7 @@ describe("projectMessages", () => {
         seq: 0,
         type: "thread.progress",
         runId: "r1",
-        payload: { text: "Let me check what I have loca", streaming: true },
+        payload: { text: "Let me check what I have ", streaming: true },
         createdAt: "2026-01-01T00:00:00.000Z",
       },
       {
@@ -242,15 +243,15 @@ describe("projectMessages", () => {
         seq: 2,
         type: "thread.progress",
         runId: "r1",
-        payload: { delta: "lly and try the GitHub API.", streaming: true },
+        payload: { delta: "locally and try the GitHub API", streaming: true },
         createdAt: "2026-01-01T00:00:02.000Z",
       },
     ]);
     expect(messages).toHaveLength(1);
+    // No sentence terminator has streamed in yet, so the "Shell" call stays hidden and
+    // everything so far renders as one continuous progress tail.
     expect(messages[0]?.blocks).toEqual([
-      { kind: "text", text: "Let me check what I have " },
-      { kind: "steps", steps: [{ label: "Shell", count: 1 }] },
-      { kind: "progress", text: "locally and try the GitHub API." },
+      { kind: "progress", text: "Let me check what I have locally and try the GitHub API" },
     ]);
   });
 
@@ -401,27 +402,24 @@ describe("trackToolNameStreak", () => {
   });
 });
 
-describe("splitFlushableText", () => {
-  it("flushes everything up to and including the last whitespace", () => {
-    expect(splitFlushableText("Let me check what I have loca")).toEqual({
-      flush: "Let me check what I have ",
-      carry: "loca",
-    });
+describe("endsSentence", () => {
+  it("is false mid-clause, with no terminal punctuation", () => {
+    expect(endsSentence("Let me check what I have loca")).toBe(false);
   });
 
-  it("holds back the whole string when there is no whitespace at all", () => {
-    expect(splitFlushableText("loca")).toEqual({ flush: "", carry: "loca" });
+  it("is false when the text trails off on whitespace with no punctuation", () => {
+    expect(endsSentence("Let me check Slack ")).toBe(false);
   });
 
-  it("flushes everything and carries nothing when the text ends on whitespace", () => {
-    expect(splitFlushableText("Let me check. ")).toEqual({
-      flush: "Let me check. ",
-      carry: "",
-    });
+  it("is true once the text ends on a sentence terminator", () => {
+    expect(endsSentence("Let me check. ")).toBe(true);
+    expect(endsSentence("Is that right?")).toBe(true);
+    expect(endsSentence('She said "stop!"')).toBe(true);
   });
 
-  it("flushes everything and carries nothing for an empty string", () => {
-    expect(splitFlushableText("")).toEqual({ flush: "", carry: "" });
+  it("is true for an empty or whitespace-only string — nothing to protect", () => {
+    expect(endsSentence("")).toBe(true);
+    expect(endsSentence("   ")).toBe(true);
   });
 });
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -100,7 +100,7 @@ export function projectMessages(
     }
     if (event.type === "thread.cleared") {
       messages.length = 0;
-      streaming = null;
+      resetLive();
       liveSubagents.clear();
       durableSubagents.clear();
       continue;

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -19,6 +19,9 @@ export function projectMessages(
   let fullStreamText = "";
   let flushedUpTo = 0;
   let liveBlocks: MessageBlock[] = [];
+  // Tool calls that landed mid-sentence wait here until the narration catches up to a sentence
+  // boundary, so the step chips never render in the middle of a clause.
+  let pendingToolNames: string[] = [];
   let liveMeta: {
     id: string;
     threadId: string;
@@ -32,7 +35,19 @@ export function projectMessages(
     fullStreamText = "";
     flushedUpTo = 0;
     liveBlocks = [];
+    pendingToolNames = [];
     liveMeta = null;
+  };
+  const tryFlushPendingTools = () => {
+    if (pendingToolNames.length === 0) return;
+    const tailText = fullStreamText.slice(flushedUpTo);
+    if (!endsSentence(tailText)) return;
+    liveBlocks = appendTextSegment(liveBlocks, tailText);
+    flushedUpTo = fullStreamText.length;
+    for (const name of pendingToolNames) {
+      liveBlocks = appendToolCallSegment(liveBlocks, name);
+    }
+    pendingToolNames = [];
   };
   for (const event of events) {
     const payload = asRecord(event.payload);
@@ -61,6 +76,7 @@ export function projectMessages(
     }
     if (event.type === "thread.progress") {
       fullStreamText = progressMessageText(payload, fullStreamText);
+      tryFlushPendingTools();
       liveMeta = {
         id: progressMessageId(event),
         threadId: event.threadId,
@@ -71,10 +87,8 @@ export function projectMessages(
       continue;
     }
     if (event.type === "agent.tool.called") {
-      const { flush } = splitFlushableText(fullStreamText.slice(flushedUpTo));
-      liveBlocks = appendTextSegment(liveBlocks, flush);
-      flushedUpTo += flush.length;
-      liveBlocks = appendToolCallSegment(liveBlocks, String(payload.name ?? ""));
+      pendingToolNames.push(String(payload.name ?? ""));
+      tryFlushPendingTools();
       liveMeta = {
         id: progressMessageId(event),
         threadId: event.threadId,
@@ -166,10 +180,11 @@ export function trackToolNameStreak(streak: ToolNameStreak, name: string): ToolN
   return name === streak.name ? { name, count: streak.count + 1 } : { name, count: 1 };
 }
 
-export function splitFlushableText(text: string): { flush: string; carry: string } {
-  const match = /^([\s\S]*\s)([^\s]*)$/.exec(text);
-  if (!match) return { flush: "", carry: text };
-  return { flush: match[1] ?? "", carry: match[2] ?? "" };
+const SENTENCE_END_RE = /[.!?]["'”’)\]]*\s*$/;
+
+/** True once `text` ends at a sentence boundary (or is empty) — safe to flush without cutting a clause. */
+export function endsSentence(text: string): boolean {
+  return text.trim() === "" || SENTENCE_END_RE.test(text);
 }
 
 export function appendTextSegment(segments: readonly MessageBlock[], text: string): MessageBlock[] {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -12,15 +12,34 @@ export function projectMessages(
   }>,
 ): ThreadMessage[] {
   const messages: ThreadMessage[] = [];
-  let streaming: ThreadMessage | null = null;
+  // The live bot message merges narration and tool calls into one bubble, in the order they
+  // happened: fullStreamText is the whole model text stream (deltas are relative to it, never
+  // reset by a tool call), flushedUpTo marks how much of it is already folded into liveBlocks,
+  // and the remainder renders as the still-streaming tail.
+  let fullStreamText = "";
+  let flushedUpTo = 0;
+  let liveBlocks: MessageBlock[] = [];
+  let liveMeta: {
+    id: string;
+    threadId: string;
+    seq: number;
+    runId?: string;
+    createdAt: string;
+  } | null = null;
   const liveSubagents = new Map<string, ThreadMessage>();
   const durableSubagents = new Set<string>();
+  const resetLive = () => {
+    fullStreamText = "";
+    flushedUpTo = 0;
+    liveBlocks = [];
+    liveMeta = null;
+  };
   for (const event of events) {
     const payload = asRecord(event.payload);
     const createdAt =
       typeof event.createdAt === "string" ? event.createdAt : event.createdAt.toISOString();
     if (event.type === "thread.message.created") {
-      streaming = null;
+      resetLive();
       const role = (payload.role as ThreadMessage["role"]) ?? "bot";
       const blocks = (payload.blocks as MessageBlock[]) ?? [];
       for (const block of blocks) {
@@ -41,18 +60,25 @@ export function projectMessages(
       continue;
     }
     if (event.type === "thread.progress") {
-      const progressId = progressMessageId(event);
-      const previousText: string =
-        streaming?.id === progressId && streaming.blocks[0]?.kind === "progress"
-          ? streaming.blocks[0].text
-          : "";
-      const text = progressMessageText(payload, previousText);
-      streaming = {
-        id: progressId,
+      fullStreamText = progressMessageText(payload, fullStreamText);
+      liveMeta = {
+        id: progressMessageId(event),
         threadId: event.threadId,
         seq: event.seq,
-        role: "bot",
-        blocks: [{ kind: "progress", text }],
+        runId: event.runId ?? undefined,
+        createdAt,
+      };
+      continue;
+    }
+    if (event.type === "agent.tool.called") {
+      const { flush } = splitFlushableText(fullStreamText.slice(flushedUpTo));
+      liveBlocks = appendTextSegment(liveBlocks, flush);
+      flushedUpTo += flush.length;
+      liveBlocks = appendToolCallSegment(liveBlocks, String(payload.name ?? ""));
+      liveMeta = {
+        id: progressMessageId(event),
+        threadId: event.threadId,
+        seq: event.seq,
         runId: event.runId ?? undefined,
         createdAt,
       };
@@ -84,16 +110,95 @@ export function projectMessages(
       event.type === "run.failed" ||
       event.type === "run.cancelled"
     ) {
-      streaming = null;
+      resetLive();
     }
   }
   for (const live of liveSubagents.values()) messages.push(live);
-  if (streaming) messages.push(streaming);
+  if (liveMeta) {
+    const tailText = fullStreamText.slice(flushedUpTo);
+    const blocks = tailText
+      ? [...liveBlocks, { kind: "progress" as const, text: tailText }]
+      : liveBlocks;
+    if (blocks.length > 0) {
+      messages.push({
+        id: liveMeta.id,
+        threadId: liveMeta.threadId,
+        seq: liveMeta.seq,
+        role: "bot",
+        blocks,
+        runId: liveMeta.runId,
+        createdAt: liveMeta.createdAt,
+      });
+    }
+  }
   return messages;
 }
 
 export function progressMessageId(event: { runId?: string | null; id?: string }): string {
   return `progress:${event.runId ?? event.id ?? "live"}`;
+}
+
+export type ToolStep = { label: string; count: number };
+
+export function appendToolStep(steps: readonly ToolStep[], toolName: string): ToolStep[] {
+  const label = humanizeToolName(toolName);
+  const last = steps.at(-1);
+  if (last && last.label === label) {
+    return [...steps.slice(0, -1), { label, count: last.count + 1 }];
+  }
+  return [...steps, { label, count: 1 }];
+}
+
+export type ToolCallStreak = { key: string | undefined; count: number };
+
+export function trackToolCallStreak(
+  streak: ToolCallStreak,
+  name: string,
+  args: unknown,
+): ToolCallStreak {
+  const key = `${name}:${JSON.stringify(args)}`;
+  return key === streak.key ? { key, count: streak.count + 1 } : { key, count: 1 };
+}
+
+export type ToolNameStreak = { name: string | undefined; count: number };
+
+export function trackToolNameStreak(streak: ToolNameStreak, name: string): ToolNameStreak {
+  return name === streak.name ? { name, count: streak.count + 1 } : { name, count: 1 };
+}
+
+export function splitFlushableText(text: string): { flush: string; carry: string } {
+  const match = /^([\s\S]*\s)([^\s]*)$/.exec(text);
+  if (!match) return { flush: "", carry: text };
+  return { flush: match[1] ?? "", carry: match[2] ?? "" };
+}
+
+export function appendTextSegment(segments: readonly MessageBlock[], text: string): MessageBlock[] {
+  if (!text) return [...segments];
+  const last = segments.at(-1);
+  if (last?.kind === "text") {
+    return [...segments.slice(0, -1), { kind: "text", text: last.text + text }];
+  }
+  return [...segments, { kind: "text", text }];
+}
+
+export function appendToolCallSegment(
+  segments: readonly MessageBlock[],
+  toolName: string,
+): MessageBlock[] {
+  const last = segments.at(-1);
+  const priorSteps = last?.kind === "steps" ? last.steps : [];
+  const steps = appendToolStep(priorSteps, toolName);
+  if (last?.kind === "steps") {
+    return [...segments.slice(0, -1), { kind: "steps", steps }];
+  }
+  return [...segments, { kind: "steps", steps }];
+}
+
+export function humanizeToolName(name: string): string {
+  const spaced = name.replace(/_/g, " ").trim();
+  if (!spaced) return name;
+  const lower = spaced.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
 }
 
 export function progressMessageText(


### PR DESCRIPTION
## Summary
- Interleave tool-call steps into the live bot message as compact step rows (with repeat counts) instead of a silent spinner; stop stuck agents by capping consecutive identical tool calls and same-tool streaks
- Fix tool-call narration splitting mid-sentence (sentence-aware text segmentation)
- Fix pending-tool-call state corrupting under React StrictMode
- Fix stale streaming reference reintroduced after the merge
- Restore the "Speak this reply" button on narration-only bot messages
- Stop Chrome autofilling the account password into API key fields and the chat composer (`autoComplete="off"` + `name` attributes)

## Test plan
- pnpm vitest run packages/core packages/adapters apps/web (464 passed)
- tsc clean for core, adapters, apps/web; biome clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear progress indicators for tool activity during streamed responses.
  * Grouped narration, progress updates, and tool steps into a unified conversation bubble.
  * Repeated tool activity is consolidated with readable labels and counts.
  * Standalone progress updates now display instead of being hidden.
* **Bug Fixes**
  * Improved streamed response ordering by showing tool activity at sentence boundaries.
  * Prevented duplicate updates during replay and removed temporary progress trails once a final answer arrives.
  * Improved autocomplete behavior for message and API key inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->