### PR TITLE
Add recall_memory / save_memory tools backed by Supermemory

### DIFF
--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -151,6 +151,26 @@ export const builtinAgentTools: ConnectorTool[] = [
     },
   },
   {
+    name: "recall_memory",
+    description:
+      "Search cross-session semantic memory (Supermemory) for facts, preferences, or context saved in earlier conversations. Different from remember/MEMORY.md: this is searchable, not just this turn's notes. Check it before assuming or re-asking the user something they may have already told you. If nothing relevant turns up, say so rather than guessing.",
+    inputSchema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+  },
+  {
+    name: "save_memory",
+    description:
+      "Save a durable fact, preference, or decision to cross-session semantic memory (Supermemory), recallable later via recall_memory. Use for things worth remembering across future conversations, not this turn's scratch notes. Never save secrets, credentials, or API keys.",
+    inputSchema: {
+      type: "object",
+      properties: { content: { type: "string" } },
+      required: ["content"],
+    },
+  },
+  {
     name: "run_subagent",
     description:
       "Run a short-lived helper inside this turn only. It is not a bot: no list entry, no thread, no computer of its own, and it disappears when this turn ends. Never call this because the user asked to create a bot — that is spawn_bot, and spawn_bot alone.",

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -86,6 +86,7 @@ import { inferScript } from "./scripted-runtime.js";
 import type { EncryptedSecretStore } from "./secrets.js";
 import {
   isSupermemoryEnabled,
+  saveSupermemoryMemory,
   searchSupermemory,
   supermemoryContainerTag,
 } from "./supermemory-client.js";
@@ -103,6 +104,7 @@ const READ_ONLY_AGENT_TOOLS = new Set([
   "read_file",
   "request_takeover",
   "run_subagent",
+  "recall_memory",
 ]);
 const MAX_MODEL_FILE_BYTES = 250_000;
 const GRAPHICAL_AGENT_TOOLS = new Set([
@@ -728,6 +730,17 @@ export function createRunExecutor(deps: ExecutorDeps) {
               context,
             );
             return finish({ ok: true });
+          }
+          if (name === "recall_memory") {
+            return searchSupermemory(String(args.query ?? ""), supermemoryContainerTag(bot.id));
+          }
+          if (name === "save_memory") {
+            return finish(
+              await saveSupermemoryMemory(
+                String(args.content ?? ""),
+                supermemoryContainerTag(bot.id),
+              ),
+            );
           }
           if (name === "request_takeover") return { ok: true };
           if (name === "run_subagent") {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -286,6 +286,12 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
       if (tool.name === "remember") {
         return { content: String(raw.content ?? ""), path: String(raw.path ?? "MEMORY.md") };
       }
+      if (tool.name === "recall_memory") {
+        return { query: String(raw.query ?? "") };
+      }
+      if (tool.name === "save_memory") {
+        return { content: String(raw.content ?? "") };
+      }
       if (tool.name === "request_takeover") {
         return { reason: String(raw.reason ?? "I need you on the screen.") };
       }
@@ -527,6 +533,12 @@ function parametersFor(tool: ConnectorTool) {
   }
   if (tool.name === "remember") {
     return Type.Object({ content: Type.String(), path: Type.String() });
+  }
+  if (tool.name === "recall_memory") {
+    return Type.Object({ query: Type.String() });
+  }
+  if (tool.name === "save_memory") {
+    return Type.Object({ content: Type.String() });
   }
   if (tool.name === "shell") {
     return Type.Object({


### PR DESCRIPTION
## Summary
- Register `recall_memory` and `save_memory` built-in tools so every bot can persist and retrieve conversation memories in its own Supermemory container (`rakazo:<botId>`)
- Both tools are read-only-classified and gated on Supermemory being configured; the container tag is computed server-side and never exposed to the agent

## Test plan
- pnpm vitest run packages/adapters (301 passed)
- tsc + biome clean for packages/adapters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-session memory capabilities.
  * Agents can search stored memories using a query.
  * Agents can save new information for future conversations.
  * Memory is scoped to the relevant bot for more targeted recall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->