### PR TITLE
Fix write_file silently corrupting JSON object content

### DIFF
--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -38,6 +38,7 @@ import {
   type ThreadEvents,
 } from "@rakazo/db";
 import { builtinAgentTools } from "./builtin-tools.js";
+import { textContentArg } from "./tool-text.js";
 import { archiveSpawnedBot, spawnBot } from "./child-bots.js";
 import {
   collectLogIds,
@@ -601,7 +602,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           }
           if (name === "write_file") {
             const filePath = String(args.path ?? "notes/result.txt");
-            const content = String(args.content ?? "");
+            const content = textContentArg(args.content, "");
             await deps.sandbox.writeFile(
               computer,
               {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -7,6 +7,10 @@ const fakeAgentState = vi.hoisted(() => ({
     prepareArguments?: (args: unknown) => Record<string, unknown>;
     execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
   }>,
+  invoke: {
+    name: "destination_write",
+    args: { collection: "notes", title: "Result", body: "Done" } as Record<string, unknown>,
+  },
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
@@ -22,11 +26,12 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     subscribe(_listener: unknown) {}
 
     async prompt() {
-      const destination = this.tools.find((tool) => tool.name === "destination_write");
-      if (!destination) throw new Error("sanitized destination tool was not exposed");
-      const rawArgs = { collection: "notes", title: "Result", body: "Done" };
-      const args = destination.prepareArguments?.(rawArgs) ?? rawArgs;
-      await destination.execute("call-1", args);
+      const target =
+        this.tools.find((tool) => tool.name === fakeAgentState.invoke.name) ?? this.tools[0];
+      if (!target) throw new Error("expected tool was not exposed");
+      const rawArgs = fakeAgentState.invoke.args;
+      const args = target.prepareArguments?.(rawArgs) ?? rawArgs;
+      await target.execute("call-1", args);
     }
 
     async waitForIdle() {}
@@ -60,9 +65,25 @@ const destinationTool: ConnectorTool = {
   },
 };
 
+const writeFileTool: ConnectorTool = {
+  name: "write_file",
+  description: "Write a UTF-8 file into this bot's home.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      content: { type: "string" },
+    },
+  },
+};
+
 describe("Pi connector tool dispatch", () => {
   beforeEach(() => {
     fakeAgentState.tools = [];
+    fakeAgentState.invoke = {
+      name: "destination_write",
+      args: { collection: "notes", title: "Result", body: "Done" },
+    };
   });
 
   it("exposes a provider-safe name while executing the original connector name", async () => {
@@ -96,6 +117,47 @@ describe("Pi connector tool dispatch", () => {
     expect(executeTool).toHaveBeenCalledWith(
       "destination.write",
       { collection: "notes", title: "Result", body: "Done" },
+      "call-1",
+    );
+  });
+
+  it("serialises object content instead of writing [object Object] for write_file", async () => {
+    fakeAgentState.invoke = {
+      name: "write_file",
+      args: { path: "shared/state.json", content: { last_run: 1_787_648_953 } },
+    };
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "r",
+        prompt: "save the state file",
+        instructions: "Use write_file to save state.",
+        history: [],
+        tools: [writeFileTool],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool,
+      },
+      {
+        operationId: "2",
+        traceId: "2",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      // Exhaust the runtime event stream so tool execution completes.
+    }
+
+    expect(executeTool).toHaveBeenCalledWith(
+      "write_file",
+      {
+        path: "shared/state.json",
+        content: '{\n  "last_run": 1787648953\n}',
+      },
       "call-1",
     );
   });

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -11,6 +11,7 @@ import type {
 } from "@rakazo/adapter-kit";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
+import { textContentArg } from "./tool-text.js";
 
 const running = new Map<string, AbortController>();
 const catalogModels = builtinModels();
@@ -290,7 +291,10 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
         return { reason: String(raw.reason ?? "I need you on the screen.") };
       }
       if (tool.name === "write_file") {
-        return { path: String(raw.path ?? "notes/result.txt"), content: String(raw.content ?? "") };
+        return {
+          path: String(raw.path ?? "notes/result.txt"),
+          content: textContentArg(raw.content, ""),
+        };
       }
       if (tool.name === "computer_act") {
         return {

--- a/packages/adapters/src/tool-text.ts
+++ b/packages/adapters/src/tool-text.ts
@@ -1,0 +1,13 @@
+/**
+ * Coerce a tool-call argument into text for file-writing tools.
+ *
+ * Models occasionally pass structured JSON where a string is expected
+ * (e.g. write_file content). String() on an object yields "[object Object]",
+ * which would silently corrupt the written file — serialise objects to
+ * readable JSON instead.
+ */
+export function textContentArg(value: unknown, fallback: string): string {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === "object") return JSON.stringify(value, null, 2);
+  return String(value);
+}


### PR DESCRIPTION
## Summary
- Models sometimes pass `content` as a JSON object where a string is expected; `String()` coerced it to the literal text `[object Object]`, so the file was written corrupted while the tool still reported success
- Serialise object arguments to readable JSON instead, at both the pi-agent argument-normalisation layer and the executor's write_file handler

## Test plan
- New regression test in pi-runtime-tool-dispatch.test.ts asserting object content is serialised (fails with "[object Object]" before the fix)
- pnpm vitest run packages/adapters (302 passed); tsc + biome clean