### PR TITLE
Fix write_file silently corrupting JSON object content

### DIFF
--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -180,6 +180,7 @@ import {
   currentTurnFilesInstruction,
   materializeCurrentTurnFiles,
 } from "./thread-artifacts.js";
+import { textContentArg } from "./tool-text.js";
 
 const modelCredentialLocks = new Map<string, Promise<void>>();
 const READ_ONLY_AGENT_TOOLS = new Set([
@@ -1117,7 +1118,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           }
           if (name === "write_file") {
             const filePath = String(args.path ?? "notes/result.txt");
-            const content = String(args.content ?? "");
+            const content = textContentArg(args.content, "");
             await deps.sandbox.writeFile(
               computer,
               {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -9,6 +9,10 @@ const fakeAgentState = vi.hoisted(() => ({
     prepareArguments?: (args: unknown) => Record<string, unknown>;
     execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
   }>,
+  invoke: {
+    name: "destination_write",
+    args: { collection: "notes", title: "Result", body: "Done" } as Record<string, unknown>,
+  },
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
@@ -29,11 +33,12 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
 
     async prompt() {
       if (fakeAgentState.mode === "dispatch") {
-        const destination = this.tools.find((tool) => tool.name === "destination_write");
-        if (!destination) throw new Error("sanitized destination tool was not exposed");
-        const rawArgs = { collection: "notes", title: "Result", body: "Done" };
-        const args = destination.prepareArguments?.(rawArgs) ?? rawArgs;
-        await destination.execute("call-1", args);
+        const target =
+          this.tools.find((tool) => tool.name === fakeAgentState.invoke.name) ?? this.tools[0];
+        if (!target) throw new Error("expected tool was not exposed");
+        const rawArgs = fakeAgentState.invoke.args;
+        const args = target.prepareArguments?.(rawArgs) ?? rawArgs;
+        await target.execute("call-1", args);
         return;
       }
 
@@ -104,11 +109,27 @@ const destinationTool: ConnectorTool = {
   route: { connectorId: "destination", toolName: "destination.write" },
 };
 
+const writeFileTool: ConnectorTool = {
+  name: "write_file",
+  description: "Write a UTF-8 file into this bot's home.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      content: { type: "string" },
+    },
+  },
+};
+
 describe("Pi connector tool dispatch", () => {
   beforeEach(() => {
     fakeAgentState.mode = "dispatch";
     fakeAgentState.abortCount = 0;
     fakeAgentState.tools = [];
+    fakeAgentState.invoke = {
+      name: "destination_write",
+      args: { collection: "notes", title: "Result", body: "Done" },
+    };
   });
 
   it("exposes a provider-safe name while executing the original connector name", async () => {
@@ -193,5 +214,46 @@ describe("Pi connector tool dispatch", () => {
       type: "progress",
       text: "Stopped: more than 80 tool calls in one turn.",
     });
+  });
+
+  it("serialises object content instead of writing [object Object] for write_file", async () => {
+    fakeAgentState.invoke = {
+      name: "write_file",
+      args: { path: "shared/state.json", content: { last_run: 1_787_648_953 } },
+    };
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "r",
+        prompt: "save the state file",
+        instructions: "Use write_file to save state.",
+        history: [],
+        tools: [writeFileTool],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool,
+      },
+      {
+        operationId: "3",
+        traceId: "3",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      // Exhaust the runtime event stream so tool execution completes.
+    }
+
+    expect(executeTool).toHaveBeenCalledWith(
+      "write_file",
+      {
+        path: "shared/state.json",
+        content: '{\n  "last_run": 1787648953\n}',
+      },
+      "call-1",
+    );
   });
 });

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -25,6 +25,7 @@ import {
   registerOpenAiCompatibleCatalog,
   registerOpenAiCompatibleRuntime,
 } from "./pi-openai-compatible-provider.js";
+import { textContentArg } from "./tool-text.js";
 
 const running = new Map<string, AbortController>();
 // Built on first use, not at module load: entry points call loadRootEnv() after
@@ -434,7 +435,10 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
         return { reason: String(raw.reason ?? "I need you on the screen.") };
       }
       if (tool.name === "write_file") {
-        return { path: String(raw.path ?? "notes/result.txt"), content: String(raw.content ?? "") };
+        return {
+          path: String(raw.path ?? "notes/result.txt"),
+          content: textContentArg(raw.content, ""),
+        };
       }
       if (tool.name === "computer_act") {
         return {

--- a/packages/adapters/src/tool-text.ts
+++ b/packages/adapters/src/tool-text.ts
@@ -1,0 +1,13 @@
+/**
+ * Coerce a tool-call argument into text for file-writing tools.
+ *
+ * Models occasionally pass structured JSON where a string is expected
+ * (e.g. write_file content). String() on an object yields "[object Object]",
+ * which would silently corrupt the written file — serialise objects to
+ * readable JSON instead.
+ */
+export function textContentArg(value: unknown, fallback: string): string {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === "object") return JSON.stringify(value, null, 2);
+  return String(value);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Models sometimes pass `content` as a JSON object where a string is expected; `String()` coerced it to the literal text `[object Object]`, so the file was written corrupted while the tool still reported success
- Serialise object arguments to readable JSON instead, via a shared `textContentArg` helper used in the executor `write_file` handler and pi-runtime `prepareArguments`
- Port of the community fix from #236 onto current main (credit: [@taur-us](https://github.com/taur-us))

## Test plan
- [x] Regression test in `pi-runtime-tool-dispatch.test.ts` asserting object content is serialised (would fail with `"[object Object]"` before the fix)
- [x] `pnpm vitest run packages/adapters/src/pi-runtime-tool-dispatch.test.ts` (3 passed)
- [x] `pnpm biome check` on touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df74da58-f410-4a78-b5d0-c0410828bfc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df74da58-f410-4a78-b5d0-c0410828bfc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file-writing behavior when content is provided as structured data.
  - Structured content is now converted into readable, formatted JSON instead of an opaque string.
  - Empty or missing content continues to use the appropriate fallback value.

- **Tests**
  - Added coverage for writing structured content.
  - Expanded tool dispatch testing to support multiple exposed tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->