### PR TITLE
Default new routines to the browser's local timezone

### DIFF
--- a/apps/web/src/lib/local-timezone.test.ts
+++ b/apps/web/src/lib/local-timezone.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { localTimezone } from "./local-timezone.js";
+
+describe("localTimezone", () => {
+  it("returns the browser's IANA timezone", () => {
+    const zone = localTimezone();
+    expect(zone).not.toBe("");
+    // IANA zones contain a slash; the UTC fallback does not.
+    if (Intl.DateTimeFormat().resolvedOptions().timeZone) {
+      expect(zone).toContain("/");
+    }
+  });
+
+  it("matches what Intl reports", () => {
+    expect(localTimezone()).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC");
+  });
+});

--- a/apps/web/src/lib/local-timezone.test.ts
+++ b/apps/web/src/lib/local-timezone.test.ts
@@ -3,16 +3,8 @@ import { describe, expect, it } from "vitest";
 import { localTimezone } from "./local-timezone.js";
 
 describe("localTimezone", () => {
-  it("returns the browser's IANA timezone", () => {
-    const zone = localTimezone();
-    expect(zone).not.toBe("");
-    // IANA zones contain a slash; the UTC fallback does not.
-    if (Intl.DateTimeFormat().resolvedOptions().timeZone) {
-      expect(zone).toContain("/");
-    }
-  });
-
-  it("matches what Intl reports", () => {
+  it("returns the environment's IANA timezone, falling back to UTC", () => {
+    // CI runners legitimately resolve to "UTC", so assert against Intl itself.
     expect(localTimezone()).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC");
   });
 });

--- a/apps/web/src/lib/local-timezone.ts
+++ b/apps/web/src/lib/local-timezone.ts
@@ -1,0 +1,7 @@
+/**
+ * The browser's IANA timezone (e.g. "Australia/Sydney"), for timestamp inputs
+ * that would otherwise default to UTC. Falls back to UTC when unavailable.
+ */
+export function localTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -110,6 +110,7 @@ import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
 import { chartViewport } from "../lib/chart-viewport";
 import { dictation } from "../lib/dictation";
+import { localTimezone } from "../lib/local-timezone";
 import { connectMcpOauth } from "../lib/mcp-connect";
 import { revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
@@ -2467,6 +2468,9 @@ export function ShellPage() {
                 </label>
                 <div className="mt-5 text-[14px] text-[#85858A]">
                   When to run
+                  <span className="ml-2 text-[12.5px] text-[#6E6E74]">
+                    times in {editingRoutine?.timezone ?? localTimezone()}
+                  </span>
                   <Suspense fallback={null}>
                     <RoutineSchedules
                       value={routineDraft.schedules}
@@ -2502,7 +2506,7 @@ export function ShellPage() {
                             name: routineDraft.name || "Routine",
                             prompt: routineDraft.prompt || "Check in.",
                             crons,
-                            timezone: "UTC",
+                            timezone: localTimezone(),
                             active: true,
                             notify: true,
                           });


### PR DESCRIPTION
## Summary
- The routine editor hardcoded `timezone: "UTC"` on create, so a "9:00 AM every day" schedule fired at 9:00 UTC regardless of where the user lives (hit in practice: a 9am news routine firing at 7pm Sydney time)
- New routines now send the browser's IANA timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`, falling back to `UTC` when unavailable) — the scheduler already handles IANA zones and DST correctly
- The editor shows which timezone the schedule times refer to (the routine's stored zone when editing, the detected local zone when creating)

Deliberately left out: mobile create path and chat-native /schedule tools (bots can pass an explicit timezone); a workspace-level default timezone feels like a separate design discussion.

## Test plan
- New unit test for the helper; pnpm vitest run apps/web (102 passed)
- Existing routine e2e seeds via RPC with explicit timezones and asserts timezone preservation on edit — unaffected
- tsc + biome clean for apps/web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routine schedules now automatically use the browser’s local timezone.
  * The routine editor displays the timezone applied to schedule times.
  * New routines preserve the detected local timezone, with UTC used as a fallback.

* **Bug Fixes**
  * Improved timezone handling for routine scheduling across different regions.
  * Schedule times now remain consistent with the timezone detected by the browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->