### PR TITLE
Default new web routines to the browser timezone.

### DIFF
--- a/apps/web/src/lib/local-timezone.test.ts
+++ b/apps/web/src/lib/local-timezone.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { localTimezone } from "./local-timezone.js";
+
+describe("localTimezone", () => {
+  it("returns a non-empty IANA timezone string", () => {
+    const zone = localTimezone();
+    expect(zone).not.toBe("");
+    expect(zone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC");
+  });
+});

--- a/apps/web/src/lib/local-timezone.ts
+++ b/apps/web/src/lib/local-timezone.ts
@@ -1,0 +1,7 @@
+/**
+ * The browser's IANA timezone (e.g. "Australia/Sydney"), for timestamp inputs
+ * that would otherwise default to UTC. Falls back to UTC when unavailable.
+ */
+export function localTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -110,6 +110,7 @@ import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
 import { chartViewport } from "../lib/chart-viewport";
 import { dictation } from "../lib/dictation";
+import { localTimezone } from "../lib/local-timezone";
 import { connectMcpOauth } from "../lib/mcp-connect";
 import { revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
@@ -2467,6 +2468,9 @@ export function ShellPage() {
                 </label>
                 <div className="mt-5 text-[14px] text-[#85858A]">
                   When to run
+                  <span className="ml-2 text-[12.5px] text-[#6E6E74]">
+                    {editingRoutine?.timezone ?? localTimezone()}
+                  </span>
                   <Suspense fallback={null}>
                     <RoutineSchedules
                       value={routineDraft.schedules}
@@ -2502,7 +2506,7 @@ export function ShellPage() {
                             name: routineDraft.name || "Routine",
                             prompt: routineDraft.prompt || "Check in.",
                             crons,
-                            timezone: "UTC",
+                            timezone: localTimezone(),
                             active: true,
                             notify: true,
                           });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1034,6 +1034,7 @@ export function ShellPage() {
           prompt: routine.prompt,
           schedules: routine.crons.map(presetFromCron),
         });
+        setEditingRoutine(routine);
         setPanel("routine");
       } else {
         setPanel("computer");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Ports community [#238](https://github.com/elie222/rakazo/pull/238) by [@taur-us](https://github.com/taur-us) (with a CI fix for the unit test).

- New routines created in the web editor send `timezone: localTimezone()` (browser IANA zone via `Intl`, fallback `UTC`) instead of hardcoded `"UTC"`, so schedule times like "9:00 AM" mean local time.
- `rpc.routines.update` still omits `timezone` so an existing zone (e.g. Asia/Tokyo from e2e) survives edits.
- Next to "When to run", show the active IANA zone name in the existing muted style (`editingRoutine?.timezone ?? localTimezone()`).
- Unit tests assert a non-empty string matching Intl/`UTC` and do **not** require a slash in the name — `"UTC"` is valid IANA and has no slash (why #238's tests failed on GitHub Actions).

Out of scope: mobile, schedule-tools, server/DB defaults, timezone picker.

## Test plan
- [x] `TZ=UTC pnpm --filter @rakazo/web test` — local-timezone tests pass when env timezone is UTC
- [ ] CI green on this PR
- [ ] Existing routine e2e still asserts timezone preservation on edit

Co-authored-by: taur-us <93385619+taur-us@users.noreply.github.com>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bcdf9bd-24f4-487b-98fd-33298cb17e54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bcdf9bd-24f4-487b-98fd-33298cb17e54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routine scheduling now uses the browser’s local timezone by default.
  * The routine editor displays the saved timezone or falls back to the local timezone.
  * New routines are saved with the local timezone instead of UTC.
  * Opening a routine from search results now loads it into the editor.

* **Tests**
  * Added coverage for timezone detection and its UTC fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->