### PR TITLE
Fix bot message run output validation

### DIFF
--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -264,6 +264,19 @@ describe("thread event reduction", () => {
     expect(progressed?.cursor).toBe(4);
   });
 
+  it("preserves bot_message when event-sourcing a peer run", () => {
+    const started = reduceThreadSnapshot(
+      snapshot([]),
+      event({
+        type: "run.started",
+        runId: "peer-run-1",
+        payload: { trigger: "bot_message" },
+      }),
+    );
+
+    expect(started?.run?.trigger).toBe("bot_message");
+  });
+
   it("marks the run as waiting when computer takeover is requested", () => {
     const run = threadRun("run-1");
     const initial: ThreadSnapshot = {

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -24,6 +24,7 @@ const runTriggers = new Set<Run["trigger"]>([
   "follow_up",
   "spawn",
   "skill",
+  "bot_message",
 ]);
 
 function runFromStartedEvent(event: ProductEvent, previous: Run | undefined): Run {

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -524,7 +524,7 @@ export const RunSchema = z.object({
   threadId: Id,
   taskId: Id,
   status: RunStatus,
-  trigger: z.enum(["user", "routine", "resume", "follow_up", "spawn", "skill"]),
+  trigger: z.enum(["user", "routine", "resume", "follow_up", "spawn", "skill", "bot_message"]),
   routineId: Id.nullable(),
   modelProvider: z.string().nullable(),
   modelId: z.string().nullable(),

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -11,6 +11,8 @@ import {
   ModelOAuthBeginSchema,
   normalizeCreateBotProfile,
   ProductEventType,
+  RunActivityRowSchema,
+  RunSchema,
   UpdateBotInput,
   UpdateGroupInput,
 } from "./index.js";
@@ -117,6 +119,40 @@ describe("contracts", () => {
     expect(ProductEventType.options).toContain("thread.cleared");
     expect(ProductEventType.options).toContain("thread.subagent");
     expect(ProductEventType.options).toContain("bot.spawned");
+  });
+
+  it("accepts bot-to-bot runs in thread snapshots and activity rows", () => {
+    const run = {
+      id: "run-1",
+      botId: "bot-1",
+      threadId: "thread-1",
+      taskId: "task-1",
+      status: "running",
+      trigger: "bot_message",
+      routineId: null,
+      modelProvider: null,
+      modelId: null,
+      error: null,
+      startedAt: "2026-08-26T00:00:00.000Z",
+      completedAt: null,
+      createdAt: "2026-08-26T00:00:00.000Z",
+    };
+
+    expect(RunSchema.safeParse(run).success).toBe(true);
+    expect(
+      RunActivityRowSchema.safeParse({
+        runId: run.id,
+        botId: run.botId,
+        botName: "Researcher",
+        groupId: null,
+        groupName: null,
+        threadId: run.threadId,
+        status: run.status,
+        trigger: run.trigger,
+        promptSnippet: "Review the report",
+        updatedAt: "2026-08-26T00:00:01.000Z",
+      }).success,
+    ).toBe(true);
   });
 
   it("caps remote MCP headers", () => {

--- a/packages/contracts/src/runs.ts
+++ b/packages/contracts/src/runs.ts
@@ -9,7 +9,7 @@ export const RunActivityRowSchema = z.object({
   groupName: z.string().nullable(),
   threadId: Id,
   status: RunStatus,
-  trigger: z.enum(["user", "routine", "resume", "follow_up", "spawn", "skill"]),
+  trigger: z.enum(["user", "routine", "resume", "follow_up", "spawn", "skill", "bot_message"]),
   promptSnippet: z.string(),
   updatedAt: z.string(),
 });


### PR DESCRIPTION
## Summary

- accept bot_message as a run trigger in thread snapshots and activity rows
- preserve bot_message when reducing live run.started events in the web client
- add regression coverage for serialized and live bot-to-bot runs

## Problem

Bot-to-bot runs are persisted with trigger bot_message, but the output contracts and web event allowlist omitted that value. Thread snapshots containing an active bot-to-bot run therefore failed output validation with a generic 500 response.

## Tests

- pnpm --filter @rakazo/contracts test
- pnpm --filter @rakazo/web exec vitest run --root ../.. apps/web/src/lib/thread-events.test.ts
- pnpm --filter @rakazo/contracts check
- pnpm --filter @rakazo/web check
- Biome check on all five changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bot-to-bot runs triggered by a bot message.
  * Bot-message triggers are now recognized and preserved in run history and activity records.

* **Tests**
  * Added coverage validating bot-to-bot run snapshots, activity records, and event-sourced runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->