### PR TITLE
fix(web): follow up Korean localization review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,5 +78,6 @@ RAKAZO_UPDATER_IMAGE_TAG=local
 # ≥32 chars in production. Leave empty when the sidecar is disabled.
 RAKAZO_UPDATER_URL=
 RAKAZO_UPDATER_TOKEN=
-# Optional BCP 47 locale baked into the web build (for example, ko or ko-KR).
+# Optional BCP 47 default locale for the web UI (for example, ko or ko-KR).
+# A user's saved language choice takes precedence.
 VITE_DEFAULT_UI_LOCALE=

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,6 +14,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/runtime-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "cross-env NODE_ENV=production vite build",
+    "write-runtime-config": "node scripts/write-runtime-config.mjs",
     "preview": "vite preview",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --root ../.. apps/web/src",

--- a/apps/web/public/runtime-config.js
+++ b/apps/web/public/runtime-config.js
@@ -1,0 +1,1 @@
+globalThis.__RAKAZO_RUNTIME_CONFIG__ = {};

--- a/apps/web/scripts/write-runtime-config.mjs
+++ b/apps/web/scripts/write-runtime-config.mjs
@@ -1,0 +1,7 @@
+import { writeFile } from "node:fs/promises";
+
+const defaultUiLocale = process.env.VITE_DEFAULT_UI_LOCALE?.trim() || "";
+const runtimeConfig = JSON.stringify({ defaultUiLocale });
+const output = `globalThis.__RAKAZO_RUNTIME_CONFIG__ = ${runtimeConfig};\n`;
+
+await writeFile(new URL("../dist/runtime-config.js", import.meta.url), output, "utf8");

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -5,3 +5,9 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+type RakazoRuntimeConfig = {
+  readonly defaultUiLocale?: string;
+};
+
+var __RAKAZO_RUNTIME_CONFIG__: RakazoRuntimeConfig | undefined;

--- a/apps/web/src/lib/ui-activity.test.ts
+++ b/apps/web/src/lib/ui-activity.test.ts
@@ -17,5 +17,8 @@ describe("localizeAgentActivity", () => {
     expect(localizeAgentActivity("사용자가 작성한 일반 문장", "ko-KR")).toBe(
       "사용자가 작성한 일반 문장",
     );
+    expect(
+      localizeAgentActivity("Reading the latest status before deciding what to do", "ko-KR"),
+    ).toBe("Reading the latest status before deciding what to do");
   });
 });

--- a/apps/web/src/lib/ui-activity.ts
+++ b/apps/web/src/lib/ui-activity.ts
@@ -8,24 +8,41 @@ const exactKoreanActivity: Readonly<Record<string, string>> = {
   "Saving a note to memory": "기억해두는 중",
 };
 
-const prefixedKoreanActivity: ReadonlyArray<readonly [string, string]> = [
+const delimitedKoreanActivity: ReadonlyArray<readonly [string, string]> = [
   ["Running: ", " 실행 중"],
+  ["Connecting MCP server: ", " MCP 서버 연결 중"],
+  ["Delegating to helper: ", " 보조 에이전트에게 맡기는 중"],
+];
+
+const targetedKoreanActivity: ReadonlyArray<readonly [string, string]> = [
   ["Reading ", " 읽는 중"],
   ["Writing ", " 작성 중"],
   ["Listing ", " 목록 확인 중"],
   ["Attaching ", " 첨부 중"],
   ["Opening ", " 여는 중"],
-  ["Connecting MCP server: ", " MCP 서버 연결 중"],
-  ["Delegating to helper: ", " 보조 에이전트에게 맡기는 중"],
 ];
+
+function looksLikeActivityTarget(value: string): boolean {
+  const target = value.trim();
+  return (
+    /^(?:\.{0,2}\/|~\/|https?:\/\/)/.test(target) ||
+    target.includes("/") ||
+    /\.[A-Za-z0-9]{1,10}$/.test(target)
+  );
+}
 
 export function localizeAgentActivity(text: string, locale?: string): string {
   if (resolveUiLanguage(locale) !== "ko") return text;
   const exact = exactKoreanActivity[text];
   if (exact) return exact;
 
-  for (const [prefix, suffix] of prefixedKoreanActivity) {
+  for (const [prefix, suffix] of delimitedKoreanActivity) {
     if (text.startsWith(prefix)) return `${text.slice(prefix.length)}${suffix}`;
+  }
+  for (const [prefix, suffix] of targetedKoreanActivity) {
+    if (!text.startsWith(prefix)) continue;
+    const target = text.slice(prefix.length);
+    if (looksLikeActivityTarget(target)) return `${target}${suffix}`;
   }
 
   const mcp = /^Using ([^:]+): (.+)$/.exec(text);

--- a/apps/web/src/lib/ui-locale.test.ts
+++ b/apps/web/src/lib/ui-locale.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { resolveUiLocale, selectUiLocale } from "./ui-locale";
 
 describe("selectUiLocale", () => {
-  it("prefers a deployment locale over browser language", () => {
-    expect(selectUiLocale("ko", null, "en-US")).toBe("ko");
+  it("uses a saved user choice before the deployment default", () => {
+    expect(selectUiLocale("ko", "en-US", "ko-KR")).toBe("en-US");
   });
 
   it("allows a saved user choice to override browser language", () => {

--- a/apps/web/src/lib/ui-locale.ts
+++ b/apps/web/src/lib/ui-locale.ts
@@ -3,7 +3,7 @@ export function selectUiLocale(
   savedLocale: string | null | undefined,
   browserLocale: string | null | undefined,
 ): string {
-  return deploymentLocale?.trim() || savedLocale?.trim() || browserLocale?.trim() || "en";
+  return savedLocale?.trim() || deploymentLocale?.trim() || browserLocale?.trim() || "en";
 }
 
 export function resolveUiLocale(): string {
@@ -15,5 +15,7 @@ export function resolveUiLocale(): string {
     // Storage can be unavailable in restricted browser contexts.
   }
   const browserLocale = typeof navigator === "undefined" ? null : navigator.language;
-  return selectUiLocale(import.meta.env.VITE_DEFAULT_UI_LOCALE, savedLocale, browserLocale);
+  const deploymentLocale =
+    globalThis.__RAKAZO_RUNTIME_CONFIG__?.defaultUiLocale ?? import.meta.env.VITE_DEFAULT_UI_LOCALE;
+  return selectUiLocale(deploymentLocale, savedLocale, browserLocale);
 }

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -125,7 +125,10 @@ services:
         GIT_SHA: ${GIT_SHA:-}
         VITE_DEFAULT_UI_LOCALE: ${VITE_DEFAULT_UI_LOCALE:-}
     restart: unless-stopped
-    command: ["pnpm", "--filter", "@rakazo/web", "preview", "--host", "0.0.0.0", "--port", "5173"]
+    command:
+      - bash
+      - -lc
+      - pnpm --filter @rakazo/web write-runtime-config && pnpm --filter @rakazo/web preview --host 0.0.0.0 --port 5173
     init: true
     security_opt:
       - no-new-privileges:true
@@ -138,6 +141,7 @@ services:
     environment:
       NODE_ENV: production
       API_PROXY_TARGET: http://api:3100
+      VITE_DEFAULT_UI_LOCALE: ${VITE_DEFAULT_UI_LOCALE:-}
     expose:
       - "5173"
     networks:

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -101,11 +101,15 @@ services:
       dockerfile: infra/compose/Dockerfile
       args:
         VITE_DEFAULT_UI_LOCALE: ${VITE_DEFAULT_UI_LOCALE:-}
-    command: ["pnpm", "--filter", "@rakazo/web", "preview", "--host", "0.0.0.0", "--port", "5173"]
+    command:
+      - bash
+      - -lc
+      - pnpm --filter @rakazo/web write-runtime-config && pnpm --filter @rakazo/web preview --host 0.0.0.0 --port 5173
     environment:
       API_PROXY_TARGET: http://api:3100
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-}
       RAKAZO_HOST: ${RAKAZO_HOST:-localhost}
+      VITE_DEFAULT_UI_LOCALE: ${VITE_DEFAULT_UI_LOCALE:-}
     ports:
       - "5173:5173"
     depends_on:


### PR DESCRIPTION
## Summary

Follow-up for #250, limited to the remaining automated-review findings:

- let a saved user locale override the deployment default while preserving the restricted-storage fallback
- prevent broad activity-prefix matching from rewriting ordinary model prose
- generate a runtime locale config when the web container starts so pulled prebuilt images honor `VITE_DEFAULT_UI_LOCALE`

## Verification

- `pnpm lint`
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web test` — 21 files, 115 tests passed
- production web build
- development and production Compose YAML parsed successfully
- production preview served `runtime-config.js` with `defaultUiLocale: ko-KR`

This targets the head branch of #250 so it can be reviewed or merged without reopening superseded #249.