### PR TITLE
Default uncapped tool calls; optional MAX_TOOL_CALLS_PER_TURN soft-stop (#248)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ WAKEUP_DRIVER=graphile
 # Pause or stop computers after this many idle ms. Minimum 30000.
 SANDBOX_IDLE_MS=600000
 SANDBOX_COMMAND_TIMEOUT_MS=300000
+# Optional per-turn tool-call fuse for the Pi agent runtime. Unset, empty, or 0
+# means unlimited (default). Set a positive integer to soft-stop a turn that
+# exceeds the budget and still emit a final assistant message.
+MAX_TOOL_CALLS_PER_TURN=
 OPENROUTER_API_KEY=
 PI_DEFAULT_PROVIDER=openrouter
 # Text-only by default. Computer use (screenshots via computer_observe / computer_act)

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -42,6 +42,7 @@ AGENT_RUNTIME=pi          # Keep scripted only for pnpm test.
 WAKEUP_DRIVER=graphile
 SANDBOX_IDLE_MS=600000    # pause the bot computer after 10 minutes idle
 SANDBOX_COMMAND_TIMEOUT_MS=300000 # stop a shell command after 5 minutes
+MAX_TOOL_CALLS_PER_TURN=  # optional Pi turn tool-call fuse; unset/0 = unlimited
 E2B_API_KEY=              # when SANDBOX_PROVIDER=e2b
 DAYTONA_API_KEY=          # when SANDBOX_PROVIDER=daytona
 BOX_API_KEY=              # when SANDBOX_PROVIDER=box

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -1,5 +1,5 @@
 import type { ConnectorTool } from "@rakazo/adapter-kit";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakeAgentState = vi.hoisted(() => ({
   mode: "dispatch" as "dispatch" | "subagent-limit" | "parent-limit",
@@ -108,7 +108,7 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
-import { PiAgentRuntime } from "./pi-runtime.js";
+import { PiAgentRuntime, maxToolCallsPerTurn } from "./pi-runtime.js";
 
 const destinationTool: ConnectorTool = {
   name: "destination.write",
@@ -136,6 +136,14 @@ const writeFileTool: ConnectorTool = {
   },
 };
 
+const shellTool = {
+  name: "shell",
+  description: "Run a command",
+  inputSchema: { type: "object", properties: { command: { type: "string" } } },
+};
+
+const previousMaxToolCalls = process.env.MAX_TOOL_CALLS_PER_TURN;
+
 describe("Pi connector tool dispatch", () => {
   beforeEach(() => {
     fakeAgentState.mode = "dispatch";
@@ -145,6 +153,12 @@ describe("Pi connector tool dispatch", () => {
       name: "destination_write",
       args: { collection: "notes", title: "Result", body: "Done" },
     };
+    delete process.env.MAX_TOOL_CALLS_PER_TURN;
+  });
+
+  afterEach(() => {
+    if (previousMaxToolCalls === undefined) delete process.env.MAX_TOOL_CALLS_PER_TURN;
+    else process.env.MAX_TOOL_CALLS_PER_TURN = previousMaxToolCalls;
   });
 
   it("exposes a provider-safe name while executing the original connector name", async () => {
@@ -183,7 +197,93 @@ describe("Pi connector tool dispatch", () => {
     );
   });
 
-  it("shares the tool-call budget with subagents and still emits a final message", async () => {
+  it("allows more than 80 tool calls by default when no fuse is configured", async () => {
+    fakeAgentState.mode = "parent-limit";
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const runtime = new PiAgentRuntime();
+    const events: unknown[] = [];
+
+    for await (const event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "unlimited",
+        prompt: "keep going",
+        instructions: "Use shell.",
+        history: [],
+        tools: [shellTool],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool,
+      },
+      {
+        operationId: "2a",
+        traceId: "2a",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(executeTool).toHaveBeenCalledTimes(100);
+    expect(fakeAgentState.abortCount).toBe(0);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        type: "progress",
+        text: expect.stringContaining("tool calls in one turn"),
+      }),
+    );
+  });
+
+  it("soft-stops with a final message when MAX_TOOL_CALLS_PER_TURN is set", async () => {
+    process.env.MAX_TOOL_CALLS_PER_TURN = "80";
+    fakeAgentState.mode = "parent-limit";
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const runtime = new PiAgentRuntime();
+    const events: unknown[] = [];
+
+    for await (const event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "parent-limited",
+        prompt: "keep going",
+        instructions: "Use shell.",
+        history: [],
+        tools: [shellTool],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool,
+      },
+      {
+        operationId: "2b",
+        traceId: "2b",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(executeTool).toHaveBeenCalledTimes(80);
+    expect(fakeAgentState.abortCount).toBeGreaterThanOrEqual(1);
+    expect(events).toContainEqual({
+      type: "progress",
+      text: "Stopped: more than 80 tool calls in one turn.",
+    });
+    expect(events).toContainEqual({
+      type: "text",
+      text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
+    });
+    expect(events.at(-1)).toEqual({
+      type: "done",
+      text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
+    });
+  });
+
+  it("shares an optional tool-call fuse with subagents and still emits a final message", async () => {
+    process.env.MAX_TOOL_CALLS_PER_TURN = "80";
     fakeAgentState.mode = "subagent-limit";
     const executeTool = vi.fn(async () => ({ ok: true }));
     const runtime = new PiAgentRuntime();
@@ -203,11 +303,7 @@ describe("Pi connector tool dispatch", () => {
             description: "Delegate work",
             inputSchema: { type: "object", properties: {} },
           },
-          {
-            name: "shell",
-            description: "Run a command",
-            inputSchema: { type: "object", properties: { command: { type: "string" } } },
-          },
+          shellTool,
         ],
         model: { provider: "test", id: "dispatch-test-model" },
         executeTool,
@@ -255,55 +351,14 @@ describe("Pi connector tool dispatch", () => {
     );
   });
 
-  it("emits a final assistant message when the parent turn hits the tool-call budget", async () => {
-    fakeAgentState.mode = "parent-limit";
-    const executeTool = vi.fn(async () => ({ ok: true }));
-    const runtime = new PiAgentRuntime();
-    const events: unknown[] = [];
-
-    for await (const event of runtime.run(
-      {
-        botId: "b",
-        threadId: "t",
-        runId: "parent-limited",
-        prompt: "keep going",
-        instructions: "Use shell.",
-        history: [],
-        tools: [
-          {
-            name: "shell",
-            description: "Run a command",
-            inputSchema: { type: "object", properties: { command: { type: "string" } } },
-          },
-        ],
-        model: { provider: "test", id: "dispatch-test-model" },
-        executeTool,
-      },
-      {
-        operationId: "2b",
-        traceId: "2b",
-        workspaceId: "w",
-        userId: "u",
-        signal: new AbortController().signal,
-      },
-    )) {
-      events.push(event);
-    }
-
-    expect(executeTool).toHaveBeenCalledTimes(80);
-    expect(fakeAgentState.abortCount).toBeGreaterThanOrEqual(1);
-    expect(events).toContainEqual({
-      type: "progress",
-      text: "Stopped: more than 80 tool calls in one turn.",
-    });
-    expect(events).toContainEqual({
-      type: "text",
-      text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
-    });
-    expect(events.at(-1)).toEqual({
-      type: "done",
-      text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
-    });
+  it("treats unset, empty, and non-positive MAX_TOOL_CALLS_PER_TURN as unlimited", () => {
+    expect(maxToolCallsPerTurn({})).toBe(0);
+    expect(maxToolCallsPerTurn({ MAX_TOOL_CALLS_PER_TURN: "" })).toBe(0);
+    expect(maxToolCallsPerTurn({ MAX_TOOL_CALLS_PER_TURN: "0" })).toBe(0);
+    expect(maxToolCallsPerTurn({ MAX_TOOL_CALLS_PER_TURN: "-5" })).toBe(0);
+    expect(maxToolCallsPerTurn({ MAX_TOOL_CALLS_PER_TURN: "abc" })).toBe(0);
+    expect(maxToolCallsPerTurn({ MAX_TOOL_CALLS_PER_TURN: "80" })).toBe(80);
+    expect(maxToolCallsPerTurn({ MAX_TOOL_CALLS_PER_TURN: " 12.9 " })).toBe(12);
   });
 
   it("serialises object content instead of writing [object Object] for write_file", async () => {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -108,7 +108,7 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
-import { PiAgentRuntime, maxToolCallsPerTurn } from "./pi-runtime.js";
+import { maxToolCallsPerTurn, PiAgentRuntime } from "./pi-runtime.js";
 
 const destinationTool: ConnectorTool = {
   name: "destination.write",

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -2,7 +2,7 @@ import type { ConnectorTool } from "@rakazo/adapter-kit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakeAgentState = vi.hoisted(() => ({
-  mode: "dispatch" as "dispatch" | "subagent-limit",
+  mode: "dispatch" as "dispatch" | "subagent-limit" | "parent-limit",
   abortCount: 0,
   tools: [] as Array<{
     name: string;
@@ -17,7 +17,7 @@ const fakeAgentState = vi.hoisted(() => ({
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
   Agent: class {
-    state = { errorMessage: undefined, messages: [] };
+    state = { errorMessage: undefined as string | undefined, messages: [] as unknown[] };
     private readonly tools: typeof fakeAgentState.tools;
     private readonly listeners: Array<(event: Record<string, unknown>) => void> = [];
     private aborted = false;
@@ -39,6 +39,18 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
         const rawArgs = fakeAgentState.invoke.args;
         const args = target.prepareArguments?.(rawArgs) ?? rawArgs;
         await target.execute("call-1", args);
+        return;
+      }
+
+      if (fakeAgentState.mode === "parent-limit") {
+        const shell = this.tools.find((tool) => tool.name === "shell");
+        if (!shell) throw new Error("shell was not exposed");
+        for (let index = 0; index < 100; index += 1) {
+          const args = { command: `echo ${index}` };
+          this.emit({ type: "tool_execution_start", toolName: shell.name, args });
+          if (this.aborted) break;
+          await shell.execute(`shell-${index}`, args);
+        }
         return;
       }
 
@@ -64,6 +76,9 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
 
     abort() {
       this.aborted = true;
+      // Mirror pi-agent-core: abort settles the run with an errorMessage that
+      // would otherwise make PiAgentRuntime throw and skip a final reply.
+      this.state.errorMessage = "Request aborted by user";
       fakeAgentState.abortCount += 1;
     }
 
@@ -168,7 +183,7 @@ describe("Pi connector tool dispatch", () => {
     );
   });
 
-  it("shares the tool-call budget with subagents", async () => {
+  it("shares the tool-call budget with subagents and still emits a final message", async () => {
     fakeAgentState.mode = "subagent-limit";
     const executeTool = vi.fn(async () => ({ ok: true }));
     const runtime = new PiAgentRuntime();
@@ -213,6 +228,65 @@ describe("Pi connector tool dispatch", () => {
     expect(events).toContainEqual({
       type: "progress",
       text: "Stopped: more than 80 tool calls in one turn.",
+    });
+    expect(events).toContainEqual({
+      type: "text",
+      text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
+    });
+    expect(events).toContainEqual({
+      type: "done",
+      text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
+    });
+  });
+
+  it("emits a final assistant message when the parent turn hits the tool-call budget", async () => {
+    fakeAgentState.mode = "parent-limit";
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const runtime = new PiAgentRuntime();
+    const events: unknown[] = [];
+
+    for await (const event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "parent-limited",
+        prompt: "keep going",
+        instructions: "Use shell.",
+        history: [],
+        tools: [
+          {
+            name: "shell",
+            description: "Run a command",
+            inputSchema: { type: "object", properties: { command: { type: "string" } } },
+          },
+        ],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool,
+      },
+      {
+        operationId: "2b",
+        traceId: "2b",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(executeTool).toHaveBeenCalledTimes(80);
+    expect(fakeAgentState.abortCount).toBeGreaterThanOrEqual(1);
+    expect(events).toContainEqual({
+      type: "progress",
+      text: "Stopped: more than 80 tool calls in one turn.",
+    });
+    expect(events).toContainEqual({
+      type: "text",
+      text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
+    });
+    expect(events.at(-1)).toEqual({
+      type: "done",
+      text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
     });
   });
 

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -237,6 +237,22 @@ describe("Pi connector tool dispatch", () => {
       type: "done",
       text: "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
     });
+    const subagentEvents = events.filter(
+      (event): event is { type: "subagent"; status: string; result?: string } =>
+        typeof event === "object" &&
+        event !== null &&
+        "type" in event &&
+        (event as { type?: string }).type === "subagent",
+    );
+    expect(subagentEvents.some((event) => event.status === "failed")).toBe(false);
+    expect(subagentEvents).toContainEqual(
+      expect.objectContaining({
+        type: "subagent",
+        status: "completed",
+        result:
+          "I stopped after reaching the limit of 80 tool calls in this turn. Send another message to continue.",
+      }),
+    );
   });
 
   it("emits a final assistant message when the parent turn hits the tool-call budget", async () => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -55,8 +55,15 @@ function thinkingLevelFor(
 const AGENT_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_AGENT_TOOL_NAME_LENGTH = 64;
 const FALLBACK_AGENT_TOOL_NAME = "connector_tool";
-// Bound runaway agent loops before they can issue unbounded billable tool calls.
-const MAX_TOOL_CALLS_PER_TURN = 80;
+
+/** Optional self-host fuse. Unset, empty, or 0 means unlimited (default). */
+export function maxToolCallsPerTurn(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.MAX_TOOL_CALLS_PER_TURN?.trim();
+  if (!raw) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}
 
 export class PiAgentRuntime implements AgentRuntime {
   describe() {
@@ -122,7 +129,7 @@ export class PiAgentRuntime implements AgentRuntime {
           apiKey,
           nestedAgents,
           subagentGate: createGate(MAX_PARALLEL_SUBAGENTS),
-          toolCallBudget: { count: 0, exceeded: false },
+          toolCallBudget: { count: 0, exceeded: false, limit: maxToolCallsPerTurn() },
           abortTurn: () => undefined,
           signal,
           depth: 0,
@@ -228,7 +235,7 @@ export class PiAgentRuntime implements AgentRuntime {
           throw new Error(sanitizeError(error));
         }
         if (budgetExceeded) {
-          const budgetMessage = toolCallBudgetExceededMessage(MAX_TOOL_CALLS_PER_TURN);
+          const budgetMessage = toolCallBudgetExceededMessage(host.toolCallBudget.limit);
           if (streamed.trim()) {
             const suffix = `\n\n${budgetMessage}`;
             queue.push({ type: "text", text: suffix });
@@ -660,7 +667,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
       return `Subagent failed: ${message}`;
     }
     const budgetMessage = budgetExceeded
-      ? toolCallBudgetExceededMessage(MAX_TOOL_CALLS_PER_TURN)
+      ? toolCallBudgetExceededMessage(host.toolCallBudget.limit)
       : undefined;
     const result =
       budgetMessage && streamed.trim()
@@ -876,7 +883,7 @@ interface ToolHost {
   apiKey: string | undefined;
   nestedAgents: Set<Agent>;
   subagentGate: { acquire(): Promise<void>; release(): void };
-  toolCallBudget: { count: number; exceeded: boolean };
+  toolCallBudget: { count: number; exceeded: boolean; limit: number };
   abortTurn(): void;
   signal: AbortSignal;
   depth: number;
@@ -888,12 +895,14 @@ function toolCallBudgetExceededMessage(limit: number) {
 
 function consumeToolCall(host: ToolHost): boolean {
   host.toolCallBudget.count += 1;
-  if (host.toolCallBudget.count <= MAX_TOOL_CALLS_PER_TURN) return true;
+  const limit = host.toolCallBudget.limit;
+  // limit <= 0 means unlimited — do not abort.
+  if (limit <= 0 || host.toolCallBudget.count <= limit) return true;
   if (!host.toolCallBudget.exceeded) {
     host.toolCallBudget.exceeded = true;
     host.queue.push({
       type: "progress",
-      text: `Stopped: more than ${MAX_TOOL_CALLS_PER_TURN} tool calls in one turn.`,
+      text: `Stopped: more than ${limit} tool calls in one turn.`,
     });
   }
   host.abortTurn();

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -219,11 +219,25 @@ export class PiAgentRuntime implements AgentRuntime {
           signal.removeEventListener("abort", onAbort);
         }
 
+        // Budget abort stops the agent underneath the model, which leaves
+        // errorMessage set. Treat that as a soft stop so the turn still ends
+        // with a durable assistant message instead of a failed run.
+        const budgetExceeded = host.toolCallBudget.exceeded;
         const error = agent.state.errorMessage;
-        if (error) {
+        if (error && !budgetExceeded) {
           throw new Error(sanitizeError(error));
         }
-        if (!streamed) {
+        if (budgetExceeded) {
+          const budgetMessage = toolCallBudgetExceededMessage(MAX_TOOL_CALLS_PER_TURN);
+          if (streamed.trim()) {
+            const suffix = `\n\n${budgetMessage}`;
+            queue.push({ type: "text", text: suffix });
+            streamed += suffix;
+          } else {
+            queue.push({ type: "text", text: budgetMessage });
+            streamed = budgetMessage;
+          }
+        } else if (!streamed) {
           const fallback = assistantText(agent.state.messages.at(-1)) || "I finished the work.";
           queue.push({ type: "text", text: fallback });
           streamed = fallback;
@@ -857,6 +871,10 @@ interface ToolHost {
   abortTurn(): void;
   signal: AbortSignal;
   depth: number;
+}
+
+function toolCallBudgetExceededMessage(limit: number) {
+  return `I stopped after reaching the limit of ${limit} tool calls in this turn. Send another message to continue.`;
 }
 
 function consumeToolCall(host: ToolHost): boolean {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -650,13 +650,22 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
     await nested.prompt(task || "Complete the delegated task.");
     await nested.waitForIdle();
     host.signal.removeEventListener("abort", onAbort);
+    // Shared-budget abort leaves errorMessage on the nested agent; surface it as a
+    // completed stop rather than a failed subagent chip.
+    const budgetExceeded = host.toolCallBudget.exceeded;
     const error = nested.state.errorMessage;
-    if (error) {
+    if (error && !budgetExceeded) {
       const message = sanitizeError(error);
       host.queue.push({ type: "subagent", agentId, name, task, status: "failed", result: message });
       return `Subagent failed: ${message}`;
     }
-    const result = streamed || assistantText(nested.state.messages.at(-1)) || "done.";
+    const budgetMessage = budgetExceeded
+      ? toolCallBudgetExceededMessage(MAX_TOOL_CALLS_PER_TURN)
+      : undefined;
+    const result =
+      budgetMessage && streamed.trim()
+        ? `${streamed.trim()}\n\n${budgetMessage}`
+        : budgetMessage || streamed || assistantText(nested.state.messages.at(-1)) || "done.";
     const clipped = result.length > 12_000 ? `${result.slice(0, 12_000)}…` : result;
     host.queue.push({
       type: "subagent",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reference: #248

## Decision
Default is no per-turn tool-call limit (like Codex/Claude). The old hard-coded 80 is gone.

## Change
- `consumeToolCall` only enforces a limit when `MAX_TOOL_CALLS_PER_TURN` is a positive integer.
- Unset, empty, or `0` means unlimited.
- When a fuse is configured and hit: keep the soft-stop path (progress chip + durable assistant message; do not fail the run on abort `errorMessage`). Nested agents complete with the limit message instead of `failed`.
- Documented in `.env.example` (and a one-liner in `docs/self-host.md`).
- Tests cover unlimited default (>80 calls), capped soft-stop with a final message, shared subagent fuse, and env parsing.

No settings UI. No merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85443f7c-4b26-42e0-b604-94893a1b09ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85443f7c-4b26-42e0-b604-94893a1b09ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tool-call limit exhaustion now ends the current turn gracefully instead of producing an agent error.
  - The assistant provides a clear explanation when the tool-call budget is reached.
  - Completed responses and completion events are now preserved when subagent or parent tool limits are reached.
  - Other agent errors continue to be reported normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->