### PR TITLE
feat(web): view any other agent's computer, read only

### DIFF
--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -88,6 +88,7 @@ describe("computer.peek", () => {
       overrides.connectScreen ??
       vi.fn().mockResolvedValue({ url: "https://sandbox.test/vnc.html", close: async () => {} });
     const leaseFindUnique = overrides.leaseFindUnique ?? vi.fn();
+    const enqueue = vi.fn().mockResolvedValue(undefined);
     const prisma = {
       bot: { findFirst: overrides.botFindFirst ?? vi.fn().mockResolvedValue(null) },
       computerExecutionLease: { findUnique: leaseFindUnique },
@@ -95,6 +96,7 @@ describe("computer.peek", () => {
     const deps = {
       prisma,
       sandbox: { connectScreen },
+      jobs: { enqueue },
       env: {
         defaultProvider: "fake",
         defaultModel: "fake-model",
@@ -104,7 +106,13 @@ describe("computer.peek", () => {
       },
       dataDir: "/tmp/rakazo-router-test",
     } as unknown as RouterDeps;
-    return { deps, connectScreen, leaseFindUnique, handler: new RPCHandler(createRouter(deps)) };
+    return {
+      deps,
+      connectScreen,
+      leaseFindUnique,
+      enqueue,
+      handler: new RPCHandler(createRouter(deps)),
+    };
   }
 
   async function callPeek(

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -71,6 +71,123 @@ describe("thread answer delivery", () => {
   });
 });
 
+describe("computer.peek", () => {
+  const actor = {
+    workspaceId: "workspace-1",
+    userId: "user-1",
+    email: "user@rakazo.test",
+    isDeploymentOwner: true,
+  } satisfies Actor;
+
+  function peekDeps(overrides: {
+    botFindFirst?: ReturnType<typeof vi.fn>;
+    leaseFindUnique?: ReturnType<typeof vi.fn>;
+    connectScreen?: ReturnType<typeof vi.fn>;
+  }) {
+    const connectScreen =
+      overrides.connectScreen ??
+      vi.fn().mockResolvedValue({ url: "https://sandbox.test/vnc.html", close: async () => {} });
+    const leaseFindUnique = overrides.leaseFindUnique ?? vi.fn();
+    const prisma = {
+      bot: { findFirst: overrides.botFindFirst ?? vi.fn().mockResolvedValue(null) },
+      computerExecutionLease: { findUnique: leaseFindUnique },
+    } as unknown as PrismaClient;
+    const deps = {
+      prisma,
+      sandbox: { connectScreen },
+      env: {
+        defaultProvider: "fake",
+        defaultModel: "fake-model",
+        webOrigin: "http://127.0.0.1:5173",
+        screenProxySecret: "fake-test-secret",
+        sandboxProvider: "fake",
+      },
+      dataDir: "/tmp/rakazo-router-test",
+    } as unknown as RouterDeps;
+    return { deps, connectScreen, leaseFindUnique, handler: new RPCHandler(createRouter(deps)) };
+  }
+
+  async function callPeek(
+    handler: ReturnType<typeof peekDeps>["handler"],
+    targetBotId: string,
+    peekActor: Actor = actor,
+  ) {
+    return handler.handle(
+      new Request("http://127.0.0.1/rpc/computer/peek", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { targetBotId } }),
+      }),
+      { prefix: "/rpc", context: { actor: peekActor } },
+    );
+  }
+
+  it("fails closed for an unknown or foreign bot id", async () => {
+    const { handler, connectScreen, leaseFindUnique } = peekDeps({
+      botFindFirst: vi.fn().mockResolvedValue(null),
+    });
+    const { matched, response } = await callPeek(handler, "missing-bot");
+    expect(matched).toBe(true);
+    expect(response.status).not.toBe(200);
+    expect(connectScreen).not.toHaveBeenCalled();
+    expect(leaseFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("connects the target screen without an execution lease", async () => {
+    const target = {
+      id: "bot-other",
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      thread: { id: "thread-other" },
+      computer: {
+        id: "computer-1",
+        homeKey: "home-1",
+        kind: "fake",
+        scope: "team",
+        state: "running",
+        providerRef: "provider-1",
+        controlHolder: "none",
+        controlBotId: null,
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlRunId: null,
+      },
+    };
+    const { handler, connectScreen, leaseFindUnique } = peekDeps({
+      botFindFirst: vi.fn().mockResolvedValue(target),
+      // If peek incorrectly used computerScreenContext, this lease would be attached.
+      leaseFindUnique: vi.fn().mockResolvedValue({
+        runId: "run-1",
+        fence: 3,
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    });
+
+    const { matched, response } = await callPeek(handler, target.id);
+    expect(matched).toBe(true);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      json: { mode: "team", exists: true, state: "running" },
+    });
+    expect(typeof body.json.url).toBe("string");
+    expect(connectScreen).toHaveBeenCalledOnce();
+    expect(connectScreen).toHaveBeenCalledWith(
+      expect.objectContaining({ providerRef: "provider-1" }),
+      { view: "stream", interactive: false },
+      expect.objectContaining({
+        botId: "bot-other",
+        operationId: "peek",
+        workspaceId: "workspace-1",
+        userId: "user-1",
+      }),
+    );
+    const context = connectScreen.mock.calls[0]?.[2] as { screenLeaseId?: string };
+    expect(context.screenLeaseId).toBeUndefined();
+    expect(leaseFindUnique).not.toHaveBeenCalled();
+  });
+});
+
 describe("MCP server deletion", () => {
   it("does not fail when a concurrent credential rotation already removed the old secret", async () => {
     const deleteServer = vi.fn().mockResolvedValue({ id: "server-1" });

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1470,6 +1470,7 @@ export function createRouter(deps: RouterDeps) {
         if (!session.url) {
           return { mode, exists: true, state: other.state as never, url: null };
         }
+        scheduleComputerSleep(deps.jobs, other.id);
         const viewUrl = withViewOnly(session.url, true);
         return {
           mode,

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1442,6 +1442,47 @@ export function createRouter(deps: RouterDeps) {
           ),
         };
       }),
+      /**
+       * Read-only look at ANY other bot's currently assigned computer — for
+       * the computer-pane picker, which is a view toggle, not a
+       * reassignment or takeover. Never boots, provisions, or mutates
+       * anything: a stopped/never-used computer just reports
+       * { exists, state } with a null screen.
+       */
+      peek: authed.computer.peek.handler(async ({ context, input }) => {
+        const target = await repos.getBot(context.actor, input.targetBotId);
+        const mode = target.computer?.scope === "dedicated" ? "dedicated" : "team";
+        const other = target.computer;
+        if (!other) return { mode, exists: false, state: null, url: null };
+        if (!other.providerRef || (other.state !== "running" && other.state !== "booting")) {
+          return { mode, exists: true, state: other.state as never, url: null };
+        }
+        const session = await deps.sandbox
+          .connectScreen(
+            toComputerRef(other),
+            { view: "stream", interactive: false },
+            await computerScreenContext(deps.prisma, context.actor, other.id, target.id, "peek"),
+          )
+          .catch(() => ({ url: null }));
+        if (!session.url) {
+          return { mode, exists: true, state: other.state as never, url: null };
+        }
+        const viewUrl = withViewOnly(session.url, true);
+        return {
+          mode,
+          exists: true,
+          state: other.state as never,
+          url: addScreenProxyCapability(
+            viewUrl,
+            deps.env.screenProxySecret,
+            deps.env.webOrigin,
+            undefined,
+            {
+              proxyExternal: other.kind === "box",
+            },
+          ),
+        };
+      }),
       heartbeat: authed.computer.heartbeat.handler(async ({ context, input }) => {
         const bot = await repos.getBot(context.actor, input.botId);
         if (bot.computer?.state === "running" && bot.computer.providerRef) {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1457,11 +1457,14 @@ export function createRouter(deps: RouterDeps) {
         if (!other.providerRef || (other.state !== "running" && other.state !== "booting")) {
           return { mode, exists: true, state: other.state as never, url: null };
         }
+        // Peek is strictly view-only: never attach the target bot's execution
+        // lease. computerScreenContext would set screenLeaseId and let the
+        // supervisor overwrite or reject the shared screen assignment.
         const session = await deps.sandbox
           .connectScreen(
             toComputerRef(other),
             { view: "stream", interactive: false },
-            await computerScreenContext(deps.prisma, context.actor, other.id, target.id, "peek"),
+            computerContext(context.actor, target.id, "peek"),
           )
           .catch(() => ({ url: null }));
         if (!session.url) {

--- a/apps/web/e2e/computer-peek.spec.ts
+++ b/apps/web/e2e/computer-peek.spec.ts
@@ -1,0 +1,55 @@
+import { expect, type Page, test } from "@playwright/test";
+import { activeBotId, captureScreenshot, completeOnboarding, openNewBot, signup } from "./helpers";
+
+test("View… peeks another bot's computer read-only", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+
+  await signup(page, `computer-peek-${stamp}@rakazo.test`, "password12", "Computer Peek");
+  await completeOnboarding(page);
+  const chiefId = activeBotId(page);
+
+  await createBot(page, "Writer", "team");
+  await openBot(page, "Chief");
+  expect(activeBotId(page)).toBe(chiefId);
+
+  await openComputerPanel(page);
+  const panel = page.getByTestId("side-panel");
+  await panel.getByRole("button", { name: "View another computer" }).click();
+  const picker = panel.getByRole("button", { name: "Writer", exact: true });
+  await expect(picker).toBeVisible();
+  await captureScreenshot(page, testInfo, "computer-peek-picker");
+
+  await picker.click();
+  await expect(panel.getByRole("button", { name: "Back to your computer" })).toBeVisible();
+  await expect(panel.getByText("Viewing Writer (read only)", { exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "computer-peek-view");
+});
+
+async function createBot(page: Page, name: string, mode: "team" | "dedicated") {
+  await openNewBot(page);
+  await expect(page.getByText("New bot", { exact: true })).toBeVisible();
+  const team = page.getByRole("button", { name: "Team", exact: true });
+  const privateComputer = page.getByRole("button", { name: "Private", exact: true });
+  await expect(team).toHaveAttribute("aria-pressed", "true");
+  if (mode === "dedicated") await privateComputer.click();
+  await expect(mode === "team" ? team : privateComputer).toHaveAttribute("aria-pressed", "true");
+  await page.getByPlaceholder("Name this bot").fill(name);
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await expect(page.getByPlaceholder(`Message ${name}`)).toBeVisible();
+  return activeBotId(page);
+}
+
+async function openBot(page: Page, name: string) {
+  await page
+    .locator("aside")
+    .first()
+    .getByRole("button", { name: new RegExp(`^${name}`) })
+    .click();
+  await expect(page.getByPlaceholder(`Message ${name}`)).toBeVisible();
+}
+
+async function openComputerPanel(page: Page) {
+  await page.getByTitle("Agent computer").click();
+  await expect(page.getByRole("button", { name: "Take control", exact: true })).toBeVisible();
+}

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1816
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (ungelesen)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# Modell} other {# Modelle}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1260
+#: src/pages/Shell.tsx:1273
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (maximal {ATTACHMENT_MAX_COUNT} Anhänge)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1264
+#: src/pages/Shell.tsx:1277
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (über 10 MiB)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5070
+#: src/pages/Shell.tsx:5191
 msgid "{0} connection"
 msgstr "{0}-Verbindung"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2298
+#: src/pages/Shell.tsx:2419
 msgid "{0} is using it"
 msgstr "{0} verwendet es"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:118
-#: src/pages/Shell.tsx:2020
+#: src/pages/AccountSettingsOverlay.tsx:121
+#: src/pages/Shell.tsx:2066
 msgid "{0} runs · {1} tokens"
 msgstr "{0} Läufe · {1} Tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# verbundener Bot} other {# verbundene Bot
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} hat noch keinem anderen Bot eine Nachricht gesendet."
 
-#: src/pages/Shell.tsx:4947
+#: src/pages/Shell.tsx:5068
 msgid "{botName}’s computer"
 msgstr "Computer von {botName}"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3311
+#: src/pages/Shell.tsx:3432
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ Aufgabe anlernen"
 msgid "Access token (optional)"
 msgstr "Zugriffstoken (optional)"
 
-#: src/pages/AccountSettingsOverlay.tsx:94
+#: src/pages/AccountSettingsOverlay.tsx:97
 msgid "Account"
 msgstr "Konto"
 
-#: src/pages/Shell.tsx:4461
+#: src/pages/Shell.tsx:4582
 msgid "Account default"
 msgstr "Kontostandard"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
+#: src/pages/AccountSettingsOverlay.tsx:82
 msgid "Account preferences apply across all your bots."
 msgstr "Kontoeinstellungen gelten für alle deine Bots."
 
@@ -156,8 +156,8 @@ msgstr "Aktives Modell"
 msgid "Active voice"
 msgstr "Aktive Stimme"
 
-#: src/pages/Shell.tsx:1700
-#: src/pages/Shell.tsx:1702
+#: src/pages/Shell.tsx:1746
+#: src/pages/Shell.tsx:1748
 msgid "Activity"
 msgstr "Aktivität"
 
@@ -214,9 +214,9 @@ msgstr "Treg hinzufügen"
 msgid "Adding…"
 msgstr "Wird hinzugefügt…"
 
-#: src/pages/AccountSettingsOverlay.tsx:135
+#: src/pages/AccountSettingsOverlay.tsx:138
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4364
+#: src/pages/Shell.tsx:4485
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -224,7 +224,7 @@ msgstr "Erweitert"
 msgid "Agent access for new servers"
 msgstr "Agent-Zugriff für neue Server"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2153
 msgid "Agent computer"
 msgstr "Agent-Computer"
 
@@ -311,11 +311,11 @@ msgstr "Gilt beim Hinzufügen des Servers. Mit den Agent-Chips auf jeder Serverk
 msgid "Approval boundaries"
 msgstr "Bestätigungsgrenzen"
 
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5384
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: src/pages/Shell.tsx:5254
+#: src/pages/Shell.tsx:5375
 msgid "Approve this server to let your agent use its tools."
 msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 
@@ -327,15 +327,15 @@ msgstr "Apps"
 msgid "Archive"
 msgstr "Archivieren"
 
-#: src/pages/Shell.tsx:3912
+#: src/pages/Shell.tsx:4033
 msgid "archived"
 msgstr "archiviert"
 
-#: src/pages/Shell.tsx:1900
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "Archiviert"
 
-#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4044
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archiviert. Chat, Erinnerungen und Dateien bleiben erhalten."
 
@@ -374,7 +374,7 @@ msgstr "Vor Käufen nachfragen"
 msgid "Ask before sending external email"
 msgstr "Vor dem Senden externer E-Mails nachfragen"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2421
 msgid "Asleep"
 msgstr "Im Ruhezustand"
 
@@ -389,11 +389,11 @@ msgstr "um {0}"
 msgid "at {timeSelect}"
 msgstr "um {timeSelect}"
 
-#: src/pages/Shell.tsx:3382
+#: src/pages/Shell.tsx:3503
 msgid "Attach file"
 msgstr "Datei anhängen"
 
-#: src/pages/Shell.tsx:3581
+#: src/pages/Shell.tsx:3702
 msgid "Attachment"
 msgstr "Anhang"
 
@@ -406,14 +406,19 @@ msgstr "Autorisierungscode oder Callback-URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Autorisierung abgelaufen — erneute Verbindung erforderlich"
 
-#: src/pages/Shell.tsx:5055
+#: src/pages/Shell.tsx:5176
 msgid "Authorization timed out. Please try again."
 msgstr "Zeitüberschreitung bei der Autorisierung. Versuche es erneut."
 
-#: src/pages/Shell.tsx:5097
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5384
 msgid "Authorize"
 msgstr "Autorisieren"
+
+#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2283
+msgid "Back to your computer"
+msgstr "Zurück zu deinem Computer"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -423,18 +428,18 @@ msgstr "Basis-URL"
 msgid "Bearer token"
 msgstr "Bearer-Token"
 
-#: src/pages/Shell.tsx:4939
+#: src/pages/Shell.tsx:5060
 msgid "Booting live desktop…"
 msgstr "Live-Desktop wird gestartet…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:2944
 msgid "Booting up {0}’s computer"
 msgstr "Computer von {0} wird gestartet"
 
-#: src/pages/Shell.tsx:3782
-#: src/pages/Shell.tsx:3783
-#: src/pages/Shell.tsx:3916
+#: src/pages/Shell.tsx:3903
+#: src/pages/Shell.tsx:3904
+#: src/pages/Shell.tsx:4037
 msgid "bot"
 msgstr "Bot"
 
@@ -442,11 +447,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot-Nachrichten"
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:3036
 msgid "Bot screen"
 msgstr "Bot-Bildschirm"
 
-#: src/pages/Shell.tsx:2268
+#: src/pages/Shell.tsx:2385
 msgid "Bot screen preview"
 msgstr "Bot-Bildschirmvorschau"
 
@@ -459,8 +464,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Verwende deinen eigenen Schlüssel. Der Anbieter ist austauschbar; die Schaltflächen zum Sprechen und Anrufen deiner Bots bleiben gleich."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2089
-#: src/pages/Shell.tsx:2090
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2136
 msgid "Call"
 msgstr "Anrufen"
 
@@ -471,14 +476,14 @@ msgstr "Server nicht erreichbar."
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4623
-#: src/pages/Shell.tsx:4695
-#: src/pages/Shell.tsx:4810
-#: src/pages/Shell.tsx:4884
+#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4931
+#: src/pages/Shell.tsx:5005
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/pages/Shell.tsx:4160
+#: src/pages/Shell.tsx:4281
 msgid "Cancel new bot"
 msgstr "Neuen Bot abbrechen"
 
@@ -486,7 +491,7 @@ msgstr "Neuen Bot abbrechen"
 msgid "Cancel new group"
 msgstr "Neue Gruppe abbrechen"
 
-#: src/pages/Shell.tsx:3258
+#: src/pages/Shell.tsx:3379
 msgid "Cancel reply"
 msgstr "Antwort abbrechen"
 
@@ -494,16 +499,16 @@ msgstr "Antwort abbrechen"
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/pages/Shell.tsx:5160
+#: src/pages/Shell.tsx:5281
 msgid "Chart failed to render: {error}"
 msgstr "Diagramm konnte nicht angezeigt werden: {error}"
 
-#: src/pages/Shell.tsx:3524
+#: src/pages/Shell.tsx:3645
 msgid "Chat Settings"
 msgstr "Chat-Einstellungen"
 
-#: src/pages/Shell.tsx:2534
-#: src/pages/Shell.tsx:2541
+#: src/pages/Shell.tsx:2655
+#: src/pages/Shell.tsx:2662
 msgid "Check in."
 msgstr "Melde dich."
 
@@ -515,21 +520,21 @@ msgstr "Wähle zunächst ein Modell aus."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Wähle das verbundene Modell aus, das Rakazo verwendet."
 
-#: src/pages/Shell.tsx:4710
+#: src/pages/Shell.tsx:4831
 msgid "Clear"
 msgstr "Leeren"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:4797
 msgid "Clear {0}’s conversation?"
 msgstr "Unterhaltung mit {0} leeren?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4516
+#: src/pages/Shell.tsx:4637
 msgid "Clear conversation"
 msgstr "Unterhaltung leeren"
 
-#: src/pages/Shell.tsx:4710
+#: src/pages/Shell.tsx:4831
 msgid "Clearing…"
 msgstr "Wird geleert…"
 
@@ -545,15 +550,15 @@ msgstr "Bot-Menü schließen"
 msgid "Close bot messages"
 msgstr "Bot-Nachrichten schließen"
 
-#: src/pages/Shell.tsx:5345
+#: src/pages/Shell.tsx:5466
 msgid "Close chart"
 msgstr "Diagramm schließen"
 
-#: src/pages/Shell.tsx:2889
+#: src/pages/Shell.tsx:3010
 msgid "Close computer"
 msgstr "Computer schließen"
 
-#: src/pages/Shell.tsx:5445
+#: src/pages/Shell.tsx:5566
 msgid "Close image preview"
 msgstr "Bildvorschau schließen"
 
@@ -573,11 +578,11 @@ msgstr "Erinnerungseinstellungen schließen"
 msgid "Close model settings"
 msgstr "Modelleinstellungen schließen"
 
-#: src/pages/Shell.tsx:1685
+#: src/pages/Shell.tsx:1731
 msgid "Close navigation"
 msgstr "Navigation schließen"
 
-#: src/pages/Shell.tsx:2246
+#: src/pages/Shell.tsx:2343
 msgid "Close panel"
 msgstr "Panel schließen"
 
@@ -586,7 +591,7 @@ msgstr "Panel schließen"
 msgid "Close preview"
 msgstr "Vorschau schließen"
 
-#: src/pages/AccountSettingsOverlay.tsx:84
+#: src/pages/AccountSettingsOverlay.tsx:87
 msgid "Close user settings"
 msgstr "Benutzereinstellungen schließen"
 
@@ -606,24 +611,24 @@ msgstr "Befehl"
 msgid "Complete"
 msgstr "Abschließen"
 
-#: src/pages/Shell.tsx:4070
-#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4191
+#: src/pages/Shell.tsx:4219
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:4942
+#: src/pages/Shell.tsx:5063
 msgid "Computer failed to boot"
 msgstr "Computer konnte nicht gestartet werden"
 
-#: src/pages/Shell.tsx:2937
+#: src/pages/Shell.tsx:3058
 msgid "Computer is asleep"
 msgstr "Computer ist im Ruhezustand"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5062
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer schläft — übernimm die Kontrolle, um ihn zu wecken"
 
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:5064
 msgid "Computer is stopped"
 msgstr "Computer ist gestoppt"
 
@@ -661,7 +666,7 @@ msgstr "Verbinde Apps oder füge Treg-, MCP- und OpenAPI-Toolquellen hinzu."
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI oder Cartesia verbinden"
 
-#: src/pages/Shell.tsx:5243
+#: src/pages/Shell.tsx:5364
 msgid "Connect MCP server “{name}”"
 msgstr "MCP-Server „{name}“ verbinden"
 
@@ -685,12 +690,12 @@ msgstr "Treg verbinden"
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
 #: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5094
+#: src/pages/Shell.tsx:5215
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Verbunden"
 
-#: src/pages/Shell.tsx:5273
+#: src/pages/Shell.tsx:5394
 msgid "Connected — its tools are available from your next message."
 msgstr "Verbunden – die Tools sind ab deiner nächsten Nachricht verfügbar."
 
@@ -716,7 +721,7 @@ msgstr "Verbunden, {0} wird verwendet."
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
 #: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5384
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Verbindung wird hergestellt…"
@@ -743,11 +748,11 @@ msgstr "Hinzufügen fehlgeschlagen"
 msgid "Could not add MCP server"
 msgstr "MCP-Server konnte nicht hinzugefügt werden"
 
-#: src/pages/Shell.tsx:5230
+#: src/pages/Shell.tsx:5351
 msgid "Could not approve this server"
 msgstr "Server konnte nicht genehmigt werden"
 
-#: src/pages/Shell.tsx:5058
+#: src/pages/Shell.tsx:5179
 msgid "Could not authorize this app"
 msgstr "App konnte nicht autorisiert werden"
 
@@ -755,7 +760,7 @@ msgstr "App konnte nicht autorisiert werden"
 msgid "Could not change the default model"
 msgstr "Standardmodell konnte nicht geändert werden"
 
-#: src/pages/Shell.tsx:4704
+#: src/pages/Shell.tsx:4825
 msgid "Could not clear conversation"
 msgstr "Unterhaltung konnte nicht geleert werden"
 
@@ -784,7 +789,7 @@ msgstr "Stimmanbieter konnte nicht verbunden werden"
 msgid "Could not continue"
 msgstr "Fortfahren fehlgeschlagen"
 
-#: src/pages/Shell.tsx:4148
+#: src/pages/Shell.tsx:4269
 msgid "Could not create bot"
 msgstr "Bot konnte nicht erstellt werden"
 
@@ -792,7 +797,7 @@ msgstr "Bot konnte nicht erstellt werden"
 msgid "Could not create group"
 msgstr "Gruppe konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4595
+#: src/pages/Shell.tsx:4716
 msgid "Could not create section"
 msgstr "Abschnitt konnte nicht erstellt werden"
 
@@ -800,7 +805,7 @@ msgstr "Abschnitt konnte nicht erstellt werden"
 msgid "Could not create your bot"
 msgstr "Dein Bot konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4819
+#: src/pages/Shell.tsx:4940
 msgid "Could not delete bot"
 msgstr "Bot konnte nicht gelöscht werden"
 
@@ -808,7 +813,7 @@ msgstr "Bot konnte nicht gelöscht werden"
 msgid "Could not delete MCP server"
 msgstr "MCP-Server konnte nicht gelöscht werden"
 
-#: src/pages/Shell.tsx:4893
+#: src/pages/Shell.tsx:5014
 msgid "Could not delete routine"
 msgstr "Routine konnte nicht gelöscht werden"
 
@@ -882,7 +887,7 @@ msgstr "Gruppe konnte nicht entfernt werden"
 msgid "Could not remove rule"
 msgstr "Regel konnte nicht entfernt werden"
 
-#: src/pages/Shell.tsx:5150
+#: src/pages/Shell.tsx:5271
 msgid "Could not render chart"
 msgstr "Diagramm konnte nicht angezeigt werden"
 
@@ -890,7 +895,7 @@ msgstr "Diagramm konnte nicht angezeigt werden"
 msgid "Could not revoke connection"
 msgstr "Verbindung konnte nicht widerrufen werden"
 
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4622
 msgid "Could not save"
 msgstr "Speichern fehlgeschlagen"
 
@@ -902,7 +907,7 @@ msgstr "Gruppe konnte nicht gespeichert werden"
 msgid "Could not save model"
 msgstr "Modell konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:2556
+#: src/pages/Shell.tsx:2677
 msgid "Could not save routine"
 msgstr "Routine konnte nicht gespeichert werden"
 
@@ -918,7 +923,7 @@ msgstr "Auswahl konnte nicht gespeichert werden"
 msgid "Could not save that voice"
 msgstr "Stimme konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:5091
 msgid "Could not save this choice"
 msgstr "Diese Auswahl konnte nicht gespeichert werden"
 
@@ -934,7 +939,7 @@ msgstr "OAuth konnte nicht gestartet werden"
 msgid "Could not submit this answer"
 msgstr "Antwort konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:1543
+#: src/pages/Shell.tsx:1556
 msgid "Could not take control"
 msgstr "Kontrolle konnte nicht übernommen werden"
 
@@ -950,14 +955,14 @@ msgstr "Agent-Zugriff konnte nicht aktualisiert werden"
 msgid "Could not update the default memory scope"
 msgstr "Standardbereich für Erinnerungen konnte nicht aktualisiert werden"
 
-#: src/pages/Shell.tsx:1720
-#: src/pages/Shell.tsx:4207
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:1766
+#: src/pages/Shell.tsx:4328
+#: src/pages/Shell.tsx:4751
 msgid "Create"
 msgstr "Erstellen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4604
+#: src/pages/Shell.tsx:4725
 msgid "Create a section and move {0} into it."
 msgstr "Erstelle einen Abschnitt und verschiebe {0} dorthin."
 
@@ -978,8 +983,8 @@ msgid "Create your Rakazo"
 msgstr "Dein Rakazo erstellen"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4207
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4328
+#: src/pages/Shell.tsx:4751
 msgid "Creating…"
 msgstr "Wird erstellt…"
 
@@ -1007,7 +1012,7 @@ msgstr "Tag"
 msgid "days"
 msgstr "Tage"
 
-#: src/pages/Shell.tsx:4408
+#: src/pages/Shell.tsx:4529
 msgid "Default (medium)"
 msgstr "Standard (mittel)"
 
@@ -1017,21 +1022,21 @@ msgstr "Standardbereich"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1929
-#: src/pages/Shell.tsx:4825
-#: src/pages/Shell.tsx:4899
+#: src/pages/Shell.tsx:1975
+#: src/pages/Shell.tsx:4946
+#: src/pages/Shell.tsx:5020
 msgid "Delete"
 msgstr "Löschen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1925
+#: src/pages/Shell.tsx:1971
 msgid "Delete {0}"
 msgstr "{0} löschen"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4871
+#: src/pages/Shell.tsx:4878
+#: src/pages/Shell.tsx:4992
 msgid "Delete {0}?"
 msgstr "{0} löschen?"
 
@@ -1039,21 +1044,21 @@ msgstr "{0} löschen?"
 msgid "Delete group"
 msgstr "Gruppe löschen"
 
-#: src/pages/Shell.tsx:4794
+#: src/pages/Shell.tsx:4915
 msgid "Delete memories too"
 msgstr "Erinnerungen ebenfalls löschen"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2732
 msgid "Delete routine"
 msgstr "Routine löschen"
 
-#: src/pages/Shell.tsx:3914
+#: src/pages/Shell.tsx:4035
 msgid "deleted"
 msgstr "gelöscht"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4825
-#: src/pages/Shell.tsx:4899
+#: src/pages/Shell.tsx:4946
+#: src/pages/Shell.tsx:5020
 msgid "Deleting…"
 msgstr "Wird gelöscht…"
 
@@ -1070,17 +1075,17 @@ msgid "Deployment default"
 msgstr "Bereitstellungsstandard"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4185
+#: src/pages/Shell.tsx:4306
 msgid "Describe what this bot does"
 msgstr "Beschreibe, was dieser Bot macht"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4190
-#: src/pages/Shell.tsx:4352
+#: src/pages/Shell.tsx:4311
+#: src/pages/Shell.tsx:4473
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3512
 msgid "Dictate"
 msgstr "Diktieren"
 
@@ -1093,7 +1098,7 @@ msgstr "Trennen"
 msgid "Disconnecting…"
 msgstr "Verbindung wird getrennt…"
 
-#: src/pages/Shell.tsx:5278
+#: src/pages/Shell.tsx:5399
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Verworfen – du kannst die Verbindung jederzeit in den MCP-Einstellungen wiederherstellen."
 
@@ -1193,11 +1198,11 @@ msgstr "Jeden Monat"
 msgid "Every week"
 msgstr "Jede Woche"
 
-#: src/pages/Shell.tsx:5324
+#: src/pages/Shell.tsx:5445
 msgid "Expand"
 msgstr "Erweitern"
 
-#: src/pages/Shell.tsx:4513
+#: src/pages/Shell.tsx:4634
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1205,7 +1210,7 @@ msgstr "Exportieren"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Exportiere die Liste dieser Woche aus dem CRM und lege sie im freigegebenen Ordner ab"
 
-#: src/pages/Shell.tsx:4528
+#: src/pages/Shell.tsx:4649
 msgid "Extra high"
 msgstr "Sehr hoch"
 
@@ -1213,14 +1218,14 @@ msgstr "Sehr hoch"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: src/pages/Shell.tsx:1386
-#: src/pages/Shell.tsx:1388
-#: src/pages/Shell.tsx:1390
+#: src/pages/Shell.tsx:1399
+#: src/pages/Shell.tsx:1401
+#: src/pages/Shell.tsx:1403
 msgid "Failed to send message"
 msgstr "Nachricht konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:1413
-#: src/pages/Shell.tsx:1432
+#: src/pages/Shell.tsx:1426
+#: src/pages/Shell.tsx:1445
 msgid "Failed to stop"
 msgstr "Stoppen fehlgeschlagen"
 
@@ -1252,8 +1257,8 @@ msgstr "MCP-Verbindung wird abgeschlossen…"
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#: src/pages/Shell.tsx:2079
-#: src/pages/Shell.tsx:2228
+#: src/pages/Shell.tsx:2125
+#: src/pages/Shell.tsx:2274
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1282,15 +1287,15 @@ msgstr "Beispiel anhören"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hallo, so klinge ich, wenn ich Antworten vorlese."
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4652
 msgid "High"
 msgstr "Hoch"
 
-#: src/pages/Shell.tsx:3410
+#: src/pages/Shell.tsx:3531
 msgid "Hold to talk"
 msgstr "Zum Sprechen gedrückt halten"
 
-#: src/pages/Shell.tsx:3410
+#: src/pages/Shell.tsx:3531
 msgid "Hold to talk (on-device dictation)"
 msgstr "Zum Sprechen gedrückt halten (Diktat auf dem Gerät)"
 
@@ -1310,7 +1315,7 @@ msgstr "Wie oft"
 msgid "How to check"
 msgstr "So wird geprüft"
 
-#: src/pages/Shell.tsx:3632
+#: src/pages/Shell.tsx:3753
 msgid "I’m done"
 msgstr "Ich bin fertig"
 
@@ -1322,7 +1327,7 @@ msgstr "Wenn du das gehört hast, ist die Stimme einsatzbereit."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI-JSON importieren"
 
-#: src/pages/Shell.tsx:4423
+#: src/pages/Shell.tsx:4544
 msgid "Inherit default"
 msgstr "Standard übernehmen"
 
@@ -1334,7 +1339,7 @@ msgstr "Eingaben"
 msgid "Instance API key"
 msgstr "Instanz-API-Schlüssel"
 
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2616
 msgid "Instruction"
 msgstr "Anweisung"
 
@@ -1343,7 +1348,7 @@ msgid "Integration views"
 msgstr "Integrationsansichten"
 
 #: src/pages/PluginsOverlay.tsx:213
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1992
 msgid "Integrations"
 msgstr "Integrationen"
 
@@ -1364,11 +1369,11 @@ msgid "Interval unit"
 msgstr "Intervalleinheit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4424
+#: src/pages/Shell.tsx:4545
 msgid "Isolated"
 msgstr "Isoliert"
 
-#: src/pages/Shell.tsx:4760
+#: src/pages/Shell.tsx:4881
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von ihm erstellte Bots bleiben in deiner Liste."
 
@@ -1376,7 +1381,7 @@ msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von
 msgid "just now"
 msgstr "gerade eben"
 
-#: src/pages/Shell.tsx:4778
+#: src/pages/Shell.tsx:4899
 msgid "Keep memories"
 msgstr "Erinnerungen behalten"
 
@@ -1384,9 +1389,9 @@ msgstr "Erinnerungen behalten"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "Schlüssel bleiben auf dem Server. Die App erfährt nur, ob ein Anbieter konfiguriert ist."
 
-#: src/pages/AccountSettingsOverlay.tsx:102
-#: src/pages/AccountSettingsOverlay.tsx:255
-#: src/pages/AccountSettingsOverlay.tsx:274
+#: src/pages/AccountSettingsOverlay.tsx:105
+#: src/pages/AccountSettingsOverlay.tsx:254
+#: src/pages/AccountSettingsOverlay.tsx:271
 msgid "Language"
 msgstr "Sprache"
 
@@ -1394,7 +1399,7 @@ msgstr "Sprache"
 msgid "Listening…"
 msgstr "Hört zu…"
 
-#: src/pages/Shell.tsx:3009
+#: src/pages/Shell.tsx:3130
 msgid "Load earlier messages"
 msgstr "Frühere Nachrichten laden"
 
@@ -1434,7 +1439,7 @@ msgstr "Stimmanbieter werden geladen…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3009
+#: src/pages/Shell.tsx:3130
 msgid "Loading…"
 msgstr "Wird geladen…"
 
@@ -1442,11 +1447,11 @@ msgstr "Wird geladen…"
 msgid "Local"
 msgstr "Lokal"
 
-#: src/pages/Shell.tsx:2032
+#: src/pages/Shell.tsx:2078
 msgid "Log out"
 msgstr "Abmelden"
 
-#: src/pages/Shell.tsx:4529
+#: src/pages/Shell.tsx:4650
 msgid "Low"
 msgstr "Niedrig"
 
@@ -1462,7 +1467,7 @@ msgstr "Als gelesen markieren"
 msgid "Mark as Unread"
 msgstr "Als ungelesen markieren"
 
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4654
 msgid "Max"
 msgstr "Max."
 
@@ -1472,7 +1477,7 @@ msgstr "Max."
 msgid "MCP servers"
 msgstr "MCP-Server"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4651
 msgid "Medium"
 msgstr "Mittel"
 
@@ -1485,33 +1490,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Mitglieder ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} auswählen)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:1990
+#: src/pages/Shell.tsx:2036
 msgid "Memory"
 msgstr "Erinnerungen"
 
-#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4540
 msgid "Memory scope"
 msgstr "Erinnerungsbereich"
 
-#: src/pages/Shell.tsx:3488
-#: src/pages/Shell.tsx:3583
+#: src/pages/Shell.tsx:3609
+#: src/pages/Shell.tsx:3704
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/pages/Shell.tsx:3484
-#: src/pages/Shell.tsx:3488
+#: src/pages/Shell.tsx:3605
+#: src/pages/Shell.tsx:3609
 msgid "Message {activeName}"
 msgstr "Nachricht an {activeName}"
 
-#: src/pages/Shell.tsx:3800
+#: src/pages/Shell.tsx:3921
 msgid "Message from {peer}"
 msgstr "Nachricht von {peer}"
 
-#: src/pages/Shell.tsx:3485
+#: src/pages/Shell.tsx:3606
 msgid "Message…"
 msgstr "Nachricht…"
 
-#: src/pages/Shell.tsx:3800
+#: src/pages/Shell.tsx:3921
 msgid "Messaged {peer}"
 msgstr "Nachricht an {peer} gesendet"
 
@@ -1519,7 +1524,7 @@ msgstr "Nachricht an {peer} gesendet"
 msgid "Microphone failed"
 msgstr "Mikrofonfehler"
 
-#: src/pages/Shell.tsx:4532
+#: src/pages/Shell.tsx:4653
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1541,7 +1546,7 @@ msgstr "Minuten"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4375
+#: src/pages/Shell.tsx:4496
 msgid "Model"
 msgstr "Modell"
 
@@ -1554,7 +1559,7 @@ msgstr "Modell-ID"
 msgid "Model options"
 msgstr "Modelloptionen"
 
-#: src/pages/AccountSettingsOverlay.tsx:124
+#: src/pages/AccountSettingsOverlay.tsx:127
 msgid "Model spend uses your provider keys."
 msgstr "Modellkosten werden über deine Anbieterschlüssel abgerechnet."
 
@@ -1563,7 +1568,7 @@ msgid "Model updated."
 msgstr "Modell aktualisiert."
 
 #: src/pages/ModelSettingsOverlay.tsx:303
-#: src/pages/Shell.tsx:1977
+#: src/pages/Shell.tsx:2023
 msgid "Models"
 msgstr "Modelle"
 
@@ -1581,7 +1586,7 @@ msgstr "Monatlich"
 msgid "Move {0} to section"
 msgstr "{0} in Abschnitt verschieben"
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4902
 msgid "Move them to your shared memory."
 msgstr "Verschiebe sie in deine geteilten Erinnerungen."
 
@@ -1594,15 +1599,15 @@ msgstr "Verschieben nach"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2487
-#: src/pages/Shell.tsx:4170
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:4291
+#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4728
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4175
+#: src/pages/Shell.tsx:4296
 msgid "Name this bot"
 msgstr "Bot benennen"
 
@@ -1618,13 +1623,17 @@ msgstr "Eingabe erforderlich"
 msgid "Needs takeover"
 msgstr "Übernahme erforderlich"
 
-#: src/pages/Shell.tsx:1734
-#: src/pages/Shell.tsx:4158
+#: src/pages/Shell.tsx:2369
+msgid "Never used yet"
+msgstr "Noch nie verwendet"
+
+#: src/pages/Shell.tsx:1780
+#: src/pages/Shell.tsx:4279
 msgid "New bot"
 msgstr "Neuer Bot"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1744
+#: src/pages/Shell.tsx:1790
 msgid "New group"
 msgstr "Neue Gruppe"
 
@@ -1632,12 +1641,12 @@ msgstr "Neue Gruppe"
 msgid "New open-work item"
 msgstr "Neuer offener Arbeitspunkt"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2498
 msgid "New routine"
 msgstr "Neue Routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4722
 msgid "New section"
 msgstr "Neuer Abschnitt"
 
@@ -1691,6 +1700,10 @@ msgstr "Noch keine MCP-Server."
 msgid "No model catalog is available."
 msgstr "Kein Modellkatalog verfügbar."
 
+#: src/pages/Shell.tsx:2305
+msgid "No other agents yet"
+msgstr "Noch keine anderen Agenten"
+
 #: src/pages/ModelSettingsOverlay.tsx:385
 msgid "No providers found."
 msgstr "Keine Anbieter gefunden."
@@ -1712,7 +1725,7 @@ msgstr "Nicht konfiguriert"
 msgid "Not connected"
 msgstr "Nicht verbunden"
 
-#: src/pages/Shell.tsx:5266
+#: src/pages/Shell.tsx:5387
 msgid "Not now"
 msgstr "Jetzt nicht"
 
@@ -1750,15 +1763,15 @@ msgstr "am 1. um {0}"
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/pages/Shell.tsx:2287
+#: src/pages/Shell.tsx:2405
 msgid "Open computer"
 msgstr "Computer öffnen"
 
-#: src/pages/Shell.tsx:2257
+#: src/pages/Shell.tsx:2374
 msgid "Open in full window"
 msgstr "In vollständigem Fenster öffnen"
 
-#: src/pages/Shell.tsx:2056
+#: src/pages/Shell.tsx:2102
 msgid "Open navigation"
 msgstr "Navigation öffnen"
 
@@ -1775,7 +1788,7 @@ msgstr "Offene Arbeit"
 msgid "OpenAI-compatible server URL"
 msgstr "URL eines OpenAI-kompatiblen Servers"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:4046
 msgid "Opened its thread."
 msgstr "Thread geöffnet."
 
@@ -1788,7 +1801,7 @@ msgstr "Dein Arbeitsbereich wird geöffnet…"
 msgid "Optional"
 msgstr "Optional"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:141
 msgid "Optional controls most people never need"
 msgstr "Optionale Einstellungen, die die meisten nie benötigen"
 
@@ -1807,6 +1820,10 @@ msgstr "Oder einen API-Schlüssel einfügen"
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
 msgstr "Organisations-API-Schlüssel"
+
+#: src/pages/Shell.tsx:2355
+msgid "Other computer preview (view only)"
+msgstr "Vorschau eines anderen Computers (nur Ansicht)"
 
 #: src/pages/ModelSettingsOverlay.tsx:453
 #: src/pages/Onboarding.tsx:311
@@ -1858,7 +1875,7 @@ msgstr "Wiedergabe…"
 msgid "Preview {0}"
 msgstr "Vorschau von {0}"
 
-#: src/pages/Shell.tsx:4113
+#: src/pages/Shell.tsx:4234
 msgid "Private"
 msgstr "Privat"
 
@@ -1879,7 +1896,7 @@ msgstr "In Warteschlange"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo prüft die Quelle vor dem Speichern. Zugangsdaten werden verschlüsselt und weder an Clients zurückgegeben noch dem Modell zugänglich gemacht."
 
-#: src/pages/Shell.tsx:4451
+#: src/pages/Shell.tsx:4572
 msgid "Read replies aloud"
 msgstr "Antworten vorlesen"
 
@@ -1901,7 +1918,7 @@ msgstr "Verbindung wird wiederhergestellt"
 msgid "Recording: {0}"
 msgstr "Aufnahme: {0}"
 
-#: src/pages/Shell.tsx:3622
+#: src/pages/Shell.tsx:3743
 msgid "Release"
 msgstr "Freigeben"
 
@@ -1912,17 +1929,17 @@ msgid "Remove"
 msgstr "Entfernen"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3292
+#: src/pages/Shell.tsx:3413
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3447
+#: src/pages/Shell.tsx:3568
 msgid "Remove mention {0}"
 msgstr "Erwähnung von {0} entfernen"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3426
+#: src/pages/Shell.tsx:3547
 msgid "Remove skill {0}"
 msgstr "Skill {0} entfernen"
 
@@ -1930,7 +1947,7 @@ msgstr "Skill {0} entfernen"
 msgid "Remove this schedule"
 msgstr "Diesen Zeitplan entfernen"
 
-#: src/pages/Shell.tsx:3924
+#: src/pages/Shell.tsx:4045
 msgid "Removed with chat, computer, and memory."
 msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 
@@ -1956,16 +1973,16 @@ msgstr "API-Schlüssel ersetzen"
 msgid "Replace key"
 msgstr "Schlüssel ersetzen"
 
-#: src/pages/Shell.tsx:3016
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3137
+#: src/pages/Shell.tsx:3141
 msgid "Reply"
 msgstr "Antworten"
 
-#: src/pages/Shell.tsx:3250
+#: src/pages/Shell.tsx:3371
 msgid "Replying to"
 msgstr "Antwort auf"
 
-#: src/pages/Shell.tsx:1921
+#: src/pages/Shell.tsx:1967
 msgid "Restore"
 msgstr "Wiederherstellen"
 
@@ -1985,17 +2002,17 @@ msgstr "Widerrufen"
 msgid "Revoking…"
 msgstr "Wird widerrufen…"
 
-#: src/pages/Shell.tsx:2480
-#: src/pages/Shell.tsx:2533
-#: src/pages/Shell.tsx:2540
+#: src/pages/Shell.tsx:2601
+#: src/pages/Shell.tsx:2654
+#: src/pages/Shell.tsx:2661
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2322
+#: src/pages/Shell.tsx:2443
 msgid "Routines"
 msgstr "Routinen"
 
-#: src/pages/Shell.tsx:2603
+#: src/pages/Shell.tsx:2724
 msgid "Run now"
 msgstr "Jetzt ausführen"
 
@@ -2003,11 +2020,11 @@ msgstr "Jetzt ausführen"
 msgid "Running"
 msgstr "Läuft"
 
-#: src/pages/Shell.tsx:2362
+#: src/pages/Shell.tsx:2483
 msgid "Running · Stop"
 msgstr "Wird ausgeführt · Stoppen"
 
-#: src/pages/Shell.tsx:2603
+#: src/pages/Shell.tsx:2724
 msgid "Running…"
 msgstr "Wird ausgeführt…"
 
@@ -2015,8 +2032,8 @@ msgstr "Wird ausgeführt…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2579
-#: src/pages/Shell.tsx:4506
+#: src/pages/Shell.tsx:2700
+#: src/pages/Shell.tsx:4627
 msgid "Save"
 msgstr "Speichern"
 
@@ -2040,7 +2057,7 @@ msgstr "Gespeichert."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2579
+#: src/pages/Shell.tsx:2700
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
@@ -2053,7 +2070,7 @@ msgstr "Sag etwas. Bei Stille wird es gesendet."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Antworte mit Ja oder Nein oder in einem Satz."
 
-#: src/pages/Shell.tsx:1755
+#: src/pages/Shell.tsx:1801
 msgid "Search"
 msgstr "Suchen"
 
@@ -2075,11 +2092,11 @@ msgstr "Anbieter und Modelle suchen"
 msgid "Searching…"
 msgstr "Suche…"
 
-#: src/pages/Shell.tsx:2080
+#: src/pages/Shell.tsx:2126
 msgid "Select a bot"
 msgstr "Bot auswählen"
 
-#: src/pages/Shell.tsx:3508
+#: src/pages/Shell.tsx:3629
 msgid "Send"
 msgstr "Senden"
 
@@ -2107,22 +2124,22 @@ msgstr "Servername"
 msgid "Server URL"
 msgstr "Server-URL"
 
-#: src/pages/Shell.tsx:2089
+#: src/pages/Shell.tsx:2135
 msgid "Set up voice to call"
 msgstr "Stimme für Anrufe einrichten"
 
-#: src/pages/AccountSettingsOverlay.tsx:76
-#: src/pages/Shell.tsx:1954
-#: src/pages/Shell.tsx:1964
-#: src/pages/Shell.tsx:2224
+#: src/pages/AccountSettingsOverlay.tsx:79
+#: src/pages/Shell.tsx:2000
+#: src/pages/Shell.tsx:2010
+#: src/pages/Shell.tsx:2270
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/pages/Shell.tsx:3526
+#: src/pages/Shell.tsx:3647
 msgid "Settings: General"
 msgstr "Einstellungen: Allgemein"
 
-#: src/pages/Shell.tsx:3528
+#: src/pages/Shell.tsx:3649
 msgid "Settings: Usage"
 msgstr "Einstellungen: Nutzung"
 
@@ -2132,15 +2149,15 @@ msgid "Setup help"
 msgstr "Einrichtungshilfe"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4425
+#: src/pages/Shell.tsx:4546
 msgid "Shared"
 msgstr "Geteilt"
 
-#: src/pages/Shell.tsx:2235
+#: src/pages/Shell.tsx:2332
 msgid "Show computer"
 msgstr "Computer anzeigen"
 
-#: src/pages/Shell.tsx:2235
+#: src/pages/Shell.tsx:2332
 msgid "Show settings"
 msgstr "Einstellungen anzeigen"
 
@@ -2164,11 +2181,11 @@ msgid "Sign up"
 msgstr "Registrieren"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3339
+#: src/pages/Shell.tsx:3460
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3629
+#: src/pages/Shell.tsx:3750
 msgid "Skip"
 msgstr "Überspringen"
 
@@ -2181,7 +2198,7 @@ msgid "Skip or deploy key"
 msgstr "Überspringen oder Deploy-Key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1280
+#: src/pages/Shell.tsx:1293
 msgid "Skipped {0}"
 msgstr "{0} übersprungen"
 
@@ -2189,8 +2206,8 @@ msgstr "{0} übersprungen"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Leertaste unterbricht · Esc legt auf"
 
-#: src/pages/Shell.tsx:3769
-#: src/pages/Shell.tsx:4022
+#: src/pages/Shell.tsx:3890
+#: src/pages/Shell.tsx:4143
 msgid "Speak"
 msgstr "Vorlesen"
 
@@ -2202,8 +2219,8 @@ msgstr "Sprechen + transkribieren"
 msgid "Speak only"
 msgstr "Nur sprechen"
 
-#: src/pages/Shell.tsx:3765
-#: src/pages/Shell.tsx:4018
+#: src/pages/Shell.tsx:3886
+#: src/pages/Shell.tsx:4139
 msgid "Speak this reply"
 msgstr "Diese Antwort vorlesen"
 
@@ -2229,20 +2246,20 @@ msgstr "Wird gestartet…"
 msgid "Steps"
 msgstr "Schritte"
 
-#: src/pages/Shell.tsx:2858
-#: src/pages/Shell.tsx:2862
-#: src/pages/Shell.tsx:3499
-#: src/pages/Shell.tsx:3769
-#: src/pages/Shell.tsx:4022
+#: src/pages/Shell.tsx:2979
+#: src/pages/Shell.tsx:2983
+#: src/pages/Shell.tsx:3620
+#: src/pages/Shell.tsx:3890
+#: src/pages/Shell.tsx:4143
 msgid "Stop"
 msgstr "Stoppen"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3512
 msgid "Stop dictation"
 msgstr "Diktat stoppen"
 
-#: src/pages/Shell.tsx:3765
-#: src/pages/Shell.tsx:4018
+#: src/pages/Shell.tsx:3886
+#: src/pages/Shell.tsx:4139
 msgid "Stop speaking"
 msgstr "Vorlesen stoppen"
 
@@ -2251,8 +2268,8 @@ msgstr "Vorlesen stoppen"
 msgid "Stop teaching"
 msgstr "Anlernen beenden"
 
-#: src/pages/Shell.tsx:2314
-#: src/pages/Shell.tsx:2878
+#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2999
 msgid "Stop the bot first"
 msgstr "Zuerst den Bot stoppen"
 
@@ -2260,7 +2277,7 @@ msgstr "Zuerst den Bot stoppen"
 msgid "Stored encrypted"
 msgstr "Verschlüsselt gespeichert"
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3997
 msgid "subagent"
 msgstr "Subagent"
 
@@ -2273,8 +2290,8 @@ msgstr "Absenden"
 msgid "Switching…"
 msgstr "Wird gewechselt…"
 
-#: src/pages/Shell.tsx:2317
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2438
+#: src/pages/Shell.tsx:3004
 msgid "Take control"
 msgstr "Kontrolle übernehmen"
 
@@ -2282,7 +2299,7 @@ msgstr "Kontrolle übernehmen"
 msgid "Teach a task"
 msgstr "Aufgabe anlernen"
 
-#: src/pages/Shell.tsx:2151
+#: src/pages/Shell.tsx:2197
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachricht sendest."
 
@@ -2290,11 +2307,11 @@ msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachr
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Zum Anlernen ist ein grafischer Sandbox-Computer erforderlich. Auf dem Desktop gehostete Bots können Shell-Aufgaben ausführen, aber keine Bildschirmaufnahmen erstellen."
 
-#: src/pages/Shell.tsx:4113
+#: src/pages/Shell.tsx:4234
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:4947
+#: src/pages/Shell.tsx:5068
 msgid "Team Computer"
 msgstr "Team-Computer"
 
@@ -2307,20 +2324,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügbar."
 
-#: src/pages/Shell.tsx:4402
+#: src/pages/Shell.tsx:4523
 msgid "Thinking"
 msgstr "Denkmodus"
 
-#: src/pages/Shell.tsx:2261
+#: src/pages/Shell.tsx:2378
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Dieser Bot wird auf diesem Computer und nicht auf einem Linux-Desktop ausgeführt. Shell und Dateien verwenden deinen persönlichen Ordner."
 
-#: src/pages/Shell.tsx:2907
+#: src/pages/Shell.tsx:3028
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Dieser Bot wird auf diesem Computer ausgeführt. Es gibt keinen separaten Linux-Desktop. Bitte ihn, die Shell zu verwenden; Arbeitsverzeichnisse in deinem persönlichen Ordner sind zulässig."
 
-#: src/pages/Shell.tsx:4797
-#: src/pages/Shell.tsx:4874
+#: src/pages/Shell.tsx:4918
+#: src/pages/Shell.tsx:4995
 msgid "This cannot be undone."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
@@ -2344,7 +2361,7 @@ msgstr "dieser Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Dieser Mac führt Shell-Befehle mit deinem Konto aus und kann auf Dateien in deinem persönlichen Ordner zugreifen. Aktiviere dies nicht auf einem gemeinsam genutzten oder öffentlichen Server."
 
-#: src/pages/Shell.tsx:4682
+#: src/pages/Shell.tsx:4803
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbeit beendet. Bot, Computer, Erinnerungen und Routinen bleiben erhalten."
 
@@ -2352,7 +2369,7 @@ msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbe
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bei diesem Anbieter kann hier kein Schlüssel eingefügt werden. Überspringe diesen Schritt, wenn die Bereitstellung bereits Zugangsdaten enthält."
 
-#: src/pages/Shell.tsx:5214
+#: src/pages/Shell.tsx:5335
 msgid "This server cannot be assigned without a bot."
 msgstr "Dieser Server kann ohne Bot nicht zugewiesen werden."
 
@@ -2364,7 +2381,7 @@ msgstr "Dieser Server hat keine Browserautorisierung angefordert."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Dieser Server ist bereits verbunden. Trenne zuerst die Verbindung, um ihn erneut zu autorisieren."
 
-#: src/pages/Shell.tsx:5253
+#: src/pages/Shell.tsx:5374
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Dieser Server verwendet die Browseranmeldung. Autorisiere ihn, damit deine Agents seine Tools verwenden können – ein Pop-up wird geöffnet."
 
@@ -2377,8 +2394,8 @@ msgid "Time of day"
 msgstr "Uhrzeit"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4180
-#: src/pages/Shell.tsx:4343
+#: src/pages/Shell.tsx:4301
+#: src/pages/Shell.tsx:4464
 msgid "Title"
 msgstr "Titel"
 
@@ -2403,12 +2420,12 @@ msgid "Unpin"
 msgstr "Lösen"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1344
+#: src/pages/Shell.tsx:1357
 msgid "Unsupported file type: {0}"
 msgstr "Nicht unterstützter Dateityp: {0}"
 
-#: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2015
+#: src/pages/AccountSettingsOverlay.tsx:117
+#: src/pages/Shell.tsx:2061
 msgid "Usage"
 msgstr "Nutzung"
 
@@ -2433,8 +2450,22 @@ msgstr "Prüfen und hinzufügen"
 msgid "Verifying…"
 msgstr "Wird geprüft…"
 
-#: src/pages/Shell.tsx:2003
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2294
+msgid "View another computer"
+msgstr "Anderen Computer ansehen"
+
+#: src/pages/Shell.tsx:2298
+msgid "View…"
+msgstr "Ansehen…"
+
+#. placeholder {0}: peekTarget?.name ?? active.name
+#: src/pages/Shell.tsx:2413
+msgid "Viewing {0} (read only)"
+msgstr "Ansicht von {0} (nur Lesen)"
+
+#: src/pages/Shell.tsx:2049
+#: src/pages/Shell.tsx:4576
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2447,7 +2478,7 @@ msgstr "Stimme"
 msgid "Waiting for sign-in…"
 msgstr "Warten auf Anmeldung…"
 
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5218
 msgid "Waiting…"
 msgstr "Warten…"
 
@@ -2456,7 +2487,7 @@ msgstr "Warten…"
 msgid "Weekdays"
 msgstr "Wochentage"
 
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4888
 msgid "What about its memories?"
 msgstr "Was soll mit seinen Erinnerungen geschehen?"
 
@@ -2465,7 +2496,7 @@ msgid "What result will you demonstrate?"
 msgstr "Welches Ergebnis wirst du vorführen?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4195
+#: src/pages/Shell.tsx:4316
 msgid "What this bot is for"
 msgstr "Wofür dieser Bot gedacht ist"
 
@@ -2477,7 +2508,7 @@ msgstr "Was zurückgegeben werden soll"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "Wenn {botName} einem anderen Bot eine Nachricht sendet, wird der Austausch hier statt im Chat angezeigt."
 
-#: src/pages/Shell.tsx:2504
+#: src/pages/Shell.tsx:2625
 msgid "When to run"
 msgstr "Ausführungszeit"
 
@@ -2494,11 +2525,11 @@ msgstr "Wo sollen Bots ausgeführt werden?"
 msgid "Working…"
 msgstr "Wird verarbeitet…"
 
-#: src/pages/Shell.tsx:4385
+#: src/pages/Shell.tsx:4506
 msgid "Workspace default"
 msgstr "Arbeitsbereichsstandard"
 
-#: src/pages/Shell.tsx:1665
+#: src/pages/Shell.tsx:1711
 msgid "You"
 msgstr "Du"
 
@@ -2510,8 +2541,8 @@ msgstr "Du kannst diesen Tab schließen, wenn du nicht automatisch weitergeleite
 msgid "You can close this window."
 msgstr "Du kannst dieses Fenster schließen."
 
-#: src/pages/Shell.tsx:2294
-#: src/pages/Shell.tsx:2848
+#: src/pages/Shell.tsx:2415
+#: src/pages/Shell.tsx:2969
 msgid "You have control"
 msgstr "Du hast die Kontrolle"
 
@@ -2530,5 +2561,3 @@ msgstr "Dein Name"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Dein Team aus jederzeit verfügbaren Agents<0/>für echte Aufgaben."
-
-

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1816
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (unread)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# model} other {# models}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1260
+#: src/pages/Shell.tsx:1273
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1264
+#: src/pages/Shell.tsx:1277
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (over 10 MiB)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5070
+#: src/pages/Shell.tsx:5191
 msgid "{0} connection"
 msgstr "{0} connection"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2298
+#: src/pages/Shell.tsx:2419
 msgid "{0} is using it"
 msgstr "{0} is using it"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:118
-#: src/pages/Shell.tsx:2020
+#: src/pages/AccountSettingsOverlay.tsx:121
+#: src/pages/Shell.tsx:2066
 msgid "{0} runs · {1} tokens"
 msgstr "{0} runs · {1} tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# peer} other {# peers}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} has not messaged another bot yet."
 
-#: src/pages/Shell.tsx:4947
+#: src/pages/Shell.tsx:5068
 msgid "{botName}’s computer"
 msgstr "{botName}’s computer"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3311
+#: src/pages/Shell.tsx:3432
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ Teach a task"
 msgid "Access token (optional)"
 msgstr "Access token (optional)"
 
-#: src/pages/AccountSettingsOverlay.tsx:94
+#: src/pages/AccountSettingsOverlay.tsx:97
 msgid "Account"
 msgstr "Account"
 
-#: src/pages/Shell.tsx:4461
+#: src/pages/Shell.tsx:4582
 msgid "Account default"
 msgstr "Account default"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
+#: src/pages/AccountSettingsOverlay.tsx:82
 msgid "Account preferences apply across all your bots."
 msgstr "Account preferences apply across all your bots."
 
@@ -156,8 +156,8 @@ msgstr "Active model"
 msgid "Active voice"
 msgstr "Active voice"
 
-#: src/pages/Shell.tsx:1700
-#: src/pages/Shell.tsx:1702
+#: src/pages/Shell.tsx:1746
+#: src/pages/Shell.tsx:1748
 msgid "Activity"
 msgstr "Activity"
 
@@ -214,9 +214,9 @@ msgstr "Add Treg"
 msgid "Adding…"
 msgstr "Adding…"
 
-#: src/pages/AccountSettingsOverlay.tsx:135
+#: src/pages/AccountSettingsOverlay.tsx:138
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4364
+#: src/pages/Shell.tsx:4485
 msgid "Advanced"
 msgstr "Advanced"
 
@@ -224,7 +224,7 @@ msgstr "Advanced"
 msgid "Agent access for new servers"
 msgstr "Agent access for new servers"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2153
 msgid "Agent computer"
 msgstr "Agent computer"
 
@@ -311,11 +311,11 @@ msgstr "Applies when you click Add server. Use the agent chips on each server ca
 msgid "Approval boundaries"
 msgstr "Approval boundaries"
 
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5384
 msgid "Approve"
 msgstr "Approve"
 
-#: src/pages/Shell.tsx:5254
+#: src/pages/Shell.tsx:5375
 msgid "Approve this server to let your agent use its tools."
 msgstr "Approve this server to let your agent use its tools."
 
@@ -327,15 +327,15 @@ msgstr "Apps"
 msgid "Archive"
 msgstr "Archive"
 
-#: src/pages/Shell.tsx:3912
+#: src/pages/Shell.tsx:4033
 msgid "archived"
 msgstr "archived"
 
-#: src/pages/Shell.tsx:1900
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4044
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archived. Chat, memory, and files kept."
 
@@ -374,7 +374,7 @@ msgstr "Ask before purchases"
 msgid "Ask before sending external email"
 msgstr "Ask before sending external email"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2421
 msgid "Asleep"
 msgstr "Asleep"
 
@@ -389,11 +389,11 @@ msgstr "at {0}"
 msgid "at {timeSelect}"
 msgstr "at {timeSelect}"
 
-#: src/pages/Shell.tsx:3382
+#: src/pages/Shell.tsx:3503
 msgid "Attach file"
 msgstr "Attach file"
 
-#: src/pages/Shell.tsx:3581
+#: src/pages/Shell.tsx:3702
 msgid "Attachment"
 msgstr "Attachment"
 
@@ -406,14 +406,19 @@ msgstr "Authorization code or callback URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Authorization expired — reconnect required"
 
-#: src/pages/Shell.tsx:5055
+#: src/pages/Shell.tsx:5176
 msgid "Authorization timed out. Please try again."
 msgstr "Authorization timed out. Please try again."
 
-#: src/pages/Shell.tsx:5097
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5384
 msgid "Authorize"
 msgstr "Authorize"
+
+#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2283
+msgid "Back to your computer"
+msgstr "Back to your computer"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -423,18 +428,18 @@ msgstr "Base URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:4939
+#: src/pages/Shell.tsx:5060
 msgid "Booting live desktop…"
 msgstr "Booting live desktop…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:2944
 msgid "Booting up {0}’s computer"
 msgstr "Booting up {0}’s computer"
 
-#: src/pages/Shell.tsx:3782
-#: src/pages/Shell.tsx:3783
-#: src/pages/Shell.tsx:3916
+#: src/pages/Shell.tsx:3903
+#: src/pages/Shell.tsx:3904
+#: src/pages/Shell.tsx:4037
 msgid "bot"
 msgstr "bot"
 
@@ -442,11 +447,11 @@ msgstr "bot"
 msgid "Bot messages"
 msgstr "Bot messages"
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:3036
 msgid "Bot screen"
 msgstr "Bot screen"
 
-#: src/pages/Shell.tsx:2268
+#: src/pages/Shell.tsx:2385
 msgid "Bot screen preview"
 msgstr "Bot screen preview"
 
@@ -459,8 +464,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Bring your own key. The provider is swappable; your bots keep the same speak and call buttons."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2089
-#: src/pages/Shell.tsx:2090
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2136
 msgid "Call"
 msgstr "Call"
 
@@ -471,14 +476,14 @@ msgstr "Can't reach the server."
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4623
-#: src/pages/Shell.tsx:4695
-#: src/pages/Shell.tsx:4810
-#: src/pages/Shell.tsx:4884
+#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4931
+#: src/pages/Shell.tsx:5005
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/pages/Shell.tsx:4160
+#: src/pages/Shell.tsx:4281
 msgid "Cancel new bot"
 msgstr "Cancel new bot"
 
@@ -486,7 +491,7 @@ msgstr "Cancel new bot"
 msgid "Cancel new group"
 msgstr "Cancel new group"
 
-#: src/pages/Shell.tsx:3258
+#: src/pages/Shell.tsx:3379
 msgid "Cancel reply"
 msgstr "Cancel reply"
 
@@ -494,16 +499,16 @@ msgstr "Cancel reply"
 msgid "Cancelled"
 msgstr "Cancelled"
 
-#: src/pages/Shell.tsx:5160
+#: src/pages/Shell.tsx:5281
 msgid "Chart failed to render: {error}"
 msgstr "Chart failed to render: {error}"
 
-#: src/pages/Shell.tsx:3524
+#: src/pages/Shell.tsx:3645
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
-#: src/pages/Shell.tsx:2534
-#: src/pages/Shell.tsx:2541
+#: src/pages/Shell.tsx:2655
+#: src/pages/Shell.tsx:2662
 msgid "Check in."
 msgstr "Check in."
 
@@ -515,21 +520,21 @@ msgstr "Choose a model to get started."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Choose which connected model Rakazo uses."
 
-#: src/pages/Shell.tsx:4710
+#: src/pages/Shell.tsx:4831
 msgid "Clear"
 msgstr "Clear"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:4797
 msgid "Clear {0}’s conversation?"
 msgstr "Clear {0}’s conversation?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4516
+#: src/pages/Shell.tsx:4637
 msgid "Clear conversation"
 msgstr "Clear conversation"
 
-#: src/pages/Shell.tsx:4710
+#: src/pages/Shell.tsx:4831
 msgid "Clearing…"
 msgstr "Clearing…"
 
@@ -545,15 +550,15 @@ msgstr "Close bot menu"
 msgid "Close bot messages"
 msgstr "Close bot messages"
 
-#: src/pages/Shell.tsx:5345
+#: src/pages/Shell.tsx:5466
 msgid "Close chart"
 msgstr "Close chart"
 
-#: src/pages/Shell.tsx:2889
+#: src/pages/Shell.tsx:3010
 msgid "Close computer"
 msgstr "Close computer"
 
-#: src/pages/Shell.tsx:5445
+#: src/pages/Shell.tsx:5566
 msgid "Close image preview"
 msgstr "Close image preview"
 
@@ -573,11 +578,11 @@ msgstr "Close memory settings"
 msgid "Close model settings"
 msgstr "Close model settings"
 
-#: src/pages/Shell.tsx:1685
+#: src/pages/Shell.tsx:1731
 msgid "Close navigation"
 msgstr "Close navigation"
 
-#: src/pages/Shell.tsx:2246
+#: src/pages/Shell.tsx:2343
 msgid "Close panel"
 msgstr "Close panel"
 
@@ -586,7 +591,7 @@ msgstr "Close panel"
 msgid "Close preview"
 msgstr "Close preview"
 
-#: src/pages/AccountSettingsOverlay.tsx:84
+#: src/pages/AccountSettingsOverlay.tsx:87
 msgid "Close user settings"
 msgstr "Close user settings"
 
@@ -606,24 +611,24 @@ msgstr "Command"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/pages/Shell.tsx:4070
-#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4191
+#: src/pages/Shell.tsx:4219
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:4942
+#: src/pages/Shell.tsx:5063
 msgid "Computer failed to boot"
 msgstr "Computer failed to boot"
 
-#: src/pages/Shell.tsx:2937
+#: src/pages/Shell.tsx:3058
 msgid "Computer is asleep"
 msgstr "Computer is asleep"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5062
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer is asleep — take control to wake it"
 
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:5064
 msgid "Computer is stopped"
 msgstr "Computer is stopped"
 
@@ -661,7 +666,7 @@ msgstr "Connect apps or add Treg, MCP, and OpenAPI tool sources."
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "Connect ElevenLabs, OpenAI, or Cartesia"
 
-#: src/pages/Shell.tsx:5243
+#: src/pages/Shell.tsx:5364
 msgid "Connect MCP server “{name}”"
 msgstr "Connect MCP server “{name}”"
 
@@ -685,12 +690,12 @@ msgstr "Connect Treg"
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
 #: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5094
+#: src/pages/Shell.tsx:5215
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Connected"
 
-#: src/pages/Shell.tsx:5273
+#: src/pages/Shell.tsx:5394
 msgid "Connected — its tools are available from your next message."
 msgstr "Connected — its tools are available from your next message."
 
@@ -716,7 +721,7 @@ msgstr "Connected and using {0}."
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
 #: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5384
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Connecting…"
@@ -743,11 +748,11 @@ msgstr "Could not add"
 msgid "Could not add MCP server"
 msgstr "Could not add MCP server"
 
-#: src/pages/Shell.tsx:5230
+#: src/pages/Shell.tsx:5351
 msgid "Could not approve this server"
 msgstr "Could not approve this server"
 
-#: src/pages/Shell.tsx:5058
+#: src/pages/Shell.tsx:5179
 msgid "Could not authorize this app"
 msgstr "Could not authorize this app"
 
@@ -755,7 +760,7 @@ msgstr "Could not authorize this app"
 msgid "Could not change the default model"
 msgstr "Could not change the default model"
 
-#: src/pages/Shell.tsx:4704
+#: src/pages/Shell.tsx:4825
 msgid "Could not clear conversation"
 msgstr "Could not clear conversation"
 
@@ -784,7 +789,7 @@ msgstr "Could not connect this voice provider"
 msgid "Could not continue"
 msgstr "Could not continue"
 
-#: src/pages/Shell.tsx:4148
+#: src/pages/Shell.tsx:4269
 msgid "Could not create bot"
 msgstr "Could not create bot"
 
@@ -792,7 +797,7 @@ msgstr "Could not create bot"
 msgid "Could not create group"
 msgstr "Could not create group"
 
-#: src/pages/Shell.tsx:4595
+#: src/pages/Shell.tsx:4716
 msgid "Could not create section"
 msgstr "Could not create section"
 
@@ -800,7 +805,7 @@ msgstr "Could not create section"
 msgid "Could not create your bot"
 msgstr "Could not create your bot"
 
-#: src/pages/Shell.tsx:4819
+#: src/pages/Shell.tsx:4940
 msgid "Could not delete bot"
 msgstr "Could not delete bot"
 
@@ -808,7 +813,7 @@ msgstr "Could not delete bot"
 msgid "Could not delete MCP server"
 msgstr "Could not delete MCP server"
 
-#: src/pages/Shell.tsx:4893
+#: src/pages/Shell.tsx:5014
 msgid "Could not delete routine"
 msgstr "Could not delete routine"
 
@@ -882,7 +887,7 @@ msgstr "Could not remove group"
 msgid "Could not remove rule"
 msgstr "Could not remove rule"
 
-#: src/pages/Shell.tsx:5150
+#: src/pages/Shell.tsx:5271
 msgid "Could not render chart"
 msgstr "Could not render chart"
 
@@ -890,7 +895,7 @@ msgstr "Could not render chart"
 msgid "Could not revoke connection"
 msgstr "Could not revoke connection"
 
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4622
 msgid "Could not save"
 msgstr "Could not save"
 
@@ -902,7 +907,7 @@ msgstr "Could not save group"
 msgid "Could not save model"
 msgstr "Could not save model"
 
-#: src/pages/Shell.tsx:2556
+#: src/pages/Shell.tsx:2677
 msgid "Could not save routine"
 msgstr "Could not save routine"
 
@@ -918,7 +923,7 @@ msgstr "Could not save that choice"
 msgid "Could not save that voice"
 msgstr "Could not save that voice"
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:5091
 msgid "Could not save this choice"
 msgstr "Could not save this choice"
 
@@ -934,7 +939,7 @@ msgstr "Could not start OAuth"
 msgid "Could not submit this answer"
 msgstr "Could not submit this answer"
 
-#: src/pages/Shell.tsx:1543
+#: src/pages/Shell.tsx:1556
 msgid "Could not take control"
 msgstr "Could not take control"
 
@@ -950,14 +955,14 @@ msgstr "Could not update agent access"
 msgid "Could not update the default memory scope"
 msgstr "Could not update the default memory scope"
 
-#: src/pages/Shell.tsx:1720
-#: src/pages/Shell.tsx:4207
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:1766
+#: src/pages/Shell.tsx:4328
+#: src/pages/Shell.tsx:4751
 msgid "Create"
 msgstr "Create"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4604
+#: src/pages/Shell.tsx:4725
 msgid "Create a section and move {0} into it."
 msgstr "Create a section and move {0} into it."
 
@@ -978,8 +983,8 @@ msgid "Create your Rakazo"
 msgstr "Create your Rakazo"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4207
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4328
+#: src/pages/Shell.tsx:4751
 msgid "Creating…"
 msgstr "Creating…"
 
@@ -1007,7 +1012,7 @@ msgstr "day"
 msgid "days"
 msgstr "days"
 
-#: src/pages/Shell.tsx:4408
+#: src/pages/Shell.tsx:4529
 msgid "Default (medium)"
 msgstr "Default (medium)"
 
@@ -1017,21 +1022,21 @@ msgstr "Default scope"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1929
-#: src/pages/Shell.tsx:4825
-#: src/pages/Shell.tsx:4899
+#: src/pages/Shell.tsx:1975
+#: src/pages/Shell.tsx:4946
+#: src/pages/Shell.tsx:5020
 msgid "Delete"
 msgstr "Delete"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1925
+#: src/pages/Shell.tsx:1971
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4871
+#: src/pages/Shell.tsx:4878
+#: src/pages/Shell.tsx:4992
 msgid "Delete {0}?"
 msgstr "Delete {0}?"
 
@@ -1039,21 +1044,21 @@ msgstr "Delete {0}?"
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/pages/Shell.tsx:4794
+#: src/pages/Shell.tsx:4915
 msgid "Delete memories too"
 msgstr "Delete memories too"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2732
 msgid "Delete routine"
 msgstr "Delete routine"
 
-#: src/pages/Shell.tsx:3914
+#: src/pages/Shell.tsx:4035
 msgid "deleted"
 msgstr "deleted"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4825
-#: src/pages/Shell.tsx:4899
+#: src/pages/Shell.tsx:4946
+#: src/pages/Shell.tsx:5020
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1070,17 +1075,17 @@ msgid "Deployment default"
 msgstr "Deployment default"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4185
+#: src/pages/Shell.tsx:4306
 msgid "Describe what this bot does"
 msgstr "Describe what this bot does"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4190
-#: src/pages/Shell.tsx:4352
+#: src/pages/Shell.tsx:4311
+#: src/pages/Shell.tsx:4473
 msgid "Description"
 msgstr "Description"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3512
 msgid "Dictate"
 msgstr "Dictate"
 
@@ -1093,7 +1098,7 @@ msgstr "Disconnect"
 msgid "Disconnecting…"
 msgstr "Disconnecting…"
 
-#: src/pages/Shell.tsx:5278
+#: src/pages/Shell.tsx:5399
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Dismissed — reconnect anytime from MCP settings."
 
@@ -1193,11 +1198,11 @@ msgstr "Every month"
 msgid "Every week"
 msgstr "Every week"
 
-#: src/pages/Shell.tsx:5324
+#: src/pages/Shell.tsx:5445
 msgid "Expand"
 msgstr "Expand"
 
-#: src/pages/Shell.tsx:4513
+#: src/pages/Shell.tsx:4634
 msgid "Export"
 msgstr "Export"
 
@@ -1205,7 +1210,7 @@ msgstr "Export"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Export this week's list from the CRM and drop it in the shared folder"
 
-#: src/pages/Shell.tsx:4528
+#: src/pages/Shell.tsx:4649
 msgid "Extra high"
 msgstr "Extra high"
 
@@ -1213,14 +1218,14 @@ msgstr "Extra high"
 msgid "Failed"
 msgstr "Failed"
 
-#: src/pages/Shell.tsx:1386
-#: src/pages/Shell.tsx:1388
-#: src/pages/Shell.tsx:1390
+#: src/pages/Shell.tsx:1399
+#: src/pages/Shell.tsx:1401
+#: src/pages/Shell.tsx:1403
 msgid "Failed to send message"
 msgstr "Failed to send message"
 
-#: src/pages/Shell.tsx:1413
-#: src/pages/Shell.tsx:1432
+#: src/pages/Shell.tsx:1426
+#: src/pages/Shell.tsx:1445
 msgid "Failed to stop"
 msgstr "Failed to stop"
 
@@ -1252,8 +1257,8 @@ msgstr "Finishing MCP connection…"
 msgid "Fullscreen"
 msgstr "Fullscreen"
 
-#: src/pages/Shell.tsx:2079
-#: src/pages/Shell.tsx:2228
+#: src/pages/Shell.tsx:2125
+#: src/pages/Shell.tsx:2274
 msgid "Group"
 msgstr "Group"
 
@@ -1282,15 +1287,15 @@ msgstr "Hear a sample"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hi, this is how I'll sound when I read replies out loud."
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4652
 msgid "High"
 msgstr "High"
 
-#: src/pages/Shell.tsx:3410
+#: src/pages/Shell.tsx:3531
 msgid "Hold to talk"
 msgstr "Hold to talk"
 
-#: src/pages/Shell.tsx:3410
+#: src/pages/Shell.tsx:3531
 msgid "Hold to talk (on-device dictation)"
 msgstr "Hold to talk (on-device dictation)"
 
@@ -1310,7 +1315,7 @@ msgstr "How often"
 msgid "How to check"
 msgstr "How to check"
 
-#: src/pages/Shell.tsx:3632
+#: src/pages/Shell.tsx:3753
 msgid "I’m done"
 msgstr "I’m done"
 
@@ -1322,7 +1327,7 @@ msgstr "If you heard that, voice is ready."
 msgid "Import OpenAPI JSON"
 msgstr "Import OpenAPI JSON"
 
-#: src/pages/Shell.tsx:4423
+#: src/pages/Shell.tsx:4544
 msgid "Inherit default"
 msgstr "Inherit default"
 
@@ -1334,7 +1339,7 @@ msgstr "Inputs"
 msgid "Instance API key"
 msgstr "Instance API key"
 
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2616
 msgid "Instruction"
 msgstr "Instruction"
 
@@ -1343,7 +1348,7 @@ msgid "Integration views"
 msgstr "Integration views"
 
 #: src/pages/PluginsOverlay.tsx:213
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1992
 msgid "Integrations"
 msgstr "Integrations"
 
@@ -1364,11 +1369,11 @@ msgid "Interval unit"
 msgstr "Interval unit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4424
+#: src/pages/Shell.tsx:4545
 msgid "Isolated"
 msgstr "Isolated"
 
-#: src/pages/Shell.tsx:4760
+#: src/pages/Shell.tsx:4881
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 
@@ -1376,7 +1381,7 @@ msgstr "Its conversation, files, and routines will be permanently deleted. Bots 
 msgid "just now"
 msgstr "just now"
 
-#: src/pages/Shell.tsx:4778
+#: src/pages/Shell.tsx:4899
 msgid "Keep memories"
 msgstr "Keep memories"
 
@@ -1384,9 +1389,9 @@ msgstr "Keep memories"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "Keys stay on the server. The app only learns whether a provider is configured."
 
-#: src/pages/AccountSettingsOverlay.tsx:102
-#: src/pages/AccountSettingsOverlay.tsx:255
-#: src/pages/AccountSettingsOverlay.tsx:274
+#: src/pages/AccountSettingsOverlay.tsx:105
+#: src/pages/AccountSettingsOverlay.tsx:254
+#: src/pages/AccountSettingsOverlay.tsx:271
 msgid "Language"
 msgstr "Language"
 
@@ -1394,7 +1399,7 @@ msgstr "Language"
 msgid "Listening…"
 msgstr "Listening…"
 
-#: src/pages/Shell.tsx:3009
+#: src/pages/Shell.tsx:3130
 msgid "Load earlier messages"
 msgstr "Load earlier messages"
 
@@ -1434,7 +1439,7 @@ msgstr "Loading voice providers…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3009
+#: src/pages/Shell.tsx:3130
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -1442,11 +1447,11 @@ msgstr "Loading…"
 msgid "Local"
 msgstr "Local"
 
-#: src/pages/Shell.tsx:2032
+#: src/pages/Shell.tsx:2078
 msgid "Log out"
 msgstr "Log out"
 
-#: src/pages/Shell.tsx:4529
+#: src/pages/Shell.tsx:4650
 msgid "Low"
 msgstr "Low"
 
@@ -1462,7 +1467,7 @@ msgstr "Mark as Read"
 msgid "Mark as Unread"
 msgstr "Mark as Unread"
 
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4654
 msgid "Max"
 msgstr "Max"
 
@@ -1472,7 +1477,7 @@ msgstr "Max"
 msgid "MCP servers"
 msgstr "MCP servers"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4651
 msgid "Medium"
 msgstr "Medium"
 
@@ -1485,33 +1490,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:1990
+#: src/pages/Shell.tsx:2036
 msgid "Memory"
 msgstr "Memory"
 
-#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4540
 msgid "Memory scope"
 msgstr "Memory scope"
 
-#: src/pages/Shell.tsx:3488
-#: src/pages/Shell.tsx:3583
+#: src/pages/Shell.tsx:3609
+#: src/pages/Shell.tsx:3704
 msgid "Message"
 msgstr "Message"
 
-#: src/pages/Shell.tsx:3484
-#: src/pages/Shell.tsx:3488
+#: src/pages/Shell.tsx:3605
+#: src/pages/Shell.tsx:3609
 msgid "Message {activeName}"
 msgstr "Message {activeName}"
 
-#: src/pages/Shell.tsx:3800
+#: src/pages/Shell.tsx:3921
 msgid "Message from {peer}"
 msgstr "Message from {peer}"
 
-#: src/pages/Shell.tsx:3485
+#: src/pages/Shell.tsx:3606
 msgid "Message…"
 msgstr "Message…"
 
-#: src/pages/Shell.tsx:3800
+#: src/pages/Shell.tsx:3921
 msgid "Messaged {peer}"
 msgstr "Messaged {peer}"
 
@@ -1519,7 +1524,7 @@ msgstr "Messaged {peer}"
 msgid "Microphone failed"
 msgstr "Microphone failed"
 
-#: src/pages/Shell.tsx:4532
+#: src/pages/Shell.tsx:4653
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1541,7 +1546,7 @@ msgstr "minutes"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4375
+#: src/pages/Shell.tsx:4496
 msgid "Model"
 msgstr "Model"
 
@@ -1554,7 +1559,7 @@ msgstr "Model id"
 msgid "Model options"
 msgstr "Model options"
 
-#: src/pages/AccountSettingsOverlay.tsx:124
+#: src/pages/AccountSettingsOverlay.tsx:127
 msgid "Model spend uses your provider keys."
 msgstr "Model spend uses your provider keys."
 
@@ -1563,7 +1568,7 @@ msgid "Model updated."
 msgstr "Model updated."
 
 #: src/pages/ModelSettingsOverlay.tsx:303
-#: src/pages/Shell.tsx:1977
+#: src/pages/Shell.tsx:2023
 msgid "Models"
 msgstr "Models"
 
@@ -1581,7 +1586,7 @@ msgstr "Monthly"
 msgid "Move {0} to section"
 msgstr "Move {0} to section"
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4902
 msgid "Move them to your shared memory."
 msgstr "Move them to your shared memory."
 
@@ -1594,15 +1599,15 @@ msgstr "Move to"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2487
-#: src/pages/Shell.tsx:4170
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:4291
+#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4728
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4175
+#: src/pages/Shell.tsx:4296
 msgid "Name this bot"
 msgstr "Name this bot"
 
@@ -1618,13 +1623,17 @@ msgstr "Needs input"
 msgid "Needs takeover"
 msgstr "Needs takeover"
 
-#: src/pages/Shell.tsx:1734
-#: src/pages/Shell.tsx:4158
+#: src/pages/Shell.tsx:2369
+msgid "Never used yet"
+msgstr "Never used yet"
+
+#: src/pages/Shell.tsx:1780
+#: src/pages/Shell.tsx:4279
 msgid "New bot"
 msgstr "New bot"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1744
+#: src/pages/Shell.tsx:1790
 msgid "New group"
 msgstr "New group"
 
@@ -1632,12 +1641,12 @@ msgstr "New group"
 msgid "New open-work item"
 msgstr "New open-work item"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2498
 msgid "New routine"
 msgstr "New routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4722
 msgid "New section"
 msgstr "New section"
 
@@ -1691,6 +1700,10 @@ msgstr "No MCP servers yet."
 msgid "No model catalog is available."
 msgstr "No model catalog is available."
 
+#: src/pages/Shell.tsx:2305
+msgid "No other agents yet"
+msgstr "No other agents yet"
+
 #: src/pages/ModelSettingsOverlay.tsx:385
 msgid "No providers found."
 msgstr "No providers found."
@@ -1712,7 +1725,7 @@ msgstr "Not configured"
 msgid "Not connected"
 msgstr "Not connected"
 
-#: src/pages/Shell.tsx:5266
+#: src/pages/Shell.tsx:5387
 msgid "Not now"
 msgstr "Not now"
 
@@ -1750,15 +1763,15 @@ msgstr "on the 1st at {0}"
 msgid "Open"
 msgstr "Open"
 
-#: src/pages/Shell.tsx:2287
+#: src/pages/Shell.tsx:2405
 msgid "Open computer"
 msgstr "Open computer"
 
-#: src/pages/Shell.tsx:2257
+#: src/pages/Shell.tsx:2374
 msgid "Open in full window"
 msgstr "Open in full window"
 
-#: src/pages/Shell.tsx:2056
+#: src/pages/Shell.tsx:2102
 msgid "Open navigation"
 msgstr "Open navigation"
 
@@ -1775,7 +1788,7 @@ msgstr "Open work"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-compatible server URL"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:4046
 msgid "Opened its thread."
 msgstr "Opened its thread."
 
@@ -1788,7 +1801,7 @@ msgstr "Opening your workspace…"
 msgid "Optional"
 msgstr "Optional"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:141
 msgid "Optional controls most people never need"
 msgstr "Optional controls most people never need"
 
@@ -1807,6 +1820,10 @@ msgstr "Or paste an API key"
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
 msgstr "Organization API key"
+
+#: src/pages/Shell.tsx:2355
+msgid "Other computer preview (view only)"
+msgstr "Other computer preview (view only)"
 
 #: src/pages/ModelSettingsOverlay.tsx:453
 #: src/pages/Onboarding.tsx:311
@@ -1858,7 +1875,7 @@ msgstr "Playing…"
 msgid "Preview {0}"
 msgstr "Preview {0}"
 
-#: src/pages/Shell.tsx:4113
+#: src/pages/Shell.tsx:4234
 msgid "Private"
 msgstr "Private"
 
@@ -1879,7 +1896,7 @@ msgstr "Queued"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 
-#: src/pages/Shell.tsx:4451
+#: src/pages/Shell.tsx:4572
 msgid "Read replies aloud"
 msgstr "Read replies aloud"
 
@@ -1901,7 +1918,7 @@ msgstr "Reconnecting"
 msgid "Recording: {0}"
 msgstr "Recording: {0}"
 
-#: src/pages/Shell.tsx:3622
+#: src/pages/Shell.tsx:3743
 msgid "Release"
 msgstr "Release"
 
@@ -1912,17 +1929,17 @@ msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3292
+#: src/pages/Shell.tsx:3413
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3447
+#: src/pages/Shell.tsx:3568
 msgid "Remove mention {0}"
 msgstr "Remove mention {0}"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3426
+#: src/pages/Shell.tsx:3547
 msgid "Remove skill {0}"
 msgstr "Remove skill {0}"
 
@@ -1930,7 +1947,7 @@ msgstr "Remove skill {0}"
 msgid "Remove this schedule"
 msgstr "Remove this schedule"
 
-#: src/pages/Shell.tsx:3924
+#: src/pages/Shell.tsx:4045
 msgid "Removed with chat, computer, and memory."
 msgstr "Removed with chat, computer, and memory."
 
@@ -1956,16 +1973,16 @@ msgstr "Replace API key"
 msgid "Replace key"
 msgstr "Replace key"
 
-#: src/pages/Shell.tsx:3016
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3137
+#: src/pages/Shell.tsx:3141
 msgid "Reply"
 msgstr "Reply"
 
-#: src/pages/Shell.tsx:3250
+#: src/pages/Shell.tsx:3371
 msgid "Replying to"
 msgstr "Replying to"
 
-#: src/pages/Shell.tsx:1921
+#: src/pages/Shell.tsx:1967
 msgid "Restore"
 msgstr "Restore"
 
@@ -1985,17 +2002,17 @@ msgstr "Revoke"
 msgid "Revoking…"
 msgstr "Revoking…"
 
-#: src/pages/Shell.tsx:2480
-#: src/pages/Shell.tsx:2533
-#: src/pages/Shell.tsx:2540
+#: src/pages/Shell.tsx:2601
+#: src/pages/Shell.tsx:2654
+#: src/pages/Shell.tsx:2661
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2322
+#: src/pages/Shell.tsx:2443
 msgid "Routines"
 msgstr "Routines"
 
-#: src/pages/Shell.tsx:2603
+#: src/pages/Shell.tsx:2724
 msgid "Run now"
 msgstr "Run now"
 
@@ -2003,11 +2020,11 @@ msgstr "Run now"
 msgid "Running"
 msgstr "Running"
 
-#: src/pages/Shell.tsx:2362
+#: src/pages/Shell.tsx:2483
 msgid "Running · Stop"
 msgstr "Running · Stop"
 
-#: src/pages/Shell.tsx:2603
+#: src/pages/Shell.tsx:2724
 msgid "Running…"
 msgstr "Running…"
 
@@ -2015,8 +2032,8 @@ msgstr "Running…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2579
-#: src/pages/Shell.tsx:4506
+#: src/pages/Shell.tsx:2700
+#: src/pages/Shell.tsx:4627
 msgid "Save"
 msgstr "Save"
 
@@ -2040,7 +2057,7 @@ msgstr "Saved."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2579
+#: src/pages/Shell.tsx:2700
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2053,7 +2070,7 @@ msgstr "Say something. Silence sends it."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Say yes or no, or answer in a sentence."
 
-#: src/pages/Shell.tsx:1755
+#: src/pages/Shell.tsx:1801
 msgid "Search"
 msgstr "Search"
 
@@ -2075,11 +2092,11 @@ msgstr "Search providers and models"
 msgid "Searching…"
 msgstr "Searching…"
 
-#: src/pages/Shell.tsx:2080
+#: src/pages/Shell.tsx:2126
 msgid "Select a bot"
 msgstr "Select a bot"
 
-#: src/pages/Shell.tsx:3508
+#: src/pages/Shell.tsx:3629
 msgid "Send"
 msgstr "Send"
 
@@ -2107,22 +2124,22 @@ msgstr "Server name"
 msgid "Server URL"
 msgstr "Server URL"
 
-#: src/pages/Shell.tsx:2089
+#: src/pages/Shell.tsx:2135
 msgid "Set up voice to call"
 msgstr "Set up voice to call"
 
-#: src/pages/AccountSettingsOverlay.tsx:76
-#: src/pages/Shell.tsx:1954
-#: src/pages/Shell.tsx:1964
-#: src/pages/Shell.tsx:2224
+#: src/pages/AccountSettingsOverlay.tsx:79
+#: src/pages/Shell.tsx:2000
+#: src/pages/Shell.tsx:2010
+#: src/pages/Shell.tsx:2270
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Shell.tsx:3526
+#: src/pages/Shell.tsx:3647
 msgid "Settings: General"
 msgstr "Settings: General"
 
-#: src/pages/Shell.tsx:3528
+#: src/pages/Shell.tsx:3649
 msgid "Settings: Usage"
 msgstr "Settings: Usage"
 
@@ -2132,15 +2149,15 @@ msgid "Setup help"
 msgstr "Setup help"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4425
+#: src/pages/Shell.tsx:4546
 msgid "Shared"
 msgstr "Shared"
 
-#: src/pages/Shell.tsx:2235
+#: src/pages/Shell.tsx:2332
 msgid "Show computer"
 msgstr "Show computer"
 
-#: src/pages/Shell.tsx:2235
+#: src/pages/Shell.tsx:2332
 msgid "Show settings"
 msgstr "Show settings"
 
@@ -2164,11 +2181,11 @@ msgid "Sign up"
 msgstr "Sign up"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3339
+#: src/pages/Shell.tsx:3460
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3629
+#: src/pages/Shell.tsx:3750
 msgid "Skip"
 msgstr "Skip"
 
@@ -2181,7 +2198,7 @@ msgid "Skip or deploy key"
 msgstr "Skip or deploy key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1280
+#: src/pages/Shell.tsx:1293
 msgid "Skipped {0}"
 msgstr "Skipped {0}"
 
@@ -2189,8 +2206,8 @@ msgstr "Skipped {0}"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space interrupts · Esc hangs up"
 
-#: src/pages/Shell.tsx:3769
-#: src/pages/Shell.tsx:4022
+#: src/pages/Shell.tsx:3890
+#: src/pages/Shell.tsx:4143
 msgid "Speak"
 msgstr "Speak"
 
@@ -2202,8 +2219,8 @@ msgstr "Speak + transcribe"
 msgid "Speak only"
 msgstr "Speak only"
 
-#: src/pages/Shell.tsx:3765
-#: src/pages/Shell.tsx:4018
+#: src/pages/Shell.tsx:3886
+#: src/pages/Shell.tsx:4139
 msgid "Speak this reply"
 msgstr "Speak this reply"
 
@@ -2229,20 +2246,20 @@ msgstr "Starting…"
 msgid "Steps"
 msgstr "Steps"
 
-#: src/pages/Shell.tsx:2858
-#: src/pages/Shell.tsx:2862
-#: src/pages/Shell.tsx:3499
-#: src/pages/Shell.tsx:3769
-#: src/pages/Shell.tsx:4022
+#: src/pages/Shell.tsx:2979
+#: src/pages/Shell.tsx:2983
+#: src/pages/Shell.tsx:3620
+#: src/pages/Shell.tsx:3890
+#: src/pages/Shell.tsx:4143
 msgid "Stop"
 msgstr "Stop"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3512
 msgid "Stop dictation"
 msgstr "Stop dictation"
 
-#: src/pages/Shell.tsx:3765
-#: src/pages/Shell.tsx:4018
+#: src/pages/Shell.tsx:3886
+#: src/pages/Shell.tsx:4139
 msgid "Stop speaking"
 msgstr "Stop speaking"
 
@@ -2251,8 +2268,8 @@ msgstr "Stop speaking"
 msgid "Stop teaching"
 msgstr "Stop teaching"
 
-#: src/pages/Shell.tsx:2314
-#: src/pages/Shell.tsx:2878
+#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2999
 msgid "Stop the bot first"
 msgstr "Stop the bot first"
 
@@ -2260,7 +2277,7 @@ msgstr "Stop the bot first"
 msgid "Stored encrypted"
 msgstr "Stored encrypted"
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3997
 msgid "subagent"
 msgstr "subagent"
 
@@ -2273,8 +2290,8 @@ msgstr "Submit"
 msgid "Switching…"
 msgstr "Switching…"
 
-#: src/pages/Shell.tsx:2317
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2438
+#: src/pages/Shell.tsx:3004
 msgid "Take control"
 msgstr "Take control"
 
@@ -2282,7 +2299,7 @@ msgstr "Take control"
 msgid "Teach a task"
 msgstr "Teach a task"
 
-#: src/pages/Shell.tsx:2151
+#: src/pages/Shell.tsx:2197
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Teaching in progress — stop teaching before sending a new message."
 
@@ -2290,11 +2307,11 @@ msgstr "Teaching in progress — stop teaching before sending a new message."
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 
-#: src/pages/Shell.tsx:4113
+#: src/pages/Shell.tsx:4234
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:4947
+#: src/pages/Shell.tsx:5068
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -2307,20 +2324,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "The selected memory provider is not available in this build."
 
-#: src/pages/Shell.tsx:4402
+#: src/pages/Shell.tsx:4523
 msgid "Thinking"
 msgstr "Thinking"
 
-#: src/pages/Shell.tsx:2261
+#: src/pages/Shell.tsx:2378
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 
-#: src/pages/Shell.tsx:2907
+#: src/pages/Shell.tsx:3028
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 
-#: src/pages/Shell.tsx:4797
-#: src/pages/Shell.tsx:4874
+#: src/pages/Shell.tsx:4918
+#: src/pages/Shell.tsx:4995
 msgid "This cannot be undone."
 msgstr "This cannot be undone."
 
@@ -2344,7 +2361,7 @@ msgstr "this Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 
-#: src/pages/Shell.tsx:4682
+#: src/pages/Shell.tsx:4803
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 
@@ -2352,7 +2369,7 @@ msgstr "This permanently removes every message and stops current work. The bot, 
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "This provider cannot paste a key here. Skip if this deployment already has credentials."
 
-#: src/pages/Shell.tsx:5214
+#: src/pages/Shell.tsx:5335
 msgid "This server cannot be assigned without a bot."
 msgstr "This server cannot be assigned without a bot."
 
@@ -2364,7 +2381,7 @@ msgstr "This server did not request browser authorization."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "This server is already connected. Disconnect it first to authorize again."
 
-#: src/pages/Shell.tsx:5253
+#: src/pages/Shell.tsx:5374
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 
@@ -2377,8 +2394,8 @@ msgid "Time of day"
 msgstr "Time of day"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4180
-#: src/pages/Shell.tsx:4343
+#: src/pages/Shell.tsx:4301
+#: src/pages/Shell.tsx:4464
 msgid "Title"
 msgstr "Title"
 
@@ -2403,12 +2420,12 @@ msgid "Unpin"
 msgstr "Unpin"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1344
+#: src/pages/Shell.tsx:1357
 msgid "Unsupported file type: {0}"
 msgstr "Unsupported file type: {0}"
 
-#: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2015
+#: src/pages/AccountSettingsOverlay.tsx:117
+#: src/pages/Shell.tsx:2061
 msgid "Usage"
 msgstr "Usage"
 
@@ -2433,8 +2450,22 @@ msgstr "Verify and add"
 msgid "Verifying…"
 msgstr "Verifying…"
 
-#: src/pages/Shell.tsx:2003
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2294
+msgid "View another computer"
+msgstr "View another computer"
+
+#: src/pages/Shell.tsx:2298
+msgid "View…"
+msgstr "View…"
+
+#. placeholder {0}: peekTarget?.name ?? active.name
+#: src/pages/Shell.tsx:2413
+msgid "Viewing {0} (read only)"
+msgstr "Viewing {0} (read only)"
+
+#: src/pages/Shell.tsx:2049
+#: src/pages/Shell.tsx:4576
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2447,7 +2478,7 @@ msgstr "Voice"
 msgid "Waiting for sign-in…"
 msgstr "Waiting for sign-in…"
 
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5218
 msgid "Waiting…"
 msgstr "Waiting…"
 
@@ -2456,7 +2487,7 @@ msgstr "Waiting…"
 msgid "Weekdays"
 msgstr "Weekdays"
 
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4888
 msgid "What about its memories?"
 msgstr "What about its memories?"
 
@@ -2465,7 +2496,7 @@ msgid "What result will you demonstrate?"
 msgstr "What result will you demonstrate?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4195
+#: src/pages/Shell.tsx:4316
 msgid "What this bot is for"
 msgstr "What this bot is for"
 
@@ -2477,7 +2508,7 @@ msgstr "What to return"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 
-#: src/pages/Shell.tsx:2504
+#: src/pages/Shell.tsx:2625
 msgid "When to run"
 msgstr "When to run"
 
@@ -2494,11 +2525,11 @@ msgstr "Where should bots run?"
 msgid "Working…"
 msgstr "Working…"
 
-#: src/pages/Shell.tsx:4385
+#: src/pages/Shell.tsx:4506
 msgid "Workspace default"
 msgstr "Workspace default"
 
-#: src/pages/Shell.tsx:1665
+#: src/pages/Shell.tsx:1711
 msgid "You"
 msgstr "You"
 
@@ -2510,8 +2541,8 @@ msgstr "You can close this tab if it does not redirect automatically."
 msgid "You can close this window."
 msgstr "You can close this window."
 
-#: src/pages/Shell.tsx:2294
-#: src/pages/Shell.tsx:2848
+#: src/pages/Shell.tsx:2415
+#: src/pages/Shell.tsx:2969
 msgid "You have control"
 msgstr "You have control"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1816
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (읽지 않음)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {모델 #개} other {모델 #개}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1260
+#: src/pages/Shell.tsx:1273
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (첨부 파일 최대 {ATTACHMENT_MAX_COUNT}개)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1264
+#: src/pages/Shell.tsx:1277
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB 초과)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5070
+#: src/pages/Shell.tsx:5191
 msgid "{0} connection"
 msgstr "{0} 연결"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2298
+#: src/pages/Shell.tsx:2419
 msgid "{0} is using it"
 msgstr "{0}가 사용 중"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:118
-#: src/pages/Shell.tsx:2020
+#: src/pages/AccountSettingsOverlay.tsx:121
+#: src/pages/Shell.tsx:2066
 msgid "{0} runs · {1} tokens"
 msgstr "{0}회 실행 · 토큰 {1}개"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {동료 Bot #개} other {동료 Bot #개}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName}은 아직 다른 Bot에게 메시지를 보내지 않았습니다."
 
-#: src/pages/Shell.tsx:4947
+#: src/pages/Shell.tsx:5068
 msgid "{botName}’s computer"
 msgstr "{botName}의 컴퓨터"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3311
+#: src/pages/Shell.tsx:3432
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ 작업 가르치기"
 msgid "Access token (optional)"
 msgstr "액세스 토큰(선택 사항)"
 
-#: src/pages/AccountSettingsOverlay.tsx:94
+#: src/pages/AccountSettingsOverlay.tsx:97
 msgid "Account"
 msgstr "계정"
 
-#: src/pages/Shell.tsx:4461
+#: src/pages/Shell.tsx:4582
 msgid "Account default"
 msgstr "계정 기본값"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
+#: src/pages/AccountSettingsOverlay.tsx:82
 msgid "Account preferences apply across all your bots."
 msgstr "이 설정은 내가 만든 모든 Bot에 똑같이 적용됩니다."
 
@@ -156,8 +156,8 @@ msgstr "현재 모델"
 msgid "Active voice"
 msgstr "현재 목소리"
 
-#: src/pages/Shell.tsx:1700
-#: src/pages/Shell.tsx:1702
+#: src/pages/Shell.tsx:1746
+#: src/pages/Shell.tsx:1748
 msgid "Activity"
 msgstr "활동"
 
@@ -214,9 +214,9 @@ msgstr "Treg 추가"
 msgid "Adding…"
 msgstr "추가 중…"
 
-#: src/pages/AccountSettingsOverlay.tsx:135
+#: src/pages/AccountSettingsOverlay.tsx:138
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4364
+#: src/pages/Shell.tsx:4485
 msgid "Advanced"
 msgstr "고급 설정"
 
@@ -224,7 +224,7 @@ msgstr "고급 설정"
 msgid "Agent access for new servers"
 msgstr "새 서버를 사용할 Bot"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2153
 msgid "Agent computer"
 msgstr "Agent 컴퓨터"
 
@@ -311,11 +311,11 @@ msgstr "서버를 추가할 때 적용됩니다. 각 서버 카드의 Bot 버튼
 msgid "Approval boundaries"
 msgstr "승인이 필요한 범위"
 
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5384
 msgid "Approve"
 msgstr "승인"
 
-#: src/pages/Shell.tsx:5254
+#: src/pages/Shell.tsx:5375
 msgid "Approve this server to let your agent use its tools."
 msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 있습니다."
 
@@ -327,15 +327,15 @@ msgstr "앱"
 msgid "Archive"
 msgstr "보관"
 
-#: src/pages/Shell.tsx:3912
+#: src/pages/Shell.tsx:4033
 msgid "archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:1900
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4044
 msgid "Archived. Chat, memory, and files kept."
 msgstr "보관되었습니다. 대화, 기억, 파일은 유지됩니다."
 
@@ -374,7 +374,7 @@ msgstr "결제하기 전에 확인"
 msgid "Ask before sending external email"
 msgstr "외부 이메일을 보내기 전에 확인"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2421
 msgid "Asleep"
 msgstr "절전 중"
 
@@ -389,11 +389,11 @@ msgstr "{0}에"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}에"
 
-#: src/pages/Shell.tsx:3382
+#: src/pages/Shell.tsx:3503
 msgid "Attach file"
 msgstr "파일 첨부"
 
-#: src/pages/Shell.tsx:3581
+#: src/pages/Shell.tsx:3702
 msgid "Attachment"
 msgstr "첨부 파일"
 
@@ -406,14 +406,19 @@ msgstr "인증 코드 또는 돌아온 페이지 주소"
 msgid "Authorization expired — reconnect required"
 msgstr "인증이 만료됨 — 다시 연결해야 함"
 
-#: src/pages/Shell.tsx:5055
+#: src/pages/Shell.tsx:5176
 msgid "Authorization timed out. Please try again."
 msgstr "인증 시간이 만료되었습니다. 다시 시도해 주세요."
 
-#: src/pages/Shell.tsx:5097
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5384
 msgid "Authorize"
 msgstr "인증하기"
+
+#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2283
+msgid "Back to your computer"
+msgstr "내 컴퓨터로 돌아가기"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -423,18 +428,18 @@ msgstr "서버 주소"
 msgid "Bearer token"
 msgstr "Bearer 토큰"
 
-#: src/pages/Shell.tsx:4939
+#: src/pages/Shell.tsx:5060
 msgid "Booting live desktop…"
 msgstr "라이브 데스크톱 시작 중…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:2944
 msgid "Booting up {0}’s computer"
 msgstr "{0}의 컴퓨터를 켜는 중"
 
-#: src/pages/Shell.tsx:3782
-#: src/pages/Shell.tsx:3783
-#: src/pages/Shell.tsx:3916
+#: src/pages/Shell.tsx:3903
+#: src/pages/Shell.tsx:3904
+#: src/pages/Shell.tsx:4037
 msgid "bot"
 msgstr "Bot"
 
@@ -442,11 +447,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot 메시지"
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:3036
 msgid "Bot screen"
 msgstr "Bot 화면"
 
-#: src/pages/Shell.tsx:2268
+#: src/pages/Shell.tsx:2385
 msgid "Bot screen preview"
 msgstr "Bot 화면 미리보기"
 
@@ -459,8 +464,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "사용 중인 서비스의 API 키를 연결하세요. 서비스를 바꿔도 Bot의 읽기·통화 기능은 그대로 유지됩니다."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2089
-#: src/pages/Shell.tsx:2090
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2136
 msgid "Call"
 msgstr "통화"
 
@@ -471,14 +476,14 @@ msgstr "서버에 연결할 수 없습니다."
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4623
-#: src/pages/Shell.tsx:4695
-#: src/pages/Shell.tsx:4810
-#: src/pages/Shell.tsx:4884
+#: src/pages/Shell.tsx:4744
+#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4931
+#: src/pages/Shell.tsx:5005
 msgid "Cancel"
 msgstr "취소"
 
-#: src/pages/Shell.tsx:4160
+#: src/pages/Shell.tsx:4281
 msgid "Cancel new bot"
 msgstr "새 Bot 만들기 취소"
 
@@ -486,7 +491,7 @@ msgstr "새 Bot 만들기 취소"
 msgid "Cancel new group"
 msgstr "새 그룹 만들기 취소"
 
-#: src/pages/Shell.tsx:3258
+#: src/pages/Shell.tsx:3379
 msgid "Cancel reply"
 msgstr "답장 취소"
 
@@ -494,16 +499,16 @@ msgstr "답장 취소"
 msgid "Cancelled"
 msgstr "취소됨"
 
-#: src/pages/Shell.tsx:5160
+#: src/pages/Shell.tsx:5281
 msgid "Chart failed to render: {error}"
 msgstr "차트를 표시하지 못했습니다: {error}"
 
-#: src/pages/Shell.tsx:3524
+#: src/pages/Shell.tsx:3645
 msgid "Chat Settings"
 msgstr "채팅 설정"
 
-#: src/pages/Shell.tsx:2534
-#: src/pages/Shell.tsx:2541
+#: src/pages/Shell.tsx:2655
+#: src/pages/Shell.tsx:2662
 msgid "Check in."
 msgstr "확인해 주세요."
 
@@ -515,21 +520,21 @@ msgstr "먼저 사용할 AI 모델을 선택하세요."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo에서 기본으로 사용할 연결된 모델을 선택하세요."
 
-#: src/pages/Shell.tsx:4710
+#: src/pages/Shell.tsx:4831
 msgid "Clear"
 msgstr "비우기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:4797
 msgid "Clear {0}’s conversation?"
 msgstr "{0}와의 대화 내용을 비울까요?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4516
+#: src/pages/Shell.tsx:4637
 msgid "Clear conversation"
 msgstr "대화 내용 비우기"
 
-#: src/pages/Shell.tsx:4710
+#: src/pages/Shell.tsx:4831
 msgid "Clearing…"
 msgstr "비우는 중…"
 
@@ -545,15 +550,15 @@ msgstr "Bot 메뉴 닫기"
 msgid "Close bot messages"
 msgstr "Bot 메시지 닫기"
 
-#: src/pages/Shell.tsx:5345
+#: src/pages/Shell.tsx:5466
 msgid "Close chart"
 msgstr "차트 닫기"
 
-#: src/pages/Shell.tsx:2889
+#: src/pages/Shell.tsx:3010
 msgid "Close computer"
 msgstr "컴퓨터 닫기"
 
-#: src/pages/Shell.tsx:5445
+#: src/pages/Shell.tsx:5566
 msgid "Close image preview"
 msgstr "이미지 미리보기 닫기"
 
@@ -573,11 +578,11 @@ msgstr "기억 설정 닫기"
 msgid "Close model settings"
 msgstr "AI 모델 설정 닫기"
 
-#: src/pages/Shell.tsx:1685
+#: src/pages/Shell.tsx:1731
 msgid "Close navigation"
 msgstr "메뉴 닫기"
 
-#: src/pages/Shell.tsx:2246
+#: src/pages/Shell.tsx:2343
 msgid "Close panel"
 msgstr "패널 닫기"
 
@@ -586,7 +591,7 @@ msgstr "패널 닫기"
 msgid "Close preview"
 msgstr "미리보기 닫기"
 
-#: src/pages/AccountSettingsOverlay.tsx:84
+#: src/pages/AccountSettingsOverlay.tsx:87
 msgid "Close user settings"
 msgstr "계정 설정 닫기"
 
@@ -606,24 +611,24 @@ msgstr "실행 명령"
 msgid "Complete"
 msgstr "완료"
 
-#: src/pages/Shell.tsx:4070
-#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4191
+#: src/pages/Shell.tsx:4219
 msgid "Computer"
 msgstr "컴퓨터"
 
-#: src/pages/Shell.tsx:4942
+#: src/pages/Shell.tsx:5063
 msgid "Computer failed to boot"
 msgstr "컴퓨터를 시작하지 못했습니다"
 
-#: src/pages/Shell.tsx:2937
+#: src/pages/Shell.tsx:3058
 msgid "Computer is asleep"
 msgstr "컴퓨터가 절전 상태입니다"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5062
 msgid "Computer is asleep — take control to wake it"
 msgstr "컴퓨터가 절전 상태입니다 — 제어를 맡아 깨우세요"
 
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:5064
 msgid "Computer is stopped"
 msgstr "컴퓨터가 중지됨"
 
@@ -661,7 +666,7 @@ msgstr "앱을 연결하거나 Treg, MCP, OpenAPI 도구를 추가하세요."
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI 또는 Cartesia 연결"
 
-#: src/pages/Shell.tsx:5243
+#: src/pages/Shell.tsx:5364
 msgid "Connect MCP server “{name}”"
 msgstr "MCP 서버 ‘{name}’ 연결"
 
@@ -685,12 +690,12 @@ msgstr "Treg 연결"
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
 #: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5094
+#: src/pages/Shell.tsx:5215
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "연결됨"
 
-#: src/pages/Shell.tsx:5273
+#: src/pages/Shell.tsx:5394
 msgid "Connected — its tools are available from your next message."
 msgstr "연결되었습니다. 다음 메시지부터 이 도구를 사용할 수 있습니다."
 
@@ -716,7 +721,7 @@ msgstr "{0}에 연결하고 기본 모델로 설정했습니다."
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
 #: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5263
+#: src/pages/Shell.tsx:5384
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "연결 중…"
@@ -743,11 +748,11 @@ msgstr "추가하지 못했습니다."
 msgid "Could not add MCP server"
 msgstr "MCP 서버를 추가하지 못했습니다."
 
-#: src/pages/Shell.tsx:5230
+#: src/pages/Shell.tsx:5351
 msgid "Could not approve this server"
 msgstr "서버를 승인하지 못했습니다."
 
-#: src/pages/Shell.tsx:5058
+#: src/pages/Shell.tsx:5179
 msgid "Could not authorize this app"
 msgstr "앱 인증을 완료하지 못했습니다."
 
@@ -755,7 +760,7 @@ msgstr "앱 인증을 완료하지 못했습니다."
 msgid "Could not change the default model"
 msgstr "기본 모델을 변경하지 못했습니다."
 
-#: src/pages/Shell.tsx:4704
+#: src/pages/Shell.tsx:4825
 msgid "Could not clear conversation"
 msgstr "대화 내용을 비우지 못했습니다."
 
@@ -784,7 +789,7 @@ msgstr "음성 서비스에 연결하지 못했습니다."
 msgid "Could not continue"
 msgstr "계속 진행하지 못했습니다."
 
-#: src/pages/Shell.tsx:4148
+#: src/pages/Shell.tsx:4269
 msgid "Could not create bot"
 msgstr "Bot을 만들지 못했습니다."
 
@@ -792,7 +797,7 @@ msgstr "Bot을 만들지 못했습니다."
 msgid "Could not create group"
 msgstr "그룹을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4595
+#: src/pages/Shell.tsx:4716
 msgid "Could not create section"
 msgstr "섹션을 만들지 못했습니다."
 
@@ -800,7 +805,7 @@ msgstr "섹션을 만들지 못했습니다."
 msgid "Could not create your bot"
 msgstr "Bot을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4819
+#: src/pages/Shell.tsx:4940
 msgid "Could not delete bot"
 msgstr "Bot을 삭제하지 못했습니다."
 
@@ -808,7 +813,7 @@ msgstr "Bot을 삭제하지 못했습니다."
 msgid "Could not delete MCP server"
 msgstr "MCP 서버를 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4893
+#: src/pages/Shell.tsx:5014
 msgid "Could not delete routine"
 msgstr "자동 실행을 삭제하지 못했습니다."
 
@@ -882,7 +887,7 @@ msgstr "그룹을 삭제하지 못했습니다."
 msgid "Could not remove rule"
 msgstr "확인 규칙을 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:5150
+#: src/pages/Shell.tsx:5271
 msgid "Could not render chart"
 msgstr "차트를 만들지 못했습니다."
 
@@ -890,7 +895,7 @@ msgstr "차트를 만들지 못했습니다."
 msgid "Could not revoke connection"
 msgstr "연결을 해제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4622
 msgid "Could not save"
 msgstr "저장하지 못했습니다."
 
@@ -902,7 +907,7 @@ msgstr "그룹을 저장하지 못했습니다."
 msgid "Could not save model"
 msgstr "AI 모델을 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:2556
+#: src/pages/Shell.tsx:2677
 msgid "Could not save routine"
 msgstr "자동 실행을 저장하지 못했습니다."
 
@@ -918,7 +923,7 @@ msgstr "선택 내용을 저장하지 못했습니다."
 msgid "Could not save that voice"
 msgstr "목소리를 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:5091
 msgid "Could not save this choice"
 msgstr "선택 내용을 저장하지 못했습니다."
 
@@ -934,7 +939,7 @@ msgstr "OAuth 인증을 시작하지 못했습니다."
 msgid "Could not submit this answer"
 msgstr "답변을 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:1543
+#: src/pages/Shell.tsx:1556
 msgid "Could not take control"
 msgstr "직접 조작으로 전환하지 못했습니다."
 
@@ -950,14 +955,14 @@ msgstr "Bot의 서버 사용 권한을 변경하지 못했습니다."
 msgid "Could not update the default memory scope"
 msgstr "기본 기억 범위를 변경하지 못했습니다."
 
-#: src/pages/Shell.tsx:1720
-#: src/pages/Shell.tsx:4207
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:1766
+#: src/pages/Shell.tsx:4328
+#: src/pages/Shell.tsx:4751
 msgid "Create"
 msgstr "만들기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4604
+#: src/pages/Shell.tsx:4725
 msgid "Create a section and move {0} into it."
 msgstr "새 섹션을 만들고 {0}을 옮깁니다."
 
@@ -978,8 +983,8 @@ msgid "Create your Rakazo"
 msgstr "Rakazo 계정 만들기"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4207
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4328
+#: src/pages/Shell.tsx:4751
 msgid "Creating…"
 msgstr "만드는 중…"
 
@@ -1007,7 +1012,7 @@ msgstr "일"
 msgid "days"
 msgstr "일"
 
-#: src/pages/Shell.tsx:4408
+#: src/pages/Shell.tsx:4529
 msgid "Default (medium)"
 msgstr "기본(보통)"
 
@@ -1017,21 +1022,21 @@ msgstr "기본 기억 범위"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1929
-#: src/pages/Shell.tsx:4825
-#: src/pages/Shell.tsx:4899
+#: src/pages/Shell.tsx:1975
+#: src/pages/Shell.tsx:4946
+#: src/pages/Shell.tsx:5020
 msgid "Delete"
 msgstr "삭제"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1925
+#: src/pages/Shell.tsx:1971
 msgid "Delete {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4871
+#: src/pages/Shell.tsx:4878
+#: src/pages/Shell.tsx:4992
 msgid "Delete {0}?"
 msgstr "{0}을 삭제할까요?"
 
@@ -1039,21 +1044,21 @@ msgstr "{0}을 삭제할까요?"
 msgid "Delete group"
 msgstr "그룹 삭제"
 
-#: src/pages/Shell.tsx:4794
+#: src/pages/Shell.tsx:4915
 msgid "Delete memories too"
 msgstr "기억도 함께 삭제"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2732
 msgid "Delete routine"
 msgstr "자동 실행 삭제"
 
-#: src/pages/Shell.tsx:3914
+#: src/pages/Shell.tsx:4035
 msgid "deleted"
 msgstr "삭제됨"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4825
-#: src/pages/Shell.tsx:4899
+#: src/pages/Shell.tsx:4946
+#: src/pages/Shell.tsx:5020
 msgid "Deleting…"
 msgstr "삭제 중…"
 
@@ -1070,17 +1075,17 @@ msgid "Deployment default"
 msgstr "서버 기본값"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4185
+#: src/pages/Shell.tsx:4306
 msgid "Describe what this bot does"
 msgstr "이 Bot이 하는 일을 짧게 설명하세요"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4190
-#: src/pages/Shell.tsx:4352
+#: src/pages/Shell.tsx:4311
+#: src/pages/Shell.tsx:4473
 msgid "Description"
 msgstr "설명"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3512
 msgid "Dictate"
 msgstr "음성 입력"
 
@@ -1093,7 +1098,7 @@ msgstr "연결 해제"
 msgid "Disconnecting…"
 msgstr "연결 해제 중…"
 
-#: src/pages/Shell.tsx:5278
+#: src/pages/Shell.tsx:5399
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "지금은 연결하지 않았습니다. MCP 설정에서 언제든 다시 연결할 수 있습니다."
 
@@ -1193,11 +1198,11 @@ msgstr "매월"
 msgid "Every week"
 msgstr "매주"
 
-#: src/pages/Shell.tsx:5324
+#: src/pages/Shell.tsx:5445
 msgid "Expand"
 msgstr "펼치기"
 
-#: src/pages/Shell.tsx:4513
+#: src/pages/Shell.tsx:4634
 msgid "Export"
 msgstr "내보내기"
 
@@ -1205,7 +1210,7 @@ msgstr "내보내기"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "CRM에서 이번 주 목록을 내려받아 공유 폴더에 넣기"
 
-#: src/pages/Shell.tsx:4528
+#: src/pages/Shell.tsx:4649
 msgid "Extra high"
 msgstr "매우 높음"
 
@@ -1213,14 +1218,14 @@ msgstr "매우 높음"
 msgid "Failed"
 msgstr "실패"
 
-#: src/pages/Shell.tsx:1386
-#: src/pages/Shell.tsx:1388
-#: src/pages/Shell.tsx:1390
+#: src/pages/Shell.tsx:1399
+#: src/pages/Shell.tsx:1401
+#: src/pages/Shell.tsx:1403
 msgid "Failed to send message"
 msgstr "메시지를 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:1413
-#: src/pages/Shell.tsx:1432
+#: src/pages/Shell.tsx:1426
+#: src/pages/Shell.tsx:1445
 msgid "Failed to stop"
 msgstr "작업을 중지하지 못했습니다."
 
@@ -1252,8 +1257,8 @@ msgstr "MCP 연결을 마무리하는 중…"
 msgid "Fullscreen"
 msgstr "전체 화면"
 
-#: src/pages/Shell.tsx:2079
-#: src/pages/Shell.tsx:2228
+#: src/pages/Shell.tsx:2125
+#: src/pages/Shell.tsx:2274
 msgid "Group"
 msgstr "그룹"
 
@@ -1282,15 +1287,15 @@ msgstr "샘플 듣기"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "안녕하세요. 답변을 소리 내어 읽을 때 이런 목소리로 들립니다."
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4652
 msgid "High"
 msgstr "높음"
 
-#: src/pages/Shell.tsx:3410
+#: src/pages/Shell.tsx:3531
 msgid "Hold to talk"
 msgstr "누르고 말하기"
 
-#: src/pages/Shell.tsx:3410
+#: src/pages/Shell.tsx:3531
 msgid "Hold to talk (on-device dictation)"
 msgstr "누르고 말하기(기기 내 음성 인식)"
 
@@ -1310,7 +1315,7 @@ msgstr "실행 주기"
 msgid "How to check"
 msgstr "완료 확인 방법"
 
-#: src/pages/Shell.tsx:3632
+#: src/pages/Shell.tsx:3753
 msgid "I’m done"
 msgstr "조작 끝내기"
 
@@ -1322,7 +1327,7 @@ msgstr "샘플이 들렸다면 음성 설정이 완료되었습니다."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON 가져오기"
 
-#: src/pages/Shell.tsx:4423
+#: src/pages/Shell.tsx:4544
 msgid "Inherit default"
 msgstr "기본 설정 사용"
 
@@ -1334,7 +1339,7 @@ msgstr "입력값"
 msgid "Instance API key"
 msgstr "인스턴스 API 키"
 
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2616
 msgid "Instruction"
 msgstr "실행할 내용"
 
@@ -1343,7 +1348,7 @@ msgid "Integration views"
 msgstr "연동 목록 보기"
 
 #: src/pages/PluginsOverlay.tsx:213
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1992
 msgid "Integrations"
 msgstr "앱·도구 연동"
 
@@ -1364,11 +1369,11 @@ msgid "Interval unit"
 msgstr "간격 단위"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4424
+#: src/pages/Shell.tsx:4545
 msgid "Isolated"
 msgstr "이 Bot만 사용"
 
-#: src/pages/Shell.tsx:4760
+#: src/pages/Shell.tsx:4881
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만든 다른 Bot은 목록에 남습니다."
 
@@ -1376,7 +1381,7 @@ msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만�
 msgid "just now"
 msgstr "방금"
 
-#: src/pages/Shell.tsx:4778
+#: src/pages/Shell.tsx:4899
 msgid "Keep memories"
 msgstr "기억은 유지"
 
@@ -1384,9 +1389,9 @@ msgstr "기억은 유지"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "API 키는 서버에만 안전하게 보관되며, 앱에는 연결 여부만 표시됩니다."
 
-#: src/pages/AccountSettingsOverlay.tsx:102
-#: src/pages/AccountSettingsOverlay.tsx:255
-#: src/pages/AccountSettingsOverlay.tsx:274
+#: src/pages/AccountSettingsOverlay.tsx:105
+#: src/pages/AccountSettingsOverlay.tsx:254
+#: src/pages/AccountSettingsOverlay.tsx:271
 msgid "Language"
 msgstr "언어"
 
@@ -1394,7 +1399,7 @@ msgstr "언어"
 msgid "Listening…"
 msgstr "듣는 중…"
 
-#: src/pages/Shell.tsx:3009
+#: src/pages/Shell.tsx:3130
 msgid "Load earlier messages"
 msgstr "이전 메시지 불러오기"
 
@@ -1434,7 +1439,7 @@ msgstr "음성 서비스를 불러오는 중…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3009
+#: src/pages/Shell.tsx:3130
 msgid "Loading…"
 msgstr "불러오는 중…"
 
@@ -1442,11 +1447,11 @@ msgstr "불러오는 중…"
 msgid "Local"
 msgstr "로컬"
 
-#: src/pages/Shell.tsx:2032
+#: src/pages/Shell.tsx:2078
 msgid "Log out"
 msgstr "로그아웃"
 
-#: src/pages/Shell.tsx:4529
+#: src/pages/Shell.tsx:4650
 msgid "Low"
 msgstr "낮음"
 
@@ -1462,7 +1467,7 @@ msgstr "읽음으로 표시"
 msgid "Mark as Unread"
 msgstr "읽지 않음으로 표시"
 
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4654
 msgid "Max"
 msgstr "최대"
 
@@ -1472,7 +1477,7 @@ msgstr "최대"
 msgid "MCP servers"
 msgstr "MCP 서버"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4651
 msgid "Medium"
 msgstr "보통"
 
@@ -1485,33 +1490,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "참여 Bot ({GROUP_MEMBER_MIN}~{GROUP_MEMBER_MAX}개 선택)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:1990
+#: src/pages/Shell.tsx:2036
 msgid "Memory"
 msgstr "기억"
 
-#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4540
 msgid "Memory scope"
 msgstr "기억 사용 범위"
 
-#: src/pages/Shell.tsx:3488
-#: src/pages/Shell.tsx:3583
+#: src/pages/Shell.tsx:3609
+#: src/pages/Shell.tsx:3704
 msgid "Message"
 msgstr "메시지"
 
-#: src/pages/Shell.tsx:3484
-#: src/pages/Shell.tsx:3488
+#: src/pages/Shell.tsx:3605
+#: src/pages/Shell.tsx:3609
 msgid "Message {activeName}"
 msgstr "{activeName}에게 메시지 보내기"
 
-#: src/pages/Shell.tsx:3800
+#: src/pages/Shell.tsx:3921
 msgid "Message from {peer}"
 msgstr "{peer}의 메시지"
 
-#: src/pages/Shell.tsx:3485
+#: src/pages/Shell.tsx:3606
 msgid "Message…"
 msgstr "메시지를 입력하세요"
 
-#: src/pages/Shell.tsx:3800
+#: src/pages/Shell.tsx:3921
 msgid "Messaged {peer}"
 msgstr "{peer}에게 메시지 보냄"
 
@@ -1519,7 +1524,7 @@ msgstr "{peer}에게 메시지 보냄"
 msgid "Microphone failed"
 msgstr "마이크를 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4532
+#: src/pages/Shell.tsx:4653
 msgid "Minimal"
 msgstr "최소"
 
@@ -1541,7 +1546,7 @@ msgstr "분"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4375
+#: src/pages/Shell.tsx:4496
 msgid "Model"
 msgstr "모델"
 
@@ -1554,7 +1559,7 @@ msgstr "모델 ID"
 msgid "Model options"
 msgstr "모델 선택지"
 
-#: src/pages/AccountSettingsOverlay.tsx:124
+#: src/pages/AccountSettingsOverlay.tsx:127
 msgid "Model spend uses your provider keys."
 msgstr "모델 사용 비용은 연결한 서비스의 API 키로 청구됩니다."
 
@@ -1563,7 +1568,7 @@ msgid "Model updated."
 msgstr "모델이 변경되었습니다."
 
 #: src/pages/ModelSettingsOverlay.tsx:303
-#: src/pages/Shell.tsx:1977
+#: src/pages/Shell.tsx:2023
 msgid "Models"
 msgstr "AI 모델"
 
@@ -1581,7 +1586,7 @@ msgstr "매월"
 msgid "Move {0} to section"
 msgstr "{0} 섹션 이동"
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4902
 msgid "Move them to your shared memory."
 msgstr "공용 기억으로 옮깁니다."
 
@@ -1594,15 +1599,15 @@ msgstr "섹션으로 이동"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2487
-#: src/pages/Shell.tsx:4170
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:4291
+#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4728
 msgid "Name"
 msgstr "이름"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4175
+#: src/pages/Shell.tsx:4296
 msgid "Name this bot"
 msgstr "Bot 이름"
 
@@ -1618,13 +1623,17 @@ msgstr "입력 필요"
 msgid "Needs takeover"
 msgstr "인수 필요"
 
-#: src/pages/Shell.tsx:1734
-#: src/pages/Shell.tsx:4158
+#: src/pages/Shell.tsx:2369
+msgid "Never used yet"
+msgstr "아직 사용하지 않음"
+
+#: src/pages/Shell.tsx:1780
+#: src/pages/Shell.tsx:4279
 msgid "New bot"
 msgstr "새 Bot 만들기"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1744
+#: src/pages/Shell.tsx:1790
 msgid "New group"
 msgstr "새 그룹 만들기"
 
@@ -1632,12 +1641,12 @@ msgstr "새 그룹 만들기"
 msgid "New open-work item"
 msgstr "새 진행 작업"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2498
 msgid "New routine"
 msgstr "새 자동 실행"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4722
 msgid "New section"
 msgstr "새 섹션"
 
@@ -1691,6 +1700,10 @@ msgstr "아직 연결된 MCP 서버가 없습니다."
 msgid "No model catalog is available."
 msgstr "사용 가능한 모델 목록이 없습니다."
 
+#: src/pages/Shell.tsx:2305
+msgid "No other agents yet"
+msgstr "다른 에이전트가 아직 없습니다"
+
 #: src/pages/ModelSettingsOverlay.tsx:385
 msgid "No providers found."
 msgstr "검색된 AI 서비스가 없습니다."
@@ -1712,7 +1725,7 @@ msgstr "설정되지 않음"
 msgid "Not connected"
 msgstr "연결되지 않음"
 
-#: src/pages/Shell.tsx:5266
+#: src/pages/Shell.tsx:5387
 msgid "Not now"
 msgstr "나중에"
 
@@ -1750,15 +1763,15 @@ msgstr "매월 1일 {0}에"
 msgid "Open"
 msgstr "열기"
 
-#: src/pages/Shell.tsx:2287
+#: src/pages/Shell.tsx:2405
 msgid "Open computer"
 msgstr "컴퓨터 열기"
 
-#: src/pages/Shell.tsx:2257
+#: src/pages/Shell.tsx:2374
 msgid "Open in full window"
 msgstr "전체 창으로 열기"
 
-#: src/pages/Shell.tsx:2056
+#: src/pages/Shell.tsx:2102
 msgid "Open navigation"
 msgstr "메뉴 열기"
 
@@ -1775,7 +1788,7 @@ msgstr "진행 중인 작업"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 호환 서버 주소"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:4046
 msgid "Opened its thread."
 msgstr "대화가 만들어졌습니다."
 
@@ -1788,7 +1801,7 @@ msgstr "작업공간을 여는 중…"
 msgid "Optional"
 msgstr "선택 사항"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:141
 msgid "Optional controls most people never need"
 msgstr "필요할 때만 쓰는 세부 설정"
 
@@ -1807,6 +1820,10 @@ msgstr "또는 API 키 붙여넣기"
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
 msgstr "조직 API 키"
+
+#: src/pages/Shell.tsx:2355
+msgid "Other computer preview (view only)"
+msgstr "다른 컴퓨터 미리보기 (보기 전용)"
 
 #: src/pages/ModelSettingsOverlay.tsx:453
 #: src/pages/Onboarding.tsx:311
@@ -1858,7 +1875,7 @@ msgstr "재생 중…"
 msgid "Preview {0}"
 msgstr "{0} 미리보기"
 
-#: src/pages/Shell.tsx:4113
+#: src/pages/Shell.tsx:4234
 msgid "Private"
 msgstr "Bot 전용"
 
@@ -1879,7 +1896,7 @@ msgstr "대기 중"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo는 저장하기 전에 연결 상태를 확인합니다. 인증 정보는 암호화되며 앱이나 AI 모델에 노출되지 않습니다."
 
-#: src/pages/Shell.tsx:4451
+#: src/pages/Shell.tsx:4572
 msgid "Read replies aloud"
 msgstr "답변을 자동으로 읽기"
 
@@ -1901,7 +1918,7 @@ msgstr "다시 연결 중"
 msgid "Recording: {0}"
 msgstr "녹화 중: {0}"
 
-#: src/pages/Shell.tsx:3622
+#: src/pages/Shell.tsx:3743
 msgid "Release"
 msgstr "제어권 돌려주기"
 
@@ -1912,17 +1929,17 @@ msgid "Remove"
 msgstr "삭제"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3292
+#: src/pages/Shell.tsx:3413
 msgid "Remove {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3447
+#: src/pages/Shell.tsx:3568
 msgid "Remove mention {0}"
 msgstr "{0} 멘션 삭제"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3426
+#: src/pages/Shell.tsx:3547
 msgid "Remove skill {0}"
 msgstr "작업 기술 {0} 삭제"
 
@@ -1930,7 +1947,7 @@ msgstr "작업 기술 {0} 삭제"
 msgid "Remove this schedule"
 msgstr "이 일정 삭제"
 
-#: src/pages/Shell.tsx:3924
+#: src/pages/Shell.tsx:4045
 msgid "Removed with chat, computer, and memory."
 msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 
@@ -1956,16 +1973,16 @@ msgstr "API 키 교체"
 msgid "Replace key"
 msgstr "키 교체"
 
-#: src/pages/Shell.tsx:3016
-#: src/pages/Shell.tsx:3020
+#: src/pages/Shell.tsx:3137
+#: src/pages/Shell.tsx:3141
 msgid "Reply"
 msgstr "답장"
 
-#: src/pages/Shell.tsx:3250
+#: src/pages/Shell.tsx:3371
 msgid "Replying to"
 msgstr "답장할 메시지"
 
-#: src/pages/Shell.tsx:1921
+#: src/pages/Shell.tsx:1967
 msgid "Restore"
 msgstr "복원"
 
@@ -1985,17 +2002,17 @@ msgstr "연결 해제"
 msgid "Revoking…"
 msgstr "연결 해제 중…"
 
-#: src/pages/Shell.tsx:2480
-#: src/pages/Shell.tsx:2533
-#: src/pages/Shell.tsx:2540
+#: src/pages/Shell.tsx:2601
+#: src/pages/Shell.tsx:2654
+#: src/pages/Shell.tsx:2661
 msgid "Routine"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2322
+#: src/pages/Shell.tsx:2443
 msgid "Routines"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2603
+#: src/pages/Shell.tsx:2724
 msgid "Run now"
 msgstr "지금 실행"
 
@@ -2003,11 +2020,11 @@ msgstr "지금 실행"
 msgid "Running"
 msgstr "실행 중"
 
-#: src/pages/Shell.tsx:2362
+#: src/pages/Shell.tsx:2483
 msgid "Running · Stop"
 msgstr "실행 중 · 중지"
 
-#: src/pages/Shell.tsx:2603
+#: src/pages/Shell.tsx:2724
 msgid "Running…"
 msgstr "실행 중…"
 
@@ -2015,8 +2032,8 @@ msgstr "실행 중…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2579
-#: src/pages/Shell.tsx:4506
+#: src/pages/Shell.tsx:2700
+#: src/pages/Shell.tsx:4627
 msgid "Save"
 msgstr "저장"
 
@@ -2040,7 +2057,7 @@ msgstr "저장되었습니다."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2579
+#: src/pages/Shell.tsx:2700
 msgid "Saving…"
 msgstr "저장 중…"
 
@@ -2053,7 +2070,7 @@ msgstr "말씀하세요. 잠시 멈추면 자동으로 전송됩니다."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "예 또는 아니요로 답하거나 문장으로 답해 주세요."
 
-#: src/pages/Shell.tsx:1755
+#: src/pages/Shell.tsx:1801
 msgid "Search"
 msgstr "검색"
 
@@ -2075,11 +2092,11 @@ msgstr "AI 서비스 또는 모델 검색"
 msgid "Searching…"
 msgstr "검색 중…"
 
-#: src/pages/Shell.tsx:2080
+#: src/pages/Shell.tsx:2126
 msgid "Select a bot"
 msgstr "대화할 Bot을 선택하세요"
 
-#: src/pages/Shell.tsx:3508
+#: src/pages/Shell.tsx:3629
 msgid "Send"
 msgstr "보내기"
 
@@ -2107,22 +2124,22 @@ msgstr "서버 이름"
 msgid "Server URL"
 msgstr "서버 URL"
 
-#: src/pages/Shell.tsx:2089
+#: src/pages/Shell.tsx:2135
 msgid "Set up voice to call"
 msgstr "통화하려면 음성을 먼저 설정하세요"
 
-#: src/pages/AccountSettingsOverlay.tsx:76
-#: src/pages/Shell.tsx:1954
-#: src/pages/Shell.tsx:1964
-#: src/pages/Shell.tsx:2224
+#: src/pages/AccountSettingsOverlay.tsx:79
+#: src/pages/Shell.tsx:2000
+#: src/pages/Shell.tsx:2010
+#: src/pages/Shell.tsx:2270
 msgid "Settings"
 msgstr "설정"
 
-#: src/pages/Shell.tsx:3526
+#: src/pages/Shell.tsx:3647
 msgid "Settings: General"
 msgstr "설정: 일반"
 
-#: src/pages/Shell.tsx:3528
+#: src/pages/Shell.tsx:3649
 msgid "Settings: Usage"
 msgstr "설정: 사용량"
 
@@ -2132,15 +2149,15 @@ msgid "Setup help"
 msgstr "설정 도움말"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4425
+#: src/pages/Shell.tsx:4546
 msgid "Shared"
 msgstr "함께 사용"
 
-#: src/pages/Shell.tsx:2235
+#: src/pages/Shell.tsx:2332
 msgid "Show computer"
 msgstr "컴퓨터 보기"
 
-#: src/pages/Shell.tsx:2235
+#: src/pages/Shell.tsx:2332
 msgid "Show settings"
 msgstr "설정 보기"
 
@@ -2164,11 +2181,11 @@ msgid "Sign up"
 msgstr "가입하기"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3339
+#: src/pages/Shell.tsx:3460
 msgid "Skill {0}"
 msgstr "작업 기술 {0}"
 
-#: src/pages/Shell.tsx:3629
+#: src/pages/Shell.tsx:3750
 msgid "Skip"
 msgstr "건너뛰기"
 
@@ -2181,7 +2198,7 @@ msgid "Skip or deploy key"
 msgstr "건너뛰거나 배포 키"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1280
+#: src/pages/Shell.tsx:1293
 msgid "Skipped {0}"
 msgstr "{0} 건너뜀"
 
@@ -2189,8 +2206,8 @@ msgstr "{0} 건너뜀"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space: 끼어들기 · Esc: 통화 종료"
 
-#: src/pages/Shell.tsx:3769
-#: src/pages/Shell.tsx:4022
+#: src/pages/Shell.tsx:3890
+#: src/pages/Shell.tsx:4143
 msgid "Speak"
 msgstr "읽기"
 
@@ -2202,8 +2219,8 @@ msgstr "음성 출력·받아쓰기"
 msgid "Speak only"
 msgstr "음성 출력만"
 
-#: src/pages/Shell.tsx:3765
-#: src/pages/Shell.tsx:4018
+#: src/pages/Shell.tsx:3886
+#: src/pages/Shell.tsx:4139
 msgid "Speak this reply"
 msgstr "이 답변 읽기"
 
@@ -2229,20 +2246,20 @@ msgstr "시작하는 중…"
 msgid "Steps"
 msgstr "실행 단계"
 
-#: src/pages/Shell.tsx:2858
-#: src/pages/Shell.tsx:2862
-#: src/pages/Shell.tsx:3499
-#: src/pages/Shell.tsx:3769
-#: src/pages/Shell.tsx:4022
+#: src/pages/Shell.tsx:2979
+#: src/pages/Shell.tsx:2983
+#: src/pages/Shell.tsx:3620
+#: src/pages/Shell.tsx:3890
+#: src/pages/Shell.tsx:4143
 msgid "Stop"
 msgstr "중지"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3512
 msgid "Stop dictation"
 msgstr "음성 입력 중지"
 
-#: src/pages/Shell.tsx:3765
-#: src/pages/Shell.tsx:4018
+#: src/pages/Shell.tsx:3886
+#: src/pages/Shell.tsx:4139
 msgid "Stop speaking"
 msgstr "읽기 중지"
 
@@ -2251,8 +2268,8 @@ msgstr "읽기 중지"
 msgid "Stop teaching"
 msgstr "가르치기 종료"
 
-#: src/pages/Shell.tsx:2314
-#: src/pages/Shell.tsx:2878
+#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2999
 msgid "Stop the bot first"
 msgstr "먼저 Bot을 중지하세요"
 
@@ -2260,7 +2277,7 @@ msgstr "먼저 Bot을 중지하세요"
 msgid "Stored encrypted"
 msgstr "암호화해 저장"
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3997
 msgid "subagent"
 msgstr "보조 에이전트"
 
@@ -2273,8 +2290,8 @@ msgstr "확인"
 msgid "Switching…"
 msgstr "전환 중…"
 
-#: src/pages/Shell.tsx:2317
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2438
+#: src/pages/Shell.tsx:3004
 msgid "Take control"
 msgstr "직접 조작"
 
@@ -2282,7 +2299,7 @@ msgstr "직접 조작"
 msgid "Teach a task"
 msgstr "작업 가르치기"
 
-#: src/pages/Shell.tsx:2151
+#: src/pages/Shell.tsx:2197
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼저 가르치기를 종료하세요."
 
@@ -2290,11 +2307,11 @@ msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼�
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "작업을 가르치려면 화면이 있는 샌드박스 컴퓨터가 필요합니다. 내 컴퓨터에서 실행되는 Bot은 터미널 작업은 가능하지만 화면 녹화는 할 수 없습니다."
 
-#: src/pages/Shell.tsx:4113
+#: src/pages/Shell.tsx:4234
 msgid "Team"
 msgstr "팀 공용"
 
-#: src/pages/Shell.tsx:4947
+#: src/pages/Shell.tsx:5068
 msgid "Team Computer"
 msgstr "팀 컴퓨터"
 
@@ -2307,20 +2324,20 @@ msgstr "시험 실행"
 msgid "The selected memory provider is not available in this build."
 msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4402
+#: src/pages/Shell.tsx:4523
 msgid "Thinking"
 msgstr "생각 깊이"
 
-#: src/pages/Shell.tsx:2261
+#: src/pages/Shell.tsx:2378
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "이 Bot은 별도 Linux 화면이 아니라 현재 컴퓨터에서 실행됩니다. 터미널과 파일 작업은 홈 폴더를 사용합니다."
 
-#: src/pages/Shell.tsx:2907
+#: src/pages/Shell.tsx:3028
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "이 Bot은 현재 컴퓨터에서 실행되며 별도 Linux 화면은 없습니다. 터미널을 사용하도록 요청할 수 있고 홈 폴더 아래에서 작업합니다."
 
-#: src/pages/Shell.tsx:4797
-#: src/pages/Shell.tsx:4874
+#: src/pages/Shell.tsx:4918
+#: src/pages/Shell.tsx:4995
 msgid "This cannot be undone."
 msgstr "이 작업은 되돌릴 수 없습니다."
 
@@ -2344,7 +2361,7 @@ msgstr "이 Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "이 Mac에서는 홈 폴더의 파일을 포함해 내 계정 권한으로 터미널 명령을 실행합니다. 여러 사람이 쓰거나 공개된 서버에서는 사용하지 마세요."
 
-#: src/pages/Shell.tsx:4682
+#: src/pages/Shell.tsx:4803
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지합니다. Bot, 컴퓨터, 기억, 자동 실행은 그대로 유지됩니다."
 
@@ -2352,7 +2369,7 @@ msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지�
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "이 서비스는 여기에서 API 키를 입력할 수 없습니다. 서버에 이미 인증 정보가 있다면 건너뛰세요."
 
-#: src/pages/Shell.tsx:5214
+#: src/pages/Shell.tsx:5335
 msgid "This server cannot be assigned without a bot."
 msgstr "연결할 Bot이 없어 이 서버를 배정할 수 없습니다."
 
@@ -2364,7 +2381,7 @@ msgstr "이 서버는 브라우저 인증을 요청하지 않았습니다."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "이 서버는 이미 연결되어 있습니다. 다시 인증하려면 먼저 연결을 해제하세요."
 
-#: src/pages/Shell.tsx:5253
+#: src/pages/Shell.tsx:5374
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "이 서버는 브라우저 로그인이 필요합니다. 인증을 누르면 새 창이 열리고, 완료 후 Bot이 도구를 사용할 수 있습니다."
 
@@ -2377,8 +2394,8 @@ msgid "Time of day"
 msgstr "실행 시각"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4180
-#: src/pages/Shell.tsx:4343
+#: src/pages/Shell.tsx:4301
+#: src/pages/Shell.tsx:4464
 msgid "Title"
 msgstr "역할"
 
@@ -2403,12 +2420,12 @@ msgid "Unpin"
 msgstr "고정 해제"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1344
+#: src/pages/Shell.tsx:1357
 msgid "Unsupported file type: {0}"
 msgstr "지원하지 않는 파일 형식: {0}"
 
-#: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2015
+#: src/pages/AccountSettingsOverlay.tsx:117
+#: src/pages/Shell.tsx:2061
 msgid "Usage"
 msgstr "사용량"
 
@@ -2433,8 +2450,22 @@ msgstr "확인 후 추가"
 msgid "Verifying…"
 msgstr "확인 중…"
 
-#: src/pages/Shell.tsx:2003
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2294
+msgid "View another computer"
+msgstr "다른 컴퓨터 보기"
+
+#: src/pages/Shell.tsx:2298
+msgid "View…"
+msgstr "보기…"
+
+#. placeholder {0}: peekTarget?.name ?? active.name
+#: src/pages/Shell.tsx:2413
+msgid "Viewing {0} (read only)"
+msgstr "{0} 보는 중 (읽기 전용)"
+
+#: src/pages/Shell.tsx:2049
+#: src/pages/Shell.tsx:4576
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2447,7 +2478,7 @@ msgstr "음성"
 msgid "Waiting for sign-in…"
 msgstr "로그인 완료를 기다리는 중…"
 
-#: src/pages/Shell.tsx:5097
+#: src/pages/Shell.tsx:5218
 msgid "Waiting…"
 msgstr "기다리는 중…"
 
@@ -2456,7 +2487,7 @@ msgstr "기다리는 중…"
 msgid "Weekdays"
 msgstr "주중"
 
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4888
 msgid "What about its memories?"
 msgstr "이 Bot의 기억은 어떻게 할까요?"
 
@@ -2465,7 +2496,7 @@ msgid "What result will you demonstrate?"
 msgstr "어떤 작업을 직접 보여줄까요?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4195
+#: src/pages/Shell.tsx:4316
 msgid "What this bot is for"
 msgstr "이 Bot을 언제, 어떤 일에 사용할지 적어주세요"
 
@@ -2477,7 +2508,7 @@ msgstr "완료 후 전달할 결과"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "{botName}이 다른 Bot에게 메시지를 보내면 대화 대신 여기에 표시됩니다."
 
-#: src/pages/Shell.tsx:2504
+#: src/pages/Shell.tsx:2625
 msgid "When to run"
 msgstr "실행 시간"
 
@@ -2494,11 +2525,11 @@ msgstr "Bot을 어디에서 실행할까요?"
 msgid "Working…"
 msgstr "처리 중…"
 
-#: src/pages/Shell.tsx:4385
+#: src/pages/Shell.tsx:4506
 msgid "Workspace default"
 msgstr "작업공간 기본값"
 
-#: src/pages/Shell.tsx:1665
+#: src/pages/Shell.tsx:1711
 msgid "You"
 msgstr "나"
 
@@ -2510,8 +2541,8 @@ msgstr "자동으로 이동하지 않으면 이 탭을 닫아도 됩니다."
 msgid "You can close this window."
 msgstr "이 창을 닫아도 됩니다."
 
-#: src/pages/Shell.tsx:2294
-#: src/pages/Shell.tsx:2848
+#: src/pages/Shell.tsx:2415
+#: src/pages/Shell.tsx:2969
 msgid "You have control"
 msgstr "직접 조작 중"
 
@@ -2530,5 +2561,3 @@ msgstr "이름"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "언제든 실제 작업을 맡길 수 있는<0/>나만의 Agent 팀"
-
-

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2283,8 +2283,8 @@ export function ShellPage() {
                       <div className="relative">
                         <button
                           type="button"
-                          aria-label="View another agent's computer"
-                          title="View another agent's computer (read only)"
+                          aria-label="View another computer"
+                          title="View another computer"
                           onClick={() => setPeekMenuOpen((open) => !open)}
                           className="rounded-full border border-[#26262A] px-2.5 py-1 text-[11px] leading-none text-[#85858A] transition-colors hover:text-[#ECECEE]"
                         >
@@ -2403,7 +2403,7 @@ export function ShellPage() {
                 <div className="mt-3 flex items-center justify-between gap-3">
                   <span className="min-w-0 text-[13.5px] text-[#85858A]">
                     {peek
-                      ? `Viewing ${computerLabel(peek.mode, peekTarget?.name ?? active.name)} — view only`
+                      ? `Viewing ${peekTarget?.name ?? active.name} (read only)`
                       : hasControl
                         ? t`You have control`
                         : computerError

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -6,6 +6,7 @@ import type {
   Bot,
   BotSection,
   ComputerMode,
+  ComputerPeek,
   ComputerReleaseReason,
   ComputerStatus,
   Connection,
@@ -331,6 +332,15 @@ export function ShellPage() {
   const [screenUrl, setScreenUrl] = useState<string | null>(null);
   const [computerOpen, setComputerOpen] = useState(false);
   const [computerError, setComputerError] = useState<string | null>(null);
+  // Read-only look at any OTHER bot's currently assigned computer —
+  // reassigning this bot's own computer happens in Settings instead.
+  const [peek, setPeek] = useState<ComputerPeek | null>(null);
+  const [peekTarget, setPeekTarget] = useState<{ id: string; name: string; color: string } | null>(
+    null,
+  );
+  const [peekLoading, setPeekLoading] = useState(false);
+  const [peekMenuOpen, setPeekMenuOpen] = useState(false);
+  const peekRequest = useRef(0);
   const [usage, setUsage] = useState<{
     inputTokens: number;
     outputTokens: number;
@@ -763,6 +773,9 @@ export function ShellPage() {
     if (!pendingJump) {
       pinnedAroundRef.current = null;
     }
+    setPeek(null);
+    setPeekTarget(null);
+    setPeekMenuOpen(false);
     screenRequest.current += 1;
     const cached = computerCacheRef.current.get(active.id);
     if (cached) {
@@ -1658,6 +1671,32 @@ export function ShellPage() {
     await refreshThread(active.id);
   }
 
+  // Read-only: shows another bot's live screen without touching which
+  // computer this bot is actually assigned to, or that bot's own state.
+  async function peekBot(bot: { id: string; name: string; color: string }) {
+    setPeekMenuOpen(false);
+    const id = ++peekRequest.current;
+    setPeekTarget(bot);
+    setPeekLoading(true);
+    try {
+      const result = await rpc.computer.peek({ targetBotId: bot.id });
+      if (id !== peekRequest.current) return;
+      setPeek(result);
+    } catch {
+      if (id !== peekRequest.current) return;
+      setPeek({ mode: "team", exists: false, state: null, url: null });
+    } finally {
+      if (id === peekRequest.current) setPeekLoading(false);
+    }
+  }
+
+  function clearPeek() {
+    peekRequest.current += 1;
+    setPeek(null);
+    setPeekTarget(null);
+    setPeekLoading(false);
+  }
+
   const embeddedScreenUrl = embeddableScreenUrl(screenUrl);
   const hasControl = userHoldsComputerControl(computer, active?.id);
   const takeoverBlocked = computerTakeoverBlocked(computer, snapshot?.run?.status);
@@ -2228,7 +2267,58 @@ export function ShellPage() {
                     <Trans>Group</Trans>
                   )}
                 </span>
-                <div className="flex gap-3.5">
+                <div className="flex items-center gap-3.5">
+                  {active && panel === "computer" ? (
+                    peekTarget ? (
+                      <button
+                        type="button"
+                        aria-label="Back to your computer"
+                        title="Back to your computer"
+                        onClick={clearPeek}
+                        className="max-w-[120px] truncate rounded-full border border-[#26262A] px-2.5 py-1 text-[11px] leading-none text-[#85858A] transition-colors hover:text-[#ECECEE]"
+                      >
+                        {peekLoading ? "…" : peekTarget.name}
+                      </button>
+                    ) : (
+                      <div className="relative">
+                        <button
+                          type="button"
+                          aria-label="View another agent's computer"
+                          title="View another agent's computer (read only)"
+                          onClick={() => setPeekMenuOpen((open) => !open)}
+                          className="rounded-full border border-[#26262A] px-2.5 py-1 text-[11px] leading-none text-[#85858A] transition-colors hover:text-[#ECECEE]"
+                        >
+                          View…
+                        </button>
+                        {peekMenuOpen ? (
+                          <div className="app-no-drag absolute end-0 top-full z-20 mt-2 max-h-[240px] min-w-[180px] overflow-y-auto rounded-xl border border-[#26262A] bg-[#141416] py-1 shadow-lg">
+                            {bots.filter((bot) => !bot.archivedAt && bot.id !== active.id)
+                              .length === 0 ? (
+                              <div className="px-3.5 py-2 text-[13px] text-[#6C6C70]">
+                                No other agents yet
+                              </div>
+                            ) : (
+                              bots
+                                .filter((bot) => !bot.archivedAt && bot.id !== active.id)
+                                .map((bot) => (
+                                  <button
+                                    key={bot.id}
+                                    type="button"
+                                    onClick={() =>
+                                      void peekBot({ id: bot.id, name: bot.name, color: bot.color })
+                                    }
+                                    className="flex w-full items-center gap-2 px-3.5 py-2 text-start text-[14px] text-[#ECECEE] hover:bg-[#1F1F22]"
+                                  >
+                                    <BotAvatar color={bot.color} size={18} />
+                                    <span className="min-w-0 flex-1 truncate">{bot.name}</span>
+                                  </button>
+                                ))
+                            )}
+                          </div>
+                        ) : null}
+                      </div>
+                    )
+                  ) : null}
                   {active ? (
                     <button
                       type="button"
@@ -2252,7 +2342,27 @@ export function ShellPage() {
             {panel === "computer" && active ? (
               <div>
                 <div className="relative aspect-[16/10] overflow-hidden rounded-[14px] bg-[#0E0E10]">
-                  {computerOpen ? (
+                  {peek ? (
+                    embeddableScreenUrl(peek.url) ? (
+                      <iframe
+                        title="Other computer preview (view only)"
+                        src={embeddableScreenUrl(peek.url) ?? undefined}
+                        sandbox={screenIframeSandbox(peek.url)}
+                        className="h-full w-full border-0 bg-black"
+                        style={{ pointerEvents: "none" }}
+                      />
+                    ) : (
+                      <div className="grid h-full place-items-center text-sm text-[#6C6C70]">
+                        {peek.exists
+                          ? computerPlaceholder(
+                              peek.state ?? undefined,
+                              false,
+                              computerLabel(peek.mode, peekTarget?.name ?? active.name),
+                            )
+                          : "Never used yet"}
+                      </div>
+                    )
+                  ) : computerOpen ? (
                     <div className="grid h-full place-items-center text-sm text-[#6C6C70]">
                       <Trans>Open in full window</Trans>
                     </div>
@@ -2281,26 +2391,30 @@ export function ShellPage() {
                       )}
                     </div>
                   )}
-                  <button
-                    type="button"
-                    className="absolute inset-0 cursor-pointer"
-                    aria-label={t`Open computer`}
-                    onClick={() => void openComputer()}
-                  />
+{peek ? null : (
+                    <button
+                      type="button"
+                      className="absolute inset-0 cursor-pointer"
+                      aria-label={t`Open computer`}
+                      onClick={() => void openComputer()}
+                    />
+                  )}
                 </div>
                 <div className="mt-3 flex items-center justify-between gap-3">
                   <span className="min-w-0 text-[13.5px] text-[#85858A]">
-                    {hasControl
-                      ? t`You have control`
-                      : computerError
-                        ? computerError
-                        : computer?.busyBotName
-                          ? t`${computer.busyBotName} is using it`
-                          : computer?.state === "suspended"
-                            ? t`Asleep`
-                            : computerLabel(computer?.mode, active.name)}
+                    {peek
+                      ? `Viewing ${computerLabel(peek.mode, peekTarget?.name ?? active.name)} — view only`
+                      : hasControl
+                        ? t`You have control`
+                        : computerError
+                          ? computerError
+                          : computer?.busyBotName
+                            ? t`${computer.busyBotName} is using it`
+                            : computer?.state === "suspended"
+                              ? t`Asleep`
+                              : computerLabel(computer?.mode, active.name)}
                   </span>
-                  {hasControl ? (
+                  {peek ? null : hasControl ? (
                     <ComputerReleaseActions
                       takeoverRequested={computer?.takeoverRequested ?? false}
                       onRelease={releaseComputer}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -773,8 +773,10 @@ export function ShellPage() {
     if (!pendingJump) {
       pinnedAroundRef.current = null;
     }
+    peekRequest.current += 1;
     setPeek(null);
     setPeekTarget(null);
+    setPeekLoading(false);
     setPeekMenuOpen(false);
     screenRequest.current += 1;
     const cached = computerCacheRef.current.get(active.id);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1641,12 +1641,19 @@ export function ShellPage() {
   }, [computerOpen]);
 
   useEffect(() => {
-    if ((panel !== "computer" && !computerOpen) || !active || computer?.state !== "running") return;
-    const ping = () => void rpc.computer.heartbeat({ botId: active.id }).catch(() => undefined);
+    if (panel !== "computer" && !computerOpen) return;
+    // While peeking, keep the *target* computer awake — heartbeats otherwise only
+    // touch the active bot, so a long-lived peek of an idle dedicated/team machine
+    // would still hit the sleep job and drop the preview.
+    const heartbeatBotId = peekTarget?.id ?? active?.id;
+    if (!heartbeatBotId) return;
+    if (!peekTarget && computer?.state !== "running") return;
+    const ping = () =>
+      void rpc.computer.heartbeat({ botId: heartbeatBotId }).catch(() => undefined);
     ping();
     const timer = window.setInterval(ping, 60_000);
     return () => window.clearInterval(timer);
-  }, [panel, computerOpen, active?.id, computer?.state]);
+  }, [panel, computerOpen, active?.id, computer?.state, peekTarget?.id]);
 
   async function openComputer() {
     if (!active) return;

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2279,8 +2279,8 @@ export function ShellPage() {
                     peekTarget ? (
                       <button
                         type="button"
-                        aria-label="Back to your computer"
-                        title="Back to your computer"
+                        aria-label={t`Back to your computer`}
+                        title={t`Back to your computer`}
                         onClick={clearPeek}
                         className="max-w-[120px] truncate rounded-full border border-[#26262A] px-2.5 py-1 text-[11px] leading-none text-[#85858A] transition-colors hover:text-[#ECECEE]"
                       >
@@ -2290,19 +2290,19 @@ export function ShellPage() {
                       <div className="relative">
                         <button
                           type="button"
-                          aria-label="View another computer"
-                          title="View another computer"
+                          aria-label={t`View another computer`}
+                          title={t`View another computer`}
                           onClick={() => setPeekMenuOpen((open) => !open)}
                           className="rounded-full border border-[#26262A] px-2.5 py-1 text-[11px] leading-none text-[#85858A] transition-colors hover:text-[#ECECEE]"
                         >
-                          View…
+                          <Trans>View…</Trans>
                         </button>
                         {peekMenuOpen ? (
                           <div className="app-no-drag absolute end-0 top-full z-20 mt-2 max-h-[240px] min-w-[180px] overflow-y-auto rounded-xl border border-[#26262A] bg-[#141416] py-1 shadow-lg">
                             {bots.filter((bot) => !bot.archivedAt && bot.id !== active.id)
                               .length === 0 ? (
                               <div className="px-3.5 py-2 text-[13px] text-[#6C6C70]">
-                                No other agents yet
+                                <Trans>No other agents yet</Trans>
                               </div>
                             ) : (
                               bots
@@ -2352,7 +2352,7 @@ export function ShellPage() {
                   {peek ? (
                     embeddableScreenUrl(peek.url) ? (
                       <iframe
-                        title="Other computer preview (view only)"
+                        title={t`Other computer preview (view only)`}
                         src={embeddableScreenUrl(peek.url) ?? undefined}
                         sandbox={screenIframeSandbox(peek.url)}
                         className="h-full w-full border-0 bg-black"
@@ -2366,7 +2366,7 @@ export function ShellPage() {
                               false,
                               computerLabel(peek.mode, peekTarget?.name ?? active.name),
                             )
-                          : "Never used yet"}
+                          : t`Never used yet`}
                       </div>
                     )
                   ) : computerOpen ? (
@@ -2398,7 +2398,7 @@ export function ShellPage() {
                       )}
                     </div>
                   )}
-{peek ? null : (
+                  {peek ? null : (
                     <button
                       type="button"
                       className="absolute inset-0 cursor-pointer"
@@ -2410,7 +2410,7 @@ export function ShellPage() {
                 <div className="mt-3 flex items-center justify-between gap-3">
                   <span className="min-w-0 text-[13.5px] text-[#85858A]">
                     {peek
-                      ? `Viewing ${peekTarget?.name ?? active.name} (read only)`
+                      ? t`Viewing ${peekTarget?.name ?? active.name} (read only)`
                       : hasControl
                         ? t`You have control`
                         : computerError

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -515,6 +515,15 @@ export const ComputerStatusSchema = z.object({
 });
 export type ComputerStatus = z.infer<typeof ComputerStatusSchema>;
 
+export const ComputerPeekSchema = z.object({
+  mode: ComputerModeSchema,
+  /** False when that computer has never been provisioned for this bot/workspace. */
+  exists: z.boolean(),
+  state: z.enum(["stopped", "booting", "running", "suspended", "error"]).nullable(),
+  url: z.string().nullable(),
+});
+export type ComputerPeek = z.infer<typeof ComputerPeekSchema>;
+
 export const ComputerReleaseReasonSchema = z.enum(["done", "skipped"]);
 export type ComputerReleaseReason = z.infer<typeof ComputerReleaseReasonSchema>;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -13,6 +13,7 @@ import {
   BotSectionSchema,
   CapabilityInstallSchema,
   ComputerModeSchema,
+  ComputerPeekSchema,
   ComputerReleaseReasonSchema,
   ComputerStatusSchema,
   ConnectionCatalogItemSchema,
@@ -267,6 +268,9 @@ export const appContract = {
       .input(z.object({ botId: Id, path: z.string() }))
       .output(z.object({ path: z.string(), content: z.string() })),
     screenUrl: oc.input(botId).output(z.object({ url: z.string().nullable() })),
+    /** Read-only peek at ANY other bot's currently assigned computer — for
+        a view-only picker, never reassigns anything. */
+    peek: oc.input(z.object({ targetBotId: Id })).output(ComputerPeekSchema),
     heartbeat: oc.input(botId).output(z.object({ ok: z.literal(true) })),
   },
   memory: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports Deepanshu’s computer peek work from #222 onto current `main` (Lingui-aware). Supersedes #222.

The computer pane only ever showed the bot you had open. With multiple bots working in parallel, there was no way to check on another one without switching to its own thread.

- New **View…** picker in the computer pane header listing every other bot
- Picking one shows that bot’s currently assigned computer live (Team or dedicated) — strictly view-only (`Viewing {name} (read only)`, Back pill, no Take control)
- `computer.peek` RPC: `getBot(actor, targetBotId)` only (same user+workspace). Never boots/provisions/reassigns; never attaches the execution screen lease. Dedicated stays dedicated; Team peek shows the one shared desktop.

## Attribution

Based on [deepanshu1422/rakazo `feat/agent-computer-picker` @ 85f0977](https://github.com/deepanshu1422/rakazo/commit/85f097757c6b06d7363d34f080929546241e3d6a) / PR #222 by @deepanshu1422.

## Screenshots

From `apps/web/e2e/computer-peek.spec.ts` (`captureScreenshot` frames):

**computer-peek-picker** — View… menu listing the other bot

![computer-peek-picker](https://cursor.com/artifacts/c/art-33681bbb-8af7-40e7-a742-6688f78e9e18)

**computer-peek-view** — read-only peek (`Viewing Writer (read only)`, Back pill, no Take control)

![computer-peek-view](https://cursor.com/artifacts/c/art-5ebca2bd-e7df-4506-b369-7ad885965251)

## Test plan

- [x] `pnpm --filter @rakazo/api check`
- [x] `pnpm --filter @rakazo/web check`
- [x] `vitest` `computer.peek` router tests
- [x] `pnpm test:e2e -- --spec=computer-peek.spec.ts` (1 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94d06944-6930-458f-bfba-2f079e9d000d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94d06944-6930-458f-bfba-2f079e9d000d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added read-only previews for viewing another bot’s computer.
  - Added bot selection and clear read-only status indicators in the computer panel.
  - Displays appropriate unavailable states when a computer cannot be viewed.
  - Prevents interactive controls while viewing a preview.

- **Localization**
  - Added English, German, and Korean translations for computer preview and read-only viewing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->