### PR TITLE
fix(web): keep message hover Reply+Copy above bubble text

### DIFF
--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -48,7 +48,8 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   const clip = {
     x: Math.max(0, Math.min(toolbarBox.x, bubbleBox.x) - pad),
     y: Math.max(0, toolbarBox.y - pad),
-    width: Math.max(toolbarBox.x + toolbarBox.width, bubbleBox.x + bubbleBox.width) -
+    width:
+      Math.max(toolbarBox.x + toolbarBox.width, bubbleBox.x + bubbleBox.width) -
       Math.min(toolbarBox.x, bubbleBox.x) +
       pad * 2,
     height: bubbleBox.y + bubbleBox.height - toolbarBox.y + pad * 2,

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -23,6 +23,17 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   await expect(toolbar).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Reply" })).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Copy" })).toBeVisible();
+
+  // Pill must float above the bubble text, not cover the first line.
+  const bubble = parentRow.locator("div").filter({ hasText: parentText }).last();
+  await expect
+    .poll(async () => {
+      const toolbarBox = await toolbar.boundingBox();
+      const bubbleBox = await bubble.boundingBox();
+      if (!toolbarBox || !bubbleBox) return null;
+      return toolbarBox.y + toolbarBox.height <= bubbleBox.y + 1;
+    })
+    .toBe(true);
   await captureScreenshot(page, testInfo, "message-hover-toolbar");
 
   await toolbar.getByRole("button", { name: "Copy" }).click();

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -34,7 +34,33 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
       return toolbarBox.y + toolbarBox.height <= bubbleBox.y + 1;
     })
     .toBe(true);
-  await captureScreenshot(page, testInfo, "message-hover-toolbar");
+
+  // Keep the pill visible for the artifact (full-page shots can drop :hover).
+  await toolbar.evaluate((el) => {
+    const node = el as HTMLElement;
+    node.style.opacity = "1";
+    node.style.pointerEvents = "auto";
+  });
+  const toolbarBox = await toolbar.boundingBox();
+  const bubbleBox = await bubble.boundingBox();
+  if (!toolbarBox || !bubbleBox) throw new Error("missing hover toolbar geometry");
+  const pad = 16;
+  const clip = {
+    x: Math.max(0, Math.min(toolbarBox.x, bubbleBox.x) - pad),
+    y: Math.max(0, toolbarBox.y - pad),
+    width: Math.max(toolbarBox.x + toolbarBox.width, bubbleBox.x + bubbleBox.width) -
+      Math.min(toolbarBox.x, bubbleBox.x) +
+      pad * 2,
+    height: bubbleBox.y + bubbleBox.height - toolbarBox.y + pad * 2,
+  };
+  const hoverPath = testInfo.outputPath("message-hover-toolbar.png");
+  await page.screenshot({
+    animations: "disabled",
+    caret: "hide",
+    clip,
+    path: hoverPath,
+  });
+  await testInfo.attach("message-hover-toolbar", { contentType: "image/png", path: hoverPath });
 
   await toolbar.getByRole("button", { name: "Copy" }).click();
   await expect

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3005,7 +3005,7 @@ const Transcript = memo(function Transcript({
     <div
       ref={scrollRef}
       data-testid="transcript"
-      className="rk-scroll flex flex-1 flex-col gap-[13px] overflow-y-auto px-4 py-5 md:px-7 md:py-6"
+      className="rk-scroll flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
     >
       {olderCursor != null ? (
         <button
@@ -3021,7 +3021,7 @@ const Transcript = memo(function Transcript({
         <div
           key={message.id}
           data-message-id={message.id}
-          className="group/message relative mt-1 pt-1 hover:z-20"
+          className="group/message relative pt-2 hover:z-20"
         >
           <MessageHoverActions message={message} onReply={onReply} />
           <MessageView
@@ -3626,7 +3626,7 @@ function MessageHoverActions({
   return (
     <div
       data-testid="message-hover-actions"
-      className="pointer-events-none absolute end-0 bottom-full mb-1 z-10 flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 opacity-0 shadow-[0_1px_4px_rgba(0,0,0,0.45)] transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
+      className="pointer-events-none absolute end-0 bottom-full mb-1.5 z-10 flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 opacity-0 shadow-[0_1px_4px_rgba(0,0,0,0.45)] transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
     >
       <button
         type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3018,7 +3018,11 @@ const Transcript = memo(function Transcript({
         </button>
       ) : null}
       {messages.map((message) => (
-        <div key={message.id} data-message-id={message.id} className="group/message relative">
+        <div
+          key={message.id}
+          data-message-id={message.id}
+          className="group/message relative mt-1 pt-1 hover:z-20"
+        >
           <MessageHoverActions message={message} onReply={onReply} />
           <MessageView
             artifactTarget={artifactTarget}
@@ -3622,7 +3626,7 @@ function MessageHoverActions({
   return (
     <div
       data-testid="message-hover-actions"
-      className="pointer-events-none absolute end-0 -top-1 z-10 flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 opacity-0 shadow-[0_1px_4px_rgba(0,0,0,0.45)] transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
+      className="pointer-events-none absolute end-0 bottom-full mb-1 z-10 flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 opacity-0 shadow-[0_1px_4px_rgba(0,0,0,0.45)] transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
     >
       <button
         type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3005,7 +3005,7 @@ const Transcript = memo(function Transcript({
     <div
       ref={scrollRef}
       data-testid="transcript"
-      className="rk-scroll flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
+      className="rk-scroll flex flex-1 flex-col gap-2 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
     >
       {olderCursor != null ? (
         <button
@@ -3021,7 +3021,7 @@ const Transcript = memo(function Transcript({
         <div
           key={message.id}
           data-message-id={message.id}
-          className="group/message relative pt-2 hover:z-20"
+          className="group/message relative pt-9 hover:z-20"
         >
           <MessageHoverActions message={message} onReply={onReply} />
           <MessageView
@@ -3626,7 +3626,7 @@ function MessageHoverActions({
   return (
     <div
       data-testid="message-hover-actions"
-      className="pointer-events-none absolute end-0 bottom-full mb-1.5 z-10 flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 opacity-0 shadow-[0_1px_4px_rgba(0,0,0,0.45)] transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
+      className="pointer-events-none absolute end-0 top-0 z-10 flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 opacity-0 shadow-[0_1px_4px_rgba(0,0,0,0.45)] transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
     >
       <button
         type="button"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #258: the dark Reply+Copy hover pill was absolutely positioned with `-top-1`, so it sat on top of the first line of the bubble (especially on right-aligned user messages).

## Changes
- Reserve `pt-9` on each message row and place `MessageHoverActions` at `top-0 end-0` so the pill floats fully above the bubble **inside** the row (avoids transcript-edge clipping and covering the previous message)
- Raise z-index on hover; keep hover-only Reply/Copy; no toolbar on `progress:` bubbles
- Assert in Playwright that the toolbar bottom is above the bubble top, then capture a clipped hover frame

## Out of scope
Reply-parent preview fallback when the parent is off the loaded page (CodeRabbit note) — needs stored preview text or a fetch; not blocking this fix.

## Demo
E2E hover frame (pill above text, not covering it):

![Message hover Reply+Copy pill floating above bubble text](https://cursor.com/artifacts/c/art-9a131ad7-dce8-4599-bea1-8f8fb4fb9b9b)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30c919a5-69c4-45a1-a82f-0bff57c2d0e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30c919a5-69c4-45a1-a82f-0bff57c2d0e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

