### PR TITLE
fix(web): keep reply parent preview across pagination

### DIFF
--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -50,3 +50,67 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   await parentPreview.click();
   await expect(parentRow).toBeInViewport();
 });
+
+test("reply preview jumps to parent outside the loaded page", async ({ page }) => {
+  const stamp = Date.now();
+  await signup(page, `hover-page-${stamp}@rakazo.test`, "password12", "Hover Page");
+  await completeOnboarding(page);
+
+  const parentText = `page-parent-${stamp}`;
+  const replyText = `page-reply-${stamp}`;
+  const composer = page.getByRole("textbox", { name: /^Message/ });
+  await expect(composer).toBeVisible();
+  await composer.fill(parentText);
+  await composer.press("Enter");
+
+  const transcript = page.getByTestId("transcript");
+  const parentRow = transcript.locator(`[data-message-id]`).filter({ hasText: parentText }).first();
+  await expect(parentRow).toBeVisible({ timeout: 20_000 });
+  const parentId = await parentRow.getAttribute("data-message-id");
+  expect(parentId).toBeTruthy();
+
+  await parentRow.hover();
+  await parentRow.getByRole("button", { name: "Reply" }).click();
+  await composer.fill(replyText);
+  await composer.press("Enter");
+
+  const replyRow = transcript.locator(`[data-message-id]`).filter({ hasText: replyText }).first();
+  await expect(replyRow).toBeVisible({ timeout: 20_000 });
+  await expect(replyRow.getByTestId("reply-parent-preview")).toContainText(parentText);
+
+  // Simulate a paginated snapshot where the parent is older than the loaded page.
+  await page.route("**/rpc/threads/get", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as {
+      json?: {
+        messages?: Array<{ id: string; replyToMessageId?: string }>;
+        olderCursor?: number | null;
+      };
+      error?: unknown;
+    };
+    if (body.json?.messages) {
+      body.json.messages = body.json.messages.filter((message) => message.id !== parentId);
+      body.json.olderCursor = body.json.olderCursor ?? 1;
+    }
+    await route.fulfill({
+      status: response.status(),
+      headers: response.headers(),
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("textbox", { name: /^Message/ })).toBeVisible({ timeout: 20_000 });
+  await expect(page.locator(`[data-message-id="${parentId}"]`)).toHaveCount(0);
+  const offlinePreview = page
+    .locator(`[data-message-id]`)
+    .filter({ hasText: replyText })
+    .getByTestId("reply-parent-preview");
+  await expect(offlinePreview).toBeVisible();
+  await expect(offlinePreview).toHaveText("Earlier message");
+
+  await page.unroute("**/rpc/threads/get");
+  await offlinePreview.click();
+  await expect(page.locator(`[data-message-id="${parentId}"]`)).toBeVisible({ timeout: 20_000 });
+  await expect(page.locator(`[data-message-id="${parentId}"]`)).toContainText(parentText);
+});

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -79,19 +79,40 @@ test("reply preview jumps to parent outside the loaded page", async ({ page }) =
   await expect(replyRow.getByTestId("reply-parent-preview")).toContainText(parentText);
 
   // Simulate a paginated snapshot where the parent is older than the loaded page.
-  await page.route("**/rpc/threads/get", async (route) => {
-    const response = await route.fetch();
-    const body = (await response.json()) as {
-      json?: {
-        messages?: Array<{ id: string; replyToMessageId?: string }>;
-        olderCursor?: number | null;
-      };
-      error?: unknown;
+  // Bootstrap and threads/get both hydrate the transcript on reload.
+  const stripParent = (body: {
+    json?: {
+      messages?: Array<{ id: string }>;
+      olderCursor?: number | null;
+      thread?: { messages?: Array<{ id: string }>; olderCursor?: number | null };
     };
+  }) => {
     if (body.json?.messages) {
       body.json.messages = body.json.messages.filter((message) => message.id !== parentId);
       body.json.olderCursor = body.json.olderCursor ?? 1;
     }
+    if (body.json?.thread?.messages) {
+      body.json.thread.messages = body.json.thread.messages.filter(
+        (message) => message.id !== parentId,
+      );
+      body.json.thread.olderCursor = body.json.thread.olderCursor ?? 1;
+    }
+  };
+
+  await page.route("**/rpc/bootstrap", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as Parameters<typeof stripParent>[0];
+    stripParent(body);
+    await route.fulfill({
+      status: response.status(),
+      headers: response.headers(),
+      body: JSON.stringify(body),
+    });
+  });
+  await page.route("**/rpc/threads/get", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as Parameters<typeof stripParent>[0];
+    stripParent(body);
     await route.fulfill({
       status: response.status(),
       headers: response.headers(),
@@ -109,6 +130,7 @@ test("reply preview jumps to parent outside the loaded page", async ({ page }) =
   await expect(offlinePreview).toBeVisible();
   await expect(offlinePreview).toHaveText("Earlier message");
 
+  await page.unroute("**/rpc/bootstrap");
   await page.unroute("**/rpc/threads/get");
   await offlinePreview.click();
   await expect(page.locator(`[data-message-id="${parentId}"]`)).toBeVisible({ timeout: 20_000 });

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5139
+#: src/pages/Shell.tsx:5151
 msgid "{0} connection"
 msgstr "{0}-Verbindung"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2306
+#: src/pages/Shell.tsx:2318
 msgid "{0} is using it"
 msgstr "{0} verwendet es"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# verbundener Bot} other {# verbundene Bot
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} hat noch keinem anderen Bot eine Nachricht gesendet."
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5028
 msgid "{botName}’s computer"
 msgstr "Computer von {botName}"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3327
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Zugriffstoken (optional)"
 msgid "Account"
 msgstr "Konto"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4542
 msgid "Account default"
 msgstr "Kontostandard"
 
@@ -216,7 +216,7 @@ msgstr "Wird hinzugefügt…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4433
+#: src/pages/Shell.tsx:4445
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -311,11 +311,11 @@ msgstr "Gilt beim Hinzufügen des Servers. Mit den Agent-Chips auf jeder Serverk
 msgid "Approval boundaries"
 msgstr "Bestätigungsgrenzen"
 
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5344
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5335
 msgid "Approve this server to let your agent use its tools."
 msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 
@@ -327,7 +327,7 @@ msgstr "Apps"
 msgid "Archive"
 msgstr "Archivieren"
 
-#: src/pages/Shell.tsx:3981
+#: src/pages/Shell.tsx:3993
 msgid "archived"
 msgstr "archiviert"
 
@@ -335,7 +335,7 @@ msgstr "archiviert"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: src/pages/Shell.tsx:3992
+#: src/pages/Shell.tsx:4004
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archiviert. Chat, Erinnerungen und Dateien bleiben erhalten."
 
@@ -374,7 +374,7 @@ msgstr "Vor Käufen nachfragen"
 msgid "Ask before sending external email"
 msgstr "Vor dem Senden externer E-Mails nachfragen"
 
-#: src/pages/Shell.tsx:2308
+#: src/pages/Shell.tsx:2320
 msgid "Asleep"
 msgstr "Im Ruhezustand"
 
@@ -389,11 +389,11 @@ msgstr "um {0}"
 msgid "at {timeSelect}"
 msgstr "um {timeSelect}"
 
-#: src/pages/Shell.tsx:3389
+#: src/pages/Shell.tsx:3398
 msgid "Attach file"
 msgstr "Datei anhängen"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3597
 msgid "Attachment"
 msgstr "Anhang"
 
@@ -406,12 +406,12 @@ msgstr "Autorisierungscode oder Callback-URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Autorisierung abgelaufen — erneute Verbindung erforderlich"
 
-#: src/pages/Shell.tsx:5124
+#: src/pages/Shell.tsx:5136
 msgid "Authorization timed out. Please try again."
 msgstr "Zeitüberschreitung bei der Autorisierung. Versuche es erneut."
 
-#: src/pages/Shell.tsx:5166
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5178
+#: src/pages/Shell.tsx:5344
 msgid "Authorize"
 msgstr "Autorisieren"
 
@@ -423,18 +423,18 @@ msgstr "Basis-URL"
 msgid "Bearer token"
 msgstr "Bearer-Token"
 
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:5020
 msgid "Booting live desktop…"
 msgstr "Live-Desktop wird gestartet…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2843
 msgid "Booting up {0}’s computer"
 msgstr "Computer von {0} wird gestartet"
 
-#: src/pages/Shell.tsx:3851
-#: src/pages/Shell.tsx:3852
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3864
+#: src/pages/Shell.tsx:3997
 msgid "bot"
 msgstr "Bot"
 
@@ -446,11 +446,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot-Nachrichten"
 
-#: src/pages/Shell.tsx:2923
+#: src/pages/Shell.tsx:2935
 msgid "Bot screen"
 msgstr "Bot-Bildschirm"
 
-#: src/pages/Shell.tsx:2276
+#: src/pages/Shell.tsx:2288
 msgid "Bot screen preview"
 msgstr "Bot-Bildschirmvorschau"
 
@@ -475,14 +475,14 @@ msgstr "Server nicht erreichbar."
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4692
-#: src/pages/Shell.tsx:4764
-#: src/pages/Shell.tsx:4879
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4704
+#: src/pages/Shell.tsx:4776
+#: src/pages/Shell.tsx:4891
+#: src/pages/Shell.tsx:4965
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:4241
 msgid "Cancel new bot"
 msgstr "Neuen Bot abbrechen"
 
@@ -490,7 +490,7 @@ msgstr "Neuen Bot abbrechen"
 msgid "Cancel new group"
 msgstr "Neue Gruppe abbrechen"
 
-#: src/pages/Shell.tsx:3265
+#: src/pages/Shell.tsx:3274
 msgid "Cancel reply"
 msgstr "Antwort abbrechen"
 
@@ -498,16 +498,16 @@ msgstr "Antwort abbrechen"
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/pages/Shell.tsx:5229
+#: src/pages/Shell.tsx:5241
 msgid "Chart failed to render: {error}"
 msgstr "Diagramm konnte nicht angezeigt werden: {error}"
 
-#: src/pages/Shell.tsx:3531
+#: src/pages/Shell.tsx:3540
 msgid "Chat Settings"
 msgstr "Chat-Einstellungen"
 
-#: src/pages/Shell.tsx:2542
-#: src/pages/Shell.tsx:2549
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2561
 msgid "Check in."
 msgstr "Melde dich."
 
@@ -519,21 +519,21 @@ msgstr "Wähle zunächst ein Modell aus."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Wähle das verbundene Modell aus, das Rakazo verwendet."
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4791
 msgid "Clear"
 msgstr "Leeren"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4745
+#: src/pages/Shell.tsx:4757
 msgid "Clear {0}’s conversation?"
 msgstr "Unterhaltung mit {0} leeren?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4585
+#: src/pages/Shell.tsx:4597
 msgid "Clear conversation"
 msgstr "Unterhaltung leeren"
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4791
 msgid "Clearing…"
 msgstr "Wird geleert…"
 
@@ -549,15 +549,15 @@ msgstr "Bot-Menü schließen"
 msgid "Close bot messages"
 msgstr "Bot-Nachrichten schließen"
 
-#: src/pages/Shell.tsx:5414
+#: src/pages/Shell.tsx:5426
 msgid "Close chart"
 msgstr "Diagramm schließen"
 
-#: src/pages/Shell.tsx:2897
+#: src/pages/Shell.tsx:2909
 msgid "Close computer"
 msgstr "Computer schließen"
 
-#: src/pages/Shell.tsx:5514
+#: src/pages/Shell.tsx:5526
 msgid "Close image preview"
 msgstr "Bildvorschau schließen"
 
@@ -581,7 +581,7 @@ msgstr "Modelleinstellungen schließen"
 msgid "Close navigation"
 msgstr "Navigation schließen"
 
-#: src/pages/Shell.tsx:2254
+#: src/pages/Shell.tsx:2266
 msgid "Close panel"
 msgstr "Panel schließen"
 
@@ -610,24 +610,24 @@ msgstr "Befehl"
 msgid "Complete"
 msgstr "Abschließen"
 
-#: src/pages/Shell.tsx:4139
-#: src/pages/Shell.tsx:4167
+#: src/pages/Shell.tsx:4151
+#: src/pages/Shell.tsx:4179
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5011
+#: src/pages/Shell.tsx:5023
 msgid "Computer failed to boot"
 msgstr "Computer konnte nicht gestartet werden"
 
-#: src/pages/Shell.tsx:2945
+#: src/pages/Shell.tsx:2957
 msgid "Computer is asleep"
 msgstr "Computer ist im Ruhezustand"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5022
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer schläft — übernimm die Kontrolle, um ihn zu wecken"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5024
 msgid "Computer is stopped"
 msgstr "Computer ist gestoppt"
 
@@ -665,7 +665,7 @@ msgstr "Verbinde Apps oder füge Treg-, MCP- und OpenAPI-Toolquellen hinzu."
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI oder Cartesia verbinden"
 
-#: src/pages/Shell.tsx:5312
+#: src/pages/Shell.tsx:5324
 msgid "Connect MCP server “{name}”"
 msgstr "MCP-Server „{name}“ verbinden"
 
@@ -689,12 +689,12 @@ msgstr "Treg verbinden"
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
 #: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5163
+#: src/pages/Shell.tsx:5175
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Verbunden"
 
-#: src/pages/Shell.tsx:5342
+#: src/pages/Shell.tsx:5354
 msgid "Connected — its tools are available from your next message."
 msgstr "Verbunden – die Tools sind ab deiner nächsten Nachricht verfügbar."
 
@@ -720,7 +720,7 @@ msgstr "Verbunden, {0} wird verwendet."
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
 #: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5344
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Verbindung wird hergestellt…"
@@ -739,7 +739,7 @@ msgstr "Weiter"
 msgid "Continue with email"
 msgstr "Mit E-Mail fortfahren"
 
-#: src/pages/Shell.tsx:3639
+#: src/pages/Shell.tsx:3648
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -751,11 +751,11 @@ msgstr "Hinzufügen fehlgeschlagen"
 msgid "Could not add MCP server"
 msgstr "MCP-Server konnte nicht hinzugefügt werden"
 
-#: src/pages/Shell.tsx:5299
+#: src/pages/Shell.tsx:5311
 msgid "Could not approve this server"
 msgstr "Server konnte nicht genehmigt werden"
 
-#: src/pages/Shell.tsx:5127
+#: src/pages/Shell.tsx:5139
 msgid "Could not authorize this app"
 msgstr "App konnte nicht autorisiert werden"
 
@@ -763,7 +763,7 @@ msgstr "App konnte nicht autorisiert werden"
 msgid "Could not change the default model"
 msgstr "Standardmodell konnte nicht geändert werden"
 
-#: src/pages/Shell.tsx:4773
+#: src/pages/Shell.tsx:4785
 msgid "Could not clear conversation"
 msgstr "Unterhaltung konnte nicht geleert werden"
 
@@ -792,7 +792,7 @@ msgstr "Stimmanbieter konnte nicht verbunden werden"
 msgid "Could not continue"
 msgstr "Fortfahren fehlgeschlagen"
 
-#: src/pages/Shell.tsx:4217
+#: src/pages/Shell.tsx:4229
 msgid "Could not create bot"
 msgstr "Bot konnte nicht erstellt werden"
 
@@ -800,7 +800,7 @@ msgstr "Bot konnte nicht erstellt werden"
 msgid "Could not create group"
 msgstr "Gruppe konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4676
 msgid "Could not create section"
 msgstr "Abschnitt konnte nicht erstellt werden"
 
@@ -808,7 +808,7 @@ msgstr "Abschnitt konnte nicht erstellt werden"
 msgid "Could not create your bot"
 msgstr "Dein Bot konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4888
+#: src/pages/Shell.tsx:4900
 msgid "Could not delete bot"
 msgstr "Bot konnte nicht gelöscht werden"
 
@@ -816,7 +816,7 @@ msgstr "Bot konnte nicht gelöscht werden"
 msgid "Could not delete MCP server"
 msgstr "MCP-Server konnte nicht gelöscht werden"
 
-#: src/pages/Shell.tsx:4962
+#: src/pages/Shell.tsx:4974
 msgid "Could not delete routine"
 msgstr "Routine konnte nicht gelöscht werden"
 
@@ -890,7 +890,7 @@ msgstr "Gruppe konnte nicht entfernt werden"
 msgid "Could not remove rule"
 msgstr "Regel konnte nicht entfernt werden"
 
-#: src/pages/Shell.tsx:5219
+#: src/pages/Shell.tsx:5231
 msgid "Could not render chart"
 msgstr "Diagramm konnte nicht angezeigt werden"
 
@@ -898,7 +898,7 @@ msgstr "Diagramm konnte nicht angezeigt werden"
 msgid "Could not revoke connection"
 msgstr "Verbindung konnte nicht widerrufen werden"
 
-#: src/pages/Shell.tsx:4570
+#: src/pages/Shell.tsx:4582
 msgid "Could not save"
 msgstr "Speichern fehlgeschlagen"
 
@@ -910,7 +910,7 @@ msgstr "Gruppe konnte nicht gespeichert werden"
 msgid "Could not save model"
 msgstr "Modell konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:2564
+#: src/pages/Shell.tsx:2576
 msgid "Could not save routine"
 msgstr "Routine konnte nicht gespeichert werden"
 
@@ -926,7 +926,7 @@ msgstr "Auswahl konnte nicht gespeichert werden"
 msgid "Could not save that voice"
 msgstr "Stimme konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:5039
+#: src/pages/Shell.tsx:5051
 msgid "Could not save this choice"
 msgstr "Diese Auswahl konnte nicht gespeichert werden"
 
@@ -959,13 +959,13 @@ msgid "Could not update the default memory scope"
 msgstr "Standardbereich für Erinnerungen konnte nicht aktualisiert werden"
 
 #: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4288
+#: src/pages/Shell.tsx:4711
 msgid "Create"
 msgstr "Erstellen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4673
+#: src/pages/Shell.tsx:4685
 msgid "Create a section and move {0} into it."
 msgstr "Erstelle einen Abschnitt und verschiebe {0} dorthin."
 
@@ -986,8 +986,8 @@ msgid "Create your Rakazo"
 msgstr "Dein Rakazo erstellen"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4288
+#: src/pages/Shell.tsx:4711
 msgid "Creating…"
 msgstr "Wird erstellt…"
 
@@ -1015,7 +1015,7 @@ msgstr "Tag"
 msgid "days"
 msgstr "Tage"
 
-#: src/pages/Shell.tsx:4477
+#: src/pages/Shell.tsx:4489
 msgid "Default (medium)"
 msgstr "Standard (mittel)"
 
@@ -1026,8 +1026,8 @@ msgstr "Standardbereich"
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
 #: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4906
+#: src/pages/Shell.tsx:4980
 msgid "Delete"
 msgstr "Löschen"
 
@@ -1038,8 +1038,8 @@ msgstr "{0} löschen"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4826
-#: src/pages/Shell.tsx:4940
+#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4952
 msgid "Delete {0}?"
 msgstr "{0} löschen?"
 
@@ -1047,21 +1047,21 @@ msgstr "{0} löschen?"
 msgid "Delete group"
 msgstr "Gruppe löschen"
 
-#: src/pages/Shell.tsx:4863
+#: src/pages/Shell.tsx:4875
 msgid "Delete memories too"
 msgstr "Erinnerungen ebenfalls löschen"
 
-#: src/pages/Shell.tsx:2619
+#: src/pages/Shell.tsx:2631
 msgid "Delete routine"
 msgstr "Routine löschen"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:3995
 msgid "deleted"
 msgstr "gelöscht"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4906
+#: src/pages/Shell.tsx:4980
 msgid "Deleting…"
 msgstr "Wird gelöscht…"
 
@@ -1078,17 +1078,17 @@ msgid "Deployment default"
 msgstr "Bereitstellungsstandard"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4254
+#: src/pages/Shell.tsx:4266
 msgid "Describe what this bot does"
 msgstr "Beschreibe, was dieser Bot macht"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4259
-#: src/pages/Shell.tsx:4421
+#: src/pages/Shell.tsx:4271
+#: src/pages/Shell.tsx:4433
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3407
 msgid "Dictate"
 msgstr "Diktieren"
 
@@ -1101,7 +1101,7 @@ msgstr "Trennen"
 msgid "Disconnecting…"
 msgstr "Verbindung wird getrennt…"
 
-#: src/pages/Shell.tsx:5347
+#: src/pages/Shell.tsx:5359
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Verworfen – du kannst die Verbindung jederzeit in den MCP-Einstellungen wiederherstellen."
 
@@ -1148,6 +1148,10 @@ msgstr "Skill-Entwurf"
 #: src/pages/BotContextMenu.tsx:99
 msgid "Duplicate"
 msgstr "Duplizieren"
+
+#: src/pages/Shell.tsx:3808
+msgid "Earlier message"
+msgstr "Frühere Nachricht"
 
 #: src/components/AskCard.tsx:149
 msgid "Edit first"
@@ -1201,11 +1205,11 @@ msgstr "Jeden Monat"
 msgid "Every week"
 msgstr "Jede Woche"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5405
 msgid "Expand"
 msgstr "Erweitern"
 
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4594
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1213,7 +1217,7 @@ msgstr "Exportieren"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Exportiere die Liste dieser Woche aus dem CRM und lege sie im freigegebenen Ordner ab"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4609
 msgid "Extra high"
 msgstr "Sehr hoch"
 
@@ -1261,7 +1265,7 @@ msgid "Fullscreen"
 msgstr "Vollbild"
 
 #: src/pages/Shell.tsx:2086
-#: src/pages/Shell.tsx:2236
+#: src/pages/Shell.tsx:2248
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1290,15 +1294,15 @@ msgstr "Beispiel anhören"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hallo, so klinge ich, wenn ich Antworten vorlese."
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4612
 msgid "High"
 msgstr "Hoch"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3426
 msgid "Hold to talk"
 msgstr "Zum Sprechen gedrückt halten"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3426
 msgid "Hold to talk (on-device dictation)"
 msgstr "Zum Sprechen gedrückt halten (Diktat auf dem Gerät)"
 
@@ -1318,7 +1322,7 @@ msgstr "Wie oft"
 msgid "How to check"
 msgstr "So wird geprüft"
 
-#: src/pages/Shell.tsx:3695
+#: src/pages/Shell.tsx:3704
 msgid "I’m done"
 msgstr "Ich bin fertig"
 
@@ -1330,7 +1334,7 @@ msgstr "Wenn du das gehört hast, ist die Stimme einsatzbereit."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI-JSON importieren"
 
-#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4504
 msgid "Inherit default"
 msgstr "Standard übernehmen"
 
@@ -1342,7 +1346,7 @@ msgstr "Eingaben"
 msgid "Instance API key"
 msgstr "Instanz-API-Schlüssel"
 
-#: src/pages/Shell.tsx:2503
+#: src/pages/Shell.tsx:2515
 msgid "Instruction"
 msgstr "Anweisung"
 
@@ -1372,15 +1376,15 @@ msgid "Interval unit"
 msgstr "Intervalleinheit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4505
 msgid "Isolated"
 msgstr "Isoliert"
 
-#: src/pages/Shell.tsx:4829
+#: src/pages/Shell.tsx:4841
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von ihm erstellte Bots bleiben in deiner Liste."
 
-#: src/pages/Shell.tsx:3791
+#: src/pages/Shell.tsx:3803
 msgid "Jump to replied message"
 msgstr "Zur beantworteten Nachricht springen"
 
@@ -1388,7 +1392,7 @@ msgstr "Zur beantworteten Nachricht springen"
 msgid "just now"
 msgstr "gerade eben"
 
-#: src/pages/Shell.tsx:4847
+#: src/pages/Shell.tsx:4859
 msgid "Keep memories"
 msgstr "Erinnerungen behalten"
 
@@ -1406,7 +1410,7 @@ msgstr "Sprache"
 msgid "Listening…"
 msgstr "Hört zu…"
 
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3031
 msgid "Load earlier messages"
 msgstr "Frühere Nachrichten laden"
 
@@ -1446,7 +1450,7 @@ msgstr "Stimmanbieter werden geladen…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3031
 msgid "Loading…"
 msgstr "Wird geladen…"
 
@@ -1458,7 +1462,7 @@ msgstr "Lokal"
 msgid "Log out"
 msgstr "Abmelden"
 
-#: src/pages/Shell.tsx:4598
+#: src/pages/Shell.tsx:4610
 msgid "Low"
 msgstr "Niedrig"
 
@@ -1474,7 +1478,7 @@ msgstr "Als gelesen markieren"
 msgid "Mark as Unread"
 msgstr "Als ungelesen markieren"
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4614
 msgid "Max"
 msgstr "Max."
 
@@ -1484,7 +1488,7 @@ msgstr "Max."
 msgid "MCP servers"
 msgstr "MCP-Server"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4611
 msgid "Medium"
 msgstr "Mittel"
 
@@ -1501,29 +1505,29 @@ msgstr "Mitglieder ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} auswählen)"
 msgid "Memory"
 msgstr "Erinnerungen"
 
-#: src/pages/Shell.tsx:4488
+#: src/pages/Shell.tsx:4500
 msgid "Memory scope"
 msgstr "Erinnerungsbereich"
 
-#: src/pages/Shell.tsx:3495
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3504
+#: src/pages/Shell.tsx:3599
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/pages/Shell.tsx:3491
-#: src/pages/Shell.tsx:3495
+#: src/pages/Shell.tsx:3500
+#: src/pages/Shell.tsx:3504
 msgid "Message {activeName}"
 msgstr "Nachricht an {activeName}"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3881
 msgid "Message from {peer}"
 msgstr "Nachricht von {peer}"
 
-#: src/pages/Shell.tsx:3492
+#: src/pages/Shell.tsx:3501
 msgid "Message…"
 msgstr "Nachricht…"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3881
 msgid "Messaged {peer}"
 msgstr "Nachricht an {peer} gesendet"
 
@@ -1531,7 +1535,7 @@ msgstr "Nachricht an {peer} gesendet"
 msgid "Microphone failed"
 msgstr "Mikrofonfehler"
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4613
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1553,7 +1557,7 @@ msgstr "Minuten"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4444
+#: src/pages/Shell.tsx:4456
 msgid "Model"
 msgstr "Modell"
 
@@ -1593,7 +1597,7 @@ msgstr "Monatlich"
 msgid "Move {0} to section"
 msgstr "{0} in Abschnitt verschieben"
 
-#: src/pages/Shell.tsx:4850
+#: src/pages/Shell.tsx:4862
 msgid "Move them to your shared memory."
 msgstr "Verschiebe sie in deine geteilten Erinnerungen."
 
@@ -1606,15 +1610,15 @@ msgstr "Verschieben nach"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4239
-#: src/pages/Shell.tsx:4403
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:2507
+#: src/pages/Shell.tsx:4251
+#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4688
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4244
+#: src/pages/Shell.tsx:4256
 msgid "Name this bot"
 msgstr "Bot benennen"
 
@@ -1631,7 +1635,7 @@ msgid "Needs takeover"
 msgstr "Übernahme erforderlich"
 
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4227
+#: src/pages/Shell.tsx:4239
 msgid "New bot"
 msgstr "Neuer Bot"
 
@@ -1644,12 +1648,12 @@ msgstr "Neue Gruppe"
 msgid "New open-work item"
 msgstr "Neuer offener Arbeitspunkt"
 
-#: src/pages/Shell.tsx:2385
+#: src/pages/Shell.tsx:2397
 msgid "New routine"
 msgstr "Neue Routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4670
+#: src/pages/Shell.tsx:4682
 msgid "New section"
 msgstr "Neuer Abschnitt"
 
@@ -1724,7 +1728,7 @@ msgstr "Nicht konfiguriert"
 msgid "Not connected"
 msgstr "Nicht verbunden"
 
-#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5347
 msgid "Not now"
 msgstr "Jetzt nicht"
 
@@ -1762,11 +1766,11 @@ msgstr "am 1. um {0}"
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/pages/Shell.tsx:2295
+#: src/pages/Shell.tsx:2307
 msgid "Open computer"
 msgstr "Computer öffnen"
 
-#: src/pages/Shell.tsx:2265
+#: src/pages/Shell.tsx:2277
 msgid "Open in full window"
 msgstr "In vollständigem Fenster öffnen"
 
@@ -1787,7 +1791,7 @@ msgstr "Offene Arbeit"
 msgid "OpenAI-compatible server URL"
 msgstr "URL eines OpenAI-kompatiblen Servers"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4006
 msgid "Opened its thread."
 msgstr "Thread geöffnet."
 
@@ -1870,7 +1874,7 @@ msgstr "Wiedergabe…"
 msgid "Preview {0}"
 msgstr "Vorschau von {0}"
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4194
 msgid "Private"
 msgstr "Privat"
 
@@ -1891,7 +1895,7 @@ msgstr "In Warteschlange"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo prüft die Quelle vor dem Speichern. Zugangsdaten werden verschlüsselt und weder an Clients zurückgegeben noch dem Modell zugänglich gemacht."
 
-#: src/pages/Shell.tsx:4520
+#: src/pages/Shell.tsx:4532
 msgid "Read replies aloud"
 msgstr "Antworten vorlesen"
 
@@ -1913,7 +1917,7 @@ msgstr "Verbindung wird wiederhergestellt"
 msgid "Recording: {0}"
 msgstr "Aufnahme: {0}"
 
-#: src/pages/Shell.tsx:3685
+#: src/pages/Shell.tsx:3694
 msgid "Release"
 msgstr "Freigeben"
 
@@ -1924,17 +1928,17 @@ msgid "Remove"
 msgstr "Entfernen"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3299
+#: src/pages/Shell.tsx:3308
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3454
+#: src/pages/Shell.tsx:3463
 msgid "Remove mention {0}"
 msgstr "Erwähnung von {0} entfernen"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3433
+#: src/pages/Shell.tsx:3442
 msgid "Remove skill {0}"
 msgstr "Skill {0} entfernen"
 
@@ -1942,7 +1946,7 @@ msgstr "Skill {0} entfernen"
 msgid "Remove this schedule"
 msgstr "Diesen Zeitplan entfernen"
 
-#: src/pages/Shell.tsx:3993
+#: src/pages/Shell.tsx:4005
 msgid "Removed with chat, computer, and memory."
 msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 
@@ -1968,11 +1972,11 @@ msgstr "API-Schlüssel ersetzen"
 msgid "Replace key"
 msgstr "Schlüssel ersetzen"
 
-#: src/pages/Shell.tsx:3631
+#: src/pages/Shell.tsx:3640
 msgid "Reply"
 msgstr "Antworten"
 
-#: src/pages/Shell.tsx:3262
+#: src/pages/Shell.tsx:3271
 msgid "Replying to {replyName}"
 msgstr "Antwort an {replyName}"
 
@@ -1996,17 +2000,17 @@ msgstr "Widerrufen"
 msgid "Revoking…"
 msgstr "Wird widerrufen…"
 
-#: src/pages/Shell.tsx:2488
-#: src/pages/Shell.tsx:2541
-#: src/pages/Shell.tsx:2548
+#: src/pages/Shell.tsx:2500
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2560
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2342
 msgid "Routines"
 msgstr "Routinen"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2623
 msgid "Run now"
 msgstr "Jetzt ausführen"
 
@@ -2014,11 +2018,11 @@ msgstr "Jetzt ausführen"
 msgid "Running"
 msgstr "Läuft"
 
-#: src/pages/Shell.tsx:2370
+#: src/pages/Shell.tsx:2382
 msgid "Running · Stop"
 msgstr "Wird ausgeführt · Stoppen"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2623
 msgid "Running…"
 msgstr "Wird ausgeführt…"
 
@@ -2026,8 +2030,8 @@ msgstr "Wird ausgeführt…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4575
+#: src/pages/Shell.tsx:2599
+#: src/pages/Shell.tsx:4587
 msgid "Save"
 msgstr "Speichern"
 
@@ -2051,7 +2055,7 @@ msgstr "Gespeichert."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2599
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
@@ -2090,7 +2094,7 @@ msgstr "Suche…"
 msgid "Select a bot"
 msgstr "Bot auswählen"
 
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3524
 msgid "Send"
 msgstr "Senden"
 
@@ -2125,15 +2129,15 @@ msgstr "Stimme für Anrufe einrichten"
 #: src/pages/AccountSettingsOverlay.tsx:79
 #: src/pages/Shell.tsx:1961
 #: src/pages/Shell.tsx:1971
-#: src/pages/Shell.tsx:2232
+#: src/pages/Shell.tsx:2244
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3542
 msgid "Settings: General"
 msgstr "Einstellungen: Allgemein"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3544
 msgid "Settings: Usage"
 msgstr "Einstellungen: Nutzung"
 
@@ -2143,15 +2147,15 @@ msgid "Setup help"
 msgstr "Einrichtungshilfe"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4506
 msgid "Shared"
 msgstr "Geteilt"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2255
 msgid "Show computer"
 msgstr "Computer anzeigen"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2255
 msgid "Show settings"
 msgstr "Einstellungen anzeigen"
 
@@ -2175,11 +2179,11 @@ msgid "Sign up"
 msgstr "Registrieren"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3346
+#: src/pages/Shell.tsx:3355
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3701
 msgid "Skip"
 msgstr "Überspringen"
 
@@ -2200,8 +2204,8 @@ msgstr "{0} übersprungen"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Leertaste unterbricht · Esc legt auf"
 
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3850
+#: src/pages/Shell.tsx:4103
 msgid "Speak"
 msgstr "Vorlesen"
 
@@ -2213,8 +2217,8 @@ msgstr "Sprechen + transkribieren"
 msgid "Speak only"
 msgstr "Nur sprechen"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3846
+#: src/pages/Shell.tsx:4099
 msgid "Speak this reply"
 msgstr "Diese Antwort vorlesen"
 
@@ -2240,20 +2244,20 @@ msgstr "Wird gestartet…"
 msgid "Steps"
 msgstr "Schritte"
 
-#: src/pages/Shell.tsx:2866
-#: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3506
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:2878
+#: src/pages/Shell.tsx:2882
+#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3850
+#: src/pages/Shell.tsx:4103
 msgid "Stop"
 msgstr "Stoppen"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3407
 msgid "Stop dictation"
 msgstr "Diktat stoppen"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3846
+#: src/pages/Shell.tsx:4099
 msgid "Stop speaking"
 msgstr "Vorlesen stoppen"
 
@@ -2262,8 +2266,8 @@ msgstr "Vorlesen stoppen"
 msgid "Stop teaching"
 msgstr "Anlernen beenden"
 
-#: src/pages/Shell.tsx:2322
-#: src/pages/Shell.tsx:2886
+#: src/pages/Shell.tsx:2334
+#: src/pages/Shell.tsx:2898
 msgid "Stop the bot first"
 msgstr "Zuerst den Bot stoppen"
 
@@ -2271,7 +2275,7 @@ msgstr "Zuerst den Bot stoppen"
 msgid "Stored encrypted"
 msgstr "Verschlüsselt gespeichert"
 
-#: src/pages/Shell.tsx:3945
+#: src/pages/Shell.tsx:3957
 msgid "subagent"
 msgstr "Subagent"
 
@@ -2284,8 +2288,8 @@ msgstr "Absenden"
 msgid "Switching…"
 msgstr "Wird gewechselt…"
 
-#: src/pages/Shell.tsx:2325
-#: src/pages/Shell.tsx:2891
+#: src/pages/Shell.tsx:2337
+#: src/pages/Shell.tsx:2903
 msgid "Take control"
 msgstr "Kontrolle übernehmen"
 
@@ -2293,7 +2297,7 @@ msgstr "Kontrolle übernehmen"
 msgid "Teach a task"
 msgstr "Aufgabe anlernen"
 
-#: src/pages/Shell.tsx:2158
+#: src/pages/Shell.tsx:2170
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachricht sendest."
 
@@ -2301,11 +2305,11 @@ msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachr
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Zum Anlernen ist ein grafischer Sandbox-Computer erforderlich. Auf dem Desktop gehostete Bots können Shell-Aufgaben ausführen, aber keine Bildschirmaufnahmen erstellen."
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4194
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5028
 msgid "Team Computer"
 msgstr "Team-Computer"
 
@@ -2318,20 +2322,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügbar."
 
-#: src/pages/Shell.tsx:4471
+#: src/pages/Shell.tsx:4483
 msgid "Thinking"
 msgstr "Denkmodus"
 
-#: src/pages/Shell.tsx:2269
+#: src/pages/Shell.tsx:2281
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Dieser Bot wird auf diesem Computer und nicht auf einem Linux-Desktop ausgeführt. Shell und Dateien verwenden deinen persönlichen Ordner."
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:2927
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Dieser Bot wird auf diesem Computer ausgeführt. Es gibt keinen separaten Linux-Desktop. Bitte ihn, die Shell zu verwenden; Arbeitsverzeichnisse in deinem persönlichen Ordner sind zulässig."
 
-#: src/pages/Shell.tsx:4866
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4878
+#: src/pages/Shell.tsx:4955
 msgid "This cannot be undone."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
@@ -2355,7 +2359,7 @@ msgstr "dieser Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Dieser Mac führt Shell-Befehle mit deinem Konto aus und kann auf Dateien in deinem persönlichen Ordner zugreifen. Aktiviere dies nicht auf einem gemeinsam genutzten oder öffentlichen Server."
 
-#: src/pages/Shell.tsx:4751
+#: src/pages/Shell.tsx:4763
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbeit beendet. Bot, Computer, Erinnerungen und Routinen bleiben erhalten."
 
@@ -2363,7 +2367,7 @@ msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbe
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bei diesem Anbieter kann hier kein Schlüssel eingefügt werden. Überspringe diesen Schritt, wenn die Bereitstellung bereits Zugangsdaten enthält."
 
-#: src/pages/Shell.tsx:5283
+#: src/pages/Shell.tsx:5295
 msgid "This server cannot be assigned without a bot."
 msgstr "Dieser Server kann ohne Bot nicht zugewiesen werden."
 
@@ -2375,7 +2379,7 @@ msgstr "Dieser Server hat keine Browserautorisierung angefordert."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Dieser Server ist bereits verbunden. Trenne zuerst die Verbindung, um ihn erneut zu autorisieren."
 
-#: src/pages/Shell.tsx:5322
+#: src/pages/Shell.tsx:5334
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Dieser Server verwendet die Browseranmeldung. Autorisiere ihn, damit deine Agents seine Tools verwenden können – ein Pop-up wird geöffnet."
 
@@ -2388,8 +2392,8 @@ msgid "Time of day"
 msgstr "Uhrzeit"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4249
-#: src/pages/Shell.tsx:4412
+#: src/pages/Shell.tsx:4261
+#: src/pages/Shell.tsx:4424
 msgid "Title"
 msgstr "Titel"
 
@@ -2445,7 +2449,7 @@ msgid "Verifying…"
 msgstr "Wird geprüft…"
 
 #: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4524
+#: src/pages/Shell.tsx:4536
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2458,7 +2462,7 @@ msgstr "Stimme"
 msgid "Waiting for sign-in…"
 msgstr "Warten auf Anmeldung…"
 
-#: src/pages/Shell.tsx:5166
+#: src/pages/Shell.tsx:5178
 msgid "Waiting…"
 msgstr "Warten…"
 
@@ -2467,7 +2471,7 @@ msgstr "Warten…"
 msgid "Weekdays"
 msgstr "Wochentage"
 
-#: src/pages/Shell.tsx:4836
+#: src/pages/Shell.tsx:4848
 msgid "What about its memories?"
 msgstr "Was soll mit seinen Erinnerungen geschehen?"
 
@@ -2476,7 +2480,7 @@ msgid "What result will you demonstrate?"
 msgstr "Welches Ergebnis wirst du vorführen?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4264
+#: src/pages/Shell.tsx:4276
 msgid "What this bot is for"
 msgstr "Wofür dieser Bot gedacht ist"
 
@@ -2488,7 +2492,7 @@ msgstr "Was zurückgegeben werden soll"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "Wenn {botName} einem anderen Bot eine Nachricht sendet, wird der Austausch hier statt im Chat angezeigt."
 
-#: src/pages/Shell.tsx:2512
+#: src/pages/Shell.tsx:2524
 msgid "When to run"
 msgstr "Ausführungszeit"
 
@@ -2505,7 +2509,7 @@ msgstr "Wo sollen Bots ausgeführt werden?"
 msgid "Working…"
 msgstr "Wird verarbeitet…"
 
-#: src/pages/Shell.tsx:4454
+#: src/pages/Shell.tsx:4466
 msgid "Workspace default"
 msgstr "Arbeitsbereichsstandard"
 
@@ -2522,8 +2526,8 @@ msgstr "Du kannst diesen Tab schließen, wenn du nicht automatisch weitergeleite
 msgid "You can close this window."
 msgstr "Du kannst dieses Fenster schließen."
 
-#: src/pages/Shell.tsx:2302
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2314
+#: src/pages/Shell.tsx:2868
 msgid "You have control"
 msgstr "Du hast die Kontrolle"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5139
+#: src/pages/Shell.tsx:5151
 msgid "{0} connection"
 msgstr "{0} connection"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2306
+#: src/pages/Shell.tsx:2318
 msgid "{0} is using it"
 msgstr "{0} is using it"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# peer} other {# peers}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} has not messaged another bot yet."
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5028
 msgid "{botName}’s computer"
 msgstr "{botName}’s computer"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3327
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Access token (optional)"
 msgid "Account"
 msgstr "Account"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4542
 msgid "Account default"
 msgstr "Account default"
 
@@ -216,7 +216,7 @@ msgstr "Adding…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4433
+#: src/pages/Shell.tsx:4445
 msgid "Advanced"
 msgstr "Advanced"
 
@@ -311,11 +311,11 @@ msgstr "Applies when you click Add server. Use the agent chips on each server ca
 msgid "Approval boundaries"
 msgstr "Approval boundaries"
 
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5344
 msgid "Approve"
 msgstr "Approve"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5335
 msgid "Approve this server to let your agent use its tools."
 msgstr "Approve this server to let your agent use its tools."
 
@@ -327,7 +327,7 @@ msgstr "Apps"
 msgid "Archive"
 msgstr "Archive"
 
-#: src/pages/Shell.tsx:3981
+#: src/pages/Shell.tsx:3993
 msgid "archived"
 msgstr "archived"
 
@@ -335,7 +335,7 @@ msgstr "archived"
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/Shell.tsx:3992
+#: src/pages/Shell.tsx:4004
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archived. Chat, memory, and files kept."
 
@@ -374,7 +374,7 @@ msgstr "Ask before purchases"
 msgid "Ask before sending external email"
 msgstr "Ask before sending external email"
 
-#: src/pages/Shell.tsx:2308
+#: src/pages/Shell.tsx:2320
 msgid "Asleep"
 msgstr "Asleep"
 
@@ -389,11 +389,11 @@ msgstr "at {0}"
 msgid "at {timeSelect}"
 msgstr "at {timeSelect}"
 
-#: src/pages/Shell.tsx:3389
+#: src/pages/Shell.tsx:3398
 msgid "Attach file"
 msgstr "Attach file"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3597
 msgid "Attachment"
 msgstr "Attachment"
 
@@ -406,12 +406,12 @@ msgstr "Authorization code or callback URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Authorization expired — reconnect required"
 
-#: src/pages/Shell.tsx:5124
+#: src/pages/Shell.tsx:5136
 msgid "Authorization timed out. Please try again."
 msgstr "Authorization timed out. Please try again."
 
-#: src/pages/Shell.tsx:5166
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5178
+#: src/pages/Shell.tsx:5344
 msgid "Authorize"
 msgstr "Authorize"
 
@@ -423,18 +423,18 @@ msgstr "Base URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:5020
 msgid "Booting live desktop…"
 msgstr "Booting live desktop…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2843
 msgid "Booting up {0}’s computer"
 msgstr "Booting up {0}’s computer"
 
-#: src/pages/Shell.tsx:3851
-#: src/pages/Shell.tsx:3852
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3864
+#: src/pages/Shell.tsx:3997
 msgid "bot"
 msgstr "bot"
 
@@ -446,11 +446,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot messages"
 
-#: src/pages/Shell.tsx:2923
+#: src/pages/Shell.tsx:2935
 msgid "Bot screen"
 msgstr "Bot screen"
 
-#: src/pages/Shell.tsx:2276
+#: src/pages/Shell.tsx:2288
 msgid "Bot screen preview"
 msgstr "Bot screen preview"
 
@@ -475,14 +475,14 @@ msgstr "Can't reach the server."
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4692
-#: src/pages/Shell.tsx:4764
-#: src/pages/Shell.tsx:4879
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4704
+#: src/pages/Shell.tsx:4776
+#: src/pages/Shell.tsx:4891
+#: src/pages/Shell.tsx:4965
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:4241
 msgid "Cancel new bot"
 msgstr "Cancel new bot"
 
@@ -490,7 +490,7 @@ msgstr "Cancel new bot"
 msgid "Cancel new group"
 msgstr "Cancel new group"
 
-#: src/pages/Shell.tsx:3265
+#: src/pages/Shell.tsx:3274
 msgid "Cancel reply"
 msgstr "Cancel reply"
 
@@ -498,16 +498,16 @@ msgstr "Cancel reply"
 msgid "Cancelled"
 msgstr "Cancelled"
 
-#: src/pages/Shell.tsx:5229
+#: src/pages/Shell.tsx:5241
 msgid "Chart failed to render: {error}"
 msgstr "Chart failed to render: {error}"
 
-#: src/pages/Shell.tsx:3531
+#: src/pages/Shell.tsx:3540
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
-#: src/pages/Shell.tsx:2542
-#: src/pages/Shell.tsx:2549
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2561
 msgid "Check in."
 msgstr "Check in."
 
@@ -519,21 +519,21 @@ msgstr "Choose a model to get started."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Choose which connected model Rakazo uses."
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4791
 msgid "Clear"
 msgstr "Clear"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4745
+#: src/pages/Shell.tsx:4757
 msgid "Clear {0}’s conversation?"
 msgstr "Clear {0}’s conversation?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4585
+#: src/pages/Shell.tsx:4597
 msgid "Clear conversation"
 msgstr "Clear conversation"
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4791
 msgid "Clearing…"
 msgstr "Clearing…"
 
@@ -549,15 +549,15 @@ msgstr "Close bot menu"
 msgid "Close bot messages"
 msgstr "Close bot messages"
 
-#: src/pages/Shell.tsx:5414
+#: src/pages/Shell.tsx:5426
 msgid "Close chart"
 msgstr "Close chart"
 
-#: src/pages/Shell.tsx:2897
+#: src/pages/Shell.tsx:2909
 msgid "Close computer"
 msgstr "Close computer"
 
-#: src/pages/Shell.tsx:5514
+#: src/pages/Shell.tsx:5526
 msgid "Close image preview"
 msgstr "Close image preview"
 
@@ -581,7 +581,7 @@ msgstr "Close model settings"
 msgid "Close navigation"
 msgstr "Close navigation"
 
-#: src/pages/Shell.tsx:2254
+#: src/pages/Shell.tsx:2266
 msgid "Close panel"
 msgstr "Close panel"
 
@@ -610,24 +610,24 @@ msgstr "Command"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/pages/Shell.tsx:4139
-#: src/pages/Shell.tsx:4167
+#: src/pages/Shell.tsx:4151
+#: src/pages/Shell.tsx:4179
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5011
+#: src/pages/Shell.tsx:5023
 msgid "Computer failed to boot"
 msgstr "Computer failed to boot"
 
-#: src/pages/Shell.tsx:2945
+#: src/pages/Shell.tsx:2957
 msgid "Computer is asleep"
 msgstr "Computer is asleep"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5022
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer is asleep — take control to wake it"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5024
 msgid "Computer is stopped"
 msgstr "Computer is stopped"
 
@@ -665,7 +665,7 @@ msgstr "Connect apps or add Treg, MCP, and OpenAPI tool sources."
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "Connect ElevenLabs, OpenAI, or Cartesia"
 
-#: src/pages/Shell.tsx:5312
+#: src/pages/Shell.tsx:5324
 msgid "Connect MCP server “{name}”"
 msgstr "Connect MCP server “{name}”"
 
@@ -689,12 +689,12 @@ msgstr "Connect Treg"
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
 #: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5163
+#: src/pages/Shell.tsx:5175
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Connected"
 
-#: src/pages/Shell.tsx:5342
+#: src/pages/Shell.tsx:5354
 msgid "Connected — its tools are available from your next message."
 msgstr "Connected — its tools are available from your next message."
 
@@ -720,7 +720,7 @@ msgstr "Connected and using {0}."
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
 #: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5344
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Connecting…"
@@ -739,7 +739,7 @@ msgstr "Continue"
 msgid "Continue with email"
 msgstr "Continue with email"
 
-#: src/pages/Shell.tsx:3639
+#: src/pages/Shell.tsx:3648
 msgid "Copy"
 msgstr "Copy"
 
@@ -751,11 +751,11 @@ msgstr "Could not add"
 msgid "Could not add MCP server"
 msgstr "Could not add MCP server"
 
-#: src/pages/Shell.tsx:5299
+#: src/pages/Shell.tsx:5311
 msgid "Could not approve this server"
 msgstr "Could not approve this server"
 
-#: src/pages/Shell.tsx:5127
+#: src/pages/Shell.tsx:5139
 msgid "Could not authorize this app"
 msgstr "Could not authorize this app"
 
@@ -763,7 +763,7 @@ msgstr "Could not authorize this app"
 msgid "Could not change the default model"
 msgstr "Could not change the default model"
 
-#: src/pages/Shell.tsx:4773
+#: src/pages/Shell.tsx:4785
 msgid "Could not clear conversation"
 msgstr "Could not clear conversation"
 
@@ -792,7 +792,7 @@ msgstr "Could not connect this voice provider"
 msgid "Could not continue"
 msgstr "Could not continue"
 
-#: src/pages/Shell.tsx:4217
+#: src/pages/Shell.tsx:4229
 msgid "Could not create bot"
 msgstr "Could not create bot"
 
@@ -800,7 +800,7 @@ msgstr "Could not create bot"
 msgid "Could not create group"
 msgstr "Could not create group"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4676
 msgid "Could not create section"
 msgstr "Could not create section"
 
@@ -808,7 +808,7 @@ msgstr "Could not create section"
 msgid "Could not create your bot"
 msgstr "Could not create your bot"
 
-#: src/pages/Shell.tsx:4888
+#: src/pages/Shell.tsx:4900
 msgid "Could not delete bot"
 msgstr "Could not delete bot"
 
@@ -816,7 +816,7 @@ msgstr "Could not delete bot"
 msgid "Could not delete MCP server"
 msgstr "Could not delete MCP server"
 
-#: src/pages/Shell.tsx:4962
+#: src/pages/Shell.tsx:4974
 msgid "Could not delete routine"
 msgstr "Could not delete routine"
 
@@ -890,7 +890,7 @@ msgstr "Could not remove group"
 msgid "Could not remove rule"
 msgstr "Could not remove rule"
 
-#: src/pages/Shell.tsx:5219
+#: src/pages/Shell.tsx:5231
 msgid "Could not render chart"
 msgstr "Could not render chart"
 
@@ -898,7 +898,7 @@ msgstr "Could not render chart"
 msgid "Could not revoke connection"
 msgstr "Could not revoke connection"
 
-#: src/pages/Shell.tsx:4570
+#: src/pages/Shell.tsx:4582
 msgid "Could not save"
 msgstr "Could not save"
 
@@ -910,7 +910,7 @@ msgstr "Could not save group"
 msgid "Could not save model"
 msgstr "Could not save model"
 
-#: src/pages/Shell.tsx:2564
+#: src/pages/Shell.tsx:2576
 msgid "Could not save routine"
 msgstr "Could not save routine"
 
@@ -926,7 +926,7 @@ msgstr "Could not save that choice"
 msgid "Could not save that voice"
 msgstr "Could not save that voice"
 
-#: src/pages/Shell.tsx:5039
+#: src/pages/Shell.tsx:5051
 msgid "Could not save this choice"
 msgstr "Could not save this choice"
 
@@ -959,13 +959,13 @@ msgid "Could not update the default memory scope"
 msgstr "Could not update the default memory scope"
 
 #: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4288
+#: src/pages/Shell.tsx:4711
 msgid "Create"
 msgstr "Create"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4673
+#: src/pages/Shell.tsx:4685
 msgid "Create a section and move {0} into it."
 msgstr "Create a section and move {0} into it."
 
@@ -986,8 +986,8 @@ msgid "Create your Rakazo"
 msgstr "Create your Rakazo"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4288
+#: src/pages/Shell.tsx:4711
 msgid "Creating…"
 msgstr "Creating…"
 
@@ -1015,7 +1015,7 @@ msgstr "day"
 msgid "days"
 msgstr "days"
 
-#: src/pages/Shell.tsx:4477
+#: src/pages/Shell.tsx:4489
 msgid "Default (medium)"
 msgstr "Default (medium)"
 
@@ -1026,8 +1026,8 @@ msgstr "Default scope"
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
 #: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4906
+#: src/pages/Shell.tsx:4980
 msgid "Delete"
 msgstr "Delete"
 
@@ -1038,8 +1038,8 @@ msgstr "Delete {0}"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4826
-#: src/pages/Shell.tsx:4940
+#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4952
 msgid "Delete {0}?"
 msgstr "Delete {0}?"
 
@@ -1047,21 +1047,21 @@ msgstr "Delete {0}?"
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/pages/Shell.tsx:4863
+#: src/pages/Shell.tsx:4875
 msgid "Delete memories too"
 msgstr "Delete memories too"
 
-#: src/pages/Shell.tsx:2619
+#: src/pages/Shell.tsx:2631
 msgid "Delete routine"
 msgstr "Delete routine"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:3995
 msgid "deleted"
 msgstr "deleted"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4906
+#: src/pages/Shell.tsx:4980
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1078,17 +1078,17 @@ msgid "Deployment default"
 msgstr "Deployment default"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4254
+#: src/pages/Shell.tsx:4266
 msgid "Describe what this bot does"
 msgstr "Describe what this bot does"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4259
-#: src/pages/Shell.tsx:4421
+#: src/pages/Shell.tsx:4271
+#: src/pages/Shell.tsx:4433
 msgid "Description"
 msgstr "Description"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3407
 msgid "Dictate"
 msgstr "Dictate"
 
@@ -1101,7 +1101,7 @@ msgstr "Disconnect"
 msgid "Disconnecting…"
 msgstr "Disconnecting…"
 
-#: src/pages/Shell.tsx:5347
+#: src/pages/Shell.tsx:5359
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Dismissed — reconnect anytime from MCP settings."
 
@@ -1148,6 +1148,10 @@ msgstr "Draft skill"
 #: src/pages/BotContextMenu.tsx:99
 msgid "Duplicate"
 msgstr "Duplicate"
+
+#: src/pages/Shell.tsx:3808
+msgid "Earlier message"
+msgstr "Earlier message"
 
 #: src/components/AskCard.tsx:149
 msgid "Edit first"
@@ -1201,11 +1205,11 @@ msgstr "Every month"
 msgid "Every week"
 msgstr "Every week"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5405
 msgid "Expand"
 msgstr "Expand"
 
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4594
 msgid "Export"
 msgstr "Export"
 
@@ -1213,7 +1217,7 @@ msgstr "Export"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Export this week's list from the CRM and drop it in the shared folder"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4609
 msgid "Extra high"
 msgstr "Extra high"
 
@@ -1261,7 +1265,7 @@ msgid "Fullscreen"
 msgstr "Fullscreen"
 
 #: src/pages/Shell.tsx:2086
-#: src/pages/Shell.tsx:2236
+#: src/pages/Shell.tsx:2248
 msgid "Group"
 msgstr "Group"
 
@@ -1290,15 +1294,15 @@ msgstr "Hear a sample"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hi, this is how I'll sound when I read replies out loud."
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4612
 msgid "High"
 msgstr "High"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3426
 msgid "Hold to talk"
 msgstr "Hold to talk"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3426
 msgid "Hold to talk (on-device dictation)"
 msgstr "Hold to talk (on-device dictation)"
 
@@ -1318,7 +1322,7 @@ msgstr "How often"
 msgid "How to check"
 msgstr "How to check"
 
-#: src/pages/Shell.tsx:3695
+#: src/pages/Shell.tsx:3704
 msgid "I’m done"
 msgstr "I’m done"
 
@@ -1330,7 +1334,7 @@ msgstr "If you heard that, voice is ready."
 msgid "Import OpenAPI JSON"
 msgstr "Import OpenAPI JSON"
 
-#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4504
 msgid "Inherit default"
 msgstr "Inherit default"
 
@@ -1342,7 +1346,7 @@ msgstr "Inputs"
 msgid "Instance API key"
 msgstr "Instance API key"
 
-#: src/pages/Shell.tsx:2503
+#: src/pages/Shell.tsx:2515
 msgid "Instruction"
 msgstr "Instruction"
 
@@ -1372,15 +1376,15 @@ msgid "Interval unit"
 msgstr "Interval unit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4505
 msgid "Isolated"
 msgstr "Isolated"
 
-#: src/pages/Shell.tsx:4829
+#: src/pages/Shell.tsx:4841
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 
-#: src/pages/Shell.tsx:3791
+#: src/pages/Shell.tsx:3803
 msgid "Jump to replied message"
 msgstr "Jump to replied message"
 
@@ -1388,7 +1392,7 @@ msgstr "Jump to replied message"
 msgid "just now"
 msgstr "just now"
 
-#: src/pages/Shell.tsx:4847
+#: src/pages/Shell.tsx:4859
 msgid "Keep memories"
 msgstr "Keep memories"
 
@@ -1406,7 +1410,7 @@ msgstr "Language"
 msgid "Listening…"
 msgstr "Listening…"
 
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3031
 msgid "Load earlier messages"
 msgstr "Load earlier messages"
 
@@ -1446,7 +1450,7 @@ msgstr "Loading voice providers…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3031
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -1458,7 +1462,7 @@ msgstr "Local"
 msgid "Log out"
 msgstr "Log out"
 
-#: src/pages/Shell.tsx:4598
+#: src/pages/Shell.tsx:4610
 msgid "Low"
 msgstr "Low"
 
@@ -1474,7 +1478,7 @@ msgstr "Mark as Read"
 msgid "Mark as Unread"
 msgstr "Mark as Unread"
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4614
 msgid "Max"
 msgstr "Max"
 
@@ -1484,7 +1488,7 @@ msgstr "Max"
 msgid "MCP servers"
 msgstr "MCP servers"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4611
 msgid "Medium"
 msgstr "Medium"
 
@@ -1501,29 +1505,29 @@ msgstr "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgid "Memory"
 msgstr "Memory"
 
-#: src/pages/Shell.tsx:4488
+#: src/pages/Shell.tsx:4500
 msgid "Memory scope"
 msgstr "Memory scope"
 
-#: src/pages/Shell.tsx:3495
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3504
+#: src/pages/Shell.tsx:3599
 msgid "Message"
 msgstr "Message"
 
-#: src/pages/Shell.tsx:3491
-#: src/pages/Shell.tsx:3495
+#: src/pages/Shell.tsx:3500
+#: src/pages/Shell.tsx:3504
 msgid "Message {activeName}"
 msgstr "Message {activeName}"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3881
 msgid "Message from {peer}"
 msgstr "Message from {peer}"
 
-#: src/pages/Shell.tsx:3492
+#: src/pages/Shell.tsx:3501
 msgid "Message…"
 msgstr "Message…"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3881
 msgid "Messaged {peer}"
 msgstr "Messaged {peer}"
 
@@ -1531,7 +1535,7 @@ msgstr "Messaged {peer}"
 msgid "Microphone failed"
 msgstr "Microphone failed"
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4613
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1553,7 +1557,7 @@ msgstr "minutes"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4444
+#: src/pages/Shell.tsx:4456
 msgid "Model"
 msgstr "Model"
 
@@ -1593,7 +1597,7 @@ msgstr "Monthly"
 msgid "Move {0} to section"
 msgstr "Move {0} to section"
 
-#: src/pages/Shell.tsx:4850
+#: src/pages/Shell.tsx:4862
 msgid "Move them to your shared memory."
 msgstr "Move them to your shared memory."
 
@@ -1606,15 +1610,15 @@ msgstr "Move to"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4239
-#: src/pages/Shell.tsx:4403
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:2507
+#: src/pages/Shell.tsx:4251
+#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4688
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4244
+#: src/pages/Shell.tsx:4256
 msgid "Name this bot"
 msgstr "Name this bot"
 
@@ -1631,7 +1635,7 @@ msgid "Needs takeover"
 msgstr "Needs takeover"
 
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4227
+#: src/pages/Shell.tsx:4239
 msgid "New bot"
 msgstr "New bot"
 
@@ -1644,12 +1648,12 @@ msgstr "New group"
 msgid "New open-work item"
 msgstr "New open-work item"
 
-#: src/pages/Shell.tsx:2385
+#: src/pages/Shell.tsx:2397
 msgid "New routine"
 msgstr "New routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4670
+#: src/pages/Shell.tsx:4682
 msgid "New section"
 msgstr "New section"
 
@@ -1724,7 +1728,7 @@ msgstr "Not configured"
 msgid "Not connected"
 msgstr "Not connected"
 
-#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5347
 msgid "Not now"
 msgstr "Not now"
 
@@ -1762,11 +1766,11 @@ msgstr "on the 1st at {0}"
 msgid "Open"
 msgstr "Open"
 
-#: src/pages/Shell.tsx:2295
+#: src/pages/Shell.tsx:2307
 msgid "Open computer"
 msgstr "Open computer"
 
-#: src/pages/Shell.tsx:2265
+#: src/pages/Shell.tsx:2277
 msgid "Open in full window"
 msgstr "Open in full window"
 
@@ -1787,7 +1791,7 @@ msgstr "Open work"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-compatible server URL"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4006
 msgid "Opened its thread."
 msgstr "Opened its thread."
 
@@ -1870,7 +1874,7 @@ msgstr "Playing…"
 msgid "Preview {0}"
 msgstr "Preview {0}"
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4194
 msgid "Private"
 msgstr "Private"
 
@@ -1891,7 +1895,7 @@ msgstr "Queued"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 
-#: src/pages/Shell.tsx:4520
+#: src/pages/Shell.tsx:4532
 msgid "Read replies aloud"
 msgstr "Read replies aloud"
 
@@ -1913,7 +1917,7 @@ msgstr "Reconnecting"
 msgid "Recording: {0}"
 msgstr "Recording: {0}"
 
-#: src/pages/Shell.tsx:3685
+#: src/pages/Shell.tsx:3694
 msgid "Release"
 msgstr "Release"
 
@@ -1924,17 +1928,17 @@ msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3299
+#: src/pages/Shell.tsx:3308
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3454
+#: src/pages/Shell.tsx:3463
 msgid "Remove mention {0}"
 msgstr "Remove mention {0}"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3433
+#: src/pages/Shell.tsx:3442
 msgid "Remove skill {0}"
 msgstr "Remove skill {0}"
 
@@ -1942,7 +1946,7 @@ msgstr "Remove skill {0}"
 msgid "Remove this schedule"
 msgstr "Remove this schedule"
 
-#: src/pages/Shell.tsx:3993
+#: src/pages/Shell.tsx:4005
 msgid "Removed with chat, computer, and memory."
 msgstr "Removed with chat, computer, and memory."
 
@@ -1968,11 +1972,11 @@ msgstr "Replace API key"
 msgid "Replace key"
 msgstr "Replace key"
 
-#: src/pages/Shell.tsx:3631
+#: src/pages/Shell.tsx:3640
 msgid "Reply"
 msgstr "Reply"
 
-#: src/pages/Shell.tsx:3262
+#: src/pages/Shell.tsx:3271
 msgid "Replying to {replyName}"
 msgstr "Replying to {replyName}"
 
@@ -1996,17 +2000,17 @@ msgstr "Revoke"
 msgid "Revoking…"
 msgstr "Revoking…"
 
-#: src/pages/Shell.tsx:2488
-#: src/pages/Shell.tsx:2541
-#: src/pages/Shell.tsx:2548
+#: src/pages/Shell.tsx:2500
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2560
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2342
 msgid "Routines"
 msgstr "Routines"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2623
 msgid "Run now"
 msgstr "Run now"
 
@@ -2014,11 +2018,11 @@ msgstr "Run now"
 msgid "Running"
 msgstr "Running"
 
-#: src/pages/Shell.tsx:2370
+#: src/pages/Shell.tsx:2382
 msgid "Running · Stop"
 msgstr "Running · Stop"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2623
 msgid "Running…"
 msgstr "Running…"
 
@@ -2026,8 +2030,8 @@ msgstr "Running…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4575
+#: src/pages/Shell.tsx:2599
+#: src/pages/Shell.tsx:4587
 msgid "Save"
 msgstr "Save"
 
@@ -2051,7 +2055,7 @@ msgstr "Saved."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2599
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2090,7 +2094,7 @@ msgstr "Searching…"
 msgid "Select a bot"
 msgstr "Select a bot"
 
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3524
 msgid "Send"
 msgstr "Send"
 
@@ -2125,15 +2129,15 @@ msgstr "Set up voice to call"
 #: src/pages/AccountSettingsOverlay.tsx:79
 #: src/pages/Shell.tsx:1961
 #: src/pages/Shell.tsx:1971
-#: src/pages/Shell.tsx:2232
+#: src/pages/Shell.tsx:2244
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3542
 msgid "Settings: General"
 msgstr "Settings: General"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3544
 msgid "Settings: Usage"
 msgstr "Settings: Usage"
 
@@ -2143,15 +2147,15 @@ msgid "Setup help"
 msgstr "Setup help"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4506
 msgid "Shared"
 msgstr "Shared"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2255
 msgid "Show computer"
 msgstr "Show computer"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2255
 msgid "Show settings"
 msgstr "Show settings"
 
@@ -2175,11 +2179,11 @@ msgid "Sign up"
 msgstr "Sign up"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3346
+#: src/pages/Shell.tsx:3355
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3701
 msgid "Skip"
 msgstr "Skip"
 
@@ -2200,8 +2204,8 @@ msgstr "Skipped {0}"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space interrupts · Esc hangs up"
 
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3850
+#: src/pages/Shell.tsx:4103
 msgid "Speak"
 msgstr "Speak"
 
@@ -2213,8 +2217,8 @@ msgstr "Speak + transcribe"
 msgid "Speak only"
 msgstr "Speak only"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3846
+#: src/pages/Shell.tsx:4099
 msgid "Speak this reply"
 msgstr "Speak this reply"
 
@@ -2240,20 +2244,20 @@ msgstr "Starting…"
 msgid "Steps"
 msgstr "Steps"
 
-#: src/pages/Shell.tsx:2866
-#: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3506
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:2878
+#: src/pages/Shell.tsx:2882
+#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3850
+#: src/pages/Shell.tsx:4103
 msgid "Stop"
 msgstr "Stop"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3407
 msgid "Stop dictation"
 msgstr "Stop dictation"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3846
+#: src/pages/Shell.tsx:4099
 msgid "Stop speaking"
 msgstr "Stop speaking"
 
@@ -2262,8 +2266,8 @@ msgstr "Stop speaking"
 msgid "Stop teaching"
 msgstr "Stop teaching"
 
-#: src/pages/Shell.tsx:2322
-#: src/pages/Shell.tsx:2886
+#: src/pages/Shell.tsx:2334
+#: src/pages/Shell.tsx:2898
 msgid "Stop the bot first"
 msgstr "Stop the bot first"
 
@@ -2271,7 +2275,7 @@ msgstr "Stop the bot first"
 msgid "Stored encrypted"
 msgstr "Stored encrypted"
 
-#: src/pages/Shell.tsx:3945
+#: src/pages/Shell.tsx:3957
 msgid "subagent"
 msgstr "subagent"
 
@@ -2284,8 +2288,8 @@ msgstr "Submit"
 msgid "Switching…"
 msgstr "Switching…"
 
-#: src/pages/Shell.tsx:2325
-#: src/pages/Shell.tsx:2891
+#: src/pages/Shell.tsx:2337
+#: src/pages/Shell.tsx:2903
 msgid "Take control"
 msgstr "Take control"
 
@@ -2293,7 +2297,7 @@ msgstr "Take control"
 msgid "Teach a task"
 msgstr "Teach a task"
 
-#: src/pages/Shell.tsx:2158
+#: src/pages/Shell.tsx:2170
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Teaching in progress — stop teaching before sending a new message."
 
@@ -2301,11 +2305,11 @@ msgstr "Teaching in progress — stop teaching before sending a new message."
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4194
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5028
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -2318,20 +2322,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "The selected memory provider is not available in this build."
 
-#: src/pages/Shell.tsx:4471
+#: src/pages/Shell.tsx:4483
 msgid "Thinking"
 msgstr "Thinking"
 
-#: src/pages/Shell.tsx:2269
+#: src/pages/Shell.tsx:2281
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:2927
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 
-#: src/pages/Shell.tsx:4866
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4878
+#: src/pages/Shell.tsx:4955
 msgid "This cannot be undone."
 msgstr "This cannot be undone."
 
@@ -2355,7 +2359,7 @@ msgstr "this Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 
-#: src/pages/Shell.tsx:4751
+#: src/pages/Shell.tsx:4763
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 
@@ -2363,7 +2367,7 @@ msgstr "This permanently removes every message and stops current work. The bot, 
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "This provider cannot paste a key here. Skip if this deployment already has credentials."
 
-#: src/pages/Shell.tsx:5283
+#: src/pages/Shell.tsx:5295
 msgid "This server cannot be assigned without a bot."
 msgstr "This server cannot be assigned without a bot."
 
@@ -2375,7 +2379,7 @@ msgstr "This server did not request browser authorization."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "This server is already connected. Disconnect it first to authorize again."
 
-#: src/pages/Shell.tsx:5322
+#: src/pages/Shell.tsx:5334
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 
@@ -2388,8 +2392,8 @@ msgid "Time of day"
 msgstr "Time of day"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4249
-#: src/pages/Shell.tsx:4412
+#: src/pages/Shell.tsx:4261
+#: src/pages/Shell.tsx:4424
 msgid "Title"
 msgstr "Title"
 
@@ -2445,7 +2449,7 @@ msgid "Verifying…"
 msgstr "Verifying…"
 
 #: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4524
+#: src/pages/Shell.tsx:4536
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2458,7 +2462,7 @@ msgstr "Voice"
 msgid "Waiting for sign-in…"
 msgstr "Waiting for sign-in…"
 
-#: src/pages/Shell.tsx:5166
+#: src/pages/Shell.tsx:5178
 msgid "Waiting…"
 msgstr "Waiting…"
 
@@ -2467,7 +2471,7 @@ msgstr "Waiting…"
 msgid "Weekdays"
 msgstr "Weekdays"
 
-#: src/pages/Shell.tsx:4836
+#: src/pages/Shell.tsx:4848
 msgid "What about its memories?"
 msgstr "What about its memories?"
 
@@ -2476,7 +2480,7 @@ msgid "What result will you demonstrate?"
 msgstr "What result will you demonstrate?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4264
+#: src/pages/Shell.tsx:4276
 msgid "What this bot is for"
 msgstr "What this bot is for"
 
@@ -2488,7 +2492,7 @@ msgstr "What to return"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 
-#: src/pages/Shell.tsx:2512
+#: src/pages/Shell.tsx:2524
 msgid "When to run"
 msgstr "When to run"
 
@@ -2505,7 +2509,7 @@ msgstr "Where should bots run?"
 msgid "Working…"
 msgstr "Working…"
 
-#: src/pages/Shell.tsx:4454
+#: src/pages/Shell.tsx:4466
 msgid "Workspace default"
 msgstr "Workspace default"
 
@@ -2522,8 +2526,8 @@ msgstr "You can close this tab if it does not redirect automatically."
 msgid "You can close this window."
 msgstr "You can close this window."
 
-#: src/pages/Shell.tsx:2302
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2314
+#: src/pages/Shell.tsx:2868
 msgid "You have control"
 msgstr "You have control"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5139
+#: src/pages/Shell.tsx:5151
 msgid "{0} connection"
 msgstr "{0} 연결"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2306
+#: src/pages/Shell.tsx:2318
 msgid "{0} is using it"
 msgstr "{0}가 사용 중"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {동료 Bot #개} other {동료 Bot #개}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName}은 아직 다른 Bot에게 메시지를 보내지 않았습니다."
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5028
 msgid "{botName}’s computer"
 msgstr "{botName}의 컴퓨터"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3327
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "액세스 토큰(선택 사항)"
 msgid "Account"
 msgstr "계정"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4542
 msgid "Account default"
 msgstr "계정 기본값"
 
@@ -216,7 +216,7 @@ msgstr "추가 중…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4433
+#: src/pages/Shell.tsx:4445
 msgid "Advanced"
 msgstr "고급 설정"
 
@@ -311,11 +311,11 @@ msgstr "서버를 추가할 때 적용됩니다. 각 서버 카드의 Bot 버튼
 msgid "Approval boundaries"
 msgstr "승인이 필요한 범위"
 
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5344
 msgid "Approve"
 msgstr "승인"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5335
 msgid "Approve this server to let your agent use its tools."
 msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 있습니다."
 
@@ -327,7 +327,7 @@ msgstr "앱"
 msgid "Archive"
 msgstr "보관"
 
-#: src/pages/Shell.tsx:3981
+#: src/pages/Shell.tsx:3993
 msgid "archived"
 msgstr "보관됨"
 
@@ -335,7 +335,7 @@ msgstr "보관됨"
 msgid "Archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:3992
+#: src/pages/Shell.tsx:4004
 msgid "Archived. Chat, memory, and files kept."
 msgstr "보관되었습니다. 대화, 기억, 파일은 유지됩니다."
 
@@ -374,7 +374,7 @@ msgstr "결제하기 전에 확인"
 msgid "Ask before sending external email"
 msgstr "외부 이메일을 보내기 전에 확인"
 
-#: src/pages/Shell.tsx:2308
+#: src/pages/Shell.tsx:2320
 msgid "Asleep"
 msgstr "절전 중"
 
@@ -389,11 +389,11 @@ msgstr "{0}에"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}에"
 
-#: src/pages/Shell.tsx:3389
+#: src/pages/Shell.tsx:3398
 msgid "Attach file"
 msgstr "파일 첨부"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3597
 msgid "Attachment"
 msgstr "첨부 파일"
 
@@ -406,12 +406,12 @@ msgstr "인증 코드 또는 돌아온 페이지 주소"
 msgid "Authorization expired — reconnect required"
 msgstr "인증이 만료됨 — 다시 연결해야 함"
 
-#: src/pages/Shell.tsx:5124
+#: src/pages/Shell.tsx:5136
 msgid "Authorization timed out. Please try again."
 msgstr "인증 시간이 만료되었습니다. 다시 시도해 주세요."
 
-#: src/pages/Shell.tsx:5166
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5178
+#: src/pages/Shell.tsx:5344
 msgid "Authorize"
 msgstr "인증하기"
 
@@ -423,18 +423,18 @@ msgstr "서버 주소"
 msgid "Bearer token"
 msgstr "Bearer 토큰"
 
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:5020
 msgid "Booting live desktop…"
 msgstr "라이브 데스크톱 시작 중…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2843
 msgid "Booting up {0}’s computer"
 msgstr "{0}의 컴퓨터를 켜는 중"
 
-#: src/pages/Shell.tsx:3851
-#: src/pages/Shell.tsx:3852
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:3863
+#: src/pages/Shell.tsx:3864
+#: src/pages/Shell.tsx:3997
 msgid "bot"
 msgstr "Bot"
 
@@ -446,11 +446,11 @@ msgstr "봇"
 msgid "Bot messages"
 msgstr "Bot 메시지"
 
-#: src/pages/Shell.tsx:2923
+#: src/pages/Shell.tsx:2935
 msgid "Bot screen"
 msgstr "Bot 화면"
 
-#: src/pages/Shell.tsx:2276
+#: src/pages/Shell.tsx:2288
 msgid "Bot screen preview"
 msgstr "Bot 화면 미리보기"
 
@@ -475,14 +475,14 @@ msgstr "서버에 연결할 수 없습니다."
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4692
-#: src/pages/Shell.tsx:4764
-#: src/pages/Shell.tsx:4879
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4704
+#: src/pages/Shell.tsx:4776
+#: src/pages/Shell.tsx:4891
+#: src/pages/Shell.tsx:4965
 msgid "Cancel"
 msgstr "취소"
 
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:4241
 msgid "Cancel new bot"
 msgstr "새 Bot 만들기 취소"
 
@@ -490,7 +490,7 @@ msgstr "새 Bot 만들기 취소"
 msgid "Cancel new group"
 msgstr "새 그룹 만들기 취소"
 
-#: src/pages/Shell.tsx:3265
+#: src/pages/Shell.tsx:3274
 msgid "Cancel reply"
 msgstr "답장 취소"
 
@@ -498,16 +498,16 @@ msgstr "답장 취소"
 msgid "Cancelled"
 msgstr "취소됨"
 
-#: src/pages/Shell.tsx:5229
+#: src/pages/Shell.tsx:5241
 msgid "Chart failed to render: {error}"
 msgstr "차트를 표시하지 못했습니다: {error}"
 
-#: src/pages/Shell.tsx:3531
+#: src/pages/Shell.tsx:3540
 msgid "Chat Settings"
 msgstr "채팅 설정"
 
-#: src/pages/Shell.tsx:2542
-#: src/pages/Shell.tsx:2549
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2561
 msgid "Check in."
 msgstr "확인해 주세요."
 
@@ -519,21 +519,21 @@ msgstr "먼저 사용할 AI 모델을 선택하세요."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo에서 기본으로 사용할 연결된 모델을 선택하세요."
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4791
 msgid "Clear"
 msgstr "비우기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4745
+#: src/pages/Shell.tsx:4757
 msgid "Clear {0}’s conversation?"
 msgstr "{0}와의 대화 내용을 비울까요?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4585
+#: src/pages/Shell.tsx:4597
 msgid "Clear conversation"
 msgstr "대화 내용 비우기"
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4791
 msgid "Clearing…"
 msgstr "비우는 중…"
 
@@ -549,15 +549,15 @@ msgstr "Bot 메뉴 닫기"
 msgid "Close bot messages"
 msgstr "Bot 메시지 닫기"
 
-#: src/pages/Shell.tsx:5414
+#: src/pages/Shell.tsx:5426
 msgid "Close chart"
 msgstr "차트 닫기"
 
-#: src/pages/Shell.tsx:2897
+#: src/pages/Shell.tsx:2909
 msgid "Close computer"
 msgstr "컴퓨터 닫기"
 
-#: src/pages/Shell.tsx:5514
+#: src/pages/Shell.tsx:5526
 msgid "Close image preview"
 msgstr "이미지 미리보기 닫기"
 
@@ -581,7 +581,7 @@ msgstr "AI 모델 설정 닫기"
 msgid "Close navigation"
 msgstr "메뉴 닫기"
 
-#: src/pages/Shell.tsx:2254
+#: src/pages/Shell.tsx:2266
 msgid "Close panel"
 msgstr "패널 닫기"
 
@@ -610,24 +610,24 @@ msgstr "실행 명령"
 msgid "Complete"
 msgstr "완료"
 
-#: src/pages/Shell.tsx:4139
-#: src/pages/Shell.tsx:4167
+#: src/pages/Shell.tsx:4151
+#: src/pages/Shell.tsx:4179
 msgid "Computer"
 msgstr "컴퓨터"
 
-#: src/pages/Shell.tsx:5011
+#: src/pages/Shell.tsx:5023
 msgid "Computer failed to boot"
 msgstr "컴퓨터를 시작하지 못했습니다"
 
-#: src/pages/Shell.tsx:2945
+#: src/pages/Shell.tsx:2957
 msgid "Computer is asleep"
 msgstr "컴퓨터가 절전 상태입니다"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5022
 msgid "Computer is asleep — take control to wake it"
 msgstr "컴퓨터가 절전 상태입니다 — 제어를 맡아 깨우세요"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5024
 msgid "Computer is stopped"
 msgstr "컴퓨터가 중지됨"
 
@@ -665,7 +665,7 @@ msgstr "앱을 연결하거나 Treg, MCP, OpenAPI 도구를 추가하세요."
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI 또는 Cartesia 연결"
 
-#: src/pages/Shell.tsx:5312
+#: src/pages/Shell.tsx:5324
 msgid "Connect MCP server “{name}”"
 msgstr "MCP 서버 ‘{name}’ 연결"
 
@@ -689,12 +689,12 @@ msgstr "Treg 연결"
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
 #: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5163
+#: src/pages/Shell.tsx:5175
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "연결됨"
 
-#: src/pages/Shell.tsx:5342
+#: src/pages/Shell.tsx:5354
 msgid "Connected — its tools are available from your next message."
 msgstr "연결되었습니다. 다음 메시지부터 이 도구를 사용할 수 있습니다."
 
@@ -720,7 +720,7 @@ msgstr "{0}에 연결하고 기본 모델로 설정했습니다."
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
 #: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5344
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "연결 중…"
@@ -739,7 +739,7 @@ msgstr "계속"
 msgid "Continue with email"
 msgstr "이메일로 계속하기"
 
-#: src/pages/Shell.tsx:3639
+#: src/pages/Shell.tsx:3648
 msgid "Copy"
 msgstr "복사"
 
@@ -751,11 +751,11 @@ msgstr "추가하지 못했습니다."
 msgid "Could not add MCP server"
 msgstr "MCP 서버를 추가하지 못했습니다."
 
-#: src/pages/Shell.tsx:5299
+#: src/pages/Shell.tsx:5311
 msgid "Could not approve this server"
 msgstr "서버를 승인하지 못했습니다."
 
-#: src/pages/Shell.tsx:5127
+#: src/pages/Shell.tsx:5139
 msgid "Could not authorize this app"
 msgstr "앱 인증을 완료하지 못했습니다."
 
@@ -763,7 +763,7 @@ msgstr "앱 인증을 완료하지 못했습니다."
 msgid "Could not change the default model"
 msgstr "기본 모델을 변경하지 못했습니다."
 
-#: src/pages/Shell.tsx:4773
+#: src/pages/Shell.tsx:4785
 msgid "Could not clear conversation"
 msgstr "대화 내용을 비우지 못했습니다."
 
@@ -792,7 +792,7 @@ msgstr "음성 서비스에 연결하지 못했습니다."
 msgid "Could not continue"
 msgstr "계속 진행하지 못했습니다."
 
-#: src/pages/Shell.tsx:4217
+#: src/pages/Shell.tsx:4229
 msgid "Could not create bot"
 msgstr "Bot을 만들지 못했습니다."
 
@@ -800,7 +800,7 @@ msgstr "Bot을 만들지 못했습니다."
 msgid "Could not create group"
 msgstr "그룹을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4676
 msgid "Could not create section"
 msgstr "섹션을 만들지 못했습니다."
 
@@ -808,7 +808,7 @@ msgstr "섹션을 만들지 못했습니다."
 msgid "Could not create your bot"
 msgstr "Bot을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4888
+#: src/pages/Shell.tsx:4900
 msgid "Could not delete bot"
 msgstr "Bot을 삭제하지 못했습니다."
 
@@ -816,7 +816,7 @@ msgstr "Bot을 삭제하지 못했습니다."
 msgid "Could not delete MCP server"
 msgstr "MCP 서버를 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4962
+#: src/pages/Shell.tsx:4974
 msgid "Could not delete routine"
 msgstr "자동 실행을 삭제하지 못했습니다."
 
@@ -890,7 +890,7 @@ msgstr "그룹을 삭제하지 못했습니다."
 msgid "Could not remove rule"
 msgstr "확인 규칙을 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:5219
+#: src/pages/Shell.tsx:5231
 msgid "Could not render chart"
 msgstr "차트를 만들지 못했습니다."
 
@@ -898,7 +898,7 @@ msgstr "차트를 만들지 못했습니다."
 msgid "Could not revoke connection"
 msgstr "연결을 해제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4570
+#: src/pages/Shell.tsx:4582
 msgid "Could not save"
 msgstr "저장하지 못했습니다."
 
@@ -910,7 +910,7 @@ msgstr "그룹을 저장하지 못했습니다."
 msgid "Could not save model"
 msgstr "AI 모델을 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:2564
+#: src/pages/Shell.tsx:2576
 msgid "Could not save routine"
 msgstr "자동 실행을 저장하지 못했습니다."
 
@@ -926,7 +926,7 @@ msgstr "선택 내용을 저장하지 못했습니다."
 msgid "Could not save that voice"
 msgstr "목소리를 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:5039
+#: src/pages/Shell.tsx:5051
 msgid "Could not save this choice"
 msgstr "선택 내용을 저장하지 못했습니다."
 
@@ -959,13 +959,13 @@ msgid "Could not update the default memory scope"
 msgstr "기본 기억 범위를 변경하지 못했습니다."
 
 #: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4288
+#: src/pages/Shell.tsx:4711
 msgid "Create"
 msgstr "만들기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4673
+#: src/pages/Shell.tsx:4685
 msgid "Create a section and move {0} into it."
 msgstr "새 섹션을 만들고 {0}을 옮깁니다."
 
@@ -986,8 +986,8 @@ msgid "Create your Rakazo"
 msgstr "Rakazo 계정 만들기"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4288
+#: src/pages/Shell.tsx:4711
 msgid "Creating…"
 msgstr "만드는 중…"
 
@@ -1015,7 +1015,7 @@ msgstr "일"
 msgid "days"
 msgstr "일"
 
-#: src/pages/Shell.tsx:4477
+#: src/pages/Shell.tsx:4489
 msgid "Default (medium)"
 msgstr "기본(보통)"
 
@@ -1026,8 +1026,8 @@ msgstr "기본 기억 범위"
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
 #: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4906
+#: src/pages/Shell.tsx:4980
 msgid "Delete"
 msgstr "삭제"
 
@@ -1038,8 +1038,8 @@ msgstr "{0} 삭제"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4826
-#: src/pages/Shell.tsx:4940
+#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4952
 msgid "Delete {0}?"
 msgstr "{0}을 삭제할까요?"
 
@@ -1047,21 +1047,21 @@ msgstr "{0}을 삭제할까요?"
 msgid "Delete group"
 msgstr "그룹 삭제"
 
-#: src/pages/Shell.tsx:4863
+#: src/pages/Shell.tsx:4875
 msgid "Delete memories too"
 msgstr "기억도 함께 삭제"
 
-#: src/pages/Shell.tsx:2619
+#: src/pages/Shell.tsx:2631
 msgid "Delete routine"
 msgstr "자동 실행 삭제"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:3995
 msgid "deleted"
 msgstr "삭제됨"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4906
+#: src/pages/Shell.tsx:4980
 msgid "Deleting…"
 msgstr "삭제 중…"
 
@@ -1078,17 +1078,17 @@ msgid "Deployment default"
 msgstr "서버 기본값"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4254
+#: src/pages/Shell.tsx:4266
 msgid "Describe what this bot does"
 msgstr "이 Bot이 하는 일을 짧게 설명하세요"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4259
-#: src/pages/Shell.tsx:4421
+#: src/pages/Shell.tsx:4271
+#: src/pages/Shell.tsx:4433
 msgid "Description"
 msgstr "설명"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3407
 msgid "Dictate"
 msgstr "음성 입력"
 
@@ -1101,7 +1101,7 @@ msgstr "연결 해제"
 msgid "Disconnecting…"
 msgstr "연결 해제 중…"
 
-#: src/pages/Shell.tsx:5347
+#: src/pages/Shell.tsx:5359
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "지금은 연결하지 않았습니다. MCP 설정에서 언제든 다시 연결할 수 있습니다."
 
@@ -1148,6 +1148,10 @@ msgstr "작업 기술 초안"
 #: src/pages/BotContextMenu.tsx:99
 msgid "Duplicate"
 msgstr "복제"
+
+#: src/pages/Shell.tsx:3808
+msgid "Earlier message"
+msgstr "이전 메시지"
 
 #: src/components/AskCard.tsx:149
 msgid "Edit first"
@@ -1201,11 +1205,11 @@ msgstr "매월"
 msgid "Every week"
 msgstr "매주"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5405
 msgid "Expand"
 msgstr "펼치기"
 
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4594
 msgid "Export"
 msgstr "내보내기"
 
@@ -1213,7 +1217,7 @@ msgstr "내보내기"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "CRM에서 이번 주 목록을 내려받아 공유 폴더에 넣기"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4609
 msgid "Extra high"
 msgstr "매우 높음"
 
@@ -1261,7 +1265,7 @@ msgid "Fullscreen"
 msgstr "전체 화면"
 
 #: src/pages/Shell.tsx:2086
-#: src/pages/Shell.tsx:2236
+#: src/pages/Shell.tsx:2248
 msgid "Group"
 msgstr "그룹"
 
@@ -1290,15 +1294,15 @@ msgstr "샘플 듣기"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "안녕하세요. 답변을 소리 내어 읽을 때 이런 목소리로 들립니다."
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4612
 msgid "High"
 msgstr "높음"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3426
 msgid "Hold to talk"
 msgstr "누르고 말하기"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3426
 msgid "Hold to talk (on-device dictation)"
 msgstr "누르고 말하기(기기 내 음성 인식)"
 
@@ -1318,7 +1322,7 @@ msgstr "실행 주기"
 msgid "How to check"
 msgstr "완료 확인 방법"
 
-#: src/pages/Shell.tsx:3695
+#: src/pages/Shell.tsx:3704
 msgid "I’m done"
 msgstr "조작 끝내기"
 
@@ -1330,7 +1334,7 @@ msgstr "샘플이 들렸다면 음성 설정이 완료되었습니다."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON 가져오기"
 
-#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4504
 msgid "Inherit default"
 msgstr "기본 설정 사용"
 
@@ -1342,7 +1346,7 @@ msgstr "입력값"
 msgid "Instance API key"
 msgstr "인스턴스 API 키"
 
-#: src/pages/Shell.tsx:2503
+#: src/pages/Shell.tsx:2515
 msgid "Instruction"
 msgstr "실행할 내용"
 
@@ -1372,15 +1376,15 @@ msgid "Interval unit"
 msgstr "간격 단위"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4505
 msgid "Isolated"
 msgstr "이 Bot만 사용"
 
-#: src/pages/Shell.tsx:4829
+#: src/pages/Shell.tsx:4841
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만든 다른 Bot은 목록에 남습니다."
 
-#: src/pages/Shell.tsx:3791
+#: src/pages/Shell.tsx:3803
 msgid "Jump to replied message"
 msgstr "답장한 메시지로 이동"
 
@@ -1388,7 +1392,7 @@ msgstr "답장한 메시지로 이동"
 msgid "just now"
 msgstr "방금"
 
-#: src/pages/Shell.tsx:4847
+#: src/pages/Shell.tsx:4859
 msgid "Keep memories"
 msgstr "기억은 유지"
 
@@ -1406,7 +1410,7 @@ msgstr "언어"
 msgid "Listening…"
 msgstr "듣는 중…"
 
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3031
 msgid "Load earlier messages"
 msgstr "이전 메시지 불러오기"
 
@@ -1446,7 +1450,7 @@ msgstr "음성 서비스를 불러오는 중…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3031
 msgid "Loading…"
 msgstr "불러오는 중…"
 
@@ -1458,7 +1462,7 @@ msgstr "로컬"
 msgid "Log out"
 msgstr "로그아웃"
 
-#: src/pages/Shell.tsx:4598
+#: src/pages/Shell.tsx:4610
 msgid "Low"
 msgstr "낮음"
 
@@ -1474,7 +1478,7 @@ msgstr "읽음으로 표시"
 msgid "Mark as Unread"
 msgstr "읽지 않음으로 표시"
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4614
 msgid "Max"
 msgstr "최대"
 
@@ -1484,7 +1488,7 @@ msgstr "최대"
 msgid "MCP servers"
 msgstr "MCP 서버"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4611
 msgid "Medium"
 msgstr "보통"
 
@@ -1501,29 +1505,29 @@ msgstr "참여 Bot ({GROUP_MEMBER_MIN}~{GROUP_MEMBER_MAX}개 선택)"
 msgid "Memory"
 msgstr "기억"
 
-#: src/pages/Shell.tsx:4488
+#: src/pages/Shell.tsx:4500
 msgid "Memory scope"
 msgstr "기억 사용 범위"
 
-#: src/pages/Shell.tsx:3495
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3504
+#: src/pages/Shell.tsx:3599
 msgid "Message"
 msgstr "메시지"
 
-#: src/pages/Shell.tsx:3491
-#: src/pages/Shell.tsx:3495
+#: src/pages/Shell.tsx:3500
+#: src/pages/Shell.tsx:3504
 msgid "Message {activeName}"
 msgstr "{activeName}에게 메시지 보내기"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3881
 msgid "Message from {peer}"
 msgstr "{peer}의 메시지"
 
-#: src/pages/Shell.tsx:3492
+#: src/pages/Shell.tsx:3501
 msgid "Message…"
 msgstr "메시지를 입력하세요"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3881
 msgid "Messaged {peer}"
 msgstr "{peer}에게 메시지 보냄"
 
@@ -1531,7 +1535,7 @@ msgstr "{peer}에게 메시지 보냄"
 msgid "Microphone failed"
 msgstr "마이크를 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4613
 msgid "Minimal"
 msgstr "최소"
 
@@ -1553,7 +1557,7 @@ msgstr "분"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4444
+#: src/pages/Shell.tsx:4456
 msgid "Model"
 msgstr "모델"
 
@@ -1593,7 +1597,7 @@ msgstr "매월"
 msgid "Move {0} to section"
 msgstr "{0} 섹션 이동"
 
-#: src/pages/Shell.tsx:4850
+#: src/pages/Shell.tsx:4862
 msgid "Move them to your shared memory."
 msgstr "공용 기억으로 옮깁니다."
 
@@ -1606,15 +1610,15 @@ msgstr "섹션으로 이동"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4239
-#: src/pages/Shell.tsx:4403
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:2507
+#: src/pages/Shell.tsx:4251
+#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4688
 msgid "Name"
 msgstr "이름"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4244
+#: src/pages/Shell.tsx:4256
 msgid "Name this bot"
 msgstr "Bot 이름"
 
@@ -1631,7 +1635,7 @@ msgid "Needs takeover"
 msgstr "인수 필요"
 
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4227
+#: src/pages/Shell.tsx:4239
 msgid "New bot"
 msgstr "새 Bot 만들기"
 
@@ -1644,12 +1648,12 @@ msgstr "새 그룹 만들기"
 msgid "New open-work item"
 msgstr "새 진행 작업"
 
-#: src/pages/Shell.tsx:2385
+#: src/pages/Shell.tsx:2397
 msgid "New routine"
 msgstr "새 자동 실행"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4670
+#: src/pages/Shell.tsx:4682
 msgid "New section"
 msgstr "새 섹션"
 
@@ -1724,7 +1728,7 @@ msgstr "설정되지 않음"
 msgid "Not connected"
 msgstr "연결되지 않음"
 
-#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5347
 msgid "Not now"
 msgstr "나중에"
 
@@ -1762,11 +1766,11 @@ msgstr "매월 1일 {0}에"
 msgid "Open"
 msgstr "열기"
 
-#: src/pages/Shell.tsx:2295
+#: src/pages/Shell.tsx:2307
 msgid "Open computer"
 msgstr "컴퓨터 열기"
 
-#: src/pages/Shell.tsx:2265
+#: src/pages/Shell.tsx:2277
 msgid "Open in full window"
 msgstr "전체 창으로 열기"
 
@@ -1787,7 +1791,7 @@ msgstr "진행 중인 작업"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 호환 서버 주소"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4006
 msgid "Opened its thread."
 msgstr "대화가 만들어졌습니다."
 
@@ -1870,7 +1874,7 @@ msgstr "재생 중…"
 msgid "Preview {0}"
 msgstr "{0} 미리보기"
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4194
 msgid "Private"
 msgstr "Bot 전용"
 
@@ -1891,7 +1895,7 @@ msgstr "대기 중"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo는 저장하기 전에 연결 상태를 확인합니다. 인증 정보는 암호화되며 앱이나 AI 모델에 노출되지 않습니다."
 
-#: src/pages/Shell.tsx:4520
+#: src/pages/Shell.tsx:4532
 msgid "Read replies aloud"
 msgstr "답변을 자동으로 읽기"
 
@@ -1913,7 +1917,7 @@ msgstr "다시 연결 중"
 msgid "Recording: {0}"
 msgstr "녹화 중: {0}"
 
-#: src/pages/Shell.tsx:3685
+#: src/pages/Shell.tsx:3694
 msgid "Release"
 msgstr "제어권 돌려주기"
 
@@ -1924,17 +1928,17 @@ msgid "Remove"
 msgstr "삭제"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3299
+#: src/pages/Shell.tsx:3308
 msgid "Remove {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3454
+#: src/pages/Shell.tsx:3463
 msgid "Remove mention {0}"
 msgstr "{0} 멘션 삭제"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3433
+#: src/pages/Shell.tsx:3442
 msgid "Remove skill {0}"
 msgstr "작업 기술 {0} 삭제"
 
@@ -1942,7 +1946,7 @@ msgstr "작업 기술 {0} 삭제"
 msgid "Remove this schedule"
 msgstr "이 일정 삭제"
 
-#: src/pages/Shell.tsx:3993
+#: src/pages/Shell.tsx:4005
 msgid "Removed with chat, computer, and memory."
 msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 
@@ -1968,11 +1972,11 @@ msgstr "API 키 교체"
 msgid "Replace key"
 msgstr "키 교체"
 
-#: src/pages/Shell.tsx:3631
+#: src/pages/Shell.tsx:3640
 msgid "Reply"
 msgstr "답장"
 
-#: src/pages/Shell.tsx:3262
+#: src/pages/Shell.tsx:3271
 msgid "Replying to {replyName}"
 msgstr "{replyName}에게 답장"
 
@@ -1996,17 +2000,17 @@ msgstr "연결 해제"
 msgid "Revoking…"
 msgstr "연결 해제 중…"
 
-#: src/pages/Shell.tsx:2488
-#: src/pages/Shell.tsx:2541
-#: src/pages/Shell.tsx:2548
+#: src/pages/Shell.tsx:2500
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2560
 msgid "Routine"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2342
 msgid "Routines"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2623
 msgid "Run now"
 msgstr "지금 실행"
 
@@ -2014,11 +2018,11 @@ msgstr "지금 실행"
 msgid "Running"
 msgstr "실행 중"
 
-#: src/pages/Shell.tsx:2370
+#: src/pages/Shell.tsx:2382
 msgid "Running · Stop"
 msgstr "실행 중 · 중지"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2623
 msgid "Running…"
 msgstr "실행 중…"
 
@@ -2026,8 +2030,8 @@ msgstr "실행 중…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4575
+#: src/pages/Shell.tsx:2599
+#: src/pages/Shell.tsx:4587
 msgid "Save"
 msgstr "저장"
 
@@ -2051,7 +2055,7 @@ msgstr "저장되었습니다."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2599
 msgid "Saving…"
 msgstr "저장 중…"
 
@@ -2090,7 +2094,7 @@ msgstr "검색 중…"
 msgid "Select a bot"
 msgstr "대화할 Bot을 선택하세요"
 
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3524
 msgid "Send"
 msgstr "보내기"
 
@@ -2125,15 +2129,15 @@ msgstr "통화하려면 음성을 먼저 설정하세요"
 #: src/pages/AccountSettingsOverlay.tsx:79
 #: src/pages/Shell.tsx:1961
 #: src/pages/Shell.tsx:1971
-#: src/pages/Shell.tsx:2232
+#: src/pages/Shell.tsx:2244
 msgid "Settings"
 msgstr "설정"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3542
 msgid "Settings: General"
 msgstr "설정: 일반"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3544
 msgid "Settings: Usage"
 msgstr "설정: 사용량"
 
@@ -2143,15 +2147,15 @@ msgid "Setup help"
 msgstr "설정 도움말"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4506
 msgid "Shared"
 msgstr "함께 사용"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2255
 msgid "Show computer"
 msgstr "컴퓨터 보기"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2255
 msgid "Show settings"
 msgstr "설정 보기"
 
@@ -2175,11 +2179,11 @@ msgid "Sign up"
 msgstr "가입하기"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3346
+#: src/pages/Shell.tsx:3355
 msgid "Skill {0}"
 msgstr "작업 기술 {0}"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3701
 msgid "Skip"
 msgstr "건너뛰기"
 
@@ -2200,8 +2204,8 @@ msgstr "{0} 건너뜀"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space: 끼어들기 · Esc: 통화 종료"
 
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3850
+#: src/pages/Shell.tsx:4103
 msgid "Speak"
 msgstr "읽기"
 
@@ -2213,8 +2217,8 @@ msgstr "음성 출력·받아쓰기"
 msgid "Speak only"
 msgstr "음성 출력만"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3846
+#: src/pages/Shell.tsx:4099
 msgid "Speak this reply"
 msgstr "이 답변 읽기"
 
@@ -2240,20 +2244,20 @@ msgstr "시작하는 중…"
 msgid "Steps"
 msgstr "실행 단계"
 
-#: src/pages/Shell.tsx:2866
-#: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3506
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:2878
+#: src/pages/Shell.tsx:2882
+#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3850
+#: src/pages/Shell.tsx:4103
 msgid "Stop"
 msgstr "중지"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3407
 msgid "Stop dictation"
 msgstr "음성 입력 중지"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3846
+#: src/pages/Shell.tsx:4099
 msgid "Stop speaking"
 msgstr "읽기 중지"
 
@@ -2262,8 +2266,8 @@ msgstr "읽기 중지"
 msgid "Stop teaching"
 msgstr "가르치기 종료"
 
-#: src/pages/Shell.tsx:2322
-#: src/pages/Shell.tsx:2886
+#: src/pages/Shell.tsx:2334
+#: src/pages/Shell.tsx:2898
 msgid "Stop the bot first"
 msgstr "먼저 Bot을 중지하세요"
 
@@ -2271,7 +2275,7 @@ msgstr "먼저 Bot을 중지하세요"
 msgid "Stored encrypted"
 msgstr "암호화해 저장"
 
-#: src/pages/Shell.tsx:3945
+#: src/pages/Shell.tsx:3957
 msgid "subagent"
 msgstr "보조 에이전트"
 
@@ -2284,8 +2288,8 @@ msgstr "확인"
 msgid "Switching…"
 msgstr "전환 중…"
 
-#: src/pages/Shell.tsx:2325
-#: src/pages/Shell.tsx:2891
+#: src/pages/Shell.tsx:2337
+#: src/pages/Shell.tsx:2903
 msgid "Take control"
 msgstr "직접 조작"
 
@@ -2293,7 +2297,7 @@ msgstr "직접 조작"
 msgid "Teach a task"
 msgstr "작업 가르치기"
 
-#: src/pages/Shell.tsx:2158
+#: src/pages/Shell.tsx:2170
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼저 가르치기를 종료하세요."
 
@@ -2301,11 +2305,11 @@ msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼�
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "작업을 가르치려면 화면이 있는 샌드박스 컴퓨터가 필요합니다. 내 컴퓨터에서 실행되는 Bot은 터미널 작업은 가능하지만 화면 녹화는 할 수 없습니다."
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4194
 msgid "Team"
 msgstr "팀 공용"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5028
 msgid "Team Computer"
 msgstr "팀 컴퓨터"
 
@@ -2318,20 +2322,20 @@ msgstr "시험 실행"
 msgid "The selected memory provider is not available in this build."
 msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4471
+#: src/pages/Shell.tsx:4483
 msgid "Thinking"
 msgstr "생각 깊이"
 
-#: src/pages/Shell.tsx:2269
+#: src/pages/Shell.tsx:2281
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "이 Bot은 별도 Linux 화면이 아니라 현재 컴퓨터에서 실행됩니다. 터미널과 파일 작업은 홈 폴더를 사용합니다."
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:2927
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "이 Bot은 현재 컴퓨터에서 실행되며 별도 Linux 화면은 없습니다. 터미널을 사용하도록 요청할 수 있고 홈 폴더 아래에서 작업합니다."
 
-#: src/pages/Shell.tsx:4866
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4878
+#: src/pages/Shell.tsx:4955
 msgid "This cannot be undone."
 msgstr "이 작업은 되돌릴 수 없습니다."
 
@@ -2355,7 +2359,7 @@ msgstr "이 Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "이 Mac에서는 홈 폴더의 파일을 포함해 내 계정 권한으로 터미널 명령을 실행합니다. 여러 사람이 쓰거나 공개된 서버에서는 사용하지 마세요."
 
-#: src/pages/Shell.tsx:4751
+#: src/pages/Shell.tsx:4763
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지합니다. Bot, 컴퓨터, 기억, 자동 실행은 그대로 유지됩니다."
 
@@ -2363,7 +2367,7 @@ msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지�
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "이 서비스는 여기에서 API 키를 입력할 수 없습니다. 서버에 이미 인증 정보가 있다면 건너뛰세요."
 
-#: src/pages/Shell.tsx:5283
+#: src/pages/Shell.tsx:5295
 msgid "This server cannot be assigned without a bot."
 msgstr "연결할 Bot이 없어 이 서버를 배정할 수 없습니다."
 
@@ -2375,7 +2379,7 @@ msgstr "이 서버는 브라우저 인증을 요청하지 않았습니다."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "이 서버는 이미 연결되어 있습니다. 다시 인증하려면 먼저 연결을 해제하세요."
 
-#: src/pages/Shell.tsx:5322
+#: src/pages/Shell.tsx:5334
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "이 서버는 브라우저 로그인이 필요합니다. 인증을 누르면 새 창이 열리고, 완료 후 Bot이 도구를 사용할 수 있습니다."
 
@@ -2388,8 +2392,8 @@ msgid "Time of day"
 msgstr "실행 시각"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4249
-#: src/pages/Shell.tsx:4412
+#: src/pages/Shell.tsx:4261
+#: src/pages/Shell.tsx:4424
 msgid "Title"
 msgstr "역할"
 
@@ -2445,7 +2449,7 @@ msgid "Verifying…"
 msgstr "확인 중…"
 
 #: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4524
+#: src/pages/Shell.tsx:4536
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2458,7 +2462,7 @@ msgstr "음성"
 msgid "Waiting for sign-in…"
 msgstr "로그인 완료를 기다리는 중…"
 
-#: src/pages/Shell.tsx:5166
+#: src/pages/Shell.tsx:5178
 msgid "Waiting…"
 msgstr "기다리는 중…"
 
@@ -2467,7 +2471,7 @@ msgstr "기다리는 중…"
 msgid "Weekdays"
 msgstr "주중"
 
-#: src/pages/Shell.tsx:4836
+#: src/pages/Shell.tsx:4848
 msgid "What about its memories?"
 msgstr "이 Bot의 기억은 어떻게 할까요?"
 
@@ -2476,7 +2480,7 @@ msgid "What result will you demonstrate?"
 msgstr "어떤 작업을 직접 보여줄까요?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4264
+#: src/pages/Shell.tsx:4276
 msgid "What this bot is for"
 msgstr "이 Bot을 언제, 어떤 일에 사용할지 적어주세요"
 
@@ -2488,7 +2492,7 @@ msgstr "완료 후 전달할 결과"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "{botName}이 다른 Bot에게 메시지를 보내면 대화 대신 여기에 표시됩니다."
 
-#: src/pages/Shell.tsx:2512
+#: src/pages/Shell.tsx:2524
 msgid "When to run"
 msgstr "실행 시간"
 
@@ -2505,7 +2509,7 @@ msgstr "Bot을 어디에서 실행할까요?"
 msgid "Working…"
 msgstr "처리 중…"
 
-#: src/pages/Shell.tsx:4454
+#: src/pages/Shell.tsx:4466
 msgid "Workspace default"
 msgstr "작업공간 기본값"
 
@@ -2522,8 +2526,8 @@ msgstr "자동으로 이동하지 않으면 이 탭을 닫아도 됩니다."
 msgid "You can close this window."
 msgstr "이 창을 닫아도 됩니다."
 
-#: src/pages/Shell.tsx:2302
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2314
+#: src/pages/Shell.tsx:2868
 msgid "You have control"
 msgstr "직접 조작 중"
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2141,6 +2141,18 @@ export function ShellPage() {
           onOpenBot={openBot}
           onAnswer={answerMessage}
           onReply={setReplyTarget}
+          onJumpToMessage={(messageId) => {
+            const existing = document.querySelector(`[data-message-id="${CSS.escape(messageId)}"]`);
+            if (existing) {
+              existing.scrollIntoView({ behavior: "smooth", block: "center" });
+              return;
+            }
+            if (inGroup && groupId) {
+              void jumpToMessage({ groupId, messageId });
+              return;
+            }
+            if (active?.id) void jumpToMessage({ botId: active.id, messageId });
+          }}
           onOpenPeerMessages={(peerBotId) => {
             setPeerMessagesFocusId(peerBotId);
             setPeerMessagesOpen(true);
@@ -2966,6 +2978,7 @@ const Transcript = memo(function Transcript({
   onOpenBot,
   onAnswer,
   onReply,
+  onJumpToMessage,
   onOpenPeerMessages,
   memberName,
   onRefresh,
@@ -2987,6 +3000,7 @@ const Transcript = memo(function Transcript({
   onOpenBot: (botId: string) => void;
   onAnswer: (message: ThreadMessage, text: string) => Promise<void>;
   onReply: (message: ThreadMessage) => void;
+  onJumpToMessage: (messageId: string) => void;
   onOpenPeerMessages: (peerBotId: string) => void;
   memberName?: (botId: string | undefined) => string | undefined;
   onRefresh: () => Promise<void>;
@@ -3032,11 +3046,8 @@ const Transcript = memo(function Transcript({
             replyPreview={
               message.replyToMessageId ? messageById.get(message.replyToMessageId) : undefined
             }
-            onJumpToMessage={(messageId) => {
-              document
-                .querySelector(`[data-message-id="${messageId}"]`)
-                ?.scrollIntoView({ behavior: "smooth", block: "center" });
-            }}
+            replyToMessageId={message.replyToMessageId}
+            onJumpToMessage={onJumpToMessage}
             onRefresh={onRefresh}
             onBotChanged={onBotChanged}
             onAddRoutine={onAddRoutine}
@@ -3742,6 +3753,7 @@ const MessageView = memo(function MessageView({
   speakerName,
   memberName,
   replyPreview,
+  replyToMessageId,
   onJumpToMessage,
   onRefresh,
   onBotChanged,
@@ -3759,6 +3771,7 @@ const MessageView = memo(function MessageView({
   speakerName?: string;
   memberName?: (botId: string | undefined) => string | undefined;
   replyPreview?: ThreadMessage;
+  replyToMessageId?: string;
   onJumpToMessage?: (messageId: string) => void;
   onRefresh: () => Promise<void>;
   onBotChanged: () => Promise<void>;
@@ -3775,6 +3788,7 @@ const MessageView = memo(function MessageView({
       (block) => block.kind === "text" || block.kind === "progress" || block.kind === "steps",
     );
   const isLive = message.id.startsWith("progress:");
+  const parentJumpId = replyPreview?.id ?? replyToMessageId;
   const messageContext = (
     <>
       {speakerName ? (
@@ -3782,16 +3796,16 @@ const MessageView = memo(function MessageView({
           {speakerName}
         </div>
       ) : null}
-      {replyPreview ? (
+      {parentJumpId ? (
         <button
           type="button"
           data-testid="reply-parent-preview"
           aria-label={t`Jump to replied message`}
-          onClick={() => onJumpToMessage?.(replyPreview.id)}
+          onClick={() => onJumpToMessage?.(parentJumpId)}
           className="mb-2 block max-w-[74%] truncate rounded-[14px] border border-[#26262A] bg-[#131315] px-3 py-2 text-start text-[12.5px] text-[#85858A] hover:border-[#34343B] hover:text-[#C9C9CE]"
           dir="auto"
         >
-          {previewMessageText(replyPreview)}
+          {replyPreview ? previewMessageText(replyPreview) : t`Earlier message`}
         </button>
       ) : null}
     </>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -980,7 +980,8 @@ export function ShellPage() {
   async function jumpToMessage(target: { botId?: string; groupId?: string; messageId: string }) {
     const threadTarget = searchHitThreadTarget(target);
     const epoch = historyEpoch.current;
-    const jumpId = (jumpGeneration.current += 1);
+    jumpGeneration.current += 1;
+    const jumpId = jumpGeneration.current;
     const [snap, page] = await Promise.all([
       rpc.threads.get(threadTarget),
       rpc.threads.messages({ ...threadTarget, around: { messageId: target.messageId } }),

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1249,6 +1249,8 @@ export function ShellPage() {
   const jumpToReplyMessage = useCallback((messageId: string) => {
     const existing = document.querySelector(`[data-message-id="${CSS.escape(messageId)}"]`);
     if (existing) {
+      // Cancel any in-flight around-fetch so it cannot overwrite this scroll.
+      jumpGeneration.current += 1;
       existing.scrollIntoView({ behavior: "smooth", block: "center" });
       return;
     }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -345,6 +345,7 @@ export function ShellPage() {
   const bootstrappedThread = useRef<ThreadSnapshot | null>(null);
   const expandedHistoryThread = useRef<string | null>(null);
   const historyEpoch = useRef(0);
+  const jumpGeneration = useRef(0);
   const initiallyScrolledThread = useRef<string | null>(null);
   const messageScroll = useRef<HTMLDivElement>(null);
   const pinnedAroundRef = useRef<{
@@ -979,13 +980,15 @@ export function ShellPage() {
   async function jumpToMessage(target: { botId?: string; groupId?: string; messageId: string }) {
     const threadTarget = searchHitThreadTarget(target);
     const epoch = historyEpoch.current;
+    const jumpId = (jumpGeneration.current += 1);
     const [snap, page] = await Promise.all([
       rpc.threads.get(threadTarget),
       rpc.threads.messages({ ...threadTarget, around: { messageId: target.messageId } }),
     ]);
     // The epoch check drops a jump that raced a conversation clear (or a bot switch): applying
     // the fetched page would pin deleted messages that every later refresh keeps restoring.
-    if (epoch !== historyEpoch.current) return;
+    // jumpId drops an older jump that finished after a newer click.
+    if (epoch !== historyEpoch.current || jumpId !== jumpGeneration.current) return;
     if (target.groupId && activeGroupId.current !== target.groupId) return;
     if (target.botId && activeBotId.current !== target.botId) return;
     expandedHistoryThread.current = page.threadId;
@@ -1011,6 +1014,7 @@ export function ShellPage() {
       setRoutines([]);
       setRoutinesBotId(null);
     }
+    if (jumpId !== jumpGeneration.current) return;
     window.requestAnimationFrame(() => {
       document
         .querySelector(`[data-message-id="${target.messageId}"]`)
@@ -1130,6 +1134,8 @@ export function ShellPage() {
   refreshGroupThreadRef.current = refreshGroupThread;
   const loadOlderMessagesRef = useRef(loadOlderMessages);
   loadOlderMessagesRef.current = loadOlderMessages;
+  const jumpToMessageRef = useRef(jumpToMessage);
+  jumpToMessageRef.current = jumpToMessage;
 
   const mentionBotsKey = useMemo(
     () => bots.map((bot) => `${bot.id}:${bot.name}`).join(","),
@@ -1239,6 +1245,20 @@ export function ShellPage() {
 
   const openBot = useCallback((id: string) => navigate(`/app/${id}`), [navigate]);
   const loadOlder = useCallback(() => loadOlderMessagesRef.current(), []);
+  const jumpToReplyMessage = useCallback((messageId: string) => {
+    const existing = document.querySelector(`[data-message-id="${CSS.escape(messageId)}"]`);
+    if (existing) {
+      existing.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
+    const groupId = activeGroupId.current;
+    if (groupId) {
+      void jumpToMessageRef.current({ groupId, messageId });
+      return;
+    }
+    const botId = activeBotId.current;
+    if (botId) void jumpToMessageRef.current({ botId, messageId });
+  }, []);
   const answerMessage = useCallback(async (message: ThreadMessage, text: string) => {
     const botId = activeBotId.current;
     const groupId = activeGroupId.current;
@@ -2141,18 +2161,7 @@ export function ShellPage() {
           onOpenBot={openBot}
           onAnswer={answerMessage}
           onReply={setReplyTarget}
-          onJumpToMessage={(messageId) => {
-            const existing = document.querySelector(`[data-message-id="${CSS.escape(messageId)}"]`);
-            if (existing) {
-              existing.scrollIntoView({ behavior: "smooth", block: "center" });
-              return;
-            }
-            if (inGroup && groupId) {
-              void jumpToMessage({ groupId, messageId });
-              return;
-            }
-            if (active?.id) void jumpToMessage({ botId: active.id, messageId });
-          }}
+          onJumpToMessage={jumpToReplyMessage}
           onOpenPeerMessages={(peerBotId) => {
             setPeerMessagesFocusId(peerBotId);
             setPeerMessagesOpen(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #258 (CodeRabbit + Greptile P1): when a reply’s parent is outside the loaded transcript page, still show a clickable “Earlier message” preview and jump via `threads.messages` around (`jumpToMessage`) instead of DOM-only scroll.

Also addresses CodeRabbit on this PR: serialize overlapping jumps and keep the transcript jump handler stable.

## Merge conflict resolution

Merged current `main` into this branch (includes #259 hover toolbar placement and later main commits). Conflicts were in `apps/web/src/locales/{en,de,ko}/messages.po` (gettext `#:` line refs + Integration copy from #268), not in `Shell.tsx` — reply-parent pagination behavior and #259 hover geometry both preserved.

## Test plan

- [x] Typecheck / biome
- [x] Playwright `message-hover-actions.spec.ts` (hover + off-page parent jump)
- [ ] CI green after main merge

Refs #258 review comments on paginated reply context.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d12918f1-9edf-4f71-a03f-12202ba71019?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d12918f1-9edf-4f71-a03f-12202ba71019&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reply previews remain available when the original message is outside the currently loaded conversation.
  * An “Earlier message” preview lets you load and navigate to the referenced message.

* **Bug Fixes**
  * Improved navigation when multiple reply jumps occur or conversations change.
  * Improved scrolling to referenced bot and group messages.
  * Adjusted message spacing and hover-action positioning.

* **Localization**
  * Updated “Earlier message” translations in English, German, and Korean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->