### PR TITLE
fix(sandboxes): suppress Chromium --no-sandbox infobar with --test-type flag

### DIFF
--- a/infra/sandboxes/computer/rakazo-browser
+++ b/infra/sandboxes/computer/rakazo-browser
@@ -9,6 +9,7 @@ if [ -z "$BIN" ]; then
   exit 1
 fi
 exec "$BIN" \
+  --test-type \
   --no-sandbox \
   --disable-dev-shm-usage \
   --disable-gpu \


### PR DESCRIPTION
### Summary
Adds the standard \--test-type\ flag to the Chromium sandbox launcher in \infra/sandboxes/computer/rakazo-browser\.

### Rationale
In Linux / Docker container sandboxes, running Chromium with \--no-sandbox\ causes Chromium to display a persistent warning banner at the top of the browser:
> *'You are using an unsupported command-line flag: --no-sandbox. Stability and security will suffer.'*

Adding \--test-type\ silences this unsupported flag infobar, reclaiming vertical screen area and preventing computer vision bots from reading the banner as webpage content.

### Verification
- Tested in Docker computer sandbox launcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chromium startup behavior by enabling test mode during launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->