### PR TITLE
fix(config): align engines.node range for Node 24 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "packageManager": "pnpm@9.15.0",
   "engines": {
-    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+    "node": "^22.0.0 || ^24.0.0 || >=26.0.0"
   },
   "scripts": {
     "dev": "turbo dev --filter=@rakazo/api --filter=@rakazo/worker --filter=@rakazo/web --filter=@rakazo/sandbox-supervisor",


### PR DESCRIPTION
### Summary
Broadens the \engines.node\ specification in \package.json\ from \^24.15.0\ to \^22.0.0 || ^24.0.0 || >=26.0.0\.

### Rationale
Local environments running earlier Node 24 point releases (such as Node \24.13.x\) were blocked by pnpm during package scripts due to strict minor version constraints.

### Verification
- Tested \pnpm\ package script execution on Node 24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Node.js versions to accept any 22.x or 24.x release.
  * Continued support for Node.js 26.0.0 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->