### PR TITLE
Quiet Integrations default; tool sources under Advanced

### DIFF
--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -149,9 +149,7 @@ export default function Account() {
         >
           <View>
             <Text style={styles.settingsTitle}>Integrations</Text>
-            <Text style={styles.settingsExplanation}>
-              Connect apps and add Treg, MCP, or OpenAPI tools
-            </Text>
+            <Text style={styles.settingsExplanation}>Connect apps.</Text>
           </View>
           <Text style={styles.chevron}>›</Text>
         </Pressable>

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -22,12 +22,14 @@ export default function Integrations() {
   const [catalog, setCatalog] = useState<ConnectionCatalogItem[]>([]);
   const [sources, setSources] = useState<CapabilityInstall[]>([]);
   const [sourceKind, setSourceKind] = useState<SourceKind | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
   const [credential, setCredential] = useState("");
   const [requiresAuth, setRequiresAuth] = useState(true);
   const [pending, setPending] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [sourceError, setSourceError] = useState<string | null>(null);
   const connectionAttempt = useRef<AbortController | null>(null);
 
   async function refresh() {
@@ -41,10 +43,20 @@ export default function Integrations() {
 
   useEffect(() => {
     void refresh().catch((reason) =>
-      setError(reason instanceof Error ? reason.message : "Could not load integrations"),
+      setCatalogError(reason instanceof Error ? reason.message : "Could not load integrations"),
     );
     return () => connectionAttempt.current?.abort();
   }, []);
+
+  function closeAdvanced() {
+    setAdvancedOpen(false);
+    setSourceKind(null);
+    setSourceError(null);
+    setName("");
+    setUrl("");
+    setCredential("");
+    setRequiresAuth(true);
+  }
 
   async function connect(item: ConnectionCatalogItem) {
     connectionAttempt.current?.abort();
@@ -52,7 +64,7 @@ export default function Integrations() {
     connectionAttempt.current = controller;
     const key = `${item.connectorId}:${item.slug}`;
     setPending(key);
-    setError(null);
+    setCatalogError(null);
     try {
       const started = await rpc<{ connectionId: string; authorizationUrl: string | null }>(
         "connections/begin",
@@ -82,7 +94,7 @@ export default function Integrations() {
       );
     } catch (reason) {
       if (controller.signal.aborted) return;
-      setError(reason instanceof Error ? reason.message : "Could not connect");
+      setCatalogError(reason instanceof Error ? reason.message : "Could not connect");
     } finally {
       if (connectionAttempt.current === controller) {
         connectionAttempt.current = null;
@@ -94,7 +106,7 @@ export default function Integrations() {
   async function revoke(item: ConnectionCatalogItem) {
     const key = `${item.connectorId}:${item.slug}`;
     setPending(key);
-    setError(null);
+    setCatalogError(null);
     const connections = await rpc<Connection[]>("connections/list").catch(() => []);
     const matches = connections.filter(
       (connection) =>
@@ -109,7 +121,7 @@ export default function Integrations() {
       await rpc("connections/revoke", { connectionId: row.id });
       await refresh();
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : "Could not revoke connection");
+      setCatalogError(reason instanceof Error ? reason.message : "Could not revoke connection");
     } finally {
       setPending(null);
     }
@@ -117,6 +129,7 @@ export default function Integrations() {
 
   function beginSource(kind: SourceKind) {
     setSourceKind(kind);
+    setSourceError(null);
     setName(kind === "treg" ? "Treg" : "");
     setUrl(kind === "treg" ? "https://treg.to/mcp/" : "");
     setCredential("");
@@ -126,7 +139,7 @@ export default function Integrations() {
   async function addSource() {
     if (!sourceKind) return;
     setPending("source");
-    setError(null);
+    setSourceError(null);
     try {
       await rpc("capabilities/install", {
         kind: sourceKind === "api" ? "api" : "mcp",
@@ -144,7 +157,7 @@ export default function Integrations() {
       setSourceKind(null);
       await refresh();
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : "Could not add source");
+      setSourceError(reason instanceof Error ? reason.message : "Could not add source");
     } finally {
       setPending(null);
     }
@@ -152,11 +165,12 @@ export default function Integrations() {
 
   async function removeSource(source: CapabilityInstall) {
     setPending(source.id);
+    setSourceError(null);
     try {
       await rpc("capabilities/remove", { id: source.id });
       setSources((current) => current.filter((item) => item.id !== source.id));
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : "Could not remove source");
+      setSourceError(reason instanceof Error ? reason.message : "Could not remove source");
     } finally {
       setPending(null);
     }
@@ -165,123 +179,9 @@ export default function Integrations() {
   return (
     <SafeAreaView edges={["bottom"]} style={styles.screen}>
       <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.explanation}>
-          Connect managed apps or install a remote tool source. Credentials are encrypted and never
-          shown to bots.
-        </Text>
+        <Text style={styles.explanation}>Connect apps.</Text>
 
-        <View style={styles.actions}>
-          {(["treg", "mcp", "api"] as const).map((kind) => (
-            <Pressable
-              key={kind}
-              accessibilityRole="button"
-              onPress={() => beginSource(kind)}
-              style={styles.smallButton}
-            >
-              <Text style={styles.buttonLabel}>
-                {kind === "treg" ? "Add Treg" : kind === "mcp" ? "Add MCP" : "Add OpenAPI"}
-              </Text>
-            </Pressable>
-          ))}
-        </View>
-
-        {sourceKind ? (
-          <View style={styles.card}>
-            <Text style={styles.title}>
-              {sourceKind === "treg"
-                ? "Connect Treg"
-                : sourceKind === "mcp"
-                  ? "Remote MCP server"
-                  : "OpenAPI JSON"}
-            </Text>
-            <TextInput
-              value={name}
-              onChangeText={setName}
-              placeholder="Display name"
-              placeholderTextColor={native.tertiaryLabel}
-              style={styles.input}
-            />
-            {sourceKind !== "treg" ? (
-              <TextInput
-                value={url}
-                onChangeText={setUrl}
-                autoCapitalize="none"
-                autoCorrect={false}
-                placeholder={
-                  sourceKind === "mcp"
-                    ? "https://example.com/mcp"
-                    : "https://example.com/openapi.json"
-                }
-                placeholderTextColor={native.tertiaryLabel}
-                style={styles.input}
-              />
-            ) : null}
-            {sourceKind !== "treg" ? (
-              <Pressable
-                accessibilityRole="button"
-                onPress={() => setRequiresAuth((value) => !value)}
-                style={styles.authToggle}
-              >
-                <Text style={styles.secondary}>
-                  {requiresAuth ? "Bearer authentication" : "No authentication"}
-                </Text>
-              </Pressable>
-            ) : null}
-            {sourceKind === "treg" || requiresAuth ? (
-              <TextInput
-                value={credential}
-                onChangeText={setCredential}
-                secureTextEntry
-                autoCapitalize="none"
-                autoCorrect={false}
-                placeholder={sourceKind === "treg" ? "Treg token" : "Bearer token"}
-                placeholderTextColor={native.tertiaryLabel}
-                style={styles.input}
-              />
-            ) : null}
-            <View style={styles.actions}>
-              <Pressable
-                accessibilityRole="button"
-                disabled={pending === "source"}
-                onPress={() => void addSource()}
-                style={styles.smallButton}
-              >
-                {pending === "source" ? (
-                  <ActivityIndicator color={native.label} />
-                ) : (
-                  <Text style={styles.buttonLabel}>Verify and add</Text>
-                )}
-              </Pressable>
-              <Pressable
-                accessibilityRole="button"
-                onPress={() => setSourceKind(null)}
-                style={styles.smallButton}
-              >
-                <Text style={styles.buttonLabel}>Cancel</Text>
-              </Pressable>
-            </View>
-          </View>
-        ) : null}
-
-        {error ? <Text style={styles.error}>{error}</Text> : null}
-
-        <Text style={styles.section}>Tool sources</Text>
-        {sources.length === 0 ? (
-          <Text style={styles.secondary}>No custom sources installed.</Text>
-        ) : null}
-        {sources.map((source) => (
-          <View key={source.id} style={styles.row}>
-            <View style={styles.grow}>
-              <Text style={styles.title}>{source.name}</Text>
-              <Text numberOfLines={1} style={styles.secondary}>
-                {source.kind.toUpperCase()} · {source.source}
-              </Text>
-            </View>
-            <Pressable accessibilityRole="button" onPress={() => void removeSource(source)}>
-              <Text style={styles.remove}>{pending === source.id ? "Removing…" : "Remove"}</Text>
-            </Pressable>
-          </View>
-        ))}
+        {catalogError ? <Text style={styles.error}>{catalogError}</Text> : null}
 
         <Text style={styles.section}>Apps</Text>
         {catalog.length === 0 ? (
@@ -293,9 +193,6 @@ export default function Integrations() {
             <View key={key} style={styles.row}>
               <View style={styles.grow}>
                 <Text style={styles.title}>{item.name}</Text>
-                <Text style={styles.secondary}>
-                  {item.connectorId} · {item.slug}
-                </Text>
               </View>
               <Pressable
                 accessibilityRole="button"
@@ -303,12 +200,149 @@ export default function Integrations() {
                 onPress={() => void (item.connected ? revoke(item) : connect(item))}
               >
                 <Text style={styles.link}>
-                  {pending === key ? "Working…" : item.connected ? "Revoke" : "Connect"}
+                  {pending === key ? "Working…" : item.connected ? "Remove" : "Add"}
                 </Text>
               </Pressable>
             </View>
           );
         })}
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ expanded: advancedOpen }}
+          testID="integrations-advanced"
+          onPress={() => {
+            if (advancedOpen) closeAdvanced();
+            else setAdvancedOpen(true);
+          }}
+          style={styles.advancedToggle}
+        >
+          <Text style={styles.advancedLabel}>Advanced</Text>
+          <Text style={styles.chevron}>›</Text>
+        </Pressable>
+
+        {advancedOpen ? (
+          <View style={styles.advancedBody}>
+            <View style={styles.actions}>
+              {(["mcp", "api", "treg"] as const).map((kind) => (
+                <Pressable
+                  key={kind}
+                  accessibilityRole="button"
+                  onPress={() => beginSource(kind)}
+                  style={styles.smallButton}
+                >
+                  <Text style={styles.buttonLabel}>
+                    {kind === "treg"
+                      ? "Add Treg"
+                      : kind === "mcp"
+                        ? "Add MCP server"
+                        : "Add OpenAPI"}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+
+            {sourceError ? <Text style={styles.error}>{sourceError}</Text> : null}
+
+            {sourceKind ? (
+              <View style={styles.card}>
+                <Text style={styles.title}>
+                  {sourceKind === "treg"
+                    ? "Connect Treg"
+                    : sourceKind === "mcp"
+                      ? "Remote MCP server"
+                      : "OpenAPI JSON"}
+                </Text>
+                <TextInput
+                  value={name}
+                  onChangeText={setName}
+                  placeholder="Display name"
+                  placeholderTextColor={native.tertiaryLabel}
+                  style={styles.input}
+                />
+                {sourceKind !== "treg" ? (
+                  <TextInput
+                    value={url}
+                    onChangeText={setUrl}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder={
+                      sourceKind === "mcp"
+                        ? "https://example.com/mcp"
+                        : "https://example.com/openapi.json"
+                    }
+                    placeholderTextColor={native.tertiaryLabel}
+                    style={styles.input}
+                  />
+                ) : null}
+                {sourceKind !== "treg" ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => setRequiresAuth((value) => !value)}
+                    style={styles.authToggle}
+                  >
+                    <Text style={styles.secondary}>
+                      {requiresAuth ? "Bearer authentication" : "No authentication"}
+                    </Text>
+                  </Pressable>
+                ) : null}
+                {sourceKind === "treg" || requiresAuth ? (
+                  <TextInput
+                    value={credential}
+                    onChangeText={setCredential}
+                    secureTextEntry
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder={sourceKind === "treg" ? "Treg token" : "Bearer token"}
+                    placeholderTextColor={native.tertiaryLabel}
+                    style={styles.input}
+                  />
+                ) : null}
+                <View style={styles.actions}>
+                  <Pressable
+                    accessibilityRole="button"
+                    disabled={pending === "source"}
+                    onPress={() => void addSource()}
+                    style={styles.smallButton}
+                  >
+                    {pending === "source" ? (
+                      <ActivityIndicator color={native.label} />
+                    ) : (
+                      <Text style={styles.buttonLabel}>Verify and add</Text>
+                    )}
+                  </Pressable>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => setSourceKind(null)}
+                    style={styles.smallButton}
+                  >
+                    <Text style={styles.buttonLabel}>Cancel</Text>
+                  </Pressable>
+                </View>
+              </View>
+            ) : null}
+
+            <Text style={styles.section}>Tool sources</Text>
+            {sources.length === 0 ? (
+              <Text style={styles.secondary}>No custom sources installed.</Text>
+            ) : null}
+            {sources.map((source) => (
+              <View key={source.id} style={styles.row}>
+                <View style={styles.grow}>
+                  <Text style={styles.title}>{source.name}</Text>
+                  <Text numberOfLines={1} style={styles.secondary}>
+                    {source.kind.toUpperCase()} · {source.source}
+                  </Text>
+                </View>
+                <Pressable accessibilityRole="button" onPress={() => void removeSource(source)}>
+                  <Text style={styles.remove}>
+                    {pending === source.id ? "Removing…" : "Remove"}
+                  </Text>
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        ) : null}
       </ScrollView>
     </SafeAreaView>
   );
@@ -354,4 +388,14 @@ const styles = StyleSheet.create({
   link: { color: native.label, fontSize: 14, fontWeight: "600" },
   remove: { color: "#E96B6B", fontSize: 14, fontWeight: "600" },
   error: { color: "#E96B6B", fontSize: 14 },
+  advancedToggle: {
+    marginTop: 8,
+    minHeight: 44,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  advancedLabel: { color: native.secondaryLabel, fontSize: 14 },
+  advancedBody: { gap: 14 },
+  chevron: { color: native.secondaryLabel, fontSize: 18 },
 });

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -128,32 +128,48 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await expect(page.getByText("Slack", { exact: true })).toBeVisible();
   await expect(page.getByText("GitHub", { exact: true })).toBeVisible();
   await expect(page.getByText("Notion", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add Treg", exact: true })).toBeHidden();
+  await expect(page.getByRole("button", { name: "Add MCP server", exact: true })).toBeHidden();
+  await expect(page.getByRole("button", { name: "Add OpenAPI", exact: true })).toBeHidden();
+  await expect(page.getByText("Tool sources", { exact: true })).toBeHidden();
+  await expect(
+    page.getByText("Connect apps or add Treg, MCP, and OpenAPI tool sources.", { exact: true }),
+  ).toBeHidden();
   await captureScreenshot(page, testInfo, "11-plugins-catalog");
 
   const gmailRow = page.getByText("Gmail", { exact: true }).locator("..").locator("..");
-  await gmailRow.getByRole("button", { name: "Connect", exact: true }).click();
-  await expect(gmailRow.getByRole("button", { name: "Revoke", exact: true })).toBeVisible();
-  await page.getByRole("tab", { name: "Connected", exact: true }).click();
-  await expect(page.getByText("Slack", { exact: true })).toBeHidden();
+  await gmailRow.getByRole("button", { name: "Add", exact: true }).click();
+  await expect(gmailRow.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11a-connected-plugins");
 
-  await gmailRow.getByRole("button", { name: "Revoke", exact: true }).click();
-  await expect(page.getByText("No connected apps yet.", { exact: true })).toBeVisible();
-  await expect(page.getByText("Gmail", { exact: true })).toBeHidden();
+  await gmailRow.getByRole("button", { name: "Remove", exact: true }).click();
+  await expect(gmailRow.getByRole("button", { name: "Add", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11b-connected-plugins-empty");
-
-  await page.getByRole("tab", { name: "Apps", exact: true }).click();
-  await expect(page.getByText("Gmail", { exact: true })).toBeVisible();
-  await expect(gmailRow.getByRole("button", { name: "Connect", exact: true })).toBeVisible();
 
   const linearRow = page.getByText("Linear", { exact: true }).locator("..").locator("..");
   const connectPopup = page.waitForEvent("popup");
-  await linearRow.getByRole("button", { name: "Connect", exact: true }).click();
+  await linearRow.getByRole("button", { name: "Add", exact: true }).click();
   const popup = await connectPopup;
   await popup.close();
-  await expect(linearRow.getByRole("button", { name: "Revoke", exact: true })).toBeVisible();
-  await linearRow.getByRole("button", { name: "Revoke", exact: true }).click();
-  await expect(linearRow.getByRole("button", { name: "Connect", exact: true })).toBeVisible();
+  await expect(linearRow.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
+  await linearRow.getByRole("button", { name: "Remove", exact: true }).click();
+  await expect(linearRow.getByRole("button", { name: "Add", exact: true })).toBeVisible();
+
+  const advanced = page.getByTestId("integrations-advanced");
+  await advanced.evaluate((element) => {
+    (element as HTMLDetailsElement).open = true;
+  });
+  await expect(page.getByRole("button", { name: "MCP servers", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add MCP server", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add OpenAPI", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add Treg", exact: true })).toBeVisible();
+  await expect(page.getByText("Tool sources", { exact: true })).toBeVisible();
+  // MCP → OpenAPI → Treg order inside Advanced.
+  const advancedActions = advanced.locator("button");
+  await expect(advancedActions.nth(0)).toHaveText("MCP servers");
+  await expect(advancedActions.nth(1)).toHaveText("Add MCP server");
+  await expect(advancedActions.nth(2)).toHaveText("Add OpenAPI");
+  await expect(advancedActions.nth(3)).toHaveText("Add Treg");
 
   await page.getByRole("button", { name: "Add Treg", exact: true }).click();
   await page.getByPlaceholder("Treg token").fill("fake-treg-browser-credential");

--- a/apps/web/e2e/mcp-oauth.spec.ts
+++ b/apps/web/e2e/mcp-oauth.spec.ts
@@ -82,6 +82,9 @@ test("connects an MCP server through the OAuth popup callback", async ({ page },
   });
 
   await page.getByText("Integrations", { exact: true }).click();
+  await page.getByTestId("integrations-advanced").evaluate((element) => {
+    (element as HTMLDetailsElement).open = true;
+  });
   await page.getByRole("button", { name: "MCP servers", exact: true }).click();
   await expect(page.getByRole("heading", { name: "MCP servers" })).toBeVisible();
   await expect(page.getByText("Linear MCP", { exact: true })).toBeVisible();

--- a/apps/web/scripts/translations-de.json
+++ b/apps/web/scripts/translations-de.json
@@ -149,7 +149,6 @@
   "Connect": "Verbinden",
   "Connect a model": "Modell verbinden",
   "Connect API key": "API-Schlüssel verbinden",
-  "Connect apps or add Treg, MCP, and OpenAPI tool sources.": "Verbinde Apps oder füge Treg-, MCP- und OpenAPI-Toolquellen hinzu.",
   "Connect ElevenLabs, OpenAI, or Cartesia": "ElevenLabs, OpenAI oder Cartesia verbinden",
   "Connect MCP server “{name}”": "MCP-Server „{name}“ verbinden",
   "Connect OAuth": "OAuth verbinden",
@@ -308,7 +307,6 @@
   "Inputs": "Eingaben",
   "Instance API key": "Instanz-API-Schlüssel",
   "Instruction": "Anweisung",
-  "Integration views": "Integrationsansichten",
   "Integrations": "Integrationen",
   "Interrupt": "Unterbrechen",
   "Interval": "Intervall",
@@ -378,12 +376,10 @@
   "No apps match your search.": "Keine Apps entsprechen deiner Suche.",
   "no auth": "keine Authentifizierung",
   "No authentication": "Keine Authentifizierung",
-  "No connected apps yet.": "Noch keine Apps verbunden.",
   "No connection record found for {0}.": "Kein Verbindungseintrag für {0} gefunden.",
   "No credential saved": "Keine Anmeldedaten gespeichert",
   "No exceptions. Actions run automatically.": "Keine Ausnahmen. Aktionen werden automatisch ausgeführt.",
   "No longer active": "Nicht mehr aktiv",
-  "No managed app catalog is configured on this deployment. You can still add Treg, MCP, or OpenAPI sources.": "Für diese Bereitstellung ist kein verwalteter App-Katalog konfiguriert. Du kannst weiterhin Treg-, MCP- oder OpenAPI-Quellen hinzufügen.",
   "No MCP or API tool sources installed yet.": "Noch keine MCP- oder API-Toolquellen installiert.",
   "No MCP servers yet.": "Noch keine MCP-Server.",
   "No model catalog is available.": "Kein Modellkatalog verfügbar.",
@@ -576,5 +572,6 @@
   "Your email address": "Deine E-Mail-Adresse",
   "Your key or subscription token is stored securely and is never shown here.": "Dein Schlüssel oder Abonnementtoken wird sicher gespeichert und hier nie angezeigt.",
   "Your name": "Dein Name",
-  "Your team of always-on agents<0/>that you can give real work to.": "Dein Team aus jederzeit verfügbaren Agents<0/>für echte Aufgaben."
+  "Your team of always-on agents<0/>that you can give real work to.": "Dein Team aus jederzeit verfügbaren Agents<0/>für echte Aufgaben.",
+  "No managed app catalog is configured on this deployment.": "Für diese Bereitstellung ist kein verwalteter App-Katalog konfiguriert."
 }

--- a/apps/web/scripts/translations-ko.json
+++ b/apps/web/scripts/translations-ko.json
@@ -149,7 +149,6 @@
   "Connect": "연결",
   "Connect a model": "AI 모델 연결",
   "Connect API key": "API 키 연결",
-  "Connect apps or add Treg, MCP, and OpenAPI tool sources.": "앱을 연결하거나 Treg, MCP, OpenAPI 도구를 추가하세요.",
   "Connect ElevenLabs, OpenAI, or Cartesia": "ElevenLabs, OpenAI 또는 Cartesia 연결",
   "Connect MCP server “{name}”": "MCP 서버 ‘{name}’ 연결",
   "Connect OAuth": "OAuth 연결",
@@ -308,7 +307,6 @@
   "Inputs": "입력값",
   "Instance API key": "인스턴스 API 키",
   "Instruction": "실행할 내용",
-  "Integration views": "연동 목록 보기",
   "Integrations": "앱·도구 연동",
   "Interrupt": "끼어들기",
   "Interval": "간격",
@@ -378,12 +376,10 @@
   "No apps match your search.": "검색 결과가 없습니다.",
   "no auth": "인증 없음",
   "No authentication": "인증 없음",
-  "No connected apps yet.": "아직 연결된 앱이 없습니다.",
   "No connection record found for {0}.": "{0}의 연결 정보를 찾지 못했습니다.",
   "No credential saved": "저장된 인증 정보 없음",
   "No exceptions. Actions run automatically.": "별도 확인 규칙이 없습니다. 작업이 자동으로 실행됩니다.",
   "No longer active": "이미 종료된 요청입니다",
-  "No managed app catalog is configured on this deployment. You can still add Treg, MCP, or OpenAPI sources.": "이 서버에는 관리형 앱 목록이 설정되지 않았습니다. Treg, MCP 또는 OpenAPI 도구는 직접 추가할 수 있습니다.",
   "No MCP or API tool sources installed yet.": "아직 추가된 MCP 또는 API 도구가 없습니다.",
   "No MCP servers yet.": "아직 연결된 MCP 서버가 없습니다.",
   "No model catalog is available.": "사용 가능한 모델 목록이 없습니다.",
@@ -576,5 +572,6 @@
   "Your email address": "이메일 주소",
   "Your key or subscription token is stored securely and is never shown here.": "API 키 또는 구독 토큰은 서버에 안전하게 저장되며 이 화면에 다시 표시되지 않습니다.",
   "Your name": "이름",
-  "Your team of always-on agents<0/>that you can give real work to.": "언제든 실제 작업을 맡길 수 있는<0/>나만의 Agent 팀"
+  "Your team of always-on agents<0/>that you can give real work to.": "언제든 실제 작업을 맡길 수 있는<0/>나만의 Agent 팀",
+  "No managed app catalog is configured on this deployment.": "이 서버에는 관리형 앱 목록이 설정되지 않았습니다."
 }

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -46,7 +46,7 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5139
+#: src/pages/Shell.tsx:5141
 msgid "{0} connection"
 msgstr "{0}-Verbindung"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# verbundener Bot} other {# verbundene Bot
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} hat noch keinem anderen Bot eine Nachricht gesendet."
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5018
 msgid "{botName}’s computer"
 msgstr "Computer von {botName}"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3320
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Zugriffstoken (optional)"
 msgid "Account"
 msgstr "Konto"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4532
 msgid "Account default"
 msgstr "Kontostandard"
 
@@ -161,6 +161,7 @@ msgstr "Aktive Stimme"
 msgid "Activity"
 msgstr "Aktivität"
 
+#: src/pages/PluginsOverlay.tsx:281
 #: src/pages/ScratchpadSection.tsx:188
 msgid "Add"
 msgstr "Hinzufügen"
@@ -185,15 +186,15 @@ msgstr "Gib eine HTTPS-Server-URL ein."
 msgid "Add item"
 msgstr "Element hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:245
+#: src/pages/PluginsOverlay.tsx:311
 msgid "Add MCP server"
 msgstr "MCP-Server hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:248
+#: src/pages/PluginsOverlay.tsx:314
 msgid "Add OpenAPI"
 msgstr "OpenAPI hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:312
+#: src/pages/PluginsOverlay.tsx:329
 msgid "Add remote MCP server"
 msgstr "Remote-MCP-Server hinzufügen"
 
@@ -206,17 +207,19 @@ msgstr "Server hinzufügen"
 msgid "Add to routine"
 msgstr "Zur Routine hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:242
+#: src/pages/PluginsOverlay.tsx:317
 msgid "Add Treg"
 msgstr "Treg hinzufügen"
 
 #: src/pages/McpServersOverlay.tsx:363
+#: src/pages/PluginsOverlay.tsx:276
 msgid "Adding…"
 msgstr "Wird hinzugefügt…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/PluginsOverlay.tsx:291
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4433
+#: src/pages/Shell.tsx:4435
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -299,7 +302,7 @@ msgstr "Beantwortet: {answer}"
 msgid "API key"
 msgstr "API-Schlüssel"
 
-#: src/pages/PluginsOverlay.tsx:348
+#: src/pages/PluginsOverlay.tsx:365
 msgid "API key header"
 msgstr "API-Schlüssel-Header"
 
@@ -311,23 +314,19 @@ msgstr "Gilt beim Hinzufügen des Servers. Mit den Agent-Chips auf jeder Serverk
 msgid "Approval boundaries"
 msgstr "Bestätigungsgrenzen"
 
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5334
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5325
 msgid "Approve this server to let your agent use its tools."
 msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
-
-#: src/pages/PluginsOverlay.tsx:282
-msgid "Apps"
-msgstr "Apps"
 
 #: src/pages/BotContextMenu.tsx:102
 msgid "Archive"
 msgstr "Archivieren"
 
-#: src/pages/Shell.tsx:3981
+#: src/pages/Shell.tsx:3983
 msgid "archived"
 msgstr "archiviert"
 
@@ -335,7 +334,7 @@ msgstr "archiviert"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: src/pages/Shell.tsx:3992
+#: src/pages/Shell.tsx:3994
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archiviert. Chat, Erinnerungen und Dateien bleiben erhalten."
 
@@ -389,11 +388,11 @@ msgstr "um {0}"
 msgid "at {timeSelect}"
 msgstr "um {timeSelect}"
 
-#: src/pages/Shell.tsx:3389
+#: src/pages/Shell.tsx:3391
 msgid "Attach file"
 msgstr "Datei anhängen"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3590
 msgid "Attachment"
 msgstr "Anhang"
 
@@ -406,12 +405,12 @@ msgstr "Autorisierungscode oder Callback-URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Autorisierung abgelaufen — erneute Verbindung erforderlich"
 
-#: src/pages/Shell.tsx:5124
+#: src/pages/Shell.tsx:5126
 msgid "Authorization timed out. Please try again."
 msgstr "Zeitüberschreitung bei der Autorisierung. Versuche es erneut."
 
-#: src/pages/Shell.tsx:5166
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5168
+#: src/pages/Shell.tsx:5334
 msgid "Authorize"
 msgstr "Autorisieren"
 
@@ -419,11 +418,11 @@ msgstr "Autorisieren"
 msgid "Base URL"
 msgstr "Basis-URL"
 
-#: src/pages/PluginsOverlay.tsx:345
+#: src/pages/PluginsOverlay.tsx:362
 msgid "Bearer token"
 msgstr "Bearer-Token"
 
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:5010
 msgid "Booting live desktop…"
 msgstr "Live-Desktop wird gestartet…"
 
@@ -432,9 +431,9 @@ msgstr "Live-Desktop wird gestartet…"
 msgid "Booting up {0}’s computer"
 msgstr "Computer von {0} wird gestartet"
 
-#: src/pages/Shell.tsx:3851
-#: src/pages/Shell.tsx:3852
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:3853
+#: src/pages/Shell.tsx:3854
+#: src/pages/Shell.tsx:3987
 msgid "bot"
 msgstr "Bot"
 
@@ -474,15 +473,15 @@ msgstr "Server nicht erreichbar."
 
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
-#: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4692
-#: src/pages/Shell.tsx:4764
-#: src/pages/Shell.tsx:4879
-#: src/pages/Shell.tsx:4953
+#: src/pages/PluginsOverlay.tsx:413
+#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4766
+#: src/pages/Shell.tsx:4881
+#: src/pages/Shell.tsx:4955
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:4231
 msgid "Cancel new bot"
 msgstr "Neuen Bot abbrechen"
 
@@ -490,7 +489,7 @@ msgstr "Neuen Bot abbrechen"
 msgid "Cancel new group"
 msgstr "Neue Gruppe abbrechen"
 
-#: src/pages/Shell.tsx:3265
+#: src/pages/Shell.tsx:3267
 msgid "Cancel reply"
 msgstr "Antwort abbrechen"
 
@@ -498,11 +497,11 @@ msgstr "Antwort abbrechen"
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/pages/Shell.tsx:5229
+#: src/pages/Shell.tsx:5231
 msgid "Chart failed to render: {error}"
 msgstr "Diagramm konnte nicht angezeigt werden: {error}"
 
-#: src/pages/Shell.tsx:3531
+#: src/pages/Shell.tsx:3533
 msgid "Chat Settings"
 msgstr "Chat-Einstellungen"
 
@@ -519,21 +518,21 @@ msgstr "Wähle zunächst ein Modell aus."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Wähle das verbundene Modell aus, das Rakazo verwendet."
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4781
 msgid "Clear"
 msgstr "Leeren"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4745
+#: src/pages/Shell.tsx:4747
 msgid "Clear {0}’s conversation?"
 msgstr "Unterhaltung mit {0} leeren?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4585
+#: src/pages/Shell.tsx:4587
 msgid "Clear conversation"
 msgstr "Unterhaltung leeren"
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4781
 msgid "Clearing…"
 msgstr "Wird geleert…"
 
@@ -549,7 +548,7 @@ msgstr "Bot-Menü schließen"
 msgid "Close bot messages"
 msgstr "Bot-Nachrichten schließen"
 
-#: src/pages/Shell.tsx:5414
+#: src/pages/Shell.tsx:5416
 msgid "Close chart"
 msgstr "Diagramm schließen"
 
@@ -557,11 +556,11 @@ msgstr "Diagramm schließen"
 msgid "Close computer"
 msgstr "Computer schließen"
 
-#: src/pages/Shell.tsx:5514
+#: src/pages/Shell.tsx:5516
 msgid "Close image preview"
 msgstr "Bildvorschau schließen"
 
-#: src/pages/PluginsOverlay.tsx:231
+#: src/pages/PluginsOverlay.tsx:212
 msgid "Close integrations"
 msgstr "Integrationen schließen"
 
@@ -610,12 +609,12 @@ msgstr "Befehl"
 msgid "Complete"
 msgstr "Abschließen"
 
-#: src/pages/Shell.tsx:4139
-#: src/pages/Shell.tsx:4167
+#: src/pages/Shell.tsx:4141
+#: src/pages/Shell.tsx:4169
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5011
+#: src/pages/Shell.tsx:5013
 msgid "Computer failed to boot"
 msgstr "Computer konnte nicht gestartet werden"
 
@@ -623,11 +622,11 @@ msgstr "Computer konnte nicht gestartet werden"
 msgid "Computer is asleep"
 msgstr "Computer ist im Ruhezustand"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5012
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer schläft — übernimm die Kontrolle, um ihn zu wecken"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5014
 msgid "Computer is stopped"
 msgstr "Computer ist gestoppt"
 
@@ -644,7 +643,6 @@ msgid "Confirm delete"
 msgstr "Löschen bestätigen"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/PluginsOverlay.tsx:499
 #: src/pages/VoiceSettingsOverlay.tsx:257
 msgid "Connect"
 msgstr "Verbinden"
@@ -657,15 +655,11 @@ msgstr "Modell verbinden"
 msgid "Connect API key"
 msgstr "API-Schlüssel verbinden"
 
-#: src/pages/PluginsOverlay.tsx:216
-msgid "Connect apps or add Treg, MCP, and OpenAPI tool sources."
-msgstr "Verbinde Apps oder füge Treg-, MCP- und OpenAPI-Toolquellen hinzu."
-
 #: src/pages/VoiceSettingsOverlay.tsx:160
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI oder Cartesia verbinden"
 
-#: src/pages/Shell.tsx:5312
+#: src/pages/Shell.tsx:5314
 msgid "Connect MCP server “{name}”"
 msgstr "MCP-Server „{name}“ verbinden"
 
@@ -681,20 +675,19 @@ msgstr "Verbinde Remote- oder lokale Toolserver und wähle aus, welche Agents si
 msgid "Connect this provider to use it as your personal model."
 msgstr "Verbinde diesen Anbieter, um ihn als persönliches Modell zu verwenden."
 
-#: src/pages/PluginsOverlay.tsx:310
+#: src/pages/PluginsOverlay.tsx:327
 msgid "Connect Treg"
 msgstr "Treg verbinden"
 
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
-#: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5163
+#: src/pages/Shell.tsx:5165
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Verbunden"
 
-#: src/pages/Shell.tsx:5342
+#: src/pages/Shell.tsx:5344
 msgid "Connected — its tools are available from your next message."
 msgstr "Verbunden – die Tools sind ab deiner nächsten Nachricht verfügbar."
 
@@ -719,14 +712,13 @@ msgstr "Verbunden, {0} wird verwendet."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5334
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Verbindung wird hergestellt…"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:117
+#: src/pages/PluginsOverlay.tsx:114
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "Die Verbindung zu {0} steht noch aus. Du kannst dieses Fenster schließen und später erneut nachsehen."
 
@@ -739,7 +731,7 @@ msgstr "Weiter"
 msgid "Continue with email"
 msgstr "Mit E-Mail fortfahren"
 
-#: src/pages/Shell.tsx:3639
+#: src/pages/Shell.tsx:3641
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -751,11 +743,11 @@ msgstr "Hinzufügen fehlgeschlagen"
 msgid "Could not add MCP server"
 msgstr "MCP-Server konnte nicht hinzugefügt werden"
 
-#: src/pages/Shell.tsx:5299
+#: src/pages/Shell.tsx:5301
 msgid "Could not approve this server"
 msgstr "Server konnte nicht genehmigt werden"
 
-#: src/pages/Shell.tsx:5127
+#: src/pages/Shell.tsx:5129
 msgid "Could not authorize this app"
 msgstr "App konnte nicht autorisiert werden"
 
@@ -763,7 +755,7 @@ msgstr "App konnte nicht autorisiert werden"
 msgid "Could not change the default model"
 msgstr "Standardmodell konnte nicht geändert werden"
 
-#: src/pages/Shell.tsx:4773
+#: src/pages/Shell.tsx:4775
 msgid "Could not clear conversation"
 msgstr "Unterhaltung konnte nicht geleert werden"
 
@@ -771,7 +763,7 @@ msgstr "Unterhaltung konnte nicht geleert werden"
 msgid "Could not complete OAuth"
 msgstr "OAuth konnte nicht abgeschlossen werden"
 
-#: src/pages/PluginsOverlay.tsx:120
+#: src/pages/PluginsOverlay.tsx:117
 msgid "Could not connect"
 msgstr "Verbindung fehlgeschlagen"
 
@@ -792,7 +784,7 @@ msgstr "Stimmanbieter konnte nicht verbunden werden"
 msgid "Could not continue"
 msgstr "Fortfahren fehlgeschlagen"
 
-#: src/pages/Shell.tsx:4217
+#: src/pages/Shell.tsx:4219
 msgid "Could not create bot"
 msgstr "Bot konnte nicht erstellt werden"
 
@@ -800,7 +792,7 @@ msgstr "Bot konnte nicht erstellt werden"
 msgid "Could not create group"
 msgstr "Gruppe konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4666
 msgid "Could not create section"
 msgstr "Abschnitt konnte nicht erstellt werden"
 
@@ -808,7 +800,7 @@ msgstr "Abschnitt konnte nicht erstellt werden"
 msgid "Could not create your bot"
 msgstr "Dein Bot konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4888
+#: src/pages/Shell.tsx:4890
 msgid "Could not delete bot"
 msgstr "Bot konnte nicht gelöscht werden"
 
@@ -816,7 +808,7 @@ msgstr "Bot konnte nicht gelöscht werden"
 msgid "Could not delete MCP server"
 msgstr "MCP-Server konnte nicht gelöscht werden"
 
-#: src/pages/Shell.tsx:4962
+#: src/pages/Shell.tsx:4964
 msgid "Could not delete routine"
 msgstr "Routine konnte nicht gelöscht werden"
 
@@ -837,7 +829,7 @@ msgstr "{0} konnte nicht heruntergeladen werden. Versuche es erneut."
 msgid "Could not download {name}. Try again."
 msgstr "{name} konnte nicht heruntergeladen werden. Versuche es erneut."
 
-#: src/pages/PluginsOverlay.tsx:188
+#: src/pages/PluginsOverlay.tsx:184
 msgid "Could not install connector"
 msgstr "Connector konnte nicht installiert werden"
 
@@ -845,7 +837,7 @@ msgstr "Connector konnte nicht installiert werden"
 msgid "Could not load approval rules"
 msgstr "Bestätigungsregeln konnten nicht geladen werden"
 
-#: src/pages/PluginsOverlay.tsx:62
+#: src/pages/PluginsOverlay.tsx:60
 msgid "Could not load integrations"
 msgstr "Integrationen konnten nicht geladen werden"
 
@@ -878,7 +870,7 @@ msgstr "Modellserver konnte nicht erreicht werden"
 msgid "Could not remove"
 msgstr "Entfernen fehlgeschlagen"
 
-#: src/pages/PluginsOverlay.tsx:201
+#: src/pages/PluginsOverlay.tsx:197
 msgid "Could not remove connector"
 msgstr "Connector konnte nicht entfernt werden"
 
@@ -890,15 +882,15 @@ msgstr "Gruppe konnte nicht entfernt werden"
 msgid "Could not remove rule"
 msgstr "Regel konnte nicht entfernt werden"
 
-#: src/pages/Shell.tsx:5219
+#: src/pages/Shell.tsx:5221
 msgid "Could not render chart"
 msgstr "Diagramm konnte nicht angezeigt werden"
 
-#: src/pages/PluginsOverlay.tsx:146
+#: src/pages/PluginsOverlay.tsx:143
 msgid "Could not revoke connection"
 msgstr "Verbindung konnte nicht widerrufen werden"
 
-#: src/pages/Shell.tsx:4570
+#: src/pages/Shell.tsx:4572
 msgid "Could not save"
 msgstr "Speichern fehlgeschlagen"
 
@@ -926,7 +918,7 @@ msgstr "Auswahl konnte nicht gespeichert werden"
 msgid "Could not save that voice"
 msgstr "Stimme konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:5039
+#: src/pages/Shell.tsx:5041
 msgid "Could not save this choice"
 msgstr "Diese Auswahl konnte nicht gespeichert werden"
 
@@ -959,13 +951,13 @@ msgid "Could not update the default memory scope"
 msgstr "Standardbereich für Erinnerungen konnte nicht aktualisiert werden"
 
 #: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4278
+#: src/pages/Shell.tsx:4701
 msgid "Create"
 msgstr "Erstellen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4673
+#: src/pages/Shell.tsx:4675
 msgid "Create a section and move {0} into it."
 msgstr "Erstelle einen Abschnitt und verschiebe {0} dorthin."
 
@@ -986,16 +978,16 @@ msgid "Create your Rakazo"
 msgstr "Dein Rakazo erstellen"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4278
+#: src/pages/Shell.tsx:4701
 msgid "Creating…"
 msgstr "Wird erstellt…"
 
-#: src/pages/PluginsOverlay.tsx:366
+#: src/pages/PluginsOverlay.tsx:383
 msgid "Credential"
 msgstr "Zugangsdaten"
 
-#: src/pages/PluginsOverlay.tsx:417
+#: src/pages/PluginsOverlay.tsx:441
 msgid "credential saved"
 msgstr "Zugangsdaten gespeichert"
 
@@ -1015,7 +1007,7 @@ msgstr "Tag"
 msgid "days"
 msgstr "Tage"
 
-#: src/pages/Shell.tsx:4477
+#: src/pages/Shell.tsx:4479
 msgid "Default (medium)"
 msgstr "Standard (mittel)"
 
@@ -1026,8 +1018,8 @@ msgstr "Standardbereich"
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
 #: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4970
 msgid "Delete"
 msgstr "Löschen"
 
@@ -1038,8 +1030,8 @@ msgstr "{0} löschen"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4826
-#: src/pages/Shell.tsx:4940
+#: src/pages/Shell.tsx:4828
+#: src/pages/Shell.tsx:4942
 msgid "Delete {0}?"
 msgstr "{0} löschen?"
 
@@ -1047,7 +1039,7 @@ msgstr "{0} löschen?"
 msgid "Delete group"
 msgstr "Gruppe löschen"
 
-#: src/pages/Shell.tsx:4863
+#: src/pages/Shell.tsx:4865
 msgid "Delete memories too"
 msgstr "Erinnerungen ebenfalls löschen"
 
@@ -1055,13 +1047,13 @@ msgstr "Erinnerungen ebenfalls löschen"
 msgid "Delete routine"
 msgstr "Routine löschen"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:3985
 msgid "deleted"
 msgstr "gelöscht"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4970
 msgid "Deleting…"
 msgstr "Wird gelöscht…"
 
@@ -1078,17 +1070,17 @@ msgid "Deployment default"
 msgstr "Bereitstellungsstandard"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4254
+#: src/pages/Shell.tsx:4256
 msgid "Describe what this bot does"
 msgstr "Beschreibe, was dieser Bot macht"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4259
-#: src/pages/Shell.tsx:4421
+#: src/pages/Shell.tsx:4261
+#: src/pages/Shell.tsx:4423
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3400
 msgid "Dictate"
 msgstr "Diktieren"
 
@@ -1101,11 +1093,11 @@ msgstr "Trennen"
 msgid "Disconnecting…"
 msgstr "Verbindung wird getrennt…"
 
-#: src/pages/Shell.tsx:5347
+#: src/pages/Shell.tsx:5349
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Verworfen – du kannst die Verbindung jederzeit in den MCP-Einstellungen wiederherstellen."
 
-#: src/pages/PluginsOverlay.tsx:320
+#: src/pages/PluginsOverlay.tsx:337
 msgid "Display name"
 msgstr "Anzeigename"
 
@@ -1201,11 +1193,11 @@ msgstr "Jeden Monat"
 msgid "Every week"
 msgstr "Jede Woche"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5395
 msgid "Expand"
 msgstr "Erweitern"
 
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4584
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1213,7 +1205,7 @@ msgstr "Exportieren"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Exportiere die Liste dieser Woche aus dem CRM und lege sie im freigegebenen Ordner ab"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4599
 msgid "Extra high"
 msgstr "Sehr hoch"
 
@@ -1274,7 +1266,7 @@ msgid "Hang up"
 msgstr "Auflegen"
 
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/PluginsOverlay.tsx:356
+#: src/pages/PluginsOverlay.tsx:373
 msgid "Header name"
 msgstr "Header-Name"
 
@@ -1290,15 +1282,15 @@ msgstr "Beispiel anhören"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hallo, so klinge ich, wenn ich Antworten vorlese."
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4602
 msgid "High"
 msgstr "Hoch"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3419
 msgid "Hold to talk"
 msgstr "Zum Sprechen gedrückt halten"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3419
 msgid "Hold to talk (on-device dictation)"
 msgstr "Zum Sprechen gedrückt halten (Diktat auf dem Gerät)"
 
@@ -1318,7 +1310,7 @@ msgstr "Wie oft"
 msgid "How to check"
 msgstr "So wird geprüft"
 
-#: src/pages/Shell.tsx:3695
+#: src/pages/Shell.tsx:3697
 msgid "I’m done"
 msgstr "Ich bin fertig"
 
@@ -1326,11 +1318,11 @@ msgstr "Ich bin fertig"
 msgid "If you heard that, voice is ready."
 msgstr "Wenn du das gehört hast, ist die Stimme einsatzbereit."
 
-#: src/pages/PluginsOverlay.tsx:314
+#: src/pages/PluginsOverlay.tsx:331
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI-JSON importieren"
 
-#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4494
 msgid "Inherit default"
 msgstr "Standard übernehmen"
 
@@ -1346,11 +1338,7 @@ msgstr "Instanz-API-Schlüssel"
 msgid "Instruction"
 msgstr "Anweisung"
 
-#: src/pages/PluginsOverlay.tsx:263
-msgid "Integration views"
-msgstr "Integrationsansichten"
-
-#: src/pages/PluginsOverlay.tsx:213
+#: src/pages/PluginsOverlay.tsx:208
 #: src/pages/Shell.tsx:1953
 msgid "Integrations"
 msgstr "Integrationen"
@@ -1372,15 +1360,15 @@ msgid "Interval unit"
 msgstr "Intervalleinheit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4495
 msgid "Isolated"
 msgstr "Isoliert"
 
-#: src/pages/Shell.tsx:4829
+#: src/pages/Shell.tsx:4831
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von ihm erstellte Bots bleiben in deiner Liste."
 
-#: src/pages/Shell.tsx:3791
+#: src/pages/Shell.tsx:3793
 msgid "Jump to replied message"
 msgstr "Zur beantworteten Nachricht springen"
 
@@ -1388,7 +1376,7 @@ msgstr "Zur beantworteten Nachricht springen"
 msgid "just now"
 msgstr "gerade eben"
 
-#: src/pages/Shell.tsx:4847
+#: src/pages/Shell.tsx:4849
 msgid "Keep memories"
 msgstr "Erinnerungen behalten"
 
@@ -1414,7 +1402,7 @@ msgstr "Frühere Nachrichten laden"
 msgid "Loading activity…"
 msgstr "Aktivität wird geladen…"
 
-#: src/pages/PluginsOverlay.tsx:300
+#: src/pages/PluginsOverlay.tsx:233
 msgid "Loading integrations…"
 msgstr "Integrationen werden geladen…"
 
@@ -1458,7 +1446,7 @@ msgstr "Lokal"
 msgid "Log out"
 msgstr "Abmelden"
 
-#: src/pages/Shell.tsx:4598
+#: src/pages/Shell.tsx:4600
 msgid "Low"
 msgstr "Niedrig"
 
@@ -1474,17 +1462,17 @@ msgstr "Als gelesen markieren"
 msgid "Mark as Unread"
 msgstr "Als ungelesen markieren"
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4604
 msgid "Max"
 msgstr "Max."
 
 #: src/pages/McpServersOverlay.tsx:224
 #: src/pages/McpServersOverlay.tsx:229
-#: src/pages/PluginsOverlay.tsx:226
+#: src/pages/PluginsOverlay.tsx:305
 msgid "MCP servers"
 msgstr "MCP-Server"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4601
 msgid "Medium"
 msgstr "Mittel"
 
@@ -1501,29 +1489,29 @@ msgstr "Mitglieder ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} auswählen)"
 msgid "Memory"
 msgstr "Erinnerungen"
 
-#: src/pages/Shell.tsx:4488
+#: src/pages/Shell.tsx:4490
 msgid "Memory scope"
 msgstr "Erinnerungsbereich"
 
-#: src/pages/Shell.tsx:3495
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3497
+#: src/pages/Shell.tsx:3592
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/pages/Shell.tsx:3491
-#: src/pages/Shell.tsx:3495
+#: src/pages/Shell.tsx:3493
+#: src/pages/Shell.tsx:3497
 msgid "Message {activeName}"
 msgstr "Nachricht an {activeName}"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3871
 msgid "Message from {peer}"
 msgstr "Nachricht von {peer}"
 
-#: src/pages/Shell.tsx:3492
+#: src/pages/Shell.tsx:3494
 msgid "Message…"
 msgstr "Nachricht…"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3871
 msgid "Messaged {peer}"
 msgstr "Nachricht an {peer} gesendet"
 
@@ -1531,7 +1519,7 @@ msgstr "Nachricht an {peer} gesendet"
 msgid "Microphone failed"
 msgstr "Mikrofonfehler"
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4603
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1553,7 +1541,7 @@ msgstr "Minuten"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4444
+#: src/pages/Shell.tsx:4446
 msgid "Model"
 msgstr "Modell"
 
@@ -1593,7 +1581,7 @@ msgstr "Monatlich"
 msgid "Move {0} to section"
 msgstr "{0} in Abschnitt verschieben"
 
-#: src/pages/Shell.tsx:4850
+#: src/pages/Shell.tsx:4852
 msgid "Move them to your shared memory."
 msgstr "Verschiebe sie in deine geteilten Erinnerungen."
 
@@ -1607,14 +1595,14 @@ msgstr "Verschieben nach"
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
 #: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4239
-#: src/pages/Shell.tsx:4403
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:4241
+#: src/pages/Shell.tsx:4405
+#: src/pages/Shell.tsx:4678
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4244
+#: src/pages/Shell.tsx:4246
 msgid "Name this bot"
 msgstr "Bot benennen"
 
@@ -1631,7 +1619,7 @@ msgid "Needs takeover"
 msgstr "Übernahme erforderlich"
 
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4227
+#: src/pages/Shell.tsx:4229
 msgid "New bot"
 msgstr "Neuer Bot"
 
@@ -1649,29 +1637,24 @@ msgid "New routine"
 msgstr "Neue Routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4670
+#: src/pages/Shell.tsx:4672
 msgid "New section"
 msgstr "Neuer Abschnitt"
 
-#: src/pages/PluginsOverlay.tsx:448
+#: src/pages/PluginsOverlay.tsx:244
 msgid "No apps match your search."
 msgstr "Keine Apps entsprechen deiner Suche."
 
-#: src/pages/PluginsOverlay.tsx:419
-#: src/pages/PluginsOverlay.tsx:476
+#: src/pages/PluginsOverlay.tsx:443
 msgid "no auth"
 msgstr "keine Authentifizierung"
 
-#: src/pages/PluginsOverlay.tsx:342
+#: src/pages/PluginsOverlay.tsx:359
 msgid "No authentication"
 msgstr "Keine Authentifizierung"
 
-#: src/pages/PluginsOverlay.tsx:450
-msgid "No connected apps yet."
-msgstr "Noch keine Apps verbunden."
-
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:142
+#: src/pages/PluginsOverlay.tsx:139
 msgid "No connection record found for {0}."
 msgstr "Kein Verbindungseintrag für {0} gefunden."
 
@@ -1687,11 +1670,11 @@ msgstr "Keine Ausnahmen. Aktionen werden automatisch ausgeführt."
 msgid "No longer active"
 msgstr "Nicht mehr aktiv"
 
-#: src/pages/PluginsOverlay.tsx:439
-msgid "No managed app catalog is configured on this deployment. You can still add Treg, MCP, or OpenAPI sources."
-msgstr "Für diese Bereitstellung ist kein verwalteter App-Katalog konfiguriert. Du kannst weiterhin Treg-, MCP- oder OpenAPI-Quellen hinzufügen."
+#: src/pages/PluginsOverlay.tsx:239
+msgid "No managed app catalog is configured on this deployment."
+msgstr "Für diese Bereitstellung ist kein verwalteter App-Katalog konfiguriert."
 
-#: src/pages/PluginsOverlay.tsx:404
+#: src/pages/PluginsOverlay.tsx:425
 msgid "No MCP or API tool sources installed yet."
 msgstr "Noch keine MCP- oder API-Toolquellen installiert."
 
@@ -1724,7 +1707,7 @@ msgstr "Nicht konfiguriert"
 msgid "Not connected"
 msgstr "Nicht verbunden"
 
-#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5337
 msgid "Not now"
 msgstr "Jetzt nicht"
 
@@ -1787,7 +1770,7 @@ msgstr "Offene Arbeit"
 msgid "OpenAI-compatible server URL"
 msgstr "URL eines OpenAI-kompatiblen Servers"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:3996
 msgid "Opened its thread."
 msgstr "Thread geöffnet."
 
@@ -1870,7 +1853,7 @@ msgstr "Wiedergabe…"
 msgid "Preview {0}"
 msgstr "Vorschau von {0}"
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4184
 msgid "Private"
 msgstr "Privat"
 
@@ -1887,11 +1870,11 @@ msgstr "Anbieter"
 msgid "Queued"
 msgstr "In Warteschlange"
 
-#: src/pages/PluginsOverlay.tsx:371
+#: src/pages/PluginsOverlay.tsx:388
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo prüft die Quelle vor dem Speichern. Zugangsdaten werden verschlüsselt und weder an Clients zurückgegeben noch dem Modell zugänglich gemacht."
 
-#: src/pages/Shell.tsx:4520
+#: src/pages/Shell.tsx:4522
 msgid "Read replies aloud"
 msgstr "Antworten vorlesen"
 
@@ -1913,28 +1896,29 @@ msgstr "Verbindung wird wiederhergestellt"
 msgid "Recording: {0}"
 msgstr "Aufnahme: {0}"
 
-#: src/pages/Shell.tsx:3685
+#: src/pages/Shell.tsx:3687
 msgid "Release"
 msgstr "Freigeben"
 
 #: src/components/ApprovalRulesSettings.tsx:138
-#: src/pages/PluginsOverlay.tsx:430
+#: src/pages/PluginsOverlay.tsx:279
+#: src/pages/PluginsOverlay.tsx:454
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "Entfernen"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3299
+#: src/pages/Shell.tsx:3301
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3454
+#: src/pages/Shell.tsx:3456
 msgid "Remove mention {0}"
 msgstr "Erwähnung von {0} entfernen"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3433
+#: src/pages/Shell.tsx:3435
 msgid "Remove skill {0}"
 msgstr "Skill {0} entfernen"
 
@@ -1942,7 +1926,7 @@ msgstr "Skill {0} entfernen"
 msgid "Remove this schedule"
 msgstr "Diesen Zeitplan entfernen"
 
-#: src/pages/Shell.tsx:3993
+#: src/pages/Shell.tsx:3995
 msgid "Removed with chat, computer, and memory."
 msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 
@@ -1950,7 +1934,8 @@ msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 msgid "Removed, but list refresh failed"
 msgstr "Entfernt, aber die Liste konnte nicht aktualisiert werden"
 
-#: src/pages/PluginsOverlay.tsx:430
+#: src/pages/PluginsOverlay.tsx:274
+#: src/pages/PluginsOverlay.tsx:454
 msgid "Removing…"
 msgstr "Wird entfernt…"
 
@@ -1968,11 +1953,11 @@ msgstr "API-Schlüssel ersetzen"
 msgid "Replace key"
 msgstr "Schlüssel ersetzen"
 
-#: src/pages/Shell.tsx:3631
+#: src/pages/Shell.tsx:3633
 msgid "Reply"
 msgstr "Antworten"
 
-#: src/pages/Shell.tsx:3262
+#: src/pages/Shell.tsx:3264
 msgid "Replying to {replyName}"
 msgstr "Antwort an {replyName}"
 
@@ -1987,14 +1972,6 @@ msgstr "Jetzt erneut versuchen"
 #: src/pages/McpOAuthCallback.tsx:65
 msgid "Return to Rakazo"
 msgstr "Zurück zu Rakazo"
-
-#: src/pages/PluginsOverlay.tsx:497
-msgid "Revoke"
-msgstr "Widerrufen"
-
-#: src/pages/PluginsOverlay.tsx:492
-msgid "Revoking…"
-msgstr "Wird widerrufen…"
 
 #: src/pages/Shell.tsx:2488
 #: src/pages/Shell.tsx:2541
@@ -2027,7 +2004,7 @@ msgstr "Wird ausgeführt…"
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
 #: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4575
+#: src/pages/Shell.tsx:4577
 msgid "Save"
 msgstr "Speichern"
 
@@ -2068,7 +2045,7 @@ msgstr "Antworte mit Ja oder Nein oder in einem Satz."
 msgid "Search"
 msgstr "Suchen"
 
-#: src/pages/PluginsOverlay.tsx:257
+#: src/pages/PluginsOverlay.tsx:224
 msgid "Search apps"
 msgstr "Apps suchen"
 
@@ -2090,7 +2067,7 @@ msgstr "Suche…"
 msgid "Select a bot"
 msgstr "Bot auswählen"
 
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3517
 msgid "Send"
 msgstr "Senden"
 
@@ -2129,11 +2106,11 @@ msgstr "Stimme für Anrufe einrichten"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3535
 msgid "Settings: General"
 msgstr "Einstellungen: Allgemein"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3537
 msgid "Settings: Usage"
 msgstr "Einstellungen: Nutzung"
 
@@ -2143,7 +2120,7 @@ msgid "Setup help"
 msgstr "Einrichtungshilfe"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4496
 msgid "Shared"
 msgstr "Geteilt"
 
@@ -2175,11 +2152,11 @@ msgid "Sign up"
 msgstr "Registrieren"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3346
+#: src/pages/Shell.tsx:3348
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3694
 msgid "Skip"
 msgstr "Überspringen"
 
@@ -2200,8 +2177,8 @@ msgstr "{0} übersprungen"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Leertaste unterbricht · Esc legt auf"
 
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3840
+#: src/pages/Shell.tsx:4093
 msgid "Speak"
 msgstr "Vorlesen"
 
@@ -2213,8 +2190,8 @@ msgstr "Sprechen + transkribieren"
 msgid "Speak only"
 msgstr "Nur sprechen"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3836
+#: src/pages/Shell.tsx:4089
 msgid "Speak this reply"
 msgstr "Diese Antwort vorlesen"
 
@@ -2242,18 +2219,18 @@ msgstr "Schritte"
 
 #: src/pages/Shell.tsx:2866
 #: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3506
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3508
+#: src/pages/Shell.tsx:3840
+#: src/pages/Shell.tsx:4093
 msgid "Stop"
 msgstr "Stoppen"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3400
 msgid "Stop dictation"
 msgstr "Diktat stoppen"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3836
+#: src/pages/Shell.tsx:4089
 msgid "Stop speaking"
 msgstr "Vorlesen stoppen"
 
@@ -2271,7 +2248,7 @@ msgstr "Zuerst den Bot stoppen"
 msgid "Stored encrypted"
 msgstr "Verschlüsselt gespeichert"
 
-#: src/pages/Shell.tsx:3945
+#: src/pages/Shell.tsx:3947
 msgid "subagent"
 msgstr "Subagent"
 
@@ -2301,11 +2278,11 @@ msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachr
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Zum Anlernen ist ein grafischer Sandbox-Computer erforderlich. Auf dem Desktop gehostete Bots können Shell-Aufgaben ausführen, aber keine Bildschirmaufnahmen erstellen."
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4184
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5018
 msgid "Team Computer"
 msgstr "Team-Computer"
 
@@ -2318,7 +2295,7 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügbar."
 
-#: src/pages/Shell.tsx:4471
+#: src/pages/Shell.tsx:4473
 msgid "Thinking"
 msgstr "Denkmodus"
 
@@ -2330,8 +2307,8 @@ msgstr "Dieser Bot wird auf diesem Computer und nicht auf einem Linux-Desktop au
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Dieser Bot wird auf diesem Computer ausgeführt. Es gibt keinen separaten Linux-Desktop. Bitte ihn, die Shell zu verwenden; Arbeitsverzeichnisse in deinem persönlichen Ordner sind zulässig."
 
-#: src/pages/Shell.tsx:4866
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4868
+#: src/pages/Shell.tsx:4945
 msgid "This cannot be undone."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
@@ -2355,7 +2332,7 @@ msgstr "dieser Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Dieser Mac führt Shell-Befehle mit deinem Konto aus und kann auf Dateien in deinem persönlichen Ordner zugreifen. Aktiviere dies nicht auf einem gemeinsam genutzten oder öffentlichen Server."
 
-#: src/pages/Shell.tsx:4751
+#: src/pages/Shell.tsx:4753
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbeit beendet. Bot, Computer, Erinnerungen und Routinen bleiben erhalten."
 
@@ -2363,7 +2340,7 @@ msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbe
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bei diesem Anbieter kann hier kein Schlüssel eingefügt werden. Überspringe diesen Schritt, wenn die Bereitstellung bereits Zugangsdaten enthält."
 
-#: src/pages/Shell.tsx:5283
+#: src/pages/Shell.tsx:5285
 msgid "This server cannot be assigned without a bot."
 msgstr "Dieser Server kann ohne Bot nicht zugewiesen werden."
 
@@ -2375,7 +2352,7 @@ msgstr "Dieser Server hat keine Browserautorisierung angefordert."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Dieser Server ist bereits verbunden. Trenne zuerst die Verbindung, um ihn erneut zu autorisieren."
 
-#: src/pages/Shell.tsx:5322
+#: src/pages/Shell.tsx:5324
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Dieser Server verwendet die Browseranmeldung. Autorisiere ihn, damit deine Agents seine Tools verwenden können – ein Pop-up wird geöffnet."
 
@@ -2388,16 +2365,16 @@ msgid "Time of day"
 msgstr "Uhrzeit"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4249
-#: src/pages/Shell.tsx:4412
+#: src/pages/Shell.tsx:4251
+#: src/pages/Shell.tsx:4414
 msgid "Title"
 msgstr "Titel"
 
-#: src/pages/PluginsOverlay.tsx:286
+#: src/pages/PluginsOverlay.tsx:421
 msgid "Tool sources"
 msgstr "Toolquellen"
 
-#: src/pages/PluginsOverlay.tsx:366
+#: src/pages/PluginsOverlay.tsx:383
 msgid "Treg token"
 msgstr "Treg-Token"
 
@@ -2436,16 +2413,16 @@ msgstr "Gefundenes Modell verwenden"
 msgid "Use this model"
 msgstr "Dieses Modell verwenden"
 
-#: src/pages/PluginsOverlay.tsx:387
+#: src/pages/PluginsOverlay.tsx:404
 msgid "Verify and add"
 msgstr "Prüfen und hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:385
+#: src/pages/PluginsOverlay.tsx:402
 msgid "Verifying…"
 msgstr "Wird geprüft…"
 
 #: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4524
+#: src/pages/Shell.tsx:4526
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2458,7 +2435,7 @@ msgstr "Stimme"
 msgid "Waiting for sign-in…"
 msgstr "Warten auf Anmeldung…"
 
-#: src/pages/Shell.tsx:5166
+#: src/pages/Shell.tsx:5168
 msgid "Waiting…"
 msgstr "Warten…"
 
@@ -2467,7 +2444,7 @@ msgstr "Warten…"
 msgid "Weekdays"
 msgstr "Wochentage"
 
-#: src/pages/Shell.tsx:4836
+#: src/pages/Shell.tsx:4838
 msgid "What about its memories?"
 msgstr "Was soll mit seinen Erinnerungen geschehen?"
 
@@ -2476,7 +2453,7 @@ msgid "What result will you demonstrate?"
 msgstr "Welches Ergebnis wirst du vorführen?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4264
+#: src/pages/Shell.tsx:4266
 msgid "What this bot is for"
 msgstr "Wofür dieser Bot gedacht ist"
 
@@ -2505,7 +2482,7 @@ msgstr "Wo sollen Bots ausgeführt werden?"
 msgid "Working…"
 msgstr "Wird verarbeitet…"
 
-#: src/pages/Shell.tsx:4454
+#: src/pages/Shell.tsx:4456
 msgid "Workspace default"
 msgstr "Arbeitsbereichsstandard"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -46,7 +46,7 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5139
+#: src/pages/Shell.tsx:5141
 msgid "{0} connection"
 msgstr "{0} connection"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# peer} other {# peers}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} has not messaged another bot yet."
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5018
 msgid "{botName}’s computer"
 msgstr "{botName}’s computer"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3320
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Access token (optional)"
 msgid "Account"
 msgstr "Account"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4532
 msgid "Account default"
 msgstr "Account default"
 
@@ -161,6 +161,7 @@ msgstr "Active voice"
 msgid "Activity"
 msgstr "Activity"
 
+#: src/pages/PluginsOverlay.tsx:281
 #: src/pages/ScratchpadSection.tsx:188
 msgid "Add"
 msgstr "Add"
@@ -185,15 +186,15 @@ msgstr "Add an HTTPS server URL."
 msgid "Add item"
 msgstr "Add item"
 
-#: src/pages/PluginsOverlay.tsx:245
+#: src/pages/PluginsOverlay.tsx:311
 msgid "Add MCP server"
 msgstr "Add MCP server"
 
-#: src/pages/PluginsOverlay.tsx:248
+#: src/pages/PluginsOverlay.tsx:314
 msgid "Add OpenAPI"
 msgstr "Add OpenAPI"
 
-#: src/pages/PluginsOverlay.tsx:312
+#: src/pages/PluginsOverlay.tsx:329
 msgid "Add remote MCP server"
 msgstr "Add remote MCP server"
 
@@ -206,17 +207,19 @@ msgstr "Add server"
 msgid "Add to routine"
 msgstr "Add to routine"
 
-#: src/pages/PluginsOverlay.tsx:242
+#: src/pages/PluginsOverlay.tsx:317
 msgid "Add Treg"
 msgstr "Add Treg"
 
 #: src/pages/McpServersOverlay.tsx:363
+#: src/pages/PluginsOverlay.tsx:276
 msgid "Adding…"
 msgstr "Adding…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/PluginsOverlay.tsx:291
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4433
+#: src/pages/Shell.tsx:4435
 msgid "Advanced"
 msgstr "Advanced"
 
@@ -299,7 +302,7 @@ msgstr "Answered: {answer}"
 msgid "API key"
 msgstr "API key"
 
-#: src/pages/PluginsOverlay.tsx:348
+#: src/pages/PluginsOverlay.tsx:365
 msgid "API key header"
 msgstr "API key header"
 
@@ -311,23 +314,19 @@ msgstr "Applies when you click Add server. Use the agent chips on each server ca
 msgid "Approval boundaries"
 msgstr "Approval boundaries"
 
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5334
 msgid "Approve"
 msgstr "Approve"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5325
 msgid "Approve this server to let your agent use its tools."
 msgstr "Approve this server to let your agent use its tools."
-
-#: src/pages/PluginsOverlay.tsx:282
-msgid "Apps"
-msgstr "Apps"
 
 #: src/pages/BotContextMenu.tsx:102
 msgid "Archive"
 msgstr "Archive"
 
-#: src/pages/Shell.tsx:3981
+#: src/pages/Shell.tsx:3983
 msgid "archived"
 msgstr "archived"
 
@@ -335,7 +334,7 @@ msgstr "archived"
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/Shell.tsx:3992
+#: src/pages/Shell.tsx:3994
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archived. Chat, memory, and files kept."
 
@@ -389,11 +388,11 @@ msgstr "at {0}"
 msgid "at {timeSelect}"
 msgstr "at {timeSelect}"
 
-#: src/pages/Shell.tsx:3389
+#: src/pages/Shell.tsx:3391
 msgid "Attach file"
 msgstr "Attach file"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3590
 msgid "Attachment"
 msgstr "Attachment"
 
@@ -406,12 +405,12 @@ msgstr "Authorization code or callback URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Authorization expired — reconnect required"
 
-#: src/pages/Shell.tsx:5124
+#: src/pages/Shell.tsx:5126
 msgid "Authorization timed out. Please try again."
 msgstr "Authorization timed out. Please try again."
 
-#: src/pages/Shell.tsx:5166
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5168
+#: src/pages/Shell.tsx:5334
 msgid "Authorize"
 msgstr "Authorize"
 
@@ -419,11 +418,11 @@ msgstr "Authorize"
 msgid "Base URL"
 msgstr "Base URL"
 
-#: src/pages/PluginsOverlay.tsx:345
+#: src/pages/PluginsOverlay.tsx:362
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:5010
 msgid "Booting live desktop…"
 msgstr "Booting live desktop…"
 
@@ -432,9 +431,9 @@ msgstr "Booting live desktop…"
 msgid "Booting up {0}’s computer"
 msgstr "Booting up {0}’s computer"
 
-#: src/pages/Shell.tsx:3851
-#: src/pages/Shell.tsx:3852
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:3853
+#: src/pages/Shell.tsx:3854
+#: src/pages/Shell.tsx:3987
 msgid "bot"
 msgstr "bot"
 
@@ -474,15 +473,15 @@ msgstr "Can't reach the server."
 
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
-#: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4692
-#: src/pages/Shell.tsx:4764
-#: src/pages/Shell.tsx:4879
-#: src/pages/Shell.tsx:4953
+#: src/pages/PluginsOverlay.tsx:413
+#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4766
+#: src/pages/Shell.tsx:4881
+#: src/pages/Shell.tsx:4955
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:4231
 msgid "Cancel new bot"
 msgstr "Cancel new bot"
 
@@ -490,7 +489,7 @@ msgstr "Cancel new bot"
 msgid "Cancel new group"
 msgstr "Cancel new group"
 
-#: src/pages/Shell.tsx:3265
+#: src/pages/Shell.tsx:3267
 msgid "Cancel reply"
 msgstr "Cancel reply"
 
@@ -498,11 +497,11 @@ msgstr "Cancel reply"
 msgid "Cancelled"
 msgstr "Cancelled"
 
-#: src/pages/Shell.tsx:5229
+#: src/pages/Shell.tsx:5231
 msgid "Chart failed to render: {error}"
 msgstr "Chart failed to render: {error}"
 
-#: src/pages/Shell.tsx:3531
+#: src/pages/Shell.tsx:3533
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
@@ -519,21 +518,21 @@ msgstr "Choose a model to get started."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Choose which connected model Rakazo uses."
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4781
 msgid "Clear"
 msgstr "Clear"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4745
+#: src/pages/Shell.tsx:4747
 msgid "Clear {0}’s conversation?"
 msgstr "Clear {0}’s conversation?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4585
+#: src/pages/Shell.tsx:4587
 msgid "Clear conversation"
 msgstr "Clear conversation"
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4781
 msgid "Clearing…"
 msgstr "Clearing…"
 
@@ -549,7 +548,7 @@ msgstr "Close bot menu"
 msgid "Close bot messages"
 msgstr "Close bot messages"
 
-#: src/pages/Shell.tsx:5414
+#: src/pages/Shell.tsx:5416
 msgid "Close chart"
 msgstr "Close chart"
 
@@ -557,11 +556,11 @@ msgstr "Close chart"
 msgid "Close computer"
 msgstr "Close computer"
 
-#: src/pages/Shell.tsx:5514
+#: src/pages/Shell.tsx:5516
 msgid "Close image preview"
 msgstr "Close image preview"
 
-#: src/pages/PluginsOverlay.tsx:231
+#: src/pages/PluginsOverlay.tsx:212
 msgid "Close integrations"
 msgstr "Close integrations"
 
@@ -610,12 +609,12 @@ msgstr "Command"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/pages/Shell.tsx:4139
-#: src/pages/Shell.tsx:4167
+#: src/pages/Shell.tsx:4141
+#: src/pages/Shell.tsx:4169
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5011
+#: src/pages/Shell.tsx:5013
 msgid "Computer failed to boot"
 msgstr "Computer failed to boot"
 
@@ -623,11 +622,11 @@ msgstr "Computer failed to boot"
 msgid "Computer is asleep"
 msgstr "Computer is asleep"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5012
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer is asleep — take control to wake it"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5014
 msgid "Computer is stopped"
 msgstr "Computer is stopped"
 
@@ -644,7 +643,6 @@ msgid "Confirm delete"
 msgstr "Confirm delete"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/PluginsOverlay.tsx:499
 #: src/pages/VoiceSettingsOverlay.tsx:257
 msgid "Connect"
 msgstr "Connect"
@@ -657,15 +655,11 @@ msgstr "Connect a model"
 msgid "Connect API key"
 msgstr "Connect API key"
 
-#: src/pages/PluginsOverlay.tsx:216
-msgid "Connect apps or add Treg, MCP, and OpenAPI tool sources."
-msgstr "Connect apps or add Treg, MCP, and OpenAPI tool sources."
-
 #: src/pages/VoiceSettingsOverlay.tsx:160
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "Connect ElevenLabs, OpenAI, or Cartesia"
 
-#: src/pages/Shell.tsx:5312
+#: src/pages/Shell.tsx:5314
 msgid "Connect MCP server “{name}”"
 msgstr "Connect MCP server “{name}”"
 
@@ -681,20 +675,19 @@ msgstr "Connect remote or local tool servers and choose which agents can use the
 msgid "Connect this provider to use it as your personal model."
 msgstr "Connect this provider to use it as your personal model."
 
-#: src/pages/PluginsOverlay.tsx:310
+#: src/pages/PluginsOverlay.tsx:327
 msgid "Connect Treg"
 msgstr "Connect Treg"
 
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
-#: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5163
+#: src/pages/Shell.tsx:5165
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Connected"
 
-#: src/pages/Shell.tsx:5342
+#: src/pages/Shell.tsx:5344
 msgid "Connected — its tools are available from your next message."
 msgstr "Connected — its tools are available from your next message."
 
@@ -719,14 +712,13 @@ msgstr "Connected and using {0}."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5334
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Connecting…"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:117
+#: src/pages/PluginsOverlay.tsx:114
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "Connection to {0} is still pending. You can close this and check again."
 
@@ -739,7 +731,7 @@ msgstr "Continue"
 msgid "Continue with email"
 msgstr "Continue with email"
 
-#: src/pages/Shell.tsx:3639
+#: src/pages/Shell.tsx:3641
 msgid "Copy"
 msgstr "Copy"
 
@@ -751,11 +743,11 @@ msgstr "Could not add"
 msgid "Could not add MCP server"
 msgstr "Could not add MCP server"
 
-#: src/pages/Shell.tsx:5299
+#: src/pages/Shell.tsx:5301
 msgid "Could not approve this server"
 msgstr "Could not approve this server"
 
-#: src/pages/Shell.tsx:5127
+#: src/pages/Shell.tsx:5129
 msgid "Could not authorize this app"
 msgstr "Could not authorize this app"
 
@@ -763,7 +755,7 @@ msgstr "Could not authorize this app"
 msgid "Could not change the default model"
 msgstr "Could not change the default model"
 
-#: src/pages/Shell.tsx:4773
+#: src/pages/Shell.tsx:4775
 msgid "Could not clear conversation"
 msgstr "Could not clear conversation"
 
@@ -771,7 +763,7 @@ msgstr "Could not clear conversation"
 msgid "Could not complete OAuth"
 msgstr "Could not complete OAuth"
 
-#: src/pages/PluginsOverlay.tsx:120
+#: src/pages/PluginsOverlay.tsx:117
 msgid "Could not connect"
 msgstr "Could not connect"
 
@@ -792,7 +784,7 @@ msgstr "Could not connect this voice provider"
 msgid "Could not continue"
 msgstr "Could not continue"
 
-#: src/pages/Shell.tsx:4217
+#: src/pages/Shell.tsx:4219
 msgid "Could not create bot"
 msgstr "Could not create bot"
 
@@ -800,7 +792,7 @@ msgstr "Could not create bot"
 msgid "Could not create group"
 msgstr "Could not create group"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4666
 msgid "Could not create section"
 msgstr "Could not create section"
 
@@ -808,7 +800,7 @@ msgstr "Could not create section"
 msgid "Could not create your bot"
 msgstr "Could not create your bot"
 
-#: src/pages/Shell.tsx:4888
+#: src/pages/Shell.tsx:4890
 msgid "Could not delete bot"
 msgstr "Could not delete bot"
 
@@ -816,7 +808,7 @@ msgstr "Could not delete bot"
 msgid "Could not delete MCP server"
 msgstr "Could not delete MCP server"
 
-#: src/pages/Shell.tsx:4962
+#: src/pages/Shell.tsx:4964
 msgid "Could not delete routine"
 msgstr "Could not delete routine"
 
@@ -837,7 +829,7 @@ msgstr "Could not download {0}. Try again."
 msgid "Could not download {name}. Try again."
 msgstr "Could not download {name}. Try again."
 
-#: src/pages/PluginsOverlay.tsx:188
+#: src/pages/PluginsOverlay.tsx:184
 msgid "Could not install connector"
 msgstr "Could not install connector"
 
@@ -845,7 +837,7 @@ msgstr "Could not install connector"
 msgid "Could not load approval rules"
 msgstr "Could not load approval rules"
 
-#: src/pages/PluginsOverlay.tsx:62
+#: src/pages/PluginsOverlay.tsx:60
 msgid "Could not load integrations"
 msgstr "Could not load integrations"
 
@@ -878,7 +870,7 @@ msgstr "Could not reach this model server"
 msgid "Could not remove"
 msgstr "Could not remove"
 
-#: src/pages/PluginsOverlay.tsx:201
+#: src/pages/PluginsOverlay.tsx:197
 msgid "Could not remove connector"
 msgstr "Could not remove connector"
 
@@ -890,15 +882,15 @@ msgstr "Could not remove group"
 msgid "Could not remove rule"
 msgstr "Could not remove rule"
 
-#: src/pages/Shell.tsx:5219
+#: src/pages/Shell.tsx:5221
 msgid "Could not render chart"
 msgstr "Could not render chart"
 
-#: src/pages/PluginsOverlay.tsx:146
+#: src/pages/PluginsOverlay.tsx:143
 msgid "Could not revoke connection"
 msgstr "Could not revoke connection"
 
-#: src/pages/Shell.tsx:4570
+#: src/pages/Shell.tsx:4572
 msgid "Could not save"
 msgstr "Could not save"
 
@@ -926,7 +918,7 @@ msgstr "Could not save that choice"
 msgid "Could not save that voice"
 msgstr "Could not save that voice"
 
-#: src/pages/Shell.tsx:5039
+#: src/pages/Shell.tsx:5041
 msgid "Could not save this choice"
 msgstr "Could not save this choice"
 
@@ -959,13 +951,13 @@ msgid "Could not update the default memory scope"
 msgstr "Could not update the default memory scope"
 
 #: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4278
+#: src/pages/Shell.tsx:4701
 msgid "Create"
 msgstr "Create"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4673
+#: src/pages/Shell.tsx:4675
 msgid "Create a section and move {0} into it."
 msgstr "Create a section and move {0} into it."
 
@@ -986,16 +978,16 @@ msgid "Create your Rakazo"
 msgstr "Create your Rakazo"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4278
+#: src/pages/Shell.tsx:4701
 msgid "Creating…"
 msgstr "Creating…"
 
-#: src/pages/PluginsOverlay.tsx:366
+#: src/pages/PluginsOverlay.tsx:383
 msgid "Credential"
 msgstr "Credential"
 
-#: src/pages/PluginsOverlay.tsx:417
+#: src/pages/PluginsOverlay.tsx:441
 msgid "credential saved"
 msgstr "credential saved"
 
@@ -1015,7 +1007,7 @@ msgstr "day"
 msgid "days"
 msgstr "days"
 
-#: src/pages/Shell.tsx:4477
+#: src/pages/Shell.tsx:4479
 msgid "Default (medium)"
 msgstr "Default (medium)"
 
@@ -1026,8 +1018,8 @@ msgstr "Default scope"
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
 #: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4970
 msgid "Delete"
 msgstr "Delete"
 
@@ -1038,8 +1030,8 @@ msgstr "Delete {0}"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4826
-#: src/pages/Shell.tsx:4940
+#: src/pages/Shell.tsx:4828
+#: src/pages/Shell.tsx:4942
 msgid "Delete {0}?"
 msgstr "Delete {0}?"
 
@@ -1047,7 +1039,7 @@ msgstr "Delete {0}?"
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/pages/Shell.tsx:4863
+#: src/pages/Shell.tsx:4865
 msgid "Delete memories too"
 msgstr "Delete memories too"
 
@@ -1055,13 +1047,13 @@ msgstr "Delete memories too"
 msgid "Delete routine"
 msgstr "Delete routine"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:3985
 msgid "deleted"
 msgstr "deleted"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4970
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1078,17 +1070,17 @@ msgid "Deployment default"
 msgstr "Deployment default"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4254
+#: src/pages/Shell.tsx:4256
 msgid "Describe what this bot does"
 msgstr "Describe what this bot does"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4259
-#: src/pages/Shell.tsx:4421
+#: src/pages/Shell.tsx:4261
+#: src/pages/Shell.tsx:4423
 msgid "Description"
 msgstr "Description"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3400
 msgid "Dictate"
 msgstr "Dictate"
 
@@ -1101,11 +1093,11 @@ msgstr "Disconnect"
 msgid "Disconnecting…"
 msgstr "Disconnecting…"
 
-#: src/pages/Shell.tsx:5347
+#: src/pages/Shell.tsx:5349
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Dismissed — reconnect anytime from MCP settings."
 
-#: src/pages/PluginsOverlay.tsx:320
+#: src/pages/PluginsOverlay.tsx:337
 msgid "Display name"
 msgstr "Display name"
 
@@ -1201,11 +1193,11 @@ msgstr "Every month"
 msgid "Every week"
 msgstr "Every week"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5395
 msgid "Expand"
 msgstr "Expand"
 
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4584
 msgid "Export"
 msgstr "Export"
 
@@ -1213,7 +1205,7 @@ msgstr "Export"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Export this week's list from the CRM and drop it in the shared folder"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4599
 msgid "Extra high"
 msgstr "Extra high"
 
@@ -1274,7 +1266,7 @@ msgid "Hang up"
 msgstr "Hang up"
 
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/PluginsOverlay.tsx:356
+#: src/pages/PluginsOverlay.tsx:373
 msgid "Header name"
 msgstr "Header name"
 
@@ -1290,15 +1282,15 @@ msgstr "Hear a sample"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hi, this is how I'll sound when I read replies out loud."
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4602
 msgid "High"
 msgstr "High"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3419
 msgid "Hold to talk"
 msgstr "Hold to talk"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3419
 msgid "Hold to talk (on-device dictation)"
 msgstr "Hold to talk (on-device dictation)"
 
@@ -1318,7 +1310,7 @@ msgstr "How often"
 msgid "How to check"
 msgstr "How to check"
 
-#: src/pages/Shell.tsx:3695
+#: src/pages/Shell.tsx:3697
 msgid "I’m done"
 msgstr "I’m done"
 
@@ -1326,11 +1318,11 @@ msgstr "I’m done"
 msgid "If you heard that, voice is ready."
 msgstr "If you heard that, voice is ready."
 
-#: src/pages/PluginsOverlay.tsx:314
+#: src/pages/PluginsOverlay.tsx:331
 msgid "Import OpenAPI JSON"
 msgstr "Import OpenAPI JSON"
 
-#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4494
 msgid "Inherit default"
 msgstr "Inherit default"
 
@@ -1346,11 +1338,7 @@ msgstr "Instance API key"
 msgid "Instruction"
 msgstr "Instruction"
 
-#: src/pages/PluginsOverlay.tsx:263
-msgid "Integration views"
-msgstr "Integration views"
-
-#: src/pages/PluginsOverlay.tsx:213
+#: src/pages/PluginsOverlay.tsx:208
 #: src/pages/Shell.tsx:1953
 msgid "Integrations"
 msgstr "Integrations"
@@ -1372,15 +1360,15 @@ msgid "Interval unit"
 msgstr "Interval unit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4495
 msgid "Isolated"
 msgstr "Isolated"
 
-#: src/pages/Shell.tsx:4829
+#: src/pages/Shell.tsx:4831
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 
-#: src/pages/Shell.tsx:3791
+#: src/pages/Shell.tsx:3793
 msgid "Jump to replied message"
 msgstr "Jump to replied message"
 
@@ -1388,7 +1376,7 @@ msgstr "Jump to replied message"
 msgid "just now"
 msgstr "just now"
 
-#: src/pages/Shell.tsx:4847
+#: src/pages/Shell.tsx:4849
 msgid "Keep memories"
 msgstr "Keep memories"
 
@@ -1414,7 +1402,7 @@ msgstr "Load earlier messages"
 msgid "Loading activity…"
 msgstr "Loading activity…"
 
-#: src/pages/PluginsOverlay.tsx:300
+#: src/pages/PluginsOverlay.tsx:233
 msgid "Loading integrations…"
 msgstr "Loading integrations…"
 
@@ -1458,7 +1446,7 @@ msgstr "Local"
 msgid "Log out"
 msgstr "Log out"
 
-#: src/pages/Shell.tsx:4598
+#: src/pages/Shell.tsx:4600
 msgid "Low"
 msgstr "Low"
 
@@ -1474,17 +1462,17 @@ msgstr "Mark as Read"
 msgid "Mark as Unread"
 msgstr "Mark as Unread"
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4604
 msgid "Max"
 msgstr "Max"
 
 #: src/pages/McpServersOverlay.tsx:224
 #: src/pages/McpServersOverlay.tsx:229
-#: src/pages/PluginsOverlay.tsx:226
+#: src/pages/PluginsOverlay.tsx:305
 msgid "MCP servers"
 msgstr "MCP servers"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4601
 msgid "Medium"
 msgstr "Medium"
 
@@ -1501,29 +1489,29 @@ msgstr "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgid "Memory"
 msgstr "Memory"
 
-#: src/pages/Shell.tsx:4488
+#: src/pages/Shell.tsx:4490
 msgid "Memory scope"
 msgstr "Memory scope"
 
-#: src/pages/Shell.tsx:3495
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3497
+#: src/pages/Shell.tsx:3592
 msgid "Message"
 msgstr "Message"
 
-#: src/pages/Shell.tsx:3491
-#: src/pages/Shell.tsx:3495
+#: src/pages/Shell.tsx:3493
+#: src/pages/Shell.tsx:3497
 msgid "Message {activeName}"
 msgstr "Message {activeName}"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3871
 msgid "Message from {peer}"
 msgstr "Message from {peer}"
 
-#: src/pages/Shell.tsx:3492
+#: src/pages/Shell.tsx:3494
 msgid "Message…"
 msgstr "Message…"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3871
 msgid "Messaged {peer}"
 msgstr "Messaged {peer}"
 
@@ -1531,7 +1519,7 @@ msgstr "Messaged {peer}"
 msgid "Microphone failed"
 msgstr "Microphone failed"
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4603
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1553,7 +1541,7 @@ msgstr "minutes"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4444
+#: src/pages/Shell.tsx:4446
 msgid "Model"
 msgstr "Model"
 
@@ -1593,7 +1581,7 @@ msgstr "Monthly"
 msgid "Move {0} to section"
 msgstr "Move {0} to section"
 
-#: src/pages/Shell.tsx:4850
+#: src/pages/Shell.tsx:4852
 msgid "Move them to your shared memory."
 msgstr "Move them to your shared memory."
 
@@ -1607,14 +1595,14 @@ msgstr "Move to"
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
 #: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4239
-#: src/pages/Shell.tsx:4403
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:4241
+#: src/pages/Shell.tsx:4405
+#: src/pages/Shell.tsx:4678
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4244
+#: src/pages/Shell.tsx:4246
 msgid "Name this bot"
 msgstr "Name this bot"
 
@@ -1631,7 +1619,7 @@ msgid "Needs takeover"
 msgstr "Needs takeover"
 
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4227
+#: src/pages/Shell.tsx:4229
 msgid "New bot"
 msgstr "New bot"
 
@@ -1649,29 +1637,24 @@ msgid "New routine"
 msgstr "New routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4670
+#: src/pages/Shell.tsx:4672
 msgid "New section"
 msgstr "New section"
 
-#: src/pages/PluginsOverlay.tsx:448
+#: src/pages/PluginsOverlay.tsx:244
 msgid "No apps match your search."
 msgstr "No apps match your search."
 
-#: src/pages/PluginsOverlay.tsx:419
-#: src/pages/PluginsOverlay.tsx:476
+#: src/pages/PluginsOverlay.tsx:443
 msgid "no auth"
 msgstr "no auth"
 
-#: src/pages/PluginsOverlay.tsx:342
+#: src/pages/PluginsOverlay.tsx:359
 msgid "No authentication"
 msgstr "No authentication"
 
-#: src/pages/PluginsOverlay.tsx:450
-msgid "No connected apps yet."
-msgstr "No connected apps yet."
-
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:142
+#: src/pages/PluginsOverlay.tsx:139
 msgid "No connection record found for {0}."
 msgstr "No connection record found for {0}."
 
@@ -1687,11 +1670,11 @@ msgstr "No exceptions. Actions run automatically."
 msgid "No longer active"
 msgstr "No longer active"
 
-#: src/pages/PluginsOverlay.tsx:439
-msgid "No managed app catalog is configured on this deployment. You can still add Treg, MCP, or OpenAPI sources."
-msgstr "No managed app catalog is configured on this deployment. You can still add Treg, MCP, or OpenAPI sources."
+#: src/pages/PluginsOverlay.tsx:239
+msgid "No managed app catalog is configured on this deployment."
+msgstr "No managed app catalog is configured on this deployment."
 
-#: src/pages/PluginsOverlay.tsx:404
+#: src/pages/PluginsOverlay.tsx:425
 msgid "No MCP or API tool sources installed yet."
 msgstr "No MCP or API tool sources installed yet."
 
@@ -1724,7 +1707,7 @@ msgstr "Not configured"
 msgid "Not connected"
 msgstr "Not connected"
 
-#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5337
 msgid "Not now"
 msgstr "Not now"
 
@@ -1787,7 +1770,7 @@ msgstr "Open work"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-compatible server URL"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:3996
 msgid "Opened its thread."
 msgstr "Opened its thread."
 
@@ -1870,7 +1853,7 @@ msgstr "Playing…"
 msgid "Preview {0}"
 msgstr "Preview {0}"
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4184
 msgid "Private"
 msgstr "Private"
 
@@ -1887,11 +1870,11 @@ msgstr "Providers"
 msgid "Queued"
 msgstr "Queued"
 
-#: src/pages/PluginsOverlay.tsx:371
+#: src/pages/PluginsOverlay.tsx:388
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 
-#: src/pages/Shell.tsx:4520
+#: src/pages/Shell.tsx:4522
 msgid "Read replies aloud"
 msgstr "Read replies aloud"
 
@@ -1913,28 +1896,29 @@ msgstr "Reconnecting"
 msgid "Recording: {0}"
 msgstr "Recording: {0}"
 
-#: src/pages/Shell.tsx:3685
+#: src/pages/Shell.tsx:3687
 msgid "Release"
 msgstr "Release"
 
 #: src/components/ApprovalRulesSettings.tsx:138
-#: src/pages/PluginsOverlay.tsx:430
+#: src/pages/PluginsOverlay.tsx:279
+#: src/pages/PluginsOverlay.tsx:454
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3299
+#: src/pages/Shell.tsx:3301
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3454
+#: src/pages/Shell.tsx:3456
 msgid "Remove mention {0}"
 msgstr "Remove mention {0}"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3433
+#: src/pages/Shell.tsx:3435
 msgid "Remove skill {0}"
 msgstr "Remove skill {0}"
 
@@ -1942,7 +1926,7 @@ msgstr "Remove skill {0}"
 msgid "Remove this schedule"
 msgstr "Remove this schedule"
 
-#: src/pages/Shell.tsx:3993
+#: src/pages/Shell.tsx:3995
 msgid "Removed with chat, computer, and memory."
 msgstr "Removed with chat, computer, and memory."
 
@@ -1950,7 +1934,8 @@ msgstr "Removed with chat, computer, and memory."
 msgid "Removed, but list refresh failed"
 msgstr "Removed, but list refresh failed"
 
-#: src/pages/PluginsOverlay.tsx:430
+#: src/pages/PluginsOverlay.tsx:274
+#: src/pages/PluginsOverlay.tsx:454
 msgid "Removing…"
 msgstr "Removing…"
 
@@ -1968,11 +1953,11 @@ msgstr "Replace API key"
 msgid "Replace key"
 msgstr "Replace key"
 
-#: src/pages/Shell.tsx:3631
+#: src/pages/Shell.tsx:3633
 msgid "Reply"
 msgstr "Reply"
 
-#: src/pages/Shell.tsx:3262
+#: src/pages/Shell.tsx:3264
 msgid "Replying to {replyName}"
 msgstr "Replying to {replyName}"
 
@@ -1987,14 +1972,6 @@ msgstr "Retry now"
 #: src/pages/McpOAuthCallback.tsx:65
 msgid "Return to Rakazo"
 msgstr "Return to Rakazo"
-
-#: src/pages/PluginsOverlay.tsx:497
-msgid "Revoke"
-msgstr "Revoke"
-
-#: src/pages/PluginsOverlay.tsx:492
-msgid "Revoking…"
-msgstr "Revoking…"
 
 #: src/pages/Shell.tsx:2488
 #: src/pages/Shell.tsx:2541
@@ -2027,7 +2004,7 @@ msgstr "Running…"
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
 #: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4575
+#: src/pages/Shell.tsx:4577
 msgid "Save"
 msgstr "Save"
 
@@ -2068,7 +2045,7 @@ msgstr "Say yes or no, or answer in a sentence."
 msgid "Search"
 msgstr "Search"
 
-#: src/pages/PluginsOverlay.tsx:257
+#: src/pages/PluginsOverlay.tsx:224
 msgid "Search apps"
 msgstr "Search apps"
 
@@ -2090,7 +2067,7 @@ msgstr "Searching…"
 msgid "Select a bot"
 msgstr "Select a bot"
 
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3517
 msgid "Send"
 msgstr "Send"
 
@@ -2129,11 +2106,11 @@ msgstr "Set up voice to call"
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3535
 msgid "Settings: General"
 msgstr "Settings: General"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3537
 msgid "Settings: Usage"
 msgstr "Settings: Usage"
 
@@ -2143,7 +2120,7 @@ msgid "Setup help"
 msgstr "Setup help"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4496
 msgid "Shared"
 msgstr "Shared"
 
@@ -2175,11 +2152,11 @@ msgid "Sign up"
 msgstr "Sign up"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3346
+#: src/pages/Shell.tsx:3348
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3694
 msgid "Skip"
 msgstr "Skip"
 
@@ -2200,8 +2177,8 @@ msgstr "Skipped {0}"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space interrupts · Esc hangs up"
 
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3840
+#: src/pages/Shell.tsx:4093
 msgid "Speak"
 msgstr "Speak"
 
@@ -2213,8 +2190,8 @@ msgstr "Speak + transcribe"
 msgid "Speak only"
 msgstr "Speak only"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3836
+#: src/pages/Shell.tsx:4089
 msgid "Speak this reply"
 msgstr "Speak this reply"
 
@@ -2242,18 +2219,18 @@ msgstr "Steps"
 
 #: src/pages/Shell.tsx:2866
 #: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3506
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3508
+#: src/pages/Shell.tsx:3840
+#: src/pages/Shell.tsx:4093
 msgid "Stop"
 msgstr "Stop"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3400
 msgid "Stop dictation"
 msgstr "Stop dictation"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3836
+#: src/pages/Shell.tsx:4089
 msgid "Stop speaking"
 msgstr "Stop speaking"
 
@@ -2271,7 +2248,7 @@ msgstr "Stop the bot first"
 msgid "Stored encrypted"
 msgstr "Stored encrypted"
 
-#: src/pages/Shell.tsx:3945
+#: src/pages/Shell.tsx:3947
 msgid "subagent"
 msgstr "subagent"
 
@@ -2301,11 +2278,11 @@ msgstr "Teaching in progress — stop teaching before sending a new message."
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4184
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5018
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -2318,7 +2295,7 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "The selected memory provider is not available in this build."
 
-#: src/pages/Shell.tsx:4471
+#: src/pages/Shell.tsx:4473
 msgid "Thinking"
 msgstr "Thinking"
 
@@ -2330,8 +2307,8 @@ msgstr "This bot runs on this computer, not a Linux desktop. Shell and files use
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 
-#: src/pages/Shell.tsx:4866
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4868
+#: src/pages/Shell.tsx:4945
 msgid "This cannot be undone."
 msgstr "This cannot be undone."
 
@@ -2355,7 +2332,7 @@ msgstr "this Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 
-#: src/pages/Shell.tsx:4751
+#: src/pages/Shell.tsx:4753
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 
@@ -2363,7 +2340,7 @@ msgstr "This permanently removes every message and stops current work. The bot, 
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "This provider cannot paste a key here. Skip if this deployment already has credentials."
 
-#: src/pages/Shell.tsx:5283
+#: src/pages/Shell.tsx:5285
 msgid "This server cannot be assigned without a bot."
 msgstr "This server cannot be assigned without a bot."
 
@@ -2375,7 +2352,7 @@ msgstr "This server did not request browser authorization."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "This server is already connected. Disconnect it first to authorize again."
 
-#: src/pages/Shell.tsx:5322
+#: src/pages/Shell.tsx:5324
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 
@@ -2388,16 +2365,16 @@ msgid "Time of day"
 msgstr "Time of day"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4249
-#: src/pages/Shell.tsx:4412
+#: src/pages/Shell.tsx:4251
+#: src/pages/Shell.tsx:4414
 msgid "Title"
 msgstr "Title"
 
-#: src/pages/PluginsOverlay.tsx:286
+#: src/pages/PluginsOverlay.tsx:421
 msgid "Tool sources"
 msgstr "Tool sources"
 
-#: src/pages/PluginsOverlay.tsx:366
+#: src/pages/PluginsOverlay.tsx:383
 msgid "Treg token"
 msgstr "Treg token"
 
@@ -2436,16 +2413,16 @@ msgstr "Use a found model"
 msgid "Use this model"
 msgstr "Use this model"
 
-#: src/pages/PluginsOverlay.tsx:387
+#: src/pages/PluginsOverlay.tsx:404
 msgid "Verify and add"
 msgstr "Verify and add"
 
-#: src/pages/PluginsOverlay.tsx:385
+#: src/pages/PluginsOverlay.tsx:402
 msgid "Verifying…"
 msgstr "Verifying…"
 
 #: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4524
+#: src/pages/Shell.tsx:4526
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2458,7 +2435,7 @@ msgstr "Voice"
 msgid "Waiting for sign-in…"
 msgstr "Waiting for sign-in…"
 
-#: src/pages/Shell.tsx:5166
+#: src/pages/Shell.tsx:5168
 msgid "Waiting…"
 msgstr "Waiting…"
 
@@ -2467,7 +2444,7 @@ msgstr "Waiting…"
 msgid "Weekdays"
 msgstr "Weekdays"
 
-#: src/pages/Shell.tsx:4836
+#: src/pages/Shell.tsx:4838
 msgid "What about its memories?"
 msgstr "What about its memories?"
 
@@ -2476,7 +2453,7 @@ msgid "What result will you demonstrate?"
 msgstr "What result will you demonstrate?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4264
+#: src/pages/Shell.tsx:4266
 msgid "What this bot is for"
 msgstr "What this bot is for"
 
@@ -2505,7 +2482,7 @@ msgstr "Where should bots run?"
 msgid "Working…"
 msgstr "Working…"
 
-#: src/pages/Shell.tsx:4454
+#: src/pages/Shell.tsx:4456
 msgid "Workspace default"
 msgstr "Workspace default"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -46,7 +46,7 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5139
+#: src/pages/Shell.tsx:5141
 msgid "{0} connection"
 msgstr "{0} 연결"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {동료 Bot #개} other {동료 Bot #개}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName}은 아직 다른 Bot에게 메시지를 보내지 않았습니다."
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5018
 msgid "{botName}’s computer"
 msgstr "{botName}의 컴퓨터"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3320
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "액세스 토큰(선택 사항)"
 msgid "Account"
 msgstr "계정"
 
-#: src/pages/Shell.tsx:4530
+#: src/pages/Shell.tsx:4532
 msgid "Account default"
 msgstr "계정 기본값"
 
@@ -161,6 +161,7 @@ msgstr "현재 목소리"
 msgid "Activity"
 msgstr "활동"
 
+#: src/pages/PluginsOverlay.tsx:281
 #: src/pages/ScratchpadSection.tsx:188
 msgid "Add"
 msgstr "추가"
@@ -185,15 +186,15 @@ msgstr "HTTPS 서버 URL을 입력하세요."
 msgid "Add item"
 msgstr "항목 추가"
 
-#: src/pages/PluginsOverlay.tsx:245
+#: src/pages/PluginsOverlay.tsx:311
 msgid "Add MCP server"
 msgstr "MCP 서버 추가"
 
-#: src/pages/PluginsOverlay.tsx:248
+#: src/pages/PluginsOverlay.tsx:314
 msgid "Add OpenAPI"
 msgstr "OpenAPI 추가"
 
-#: src/pages/PluginsOverlay.tsx:312
+#: src/pages/PluginsOverlay.tsx:329
 msgid "Add remote MCP server"
 msgstr "원격 MCP 서버 추가"
 
@@ -206,17 +207,19 @@ msgstr "서버 추가"
 msgid "Add to routine"
 msgstr "자동 실행에 추가"
 
-#: src/pages/PluginsOverlay.tsx:242
+#: src/pages/PluginsOverlay.tsx:317
 msgid "Add Treg"
 msgstr "Treg 추가"
 
 #: src/pages/McpServersOverlay.tsx:363
+#: src/pages/PluginsOverlay.tsx:276
 msgid "Adding…"
 msgstr "추가 중…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/PluginsOverlay.tsx:291
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4433
+#: src/pages/Shell.tsx:4435
 msgid "Advanced"
 msgstr "고급 설정"
 
@@ -299,7 +302,7 @@ msgstr "응답: {answer}"
 msgid "API key"
 msgstr "API 키"
 
-#: src/pages/PluginsOverlay.tsx:348
+#: src/pages/PluginsOverlay.tsx:365
 msgid "API key header"
 msgstr "API 키 헤더"
 
@@ -311,23 +314,19 @@ msgstr "서버를 추가할 때 적용됩니다. 각 서버 카드의 Bot 버튼
 msgid "Approval boundaries"
 msgstr "승인이 필요한 범위"
 
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5334
 msgid "Approve"
 msgstr "승인"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5325
 msgid "Approve this server to let your agent use its tools."
 msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 있습니다."
-
-#: src/pages/PluginsOverlay.tsx:282
-msgid "Apps"
-msgstr "앱"
 
 #: src/pages/BotContextMenu.tsx:102
 msgid "Archive"
 msgstr "보관"
 
-#: src/pages/Shell.tsx:3981
+#: src/pages/Shell.tsx:3983
 msgid "archived"
 msgstr "보관됨"
 
@@ -335,7 +334,7 @@ msgstr "보관됨"
 msgid "Archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:3992
+#: src/pages/Shell.tsx:3994
 msgid "Archived. Chat, memory, and files kept."
 msgstr "보관되었습니다. 대화, 기억, 파일은 유지됩니다."
 
@@ -389,11 +388,11 @@ msgstr "{0}에"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}에"
 
-#: src/pages/Shell.tsx:3389
+#: src/pages/Shell.tsx:3391
 msgid "Attach file"
 msgstr "파일 첨부"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3590
 msgid "Attachment"
 msgstr "첨부 파일"
 
@@ -406,12 +405,12 @@ msgstr "인증 코드 또는 돌아온 페이지 주소"
 msgid "Authorization expired — reconnect required"
 msgstr "인증이 만료됨 — 다시 연결해야 함"
 
-#: src/pages/Shell.tsx:5124
+#: src/pages/Shell.tsx:5126
 msgid "Authorization timed out. Please try again."
 msgstr "인증 시간이 만료되었습니다. 다시 시도해 주세요."
 
-#: src/pages/Shell.tsx:5166
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5168
+#: src/pages/Shell.tsx:5334
 msgid "Authorize"
 msgstr "인증하기"
 
@@ -419,11 +418,11 @@ msgstr "인증하기"
 msgid "Base URL"
 msgstr "서버 주소"
 
-#: src/pages/PluginsOverlay.tsx:345
+#: src/pages/PluginsOverlay.tsx:362
 msgid "Bearer token"
 msgstr "Bearer 토큰"
 
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:5010
 msgid "Booting live desktop…"
 msgstr "라이브 데스크톱 시작 중…"
 
@@ -432,9 +431,9 @@ msgstr "라이브 데스크톱 시작 중…"
 msgid "Booting up {0}’s computer"
 msgstr "{0}의 컴퓨터를 켜는 중"
 
-#: src/pages/Shell.tsx:3851
-#: src/pages/Shell.tsx:3852
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:3853
+#: src/pages/Shell.tsx:3854
+#: src/pages/Shell.tsx:3987
 msgid "bot"
 msgstr "Bot"
 
@@ -474,15 +473,15 @@ msgstr "서버에 연결할 수 없습니다."
 
 #: src/components/AskCard.tsx:129
 #: src/components/teach/TeachComputerSection.tsx:122
-#: src/pages/PluginsOverlay.tsx:396
-#: src/pages/Shell.tsx:4692
-#: src/pages/Shell.tsx:4764
-#: src/pages/Shell.tsx:4879
-#: src/pages/Shell.tsx:4953
+#: src/pages/PluginsOverlay.tsx:413
+#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4766
+#: src/pages/Shell.tsx:4881
+#: src/pages/Shell.tsx:4955
 msgid "Cancel"
 msgstr "취소"
 
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:4231
 msgid "Cancel new bot"
 msgstr "새 Bot 만들기 취소"
 
@@ -490,7 +489,7 @@ msgstr "새 Bot 만들기 취소"
 msgid "Cancel new group"
 msgstr "새 그룹 만들기 취소"
 
-#: src/pages/Shell.tsx:3265
+#: src/pages/Shell.tsx:3267
 msgid "Cancel reply"
 msgstr "답장 취소"
 
@@ -498,11 +497,11 @@ msgstr "답장 취소"
 msgid "Cancelled"
 msgstr "취소됨"
 
-#: src/pages/Shell.tsx:5229
+#: src/pages/Shell.tsx:5231
 msgid "Chart failed to render: {error}"
 msgstr "차트를 표시하지 못했습니다: {error}"
 
-#: src/pages/Shell.tsx:3531
+#: src/pages/Shell.tsx:3533
 msgid "Chat Settings"
 msgstr "채팅 설정"
 
@@ -519,21 +518,21 @@ msgstr "먼저 사용할 AI 모델을 선택하세요."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo에서 기본으로 사용할 연결된 모델을 선택하세요."
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4781
 msgid "Clear"
 msgstr "비우기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4745
+#: src/pages/Shell.tsx:4747
 msgid "Clear {0}’s conversation?"
 msgstr "{0}와의 대화 내용을 비울까요?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4585
+#: src/pages/Shell.tsx:4587
 msgid "Clear conversation"
 msgstr "대화 내용 비우기"
 
-#: src/pages/Shell.tsx:4779
+#: src/pages/Shell.tsx:4781
 msgid "Clearing…"
 msgstr "비우는 중…"
 
@@ -549,7 +548,7 @@ msgstr "Bot 메뉴 닫기"
 msgid "Close bot messages"
 msgstr "Bot 메시지 닫기"
 
-#: src/pages/Shell.tsx:5414
+#: src/pages/Shell.tsx:5416
 msgid "Close chart"
 msgstr "차트 닫기"
 
@@ -557,11 +556,11 @@ msgstr "차트 닫기"
 msgid "Close computer"
 msgstr "컴퓨터 닫기"
 
-#: src/pages/Shell.tsx:5514
+#: src/pages/Shell.tsx:5516
 msgid "Close image preview"
 msgstr "이미지 미리보기 닫기"
 
-#: src/pages/PluginsOverlay.tsx:231
+#: src/pages/PluginsOverlay.tsx:212
 msgid "Close integrations"
 msgstr "앱·도구 연동 닫기"
 
@@ -610,12 +609,12 @@ msgstr "실행 명령"
 msgid "Complete"
 msgstr "완료"
 
-#: src/pages/Shell.tsx:4139
-#: src/pages/Shell.tsx:4167
+#: src/pages/Shell.tsx:4141
+#: src/pages/Shell.tsx:4169
 msgid "Computer"
 msgstr "컴퓨터"
 
-#: src/pages/Shell.tsx:5011
+#: src/pages/Shell.tsx:5013
 msgid "Computer failed to boot"
 msgstr "컴퓨터를 시작하지 못했습니다"
 
@@ -623,11 +622,11 @@ msgstr "컴퓨터를 시작하지 못했습니다"
 msgid "Computer is asleep"
 msgstr "컴퓨터가 절전 상태입니다"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5012
 msgid "Computer is asleep — take control to wake it"
 msgstr "컴퓨터가 절전 상태입니다 — 제어를 맡아 깨우세요"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5014
 msgid "Computer is stopped"
 msgstr "컴퓨터가 중지됨"
 
@@ -644,7 +643,6 @@ msgid "Confirm delete"
 msgstr "삭제 확인"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/PluginsOverlay.tsx:499
 #: src/pages/VoiceSettingsOverlay.tsx:257
 msgid "Connect"
 msgstr "연결"
@@ -657,15 +655,11 @@ msgstr "AI 모델 연결"
 msgid "Connect API key"
 msgstr "API 키 연결"
 
-#: src/pages/PluginsOverlay.tsx:216
-msgid "Connect apps or add Treg, MCP, and OpenAPI tool sources."
-msgstr "앱을 연결하거나 Treg, MCP, OpenAPI 도구를 추가하세요."
-
 #: src/pages/VoiceSettingsOverlay.tsx:160
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI 또는 Cartesia 연결"
 
-#: src/pages/Shell.tsx:5312
+#: src/pages/Shell.tsx:5314
 msgid "Connect MCP server “{name}”"
 msgstr "MCP 서버 ‘{name}’ 연결"
 
@@ -681,20 +675,19 @@ msgstr "원격 또는 로컬 도구 서버를 연결하고 사용할 Bot을 선�
 msgid "Connect this provider to use it as your personal model."
 msgstr "이 AI 서비스를 연결하면 내 기본 모델로 사용할 수 있습니다."
 
-#: src/pages/PluginsOverlay.tsx:310
+#: src/pages/PluginsOverlay.tsx:327
 msgid "Connect Treg"
 msgstr "Treg 연결"
 
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
-#: src/pages/PluginsOverlay.tsx:284
-#: src/pages/Shell.tsx:5163
+#: src/pages/Shell.tsx:5165
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "연결됨"
 
-#: src/pages/Shell.tsx:5342
+#: src/pages/Shell.tsx:5344
 msgid "Connected — its tools are available from your next message."
 msgstr "연결되었습니다. 다음 메시지부터 이 도구를 사용할 수 있습니다."
 
@@ -719,14 +712,13 @@ msgstr "{0}에 연결하고 기본 모델로 설정했습니다."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/PluginsOverlay.tsx:494
-#: src/pages/Shell.tsx:5332
+#: src/pages/Shell.tsx:5334
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "연결 중…"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:117
+#: src/pages/PluginsOverlay.tsx:114
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "{0} 연결이 아직 진행 중입니다. 이 창을 닫고 나중에 다시 확인할 수 있습니다."
 
@@ -739,7 +731,7 @@ msgstr "계속"
 msgid "Continue with email"
 msgstr "이메일로 계속하기"
 
-#: src/pages/Shell.tsx:3639
+#: src/pages/Shell.tsx:3641
 msgid "Copy"
 msgstr "복사"
 
@@ -751,11 +743,11 @@ msgstr "추가하지 못했습니다."
 msgid "Could not add MCP server"
 msgstr "MCP 서버를 추가하지 못했습니다."
 
-#: src/pages/Shell.tsx:5299
+#: src/pages/Shell.tsx:5301
 msgid "Could not approve this server"
 msgstr "서버를 승인하지 못했습니다."
 
-#: src/pages/Shell.tsx:5127
+#: src/pages/Shell.tsx:5129
 msgid "Could not authorize this app"
 msgstr "앱 인증을 완료하지 못했습니다."
 
@@ -763,7 +755,7 @@ msgstr "앱 인증을 완료하지 못했습니다."
 msgid "Could not change the default model"
 msgstr "기본 모델을 변경하지 못했습니다."
 
-#: src/pages/Shell.tsx:4773
+#: src/pages/Shell.tsx:4775
 msgid "Could not clear conversation"
 msgstr "대화 내용을 비우지 못했습니다."
 
@@ -771,7 +763,7 @@ msgstr "대화 내용을 비우지 못했습니다."
 msgid "Could not complete OAuth"
 msgstr "OAuth 인증을 완료하지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:120
+#: src/pages/PluginsOverlay.tsx:117
 msgid "Could not connect"
 msgstr "연결하지 못했습니다."
 
@@ -792,7 +784,7 @@ msgstr "음성 서비스에 연결하지 못했습니다."
 msgid "Could not continue"
 msgstr "계속 진행하지 못했습니다."
 
-#: src/pages/Shell.tsx:4217
+#: src/pages/Shell.tsx:4219
 msgid "Could not create bot"
 msgstr "Bot을 만들지 못했습니다."
 
@@ -800,7 +792,7 @@ msgstr "Bot을 만들지 못했습니다."
 msgid "Could not create group"
 msgstr "그룹을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4666
 msgid "Could not create section"
 msgstr "섹션을 만들지 못했습니다."
 
@@ -808,7 +800,7 @@ msgstr "섹션을 만들지 못했습니다."
 msgid "Could not create your bot"
 msgstr "Bot을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4888
+#: src/pages/Shell.tsx:4890
 msgid "Could not delete bot"
 msgstr "Bot을 삭제하지 못했습니다."
 
@@ -816,7 +808,7 @@ msgstr "Bot을 삭제하지 못했습니다."
 msgid "Could not delete MCP server"
 msgstr "MCP 서버를 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4962
+#: src/pages/Shell.tsx:4964
 msgid "Could not delete routine"
 msgstr "자동 실행을 삭제하지 못했습니다."
 
@@ -837,7 +829,7 @@ msgstr "{0}을 다운로드하지 못했습니다. 다시 시도해 주세요."
 msgid "Could not download {name}. Try again."
 msgstr "{name}을 다운로드하지 못했습니다. 다시 시도해 주세요."
 
-#: src/pages/PluginsOverlay.tsx:188
+#: src/pages/PluginsOverlay.tsx:184
 msgid "Could not install connector"
 msgstr "도구 연결을 추가하지 못했습니다."
 
@@ -845,7 +837,7 @@ msgstr "도구 연결을 추가하지 못했습니다."
 msgid "Could not load approval rules"
 msgstr "확인 규칙을 불러오지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:62
+#: src/pages/PluginsOverlay.tsx:60
 msgid "Could not load integrations"
 msgstr "연동 목록을 불러오지 못했습니다."
 
@@ -878,7 +870,7 @@ msgstr "모델 서버에 연결하지 못했습니다."
 msgid "Could not remove"
 msgstr "삭제하지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:201
+#: src/pages/PluginsOverlay.tsx:197
 msgid "Could not remove connector"
 msgstr "도구 연결을 삭제하지 못했습니다."
 
@@ -890,15 +882,15 @@ msgstr "그룹을 삭제하지 못했습니다."
 msgid "Could not remove rule"
 msgstr "확인 규칙을 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:5219
+#: src/pages/Shell.tsx:5221
 msgid "Could not render chart"
 msgstr "차트를 만들지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:146
+#: src/pages/PluginsOverlay.tsx:143
 msgid "Could not revoke connection"
 msgstr "연결을 해제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4570
+#: src/pages/Shell.tsx:4572
 msgid "Could not save"
 msgstr "저장하지 못했습니다."
 
@@ -926,7 +918,7 @@ msgstr "선택 내용을 저장하지 못했습니다."
 msgid "Could not save that voice"
 msgstr "목소리를 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:5039
+#: src/pages/Shell.tsx:5041
 msgid "Could not save this choice"
 msgstr "선택 내용을 저장하지 못했습니다."
 
@@ -959,13 +951,13 @@ msgid "Could not update the default memory scope"
 msgstr "기본 기억 범위를 변경하지 못했습니다."
 
 #: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4278
+#: src/pages/Shell.tsx:4701
 msgid "Create"
 msgstr "만들기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4673
+#: src/pages/Shell.tsx:4675
 msgid "Create a section and move {0} into it."
 msgstr "새 섹션을 만들고 {0}을 옮깁니다."
 
@@ -986,16 +978,16 @@ msgid "Create your Rakazo"
 msgstr "Rakazo 계정 만들기"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4276
-#: src/pages/Shell.tsx:4699
+#: src/pages/Shell.tsx:4278
+#: src/pages/Shell.tsx:4701
 msgid "Creating…"
 msgstr "만드는 중…"
 
-#: src/pages/PluginsOverlay.tsx:366
+#: src/pages/PluginsOverlay.tsx:383
 msgid "Credential"
 msgstr "인증 정보"
 
-#: src/pages/PluginsOverlay.tsx:417
+#: src/pages/PluginsOverlay.tsx:441
 msgid "credential saved"
 msgstr "인증 정보 저장됨"
 
@@ -1015,7 +1007,7 @@ msgstr "일"
 msgid "days"
 msgstr "일"
 
-#: src/pages/Shell.tsx:4477
+#: src/pages/Shell.tsx:4479
 msgid "Default (medium)"
 msgstr "기본(보통)"
 
@@ -1026,8 +1018,8 @@ msgstr "기본 기억 범위"
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
 #: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4970
 msgid "Delete"
 msgstr "삭제"
 
@@ -1038,8 +1030,8 @@ msgstr "{0} 삭제"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4826
-#: src/pages/Shell.tsx:4940
+#: src/pages/Shell.tsx:4828
+#: src/pages/Shell.tsx:4942
 msgid "Delete {0}?"
 msgstr "{0}을 삭제할까요?"
 
@@ -1047,7 +1039,7 @@ msgstr "{0}을 삭제할까요?"
 msgid "Delete group"
 msgstr "그룹 삭제"
 
-#: src/pages/Shell.tsx:4863
+#: src/pages/Shell.tsx:4865
 msgid "Delete memories too"
 msgstr "기억도 함께 삭제"
 
@@ -1055,13 +1047,13 @@ msgstr "기억도 함께 삭제"
 msgid "Delete routine"
 msgstr "자동 실행 삭제"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:3985
 msgid "deleted"
 msgstr "삭제됨"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4894
-#: src/pages/Shell.tsx:4968
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4970
 msgid "Deleting…"
 msgstr "삭제 중…"
 
@@ -1078,17 +1070,17 @@ msgid "Deployment default"
 msgstr "서버 기본값"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4254
+#: src/pages/Shell.tsx:4256
 msgid "Describe what this bot does"
 msgstr "이 Bot이 하는 일을 짧게 설명하세요"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4259
-#: src/pages/Shell.tsx:4421
+#: src/pages/Shell.tsx:4261
+#: src/pages/Shell.tsx:4423
 msgid "Description"
 msgstr "설명"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3400
 msgid "Dictate"
 msgstr "음성 입력"
 
@@ -1101,11 +1093,11 @@ msgstr "연결 해제"
 msgid "Disconnecting…"
 msgstr "연결 해제 중…"
 
-#: src/pages/Shell.tsx:5347
+#: src/pages/Shell.tsx:5349
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "지금은 연결하지 않았습니다. MCP 설정에서 언제든 다시 연결할 수 있습니다."
 
-#: src/pages/PluginsOverlay.tsx:320
+#: src/pages/PluginsOverlay.tsx:337
 msgid "Display name"
 msgstr "표시 이름"
 
@@ -1201,11 +1193,11 @@ msgstr "매월"
 msgid "Every week"
 msgstr "매주"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5395
 msgid "Expand"
 msgstr "펼치기"
 
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4584
 msgid "Export"
 msgstr "내보내기"
 
@@ -1213,7 +1205,7 @@ msgstr "내보내기"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "CRM에서 이번 주 목록을 내려받아 공유 폴더에 넣기"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4599
 msgid "Extra high"
 msgstr "매우 높음"
 
@@ -1274,7 +1266,7 @@ msgid "Hang up"
 msgstr "통화 종료"
 
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/PluginsOverlay.tsx:356
+#: src/pages/PluginsOverlay.tsx:373
 msgid "Header name"
 msgstr "헤더 이름"
 
@@ -1290,15 +1282,15 @@ msgstr "샘플 듣기"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "안녕하세요. 답변을 소리 내어 읽을 때 이런 목소리로 들립니다."
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4602
 msgid "High"
 msgstr "높음"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3419
 msgid "Hold to talk"
 msgstr "누르고 말하기"
 
-#: src/pages/Shell.tsx:3417
+#: src/pages/Shell.tsx:3419
 msgid "Hold to talk (on-device dictation)"
 msgstr "누르고 말하기(기기 내 음성 인식)"
 
@@ -1318,7 +1310,7 @@ msgstr "실행 주기"
 msgid "How to check"
 msgstr "완료 확인 방법"
 
-#: src/pages/Shell.tsx:3695
+#: src/pages/Shell.tsx:3697
 msgid "I’m done"
 msgstr "조작 끝내기"
 
@@ -1326,11 +1318,11 @@ msgstr "조작 끝내기"
 msgid "If you heard that, voice is ready."
 msgstr "샘플이 들렸다면 음성 설정이 완료되었습니다."
 
-#: src/pages/PluginsOverlay.tsx:314
+#: src/pages/PluginsOverlay.tsx:331
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON 가져오기"
 
-#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4494
 msgid "Inherit default"
 msgstr "기본 설정 사용"
 
@@ -1346,11 +1338,7 @@ msgstr "인스턴스 API 키"
 msgid "Instruction"
 msgstr "실행할 내용"
 
-#: src/pages/PluginsOverlay.tsx:263
-msgid "Integration views"
-msgstr "연동 목록 보기"
-
-#: src/pages/PluginsOverlay.tsx:213
+#: src/pages/PluginsOverlay.tsx:208
 #: src/pages/Shell.tsx:1953
 msgid "Integrations"
 msgstr "앱·도구 연동"
@@ -1372,15 +1360,15 @@ msgid "Interval unit"
 msgstr "간격 단위"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4495
 msgid "Isolated"
 msgstr "이 Bot만 사용"
 
-#: src/pages/Shell.tsx:4829
+#: src/pages/Shell.tsx:4831
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만든 다른 Bot은 목록에 남습니다."
 
-#: src/pages/Shell.tsx:3791
+#: src/pages/Shell.tsx:3793
 msgid "Jump to replied message"
 msgstr "답장한 메시지로 이동"
 
@@ -1388,7 +1376,7 @@ msgstr "답장한 메시지로 이동"
 msgid "just now"
 msgstr "방금"
 
-#: src/pages/Shell.tsx:4847
+#: src/pages/Shell.tsx:4849
 msgid "Keep memories"
 msgstr "기억은 유지"
 
@@ -1414,7 +1402,7 @@ msgstr "이전 메시지 불러오기"
 msgid "Loading activity…"
 msgstr "활동을 불러오는 중…"
 
-#: src/pages/PluginsOverlay.tsx:300
+#: src/pages/PluginsOverlay.tsx:233
 msgid "Loading integrations…"
 msgstr "연동 목록을 불러오는 중…"
 
@@ -1458,7 +1446,7 @@ msgstr "로컬"
 msgid "Log out"
 msgstr "로그아웃"
 
-#: src/pages/Shell.tsx:4598
+#: src/pages/Shell.tsx:4600
 msgid "Low"
 msgstr "낮음"
 
@@ -1474,17 +1462,17 @@ msgstr "읽음으로 표시"
 msgid "Mark as Unread"
 msgstr "읽지 않음으로 표시"
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4604
 msgid "Max"
 msgstr "최대"
 
 #: src/pages/McpServersOverlay.tsx:224
 #: src/pages/McpServersOverlay.tsx:229
-#: src/pages/PluginsOverlay.tsx:226
+#: src/pages/PluginsOverlay.tsx:305
 msgid "MCP servers"
 msgstr "MCP 서버"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4601
 msgid "Medium"
 msgstr "보통"
 
@@ -1501,29 +1489,29 @@ msgstr "참여 Bot ({GROUP_MEMBER_MIN}~{GROUP_MEMBER_MAX}개 선택)"
 msgid "Memory"
 msgstr "기억"
 
-#: src/pages/Shell.tsx:4488
+#: src/pages/Shell.tsx:4490
 msgid "Memory scope"
 msgstr "기억 사용 범위"
 
-#: src/pages/Shell.tsx:3495
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3497
+#: src/pages/Shell.tsx:3592
 msgid "Message"
 msgstr "메시지"
 
-#: src/pages/Shell.tsx:3491
-#: src/pages/Shell.tsx:3495
+#: src/pages/Shell.tsx:3493
+#: src/pages/Shell.tsx:3497
 msgid "Message {activeName}"
 msgstr "{activeName}에게 메시지 보내기"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3871
 msgid "Message from {peer}"
 msgstr "{peer}의 메시지"
 
-#: src/pages/Shell.tsx:3492
+#: src/pages/Shell.tsx:3494
 msgid "Message…"
 msgstr "메시지를 입력하세요"
 
-#: src/pages/Shell.tsx:3869
+#: src/pages/Shell.tsx:3871
 msgid "Messaged {peer}"
 msgstr "{peer}에게 메시지 보냄"
 
@@ -1531,7 +1519,7 @@ msgstr "{peer}에게 메시지 보냄"
 msgid "Microphone failed"
 msgstr "마이크를 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4603
 msgid "Minimal"
 msgstr "최소"
 
@@ -1553,7 +1541,7 @@ msgstr "분"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4444
+#: src/pages/Shell.tsx:4446
 msgid "Model"
 msgstr "모델"
 
@@ -1593,7 +1581,7 @@ msgstr "매월"
 msgid "Move {0} to section"
 msgstr "{0} 섹션 이동"
 
-#: src/pages/Shell.tsx:4850
+#: src/pages/Shell.tsx:4852
 msgid "Move them to your shared memory."
 msgstr "공용 기억으로 옮깁니다."
 
@@ -1607,14 +1595,14 @@ msgstr "섹션으로 이동"
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
 #: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4239
-#: src/pages/Shell.tsx:4403
-#: src/pages/Shell.tsx:4676
+#: src/pages/Shell.tsx:4241
+#: src/pages/Shell.tsx:4405
+#: src/pages/Shell.tsx:4678
 msgid "Name"
 msgstr "이름"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4244
+#: src/pages/Shell.tsx:4246
 msgid "Name this bot"
 msgstr "Bot 이름"
 
@@ -1631,7 +1619,7 @@ msgid "Needs takeover"
 msgstr "인수 필요"
 
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4227
+#: src/pages/Shell.tsx:4229
 msgid "New bot"
 msgstr "새 Bot 만들기"
 
@@ -1649,29 +1637,24 @@ msgid "New routine"
 msgstr "새 자동 실행"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4670
+#: src/pages/Shell.tsx:4672
 msgid "New section"
 msgstr "새 섹션"
 
-#: src/pages/PluginsOverlay.tsx:448
+#: src/pages/PluginsOverlay.tsx:244
 msgid "No apps match your search."
 msgstr "검색 결과가 없습니다."
 
-#: src/pages/PluginsOverlay.tsx:419
-#: src/pages/PluginsOverlay.tsx:476
+#: src/pages/PluginsOverlay.tsx:443
 msgid "no auth"
 msgstr "인증 없음"
 
-#: src/pages/PluginsOverlay.tsx:342
+#: src/pages/PluginsOverlay.tsx:359
 msgid "No authentication"
 msgstr "인증 없음"
 
-#: src/pages/PluginsOverlay.tsx:450
-msgid "No connected apps yet."
-msgstr "아직 연결된 앱이 없습니다."
-
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:142
+#: src/pages/PluginsOverlay.tsx:139
 msgid "No connection record found for {0}."
 msgstr "{0}의 연결 정보를 찾지 못했습니다."
 
@@ -1687,11 +1670,11 @@ msgstr "별도 확인 규칙이 없습니다. 작업이 자동으로 실행됩�
 msgid "No longer active"
 msgstr "이미 종료된 요청입니다"
 
-#: src/pages/PluginsOverlay.tsx:439
-msgid "No managed app catalog is configured on this deployment. You can still add Treg, MCP, or OpenAPI sources."
-msgstr "이 서버에는 관리형 앱 목록이 설정되지 않았습니다. Treg, MCP 또는 OpenAPI 도구는 직접 추가할 수 있습니다."
+#: src/pages/PluginsOverlay.tsx:239
+msgid "No managed app catalog is configured on this deployment."
+msgstr "이 서버에는 관리형 앱 목록이 설정되지 않았습니다."
 
-#: src/pages/PluginsOverlay.tsx:404
+#: src/pages/PluginsOverlay.tsx:425
 msgid "No MCP or API tool sources installed yet."
 msgstr "아직 추가된 MCP 또는 API 도구가 없습니다."
 
@@ -1724,7 +1707,7 @@ msgstr "설정되지 않음"
 msgid "Not connected"
 msgstr "연결되지 않음"
 
-#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5337
 msgid "Not now"
 msgstr "나중에"
 
@@ -1787,7 +1770,7 @@ msgstr "진행 중인 작업"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 호환 서버 주소"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:3996
 msgid "Opened its thread."
 msgstr "대화가 만들어졌습니다."
 
@@ -1870,7 +1853,7 @@ msgstr "재생 중…"
 msgid "Preview {0}"
 msgstr "{0} 미리보기"
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4184
 msgid "Private"
 msgstr "Bot 전용"
 
@@ -1887,11 +1870,11 @@ msgstr "서비스"
 msgid "Queued"
 msgstr "대기 중"
 
-#: src/pages/PluginsOverlay.tsx:371
+#: src/pages/PluginsOverlay.tsx:388
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo는 저장하기 전에 연결 상태를 확인합니다. 인증 정보는 암호화되며 앱이나 AI 모델에 노출되지 않습니다."
 
-#: src/pages/Shell.tsx:4520
+#: src/pages/Shell.tsx:4522
 msgid "Read replies aloud"
 msgstr "답변을 자동으로 읽기"
 
@@ -1913,28 +1896,29 @@ msgstr "다시 연결 중"
 msgid "Recording: {0}"
 msgstr "녹화 중: {0}"
 
-#: src/pages/Shell.tsx:3685
+#: src/pages/Shell.tsx:3687
 msgid "Release"
 msgstr "제어권 돌려주기"
 
 #: src/components/ApprovalRulesSettings.tsx:138
-#: src/pages/PluginsOverlay.tsx:430
+#: src/pages/PluginsOverlay.tsx:279
+#: src/pages/PluginsOverlay.tsx:454
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "삭제"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3299
+#: src/pages/Shell.tsx:3301
 msgid "Remove {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3454
+#: src/pages/Shell.tsx:3456
 msgid "Remove mention {0}"
 msgstr "{0} 멘션 삭제"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3433
+#: src/pages/Shell.tsx:3435
 msgid "Remove skill {0}"
 msgstr "작업 기술 {0} 삭제"
 
@@ -1942,7 +1926,7 @@ msgstr "작업 기술 {0} 삭제"
 msgid "Remove this schedule"
 msgstr "이 일정 삭제"
 
-#: src/pages/Shell.tsx:3993
+#: src/pages/Shell.tsx:3995
 msgid "Removed with chat, computer, and memory."
 msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 
@@ -1950,7 +1934,8 @@ msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 msgid "Removed, but list refresh failed"
 msgstr "삭제했지만 목록을 새로고침하지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:430
+#: src/pages/PluginsOverlay.tsx:274
+#: src/pages/PluginsOverlay.tsx:454
 msgid "Removing…"
 msgstr "삭제 중…"
 
@@ -1968,11 +1953,11 @@ msgstr "API 키 교체"
 msgid "Replace key"
 msgstr "키 교체"
 
-#: src/pages/Shell.tsx:3631
+#: src/pages/Shell.tsx:3633
 msgid "Reply"
 msgstr "답장"
 
-#: src/pages/Shell.tsx:3262
+#: src/pages/Shell.tsx:3264
 msgid "Replying to {replyName}"
 msgstr "{replyName}에게 답장"
 
@@ -1987,14 +1972,6 @@ msgstr "지금 다시 시도"
 #: src/pages/McpOAuthCallback.tsx:65
 msgid "Return to Rakazo"
 msgstr "Rakazo로 돌아가기"
-
-#: src/pages/PluginsOverlay.tsx:497
-msgid "Revoke"
-msgstr "연결 해제"
-
-#: src/pages/PluginsOverlay.tsx:492
-msgid "Revoking…"
-msgstr "연결 해제 중…"
 
 #: src/pages/Shell.tsx:2488
 #: src/pages/Shell.tsx:2541
@@ -2027,7 +2004,7 @@ msgstr "실행 중…"
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
 #: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4575
+#: src/pages/Shell.tsx:4577
 msgid "Save"
 msgstr "저장"
 
@@ -2068,7 +2045,7 @@ msgstr "예 또는 아니요로 답하거나 문장으로 답해 주세요."
 msgid "Search"
 msgstr "검색"
 
-#: src/pages/PluginsOverlay.tsx:257
+#: src/pages/PluginsOverlay.tsx:224
 msgid "Search apps"
 msgstr "앱 검색"
 
@@ -2090,7 +2067,7 @@ msgstr "검색 중…"
 msgid "Select a bot"
 msgstr "대화할 Bot을 선택하세요"
 
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3517
 msgid "Send"
 msgstr "보내기"
 
@@ -2129,11 +2106,11 @@ msgstr "통화하려면 음성을 먼저 설정하세요"
 msgid "Settings"
 msgstr "설정"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3535
 msgid "Settings: General"
 msgstr "설정: 일반"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3537
 msgid "Settings: Usage"
 msgstr "설정: 사용량"
 
@@ -2143,7 +2120,7 @@ msgid "Setup help"
 msgstr "설정 도움말"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4496
 msgid "Shared"
 msgstr "함께 사용"
 
@@ -2175,11 +2152,11 @@ msgid "Sign up"
 msgstr "가입하기"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3346
+#: src/pages/Shell.tsx:3348
 msgid "Skill {0}"
 msgstr "작업 기술 {0}"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3694
 msgid "Skip"
 msgstr "건너뛰기"
 
@@ -2200,8 +2177,8 @@ msgstr "{0} 건너뜀"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space: 끼어들기 · Esc: 통화 종료"
 
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3840
+#: src/pages/Shell.tsx:4093
 msgid "Speak"
 msgstr "읽기"
 
@@ -2213,8 +2190,8 @@ msgstr "음성 출력·받아쓰기"
 msgid "Speak only"
 msgstr "음성 출력만"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3836
+#: src/pages/Shell.tsx:4089
 msgid "Speak this reply"
 msgstr "이 답변 읽기"
 
@@ -2242,18 +2219,18 @@ msgstr "실행 단계"
 
 #: src/pages/Shell.tsx:2866
 #: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3506
-#: src/pages/Shell.tsx:3838
-#: src/pages/Shell.tsx:4091
+#: src/pages/Shell.tsx:3508
+#: src/pages/Shell.tsx:3840
+#: src/pages/Shell.tsx:4093
 msgid "Stop"
 msgstr "중지"
 
-#: src/pages/Shell.tsx:3398
+#: src/pages/Shell.tsx:3400
 msgid "Stop dictation"
 msgstr "음성 입력 중지"
 
-#: src/pages/Shell.tsx:3834
-#: src/pages/Shell.tsx:4087
+#: src/pages/Shell.tsx:3836
+#: src/pages/Shell.tsx:4089
 msgid "Stop speaking"
 msgstr "읽기 중지"
 
@@ -2271,7 +2248,7 @@ msgstr "먼저 Bot을 중지하세요"
 msgid "Stored encrypted"
 msgstr "암호화해 저장"
 
-#: src/pages/Shell.tsx:3945
+#: src/pages/Shell.tsx:3947
 msgid "subagent"
 msgstr "보조 에이전트"
 
@@ -2301,11 +2278,11 @@ msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼�
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "작업을 가르치려면 화면이 있는 샌드박스 컴퓨터가 필요합니다. 내 컴퓨터에서 실행되는 Bot은 터미널 작업은 가능하지만 화면 녹화는 할 수 없습니다."
 
-#: src/pages/Shell.tsx:4182
+#: src/pages/Shell.tsx:4184
 msgid "Team"
 msgstr "팀 공용"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5018
 msgid "Team Computer"
 msgstr "팀 컴퓨터"
 
@@ -2318,7 +2295,7 @@ msgstr "시험 실행"
 msgid "The selected memory provider is not available in this build."
 msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4471
+#: src/pages/Shell.tsx:4473
 msgid "Thinking"
 msgstr "생각 깊이"
 
@@ -2330,8 +2307,8 @@ msgstr "이 Bot은 별도 Linux 화면이 아니라 현재 컴퓨터에서 실�
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "이 Bot은 현재 컴퓨터에서 실행되며 별도 Linux 화면은 없습니다. 터미널을 사용하도록 요청할 수 있고 홈 폴더 아래에서 작업합니다."
 
-#: src/pages/Shell.tsx:4866
-#: src/pages/Shell.tsx:4943
+#: src/pages/Shell.tsx:4868
+#: src/pages/Shell.tsx:4945
 msgid "This cannot be undone."
 msgstr "이 작업은 되돌릴 수 없습니다."
 
@@ -2355,7 +2332,7 @@ msgstr "이 Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "이 Mac에서는 홈 폴더의 파일을 포함해 내 계정 권한으로 터미널 명령을 실행합니다. 여러 사람이 쓰거나 공개된 서버에서는 사용하지 마세요."
 
-#: src/pages/Shell.tsx:4751
+#: src/pages/Shell.tsx:4753
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지합니다. Bot, 컴퓨터, 기억, 자동 실행은 그대로 유지됩니다."
 
@@ -2363,7 +2340,7 @@ msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지�
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "이 서비스는 여기에서 API 키를 입력할 수 없습니다. 서버에 이미 인증 정보가 있다면 건너뛰세요."
 
-#: src/pages/Shell.tsx:5283
+#: src/pages/Shell.tsx:5285
 msgid "This server cannot be assigned without a bot."
 msgstr "연결할 Bot이 없어 이 서버를 배정할 수 없습니다."
 
@@ -2375,7 +2352,7 @@ msgstr "이 서버는 브라우저 인증을 요청하지 않았습니다."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "이 서버는 이미 연결되어 있습니다. 다시 인증하려면 먼저 연결을 해제하세요."
 
-#: src/pages/Shell.tsx:5322
+#: src/pages/Shell.tsx:5324
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "이 서버는 브라우저 로그인이 필요합니다. 인증을 누르면 새 창이 열리고, 완료 후 Bot이 도구를 사용할 수 있습니다."
 
@@ -2388,16 +2365,16 @@ msgid "Time of day"
 msgstr "실행 시각"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4249
-#: src/pages/Shell.tsx:4412
+#: src/pages/Shell.tsx:4251
+#: src/pages/Shell.tsx:4414
 msgid "Title"
 msgstr "역할"
 
-#: src/pages/PluginsOverlay.tsx:286
+#: src/pages/PluginsOverlay.tsx:421
 msgid "Tool sources"
 msgstr "도구 소스"
 
-#: src/pages/PluginsOverlay.tsx:366
+#: src/pages/PluginsOverlay.tsx:383
 msgid "Treg token"
 msgstr "Treg 토큰"
 
@@ -2436,16 +2413,16 @@ msgstr "찾은 모델 중에서 선택"
 msgid "Use this model"
 msgstr "이 모델 사용"
 
-#: src/pages/PluginsOverlay.tsx:387
+#: src/pages/PluginsOverlay.tsx:404
 msgid "Verify and add"
 msgstr "확인 후 추가"
 
-#: src/pages/PluginsOverlay.tsx:385
+#: src/pages/PluginsOverlay.tsx:402
 msgid "Verifying…"
 msgstr "확인 중…"
 
 #: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4524
+#: src/pages/Shell.tsx:4526
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2458,7 +2435,7 @@ msgstr "음성"
 msgid "Waiting for sign-in…"
 msgstr "로그인 완료를 기다리는 중…"
 
-#: src/pages/Shell.tsx:5166
+#: src/pages/Shell.tsx:5168
 msgid "Waiting…"
 msgstr "기다리는 중…"
 
@@ -2467,7 +2444,7 @@ msgstr "기다리는 중…"
 msgid "Weekdays"
 msgstr "주중"
 
-#: src/pages/Shell.tsx:4836
+#: src/pages/Shell.tsx:4838
 msgid "What about its memories?"
 msgstr "이 Bot의 기억은 어떻게 할까요?"
 
@@ -2476,7 +2453,7 @@ msgid "What result will you demonstrate?"
 msgstr "어떤 작업을 직접 보여줄까요?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4264
+#: src/pages/Shell.tsx:4266
 msgid "What this bot is for"
 msgstr "이 Bot을 언제, 어떤 일에 사용할지 적어주세요"
 
@@ -2505,7 +2482,7 @@ msgstr "Bot을 어디에서 실행할까요?"
 msgid "Working…"
 msgstr "처리 중…"
 
-#: src/pages/Shell.tsx:4454
+#: src/pages/Shell.tsx:4456
 msgid "Workspace default"
 msgstr "작업공간 기본값"
 

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -5,7 +5,6 @@ import { Button } from "@rakazo/ui-web";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { rpc } from "../lib/rpc";
 
-type CatalogView = "all" | "connected" | "sources";
 type SourceKind = "treg" | "mcp" | "api";
 
 function itemKey(item: Pick<ConnectionCatalogItem, "connectorId" | "slug">) {
@@ -32,7 +31,6 @@ export function PluginsOverlay({
 }) {
   const { t } = useLingui();
   const [query, setQuery] = useState("");
-  const [view, setView] = useState<CatalogView>("all");
   const [catalog, setCatalog] = useState<ConnectionCatalogItem[]>([]);
   const [sources, setSources] = useState<CapabilityInstall[]>([]);
   const [sourceKind, setSourceKind] = useState<SourceKind | null>(null);
@@ -42,7 +40,8 @@ export function PluginsOverlay({
   const [authType, setAuthType] = useState<"none" | "bearer" | "header">("bearer");
   const [authName, setAuthName] = useState("x-api-key");
   const [pending, setPending] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [sourceError, setSourceError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const connectionAttempt = useRef<AbortController | null>(null);
 
@@ -59,7 +58,7 @@ export function PluginsOverlay({
   useEffect(() => {
     void refresh()
       .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : t`Could not load integrations`),
+        setCatalogError(err instanceof Error ? err.message : t`Could not load integrations`),
       )
       .finally(() => setLoading(false));
     return () => connectionAttempt.current?.abort();
@@ -67,15 +66,14 @@ export function PluginsOverlay({
 
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    const scoped = view === "connected" ? catalog.filter((item) => item.connected) : catalog;
-    if (!needle) return scoped;
-    return scoped.filter(
+    if (!needle) return catalog;
+    return catalog.filter(
       (item) =>
         item.name.toLowerCase().includes(needle) ||
         item.slug.toLowerCase().includes(needle) ||
         item.connectorId.toLowerCase().includes(needle),
     );
-  }, [catalog, query, view]);
+  }, [catalog, query]);
 
   function setItemConnected(item: ConnectionCatalogItem, connected: boolean) {
     setCatalog((prev) => markConnected(prev, item.connectorId, item.slug, connected));
@@ -85,7 +83,7 @@ export function PluginsOverlay({
     connectionAttempt.current?.abort();
     const controller = new AbortController();
     connectionAttempt.current = controller;
-    setError(null);
+    setCatalogError(null);
     const key = itemKey(item);
     setPending(key);
     try {
@@ -114,10 +112,12 @@ export function PluginsOverlay({
         await abortableDelay(2_000, controller.signal);
       }
       if (controller.signal.aborted) return;
-      setError(t`Connection to ${item.name} is still pending. You can close this and check again.`);
+      setCatalogError(
+        t`Connection to ${item.name} is still pending. You can close this and check again.`,
+      );
     } catch (err) {
       if (controller.signal.aborted) return;
-      setError(err instanceof Error ? err.message : t`Could not connect`);
+      setCatalogError(err instanceof Error ? err.message : t`Could not connect`);
     } finally {
       if (connectionAttempt.current === controller) {
         connectionAttempt.current = null;
@@ -127,7 +127,7 @@ export function PluginsOverlay({
   }
 
   async function revoke(item: ConnectionCatalogItem) {
-    setError(null);
+    setCatalogError(null);
     const key = itemKey(item);
     setPending(key);
     try {
@@ -143,7 +143,7 @@ export function PluginsOverlay({
       await rpc.connections.revoke({ connectionId: row.id });
       setItemConnected(item, false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : t`Could not revoke connection`);
+      setCatalogError(err instanceof Error ? err.message : t`Could not revoke connection`);
     } finally {
       setPending(null);
     }
@@ -151,8 +151,7 @@ export function PluginsOverlay({
 
   function beginSource(kind: SourceKind) {
     setSourceKind(kind);
-    setView("sources");
-    setError(null);
+    setSourceError(null);
     setSourceName(kind === "treg" ? "Treg" : "");
     setSourceUrl(kind === "treg" ? "https://treg.to/mcp/" : "");
     setCredential("");
@@ -162,7 +161,7 @@ export function PluginsOverlay({
 
   async function installSource() {
     if (!sourceKind) return;
-    setError(null);
+    setSourceError(null);
     setPending("install-source");
     try {
       const auth = {
@@ -185,7 +184,7 @@ export function PluginsOverlay({
       setSourceKind(null);
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : t`Could not install connector`);
+      setSourceError(err instanceof Error ? err.message : t`Could not install connector`);
     } finally {
       setPending(null);
     }
@@ -193,12 +192,12 @@ export function PluginsOverlay({
 
   async function removeSource(install: CapabilityInstall) {
     setPending(install.id);
-    setError(null);
+    setSourceError(null);
     try {
       await rpc.capabilities.remove({ id: install.id });
       setSources((current) => current.filter((source) => source.id !== install.id));
     } catch (err) {
-      setError(err instanceof Error ? err.message : t`Could not remove connector`);
+      setSourceError(err instanceof Error ? err.message : t`Could not remove connector`);
     } finally {
       setPending(null);
     }
@@ -208,101 +207,137 @@ export function PluginsOverlay({
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-[rgba(4,4,5,.62)] p-10">
       <div className="flex h-[760px] w-[1080px] max-w-full flex-col overflow-hidden rounded-[26px] border border-[#232326] bg-[#141416] shadow-[0_40px_90px_rgba(0,0,0,.55)]">
         <div className="flex items-start justify-between px-8 pt-7">
-          <div>
-            <div className="text-2xl font-medium text-[#F1F1F2]">
-              <Trans>Integrations</Trans>
-            </div>
-            <p className="mt-1 text-[13.5px] text-[#7A7A80]">
-              <Trans>Connect apps or add Treg, MCP, and OpenAPI tool sources.</Trans>
-            </p>
+          <div className="text-2xl font-medium text-[#F1F1F2]">
+            <Trans>Integrations</Trans>
           </div>
-          <div className="flex items-center gap-3">
-            {onOpenMcp ? (
-              <button
-                type="button"
-                onClick={onOpenMcp}
-                className="rounded-full border border-[#383844] px-3 py-1.5 text-xs text-[#C9C9CE] hover:bg-[#232327]"
-              >
-                <Trans>MCP servers</Trans>
-              </button>
-            ) : null}
-            <button
-              type="button"
-              aria-label={t`Close integrations`}
-              onClick={onClose}
-              className="text-[#85858A]"
-            >
-              ✕
-            </button>
-          </div>
+          <button
+            type="button"
+            aria-label={t`Close integrations`}
+            onClick={onClose}
+            className="text-[#85858A]"
+          >
+            ✕
+          </button>
         </div>
 
-        <div className="flex flex-wrap gap-2 px-8 pt-4">
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("treg")}>
-            <Trans>Add Treg</Trans>
-          </Button>
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("mcp")}>
-            <Trans>Add MCP server</Trans>
-          </Button>
-          <Button type="button" variant="pill" size="sm" onClick={() => beginSource("api")}>
-            <Trans>Add OpenAPI</Trans>
-          </Button>
+        <div className="px-8 pt-4">
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            aria-label={t`Search apps`}
+            placeholder={t`Search apps`}
+            className="w-full rounded-[13px] border border-[#26262A] bg-[#101012] px-4 py-3 text-[15px] text-[#ECECEE] outline-none"
+          />
         </div>
 
-        {view !== "sources" ? (
-          <div className="px-8 pt-4">
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder={t`Search apps`}
-              className="w-full rounded-[13px] border border-[#26262A] bg-[#101012] px-4 py-3 text-[15px] text-[#ECECEE] outline-none"
-            />
-          </div>
-        ) : null}
-
-        <div role="tablist" aria-label={t`Integration views`} className="flex gap-1 px-8 pt-4">
-          {(["all", "connected", "sources"] as const).map((option) => (
-            <button
-              key={option}
-              type="button"
-              role="tab"
-              aria-selected={view === option}
-              aria-controls="integration-list"
-              onClick={() => {
-                setView(option);
-                if (option !== "sources") setSourceKind(null);
-              }}
-              className={`rounded-full px-3.5 py-1.5 text-sm transition-colors ${
-                view === option
-                  ? "bg-[#2C2C30] text-[#F1F1F2]"
-                  : "text-[#7A7A80] hover:text-[#C8C8CC]"
-              }`}
-            >
-              {option === "all" ? (
-                <Trans>Apps</Trans>
-              ) : option === "connected" ? (
-                <Trans>Connected</Trans>
-              ) : (
-                <Trans>Tool sources</Trans>
-              )}
-            </button>
-          ))}
-        </div>
-
-        <div
-          id="integration-list"
-          role="tabpanel"
-          className="rk-scroll flex-1 overflow-y-auto px-8 py-6"
-        >
-          {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
+        <div id="integration-list" className="rk-scroll flex-1 overflow-y-auto px-8 py-6">
+          {catalogError ? <p className="mb-4 text-sm text-[#C94244]">{catalogError}</p> : null}
           {loading ? (
             <p className="text-[#6C6C70]">
               <Trans>Loading integrations…</Trans>
             </p>
           ) : null}
 
-          {view === "sources" ? (
-            <div className="space-y-4">
+          {!loading && catalog.length === 0 ? (
+            <p className="text-[#6C6C70]">
+              <Trans>No managed app catalog is configured on this deployment.</Trans>
+            </p>
+          ) : null}
+          {!loading && catalog.length > 0 && visible.length === 0 ? (
+            <p className="text-[#6C6C70]">
+              <Trans>No apps match your search.</Trans>
+            </p>
+          ) : null}
+          {visible.map((item) => {
+            const key = itemKey(item);
+            return (
+              <div key={key} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">
+                {item.logo ? (
+                  <img
+                    src={item.logo}
+                    alt=""
+                    className="h-[42px] w-[42px] rounded-xl bg-[#2C2C30] object-contain"
+                  />
+                ) : (
+                  <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold text-[#ECECEE]">
+                    {item.name[0]}
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="text-[15.5px] font-medium text-[#ECECEE]">{item.name}</div>
+                </div>
+                <Button
+                  type="button"
+                  variant="pill"
+                  size="sm"
+                  disabled={pending === key}
+                  onClick={() => void (item.connected ? revoke(item) : connect(item))}
+                >
+                  {pending === key ? (
+                    item.connected ? (
+                      <Trans>Removing…</Trans>
+                    ) : (
+                      <Trans>Adding…</Trans>
+                    )
+                  ) : item.connected ? (
+                    <Trans>Remove</Trans>
+                  ) : (
+                    <Trans>Add</Trans>
+                  )}
+                </Button>
+              </div>
+            );
+          })}
+
+          <details
+            data-testid="integrations-advanced"
+            className="group mt-8"
+            onToggle={(event) => {
+              if (!(event.currentTarget as HTMLDetailsElement).open) {
+                setSourceKind(null);
+                setSourceError(null);
+                setSourceName("");
+                setSourceUrl("");
+                setCredential("");
+                setAuthType("none");
+                setAuthName("x-api-key");
+              }
+            }}
+          >
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-[14px] text-[#85858A]">
+              <span className="text-[#85858A]">
+                <Trans>Advanced</Trans>
+              </span>
+              <span aria-hidden="true" className="transition-transform group-open:rotate-90">
+                ›
+              </span>
+            </summary>
+
+            <div className="mt-4 space-y-4">
+              {onOpenMcp ? (
+                <button
+                  type="button"
+                  onClick={onOpenMcp}
+                  className="rounded-full border border-[#383844] px-3 py-1.5 text-xs text-[#C9C9CE] hover:bg-[#232327]"
+                >
+                  <Trans>MCP servers</Trans>
+                </button>
+              ) : null}
+
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" variant="pill" size="sm" onClick={() => beginSource("mcp")}>
+                  <Trans>Add MCP server</Trans>
+                </Button>
+                <Button type="button" variant="pill" size="sm" onClick={() => beginSource("api")}>
+                  <Trans>Add OpenAPI</Trans>
+                </Button>
+                <Button type="button" variant="pill" size="sm" onClick={() => beginSource("treg")}>
+                  <Trans>Add Treg</Trans>
+                </Button>
+              </div>
+
+              {sourceError ? <p className="text-sm text-[#C94244]">{sourceError}</p> : null}
+
               {sourceKind ? (
                 <div className="space-y-3 rounded-[16px] border border-[#2C2C30] bg-[#101012] p-5">
                   <div className="text-base font-medium text-[#ECECEE]">
@@ -399,84 +434,31 @@ export function PluginsOverlay({
                 </div>
               ) : null}
 
-              {sources.length === 0 && !sourceKind ? (
-                <p className="text-[#6C6C70]">
-                  <Trans>No MCP or API tool sources installed yet.</Trans>
-                </p>
-              ) : null}
-              {sources.map((source) => (
-                <div key={source.id} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">
-                  <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold uppercase text-[#ECECEE]">
-                    {source.kind === "mcp" ? "M" : "A"}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="text-[15.5px] font-medium text-[#ECECEE]">{source.name}</div>
-                    <div className="truncate text-[13.5px] text-[#7A7A80]">
-                      {source.kind.toUpperCase()} · {source.source} ·{" "}
-                      {source.secretConfigured ? (
-                        <Trans>credential saved</Trans>
-                      ) : (
-                        <Trans>no auth</Trans>
-                      )}
-                    </div>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="pill"
-                    size="sm"
-                    disabled={pending === source.id}
-                    onClick={() => void removeSource(source)}
-                  >
-                    {pending === source.id ? <Trans>Removing…</Trans> : <Trans>Remove</Trans>}
-                  </Button>
+              <div>
+                <div className="mb-3 text-sm font-medium text-[#A8A8AD]">
+                  <Trans>Tool sources</Trans>
                 </div>
-              ))}
-            </div>
-          ) : (
-            <>
-              {!loading && catalog.length === 0 ? (
-                <p className="text-[#6C6C70]">
-                  <Trans>
-                    No managed app catalog is configured on this deployment. You can still add Treg,
-                    MCP, or OpenAPI sources.
-                  </Trans>
-                </p>
-              ) : null}
-              {!loading && catalog.length > 0 && visible.length === 0 ? (
-                <p className="text-[#6C6C70]">
-                  {query.trim() ? (
-                    <Trans>No apps match your search.</Trans>
-                  ) : (
-                    <Trans>No connected apps yet.</Trans>
-                  )}
-                </p>
-              ) : null}
-              {visible.map((item) => {
-                const key = itemKey(item);
-                return (
-                  <div key={key} className="flex items-center gap-4 rounded-[13px] px-3 py-2.5">
-                    {item.logo ? (
-                      <img
-                        src={item.logo}
-                        alt=""
-                        className="h-[42px] w-[42px] rounded-xl bg-[#2C2C30] object-contain"
-                      />
-                    ) : (
-                      <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold">
-                        {item.name[0]}
-                      </div>
-                    )}
+                {sources.length === 0 && !sourceKind ? (
+                  <p className="text-[#6C6C70]">
+                    <Trans>No MCP or API tool sources installed yet.</Trans>
+                  </p>
+                ) : null}
+                {sources.map((source) => (
+                  <div
+                    key={source.id}
+                    className="flex items-center gap-4 rounded-[13px] px-3 py-2.5"
+                  >
+                    <div className="grid h-[42px] w-[42px] place-items-center rounded-xl bg-[#2C2C30] font-semibold uppercase text-[#ECECEE]">
+                      {source.kind === "mcp" ? "M" : "A"}
+                    </div>
                     <div className="min-w-0 flex-1">
-                      <div className="text-[15.5px] font-medium text-[#ECECEE]">{item.name}</div>
-                      <div className="text-[13.5px] text-[#7A7A80]">
-                        {item.connectorId} · {item.slug}
-                        {item.noAuth ? (
-                          <>
-                            {" "}
-                            · <Trans>no auth</Trans>
-                          </>
+                      <div className="text-[15.5px] font-medium text-[#ECECEE]">{source.name}</div>
+                      <div className="truncate text-[13.5px] text-[#7A7A80]">
+                        {source.kind.toUpperCase()} · {source.source} ·{" "}
+                        {source.secretConfigured ? (
+                          <Trans>credential saved</Trans>
                         ) : (
-                          ""
+                          <Trans>no auth</Trans>
                         )}
                       </div>
                     </div>
@@ -484,26 +466,16 @@ export function PluginsOverlay({
                       type="button"
                       variant="pill"
                       size="sm"
-                      disabled={pending === key}
-                      onClick={() => void (item.connected ? revoke(item) : connect(item))}
+                      disabled={pending === source.id}
+                      onClick={() => void removeSource(source)}
                     >
-                      {pending === key ? (
-                        item.connected ? (
-                          <Trans>Revoking…</Trans>
-                        ) : (
-                          <Trans>Connecting…</Trans>
-                        )
-                      ) : item.connected ? (
-                        <Trans>Revoke</Trans>
-                      ) : (
-                        <Trans>Connect</Trans>
-                      )}
+                      {pending === source.id ? <Trans>Removing…</Trans> : <Trans>Remove</Trans>}
                     </Button>
                   </div>
-                );
-              })}
-            </>
-          )}
+                ))}
+              </div>
+            </div>
+          </details>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Same work as #262 (quiet Integrations default; tool sources under Advanced). Opening a fresh PR because GitHub Actions stopped creating check suites on #262 after the first couple of commits, while other PRs continue to get CI.

Default view: title + close, search, quiet catalog rows (Add/Remove). No Treg/MCP/OpenAPI chrome until Advanced.

**Advanced** (`data-testid="integrations-advanced"`): MCP servers → Add MCP server → Add OpenAPI → Add Treg; install forms + Tool sources. Mobile mirrors (Treg last). Closing Advanced clears source form secrets.

## Tests
- `golden.spec.ts`: default hides source chrome; opens Advanced before installing; asserts MCP/OpenAPI/Treg order
- `mcp-oauth.spec.ts`: opens Advanced before MCP servers

Does not change featured-connector IDs (#240). Screenshots on #262.

## Note
Not merging. Please close #262 as superseded once this PR’s CI is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c027ba4-cc20-41d0-a3bb-c70e74704a89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c027ba4-cc20-41d0-a3bb-c70e74704a89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

