### PR TITLE
Pin Gmail, Calendar, Drive, Slack, and Notion in Integrations

### DIFF
--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -1,5 +1,6 @@
 import type { ComposioProvider } from "@rakazo/adapters";
 import type { Actor, MessageBlock } from "@rakazo/contracts";
+import { featuredConnectorProvidersMatch } from "@rakazo/core";
 import {
   createThreadMessage,
   IsolationError,
@@ -258,13 +259,13 @@ export async function markAppConnected(
       !blocks.some(
         (block) =>
           block.kind === "app_connect" &&
-          block.provider === provider &&
+          featuredConnectorProvidersMatch(block.provider, provider) &&
           block.status !== "connected",
       )
     )
       continue;
     const next = blocks.map((block) =>
-      block.kind === "app_connect" && block.provider === provider
+      block.kind === "app_connect" && featuredConnectorProvidersMatch(block.provider, provider)
         ? { ...block, status: "connected" as const }
         : block,
     );

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -55,13 +55,15 @@ export default function Integrations() {
   );
 
   async function refresh() {
-    const [nextCatalog, installs] = await Promise.all([
-      rpc<ConnectionCatalogItem[]>("connections/catalog"),
-      rpc<CapabilityInstall[]>("capabilities/list"),
-    ]);
-    setCatalog(nextCatalog);
-    setSources(installs.filter((item) => item.kind === "mcp" || item.kind === "api"));
+    const catalogResult = await rpc<ConnectionCatalogItem[]>("connections/catalog");
+    setCatalog(catalogResult);
     setCatalogReady(true);
+    try {
+      const installs = await rpc<CapabilityInstall[]>("capabilities/list");
+      setSources(installs.filter((item) => item.kind === "mcp" || item.kind === "api"));
+    } catch {
+      // Tool sources are optional; keep featured/catalog usable if this fails.
+    }
   }
 
   useEffect(() => {

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -1,6 +1,11 @@
 import type { CapabilityInstall, Connection, ConnectionCatalogItem } from "@rakazo/contracts";
-import { abortableDelay } from "@rakazo/core";
-import { useEffect, useRef, useState } from "react";
+import {
+  abortableDelay,
+  buildFeaturedConnectorTiles,
+  EMPTY_PLUGIN_CATALOG_MESSAGE,
+  matchFeaturedConnectorId,
+} from "@rakazo/core";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -15,6 +20,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { rpc } from "../lib/api";
+import { loadLastBotId } from "../lib/last-bot";
 import { native } from "../lib/native";
 
 type SourceKind = "treg" | "mcp" | "api";
@@ -33,7 +39,20 @@ export default function Integrations() {
   const [pending, setPending] = useState<string | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [sourceError, setSourceError] = useState<string | null>(null);
+  const [lastBotId, setLastBotId] = useState("");
+  const [catalogReady, setCatalogReady] = useState(false);
   const connectionAttempt = useRef<AbortController | null>(null);
+
+  const featuredTiles = useMemo(() => buildFeaturedConnectorTiles(catalog), [catalog]);
+  const catalogApps = useMemo(
+    () =>
+      catalog.filter(
+        (item) =>
+          matchFeaturedConnectorId(item.slug) === null &&
+          matchFeaturedConnectorId(item.name) === null,
+      ),
+    [catalog],
+  );
 
   async function refresh() {
     const [nextCatalog, installs] = await Promise.all([
@@ -42,12 +61,15 @@ export default function Integrations() {
     ]);
     setCatalog(nextCatalog);
     setSources(installs.filter((item) => item.kind === "mcp" || item.kind === "api"));
+    setCatalogReady(true);
   }
 
   useEffect(() => {
-    void refresh().catch((reason) =>
-      setCatalogError(reason instanceof Error ? reason.message : "Could not load integrations"),
-    );
+    void refresh().catch((reason) => {
+      setCatalogReady(false);
+      setCatalogError(reason instanceof Error ? reason.message : "Could not load integrations");
+    });
+    void loadLastBotId().then(setLastBotId);
     return () => connectionAttempt.current?.abort();
   }, []);
 
@@ -59,6 +81,13 @@ export default function Integrations() {
     setUrl("");
     setCredential("");
     setRequiresAuth(true);
+  }
+
+  async function notifyAppConnected(item: ConnectionCatalogItem) {
+    const botId = lastBotId || (await loadLastBotId());
+    if (!botId) return;
+    if (botId !== lastBotId) setLastBotId(botId);
+    void rpc("onboarding/appConnected", { botId, provider: item.slug }).catch(() => undefined);
   }
 
   async function connect(item: ConnectionCatalogItem) {
@@ -85,6 +114,7 @@ export default function Integrations() {
         }).catch(() => undefined);
         if (row?.status === "connected") {
           if (controller.signal.aborted) return;
+          void notifyAppConnected(item);
           await refresh();
           return;
         }
@@ -186,36 +216,76 @@ export default function Integrations() {
 
         {catalogError ? <Text style={styles.error}>{catalogError}</Text> : null}
 
-        <Text style={styles.section}>Apps</Text>
-        {catalog.length === 0 ? (
-          <Text style={styles.secondary}>No managed app catalog configured.</Text>
+        {!catalogReady ? <ActivityIndicator color={native.fillPressed} /> : null}
+
+        {catalogReady && catalog.length === 0 ? (
+          <Text style={styles.secondary}>{EMPTY_PLUGIN_CATALOG_MESSAGE}</Text>
         ) : null}
-        <View style={catalogColumns === 2 ? styles.catalogGrid : styles.catalogStack}>
-          {catalog.map((item) => {
-            const key = `${item.connectorId}:${item.slug}`;
-            return (
-              <View
-                key={key}
-                style={[styles.row, catalogColumns === 2 ? styles.catalogCell : null]}
-              >
-                <View style={styles.grow}>
-                  <Text numberOfLines={1} style={styles.title}>
-                    {item.name}
-                  </Text>
-                </View>
-                <Pressable
-                  accessibilityRole="button"
-                  disabled={pending === key}
-                  onPress={() => void (item.connected ? revoke(item) : connect(item))}
+
+        {catalogReady && catalog.length > 0 ? (
+          <View style={catalogColumns === 2 ? styles.catalogGrid : styles.catalogStack}>
+            {featuredTiles.map((tile) => {
+              const item = tile.item;
+              const key = item ? `${item.connectorId}:${item.slug}` : tile.id;
+              const disabled = tile.missing || !item;
+              const connected = item?.connected ?? false;
+              return (
+                <View
+                  key={key}
+                  style={[
+                    styles.row,
+                    catalogColumns === 2 ? styles.catalogCell : null,
+                    disabled ? { opacity: 0.7 } : null,
+                  ]}
                 >
-                  <Text style={styles.link}>
-                    {pending === key ? "Working…" : item.connected ? "Remove" : "Add"}
-                  </Text>
-                </Pressable>
-              </View>
-            );
-          })}
-        </View>
+                  <View style={styles.grow}>
+                    <Text numberOfLines={1} style={styles.title}>
+                      {tile.label}
+                    </Text>
+                    {disabled ? (
+                      <Text style={styles.secondary}>Not in the plugin catalog</Text>
+                    ) : null}
+                  </View>
+                  {disabled || !item ? null : (
+                    <Pressable
+                      accessibilityRole="button"
+                      disabled={pending === key}
+                      onPress={() => void (connected ? revoke(item) : connect(item))}
+                    >
+                      <Text style={styles.link}>
+                        {pending === key ? "Working…" : connected ? "Remove" : "Add"}
+                      </Text>
+                    </Pressable>
+                  )}
+                </View>
+              );
+            })}
+            {catalogApps.map((item) => {
+              const key = `${item.connectorId}:${item.slug}`;
+              return (
+                <View
+                  key={key}
+                  style={[styles.row, catalogColumns === 2 ? styles.catalogCell : null]}
+                >
+                  <View style={styles.grow}>
+                    <Text numberOfLines={1} style={styles.title}>
+                      {item.name}
+                    </Text>
+                  </View>
+                  <Pressable
+                    accessibilityRole="button"
+                    disabled={pending === key}
+                    onPress={() => void (item.connected ? revoke(item) : connect(item))}
+                  >
+                    <Text style={styles.link}>
+                      {pending === key ? "Working…" : item.connected ? "Remove" : "Add"}
+                    </Text>
+                  </Pressable>
+                </View>
+              );
+            })}
+          </View>
+        ) : null}
 
         <Pressable
           accessibilityRole="button"

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -24,6 +24,7 @@ import {
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Alert, AppState, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { AppConnectCard } from "../components/AppConnectCard";
 import { AskActions } from "../components/AskActions";
 import {
   MarkdownArtifactPreview,
@@ -46,6 +47,7 @@ import {
 } from "../lib/api";
 import { type MobileArtifactTarget, openMobileArtifact } from "../lib/artifact-open";
 import { confirmDeleteBot } from "../lib/bot-lifecycle";
+import { saveLastBotId } from "../lib/last-bot";
 import {
   type PickedAttachment,
   pickDocuments,
@@ -449,8 +451,9 @@ export default function Thread() {
   // Covers returning from a pushed screen; the AppState listener covers returning from background.
   useFocusEffect(
     useCallback(() => {
+      if (botId) void saveLastBotId(botId).catch(() => undefined);
       markReadIfVisible();
-    }, [markReadIfVisible]),
+    }, [botId, markReadIfVisible]),
   );
 
   useEffect(() => {
@@ -1361,11 +1364,24 @@ function MessageBubble({
 }) {
   const [peerExpanded, setPeerExpanded] = useState(false);
   const artifactTarget: MobileArtifactTarget = groupId ? { groupId } : { botId };
+  const appConnectBlocks = message.blocks.filter(
+    (block): block is Extract<MessageBlock, { kind: "app_connect" }> =>
+      block.kind === "app_connect",
+  );
   const ask = message.blocks.find(
     (block): block is Extract<MessageBlock, { kind: "ask" }> =>
       block.kind === "ask" && !isApprovalAskBlock(block),
   );
-  if (ask) return <AskBlock ask={ask} canAnswer={canAnswer} onAnswer={onAnswer} />;
+  if (ask) {
+    return (
+      <View style={{ gap: 8, width: "100%" }}>
+        <AskBlock ask={ask} canAnswer={canAnswer} onAnswer={onAnswer} />
+        {appConnectBlocks.map((block, index) => (
+          <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+        ))}
+      </View>
+    );
+  }
   const handoff = message.blocks.find((block) => block.kind === "handoff");
   if (handoff) {
     const from = memberName(members, handoff.fromBotId) ?? "bot";
@@ -1507,45 +1523,63 @@ function MessageBubble({
       </Pressable>
     );
   }
+  if (appConnectBlocks.length > 0 && appConnectBlocks.length === message.blocks.length) {
+    return (
+      <View style={{ gap: 8, width: "100%" }}>
+        {appConnectBlocks.map((block, index) => (
+          <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+        ))}
+      </View>
+    );
+  }
   const askBlock = message.blocks.find(isApprovalAskBlock);
   if (askBlock?.kind === "ask" && askBlock.actions?.length) {
     return (
-      <View
-        style={{
-          width: "90%",
-          borderRadius: 18,
-          borderWidth: 1,
-          borderColor: "#232326",
-          backgroundColor: "#17171A",
-          paddingHorizontal: 16,
-          paddingVertical: 14,
-        }}
-      >
-        {askBlock.text ? (
-          <Text style={{ color: "#ECECEE", fontSize: 15.5, lineHeight: 23 }}>{askBlock.text}</Text>
-        ) : null}
-        {askBlock.detail ? (
-          <Text
-            style={{
-              color: "#85858A",
-              marginTop: 8,
-              fontSize: 12.5,
-              fontFamily: "Menlo",
-              lineHeight: 20,
-            }}
-          >
-            {askBlock.detail}
-          </Text>
-        ) : null}
-        {askBlock.status === "answered" ? (
-          <Text style={{ color: "#4ECB71", marginTop: 12, fontSize: 13.5, fontWeight: "600" }}>
-            {formatApprovalAnswer(askBlock.answer)}
-          </Text>
-        ) : canAnswer && onAnswer ? (
-          <AskActions actions={askBlock.actions} onAnswer={onAnswer} />
-        ) : (
-          <Text style={{ color: "#85858A", marginTop: 12, fontSize: 13.5 }}>No longer active</Text>
-        )}
+      <View style={{ gap: 8, width: "100%" }}>
+        <View
+          style={{
+            width: "90%",
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: "#232326",
+            backgroundColor: "#17171A",
+            paddingHorizontal: 16,
+            paddingVertical: 14,
+          }}
+        >
+          {askBlock.text ? (
+            <Text style={{ color: "#ECECEE", fontSize: 15.5, lineHeight: 23 }}>
+              {askBlock.text}
+            </Text>
+          ) : null}
+          {askBlock.detail ? (
+            <Text
+              style={{
+                color: "#85858A",
+                marginTop: 8,
+                fontSize: 12.5,
+                fontFamily: "Menlo",
+                lineHeight: 20,
+              }}
+            >
+              {askBlock.detail}
+            </Text>
+          ) : null}
+          {askBlock.status === "answered" ? (
+            <Text style={{ color: "#4ECB71", marginTop: 12, fontSize: 13.5, fontWeight: "600" }}>
+              {formatApprovalAnswer(askBlock.answer)}
+            </Text>
+          ) : canAnswer && onAnswer ? (
+            <AskActions actions={askBlock.actions} onAnswer={onAnswer} />
+          ) : (
+            <Text style={{ color: "#85858A", marginTop: 12, fontSize: 13.5 }}>
+              No longer active
+            </Text>
+          )}
+        </View>
+        {appConnectBlocks.map((block, index) => (
+          <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+        ))}
       </View>
     );
   }
@@ -1647,47 +1681,55 @@ function MessageBubble({
             </Pressable>
           ),
         )}
+        {appConnectBlocks.map((block, index) => (
+          <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+        ))}
       </View>
     );
   }
   const speaker = message.role === "bot" ? memberName(members, message.botId) : undefined;
   return (
-    <View
-      style={{
-        flexShrink: 1,
-        minWidth: 0,
-        maxWidth: "100%",
-        backgroundColor: message.role === "user" ? "#F1F1EF" : "#1A1A1D",
-        padding: 12,
-        borderRadius: 20,
-      }}
-    >
-      {speaker ? (
-        <Text style={{ color: "#85858A", fontSize: 12.5, fontWeight: "600", marginBottom: 4 }}>
-          {speaker}
-        </Text>
-      ) : null}
-      {replyPreview ? (
-        <Text style={{ color: "#85858A", fontSize: 12.5, marginBottom: 6 }} numberOfLines={2}>
-          {previewMessageText(replyPreview)}
-        </Text>
-      ) : null}
-      {message.role === "user" ? (
-        <Text style={{ color: "#1A1A1A", fontSize: 15.5, lineHeight: 23 }}>
-          {blockText(message)}
-        </Text>
-      ) : (
-        <>
-          <ChatMarkdown streaming={message.id.startsWith("progress:")}>
+    <View style={{ gap: 8, width: "100%" }}>
+      <View
+        style={{
+          flexShrink: 1,
+          minWidth: 0,
+          maxWidth: "100%",
+          backgroundColor: message.role === "user" ? "#F1F1EF" : "#1A1A1D",
+          padding: 12,
+          borderRadius: 20,
+        }}
+      >
+        {speaker ? (
+          <Text style={{ color: "#85858A", fontSize: 12.5, fontWeight: "600", marginBottom: 4 }}>
+            {speaker}
+          </Text>
+        ) : null}
+        {replyPreview ? (
+          <Text style={{ color: "#85858A", fontSize: 12.5, marginBottom: 6 }} numberOfLines={2}>
+            {previewMessageText(replyPreview)}
+          </Text>
+        ) : null}
+        {message.role === "user" ? (
+          <Text style={{ color: "#1A1A1A", fontSize: 15.5, lineHeight: 23 }}>
             {blockText(message)}
-          </ChatMarkdown>
-          {onSpeak ? (
-            <Pressable onPress={onSpeak} hitSlop={8} style={{ marginTop: 8 }}>
-              <Text style={{ color: "#85858A", fontSize: 13 }}>Speak</Text>
-            </Pressable>
-          ) : null}
-        </>
-      )}
+          </Text>
+        ) : (
+          <>
+            <ChatMarkdown streaming={message.id.startsWith("progress:")}>
+              {blockText(message)}
+            </ChatMarkdown>
+            {onSpeak ? (
+              <Pressable onPress={onSpeak} hitSlop={8} style={{ marginTop: 8 }}>
+                <Text style={{ color: "#85858A", fontSize: 13 }}>Speak</Text>
+              </Pressable>
+            ) : null}
+          </>
+        )}
+      </View>
+      {appConnectBlocks.map((block, index) => (
+        <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+      ))}
     </View>
   );
 }

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1364,6 +1364,7 @@ function MessageBubble({
 }) {
   const [peerExpanded, setPeerExpanded] = useState(false);
   const artifactTarget: MobileArtifactTarget = groupId ? { groupId } : { botId };
+  const cardBotId = message.botId ?? botId;
   const appConnectBlocks = message.blocks.filter(
     (block): block is Extract<MessageBlock, { kind: "app_connect" }> =>
       block.kind === "app_connect",
@@ -1377,7 +1378,7 @@ function MessageBubble({
       <View style={{ gap: 8, width: "100%" }}>
         <AskBlock ask={ask} canAnswer={canAnswer} onAnswer={onAnswer} />
         {appConnectBlocks.map((block, index) => (
-          <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+          <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
         ))}
       </View>
     );
@@ -1527,7 +1528,7 @@ function MessageBubble({
     return (
       <View style={{ gap: 8, width: "100%" }}>
         {appConnectBlocks.map((block, index) => (
-          <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+          <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
         ))}
       </View>
     );
@@ -1578,7 +1579,7 @@ function MessageBubble({
           )}
         </View>
         {appConnectBlocks.map((block, index) => (
-          <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+          <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
         ))}
       </View>
     );
@@ -1682,7 +1683,7 @@ function MessageBubble({
           ),
         )}
         {appConnectBlocks.map((block, index) => (
-          <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+          <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
         ))}
       </View>
     );
@@ -1728,7 +1729,7 @@ function MessageBubble({
         )}
       </View>
       {appConnectBlocks.map((block, index) => (
-        <AppConnectCard key={`${block.provider}-${index}`} botId={botId} block={block} />
+        <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
       ))}
     </View>
   );

--- a/apps/mobile/components/AppConnectCard.tsx
+++ b/apps/mobile/components/AppConnectCard.tsx
@@ -1,0 +1,138 @@
+import type { MessageBlock } from "@rakazo/contracts";
+import { abortableDelay } from "@rakazo/core";
+import { useEffect, useRef, useState } from "react";
+import { ActivityIndicator, Linking, Pressable, Text, View } from "react-native";
+import { rpc } from "../lib/api";
+import { appConnectPresentation } from "../lib/app-connect";
+import { native } from "../lib/native";
+
+export function AppConnectCard({
+  botId,
+  block,
+}: {
+  botId: string;
+  block: Extract<MessageBlock, { kind: "app_connect" }>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [localStatus, setLocalStatus] = useState<"pending" | "connected">(block.status);
+  const [error, setError] = useState<string | null>(null);
+  const connectionAttempt = useRef<AbortController | null>(null);
+  const status = block.status === "connected" ? "connected" : localStatus;
+  const view = appConnectPresentation({ ...block, status }, busy);
+
+  useEffect(() => () => connectionAttempt.current?.abort(), []);
+
+  async function authorize() {
+    connectionAttempt.current?.abort();
+    const controller = new AbortController();
+    connectionAttempt.current = controller;
+    setBusy(true);
+    setError(null);
+    try {
+      const started = await rpc<{ connectionId: string; authorizationUrl: string | null }>(
+        "connections/begin",
+        {
+          provider: block.provider,
+          displayName: block.name,
+        },
+        { signal: controller.signal },
+      );
+      if (controller.signal.aborted) return;
+      if (started.authorizationUrl) await Linking.openURL(started.authorizationUrl);
+      for (let attempt = 0; attempt < 60; attempt += 1) {
+        if (controller.signal.aborted) return;
+        const row = await rpc<{ status: string }>(
+          "connections/complete",
+          { connectionId: started.connectionId },
+          { signal: controller.signal },
+        ).catch(() => undefined);
+        if (row?.status === "connected") {
+          if (controller.signal.aborted) return;
+          await rpc("onboarding/appConnected", { botId, provider: block.provider });
+          if (controller.signal.aborted) return;
+          setLocalStatus("connected");
+          return;
+        }
+        await abortableDelay(2_000, controller.signal);
+      }
+      if (!controller.signal.aborted) setError("Authorization timed out. Please try again.");
+    } catch (reason) {
+      if (!controller.signal.aborted) {
+        setError(reason instanceof Error ? reason.message : "Could not authorize this app");
+      }
+    } finally {
+      if (connectionAttempt.current === controller) {
+        connectionAttempt.current = null;
+        setBusy(false);
+      }
+    }
+  }
+
+  return (
+    <View
+      accessibilityLabel={`${block.name} connection`}
+      style={{
+        width: "90%",
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor: "#232326",
+        backgroundColor: "#17171A",
+        paddingHorizontal: 16,
+        paddingVertical: 14,
+        gap: 8,
+      }}
+    >
+      <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+        <View
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 10,
+            backgroundColor: "#30356A",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Text style={{ color: "#E2E4FF", fontSize: 15, fontWeight: "600" }}>
+            {block.name.slice(0, 1).toUpperCase()}
+          </Text>
+        </View>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text style={{ color: "#ECECEE", fontSize: 15, fontWeight: "600" }}>{view.title}</Text>
+          <Text style={{ color: "#85858A", fontSize: 13.5 }} numberOfLines={2}>
+            {view.description}
+          </Text>
+        </View>
+        {view.showAuthorize ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Authorize ${block.name}`}
+            disabled={busy}
+            onPress={() => void authorize()}
+            style={{
+              minHeight: 36,
+              paddingHorizontal: 14,
+              borderRadius: 999,
+              backgroundColor: native.fillPressed,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            {busy ? (
+              <ActivityIndicator color={native.label} />
+            ) : (
+              <Text style={{ color: native.label, fontSize: 14, fontWeight: "600" }}>
+                {view.actionLabel}
+              </Text>
+            )}
+          </Pressable>
+        ) : (
+          <Text style={{ color: "#4ECB71", fontSize: 13.5, fontWeight: "600" }}>
+            {view.actionLabel}
+          </Text>
+        )}
+      </View>
+      {error ? <Text style={{ color: "#E96B6B", fontSize: 13 }}>{error}</Text> : null}
+    </View>
+  );
+}

--- a/apps/mobile/lib/app-connect.test.ts
+++ b/apps/mobile/lib/app-connect.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { appConnectPresentation } from "./app-connect.js";
+
+describe("appConnectPresentation", () => {
+  const block = {
+    kind: "app_connect" as const,
+    provider: "gmail",
+    name: "Gmail",
+    description: "Search, read, draft, and send email.",
+    logo: null,
+    status: "pending" as const,
+  };
+
+  it("renders an authorize control for pending app_connect blocks", () => {
+    const view = appConnectPresentation(block);
+    expect(view.showAuthorize).toBe(true);
+    expect(view.actionLabel).toBe("Authorize");
+  });
+
+  it("hides authorize once connected", () => {
+    const view = appConnectPresentation({ ...block, status: "connected" });
+    expect(view.showAuthorize).toBe(false);
+    expect(view.actionLabel).toBe("Connected");
+  });
+});

--- a/apps/mobile/lib/app-connect.ts
+++ b/apps/mobile/lib/app-connect.ts
@@ -1,0 +1,14 @@
+import type { MessageBlock } from "@rakazo/contracts";
+
+export type AppConnectBlock = Extract<MessageBlock, { kind: "app_connect" }>;
+
+export function appConnectPresentation(block: AppConnectBlock, busy = false) {
+  const connected = block.status === "connected";
+  return {
+    title: block.name,
+    description: block.description,
+    showAuthorize: !connected,
+    actionLabel: connected ? "Connected" : busy ? "Waiting…" : "Authorize",
+    connected,
+  };
+}

--- a/apps/mobile/lib/last-bot.ts
+++ b/apps/mobile/lib/last-bot.ts
@@ -1,0 +1,16 @@
+import * as SecureStore from "expo-secure-store";
+
+const LAST_BOT_KEY = "rakazo.last_bot_id";
+
+export async function saveLastBotId(botId: string) {
+  if (!botId.trim()) return;
+  await SecureStore.setItemAsync(LAST_BOT_KEY, botId);
+}
+
+export async function loadLastBotId() {
+  try {
+    return (await SecureStore.getItemAsync(LAST_BOT_KEY)) ?? "";
+  } catch {
+    return "";
+  }
+}

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -124,10 +124,11 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
 
   await page.getByText("Integrations").click();
   await expect(page.getByPlaceholder("Search apps")).toBeVisible();
-  await expect(page.getByText("Gmail", { exact: true })).toBeVisible();
-  await expect(page.getByText("Slack", { exact: true })).toBeVisible();
+  const featured = page.getByTestId("featured-connectors");
+  await expect(featured).toContainText(
+    /Gmail[\s\S]*Google Calendar[\s\S]*Google Drive[\s\S]*Slack[\s\S]*Notion/,
+  );
   await expect(page.getByText("GitHub", { exact: true })).toBeVisible();
-  await expect(page.getByText("Notion", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add Treg", exact: true })).toBeHidden();
   await expect(page.getByRole("button", { name: "Add MCP server", exact: true })).toBeHidden();
   await expect(page.getByRole("button", { name: "Add OpenAPI", exact: true })).toBeHidden();
@@ -137,7 +138,10 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   ).toBeHidden();
   await captureScreenshot(page, testInfo, "11-plugins-catalog");
 
-  const gmailRow = page.getByText("Gmail", { exact: true }).locator("..").locator("..");
+  // Nearest ancestor with an Add/Remove control (featured tile or catalog row).
+  const gmailRow = featured
+    .getByText("Gmail", { exact: true })
+    .locator("xpath=ancestor::*[.//button][1]");
   await gmailRow.getByRole("button", { name: "Add", exact: true }).click();
   await expect(gmailRow.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11a-connected-plugins");
@@ -146,7 +150,9 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await expect(gmailRow.getByRole("button", { name: "Add", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11b-connected-plugins-empty");
 
-  const linearRow = page.getByText("Linear", { exact: true }).locator("..").locator("..");
+  const linearRow = page
+    .getByText("Linear", { exact: true })
+    .locator("xpath=ancestor::*[.//button][1]");
   const connectPopup = page.waitForEvent("popup");
   await linearRow.getByRole("button", { name: "Add", exact: true }).click();
   const popup = await connectPopup;

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -1,6 +1,11 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { CapabilityInstall, ConnectionCatalogItem } from "@rakazo/contracts";
-import { abortableDelay } from "@rakazo/core";
+import {
+  abortableDelay,
+  buildFeaturedConnectorTiles,
+  EMPTY_PLUGIN_CATALOG_MESSAGE,
+  matchFeaturedConnectorId,
+} from "@rakazo/core";
 import { Button } from "@rakazo/ui-web";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { rpc } from "../lib/rpc";
@@ -25,9 +30,11 @@ function markConnected(
 export function PluginsOverlay({
   onClose,
   onOpenMcp,
+  activeBotId,
 }: {
   onClose: () => void;
   onOpenMcp?: () => void;
+  activeBotId?: string;
 }) {
   const { t } = useLingui();
   const [query, setQuery] = useState("");
@@ -64,16 +71,33 @@ export function PluginsOverlay({
     return () => connectionAttempt.current?.abort();
   }, []);
 
+  const featuredTiles = useMemo(() => buildFeaturedConnectorTiles(catalog), [catalog]);
+  const showFeatured = !query.trim();
+
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    if (!needle) return catalog;
-    return catalog.filter(
+    const scoped = showFeatured
+      ? catalog.filter(
+          (item) =>
+            matchFeaturedConnectorId(item.slug) === null &&
+            matchFeaturedConnectorId(item.name) === null,
+        )
+      : catalog;
+    if (!needle) return scoped;
+    return scoped.filter(
       (item) =>
         item.name.toLowerCase().includes(needle) ||
         item.slug.toLowerCase().includes(needle) ||
         item.connectorId.toLowerCase().includes(needle),
     );
-  }, [catalog, query]);
+  }, [catalog, query, showFeatured]);
+
+  async function notifyAppConnected(item: ConnectionCatalogItem) {
+    if (!activeBotId) return;
+    await rpc.onboarding
+      .appConnected({ botId: activeBotId, provider: item.slug })
+      .catch(() => undefined);
+  }
 
   function setItemConnected(item: ConnectionCatalogItem, connected: boolean) {
     setCatalog((prev) => markConnected(prev, item.connectorId, item.slug, connected));
@@ -97,6 +121,7 @@ export function PluginsOverlay({
       if (item.noAuth && !started.authorizationUrl) {
         if (controller.signal.aborted) return;
         setItemConnected(item, true);
+        void notifyAppConnected(item);
         return;
       }
       for (let i = 0; i < 45; i += 1) {
@@ -107,6 +132,7 @@ export function PluginsOverlay({
         if (row?.status === "connected") {
           if (controller.signal.aborted) return;
           setItemConnected(item, true);
+          void notifyAppConnected(item);
           return;
         }
         await abortableDelay(2_000, controller.signal);
@@ -238,12 +264,82 @@ export function PluginsOverlay({
             </p>
           ) : null}
 
-          {!loading && catalog.length === 0 ? (
+          {showFeatured ? (
+            <div className="mb-6" data-testid="featured-connectors">
+              {!loading && catalog.length === 0 ? (
+                <p className="text-[13.5px] leading-6 text-[#6C6C70]">
+                  {EMPTY_PLUGIN_CATALOG_MESSAGE}
+                </p>
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  {featuredTiles.map((tile) => {
+                    const item = tile.item;
+                    const key = item ? itemKey(item) : tile.id;
+                    const disabled = tile.missing || !item;
+                    const connected = item?.connected ?? false;
+                    return (
+                      <div
+                        key={key}
+                        className={`flex min-w-0 items-center gap-3 rounded-[13px] px-2.5 py-2 ${
+                          disabled ? "opacity-70" : ""
+                        }`}
+                      >
+                        {item?.logo ? (
+                          <img
+                            src={item.logo}
+                            alt=""
+                            className="h-9 w-9 shrink-0 rounded-xl bg-[#2C2C30] object-contain"
+                          />
+                        ) : (
+                          <div className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-[#2C2C30] text-sm font-semibold text-[#ECECEE]">
+                            {tile.label[0]}
+                          </div>
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-[15px] font-medium text-[#ECECEE]">
+                            {tile.label}
+                          </div>
+                          {disabled ? (
+                            <div className="truncate text-[12.5px] text-[#707077]">
+                              <Trans>Not in the plugin catalog</Trans>
+                            </div>
+                          ) : null}
+                        </div>
+                        {item && !tile.missing ? (
+                          <Button
+                            type="button"
+                            variant="pill"
+                            size="sm"
+                            disabled={pending === key}
+                            onClick={() => void (connected ? revoke(item) : connect(item))}
+                          >
+                            {pending === key ? (
+                              connected ? (
+                                <Trans>Removing…</Trans>
+                              ) : (
+                                <Trans>Adding…</Trans>
+                              )
+                            ) : connected ? (
+                              <Trans>Remove</Trans>
+                            ) : (
+                              <Trans>Add</Trans>
+                            )}
+                          </Button>
+                        ) : null}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ) : null}
+
+          {!loading && catalog.length === 0 && !showFeatured ? (
             <p className="text-[#6C6C70]">
               <Trans>No managed app catalog is configured on this deployment.</Trans>
             </p>
           ) : null}
-          {!loading && catalog.length > 0 && visible.length === 0 ? (
+          {!loading && catalog.length > 0 && visible.length === 0 && !showFeatured ? (
             <p className="text-[#6C6C70]">
               <Trans>No apps match your search.</Trans>
             </p>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2801,6 +2801,7 @@ export function ShellPage() {
 
         {pluginsOpen ? (
           <PluginsOverlay
+            activeBotId={activeBotId.current}
             onClose={() => setPluginsOpen(false)}
             onOpenMcp={() => {
               setPluginsOpen(false);

--- a/packages/adapters/src/composio-emulator.test.ts
+++ b/packages/adapters/src/composio-emulator.test.ts
@@ -21,7 +21,7 @@ describe("ComposioEmulator", () => {
   it("serves and searches a deterministic catalog", async () => {
     const emulator = new ComposioEmulator();
 
-    await expect(emulator.catalog(context)).resolves.toHaveLength(4);
+    await expect(emulator.catalog(context)).resolves.toHaveLength(6);
     await expect(emulator.catalog(context, "git")).resolves.toEqual([
       expect.objectContaining({ slug: "GITHUB", name: "GitHub", connected: false }),
     ]);

--- a/packages/adapters/src/composio-emulator.ts
+++ b/packages/adapters/src/composio-emulator.ts
@@ -12,6 +12,8 @@ import {
 
 const DEFAULT_CATALOG: ReadonlyArray<Omit<ComposioCatalogItem, "connected">> = [
   { slug: "GMAIL", name: "Gmail", logo: null, noAuth: false },
+  { slug: "GOOGLECALENDAR", name: "Google Calendar", logo: null, noAuth: false },
+  { slug: "GOOGLEDRIVE", name: "Google Drive", logo: null, noAuth: false },
   { slug: "SLACK", name: "Slack", logo: null, noAuth: false },
   { slug: "GITHUB", name: "GitHub", logo: null, noAuth: false },
   { slug: "NOTION", name: "Notion", logo: null, noAuth: false },

--- a/packages/core/src/featured-connectors.test.ts
+++ b/packages/core/src/featured-connectors.test.ts
@@ -1,0 +1,74 @@
+import type { ConnectionCatalogItem } from "@rakazo/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  buildFeaturedConnectorTiles,
+  featuredConnectorProvidersMatch,
+  matchFeaturedConnectorId,
+  resolveFeaturedCatalogItem,
+} from "./featured-connectors.js";
+
+function item(slug: string, name: string, connected = false): ConnectionCatalogItem {
+  return {
+    connectorId: "composio",
+    slug,
+    name,
+    logo: null,
+    connected,
+    noAuth: false,
+  };
+}
+
+describe("featured connectors", () => {
+  it("maps gmail aliases to the same featured id", () => {
+    expect(matchFeaturedConnectorId("gmail")).toBe("gmail");
+    expect(matchFeaturedConnectorId("Google Mail")).toBe("gmail");
+    expect(matchFeaturedConnectorId("GMAIL")).toBe("gmail");
+    expect(featuredConnectorProvidersMatch("gmail", "Google Mail")).toBe(true);
+  });
+
+  it("maps calendar and drive catalog slugs", () => {
+    expect(matchFeaturedConnectorId("googlecalendar")).toBe("google-calendar");
+    expect(matchFeaturedConnectorId("google_drive")).toBe("google-drive");
+    expect(matchFeaturedConnectorId("googledrive")).toBe("google-drive");
+  });
+
+  it("maps slack and notion catalog aliases", () => {
+    expect(matchFeaturedConnectorId("slack")).toBe("slack");
+    expect(matchFeaturedConnectorId("slackbot")).toBe("slack");
+    expect(matchFeaturedConnectorId("SLACK")).toBe("slack");
+    expect(matchFeaturedConnectorId("notion")).toBe("notion");
+    expect(matchFeaturedConnectorId("notion.so")).toBe("notion");
+    expect(matchFeaturedConnectorId("NOTION")).toBe("notion");
+    expect(featuredConnectorProvidersMatch("slack", "slackbot")).toBe(true);
+    expect(featuredConnectorProvidersMatch("notion", "notion.so")).toBe(true);
+  });
+
+  it("returns null for unknown catalog entries", () => {
+    expect(matchFeaturedConnectorId("salesforce")).toBeNull();
+    expect(matchFeaturedConnectorId("outlook")).toBeNull();
+    expect(resolveFeaturedCatalogItem("gmail", [item("github", "GitHub")])).toBeUndefined();
+  });
+
+  it("resolves featured rows from slug or display name", () => {
+    const catalog = [item("gmail", "Gmail"), item("slackbot", "Slack"), item("NOTION", "Notion")];
+    expect(resolveFeaturedCatalogItem("gmail", catalog)?.slug).toBe("gmail");
+    expect(resolveFeaturedCatalogItem("slack", catalog)?.slug).toBe("slackbot");
+    expect(resolveFeaturedCatalogItem("notion", catalog)?.slug).toBe("NOTION");
+  });
+
+  it("marks all featured tiles missing when the catalog is empty", () => {
+    const tiles = buildFeaturedConnectorTiles([]);
+    expect(tiles).toHaveLength(5);
+    expect(tiles.every((tile) => !tile.item && !tile.missing)).toBe(true);
+  });
+
+  it("marks unknown featured apps missing when the catalog has other apps", () => {
+    const tiles = buildFeaturedConnectorTiles([item("gmail", "Gmail", true)]);
+    const gmail = tiles.find((tile) => tile.id === "gmail");
+    const drive = tiles.find((tile) => tile.id === "google-drive");
+    expect(gmail?.item?.connected).toBe(true);
+    expect(gmail?.missing).toBe(false);
+    expect(drive?.missing).toBe(true);
+    expect(drive?.item).toBeUndefined();
+  });
+});

--- a/packages/core/src/featured-connectors.ts
+++ b/packages/core/src/featured-connectors.ts
@@ -1,0 +1,86 @@
+import type { ConnectionCatalogItem } from "@rakazo/contracts";
+
+export const FEATURED_CONNECTOR_IDS = [
+  "gmail",
+  "google-calendar",
+  "google-drive",
+  "slack",
+  "notion",
+] as const;
+
+export type FeaturedConnectorId = (typeof FEATURED_CONNECTOR_IDS)[number];
+
+export const FEATURED_CONNECTOR_LABELS: Record<FeaturedConnectorId, string> = {
+  gmail: "Gmail",
+  "google-calendar": "Google Calendar",
+  "google-drive": "Google Drive",
+  slack: "Slack",
+  notion: "Notion",
+};
+
+const FEATURED_ALIASES: Record<FeaturedConnectorId, readonly string[]> = {
+  gmail: ["gmail", "googlemail", "google mail"],
+  "google-calendar": ["googlecalendar", "google calendar", "google_calendar", "gcal"],
+  "google-drive": ["googledrive", "google drive", "google_drive", "gdrive"],
+  slack: ["slack", "slackbot"],
+  notion: ["notion", "notion.so"],
+};
+
+export type FeaturedConnectorTile = {
+  id: FeaturedConnectorId;
+  label: string;
+  item?: ConnectionCatalogItem;
+  /** Catalog has items but none matched this featured connector. */
+  missing: boolean;
+};
+
+function normalizeConnectorKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+export function matchFeaturedConnectorId(value: string): FeaturedConnectorId | null {
+  const normalized = normalizeConnectorKey(value);
+  if (!normalized) return null;
+  for (const id of FEATURED_CONNECTOR_IDS) {
+    if (FEATURED_ALIASES[id].some((alias) => normalizeConnectorKey(alias) === normalized)) {
+      return id;
+    }
+  }
+  return null;
+}
+
+export function featuredConnectorProvidersMatch(left: string, right: string): boolean {
+  if (left === right) return true;
+  const leftId = matchFeaturedConnectorId(left);
+  const rightId = matchFeaturedConnectorId(right);
+  return leftId !== null && leftId === rightId;
+}
+
+export function resolveFeaturedCatalogItem(
+  id: FeaturedConnectorId,
+  catalog: readonly ConnectionCatalogItem[],
+): ConnectionCatalogItem | undefined {
+  for (const item of catalog) {
+    if (matchFeaturedConnectorId(item.slug) === id) return item;
+    if (matchFeaturedConnectorId(item.name) === id) return item;
+  }
+  return undefined;
+}
+
+export function buildFeaturedConnectorTiles(
+  catalog: readonly ConnectionCatalogItem[],
+): FeaturedConnectorTile[] {
+  const hasCatalog = catalog.length > 0;
+  return FEATURED_CONNECTOR_IDS.map((id) => {
+    const item = hasCatalog ? resolveFeaturedCatalogItem(id, catalog) : undefined;
+    return {
+      id,
+      label: FEATURED_CONNECTOR_LABELS[id],
+      item,
+      missing: hasCatalog && !item,
+    };
+  });
+}
+
+export const EMPTY_PLUGIN_CATALOG_MESSAGE =
+  "Configure a plugin catalog on the server to connect apps.";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from "./composer-slash.js";
 export * from "./cron.js";
 
 export * from "./events.js";
+export * from "./featured-connectors.js";
 export * from "./group-mentions.js";
 export * from "./mcp.js";
 export * from "./message-pages.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rebased onto current `main` so the featured pin set lands **on top of** the quiet Integrations layout from #268 (not the older tabbed/subtitle chrome).
- Featured connectors at the top, in order: **Gmail → Google Calendar → Google Drive → Slack → Notion** (Outlook / Teams / Salesforce / Granola stay out).
- Quiet chrome kept: title Integrations, search, Add/Remove, 2-column grid; Treg/MCP/OpenAPI + Tool sources under collapsed Advanced (MCP → OpenAPI → Treg when add buttons show).
- Kept useful #269 work: shared `featured-connectors` resolver, mobile `AppConnectCard` / `app_connect` mixed-block render, last-bot persistence, onboarding `appConnected` alias matching.
- Emulator catalog includes Calendar + Drive so featured tiles resolve in offline/dev/E2E.
- Follow-up: mobile catalog load decoupled from capabilities; AppConnectCard uses emitting message bot in groups.

## Screenshots
![Integrations featured default](https://cursor.com/artifacts/c/art-3d9333f0-ffb3-45ff-880c-9e2fa867cdc5)
![Integrations Advanced open](https://cursor.com/artifacts/c/art-9c90eaad-715a-4c51-b7eb-ced1e5f635a7)

## Test plan
- [ ] Open Integrations: five featured tiles in order; Advanced collapsed; no subtitle / category chips / installed count
- [ ] Connect Gmail from featured tile (Add → Remove); Linear still works from the catalog grid
- [ ] Advanced open: MCP → OpenAPI → Treg order (with MCP servers link when present)
- [ ] Expo: mixed ask + `app_connect` shows connection card; connect flips onboarding card
- [ ] Empty catalog shows configure message (provider-neutral)

## Conflict resolution
Plain rebase of the old tip onto #268 fought the pre-quiet UI commits. Resolved by replaying the final #269 product intent as a clean commit on current `main`: keep #268 overlay structure, graft featured tiles + mobile/onboarding helpers.

SHA: `ec12fae79e4b881facd7690251fd3c79e23bafbf`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a465262-0405-4afb-9486-aaa9596a7f87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a465262-0405-4afb-9486-aaa9596a7f87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added featured connector tiles for Gmail, Google Calendar, Google Drive, Slack, and Notion.
  * Added app authorization cards with connection status, loading states, errors, and completion handling.
  * Added featured connector support across web and mobile integrations screens.
  * Added Advanced integrations controls and improved empty-catalog messaging.
  * Preserved the last visited bot for smoother connection flows.

* **Bug Fixes**
  * Equivalent connector providers are now recognized consistently, including aliases.

* **Tests**
  * Expanded coverage for featured connectors, authorization states, catalog behavior, and integration layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->