### PR TITLE
feat(sidebar): add collapsible sections

### DIFF
--- a/apps/web/e2e/collapsible-sidebar-sections.spec.ts
+++ b/apps/web/e2e/collapsible-sidebar-sections.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+test("titled sidebar section expands and collapses", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `sidebar-collapse-${stamp}@rakazo.test`, "password12", "Test User");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  const sidebar = page.locator("aside").first();
+  const bot = sidebar.getByRole("button", { name: /^Chief/ });
+
+  await bot.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Move to", exact: true }).click();
+  await page
+    .getByRole("menu", { name: /Move Chief to section/ })
+    .getByText("New section")
+    .click();
+  const dialog = page.getByRole("dialog", { name: "New section" });
+  await dialog.getByLabel("Name").fill("Projects");
+  await dialog.getByRole("button", { name: "Create" }).click();
+
+  const projects = sidebar.locator('[data-sidebar-group^="section:"]');
+  await expect(projects).toContainText("Projects");
+  await expect(projects).toContainText("Chief");
+
+  const toggle = projects.getByRole("button", { name: /Collapse Projects|Expand Projects/ });
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await captureScreenshot(page, testInfo, "sidebar-section-expanded");
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  await expect(projects.getByRole("button", { name: /^Chief/ })).toHaveCount(0);
+  await captureScreenshot(page, testInfo, "sidebar-section-collapsed");
+});

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1812,7 +1812,7 @@ export function ShellPage() {
                 />
               ) : null}
               {sidebarGroups.map((group) => {
-                const collapsed = collapsedSidebarSections.has(group.key);
+                const collapsed = Boolean(group.title) && collapsedSidebarSections.has(group.key);
                 return (
                   <div key={group.key} data-sidebar-group={group.key}>
                     {group.title ? (

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1854,7 +1854,8 @@ export function ShellPage() {
                           }}
                           className="flex w-full gap-3 rounded-xl px-2.5 py-[11px] text-start"
                           style={{
-                            background: !inGroup && active?.id === bot.id ? "#161618" : "transparent",
+                            background:
+                              !inGroup && active?.id === bot.id ? "#161618" : "transparent",
                           }}
                         >
                           <BotAvatar color={bot.color} size={38} status={bot.status} />

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -63,6 +63,7 @@ import {
   ArrowUp,
   Bell,
   Box,
+  ChevronDown,
   ChevronLeft,
   Clock,
   Copy,
@@ -193,6 +194,17 @@ type PendingAttachment = {
 };
 
 const ATTACHMENT_ACCEPT = ATTACHMENT_ALLOWED_MIME_TYPES.join(",");
+const COLLAPSED_SIDEBAR_SECTIONS_KEY = "rakazo:collapsed-sidebar-sections";
+
+function readCollapsedSidebarSections(): Set<string> {
+  try {
+    const value = window.localStorage.getItem(COLLAPSED_SIDEBAR_SECTIONS_KEY);
+    const keys: unknown = value ? JSON.parse(value) : [];
+    return new Set(Array.isArray(keys) ? keys.filter((key): key is string => typeof key === "string") : []);
+  } catch {
+    return new Set();
+  }
+}
 
 export function ShellPage() {
   const { t } = useLingui();
@@ -210,6 +222,7 @@ export function ShellPage() {
   const [botSections, setBotSections] = useState<BotSection[]>([]);
   const [archivedBots, setArchivedBots] = useState<Bot[]>([]);
   const [archivedOpen, setArchivedOpen] = useState(false);
+  const [collapsedSidebarSections, setCollapsedSidebarSections] = useState(readCollapsedSidebarSections);
   const [query, setQuery] = useState("");
   const [searchHits, setSearchHits] = useState<SearchHit[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
@@ -934,6 +947,19 @@ export function ShellPage() {
     () => groupBotsForSidebar<Bot>(filtered, botSections),
     [botSections, filtered],
   );
+  const toggleSidebarSection = useCallback((key: string) => {
+    setCollapsedSidebarSections((previous) => {
+      const next = new Set(previous);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      try {
+        window.localStorage.setItem(COLLAPSED_SIDEBAR_SECTIONS_KEY, JSON.stringify([...next]));
+      } catch {
+        // Keep the UI usable when storage is unavailable.
+      }
+      return next;
+    });
+  }, []);
   const workspaceQuery = query.trim();
   const showWorkspaceSearch = workspaceQuery.length > 0;
 
@@ -1781,14 +1807,28 @@ export function ShellPage() {
                   }}
                 />
               ) : null}
-              {sidebarGroups.map((group) => (
-                <div key={group.key} data-sidebar-group={group.key}>
-                  {group.title ? (
-                    <div className="px-2.5 pb-1 pt-3 text-[12.5px] font-medium text-[#6C6C70]">
-                      {group.title}
-                    </div>
-                  ) : null}
-                  {group.bots.map((bot) => (
+              {sidebarGroups.map((group) => {
+                const collapsed = collapsedSidebarSections.has(group.key);
+                return (
+                  <div key={group.key} data-sidebar-group={group.key}>
+                    {group.title ? (
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between rounded-lg px-2.5 pb-1 pt-3 text-[12.5px] font-medium text-[#6C6C70] hover:bg-[#1A1A1D] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#8B5CF6]"
+                        onClick={() => toggleSidebarSection(group.key)}
+                        aria-expanded={!collapsed}
+                        aria-label={collapsed ? t`Expand ${group.title}` : t`Collapse ${group.title}`}
+                      >
+                        <span>{group.title}</span>
+                        <ChevronDown
+                          size={15}
+                          strokeWidth={1.8}
+                          className={collapsed ? "-rotate-90 transition-transform" : "transition-transform"}
+                          aria-hidden="true"
+                        />
+                      </button>
+                    ) : null}
+                    {!collapsed && group.bots.map((bot) => (
                     <button
                       key={bot.id}
                       type="button"
@@ -1844,9 +1884,10 @@ export function ShellPage() {
                         </div>
                       </div>
                     </button>
-                  ))}
-                </div>
-              ))}
+                    ))}
+                  </div>
+                );
+              })}
             </>
           )}
           {!showWorkspaceSearch

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -200,7 +200,9 @@ function readCollapsedSidebarSections(): Set<string> {
   try {
     const value = window.localStorage.getItem(COLLAPSED_SIDEBAR_SECTIONS_KEY);
     const keys: unknown = value ? JSON.parse(value) : [];
-    return new Set(Array.isArray(keys) ? keys.filter((key): key is string => typeof key === "string") : []);
+    return new Set(
+      Array.isArray(keys) ? keys.filter((key): key is string => typeof key === "string") : [],
+    );
   } catch {
     return new Set();
   }
@@ -222,7 +224,9 @@ export function ShellPage() {
   const [botSections, setBotSections] = useState<BotSection[]>([]);
   const [archivedBots, setArchivedBots] = useState<Bot[]>([]);
   const [archivedOpen, setArchivedOpen] = useState(false);
-  const [collapsedSidebarSections, setCollapsedSidebarSections] = useState(readCollapsedSidebarSections);
+  const [collapsedSidebarSections, setCollapsedSidebarSections] = useState(
+    readCollapsedSidebarSections,
+  );
   const [query, setQuery] = useState("");
   const [searchHits, setSearchHits] = useState<SearchHit[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
@@ -1817,74 +1821,79 @@ export function ShellPage() {
                         className="flex w-full items-center justify-between rounded-lg px-2.5 pb-1 pt-3 text-[12.5px] font-medium text-[#6C6C70] hover:bg-[#1A1A1D] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#8B5CF6]"
                         onClick={() => toggleSidebarSection(group.key)}
                         aria-expanded={!collapsed}
-                        aria-label={collapsed ? t`Expand ${group.title}` : t`Collapse ${group.title}`}
+                        aria-label={
+                          collapsed ? t`Expand ${group.title}` : t`Collapse ${group.title}`
+                        }
                       >
                         <span>{group.title}</span>
                         <ChevronDown
                           size={15}
                           strokeWidth={1.8}
-                          className={collapsed ? "-rotate-90 transition-transform" : "transition-transform"}
+                          className={
+                            collapsed ? "-rotate-90 transition-transform" : "transition-transform"
+                          }
                           aria-hidden="true"
                         />
                       </button>
                     ) : null}
-                    {!collapsed && group.bots.map((bot) => (
-                    <button
-                      key={bot.id}
-                      type="button"
-                      onClick={() => {
-                        setMobileSidebarOpen(false);
-                        navigate(`/app/${bot.id}`);
-                      }}
-                      onContextMenu={(event) => {
-                        event.preventDefault();
-                        setBotMenu({
-                          botId: bot.id,
-                          position: { x: event.clientX, y: event.clientY },
-                        });
-                      }}
-                      className="flex w-full gap-3 rounded-xl px-2.5 py-[11px] text-start"
-                      style={{
-                        background: !inGroup && active?.id === bot.id ? "#161618" : "transparent",
-                      }}
-                    >
-                      <BotAvatar color={bot.color} size={38} status={bot.status} />
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-baseline justify-between gap-2">
-                          <span
-                            dir="auto"
-                            className={`truncate text-[15px] text-[#ECECEE] ${
-                              bot.unread ? "font-semibold" : "font-medium"
-                            }`}
-                          >
-                            {bot.name}
-                            {bot.unread ? (
-                              <span className="sr-only">
-                                <Trans> (unread)</Trans>
-                              </span>
-                            ) : null}
-                          </span>
-                          <span className="flex shrink-0 items-center gap-1.5 text-[12.5px] text-[#6C6C70]">
-                            {bot.status === "idle" ? "" : bot.status}
-                            {bot.unread ? (
-                              <span
-                                aria-hidden="true"
-                                className="inline-block h-2 w-2 rounded-full bg-[#8B5CF6]"
-                              />
-                            ) : null}
-                          </span>
-                        </div>
-                        <div
-                          dir="auto"
-                          className={`mt-0.5 truncate text-[13.5px] ${
-                            bot.unread ? "font-medium text-[#C9C9CE]" : "text-[#85858A]"
-                          }`}
+                    {!collapsed &&
+                      group.bots.map((bot) => (
+                        <button
+                          key={bot.id}
+                          type="button"
+                          onClick={() => {
+                            setMobileSidebarOpen(false);
+                            navigate(`/app/${bot.id}`);
+                          }}
+                          onContextMenu={(event) => {
+                            event.preventDefault();
+                            setBotMenu({
+                              botId: bot.id,
+                              position: { x: event.clientX, y: event.clientY },
+                            });
+                          }}
+                          className="flex w-full gap-3 rounded-xl px-2.5 py-[11px] text-start"
+                          style={{
+                            background: !inGroup && active?.id === bot.id ? "#161618" : "transparent",
+                          }}
                         >
-                          {bot.preview || bot.title}
-                        </div>
-                      </div>
-                    </button>
-                    ))}
+                          <BotAvatar color={bot.color} size={38} status={bot.status} />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-baseline justify-between gap-2">
+                              <span
+                                dir="auto"
+                                className={`truncate text-[15px] text-[#ECECEE] ${
+                                  bot.unread ? "font-semibold" : "font-medium"
+                                }`}
+                              >
+                                {bot.name}
+                                {bot.unread ? (
+                                  <span className="sr-only">
+                                    <Trans> (unread)</Trans>
+                                  </span>
+                                ) : null}
+                              </span>
+                              <span className="flex shrink-0 items-center gap-1.5 text-[12.5px] text-[#6C6C70]">
+                                {bot.status === "idle" ? "" : bot.status}
+                                {bot.unread ? (
+                                  <span
+                                    aria-hidden="true"
+                                    className="inline-block h-2 w-2 rounded-full bg-[#8B5CF6]"
+                                  />
+                                ) : null}
+                              </span>
+                            </div>
+                            <div
+                              dir="auto"
+                              className={`mt-0.5 truncate text-[13.5px] ${
+                                bot.unread ? "font-medium text-[#C9C9CE]" : "text-[#85858A]"
+                              }`}
+                            >
+                              {bot.preview || bot.title}
+                            </div>
+                          </div>
+                        </button>
+                      ))}
                   </div>
                 );
               })}


### PR DESCRIPTION
Closes #270

## Summary
- make each titled sidebar section expandable/collapsible with a chevron control
- persist collapsed section keys in local storage
- expose expanded state and accessible labels on the native button

## Testing
- Not run: the checkout has no package manager available (`pnpm`/`npm` are not installed in this environment).
- Verified whitespace with `git diff --check` before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added collapsible sections to the sidebar.
  * Section states persist between sessions.
  * Added expand/collapse controls with visual chevron indicators.
  * Collapsing a section hides its contents for cleaner navigation.
  * Untitled sections remain expanded so their contents are always accessible.
* **Bug Fixes**
  * Sidebar remains usable if saved section preferences cannot be loaded or updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->