### PR TITLE
Recover, reset, and update a bot computer from settings

### DIFF
--- a/.amqrc
+++ b/.amqrc
@@ -1,0 +1,3 @@
+{
+  "root": "/Users/benshaharizad/git/rakazo/.agent-mail"
+}

--- a/.amqrc
+++ b/.amqrc
@@ -1,3 +1,0 @@
-{
-  "root": "/Users/benshaharizad/git/rakazo/.agent-mail"
-}

--- a/apps/api/src/computer-status.test.ts
+++ b/apps/api/src/computer-status.test.ts
@@ -32,8 +32,24 @@ describe("toComputerStatus", () => {
   });
 
   it("hides update on desktop computers", () => {
-    expect(toComputerStatus("bot-1", { kind: "desktop", state: "running", scope: "team", controlHolder: "none", homeRevision: "r1" }).updateAvailable).toBe(false);
-    expect(toComputerStatus("bot-1", { kind: "e2b", state: "running", scope: "team", controlHolder: "none", homeRevision: "r1" }).updateAvailable).toBe(true);
+    expect(
+      toComputerStatus("bot-1", {
+        kind: "desktop",
+        state: "running",
+        scope: "team",
+        controlHolder: "none",
+        homeRevision: "r1",
+      }).updateAvailable,
+    ).toBe(false);
+    expect(
+      toComputerStatus("bot-1", {
+        kind: "e2b",
+        state: "running",
+        scope: "team",
+        controlHolder: "none",
+        homeRevision: "r1",
+      }).updateAvailable,
+    ).toBe(true);
   });
 });
 

--- a/apps/api/src/computer-status.test.ts
+++ b/apps/api/src/computer-status.test.ts
@@ -30,6 +30,11 @@ describe("toComputerStatus", () => {
     expect(toComputerStatus("bot-1", computer).busyBotName).toBeNull();
     expect(toComputerStatus("bot-1", computer, "Writer").busyBotName).toBe("Writer");
   });
+
+  it("hides update on desktop computers", () => {
+    expect(toComputerStatus("bot-1", { kind: "desktop", state: "running", scope: "team", controlHolder: "none", homeRevision: "r1" }).updateAvailable).toBe(false);
+    expect(toComputerStatus("bot-1", { kind: "e2b", state: "running", scope: "team", controlHolder: "none", homeRevision: "r1" }).updateAvailable).toBe(true);
+  });
 });
 
 describe("executionBlocksUserTakeover", () => {

--- a/apps/api/src/computer-status.ts
+++ b/apps/api/src/computer-status.ts
@@ -70,10 +70,11 @@ export function toComputerStatus(
         ? computer.state
         : "stopped";
   const screen = computerScreenSize(computer?.kind);
+  const kind = (computer?.kind ?? "fake") as ComputerStatus["kind"];
   return {
     botId,
     mode: computer?.scope === "dedicated" ? "dedicated" : "team",
-    kind: (computer?.kind ?? "fake") as ComputerStatus["kind"],
+    kind,
     state,
     controlHolder: (computer?.controlHolder ?? "none") as ComputerStatus["controlHolder"],
     controlBotId: computer?.controlBotId ?? null,
@@ -83,5 +84,6 @@ export function toComputerStatus(
     screenHeight: screen.height,
     homeRevision: computer?.homeRevision ?? null,
     busyBotName,
+    updateAvailable: kind !== "desktop",
   };
 }

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -47,6 +47,8 @@ import {
   provisionComputer,
   type RemoteConnectorDependencies,
   releaseComputerExecutionLease,
+  replaceComputer,
+  computerSupportsUpdate,
   resolveBotWorkspacePath,
   sanitizeComposioError,
   savePushToken,
@@ -1114,6 +1116,15 @@ export function createRouter(deps: RouterDeps) {
         );
         return computerStatus(deps, context.actor, input.botId);
       }),
+      recover: authed.computer.recover.handler(async ({ context, input }) =>
+        runComputerReplace(deps, context, input.botId, "recover", "recover"),
+      ),
+      reset: authed.computer.reset.handler(async ({ context, input }) =>
+        runComputerReplace(deps, context, input.botId, "reset", "reset"),
+      ),
+      update: authed.computer.update.handler(async ({ context, input }) =>
+        runComputerReplace(deps, context, input.botId, "update", "update"),
+      ),
       takeover: authed.computer.takeover.handler(async ({ context, input }) => {
         let bot = await repos.getBot(context.actor, input.botId);
         if (!bot.computer?.providerRef || bot.computer.state !== "running") {
@@ -2918,6 +2929,52 @@ async function computerStatus(
     botName: bot.name,
   });
   return toComputerStatus(botId, bot.computer, busyBotName);
+}
+
+async function runComputerReplace(
+  deps: RouterDeps,
+  context: { actor: Actor },
+  botId: string,
+  mode: "recover" | "reset" | "update",
+  operationId: string,
+): Promise<ComputerStatus> {
+  const repos = createRepos(deps.prisma);
+  const bot = await repos.getBot(context.actor, botId);
+  if (!bot.computer) throw new IsolationError();
+  if (mode === "update" && !computerSupportsUpdate(bot.computer.kind)) {
+    throw new ORPCError("BAD_REQUEST", {
+      message: "Computer update is not available on this device",
+    });
+  }
+  const manualRunId = `${mode}:${randomUUID()}`;
+  let lease: ComputerExecutionLease | null;
+  try {
+    lease = await acquireComputerExecutionLease(deps.prisma, {
+      computerId: bot.computer.id,
+      runId: manualRunId,
+      botId: bot.id,
+    });
+  } catch (error) {
+    if (error instanceof ComputerBusyError) {
+      throw new ORPCError("CONFLICT", { message: "Computer is busy" });
+    }
+    throw error;
+  }
+  try {
+    await replaceComputer(
+      deps,
+      bot.computer.id,
+      mode,
+      {
+        ...computerContext(context.actor, bot.id, operationId),
+        screenLeaseId: screenLeaseIdForRun(lease, manualRunId),
+      },
+    );
+    scheduleComputerSleep(deps.jobs, bot.computer.id);
+  } finally {
+    await releaseComputerExecutionLease(deps.prisma, lease);
+  }
+  return computerStatus(deps, context.actor, botId);
 }
 
 async function expireStaleComputerControl(

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -25,6 +25,7 @@ import {
   type ComputerExecutionLease,
   type ConnectorRegistry,
   checkpointAndRecordComputerWorkspace,
+  computerSupportsUpdate,
   createVoiceProvider,
   destroyBot,
   displayBotWorkspacePath,
@@ -48,7 +49,6 @@ import {
   type RemoteConnectorDependencies,
   releaseComputerExecutionLease,
   replaceComputer,
-  computerSupportsUpdate,
   resolveBotWorkspacePath,
   sanitizeComposioError,
   savePushToken,
@@ -2961,16 +2961,16 @@ async function runComputerReplace(
     throw error;
   }
   try {
-    await replaceComputer(
-      deps,
-      bot.computer.id,
-      mode,
-      {
-        ...computerContext(context.actor, bot.id, operationId),
-        screenLeaseId: screenLeaseIdForRun(lease, manualRunId),
-      },
-    );
+    await replaceComputer(deps, bot.computer.id, mode, {
+      ...computerContext(context.actor, bot.id, operationId),
+      screenLeaseId: screenLeaseIdForRun(lease, manualRunId),
+    });
     scheduleComputerSleep(deps.jobs, bot.computer.id);
+  } catch (error) {
+    if (error instanceof ComputerBusyError) {
+      throw new ORPCError("CONFLICT", { message: "Computer is busy" });
+    }
+    throw error;
   } finally {
     await releaseComputerExecutionLease(deps.prisma, lease);
   }

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1206,6 +1206,7 @@ export function createRouter(deps: RouterDeps) {
         const granted = await deps.prisma.computer.updateMany({
           where: {
             id: bot.computer.id,
+            state: "running",
             controlHolder: { not: "user" },
             controlLeaseId: null,
           },

--- a/apps/api/src/taught-skills.ts
+++ b/apps/api/src/taught-skills.ts
@@ -185,6 +185,7 @@ async function grantTakeover(
   const granted = await deps.prisma.computer.updateMany({
     where: {
       id: bot.computer.id,
+      state: "running",
       OR: [{ controlHolder: { not: "user" } }, { controlBotId: bot.id }],
     },
     data: {

--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -1,3 +1,4 @@
+import type { ComputerStatus } from "@rakazo/contracts";
 import {
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
@@ -8,10 +9,9 @@ import {
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Pressable, ScrollView, Text, TextInput } from "react-native";
-import { ComputerModePicker } from "../components/computer-mode-picker";
 import { ComputerMaintenanceActions } from "../components/computer-maintenance-actions";
+import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
-import type { ComputerStatus } from "@rakazo/contracts";
 
 type BotSettingsRecord = MobileBot & {
   description?: string;

--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -9,7 +9,9 @@ import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Pressable, ScrollView, Text, TextInput } from "react-native";
 import { ComputerModePicker } from "../components/computer-mode-picker";
+import { ComputerMaintenanceActions } from "../components/computer-maintenance-actions";
 import { type MobileBot, rpc } from "../lib/api";
+import type { ComputerStatus } from "@rakazo/contracts";
 
 type BotSettingsRecord = MobileBot & {
   description?: string;
@@ -23,18 +25,23 @@ export default function BotSettingsScreen() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [computerMode, setComputerMode] = useState<ComputerMode>("team");
+  const [computer, setComputer] = useState<ComputerStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
   useEffect(() => {
     if (!botId) return;
-    void rpc<BotSettingsRecord>("bots/get", { botId })
-      .then((next) => {
+    void Promise.all([
+      rpc<BotSettingsRecord>("bots/get", { botId }),
+      rpc<ComputerStatus>("computer/status", { botId }).catch(() => null),
+    ])
+      .then(([next, status]) => {
         setBot(next);
         setName(next.name);
         setTitle(next.title);
         setDescription(next.description ?? "");
         setComputerMode(next.computerMode);
+        setComputer(status);
       })
       .catch((err) => setError(err instanceof Error ? err.message : "Could not load bot"));
   }, [botId]);
@@ -132,6 +139,14 @@ export default function BotSettingsScreen() {
           }}
         />
         <ComputerModePicker value={computerMode} onChange={setComputerMode} />
+        <ComputerMaintenanceActions
+          botId={botId}
+          computer={computer}
+          onChanged={async () => {
+            const status = await rpc<ComputerStatus>("computer/status", { botId });
+            setComputer(status);
+          }}
+        />
         {error ? <Text style={{ color: "#E65707", marginTop: 16 }}>{error}</Text> : null}
         <Pressable
           onPress={() => void save()}

--- a/apps/mobile/app/computer.tsx
+++ b/apps/mobile/app/computer.tsx
@@ -8,8 +8,8 @@ import {
   SafeAreaView,
 } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
-import { ComputerModePicker } from "../components/computer-mode-picker";
 import { ComputerMaintenanceActions } from "../components/computer-maintenance-actions";
+import { ComputerModePicker } from "../components/computer-mode-picker";
 import { NativeSymbol } from "../components/native-symbol";
 import { currentApiBase, rpc } from "../lib/api";
 import {
@@ -240,7 +240,9 @@ export default function Computer() {
         <ComputerMaintenanceActions
           botId={botId ?? ""}
           computer={computer}
-          onChanged={refresh}
+          onChanged={async () => {
+            await refresh();
+          }}
         />
       ) : null}
       <ComputerModePicker

--- a/apps/mobile/app/computer.tsx
+++ b/apps/mobile/app/computer.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native-safe-area-context";
 import { WebView } from "react-native-webview";
 import { ComputerModePicker } from "../components/computer-mode-picker";
+import { ComputerMaintenanceActions } from "../components/computer-maintenance-actions";
 import { NativeSymbol } from "../components/native-symbol";
 import { currentApiBase, rpc } from "../lib/api";
 import {
@@ -233,6 +234,15 @@ export default function Computer() {
           </Pressable>
         )}
       </View>
+      {computer?.state === "error" ||
+      computer?.state === "stopped" ||
+      (computer?.state === "running" && !embeddedScreenUrl) ? (
+        <ComputerMaintenanceActions
+          botId={botId ?? ""}
+          computer={computer}
+          onChanged={refresh}
+        />
+      ) : null}
       <ComputerModePicker
         value={computer?.mode}
         disabled={switching}

--- a/apps/mobile/components/computer-maintenance-actions.tsx
+++ b/apps/mobile/components/computer-maintenance-actions.tsx
@@ -17,7 +17,7 @@ export function ComputerMaintenanceActions({
   const [pending, setPending] = useState<Action | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  if (!computer || computer.kind === "desktop") return null;
+  if (!computer) return null;
 
   const busy = Boolean(computer.busyBotName) || computer.state === "booting";
 

--- a/apps/mobile/components/computer-maintenance-actions.tsx
+++ b/apps/mobile/components/computer-maintenance-actions.tsx
@@ -1,0 +1,84 @@
+import type { ComputerStatus } from "@rakazo/contracts";
+import { useState } from "react";
+import { Alert, Pressable, Text, View } from "react-native";
+import { rpc } from "../lib/api";
+
+type Action = "recover" | "reset" | "update";
+
+export function ComputerMaintenanceActions({
+  botId,
+  computer,
+  onChanged,
+}: {
+  botId: string;
+  computer: ComputerStatus | null;
+  onChanged: () => Promise<void>;
+}) {
+  const [pending, setPending] = useState<Action | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!computer || computer.kind === "desktop") return null;
+
+  const busy = Boolean(computer.busyBotName) || computer.state === "booting";
+
+  async function run(action: Action) {
+    setPending(action);
+    setError(null);
+    try {
+      if (action === "recover") await rpc("computer/recover", { botId });
+      else if (action === "reset") await rpc("computer/reset", { botId });
+      else await rpc("computer/update", { botId });
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not update computer");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  function confirmReset() {
+    Alert.alert(
+      "Reset computer?",
+      "Restore the last saved workspace. Unsaved work on the computer is lost.",
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Reset", style: "destructive", onPress: () => void run("reset") },
+      ],
+    );
+  }
+
+  return (
+    <View style={{ marginTop: 16, gap: 10 }}>
+      <Pressable
+        disabled={busy || pending !== null}
+        onPress={() => void run("recover")}
+        style={{ opacity: busy || pending !== null ? 0.4 : 1 }}
+      >
+        <Text style={{ color: "#85858A", fontSize: 14 }}>
+          {pending === "recover" ? "Recovering…" : "Recover computer"}
+        </Text>
+      </Pressable>
+      <Pressable
+        disabled={busy || pending !== null}
+        onPress={confirmReset}
+        style={{ opacity: busy || pending !== null ? 0.4 : 1 }}
+      >
+        <Text style={{ color: "#85858A", fontSize: 14 }}>
+          {pending === "reset" ? "Resetting…" : "Reset computer"}
+        </Text>
+      </Pressable>
+      {computer.updateAvailable ? (
+        <Pressable
+          disabled={busy || pending !== null}
+          onPress={() => void run("update")}
+          style={{ opacity: busy || pending !== null ? 0.4 : 1 }}
+        >
+          <Text style={{ color: "#85858A", fontSize: 14 }}>
+            {pending === "update" ? "Updating…" : "Update computer"}
+          </Text>
+        </Pressable>
+      ) : null}
+      {error ? <Text style={{ color: "#E65707", fontSize: 13 }}>{error}</Text> : null}
+    </View>
+  );
+}

--- a/apps/mobile/lib/computer.test.ts
+++ b/apps/mobile/lib/computer.test.ts
@@ -3,11 +3,31 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
+  type ComputerStatus,
   controlLabel,
   embeddableScreenUrl,
   previewPlaceholder,
   readScreenUrl,
 } from "./computer.js";
+
+function computer(overrides: Partial<ComputerStatus> = {}): ComputerStatus {
+  return {
+    botId: "bot-1",
+    mode: "team",
+    kind: "fake",
+    state: "running",
+    controlHolder: "none",
+    controlBotId: null,
+    takeoverRequested: false,
+    screenAvailable: true,
+    screenWidth: 1280,
+    screenHeight: 800,
+    homeRevision: null,
+    busyBotName: null,
+    updateAvailable: true,
+    ...overrides,
+  };
+}
 
 describe("embeddableScreenUrl", () => {
   it("leaves a public stream URL alone", () => {
@@ -47,45 +67,35 @@ describe("computer copy", () => {
     expect(previewPlaceholder("running", true, "Chief")).toBe("Booting live desktop…");
     expect(
       controlLabel(
-        {
+        computer({
           state: "running",
           controlHolder: "user",
           controlBotId: "bot-1",
           takeoverRequested: true,
-          screenAvailable: true,
-          mode: "team",
-          busyBotName: null,
-        },
+        }),
         "Chief",
         "bot-1",
       ),
     ).toBe("You have control");
     expect(
       controlLabel(
-        {
+        computer({
           state: "running",
           controlHolder: "user",
           controlBotId: "other-bot",
-          takeoverRequested: false,
-          screenAvailable: true,
-          mode: "team",
-          busyBotName: null,
-        },
+        }),
         "Chief",
         "bot-1",
       ),
     ).toBe("Team Computer");
     expect(
       controlLabel(
-        {
+        computer({
           state: "suspended",
           controlHolder: "none",
           controlBotId: null,
-          takeoverRequested: false,
           screenAvailable: false,
-          mode: "team",
-          busyBotName: null,
-        },
+        }),
         "Chief",
       ),
     ).toBe("Asleep");

--- a/apps/mobile/lib/computer.ts
+++ b/apps/mobile/lib/computer.ts
@@ -1,18 +1,10 @@
-import type { ComputerMode } from "@rakazo/contracts";
+import type { ComputerMode, ComputerStatus as ContractComputerStatus } from "@rakazo/contracts";
 
 export const COMPUTER_HEARTBEAT_MS = 60_000;
 export const SCREEN_URL_OPEN_ATTEMPTS = 5;
 export const SCREEN_URL_RETRY_DELAY_MS = 400;
 
-export type ComputerStatus = {
-  state: string;
-  controlHolder: string;
-  controlBotId: string | null;
-  takeoverRequested: boolean;
-  screenAvailable: boolean;
-  mode: ComputerMode;
-  busyBotName: string | null;
-};
+export type ComputerStatus = ContractComputerStatus;
 
 function isLocalHostname(hostname: string) {
   return (

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -19,7 +19,7 @@ export function ComputerMaintenanceActions({
   const [confirmReset, setConfirmReset] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  if (!computer || computer.kind === "desktop") return null;
+  if (!computer) return null;
 
   const busy = Boolean(computer.busyBotName) || computer.state === "booting";
   const showRecover =

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -1,3 +1,4 @@
+import { Trans, useLingui } from "@lingui/react/macro";
 import type { ComputerStatus } from "@rakazo/contracts";
 import { useState } from "react";
 import { rpc } from "../lib/rpc";
@@ -16,6 +17,7 @@ export function ComputerMaintenanceActions({
   onChanged: () => Promise<void>;
   compact?: boolean;
 }) {
+  const { t } = useLingui();
   const [pending, setPending] = useState<Action | null>(null);
   const [confirmReset, setConfirmReset] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -41,7 +43,7 @@ export function ComputerMaintenanceActions({
       setConfirmReset(false);
       await onChanged();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not update computer");
+      setError(err instanceof Error ? err.message : t`Could not update computer`);
     } finally {
       setPending(null);
     }
@@ -52,25 +54,27 @@ export function ComputerMaintenanceActions({
       <div className={compact ? "flex flex-wrap gap-2" : "flex flex-col gap-2"}>
         {showRecover ? (
           <BuiButton disabled={busy || pending !== null} onClick={() => void run("recover")}>
-            {pending === "recover" ? "Recovering…" : "Recover computer"}
+            {pending === "recover" ? <Trans>Recovering…</Trans> : <Trans>Recover computer</Trans>}
           </BuiButton>
         ) : null}
         {showReset ? (
           <BuiButton disabled={busy || pending !== null} onClick={() => setConfirmReset(true)}>
-            {pending === "reset" ? "Resetting…" : "Reset computer"}
+            {pending === "reset" ? <Trans>Resetting…</Trans> : <Trans>Reset computer</Trans>}
           </BuiButton>
         ) : null}
         {showUpdate ? (
           <BuiButton disabled={busy || pending !== null} onClick={() => void run("update")}>
-            {pending === "update" ? "Updating…" : "Update computer"}
+            {pending === "update" ? <Trans>Updating…</Trans> : <Trans>Update computer</Trans>}
           </BuiButton>
         ) : null}
       </div>
       {!compact ? (
         <p className="text-[13px] leading-[1.45] text-[#6C6C70]">
-          Recover replaces an unreachable computer and keeps files in the saved workspace. Reset
-          restores the last saved workspace and loses unsaved work. Update rebuilds with the latest
-          image and keeps the saved workspace.
+          <Trans>
+            Recover replaces an unreachable computer and keeps files in the saved workspace. Reset
+            restores the last saved workspace and loses unsaved work. Update rebuilds with the latest
+            image and keeps the saved workspace.
+          </Trans>
         </p>
       ) : null}
       {error ? <p className="text-[13px] text-[#E65707]">{error}</p> : null}
@@ -81,18 +85,22 @@ export function ComputerMaintenanceActions({
           aria-modal="true"
         >
           <BuiCard className="w-full max-w-[420px] border border-[#232326] p-5">
-            <div className="text-[16px] font-medium text-[#ECECEE]">Reset computer?</div>
+            <div className="text-[16px] font-medium text-[#ECECEE]">
+              <Trans>Reset computer?</Trans>
+            </div>
             <p className="mt-2 text-[14px] leading-[1.5] text-[#85858A]">
-              Restore the last saved workspace. Unsaved work on the computer is lost.
+              <Trans>Restore the last saved workspace. Unsaved work on the computer is lost.</Trans>
             </p>
             <div className="mt-4 flex justify-end gap-2">
-              <BuiButton onClick={() => setConfirmReset(false)}>Cancel</BuiButton>
+              <BuiButton onClick={() => setConfirmReset(false)}>
+                <Trans>Cancel</Trans>
+              </BuiButton>
               <BuiButton
                 tone="accent"
                 disabled={pending !== null}
                 onClick={() => void run("reset")}
               >
-                Reset
+                <Trans>Reset</Trans>
               </BuiButton>
             </div>
           </BuiCard>

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -1,0 +1,127 @@
+import type { ComputerStatus } from "@rakazo/contracts";
+import { useState } from "react";
+import { rpc } from "../lib/rpc";
+
+type Action = "recover" | "reset" | "update";
+
+export function ComputerMaintenanceActions({
+  botId,
+  computer,
+  onChanged,
+  compact = false,
+}: {
+  botId: string;
+  computer: ComputerStatus | null;
+  onChanged: () => Promise<void>;
+  compact?: boolean;
+}) {
+  const [pending, setPending] = useState<Action | null>(null);
+  const [confirmReset, setConfirmReset] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!computer || computer.kind === "desktop") return null;
+
+  const busy = Boolean(computer.busyBotName) || computer.state === "booting";
+  const showRecover =
+    computer.state === "error" ||
+    computer.state === "running" ||
+    computer.state === "suspended" ||
+    computer.state === "stopped";
+  const showReset = showRecover;
+  const showUpdate = computer.updateAvailable;
+
+  async function run(action: Action) {
+    setPending(action);
+    setError(null);
+    try {
+      if (action === "recover") await rpc.computer.recover({ botId });
+      else if (action === "reset") await rpc.computer.reset({ botId });
+      else await rpc.computer.update({ botId });
+      setConfirmReset(false);
+      await onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not update computer");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  const buttonClass = compact
+    ? "text-[13px] text-[#85858A] hover:text-[#ECECEE] disabled:opacity-40"
+    : "rounded-[11px] border border-[#26262A] px-3.5 py-2 text-[14px] text-[#ECECEE] disabled:opacity-40";
+
+  return (
+    <div className={compact ? "flex flex-col items-start gap-2" : "mt-4 flex flex-col gap-3"}>
+      <div className={compact ? "flex flex-wrap gap-3" : "flex flex-col gap-2"}>
+        {showRecover ? (
+          <button
+            type="button"
+            disabled={busy || pending !== null}
+            className={buttonClass}
+            onClick={() => void run("recover")}
+          >
+            {pending === "recover" ? "Recovering…" : "Recover computer"}
+          </button>
+        ) : null}
+        {showReset ? (
+          <button
+            type="button"
+            disabled={busy || pending !== null}
+            className={buttonClass}
+            onClick={() => setConfirmReset(true)}
+          >
+            {pending === "reset" ? "Resetting…" : "Reset computer"}
+          </button>
+        ) : null}
+        {showUpdate ? (
+          <button
+            type="button"
+            disabled={busy || pending !== null}
+            className={buttonClass}
+            onClick={() => void run("update")}
+          >
+            {pending === "update" ? "Updating…" : "Update computer"}
+          </button>
+        ) : null}
+      </div>
+      {!compact ? (
+        <p className="text-[13px] leading-[1.45] text-[#6C6C70]">
+          Recover replaces an unreachable computer and keeps files in the saved workspace. Reset
+          restores the last saved workspace and loses unsaved work. Update rebuilds with the latest
+          image and keeps the saved workspace.
+        </p>
+      ) : null}
+      {error ? <p className="text-[13px] text-[#E65707]">{error}</p> : null}
+      {confirmReset ? (
+        <div
+          className="fixed inset-0 z-50 grid place-items-center bg-[rgba(4,4,5,.72)] px-6"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="w-full max-w-[420px] rounded-[14px] border border-[#232326] bg-[#0E0E10] p-5">
+            <div className="text-[16px] font-medium text-[#ECECEE]">Reset computer?</div>
+            <p className="mt-2 text-[14px] leading-[1.5] text-[#85858A]">
+              Restore the last saved workspace. Unsaved work on the computer is lost.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded-[11px] border border-[#26262A] px-4 py-2 text-[14px] text-[#ECECEE]"
+                onClick={() => setConfirmReset(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="rounded-[11px] bg-[#E65707] px-4 py-2 text-[14px] text-[#17171A]"
+                onClick={() => void run("reset")}
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -1,6 +1,7 @@
 import type { ComputerStatus } from "@rakazo/contracts";
 import { useState } from "react";
 import { rpc } from "../lib/rpc";
+import { BuiButton, BuiCard } from "./beautiful-ui/primitives";
 
 type Action = "recover" | "reset" | "update";
 
@@ -46,42 +47,23 @@ export function ComputerMaintenanceActions({
     }
   }
 
-  const buttonClass = compact
-    ? "text-[13px] text-[#85858A] hover:text-[#ECECEE] disabled:opacity-40"
-    : "rounded-[11px] border border-[#26262A] px-3.5 py-2 text-[14px] text-[#ECECEE] disabled:opacity-40";
-
   return (
     <div className={compact ? "flex flex-col items-start gap-2" : "mt-4 flex flex-col gap-3"}>
-      <div className={compact ? "flex flex-wrap gap-3" : "flex flex-col gap-2"}>
+      <div className={compact ? "flex flex-wrap gap-2" : "flex flex-col gap-2"}>
         {showRecover ? (
-          <button
-            type="button"
-            disabled={busy || pending !== null}
-            className={buttonClass}
-            onClick={() => void run("recover")}
-          >
+          <BuiButton disabled={busy || pending !== null} onClick={() => void run("recover")}>
             {pending === "recover" ? "Recovering…" : "Recover computer"}
-          </button>
+          </BuiButton>
         ) : null}
         {showReset ? (
-          <button
-            type="button"
-            disabled={busy || pending !== null}
-            className={buttonClass}
-            onClick={() => setConfirmReset(true)}
-          >
+          <BuiButton disabled={busy || pending !== null} onClick={() => setConfirmReset(true)}>
             {pending === "reset" ? "Resetting…" : "Reset computer"}
-          </button>
+          </BuiButton>
         ) : null}
         {showUpdate ? (
-          <button
-            type="button"
-            disabled={busy || pending !== null}
-            className={buttonClass}
-            onClick={() => void run("update")}
-          >
+          <BuiButton disabled={busy || pending !== null} onClick={() => void run("update")}>
             {pending === "update" ? "Updating…" : "Update computer"}
-          </button>
+          </BuiButton>
         ) : null}
       </div>
       {!compact ? (
@@ -98,28 +80,22 @@ export function ComputerMaintenanceActions({
           role="dialog"
           aria-modal="true"
         >
-          <div className="w-full max-w-[420px] rounded-[14px] border border-[#232326] bg-[#0E0E10] p-5">
+          <BuiCard className="w-full max-w-[420px] border border-[#232326] p-5">
             <div className="text-[16px] font-medium text-[#ECECEE]">Reset computer?</div>
             <p className="mt-2 text-[14px] leading-[1.5] text-[#85858A]">
               Restore the last saved workspace. Unsaved work on the computer is lost.
             </p>
             <div className="mt-4 flex justify-end gap-2">
-              <button
-                type="button"
-                className="rounded-[11px] border border-[#26262A] px-4 py-2 text-[14px] text-[#ECECEE]"
-                onClick={() => setConfirmReset(false)}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="rounded-[11px] bg-[#E65707] px-4 py-2 text-[14px] text-[#17171A]"
+              <BuiButton onClick={() => setConfirmReset(false)}>Cancel</BuiButton>
+              <BuiButton
+                tone="accent"
+                disabled={pending !== null}
                 onClick={() => void run("reset")}
               >
                 Reset
-              </button>
+              </BuiButton>
             </div>
-          </div>
+          </BuiCard>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -72,8 +72,8 @@ export function ComputerMaintenanceActions({
         <p className="text-[13px] leading-[1.45] text-[#6C6C70]">
           <Trans>
             Recover replaces an unreachable computer and keeps files in the saved workspace. Reset
-            restores the last saved workspace and loses unsaved work. Update rebuilds with the latest
-            image and keeps the saved workspace.
+            restores the last saved workspace and loses unsaved work. Update rebuilds with the
+            latest image and keeps the saved workspace.
           </Trans>
         </p>
       ) : null}

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -58,7 +58,13 @@ export function ComputerMaintenanceActions({
           </BuiButton>
         ) : null}
         {showReset ? (
-          <BuiButton disabled={busy || pending !== null} onClick={() => setConfirmReset(true)}>
+          <BuiButton
+            disabled={busy || pending !== null}
+            onClick={() => {
+              setError(null);
+              setConfirmReset(true);
+            }}
+          >
             {pending === "reset" ? <Trans>Resetting…</Trans> : <Trans>Reset computer</Trans>}
           </BuiButton>
         ) : null}
@@ -77,20 +83,26 @@ export function ComputerMaintenanceActions({
           </Trans>
         </p>
       ) : null}
-      {error ? <p className="text-[13px] text-[#E65707]">{error}</p> : null}
+      {error && !confirmReset ? <p className="text-[13px] text-[#E65707]">{error}</p> : null}
       {confirmReset ? (
         <div
           className="fixed inset-0 z-50 grid place-items-center bg-[rgba(4,4,5,.72)] px-6"
-          role="dialog"
+          role="alertdialog"
           aria-modal="true"
+          aria-labelledby="reset-computer-title"
+          aria-describedby="reset-computer-description"
         >
           <BuiCard className="w-full max-w-[420px] border border-[#232326] p-5">
-            <div className="text-[16px] font-medium text-[#ECECEE]">
+            <div id="reset-computer-title" className="text-[16px] font-medium text-[#ECECEE]">
               <Trans>Reset computer?</Trans>
             </div>
-            <p className="mt-2 text-[14px] leading-[1.5] text-[#85858A]">
+            <p
+              id="reset-computer-description"
+              className="mt-2 text-[14px] leading-[1.5] text-[#85858A]"
+            >
               <Trans>Restore the last saved workspace. Unsaved work on the computer is lost.</Trans>
             </p>
+            {error ? <p className="mt-2 text-[13px] text-[#E65707]">{error}</p> : null}
             <div className="mt-4 flex justify-end gap-2">
               <BuiButton onClick={() => setConfirmReset(false)}>
                 <Trans>Cancel</Trans>
@@ -100,7 +112,7 @@ export function ComputerMaintenanceActions({
                 disabled={pending !== null}
                 onClick={() => void run("reset")}
               >
-                <Trans>Reset</Trans>
+                {pending === "reset" ? <Trans>Resetting…</Trans> : <Trans>Reset</Trans>}
               </BuiButton>
             </div>
           </BuiCard>

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -9,6 +9,7 @@ import {
   activeThreadRuns,
   clearActiveThreadRuns,
   computerPanelAutoBoot,
+  computerPanelAutoUsesBoot,
   computerTakeoverBlocked,
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
@@ -1150,6 +1151,12 @@ describe("computer event reduction", () => {
     expect(computerPanelAutoBoot("running", null)).toBe("recover-screen");
     expect(computerPanelAutoBoot("booting")).toBe("wait");
     expect(computerPanelAutoBoot("suspended")).toBe("wait");
+  });
+
+  it("maps recover-screen to computer.boot, not computer.recover", () => {
+    expect(computerPanelAutoUsesBoot("recover-screen")).toBe(true);
+    expect(computerPanelAutoUsesBoot("boot")).toBe(true);
+    expect(computerPanelAutoUsesBoot("wait")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -1197,6 +1197,7 @@ function computer(overrides: Partial<ComputerStatus> = {}): ComputerStatus {
     screenHeight: 800,
     homeRevision: null,
     busyBotName: null,
+    updateAvailable: true,
     ...overrides,
   };
 }

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -428,6 +428,13 @@ export function computerPanelAutoBoot(
   return "boot";
 }
 
+/** Auto panel reconnect must use computer.boot — never computer.recover (that destroys the sandbox). */
+export function computerPanelAutoUsesBoot(
+  action: ReturnType<typeof computerPanelAutoBoot>,
+): boolean {
+  return action === "boot" || action === "recover-screen";
+}
+
 export function reduceComputerStatus(
   prev: ComputerStatus | null,
   event: ProductEvent,

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1823
+#: src/pages/Shell.tsx:1826
 msgid " (unread)"
 msgstr " (ungelesen)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# Modell} other {# Modelle}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1267
+#: src/pages/Shell.tsx:1269
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (maximal {ATTACHMENT_MAX_COUNT} Anhänge)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1271
+#: src/pages/Shell.tsx:1273
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (über 10 MiB)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5141
+#: src/pages/Shell.tsx:5169
 msgid "{0} connection"
 msgstr "{0}-Verbindung"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2306
+#: src/pages/Shell.tsx:2309
 msgid "{0} is using it"
 msgstr "{0} verwendet es"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2030
 msgid "{0} runs · {1} tokens"
 msgstr "{0} Läufe · {1} Tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# verbundener Bot} other {# verbundene Bot
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} hat noch keinem anderen Bot eine Nachricht gesendet."
 
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:5046
 msgid "{botName}’s computer"
 msgstr "Computer von {botName}"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3320
+#: src/pages/Shell.tsx:3339
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Zugriffstoken (optional)"
 msgid "Account"
 msgstr "Konto"
 
-#: src/pages/Shell.tsx:4532
+#: src/pages/Shell.tsx:4555
 msgid "Account default"
 msgstr "Kontostandard"
 
@@ -156,12 +156,12 @@ msgstr "Aktives Modell"
 msgid "Active voice"
 msgstr "Aktive Stimme"
 
-#: src/pages/Shell.tsx:1707
-#: src/pages/Shell.tsx:1709
+#: src/pages/Shell.tsx:1710
+#: src/pages/Shell.tsx:1712
 msgid "Activity"
 msgstr "Aktivität"
 
-#: src/pages/PluginsOverlay.tsx:281
+#: src/pages/PluginsOverlay.tsx:292
 #: src/pages/ScratchpadSection.tsx:188
 msgid "Add"
 msgstr "Hinzufügen"
@@ -186,15 +186,15 @@ msgstr "Gib eine HTTPS-Server-URL ein."
 msgid "Add item"
 msgstr "Element hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:311
+#: src/pages/PluginsOverlay.tsx:338
 msgid "Add MCP server"
 msgstr "MCP-Server hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:314
+#: src/pages/PluginsOverlay.tsx:341
 msgid "Add OpenAPI"
 msgstr "OpenAPI hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:329
+#: src/pages/PluginsOverlay.tsx:356
 msgid "Add remote MCP server"
 msgstr "Remote-MCP-Server hinzufügen"
 
@@ -207,19 +207,19 @@ msgstr "Server hinzufügen"
 msgid "Add to routine"
 msgstr "Zur Routine hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:317
+#: src/pages/PluginsOverlay.tsx:344
 msgid "Add Treg"
 msgstr "Treg hinzufügen"
 
 #: src/pages/McpServersOverlay.tsx:363
-#: src/pages/PluginsOverlay.tsx:276
+#: src/pages/PluginsOverlay.tsx:287
 msgid "Adding…"
 msgstr "Wird hinzugefügt…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
-#: src/pages/PluginsOverlay.tsx:291
+#: src/pages/PluginsOverlay.tsx:318
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4458
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -227,7 +227,7 @@ msgstr "Erweitert"
 msgid "Agent access for new servers"
 msgstr "Agent-Zugriff für neue Server"
 
-#: src/pages/Shell.tsx:2114
+#: src/pages/Shell.tsx:2117
 msgid "Agent computer"
 msgstr "Agent-Computer"
 
@@ -302,7 +302,7 @@ msgstr "Beantwortet: {answer}"
 msgid "API key"
 msgstr "API-Schlüssel"
 
-#: src/pages/PluginsOverlay.tsx:365
+#: src/pages/PluginsOverlay.tsx:392
 msgid "API key header"
 msgstr "API-Schlüssel-Header"
 
@@ -314,11 +314,11 @@ msgstr "Gilt beim Hinzufügen des Servers. Mit den Agent-Chips auf jeder Serverk
 msgid "Approval boundaries"
 msgstr "Bestätigungsgrenzen"
 
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5362
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: src/pages/Shell.tsx:5325
+#: src/pages/Shell.tsx:5353
 msgid "Approve this server to let your agent use its tools."
 msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 
@@ -326,15 +326,15 @@ msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 msgid "Archive"
 msgstr "Archivieren"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:4002
 msgid "archived"
 msgstr "archiviert"
 
-#: src/pages/Shell.tsx:1907
+#: src/pages/Shell.tsx:1910
 msgid "Archived"
 msgstr "Archiviert"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4013
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archiviert. Chat, Erinnerungen und Dateien bleiben erhalten."
 
@@ -373,7 +373,7 @@ msgstr "Vor Käufen nachfragen"
 msgid "Ask before sending external email"
 msgstr "Vor dem Senden externer E-Mails nachfragen"
 
-#: src/pages/Shell.tsx:2308
+#: src/pages/Shell.tsx:2311
 msgid "Asleep"
 msgstr "Im Ruhezustand"
 
@@ -388,11 +388,11 @@ msgstr "um {0}"
 msgid "at {timeSelect}"
 msgstr "um {timeSelect}"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3410
 msgid "Attach file"
 msgstr "Datei anhängen"
 
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3609
 msgid "Attachment"
 msgstr "Anhang"
 
@@ -405,12 +405,12 @@ msgstr "Autorisierungscode oder Callback-URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Autorisierung abgelaufen — erneute Verbindung erforderlich"
 
-#: src/pages/Shell.tsx:5126
+#: src/pages/Shell.tsx:5154
 msgid "Authorization timed out. Please try again."
 msgstr "Zeitüberschreitung bei der Autorisierung. Versuche es erneut."
 
-#: src/pages/Shell.tsx:5168
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5196
+#: src/pages/Shell.tsx:5362
 msgid "Authorize"
 msgstr "Autorisieren"
 
@@ -418,26 +418,26 @@ msgstr "Autorisieren"
 msgid "Base URL"
 msgstr "Basis-URL"
 
-#: src/pages/PluginsOverlay.tsx:362
+#: src/pages/PluginsOverlay.tsx:389
 msgid "Bearer token"
 msgstr "Bearer-Token"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5038
 msgid "Booting live desktop…"
 msgstr "Live-Desktop wird gestartet…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2850
 msgid "Booting up {0}’s computer"
 msgstr "Computer von {0} wird gestartet"
 
-#: src/pages/Shell.tsx:3853
-#: src/pages/Shell.tsx:3854
-#: src/pages/Shell.tsx:3987
+#: src/pages/Shell.tsx:3872
+#: src/pages/Shell.tsx:3873
+#: src/pages/Shell.tsx:4006
 msgid "bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:1101
+#: src/pages/Shell.tsx:1103
 msgid "Bot"
 msgstr "Bot"
 
@@ -445,11 +445,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot-Nachrichten"
 
-#: src/pages/Shell.tsx:2923
+#: src/pages/Shell.tsx:2942
 msgid "Bot screen"
 msgstr "Bot-Bildschirm"
 
-#: src/pages/Shell.tsx:2276
+#: src/pages/Shell.tsx:2279
 msgid "Bot screen preview"
 msgstr "Bot-Bildschirmvorschau"
 
@@ -462,8 +462,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Verwende deinen eigenen Schlüssel. Der Anbieter ist austauschbar; die Schaltflächen zum Sprechen und Anrufen deiner Bots bleiben gleich."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2096
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2099
+#: src/pages/Shell.tsx:2100
 msgid "Call"
 msgstr "Anrufen"
 
@@ -472,16 +472,17 @@ msgid "Can't reach the server."
 msgstr "Server nicht erreichbar."
 
 #: src/components/AskCard.tsx:129
+#: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
-#: src/pages/PluginsOverlay.tsx:413
-#: src/pages/Shell.tsx:4694
-#: src/pages/Shell.tsx:4766
-#: src/pages/Shell.tsx:4881
-#: src/pages/Shell.tsx:4955
+#: src/pages/PluginsOverlay.tsx:440
+#: src/pages/Shell.tsx:4722
+#: src/pages/Shell.tsx:4794
+#: src/pages/Shell.tsx:4909
+#: src/pages/Shell.tsx:4983
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/pages/Shell.tsx:4231
+#: src/pages/Shell.tsx:4250
 msgid "Cancel new bot"
 msgstr "Neuen Bot abbrechen"
 
@@ -489,7 +490,7 @@ msgstr "Neuen Bot abbrechen"
 msgid "Cancel new group"
 msgstr "Neue Gruppe abbrechen"
 
-#: src/pages/Shell.tsx:3267
+#: src/pages/Shell.tsx:3286
 msgid "Cancel reply"
 msgstr "Antwort abbrechen"
 
@@ -497,16 +498,16 @@ msgstr "Antwort abbrechen"
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5259
 msgid "Chart failed to render: {error}"
 msgstr "Diagramm konnte nicht angezeigt werden: {error}"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3552
 msgid "Chat Settings"
 msgstr "Chat-Einstellungen"
 
-#: src/pages/Shell.tsx:2542
-#: src/pages/Shell.tsx:2549
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:2568
 msgid "Check in."
 msgstr "Melde dich."
 
@@ -518,21 +519,21 @@ msgstr "Wähle zunächst ein Modell aus."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Wähle das verbundene Modell aus, das Rakazo verwendet."
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4809
 msgid "Clear"
 msgstr "Leeren"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4775
 msgid "Clear {0}’s conversation?"
 msgstr "Unterhaltung mit {0} leeren?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4587
+#: src/pages/Shell.tsx:4610
 msgid "Clear conversation"
 msgstr "Unterhaltung leeren"
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4809
 msgid "Clearing…"
 msgstr "Wird geleert…"
 
@@ -548,19 +549,19 @@ msgstr "Bot-Menü schließen"
 msgid "Close bot messages"
 msgstr "Bot-Nachrichten schließen"
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5444
 msgid "Close chart"
 msgstr "Diagramm schließen"
 
-#: src/pages/Shell.tsx:2897
+#: src/pages/Shell.tsx:2916
 msgid "Close computer"
 msgstr "Computer schließen"
 
-#: src/pages/Shell.tsx:5516
+#: src/pages/Shell.tsx:5544
 msgid "Close image preview"
 msgstr "Bildvorschau schließen"
 
-#: src/pages/PluginsOverlay.tsx:212
+#: src/pages/PluginsOverlay.tsx:215
 msgid "Close integrations"
 msgstr "Integrationen schließen"
 
@@ -576,11 +577,11 @@ msgstr "Erinnerungseinstellungen schließen"
 msgid "Close model settings"
 msgstr "Modelleinstellungen schließen"
 
-#: src/pages/Shell.tsx:1692
+#: src/pages/Shell.tsx:1695
 msgid "Close navigation"
 msgstr "Navigation schließen"
 
-#: src/pages/Shell.tsx:2254
+#: src/pages/Shell.tsx:2257
 msgid "Close panel"
 msgstr "Panel schließen"
 
@@ -609,24 +610,24 @@ msgstr "Befehl"
 msgid "Complete"
 msgstr "Abschließen"
 
-#: src/pages/Shell.tsx:4141
-#: src/pages/Shell.tsx:4169
+#: src/pages/Shell.tsx:4160
+#: src/pages/Shell.tsx:4188
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5013
+#: src/pages/Shell.tsx:5041
 msgid "Computer failed to boot"
 msgstr "Computer konnte nicht gestartet werden"
 
-#: src/pages/Shell.tsx:2945
+#: src/pages/Shell.tsx:2964
 msgid "Computer is asleep"
 msgstr "Computer ist im Ruhezustand"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5040
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer schläft — übernimm die Kontrolle, um ihn zu wecken"
 
-#: src/pages/Shell.tsx:5014
+#: src/pages/Shell.tsx:5042
 msgid "Computer is stopped"
 msgstr "Computer ist gestoppt"
 
@@ -659,7 +660,7 @@ msgstr "API-Schlüssel verbinden"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI oder Cartesia verbinden"
 
-#: src/pages/Shell.tsx:5314
+#: src/pages/Shell.tsx:5342
 msgid "Connect MCP server “{name}”"
 msgstr "MCP-Server „{name}“ verbinden"
 
@@ -675,19 +676,19 @@ msgstr "Verbinde Remote- oder lokale Toolserver und wähle aus, welche Agents si
 msgid "Connect this provider to use it as your personal model."
 msgstr "Verbinde diesen Anbieter, um ihn als persönliches Modell zu verwenden."
 
-#: src/pages/PluginsOverlay.tsx:327
+#: src/pages/PluginsOverlay.tsx:354
 msgid "Connect Treg"
 msgstr "Treg verbinden"
 
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
-#: src/pages/Shell.tsx:5165
+#: src/pages/Shell.tsx:5193
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Verbunden"
 
-#: src/pages/Shell.tsx:5344
+#: src/pages/Shell.tsx:5372
 msgid "Connected — its tools are available from your next message."
 msgstr "Verbunden – die Tools sind ab deiner nächsten Nachricht verfügbar."
 
@@ -712,13 +713,13 @@ msgstr "Verbunden, {0} wird verwendet."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5362
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Verbindung wird hergestellt…"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:114
+#: src/pages/PluginsOverlay.tsx:116
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "Die Verbindung zu {0} steht noch aus. Du kannst dieses Fenster schließen und später erneut nachsehen."
 
@@ -731,7 +732,7 @@ msgstr "Weiter"
 msgid "Continue with email"
 msgstr "Mit E-Mail fortfahren"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3660
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -743,11 +744,11 @@ msgstr "Hinzufügen fehlgeschlagen"
 msgid "Could not add MCP server"
 msgstr "MCP-Server konnte nicht hinzugefügt werden"
 
-#: src/pages/Shell.tsx:5301
+#: src/pages/Shell.tsx:5329
 msgid "Could not approve this server"
 msgstr "Server konnte nicht genehmigt werden"
 
-#: src/pages/Shell.tsx:5129
+#: src/pages/Shell.tsx:5157
 msgid "Could not authorize this app"
 msgstr "App konnte nicht autorisiert werden"
 
@@ -755,7 +756,7 @@ msgstr "App konnte nicht autorisiert werden"
 msgid "Could not change the default model"
 msgstr "Standardmodell konnte nicht geändert werden"
 
-#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:4803
 msgid "Could not clear conversation"
 msgstr "Unterhaltung konnte nicht geleert werden"
 
@@ -763,7 +764,7 @@ msgstr "Unterhaltung konnte nicht geleert werden"
 msgid "Could not complete OAuth"
 msgstr "OAuth konnte nicht abgeschlossen werden"
 
-#: src/pages/PluginsOverlay.tsx:117
+#: src/pages/PluginsOverlay.tsx:120
 msgid "Could not connect"
 msgstr "Verbindung fehlgeschlagen"
 
@@ -784,7 +785,7 @@ msgstr "Stimmanbieter konnte nicht verbunden werden"
 msgid "Could not continue"
 msgstr "Fortfahren fehlgeschlagen"
 
-#: src/pages/Shell.tsx:4219
+#: src/pages/Shell.tsx:4238
 msgid "Could not create bot"
 msgstr "Bot konnte nicht erstellt werden"
 
@@ -792,7 +793,7 @@ msgstr "Bot konnte nicht erstellt werden"
 msgid "Could not create group"
 msgstr "Gruppe konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4694
 msgid "Could not create section"
 msgstr "Abschnitt konnte nicht erstellt werden"
 
@@ -800,7 +801,7 @@ msgstr "Abschnitt konnte nicht erstellt werden"
 msgid "Could not create your bot"
 msgstr "Dein Bot konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4890
+#: src/pages/Shell.tsx:4918
 msgid "Could not delete bot"
 msgstr "Bot konnte nicht gelöscht werden"
 
@@ -808,7 +809,7 @@ msgstr "Bot konnte nicht gelöscht werden"
 msgid "Could not delete MCP server"
 msgstr "MCP-Server konnte nicht gelöscht werden"
 
-#: src/pages/Shell.tsx:4964
+#: src/pages/Shell.tsx:4992
 msgid "Could not delete routine"
 msgstr "Routine konnte nicht gelöscht werden"
 
@@ -829,7 +830,7 @@ msgstr "{0} konnte nicht heruntergeladen werden. Versuche es erneut."
 msgid "Could not download {name}. Try again."
 msgstr "{name} konnte nicht heruntergeladen werden. Versuche es erneut."
 
-#: src/pages/PluginsOverlay.tsx:184
+#: src/pages/PluginsOverlay.tsx:187
 msgid "Could not install connector"
 msgstr "Connector konnte nicht installiert werden"
 
@@ -837,7 +838,7 @@ msgstr "Connector konnte nicht installiert werden"
 msgid "Could not load approval rules"
 msgstr "Bestätigungsregeln konnten nicht geladen werden"
 
-#: src/pages/PluginsOverlay.tsx:60
+#: src/pages/PluginsOverlay.tsx:61
 msgid "Could not load integrations"
 msgstr "Integrationen konnten nicht geladen werden"
 
@@ -870,7 +871,7 @@ msgstr "Modellserver konnte nicht erreicht werden"
 msgid "Could not remove"
 msgstr "Entfernen fehlgeschlagen"
 
-#: src/pages/PluginsOverlay.tsx:197
+#: src/pages/PluginsOverlay.tsx:200
 msgid "Could not remove connector"
 msgstr "Connector konnte nicht entfernt werden"
 
@@ -882,15 +883,15 @@ msgstr "Gruppe konnte nicht entfernt werden"
 msgid "Could not remove rule"
 msgstr "Regel konnte nicht entfernt werden"
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5249
 msgid "Could not render chart"
 msgstr "Diagramm konnte nicht angezeigt werden"
 
-#: src/pages/PluginsOverlay.tsx:143
+#: src/pages/PluginsOverlay.tsx:146
 msgid "Could not revoke connection"
 msgstr "Verbindung konnte nicht widerrufen werden"
 
-#: src/pages/Shell.tsx:4572
+#: src/pages/Shell.tsx:4595
 msgid "Could not save"
 msgstr "Speichern fehlgeschlagen"
 
@@ -902,7 +903,7 @@ msgstr "Gruppe konnte nicht gespeichert werden"
 msgid "Could not save model"
 msgstr "Modell konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:2564
+#: src/pages/Shell.tsx:2583
 msgid "Could not save routine"
 msgstr "Routine konnte nicht gespeichert werden"
 
@@ -918,7 +919,7 @@ msgstr "Auswahl konnte nicht gespeichert werden"
 msgid "Could not save that voice"
 msgstr "Stimme konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:5041
+#: src/pages/Shell.tsx:5069
 msgid "Could not save this choice"
 msgstr "Diese Auswahl konnte nicht gespeichert werden"
 
@@ -934,7 +935,7 @@ msgstr "OAuth konnte nicht gestartet werden"
 msgid "Could not submit this answer"
 msgstr "Antwort konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:1550
+#: src/pages/Shell.tsx:1552
 msgid "Could not take control"
 msgstr "Kontrolle konnte nicht übernommen werden"
 
@@ -946,18 +947,22 @@ msgstr "Aktualisierung fehlgeschlagen"
 msgid "Could not update agent access"
 msgstr "Agent-Zugriff konnte nicht aktualisiert werden"
 
+#: src/components/ComputerMaintenanceActions.tsx:46
+msgid "Could not update computer"
+msgstr ""
+
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "Standardbereich für Erinnerungen konnte nicht aktualisiert werden"
 
-#: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4278
-#: src/pages/Shell.tsx:4701
+#: src/pages/Shell.tsx:1730
+#: src/pages/Shell.tsx:4297
+#: src/pages/Shell.tsx:4729
 msgid "Create"
 msgstr "Erstellen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4675
+#: src/pages/Shell.tsx:4703
 msgid "Create a section and move {0} into it."
 msgstr "Erstelle einen Abschnitt und verschiebe {0} dorthin."
 
@@ -978,16 +983,16 @@ msgid "Create your Rakazo"
 msgstr "Dein Rakazo erstellen"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4278
-#: src/pages/Shell.tsx:4701
+#: src/pages/Shell.tsx:4297
+#: src/pages/Shell.tsx:4729
 msgid "Creating…"
 msgstr "Wird erstellt…"
 
-#: src/pages/PluginsOverlay.tsx:383
+#: src/pages/PluginsOverlay.tsx:410
 msgid "Credential"
 msgstr "Zugangsdaten"
 
-#: src/pages/PluginsOverlay.tsx:441
+#: src/pages/PluginsOverlay.tsx:468
 msgid "credential saved"
 msgstr "Zugangsdaten gespeichert"
 
@@ -1007,7 +1012,7 @@ msgstr "Tag"
 msgid "days"
 msgstr "Tage"
 
-#: src/pages/Shell.tsx:4479
+#: src/pages/Shell.tsx:4502
 msgid "Default (medium)"
 msgstr "Standard (mittel)"
 
@@ -1017,21 +1022,21 @@ msgstr "Standardbereich"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4896
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:1939
+#: src/pages/Shell.tsx:4924
+#: src/pages/Shell.tsx:4998
 msgid "Delete"
 msgstr "Löschen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1932
+#: src/pages/Shell.tsx:1935
 msgid "Delete {0}"
 msgstr "{0} löschen"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4828
-#: src/pages/Shell.tsx:4942
+#: src/pages/Shell.tsx:4856
+#: src/pages/Shell.tsx:4970
 msgid "Delete {0}?"
 msgstr "{0} löschen?"
 
@@ -1039,21 +1044,21 @@ msgstr "{0} löschen?"
 msgid "Delete group"
 msgstr "Gruppe löschen"
 
-#: src/pages/Shell.tsx:4865
+#: src/pages/Shell.tsx:4893
 msgid "Delete memories too"
 msgstr "Erinnerungen ebenfalls löschen"
 
-#: src/pages/Shell.tsx:2619
+#: src/pages/Shell.tsx:2638
 msgid "Delete routine"
 msgstr "Routine löschen"
 
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:4004
 msgid "deleted"
 msgstr "gelöscht"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4896
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4924
+#: src/pages/Shell.tsx:4998
 msgid "Deleting…"
 msgstr "Wird gelöscht…"
 
@@ -1070,17 +1075,17 @@ msgid "Deployment default"
 msgstr "Bereitstellungsstandard"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4256
+#: src/pages/Shell.tsx:4275
 msgid "Describe what this bot does"
 msgstr "Beschreibe, was dieser Bot macht"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4261
-#: src/pages/Shell.tsx:4423
+#: src/pages/Shell.tsx:4280
+#: src/pages/Shell.tsx:4446
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3419
 msgid "Dictate"
 msgstr "Diktieren"
 
@@ -1093,11 +1098,11 @@ msgstr "Trennen"
 msgid "Disconnecting…"
 msgstr "Verbindung wird getrennt…"
 
-#: src/pages/Shell.tsx:5349
+#: src/pages/Shell.tsx:5377
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Verworfen – du kannst die Verbindung jederzeit in den MCP-Einstellungen wiederherstellen."
 
-#: src/pages/PluginsOverlay.tsx:337
+#: src/pages/PluginsOverlay.tsx:364
 msgid "Display name"
 msgstr "Anzeigename"
 
@@ -1193,11 +1198,11 @@ msgstr "Jeden Monat"
 msgid "Every week"
 msgstr "Jede Woche"
 
-#: src/pages/Shell.tsx:5395
+#: src/pages/Shell.tsx:5423
 msgid "Expand"
 msgstr "Erweitern"
 
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:4607
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1205,7 +1210,7 @@ msgstr "Exportieren"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Exportiere die Liste dieser Woche aus dem CRM und lege sie im freigegebenen Ordner ab"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4627
 msgid "Extra high"
 msgstr "Sehr hoch"
 
@@ -1213,14 +1218,14 @@ msgstr "Sehr hoch"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: src/pages/Shell.tsx:1393
 #: src/pages/Shell.tsx:1395
 #: src/pages/Shell.tsx:1397
+#: src/pages/Shell.tsx:1399
 msgid "Failed to send message"
 msgstr "Nachricht konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:1420
-#: src/pages/Shell.tsx:1439
+#: src/pages/Shell.tsx:1422
+#: src/pages/Shell.tsx:1441
 msgid "Failed to stop"
 msgstr "Stoppen fehlgeschlagen"
 
@@ -1252,8 +1257,8 @@ msgstr "MCP-Verbindung wird abgeschlossen…"
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#: src/pages/Shell.tsx:2086
-#: src/pages/Shell.tsx:2236
+#: src/pages/Shell.tsx:2089
+#: src/pages/Shell.tsx:2239
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1266,7 +1271,7 @@ msgid "Hang up"
 msgstr "Auflegen"
 
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/PluginsOverlay.tsx:373
+#: src/pages/PluginsOverlay.tsx:400
 msgid "Header name"
 msgstr "Header-Name"
 
@@ -1282,15 +1287,15 @@ msgstr "Beispiel anhören"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hallo, so klinge ich, wenn ich Antworten vorlese."
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4630
 msgid "High"
 msgstr "Hoch"
 
-#: src/pages/Shell.tsx:3419
+#: src/pages/Shell.tsx:3438
 msgid "Hold to talk"
 msgstr "Zum Sprechen gedrückt halten"
 
-#: src/pages/Shell.tsx:3419
+#: src/pages/Shell.tsx:3438
 msgid "Hold to talk (on-device dictation)"
 msgstr "Zum Sprechen gedrückt halten (Diktat auf dem Gerät)"
 
@@ -1310,7 +1315,7 @@ msgstr "Wie oft"
 msgid "How to check"
 msgstr "So wird geprüft"
 
-#: src/pages/Shell.tsx:3697
+#: src/pages/Shell.tsx:3716
 msgid "I’m done"
 msgstr "Ich bin fertig"
 
@@ -1318,11 +1323,11 @@ msgstr "Ich bin fertig"
 msgid "If you heard that, voice is ready."
 msgstr "Wenn du das gehört hast, ist die Stimme einsatzbereit."
 
-#: src/pages/PluginsOverlay.tsx:331
+#: src/pages/PluginsOverlay.tsx:358
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI-JSON importieren"
 
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4517
 msgid "Inherit default"
 msgstr "Standard übernehmen"
 
@@ -1334,12 +1339,12 @@ msgstr "Eingaben"
 msgid "Instance API key"
 msgstr "Instanz-API-Schlüssel"
 
-#: src/pages/Shell.tsx:2503
+#: src/pages/Shell.tsx:2522
 msgid "Instruction"
 msgstr "Anweisung"
 
-#: src/pages/PluginsOverlay.tsx:208
-#: src/pages/Shell.tsx:1953
+#: src/pages/PluginsOverlay.tsx:211
+#: src/pages/Shell.tsx:1956
 msgid "Integrations"
 msgstr "Integrationen"
 
@@ -1360,15 +1365,15 @@ msgid "Interval unit"
 msgstr "Intervalleinheit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4495
+#: src/pages/Shell.tsx:4518
 msgid "Isolated"
 msgstr "Isoliert"
 
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4859
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von ihm erstellte Bots bleiben in deiner Liste."
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3812
 msgid "Jump to replied message"
 msgstr "Zur beantworteten Nachricht springen"
 
@@ -1376,7 +1381,7 @@ msgstr "Zur beantworteten Nachricht springen"
 msgid "just now"
 msgstr "gerade eben"
 
-#: src/pages/Shell.tsx:4849
+#: src/pages/Shell.tsx:4877
 msgid "Keep memories"
 msgstr "Erinnerungen behalten"
 
@@ -1394,7 +1399,7 @@ msgstr "Sprache"
 msgid "Listening…"
 msgstr "Hört zu…"
 
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3036
 msgid "Load earlier messages"
 msgstr "Frühere Nachrichten laden"
 
@@ -1402,7 +1407,7 @@ msgstr "Frühere Nachrichten laden"
 msgid "Loading activity…"
 msgstr "Aktivität wird geladen…"
 
-#: src/pages/PluginsOverlay.tsx:233
+#: src/pages/PluginsOverlay.tsx:237
 msgid "Loading integrations…"
 msgstr "Integrationen werden geladen…"
 
@@ -1434,7 +1439,7 @@ msgstr "Stimmanbieter werden geladen…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3036
 msgid "Loading…"
 msgstr "Wird geladen…"
 
@@ -1442,11 +1447,11 @@ msgstr "Wird geladen…"
 msgid "Local"
 msgstr "Lokal"
 
-#: src/pages/Shell.tsx:2039
+#: src/pages/Shell.tsx:2042
 msgid "Log out"
 msgstr "Abmelden"
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4628
 msgid "Low"
 msgstr "Niedrig"
 
@@ -1462,17 +1467,17 @@ msgstr "Als gelesen markieren"
 msgid "Mark as Unread"
 msgstr "Als ungelesen markieren"
 
-#: src/pages/Shell.tsx:4604
+#: src/pages/Shell.tsx:4632
 msgid "Max"
 msgstr "Max."
 
 #: src/pages/McpServersOverlay.tsx:224
 #: src/pages/McpServersOverlay.tsx:229
-#: src/pages/PluginsOverlay.tsx:305
+#: src/pages/PluginsOverlay.tsx:332
 msgid "MCP servers"
 msgstr "MCP-Server"
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4629
 msgid "Medium"
 msgstr "Mittel"
 
@@ -1485,33 +1490,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Mitglieder ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} auswählen)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:2000
 msgid "Memory"
 msgstr "Erinnerungen"
 
-#: src/pages/Shell.tsx:4490
+#: src/pages/Shell.tsx:4513
 msgid "Memory scope"
 msgstr "Erinnerungsbereich"
 
-#: src/pages/Shell.tsx:3497
-#: src/pages/Shell.tsx:3592
+#: src/pages/Shell.tsx:3516
+#: src/pages/Shell.tsx:3611
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/pages/Shell.tsx:3493
-#: src/pages/Shell.tsx:3497
+#: src/pages/Shell.tsx:3512
+#: src/pages/Shell.tsx:3516
 msgid "Message {activeName}"
 msgstr "Nachricht an {activeName}"
 
-#: src/pages/Shell.tsx:3871
+#: src/pages/Shell.tsx:3890
 msgid "Message from {peer}"
 msgstr "Nachricht von {peer}"
 
-#: src/pages/Shell.tsx:3494
+#: src/pages/Shell.tsx:3513
 msgid "Message…"
 msgstr "Nachricht…"
 
-#: src/pages/Shell.tsx:3871
+#: src/pages/Shell.tsx:3890
 msgid "Messaged {peer}"
 msgstr "Nachricht an {peer} gesendet"
 
@@ -1519,7 +1524,7 @@ msgstr "Nachricht an {peer} gesendet"
 msgid "Microphone failed"
 msgstr "Mikrofonfehler"
 
-#: src/pages/Shell.tsx:4603
+#: src/pages/Shell.tsx:4631
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1541,7 +1546,7 @@ msgstr "Minuten"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4446
+#: src/pages/Shell.tsx:4469
 msgid "Model"
 msgstr "Modell"
 
@@ -1563,7 +1568,7 @@ msgid "Model updated."
 msgstr "Modell aktualisiert."
 
 #: src/pages/ModelSettingsOverlay.tsx:303
-#: src/pages/Shell.tsx:1984
+#: src/pages/Shell.tsx:1987
 msgid "Models"
 msgstr "Modelle"
 
@@ -1581,7 +1586,7 @@ msgstr "Monatlich"
 msgid "Move {0} to section"
 msgstr "{0} in Abschnitt verschieben"
 
-#: src/pages/Shell.tsx:4852
+#: src/pages/Shell.tsx:4880
 msgid "Move them to your shared memory."
 msgstr "Verschiebe sie in deine geteilten Erinnerungen."
 
@@ -1594,15 +1599,15 @@ msgstr "Verschieben nach"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4241
-#: src/pages/Shell.tsx:4405
-#: src/pages/Shell.tsx:4678
+#: src/pages/Shell.tsx:2514
+#: src/pages/Shell.tsx:4260
+#: src/pages/Shell.tsx:4428
+#: src/pages/Shell.tsx:4706
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4246
+#: src/pages/Shell.tsx:4265
 msgid "Name this bot"
 msgstr "Bot benennen"
 
@@ -1618,13 +1623,13 @@ msgstr "Eingabe erforderlich"
 msgid "Needs takeover"
 msgstr "Übernahme erforderlich"
 
-#: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:1744
+#: src/pages/Shell.tsx:4248
 msgid "New bot"
 msgstr "Neuer Bot"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1751
+#: src/pages/Shell.tsx:1754
 msgid "New group"
 msgstr "Neue Gruppe"
 
@@ -1632,29 +1637,29 @@ msgstr "Neue Gruppe"
 msgid "New open-work item"
 msgstr "Neuer offener Arbeitspunkt"
 
-#: src/pages/Shell.tsx:2385
+#: src/pages/Shell.tsx:2400
 msgid "New routine"
 msgstr "Neue Routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4672
+#: src/pages/Shell.tsx:4700
 msgid "New section"
 msgstr "Neuer Abschnitt"
 
-#: src/pages/PluginsOverlay.tsx:244
+#: src/pages/PluginsOverlay.tsx:248
 msgid "No apps match your search."
 msgstr "Keine Apps entsprechen deiner Suche."
 
-#: src/pages/PluginsOverlay.tsx:443
+#: src/pages/PluginsOverlay.tsx:470
 msgid "no auth"
 msgstr "keine Authentifizierung"
 
-#: src/pages/PluginsOverlay.tsx:359
+#: src/pages/PluginsOverlay.tsx:386
 msgid "No authentication"
 msgstr "Keine Authentifizierung"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:139
+#: src/pages/PluginsOverlay.tsx:142
 msgid "No connection record found for {0}."
 msgstr "Kein Verbindungseintrag für {0} gefunden."
 
@@ -1670,11 +1675,11 @@ msgstr "Keine Ausnahmen. Aktionen werden automatisch ausgeführt."
 msgid "No longer active"
 msgstr "Nicht mehr aktiv"
 
-#: src/pages/PluginsOverlay.tsx:239
+#: src/pages/PluginsOverlay.tsx:243
 msgid "No managed app catalog is configured on this deployment."
 msgstr "Für diese Bereitstellung ist kein verwalteter App-Katalog konfiguriert."
 
-#: src/pages/PluginsOverlay.tsx:425
+#: src/pages/PluginsOverlay.tsx:452
 msgid "No MCP or API tool sources installed yet."
 msgstr "Noch keine MCP- oder API-Toolquellen installiert."
 
@@ -1707,7 +1712,7 @@ msgstr "Nicht konfiguriert"
 msgid "Not connected"
 msgstr "Nicht verbunden"
 
-#: src/pages/Shell.tsx:5337
+#: src/pages/Shell.tsx:5365
 msgid "Not now"
 msgstr "Jetzt nicht"
 
@@ -1745,15 +1750,15 @@ msgstr "am 1. um {0}"
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/pages/Shell.tsx:2295
+#: src/pages/Shell.tsx:2298
 msgid "Open computer"
 msgstr "Computer öffnen"
 
-#: src/pages/Shell.tsx:2265
+#: src/pages/Shell.tsx:2268
 msgid "Open in full window"
 msgstr "In vollständigem Fenster öffnen"
 
-#: src/pages/Shell.tsx:2063
+#: src/pages/Shell.tsx:2066
 msgid "Open navigation"
 msgstr "Navigation öffnen"
 
@@ -1770,7 +1775,7 @@ msgstr "Offene Arbeit"
 msgid "OpenAI-compatible server URL"
 msgstr "URL eines OpenAI-kompatiblen Servers"
 
-#: src/pages/Shell.tsx:3996
+#: src/pages/Shell.tsx:4015
 msgid "Opened its thread."
 msgstr "Thread geöffnet."
 
@@ -1853,7 +1858,7 @@ msgstr "Wiedergabe…"
 msgid "Preview {0}"
 msgstr "Vorschau von {0}"
 
-#: src/pages/Shell.tsx:4184
+#: src/pages/Shell.tsx:4203
 msgid "Private"
 msgstr "Privat"
 
@@ -1870,11 +1875,11 @@ msgstr "Anbieter"
 msgid "Queued"
 msgstr "In Warteschlange"
 
-#: src/pages/PluginsOverlay.tsx:388
+#: src/pages/PluginsOverlay.tsx:415
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo prüft die Quelle vor dem Speichern. Zugangsdaten werden verschlüsselt und weder an Clients zurückgegeben noch dem Modell zugänglich gemacht."
 
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4545
 msgid "Read replies aloud"
 msgstr "Antworten vorlesen"
 
@@ -1896,29 +1901,41 @@ msgstr "Verbindung wird wiederhergestellt"
 msgid "Recording: {0}"
 msgstr "Aufnahme: {0}"
 
-#: src/pages/Shell.tsx:3687
+#: src/components/ComputerMaintenanceActions.tsx:57
+msgid "Recover computer"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:79
+msgid "Recover replaces an unreachable computer and keeps files in the saved workspace. Reset restores the last saved workspace and loses unsaved work. Update rebuilds with the latest image and keeps the saved workspace."
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:57
+msgid "Recovering…"
+msgstr ""
+
+#: src/pages/Shell.tsx:3706
 msgid "Release"
 msgstr "Freigeben"
 
 #: src/components/ApprovalRulesSettings.tsx:138
-#: src/pages/PluginsOverlay.tsx:279
-#: src/pages/PluginsOverlay.tsx:454
+#: src/pages/PluginsOverlay.tsx:290
+#: src/pages/PluginsOverlay.tsx:481
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "Entfernen"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3301
+#: src/pages/Shell.tsx:3320
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3456
+#: src/pages/Shell.tsx:3475
 msgid "Remove mention {0}"
 msgstr "Erwähnung von {0} entfernen"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3435
+#: src/pages/Shell.tsx:3454
 msgid "Remove skill {0}"
 msgstr "Skill {0} entfernen"
 
@@ -1926,7 +1943,7 @@ msgstr "Skill {0} entfernen"
 msgid "Remove this schedule"
 msgstr "Diesen Zeitplan entfernen"
 
-#: src/pages/Shell.tsx:3995
+#: src/pages/Shell.tsx:4014
 msgid "Removed with chat, computer, and memory."
 msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 
@@ -1934,8 +1951,8 @@ msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 msgid "Removed, but list refresh failed"
 msgstr "Entfernt, aber die Liste konnte nicht aktualisiert werden"
 
-#: src/pages/PluginsOverlay.tsx:274
-#: src/pages/PluginsOverlay.tsx:454
+#: src/pages/PluginsOverlay.tsx:285
+#: src/pages/PluginsOverlay.tsx:481
 msgid "Removing…"
 msgstr "Wird entfernt…"
 
@@ -1953,17 +1970,38 @@ msgstr "API-Schlüssel ersetzen"
 msgid "Replace key"
 msgstr "Schlüssel ersetzen"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3652
 msgid "Reply"
 msgstr "Antworten"
 
-#: src/pages/Shell.tsx:3264
+#: src/pages/Shell.tsx:3283
 msgid "Replying to {replyName}"
 msgstr "Antwort an {replyName}"
 
-#: src/pages/Shell.tsx:1928
+#: src/components/ComputerMaintenanceActions.tsx:115
+msgid "Reset"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:68
+msgid "Reset computer"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:97
+msgid "Reset computer?"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:68
+#: src/components/ComputerMaintenanceActions.tsx:115
+msgid "Resetting…"
+msgstr ""
+
+#: src/pages/Shell.tsx:1931
 msgid "Restore"
 msgstr "Wiederherstellen"
+
+#: src/components/ComputerMaintenanceActions.tsx:103
+msgid "Restore the last saved workspace. Unsaved work on the computer is lost."
+msgstr ""
 
 #: src/App.tsx:135
 msgid "Retry now"
@@ -1973,17 +2011,17 @@ msgstr "Jetzt erneut versuchen"
 msgid "Return to Rakazo"
 msgstr "Zurück zu Rakazo"
 
-#: src/pages/Shell.tsx:2488
-#: src/pages/Shell.tsx:2541
-#: src/pages/Shell.tsx:2548
+#: src/pages/Shell.tsx:2507
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:2567
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Routines"
 msgstr "Routinen"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2630
 msgid "Run now"
 msgstr "Jetzt ausführen"
 
@@ -1991,11 +2029,11 @@ msgstr "Jetzt ausführen"
 msgid "Running"
 msgstr "Läuft"
 
-#: src/pages/Shell.tsx:2370
+#: src/pages/Shell.tsx:2385
 msgid "Running · Stop"
 msgstr "Wird ausgeführt · Stoppen"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2630
 msgid "Running…"
 msgstr "Wird ausgeführt…"
 
@@ -2003,8 +2041,8 @@ msgstr "Wird ausgeführt…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:4600
 msgid "Save"
 msgstr "Speichern"
 
@@ -2028,7 +2066,7 @@ msgstr "Gespeichert."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2606
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
@@ -2041,11 +2079,12 @@ msgstr "Sag etwas. Bei Stille wird es gesendet."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Antworte mit Ja oder Nein oder in einem Satz."
 
-#: src/pages/Shell.tsx:1762
+#: src/pages/Shell.tsx:1765
 msgid "Search"
 msgstr "Suchen"
 
-#: src/pages/PluginsOverlay.tsx:224
+#: src/pages/PluginsOverlay.tsx:227
+#: src/pages/PluginsOverlay.tsx:228
 msgid "Search apps"
 msgstr "Apps suchen"
 
@@ -2063,11 +2102,11 @@ msgstr "Anbieter und Modelle suchen"
 msgid "Searching…"
 msgstr "Suche…"
 
-#: src/pages/Shell.tsx:2087
+#: src/pages/Shell.tsx:2090
 msgid "Select a bot"
 msgstr "Bot auswählen"
 
-#: src/pages/Shell.tsx:3517
+#: src/pages/Shell.tsx:3536
 msgid "Send"
 msgstr "Senden"
 
@@ -2095,22 +2134,22 @@ msgstr "Servername"
 msgid "Server URL"
 msgstr "Server-URL"
 
-#: src/pages/Shell.tsx:2096
+#: src/pages/Shell.tsx:2099
 msgid "Set up voice to call"
 msgstr "Stimme für Anrufe einrichten"
 
 #: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1961
-#: src/pages/Shell.tsx:1971
-#: src/pages/Shell.tsx:2232
+#: src/pages/Shell.tsx:1964
+#: src/pages/Shell.tsx:1974
+#: src/pages/Shell.tsx:2235
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3554
 msgid "Settings: General"
 msgstr "Einstellungen: Allgemein"
 
-#: src/pages/Shell.tsx:3537
+#: src/pages/Shell.tsx:3556
 msgid "Settings: Usage"
 msgstr "Einstellungen: Nutzung"
 
@@ -2120,15 +2159,15 @@ msgid "Setup help"
 msgstr "Einrichtungshilfe"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4496
+#: src/pages/Shell.tsx:4519
 msgid "Shared"
 msgstr "Geteilt"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2246
 msgid "Show computer"
 msgstr "Computer anzeigen"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2246
 msgid "Show settings"
 msgstr "Einstellungen anzeigen"
 
@@ -2152,11 +2191,11 @@ msgid "Sign up"
 msgstr "Registrieren"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3367
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3694
+#: src/pages/Shell.tsx:3713
 msgid "Skip"
 msgstr "Überspringen"
 
@@ -2169,7 +2208,7 @@ msgid "Skip or deploy key"
 msgstr "Überspringen oder Deploy-Key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1287
+#: src/pages/Shell.tsx:1289
 msgid "Skipped {0}"
 msgstr "{0} übersprungen"
 
@@ -2177,8 +2216,8 @@ msgstr "{0} übersprungen"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Leertaste unterbricht · Esc legt auf"
 
-#: src/pages/Shell.tsx:3840
-#: src/pages/Shell.tsx:4093
+#: src/pages/Shell.tsx:3859
+#: src/pages/Shell.tsx:4112
 msgid "Speak"
 msgstr "Vorlesen"
 
@@ -2190,8 +2229,8 @@ msgstr "Sprechen + transkribieren"
 msgid "Speak only"
 msgstr "Nur sprechen"
 
-#: src/pages/Shell.tsx:3836
-#: src/pages/Shell.tsx:4089
+#: src/pages/Shell.tsx:3855
+#: src/pages/Shell.tsx:4108
 msgid "Speak this reply"
 msgstr "Diese Antwort vorlesen"
 
@@ -2217,20 +2256,20 @@ msgstr "Wird gestartet…"
 msgid "Steps"
 msgstr "Schritte"
 
-#: src/pages/Shell.tsx:2866
-#: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3508
-#: src/pages/Shell.tsx:3840
-#: src/pages/Shell.tsx:4093
+#: src/pages/Shell.tsx:2885
+#: src/pages/Shell.tsx:2889
+#: src/pages/Shell.tsx:3527
+#: src/pages/Shell.tsx:3859
+#: src/pages/Shell.tsx:4112
 msgid "Stop"
 msgstr "Stoppen"
 
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3419
 msgid "Stop dictation"
 msgstr "Diktat stoppen"
 
-#: src/pages/Shell.tsx:3836
-#: src/pages/Shell.tsx:4089
+#: src/pages/Shell.tsx:3855
+#: src/pages/Shell.tsx:4108
 msgid "Stop speaking"
 msgstr "Vorlesen stoppen"
 
@@ -2239,8 +2278,8 @@ msgstr "Vorlesen stoppen"
 msgid "Stop teaching"
 msgstr "Anlernen beenden"
 
-#: src/pages/Shell.tsx:2322
-#: src/pages/Shell.tsx:2886
+#: src/pages/Shell.tsx:2325
+#: src/pages/Shell.tsx:2905
 msgid "Stop the bot first"
 msgstr "Zuerst den Bot stoppen"
 
@@ -2248,7 +2287,7 @@ msgstr "Zuerst den Bot stoppen"
 msgid "Stored encrypted"
 msgstr "Verschlüsselt gespeichert"
 
-#: src/pages/Shell.tsx:3947
+#: src/pages/Shell.tsx:3966
 msgid "subagent"
 msgstr "Subagent"
 
@@ -2261,8 +2300,8 @@ msgstr "Absenden"
 msgid "Switching…"
 msgstr "Wird gewechselt…"
 
-#: src/pages/Shell.tsx:2325
-#: src/pages/Shell.tsx:2891
+#: src/pages/Shell.tsx:2328
+#: src/pages/Shell.tsx:2910
 msgid "Take control"
 msgstr "Kontrolle übernehmen"
 
@@ -2270,7 +2309,7 @@ msgstr "Kontrolle übernehmen"
 msgid "Teach a task"
 msgstr "Aufgabe anlernen"
 
-#: src/pages/Shell.tsx:2158
+#: src/pages/Shell.tsx:2161
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachricht sendest."
 
@@ -2278,11 +2317,11 @@ msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachr
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Zum Anlernen ist ein grafischer Sandbox-Computer erforderlich. Auf dem Desktop gehostete Bots können Shell-Aufgaben ausführen, aber keine Bildschirmaufnahmen erstellen."
 
-#: src/pages/Shell.tsx:4184
+#: src/pages/Shell.tsx:4203
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:5046
 msgid "Team Computer"
 msgstr "Team-Computer"
 
@@ -2295,20 +2334,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügbar."
 
-#: src/pages/Shell.tsx:4473
+#: src/pages/Shell.tsx:4496
 msgid "Thinking"
 msgstr "Denkmodus"
 
-#: src/pages/Shell.tsx:2269
+#: src/pages/Shell.tsx:2272
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Dieser Bot wird auf diesem Computer und nicht auf einem Linux-Desktop ausgeführt. Shell und Dateien verwenden deinen persönlichen Ordner."
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:2934
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Dieser Bot wird auf diesem Computer ausgeführt. Es gibt keinen separaten Linux-Desktop. Bitte ihn, die Shell zu verwenden; Arbeitsverzeichnisse in deinem persönlichen Ordner sind zulässig."
 
-#: src/pages/Shell.tsx:4868
-#: src/pages/Shell.tsx:4945
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4973
 msgid "This cannot be undone."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
@@ -2332,7 +2371,7 @@ msgstr "dieser Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Dieser Mac führt Shell-Befehle mit deinem Konto aus und kann auf Dateien in deinem persönlichen Ordner zugreifen. Aktiviere dies nicht auf einem gemeinsam genutzten oder öffentlichen Server."
 
-#: src/pages/Shell.tsx:4753
+#: src/pages/Shell.tsx:4781
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbeit beendet. Bot, Computer, Erinnerungen und Routinen bleiben erhalten."
 
@@ -2340,7 +2379,7 @@ msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbe
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bei diesem Anbieter kann hier kein Schlüssel eingefügt werden. Überspringe diesen Schritt, wenn die Bereitstellung bereits Zugangsdaten enthält."
 
-#: src/pages/Shell.tsx:5285
+#: src/pages/Shell.tsx:5313
 msgid "This server cannot be assigned without a bot."
 msgstr "Dieser Server kann ohne Bot nicht zugewiesen werden."
 
@@ -2352,7 +2391,7 @@ msgstr "Dieser Server hat keine Browserautorisierung angefordert."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Dieser Server ist bereits verbunden. Trenne zuerst die Verbindung, um ihn erneut zu autorisieren."
 
-#: src/pages/Shell.tsx:5324
+#: src/pages/Shell.tsx:5352
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Dieser Server verwendet die Browseranmeldung. Autorisiere ihn, damit deine Agents seine Tools verwenden können – ein Pop-up wird geöffnet."
 
@@ -2365,16 +2404,16 @@ msgid "Time of day"
 msgstr "Uhrzeit"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4251
-#: src/pages/Shell.tsx:4414
+#: src/pages/Shell.tsx:4270
+#: src/pages/Shell.tsx:4437
 msgid "Title"
 msgstr "Titel"
 
-#: src/pages/PluginsOverlay.tsx:421
+#: src/pages/PluginsOverlay.tsx:448
 msgid "Tool sources"
 msgstr "Toolquellen"
 
-#: src/pages/PluginsOverlay.tsx:383
+#: src/pages/PluginsOverlay.tsx:410
 msgid "Treg token"
 msgstr "Treg-Token"
 
@@ -2391,12 +2430,20 @@ msgid "Unpin"
 msgstr "Lösen"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1351
+#: src/pages/Shell.tsx:1353
 msgid "Unsupported file type: {0}"
 msgstr "Nicht unterstützter Dateityp: {0}"
 
+#: src/components/ComputerMaintenanceActions.tsx:73
+msgid "Update computer"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:73
+msgid "Updating…"
+msgstr ""
+
 #: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2022
+#: src/pages/Shell.tsx:2025
 msgid "Usage"
 msgstr "Nutzung"
 
@@ -2413,16 +2460,16 @@ msgstr "Gefundenes Modell verwenden"
 msgid "Use this model"
 msgstr "Dieses Modell verwenden"
 
-#: src/pages/PluginsOverlay.tsx:404
+#: src/pages/PluginsOverlay.tsx:431
 msgid "Verify and add"
 msgstr "Prüfen und hinzufügen"
 
-#: src/pages/PluginsOverlay.tsx:402
+#: src/pages/PluginsOverlay.tsx:429
 msgid "Verifying…"
 msgstr "Wird geprüft…"
 
-#: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4526
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:4549
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2435,7 +2482,7 @@ msgstr "Stimme"
 msgid "Waiting for sign-in…"
 msgstr "Warten auf Anmeldung…"
 
-#: src/pages/Shell.tsx:5168
+#: src/pages/Shell.tsx:5196
 msgid "Waiting…"
 msgstr "Warten…"
 
@@ -2444,7 +2491,7 @@ msgstr "Warten…"
 msgid "Weekdays"
 msgstr "Wochentage"
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4866
 msgid "What about its memories?"
 msgstr "Was soll mit seinen Erinnerungen geschehen?"
 
@@ -2453,7 +2500,7 @@ msgid "What result will you demonstrate?"
 msgstr "Welches Ergebnis wirst du vorführen?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4266
+#: src/pages/Shell.tsx:4285
 msgid "What this bot is for"
 msgstr "Wofür dieser Bot gedacht ist"
 
@@ -2465,7 +2512,7 @@ msgstr "Was zurückgegeben werden soll"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "Wenn {botName} einem anderen Bot eine Nachricht sendet, wird der Austausch hier statt im Chat angezeigt."
 
-#: src/pages/Shell.tsx:2512
+#: src/pages/Shell.tsx:2531
 msgid "When to run"
 msgstr "Ausführungszeit"
 
@@ -2482,12 +2529,12 @@ msgstr "Wo sollen Bots ausgeführt werden?"
 msgid "Working…"
 msgstr "Wird verarbeitet…"
 
-#: src/pages/Shell.tsx:4456
+#: src/pages/Shell.tsx:4479
 msgid "Workspace default"
 msgstr "Arbeitsbereichsstandard"
 
-#: src/pages/Shell.tsx:1100
-#: src/pages/Shell.tsx:1672
+#: src/pages/Shell.tsx:1102
+#: src/pages/Shell.tsx:1675
 msgid "You"
 msgstr "Du"
 
@@ -2499,8 +2546,8 @@ msgstr "Du kannst diesen Tab schließen, wenn du nicht automatisch weitergeleite
 msgid "You can close this window."
 msgstr "Du kannst dieses Fenster schließen."
 
-#: src/pages/Shell.tsx:2302
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2305
+#: src/pages/Shell.tsx:2875
 msgid "You have control"
 msgstr "Du hast die Kontrolle"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1823
+#: src/pages/Shell.tsx:1826
 msgid " (unread)"
 msgstr " (unread)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# model} other {# models}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1267
+#: src/pages/Shell.tsx:1269
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1271
+#: src/pages/Shell.tsx:1273
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (over 10 MiB)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5141
+#: src/pages/Shell.tsx:5169
 msgid "{0} connection"
 msgstr "{0} connection"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2306
+#: src/pages/Shell.tsx:2309
 msgid "{0} is using it"
 msgstr "{0} is using it"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2030
 msgid "{0} runs · {1} tokens"
 msgstr "{0} runs · {1} tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# peer} other {# peers}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} has not messaged another bot yet."
 
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:5046
 msgid "{botName}’s computer"
 msgstr "{botName}’s computer"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3320
+#: src/pages/Shell.tsx:3339
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Access token (optional)"
 msgid "Account"
 msgstr "Account"
 
-#: src/pages/Shell.tsx:4532
+#: src/pages/Shell.tsx:4555
 msgid "Account default"
 msgstr "Account default"
 
@@ -156,12 +156,12 @@ msgstr "Active model"
 msgid "Active voice"
 msgstr "Active voice"
 
-#: src/pages/Shell.tsx:1707
-#: src/pages/Shell.tsx:1709
+#: src/pages/Shell.tsx:1710
+#: src/pages/Shell.tsx:1712
 msgid "Activity"
 msgstr "Activity"
 
-#: src/pages/PluginsOverlay.tsx:281
+#: src/pages/PluginsOverlay.tsx:292
 #: src/pages/ScratchpadSection.tsx:188
 msgid "Add"
 msgstr "Add"
@@ -186,15 +186,15 @@ msgstr "Add an HTTPS server URL."
 msgid "Add item"
 msgstr "Add item"
 
-#: src/pages/PluginsOverlay.tsx:311
+#: src/pages/PluginsOverlay.tsx:338
 msgid "Add MCP server"
 msgstr "Add MCP server"
 
-#: src/pages/PluginsOverlay.tsx:314
+#: src/pages/PluginsOverlay.tsx:341
 msgid "Add OpenAPI"
 msgstr "Add OpenAPI"
 
-#: src/pages/PluginsOverlay.tsx:329
+#: src/pages/PluginsOverlay.tsx:356
 msgid "Add remote MCP server"
 msgstr "Add remote MCP server"
 
@@ -207,19 +207,19 @@ msgstr "Add server"
 msgid "Add to routine"
 msgstr "Add to routine"
 
-#: src/pages/PluginsOverlay.tsx:317
+#: src/pages/PluginsOverlay.tsx:344
 msgid "Add Treg"
 msgstr "Add Treg"
 
 #: src/pages/McpServersOverlay.tsx:363
-#: src/pages/PluginsOverlay.tsx:276
+#: src/pages/PluginsOverlay.tsx:287
 msgid "Adding…"
 msgstr "Adding…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
-#: src/pages/PluginsOverlay.tsx:291
+#: src/pages/PluginsOverlay.tsx:318
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4458
 msgid "Advanced"
 msgstr "Advanced"
 
@@ -227,7 +227,7 @@ msgstr "Advanced"
 msgid "Agent access for new servers"
 msgstr "Agent access for new servers"
 
-#: src/pages/Shell.tsx:2114
+#: src/pages/Shell.tsx:2117
 msgid "Agent computer"
 msgstr "Agent computer"
 
@@ -302,7 +302,7 @@ msgstr "Answered: {answer}"
 msgid "API key"
 msgstr "API key"
 
-#: src/pages/PluginsOverlay.tsx:365
+#: src/pages/PluginsOverlay.tsx:392
 msgid "API key header"
 msgstr "API key header"
 
@@ -314,11 +314,11 @@ msgstr "Applies when you click Add server. Use the agent chips on each server ca
 msgid "Approval boundaries"
 msgstr "Approval boundaries"
 
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5362
 msgid "Approve"
 msgstr "Approve"
 
-#: src/pages/Shell.tsx:5325
+#: src/pages/Shell.tsx:5353
 msgid "Approve this server to let your agent use its tools."
 msgstr "Approve this server to let your agent use its tools."
 
@@ -326,15 +326,15 @@ msgstr "Approve this server to let your agent use its tools."
 msgid "Archive"
 msgstr "Archive"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:4002
 msgid "archived"
 msgstr "archived"
 
-#: src/pages/Shell.tsx:1907
+#: src/pages/Shell.tsx:1910
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4013
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archived. Chat, memory, and files kept."
 
@@ -373,7 +373,7 @@ msgstr "Ask before purchases"
 msgid "Ask before sending external email"
 msgstr "Ask before sending external email"
 
-#: src/pages/Shell.tsx:2308
+#: src/pages/Shell.tsx:2311
 msgid "Asleep"
 msgstr "Asleep"
 
@@ -388,11 +388,11 @@ msgstr "at {0}"
 msgid "at {timeSelect}"
 msgstr "at {timeSelect}"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3410
 msgid "Attach file"
 msgstr "Attach file"
 
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3609
 msgid "Attachment"
 msgstr "Attachment"
 
@@ -405,12 +405,12 @@ msgstr "Authorization code or callback URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Authorization expired — reconnect required"
 
-#: src/pages/Shell.tsx:5126
+#: src/pages/Shell.tsx:5154
 msgid "Authorization timed out. Please try again."
 msgstr "Authorization timed out. Please try again."
 
-#: src/pages/Shell.tsx:5168
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5196
+#: src/pages/Shell.tsx:5362
 msgid "Authorize"
 msgstr "Authorize"
 
@@ -418,26 +418,26 @@ msgstr "Authorize"
 msgid "Base URL"
 msgstr "Base URL"
 
-#: src/pages/PluginsOverlay.tsx:362
+#: src/pages/PluginsOverlay.tsx:389
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5038
 msgid "Booting live desktop…"
 msgstr "Booting live desktop…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2850
 msgid "Booting up {0}’s computer"
 msgstr "Booting up {0}’s computer"
 
-#: src/pages/Shell.tsx:3853
-#: src/pages/Shell.tsx:3854
-#: src/pages/Shell.tsx:3987
+#: src/pages/Shell.tsx:3872
+#: src/pages/Shell.tsx:3873
+#: src/pages/Shell.tsx:4006
 msgid "bot"
 msgstr "bot"
 
-#: src/pages/Shell.tsx:1101
+#: src/pages/Shell.tsx:1103
 msgid "Bot"
 msgstr "Bot"
 
@@ -445,11 +445,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot messages"
 
-#: src/pages/Shell.tsx:2923
+#: src/pages/Shell.tsx:2942
 msgid "Bot screen"
 msgstr "Bot screen"
 
-#: src/pages/Shell.tsx:2276
+#: src/pages/Shell.tsx:2279
 msgid "Bot screen preview"
 msgstr "Bot screen preview"
 
@@ -462,8 +462,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Bring your own key. The provider is swappable; your bots keep the same speak and call buttons."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2096
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2099
+#: src/pages/Shell.tsx:2100
 msgid "Call"
 msgstr "Call"
 
@@ -472,16 +472,17 @@ msgid "Can't reach the server."
 msgstr "Can't reach the server."
 
 #: src/components/AskCard.tsx:129
+#: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
-#: src/pages/PluginsOverlay.tsx:413
-#: src/pages/Shell.tsx:4694
-#: src/pages/Shell.tsx:4766
-#: src/pages/Shell.tsx:4881
-#: src/pages/Shell.tsx:4955
+#: src/pages/PluginsOverlay.tsx:440
+#: src/pages/Shell.tsx:4722
+#: src/pages/Shell.tsx:4794
+#: src/pages/Shell.tsx:4909
+#: src/pages/Shell.tsx:4983
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/pages/Shell.tsx:4231
+#: src/pages/Shell.tsx:4250
 msgid "Cancel new bot"
 msgstr "Cancel new bot"
 
@@ -489,7 +490,7 @@ msgstr "Cancel new bot"
 msgid "Cancel new group"
 msgstr "Cancel new group"
 
-#: src/pages/Shell.tsx:3267
+#: src/pages/Shell.tsx:3286
 msgid "Cancel reply"
 msgstr "Cancel reply"
 
@@ -497,16 +498,16 @@ msgstr "Cancel reply"
 msgid "Cancelled"
 msgstr "Cancelled"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5259
 msgid "Chart failed to render: {error}"
 msgstr "Chart failed to render: {error}"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3552
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
-#: src/pages/Shell.tsx:2542
-#: src/pages/Shell.tsx:2549
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:2568
 msgid "Check in."
 msgstr "Check in."
 
@@ -518,21 +519,21 @@ msgstr "Choose a model to get started."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Choose which connected model Rakazo uses."
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4809
 msgid "Clear"
 msgstr "Clear"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4775
 msgid "Clear {0}’s conversation?"
 msgstr "Clear {0}’s conversation?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4587
+#: src/pages/Shell.tsx:4610
 msgid "Clear conversation"
 msgstr "Clear conversation"
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4809
 msgid "Clearing…"
 msgstr "Clearing…"
 
@@ -548,19 +549,19 @@ msgstr "Close bot menu"
 msgid "Close bot messages"
 msgstr "Close bot messages"
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5444
 msgid "Close chart"
 msgstr "Close chart"
 
-#: src/pages/Shell.tsx:2897
+#: src/pages/Shell.tsx:2916
 msgid "Close computer"
 msgstr "Close computer"
 
-#: src/pages/Shell.tsx:5516
+#: src/pages/Shell.tsx:5544
 msgid "Close image preview"
 msgstr "Close image preview"
 
-#: src/pages/PluginsOverlay.tsx:212
+#: src/pages/PluginsOverlay.tsx:215
 msgid "Close integrations"
 msgstr "Close integrations"
 
@@ -576,11 +577,11 @@ msgstr "Close memory settings"
 msgid "Close model settings"
 msgstr "Close model settings"
 
-#: src/pages/Shell.tsx:1692
+#: src/pages/Shell.tsx:1695
 msgid "Close navigation"
 msgstr "Close navigation"
 
-#: src/pages/Shell.tsx:2254
+#: src/pages/Shell.tsx:2257
 msgid "Close panel"
 msgstr "Close panel"
 
@@ -609,24 +610,24 @@ msgstr "Command"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/pages/Shell.tsx:4141
-#: src/pages/Shell.tsx:4169
+#: src/pages/Shell.tsx:4160
+#: src/pages/Shell.tsx:4188
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5013
+#: src/pages/Shell.tsx:5041
 msgid "Computer failed to boot"
 msgstr "Computer failed to boot"
 
-#: src/pages/Shell.tsx:2945
+#: src/pages/Shell.tsx:2964
 msgid "Computer is asleep"
 msgstr "Computer is asleep"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5040
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer is asleep — take control to wake it"
 
-#: src/pages/Shell.tsx:5014
+#: src/pages/Shell.tsx:5042
 msgid "Computer is stopped"
 msgstr "Computer is stopped"
 
@@ -659,7 +660,7 @@ msgstr "Connect API key"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "Connect ElevenLabs, OpenAI, or Cartesia"
 
-#: src/pages/Shell.tsx:5314
+#: src/pages/Shell.tsx:5342
 msgid "Connect MCP server “{name}”"
 msgstr "Connect MCP server “{name}”"
 
@@ -675,19 +676,19 @@ msgstr "Connect remote or local tool servers and choose which agents can use the
 msgid "Connect this provider to use it as your personal model."
 msgstr "Connect this provider to use it as your personal model."
 
-#: src/pages/PluginsOverlay.tsx:327
+#: src/pages/PluginsOverlay.tsx:354
 msgid "Connect Treg"
 msgstr "Connect Treg"
 
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
-#: src/pages/Shell.tsx:5165
+#: src/pages/Shell.tsx:5193
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Connected"
 
-#: src/pages/Shell.tsx:5344
+#: src/pages/Shell.tsx:5372
 msgid "Connected — its tools are available from your next message."
 msgstr "Connected — its tools are available from your next message."
 
@@ -712,13 +713,13 @@ msgstr "Connected and using {0}."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5362
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Connecting…"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:114
+#: src/pages/PluginsOverlay.tsx:116
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "Connection to {0} is still pending. You can close this and check again."
 
@@ -731,7 +732,7 @@ msgstr "Continue"
 msgid "Continue with email"
 msgstr "Continue with email"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3660
 msgid "Copy"
 msgstr "Copy"
 
@@ -743,11 +744,11 @@ msgstr "Could not add"
 msgid "Could not add MCP server"
 msgstr "Could not add MCP server"
 
-#: src/pages/Shell.tsx:5301
+#: src/pages/Shell.tsx:5329
 msgid "Could not approve this server"
 msgstr "Could not approve this server"
 
-#: src/pages/Shell.tsx:5129
+#: src/pages/Shell.tsx:5157
 msgid "Could not authorize this app"
 msgstr "Could not authorize this app"
 
@@ -755,7 +756,7 @@ msgstr "Could not authorize this app"
 msgid "Could not change the default model"
 msgstr "Could not change the default model"
 
-#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:4803
 msgid "Could not clear conversation"
 msgstr "Could not clear conversation"
 
@@ -763,7 +764,7 @@ msgstr "Could not clear conversation"
 msgid "Could not complete OAuth"
 msgstr "Could not complete OAuth"
 
-#: src/pages/PluginsOverlay.tsx:117
+#: src/pages/PluginsOverlay.tsx:120
 msgid "Could not connect"
 msgstr "Could not connect"
 
@@ -784,7 +785,7 @@ msgstr "Could not connect this voice provider"
 msgid "Could not continue"
 msgstr "Could not continue"
 
-#: src/pages/Shell.tsx:4219
+#: src/pages/Shell.tsx:4238
 msgid "Could not create bot"
 msgstr "Could not create bot"
 
@@ -792,7 +793,7 @@ msgstr "Could not create bot"
 msgid "Could not create group"
 msgstr "Could not create group"
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4694
 msgid "Could not create section"
 msgstr "Could not create section"
 
@@ -800,7 +801,7 @@ msgstr "Could not create section"
 msgid "Could not create your bot"
 msgstr "Could not create your bot"
 
-#: src/pages/Shell.tsx:4890
+#: src/pages/Shell.tsx:4918
 msgid "Could not delete bot"
 msgstr "Could not delete bot"
 
@@ -808,7 +809,7 @@ msgstr "Could not delete bot"
 msgid "Could not delete MCP server"
 msgstr "Could not delete MCP server"
 
-#: src/pages/Shell.tsx:4964
+#: src/pages/Shell.tsx:4992
 msgid "Could not delete routine"
 msgstr "Could not delete routine"
 
@@ -829,7 +830,7 @@ msgstr "Could not download {0}. Try again."
 msgid "Could not download {name}. Try again."
 msgstr "Could not download {name}. Try again."
 
-#: src/pages/PluginsOverlay.tsx:184
+#: src/pages/PluginsOverlay.tsx:187
 msgid "Could not install connector"
 msgstr "Could not install connector"
 
@@ -837,7 +838,7 @@ msgstr "Could not install connector"
 msgid "Could not load approval rules"
 msgstr "Could not load approval rules"
 
-#: src/pages/PluginsOverlay.tsx:60
+#: src/pages/PluginsOverlay.tsx:61
 msgid "Could not load integrations"
 msgstr "Could not load integrations"
 
@@ -870,7 +871,7 @@ msgstr "Could not reach this model server"
 msgid "Could not remove"
 msgstr "Could not remove"
 
-#: src/pages/PluginsOverlay.tsx:197
+#: src/pages/PluginsOverlay.tsx:200
 msgid "Could not remove connector"
 msgstr "Could not remove connector"
 
@@ -882,15 +883,15 @@ msgstr "Could not remove group"
 msgid "Could not remove rule"
 msgstr "Could not remove rule"
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5249
 msgid "Could not render chart"
 msgstr "Could not render chart"
 
-#: src/pages/PluginsOverlay.tsx:143
+#: src/pages/PluginsOverlay.tsx:146
 msgid "Could not revoke connection"
 msgstr "Could not revoke connection"
 
-#: src/pages/Shell.tsx:4572
+#: src/pages/Shell.tsx:4595
 msgid "Could not save"
 msgstr "Could not save"
 
@@ -902,7 +903,7 @@ msgstr "Could not save group"
 msgid "Could not save model"
 msgstr "Could not save model"
 
-#: src/pages/Shell.tsx:2564
+#: src/pages/Shell.tsx:2583
 msgid "Could not save routine"
 msgstr "Could not save routine"
 
@@ -918,7 +919,7 @@ msgstr "Could not save that choice"
 msgid "Could not save that voice"
 msgstr "Could not save that voice"
 
-#: src/pages/Shell.tsx:5041
+#: src/pages/Shell.tsx:5069
 msgid "Could not save this choice"
 msgstr "Could not save this choice"
 
@@ -934,7 +935,7 @@ msgstr "Could not start OAuth"
 msgid "Could not submit this answer"
 msgstr "Could not submit this answer"
 
-#: src/pages/Shell.tsx:1550
+#: src/pages/Shell.tsx:1552
 msgid "Could not take control"
 msgstr "Could not take control"
 
@@ -946,18 +947,22 @@ msgstr "Could not update"
 msgid "Could not update agent access"
 msgstr "Could not update agent access"
 
+#: src/components/ComputerMaintenanceActions.tsx:46
+msgid "Could not update computer"
+msgstr "Could not update computer"
+
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "Could not update the default memory scope"
 
-#: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4278
-#: src/pages/Shell.tsx:4701
+#: src/pages/Shell.tsx:1730
+#: src/pages/Shell.tsx:4297
+#: src/pages/Shell.tsx:4729
 msgid "Create"
 msgstr "Create"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4675
+#: src/pages/Shell.tsx:4703
 msgid "Create a section and move {0} into it."
 msgstr "Create a section and move {0} into it."
 
@@ -978,16 +983,16 @@ msgid "Create your Rakazo"
 msgstr "Create your Rakazo"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4278
-#: src/pages/Shell.tsx:4701
+#: src/pages/Shell.tsx:4297
+#: src/pages/Shell.tsx:4729
 msgid "Creating…"
 msgstr "Creating…"
 
-#: src/pages/PluginsOverlay.tsx:383
+#: src/pages/PluginsOverlay.tsx:410
 msgid "Credential"
 msgstr "Credential"
 
-#: src/pages/PluginsOverlay.tsx:441
+#: src/pages/PluginsOverlay.tsx:468
 msgid "credential saved"
 msgstr "credential saved"
 
@@ -1007,7 +1012,7 @@ msgstr "day"
 msgid "days"
 msgstr "days"
 
-#: src/pages/Shell.tsx:4479
+#: src/pages/Shell.tsx:4502
 msgid "Default (medium)"
 msgstr "Default (medium)"
 
@@ -1017,21 +1022,21 @@ msgstr "Default scope"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4896
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:1939
+#: src/pages/Shell.tsx:4924
+#: src/pages/Shell.tsx:4998
 msgid "Delete"
 msgstr "Delete"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1932
+#: src/pages/Shell.tsx:1935
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4828
-#: src/pages/Shell.tsx:4942
+#: src/pages/Shell.tsx:4856
+#: src/pages/Shell.tsx:4970
 msgid "Delete {0}?"
 msgstr "Delete {0}?"
 
@@ -1039,21 +1044,21 @@ msgstr "Delete {0}?"
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/pages/Shell.tsx:4865
+#: src/pages/Shell.tsx:4893
 msgid "Delete memories too"
 msgstr "Delete memories too"
 
-#: src/pages/Shell.tsx:2619
+#: src/pages/Shell.tsx:2638
 msgid "Delete routine"
 msgstr "Delete routine"
 
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:4004
 msgid "deleted"
 msgstr "deleted"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4896
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4924
+#: src/pages/Shell.tsx:4998
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1070,17 +1075,17 @@ msgid "Deployment default"
 msgstr "Deployment default"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4256
+#: src/pages/Shell.tsx:4275
 msgid "Describe what this bot does"
 msgstr "Describe what this bot does"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4261
-#: src/pages/Shell.tsx:4423
+#: src/pages/Shell.tsx:4280
+#: src/pages/Shell.tsx:4446
 msgid "Description"
 msgstr "Description"
 
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3419
 msgid "Dictate"
 msgstr "Dictate"
 
@@ -1093,11 +1098,11 @@ msgstr "Disconnect"
 msgid "Disconnecting…"
 msgstr "Disconnecting…"
 
-#: src/pages/Shell.tsx:5349
+#: src/pages/Shell.tsx:5377
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Dismissed — reconnect anytime from MCP settings."
 
-#: src/pages/PluginsOverlay.tsx:337
+#: src/pages/PluginsOverlay.tsx:364
 msgid "Display name"
 msgstr "Display name"
 
@@ -1193,11 +1198,11 @@ msgstr "Every month"
 msgid "Every week"
 msgstr "Every week"
 
-#: src/pages/Shell.tsx:5395
+#: src/pages/Shell.tsx:5423
 msgid "Expand"
 msgstr "Expand"
 
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:4607
 msgid "Export"
 msgstr "Export"
 
@@ -1205,7 +1210,7 @@ msgstr "Export"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Export this week's list from the CRM and drop it in the shared folder"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4627
 msgid "Extra high"
 msgstr "Extra high"
 
@@ -1213,14 +1218,14 @@ msgstr "Extra high"
 msgid "Failed"
 msgstr "Failed"
 
-#: src/pages/Shell.tsx:1393
 #: src/pages/Shell.tsx:1395
 #: src/pages/Shell.tsx:1397
+#: src/pages/Shell.tsx:1399
 msgid "Failed to send message"
 msgstr "Failed to send message"
 
-#: src/pages/Shell.tsx:1420
-#: src/pages/Shell.tsx:1439
+#: src/pages/Shell.tsx:1422
+#: src/pages/Shell.tsx:1441
 msgid "Failed to stop"
 msgstr "Failed to stop"
 
@@ -1252,8 +1257,8 @@ msgstr "Finishing MCP connection…"
 msgid "Fullscreen"
 msgstr "Fullscreen"
 
-#: src/pages/Shell.tsx:2086
-#: src/pages/Shell.tsx:2236
+#: src/pages/Shell.tsx:2089
+#: src/pages/Shell.tsx:2239
 msgid "Group"
 msgstr "Group"
 
@@ -1266,7 +1271,7 @@ msgid "Hang up"
 msgstr "Hang up"
 
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/PluginsOverlay.tsx:373
+#: src/pages/PluginsOverlay.tsx:400
 msgid "Header name"
 msgstr "Header name"
 
@@ -1282,15 +1287,15 @@ msgstr "Hear a sample"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hi, this is how I'll sound when I read replies out loud."
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4630
 msgid "High"
 msgstr "High"
 
-#: src/pages/Shell.tsx:3419
+#: src/pages/Shell.tsx:3438
 msgid "Hold to talk"
 msgstr "Hold to talk"
 
-#: src/pages/Shell.tsx:3419
+#: src/pages/Shell.tsx:3438
 msgid "Hold to talk (on-device dictation)"
 msgstr "Hold to talk (on-device dictation)"
 
@@ -1310,7 +1315,7 @@ msgstr "How often"
 msgid "How to check"
 msgstr "How to check"
 
-#: src/pages/Shell.tsx:3697
+#: src/pages/Shell.tsx:3716
 msgid "I’m done"
 msgstr "I’m done"
 
@@ -1318,11 +1323,11 @@ msgstr "I’m done"
 msgid "If you heard that, voice is ready."
 msgstr "If you heard that, voice is ready."
 
-#: src/pages/PluginsOverlay.tsx:331
+#: src/pages/PluginsOverlay.tsx:358
 msgid "Import OpenAPI JSON"
 msgstr "Import OpenAPI JSON"
 
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4517
 msgid "Inherit default"
 msgstr "Inherit default"
 
@@ -1334,12 +1339,12 @@ msgstr "Inputs"
 msgid "Instance API key"
 msgstr "Instance API key"
 
-#: src/pages/Shell.tsx:2503
+#: src/pages/Shell.tsx:2522
 msgid "Instruction"
 msgstr "Instruction"
 
-#: src/pages/PluginsOverlay.tsx:208
-#: src/pages/Shell.tsx:1953
+#: src/pages/PluginsOverlay.tsx:211
+#: src/pages/Shell.tsx:1956
 msgid "Integrations"
 msgstr "Integrations"
 
@@ -1360,15 +1365,15 @@ msgid "Interval unit"
 msgstr "Interval unit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4495
+#: src/pages/Shell.tsx:4518
 msgid "Isolated"
 msgstr "Isolated"
 
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4859
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3812
 msgid "Jump to replied message"
 msgstr "Jump to replied message"
 
@@ -1376,7 +1381,7 @@ msgstr "Jump to replied message"
 msgid "just now"
 msgstr "just now"
 
-#: src/pages/Shell.tsx:4849
+#: src/pages/Shell.tsx:4877
 msgid "Keep memories"
 msgstr "Keep memories"
 
@@ -1394,7 +1399,7 @@ msgstr "Language"
 msgid "Listening…"
 msgstr "Listening…"
 
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3036
 msgid "Load earlier messages"
 msgstr "Load earlier messages"
 
@@ -1402,7 +1407,7 @@ msgstr "Load earlier messages"
 msgid "Loading activity…"
 msgstr "Loading activity…"
 
-#: src/pages/PluginsOverlay.tsx:233
+#: src/pages/PluginsOverlay.tsx:237
 msgid "Loading integrations…"
 msgstr "Loading integrations…"
 
@@ -1434,7 +1439,7 @@ msgstr "Loading voice providers…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3036
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -1442,11 +1447,11 @@ msgstr "Loading…"
 msgid "Local"
 msgstr "Local"
 
-#: src/pages/Shell.tsx:2039
+#: src/pages/Shell.tsx:2042
 msgid "Log out"
 msgstr "Log out"
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4628
 msgid "Low"
 msgstr "Low"
 
@@ -1462,17 +1467,17 @@ msgstr "Mark as Read"
 msgid "Mark as Unread"
 msgstr "Mark as Unread"
 
-#: src/pages/Shell.tsx:4604
+#: src/pages/Shell.tsx:4632
 msgid "Max"
 msgstr "Max"
 
 #: src/pages/McpServersOverlay.tsx:224
 #: src/pages/McpServersOverlay.tsx:229
-#: src/pages/PluginsOverlay.tsx:305
+#: src/pages/PluginsOverlay.tsx:332
 msgid "MCP servers"
 msgstr "MCP servers"
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4629
 msgid "Medium"
 msgstr "Medium"
 
@@ -1485,33 +1490,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:2000
 msgid "Memory"
 msgstr "Memory"
 
-#: src/pages/Shell.tsx:4490
+#: src/pages/Shell.tsx:4513
 msgid "Memory scope"
 msgstr "Memory scope"
 
-#: src/pages/Shell.tsx:3497
-#: src/pages/Shell.tsx:3592
+#: src/pages/Shell.tsx:3516
+#: src/pages/Shell.tsx:3611
 msgid "Message"
 msgstr "Message"
 
-#: src/pages/Shell.tsx:3493
-#: src/pages/Shell.tsx:3497
+#: src/pages/Shell.tsx:3512
+#: src/pages/Shell.tsx:3516
 msgid "Message {activeName}"
 msgstr "Message {activeName}"
 
-#: src/pages/Shell.tsx:3871
+#: src/pages/Shell.tsx:3890
 msgid "Message from {peer}"
 msgstr "Message from {peer}"
 
-#: src/pages/Shell.tsx:3494
+#: src/pages/Shell.tsx:3513
 msgid "Message…"
 msgstr "Message…"
 
-#: src/pages/Shell.tsx:3871
+#: src/pages/Shell.tsx:3890
 msgid "Messaged {peer}"
 msgstr "Messaged {peer}"
 
@@ -1519,7 +1524,7 @@ msgstr "Messaged {peer}"
 msgid "Microphone failed"
 msgstr "Microphone failed"
 
-#: src/pages/Shell.tsx:4603
+#: src/pages/Shell.tsx:4631
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1541,7 +1546,7 @@ msgstr "minutes"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4446
+#: src/pages/Shell.tsx:4469
 msgid "Model"
 msgstr "Model"
 
@@ -1563,7 +1568,7 @@ msgid "Model updated."
 msgstr "Model updated."
 
 #: src/pages/ModelSettingsOverlay.tsx:303
-#: src/pages/Shell.tsx:1984
+#: src/pages/Shell.tsx:1987
 msgid "Models"
 msgstr "Models"
 
@@ -1581,7 +1586,7 @@ msgstr "Monthly"
 msgid "Move {0} to section"
 msgstr "Move {0} to section"
 
-#: src/pages/Shell.tsx:4852
+#: src/pages/Shell.tsx:4880
 msgid "Move them to your shared memory."
 msgstr "Move them to your shared memory."
 
@@ -1594,15 +1599,15 @@ msgstr "Move to"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4241
-#: src/pages/Shell.tsx:4405
-#: src/pages/Shell.tsx:4678
+#: src/pages/Shell.tsx:2514
+#: src/pages/Shell.tsx:4260
+#: src/pages/Shell.tsx:4428
+#: src/pages/Shell.tsx:4706
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4246
+#: src/pages/Shell.tsx:4265
 msgid "Name this bot"
 msgstr "Name this bot"
 
@@ -1618,13 +1623,13 @@ msgstr "Needs input"
 msgid "Needs takeover"
 msgstr "Needs takeover"
 
-#: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:1744
+#: src/pages/Shell.tsx:4248
 msgid "New bot"
 msgstr "New bot"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1751
+#: src/pages/Shell.tsx:1754
 msgid "New group"
 msgstr "New group"
 
@@ -1632,29 +1637,29 @@ msgstr "New group"
 msgid "New open-work item"
 msgstr "New open-work item"
 
-#: src/pages/Shell.tsx:2385
+#: src/pages/Shell.tsx:2400
 msgid "New routine"
 msgstr "New routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4672
+#: src/pages/Shell.tsx:4700
 msgid "New section"
 msgstr "New section"
 
-#: src/pages/PluginsOverlay.tsx:244
+#: src/pages/PluginsOverlay.tsx:248
 msgid "No apps match your search."
 msgstr "No apps match your search."
 
-#: src/pages/PluginsOverlay.tsx:443
+#: src/pages/PluginsOverlay.tsx:470
 msgid "no auth"
 msgstr "no auth"
 
-#: src/pages/PluginsOverlay.tsx:359
+#: src/pages/PluginsOverlay.tsx:386
 msgid "No authentication"
 msgstr "No authentication"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:139
+#: src/pages/PluginsOverlay.tsx:142
 msgid "No connection record found for {0}."
 msgstr "No connection record found for {0}."
 
@@ -1670,11 +1675,11 @@ msgstr "No exceptions. Actions run automatically."
 msgid "No longer active"
 msgstr "No longer active"
 
-#: src/pages/PluginsOverlay.tsx:239
+#: src/pages/PluginsOverlay.tsx:243
 msgid "No managed app catalog is configured on this deployment."
 msgstr "No managed app catalog is configured on this deployment."
 
-#: src/pages/PluginsOverlay.tsx:425
+#: src/pages/PluginsOverlay.tsx:452
 msgid "No MCP or API tool sources installed yet."
 msgstr "No MCP or API tool sources installed yet."
 
@@ -1707,7 +1712,7 @@ msgstr "Not configured"
 msgid "Not connected"
 msgstr "Not connected"
 
-#: src/pages/Shell.tsx:5337
+#: src/pages/Shell.tsx:5365
 msgid "Not now"
 msgstr "Not now"
 
@@ -1745,15 +1750,15 @@ msgstr "on the 1st at {0}"
 msgid "Open"
 msgstr "Open"
 
-#: src/pages/Shell.tsx:2295
+#: src/pages/Shell.tsx:2298
 msgid "Open computer"
 msgstr "Open computer"
 
-#: src/pages/Shell.tsx:2265
+#: src/pages/Shell.tsx:2268
 msgid "Open in full window"
 msgstr "Open in full window"
 
-#: src/pages/Shell.tsx:2063
+#: src/pages/Shell.tsx:2066
 msgid "Open navigation"
 msgstr "Open navigation"
 
@@ -1770,7 +1775,7 @@ msgstr "Open work"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-compatible server URL"
 
-#: src/pages/Shell.tsx:3996
+#: src/pages/Shell.tsx:4015
 msgid "Opened its thread."
 msgstr "Opened its thread."
 
@@ -1853,7 +1858,7 @@ msgstr "Playing…"
 msgid "Preview {0}"
 msgstr "Preview {0}"
 
-#: src/pages/Shell.tsx:4184
+#: src/pages/Shell.tsx:4203
 msgid "Private"
 msgstr "Private"
 
@@ -1870,11 +1875,11 @@ msgstr "Providers"
 msgid "Queued"
 msgstr "Queued"
 
-#: src/pages/PluginsOverlay.tsx:388
+#: src/pages/PluginsOverlay.tsx:415
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4545
 msgid "Read replies aloud"
 msgstr "Read replies aloud"
 
@@ -1896,29 +1901,41 @@ msgstr "Reconnecting"
 msgid "Recording: {0}"
 msgstr "Recording: {0}"
 
-#: src/pages/Shell.tsx:3687
+#: src/components/ComputerMaintenanceActions.tsx:57
+msgid "Recover computer"
+msgstr "Recover computer"
+
+#: src/components/ComputerMaintenanceActions.tsx:79
+msgid "Recover replaces an unreachable computer and keeps files in the saved workspace. Reset restores the last saved workspace and loses unsaved work. Update rebuilds with the latest image and keeps the saved workspace."
+msgstr "Recover replaces an unreachable computer and keeps files in the saved workspace. Reset restores the last saved workspace and loses unsaved work. Update rebuilds with the latest image and keeps the saved workspace."
+
+#: src/components/ComputerMaintenanceActions.tsx:57
+msgid "Recovering…"
+msgstr "Recovering…"
+
+#: src/pages/Shell.tsx:3706
 msgid "Release"
 msgstr "Release"
 
 #: src/components/ApprovalRulesSettings.tsx:138
-#: src/pages/PluginsOverlay.tsx:279
-#: src/pages/PluginsOverlay.tsx:454
+#: src/pages/PluginsOverlay.tsx:290
+#: src/pages/PluginsOverlay.tsx:481
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3301
+#: src/pages/Shell.tsx:3320
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3456
+#: src/pages/Shell.tsx:3475
 msgid "Remove mention {0}"
 msgstr "Remove mention {0}"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3435
+#: src/pages/Shell.tsx:3454
 msgid "Remove skill {0}"
 msgstr "Remove skill {0}"
 
@@ -1926,7 +1943,7 @@ msgstr "Remove skill {0}"
 msgid "Remove this schedule"
 msgstr "Remove this schedule"
 
-#: src/pages/Shell.tsx:3995
+#: src/pages/Shell.tsx:4014
 msgid "Removed with chat, computer, and memory."
 msgstr "Removed with chat, computer, and memory."
 
@@ -1934,8 +1951,8 @@ msgstr "Removed with chat, computer, and memory."
 msgid "Removed, but list refresh failed"
 msgstr "Removed, but list refresh failed"
 
-#: src/pages/PluginsOverlay.tsx:274
-#: src/pages/PluginsOverlay.tsx:454
+#: src/pages/PluginsOverlay.tsx:285
+#: src/pages/PluginsOverlay.tsx:481
 msgid "Removing…"
 msgstr "Removing…"
 
@@ -1953,17 +1970,38 @@ msgstr "Replace API key"
 msgid "Replace key"
 msgstr "Replace key"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3652
 msgid "Reply"
 msgstr "Reply"
 
-#: src/pages/Shell.tsx:3264
+#: src/pages/Shell.tsx:3283
 msgid "Replying to {replyName}"
 msgstr "Replying to {replyName}"
 
-#: src/pages/Shell.tsx:1928
+#: src/components/ComputerMaintenanceActions.tsx:115
+msgid "Reset"
+msgstr "Reset"
+
+#: src/components/ComputerMaintenanceActions.tsx:68
+msgid "Reset computer"
+msgstr "Reset computer"
+
+#: src/components/ComputerMaintenanceActions.tsx:97
+msgid "Reset computer?"
+msgstr "Reset computer?"
+
+#: src/components/ComputerMaintenanceActions.tsx:68
+#: src/components/ComputerMaintenanceActions.tsx:115
+msgid "Resetting…"
+msgstr "Resetting…"
+
+#: src/pages/Shell.tsx:1931
 msgid "Restore"
 msgstr "Restore"
+
+#: src/components/ComputerMaintenanceActions.tsx:103
+msgid "Restore the last saved workspace. Unsaved work on the computer is lost."
+msgstr "Restore the last saved workspace. Unsaved work on the computer is lost."
 
 #: src/App.tsx:135
 msgid "Retry now"
@@ -1973,17 +2011,17 @@ msgstr "Retry now"
 msgid "Return to Rakazo"
 msgstr "Return to Rakazo"
 
-#: src/pages/Shell.tsx:2488
-#: src/pages/Shell.tsx:2541
-#: src/pages/Shell.tsx:2548
+#: src/pages/Shell.tsx:2507
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:2567
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Routines"
 msgstr "Routines"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2630
 msgid "Run now"
 msgstr "Run now"
 
@@ -1991,11 +2029,11 @@ msgstr "Run now"
 msgid "Running"
 msgstr "Running"
 
-#: src/pages/Shell.tsx:2370
+#: src/pages/Shell.tsx:2385
 msgid "Running · Stop"
 msgstr "Running · Stop"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2630
 msgid "Running…"
 msgstr "Running…"
 
@@ -2003,8 +2041,8 @@ msgstr "Running…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:4600
 msgid "Save"
 msgstr "Save"
 
@@ -2028,7 +2066,7 @@ msgstr "Saved."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2606
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2041,11 +2079,12 @@ msgstr "Say something. Silence sends it."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "Say yes or no, or answer in a sentence."
 
-#: src/pages/Shell.tsx:1762
+#: src/pages/Shell.tsx:1765
 msgid "Search"
 msgstr "Search"
 
-#: src/pages/PluginsOverlay.tsx:224
+#: src/pages/PluginsOverlay.tsx:227
+#: src/pages/PluginsOverlay.tsx:228
 msgid "Search apps"
 msgstr "Search apps"
 
@@ -2063,11 +2102,11 @@ msgstr "Search providers and models"
 msgid "Searching…"
 msgstr "Searching…"
 
-#: src/pages/Shell.tsx:2087
+#: src/pages/Shell.tsx:2090
 msgid "Select a bot"
 msgstr "Select a bot"
 
-#: src/pages/Shell.tsx:3517
+#: src/pages/Shell.tsx:3536
 msgid "Send"
 msgstr "Send"
 
@@ -2095,22 +2134,22 @@ msgstr "Server name"
 msgid "Server URL"
 msgstr "Server URL"
 
-#: src/pages/Shell.tsx:2096
+#: src/pages/Shell.tsx:2099
 msgid "Set up voice to call"
 msgstr "Set up voice to call"
 
 #: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1961
-#: src/pages/Shell.tsx:1971
-#: src/pages/Shell.tsx:2232
+#: src/pages/Shell.tsx:1964
+#: src/pages/Shell.tsx:1974
+#: src/pages/Shell.tsx:2235
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3554
 msgid "Settings: General"
 msgstr "Settings: General"
 
-#: src/pages/Shell.tsx:3537
+#: src/pages/Shell.tsx:3556
 msgid "Settings: Usage"
 msgstr "Settings: Usage"
 
@@ -2120,15 +2159,15 @@ msgid "Setup help"
 msgstr "Setup help"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4496
+#: src/pages/Shell.tsx:4519
 msgid "Shared"
 msgstr "Shared"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2246
 msgid "Show computer"
 msgstr "Show computer"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2246
 msgid "Show settings"
 msgstr "Show settings"
 
@@ -2152,11 +2191,11 @@ msgid "Sign up"
 msgstr "Sign up"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3367
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3694
+#: src/pages/Shell.tsx:3713
 msgid "Skip"
 msgstr "Skip"
 
@@ -2169,7 +2208,7 @@ msgid "Skip or deploy key"
 msgstr "Skip or deploy key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1287
+#: src/pages/Shell.tsx:1289
 msgid "Skipped {0}"
 msgstr "Skipped {0}"
 
@@ -2177,8 +2216,8 @@ msgstr "Skipped {0}"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space interrupts · Esc hangs up"
 
-#: src/pages/Shell.tsx:3840
-#: src/pages/Shell.tsx:4093
+#: src/pages/Shell.tsx:3859
+#: src/pages/Shell.tsx:4112
 msgid "Speak"
 msgstr "Speak"
 
@@ -2190,8 +2229,8 @@ msgstr "Speak + transcribe"
 msgid "Speak only"
 msgstr "Speak only"
 
-#: src/pages/Shell.tsx:3836
-#: src/pages/Shell.tsx:4089
+#: src/pages/Shell.tsx:3855
+#: src/pages/Shell.tsx:4108
 msgid "Speak this reply"
 msgstr "Speak this reply"
 
@@ -2217,20 +2256,20 @@ msgstr "Starting…"
 msgid "Steps"
 msgstr "Steps"
 
-#: src/pages/Shell.tsx:2866
-#: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3508
-#: src/pages/Shell.tsx:3840
-#: src/pages/Shell.tsx:4093
+#: src/pages/Shell.tsx:2885
+#: src/pages/Shell.tsx:2889
+#: src/pages/Shell.tsx:3527
+#: src/pages/Shell.tsx:3859
+#: src/pages/Shell.tsx:4112
 msgid "Stop"
 msgstr "Stop"
 
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3419
 msgid "Stop dictation"
 msgstr "Stop dictation"
 
-#: src/pages/Shell.tsx:3836
-#: src/pages/Shell.tsx:4089
+#: src/pages/Shell.tsx:3855
+#: src/pages/Shell.tsx:4108
 msgid "Stop speaking"
 msgstr "Stop speaking"
 
@@ -2239,8 +2278,8 @@ msgstr "Stop speaking"
 msgid "Stop teaching"
 msgstr "Stop teaching"
 
-#: src/pages/Shell.tsx:2322
-#: src/pages/Shell.tsx:2886
+#: src/pages/Shell.tsx:2325
+#: src/pages/Shell.tsx:2905
 msgid "Stop the bot first"
 msgstr "Stop the bot first"
 
@@ -2248,7 +2287,7 @@ msgstr "Stop the bot first"
 msgid "Stored encrypted"
 msgstr "Stored encrypted"
 
-#: src/pages/Shell.tsx:3947
+#: src/pages/Shell.tsx:3966
 msgid "subagent"
 msgstr "subagent"
 
@@ -2261,8 +2300,8 @@ msgstr "Submit"
 msgid "Switching…"
 msgstr "Switching…"
 
-#: src/pages/Shell.tsx:2325
-#: src/pages/Shell.tsx:2891
+#: src/pages/Shell.tsx:2328
+#: src/pages/Shell.tsx:2910
 msgid "Take control"
 msgstr "Take control"
 
@@ -2270,7 +2309,7 @@ msgstr "Take control"
 msgid "Teach a task"
 msgstr "Teach a task"
 
-#: src/pages/Shell.tsx:2158
+#: src/pages/Shell.tsx:2161
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Teaching in progress — stop teaching before sending a new message."
 
@@ -2278,11 +2317,11 @@ msgstr "Teaching in progress — stop teaching before sending a new message."
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 
-#: src/pages/Shell.tsx:4184
+#: src/pages/Shell.tsx:4203
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:5046
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -2295,20 +2334,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "The selected memory provider is not available in this build."
 
-#: src/pages/Shell.tsx:4473
+#: src/pages/Shell.tsx:4496
 msgid "Thinking"
 msgstr "Thinking"
 
-#: src/pages/Shell.tsx:2269
+#: src/pages/Shell.tsx:2272
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:2934
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 
-#: src/pages/Shell.tsx:4868
-#: src/pages/Shell.tsx:4945
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4973
 msgid "This cannot be undone."
 msgstr "This cannot be undone."
 
@@ -2332,7 +2371,7 @@ msgstr "this Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 
-#: src/pages/Shell.tsx:4753
+#: src/pages/Shell.tsx:4781
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 
@@ -2340,7 +2379,7 @@ msgstr "This permanently removes every message and stops current work. The bot, 
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "This provider cannot paste a key here. Skip if this deployment already has credentials."
 
-#: src/pages/Shell.tsx:5285
+#: src/pages/Shell.tsx:5313
 msgid "This server cannot be assigned without a bot."
 msgstr "This server cannot be assigned without a bot."
 
@@ -2352,7 +2391,7 @@ msgstr "This server did not request browser authorization."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "This server is already connected. Disconnect it first to authorize again."
 
-#: src/pages/Shell.tsx:5324
+#: src/pages/Shell.tsx:5352
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 
@@ -2365,16 +2404,16 @@ msgid "Time of day"
 msgstr "Time of day"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4251
-#: src/pages/Shell.tsx:4414
+#: src/pages/Shell.tsx:4270
+#: src/pages/Shell.tsx:4437
 msgid "Title"
 msgstr "Title"
 
-#: src/pages/PluginsOverlay.tsx:421
+#: src/pages/PluginsOverlay.tsx:448
 msgid "Tool sources"
 msgstr "Tool sources"
 
-#: src/pages/PluginsOverlay.tsx:383
+#: src/pages/PluginsOverlay.tsx:410
 msgid "Treg token"
 msgstr "Treg token"
 
@@ -2391,12 +2430,20 @@ msgid "Unpin"
 msgstr "Unpin"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1351
+#: src/pages/Shell.tsx:1353
 msgid "Unsupported file type: {0}"
 msgstr "Unsupported file type: {0}"
 
+#: src/components/ComputerMaintenanceActions.tsx:73
+msgid "Update computer"
+msgstr "Update computer"
+
+#: src/components/ComputerMaintenanceActions.tsx:73
+msgid "Updating…"
+msgstr "Updating…"
+
 #: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2022
+#: src/pages/Shell.tsx:2025
 msgid "Usage"
 msgstr "Usage"
 
@@ -2413,16 +2460,16 @@ msgstr "Use a found model"
 msgid "Use this model"
 msgstr "Use this model"
 
-#: src/pages/PluginsOverlay.tsx:404
+#: src/pages/PluginsOverlay.tsx:431
 msgid "Verify and add"
 msgstr "Verify and add"
 
-#: src/pages/PluginsOverlay.tsx:402
+#: src/pages/PluginsOverlay.tsx:429
 msgid "Verifying…"
 msgstr "Verifying…"
 
-#: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4526
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:4549
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2435,7 +2482,7 @@ msgstr "Voice"
 msgid "Waiting for sign-in…"
 msgstr "Waiting for sign-in…"
 
-#: src/pages/Shell.tsx:5168
+#: src/pages/Shell.tsx:5196
 msgid "Waiting…"
 msgstr "Waiting…"
 
@@ -2444,7 +2491,7 @@ msgstr "Waiting…"
 msgid "Weekdays"
 msgstr "Weekdays"
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4866
 msgid "What about its memories?"
 msgstr "What about its memories?"
 
@@ -2453,7 +2500,7 @@ msgid "What result will you demonstrate?"
 msgstr "What result will you demonstrate?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4266
+#: src/pages/Shell.tsx:4285
 msgid "What this bot is for"
 msgstr "What this bot is for"
 
@@ -2465,7 +2512,7 @@ msgstr "What to return"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 
-#: src/pages/Shell.tsx:2512
+#: src/pages/Shell.tsx:2531
 msgid "When to run"
 msgstr "When to run"
 
@@ -2482,12 +2529,12 @@ msgstr "Where should bots run?"
 msgid "Working…"
 msgstr "Working…"
 
-#: src/pages/Shell.tsx:4456
+#: src/pages/Shell.tsx:4479
 msgid "Workspace default"
 msgstr "Workspace default"
 
-#: src/pages/Shell.tsx:1100
-#: src/pages/Shell.tsx:1672
+#: src/pages/Shell.tsx:1102
+#: src/pages/Shell.tsx:1675
 msgid "You"
 msgstr "You"
 
@@ -2499,8 +2546,8 @@ msgstr "You can close this tab if it does not redirect automatically."
 msgid "You can close this window."
 msgstr "You can close this window."
 
-#: src/pages/Shell.tsx:2302
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2305
+#: src/pages/Shell.tsx:2875
 msgid "You have control"
 msgstr "You have control"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1823
+#: src/pages/Shell.tsx:1826
 msgid " (unread)"
 msgstr " (읽지 않음)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {모델 #개} other {모델 #개}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1267
+#: src/pages/Shell.tsx:1269
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (첨부 파일 최대 {ATTACHMENT_MAX_COUNT}개)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1271
+#: src/pages/Shell.tsx:1273
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB 초과)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5141
+#: src/pages/Shell.tsx:5169
 msgid "{0} connection"
 msgstr "{0} 연결"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2306
+#: src/pages/Shell.tsx:2309
 msgid "{0} is using it"
 msgstr "{0}가 사용 중"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2030
 msgid "{0} runs · {1} tokens"
 msgstr "{0}회 실행 · 토큰 {1}개"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {동료 Bot #개} other {동료 Bot #개}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName}은 아직 다른 Bot에게 메시지를 보내지 않았습니다."
 
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:5046
 msgid "{botName}’s computer"
 msgstr "{botName}의 컴퓨터"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3320
+#: src/pages/Shell.tsx:3339
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "액세스 토큰(선택 사항)"
 msgid "Account"
 msgstr "계정"
 
-#: src/pages/Shell.tsx:4532
+#: src/pages/Shell.tsx:4555
 msgid "Account default"
 msgstr "계정 기본값"
 
@@ -156,12 +156,12 @@ msgstr "현재 모델"
 msgid "Active voice"
 msgstr "현재 목소리"
 
-#: src/pages/Shell.tsx:1707
-#: src/pages/Shell.tsx:1709
+#: src/pages/Shell.tsx:1710
+#: src/pages/Shell.tsx:1712
 msgid "Activity"
 msgstr "활동"
 
-#: src/pages/PluginsOverlay.tsx:281
+#: src/pages/PluginsOverlay.tsx:292
 #: src/pages/ScratchpadSection.tsx:188
 msgid "Add"
 msgstr "추가"
@@ -186,15 +186,15 @@ msgstr "HTTPS 서버 URL을 입력하세요."
 msgid "Add item"
 msgstr "항목 추가"
 
-#: src/pages/PluginsOverlay.tsx:311
+#: src/pages/PluginsOverlay.tsx:338
 msgid "Add MCP server"
 msgstr "MCP 서버 추가"
 
-#: src/pages/PluginsOverlay.tsx:314
+#: src/pages/PluginsOverlay.tsx:341
 msgid "Add OpenAPI"
 msgstr "OpenAPI 추가"
 
-#: src/pages/PluginsOverlay.tsx:329
+#: src/pages/PluginsOverlay.tsx:356
 msgid "Add remote MCP server"
 msgstr "원격 MCP 서버 추가"
 
@@ -207,19 +207,19 @@ msgstr "서버 추가"
 msgid "Add to routine"
 msgstr "자동 실행에 추가"
 
-#: src/pages/PluginsOverlay.tsx:317
+#: src/pages/PluginsOverlay.tsx:344
 msgid "Add Treg"
 msgstr "Treg 추가"
 
 #: src/pages/McpServersOverlay.tsx:363
-#: src/pages/PluginsOverlay.tsx:276
+#: src/pages/PluginsOverlay.tsx:287
 msgid "Adding…"
 msgstr "추가 중…"
 
 #: src/pages/AccountSettingsOverlay.tsx:138
-#: src/pages/PluginsOverlay.tsx:291
+#: src/pages/PluginsOverlay.tsx:318
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4458
 msgid "Advanced"
 msgstr "고급 설정"
 
@@ -227,7 +227,7 @@ msgstr "고급 설정"
 msgid "Agent access for new servers"
 msgstr "새 서버를 사용할 Bot"
 
-#: src/pages/Shell.tsx:2114
+#: src/pages/Shell.tsx:2117
 msgid "Agent computer"
 msgstr "Agent 컴퓨터"
 
@@ -302,7 +302,7 @@ msgstr "응답: {answer}"
 msgid "API key"
 msgstr "API 키"
 
-#: src/pages/PluginsOverlay.tsx:365
+#: src/pages/PluginsOverlay.tsx:392
 msgid "API key header"
 msgstr "API 키 헤더"
 
@@ -314,11 +314,11 @@ msgstr "서버를 추가할 때 적용됩니다. 각 서버 카드의 Bot 버튼
 msgid "Approval boundaries"
 msgstr "승인이 필요한 범위"
 
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5362
 msgid "Approve"
 msgstr "승인"
 
-#: src/pages/Shell.tsx:5325
+#: src/pages/Shell.tsx:5353
 msgid "Approve this server to let your agent use its tools."
 msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 있습니다."
 
@@ -326,15 +326,15 @@ msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 �
 msgid "Archive"
 msgstr "보관"
 
-#: src/pages/Shell.tsx:3983
+#: src/pages/Shell.tsx:4002
 msgid "archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:1907
+#: src/pages/Shell.tsx:1910
 msgid "Archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4013
 msgid "Archived. Chat, memory, and files kept."
 msgstr "보관되었습니다. 대화, 기억, 파일은 유지됩니다."
 
@@ -373,7 +373,7 @@ msgstr "결제하기 전에 확인"
 msgid "Ask before sending external email"
 msgstr "외부 이메일을 보내기 전에 확인"
 
-#: src/pages/Shell.tsx:2308
+#: src/pages/Shell.tsx:2311
 msgid "Asleep"
 msgstr "절전 중"
 
@@ -388,11 +388,11 @@ msgstr "{0}에"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}에"
 
-#: src/pages/Shell.tsx:3391
+#: src/pages/Shell.tsx:3410
 msgid "Attach file"
 msgstr "파일 첨부"
 
-#: src/pages/Shell.tsx:3590
+#: src/pages/Shell.tsx:3609
 msgid "Attachment"
 msgstr "첨부 파일"
 
@@ -405,12 +405,12 @@ msgstr "인증 코드 또는 돌아온 페이지 주소"
 msgid "Authorization expired — reconnect required"
 msgstr "인증이 만료됨 — 다시 연결해야 함"
 
-#: src/pages/Shell.tsx:5126
+#: src/pages/Shell.tsx:5154
 msgid "Authorization timed out. Please try again."
 msgstr "인증 시간이 만료되었습니다. 다시 시도해 주세요."
 
-#: src/pages/Shell.tsx:5168
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5196
+#: src/pages/Shell.tsx:5362
 msgid "Authorize"
 msgstr "인증하기"
 
@@ -418,26 +418,26 @@ msgstr "인증하기"
 msgid "Base URL"
 msgstr "서버 주소"
 
-#: src/pages/PluginsOverlay.tsx:362
+#: src/pages/PluginsOverlay.tsx:389
 msgid "Bearer token"
 msgstr "Bearer 토큰"
 
-#: src/pages/Shell.tsx:5010
+#: src/pages/Shell.tsx:5038
 msgid "Booting live desktop…"
 msgstr "라이브 데스크톱 시작 중…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2850
 msgid "Booting up {0}’s computer"
 msgstr "{0}의 컴퓨터를 켜는 중"
 
-#: src/pages/Shell.tsx:3853
-#: src/pages/Shell.tsx:3854
-#: src/pages/Shell.tsx:3987
+#: src/pages/Shell.tsx:3872
+#: src/pages/Shell.tsx:3873
+#: src/pages/Shell.tsx:4006
 msgid "bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:1101
+#: src/pages/Shell.tsx:1103
 msgid "Bot"
 msgstr "봇"
 
@@ -445,11 +445,11 @@ msgstr "봇"
 msgid "Bot messages"
 msgstr "Bot 메시지"
 
-#: src/pages/Shell.tsx:2923
+#: src/pages/Shell.tsx:2942
 msgid "Bot screen"
 msgstr "Bot 화면"
 
-#: src/pages/Shell.tsx:2276
+#: src/pages/Shell.tsx:2279
 msgid "Bot screen preview"
 msgstr "Bot 화면 미리보기"
 
@@ -462,8 +462,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "사용 중인 서비스의 API 키를 연결하세요. 서비스를 바꿔도 Bot의 읽기·통화 기능은 그대로 유지됩니다."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2096
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2099
+#: src/pages/Shell.tsx:2100
 msgid "Call"
 msgstr "통화"
 
@@ -472,16 +472,17 @@ msgid "Can't reach the server."
 msgstr "서버에 연결할 수 없습니다."
 
 #: src/components/AskCard.tsx:129
+#: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
-#: src/pages/PluginsOverlay.tsx:413
-#: src/pages/Shell.tsx:4694
-#: src/pages/Shell.tsx:4766
-#: src/pages/Shell.tsx:4881
-#: src/pages/Shell.tsx:4955
+#: src/pages/PluginsOverlay.tsx:440
+#: src/pages/Shell.tsx:4722
+#: src/pages/Shell.tsx:4794
+#: src/pages/Shell.tsx:4909
+#: src/pages/Shell.tsx:4983
 msgid "Cancel"
 msgstr "취소"
 
-#: src/pages/Shell.tsx:4231
+#: src/pages/Shell.tsx:4250
 msgid "Cancel new bot"
 msgstr "새 Bot 만들기 취소"
 
@@ -489,7 +490,7 @@ msgstr "새 Bot 만들기 취소"
 msgid "Cancel new group"
 msgstr "새 그룹 만들기 취소"
 
-#: src/pages/Shell.tsx:3267
+#: src/pages/Shell.tsx:3286
 msgid "Cancel reply"
 msgstr "답장 취소"
 
@@ -497,16 +498,16 @@ msgstr "답장 취소"
 msgid "Cancelled"
 msgstr "취소됨"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5259
 msgid "Chart failed to render: {error}"
 msgstr "차트를 표시하지 못했습니다: {error}"
 
-#: src/pages/Shell.tsx:3533
+#: src/pages/Shell.tsx:3552
 msgid "Chat Settings"
 msgstr "채팅 설정"
 
-#: src/pages/Shell.tsx:2542
-#: src/pages/Shell.tsx:2549
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:2568
 msgid "Check in."
 msgstr "확인해 주세요."
 
@@ -518,21 +519,21 @@ msgstr "먼저 사용할 AI 모델을 선택하세요."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo에서 기본으로 사용할 연결된 모델을 선택하세요."
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4809
 msgid "Clear"
 msgstr "비우기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4775
 msgid "Clear {0}’s conversation?"
 msgstr "{0}와의 대화 내용을 비울까요?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4587
+#: src/pages/Shell.tsx:4610
 msgid "Clear conversation"
 msgstr "대화 내용 비우기"
 
-#: src/pages/Shell.tsx:4781
+#: src/pages/Shell.tsx:4809
 msgid "Clearing…"
 msgstr "비우는 중…"
 
@@ -548,19 +549,19 @@ msgstr "Bot 메뉴 닫기"
 msgid "Close bot messages"
 msgstr "Bot 메시지 닫기"
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5444
 msgid "Close chart"
 msgstr "차트 닫기"
 
-#: src/pages/Shell.tsx:2897
+#: src/pages/Shell.tsx:2916
 msgid "Close computer"
 msgstr "컴퓨터 닫기"
 
-#: src/pages/Shell.tsx:5516
+#: src/pages/Shell.tsx:5544
 msgid "Close image preview"
 msgstr "이미지 미리보기 닫기"
 
-#: src/pages/PluginsOverlay.tsx:212
+#: src/pages/PluginsOverlay.tsx:215
 msgid "Close integrations"
 msgstr "앱·도구 연동 닫기"
 
@@ -576,11 +577,11 @@ msgstr "기억 설정 닫기"
 msgid "Close model settings"
 msgstr "AI 모델 설정 닫기"
 
-#: src/pages/Shell.tsx:1692
+#: src/pages/Shell.tsx:1695
 msgid "Close navigation"
 msgstr "메뉴 닫기"
 
-#: src/pages/Shell.tsx:2254
+#: src/pages/Shell.tsx:2257
 msgid "Close panel"
 msgstr "패널 닫기"
 
@@ -609,24 +610,24 @@ msgstr "실행 명령"
 msgid "Complete"
 msgstr "완료"
 
-#: src/pages/Shell.tsx:4141
-#: src/pages/Shell.tsx:4169
+#: src/pages/Shell.tsx:4160
+#: src/pages/Shell.tsx:4188
 msgid "Computer"
 msgstr "컴퓨터"
 
-#: src/pages/Shell.tsx:5013
+#: src/pages/Shell.tsx:5041
 msgid "Computer failed to boot"
 msgstr "컴퓨터를 시작하지 못했습니다"
 
-#: src/pages/Shell.tsx:2945
+#: src/pages/Shell.tsx:2964
 msgid "Computer is asleep"
 msgstr "컴퓨터가 절전 상태입니다"
 
-#: src/pages/Shell.tsx:5012
+#: src/pages/Shell.tsx:5040
 msgid "Computer is asleep — take control to wake it"
 msgstr "컴퓨터가 절전 상태입니다 — 제어를 맡아 깨우세요"
 
-#: src/pages/Shell.tsx:5014
+#: src/pages/Shell.tsx:5042
 msgid "Computer is stopped"
 msgstr "컴퓨터가 중지됨"
 
@@ -659,7 +660,7 @@ msgstr "API 키 연결"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI 또는 Cartesia 연결"
 
-#: src/pages/Shell.tsx:5314
+#: src/pages/Shell.tsx:5342
 msgid "Connect MCP server “{name}”"
 msgstr "MCP 서버 ‘{name}’ 연결"
 
@@ -675,19 +676,19 @@ msgstr "원격 또는 로컬 도구 서버를 연결하고 사용할 Bot을 선�
 msgid "Connect this provider to use it as your personal model."
 msgstr "이 AI 서비스를 연결하면 내 기본 모델로 사용할 수 있습니다."
 
-#: src/pages/PluginsOverlay.tsx:327
+#: src/pages/PluginsOverlay.tsx:354
 msgid "Connect Treg"
 msgstr "Treg 연결"
 
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:377
-#: src/pages/Shell.tsx:5165
+#: src/pages/Shell.tsx:5193
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "연결됨"
 
-#: src/pages/Shell.tsx:5344
+#: src/pages/Shell.tsx:5372
 msgid "Connected — its tools are available from your next message."
 msgstr "연결되었습니다. 다음 메시지부터 이 도구를 사용할 수 있습니다."
 
@@ -712,13 +713,13 @@ msgstr "{0}에 연결하고 기본 모델로 설정했습니다."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5334
+#: src/pages/Shell.tsx:5362
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "연결 중…"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:114
+#: src/pages/PluginsOverlay.tsx:116
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "{0} 연결이 아직 진행 중입니다. 이 창을 닫고 나중에 다시 확인할 수 있습니다."
 
@@ -731,7 +732,7 @@ msgstr "계속"
 msgid "Continue with email"
 msgstr "이메일로 계속하기"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3660
 msgid "Copy"
 msgstr "복사"
 
@@ -743,11 +744,11 @@ msgstr "추가하지 못했습니다."
 msgid "Could not add MCP server"
 msgstr "MCP 서버를 추가하지 못했습니다."
 
-#: src/pages/Shell.tsx:5301
+#: src/pages/Shell.tsx:5329
 msgid "Could not approve this server"
 msgstr "서버를 승인하지 못했습니다."
 
-#: src/pages/Shell.tsx:5129
+#: src/pages/Shell.tsx:5157
 msgid "Could not authorize this app"
 msgstr "앱 인증을 완료하지 못했습니다."
 
@@ -755,7 +756,7 @@ msgstr "앱 인증을 완료하지 못했습니다."
 msgid "Could not change the default model"
 msgstr "기본 모델을 변경하지 못했습니다."
 
-#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:4803
 msgid "Could not clear conversation"
 msgstr "대화 내용을 비우지 못했습니다."
 
@@ -763,7 +764,7 @@ msgstr "대화 내용을 비우지 못했습니다."
 msgid "Could not complete OAuth"
 msgstr "OAuth 인증을 완료하지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:117
+#: src/pages/PluginsOverlay.tsx:120
 msgid "Could not connect"
 msgstr "연결하지 못했습니다."
 
@@ -784,7 +785,7 @@ msgstr "음성 서비스에 연결하지 못했습니다."
 msgid "Could not continue"
 msgstr "계속 진행하지 못했습니다."
 
-#: src/pages/Shell.tsx:4219
+#: src/pages/Shell.tsx:4238
 msgid "Could not create bot"
 msgstr "Bot을 만들지 못했습니다."
 
@@ -792,7 +793,7 @@ msgstr "Bot을 만들지 못했습니다."
 msgid "Could not create group"
 msgstr "그룹을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4694
 msgid "Could not create section"
 msgstr "섹션을 만들지 못했습니다."
 
@@ -800,7 +801,7 @@ msgstr "섹션을 만들지 못했습니다."
 msgid "Could not create your bot"
 msgstr "Bot을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4890
+#: src/pages/Shell.tsx:4918
 msgid "Could not delete bot"
 msgstr "Bot을 삭제하지 못했습니다."
 
@@ -808,7 +809,7 @@ msgstr "Bot을 삭제하지 못했습니다."
 msgid "Could not delete MCP server"
 msgstr "MCP 서버를 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4964
+#: src/pages/Shell.tsx:4992
 msgid "Could not delete routine"
 msgstr "자동 실행을 삭제하지 못했습니다."
 
@@ -829,7 +830,7 @@ msgstr "{0}을 다운로드하지 못했습니다. 다시 시도해 주세요."
 msgid "Could not download {name}. Try again."
 msgstr "{name}을 다운로드하지 못했습니다. 다시 시도해 주세요."
 
-#: src/pages/PluginsOverlay.tsx:184
+#: src/pages/PluginsOverlay.tsx:187
 msgid "Could not install connector"
 msgstr "도구 연결을 추가하지 못했습니다."
 
@@ -837,7 +838,7 @@ msgstr "도구 연결을 추가하지 못했습니다."
 msgid "Could not load approval rules"
 msgstr "확인 규칙을 불러오지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:60
+#: src/pages/PluginsOverlay.tsx:61
 msgid "Could not load integrations"
 msgstr "연동 목록을 불러오지 못했습니다."
 
@@ -870,7 +871,7 @@ msgstr "모델 서버에 연결하지 못했습니다."
 msgid "Could not remove"
 msgstr "삭제하지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:197
+#: src/pages/PluginsOverlay.tsx:200
 msgid "Could not remove connector"
 msgstr "도구 연결을 삭제하지 못했습니다."
 
@@ -882,15 +883,15 @@ msgstr "그룹을 삭제하지 못했습니다."
 msgid "Could not remove rule"
 msgstr "확인 규칙을 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5249
 msgid "Could not render chart"
 msgstr "차트를 만들지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:143
+#: src/pages/PluginsOverlay.tsx:146
 msgid "Could not revoke connection"
 msgstr "연결을 해제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4572
+#: src/pages/Shell.tsx:4595
 msgid "Could not save"
 msgstr "저장하지 못했습니다."
 
@@ -902,7 +903,7 @@ msgstr "그룹을 저장하지 못했습니다."
 msgid "Could not save model"
 msgstr "AI 모델을 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:2564
+#: src/pages/Shell.tsx:2583
 msgid "Could not save routine"
 msgstr "자동 실행을 저장하지 못했습니다."
 
@@ -918,7 +919,7 @@ msgstr "선택 내용을 저장하지 못했습니다."
 msgid "Could not save that voice"
 msgstr "목소리를 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:5041
+#: src/pages/Shell.tsx:5069
 msgid "Could not save this choice"
 msgstr "선택 내용을 저장하지 못했습니다."
 
@@ -934,7 +935,7 @@ msgstr "OAuth 인증을 시작하지 못했습니다."
 msgid "Could not submit this answer"
 msgstr "답변을 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:1550
+#: src/pages/Shell.tsx:1552
 msgid "Could not take control"
 msgstr "직접 조작으로 전환하지 못했습니다."
 
@@ -946,18 +947,22 @@ msgstr "업데이트하지 못했습니다."
 msgid "Could not update agent access"
 msgstr "Bot의 서버 사용 권한을 변경하지 못했습니다."
 
+#: src/components/ComputerMaintenanceActions.tsx:46
+msgid "Could not update computer"
+msgstr ""
+
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "기본 기억 범위를 변경하지 못했습니다."
 
-#: src/pages/Shell.tsx:1727
-#: src/pages/Shell.tsx:4278
-#: src/pages/Shell.tsx:4701
+#: src/pages/Shell.tsx:1730
+#: src/pages/Shell.tsx:4297
+#: src/pages/Shell.tsx:4729
 msgid "Create"
 msgstr "만들기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4675
+#: src/pages/Shell.tsx:4703
 msgid "Create a section and move {0} into it."
 msgstr "새 섹션을 만들고 {0}을 옮깁니다."
 
@@ -978,16 +983,16 @@ msgid "Create your Rakazo"
 msgstr "Rakazo 계정 만들기"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4278
-#: src/pages/Shell.tsx:4701
+#: src/pages/Shell.tsx:4297
+#: src/pages/Shell.tsx:4729
 msgid "Creating…"
 msgstr "만드는 중…"
 
-#: src/pages/PluginsOverlay.tsx:383
+#: src/pages/PluginsOverlay.tsx:410
 msgid "Credential"
 msgstr "인증 정보"
 
-#: src/pages/PluginsOverlay.tsx:441
+#: src/pages/PluginsOverlay.tsx:468
 msgid "credential saved"
 msgstr "인증 정보 저장됨"
 
@@ -1007,7 +1012,7 @@ msgstr "일"
 msgid "days"
 msgstr "일"
 
-#: src/pages/Shell.tsx:4479
+#: src/pages/Shell.tsx:4502
 msgid "Default (medium)"
 msgstr "기본(보통)"
 
@@ -1017,21 +1022,21 @@ msgstr "기본 기억 범위"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1936
-#: src/pages/Shell.tsx:4896
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:1939
+#: src/pages/Shell.tsx:4924
+#: src/pages/Shell.tsx:4998
 msgid "Delete"
 msgstr "삭제"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1932
+#: src/pages/Shell.tsx:1935
 msgid "Delete {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4828
-#: src/pages/Shell.tsx:4942
+#: src/pages/Shell.tsx:4856
+#: src/pages/Shell.tsx:4970
 msgid "Delete {0}?"
 msgstr "{0}을 삭제할까요?"
 
@@ -1039,21 +1044,21 @@ msgstr "{0}을 삭제할까요?"
 msgid "Delete group"
 msgstr "그룹 삭제"
 
-#: src/pages/Shell.tsx:4865
+#: src/pages/Shell.tsx:4893
 msgid "Delete memories too"
 msgstr "기억도 함께 삭제"
 
-#: src/pages/Shell.tsx:2619
+#: src/pages/Shell.tsx:2638
 msgid "Delete routine"
 msgstr "자동 실행 삭제"
 
-#: src/pages/Shell.tsx:3985
+#: src/pages/Shell.tsx:4004
 msgid "deleted"
 msgstr "삭제됨"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4896
-#: src/pages/Shell.tsx:4970
+#: src/pages/Shell.tsx:4924
+#: src/pages/Shell.tsx:4998
 msgid "Deleting…"
 msgstr "삭제 중…"
 
@@ -1070,17 +1075,17 @@ msgid "Deployment default"
 msgstr "서버 기본값"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4256
+#: src/pages/Shell.tsx:4275
 msgid "Describe what this bot does"
 msgstr "이 Bot이 하는 일을 짧게 설명하세요"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4261
-#: src/pages/Shell.tsx:4423
+#: src/pages/Shell.tsx:4280
+#: src/pages/Shell.tsx:4446
 msgid "Description"
 msgstr "설명"
 
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3419
 msgid "Dictate"
 msgstr "음성 입력"
 
@@ -1093,11 +1098,11 @@ msgstr "연결 해제"
 msgid "Disconnecting…"
 msgstr "연결 해제 중…"
 
-#: src/pages/Shell.tsx:5349
+#: src/pages/Shell.tsx:5377
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "지금은 연결하지 않았습니다. MCP 설정에서 언제든 다시 연결할 수 있습니다."
 
-#: src/pages/PluginsOverlay.tsx:337
+#: src/pages/PluginsOverlay.tsx:364
 msgid "Display name"
 msgstr "표시 이름"
 
@@ -1193,11 +1198,11 @@ msgstr "매월"
 msgid "Every week"
 msgstr "매주"
 
-#: src/pages/Shell.tsx:5395
+#: src/pages/Shell.tsx:5423
 msgid "Expand"
 msgstr "펼치기"
 
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:4607
 msgid "Export"
 msgstr "내보내기"
 
@@ -1205,7 +1210,7 @@ msgstr "내보내기"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "CRM에서 이번 주 목록을 내려받아 공유 폴더에 넣기"
 
-#: src/pages/Shell.tsx:4599
+#: src/pages/Shell.tsx:4627
 msgid "Extra high"
 msgstr "매우 높음"
 
@@ -1213,14 +1218,14 @@ msgstr "매우 높음"
 msgid "Failed"
 msgstr "실패"
 
-#: src/pages/Shell.tsx:1393
 #: src/pages/Shell.tsx:1395
 #: src/pages/Shell.tsx:1397
+#: src/pages/Shell.tsx:1399
 msgid "Failed to send message"
 msgstr "메시지를 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:1420
-#: src/pages/Shell.tsx:1439
+#: src/pages/Shell.tsx:1422
+#: src/pages/Shell.tsx:1441
 msgid "Failed to stop"
 msgstr "작업을 중지하지 못했습니다."
 
@@ -1252,8 +1257,8 @@ msgstr "MCP 연결을 마무리하는 중…"
 msgid "Fullscreen"
 msgstr "전체 화면"
 
-#: src/pages/Shell.tsx:2086
-#: src/pages/Shell.tsx:2236
+#: src/pages/Shell.tsx:2089
+#: src/pages/Shell.tsx:2239
 msgid "Group"
 msgstr "그룹"
 
@@ -1266,7 +1271,7 @@ msgid "Hang up"
 msgstr "통화 종료"
 
 #: src/pages/McpServersOverlay.tsx:342
-#: src/pages/PluginsOverlay.tsx:373
+#: src/pages/PluginsOverlay.tsx:400
 msgid "Header name"
 msgstr "헤더 이름"
 
@@ -1282,15 +1287,15 @@ msgstr "샘플 듣기"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "안녕하세요. 답변을 소리 내어 읽을 때 이런 목소리로 들립니다."
 
-#: src/pages/Shell.tsx:4602
+#: src/pages/Shell.tsx:4630
 msgid "High"
 msgstr "높음"
 
-#: src/pages/Shell.tsx:3419
+#: src/pages/Shell.tsx:3438
 msgid "Hold to talk"
 msgstr "누르고 말하기"
 
-#: src/pages/Shell.tsx:3419
+#: src/pages/Shell.tsx:3438
 msgid "Hold to talk (on-device dictation)"
 msgstr "누르고 말하기(기기 내 음성 인식)"
 
@@ -1310,7 +1315,7 @@ msgstr "실행 주기"
 msgid "How to check"
 msgstr "완료 확인 방법"
 
-#: src/pages/Shell.tsx:3697
+#: src/pages/Shell.tsx:3716
 msgid "I’m done"
 msgstr "조작 끝내기"
 
@@ -1318,11 +1323,11 @@ msgstr "조작 끝내기"
 msgid "If you heard that, voice is ready."
 msgstr "샘플이 들렸다면 음성 설정이 완료되었습니다."
 
-#: src/pages/PluginsOverlay.tsx:331
+#: src/pages/PluginsOverlay.tsx:358
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON 가져오기"
 
-#: src/pages/Shell.tsx:4494
+#: src/pages/Shell.tsx:4517
 msgid "Inherit default"
 msgstr "기본 설정 사용"
 
@@ -1334,12 +1339,12 @@ msgstr "입력값"
 msgid "Instance API key"
 msgstr "인스턴스 API 키"
 
-#: src/pages/Shell.tsx:2503
+#: src/pages/Shell.tsx:2522
 msgid "Instruction"
 msgstr "실행할 내용"
 
-#: src/pages/PluginsOverlay.tsx:208
-#: src/pages/Shell.tsx:1953
+#: src/pages/PluginsOverlay.tsx:211
+#: src/pages/Shell.tsx:1956
 msgid "Integrations"
 msgstr "앱·도구 연동"
 
@@ -1360,15 +1365,15 @@ msgid "Interval unit"
 msgstr "간격 단위"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4495
+#: src/pages/Shell.tsx:4518
 msgid "Isolated"
 msgstr "이 Bot만 사용"
 
-#: src/pages/Shell.tsx:4831
+#: src/pages/Shell.tsx:4859
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만든 다른 Bot은 목록에 남습니다."
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3812
 msgid "Jump to replied message"
 msgstr "답장한 메시지로 이동"
 
@@ -1376,7 +1381,7 @@ msgstr "답장한 메시지로 이동"
 msgid "just now"
 msgstr "방금"
 
-#: src/pages/Shell.tsx:4849
+#: src/pages/Shell.tsx:4877
 msgid "Keep memories"
 msgstr "기억은 유지"
 
@@ -1394,7 +1399,7 @@ msgstr "언어"
 msgid "Listening…"
 msgstr "듣는 중…"
 
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3036
 msgid "Load earlier messages"
 msgstr "이전 메시지 불러오기"
 
@@ -1402,7 +1407,7 @@ msgstr "이전 메시지 불러오기"
 msgid "Loading activity…"
 msgstr "활동을 불러오는 중…"
 
-#: src/pages/PluginsOverlay.tsx:233
+#: src/pages/PluginsOverlay.tsx:237
 msgid "Loading integrations…"
 msgstr "연동 목록을 불러오는 중…"
 
@@ -1434,7 +1439,7 @@ msgstr "음성 서비스를 불러오는 중…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3017
+#: src/pages/Shell.tsx:3036
 msgid "Loading…"
 msgstr "불러오는 중…"
 
@@ -1442,11 +1447,11 @@ msgstr "불러오는 중…"
 msgid "Local"
 msgstr "로컬"
 
-#: src/pages/Shell.tsx:2039
+#: src/pages/Shell.tsx:2042
 msgid "Log out"
 msgstr "로그아웃"
 
-#: src/pages/Shell.tsx:4600
+#: src/pages/Shell.tsx:4628
 msgid "Low"
 msgstr "낮음"
 
@@ -1462,17 +1467,17 @@ msgstr "읽음으로 표시"
 msgid "Mark as Unread"
 msgstr "읽지 않음으로 표시"
 
-#: src/pages/Shell.tsx:4604
+#: src/pages/Shell.tsx:4632
 msgid "Max"
 msgstr "최대"
 
 #: src/pages/McpServersOverlay.tsx:224
 #: src/pages/McpServersOverlay.tsx:229
-#: src/pages/PluginsOverlay.tsx:305
+#: src/pages/PluginsOverlay.tsx:332
 msgid "MCP servers"
 msgstr "MCP 서버"
 
-#: src/pages/Shell.tsx:4601
+#: src/pages/Shell.tsx:4629
 msgid "Medium"
 msgstr "보통"
 
@@ -1485,33 +1490,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "참여 Bot ({GROUP_MEMBER_MIN}~{GROUP_MEMBER_MAX}개 선택)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:2000
 msgid "Memory"
 msgstr "기억"
 
-#: src/pages/Shell.tsx:4490
+#: src/pages/Shell.tsx:4513
 msgid "Memory scope"
 msgstr "기억 사용 범위"
 
-#: src/pages/Shell.tsx:3497
-#: src/pages/Shell.tsx:3592
+#: src/pages/Shell.tsx:3516
+#: src/pages/Shell.tsx:3611
 msgid "Message"
 msgstr "메시지"
 
-#: src/pages/Shell.tsx:3493
-#: src/pages/Shell.tsx:3497
+#: src/pages/Shell.tsx:3512
+#: src/pages/Shell.tsx:3516
 msgid "Message {activeName}"
 msgstr "{activeName}에게 메시지 보내기"
 
-#: src/pages/Shell.tsx:3871
+#: src/pages/Shell.tsx:3890
 msgid "Message from {peer}"
 msgstr "{peer}의 메시지"
 
-#: src/pages/Shell.tsx:3494
+#: src/pages/Shell.tsx:3513
 msgid "Message…"
 msgstr "메시지를 입력하세요"
 
-#: src/pages/Shell.tsx:3871
+#: src/pages/Shell.tsx:3890
 msgid "Messaged {peer}"
 msgstr "{peer}에게 메시지 보냄"
 
@@ -1519,7 +1524,7 @@ msgstr "{peer}에게 메시지 보냄"
 msgid "Microphone failed"
 msgstr "마이크를 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4603
+#: src/pages/Shell.tsx:4631
 msgid "Minimal"
 msgstr "최소"
 
@@ -1541,7 +1546,7 @@ msgstr "분"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4446
+#: src/pages/Shell.tsx:4469
 msgid "Model"
 msgstr "모델"
 
@@ -1563,7 +1568,7 @@ msgid "Model updated."
 msgstr "모델이 변경되었습니다."
 
 #: src/pages/ModelSettingsOverlay.tsx:303
-#: src/pages/Shell.tsx:1984
+#: src/pages/Shell.tsx:1987
 msgid "Models"
 msgstr "AI 모델"
 
@@ -1581,7 +1586,7 @@ msgstr "매월"
 msgid "Move {0} to section"
 msgstr "{0} 섹션 이동"
 
-#: src/pages/Shell.tsx:4852
+#: src/pages/Shell.tsx:4880
 msgid "Move them to your shared memory."
 msgstr "공용 기억으로 옮깁니다."
 
@@ -1594,15 +1599,15 @@ msgstr "섹션으로 이동"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2495
-#: src/pages/Shell.tsx:4241
-#: src/pages/Shell.tsx:4405
-#: src/pages/Shell.tsx:4678
+#: src/pages/Shell.tsx:2514
+#: src/pages/Shell.tsx:4260
+#: src/pages/Shell.tsx:4428
+#: src/pages/Shell.tsx:4706
 msgid "Name"
 msgstr "이름"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4246
+#: src/pages/Shell.tsx:4265
 msgid "Name this bot"
 msgstr "Bot 이름"
 
@@ -1618,13 +1623,13 @@ msgstr "입력 필요"
 msgid "Needs takeover"
 msgstr "인수 필요"
 
-#: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:4229
+#: src/pages/Shell.tsx:1744
+#: src/pages/Shell.tsx:4248
 msgid "New bot"
 msgstr "새 Bot 만들기"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1751
+#: src/pages/Shell.tsx:1754
 msgid "New group"
 msgstr "새 그룹 만들기"
 
@@ -1632,29 +1637,29 @@ msgstr "새 그룹 만들기"
 msgid "New open-work item"
 msgstr "새 진행 작업"
 
-#: src/pages/Shell.tsx:2385
+#: src/pages/Shell.tsx:2400
 msgid "New routine"
 msgstr "새 자동 실행"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4672
+#: src/pages/Shell.tsx:4700
 msgid "New section"
 msgstr "새 섹션"
 
-#: src/pages/PluginsOverlay.tsx:244
+#: src/pages/PluginsOverlay.tsx:248
 msgid "No apps match your search."
 msgstr "검색 결과가 없습니다."
 
-#: src/pages/PluginsOverlay.tsx:443
+#: src/pages/PluginsOverlay.tsx:470
 msgid "no auth"
 msgstr "인증 없음"
 
-#: src/pages/PluginsOverlay.tsx:359
+#: src/pages/PluginsOverlay.tsx:386
 msgid "No authentication"
 msgstr "인증 없음"
 
 #. placeholder {0}: item.name
-#: src/pages/PluginsOverlay.tsx:139
+#: src/pages/PluginsOverlay.tsx:142
 msgid "No connection record found for {0}."
 msgstr "{0}의 연결 정보를 찾지 못했습니다."
 
@@ -1670,11 +1675,11 @@ msgstr "별도 확인 규칙이 없습니다. 작업이 자동으로 실행됩�
 msgid "No longer active"
 msgstr "이미 종료된 요청입니다"
 
-#: src/pages/PluginsOverlay.tsx:239
+#: src/pages/PluginsOverlay.tsx:243
 msgid "No managed app catalog is configured on this deployment."
 msgstr "이 서버에는 관리형 앱 목록이 설정되지 않았습니다."
 
-#: src/pages/PluginsOverlay.tsx:425
+#: src/pages/PluginsOverlay.tsx:452
 msgid "No MCP or API tool sources installed yet."
 msgstr "아직 추가된 MCP 또는 API 도구가 없습니다."
 
@@ -1707,7 +1712,7 @@ msgstr "설정되지 않음"
 msgid "Not connected"
 msgstr "연결되지 않음"
 
-#: src/pages/Shell.tsx:5337
+#: src/pages/Shell.tsx:5365
 msgid "Not now"
 msgstr "나중에"
 
@@ -1745,15 +1750,15 @@ msgstr "매월 1일 {0}에"
 msgid "Open"
 msgstr "열기"
 
-#: src/pages/Shell.tsx:2295
+#: src/pages/Shell.tsx:2298
 msgid "Open computer"
 msgstr "컴퓨터 열기"
 
-#: src/pages/Shell.tsx:2265
+#: src/pages/Shell.tsx:2268
 msgid "Open in full window"
 msgstr "전체 창으로 열기"
 
-#: src/pages/Shell.tsx:2063
+#: src/pages/Shell.tsx:2066
 msgid "Open navigation"
 msgstr "메뉴 열기"
 
@@ -1770,7 +1775,7 @@ msgstr "진행 중인 작업"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 호환 서버 주소"
 
-#: src/pages/Shell.tsx:3996
+#: src/pages/Shell.tsx:4015
 msgid "Opened its thread."
 msgstr "대화가 만들어졌습니다."
 
@@ -1853,7 +1858,7 @@ msgstr "재생 중…"
 msgid "Preview {0}"
 msgstr "{0} 미리보기"
 
-#: src/pages/Shell.tsx:4184
+#: src/pages/Shell.tsx:4203
 msgid "Private"
 msgstr "Bot 전용"
 
@@ -1870,11 +1875,11 @@ msgstr "서비스"
 msgid "Queued"
 msgstr "대기 중"
 
-#: src/pages/PluginsOverlay.tsx:388
+#: src/pages/PluginsOverlay.tsx:415
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo는 저장하기 전에 연결 상태를 확인합니다. 인증 정보는 암호화되며 앱이나 AI 모델에 노출되지 않습니다."
 
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4545
 msgid "Read replies aloud"
 msgstr "답변을 자동으로 읽기"
 
@@ -1896,29 +1901,41 @@ msgstr "다시 연결 중"
 msgid "Recording: {0}"
 msgstr "녹화 중: {0}"
 
-#: src/pages/Shell.tsx:3687
+#: src/components/ComputerMaintenanceActions.tsx:57
+msgid "Recover computer"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:79
+msgid "Recover replaces an unreachable computer and keeps files in the saved workspace. Reset restores the last saved workspace and loses unsaved work. Update rebuilds with the latest image and keeps the saved workspace."
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:57
+msgid "Recovering…"
+msgstr ""
+
+#: src/pages/Shell.tsx:3706
 msgid "Release"
 msgstr "제어권 돌려주기"
 
 #: src/components/ApprovalRulesSettings.tsx:138
-#: src/pages/PluginsOverlay.tsx:279
-#: src/pages/PluginsOverlay.tsx:454
+#: src/pages/PluginsOverlay.tsx:290
+#: src/pages/PluginsOverlay.tsx:481
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "삭제"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3301
+#: src/pages/Shell.tsx:3320
 msgid "Remove {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3456
+#: src/pages/Shell.tsx:3475
 msgid "Remove mention {0}"
 msgstr "{0} 멘션 삭제"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3435
+#: src/pages/Shell.tsx:3454
 msgid "Remove skill {0}"
 msgstr "작업 기술 {0} 삭제"
 
@@ -1926,7 +1943,7 @@ msgstr "작업 기술 {0} 삭제"
 msgid "Remove this schedule"
 msgstr "이 일정 삭제"
 
-#: src/pages/Shell.tsx:3995
+#: src/pages/Shell.tsx:4014
 msgid "Removed with chat, computer, and memory."
 msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 
@@ -1934,8 +1951,8 @@ msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 msgid "Removed, but list refresh failed"
 msgstr "삭제했지만 목록을 새로고침하지 못했습니다."
 
-#: src/pages/PluginsOverlay.tsx:274
-#: src/pages/PluginsOverlay.tsx:454
+#: src/pages/PluginsOverlay.tsx:285
+#: src/pages/PluginsOverlay.tsx:481
 msgid "Removing…"
 msgstr "삭제 중…"
 
@@ -1953,17 +1970,38 @@ msgstr "API 키 교체"
 msgid "Replace key"
 msgstr "키 교체"
 
-#: src/pages/Shell.tsx:3633
+#: src/pages/Shell.tsx:3652
 msgid "Reply"
 msgstr "답장"
 
-#: src/pages/Shell.tsx:3264
+#: src/pages/Shell.tsx:3283
 msgid "Replying to {replyName}"
 msgstr "{replyName}에게 답장"
 
-#: src/pages/Shell.tsx:1928
+#: src/components/ComputerMaintenanceActions.tsx:115
+msgid "Reset"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:68
+msgid "Reset computer"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:97
+msgid "Reset computer?"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:68
+#: src/components/ComputerMaintenanceActions.tsx:115
+msgid "Resetting…"
+msgstr ""
+
+#: src/pages/Shell.tsx:1931
 msgid "Restore"
 msgstr "복원"
+
+#: src/components/ComputerMaintenanceActions.tsx:103
+msgid "Restore the last saved workspace. Unsaved work on the computer is lost."
+msgstr ""
 
 #: src/App.tsx:135
 msgid "Retry now"
@@ -1973,17 +2011,17 @@ msgstr "지금 다시 시도"
 msgid "Return to Rakazo"
 msgstr "Rakazo로 돌아가기"
 
-#: src/pages/Shell.tsx:2488
-#: src/pages/Shell.tsx:2541
-#: src/pages/Shell.tsx:2548
+#: src/pages/Shell.tsx:2507
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:2567
 msgid "Routine"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Routines"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2630
 msgid "Run now"
 msgstr "지금 실행"
 
@@ -1991,11 +2029,11 @@ msgstr "지금 실행"
 msgid "Running"
 msgstr "실행 중"
 
-#: src/pages/Shell.tsx:2370
+#: src/pages/Shell.tsx:2385
 msgid "Running · Stop"
 msgstr "실행 중 · 중지"
 
-#: src/pages/Shell.tsx:2611
+#: src/pages/Shell.tsx:2630
 msgid "Running…"
 msgstr "실행 중…"
 
@@ -2003,8 +2041,8 @@ msgstr "실행 중…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:674
-#: src/pages/Shell.tsx:2587
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:4600
 msgid "Save"
 msgstr "저장"
 
@@ -2028,7 +2066,7 @@ msgstr "저장되었습니다."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:672
-#: src/pages/Shell.tsx:2587
+#: src/pages/Shell.tsx:2606
 msgid "Saving…"
 msgstr "저장 중…"
 
@@ -2041,11 +2079,12 @@ msgstr "말씀하세요. 잠시 멈추면 자동으로 전송됩니다."
 msgid "Say yes or no, or answer in a sentence."
 msgstr "예 또는 아니요로 답하거나 문장으로 답해 주세요."
 
-#: src/pages/Shell.tsx:1762
+#: src/pages/Shell.tsx:1765
 msgid "Search"
 msgstr "검색"
 
-#: src/pages/PluginsOverlay.tsx:224
+#: src/pages/PluginsOverlay.tsx:227
+#: src/pages/PluginsOverlay.tsx:228
 msgid "Search apps"
 msgstr "앱 검색"
 
@@ -2063,11 +2102,11 @@ msgstr "AI 서비스 또는 모델 검색"
 msgid "Searching…"
 msgstr "검색 중…"
 
-#: src/pages/Shell.tsx:2087
+#: src/pages/Shell.tsx:2090
 msgid "Select a bot"
 msgstr "대화할 Bot을 선택하세요"
 
-#: src/pages/Shell.tsx:3517
+#: src/pages/Shell.tsx:3536
 msgid "Send"
 msgstr "보내기"
 
@@ -2095,22 +2134,22 @@ msgstr "서버 이름"
 msgid "Server URL"
 msgstr "서버 URL"
 
-#: src/pages/Shell.tsx:2096
+#: src/pages/Shell.tsx:2099
 msgid "Set up voice to call"
 msgstr "통화하려면 음성을 먼저 설정하세요"
 
 #: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1961
-#: src/pages/Shell.tsx:1971
-#: src/pages/Shell.tsx:2232
+#: src/pages/Shell.tsx:1964
+#: src/pages/Shell.tsx:1974
+#: src/pages/Shell.tsx:2235
 msgid "Settings"
 msgstr "설정"
 
-#: src/pages/Shell.tsx:3535
+#: src/pages/Shell.tsx:3554
 msgid "Settings: General"
 msgstr "설정: 일반"
 
-#: src/pages/Shell.tsx:3537
+#: src/pages/Shell.tsx:3556
 msgid "Settings: Usage"
 msgstr "설정: 사용량"
 
@@ -2120,15 +2159,15 @@ msgid "Setup help"
 msgstr "설정 도움말"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4496
+#: src/pages/Shell.tsx:4519
 msgid "Shared"
 msgstr "함께 사용"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2246
 msgid "Show computer"
 msgstr "컴퓨터 보기"
 
-#: src/pages/Shell.tsx:2243
+#: src/pages/Shell.tsx:2246
 msgid "Show settings"
 msgstr "설정 보기"
 
@@ -2152,11 +2191,11 @@ msgid "Sign up"
 msgstr "가입하기"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3367
 msgid "Skill {0}"
 msgstr "작업 기술 {0}"
 
-#: src/pages/Shell.tsx:3694
+#: src/pages/Shell.tsx:3713
 msgid "Skip"
 msgstr "건너뛰기"
 
@@ -2169,7 +2208,7 @@ msgid "Skip or deploy key"
 msgstr "건너뛰거나 배포 키"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1287
+#: src/pages/Shell.tsx:1289
 msgid "Skipped {0}"
 msgstr "{0} 건너뜀"
 
@@ -2177,8 +2216,8 @@ msgstr "{0} 건너뜀"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space: 끼어들기 · Esc: 통화 종료"
 
-#: src/pages/Shell.tsx:3840
-#: src/pages/Shell.tsx:4093
+#: src/pages/Shell.tsx:3859
+#: src/pages/Shell.tsx:4112
 msgid "Speak"
 msgstr "읽기"
 
@@ -2190,8 +2229,8 @@ msgstr "음성 출력·받아쓰기"
 msgid "Speak only"
 msgstr "음성 출력만"
 
-#: src/pages/Shell.tsx:3836
-#: src/pages/Shell.tsx:4089
+#: src/pages/Shell.tsx:3855
+#: src/pages/Shell.tsx:4108
 msgid "Speak this reply"
 msgstr "이 답변 읽기"
 
@@ -2217,20 +2256,20 @@ msgstr "시작하는 중…"
 msgid "Steps"
 msgstr "실행 단계"
 
-#: src/pages/Shell.tsx:2866
-#: src/pages/Shell.tsx:2870
-#: src/pages/Shell.tsx:3508
-#: src/pages/Shell.tsx:3840
-#: src/pages/Shell.tsx:4093
+#: src/pages/Shell.tsx:2885
+#: src/pages/Shell.tsx:2889
+#: src/pages/Shell.tsx:3527
+#: src/pages/Shell.tsx:3859
+#: src/pages/Shell.tsx:4112
 msgid "Stop"
 msgstr "중지"
 
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3419
 msgid "Stop dictation"
 msgstr "음성 입력 중지"
 
-#: src/pages/Shell.tsx:3836
-#: src/pages/Shell.tsx:4089
+#: src/pages/Shell.tsx:3855
+#: src/pages/Shell.tsx:4108
 msgid "Stop speaking"
 msgstr "읽기 중지"
 
@@ -2239,8 +2278,8 @@ msgstr "읽기 중지"
 msgid "Stop teaching"
 msgstr "가르치기 종료"
 
-#: src/pages/Shell.tsx:2322
-#: src/pages/Shell.tsx:2886
+#: src/pages/Shell.tsx:2325
+#: src/pages/Shell.tsx:2905
 msgid "Stop the bot first"
 msgstr "먼저 Bot을 중지하세요"
 
@@ -2248,7 +2287,7 @@ msgstr "먼저 Bot을 중지하세요"
 msgid "Stored encrypted"
 msgstr "암호화해 저장"
 
-#: src/pages/Shell.tsx:3947
+#: src/pages/Shell.tsx:3966
 msgid "subagent"
 msgstr "보조 에이전트"
 
@@ -2261,8 +2300,8 @@ msgstr "확인"
 msgid "Switching…"
 msgstr "전환 중…"
 
-#: src/pages/Shell.tsx:2325
-#: src/pages/Shell.tsx:2891
+#: src/pages/Shell.tsx:2328
+#: src/pages/Shell.tsx:2910
 msgid "Take control"
 msgstr "직접 조작"
 
@@ -2270,7 +2309,7 @@ msgstr "직접 조작"
 msgid "Teach a task"
 msgstr "작업 가르치기"
 
-#: src/pages/Shell.tsx:2158
+#: src/pages/Shell.tsx:2161
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼저 가르치기를 종료하세요."
 
@@ -2278,11 +2317,11 @@ msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼�
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "작업을 가르치려면 화면이 있는 샌드박스 컴퓨터가 필요합니다. 내 컴퓨터에서 실행되는 Bot은 터미널 작업은 가능하지만 화면 녹화는 할 수 없습니다."
 
-#: src/pages/Shell.tsx:4184
+#: src/pages/Shell.tsx:4203
 msgid "Team"
 msgstr "팀 공용"
 
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:5046
 msgid "Team Computer"
 msgstr "팀 컴퓨터"
 
@@ -2295,20 +2334,20 @@ msgstr "시험 실행"
 msgid "The selected memory provider is not available in this build."
 msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4473
+#: src/pages/Shell.tsx:4496
 msgid "Thinking"
 msgstr "생각 깊이"
 
-#: src/pages/Shell.tsx:2269
+#: src/pages/Shell.tsx:2272
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "이 Bot은 별도 Linux 화면이 아니라 현재 컴퓨터에서 실행됩니다. 터미널과 파일 작업은 홈 폴더를 사용합니다."
 
-#: src/pages/Shell.tsx:2915
+#: src/pages/Shell.tsx:2934
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "이 Bot은 현재 컴퓨터에서 실행되며 별도 Linux 화면은 없습니다. 터미널을 사용하도록 요청할 수 있고 홈 폴더 아래에서 작업합니다."
 
-#: src/pages/Shell.tsx:4868
-#: src/pages/Shell.tsx:4945
+#: src/pages/Shell.tsx:4896
+#: src/pages/Shell.tsx:4973
 msgid "This cannot be undone."
 msgstr "이 작업은 되돌릴 수 없습니다."
 
@@ -2332,7 +2371,7 @@ msgstr "이 Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "이 Mac에서는 홈 폴더의 파일을 포함해 내 계정 권한으로 터미널 명령을 실행합니다. 여러 사람이 쓰거나 공개된 서버에서는 사용하지 마세요."
 
-#: src/pages/Shell.tsx:4753
+#: src/pages/Shell.tsx:4781
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지합니다. Bot, 컴퓨터, 기억, 자동 실행은 그대로 유지됩니다."
 
@@ -2340,7 +2379,7 @@ msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지�
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "이 서비스는 여기에서 API 키를 입력할 수 없습니다. 서버에 이미 인증 정보가 있다면 건너뛰세요."
 
-#: src/pages/Shell.tsx:5285
+#: src/pages/Shell.tsx:5313
 msgid "This server cannot be assigned without a bot."
 msgstr "연결할 Bot이 없어 이 서버를 배정할 수 없습니다."
 
@@ -2352,7 +2391,7 @@ msgstr "이 서버는 브라우저 인증을 요청하지 않았습니다."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "이 서버는 이미 연결되어 있습니다. 다시 인증하려면 먼저 연결을 해제하세요."
 
-#: src/pages/Shell.tsx:5324
+#: src/pages/Shell.tsx:5352
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "이 서버는 브라우저 로그인이 필요합니다. 인증을 누르면 새 창이 열리고, 완료 후 Bot이 도구를 사용할 수 있습니다."
 
@@ -2365,16 +2404,16 @@ msgid "Time of day"
 msgstr "실행 시각"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4251
-#: src/pages/Shell.tsx:4414
+#: src/pages/Shell.tsx:4270
+#: src/pages/Shell.tsx:4437
 msgid "Title"
 msgstr "역할"
 
-#: src/pages/PluginsOverlay.tsx:421
+#: src/pages/PluginsOverlay.tsx:448
 msgid "Tool sources"
 msgstr "도구 소스"
 
-#: src/pages/PluginsOverlay.tsx:383
+#: src/pages/PluginsOverlay.tsx:410
 msgid "Treg token"
 msgstr "Treg 토큰"
 
@@ -2391,12 +2430,20 @@ msgid "Unpin"
 msgstr "고정 해제"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1351
+#: src/pages/Shell.tsx:1353
 msgid "Unsupported file type: {0}"
 msgstr "지원하지 않는 파일 형식: {0}"
 
+#: src/components/ComputerMaintenanceActions.tsx:73
+msgid "Update computer"
+msgstr ""
+
+#: src/components/ComputerMaintenanceActions.tsx:73
+msgid "Updating…"
+msgstr ""
+
 #: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2022
+#: src/pages/Shell.tsx:2025
 msgid "Usage"
 msgstr "사용량"
 
@@ -2413,16 +2460,16 @@ msgstr "찾은 모델 중에서 선택"
 msgid "Use this model"
 msgstr "이 모델 사용"
 
-#: src/pages/PluginsOverlay.tsx:404
+#: src/pages/PluginsOverlay.tsx:431
 msgid "Verify and add"
 msgstr "확인 후 추가"
 
-#: src/pages/PluginsOverlay.tsx:402
+#: src/pages/PluginsOverlay.tsx:429
 msgid "Verifying…"
 msgstr "확인 중…"
 
-#: src/pages/Shell.tsx:2010
-#: src/pages/Shell.tsx:4526
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:4549
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2435,7 +2482,7 @@ msgstr "음성"
 msgid "Waiting for sign-in…"
 msgstr "로그인 완료를 기다리는 중…"
 
-#: src/pages/Shell.tsx:5168
+#: src/pages/Shell.tsx:5196
 msgid "Waiting…"
 msgstr "기다리는 중…"
 
@@ -2444,7 +2491,7 @@ msgstr "기다리는 중…"
 msgid "Weekdays"
 msgstr "주중"
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4866
 msgid "What about its memories?"
 msgstr "이 Bot의 기억은 어떻게 할까요?"
 
@@ -2453,7 +2500,7 @@ msgid "What result will you demonstrate?"
 msgstr "어떤 작업을 직접 보여줄까요?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4266
+#: src/pages/Shell.tsx:4285
 msgid "What this bot is for"
 msgstr "이 Bot을 언제, 어떤 일에 사용할지 적어주세요"
 
@@ -2465,7 +2512,7 @@ msgstr "완료 후 전달할 결과"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "{botName}이 다른 Bot에게 메시지를 보내면 대화 대신 여기에 표시됩니다."
 
-#: src/pages/Shell.tsx:2512
+#: src/pages/Shell.tsx:2531
 msgid "When to run"
 msgstr "실행 시간"
 
@@ -2482,12 +2529,12 @@ msgstr "Bot을 어디에서 실행할까요?"
 msgid "Working…"
 msgstr "처리 중…"
 
-#: src/pages/Shell.tsx:4456
+#: src/pages/Shell.tsx:4479
 msgid "Workspace default"
 msgstr "작업공간 기본값"
 
-#: src/pages/Shell.tsx:1100
-#: src/pages/Shell.tsx:1672
+#: src/pages/Shell.tsx:1102
+#: src/pages/Shell.tsx:1675
 msgid "You"
 msgstr "나"
 
@@ -2499,8 +2546,8 @@ msgstr "자동으로 이동하지 않으면 이 탭을 닫아도 됩니다."
 msgid "You can close this window."
 msgstr "이 창을 닫아도 됩니다."
 
-#: src/pages/Shell.tsx:2302
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2305
+#: src/pages/Shell.tsx:2875
 msgid "You have control"
 msgstr "직접 조작 중"
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -106,6 +106,7 @@ import {
 } from "../components/beautiful-ui/primitives";
 import { SkillDraftCard } from "../components/teach/SkillDraftCard";
 import { TeachCaptureOverlay } from "../components/teach/TeachCaptureOverlay";
+import { ComputerMaintenanceActions } from "../components/ComputerMaintenanceActions";
 import { TeachComputerSection } from "../components/teach/TeachComputerSection";
 import { TeachRecordingChrome, TeachStopButton } from "../components/teach/TeachRecordingChrome";
 import { readActivityMode, writeActivityMode } from "../lib/activity-mode";
@@ -1533,16 +1534,21 @@ export function ShellPage() {
     takeControl,
     overlay,
     force = false,
+    action = "boot",
   }: {
     takeControl: boolean;
     overlay: boolean;
     force?: boolean;
+    action?: "boot" | "recover";
   }) {
     if (!active) return;
     const needsBoot = force || computer?.state !== "running" || !screenUrl;
     if (overlay && needsBoot) setBooting(true);
     try {
-      if (needsBoot) await rpc.computer.boot({ botId: active.id });
+      if (needsBoot) {
+        if (action === "recover") await rpc.computer.recover({ botId: active.id });
+        else await rpc.computer.boot({ botId: active.id });
+      }
       if (takeControl) await rpc.computer.takeover({ botId: active.id });
       await refreshThread(active.id);
       setComputerError(null);
@@ -1581,6 +1587,7 @@ export function ShellPage() {
         takeControl: false,
         overlay: action === "boot",
         force: true,
+        action: action === "recover-screen" ? "recover" : "boot",
       }).catch(() => undefined);
     })();
     return () => {
@@ -2326,6 +2333,18 @@ export function ShellPage() {
                     </Button>
                   )}
                 </div>
+                {computer?.state === "error" ||
+                computer?.state === "stopped" ||
+                (computer?.state === "running" && !embeddedScreenUrl) ? (
+                  <ComputerMaintenanceActions
+                    botId={active.id}
+                    computer={computer}
+                    compact
+                    onChanged={async () => {
+                      await refreshThread(active.id);
+                    }}
+                  />
+                ) : null}
                 <div className="mt-[30px] mb-3 text-[14px] text-[#85858A]">
                   <Trans>Routines</Trans>
                 </div>
@@ -2448,6 +2467,7 @@ export function ShellPage() {
               <BotSettings
                 key={active.id}
                 bot={active}
+                computer={computer}
                 memoryProviderConfigured={memoryProviderConfig != null}
                 onSave={async ({ computerMode, ...patch }) => {
                   if (computerMode !== active.computerMode) {
@@ -2472,6 +2492,9 @@ export function ShellPage() {
                   URL.revokeObjectURL(url);
                 }}
                 onClear={() => setClearTarget(active)}
+                onComputerChanged={async () => {
+                  await refreshThread(active.id);
+                }}
               />
             ) : null}
             {panel === "routine" && active ? (
@@ -4283,12 +4306,15 @@ function CreateBotForm({
 
 function BotSettings({
   bot,
+  computer,
   memoryProviderConfigured,
   onSave,
   onExport,
   onClear,
+  onComputerChanged,
 }: {
   bot: Bot;
+  computer: ComputerStatus | null;
   memoryProviderConfigured: boolean;
   onSave: (patch: {
     name?: string;
@@ -4305,6 +4331,7 @@ function BotSettings({
   }) => Promise<void>;
   onExport: () => Promise<void>;
   onClear: () => void;
+  onComputerChanged: () => Promise<void>;
 }) {
   const { t } = useLingui();
   const [name, setName] = useState(bot.name);
@@ -4586,6 +4613,11 @@ function BotSettings({
         <button type="button" onClick={onClear} className="text-[14px] text-[#E65707]">
           <Trans>Clear conversation</Trans>
         </button>
+        <ComputerMaintenanceActions
+          botId={bot.id}
+          computer={computer}
+          onChanged={onComputerChanged}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -104,9 +104,9 @@ import {
   LoadingState,
   SuccessPop,
 } from "../components/beautiful-ui/primitives";
+import { ComputerMaintenanceActions } from "../components/ComputerMaintenanceActions";
 import { SkillDraftCard } from "../components/teach/SkillDraftCard";
 import { TeachCaptureOverlay } from "../components/teach/TeachCaptureOverlay";
-import { ComputerMaintenanceActions } from "../components/ComputerMaintenanceActions";
 import { TeachComputerSection } from "../components/teach/TeachComputerSection";
 import { TeachRecordingChrome, TeachStopButton } from "../components/teach/TeachRecordingChrome";
 import { readActivityMode, writeActivityMode } from "../lib/activity-mode";

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -124,6 +124,7 @@ import {
   activeThreadRuns,
   clearActiveThreadRuns,
   computerPanelAutoBoot,
+  computerPanelAutoUsesBoot,
   computerTakeoverBlocked,
   isComputerStatusEvent,
   isThreadSnapshotEvent,
@@ -1534,21 +1535,16 @@ export function ShellPage() {
     takeControl,
     overlay,
     force = false,
-    action = "boot",
   }: {
     takeControl: boolean;
     overlay: boolean;
     force?: boolean;
-    action?: "boot" | "recover";
   }) {
     if (!active) return;
     const needsBoot = force || computer?.state !== "running" || !screenUrl;
     if (overlay && needsBoot) setBooting(true);
     try {
-      if (needsBoot) {
-        if (action === "recover") await rpc.computer.recover({ botId: active.id });
-        else await rpc.computer.boot({ botId: active.id });
-      }
+      if (needsBoot) await rpc.computer.boot({ botId: active.id });
       if (takeControl) await rpc.computer.takeover({ botId: active.id });
       await refreshThread(active.id);
       setComputerError(null);
@@ -1583,11 +1579,11 @@ export function ShellPage() {
       }
       if (action === "boot" && autoBooted.current === botId) return;
       autoBooted.current = botId;
+      if (!computerPanelAutoUsesBoot(action)) return;
       await bootComputer({
         takeControl: false,
         overlay: action === "boot",
         force: true,
-        action: action === "recover-screen" ? "recover" : "boot",
       }).catch(() => undefined);
     })();
     return () => {

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -11,11 +11,17 @@ import type { PrismaClient, ThreadEvents } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireComputerExecutionLease,
+  ComputerBusyError,
+  computerSupportsUpdate,
   provisionComputer,
   releaseComputerExecutionLease,
   renewComputerExecutionLease,
+  replaceComputer,
   screenLeaseIdForRun,
 } from "./computer-lifecycle.js";
+import { FakeSandboxProvider } from "./fake-sandbox.js";
+import { checkpointComputerWorkspace } from "./computer-workspace.js";
+import { LocalAgentHomeStore } from "./home.js";
 
 const context = {
   operationId: "test",
@@ -537,3 +543,117 @@ function leasePrisma(options: {
     findUniqueOrThrow,
   };
 }
+
+describe("computer replacement", () => {
+  it("exposes update availability by sandbox kind", () => {
+    expect(computerSupportsUpdate("e2b")).toBe(true);
+    expect(computerSupportsUpdate("desktop")).toBe(false);
+  });
+
+  it("replaces a wedged computer and restores the durable home", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-replace-"));
+    const homeRoot = await mkdtemp(path.join(tmpdir(), "rakazo-replace-home-"));
+    const home = new LocalAgentHomeStore(homeRoot);
+    const sandbox = new FakeSandboxProvider();
+    const first = await sandbox.provision({ botId: "bot-1", homePath: dataDir }, context);
+    await sandbox.writeFile(
+      first,
+      { path: "notes/keep.txt", content: new TextEncoder().encode("saved") },
+      context,
+    );
+    const revision = await checkpointComputerWorkspace(home, sandbox, "bot-1", first, context);
+
+    const computerRecord = {
+      id: "computer-1",
+      homeKey: "bot-1",
+      providerRef: first.providerRef,
+      kind: "fake",
+      scope: "dedicated",
+      state: "running",
+      controlLeaseId: null,
+      homeRevision: revision,
+    };
+    const findUniqueOrThrow = vi
+      .fn()
+      .mockResolvedValueOnce(computerRecord)
+      .mockResolvedValueOnce({ ...computerRecord, state: "stopped", providerRef: null })
+      .mockResolvedValue({
+        ...computerRecord,
+        state: "stopped",
+        providerRef: null,
+      });
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValue({ count: 1 });
+    const update = vi.fn().mockResolvedValue({});
+    const prisma = {
+      computer: { findUniqueOrThrow, updateMany, update },
+      computerExecutionLease: { deleteMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      run: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+
+    const destroy = vi.spyOn(sandbox, "destroy");
+    try {
+      const ref = await replaceComputer(
+        {
+          prisma,
+          sandbox,
+          home,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+          dataDir,
+        },
+        "computer-1",
+        "recover",
+        context,
+      );
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(ref.fresh).toBe(true);
+      expect(
+        new TextDecoder().decode(await sandbox.readFile(ref, "notes/keep.txt", context)),
+      ).toBe("saved");
+      await rm(dataDir, { recursive: true, force: true });
+      await rm(homeRoot, { recursive: true, force: true });
+    } catch (error) {
+      await rm(dataDir, { recursive: true, force: true });
+      await rm(homeRoot, { recursive: true, force: true });
+      throw error;
+    }
+  });
+
+  it("rejects replacement while another team bot holds the computer", async () => {
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "provider-1",
+          kind: "fake",
+          scope: "team",
+          state: "running",
+          controlLeaseId: null,
+        }),
+        updateMany: vi.fn().mockResolvedValueOnce({ count: 1 }),
+      },
+      run: {
+        findFirst: vi.fn().mockResolvedValue({ id: "other-run" }),
+      },
+    } as unknown as PrismaClient;
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "reset",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+  });
+});

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -19,8 +19,8 @@ import {
   replaceComputer,
   screenLeaseIdForRun,
 } from "./computer-lifecycle.js";
-import { FakeSandboxProvider } from "./fake-sandbox.js";
 import { checkpointComputerWorkspace } from "./computer-workspace.js";
+import { FakeSandboxProvider } from "./fake-sandbox.js";
 import { LocalAgentHomeStore } from "./home.js";
 
 const context = {
@@ -611,9 +611,9 @@ describe("computer replacement", () => {
       );
       expect(destroy).toHaveBeenCalledOnce();
       expect(ref.fresh).toBe(true);
-      expect(
-        new TextDecoder().decode(await sandbox.readFile(ref, "notes/keep.txt", context)),
-      ).toBe("saved");
+      expect(new TextDecoder().decode(await sandbox.readFile(ref, "notes/keep.txt", context))).toBe(
+        "saved",
+      );
       await rm(dataDir, { recursive: true, force: true });
       await rm(homeRoot, { recursive: true, force: true });
     } catch (error) {
@@ -652,6 +652,40 @@ describe("computer replacement", () => {
         },
         "computer-1",
         "reset",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+  });
+
+  it("rejects replacement while the target bot has an active run", async () => {
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "provider-1",
+          kind: "fake",
+          scope: "dedicated",
+          state: "running",
+          controlLeaseId: null,
+        }),
+        updateMany: vi.fn().mockResolvedValueOnce({ count: 1 }),
+      },
+      run: {
+        findFirst: vi.fn().mockResolvedValue({ id: "same-bot-run" }),
+      },
+    } as unknown as PrismaClient;
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "recover",
         context,
       ),
     ).rejects.toBeInstanceOf(ComputerBusyError);

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -690,4 +690,37 @@ describe("computer replacement", () => {
       ),
     ).rejects.toBeInstanceOf(ComputerBusyError);
   });
+
+  it("rejects replacement while another bot holds user control", async () => {
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "provider-1",
+          kind: "fake",
+          scope: "team",
+          state: "running",
+          controlHolder: "user",
+          controlLeaseId: "lease-1",
+          controlLeaseExpiresAt: new Date(Date.now() + 60_000),
+          controlBotId: "other-bot",
+        }),
+      },
+    } as unknown as PrismaClient;
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "recover",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+  });
 });

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -691,7 +691,7 @@ describe("computer replacement", () => {
     ).rejects.toBeInstanceOf(ComputerBusyError);
   });
 
-  it("rejects replacement while another bot holds user control", async () => {
+  it("rejects replacement while any bot holds user control", async () => {
     const prisma = {
       computer: {
         findUniqueOrThrow: vi.fn().mockResolvedValue({
@@ -719,6 +719,39 @@ describe("computer replacement", () => {
         },
         "computer-1",
         "recover",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+  });
+
+  it("rejects replacement while the same bot holds user control", async () => {
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "provider-1",
+          kind: "fake",
+          scope: "dedicated",
+          state: "running",
+          controlHolder: "user",
+          controlLeaseId: "lease-1",
+          controlLeaseExpiresAt: new Date(Date.now() + 60_000),
+          controlBotId: "bot-1",
+        }),
+      },
+    } as unknown as PrismaClient;
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "reset",
         context,
       ),
     ).rejects.toBeInstanceOf(ComputerBusyError);

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -756,4 +756,51 @@ describe("computer replacement", () => {
       ),
     ).rejects.toBeInstanceOf(ComputerBusyError);
   });
+
+  it("rejects replacement when control is claimed before the suspending lock", async () => {
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "provider-1",
+          kind: "fake",
+          scope: "dedicated",
+          state: "running",
+          controlHolder: "none",
+          controlLeaseId: null,
+          controlLeaseExpiresAt: null,
+          controlBotId: null,
+        }),
+        updateMany: vi.fn().mockResolvedValueOnce({ count: 0 }),
+      },
+      run: { findFirst: vi.fn() },
+    } as unknown as PrismaClient;
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "recover",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+    expect(prisma.computer.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            { controlHolder: { not: "user" } },
+            { controlLeaseId: null },
+            { controlLeaseExpiresAt: null },
+            { controlLeaseExpiresAt: { lte: expect.any(Date) } },
+          ]),
+        }),
+      }),
+    );
+  });
 });

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -803,4 +803,74 @@ describe("computer replacement", () => {
       }),
     );
   });
+
+  it("rejects replacement of a stopped computer while a run is still active", async () => {
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: null,
+          kind: "fake",
+          scope: "dedicated",
+          state: "stopped",
+          controlLeaseId: null,
+        }),
+        updateMany: vi.fn(),
+      },
+      run: {
+        findFirst: vi.fn().mockResolvedValue({ id: "active-run" }),
+      },
+    } as unknown as PrismaClient;
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "recover",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+    expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects replacement of a suspended computer while a run is still active", async () => {
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "provider-1",
+          kind: "fake",
+          scope: "dedicated",
+          state: "suspended",
+          controlLeaseId: null,
+        }),
+        updateMany: vi.fn(),
+      },
+      run: {
+        findFirst: vi.fn().mockResolvedValue({ id: "active-run" }),
+      },
+    } as unknown as PrismaClient;
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "update",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+    expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+  });
 });

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -413,6 +413,7 @@ export async function replaceComputer(
   }
 
   const previousState = existing.state;
+  let claimedSuspending = false;
   if (existing.state !== "stopped" && existing.state !== "suspended") {
     const now = new Date();
     const claimed = await deps.prisma.computer.updateMany({
@@ -430,20 +431,23 @@ export async function replaceComputer(
       data: { state: "suspending" },
     });
     if (claimed.count !== 1) throw new ComputerBusyError();
-    const activeRun = await deps.prisma.run.findFirst({
-      where: {
-        status: { in: [...ACTIVE_RUN_STATUSES] },
-        bot: { computerId },
-      },
-      select: { id: true },
-    });
-    if (activeRun) {
+    claimedSuspending = true;
+  }
+  const activeRun = await deps.prisma.run.findFirst({
+    where: {
+      status: { in: [...ACTIVE_RUN_STATUSES] },
+      bot: { computerId },
+    },
+    select: { id: true },
+  });
+  if (activeRun) {
+    if (claimedSuspending) {
       await deps.prisma.computer.updateMany({
         where: { id: computerId, state: "suspending" },
         data: { state: previousState },
       });
-      throw new ComputerBusyError();
     }
+    throw new ComputerBusyError();
   }
 
   const oldRef = existing.providerRef ? toComputerRef(existing) : null;

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -420,6 +420,12 @@ export async function replaceComputer(
         id: computerId,
         state: { notIn: ["booting", "suspending", "stopped", "suspended"] },
         executionLeases: { none: { botId: { not: botId }, expiresAt: { gt: now } } },
+        OR: [
+          { controlHolder: { not: "user" } },
+          { controlLeaseId: null },
+          { controlLeaseExpiresAt: null },
+          { controlLeaseExpiresAt: { lte: now } },
+        ],
       },
       data: { state: "suspending" },
     });

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -6,10 +6,16 @@ import type {
   JobPublisher,
   SandboxProvider,
 } from "@rakazo/adapter-kit";
-import { screenLeaseId } from "@rakazo/core";
+import { ACTIVE_RUN_STATUSES, screenLeaseId } from "@rakazo/core";
 import { type PrismaClient, parseComputerMode, type ThreadEvents } from "@rakazo/db";
 import { expireComputerControl, hasActiveComputerControl } from "./computer-control.js";
-import { ensureComputerWorkspaceLayout, restoreComputerWorkspace } from "./computer-workspace.js";
+import {
+  checkpointAndRecordComputerWorkspace,
+  ensureComputerWorkspaceLayout,
+  restoreComputerWorkspace,
+} from "./computer-workspace.js";
+import { toComputerRef } from "./computer-support.js";
+import { isUnrecoverableSandboxError } from "./e2b-sandbox.js";
 import { resolveAgentHomePath } from "./home.js";
 
 const EXECUTION_LEASE_MS = 5 * 60_000;
@@ -367,4 +373,112 @@ export async function releaseComputerExecutionLease(
 
 function isUniqueConstraintError(error: unknown) {
   return Boolean(error && typeof error === "object" && "code" in error && error.code === "P2002");
+}
+
+export type ComputerReplaceMode = "recover" | "reset" | "update";
+
+export function computerSupportsUpdate(kind: string): boolean {
+  return kind !== "desktop";
+}
+
+export async function replaceComputer(
+  deps: {
+    prisma: PrismaClient;
+    sandbox: SandboxProvider;
+    home: AgentHomeStore;
+    jobs: JobPublisher;
+    events: ThreadEvents;
+    dataDir?: string;
+  },
+  computerId: string,
+  mode: ComputerReplaceMode,
+  context: AdapterContext,
+  controlHolder: "bot" | "none" = "none",
+): Promise<ComputerRef> {
+  let existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
+  if (existing.controlLeaseId && !hasActiveComputerControl(existing)) {
+    await expireComputerControl(deps, existing.id, existing.controlLeaseId);
+    existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
+    if (existing.controlLeaseId && !hasActiveComputerControl(existing)) {
+      throw new Error("computer control revocation is still in progress");
+    }
+  }
+  if (existing.state === "booting" || existing.state === "suspending") {
+    throw new ComputerBusyError();
+  }
+  const botId = context.botId;
+  if (!botId) throw new Error("computer replacement requires a bot id");
+
+  const previousState = existing.state;
+  if (existing.state !== "stopped" && existing.state !== "suspended") {
+    const now = new Date();
+    const claimed = await deps.prisma.computer.updateMany({
+      where: {
+        id: computerId,
+        state: { notIn: ["booting", "suspending", "stopped", "suspended"] },
+        executionLeases: { none: { botId: { not: botId }, expiresAt: { gt: now } } },
+      },
+      data: { state: "suspending" },
+    });
+    if (claimed.count !== 1) throw new ComputerBusyError();
+    const otherRun = await deps.prisma.run.findFirst({
+      where: {
+        botId: { not: botId },
+        status: { in: [...ACTIVE_RUN_STATUSES] },
+        bot: { computerId },
+      },
+      select: { id: true },
+    });
+    if (otherRun) {
+      await deps.prisma.computer.updateMany({
+        where: { id: computerId, state: "suspending" },
+        data: { state: previousState },
+      });
+      throw new ComputerBusyError();
+    }
+  }
+
+  const oldRef = existing.providerRef ? toComputerRef(existing) : null;
+  try {
+    if (oldRef && existing.state === "running") {
+      try {
+        await checkpointAndRecordComputerWorkspace(deps, existing, oldRef, context);
+      } catch (error) {
+        if (mode === "reset") throw error;
+        if (!isUnrecoverableSandboxError(error)) throw error;
+      }
+    }
+    if (oldRef) {
+      await deps.sandbox.releaseScreen?.(oldRef, context).catch(() => undefined);
+      try {
+        await deps.sandbox.destroy(oldRef, context);
+      } catch (error) {
+        if (mode !== "recover" && !isUnrecoverableSandboxError(error)) throw error;
+      }
+    }
+    await deps.prisma.computerExecutionLease.deleteMany({
+      where: { computerId, botId },
+    });
+    await deps.prisma.computer.update({
+      where: { id: computerId },
+      data: {
+        state: "stopped",
+        providerRef: null,
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlBotId: null,
+        controlRunId: null,
+      },
+    });
+    return provisionComputer(deps, computerId, context, controlHolder);
+  } catch (error) {
+    await deps.prisma.computer
+      .updateMany({
+        where: { id: computerId },
+        data: { state: "error" },
+      })
+      .catch(() => undefined);
+    throw error;
+  }
 }

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -405,7 +405,7 @@ export async function replaceComputer(
   }
   const botId = context.botId;
   if (!botId) throw new Error("computer replacement requires a bot id");
-  if (hasActiveComputerControl(existing) && existing.controlBotId !== botId) {
+  if (hasActiveComputerControl(existing)) {
     throw new ComputerBusyError();
   }
   if (existing.state === "booting" || existing.state === "suspending") {

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -403,11 +403,14 @@ export async function replaceComputer(
       throw new Error("computer control revocation is still in progress");
     }
   }
+  const botId = context.botId;
+  if (!botId) throw new Error("computer replacement requires a bot id");
+  if (hasActiveComputerControl(existing) && existing.controlBotId !== botId) {
+    throw new ComputerBusyError();
+  }
   if (existing.state === "booting" || existing.state === "suspending") {
     throw new ComputerBusyError();
   }
-  const botId = context.botId;
-  if (!botId) throw new Error("computer replacement requires a bot id");
 
   const previousState = existing.state;
   if (existing.state !== "stopped" && existing.state !== "suspended") {

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -9,12 +9,12 @@ import type {
 import { ACTIVE_RUN_STATUSES, screenLeaseId } from "@rakazo/core";
 import { type PrismaClient, parseComputerMode, type ThreadEvents } from "@rakazo/db";
 import { expireComputerControl, hasActiveComputerControl } from "./computer-control.js";
+import { toComputerRef } from "./computer-support.js";
 import {
   checkpointAndRecordComputerWorkspace,
   ensureComputerWorkspaceLayout,
   restoreComputerWorkspace,
 } from "./computer-workspace.js";
-import { toComputerRef } from "./computer-support.js";
 import { isUnrecoverableSandboxError } from "./e2b-sandbox.js";
 import { resolveAgentHomePath } from "./home.js";
 
@@ -421,15 +421,14 @@ export async function replaceComputer(
       data: { state: "suspending" },
     });
     if (claimed.count !== 1) throw new ComputerBusyError();
-    const otherRun = await deps.prisma.run.findFirst({
+    const activeRun = await deps.prisma.run.findFirst({
       where: {
-        botId: { not: botId },
         status: { in: [...ACTIVE_RUN_STATUSES] },
         bot: { computerId },
       },
       select: { id: true },
     });
-    if (otherRun) {
+    if (activeRun) {
       await deps.prisma.computer.updateMany({
         where: { id: computerId, state: "suspending" },
         data: { state: previousState },
@@ -440,11 +439,10 @@ export async function replaceComputer(
 
   const oldRef = existing.providerRef ? toComputerRef(existing) : null;
   try {
-    if (oldRef && existing.state === "running") {
+    if (oldRef && existing.state === "running" && mode !== "reset") {
       try {
         await checkpointAndRecordComputerWorkspace(deps, existing, oldRef, context);
       } catch (error) {
-        if (mode === "reset") throw error;
         if (!isUnrecoverableSandboxError(error)) throw error;
       }
     }
@@ -456,9 +454,6 @@ export async function replaceComputer(
         if (mode !== "recover" && !isUnrecoverableSandboxError(error)) throw error;
       }
     }
-    await deps.prisma.computerExecutionLease.deleteMany({
-      where: { computerId, botId },
-    });
     await deps.prisma.computer.update({
       where: { id: computerId },
       data: {

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -512,6 +512,7 @@ export const ComputerStatusSchema = z.object({
   screenHeight: z.number().int().positive(),
   homeRevision: z.string().nullable(),
   busyBotName: z.string().nullable(),
+  updateAvailable: z.boolean(),
 });
 export type ComputerStatus = z.infer<typeof ComputerStatusSchema>;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -240,6 +240,9 @@ export const appContract = {
     status: oc.input(botId).output(ComputerStatusSchema),
     boot: oc.input(botId).output(ComputerStatusSchema),
     stop: oc.input(botId).output(ComputerStatusSchema),
+    recover: oc.input(botId).output(ComputerStatusSchema),
+    reset: oc.input(botId).output(ComputerStatusSchema),
+    update: oc.input(botId).output(ComputerStatusSchema),
     takeover: oc.input(botId).output(z.object({ leaseId: Id, expiresAt: z.string() })),
     release: oc
       .input(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes #241 (fork PR from [@bnsd55](https://github.com/bnsd55) / Ben Shaharizad) after rebase onto current `main`. Could not push the fork branch (`bnsd55/rakazo`), so this PR on `elie222/rakazo` keeps Ben’s commits plus conflict resolution (Lingui catalog refresh).

## Summary
- Add `computer.recover`, `computer.reset`, and `computer.update` on the existing provision/checkpoint/home path (no new snapshot table).
- Recover replaces an unreachable sandbox and keeps durable home; Reset checkpoints then restores last saved workspace; Update rebuilds with the current image (hidden on This Mac).
- Web bot settings + computer panel and Expo bot-settings + computer. Auto `recover-screen` still uses `computer.boot` so a missing stream URL does not destroy a live box.

## Test plan
- [ ] Recover on a wedged/unreachable computer: new provider instance, home files still there
- [ ] Reset with confirm: unsaved sandbox state gone, last checkpoint restored
- [ ] Update shown for e2b/docker; hidden on This Mac; 400 if called anyway
- [ ] Open computer panel while running but screen URL still loading: does **not** recreate the sandbox
- [ ] Other Team bot using the computer: 409

Credit: original work by Ben Shaharizad (@bnsd55) in #241.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dd3e7cd-e5b9-462f-8f0b-8cbb94753fe7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dd3e7cd-e5b9-462f-8f0b-8cbb94753fe7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added computer maintenance actions to web and mobile interfaces.
  - Recover unreachable computers while preserving saved workspace data.
  - Reset computers to the last saved workspace, with confirmation before unsaved work is lost.
  - Update supported computers using the latest image while preserving saved workspace data.
  - Maintenance controls now show progress, errors, availability, and refreshed status.

- **Bug Fixes**
  - Improved computer boot behavior for recovery-related actions.
  - Prevented control takeover unless the computer is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->