### PR TITLE
fix(web): harden jumpToMessage against stale scroll races

### DIFF
--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1010,15 +1010,23 @@ export function ShellPage() {
     });
     if (threadTarget.botId) {
       commitComputer(snap.computer ?? null);
-      setRoutines(await rpc.routines.list({ botId: threadTarget.botId }));
-      setRoutinesBotId(threadTarget.botId);
+      // Don't block parent-scroll on routines metadata; a list failure must not abort the jump.
+      void rpc.routines
+        .list({ botId: threadTarget.botId })
+        .then((routines) => {
+          if (epoch !== historyEpoch.current || jumpId !== jumpGeneration.current) return;
+          if (activeBotId.current !== threadTarget.botId) return;
+          setRoutines(routines);
+          setRoutinesBotId(threadTarget.botId);
+        })
+        .catch(() => undefined);
     } else {
       commitComputer(null);
       setRoutines([]);
       setRoutinesBotId(null);
     }
-    if (jumpId !== jumpGeneration.current) return;
     window.requestAnimationFrame(() => {
+      if (epoch !== historyEpoch.current || jumpId !== jumpGeneration.current) return;
       document
         .querySelector(`[data-message-id="${target.messageId}"]`)
         ?.scrollIntoView({ behavior: "smooth", block: "center" });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to CodeRabbit’s post-merge notes on #260:

1. Revalidate `jumpGeneration` / `historyEpoch` inside the `requestAnimationFrame` scroll callback so a newer click can’t be overridden by a stale frame.
2. Refresh routines off the jump critical path so a `routines.list` failure can’t prevent scrolling to the jumped-to parent.

## Test plan

- [x] Typecheck / biome
- [ ] CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d12918f1-9edf-4f71-a03f-12202ba71019?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d12918f1-9edf-4f71-a03f-12202ba71019&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search-result navigation now scrolls to matching messages without unnecessary delays.
  * Navigation remains reliable when routine data loads slowly or fails.
  * Prevented outdated navigation requests from overriding newer jumps or history changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->