### PR TITLE
fix: prevent Corepack prompt from hanging dev startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
   "scripts": {
-    "dev": "turbo dev --filter=@rakazo/api --filter=@rakazo/worker --filter=@rakazo/web --filter=@rakazo/sandbox-supervisor",
+    "dev": "cross-env COREPACK_ENABLE_DOWNLOAD_PROMPT=0 turbo dev --filter=@rakazo/api --filter=@rakazo/worker --filter=@rakazo/web --filter=@rakazo/sandbox-supervisor",
     "build": "turbo build",
     "check": "turbo check",
     "lint": "biome check .",
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.8",
     "@types/node": "^24.3.0",
+    "cross-env": "^10.1.0",
     "tsx": "^4.20.5",
     "turbo": "^2.5.6",
     "typescript": "^5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@types/node':
         specifier: ^24.3.0
         version: 24.13.3
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       tsx:
         specifier: ^4.20.5
         version: 4.23.12


### PR DESCRIPTION
 ## Summary

  - disable Corepack's download confirmation for the root development command
  - prevent Turbo's non-interactive child processes from waiting on hidden prompts
  - use `cross-env` so the fix works across macOS, Linux, and Windows

  ## Problem

  On a cold Corepack cache, `pnpm dev` starts four Turbo tasks. Each nested `pnpm run dev` process asks for confirmation before downloading the repository-pinned
  pnpm version, but Turbo does not expose those prompts. Startup therefore appears to hang after the Corepack download messages.

  ## Testing

  - verified startup against an empty temporary Corepack cache
  - verified web, API, worker, and sandbox supervisor reached their ready states
  - `CI=1 EXPO_NO_TELEMETRY=1 pnpm check`
  - `pnpm exec biome check package.json`
  - `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development command to run more consistently across environments.
  * Disabled interactive download prompts during development startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->