### PR TITLE
fix(dev): skip Corepack download prompt that hangs pnpm dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
   "scripts": {
-    "dev": "turbo dev --filter=@rakazo/api --filter=@rakazo/worker --filter=@rakazo/web --filter=@rakazo/sandbox-supervisor",
+    "dev": "COREPACK_ENABLE_DOWNLOAD_PROMPT=0 turbo dev --filter=@rakazo/api --filter=@rakazo/worker --filter=@rakazo/web --filter=@rakazo/sandbox-supervisor",
     "build": "turbo build",
     "check": "turbo check",
     "lint": "biome check .",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": ["COREPACK_ENABLE_DOWNLOAD_PROMPT"],
   "tasks": {
     "generate": {
       "cache": false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nested Corepack download prompts can hang `turbo` on a cold cache when running `pnpm dev`. This sets `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` on the root `dev` script (POSIX env prefix only) and adds it to Turbo `globalPassThroughEnv` so nested `pnpm run dev` tasks inherit it under Turbo 2 strict env mode.

No new dependencies and no lockfile changes.

Based on work by Rupinder Mazara in https://github.com/elie222/rakazo/pull/277; this supersedes that PR with a smaller approach (no `cross-env`).

Co-authored-by: Rupinder Mazara &lt;mazara.rupinder@gmail.com&gt;

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60801076-6ad3-424a-aadb-bca6a6f63c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60801076-6ad3-424a-aadb-bca6a6f63c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development startup reliability by preventing unexpected Corepack download prompts.
  * Ensured the relevant environment setting is consistently forwarded to development tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->