### PR TITLE
Add accessibility labels for Integrations Add/Remove and Speak

### DIFF
--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -277,9 +277,7 @@ export default function Integrations() {
                   </View>
                   <Pressable
                     accessibilityRole="button"
-                    accessibilityLabel={
-                      item.connected ? `Remove ${item.name}` : `Add ${item.name}`
-                    }
+                    accessibilityLabel={item.connected ? `Remove ${item.name}` : `Add ${item.name}`}
                     disabled={pending === key}
                     onPress={() => void (item.connected ? revoke(item) : connect(item))}
                   >

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -251,6 +251,7 @@ export default function Integrations() {
                   {disabled || !item ? null : (
                     <Pressable
                       accessibilityRole="button"
+                      accessibilityLabel={connected ? `Remove ${tile.label}` : `Add ${tile.label}`}
                       disabled={pending === key}
                       onPress={() => void (connected ? revoke(item) : connect(item))}
                     >
@@ -276,6 +277,9 @@ export default function Integrations() {
                   </View>
                   <Pressable
                     accessibilityRole="button"
+                    accessibilityLabel={
+                      item.connected ? `Remove ${item.name}` : `Add ${item.name}`
+                    }
                     disabled={pending === key}
                     onPress={() => void (item.connected ? revoke(item) : connect(item))}
                   >

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1721,7 +1721,13 @@ function MessageBubble({
               {blockText(message)}
             </ChatMarkdown>
             {onSpeak ? (
-              <Pressable onPress={onSpeak} hitSlop={8} style={{ marginTop: 8 }}>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Speak message"
+                onPress={onSpeak}
+                hitSlop={8}
+                style={{ marginTop: 8 }}
+              >
                 <Text style={{ color: "#85858A", fontSize: 13 }}>Speak</Text>
               </Pressable>
             ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Follow-up to #269 (already merged) for a CodeRabbit a11y note that landed after merge.
- Featured/catalog Add/Remove buttons get dynamic `accessibilityLabel` (`Add/Remove ${name}`).
- Speak control gets `accessibilityRole="button"` and `accessibilityLabel="Speak message"`.
- Biome formatting fix for the catalog `accessibilityLabel`.

## Test plan
- [ ] Expo Integrations: VoiceOver/TalkBack announces Add/Remove with the app name
- [ ] Expo thread Speak control announces “Speak message”
- [x] `biome check` clean on touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bd74b6f-60e6-411c-a9bb-c6d873ecde5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bd74b6f-60e6-411c-a9bb-c6d873ecde5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

