### PR TITLE
fix: allow parallel Open Connector action batches

### DIFF
--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -47,10 +47,7 @@ import {
   resolveActionApproval,
   sandboxCommandTimeoutMs,
   type ToolCallStreak,
-  type ToolNameStreak,
   toolRequiresApproval,
-  trackToolCallStreak,
-  trackToolNameStreak,
   userTurnBlocksForRun,
 } from "@rakazo/core";
 import { approvalEffectKey } from "@rakazo/core/node/approval-effect-key";
@@ -180,6 +177,7 @@ import {
   currentTurnFilesInstruction,
   materializeCurrentTurnFiles,
 } from "./thread-artifacts.js";
+import { advanceToolCallLoopGuard } from "./tool-loop.js";
 import { textContentArg } from "./tool-text.js";
 
 const modelCredentialLocks = new Map<string, Promise<void>>();
@@ -195,11 +193,6 @@ const READ_ONLY_AGENT_TOOLS = new Set([
   "skill_read",
 ]);
 const MAX_MODEL_FILE_BYTES = 250_000;
-// Same tool, same arguments, this many times in a row means the agent is stuck, not paginating.
-const MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 6;
-// Backstop for a stuck agent that varies its arguments each call (so the exact-match cap above
-// never trips) but keeps hammering the same tool without ever narrating progress in between.
-const MAX_CONSECUTIVE_SAME_TOOL_CALLS = 20;
 const BUILTIN_AGENT_TOOL_NAMES = new Set(builtinAgentTools.map((tool) => tool.name));
 
 /** Cap the roster so a large workspace cannot flood the prompt. */
@@ -863,7 +856,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
         let lastProgressAt = 0;
         let hasStreamedText = false;
         let toolCallStreak: ToolCallStreak = { key: undefined, count: 0 };
-        let toolNameStreak: ToolNameStreak = { name: undefined, count: 0 };
         let lastComputerFrameId: string | undefined;
         let terminalCheckpointComplete = false;
         let approvalPausePending = false;
@@ -1904,7 +1896,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
               assembled += event.text;
               currentTextSegment += event.text;
               toolCallStreak = { key: undefined, count: 0 };
-              toolNameStreak = { name: undefined, count: 0 };
               tryFlushPendingTools();
               pendingProgress += progressRedactor.push(event.text);
               const now = Date.now();
@@ -1913,7 +1904,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
               }
             } else if (event.type === "progress") {
               toolCallStreak = { key: undefined, count: 0 };
-              toolNameStreak = { name: undefined, count: 0 };
               // Flush batched text deltas first so an activity line cannot land
               // ahead of text the model streamed before the tool call.
               if (pendingProgress) {
@@ -2022,12 +2012,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
               });
               pendingToolNames.push(event.name);
               tryFlushPendingTools();
-              toolCallStreak = trackToolCallStreak(toolCallStreak, event.name, event.args);
-              toolNameStreak = trackToolNameStreak(toolNameStreak, event.name);
-              const stuckOnExactRepeat =
-                toolCallStreak.count >= MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS;
-              const stuckOnSameTool = toolNameStreak.count >= MAX_CONSECUTIVE_SAME_TOOL_CALLS;
-              if (stuckOnExactRepeat || stuckOnSameTool) {
+              const loopGuard = advanceToolCallLoopGuard(toolCallStreak, event.name, event.args);
+              toolCallStreak = loopGuard.streak;
+              if (loopGuard.stuck) {
                 approvedEffectReplays.assertDrained();
                 flushPendingTools();
                 if (!(await renewRunLease(deps, runId, workerId, fence))) return;
@@ -2036,9 +2023,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 }
                 await checkpointAndRecordComputerWorkspace(deps, storedComputer, computer, context);
                 terminalCheckpointComplete = true;
-                const stuckCount = stuckOnExactRepeat ? toolCallStreak.count : toolNameStreak.count;
-                const stuckDetail = stuckOnExactRepeat ? " with the same input" : "";
-                const stuckText = `I got stuck calling ${humanizeToolName(event.name)}${stuckDetail} ${stuckCount} times in a row without making progress, so I stopped early. Try rephrasing this, or ask me to try a different approach.`;
+                const stuckText = `I got stuck calling ${humanizeToolName(event.name)} with the same input ${toolCallStreak.count} times in a row without making progress, so I stopped early. Try rephrasing this, or ask me to try a different approach.`;
                 await deps.events.finalizeRun({
                   workspaceId: run.workspaceId,
                   threadId: thread.id,

--- a/packages/adapters/src/tool-loop.test.ts
+++ b/packages/adapters/src/tool-loop.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { advanceToolCallLoopGuard } from "./tool-loop.js";
+
+describe("advanceToolCallLoopGuard", () => {
+  it("allows a parallel Open Connector batch with distinct action inputs", () => {
+    let streak = { key: undefined as string | undefined, count: 0 };
+
+    for (let index = 0; index < 20; index += 1) {
+      const result = advanceToolCallLoopGuard(streak, "mcp__open-connector__execute_action", {
+        actionId: "records.get",
+        input: { recordId: index + 1 },
+      });
+      streak = result.streak;
+      expect(result.stuck).toBe(false);
+    }
+  });
+
+  it("stops six consecutive calls with identical inputs", () => {
+    let streak = { key: undefined as string | undefined, count: 0 };
+    let stuck = false;
+
+    for (let index = 0; index < 6; index += 1) {
+      const result = advanceToolCallLoopGuard(streak, "shell", { command: "npm test" });
+      streak = result.streak;
+      stuck = result.stuck;
+    }
+
+    expect(stuck).toBe(true);
+    expect(streak.count).toBe(6);
+  });
+});

--- a/packages/adapters/src/tool-loop.ts
+++ b/packages/adapters/src/tool-loop.ts
@@ -1,0 +1,16 @@
+import { type ToolCallStreak, trackToolCallStreak } from "@rakazo/core";
+
+// Same tool, same arguments, this many times in a row means the agent is stuck, not paginating.
+const MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 6;
+
+export function advanceToolCallLoopGuard(
+  streak: ToolCallStreak,
+  name: string,
+  args: unknown,
+): { streak: ToolCallStreak; stuck: boolean } {
+  const next = trackToolCallStreak(streak, name, args);
+  return {
+    streak: next,
+    stuck: next.count >= MAX_CONSECUTIVE_IDENTICAL_TOOL_CALLS,
+  };
+}


### PR DESCRIPTION
## Summary

- stop treating repeated tool names alone as evidence of a loop
- keep the existing six-call guard for identical tool names and arguments
- add regression coverage for 20 distinct Open Connector actions in one batch

## Why

Generic action routers expose many actions through one tool name. A model can emit a parallel batch of distinct calls before any progress event arrives, so the name-only streak could terminate a productive batch on its twentieth call.

## Testing

- pnpm --filter @rakazo/core test
- pnpm --filter @rakazo/adapters test
- pnpm --filter @rakazo/core check
- pnpm --filter @rakazo/adapters check
- pnpm exec biome check on the changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of repeated tool-call loops.
  * Prevents valid parallel actions with different inputs from being incorrectly stopped.
  * Stops execution after six consecutive identical tool calls and provides a consistent call count in the message.

* **Tests**
  * Added coverage for valid parallel tool calls and repeated identical calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->