### PR TITLE
fix(config): relax engines.node 24 floor to any 24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "packageManager": "pnpm@9.15.0",
   "engines": {
-    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+    "node": "^22.22.2 || ^24.0.0 || >=26.0.0"
   },
   "scripts": {
     "dev": "cross-env COREPACK_ENABLE_DOWNLOAD_PROMPT=0 turbo dev --filter=@rakazo/api --filter=@rakazo/worker --filter=@rakazo/web --filter=@rakazo/sandbox-supervisor",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
Relaxes only the Node 24 floor in root `package.json` `engines.node` from `^24.15.0` to `^24.0.0`, so earlier Node 24 point releases are accepted by pnpm.

**Final range:** `^22.22.2 || ^24.0.0 || >=26.0.0`

### Why this instead of #265
Community PR #265 by [@coneborg](https://github.com/coneborg) correctly identified that `^24.15.0` blocks Node 24 users, but also widened the Node 22 floor to `^22.0.0`. CI uses `node-version: 22` and docs target Node 22 — keep the existing `^22.22.2` floor and only relax Node 24. Retain `>=26.0.0`.

This PR supersedes #265 with that tightened engines string. Only the root `package.json` declares `engines`.

### Attribution
Original fix idea and PR: [#265](https://github.com/elie222/rakazo/pull/265) by coneborg.

### Test plan
- [ ] Confirm `package.json` engines is exactly `^22.22.2 || ^24.0.0 || >=26.0.0`
- [ ] Required CI green (Lint, Typecheck, Production builds, Unit tests, Postgres journeys, Web E2E)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a185b1a-6e54-41a0-a5ba-c1f2feef7d90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a185b1a-6e54-41a0-a5ba-c1f2feef7d90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded compatibility to support earlier Node.js 24.x releases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->