### PR TITLE
Stop markdown tables collapsing to one character per column

### DIFF
--- a/packages/chat-ui/src/markdown.web.css
+++ b/packages/chat-ui/src/markdown.web.css
@@ -172,6 +172,9 @@
   border: 1px solid #34343a;
   padding: 0.4em 0.6em;
   text-align: left;
+  /* Not the container's `anywhere`: its break opportunities count toward
+     min-content, so columns collapse to 1ch and the table never overflows. */
+  overflow-wrap: break-word;
 }
 
 .rk-chat-markdown th {


### PR DESCRIPTION
The markdown container sets overflow-wrap: anywhere so long URLs cannot escape the bubble. Table cells inherit it, and unlike break-word, `anywhere` counts its break opportunities toward min-content intrinsic sizing. Every column could therefore shrink to a single character, so the table always fit inside max-width: 100%, never overflowed, and the overflow-x: auto scroller had nothing to scroll. On a phone the result was vertical strings of letters.

Give cells overflow-wrap: break-word so they size to their longest word. The table then exceeds its container as intended and scrolls horizontally, while long words and URLs still wrap everywhere else.

Fixes #287 

<img width="431" height="797" alt="image" src="https://github.com/user-attachments/assets/9473e25d-ba28-4526-ab76-36c890eb680f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat markdown tables so long text wraps within cells without causing columns to collapse.
  * Prevented table content from overflowing its container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->