### PR TITLE
fix(onboarding): preserve chosen bot name and add password reveal

### DIFF
--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -10,8 +10,8 @@ import {
 
 /**
  * First-run conversational onboarding, seeded deterministically into the bot's
- * thread: greeting, a focus choice, two renames, and Composio app cards the
- * user authorizes inline. No model tokens are spent.
+ * thread: greeting, a focus choice, and Composio app cards the user authorizes
+ * inline. Focus must not rename the bot. No model tokens are spent.
  */
 
 type OnboardingDeps = {

--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -24,8 +24,6 @@ type FocusOption = {
   id: string;
   letter: string;
   label: string;
-  title: string;
-  persona: string;
   summary: string;
   apps: string[];
 };
@@ -35,8 +33,6 @@ const FOCUS_OPTIONS: FocusOption[] = [
     id: "day",
     letter: "A",
     label: "Day-to-day work",
-    title: "Chief of Staff",
-    persona: "Sarah",
     summary: "Slack, calendar, and email",
     apps: ["slack", "gmail", "googlecalendar"],
   },
@@ -44,8 +40,6 @@ const FOCUS_OPTIONS: FocusOption[] = [
     id: "inbox",
     letter: "B",
     label: "Inbox & email",
-    title: "Inbox Manager",
-    persona: "Maya",
     summary: "email and calendar",
     apps: ["gmail", "googlecalendar", "slack"],
   },
@@ -53,8 +47,6 @@ const FOCUS_OPTIONS: FocusOption[] = [
     id: "research",
     letter: "C",
     label: "Research & writing",
-    title: "Research Partner",
-    persona: "Alex",
     summary: "the web, notes, and docs",
     apps: ["hackernews", "notion", "googledocs"],
   },
@@ -62,8 +54,6 @@ const FOCUS_OPTIONS: FocusOption[] = [
     id: "everything",
     letter: "D",
     label: "A bit of everything",
-    title: "Chief of Staff",
-    persona: "June",
     summary: "Slack, calendar, and email",
     apps: ["slack", "gmail", "googlecalendar"],
   },
@@ -182,19 +172,14 @@ export async function chooseFocus(
   );
   await updateBlocks(deps, target, pending.id, blocks);
 
-  await deps.prisma.bot.update({
-    where: { id: bot.id },
-    data: { name: option.title, title: option.title },
-  });
-  await post(deps, target, [{ kind: "meta", text: `Renamed to ${option.title}` }]);
+  // Keep the name and title the user chose when creating the bot; the focus
+  // step only suggests apps, it must not rename the bot.
   await post(deps, target, [
     {
       kind: "text",
       text: `Got it. ${capitalize(option.summary)}. I’ll see what’s already connected so I don’t make you set something up twice.`,
     },
   ]);
-  await deps.prisma.bot.update({ where: { id: bot.id }, data: { name: option.persona } });
-  await post(deps, target, [{ kind: "meta", text: `Renamed to ${option.persona}` }]);
 
   const catalog = deps.composio
     ? await deps.composio

--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -12,7 +12,10 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await page.goto("/sign-up");
   await expect(page.getByLabel("Name")).toHaveAttribute("autocomplete", "name");
   await expect(page.getByLabel("Email")).toHaveAttribute("autocomplete", "username");
-  await expect(page.getByLabel("Password")).toHaveAttribute("autocomplete", "new-password");
+  await expect(page.getByLabel("Password", { exact: true })).toHaveAttribute(
+    "autocomplete",
+    "new-password",
+  );
 
   await signup(page, email, password, userName);
   await completeOnboarding(page);
@@ -38,7 +41,10 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await expect(page.getByText("Chief", { exact: true })).toHaveCount(0);
   await expect(page.getByText(userName, { exact: true })).toHaveCount(0);
   await expect(page.getByLabel("Email")).toHaveAttribute("autocomplete", "username");
-  await expect(page.getByLabel("Password")).toHaveAttribute("autocomplete", "current-password");
+  await expect(page.getByLabel("Password", { exact: true })).toHaveAttribute(
+    "autocomplete",
+    "current-password",
+  );
   await captureScreenshot(page, testInfo, "38-protected-deep-link-sign-in");
 
   await page.getByPlaceholder("Your email address").fill(email);

--- a/apps/web/e2e/onboarding-conversation.spec.ts
+++ b/apps/web/e2e/onboarding-conversation.spec.ts
@@ -20,10 +20,10 @@ test("focus choice suggests apps and preserves a completed connection", async ({
   await captureScreenshot(page, testInfo, "01-focus-choice");
 
   await page.getByRole("button", { name: /Day-to-day work/ }).click();
-  await expect(page.getByText("Renamed to Chief of Staff", { exact: true })).toBeVisible();
-  await expect(page.getByText("Renamed to Sarah", { exact: true })).toBeVisible();
-  await expect(page.locator("main").getByText("Sarah", { exact: true })).toBeVisible();
-  await expect(page.getByPlaceholder("Message Sarah")).toBeVisible();
+  // The focus step suggests apps but must not rename the bot: the name the
+  // user chose during creation ("Chief") is preserved.
+  await expect(page.locator("main").getByText("Chief", { exact: true })).toBeVisible();
+  await expect(page.getByPlaceholder("Message Chief")).toBeVisible();
   await expect(page.getByText("Slack", { exact: true })).toBeVisible();
   await expect(page.getByText("Gmail", { exact: true })).toBeVisible();
   await page

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -60,11 +60,11 @@ export function App() {
           <Route path="/" element={user ? <Navigate to="/app" replace /> : <WelcomePage />} />
           <Route
             path="/sign-in"
-            element={user ? <Navigate to="/app" replace /> : <AuthPage mode="in" />}
+            element={user ? <Navigate to="/app" replace /> : <AuthPage key="in" mode="in" />}
           />
           <Route
             path="/sign-up"
-            element={user ? <Navigate to="/onboarding" replace /> : <AuthPage mode="up" />}
+            element={user ? <Navigate to="/onboarding" replace /> : <AuthPage key="up" mode="up" />}
           />
           <Route
             path="/onboarding"

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -9,6 +9,7 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const title =
@@ -72,18 +73,61 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
         </label>
         <label className="mt-4 w-full text-[16px] text-[#6E6E68]">
           <Trans>Password</Trans>
-          <input
-            id={mode === "in" ? "current-password" : "new-password"}
-            name="password"
-            autoComplete={mode === "in" ? "current-password" : "new-password"}
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder={t`Password`}
-            type="password"
-            required
-            minLength={8}
-            className="mt-2 w-full rounded-[13px] border border-[#E4E4DE] bg-[#F1F1ED] px-[18px] py-[17px] text-[17px] text-[#1B1B1E] outline-none"
-          />
+          <div className="relative mt-2">
+            <input
+              id={mode === "in" ? "current-password" : "new-password"}
+              name="password"
+              autoComplete={mode === "in" ? "current-password" : "new-password"}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={t`Password`}
+              type={showPassword ? "text" : "password"}
+              required
+              minLength={8}
+              className="w-full rounded-[13px] border border-[#E4E4DE] bg-[#F1F1ED] py-[17px] pl-[18px] pr-[52px] text-[17px] text-[#1B1B1E] outline-none"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((shown) => !shown)}
+              aria-label={showPassword ? t`Hide password` : t`Show password`}
+              aria-pressed={showPassword}
+              className="absolute inset-y-0 right-0 flex items-center px-[18px] text-[#8C8C86] hover:text-[#1B1B1E]"
+            >
+              {showPassword ? (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M9.88 9.88a3 3 0 1 0 4.24 4.24" />
+                  <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68" />
+                  <path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61" />
+                  <line x1="2" y1="2" x2="22" y2="22" />
+                </svg>
+              ) : (
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              )}
+            </button>
+          </div>
         </label>
         {error ? <p className="mt-3 w-full text-sm text-[#C94244]">{error}</p> : null}
         <button

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { authClient } from "../lib/auth";
 
@@ -15,11 +15,6 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
   const passwordFieldId = mode === "in" ? "current-password" : "new-password";
   const title =
     mode === "in" ? <Trans>Sign in to Rakazo</Trans> : <Trans>Create your Rakazo</Trans>;
-
-  useEffect(() => {
-    setPassword("");
-    setShowPassword(false);
-  }, [mode]);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { authClient } from "../lib/auth";
 
@@ -12,8 +12,14 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const passwordFieldId = mode === "in" ? "current-password" : "new-password";
   const title =
     mode === "in" ? <Trans>Sign in to Rakazo</Trans> : <Trans>Create your Rakazo</Trans>;
+
+  useEffect(() => {
+    setPassword("");
+    setShowPassword(false);
+  }, [mode]);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -71,11 +77,13 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
             className="mt-2 w-full rounded-[13px] border border-[#E4E4DE] bg-[#F1F1ED] px-[18px] py-[17px] text-[17px] text-[#1B1B1E] outline-none"
           />
         </label>
-        <label className="mt-4 w-full text-[16px] text-[#6E6E68]">
-          <Trans>Password</Trans>
+        <div className="mt-4 w-full text-[16px] text-[#6E6E68]">
+          <label htmlFor={passwordFieldId}>
+            <Trans>Password</Trans>
+          </label>
           <div className="relative mt-2">
             <input
-              id={mode === "in" ? "current-password" : "new-password"}
+              id={passwordFieldId}
               name="password"
               autoComplete={mode === "in" ? "current-password" : "new-password"}
               value={password}
@@ -128,7 +136,7 @@ export function AuthPage({ mode }: { mode: "in" | "up" }) {
               )}
             </button>
           </div>
-        </label>
+        </div>
         {error ? <p className="mt-3 w-full text-sm text-[#C94244]">{error}</p> : null}
         <button
           type="submit"


### PR DESCRIPTION
## Summary

Two fixes:

1. **Onboarding always renamed the first bot** (e.g. every bot ended up named `Maya`). The conversational focus step in `chooseFocus` unconditionally overwrote the user's chosen `name`/`title` with a hardcoded persona tied to each focus option (`Inbox & email` -> `Maya`). The name the user typed reached `bots.create` correctly, then got clobbered seconds later. The focus step now only suggests apps and leaves the user's name/title intact. Removed the dead `title`/`persona` fields on `FocusOption`.

2. **No show/hide toggle on the auth password field.** Added a reveal toggle (icon-only, `aria-label` + `aria-pressed`) to `apps/web/src/pages/Auth.tsx`. Covers the desktop surface too, since Electron hosts the web renderer.

## Testing

- `biome check` on changed files — clean
- `tsc` for `apps/api` and `apps/web` — 0 errors
- `vitest` `bootstrap-target.test.ts` — pass
- Updated `apps/web/e2e/onboarding-conversation.spec.ts`: it previously asserted the buggy rename ("Renamed to Sarah"); now asserts the chosen name is preserved. e2e (Playwright) needs Docker — CI runs it.

## Notes

Other web password/API-key fields (model/voice/MCP settings, onboarding provider keys) and the mobile app still lack reveal toggles — left out of scope for this focused fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a show/hide password control on authentication forms.
  * Improved password field accessibility with descriptive labels and state indicators.
  * Authentication forms now reset correctly when switching between sign-in and sign-up.
  * Bot names selected during creation are preserved throughout onboarding.
  * Onboarding focus choices proceed directly to confirmation and app connection steps.

* **Bug Fixes**
  * Prevented onboarding from unexpectedly renaming bots after a focus is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->