### PR TITLE
fix(web): harden bot-crud computer panel E2E against skipped boot overlay

### DIFF
--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -79,14 +79,10 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   const sidePanel = page.getByTestId("side-panel");
   await expect(sidePanel).toHaveAttribute("data-panel", "computer");
   await expect(page.getByRole("button", { name: "Show settings" })).toBeVisible();
-  // "Booting up … computer" only flashes when auto-boot runs with overlay. Team desktops that
-  // are already running/asleep/stopped (or finish before Playwright observes the flash) skip it.
+  // Overlay may flash during boot or never appear (already ready/asleep/stopped). Assert panel
+  // chrome, then wait until any overlay has cleared — avoid Locator.or() strict-mode multi-hits.
   const bootOverlay = page.getByText(/Booting up .* computer/);
-  await expect(
-    bootOverlay
-      .or(sidePanel.getByRole("button", { name: "Take control" }))
-      .or(sidePanel.getByText(/Computer is asleep|Computer is stopped|Team Computer/)),
-  ).toBeVisible();
+  await expect(sidePanel.getByRole("button", { name: "Take control" })).toBeVisible();
   await expect(bootOverlay).toBeHidden();
   await captureScreenshot(page, testInfo, "27b-computer-panel");
   await page.getByRole("button", { name: "Show settings" }).click();

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -76,10 +76,17 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   await expect(modelSelect).toContainText("Workspace default");
   await captureScreenshot(page, testInfo, "27a-bot-settings-model");
   await page.getByRole("button", { name: "Show computer" }).click();
-  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "computer");
+  const sidePanel = page.getByTestId("side-panel");
+  await expect(sidePanel).toHaveAttribute("data-panel", "computer");
   await expect(page.getByRole("button", { name: "Show settings" })).toBeVisible();
+  // "Booting up … computer" only flashes when auto-boot runs with overlay. Team desktops that
+  // are already running/asleep/stopped (or finish before Playwright observes the flash) skip it.
   const bootOverlay = page.getByText(/Booting up .* computer/);
-  await expect(bootOverlay).toBeVisible();
+  await expect(
+    bootOverlay
+      .or(sidePanel.getByRole("button", { name: "Take control" }))
+      .or(sidePanel.getByText(/Computer is asleep|Computer is stopped|Team Computer/)),
+  ).toBeVisible();
   await expect(bootOverlay).toBeHidden();
   await captureScreenshot(page, testInfo, "27b-computer-panel");
   await page.getByRole("button", { name: "Show settings" }).click();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Web E2E on main failed at `bot-crud.spec.ts` waiting for `Booting up .* computer` after opening the computer panel. That full-screen overlay only appears when `computerPanelAutoBoot` chooses `"boot"` with `overlay: true`. New bots default to **Team** mode, so the shared desktop can already be running, asleep, stopped, or mid-boot/recover without ever showing that copy—or the flash can finish before Playwright observes it.

## Change

Harden the bot-crud computer-panel assertion:
1. Require a usable panel via `Take control` (always present when the user does not hold control).
2. Require any `Booting up … computer` overlay to clear (passes immediately if it never appeared; waits if boot is in flight).

Avoids `Locator.or()` multi-match strict-mode failures when overlay and panel chrome are visible together. Does not change product boot UX or revert #291 markdown CSS.

## Why this should fix CI

The original failure was requiring overlay visibility. An intermediate `.or()` harden failed with a Playwright strict-mode violation when overlay + Take control + Team Computer matched at once. Asserting panel chrome + cleared overlay covers both the skipped-overlay and mid-boot cases without multi-match.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34a147d6-16b0-4ca9-96ba-20296e570290?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34a147d6-16b0-4ca9-96ba-20296e570290&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for the bot computer panel.
  * Tests now take control of the computer and verify that the boot overlay is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->