### PR TITLE
fix(api): expose failed bot runs to clients

### DIFF
--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -74,6 +74,53 @@ describe("threadSnapshot", () => {
       }),
     ]);
   });
+
+  it("returns the latest failed run so the client can show its error", async () => {
+    const run = {
+      id: "run-failed",
+      botId: "bot-1",
+      threadId: "thread-1",
+      taskId: "task-1",
+      status: "failed",
+      trigger: "user",
+      modelProvider: "openrouter",
+      modelId: "openrouter/unknown",
+      error: "Provider is not configured: openrouter",
+      startedAt: null,
+      completedAt: new Date("2026-08-23T00:00:01.000Z"),
+      createdAt: new Date("2026-08-23T00:00:00.000Z"),
+    };
+    const findManyEvents = vi.fn();
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      message: { findMany: vi.fn().mockResolvedValue([]) },
+      event: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: findManyEvents,
+      },
+      run: { findFirst: vi.fn().mockResolvedValue(run) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+    const target = {
+      kind: "bot",
+      botId: "bot-1",
+      threadId: "thread-1",
+      bot: { computer: null },
+    } as ThreadTarget;
+
+    const snapshot = await threadSnapshot({ prisma }, target);
+
+    expect(snapshot.run).toEqual(
+      expect.objectContaining({
+        id: "run-failed",
+        status: "failed",
+        error: "Provider is not configured: openrouter",
+      }),
+    );
+    expect(findManyEvents).not.toHaveBeenCalled();
+  });
 });
 
 describe("stopThreadRuns", () => {

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -279,6 +279,7 @@ export async function threadSnapshot(
             where: {
               botId: target.botId,
               threadId: target.threadId,
+              status: { in: [...ACTIVE_RUN_STATUSES, "failed"] },
             },
             orderBy: { createdAt: "desc" },
           }),

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -278,21 +278,22 @@ export async function threadSnapshot(
           tx.run.findFirst({
             where: {
               botId: target.botId,
-              status: { in: [...ACTIVE_RUN_STATUSES] },
+              threadId: target.threadId,
             },
             orderBy: { createdAt: "desc" },
           }),
         ]);
-        const liveEvents = run
-          ? await tx.event.findMany({
-              where: {
-                threadId: target.threadId,
-                runId: run.id,
-                type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
-              },
-              orderBy: { seq: "asc" },
-            })
-          : [];
+        const liveEvents =
+          run && ACTIVE_RUN_STATUSES.includes(run.status as never)
+            ? await tx.event.findMany({
+                where: {
+                  threadId: target.threadId,
+                  runId: run.id,
+                  type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
+                },
+                orderBy: { seq: "asc" },
+              })
+            : [];
         return { messagePage, last, run, liveEvents };
       }),
     ]);


### PR DESCRIPTION
## Summary
- Return the latest run for a bot thread, including failed runs.
- Only load live events for active runs.
- Prevent failed provider errors from appearing as an empty chat.

## Verification
- `pnpm exec biome check apps/api/src/thread-target.ts apps/api/src/thread-target.test.ts`
- `pnpm --filter @rakazo/api check`
- `npx vitest run apps/api/src/thread-target.test.ts` (3 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Thread snapshots now include the latest run regardless of its status.
  - Failed runs display their error details in the snapshot.
  - Live events are loaded only when a run is actively in progress, preventing unnecessary event loading for completed or failed runs.

- **Tests**
  - Added coverage for displaying failed runs and skipping event loading when no active run exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->