### PR TITLE
fix(api): expose failed bot runs in threadSnapshot (not cancelled/completed)

### DIFF
--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -74,6 +74,53 @@ describe("threadSnapshot", () => {
       }),
     ]);
   });
+
+  it("returns the latest failed run so the client can show its error", async () => {
+    const run = {
+      id: "run-failed",
+      botId: "bot-1",
+      threadId: "thread-1",
+      taskId: "task-1",
+      status: "failed",
+      trigger: "user",
+      modelProvider: "openrouter",
+      modelId: "openrouter/unknown",
+      error: "Provider is not configured: openrouter",
+      startedAt: null,
+      completedAt: new Date("2026-08-23T00:00:01.000Z"),
+      createdAt: new Date("2026-08-23T00:00:00.000Z"),
+    };
+    const findManyEvents = vi.fn();
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      message: { findMany: vi.fn().mockResolvedValue([]) },
+      event: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: findManyEvents,
+      },
+      run: { findFirst: vi.fn().mockResolvedValue(run) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+    const target = {
+      kind: "bot",
+      botId: "bot-1",
+      threadId: "thread-1",
+      bot: { computer: null },
+    } as ThreadTarget;
+
+    const snapshot = await threadSnapshot({ prisma }, target);
+
+    expect(snapshot.run).toEqual(
+      expect.objectContaining({
+        id: "run-failed",
+        status: "failed",
+        error: "Provider is not configured: openrouter",
+      }),
+    );
+    expect(findManyEvents).not.toHaveBeenCalled();
+  });
 });
 
 describe("stopThreadRuns", () => {

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -91,6 +91,7 @@ describe("threadSnapshot", () => {
       createdAt: new Date("2026-08-23T00:00:00.000Z"),
     };
     const findManyEvents = vi.fn();
+    const findFirstRun = vi.fn().mockResolvedValue(run);
     const tx = {
       $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
       message: { findMany: vi.fn().mockResolvedValue([]) },
@@ -98,7 +99,7 @@ describe("threadSnapshot", () => {
         findFirst: vi.fn().mockResolvedValue(null),
         findMany: findManyEvents,
       },
-      run: { findFirst: vi.fn().mockResolvedValue(run) },
+      run: { findFirst: findFirstRun },
     };
     const prisma = {
       $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
@@ -112,6 +113,17 @@ describe("threadSnapshot", () => {
 
     const snapshot = await threadSnapshot({ prisma }, target);
 
+    expect(findFirstRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          botId: "bot-1",
+          threadId: "thread-1",
+          status: {
+            in: ["queued", "leased", "running", "waiting_input", "waiting_takeover", "failed"],
+          },
+        }),
+      }),
+    );
     expect(snapshot.run).toEqual(
       expect.objectContaining({
         id: "run-failed",
@@ -119,6 +131,43 @@ describe("threadSnapshot", () => {
         error: "Provider is not configured: openrouter",
       }),
     );
+    expect(findManyEvents).not.toHaveBeenCalled();
+  });
+
+  it("does not return a cancelled or completed run", async () => {
+    const findManyEvents = vi.fn();
+    const findFirstRun = vi.fn().mockResolvedValue(null);
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      message: { findMany: vi.fn().mockResolvedValue([]) },
+      event: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: findManyEvents,
+      },
+      run: { findFirst: findFirstRun },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+    const target = {
+      kind: "bot",
+      botId: "bot-1",
+      threadId: "thread-1",
+      bot: { computer: null },
+    } as ThreadTarget;
+
+    const snapshot = await threadSnapshot({ prisma }, target);
+
+    expect(findFirstRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: {
+            in: ["queued", "leased", "running", "waiting_input", "waiting_takeover", "failed"],
+          },
+        }),
+      }),
+    );
+    expect(snapshot.run).toBeNull();
     expect(findManyEvents).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -278,21 +278,22 @@ export async function threadSnapshot(
           tx.run.findFirst({
             where: {
               botId: target.botId,
-              status: { in: [...ACTIVE_RUN_STATUSES] },
+              threadId: target.threadId,
             },
             orderBy: { createdAt: "desc" },
           }),
         ]);
-        const liveEvents = run
-          ? await tx.event.findMany({
-              where: {
-                threadId: target.threadId,
-                runId: run.id,
-                type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
-              },
-              orderBy: { seq: "asc" },
-            })
-          : [];
+        const liveEvents =
+          run && ACTIVE_RUN_STATUSES.includes(run.status as never)
+            ? await tx.event.findMany({
+                where: {
+                  threadId: target.threadId,
+                  runId: run.id,
+                  type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
+                },
+                orderBy: { seq: "asc" },
+              })
+            : [];
         return { messagePage, last, run, liveEvents };
       }),
     ]);

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -4,9 +4,15 @@ import {
   type Actor,
   GROUP_MEMBER_MIN,
   type GroupMember,
+  type RunStatus,
   type ThreadSnapshot,
 } from "@rakazo/contracts";
-import { ACTIVE_RUN_STATUSES, projectMessages, resolveGroupTargetBotIds } from "@rakazo/core";
+import {
+  ACTIVE_RUN_STATUSES,
+  isActive,
+  projectMessages,
+  resolveGroupTargetBotIds,
+} from "@rakazo/core";
 import {
   appendEventInTransaction,
   createGroupRepos,
@@ -279,12 +285,13 @@ export async function threadSnapshot(
             where: {
               botId: target.botId,
               threadId: target.threadId,
+              status: { in: [...ACTIVE_RUN_STATUSES, "failed"] },
             },
             orderBy: { createdAt: "desc" },
           }),
         ]);
         const liveEvents =
-          run && ACTIVE_RUN_STATUSES.includes(run.status as never)
+          run && isActive(run.status as RunStatus)
             ? await tx.event.findMany({
                 where: {
                   threadId: target.threadId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Builds on community work by **Huynh Huu Khang** ([@shinjikhang](https://github.com/shinjikhang)) in #294 to surface failed 1:1 bot runs in `threadSnapshot` (so provider errors are not an empty chat), while preserving the product contract that after clear/stop `snap.run` is null.

### What changed vs #294

#294 scoped the run query with `threadId` and returned the **latest run of any status**, then loaded live events only when active. That broke Postgres journeys that expect `snap.run === null` after clear/stop when the latest run is `cancelled`.

This PR:

- Keeps `botId` + `threadId` scoping from #294
- Returns the latest run whose status is in `ACTIVE_RUN_STATUSES` **or** `"failed"` (not `cancelled` / `completed`)
- Loads live events only when `isActive(run.status)` (from `@rakazo/core`)
- Keeps the failed-run unit test; adds coverage that cancelled/completed are excluded from the query so `snap.run` is null
- Does **not** change journey assertions or group snapshot behavior

### Attribution

Cherry-picked `92d7f18` from #294, then fixed the status filter. Co-authored-by Huynh Huu Khang &lt;huukhang1999@gmail.com&gt;.

### Verification

- `pnpm exec biome check apps/api/src/thread-target.ts apps/api/src/thread-target.test.ts`
- `pnpm --filter @rakazo/api check`
- `pnpm exec vitest run apps/api/src/thread-target.test.ts` (4 passed)

Journey assertions that require `snap.run` null after clear/stop were **not** rewritten.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68c63af8-034b-4405-851c-2930f047bcea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68c63af8-034b-4405-851c-2930f047bcea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread snapshots now correctly display the latest failed run and its error message.
  * Completed or cancelled runs no longer incorrectly appear as active.
  * Live event details are shown only for runs that are still active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->