### PR TITLE
fix: key MCP session cache by identity, not server id

### DIFF
--- a/packages/adapters/src/mcp-connector.test.ts
+++ b/packages/adapters/src/mcp-connector.test.ts
@@ -105,4 +105,31 @@ describe("MCP connector session cache", () => {
 
     await connector.close();
   });
+
+  it("does not reuse one session across workspaces", async () => {
+    const state = { failNext: false, initializations: 0 };
+    vi.stubGlobal("fetch", mcpFetch(state));
+    const prisma = {
+      botMcpServer: {
+        findMany: vi.fn().mockResolvedValue([ASSIGNMENT]),
+        findFirst: vi.fn().mockResolvedValue(ASSIGNMENT),
+      },
+    };
+    const connector = new McpConnector(prisma as never, {} as never, {
+      network: { resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }] },
+    });
+    const contextFor = (workspaceId: string, userId: string) =>
+      ({ workspaceId, userId, botId: "bot-1", signal: new AbortController().signal }) as never;
+
+    await connector.discoverTools(contextFor("w1", "u1"));
+    expect(state.initializations).toBe(1);
+
+    await connector.discoverTools(contextFor("w2", "u2"));
+    expect(state.initializations).toBe(2);
+
+    await connector.discoverTools(contextFor("w1", "u1"));
+    expect(state.initializations).toBe(2);
+
+    await connector.close();
+  });
 });

--- a/packages/adapters/src/mcp-connector.ts
+++ b/packages/adapters/src/mcp-connector.ts
@@ -76,7 +76,7 @@ export class McpConnector implements ConnectorProvider {
             `mcp discovery failed for server ${assignment.server.slug}:`,
             error instanceof Error ? error.message : error,
           );
-          await this.evict(assignment.server.id);
+          await this.evict(this.sessionKey(assignment.server, context));
           return [];
         }
       }),
@@ -120,7 +120,7 @@ export class McpConnector implements ConnectorProvider {
       yield { type: "result", data: result };
     } catch (error) {
       // A thrown call means the transport or auth broke; drop the session so the next call reconnects.
-      await this.evict(assignment.server.id);
+      await this.evict(this.sessionKey(assignment.server, context));
       yield { type: "error", message: error instanceof Error ? error.message : String(error) };
     }
   }
@@ -132,25 +132,31 @@ export class McpConnector implements ConnectorProvider {
     this.connecting.clear();
   }
 
-  private async evict(serverId: string): Promise<void> {
-    const entry = this.sessions.get(String(serverId));
+  private sessionKey(server: McpServer, context: AdapterContext): string {
+    // Identity headers are applied once, at connect time, so a session is only
+    // valid for the identity it connected as. The key has to carry that identity.
+    return `${server.id} ${context.workspaceId} ${context.userId}`;
+  }
+
+  private async evict(sessionKey: string): Promise<void> {
+    const entry = this.sessions.get(sessionKey);
     if (!entry) return;
-    this.sessions.delete(String(serverId));
+    this.sessions.delete(sessionKey);
     await entry.session.close();
   }
 
   private async sessionFor(server: McpServer, context: AdapterContext): Promise<McpSession> {
-    const sessionKey = String(server.id);
+    const sessionKey = this.sessionKey(server, context);
     const existing = this.sessions.get(sessionKey);
     if (existing && existing.revision === server.revision) return existing.session;
     const pending = this.connecting.get(sessionKey);
     if (pending?.revision === server.revision) return pending.promise;
     if (pending) {
       await pending.promise.catch(() => undefined);
-      await this.evict(server.id);
+      await this.evict(sessionKey);
       return this.sessionFor(server, context);
     }
-    if (existing) await this.evict(server.id);
+    if (existing) await this.evict(sessionKey);
 
     const promise = this.connectSession(server, context).then((session) => {
       this.sessions.set(sessionKey, { session, revision: server.revision });


### PR DESCRIPTION
## What changed

MCP sessions are now cached by MCP server, workspace, and user identity instead of server ID alone. This prevents a session opened for one workspace/user from being reused by another identity.

## How tested

- `pnpm exec biome check packages/adapters/src/mcp-connector.ts packages/adapters/src/mcp-connector.test.ts`
- `npx vitest run packages/adapters/src/mcp-connector.test.ts`

Both checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling to prevent connections from being incorrectly reused across different workspaces or user contexts.
  * Ensured each workspace and user combination maintains the correct isolated session.
  * Updated error recovery so failed sessions are properly cleared and re-established when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->