### PR TITLE
fix: pair the deployment model key with the provider it belongs to

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,13 @@ SANDBOX_COMMAND_TIMEOUT_MS=300000
 # means unlimited (default). Set a positive integer to soft-stop a turn that
 # exceeds the budget and still emit a final assistant message.
 MAX_TOOL_CALLS_PER_TURN=
+# The deployment-wide fallback model: one provider, one key for it. PI_DEFAULT_PROVIDER
+# picks which key below is used, so the two must be set together — see
+# resolveDeploymentModel in @rakazo/core. Users who connect their own key
+# (rpc/models/connect) never touch these.
 OPENROUTER_API_KEY=
+# Set only when PI_DEFAULT_PROVIDER=anthropic.
+ANTHROPIC_API_KEY=
 PI_DEFAULT_PROVIDER=openrouter
 # Text-only by default. Computer use (screenshots via computer_observe / computer_act)
 # needs a vision-capable model — one whose catalog entry lists image input modalities

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -196,9 +196,9 @@ export async function createApp(
     artifacts,
     connector: stack.connector,
     listConnectedPluginSlugs: stack.composio?.listConnectedSlugs.bind(stack.composio),
-    secrets: [env.openRouterKey ?? "", env.composioApiKey ?? ""].filter(Boolean),
+    secrets: [env.deploymentModelKey ?? "", env.composioApiKey ?? ""].filter(Boolean),
     secretStore: secrets,
-    deploymentModelKey: env.openRouterKey,
+    deploymentModelKey: env.deploymentModelKey,
     dataDir: env.dataDir,
     notifications,
     jobs,
@@ -216,7 +216,7 @@ export async function createApp(
     runtime,
     secretStore: secrets,
     memoryProviders,
-    deploymentModelKey: env.openRouterKey,
+    deploymentModelKey: env.deploymentModelKey,
   });
   if (inMemoryJobs) {
     await inMemoryJobs.start(jobHandlers);
@@ -244,7 +244,7 @@ export async function createApp(
     env: {
       defaultProvider: env.defaultProvider,
       defaultModel: env.defaultModel,
-      openRouterKey: env.openRouterKey,
+      deploymentModelKey: env.deploymentModelKey,
       webOrigin: env.webOrigin,
       screenProxySecret: env.authSecret,
       sandboxProvider: env.sandboxProvider,

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,4 +1,9 @@
-import { resolveAuthSecret, resolveEncryptionKey, resolveSupervisorToken } from "@rakazo/core";
+import {
+  resolveAuthSecret,
+  resolveDeploymentModel,
+  resolveEncryptionKey,
+  resolveSupervisorToken,
+} from "@rakazo/core";
 
 export interface AppEnv {
   databaseUrl: string;
@@ -15,7 +20,7 @@ export interface AppEnv {
   sandboxSupervisorToken: string;
   sandboxProvider: string;
   agentRuntime: string;
-  openRouterKey: string | undefined;
+  deploymentModelKey: string | undefined;
   e2bApiKey: string | undefined;
   daytonaApiKey: string | undefined;
   daytonaApiUrl: string | undefined;
@@ -38,6 +43,7 @@ export interface AppEnv {
 
 export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
   const authSecret = resolveAuthSecret(source);
+  const deploymentModel = resolveDeploymentModel(source);
   return {
     databaseUrl: required(source, "DATABASE_URL"),
     realtimeDatabaseUrl: source.REALTIME_DATABASE_URL ?? required(source, "DATABASE_URL"),
@@ -53,7 +59,8 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     sandboxSupervisorToken: resolveSupervisorToken(source),
     sandboxProvider: source.SANDBOX_PROVIDER ?? "docker",
     agentRuntime: source.AGENT_RUNTIME ?? "pi",
-    openRouterKey: source.OPENROUTER_API_KEY,
+    // Provider, model and key resolve together: see resolveDeploymentModel.
+    deploymentModelKey: deploymentModel.key,
     e2bApiKey: source.E2B_API_KEY,
     daytonaApiKey: source.DAYTONA_API_KEY,
     daytonaApiUrl: source.DAYTONA_API_URL,
@@ -66,8 +73,8 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     pipedreamProjectId: optional(source.PIPEDREAM_PROJECT_ID),
     pipedreamEnvironment:
       source.PIPEDREAM_ENVIRONMENT === "production" ? "production" : "development",
-    defaultProvider: source.PI_DEFAULT_PROVIDER ?? "openrouter",
-    defaultModel: source.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731",
+    defaultProvider: deploymentModel.provider,
+    defaultModel: deploymentModel.model,
     wakeupDriver: source.WAKEUP_DRIVER ?? "graphile",
     mcpStdioEnabled: source.MCP_STDIO_ENABLED === "true",
     mcpStdioAllowedCommands: (source.MCP_STDIO_ALLOWED_COMMANDS ?? "")

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -303,7 +303,7 @@ export interface RouterDeps {
   env: {
     defaultProvider: string;
     defaultModel: string;
-    openRouterKey?: string;
+    deploymentModelKey?: string;
     webOrigin: string;
     screenProxySecret: string;
     sandboxProvider: string;
@@ -2898,7 +2898,7 @@ async function meDto(deps: RouterDeps, actor: Actor): Promise<Me> {
     deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
   ]);
   const hasDeployment = Boolean(
-    settings?.deploymentModelCredentialCipher || deps.env.openRouterKey,
+    settings?.deploymentModelCredentialCipher || deps.env.deploymentModelKey,
   );
   return {
     userId: actor.userId,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -29,7 +29,7 @@ import {
   ScriptedAgentRuntime,
   WorkspaceMemoryProviderResolver,
 } from "@rakazo/adapters";
-import { resolveEncryptionKey } from "@rakazo/core";
+import { resolveDeploymentModel, resolveEncryptionKey } from "@rakazo/core";
 import { createDb, createThreadEvents } from "@rakazo/db";
 import { MarkdownMemoryStore } from "@rakazo/memory";
 
@@ -45,6 +45,8 @@ async function main() {
   const runtime =
     process.env.AGENT_RUNTIME === "scripted" ? new ScriptedAgentRuntime() : new PiAgentRuntime();
   const dataDir = process.env.DATA_DIR ?? "./data";
+  // Same resolver the API uses, so both processes agree on provider, model and key.
+  const { key: deploymentModelKey } = resolveDeploymentModel();
   const sandbox = createRunSandbox(process.env.SANDBOX_PROVIDER ?? "docker", {
     supervisorUrl: process.env.SANDBOX_SUPERVISOR_URL ?? "http://127.0.0.1:7091",
     e2bApiKey: process.env.E2B_API_KEY,
@@ -103,11 +105,9 @@ async function main() {
     artifacts,
     connector: stack.connector,
     listConnectedPluginSlugs: stack.composio?.listConnectedSlugs.bind(stack.composio),
-    secrets: [process.env.OPENROUTER_API_KEY ?? "", process.env.COMPOSIO_API_KEY ?? ""].filter(
-      Boolean,
-    ),
+    secrets: [deploymentModelKey ?? "", process.env.COMPOSIO_API_KEY ?? ""].filter(Boolean),
     secretStore: secrets,
-    deploymentModelKey: process.env.OPENROUTER_API_KEY,
+    deploymentModelKey,
     dataDir,
     notifications: new ExpoPushProvider(dataDir),
     jobs,
@@ -125,7 +125,7 @@ async function main() {
     runtime,
     secretStore: secrets,
     memoryProviders,
-    deploymentModelKey: process.env.OPENROUTER_API_KEY,
+    deploymentModelKey,
   });
   await jobHost.start(jobHandlers);
   const reconciler = createJobReconciler({

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -45,6 +45,7 @@ import {
   redactSecrets,
   renderBotDirectory,
   resolveActionApproval,
+  resolveDeploymentModel,
   sandboxCommandTimeoutMs,
   type ToolCallStreak,
   toolRequiresApproval,
@@ -312,18 +313,21 @@ export function createRunExecutor(deps: ExecutorDeps) {
       const useOverride = Boolean(hasOverride && overrideCredential);
       const credential = useOverride ? overrideCredential : defaultCredential;
       const resolved = await resolveModelKey(deps, scope.userId, scope.workspaceId, credential);
+      // Provider and model come from one resolver, so the deployment key can never be
+      // offered to a provider it does not belong to.
+      const deployment = deps.deploymentModelKey ? resolveDeploymentModel() : null;
       const provider =
         (useOverride ? override!.modelProvider : null) ??
         credential?.provider ??
         settings?.defaultModelProvider ??
-        (deps.deploymentModelKey ? "openrouter" : "scripted");
+        deployment?.provider ??
+        "scripted";
       const id =
         (useOverride ? override!.modelId : null) ??
         credential?.defaultModel ??
         settings?.defaultModelId ??
-        (deps.deploymentModelKey
-          ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731")
-          : "scripted");
+        deployment?.model ??
+        "scripted";
       return {
         provider,
         id,
@@ -747,18 +751,19 @@ export function createRunExecutor(deps: ExecutorDeps) {
           (values) => runSecrets.push(...values),
         );
         runSecrets.push(...resolved.redact);
+        const runDeployment = deps.deploymentModelKey ? resolveDeploymentModel() : null;
         const runModelProvider =
           (useModelOverride ? bot.modelProvider : null) ??
           credential?.provider ??
           settings?.defaultModelProvider ??
-          (deps.deploymentModelKey ? "openrouter" : "scripted");
+          runDeployment?.provider ??
+          "scripted";
         const runModelId =
           (useModelOverride ? bot.modelId : null) ??
           credential?.defaultModel ??
           settings?.defaultModelId ??
-          (deps.deploymentModelKey
-            ? (process.env.PI_DEFAULT_MODEL ?? "deepseek/deepseek-v4-flash-0731")
-            : "scripted");
+          runDeployment?.model ??
+          "scripted";
         await deps.prisma.run.updateMany({
           where: { id: runId, status: "running", leaseOwner: workerId, leaseFence: fence },
           data: { modelProvider: runModelProvider, modelId: runModelId },

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -784,13 +784,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const attachedFilesPrompt = currentTurnFilesInstruction(currentTurnFiles);
         const graphical =
           computer.kind !== "desktop" && deps.sandbox.describe().capabilities.graphical;
-        const modelProvider = credential?.provider ?? settings?.defaultModelProvider ?? "scripted";
-        const modelId = credential?.defaultModel ?? settings?.defaultModelId ?? "scripted";
-        // Scripted runtime fixtures still need screenshot tools; for Pi, resolve
-        // the scripted placeholder the same way the runtime does before gating.
+        // Gate on the model this run will actually call — the same pair written to the
+        // run row above. Re-deriving it here without the deployment fallback gated the
+        // wrong model: a deployment default resolved to "scripted", whose vision lookup
+        // is openrouter/PI_DEFAULT_MODEL, so a vision-capable default lost its screenshot
+        // tools.
         const acceptsImages =
           deps.runtime.describe().capabilities.scripted ||
-          modelAcceptsImageInput(modelProvider, modelId);
+          modelAcceptsImageInput(runModelProvider, runModelId);
         const groupContext = thread.groupId
           ? await loadGroupContext(deps.prisma, thread.groupId)
           : undefined;

--- a/packages/adapters/src/history-compaction.ts
+++ b/packages/adapters/src/history-compaction.ts
@@ -1,7 +1,7 @@
 import type { AgentRunRequest, AgentRuntime, JobPublisher } from "@rakazo/adapter-kit";
 import { historyCompactJob } from "@rakazo/adapter-kit";
 import type { MessageBlock } from "@rakazo/contracts";
-import { blocksToAgentHistoryText } from "@rakazo/core";
+import { blocksToAgentHistoryText, resolveDeploymentModel } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
 import type {
   ConfiguredMemoryProvider,
@@ -115,8 +115,6 @@ export const MAX_TRANSCRIPT_CHARS = 40_000;
 
 /** Bounds a hung summarization call, which would otherwise hold a background-worker slot open. */
 const SUMMARIZE_TIMEOUT_MS = 120_000;
-
-const DEFAULT_SUMMARIZER_MODEL_ID = "deepseek/deepseek-v4-flash-0731";
 
 export interface CompactHistoryDeps {
   prisma: PrismaClient;
@@ -249,8 +247,11 @@ export async function compactHistory(deps: CompactHistoryDeps, threadId: string)
       })
     : deps.deploymentModelKey
       ? {
-          provider: "openrouter",
-          id: process.env.PI_DEFAULT_MODEL ?? DEFAULT_SUMMARIZER_MODEL_ID,
+          // Provider comes from the same resolver as the key, not a hardcoded
+          // "openrouter" — a deployment default of anthropic would otherwise summarize
+          // by sending an Anthropic key to OpenRouter.
+          provider: resolveDeploymentModel().provider,
+          id: resolveDeploymentModel().model,
           apiKey: deps.deploymentModelKey,
         }
       : await (async () => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -118,7 +118,10 @@ export class PiAgentRuntime implements AgentRuntime {
           ? undefined
           : request.model.provider === OPENAI_COMPATIBLE_PROVIDER_ID
             ? request.model.apiKey || "local"
-            : (request.model.apiKey ?? process.env.OPENROUTER_API_KEY);
+            : // Only OpenRouter may fall back to the OpenRouter env key. Handing it to
+              // another provider would ship our key to a vendor it was not issued for.
+              (request.model.apiKey ??
+              (provider === "openrouter" ? process.env.OPENROUTER_API_KEY : undefined));
         const toolDefs = request.tools.length ? request.tools : builtinAgentTools;
         const nestedAgents = new Set<Agent>();
         const host: ToolHost = {

--- a/packages/core/src/secrets-guard.test.ts
+++ b/packages/core/src/secrets-guard.test.ts
@@ -4,6 +4,7 @@ import {
   DEV_ENCRYPTION_KEY_PLACEHOLDER,
   hasValidBearerToken,
   resolveAuthSecret,
+  resolveDeploymentModel,
   resolveEncryptionKey,
   resolveSupervisorToken,
   resolveUpdaterToken,
@@ -101,5 +102,30 @@ describe("secrets-guard", () => {
     expect(hasValidBearerToken("secret-token", "secret-token")).toBe(false);
     expect(hasValidBearerToken("Basic secret-token", "secret-token")).toBe(false);
     expect(hasValidBearerToken(undefined, "secret-token")).toBe(false);
+  });
+
+  it("pairs the deployment model key with the provider it belongs to", () => {
+    const both = { OPENROUTER_API_KEY: "or-key", ANTHROPIC_API_KEY: "sk-ant-key" };
+    expect(resolveDeploymentModel(both)).toEqual({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash-0731",
+      key: "or-key",
+    });
+    // The whole point: switching the provider switches the key with it.
+    expect(resolveDeploymentModel({ ...both, PI_DEFAULT_PROVIDER: "anthropic" })).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      key: "sk-ant-key",
+    });
+    // A provider with no key configured yields no key — never another vendor's.
+    expect(
+      resolveDeploymentModel({ OPENROUTER_API_KEY: "or-key", PI_DEFAULT_PROVIDER: "anthropic" }),
+    ).toEqual({ provider: "anthropic", model: "claude-sonnet-5", key: undefined });
+    expect(
+      resolveDeploymentModel({
+        PI_DEFAULT_PROVIDER: "anthropic",
+        PI_DEFAULT_MODEL: "claude-haiku-4-5",
+      }).model,
+    ).toBe("claude-haiku-4-5");
   });
 });

--- a/packages/core/src/secrets-guard.ts
+++ b/packages/core/src/secrets-guard.ts
@@ -84,3 +84,38 @@ export function hasValidBearerToken(authorization: string | undefined, expectedT
   }
   return difference === 0;
 }
+
+/**
+ * The deployment-wide model default: provider, model id, and the key for that provider.
+ *
+ * They resolve together on purpose. A deployment key is a bearer credential for one
+ * vendor, so the provider it is offered to must be decided by the same expression that
+ * picks it — the previous code hardcoded `"openrouter"` as the fallback provider while
+ * reading whatever key was configured, which sends an Anthropic key to OpenRouter the
+ * moment the deployment default is not OpenRouter.
+ *
+ * `key` is undefined when the provider named by PI_DEFAULT_PROVIDER has no key set;
+ * callers already treat a missing deployment key as "no usable model" (scripted).
+ */
+export function resolveDeploymentModel(env: NodeJS.ProcessEnv = process.env): {
+  provider: string;
+  model: string;
+  key: string | undefined;
+} {
+  const provider = env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
+  // ponytail: two rows because two providers ship a deployment key today. A third one
+  // adds a row here, not a branch at each call site.
+  const keys: Record<string, string | undefined> = {
+    openrouter: env.OPENROUTER_API_KEY,
+    anthropic: env.ANTHROPIC_API_KEY,
+  };
+  const models: Record<string, string> = {
+    openrouter: "deepseek/deepseek-v4-flash-0731",
+    anthropic: "claude-sonnet-5",
+  };
+  return {
+    provider,
+    model: env.PI_DEFAULT_MODEL?.trim() || models[provider] || models.openrouter!,
+    key: keys[provider],
+  };
+}


### PR DESCRIPTION
## Problem

`.env.example` ships `PI_DEFAULT_PROVIDER=openrouter`, but no code path uses it to pick the provider a run actually calls. The deployment fallback hardcodes the provider in three places while reading whatever key sits in `deploymentModelKey`:

- `packages/adapters/src/executor.ts` — the `resolveModel` path (routines, child bots) and the run path
- `packages/adapters/src/history-compaction.ts` — the summarizer model

That pairing is only safe while the deployment key is an OpenRouter key. It can already come apart without touching env, because `deployment_settings.defaultModelProvider` is read *before* the fallback: set that column to another provider and the OpenRouter deployment key is sent to it — a bearer credential offered to a vendor it was not issued for. `PiAgentRuntime.run` has the mirror image of the same hole: it falls back to `process.env.OPENROUTER_API_KEY` for any provider whose request carries no key.

## Change

1. **`resolveDeploymentModel` in `@rakazo/core`** returns provider, model and key from one expression so they cannot drift apart, and adds `ANTHROPIC_API_KEY` as a second provider a deployment can default to. A provider with no key configured yields no key rather than another vendor's. `AppEnv.openRouterKey` becomes `deploymentModelKey` to match what it now holds.
2. **`PiAgentRuntime`**: the `OPENROUTER_API_KEY` fallback is scoped to OpenRouter.
3. **Vision gate**: it re-derived provider and model without the deployment fallback the two lines above it use, so a run whose model came from that fallback was gated as `"scripted"` — whose vision lookup is `openrouter/PI_DEFAULT_MODEL`. Benign today; once a deployment defaults elsewhere, the lookup misses and a vision-capable model silently loses `computer_observe` / `computer_act`. Now it reuses the pair already written to the run row.

Existing deployments are unaffected: with `PI_DEFAULT_PROVIDER` unset or `openrouter`, the resolver returns exactly today's provider, model and key.

Three commits, one concern each.

## Testing

- `pnpm lint` — clean
- `pnpm check` — 20/20
- `pnpm test` — 1473 passed. The single failure, `desktop-sandbox-write-containment › keeps writes on the opened inode when the final name is replaced after lstat`, fails identically on an unmodified tree here (macOS), so it is not from this change.
- New unit test in `packages/core/src/secrets-guard.test.ts` covers the property that matters: switching the provider switches the key with it, and a provider without a key gets `undefined` instead of another vendor's key.

Not run locally: `pnpm test:integration` / `pnpm test:e2e` (no Docker in this environment). Nothing here touches DB schema, migrations or UI.

## Open question

`deployment_settings.deploymentModelCredentialCipher` is written by nothing today, and `defaultModelProvider` / `defaultModelId` have no writer either — if a deployment-owner-connects-a-key flow is already planned, this env path may be the wrong shape for the second provider and I am happy to cut commit 1 down to just the pairing fix (no `ANTHROPIC_API_KEY`), leaving the provider to come from `deployment_settings` alone. Commits 2 and 3 stand on their own either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Anthropic as the deployment-wide model provider.
  * Added provider-specific API key configuration and automatic default model selection.

* **Bug Fixes**
  * Prevented API keys from being shared with unrelated providers.
  * Preserved screenshot and vision capabilities when using deployment defaults.
  * Improved consistency of model selection across runs and background tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->