### PR TITLE
fix: withhold the deployment key from a provider it was not issued for

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,12 +33,8 @@ SANDBOX_COMMAND_TIMEOUT_MS=300000
 # means unlimited (default). Set a positive integer to soft-stop a turn that
 # exceeds the budget and still emit a final assistant message.
 MAX_TOOL_CALLS_PER_TURN=
-# The deployment-wide fallback model: one provider, one key for it. PI_DEFAULT_PROVIDER
-# picks which key below is used, so the two must be set together — see
-# resolveDeploymentModel in @rakazo/core. Users who connect their own key
-# (rpc/models/connect) never touch these.
+# Deployment-wide fallback model. PI_DEFAULT_PROVIDER picks which key below is used.
 OPENROUTER_API_KEY=
-# Set only when PI_DEFAULT_PROVIDER=anthropic.
 ANTHROPIC_API_KEY=
 PI_DEFAULT_PROVIDER=openrouter
 # Text-only by default. Computer use (screenshots via computer_observe / computer_act)

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,9 +1,5 @@
-import {
-  resolveAuthSecret,
-  resolveDeploymentModel,
-  resolveEncryptionKey,
-  resolveSupervisorToken,
-} from "@rakazo/core";
+import { resolveDeploymentModel } from "@rakazo/adapters";
+import { resolveAuthSecret, resolveEncryptionKey, resolveSupervisorToken } from "@rakazo/core";
 
 export interface AppEnv {
   databaseUrl: string;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -26,10 +26,11 @@ import {
   PipedreamConnector,
   PostgresRealtimeFanout,
   pipedreamConfigFromEnv,
+  resolveDeploymentModel,
   ScriptedAgentRuntime,
   WorkspaceMemoryProviderResolver,
 } from "@rakazo/adapters";
-import { resolveDeploymentModel, resolveEncryptionKey } from "@rakazo/core";
+import { resolveEncryptionKey } from "@rakazo/core";
 import { createDb, createThreadEvents } from "@rakazo/db";
 import { MarkdownMemoryStore } from "@rakazo/memory";
 

--- a/packages/adapters/src/deployment-model.test.ts
+++ b/packages/adapters/src/deployment-model.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { resolveDeploymentModel } from "./deployment-model.js";
+
+describe("resolveDeploymentModel", () => {
+  it("pairs the deployment model key with the provider it belongs to", () => {
+    const both = { OPENROUTER_API_KEY: "or-key", ANTHROPIC_API_KEY: "sk-ant-key" };
+    expect(resolveDeploymentModel(both)).toEqual({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash-0731",
+      key: "or-key",
+    });
+    // The whole point: switching the provider switches the key with it.
+    expect(resolveDeploymentModel({ ...both, PI_DEFAULT_PROVIDER: "anthropic" })).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+      key: "sk-ant-key",
+    });
+    // A provider with no key configured yields no key — never another vendor's.
+    expect(
+      resolveDeploymentModel({ OPENROUTER_API_KEY: "or-key", PI_DEFAULT_PROVIDER: "anthropic" }),
+    ).toEqual({ provider: "anthropic", model: "claude-sonnet-5", key: undefined });
+  });
+});

--- a/packages/adapters/src/deployment-model.ts
+++ b/packages/adapters/src/deployment-model.ts
@@ -1,0 +1,25 @@
+/**
+ * The deployment-wide model default: which provider a run falls back to when no user
+ * credential applies, and the key for that provider.
+ *
+ * Vendor env names and model ids live here, in the adapter layer, not in core.
+ */
+export function resolveDeploymentModel(env: NodeJS.ProcessEnv = process.env) {
+  const provider = env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
+  // A row per provider that ships a deployment key. A third one adds a row here, not a
+  // branch at each call site — and an unknown provider gets no key rather than another
+  // vendor's, which a ternary on one provider would not give.
+  const keys: Record<string, string | undefined> = {
+    openrouter: env.OPENROUTER_API_KEY,
+    anthropic: env.ANTHROPIC_API_KEY,
+  };
+  const models: Record<string, string> = {
+    openrouter: "deepseek/deepseek-v4-flash-0731",
+    anthropic: "claude-sonnet-5",
+  };
+  return {
+    provider,
+    model: env.PI_DEFAULT_MODEL?.trim() || models[provider] || models.openrouter!,
+    key: keys[provider],
+  };
+}

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -433,6 +433,31 @@ description: Prepare standup notes
     );
   });
 
+  it("withholds the deployment key when settings name a different provider", async () => {
+    const prisma = {
+      bot: { findFirst: vi.fn(async () => null) },
+      userModelCredential: { findFirst: vi.fn(async () => null) },
+      deploymentSettings: {
+        findUnique: vi.fn(async () => ({
+          defaultModelProvider: "anthropic",
+          defaultModelId: "claude-sonnet-5",
+        })),
+      },
+      secret: { findUnique: vi.fn(async () => null) },
+    } as unknown as PrismaClient;
+    const executor = createRunExecutor({
+      prisma,
+      secretStore: { load: vi.fn(), put: vi.fn() },
+      // PI_DEFAULT_PROVIDER is unset here, so this key belongs to OpenRouter.
+      deploymentModelKey: "deployment-openrouter-key",
+    } as unknown as Parameters<typeof createRunExecutor>[0]);
+
+    const model = await executor.resolveModel({ userId: "user-1", workspaceId: "ws-1" });
+
+    expect(model.provider).toBe("anthropic");
+    expect(model.apiKey).toBeUndefined();
+  });
+
   it("keeps per-bot thinking when using the workspace default model", async () => {
     const findFirst = vi.fn(async (args: { where: { provider?: string; isDefault?: boolean } }) => {
       if (args.where.isDefault) {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -45,7 +45,6 @@ import {
   redactSecrets,
   renderBotDirectory,
   resolveActionApproval,
-  resolveDeploymentModel,
   sandboxCommandTimeoutMs,
   type ToolCallStreak,
   toolRequiresApproval,
@@ -106,6 +105,7 @@ import {
 } from "./computer-support.js";
 import { observationToolResult, parseComputerActions } from "./computer-tools.js";
 import { checkpointAndRecordComputerWorkspace } from "./computer-workspace.js";
+import { resolveDeploymentModel } from "./deployment-model.js";
 import { handoffToGroupBot, loadGroupContext } from "./group-handoff.js";
 import {
   COMPACTION_BATCH_SIZE,
@@ -312,9 +312,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
       // provider with a workspace or deployment secret from another provider.
       const useOverride = Boolean(hasOverride && overrideCredential);
       const credential = useOverride ? overrideCredential : defaultCredential;
-      const resolved = await resolveModelKey(deps, scope.userId, scope.workspaceId, credential);
-      // Provider and model come from one resolver, so the deployment key can never be
-      // offered to a provider it does not belong to.
       const deployment = deps.deploymentModelKey ? resolveDeploymentModel() : null;
       const provider =
         (useOverride ? override!.modelProvider : null) ??
@@ -328,6 +325,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
         settings?.defaultModelId ??
         deployment?.model ??
         "scripted";
+      // The key is resolved for the provider that won above, not before it is known.
+      const resolved = await resolveModelKey(
+        deps,
+        scope.userId,
+        scope.workspaceId,
+        credential,
+        provider,
+      );
       return {
         provider,
         id,
@@ -743,14 +748,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
             }),
           );
         }
-        const resolved = await resolveModelKey(
-          deps,
-          run.userId,
-          run.workspaceId,
-          credential,
-          (values) => runSecrets.push(...values),
-        );
-        runSecrets.push(...resolved.redact);
         const runDeployment = deps.deploymentModelKey ? resolveDeploymentModel() : null;
         const runModelProvider =
           (useModelOverride ? bot.modelProvider : null) ??
@@ -764,6 +761,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
           settings?.defaultModelId ??
           runDeployment?.model ??
           "scripted";
+        const resolved = await resolveModelKey(
+          deps,
+          run.userId,
+          run.workspaceId,
+          credential,
+          runModelProvider,
+          (values) => runSecrets.push(...values),
+        );
+        runSecrets.push(...resolved.redact);
         await deps.prisma.run.updateMany({
           where: { id: runId, status: "running", leaseOwner: workerId, leaseFence: fence },
           data: { modelProvider: runModelProvider, modelId: runModelId },
@@ -784,11 +790,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const attachedFilesPrompt = currentTurnFilesInstruction(currentTurnFiles);
         const graphical =
           computer.kind !== "desktop" && deps.sandbox.describe().capabilities.graphical;
-        // Gate on the model this run will actually call — the same pair written to the
-        // run row above. Re-deriving it here without the deployment fallback gated the
-        // wrong model: a deployment default resolved to "scripted", whose vision lookup
-        // is openrouter/PI_DEFAULT_MODEL, so a vision-capable default lost its screenshot
-        // tools.
+        // Gate on the model this run will actually call — the pair written to the run row
+        // above. Deriving it a second time here dropped the deployment fallback, so a
+        // vision-capable default was gated as "scripted" and lost its screenshot tools.
         const acceptsImages =
           deps.runtime.describe().capabilities.scripted ||
           modelAcceptsImageInput(runModelProvider, runModelId);
@@ -2508,11 +2512,22 @@ async function runSandboxCommand(
   return { stdout, stderr, code };
 }
 
+/**
+ * The deployment key is a bearer credential for exactly one vendor, so it is handed out
+ * only when the provider that won the resolution above is that vendor. A provider named
+ * by deployment settings or a bot override gets no key rather than another vendor's.
+ */
+function deploymentKeyFor(deps: ExecutorDeps, provider: string): string | undefined {
+  if (!deps.deploymentModelKey) return undefined;
+  return provider === resolveDeploymentModel().provider ? deps.deploymentModelKey : undefined;
+}
+
 async function resolveModelKey(
   deps: ExecutorDeps,
   userId: string,
   workspaceId: string,
   credential: { secretId: string; provider: string } | null,
+  provider: string,
   registerSecrets?: (values: string[]) => void,
 ): Promise<{
   apiKey?: string;
@@ -2524,7 +2539,7 @@ async function resolveModelKey(
   if (credential) {
     return withModelCredentialLock(credential.secretId, async () => {
       const row = await deps.prisma.secret.findUnique({ where: { id: credential.secretId } });
-      if (!row) return { apiKey: deps.deploymentModelKey, redact: [] };
+      if (!row) return { apiKey: deploymentKeyFor(deps, provider), redact: [] };
       const plaintext = deps.secretStore.load(row.ciphertext);
       registerSecrets?.(secretValuesToRedact(parseModelSecret(plaintext)));
       const persist = async (next: string) => {
@@ -2581,7 +2596,7 @@ async function resolveModelKey(
       };
     });
   }
-  return { apiKey: deps.deploymentModelKey, redact: [] };
+  return { apiKey: deploymentKeyFor(deps, provider), redact: [] };
 }
 
 async function withModelCredentialLock<T>(key: string, fn: () => Promise<T>): Promise<T> {

--- a/packages/adapters/src/history-compaction.ts
+++ b/packages/adapters/src/history-compaction.ts
@@ -1,8 +1,9 @@
 import type { AgentRunRequest, AgentRuntime, JobPublisher } from "@rakazo/adapter-kit";
 import { historyCompactJob } from "@rakazo/adapter-kit";
 import type { MessageBlock } from "@rakazo/contracts";
-import { blocksToAgentHistoryText, resolveDeploymentModel } from "@rakazo/core";
+import { blocksToAgentHistoryText } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
+import { resolveDeploymentModel } from "./deployment-model.js";
 import type {
   ConfiguredMemoryProvider,
   MemoryProviderResolver,
@@ -239,6 +240,7 @@ export async function compactHistory(deps: CompactHistoryDeps, threadId: string)
   // "scripted" means nothing at all is configured: ScriptedAgentRuntime answers by echoing canned
   // text keyed off the prompt, so summarizing with it would save nonsense to external memory and
   // advance the cursor past messages that are then lost from both stores. Skip instead.
+  const deploymentFallback = resolveDeploymentModel();
   const model = deps.resolveModel
     ? await deps.resolveModel({
         userId: thread.userId,
@@ -247,11 +249,9 @@ export async function compactHistory(deps: CompactHistoryDeps, threadId: string)
       })
     : deps.deploymentModelKey
       ? {
-          // Provider comes from the same resolver as the key, not a hardcoded
-          // "openrouter" — a deployment default of anthropic would otherwise summarize
-          // by sending an Anthropic key to OpenRouter.
-          provider: resolveDeploymentModel().provider,
-          id: resolveDeploymentModel().model,
+          // Provider must come from the same resolver as the key, not a hardcoded one.
+          provider: deploymentFallback.provider,
+          id: deploymentFallback.model,
           apiKey: deps.deploymentModelKey,
         }
       : await (async () => {

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -19,6 +19,7 @@ export * from "./computer-tools.js";
 export * from "./computer-workspace.js";
 export * from "./daytona-emulator.js";
 export * from "./daytona-sandbox.js";
+export * from "./deployment-model.js";
 export * from "./desktop-sandbox.js";
 export * from "./destination-emulator.js";
 export * from "./docker-sandbox.js";

--- a/packages/core/src/secrets-guard.test.ts
+++ b/packages/core/src/secrets-guard.test.ts
@@ -4,7 +4,6 @@ import {
   DEV_ENCRYPTION_KEY_PLACEHOLDER,
   hasValidBearerToken,
   resolveAuthSecret,
-  resolveDeploymentModel,
   resolveEncryptionKey,
   resolveSupervisorToken,
   resolveUpdaterToken,
@@ -102,30 +101,5 @@ describe("secrets-guard", () => {
     expect(hasValidBearerToken("secret-token", "secret-token")).toBe(false);
     expect(hasValidBearerToken("Basic secret-token", "secret-token")).toBe(false);
     expect(hasValidBearerToken(undefined, "secret-token")).toBe(false);
-  });
-
-  it("pairs the deployment model key with the provider it belongs to", () => {
-    const both = { OPENROUTER_API_KEY: "or-key", ANTHROPIC_API_KEY: "sk-ant-key" };
-    expect(resolveDeploymentModel(both)).toEqual({
-      provider: "openrouter",
-      model: "deepseek/deepseek-v4-flash-0731",
-      key: "or-key",
-    });
-    // The whole point: switching the provider switches the key with it.
-    expect(resolveDeploymentModel({ ...both, PI_DEFAULT_PROVIDER: "anthropic" })).toEqual({
-      provider: "anthropic",
-      model: "claude-sonnet-5",
-      key: "sk-ant-key",
-    });
-    // A provider with no key configured yields no key — never another vendor's.
-    expect(
-      resolveDeploymentModel({ OPENROUTER_API_KEY: "or-key", PI_DEFAULT_PROVIDER: "anthropic" }),
-    ).toEqual({ provider: "anthropic", model: "claude-sonnet-5", key: undefined });
-    expect(
-      resolveDeploymentModel({
-        PI_DEFAULT_PROVIDER: "anthropic",
-        PI_DEFAULT_MODEL: "claude-haiku-4-5",
-      }).model,
-    ).toBe("claude-haiku-4-5");
   });
 });

--- a/packages/core/src/secrets-guard.ts
+++ b/packages/core/src/secrets-guard.ts
@@ -84,38 +84,3 @@ export function hasValidBearerToken(authorization: string | undefined, expectedT
   }
   return difference === 0;
 }
-
-/**
- * The deployment-wide model default: provider, model id, and the key for that provider.
- *
- * They resolve together on purpose. A deployment key is a bearer credential for one
- * vendor, so the provider it is offered to must be decided by the same expression that
- * picks it — the previous code hardcoded `"openrouter"` as the fallback provider while
- * reading whatever key was configured, which sends an Anthropic key to OpenRouter the
- * moment the deployment default is not OpenRouter.
- *
- * `key` is undefined when the provider named by PI_DEFAULT_PROVIDER has no key set;
- * callers already treat a missing deployment key as "no usable model" (scripted).
- */
-export function resolveDeploymentModel(env: NodeJS.ProcessEnv = process.env): {
-  provider: string;
-  model: string;
-  key: string | undefined;
-} {
-  const provider = env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
-  // ponytail: two rows because two providers ship a deployment key today. A third one
-  // adds a row here, not a branch at each call site.
-  const keys: Record<string, string | undefined> = {
-    openrouter: env.OPENROUTER_API_KEY,
-    anthropic: env.ANTHROPIC_API_KEY,
-  };
-  const models: Record<string, string> = {
-    openrouter: "deepseek/deepseek-v4-flash-0731",
-    anthropic: "claude-sonnet-5",
-  };
-  return {
-    provider,
-    model: env.PI_DEFAULT_MODEL?.trim() || models[provider] || models.openrouter!,
-    key: keys[provider],
-  };
-}


### PR DESCRIPTION
Follow-up to #297. Two review findings on that PR (from Greptile) landed after it was already merged, and one of them is the hole #297 set out to close, left open on a second path.

## 1. The deployment key still reaches a provider it was not issued for

`resolveModelKey` returns `deps.deploymentModelKey` whenever no user credential applies, regardless of which provider won the resolution:

```ts
settings?.defaultModelProvider ?? deployment?.provider ?? "scripted"
```

`deployment_settings.defaultModelProvider` wins over the resolved deployment provider, so a settings row naming another vendor receives the OpenRouter deployment key — reachable today with a single DB write, no env change. A bot override whose own credential is missing takes the same path.

`resolveModelKey` now takes the provider that actually won, and hands out the deployment key only when it is that provider's key. Both call sites resolve provider and model first, then the key. On a mismatch there is no key, so the run fails to authenticate rather than disclosing a credential to the wrong vendor.

## 2. Provider config belongs in the adapter layer

`AGENTS.md`: *"keep provider-specific configuration and translation inside its adapter"*. `resolveDeploymentModel` moves from `@rakazo/core` to `packages/adapters/src/deployment-model.ts`, so vendor env names and model ids no longer sit in core.

Also drops an internal marker comment and trims a docblock that #297 carried in by mistake — my oversight, not a review finding.

## Testing

- `pnpm lint` clean, `pnpm check` 20/20, `pnpm test` 1474 passed.
- The single failure, `desktop-sandbox-write-containment › keeps writes on the opened inode when the final name is replaced after lstat`, fails identically on an unmodified tree here (macOS), so it is not from this change.
- New cases cover both halves: `resolveDeploymentModel` pairs provider with key (and yields `undefined` rather than another vendor's key), and `resolveModel` withholds the deployment key when deployment settings name a different provider.
- Not run locally: `pnpm test:integration` / `pnpm test:e2e` (no Docker here). No schema, migration or UI changes.
