### PR TITLE
fix(web): follow new chat messages without interrupting readers

### DIFF
--- a/apps/web/src/components/beautiful-ui/primitives.tsx
+++ b/apps/web/src/components/beautiful-ui/primitives.tsx
@@ -144,28 +144,24 @@ export function BuiCard({
 /** Primary pill button in the Beautiful UI control style. */
 export function BuiButton({
   children,
-  onClick,
-  disabled,
   tone = "neutral",
-}: {
-  children: React.ReactNode;
-  onClick?: () => void;
-  disabled?: boolean;
-  tone?: "neutral" | "accent";
-}) {
+  className = "",
+  style,
+  ...props
+}: React.ComponentPropsWithoutRef<"button"> & { tone?: "neutral" | "accent" }) {
   return (
     <button
+      {...props}
       type="button"
-      disabled={disabled}
-      onClick={onClick}
-      className="rounded-full px-4 py-2 text-[13.5px] font-medium transition-colors duration-150 disabled:opacity-60"
+      className={`rounded-full px-4 py-2 text-[13.5px] font-medium transition-colors duration-150 disabled:opacity-60 ${className}`}
       style={
         tone === "accent"
-          ? { background: "var(--bui-accent)", color: "#090a12" }
+          ? { background: "var(--bui-accent)", color: "#090a12", ...style }
           : {
               background: "var(--bui-hover)",
               color: "var(--bui-ink)",
               boxShadow: "var(--bui-shadow-btn)",
+              ...style,
             }
       }
     >

--- a/apps/web/src/lib/transcript-scroll.test.ts
+++ b/apps/web/src/lib/transcript-scroll.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { transcriptIsNearEnd } from "./transcript-scroll.js";
+
+describe("transcriptIsNearEnd", () => {
+  it("follows only while the viewport is within 80px of the latest message", () => {
+    expect(transcriptIsNearEnd({ scrollHeight: 1_000, scrollTop: 421, clientHeight: 500 })).toBe(
+      true,
+    );
+    expect(transcriptIsNearEnd({ scrollHeight: 1_000, scrollTop: 420, clientHeight: 500 })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/lib/transcript-scroll.ts
+++ b/apps/web/src/lib/transcript-scroll.ts
@@ -1,0 +1,5 @@
+export function transcriptIsNearEnd(
+  element: Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">,
+): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight < 80;
+}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3079,7 +3079,12 @@ const Transcript = memo(function Transcript({
   }, [scrollRef]);
 
   useLayoutEffect(() => {
-    if (following.current) scrollToEnd();
+    if (following.current) {
+      scrollToEnd();
+      return;
+    }
+    const element = scrollRef.current;
+    if (element) setAtEnd(transcriptIsNearEnd(element));
   }, [messages, running, scrollToEnd]);
 
   useEffect(
@@ -3096,9 +3101,11 @@ const Transcript = memo(function Transcript({
         data-testid="transcript"
         onPointerDown={() => {
           autoScrolling.current = false;
+          following.current = false;
         }}
         onTouchStart={() => {
           autoScrolling.current = false;
+          following.current = false;
         }}
         onWheel={(event) => {
           if (event.deltaY < 0) {
@@ -3170,18 +3177,17 @@ const Transcript = memo(function Transcript({
           </div>
         ) : null}
       </div>
-      <button
-        type="button"
+      <BuiButton
         aria-label={t`Jump to latest message`}
         aria-hidden={atEnd}
         tabIndex={atEnd ? -1 : 0}
         onClick={scrollToEnd}
-        className={`absolute bottom-4 left-1/2 z-20 grid h-9 w-9 -translate-x-1/2 place-items-center rounded-full border border-[#303034] bg-[#1A1A1D]/95 text-[#C9C9CE] shadow-[0_8px_24px_rgba(0,0,0,.45)] backdrop-blur transition-[opacity,transform,background-color] duration-200 ease-[cubic-bezier(.22,1,.36,1)] hover:bg-[#242428] motion-reduce:transition-none ${
+        className={`absolute bottom-4 left-1/2 z-20 grid h-9 w-9 !-translate-x-1/2 place-items-center border border-[#303034] !p-0 backdrop-blur transition-[opacity,transform] duration-200 ease-[cubic-bezier(.22,1,.36,1)] motion-reduce:transition-none ${
           atEnd ? "pointer-events-none translate-y-2 opacity-0" : "translate-y-0 opacity-100"
         }`}
       >
         <ArrowDown size={17} strokeWidth={1.8} />
-      </button>
+      </BuiButton>
     </div>
   );
 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2163,6 +2163,7 @@ export function ShellPage() {
         <Transcript
           key={activeSnapshot?.threadId}
           scrollRef={messageScroll}
+          preserveViewport={expandedHistoryThread.current === activeSnapshot?.threadId}
           artifactTarget={transcriptArtifactTarget}
           messages={activeSnapshot?.messages ?? []}
           olderCursor={activeSnapshot?.olderCursor ?? null}
@@ -3006,6 +3007,7 @@ export function ShellPage() {
 
 const Transcript = memo(function Transcript({
   scrollRef,
+  preserveViewport,
   artifactTarget,
   messages,
   olderCursor,
@@ -3028,6 +3030,7 @@ const Transcript = memo(function Transcript({
   onSpeak,
 }: {
   scrollRef: RefObject<HTMLDivElement | null>;
+  preserveViewport: boolean;
   artifactTarget: ArtifactTarget;
   messages: ThreadMessage[];
   olderCursor: number | null;
@@ -3079,13 +3082,14 @@ const Transcript = memo(function Transcript({
   }, [scrollRef]);
 
   useLayoutEffect(() => {
+    if (preserveViewport) return;
     if (following.current) {
       scrollToEnd();
       return;
     }
     const element = scrollRef.current;
     if (element) setAtEnd(transcriptIsNearEnd(element));
-  }, [messages, running, scrollToEnd]);
+  }, [messages, preserveViewport, running, scrollRef, scrollToEnd]);
 
   useEffect(
     () => () => {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -60,6 +60,7 @@ import {
 } from "@rakazo/core";
 import { BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
 import {
+  ArrowDown,
   ArrowUp,
   Bell,
   Box,
@@ -134,6 +135,7 @@ import {
   reduceThreadSnapshot,
   userHoldsComputerControl,
 } from "../lib/thread-events";
+import { transcriptIsNearEnd } from "../lib/transcript-scroll";
 import { speaker } from "../lib/tts";
 import { ActivityList } from "./ActivityList";
 import type { ContextMenuPosition } from "./BotContextMenu";
@@ -469,9 +471,7 @@ export function ShellPage() {
 
   async function refreshGroupThread(id: string) {
     const scrollElement = messageScroll.current;
-    const stickToEnd =
-      !scrollElement ||
-      scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight < 80;
+    const stickToEnd = !scrollElement || transcriptIsNearEnd(scrollElement);
     markOnce("rk:renderer:thread-request-start");
     const request = ++groupRefreshEpoch.current;
     const snap = await rpc.threads.get({ groupId: id });
@@ -499,9 +499,7 @@ export function ShellPage() {
 
   async function refreshThread(id: string) {
     const scrollElement = messageScroll.current;
-    const stickToEnd =
-      !scrollElement ||
-      scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight < 80;
+    const stickToEnd = !scrollElement || transcriptIsNearEnd(scrollElement);
     markOnce("rk:renderer:thread-request-start");
     const epoch = historyEpoch.current;
     const request = ++threadRefreshEpoch.current;
@@ -2163,6 +2161,7 @@ export function ShellPage() {
           </div>
         </div>
         <Transcript
+          key={activeSnapshot?.threadId}
           scrollRef={messageScroll}
           artifactTarget={transcriptArtifactTarget}
           messages={activeSnapshot?.messages ?? []}
@@ -3051,71 +3050,138 @@ const Transcript = memo(function Transcript({
   onSpeak: (message: ThreadMessage) => void;
 }) {
   const { t } = useLingui();
+  const [atEnd, setAtEnd] = useState(true);
+  const following = useRef(true);
+  const autoScrolling = useRef(false);
+  const autoScrollTimer = useRef<number | undefined>(undefined);
   const messageById = useMemo(
     () => new Map(messages.map((message) => [message.id, message])),
     [messages],
   );
+  const scrollToEnd = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    following.current = true;
+    autoScrolling.current = !reducedMotion;
+    setAtEnd(true);
+    element.scrollTo({
+      top: element.scrollHeight,
+      behavior: reducedMotion ? "auto" : "smooth",
+    });
+    window.clearTimeout(autoScrollTimer.current);
+    autoScrollTimer.current = window.setTimeout(
+      () => {
+        autoScrolling.current = false;
+      },
+      reducedMotion ? 0 : 420,
+    );
+  }, [scrollRef]);
+
+  useLayoutEffect(() => {
+    if (following.current) scrollToEnd();
+  }, [messages, running, scrollToEnd]);
+
+  useEffect(
+    () => () => {
+      window.clearTimeout(autoScrollTimer.current);
+    },
+    [],
+  );
+
   return (
-    <div
-      ref={scrollRef}
-      data-testid="transcript"
-      className="rk-scroll flex flex-1 flex-col gap-2 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
-    >
-      {olderCursor != null ? (
-        <button
-          type="button"
-          disabled={loadingOlder}
-          onClick={() => void onLoadOlder()}
-          className="self-center rounded-lg px-3 py-1.5 text-[13px] text-[#85858A] hover:bg-[#1A1A1D] hover:text-[#C9C9CE] disabled:opacity-50"
-        >
-          {loadingOlder ? t`Loading…` : t`Load earlier messages`}
-        </button>
-      ) : null}
-      {messages.map((message) => (
-        <div
-          key={message.id}
-          data-message-id={message.id}
-          className="group/message relative pt-9 hover:z-20"
-        >
-          <MessageHoverActions message={message} onReply={onReply} />
-          <MessageView
-            artifactTarget={artifactTarget}
-            message={message}
-            canAnswer={message.id === answerableAskMessageId}
-            onOpenBot={onOpenBot}
-            onOpenPeerMessages={onOpenPeerMessages}
-            onAnswer={onAnswer}
-            speakerName={message.role === "bot" ? memberName?.(message.botId) : undefined}
-            memberName={memberName}
-            replyPreview={
-              message.replyToMessageId ? messageById.get(message.replyToMessageId) : undefined
-            }
-            replyToMessageId={message.replyToMessageId}
-            onJumpToMessage={onJumpToMessage}
-            onRefresh={onRefresh}
-            onBotChanged={onBotChanged}
-            onAddRoutine={onAddRoutine}
-            voiceReady={voiceReady}
-            speaking={speakingMessageId === message.id}
-            onSpeak={() => onSpeak(message)}
-          />
-        </div>
-      ))}
-      {running &&
-      !messages.some(
-        (message) =>
-          message.id.startsWith("progress:") &&
-          message.blocks[0]?.kind === "progress" &&
-          message.blocks[0].text,
-      ) ? (
-        <div className="flex justify-start">
-          {/* Box metrics match the progress bubble exactly so swapping between
-              them never changes height or text position. */}
-          <div className="flex max-w-[74%] items-center rounded-[20px] bg-[#1A1A1D] px-[18px] py-3 text-[15.5px] leading-[1.5]">
-            <LoadingState label="working" startedAt={workingStartedAt} />
+    <div className="relative flex min-h-0 flex-1">
+      <div
+        ref={scrollRef}
+        data-testid="transcript"
+        onPointerDown={() => {
+          autoScrolling.current = false;
+        }}
+        onTouchStart={() => {
+          autoScrolling.current = false;
+        }}
+        onWheel={(event) => {
+          if (event.deltaY < 0) {
+            autoScrolling.current = false;
+            following.current = false;
+          }
+        }}
+        onScroll={(event) => {
+          const nearEnd = transcriptIsNearEnd(event.currentTarget);
+          setAtEnd(nearEnd);
+          if (nearEnd) following.current = true;
+          else if (!autoScrolling.current) following.current = false;
+        }}
+        className="rk-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
+      >
+        {olderCursor != null ? (
+          <button
+            type="button"
+            disabled={loadingOlder}
+            onClick={() => void onLoadOlder()}
+            className="self-center rounded-lg px-3 py-1.5 text-[13px] text-[#85858A] hover:bg-[#1A1A1D] hover:text-[#C9C9CE] disabled:opacity-50"
+          >
+            {loadingOlder ? t`Loading…` : t`Load earlier messages`}
+          </button>
+        ) : null}
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            data-message-id={message.id}
+            className="group/message relative pt-9 hover:z-20"
+          >
+            <MessageHoverActions message={message} onReply={onReply} />
+            <MessageView
+              artifactTarget={artifactTarget}
+              message={message}
+              canAnswer={message.id === answerableAskMessageId}
+              onOpenBot={onOpenBot}
+              onOpenPeerMessages={onOpenPeerMessages}
+              onAnswer={onAnswer}
+              speakerName={message.role === "bot" ? memberName?.(message.botId) : undefined}
+              memberName={memberName}
+              replyPreview={
+                message.replyToMessageId ? messageById.get(message.replyToMessageId) : undefined
+              }
+              replyToMessageId={message.replyToMessageId}
+              onJumpToMessage={onJumpToMessage}
+              onRefresh={onRefresh}
+              onBotChanged={onBotChanged}
+              onAddRoutine={onAddRoutine}
+              voiceReady={voiceReady}
+              speaking={speakingMessageId === message.id}
+              onSpeak={() => onSpeak(message)}
+            />
           </div>
-        </div>
-      ) : null}
+        ))}
+        {running &&
+        !messages.some(
+          (message) =>
+            message.id.startsWith("progress:") &&
+            message.blocks[0]?.kind === "progress" &&
+            message.blocks[0].text,
+        ) ? (
+          <div className="flex justify-start">
+            {/* Box metrics match the progress bubble exactly so swapping between
+              them never changes height or text position. */}
+            <div className="flex max-w-[74%] items-center rounded-[20px] bg-[#1A1A1D] px-[18px] py-3 text-[15.5px] leading-[1.5]">
+              <LoadingState label="working" startedAt={workingStartedAt} />
+            </div>
+          </div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        aria-label={t`Jump to latest message`}
+        aria-hidden={atEnd}
+        tabIndex={atEnd ? -1 : 0}
+        onClick={scrollToEnd}
+        className={`absolute bottom-4 left-1/2 z-20 grid h-9 w-9 -translate-x-1/2 place-items-center rounded-full border border-[#303034] bg-[#1A1A1D]/95 text-[#C9C9CE] shadow-[0_8px_24px_rgba(0,0,0,.45)] backdrop-blur transition-[opacity,transform,background-color] duration-200 ease-[cubic-bezier(.22,1,.36,1)] hover:bg-[#242428] motion-reduce:transition-none ${
+          atEnd ? "pointer-events-none translate-y-2 opacity-0" : "translate-y-0 opacity-100"
+        }`}
+      >
+        <ArrowDown size={17} strokeWidth={1.8} />
+      </button>
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- follow new and streaming messages while the transcript is already at the latest message
- preserve the reader's position when they scroll up
- add an accessible, smoothly animated jump-to-latest control with reduced-motion support

## Verification
- `pnpm --filter @rakazo/web test` (20 files, 119 tests)
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web build` (with CI placeholder secrets; existing bundle warnings only)
- `biome check` on changed files
- regression check proved red with the near-end threshold disabled, then green after restoration

## Manual proof
Local full-app browser proof was unavailable because this worktree has no PostgreSQL service. The repository Playwright lane remains required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic transcript scrolling when viewing the latest messages.
  * Added a “Jump to latest message” button when the transcript is scrolled away from the end.
  * Added smooth scrolling to the newest message.

* **Bug Fixes**
  * Improved detection of whether the transcript is close enough to the bottom to continue following new messages.

* **Tests**
  * Added coverage for near-end transcript scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->