### PR TITLE
fix(web): follow new chat messages without interrupting readers

### DIFF
--- a/apps/web/src/lib/transcript-scroll.test.ts
+++ b/apps/web/src/lib/transcript-scroll.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { transcriptIsNearEnd } from "./transcript-scroll.js";
+
+describe("transcriptIsNearEnd", () => {
+  it("follows only while the viewport is within 80px of the latest message", () => {
+    expect(transcriptIsNearEnd({ scrollHeight: 1_000, scrollTop: 421, clientHeight: 500 })).toBe(
+      true,
+    );
+    expect(transcriptIsNearEnd({ scrollHeight: 1_000, scrollTop: 420, clientHeight: 500 })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/src/lib/transcript-scroll.ts
+++ b/apps/web/src/lib/transcript-scroll.ts
@@ -1,0 +1,5 @@
+export function transcriptIsNearEnd(
+  element: Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">,
+): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight < 80;
+}

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1862
+#: src/pages/Shell.tsx:1860
 msgid " (unread)"
 msgstr " (ungelesen)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# Modell} other {# Modelle}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1300
+#: src/pages/Shell.tsx:1298
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (maximal {ATTACHMENT_MAX_COUNT} Anhänge)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1304
+#: src/pages/Shell.tsx:1302
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (über 10 MiB)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5308
 msgid "{0} connection"
 msgstr "{0}-Verbindung"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2356
+#: src/pages/Shell.tsx:2355
 msgid "{0} is using it"
 msgstr "{0} verwendet es"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:180
-#: src/pages/Shell.tsx:2071
+#: src/pages/Shell.tsx:2069
 msgid "{0} runs · {1} tokens"
 msgstr "{0} Läufe · {1} Tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# verbundener Bot} other {# verbundene Bot
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} hat noch keinem anderen Bot eine Nachricht gesendet."
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "{botName}’s computer"
 msgstr "Computer von {botName}"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3475
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Zugriffstoken (optional)"
 msgid "Account"
 msgstr "Konto"
 
-#: src/pages/Shell.tsx:4619
+#: src/pages/Shell.tsx:4694
 msgid "Account default"
 msgstr "Kontostandard"
 
@@ -156,8 +156,8 @@ msgstr "Aktives Modell"
 msgid "Active voice"
 msgstr "Aktive Stimme"
 
+#: src/pages/Shell.tsx:1739
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:1743
 msgid "Activity"
 msgstr "Aktivität"
 
@@ -221,7 +221,7 @@ msgstr "Wird hinzugefügt…"
 #: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4597
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -229,7 +229,7 @@ msgstr "Erweitert"
 msgid "Agent access for new servers"
 msgstr "Agent-Zugriff für neue Server"
 
-#: src/pages/Shell.tsx:2163
+#: src/pages/Shell.tsx:2161
 msgid "Agent computer"
 msgstr "Agent-Computer"
 
@@ -316,11 +316,11 @@ msgstr "Gilt beim Hinzufügen des Servers. Mit den Agent-Chips auf jeder Serverk
 msgid "Approval boundaries"
 msgstr "Bestätigungsgrenzen"
 
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5492
 msgid "Approve this server to let your agent use its tools."
 msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 
@@ -328,15 +328,15 @@ msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 msgid "Archive"
 msgstr "Archivieren"
 
-#: src/pages/Shell.tsx:4066
+#: src/pages/Shell.tsx:4141
 msgid "archived"
 msgstr "archiviert"
 
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1944
 msgid "Archived"
 msgstr "Archiviert"
 
-#: src/pages/Shell.tsx:4077
+#: src/pages/Shell.tsx:4152
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archiviert. Chat, Erinnerungen und Dateien bleiben erhalten."
 
@@ -375,7 +375,7 @@ msgstr "Vor Käufen nachfragen"
 msgid "Ask before sending external email"
 msgstr "Vor dem Senden externer E-Mails nachfragen"
 
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2357
 msgid "Asleep"
 msgstr "Im Ruhezustand"
 
@@ -390,11 +390,11 @@ msgstr "um {0}"
 msgid "at {timeSelect}"
 msgstr "um {timeSelect}"
 
-#: src/pages/Shell.tsx:3471
+#: src/pages/Shell.tsx:3546
 msgid "Attach file"
 msgstr "Datei anhängen"
 
-#: src/pages/Shell.tsx:3670
+#: src/pages/Shell.tsx:3745
 msgid "Attachment"
 msgstr "Anhang"
 
@@ -407,12 +407,12 @@ msgstr "Autorisierungscode oder Callback-URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Autorisierung abgelaufen — erneute Verbindung erforderlich"
 
-#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5293
 msgid "Authorization timed out. Please try again."
 msgstr "Zeitüberschreitung bei der Autorisierung. Versuche es erneut."
 
-#: src/pages/Shell.tsx:5260
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5501
 msgid "Authorize"
 msgstr "Autorisieren"
 
@@ -428,22 +428,22 @@ msgstr "Basis-URL"
 msgid "Bearer token"
 msgstr "Bearer-Token"
 
-#: src/pages/Shell.tsx:5102
+#: src/pages/Shell.tsx:5177
 msgid "Booting live desktop…"
 msgstr "Live-Desktop wird gestartet…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2903
+#: src/pages/Shell.tsx:2902
 msgid "Booting up {0}’s computer"
 msgstr "Computer von {0} wird gestartet"
 
-#: src/pages/Shell.tsx:3936
-#: src/pages/Shell.tsx:3937
-#: src/pages/Shell.tsx:4070
+#: src/pages/Shell.tsx:4011
+#: src/pages/Shell.tsx:4012
+#: src/pages/Shell.tsx:4145
 msgid "bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:1116
+#: src/pages/Shell.tsx:1114
 msgid "Bot"
 msgstr "Bot"
 
@@ -451,11 +451,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot-Nachrichten"
 
-#: src/pages/Shell.tsx:3000
+#: src/pages/Shell.tsx:2999
 msgid "Bot screen"
 msgstr "Bot-Bildschirm"
 
-#: src/pages/Shell.tsx:2326
+#: src/pages/Shell.tsx:2325
 msgid "Bot screen preview"
 msgstr "Bot-Bildschirmvorschau"
 
@@ -468,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Verwende deinen eigenen Schlüssel. Der Anbieter ist austauschbar; die Schaltflächen zum Sprechen und Anrufen deiner Bots bleiben gleich."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2145
-#: src/pages/Shell.tsx:2146
+#: src/pages/Shell.tsx:2143
+#: src/pages/Shell.tsx:2144
 msgid "Call"
 msgstr "Anrufen"
 
@@ -481,14 +481,14 @@ msgstr "Server nicht erreichbar."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4786
-#: src/pages/Shell.tsx:4858
-#: src/pages/Shell.tsx:4973
-#: src/pages/Shell.tsx:5047
+#: src/pages/Shell.tsx:4861
+#: src/pages/Shell.tsx:4933
+#: src/pages/Shell.tsx:5048
+#: src/pages/Shell.tsx:5122
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/pages/Shell.tsx:4314
+#: src/pages/Shell.tsx:4389
 msgid "Cancel new bot"
 msgstr "Neuen Bot abbrechen"
 
@@ -496,7 +496,7 @@ msgstr "Neuen Bot abbrechen"
 msgid "Cancel new group"
 msgstr "Neue Gruppe abbrechen"
 
-#: src/pages/Shell.tsx:3347
+#: src/pages/Shell.tsx:3422
 msgid "Cancel reply"
 msgstr "Antwort abbrechen"
 
@@ -504,16 +504,16 @@ msgstr "Antwort abbrechen"
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5398
 msgid "Chart failed to render: {error}"
 msgstr "Diagramm konnte nicht angezeigt werden: {error}"
 
-#: src/pages/Shell.tsx:3613
+#: src/pages/Shell.tsx:3688
 msgid "Chat Settings"
 msgstr "Chat-Einstellungen"
 
-#: src/pages/Shell.tsx:2608
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Check in."
 msgstr "Melde dich."
 
@@ -525,21 +525,21 @@ msgstr "Wähle zunächst ein Modell aus."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Wähle das verbundene Modell aus, das Rakazo verwendet."
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clear"
 msgstr "Leeren"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4839
+#: src/pages/Shell.tsx:4914
 msgid "Clear {0}’s conversation?"
 msgstr "Unterhaltung mit {0} leeren?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4674
+#: src/pages/Shell.tsx:4749
 msgid "Clear conversation"
 msgstr "Unterhaltung leeren"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clearing…"
 msgstr "Wird geleert…"
 
@@ -555,15 +555,15 @@ msgstr "Bot-Menü schließen"
 msgid "Close bot messages"
 msgstr "Bot-Nachrichten schließen"
 
-#: src/pages/Shell.tsx:5508
+#: src/pages/Shell.tsx:5583
 msgid "Close chart"
 msgstr "Diagramm schließen"
 
-#: src/pages/Shell.tsx:2974
+#: src/pages/Shell.tsx:2973
 msgid "Close computer"
 msgstr "Computer schließen"
 
-#: src/pages/Shell.tsx:5608
+#: src/pages/Shell.tsx:5683
 msgid "Close image preview"
 msgstr "Bildvorschau schließen"
 
@@ -583,11 +583,11 @@ msgstr "Erinnerungseinstellungen schließen"
 msgid "Close model settings"
 msgstr "Modelleinstellungen schließen"
 
-#: src/pages/Shell.tsx:1726
+#: src/pages/Shell.tsx:1724
 msgid "Close navigation"
 msgstr "Navigation schließen"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2303
 msgid "Close panel"
 msgstr "Panel schließen"
 
@@ -616,24 +616,24 @@ msgstr "Befehl"
 msgid "Complete"
 msgstr "Abschließen"
 
-#: src/pages/Shell.tsx:4224
-#: src/pages/Shell.tsx:4252
+#: src/pages/Shell.tsx:4299
+#: src/pages/Shell.tsx:4327
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5180
 msgid "Computer failed to boot"
 msgstr "Computer konnte nicht gestartet werden"
 
-#: src/pages/Shell.tsx:3022
+#: src/pages/Shell.tsx:3021
 msgid "Computer is asleep"
 msgstr "Computer ist im Ruhezustand"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5179
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer schläft — übernimm die Kontrolle, um ihn zu wecken"
 
-#: src/pages/Shell.tsx:5106
+#: src/pages/Shell.tsx:5181
 msgid "Computer is stopped"
 msgstr "Computer ist gestoppt"
 
@@ -666,7 +666,7 @@ msgstr "API-Schlüssel verbinden"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI oder Cartesia verbinden"
 
-#: src/pages/Shell.tsx:5406
+#: src/pages/Shell.tsx:5481
 msgid "Connect MCP server “{name}”"
 msgstr "MCP-Server „{name}“ verbinden"
 
@@ -689,12 +689,12 @@ msgstr "Treg verbinden"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5257
+#: src/pages/Shell.tsx:5332
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Verbunden"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5511
 msgid "Connected — its tools are available from your next message."
 msgstr "Verbunden – die Tools sind ab deiner nächsten Nachricht verfügbar."
 
@@ -719,7 +719,7 @@ msgstr "Verbunden, {0} wird verwendet."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Verbindung wird hergestellt…"
@@ -738,7 +738,7 @@ msgstr "Weiter"
 msgid "Continue with email"
 msgstr "Mit E-Mail fortfahren"
 
-#: src/pages/Shell.tsx:3721
+#: src/pages/Shell.tsx:3796
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -750,11 +750,11 @@ msgstr "Hinzufügen fehlgeschlagen"
 msgid "Could not add MCP server"
 msgstr "MCP-Server konnte nicht hinzugefügt werden"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5468
 msgid "Could not approve this server"
 msgstr "Server konnte nicht genehmigt werden"
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5296
 msgid "Could not authorize this app"
 msgstr "App konnte nicht autorisiert werden"
 
@@ -762,7 +762,7 @@ msgstr "App konnte nicht autorisiert werden"
 msgid "Could not change the default model"
 msgstr "Standardmodell konnte nicht geändert werden"
 
-#: src/pages/Shell.tsx:4867
+#: src/pages/Shell.tsx:4942
 msgid "Could not clear conversation"
 msgstr "Unterhaltung konnte nicht geleert werden"
 
@@ -791,7 +791,7 @@ msgstr "Stimmanbieter konnte nicht verbunden werden"
 msgid "Could not continue"
 msgstr "Fortfahren fehlgeschlagen"
 
-#: src/pages/Shell.tsx:4302
+#: src/pages/Shell.tsx:4377
 msgid "Could not create bot"
 msgstr "Bot konnte nicht erstellt werden"
 
@@ -799,7 +799,7 @@ msgstr "Bot konnte nicht erstellt werden"
 msgid "Could not create group"
 msgstr "Gruppe konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4758
+#: src/pages/Shell.tsx:4833
 msgid "Could not create section"
 msgstr "Abschnitt konnte nicht erstellt werden"
 
@@ -807,7 +807,7 @@ msgstr "Abschnitt konnte nicht erstellt werden"
 msgid "Could not create your bot"
 msgstr "Dein Bot konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4982
+#: src/pages/Shell.tsx:5057
 msgid "Could not delete bot"
 msgstr "Bot konnte nicht gelöscht werden"
 
@@ -815,7 +815,7 @@ msgstr "Bot konnte nicht gelöscht werden"
 msgid "Could not delete MCP server"
 msgstr "MCP-Server konnte nicht gelöscht werden"
 
-#: src/pages/Shell.tsx:5056
+#: src/pages/Shell.tsx:5131
 msgid "Could not delete routine"
 msgstr "Routine konnte nicht gelöscht werden"
 
@@ -889,7 +889,7 @@ msgstr "Gruppe konnte nicht entfernt werden"
 msgid "Could not remove rule"
 msgstr "Regel konnte nicht entfernt werden"
 
-#: src/pages/Shell.tsx:5313
+#: src/pages/Shell.tsx:5388
 msgid "Could not render chart"
 msgstr "Diagramm konnte nicht angezeigt werden"
 
@@ -897,7 +897,7 @@ msgstr "Diagramm konnte nicht angezeigt werden"
 msgid "Could not revoke connection"
 msgstr "Verbindung konnte nicht widerrufen werden"
 
-#: src/pages/Shell.tsx:4659
+#: src/pages/Shell.tsx:4734
 msgid "Could not save"
 msgstr "Speichern fehlgeschlagen"
 
@@ -909,7 +909,7 @@ msgstr "Gruppe konnte nicht gespeichert werden"
 msgid "Could not save model"
 msgstr "Modell konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:2630
+#: src/pages/Shell.tsx:2629
 msgid "Could not save routine"
 msgstr "Routine konnte nicht gespeichert werden"
 
@@ -925,7 +925,7 @@ msgstr "Auswahl konnte nicht gespeichert werden"
 msgid "Could not save that voice"
 msgstr "Stimme konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:5133
+#: src/pages/Shell.tsx:5208
 msgid "Could not save this choice"
 msgstr "Diese Auswahl konnte nicht gespeichert werden"
 
@@ -941,7 +941,7 @@ msgstr "OAuth konnte nicht gestartet werden"
 msgid "Could not submit this answer"
 msgstr "Antwort konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:1583
+#: src/pages/Shell.tsx:1581
 msgid "Could not take control"
 msgstr "Kontrolle konnte nicht übernommen werden"
 
@@ -965,14 +965,14 @@ msgstr "Standardbereich für Erinnerungen konnte nicht aktualisiert werden"
 msgid "Couldn't update avatars"
 msgstr ""
 
-#: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:1759
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Create"
 msgstr "Erstellen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4842
 msgid "Create a section and move {0} into it."
 msgstr "Erstelle einen Abschnitt und verschiebe {0} dorthin."
 
@@ -993,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Dein Rakazo erstellen"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Creating…"
 msgstr "Wird erstellt…"
 
@@ -1022,7 +1022,7 @@ msgstr "Tag"
 msgid "days"
 msgstr "Tage"
 
-#: src/pages/Shell.tsx:4566
+#: src/pages/Shell.tsx:4641
 msgid "Default (medium)"
 msgstr "Standard (mittel)"
 
@@ -1032,21 +1032,21 @@ msgstr "Standardbereich"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1980
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:1978
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Delete"
 msgstr "Löschen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1974
 msgid "Delete {0}"
 msgstr "{0} löschen"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4920
-#: src/pages/Shell.tsx:5034
+#: src/pages/Shell.tsx:4995
+#: src/pages/Shell.tsx:5109
 msgid "Delete {0}?"
 msgstr "{0} löschen?"
 
@@ -1054,21 +1054,21 @@ msgstr "{0} löschen?"
 msgid "Delete group"
 msgstr "Gruppe löschen"
 
-#: src/pages/Shell.tsx:4957
+#: src/pages/Shell.tsx:5032
 msgid "Delete memories too"
 msgstr "Erinnerungen ebenfalls löschen"
 
-#: src/pages/Shell.tsx:2685
+#: src/pages/Shell.tsx:2684
 msgid "Delete routine"
 msgstr "Routine löschen"
 
-#: src/pages/Shell.tsx:4068
+#: src/pages/Shell.tsx:4143
 msgid "deleted"
 msgstr "gelöscht"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Deleting…"
 msgstr "Wird gelöscht…"
 
@@ -1085,17 +1085,17 @@ msgid "Deployment default"
 msgstr "Bereitstellungsstandard"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4339
+#: src/pages/Shell.tsx:4414
 msgid "Describe what this bot does"
 msgstr "Beschreibe, was dieser Bot macht"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4344
-#: src/pages/Shell.tsx:4510
+#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4585
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Dictate"
 msgstr "Diktieren"
 
@@ -1108,7 +1108,7 @@ msgstr "Trennen"
 msgid "Disconnecting…"
 msgstr "Verbindung wird getrennt…"
 
-#: src/pages/Shell.tsx:5441
+#: src/pages/Shell.tsx:5516
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Verworfen – du kannst die Verbindung jederzeit in den MCP-Einstellungen wiederherstellen."
 
@@ -1156,7 +1156,7 @@ msgstr "Skill-Entwurf"
 msgid "Duplicate"
 msgstr "Duplizieren"
 
-#: src/pages/Shell.tsx:3881
+#: src/pages/Shell.tsx:3956
 msgid "Earlier message"
 msgstr "Frühere Nachricht"
 
@@ -1212,11 +1212,11 @@ msgstr "Jeden Monat"
 msgid "Every week"
 msgstr "Jede Woche"
 
-#: src/pages/Shell.tsx:5487
+#: src/pages/Shell.tsx:5562
 msgid "Expand"
 msgstr "Erweitern"
 
-#: src/pages/Shell.tsx:4671
+#: src/pages/Shell.tsx:4746
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1224,7 +1224,7 @@ msgstr "Exportieren"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Exportiere die Liste dieser Woche aus dem CRM und lege sie im freigegebenen Ordner ab"
 
-#: src/pages/Shell.tsx:4691
+#: src/pages/Shell.tsx:4766
 msgid "Extra high"
 msgstr "Sehr hoch"
 
@@ -1232,14 +1232,14 @@ msgstr "Sehr hoch"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
+#: src/pages/Shell.tsx:1424
 #: src/pages/Shell.tsx:1426
 #: src/pages/Shell.tsx:1428
-#: src/pages/Shell.tsx:1430
 msgid "Failed to send message"
 msgstr "Nachricht konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:1453
-#: src/pages/Shell.tsx:1472
+#: src/pages/Shell.tsx:1451
+#: src/pages/Shell.tsx:1470
 msgid "Failed to stop"
 msgstr "Stoppen fehlgeschlagen"
 
@@ -1275,8 +1275,8 @@ msgstr "Kostenlos"
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#: src/pages/Shell.tsx:2135
-#: src/pages/Shell.tsx:2286
+#: src/pages/Shell.tsx:2133
+#: src/pages/Shell.tsx:2285
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1305,15 +1305,15 @@ msgstr "Beispiel anhören"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hallo, so klinge ich, wenn ich Antworten vorlese."
 
-#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4769
 msgid "High"
 msgstr "Hoch"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk"
 msgstr "Zum Sprechen gedrückt halten"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk (on-device dictation)"
 msgstr "Zum Sprechen gedrückt halten (Diktat auf dem Gerät)"
 
@@ -1333,7 +1333,7 @@ msgstr "Wie oft"
 msgid "How to check"
 msgstr "So wird geprüft"
 
-#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:3852
 msgid "I’m done"
 msgstr "Ich bin fertig"
 
@@ -1345,7 +1345,7 @@ msgstr "Wenn du das gehört hast, ist die Stimme einsatzbereit."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI-JSON importieren"
 
-#: src/pages/Shell.tsx:4581
+#: src/pages/Shell.tsx:4656
 msgid "Inherit default"
 msgstr "Standard übernehmen"
 
@@ -1357,12 +1357,12 @@ msgstr "Eingaben"
 msgid "Instance API key"
 msgstr "Instanz-API-Schlüssel"
 
-#: src/pages/Shell.tsx:2569
+#: src/pages/Shell.tsx:2568
 msgid "Instruction"
 msgstr "Anweisung"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:1995
 msgid "Integrations"
 msgstr "Integrationen"
 
@@ -1383,15 +1383,19 @@ msgid "Interval unit"
 msgstr "Intervalleinheit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4657
 msgid "Isolated"
 msgstr "Isoliert"
 
-#: src/pages/Shell.tsx:4923
+#: src/pages/Shell.tsx:4998
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von ihm erstellte Bots bleiben in deiner Liste."
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3213
+msgid "Jump to latest"
+msgstr ""
+
+#: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"
 msgstr "Zur beantworteten Nachricht springen"
 
@@ -1399,7 +1403,7 @@ msgstr "Zur beantworteten Nachricht springen"
 msgid "just now"
 msgstr "gerade eben"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5016
 msgid "Keep memories"
 msgstr "Erinnerungen behalten"
 
@@ -1417,7 +1421,7 @@ msgstr "Sprache"
 msgid "Listening…"
 msgstr "Hört zu…"
 
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Load earlier messages"
 msgstr "Frühere Nachrichten laden"
 
@@ -1457,7 +1461,7 @@ msgstr "Stimmanbieter werden geladen…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Loading…"
 msgstr "Wird geladen…"
 
@@ -1465,11 +1469,11 @@ msgstr "Wird geladen…"
 msgid "Local"
 msgstr "Lokal"
 
-#: src/pages/Shell.tsx:2083
+#: src/pages/Shell.tsx:2081
 msgid "Log out"
 msgstr "Abmelden"
 
-#: src/pages/Shell.tsx:4692
+#: src/pages/Shell.tsx:4767
 msgid "Low"
 msgstr "Niedrig"
 
@@ -1485,7 +1489,7 @@ msgstr "Als gelesen markieren"
 msgid "Mark as Unread"
 msgstr "Als ungelesen markieren"
 
-#: src/pages/Shell.tsx:4696
+#: src/pages/Shell.tsx:4771
 msgid "Max"
 msgstr "Max."
 
@@ -1495,7 +1499,7 @@ msgstr "Max."
 msgid "MCP servers"
 msgstr "MCP-Server"
 
-#: src/pages/Shell.tsx:4693
+#: src/pages/Shell.tsx:4768
 msgid "Medium"
 msgstr "Mittel"
 
@@ -1508,33 +1512,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Mitglieder ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} auswählen)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2041
+#: src/pages/Shell.tsx:2039
 msgid "Memory"
 msgstr "Erinnerungen"
 
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:4652
 msgid "Memory scope"
 msgstr "Erinnerungsbereich"
 
-#: src/pages/Shell.tsx:3577
-#: src/pages/Shell.tsx:3672
+#: src/pages/Shell.tsx:3652
+#: src/pages/Shell.tsx:3747
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/pages/Shell.tsx:3573
-#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3648
+#: src/pages/Shell.tsx:3652
 msgid "Message {activeName}"
 msgstr "Nachricht an {activeName}"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Message from {peer}"
 msgstr "Nachricht von {peer}"
 
-#: src/pages/Shell.tsx:3574
+#: src/pages/Shell.tsx:3649
 msgid "Message…"
 msgstr "Nachricht…"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Messaged {peer}"
 msgstr "Nachricht an {peer} gesendet"
 
@@ -1542,7 +1546,7 @@ msgstr "Nachricht an {peer} gesendet"
 msgid "Microphone failed"
 msgstr "Mikrofonfehler"
 
-#: src/pages/Shell.tsx:4695
+#: src/pages/Shell.tsx:4770
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1564,7 +1568,7 @@ msgstr "Minuten"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4608
 msgid "Model"
 msgstr "Modell"
 
@@ -1586,7 +1590,7 @@ msgid "Model updated."
 msgstr "Modell aktualisiert."
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2026
 msgid "Models"
 msgstr "Modelle"
 
@@ -1604,7 +1608,7 @@ msgstr "Monatlich"
 msgid "Move {0} to section"
 msgstr "{0} in Abschnitt verschieben"
 
-#: src/pages/Shell.tsx:4944
+#: src/pages/Shell.tsx:5019
 msgid "Move them to your shared memory."
 msgstr "Verschiebe sie in deine geteilten Erinnerungen."
 
@@ -1617,15 +1621,15 @@ msgstr "Verschieben nach"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2561
-#: src/pages/Shell.tsx:4324
-#: src/pages/Shell.tsx:4492
-#: src/pages/Shell.tsx:4770
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:4399
+#: src/pages/Shell.tsx:4567
+#: src/pages/Shell.tsx:4845
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4329
+#: src/pages/Shell.tsx:4404
 msgid "Name this bot"
 msgstr "Bot benennen"
 
@@ -1641,13 +1645,13 @@ msgstr "Eingabe erforderlich"
 msgid "Needs takeover"
 msgstr "Übernahme erforderlich"
 
-#: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4312
+#: src/pages/Shell.tsx:1773
+#: src/pages/Shell.tsx:4387
 msgid "New bot"
 msgstr "Neuer Bot"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1785
+#: src/pages/Shell.tsx:1783
 msgid "New group"
 msgstr "Neue Gruppe"
 
@@ -1655,12 +1659,12 @@ msgstr "Neue Gruppe"
 msgid "New open-work item"
 msgstr "Neuer offener Arbeitspunkt"
 
-#: src/pages/Shell.tsx:2447
+#: src/pages/Shell.tsx:2446
 msgid "New routine"
 msgstr "Neue Routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4839
 msgid "New section"
 msgstr "Neuer Abschnitt"
 
@@ -1738,7 +1742,7 @@ msgstr "Nicht verbunden"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5504
 msgid "Not now"
 msgstr "Jetzt nicht"
 
@@ -1776,15 +1780,15 @@ msgstr "am 1. um {0}"
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/pages/Shell.tsx:2345
+#: src/pages/Shell.tsx:2344
 msgid "Open computer"
 msgstr "Computer öffnen"
 
-#: src/pages/Shell.tsx:2315
+#: src/pages/Shell.tsx:2314
 msgid "Open in full window"
 msgstr "In vollständigem Fenster öffnen"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2105
 msgid "Open navigation"
 msgstr "Navigation öffnen"
 
@@ -1801,7 +1805,7 @@ msgstr "Offene Arbeit"
 msgid "OpenAI-compatible server URL"
 msgstr "URL eines OpenAI-kompatiblen Servers"
 
-#: src/pages/Shell.tsx:4079
+#: src/pages/Shell.tsx:4154
 msgid "Opened its thread."
 msgstr "Thread geöffnet."
 
@@ -1888,7 +1892,7 @@ msgstr "Wiedergabe…"
 msgid "Preview {0}"
 msgstr "Vorschau von {0}"
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Private"
 msgstr "Privat"
 
@@ -1909,7 +1913,7 @@ msgstr "In Warteschlange"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo prüft die Quelle vor dem Speichern. Zugangsdaten werden verschlüsselt und weder an Clients zurückgegeben noch dem Modell zugänglich gemacht."
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4684
 msgid "Read replies aloud"
 msgstr "Antworten vorlesen"
 
@@ -1943,7 +1947,7 @@ msgstr ""
 msgid "Recovering…"
 msgstr ""
 
-#: src/pages/Shell.tsx:3767
+#: src/pages/Shell.tsx:3842
 msgid "Release"
 msgstr "Freigeben"
 
@@ -1956,17 +1960,17 @@ msgid "Remove"
 msgstr "Entfernen"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3381
+#: src/pages/Shell.tsx:3456
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3536
+#: src/pages/Shell.tsx:3611
 msgid "Remove mention {0}"
 msgstr "Erwähnung von {0} entfernen"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3590
 msgid "Remove skill {0}"
 msgstr "Skill {0} entfernen"
 
@@ -1974,7 +1978,7 @@ msgstr "Skill {0} entfernen"
 msgid "Remove this schedule"
 msgstr "Diesen Zeitplan entfernen"
 
-#: src/pages/Shell.tsx:4078
+#: src/pages/Shell.tsx:4153
 msgid "Removed with chat, computer, and memory."
 msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 
@@ -2002,11 +2006,11 @@ msgstr "API-Schlüssel ersetzen"
 msgid "Replace key"
 msgstr "Schlüssel ersetzen"
 
-#: src/pages/Shell.tsx:3713
+#: src/pages/Shell.tsx:3788
 msgid "Reply"
 msgstr "Antworten"
 
-#: src/pages/Shell.tsx:3344
+#: src/pages/Shell.tsx:3419
 msgid "Replying to {replyName}"
 msgstr "Antwort an {replyName}"
 
@@ -2027,7 +2031,7 @@ msgstr ""
 msgid "Resetting…"
 msgstr ""
 
-#: src/pages/Shell.tsx:1972
+#: src/pages/Shell.tsx:1970
 msgid "Restore"
 msgstr "Wiederherstellen"
 
@@ -2047,17 +2051,17 @@ msgstr "Zurück zu Rakazo"
 msgid "Robot"
 msgstr ""
 
-#: src/pages/Shell.tsx:2554
-#: src/pages/Shell.tsx:2607
-#: src/pages/Shell.tsx:2614
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:2613
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2392
+#: src/pages/Shell.tsx:2391
 msgid "Routines"
 msgstr "Routinen"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Run now"
 msgstr "Jetzt ausführen"
 
@@ -2065,11 +2069,11 @@ msgstr "Jetzt ausführen"
 msgid "Running"
 msgstr "Läuft"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2431
 msgid "Running · Stop"
 msgstr "Wird ausgeführt · Stoppen"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Running…"
 msgstr "Wird ausgeführt…"
 
@@ -2077,8 +2081,8 @@ msgstr "Wird ausgeführt…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2653
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:2652
+#: src/pages/Shell.tsx:4739
 msgid "Save"
 msgstr "Speichern"
 
@@ -2102,7 +2106,7 @@ msgstr "Gespeichert."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:2652
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
@@ -2116,7 +2120,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "Antworte mit Ja oder Nein oder in einem Satz."
 
 #: src/pages/ModelSettingsOverlay.tsx:939
-#: src/pages/Shell.tsx:1796
+#: src/pages/Shell.tsx:1794
 msgid "Search"
 msgstr "Suchen"
 
@@ -2143,11 +2147,11 @@ msgstr "Anbieter und Modelle suchen"
 msgid "Searching…"
 msgstr "Suche…"
 
-#: src/pages/Shell.tsx:2136
+#: src/pages/Shell.tsx:2134
 msgid "Select a bot"
 msgstr "Bot auswählen"
 
-#: src/pages/Shell.tsx:3597
+#: src/pages/Shell.tsx:3672
 msgid "Send"
 msgstr "Senden"
 
@@ -2175,22 +2179,22 @@ msgstr "Servername"
 msgid "Server URL"
 msgstr "Server-URL"
 
-#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2143
 msgid "Set up voice to call"
 msgstr "Stimme für Anrufe einrichten"
 
 #: src/pages/AccountSettingsOverlay.tsx:100
-#: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2015
-#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2003
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:2281
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/pages/Shell.tsx:3615
+#: src/pages/Shell.tsx:3690
 msgid "Settings: General"
 msgstr "Einstellungen: Allgemein"
 
-#: src/pages/Shell.tsx:3617
+#: src/pages/Shell.tsx:3692
 msgid "Settings: Usage"
 msgstr "Einstellungen: Nutzung"
 
@@ -2200,15 +2204,15 @@ msgid "Setup help"
 msgstr "Einrichtungshilfe"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4583
+#: src/pages/Shell.tsx:4658
 msgid "Shared"
 msgstr "Geteilt"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show computer"
 msgstr "Computer anzeigen"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show settings"
 msgstr "Einstellungen anzeigen"
 
@@ -2232,11 +2236,11 @@ msgid "Sign up"
 msgstr "Registrieren"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3428
+#: src/pages/Shell.tsx:3503
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3774
+#: src/pages/Shell.tsx:3849
 msgid "Skip"
 msgstr "Überspringen"
 
@@ -2249,7 +2253,7 @@ msgid "Skip or deploy key"
 msgstr "Überspringen oder Deploy-Key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1320
+#: src/pages/Shell.tsx:1318
 msgid "Skipped {0}"
 msgstr "{0} übersprungen"
 
@@ -2257,8 +2261,8 @@ msgstr "{0} übersprungen"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Leertaste unterbricht · Esc legt auf"
 
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Speak"
 msgstr "Vorlesen"
 
@@ -2270,8 +2274,8 @@ msgstr "Sprechen + transkribieren"
 msgid "Speak only"
 msgstr "Nur sprechen"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Speak this reply"
 msgstr "Diese Antwort vorlesen"
 
@@ -2297,20 +2301,20 @@ msgstr "Wird gestartet…"
 msgid "Steps"
 msgstr "Schritte"
 
-#: src/pages/Shell.tsx:2943
-#: src/pages/Shell.tsx:2947
-#: src/pages/Shell.tsx:3588
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2946
+#: src/pages/Shell.tsx:3663
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Stop"
 msgstr "Stoppen"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Stop dictation"
 msgstr "Diktat stoppen"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Stop speaking"
 msgstr "Vorlesen stoppen"
 
@@ -2319,8 +2323,8 @@ msgstr "Vorlesen stoppen"
 msgid "Stop teaching"
 msgstr "Anlernen beenden"
 
-#: src/pages/Shell.tsx:2372
-#: src/pages/Shell.tsx:2963
+#: src/pages/Shell.tsx:2371
+#: src/pages/Shell.tsx:2962
 msgid "Stop the bot first"
 msgstr "Zuerst den Bot stoppen"
 
@@ -2328,7 +2332,7 @@ msgstr "Zuerst den Bot stoppen"
 msgid "Stored encrypted"
 msgstr "Verschlüsselt gespeichert"
 
-#: src/pages/Shell.tsx:4030
+#: src/pages/Shell.tsx:4105
 msgid "subagent"
 msgstr "Subagent"
 
@@ -2341,8 +2345,8 @@ msgstr "Absenden"
 msgid "Switching…"
 msgstr "Wird gewechselt…"
 
-#: src/pages/Shell.tsx:2375
-#: src/pages/Shell.tsx:2968
+#: src/pages/Shell.tsx:2374
+#: src/pages/Shell.tsx:2967
 msgid "Take control"
 msgstr "Kontrolle übernehmen"
 
@@ -2350,7 +2354,7 @@ msgstr "Kontrolle übernehmen"
 msgid "Teach a task"
 msgstr "Aufgabe anlernen"
 
-#: src/pages/Shell.tsx:2208
+#: src/pages/Shell.tsx:2207
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachricht sendest."
 
@@ -2358,11 +2362,11 @@ msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachr
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Zum Anlernen ist ein grafischer Sandbox-Computer erforderlich. Auf dem Desktop gehostete Bots können Shell-Aufgaben ausführen, aber keine Bildschirmaufnahmen erstellen."
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "Team Computer"
 msgstr "Team-Computer"
 
@@ -2375,20 +2379,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügbar."
 
-#: src/pages/Shell.tsx:4560
+#: src/pages/Shell.tsx:4635
 msgid "Thinking"
 msgstr "Denkmodus"
 
-#: src/pages/Shell.tsx:2319
+#: src/pages/Shell.tsx:2318
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Dieser Bot wird auf diesem Computer und nicht auf einem Linux-Desktop ausgeführt. Shell und Dateien verwenden deinen persönlichen Ordner."
 
-#: src/pages/Shell.tsx:2992
+#: src/pages/Shell.tsx:2991
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Dieser Bot wird auf diesem Computer ausgeführt. Es gibt keinen separaten Linux-Desktop. Bitte ihn, die Shell zu verwenden; Arbeitsverzeichnisse in deinem persönlichen Ordner sind zulässig."
 
-#: src/pages/Shell.tsx:4960
-#: src/pages/Shell.tsx:5037
+#: src/pages/Shell.tsx:5035
+#: src/pages/Shell.tsx:5112
 msgid "This cannot be undone."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
@@ -2412,7 +2416,7 @@ msgstr "dieser Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Dieser Mac führt Shell-Befehle mit deinem Konto aus und kann auf Dateien in deinem persönlichen Ordner zugreifen. Aktiviere dies nicht auf einem gemeinsam genutzten oder öffentlichen Server."
 
-#: src/pages/Shell.tsx:4845
+#: src/pages/Shell.tsx:4920
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbeit beendet. Bot, Computer, Erinnerungen und Routinen bleiben erhalten."
 
@@ -2420,7 +2424,7 @@ msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbe
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bei diesem Anbieter kann hier kein Schlüssel eingefügt werden. Überspringe diesen Schritt, wenn die Bereitstellung bereits Zugangsdaten enthält."
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5452
 msgid "This server cannot be assigned without a bot."
 msgstr "Dieser Server kann ohne Bot nicht zugewiesen werden."
 
@@ -2432,7 +2436,7 @@ msgstr "Dieser Server hat keine Browserautorisierung angefordert."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Dieser Server ist bereits verbunden. Trenne zuerst die Verbindung, um ihn erneut zu autorisieren."
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5491
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Dieser Server verwendet die Browseranmeldung. Autorisiere ihn, damit deine Agents seine Tools verwenden können – ein Pop-up wird geöffnet."
 
@@ -2445,8 +2449,8 @@ msgid "Time of day"
 msgstr "Uhrzeit"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4409
+#: src/pages/Shell.tsx:4576
 msgid "Title"
 msgstr "Titel"
 
@@ -2471,7 +2475,7 @@ msgid "Unpin"
 msgstr "Lösen"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1384
+#: src/pages/Shell.tsx:1382
 msgid "Unsupported file type: {0}"
 msgstr "Nicht unterstützter Dateityp: {0}"
 
@@ -2484,7 +2488,7 @@ msgid "Updating…"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:176
-#: src/pages/Shell.tsx:2066
+#: src/pages/Shell.tsx:2064
 msgid "Usage"
 msgstr "Nutzung"
 
@@ -2509,8 +2513,8 @@ msgstr "Prüfen und hinzufügen"
 msgid "Verifying…"
 msgstr "Wird geprüft…"
 
-#: src/pages/Shell.tsx:2054
-#: src/pages/Shell.tsx:4613
+#: src/pages/Shell.tsx:2052
+#: src/pages/Shell.tsx:4688
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2523,7 +2527,7 @@ msgstr "Stimme"
 msgid "Waiting for sign-in…"
 msgstr "Warten auf Anmeldung…"
 
-#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5335
 msgid "Waiting…"
 msgstr "Warten…"
 
@@ -2532,7 +2536,7 @@ msgstr "Warten…"
 msgid "Weekdays"
 msgstr "Wochentage"
 
-#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:5005
 msgid "What about its memories?"
 msgstr "Was soll mit seinen Erinnerungen geschehen?"
 
@@ -2541,7 +2545,7 @@ msgid "What result will you demonstrate?"
 msgstr "Welches Ergebnis wirst du vorführen?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4349
+#: src/pages/Shell.tsx:4424
 msgid "What this bot is for"
 msgstr "Wofür dieser Bot gedacht ist"
 
@@ -2553,7 +2557,7 @@ msgstr "Was zurückgegeben werden soll"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "Wenn {botName} einem anderen Bot eine Nachricht sendet, wird der Austausch hier statt im Chat angezeigt."
 
-#: src/pages/Shell.tsx:2578
+#: src/pages/Shell.tsx:2577
 msgid "When to run"
 msgstr "Ausführungszeit"
 
@@ -2570,12 +2574,12 @@ msgstr "Wo sollen Bots ausgeführt werden?"
 msgid "Working…"
 msgstr "Wird verarbeitet…"
 
-#: src/pages/Shell.tsx:4543
+#: src/pages/Shell.tsx:4618
 msgid "Workspace default"
 msgstr "Arbeitsbereichsstandard"
 
-#: src/pages/Shell.tsx:1115
-#: src/pages/Shell.tsx:1706
+#: src/pages/Shell.tsx:1113
+#: src/pages/Shell.tsx:1704
 msgid "You"
 msgstr "Du"
 
@@ -2587,8 +2591,8 @@ msgstr "Du kannst diesen Tab schließen, wenn du nicht automatisch weitergeleite
 msgid "You can close this window."
 msgstr "Du kannst dieses Fenster schließen."
 
-#: src/pages/Shell.tsx:2352
-#: src/pages/Shell.tsx:2933
+#: src/pages/Shell.tsx:2351
+#: src/pages/Shell.tsx:2932
 msgid "You have control"
 msgstr "Du hast die Kontrolle"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1862
+#: src/pages/Shell.tsx:1860
 msgid " (unread)"
 msgstr " (unread)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# model} other {# models}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1300
+#: src/pages/Shell.tsx:1298
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1304
+#: src/pages/Shell.tsx:1302
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (over 10 MiB)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5308
 msgid "{0} connection"
 msgstr "{0} connection"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2356
+#: src/pages/Shell.tsx:2355
 msgid "{0} is using it"
 msgstr "{0} is using it"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:180
-#: src/pages/Shell.tsx:2071
+#: src/pages/Shell.tsx:2069
 msgid "{0} runs · {1} tokens"
 msgstr "{0} runs · {1} tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# peer} other {# peers}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} has not messaged another bot yet."
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "{botName}’s computer"
 msgstr "{botName}’s computer"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3475
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Access token (optional)"
 msgid "Account"
 msgstr "Account"
 
-#: src/pages/Shell.tsx:4619
+#: src/pages/Shell.tsx:4694
 msgid "Account default"
 msgstr "Account default"
 
@@ -156,8 +156,8 @@ msgstr "Active model"
 msgid "Active voice"
 msgstr "Active voice"
 
+#: src/pages/Shell.tsx:1739
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:1743
 msgid "Activity"
 msgstr "Activity"
 
@@ -221,7 +221,7 @@ msgstr "Adding…"
 #: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4597
 msgid "Advanced"
 msgstr "Advanced"
 
@@ -229,7 +229,7 @@ msgstr "Advanced"
 msgid "Agent access for new servers"
 msgstr "Agent access for new servers"
 
-#: src/pages/Shell.tsx:2163
+#: src/pages/Shell.tsx:2161
 msgid "Agent computer"
 msgstr "Agent computer"
 
@@ -316,11 +316,11 @@ msgstr "Applies when you click Add server. Use the agent chips on each server ca
 msgid "Approval boundaries"
 msgstr "Approval boundaries"
 
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 msgid "Approve"
 msgstr "Approve"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5492
 msgid "Approve this server to let your agent use its tools."
 msgstr "Approve this server to let your agent use its tools."
 
@@ -328,15 +328,15 @@ msgstr "Approve this server to let your agent use its tools."
 msgid "Archive"
 msgstr "Archive"
 
-#: src/pages/Shell.tsx:4066
+#: src/pages/Shell.tsx:4141
 msgid "archived"
 msgstr "archived"
 
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1944
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/Shell.tsx:4077
+#: src/pages/Shell.tsx:4152
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archived. Chat, memory, and files kept."
 
@@ -375,7 +375,7 @@ msgstr "Ask before purchases"
 msgid "Ask before sending external email"
 msgstr "Ask before sending external email"
 
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2357
 msgid "Asleep"
 msgstr "Asleep"
 
@@ -390,11 +390,11 @@ msgstr "at {0}"
 msgid "at {timeSelect}"
 msgstr "at {timeSelect}"
 
-#: src/pages/Shell.tsx:3471
+#: src/pages/Shell.tsx:3546
 msgid "Attach file"
 msgstr "Attach file"
 
-#: src/pages/Shell.tsx:3670
+#: src/pages/Shell.tsx:3745
 msgid "Attachment"
 msgstr "Attachment"
 
@@ -407,12 +407,12 @@ msgstr "Authorization code or callback URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Authorization expired — reconnect required"
 
-#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5293
 msgid "Authorization timed out. Please try again."
 msgstr "Authorization timed out. Please try again."
 
-#: src/pages/Shell.tsx:5260
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5501
 msgid "Authorize"
 msgstr "Authorize"
 
@@ -428,22 +428,22 @@ msgstr "Base URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5102
+#: src/pages/Shell.tsx:5177
 msgid "Booting live desktop…"
 msgstr "Booting live desktop…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2903
+#: src/pages/Shell.tsx:2902
 msgid "Booting up {0}’s computer"
 msgstr "Booting up {0}’s computer"
 
-#: src/pages/Shell.tsx:3936
-#: src/pages/Shell.tsx:3937
-#: src/pages/Shell.tsx:4070
+#: src/pages/Shell.tsx:4011
+#: src/pages/Shell.tsx:4012
+#: src/pages/Shell.tsx:4145
 msgid "bot"
 msgstr "bot"
 
-#: src/pages/Shell.tsx:1116
+#: src/pages/Shell.tsx:1114
 msgid "Bot"
 msgstr "Bot"
 
@@ -451,11 +451,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot messages"
 
-#: src/pages/Shell.tsx:3000
+#: src/pages/Shell.tsx:2999
 msgid "Bot screen"
 msgstr "Bot screen"
 
-#: src/pages/Shell.tsx:2326
+#: src/pages/Shell.tsx:2325
 msgid "Bot screen preview"
 msgstr "Bot screen preview"
 
@@ -468,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Bring your own key. The provider is swappable; your bots keep the same speak and call buttons."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2145
-#: src/pages/Shell.tsx:2146
+#: src/pages/Shell.tsx:2143
+#: src/pages/Shell.tsx:2144
 msgid "Call"
 msgstr "Call"
 
@@ -481,14 +481,14 @@ msgstr "Can't reach the server."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4786
-#: src/pages/Shell.tsx:4858
-#: src/pages/Shell.tsx:4973
-#: src/pages/Shell.tsx:5047
+#: src/pages/Shell.tsx:4861
+#: src/pages/Shell.tsx:4933
+#: src/pages/Shell.tsx:5048
+#: src/pages/Shell.tsx:5122
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/pages/Shell.tsx:4314
+#: src/pages/Shell.tsx:4389
 msgid "Cancel new bot"
 msgstr "Cancel new bot"
 
@@ -496,7 +496,7 @@ msgstr "Cancel new bot"
 msgid "Cancel new group"
 msgstr "Cancel new group"
 
-#: src/pages/Shell.tsx:3347
+#: src/pages/Shell.tsx:3422
 msgid "Cancel reply"
 msgstr "Cancel reply"
 
@@ -504,16 +504,16 @@ msgstr "Cancel reply"
 msgid "Cancelled"
 msgstr "Cancelled"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5398
 msgid "Chart failed to render: {error}"
 msgstr "Chart failed to render: {error}"
 
-#: src/pages/Shell.tsx:3613
+#: src/pages/Shell.tsx:3688
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
-#: src/pages/Shell.tsx:2608
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Check in."
 msgstr "Check in."
 
@@ -525,21 +525,21 @@ msgstr "Choose a model to get started."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Choose which connected model Rakazo uses."
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clear"
 msgstr "Clear"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4839
+#: src/pages/Shell.tsx:4914
 msgid "Clear {0}’s conversation?"
 msgstr "Clear {0}’s conversation?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4674
+#: src/pages/Shell.tsx:4749
 msgid "Clear conversation"
 msgstr "Clear conversation"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clearing…"
 msgstr "Clearing…"
 
@@ -555,15 +555,15 @@ msgstr "Close bot menu"
 msgid "Close bot messages"
 msgstr "Close bot messages"
 
-#: src/pages/Shell.tsx:5508
+#: src/pages/Shell.tsx:5583
 msgid "Close chart"
 msgstr "Close chart"
 
-#: src/pages/Shell.tsx:2974
+#: src/pages/Shell.tsx:2973
 msgid "Close computer"
 msgstr "Close computer"
 
-#: src/pages/Shell.tsx:5608
+#: src/pages/Shell.tsx:5683
 msgid "Close image preview"
 msgstr "Close image preview"
 
@@ -583,11 +583,11 @@ msgstr "Close memory settings"
 msgid "Close model settings"
 msgstr "Close model settings"
 
-#: src/pages/Shell.tsx:1726
+#: src/pages/Shell.tsx:1724
 msgid "Close navigation"
 msgstr "Close navigation"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2303
 msgid "Close panel"
 msgstr "Close panel"
 
@@ -616,24 +616,24 @@ msgstr "Command"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/pages/Shell.tsx:4224
-#: src/pages/Shell.tsx:4252
+#: src/pages/Shell.tsx:4299
+#: src/pages/Shell.tsx:4327
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5180
 msgid "Computer failed to boot"
 msgstr "Computer failed to boot"
 
-#: src/pages/Shell.tsx:3022
+#: src/pages/Shell.tsx:3021
 msgid "Computer is asleep"
 msgstr "Computer is asleep"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5179
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer is asleep — take control to wake it"
 
-#: src/pages/Shell.tsx:5106
+#: src/pages/Shell.tsx:5181
 msgid "Computer is stopped"
 msgstr "Computer is stopped"
 
@@ -666,7 +666,7 @@ msgstr "Connect API key"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "Connect ElevenLabs, OpenAI, or Cartesia"
 
-#: src/pages/Shell.tsx:5406
+#: src/pages/Shell.tsx:5481
 msgid "Connect MCP server “{name}”"
 msgstr "Connect MCP server “{name}”"
 
@@ -689,12 +689,12 @@ msgstr "Connect Treg"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5257
+#: src/pages/Shell.tsx:5332
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Connected"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5511
 msgid "Connected — its tools are available from your next message."
 msgstr "Connected — its tools are available from your next message."
 
@@ -719,7 +719,7 @@ msgstr "Connected and using {0}."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Connecting…"
@@ -738,7 +738,7 @@ msgstr "Continue"
 msgid "Continue with email"
 msgstr "Continue with email"
 
-#: src/pages/Shell.tsx:3721
+#: src/pages/Shell.tsx:3796
 msgid "Copy"
 msgstr "Copy"
 
@@ -750,11 +750,11 @@ msgstr "Could not add"
 msgid "Could not add MCP server"
 msgstr "Could not add MCP server"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5468
 msgid "Could not approve this server"
 msgstr "Could not approve this server"
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5296
 msgid "Could not authorize this app"
 msgstr "Could not authorize this app"
 
@@ -762,7 +762,7 @@ msgstr "Could not authorize this app"
 msgid "Could not change the default model"
 msgstr "Could not change the default model"
 
-#: src/pages/Shell.tsx:4867
+#: src/pages/Shell.tsx:4942
 msgid "Could not clear conversation"
 msgstr "Could not clear conversation"
 
@@ -791,7 +791,7 @@ msgstr "Could not connect this voice provider"
 msgid "Could not continue"
 msgstr "Could not continue"
 
-#: src/pages/Shell.tsx:4302
+#: src/pages/Shell.tsx:4377
 msgid "Could not create bot"
 msgstr "Could not create bot"
 
@@ -799,7 +799,7 @@ msgstr "Could not create bot"
 msgid "Could not create group"
 msgstr "Could not create group"
 
-#: src/pages/Shell.tsx:4758
+#: src/pages/Shell.tsx:4833
 msgid "Could not create section"
 msgstr "Could not create section"
 
@@ -807,7 +807,7 @@ msgstr "Could not create section"
 msgid "Could not create your bot"
 msgstr "Could not create your bot"
 
-#: src/pages/Shell.tsx:4982
+#: src/pages/Shell.tsx:5057
 msgid "Could not delete bot"
 msgstr "Could not delete bot"
 
@@ -815,7 +815,7 @@ msgstr "Could not delete bot"
 msgid "Could not delete MCP server"
 msgstr "Could not delete MCP server"
 
-#: src/pages/Shell.tsx:5056
+#: src/pages/Shell.tsx:5131
 msgid "Could not delete routine"
 msgstr "Could not delete routine"
 
@@ -889,7 +889,7 @@ msgstr "Could not remove group"
 msgid "Could not remove rule"
 msgstr "Could not remove rule"
 
-#: src/pages/Shell.tsx:5313
+#: src/pages/Shell.tsx:5388
 msgid "Could not render chart"
 msgstr "Could not render chart"
 
@@ -897,7 +897,7 @@ msgstr "Could not render chart"
 msgid "Could not revoke connection"
 msgstr "Could not revoke connection"
 
-#: src/pages/Shell.tsx:4659
+#: src/pages/Shell.tsx:4734
 msgid "Could not save"
 msgstr "Could not save"
 
@@ -909,7 +909,7 @@ msgstr "Could not save group"
 msgid "Could not save model"
 msgstr "Could not save model"
 
-#: src/pages/Shell.tsx:2630
+#: src/pages/Shell.tsx:2629
 msgid "Could not save routine"
 msgstr "Could not save routine"
 
@@ -925,7 +925,7 @@ msgstr "Could not save that choice"
 msgid "Could not save that voice"
 msgstr "Could not save that voice"
 
-#: src/pages/Shell.tsx:5133
+#: src/pages/Shell.tsx:5208
 msgid "Could not save this choice"
 msgstr "Could not save this choice"
 
@@ -941,7 +941,7 @@ msgstr "Could not start OAuth"
 msgid "Could not submit this answer"
 msgstr "Could not submit this answer"
 
-#: src/pages/Shell.tsx:1583
+#: src/pages/Shell.tsx:1581
 msgid "Could not take control"
 msgstr "Could not take control"
 
@@ -965,14 +965,14 @@ msgstr "Could not update the default memory scope"
 msgid "Couldn't update avatars"
 msgstr "Couldn't update avatars"
 
-#: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:1759
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Create"
 msgstr "Create"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4842
 msgid "Create a section and move {0} into it."
 msgstr "Create a section and move {0} into it."
 
@@ -993,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Create your Rakazo"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Creating…"
 msgstr "Creating…"
 
@@ -1022,7 +1022,7 @@ msgstr "day"
 msgid "days"
 msgstr "days"
 
-#: src/pages/Shell.tsx:4566
+#: src/pages/Shell.tsx:4641
 msgid "Default (medium)"
 msgstr "Default (medium)"
 
@@ -1032,21 +1032,21 @@ msgstr "Default scope"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1980
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:1978
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Delete"
 msgstr "Delete"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1974
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4920
-#: src/pages/Shell.tsx:5034
+#: src/pages/Shell.tsx:4995
+#: src/pages/Shell.tsx:5109
 msgid "Delete {0}?"
 msgstr "Delete {0}?"
 
@@ -1054,21 +1054,21 @@ msgstr "Delete {0}?"
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/pages/Shell.tsx:4957
+#: src/pages/Shell.tsx:5032
 msgid "Delete memories too"
 msgstr "Delete memories too"
 
-#: src/pages/Shell.tsx:2685
+#: src/pages/Shell.tsx:2684
 msgid "Delete routine"
 msgstr "Delete routine"
 
-#: src/pages/Shell.tsx:4068
+#: src/pages/Shell.tsx:4143
 msgid "deleted"
 msgstr "deleted"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1085,17 +1085,17 @@ msgid "Deployment default"
 msgstr "Deployment default"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4339
+#: src/pages/Shell.tsx:4414
 msgid "Describe what this bot does"
 msgstr "Describe what this bot does"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4344
-#: src/pages/Shell.tsx:4510
+#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4585
 msgid "Description"
 msgstr "Description"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Dictate"
 msgstr "Dictate"
 
@@ -1108,7 +1108,7 @@ msgstr "Disconnect"
 msgid "Disconnecting…"
 msgstr "Disconnecting…"
 
-#: src/pages/Shell.tsx:5441
+#: src/pages/Shell.tsx:5516
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Dismissed — reconnect anytime from MCP settings."
 
@@ -1156,7 +1156,7 @@ msgstr "Draft skill"
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/pages/Shell.tsx:3881
+#: src/pages/Shell.tsx:3956
 msgid "Earlier message"
 msgstr "Earlier message"
 
@@ -1212,11 +1212,11 @@ msgstr "Every month"
 msgid "Every week"
 msgstr "Every week"
 
-#: src/pages/Shell.tsx:5487
+#: src/pages/Shell.tsx:5562
 msgid "Expand"
 msgstr "Expand"
 
-#: src/pages/Shell.tsx:4671
+#: src/pages/Shell.tsx:4746
 msgid "Export"
 msgstr "Export"
 
@@ -1224,7 +1224,7 @@ msgstr "Export"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Export this week's list from the CRM and drop it in the shared folder"
 
-#: src/pages/Shell.tsx:4691
+#: src/pages/Shell.tsx:4766
 msgid "Extra high"
 msgstr "Extra high"
 
@@ -1232,14 +1232,14 @@ msgstr "Extra high"
 msgid "Failed"
 msgstr "Failed"
 
+#: src/pages/Shell.tsx:1424
 #: src/pages/Shell.tsx:1426
 #: src/pages/Shell.tsx:1428
-#: src/pages/Shell.tsx:1430
 msgid "Failed to send message"
 msgstr "Failed to send message"
 
-#: src/pages/Shell.tsx:1453
-#: src/pages/Shell.tsx:1472
+#: src/pages/Shell.tsx:1451
+#: src/pages/Shell.tsx:1470
 msgid "Failed to stop"
 msgstr "Failed to stop"
 
@@ -1275,8 +1275,8 @@ msgstr "Free"
 msgid "Fullscreen"
 msgstr "Fullscreen"
 
-#: src/pages/Shell.tsx:2135
-#: src/pages/Shell.tsx:2286
+#: src/pages/Shell.tsx:2133
+#: src/pages/Shell.tsx:2285
 msgid "Group"
 msgstr "Group"
 
@@ -1305,15 +1305,15 @@ msgstr "Hear a sample"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hi, this is how I'll sound when I read replies out loud."
 
-#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4769
 msgid "High"
 msgstr "High"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk"
 msgstr "Hold to talk"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk (on-device dictation)"
 msgstr "Hold to talk (on-device dictation)"
 
@@ -1333,7 +1333,7 @@ msgstr "How often"
 msgid "How to check"
 msgstr "How to check"
 
-#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:3852
 msgid "I’m done"
 msgstr "I’m done"
 
@@ -1345,7 +1345,7 @@ msgstr "If you heard that, voice is ready."
 msgid "Import OpenAPI JSON"
 msgstr "Import OpenAPI JSON"
 
-#: src/pages/Shell.tsx:4581
+#: src/pages/Shell.tsx:4656
 msgid "Inherit default"
 msgstr "Inherit default"
 
@@ -1357,12 +1357,12 @@ msgstr "Inputs"
 msgid "Instance API key"
 msgstr "Instance API key"
 
-#: src/pages/Shell.tsx:2569
+#: src/pages/Shell.tsx:2568
 msgid "Instruction"
 msgstr "Instruction"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:1995
 msgid "Integrations"
 msgstr "Integrations"
 
@@ -1383,15 +1383,19 @@ msgid "Interval unit"
 msgstr "Interval unit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4657
 msgid "Isolated"
 msgstr "Isolated"
 
-#: src/pages/Shell.tsx:4923
+#: src/pages/Shell.tsx:4998
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3213
+msgid "Jump to latest"
+msgstr "Jump to latest"
+
+#: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"
 msgstr "Jump to replied message"
 
@@ -1399,7 +1403,7 @@ msgstr "Jump to replied message"
 msgid "just now"
 msgstr "just now"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5016
 msgid "Keep memories"
 msgstr "Keep memories"
 
@@ -1417,7 +1421,7 @@ msgstr "Language"
 msgid "Listening…"
 msgstr "Listening…"
 
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Load earlier messages"
 msgstr "Load earlier messages"
 
@@ -1457,7 +1461,7 @@ msgstr "Loading voice providers…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -1465,11 +1469,11 @@ msgstr "Loading…"
 msgid "Local"
 msgstr "Local"
 
-#: src/pages/Shell.tsx:2083
+#: src/pages/Shell.tsx:2081
 msgid "Log out"
 msgstr "Log out"
 
-#: src/pages/Shell.tsx:4692
+#: src/pages/Shell.tsx:4767
 msgid "Low"
 msgstr "Low"
 
@@ -1485,7 +1489,7 @@ msgstr "Mark as Read"
 msgid "Mark as Unread"
 msgstr "Mark as Unread"
 
-#: src/pages/Shell.tsx:4696
+#: src/pages/Shell.tsx:4771
 msgid "Max"
 msgstr "Max"
 
@@ -1495,7 +1499,7 @@ msgstr "Max"
 msgid "MCP servers"
 msgstr "MCP servers"
 
-#: src/pages/Shell.tsx:4693
+#: src/pages/Shell.tsx:4768
 msgid "Medium"
 msgstr "Medium"
 
@@ -1508,33 +1512,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2041
+#: src/pages/Shell.tsx:2039
 msgid "Memory"
 msgstr "Memory"
 
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:4652
 msgid "Memory scope"
 msgstr "Memory scope"
 
-#: src/pages/Shell.tsx:3577
-#: src/pages/Shell.tsx:3672
+#: src/pages/Shell.tsx:3652
+#: src/pages/Shell.tsx:3747
 msgid "Message"
 msgstr "Message"
 
-#: src/pages/Shell.tsx:3573
-#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3648
+#: src/pages/Shell.tsx:3652
 msgid "Message {activeName}"
 msgstr "Message {activeName}"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Message from {peer}"
 msgstr "Message from {peer}"
 
-#: src/pages/Shell.tsx:3574
+#: src/pages/Shell.tsx:3649
 msgid "Message…"
 msgstr "Message…"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Messaged {peer}"
 msgstr "Messaged {peer}"
 
@@ -1542,7 +1546,7 @@ msgstr "Messaged {peer}"
 msgid "Microphone failed"
 msgstr "Microphone failed"
 
-#: src/pages/Shell.tsx:4695
+#: src/pages/Shell.tsx:4770
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1564,7 +1568,7 @@ msgstr "minutes"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4608
 msgid "Model"
 msgstr "Model"
 
@@ -1586,7 +1590,7 @@ msgid "Model updated."
 msgstr "Model updated."
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2026
 msgid "Models"
 msgstr "Models"
 
@@ -1604,7 +1608,7 @@ msgstr "Monthly"
 msgid "Move {0} to section"
 msgstr "Move {0} to section"
 
-#: src/pages/Shell.tsx:4944
+#: src/pages/Shell.tsx:5019
 msgid "Move them to your shared memory."
 msgstr "Move them to your shared memory."
 
@@ -1617,15 +1621,15 @@ msgstr "Move to"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2561
-#: src/pages/Shell.tsx:4324
-#: src/pages/Shell.tsx:4492
-#: src/pages/Shell.tsx:4770
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:4399
+#: src/pages/Shell.tsx:4567
+#: src/pages/Shell.tsx:4845
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4329
+#: src/pages/Shell.tsx:4404
 msgid "Name this bot"
 msgstr "Name this bot"
 
@@ -1641,13 +1645,13 @@ msgstr "Needs input"
 msgid "Needs takeover"
 msgstr "Needs takeover"
 
-#: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4312
+#: src/pages/Shell.tsx:1773
+#: src/pages/Shell.tsx:4387
 msgid "New bot"
 msgstr "New bot"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1785
+#: src/pages/Shell.tsx:1783
 msgid "New group"
 msgstr "New group"
 
@@ -1655,12 +1659,12 @@ msgstr "New group"
 msgid "New open-work item"
 msgstr "New open-work item"
 
-#: src/pages/Shell.tsx:2447
+#: src/pages/Shell.tsx:2446
 msgid "New routine"
 msgstr "New routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4839
 msgid "New section"
 msgstr "New section"
 
@@ -1738,7 +1742,7 @@ msgstr "Not connected"
 msgid "Not in the plugin catalog"
 msgstr "Not in the plugin catalog"
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5504
 msgid "Not now"
 msgstr "Not now"
 
@@ -1776,15 +1780,15 @@ msgstr "on the 1st at {0}"
 msgid "Open"
 msgstr "Open"
 
-#: src/pages/Shell.tsx:2345
+#: src/pages/Shell.tsx:2344
 msgid "Open computer"
 msgstr "Open computer"
 
-#: src/pages/Shell.tsx:2315
+#: src/pages/Shell.tsx:2314
 msgid "Open in full window"
 msgstr "Open in full window"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2105
 msgid "Open navigation"
 msgstr "Open navigation"
 
@@ -1801,7 +1805,7 @@ msgstr "Open work"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-compatible server URL"
 
-#: src/pages/Shell.tsx:4079
+#: src/pages/Shell.tsx:4154
 msgid "Opened its thread."
 msgstr "Opened its thread."
 
@@ -1888,7 +1892,7 @@ msgstr "Playing…"
 msgid "Preview {0}"
 msgstr "Preview {0}"
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Private"
 msgstr "Private"
 
@@ -1909,7 +1913,7 @@ msgstr "Queued"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4684
 msgid "Read replies aloud"
 msgstr "Read replies aloud"
 
@@ -1943,7 +1947,7 @@ msgstr "Recover replaces an unreachable computer and keeps files in the saved wo
 msgid "Recovering…"
 msgstr "Recovering…"
 
-#: src/pages/Shell.tsx:3767
+#: src/pages/Shell.tsx:3842
 msgid "Release"
 msgstr "Release"
 
@@ -1956,17 +1960,17 @@ msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3381
+#: src/pages/Shell.tsx:3456
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3536
+#: src/pages/Shell.tsx:3611
 msgid "Remove mention {0}"
 msgstr "Remove mention {0}"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3590
 msgid "Remove skill {0}"
 msgstr "Remove skill {0}"
 
@@ -1974,7 +1978,7 @@ msgstr "Remove skill {0}"
 msgid "Remove this schedule"
 msgstr "Remove this schedule"
 
-#: src/pages/Shell.tsx:4078
+#: src/pages/Shell.tsx:4153
 msgid "Removed with chat, computer, and memory."
 msgstr "Removed with chat, computer, and memory."
 
@@ -2002,11 +2006,11 @@ msgstr "Replace API key"
 msgid "Replace key"
 msgstr "Replace key"
 
-#: src/pages/Shell.tsx:3713
+#: src/pages/Shell.tsx:3788
 msgid "Reply"
 msgstr "Reply"
 
-#: src/pages/Shell.tsx:3344
+#: src/pages/Shell.tsx:3419
 msgid "Replying to {replyName}"
 msgstr "Replying to {replyName}"
 
@@ -2027,7 +2031,7 @@ msgstr "Reset computer?"
 msgid "Resetting…"
 msgstr "Resetting…"
 
-#: src/pages/Shell.tsx:1972
+#: src/pages/Shell.tsx:1970
 msgid "Restore"
 msgstr "Restore"
 
@@ -2047,17 +2051,17 @@ msgstr "Return to Rakazo"
 msgid "Robot"
 msgstr "Robot"
 
-#: src/pages/Shell.tsx:2554
-#: src/pages/Shell.tsx:2607
-#: src/pages/Shell.tsx:2614
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:2613
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2392
+#: src/pages/Shell.tsx:2391
 msgid "Routines"
 msgstr "Routines"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Run now"
 msgstr "Run now"
 
@@ -2065,11 +2069,11 @@ msgstr "Run now"
 msgid "Running"
 msgstr "Running"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2431
 msgid "Running · Stop"
 msgstr "Running · Stop"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Running…"
 msgstr "Running…"
 
@@ -2077,8 +2081,8 @@ msgstr "Running…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2653
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:2652
+#: src/pages/Shell.tsx:4739
 msgid "Save"
 msgstr "Save"
 
@@ -2102,7 +2106,7 @@ msgstr "Saved."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:2652
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2116,7 +2120,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "Say yes or no, or answer in a sentence."
 
 #: src/pages/ModelSettingsOverlay.tsx:939
-#: src/pages/Shell.tsx:1796
+#: src/pages/Shell.tsx:1794
 msgid "Search"
 msgstr "Search"
 
@@ -2143,11 +2147,11 @@ msgstr "Search providers and models"
 msgid "Searching…"
 msgstr "Searching…"
 
-#: src/pages/Shell.tsx:2136
+#: src/pages/Shell.tsx:2134
 msgid "Select a bot"
 msgstr "Select a bot"
 
-#: src/pages/Shell.tsx:3597
+#: src/pages/Shell.tsx:3672
 msgid "Send"
 msgstr "Send"
 
@@ -2175,22 +2179,22 @@ msgstr "Server name"
 msgid "Server URL"
 msgstr "Server URL"
 
-#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2143
 msgid "Set up voice to call"
 msgstr "Set up voice to call"
 
 #: src/pages/AccountSettingsOverlay.tsx:100
-#: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2015
-#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2003
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:2281
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Shell.tsx:3615
+#: src/pages/Shell.tsx:3690
 msgid "Settings: General"
 msgstr "Settings: General"
 
-#: src/pages/Shell.tsx:3617
+#: src/pages/Shell.tsx:3692
 msgid "Settings: Usage"
 msgstr "Settings: Usage"
 
@@ -2200,15 +2204,15 @@ msgid "Setup help"
 msgstr "Setup help"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4583
+#: src/pages/Shell.tsx:4658
 msgid "Shared"
 msgstr "Shared"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show computer"
 msgstr "Show computer"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show settings"
 msgstr "Show settings"
 
@@ -2232,11 +2236,11 @@ msgid "Sign up"
 msgstr "Sign up"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3428
+#: src/pages/Shell.tsx:3503
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3774
+#: src/pages/Shell.tsx:3849
 msgid "Skip"
 msgstr "Skip"
 
@@ -2249,7 +2253,7 @@ msgid "Skip or deploy key"
 msgstr "Skip or deploy key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1320
+#: src/pages/Shell.tsx:1318
 msgid "Skipped {0}"
 msgstr "Skipped {0}"
 
@@ -2257,8 +2261,8 @@ msgstr "Skipped {0}"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space interrupts · Esc hangs up"
 
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Speak"
 msgstr "Speak"
 
@@ -2270,8 +2274,8 @@ msgstr "Speak + transcribe"
 msgid "Speak only"
 msgstr "Speak only"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Speak this reply"
 msgstr "Speak this reply"
 
@@ -2297,20 +2301,20 @@ msgstr "Starting…"
 msgid "Steps"
 msgstr "Steps"
 
-#: src/pages/Shell.tsx:2943
-#: src/pages/Shell.tsx:2947
-#: src/pages/Shell.tsx:3588
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2946
+#: src/pages/Shell.tsx:3663
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Stop"
 msgstr "Stop"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Stop dictation"
 msgstr "Stop dictation"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Stop speaking"
 msgstr "Stop speaking"
 
@@ -2319,8 +2323,8 @@ msgstr "Stop speaking"
 msgid "Stop teaching"
 msgstr "Stop teaching"
 
-#: src/pages/Shell.tsx:2372
-#: src/pages/Shell.tsx:2963
+#: src/pages/Shell.tsx:2371
+#: src/pages/Shell.tsx:2962
 msgid "Stop the bot first"
 msgstr "Stop the bot first"
 
@@ -2328,7 +2332,7 @@ msgstr "Stop the bot first"
 msgid "Stored encrypted"
 msgstr "Stored encrypted"
 
-#: src/pages/Shell.tsx:4030
+#: src/pages/Shell.tsx:4105
 msgid "subagent"
 msgstr "subagent"
 
@@ -2341,8 +2345,8 @@ msgstr "Submit"
 msgid "Switching…"
 msgstr "Switching…"
 
-#: src/pages/Shell.tsx:2375
-#: src/pages/Shell.tsx:2968
+#: src/pages/Shell.tsx:2374
+#: src/pages/Shell.tsx:2967
 msgid "Take control"
 msgstr "Take control"
 
@@ -2350,7 +2354,7 @@ msgstr "Take control"
 msgid "Teach a task"
 msgstr "Teach a task"
 
-#: src/pages/Shell.tsx:2208
+#: src/pages/Shell.tsx:2207
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Teaching in progress — stop teaching before sending a new message."
 
@@ -2358,11 +2362,11 @@ msgstr "Teaching in progress — stop teaching before sending a new message."
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -2375,20 +2379,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "The selected memory provider is not available in this build."
 
-#: src/pages/Shell.tsx:4560
+#: src/pages/Shell.tsx:4635
 msgid "Thinking"
 msgstr "Thinking"
 
-#: src/pages/Shell.tsx:2319
+#: src/pages/Shell.tsx:2318
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 
-#: src/pages/Shell.tsx:2992
+#: src/pages/Shell.tsx:2991
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 
-#: src/pages/Shell.tsx:4960
-#: src/pages/Shell.tsx:5037
+#: src/pages/Shell.tsx:5035
+#: src/pages/Shell.tsx:5112
 msgid "This cannot be undone."
 msgstr "This cannot be undone."
 
@@ -2412,7 +2416,7 @@ msgstr "this Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 
-#: src/pages/Shell.tsx:4845
+#: src/pages/Shell.tsx:4920
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 
@@ -2420,7 +2424,7 @@ msgstr "This permanently removes every message and stops current work. The bot, 
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "This provider cannot paste a key here. Skip if this deployment already has credentials."
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5452
 msgid "This server cannot be assigned without a bot."
 msgstr "This server cannot be assigned without a bot."
 
@@ -2432,7 +2436,7 @@ msgstr "This server did not request browser authorization."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "This server is already connected. Disconnect it first to authorize again."
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5491
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 
@@ -2445,8 +2449,8 @@ msgid "Time of day"
 msgstr "Time of day"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4409
+#: src/pages/Shell.tsx:4576
 msgid "Title"
 msgstr "Title"
 
@@ -2471,7 +2475,7 @@ msgid "Unpin"
 msgstr "Unpin"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1384
+#: src/pages/Shell.tsx:1382
 msgid "Unsupported file type: {0}"
 msgstr "Unsupported file type: {0}"
 
@@ -2484,7 +2488,7 @@ msgid "Updating…"
 msgstr "Updating…"
 
 #: src/pages/AccountSettingsOverlay.tsx:176
-#: src/pages/Shell.tsx:2066
+#: src/pages/Shell.tsx:2064
 msgid "Usage"
 msgstr "Usage"
 
@@ -2509,8 +2513,8 @@ msgstr "Verify and add"
 msgid "Verifying…"
 msgstr "Verifying…"
 
-#: src/pages/Shell.tsx:2054
-#: src/pages/Shell.tsx:4613
+#: src/pages/Shell.tsx:2052
+#: src/pages/Shell.tsx:4688
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2523,7 +2527,7 @@ msgstr "Voice"
 msgid "Waiting for sign-in…"
 msgstr "Waiting for sign-in…"
 
-#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5335
 msgid "Waiting…"
 msgstr "Waiting…"
 
@@ -2532,7 +2536,7 @@ msgstr "Waiting…"
 msgid "Weekdays"
 msgstr "Weekdays"
 
-#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:5005
 msgid "What about its memories?"
 msgstr "What about its memories?"
 
@@ -2541,7 +2545,7 @@ msgid "What result will you demonstrate?"
 msgstr "What result will you demonstrate?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4349
+#: src/pages/Shell.tsx:4424
 msgid "What this bot is for"
 msgstr "What this bot is for"
 
@@ -2553,7 +2557,7 @@ msgstr "What to return"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 
-#: src/pages/Shell.tsx:2578
+#: src/pages/Shell.tsx:2577
 msgid "When to run"
 msgstr "When to run"
 
@@ -2570,12 +2574,12 @@ msgstr "Where should bots run?"
 msgid "Working…"
 msgstr "Working…"
 
-#: src/pages/Shell.tsx:4543
+#: src/pages/Shell.tsx:4618
 msgid "Workspace default"
 msgstr "Workspace default"
 
-#: src/pages/Shell.tsx:1115
-#: src/pages/Shell.tsx:1706
+#: src/pages/Shell.tsx:1113
+#: src/pages/Shell.tsx:1704
 msgid "You"
 msgstr "You"
 
@@ -2587,8 +2591,8 @@ msgstr "You can close this tab if it does not redirect automatically."
 msgid "You can close this window."
 msgstr "You can close this window."
 
-#: src/pages/Shell.tsx:2352
-#: src/pages/Shell.tsx:2933
+#: src/pages/Shell.tsx:2351
+#: src/pages/Shell.tsx:2932
 msgid "You have control"
 msgstr "You have control"
 

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1862
+#: src/pages/Shell.tsx:1860
 msgid " (unread)"
 msgstr " (अपठित)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# मॉडल} other {# मॉडल}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1300
+#: src/pages/Shell.tsx:1298
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (अधिकतम {ATTACHMENT_MAX_COUNT} अटैचमेंट)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1304
+#: src/pages/Shell.tsx:1302
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB से अधिक)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5308
 msgid "{0} connection"
 msgstr "{0} कनेक्शन"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2356
+#: src/pages/Shell.tsx:2355
 msgid "{0} is using it"
 msgstr "{0} इसका उपयोग कर रहा है"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:180
-#: src/pages/Shell.tsx:2071
+#: src/pages/Shell.tsx:2069
 msgid "{0} runs · {1} tokens"
 msgstr "{0} रन · {1} टोकन"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# सहयोगी बॉट} other {# �
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} ने अभी तक किसी दूसरे बॉट को संदेश नहीं भेजा है।"
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "{botName}’s computer"
 msgstr "{botName} का कंप्यूटर"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3475
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "एक्सेस टोकन (वैकल्पिक)"
 msgid "Account"
 msgstr "खाता"
 
-#: src/pages/Shell.tsx:4619
+#: src/pages/Shell.tsx:4694
 msgid "Account default"
 msgstr "खाता डिफ़ॉल्ट"
 
@@ -156,8 +156,8 @@ msgstr "सक्रिय मॉडल"
 msgid "Active voice"
 msgstr "सक्रिय आवाज़"
 
+#: src/pages/Shell.tsx:1739
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:1743
 msgid "Activity"
 msgstr "गतिविधि"
 
@@ -221,7 +221,7 @@ msgstr "जोड़ा जा रहा है…"
 #: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4597
 msgid "Advanced"
 msgstr "उन्नत"
 
@@ -229,7 +229,7 @@ msgstr "उन्नत"
 msgid "Agent access for new servers"
 msgstr "नए सर्वरों के लिए एजेंट एक्सेस"
 
-#: src/pages/Shell.tsx:2163
+#: src/pages/Shell.tsx:2161
 msgid "Agent computer"
 msgstr "एजेंट कंप्यूटर"
 
@@ -316,11 +316,11 @@ msgstr "यह तब लागू होता है जब आप 'सर्�
 msgid "Approval boundaries"
 msgstr "अनुमोदन सीमाएं"
 
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 msgid "Approve"
 msgstr "अनुमोदित करें"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5492
 msgid "Approve this server to let your agent use its tools."
 msgstr "अपने एजेंट को इसके टूल उपयोग करने देने के लिए इस सर्वर को अनुमोदित करें।"
 
@@ -328,15 +328,15 @@ msgstr "अपने एजेंट को इसके टूल उपयो�
 msgid "Archive"
 msgstr "आर्काइव करें"
 
-#: src/pages/Shell.tsx:4066
+#: src/pages/Shell.tsx:4141
 msgid "archived"
 msgstr "आर्काइव किया गया"
 
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1944
 msgid "Archived"
 msgstr "आर्काइव किया गया"
 
-#: src/pages/Shell.tsx:4077
+#: src/pages/Shell.tsx:4152
 msgid "Archived. Chat, memory, and files kept."
 msgstr "आर्काइव किया गया। चैट, मेमोरी और फ़ाइलें सुरक्षित रखी गईं।"
 
@@ -375,7 +375,7 @@ msgstr "खरीद से पहले पूछें"
 msgid "Ask before sending external email"
 msgstr "बाहरी ईमेल भेजने से पहले पूछें"
 
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2357
 msgid "Asleep"
 msgstr "निष्क्रिय"
 
@@ -390,11 +390,11 @@ msgstr "{0} बजे"
 msgid "at {timeSelect}"
 msgstr "{timeSelect} बजे"
 
-#: src/pages/Shell.tsx:3471
+#: src/pages/Shell.tsx:3546
 msgid "Attach file"
 msgstr "फ़ाइल संलग्न करें"
 
-#: src/pages/Shell.tsx:3670
+#: src/pages/Shell.tsx:3745
 msgid "Attachment"
 msgstr "अटैचमेंट"
 
@@ -407,12 +407,12 @@ msgstr "ऑथराइज़ेशन कोड या कॉलबैक URL"
 msgid "Authorization expired — reconnect required"
 msgstr "ऑथराइज़ेशन समाप्त — पुनः कनेक्ट करना आवश्यक"
 
-#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5293
 msgid "Authorization timed out. Please try again."
 msgstr "ऑथराइज़ेशन का समय समाप्त हो गया। कृपया पुनः प्रयास करें।"
 
-#: src/pages/Shell.tsx:5260
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5501
 msgid "Authorize"
 msgstr "ऑथराइज़ करें"
 
@@ -428,22 +428,22 @@ msgstr "बेस URL"
 msgid "Bearer token"
 msgstr "बियरर टोकन"
 
-#: src/pages/Shell.tsx:5102
+#: src/pages/Shell.tsx:5177
 msgid "Booting live desktop…"
 msgstr "लाइव डेस्कटॉप शुरू हो रहा है…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2903
+#: src/pages/Shell.tsx:2902
 msgid "Booting up {0}’s computer"
 msgstr "{0} का कंप्यूटर शुरू हो रहा है"
 
-#: src/pages/Shell.tsx:3936
-#: src/pages/Shell.tsx:3937
-#: src/pages/Shell.tsx:4070
+#: src/pages/Shell.tsx:4011
+#: src/pages/Shell.tsx:4012
+#: src/pages/Shell.tsx:4145
 msgid "bot"
 msgstr "बॉट"
 
-#: src/pages/Shell.tsx:1116
+#: src/pages/Shell.tsx:1114
 msgid "Bot"
 msgstr "बॉट"
 
@@ -451,11 +451,11 @@ msgstr "बॉट"
 msgid "Bot messages"
 msgstr "बॉट संदेश"
 
-#: src/pages/Shell.tsx:3000
+#: src/pages/Shell.tsx:2999
 msgid "Bot screen"
 msgstr "बॉट स्क्रीन"
 
-#: src/pages/Shell.tsx:2326
+#: src/pages/Shell.tsx:2325
 msgid "Bot screen preview"
 msgstr "बॉट स्क्रीन प्रीव्यू"
 
@@ -468,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "अपनी कुंजी स्वयं लाएं। प्रोवाइडर बदला जा सकता है; आपके बॉट्स के बोलने और कॉल करने वाले बटन वही रहते हैं।"
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2145
-#: src/pages/Shell.tsx:2146
+#: src/pages/Shell.tsx:2143
+#: src/pages/Shell.tsx:2144
 msgid "Call"
 msgstr "कॉल"
 
@@ -481,14 +481,14 @@ msgstr "सर्वर तक नहीं पहुंचा जा सका�
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4786
-#: src/pages/Shell.tsx:4858
-#: src/pages/Shell.tsx:4973
-#: src/pages/Shell.tsx:5047
+#: src/pages/Shell.tsx:4861
+#: src/pages/Shell.tsx:4933
+#: src/pages/Shell.tsx:5048
+#: src/pages/Shell.tsx:5122
 msgid "Cancel"
 msgstr "रद्द करें"
 
-#: src/pages/Shell.tsx:4314
+#: src/pages/Shell.tsx:4389
 msgid "Cancel new bot"
 msgstr "नया बॉट रद्द करें"
 
@@ -496,7 +496,7 @@ msgstr "नया बॉट रद्द करें"
 msgid "Cancel new group"
 msgstr "नया समूह रद्द करें"
 
-#: src/pages/Shell.tsx:3347
+#: src/pages/Shell.tsx:3422
 msgid "Cancel reply"
 msgstr "उत्तर रद्द करें"
 
@@ -504,16 +504,16 @@ msgstr "उत्तर रद्द करें"
 msgid "Cancelled"
 msgstr "रद्द किया गया"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5398
 msgid "Chart failed to render: {error}"
 msgstr "चार्ट रेंडर नहीं हो सका: {error}"
 
-#: src/pages/Shell.tsx:3613
+#: src/pages/Shell.tsx:3688
 msgid "Chat Settings"
 msgstr "चैट सेटिंग्स"
 
-#: src/pages/Shell.tsx:2608
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Check in."
 msgstr "जांच करें।"
 
@@ -525,21 +525,21 @@ msgstr "शुरू करने के लिए एक मॉडल चुन
 msgid "Choose which connected model Rakazo uses."
 msgstr "चुनें कि Rakazo किस कनेक्टेड मॉडल का उपयोग करे।"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clear"
 msgstr "साफ़ करें"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4839
+#: src/pages/Shell.tsx:4914
 msgid "Clear {0}’s conversation?"
 msgstr "{0} की बातचीत साफ़ करें?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4674
+#: src/pages/Shell.tsx:4749
 msgid "Clear conversation"
 msgstr "बातचीत साफ़ करें"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clearing…"
 msgstr "साफ़ किया जा रहा है…"
 
@@ -555,15 +555,15 @@ msgstr "बॉट मेन्यू बंद करें"
 msgid "Close bot messages"
 msgstr "बॉट संदेश बंद करें"
 
-#: src/pages/Shell.tsx:5508
+#: src/pages/Shell.tsx:5583
 msgid "Close chart"
 msgstr "चार्ट बंद करें"
 
-#: src/pages/Shell.tsx:2974
+#: src/pages/Shell.tsx:2973
 msgid "Close computer"
 msgstr "कंप्यूटर बंद करें"
 
-#: src/pages/Shell.tsx:5608
+#: src/pages/Shell.tsx:5683
 msgid "Close image preview"
 msgstr "छवि प्रीव्यू बंद करें"
 
@@ -583,11 +583,11 @@ msgstr "मेमोरी सेटिंग्स बंद करें"
 msgid "Close model settings"
 msgstr "मॉडल सेटिंग्स बंद करें"
 
-#: src/pages/Shell.tsx:1726
+#: src/pages/Shell.tsx:1724
 msgid "Close navigation"
 msgstr "नेविगेशन बंद करें"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2303
 msgid "Close panel"
 msgstr "पैनल बंद करें"
 
@@ -616,24 +616,24 @@ msgstr "कमांड"
 msgid "Complete"
 msgstr "पूर्ण"
 
-#: src/pages/Shell.tsx:4224
-#: src/pages/Shell.tsx:4252
+#: src/pages/Shell.tsx:4299
+#: src/pages/Shell.tsx:4327
 msgid "Computer"
 msgstr "कंप्यूटर"
 
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5180
 msgid "Computer failed to boot"
 msgstr "कंप्यूटर शुरू नहीं हो सका"
 
-#: src/pages/Shell.tsx:3022
+#: src/pages/Shell.tsx:3021
 msgid "Computer is asleep"
 msgstr "कंप्यूटर निष्क्रिय है"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5179
 msgid "Computer is asleep — take control to wake it"
 msgstr "कंप्यूटर निष्क्रिय है — जगाने के लिए नियंत्रण लें"
 
-#: src/pages/Shell.tsx:5106
+#: src/pages/Shell.tsx:5181
 msgid "Computer is stopped"
 msgstr "कंप्यूटर रुका हुआ है"
 
@@ -666,7 +666,7 @@ msgstr "API कुंजी कनेक्ट करें"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI या Cartesia कनेक्ट करें"
 
-#: src/pages/Shell.tsx:5406
+#: src/pages/Shell.tsx:5481
 msgid "Connect MCP server “{name}”"
 msgstr "MCP सर्वर “{name}” कनेक्ट करें"
 
@@ -689,12 +689,12 @@ msgstr "Treg कनेक्ट करें"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5257
+#: src/pages/Shell.tsx:5332
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "कनेक्टेड"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5511
 msgid "Connected — its tools are available from your next message."
 msgstr "कनेक्टेड — इसके टूल आपके अगले संदेश से उपलब्ध हैं।"
 
@@ -719,7 +719,7 @@ msgstr "{0} कनेक्ट किया गया और उपयोग म
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "कनेक्ट हो रहा है…"
@@ -738,7 +738,7 @@ msgstr "जारी रखें"
 msgid "Continue with email"
 msgstr "ईमेल से जारी रखें"
 
-#: src/pages/Shell.tsx:3721
+#: src/pages/Shell.tsx:3796
 msgid "Copy"
 msgstr "कॉपी करें"
 
@@ -750,11 +750,11 @@ msgstr "जोड़ा नहीं जा सका"
 msgid "Could not add MCP server"
 msgstr "MCP सर्वर जोड़ा नहीं जा सका"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5468
 msgid "Could not approve this server"
 msgstr "इस सर्वर को अनुमोदित नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5296
 msgid "Could not authorize this app"
 msgstr "इस ऐप को ऑथराइज़ नहीं किया जा सका"
 
@@ -762,7 +762,7 @@ msgstr "इस ऐप को ऑथराइज़ नहीं किया ज
 msgid "Could not change the default model"
 msgstr "डिफ़ॉल्ट मॉडल बदला नहीं जा सका"
 
-#: src/pages/Shell.tsx:4867
+#: src/pages/Shell.tsx:4942
 msgid "Could not clear conversation"
 msgstr "बातचीत साफ़ नहीं की जा सकी"
 
@@ -791,7 +791,7 @@ msgstr "यह आवाज़ प्रोवाइडर कनेक्ट �
 msgid "Could not continue"
 msgstr "जारी नहीं रखा जा सका"
 
-#: src/pages/Shell.tsx:4302
+#: src/pages/Shell.tsx:4377
 msgid "Could not create bot"
 msgstr "बॉट नहीं बनाया जा सका"
 
@@ -799,7 +799,7 @@ msgstr "बॉट नहीं बनाया जा सका"
 msgid "Could not create group"
 msgstr "समूह नहीं बनाया जा सका"
 
-#: src/pages/Shell.tsx:4758
+#: src/pages/Shell.tsx:4833
 msgid "Could not create section"
 msgstr "सेक्शन नहीं बनाया जा सका"
 
@@ -807,7 +807,7 @@ msgstr "सेक्शन नहीं बनाया जा सका"
 msgid "Could not create your bot"
 msgstr "आपका बॉट नहीं बनाया जा सका"
 
-#: src/pages/Shell.tsx:4982
+#: src/pages/Shell.tsx:5057
 msgid "Could not delete bot"
 msgstr "बॉट डिलीट नहीं किया जा सका"
 
@@ -815,7 +815,7 @@ msgstr "बॉट डिलीट नहीं किया जा सका"
 msgid "Could not delete MCP server"
 msgstr "MCP सर्वर डिलीट नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:5056
+#: src/pages/Shell.tsx:5131
 msgid "Could not delete routine"
 msgstr "रूटीन डिलीट नहीं किया जा सका"
 
@@ -889,7 +889,7 @@ msgstr "समूह हटाया नहीं जा सका"
 msgid "Could not remove rule"
 msgstr "नियम हटाया नहीं जा सका"
 
-#: src/pages/Shell.tsx:5313
+#: src/pages/Shell.tsx:5388
 msgid "Could not render chart"
 msgstr "चार्ट रेंडर नहीं हो सका"
 
@@ -897,7 +897,7 @@ msgstr "चार्ट रेंडर नहीं हो सका"
 msgid "Could not revoke connection"
 msgstr "कनेक्शन रद्द नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:4659
+#: src/pages/Shell.tsx:4734
 msgid "Could not save"
 msgstr "सहेजा नहीं जा सका"
 
@@ -909,7 +909,7 @@ msgstr "समूह सहेजा नहीं जा सका"
 msgid "Could not save model"
 msgstr "मॉडल सहेजा नहीं जा सका"
 
-#: src/pages/Shell.tsx:2630
+#: src/pages/Shell.tsx:2629
 msgid "Could not save routine"
 msgstr "रूटीन सहेजा नहीं जा सका"
 
@@ -925,7 +925,7 @@ msgstr "वह विकल्प सहेजा नहीं जा सका"
 msgid "Could not save that voice"
 msgstr "वह आवाज़ सहेजी नहीं जा सकी"
 
-#: src/pages/Shell.tsx:5133
+#: src/pages/Shell.tsx:5208
 msgid "Could not save this choice"
 msgstr "यह विकल्प सहेजा नहीं जा सका"
 
@@ -941,7 +941,7 @@ msgstr "OAuth शुरू नहीं हो सका"
 msgid "Could not submit this answer"
 msgstr "यह उत्तर सबमिट नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:1583
+#: src/pages/Shell.tsx:1581
 msgid "Could not take control"
 msgstr "नियंत्रण नहीं लिया जा सका"
 
@@ -965,14 +965,14 @@ msgstr "डिफ़ॉल्ट मेमोरी स्कोप अपडे
 msgid "Couldn't update avatars"
 msgstr ""
 
-#: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:1759
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Create"
 msgstr "बनाएं"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4842
 msgid "Create a section and move {0} into it."
 msgstr "एक सेक्शन बनाएं और {0} को उसमें ले जाएं।"
 
@@ -993,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "अपना Rakazo बनाएं"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Creating…"
 msgstr "बनाया जा रहा है…"
 
@@ -1022,7 +1022,7 @@ msgstr "दिन"
 msgid "days"
 msgstr "दिन"
 
-#: src/pages/Shell.tsx:4566
+#: src/pages/Shell.tsx:4641
 msgid "Default (medium)"
 msgstr "डिफ़ॉल्ट (मध्यम)"
 
@@ -1032,21 +1032,21 @@ msgstr "डिफ़ॉल्ट स्कोप"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1980
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:1978
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Delete"
 msgstr "डिलीट करें"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1974
 msgid "Delete {0}"
 msgstr "{0} डिलीट करें"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4920
-#: src/pages/Shell.tsx:5034
+#: src/pages/Shell.tsx:4995
+#: src/pages/Shell.tsx:5109
 msgid "Delete {0}?"
 msgstr "{0} डिलीट करें?"
 
@@ -1054,21 +1054,21 @@ msgstr "{0} डिलीट करें?"
 msgid "Delete group"
 msgstr "समूह डिलीट करें"
 
-#: src/pages/Shell.tsx:4957
+#: src/pages/Shell.tsx:5032
 msgid "Delete memories too"
 msgstr "मेमोरी भी डिलीट करें"
 
-#: src/pages/Shell.tsx:2685
+#: src/pages/Shell.tsx:2684
 msgid "Delete routine"
 msgstr "रूटीन डिलीट करें"
 
-#: src/pages/Shell.tsx:4068
+#: src/pages/Shell.tsx:4143
 msgid "deleted"
 msgstr "डिलीट किया गया"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Deleting…"
 msgstr "डिलीट किया जा रहा है…"
 
@@ -1085,17 +1085,17 @@ msgid "Deployment default"
 msgstr "डिप्लॉयमेंट डिफ़ॉल्ट"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4339
+#: src/pages/Shell.tsx:4414
 msgid "Describe what this bot does"
 msgstr "बताएं कि यह बॉट क्या करता है"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4344
-#: src/pages/Shell.tsx:4510
+#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4585
 msgid "Description"
 msgstr "विवरण"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Dictate"
 msgstr "बोलकर लिखें"
 
@@ -1108,7 +1108,7 @@ msgstr "डिस्कनेक्ट करें"
 msgid "Disconnecting…"
 msgstr "डिस्कनेक्ट हो रहा है…"
 
-#: src/pages/Shell.tsx:5441
+#: src/pages/Shell.tsx:5516
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "खारिज किया गया — MCP सेटिंग्स से कभी भी पुनः कनेक्ट करें।"
 
@@ -1156,7 +1156,7 @@ msgstr "ड्राफ़्ट स्किल"
 msgid "Duplicate"
 msgstr "डुप्लिकेट"
 
-#: src/pages/Shell.tsx:3881
+#: src/pages/Shell.tsx:3956
 msgid "Earlier message"
 msgstr "पुराना संदेश"
 
@@ -1212,11 +1212,11 @@ msgstr "हर महीने"
 msgid "Every week"
 msgstr "हर सप्ताह"
 
-#: src/pages/Shell.tsx:5487
+#: src/pages/Shell.tsx:5562
 msgid "Expand"
 msgstr "विस्तृत करें"
 
-#: src/pages/Shell.tsx:4671
+#: src/pages/Shell.tsx:4746
 msgid "Export"
 msgstr "एक्सपोर्ट करें"
 
@@ -1224,7 +1224,7 @@ msgstr "एक्सपोर्ट करें"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "CRM से इस सप्ताह की सूची एक्सपोर्ट करें और उसे साझा फ़ोल्डर में डालें"
 
-#: src/pages/Shell.tsx:4691
+#: src/pages/Shell.tsx:4766
 msgid "Extra high"
 msgstr "अतिरिक्त उच्च"
 
@@ -1232,14 +1232,14 @@ msgstr "अतिरिक्त उच्च"
 msgid "Failed"
 msgstr "विफल"
 
+#: src/pages/Shell.tsx:1424
 #: src/pages/Shell.tsx:1426
 #: src/pages/Shell.tsx:1428
-#: src/pages/Shell.tsx:1430
 msgid "Failed to send message"
 msgstr "संदेश भेजने में विफल"
 
-#: src/pages/Shell.tsx:1453
-#: src/pages/Shell.tsx:1472
+#: src/pages/Shell.tsx:1451
+#: src/pages/Shell.tsx:1470
 msgid "Failed to stop"
 msgstr "रोकने में विफल"
 
@@ -1275,8 +1275,8 @@ msgstr ""
 msgid "Fullscreen"
 msgstr "फ़ुलस्क्रीन"
 
-#: src/pages/Shell.tsx:2135
-#: src/pages/Shell.tsx:2286
+#: src/pages/Shell.tsx:2133
+#: src/pages/Shell.tsx:2285
 msgid "Group"
 msgstr "समूह"
 
@@ -1305,15 +1305,15 @@ msgstr "एक नमूना सुनें"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "नमस्ते, उत्तर पढ़कर सुनाते समय मेरी आवाज़ ऐसी होगी।"
 
-#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4769
 msgid "High"
 msgstr "उच्च"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk"
 msgstr "बोलने के लिए दबाए रखें"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk (on-device dictation)"
 msgstr "बोलने के लिए दबाए रखें (डिवाइस पर ही श्रुतलेखन)"
 
@@ -1333,7 +1333,7 @@ msgstr "कितनी बार"
 msgid "How to check"
 msgstr "जांच कैसे करें"
 
-#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:3852
 msgid "I’m done"
 msgstr "मेरा काम हो गया"
 
@@ -1345,7 +1345,7 @@ msgstr "अगर आपने वह सुना, तो आवाज़ त�
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON इम्पोर्ट करें"
 
-#: src/pages/Shell.tsx:4581
+#: src/pages/Shell.tsx:4656
 msgid "Inherit default"
 msgstr "डिफ़ॉल्ट का पालन करें"
 
@@ -1357,12 +1357,12 @@ msgstr "इनपुट"
 msgid "Instance API key"
 msgstr "इंस्टेंस API कुंजी"
 
-#: src/pages/Shell.tsx:2569
+#: src/pages/Shell.tsx:2568
 msgid "Instruction"
 msgstr "निर्देश"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:1995
 msgid "Integrations"
 msgstr "इंटीग्रेशन"
 
@@ -1383,15 +1383,19 @@ msgid "Interval unit"
 msgstr "अंतराल इकाई"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4657
 msgid "Isolated"
 msgstr "पृथक"
 
-#: src/pages/Shell.tsx:4923
+#: src/pages/Shell.tsx:4998
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "इसकी बातचीत, फ़ाइलें और रूटीन स्थायी रूप से डिलीट कर दिए जाएंगे। इसके बनाए बॉट आपकी सूची में बने रहेंगे।"
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3213
+msgid "Jump to latest"
+msgstr ""
+
+#: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"
 msgstr "जिस संदेश का उत्तर दिया गया उस पर जाएं"
 
@@ -1399,7 +1403,7 @@ msgstr "जिस संदेश का उत्तर दिया गया 
 msgid "just now"
 msgstr "अभी-अभी"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5016
 msgid "Keep memories"
 msgstr "मेमोरी रखें"
 
@@ -1417,7 +1421,7 @@ msgstr "भाषा"
 msgid "Listening…"
 msgstr "सुना जा रहा है…"
 
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Load earlier messages"
 msgstr "पुराने संदेश लोड करें"
 
@@ -1457,7 +1461,7 @@ msgstr "आवाज़ प्रोवाइडर्स लोड हो र�
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Loading…"
 msgstr "लोड हो रहा है…"
 
@@ -1465,11 +1469,11 @@ msgstr "लोड हो रहा है…"
 msgid "Local"
 msgstr "लोकल"
 
-#: src/pages/Shell.tsx:2083
+#: src/pages/Shell.tsx:2081
 msgid "Log out"
 msgstr "लॉग आउट"
 
-#: src/pages/Shell.tsx:4692
+#: src/pages/Shell.tsx:4767
 msgid "Low"
 msgstr "निम्न"
 
@@ -1485,7 +1489,7 @@ msgstr "पढ़ा हुआ चिह्नित करें"
 msgid "Mark as Unread"
 msgstr "अपठित चिह्नित करें"
 
-#: src/pages/Shell.tsx:4696
+#: src/pages/Shell.tsx:4771
 msgid "Max"
 msgstr "अधिकतम"
 
@@ -1495,7 +1499,7 @@ msgstr "अधिकतम"
 msgid "MCP servers"
 msgstr "MCP सर्वर"
 
-#: src/pages/Shell.tsx:4693
+#: src/pages/Shell.tsx:4768
 msgid "Medium"
 msgstr "मध्यम"
 
@@ -1508,33 +1512,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "सदस्य ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} चुनें)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2041
+#: src/pages/Shell.tsx:2039
 msgid "Memory"
 msgstr "मेमोरी"
 
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:4652
 msgid "Memory scope"
 msgstr "मेमोरी स्कोप"
 
-#: src/pages/Shell.tsx:3577
-#: src/pages/Shell.tsx:3672
+#: src/pages/Shell.tsx:3652
+#: src/pages/Shell.tsx:3747
 msgid "Message"
 msgstr "संदेश"
 
-#: src/pages/Shell.tsx:3573
-#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3648
+#: src/pages/Shell.tsx:3652
 msgid "Message {activeName}"
 msgstr "{activeName} को संदेश भेजें"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Message from {peer}"
 msgstr "{peer} का संदेश"
 
-#: src/pages/Shell.tsx:3574
+#: src/pages/Shell.tsx:3649
 msgid "Message…"
 msgstr "संदेश…"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Messaged {peer}"
 msgstr "{peer} को संदेश भेजा"
 
@@ -1542,7 +1546,7 @@ msgstr "{peer} को संदेश भेजा"
 msgid "Microphone failed"
 msgstr "माइक्रोफ़ोन विफल"
 
-#: src/pages/Shell.tsx:4695
+#: src/pages/Shell.tsx:4770
 msgid "Minimal"
 msgstr "न्यूनतम"
 
@@ -1564,7 +1568,7 @@ msgstr "मिनट"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4608
 msgid "Model"
 msgstr "मॉडल"
 
@@ -1586,7 +1590,7 @@ msgid "Model updated."
 msgstr "मॉडल अपडेट किया गया।"
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2026
 msgid "Models"
 msgstr "मॉडल्स"
 
@@ -1604,7 +1608,7 @@ msgstr "मासिक"
 msgid "Move {0} to section"
 msgstr "{0} को सेक्शन में ले जाएं"
 
-#: src/pages/Shell.tsx:4944
+#: src/pages/Shell.tsx:5019
 msgid "Move them to your shared memory."
 msgstr "उन्हें अपनी साझा मेमोरी में ले जाएं।"
 
@@ -1617,15 +1621,15 @@ msgstr "यहां ले जाएं"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2561
-#: src/pages/Shell.tsx:4324
-#: src/pages/Shell.tsx:4492
-#: src/pages/Shell.tsx:4770
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:4399
+#: src/pages/Shell.tsx:4567
+#: src/pages/Shell.tsx:4845
 msgid "Name"
 msgstr "नाम"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4329
+#: src/pages/Shell.tsx:4404
 msgid "Name this bot"
 msgstr "इस बॉट को नाम दें"
 
@@ -1641,13 +1645,13 @@ msgstr "इनपुट चाहिए"
 msgid "Needs takeover"
 msgstr "नियंत्रण लेना ज़रूरी"
 
-#: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4312
+#: src/pages/Shell.tsx:1773
+#: src/pages/Shell.tsx:4387
 msgid "New bot"
 msgstr "नया बॉट"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1785
+#: src/pages/Shell.tsx:1783
 msgid "New group"
 msgstr "नया समूह"
 
@@ -1655,12 +1659,12 @@ msgstr "नया समूह"
 msgid "New open-work item"
 msgstr "नया खुला-कार्य आइटम"
 
-#: src/pages/Shell.tsx:2447
+#: src/pages/Shell.tsx:2446
 msgid "New routine"
 msgstr "नया रूटीन"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4839
 msgid "New section"
 msgstr "नया सेक्शन"
 
@@ -1738,7 +1742,7 @@ msgstr "कनेक्टेड नहीं"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5504
 msgid "Not now"
 msgstr "अभी नहीं"
 
@@ -1776,15 +1780,15 @@ msgstr "1 तारीख को {0} बजे"
 msgid "Open"
 msgstr "खोलें"
 
-#: src/pages/Shell.tsx:2345
+#: src/pages/Shell.tsx:2344
 msgid "Open computer"
 msgstr "कंप्यूटर खोलें"
 
-#: src/pages/Shell.tsx:2315
+#: src/pages/Shell.tsx:2314
 msgid "Open in full window"
 msgstr "पूरी विंडो में खोलें"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2105
 msgid "Open navigation"
 msgstr "नेविगेशन खोलें"
 
@@ -1801,7 +1805,7 @@ msgstr "खुला कार्य"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-संगत सर्वर URL"
 
-#: src/pages/Shell.tsx:4079
+#: src/pages/Shell.tsx:4154
 msgid "Opened its thread."
 msgstr "इसका थ्रेड खोला।"
 
@@ -1888,7 +1892,7 @@ msgstr "प्ले हो रहा है…"
 msgid "Preview {0}"
 msgstr "{0} का प्रीव्यू"
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Private"
 msgstr "निजी"
 
@@ -1909,7 +1913,7 @@ msgstr "कतार में"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo सहेजने से पहले स्रोत की पुष्टि करता है। क्रेडेंशियल एन्क्रिप्टेड होते हैं और कभी क्लाइंट को नहीं लौटाए जाते, न ही मॉडल को दिखाए जाते हैं।"
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4684
 msgid "Read replies aloud"
 msgstr "उत्तर पढ़कर सुनाएं"
 
@@ -1943,7 +1947,7 @@ msgstr "रिकवर एक ऐसे कंप्यूटर को बद�
 msgid "Recovering…"
 msgstr "रिकवर हो रहा है…"
 
-#: src/pages/Shell.tsx:3767
+#: src/pages/Shell.tsx:3842
 msgid "Release"
 msgstr "नियंत्रण छोड़ें"
 
@@ -1956,17 +1960,17 @@ msgid "Remove"
 msgstr "हटाएं"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3381
+#: src/pages/Shell.tsx:3456
 msgid "Remove {0}"
 msgstr "{0} हटाएं"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3536
+#: src/pages/Shell.tsx:3611
 msgid "Remove mention {0}"
 msgstr "उल्लेख {0} हटाएं"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3590
 msgid "Remove skill {0}"
 msgstr "स्किल {0} हटाएं"
 
@@ -1974,7 +1978,7 @@ msgstr "स्किल {0} हटाएं"
 msgid "Remove this schedule"
 msgstr "यह शेड्यूल हटाएं"
 
-#: src/pages/Shell.tsx:4078
+#: src/pages/Shell.tsx:4153
 msgid "Removed with chat, computer, and memory."
 msgstr "चैट, कंप्यूटर और मेमोरी सहित हटाया गया।"
 
@@ -2002,11 +2006,11 @@ msgstr "API कुंजी बदलें"
 msgid "Replace key"
 msgstr "कुंजी बदलें"
 
-#: src/pages/Shell.tsx:3713
+#: src/pages/Shell.tsx:3788
 msgid "Reply"
 msgstr "उत्तर दें"
 
-#: src/pages/Shell.tsx:3344
+#: src/pages/Shell.tsx:3419
 msgid "Replying to {replyName}"
 msgstr "{replyName} को उत्तर दे रहे हैं"
 
@@ -2027,7 +2031,7 @@ msgstr "कंप्यूटर रीसेट करें?"
 msgid "Resetting…"
 msgstr "रीसेट हो रहा है…"
 
-#: src/pages/Shell.tsx:1972
+#: src/pages/Shell.tsx:1970
 msgid "Restore"
 msgstr "बहाल करें"
 
@@ -2047,17 +2051,17 @@ msgstr "Rakazo पर लौटें"
 msgid "Robot"
 msgstr ""
 
-#: src/pages/Shell.tsx:2554
-#: src/pages/Shell.tsx:2607
-#: src/pages/Shell.tsx:2614
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:2613
 msgid "Routine"
 msgstr "रूटीन"
 
-#: src/pages/Shell.tsx:2392
+#: src/pages/Shell.tsx:2391
 msgid "Routines"
 msgstr "रूटीन्स"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Run now"
 msgstr "अभी चलाएं"
 
@@ -2065,11 +2069,11 @@ msgstr "अभी चलाएं"
 msgid "Running"
 msgstr "चल रहा है"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2431
 msgid "Running · Stop"
 msgstr "चल रहा है · रोकें"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Running…"
 msgstr "चल रहा है…"
 
@@ -2077,8 +2081,8 @@ msgstr "चल रहा है…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2653
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:2652
+#: src/pages/Shell.tsx:4739
 msgid "Save"
 msgstr "सहेजें"
 
@@ -2102,7 +2106,7 @@ msgstr "सहेजा गया।"
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:2652
 msgid "Saving…"
 msgstr "सहेजा जा रहा है…"
 
@@ -2116,7 +2120,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "हां या ना कहें, या एक वाक्य में उत्तर दें।"
 
 #: src/pages/ModelSettingsOverlay.tsx:939
-#: src/pages/Shell.tsx:1796
+#: src/pages/Shell.tsx:1794
 msgid "Search"
 msgstr "खोजें"
 
@@ -2143,11 +2147,11 @@ msgstr "प्रोवाइडर्स और मॉडल खोजें"
 msgid "Searching…"
 msgstr "खोजा जा रहा है…"
 
-#: src/pages/Shell.tsx:2136
+#: src/pages/Shell.tsx:2134
 msgid "Select a bot"
 msgstr "एक बॉट चुनें"
 
-#: src/pages/Shell.tsx:3597
+#: src/pages/Shell.tsx:3672
 msgid "Send"
 msgstr "भेजें"
 
@@ -2175,22 +2179,22 @@ msgstr "सर्वर का नाम"
 msgid "Server URL"
 msgstr "सर्वर URL"
 
-#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2143
 msgid "Set up voice to call"
 msgstr "कॉल के लिए आवाज़ सेट करें"
 
 #: src/pages/AccountSettingsOverlay.tsx:100
-#: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2015
-#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2003
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:2281
 msgid "Settings"
 msgstr "सेटिंग्स"
 
-#: src/pages/Shell.tsx:3615
+#: src/pages/Shell.tsx:3690
 msgid "Settings: General"
 msgstr "सेटिंग्स: सामान्य"
 
-#: src/pages/Shell.tsx:3617
+#: src/pages/Shell.tsx:3692
 msgid "Settings: Usage"
 msgstr "सेटिंग्स: उपयोग"
 
@@ -2200,15 +2204,15 @@ msgid "Setup help"
 msgstr "सेटअप सहायता"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4583
+#: src/pages/Shell.tsx:4658
 msgid "Shared"
 msgstr "साझा"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show computer"
 msgstr "कंप्यूटर दिखाएं"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show settings"
 msgstr "सेटिंग्स दिखाएं"
 
@@ -2232,11 +2236,11 @@ msgid "Sign up"
 msgstr "साइन अप करें"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3428
+#: src/pages/Shell.tsx:3503
 msgid "Skill {0}"
 msgstr "स्किल {0}"
 
-#: src/pages/Shell.tsx:3774
+#: src/pages/Shell.tsx:3849
 msgid "Skip"
 msgstr "छोड़ें"
 
@@ -2249,7 +2253,7 @@ msgid "Skip or deploy key"
 msgstr "छोड़ें या डिप्लॉय कुंजी दें"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1320
+#: src/pages/Shell.tsx:1318
 msgid "Skipped {0}"
 msgstr "{0} को छोड़ा गया"
 
@@ -2257,8 +2261,8 @@ msgstr "{0} को छोड़ा गया"
 msgid "Space interrupts · Esc hangs up"
 msgstr "स्पेस से बीच में रोकें · Esc से कॉल समाप्त करें"
 
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Speak"
 msgstr "बोलें"
 
@@ -2270,8 +2274,8 @@ msgstr "बोलें + लिप्यंतरण करें"
 msgid "Speak only"
 msgstr "केवल बोलें"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Speak this reply"
 msgstr "यह उत्तर बोलकर सुनाएं"
 
@@ -2297,20 +2301,20 @@ msgstr "शुरू हो रहा है…"
 msgid "Steps"
 msgstr "चरण"
 
-#: src/pages/Shell.tsx:2943
-#: src/pages/Shell.tsx:2947
-#: src/pages/Shell.tsx:3588
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2946
+#: src/pages/Shell.tsx:3663
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Stop"
 msgstr "रोकें"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Stop dictation"
 msgstr "श्रुतलेखन रोकें"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Stop speaking"
 msgstr "बोलना रोकें"
 
@@ -2319,8 +2323,8 @@ msgstr "बोलना रोकें"
 msgid "Stop teaching"
 msgstr "सिखाना रोकें"
 
-#: src/pages/Shell.tsx:2372
-#: src/pages/Shell.tsx:2963
+#: src/pages/Shell.tsx:2371
+#: src/pages/Shell.tsx:2962
 msgid "Stop the bot first"
 msgstr "पहले बॉट रोकें"
 
@@ -2328,7 +2332,7 @@ msgstr "पहले बॉट रोकें"
 msgid "Stored encrypted"
 msgstr "एन्क्रिप्टेड रूप में संग्रहीत"
 
-#: src/pages/Shell.tsx:4030
+#: src/pages/Shell.tsx:4105
 msgid "subagent"
 msgstr "सबएजेंट"
 
@@ -2341,8 +2345,8 @@ msgstr "सबमिट करें"
 msgid "Switching…"
 msgstr "बदला जा रहा है…"
 
-#: src/pages/Shell.tsx:2375
-#: src/pages/Shell.tsx:2968
+#: src/pages/Shell.tsx:2374
+#: src/pages/Shell.tsx:2967
 msgid "Take control"
 msgstr "नियंत्रण लें"
 
@@ -2350,7 +2354,7 @@ msgstr "नियंत्रण लें"
 msgid "Teach a task"
 msgstr "कोई कार्य सिखाएं"
 
-#: src/pages/Shell.tsx:2208
+#: src/pages/Shell.tsx:2207
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "सिखाना जारी है — नया संदेश भेजने से पहले सिखाना रोकें।"
 
@@ -2358,11 +2362,11 @@ msgstr "सिखाना जारी है — नया संदेश भ
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "सिखाने के लिए ग्राफ़िकल सैंडबॉक्स कंप्यूटर चाहिए। डेस्कटॉप-होस्ट बॉट शेल कार्य चला सकते हैं, लेकिन स्क्रीन रिकॉर्डिंग नहीं।"
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Team"
 msgstr "टीम"
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "Team Computer"
 msgstr "टीम कंप्यूटर"
 
@@ -2375,20 +2379,20 @@ msgstr "टेस्ट करें"
 msgid "The selected memory provider is not available in this build."
 msgstr "चयनित मेमोरी प्रोवाइडर इस बिल्ड में उपलब्ध नहीं है।"
 
-#: src/pages/Shell.tsx:4560
+#: src/pages/Shell.tsx:4635
 msgid "Thinking"
 msgstr "सोच रहा है"
 
-#: src/pages/Shell.tsx:2319
+#: src/pages/Shell.tsx:2318
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "यह बॉट इसी कंप्यूटर पर चलता है, किसी Linux डेस्कटॉप पर नहीं। शेल और फ़ाइलें आपके होम फ़ोल्डर का उपयोग करती हैं।"
 
-#: src/pages/Shell.tsx:2992
+#: src/pages/Shell.tsx:2991
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "यह बॉट इसी कंप्यूटर पर चलता है। कोई अलग Linux डेस्कटॉप नहीं है। इससे शेल का उपयोग करने को कहें; आपके होम फ़ोल्डर के अंदर की वर्किंग डायरेक्ट्री की अनुमति है।"
 
-#: src/pages/Shell.tsx:4960
-#: src/pages/Shell.tsx:5037
+#: src/pages/Shell.tsx:5035
+#: src/pages/Shell.tsx:5112
 msgid "This cannot be undone."
 msgstr "इसे पूर्ववत नहीं किया जा सकता।"
 
@@ -2412,7 +2416,7 @@ msgstr "यह Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "यह Mac आपके खाते से शेल कमांड चलाता है, जिसमें आपके होम फ़ोल्डर की फ़ाइलें भी शामिल हैं। इसे किसी साझा या सार्वजनिक सर्वर पर चालू न करें।"
 
-#: src/pages/Shell.tsx:4845
+#: src/pages/Shell.tsx:4920
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "यह हर संदेश को स्थायी रूप से हटा देता है और मौजूदा काम रोक देता है। बॉट, कंप्यूटर, मेमोरी और रूटीन सुरक्षित रहते हैं।"
 
@@ -2420,7 +2424,7 @@ msgstr "यह हर संदेश को स्थायी रूप से
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "यह प्रोवाइडर यहां कुंजी पेस्ट नहीं कर सकता। यदि इस डिप्लॉयमेंट में पहले से क्रेडेंशियल हैं तो छोड़ दें।"
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5452
 msgid "This server cannot be assigned without a bot."
 msgstr "बॉट के बिना यह सर्वर असाइन नहीं किया जा सकता।"
 
@@ -2432,7 +2436,7 @@ msgstr "इस सर्वर ने ब्राउज़र ऑथराइ�
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "यह सर्वर पहले से कनेक्टेड है। पुनः ऑथराइज़ करने के लिए पहले इसे डिस्कनेक्ट करें।"
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5491
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "यह सर्वर ब्राउज़र साइन-इन का उपयोग करता है। अपने एजेंट को इसके टूल उपयोग करने देने के लिए इसे ऑथराइज़ करें — एक पॉपअप खुलेगा।"
 
@@ -2445,8 +2449,8 @@ msgid "Time of day"
 msgstr "दिन का समय"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4409
+#: src/pages/Shell.tsx:4576
 msgid "Title"
 msgstr "शीर्षक"
 
@@ -2471,7 +2475,7 @@ msgid "Unpin"
 msgstr "पिन हटाएं"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1384
+#: src/pages/Shell.tsx:1382
 msgid "Unsupported file type: {0}"
 msgstr "असमर्थित फ़ाइल प्रकार: {0}"
 
@@ -2484,7 +2488,7 @@ msgid "Updating…"
 msgstr "अपडेट हो रहा है…"
 
 #: src/pages/AccountSettingsOverlay.tsx:176
-#: src/pages/Shell.tsx:2066
+#: src/pages/Shell.tsx:2064
 msgid "Usage"
 msgstr "उपयोग"
 
@@ -2509,8 +2513,8 @@ msgstr "पुष्टि करके जोड़ें"
 msgid "Verifying…"
 msgstr "पुष्टि की जा रही है…"
 
-#: src/pages/Shell.tsx:2054
-#: src/pages/Shell.tsx:4613
+#: src/pages/Shell.tsx:2052
+#: src/pages/Shell.tsx:4688
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2523,7 +2527,7 @@ msgstr "आवाज़"
 msgid "Waiting for sign-in…"
 msgstr "साइन-इन की प्रतीक्षा…"
 
-#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5335
 msgid "Waiting…"
 msgstr "प्रतीक्षा…"
 
@@ -2532,7 +2536,7 @@ msgstr "प्रतीक्षा…"
 msgid "Weekdays"
 msgstr "कार्यदिवस"
 
-#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:5005
 msgid "What about its memories?"
 msgstr "इसकी मेमोरी का क्या करें?"
 
@@ -2541,7 +2545,7 @@ msgid "What result will you demonstrate?"
 msgstr "आप कौन-सा परिणाम दिखाकर बताएंगे?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4349
+#: src/pages/Shell.tsx:4424
 msgid "What this bot is for"
 msgstr "यह बॉट किस लिए है"
 
@@ -2553,7 +2557,7 @@ msgstr "क्या लौटाना है"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "जब {botName} किसी दूसरे बॉट को संदेश भेजता है, तो वह आदान-प्रदान चैट के बजाय यहां दिखता है।"
 
-#: src/pages/Shell.tsx:2578
+#: src/pages/Shell.tsx:2577
 msgid "When to run"
 msgstr "कब चलाएं"
 
@@ -2570,12 +2574,12 @@ msgstr "बॉट कहां चलने चाहिए?"
 msgid "Working…"
 msgstr "काम चल रहा है…"
 
-#: src/pages/Shell.tsx:4543
+#: src/pages/Shell.tsx:4618
 msgid "Workspace default"
 msgstr "वर्कस्पेस डिफ़ॉल्ट"
 
-#: src/pages/Shell.tsx:1115
-#: src/pages/Shell.tsx:1706
+#: src/pages/Shell.tsx:1113
+#: src/pages/Shell.tsx:1704
 msgid "You"
 msgstr "आप"
 
@@ -2587,8 +2591,8 @@ msgstr "अगर यह अपने आप रीडायरेक्ट न 
 msgid "You can close this window."
 msgstr "आप यह विंडो बंद कर सकते हैं।"
 
-#: src/pages/Shell.tsx:2352
-#: src/pages/Shell.tsx:2933
+#: src/pages/Shell.tsx:2351
+#: src/pages/Shell.tsx:2932
 msgid "You have control"
 msgstr "नियंत्रण आपके पास है"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1862
+#: src/pages/Shell.tsx:1860
 msgid " (unread)"
 msgstr " (읽지 않음)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {모델 #개} other {모델 #개}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1300
+#: src/pages/Shell.tsx:1298
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (첨부 파일 최대 {ATTACHMENT_MAX_COUNT}개)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1304
+#: src/pages/Shell.tsx:1302
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB 초과)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5308
 msgid "{0} connection"
 msgstr "{0} 연결"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2356
+#: src/pages/Shell.tsx:2355
 msgid "{0} is using it"
 msgstr "{0}가 사용 중"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:180
-#: src/pages/Shell.tsx:2071
+#: src/pages/Shell.tsx:2069
 msgid "{0} runs · {1} tokens"
 msgstr "{0}회 실행 · 토큰 {1}개"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {동료 Bot #개} other {동료 Bot #개}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName}은 아직 다른 Bot에게 메시지를 보내지 않았습니다."
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "{botName}’s computer"
 msgstr "{botName}의 컴퓨터"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3475
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "액세스 토큰(선택 사항)"
 msgid "Account"
 msgstr "계정"
 
-#: src/pages/Shell.tsx:4619
+#: src/pages/Shell.tsx:4694
 msgid "Account default"
 msgstr "계정 기본값"
 
@@ -156,8 +156,8 @@ msgstr "현재 모델"
 msgid "Active voice"
 msgstr "현재 목소리"
 
+#: src/pages/Shell.tsx:1739
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:1743
 msgid "Activity"
 msgstr "활동"
 
@@ -221,7 +221,7 @@ msgstr "추가 중…"
 #: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4597
 msgid "Advanced"
 msgstr "고급 설정"
 
@@ -229,7 +229,7 @@ msgstr "고급 설정"
 msgid "Agent access for new servers"
 msgstr "새 서버를 사용할 Bot"
 
-#: src/pages/Shell.tsx:2163
+#: src/pages/Shell.tsx:2161
 msgid "Agent computer"
 msgstr "Agent 컴퓨터"
 
@@ -316,11 +316,11 @@ msgstr "서버를 추가할 때 적용됩니다. 각 서버 카드의 Bot 버튼
 msgid "Approval boundaries"
 msgstr "승인이 필요한 범위"
 
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 msgid "Approve"
 msgstr "승인"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5492
 msgid "Approve this server to let your agent use its tools."
 msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 있습니다."
 
@@ -328,15 +328,15 @@ msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 �
 msgid "Archive"
 msgstr "보관"
 
-#: src/pages/Shell.tsx:4066
+#: src/pages/Shell.tsx:4141
 msgid "archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1944
 msgid "Archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:4077
+#: src/pages/Shell.tsx:4152
 msgid "Archived. Chat, memory, and files kept."
 msgstr "보관되었습니다. 대화, 기억, 파일은 유지됩니다."
 
@@ -375,7 +375,7 @@ msgstr "결제하기 전에 확인"
 msgid "Ask before sending external email"
 msgstr "외부 이메일을 보내기 전에 확인"
 
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2357
 msgid "Asleep"
 msgstr "절전 중"
 
@@ -390,11 +390,11 @@ msgstr "{0}에"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}에"
 
-#: src/pages/Shell.tsx:3471
+#: src/pages/Shell.tsx:3546
 msgid "Attach file"
 msgstr "파일 첨부"
 
-#: src/pages/Shell.tsx:3670
+#: src/pages/Shell.tsx:3745
 msgid "Attachment"
 msgstr "첨부 파일"
 
@@ -407,12 +407,12 @@ msgstr "인증 코드 또는 돌아온 페이지 주소"
 msgid "Authorization expired — reconnect required"
 msgstr "인증이 만료됨 — 다시 연결해야 함"
 
-#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5293
 msgid "Authorization timed out. Please try again."
 msgstr "인증 시간이 만료되었습니다. 다시 시도해 주세요."
 
-#: src/pages/Shell.tsx:5260
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5501
 msgid "Authorize"
 msgstr "인증하기"
 
@@ -428,22 +428,22 @@ msgstr "서버 주소"
 msgid "Bearer token"
 msgstr "Bearer 토큰"
 
-#: src/pages/Shell.tsx:5102
+#: src/pages/Shell.tsx:5177
 msgid "Booting live desktop…"
 msgstr "라이브 데스크톱 시작 중…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2903
+#: src/pages/Shell.tsx:2902
 msgid "Booting up {0}’s computer"
 msgstr "{0}의 컴퓨터를 켜는 중"
 
-#: src/pages/Shell.tsx:3936
-#: src/pages/Shell.tsx:3937
-#: src/pages/Shell.tsx:4070
+#: src/pages/Shell.tsx:4011
+#: src/pages/Shell.tsx:4012
+#: src/pages/Shell.tsx:4145
 msgid "bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:1116
+#: src/pages/Shell.tsx:1114
 msgid "Bot"
 msgstr "봇"
 
@@ -451,11 +451,11 @@ msgstr "봇"
 msgid "Bot messages"
 msgstr "Bot 메시지"
 
-#: src/pages/Shell.tsx:3000
+#: src/pages/Shell.tsx:2999
 msgid "Bot screen"
 msgstr "Bot 화면"
 
-#: src/pages/Shell.tsx:2326
+#: src/pages/Shell.tsx:2325
 msgid "Bot screen preview"
 msgstr "Bot 화면 미리보기"
 
@@ -468,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "사용 중인 서비스의 API 키를 연결하세요. 서비스를 바꿔도 Bot의 읽기·통화 기능은 그대로 유지됩니다."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2145
-#: src/pages/Shell.tsx:2146
+#: src/pages/Shell.tsx:2143
+#: src/pages/Shell.tsx:2144
 msgid "Call"
 msgstr "통화"
 
@@ -481,14 +481,14 @@ msgstr "서버에 연결할 수 없습니다."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4786
-#: src/pages/Shell.tsx:4858
-#: src/pages/Shell.tsx:4973
-#: src/pages/Shell.tsx:5047
+#: src/pages/Shell.tsx:4861
+#: src/pages/Shell.tsx:4933
+#: src/pages/Shell.tsx:5048
+#: src/pages/Shell.tsx:5122
 msgid "Cancel"
 msgstr "취소"
 
-#: src/pages/Shell.tsx:4314
+#: src/pages/Shell.tsx:4389
 msgid "Cancel new bot"
 msgstr "새 Bot 만들기 취소"
 
@@ -496,7 +496,7 @@ msgstr "새 Bot 만들기 취소"
 msgid "Cancel new group"
 msgstr "새 그룹 만들기 취소"
 
-#: src/pages/Shell.tsx:3347
+#: src/pages/Shell.tsx:3422
 msgid "Cancel reply"
 msgstr "답장 취소"
 
@@ -504,16 +504,16 @@ msgstr "답장 취소"
 msgid "Cancelled"
 msgstr "취소됨"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5398
 msgid "Chart failed to render: {error}"
 msgstr "차트를 표시하지 못했습니다: {error}"
 
-#: src/pages/Shell.tsx:3613
+#: src/pages/Shell.tsx:3688
 msgid "Chat Settings"
 msgstr "채팅 설정"
 
-#: src/pages/Shell.tsx:2608
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Check in."
 msgstr "확인해 주세요."
 
@@ -525,21 +525,21 @@ msgstr "먼저 사용할 AI 모델을 선택하세요."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo에서 기본으로 사용할 연결된 모델을 선택하세요."
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clear"
 msgstr "비우기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4839
+#: src/pages/Shell.tsx:4914
 msgid "Clear {0}’s conversation?"
 msgstr "{0}와의 대화 내용을 비울까요?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4674
+#: src/pages/Shell.tsx:4749
 msgid "Clear conversation"
 msgstr "대화 내용 비우기"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clearing…"
 msgstr "비우는 중…"
 
@@ -555,15 +555,15 @@ msgstr "Bot 메뉴 닫기"
 msgid "Close bot messages"
 msgstr "Bot 메시지 닫기"
 
-#: src/pages/Shell.tsx:5508
+#: src/pages/Shell.tsx:5583
 msgid "Close chart"
 msgstr "차트 닫기"
 
-#: src/pages/Shell.tsx:2974
+#: src/pages/Shell.tsx:2973
 msgid "Close computer"
 msgstr "컴퓨터 닫기"
 
-#: src/pages/Shell.tsx:5608
+#: src/pages/Shell.tsx:5683
 msgid "Close image preview"
 msgstr "이미지 미리보기 닫기"
 
@@ -583,11 +583,11 @@ msgstr "기억 설정 닫기"
 msgid "Close model settings"
 msgstr "AI 모델 설정 닫기"
 
-#: src/pages/Shell.tsx:1726
+#: src/pages/Shell.tsx:1724
 msgid "Close navigation"
 msgstr "메뉴 닫기"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2303
 msgid "Close panel"
 msgstr "패널 닫기"
 
@@ -616,24 +616,24 @@ msgstr "실행 명령"
 msgid "Complete"
 msgstr "완료"
 
-#: src/pages/Shell.tsx:4224
-#: src/pages/Shell.tsx:4252
+#: src/pages/Shell.tsx:4299
+#: src/pages/Shell.tsx:4327
 msgid "Computer"
 msgstr "컴퓨터"
 
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5180
 msgid "Computer failed to boot"
 msgstr "컴퓨터를 시작하지 못했습니다"
 
-#: src/pages/Shell.tsx:3022
+#: src/pages/Shell.tsx:3021
 msgid "Computer is asleep"
 msgstr "컴퓨터가 절전 상태입니다"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5179
 msgid "Computer is asleep — take control to wake it"
 msgstr "컴퓨터가 절전 상태입니다 — 제어를 맡아 깨우세요"
 
-#: src/pages/Shell.tsx:5106
+#: src/pages/Shell.tsx:5181
 msgid "Computer is stopped"
 msgstr "컴퓨터가 중지됨"
 
@@ -666,7 +666,7 @@ msgstr "API 키 연결"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI 또는 Cartesia 연결"
 
-#: src/pages/Shell.tsx:5406
+#: src/pages/Shell.tsx:5481
 msgid "Connect MCP server “{name}”"
 msgstr "MCP 서버 ‘{name}’ 연결"
 
@@ -689,12 +689,12 @@ msgstr "Treg 연결"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5257
+#: src/pages/Shell.tsx:5332
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "연결됨"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5511
 msgid "Connected — its tools are available from your next message."
 msgstr "연결되었습니다. 다음 메시지부터 이 도구를 사용할 수 있습니다."
 
@@ -719,7 +719,7 @@ msgstr "{0}에 연결하고 기본 모델로 설정했습니다."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "연결 중…"
@@ -738,7 +738,7 @@ msgstr "계속"
 msgid "Continue with email"
 msgstr "이메일로 계속하기"
 
-#: src/pages/Shell.tsx:3721
+#: src/pages/Shell.tsx:3796
 msgid "Copy"
 msgstr "복사"
 
@@ -750,11 +750,11 @@ msgstr "추가하지 못했습니다."
 msgid "Could not add MCP server"
 msgstr "MCP 서버를 추가하지 못했습니다."
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5468
 msgid "Could not approve this server"
 msgstr "서버를 승인하지 못했습니다."
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5296
 msgid "Could not authorize this app"
 msgstr "앱 인증을 완료하지 못했습니다."
 
@@ -762,7 +762,7 @@ msgstr "앱 인증을 완료하지 못했습니다."
 msgid "Could not change the default model"
 msgstr "기본 모델을 변경하지 못했습니다."
 
-#: src/pages/Shell.tsx:4867
+#: src/pages/Shell.tsx:4942
 msgid "Could not clear conversation"
 msgstr "대화 내용을 비우지 못했습니다."
 
@@ -791,7 +791,7 @@ msgstr "음성 서비스에 연결하지 못했습니다."
 msgid "Could not continue"
 msgstr "계속 진행하지 못했습니다."
 
-#: src/pages/Shell.tsx:4302
+#: src/pages/Shell.tsx:4377
 msgid "Could not create bot"
 msgstr "Bot을 만들지 못했습니다."
 
@@ -799,7 +799,7 @@ msgstr "Bot을 만들지 못했습니다."
 msgid "Could not create group"
 msgstr "그룹을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4758
+#: src/pages/Shell.tsx:4833
 msgid "Could not create section"
 msgstr "섹션을 만들지 못했습니다."
 
@@ -807,7 +807,7 @@ msgstr "섹션을 만들지 못했습니다."
 msgid "Could not create your bot"
 msgstr "Bot을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4982
+#: src/pages/Shell.tsx:5057
 msgid "Could not delete bot"
 msgstr "Bot을 삭제하지 못했습니다."
 
@@ -815,7 +815,7 @@ msgstr "Bot을 삭제하지 못했습니다."
 msgid "Could not delete MCP server"
 msgstr "MCP 서버를 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:5056
+#: src/pages/Shell.tsx:5131
 msgid "Could not delete routine"
 msgstr "자동 실행을 삭제하지 못했습니다."
 
@@ -889,7 +889,7 @@ msgstr "그룹을 삭제하지 못했습니다."
 msgid "Could not remove rule"
 msgstr "확인 규칙을 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:5313
+#: src/pages/Shell.tsx:5388
 msgid "Could not render chart"
 msgstr "차트를 만들지 못했습니다."
 
@@ -897,7 +897,7 @@ msgstr "차트를 만들지 못했습니다."
 msgid "Could not revoke connection"
 msgstr "연결을 해제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4659
+#: src/pages/Shell.tsx:4734
 msgid "Could not save"
 msgstr "저장하지 못했습니다."
 
@@ -909,7 +909,7 @@ msgstr "그룹을 저장하지 못했습니다."
 msgid "Could not save model"
 msgstr "AI 모델을 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:2630
+#: src/pages/Shell.tsx:2629
 msgid "Could not save routine"
 msgstr "자동 실행을 저장하지 못했습니다."
 
@@ -925,7 +925,7 @@ msgstr "선택 내용을 저장하지 못했습니다."
 msgid "Could not save that voice"
 msgstr "목소리를 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:5133
+#: src/pages/Shell.tsx:5208
 msgid "Could not save this choice"
 msgstr "선택 내용을 저장하지 못했습니다."
 
@@ -941,7 +941,7 @@ msgstr "OAuth 인증을 시작하지 못했습니다."
 msgid "Could not submit this answer"
 msgstr "답변을 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:1583
+#: src/pages/Shell.tsx:1581
 msgid "Could not take control"
 msgstr "직접 조작으로 전환하지 못했습니다."
 
@@ -965,14 +965,14 @@ msgstr "기본 기억 범위를 변경하지 못했습니다."
 msgid "Couldn't update avatars"
 msgstr ""
 
-#: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:1759
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Create"
 msgstr "만들기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4842
 msgid "Create a section and move {0} into it."
 msgstr "새 섹션을 만들고 {0}을 옮깁니다."
 
@@ -993,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Rakazo 계정 만들기"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Creating…"
 msgstr "만드는 중…"
 
@@ -1022,7 +1022,7 @@ msgstr "일"
 msgid "days"
 msgstr "일"
 
-#: src/pages/Shell.tsx:4566
+#: src/pages/Shell.tsx:4641
 msgid "Default (medium)"
 msgstr "기본(보통)"
 
@@ -1032,21 +1032,21 @@ msgstr "기본 기억 범위"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1980
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:1978
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Delete"
 msgstr "삭제"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1974
 msgid "Delete {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4920
-#: src/pages/Shell.tsx:5034
+#: src/pages/Shell.tsx:4995
+#: src/pages/Shell.tsx:5109
 msgid "Delete {0}?"
 msgstr "{0}을 삭제할까요?"
 
@@ -1054,21 +1054,21 @@ msgstr "{0}을 삭제할까요?"
 msgid "Delete group"
 msgstr "그룹 삭제"
 
-#: src/pages/Shell.tsx:4957
+#: src/pages/Shell.tsx:5032
 msgid "Delete memories too"
 msgstr "기억도 함께 삭제"
 
-#: src/pages/Shell.tsx:2685
+#: src/pages/Shell.tsx:2684
 msgid "Delete routine"
 msgstr "자동 실행 삭제"
 
-#: src/pages/Shell.tsx:4068
+#: src/pages/Shell.tsx:4143
 msgid "deleted"
 msgstr "삭제됨"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Deleting…"
 msgstr "삭제 중…"
 
@@ -1085,17 +1085,17 @@ msgid "Deployment default"
 msgstr "서버 기본값"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4339
+#: src/pages/Shell.tsx:4414
 msgid "Describe what this bot does"
 msgstr "이 Bot이 하는 일을 짧게 설명하세요"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4344
-#: src/pages/Shell.tsx:4510
+#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4585
 msgid "Description"
 msgstr "설명"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Dictate"
 msgstr "음성 입력"
 
@@ -1108,7 +1108,7 @@ msgstr "연결 해제"
 msgid "Disconnecting…"
 msgstr "연결 해제 중…"
 
-#: src/pages/Shell.tsx:5441
+#: src/pages/Shell.tsx:5516
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "지금은 연결하지 않았습니다. MCP 설정에서 언제든 다시 연결할 수 있습니다."
 
@@ -1156,7 +1156,7 @@ msgstr "작업 기술 초안"
 msgid "Duplicate"
 msgstr "복제"
 
-#: src/pages/Shell.tsx:3881
+#: src/pages/Shell.tsx:3956
 msgid "Earlier message"
 msgstr "이전 메시지"
 
@@ -1212,11 +1212,11 @@ msgstr "매월"
 msgid "Every week"
 msgstr "매주"
 
-#: src/pages/Shell.tsx:5487
+#: src/pages/Shell.tsx:5562
 msgid "Expand"
 msgstr "펼치기"
 
-#: src/pages/Shell.tsx:4671
+#: src/pages/Shell.tsx:4746
 msgid "Export"
 msgstr "내보내기"
 
@@ -1224,7 +1224,7 @@ msgstr "내보내기"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "CRM에서 이번 주 목록을 내려받아 공유 폴더에 넣기"
 
-#: src/pages/Shell.tsx:4691
+#: src/pages/Shell.tsx:4766
 msgid "Extra high"
 msgstr "매우 높음"
 
@@ -1232,14 +1232,14 @@ msgstr "매우 높음"
 msgid "Failed"
 msgstr "실패"
 
+#: src/pages/Shell.tsx:1424
 #: src/pages/Shell.tsx:1426
 #: src/pages/Shell.tsx:1428
-#: src/pages/Shell.tsx:1430
 msgid "Failed to send message"
 msgstr "메시지를 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:1453
-#: src/pages/Shell.tsx:1472
+#: src/pages/Shell.tsx:1451
+#: src/pages/Shell.tsx:1470
 msgid "Failed to stop"
 msgstr "작업을 중지하지 못했습니다."
 
@@ -1275,8 +1275,8 @@ msgstr "무료"
 msgid "Fullscreen"
 msgstr "전체 화면"
 
-#: src/pages/Shell.tsx:2135
-#: src/pages/Shell.tsx:2286
+#: src/pages/Shell.tsx:2133
+#: src/pages/Shell.tsx:2285
 msgid "Group"
 msgstr "그룹"
 
@@ -1305,15 +1305,15 @@ msgstr "샘플 듣기"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "안녕하세요. 답변을 소리 내어 읽을 때 이런 목소리로 들립니다."
 
-#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4769
 msgid "High"
 msgstr "높음"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk"
 msgstr "누르고 말하기"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk (on-device dictation)"
 msgstr "누르고 말하기(기기 내 음성 인식)"
 
@@ -1333,7 +1333,7 @@ msgstr "실행 주기"
 msgid "How to check"
 msgstr "완료 확인 방법"
 
-#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:3852
 msgid "I’m done"
 msgstr "조작 끝내기"
 
@@ -1345,7 +1345,7 @@ msgstr "샘플이 들렸다면 음성 설정이 완료되었습니다."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON 가져오기"
 
-#: src/pages/Shell.tsx:4581
+#: src/pages/Shell.tsx:4656
 msgid "Inherit default"
 msgstr "기본 설정 사용"
 
@@ -1357,12 +1357,12 @@ msgstr "입력값"
 msgid "Instance API key"
 msgstr "인스턴스 API 키"
 
-#: src/pages/Shell.tsx:2569
+#: src/pages/Shell.tsx:2568
 msgid "Instruction"
 msgstr "실행할 내용"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:1995
 msgid "Integrations"
 msgstr "앱·도구 연동"
 
@@ -1383,15 +1383,19 @@ msgid "Interval unit"
 msgstr "간격 단위"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4657
 msgid "Isolated"
 msgstr "이 Bot만 사용"
 
-#: src/pages/Shell.tsx:4923
+#: src/pages/Shell.tsx:4998
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만든 다른 Bot은 목록에 남습니다."
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3213
+msgid "Jump to latest"
+msgstr ""
+
+#: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"
 msgstr "답장한 메시지로 이동"
 
@@ -1399,7 +1403,7 @@ msgstr "답장한 메시지로 이동"
 msgid "just now"
 msgstr "방금"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5016
 msgid "Keep memories"
 msgstr "기억은 유지"
 
@@ -1417,7 +1421,7 @@ msgstr "언어"
 msgid "Listening…"
 msgstr "듣는 중…"
 
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Load earlier messages"
 msgstr "이전 메시지 불러오기"
 
@@ -1457,7 +1461,7 @@ msgstr "음성 서비스를 불러오는 중…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Loading…"
 msgstr "불러오는 중…"
 
@@ -1465,11 +1469,11 @@ msgstr "불러오는 중…"
 msgid "Local"
 msgstr "로컬"
 
-#: src/pages/Shell.tsx:2083
+#: src/pages/Shell.tsx:2081
 msgid "Log out"
 msgstr "로그아웃"
 
-#: src/pages/Shell.tsx:4692
+#: src/pages/Shell.tsx:4767
 msgid "Low"
 msgstr "낮음"
 
@@ -1485,7 +1489,7 @@ msgstr "읽음으로 표시"
 msgid "Mark as Unread"
 msgstr "읽지 않음으로 표시"
 
-#: src/pages/Shell.tsx:4696
+#: src/pages/Shell.tsx:4771
 msgid "Max"
 msgstr "최대"
 
@@ -1495,7 +1499,7 @@ msgstr "최대"
 msgid "MCP servers"
 msgstr "MCP 서버"
 
-#: src/pages/Shell.tsx:4693
+#: src/pages/Shell.tsx:4768
 msgid "Medium"
 msgstr "보통"
 
@@ -1508,33 +1512,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "참여 Bot ({GROUP_MEMBER_MIN}~{GROUP_MEMBER_MAX}개 선택)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2041
+#: src/pages/Shell.tsx:2039
 msgid "Memory"
 msgstr "기억"
 
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:4652
 msgid "Memory scope"
 msgstr "기억 사용 범위"
 
-#: src/pages/Shell.tsx:3577
-#: src/pages/Shell.tsx:3672
+#: src/pages/Shell.tsx:3652
+#: src/pages/Shell.tsx:3747
 msgid "Message"
 msgstr "메시지"
 
-#: src/pages/Shell.tsx:3573
-#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3648
+#: src/pages/Shell.tsx:3652
 msgid "Message {activeName}"
 msgstr "{activeName}에게 메시지 보내기"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Message from {peer}"
 msgstr "{peer}의 메시지"
 
-#: src/pages/Shell.tsx:3574
+#: src/pages/Shell.tsx:3649
 msgid "Message…"
 msgstr "메시지를 입력하세요"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Messaged {peer}"
 msgstr "{peer}에게 메시지 보냄"
 
@@ -1542,7 +1546,7 @@ msgstr "{peer}에게 메시지 보냄"
 msgid "Microphone failed"
 msgstr "마이크를 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4695
+#: src/pages/Shell.tsx:4770
 msgid "Minimal"
 msgstr "최소"
 
@@ -1564,7 +1568,7 @@ msgstr "분"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4608
 msgid "Model"
 msgstr "모델"
 
@@ -1586,7 +1590,7 @@ msgid "Model updated."
 msgstr "모델이 변경되었습니다."
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2026
 msgid "Models"
 msgstr "AI 모델"
 
@@ -1604,7 +1608,7 @@ msgstr "매월"
 msgid "Move {0} to section"
 msgstr "{0} 섹션 이동"
 
-#: src/pages/Shell.tsx:4944
+#: src/pages/Shell.tsx:5019
 msgid "Move them to your shared memory."
 msgstr "공용 기억으로 옮깁니다."
 
@@ -1617,15 +1621,15 @@ msgstr "섹션으로 이동"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2561
-#: src/pages/Shell.tsx:4324
-#: src/pages/Shell.tsx:4492
-#: src/pages/Shell.tsx:4770
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:4399
+#: src/pages/Shell.tsx:4567
+#: src/pages/Shell.tsx:4845
 msgid "Name"
 msgstr "이름"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4329
+#: src/pages/Shell.tsx:4404
 msgid "Name this bot"
 msgstr "Bot 이름"
 
@@ -1641,13 +1645,13 @@ msgstr "입력 필요"
 msgid "Needs takeover"
 msgstr "인수 필요"
 
-#: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4312
+#: src/pages/Shell.tsx:1773
+#: src/pages/Shell.tsx:4387
 msgid "New bot"
 msgstr "새 Bot 만들기"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1785
+#: src/pages/Shell.tsx:1783
 msgid "New group"
 msgstr "새 그룹 만들기"
 
@@ -1655,12 +1659,12 @@ msgstr "새 그룹 만들기"
 msgid "New open-work item"
 msgstr "새 진행 작업"
 
-#: src/pages/Shell.tsx:2447
+#: src/pages/Shell.tsx:2446
 msgid "New routine"
 msgstr "새 자동 실행"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4839
 msgid "New section"
 msgstr "새 섹션"
 
@@ -1738,7 +1742,7 @@ msgstr "연결되지 않음"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5504
 msgid "Not now"
 msgstr "나중에"
 
@@ -1776,15 +1780,15 @@ msgstr "매월 1일 {0}에"
 msgid "Open"
 msgstr "열기"
 
-#: src/pages/Shell.tsx:2345
+#: src/pages/Shell.tsx:2344
 msgid "Open computer"
 msgstr "컴퓨터 열기"
 
-#: src/pages/Shell.tsx:2315
+#: src/pages/Shell.tsx:2314
 msgid "Open in full window"
 msgstr "전체 창으로 열기"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2105
 msgid "Open navigation"
 msgstr "메뉴 열기"
 
@@ -1801,7 +1805,7 @@ msgstr "진행 중인 작업"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 호환 서버 주소"
 
-#: src/pages/Shell.tsx:4079
+#: src/pages/Shell.tsx:4154
 msgid "Opened its thread."
 msgstr "대화가 만들어졌습니다."
 
@@ -1888,7 +1892,7 @@ msgstr "재생 중…"
 msgid "Preview {0}"
 msgstr "{0} 미리보기"
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Private"
 msgstr "Bot 전용"
 
@@ -1909,7 +1913,7 @@ msgstr "대기 중"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo는 저장하기 전에 연결 상태를 확인합니다. 인증 정보는 암호화되며 앱이나 AI 모델에 노출되지 않습니다."
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4684
 msgid "Read replies aloud"
 msgstr "답변을 자동으로 읽기"
 
@@ -1943,7 +1947,7 @@ msgstr ""
 msgid "Recovering…"
 msgstr ""
 
-#: src/pages/Shell.tsx:3767
+#: src/pages/Shell.tsx:3842
 msgid "Release"
 msgstr "제어권 돌려주기"
 
@@ -1956,17 +1960,17 @@ msgid "Remove"
 msgstr "삭제"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3381
+#: src/pages/Shell.tsx:3456
 msgid "Remove {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3536
+#: src/pages/Shell.tsx:3611
 msgid "Remove mention {0}"
 msgstr "{0} 멘션 삭제"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3590
 msgid "Remove skill {0}"
 msgstr "작업 기술 {0} 삭제"
 
@@ -1974,7 +1978,7 @@ msgstr "작업 기술 {0} 삭제"
 msgid "Remove this schedule"
 msgstr "이 일정 삭제"
 
-#: src/pages/Shell.tsx:4078
+#: src/pages/Shell.tsx:4153
 msgid "Removed with chat, computer, and memory."
 msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 
@@ -2002,11 +2006,11 @@ msgstr "API 키 교체"
 msgid "Replace key"
 msgstr "키 교체"
 
-#: src/pages/Shell.tsx:3713
+#: src/pages/Shell.tsx:3788
 msgid "Reply"
 msgstr "답장"
 
-#: src/pages/Shell.tsx:3344
+#: src/pages/Shell.tsx:3419
 msgid "Replying to {replyName}"
 msgstr "{replyName}에게 답장"
 
@@ -2027,7 +2031,7 @@ msgstr ""
 msgid "Resetting…"
 msgstr ""
 
-#: src/pages/Shell.tsx:1972
+#: src/pages/Shell.tsx:1970
 msgid "Restore"
 msgstr "복원"
 
@@ -2047,17 +2051,17 @@ msgstr "Rakazo로 돌아가기"
 msgid "Robot"
 msgstr ""
 
-#: src/pages/Shell.tsx:2554
-#: src/pages/Shell.tsx:2607
-#: src/pages/Shell.tsx:2614
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:2613
 msgid "Routine"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2392
+#: src/pages/Shell.tsx:2391
 msgid "Routines"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Run now"
 msgstr "지금 실행"
 
@@ -2065,11 +2069,11 @@ msgstr "지금 실행"
 msgid "Running"
 msgstr "실행 중"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2431
 msgid "Running · Stop"
 msgstr "실행 중 · 중지"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Running…"
 msgstr "실행 중…"
 
@@ -2077,8 +2081,8 @@ msgstr "실행 중…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2653
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:2652
+#: src/pages/Shell.tsx:4739
 msgid "Save"
 msgstr "저장"
 
@@ -2102,7 +2106,7 @@ msgstr "저장되었습니다."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:2652
 msgid "Saving…"
 msgstr "저장 중…"
 
@@ -2116,7 +2120,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "예 또는 아니요로 답하거나 문장으로 답해 주세요."
 
 #: src/pages/ModelSettingsOverlay.tsx:939
-#: src/pages/Shell.tsx:1796
+#: src/pages/Shell.tsx:1794
 msgid "Search"
 msgstr "검색"
 
@@ -2143,11 +2147,11 @@ msgstr "AI 서비스 또는 모델 검색"
 msgid "Searching…"
 msgstr "검색 중…"
 
-#: src/pages/Shell.tsx:2136
+#: src/pages/Shell.tsx:2134
 msgid "Select a bot"
 msgstr "대화할 Bot을 선택하세요"
 
-#: src/pages/Shell.tsx:3597
+#: src/pages/Shell.tsx:3672
 msgid "Send"
 msgstr "보내기"
 
@@ -2175,22 +2179,22 @@ msgstr "서버 이름"
 msgid "Server URL"
 msgstr "서버 URL"
 
-#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2143
 msgid "Set up voice to call"
 msgstr "통화하려면 음성을 먼저 설정하세요"
 
 #: src/pages/AccountSettingsOverlay.tsx:100
-#: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2015
-#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2003
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:2281
 msgid "Settings"
 msgstr "설정"
 
-#: src/pages/Shell.tsx:3615
+#: src/pages/Shell.tsx:3690
 msgid "Settings: General"
 msgstr "설정: 일반"
 
-#: src/pages/Shell.tsx:3617
+#: src/pages/Shell.tsx:3692
 msgid "Settings: Usage"
 msgstr "설정: 사용량"
 
@@ -2200,15 +2204,15 @@ msgid "Setup help"
 msgstr "설정 도움말"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4583
+#: src/pages/Shell.tsx:4658
 msgid "Shared"
 msgstr "함께 사용"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show computer"
 msgstr "컴퓨터 보기"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show settings"
 msgstr "설정 보기"
 
@@ -2232,11 +2236,11 @@ msgid "Sign up"
 msgstr "가입하기"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3428
+#: src/pages/Shell.tsx:3503
 msgid "Skill {0}"
 msgstr "작업 기술 {0}"
 
-#: src/pages/Shell.tsx:3774
+#: src/pages/Shell.tsx:3849
 msgid "Skip"
 msgstr "건너뛰기"
 
@@ -2249,7 +2253,7 @@ msgid "Skip or deploy key"
 msgstr "건너뛰거나 배포 키"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1320
+#: src/pages/Shell.tsx:1318
 msgid "Skipped {0}"
 msgstr "{0} 건너뜀"
 
@@ -2257,8 +2261,8 @@ msgstr "{0} 건너뜀"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space: 끼어들기 · Esc: 통화 종료"
 
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Speak"
 msgstr "읽기"
 
@@ -2270,8 +2274,8 @@ msgstr "음성 출력·받아쓰기"
 msgid "Speak only"
 msgstr "음성 출력만"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Speak this reply"
 msgstr "이 답변 읽기"
 
@@ -2297,20 +2301,20 @@ msgstr "시작하는 중…"
 msgid "Steps"
 msgstr "실행 단계"
 
-#: src/pages/Shell.tsx:2943
-#: src/pages/Shell.tsx:2947
-#: src/pages/Shell.tsx:3588
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2946
+#: src/pages/Shell.tsx:3663
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Stop"
 msgstr "중지"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Stop dictation"
 msgstr "음성 입력 중지"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Stop speaking"
 msgstr "읽기 중지"
 
@@ -2319,8 +2323,8 @@ msgstr "읽기 중지"
 msgid "Stop teaching"
 msgstr "가르치기 종료"
 
-#: src/pages/Shell.tsx:2372
-#: src/pages/Shell.tsx:2963
+#: src/pages/Shell.tsx:2371
+#: src/pages/Shell.tsx:2962
 msgid "Stop the bot first"
 msgstr "먼저 Bot을 중지하세요"
 
@@ -2328,7 +2332,7 @@ msgstr "먼저 Bot을 중지하세요"
 msgid "Stored encrypted"
 msgstr "암호화해 저장"
 
-#: src/pages/Shell.tsx:4030
+#: src/pages/Shell.tsx:4105
 msgid "subagent"
 msgstr "보조 에이전트"
 
@@ -2341,8 +2345,8 @@ msgstr "확인"
 msgid "Switching…"
 msgstr "전환 중…"
 
-#: src/pages/Shell.tsx:2375
-#: src/pages/Shell.tsx:2968
+#: src/pages/Shell.tsx:2374
+#: src/pages/Shell.tsx:2967
 msgid "Take control"
 msgstr "직접 조작"
 
@@ -2350,7 +2354,7 @@ msgstr "직접 조작"
 msgid "Teach a task"
 msgstr "작업 가르치기"
 
-#: src/pages/Shell.tsx:2208
+#: src/pages/Shell.tsx:2207
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼저 가르치기를 종료하세요."
 
@@ -2358,11 +2362,11 @@ msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼�
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "작업을 가르치려면 화면이 있는 샌드박스 컴퓨터가 필요합니다. 내 컴퓨터에서 실행되는 Bot은 터미널 작업은 가능하지만 화면 녹화는 할 수 없습니다."
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Team"
 msgstr "팀 공용"
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "Team Computer"
 msgstr "팀 컴퓨터"
 
@@ -2375,20 +2379,20 @@ msgstr "시험 실행"
 msgid "The selected memory provider is not available in this build."
 msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4560
+#: src/pages/Shell.tsx:4635
 msgid "Thinking"
 msgstr "생각 깊이"
 
-#: src/pages/Shell.tsx:2319
+#: src/pages/Shell.tsx:2318
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "이 Bot은 별도 Linux 화면이 아니라 현재 컴퓨터에서 실행됩니다. 터미널과 파일 작업은 홈 폴더를 사용합니다."
 
-#: src/pages/Shell.tsx:2992
+#: src/pages/Shell.tsx:2991
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "이 Bot은 현재 컴퓨터에서 실행되며 별도 Linux 화면은 없습니다. 터미널을 사용하도록 요청할 수 있고 홈 폴더 아래에서 작업합니다."
 
-#: src/pages/Shell.tsx:4960
-#: src/pages/Shell.tsx:5037
+#: src/pages/Shell.tsx:5035
+#: src/pages/Shell.tsx:5112
 msgid "This cannot be undone."
 msgstr "이 작업은 되돌릴 수 없습니다."
 
@@ -2412,7 +2416,7 @@ msgstr "이 Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "이 Mac에서는 홈 폴더의 파일을 포함해 내 계정 권한으로 터미널 명령을 실행합니다. 여러 사람이 쓰거나 공개된 서버에서는 사용하지 마세요."
 
-#: src/pages/Shell.tsx:4845
+#: src/pages/Shell.tsx:4920
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지합니다. Bot, 컴퓨터, 기억, 자동 실행은 그대로 유지됩니다."
 
@@ -2420,7 +2424,7 @@ msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지�
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "이 서비스는 여기에서 API 키를 입력할 수 없습니다. 서버에 이미 인증 정보가 있다면 건너뛰세요."
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5452
 msgid "This server cannot be assigned without a bot."
 msgstr "연결할 Bot이 없어 이 서버를 배정할 수 없습니다."
 
@@ -2432,7 +2436,7 @@ msgstr "이 서버는 브라우저 인증을 요청하지 않았습니다."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "이 서버는 이미 연결되어 있습니다. 다시 인증하려면 먼저 연결을 해제하세요."
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5491
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "이 서버는 브라우저 로그인이 필요합니다. 인증을 누르면 새 창이 열리고, 완료 후 Bot이 도구를 사용할 수 있습니다."
 
@@ -2445,8 +2449,8 @@ msgid "Time of day"
 msgstr "실행 시각"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4409
+#: src/pages/Shell.tsx:4576
 msgid "Title"
 msgstr "역할"
 
@@ -2471,7 +2475,7 @@ msgid "Unpin"
 msgstr "고정 해제"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1384
+#: src/pages/Shell.tsx:1382
 msgid "Unsupported file type: {0}"
 msgstr "지원하지 않는 파일 형식: {0}"
 
@@ -2484,7 +2488,7 @@ msgid "Updating…"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:176
-#: src/pages/Shell.tsx:2066
+#: src/pages/Shell.tsx:2064
 msgid "Usage"
 msgstr "사용량"
 
@@ -2509,8 +2513,8 @@ msgstr "확인 후 추가"
 msgid "Verifying…"
 msgstr "확인 중…"
 
-#: src/pages/Shell.tsx:2054
-#: src/pages/Shell.tsx:4613
+#: src/pages/Shell.tsx:2052
+#: src/pages/Shell.tsx:4688
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2523,7 +2527,7 @@ msgstr "음성"
 msgid "Waiting for sign-in…"
 msgstr "로그인 완료를 기다리는 중…"
 
-#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5335
 msgid "Waiting…"
 msgstr "기다리는 중…"
 
@@ -2532,7 +2536,7 @@ msgstr "기다리는 중…"
 msgid "Weekdays"
 msgstr "주중"
 
-#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:5005
 msgid "What about its memories?"
 msgstr "이 Bot의 기억은 어떻게 할까요?"
 
@@ -2541,7 +2545,7 @@ msgid "What result will you demonstrate?"
 msgstr "어떤 작업을 직접 보여줄까요?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4349
+#: src/pages/Shell.tsx:4424
 msgid "What this bot is for"
 msgstr "이 Bot을 언제, 어떤 일에 사용할지 적어주세요"
 
@@ -2553,7 +2557,7 @@ msgstr "완료 후 전달할 결과"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "{botName}이 다른 Bot에게 메시지를 보내면 대화 대신 여기에 표시됩니다."
 
-#: src/pages/Shell.tsx:2578
+#: src/pages/Shell.tsx:2577
 msgid "When to run"
 msgstr "실행 시간"
 
@@ -2570,12 +2574,12 @@ msgstr "Bot을 어디에서 실행할까요?"
 msgid "Working…"
 msgstr "처리 중…"
 
-#: src/pages/Shell.tsx:4543
+#: src/pages/Shell.tsx:4618
 msgid "Workspace default"
 msgstr "작업공간 기본값"
 
-#: src/pages/Shell.tsx:1115
-#: src/pages/Shell.tsx:1706
+#: src/pages/Shell.tsx:1113
+#: src/pages/Shell.tsx:1704
 msgid "You"
 msgstr "나"
 
@@ -2587,8 +2591,8 @@ msgstr "자동으로 이동하지 않으면 이 탭을 닫아도 됩니다."
 msgid "You can close this window."
 msgstr "이 창을 닫아도 됩니다."
 
-#: src/pages/Shell.tsx:2352
-#: src/pages/Shell.tsx:2933
+#: src/pages/Shell.tsx:2351
+#: src/pages/Shell.tsx:2932
 msgid "You have control"
 msgstr "직접 조작 중"
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/pages/Shell.tsx:1862
+#: src/pages/Shell.tsx:1860
 msgid " (unread)"
 msgstr " (não lido)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# modelo} other {# modelos}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1300
+#: src/pages/Shell.tsx:1298
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (máx. anexos {ATTACHMENT_MAX_COUNT})"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1304
+#: src/pages/Shell.tsx:1302
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (acima de 10 MiB)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5308
 msgid "{0} connection"
 msgstr "Conexão {0}"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2356
+#: src/pages/Shell.tsx:2355
 msgid "{0} is using it"
 msgstr "{0} está usando"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:180
-#: src/pages/Shell.tsx:2071
+#: src/pages/Shell.tsx:2069
 msgid "{0} runs · {1} tokens"
 msgstr "{0} execuções · {1} tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# par} other {# pares}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "O {botName} ainda não enviou mensagens para outro bot."
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "{botName}’s computer"
 msgstr "Computador do {botName}"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3475
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Token de acesso (opcional)"
 msgid "Account"
 msgstr "Conta"
 
-#: src/pages/Shell.tsx:4619
+#: src/pages/Shell.tsx:4694
 msgid "Account default"
 msgstr "Padrão da conta"
 
@@ -156,8 +156,8 @@ msgstr "Modelo ativo"
 msgid "Active voice"
 msgstr "Voz ativa"
 
+#: src/pages/Shell.tsx:1739
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:1743
 msgid "Activity"
 msgstr "Atividade"
 
@@ -221,7 +221,7 @@ msgstr "Adicionando"
 #: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4597
 msgid "Advanced"
 msgstr "Avançado"
 
@@ -229,7 +229,7 @@ msgstr "Avançado"
 msgid "Agent access for new servers"
 msgstr "Acesso de agente para novos servidores"
 
-#: src/pages/Shell.tsx:2163
+#: src/pages/Shell.tsx:2161
 msgid "Agent computer"
 msgstr "Computador do agente"
 
@@ -316,11 +316,11 @@ msgstr "Aplica-se quando você clica em Adicionar servidor. Use os chips do agen
 msgid "Approval boundaries"
 msgstr "Limites de aprovação"
 
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 msgid "Approve"
 msgstr "Aprovar"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5492
 msgid "Approve this server to let your agent use its tools."
 msgstr "Aprove este servidor para permitir que seu agente use suas ferramentas."
 
@@ -328,15 +328,15 @@ msgstr "Aprove este servidor para permitir que seu agente use suas ferramentas."
 msgid "Archive"
 msgstr "Arquivar"
 
-#: src/pages/Shell.tsx:4066
+#: src/pages/Shell.tsx:4141
 msgid "archived"
 msgstr "arquivado"
 
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1944
 msgid "Archived"
 msgstr "Arquivado"
 
-#: src/pages/Shell.tsx:4077
+#: src/pages/Shell.tsx:4152
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Arquivado. Chat, memória e arquivos mantidos."
 
@@ -375,7 +375,7 @@ msgstr "Perguntar antes de comprar"
 msgid "Ask before sending external email"
 msgstr "Perguntar antes de enviar e-mail externo"
 
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2357
 msgid "Asleep"
 msgstr "Dormindo"
 
@@ -390,11 +390,11 @@ msgstr "em {0}"
 msgid "at {timeSelect}"
 msgstr "em {timeSelect}"
 
-#: src/pages/Shell.tsx:3471
+#: src/pages/Shell.tsx:3546
 msgid "Attach file"
 msgstr "Escolher arquivo"
 
-#: src/pages/Shell.tsx:3670
+#: src/pages/Shell.tsx:3745
 msgid "Attachment"
 msgstr "Anexo"
 
@@ -407,12 +407,12 @@ msgstr "Código de autorização ou URL de retorno de chamada"
 msgid "Authorization expired — reconnect required"
 msgstr "Autorização expirada — reconexão necessária"
 
-#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5293
 msgid "Authorization timed out. Please try again."
 msgstr "A autorização expirou. Tente novamente."
 
-#: src/pages/Shell.tsx:5260
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5501
 msgid "Authorize"
 msgstr "Autorizar"
 
@@ -428,22 +428,22 @@ msgstr "URL Base"
 msgid "Bearer token"
 msgstr "Token portador"
 
-#: src/pages/Shell.tsx:5102
+#: src/pages/Shell.tsx:5177
 msgid "Booting live desktop…"
 msgstr "Iniciando a área de trabalho ao vivo..."
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2903
+#: src/pages/Shell.tsx:2902
 msgid "Booting up {0}’s computer"
 msgstr "Inicializando o computador do {0}"
 
-#: src/pages/Shell.tsx:3936
-#: src/pages/Shell.tsx:3937
-#: src/pages/Shell.tsx:4070
+#: src/pages/Shell.tsx:4011
+#: src/pages/Shell.tsx:4012
+#: src/pages/Shell.tsx:4145
 msgid "bot"
 msgstr "bot"
 
-#: src/pages/Shell.tsx:1116
+#: src/pages/Shell.tsx:1114
 msgid "Bot"
 msgstr "Bot"
 
@@ -451,11 +451,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Mensagens de bot"
 
-#: src/pages/Shell.tsx:3000
+#: src/pages/Shell.tsx:2999
 msgid "Bot screen"
 msgstr "Tela do bot"
 
-#: src/pages/Shell.tsx:2326
+#: src/pages/Shell.tsx:2325
 msgid "Bot screen preview"
 msgstr "Pré-visualização da tela"
 
@@ -468,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Traga sua própria chave. O provedor pode ser trocado; seus bots mantêm os mesmos botões de fala e chamada."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2145
-#: src/pages/Shell.tsx:2146
+#: src/pages/Shell.tsx:2143
+#: src/pages/Shell.tsx:2144
 msgid "Call"
 msgstr "Ligar"
 
@@ -481,14 +481,14 @@ msgstr "Não é possível acessar o servidor."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4786
-#: src/pages/Shell.tsx:4858
-#: src/pages/Shell.tsx:4973
-#: src/pages/Shell.tsx:5047
+#: src/pages/Shell.tsx:4861
+#: src/pages/Shell.tsx:4933
+#: src/pages/Shell.tsx:5048
+#: src/pages/Shell.tsx:5122
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/pages/Shell.tsx:4314
+#: src/pages/Shell.tsx:4389
 msgid "Cancel new bot"
 msgstr "Cancelar novo bot"
 
@@ -496,7 +496,7 @@ msgstr "Cancelar novo bot"
 msgid "Cancel new group"
 msgstr "Cancelar novo grupo"
 
-#: src/pages/Shell.tsx:3347
+#: src/pages/Shell.tsx:3422
 msgid "Cancel reply"
 msgstr "cancelar resposta"
 
@@ -504,16 +504,16 @@ msgstr "cancelar resposta"
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5398
 msgid "Chart failed to render: {error}"
 msgstr "Falha na renderização do gráfico: {error}"
 
-#: src/pages/Shell.tsx:3613
+#: src/pages/Shell.tsx:3688
 msgid "Chat Settings"
 msgstr "Configurações do chat"
 
-#: src/pages/Shell.tsx:2608
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Check in."
 msgstr "Acompanhamento"
 
@@ -525,21 +525,21 @@ msgstr "Escolha um modelo para começar."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Escolha qual modelo conectado a Rakazo usa."
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clear"
 msgstr "Limpar"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4839
+#: src/pages/Shell.tsx:4914
 msgid "Clear {0}’s conversation?"
 msgstr "Limpar a conversa do {0}?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4674
+#: src/pages/Shell.tsx:4749
 msgid "Clear conversation"
 msgstr "Limpar conversa"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clearing…"
 msgstr "Limpeza"
 
@@ -555,15 +555,15 @@ msgstr "Fechar menu do bot"
 msgid "Close bot messages"
 msgstr "Fechar mensagens do bot"
 
-#: src/pages/Shell.tsx:5508
+#: src/pages/Shell.tsx:5583
 msgid "Close chart"
 msgstr "Fechar gráfico"
 
-#: src/pages/Shell.tsx:2974
+#: src/pages/Shell.tsx:2973
 msgid "Close computer"
 msgstr "Fechar computador"
 
-#: src/pages/Shell.tsx:5608
+#: src/pages/Shell.tsx:5683
 msgid "Close image preview"
 msgstr "Fechar visualização da imagem"
 
@@ -583,11 +583,11 @@ msgstr "Fechar configurações de memória"
 msgid "Close model settings"
 msgstr "Fechar configurações do modelo"
 
-#: src/pages/Shell.tsx:1726
+#: src/pages/Shell.tsx:1724
 msgid "Close navigation"
 msgstr "Fechar navegação"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2303
 msgid "Close panel"
 msgstr "Fechar painel"
 
@@ -616,24 +616,24 @@ msgstr "Comando"
 msgid "Complete"
 msgstr "Concluir"
 
-#: src/pages/Shell.tsx:4224
-#: src/pages/Shell.tsx:4252
+#: src/pages/Shell.tsx:4299
+#: src/pages/Shell.tsx:4327
 msgid "Computer"
 msgstr "Computador"
 
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5180
 msgid "Computer failed to boot"
 msgstr "Falha ao inicializar o computador"
 
-#: src/pages/Shell.tsx:3022
+#: src/pages/Shell.tsx:3021
 msgid "Computer is asleep"
 msgstr "O computador está dormindo"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5179
 msgid "Computer is asleep — take control to wake it"
 msgstr "O computador está adormecido — assuma o controle para despertá-lo"
 
-#: src/pages/Shell.tsx:5106
+#: src/pages/Shell.tsx:5181
 msgid "Computer is stopped"
 msgstr "O computador está parado"
 
@@ -666,7 +666,7 @@ msgstr "Conecte-se com a chave API"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "Conecte ElevenLabs, OpenAI ou Cartesia"
 
-#: src/pages/Shell.tsx:5406
+#: src/pages/Shell.tsx:5481
 msgid "Connect MCP server “{name}”"
 msgstr "Conecte o servidor MCP “{name}”"
 
@@ -689,12 +689,12 @@ msgstr "Conectar Treg"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5257
+#: src/pages/Shell.tsx:5332
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Conectado"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5511
 msgid "Connected — its tools are available from your next message."
 msgstr "Conectado — suas ferramentas estão disponíveis na sua próxima mensagem."
 
@@ -719,7 +719,7 @@ msgstr "Conectado e usando {0}."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Conectando…"
@@ -738,7 +738,7 @@ msgstr "Continuar"
 msgid "Continue with email"
 msgstr "Continuar com e-mail"
 
-#: src/pages/Shell.tsx:3721
+#: src/pages/Shell.tsx:3796
 msgid "Copy"
 msgstr "Copiar"
 
@@ -750,11 +750,11 @@ msgstr "Não foi possível adicionar."
 msgid "Could not add MCP server"
 msgstr "Não foi possível adicionar o servidor MCP"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5468
 msgid "Could not approve this server"
 msgstr "Não foi possível aprovar este servidor"
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5296
 msgid "Could not authorize this app"
 msgstr "Não foi possível autorizar este aplicativo"
 
@@ -762,7 +762,7 @@ msgstr "Não foi possível autorizar este aplicativo"
 msgid "Could not change the default model"
 msgstr "Não foi possível alterar o modelo padrão"
 
-#: src/pages/Shell.tsx:4867
+#: src/pages/Shell.tsx:4942
 msgid "Could not clear conversation"
 msgstr "Não foi possível limpar a conversa"
 
@@ -791,7 +791,7 @@ msgstr "Não foi possível conectar este provedor de voz"
 msgid "Could not continue"
 msgstr "Não foi possível continuar"
 
-#: src/pages/Shell.tsx:4302
+#: src/pages/Shell.tsx:4377
 msgid "Could not create bot"
 msgstr "Não foi possível criar o bot"
 
@@ -799,7 +799,7 @@ msgstr "Não foi possível criar o bot"
 msgid "Could not create group"
 msgstr "Não foi possível criar o grupo"
 
-#: src/pages/Shell.tsx:4758
+#: src/pages/Shell.tsx:4833
 msgid "Could not create section"
 msgstr "Não foi possível criar a seção"
 
@@ -807,7 +807,7 @@ msgstr "Não foi possível criar a seção"
 msgid "Could not create your bot"
 msgstr "Não foi possível criar o seu bot"
 
-#: src/pages/Shell.tsx:4982
+#: src/pages/Shell.tsx:5057
 msgid "Could not delete bot"
 msgstr "Não foi possível apagar"
 
@@ -815,7 +815,7 @@ msgstr "Não foi possível apagar"
 msgid "Could not delete MCP server"
 msgstr "Não foi possível excluir o servidor MCP"
 
-#: src/pages/Shell.tsx:5056
+#: src/pages/Shell.tsx:5131
 msgid "Could not delete routine"
 msgstr "Não foi possível excluir a rotina"
 
@@ -889,7 +889,7 @@ msgstr "Não foi possível remover o grupo"
 msgid "Could not remove rule"
 msgstr "Não foi possível remover."
 
-#: src/pages/Shell.tsx:5313
+#: src/pages/Shell.tsx:5388
 msgid "Could not render chart"
 msgstr "Não foi possível renderizar o gráfico"
 
@@ -897,7 +897,7 @@ msgstr "Não foi possível renderizar o gráfico"
 msgid "Could not revoke connection"
 msgstr "Não foi possível revogar a conexão"
 
-#: src/pages/Shell.tsx:4659
+#: src/pages/Shell.tsx:4734
 msgid "Could not save"
 msgstr "Não foi possível salvar"
 
@@ -909,7 +909,7 @@ msgstr "Não foi possível salvar o grupo"
 msgid "Could not save model"
 msgstr "Não foi possível salvar o modelo"
 
-#: src/pages/Shell.tsx:2630
+#: src/pages/Shell.tsx:2629
 msgid "Could not save routine"
 msgstr "Não foi possível salvar a rotina"
 
@@ -925,7 +925,7 @@ msgstr "Não foi possível salvar essa opção"
 msgid "Could not save that voice"
 msgstr "Não foi possível salvar essa voz"
 
-#: src/pages/Shell.tsx:5133
+#: src/pages/Shell.tsx:5208
 msgid "Could not save this choice"
 msgstr "Não foi possível salvar esta opção"
 
@@ -941,7 +941,7 @@ msgstr "Não foi possível iniciar o OAuth"
 msgid "Could not submit this answer"
 msgstr "Não foi possível enviar esta resposta"
 
-#: src/pages/Shell.tsx:1583
+#: src/pages/Shell.tsx:1581
 msgid "Could not take control"
 msgstr "Não foi possível assumir o controle"
 
@@ -965,14 +965,14 @@ msgstr "Não foi possível atualizar o escopo de memória padrão"
 msgid "Couldn't update avatars"
 msgstr ""
 
-#: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:1759
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Create"
 msgstr "Criar"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4842
 msgid "Create a section and move {0} into it."
 msgstr "Crie uma seção e mova {0} para ela."
 
@@ -993,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Crie o seu Rakazo"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Creating…"
 msgstr "Criando..."
 
@@ -1022,7 +1022,7 @@ msgstr "dia"
 msgid "days"
 msgstr "dias"
 
-#: src/pages/Shell.tsx:4566
+#: src/pages/Shell.tsx:4641
 msgid "Default (medium)"
 msgstr "Padrão (médio)"
 
@@ -1032,21 +1032,21 @@ msgstr "Escopo padrão"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1980
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:1978
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Delete"
 msgstr "Excluir"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1974
 msgid "Delete {0}"
 msgstr "Excluir {0}"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4920
-#: src/pages/Shell.tsx:5034
+#: src/pages/Shell.tsx:4995
+#: src/pages/Shell.tsx:5109
 msgid "Delete {0}?"
 msgstr "Excluir {0}?"
 
@@ -1054,21 +1054,21 @@ msgstr "Excluir {0}?"
 msgid "Delete group"
 msgstr "Excluir o grupo"
 
-#: src/pages/Shell.tsx:4957
+#: src/pages/Shell.tsx:5032
 msgid "Delete memories too"
 msgstr "Excluir memórias também"
 
-#: src/pages/Shell.tsx:2685
+#: src/pages/Shell.tsx:2684
 msgid "Delete routine"
 msgstr "Excluir Rotina"
 
-#: src/pages/Shell.tsx:4068
+#: src/pages/Shell.tsx:4143
 msgid "deleted"
 msgstr "excluído"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Deleting…"
 msgstr "Excluindo…"
 
@@ -1085,17 +1085,17 @@ msgid "Deployment default"
 msgstr "Padrão de implantação"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4339
+#: src/pages/Shell.tsx:4414
 msgid "Describe what this bot does"
 msgstr "Descreva o que este bot faz"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4344
-#: src/pages/Shell.tsx:4510
+#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4585
 msgid "Description"
 msgstr "Descrição"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Dictate"
 msgstr "Ditar"
 
@@ -1108,7 +1108,7 @@ msgstr "Desconectar"
 msgid "Disconnecting…"
 msgstr "Desconectando…"
 
-#: src/pages/Shell.tsx:5441
+#: src/pages/Shell.tsx:5516
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Dispensado — reconecte a qualquer momento a partir das configurações do MCP."
 
@@ -1156,7 +1156,7 @@ msgstr "Habilidade de rascunho"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/pages/Shell.tsx:3881
+#: src/pages/Shell.tsx:3956
 msgid "Earlier message"
 msgstr ""
 
@@ -1212,11 +1212,11 @@ msgstr "A cada mês"
 msgid "Every week"
 msgstr "A cada semana"
 
-#: src/pages/Shell.tsx:5487
+#: src/pages/Shell.tsx:5562
 msgid "Expand"
 msgstr "Expandir"
 
-#: src/pages/Shell.tsx:4671
+#: src/pages/Shell.tsx:4746
 msgid "Export"
 msgstr "Exportar"
 
@@ -1224,7 +1224,7 @@ msgstr "Exportar"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Exporte a lista desta semana do CRM e solte-a na pasta compartilhada"
 
-#: src/pages/Shell.tsx:4691
+#: src/pages/Shell.tsx:4766
 msgid "Extra high"
 msgstr "Extra alta"
 
@@ -1232,14 +1232,14 @@ msgstr "Extra alta"
 msgid "Failed"
 msgstr "Falha"
 
+#: src/pages/Shell.tsx:1424
 #: src/pages/Shell.tsx:1426
 #: src/pages/Shell.tsx:1428
-#: src/pages/Shell.tsx:1430
 msgid "Failed to send message"
 msgstr "Ocorreu um erro ao enviar a mensagem"
 
-#: src/pages/Shell.tsx:1453
-#: src/pages/Shell.tsx:1472
+#: src/pages/Shell.tsx:1451
+#: src/pages/Shell.tsx:1470
 msgid "Failed to stop"
 msgstr "Não foi possível parar"
 
@@ -1275,8 +1275,8 @@ msgstr ""
 msgid "Fullscreen"
 msgstr "Tela Cheia"
 
-#: src/pages/Shell.tsx:2135
-#: src/pages/Shell.tsx:2286
+#: src/pages/Shell.tsx:2133
+#: src/pages/Shell.tsx:2285
 msgid "Group"
 msgstr "Grupo"
 
@@ -1305,15 +1305,15 @@ msgstr "Ouvir uma amostra"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Olá, é assim que vou soar quando ler as respostas em voz alta."
 
-#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4769
 msgid "High"
 msgstr "Alto"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk"
 msgstr "Segure para falar"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk (on-device dictation)"
 msgstr "Segure para falar (ditado no dispositivo)"
 
@@ -1333,7 +1333,7 @@ msgstr "Com que frequência"
 msgid "How to check"
 msgstr "Como verificar"
 
-#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:3852
 msgid "I’m done"
 msgstr "Eu terminei."
 
@@ -1345,7 +1345,7 @@ msgstr "Se você ouviu isso, a voz está pronta."
 msgid "Import OpenAPI JSON"
 msgstr "Importar OpenAPI JSON"
 
-#: src/pages/Shell.tsx:4581
+#: src/pages/Shell.tsx:4656
 msgid "Inherit default"
 msgstr "Herdar (padrão)"
 
@@ -1357,12 +1357,12 @@ msgstr "Entradas"
 msgid "Instance API key"
 msgstr "Chave de API da instância"
 
-#: src/pages/Shell.tsx:2569
+#: src/pages/Shell.tsx:2568
 msgid "Instruction"
 msgstr "Instrução"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:1995
 msgid "Integrations"
 msgstr "Integrações"
 
@@ -1383,15 +1383,19 @@ msgid "Interval unit"
 msgstr "Unidade do intervalo:"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4657
 msgid "Isolated"
 msgstr "Isolado"
 
-#: src/pages/Shell.tsx:4923
+#: src/pages/Shell.tsx:4998
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Suas conversas, arquivos e rotinas serão excluídos permanentemente. Os bots criados ficam na sua lista."
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3213
+msgid "Jump to latest"
+msgstr ""
+
+#: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"
 msgstr "Ir para a mensagem respondida"
 
@@ -1399,7 +1403,7 @@ msgstr "Ir para a mensagem respondida"
 msgid "just now"
 msgstr "agora mesmo"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5016
 msgid "Keep memories"
 msgstr "Manter memórias"
 
@@ -1417,7 +1421,7 @@ msgstr "Idioma"
 msgid "Listening…"
 msgstr "Ouvindo..."
 
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Load earlier messages"
 msgstr "Carregar mensagens anteriores..."
 
@@ -1457,7 +1461,7 @@ msgstr "Carregando provedores de voz..."
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Loading…"
 msgstr "Carregando..."
 
@@ -1465,11 +1469,11 @@ msgstr "Carregando..."
 msgid "Local"
 msgstr "Local"
 
-#: src/pages/Shell.tsx:2083
+#: src/pages/Shell.tsx:2081
 msgid "Log out"
 msgstr "Sair"
 
-#: src/pages/Shell.tsx:4692
+#: src/pages/Shell.tsx:4767
 msgid "Low"
 msgstr "Baixo"
 
@@ -1485,7 +1489,7 @@ msgstr "Marcar como Lido"
 msgid "Mark as Unread"
 msgstr "Marcar como Não Lida"
 
-#: src/pages/Shell.tsx:4696
+#: src/pages/Shell.tsx:4771
 msgid "Max"
 msgstr "Máximo"
 
@@ -1495,7 +1499,7 @@ msgstr "Máximo"
 msgid "MCP servers"
 msgstr "Servidores MCP"
 
-#: src/pages/Shell.tsx:4693
+#: src/pages/Shell.tsx:4768
 msgid "Medium"
 msgstr "Médio"
 
@@ -1508,33 +1512,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Membros (escolha {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2041
+#: src/pages/Shell.tsx:2039
 msgid "Memory"
 msgstr "Memória"
 
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:4652
 msgid "Memory scope"
 msgstr "Escopo de memória"
 
-#: src/pages/Shell.tsx:3577
-#: src/pages/Shell.tsx:3672
+#: src/pages/Shell.tsx:3652
+#: src/pages/Shell.tsx:3747
 msgid "Message"
 msgstr "Mensagem"
 
-#: src/pages/Shell.tsx:3573
-#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3648
+#: src/pages/Shell.tsx:3652
 msgid "Message {activeName}"
 msgstr "Mensagem {activeName}"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Message from {peer}"
 msgstr "Mensagem de {peer}"
 
-#: src/pages/Shell.tsx:3574
+#: src/pages/Shell.tsx:3649
 msgid "Message…"
 msgstr "Mensagem…"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Messaged {peer}"
 msgstr "Enviou mensagem para {peer}"
 
@@ -1542,7 +1546,7 @@ msgstr "Enviou mensagem para {peer}"
 msgid "Microphone failed"
 msgstr "Falha no microfone"
 
-#: src/pages/Shell.tsx:4695
+#: src/pages/Shell.tsx:4770
 msgid "Minimal"
 msgstr "Mínimo"
 
@@ -1564,7 +1568,7 @@ msgstr "minutos"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4608
 msgid "Model"
 msgstr "Modelo"
 
@@ -1586,7 +1590,7 @@ msgid "Model updated."
 msgstr "Modelo Atualizado"
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2026
 msgid "Models"
 msgstr "Modelos"
 
@@ -1604,7 +1608,7 @@ msgstr "Mensalmente"
 msgid "Move {0} to section"
 msgstr "Mover {0} para a seção"
 
-#: src/pages/Shell.tsx:4944
+#: src/pages/Shell.tsx:5019
 msgid "Move them to your shared memory."
 msgstr "Mova-os para a sua memória compartilhada."
 
@@ -1617,15 +1621,15 @@ msgstr "Mover para"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2561
-#: src/pages/Shell.tsx:4324
-#: src/pages/Shell.tsx:4492
-#: src/pages/Shell.tsx:4770
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:4399
+#: src/pages/Shell.tsx:4567
+#: src/pages/Shell.tsx:4845
 msgid "Name"
 msgstr "Nome"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4329
+#: src/pages/Shell.tsx:4404
 msgid "Name this bot"
 msgstr "Nomeie este bot"
 
@@ -1641,13 +1645,13 @@ msgstr "Precisa de entrada"
 msgid "Needs takeover"
 msgstr "Requer assumir o controle"
 
-#: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4312
+#: src/pages/Shell.tsx:1773
+#: src/pages/Shell.tsx:4387
 msgid "New bot"
 msgstr "Novo bot"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1785
+#: src/pages/Shell.tsx:1783
 msgid "New group"
 msgstr "Novo grupo"
 
@@ -1655,12 +1659,12 @@ msgstr "Novo grupo"
 msgid "New open-work item"
 msgstr "Novo item de trabalho aberto"
 
-#: src/pages/Shell.tsx:2447
+#: src/pages/Shell.tsx:2446
 msgid "New routine"
 msgstr "Nova rotina"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4839
 msgid "New section"
 msgstr "Nova seção"
 
@@ -1738,7 +1742,7 @@ msgstr "Não Conectado"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5504
 msgid "Not now"
 msgstr "Agora não"
 
@@ -1776,15 +1780,15 @@ msgstr "no dia 1º às {0}"
 msgid "Open"
 msgstr "Abrir"
 
-#: src/pages/Shell.tsx:2345
+#: src/pages/Shell.tsx:2344
 msgid "Open computer"
 msgstr "Abrir computador"
 
-#: src/pages/Shell.tsx:2315
+#: src/pages/Shell.tsx:2314
 msgid "Open in full window"
 msgstr "Abrir em janela cheia"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2105
 msgid "Open navigation"
 msgstr "Abrir a navegação"
 
@@ -1801,7 +1805,7 @@ msgstr "Trabalho aberto"
 msgid "OpenAI-compatible server URL"
 msgstr "URL do servidor compatível com OpenAI"
 
-#: src/pages/Shell.tsx:4079
+#: src/pages/Shell.tsx:4154
 msgid "Opened its thread."
 msgstr "Abriu a conversa."
 
@@ -1888,7 +1892,7 @@ msgstr "Reproduzindo"
 msgid "Preview {0}"
 msgstr "Pré-visualizar {0}"
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Private"
 msgstr "Privado"
 
@@ -1909,7 +1913,7 @@ msgstr "Na fila"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo verifica a fonte antes de salvá-la. As credenciais são criptografadas e nunca são devolvidas aos clientes ou expostas ao modelo."
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4684
 msgid "Read replies aloud"
 msgstr "Leia as respostas em voz alta"
 
@@ -1943,7 +1947,7 @@ msgstr "Recuperar substitui um computador inacessível e mantém os arquivos no 
 msgid "Recovering…"
 msgstr "Recuperando…"
 
-#: src/pages/Shell.tsx:3767
+#: src/pages/Shell.tsx:3842
 msgid "Release"
 msgstr "Libere"
 
@@ -1956,17 +1960,17 @@ msgid "Remove"
 msgstr "Remover"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3381
+#: src/pages/Shell.tsx:3456
 msgid "Remove {0}"
 msgstr "Remover {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3536
+#: src/pages/Shell.tsx:3611
 msgid "Remove mention {0}"
 msgstr "Remover menção {0}"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3590
 msgid "Remove skill {0}"
 msgstr "Remover habilidade {0}"
 
@@ -1974,7 +1978,7 @@ msgstr "Remover habilidade {0}"
 msgid "Remove this schedule"
 msgstr "Remover esta programação"
 
-#: src/pages/Shell.tsx:4078
+#: src/pages/Shell.tsx:4153
 msgid "Removed with chat, computer, and memory."
 msgstr "Removido com chat, computador e memória."
 
@@ -2002,11 +2006,11 @@ msgstr "Substituir chave de API"
 msgid "Replace key"
 msgstr "Substituir chave"
 
-#: src/pages/Shell.tsx:3713
+#: src/pages/Shell.tsx:3788
 msgid "Reply"
 msgstr "Responder"
 
-#: src/pages/Shell.tsx:3344
+#: src/pages/Shell.tsx:3419
 msgid "Replying to {replyName}"
 msgstr "Respondendo a {replyName}"
 
@@ -2027,7 +2031,7 @@ msgstr "Redefinir o computador?"
 msgid "Resetting…"
 msgstr "Redefinindo…"
 
-#: src/pages/Shell.tsx:1972
+#: src/pages/Shell.tsx:1970
 msgid "Restore"
 msgstr "Restaurar"
 
@@ -2047,17 +2051,17 @@ msgstr "Retorno a Rakazo"
 msgid "Robot"
 msgstr ""
 
-#: src/pages/Shell.tsx:2554
-#: src/pages/Shell.tsx:2607
-#: src/pages/Shell.tsx:2614
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:2613
 msgid "Routine"
 msgstr "Rotina"
 
-#: src/pages/Shell.tsx:2392
+#: src/pages/Shell.tsx:2391
 msgid "Routines"
 msgstr "Rotinas"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Run now"
 msgstr "Executar agora"
 
@@ -2065,11 +2069,11 @@ msgstr "Executar agora"
 msgid "Running"
 msgstr "Em execução"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2431
 msgid "Running · Stop"
 msgstr "Em execução · Parar"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Running…"
 msgstr "Executando..."
 
@@ -2077,8 +2081,8 @@ msgstr "Executando..."
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2653
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:2652
+#: src/pages/Shell.tsx:4739
 msgid "Save"
 msgstr "Salvar"
 
@@ -2102,7 +2106,7 @@ msgstr "Salvo."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:2652
 msgid "Saving…"
 msgstr "Salvando..."
 
@@ -2116,7 +2120,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "Diga sim ou não, ou responda em uma frase."
 
 #: src/pages/ModelSettingsOverlay.tsx:939
-#: src/pages/Shell.tsx:1796
+#: src/pages/Shell.tsx:1794
 msgid "Search"
 msgstr "Pesquisar"
 
@@ -2143,11 +2147,11 @@ msgstr "Pesquisar fornecedores e modelos"
 msgid "Searching…"
 msgstr "Pesquisando…"
 
-#: src/pages/Shell.tsx:2136
+#: src/pages/Shell.tsx:2134
 msgid "Select a bot"
 msgstr "Selecione um bot"
 
-#: src/pages/Shell.tsx:3597
+#: src/pages/Shell.tsx:3672
 msgid "Send"
 msgstr "Enviar"
 
@@ -2175,22 +2179,22 @@ msgstr "Nome do servidor"
 msgid "Server URL"
 msgstr "URL do servidor"
 
-#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2143
 msgid "Set up voice to call"
 msgstr "Configurar voz para ligar"
 
 #: src/pages/AccountSettingsOverlay.tsx:100
-#: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2015
-#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2003
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:2281
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/pages/Shell.tsx:3615
+#: src/pages/Shell.tsx:3690
 msgid "Settings: General"
 msgstr "Opções > Geral"
 
-#: src/pages/Shell.tsx:3617
+#: src/pages/Shell.tsx:3692
 msgid "Settings: Usage"
 msgstr "Configurações: Uso"
 
@@ -2200,15 +2204,15 @@ msgid "Setup help"
 msgstr "Ajuda"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4583
+#: src/pages/Shell.tsx:4658
 msgid "Shared"
 msgstr "Compartilhado"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show computer"
 msgstr "Mostrar computador"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show settings"
 msgstr "Mostrar configurações"
 
@@ -2232,11 +2236,11 @@ msgid "Sign up"
 msgstr "Cadastre-se"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3428
+#: src/pages/Shell.tsx:3503
 msgid "Skill {0}"
 msgstr "Habilidade {0}"
 
-#: src/pages/Shell.tsx:3774
+#: src/pages/Shell.tsx:3849
 msgid "Skip"
 msgstr "Pular"
 
@@ -2249,7 +2253,7 @@ msgid "Skip or deploy key"
 msgstr "Ignorar ou implantar chave"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1320
+#: src/pages/Shell.tsx:1318
 msgid "Skipped {0}"
 msgstr "{0} ignorado"
 
@@ -2257,8 +2261,8 @@ msgstr "{0} ignorado"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Interrupções de espaço · Esc desliga"
 
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Speak"
 msgstr "Falar"
 
@@ -2270,8 +2274,8 @@ msgstr "Falar + transcrever"
 msgid "Speak only"
 msgstr "Falar apenas"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Speak this reply"
 msgstr "Fale esta resposta"
 
@@ -2297,20 +2301,20 @@ msgstr "Iniciando…"
 msgid "Steps"
 msgstr "Passos"
 
-#: src/pages/Shell.tsx:2943
-#: src/pages/Shell.tsx:2947
-#: src/pages/Shell.tsx:3588
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2946
+#: src/pages/Shell.tsx:3663
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Stop"
 msgstr "Parar"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Stop dictation"
 msgstr "Parar ditado"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Stop speaking"
 msgstr "Pare de Falar"
 
@@ -2319,8 +2323,8 @@ msgstr "Pare de Falar"
 msgid "Stop teaching"
 msgstr "Parar de ensinar"
 
-#: src/pages/Shell.tsx:2372
-#: src/pages/Shell.tsx:2963
+#: src/pages/Shell.tsx:2371
+#: src/pages/Shell.tsx:2962
 msgid "Stop the bot first"
 msgstr "Pare o bot primeiro"
 
@@ -2328,7 +2332,7 @@ msgstr "Pare o bot primeiro"
 msgid "Stored encrypted"
 msgstr "Armazenado criptografado"
 
-#: src/pages/Shell.tsx:4030
+#: src/pages/Shell.tsx:4105
 msgid "subagent"
 msgstr "subagente"
 
@@ -2341,8 +2345,8 @@ msgstr "Enviar"
 msgid "Switching…"
 msgstr "Alternando…"
 
-#: src/pages/Shell.tsx:2375
-#: src/pages/Shell.tsx:2968
+#: src/pages/Shell.tsx:2374
+#: src/pages/Shell.tsx:2967
 msgid "Take control"
 msgstr "Assumir o controle"
 
@@ -2350,7 +2354,7 @@ msgstr "Assumir o controle"
 msgid "Teach a task"
 msgstr "Ensinar uma tarefa"
 
-#: src/pages/Shell.tsx:2208
+#: src/pages/Shell.tsx:2207
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Ensino em andamento — pare de ensinar antes de enviar uma nova mensagem."
 
@@ -2358,11 +2362,11 @@ msgstr "Ensino em andamento — pare de ensinar antes de enviar uma nova mensage
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "O ensino precisa de um computador sandbox gráfico. Os bots de host de desktop podem executar tarefas de shell, mas não a gravação de tela."
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Team"
 msgstr "Equipe"
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "Team Computer"
 msgstr "Computador da equipe"
 
@@ -2375,20 +2379,20 @@ msgstr "Teste"
 msgid "The selected memory provider is not available in this build."
 msgstr "O provedor de memória selecionado não está disponível nesta compilação."
 
-#: src/pages/Shell.tsx:4560
+#: src/pages/Shell.tsx:4635
 msgid "Thinking"
 msgstr "Pensando"
 
-#: src/pages/Shell.tsx:2319
+#: src/pages/Shell.tsx:2318
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Este bot é executado neste computador, não em um desktop Linux. Shell e arquivos usam sua pasta inicial."
 
-#: src/pages/Shell.tsx:2992
+#: src/pages/Shell.tsx:2991
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Este bot é executado neste computador. Não há uma área de trabalho Linux separada. Peça-lhe para usar o shell; diretórios de trabalho na sua pasta pessoal são permitidos."
 
-#: src/pages/Shell.tsx:4960
-#: src/pages/Shell.tsx:5037
+#: src/pages/Shell.tsx:5035
+#: src/pages/Shell.tsx:5112
 msgid "This cannot be undone."
 msgstr "Essa ação não pode ser desfeita."
 
@@ -2412,7 +2416,7 @@ msgstr "esse Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Este Mac executa comandos do shell com sua conta, incluindo arquivos em sua pasta inicial. Não o ligue para um servidor compartilhado ou público."
 
-#: src/pages/Shell.tsx:4845
+#: src/pages/Shell.tsx:4920
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Isso remove permanentemente todas as mensagens e interrompe o trabalho atual. O bot, o computador, a memória e as rotinas são mantidos."
 
@@ -2420,7 +2424,7 @@ msgstr "Isso remove permanentemente todas as mensagens e interrompe o trabalho a
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Este provedor não pode colar uma chave aqui. Ignore se esta implantação já tiver credenciais."
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5452
 msgid "This server cannot be assigned without a bot."
 msgstr "Este servidor não pode ser atribuído sem um bot."
 
@@ -2432,7 +2436,7 @@ msgstr "Este servidor não solicitou autorização do navegador."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Este servidor já está conectado. Desconecte-o primeiro para autorizar novamente."
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5491
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Este servidor usa o login do navegador. Autorize-o a permitir que seus agentes usem suas ferramentas — um pop-up será aberto."
 
@@ -2445,8 +2449,8 @@ msgid "Time of day"
 msgstr "Hora do dia"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4409
+#: src/pages/Shell.tsx:4576
 msgid "Title"
 msgstr "Título"
 
@@ -2471,7 +2475,7 @@ msgid "Unpin"
 msgstr "Desafixar"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1384
+#: src/pages/Shell.tsx:1382
 msgid "Unsupported file type: {0}"
 msgstr "Tipo de arquivo não suportado: {0}"
 
@@ -2484,7 +2488,7 @@ msgid "Updating…"
 msgstr "Atualizando…"
 
 #: src/pages/AccountSettingsOverlay.tsx:176
-#: src/pages/Shell.tsx:2066
+#: src/pages/Shell.tsx:2064
 msgid "Usage"
 msgstr "Uso"
 
@@ -2509,8 +2513,8 @@ msgstr "Verificar e adicionar"
 msgid "Verifying…"
 msgstr "Verificando…"
 
-#: src/pages/Shell.tsx:2054
-#: src/pages/Shell.tsx:4613
+#: src/pages/Shell.tsx:2052
+#: src/pages/Shell.tsx:4688
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2523,7 +2527,7 @@ msgstr "Voz"
 msgid "Waiting for sign-in…"
 msgstr "Aguardando login..."
 
-#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5335
 msgid "Waiting…"
 msgstr "Aguardando…"
 
@@ -2532,7 +2536,7 @@ msgstr "Aguardando…"
 msgid "Weekdays"
 msgstr "Dias da semana"
 
-#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:5005
 msgid "What about its memories?"
 msgstr "E suas memórias?"
 
@@ -2541,7 +2545,7 @@ msgid "What result will you demonstrate?"
 msgstr "Que resultado você demonstrará?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4349
+#: src/pages/Shell.tsx:4424
 msgid "What this bot is for"
 msgstr "Para que serve este bot"
 
@@ -2553,7 +2557,7 @@ msgstr "O que devolver"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "Quando o {botName} envia mensagens para outro bot, a conversa aparece aqui em vez de no chat."
 
-#: src/pages/Shell.tsx:2578
+#: src/pages/Shell.tsx:2577
 msgid "When to run"
 msgstr "Quando executar"
 
@@ -2570,12 +2574,12 @@ msgstr "Onde os bots devem ser executados?"
 msgid "Working…"
 msgstr "Funcionando"
 
-#: src/pages/Shell.tsx:4543
+#: src/pages/Shell.tsx:4618
 msgid "Workspace default"
 msgstr "Padrão do espaço de trabalho"
 
-#: src/pages/Shell.tsx:1115
-#: src/pages/Shell.tsx:1706
+#: src/pages/Shell.tsx:1113
+#: src/pages/Shell.tsx:1704
 msgid "You"
 msgstr "Você"
 
@@ -2587,8 +2591,8 @@ msgstr "Você pode fechar esta guia se ela não for redirecionada automaticament
 msgid "You can close this window."
 msgstr "Você pode fechar esta janela."
 
-#: src/pages/Shell.tsx:2352
-#: src/pages/Shell.tsx:2933
+#: src/pages/Shell.tsx:2351
+#: src/pages/Shell.tsx:2932
 msgid "You have control"
 msgstr "Você tem o controle"
 

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1862
+#: src/pages/Shell.tsx:1860
 msgid " (unread)"
 msgstr " (okunmadı)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# model} other {# model}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1300
+#: src/pages/Shell.tsx:1298
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (en fazla {ATTACHMENT_MAX_COUNT} ek)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1304
+#: src/pages/Shell.tsx:1302
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB üzeri)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5308
 msgid "{0} connection"
 msgstr "{0} bağlantısı"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2356
+#: src/pages/Shell.tsx:2355
 msgid "{0} is using it"
 msgstr "{0} bunu kullanıyor"
 
@@ -68,7 +68,7 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:180
-#: src/pages/Shell.tsx:2071
+#: src/pages/Shell.tsx:2069
 msgid "{0} runs · {1} tokens"
 msgstr "{0} çalıştırma · {1} token"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# eş bot} other {# eş bot}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} henüz başka bir bota mesaj göndermedi."
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "{botName}’s computer"
 msgstr "{botName} adlı botun bilgisayarı"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3400
+#: src/pages/Shell.tsx:3475
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -131,7 +131,7 @@ msgstr "Erişim token'ı (isteğe bağlı)"
 msgid "Account"
 msgstr "Hesap"
 
-#: src/pages/Shell.tsx:4619
+#: src/pages/Shell.tsx:4694
 msgid "Account default"
 msgstr "Hesap varsayılanı"
 
@@ -156,8 +156,8 @@ msgstr "Etkin model"
 msgid "Active voice"
 msgstr "Etkin ses"
 
+#: src/pages/Shell.tsx:1739
 #: src/pages/Shell.tsx:1741
-#: src/pages/Shell.tsx:1743
 msgid "Activity"
 msgstr "Etkinlik"
 
@@ -221,7 +221,7 @@ msgstr "Ekleniyor…"
 #: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4522
+#: src/pages/Shell.tsx:4597
 msgid "Advanced"
 msgstr "Gelişmiş"
 
@@ -229,7 +229,7 @@ msgstr "Gelişmiş"
 msgid "Agent access for new servers"
 msgstr "Yeni sunucular için agent erişimi"
 
-#: src/pages/Shell.tsx:2163
+#: src/pages/Shell.tsx:2161
 msgid "Agent computer"
 msgstr "Agent bilgisayarı"
 
@@ -316,11 +316,11 @@ msgstr "Sunucu ekle'ye tıkladığında uygulanır. Erişimi istediğin zaman de
 msgid "Approval boundaries"
 msgstr "Onay sınırları"
 
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 msgid "Approve"
 msgstr "Onayla"
 
-#: src/pages/Shell.tsx:5417
+#: src/pages/Shell.tsx:5492
 msgid "Approve this server to let your agent use its tools."
 msgstr "Agent'ının bu sunucunun araçlarını kullanabilmesi için sunucuyu onayla."
 
@@ -328,15 +328,15 @@ msgstr "Agent'ının bu sunucunun araçlarını kullanabilmesi için sunucuyu on
 msgid "Archive"
 msgstr "Arşivle"
 
-#: src/pages/Shell.tsx:4066
+#: src/pages/Shell.tsx:4141
 msgid "archived"
 msgstr "arşivlendi"
 
-#: src/pages/Shell.tsx:1946
+#: src/pages/Shell.tsx:1944
 msgid "Archived"
 msgstr "Arşivlendi"
 
-#: src/pages/Shell.tsx:4077
+#: src/pages/Shell.tsx:4152
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Arşivlendi. Sohbet, hafıza ve dosyalar korundu."
 
@@ -375,7 +375,7 @@ msgstr "Satın almadan önce sor"
 msgid "Ask before sending external email"
 msgstr "Dışarıya e-posta göndermeden önce sor"
 
-#: src/pages/Shell.tsx:2358
+#: src/pages/Shell.tsx:2357
 msgid "Asleep"
 msgstr "Uykuda"
 
@@ -390,11 +390,11 @@ msgstr "saat {0}"
 msgid "at {timeSelect}"
 msgstr "saat {timeSelect}"
 
-#: src/pages/Shell.tsx:3471
+#: src/pages/Shell.tsx:3546
 msgid "Attach file"
 msgstr "Dosya ekle"
 
-#: src/pages/Shell.tsx:3670
+#: src/pages/Shell.tsx:3745
 msgid "Attachment"
 msgstr "Ek"
 
@@ -407,12 +407,12 @@ msgstr "Yetkilendirme kodu veya callback URL'si"
 msgid "Authorization expired — reconnect required"
 msgstr "Yetkilendirme süresi doldu — yeniden bağlanmak gerekiyor"
 
-#: src/pages/Shell.tsx:5218
+#: src/pages/Shell.tsx:5293
 msgid "Authorization timed out. Please try again."
 msgstr "Yetkilendirme zaman aşımına uğradı. Lütfen tekrar dene."
 
-#: src/pages/Shell.tsx:5260
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5335
+#: src/pages/Shell.tsx:5501
 msgid "Authorize"
 msgstr "Yetkilendir"
 
@@ -428,22 +428,22 @@ msgstr "Temel URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5102
+#: src/pages/Shell.tsx:5177
 msgid "Booting live desktop…"
 msgstr "Canlı masaüstü başlatılıyor…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2903
+#: src/pages/Shell.tsx:2902
 msgid "Booting up {0}’s computer"
 msgstr "{0} adlı botun bilgisayarı başlatılıyor"
 
-#: src/pages/Shell.tsx:3936
-#: src/pages/Shell.tsx:3937
-#: src/pages/Shell.tsx:4070
+#: src/pages/Shell.tsx:4011
+#: src/pages/Shell.tsx:4012
+#: src/pages/Shell.tsx:4145
 msgid "bot"
 msgstr "bot"
 
-#: src/pages/Shell.tsx:1116
+#: src/pages/Shell.tsx:1114
 msgid "Bot"
 msgstr "Bot"
 
@@ -451,11 +451,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot mesajları"
 
-#: src/pages/Shell.tsx:3000
+#: src/pages/Shell.tsx:2999
 msgid "Bot screen"
 msgstr "Bot ekranı"
 
-#: src/pages/Shell.tsx:2326
+#: src/pages/Shell.tsx:2325
 msgid "Bot screen preview"
 msgstr "Bot ekranı önizlemesi"
 
@@ -468,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Kendi anahtarını getir. Sağlayıcı değiştirilebilir; botlarındaki seslendirme ve arama düğmeleri aynı kalır."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2145
-#: src/pages/Shell.tsx:2146
+#: src/pages/Shell.tsx:2143
+#: src/pages/Shell.tsx:2144
 msgid "Call"
 msgstr "Ara"
 
@@ -481,14 +481,14 @@ msgstr "Sunucuya ulaşılamıyor."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4786
-#: src/pages/Shell.tsx:4858
-#: src/pages/Shell.tsx:4973
-#: src/pages/Shell.tsx:5047
+#: src/pages/Shell.tsx:4861
+#: src/pages/Shell.tsx:4933
+#: src/pages/Shell.tsx:5048
+#: src/pages/Shell.tsx:5122
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/pages/Shell.tsx:4314
+#: src/pages/Shell.tsx:4389
 msgid "Cancel new bot"
 msgstr "Yeni botu iptal et"
 
@@ -496,7 +496,7 @@ msgstr "Yeni botu iptal et"
 msgid "Cancel new group"
 msgstr "Yeni grubu iptal et"
 
-#: src/pages/Shell.tsx:3347
+#: src/pages/Shell.tsx:3422
 msgid "Cancel reply"
 msgstr "Yanıtı iptal et"
 
@@ -504,16 +504,16 @@ msgstr "Yanıtı iptal et"
 msgid "Cancelled"
 msgstr "İptal edildi"
 
-#: src/pages/Shell.tsx:5323
+#: src/pages/Shell.tsx:5398
 msgid "Chart failed to render: {error}"
 msgstr "Grafik çizilemedi: {error}"
 
-#: src/pages/Shell.tsx:3613
+#: src/pages/Shell.tsx:3688
 msgid "Chat Settings"
 msgstr "Sohbet Ayarları"
 
-#: src/pages/Shell.tsx:2608
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Check in."
 msgstr "Durum bildir."
 
@@ -525,21 +525,21 @@ msgstr "Başlamak için bir model seç."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo'nun hangi bağlı modeli kullanacağını seç."
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clear"
 msgstr "Temizle"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4839
+#: src/pages/Shell.tsx:4914
 msgid "Clear {0}’s conversation?"
 msgstr "{0} sohbeti temizlensin mi?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4674
+#: src/pages/Shell.tsx:4749
 msgid "Clear conversation"
 msgstr "Sohbeti temizle"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4948
 msgid "Clearing…"
 msgstr "Temizleniyor…"
 
@@ -555,15 +555,15 @@ msgstr "Bot menüsünü kapat"
 msgid "Close bot messages"
 msgstr "Bot mesajlarını kapat"
 
-#: src/pages/Shell.tsx:5508
+#: src/pages/Shell.tsx:5583
 msgid "Close chart"
 msgstr "Grafiği kapat"
 
-#: src/pages/Shell.tsx:2974
+#: src/pages/Shell.tsx:2973
 msgid "Close computer"
 msgstr "Bilgisayarı kapat"
 
-#: src/pages/Shell.tsx:5608
+#: src/pages/Shell.tsx:5683
 msgid "Close image preview"
 msgstr "Görsel önizlemesini kapat"
 
@@ -583,11 +583,11 @@ msgstr "Hafıza ayarlarını kapat"
 msgid "Close model settings"
 msgstr "Model ayarlarını kapat"
 
-#: src/pages/Shell.tsx:1726
+#: src/pages/Shell.tsx:1724
 msgid "Close navigation"
 msgstr "Gezinmeyi kapat"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2303
 msgid "Close panel"
 msgstr "Paneli kapat"
 
@@ -616,24 +616,24 @@ msgstr "Komut"
 msgid "Complete"
 msgstr "Tamamlandı"
 
-#: src/pages/Shell.tsx:4224
-#: src/pages/Shell.tsx:4252
+#: src/pages/Shell.tsx:4299
+#: src/pages/Shell.tsx:4327
 msgid "Computer"
 msgstr "Bilgisayar"
 
-#: src/pages/Shell.tsx:5105
+#: src/pages/Shell.tsx:5180
 msgid "Computer failed to boot"
 msgstr "Bilgisayar başlatılamadı"
 
-#: src/pages/Shell.tsx:3022
+#: src/pages/Shell.tsx:3021
 msgid "Computer is asleep"
 msgstr "Bilgisayar uykuda"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5179
 msgid "Computer is asleep — take control to wake it"
 msgstr "Bilgisayar uykuda — uyandırmak için kontrolü al"
 
-#: src/pages/Shell.tsx:5106
+#: src/pages/Shell.tsx:5181
 msgid "Computer is stopped"
 msgstr "Bilgisayar durduruldu"
 
@@ -666,7 +666,7 @@ msgstr "API anahtarıyla bağlan"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI veya Cartesia bağla"
 
-#: src/pages/Shell.tsx:5406
+#: src/pages/Shell.tsx:5481
 msgid "Connect MCP server “{name}”"
 msgstr "“{name}” MCP sunucusunu bağla"
 
@@ -689,12 +689,12 @@ msgstr "Treg'i bağla"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5257
+#: src/pages/Shell.tsx:5332
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Bağlandı"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5511
 msgid "Connected — its tools are available from your next message."
 msgstr "Bağlandı — araçları bir sonraki mesajından itibaren kullanılabilir."
 
@@ -719,7 +719,7 @@ msgstr "Bağlandı, {0} kullanılıyor."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5426
+#: src/pages/Shell.tsx:5501
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Bağlanıyor…"
@@ -738,7 +738,7 @@ msgstr "Devam"
 msgid "Continue with email"
 msgstr "E-posta ile devam et"
 
-#: src/pages/Shell.tsx:3721
+#: src/pages/Shell.tsx:3796
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -750,11 +750,11 @@ msgstr "Eklenemedi"
 msgid "Could not add MCP server"
 msgstr "MCP sunucusu eklenemedi"
 
-#: src/pages/Shell.tsx:5393
+#: src/pages/Shell.tsx:5468
 msgid "Could not approve this server"
 msgstr "Bu sunucu onaylanamadı"
 
-#: src/pages/Shell.tsx:5221
+#: src/pages/Shell.tsx:5296
 msgid "Could not authorize this app"
 msgstr "Bu uygulama yetkilendirilemedi"
 
@@ -762,7 +762,7 @@ msgstr "Bu uygulama yetkilendirilemedi"
 msgid "Could not change the default model"
 msgstr "Varsayılan model değiştirilemedi"
 
-#: src/pages/Shell.tsx:4867
+#: src/pages/Shell.tsx:4942
 msgid "Could not clear conversation"
 msgstr "Sohbet temizlenemedi"
 
@@ -791,7 +791,7 @@ msgstr "Bu ses sağlayıcısı bağlanamadı"
 msgid "Could not continue"
 msgstr "Devam edilemedi"
 
-#: src/pages/Shell.tsx:4302
+#: src/pages/Shell.tsx:4377
 msgid "Could not create bot"
 msgstr "Bot oluşturulamadı"
 
@@ -799,7 +799,7 @@ msgstr "Bot oluşturulamadı"
 msgid "Could not create group"
 msgstr "Grup oluşturulamadı"
 
-#: src/pages/Shell.tsx:4758
+#: src/pages/Shell.tsx:4833
 msgid "Could not create section"
 msgstr "Bölüm oluşturulamadı"
 
@@ -807,7 +807,7 @@ msgstr "Bölüm oluşturulamadı"
 msgid "Could not create your bot"
 msgstr "Botun oluşturulamadı"
 
-#: src/pages/Shell.tsx:4982
+#: src/pages/Shell.tsx:5057
 msgid "Could not delete bot"
 msgstr "Bot silinemedi"
 
@@ -815,7 +815,7 @@ msgstr "Bot silinemedi"
 msgid "Could not delete MCP server"
 msgstr "MCP sunucusu silinemedi"
 
-#: src/pages/Shell.tsx:5056
+#: src/pages/Shell.tsx:5131
 msgid "Could not delete routine"
 msgstr "Rutin silinemedi"
 
@@ -889,7 +889,7 @@ msgstr "Grup kaldırılamadı"
 msgid "Could not remove rule"
 msgstr "Kural kaldırılamadı"
 
-#: src/pages/Shell.tsx:5313
+#: src/pages/Shell.tsx:5388
 msgid "Could not render chart"
 msgstr "Grafik çizilemedi"
 
@@ -897,7 +897,7 @@ msgstr "Grafik çizilemedi"
 msgid "Could not revoke connection"
 msgstr "Bağlantı iptal edilemedi"
 
-#: src/pages/Shell.tsx:4659
+#: src/pages/Shell.tsx:4734
 msgid "Could not save"
 msgstr "Kaydedilemedi"
 
@@ -909,7 +909,7 @@ msgstr "Grup kaydedilemedi"
 msgid "Could not save model"
 msgstr "Model kaydedilemedi"
 
-#: src/pages/Shell.tsx:2630
+#: src/pages/Shell.tsx:2629
 msgid "Could not save routine"
 msgstr "Rutin kaydedilemedi"
 
@@ -925,7 +925,7 @@ msgstr "Bu seçim kaydedilemedi"
 msgid "Could not save that voice"
 msgstr "Bu ses kaydedilemedi"
 
-#: src/pages/Shell.tsx:5133
+#: src/pages/Shell.tsx:5208
 msgid "Could not save this choice"
 msgstr "Bu seçim kaydedilemedi"
 
@@ -941,7 +941,7 @@ msgstr "OAuth başlatılamadı"
 msgid "Could not submit this answer"
 msgstr "Bu yanıt gönderilemedi"
 
-#: src/pages/Shell.tsx:1583
+#: src/pages/Shell.tsx:1581
 msgid "Could not take control"
 msgstr "Kontrol alınamadı"
 
@@ -965,14 +965,14 @@ msgstr "Varsayılan hafıza kapsamı güncellenemedi"
 msgid "Couldn't update avatars"
 msgstr ""
 
-#: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:1759
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Create"
 msgstr "Oluştur"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4767
+#: src/pages/Shell.tsx:4842
 msgid "Create a section and move {0} into it."
 msgstr "Bir bölüm oluştur ve {0} botunu içine taşı."
 
@@ -993,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Rakazo hesabını oluştur"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4361
-#: src/pages/Shell.tsx:4793
+#: src/pages/Shell.tsx:4436
+#: src/pages/Shell.tsx:4868
 msgid "Creating…"
 msgstr "Oluşturuluyor…"
 
@@ -1022,7 +1022,7 @@ msgstr "gün"
 msgid "days"
 msgstr "gün"
 
-#: src/pages/Shell.tsx:4566
+#: src/pages/Shell.tsx:4641
 msgid "Default (medium)"
 msgstr "Varsayılan (orta)"
 
@@ -1032,21 +1032,21 @@ msgstr "Varsayılan kapsam"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1980
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:1978
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Delete"
 msgstr "Sil"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1974
 msgid "Delete {0}"
 msgstr "{0} sil"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4920
-#: src/pages/Shell.tsx:5034
+#: src/pages/Shell.tsx:4995
+#: src/pages/Shell.tsx:5109
 msgid "Delete {0}?"
 msgstr "{0} silinsin mi?"
 
@@ -1054,21 +1054,21 @@ msgstr "{0} silinsin mi?"
 msgid "Delete group"
 msgstr "Grubu sil"
 
-#: src/pages/Shell.tsx:4957
+#: src/pages/Shell.tsx:5032
 msgid "Delete memories too"
 msgstr "Hafızayı da sil"
 
-#: src/pages/Shell.tsx:2685
+#: src/pages/Shell.tsx:2684
 msgid "Delete routine"
 msgstr "Rutini sil"
 
-#: src/pages/Shell.tsx:4068
+#: src/pages/Shell.tsx:4143
 msgid "deleted"
 msgstr "silindi"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4988
-#: src/pages/Shell.tsx:5062
+#: src/pages/Shell.tsx:5063
+#: src/pages/Shell.tsx:5137
 msgid "Deleting…"
 msgstr "Siliniyor…"
 
@@ -1085,17 +1085,17 @@ msgid "Deployment default"
 msgstr "Dağıtım varsayılanı"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4339
+#: src/pages/Shell.tsx:4414
 msgid "Describe what this bot does"
 msgstr "Bu botun ne yaptığını açıkla"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4344
-#: src/pages/Shell.tsx:4510
+#: src/pages/Shell.tsx:4419
+#: src/pages/Shell.tsx:4585
 msgid "Description"
 msgstr "Açıklama"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Dictate"
 msgstr "Dikte et"
 
@@ -1108,7 +1108,7 @@ msgstr "Bağlantıyı kes"
 msgid "Disconnecting…"
 msgstr "Bağlantı kesiliyor…"
 
-#: src/pages/Shell.tsx:5441
+#: src/pages/Shell.tsx:5516
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Kapatıldı — MCP ayarlarından istediğin zaman yeniden bağlanabilirsin."
 
@@ -1156,7 +1156,7 @@ msgstr "Taslak beceri"
 msgid "Duplicate"
 msgstr "Çoğalt"
 
-#: src/pages/Shell.tsx:3881
+#: src/pages/Shell.tsx:3956
 msgid "Earlier message"
 msgstr ""
 
@@ -1212,11 +1212,11 @@ msgstr "Her ay"
 msgid "Every week"
 msgstr "Her hafta"
 
-#: src/pages/Shell.tsx:5487
+#: src/pages/Shell.tsx:5562
 msgid "Expand"
 msgstr "Genişlet"
 
-#: src/pages/Shell.tsx:4671
+#: src/pages/Shell.tsx:4746
 msgid "Export"
 msgstr "Dışa aktar"
 
@@ -1224,7 +1224,7 @@ msgstr "Dışa aktar"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Bu haftanın listesini CRM'den dışa aktar ve ortak klasöre bırak"
 
-#: src/pages/Shell.tsx:4691
+#: src/pages/Shell.tsx:4766
 msgid "Extra high"
 msgstr "Çok yüksek"
 
@@ -1232,14 +1232,14 @@ msgstr "Çok yüksek"
 msgid "Failed"
 msgstr "Başarısız"
 
+#: src/pages/Shell.tsx:1424
 #: src/pages/Shell.tsx:1426
 #: src/pages/Shell.tsx:1428
-#: src/pages/Shell.tsx:1430
 msgid "Failed to send message"
 msgstr "Mesaj gönderilemedi"
 
-#: src/pages/Shell.tsx:1453
-#: src/pages/Shell.tsx:1472
+#: src/pages/Shell.tsx:1451
+#: src/pages/Shell.tsx:1470
 msgid "Failed to stop"
 msgstr "Durdurulamadı"
 
@@ -1275,8 +1275,8 @@ msgstr ""
 msgid "Fullscreen"
 msgstr "Tam ekran"
 
-#: src/pages/Shell.tsx:2135
-#: src/pages/Shell.tsx:2286
+#: src/pages/Shell.tsx:2133
+#: src/pages/Shell.tsx:2285
 msgid "Group"
 msgstr "Grup"
 
@@ -1305,15 +1305,15 @@ msgstr "Örnek dinle"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Merhaba, yanıtları sesli okuduğumda böyle duyulacağım."
 
-#: src/pages/Shell.tsx:4694
+#: src/pages/Shell.tsx:4769
 msgid "High"
 msgstr "Yüksek"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk"
 msgstr "Konuşmak için basılı tut"
 
-#: src/pages/Shell.tsx:3499
+#: src/pages/Shell.tsx:3574
 msgid "Hold to talk (on-device dictation)"
 msgstr "Konuşmak için basılı tut (cihaz üzerinde dikte)"
 
@@ -1333,7 +1333,7 @@ msgstr "Ne sıklıkla"
 msgid "How to check"
 msgstr "Nasıl kontrol edilir"
 
-#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:3852
 msgid "I’m done"
 msgstr "Bitirdim"
 
@@ -1345,7 +1345,7 @@ msgstr "Bunu duyduysan ses hazır."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON içe aktar"
 
-#: src/pages/Shell.tsx:4581
+#: src/pages/Shell.tsx:4656
 msgid "Inherit default"
 msgstr "Varsayılanı devral"
 
@@ -1357,12 +1357,12 @@ msgstr "Girdiler"
 msgid "Instance API key"
 msgstr "Instance API anahtarı"
 
-#: src/pages/Shell.tsx:2569
+#: src/pages/Shell.tsx:2568
 msgid "Instruction"
 msgstr "Talimat"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1997
+#: src/pages/Shell.tsx:1995
 msgid "Integrations"
 msgstr "Entegrasyonlar"
 
@@ -1383,15 +1383,19 @@ msgid "Interval unit"
 msgstr "Aralık birimi"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4582
+#: src/pages/Shell.tsx:4657
 msgid "Isolated"
 msgstr "Yalıtılmış"
 
-#: src/pages/Shell.tsx:4923
+#: src/pages/Shell.tsx:4998
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Sohbeti, dosyaları ve rutinleri kalıcı olarak silinecek. Oluşturduğu botlar listende kalır."
 
-#: src/pages/Shell.tsx:3876
+#: src/pages/Shell.tsx:3213
+msgid "Jump to latest"
+msgstr ""
+
+#: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"
 msgstr "Yanıtlanan mesaja git"
 
@@ -1399,7 +1403,7 @@ msgstr "Yanıtlanan mesaja git"
 msgid "just now"
 msgstr "az önce"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:5016
 msgid "Keep memories"
 msgstr "Hafızayı koru"
 
@@ -1417,7 +1421,7 @@ msgstr "Dil"
 msgid "Listening…"
 msgstr "Dinliyor…"
 
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Load earlier messages"
 msgstr "Önceki mesajları yükle"
 
@@ -1457,7 +1461,7 @@ msgstr "Ses sağlayıcıları yükleniyor…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3100
+#: src/pages/Shell.tsx:3162
 msgid "Loading…"
 msgstr "Yükleniyor…"
 
@@ -1465,11 +1469,11 @@ msgstr "Yükleniyor…"
 msgid "Local"
 msgstr "Yerel"
 
-#: src/pages/Shell.tsx:2083
+#: src/pages/Shell.tsx:2081
 msgid "Log out"
 msgstr "Çıkış yap"
 
-#: src/pages/Shell.tsx:4692
+#: src/pages/Shell.tsx:4767
 msgid "Low"
 msgstr "Düşük"
 
@@ -1485,7 +1489,7 @@ msgstr "Okundu olarak işaretle"
 msgid "Mark as Unread"
 msgstr "Okunmadı olarak işaretle"
 
-#: src/pages/Shell.tsx:4696
+#: src/pages/Shell.tsx:4771
 msgid "Max"
 msgstr "Maksimum"
 
@@ -1495,7 +1499,7 @@ msgstr "Maksimum"
 msgid "MCP servers"
 msgstr "MCP sunucuları"
 
-#: src/pages/Shell.tsx:4693
+#: src/pages/Shell.tsx:4768
 msgid "Medium"
 msgstr "Orta"
 
@@ -1508,33 +1512,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Üyeler ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} seç)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2041
+#: src/pages/Shell.tsx:2039
 msgid "Memory"
 msgstr "Hafıza"
 
-#: src/pages/Shell.tsx:4577
+#: src/pages/Shell.tsx:4652
 msgid "Memory scope"
 msgstr "Hafıza kapsamı"
 
-#: src/pages/Shell.tsx:3577
-#: src/pages/Shell.tsx:3672
+#: src/pages/Shell.tsx:3652
+#: src/pages/Shell.tsx:3747
 msgid "Message"
 msgstr "Mesaj"
 
-#: src/pages/Shell.tsx:3573
-#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3648
+#: src/pages/Shell.tsx:3652
 msgid "Message {activeName}"
 msgstr "{activeName} sohbetine yaz"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Message from {peer}"
 msgstr "{peer} botundan mesaj"
 
-#: src/pages/Shell.tsx:3574
+#: src/pages/Shell.tsx:3649
 msgid "Message…"
 msgstr "Mesaj…"
 
-#: src/pages/Shell.tsx:3954
+#: src/pages/Shell.tsx:4029
 msgid "Messaged {peer}"
 msgstr "{peer} botuna mesaj gönderildi"
 
@@ -1542,7 +1546,7 @@ msgstr "{peer} botuna mesaj gönderildi"
 msgid "Microphone failed"
 msgstr "Mikrofon hatası"
 
-#: src/pages/Shell.tsx:4695
+#: src/pages/Shell.tsx:4770
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1564,7 +1568,7 @@ msgstr "dakika"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4533
+#: src/pages/Shell.tsx:4608
 msgid "Model"
 msgstr "Model"
 
@@ -1586,7 +1590,7 @@ msgid "Model updated."
 msgstr "Model güncellendi."
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2028
+#: src/pages/Shell.tsx:2026
 msgid "Models"
 msgstr "Modeller"
 
@@ -1604,7 +1608,7 @@ msgstr "Aylık"
 msgid "Move {0} to section"
 msgstr "{0} botunu bölüme taşı"
 
-#: src/pages/Shell.tsx:4944
+#: src/pages/Shell.tsx:5019
 msgid "Move them to your shared memory."
 msgstr "Bunları ortak hafızana taşı."
 
@@ -1617,15 +1621,15 @@ msgstr "Taşı"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2561
-#: src/pages/Shell.tsx:4324
-#: src/pages/Shell.tsx:4492
-#: src/pages/Shell.tsx:4770
+#: src/pages/Shell.tsx:2560
+#: src/pages/Shell.tsx:4399
+#: src/pages/Shell.tsx:4567
+#: src/pages/Shell.tsx:4845
 msgid "Name"
 msgstr "Ad"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4329
+#: src/pages/Shell.tsx:4404
 msgid "Name this bot"
 msgstr "Bota bir ad ver"
 
@@ -1641,13 +1645,13 @@ msgstr "Girdi bekliyor"
 msgid "Needs takeover"
 msgstr "Devralma bekliyor"
 
-#: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4312
+#: src/pages/Shell.tsx:1773
+#: src/pages/Shell.tsx:4387
 msgid "New bot"
 msgstr "Yeni bot"
 
 #: src/pages/GroupPanel.tsx:98
-#: src/pages/Shell.tsx:1785
+#: src/pages/Shell.tsx:1783
 msgid "New group"
 msgstr "Yeni grup"
 
@@ -1655,12 +1659,12 @@ msgstr "Yeni grup"
 msgid "New open-work item"
 msgstr "Yeni açık iş öğesi"
 
-#: src/pages/Shell.tsx:2447
+#: src/pages/Shell.tsx:2446
 msgid "New routine"
 msgstr "Yeni rutin"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4839
 msgid "New section"
 msgstr "Yeni bölüm"
 
@@ -1738,7 +1742,7 @@ msgstr "Bağlı değil"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5429
+#: src/pages/Shell.tsx:5504
 msgid "Not now"
 msgstr "Şimdi değil"
 
@@ -1776,15 +1780,15 @@ msgstr "her ayın 1'inde saat {0}"
 msgid "Open"
 msgstr "Aç"
 
-#: src/pages/Shell.tsx:2345
+#: src/pages/Shell.tsx:2344
 msgid "Open computer"
 msgstr "Bilgisayarı aç"
 
-#: src/pages/Shell.tsx:2315
+#: src/pages/Shell.tsx:2314
 msgid "Open in full window"
 msgstr "Tam pencerede aç"
 
-#: src/pages/Shell.tsx:2107
+#: src/pages/Shell.tsx:2105
 msgid "Open navigation"
 msgstr "Gezinmeyi aç"
 
@@ -1801,7 +1805,7 @@ msgstr "Açık işler"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI uyumlu sunucu URL'si"
 
-#: src/pages/Shell.tsx:4079
+#: src/pages/Shell.tsx:4154
 msgid "Opened its thread."
 msgstr "Sohbeti açıldı."
 
@@ -1888,7 +1892,7 @@ msgstr "Çalınıyor…"
 msgid "Preview {0}"
 msgstr "{0} önizle"
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Private"
 msgstr "Özel"
 
@@ -1909,7 +1913,7 @@ msgstr "Kuyrukta"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo kaynağı kaydetmeden önce doğrular. Kimlik bilgileri şifrelenir; istemcilere asla geri gönderilmez ve modele gösterilmez."
 
-#: src/pages/Shell.tsx:4609
+#: src/pages/Shell.tsx:4684
 msgid "Read replies aloud"
 msgstr "Yanıtları sesli oku"
 
@@ -1943,7 +1947,7 @@ msgstr ""
 msgid "Recovering…"
 msgstr ""
 
-#: src/pages/Shell.tsx:3767
+#: src/pages/Shell.tsx:3842
 msgid "Release"
 msgstr "Bırak"
 
@@ -1956,17 +1960,17 @@ msgid "Remove"
 msgstr "Kaldır"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3381
+#: src/pages/Shell.tsx:3456
 msgid "Remove {0}"
 msgstr "{0} kaldır"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3536
+#: src/pages/Shell.tsx:3611
 msgid "Remove mention {0}"
 msgstr "{0} bahsini kaldır"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3515
+#: src/pages/Shell.tsx:3590
 msgid "Remove skill {0}"
 msgstr "{0} becerisini kaldır"
 
@@ -1974,7 +1978,7 @@ msgstr "{0} becerisini kaldır"
 msgid "Remove this schedule"
 msgstr "Bu zamanlamayı kaldır"
 
-#: src/pages/Shell.tsx:4078
+#: src/pages/Shell.tsx:4153
 msgid "Removed with chat, computer, and memory."
 msgstr "Sohbeti, bilgisayarı ve hafızasıyla birlikte kaldırıldı."
 
@@ -2002,11 +2006,11 @@ msgstr "API anahtarını değiştir"
 msgid "Replace key"
 msgstr "Anahtarı değiştir"
 
-#: src/pages/Shell.tsx:3713
+#: src/pages/Shell.tsx:3788
 msgid "Reply"
 msgstr "Yanıtla"
 
-#: src/pages/Shell.tsx:3344
+#: src/pages/Shell.tsx:3419
 msgid "Replying to {replyName}"
 msgstr "{replyName} yanıtlanıyor"
 
@@ -2027,7 +2031,7 @@ msgstr ""
 msgid "Resetting…"
 msgstr ""
 
-#: src/pages/Shell.tsx:1972
+#: src/pages/Shell.tsx:1970
 msgid "Restore"
 msgstr "Geri yükle"
 
@@ -2047,17 +2051,17 @@ msgstr "Rakazo'ya dön"
 msgid "Robot"
 msgstr ""
 
-#: src/pages/Shell.tsx:2554
-#: src/pages/Shell.tsx:2607
-#: src/pages/Shell.tsx:2614
+#: src/pages/Shell.tsx:2553
+#: src/pages/Shell.tsx:2606
+#: src/pages/Shell.tsx:2613
 msgid "Routine"
 msgstr "Rutin"
 
-#: src/pages/Shell.tsx:2392
+#: src/pages/Shell.tsx:2391
 msgid "Routines"
 msgstr "Rutinler"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Run now"
 msgstr "Şimdi çalıştır"
 
@@ -2065,11 +2069,11 @@ msgstr "Şimdi çalıştır"
 msgid "Running"
 msgstr "Çalışıyor"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2431
 msgid "Running · Stop"
 msgstr "Çalışıyor · Durdur"
 
-#: src/pages/Shell.tsx:2677
+#: src/pages/Shell.tsx:2676
 msgid "Running…"
 msgstr "Çalışıyor…"
 
@@ -2077,8 +2081,8 @@ msgstr "Çalışıyor…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2653
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:2652
+#: src/pages/Shell.tsx:4739
 msgid "Save"
 msgstr "Kaydet"
 
@@ -2102,7 +2106,7 @@ msgstr "Kaydedildi."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:2652
 msgid "Saving…"
 msgstr "Kaydediliyor…"
 
@@ -2116,7 +2120,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "Evet ya da hayır de veya bir cümleyle yanıtla."
 
 #: src/pages/ModelSettingsOverlay.tsx:939
-#: src/pages/Shell.tsx:1796
+#: src/pages/Shell.tsx:1794
 msgid "Search"
 msgstr "Ara"
 
@@ -2143,11 +2147,11 @@ msgstr "Sağlayıcı ve model ara"
 msgid "Searching…"
 msgstr "Aranıyor…"
 
-#: src/pages/Shell.tsx:2136
+#: src/pages/Shell.tsx:2134
 msgid "Select a bot"
 msgstr "Bir bot seç"
 
-#: src/pages/Shell.tsx:3597
+#: src/pages/Shell.tsx:3672
 msgid "Send"
 msgstr "Gönder"
 
@@ -2175,22 +2179,22 @@ msgstr "Sunucu adı"
 msgid "Server URL"
 msgstr "Sunucu URL'si"
 
-#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2143
 msgid "Set up voice to call"
 msgstr "Arama için sesi ayarla"
 
 #: src/pages/AccountSettingsOverlay.tsx:100
-#: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2015
-#: src/pages/Shell.tsx:2282
+#: src/pages/Shell.tsx:2003
+#: src/pages/Shell.tsx:2013
+#: src/pages/Shell.tsx:2281
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/pages/Shell.tsx:3615
+#: src/pages/Shell.tsx:3690
 msgid "Settings: General"
 msgstr "Ayarlar: Genel"
 
-#: src/pages/Shell.tsx:3617
+#: src/pages/Shell.tsx:3692
 msgid "Settings: Usage"
 msgstr "Ayarlar: Kullanım"
 
@@ -2200,15 +2204,15 @@ msgid "Setup help"
 msgstr "Kurulum yardımı"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4583
+#: src/pages/Shell.tsx:4658
 msgid "Shared"
 msgstr "Ortak"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show computer"
 msgstr "Bilgisayarı göster"
 
-#: src/pages/Shell.tsx:2293
+#: src/pages/Shell.tsx:2292
 msgid "Show settings"
 msgstr "Ayarları göster"
 
@@ -2232,11 +2236,11 @@ msgid "Sign up"
 msgstr "Kaydol"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3428
+#: src/pages/Shell.tsx:3503
 msgid "Skill {0}"
 msgstr "Beceri: {0}"
 
-#: src/pages/Shell.tsx:3774
+#: src/pages/Shell.tsx:3849
 msgid "Skip"
 msgstr "Atla"
 
@@ -2249,7 +2253,7 @@ msgid "Skip or deploy key"
 msgstr "Atla veya dağıtım anahtarı kullan"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1320
+#: src/pages/Shell.tsx:1318
 msgid "Skipped {0}"
 msgstr "{0} atlandı"
 
@@ -2257,8 +2261,8 @@ msgstr "{0} atlandı"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Boşluk keser · Esc aramayı sonlandırır"
 
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Speak"
 msgstr "Seslendir"
 
@@ -2270,8 +2274,8 @@ msgstr "Seslendir + yazıya dök"
 msgid "Speak only"
 msgstr "Yalnızca seslendir"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Speak this reply"
 msgstr "Bu yanıtı seslendir"
 
@@ -2297,20 +2301,20 @@ msgstr "Başlatılıyor…"
 msgid "Steps"
 msgstr "Adımlar"
 
-#: src/pages/Shell.tsx:2943
-#: src/pages/Shell.tsx:2947
-#: src/pages/Shell.tsx:3588
-#: src/pages/Shell.tsx:3923
-#: src/pages/Shell.tsx:4176
+#: src/pages/Shell.tsx:2942
+#: src/pages/Shell.tsx:2946
+#: src/pages/Shell.tsx:3663
+#: src/pages/Shell.tsx:3998
+#: src/pages/Shell.tsx:4251
 msgid "Stop"
 msgstr "Durdur"
 
-#: src/pages/Shell.tsx:3480
+#: src/pages/Shell.tsx:3555
 msgid "Stop dictation"
 msgstr "Dikteyi durdur"
 
-#: src/pages/Shell.tsx:3919
-#: src/pages/Shell.tsx:4172
+#: src/pages/Shell.tsx:3994
+#: src/pages/Shell.tsx:4247
 msgid "Stop speaking"
 msgstr "Seslendirmeyi durdur"
 
@@ -2319,8 +2323,8 @@ msgstr "Seslendirmeyi durdur"
 msgid "Stop teaching"
 msgstr "Öğretmeyi durdur"
 
-#: src/pages/Shell.tsx:2372
-#: src/pages/Shell.tsx:2963
+#: src/pages/Shell.tsx:2371
+#: src/pages/Shell.tsx:2962
 msgid "Stop the bot first"
 msgstr "Önce botu durdur"
 
@@ -2328,7 +2332,7 @@ msgstr "Önce botu durdur"
 msgid "Stored encrypted"
 msgstr "Şifreli saklanıyor"
 
-#: src/pages/Shell.tsx:4030
+#: src/pages/Shell.tsx:4105
 msgid "subagent"
 msgstr "alt ajan"
 
@@ -2341,8 +2345,8 @@ msgstr "Gönder"
 msgid "Switching…"
 msgstr "Geçiliyor…"
 
-#: src/pages/Shell.tsx:2375
-#: src/pages/Shell.tsx:2968
+#: src/pages/Shell.tsx:2374
+#: src/pages/Shell.tsx:2967
 msgid "Take control"
 msgstr "Kontrolü al"
 
@@ -2350,7 +2354,7 @@ msgstr "Kontrolü al"
 msgid "Teach a task"
 msgstr "Görev öğret"
 
-#: src/pages/Shell.tsx:2208
+#: src/pages/Shell.tsx:2207
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Öğretme sürüyor — yeni mesaj göndermeden önce öğretmeyi durdur."
 
@@ -2358,11 +2362,11 @@ msgstr "Öğretme sürüyor — yeni mesaj göndermeden önce öğretmeyi durdur
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Öğretme, grafik arayüzlü bir sandbox bilgisayarı gerektirir. Masaüstünde çalışan botlar kabuk görevleri çalıştırabilir ama ekran kaydı yapamaz."
 
-#: src/pages/Shell.tsx:4267
+#: src/pages/Shell.tsx:4342
 msgid "Team"
 msgstr "Takım"
 
-#: src/pages/Shell.tsx:5110
+#: src/pages/Shell.tsx:5185
 msgid "Team Computer"
 msgstr "Takım Bilgisayarı"
 
@@ -2375,20 +2379,20 @@ msgstr "Dene"
 msgid "The selected memory provider is not available in this build."
 msgstr "Seçilen hafıza sağlayıcısı bu sürümde kullanılamıyor."
 
-#: src/pages/Shell.tsx:4560
+#: src/pages/Shell.tsx:4635
 msgid "Thinking"
 msgstr "Düşünüyor"
 
-#: src/pages/Shell.tsx:2319
+#: src/pages/Shell.tsx:2318
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Bu bot bir Linux masaüstünde değil, bu bilgisayarda çalışır. Kabuk ve dosyalar senin kullanıcı klasörünü kullanır."
 
-#: src/pages/Shell.tsx:2992
+#: src/pages/Shell.tsx:2991
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Bu bot bu bilgisayarda çalışır. Ayrı bir Linux masaüstü yoktur. Kabuğu kullanmasını isteyebilirsin; kullanıcı klasörünün altındaki çalışma dizinlerine izin verilir."
 
-#: src/pages/Shell.tsx:4960
-#: src/pages/Shell.tsx:5037
+#: src/pages/Shell.tsx:5035
+#: src/pages/Shell.tsx:5112
 msgid "This cannot be undone."
 msgstr "Bu işlem geri alınamaz."
 
@@ -2412,7 +2416,7 @@ msgstr "bu Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Bu Mac kabuk komutlarını senin hesabınla çalıştırır; kullanıcı klasöründeki dosyalar buna dahildir. Ortak veya herkese açık bir sunucuda etkinleştirme."
 
-#: src/pages/Shell.tsx:4845
+#: src/pages/Shell.tsx:4920
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Bu, tüm mesajları kalıcı olarak siler ve mevcut çalışmayı durdurur. Bot, bilgisayar, hafıza ve rutinler korunur."
 
@@ -2420,7 +2424,7 @@ msgstr "Bu, tüm mesajları kalıcı olarak siler ve mevcut çalışmayı durdur
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bu sağlayıcı için buraya anahtar yapıştırılamaz. Bu dağıtımda kimlik bilgileri zaten varsa atla."
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5452
 msgid "This server cannot be assigned without a bot."
 msgstr "Bu sunucu bir bot olmadan atanamaz."
 
@@ -2432,7 +2436,7 @@ msgstr "Bu sunucu tarayıcı yetkilendirmesi istemedi."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Bu sunucu zaten bağlı. Yeniden yetkilendirmek için önce bağlantısını kes."
 
-#: src/pages/Shell.tsx:5416
+#: src/pages/Shell.tsx:5491
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Bu sunucu tarayıcıyla oturum açar. Agent'larının araçlarını kullanabilmesi için yetkilendir — bir açılır pencere açılacak."
 
@@ -2445,8 +2449,8 @@ msgid "Time of day"
 msgstr "Günün saati"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4334
-#: src/pages/Shell.tsx:4501
+#: src/pages/Shell.tsx:4409
+#: src/pages/Shell.tsx:4576
 msgid "Title"
 msgstr "Başlık"
 
@@ -2471,7 +2475,7 @@ msgid "Unpin"
 msgstr "Sabitlemeyi kaldır"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1384
+#: src/pages/Shell.tsx:1382
 msgid "Unsupported file type: {0}"
 msgstr "Desteklenmeyen dosya türü: {0}"
 
@@ -2484,7 +2488,7 @@ msgid "Updating…"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:176
-#: src/pages/Shell.tsx:2066
+#: src/pages/Shell.tsx:2064
 msgid "Usage"
 msgstr "Kullanım"
 
@@ -2509,8 +2513,8 @@ msgstr "Doğrula ve ekle"
 msgid "Verifying…"
 msgstr "Doğrulanıyor…"
 
-#: src/pages/Shell.tsx:2054
-#: src/pages/Shell.tsx:4613
+#: src/pages/Shell.tsx:2052
+#: src/pages/Shell.tsx:4688
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2523,7 +2527,7 @@ msgstr "Ses"
 msgid "Waiting for sign-in…"
 msgstr "Oturum açma bekleniyor…"
 
-#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5335
 msgid "Waiting…"
 msgstr "Bekleniyor…"
 
@@ -2532,7 +2536,7 @@ msgstr "Bekleniyor…"
 msgid "Weekdays"
 msgstr "Hafta içi"
 
-#: src/pages/Shell.tsx:4930
+#: src/pages/Shell.tsx:5005
 msgid "What about its memories?"
 msgstr "Hafızası ne olsun?"
 
@@ -2541,7 +2545,7 @@ msgid "What result will you demonstrate?"
 msgstr "Hangi sonucu göstereceksin?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4349
+#: src/pages/Shell.tsx:4424
 msgid "What this bot is for"
 msgstr "Bu botun amacı"
 
@@ -2553,7 +2557,7 @@ msgstr "Ne döndürülecek"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "{botName} başka bir bota mesaj gönderdiğinde yazışma sohbet yerine burada görünür."
 
-#: src/pages/Shell.tsx:2578
+#: src/pages/Shell.tsx:2577
 msgid "When to run"
 msgstr "Ne zaman çalışacak"
 
@@ -2570,12 +2574,12 @@ msgstr "Botlar nerede çalışsın?"
 msgid "Working…"
 msgstr "Çalışıyor…"
 
-#: src/pages/Shell.tsx:4543
+#: src/pages/Shell.tsx:4618
 msgid "Workspace default"
 msgstr "Çalışma alanı varsayılanı"
 
-#: src/pages/Shell.tsx:1115
-#: src/pages/Shell.tsx:1706
+#: src/pages/Shell.tsx:1113
+#: src/pages/Shell.tsx:1704
 msgid "You"
 msgstr "Sen"
 
@@ -2587,8 +2591,8 @@ msgstr "Otomatik yönlendirilmezsen bu sekmeyi kapatabilirsin."
 msgid "You can close this window."
 msgstr "Bu pencereyi kapatabilirsin."
 
-#: src/pages/Shell.tsx:2352
-#: src/pages/Shell.tsx:2933
+#: src/pages/Shell.tsx:2351
+#: src/pages/Shell.tsx:2932
 msgid "You have control"
 msgstr "Kontrol sende"
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3087,7 +3087,16 @@ const Transcript = memo(function Transcript({
     () => new Map(messages.map((message) => [message.id, message])),
     [messages],
   );
-  const scrollToEnd = useCallback(() => {
+  const snapToEnd = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    following.current = true;
+    autoScrolling.current = false;
+    setAtEnd(true);
+    element.scrollTo({ top: element.scrollHeight, behavior: "auto" });
+  }, [scrollRef]);
+
+  const jumpToLatest = useCallback(() => {
     const element = scrollRef.current;
     if (!element) return;
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -3108,8 +3117,8 @@ const Transcript = memo(function Transcript({
   }, [scrollRef]);
 
   useLayoutEffect(() => {
-    if (following.current) scrollToEnd();
-  }, [messages, running, scrollToEnd]);
+    if (following.current) snapToEnd();
+  }, [messages, running, snapToEnd]);
 
   useEffect(
     () => () => {
@@ -3201,10 +3210,10 @@ const Transcript = memo(function Transcript({
       </div>
       <button
         type="button"
-        aria-label={t`Jump to latest message`}
+        aria-label={t`Jump to latest`}
         aria-hidden={atEnd}
         tabIndex={atEnd ? -1 : 0}
-        onClick={scrollToEnd}
+        onClick={jumpToLatest}
         className={`absolute bottom-4 left-1/2 z-20 grid h-9 w-9 -translate-x-1/2 place-items-center rounded-full border border-[#303034] bg-[#1A1A1D]/95 text-[#C9C9CE] shadow-[0_8px_24px_rgba(0,0,0,.45)] backdrop-blur transition-[opacity,transform,background-color] duration-200 ease-[cubic-bezier(.22,1,.36,1)] hover:bg-[#242428] motion-reduce:transition-none ${
           atEnd ? "pointer-events-none translate-y-2 opacity-0" : "translate-y-0 opacity-100"
         }`}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3120,6 +3120,13 @@ const Transcript = memo(function Transcript({
     if (following.current) snapToEnd();
   }, [messages, running, snapToEnd]);
 
+  const loadOlder = useCallback(() => {
+    // Prepend must not race the messages-driven snap-to-end follow path.
+    following.current = false;
+    autoScrolling.current = false;
+    return onLoadOlder();
+  }, [onLoadOlder]);
+
   useEffect(
     () => () => {
       window.clearTimeout(autoScrollTimer.current);
@@ -3156,7 +3163,7 @@ const Transcript = memo(function Transcript({
           <button
             type="button"
             disabled={loadingOlder}
-            onClick={() => void onLoadOlder()}
+            onClick={() => void loadOlder()}
             className="self-center rounded-lg px-3 py-1.5 text-[13px] text-[#85858A] hover:bg-[#1A1A1D] hover:text-[#C9C9CE] disabled:opacity-50"
           >
             {loadingOlder ? t`Loading…` : t`Load earlier messages`}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -60,6 +60,7 @@ import {
 } from "@rakazo/core";
 import { AvatarStyleProvider, BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
 import {
+  ArrowDown,
   ArrowUp,
   Bell,
   Box,
@@ -134,6 +135,7 @@ import {
   reduceThreadSnapshot,
   userHoldsComputerControl,
 } from "../lib/thread-events";
+import { transcriptIsNearEnd } from "../lib/transcript-scroll";
 import { speaker } from "../lib/tts";
 import { ActivityList } from "./ActivityList";
 import type { ContextMenuPosition } from "./BotContextMenu";
@@ -469,9 +471,7 @@ export function ShellPage() {
 
   async function refreshGroupThread(id: string) {
     const scrollElement = messageScroll.current;
-    const stickToEnd =
-      !scrollElement ||
-      scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight < 80;
+    const stickToEnd = !scrollElement || transcriptIsNearEnd(scrollElement);
     markOnce("rk:renderer:thread-request-start");
     const request = ++groupRefreshEpoch.current;
     const snap = await rpc.threads.get({ groupId: id });
@@ -499,9 +499,7 @@ export function ShellPage() {
 
   async function refreshThread(id: string) {
     const scrollElement = messageScroll.current;
-    const stickToEnd =
-      !scrollElement ||
-      scrollElement.scrollHeight - scrollElement.scrollTop - scrollElement.clientHeight < 80;
+    const stickToEnd = !scrollElement || transcriptIsNearEnd(scrollElement);
     markOnce("rk:renderer:thread-request-start");
     const epoch = historyEpoch.current;
     const request = ++threadRefreshEpoch.current;
@@ -2178,6 +2176,7 @@ export function ShellPage() {
           </div>
         </div>
         <Transcript
+          key={activeSnapshot?.threadId}
           scrollRef={messageScroll}
           artifactTarget={transcriptArtifactTarget}
           messages={activeSnapshot?.messages ?? []}
@@ -3080,71 +3079,138 @@ const Transcript = memo(function Transcript({
   onSpeak: (message: ThreadMessage) => void;
 }) {
   const { t } = useLingui();
+  const [atEnd, setAtEnd] = useState(true);
+  const following = useRef(true);
+  const autoScrolling = useRef(false);
+  const autoScrollTimer = useRef<number | undefined>(undefined);
   const messageById = useMemo(
     () => new Map(messages.map((message) => [message.id, message])),
     [messages],
   );
+  const scrollToEnd = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    following.current = true;
+    autoScrolling.current = !reducedMotion;
+    setAtEnd(true);
+    element.scrollTo({
+      top: element.scrollHeight,
+      behavior: reducedMotion ? "auto" : "smooth",
+    });
+    window.clearTimeout(autoScrollTimer.current);
+    autoScrollTimer.current = window.setTimeout(
+      () => {
+        autoScrolling.current = false;
+      },
+      reducedMotion ? 0 : 420,
+    );
+  }, [scrollRef]);
+
+  useLayoutEffect(() => {
+    if (following.current) scrollToEnd();
+  }, [messages, running, scrollToEnd]);
+
+  useEffect(
+    () => () => {
+      window.clearTimeout(autoScrollTimer.current);
+    },
+    [],
+  );
+
   return (
-    <div
-      ref={scrollRef}
-      data-testid="transcript"
-      className="rk-scroll flex flex-1 flex-col gap-2 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
-    >
-      {olderCursor != null ? (
-        <button
-          type="button"
-          disabled={loadingOlder}
-          onClick={() => void onLoadOlder()}
-          className="self-center rounded-lg px-3 py-1.5 text-[13px] text-[#85858A] hover:bg-[#1A1A1D] hover:text-[#C9C9CE] disabled:opacity-50"
-        >
-          {loadingOlder ? t`Loading…` : t`Load earlier messages`}
-        </button>
-      ) : null}
-      {messages.map((message) => (
-        <div
-          key={message.id}
-          data-message-id={message.id}
-          className="group/message relative pt-9 hover:z-20"
-        >
-          <MessageHoverActions message={message} onReply={onReply} />
-          <MessageView
-            artifactTarget={artifactTarget}
-            message={message}
-            canAnswer={message.id === answerableAskMessageId}
-            onOpenBot={onOpenBot}
-            onOpenPeerMessages={onOpenPeerMessages}
-            onAnswer={onAnswer}
-            speakerName={message.role === "bot" ? memberName?.(message.botId) : undefined}
-            memberName={memberName}
-            replyPreview={
-              message.replyToMessageId ? messageById.get(message.replyToMessageId) : undefined
-            }
-            replyToMessageId={message.replyToMessageId}
-            onJumpToMessage={onJumpToMessage}
-            onRefresh={onRefresh}
-            onBotChanged={onBotChanged}
-            onAddRoutine={onAddRoutine}
-            voiceReady={voiceReady}
-            speaking={speakingMessageId === message.id}
-            onSpeak={() => onSpeak(message)}
-          />
-        </div>
-      ))}
-      {running &&
-      !messages.some(
-        (message) =>
-          message.id.startsWith("progress:") &&
-          message.blocks[0]?.kind === "progress" &&
-          message.blocks[0].text,
-      ) ? (
-        <div className="flex justify-start">
-          {/* Box metrics match the progress bubble exactly so swapping between
-              them never changes height or text position. */}
-          <div className="flex max-w-[74%] items-center rounded-[20px] bg-[#1A1A1D] px-[18px] py-3 text-[15.5px] leading-[1.5]">
-            <LoadingState label="working" startedAt={workingStartedAt} />
+    <div className="relative flex min-h-0 flex-1">
+      <div
+        ref={scrollRef}
+        data-testid="transcript"
+        onPointerDown={() => {
+          autoScrolling.current = false;
+        }}
+        onTouchStart={() => {
+          autoScrolling.current = false;
+        }}
+        onWheel={(event) => {
+          if (event.deltaY < 0) {
+            autoScrolling.current = false;
+            following.current = false;
+          }
+        }}
+        onScroll={(event) => {
+          const nearEnd = transcriptIsNearEnd(event.currentTarget);
+          setAtEnd(nearEnd);
+          if (nearEnd) following.current = true;
+          else if (!autoScrolling.current) following.current = false;
+        }}
+        className="rk-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
+      >
+        {olderCursor != null ? (
+          <button
+            type="button"
+            disabled={loadingOlder}
+            onClick={() => void onLoadOlder()}
+            className="self-center rounded-lg px-3 py-1.5 text-[13px] text-[#85858A] hover:bg-[#1A1A1D] hover:text-[#C9C9CE] disabled:opacity-50"
+          >
+            {loadingOlder ? t`Loading…` : t`Load earlier messages`}
+          </button>
+        ) : null}
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            data-message-id={message.id}
+            className="group/message relative pt-9 hover:z-20"
+          >
+            <MessageHoverActions message={message} onReply={onReply} />
+            <MessageView
+              artifactTarget={artifactTarget}
+              message={message}
+              canAnswer={message.id === answerableAskMessageId}
+              onOpenBot={onOpenBot}
+              onOpenPeerMessages={onOpenPeerMessages}
+              onAnswer={onAnswer}
+              speakerName={message.role === "bot" ? memberName?.(message.botId) : undefined}
+              memberName={memberName}
+              replyPreview={
+                message.replyToMessageId ? messageById.get(message.replyToMessageId) : undefined
+              }
+              replyToMessageId={message.replyToMessageId}
+              onJumpToMessage={onJumpToMessage}
+              onRefresh={onRefresh}
+              onBotChanged={onBotChanged}
+              onAddRoutine={onAddRoutine}
+              voiceReady={voiceReady}
+              speaking={speakingMessageId === message.id}
+              onSpeak={() => onSpeak(message)}
+            />
           </div>
-        </div>
-      ) : null}
+        ))}
+        {running &&
+        !messages.some(
+          (message) =>
+            message.id.startsWith("progress:") &&
+            message.blocks[0]?.kind === "progress" &&
+            message.blocks[0].text,
+        ) ? (
+          <div className="flex justify-start">
+            {/* Box metrics match the progress bubble exactly so swapping between
+              them never changes height or text position. */}
+            <div className="flex max-w-[74%] items-center rounded-[20px] bg-[#1A1A1D] px-[18px] py-3 text-[15.5px] leading-[1.5]">
+              <LoadingState label="working" startedAt={workingStartedAt} />
+            </div>
+          </div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        aria-label={t`Jump to latest message`}
+        aria-hidden={atEnd}
+        tabIndex={atEnd ? -1 : 0}
+        onClick={scrollToEnd}
+        className={`absolute bottom-4 left-1/2 z-20 grid h-9 w-9 -translate-x-1/2 place-items-center rounded-full border border-[#303034] bg-[#1A1A1D]/95 text-[#C9C9CE] shadow-[0_8px_24px_rgba(0,0,0,.45)] backdrop-blur transition-[opacity,transform,background-color] duration-200 ease-[cubic-bezier(.22,1,.36,1)] hover:bg-[#242428] motion-reduce:transition-none ${
+          atEnd ? "pointer-events-none translate-y-2 opacity-0" : "translate-y-0 opacity-100"
+        }`}
+      >
+        <ArrowDown size={17} strokeWidth={1.8} />
+      </button>
     </div>
   );
 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3123,8 +3123,9 @@ const Transcript = memo(function Transcript({
   }, [messages, running, snapToEnd]);
 
   useLayoutEffect(() => {
-    if (atEnd && document.activeElement === jumpButtonRef.current) {
-      jumpButtonRef.current.blur();
+    const button = jumpButtonRef.current;
+    if (atEnd && button && document.activeElement === button) {
+      button.blur();
     }
   }, [atEnd]);
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3121,11 +3121,21 @@ const Transcript = memo(function Transcript({
   }, [messages, running, snapToEnd]);
 
   const loadOlder = useCallback(() => {
+    const wasFollowing = following.current;
     // Prepend must not race the messages-driven snap-to-end follow path.
     following.current = false;
     autoScrolling.current = false;
-    return onLoadOlder();
-  }, [onLoadOlder]);
+    const pending = onLoadOlder();
+    if (!pending) return;
+    return Promise.resolve(pending).catch((error) => {
+      const element = scrollRef.current;
+      if (wasFollowing && element && transcriptIsNearEnd(element)) {
+        following.current = true;
+        setAtEnd(true);
+      }
+      throw error;
+    });
+  }, [onLoadOlder, scrollRef]);
 
   useEffect(
     () => () => {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3083,6 +3083,7 @@ const Transcript = memo(function Transcript({
   const following = useRef(true);
   const autoScrolling = useRef(false);
   const autoScrollTimer = useRef<number | undefined>(undefined);
+  const jumpButtonRef = useRef<HTMLButtonElement>(null);
   const messageById = useMemo(
     () => new Map(messages.map((message) => [message.id, message])),
     [messages],
@@ -3108,17 +3109,24 @@ const Transcript = memo(function Transcript({
       behavior: reducedMotion ? "auto" : "smooth",
     });
     window.clearTimeout(autoScrollTimer.current);
+    // Fallback only: onScroll clears autoScrolling once near-end is reached.
     autoScrollTimer.current = window.setTimeout(
       () => {
         autoScrolling.current = false;
       },
-      reducedMotion ? 0 : 420,
+      reducedMotion ? 0 : 2_000,
     );
   }, [scrollRef]);
 
   useLayoutEffect(() => {
     if (following.current) snapToEnd();
   }, [messages, running, snapToEnd]);
+
+  useLayoutEffect(() => {
+    if (atEnd && document.activeElement === jumpButtonRef.current) {
+      jumpButtonRef.current.blur();
+    }
+  }, [atEnd]);
 
   const loadOlder = useCallback(() => {
     const wasFollowing = following.current;
@@ -3164,8 +3172,15 @@ const Transcript = memo(function Transcript({
         onScroll={(event) => {
           const nearEnd = transcriptIsNearEnd(event.currentTarget);
           setAtEnd(nearEnd);
-          if (nearEnd) following.current = true;
-          else if (!autoScrolling.current) following.current = false;
+          if (nearEnd) {
+            following.current = true;
+            if (autoScrolling.current) {
+              autoScrolling.current = false;
+              window.clearTimeout(autoScrollTimer.current);
+            }
+          } else if (!autoScrolling.current) {
+            following.current = false;
+          }
         }}
         className="rk-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
       >
@@ -3226,6 +3241,7 @@ const Transcript = memo(function Transcript({
         ) : null}
       </div>
       <button
+        ref={jumpButtonRef}
         type="button"
         aria-label={t`Jump to latest`}
         aria-hidden={atEnd}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes PR 304 from @luinbytes.

## Summary
- Follow new and streaming messages while the transcript is already at the latest message
- Preserve the reader's position when they scroll up
- Show an icon-only jump-to-latest control when not near the end (80px threshold, matching thread-refresh stickiness)
- Remount Transcript on thread change via `key={threadId}`

## Review fixes (on top of the contributor's work)
- Auto-follow on new/streaming updates snaps instantly (`behavior: "auto"`); smooth scroll is only for the explicit jump click (respects reduced-motion)
- Accessible label shortened to `Jump to latest`; Lingui catalogs extracted for de/ko/tr/hi/pt-BR (placeholders left empty; no invented translations)
- Clear follow state before load-older so prepend offset restore is not raced by snap-to-end; restore follow if that request fails while still near the end
- Blur jump control before it becomes `aria-hidden`; clear the smooth-scroll guard when near-end is reached
- No extra visible label or chrome

## Attribution
Original work by @luinbytes (`luinbytes <42706009+luinbytes@users.noreply.github.com>`). Fork branch was not pushable, so this PR carries their commit plus the review fixes.

Co-authored-by: luinbytes <42706009+luinbytes@users.noreply.github.com>

## Screenshots
- `pr304-at-end.png` — at latest, jump control hidden
- `pr304-scrolled-up.png` — scrolled up, icon-only jump control visible
- `pr304-jumped.png` — after click, back at latest

## Verification
- Unit test for 80px near-end helper
- biome check on changed files
- Lingui extract for catalogs
- CI on this branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcff7d07-fcf6-415c-9028-86119785ef8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcff7d07-fcf6-415c-9028-86119785ef8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Jump to latest” button when you scroll away from the newest transcript message.
  * New messages stay in view automatically only when you are near the transcript’s end.
  * Transcript position resets appropriately when switching conversations.

* **Bug Fixes**
  * Improved transcript scrolling behavior, including recovery when loading earlier messages fails.

* **Tests**
  * Added coverage for near-end transcript detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->