### PR TITLE
fix(agents): support useful bot updates without fake completion replies

### DIFF
--- a/packages/adapters/src/bot-messages.test.ts
+++ b/packages/adapters/src/bot-messages.test.ts
@@ -116,13 +116,14 @@ describe("messaging another bot", () => {
     expect(harness.enqueue).toHaveBeenCalledTimes(1);
   });
 
-  it("tells the sender not to wait for a reply", async () => {
+  it("tells the sender to continue independent work", async () => {
     const harness = deps();
     const sent = await messageBot(harness.deps, run, sender, {
       bot_id: "bot-target",
       message: "ping",
     });
     expect(sent.ok && sent.note).toContain("asynchronous");
+    expect(sent.ok && sent.note).toContain("Continue any work that does not depend on their reply");
   });
 
   it("refuses a bot messaging itself", async () => {

--- a/packages/adapters/src/bot-messages.ts
+++ b/packages/adapters/src/bot-messages.ts
@@ -254,7 +254,7 @@ export async function messageBot(
     botId: target.id,
     name: target.name,
     delivered: message,
-    note: `Sent to ${target.name}. Delivery is asynchronous — if they reply it arrives later as a new message that wakes you. Do not wait for it now.`,
+    note: `Sent to ${target.name}. Delivery is asynchronous — if they reply it arrives later as a new message that wakes you. Continue any work that does not depend on their reply; send another update later only when it adds new information.`,
   };
 }
 

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -509,7 +509,7 @@ export const builtinAgentTools: ConnectorTool[] = [
   {
     name: "message_bot",
     description:
-      "Send a message to one of the user's other bots. Asynchronous: this returns as soon as the message is sent, and any reply arrives later as a new message that wakes you. Never wait for a reply in this turn.",
+      "Send a useful update, question, or result to one of the user's other bots. Delivery is asynchronous and does not end your turn: continue work that does not depend on the reply, and send later updates when they add new information. Never poll or send acknowledgement-only messages.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/adapters/src/executor-completion.test.ts
+++ b/packages/adapters/src/executor-completion.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { completionMessageSegments } from "./executor.js";
+
+describe("completionMessageSegments", () => {
+  it("keeps visible tool activity without appending a generic completion claim", () => {
+    const steps = [{ kind: "steps" as const, steps: [{ label: "Message bot", count: 1 }] }];
+    expect(completionMessageSegments(steps)).toEqual(steps);
+  });
+
+  it("keeps the last-resort fallback for a runtime that produced nothing", () => {
+    expect(completionMessageSegments([])).toEqual([{ kind: "text", text: "done." }]);
+  });
+});

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2160,9 +2160,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             throw new Error("refusing to persist a secret in the thread");
           }
           flushPendingTools();
-          if (!assembled) {
-            messageSegments = appendTextSegment(messageSegments, "done.");
-          }
+          if (!assembled) messageSegments = completionMessageSegments(messageSegments);
           const blocks = redactBlocks(messageSegments, runSecrets);
           if (!(await renewRunLease(deps, runId, workerId, fence))) return;
           const completed = await deps.events.finalizeRun({
@@ -2347,6 +2345,10 @@ async function renewRunLease(
 
 function computerRetryDelay(fence: number): number {
   return Math.min(10_000, 250 * 2 ** Math.min(Math.max(fence - 1, 0), 5));
+}
+
+export function completionMessageSegments(segments: MessageBlock[]): MessageBlock[] {
+  return segments.length > 0 ? segments : [{ kind: "text", text: "done." }];
 }
 
 function computerRunRequeueData(

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -38,6 +38,7 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
         if (!target) throw new Error("expected tool was not exposed");
         const rawArgs = fakeAgentState.invoke.args;
         const args = target.prepareArguments?.(rawArgs) ?? rawArgs;
+        this.emit({ type: "tool_execution_start", toolName: target.name, args });
         await target.execute("call-1", args);
         return;
       }
@@ -195,6 +196,37 @@ describe("Pi connector tool dispatch", () => {
       "call-1",
       { connectorId: "destination", toolName: "destination.write" },
     );
+  });
+
+  it("does not claim a tool-only turn finished work the model never described", async () => {
+    const runtime = new PiAgentRuntime();
+    const events: unknown[] = [];
+
+    for await (const event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "tool-only",
+        prompt: "send the update",
+        instructions: "Use the destination tool.",
+        history: [],
+        tools: [destinationTool],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool: vi.fn(async () => ({ ok: true })),
+      },
+      {
+        operationId: "tool-only",
+        traceId: "tool-only",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(events).not.toContainEqual({ type: "text", text: "I finished the work." });
+    expect(events.at(-1)).toEqual({ type: "done" });
   });
 
   it("allows more than 80 tool calls by default when no fuse is configured", async () => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -170,10 +170,12 @@ export class PiAgentRuntime implements AgentRuntime {
         signal.addEventListener("abort", onAbort);
 
         let streamed = "";
+        let toolCalls = 0;
         let toolActivityShowing = false;
         agent.subscribe((event) => {
           if (event.type === "tool_execution_start") {
             if (!consumeToolCall(host)) return;
+            toolCalls += 1;
             // Live activity feedback: without this the thread shows a bare
             // "working…" for the whole tool call with nothing actionable.
             toolActivityShowing = true;
@@ -248,11 +250,16 @@ export class PiAgentRuntime implements AgentRuntime {
             streamed = budgetMessage;
           }
         } else if (!streamed) {
-          const fallback = assistantText(agent.state.messages.at(-1)) || "I finished the work.";
-          queue.push({ type: "text", text: fallback });
-          streamed = fallback;
+          const fallback = assistantText(agent.state.messages.at(-1));
+          if (fallback) {
+            queue.push({ type: "text", text: fallback });
+            streamed = fallback;
+          } else if (toolCalls === 0) {
+            streamed = "I didn't receive a response from the model. Please try again.";
+            queue.push({ type: "text", text: streamed });
+          }
         }
-        queue.push({ type: "done", text: streamed });
+        queue.push(streamed ? { type: "done", text: streamed } : { type: "done" });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
         queue.fail(new Error(message));

--- a/packages/core/src/bot-messages.test.ts
+++ b/packages/core/src/bot-messages.test.ts
@@ -96,6 +96,8 @@ describe("directory", () => {
     expect(directory).toContain("Investigates source-backed questions");
     expect(directory).toContain("Analyst (id: b_2)");
     expect(directory).toContain("asynchronous");
+    expect(directory).toContain("does not end your turn");
+    expect(directory).toContain("send later updates when they add new information");
   });
 
   it("treats directory fields as untrusted prompt data", () => {
@@ -209,5 +211,10 @@ describe("inbound wake prompt", () => {
 
   it("does not demand a reply for an FYI", () => {
     expect(prompt).toContain("staying silent is fine");
+  });
+
+  it("continues independent work after sending useful updates", () => {
+    expect(prompt).toContain("sending does not end your turn");
+    expect(prompt).toContain("continue work that does not depend on their reply");
   });
 });

--- a/packages/core/src/bot-messages.ts
+++ b/packages/core/src/bot-messages.ts
@@ -79,7 +79,7 @@ export function renderBotDirectory(bots: readonly BotAddress[]): string | undefi
     "<teammate_directory>",
     ...lines,
     "</teammate_directory>",
-    "Use message_bot to send one of them a message. Delivery is asynchronous: the tool returns as soon as it is sent, and any reply arrives later as a new message that wakes you. Never wait for a reply in this turn.",
+    "Use message_bot for useful updates, questions, and results. Delivery is asynchronous and does not end your turn: continue work that does not depend on the reply, and send later updates when they add new information. Never poll or send acknowledgement-only messages.",
   ].join("\n");
 }
 
@@ -112,6 +112,6 @@ export function buildBotMessageWakePrompt(args: { from: BotAddress; text: string
     escapePromptData(args.text),
     "</bot_message>",
     "",
-    `If it needs a reply or an action, handle it: reply to ${name} with message_bot using bot_id ${id}. That reaches them on a later turn, not as a live back-and-forth. Tell your user only when you have a real result to share. If it is just an FYI with nothing for you to do, staying silent is fine — do not reply only to acknowledge it.`,
+    `If it needs a reply or an action, handle it: reply to ${name} with message_bot using bot_id ${id}. Delivery is asynchronous, but sending does not end your turn: continue work that does not depend on their reply, and send another update later when it adds new information. Tell your user only when you have a real result to share. If it is just an FYI with nothing for you to do, staying silent is fine — do not reply only to acknowledge it.`,
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

- stop replacing tool-only agent turns with the hard-coded `I finished the work.` reply
- preserve visible tool activity and report an honest retry message only when the model produced neither text nor tools
- clarify the bot messaging contract so agents continue independent work and can send later updates when they add useful information

## Verification

- `pnpm --filter @rakazo/adapters test` (614 passed, 7 skipped)
- `pnpm --filter @rakazo/core test` (313 passed)
- `pnpm check` (20 packages)
- regression tests cover the Pi tool-only path and executor completion behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clarified asynchronous messaging guidance: sending a message does not end the current turn.
  * Bots are encouraged to continue independent work and provide later updates only when they add new information.
  * Added clearer guidance against polling and acknowledgement-only messages.
  * Improved completion handling so tool-only activity is not reported as a fabricated response.
  * Empty responses now receive a fallback message only when no tool activity occurred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->