### PR TITLE
fix(agents): keep tool-only turns honest

### DIFF
--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -325,6 +325,11 @@ export interface AgentRunRequest {
   };
   resumeFromCheckpoint?: string;
   script?: ScriptedTurn[];
+  /**
+   * Bot-message wakes may finish with no text and no tools (FYI silence).
+   * When set, skip synthetic empty-turn fallbacks.
+   */
+  allowSilentEmpty?: boolean;
   executeTool?: (
     name: string,
     args: Record<string, unknown>,

--- a/packages/adapters/src/bot-messages.test.ts
+++ b/packages/adapters/src/bot-messages.test.ts
@@ -116,13 +116,14 @@ describe("messaging another bot", () => {
     expect(harness.enqueue).toHaveBeenCalledTimes(1);
   });
 
-  it("tells the sender not to wait for a reply", async () => {
+  it("tells the sender to continue independent work", async () => {
     const harness = deps();
     const sent = await messageBot(harness.deps, run, sender, {
       bot_id: "bot-target",
       message: "ping",
     });
     expect(sent.ok && sent.note).toContain("asynchronous");
+    expect(sent.ok && sent.note).toContain("Continue any work that does not depend on their reply");
   });
 
   it("refuses a bot messaging itself", async () => {

--- a/packages/adapters/src/bot-messages.test.ts
+++ b/packages/adapters/src/bot-messages.test.ts
@@ -122,8 +122,8 @@ describe("messaging another bot", () => {
       bot_id: "bot-target",
       message: "ping",
     });
-    expect(sent.ok && sent.note).toContain("asynchronous");
-    expect(sent.ok && sent.note).toContain("Continue any work that does not depend on their reply");
+    expect(sent.ok && sent.note).toContain("async");
+    expect(sent.ok && sent.note).toContain("Continue independent work");
   });
 
   it("refuses a bot messaging itself", async () => {

--- a/packages/adapters/src/bot-messages.ts
+++ b/packages/adapters/src/bot-messages.ts
@@ -254,7 +254,7 @@ export async function messageBot(
     botId: target.id,
     name: target.name,
     delivered: message,
-    note: `Sent to ${target.name}. Delivery is asynchronous — if they reply it arrives later as a new message that wakes you. Do not wait for it now.`,
+    note: `Sent to ${target.name}. Delivery is asynchronous — if they reply it arrives later as a new message that wakes you. Continue any work that does not depend on their reply; send another update later only when it adds new information.`,
   };
 }
 

--- a/packages/adapters/src/bot-messages.ts
+++ b/packages/adapters/src/bot-messages.ts
@@ -254,7 +254,7 @@ export async function messageBot(
     botId: target.id,
     name: target.name,
     delivered: message,
-    note: `Sent to ${target.name}. Delivery is asynchronous — if they reply it arrives later as a new message that wakes you. Continue any work that does not depend on their reply; send another update later only when it adds new information.`,
+    note: `Sent to ${target.name}. Delivery is async; a reply wakes you later as a new message. Continue independent work; send another update later only if it adds something new.`,
   };
 }
 

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -509,7 +509,7 @@ export const builtinAgentTools: ConnectorTool[] = [
   {
     name: "message_bot",
     description:
-      "Send a message to one of the user's other bots. Asynchronous: this returns as soon as the message is sent, and any reply arrives later as a new message that wakes you. Never wait for a reply in this turn.",
+      "Send a useful update, question, or result to one of the user's other bots. Delivery is asynchronous and does not end your turn: continue work that does not depend on the reply, and send later updates when they add new information. Never poll or send acknowledgement-only messages.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -509,7 +509,7 @@ export const builtinAgentTools: ConnectorTool[] = [
   {
     name: "message_bot",
     description:
-      "Send a useful update, question, or result to one of the user's other bots. Delivery is asynchronous and does not end your turn: continue work that does not depend on the reply, and send later updates when they add new information. Never poll or send acknowledgement-only messages.",
+      "Send a useful update, question, or result to another of the user's bots. Delivery is async and does not end your turn. Continue independent work; do not poll or send ack-only messages. Later updates only if they add something new.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/adapters/src/executor-completion.test.ts
+++ b/packages/adapters/src/executor-completion.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { completionMessageSegments } from "./executor.js";
+
+describe("completionMessageSegments", () => {
+  it("keeps visible tool activity without appending a generic completion claim", () => {
+    const steps = [{ kind: "steps" as const, steps: [{ label: "Message bot", count: 1 }] }];
+    expect(completionMessageSegments(steps)).toEqual(steps);
+  });
+
+  it("keeps the last-resort fallback for a runtime that produced nothing", () => {
+    expect(completionMessageSegments([])).toEqual([{ kind: "text", text: "done." }]);
+  });
+});

--- a/packages/adapters/src/executor-completion.test.ts
+++ b/packages/adapters/src/executor-completion.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { completionMessageSegments } from "./executor.js";
+import { completionMessageSegments, completionNotificationBody } from "./executor.js";
 
 describe("completionMessageSegments", () => {
   it("keeps visible tool activity without appending a generic completion claim", () => {
@@ -9,5 +9,18 @@ describe("completionMessageSegments", () => {
 
   it("keeps the last-resort fallback for a runtime that produced nothing", () => {
     expect(completionMessageSegments([])).toEqual([{ kind: "text", text: "done." }]);
+  });
+});
+
+describe("completionNotificationBody", () => {
+  it("omits a body when only tool or step activity remains", () => {
+    const steps = completionMessageSegments([
+      { kind: "steps" as const, steps: [{ label: "Message bot", count: 1 }] },
+    ]);
+    expect(completionNotificationBody("", steps)).toBe("");
+  });
+
+  it("uses the empty-run text when that is all the run produced", () => {
+    expect(completionNotificationBody("", completionMessageSegments([]))).toBe("done.");
   });
 });

--- a/packages/adapters/src/executor-completion.test.ts
+++ b/packages/adapters/src/executor-completion.test.ts
@@ -10,6 +10,10 @@ describe("completionMessageSegments", () => {
   it("keeps the last-resort fallback for a runtime that produced nothing", () => {
     expect(completionMessageSegments([])).toEqual([{ kind: "text", text: "done." }]);
   });
+
+  it("allows a fully empty completion for silent bot-message wakes", () => {
+    expect(completionMessageSegments([], { allowSilentEmpty: true })).toEqual([]);
+  });
 });
 
 describe("completionNotificationBody", () => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2160,9 +2160,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             throw new Error("refusing to persist a secret in the thread");
           }
           flushPendingTools();
-          if (!assembled) {
-            messageSegments = appendTextSegment(messageSegments, "done.");
-          }
+          if (!assembled) messageSegments = completionMessageSegments(messageSegments);
           const blocks = redactBlocks(messageSegments, runSecrets);
           if (!(await renewRunLease(deps, runId, workerId, fence))) return;
           const completed = await deps.events.finalizeRun({
@@ -2347,6 +2345,10 @@ async function renewRunLease(
 
 function computerRetryDelay(fence: number): number {
   return Math.min(10_000, 250 * 2 ** Math.min(Math.max(fence - 1, 0), 5));
+}
+
+export function completionMessageSegments(segments: MessageBlock[]): MessageBlock[] {
+  return segments.length > 0 ? segments : [{ kind: "text", text: "done." }];
 }
 
 function computerRunRequeueData(

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1883,6 +1883,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               },
               resumeFromCheckpoint: takeoverResume?.checkpoint,
               script,
+              allowSilentEmpty: run.trigger === "bot_message",
               executeTool: scripted ? undefined : applyTool,
             },
             context,
@@ -2156,7 +2157,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
           terminalCheckpointComplete = true;
 
           flushPendingTools();
-          if (!assembled) messageSegments = completionMessageSegments(messageSegments);
+          if (!assembled) {
+            messageSegments = completionMessageSegments(messageSegments, {
+              allowSilentEmpty: run.trigger === "bot_message",
+            });
+          }
           const blocks = redactBlocks(messageSegments, runSecrets);
           const text = redactSecrets(completionNotificationBody(assembled, blocks), runSecrets);
           if (containsSecret(text, runSecrets)) {
@@ -2347,8 +2352,13 @@ function computerRetryDelay(fence: number): number {
   return Math.min(10_000, 250 * 2 ** Math.min(Math.max(fence - 1, 0), 5));
 }
 
-export function completionMessageSegments(segments: MessageBlock[]): MessageBlock[] {
-  return segments.length > 0 ? segments : [{ kind: "text", text: "done." }];
+export function completionMessageSegments(
+  segments: MessageBlock[],
+  options?: { allowSilentEmpty?: boolean },
+): MessageBlock[] {
+  if (segments.length > 0) return segments;
+  if (options?.allowSilentEmpty) return [];
+  return [{ kind: "text", text: "done." }];
 }
 
 /** User-facing text for completion notifications; empty when only tool/step activity remains. */

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2155,13 +2155,13 @@ export function createRunExecutor(deps: ExecutorDeps) {
           await checkpointAndRecordComputerWorkspace(deps, storedComputer, computer, context);
           terminalCheckpointComplete = true;
 
-          const text = redactSecrets(assembled || "done.", runSecrets);
-          if (containsSecret(text, runSecrets)) {
-            throw new Error("refusing to persist a secret in the thread");
-          }
           flushPendingTools();
           if (!assembled) messageSegments = completionMessageSegments(messageSegments);
           const blocks = redactBlocks(messageSegments, runSecrets);
+          const text = redactSecrets(completionNotificationBody(assembled, blocks), runSecrets);
+          if (containsSecret(text, runSecrets)) {
+            throw new Error("refusing to persist a secret in the thread");
+          }
           if (!(await renewRunLease(deps, runId, workerId, fence))) return;
           const completed = await deps.events.finalizeRun({
             workspaceId: run.workspaceId,
@@ -2176,7 +2176,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             blocks,
           });
           if (!completed) return;
-          if (bot.notifyOnFinish) {
+          if (bot.notifyOnFinish && text) {
             await notifyRun(deps, run, {
               kind: "completion",
               title: `${bot.name} finished`,
@@ -2349,6 +2349,15 @@ function computerRetryDelay(fence: number): number {
 
 export function completionMessageSegments(segments: MessageBlock[]): MessageBlock[] {
   return segments.length > 0 ? segments : [{ kind: "text", text: "done." }];
+}
+
+/** User-facing text for completion notifications; empty when only tool/step activity remains. */
+export function completionNotificationBody(assembled: string, blocks: MessageBlock[]): string {
+  if (assembled) return assembled;
+  return blocks
+    .filter((block): block is Extract<MessageBlock, { kind: "text" }> => block.kind === "text")
+    .map((block) => block.text)
+    .join("");
 }
 
 function computerRunRequeueData(

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -38,6 +38,7 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
         if (!target) throw new Error("expected tool was not exposed");
         const rawArgs = fakeAgentState.invoke.args;
         const args = target.prepareArguments?.(rawArgs) ?? rawArgs;
+        this.emit({ type: "tool_execution_start", toolName: target.name, args });
         await target.execute("call-1", args);
         return;
       }
@@ -195,6 +196,37 @@ describe("Pi connector tool dispatch", () => {
       "call-1",
       { connectorId: "destination", toolName: "destination.write" },
     );
+  });
+
+  it("does not claim a tool-only turn finished work the model never described", async () => {
+    const runtime = new PiAgentRuntime();
+    const events: unknown[] = [];
+
+    for await (const event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "tool-only",
+        prompt: "send the update",
+        instructions: "Use the destination tool.",
+        history: [],
+        tools: [destinationTool],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool: vi.fn(async () => ({ ok: true })),
+      },
+      {
+        operationId: "tool-only",
+        traceId: "tool-only",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(events).not.toContainEqual({ type: "text", text: "I finished the work." });
+    expect(events.at(-1)).toEqual({ type: "done" });
   });
 
   it("allows more than 80 tool calls by default when no fuse is configured", async () => {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -2,7 +2,7 @@ import type { ConnectorTool } from "@rakazo/adapter-kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakeAgentState = vi.hoisted(() => ({
-  mode: "dispatch" as "dispatch" | "subagent-limit" | "parent-limit",
+  mode: "dispatch" as "dispatch" | "empty" | "subagent-limit" | "parent-limit",
   abortCount: 0,
   tools: [] as Array<{
     name: string;
@@ -32,6 +32,10 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     }
 
     async prompt() {
+      if (fakeAgentState.mode === "empty") {
+        return;
+      }
+
       if (fakeAgentState.mode === "dispatch") {
         const target =
           this.tools.find((tool) => tool.name === fakeAgentState.invoke.name) ?? this.tools[0];
@@ -227,6 +231,71 @@ describe("Pi connector tool dispatch", () => {
 
     expect(events).not.toContainEqual({ type: "text", text: "I finished the work." });
     expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
+  it("keeps FYI bot-message wakes silent when the model produces nothing", async () => {
+    fakeAgentState.mode = "empty";
+    const runtime = new PiAgentRuntime();
+    const events: unknown[] = [];
+
+    for await (const event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "bot-wake-silent",
+        prompt: "[bot] FYI only",
+        instructions: "Stay silent when there is nothing to do.",
+        history: [],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        allowSilentEmpty: true,
+        executeTool: vi.fn(async () => ({ ok: true })),
+      },
+      {
+        operationId: "bot-wake-silent",
+        traceId: "bot-wake-silent",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(events).not.toContainEqual({ type: "text", text: "No response. Try again." });
+    expect(events).toEqual([{ type: "done" }]);
+  });
+
+  it("still asks the user to retry when a normal empty turn produces nothing", async () => {
+    fakeAgentState.mode = "empty";
+    const runtime = new PiAgentRuntime();
+    const events: unknown[] = [];
+
+    for await (const event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "user-empty",
+        prompt: "hello",
+        instructions: "Reply to the user.",
+        history: [],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        executeTool: vi.fn(async () => ({ ok: true })),
+      },
+      {
+        operationId: "user-empty",
+        traceId: "user-empty",
+        workspaceId: "w",
+        userId: "u",
+        signal: new AbortController().signal,
+      },
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toContainEqual({ type: "text", text: "No response. Try again." });
+    expect(events.at(-1)).toEqual({ type: "done", text: "No response. Try again." });
   });
 
   it("allows more than 80 tool calls by default when no fuse is configured", async () => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -170,10 +170,12 @@ export class PiAgentRuntime implements AgentRuntime {
         signal.addEventListener("abort", onAbort);
 
         let streamed = "";
+        let toolCalls = 0;
         let toolActivityShowing = false;
         agent.subscribe((event) => {
           if (event.type === "tool_execution_start") {
             if (!consumeToolCall(host)) return;
+            toolCalls += 1;
             // Live activity feedback: without this the thread shows a bare
             // "working…" for the whole tool call with nothing actionable.
             toolActivityShowing = true;
@@ -248,11 +250,16 @@ export class PiAgentRuntime implements AgentRuntime {
             streamed = budgetMessage;
           }
         } else if (!streamed) {
-          const fallback = assistantText(agent.state.messages.at(-1)) || "I finished the work.";
-          queue.push({ type: "text", text: fallback });
-          streamed = fallback;
+          const fallback = assistantText(agent.state.messages.at(-1));
+          if (fallback) {
+            queue.push({ type: "text", text: fallback });
+            streamed = fallback;
+          } else if (toolCalls === 0) {
+            streamed = "I didn't receive a response from the model. Please try again.";
+            queue.push({ type: "text", text: streamed });
+          }
         }
-        queue.push({ type: "done", text: streamed });
+        queue.push(streamed ? { type: "done", text: streamed } : { type: "done" });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
         queue.fail(new Error(message));

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -255,7 +255,7 @@ export class PiAgentRuntime implements AgentRuntime {
             queue.push({ type: "text", text: fallback });
             streamed = fallback;
           } else if (toolCalls === 0) {
-            streamed = "I didn't receive a response from the model. Please try again.";
+            streamed = "No response. Try again.";
             queue.push({ type: "text", text: streamed });
           }
         }

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -252,8 +252,7 @@ export class PiAgentRuntime implements AgentRuntime {
         } else if (!streamed.trim()) {
           streamed = "";
           const lastMessage = agent.state.messages.at(-1);
-          const fallback =
-            lastMessage?.role === "assistant" ? assistantText(lastMessage) : "";
+          const fallback = lastMessage?.role === "assistant" ? assistantText(lastMessage) : "";
           if (fallback.trim()) {
             queue.push({ type: "text", text: fallback });
             streamed = fallback;

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -251,7 +251,9 @@ export class PiAgentRuntime implements AgentRuntime {
           }
         } else if (!streamed.trim()) {
           streamed = "";
-          const fallback = assistantText(agent.state.messages.at(-1));
+          const lastMessage = agent.state.messages.at(-1);
+          const fallback =
+            lastMessage?.role === "assistant" ? assistantText(lastMessage) : "";
           if (fallback.trim()) {
             queue.push({ type: "text", text: fallback });
             streamed = fallback;

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -256,7 +256,7 @@ export class PiAgentRuntime implements AgentRuntime {
           if (fallback.trim()) {
             queue.push({ type: "text", text: fallback });
             streamed = fallback;
-          } else if (toolCalls === 0) {
+          } else if (toolCalls === 0 && !request.allowSilentEmpty) {
             streamed = "No response. Try again.";
             queue.push({ type: "text", text: streamed });
           }

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -249,9 +249,10 @@ export class PiAgentRuntime implements AgentRuntime {
             queue.push({ type: "text", text: budgetMessage });
             streamed = budgetMessage;
           }
-        } else if (!streamed) {
+        } else if (!streamed.trim()) {
+          streamed = "";
           const fallback = assistantText(agent.state.messages.at(-1));
-          if (fallback) {
+          if (fallback.trim()) {
             queue.push({ type: "text", text: fallback });
             streamed = fallback;
           } else if (toolCalls === 0) {
@@ -259,7 +260,7 @@ export class PiAgentRuntime implements AgentRuntime {
             queue.push({ type: "text", text: streamed });
           }
         }
-        queue.push(streamed ? { type: "done", text: streamed } : { type: "done" });
+        queue.push(streamed.trim() ? { type: "done", text: streamed } : { type: "done" });
       } catch (error) {
         const message = sanitizeError(error instanceof Error ? error.message : String(error));
         queue.fail(new Error(message));

--- a/packages/core/src/bot-messages.test.ts
+++ b/packages/core/src/bot-messages.test.ts
@@ -96,6 +96,8 @@ describe("directory", () => {
     expect(directory).toContain("Investigates source-backed questions");
     expect(directory).toContain("Analyst (id: b_2)");
     expect(directory).toContain("asynchronous");
+    expect(directory).toContain("does not end your turn");
+    expect(directory).toContain("send later updates when they add new information");
   });
 
   it("treats directory fields as untrusted prompt data", () => {
@@ -209,5 +211,10 @@ describe("inbound wake prompt", () => {
 
   it("does not demand a reply for an FYI", () => {
     expect(prompt).toContain("staying silent is fine");
+  });
+
+  it("continues independent work after sending useful updates", () => {
+    expect(prompt).toContain("sending does not end your turn");
+    expect(prompt).toContain("continue work that does not depend on their reply");
   });
 });

--- a/packages/core/src/bot-messages.test.ts
+++ b/packages/core/src/bot-messages.test.ts
@@ -95,9 +95,9 @@ describe("directory", () => {
     expect(directory).toContain("Researcher (id: b_1) — Finds things");
     expect(directory).toContain("Investigates source-backed questions");
     expect(directory).toContain("Analyst (id: b_2)");
-    expect(directory).toContain("asynchronous");
+    expect(directory).toContain("async");
     expect(directory).toContain("does not end your turn");
-    expect(directory).toContain("send later updates when they add new information");
+    expect(directory).toContain("Later updates only if they add something new");
   });
 
   it("treats directory fields as untrusted prompt data", () => {
@@ -214,7 +214,7 @@ describe("inbound wake prompt", () => {
   });
 
   it("continues independent work after sending useful updates", () => {
-    expect(prompt).toContain("sending does not end your turn");
-    expect(prompt).toContain("continue work that does not depend on their reply");
+    expect(prompt).toContain("Sending does not end your turn");
+    expect(prompt).toContain("continue independent work");
   });
 });

--- a/packages/core/src/bot-messages.ts
+++ b/packages/core/src/bot-messages.ts
@@ -79,7 +79,7 @@ export function renderBotDirectory(bots: readonly BotAddress[]): string | undefi
     "<teammate_directory>",
     ...lines,
     "</teammate_directory>",
-    "Use message_bot to send one of them a message. Delivery is asynchronous: the tool returns as soon as it is sent, and any reply arrives later as a new message that wakes you. Never wait for a reply in this turn.",
+    "Use message_bot for useful updates, questions, and results. Delivery is asynchronous and does not end your turn: continue work that does not depend on the reply, and send later updates when they add new information. Never poll or send acknowledgement-only messages.",
   ].join("\n");
 }
 
@@ -112,6 +112,6 @@ export function buildBotMessageWakePrompt(args: { from: BotAddress; text: string
     escapePromptData(args.text),
     "</bot_message>",
     "",
-    `If it needs a reply or an action, handle it: reply to ${name} with message_bot using bot_id ${id}. That reaches them on a later turn, not as a live back-and-forth. Tell your user only when you have a real result to share. If it is just an FYI with nothing for you to do, staying silent is fine — do not reply only to acknowledge it.`,
+    `If it needs a reply or an action, handle it: reply to ${name} with message_bot using bot_id ${id}. Delivery is asynchronous, but sending does not end your turn: continue work that does not depend on their reply, and send another update later when it adds new information. Tell your user only when you have a real result to share. If it is just an FYI with nothing for you to do, staying silent is fine — do not reply only to acknowledge it.`,
   ].join("\n");
 }

--- a/packages/core/src/bot-messages.ts
+++ b/packages/core/src/bot-messages.ts
@@ -79,7 +79,7 @@ export function renderBotDirectory(bots: readonly BotAddress[]): string | undefi
     "<teammate_directory>",
     ...lines,
     "</teammate_directory>",
-    "Use message_bot for useful updates, questions, and results. Delivery is asynchronous and does not end your turn: continue work that does not depend on the reply, and send later updates when they add new information. Never poll or send acknowledgement-only messages.",
+    "Use message_bot for useful updates, questions, and results. Delivery is async and does not end your turn. Continue independent work; do not poll or send ack-only messages. Later updates only if they add something new.",
   ].join("\n");
 }
 
@@ -112,6 +112,6 @@ export function buildBotMessageWakePrompt(args: { from: BotAddress; text: string
     escapePromptData(args.text),
     "</bot_message>",
     "",
-    `If it needs a reply or an action, handle it: reply to ${name} with message_bot using bot_id ${id}. Delivery is asynchronous, but sending does not end your turn: continue work that does not depend on their reply, and send another update later when it adds new information. Tell your user only when you have a real result to share. If it is just an FYI with nothing for you to do, staying silent is fine — do not reply only to acknowledge it.`,
+    `If it needs a reply or an action, handle it: reply to ${name} with message_bot using bot_id ${id}. Sending does not end your turn: continue independent work, and send another update later only if it adds something new. Tell your user only when you have a real result. For an FYI with nothing to do, staying silent is fine; do not reply only to acknowledge.`,
   ].join("\n");
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes PR 306 (fork was not pushable). Builds on @luinbytes's work.

## Summary

- Tool-only Pi turns no longer get a fake `I finished the work.` line; they end with tool activity as-is
- Empty model output (no text, no tools) shows `No response. Try again.` on normal turns
- Bot-message wakes set `allowSilentEmpty` so tool-less FYI silence stays silent (no retry line, no executor `done.`)
- Whitespace-only model output is treated as empty for that path
- Executor keeps visible tool/step segments and only appends `done.` when the run produced nothing (unless silent empty is allowed)
- Finish notifications use finalized text segments (no `"done."` body for tool-only runs)
- `message_bot` tool/directory/wake/result copy: async delivery does not end the turn; later updates only if they add something new; no em dashes in the rewritten strings

## `done` without text

`AgentRuntimeEvent` already types `done.text` as optional. The executor only uses `event.text` when present (`if (!assembled && event.text)`), so omitting `text` on tool-only completion is safe.

## Verification

- `packages/adapters` bot-messages / executor-completion / pi-runtime-tool-dispatch
- `packages/core` bot-messages

Co-authored-by: luinbytes <42706009+luinbytes@users.noreply.github.com>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8da554e3-2547-49e3-8f15-1a75d3aedaab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8da554e3-2547-49e3-8f15-1a75d3aedaab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified that bot messages are delivered asynchronously and do not end ongoing work.
  * Bots are guided to continue independently, avoid polling or acknowledgment-only updates, and send follow-ups only when they add new information.
  * Improved completion handling so tool-only activity does not produce misleading completion messages.

* **Bug Fixes**
  * Empty responses now provide a clearer retry prompt instead of an inaccurate completion statement.
  * Completion notifications are omitted when no user-facing message is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->