### PR TITLE
Add an organic avatar style preference

### DIFF
--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createRouter, type RouterDeps } from "./router.js";
 
 describe("account preferences", () => {
-  it("persists and returns the selected avatar style", async () => {
+  function preferencesDeps(avatarStyle: string) {
     const update = vi.fn().mockResolvedValue({});
     const prisma = {
       user: {
@@ -13,7 +13,7 @@ describe("account preferences", () => {
         findUniqueOrThrow: vi.fn().mockResolvedValue({
           email: "user@rakazo.test",
           name: "Test User",
-          avatarStyle: "organic",
+          avatarStyle,
         }),
       },
       userModelCredential: { findFirst: vi.fn().mockResolvedValue(null) },
@@ -36,7 +36,11 @@ describe("account preferences", () => {
       email: "user@rakazo.test",
       isDeploymentOwner: true,
     } satisfies Actor;
-    const handler = new RPCHandler(createRouter(deps));
+    return { update, deps, actor, handler: new RPCHandler(createRouter(deps)) };
+  }
+
+  it("persists and returns the selected avatar style", async () => {
+    const { update, actor, handler } = preferencesDeps("organic");
 
     const { response } = await handler.handle(
       new Request("http://127.0.0.1/rpc/preferences/update", {
@@ -54,6 +58,40 @@ describe("account preferences", () => {
     });
     await expect(response.json()).resolves.toEqual({
       json: expect.objectContaining({ avatarStyle: "organic" }),
+    });
+  });
+
+  it("rejects avatar styles outside robot|organic", async () => {
+    const { update, actor, handler } = preferencesDeps("robot");
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/preferences/update", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { avatarStyle: "dicebear" } }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("coerces unknown stored avatar styles to robot on me", async () => {
+    const { actor, handler } = preferencesDeps("custom-cdn");
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/me", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: null }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      json: expect.objectContaining({ avatarStyle: "robot" }),
     });
   });
 });

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -4,6 +4,60 @@ import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import { createRouter, type RouterDeps } from "./router.js";
 
+describe("account preferences", () => {
+  it("persists and returns the selected avatar style", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    const prisma = {
+      user: {
+        update,
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          email: "user@rakazo.test",
+          name: "Test User",
+          avatarStyle: "organic",
+        }),
+      },
+      userModelCredential: { findFirst: vi.fn().mockResolvedValue(null) },
+      deploymentSettings: { findUnique: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+    const deps = {
+      prisma,
+      env: {
+        defaultProvider: "fake",
+        defaultModel: "fake-model",
+        webOrigin: "http://127.0.0.1:5173",
+        screenProxySecret: "fake-test-secret",
+        sandboxProvider: "fake",
+      },
+      dataDir: "/tmp/rakazo-router-test",
+    } as unknown as RouterDeps;
+    const actor = {
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      email: "user@rakazo.test",
+      isDeploymentOwner: true,
+    } satisfies Actor;
+    const handler = new RPCHandler(createRouter(deps));
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/preferences/update", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { avatarStyle: "organic" } }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { avatarStyle: "organic" },
+    });
+    await expect(response.json()).resolves.toEqual({
+      json: expect.objectContaining({ avatarStyle: "organic" }),
+    });
+  });
+});
+
 describe("thread answer delivery", () => {
   it("accepts a durable answer when the immediate worker wake fails", async () => {
     const answerRunInput = vi.fn().mockResolvedValue(true);

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -333,6 +333,15 @@ export function createRouter(deps: RouterDeps) {
   return os.router({
     health: os.health.handler(async () => ({ ok: true as const, version: "0.1.0" })),
     me: authed.me.handler(async ({ context }): Promise<Me> => meDto(deps, context.actor)),
+    preferences: {
+      update: authed.preferences.update.handler(async ({ context, input }): Promise<Me> => {
+        await deps.prisma.user.update({
+          where: { id: context.actor.userId },
+          data: { avatarStyle: input.avatarStyle },
+        });
+        return meDto(deps, context.actor);
+      }),
+    },
     bootstrap: authed.bootstrap.handler(async ({ context, input }) => {
       const actor = context.actor;
       const [me, bots, botSections, archivedBots] = await Promise.all([
@@ -2911,6 +2920,7 @@ async function meDto(deps: RouterDeps, actor: Actor): Promise<Me> {
     defaultModel: cred?.defaultModel ?? settings?.defaultModelId ?? deps.env.defaultModel,
     computerHost: computerHostFor(settings?.computerHost, deps.env.sandboxProvider),
     canChooseHostComputer: actor.isDeploymentOwner && deps.env.sandboxProvider === "docker",
+    avatarStyle: user.avatarStyle === "organic" ? "organic" : "robot",
   };
 }
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -3,6 +3,7 @@ import { StatusBar } from "expo-status-bar";
 import { useEffect, useState } from "react";
 import { View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { AvatarStyleProvider } from "../components/avatar-style";
 import { loadApiBase } from "../lib/api";
 import { applyMobileUiDirection } from "../lib/ui-direction";
 
@@ -18,48 +19,50 @@ export default function Layout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       {ready ? (
-        <ThemeProvider value={DarkTheme}>
-          <StatusBar style="light" />
-          <Stack
-            screenOptions={{
-              headerStyle: { backgroundColor: "#000" },
-              headerTintColor: "#ECECEE",
-              headerShadowVisible: false,
-              headerBackButtonDisplayMode: "minimal",
-              contentStyle: { backgroundColor: "#000" },
-            }}
-          >
-            <Stack.Screen name="index" options={{ headerShown: false, title: "Rakazo" }} />
-            <Stack.Screen name="sign-in" options={{ headerShown: false }} />
-            <Stack.Screen name="account" options={{ title: "Account" }} />
-            <Stack.Screen name="models" options={{ title: "Models" }} />
-            <Stack.Screen name="voice" options={{ title: "Voice" }} />
-            <Stack.Screen name="integrations" options={{ title: "Integrations" }} />
-            <Stack.Screen
-              name="new"
-              options={{
-                title: "New bot",
-                presentation: "modal",
-                gestureEnabled: true,
-                headerBackVisible: false,
+        <AvatarStyleProvider>
+          <ThemeProvider value={DarkTheme}>
+            <StatusBar style="light" />
+            <Stack
+              screenOptions={{
+                headerStyle: { backgroundColor: "#000" },
+                headerTintColor: "#ECECEE",
+                headerShadowVisible: false,
+                headerBackButtonDisplayMode: "minimal",
+                contentStyle: { backgroundColor: "#000" },
               }}
-            />
-            <Stack.Screen
-              name="new-group"
-              options={{
-                title: "New group",
-                presentation: "modal",
-                gestureEnabled: true,
-              }}
-            />
-            <Stack.Screen name="group-thread" options={{ title: "Group" }} />
-            <Stack.Screen name="group-settings" options={{ title: "Group settings" }} />
-            <Stack.Screen name="bot-settings" options={{ title: "Chat settings" }} />
-            <Stack.Screen name="thread" options={{ title: "Thread" }} />
-            <Stack.Screen name="routine" options={{ title: "Routine" }} />
-            <Stack.Screen name="computer" options={{ title: "Computer" }} />
-          </Stack>
-        </ThemeProvider>
+            >
+              <Stack.Screen name="index" options={{ headerShown: false, title: "Rakazo" }} />
+              <Stack.Screen name="sign-in" options={{ headerShown: false }} />
+              <Stack.Screen name="account" options={{ title: "Account" }} />
+              <Stack.Screen name="models" options={{ title: "Models" }} />
+              <Stack.Screen name="voice" options={{ title: "Voice" }} />
+              <Stack.Screen name="integrations" options={{ title: "Integrations" }} />
+              <Stack.Screen
+                name="new"
+                options={{
+                  title: "New bot",
+                  presentation: "modal",
+                  gestureEnabled: true,
+                  headerBackVisible: false,
+                }}
+              />
+              <Stack.Screen
+                name="new-group"
+                options={{
+                  title: "New group",
+                  presentation: "modal",
+                  gestureEnabled: true,
+                }}
+              />
+              <Stack.Screen name="group-thread" options={{ title: "Group" }} />
+              <Stack.Screen name="group-settings" options={{ title: "Group settings" }} />
+              <Stack.Screen name="bot-settings" options={{ title: "Chat settings" }} />
+              <Stack.Screen name="thread" options={{ title: "Thread" }} />
+              <Stack.Screen name="routine" options={{ title: "Routine" }} />
+              <Stack.Screen name="computer" options={{ title: "Computer" }} />
+            </Stack>
+          </ThemeProvider>
+        </AvatarStyleProvider>
       ) : (
         <View style={{ flex: 1, backgroundColor: "#000" }} />
       )}

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -1,3 +1,4 @@
+import type { AvatarStyle } from "@rakazo/contracts";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import {
@@ -11,6 +12,8 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { useAvatarStyle } from "../components/avatar-style";
+import { BotAvatar } from "../components/bot-avatar";
 import type { MobileBot } from "../lib/api";
 import { deleteAccount, type MobileMe, rpc, signOut } from "../lib/api";
 import { confirmDeleteBot } from "../lib/bot-lifecycle";
@@ -22,6 +25,8 @@ export default function Account() {
   const [me, setMe] = useState<MobileMe | null>(null);
   const [password, setPassword] = useState("");
   const [pending, setPending] = useState(false);
+  const [avatarPending, setAvatarPending] = useState(false);
+  const [avatarError, setAvatarError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [archivedBots, setArchivedBots] = useState<MobileBot[]>([]);
   const [usage, setUsage] = useState<{
@@ -29,6 +34,7 @@ export default function Account() {
     inputTokens: number;
     outputTokens: number;
   } | null>(null);
+  const { avatarStyle, updateAvatarStyle } = useAvatarStyle();
 
   useEffect(() => {
     void rpc<MobileMe>("me")
@@ -63,6 +69,21 @@ export default function Account() {
         "Could not restore bot",
         restoreError instanceof Error ? restoreError.message : "Try again.",
       );
+    }
+  }
+
+  async function selectAvatarStyle(next: AvatarStyle) {
+    if (next === avatarStyle) return;
+    setAvatarPending(true);
+    setAvatarError(null);
+    try {
+      await updateAvatarStyle(next);
+    } catch (updateError) {
+      setAvatarError(
+        updateError instanceof Error ? updateError.message : "Could not update avatar style",
+      );
+    } finally {
+      setAvatarPending(false);
     }
   }
 
@@ -112,6 +133,39 @@ export default function Account() {
           {me?.email ? <Text style={styles.email}>{me.email}</Text> : null}
         </View>
         {focus !== "usage" ? usageBlock : null}
+
+        <View accessibilityLabel="Avatar style" style={styles.avatarSection}>
+          <Text style={styles.settingsTitle}>Avatars</Text>
+          <View style={styles.avatarOptions}>
+            {(["robot", "organic"] as const).map((style) => {
+              const selected = avatarStyle === style;
+              return (
+                <Pressable
+                  key={style}
+                  accessibilityLabel={`${style === "robot" ? "Robot" : "Organic"} avatars`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected, disabled: avatarPending }}
+                  disabled={avatarPending}
+                  onPress={() => void selectAvatarStyle(style)}
+                  style={({ pressed }) => [
+                    styles.avatarOption,
+                    selected && styles.avatarOptionSelected,
+                    pressed && styles.pressed,
+                  ]}
+                >
+                  <BotAvatar
+                    color={style === "robot" ? "#8B5CF6" : "#D62F8B"}
+                    identity="avatar-preview"
+                    size={42}
+                    variant={style}
+                  />
+                  <Text style={styles.avatarLabel}>{style === "robot" ? "Robot" : "Organic"}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          {avatarError ? <Text style={styles.error}>{avatarError}</Text> : null}
+        </View>
 
         <Pressable
           accessibilityRole="button"
@@ -310,6 +364,35 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
+  },
+  avatarSection: {
+    borderRadius: 16,
+    backgroundColor: native.fill,
+    padding: 18,
+    gap: 14,
+  },
+  avatarOptions: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  avatarOption: {
+    flex: 1,
+    minHeight: 86,
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: native.tertiaryLabel,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+  },
+  avatarOptionSelected: {
+    borderColor: native.label,
+    backgroundColor: native.fillPressed,
+  },
+  avatarLabel: {
+    color: native.label,
+    fontSize: 14,
+    fontWeight: "600",
   },
   settingsTitle: {
     color: native.label,

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -78,10 +78,8 @@ export default function Account() {
     setAvatarError(null);
     try {
       await updateAvatarStyle(next);
-    } catch (updateError) {
-      setAvatarError(
-        updateError instanceof Error ? updateError.message : "Could not update avatar style",
-      );
+    } catch {
+      setAvatarError("Couldn't update avatars");
     } finally {
       setAvatarPending(false);
     }

--- a/apps/mobile/app/group-settings.tsx
+++ b/apps/mobile/app/group-settings.tsx
@@ -112,7 +112,7 @@ export default function GroupSettingsScreen() {
               onPress={() => toggle(bot.id)}
               style={{ flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 12 }}
             >
-              <BotAvatar color={bot.color} size={34} status={bot.status} />
+              <BotAvatar color={bot.color} identity={bot.id} size={34} status={bot.status} />
               <Text style={{ flex: 1, color: "#ECECEE", fontSize: 16 }}>{bot.name}</Text>
               <Text style={{ color: "#6C6C70" }}>{checked ? "✓" : ""}</Text>
             </Pressable>

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -508,7 +508,7 @@ function BotRow({ bot, onLongPress }: { bot: MobileBot; onLongPress: () => void 
       onLongPress={onLongPress}
       style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
     >
-      <BotAvatar color={bot.color || FALLBACK_COLOR} status={bot.status} />
+      <BotAvatar color={bot.color || FALLBACK_COLOR} identity={bot.id} status={bot.status} />
       <View style={styles.rowBody}>
         <View style={styles.rowTop}>
           <View style={styles.titleRow}>

--- a/apps/mobile/app/new-group.tsx
+++ b/apps/mobile/app/new-group.tsx
@@ -91,7 +91,7 @@ export default function NewGroup() {
                 paddingVertical: 12,
               }}
             >
-              <BotAvatar color={bot.color} size={34} status={bot.status} />
+              <BotAvatar color={bot.color} identity={bot.id} size={34} status={bot.status} />
               <Text style={{ flex: 1, color: "#ECECEE", fontSize: 16 }}>{bot.name}</Text>
               <Text style={{ color: "#6C6C70" }}>{checked ? "✓" : ""}</Text>
             </Pressable>

--- a/apps/mobile/components/avatar-style.tsx
+++ b/apps/mobile/components/avatar-style.tsx
@@ -1,0 +1,36 @@
+import type { AvatarStyle, Me } from "@rakazo/contracts";
+import { usePathname } from "expo-router";
+import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import { rpc } from "../lib/api";
+
+const AvatarStyleContext = createContext<{
+  avatarStyle: AvatarStyle;
+  updateAvatarStyle: (avatarStyle: AvatarStyle) => Promise<void>;
+}>({
+  avatarStyle: "robot",
+  updateAvatarStyle: async () => undefined,
+});
+
+export function AvatarStyleProvider({ children }: { children: ReactNode }) {
+  const [avatarStyle, setAvatarStyle] = useState<AvatarStyle>("robot");
+  const pathname = usePathname();
+
+  useEffect(() => {
+    void rpc<Me>("me")
+      .then((me) => setAvatarStyle(me.avatarStyle))
+      .catch(() => undefined);
+  }, [pathname]);
+
+  async function updateAvatarStyle(next: AvatarStyle) {
+    const me = await rpc<Me>("preferences/update", { avatarStyle: next });
+    setAvatarStyle(me.avatarStyle);
+  }
+
+  return (
+    <AvatarStyleContext value={{ avatarStyle, updateAvatarStyle }}>{children}</AvatarStyleContext>
+  );
+}
+
+export function useAvatarStyle() {
+  return useContext(AvatarStyleContext);
+}

--- a/apps/mobile/components/avatar-style.tsx
+++ b/apps/mobile/components/avatar-style.tsx
@@ -1,6 +1,6 @@
 import type { AvatarStyle, Me } from "@rakazo/contracts";
 import { usePathname } from "expo-router";
-import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import { createContext, type ReactNode, useContext, useEffect, useRef, useState } from "react";
 import { rpc } from "../lib/api";
 
 const AvatarStyleContext = createContext<{
@@ -14,15 +14,23 @@ const AvatarStyleContext = createContext<{
 export function AvatarStyleProvider({ children }: { children: ReactNode }) {
   const [avatarStyle, setAvatarStyle] = useState<AvatarStyle>("robot");
   const pathname = usePathname();
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
+    const requestId = ++requestIdRef.current;
     void rpc<Me>("me")
-      .then((me) => setAvatarStyle(me.avatarStyle))
+      .then((me) => {
+        if (requestId !== requestIdRef.current) return;
+        setAvatarStyle(me.avatarStyle);
+      })
       .catch(() => undefined);
   }, [pathname]);
 
   async function updateAvatarStyle(next: AvatarStyle) {
+    const requestId = ++requestIdRef.current;
+    setAvatarStyle(next);
     const me = await rpc<Me>("preferences/update", { avatarStyle: next });
+    if (requestId !== requestIdRef.current) return;
     setAvatarStyle(me.avatarStyle);
   }
 

--- a/apps/mobile/components/bot-avatar.tsx
+++ b/apps/mobile/components/bot-avatar.tsx
@@ -1,17 +1,63 @@
-import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
+import type { AvatarStyle } from "@rakazo/contracts";
+import { ACTIVE_RUN_STATUSES, avatarIdentitySeed, organicAvatarPath } from "@rakazo/core";
 import { memo } from "react";
 import { View } from "react-native";
+import Svg, { Path, Rect } from "react-native-svg";
+import { useAvatarStyle } from "./avatar-style";
 
 export const BotAvatar = memo(function BotAvatar({
   color,
   size = 54,
   status,
+  identity,
+  variant,
 }: {
   color: string;
   size?: number;
   status?: string;
+  identity?: string;
+  variant?: AvatarStyle;
 }) {
   const isWorking = ACTIVE_RUN_STATUSES.some((activeStatus) => activeStatus === status);
+  const { avatarStyle } = useAvatarStyle();
+  if ((variant ?? avatarStyle) === "organic") {
+    const seed = avatarIdentitySeed(identity || color || "#8B5CF6");
+    return (
+      <View
+        style={{
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          borderWidth: isWorking ? 2 : 0,
+          borderColor: "#FFFFFF",
+        }}
+      >
+        <Svg width={size} height={size} viewBox="-60 -60 120 120">
+          <Path d={organicAvatarPath(seed)} fill={color} />
+          <Rect
+            x={-14}
+            y={-12}
+            width={7}
+            height={24}
+            rx={3.5}
+            fill="#101014"
+            rotation={(seed % 9) - 4}
+            origin="0, 0"
+          />
+          <Rect
+            x={7}
+            y={-12}
+            width={7}
+            height={24}
+            rx={3.5}
+            fill="#101014"
+            rotation={(seed % 9) - 4}
+            origin="0, 0"
+          />
+        </Svg>
+      </View>
+    );
+  }
   const visorW = Math.round(size * 0.68);
   const visorH = Math.round(size * 0.44);
   const eyeW = Math.max(3, Math.round(size * 0.11));

--- a/apps/mobile/components/group-avatar.tsx
+++ b/apps/mobile/components/group-avatar.tsx
@@ -35,7 +35,14 @@ export const GroupAvatar = memo(function GroupAvatar({
   }
 
   if (members.length === 1) {
-    return <BotAvatar color={firstMember.color} size={size} status={firstMember.status} />;
+    return (
+      <BotAvatar
+        color={firstMember.color}
+        identity={firstMember.botId ?? firstMember.name}
+        size={size}
+        status={firstMember.status}
+      />
+    );
   }
 
   const pair = members.length === 2;
@@ -66,7 +73,12 @@ export const GroupAvatar = memo(function GroupAvatar({
             borderColor: "#121215",
           }}
         >
-          <BotAvatar color={member.color} size={miniSize} status={member.status} />
+          <BotAvatar
+            color={member.color}
+            identity={member.botId ?? member.name}
+            size={miniSize}
+            status={member.status}
+          />
         </View>
       ))}
       {members.length > 3 ? (

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -163,7 +163,13 @@ export type MobileBotSection = BotSection;
 
 export type MobileMe = Pick<
   Me,
-  "name" | "email" | "workspaceId" | "defaultProvider" | "defaultModel" | "needsModel"
+  | "name"
+  | "email"
+  | "workspaceId"
+  | "defaultProvider"
+  | "defaultModel"
+  | "needsModel"
+  | "avatarStyle"
 >;
 
 export type MobileModel = ModelCatalogEntry;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -41,6 +41,7 @@
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.26.0",
+    "react-native-svg": "15.15.4",
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.16.1",
     "react-native-worklets": "0.10.1"

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -418,7 +418,7 @@ msgstr "Autorisieren"
 
 #: src/pages/AccountSettingsOverlay.tsx:133
 msgid "Avatars"
-msgstr "Avatare"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -953,10 +953,6 @@ msgstr "Aktualisierung fehlgeschlagen"
 msgid "Could not update agent access"
 msgstr "Agent-Zugriff konnte nicht aktualisiert werden"
 
-#: src/pages/AccountSettingsOverlay.tsx:80
-msgid "Could not update avatar style"
-msgstr "Avatarstil konnte nicht aktualisiert werden"
-
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr ""
@@ -964,6 +960,10 @@ msgstr ""
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "Standardbereich für Erinnerungen konnte nicht aktualisiert werden"
+
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Couldn't update avatars"
+msgstr ""
 
 #: src/pages/Shell.tsx:1761
 #: src/pages/Shell.tsx:4361
@@ -1832,7 +1832,7 @@ msgstr "Oder einen API-Schlüssel einfügen"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Organic"
-msgstr "Organisch"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -2045,7 +2045,7 @@ msgstr "Zurück zu Rakazo"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Robot"
-msgstr "Roboter"
+msgstr ""
 
 #: src/pages/Shell.tsx:2554
 #: src/pages/Shell.tsx:2607

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1857
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (ungelesen)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5204
+#: src/pages/Shell.tsx:5233
 msgid "{0} connection"
 msgstr "{0}-Verbindung"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2341
+#: src/pages/Shell.tsx:2356
 msgid "{0} is using it"
 msgstr "{0} verwendet es"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2061
+#: src/pages/AccountSettingsOverlay.tsx:180
+#: src/pages/Shell.tsx:2071
 msgid "{0} runs · {1} tokens"
 msgstr "{0} Läufe · {1} Tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# verbundener Bot} other {# verbundene Bot
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} hat noch keinem anderen Bot eine Nachricht gesendet."
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "{botName}’s computer"
 msgstr "Computer von {botName}"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3371
+#: src/pages/Shell.tsx:3400
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ Aufgabe anlernen"
 msgid "Access token (optional)"
 msgstr "Zugriffstoken (optional)"
 
-#: src/pages/AccountSettingsOverlay.tsx:97
+#: src/pages/AccountSettingsOverlay.tsx:118
 msgid "Account"
 msgstr "Konto"
 
-#: src/pages/Shell.tsx:4590
+#: src/pages/Shell.tsx:4619
 msgid "Account default"
 msgstr "Kontostandard"
 
-#: src/pages/AccountSettingsOverlay.tsx:82
+#: src/pages/AccountSettingsOverlay.tsx:103
 msgid "Account preferences apply across all your bots."
 msgstr "Kontoeinstellungen gelten für alle deine Bots."
 
@@ -218,10 +218,10 @@ msgstr "Treg hinzufügen"
 msgid "Adding…"
 msgstr "Wird hinzugefügt…"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4522
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -229,7 +229,7 @@ msgstr "Erweitert"
 msgid "Agent access for new servers"
 msgstr "Agent-Zugriff für neue Server"
 
-#: src/pages/Shell.tsx:2148
+#: src/pages/Shell.tsx:2163
 msgid "Agent computer"
 msgstr "Agent-Computer"
 
@@ -316,11 +316,11 @@ msgstr "Gilt beim Hinzufügen des Servers. Mit den Agent-Chips auf jeder Serverk
 msgid "Approval boundaries"
 msgstr "Bestätigungsgrenzen"
 
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: src/pages/Shell.tsx:5388
+#: src/pages/Shell.tsx:5417
 msgid "Approve this server to let your agent use its tools."
 msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 
@@ -328,15 +328,15 @@ msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 msgid "Archive"
 msgstr "Archivieren"
 
-#: src/pages/Shell.tsx:4037
+#: src/pages/Shell.tsx:4066
 msgid "archived"
 msgstr "archiviert"
 
-#: src/pages/Shell.tsx:1941
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "Archiviert"
 
-#: src/pages/Shell.tsx:4048
+#: src/pages/Shell.tsx:4077
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archiviert. Chat, Erinnerungen und Dateien bleiben erhalten."
 
@@ -375,7 +375,7 @@ msgstr "Vor Käufen nachfragen"
 msgid "Ask before sending external email"
 msgstr "Vor dem Senden externer E-Mails nachfragen"
 
-#: src/pages/Shell.tsx:2343
+#: src/pages/Shell.tsx:2358
 msgid "Asleep"
 msgstr "Im Ruhezustand"
 
@@ -390,11 +390,11 @@ msgstr "um {0}"
 msgid "at {timeSelect}"
 msgstr "um {timeSelect}"
 
-#: src/pages/Shell.tsx:3442
+#: src/pages/Shell.tsx:3471
 msgid "Attach file"
 msgstr "Datei anhängen"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3670
 msgid "Attachment"
 msgstr "Anhang"
 
@@ -407,14 +407,18 @@ msgstr "Autorisierungscode oder Callback-URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Autorisierung abgelaufen — erneute Verbindung erforderlich"
 
-#: src/pages/Shell.tsx:5189
+#: src/pages/Shell.tsx:5218
 msgid "Authorization timed out. Please try again."
 msgstr "Zeitüberschreitung bei der Autorisierung. Versuche es erneut."
 
-#: src/pages/Shell.tsx:5231
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5426
 msgid "Authorize"
 msgstr "Autorisieren"
+
+#: src/pages/AccountSettingsOverlay.tsx:133
+msgid "Avatars"
+msgstr "Avatare"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -424,18 +428,18 @@ msgstr "Basis-URL"
 msgid "Bearer token"
 msgstr "Bearer-Token"
 
-#: src/pages/Shell.tsx:5073
+#: src/pages/Shell.tsx:5102
 msgid "Booting live desktop…"
 msgstr "Live-Desktop wird gestartet…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2903
 msgid "Booting up {0}’s computer"
 msgstr "Computer von {0} wird gestartet"
 
-#: src/pages/Shell.tsx:3907
-#: src/pages/Shell.tsx:3908
-#: src/pages/Shell.tsx:4041
+#: src/pages/Shell.tsx:3936
+#: src/pages/Shell.tsx:3937
+#: src/pages/Shell.tsx:4070
 msgid "bot"
 msgstr "Bot"
 
@@ -447,11 +451,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot-Nachrichten"
 
-#: src/pages/Shell.tsx:2975
+#: src/pages/Shell.tsx:3000
 msgid "Bot screen"
 msgstr "Bot-Bildschirm"
 
-#: src/pages/Shell.tsx:2311
+#: src/pages/Shell.tsx:2326
 msgid "Bot screen preview"
 msgstr "Bot-Bildschirmvorschau"
 
@@ -464,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Verwende deinen eigenen Schlüssel. Der Anbieter ist austauschbar; die Schaltflächen zum Sprechen und Anrufen deiner Bots bleiben gleich."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2130
-#: src/pages/Shell.tsx:2131
+#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2146
 msgid "Call"
 msgstr "Anrufen"
 
@@ -477,14 +481,14 @@ msgstr "Server nicht erreichbar."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4829
-#: src/pages/Shell.tsx:4944
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4858
+#: src/pages/Shell.tsx:4973
+#: src/pages/Shell.tsx:5047
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/pages/Shell.tsx:4285
+#: src/pages/Shell.tsx:4314
 msgid "Cancel new bot"
 msgstr "Neuen Bot abbrechen"
 
@@ -492,7 +496,7 @@ msgstr "Neuen Bot abbrechen"
 msgid "Cancel new group"
 msgstr "Neue Gruppe abbrechen"
 
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3347
 msgid "Cancel reply"
 msgstr "Antwort abbrechen"
 
@@ -500,16 +504,16 @@ msgstr "Antwort abbrechen"
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/pages/Shell.tsx:5294
+#: src/pages/Shell.tsx:5323
 msgid "Chart failed to render: {error}"
 msgstr "Diagramm konnte nicht angezeigt werden: {error}"
 
-#: src/pages/Shell.tsx:3584
+#: src/pages/Shell.tsx:3613
 msgid "Chat Settings"
 msgstr "Chat-Einstellungen"
 
-#: src/pages/Shell.tsx:2593
-#: src/pages/Shell.tsx:2600
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:2615
 msgid "Check in."
 msgstr "Melde dich."
 
@@ -521,21 +525,21 @@ msgstr "Wähle zunächst ein Modell aus."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Wähle das verbundene Modell aus, das Rakazo verwendet."
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clear"
 msgstr "Leeren"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4839
 msgid "Clear {0}’s conversation?"
 msgstr "Unterhaltung mit {0} leeren?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4645
+#: src/pages/Shell.tsx:4674
 msgid "Clear conversation"
 msgstr "Unterhaltung leeren"
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clearing…"
 msgstr "Wird geleert…"
 
@@ -551,15 +555,15 @@ msgstr "Bot-Menü schließen"
 msgid "Close bot messages"
 msgstr "Bot-Nachrichten schließen"
 
-#: src/pages/Shell.tsx:5479
+#: src/pages/Shell.tsx:5508
 msgid "Close chart"
 msgstr "Diagramm schließen"
 
-#: src/pages/Shell.tsx:2949
+#: src/pages/Shell.tsx:2974
 msgid "Close computer"
 msgstr "Computer schließen"
 
-#: src/pages/Shell.tsx:5579
+#: src/pages/Shell.tsx:5608
 msgid "Close image preview"
 msgstr "Bildvorschau schließen"
 
@@ -583,7 +587,7 @@ msgstr "Modelleinstellungen schließen"
 msgid "Close navigation"
 msgstr "Navigation schließen"
 
-#: src/pages/Shell.tsx:2289
+#: src/pages/Shell.tsx:2304
 msgid "Close panel"
 msgstr "Panel schließen"
 
@@ -592,7 +596,7 @@ msgstr "Panel schließen"
 msgid "Close preview"
 msgstr "Vorschau schließen"
 
-#: src/pages/AccountSettingsOverlay.tsx:87
+#: src/pages/AccountSettingsOverlay.tsx:108
 msgid "Close user settings"
 msgstr "Benutzereinstellungen schließen"
 
@@ -612,24 +616,24 @@ msgstr "Befehl"
 msgid "Complete"
 msgstr "Abschließen"
 
-#: src/pages/Shell.tsx:4195
-#: src/pages/Shell.tsx:4223
+#: src/pages/Shell.tsx:4224
+#: src/pages/Shell.tsx:4252
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5076
+#: src/pages/Shell.tsx:5105
 msgid "Computer failed to boot"
 msgstr "Computer konnte nicht gestartet werden"
 
-#: src/pages/Shell.tsx:2997
+#: src/pages/Shell.tsx:3022
 msgid "Computer is asleep"
 msgstr "Computer ist im Ruhezustand"
 
-#: src/pages/Shell.tsx:5075
+#: src/pages/Shell.tsx:5104
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer schläft — übernimm die Kontrolle, um ihn zu wecken"
 
-#: src/pages/Shell.tsx:5077
+#: src/pages/Shell.tsx:5106
 msgid "Computer is stopped"
 msgstr "Computer ist gestoppt"
 
@@ -662,7 +666,7 @@ msgstr "API-Schlüssel verbinden"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI oder Cartesia verbinden"
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5406
 msgid "Connect MCP server “{name}”"
 msgstr "MCP-Server „{name}“ verbinden"
 
@@ -685,12 +689,12 @@ msgstr "Treg verbinden"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5228
+#: src/pages/Shell.tsx:5257
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Verbunden"
 
-#: src/pages/Shell.tsx:5407
+#: src/pages/Shell.tsx:5436
 msgid "Connected — its tools are available from your next message."
 msgstr "Verbunden – die Tools sind ab deiner nächsten Nachricht verfügbar."
 
@@ -715,7 +719,7 @@ msgstr "Verbunden, {0} wird verwendet."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Verbindung wird hergestellt…"
@@ -734,7 +738,7 @@ msgstr "Weiter"
 msgid "Continue with email"
 msgstr "Mit E-Mail fortfahren"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3721
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -746,11 +750,11 @@ msgstr "Hinzufügen fehlgeschlagen"
 msgid "Could not add MCP server"
 msgstr "MCP-Server konnte nicht hinzugefügt werden"
 
-#: src/pages/Shell.tsx:5364
+#: src/pages/Shell.tsx:5393
 msgid "Could not approve this server"
 msgstr "Server konnte nicht genehmigt werden"
 
-#: src/pages/Shell.tsx:5192
+#: src/pages/Shell.tsx:5221
 msgid "Could not authorize this app"
 msgstr "App konnte nicht autorisiert werden"
 
@@ -758,7 +762,7 @@ msgstr "App konnte nicht autorisiert werden"
 msgid "Could not change the default model"
 msgstr "Standardmodell konnte nicht geändert werden"
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4867
 msgid "Could not clear conversation"
 msgstr "Unterhaltung konnte nicht geleert werden"
 
@@ -787,7 +791,7 @@ msgstr "Stimmanbieter konnte nicht verbunden werden"
 msgid "Could not continue"
 msgstr "Fortfahren fehlgeschlagen"
 
-#: src/pages/Shell.tsx:4273
+#: src/pages/Shell.tsx:4302
 msgid "Could not create bot"
 msgstr "Bot konnte nicht erstellt werden"
 
@@ -795,7 +799,7 @@ msgstr "Bot konnte nicht erstellt werden"
 msgid "Could not create group"
 msgstr "Gruppe konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4758
 msgid "Could not create section"
 msgstr "Abschnitt konnte nicht erstellt werden"
 
@@ -803,7 +807,7 @@ msgstr "Abschnitt konnte nicht erstellt werden"
 msgid "Could not create your bot"
 msgstr "Dein Bot konnte nicht erstellt werden"
 
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4982
 msgid "Could not delete bot"
 msgstr "Bot konnte nicht gelöscht werden"
 
@@ -811,7 +815,7 @@ msgstr "Bot konnte nicht gelöscht werden"
 msgid "Could not delete MCP server"
 msgstr "MCP-Server konnte nicht gelöscht werden"
 
-#: src/pages/Shell.tsx:5027
+#: src/pages/Shell.tsx:5056
 msgid "Could not delete routine"
 msgstr "Routine konnte nicht gelöscht werden"
 
@@ -885,7 +889,7 @@ msgstr "Gruppe konnte nicht entfernt werden"
 msgid "Could not remove rule"
 msgstr "Regel konnte nicht entfernt werden"
 
-#: src/pages/Shell.tsx:5284
+#: src/pages/Shell.tsx:5313
 msgid "Could not render chart"
 msgstr "Diagramm konnte nicht angezeigt werden"
 
@@ -893,7 +897,7 @@ msgstr "Diagramm konnte nicht angezeigt werden"
 msgid "Could not revoke connection"
 msgstr "Verbindung konnte nicht widerrufen werden"
 
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4659
 msgid "Could not save"
 msgstr "Speichern fehlgeschlagen"
 
@@ -905,7 +909,7 @@ msgstr "Gruppe konnte nicht gespeichert werden"
 msgid "Could not save model"
 msgstr "Modell konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2630
 msgid "Could not save routine"
 msgstr "Routine konnte nicht gespeichert werden"
 
@@ -921,7 +925,7 @@ msgstr "Auswahl konnte nicht gespeichert werden"
 msgid "Could not save that voice"
 msgstr "Stimme konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5133
 msgid "Could not save this choice"
 msgstr "Diese Auswahl konnte nicht gespeichert werden"
 
@@ -949,6 +953,10 @@ msgstr "Aktualisierung fehlgeschlagen"
 msgid "Could not update agent access"
 msgstr "Agent-Zugriff konnte nicht aktualisiert werden"
 
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Could not update avatar style"
+msgstr "Avatarstil konnte nicht aktualisiert werden"
+
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr ""
@@ -958,13 +966,13 @@ msgid "Could not update the default memory scope"
 msgstr "Standardbereich für Erinnerungen konnte nicht aktualisiert werden"
 
 #: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Create"
 msgstr "Erstellen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4738
+#: src/pages/Shell.tsx:4767
 msgid "Create a section and move {0} into it."
 msgstr "Erstelle einen Abschnitt und verschiebe {0} dorthin."
 
@@ -985,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Dein Rakazo erstellen"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Creating…"
 msgstr "Wird erstellt…"
 
@@ -1014,7 +1022,7 @@ msgstr "Tag"
 msgid "days"
 msgstr "Tage"
 
-#: src/pages/Shell.tsx:4537
+#: src/pages/Shell.tsx:4566
 msgid "Default (medium)"
 msgstr "Standard (mittel)"
 
@@ -1024,21 +1032,21 @@ msgstr "Standardbereich"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1970
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:1980
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Delete"
 msgstr "Löschen"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1966
+#: src/pages/Shell.tsx:1976
 msgid "Delete {0}"
 msgstr "{0} löschen"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4891
-#: src/pages/Shell.tsx:5005
+#: src/pages/Shell.tsx:4920
+#: src/pages/Shell.tsx:5034
 msgid "Delete {0}?"
 msgstr "{0} löschen?"
 
@@ -1046,21 +1054,21 @@ msgstr "{0} löschen?"
 msgid "Delete group"
 msgstr "Gruppe löschen"
 
-#: src/pages/Shell.tsx:4928
+#: src/pages/Shell.tsx:4957
 msgid "Delete memories too"
 msgstr "Erinnerungen ebenfalls löschen"
 
-#: src/pages/Shell.tsx:2670
+#: src/pages/Shell.tsx:2685
 msgid "Delete routine"
 msgstr "Routine löschen"
 
-#: src/pages/Shell.tsx:4039
+#: src/pages/Shell.tsx:4068
 msgid "deleted"
 msgstr "gelöscht"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Deleting…"
 msgstr "Wird gelöscht…"
 
@@ -1077,17 +1085,17 @@ msgid "Deployment default"
 msgstr "Bereitstellungsstandard"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4310
+#: src/pages/Shell.tsx:4339
 msgid "Describe what this bot does"
 msgstr "Beschreibe, was dieser Bot macht"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4315
-#: src/pages/Shell.tsx:4481
+#: src/pages/Shell.tsx:4344
+#: src/pages/Shell.tsx:4510
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Dictate"
 msgstr "Diktieren"
 
@@ -1100,7 +1108,7 @@ msgstr "Trennen"
 msgid "Disconnecting…"
 msgstr "Verbindung wird getrennt…"
 
-#: src/pages/Shell.tsx:5412
+#: src/pages/Shell.tsx:5441
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Verworfen – du kannst die Verbindung jederzeit in den MCP-Einstellungen wiederherstellen."
 
@@ -1148,7 +1156,7 @@ msgstr "Skill-Entwurf"
 msgid "Duplicate"
 msgstr "Duplizieren"
 
-#: src/pages/Shell.tsx:3852
+#: src/pages/Shell.tsx:3881
 msgid "Earlier message"
 msgstr "Frühere Nachricht"
 
@@ -1204,11 +1212,11 @@ msgstr "Jeden Monat"
 msgid "Every week"
 msgstr "Jede Woche"
 
-#: src/pages/Shell.tsx:5458
+#: src/pages/Shell.tsx:5487
 msgid "Expand"
 msgstr "Erweitern"
 
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4671
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1216,7 +1224,7 @@ msgstr "Exportieren"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Exportiere die Liste dieser Woche aus dem CRM und lege sie im freigegebenen Ordner ab"
 
-#: src/pages/Shell.tsx:4662
+#: src/pages/Shell.tsx:4691
 msgid "Extra high"
 msgstr "Sehr hoch"
 
@@ -1267,8 +1275,8 @@ msgstr "Kostenlos"
 msgid "Fullscreen"
 msgstr "Vollbild"
 
-#: src/pages/Shell.tsx:2120
-#: src/pages/Shell.tsx:2271
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2286
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1297,15 +1305,15 @@ msgstr "Beispiel anhören"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hallo, so klinge ich, wenn ich Antworten vorlese."
 
-#: src/pages/Shell.tsx:4665
+#: src/pages/Shell.tsx:4694
 msgid "High"
 msgstr "Hoch"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk"
 msgstr "Zum Sprechen gedrückt halten"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk (on-device dictation)"
 msgstr "Zum Sprechen gedrückt halten (Diktat auf dem Gerät)"
 
@@ -1325,7 +1333,7 @@ msgstr "Wie oft"
 msgid "How to check"
 msgstr "So wird geprüft"
 
-#: src/pages/Shell.tsx:3748
+#: src/pages/Shell.tsx:3777
 msgid "I’m done"
 msgstr "Ich bin fertig"
 
@@ -1337,7 +1345,7 @@ msgstr "Wenn du das gehört hast, ist die Stimme einsatzbereit."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI-JSON importieren"
 
-#: src/pages/Shell.tsx:4552
+#: src/pages/Shell.tsx:4581
 msgid "Inherit default"
 msgstr "Standard übernehmen"
 
@@ -1349,12 +1357,12 @@ msgstr "Eingaben"
 msgid "Instance API key"
 msgstr "Instanz-API-Schlüssel"
 
-#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2569
 msgid "Instruction"
 msgstr "Anweisung"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1987
+#: src/pages/Shell.tsx:1997
 msgid "Integrations"
 msgstr "Integrationen"
 
@@ -1375,15 +1383,15 @@ msgid "Interval unit"
 msgstr "Intervalleinheit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4553
+#: src/pages/Shell.tsx:4582
 msgid "Isolated"
 msgstr "Isoliert"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4923
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von ihm erstellte Bots bleiben in deiner Liste."
 
-#: src/pages/Shell.tsx:3847
+#: src/pages/Shell.tsx:3876
 msgid "Jump to replied message"
 msgstr "Zur beantworteten Nachricht springen"
 
@@ -1391,7 +1399,7 @@ msgstr "Zur beantworteten Nachricht springen"
 msgid "just now"
 msgstr "gerade eben"
 
-#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:4941
 msgid "Keep memories"
 msgstr "Erinnerungen behalten"
 
@@ -1399,9 +1407,9 @@ msgstr "Erinnerungen behalten"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "Schlüssel bleiben auf dem Server. Die App erfährt nur, ob ein Anbieter konfiguriert ist."
 
-#: src/pages/AccountSettingsOverlay.tsx:105
-#: src/pages/AccountSettingsOverlay.tsx:254
-#: src/pages/AccountSettingsOverlay.tsx:271
+#: src/pages/AccountSettingsOverlay.tsx:126
+#: src/pages/AccountSettingsOverlay.tsx:313
+#: src/pages/AccountSettingsOverlay.tsx:330
 msgid "Language"
 msgstr "Sprache"
 
@@ -1409,7 +1417,7 @@ msgstr "Sprache"
 msgid "Listening…"
 msgstr "Hört zu…"
 
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Load earlier messages"
 msgstr "Frühere Nachrichten laden"
 
@@ -1449,7 +1457,7 @@ msgstr "Stimmanbieter werden geladen…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Loading…"
 msgstr "Wird geladen…"
 
@@ -1457,11 +1465,11 @@ msgstr "Wird geladen…"
 msgid "Local"
 msgstr "Lokal"
 
-#: src/pages/Shell.tsx:2073
+#: src/pages/Shell.tsx:2083
 msgid "Log out"
 msgstr "Abmelden"
 
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4692
 msgid "Low"
 msgstr "Niedrig"
 
@@ -1477,7 +1485,7 @@ msgstr "Als gelesen markieren"
 msgid "Mark as Unread"
 msgstr "Als ungelesen markieren"
 
-#: src/pages/Shell.tsx:4667
+#: src/pages/Shell.tsx:4696
 msgid "Max"
 msgstr "Max."
 
@@ -1487,7 +1495,7 @@ msgstr "Max."
 msgid "MCP servers"
 msgstr "MCP-Server"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4693
 msgid "Medium"
 msgstr "Mittel"
 
@@ -1500,33 +1508,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Mitglieder ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} auswählen)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2031
+#: src/pages/Shell.tsx:2041
 msgid "Memory"
 msgstr "Erinnerungen"
 
-#: src/pages/Shell.tsx:4548
+#: src/pages/Shell.tsx:4577
 msgid "Memory scope"
 msgstr "Erinnerungsbereich"
 
-#: src/pages/Shell.tsx:3548
-#: src/pages/Shell.tsx:3643
+#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3672
 msgid "Message"
 msgstr "Nachricht"
 
-#: src/pages/Shell.tsx:3544
-#: src/pages/Shell.tsx:3548
+#: src/pages/Shell.tsx:3573
+#: src/pages/Shell.tsx:3577
 msgid "Message {activeName}"
 msgstr "Nachricht an {activeName}"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Message from {peer}"
 msgstr "Nachricht von {peer}"
 
-#: src/pages/Shell.tsx:3545
+#: src/pages/Shell.tsx:3574
 msgid "Message…"
 msgstr "Nachricht…"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Messaged {peer}"
 msgstr "Nachricht an {peer} gesendet"
 
@@ -1534,7 +1542,7 @@ msgstr "Nachricht an {peer} gesendet"
 msgid "Microphone failed"
 msgstr "Mikrofonfehler"
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4695
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1556,7 +1564,7 @@ msgstr "Minuten"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4504
+#: src/pages/Shell.tsx:4533
 msgid "Model"
 msgstr "Modell"
 
@@ -1569,7 +1577,7 @@ msgstr "Modell-ID"
 msgid "Model options"
 msgstr "Modelloptionen"
 
-#: src/pages/AccountSettingsOverlay.tsx:127
+#: src/pages/AccountSettingsOverlay.tsx:186
 msgid "Model spend uses your provider keys."
 msgstr "Modellkosten werden über deine Anbieterschlüssel abgerechnet."
 
@@ -1578,7 +1586,7 @@ msgid "Model updated."
 msgstr "Modell aktualisiert."
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2018
+#: src/pages/Shell.tsx:2028
 msgid "Models"
 msgstr "Modelle"
 
@@ -1596,7 +1604,7 @@ msgstr "Monatlich"
 msgid "Move {0} to section"
 msgstr "{0} in Abschnitt verschieben"
 
-#: src/pages/Shell.tsx:4915
+#: src/pages/Shell.tsx:4944
 msgid "Move them to your shared memory."
 msgstr "Verschiebe sie in deine geteilten Erinnerungen."
 
@@ -1609,15 +1617,15 @@ msgstr "Verschieben nach"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2546
-#: src/pages/Shell.tsx:4295
-#: src/pages/Shell.tsx:4463
-#: src/pages/Shell.tsx:4741
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:4324
+#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4770
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4300
+#: src/pages/Shell.tsx:4329
 msgid "Name this bot"
 msgstr "Bot benennen"
 
@@ -1634,7 +1642,7 @@ msgid "Needs takeover"
 msgstr "Übernahme erforderlich"
 
 #: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4283
+#: src/pages/Shell.tsx:4312
 msgid "New bot"
 msgstr "Neuer Bot"
 
@@ -1647,12 +1655,12 @@ msgstr "Neue Gruppe"
 msgid "New open-work item"
 msgstr "Neuer offener Arbeitspunkt"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2447
 msgid "New routine"
 msgstr "Neue Routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4735
+#: src/pages/Shell.tsx:4764
 msgid "New section"
 msgstr "Neuer Abschnitt"
 
@@ -1730,7 +1738,7 @@ msgstr "Nicht verbunden"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5400
+#: src/pages/Shell.tsx:5429
 msgid "Not now"
 msgstr "Jetzt nicht"
 
@@ -1768,15 +1776,15 @@ msgstr "am 1. um {0}"
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Open computer"
 msgstr "Computer öffnen"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2315
 msgid "Open in full window"
 msgstr "In vollständigem Fenster öffnen"
 
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2107
 msgid "Open navigation"
 msgstr "Navigation öffnen"
 
@@ -1793,7 +1801,7 @@ msgstr "Offene Arbeit"
 msgid "OpenAI-compatible server URL"
 msgstr "URL eines OpenAI-kompatiblen Servers"
 
-#: src/pages/Shell.tsx:4050
+#: src/pages/Shell.tsx:4079
 msgid "Opened its thread."
 msgstr "Thread geöffnet."
 
@@ -1806,7 +1814,7 @@ msgstr "Dein Arbeitsbereich wird geöffnet…"
 msgid "Optional"
 msgstr "Optional"
 
-#: src/pages/AccountSettingsOverlay.tsx:141
+#: src/pages/AccountSettingsOverlay.tsx:200
 msgid "Optional controls most people never need"
 msgstr "Optionale Einstellungen, die die meisten nie benötigen"
 
@@ -1821,6 +1829,10 @@ msgstr "Oder einen API-Schlüssel verbinden"
 #: src/pages/Onboarding.tsx:464
 msgid "Or paste an API key"
 msgstr "Oder einen API-Schlüssel einfügen"
+
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Organic"
+msgstr "Organisch"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -1876,7 +1888,7 @@ msgstr "Wiedergabe…"
 msgid "Preview {0}"
 msgstr "Vorschau von {0}"
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Private"
 msgstr "Privat"
 
@@ -1897,7 +1909,7 @@ msgstr "In Warteschlange"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo prüft die Quelle vor dem Speichern. Zugangsdaten werden verschlüsselt und weder an Clients zurückgegeben noch dem Modell zugänglich gemacht."
 
-#: src/pages/Shell.tsx:4580
+#: src/pages/Shell.tsx:4609
 msgid "Read replies aloud"
 msgstr "Antworten vorlesen"
 
@@ -1931,7 +1943,7 @@ msgstr ""
 msgid "Recovering…"
 msgstr ""
 
-#: src/pages/Shell.tsx:3738
+#: src/pages/Shell.tsx:3767
 msgid "Release"
 msgstr "Freigeben"
 
@@ -1944,17 +1956,17 @@ msgid "Remove"
 msgstr "Entfernen"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3352
+#: src/pages/Shell.tsx:3381
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3507
+#: src/pages/Shell.tsx:3536
 msgid "Remove mention {0}"
 msgstr "Erwähnung von {0} entfernen"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3515
 msgid "Remove skill {0}"
 msgstr "Skill {0} entfernen"
 
@@ -1962,7 +1974,7 @@ msgstr "Skill {0} entfernen"
 msgid "Remove this schedule"
 msgstr "Diesen Zeitplan entfernen"
 
-#: src/pages/Shell.tsx:4049
+#: src/pages/Shell.tsx:4078
 msgid "Removed with chat, computer, and memory."
 msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 
@@ -1990,11 +2002,11 @@ msgstr "API-Schlüssel ersetzen"
 msgid "Replace key"
 msgstr "Schlüssel ersetzen"
 
-#: src/pages/Shell.tsx:3684
+#: src/pages/Shell.tsx:3713
 msgid "Reply"
 msgstr "Antworten"
 
-#: src/pages/Shell.tsx:3315
+#: src/pages/Shell.tsx:3344
 msgid "Replying to {replyName}"
 msgstr "Antwort an {replyName}"
 
@@ -2015,7 +2027,7 @@ msgstr ""
 msgid "Resetting…"
 msgstr ""
 
-#: src/pages/Shell.tsx:1962
+#: src/pages/Shell.tsx:1972
 msgid "Restore"
 msgstr "Wiederherstellen"
 
@@ -2031,17 +2043,21 @@ msgstr "Jetzt erneut versuchen"
 msgid "Return to Rakazo"
 msgstr "Zurück zu Rakazo"
 
-#: src/pages/Shell.tsx:2539
-#: src/pages/Shell.tsx:2592
-#: src/pages/Shell.tsx:2599
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Robot"
+msgstr "Roboter"
+
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2392
 msgid "Routines"
 msgstr "Routinen"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Run now"
 msgstr "Jetzt ausführen"
 
@@ -2049,11 +2065,11 @@ msgstr "Jetzt ausführen"
 msgid "Running"
 msgstr "Läuft"
 
-#: src/pages/Shell.tsx:2417
+#: src/pages/Shell.tsx:2432
 msgid "Running · Stop"
 msgstr "Wird ausgeführt · Stoppen"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Running…"
 msgstr "Wird ausgeführt…"
 
@@ -2061,8 +2077,8 @@ msgstr "Wird ausgeführt…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2638
-#: src/pages/Shell.tsx:4635
+#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:4664
 msgid "Save"
 msgstr "Speichern"
 
@@ -2086,7 +2102,7 @@ msgstr "Gespeichert."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2638
+#: src/pages/Shell.tsx:2653
 msgid "Saving…"
 msgstr "Wird gespeichert…"
 
@@ -2127,11 +2143,11 @@ msgstr "Anbieter und Modelle suchen"
 msgid "Searching…"
 msgstr "Suche…"
 
-#: src/pages/Shell.tsx:2121
+#: src/pages/Shell.tsx:2136
 msgid "Select a bot"
 msgstr "Bot auswählen"
 
-#: src/pages/Shell.tsx:3568
+#: src/pages/Shell.tsx:3597
 msgid "Send"
 msgstr "Senden"
 
@@ -2159,22 +2175,22 @@ msgstr "Servername"
 msgid "Server URL"
 msgstr "Server-URL"
 
-#: src/pages/Shell.tsx:2130
+#: src/pages/Shell.tsx:2145
 msgid "Set up voice to call"
 msgstr "Stimme für Anrufe einrichten"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1995
+#: src/pages/AccountSettingsOverlay.tsx:100
 #: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2267
+#: src/pages/Shell.tsx:2015
+#: src/pages/Shell.tsx:2282
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/pages/Shell.tsx:3586
+#: src/pages/Shell.tsx:3615
 msgid "Settings: General"
 msgstr "Einstellungen: Allgemein"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3617
 msgid "Settings: Usage"
 msgstr "Einstellungen: Nutzung"
 
@@ -2184,15 +2200,15 @@ msgid "Setup help"
 msgstr "Einrichtungshilfe"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4554
+#: src/pages/Shell.tsx:4583
 msgid "Shared"
 msgstr "Geteilt"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show computer"
 msgstr "Computer anzeigen"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show settings"
 msgstr "Einstellungen anzeigen"
 
@@ -2216,11 +2232,11 @@ msgid "Sign up"
 msgstr "Registrieren"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3399
+#: src/pages/Shell.tsx:3428
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3774
 msgid "Skip"
 msgstr "Überspringen"
 
@@ -2241,8 +2257,8 @@ msgstr "{0} übersprungen"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Leertaste unterbricht · Esc legt auf"
 
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Speak"
 msgstr "Vorlesen"
 
@@ -2254,8 +2270,8 @@ msgstr "Sprechen + transkribieren"
 msgid "Speak only"
 msgstr "Nur sprechen"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Speak this reply"
 msgstr "Diese Antwort vorlesen"
 
@@ -2281,20 +2297,20 @@ msgstr "Wird gestartet…"
 msgid "Steps"
 msgstr "Schritte"
 
-#: src/pages/Shell.tsx:2918
-#: src/pages/Shell.tsx:2922
-#: src/pages/Shell.tsx:3559
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2947
+#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Stop"
 msgstr "Stoppen"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Stop dictation"
 msgstr "Diktat stoppen"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Stop speaking"
 msgstr "Vorlesen stoppen"
 
@@ -2303,8 +2319,8 @@ msgstr "Vorlesen stoppen"
 msgid "Stop teaching"
 msgstr "Anlernen beenden"
 
-#: src/pages/Shell.tsx:2357
-#: src/pages/Shell.tsx:2938
+#: src/pages/Shell.tsx:2372
+#: src/pages/Shell.tsx:2963
 msgid "Stop the bot first"
 msgstr "Zuerst den Bot stoppen"
 
@@ -2312,7 +2328,7 @@ msgstr "Zuerst den Bot stoppen"
 msgid "Stored encrypted"
 msgstr "Verschlüsselt gespeichert"
 
-#: src/pages/Shell.tsx:4001
+#: src/pages/Shell.tsx:4030
 msgid "subagent"
 msgstr "Subagent"
 
@@ -2325,8 +2341,8 @@ msgstr "Absenden"
 msgid "Switching…"
 msgstr "Wird gewechselt…"
 
-#: src/pages/Shell.tsx:2360
-#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2375
+#: src/pages/Shell.tsx:2968
 msgid "Take control"
 msgstr "Kontrolle übernehmen"
 
@@ -2334,7 +2350,7 @@ msgstr "Kontrolle übernehmen"
 msgid "Teach a task"
 msgstr "Aufgabe anlernen"
 
-#: src/pages/Shell.tsx:2193
+#: src/pages/Shell.tsx:2208
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachricht sendest."
 
@@ -2342,11 +2358,11 @@ msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachr
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Zum Anlernen ist ein grafischer Sandbox-Computer erforderlich. Auf dem Desktop gehostete Bots können Shell-Aufgaben ausführen, aber keine Bildschirmaufnahmen erstellen."
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "Team Computer"
 msgstr "Team-Computer"
 
@@ -2359,20 +2375,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügbar."
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4560
 msgid "Thinking"
 msgstr "Denkmodus"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2319
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Dieser Bot wird auf diesem Computer und nicht auf einem Linux-Desktop ausgeführt. Shell und Dateien verwenden deinen persönlichen Ordner."
 
-#: src/pages/Shell.tsx:2967
+#: src/pages/Shell.tsx:2992
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Dieser Bot wird auf diesem Computer ausgeführt. Es gibt keinen separaten Linux-Desktop. Bitte ihn, die Shell zu verwenden; Arbeitsverzeichnisse in deinem persönlichen Ordner sind zulässig."
 
-#: src/pages/Shell.tsx:4931
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:4960
+#: src/pages/Shell.tsx:5037
 msgid "This cannot be undone."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
@@ -2396,7 +2412,7 @@ msgstr "dieser Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Dieser Mac führt Shell-Befehle mit deinem Konto aus und kann auf Dateien in deinem persönlichen Ordner zugreifen. Aktiviere dies nicht auf einem gemeinsam genutzten oder öffentlichen Server."
 
-#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4845
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbeit beendet. Bot, Computer, Erinnerungen und Routinen bleiben erhalten."
 
@@ -2404,7 +2420,7 @@ msgstr "Dadurch werden alle Nachrichten dauerhaft entfernt und die aktuelle Arbe
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bei diesem Anbieter kann hier kein Schlüssel eingefügt werden. Überspringe diesen Schritt, wenn die Bereitstellung bereits Zugangsdaten enthält."
 
-#: src/pages/Shell.tsx:5348
+#: src/pages/Shell.tsx:5377
 msgid "This server cannot be assigned without a bot."
 msgstr "Dieser Server kann ohne Bot nicht zugewiesen werden."
 
@@ -2416,7 +2432,7 @@ msgstr "Dieser Server hat keine Browserautorisierung angefordert."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Dieser Server ist bereits verbunden. Trenne zuerst die Verbindung, um ihn erneut zu autorisieren."
 
-#: src/pages/Shell.tsx:5387
+#: src/pages/Shell.tsx:5416
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Dieser Server verwendet die Browseranmeldung. Autorisiere ihn, damit deine Agents seine Tools verwenden können – ein Pop-up wird geöffnet."
 
@@ -2429,8 +2445,8 @@ msgid "Time of day"
 msgstr "Uhrzeit"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4305
-#: src/pages/Shell.tsx:4472
+#: src/pages/Shell.tsx:4334
+#: src/pages/Shell.tsx:4501
 msgid "Title"
 msgstr "Titel"
 
@@ -2467,8 +2483,8 @@ msgstr ""
 msgid "Updating…"
 msgstr ""
 
-#: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2056
+#: src/pages/AccountSettingsOverlay.tsx:176
+#: src/pages/Shell.tsx:2066
 msgid "Usage"
 msgstr "Nutzung"
 
@@ -2493,8 +2509,8 @@ msgstr "Prüfen und hinzufügen"
 msgid "Verifying…"
 msgstr "Wird geprüft…"
 
-#: src/pages/Shell.tsx:2044
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:2054
+#: src/pages/Shell.tsx:4613
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2507,7 +2523,7 @@ msgstr "Stimme"
 msgid "Waiting for sign-in…"
 msgstr "Warten auf Anmeldung…"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5260
 msgid "Waiting…"
 msgstr "Warten…"
 
@@ -2516,7 +2532,7 @@ msgstr "Warten…"
 msgid "Weekdays"
 msgstr "Wochentage"
 
-#: src/pages/Shell.tsx:4901
+#: src/pages/Shell.tsx:4930
 msgid "What about its memories?"
 msgstr "Was soll mit seinen Erinnerungen geschehen?"
 
@@ -2525,7 +2541,7 @@ msgid "What result will you demonstrate?"
 msgstr "Welches Ergebnis wirst du vorführen?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4320
+#: src/pages/Shell.tsx:4349
 msgid "What this bot is for"
 msgstr "Wofür dieser Bot gedacht ist"
 
@@ -2537,7 +2553,7 @@ msgstr "Was zurückgegeben werden soll"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "Wenn {botName} einem anderen Bot eine Nachricht sendet, wird der Austausch hier statt im Chat angezeigt."
 
-#: src/pages/Shell.tsx:2563
+#: src/pages/Shell.tsx:2578
 msgid "When to run"
 msgstr "Ausführungszeit"
 
@@ -2554,7 +2570,7 @@ msgstr "Wo sollen Bots ausgeführt werden?"
 msgid "Working…"
 msgstr "Wird verarbeitet…"
 
-#: src/pages/Shell.tsx:4514
+#: src/pages/Shell.tsx:4543
 msgid "Workspace default"
 msgstr "Arbeitsbereichsstandard"
 
@@ -2571,8 +2587,8 @@ msgstr "Du kannst diesen Tab schließen, wenn du nicht automatisch weitergeleite
 msgid "You can close this window."
 msgstr "Du kannst dieses Fenster schließen."
 
-#: src/pages/Shell.tsx:2337
-#: src/pages/Shell.tsx:2908
+#: src/pages/Shell.tsx:2352
+#: src/pages/Shell.tsx:2933
 msgid "You have control"
 msgstr "Du hast die Kontrolle"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -953,10 +953,6 @@ msgstr "Could not update"
 msgid "Could not update agent access"
 msgstr "Could not update agent access"
 
-#: src/pages/AccountSettingsOverlay.tsx:80
-msgid "Could not update avatar style"
-msgstr "Could not update avatar style"
-
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr "Could not update computer"
@@ -964,6 +960,10 @@ msgstr "Could not update computer"
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "Could not update the default memory scope"
+
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Couldn't update avatars"
+msgstr "Couldn't update avatars"
 
 #: src/pages/Shell.tsx:1761
 #: src/pages/Shell.tsx:4361

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1857
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (unread)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5204
+#: src/pages/Shell.tsx:5233
 msgid "{0} connection"
 msgstr "{0} connection"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2341
+#: src/pages/Shell.tsx:2356
 msgid "{0} is using it"
 msgstr "{0} is using it"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2061
+#: src/pages/AccountSettingsOverlay.tsx:180
+#: src/pages/Shell.tsx:2071
 msgid "{0} runs · {1} tokens"
 msgstr "{0} runs · {1} tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# peer} other {# peers}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} has not messaged another bot yet."
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "{botName}’s computer"
 msgstr "{botName}’s computer"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3371
+#: src/pages/Shell.tsx:3400
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ Teach a task"
 msgid "Access token (optional)"
 msgstr "Access token (optional)"
 
-#: src/pages/AccountSettingsOverlay.tsx:97
+#: src/pages/AccountSettingsOverlay.tsx:118
 msgid "Account"
 msgstr "Account"
 
-#: src/pages/Shell.tsx:4590
+#: src/pages/Shell.tsx:4619
 msgid "Account default"
 msgstr "Account default"
 
-#: src/pages/AccountSettingsOverlay.tsx:82
+#: src/pages/AccountSettingsOverlay.tsx:103
 msgid "Account preferences apply across all your bots."
 msgstr "Account preferences apply across all your bots."
 
@@ -218,10 +218,10 @@ msgstr "Add Treg"
 msgid "Adding…"
 msgstr "Adding…"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4522
 msgid "Advanced"
 msgstr "Advanced"
 
@@ -229,7 +229,7 @@ msgstr "Advanced"
 msgid "Agent access for new servers"
 msgstr "Agent access for new servers"
 
-#: src/pages/Shell.tsx:2148
+#: src/pages/Shell.tsx:2163
 msgid "Agent computer"
 msgstr "Agent computer"
 
@@ -316,11 +316,11 @@ msgstr "Applies when you click Add server. Use the agent chips on each server ca
 msgid "Approval boundaries"
 msgstr "Approval boundaries"
 
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 msgid "Approve"
 msgstr "Approve"
 
-#: src/pages/Shell.tsx:5388
+#: src/pages/Shell.tsx:5417
 msgid "Approve this server to let your agent use its tools."
 msgstr "Approve this server to let your agent use its tools."
 
@@ -328,15 +328,15 @@ msgstr "Approve this server to let your agent use its tools."
 msgid "Archive"
 msgstr "Archive"
 
-#: src/pages/Shell.tsx:4037
+#: src/pages/Shell.tsx:4066
 msgid "archived"
 msgstr "archived"
 
-#: src/pages/Shell.tsx:1941
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/Shell.tsx:4048
+#: src/pages/Shell.tsx:4077
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archived. Chat, memory, and files kept."
 
@@ -375,7 +375,7 @@ msgstr "Ask before purchases"
 msgid "Ask before sending external email"
 msgstr "Ask before sending external email"
 
-#: src/pages/Shell.tsx:2343
+#: src/pages/Shell.tsx:2358
 msgid "Asleep"
 msgstr "Asleep"
 
@@ -390,11 +390,11 @@ msgstr "at {0}"
 msgid "at {timeSelect}"
 msgstr "at {timeSelect}"
 
-#: src/pages/Shell.tsx:3442
+#: src/pages/Shell.tsx:3471
 msgid "Attach file"
 msgstr "Attach file"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3670
 msgid "Attachment"
 msgstr "Attachment"
 
@@ -407,14 +407,18 @@ msgstr "Authorization code or callback URL"
 msgid "Authorization expired — reconnect required"
 msgstr "Authorization expired — reconnect required"
 
-#: src/pages/Shell.tsx:5189
+#: src/pages/Shell.tsx:5218
 msgid "Authorization timed out. Please try again."
 msgstr "Authorization timed out. Please try again."
 
-#: src/pages/Shell.tsx:5231
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5426
 msgid "Authorize"
 msgstr "Authorize"
+
+#: src/pages/AccountSettingsOverlay.tsx:133
+msgid "Avatars"
+msgstr "Avatars"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -424,18 +428,18 @@ msgstr "Base URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5073
+#: src/pages/Shell.tsx:5102
 msgid "Booting live desktop…"
 msgstr "Booting live desktop…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2903
 msgid "Booting up {0}’s computer"
 msgstr "Booting up {0}’s computer"
 
-#: src/pages/Shell.tsx:3907
-#: src/pages/Shell.tsx:3908
-#: src/pages/Shell.tsx:4041
+#: src/pages/Shell.tsx:3936
+#: src/pages/Shell.tsx:3937
+#: src/pages/Shell.tsx:4070
 msgid "bot"
 msgstr "bot"
 
@@ -447,11 +451,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot messages"
 
-#: src/pages/Shell.tsx:2975
+#: src/pages/Shell.tsx:3000
 msgid "Bot screen"
 msgstr "Bot screen"
 
-#: src/pages/Shell.tsx:2311
+#: src/pages/Shell.tsx:2326
 msgid "Bot screen preview"
 msgstr "Bot screen preview"
 
@@ -464,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Bring your own key. The provider is swappable; your bots keep the same speak and call buttons."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2130
-#: src/pages/Shell.tsx:2131
+#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2146
 msgid "Call"
 msgstr "Call"
 
@@ -477,14 +481,14 @@ msgstr "Can't reach the server."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4829
-#: src/pages/Shell.tsx:4944
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4858
+#: src/pages/Shell.tsx:4973
+#: src/pages/Shell.tsx:5047
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/pages/Shell.tsx:4285
+#: src/pages/Shell.tsx:4314
 msgid "Cancel new bot"
 msgstr "Cancel new bot"
 
@@ -492,7 +496,7 @@ msgstr "Cancel new bot"
 msgid "Cancel new group"
 msgstr "Cancel new group"
 
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3347
 msgid "Cancel reply"
 msgstr "Cancel reply"
 
@@ -500,16 +504,16 @@ msgstr "Cancel reply"
 msgid "Cancelled"
 msgstr "Cancelled"
 
-#: src/pages/Shell.tsx:5294
+#: src/pages/Shell.tsx:5323
 msgid "Chart failed to render: {error}"
 msgstr "Chart failed to render: {error}"
 
-#: src/pages/Shell.tsx:3584
+#: src/pages/Shell.tsx:3613
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
-#: src/pages/Shell.tsx:2593
-#: src/pages/Shell.tsx:2600
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:2615
 msgid "Check in."
 msgstr "Check in."
 
@@ -521,21 +525,21 @@ msgstr "Choose a model to get started."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Choose which connected model Rakazo uses."
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clear"
 msgstr "Clear"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4839
 msgid "Clear {0}’s conversation?"
 msgstr "Clear {0}’s conversation?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4645
+#: src/pages/Shell.tsx:4674
 msgid "Clear conversation"
 msgstr "Clear conversation"
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clearing…"
 msgstr "Clearing…"
 
@@ -551,15 +555,15 @@ msgstr "Close bot menu"
 msgid "Close bot messages"
 msgstr "Close bot messages"
 
-#: src/pages/Shell.tsx:5479
+#: src/pages/Shell.tsx:5508
 msgid "Close chart"
 msgstr "Close chart"
 
-#: src/pages/Shell.tsx:2949
+#: src/pages/Shell.tsx:2974
 msgid "Close computer"
 msgstr "Close computer"
 
-#: src/pages/Shell.tsx:5579
+#: src/pages/Shell.tsx:5608
 msgid "Close image preview"
 msgstr "Close image preview"
 
@@ -583,7 +587,7 @@ msgstr "Close model settings"
 msgid "Close navigation"
 msgstr "Close navigation"
 
-#: src/pages/Shell.tsx:2289
+#: src/pages/Shell.tsx:2304
 msgid "Close panel"
 msgstr "Close panel"
 
@@ -592,7 +596,7 @@ msgstr "Close panel"
 msgid "Close preview"
 msgstr "Close preview"
 
-#: src/pages/AccountSettingsOverlay.tsx:87
+#: src/pages/AccountSettingsOverlay.tsx:108
 msgid "Close user settings"
 msgstr "Close user settings"
 
@@ -612,24 +616,24 @@ msgstr "Command"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/pages/Shell.tsx:4195
-#: src/pages/Shell.tsx:4223
+#: src/pages/Shell.tsx:4224
+#: src/pages/Shell.tsx:4252
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5076
+#: src/pages/Shell.tsx:5105
 msgid "Computer failed to boot"
 msgstr "Computer failed to boot"
 
-#: src/pages/Shell.tsx:2997
+#: src/pages/Shell.tsx:3022
 msgid "Computer is asleep"
 msgstr "Computer is asleep"
 
-#: src/pages/Shell.tsx:5075
+#: src/pages/Shell.tsx:5104
 msgid "Computer is asleep — take control to wake it"
 msgstr "Computer is asleep — take control to wake it"
 
-#: src/pages/Shell.tsx:5077
+#: src/pages/Shell.tsx:5106
 msgid "Computer is stopped"
 msgstr "Computer is stopped"
 
@@ -662,7 +666,7 @@ msgstr "Connect API key"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "Connect ElevenLabs, OpenAI, or Cartesia"
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5406
 msgid "Connect MCP server “{name}”"
 msgstr "Connect MCP server “{name}”"
 
@@ -685,12 +689,12 @@ msgstr "Connect Treg"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5228
+#: src/pages/Shell.tsx:5257
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Connected"
 
-#: src/pages/Shell.tsx:5407
+#: src/pages/Shell.tsx:5436
 msgid "Connected — its tools are available from your next message."
 msgstr "Connected — its tools are available from your next message."
 
@@ -715,7 +719,7 @@ msgstr "Connected and using {0}."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Connecting…"
@@ -734,7 +738,7 @@ msgstr "Continue"
 msgid "Continue with email"
 msgstr "Continue with email"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3721
 msgid "Copy"
 msgstr "Copy"
 
@@ -746,11 +750,11 @@ msgstr "Could not add"
 msgid "Could not add MCP server"
 msgstr "Could not add MCP server"
 
-#: src/pages/Shell.tsx:5364
+#: src/pages/Shell.tsx:5393
 msgid "Could not approve this server"
 msgstr "Could not approve this server"
 
-#: src/pages/Shell.tsx:5192
+#: src/pages/Shell.tsx:5221
 msgid "Could not authorize this app"
 msgstr "Could not authorize this app"
 
@@ -758,7 +762,7 @@ msgstr "Could not authorize this app"
 msgid "Could not change the default model"
 msgstr "Could not change the default model"
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4867
 msgid "Could not clear conversation"
 msgstr "Could not clear conversation"
 
@@ -787,7 +791,7 @@ msgstr "Could not connect this voice provider"
 msgid "Could not continue"
 msgstr "Could not continue"
 
-#: src/pages/Shell.tsx:4273
+#: src/pages/Shell.tsx:4302
 msgid "Could not create bot"
 msgstr "Could not create bot"
 
@@ -795,7 +799,7 @@ msgstr "Could not create bot"
 msgid "Could not create group"
 msgstr "Could not create group"
 
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4758
 msgid "Could not create section"
 msgstr "Could not create section"
 
@@ -803,7 +807,7 @@ msgstr "Could not create section"
 msgid "Could not create your bot"
 msgstr "Could not create your bot"
 
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4982
 msgid "Could not delete bot"
 msgstr "Could not delete bot"
 
@@ -811,7 +815,7 @@ msgstr "Could not delete bot"
 msgid "Could not delete MCP server"
 msgstr "Could not delete MCP server"
 
-#: src/pages/Shell.tsx:5027
+#: src/pages/Shell.tsx:5056
 msgid "Could not delete routine"
 msgstr "Could not delete routine"
 
@@ -885,7 +889,7 @@ msgstr "Could not remove group"
 msgid "Could not remove rule"
 msgstr "Could not remove rule"
 
-#: src/pages/Shell.tsx:5284
+#: src/pages/Shell.tsx:5313
 msgid "Could not render chart"
 msgstr "Could not render chart"
 
@@ -893,7 +897,7 @@ msgstr "Could not render chart"
 msgid "Could not revoke connection"
 msgstr "Could not revoke connection"
 
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4659
 msgid "Could not save"
 msgstr "Could not save"
 
@@ -905,7 +909,7 @@ msgstr "Could not save group"
 msgid "Could not save model"
 msgstr "Could not save model"
 
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2630
 msgid "Could not save routine"
 msgstr "Could not save routine"
 
@@ -921,7 +925,7 @@ msgstr "Could not save that choice"
 msgid "Could not save that voice"
 msgstr "Could not save that voice"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5133
 msgid "Could not save this choice"
 msgstr "Could not save this choice"
 
@@ -949,6 +953,10 @@ msgstr "Could not update"
 msgid "Could not update agent access"
 msgstr "Could not update agent access"
 
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Could not update avatar style"
+msgstr "Could not update avatar style"
+
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr "Could not update computer"
@@ -958,13 +966,13 @@ msgid "Could not update the default memory scope"
 msgstr "Could not update the default memory scope"
 
 #: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Create"
 msgstr "Create"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4738
+#: src/pages/Shell.tsx:4767
 msgid "Create a section and move {0} into it."
 msgstr "Create a section and move {0} into it."
 
@@ -985,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Create your Rakazo"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Creating…"
 msgstr "Creating…"
 
@@ -1014,7 +1022,7 @@ msgstr "day"
 msgid "days"
 msgstr "days"
 
-#: src/pages/Shell.tsx:4537
+#: src/pages/Shell.tsx:4566
 msgid "Default (medium)"
 msgstr "Default (medium)"
 
@@ -1024,21 +1032,21 @@ msgstr "Default scope"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1970
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:1980
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Delete"
 msgstr "Delete"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1966
+#: src/pages/Shell.tsx:1976
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4891
-#: src/pages/Shell.tsx:5005
+#: src/pages/Shell.tsx:4920
+#: src/pages/Shell.tsx:5034
 msgid "Delete {0}?"
 msgstr "Delete {0}?"
 
@@ -1046,21 +1054,21 @@ msgstr "Delete {0}?"
 msgid "Delete group"
 msgstr "Delete group"
 
-#: src/pages/Shell.tsx:4928
+#: src/pages/Shell.tsx:4957
 msgid "Delete memories too"
 msgstr "Delete memories too"
 
-#: src/pages/Shell.tsx:2670
+#: src/pages/Shell.tsx:2685
 msgid "Delete routine"
 msgstr "Delete routine"
 
-#: src/pages/Shell.tsx:4039
+#: src/pages/Shell.tsx:4068
 msgid "deleted"
 msgstr "deleted"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Deleting…"
 msgstr "Deleting…"
 
@@ -1077,17 +1085,17 @@ msgid "Deployment default"
 msgstr "Deployment default"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4310
+#: src/pages/Shell.tsx:4339
 msgid "Describe what this bot does"
 msgstr "Describe what this bot does"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4315
-#: src/pages/Shell.tsx:4481
+#: src/pages/Shell.tsx:4344
+#: src/pages/Shell.tsx:4510
 msgid "Description"
 msgstr "Description"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Dictate"
 msgstr "Dictate"
 
@@ -1100,7 +1108,7 @@ msgstr "Disconnect"
 msgid "Disconnecting…"
 msgstr "Disconnecting…"
 
-#: src/pages/Shell.tsx:5412
+#: src/pages/Shell.tsx:5441
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Dismissed — reconnect anytime from MCP settings."
 
@@ -1148,7 +1156,7 @@ msgstr "Draft skill"
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/pages/Shell.tsx:3852
+#: src/pages/Shell.tsx:3881
 msgid "Earlier message"
 msgstr "Earlier message"
 
@@ -1204,11 +1212,11 @@ msgstr "Every month"
 msgid "Every week"
 msgstr "Every week"
 
-#: src/pages/Shell.tsx:5458
+#: src/pages/Shell.tsx:5487
 msgid "Expand"
 msgstr "Expand"
 
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4671
 msgid "Export"
 msgstr "Export"
 
@@ -1216,7 +1224,7 @@ msgstr "Export"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Export this week's list from the CRM and drop it in the shared folder"
 
-#: src/pages/Shell.tsx:4662
+#: src/pages/Shell.tsx:4691
 msgid "Extra high"
 msgstr "Extra high"
 
@@ -1267,8 +1275,8 @@ msgstr "Free"
 msgid "Fullscreen"
 msgstr "Fullscreen"
 
-#: src/pages/Shell.tsx:2120
-#: src/pages/Shell.tsx:2271
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2286
 msgid "Group"
 msgstr "Group"
 
@@ -1297,15 +1305,15 @@ msgstr "Hear a sample"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Hi, this is how I'll sound when I read replies out loud."
 
-#: src/pages/Shell.tsx:4665
+#: src/pages/Shell.tsx:4694
 msgid "High"
 msgstr "High"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk"
 msgstr "Hold to talk"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk (on-device dictation)"
 msgstr "Hold to talk (on-device dictation)"
 
@@ -1325,7 +1333,7 @@ msgstr "How often"
 msgid "How to check"
 msgstr "How to check"
 
-#: src/pages/Shell.tsx:3748
+#: src/pages/Shell.tsx:3777
 msgid "I’m done"
 msgstr "I’m done"
 
@@ -1337,7 +1345,7 @@ msgstr "If you heard that, voice is ready."
 msgid "Import OpenAPI JSON"
 msgstr "Import OpenAPI JSON"
 
-#: src/pages/Shell.tsx:4552
+#: src/pages/Shell.tsx:4581
 msgid "Inherit default"
 msgstr "Inherit default"
 
@@ -1349,12 +1357,12 @@ msgstr "Inputs"
 msgid "Instance API key"
 msgstr "Instance API key"
 
-#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2569
 msgid "Instruction"
 msgstr "Instruction"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1987
+#: src/pages/Shell.tsx:1997
 msgid "Integrations"
 msgstr "Integrations"
 
@@ -1375,15 +1383,15 @@ msgid "Interval unit"
 msgstr "Interval unit"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4553
+#: src/pages/Shell.tsx:4582
 msgid "Isolated"
 msgstr "Isolated"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4923
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 
-#: src/pages/Shell.tsx:3847
+#: src/pages/Shell.tsx:3876
 msgid "Jump to replied message"
 msgstr "Jump to replied message"
 
@@ -1391,7 +1399,7 @@ msgstr "Jump to replied message"
 msgid "just now"
 msgstr "just now"
 
-#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:4941
 msgid "Keep memories"
 msgstr "Keep memories"
 
@@ -1399,9 +1407,9 @@ msgstr "Keep memories"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "Keys stay on the server. The app only learns whether a provider is configured."
 
-#: src/pages/AccountSettingsOverlay.tsx:105
-#: src/pages/AccountSettingsOverlay.tsx:254
-#: src/pages/AccountSettingsOverlay.tsx:271
+#: src/pages/AccountSettingsOverlay.tsx:126
+#: src/pages/AccountSettingsOverlay.tsx:313
+#: src/pages/AccountSettingsOverlay.tsx:330
 msgid "Language"
 msgstr "Language"
 
@@ -1409,7 +1417,7 @@ msgstr "Language"
 msgid "Listening…"
 msgstr "Listening…"
 
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Load earlier messages"
 msgstr "Load earlier messages"
 
@@ -1449,7 +1457,7 @@ msgstr "Loading voice providers…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -1457,11 +1465,11 @@ msgstr "Loading…"
 msgid "Local"
 msgstr "Local"
 
-#: src/pages/Shell.tsx:2073
+#: src/pages/Shell.tsx:2083
 msgid "Log out"
 msgstr "Log out"
 
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4692
 msgid "Low"
 msgstr "Low"
 
@@ -1477,7 +1485,7 @@ msgstr "Mark as Read"
 msgid "Mark as Unread"
 msgstr "Mark as Unread"
 
-#: src/pages/Shell.tsx:4667
+#: src/pages/Shell.tsx:4696
 msgid "Max"
 msgstr "Max"
 
@@ -1487,7 +1495,7 @@ msgstr "Max"
 msgid "MCP servers"
 msgstr "MCP servers"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4693
 msgid "Medium"
 msgstr "Medium"
 
@@ -1500,33 +1508,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2031
+#: src/pages/Shell.tsx:2041
 msgid "Memory"
 msgstr "Memory"
 
-#: src/pages/Shell.tsx:4548
+#: src/pages/Shell.tsx:4577
 msgid "Memory scope"
 msgstr "Memory scope"
 
-#: src/pages/Shell.tsx:3548
-#: src/pages/Shell.tsx:3643
+#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3672
 msgid "Message"
 msgstr "Message"
 
-#: src/pages/Shell.tsx:3544
-#: src/pages/Shell.tsx:3548
+#: src/pages/Shell.tsx:3573
+#: src/pages/Shell.tsx:3577
 msgid "Message {activeName}"
 msgstr "Message {activeName}"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Message from {peer}"
 msgstr "Message from {peer}"
 
-#: src/pages/Shell.tsx:3545
+#: src/pages/Shell.tsx:3574
 msgid "Message…"
 msgstr "Message…"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Messaged {peer}"
 msgstr "Messaged {peer}"
 
@@ -1534,7 +1542,7 @@ msgstr "Messaged {peer}"
 msgid "Microphone failed"
 msgstr "Microphone failed"
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4695
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1556,7 +1564,7 @@ msgstr "minutes"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4504
+#: src/pages/Shell.tsx:4533
 msgid "Model"
 msgstr "Model"
 
@@ -1569,7 +1577,7 @@ msgstr "Model id"
 msgid "Model options"
 msgstr "Model options"
 
-#: src/pages/AccountSettingsOverlay.tsx:127
+#: src/pages/AccountSettingsOverlay.tsx:186
 msgid "Model spend uses your provider keys."
 msgstr "Model spend uses your provider keys."
 
@@ -1578,7 +1586,7 @@ msgid "Model updated."
 msgstr "Model updated."
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2018
+#: src/pages/Shell.tsx:2028
 msgid "Models"
 msgstr "Models"
 
@@ -1596,7 +1604,7 @@ msgstr "Monthly"
 msgid "Move {0} to section"
 msgstr "Move {0} to section"
 
-#: src/pages/Shell.tsx:4915
+#: src/pages/Shell.tsx:4944
 msgid "Move them to your shared memory."
 msgstr "Move them to your shared memory."
 
@@ -1609,15 +1617,15 @@ msgstr "Move to"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2546
-#: src/pages/Shell.tsx:4295
-#: src/pages/Shell.tsx:4463
-#: src/pages/Shell.tsx:4741
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:4324
+#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4770
 msgid "Name"
 msgstr "Name"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4300
+#: src/pages/Shell.tsx:4329
 msgid "Name this bot"
 msgstr "Name this bot"
 
@@ -1634,7 +1642,7 @@ msgid "Needs takeover"
 msgstr "Needs takeover"
 
 #: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4283
+#: src/pages/Shell.tsx:4312
 msgid "New bot"
 msgstr "New bot"
 
@@ -1647,12 +1655,12 @@ msgstr "New group"
 msgid "New open-work item"
 msgstr "New open-work item"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2447
 msgid "New routine"
 msgstr "New routine"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4735
+#: src/pages/Shell.tsx:4764
 msgid "New section"
 msgstr "New section"
 
@@ -1730,7 +1738,7 @@ msgstr "Not connected"
 msgid "Not in the plugin catalog"
 msgstr "Not in the plugin catalog"
 
-#: src/pages/Shell.tsx:5400
+#: src/pages/Shell.tsx:5429
 msgid "Not now"
 msgstr "Not now"
 
@@ -1768,15 +1776,15 @@ msgstr "on the 1st at {0}"
 msgid "Open"
 msgstr "Open"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Open computer"
 msgstr "Open computer"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2315
 msgid "Open in full window"
 msgstr "Open in full window"
 
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2107
 msgid "Open navigation"
 msgstr "Open navigation"
 
@@ -1793,7 +1801,7 @@ msgstr "Open work"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-compatible server URL"
 
-#: src/pages/Shell.tsx:4050
+#: src/pages/Shell.tsx:4079
 msgid "Opened its thread."
 msgstr "Opened its thread."
 
@@ -1806,7 +1814,7 @@ msgstr "Opening your workspace…"
 msgid "Optional"
 msgstr "Optional"
 
-#: src/pages/AccountSettingsOverlay.tsx:141
+#: src/pages/AccountSettingsOverlay.tsx:200
 msgid "Optional controls most people never need"
 msgstr "Optional controls most people never need"
 
@@ -1821,6 +1829,10 @@ msgstr "Or connect an API key"
 #: src/pages/Onboarding.tsx:464
 msgid "Or paste an API key"
 msgstr "Or paste an API key"
+
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Organic"
+msgstr "Organic"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -1876,7 +1888,7 @@ msgstr "Playing…"
 msgid "Preview {0}"
 msgstr "Preview {0}"
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Private"
 msgstr "Private"
 
@@ -1897,7 +1909,7 @@ msgstr "Queued"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 
-#: src/pages/Shell.tsx:4580
+#: src/pages/Shell.tsx:4609
 msgid "Read replies aloud"
 msgstr "Read replies aloud"
 
@@ -1931,7 +1943,7 @@ msgstr "Recover replaces an unreachable computer and keeps files in the saved wo
 msgid "Recovering…"
 msgstr "Recovering…"
 
-#: src/pages/Shell.tsx:3738
+#: src/pages/Shell.tsx:3767
 msgid "Release"
 msgstr "Release"
 
@@ -1944,17 +1956,17 @@ msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3352
+#: src/pages/Shell.tsx:3381
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3507
+#: src/pages/Shell.tsx:3536
 msgid "Remove mention {0}"
 msgstr "Remove mention {0}"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3515
 msgid "Remove skill {0}"
 msgstr "Remove skill {0}"
 
@@ -1962,7 +1974,7 @@ msgstr "Remove skill {0}"
 msgid "Remove this schedule"
 msgstr "Remove this schedule"
 
-#: src/pages/Shell.tsx:4049
+#: src/pages/Shell.tsx:4078
 msgid "Removed with chat, computer, and memory."
 msgstr "Removed with chat, computer, and memory."
 
@@ -1990,11 +2002,11 @@ msgstr "Replace API key"
 msgid "Replace key"
 msgstr "Replace key"
 
-#: src/pages/Shell.tsx:3684
+#: src/pages/Shell.tsx:3713
 msgid "Reply"
 msgstr "Reply"
 
-#: src/pages/Shell.tsx:3315
+#: src/pages/Shell.tsx:3344
 msgid "Replying to {replyName}"
 msgstr "Replying to {replyName}"
 
@@ -2015,7 +2027,7 @@ msgstr "Reset computer?"
 msgid "Resetting…"
 msgstr "Resetting…"
 
-#: src/pages/Shell.tsx:1962
+#: src/pages/Shell.tsx:1972
 msgid "Restore"
 msgstr "Restore"
 
@@ -2031,17 +2043,21 @@ msgstr "Retry now"
 msgid "Return to Rakazo"
 msgstr "Return to Rakazo"
 
-#: src/pages/Shell.tsx:2539
-#: src/pages/Shell.tsx:2592
-#: src/pages/Shell.tsx:2599
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Robot"
+msgstr "Robot"
+
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Routine"
 msgstr "Routine"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2392
 msgid "Routines"
 msgstr "Routines"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Run now"
 msgstr "Run now"
 
@@ -2049,11 +2065,11 @@ msgstr "Run now"
 msgid "Running"
 msgstr "Running"
 
-#: src/pages/Shell.tsx:2417
+#: src/pages/Shell.tsx:2432
 msgid "Running · Stop"
 msgstr "Running · Stop"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Running…"
 msgstr "Running…"
 
@@ -2061,8 +2077,8 @@ msgstr "Running…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2638
-#: src/pages/Shell.tsx:4635
+#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:4664
 msgid "Save"
 msgstr "Save"
 
@@ -2086,7 +2102,7 @@ msgstr "Saved."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2638
+#: src/pages/Shell.tsx:2653
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2127,11 +2143,11 @@ msgstr "Search providers and models"
 msgid "Searching…"
 msgstr "Searching…"
 
-#: src/pages/Shell.tsx:2121
+#: src/pages/Shell.tsx:2136
 msgid "Select a bot"
 msgstr "Select a bot"
 
-#: src/pages/Shell.tsx:3568
+#: src/pages/Shell.tsx:3597
 msgid "Send"
 msgstr "Send"
 
@@ -2159,22 +2175,22 @@ msgstr "Server name"
 msgid "Server URL"
 msgstr "Server URL"
 
-#: src/pages/Shell.tsx:2130
+#: src/pages/Shell.tsx:2145
 msgid "Set up voice to call"
 msgstr "Set up voice to call"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1995
+#: src/pages/AccountSettingsOverlay.tsx:100
 #: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2267
+#: src/pages/Shell.tsx:2015
+#: src/pages/Shell.tsx:2282
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Shell.tsx:3586
+#: src/pages/Shell.tsx:3615
 msgid "Settings: General"
 msgstr "Settings: General"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3617
 msgid "Settings: Usage"
 msgstr "Settings: Usage"
 
@@ -2184,15 +2200,15 @@ msgid "Setup help"
 msgstr "Setup help"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4554
+#: src/pages/Shell.tsx:4583
 msgid "Shared"
 msgstr "Shared"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show computer"
 msgstr "Show computer"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show settings"
 msgstr "Show settings"
 
@@ -2216,11 +2232,11 @@ msgid "Sign up"
 msgstr "Sign up"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3399
+#: src/pages/Shell.tsx:3428
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3774
 msgid "Skip"
 msgstr "Skip"
 
@@ -2241,8 +2257,8 @@ msgstr "Skipped {0}"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space interrupts · Esc hangs up"
 
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Speak"
 msgstr "Speak"
 
@@ -2254,8 +2270,8 @@ msgstr "Speak + transcribe"
 msgid "Speak only"
 msgstr "Speak only"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Speak this reply"
 msgstr "Speak this reply"
 
@@ -2281,20 +2297,20 @@ msgstr "Starting…"
 msgid "Steps"
 msgstr "Steps"
 
-#: src/pages/Shell.tsx:2918
-#: src/pages/Shell.tsx:2922
-#: src/pages/Shell.tsx:3559
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2947
+#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Stop"
 msgstr "Stop"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Stop dictation"
 msgstr "Stop dictation"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Stop speaking"
 msgstr "Stop speaking"
 
@@ -2303,8 +2319,8 @@ msgstr "Stop speaking"
 msgid "Stop teaching"
 msgstr "Stop teaching"
 
-#: src/pages/Shell.tsx:2357
-#: src/pages/Shell.tsx:2938
+#: src/pages/Shell.tsx:2372
+#: src/pages/Shell.tsx:2963
 msgid "Stop the bot first"
 msgstr "Stop the bot first"
 
@@ -2312,7 +2328,7 @@ msgstr "Stop the bot first"
 msgid "Stored encrypted"
 msgstr "Stored encrypted"
 
-#: src/pages/Shell.tsx:4001
+#: src/pages/Shell.tsx:4030
 msgid "subagent"
 msgstr "subagent"
 
@@ -2325,8 +2341,8 @@ msgstr "Submit"
 msgid "Switching…"
 msgstr "Switching…"
 
-#: src/pages/Shell.tsx:2360
-#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2375
+#: src/pages/Shell.tsx:2968
 msgid "Take control"
 msgstr "Take control"
 
@@ -2334,7 +2350,7 @@ msgstr "Take control"
 msgid "Teach a task"
 msgstr "Teach a task"
 
-#: src/pages/Shell.tsx:2193
+#: src/pages/Shell.tsx:2208
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Teaching in progress — stop teaching before sending a new message."
 
@@ -2342,11 +2358,11 @@ msgstr "Teaching in progress — stop teaching before sending a new message."
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -2359,20 +2375,20 @@ msgstr "Test"
 msgid "The selected memory provider is not available in this build."
 msgstr "The selected memory provider is not available in this build."
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4560
 msgid "Thinking"
 msgstr "Thinking"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2319
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 
-#: src/pages/Shell.tsx:2967
+#: src/pages/Shell.tsx:2992
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 
-#: src/pages/Shell.tsx:4931
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:4960
+#: src/pages/Shell.tsx:5037
 msgid "This cannot be undone."
 msgstr "This cannot be undone."
 
@@ -2396,7 +2412,7 @@ msgstr "this Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 
-#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4845
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 
@@ -2404,7 +2420,7 @@ msgstr "This permanently removes every message and stops current work. The bot, 
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "This provider cannot paste a key here. Skip if this deployment already has credentials."
 
-#: src/pages/Shell.tsx:5348
+#: src/pages/Shell.tsx:5377
 msgid "This server cannot be assigned without a bot."
 msgstr "This server cannot be assigned without a bot."
 
@@ -2416,7 +2432,7 @@ msgstr "This server did not request browser authorization."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "This server is already connected. Disconnect it first to authorize again."
 
-#: src/pages/Shell.tsx:5387
+#: src/pages/Shell.tsx:5416
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 
@@ -2429,8 +2445,8 @@ msgid "Time of day"
 msgstr "Time of day"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4305
-#: src/pages/Shell.tsx:4472
+#: src/pages/Shell.tsx:4334
+#: src/pages/Shell.tsx:4501
 msgid "Title"
 msgstr "Title"
 
@@ -2467,8 +2483,8 @@ msgstr "Update computer"
 msgid "Updating…"
 msgstr "Updating…"
 
-#: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2056
+#: src/pages/AccountSettingsOverlay.tsx:176
+#: src/pages/Shell.tsx:2066
 msgid "Usage"
 msgstr "Usage"
 
@@ -2493,8 +2509,8 @@ msgstr "Verify and add"
 msgid "Verifying…"
 msgstr "Verifying…"
 
-#: src/pages/Shell.tsx:2044
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:2054
+#: src/pages/Shell.tsx:4613
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2507,7 +2523,7 @@ msgstr "Voice"
 msgid "Waiting for sign-in…"
 msgstr "Waiting for sign-in…"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5260
 msgid "Waiting…"
 msgstr "Waiting…"
 
@@ -2516,7 +2532,7 @@ msgstr "Waiting…"
 msgid "Weekdays"
 msgstr "Weekdays"
 
-#: src/pages/Shell.tsx:4901
+#: src/pages/Shell.tsx:4930
 msgid "What about its memories?"
 msgstr "What about its memories?"
 
@@ -2525,7 +2541,7 @@ msgid "What result will you demonstrate?"
 msgstr "What result will you demonstrate?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4320
+#: src/pages/Shell.tsx:4349
 msgid "What this bot is for"
 msgstr "What this bot is for"
 
@@ -2537,7 +2553,7 @@ msgstr "What to return"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 
-#: src/pages/Shell.tsx:2563
+#: src/pages/Shell.tsx:2578
 msgid "When to run"
 msgstr "When to run"
 
@@ -2554,7 +2570,7 @@ msgstr "Where should bots run?"
 msgid "Working…"
 msgstr "Working…"
 
-#: src/pages/Shell.tsx:4514
+#: src/pages/Shell.tsx:4543
 msgid "Workspace default"
 msgstr "Workspace default"
 
@@ -2571,8 +2587,8 @@ msgstr "You can close this tab if it does not redirect automatically."
 msgid "You can close this window."
 msgstr "You can close this window."
 
-#: src/pages/Shell.tsx:2337
-#: src/pages/Shell.tsx:2908
+#: src/pages/Shell.tsx:2352
+#: src/pages/Shell.tsx:2933
 msgid "You have control"
 msgstr "You have control"
 

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1857
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (अपठित)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5204
+#: src/pages/Shell.tsx:5233
 msgid "{0} connection"
 msgstr "{0} कनेक्शन"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2341
+#: src/pages/Shell.tsx:2356
 msgid "{0} is using it"
 msgstr "{0} इसका उपयोग कर रहा है"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2061
+#: src/pages/AccountSettingsOverlay.tsx:180
+#: src/pages/Shell.tsx:2071
 msgid "{0} runs · {1} tokens"
 msgstr "{0} रन · {1} टोकन"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# सहयोगी बॉट} other {# �
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} ने अभी तक किसी दूसरे बॉट को संदेश नहीं भेजा है।"
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "{botName}’s computer"
 msgstr "{botName} का कंप्यूटर"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3371
+#: src/pages/Shell.tsx:3400
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ कोई कार्य सिखाएं"
 msgid "Access token (optional)"
 msgstr "एक्सेस टोकन (वैकल्पिक)"
 
-#: src/pages/AccountSettingsOverlay.tsx:97
+#: src/pages/AccountSettingsOverlay.tsx:118
 msgid "Account"
 msgstr "खाता"
 
-#: src/pages/Shell.tsx:4590
+#: src/pages/Shell.tsx:4619
 msgid "Account default"
 msgstr "खाता डिफ़ॉल्ट"
 
-#: src/pages/AccountSettingsOverlay.tsx:82
+#: src/pages/AccountSettingsOverlay.tsx:103
 msgid "Account preferences apply across all your bots."
 msgstr "खाता प्राथमिकताएं आपके सभी बॉट्स पर लागू होती हैं।"
 
@@ -218,10 +218,10 @@ msgstr "Treg जोड़ें"
 msgid "Adding…"
 msgstr "जोड़ा जा रहा है…"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4522
 msgid "Advanced"
 msgstr "उन्नत"
 
@@ -229,7 +229,7 @@ msgstr "उन्नत"
 msgid "Agent access for new servers"
 msgstr "नए सर्वरों के लिए एजेंट एक्सेस"
 
-#: src/pages/Shell.tsx:2148
+#: src/pages/Shell.tsx:2163
 msgid "Agent computer"
 msgstr "एजेंट कंप्यूटर"
 
@@ -316,11 +316,11 @@ msgstr "यह तब लागू होता है जब आप 'सर्�
 msgid "Approval boundaries"
 msgstr "अनुमोदन सीमाएं"
 
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 msgid "Approve"
 msgstr "अनुमोदित करें"
 
-#: src/pages/Shell.tsx:5388
+#: src/pages/Shell.tsx:5417
 msgid "Approve this server to let your agent use its tools."
 msgstr "अपने एजेंट को इसके टूल उपयोग करने देने के लिए इस सर्वर को अनुमोदित करें।"
 
@@ -328,15 +328,15 @@ msgstr "अपने एजेंट को इसके टूल उपयो�
 msgid "Archive"
 msgstr "आर्काइव करें"
 
-#: src/pages/Shell.tsx:4037
+#: src/pages/Shell.tsx:4066
 msgid "archived"
 msgstr "आर्काइव किया गया"
 
-#: src/pages/Shell.tsx:1941
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "आर्काइव किया गया"
 
-#: src/pages/Shell.tsx:4048
+#: src/pages/Shell.tsx:4077
 msgid "Archived. Chat, memory, and files kept."
 msgstr "आर्काइव किया गया। चैट, मेमोरी और फ़ाइलें सुरक्षित रखी गईं।"
 
@@ -375,7 +375,7 @@ msgstr "खरीद से पहले पूछें"
 msgid "Ask before sending external email"
 msgstr "बाहरी ईमेल भेजने से पहले पूछें"
 
-#: src/pages/Shell.tsx:2343
+#: src/pages/Shell.tsx:2358
 msgid "Asleep"
 msgstr "निष्क्रिय"
 
@@ -390,11 +390,11 @@ msgstr "{0} बजे"
 msgid "at {timeSelect}"
 msgstr "{timeSelect} बजे"
 
-#: src/pages/Shell.tsx:3442
+#: src/pages/Shell.tsx:3471
 msgid "Attach file"
 msgstr "फ़ाइल संलग्न करें"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3670
 msgid "Attachment"
 msgstr "अटैचमेंट"
 
@@ -407,14 +407,18 @@ msgstr "ऑथराइज़ेशन कोड या कॉलबैक URL"
 msgid "Authorization expired — reconnect required"
 msgstr "ऑथराइज़ेशन समाप्त — पुनः कनेक्ट करना आवश्यक"
 
-#: src/pages/Shell.tsx:5189
+#: src/pages/Shell.tsx:5218
 msgid "Authorization timed out. Please try again."
 msgstr "ऑथराइज़ेशन का समय समाप्त हो गया। कृपया पुनः प्रयास करें।"
 
-#: src/pages/Shell.tsx:5231
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5426
 msgid "Authorize"
 msgstr "ऑथराइज़ करें"
+
+#: src/pages/AccountSettingsOverlay.tsx:133
+msgid "Avatars"
+msgstr "अवतार"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -424,18 +428,18 @@ msgstr "बेस URL"
 msgid "Bearer token"
 msgstr "बियरर टोकन"
 
-#: src/pages/Shell.tsx:5073
+#: src/pages/Shell.tsx:5102
 msgid "Booting live desktop…"
 msgstr "लाइव डेस्कटॉप शुरू हो रहा है…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2903
 msgid "Booting up {0}’s computer"
 msgstr "{0} का कंप्यूटर शुरू हो रहा है"
 
-#: src/pages/Shell.tsx:3907
-#: src/pages/Shell.tsx:3908
-#: src/pages/Shell.tsx:4041
+#: src/pages/Shell.tsx:3936
+#: src/pages/Shell.tsx:3937
+#: src/pages/Shell.tsx:4070
 msgid "bot"
 msgstr "बॉट"
 
@@ -447,11 +451,11 @@ msgstr "बॉट"
 msgid "Bot messages"
 msgstr "बॉट संदेश"
 
-#: src/pages/Shell.tsx:2975
+#: src/pages/Shell.tsx:3000
 msgid "Bot screen"
 msgstr "बॉट स्क्रीन"
 
-#: src/pages/Shell.tsx:2311
+#: src/pages/Shell.tsx:2326
 msgid "Bot screen preview"
 msgstr "बॉट स्क्रीन प्रीव्यू"
 
@@ -464,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "अपनी कुंजी स्वयं लाएं। प्रोवाइडर बदला जा सकता है; आपके बॉट्स के बोलने और कॉल करने वाले बटन वही रहते हैं।"
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2130
-#: src/pages/Shell.tsx:2131
+#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2146
 msgid "Call"
 msgstr "कॉल"
 
@@ -477,14 +481,14 @@ msgstr "सर्वर तक नहीं पहुंचा जा सका�
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4829
-#: src/pages/Shell.tsx:4944
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4858
+#: src/pages/Shell.tsx:4973
+#: src/pages/Shell.tsx:5047
 msgid "Cancel"
 msgstr "रद्द करें"
 
-#: src/pages/Shell.tsx:4285
+#: src/pages/Shell.tsx:4314
 msgid "Cancel new bot"
 msgstr "नया बॉट रद्द करें"
 
@@ -492,7 +496,7 @@ msgstr "नया बॉट रद्द करें"
 msgid "Cancel new group"
 msgstr "नया समूह रद्द करें"
 
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3347
 msgid "Cancel reply"
 msgstr "उत्तर रद्द करें"
 
@@ -500,16 +504,16 @@ msgstr "उत्तर रद्द करें"
 msgid "Cancelled"
 msgstr "रद्द किया गया"
 
-#: src/pages/Shell.tsx:5294
+#: src/pages/Shell.tsx:5323
 msgid "Chart failed to render: {error}"
 msgstr "चार्ट रेंडर नहीं हो सका: {error}"
 
-#: src/pages/Shell.tsx:3584
+#: src/pages/Shell.tsx:3613
 msgid "Chat Settings"
 msgstr "चैट सेटिंग्स"
 
-#: src/pages/Shell.tsx:2593
-#: src/pages/Shell.tsx:2600
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:2615
 msgid "Check in."
 msgstr "जांच करें।"
 
@@ -521,21 +525,21 @@ msgstr "शुरू करने के लिए एक मॉडल चुन
 msgid "Choose which connected model Rakazo uses."
 msgstr "चुनें कि Rakazo किस कनेक्टेड मॉडल का उपयोग करे।"
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clear"
 msgstr "साफ़ करें"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4839
 msgid "Clear {0}’s conversation?"
 msgstr "{0} की बातचीत साफ़ करें?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4645
+#: src/pages/Shell.tsx:4674
 msgid "Clear conversation"
 msgstr "बातचीत साफ़ करें"
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clearing…"
 msgstr "साफ़ किया जा रहा है…"
 
@@ -551,15 +555,15 @@ msgstr "बॉट मेन्यू बंद करें"
 msgid "Close bot messages"
 msgstr "बॉट संदेश बंद करें"
 
-#: src/pages/Shell.tsx:5479
+#: src/pages/Shell.tsx:5508
 msgid "Close chart"
 msgstr "चार्ट बंद करें"
 
-#: src/pages/Shell.tsx:2949
+#: src/pages/Shell.tsx:2974
 msgid "Close computer"
 msgstr "कंप्यूटर बंद करें"
 
-#: src/pages/Shell.tsx:5579
+#: src/pages/Shell.tsx:5608
 msgid "Close image preview"
 msgstr "छवि प्रीव्यू बंद करें"
 
@@ -583,7 +587,7 @@ msgstr "मॉडल सेटिंग्स बंद करें"
 msgid "Close navigation"
 msgstr "नेविगेशन बंद करें"
 
-#: src/pages/Shell.tsx:2289
+#: src/pages/Shell.tsx:2304
 msgid "Close panel"
 msgstr "पैनल बंद करें"
 
@@ -592,7 +596,7 @@ msgstr "पैनल बंद करें"
 msgid "Close preview"
 msgstr "प्रीव्यू बंद करें"
 
-#: src/pages/AccountSettingsOverlay.tsx:87
+#: src/pages/AccountSettingsOverlay.tsx:108
 msgid "Close user settings"
 msgstr "उपयोगकर्ता सेटिंग्स बंद करें"
 
@@ -612,24 +616,24 @@ msgstr "कमांड"
 msgid "Complete"
 msgstr "पूर्ण"
 
-#: src/pages/Shell.tsx:4195
-#: src/pages/Shell.tsx:4223
+#: src/pages/Shell.tsx:4224
+#: src/pages/Shell.tsx:4252
 msgid "Computer"
 msgstr "कंप्यूटर"
 
-#: src/pages/Shell.tsx:5076
+#: src/pages/Shell.tsx:5105
 msgid "Computer failed to boot"
 msgstr "कंप्यूटर शुरू नहीं हो सका"
 
-#: src/pages/Shell.tsx:2997
+#: src/pages/Shell.tsx:3022
 msgid "Computer is asleep"
 msgstr "कंप्यूटर निष्क्रिय है"
 
-#: src/pages/Shell.tsx:5075
+#: src/pages/Shell.tsx:5104
 msgid "Computer is asleep — take control to wake it"
 msgstr "कंप्यूटर निष्क्रिय है — जगाने के लिए नियंत्रण लें"
 
-#: src/pages/Shell.tsx:5077
+#: src/pages/Shell.tsx:5106
 msgid "Computer is stopped"
 msgstr "कंप्यूटर रुका हुआ है"
 
@@ -662,7 +666,7 @@ msgstr "API कुंजी कनेक्ट करें"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI या Cartesia कनेक्ट करें"
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5406
 msgid "Connect MCP server “{name}”"
 msgstr "MCP सर्वर “{name}” कनेक्ट करें"
 
@@ -685,12 +689,12 @@ msgstr "Treg कनेक्ट करें"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5228
+#: src/pages/Shell.tsx:5257
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "कनेक्टेड"
 
-#: src/pages/Shell.tsx:5407
+#: src/pages/Shell.tsx:5436
 msgid "Connected — its tools are available from your next message."
 msgstr "कनेक्टेड — इसके टूल आपके अगले संदेश से उपलब्ध हैं।"
 
@@ -715,7 +719,7 @@ msgstr "{0} कनेक्ट किया गया और उपयोग म
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "कनेक्ट हो रहा है…"
@@ -734,7 +738,7 @@ msgstr "जारी रखें"
 msgid "Continue with email"
 msgstr "ईमेल से जारी रखें"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3721
 msgid "Copy"
 msgstr "कॉपी करें"
 
@@ -746,11 +750,11 @@ msgstr "जोड़ा नहीं जा सका"
 msgid "Could not add MCP server"
 msgstr "MCP सर्वर जोड़ा नहीं जा सका"
 
-#: src/pages/Shell.tsx:5364
+#: src/pages/Shell.tsx:5393
 msgid "Could not approve this server"
 msgstr "इस सर्वर को अनुमोदित नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:5192
+#: src/pages/Shell.tsx:5221
 msgid "Could not authorize this app"
 msgstr "इस ऐप को ऑथराइज़ नहीं किया जा सका"
 
@@ -758,7 +762,7 @@ msgstr "इस ऐप को ऑथराइज़ नहीं किया ज
 msgid "Could not change the default model"
 msgstr "डिफ़ॉल्ट मॉडल बदला नहीं जा सका"
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4867
 msgid "Could not clear conversation"
 msgstr "बातचीत साफ़ नहीं की जा सकी"
 
@@ -787,7 +791,7 @@ msgstr "यह आवाज़ प्रोवाइडर कनेक्ट �
 msgid "Could not continue"
 msgstr "जारी नहीं रखा जा सका"
 
-#: src/pages/Shell.tsx:4273
+#: src/pages/Shell.tsx:4302
 msgid "Could not create bot"
 msgstr "बॉट नहीं बनाया जा सका"
 
@@ -795,7 +799,7 @@ msgstr "बॉट नहीं बनाया जा सका"
 msgid "Could not create group"
 msgstr "समूह नहीं बनाया जा सका"
 
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4758
 msgid "Could not create section"
 msgstr "सेक्शन नहीं बनाया जा सका"
 
@@ -803,7 +807,7 @@ msgstr "सेक्शन नहीं बनाया जा सका"
 msgid "Could not create your bot"
 msgstr "आपका बॉट नहीं बनाया जा सका"
 
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4982
 msgid "Could not delete bot"
 msgstr "बॉट डिलीट नहीं किया जा सका"
 
@@ -811,7 +815,7 @@ msgstr "बॉट डिलीट नहीं किया जा सका"
 msgid "Could not delete MCP server"
 msgstr "MCP सर्वर डिलीट नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:5027
+#: src/pages/Shell.tsx:5056
 msgid "Could not delete routine"
 msgstr "रूटीन डिलीट नहीं किया जा सका"
 
@@ -885,7 +889,7 @@ msgstr "समूह हटाया नहीं जा सका"
 msgid "Could not remove rule"
 msgstr "नियम हटाया नहीं जा सका"
 
-#: src/pages/Shell.tsx:5284
+#: src/pages/Shell.tsx:5313
 msgid "Could not render chart"
 msgstr "चार्ट रेंडर नहीं हो सका"
 
@@ -893,7 +897,7 @@ msgstr "चार्ट रेंडर नहीं हो सका"
 msgid "Could not revoke connection"
 msgstr "कनेक्शन रद्द नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4659
 msgid "Could not save"
 msgstr "सहेजा नहीं जा सका"
 
@@ -905,7 +909,7 @@ msgstr "समूह सहेजा नहीं जा सका"
 msgid "Could not save model"
 msgstr "मॉडल सहेजा नहीं जा सका"
 
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2630
 msgid "Could not save routine"
 msgstr "रूटीन सहेजा नहीं जा सका"
 
@@ -921,7 +925,7 @@ msgstr "वह विकल्प सहेजा नहीं जा सका"
 msgid "Could not save that voice"
 msgstr "वह आवाज़ सहेजी नहीं जा सकी"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5133
 msgid "Could not save this choice"
 msgstr "यह विकल्प सहेजा नहीं जा सका"
 
@@ -949,6 +953,10 @@ msgstr "अपडेट नहीं हो सका"
 msgid "Could not update agent access"
 msgstr "एजेंट एक्सेस अपडेट नहीं हो सका"
 
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Could not update avatar style"
+msgstr "अवतार शैली अपडेट नहीं की जा सकी"
+
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr "कंप्यूटर अपडेट नहीं हो सका"
@@ -958,13 +966,13 @@ msgid "Could not update the default memory scope"
 msgstr "डिफ़ॉल्ट मेमोरी स्कोप अपडेट नहीं हो सका"
 
 #: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Create"
 msgstr "बनाएं"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4738
+#: src/pages/Shell.tsx:4767
 msgid "Create a section and move {0} into it."
 msgstr "एक सेक्शन बनाएं और {0} को उसमें ले जाएं।"
 
@@ -985,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "अपना Rakazo बनाएं"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Creating…"
 msgstr "बनाया जा रहा है…"
 
@@ -1014,7 +1022,7 @@ msgstr "दिन"
 msgid "days"
 msgstr "दिन"
 
-#: src/pages/Shell.tsx:4537
+#: src/pages/Shell.tsx:4566
 msgid "Default (medium)"
 msgstr "डिफ़ॉल्ट (मध्यम)"
 
@@ -1024,21 +1032,21 @@ msgstr "डिफ़ॉल्ट स्कोप"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1970
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:1980
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Delete"
 msgstr "डिलीट करें"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1966
+#: src/pages/Shell.tsx:1976
 msgid "Delete {0}"
 msgstr "{0} डिलीट करें"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4891
-#: src/pages/Shell.tsx:5005
+#: src/pages/Shell.tsx:4920
+#: src/pages/Shell.tsx:5034
 msgid "Delete {0}?"
 msgstr "{0} डिलीट करें?"
 
@@ -1046,21 +1054,21 @@ msgstr "{0} डिलीट करें?"
 msgid "Delete group"
 msgstr "समूह डिलीट करें"
 
-#: src/pages/Shell.tsx:4928
+#: src/pages/Shell.tsx:4957
 msgid "Delete memories too"
 msgstr "मेमोरी भी डिलीट करें"
 
-#: src/pages/Shell.tsx:2670
+#: src/pages/Shell.tsx:2685
 msgid "Delete routine"
 msgstr "रूटीन डिलीट करें"
 
-#: src/pages/Shell.tsx:4039
+#: src/pages/Shell.tsx:4068
 msgid "deleted"
 msgstr "डिलीट किया गया"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Deleting…"
 msgstr "डिलीट किया जा रहा है…"
 
@@ -1077,17 +1085,17 @@ msgid "Deployment default"
 msgstr "डिप्लॉयमेंट डिफ़ॉल्ट"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4310
+#: src/pages/Shell.tsx:4339
 msgid "Describe what this bot does"
 msgstr "बताएं कि यह बॉट क्या करता है"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4315
-#: src/pages/Shell.tsx:4481
+#: src/pages/Shell.tsx:4344
+#: src/pages/Shell.tsx:4510
 msgid "Description"
 msgstr "विवरण"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Dictate"
 msgstr "बोलकर लिखें"
 
@@ -1100,7 +1108,7 @@ msgstr "डिस्कनेक्ट करें"
 msgid "Disconnecting…"
 msgstr "डिस्कनेक्ट हो रहा है…"
 
-#: src/pages/Shell.tsx:5412
+#: src/pages/Shell.tsx:5441
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "खारिज किया गया — MCP सेटिंग्स से कभी भी पुनः कनेक्ट करें।"
 
@@ -1148,7 +1156,7 @@ msgstr "ड्राफ़्ट स्किल"
 msgid "Duplicate"
 msgstr "डुप्लिकेट"
 
-#: src/pages/Shell.tsx:3852
+#: src/pages/Shell.tsx:3881
 msgid "Earlier message"
 msgstr "पुराना संदेश"
 
@@ -1204,11 +1212,11 @@ msgstr "हर महीने"
 msgid "Every week"
 msgstr "हर सप्ताह"
 
-#: src/pages/Shell.tsx:5458
+#: src/pages/Shell.tsx:5487
 msgid "Expand"
 msgstr "विस्तृत करें"
 
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4671
 msgid "Export"
 msgstr "एक्सपोर्ट करें"
 
@@ -1216,7 +1224,7 @@ msgstr "एक्सपोर्ट करें"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "CRM से इस सप्ताह की सूची एक्सपोर्ट करें और उसे साझा फ़ोल्डर में डालें"
 
-#: src/pages/Shell.tsx:4662
+#: src/pages/Shell.tsx:4691
 msgid "Extra high"
 msgstr "अतिरिक्त उच्च"
 
@@ -1267,8 +1275,8 @@ msgstr ""
 msgid "Fullscreen"
 msgstr "फ़ुलस्क्रीन"
 
-#: src/pages/Shell.tsx:2120
-#: src/pages/Shell.tsx:2271
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2286
 msgid "Group"
 msgstr "समूह"
 
@@ -1297,15 +1305,15 @@ msgstr "एक नमूना सुनें"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "नमस्ते, उत्तर पढ़कर सुनाते समय मेरी आवाज़ ऐसी होगी।"
 
-#: src/pages/Shell.tsx:4665
+#: src/pages/Shell.tsx:4694
 msgid "High"
 msgstr "उच्च"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk"
 msgstr "बोलने के लिए दबाए रखें"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk (on-device dictation)"
 msgstr "बोलने के लिए दबाए रखें (डिवाइस पर ही श्रुतलेखन)"
 
@@ -1325,7 +1333,7 @@ msgstr "कितनी बार"
 msgid "How to check"
 msgstr "जांच कैसे करें"
 
-#: src/pages/Shell.tsx:3748
+#: src/pages/Shell.tsx:3777
 msgid "I’m done"
 msgstr "मेरा काम हो गया"
 
@@ -1337,7 +1345,7 @@ msgstr "अगर आपने वह सुना, तो आवाज़ त�
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON इम्पोर्ट करें"
 
-#: src/pages/Shell.tsx:4552
+#: src/pages/Shell.tsx:4581
 msgid "Inherit default"
 msgstr "डिफ़ॉल्ट का पालन करें"
 
@@ -1349,12 +1357,12 @@ msgstr "इनपुट"
 msgid "Instance API key"
 msgstr "इंस्टेंस API कुंजी"
 
-#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2569
 msgid "Instruction"
 msgstr "निर्देश"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1987
+#: src/pages/Shell.tsx:1997
 msgid "Integrations"
 msgstr "इंटीग्रेशन"
 
@@ -1375,15 +1383,15 @@ msgid "Interval unit"
 msgstr "अंतराल इकाई"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4553
+#: src/pages/Shell.tsx:4582
 msgid "Isolated"
 msgstr "पृथक"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4923
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "इसकी बातचीत, फ़ाइलें और रूटीन स्थायी रूप से डिलीट कर दिए जाएंगे। इसके बनाए बॉट आपकी सूची में बने रहेंगे।"
 
-#: src/pages/Shell.tsx:3847
+#: src/pages/Shell.tsx:3876
 msgid "Jump to replied message"
 msgstr "जिस संदेश का उत्तर दिया गया उस पर जाएं"
 
@@ -1391,7 +1399,7 @@ msgstr "जिस संदेश का उत्तर दिया गया 
 msgid "just now"
 msgstr "अभी-अभी"
 
-#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:4941
 msgid "Keep memories"
 msgstr "मेमोरी रखें"
 
@@ -1399,9 +1407,9 @@ msgstr "मेमोरी रखें"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "कुंजियां सर्वर पर ही रहती हैं। ऐप को केवल यह पता चलता है कि कोई प्रोवाइडर कॉन्फ़िगर है या नहीं।"
 
-#: src/pages/AccountSettingsOverlay.tsx:105
-#: src/pages/AccountSettingsOverlay.tsx:254
-#: src/pages/AccountSettingsOverlay.tsx:271
+#: src/pages/AccountSettingsOverlay.tsx:126
+#: src/pages/AccountSettingsOverlay.tsx:313
+#: src/pages/AccountSettingsOverlay.tsx:330
 msgid "Language"
 msgstr "भाषा"
 
@@ -1409,7 +1417,7 @@ msgstr "भाषा"
 msgid "Listening…"
 msgstr "सुना जा रहा है…"
 
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Load earlier messages"
 msgstr "पुराने संदेश लोड करें"
 
@@ -1449,7 +1457,7 @@ msgstr "आवाज़ प्रोवाइडर्स लोड हो र�
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Loading…"
 msgstr "लोड हो रहा है…"
 
@@ -1457,11 +1465,11 @@ msgstr "लोड हो रहा है…"
 msgid "Local"
 msgstr "लोकल"
 
-#: src/pages/Shell.tsx:2073
+#: src/pages/Shell.tsx:2083
 msgid "Log out"
 msgstr "लॉग आउट"
 
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4692
 msgid "Low"
 msgstr "निम्न"
 
@@ -1477,7 +1485,7 @@ msgstr "पढ़ा हुआ चिह्नित करें"
 msgid "Mark as Unread"
 msgstr "अपठित चिह्नित करें"
 
-#: src/pages/Shell.tsx:4667
+#: src/pages/Shell.tsx:4696
 msgid "Max"
 msgstr "अधिकतम"
 
@@ -1487,7 +1495,7 @@ msgstr "अधिकतम"
 msgid "MCP servers"
 msgstr "MCP सर्वर"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4693
 msgid "Medium"
 msgstr "मध्यम"
 
@@ -1500,33 +1508,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "सदस्य ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} चुनें)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2031
+#: src/pages/Shell.tsx:2041
 msgid "Memory"
 msgstr "मेमोरी"
 
-#: src/pages/Shell.tsx:4548
+#: src/pages/Shell.tsx:4577
 msgid "Memory scope"
 msgstr "मेमोरी स्कोप"
 
-#: src/pages/Shell.tsx:3548
-#: src/pages/Shell.tsx:3643
+#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3672
 msgid "Message"
 msgstr "संदेश"
 
-#: src/pages/Shell.tsx:3544
-#: src/pages/Shell.tsx:3548
+#: src/pages/Shell.tsx:3573
+#: src/pages/Shell.tsx:3577
 msgid "Message {activeName}"
 msgstr "{activeName} को संदेश भेजें"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Message from {peer}"
 msgstr "{peer} का संदेश"
 
-#: src/pages/Shell.tsx:3545
+#: src/pages/Shell.tsx:3574
 msgid "Message…"
 msgstr "संदेश…"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Messaged {peer}"
 msgstr "{peer} को संदेश भेजा"
 
@@ -1534,7 +1542,7 @@ msgstr "{peer} को संदेश भेजा"
 msgid "Microphone failed"
 msgstr "माइक्रोफ़ोन विफल"
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4695
 msgid "Minimal"
 msgstr "न्यूनतम"
 
@@ -1556,7 +1564,7 @@ msgstr "मिनट"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4504
+#: src/pages/Shell.tsx:4533
 msgid "Model"
 msgstr "मॉडल"
 
@@ -1569,7 +1577,7 @@ msgstr "मॉडल आईडी"
 msgid "Model options"
 msgstr "मॉडल विकल्प"
 
-#: src/pages/AccountSettingsOverlay.tsx:127
+#: src/pages/AccountSettingsOverlay.tsx:186
 msgid "Model spend uses your provider keys."
 msgstr "मॉडल का खर्च आपकी प्रोवाइडर कुंजियों से होता है।"
 
@@ -1578,7 +1586,7 @@ msgid "Model updated."
 msgstr "मॉडल अपडेट किया गया।"
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2018
+#: src/pages/Shell.tsx:2028
 msgid "Models"
 msgstr "मॉडल्स"
 
@@ -1596,7 +1604,7 @@ msgstr "मासिक"
 msgid "Move {0} to section"
 msgstr "{0} को सेक्शन में ले जाएं"
 
-#: src/pages/Shell.tsx:4915
+#: src/pages/Shell.tsx:4944
 msgid "Move them to your shared memory."
 msgstr "उन्हें अपनी साझा मेमोरी में ले जाएं।"
 
@@ -1609,15 +1617,15 @@ msgstr "यहां ले जाएं"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2546
-#: src/pages/Shell.tsx:4295
-#: src/pages/Shell.tsx:4463
-#: src/pages/Shell.tsx:4741
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:4324
+#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4770
 msgid "Name"
 msgstr "नाम"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4300
+#: src/pages/Shell.tsx:4329
 msgid "Name this bot"
 msgstr "इस बॉट को नाम दें"
 
@@ -1634,7 +1642,7 @@ msgid "Needs takeover"
 msgstr "नियंत्रण लेना ज़रूरी"
 
 #: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4283
+#: src/pages/Shell.tsx:4312
 msgid "New bot"
 msgstr "नया बॉट"
 
@@ -1647,12 +1655,12 @@ msgstr "नया समूह"
 msgid "New open-work item"
 msgstr "नया खुला-कार्य आइटम"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2447
 msgid "New routine"
 msgstr "नया रूटीन"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4735
+#: src/pages/Shell.tsx:4764
 msgid "New section"
 msgstr "नया सेक्शन"
 
@@ -1730,7 +1738,7 @@ msgstr "कनेक्टेड नहीं"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5400
+#: src/pages/Shell.tsx:5429
 msgid "Not now"
 msgstr "अभी नहीं"
 
@@ -1768,15 +1776,15 @@ msgstr "1 तारीख को {0} बजे"
 msgid "Open"
 msgstr "खोलें"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Open computer"
 msgstr "कंप्यूटर खोलें"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2315
 msgid "Open in full window"
 msgstr "पूरी विंडो में खोलें"
 
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2107
 msgid "Open navigation"
 msgstr "नेविगेशन खोलें"
 
@@ -1793,7 +1801,7 @@ msgstr "खुला कार्य"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-संगत सर्वर URL"
 
-#: src/pages/Shell.tsx:4050
+#: src/pages/Shell.tsx:4079
 msgid "Opened its thread."
 msgstr "इसका थ्रेड खोला।"
 
@@ -1806,7 +1814,7 @@ msgstr "आपका वर्कस्पेस खुल रहा है…"
 msgid "Optional"
 msgstr "वैकल्पिक"
 
-#: src/pages/AccountSettingsOverlay.tsx:141
+#: src/pages/AccountSettingsOverlay.tsx:200
 msgid "Optional controls most people never need"
 msgstr "वैकल्पिक नियंत्रण जिनकी अधिकांश लोगों को कभी ज़रूरत नहीं होती"
 
@@ -1821,6 +1829,10 @@ msgstr "या एक API कुंजी कनेक्ट करें"
 #: src/pages/Onboarding.tsx:464
 msgid "Or paste an API key"
 msgstr "या एक API कुंजी पेस्ट करें"
+
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Organic"
+msgstr "ऑर्गेनिक"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -1876,7 +1888,7 @@ msgstr "प्ले हो रहा है…"
 msgid "Preview {0}"
 msgstr "{0} का प्रीव्यू"
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Private"
 msgstr "निजी"
 
@@ -1897,7 +1909,7 @@ msgstr "कतार में"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo सहेजने से पहले स्रोत की पुष्टि करता है। क्रेडेंशियल एन्क्रिप्टेड होते हैं और कभी क्लाइंट को नहीं लौटाए जाते, न ही मॉडल को दिखाए जाते हैं।"
 
-#: src/pages/Shell.tsx:4580
+#: src/pages/Shell.tsx:4609
 msgid "Read replies aloud"
 msgstr "उत्तर पढ़कर सुनाएं"
 
@@ -1931,7 +1943,7 @@ msgstr "रिकवर एक ऐसे कंप्यूटर को बद�
 msgid "Recovering…"
 msgstr "रिकवर हो रहा है…"
 
-#: src/pages/Shell.tsx:3738
+#: src/pages/Shell.tsx:3767
 msgid "Release"
 msgstr "नियंत्रण छोड़ें"
 
@@ -1944,17 +1956,17 @@ msgid "Remove"
 msgstr "हटाएं"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3352
+#: src/pages/Shell.tsx:3381
 msgid "Remove {0}"
 msgstr "{0} हटाएं"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3507
+#: src/pages/Shell.tsx:3536
 msgid "Remove mention {0}"
 msgstr "उल्लेख {0} हटाएं"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3515
 msgid "Remove skill {0}"
 msgstr "स्किल {0} हटाएं"
 
@@ -1962,7 +1974,7 @@ msgstr "स्किल {0} हटाएं"
 msgid "Remove this schedule"
 msgstr "यह शेड्यूल हटाएं"
 
-#: src/pages/Shell.tsx:4049
+#: src/pages/Shell.tsx:4078
 msgid "Removed with chat, computer, and memory."
 msgstr "चैट, कंप्यूटर और मेमोरी सहित हटाया गया।"
 
@@ -1990,11 +2002,11 @@ msgstr "API कुंजी बदलें"
 msgid "Replace key"
 msgstr "कुंजी बदलें"
 
-#: src/pages/Shell.tsx:3684
+#: src/pages/Shell.tsx:3713
 msgid "Reply"
 msgstr "उत्तर दें"
 
-#: src/pages/Shell.tsx:3315
+#: src/pages/Shell.tsx:3344
 msgid "Replying to {replyName}"
 msgstr "{replyName} को उत्तर दे रहे हैं"
 
@@ -2015,7 +2027,7 @@ msgstr "कंप्यूटर रीसेट करें?"
 msgid "Resetting…"
 msgstr "रीसेट हो रहा है…"
 
-#: src/pages/Shell.tsx:1962
+#: src/pages/Shell.tsx:1972
 msgid "Restore"
 msgstr "बहाल करें"
 
@@ -2031,17 +2043,21 @@ msgstr "अभी पुनः प्रयास करें"
 msgid "Return to Rakazo"
 msgstr "Rakazo पर लौटें"
 
-#: src/pages/Shell.tsx:2539
-#: src/pages/Shell.tsx:2592
-#: src/pages/Shell.tsx:2599
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Robot"
+msgstr "रोबोट"
+
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Routine"
 msgstr "रूटीन"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2392
 msgid "Routines"
 msgstr "रूटीन्स"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Run now"
 msgstr "अभी चलाएं"
 
@@ -2049,11 +2065,11 @@ msgstr "अभी चलाएं"
 msgid "Running"
 msgstr "चल रहा है"
 
-#: src/pages/Shell.tsx:2417
+#: src/pages/Shell.tsx:2432
 msgid "Running · Stop"
 msgstr "चल रहा है · रोकें"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Running…"
 msgstr "चल रहा है…"
 
@@ -2061,8 +2077,8 @@ msgstr "चल रहा है…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2638
-#: src/pages/Shell.tsx:4635
+#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:4664
 msgid "Save"
 msgstr "सहेजें"
 
@@ -2086,7 +2102,7 @@ msgstr "सहेजा गया।"
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2638
+#: src/pages/Shell.tsx:2653
 msgid "Saving…"
 msgstr "सहेजा जा रहा है…"
 
@@ -2127,11 +2143,11 @@ msgstr "प्रोवाइडर्स और मॉडल खोजें"
 msgid "Searching…"
 msgstr "खोजा जा रहा है…"
 
-#: src/pages/Shell.tsx:2121
+#: src/pages/Shell.tsx:2136
 msgid "Select a bot"
 msgstr "एक बॉट चुनें"
 
-#: src/pages/Shell.tsx:3568
+#: src/pages/Shell.tsx:3597
 msgid "Send"
 msgstr "भेजें"
 
@@ -2159,22 +2175,22 @@ msgstr "सर्वर का नाम"
 msgid "Server URL"
 msgstr "सर्वर URL"
 
-#: src/pages/Shell.tsx:2130
+#: src/pages/Shell.tsx:2145
 msgid "Set up voice to call"
 msgstr "कॉल के लिए आवाज़ सेट करें"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1995
+#: src/pages/AccountSettingsOverlay.tsx:100
 #: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2267
+#: src/pages/Shell.tsx:2015
+#: src/pages/Shell.tsx:2282
 msgid "Settings"
 msgstr "सेटिंग्स"
 
-#: src/pages/Shell.tsx:3586
+#: src/pages/Shell.tsx:3615
 msgid "Settings: General"
 msgstr "सेटिंग्स: सामान्य"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3617
 msgid "Settings: Usage"
 msgstr "सेटिंग्स: उपयोग"
 
@@ -2184,15 +2200,15 @@ msgid "Setup help"
 msgstr "सेटअप सहायता"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4554
+#: src/pages/Shell.tsx:4583
 msgid "Shared"
 msgstr "साझा"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show computer"
 msgstr "कंप्यूटर दिखाएं"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show settings"
 msgstr "सेटिंग्स दिखाएं"
 
@@ -2216,11 +2232,11 @@ msgid "Sign up"
 msgstr "साइन अप करें"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3399
+#: src/pages/Shell.tsx:3428
 msgid "Skill {0}"
 msgstr "स्किल {0}"
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3774
 msgid "Skip"
 msgstr "छोड़ें"
 
@@ -2241,8 +2257,8 @@ msgstr "{0} को छोड़ा गया"
 msgid "Space interrupts · Esc hangs up"
 msgstr "स्पेस से बीच में रोकें · Esc से कॉल समाप्त करें"
 
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Speak"
 msgstr "बोलें"
 
@@ -2254,8 +2270,8 @@ msgstr "बोलें + लिप्यंतरण करें"
 msgid "Speak only"
 msgstr "केवल बोलें"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Speak this reply"
 msgstr "यह उत्तर बोलकर सुनाएं"
 
@@ -2281,20 +2297,20 @@ msgstr "शुरू हो रहा है…"
 msgid "Steps"
 msgstr "चरण"
 
-#: src/pages/Shell.tsx:2918
-#: src/pages/Shell.tsx:2922
-#: src/pages/Shell.tsx:3559
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2947
+#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Stop"
 msgstr "रोकें"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Stop dictation"
 msgstr "श्रुतलेखन रोकें"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Stop speaking"
 msgstr "बोलना रोकें"
 
@@ -2303,8 +2319,8 @@ msgstr "बोलना रोकें"
 msgid "Stop teaching"
 msgstr "सिखाना रोकें"
 
-#: src/pages/Shell.tsx:2357
-#: src/pages/Shell.tsx:2938
+#: src/pages/Shell.tsx:2372
+#: src/pages/Shell.tsx:2963
 msgid "Stop the bot first"
 msgstr "पहले बॉट रोकें"
 
@@ -2312,7 +2328,7 @@ msgstr "पहले बॉट रोकें"
 msgid "Stored encrypted"
 msgstr "एन्क्रिप्टेड रूप में संग्रहीत"
 
-#: src/pages/Shell.tsx:4001
+#: src/pages/Shell.tsx:4030
 msgid "subagent"
 msgstr "सबएजेंट"
 
@@ -2325,8 +2341,8 @@ msgstr "सबमिट करें"
 msgid "Switching…"
 msgstr "बदला जा रहा है…"
 
-#: src/pages/Shell.tsx:2360
-#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2375
+#: src/pages/Shell.tsx:2968
 msgid "Take control"
 msgstr "नियंत्रण लें"
 
@@ -2334,7 +2350,7 @@ msgstr "नियंत्रण लें"
 msgid "Teach a task"
 msgstr "कोई कार्य सिखाएं"
 
-#: src/pages/Shell.tsx:2193
+#: src/pages/Shell.tsx:2208
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "सिखाना जारी है — नया संदेश भेजने से पहले सिखाना रोकें।"
 
@@ -2342,11 +2358,11 @@ msgstr "सिखाना जारी है — नया संदेश भ
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "सिखाने के लिए ग्राफ़िकल सैंडबॉक्स कंप्यूटर चाहिए। डेस्कटॉप-होस्ट बॉट शेल कार्य चला सकते हैं, लेकिन स्क्रीन रिकॉर्डिंग नहीं।"
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Team"
 msgstr "टीम"
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "Team Computer"
 msgstr "टीम कंप्यूटर"
 
@@ -2359,20 +2375,20 @@ msgstr "टेस्ट करें"
 msgid "The selected memory provider is not available in this build."
 msgstr "चयनित मेमोरी प्रोवाइडर इस बिल्ड में उपलब्ध नहीं है।"
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4560
 msgid "Thinking"
 msgstr "सोच रहा है"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2319
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "यह बॉट इसी कंप्यूटर पर चलता है, किसी Linux डेस्कटॉप पर नहीं। शेल और फ़ाइलें आपके होम फ़ोल्डर का उपयोग करती हैं।"
 
-#: src/pages/Shell.tsx:2967
+#: src/pages/Shell.tsx:2992
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "यह बॉट इसी कंप्यूटर पर चलता है। कोई अलग Linux डेस्कटॉप नहीं है। इससे शेल का उपयोग करने को कहें; आपके होम फ़ोल्डर के अंदर की वर्किंग डायरेक्ट्री की अनुमति है।"
 
-#: src/pages/Shell.tsx:4931
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:4960
+#: src/pages/Shell.tsx:5037
 msgid "This cannot be undone."
 msgstr "इसे पूर्ववत नहीं किया जा सकता।"
 
@@ -2396,7 +2412,7 @@ msgstr "यह Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "यह Mac आपके खाते से शेल कमांड चलाता है, जिसमें आपके होम फ़ोल्डर की फ़ाइलें भी शामिल हैं। इसे किसी साझा या सार्वजनिक सर्वर पर चालू न करें।"
 
-#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4845
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "यह हर संदेश को स्थायी रूप से हटा देता है और मौजूदा काम रोक देता है। बॉट, कंप्यूटर, मेमोरी और रूटीन सुरक्षित रहते हैं।"
 
@@ -2404,7 +2420,7 @@ msgstr "यह हर संदेश को स्थायी रूप से
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "यह प्रोवाइडर यहां कुंजी पेस्ट नहीं कर सकता। यदि इस डिप्लॉयमेंट में पहले से क्रेडेंशियल हैं तो छोड़ दें।"
 
-#: src/pages/Shell.tsx:5348
+#: src/pages/Shell.tsx:5377
 msgid "This server cannot be assigned without a bot."
 msgstr "बॉट के बिना यह सर्वर असाइन नहीं किया जा सकता।"
 
@@ -2416,7 +2432,7 @@ msgstr "इस सर्वर ने ब्राउज़र ऑथराइ�
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "यह सर्वर पहले से कनेक्टेड है। पुनः ऑथराइज़ करने के लिए पहले इसे डिस्कनेक्ट करें।"
 
-#: src/pages/Shell.tsx:5387
+#: src/pages/Shell.tsx:5416
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "यह सर्वर ब्राउज़र साइन-इन का उपयोग करता है। अपने एजेंट को इसके टूल उपयोग करने देने के लिए इसे ऑथराइज़ करें — एक पॉपअप खुलेगा।"
 
@@ -2429,8 +2445,8 @@ msgid "Time of day"
 msgstr "दिन का समय"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4305
-#: src/pages/Shell.tsx:4472
+#: src/pages/Shell.tsx:4334
+#: src/pages/Shell.tsx:4501
 msgid "Title"
 msgstr "शीर्षक"
 
@@ -2467,8 +2483,8 @@ msgstr "कंप्यूटर अपडेट करें"
 msgid "Updating…"
 msgstr "अपडेट हो रहा है…"
 
-#: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2056
+#: src/pages/AccountSettingsOverlay.tsx:176
+#: src/pages/Shell.tsx:2066
 msgid "Usage"
 msgstr "उपयोग"
 
@@ -2493,8 +2509,8 @@ msgstr "पुष्टि करके जोड़ें"
 msgid "Verifying…"
 msgstr "पुष्टि की जा रही है…"
 
-#: src/pages/Shell.tsx:2044
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:2054
+#: src/pages/Shell.tsx:4613
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2507,7 +2523,7 @@ msgstr "आवाज़"
 msgid "Waiting for sign-in…"
 msgstr "साइन-इन की प्रतीक्षा…"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5260
 msgid "Waiting…"
 msgstr "प्रतीक्षा…"
 
@@ -2516,7 +2532,7 @@ msgstr "प्रतीक्षा…"
 msgid "Weekdays"
 msgstr "कार्यदिवस"
 
-#: src/pages/Shell.tsx:4901
+#: src/pages/Shell.tsx:4930
 msgid "What about its memories?"
 msgstr "इसकी मेमोरी का क्या करें?"
 
@@ -2525,7 +2541,7 @@ msgid "What result will you demonstrate?"
 msgstr "आप कौन-सा परिणाम दिखाकर बताएंगे?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4320
+#: src/pages/Shell.tsx:4349
 msgid "What this bot is for"
 msgstr "यह बॉट किस लिए है"
 
@@ -2537,7 +2553,7 @@ msgstr "क्या लौटाना है"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "जब {botName} किसी दूसरे बॉट को संदेश भेजता है, तो वह आदान-प्रदान चैट के बजाय यहां दिखता है।"
 
-#: src/pages/Shell.tsx:2563
+#: src/pages/Shell.tsx:2578
 msgid "When to run"
 msgstr "कब चलाएं"
 
@@ -2554,7 +2570,7 @@ msgstr "बॉट कहां चलने चाहिए?"
 msgid "Working…"
 msgstr "काम चल रहा है…"
 
-#: src/pages/Shell.tsx:4514
+#: src/pages/Shell.tsx:4543
 msgid "Workspace default"
 msgstr "वर्कस्पेस डिफ़ॉल्ट"
 
@@ -2571,8 +2587,8 @@ msgstr "अगर यह अपने आप रीडायरेक्ट न 
 msgid "You can close this window."
 msgstr "आप यह विंडो बंद कर सकते हैं।"
 
-#: src/pages/Shell.tsx:2337
-#: src/pages/Shell.tsx:2908
+#: src/pages/Shell.tsx:2352
+#: src/pages/Shell.tsx:2933
 msgid "You have control"
 msgstr "नियंत्रण आपके पास है"
 

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -418,7 +418,7 @@ msgstr "ऑथराइज़ करें"
 
 #: src/pages/AccountSettingsOverlay.tsx:133
 msgid "Avatars"
-msgstr "अवतार"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -953,10 +953,6 @@ msgstr "अपडेट नहीं हो सका"
 msgid "Could not update agent access"
 msgstr "एजेंट एक्सेस अपडेट नहीं हो सका"
 
-#: src/pages/AccountSettingsOverlay.tsx:80
-msgid "Could not update avatar style"
-msgstr "अवतार शैली अपडेट नहीं की जा सकी"
-
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr "कंप्यूटर अपडेट नहीं हो सका"
@@ -964,6 +960,10 @@ msgstr "कंप्यूटर अपडेट नहीं हो सका"
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "डिफ़ॉल्ट मेमोरी स्कोप अपडेट नहीं हो सका"
+
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Couldn't update avatars"
+msgstr ""
 
 #: src/pages/Shell.tsx:1761
 #: src/pages/Shell.tsx:4361
@@ -1832,7 +1832,7 @@ msgstr "या एक API कुंजी पेस्ट करें"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Organic"
-msgstr "ऑर्गेनिक"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -2045,7 +2045,7 @@ msgstr "Rakazo पर लौटें"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Robot"
-msgstr "रोबोट"
+msgstr ""
 
 #: src/pages/Shell.tsx:2554
 #: src/pages/Shell.tsx:2607

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1857
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (읽지 않음)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5204
+#: src/pages/Shell.tsx:5233
 msgid "{0} connection"
 msgstr "{0} 연결"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2341
+#: src/pages/Shell.tsx:2356
 msgid "{0} is using it"
 msgstr "{0}가 사용 중"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2061
+#: src/pages/AccountSettingsOverlay.tsx:180
+#: src/pages/Shell.tsx:2071
 msgid "{0} runs · {1} tokens"
 msgstr "{0}회 실행 · 토큰 {1}개"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {동료 Bot #개} other {동료 Bot #개}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName}은 아직 다른 Bot에게 메시지를 보내지 않았습니다."
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "{botName}’s computer"
 msgstr "{botName}의 컴퓨터"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3371
+#: src/pages/Shell.tsx:3400
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ 작업 가르치기"
 msgid "Access token (optional)"
 msgstr "액세스 토큰(선택 사항)"
 
-#: src/pages/AccountSettingsOverlay.tsx:97
+#: src/pages/AccountSettingsOverlay.tsx:118
 msgid "Account"
 msgstr "계정"
 
-#: src/pages/Shell.tsx:4590
+#: src/pages/Shell.tsx:4619
 msgid "Account default"
 msgstr "계정 기본값"
 
-#: src/pages/AccountSettingsOverlay.tsx:82
+#: src/pages/AccountSettingsOverlay.tsx:103
 msgid "Account preferences apply across all your bots."
 msgstr "이 설정은 내가 만든 모든 Bot에 똑같이 적용됩니다."
 
@@ -218,10 +218,10 @@ msgstr "Treg 추가"
 msgid "Adding…"
 msgstr "추가 중…"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4522
 msgid "Advanced"
 msgstr "고급 설정"
 
@@ -229,7 +229,7 @@ msgstr "고급 설정"
 msgid "Agent access for new servers"
 msgstr "새 서버를 사용할 Bot"
 
-#: src/pages/Shell.tsx:2148
+#: src/pages/Shell.tsx:2163
 msgid "Agent computer"
 msgstr "Agent 컴퓨터"
 
@@ -316,11 +316,11 @@ msgstr "서버를 추가할 때 적용됩니다. 각 서버 카드의 Bot 버튼
 msgid "Approval boundaries"
 msgstr "승인이 필요한 범위"
 
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 msgid "Approve"
 msgstr "승인"
 
-#: src/pages/Shell.tsx:5388
+#: src/pages/Shell.tsx:5417
 msgid "Approve this server to let your agent use its tools."
 msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 있습니다."
 
@@ -328,15 +328,15 @@ msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 �
 msgid "Archive"
 msgstr "보관"
 
-#: src/pages/Shell.tsx:4037
+#: src/pages/Shell.tsx:4066
 msgid "archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:1941
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:4048
+#: src/pages/Shell.tsx:4077
 msgid "Archived. Chat, memory, and files kept."
 msgstr "보관되었습니다. 대화, 기억, 파일은 유지됩니다."
 
@@ -375,7 +375,7 @@ msgstr "결제하기 전에 확인"
 msgid "Ask before sending external email"
 msgstr "외부 이메일을 보내기 전에 확인"
 
-#: src/pages/Shell.tsx:2343
+#: src/pages/Shell.tsx:2358
 msgid "Asleep"
 msgstr "절전 중"
 
@@ -390,11 +390,11 @@ msgstr "{0}에"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}에"
 
-#: src/pages/Shell.tsx:3442
+#: src/pages/Shell.tsx:3471
 msgid "Attach file"
 msgstr "파일 첨부"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3670
 msgid "Attachment"
 msgstr "첨부 파일"
 
@@ -407,14 +407,18 @@ msgstr "인증 코드 또는 돌아온 페이지 주소"
 msgid "Authorization expired — reconnect required"
 msgstr "인증이 만료됨 — 다시 연결해야 함"
 
-#: src/pages/Shell.tsx:5189
+#: src/pages/Shell.tsx:5218
 msgid "Authorization timed out. Please try again."
 msgstr "인증 시간이 만료되었습니다. 다시 시도해 주세요."
 
-#: src/pages/Shell.tsx:5231
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5426
 msgid "Authorize"
 msgstr "인증하기"
+
+#: src/pages/AccountSettingsOverlay.tsx:133
+msgid "Avatars"
+msgstr "아바타"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -424,18 +428,18 @@ msgstr "서버 주소"
 msgid "Bearer token"
 msgstr "Bearer 토큰"
 
-#: src/pages/Shell.tsx:5073
+#: src/pages/Shell.tsx:5102
 msgid "Booting live desktop…"
 msgstr "라이브 데스크톱 시작 중…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2903
 msgid "Booting up {0}’s computer"
 msgstr "{0}의 컴퓨터를 켜는 중"
 
-#: src/pages/Shell.tsx:3907
-#: src/pages/Shell.tsx:3908
-#: src/pages/Shell.tsx:4041
+#: src/pages/Shell.tsx:3936
+#: src/pages/Shell.tsx:3937
+#: src/pages/Shell.tsx:4070
 msgid "bot"
 msgstr "Bot"
 
@@ -447,11 +451,11 @@ msgstr "봇"
 msgid "Bot messages"
 msgstr "Bot 메시지"
 
-#: src/pages/Shell.tsx:2975
+#: src/pages/Shell.tsx:3000
 msgid "Bot screen"
 msgstr "Bot 화면"
 
-#: src/pages/Shell.tsx:2311
+#: src/pages/Shell.tsx:2326
 msgid "Bot screen preview"
 msgstr "Bot 화면 미리보기"
 
@@ -464,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "사용 중인 서비스의 API 키를 연결하세요. 서비스를 바꿔도 Bot의 읽기·통화 기능은 그대로 유지됩니다."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2130
-#: src/pages/Shell.tsx:2131
+#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2146
 msgid "Call"
 msgstr "통화"
 
@@ -477,14 +481,14 @@ msgstr "서버에 연결할 수 없습니다."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4829
-#: src/pages/Shell.tsx:4944
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4858
+#: src/pages/Shell.tsx:4973
+#: src/pages/Shell.tsx:5047
 msgid "Cancel"
 msgstr "취소"
 
-#: src/pages/Shell.tsx:4285
+#: src/pages/Shell.tsx:4314
 msgid "Cancel new bot"
 msgstr "새 Bot 만들기 취소"
 
@@ -492,7 +496,7 @@ msgstr "새 Bot 만들기 취소"
 msgid "Cancel new group"
 msgstr "새 그룹 만들기 취소"
 
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3347
 msgid "Cancel reply"
 msgstr "답장 취소"
 
@@ -500,16 +504,16 @@ msgstr "답장 취소"
 msgid "Cancelled"
 msgstr "취소됨"
 
-#: src/pages/Shell.tsx:5294
+#: src/pages/Shell.tsx:5323
 msgid "Chart failed to render: {error}"
 msgstr "차트를 표시하지 못했습니다: {error}"
 
-#: src/pages/Shell.tsx:3584
+#: src/pages/Shell.tsx:3613
 msgid "Chat Settings"
 msgstr "채팅 설정"
 
-#: src/pages/Shell.tsx:2593
-#: src/pages/Shell.tsx:2600
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:2615
 msgid "Check in."
 msgstr "확인해 주세요."
 
@@ -521,21 +525,21 @@ msgstr "먼저 사용할 AI 모델을 선택하세요."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo에서 기본으로 사용할 연결된 모델을 선택하세요."
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clear"
 msgstr "비우기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4839
 msgid "Clear {0}’s conversation?"
 msgstr "{0}와의 대화 내용을 비울까요?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4645
+#: src/pages/Shell.tsx:4674
 msgid "Clear conversation"
 msgstr "대화 내용 비우기"
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clearing…"
 msgstr "비우는 중…"
 
@@ -551,15 +555,15 @@ msgstr "Bot 메뉴 닫기"
 msgid "Close bot messages"
 msgstr "Bot 메시지 닫기"
 
-#: src/pages/Shell.tsx:5479
+#: src/pages/Shell.tsx:5508
 msgid "Close chart"
 msgstr "차트 닫기"
 
-#: src/pages/Shell.tsx:2949
+#: src/pages/Shell.tsx:2974
 msgid "Close computer"
 msgstr "컴퓨터 닫기"
 
-#: src/pages/Shell.tsx:5579
+#: src/pages/Shell.tsx:5608
 msgid "Close image preview"
 msgstr "이미지 미리보기 닫기"
 
@@ -583,7 +587,7 @@ msgstr "AI 모델 설정 닫기"
 msgid "Close navigation"
 msgstr "메뉴 닫기"
 
-#: src/pages/Shell.tsx:2289
+#: src/pages/Shell.tsx:2304
 msgid "Close panel"
 msgstr "패널 닫기"
 
@@ -592,7 +596,7 @@ msgstr "패널 닫기"
 msgid "Close preview"
 msgstr "미리보기 닫기"
 
-#: src/pages/AccountSettingsOverlay.tsx:87
+#: src/pages/AccountSettingsOverlay.tsx:108
 msgid "Close user settings"
 msgstr "계정 설정 닫기"
 
@@ -612,24 +616,24 @@ msgstr "실행 명령"
 msgid "Complete"
 msgstr "완료"
 
-#: src/pages/Shell.tsx:4195
-#: src/pages/Shell.tsx:4223
+#: src/pages/Shell.tsx:4224
+#: src/pages/Shell.tsx:4252
 msgid "Computer"
 msgstr "컴퓨터"
 
-#: src/pages/Shell.tsx:5076
+#: src/pages/Shell.tsx:5105
 msgid "Computer failed to boot"
 msgstr "컴퓨터를 시작하지 못했습니다"
 
-#: src/pages/Shell.tsx:2997
+#: src/pages/Shell.tsx:3022
 msgid "Computer is asleep"
 msgstr "컴퓨터가 절전 상태입니다"
 
-#: src/pages/Shell.tsx:5075
+#: src/pages/Shell.tsx:5104
 msgid "Computer is asleep — take control to wake it"
 msgstr "컴퓨터가 절전 상태입니다 — 제어를 맡아 깨우세요"
 
-#: src/pages/Shell.tsx:5077
+#: src/pages/Shell.tsx:5106
 msgid "Computer is stopped"
 msgstr "컴퓨터가 중지됨"
 
@@ -662,7 +666,7 @@ msgstr "API 키 연결"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI 또는 Cartesia 연결"
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5406
 msgid "Connect MCP server “{name}”"
 msgstr "MCP 서버 ‘{name}’ 연결"
 
@@ -685,12 +689,12 @@ msgstr "Treg 연결"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5228
+#: src/pages/Shell.tsx:5257
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "연결됨"
 
-#: src/pages/Shell.tsx:5407
+#: src/pages/Shell.tsx:5436
 msgid "Connected — its tools are available from your next message."
 msgstr "연결되었습니다. 다음 메시지부터 이 도구를 사용할 수 있습니다."
 
@@ -715,7 +719,7 @@ msgstr "{0}에 연결하고 기본 모델로 설정했습니다."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "연결 중…"
@@ -734,7 +738,7 @@ msgstr "계속"
 msgid "Continue with email"
 msgstr "이메일로 계속하기"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3721
 msgid "Copy"
 msgstr "복사"
 
@@ -746,11 +750,11 @@ msgstr "추가하지 못했습니다."
 msgid "Could not add MCP server"
 msgstr "MCP 서버를 추가하지 못했습니다."
 
-#: src/pages/Shell.tsx:5364
+#: src/pages/Shell.tsx:5393
 msgid "Could not approve this server"
 msgstr "서버를 승인하지 못했습니다."
 
-#: src/pages/Shell.tsx:5192
+#: src/pages/Shell.tsx:5221
 msgid "Could not authorize this app"
 msgstr "앱 인증을 완료하지 못했습니다."
 
@@ -758,7 +762,7 @@ msgstr "앱 인증을 완료하지 못했습니다."
 msgid "Could not change the default model"
 msgstr "기본 모델을 변경하지 못했습니다."
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4867
 msgid "Could not clear conversation"
 msgstr "대화 내용을 비우지 못했습니다."
 
@@ -787,7 +791,7 @@ msgstr "음성 서비스에 연결하지 못했습니다."
 msgid "Could not continue"
 msgstr "계속 진행하지 못했습니다."
 
-#: src/pages/Shell.tsx:4273
+#: src/pages/Shell.tsx:4302
 msgid "Could not create bot"
 msgstr "Bot을 만들지 못했습니다."
 
@@ -795,7 +799,7 @@ msgstr "Bot을 만들지 못했습니다."
 msgid "Could not create group"
 msgstr "그룹을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4758
 msgid "Could not create section"
 msgstr "섹션을 만들지 못했습니다."
 
@@ -803,7 +807,7 @@ msgstr "섹션을 만들지 못했습니다."
 msgid "Could not create your bot"
 msgstr "Bot을 만들지 못했습니다."
 
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4982
 msgid "Could not delete bot"
 msgstr "Bot을 삭제하지 못했습니다."
 
@@ -811,7 +815,7 @@ msgstr "Bot을 삭제하지 못했습니다."
 msgid "Could not delete MCP server"
 msgstr "MCP 서버를 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:5027
+#: src/pages/Shell.tsx:5056
 msgid "Could not delete routine"
 msgstr "자동 실행을 삭제하지 못했습니다."
 
@@ -885,7 +889,7 @@ msgstr "그룹을 삭제하지 못했습니다."
 msgid "Could not remove rule"
 msgstr "확인 규칙을 삭제하지 못했습니다."
 
-#: src/pages/Shell.tsx:5284
+#: src/pages/Shell.tsx:5313
 msgid "Could not render chart"
 msgstr "차트를 만들지 못했습니다."
 
@@ -893,7 +897,7 @@ msgstr "차트를 만들지 못했습니다."
 msgid "Could not revoke connection"
 msgstr "연결을 해제하지 못했습니다."
 
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4659
 msgid "Could not save"
 msgstr "저장하지 못했습니다."
 
@@ -905,7 +909,7 @@ msgstr "그룹을 저장하지 못했습니다."
 msgid "Could not save model"
 msgstr "AI 모델을 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2630
 msgid "Could not save routine"
 msgstr "자동 실행을 저장하지 못했습니다."
 
@@ -921,7 +925,7 @@ msgstr "선택 내용을 저장하지 못했습니다."
 msgid "Could not save that voice"
 msgstr "목소리를 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5133
 msgid "Could not save this choice"
 msgstr "선택 내용을 저장하지 못했습니다."
 
@@ -949,6 +953,10 @@ msgstr "업데이트하지 못했습니다."
 msgid "Could not update agent access"
 msgstr "Bot의 서버 사용 권한을 변경하지 못했습니다."
 
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Could not update avatar style"
+msgstr "아바타 스타일을 업데이트할 수 없습니다"
+
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr ""
@@ -958,13 +966,13 @@ msgid "Could not update the default memory scope"
 msgstr "기본 기억 범위를 변경하지 못했습니다."
 
 #: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Create"
 msgstr "만들기"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4738
+#: src/pages/Shell.tsx:4767
 msgid "Create a section and move {0} into it."
 msgstr "새 섹션을 만들고 {0}을 옮깁니다."
 
@@ -985,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Rakazo 계정 만들기"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Creating…"
 msgstr "만드는 중…"
 
@@ -1014,7 +1022,7 @@ msgstr "일"
 msgid "days"
 msgstr "일"
 
-#: src/pages/Shell.tsx:4537
+#: src/pages/Shell.tsx:4566
 msgid "Default (medium)"
 msgstr "기본(보통)"
 
@@ -1024,21 +1032,21 @@ msgstr "기본 기억 범위"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1970
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:1980
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Delete"
 msgstr "삭제"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1966
+#: src/pages/Shell.tsx:1976
 msgid "Delete {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4891
-#: src/pages/Shell.tsx:5005
+#: src/pages/Shell.tsx:4920
+#: src/pages/Shell.tsx:5034
 msgid "Delete {0}?"
 msgstr "{0}을 삭제할까요?"
 
@@ -1046,21 +1054,21 @@ msgstr "{0}을 삭제할까요?"
 msgid "Delete group"
 msgstr "그룹 삭제"
 
-#: src/pages/Shell.tsx:4928
+#: src/pages/Shell.tsx:4957
 msgid "Delete memories too"
 msgstr "기억도 함께 삭제"
 
-#: src/pages/Shell.tsx:2670
+#: src/pages/Shell.tsx:2685
 msgid "Delete routine"
 msgstr "자동 실행 삭제"
 
-#: src/pages/Shell.tsx:4039
+#: src/pages/Shell.tsx:4068
 msgid "deleted"
 msgstr "삭제됨"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Deleting…"
 msgstr "삭제 중…"
 
@@ -1077,17 +1085,17 @@ msgid "Deployment default"
 msgstr "서버 기본값"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4310
+#: src/pages/Shell.tsx:4339
 msgid "Describe what this bot does"
 msgstr "이 Bot이 하는 일을 짧게 설명하세요"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4315
-#: src/pages/Shell.tsx:4481
+#: src/pages/Shell.tsx:4344
+#: src/pages/Shell.tsx:4510
 msgid "Description"
 msgstr "설명"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Dictate"
 msgstr "음성 입력"
 
@@ -1100,7 +1108,7 @@ msgstr "연결 해제"
 msgid "Disconnecting…"
 msgstr "연결 해제 중…"
 
-#: src/pages/Shell.tsx:5412
+#: src/pages/Shell.tsx:5441
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "지금은 연결하지 않았습니다. MCP 설정에서 언제든 다시 연결할 수 있습니다."
 
@@ -1148,7 +1156,7 @@ msgstr "작업 기술 초안"
 msgid "Duplicate"
 msgstr "복제"
 
-#: src/pages/Shell.tsx:3852
+#: src/pages/Shell.tsx:3881
 msgid "Earlier message"
 msgstr "이전 메시지"
 
@@ -1204,11 +1212,11 @@ msgstr "매월"
 msgid "Every week"
 msgstr "매주"
 
-#: src/pages/Shell.tsx:5458
+#: src/pages/Shell.tsx:5487
 msgid "Expand"
 msgstr "펼치기"
 
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4671
 msgid "Export"
 msgstr "내보내기"
 
@@ -1216,7 +1224,7 @@ msgstr "내보내기"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "CRM에서 이번 주 목록을 내려받아 공유 폴더에 넣기"
 
-#: src/pages/Shell.tsx:4662
+#: src/pages/Shell.tsx:4691
 msgid "Extra high"
 msgstr "매우 높음"
 
@@ -1267,8 +1275,8 @@ msgstr "무료"
 msgid "Fullscreen"
 msgstr "전체 화면"
 
-#: src/pages/Shell.tsx:2120
-#: src/pages/Shell.tsx:2271
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2286
 msgid "Group"
 msgstr "그룹"
 
@@ -1297,15 +1305,15 @@ msgstr "샘플 듣기"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "안녕하세요. 답변을 소리 내어 읽을 때 이런 목소리로 들립니다."
 
-#: src/pages/Shell.tsx:4665
+#: src/pages/Shell.tsx:4694
 msgid "High"
 msgstr "높음"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk"
 msgstr "누르고 말하기"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk (on-device dictation)"
 msgstr "누르고 말하기(기기 내 음성 인식)"
 
@@ -1325,7 +1333,7 @@ msgstr "실행 주기"
 msgid "How to check"
 msgstr "완료 확인 방법"
 
-#: src/pages/Shell.tsx:3748
+#: src/pages/Shell.tsx:3777
 msgid "I’m done"
 msgstr "조작 끝내기"
 
@@ -1337,7 +1345,7 @@ msgstr "샘플이 들렸다면 음성 설정이 완료되었습니다."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON 가져오기"
 
-#: src/pages/Shell.tsx:4552
+#: src/pages/Shell.tsx:4581
 msgid "Inherit default"
 msgstr "기본 설정 사용"
 
@@ -1349,12 +1357,12 @@ msgstr "입력값"
 msgid "Instance API key"
 msgstr "인스턴스 API 키"
 
-#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2569
 msgid "Instruction"
 msgstr "실행할 내용"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1987
+#: src/pages/Shell.tsx:1997
 msgid "Integrations"
 msgstr "앱·도구 연동"
 
@@ -1375,15 +1383,15 @@ msgid "Interval unit"
 msgstr "간격 단위"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4553
+#: src/pages/Shell.tsx:4582
 msgid "Isolated"
 msgstr "이 Bot만 사용"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4923
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만든 다른 Bot은 목록에 남습니다."
 
-#: src/pages/Shell.tsx:3847
+#: src/pages/Shell.tsx:3876
 msgid "Jump to replied message"
 msgstr "답장한 메시지로 이동"
 
@@ -1391,7 +1399,7 @@ msgstr "답장한 메시지로 이동"
 msgid "just now"
 msgstr "방금"
 
-#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:4941
 msgid "Keep memories"
 msgstr "기억은 유지"
 
@@ -1399,9 +1407,9 @@ msgstr "기억은 유지"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "API 키는 서버에만 안전하게 보관되며, 앱에는 연결 여부만 표시됩니다."
 
-#: src/pages/AccountSettingsOverlay.tsx:105
-#: src/pages/AccountSettingsOverlay.tsx:254
-#: src/pages/AccountSettingsOverlay.tsx:271
+#: src/pages/AccountSettingsOverlay.tsx:126
+#: src/pages/AccountSettingsOverlay.tsx:313
+#: src/pages/AccountSettingsOverlay.tsx:330
 msgid "Language"
 msgstr "언어"
 
@@ -1409,7 +1417,7 @@ msgstr "언어"
 msgid "Listening…"
 msgstr "듣는 중…"
 
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Load earlier messages"
 msgstr "이전 메시지 불러오기"
 
@@ -1449,7 +1457,7 @@ msgstr "음성 서비스를 불러오는 중…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Loading…"
 msgstr "불러오는 중…"
 
@@ -1457,11 +1465,11 @@ msgstr "불러오는 중…"
 msgid "Local"
 msgstr "로컬"
 
-#: src/pages/Shell.tsx:2073
+#: src/pages/Shell.tsx:2083
 msgid "Log out"
 msgstr "로그아웃"
 
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4692
 msgid "Low"
 msgstr "낮음"
 
@@ -1477,7 +1485,7 @@ msgstr "읽음으로 표시"
 msgid "Mark as Unread"
 msgstr "읽지 않음으로 표시"
 
-#: src/pages/Shell.tsx:4667
+#: src/pages/Shell.tsx:4696
 msgid "Max"
 msgstr "최대"
 
@@ -1487,7 +1495,7 @@ msgstr "최대"
 msgid "MCP servers"
 msgstr "MCP 서버"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4693
 msgid "Medium"
 msgstr "보통"
 
@@ -1500,33 +1508,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "참여 Bot ({GROUP_MEMBER_MIN}~{GROUP_MEMBER_MAX}개 선택)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2031
+#: src/pages/Shell.tsx:2041
 msgid "Memory"
 msgstr "기억"
 
-#: src/pages/Shell.tsx:4548
+#: src/pages/Shell.tsx:4577
 msgid "Memory scope"
 msgstr "기억 사용 범위"
 
-#: src/pages/Shell.tsx:3548
-#: src/pages/Shell.tsx:3643
+#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3672
 msgid "Message"
 msgstr "메시지"
 
-#: src/pages/Shell.tsx:3544
-#: src/pages/Shell.tsx:3548
+#: src/pages/Shell.tsx:3573
+#: src/pages/Shell.tsx:3577
 msgid "Message {activeName}"
 msgstr "{activeName}에게 메시지 보내기"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Message from {peer}"
 msgstr "{peer}의 메시지"
 
-#: src/pages/Shell.tsx:3545
+#: src/pages/Shell.tsx:3574
 msgid "Message…"
 msgstr "메시지를 입력하세요"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Messaged {peer}"
 msgstr "{peer}에게 메시지 보냄"
 
@@ -1534,7 +1542,7 @@ msgstr "{peer}에게 메시지 보냄"
 msgid "Microphone failed"
 msgstr "마이크를 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4695
 msgid "Minimal"
 msgstr "최소"
 
@@ -1556,7 +1564,7 @@ msgstr "분"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4504
+#: src/pages/Shell.tsx:4533
 msgid "Model"
 msgstr "모델"
 
@@ -1569,7 +1577,7 @@ msgstr "모델 ID"
 msgid "Model options"
 msgstr "모델 선택지"
 
-#: src/pages/AccountSettingsOverlay.tsx:127
+#: src/pages/AccountSettingsOverlay.tsx:186
 msgid "Model spend uses your provider keys."
 msgstr "모델 사용 비용은 연결한 서비스의 API 키로 청구됩니다."
 
@@ -1578,7 +1586,7 @@ msgid "Model updated."
 msgstr "모델이 변경되었습니다."
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2018
+#: src/pages/Shell.tsx:2028
 msgid "Models"
 msgstr "AI 모델"
 
@@ -1596,7 +1604,7 @@ msgstr "매월"
 msgid "Move {0} to section"
 msgstr "{0} 섹션 이동"
 
-#: src/pages/Shell.tsx:4915
+#: src/pages/Shell.tsx:4944
 msgid "Move them to your shared memory."
 msgstr "공용 기억으로 옮깁니다."
 
@@ -1609,15 +1617,15 @@ msgstr "섹션으로 이동"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2546
-#: src/pages/Shell.tsx:4295
-#: src/pages/Shell.tsx:4463
-#: src/pages/Shell.tsx:4741
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:4324
+#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4770
 msgid "Name"
 msgstr "이름"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4300
+#: src/pages/Shell.tsx:4329
 msgid "Name this bot"
 msgstr "Bot 이름"
 
@@ -1634,7 +1642,7 @@ msgid "Needs takeover"
 msgstr "인수 필요"
 
 #: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4283
+#: src/pages/Shell.tsx:4312
 msgid "New bot"
 msgstr "새 Bot 만들기"
 
@@ -1647,12 +1655,12 @@ msgstr "새 그룹 만들기"
 msgid "New open-work item"
 msgstr "새 진행 작업"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2447
 msgid "New routine"
 msgstr "새 자동 실행"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4735
+#: src/pages/Shell.tsx:4764
 msgid "New section"
 msgstr "새 섹션"
 
@@ -1730,7 +1738,7 @@ msgstr "연결되지 않음"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5400
+#: src/pages/Shell.tsx:5429
 msgid "Not now"
 msgstr "나중에"
 
@@ -1768,15 +1776,15 @@ msgstr "매월 1일 {0}에"
 msgid "Open"
 msgstr "열기"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Open computer"
 msgstr "컴퓨터 열기"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2315
 msgid "Open in full window"
 msgstr "전체 창으로 열기"
 
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2107
 msgid "Open navigation"
 msgstr "메뉴 열기"
 
@@ -1793,7 +1801,7 @@ msgstr "진행 중인 작업"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 호환 서버 주소"
 
-#: src/pages/Shell.tsx:4050
+#: src/pages/Shell.tsx:4079
 msgid "Opened its thread."
 msgstr "대화가 만들어졌습니다."
 
@@ -1806,7 +1814,7 @@ msgstr "작업공간을 여는 중…"
 msgid "Optional"
 msgstr "선택 사항"
 
-#: src/pages/AccountSettingsOverlay.tsx:141
+#: src/pages/AccountSettingsOverlay.tsx:200
 msgid "Optional controls most people never need"
 msgstr "필요할 때만 쓰는 세부 설정"
 
@@ -1821,6 +1829,10 @@ msgstr "또는 API 키 연결"
 #: src/pages/Onboarding.tsx:464
 msgid "Or paste an API key"
 msgstr "또는 API 키 붙여넣기"
+
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Organic"
+msgstr "유기형"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -1876,7 +1888,7 @@ msgstr "재생 중…"
 msgid "Preview {0}"
 msgstr "{0} 미리보기"
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Private"
 msgstr "Bot 전용"
 
@@ -1897,7 +1909,7 @@ msgstr "대기 중"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo는 저장하기 전에 연결 상태를 확인합니다. 인증 정보는 암호화되며 앱이나 AI 모델에 노출되지 않습니다."
 
-#: src/pages/Shell.tsx:4580
+#: src/pages/Shell.tsx:4609
 msgid "Read replies aloud"
 msgstr "답변을 자동으로 읽기"
 
@@ -1931,7 +1943,7 @@ msgstr ""
 msgid "Recovering…"
 msgstr ""
 
-#: src/pages/Shell.tsx:3738
+#: src/pages/Shell.tsx:3767
 msgid "Release"
 msgstr "제어권 돌려주기"
 
@@ -1944,17 +1956,17 @@ msgid "Remove"
 msgstr "삭제"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3352
+#: src/pages/Shell.tsx:3381
 msgid "Remove {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3507
+#: src/pages/Shell.tsx:3536
 msgid "Remove mention {0}"
 msgstr "{0} 멘션 삭제"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3515
 msgid "Remove skill {0}"
 msgstr "작업 기술 {0} 삭제"
 
@@ -1962,7 +1974,7 @@ msgstr "작업 기술 {0} 삭제"
 msgid "Remove this schedule"
 msgstr "이 일정 삭제"
 
-#: src/pages/Shell.tsx:4049
+#: src/pages/Shell.tsx:4078
 msgid "Removed with chat, computer, and memory."
 msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 
@@ -1990,11 +2002,11 @@ msgstr "API 키 교체"
 msgid "Replace key"
 msgstr "키 교체"
 
-#: src/pages/Shell.tsx:3684
+#: src/pages/Shell.tsx:3713
 msgid "Reply"
 msgstr "답장"
 
-#: src/pages/Shell.tsx:3315
+#: src/pages/Shell.tsx:3344
 msgid "Replying to {replyName}"
 msgstr "{replyName}에게 답장"
 
@@ -2015,7 +2027,7 @@ msgstr ""
 msgid "Resetting…"
 msgstr ""
 
-#: src/pages/Shell.tsx:1962
+#: src/pages/Shell.tsx:1972
 msgid "Restore"
 msgstr "복원"
 
@@ -2031,17 +2043,21 @@ msgstr "지금 다시 시도"
 msgid "Return to Rakazo"
 msgstr "Rakazo로 돌아가기"
 
-#: src/pages/Shell.tsx:2539
-#: src/pages/Shell.tsx:2592
-#: src/pages/Shell.tsx:2599
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Robot"
+msgstr "로봇"
+
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Routine"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2392
 msgid "Routines"
 msgstr "자동 실행"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Run now"
 msgstr "지금 실행"
 
@@ -2049,11 +2065,11 @@ msgstr "지금 실행"
 msgid "Running"
 msgstr "실행 중"
 
-#: src/pages/Shell.tsx:2417
+#: src/pages/Shell.tsx:2432
 msgid "Running · Stop"
 msgstr "실행 중 · 중지"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Running…"
 msgstr "실행 중…"
 
@@ -2061,8 +2077,8 @@ msgstr "실행 중…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2638
-#: src/pages/Shell.tsx:4635
+#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:4664
 msgid "Save"
 msgstr "저장"
 
@@ -2086,7 +2102,7 @@ msgstr "저장되었습니다."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2638
+#: src/pages/Shell.tsx:2653
 msgid "Saving…"
 msgstr "저장 중…"
 
@@ -2127,11 +2143,11 @@ msgstr "AI 서비스 또는 모델 검색"
 msgid "Searching…"
 msgstr "검색 중…"
 
-#: src/pages/Shell.tsx:2121
+#: src/pages/Shell.tsx:2136
 msgid "Select a bot"
 msgstr "대화할 Bot을 선택하세요"
 
-#: src/pages/Shell.tsx:3568
+#: src/pages/Shell.tsx:3597
 msgid "Send"
 msgstr "보내기"
 
@@ -2159,22 +2175,22 @@ msgstr "서버 이름"
 msgid "Server URL"
 msgstr "서버 URL"
 
-#: src/pages/Shell.tsx:2130
+#: src/pages/Shell.tsx:2145
 msgid "Set up voice to call"
 msgstr "통화하려면 음성을 먼저 설정하세요"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1995
+#: src/pages/AccountSettingsOverlay.tsx:100
 #: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2267
+#: src/pages/Shell.tsx:2015
+#: src/pages/Shell.tsx:2282
 msgid "Settings"
 msgstr "설정"
 
-#: src/pages/Shell.tsx:3586
+#: src/pages/Shell.tsx:3615
 msgid "Settings: General"
 msgstr "설정: 일반"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3617
 msgid "Settings: Usage"
 msgstr "설정: 사용량"
 
@@ -2184,15 +2200,15 @@ msgid "Setup help"
 msgstr "설정 도움말"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4554
+#: src/pages/Shell.tsx:4583
 msgid "Shared"
 msgstr "함께 사용"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show computer"
 msgstr "컴퓨터 보기"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show settings"
 msgstr "설정 보기"
 
@@ -2216,11 +2232,11 @@ msgid "Sign up"
 msgstr "가입하기"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3399
+#: src/pages/Shell.tsx:3428
 msgid "Skill {0}"
 msgstr "작업 기술 {0}"
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3774
 msgid "Skip"
 msgstr "건너뛰기"
 
@@ -2241,8 +2257,8 @@ msgstr "{0} 건너뜀"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space: 끼어들기 · Esc: 통화 종료"
 
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Speak"
 msgstr "읽기"
 
@@ -2254,8 +2270,8 @@ msgstr "음성 출력·받아쓰기"
 msgid "Speak only"
 msgstr "음성 출력만"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Speak this reply"
 msgstr "이 답변 읽기"
 
@@ -2281,20 +2297,20 @@ msgstr "시작하는 중…"
 msgid "Steps"
 msgstr "실행 단계"
 
-#: src/pages/Shell.tsx:2918
-#: src/pages/Shell.tsx:2922
-#: src/pages/Shell.tsx:3559
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2947
+#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Stop"
 msgstr "중지"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Stop dictation"
 msgstr "음성 입력 중지"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Stop speaking"
 msgstr "읽기 중지"
 
@@ -2303,8 +2319,8 @@ msgstr "읽기 중지"
 msgid "Stop teaching"
 msgstr "가르치기 종료"
 
-#: src/pages/Shell.tsx:2357
-#: src/pages/Shell.tsx:2938
+#: src/pages/Shell.tsx:2372
+#: src/pages/Shell.tsx:2963
 msgid "Stop the bot first"
 msgstr "먼저 Bot을 중지하세요"
 
@@ -2312,7 +2328,7 @@ msgstr "먼저 Bot을 중지하세요"
 msgid "Stored encrypted"
 msgstr "암호화해 저장"
 
-#: src/pages/Shell.tsx:4001
+#: src/pages/Shell.tsx:4030
 msgid "subagent"
 msgstr "보조 에이전트"
 
@@ -2325,8 +2341,8 @@ msgstr "확인"
 msgid "Switching…"
 msgstr "전환 중…"
 
-#: src/pages/Shell.tsx:2360
-#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2375
+#: src/pages/Shell.tsx:2968
 msgid "Take control"
 msgstr "직접 조작"
 
@@ -2334,7 +2350,7 @@ msgstr "직접 조작"
 msgid "Teach a task"
 msgstr "작업 가르치기"
 
-#: src/pages/Shell.tsx:2193
+#: src/pages/Shell.tsx:2208
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼저 가르치기를 종료하세요."
 
@@ -2342,11 +2358,11 @@ msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼�
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "작업을 가르치려면 화면이 있는 샌드박스 컴퓨터가 필요합니다. 내 컴퓨터에서 실행되는 Bot은 터미널 작업은 가능하지만 화면 녹화는 할 수 없습니다."
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Team"
 msgstr "팀 공용"
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "Team Computer"
 msgstr "팀 컴퓨터"
 
@@ -2359,20 +2375,20 @@ msgstr "시험 실행"
 msgid "The selected memory provider is not available in this build."
 msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습니다."
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4560
 msgid "Thinking"
 msgstr "생각 깊이"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2319
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "이 Bot은 별도 Linux 화면이 아니라 현재 컴퓨터에서 실행됩니다. 터미널과 파일 작업은 홈 폴더를 사용합니다."
 
-#: src/pages/Shell.tsx:2967
+#: src/pages/Shell.tsx:2992
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "이 Bot은 현재 컴퓨터에서 실행되며 별도 Linux 화면은 없습니다. 터미널을 사용하도록 요청할 수 있고 홈 폴더 아래에서 작업합니다."
 
-#: src/pages/Shell.tsx:4931
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:4960
+#: src/pages/Shell.tsx:5037
 msgid "This cannot be undone."
 msgstr "이 작업은 되돌릴 수 없습니다."
 
@@ -2396,7 +2412,7 @@ msgstr "이 Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "이 Mac에서는 홈 폴더의 파일을 포함해 내 계정 권한으로 터미널 명령을 실행합니다. 여러 사람이 쓰거나 공개된 서버에서는 사용하지 마세요."
 
-#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4845
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지합니다. Bot, 컴퓨터, 기억, 자동 실행은 그대로 유지됩니다."
 
@@ -2404,7 +2420,7 @@ msgstr "모든 메시지를 영구 삭제하고 진행 중인 작업을 중지�
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "이 서비스는 여기에서 API 키를 입력할 수 없습니다. 서버에 이미 인증 정보가 있다면 건너뛰세요."
 
-#: src/pages/Shell.tsx:5348
+#: src/pages/Shell.tsx:5377
 msgid "This server cannot be assigned without a bot."
 msgstr "연결할 Bot이 없어 이 서버를 배정할 수 없습니다."
 
@@ -2416,7 +2432,7 @@ msgstr "이 서버는 브라우저 인증을 요청하지 않았습니다."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "이 서버는 이미 연결되어 있습니다. 다시 인증하려면 먼저 연결을 해제하세요."
 
-#: src/pages/Shell.tsx:5387
+#: src/pages/Shell.tsx:5416
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "이 서버는 브라우저 로그인이 필요합니다. 인증을 누르면 새 창이 열리고, 완료 후 Bot이 도구를 사용할 수 있습니다."
 
@@ -2429,8 +2445,8 @@ msgid "Time of day"
 msgstr "실행 시각"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4305
-#: src/pages/Shell.tsx:4472
+#: src/pages/Shell.tsx:4334
+#: src/pages/Shell.tsx:4501
 msgid "Title"
 msgstr "역할"
 
@@ -2467,8 +2483,8 @@ msgstr ""
 msgid "Updating…"
 msgstr ""
 
-#: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2056
+#: src/pages/AccountSettingsOverlay.tsx:176
+#: src/pages/Shell.tsx:2066
 msgid "Usage"
 msgstr "사용량"
 
@@ -2493,8 +2509,8 @@ msgstr "확인 후 추가"
 msgid "Verifying…"
 msgstr "확인 중…"
 
-#: src/pages/Shell.tsx:2044
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:2054
+#: src/pages/Shell.tsx:4613
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2507,7 +2523,7 @@ msgstr "음성"
 msgid "Waiting for sign-in…"
 msgstr "로그인 완료를 기다리는 중…"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5260
 msgid "Waiting…"
 msgstr "기다리는 중…"
 
@@ -2516,7 +2532,7 @@ msgstr "기다리는 중…"
 msgid "Weekdays"
 msgstr "주중"
 
-#: src/pages/Shell.tsx:4901
+#: src/pages/Shell.tsx:4930
 msgid "What about its memories?"
 msgstr "이 Bot의 기억은 어떻게 할까요?"
 
@@ -2525,7 +2541,7 @@ msgid "What result will you demonstrate?"
 msgstr "어떤 작업을 직접 보여줄까요?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4320
+#: src/pages/Shell.tsx:4349
 msgid "What this bot is for"
 msgstr "이 Bot을 언제, 어떤 일에 사용할지 적어주세요"
 
@@ -2537,7 +2553,7 @@ msgstr "완료 후 전달할 결과"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "{botName}이 다른 Bot에게 메시지를 보내면 대화 대신 여기에 표시됩니다."
 
-#: src/pages/Shell.tsx:2563
+#: src/pages/Shell.tsx:2578
 msgid "When to run"
 msgstr "실행 시간"
 
@@ -2554,7 +2570,7 @@ msgstr "Bot을 어디에서 실행할까요?"
 msgid "Working…"
 msgstr "처리 중…"
 
-#: src/pages/Shell.tsx:4514
+#: src/pages/Shell.tsx:4543
 msgid "Workspace default"
 msgstr "작업공간 기본값"
 
@@ -2571,8 +2587,8 @@ msgstr "자동으로 이동하지 않으면 이 탭을 닫아도 됩니다."
 msgid "You can close this window."
 msgstr "이 창을 닫아도 됩니다."
 
-#: src/pages/Shell.tsx:2337
-#: src/pages/Shell.tsx:2908
+#: src/pages/Shell.tsx:2352
+#: src/pages/Shell.tsx:2933
 msgid "You have control"
 msgstr "직접 조작 중"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -418,7 +418,7 @@ msgstr "인증하기"
 
 #: src/pages/AccountSettingsOverlay.tsx:133
 msgid "Avatars"
-msgstr "아바타"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -953,10 +953,6 @@ msgstr "업데이트하지 못했습니다."
 msgid "Could not update agent access"
 msgstr "Bot의 서버 사용 권한을 변경하지 못했습니다."
 
-#: src/pages/AccountSettingsOverlay.tsx:80
-msgid "Could not update avatar style"
-msgstr "아바타 스타일을 업데이트할 수 없습니다"
-
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr ""
@@ -964,6 +960,10 @@ msgstr ""
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "기본 기억 범위를 변경하지 못했습니다."
+
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Couldn't update avatars"
+msgstr ""
 
 #: src/pages/Shell.tsx:1761
 #: src/pages/Shell.tsx:4361
@@ -1832,7 +1832,7 @@ msgstr "또는 API 키 붙여넣기"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Organic"
-msgstr "유기형"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -2045,7 +2045,7 @@ msgstr "Rakazo로 돌아가기"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Robot"
-msgstr "로봇"
+msgstr ""
 
 #: src/pages/Shell.tsx:2554
 #: src/pages/Shell.tsx:2607

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/pages/Shell.tsx:1857
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (não lido)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5204
+#: src/pages/Shell.tsx:5233
 msgid "{0} connection"
 msgstr "Conexão {0}"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2341
+#: src/pages/Shell.tsx:2356
 msgid "{0} is using it"
 msgstr "{0} está usando"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2061
+#: src/pages/AccountSettingsOverlay.tsx:180
+#: src/pages/Shell.tsx:2071
 msgid "{0} runs · {1} tokens"
 msgstr "{0} execuções · {1} tokens"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# par} other {# pares}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "O {botName} ainda não enviou mensagens para outro bot."
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "{botName}’s computer"
 msgstr "Computador do {botName}"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3371
+#: src/pages/Shell.tsx:3400
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ Ensinar uma tarefa"
 msgid "Access token (optional)"
 msgstr "Token de acesso (opcional)"
 
-#: src/pages/AccountSettingsOverlay.tsx:97
+#: src/pages/AccountSettingsOverlay.tsx:118
 msgid "Account"
 msgstr "Conta"
 
-#: src/pages/Shell.tsx:4590
+#: src/pages/Shell.tsx:4619
 msgid "Account default"
 msgstr "Padrão da conta"
 
-#: src/pages/AccountSettingsOverlay.tsx:82
+#: src/pages/AccountSettingsOverlay.tsx:103
 msgid "Account preferences apply across all your bots."
 msgstr "As preferências da conta se aplicam a todos os seus bots."
 
@@ -218,10 +218,10 @@ msgstr "Adicionar Treg"
 msgid "Adding…"
 msgstr "Adicionando"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4522
 msgid "Advanced"
 msgstr "Avançado"
 
@@ -229,7 +229,7 @@ msgstr "Avançado"
 msgid "Agent access for new servers"
 msgstr "Acesso de agente para novos servidores"
 
-#: src/pages/Shell.tsx:2148
+#: src/pages/Shell.tsx:2163
 msgid "Agent computer"
 msgstr "Computador do agente"
 
@@ -316,11 +316,11 @@ msgstr "Aplica-se quando você clica em Adicionar servidor. Use os chips do agen
 msgid "Approval boundaries"
 msgstr "Limites de aprovação"
 
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 msgid "Approve"
 msgstr "Aprovar"
 
-#: src/pages/Shell.tsx:5388
+#: src/pages/Shell.tsx:5417
 msgid "Approve this server to let your agent use its tools."
 msgstr "Aprove este servidor para permitir que seu agente use suas ferramentas."
 
@@ -328,15 +328,15 @@ msgstr "Aprove este servidor para permitir que seu agente use suas ferramentas."
 msgid "Archive"
 msgstr "Arquivar"
 
-#: src/pages/Shell.tsx:4037
+#: src/pages/Shell.tsx:4066
 msgid "archived"
 msgstr "arquivado"
 
-#: src/pages/Shell.tsx:1941
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "Arquivado"
 
-#: src/pages/Shell.tsx:4048
+#: src/pages/Shell.tsx:4077
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Arquivado. Chat, memória e arquivos mantidos."
 
@@ -375,7 +375,7 @@ msgstr "Perguntar antes de comprar"
 msgid "Ask before sending external email"
 msgstr "Perguntar antes de enviar e-mail externo"
 
-#: src/pages/Shell.tsx:2343
+#: src/pages/Shell.tsx:2358
 msgid "Asleep"
 msgstr "Dormindo"
 
@@ -390,11 +390,11 @@ msgstr "em {0}"
 msgid "at {timeSelect}"
 msgstr "em {timeSelect}"
 
-#: src/pages/Shell.tsx:3442
+#: src/pages/Shell.tsx:3471
 msgid "Attach file"
 msgstr "Escolher arquivo"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3670
 msgid "Attachment"
 msgstr "Anexo"
 
@@ -407,14 +407,18 @@ msgstr "Código de autorização ou URL de retorno de chamada"
 msgid "Authorization expired — reconnect required"
 msgstr "Autorização expirada — reconexão necessária"
 
-#: src/pages/Shell.tsx:5189
+#: src/pages/Shell.tsx:5218
 msgid "Authorization timed out. Please try again."
 msgstr "A autorização expirou. Tente novamente."
 
-#: src/pages/Shell.tsx:5231
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5426
 msgid "Authorize"
 msgstr "Autorizar"
+
+#: src/pages/AccountSettingsOverlay.tsx:133
+msgid "Avatars"
+msgstr "Avatares"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -424,18 +428,18 @@ msgstr "URL Base"
 msgid "Bearer token"
 msgstr "Token portador"
 
-#: src/pages/Shell.tsx:5073
+#: src/pages/Shell.tsx:5102
 msgid "Booting live desktop…"
 msgstr "Iniciando a área de trabalho ao vivo..."
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2903
 msgid "Booting up {0}’s computer"
 msgstr "Inicializando o computador do {0}"
 
-#: src/pages/Shell.tsx:3907
-#: src/pages/Shell.tsx:3908
-#: src/pages/Shell.tsx:4041
+#: src/pages/Shell.tsx:3936
+#: src/pages/Shell.tsx:3937
+#: src/pages/Shell.tsx:4070
 msgid "bot"
 msgstr "bot"
 
@@ -447,11 +451,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Mensagens de bot"
 
-#: src/pages/Shell.tsx:2975
+#: src/pages/Shell.tsx:3000
 msgid "Bot screen"
 msgstr "Tela do bot"
 
-#: src/pages/Shell.tsx:2311
+#: src/pages/Shell.tsx:2326
 msgid "Bot screen preview"
 msgstr "Pré-visualização da tela"
 
@@ -464,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Traga sua própria chave. O provedor pode ser trocado; seus bots mantêm os mesmos botões de fala e chamada."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2130
-#: src/pages/Shell.tsx:2131
+#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2146
 msgid "Call"
 msgstr "Ligar"
 
@@ -477,14 +481,14 @@ msgstr "Não é possível acessar o servidor."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4829
-#: src/pages/Shell.tsx:4944
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4858
+#: src/pages/Shell.tsx:4973
+#: src/pages/Shell.tsx:5047
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/pages/Shell.tsx:4285
+#: src/pages/Shell.tsx:4314
 msgid "Cancel new bot"
 msgstr "Cancelar novo bot"
 
@@ -492,7 +496,7 @@ msgstr "Cancelar novo bot"
 msgid "Cancel new group"
 msgstr "Cancelar novo grupo"
 
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3347
 msgid "Cancel reply"
 msgstr "cancelar resposta"
 
@@ -500,16 +504,16 @@ msgstr "cancelar resposta"
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: src/pages/Shell.tsx:5294
+#: src/pages/Shell.tsx:5323
 msgid "Chart failed to render: {error}"
 msgstr "Falha na renderização do gráfico: {error}"
 
-#: src/pages/Shell.tsx:3584
+#: src/pages/Shell.tsx:3613
 msgid "Chat Settings"
 msgstr "Configurações do chat"
 
-#: src/pages/Shell.tsx:2593
-#: src/pages/Shell.tsx:2600
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:2615
 msgid "Check in."
 msgstr "Acompanhamento"
 
@@ -521,21 +525,21 @@ msgstr "Escolha um modelo para começar."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Escolha qual modelo conectado a Rakazo usa."
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clear"
 msgstr "Limpar"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4839
 msgid "Clear {0}’s conversation?"
 msgstr "Limpar a conversa do {0}?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4645
+#: src/pages/Shell.tsx:4674
 msgid "Clear conversation"
 msgstr "Limpar conversa"
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clearing…"
 msgstr "Limpeza"
 
@@ -551,15 +555,15 @@ msgstr "Fechar menu do bot"
 msgid "Close bot messages"
 msgstr "Fechar mensagens do bot"
 
-#: src/pages/Shell.tsx:5479
+#: src/pages/Shell.tsx:5508
 msgid "Close chart"
 msgstr "Fechar gráfico"
 
-#: src/pages/Shell.tsx:2949
+#: src/pages/Shell.tsx:2974
 msgid "Close computer"
 msgstr "Fechar computador"
 
-#: src/pages/Shell.tsx:5579
+#: src/pages/Shell.tsx:5608
 msgid "Close image preview"
 msgstr "Fechar visualização da imagem"
 
@@ -583,7 +587,7 @@ msgstr "Fechar configurações do modelo"
 msgid "Close navigation"
 msgstr "Fechar navegação"
 
-#: src/pages/Shell.tsx:2289
+#: src/pages/Shell.tsx:2304
 msgid "Close panel"
 msgstr "Fechar painel"
 
@@ -592,7 +596,7 @@ msgstr "Fechar painel"
 msgid "Close preview"
 msgstr "Fechar pré-visualização"
 
-#: src/pages/AccountSettingsOverlay.tsx:87
+#: src/pages/AccountSettingsOverlay.tsx:108
 msgid "Close user settings"
 msgstr "Fechar configurações do usuário"
 
@@ -612,24 +616,24 @@ msgstr "Comando"
 msgid "Complete"
 msgstr "Concluir"
 
-#: src/pages/Shell.tsx:4195
-#: src/pages/Shell.tsx:4223
+#: src/pages/Shell.tsx:4224
+#: src/pages/Shell.tsx:4252
 msgid "Computer"
 msgstr "Computador"
 
-#: src/pages/Shell.tsx:5076
+#: src/pages/Shell.tsx:5105
 msgid "Computer failed to boot"
 msgstr "Falha ao inicializar o computador"
 
-#: src/pages/Shell.tsx:2997
+#: src/pages/Shell.tsx:3022
 msgid "Computer is asleep"
 msgstr "O computador está dormindo"
 
-#: src/pages/Shell.tsx:5075
+#: src/pages/Shell.tsx:5104
 msgid "Computer is asleep — take control to wake it"
 msgstr "O computador está adormecido — assuma o controle para despertá-lo"
 
-#: src/pages/Shell.tsx:5077
+#: src/pages/Shell.tsx:5106
 msgid "Computer is stopped"
 msgstr "O computador está parado"
 
@@ -662,7 +666,7 @@ msgstr "Conecte-se com a chave API"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "Conecte ElevenLabs, OpenAI ou Cartesia"
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5406
 msgid "Connect MCP server “{name}”"
 msgstr "Conecte o servidor MCP “{name}”"
 
@@ -685,12 +689,12 @@ msgstr "Conectar Treg"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5228
+#: src/pages/Shell.tsx:5257
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Conectado"
 
-#: src/pages/Shell.tsx:5407
+#: src/pages/Shell.tsx:5436
 msgid "Connected — its tools are available from your next message."
 msgstr "Conectado — suas ferramentas estão disponíveis na sua próxima mensagem."
 
@@ -715,7 +719,7 @@ msgstr "Conectado e usando {0}."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Conectando…"
@@ -734,7 +738,7 @@ msgstr "Continuar"
 msgid "Continue with email"
 msgstr "Continuar com e-mail"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3721
 msgid "Copy"
 msgstr "Copiar"
 
@@ -746,11 +750,11 @@ msgstr "Não foi possível adicionar."
 msgid "Could not add MCP server"
 msgstr "Não foi possível adicionar o servidor MCP"
 
-#: src/pages/Shell.tsx:5364
+#: src/pages/Shell.tsx:5393
 msgid "Could not approve this server"
 msgstr "Não foi possível aprovar este servidor"
 
-#: src/pages/Shell.tsx:5192
+#: src/pages/Shell.tsx:5221
 msgid "Could not authorize this app"
 msgstr "Não foi possível autorizar este aplicativo"
 
@@ -758,7 +762,7 @@ msgstr "Não foi possível autorizar este aplicativo"
 msgid "Could not change the default model"
 msgstr "Não foi possível alterar o modelo padrão"
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4867
 msgid "Could not clear conversation"
 msgstr "Não foi possível limpar a conversa"
 
@@ -787,7 +791,7 @@ msgstr "Não foi possível conectar este provedor de voz"
 msgid "Could not continue"
 msgstr "Não foi possível continuar"
 
-#: src/pages/Shell.tsx:4273
+#: src/pages/Shell.tsx:4302
 msgid "Could not create bot"
 msgstr "Não foi possível criar o bot"
 
@@ -795,7 +799,7 @@ msgstr "Não foi possível criar o bot"
 msgid "Could not create group"
 msgstr "Não foi possível criar o grupo"
 
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4758
 msgid "Could not create section"
 msgstr "Não foi possível criar a seção"
 
@@ -803,7 +807,7 @@ msgstr "Não foi possível criar a seção"
 msgid "Could not create your bot"
 msgstr "Não foi possível criar o seu bot"
 
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4982
 msgid "Could not delete bot"
 msgstr "Não foi possível apagar"
 
@@ -811,7 +815,7 @@ msgstr "Não foi possível apagar"
 msgid "Could not delete MCP server"
 msgstr "Não foi possível excluir o servidor MCP"
 
-#: src/pages/Shell.tsx:5027
+#: src/pages/Shell.tsx:5056
 msgid "Could not delete routine"
 msgstr "Não foi possível excluir a rotina"
 
@@ -885,7 +889,7 @@ msgstr "Não foi possível remover o grupo"
 msgid "Could not remove rule"
 msgstr "Não foi possível remover."
 
-#: src/pages/Shell.tsx:5284
+#: src/pages/Shell.tsx:5313
 msgid "Could not render chart"
 msgstr "Não foi possível renderizar o gráfico"
 
@@ -893,7 +897,7 @@ msgstr "Não foi possível renderizar o gráfico"
 msgid "Could not revoke connection"
 msgstr "Não foi possível revogar a conexão"
 
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4659
 msgid "Could not save"
 msgstr "Não foi possível salvar"
 
@@ -905,7 +909,7 @@ msgstr "Não foi possível salvar o grupo"
 msgid "Could not save model"
 msgstr "Não foi possível salvar o modelo"
 
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2630
 msgid "Could not save routine"
 msgstr "Não foi possível salvar a rotina"
 
@@ -921,7 +925,7 @@ msgstr "Não foi possível salvar essa opção"
 msgid "Could not save that voice"
 msgstr "Não foi possível salvar essa voz"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5133
 msgid "Could not save this choice"
 msgstr "Não foi possível salvar esta opção"
 
@@ -949,6 +953,10 @@ msgstr "Não foi possível atualizar"
 msgid "Could not update agent access"
 msgstr "Não foi possível atualizar o acesso do agente"
 
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Could not update avatar style"
+msgstr "Não foi possível atualizar o estilo do avatar"
+
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr "Não foi possível atualizar o computador"
@@ -958,13 +966,13 @@ msgid "Could not update the default memory scope"
 msgstr "Não foi possível atualizar o escopo de memória padrão"
 
 #: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Create"
 msgstr "Criar"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4738
+#: src/pages/Shell.tsx:4767
 msgid "Create a section and move {0} into it."
 msgstr "Crie uma seção e mova {0} para ela."
 
@@ -985,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Crie o seu Rakazo"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Creating…"
 msgstr "Criando..."
 
@@ -1014,7 +1022,7 @@ msgstr "dia"
 msgid "days"
 msgstr "dias"
 
-#: src/pages/Shell.tsx:4537
+#: src/pages/Shell.tsx:4566
 msgid "Default (medium)"
 msgstr "Padrão (médio)"
 
@@ -1024,21 +1032,21 @@ msgstr "Escopo padrão"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1970
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:1980
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Delete"
 msgstr "Excluir"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1966
+#: src/pages/Shell.tsx:1976
 msgid "Delete {0}"
 msgstr "Excluir {0}"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4891
-#: src/pages/Shell.tsx:5005
+#: src/pages/Shell.tsx:4920
+#: src/pages/Shell.tsx:5034
 msgid "Delete {0}?"
 msgstr "Excluir {0}?"
 
@@ -1046,21 +1054,21 @@ msgstr "Excluir {0}?"
 msgid "Delete group"
 msgstr "Excluir o grupo"
 
-#: src/pages/Shell.tsx:4928
+#: src/pages/Shell.tsx:4957
 msgid "Delete memories too"
 msgstr "Excluir memórias também"
 
-#: src/pages/Shell.tsx:2670
+#: src/pages/Shell.tsx:2685
 msgid "Delete routine"
 msgstr "Excluir Rotina"
 
-#: src/pages/Shell.tsx:4039
+#: src/pages/Shell.tsx:4068
 msgid "deleted"
 msgstr "excluído"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Deleting…"
 msgstr "Excluindo…"
 
@@ -1077,17 +1085,17 @@ msgid "Deployment default"
 msgstr "Padrão de implantação"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4310
+#: src/pages/Shell.tsx:4339
 msgid "Describe what this bot does"
 msgstr "Descreva o que este bot faz"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4315
-#: src/pages/Shell.tsx:4481
+#: src/pages/Shell.tsx:4344
+#: src/pages/Shell.tsx:4510
 msgid "Description"
 msgstr "Descrição"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Dictate"
 msgstr "Ditar"
 
@@ -1100,7 +1108,7 @@ msgstr "Desconectar"
 msgid "Disconnecting…"
 msgstr "Desconectando…"
 
-#: src/pages/Shell.tsx:5412
+#: src/pages/Shell.tsx:5441
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Dispensado — reconecte a qualquer momento a partir das configurações do MCP."
 
@@ -1148,7 +1156,7 @@ msgstr "Habilidade de rascunho"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/pages/Shell.tsx:3852
+#: src/pages/Shell.tsx:3881
 msgid "Earlier message"
 msgstr ""
 
@@ -1204,11 +1212,11 @@ msgstr "A cada mês"
 msgid "Every week"
 msgstr "A cada semana"
 
-#: src/pages/Shell.tsx:5458
+#: src/pages/Shell.tsx:5487
 msgid "Expand"
 msgstr "Expandir"
 
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4671
 msgid "Export"
 msgstr "Exportar"
 
@@ -1216,7 +1224,7 @@ msgstr "Exportar"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Exporte a lista desta semana do CRM e solte-a na pasta compartilhada"
 
-#: src/pages/Shell.tsx:4662
+#: src/pages/Shell.tsx:4691
 msgid "Extra high"
 msgstr "Extra alta"
 
@@ -1267,8 +1275,8 @@ msgstr ""
 msgid "Fullscreen"
 msgstr "Tela Cheia"
 
-#: src/pages/Shell.tsx:2120
-#: src/pages/Shell.tsx:2271
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2286
 msgid "Group"
 msgstr "Grupo"
 
@@ -1297,15 +1305,15 @@ msgstr "Ouvir uma amostra"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Olá, é assim que vou soar quando ler as respostas em voz alta."
 
-#: src/pages/Shell.tsx:4665
+#: src/pages/Shell.tsx:4694
 msgid "High"
 msgstr "Alto"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk"
 msgstr "Segure para falar"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk (on-device dictation)"
 msgstr "Segure para falar (ditado no dispositivo)"
 
@@ -1325,7 +1333,7 @@ msgstr "Com que frequência"
 msgid "How to check"
 msgstr "Como verificar"
 
-#: src/pages/Shell.tsx:3748
+#: src/pages/Shell.tsx:3777
 msgid "I’m done"
 msgstr "Eu terminei."
 
@@ -1337,7 +1345,7 @@ msgstr "Se você ouviu isso, a voz está pronta."
 msgid "Import OpenAPI JSON"
 msgstr "Importar OpenAPI JSON"
 
-#: src/pages/Shell.tsx:4552
+#: src/pages/Shell.tsx:4581
 msgid "Inherit default"
 msgstr "Herdar (padrão)"
 
@@ -1349,12 +1357,12 @@ msgstr "Entradas"
 msgid "Instance API key"
 msgstr "Chave de API da instância"
 
-#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2569
 msgid "Instruction"
 msgstr "Instrução"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1987
+#: src/pages/Shell.tsx:1997
 msgid "Integrations"
 msgstr "Integrações"
 
@@ -1375,15 +1383,15 @@ msgid "Interval unit"
 msgstr "Unidade do intervalo:"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4553
+#: src/pages/Shell.tsx:4582
 msgid "Isolated"
 msgstr "Isolado"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4923
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Suas conversas, arquivos e rotinas serão excluídos permanentemente. Os bots criados ficam na sua lista."
 
-#: src/pages/Shell.tsx:3847
+#: src/pages/Shell.tsx:3876
 msgid "Jump to replied message"
 msgstr "Ir para a mensagem respondida"
 
@@ -1391,7 +1399,7 @@ msgstr "Ir para a mensagem respondida"
 msgid "just now"
 msgstr "agora mesmo"
 
-#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:4941
 msgid "Keep memories"
 msgstr "Manter memórias"
 
@@ -1399,9 +1407,9 @@ msgstr "Manter memórias"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "As chaves permanecem no servidor. O aplicativo só descobre se um provedor está configurado."
 
-#: src/pages/AccountSettingsOverlay.tsx:105
-#: src/pages/AccountSettingsOverlay.tsx:254
-#: src/pages/AccountSettingsOverlay.tsx:271
+#: src/pages/AccountSettingsOverlay.tsx:126
+#: src/pages/AccountSettingsOverlay.tsx:313
+#: src/pages/AccountSettingsOverlay.tsx:330
 msgid "Language"
 msgstr "Idioma"
 
@@ -1409,7 +1417,7 @@ msgstr "Idioma"
 msgid "Listening…"
 msgstr "Ouvindo..."
 
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Load earlier messages"
 msgstr "Carregar mensagens anteriores..."
 
@@ -1449,7 +1457,7 @@ msgstr "Carregando provedores de voz..."
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Loading…"
 msgstr "Carregando..."
 
@@ -1457,11 +1465,11 @@ msgstr "Carregando..."
 msgid "Local"
 msgstr "Local"
 
-#: src/pages/Shell.tsx:2073
+#: src/pages/Shell.tsx:2083
 msgid "Log out"
 msgstr "Sair"
 
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4692
 msgid "Low"
 msgstr "Baixo"
 
@@ -1477,7 +1485,7 @@ msgstr "Marcar como Lido"
 msgid "Mark as Unread"
 msgstr "Marcar como Não Lida"
 
-#: src/pages/Shell.tsx:4667
+#: src/pages/Shell.tsx:4696
 msgid "Max"
 msgstr "Máximo"
 
@@ -1487,7 +1495,7 @@ msgstr "Máximo"
 msgid "MCP servers"
 msgstr "Servidores MCP"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4693
 msgid "Medium"
 msgstr "Médio"
 
@@ -1500,33 +1508,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Membros (escolha {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2031
+#: src/pages/Shell.tsx:2041
 msgid "Memory"
 msgstr "Memória"
 
-#: src/pages/Shell.tsx:4548
+#: src/pages/Shell.tsx:4577
 msgid "Memory scope"
 msgstr "Escopo de memória"
 
-#: src/pages/Shell.tsx:3548
-#: src/pages/Shell.tsx:3643
+#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3672
 msgid "Message"
 msgstr "Mensagem"
 
-#: src/pages/Shell.tsx:3544
-#: src/pages/Shell.tsx:3548
+#: src/pages/Shell.tsx:3573
+#: src/pages/Shell.tsx:3577
 msgid "Message {activeName}"
 msgstr "Mensagem {activeName}"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Message from {peer}"
 msgstr "Mensagem de {peer}"
 
-#: src/pages/Shell.tsx:3545
+#: src/pages/Shell.tsx:3574
 msgid "Message…"
 msgstr "Mensagem…"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Messaged {peer}"
 msgstr "Enviou mensagem para {peer}"
 
@@ -1534,7 +1542,7 @@ msgstr "Enviou mensagem para {peer}"
 msgid "Microphone failed"
 msgstr "Falha no microfone"
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4695
 msgid "Minimal"
 msgstr "Mínimo"
 
@@ -1556,7 +1564,7 @@ msgstr "minutos"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4504
+#: src/pages/Shell.tsx:4533
 msgid "Model"
 msgstr "Modelo"
 
@@ -1569,7 +1577,7 @@ msgstr "ID do modelo"
 msgid "Model options"
 msgstr "Opções do modelo"
 
-#: src/pages/AccountSettingsOverlay.tsx:127
+#: src/pages/AccountSettingsOverlay.tsx:186
 msgid "Model spend uses your provider keys."
 msgstr "O modelo de gasto usa suas chaves de provedor."
 
@@ -1578,7 +1586,7 @@ msgid "Model updated."
 msgstr "Modelo Atualizado"
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2018
+#: src/pages/Shell.tsx:2028
 msgid "Models"
 msgstr "Modelos"
 
@@ -1596,7 +1604,7 @@ msgstr "Mensalmente"
 msgid "Move {0} to section"
 msgstr "Mover {0} para a seção"
 
-#: src/pages/Shell.tsx:4915
+#: src/pages/Shell.tsx:4944
 msgid "Move them to your shared memory."
 msgstr "Mova-os para a sua memória compartilhada."
 
@@ -1609,15 +1617,15 @@ msgstr "Mover para"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2546
-#: src/pages/Shell.tsx:4295
-#: src/pages/Shell.tsx:4463
-#: src/pages/Shell.tsx:4741
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:4324
+#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4770
 msgid "Name"
 msgstr "Nome"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4300
+#: src/pages/Shell.tsx:4329
 msgid "Name this bot"
 msgstr "Nomeie este bot"
 
@@ -1634,7 +1642,7 @@ msgid "Needs takeover"
 msgstr "Requer assumir o controle"
 
 #: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4283
+#: src/pages/Shell.tsx:4312
 msgid "New bot"
 msgstr "Novo bot"
 
@@ -1647,12 +1655,12 @@ msgstr "Novo grupo"
 msgid "New open-work item"
 msgstr "Novo item de trabalho aberto"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2447
 msgid "New routine"
 msgstr "Nova rotina"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4735
+#: src/pages/Shell.tsx:4764
 msgid "New section"
 msgstr "Nova seção"
 
@@ -1730,7 +1738,7 @@ msgstr "Não Conectado"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5400
+#: src/pages/Shell.tsx:5429
 msgid "Not now"
 msgstr "Agora não"
 
@@ -1768,15 +1776,15 @@ msgstr "no dia 1º às {0}"
 msgid "Open"
 msgstr "Abrir"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Open computer"
 msgstr "Abrir computador"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2315
 msgid "Open in full window"
 msgstr "Abrir em janela cheia"
 
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2107
 msgid "Open navigation"
 msgstr "Abrir a navegação"
 
@@ -1793,7 +1801,7 @@ msgstr "Trabalho aberto"
 msgid "OpenAI-compatible server URL"
 msgstr "URL do servidor compatível com OpenAI"
 
-#: src/pages/Shell.tsx:4050
+#: src/pages/Shell.tsx:4079
 msgid "Opened its thread."
 msgstr "Abriu a conversa."
 
@@ -1806,7 +1814,7 @@ msgstr "Abrindo seu espaço de trabalho..."
 msgid "Optional"
 msgstr "Opcional"
 
-#: src/pages/AccountSettingsOverlay.tsx:141
+#: src/pages/AccountSettingsOverlay.tsx:200
 msgid "Optional controls most people never need"
 msgstr "Controles opcionais que a maioria das pessoas nunca precisa"
 
@@ -1821,6 +1829,10 @@ msgstr "Ou conecte uma chave de API"
 #: src/pages/Onboarding.tsx:464
 msgid "Or paste an API key"
 msgstr "Ou cole uma chave de API"
+
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Organic"
+msgstr "Orgânico"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -1876,7 +1888,7 @@ msgstr "Reproduzindo"
 msgid "Preview {0}"
 msgstr "Pré-visualizar {0}"
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Private"
 msgstr "Privado"
 
@@ -1897,7 +1909,7 @@ msgstr "Na fila"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo verifica a fonte antes de salvá-la. As credenciais são criptografadas e nunca são devolvidas aos clientes ou expostas ao modelo."
 
-#: src/pages/Shell.tsx:4580
+#: src/pages/Shell.tsx:4609
 msgid "Read replies aloud"
 msgstr "Leia as respostas em voz alta"
 
@@ -1931,7 +1943,7 @@ msgstr "Recuperar substitui um computador inacessível e mantém os arquivos no 
 msgid "Recovering…"
 msgstr "Recuperando…"
 
-#: src/pages/Shell.tsx:3738
+#: src/pages/Shell.tsx:3767
 msgid "Release"
 msgstr "Libere"
 
@@ -1944,17 +1956,17 @@ msgid "Remove"
 msgstr "Remover"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3352
+#: src/pages/Shell.tsx:3381
 msgid "Remove {0}"
 msgstr "Remover {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3507
+#: src/pages/Shell.tsx:3536
 msgid "Remove mention {0}"
 msgstr "Remover menção {0}"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3515
 msgid "Remove skill {0}"
 msgstr "Remover habilidade {0}"
 
@@ -1962,7 +1974,7 @@ msgstr "Remover habilidade {0}"
 msgid "Remove this schedule"
 msgstr "Remover esta programação"
 
-#: src/pages/Shell.tsx:4049
+#: src/pages/Shell.tsx:4078
 msgid "Removed with chat, computer, and memory."
 msgstr "Removido com chat, computador e memória."
 
@@ -1990,11 +2002,11 @@ msgstr "Substituir chave de API"
 msgid "Replace key"
 msgstr "Substituir chave"
 
-#: src/pages/Shell.tsx:3684
+#: src/pages/Shell.tsx:3713
 msgid "Reply"
 msgstr "Responder"
 
-#: src/pages/Shell.tsx:3315
+#: src/pages/Shell.tsx:3344
 msgid "Replying to {replyName}"
 msgstr "Respondendo a {replyName}"
 
@@ -2015,7 +2027,7 @@ msgstr "Redefinir o computador?"
 msgid "Resetting…"
 msgstr "Redefinindo…"
 
-#: src/pages/Shell.tsx:1962
+#: src/pages/Shell.tsx:1972
 msgid "Restore"
 msgstr "Restaurar"
 
@@ -2031,17 +2043,21 @@ msgstr "Nova tentativa agora"
 msgid "Return to Rakazo"
 msgstr "Retorno a Rakazo"
 
-#: src/pages/Shell.tsx:2539
-#: src/pages/Shell.tsx:2592
-#: src/pages/Shell.tsx:2599
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Robot"
+msgstr "Robô"
+
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Routine"
 msgstr "Rotina"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2392
 msgid "Routines"
 msgstr "Rotinas"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Run now"
 msgstr "Executar agora"
 
@@ -2049,11 +2065,11 @@ msgstr "Executar agora"
 msgid "Running"
 msgstr "Em execução"
 
-#: src/pages/Shell.tsx:2417
+#: src/pages/Shell.tsx:2432
 msgid "Running · Stop"
 msgstr "Em execução · Parar"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Running…"
 msgstr "Executando..."
 
@@ -2061,8 +2077,8 @@ msgstr "Executando..."
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2638
-#: src/pages/Shell.tsx:4635
+#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:4664
 msgid "Save"
 msgstr "Salvar"
 
@@ -2086,7 +2102,7 @@ msgstr "Salvo."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2638
+#: src/pages/Shell.tsx:2653
 msgid "Saving…"
 msgstr "Salvando..."
 
@@ -2127,11 +2143,11 @@ msgstr "Pesquisar fornecedores e modelos"
 msgid "Searching…"
 msgstr "Pesquisando…"
 
-#: src/pages/Shell.tsx:2121
+#: src/pages/Shell.tsx:2136
 msgid "Select a bot"
 msgstr "Selecione um bot"
 
-#: src/pages/Shell.tsx:3568
+#: src/pages/Shell.tsx:3597
 msgid "Send"
 msgstr "Enviar"
 
@@ -2159,22 +2175,22 @@ msgstr "Nome do servidor"
 msgid "Server URL"
 msgstr "URL do servidor"
 
-#: src/pages/Shell.tsx:2130
+#: src/pages/Shell.tsx:2145
 msgid "Set up voice to call"
 msgstr "Configurar voz para ligar"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1995
+#: src/pages/AccountSettingsOverlay.tsx:100
 #: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2267
+#: src/pages/Shell.tsx:2015
+#: src/pages/Shell.tsx:2282
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/pages/Shell.tsx:3586
+#: src/pages/Shell.tsx:3615
 msgid "Settings: General"
 msgstr "Opções > Geral"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3617
 msgid "Settings: Usage"
 msgstr "Configurações: Uso"
 
@@ -2184,15 +2200,15 @@ msgid "Setup help"
 msgstr "Ajuda"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4554
+#: src/pages/Shell.tsx:4583
 msgid "Shared"
 msgstr "Compartilhado"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show computer"
 msgstr "Mostrar computador"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show settings"
 msgstr "Mostrar configurações"
 
@@ -2216,11 +2232,11 @@ msgid "Sign up"
 msgstr "Cadastre-se"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3399
+#: src/pages/Shell.tsx:3428
 msgid "Skill {0}"
 msgstr "Habilidade {0}"
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3774
 msgid "Skip"
 msgstr "Pular"
 
@@ -2241,8 +2257,8 @@ msgstr "{0} ignorado"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Interrupções de espaço · Esc desliga"
 
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Speak"
 msgstr "Falar"
 
@@ -2254,8 +2270,8 @@ msgstr "Falar + transcrever"
 msgid "Speak only"
 msgstr "Falar apenas"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Speak this reply"
 msgstr "Fale esta resposta"
 
@@ -2281,20 +2297,20 @@ msgstr "Iniciando…"
 msgid "Steps"
 msgstr "Passos"
 
-#: src/pages/Shell.tsx:2918
-#: src/pages/Shell.tsx:2922
-#: src/pages/Shell.tsx:3559
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2947
+#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Stop"
 msgstr "Parar"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Stop dictation"
 msgstr "Parar ditado"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Stop speaking"
 msgstr "Pare de Falar"
 
@@ -2303,8 +2319,8 @@ msgstr "Pare de Falar"
 msgid "Stop teaching"
 msgstr "Parar de ensinar"
 
-#: src/pages/Shell.tsx:2357
-#: src/pages/Shell.tsx:2938
+#: src/pages/Shell.tsx:2372
+#: src/pages/Shell.tsx:2963
 msgid "Stop the bot first"
 msgstr "Pare o bot primeiro"
 
@@ -2312,7 +2328,7 @@ msgstr "Pare o bot primeiro"
 msgid "Stored encrypted"
 msgstr "Armazenado criptografado"
 
-#: src/pages/Shell.tsx:4001
+#: src/pages/Shell.tsx:4030
 msgid "subagent"
 msgstr "subagente"
 
@@ -2325,8 +2341,8 @@ msgstr "Enviar"
 msgid "Switching…"
 msgstr "Alternando…"
 
-#: src/pages/Shell.tsx:2360
-#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2375
+#: src/pages/Shell.tsx:2968
 msgid "Take control"
 msgstr "Assumir o controle"
 
@@ -2334,7 +2350,7 @@ msgstr "Assumir o controle"
 msgid "Teach a task"
 msgstr "Ensinar uma tarefa"
 
-#: src/pages/Shell.tsx:2193
+#: src/pages/Shell.tsx:2208
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Ensino em andamento — pare de ensinar antes de enviar uma nova mensagem."
 
@@ -2342,11 +2358,11 @@ msgstr "Ensino em andamento — pare de ensinar antes de enviar uma nova mensage
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "O ensino precisa de um computador sandbox gráfico. Os bots de host de desktop podem executar tarefas de shell, mas não a gravação de tela."
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Team"
 msgstr "Equipe"
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "Team Computer"
 msgstr "Computador da equipe"
 
@@ -2359,20 +2375,20 @@ msgstr "Teste"
 msgid "The selected memory provider is not available in this build."
 msgstr "O provedor de memória selecionado não está disponível nesta compilação."
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4560
 msgid "Thinking"
 msgstr "Pensando"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2319
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Este bot é executado neste computador, não em um desktop Linux. Shell e arquivos usam sua pasta inicial."
 
-#: src/pages/Shell.tsx:2967
+#: src/pages/Shell.tsx:2992
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Este bot é executado neste computador. Não há uma área de trabalho Linux separada. Peça-lhe para usar o shell; diretórios de trabalho na sua pasta pessoal são permitidos."
 
-#: src/pages/Shell.tsx:4931
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:4960
+#: src/pages/Shell.tsx:5037
 msgid "This cannot be undone."
 msgstr "Essa ação não pode ser desfeita."
 
@@ -2396,7 +2412,7 @@ msgstr "esse Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Este Mac executa comandos do shell com sua conta, incluindo arquivos em sua pasta inicial. Não o ligue para um servidor compartilhado ou público."
 
-#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4845
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Isso remove permanentemente todas as mensagens e interrompe o trabalho atual. O bot, o computador, a memória e as rotinas são mantidos."
 
@@ -2404,7 +2420,7 @@ msgstr "Isso remove permanentemente todas as mensagens e interrompe o trabalho a
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Este provedor não pode colar uma chave aqui. Ignore se esta implantação já tiver credenciais."
 
-#: src/pages/Shell.tsx:5348
+#: src/pages/Shell.tsx:5377
 msgid "This server cannot be assigned without a bot."
 msgstr "Este servidor não pode ser atribuído sem um bot."
 
@@ -2416,7 +2432,7 @@ msgstr "Este servidor não solicitou autorização do navegador."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Este servidor já está conectado. Desconecte-o primeiro para autorizar novamente."
 
-#: src/pages/Shell.tsx:5387
+#: src/pages/Shell.tsx:5416
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Este servidor usa o login do navegador. Autorize-o a permitir que seus agentes usem suas ferramentas — um pop-up será aberto."
 
@@ -2429,8 +2445,8 @@ msgid "Time of day"
 msgstr "Hora do dia"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4305
-#: src/pages/Shell.tsx:4472
+#: src/pages/Shell.tsx:4334
+#: src/pages/Shell.tsx:4501
 msgid "Title"
 msgstr "Título"
 
@@ -2467,8 +2483,8 @@ msgstr "Atualizar computador"
 msgid "Updating…"
 msgstr "Atualizando…"
 
-#: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2056
+#: src/pages/AccountSettingsOverlay.tsx:176
+#: src/pages/Shell.tsx:2066
 msgid "Usage"
 msgstr "Uso"
 
@@ -2493,8 +2509,8 @@ msgstr "Verificar e adicionar"
 msgid "Verifying…"
 msgstr "Verificando…"
 
-#: src/pages/Shell.tsx:2044
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:2054
+#: src/pages/Shell.tsx:4613
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2507,7 +2523,7 @@ msgstr "Voz"
 msgid "Waiting for sign-in…"
 msgstr "Aguardando login..."
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5260
 msgid "Waiting…"
 msgstr "Aguardando…"
 
@@ -2516,7 +2532,7 @@ msgstr "Aguardando…"
 msgid "Weekdays"
 msgstr "Dias da semana"
 
-#: src/pages/Shell.tsx:4901
+#: src/pages/Shell.tsx:4930
 msgid "What about its memories?"
 msgstr "E suas memórias?"
 
@@ -2525,7 +2541,7 @@ msgid "What result will you demonstrate?"
 msgstr "Que resultado você demonstrará?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4320
+#: src/pages/Shell.tsx:4349
 msgid "What this bot is for"
 msgstr "Para que serve este bot"
 
@@ -2537,7 +2553,7 @@ msgstr "O que devolver"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "Quando o {botName} envia mensagens para outro bot, a conversa aparece aqui em vez de no chat."
 
-#: src/pages/Shell.tsx:2563
+#: src/pages/Shell.tsx:2578
 msgid "When to run"
 msgstr "Quando executar"
 
@@ -2554,7 +2570,7 @@ msgstr "Onde os bots devem ser executados?"
 msgid "Working…"
 msgstr "Funcionando"
 
-#: src/pages/Shell.tsx:4514
+#: src/pages/Shell.tsx:4543
 msgid "Workspace default"
 msgstr "Padrão do espaço de trabalho"
 
@@ -2571,8 +2587,8 @@ msgstr "Você pode fechar esta guia se ela não for redirecionada automaticament
 msgid "You can close this window."
 msgstr "Você pode fechar esta janela."
 
-#: src/pages/Shell.tsx:2337
-#: src/pages/Shell.tsx:2908
+#: src/pages/Shell.tsx:2352
+#: src/pages/Shell.tsx:2933
 msgid "You have control"
 msgstr "Você tem o controle"
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -418,7 +418,7 @@ msgstr "Autorizar"
 
 #: src/pages/AccountSettingsOverlay.tsx:133
 msgid "Avatars"
-msgstr "Avatares"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -953,10 +953,6 @@ msgstr "Não foi possível atualizar"
 msgid "Could not update agent access"
 msgstr "Não foi possível atualizar o acesso do agente"
 
-#: src/pages/AccountSettingsOverlay.tsx:80
-msgid "Could not update avatar style"
-msgstr "Não foi possível atualizar o estilo do avatar"
-
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr "Não foi possível atualizar o computador"
@@ -964,6 +960,10 @@ msgstr "Não foi possível atualizar o computador"
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "Não foi possível atualizar o escopo de memória padrão"
+
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Couldn't update avatars"
+msgstr ""
 
 #: src/pages/Shell.tsx:1761
 #: src/pages/Shell.tsx:4361
@@ -1832,7 +1832,7 @@ msgstr "Ou cole uma chave de API"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Organic"
-msgstr "Orgânico"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -2045,7 +2045,7 @@ msgstr "Retorno a Rakazo"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Robot"
-msgstr "Robô"
+msgstr ""
 
 #: src/pages/Shell.tsx:2554
 #: src/pages/Shell.tsx:2607

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:1857
+#: src/pages/Shell.tsx:1862
 msgid " (unread)"
 msgstr " (okunmadı)"
 
@@ -46,12 +46,12 @@ msgid "{0} {unitLabel}"
 msgstr "{0} {unitLabel}"
 
 #. placeholder {0}: block.name
-#: src/pages/Shell.tsx:5204
+#: src/pages/Shell.tsx:5233
 msgid "{0} connection"
 msgstr "{0} bağlantısı"
 
 #. placeholder {0}: computer.busyBotName
-#: src/pages/Shell.tsx:2341
+#: src/pages/Shell.tsx:2356
 msgid "{0} is using it"
 msgstr "{0} bunu kullanıyor"
 
@@ -67,8 +67,8 @@ msgstr "{0} MB"
 
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
-#: src/pages/AccountSettingsOverlay.tsx:121
-#: src/pages/Shell.tsx:2061
+#: src/pages/AccountSettingsOverlay.tsx:180
+#: src/pages/Shell.tsx:2071
 msgid "{0} runs · {1} tokens"
 msgstr "{0} çalıştırma · {1} token"
 
@@ -81,7 +81,7 @@ msgstr "{botName} · {0, plural, one {# eş bot} other {# eş bot}}"
 msgid "{botName} has not messaged another bot yet."
 msgstr "{botName} henüz başka bir bota mesaj göndermedi."
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "{botName}’s computer"
 msgstr "{botName} adlı botun bilgisayarı"
 
@@ -111,7 +111,7 @@ msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3371
+#: src/pages/Shell.tsx:3400
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -127,15 +127,15 @@ msgstr "+ Görev öğret"
 msgid "Access token (optional)"
 msgstr "Erişim token'ı (isteğe bağlı)"
 
-#: src/pages/AccountSettingsOverlay.tsx:97
+#: src/pages/AccountSettingsOverlay.tsx:118
 msgid "Account"
 msgstr "Hesap"
 
-#: src/pages/Shell.tsx:4590
+#: src/pages/Shell.tsx:4619
 msgid "Account default"
 msgstr "Hesap varsayılanı"
 
-#: src/pages/AccountSettingsOverlay.tsx:82
+#: src/pages/AccountSettingsOverlay.tsx:103
 msgid "Account preferences apply across all your bots."
 msgstr "Hesap tercihleri tüm botlarında geçerlidir."
 
@@ -218,10 +218,10 @@ msgstr "Treg ekle"
 msgid "Adding…"
 msgstr "Ekleniyor…"
 
-#: src/pages/AccountSettingsOverlay.tsx:138
+#: src/pages/AccountSettingsOverlay.tsx:197
 #: src/pages/PluginsOverlay.tsx:414
 #: src/pages/RoutineSchedule.tsx:42
-#: src/pages/Shell.tsx:4493
+#: src/pages/Shell.tsx:4522
 msgid "Advanced"
 msgstr "Gelişmiş"
 
@@ -229,7 +229,7 @@ msgstr "Gelişmiş"
 msgid "Agent access for new servers"
 msgstr "Yeni sunucular için agent erişimi"
 
-#: src/pages/Shell.tsx:2148
+#: src/pages/Shell.tsx:2163
 msgid "Agent computer"
 msgstr "Agent bilgisayarı"
 
@@ -316,11 +316,11 @@ msgstr "Sunucu ekle'ye tıkladığında uygulanır. Erişimi istediğin zaman de
 msgid "Approval boundaries"
 msgstr "Onay sınırları"
 
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 msgid "Approve"
 msgstr "Onayla"
 
-#: src/pages/Shell.tsx:5388
+#: src/pages/Shell.tsx:5417
 msgid "Approve this server to let your agent use its tools."
 msgstr "Agent'ının bu sunucunun araçlarını kullanabilmesi için sunucuyu onayla."
 
@@ -328,15 +328,15 @@ msgstr "Agent'ının bu sunucunun araçlarını kullanabilmesi için sunucuyu on
 msgid "Archive"
 msgstr "Arşivle"
 
-#: src/pages/Shell.tsx:4037
+#: src/pages/Shell.tsx:4066
 msgid "archived"
 msgstr "arşivlendi"
 
-#: src/pages/Shell.tsx:1941
+#: src/pages/Shell.tsx:1946
 msgid "Archived"
 msgstr "Arşivlendi"
 
-#: src/pages/Shell.tsx:4048
+#: src/pages/Shell.tsx:4077
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Arşivlendi. Sohbet, hafıza ve dosyalar korundu."
 
@@ -375,7 +375,7 @@ msgstr "Satın almadan önce sor"
 msgid "Ask before sending external email"
 msgstr "Dışarıya e-posta göndermeden önce sor"
 
-#: src/pages/Shell.tsx:2343
+#: src/pages/Shell.tsx:2358
 msgid "Asleep"
 msgstr "Uykuda"
 
@@ -390,11 +390,11 @@ msgstr "saat {0}"
 msgid "at {timeSelect}"
 msgstr "saat {timeSelect}"
 
-#: src/pages/Shell.tsx:3442
+#: src/pages/Shell.tsx:3471
 msgid "Attach file"
 msgstr "Dosya ekle"
 
-#: src/pages/Shell.tsx:3641
+#: src/pages/Shell.tsx:3670
 msgid "Attachment"
 msgstr "Ek"
 
@@ -407,14 +407,18 @@ msgstr "Yetkilendirme kodu veya callback URL'si"
 msgid "Authorization expired — reconnect required"
 msgstr "Yetkilendirme süresi doldu — yeniden bağlanmak gerekiyor"
 
-#: src/pages/Shell.tsx:5189
+#: src/pages/Shell.tsx:5218
 msgid "Authorization timed out. Please try again."
 msgstr "Yetkilendirme zaman aşımına uğradı. Lütfen tekrar dene."
 
-#: src/pages/Shell.tsx:5231
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5260
+#: src/pages/Shell.tsx:5426
 msgid "Authorize"
 msgstr "Yetkilendir"
+
+#: src/pages/AccountSettingsOverlay.tsx:133
+msgid "Avatars"
+msgstr "Avatarlar"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -424,18 +428,18 @@ msgstr "Temel URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5073
+#: src/pages/Shell.tsx:5102
 msgid "Booting live desktop…"
 msgstr "Canlı masaüstü başlatılıyor…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:2883
+#: src/pages/Shell.tsx:2903
 msgid "Booting up {0}’s computer"
 msgstr "{0} adlı botun bilgisayarı başlatılıyor"
 
-#: src/pages/Shell.tsx:3907
-#: src/pages/Shell.tsx:3908
-#: src/pages/Shell.tsx:4041
+#: src/pages/Shell.tsx:3936
+#: src/pages/Shell.tsx:3937
+#: src/pages/Shell.tsx:4070
 msgid "bot"
 msgstr "bot"
 
@@ -447,11 +451,11 @@ msgstr "Bot"
 msgid "Bot messages"
 msgstr "Bot mesajları"
 
-#: src/pages/Shell.tsx:2975
+#: src/pages/Shell.tsx:3000
 msgid "Bot screen"
 msgstr "Bot ekranı"
 
-#: src/pages/Shell.tsx:2311
+#: src/pages/Shell.tsx:2326
 msgid "Bot screen preview"
 msgstr "Bot ekranı önizlemesi"
 
@@ -464,8 +468,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Kendi anahtarını getir. Sağlayıcı değiştirilebilir; botlarındaki seslendirme ve arama düğmeleri aynı kalır."
 
 #: src/pages/CallView.tsx:203
-#: src/pages/Shell.tsx:2130
-#: src/pages/Shell.tsx:2131
+#: src/pages/Shell.tsx:2145
+#: src/pages/Shell.tsx:2146
 msgid "Call"
 msgstr "Ara"
 
@@ -477,14 +481,14 @@ msgstr "Sunucuya ulaşılamıyor."
 #: src/components/ComputerMaintenanceActions.tsx:108
 #: src/components/teach/TeachComputerSection.tsx:122
 #: src/pages/PluginsOverlay.tsx:536
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:4829
-#: src/pages/Shell.tsx:4944
-#: src/pages/Shell.tsx:5018
+#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4858
+#: src/pages/Shell.tsx:4973
+#: src/pages/Shell.tsx:5047
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/pages/Shell.tsx:4285
+#: src/pages/Shell.tsx:4314
 msgid "Cancel new bot"
 msgstr "Yeni botu iptal et"
 
@@ -492,7 +496,7 @@ msgstr "Yeni botu iptal et"
 msgid "Cancel new group"
 msgstr "Yeni grubu iptal et"
 
-#: src/pages/Shell.tsx:3318
+#: src/pages/Shell.tsx:3347
 msgid "Cancel reply"
 msgstr "Yanıtı iptal et"
 
@@ -500,16 +504,16 @@ msgstr "Yanıtı iptal et"
 msgid "Cancelled"
 msgstr "İptal edildi"
 
-#: src/pages/Shell.tsx:5294
+#: src/pages/Shell.tsx:5323
 msgid "Chart failed to render: {error}"
 msgstr "Grafik çizilemedi: {error}"
 
-#: src/pages/Shell.tsx:3584
+#: src/pages/Shell.tsx:3613
 msgid "Chat Settings"
 msgstr "Sohbet Ayarları"
 
-#: src/pages/Shell.tsx:2593
-#: src/pages/Shell.tsx:2600
+#: src/pages/Shell.tsx:2608
+#: src/pages/Shell.tsx:2615
 msgid "Check in."
 msgstr "Durum bildir."
 
@@ -521,21 +525,21 @@ msgstr "Başlamak için bir model seç."
 msgid "Choose which connected model Rakazo uses."
 msgstr "Rakazo'nun hangi bağlı modeli kullanacağını seç."
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clear"
 msgstr "Temizle"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4810
+#: src/pages/Shell.tsx:4839
 msgid "Clear {0}’s conversation?"
 msgstr "{0} sohbeti temizlensin mi?"
 
 #: src/pages/BotContextMenu.tsx:101
-#: src/pages/Shell.tsx:4645
+#: src/pages/Shell.tsx:4674
 msgid "Clear conversation"
 msgstr "Sohbeti temizle"
 
-#: src/pages/Shell.tsx:4844
+#: src/pages/Shell.tsx:4873
 msgid "Clearing…"
 msgstr "Temizleniyor…"
 
@@ -551,15 +555,15 @@ msgstr "Bot menüsünü kapat"
 msgid "Close bot messages"
 msgstr "Bot mesajlarını kapat"
 
-#: src/pages/Shell.tsx:5479
+#: src/pages/Shell.tsx:5508
 msgid "Close chart"
 msgstr "Grafiği kapat"
 
-#: src/pages/Shell.tsx:2949
+#: src/pages/Shell.tsx:2974
 msgid "Close computer"
 msgstr "Bilgisayarı kapat"
 
-#: src/pages/Shell.tsx:5579
+#: src/pages/Shell.tsx:5608
 msgid "Close image preview"
 msgstr "Görsel önizlemesini kapat"
 
@@ -583,7 +587,7 @@ msgstr "Model ayarlarını kapat"
 msgid "Close navigation"
 msgstr "Gezinmeyi kapat"
 
-#: src/pages/Shell.tsx:2289
+#: src/pages/Shell.tsx:2304
 msgid "Close panel"
 msgstr "Paneli kapat"
 
@@ -592,7 +596,7 @@ msgstr "Paneli kapat"
 msgid "Close preview"
 msgstr "Önizlemeyi kapat"
 
-#: src/pages/AccountSettingsOverlay.tsx:87
+#: src/pages/AccountSettingsOverlay.tsx:108
 msgid "Close user settings"
 msgstr "Kullanıcı ayarlarını kapat"
 
@@ -612,24 +616,24 @@ msgstr "Komut"
 msgid "Complete"
 msgstr "Tamamlandı"
 
-#: src/pages/Shell.tsx:4195
-#: src/pages/Shell.tsx:4223
+#: src/pages/Shell.tsx:4224
+#: src/pages/Shell.tsx:4252
 msgid "Computer"
 msgstr "Bilgisayar"
 
-#: src/pages/Shell.tsx:5076
+#: src/pages/Shell.tsx:5105
 msgid "Computer failed to boot"
 msgstr "Bilgisayar başlatılamadı"
 
-#: src/pages/Shell.tsx:2997
+#: src/pages/Shell.tsx:3022
 msgid "Computer is asleep"
 msgstr "Bilgisayar uykuda"
 
-#: src/pages/Shell.tsx:5075
+#: src/pages/Shell.tsx:5104
 msgid "Computer is asleep — take control to wake it"
 msgstr "Bilgisayar uykuda — uyandırmak için kontrolü al"
 
-#: src/pages/Shell.tsx:5077
+#: src/pages/Shell.tsx:5106
 msgid "Computer is stopped"
 msgstr "Bilgisayar durduruldu"
 
@@ -662,7 +666,7 @@ msgstr "API anahtarıyla bağlan"
 msgid "Connect ElevenLabs, OpenAI, or Cartesia"
 msgstr "ElevenLabs, OpenAI veya Cartesia bağla"
 
-#: src/pages/Shell.tsx:5377
+#: src/pages/Shell.tsx:5406
 msgid "Connect MCP server “{name}”"
 msgstr "“{name}” MCP sunucusunu bağla"
 
@@ -685,12 +689,12 @@ msgstr "Treg'i bağla"
 #: src/pages/McpOAuthCallback.tsx:53
 #: src/pages/MemorySettingsOverlay.tsx:163
 #: src/pages/ModelSettingsOverlay.tsx:378
-#: src/pages/Shell.tsx:5228
+#: src/pages/Shell.tsx:5257
 #: src/pages/VoiceSettingsOverlay.tsx:202
 msgid "Connected"
 msgstr "Bağlandı"
 
-#: src/pages/Shell.tsx:5407
+#: src/pages/Shell.tsx:5436
 msgid "Connected — its tools are available from your next message."
 msgstr "Bağlandı — araçları bir sonraki mesajından itibaren kullanılabilir."
 
@@ -715,7 +719,7 @@ msgstr "Bağlandı, {0} kullanılıyor."
 
 #: src/pages/McpServersOverlay.tsx:16
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:80
-#: src/pages/Shell.tsx:5397
+#: src/pages/Shell.tsx:5426
 #: src/pages/VoiceSettingsOverlay.tsx:253
 msgid "Connecting…"
 msgstr "Bağlanıyor…"
@@ -734,7 +738,7 @@ msgstr "Devam"
 msgid "Continue with email"
 msgstr "E-posta ile devam et"
 
-#: src/pages/Shell.tsx:3692
+#: src/pages/Shell.tsx:3721
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -746,11 +750,11 @@ msgstr "Eklenemedi"
 msgid "Could not add MCP server"
 msgstr "MCP sunucusu eklenemedi"
 
-#: src/pages/Shell.tsx:5364
+#: src/pages/Shell.tsx:5393
 msgid "Could not approve this server"
 msgstr "Bu sunucu onaylanamadı"
 
-#: src/pages/Shell.tsx:5192
+#: src/pages/Shell.tsx:5221
 msgid "Could not authorize this app"
 msgstr "Bu uygulama yetkilendirilemedi"
 
@@ -758,7 +762,7 @@ msgstr "Bu uygulama yetkilendirilemedi"
 msgid "Could not change the default model"
 msgstr "Varsayılan model değiştirilemedi"
 
-#: src/pages/Shell.tsx:4838
+#: src/pages/Shell.tsx:4867
 msgid "Could not clear conversation"
 msgstr "Sohbet temizlenemedi"
 
@@ -787,7 +791,7 @@ msgstr "Bu ses sağlayıcısı bağlanamadı"
 msgid "Could not continue"
 msgstr "Devam edilemedi"
 
-#: src/pages/Shell.tsx:4273
+#: src/pages/Shell.tsx:4302
 msgid "Could not create bot"
 msgstr "Bot oluşturulamadı"
 
@@ -795,7 +799,7 @@ msgstr "Bot oluşturulamadı"
 msgid "Could not create group"
 msgstr "Grup oluşturulamadı"
 
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4758
 msgid "Could not create section"
 msgstr "Bölüm oluşturulamadı"
 
@@ -803,7 +807,7 @@ msgstr "Bölüm oluşturulamadı"
 msgid "Could not create your bot"
 msgstr "Botun oluşturulamadı"
 
-#: src/pages/Shell.tsx:4953
+#: src/pages/Shell.tsx:4982
 msgid "Could not delete bot"
 msgstr "Bot silinemedi"
 
@@ -811,7 +815,7 @@ msgstr "Bot silinemedi"
 msgid "Could not delete MCP server"
 msgstr "MCP sunucusu silinemedi"
 
-#: src/pages/Shell.tsx:5027
+#: src/pages/Shell.tsx:5056
 msgid "Could not delete routine"
 msgstr "Rutin silinemedi"
 
@@ -885,7 +889,7 @@ msgstr "Grup kaldırılamadı"
 msgid "Could not remove rule"
 msgstr "Kural kaldırılamadı"
 
-#: src/pages/Shell.tsx:5284
+#: src/pages/Shell.tsx:5313
 msgid "Could not render chart"
 msgstr "Grafik çizilemedi"
 
@@ -893,7 +897,7 @@ msgstr "Grafik çizilemedi"
 msgid "Could not revoke connection"
 msgstr "Bağlantı iptal edilemedi"
 
-#: src/pages/Shell.tsx:4630
+#: src/pages/Shell.tsx:4659
 msgid "Could not save"
 msgstr "Kaydedilemedi"
 
@@ -905,7 +909,7 @@ msgstr "Grup kaydedilemedi"
 msgid "Could not save model"
 msgstr "Model kaydedilemedi"
 
-#: src/pages/Shell.tsx:2615
+#: src/pages/Shell.tsx:2630
 msgid "Could not save routine"
 msgstr "Rutin kaydedilemedi"
 
@@ -921,7 +925,7 @@ msgstr "Bu seçim kaydedilemedi"
 msgid "Could not save that voice"
 msgstr "Bu ses kaydedilemedi"
 
-#: src/pages/Shell.tsx:5104
+#: src/pages/Shell.tsx:5133
 msgid "Could not save this choice"
 msgstr "Bu seçim kaydedilemedi"
 
@@ -949,6 +953,10 @@ msgstr "Güncellenemedi"
 msgid "Could not update agent access"
 msgstr "Agent erişimi güncellenemedi"
 
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Could not update avatar style"
+msgstr "Avatar stili güncellenemedi"
+
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr ""
@@ -958,13 +966,13 @@ msgid "Could not update the default memory scope"
 msgstr "Varsayılan hafıza kapsamı güncellenemedi"
 
 #: src/pages/Shell.tsx:1761
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Create"
 msgstr "Oluştur"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:4738
+#: src/pages/Shell.tsx:4767
 msgid "Create a section and move {0} into it."
 msgstr "Bir bölüm oluştur ve {0} botunu içine taşı."
 
@@ -985,8 +993,8 @@ msgid "Create your Rakazo"
 msgstr "Rakazo hesabını oluştur"
 
 #: src/pages/GroupPanel.tsx:134
-#: src/pages/Shell.tsx:4332
-#: src/pages/Shell.tsx:4764
+#: src/pages/Shell.tsx:4361
+#: src/pages/Shell.tsx:4793
 msgid "Creating…"
 msgstr "Oluşturuluyor…"
 
@@ -1014,7 +1022,7 @@ msgstr "gün"
 msgid "days"
 msgstr "gün"
 
-#: src/pages/Shell.tsx:4537
+#: src/pages/Shell.tsx:4566
 msgid "Default (medium)"
 msgstr "Varsayılan (orta)"
 
@@ -1024,21 +1032,21 @@ msgstr "Varsayılan kapsam"
 
 #: src/pages/BotContextMenu.tsx:103
 #: src/pages/McpServersOverlay.tsx:481
-#: src/pages/Shell.tsx:1970
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:1980
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Delete"
 msgstr "Sil"
 
 #. placeholder {0}: bot.name
-#: src/pages/Shell.tsx:1966
+#: src/pages/Shell.tsx:1976
 msgid "Delete {0}"
 msgstr "{0} sil"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: routine.name
-#: src/pages/Shell.tsx:4891
-#: src/pages/Shell.tsx:5005
+#: src/pages/Shell.tsx:4920
+#: src/pages/Shell.tsx:5034
 msgid "Delete {0}?"
 msgstr "{0} silinsin mi?"
 
@@ -1046,21 +1054,21 @@ msgstr "{0} silinsin mi?"
 msgid "Delete group"
 msgstr "Grubu sil"
 
-#: src/pages/Shell.tsx:4928
+#: src/pages/Shell.tsx:4957
 msgid "Delete memories too"
 msgstr "Hafızayı da sil"
 
-#: src/pages/Shell.tsx:2670
+#: src/pages/Shell.tsx:2685
 msgid "Delete routine"
 msgstr "Rutini sil"
 
-#: src/pages/Shell.tsx:4039
+#: src/pages/Shell.tsx:4068
 msgid "deleted"
 msgstr "silindi"
 
 #: src/pages/GroupPanel.tsx:232
-#: src/pages/Shell.tsx:4959
-#: src/pages/Shell.tsx:5033
+#: src/pages/Shell.tsx:4988
+#: src/pages/Shell.tsx:5062
 msgid "Deleting…"
 msgstr "Siliniyor…"
 
@@ -1077,17 +1085,17 @@ msgid "Deployment default"
 msgstr "Dağıtım varsayılanı"
 
 #: src/pages/Onboarding.tsx:526
-#: src/pages/Shell.tsx:4310
+#: src/pages/Shell.tsx:4339
 msgid "Describe what this bot does"
 msgstr "Bu botun ne yaptığını açıkla"
 
 #: src/pages/Onboarding.tsx:531
-#: src/pages/Shell.tsx:4315
-#: src/pages/Shell.tsx:4481
+#: src/pages/Shell.tsx:4344
+#: src/pages/Shell.tsx:4510
 msgid "Description"
 msgstr "Açıklama"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Dictate"
 msgstr "Dikte et"
 
@@ -1100,7 +1108,7 @@ msgstr "Bağlantıyı kes"
 msgid "Disconnecting…"
 msgstr "Bağlantı kesiliyor…"
 
-#: src/pages/Shell.tsx:5412
+#: src/pages/Shell.tsx:5441
 msgid "Dismissed — reconnect anytime from MCP settings."
 msgstr "Kapatıldı — MCP ayarlarından istediğin zaman yeniden bağlanabilirsin."
 
@@ -1148,7 +1156,7 @@ msgstr "Taslak beceri"
 msgid "Duplicate"
 msgstr "Çoğalt"
 
-#: src/pages/Shell.tsx:3852
+#: src/pages/Shell.tsx:3881
 msgid "Earlier message"
 msgstr ""
 
@@ -1204,11 +1212,11 @@ msgstr "Her ay"
 msgid "Every week"
 msgstr "Her hafta"
 
-#: src/pages/Shell.tsx:5458
+#: src/pages/Shell.tsx:5487
 msgid "Expand"
 msgstr "Genişlet"
 
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4671
 msgid "Export"
 msgstr "Dışa aktar"
 
@@ -1216,7 +1224,7 @@ msgstr "Dışa aktar"
 msgid "Export this week's list from the CRM and drop it in the shared folder"
 msgstr "Bu haftanın listesini CRM'den dışa aktar ve ortak klasöre bırak"
 
-#: src/pages/Shell.tsx:4662
+#: src/pages/Shell.tsx:4691
 msgid "Extra high"
 msgstr "Çok yüksek"
 
@@ -1267,8 +1275,8 @@ msgstr ""
 msgid "Fullscreen"
 msgstr "Tam ekran"
 
-#: src/pages/Shell.tsx:2120
-#: src/pages/Shell.tsx:2271
+#: src/pages/Shell.tsx:2135
+#: src/pages/Shell.tsx:2286
 msgid "Group"
 msgstr "Grup"
 
@@ -1297,15 +1305,15 @@ msgstr "Örnek dinle"
 msgid "Hi, this is how I'll sound when I read replies out loud."
 msgstr "Merhaba, yanıtları sesli okuduğumda böyle duyulacağım."
 
-#: src/pages/Shell.tsx:4665
+#: src/pages/Shell.tsx:4694
 msgid "High"
 msgstr "Yüksek"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk"
 msgstr "Konuşmak için basılı tut"
 
-#: src/pages/Shell.tsx:3470
+#: src/pages/Shell.tsx:3499
 msgid "Hold to talk (on-device dictation)"
 msgstr "Konuşmak için basılı tut (cihaz üzerinde dikte)"
 
@@ -1325,7 +1333,7 @@ msgstr "Ne sıklıkla"
 msgid "How to check"
 msgstr "Nasıl kontrol edilir"
 
-#: src/pages/Shell.tsx:3748
+#: src/pages/Shell.tsx:3777
 msgid "I’m done"
 msgstr "Bitirdim"
 
@@ -1337,7 +1345,7 @@ msgstr "Bunu duyduysan ses hazır."
 msgid "Import OpenAPI JSON"
 msgstr "OpenAPI JSON içe aktar"
 
-#: src/pages/Shell.tsx:4552
+#: src/pages/Shell.tsx:4581
 msgid "Inherit default"
 msgstr "Varsayılanı devral"
 
@@ -1349,12 +1357,12 @@ msgstr "Girdiler"
 msgid "Instance API key"
 msgstr "Instance API anahtarı"
 
-#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2569
 msgid "Instruction"
 msgstr "Talimat"
 
 #: src/pages/PluginsOverlay.tsx:237
-#: src/pages/Shell.tsx:1987
+#: src/pages/Shell.tsx:1997
 msgid "Integrations"
 msgstr "Entegrasyonlar"
 
@@ -1375,15 +1383,15 @@ msgid "Interval unit"
 msgstr "Aralık birimi"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4553
+#: src/pages/Shell.tsx:4582
 msgid "Isolated"
 msgstr "Yalıtılmış"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4923
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Sohbeti, dosyaları ve rutinleri kalıcı olarak silinecek. Oluşturduğu botlar listende kalır."
 
-#: src/pages/Shell.tsx:3847
+#: src/pages/Shell.tsx:3876
 msgid "Jump to replied message"
 msgstr "Yanıtlanan mesaja git"
 
@@ -1391,7 +1399,7 @@ msgstr "Yanıtlanan mesaja git"
 msgid "just now"
 msgstr "az önce"
 
-#: src/pages/Shell.tsx:4912
+#: src/pages/Shell.tsx:4941
 msgid "Keep memories"
 msgstr "Hafızayı koru"
 
@@ -1399,9 +1407,9 @@ msgstr "Hafızayı koru"
 msgid "Keys stay on the server. The app only learns whether a provider is configured."
 msgstr "Anahtarlar sunucuda kalır. Uygulama yalnızca bir sağlayıcının yapılandırılıp yapılandırılmadığını öğrenir."
 
-#: src/pages/AccountSettingsOverlay.tsx:105
-#: src/pages/AccountSettingsOverlay.tsx:254
-#: src/pages/AccountSettingsOverlay.tsx:271
+#: src/pages/AccountSettingsOverlay.tsx:126
+#: src/pages/AccountSettingsOverlay.tsx:313
+#: src/pages/AccountSettingsOverlay.tsx:330
 msgid "Language"
 msgstr "Dil"
 
@@ -1409,7 +1417,7 @@ msgstr "Dil"
 msgid "Listening…"
 msgstr "Dinliyor…"
 
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Load earlier messages"
 msgstr "Önceki mesajları yükle"
 
@@ -1449,7 +1457,7 @@ msgstr "Ses sağlayıcıları yükleniyor…"
 
 #: src/App.tsx:50
 #: src/pages/Onboarding.tsx:214
-#: src/pages/Shell.tsx:3071
+#: src/pages/Shell.tsx:3100
 msgid "Loading…"
 msgstr "Yükleniyor…"
 
@@ -1457,11 +1465,11 @@ msgstr "Yükleniyor…"
 msgid "Local"
 msgstr "Yerel"
 
-#: src/pages/Shell.tsx:2073
+#: src/pages/Shell.tsx:2083
 msgid "Log out"
 msgstr "Çıkış yap"
 
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4692
 msgid "Low"
 msgstr "Düşük"
 
@@ -1477,7 +1485,7 @@ msgstr "Okundu olarak işaretle"
 msgid "Mark as Unread"
 msgstr "Okunmadı olarak işaretle"
 
-#: src/pages/Shell.tsx:4667
+#: src/pages/Shell.tsx:4696
 msgid "Max"
 msgstr "Maksimum"
 
@@ -1487,7 +1495,7 @@ msgstr "Maksimum"
 msgid "MCP servers"
 msgstr "MCP sunucuları"
 
-#: src/pages/Shell.tsx:4664
+#: src/pages/Shell.tsx:4693
 msgid "Medium"
 msgstr "Orta"
 
@@ -1500,33 +1508,33 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Üyeler ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} seç)"
 
 #: src/pages/MemorySettingsOverlay.tsx:134
-#: src/pages/Shell.tsx:2031
+#: src/pages/Shell.tsx:2041
 msgid "Memory"
 msgstr "Hafıza"
 
-#: src/pages/Shell.tsx:4548
+#: src/pages/Shell.tsx:4577
 msgid "Memory scope"
 msgstr "Hafıza kapsamı"
 
-#: src/pages/Shell.tsx:3548
-#: src/pages/Shell.tsx:3643
+#: src/pages/Shell.tsx:3577
+#: src/pages/Shell.tsx:3672
 msgid "Message"
 msgstr "Mesaj"
 
-#: src/pages/Shell.tsx:3544
-#: src/pages/Shell.tsx:3548
+#: src/pages/Shell.tsx:3573
+#: src/pages/Shell.tsx:3577
 msgid "Message {activeName}"
 msgstr "{activeName} sohbetine yaz"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Message from {peer}"
 msgstr "{peer} botundan mesaj"
 
-#: src/pages/Shell.tsx:3545
+#: src/pages/Shell.tsx:3574
 msgid "Message…"
 msgstr "Mesaj…"
 
-#: src/pages/Shell.tsx:3925
+#: src/pages/Shell.tsx:3954
 msgid "Messaged {peer}"
 msgstr "{peer} botuna mesaj gönderildi"
 
@@ -1534,7 +1542,7 @@ msgstr "{peer} botuna mesaj gönderildi"
 msgid "Microphone failed"
 msgstr "Mikrofon hatası"
 
-#: src/pages/Shell.tsx:4666
+#: src/pages/Shell.tsx:4695
 msgid "Minimal"
 msgstr "Minimal"
 
@@ -1556,7 +1564,7 @@ msgstr "dakika"
 #: src/pages/Onboarding.tsx:295
 #: src/pages/Onboarding.tsx:344
 #: src/pages/Onboarding.tsx:352
-#: src/pages/Shell.tsx:4504
+#: src/pages/Shell.tsx:4533
 msgid "Model"
 msgstr "Model"
 
@@ -1569,7 +1577,7 @@ msgstr "Model kimliği"
 msgid "Model options"
 msgstr "Model seçenekleri"
 
-#: src/pages/AccountSettingsOverlay.tsx:127
+#: src/pages/AccountSettingsOverlay.tsx:186
 msgid "Model spend uses your provider keys."
 msgstr "Model harcaması senin sağlayıcı anahtarlarını kullanır."
 
@@ -1578,7 +1586,7 @@ msgid "Model updated."
 msgstr "Model güncellendi."
 
 #: src/pages/ModelSettingsOverlay.tsx:304
-#: src/pages/Shell.tsx:2018
+#: src/pages/Shell.tsx:2028
 msgid "Models"
 msgstr "Modeller"
 
@@ -1596,7 +1604,7 @@ msgstr "Aylık"
 msgid "Move {0} to section"
 msgstr "{0} botunu bölüme taşı"
 
-#: src/pages/Shell.tsx:4915
+#: src/pages/Shell.tsx:4944
 msgid "Move them to your shared memory."
 msgstr "Bunları ortak hafızana taşı."
 
@@ -1609,15 +1617,15 @@ msgstr "Taşı"
 #: src/pages/GroupPanel.tsx:110
 #: src/pages/GroupPanel.tsx:201
 #: src/pages/Onboarding.tsx:513
-#: src/pages/Shell.tsx:2546
-#: src/pages/Shell.tsx:4295
-#: src/pages/Shell.tsx:4463
-#: src/pages/Shell.tsx:4741
+#: src/pages/Shell.tsx:2561
+#: src/pages/Shell.tsx:4324
+#: src/pages/Shell.tsx:4492
+#: src/pages/Shell.tsx:4770
 msgid "Name"
 msgstr "Ad"
 
 #: src/pages/Onboarding.tsx:517
-#: src/pages/Shell.tsx:4300
+#: src/pages/Shell.tsx:4329
 msgid "Name this bot"
 msgstr "Bota bir ad ver"
 
@@ -1634,7 +1642,7 @@ msgid "Needs takeover"
 msgstr "Devralma bekliyor"
 
 #: src/pages/Shell.tsx:1775
-#: src/pages/Shell.tsx:4283
+#: src/pages/Shell.tsx:4312
 msgid "New bot"
 msgstr "Yeni bot"
 
@@ -1647,12 +1655,12 @@ msgstr "Yeni grup"
 msgid "New open-work item"
 msgstr "Yeni açık iş öğesi"
 
-#: src/pages/Shell.tsx:2432
+#: src/pages/Shell.tsx:2447
 msgid "New routine"
 msgstr "Yeni rutin"
 
 #: src/pages/BotContextMenu.tsx:128
-#: src/pages/Shell.tsx:4735
+#: src/pages/Shell.tsx:4764
 msgid "New section"
 msgstr "Yeni bölüm"
 
@@ -1730,7 +1738,7 @@ msgstr "Bağlı değil"
 msgid "Not in the plugin catalog"
 msgstr ""
 
-#: src/pages/Shell.tsx:5400
+#: src/pages/Shell.tsx:5429
 msgid "Not now"
 msgstr "Şimdi değil"
 
@@ -1768,15 +1776,15 @@ msgstr "her ayın 1'inde saat {0}"
 msgid "Open"
 msgstr "Aç"
 
-#: src/pages/Shell.tsx:2330
+#: src/pages/Shell.tsx:2345
 msgid "Open computer"
 msgstr "Bilgisayarı aç"
 
-#: src/pages/Shell.tsx:2300
+#: src/pages/Shell.tsx:2315
 msgid "Open in full window"
 msgstr "Tam pencerede aç"
 
-#: src/pages/Shell.tsx:2097
+#: src/pages/Shell.tsx:2107
 msgid "Open navigation"
 msgstr "Gezinmeyi aç"
 
@@ -1793,7 +1801,7 @@ msgstr "Açık işler"
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI uyumlu sunucu URL'si"
 
-#: src/pages/Shell.tsx:4050
+#: src/pages/Shell.tsx:4079
 msgid "Opened its thread."
 msgstr "Sohbeti açıldı."
 
@@ -1806,7 +1814,7 @@ msgstr "Çalışma alanın açılıyor…"
 msgid "Optional"
 msgstr "İsteğe bağlı"
 
-#: src/pages/AccountSettingsOverlay.tsx:141
+#: src/pages/AccountSettingsOverlay.tsx:200
 msgid "Optional controls most people never need"
 msgstr "Çoğu kişinin hiç ihtiyaç duymadığı isteğe bağlı ayarlar"
 
@@ -1821,6 +1829,10 @@ msgstr "Veya bir API anahtarı bağla"
 #: src/pages/Onboarding.tsx:464
 msgid "Or paste an API key"
 msgstr "Veya bir API anahtarı yapıştır"
+
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Organic"
+msgstr "Organik"
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -1876,7 +1888,7 @@ msgstr "Çalınıyor…"
 msgid "Preview {0}"
 msgstr "{0} önizle"
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Private"
 msgstr "Özel"
 
@@ -1897,7 +1909,7 @@ msgstr "Kuyrukta"
 msgid "Rakazo verifies the source before saving it. Credentials are encrypted and are never returned to clients or exposed to the model."
 msgstr "Rakazo kaynağı kaydetmeden önce doğrular. Kimlik bilgileri şifrelenir; istemcilere asla geri gönderilmez ve modele gösterilmez."
 
-#: src/pages/Shell.tsx:4580
+#: src/pages/Shell.tsx:4609
 msgid "Read replies aloud"
 msgstr "Yanıtları sesli oku"
 
@@ -1931,7 +1943,7 @@ msgstr ""
 msgid "Recovering…"
 msgstr ""
 
-#: src/pages/Shell.tsx:3738
+#: src/pages/Shell.tsx:3767
 msgid "Release"
 msgstr "Bırak"
 
@@ -1944,17 +1956,17 @@ msgid "Remove"
 msgstr "Kaldır"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:3352
+#: src/pages/Shell.tsx:3381
 msgid "Remove {0}"
 msgstr "{0} kaldır"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:3507
+#: src/pages/Shell.tsx:3536
 msgid "Remove mention {0}"
 msgstr "{0} bahsini kaldır"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:3486
+#: src/pages/Shell.tsx:3515
 msgid "Remove skill {0}"
 msgstr "{0} becerisini kaldır"
 
@@ -1962,7 +1974,7 @@ msgstr "{0} becerisini kaldır"
 msgid "Remove this schedule"
 msgstr "Bu zamanlamayı kaldır"
 
-#: src/pages/Shell.tsx:4049
+#: src/pages/Shell.tsx:4078
 msgid "Removed with chat, computer, and memory."
 msgstr "Sohbeti, bilgisayarı ve hafızasıyla birlikte kaldırıldı."
 
@@ -1990,11 +2002,11 @@ msgstr "API anahtarını değiştir"
 msgid "Replace key"
 msgstr "Anahtarı değiştir"
 
-#: src/pages/Shell.tsx:3684
+#: src/pages/Shell.tsx:3713
 msgid "Reply"
 msgstr "Yanıtla"
 
-#: src/pages/Shell.tsx:3315
+#: src/pages/Shell.tsx:3344
 msgid "Replying to {replyName}"
 msgstr "{replyName} yanıtlanıyor"
 
@@ -2015,7 +2027,7 @@ msgstr ""
 msgid "Resetting…"
 msgstr ""
 
-#: src/pages/Shell.tsx:1962
+#: src/pages/Shell.tsx:1972
 msgid "Restore"
 msgstr "Geri yükle"
 
@@ -2031,17 +2043,21 @@ msgstr "Şimdi tekrar dene"
 msgid "Return to Rakazo"
 msgstr "Rakazo'ya dön"
 
-#: src/pages/Shell.tsx:2539
-#: src/pages/Shell.tsx:2592
-#: src/pages/Shell.tsx:2599
+#: src/pages/AccountSettingsOverlay.tsx:157
+msgid "Robot"
+msgstr "Robot"
+
+#: src/pages/Shell.tsx:2554
+#: src/pages/Shell.tsx:2607
+#: src/pages/Shell.tsx:2614
 msgid "Routine"
 msgstr "Rutin"
 
-#: src/pages/Shell.tsx:2377
+#: src/pages/Shell.tsx:2392
 msgid "Routines"
 msgstr "Rutinler"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Run now"
 msgstr "Şimdi çalıştır"
 
@@ -2049,11 +2065,11 @@ msgstr "Şimdi çalıştır"
 msgid "Running"
 msgstr "Çalışıyor"
 
-#: src/pages/Shell.tsx:2417
+#: src/pages/Shell.tsx:2432
 msgid "Running · Stop"
 msgstr "Çalışıyor · Durdur"
 
-#: src/pages/Shell.tsx:2662
+#: src/pages/Shell.tsx:2677
 msgid "Running…"
 msgstr "Çalışıyor…"
 
@@ -2061,8 +2077,8 @@ msgstr "Çalışıyor…"
 #: src/components/teach/TeachComputerSection.tsx:183
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:675
-#: src/pages/Shell.tsx:2638
-#: src/pages/Shell.tsx:4635
+#: src/pages/Shell.tsx:2653
+#: src/pages/Shell.tsx:4664
 msgid "Save"
 msgstr "Kaydet"
 
@@ -2086,7 +2102,7 @@ msgstr "Kaydedildi."
 #: src/components/teach/SkillDraftCard.tsx:162
 #: src/pages/GroupPanel.tsx:224
 #: src/pages/ModelSettingsOverlay.tsx:673
-#: src/pages/Shell.tsx:2638
+#: src/pages/Shell.tsx:2653
 msgid "Saving…"
 msgstr "Kaydediliyor…"
 
@@ -2127,11 +2143,11 @@ msgstr "Sağlayıcı ve model ara"
 msgid "Searching…"
 msgstr "Aranıyor…"
 
-#: src/pages/Shell.tsx:2121
+#: src/pages/Shell.tsx:2136
 msgid "Select a bot"
 msgstr "Bir bot seç"
 
-#: src/pages/Shell.tsx:3568
+#: src/pages/Shell.tsx:3597
 msgid "Send"
 msgstr "Gönder"
 
@@ -2159,22 +2175,22 @@ msgstr "Sunucu adı"
 msgid "Server URL"
 msgstr "Sunucu URL'si"
 
-#: src/pages/Shell.tsx:2130
+#: src/pages/Shell.tsx:2145
 msgid "Set up voice to call"
 msgstr "Arama için sesi ayarla"
 
-#: src/pages/AccountSettingsOverlay.tsx:79
-#: src/pages/Shell.tsx:1995
+#: src/pages/AccountSettingsOverlay.tsx:100
 #: src/pages/Shell.tsx:2005
-#: src/pages/Shell.tsx:2267
+#: src/pages/Shell.tsx:2015
+#: src/pages/Shell.tsx:2282
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/pages/Shell.tsx:3586
+#: src/pages/Shell.tsx:3615
 msgid "Settings: General"
 msgstr "Ayarlar: Genel"
 
-#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3617
 msgid "Settings: Usage"
 msgstr "Ayarlar: Kullanım"
 
@@ -2184,15 +2200,15 @@ msgid "Setup help"
 msgstr "Kurulum yardımı"
 
 #: src/pages/MemorySettingsOverlay.tsx:39
-#: src/pages/Shell.tsx:4554
+#: src/pages/Shell.tsx:4583
 msgid "Shared"
 msgstr "Ortak"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show computer"
 msgstr "Bilgisayarı göster"
 
-#: src/pages/Shell.tsx:2278
+#: src/pages/Shell.tsx:2293
 msgid "Show settings"
 msgstr "Ayarları göster"
 
@@ -2216,11 +2232,11 @@ msgid "Sign up"
 msgstr "Kaydol"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:3399
+#: src/pages/Shell.tsx:3428
 msgid "Skill {0}"
 msgstr "Beceri: {0}"
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3774
 msgid "Skip"
 msgstr "Atla"
 
@@ -2241,8 +2257,8 @@ msgstr "{0} atlandı"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Boşluk keser · Esc aramayı sonlandırır"
 
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Speak"
 msgstr "Seslendir"
 
@@ -2254,8 +2270,8 @@ msgstr "Seslendir + yazıya dök"
 msgid "Speak only"
 msgstr "Yalnızca seslendir"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Speak this reply"
 msgstr "Bu yanıtı seslendir"
 
@@ -2281,20 +2297,20 @@ msgstr "Başlatılıyor…"
 msgid "Steps"
 msgstr "Adımlar"
 
-#: src/pages/Shell.tsx:2918
-#: src/pages/Shell.tsx:2922
-#: src/pages/Shell.tsx:3559
-#: src/pages/Shell.tsx:3894
-#: src/pages/Shell.tsx:4147
+#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2947
+#: src/pages/Shell.tsx:3588
+#: src/pages/Shell.tsx:3923
+#: src/pages/Shell.tsx:4176
 msgid "Stop"
 msgstr "Durdur"
 
-#: src/pages/Shell.tsx:3451
+#: src/pages/Shell.tsx:3480
 msgid "Stop dictation"
 msgstr "Dikteyi durdur"
 
-#: src/pages/Shell.tsx:3890
-#: src/pages/Shell.tsx:4143
+#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:4172
 msgid "Stop speaking"
 msgstr "Seslendirmeyi durdur"
 
@@ -2303,8 +2319,8 @@ msgstr "Seslendirmeyi durdur"
 msgid "Stop teaching"
 msgstr "Öğretmeyi durdur"
 
-#: src/pages/Shell.tsx:2357
-#: src/pages/Shell.tsx:2938
+#: src/pages/Shell.tsx:2372
+#: src/pages/Shell.tsx:2963
 msgid "Stop the bot first"
 msgstr "Önce botu durdur"
 
@@ -2312,7 +2328,7 @@ msgstr "Önce botu durdur"
 msgid "Stored encrypted"
 msgstr "Şifreli saklanıyor"
 
-#: src/pages/Shell.tsx:4001
+#: src/pages/Shell.tsx:4030
 msgid "subagent"
 msgstr "alt ajan"
 
@@ -2325,8 +2341,8 @@ msgstr "Gönder"
 msgid "Switching…"
 msgstr "Geçiliyor…"
 
-#: src/pages/Shell.tsx:2360
-#: src/pages/Shell.tsx:2943
+#: src/pages/Shell.tsx:2375
+#: src/pages/Shell.tsx:2968
 msgid "Take control"
 msgstr "Kontrolü al"
 
@@ -2334,7 +2350,7 @@ msgstr "Kontrolü al"
 msgid "Teach a task"
 msgstr "Görev öğret"
 
-#: src/pages/Shell.tsx:2193
+#: src/pages/Shell.tsx:2208
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Öğretme sürüyor — yeni mesaj göndermeden önce öğretmeyi durdur."
 
@@ -2342,11 +2358,11 @@ msgstr "Öğretme sürüyor — yeni mesaj göndermeden önce öğretmeyi durdur
 msgid "Teaching needs a graphical sandbox computer. Desktop-host bots can run shell tasks, but not screen recording."
 msgstr "Öğretme, grafik arayüzlü bir sandbox bilgisayarı gerektirir. Masaüstünde çalışan botlar kabuk görevleri çalıştırabilir ama ekran kaydı yapamaz."
 
-#: src/pages/Shell.tsx:4238
+#: src/pages/Shell.tsx:4267
 msgid "Team"
 msgstr "Takım"
 
-#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5110
 msgid "Team Computer"
 msgstr "Takım Bilgisayarı"
 
@@ -2359,20 +2375,20 @@ msgstr "Dene"
 msgid "The selected memory provider is not available in this build."
 msgstr "Seçilen hafıza sağlayıcısı bu sürümde kullanılamıyor."
 
-#: src/pages/Shell.tsx:4531
+#: src/pages/Shell.tsx:4560
 msgid "Thinking"
 msgstr "Düşünüyor"
 
-#: src/pages/Shell.tsx:2304
+#: src/pages/Shell.tsx:2319
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Bu bot bir Linux masaüstünde değil, bu bilgisayarda çalışır. Kabuk ve dosyalar senin kullanıcı klasörünü kullanır."
 
-#: src/pages/Shell.tsx:2967
+#: src/pages/Shell.tsx:2992
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Bu bot bu bilgisayarda çalışır. Ayrı bir Linux masaüstü yoktur. Kabuğu kullanmasını isteyebilirsin; kullanıcı klasörünün altındaki çalışma dizinlerine izin verilir."
 
-#: src/pages/Shell.tsx:4931
-#: src/pages/Shell.tsx:5008
+#: src/pages/Shell.tsx:4960
+#: src/pages/Shell.tsx:5037
 msgid "This cannot be undone."
 msgstr "Bu işlem geri alınamaz."
 
@@ -2396,7 +2412,7 @@ msgstr "bu Mac"
 msgid "This Mac runs shell commands with your account, including files in your home folder. Do not turn it on for a shared or public server."
 msgstr "Bu Mac kabuk komutlarını senin hesabınla çalıştırır; kullanıcı klasöründeki dosyalar buna dahildir. Ortak veya herkese açık bir sunucuda etkinleştirme."
 
-#: src/pages/Shell.tsx:4816
+#: src/pages/Shell.tsx:4845
 msgid "This permanently removes every message and stops current work. The bot, computer, memory, and routines are kept."
 msgstr "Bu, tüm mesajları kalıcı olarak siler ve mevcut çalışmayı durdurur. Bot, bilgisayar, hafıza ve rutinler korunur."
 
@@ -2404,7 +2420,7 @@ msgstr "Bu, tüm mesajları kalıcı olarak siler ve mevcut çalışmayı durdur
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bu sağlayıcı için buraya anahtar yapıştırılamaz. Bu dağıtımda kimlik bilgileri zaten varsa atla."
 
-#: src/pages/Shell.tsx:5348
+#: src/pages/Shell.tsx:5377
 msgid "This server cannot be assigned without a bot."
 msgstr "Bu sunucu bir bot olmadan atanamaz."
 
@@ -2416,7 +2432,7 @@ msgstr "Bu sunucu tarayıcı yetkilendirmesi istemedi."
 msgid "This server is already connected. Disconnect it first to authorize again."
 msgstr "Bu sunucu zaten bağlı. Yeniden yetkilendirmek için önce bağlantısını kes."
 
-#: src/pages/Shell.tsx:5387
+#: src/pages/Shell.tsx:5416
 msgid "This server uses browser sign-in. Authorize it to let your agents use its tools — a popup will open."
 msgstr "Bu sunucu tarayıcıyla oturum açar. Agent'larının araçlarını kullanabilmesi için yetkilendir — bir açılır pencere açılacak."
 
@@ -2429,8 +2445,8 @@ msgid "Time of day"
 msgstr "Günün saati"
 
 #: src/pages/Onboarding.tsx:522
-#: src/pages/Shell.tsx:4305
-#: src/pages/Shell.tsx:4472
+#: src/pages/Shell.tsx:4334
+#: src/pages/Shell.tsx:4501
 msgid "Title"
 msgstr "Başlık"
 
@@ -2467,8 +2483,8 @@ msgstr ""
 msgid "Updating…"
 msgstr ""
 
-#: src/pages/AccountSettingsOverlay.tsx:117
-#: src/pages/Shell.tsx:2056
+#: src/pages/AccountSettingsOverlay.tsx:176
+#: src/pages/Shell.tsx:2066
 msgid "Usage"
 msgstr "Kullanım"
 
@@ -2493,8 +2509,8 @@ msgstr "Doğrula ve ekle"
 msgid "Verifying…"
 msgstr "Doğrulanıyor…"
 
-#: src/pages/Shell.tsx:2044
-#: src/pages/Shell.tsx:4584
+#: src/pages/Shell.tsx:2054
+#: src/pages/Shell.tsx:4613
 #: src/pages/VoiceSettingsOverlay.tsx:124
 #: src/pages/VoiceSettingsOverlay.tsx:264
 msgid "Voice"
@@ -2507,7 +2523,7 @@ msgstr "Ses"
 msgid "Waiting for sign-in…"
 msgstr "Oturum açma bekleniyor…"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5260
 msgid "Waiting…"
 msgstr "Bekleniyor…"
 
@@ -2516,7 +2532,7 @@ msgstr "Bekleniyor…"
 msgid "Weekdays"
 msgstr "Hafta içi"
 
-#: src/pages/Shell.tsx:4901
+#: src/pages/Shell.tsx:4930
 msgid "What about its memories?"
 msgstr "Hafızası ne olsun?"
 
@@ -2525,7 +2541,7 @@ msgid "What result will you demonstrate?"
 msgstr "Hangi sonucu göstereceksin?"
 
 #: src/pages/Onboarding.tsx:535
-#: src/pages/Shell.tsx:4320
+#: src/pages/Shell.tsx:4349
 msgid "What this bot is for"
 msgstr "Bu botun amacı"
 
@@ -2537,7 +2553,7 @@ msgstr "Ne döndürülecek"
 msgid "When {botName} messages another bot, the exchange shows up here instead of in the chat."
 msgstr "{botName} başka bir bota mesaj gönderdiğinde yazışma sohbet yerine burada görünür."
 
-#: src/pages/Shell.tsx:2563
+#: src/pages/Shell.tsx:2578
 msgid "When to run"
 msgstr "Ne zaman çalışacak"
 
@@ -2554,7 +2570,7 @@ msgstr "Botlar nerede çalışsın?"
 msgid "Working…"
 msgstr "Çalışıyor…"
 
-#: src/pages/Shell.tsx:4514
+#: src/pages/Shell.tsx:4543
 msgid "Workspace default"
 msgstr "Çalışma alanı varsayılanı"
 
@@ -2571,8 +2587,8 @@ msgstr "Otomatik yönlendirilmezsen bu sekmeyi kapatabilirsin."
 msgid "You can close this window."
 msgstr "Bu pencereyi kapatabilirsin."
 
-#: src/pages/Shell.tsx:2337
-#: src/pages/Shell.tsx:2908
+#: src/pages/Shell.tsx:2352
+#: src/pages/Shell.tsx:2933
 msgid "You have control"
 msgstr "Kontrol sende"
 

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -418,7 +418,7 @@ msgstr "Yetkilendir"
 
 #: src/pages/AccountSettingsOverlay.tsx:133
 msgid "Avatars"
-msgstr "Avatarlar"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:48
 msgid "Base URL"
@@ -953,10 +953,6 @@ msgstr "Güncellenemedi"
 msgid "Could not update agent access"
 msgstr "Agent erişimi güncellenemedi"
 
-#: src/pages/AccountSettingsOverlay.tsx:80
-msgid "Could not update avatar style"
-msgstr "Avatar stili güncellenemedi"
-
 #: src/components/ComputerMaintenanceActions.tsx:46
 msgid "Could not update computer"
 msgstr ""
@@ -964,6 +960,10 @@ msgstr ""
 #: src/pages/MemorySettingsOverlay.tsx:122
 msgid "Could not update the default memory scope"
 msgstr "Varsayılan hafıza kapsamı güncellenemedi"
+
+#: src/pages/AccountSettingsOverlay.tsx:80
+msgid "Couldn't update avatars"
+msgstr ""
 
 #: src/pages/Shell.tsx:1761
 #: src/pages/Shell.tsx:4361
@@ -1832,7 +1832,7 @@ msgstr "Veya bir API anahtarı yapıştır"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Organic"
-msgstr "Organik"
+msgstr ""
 
 #: src/pages/memory-providers/SupermemorySettingsForm.tsx:60
 msgid "Organization API key"
@@ -2045,7 +2045,7 @@ msgstr "Rakazo'ya dön"
 
 #: src/pages/AccountSettingsOverlay.tsx:157
 msgid "Robot"
-msgstr "Robot"
+msgstr ""
 
 #: src/pages/Shell.tsx:2554
 #: src/pages/Shell.tsx:2607

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -76,8 +76,8 @@ export function AccountSettingsOverlay({
     setAvatarError(null);
     try {
       await onAvatarStyleChange(next);
-    } catch (error) {
-      setAvatarError(error instanceof Error ? error.message : t`Could not update avatar style`);
+    } catch {
+      setAvatarError(t`Couldn't update avatars`);
     } finally {
       setAvatarPending(false);
     }

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -1,4 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import type { AvatarStyle } from "@rakazo/contracts";
+import { BotAvatar } from "@rakazo/ui-web";
 import { ChevronDown } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
@@ -16,12 +18,16 @@ export function AccountSettingsOverlay({
   name,
   usage,
   focusUsage,
+  avatarStyle,
+  onAvatarStyleChange,
   onClose,
 }: {
   email?: string | null;
   name: string;
   usage?: { runs: number; inputTokens: number; outputTokens: number } | null;
   focusUsage?: boolean;
+  avatarStyle: AvatarStyle;
+  onAvatarStyleChange: (style: AvatarStyle) => Promise<void>;
   onClose: () => void;
 }) {
   const { t } = useLingui();
@@ -31,6 +37,8 @@ export function AccountSettingsOverlay({
   onCloseRef.current = onClose;
   const [locale, setLocale] = useState<UiLocale>(() => getActiveUiLocale());
   const localeRequestRef = useRef(0);
+  const [avatarPending, setAvatarPending] = useState(false);
+  const [avatarError, setAvatarError] = useState<string | null>(null);
 
   useEffect(() => {
     const previousFocus =
@@ -60,6 +68,19 @@ export function AccountSettingsOverlay({
       if (requestId !== localeRequestRef.current) return;
       setLocale(activated);
     });
+  }
+
+  async function chooseAvatarStyle(next: AvatarStyle) {
+    if (avatarPending || next === avatarStyle) return;
+    setAvatarPending(true);
+    setAvatarError(null);
+    try {
+      await onAvatarStyleChange(next);
+    } catch (error) {
+      setAvatarError(error instanceof Error ? error.message : t`Could not update avatar style`);
+    } finally {
+      setAvatarPending(false);
+    }
   }
 
   return (
@@ -105,6 +126,44 @@ export function AccountSettingsOverlay({
             <Trans>Language</Trans>
           </h3>
           <UiLocalePicker value={locale} onChange={chooseLocale} />
+        </section>
+
+        <section className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4">
+          <h3 className="text-[15px] font-medium text-[#ECECEE]">
+            <Trans>Avatars</Trans>
+          </h3>
+          <div className="mt-3 grid grid-cols-2 gap-3">
+            {(["robot", "organic"] as const).map((style) => {
+              const selected = style === avatarStyle;
+              return (
+                <button
+                  key={style}
+                  type="button"
+                  aria-pressed={selected}
+                  disabled={avatarPending}
+                  onClick={() => void chooseAvatarStyle(style)}
+                  className={`flex items-center gap-3 rounded-[12px] border px-3.5 py-3 text-start text-[14px] text-[#ECECEE] transition-colors disabled:opacity-50 ${
+                    selected
+                      ? "border-[#5A5A62] bg-[#1A1A1D]"
+                      : "border-[#26262A] hover:border-[#3A3A40]"
+                  }`}
+                >
+                  <BotAvatar
+                    color="#D9508A"
+                    identity="avatar-style-preview"
+                    size={32}
+                    variant={style}
+                  />
+                  <span>{style === "robot" ? <Trans>Robot</Trans> : <Trans>Organic</Trans>}</span>
+                </button>
+              );
+            })}
+          </div>
+          {avatarError ? (
+            <p role="alert" className="mt-3 text-[12.5px] text-[#F1A8A8]">
+              {avatarError}
+            </p>
+          ) : null}
         </section>
 
         <div

--- a/apps/web/src/pages/GroupPanel.tsx
+++ b/apps/web/src/pages/GroupPanel.tsx
@@ -51,7 +51,7 @@ function MemberPicker({
               checked ? "bg-[#1A1A1D]" : "hover:bg-[#141416]"
             }`}
           >
-            <BotAvatar color={bot.color} size={32} status={bot.status} />
+            <BotAvatar color={bot.color} identity={bot.id} size={32} status={bot.status} />
             <span className="flex-1 text-[15px] text-[#ECECEE]" dir="auto">
               {bot.name}
             </span>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -58,7 +58,7 @@ import {
   speechFromBlocks,
   truncateSlashDescription,
 } from "@rakazo/core";
-import { BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
+import { AvatarStyleProvider, BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
 import {
   ArrowUp,
   Bell,
@@ -1711,7 +1711,7 @@ export function ShellPage() {
     .slice(0, 2)
     .toUpperCase();
 
-  return (
+  const shell = (
     <div
       data-testid="shell-root"
       data-ready={shellReady}
@@ -1842,7 +1842,12 @@ export function ShellPage() {
                         background: !inGroup && active?.id === bot.id ? "#161618" : "transparent",
                       }}
                     >
-                      <BotAvatar color={bot.color} size={38} status={bot.status} />
+                      <BotAvatar
+                        color={bot.color}
+                        identity={bot.id}
+                        size={38}
+                        status={bot.status}
+                      />
                       <div className="min-w-0 flex-1">
                         <div className="flex items-baseline justify-between gap-2">
                           <span
@@ -1945,7 +1950,12 @@ export function ShellPage() {
               {archivedOpen
                 ? archivedBots.map((bot) => (
                     <div key={bot.id} className="flex items-center gap-2 rounded-lg px-2.5 py-2">
-                      <BotAvatar color={bot.color} size={28} status={bot.status} />
+                      <BotAvatar
+                        color={bot.color}
+                        identity={bot.id}
+                        size={28}
+                        status={bot.status}
+                      />
                       <span
                         className="min-w-0 flex-1 truncate text-[14px] text-[#A8A8AD]"
                         dir="auto"
@@ -2112,7 +2122,12 @@ export function ShellPage() {
                   size={26}
                 />
               ) : active ? (
-                <BotAvatar color={active.color} size={26} status={active.status} />
+                <BotAvatar
+                  color={active.color}
+                  identity={active.id}
+                  size={26}
+                  status={active.status}
+                />
               ) : null}
               <span className="min-w-0">
                 <span className="block truncate text-[16px] font-medium text-[#ECECEE]" dir="auto">
@@ -2819,6 +2834,11 @@ export function ShellPage() {
             email={session.data?.user.email}
             usage={usage}
             focusUsage={accountSettingsFocusUsage}
+            avatarStyle={bootstrapMe?.avatarStyle ?? "robot"}
+            onAvatarStyleChange={async (avatarStyle) => {
+              const nextMe = await rpc.preferences.update({ avatarStyle });
+              setBootstrapMe(nextMe);
+            }}
             onClose={() => {
               setAccountSettingsOpen(false);
               setAccountSettingsFocusUsage(false);
@@ -2890,7 +2910,12 @@ export function ShellPage() {
         <div className="absolute inset-0 z-30 flex flex-col bg-[#050506]">
           <div className="flex items-center justify-between gap-4 border-b border-[#171719] px-[18px] py-3.5">
             <div className="flex min-w-0 flex-1 items-center gap-3">
-              <BotAvatar color={active.color} size={28} status={active.status} />
+              <BotAvatar
+                color={active.color}
+                identity={active.id}
+                size={28}
+                status={active.status}
+              />
               {recordingSkill ? (
                 <TeachRecordingChrome
                   recording={recordingSkill}
@@ -3002,6 +3027,10 @@ export function ShellPage() {
         </div>
       ) : null}
     </div>
+  );
+
+  return (
+    <AvatarStyleProvider value={bootstrapMe?.avatarStyle ?? "robot"}>{shell}</AvatarStyleProvider>
   );
 }
 
@@ -3610,7 +3639,7 @@ function MentionOptionIcon({ mention }: { mention: ComposerMention }) {
       </span>
     );
   }
-  return <BotAvatar color={mention.color ?? "#85858A"} size={16} />;
+  return <BotAvatar color={mention.color ?? "#85858A"} identity={mention.id} size={16} />;
 }
 
 function MentionChipIcon({ mention }: { mention: ComposerMention }) {
@@ -3627,7 +3656,7 @@ function MentionChipIcon({ mention }: { mention: ComposerMention }) {
       </span>
     );
   }
-  return <BotAvatar color={mention.color ?? "#85858A"} size={16} />;
+  return <BotAvatar color={mention.color ?? "#85858A"} identity={mention.id} size={16} />;
 }
 
 function previewMessageText(message: ThreadMessage): string {
@@ -4457,7 +4486,7 @@ function BotSettings({
   return (
     <div data-testid="bot-settings">
       <div className="flex justify-center">
-        <BotAvatar color={bot.color} size={64} status={bot.status} />
+        <BotAvatar color={bot.color} identity={bot.id} size={64} status={bot.status} />
       </div>
       <label className="mt-6 block text-[14px] text-[#85858A]">
         <Trans>Name</Trans>

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -9,6 +9,9 @@ export type ComputerMode = z.infer<typeof ComputerModeSchema>;
 export const MemoryScopeSchema = z.enum(["isolated", "shared"]);
 export type MemoryScopeValue = z.infer<typeof MemoryScopeSchema>;
 
+export const AvatarStyleSchema = z.enum(["robot", "organic"]);
+export type AvatarStyle = z.infer<typeof AvatarStyleSchema>;
+
 export const ThinkingLevelSchema = z.enum([
   "off",
   "minimal",
@@ -792,6 +795,7 @@ export const MeSchema = z.object({
   defaultModel: z.string().nullable(),
   computerHost: z.enum(["docker", "this-mac"]).nullable(),
   canChooseHostComputer: z.boolean(),
+  avatarStyle: AvatarStyleSchema,
 });
 export type Me = z.infer<typeof MeSchema>;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -8,6 +8,7 @@ import {
   AppBootstrapSchema,
   ArtifactSchema,
   ArtifactWithContentSchema,
+  AvatarStyleSchema,
   BotMcpServerSchema,
   BotSchema,
   BotSectionSchema,
@@ -112,6 +113,9 @@ const threadSendInput = threadTarget
 export const appContract = {
   health: oc.output(z.object({ ok: z.literal(true), version: z.string() })),
   me: oc.output(MeSchema),
+  preferences: {
+    update: oc.input(z.object({ avatarStyle: AvatarStyleSchema })).output(MeSchema),
+  },
   bootstrap: oc.input(z.object({ botId: Id.optional() })).output(AppBootstrapSchema),
   deployment: {
     get: oc.output(DeploymentSettingsSchema),

--- a/packages/core/src/avatar-shape.test.ts
+++ b/packages/core/src/avatar-shape.test.ts
@@ -7,4 +7,10 @@ describe("organic avatar geometry", () => {
     expect(first).toBe(organicAvatarPath(avatarIdentitySeed("research")));
     expect(first).not.toBe(organicAvatarPath(avatarIdentitySeed("health")));
   });
+
+  it("emits only path geometry from a numeric seed", () => {
+    const path = organicAvatarPath(42);
+    expect(path).toMatch(/^M[-0-9. ]+(?:C[-0-9. ]+)+Z$/);
+    expect(path).not.toMatch(/<|>|javascript:|url\(/i);
+  });
 });

--- a/packages/core/src/avatar-shape.test.ts
+++ b/packages/core/src/avatar-shape.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { avatarIdentitySeed, organicAvatarPath } from "./avatar-shape.js";
+
+describe("organic avatar geometry", () => {
+  it("is stable for an identity and changes across identities", () => {
+    const first = organicAvatarPath(avatarIdentitySeed("research"));
+    expect(first).toBe(organicAvatarPath(avatarIdentitySeed("research")));
+    expect(first).not.toBe(organicAvatarPath(avatarIdentitySeed("health")));
+  });
+});

--- a/packages/core/src/avatar-shape.ts
+++ b/packages/core/src/avatar-shape.ts
@@ -1,0 +1,36 @@
+export function avatarIdentitySeed(identity: string): number {
+  let hash = 0;
+  for (let index = 0; index < identity.length; index++) {
+    hash = (hash << 5) - hash + identity.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+export function organicAvatarPath(seed: number, phaseOffset = 0): string {
+  const pointCount = 12;
+  const phase = ((seed % 360) * Math.PI) / 180 + phaseOffset;
+  const family = (seed + 1) % 4;
+  const lobes = [2, 3, 4, 5][family] ?? 4;
+  const amplitude = [0.045, 0.14, 0.09, 0.025][family] ?? 0.09;
+  const points = Array.from({ length: pointCount }, (_, index) => {
+    const angle = (index / pointCount) * Math.PI * 2;
+    const radius =
+      50 * (1 + amplitude * Math.sin(angle * lobes + phase) + 0.025 * Math.sin(angle * 2 - phase));
+    return {
+      x: Math.cos(angle) * radius * 1.08,
+      y: Math.sin(angle) * radius * 0.82,
+    };
+  });
+  const round = (value: number) => Math.round(value * 100) / 100;
+  const first = points[0]!;
+  let path = `M${round(first.x)} ${round(first.y)}`;
+  for (let index = 0; index < pointCount; index++) {
+    const before = points[(index - 1 + pointCount) % pointCount]!;
+    const current = points[index]!;
+    const next = points[(index + 1) % pointCount]!;
+    const after = points[(index + 2) % pointCount]!;
+    path += `C${round(current.x + (next.x - before.x) / 6)} ${round(current.y + (next.y - before.y) / 6)} ${round(next.x - (after.x - current.x) / 6)} ${round(next.y - (after.y - current.y) / 6)} ${round(next.x)} ${round(next.y)}`;
+  }
+  return `${path}Z`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./agent-skill.js";
 export * from "./answerable-ask.js";
 export * from "./async.js";
 export * from "./attachments.js";
+export * from "./avatar-shape.js";
 export * from "./bot-messages.js";
 export * from "./bot-sections.js";
 export * from "./compose-update.js";

--- a/packages/db/prisma/migrations/20260827140000_add_avatar_style/migration.sql
+++ b/packages/db/prisma/migrations/20260827140000_add_avatar_style/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "avatarStyle" TEXT NOT NULL DEFAULT 'robot';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   image         String?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
+  avatarStyle   String    @default("robot")
   sessions      Session[]
   accounts      Account[]
   members       Member[]

--- a/packages/ui-web/src/avatar-style.tsx
+++ b/packages/ui-web/src/avatar-style.tsx
@@ -1,0 +1,19 @@
+import { createContext, type ReactNode, useContext } from "react";
+
+export type AvatarStyle = "robot" | "organic";
+
+const AvatarStyleContext = createContext<AvatarStyle>("robot");
+
+export function AvatarStyleProvider({
+  children,
+  value,
+}: {
+  children: ReactNode;
+  value: AvatarStyle;
+}) {
+  return <AvatarStyleContext value={value}>{children}</AvatarStyleContext>;
+}
+
+export function useAvatarStyle(): AvatarStyle {
+  return useContext(AvatarStyleContext);
+}

--- a/packages/ui-web/src/bot-avatar.test.tsx
+++ b/packages/ui-web/src/bot-avatar.test.tsx
@@ -1,5 +1,6 @@
 import { renderToString } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import { AvatarStyleProvider } from "./avatar-style.js";
 import { BotAvatar } from "./bot-avatar.js";
 
 describe("BotAvatar", () => {
@@ -33,5 +34,35 @@ describe("BotAvatar", () => {
   it("renders idle avatar without working ring when idle", () => {
     const html = renderToString(<BotAvatar color="#F59E0B" status="idle" />);
     expect(html).not.toContain("<svg");
+  });
+
+  it("generates an organic avatar from the bot color", () => {
+    const html = renderToString(
+      <BotAvatar color="#D9508A" identity="maya" size={28} status="running" variant="organic" />,
+    );
+
+    expect(html).toContain("rakazo-organic-avatar");
+    expect(html).toContain('data-working="true"');
+    expect(html).toContain("<animate");
+    expect(html).not.toContain("rakazo-bot-avatar-visor");
+  });
+
+  it("generates distinct organic silhouettes for distinct bot identities", () => {
+    const maya = renderToString(<BotAvatar color="#D9508A" identity="maya" variant="organic" />);
+    const github = renderToString(
+      <BotAvatar color="#D9508A" identity="github" variant="organic" />,
+    );
+
+    expect(maya).not.toEqual(github);
+  });
+
+  it("uses the account avatar preference when no local variant is provided", () => {
+    const html = renderToString(
+      <AvatarStyleProvider value="organic">
+        <BotAvatar color="#D9508A" identity="maya" />
+      </AvatarStyleProvider>,
+    );
+
+    expect(html).toContain("rakazo-organic-avatar");
   });
 });

--- a/packages/ui-web/src/bot-avatar.tsx
+++ b/packages/ui-web/src/bot-avatar.tsx
@@ -1,5 +1,6 @@
-import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
+import { ACTIVE_RUN_STATUSES, avatarIdentitySeed, organicAvatarPath } from "@rakazo/core";
 import { type CSSProperties, memo, useId } from "react";
+import { type AvatarStyle, useAvatarStyle } from "./avatar-style.js";
 import { cn } from "./lib/utils.js";
 import "./styles.css";
 
@@ -7,6 +8,8 @@ export interface BotAvatarProps {
   color: string;
   size?: number;
   status?: string;
+  variant?: AvatarStyle;
+  identity?: string;
   className?: string;
 }
 
@@ -14,9 +17,24 @@ export const BotAvatar = memo(function BotAvatar({
   color,
   size = 38,
   status,
+  variant,
+  identity,
   className,
 }: BotAvatarProps) {
   const isWorking = ACTIVE_RUN_STATUSES.some((activeStatus) => activeStatus === status);
+  const gradId = `spin-grad-${useId().replace(/[^a-zA-Z0-9-_]/g, "")}`;
+  const preferredVariant = useAvatarStyle();
+  if ((variant ?? preferredVariant) === "organic") {
+    return (
+      <OrganicAvatar
+        color={color}
+        identity={identity}
+        size={size}
+        isWorking={isWorking}
+        className={className}
+      />
+    );
+  }
   const visorW = Math.round(size * 0.68);
   const visorH = Math.round(size * 0.44);
   const eyeW = Math.max(4, Math.round(size * 0.14));
@@ -25,15 +43,14 @@ export const BotAvatar = memo(function BotAvatar({
   const eyeGap = Math.max(3, Math.round(size * 0.1));
 
   const seed = hashString(color || "#8B5CF6");
-  const variant = seed % 4;
+  const eyeVariant = seed % 4;
   const idleDuration = (4.2 + ((seed * 7) % 28) / 10).toFixed(2);
   const idleDelay = (-(((seed * 13) % 45) / 10)).toFixed(2);
-  const gradId = `spin-grad-${useId().replace(/[^a-zA-Z0-9-_]/g, "")}`;
   const eyeGlow = `0 0 4px #FFFFFF, 0 0 8px #FFFFFF, 0 0 14px ${lightenColor(color, 20)}`;
   const eyeAnimation = {
     "--rakazo-eye-animation-name": isWorking
       ? "rakazo-eyes-working"
-      : `rakazo-eyes-idle-${variant}`,
+      : `rakazo-eyes-idle-${eyeVariant}`,
     "--rakazo-eye-animation-duration": isWorking ? "1.4s" : `${idleDuration}s`,
     "--rakazo-eye-animation-easing": isWorking ? "ease-in-out" : "cubic-bezier(0.4, 0, 0.2, 1)",
     "--rakazo-eye-animation-delay": isWorking ? "0s" : `${idleDelay}s`,
@@ -132,6 +149,68 @@ export const BotAvatar = memo(function BotAvatar({
     </div>
   );
 });
+
+function OrganicAvatar({
+  color,
+  identity,
+  size,
+  isWorking,
+  className,
+}: {
+  color: string;
+  identity?: string;
+  size: number;
+  isWorking: boolean;
+  className?: string;
+}) {
+  const seed = avatarIdentitySeed(identity || color || "#8B5CF6");
+  const shapeStyle = {
+    "--rakazo-organic-duration": `${4.8 + (seed % 24) / 10}s`,
+  } as CSSProperties;
+  const shapeA = organicAvatarPath(seed);
+  const shapeB = organicAvatarPath(seed, 0.42);
+
+  return (
+    <svg
+      viewBox="-60 -60 120 120"
+      aria-hidden="true"
+      className={cn("rakazo-organic-avatar overflow-visible select-none", className)}
+      data-working={isWorking}
+      style={{
+        ...shapeStyle,
+        width: size,
+        height: size,
+        flex: "none",
+      }}
+    >
+      <path
+        className="rakazo-organic-avatar-body"
+        d={shapeA}
+        fill={color}
+        style={{
+          filter: isWorking
+            ? `drop-shadow(0 0 ${Math.round(size * 0.16)}px ${color})`
+            : "drop-shadow(0 2px 3px rgba(0,0,0,.34))",
+        }}
+      >
+        <animate
+          attributeName="d"
+          values={`${shapeA};${shapeB};${shapeA}`}
+          dur={isWorking ? "1.35s" : `${4.8 + (seed % 24) / 10}s`}
+          repeatCount="indefinite"
+        />
+      </path>
+      <g
+        className="rakazo-organic-avatar-eyes"
+        transform={`rotate(${(seed % 9) - 4})`}
+        fill="#101014"
+      >
+        <rect x="-14" y="-12" width="7" height="24" rx="3.5" />
+        <rect x="7" y="-12" width="7" height="24" rx="3.5" />
+      </g>
+    </svg>
+  );
+}
 
 function hashString(str: string): number {
   let hash = 0;

--- a/packages/ui-web/src/group-avatar.tsx
+++ b/packages/ui-web/src/group-avatar.tsx
@@ -54,6 +54,7 @@ export const GroupAvatar = memo(function GroupAvatar({
     return (
       <BotAvatar
         color={firstMember.color}
+        identity={firstMember.botId ?? firstMember.name}
         size={size}
         status={firstMember.status}
         className={cn("rakazo-group-avatar", className)}
@@ -90,7 +91,12 @@ export const GroupAvatar = memo(function GroupAvatar({
             boxShadow: "0 0 0 1.5px #121215",
           }}
         >
-          <BotAvatar color={member.color} size={miniSize} status={member.status} />
+          <BotAvatar
+            color={member.color}
+            identity={member.botId ?? member.name}
+            size={miniSize}
+            status={member.status}
+          />
         </div>
       ))}
       {members.length > 3 ? (

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -1,3 +1,4 @@
+export { type AvatarStyle, AvatarStyleProvider, useAvatarStyle } from "./avatar-style.js";
 export { BotAvatar, Wordmark } from "./bot-avatar.js";
 export { Button, buttonVariants } from "./button.js";
 export { GroupAvatar, type GroupAvatarMember, type GroupAvatarProps } from "./group-avatar.js";

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -20,6 +20,24 @@
     var(--rakazo-eye-animation-easing) var(--rakazo-eye-animation-delay) infinite;
 }
 
+.rakazo-organic-avatar-body {
+  transform-origin: center;
+}
+
+.rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-organic-eyes 1.35s ease-in-out infinite;
+}
+
+@keyframes rakazo-organic-eyes {
+  0%,
+  100% {
+    transform: translateX(-6%);
+  }
+  50% {
+    transform: translateX(6%);
+  }
+}
+
 @keyframes rakazo-eyes-idle-0 {
   0%,
   32%,
@@ -153,6 +171,14 @@
 @media (prefers-reduced-motion: reduce) {
   .rakazo-bot-avatar-ring,
   .rakazo-bot-avatar-eyes {
+    animation: none;
+  }
+
+  .rakazo-organic-avatar-body animate {
+    display: none;
+  }
+
+  .rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-eyes {
     animation: none;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       react-native-screens:
         specifier: ~4.26.0
         version: 4.26.2(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
+      react-native-svg:
+        specifier: 15.15.4
+        version: 15.15.4(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -5132,6 +5135,10 @@ packages:
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
@@ -6980,6 +6987,9 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
@@ -7991,6 +8001,12 @@ packages:
 
   react-native-screens@4.26.2:
     resolution: {integrity: sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==}
+    peerDependencies:
+      react: 19.2.3
+      react-native: '*'
+
+  react-native-svg@15.15.4:
+    resolution: {integrity: sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A==}
     peerDependencies:
       react: 19.2.3
       react-native: '*'
@@ -14918,6 +14934,11 @@ snapshots:
       css-color-keywords: 1.0.0
       postcss-value-parser: 4.2.0
 
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
@@ -17112,6 +17133,8 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  mdn-data@2.0.14: {}
+
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
@@ -18320,6 +18343,14 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-freeze: 1.0.4(react@19.2.3)
+      react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
+      warn-once: 0.1.1
+
+  react-native-svg@15.15.4(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3)
       warn-once: 0.1.1
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes PR 310 from [@luinbytes](https://github.com/luinbytes).

## What
Account-level avatar appearance: **Robot** (current glyph) or **Organic** (stable silhouette from bot identity). Preference lives on the user, exposed on `me` and `preferences.update`, with a Prisma migration. Wired through web (Electron hosts web) and mobile. Organic paths are computed locally from a numeric seed — no Dicebear or avatar CDN.

## Cleanup on top of their work
- Keep `avatarStyle` as a contract enum (`robot` | `organic`); reject anything else at the RPC boundary; coerce unknown stored values to `robot` on `me`
- Shorten error copy to `Couldn't update avatars`; leave non-English msgstr empty (do not invent translations)
- Guard organic SVG paths so they stay numeric-seed geometry only
- Fix mobile race where a stale `me` fetch could overwrite a newer preference update
- Default remains `robot`

## Screenshots
A — Account settings Avatars picker with Robot selected:
![Account settings Avatars picker with Robot selected](https://cursor.com/artifacts/c/art-ae3d3e57-7bd9-40c3-9c5b-9a72263e5515)

B — Organic selected; sidebar/header bot avatar is the organic silhouette:
![Organic avatar style in sidebar and header](https://cursor.com/artifacts/c/art-5b75529e-c7fb-4496-bf89-c3c8d303e06a)

Do not merge until Elie has reviewed the UI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1afd330b-8e59-47f2-b8b7-c860895d55a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1afd330b-8e59-47f2-b8b7-c860895d55a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Robot and Organic avatar styles across web and mobile.
  - Added account settings controls to select and save the preferred avatar style.
  - Organic avatars now have identity-specific shapes and subtle working animations.
  - Added reduced-motion support for organic avatar animations.
  - Avatar preferences persist across sessions and default to Robot.

- **Bug Fixes**
  - Invalid or unknown avatar styles now safely fall back to Robot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->