### PR TITLE
test: isolate MCP session cache by workspace and user separately

### DIFF
--- a/packages/adapters/src/mcp-connector.test.ts
+++ b/packages/adapters/src/mcp-connector.test.ts
@@ -124,11 +124,14 @@ describe("MCP connector session cache", () => {
     await connector.discoverTools(contextFor("w1", "u1"));
     expect(state.initializations).toBe(1);
 
-    await connector.discoverTools(contextFor("w2", "u2"));
+    await connector.discoverTools(contextFor("w1", "u2"));
     expect(state.initializations).toBe(2);
 
+    await connector.discoverTools(contextFor("w2", "u1"));
+    expect(state.initializations).toBe(3);
+
     await connector.discoverTools(contextFor("w1", "u1"));
-    expect(state.initializations).toBe(2);
+    expect(state.initializations).toBe(3);
 
     await connector.close();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #296.

The session isolation test previously changed workspace and user together (`w1/u1` vs `w2/u2`). A regression that dropped either field from the session key could still pass.

This updates the test to vary each dimension independently (`w1/u2`, `w2/u1`) and assert each pair initializes a new session. Test-only; no product change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd54a798-ff41-4660-8153-6968a268470b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd54a798-ff41-4660-8153-6968a268470b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling to keep user sessions correctly separated across users and workspaces.
  * Confirmed that existing sessions are reused consistently when the same user and workspace reconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->