### PR TITLE
fix: recover past checkpoint errors and claim stopped computers

### DIFF
--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -793,6 +793,7 @@ describe("computer replacement", () => {
     expect(prisma.computer.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
+          state: "running",
           OR: expect.arrayContaining([
             { controlHolder: { not: "user" } },
             { controlLeaseId: null },
@@ -805,6 +806,10 @@ describe("computer replacement", () => {
   });
 
   it("rejects replacement of a stopped computer while a run is still active", async () => {
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 });
     const prisma = {
       computer: {
         findUniqueOrThrow: vi.fn().mockResolvedValue({
@@ -816,7 +821,7 @@ describe("computer replacement", () => {
           state: "stopped",
           controlLeaseId: null,
         }),
-        updateMany: vi.fn(),
+        updateMany,
       },
       run: {
         findFirst: vi.fn().mockResolvedValue({ id: "active-run" }),
@@ -836,10 +841,27 @@ describe("computer replacement", () => {
         context,
       ),
     ).rejects.toBeInstanceOf(ComputerBusyError);
-    expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+    expect(updateMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "computer-1", state: "stopped" }),
+        data: { state: "suspending" },
+      }),
+    );
+    expect(updateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: "computer-1", state: "suspending" },
+        data: { state: "stopped" },
+      }),
+    );
   });
 
   it("rejects replacement of a suspended computer while a run is still active", async () => {
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 });
     const prisma = {
       computer: {
         findUniqueOrThrow: vi.fn().mockResolvedValue({
@@ -851,7 +873,7 @@ describe("computer replacement", () => {
           state: "suspended",
           controlLeaseId: null,
         }),
-        updateMany: vi.fn(),
+        updateMany,
       },
       run: {
         findFirst: vi.fn().mockResolvedValue({ id: "active-run" }),
@@ -871,6 +893,231 @@ describe("computer replacement", () => {
         context,
       ),
     ).rejects.toBeInstanceOf(ComputerBusyError);
-    expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+    expect(updateMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "computer-1", state: "suspended" }),
+        data: { state: "suspending" },
+      }),
+    );
+    expect(updateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: "computer-1", state: "suspending" },
+        data: { state: "suspended" },
+      }),
+    );
+  });
+
+  it("claims a stopped computer before teardown so concurrent replacements serialize", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-replace-stopped-claim-"));
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValue({ count: 1 });
+    const update = vi.fn().mockResolvedValue({});
+    const findUniqueOrThrow = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: "computer-1",
+        homeKey: "bot-1",
+        providerRef: null,
+        kind: "fake",
+        scope: "dedicated",
+        state: "stopped",
+        controlLeaseId: null,
+      })
+      .mockResolvedValue({
+        id: "computer-1",
+        homeKey: "bot-1",
+        providerRef: null,
+        kind: "fake",
+        scope: "dedicated",
+        state: "stopped",
+        controlLeaseId: null,
+      });
+    const prisma = {
+      computer: { findUniqueOrThrow, updateMany, update },
+      run: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+    const sandbox = new FakeSandboxProvider();
+
+    try {
+      await replaceComputer(
+        {
+          prisma,
+          sandbox,
+          home: new LocalAgentHomeStore(dataDir),
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+          dataDir,
+        },
+        "computer-1",
+        "recover",
+        context,
+      );
+      expect(updateMany).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          where: expect.objectContaining({ id: "computer-1", state: "stopped" }),
+          data: { state: "suspending" },
+        }),
+      );
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a second claim on a stopped computer that is already suspending", async () => {
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: null,
+          kind: "fake",
+          scope: "dedicated",
+          state: "stopped",
+          controlLeaseId: null,
+        }),
+        updateMany: vi.fn().mockResolvedValueOnce({ count: 0 }),
+      },
+      run: { findFirst: vi.fn() },
+    } as unknown as PrismaClient;
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "reset",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+    expect(prisma.run.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("continues recover when checkpoint fails with an ordinary provider error", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-recover-checkpoint-"));
+    const homeRoot = await mkdtemp(path.join(tmpdir(), "rakazo-recover-checkpoint-home-"));
+    const home = new LocalAgentHomeStore(homeRoot);
+    const sandbox = new FakeSandboxProvider();
+    const first = await sandbox.provision({ botId: "bot-1", homePath: dataDir }, context);
+    vi.spyOn(sandbox, "exportWorkspace").mockImplementation(async function* () {
+      throw new Error("ECONNRESET");
+    });
+
+    const computerRecord = {
+      id: "computer-1",
+      homeKey: "bot-1",
+      providerRef: first.providerRef,
+      kind: "fake",
+      scope: "dedicated",
+      state: "running",
+      controlLeaseId: null,
+      homeRevision: null,
+    };
+    const findUniqueOrThrow = vi
+      .fn()
+      .mockResolvedValueOnce(computerRecord)
+      .mockResolvedValue({
+        ...computerRecord,
+        state: "stopped",
+        providerRef: null,
+      });
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const update = vi.fn().mockResolvedValue({});
+    const prisma = {
+      computer: { findUniqueOrThrow, updateMany, update },
+      run: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+    const destroy = vi.spyOn(sandbox, "destroy");
+
+    try {
+      const ref = await replaceComputer(
+        {
+          prisma,
+          sandbox,
+          home,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+          dataDir,
+        },
+        "computer-1",
+        "recover",
+        context,
+      );
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(ref.fresh).toBe(true);
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+      await rm(homeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("aborts update when checkpoint fails with an ordinary provider error", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-update-checkpoint-"));
+    const homeRoot = await mkdtemp(path.join(tmpdir(), "rakazo-update-checkpoint-home-"));
+    const home = new LocalAgentHomeStore(homeRoot);
+    const sandbox = new FakeSandboxProvider();
+    const first = await sandbox.provision({ botId: "bot-1", homePath: dataDir }, context);
+    vi.spyOn(sandbox, "exportWorkspace").mockImplementation(async function* () {
+      throw new Error("ECONNRESET");
+    });
+
+    const computerRecord = {
+      id: "computer-1",
+      homeKey: "bot-1",
+      providerRef: first.providerRef,
+      kind: "fake",
+      scope: "dedicated",
+      state: "running",
+      controlLeaseId: null,
+      homeRevision: null,
+    };
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValue({ count: 1 });
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue(computerRecord),
+        updateMany,
+        update: vi.fn(),
+      },
+      run: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+    const destroy = vi.spyOn(sandbox, "destroy");
+
+    try {
+      await expect(
+        replaceComputer(
+          {
+            prisma,
+            sandbox,
+            home,
+            jobs: {} as JobPublisher,
+            events: {} as ThreadEvents,
+            dataDir,
+          },
+          "computer-1",
+          "update",
+          context,
+        ),
+      ).rejects.toThrow("ECONNRESET");
+      expect(destroy).not.toHaveBeenCalled();
+      expect(updateMany).toHaveBeenLastCalledWith({
+        where: { id: "computer-1" },
+        data: { state: "error" },
+      });
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+      await rm(homeRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -1008,7 +1008,7 @@ describe("computer replacement", () => {
     const home = new LocalAgentHomeStore(homeRoot);
     const sandbox = new FakeSandboxProvider();
     const first = await sandbox.provision({ botId: "bot-1", homePath: dataDir }, context);
-    vi.spyOn(sandbox, "exportWorkspace").mockImplementation(async function* () {
+    vi.spyOn(sandbox, "exportWorkspace").mockImplementation(() => {
       throw new Error("ECONNRESET");
     });
 
@@ -1066,7 +1066,7 @@ describe("computer replacement", () => {
     const home = new LocalAgentHomeStore(homeRoot);
     const sandbox = new FakeSandboxProvider();
     const first = await sandbox.provision({ botId: "bot-1", homePath: dataDir }, context);
-    vi.spyOn(sandbox, "exportWorkspace").mockImplementation(async function* () {
+    vi.spyOn(sandbox, "exportWorkspace").mockImplementation(() => {
       throw new Error("ECONNRESET");
     });
 
@@ -1080,10 +1080,7 @@ describe("computer replacement", () => {
       controlLeaseId: null,
       homeRevision: null,
     };
-    const updateMany = vi
-      .fn()
-      .mockResolvedValueOnce({ count: 1 })
-      .mockResolvedValue({ count: 1 });
+    const updateMany = vi.fn().mockResolvedValueOnce({ count: 1 }).mockResolvedValue({ count: 1 });
     const prisma = {
       computer: {
         findUniqueOrThrow: vi.fn().mockResolvedValue(computerRecord),

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -413,26 +413,22 @@ export async function replaceComputer(
   }
 
   const previousState = existing.state;
-  let claimedSuspending = false;
-  if (existing.state !== "stopped" && existing.state !== "suspended") {
-    const now = new Date();
-    const claimed = await deps.prisma.computer.updateMany({
-      where: {
-        id: computerId,
-        state: { notIn: ["booting", "suspending", "stopped", "suspended"] },
-        executionLeases: { none: { botId: { not: botId }, expiresAt: { gt: now } } },
-        OR: [
-          { controlHolder: { not: "user" } },
-          { controlLeaseId: null },
-          { controlLeaseExpiresAt: null },
-          { controlLeaseExpiresAt: { lte: now } },
-        ],
-      },
-      data: { state: "suspending" },
-    });
-    if (claimed.count !== 1) throw new ComputerBusyError();
-    claimedSuspending = true;
-  }
+  const now = new Date();
+  const claimed = await deps.prisma.computer.updateMany({
+    where: {
+      id: computerId,
+      state: previousState,
+      executionLeases: { none: { botId: { not: botId }, expiresAt: { gt: now } } },
+      OR: [
+        { controlHolder: { not: "user" } },
+        { controlLeaseId: null },
+        { controlLeaseExpiresAt: null },
+        { controlLeaseExpiresAt: { lte: now } },
+      ],
+    },
+    data: { state: "suspending" },
+  });
+  if (claimed.count !== 1) throw new ComputerBusyError();
   const activeRun = await deps.prisma.run.findFirst({
     where: {
       status: { in: [...ACTIVE_RUN_STATUSES] },
@@ -441,12 +437,10 @@ export async function replaceComputer(
     select: { id: true },
   });
   if (activeRun) {
-    if (claimedSuspending) {
-      await deps.prisma.computer.updateMany({
-        where: { id: computerId, state: "suspending" },
-        data: { state: previousState },
-      });
-    }
+    await deps.prisma.computer.updateMany({
+      where: { id: computerId, state: "suspending" },
+      data: { state: previousState },
+    });
     throw new ComputerBusyError();
   }
 
@@ -456,7 +450,7 @@ export async function replaceComputer(
       try {
         await checkpointAndRecordComputerWorkspace(deps, existing, oldRef, context);
       } catch (error) {
-        if (!isUnrecoverableSandboxError(error)) throw error;
+        if (mode !== "recover" && !isUnrecoverableSandboxError(error)) throw error;
       }
     }
     if (oldRef) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #272 for two leftover review notes that still apply on main.

**Recover past ordinary checkpoint failures.** Recover was only swallowing "unrecoverable" sandbox errors during the pre-teardown checkpoint. Timeouts and transport errors aborted recover and left the wedged box in place. Recover now treats any checkpoint failure as non-fatal and continues destroy + reprovision. Update still fails closed on ordinary checkpoint errors; reset still skips checkpoint.

**Claim stopped and suspended computers before teardown.** Replacement used to skip the suspending CAS for stopped/suspended machines. Concurrent recover/reset/update could both tear down and provision. Every replaceable state is now claimed with compare-and-set against the observed state before teardown.

Tests cover recover continuing past checkpoint errors, update aborting on the same failure, stopped/suspended CAS claim + rollback when a run is active, and a lost second claim on a stopped computer.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22c77033-a8ea-43af-bf15-cf8dfaed1701?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22c77033-a8ea-43af-bf15-cf8dfaed1701&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

