### PR TITLE
Fix mobile avatar preference rollback

### DIFF
--- a/apps/mobile/components/avatar-style.tsx
+++ b/apps/mobile/components/avatar-style.tsx
@@ -28,7 +28,6 @@ export function AvatarStyleProvider({ children }: { children: ReactNode }) {
 
   async function updateAvatarStyle(next: AvatarStyle) {
     const requestId = ++requestIdRef.current;
-    setAvatarStyle(next);
     const me = await rpc<Me>("preferences/update", { avatarStyle: next });
     if (requestId !== requestIdRef.current) return;
     setAvatarStyle(me.avatarStyle);


### PR DESCRIPTION
## Summary
- keep the current avatar style visible until the preference update is confirmed
- prevent a failed mobile save from leaving an unpersisted style active

## Verification
- mobile TypeScript check
- Biome check

Post-merge review fix for #311. No production deployment is authorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar style changes now update only after the server confirms the preference change.
  * Prevented the interface from briefly displaying an avatar style that was not successfully saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->