### PR TITLE
fix(mobile): serialize avatar style updates

### DIFF
--- a/apps/mobile/components/avatar-style.tsx
+++ b/apps/mobile/components/avatar-style.tsx
@@ -15,6 +15,7 @@ export function AvatarStyleProvider({ children }: { children: ReactNode }) {
   const [avatarStyle, setAvatarStyle] = useState<AvatarStyle>("robot");
   const pathname = usePathname();
   const requestIdRef = useRef(0);
+  const updatePendingRef = useRef(false);
 
   useEffect(() => {
     const requestId = ++requestIdRef.current;
@@ -27,10 +28,16 @@ export function AvatarStyleProvider({ children }: { children: ReactNode }) {
   }, [pathname]);
 
   async function updateAvatarStyle(next: AvatarStyle) {
+    if (updatePendingRef.current) return;
+    updatePendingRef.current = true;
     const requestId = ++requestIdRef.current;
-    const me = await rpc<Me>("preferences/update", { avatarStyle: next });
-    if (requestId !== requestIdRef.current) return;
-    setAvatarStyle(me.avatarStyle);
+    try {
+      const me = await rpc<Me>("preferences/update", { avatarStyle: next });
+      if (requestId !== requestIdRef.current) return;
+      setAvatarStyle(me.avatarStyle);
+    } finally {
+      updatePendingRef.current = false;
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- ignore overlapping avatar-style updates while the settings control is pending
- keep the confirmed response from being invalidated by a rapid second tap
- release the guard after both successful and failed requests

Follow-up to #316 and its Greptile race-condition finding.

## Verification
- `pnpm exec biome check apps/mobile/components/avatar-style.tsx`
- `pnpm --filter @rakazo/mobile check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping avatar style updates.
  * Ensured avatar style changes remain responsive and recover correctly after an update succeeds or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->