### PR TITLE
fix(dev): start the watched dev services with stdin detached

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "node ../../scripts/dev-watch.mjs src/index.ts",
     "start": "tsx src/index.ts",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --root ../.. apps/api/src"

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "node ../../scripts/dev-watch.mjs src/index.ts",
     "start": "tsx src/index.ts",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --passWithNoTests"

--- a/infra/sandboxes/supervisor/package.json
+++ b/infra/sandboxes/supervisor/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "node ../../../scripts/dev-watch.mjs src/index.ts",
     "start": "tsx src/index.ts",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run --root ../../.. infra/sandboxes/supervisor/src"

--- a/scripts/dev-watch.mjs
+++ b/scripts/dev-watch.mjs
@@ -11,13 +11,14 @@ const child = spawn(process.execPath, [tsxCli, "watch", ...process.argv.slice(2)
   stdio: ["ignore", "inherit", "inherit"],
 });
 
-const forward = (signal) => {
-  process.on(signal, () => child.kill(signal));
-};
-forward("SIGINT");
-forward("SIGTERM");
+const onSigint = () => child.kill("SIGINT");
+const onSigterm = () => child.kill("SIGTERM");
+process.on("SIGINT", onSigint);
+process.on("SIGTERM", onSigterm);
 
 child.on("exit", (code, signal) => {
+  process.off("SIGINT", onSigint);
+  process.off("SIGTERM", onSigterm);
   if (signal) {
     process.kill(process.pid, signal);
     return;

--- a/scripts/dev-watch.mjs
+++ b/scripts/dev-watch.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Run `tsx watch` for a dev service with stdin detached.
+//
+// tsx watch registers `process.stdin.on("data")` for its press-Return-to-restart shortcut. Under
+// turbo on Windows the inherited stdin handle never delivers data and never closes, and the watched
+// process then never reaches its entrypoint: no output, no listening port, no error. Outside turbo
+// the same command starts in about two seconds.
+//
+// These services are non-interactive, so nothing is lost by dropping stdin, and doing it here keeps
+// the fix in one place rather than in a shell redirect that would have to differ per platform.
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const tsxCli = require.resolve("tsx/cli");
+
+const child = spawn(process.execPath, [tsxCli, "watch", ...process.argv.slice(2)], {
+  stdio: ["ignore", "inherit", "inherit"],
+});
+
+const forward = (signal) => {
+  process.on(signal, () => child.kill(signal));
+};
+forward("SIGINT");
+forward("SIGTERM");
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/scripts/dev-watch.mjs
+++ b/scripts/dev-watch.mjs
@@ -1,13 +1,6 @@
 #!/usr/bin/env node
-// Run `tsx watch` for a dev service with stdin detached.
-//
-// tsx watch registers `process.stdin.on("data")` for its press-Return-to-restart shortcut. Under
-// turbo on Windows the inherited stdin handle never delivers data and never closes, and the watched
-// process then never reaches its entrypoint: no output, no listening port, no error. Outside turbo
-// the same command starts in about two seconds.
-//
-// These services are non-interactive, so nothing is lost by dropping stdin, and doing it here keeps
-// the fix in one place rather than in a shell redirect that would have to differ per platform.
+// Spawn `tsx watch` with stdin ignored. Under turbo on Windows an inherited stdin
+// handle that never closes prevents tsx watch from reaching the entrypoint.
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 

--- a/scripts/dev-watch.mjs
+++ b/scripts/dev-watch.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
-// Spawn `tsx watch` with stdin ignored. Under turbo on Windows an inherited stdin
-// handle that never closes prevents tsx watch from reaching the entrypoint.
+// Spawn `tsx watch` with stdin ignored.
+//
+// tsx watch listens on stdin for its press-Return-to-restart shortcut. Under turbo on Windows that
+// inherited handle never delivers and never closes, and the watched service then never reaches its
+// entrypoint: no output, no port, no error. These services are non-interactive, so nothing is lost.
+// The redirect lives here rather than in the dev scripts because `< NUL` and `< /dev/null` differ.
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
 


### PR DESCRIPTION
Fixes #281.

## Cause

It is stdin.

`tsx watch` registers `process.stdin.on("data")` for its press-Return-to-restart shortcut. Under turbo on Windows the inherited stdin handle never delivers data and never closes, and the watched process then never reaches its entrypoint — an `appendFileSync` on the **first line** of `apps/api/src/index.ts` never runs. So nothing inside the app is implicated, which is why the failure has no output and no stack.

@mybehlim's report was accurate on every point; it just stops one layer short of stdin. The evidence there was enough to narrow it quickly.

## How it was narrowed

Each of these is measured on a Windows 11 host, Node 22.23.2, turbo 2.10.9, tsx 4.23.12:

| Test | Result | Rules out |
|---|---|---|
| Direct `tsx watch src/index.ts` | binds in ~2s | the app itself |
| Under `turbo dev` | hangs, **3/3** | — |
| Trivial script under turbo | binds | tsx-under-turbo generally |
| Script importing only `@rakazo/core` | runs | workspace resolution |
| Script importing the app graph | hangs | — (needs the real graph) |
| Child stdout redirected to a file | still hangs | output/pipe blocking |
| Waited **160s** | never starts | slow module loading |
| `pnpm run dev` — turbo's own inner command | binds | the pnpm layer |
| **`tsx watch src/index.ts < NUL`** under turbo | **binds, 3/3** | ✅ stdin |

One dead end worth recording so nobody repeats it: turbo strips 43 environment variables here (`LOCALAPPDATA`, `NUMBER_OF_PROCESSORS`, `PROCESSOR_*`, …), which looks like an obvious suspect. It is not — replaying turbo's exact environment outside turbo starts normally 5/5.

## The change

`< NUL` is cmd-only and the equivalent redirect differs per platform, so the redirect lives in one small runner (`scripts/dev-watch.mjs`) that spawns `tsx watch` with stdin ignored and forwards signals and the exit code. The three affected `dev` scripts point at it; nothing else changes. These services are non-interactive, so dropping stdin costs nothing — and press-Return-to-restart never worked under turbo anyway, since that is the handle at fault.

## Verified

- `pnpm dev` on Windows now brings up **api :3100, web :5173, supervisor :7091**. Before, three of those never bound.
- `turbo dev --filter=@rakazo/api` binds **3/3**; without the change, hangs **3/3**.
- `pnpm lint` clean. `pnpm check` 20/20 packages.
- `pnpm test`: **23 failures, byte-identical to a clean checkout of the same commit** — same files, all Windows-specific sandbox/filesystem cases, unrelated to this change. Confirmed by stashing the branch and re-running. (One run showed 24; re-running twice gave a deterministic 23 both times, so that was flake.)

## Notes

- This is arguably a tsx bug — a watcher that hard-requires an interactive stdin will do this under any supervisor that provides a non-interactive one. Happy to file it upstream and reference it here; the repo-side fix seemed worth having either way, since it unblocks Windows now.
- `start` scripts are untouched: they use plain `tsx`, which does not attach the stdin listener.
- Not addressed: I did not change turbo's config or version, so nothing here affects Linux or macOS behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development watch mode reliability, particularly on Windows and with Turbo.
  * Prevented development services from hanging before startup.
  * Preserved graceful handling of shutdown signals and process exit codes.
  * Standardized startup behavior across API, worker, and supervisor development services.
  * Improved handling of interrupted or terminated development processes for more predictable local development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->