### PR TITLE
fix(mobile): share pending avatar update

### DIFF
--- a/apps/mobile/components/avatar-style.tsx
+++ b/apps/mobile/components/avatar-style.tsx
@@ -15,7 +15,7 @@ export function AvatarStyleProvider({ children }: { children: ReactNode }) {
   const [avatarStyle, setAvatarStyle] = useState<AvatarStyle>("robot");
   const pathname = usePathname();
   const requestIdRef = useRef(0);
-  const updatePendingRef = useRef(false);
+  const updatePromiseRef = useRef<Promise<void> | null>(null);
 
   useEffect(() => {
     const requestId = ++requestIdRef.current;
@@ -27,17 +27,19 @@ export function AvatarStyleProvider({ children }: { children: ReactNode }) {
       .catch(() => undefined);
   }, [pathname]);
 
-  async function updateAvatarStyle(next: AvatarStyle) {
-    if (updatePendingRef.current) return;
-    updatePendingRef.current = true;
+  function updateAvatarStyle(next: AvatarStyle): Promise<void> {
+    if (updatePromiseRef.current) return updatePromiseRef.current;
     const requestId = ++requestIdRef.current;
-    try {
-      const me = await rpc<Me>("preferences/update", { avatarStyle: next });
-      if (requestId !== requestIdRef.current) return;
-      setAvatarStyle(me.avatarStyle);
-    } finally {
-      updatePendingRef.current = false;
-    }
+    const update = rpc<Me>("preferences/update", { avatarStyle: next })
+      .then((me) => {
+        if (requestId !== requestIdRef.current) return;
+        setAvatarStyle(me.avatarStyle);
+      })
+      .finally(() => {
+        updatePromiseRef.current = null;
+      });
+    updatePromiseRef.current = update;
+    return update;
   }
 
   return (


### PR DESCRIPTION
## Summary
- return the active avatar-style update to overlapping callers
- keep the settings pending state active until the real request settles
- preserve server-confirmed state and request-order protection

Follow-up to the post-merge CodeRabbit finding on #319.

The separate timeout suggestion is not included: the settings control is already disabled for the lifetime of the RPC, so an unbounded request is existing shared RPC behavior rather than a regression introduced by this guard.

## Verification
- `pnpm exec biome check apps/mobile/components/avatar-style.tsx`
- `pnpm --filter @rakazo/mobile check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar style updates by safely handling multiple changes made in quick succession.
  * Prevented concurrent update requests from being lost while an earlier update is still processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->