### PR TITLE
fix(web): preserve transcript reader position

### DIFF
--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -1393,7 +1393,7 @@ msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von
 
 #: src/pages/Shell.tsx:3213
 msgid "Jump to latest"
-msgstr ""
+msgstr "Zur neuesten Nachricht springen"
 
 #: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -1393,7 +1393,7 @@ msgstr "इसकी बातचीत, फ़ाइलें और रूट�
 
 #: src/pages/Shell.tsx:3213
 msgid "Jump to latest"
-msgstr ""
+msgstr "नवीनतम संदेश पर जाएँ"
 
 #: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -1393,7 +1393,7 @@ msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만�
 
 #: src/pages/Shell.tsx:3213
 msgid "Jump to latest"
-msgstr ""
+msgstr "최신 메시지로 이동"
 
 #: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -1393,7 +1393,7 @@ msgstr "Suas conversas, arquivos e rotinas serão excluídos permanentemente. Os
 
 #: src/pages/Shell.tsx:3213
 msgid "Jump to latest"
-msgstr ""
+msgstr "Ir para a mensagem mais recente"
 
 #: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -1393,7 +1393,7 @@ msgstr "Sohbeti, dosyaları ve rutinleri kalıcı olarak silinecek. Oluşturduğ
 
 #: src/pages/Shell.tsx:3213
 msgid "Jump to latest"
-msgstr ""
+msgstr "En son mesaja git"
 
 #: src/pages/Shell.tsx:3951
 msgid "Jump to replied message"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -493,7 +493,11 @@ export function ShellPage() {
     setRoutines([]);
     setRoutinesBotId(null);
     // Keep the search-jump viewport; expandedHistoryThread merge still accepts live messages.
-    if (stickToEnd && expandedHistoryThread.current !== snap.threadId) {
+    if (
+      stickToEnd &&
+      (!scrollElement || transcriptIsNearEnd(scrollElement)) &&
+      expandedHistoryThread.current !== snap.threadId
+    ) {
       window.requestAnimationFrame(() => {
         const element = messageScroll.current;
         if (element) element.scrollTop = element.scrollHeight;
@@ -528,7 +532,11 @@ export function ShellPage() {
     commitSnapshot(reconciled.snapshot);
     commitComputer(reconciled.computer);
     cacheComputerFor(id, { computer: reconciled.computer });
-    if (stickToEnd && expandedHistoryThread.current !== snap.threadId) {
+    if (
+      stickToEnd &&
+      (!scrollElement || transcriptIsNearEnd(scrollElement)) &&
+      expandedHistoryThread.current !== snap.threadId
+    ) {
       window.requestAnimationFrame(() => {
         const element = messageScroll.current;
         if (element) element.scrollTop = element.scrollHeight;
@@ -3178,9 +3186,11 @@ const Transcript = memo(function Transcript({
         data-testid="transcript"
         onPointerDown={() => {
           autoScrolling.current = false;
+          following.current = false;
         }}
         onTouchStart={() => {
           autoScrolling.current = false;
+          following.current = false;
         }}
         onWheel={(event) => {
           if (event.deltaY < 0) {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3103,6 +3103,7 @@ const Transcript = memo(function Transcript({
   const [atEnd, setAtEnd] = useState(true);
   const following = useRef(true);
   const autoScrolling = useRef(false);
+  const lastScrollTop = useRef(0);
   const autoScrollTimer = useRef<number | undefined>(undefined);
   const jumpButtonRef = useRef<HTMLButtonElement>(null);
   const messageById = useMemo(
@@ -3199,10 +3200,12 @@ const Transcript = memo(function Transcript({
           }
         }}
         onScroll={(event) => {
+          const scrolledDown = event.currentTarget.scrollTop >= lastScrollTop.current;
+          lastScrollTop.current = event.currentTarget.scrollTop;
           const nearEnd = transcriptIsNearEnd(event.currentTarget);
           setAtEnd(nearEnd);
           if (nearEnd) {
-            following.current = true;
+            if (scrolledDown) following.current = true;
             if (autoScrolling.current) {
               autoScrolling.current = false;
               window.clearTimeout(autoScrollTimer.current);


### PR DESCRIPTION
## Summary
- smoothly follow new messages only while the reader remains near the bottom
- stop following immediately on pointer, touch, or upward-wheel interaction
- show the accessible animated jump-to-latest control while newer content is below
- preserve scroll offset while older history is prepended

This is the verified successor to #305/#321. The maintainer-owned #305 branch copied the conflict merge but not the later Greptile interaction fix.

## Verification
- `pnpm exec biome check apps/web/src/pages/Shell.tsx`
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web test` (20 files, 119 tests)