### PR TITLE
fix(web): localize collaboration markers and reuse loading state

### DIFF
--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
@@ -1,0 +1,33 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ActiveBotGlyph, CollaborationMarker } from "./CollaborationMarker";
+
+describe("collaboration transcript markers", () => {
+  it("shows the peer avatar in an accessible message marker", () => {
+    const html = renderToString(
+      <CollaborationMarker
+        ariaLabel="Message from Research"
+        color="#14B8A6"
+        label="Message from Research"
+        onClick={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('aria-label="Message from Research"');
+    expect(html).toContain("rakazo-bot-avatar");
+    expect(html).toContain("Research");
+  });
+
+  it("animates the active bot glyph from its run status", () => {
+    const html = renderToString(
+      <ActiveBotGlyph
+        bots={[{ botId: "research", color: "#14B8A6", status: "running" }]}
+        label="Research is working"
+      />,
+    );
+
+    expect(html).toContain('role="status"');
+    expect(html).toContain('data-working="true"');
+    expect(html).toContain("rakazo-bot-avatar-ring");
+  });
+});

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
@@ -8,6 +8,7 @@ describe("collaboration transcript markers", () => {
       <CollaborationMarker
         ariaLabel="Message from Research"
         color="#14B8A6"
+        identity="research"
         label="Message from Research"
         onClick={() => undefined}
       />,

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
@@ -1,0 +1,34 @@
+import { BotAvatar, GroupAvatar, type GroupAvatarMember } from "@rakazo/ui-web";
+import { LoadingState } from "./primitives";
+
+export function CollaborationMarker({
+  ariaLabel,
+  color,
+  label,
+  onClick,
+}: {
+  ariaLabel: string;
+  color: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className="flex items-center justify-center gap-1.5 self-center rounded-full px-2.5 py-1 text-[13px] text-[#85858A] transition-colors hover:bg-[#161618] hover:text-[#B8B8BD]"
+    >
+      <BotAvatar color={color} size={16} />
+      <span dir="auto">{label}</span>
+    </button>
+  );
+}
+
+export function ActiveBotGlyph({ bots, label }: { bots: GroupAvatarMember[]; label: string }) {
+  return (
+    <div className="flex min-h-10 items-center px-1">
+      <LoadingState indicator={<GroupAvatar members={bots} size={28} />} label={label} />
+    </div>
+  );
+}

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
@@ -4,11 +4,13 @@ import { LoadingState } from "./primitives";
 export function CollaborationMarker({
   ariaLabel,
   color,
+  identity,
   label,
   onClick,
 }: {
   ariaLabel: string;
   color: string;
+  identity: string;
   label: string;
   onClick: () => void;
 }) {
@@ -19,7 +21,7 @@ export function CollaborationMarker({
       onClick={onClick}
       className="flex items-center justify-center gap-1.5 self-center rounded-full px-2.5 py-1 text-[13px] text-[#85858A] transition-colors hover:bg-[#161618] hover:text-[#B8B8BD]"
     >
-      <BotAvatar color={color} size={16} />
+      <BotAvatar color={color} identity={identity} size={16} />
       <span dir="auto">{label}</span>
     </button>
   );

--- a/apps/web/src/components/beautiful-ui/primitives.tsx
+++ b/apps/web/src/components/beautiful-ui/primitives.tsx
@@ -51,17 +51,10 @@ function useElapsed(startedAtMs?: number): string {
 }
 
 /** Pixel-grid loader with shimmering label and live elapsed timer. */
-export function LoadingState({
-  label = "working",
-  startedAt,
-}: {
-  label?: string;
-  /** Epoch ms when the run started. Falls back to mount time when omitted. */
-  startedAt?: number;
-}) {
+function DefaultLoadingState({ label, startedAt }: { label: string; startedAt?: number }) {
   const elapsed = useElapsed(startedAt);
   return (
-    <span className="flex w-fit items-center gap-2.5">
+    <>
       <span aria-hidden className="grid grid-cols-[repeat(3,4px)] gap-[1.5px]">
         {CHEVRON_DELAYS.map((delay, i) => (
           <span
@@ -81,6 +74,30 @@ export function LoadingState({
       <span className="font-mono text-[12px] tabular-nums" style={{ color: "var(--bui-ink-3)" }}>
         {elapsed}
       </span>
+    </>
+  );
+}
+
+export function LoadingState({
+  indicator,
+  label = "working",
+  startedAt,
+}: {
+  indicator?: React.ReactNode;
+  label?: string;
+  /** Epoch ms when the run started. Falls back to mount time when omitted. */
+  startedAt?: number;
+}) {
+  return (
+    <span role="status" className="flex w-fit items-center gap-2.5">
+      {indicator ? (
+        <>
+          <span className="sr-only">{label}</span>
+          {indicator}
+        </>
+      ) : (
+        <DefaultLoadingState label={label} startedAt={startedAt} />
+      )}
     </span>
   );
 }

--- a/apps/web/src/components/beautiful-ui/primitives.tsx
+++ b/apps/web/src/components/beautiful-ui/primitives.tsx
@@ -88,16 +88,17 @@ export function LoadingState({
   /** Epoch ms when the run started. Falls back to mount time when omitted. */
   startedAt?: number;
 }) {
+  if (indicator) {
+    return (
+      <span role="status" className="flex w-fit items-center gap-2.5">
+        <span className="sr-only">{label}</span>
+        {indicator}
+      </span>
+    );
+  }
   return (
-    <span role="status" className="flex w-fit items-center gap-2.5">
-      {indicator ? (
-        <>
-          <span className="sr-only">{label}</span>
-          {indicator}
-        </>
-      ) : (
-        <DefaultLoadingState label={label} startedAt={startedAt} />
-      )}
+    <span className="flex w-fit items-center gap-2.5">
+      <DefaultLoadingState label={label} startedAt={startedAt} />
     </span>
   );
 }

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -2611,3 +2611,11 @@ msgstr "Dein Name"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Dein Team aus jederzeit verfügbaren Agents<0/>für echte Aufgaben."
+
+#: src/pages/Shell.tsx:3105
+msgid "{workingBotName} is working"
+msgstr "{workingBotName} arbeitet"
+
+#: src/pages/Shell.tsx:3106
+msgid "Bots are working"
+msgstr "Bots arbeiten"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -2611,3 +2611,11 @@ msgstr "Your name"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Your team of always-on agents<0/>that you can give real work to."
+
+#: src/pages/Shell.tsx:3105
+msgid "{workingBotName} is working"
+msgstr "{workingBotName} is working"
+
+#: src/pages/Shell.tsx:3106
+msgid "Bots are working"
+msgstr "Bots are working"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -2611,3 +2611,11 @@ msgstr "आपका नाम"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "हमेशा चालू रहने वाले एजेंटों की आपकी टीम<0/>जिन्हें आप असली काम सौंप सकते हैं।"
+
+#: src/pages/Shell.tsx:3105
+msgid "{workingBotName} is working"
+msgstr "{workingBotName} काम कर रहा है"
+
+#: src/pages/Shell.tsx:3106
+msgid "Bots are working"
+msgstr "बॉट काम कर रहे हैं"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -2611,3 +2611,11 @@ msgstr "이름"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "언제든 실제 작업을 맡길 수 있는<0/>나만의 Agent 팀"
+
+#: src/pages/Shell.tsx:3105
+msgid "{workingBotName} is working"
+msgstr "{workingBotName} 작업 중"
+
+#: src/pages/Shell.tsx:3106
+msgid "Bots are working"
+msgstr "봇 작업 중"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -2611,3 +2611,11 @@ msgstr "O seu nome"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Sua equipe de agentes sempre ativos<0/>, a quem você pode dar trabalho de verdade."
+
+#: src/pages/Shell.tsx:3105
+msgid "{workingBotName} is working"
+msgstr "{workingBotName} está trabalhando"
+
+#: src/pages/Shell.tsx:3106
+msgid "Bots are working"
+msgstr "Bots estão trabalhando"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -2611,3 +2611,11 @@ msgstr "Adın"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Gerçek işler verebileceğin,<0/>her zaman açık agent takımın."
+
+#: src/pages/Shell.tsx:3105
+msgid "{workingBotName} is working"
+msgstr "{workingBotName} çalışıyor"
+
+#: src/pages/Shell.tsx:3106
+msgid "Bots are working"
+msgstr "Botlar çalışıyor"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4081,6 +4081,7 @@ const MessageView = memo(function MessageView({
               key={i}
               ariaLabel={label}
               color={peerBot(peerBotId)?.color ?? "#85858A"}
+              identity={peerBotId}
               label={label}
               onClick={() => onOpenPeerMessages(peerBotId)}
             />

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -58,7 +58,13 @@ import {
   speechFromBlocks,
   truncateSlashDescription,
 } from "@rakazo/core";
-import { AvatarStyleProvider, BotAvatar, Button, GroupAvatar } from "@rakazo/ui-web";
+import {
+  AvatarStyleProvider,
+  BotAvatar,
+  Button,
+  GroupAvatar,
+  type GroupAvatarMember,
+} from "@rakazo/ui-web";
 import {
   ArrowDown,
   ArrowUp,
@@ -100,11 +106,10 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { ArtifactFileCard } from "../components/ArtifactFileCard";
 import { AskCard } from "../components/AskCard";
 import {
-  BuiButton,
-  BuiCard,
-  LoadingState,
-  SuccessPop,
-} from "../components/beautiful-ui/primitives";
+  ActiveBotGlyph,
+  CollaborationMarker,
+} from "../components/beautiful-ui/CollaborationMarker";
+import { BuiButton, BuiCard, SuccessPop } from "../components/beautiful-ui/primitives";
 import { ComputerMaintenanceActions } from "../components/ComputerMaintenanceActions";
 import { SkillDraftCard } from "../components/teach/SkillDraftCard";
 import { TeachCaptureOverlay } from "../components/teach/TeachCaptureOverlay";
@@ -1086,24 +1091,29 @@ export function ShellPage() {
     ["running", "queued", "leased"].includes(run.status),
   );
   const transcriptRunning = workingRuns.length > 0;
-  const workingStartedAtMs = (() => {
-    let earliest: number | undefined;
-    for (const run of workingRuns) {
-      // Prefer startedAt; fall back to createdAt so queued/leased runs keep a
-      // stable clock across remounts before the executor sets startedAt.
-      const iso = run.startedAt ?? run.createdAt;
-      const ms = Date.parse(iso);
-      if (Number.isNaN(ms)) continue;
-      if (earliest === undefined || ms < earliest) earliest = ms;
-    }
-    return earliest;
-  })();
   const composerRunning = currentRuns.some((run) => isActive(run.status));
   const transcriptArtifactTarget = useMemo<ArtifactTarget>(
     () => (inGroup ? { groupId: groupId ?? "" } : { botId: active?.id ?? "" }),
     [active?.id, groupId, inGroup],
   );
   const transcriptMembers = activeSnapshot?.members ?? activeGroup?.members;
+  const resolveTranscriptBot = useCallback(
+    (botId: string) => {
+      const bot = bots.find((candidate) => candidate.id === botId);
+      if (bot) return bot;
+      return transcriptMembers?.find((member) => member.botId === botId);
+    },
+    [bots, transcriptMembers],
+  );
+  const workingBots: GroupAvatarMember[] = workingRuns.map((run) => {
+    const bot = resolveTranscriptBot(run.botId);
+    return {
+      botId: run.botId,
+      color: bot?.color ?? "#85858A",
+      name: bot?.name,
+      status: run.status,
+    };
+  });
   const resolveTranscriptMemberName = useCallback(
     (botId: string | undefined) => memberName(transcriptMembers, botId),
     [transcriptMembers],
@@ -2184,7 +2194,7 @@ export function ShellPage() {
           loadingOlder={loadingOlder}
           answerableAskMessageId={answerableAskMessageId}
           running={transcriptRunning}
-          workingStartedAt={workingStartedAtMs}
+          workingBots={workingBots}
           onLoadOlder={loadOlder}
           onOpenBot={openBot}
           onAnswer={answerMessage}
@@ -2195,6 +2205,7 @@ export function ShellPage() {
             setPeerMessagesOpen(true);
           }}
           memberName={resolveTranscriptMemberName}
+          peerBot={resolveTranscriptBot}
           onRefresh={refreshActiveThread}
           onBotChanged={refreshBots}
           onAddRoutine={addSkillRoutine}
@@ -3041,7 +3052,7 @@ const Transcript = memo(function Transcript({
   loadingOlder,
   answerableAskMessageId,
   running,
-  workingStartedAt,
+  workingBots,
   onLoadOlder,
   onOpenBot,
   onAnswer,
@@ -3049,6 +3060,7 @@ const Transcript = memo(function Transcript({
   onJumpToMessage,
   onOpenPeerMessages,
   memberName,
+  peerBot,
   onRefresh,
   onBotChanged,
   onAddRoutine,
@@ -3063,7 +3075,7 @@ const Transcript = memo(function Transcript({
   loadingOlder: boolean;
   answerableAskMessageId: string | null;
   running: boolean;
-  workingStartedAt?: number;
+  workingBots: GroupAvatarMember[];
   onLoadOlder: () => void | Promise<void>;
   onOpenBot: (botId: string) => void;
   onAnswer: (message: ThreadMessage, text: string) => Promise<void>;
@@ -3071,6 +3083,7 @@ const Transcript = memo(function Transcript({
   onJumpToMessage: (messageId: string) => void;
   onOpenPeerMessages: (peerBotId: string) => void;
   memberName?: (botId: string | undefined) => string | undefined;
+  peerBot: (botId: string) => { color: string; status?: string } | undefined;
   onRefresh: () => Promise<void>;
   onBotChanged: () => Promise<void>;
   onAddRoutine: (name: string, prompt: string) => void;
@@ -3088,6 +3101,11 @@ const Transcript = memo(function Transcript({
     () => new Map(messages.map((message) => [message.id, message])),
     [messages],
   );
+  const workingBotName = workingBots.length === 1 ? workingBots[0]?.name : undefined;
+  const workingLabel =
+    workingBotName != null && workingBotName !== ""
+      ? t`${workingBotName} is working`
+      : t`Bots are working`;
   const snapToEnd = useCallback(() => {
     const element = scrollRef.current;
     if (!element) return;
@@ -3211,6 +3229,7 @@ const Transcript = memo(function Transcript({
               onAnswer={onAnswer}
               speakerName={message.role === "bot" ? memberName?.(message.botId) : undefined}
               memberName={memberName}
+              peerBot={peerBot}
               replyPreview={
                 message.replyToMessageId ? messageById.get(message.replyToMessageId) : undefined
               }
@@ -3232,13 +3251,7 @@ const Transcript = memo(function Transcript({
             message.blocks[0]?.kind === "progress" &&
             message.blocks[0].text,
         ) ? (
-          <div className="flex justify-start">
-            {/* Box metrics match the progress bubble exactly so swapping between
-              them never changes height or text position. */}
-            <div className="flex max-w-[74%] items-center rounded-[20px] bg-[#1A1A1D] px-[18px] py-3 text-[15.5px] leading-[1.5]">
-              <LoadingState label="working" startedAt={workingStartedAt} />
-            </div>
-          </div>
+          <ActiveBotGlyph bots={workingBots} label={workingLabel} />
         ) : null}
       </div>
       <button
@@ -3934,6 +3947,7 @@ const MessageView = memo(function MessageView({
   onOpenPeerMessages,
   speakerName,
   memberName,
+  peerBot,
   replyPreview,
   replyToMessageId,
   onJumpToMessage,
@@ -3952,6 +3966,7 @@ const MessageView = memo(function MessageView({
   onOpenPeerMessages: (peerBotId: string) => void;
   speakerName?: string;
   memberName?: (botId: string | undefined) => string | undefined;
+  peerBot: (botId: string) => { color: string; status?: string } | undefined;
   replyPreview?: ThreadMessage;
   replyToMessageId?: string;
   onJumpToMessage?: (messageId: string) => void;
@@ -4062,16 +4077,13 @@ const MessageView = memo(function MessageView({
           const peerBotId = sent ? block.toBotId : block.fromBotId;
           const label = sent ? t`Messaged ${peer}` : t`Message from ${peer}`;
           return (
-            <button
+            <CollaborationMarker
               key={i}
-              type="button"
-              aria-label={label}
+              ariaLabel={label}
+              color={peerBot(peerBotId)?.color ?? "#85858A"}
+              label={label}
               onClick={() => onOpenPeerMessages(peerBotId)}
-              className="flex items-center justify-center gap-2 self-center rounded-full border border-[#26262A] px-3 py-1 text-[13px] text-[#85858A] hover:bg-[#161618]"
-            >
-              <span aria-hidden>↔</span>
-              <span>{label}</span>
-            </button>
+            />
           );
         }
         if (block.kind === "meta") {


### PR DESCRIPTION
## Summary
- display compact centered collaboration markers with the peer avatar and the complete localized label
- render active bot glyphs through the existing `LoadingState` primitive
- preserve the avatar-style context merged into current `main`
- regenerate locale catalogs from source

This is the verified successor to #309/#320. The maintainer-owned #309 branch copied the conflict merge but not the later Greptile fixes.

## Verification
- `pnpm exec biome check apps/web/src/pages/Shell.tsx apps/web/src/components/beautiful-ui/CollaborationMarker.tsx apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx apps/web/src/components/beautiful-ui/primitives.tsx apps/web/src/locales`
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web test` (20 files, 120 tests)