### PR TITLE
fix(web): keep queued transcript snaps reader-safe

### DIFF
--- a/apps/web/src/lib/transcript-scroll.test.ts
+++ b/apps/web/src/lib/transcript-scroll.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { transcriptIsNearEnd } from "./transcript-scroll.js";
+import {
+  transcriptCanSnapAfterFrame,
+  transcriptIsNearEnd,
+  transcriptMovedDown,
+} from "./transcript-scroll.js";
 
 describe("transcriptIsNearEnd", () => {
   it("follows only while the viewport is within 80px of the latest message", () => {
@@ -9,5 +13,20 @@ describe("transcriptIsNearEnd", () => {
     expect(transcriptIsNearEnd({ scrollHeight: 1_000, scrollTop: 420, clientHeight: 500 })).toBe(
       false,
     );
+  });
+});
+
+describe("transcriptCanSnapAfterFrame", () => {
+  it("does not snap after the reader moves while the frame is queued", () => {
+    expect(transcriptCanSnapAfterFrame({ scrollTop: 920 }, 950)).toBe(false);
+    expect(transcriptCanSnapAfterFrame({ scrollTop: 950 }, 950)).toBe(true);
+  });
+});
+
+describe("transcriptMovedDown", () => {
+  it("does not treat an uninitialized baseline as downward movement", () => {
+    expect(transcriptMovedDown(null, 920)).toBe(false);
+    expect(transcriptMovedDown(950, 920)).toBe(false);
+    expect(transcriptMovedDown(920, 950)).toBe(true);
   });
 });

--- a/apps/web/src/lib/transcript-scroll.test.ts
+++ b/apps/web/src/lib/transcript-scroll.test.ts
@@ -18,8 +18,16 @@ describe("transcriptIsNearEnd", () => {
 
 describe("transcriptCanSnapAfterFrame", () => {
   it("does not snap after the reader moves while the frame is queued", () => {
-    expect(transcriptCanSnapAfterFrame({ scrollTop: 920 }, 950)).toBe(false);
-    expect(transcriptCanSnapAfterFrame({ scrollTop: 950 }, 950)).toBe(true);
+    const transcript = { scrollTop: 950 };
+    expect(transcriptCanSnapAfterFrame(transcript, transcript, 950)).toBe(true);
+    transcript.scrollTop = 920;
+    expect(transcriptCanSnapAfterFrame(transcript, transcript, 950)).toBe(false);
+  });
+
+  it("does not snap a replacement transcript", () => {
+    const queuedTranscript = { scrollTop: 950 };
+    const replacementTranscript = { scrollTop: 950 };
+    expect(transcriptCanSnapAfterFrame(replacementTranscript, queuedTranscript, 950)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/transcript-scroll.ts
+++ b/apps/web/src/lib/transcript-scroll.ts
@@ -3,3 +3,14 @@ export function transcriptIsNearEnd(
 ): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight < 80;
 }
+
+export function transcriptCanSnapAfterFrame(
+  element: Pick<HTMLElement, "scrollTop">,
+  queuedScrollTop: number,
+): boolean {
+  return element.scrollTop === queuedScrollTop;
+}
+
+export function transcriptMovedDown(previousScrollTop: number | null, scrollTop: number): boolean {
+  return previousScrollTop !== null && scrollTop >= previousScrollTop;
+}

--- a/apps/web/src/lib/transcript-scroll.ts
+++ b/apps/web/src/lib/transcript-scroll.ts
@@ -5,10 +5,11 @@ export function transcriptIsNearEnd(
 }
 
 export function transcriptCanSnapAfterFrame(
-  element: Pick<HTMLElement, "scrollTop">,
+  element: Pick<HTMLElement, "scrollTop"> | null,
+  queuedElement: Pick<HTMLElement, "scrollTop">,
   queuedScrollTop: number,
 ): boolean {
-  return element.scrollTop === queuedScrollTop;
+  return element === queuedElement && queuedElement.scrollTop === queuedScrollTop;
 }
 
 export function transcriptMovedDown(previousScrollTop: number | null, scrollTop: number): boolean {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -479,12 +479,13 @@ export function ShellPage() {
   );
 
   function snapTranscriptToEndAfterFrame() {
-    const queuedScrollTop = messageScroll.current?.scrollTop;
-    if (queuedScrollTop === undefined) return;
+    const queuedElement = messageScroll.current;
+    if (!queuedElement) return;
+    const queuedScrollTop = queuedElement.scrollTop;
     window.requestAnimationFrame(() => {
       const element = messageScroll.current;
-      if (element && transcriptCanSnapAfterFrame(element, queuedScrollTop)) {
-        element.scrollTop = element.scrollHeight;
+      if (transcriptCanSnapAfterFrame(element, queuedElement, queuedScrollTop)) {
+        queuedElement.scrollTop = queuedElement.scrollHeight;
       }
     });
   }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -140,7 +140,11 @@ import {
   reduceThreadSnapshot,
   userHoldsComputerControl,
 } from "../lib/thread-events";
-import { transcriptIsNearEnd } from "../lib/transcript-scroll";
+import {
+  transcriptCanSnapAfterFrame,
+  transcriptIsNearEnd,
+  transcriptMovedDown,
+} from "../lib/transcript-scroll";
 import { speaker } from "../lib/tts";
 import { ActivityList } from "./ActivityList";
 import type { ContextMenuPosition } from "./BotContextMenu";
@@ -474,6 +478,17 @@ export function ShellPage() {
     [navigate],
   );
 
+  function snapTranscriptToEndAfterFrame() {
+    const queuedScrollTop = messageScroll.current?.scrollTop;
+    if (queuedScrollTop === undefined) return;
+    window.requestAnimationFrame(() => {
+      const element = messageScroll.current;
+      if (element && transcriptCanSnapAfterFrame(element, queuedScrollTop)) {
+        element.scrollTop = element.scrollHeight;
+      }
+    });
+  }
+
   async function refreshGroupThread(id: string) {
     const scrollElement = messageScroll.current;
     const stickToEnd = !scrollElement || transcriptIsNearEnd(scrollElement);
@@ -498,10 +513,7 @@ export function ShellPage() {
       (!scrollElement || transcriptIsNearEnd(scrollElement)) &&
       expandedHistoryThread.current !== snap.threadId
     ) {
-      window.requestAnimationFrame(() => {
-        const element = messageScroll.current;
-        if (element) element.scrollTop = element.scrollHeight;
-      });
+      snapTranscriptToEndAfterFrame();
     }
     return snap;
   }
@@ -537,10 +549,7 @@ export function ShellPage() {
       (!scrollElement || transcriptIsNearEnd(scrollElement)) &&
       expandedHistoryThread.current !== snap.threadId
     ) {
-      window.requestAnimationFrame(() => {
-        const element = messageScroll.current;
-        if (element) element.scrollTop = element.scrollHeight;
-      });
+      snapTranscriptToEndAfterFrame();
     }
     const [routines, skills] = await Promise.all([
       rpc.routines.list({ botId: id }),
@@ -3103,7 +3112,7 @@ const Transcript = memo(function Transcript({
   const [atEnd, setAtEnd] = useState(true);
   const following = useRef(true);
   const autoScrolling = useRef(false);
-  const lastScrollTop = useRef(0);
+  const lastScrollTop = useRef<number | null>(null);
   const autoScrollTimer = useRef<number | undefined>(undefined);
   const jumpButtonRef = useRef<HTMLButtonElement>(null);
   const messageById = useMemo(
@@ -3185,22 +3194,28 @@ const Transcript = memo(function Transcript({
       <div
         ref={scrollRef}
         data-testid="transcript"
-        onPointerDown={() => {
+        onPointerDown={(event) => {
+          lastScrollTop.current = event.currentTarget.scrollTop;
           autoScrolling.current = false;
           following.current = false;
         }}
-        onTouchStart={() => {
+        onTouchStart={(event) => {
+          lastScrollTop.current = event.currentTarget.scrollTop;
           autoScrolling.current = false;
           following.current = false;
         }}
         onWheel={(event) => {
           if (event.deltaY < 0) {
+            lastScrollTop.current = event.currentTarget.scrollTop;
             autoScrolling.current = false;
             following.current = false;
           }
         }}
         onScroll={(event) => {
-          const scrolledDown = event.currentTarget.scrollTop >= lastScrollTop.current;
+          const scrolledDown = transcriptMovedDown(
+            lastScrollTop.current,
+            event.currentTarget.scrollTop,
+          );
           lastScrollTop.current = event.currentTarget.scrollTop;
           const nearEnd = transcriptIsNearEnd(event.currentTarget);
           setAtEnd(nearEnd);


### PR DESCRIPTION
Follow-up to #324 for review comments that arrived after merge.

- cancel queued refresh snaps when the reader moves before the frame runs
- do not classify the first scroll event as downward without a baseline
- initialize the baseline when pointer, touch, or upward-wheel interaction starts
- cover both timing decisions with focused regression tests

Verification:
- `vitest run --root . apps/web/src` (21 files, 123 tests)
- `tsc --noEmit -p apps/web/tsconfig.json`
- `biome check` on the three changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript auto-scrolling after thread refreshes.
  * Prevented automatic snapping when the reader has moved away from the transcript’s end.
  * Improved detection of manual scrolling, including initial and upward scroll movement.
* **Tests**
  * Added coverage for transcript scroll positioning and movement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->