### PR TITLE
fix(adapters): safely handle optional context in agent runtimes

### DIFF
--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -181,7 +181,7 @@ export interface SemanticMemoryProvider {
 
 export interface AgentRuntime {
   describe(): AdapterDescriptor<AgentRuntimeCapabilities>;
-  run(request: AgentRunRequest, context: AdapterContext): AsyncIterable<AgentRuntimeEvent>;
+  run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent>;
   abort(runId: string): Promise<void>;
 }
 

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -79,10 +79,10 @@ export class PiAgentRuntime implements AgentRuntime {
     running.get(runId)?.abort();
   }
 
-  async *run(request: AgentRunRequest, context: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
+  async *run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
-    const signal = context.signal ?? controller.signal;
+    const signal = context?.signal ?? controller.signal;
     const queue = createQueue();
 
     const work = (async () => {

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -22,10 +22,10 @@ export class ScriptedAgentRuntime implements AgentRuntime {
     running.get(runId)?.abort();
   }
 
-  async *run(request: AgentRunRequest, context: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
+  async *run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
-    const signal = context.signal ?? controller.signal;
+    const signal = context?.signal ?? controller.signal;
     try {
       if (shouldHang(request.prompt)) {
         yield { type: "progress", text: "still working…" };


### PR DESCRIPTION
### Summary
Safely handles cases where `context` is omitted by callers (such as `executor.ts`) by making the parameter optional and using optional chaining (`context?.signal`).

### Problem
When `deps.runtime.run(request)` is called with a single argument, accessing `context.signal` threw `TypeError: Cannot read properties of undefined (reading 'signal')`, causing worker continuation jobs to fail silently and loop endlessly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime execution now supports optional context information.
  * Callers can provide only the context fields they need.
  * Runs automatically use an internal cancellation signal when no signal is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->