### PR TITLE
feat(groups): inject member titles and descriptions into group chat context

### DIFF
--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -509,7 +509,7 @@ export const builtinAgentTools: ConnectorTool[] = [
   {
     name: "message_bot",
     description:
-      "Send a message to one of the user's other bots. Asynchronous: this returns as soon as the message is sent, and any reply arrives later as a new message that wakes you. Never wait for a reply in this turn.",
+      "Send a message to one of the user's other bots. Asynchronous: this returns as soon as the message is sent, and any reply arrives later as a new message that wakes you. Never wait for a reply in this turn. Use this to delegate domain-specific tasks to teammate bots from your teammate directory.",
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1855,6 +1855,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 "spawn_bot creates a lasting regular bot (own chat, computer, memory) that appears in the user's bot list. If the user asked to create a bot, call spawn_bot once and stop. Do not run_subagent to demo it.",
                 "run_subagent is a short helper inside this turn only. It is not a bot, has no thread, and does not show in the list. Use it for parallel work you will summarize here.",
                 botDirectory,
+                "When acting as an orchestrator or Chief of Staff, prioritize planning and delegating tasks to teammates via message_bot over executing specialist deliverables directly.",
                 "archive_bot safely archives a bot this bot created, and only that bot. Use it when the user asks to remove that bot or when it is finished and unused. The user can restore it or permanently delete it later. confirm_name must exactly match its name.",
                 pluginLine,
                 agentSkillsLine,

--- a/packages/adapters/src/group-handoff.ts
+++ b/packages/adapters/src/group-handoff.ts
@@ -140,16 +140,20 @@ export async function loadGroupContext(
     include: {
       members: {
         where: { bot: { archivedAt: null } },
-        include: { bot: { select: { id: true, name: true } } },
+        include: { bot: { select: { id: true, name: true, title: true, description: true } } },
         orderBy: { createdAt: "asc" },
       },
     },
   });
   if (!group) return undefined;
-  const roster = group.members.map((member) => `${member.bot.name} (${member.bot.id})`).join(", ");
+  const roster = group.members
+    .map((m) => `- ${m.bot.name} (id: ${m.bot.id})${m.bot.title ? ` — ${m.bot.title}` : ""}${m.bot.description ? `: ${m.bot.description}` : ""}`)
+    .join("\n");
   return [
-    `You are in the group chat "${group.name}" with: ${roster}.`,
-    "Post in this shared thread. When another teammate should take the next stage, use handoff_to_bot instead of telling the user to switch chats.",
-    "One bot owns each stage.",
-  ].join(" ");
+    `You are in the group chat "${group.name}".`,
+    "<group_members>",
+    roster,
+    "</group_members>",
+    "Post in this shared thread. When a sub-task or stage matches a teammate's specialty or domain, use handoff_to_bot to assign the work to them rather than doing all specialist work yourself. Orchestrators should plan the work and hand off technical, research, or drafting stages to the respective specialists.",
+  ].join("\n");
 }

--- a/packages/core/src/bot-messages.ts
+++ b/packages/core/src/bot-messages.ts
@@ -79,7 +79,7 @@ export function renderBotDirectory(bots: readonly BotAddress[]): string | undefi
     "<teammate_directory>",
     ...lines,
     "</teammate_directory>",
-    "Use message_bot to send one of them a message. Delivery is asynchronous: the tool returns as soon as it is sent, and any reply arrives later as a new message that wakes you. Never wait for a reply in this turn.",
+    "Use message_bot to send one of them a message. Delivery is asynchronous: the tool returns as soon as it is sent, and any reply arrives later as a new message that wakes you. Never wait for a reply in this turn. When a request matches a teammate's specialized domain or description, delegate to them using message_bot instead of attempting all specialist work directly. It is expected and encouraged to end your turn after dispatching via message_bot with a brief status note to the user.",
   ].join("\n");
 }
 


### PR DESCRIPTION
### Summary
- Injects full member titles and descriptions into `<group_members>` in `loadGroupContext`.
- Adds prompt guidance instructing orchestrator/lead bots to use `handoff_to_bot` for specialized domain stages rather than attempting all tasks sequentially.
- Updates teammate directory instructions and `message_bot` tool description to encourage domain delegation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved task coordination by encouraging appropriate specialist work to be delegated to teammates.
  * Added clearer teammate information, including roles and areas of expertise, to support better assignment decisions.
  * Orchestration guidance now prioritizes planning and delegation over directly completing specialist deliverables.
  * Added clearer status updates after tasks are handed off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->