### PR TITLE
fix(adapters): safely handle optional context in agent runtimes

### DIFF
--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -181,7 +181,7 @@ export interface SemanticMemoryProvider {
 
 export interface AgentRuntime {
   describe(): AdapterDescriptor<AgentRuntimeCapabilities>;
-  run(request: AgentRunRequest, context: AdapterContext): AsyncIterable<AgentRuntimeEvent>;
+  run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent>;
   abort(runId: string): Promise<void>;
 }
 

--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -181,7 +181,10 @@ export interface SemanticMemoryProvider {
 
 export interface AgentRuntime {
   describe(): AdapterDescriptor<AgentRuntimeCapabilities>;
-  run(request: AgentRunRequest, context?: AdapterContext): AsyncIterable<AgentRuntimeEvent>;
+  run(
+    request: AgentRunRequest,
+    context?: Partial<AdapterContext>,
+  ): AsyncIterable<AgentRuntimeEvent>;
   abort(runId: string): Promise<void>;
 }
 

--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -181,7 +181,7 @@ export interface SemanticMemoryProvider {
 
 export interface AgentRuntime {
   describe(): AdapterDescriptor<AgentRuntimeCapabilities>;
-  run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent>;
+  run(request: AgentRunRequest, context?: AdapterContext): AsyncIterable<AgentRuntimeEvent>;
   abort(runId: string): Promise<void>;
 }
 

--- a/packages/adapters/src/history-compaction.test.ts
+++ b/packages/adapters/src/history-compaction.test.ts
@@ -394,7 +394,7 @@ describe("compactHistory", () => {
       expect.objectContaining({ workspaceId: "workspace-1", botId: "bot-1" }),
     );
 
-    const [, context] = harness.runtime.run.mock.calls[0]!;
+    const context = harness.runtime.run.mock.calls[0]![1];
     expect(context).toBeDefined();
     expect(context!.workspaceId).toBe("workspace-1");
     expect(context!.userId).toBe("user-1");

--- a/packages/adapters/src/history-compaction.test.ts
+++ b/packages/adapters/src/history-compaction.test.ts
@@ -395,8 +395,9 @@ describe("compactHistory", () => {
     );
 
     const [, context] = harness.runtime.run.mock.calls[0]!;
-    expect(context.workspaceId).toBe("workspace-1");
-    expect(context.userId).toBe("user-1");
+    expect(context).toBeDefined();
+    expect(context!.workspaceId).toBe("workspace-1");
+    expect(context!.userId).toBe("user-1");
 
     expect(harness.prisma.thread.updateMany).toHaveBeenCalledWith({
       where: {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -80,10 +80,10 @@ export class PiAgentRuntime implements AgentRuntime {
     running.get(runId)?.abort();
   }
 
-  async *run(request: AgentRunRequest, context: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
+  async *run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
-    const signal = context.signal ?? controller.signal;
+    const signal = context?.signal ?? controller.signal;
     const queue = createQueue();
 
     const work = (async () => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -80,7 +80,7 @@ export class PiAgentRuntime implements AgentRuntime {
     running.get(runId)?.abort();
   }
 
-  async *run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent> {
+  async *run(request: AgentRunRequest, context?: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
     const signal = context?.signal ?? controller.signal;

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -80,7 +80,10 @@ export class PiAgentRuntime implements AgentRuntime {
     running.get(runId)?.abort();
   }
 
-  async *run(request: AgentRunRequest, context?: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
+  async *run(
+    request: AgentRunRequest,
+    context?: Partial<AdapterContext>,
+  ): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
     const signal = context?.signal ?? controller.signal;

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -22,10 +22,10 @@ export class ScriptedAgentRuntime implements AgentRuntime {
     running.get(runId)?.abort();
   }
 
-  async *run(request: AgentRunRequest, context: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
+  async *run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
-    const signal = context.signal ?? controller.signal;
+    const signal = context?.signal ?? controller.signal;
     try {
       if (shouldHang(request.prompt)) {
         yield { type: "progress", text: "still working…" };

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -22,7 +22,7 @@ export class ScriptedAgentRuntime implements AgentRuntime {
     running.get(runId)?.abort();
   }
 
-  async *run(request: AgentRunRequest, context?: Partial<AdapterContext>): AsyncIterable<AgentRuntimeEvent> {
+  async *run(request: AgentRunRequest, context?: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
     const signal = context?.signal ?? controller.signal;

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -22,7 +22,10 @@ export class ScriptedAgentRuntime implements AgentRuntime {
     running.get(runId)?.abort();
   }
 
-  async *run(request: AgentRunRequest, context?: AdapterContext): AsyncIterable<AgentRuntimeEvent> {
+  async *run(
+    request: AgentRunRequest,
+    context?: Partial<AdapterContext>,
+  ): AsyncIterable<AgentRuntimeEvent> {
     const controller = new AbortController();
     running.set(request.runId, controller);
     const signal = context?.signal ?? controller.signal;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Supersedes #329 by [@coneborg](https://github.com/coneborg) (fork `coneborg/rakazo` is pull-only; could not push CI fixes to `fix/runtime-optional-context-signal`).

## Summary
Makes `AgentRuntime.run`'s second arg optional so omitted context does not throw when reading `.signal`. Implementations use `context?.signal ?? controller.signal`. Keeps `context?: Partial<AdapterContext>` as in the original PR.

## CI fixes on top of @coneborg's change
- Biome format: wrap long `run(...)` signatures onto multiple lines in `interfaces.ts`, `pi-runtime.ts`, and `scripted-runtime.ts`.
- Typecheck: narrow the optional mock context in `history-compaction.test.ts` (only site that read `mock.calls[...][1]`).

## Attribution
Original change: `d72ee668b8742a57512dfbf021232bda67d0382b` by c1borg / [@coneborg](https://github.com/coneborg).

Co-authored-by: c1borg <c1borg@yahoo.com>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a124fb-ad4a-425d-943f-ae6fdc34c98f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a124fb-ad4a-425d-943f-ae6fdc34c98f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime executions can now be started without providing a complete context.
  - Partial context information is supported when available, while cancellation behavior remains available through built-in defaults.

- **Bug Fixes**
  - Improved runtime compatibility for calls that omit optional execution context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->