### PR TITLE
Refine generated bot avatars

### DIFF
--- a/packages/core/src/avatar-shape.test.ts
+++ b/packages/core/src/avatar-shape.test.ts
@@ -13,4 +13,12 @@ describe("organic avatar geometry", () => {
     expect(path).toMatch(/^M[-0-9. ]+(?:C[-0-9. ]+)+Z$/);
     expect(path).not.toMatch(/<|>|javascript:|url\(/i);
   });
+
+  it("produces ten distinct smooth shape families", () => {
+    const families = Array.from({ length: 10 }, (_, seed) =>
+      organicAvatarPath(seed, -((seed % 360) * Math.PI) / 180),
+    );
+    expect(new Set(families)).toHaveLength(10);
+    expect(families.every((path) => (path.match(/C/g) ?? []).length >= 12)).toBe(true);
+  });
 });

--- a/packages/core/src/avatar-shape.ts
+++ b/packages/core/src/avatar-shape.ts
@@ -1,3 +1,7 @@
+type AvatarPoint = readonly [number, number];
+
+let organicAvatarTemplates: readonly (readonly AvatarPoint[])[] | undefined;
+
 export function avatarIdentitySeed(identity: string): number {
   let hash = 0;
   for (let index = 0; index < identity.length; index++) {
@@ -8,20 +12,167 @@ export function avatarIdentitySeed(identity: string): number {
 }
 
 export function organicAvatarPath(seed: number, phaseOffset = 0): string {
-  const pointCount = 12;
   const phase = ((seed % 360) * Math.PI) / 180 + phaseOffset;
-  const family = (seed + 1) % 4;
-  const lobes = [2, 3, 4, 5][family] ?? 4;
-  const amplitude = [0.045, 0.14, 0.09, 0.025][family] ?? 0.09;
-  const points = Array.from({ length: pointCount }, (_, index) => {
-    const angle = (index / pointCount) * Math.PI * 2;
-    const radius =
-      50 * (1 + amplitude * Math.sin(angle * lobes + phase) + 0.025 * Math.sin(angle * 2 - phase));
-    return {
-      x: Math.cos(angle) * radius * 1.08,
-      y: Math.sin(angle) * radius * 0.82,
-    };
-  });
+  const family = seed % 10;
+  if (!organicAvatarTemplates) {
+    organicAvatarTemplates = [
+      [
+        [-43, 22],
+        [-51, 16],
+        [-53, 6],
+        [-49, -4],
+        [-40, -12],
+        [-30, -13],
+        [-27, -24],
+        [-18, -34],
+        [-6, -36],
+        [4, -32],
+        [12, -42],
+        [25, -45],
+        [37, -38],
+        [43, -27],
+        [42, -17],
+        [51, -11],
+        [56, 0],
+        [54, 12],
+        [46, 20],
+        [30, 24],
+        [0, 25],
+        [-29, 25],
+      ],
+      [
+        [0, -52],
+        [12, -35],
+        [28, -17],
+        [39, 2],
+        [42, 21],
+        [34, 38],
+        [19, 49],
+        [0, 52],
+        [-19, 49],
+        [-34, 38],
+        [-42, 21],
+        [-39, 2],
+        [-28, -17],
+        [-12, -35],
+      ],
+      [
+        [-42, -23],
+        [-27, -40],
+        [-7, -46],
+        [14, -40],
+        [33, -27],
+        [46, -8],
+        [46, 14],
+        [35, 34],
+        [14, 46],
+        [-8, 46],
+        [-29, 38],
+        [-43, 21],
+        [-48, 0],
+      ],
+      Array.from({ length: 40 }, (_, index) => {
+        const angle = (index / 40) * Math.PI * 2;
+        const radius = 44 + Math.cos(angle * 5) * 5;
+        return [Math.cos(angle) * radius, Math.sin(angle) * radius];
+      }),
+      Array.from({ length: 36 }, (_, index) => {
+        const angle = (index / 36) * Math.PI * 2;
+        const radius = 43 + Math.cos(angle * 6) * 7;
+        return [Math.cos(angle) * radius, Math.sin(angle) * radius];
+      }),
+      Array.from({ length: 32 }, (_, index) => {
+        const angle = (index / 32) * Math.PI * 2;
+        const x = Math.cos(angle);
+        const y = Math.sin(angle);
+        return [
+          Math.sign(x) * Math.sqrt(Math.abs(x)) * 46,
+          Math.sign(y) * Math.sqrt(Math.abs(y)) * 43,
+        ];
+      }),
+      [
+        [0, 48],
+        [-14, 36],
+        [-32, 20],
+        [-45, 0],
+        [-43, -20],
+        [-29, -36],
+        [-10, -39],
+        [0, -27],
+        [10, -39],
+        [29, -36],
+        [43, -20],
+        [45, 0],
+        [32, 20],
+        [14, 36],
+      ],
+      [
+        [-48, 35],
+        [-38, 22],
+        [-34, -8],
+        [-27, -31],
+        [-12, -44],
+        [0, -48],
+        [12, -44],
+        [27, -31],
+        [34, -8],
+        [38, 22],
+        [48, 35],
+        [26, 42],
+        [0, 44],
+        [-26, 42],
+      ],
+      [
+        [-45, -19],
+        [-28, -38],
+        [-4, -46],
+        [22, -41],
+        [42, -25],
+        [49, -2],
+        [42, 23],
+        [22, 42],
+        [-4, 47],
+        [-29, 38],
+        [-46, 18],
+        [-50, 0],
+      ],
+      [
+        [-50, 0],
+        [-45, -20],
+        [-30, -38],
+        [0, -48],
+        [30, -38],
+        [45, -20],
+        [50, 0],
+        [35, 10],
+        [18, 12],
+        [16, 38],
+        [0, 46],
+        [-16, 38],
+        [-18, 12],
+        [-35, 10],
+      ],
+    ] as const;
+  }
+  const templates = organicAvatarTemplates;
+  const xScale = 1 + Math.sin(phase) * 0.035;
+  const yScale = 1 + Math.cos(phase) * 0.025;
+  const shear = Math.sin(phase * 1.7) * 0.025;
+  let points = (templates[family] ?? templates[5]!).map(([x, y]) => ({
+    x: x * xScale + y * shear,
+    y: y * yScale,
+  }));
+  const smoothingPasses = family >= 3 && family <= 5 ? 1 : 2;
+  for (let pass = 0; pass < smoothingPasses; pass++) {
+    points = points.flatMap((point, index) => {
+      const next = points[(index + 1) % points.length]!;
+      return [
+        { x: point.x * 0.75 + next.x * 0.25, y: point.y * 0.75 + next.y * 0.25 },
+        { x: point.x * 0.25 + next.x * 0.75, y: point.y * 0.25 + next.y * 0.75 },
+      ];
+    });
+  }
+  const pointCount = points.length;
   const round = (value: number) => Math.round(value * 100) / 100;
   const first = points[0]!;
   let path = `M${round(first.x)} ${round(first.y)}`;

--- a/packages/ui-web/src/bot-avatar.test.tsx
+++ b/packages/ui-web/src/bot-avatar.test.tsx
@@ -61,10 +61,11 @@ describe("BotAvatar", () => {
 
   it("assigns animation hooks across every organic shape family", () => {
     const identities = new Map<number, string>();
-    for (let index = 0; identities.size < 10; index++) {
+    for (let index = 0; index < 500 && identities.size < 10; index++) {
       const identity = `avatar-${index}`;
       identities.set(avatarIdentitySeed(identity) % 10, identity);
     }
+    expect(identities.size).toBe(10);
 
     for (const [family, identity] of identities) {
       const html = renderToString(

--- a/packages/ui-web/src/bot-avatar.test.tsx
+++ b/packages/ui-web/src/bot-avatar.test.tsx
@@ -1,3 +1,4 @@
+import { avatarIdentitySeed } from "@rakazo/core";
 import { renderToString } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { AvatarStyleProvider } from "./avatar-style.js";
@@ -43,6 +44,8 @@ describe("BotAvatar", () => {
 
     expect(html).toContain("rakazo-organic-avatar");
     expect(html).toContain('data-working="true"');
+    expect(html).toMatch(/data-shape-family="\d"/);
+    expect(html).toMatch(/data-eye-pattern="[0-3]"/);
     expect(html).toContain("<animate");
     expect(html).not.toContain("rakazo-bot-avatar-visor");
   });
@@ -54,6 +57,23 @@ describe("BotAvatar", () => {
     );
 
     expect(maya).not.toEqual(github);
+  });
+
+  it("assigns animation hooks across every organic shape family", () => {
+    const identities = new Map<number, string>();
+    for (let index = 0; identities.size < 10; index++) {
+      const identity = `avatar-${index}`;
+      identities.set(avatarIdentitySeed(identity) % 10, identity);
+    }
+
+    for (const [family, identity] of identities) {
+      const html = renderToString(
+        <BotAvatar color="#D9508A" identity={identity} status="running" variant="organic" />,
+      );
+      expect(html).toContain(`data-shape-family="${family}"`);
+      expect(html).toMatch(/data-eye-pattern="[0-3]"/);
+      expect(html).toContain('data-working="true"');
+    }
   });
 
   it("uses the account avatar preference when no local variant is provided", () => {

--- a/packages/ui-web/src/bot-avatar.tsx
+++ b/packages/ui-web/src/bot-avatar.tsx
@@ -189,11 +189,14 @@ function OrganicAvatar({
         className="rakazo-organic-avatar-body"
         d={shapeA}
         fill={color}
-        style={{
-          filter: isWorking
-            ? `drop-shadow(0 0 ${Math.round(size * 0.16)}px ${color})`
-            : "drop-shadow(0 2px 3px rgba(0,0,0,.34))",
-        }}
+        style={
+          {
+            "--rakazo-organic-path": `path("${shapeA}")`,
+            filter: isWorking
+              ? `drop-shadow(0 0 ${Math.round(size * 0.16)}px ${color})`
+              : "drop-shadow(0 2px 3px rgba(0,0,0,.34))",
+          } as CSSProperties
+        }
       >
         <animate
           attributeName="d"

--- a/packages/ui-web/src/bot-avatar.tsx
+++ b/packages/ui-web/src/bot-avatar.tsx
@@ -176,6 +176,8 @@ function OrganicAvatar({
       aria-hidden="true"
       className={cn("rakazo-organic-avatar overflow-visible select-none", className)}
       data-working={isWorking}
+      data-shape-family={seed % 10}
+      data-eye-pattern={seed % 4}
       style={{
         ...shapeStyle,
         width: size,
@@ -200,13 +202,11 @@ function OrganicAvatar({
           repeatCount="indefinite"
         />
       </path>
-      <g
-        className="rakazo-organic-avatar-eyes"
-        transform={`rotate(${(seed % 9) - 4})`}
-        fill="#101014"
-      >
-        <rect x="-14" y="-12" width="7" height="24" rx="3.5" />
-        <rect x="7" y="-12" width="7" height="24" rx="3.5" />
+      <g transform={`rotate(${(seed % 9) - 4})`}>
+        <g className="rakazo-organic-avatar-eyes" fill="#101014">
+          <rect x="-14" y="-12" width="7" height="24" rx="3.5" />
+          <rect x="7" y="-12" width="7" height="24" rx="3.5" />
+        </g>
       </g>
     </svg>
   );

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -24,17 +24,257 @@
   transform-origin: center;
 }
 
-.rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-eyes {
-  animation: rakazo-organic-eyes 1.35s ease-in-out infinite;
+.rakazo-organic-avatar[data-working="false"] .rakazo-organic-avatar-body {
+  animation: rakazo-organic-idle 5.6s ease-in-out infinite;
 }
 
-@keyframes rakazo-organic-eyes {
+.rakazo-organic-avatar[data-eye-pattern="0"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-eyes-idle-0 5.8s ease-in-out infinite;
+}
+
+.rakazo-organic-avatar[data-eye-pattern="1"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-eyes-idle-1 6.4s ease-in-out -1.7s infinite;
+}
+
+.rakazo-organic-avatar[data-eye-pattern="2"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-eyes-idle-2 5.2s ease-in-out -3.1s infinite;
+}
+
+.rakazo-organic-avatar[data-eye-pattern="3"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-eyes-idle-3 6.8s ease-in-out -2.3s infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-organic-eyes-loop-0 6.6s ease-in-out infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-eye-pattern="1"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-organic-eyes-loop-1 7.2s ease-in-out -1.4s infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-eye-pattern="2"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-organic-eyes-loop-2 6.1s ease-in-out -3.2s infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-eye-pattern="3"] .rakazo-organic-avatar-eyes {
+  animation: rakazo-organic-eyes-loop-3 7.8s ease-in-out -2.1s infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-shape-family="0"] .rakazo-organic-avatar-body {
+  animation: rakazo-organic-float 1.8s ease-in-out infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-shape-family="1"] .rakazo-organic-avatar-body {
+  animation: rakazo-organic-stretch 1.35s ease-in-out infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-shape-family="2"] .rakazo-organic-avatar-body,
+.rakazo-organic-avatar[data-working="true"][data-shape-family="8"] .rakazo-organic-avatar-body {
+  animation: rakazo-organic-sway 1.6s ease-in-out infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-shape-family="3"] .rakazo-organic-avatar-body,
+.rakazo-organic-avatar[data-working="true"][data-shape-family="4"] .rakazo-organic-avatar-body {
+  animation: rakazo-organic-turn 2.4s ease-in-out infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-shape-family="5"] .rakazo-organic-avatar-body,
+.rakazo-organic-avatar[data-working="true"][data-shape-family="9"] .rakazo-organic-avatar-body {
+  animation: rakazo-organic-squash 1.35s ease-in-out infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-shape-family="6"] .rakazo-organic-avatar-body {
+  animation: rakazo-organic-pulse 1.1s ease-in-out infinite;
+}
+
+.rakazo-organic-avatar[data-working="true"][data-shape-family="7"] .rakazo-organic-avatar-body {
+  transform-origin: center 20%;
+  animation: rakazo-organic-ring 1.35s ease-in-out infinite;
+}
+
+@keyframes rakazo-organic-float {
   0%,
   100% {
-    transform: translateX(-6%);
+    transform: translateY(2px) scaleX(1.02);
   }
   50% {
-    transform: translateX(6%);
+    transform: translateY(-3px) scaleX(0.98);
+  }
+}
+
+@keyframes rakazo-organic-idle {
+  0%,
+  100% {
+    transform: translateY(1.2px) scale(1.012, 0.988);
+  }
+  50% {
+    transform: translateY(-1.4px) scale(0.988, 1.012);
+  }
+}
+
+@keyframes rakazo-organic-stretch {
+  0%,
+  100% {
+    transform: translateY(2px) scale(1.04, 0.96);
+  }
+  50% {
+    transform: translateY(-3px) scale(0.96, 1.05);
+  }
+}
+
+@keyframes rakazo-organic-sway {
+  0%,
+  100% {
+    transform: rotate(-3deg) translateX(-1px);
+  }
+  50% {
+    transform: rotate(3deg) translateX(1px);
+  }
+}
+
+@keyframes rakazo-organic-turn {
+  0%,
+  100% {
+    transform: rotate(-4deg) scale(0.98);
+  }
+  50% {
+    transform: rotate(4deg) scale(1.04);
+  }
+}
+
+@keyframes rakazo-organic-squash {
+  0%,
+  100% {
+    transform: scale(1.04, 0.96);
+  }
+  50% {
+    transform: scale(0.96, 1.04);
+  }
+}
+
+@keyframes rakazo-organic-pulse {
+  0%,
+  100% {
+    transform: scale(0.96);
+  }
+  45% {
+    transform: scale(1.06);
+  }
+}
+
+@keyframes rakazo-organic-ring {
+  0%,
+  100% {
+    transform: rotate(-4deg);
+  }
+  35% {
+    transform: rotate(5deg);
+  }
+  65% {
+    transform: rotate(-3deg);
+  }
+}
+
+@keyframes rakazo-organic-eyes-loop-0 {
+  0%,
+  100% {
+    transform: translate(-9%, 1%) scaleY(0.94);
+  }
+  18% {
+    transform: translate(9%, -2%) scaleY(1.04);
+  }
+  34% {
+    transform: translate(0, -8%) scale(1.08);
+  }
+  48% {
+    transform: scale(1.12, 0.82);
+  }
+  51% {
+    transform: scale(1.05, 0.08);
+  }
+  54% {
+    transform: scale(1.12, 0.9);
+  }
+  72% {
+    transform: translate(-5%, 7%) scaleY(0.9);
+  }
+  86% {
+    transform: translate(7%, 3%);
+  }
+}
+
+@keyframes rakazo-organic-eyes-loop-1 {
+  0%,
+  100% {
+    transform: translate(0, -8%) scale(1.06);
+  }
+  16% {
+    transform: translate(8%, 2%);
+  }
+  31% {
+    transform: translate(0, 8%) scaleY(0.9);
+  }
+  46% {
+    transform: translate(-8%, 2%);
+  }
+  61% {
+    transform: scale(0.88, 1.1);
+  }
+  76% {
+    transform: translateY(-7%) scaleY(1.08);
+  }
+  88% {
+    transform: translateY(6%) scale(1.08, 0.86);
+  }
+}
+
+@keyframes rakazo-organic-eyes-loop-2 {
+  0%,
+  100% {
+    transform: scale(0.9, 1.08);
+  }
+  20% {
+    transform: scale(1.14, 0.84);
+  }
+  24% {
+    transform: scale(1.08, 0.08);
+  }
+  28% {
+    transform: scale(1.02);
+  }
+  45% {
+    transform: translate(-9%, -3%) scaleY(0.94);
+  }
+  62% {
+    transform: translate(9%, 2%) scaleY(1.05);
+  }
+  80% {
+    transform: translate(0, -8%) scale(1.06);
+  }
+}
+
+@keyframes rakazo-organic-eyes-loop-3 {
+  0%,
+  100% {
+    transform: translateY(7%) scaleY(0.9);
+  }
+  14% {
+    transform: translateY(-9%) scaleY(1.08);
+  }
+  30% {
+    transform: translate(8%, -2%);
+  }
+  47% {
+    transform: translate(-8%, 3%) scaleY(0.94);
+  }
+  63% {
+    transform: scale(1.12, 0.82);
+  }
+  78% {
+    transform: translate(0, -7%) scale(0.9, 1.08);
+  }
+  91% {
+    transform: translate(0, 5%) scale(1.06, 0.9);
   }
 }
 
@@ -178,7 +418,10 @@
     display: none;
   }
 
-  .rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-eyes {
+  .rakazo-organic-avatar[data-working="true"][data-shape-family] .rakazo-organic-avatar-body,
+  .rakazo-organic-avatar[data-working="false"] .rakazo-organic-avatar-body,
+  .rakazo-organic-avatar[data-working="true"][data-eye-pattern] .rakazo-organic-avatar-eyes,
+  .rakazo-organic-avatar[data-working="false"][data-eye-pattern] .rakazo-organic-avatar-eyes {
     animation: none;
   }
 

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -28,23 +28,23 @@
   animation: rakazo-organic-idle 5.6s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-eye-pattern="0"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-working="false"][data-eye-pattern="0"] .rakazo-organic-avatar-eyes {
   animation: rakazo-eyes-idle-0 5.8s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-eye-pattern="1"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-working="false"][data-eye-pattern="1"] .rakazo-organic-avatar-eyes {
   animation: rakazo-eyes-idle-1 6.4s ease-in-out -1.7s infinite;
 }
 
-.rakazo-organic-avatar[data-eye-pattern="2"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-working="false"][data-eye-pattern="2"] .rakazo-organic-avatar-eyes {
   animation: rakazo-eyes-idle-2 5.2s ease-in-out -3.1s infinite;
 }
 
-.rakazo-organic-avatar[data-eye-pattern="3"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-working="false"][data-eye-pattern="3"] .rakazo-organic-avatar-eyes {
   animation: rakazo-eyes-idle-3 6.8s ease-in-out -2.3s infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-working="true"][data-eye-pattern="0"] .rakazo-organic-avatar-eyes {
   animation: rakazo-organic-eyes-loop-0 6.6s ease-in-out infinite;
 }
 

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -414,8 +414,8 @@
     animation: none;
   }
 
-  .rakazo-organic-avatar-body animate {
-    display: none;
+  .rakazo-organic-avatar-body {
+    d: var(--rakazo-organic-path);
   }
 
   .rakazo-organic-avatar[data-working="true"][data-shape-family] .rakazo-organic-avatar-body,


### PR DESCRIPTION
## Summary

- replace the four coarse organic silhouettes with ten smooth generated families
- add subtle idle breathing and seeded glance/blink loops
- give working avatars shape-aware body motion and varied mixed eye reels
- preserve reduced-motion behavior and leave the existing robot avatars unchanged

## Verification

- `pnpm test` (1530 passed, 82 skipped)
- `pnpm check` (20 tasks passed)
- `pnpm lint`
- `pnpm build` with local build-only auth placeholders
- independent GPT-5.6 SOL High review, including forced reduced-motion browser checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organic avatars now offer greater visual variety across ten distinct, smoothly shaped families and multiple eye patterns.
  * Avatar animations vary by shape, eye pattern, and working state for more dynamic behavior.
  * Reduced-motion preferences now consistently disable organic avatar animations while preserving the avatar’s appearance.

* **Tests**
  * Added coverage for avatar shape families, eye patterns, working states, and animation attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->