### PR TITLE
Allow Tailscale server URLs in mobile app

### DIFF
--- a/apps/mobile/lib/endpoint.test.ts
+++ b/apps/mobile/lib/endpoint.test.ts
@@ -53,6 +53,9 @@ describe("display and warnings", () => {
     expect(apiBaseWarning("https://app.example.com")).toBeNull();
     expect(apiBaseWarning("http://127.0.0.1:3100")).toBeNull();
     expect(apiBaseWarning("http://192.168.1.20:3100")).toBeNull();
+    expect(apiBaseWarning("http://100.64.0.1:3100")).toBeNull();
+    expect(apiBaseWarning("http://100.119.57.55:3100")).toBeNull();
+    expect(apiBaseWarning("http://100.127.255.255:3100")).toBeNull();
     expect(apiBaseWarning("http://app.example.com")).toMatch(/https/i);
   });
 

--- a/apps/mobile/lib/endpoint.ts
+++ b/apps/mobile/lib/endpoint.ts
@@ -96,5 +96,6 @@ function isLanOrLocalHost(hostname: string) {
   if (/^10(?:\.\d{1,3}){3}$/.test(host)) return true;
   if (/^192\.168(?:\.\d{1,3}){2}$/.test(host)) return true;
   if (/^172\.(1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2}$/.test(host)) return true;
+  if (/^100\.(6[4-9]|[7-9]\d|1[0-1]\d|12[0-7])(?:\.\d{1,3}){2}$/.test(host)) return true;
   return false;
 }


### PR DESCRIPTION
## Summary\n- treat Tailscale CGNAT addresses as valid local/self-hosted endpoints\n- add coverage for the full 100.64.0.0/10 range\n\n## Verification\n- pnpm --filter @rakazo/mobile test\n- 76 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP API addresses in the `100.64.0.0/10` range are now correctly recognized as local or safe connections.

* **Tests**
  * Added coverage to verify the updated address handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->