### PR TITLE
Settings software update via Compose updater sidecar

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -252,6 +252,9 @@ export async function createApp(
       webOrigin: env.webOrigin,
       screenProxySecret: env.authSecret,
       sandboxProvider: env.sandboxProvider,
+      gitSha: env.gitSha,
+      updaterUrl: env.updaterUrl,
+      updaterToken: env.updaterToken,
     },
   });
   const rpc = new RPCHandler(router);

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -255,6 +255,7 @@ export async function createApp(
       gitSha: env.gitSha,
       updaterUrl: env.updaterUrl,
       updaterToken: env.updaterToken,
+      imageTag: env.imageTag,
     },
   });
   const rpc = new RPCHandler(router);

--- a/apps/api/src/env.test.ts
+++ b/apps/api/src/env.test.ts
@@ -92,4 +92,16 @@ describe("loadEnv", () => {
     expect(loadEnv({ ...base, GIT_SHA: "  3c6e209  " }).gitSha).toBe("3c6e209");
     expect(loadEnv({ ...base, RAKAZO_GIT_SHA: "abc1234" }).gitSha).toBe("abc1234");
   });
+
+  it("loads optional updater sidecar wiring without requiring the token at boot", () => {
+    expect(loadEnv(base).updaterUrl).toBeUndefined();
+    expect(loadEnv(base).updaterToken).toBeUndefined();
+    const env = loadEnv({
+      ...base,
+      RAKAZO_UPDATER_URL: " http://updater:7092 ",
+      RAKAZO_UPDATER_TOKEN: " fake-review-updater-token-000000000000 ",
+    });
+    expect(env.updaterUrl).toBe("http://updater:7092");
+    expect(env.updaterToken).toBe("fake-review-updater-token-000000000000");
+  });
 });

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -35,11 +35,17 @@ export interface AppEnv {
   mcpStdioAllowedCommands: string[];
   port: number;
   gitSha: string | undefined;
+  /** Private Compose control-network URL for the opt-in updater sidecar. */
+  updaterUrl: string | undefined;
+  /** Bearer shared with the updater; never sent to the browser. */
+  updaterToken: string | undefined;
 }
 
 export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
   const authSecret = resolveAuthSecret(source);
   const deploymentModel = resolveDeploymentModel(source);
+  const updaterUrl = optional(source.RAKAZO_UPDATER_URL);
+  const updaterToken = optional(source.RAKAZO_UPDATER_TOKEN);
   return {
     databaseUrl: required(source, "DATABASE_URL"),
     realtimeDatabaseUrl: source.REALTIME_DATABASE_URL ?? required(source, "DATABASE_URL"),
@@ -79,6 +85,8 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
       .filter(Boolean),
     port: Number(source.API_PORT ?? 3100),
     gitSha: optional(source.GIT_SHA) ?? optional(source.RAKAZO_GIT_SHA),
+    updaterUrl,
+    updaterToken,
   };
 }
 

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -39,6 +39,8 @@ export interface AppEnv {
   updaterUrl: string | undefined;
   /** Bearer shared with the updater; never sent to the browser. */
   updaterToken: string | undefined;
+  /** Current application image tag; used for compose manual-upgrade command selection. */
+  imageTag: string | undefined;
 }
 
 export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
@@ -87,6 +89,7 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     gitSha: optional(source.GIT_SHA) ?? optional(source.RAKAZO_GIT_SHA),
     updaterUrl,
     updaterToken,
+    imageTag: optional(source.RAKAZO_IMAGE_TAG),
   };
 }
 

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -288,3 +288,105 @@ describe("connections.complete", () => {
     expect(connectionReady).toHaveBeenCalled();
   });
 });
+
+describe("updater owner gate", () => {
+  function updaterDeps() {
+    const prisma = {
+      user: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          email: "user@rakazo.test",
+          name: "Test User",
+          avatarStyle: "robot",
+        }),
+      },
+      userModelCredential: { findFirst: vi.fn().mockResolvedValue(null) },
+      deploymentSettings: { findUnique: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+    const deps = {
+      prisma,
+      env: {
+        defaultProvider: "fake",
+        defaultModel: "fake-model",
+        webOrigin: "http://127.0.0.1:5173",
+        screenProxySecret: "fake-test-secret",
+        sandboxProvider: "fake",
+        gitSha: "deadbeef",
+        updaterUrl: undefined,
+        updaterToken: undefined,
+      },
+      dataDir: "/tmp/rakazo-router-test",
+    } as unknown as RouterDeps;
+    return { deps, handler: new RPCHandler(createRouter(deps)) };
+  }
+
+  it("forbids non-owners from updater status", async () => {
+    const { handler } = updaterDeps();
+    const actor = {
+      workspaceId: "workspace-1",
+      userId: "user-2",
+      email: "member@rakazo.test",
+      isDeploymentOwner: false,
+    } satisfies Actor;
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/updater/status", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: null }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("lets the deployment owner read status without applying git", async () => {
+    const { handler } = updaterDeps();
+    const actor = {
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      email: "owner@rakazo.test",
+      isDeploymentOwner: true,
+    } satisfies Actor;
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/updater/status", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: null }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.json.supported).toBe(false);
+    expect(["source", "compose"]).toContain(body.json.installKind);
+    expect(Array.isArray(body.json.manualCommands)).toBe(true);
+  });
+
+  it("refuses apply when the sidecar is not configured", async () => {
+    const { handler } = updaterDeps();
+    const actor = {
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      email: "owner@rakazo.test",
+      isDeploymentOwner: true,
+    } satisfies Actor;
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/updater/apply", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: {} }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    const body = await response.json();
+    const message = JSON.stringify(body);
+    expect(message).toMatch(/sidecar/i);
+    expect(message).not.toMatch(/git (fetch|merge|pull)/i);
+  });
+});

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -116,7 +116,6 @@ import {
   applyServerUpdate,
   checkServerUpdate,
   readServerUpdateStatus,
-  rollbackServerUpdate,
   type UpdaterProxyConfig,
   UpdaterProxyError,
 } from "./server-update.js";
@@ -421,14 +420,6 @@ export function createRouter(deps: RouterDeps) {
         if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
         try {
           return await applyServerUpdate(updaterConfig(deps), input);
-        } catch (error) {
-          mapUpdaterError(error);
-        }
-      }),
-      rollback: authed.updater.rollback.handler(async ({ context }) => {
-        if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
-        try {
-          return await rollbackServerUpdate(updaterConfig(deps));
         } catch (error) {
           mapUpdaterError(error);
         }

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -318,6 +318,7 @@ export interface RouterDeps {
     gitSha?: string;
     updaterUrl?: string;
     updaterToken?: string;
+    imageTag?: string;
   };
 }
 
@@ -2957,6 +2958,7 @@ function updaterConfig(deps: RouterDeps): UpdaterProxyConfig {
     url: deps.env.updaterUrl ?? null,
     token: deps.env.updaterToken ?? null,
     gitSha: deps.env.gitSha,
+    imageTag: deps.env.imageTag ?? null,
   };
 }
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -112,6 +112,14 @@ import { listWorkspaceRuns } from "./runs.js";
 import { addScreenProxyCapability } from "./screen-proxy.js";
 import { queryWorkspaceSearch } from "./search.js";
 import { withSerializableRetry } from "./serializable-retry.js";
+import {
+  applyServerUpdate,
+  checkServerUpdate,
+  readServerUpdateStatus,
+  rollbackServerUpdate,
+  type UpdaterProxyConfig,
+  UpdaterProxyError,
+} from "./server-update.js";
 import { assertTeachingSendAllowed, createTaughtSkillsService } from "./taught-skills.js";
 import { loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
 import {
@@ -307,6 +315,9 @@ export interface RouterDeps {
     webOrigin: string;
     screenProxySecret: string;
     sandboxProvider: string;
+    gitSha?: string;
+    updaterUrl?: string;
+    updaterToken?: string;
   };
 }
 
@@ -390,6 +401,36 @@ export function createRouter(deps: RouterDeps) {
           },
         });
         return deploymentDto(deps.prisma, deps.env.sandboxProvider);
+      }),
+    },
+    updater: {
+      status: authed.updater.status.handler(async ({ context }) => {
+        if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
+        return readServerUpdateStatus(updaterConfig(deps));
+      }),
+      check: authed.updater.check.handler(async ({ context, input }) => {
+        if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
+        try {
+          return await checkServerUpdate(updaterConfig(deps), input);
+        } catch (error) {
+          mapUpdaterError(error);
+        }
+      }),
+      apply: authed.updater.apply.handler(async ({ context, input }) => {
+        if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
+        try {
+          return await applyServerUpdate(updaterConfig(deps), input);
+        } catch (error) {
+          mapUpdaterError(error);
+        }
+      }),
+      rollback: authed.updater.rollback.handler(async ({ context }) => {
+        if (!context.actor.isDeploymentOwner) throw new ORPCError("FORBIDDEN");
+        try {
+          return await rollbackServerUpdate(updaterConfig(deps));
+        } catch (error) {
+          mapUpdaterError(error);
+        }
       }),
     },
     models: {
@@ -2908,6 +2949,29 @@ export function createRouter(deps: RouterDeps) {
         prepareVoice(deps, context.actor, input),
       ),
     },
+  });
+}
+
+function updaterConfig(deps: RouterDeps): UpdaterProxyConfig {
+  return {
+    url: deps.env.updaterUrl ?? null,
+    token: deps.env.updaterToken ?? null,
+    gitSha: deps.env.gitSha,
+  };
+}
+
+function mapUpdaterError(error: unknown): never {
+  if (error instanceof UpdaterProxyError) {
+    if (error.status === 401 || error.status === 403) {
+      throw new ORPCError("FORBIDDEN", { message: error.message });
+    }
+    if (error.status >= 500) {
+      throw new ORPCError("INTERNAL_SERVER_ERROR", { message: error.message });
+    }
+    throw new ORPCError("BAD_REQUEST", { message: error.message });
+  }
+  throw new ORPCError("INTERNAL_SERVER_ERROR", {
+    message: error instanceof Error ? error.message : "Update failed.",
   });
 }
 

--- a/apps/api/src/server-update.test.ts
+++ b/apps/api/src/server-update.test.ts
@@ -120,6 +120,67 @@ describe("server update install kind", () => {
     expect(status.canRollback).toBe(true);
     expect(status.manualCommands).toEqual([]);
     expect(status.imageTag).toMatch(/^sha-/);
+    expect(status.lastRun).toBeNull();
+  });
+
+  it("surfaces a finished sidecar lastRun for recreate confirmation", async () => {
+    const root = await tempRoot(false);
+    const lastRun = {
+      startedAt: "2026-08-27T21:00:00.000Z",
+      finishedAt: "2026-08-27T21:01:00.000Z",
+      ok: false,
+      fromCommit: null,
+      toCommit: null,
+      fromTag: "sha-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      toTag: "sha-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      strategy: "pull",
+      repoUrl: "https://github.com/elie222/rakazo",
+      branch: "main",
+      restart: "not-required",
+      restartAdvice: "Recreate failed; prior image restored, env pin not restored.",
+      error: "Recreate the stack failed.",
+      steps: [],
+    };
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const href = String(input);
+      if (href.endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (href.endsWith("/state")) {
+        return new Response(
+          JSON.stringify({
+            image: "ghcr.io/elie222/rakazo/app",
+            currentTag: "sha-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            previousTag: "sha-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            running: false,
+            lastRun,
+            checkout: {
+              present: true,
+              commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              branch: "main",
+              remoteUrl: "https://github.com/elie222/rakazo",
+              dirty: false,
+              dirtyPaths: [],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("missing", { status: 404 });
+    });
+    const status = await readServerUpdateStatus({
+      url: URL,
+      token: TOKEN,
+      gitSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      checkoutRoot: root,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    expect(status.lastRun).toMatchObject({
+      ok: false,
+      fromTag: "sha-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      toTag: "sha-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      error: "Recreate the stack failed.",
+    });
   });
 });
 

--- a/apps/api/src/server-update.test.ts
+++ b/apps/api/src/server-update.test.ts
@@ -8,7 +8,6 @@ import {
   checkServerUpdate,
   isUpdaterConfigured,
   readServerUpdateStatus,
-  rollbackServerUpdate,
   type UpdaterProxyConfig,
   UpdaterProxyError,
 } from "./server-update.js";
@@ -234,7 +233,7 @@ describe("sidecar proxy auth and no-git-apply", () => {
     expect(JSON.stringify(check)).not.toContain(TOKEN);
   });
 
-  it("rejects check/apply/rollback when the sidecar is off (no git apply path)", async () => {
+  it("rejects check/apply when the sidecar is off (no git apply path)", async () => {
     const config: UpdaterProxyConfig = {
       url: null,
       token: null,
@@ -245,7 +244,6 @@ describe("sidecar proxy auth and no-git-apply", () => {
     await expect(applyServerUpdate(config)).rejects.toMatchObject({
       message: expect.stringMatching(/sidecar/i),
     });
-    await expect(rollbackServerUpdate(config)).rejects.toBeInstanceOf(UpdaterProxyError);
     expect(assertNoGitApplyPath).toBeTypeOf("function");
     expect(() => assertNoGitApplyPath("source")).toThrow(/cannot apply/);
     expect(() => assertNoGitApplyPath("compose")).toThrow(/cannot apply/);

--- a/apps/api/src/server-update.test.ts
+++ b/apps/api/src/server-update.test.ts
@@ -50,6 +50,7 @@ describe("server update install kind", () => {
       url: URL,
       token: TOKEN,
       gitSha: "abc",
+      imageTag: "sha-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       checkoutRoot: root,
       fetch: vi.fn(async () => {
         throw new Error("ECONNREFUSED");
@@ -59,6 +60,24 @@ describe("server update install kind", () => {
     expect(status.supported).toBe(false);
     expect(status.manualCommands[0]).toMatch(/docker compose .*pull api worker web/);
     expect(status.manualCommands[1]).toMatch(/up -d --wait --pull never/);
+  });
+
+  it("shows rebuild commands for a compose install on the local image tag", async () => {
+    const root = await tempRoot(false);
+    const status = await readServerUpdateStatus({
+      url: URL,
+      token: TOKEN,
+      gitSha: "abc",
+      imageTag: "local",
+      checkoutRoot: root,
+      fetch: vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    });
+    expect(status.installKind).toBe("compose");
+    expect(status.manualCommands.some((line) => line.includes("--build"))).toBe(true);
+    expect(status.manualCommands.some((line) => line.includes("git pull"))).toBe(true);
+    expect(status.manualCommands.some((line) => /\bpull api worker web\b/.test(line))).toBe(false);
   });
 
   it("detects sidecar when health and authenticated state succeed", async () => {

--- a/apps/api/src/server-update.test.ts
+++ b/apps/api/src/server-update.test.ts
@@ -1,0 +1,196 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyServerUpdate,
+  assertNoGitApplyPath,
+  checkServerUpdate,
+  isUpdaterConfigured,
+  readServerUpdateStatus,
+  rollbackServerUpdate,
+  type UpdaterProxyConfig,
+  UpdaterProxyError,
+} from "./server-update.js";
+
+const TOKEN = "fake-review-updater-token-000000000000";
+const URL = "http://updater:7092";
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("server update install kind", () => {
+  async function tempRoot(withGit: boolean) {
+    const root = await mkdtemp(path.join(tmpdir(), "rakazo-update-"));
+    roots.push(root);
+    if (withGit) await mkdir(path.join(root, ".git"));
+    return root;
+  }
+
+  it("detects a source checkout when the sidecar is not wired", async () => {
+    const root = await tempRoot(true);
+    const status = await readServerUpdateStatus({
+      url: null,
+      token: null,
+      gitSha: "abc",
+      checkoutRoot: root,
+      fetch: vi.fn(),
+    });
+    expect(status.installKind).toBe("source");
+    expect(status.supported).toBe(false);
+    expect(status.manualCommands.some((line) => line.includes("git pull"))).toBe(true);
+    expect(status.manualCommands.some((line) => line.includes("migrate"))).toBe(true);
+  });
+
+  it("detects compose-without-sidecar when the updater URL is set but unreachable", async () => {
+    const root = await tempRoot(false);
+    const status = await readServerUpdateStatus({
+      url: URL,
+      token: TOKEN,
+      gitSha: "abc",
+      checkoutRoot: root,
+      fetch: vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    });
+    expect(status.installKind).toBe("compose");
+    expect(status.supported).toBe(false);
+    expect(status.manualCommands[0]).toMatch(/docker compose .*pull api worker web/);
+    expect(status.manualCommands[1]).toMatch(/up -d --wait --pull never/);
+  });
+
+  it("detects sidecar when health and authenticated state succeed", async () => {
+    const root = await tempRoot(false);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const href = String(input);
+      if (href.endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (href.endsWith("/state")) {
+        return new Response(
+          JSON.stringify({
+            image: "ghcr.io/elie222/rakazo/app",
+            currentTag: "sha-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            previousTag: "sha-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            running: false,
+            checkout: {
+              present: true,
+              commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              branch: "main",
+              remoteUrl: "https://github.com/elie222/rakazo",
+              dirty: false,
+              dirtyPaths: [],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("missing", { status: 404 });
+    });
+    const status = await readServerUpdateStatus({
+      url: URL,
+      token: TOKEN,
+      gitSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      checkoutRoot: root,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    expect(status.installKind).toBe("sidecar");
+    expect(status.supported).toBe(true);
+    expect(status.canRollback).toBe(true);
+    expect(status.manualCommands).toEqual([]);
+    expect(status.imageTag).toMatch(/^sha-/);
+  });
+});
+
+describe("sidecar proxy auth and no-git-apply", () => {
+  it("requires both URL and token before claiming the sidecar is configured", () => {
+    expect(isUpdaterConfigured({ url: URL, token: null, gitSha: undefined })).toBe(false);
+    expect(isUpdaterConfigured({ url: null, token: TOKEN, gitSha: undefined })).toBe(false);
+    expect(isUpdaterConfigured({ url: URL, token: TOKEN, gitSha: undefined })).toBe(true);
+  });
+
+  it("sends the bearer token to the sidecar and never returns it", async () => {
+    const authHeaders: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const href = String(input);
+      const headers = new Headers(init?.headers);
+      const authorization = headers.get("authorization");
+      if (authorization) authHeaders.push(authorization);
+      if (href.endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (href.endsWith("/state")) {
+        return new Response(JSON.stringify({ running: false, currentTag: "local" }), {
+          status: 200,
+        });
+      }
+      if (href.endsWith("/plan")) {
+        return new Response(
+          JSON.stringify({
+            upToDate: false,
+            targetCommit: "cccccccccccccccccccccccccccccccccccccccc",
+            targetTag: "sha-cccccccccccccccccccccccccccccccccccccccc",
+            checkout: { commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", dirty: false },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+    });
+    const root = await mkdtemp(path.join(tmpdir(), "rakazo-proxy-"));
+    roots.push(root);
+    const config: UpdaterProxyConfig = {
+      url: URL,
+      token: TOKEN,
+      gitSha: undefined,
+      checkoutRoot: root,
+      fetch: fetchImpl as unknown as typeof fetch,
+    };
+    const check = await checkServerUpdate(config);
+    expect(check.status).toBe("available");
+    expect(authHeaders).toContain(`Bearer ${TOKEN}`);
+    expect(JSON.stringify(check)).not.toContain(TOKEN);
+  });
+
+  it("rejects check/apply/rollback when the sidecar is off (no git apply path)", async () => {
+    const config: UpdaterProxyConfig = {
+      url: null,
+      token: null,
+      gitSha: undefined,
+      fetch: vi.fn(),
+    };
+    await expect(checkServerUpdate(config)).rejects.toBeInstanceOf(UpdaterProxyError);
+    await expect(applyServerUpdate(config)).rejects.toMatchObject({
+      message: expect.stringMatching(/sidecar/i),
+    });
+    await expect(rollbackServerUpdate(config)).rejects.toBeInstanceOf(UpdaterProxyError);
+    expect(assertNoGitApplyPath).toBeTypeOf("function");
+    expect(() => assertNoGitApplyPath("source")).toThrow(/cannot apply/);
+    expect(() => assertNoGitApplyPath("compose")).toThrow(/cannot apply/);
+    expect(() => assertNoGitApplyPath("sidecar")).not.toThrow();
+  });
+
+  it("maps a 401 from the sidecar without exposing the token", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const href = String(input);
+      if (href.endsWith("/health")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
+    });
+    const config: UpdaterProxyConfig = {
+      url: URL,
+      token: TOKEN,
+      gitSha: undefined,
+      fetch: fetchImpl as unknown as typeof fetch,
+    };
+    await expect(applyServerUpdate(config)).rejects.toMatchObject({
+      message: expect.stringMatching(/credential|reachable|sidecar/i),
+    });
+    await expect(applyServerUpdate(config)).rejects.not.toMatchObject({
+      message: expect.stringContaining(TOKEN),
+    });
+  });
+});

--- a/apps/api/src/server-update.ts
+++ b/apps/api/src/server-update.ts
@@ -6,6 +6,7 @@ import type {
   ServerUpdateRun,
   ServerUpdateStatus,
 } from "@rakazo/contracts";
+import { ServerUpdateRunSchema } from "@rakazo/contracts";
 import {
   DEFAULT_UPDATE_BRANCH,
   detectRestartSupervisor,
@@ -138,6 +139,7 @@ export async function readServerUpdateStatus(
       currentTag?: string;
       previousTag?: string | null;
       running?: boolean;
+      lastRun?: unknown;
       checkout?: {
         present?: boolean;
         commit?: string | null;
@@ -150,6 +152,7 @@ export async function readServerUpdateStatus(
 
     const remoteUrl = state.checkout?.remoteUrl ?? null;
     const official = remoteUrl ? isOfficialRepoUrl(remoteUrl) : true;
+    const parsedLastRun = ServerUpdateRunSchema.safeParse(state.lastRun);
     return {
       ...base,
       supported: true,
@@ -176,6 +179,7 @@ export async function readServerUpdateStatus(
         official,
       },
       running: state.running === true,
+      lastRun: parsedLastRun.success ? parsedLastRun.data : null,
     };
   } catch (error) {
     return {

--- a/apps/api/src/server-update.ts
+++ b/apps/api/src/server-update.ts
@@ -1,0 +1,347 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
+import type {
+  ServerUpdateCheck,
+  ServerUpdateRequest,
+  ServerUpdateRun,
+  ServerUpdateStatus,
+} from "@rakazo/contracts";
+import {
+  DEFAULT_UPDATE_BRANCH,
+  detectRestartSupervisor,
+  isOfficialRepoUrl,
+  manualUpgradeCommands,
+  OFFICIAL_REPO_URL,
+  OFFICIAL_SERVER_IMAGE,
+  resolveInstallKind,
+  restartSupervisorAdvice,
+} from "@rakazo/core";
+
+const PRODUCT_VERSION = "0.1.0";
+const STATE_TIMEOUT_MS = 15_000;
+const PLAN_TIMEOUT_MS = 180_000;
+const APPLY_TIMEOUT_MS = 2_100_000;
+
+export interface UpdaterProxyConfig {
+  url: string | null;
+  token: string | null;
+  gitSha: string | undefined;
+  disabled?: boolean;
+  /** Override for tests; defaults to process.cwd(). */
+  checkoutRoot?: string;
+  fetch?: typeof fetch;
+}
+
+export class UpdaterProxyError extends Error {
+  constructor(
+    message: string,
+    readonly status: number = 400,
+  ) {
+    super(message);
+    this.name = "UpdaterProxyError";
+  }
+}
+
+/** True only when the API can authenticate to the sidecar. The token never leaves this process. */
+export function isUpdaterConfigured(config: UpdaterProxyConfig): boolean {
+  return Boolean(config.url?.trim() && config.token?.trim());
+}
+
+export async function hasGitCheckout(root: string): Promise<boolean> {
+  try {
+    await access(path.join(root, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function probeSidecar(config: UpdaterProxyConfig, fetchImpl: typeof fetch): Promise<boolean> {
+  if (!isUpdaterConfigured(config) || !config.url || !config.token) return false;
+  try {
+    const response = await fetchImpl(new URL("/health", ensureTrailingSlash(config.url)), {
+      method: "GET",
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) return false;
+    // Confirm the bearer works: /health is open, so a wrong token would still look "up".
+    const state = await fetchImpl(new URL("/state", ensureTrailingSlash(config.url)), {
+      method: "GET",
+      headers: { authorization: `Bearer ${config.token}` },
+      signal: AbortSignal.timeout(5_000),
+    });
+    return state.ok;
+  } catch {
+    return false;
+  }
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+export async function readServerUpdateStatus(
+  config: UpdaterProxyConfig,
+): Promise<ServerUpdateStatus> {
+  const fetchImpl = config.fetch ?? fetch;
+  const checkoutRoot = config.checkoutRoot ?? process.cwd();
+  const hasCheckout = await hasGitCheckout(checkoutRoot);
+  const urlConfigured = Boolean(config.url?.trim());
+  const reachable = await probeSidecar(config, fetchImpl);
+  const install = resolveInstallKind({
+    updaterUrlConfigured: urlConfigured,
+    updaterReachable: reachable,
+    hasCheckout,
+    disabled: config.disabled === true,
+  });
+  const supervisor = detectRestartSupervisor(process.env);
+  const base: ServerUpdateStatus = {
+    supported: install.kind === "sidecar",
+    unsupportedReason: install.kind === "sidecar" ? null : install.reason,
+    installKind: install.kind,
+    manualCommands: [...manualUpgradeCommands(install.kind)],
+    mode: install.mode,
+    strategy: null,
+    strategyNote: null,
+    version: PRODUCT_VERSION,
+    revision: config.gitSha ?? null,
+    commit: config.gitSha ?? null,
+    branch: null,
+    remoteUrl: null,
+    dirty: false,
+    dirtyPaths: [],
+    image: null,
+    imageTag: null,
+    previousImageTag: null,
+    canRollback: false,
+    source: {
+      repoUrl: OFFICIAL_REPO_URL,
+      branch: DEFAULT_UPDATE_BRANCH,
+      official: true,
+    },
+    officialRepoUrl: OFFICIAL_REPO_URL,
+    restartSupervisor: supervisor.kind,
+    restartAdvice: restartSupervisorAdvice(supervisor),
+    running: false,
+    lastRun: null,
+  };
+
+  if (install.kind !== "sidecar" || !config.url || !config.token) return base;
+
+  try {
+    const state = await sidecarJson<{
+      image?: string;
+      imageRef?: string;
+      currentTag?: string;
+      previousTag?: string | null;
+      running?: boolean;
+      checkout?: {
+        present?: boolean;
+        commit?: string | null;
+        branch?: string | null;
+        remoteUrl?: string | null;
+        dirty?: boolean;
+        dirtyPaths?: string[];
+      };
+    }>(config, fetchImpl, "GET", "/state", undefined, STATE_TIMEOUT_MS);
+
+    const remoteUrl = state.checkout?.remoteUrl ?? null;
+    const official = remoteUrl ? isOfficialRepoUrl(remoteUrl) : true;
+    return {
+      ...base,
+      supported: true,
+      unsupportedReason: null,
+      strategy: official ? "pull" : "build",
+      strategyNote: official
+        ? "Official releases pull the published image."
+        : "This fork builds on the server.",
+      commit: state.checkout?.commit ?? base.commit,
+      branch: state.checkout?.branch ?? null,
+      remoteUrl,
+      dirty: state.checkout?.dirty === true,
+      dirtyPaths: state.checkout?.dirtyPaths ?? [],
+      image: state.image ?? OFFICIAL_SERVER_IMAGE,
+      imageTag: state.currentTag ?? null,
+      previousImageTag: state.previousTag ?? null,
+      canRollback: Boolean(state.previousTag),
+      source: {
+        repoUrl:
+          remoteUrl && isOfficialRepoUrl(remoteUrl)
+            ? OFFICIAL_REPO_URL
+            : (remoteUrl ?? OFFICIAL_REPO_URL),
+        branch: state.checkout?.branch ?? DEFAULT_UPDATE_BRANCH,
+        official,
+      },
+      running: state.running === true,
+    };
+  } catch (error) {
+    return {
+      ...base,
+      supported: false,
+      unsupportedReason:
+        error instanceof Error ? error.message : "The updater sidecar did not respond.",
+      installKind: "compose",
+      mode: "unavailable",
+      manualCommands: [...manualUpgradeCommands("compose")],
+    };
+  }
+}
+
+export async function checkServerUpdate(
+  config: UpdaterProxyConfig,
+  input: ServerUpdateRequest = {},
+): Promise<ServerUpdateCheck> {
+  await requireSidecar(config);
+  const fetchImpl = config.fetch ?? fetch;
+  const plan = await sidecarJson<{
+    upToDate?: boolean;
+    reason?: string;
+    targetCommit?: string | null;
+    targetTag?: string | null;
+    checkout?: { commit?: string | null; dirty?: boolean; dirtyPaths?: string[] };
+  }>(config, fetchImpl, "POST", "/plan", requestBody(input), PLAN_TIMEOUT_MS);
+
+  if (plan.checkout?.dirty === true) {
+    return {
+      status: "dirty",
+      reason: "The deployment checkout has local changes.",
+      changed: plan.checkout.dirtyPaths ?? [],
+      commit: plan.checkout.commit ?? null,
+      targetCommit: plan.targetCommit ?? null,
+      targetTag: plan.targetTag ?? null,
+      behindBy: 0,
+    };
+  }
+  if (plan.upToDate === true) {
+    return {
+      status: "up-to-date",
+      reason: plan.reason ?? null,
+      changed: [],
+      commit: plan.checkout?.commit ?? null,
+      targetCommit: plan.targetCommit ?? null,
+      targetTag: plan.targetTag ?? null,
+      behindBy: 0,
+    };
+  }
+  return {
+    status: "available",
+    reason: plan.reason ?? null,
+    changed: [],
+    commit: plan.checkout?.commit ?? null,
+    targetCommit: plan.targetCommit ?? null,
+    targetTag: plan.targetTag ?? null,
+    behindBy:
+      plan.targetCommit && plan.checkout?.commit && plan.targetCommit !== plan.checkout.commit
+        ? 1
+        : 0,
+  };
+}
+
+export async function applyServerUpdate(
+  config: UpdaterProxyConfig,
+  input: ServerUpdateRequest = {},
+): Promise<ServerUpdateRun> {
+  await requireSidecar(config);
+  const fetchImpl = config.fetch ?? fetch;
+  return sidecarJson<ServerUpdateRun>(
+    config,
+    fetchImpl,
+    "POST",
+    "/apply",
+    requestBody(input),
+    APPLY_TIMEOUT_MS,
+  );
+}
+
+export async function rollbackServerUpdate(config: UpdaterProxyConfig): Promise<ServerUpdateRun> {
+  await requireSidecar(config);
+  const fetchImpl = config.fetch ?? fetch;
+  return sidecarJson<ServerUpdateRun>(
+    config,
+    fetchImpl,
+    "POST",
+    "/rollback",
+    undefined,
+    APPLY_TIMEOUT_MS,
+  );
+}
+
+/**
+ * Hard gate: Settings apply/rollback/check never run git (or anything else) inside the API.
+ * Only the updater sidecar holds the Docker socket and outlives a recreate.
+ */
+async function requireSidecar(config: UpdaterProxyConfig): Promise<void> {
+  if (config.disabled === true) {
+    throw new UpdaterProxyError("Self-update is switched off for this deployment.");
+  }
+  if (!isUpdaterConfigured(config)) {
+    throw new UpdaterProxyError(
+      "The updater sidecar is not configured. Use the host Compose commands, or enable the updater profile.",
+    );
+  }
+  const fetchImpl = config.fetch ?? fetch;
+  if (!(await probeSidecar(config, fetchImpl))) {
+    throw new UpdaterProxyError(
+      "The updater sidecar is not reachable. Start the opt-in updater profile, or upgrade from the host.",
+    );
+  }
+}
+
+function requestBody(input: ServerUpdateRequest): Record<string, string> {
+  const body: Record<string, string> = {};
+  if (input.repoUrl?.trim()) body.repoUrl = input.repoUrl.trim();
+  if (input.branch?.trim()) body.branch = input.branch.trim();
+  return body;
+}
+
+async function sidecarJson<T>(
+  config: UpdaterProxyConfig,
+  fetchImpl: typeof fetch,
+  method: string,
+  route: string,
+  body: unknown | undefined,
+  timeoutMs: number,
+): Promise<T> {
+  if (!config.url || !config.token) {
+    throw new UpdaterProxyError("The updater sidecar is not configured.");
+  }
+  let response: Response;
+  try {
+    response = await fetchImpl(new URL(route.replace(/^\//, ""), ensureTrailingSlash(config.url)), {
+      method,
+      headers: {
+        authorization: `Bearer ${config.token}`,
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    throw new UpdaterProxyError(
+      error instanceof Error ? error.message : "The updater sidecar did not respond.",
+      502,
+    );
+  }
+  const payload = (await response.json().catch(() => ({}))) as T & { error?: string };
+  if (response.status === 401) {
+    throw new UpdaterProxyError("The updater sidecar rejected the deployment credential.", 502);
+  }
+  if (!response.ok) {
+    throw new UpdaterProxyError(
+      typeof payload.error === "string" && payload.error
+        ? payload.error
+        : `Updater sidecar returned ${response.status}.`,
+      response.status >= 400 && response.status < 500 ? 400 : 502,
+    );
+  }
+  return payload;
+}
+
+/** Exported for tests that assert the API never treats a source tree as applyable. */
+export function assertNoGitApplyPath(installKind: string): void {
+  if (installKind === "source" || installKind === "compose") {
+    throw new UpdaterProxyError(
+      "Settings cannot apply updates without the updater sidecar. Use the documented host commands.",
+    );
+  }
+}

--- a/apps/api/src/server-update.ts
+++ b/apps/api/src/server-update.ts
@@ -272,26 +272,8 @@ export async function applyServerUpdate(
 }
 
 /**
- * Proxies `/rollback` to the sidecar.
- *
- * Same recreate caveat as {@link applyServerUpdate}: a successful rollback kills this process
- * mid-response, so clients must recover by polling status after a transport drop.
- */
-export async function rollbackServerUpdate(config: UpdaterProxyConfig): Promise<ServerUpdateRun> {
-  await requireSidecar(config);
-  const fetchImpl = config.fetch ?? fetch;
-  return sidecarJson<ServerUpdateRun>(
-    config,
-    fetchImpl,
-    "POST",
-    "/rollback",
-    undefined,
-    APPLY_TIMEOUT_MS,
-  );
-}
-
-/**
- * Hard gate: Settings apply/rollback/check never run git (or anything else) inside the API.
+ * Hard gate: Settings apply/check never run git (or anything else) inside the API.
+ * Sidecar `/rollback` remains for ops only and is not exposed on the owner RPC surface.
  * Only the updater sidecar holds the Docker socket and outlives a recreate.
  */
 async function requireSidecar(config: UpdaterProxyConfig): Promise<void> {

--- a/apps/api/src/server-update.ts
+++ b/apps/api/src/server-update.ts
@@ -26,6 +26,8 @@ export interface UpdaterProxyConfig {
   url: string | null;
   token: string | null;
   gitSha: string | undefined;
+  /** Current `RAKAZO_IMAGE_TAG` when known; selects compose pull vs rebuild commands. */
+  imageTag?: string | null;
   disabled?: boolean;
   /** Override for tests; defaults to process.cwd(). */
   checkoutRoot?: string;
@@ -95,11 +97,12 @@ export async function readServerUpdateStatus(
     disabled: config.disabled === true,
   });
   const supervisor = detectRestartSupervisor(process.env);
+  const imageTagHint = config.imageTag?.trim() || process.env.RAKAZO_IMAGE_TAG?.trim() || null;
   const base: ServerUpdateStatus = {
     supported: install.kind === "sidecar",
     unsupportedReason: install.kind === "sidecar" ? null : install.reason,
     installKind: install.kind,
-    manualCommands: [...manualUpgradeCommands(install.kind)],
+    manualCommands: [...manualUpgradeCommands(install.kind, { imageTag: imageTagHint })],
     mode: install.mode,
     strategy: null,
     strategyNote: null,
@@ -111,7 +114,7 @@ export async function readServerUpdateStatus(
     dirty: false,
     dirtyPaths: [],
     image: null,
-    imageTag: null,
+    imageTag: imageTagHint,
     previousImageTag: null,
     canRollback: false,
     source: {
@@ -182,7 +185,11 @@ export async function readServerUpdateStatus(
         error instanceof Error ? error.message : "The updater sidecar did not respond.",
       installKind: "compose",
       mode: "unavailable",
-      manualCommands: [...manualUpgradeCommands("compose")],
+      manualCommands: [
+        ...manualUpgradeCommands("compose", {
+          imageTag: imageTagHint,
+        }),
+      ],
     };
   }
 }
@@ -237,6 +244,13 @@ export async function checkServerUpdate(
   };
 }
 
+/**
+ * Proxies `/apply` to the sidecar.
+ *
+ * A successful recreate replaces this API container while the request is still open, so the
+ * JSON body often never reaches the browser. Clients must treat a mid-flight transport failure
+ * as "recreate in progress" and re-fetch `status` once the API is healthy again.
+ */
 export async function applyServerUpdate(
   config: UpdaterProxyConfig,
   input: ServerUpdateRequest = {},
@@ -253,6 +267,12 @@ export async function applyServerUpdate(
   );
 }
 
+/**
+ * Proxies `/rollback` to the sidecar.
+ *
+ * Same recreate caveat as {@link applyServerUpdate}: a successful rollback kills this process
+ * mid-response, so clients must recover by polling status after a transport drop.
+ */
 export async function rollbackServerUpdate(config: UpdaterProxyConfig): Promise<ServerUpdateRun> {
   await requireSidecar(config);
   const fetchImpl = config.fetch ?? fetch;

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -2,7 +2,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import type { ServerUpdateCheck, ServerUpdateStatus } from "@rakazo/contracts";
 import { useEffect, useState } from "react";
 import { rpc } from "../lib/rpc";
-import { isLikelyUpdaterRecreateDisconnect } from "../lib/updater-recreate";
+import { confirmUpdaterRecreate, isLikelyUpdaterRecreateDisconnect } from "../lib/updater-recreate";
 import { BuiButton, LoadingState, SuccessPop } from "./beautiful-ui/primitives";
 
 const RECREATE_POLL_MS = 2_000;
@@ -13,17 +13,31 @@ function shortRev(value: string | null | undefined): string | null {
   return value.length > 12 ? value.slice(0, 12) : value;
 }
 
-async function waitForUpdaterStatus(): Promise<ServerUpdateStatus> {
+async function waitForUpdaterStatus(options: {
+  beforeImageTag: string | null;
+}): Promise<{ status: ServerUpdateStatus; confirmed: boolean }> {
   let lastError: unknown;
+  let sawApi = false;
   for (let attempt = 0; attempt < RECREATE_POLL_ATTEMPTS; attempt += 1) {
     if (attempt > 0) {
       await new Promise((resolve) => setTimeout(resolve, RECREATE_POLL_MS));
     }
     try {
-      return await rpc.updater.status();
+      const next = await rpc.updater.status();
+      sawApi = true;
+      const verdict = confirmUpdaterRecreate({
+        beforeImageTag: options.beforeImageTag,
+        afterImageTag: next.imageTag,
+        running: next.running,
+      });
+      if (verdict.reason === "running") continue;
+      return { status: next, confirmed: verdict.confirmed };
     } catch (error) {
       lastError = error;
     }
+  }
+  if (sawApi) {
+    throw new Error("The updater was still running when the wait timed out.");
   }
   throw lastError instanceof Error
     ? lastError
@@ -171,6 +185,7 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
     action: () => Promise<{ ok: boolean; error: string | null }>,
     successLabel: string,
   ) {
+    const beforeImageTag = status?.imageTag ?? null;
     try {
       const run = await action();
       setStatus(await rpc.updater.status());
@@ -189,10 +204,16 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
       }
       setDone(t`Waiting for the API to come back…`);
       try {
-        setStatus(await waitForUpdaterStatus());
+        const recovered = await waitForUpdaterStatus({ beforeImageTag });
+        setStatus(recovered.status);
         setCheck(null);
-        setError(null);
-        setDone(successLabel);
+        if (recovered.confirmed) {
+          setError(null);
+          setDone(successLabel);
+        } else {
+          setDone(null);
+          setError(t`API is back, but the image tag did not change. Check the host logs.`);
+        }
       } catch (waitError) {
         setDone(null);
         setError(

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -7,15 +7,10 @@ import {
   isLikelyUpdaterRecreateDisconnect,
   recreateWaitTimeoutError,
 } from "../lib/updater-recreate";
-import { BuiButton, LoadingState, SuccessPop } from "./beautiful-ui/primitives";
+import { BuiButton, SuccessPop } from "./beautiful-ui/primitives";
 
 const RECREATE_POLL_MS = 2_000;
 const RECREATE_POLL_ATTEMPTS = 90;
-
-function shortRev(value: string | null | undefined): string | null {
-  if (!value) return null;
-  return value.length > 12 ? value.slice(0, 12) : value;
-}
 
 async function waitForUpdaterStatus(options: { beforeImageTag: string | null }): Promise<{
   status: ServerUpdateStatus;
@@ -51,86 +46,37 @@ async function waitForUpdaterStatus(options: { beforeImageTag: string | null }):
   throw recreateWaitTimeoutError({ sawApi, sawSidecar, lastError });
 }
 
-/** Presentational body so unit tests can render install-kind branches without RPC. */
+/** Presentational body for the sidecar update path (unit-testable without RPC). */
 export function SoftwareUpdatePanel({
-  status,
   check,
   busy,
   error,
   done,
   onCheck,
   onApply,
-  onRollback,
 }: {
-  status: ServerUpdateStatus;
   check: ServerUpdateCheck | null;
-  busy: "check" | "apply" | "rollback" | null;
+  busy: "check" | "apply" | null;
   error: string | null;
   done: string | null;
   onCheck: () => void;
   onApply: () => void;
-  onRollback: () => void;
 }) {
+  const updateAvailable = check?.status === "available";
+
   return (
     <div className="mt-3 space-y-3">
-      <p className="text-[13.5px] text-[#C9C9CE]">
-        {status.imageTag ? (
-          <Trans>Image {status.imageTag}</Trans>
-        ) : status.revision ? (
-          <Trans>Revision {shortRev(status.revision)}</Trans>
-        ) : (
-          <Trans>Version {status.version}</Trans>
-        )}
-      </p>
-
-      {status.installKind === "sidecar" ? (
-        <>
-          <p className="text-[12.5px] text-[#6C6C70]">
-            <Trans>Updates pull the published image through the updater sidecar.</Trans>
-          </p>
-          <div className="flex flex-wrap gap-2">
-            <BuiButton disabled={busy !== null} onClick={onCheck}>
-              {busy === "check" ? <Trans>Checking…</Trans> : <Trans>Check</Trans>}
-            </BuiButton>
-            <BuiButton
-              tone="accent"
-              disabled={busy !== null || check?.status === "dirty"}
-              onClick={onApply}
-            >
-              {busy === "apply" ? <Trans>Updating…</Trans> : <Trans>Update</Trans>}
-            </BuiButton>
-            {status.canRollback ? (
-              <BuiButton disabled={busy !== null} onClick={onRollback}>
-                {busy === "rollback" ? <Trans>Rolling back…</Trans> : <Trans>Rollback</Trans>}
-              </BuiButton>
-            ) : null}
-          </div>
-          {check ? <CheckSummary check={check} /> : null}
-        </>
-      ) : null}
-
-      {status.installKind === "compose" ? (
-        <>
-          <p className="text-[12.5px] text-[#6C6C70]">
-            <Trans>Compose install without the updater sidecar. Run these on the host.</Trans>
-          </p>
-          <CommandBlock commands={status.manualCommands} />
-        </>
-      ) : null}
-
-      {status.installKind === "source" ? (
-        <>
-          <p className="text-[12.5px] text-[#6C6C70]">
-            <Trans>Source install. Upgrade from a terminal.</Trans>
-          </p>
-          <CommandBlock commands={status.manualCommands} />
-        </>
-      ) : null}
-
-      {status.unsupportedReason && status.installKind === "sidecar" ? (
-        <p className="text-[12.5px] text-[#F1A8A8]">{status.unsupportedReason}</p>
-      ) : null}
-
+      <div className="flex flex-wrap gap-2">
+        <BuiButton disabled={busy !== null} onClick={onCheck}>
+          {busy === "check" ? <Trans>Checking…</Trans> : <Trans>Check for updates</Trans>}
+        </BuiButton>
+        {updateAvailable ? (
+          <BuiButton tone="accent" disabled={busy !== null} onClick={onApply}>
+            {busy === "apply" ? <Trans>Updating…</Trans> : <Trans>Update</Trans>}
+          </BuiButton>
+        ) : null}
+      </div>
+      {check ? <CheckSummary check={check} /> : null}
       {error ? (
         <p role="alert" className="text-[12.5px] text-[#F1A8A8]">
           {error}
@@ -146,7 +92,7 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
   const [status, setStatus] = useState<ServerUpdateStatus | null>(null);
   const [check, setCheck] = useState<ServerUpdateCheck | null>(null);
   const [loading, setLoading] = useState(false);
-  const [busy, setBusy] = useState<"check" | "apply" | "rollback" | null>(null);
+  const [busy, setBusy] = useState<"check" | "apply" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<string | null>(null);
 
@@ -175,6 +121,26 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
 
   if (!isDeploymentOwner) return null;
 
+  // Wait for status before deciding whether to show the section (compose/source stay hidden).
+  if (loading) return null;
+  if (!status) {
+    if (!error) return null;
+    return (
+      <section
+        data-testid="software-update-settings"
+        className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4"
+      >
+        <h3 className="text-[15px] font-medium text-[#ECECEE]">
+          <Trans>Software update</Trans>
+        </h3>
+        <p role="alert" className="mt-3 text-[12.5px] text-[#F1A8A8]">
+          {error}
+        </p>
+      </section>
+    );
+  }
+  if (status.installKind !== "sidecar") return null;
+
   async function runCheck() {
     setBusy("check");
     setError(null);
@@ -190,10 +156,9 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
 
   async function finishAfterPossibleRecreate(
     action: () => Promise<{ ok: boolean; error: string | null }>,
-    successLabel: string,
   ) {
-    // Snapshot the live tag right before apply/rollback. Panel state can be stale if
-    // another tab or host update moved the image after this section last loaded.
+    // Snapshot the live tag right before apply. Panel state can be stale if another tab or
+    // host update moved the image after this section last loaded.
     let beforeImageTag: string | null = null;
     try {
       const before = await rpc.updater.status();
@@ -204,7 +169,7 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
       setCheck(null);
       if (run.ok) {
         setError(null);
-        setDone(successLabel);
+        setDone(t`Updated`);
       } else {
         setDone(null);
         setError(run.error ?? t`Update finished with errors`);
@@ -221,7 +186,7 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
         setCheck(null);
         if (recovered.confirmed) {
           setError(null);
-          setDone(successLabel);
+          setDone(t`Updated`);
         } else if (recovered.reason === "failed") {
           setDone(null);
           setError(
@@ -231,7 +196,7 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
           );
         } else {
           setDone(null);
-          setError(t`API is back, but the image tag did not change. Check the host logs.`);
+          setError(t`API is back, but the update did not finish. Check the host logs.`);
         }
       } catch (waitError) {
         setDone(null);
@@ -249,18 +214,7 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
     setError(null);
     setDone(null);
     try {
-      await finishAfterPossibleRecreate(() => rpc.updater.apply({}), t`Updated`);
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  async function runRollback() {
-    setBusy("rollback");
-    setError(null);
-    setDone(null);
-    try {
-      await finishAfterPossibleRecreate(() => rpc.updater.rollback(), t`Rolled back`);
+      await finishAfterPossibleRecreate(() => rpc.updater.apply({}));
     } finally {
       setBusy(null);
     }
@@ -274,31 +228,14 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
       <h3 className="text-[15px] font-medium text-[#ECECEE]">
         <Trans>Software update</Trans>
       </h3>
-
-      {loading ? (
-        <div className="mt-3">
-          <LoadingState label={t`Loading`} />
-        </div>
-      ) : null}
-
-      {!loading && status ? (
-        <SoftwareUpdatePanel
-          status={status}
-          check={check}
-          busy={busy}
-          error={error}
-          done={done}
-          onCheck={() => void runCheck()}
-          onApply={() => void runApply()}
-          onRollback={() => void runRollback()}
-        />
-      ) : null}
-
-      {!loading && !status && error ? (
-        <p role="alert" className="mt-3 text-[12.5px] text-[#F1A8A8]">
-          {error}
-        </p>
-      ) : null}
+      <SoftwareUpdatePanel
+        check={check}
+        busy={busy}
+        error={error}
+        done={done}
+        onCheck={() => void runCheck()}
+        onApply={() => void runApply()}
+      />
     </section>
   );
 }
@@ -308,7 +245,6 @@ function CheckSummary({ check }: { check: ServerUpdateCheck }) {
     return (
       <p className="text-[12.5px] text-[#6C6C70]">
         <Trans>Up to date</Trans>
-        {check.targetTag ? ` (${check.targetTag})` : null}
       </p>
     );
   }
@@ -316,8 +252,6 @@ function CheckSummary({ check }: { check: ServerUpdateCheck }) {
     return (
       <p className="text-[12.5px] text-[#C9C9CE]">
         <Trans>Update available</Trans>
-        {check.targetTag ? `: ${check.targetTag}` : null}
-        {check.targetCommit && !check.targetTag ? `: ${shortRev(check.targetCommit)}` : null}
       </p>
     );
   }
@@ -330,17 +264,5 @@ function CheckSummary({ check }: { check: ServerUpdateCheck }) {
   }
   return (
     <p className="text-[12.5px] text-[#F1A8A8]">{check.reason ?? <Trans>Unavailable</Trans>}</p>
-  );
-}
-
-function CommandBlock({ commands }: { commands: string[] }) {
-  if (commands.length === 0) return null;
-  return (
-    <pre
-      data-testid="software-update-commands"
-      className="overflow-x-auto rounded-[10px] border border-[#232326] bg-[#0C0C0E] px-3 py-2.5 font-mono text-[11.5px] leading-5 text-[#C9C9CE]"
-    >
-      {commands.join("\n")}
-    </pre>
   );
 }

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -1,0 +1,258 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { ServerUpdateCheck, ServerUpdateStatus } from "@rakazo/contracts";
+import { useEffect, useState } from "react";
+import { rpc } from "../lib/rpc";
+import { BuiButton, LoadingState, SuccessPop } from "./beautiful-ui/primitives";
+
+function shortRev(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return value.length > 12 ? value.slice(0, 12) : value;
+}
+
+/** Presentational body so unit tests can render install-kind branches without RPC. */
+export function SoftwareUpdatePanel({
+  status,
+  check,
+  busy,
+  error,
+  done,
+  onCheck,
+  onApply,
+  onRollback,
+}: {
+  status: ServerUpdateStatus;
+  check: ServerUpdateCheck | null;
+  busy: "check" | "apply" | "rollback" | null;
+  error: string | null;
+  done: string | null;
+  onCheck: () => void;
+  onApply: () => void;
+  onRollback: () => void;
+}) {
+  return (
+    <div className="mt-3 space-y-3">
+      <p className="text-[13.5px] text-[#C9C9CE]">
+        {status.imageTag ? (
+          <Trans>Image {status.imageTag}</Trans>
+        ) : status.revision ? (
+          <Trans>Revision {shortRev(status.revision)}</Trans>
+        ) : (
+          <Trans>Version {status.version}</Trans>
+        )}
+      </p>
+
+      {status.installKind === "sidecar" ? (
+        <>
+          <p className="text-[12.5px] text-[#6C6C70]">
+            <Trans>Updates pull the published image through the updater sidecar.</Trans>
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <BuiButton disabled={busy !== null} onClick={onCheck}>
+              {busy === "check" ? <Trans>Checking…</Trans> : <Trans>Check</Trans>}
+            </BuiButton>
+            <BuiButton
+              tone="accent"
+              disabled={busy !== null || check?.status === "dirty"}
+              onClick={onApply}
+            >
+              {busy === "apply" ? <Trans>Updating…</Trans> : <Trans>Update</Trans>}
+            </BuiButton>
+            {status.canRollback ? (
+              <BuiButton disabled={busy !== null} onClick={onRollback}>
+                {busy === "rollback" ? <Trans>Rolling back…</Trans> : <Trans>Rollback</Trans>}
+              </BuiButton>
+            ) : null}
+          </div>
+          {check ? <CheckSummary check={check} /> : null}
+        </>
+      ) : null}
+
+      {status.installKind === "compose" ? (
+        <>
+          <p className="text-[12.5px] text-[#6C6C70]">
+            <Trans>Compose install without the updater sidecar. Run these on the host.</Trans>
+          </p>
+          <CommandBlock commands={status.manualCommands} />
+        </>
+      ) : null}
+
+      {status.installKind === "source" ? (
+        <>
+          <p className="text-[12.5px] text-[#6C6C70]">
+            <Trans>Source install. Upgrade from a terminal.</Trans>
+          </p>
+          <CommandBlock commands={status.manualCommands} />
+        </>
+      ) : null}
+
+      {status.unsupportedReason && status.installKind === "sidecar" ? (
+        <p className="text-[12.5px] text-[#F1A8A8]">{status.unsupportedReason}</p>
+      ) : null}
+
+      {error ? (
+        <p role="alert" className="text-[12.5px] text-[#F1A8A8]">
+          {error}
+        </p>
+      ) : null}
+      {done ? <SuccessPop label={done} /> : null}
+    </div>
+  );
+}
+
+export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner: boolean }) {
+  const { t } = useLingui();
+  const [status, setStatus] = useState<ServerUpdateStatus | null>(null);
+  const [check, setCheck] = useState<ServerUpdateCheck | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState<"check" | "apply" | "rollback" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isDeploymentOwner) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void rpc.updater
+      .status()
+      .then((next) => {
+        if (!cancelled) setStatus(next);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : t`Could not load update status`);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isDeploymentOwner, t]);
+
+  if (!isDeploymentOwner) return null;
+
+  async function runCheck() {
+    setBusy("check");
+    setError(null);
+    setDone(null);
+    try {
+      setCheck(await rpc.updater.check({}));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t`Check failed`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function runApply() {
+    setBusy("apply");
+    setError(null);
+    setDone(null);
+    try {
+      const run = await rpc.updater.apply({});
+      setStatus(await rpc.updater.status());
+      setCheck(null);
+      setDone(run.ok ? t`Updated` : (run.error ?? t`Update finished with errors`));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t`Update failed`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function runRollback() {
+    setBusy("rollback");
+    setError(null);
+    setDone(null);
+    try {
+      const run = await rpc.updater.rollback();
+      setStatus(await rpc.updater.status());
+      setCheck(null);
+      setDone(run.ok ? t`Rolled back` : (run.error ?? t`Rollback finished with errors`));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t`Rollback failed`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section
+      data-testid="software-update-settings"
+      className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4"
+    >
+      <h3 className="text-[15px] font-medium text-[#ECECEE]">
+        <Trans>Software update</Trans>
+      </h3>
+
+      {loading ? (
+        <div className="mt-3">
+          <LoadingState label={t`Loading`} />
+        </div>
+      ) : null}
+
+      {!loading && status ? (
+        <SoftwareUpdatePanel
+          status={status}
+          check={check}
+          busy={busy}
+          error={error}
+          done={done}
+          onCheck={() => void runCheck()}
+          onApply={() => void runApply()}
+          onRollback={() => void runRollback()}
+        />
+      ) : null}
+
+      {!loading && !status && error ? (
+        <p role="alert" className="mt-3 text-[12.5px] text-[#F1A8A8]">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function CheckSummary({ check }: { check: ServerUpdateCheck }) {
+  if (check.status === "up-to-date") {
+    return (
+      <p className="text-[12.5px] text-[#6C6C70]">
+        <Trans>Up to date</Trans>
+        {check.targetTag ? ` (${check.targetTag})` : null}
+      </p>
+    );
+  }
+  if (check.status === "available") {
+    return (
+      <p className="text-[12.5px] text-[#C9C9CE]">
+        <Trans>Update available</Trans>
+        {check.targetTag ? `: ${check.targetTag}` : null}
+        {check.targetCommit && !check.targetTag ? `: ${shortRev(check.targetCommit)}` : null}
+      </p>
+    );
+  }
+  if (check.status === "dirty") {
+    return (
+      <p className="text-[12.5px] text-[#F1A8A8]">
+        <Trans>Checkout has local changes. Clean it before updating.</Trans>
+      </p>
+    );
+  }
+  return (
+    <p className="text-[12.5px] text-[#F1A8A8]">{check.reason ?? <Trans>Unavailable</Trans>}</p>
+  );
+}
+
+function CommandBlock({ commands }: { commands: string[] }) {
+  if (commands.length === 0) return null;
+  return (
+    <pre
+      data-testid="software-update-commands"
+      className="overflow-x-auto rounded-[10px] border border-[#232326] bg-[#0C0C0E] px-3 py-2.5 font-mono text-[11.5px] leading-5 text-[#C9C9CE]"
+    >
+      {commands.join("\n")}
+    </pre>
+  );
+}

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -189,8 +189,13 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
     action: () => Promise<{ ok: boolean; error: string | null }>,
     successLabel: string,
   ) {
-    const beforeImageTag = status?.imageTag ?? null;
+    // Snapshot the live tag right before apply/rollback. Panel state can be stale if
+    // another tab or host update moved the image after this section last loaded.
+    let beforeImageTag: string | null = null;
     try {
+      const before = await rpc.updater.status();
+      beforeImageTag = before.imageTag ?? null;
+      setStatus(before);
       const run = await action();
       setStatus(await rpc.updater.status());
       setCheck(null);

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -29,8 +29,10 @@ async function waitForUpdaterStatus(options: {
         beforeImageTag: options.beforeImageTag,
         afterImageTag: next.imageTag,
         running: next.running,
+        supported: next.supported,
+        installKind: next.installKind,
       });
-      if (verdict.reason === "running") continue;
+      if (verdict.reason === "waiting" || verdict.reason === "running") continue;
       return { status: next, confirmed: verdict.confirmed };
     } catch (error) {
       lastError = error;

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -17,9 +17,7 @@ function shortRev(value: string | null | undefined): string | null {
   return value.length > 12 ? value.slice(0, 12) : value;
 }
 
-async function waitForUpdaterStatus(options: {
-  beforeImageTag: string | null;
-}): Promise<{
+async function waitForUpdaterStatus(options: { beforeImageTag: string | null }): Promise<{
   status: ServerUpdateStatus;
   confirmed: boolean;
   reason: "waiting" | "running" | "unchanged" | "changed" | "failed";

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -175,7 +175,13 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
       const run = await action();
       setStatus(await rpc.updater.status());
       setCheck(null);
-      setDone(run.ok ? successLabel : (run.error ?? t`Update finished with errors`));
+      if (run.ok) {
+        setError(null);
+        setDone(successLabel);
+      } else {
+        setDone(null);
+        setError(run.error ?? t`Update finished with errors`);
+      }
     } catch (err) {
       if (!isLikelyUpdaterRecreateDisconnect(err)) {
         setError(err instanceof Error ? err.message : t`Update failed`);

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -19,7 +19,11 @@ function shortRev(value: string | null | undefined): string | null {
 
 async function waitForUpdaterStatus(options: {
   beforeImageTag: string | null;
-}): Promise<{ status: ServerUpdateStatus; confirmed: boolean }> {
+}): Promise<{
+  status: ServerUpdateStatus;
+  confirmed: boolean;
+  reason: "waiting" | "running" | "unchanged" | "changed" | "failed";
+}> {
   let lastError: unknown;
   let sawApi = false;
   let sawSidecar = false;
@@ -36,11 +40,12 @@ async function waitForUpdaterStatus(options: {
         running: next.running,
         supported: next.supported,
         installKind: next.installKind,
+        lastRun: next.lastRun,
       });
       if (verdict.reason === "waiting") continue;
       sawSidecar = true;
       if (verdict.reason === "running") continue;
-      return { status: next, confirmed: verdict.confirmed };
+      return { status: next, confirmed: verdict.confirmed, reason: verdict.reason };
     } catch (error) {
       lastError = error;
     }
@@ -219,6 +224,13 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
         if (recovered.confirmed) {
           setError(null);
           setDone(successLabel);
+        } else if (recovered.reason === "failed") {
+          setDone(null);
+          setError(
+            recovered.status.lastRun?.error ??
+              recovered.status.lastRun?.restartAdvice ??
+              t`Update finished with errors`,
+          );
         } else {
           setDone(null);
           setError(t`API is back, but the image tag did not change. Check the host logs.`);

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -2,11 +2,32 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import type { ServerUpdateCheck, ServerUpdateStatus } from "@rakazo/contracts";
 import { useEffect, useState } from "react";
 import { rpc } from "../lib/rpc";
+import { isLikelyUpdaterRecreateDisconnect } from "../lib/updater-recreate";
 import { BuiButton, LoadingState, SuccessPop } from "./beautiful-ui/primitives";
+
+const RECREATE_POLL_MS = 2_000;
+const RECREATE_POLL_ATTEMPTS = 90;
 
 function shortRev(value: string | null | undefined): string | null {
   if (!value) return null;
   return value.length > 12 ? value.slice(0, 12) : value;
+}
+
+async function waitForUpdaterStatus(): Promise<ServerUpdateStatus> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < RECREATE_POLL_ATTEMPTS; attempt += 1) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, RECREATE_POLL_MS));
+    }
+    try {
+      return await rpc.updater.status();
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("The API did not come back after the update.");
 }
 
 /** Presentational body so unit tests can render install-kind branches without RPC. */
@@ -146,17 +167,43 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
     }
   }
 
+  async function finishAfterPossibleRecreate(
+    action: () => Promise<{ ok: boolean; error: string | null }>,
+    successLabel: string,
+  ) {
+    try {
+      const run = await action();
+      setStatus(await rpc.updater.status());
+      setCheck(null);
+      setDone(run.ok ? successLabel : (run.error ?? t`Update finished with errors`));
+    } catch (err) {
+      if (!isLikelyUpdaterRecreateDisconnect(err)) {
+        setError(err instanceof Error ? err.message : t`Update failed`);
+        return;
+      }
+      setDone(t`Waiting for the API to come back…`);
+      try {
+        setStatus(await waitForUpdaterStatus());
+        setCheck(null);
+        setError(null);
+        setDone(successLabel);
+      } catch (waitError) {
+        setDone(null);
+        setError(
+          waitError instanceof Error
+            ? waitError.message
+            : t`The API did not come back. Refresh this page.`,
+        );
+      }
+    }
+  }
+
   async function runApply() {
     setBusy("apply");
     setError(null);
     setDone(null);
     try {
-      const run = await rpc.updater.apply({});
-      setStatus(await rpc.updater.status());
-      setCheck(null);
-      setDone(run.ok ? t`Updated` : (run.error ?? t`Update finished with errors`));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t`Update failed`);
+      await finishAfterPossibleRecreate(() => rpc.updater.apply({}), t`Updated`);
     } finally {
       setBusy(null);
     }
@@ -167,12 +214,7 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
     setError(null);
     setDone(null);
     try {
-      const run = await rpc.updater.rollback();
-      setStatus(await rpc.updater.status());
-      setCheck(null);
-      setDone(run.ok ? t`Rolled back` : (run.error ?? t`Rollback finished with errors`));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t`Rollback failed`);
+      await finishAfterPossibleRecreate(() => rpc.updater.rollback(), t`Rolled back`);
     } finally {
       setBusy(null);
     }

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -2,7 +2,11 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import type { ServerUpdateCheck, ServerUpdateStatus } from "@rakazo/contracts";
 import { useEffect, useState } from "react";
 import { rpc } from "../lib/rpc";
-import { confirmUpdaterRecreate, isLikelyUpdaterRecreateDisconnect } from "../lib/updater-recreate";
+import {
+  confirmUpdaterRecreate,
+  isLikelyUpdaterRecreateDisconnect,
+  recreateWaitTimeoutError,
+} from "../lib/updater-recreate";
 import { BuiButton, LoadingState, SuccessPop } from "./beautiful-ui/primitives";
 
 const RECREATE_POLL_MS = 2_000;
@@ -18,6 +22,7 @@ async function waitForUpdaterStatus(options: {
 }): Promise<{ status: ServerUpdateStatus; confirmed: boolean }> {
   let lastError: unknown;
   let sawApi = false;
+  let sawSidecar = false;
   for (let attempt = 0; attempt < RECREATE_POLL_ATTEMPTS; attempt += 1) {
     if (attempt > 0) {
       await new Promise((resolve) => setTimeout(resolve, RECREATE_POLL_MS));
@@ -32,18 +37,15 @@ async function waitForUpdaterStatus(options: {
         supported: next.supported,
         installKind: next.installKind,
       });
-      if (verdict.reason === "waiting" || verdict.reason === "running") continue;
+      if (verdict.reason === "waiting") continue;
+      sawSidecar = true;
+      if (verdict.reason === "running") continue;
       return { status: next, confirmed: verdict.confirmed };
     } catch (error) {
       lastError = error;
     }
   }
-  if (sawApi) {
-    throw new Error("The updater was still running when the wait timed out.");
-  }
-  throw lastError instanceof Error
-    ? lastError
-    : new Error("The API did not come back after the update.");
+  throw recreateWaitTimeoutError({ sawApi, sawSidecar, lastError });
 }
 
 /** Presentational body so unit tests can render install-kind branches without RPC. */

--- a/apps/web/src/lib/updater-recreate.test.ts
+++ b/apps/web/src/lib/updater-recreate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isLikelyUpdaterRecreateDisconnect } from "./updater-recreate.js";
+import { confirmUpdaterRecreate, isLikelyUpdaterRecreateDisconnect } from "./updater-recreate.js";
 
 describe("isLikelyUpdaterRecreateDisconnect", () => {
   it("recognizes common browser and Node transport failures after API recreate", () => {
@@ -17,5 +17,31 @@ describe("isLikelyUpdaterRecreateDisconnect", () => {
     ).toBe(false);
     expect(isLikelyUpdaterRecreateDisconnect("failed to fetch")).toBe(false);
     expect(isLikelyUpdaterRecreateDisconnect(null)).toBe(false);
+  });
+});
+
+describe("confirmUpdaterRecreate", () => {
+  it("requires an idle sidecar and a changed image tag", () => {
+    expect(
+      confirmUpdaterRecreate({
+        beforeImageTag: "sha-aaa",
+        afterImageTag: "sha-bbb",
+        running: false,
+      }),
+    ).toEqual({ confirmed: true, reason: "changed" });
+    expect(
+      confirmUpdaterRecreate({
+        beforeImageTag: "sha-aaa",
+        afterImageTag: "sha-bbb",
+        running: true,
+      }),
+    ).toEqual({ confirmed: false, reason: "running" });
+    expect(
+      confirmUpdaterRecreate({
+        beforeImageTag: "sha-aaa",
+        afterImageTag: "sha-aaa",
+        running: false,
+      }),
+    ).toEqual({ confirmed: false, reason: "unchanged" });
   });
 });

--- a/apps/web/src/lib/updater-recreate.test.ts
+++ b/apps/web/src/lib/updater-recreate.test.ts
@@ -3,7 +3,17 @@ import {
   confirmUpdaterRecreate,
   isLikelyUpdaterRecreateDisconnect,
   recreateWaitTimeoutError,
+  type RecreateLastRun,
 } from "./updater-recreate.js";
+
+function run(partial: Partial<RecreateLastRun> & Pick<RecreateLastRun, "ok" | "fromTag" | "toTag">): RecreateLastRun {
+  return {
+    finishedAt: "2026-08-27T21:00:00.000Z",
+    error: null,
+    restartAdvice: "",
+    ...partial,
+  };
+}
 
 describe("isLikelyUpdaterRecreateDisconnect", () => {
   it("recognizes common browser and Node transport failures after API recreate", () => {
@@ -25,7 +35,7 @@ describe("isLikelyUpdaterRecreateDisconnect", () => {
 });
 
 describe("confirmUpdaterRecreate", () => {
-  it("requires an idle sidecar and a changed image tag", () => {
+  it("requires an idle sidecar, matching lastRun, and a changed image tag", () => {
     expect(
       confirmUpdaterRecreate({
         beforeImageTag: "sha-aaa",
@@ -33,6 +43,7 @@ describe("confirmUpdaterRecreate", () => {
         running: false,
         supported: true,
         installKind: "sidecar",
+        lastRun: run({ ok: true, fromTag: "sha-aaa", toTag: "sha-bbb" }),
       }),
     ).toEqual({ confirmed: true, reason: "changed" });
     expect(
@@ -42,17 +53,9 @@ describe("confirmUpdaterRecreate", () => {
         running: true,
         supported: true,
         installKind: "sidecar",
+        lastRun: run({ ok: true, fromTag: "sha-aaa", toTag: "sha-bbb" }),
       }),
     ).toEqual({ confirmed: false, reason: "running" });
-    expect(
-      confirmUpdaterRecreate({
-        beforeImageTag: "sha-aaa",
-        afterImageTag: "sha-aaa",
-        running: false,
-        supported: true,
-        installKind: "sidecar",
-      }),
-    ).toEqual({ confirmed: false, reason: "unchanged" });
   });
 
   it("does not treat a compose fallback with a changed configured tag as success", () => {
@@ -63,12 +66,12 @@ describe("confirmUpdaterRecreate", () => {
         running: false,
         supported: false,
         installKind: "compose",
+        lastRun: run({ ok: true, fromTag: "sha-aaa", toTag: "sha-bbb" }),
       }),
     ).toEqual({ confirmed: false, reason: "waiting" });
   });
 
-  it("confirms rollback when the live before-tag differs from the restored after-tag", () => {
-    // Caller must pass the tag at action start (B), not a stale panel tag (A).
+  it("confirms rollback when lastRun moved from the live before-tag to the restored tag", () => {
     expect(
       confirmUpdaterRecreate({
         beforeImageTag: "sha-bbb",
@@ -76,8 +79,42 @@ describe("confirmUpdaterRecreate", () => {
         running: false,
         supported: true,
         installKind: "sidecar",
+        lastRun: run({ ok: true, fromTag: "sha-bbb", toTag: "sha-aaa" }),
       }),
     ).toEqual({ confirmed: true, reason: "changed" });
+  });
+
+  it("rejects a stale env pin when recreate failed even if the tag appears to change", () => {
+    expect(
+      confirmUpdaterRecreate({
+        beforeImageTag: "sha-aaa",
+        afterImageTag: "sha-bbb",
+        running: false,
+        supported: true,
+        installKind: "sidecar",
+        lastRun: run({
+          ok: false,
+          fromTag: "sha-aaa",
+          toTag: "sha-bbb",
+          error: "Recreate the stack failed.",
+          restartAdvice:
+            "Recreate the stack failed. The updater restored the previously running sha-aaa image, but could not restore the environment pin.",
+        }),
+      }),
+    ).toEqual({ confirmed: false, reason: "failed" });
+  });
+
+  it("waits until a finished lastRun is available", () => {
+    expect(
+      confirmUpdaterRecreate({
+        beforeImageTag: "sha-aaa",
+        afterImageTag: "sha-aaa",
+        running: false,
+        supported: true,
+        installKind: "sidecar",
+        lastRun: null,
+      }),
+    ).toEqual({ confirmed: false, reason: "waiting" });
   });
 });
 

--- a/apps/web/src/lib/updater-recreate.test.ts
+++ b/apps/web/src/lib/updater-recreate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { confirmUpdaterRecreate, isLikelyUpdaterRecreateDisconnect } from "./updater-recreate.js";
+import {
+  confirmUpdaterRecreate,
+  isLikelyUpdaterRecreateDisconnect,
+  recreateWaitTimeoutError,
+} from "./updater-recreate.js";
 
 describe("isLikelyUpdaterRecreateDisconnect", () => {
   it("recognizes common browser and Node transport failures after API recreate", () => {
@@ -61,5 +65,29 @@ describe("confirmUpdaterRecreate", () => {
         installKind: "compose",
       }),
     ).toEqual({ confirmed: false, reason: "waiting" });
+  });
+});
+
+describe("recreateWaitTimeoutError", () => {
+  it("reports sidecar unavailable when only fallback status was seen", () => {
+    expect(recreateWaitTimeoutError({ sawApi: true, sawSidecar: false }).message).toBe(
+      "The updater sidecar was unavailable after reconnect.",
+    );
+  });
+
+  it("reports still running when a live sidecar status was seen", () => {
+    expect(recreateWaitTimeoutError({ sawApi: true, sawSidecar: true }).message).toBe(
+      "The updater was still running when the wait timed out.",
+    );
+  });
+
+  it("keeps the last transport error when the API never came back", () => {
+    expect(
+      recreateWaitTimeoutError({
+        sawApi: false,
+        sawSidecar: false,
+        lastError: new Error("Failed to fetch"),
+      }).message,
+    ).toBe("Failed to fetch");
   });
 });

--- a/apps/web/src/lib/updater-recreate.test.ts
+++ b/apps/web/src/lib/updater-recreate.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   confirmUpdaterRecreate,
   isLikelyUpdaterRecreateDisconnect,
-  recreateWaitTimeoutError,
   type RecreateLastRun,
+  recreateWaitTimeoutError,
 } from "./updater-recreate.js";
 
-function run(partial: Partial<RecreateLastRun> & Pick<RecreateLastRun, "ok" | "fromTag" | "toTag">): RecreateLastRun {
+function run(
+  partial: Partial<RecreateLastRun> & Pick<RecreateLastRun, "ok" | "fromTag" | "toTag">,
+): RecreateLastRun {
   return {
     finishedAt: "2026-08-27T21:00:00.000Z",
     error: null,

--- a/apps/web/src/lib/updater-recreate.test.ts
+++ b/apps/web/src/lib/updater-recreate.test.ts
@@ -66,6 +66,19 @@ describe("confirmUpdaterRecreate", () => {
       }),
     ).toEqual({ confirmed: false, reason: "waiting" });
   });
+
+  it("confirms rollback when the live before-tag differs from the restored after-tag", () => {
+    // Caller must pass the tag at action start (B), not a stale panel tag (A).
+    expect(
+      confirmUpdaterRecreate({
+        beforeImageTag: "sha-bbb",
+        afterImageTag: "sha-aaa",
+        running: false,
+        supported: true,
+        installKind: "sidecar",
+      }),
+    ).toEqual({ confirmed: true, reason: "changed" });
+  });
 });
 
 describe("recreateWaitTimeoutError", () => {

--- a/apps/web/src/lib/updater-recreate.test.ts
+++ b/apps/web/src/lib/updater-recreate.test.ts
@@ -73,7 +73,7 @@ describe("confirmUpdaterRecreate", () => {
     ).toEqual({ confirmed: false, reason: "waiting" });
   });
 
-  it("confirms rollback when lastRun moved from the live before-tag to the restored tag", () => {
+  it("confirms a tag move when lastRun moved from the live before-tag", () => {
     expect(
       confirmUpdaterRecreate({
         beforeImageTag: "sha-bbb",

--- a/apps/web/src/lib/updater-recreate.test.ts
+++ b/apps/web/src/lib/updater-recreate.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isLikelyUpdaterRecreateDisconnect } from "./updater-recreate.js";
+
+describe("isLikelyUpdaterRecreateDisconnect", () => {
+  it("recognizes common browser and Node transport failures after API recreate", () => {
+    expect(isLikelyUpdaterRecreateDisconnect(new Error("Failed to fetch"))).toBe(true);
+    expect(
+      isLikelyUpdaterRecreateDisconnect(new Error("NetworkError when attempting to fetch")),
+    ).toBe(true);
+    expect(isLikelyUpdaterRecreateDisconnect(new Error("socket hang up"))).toBe(true);
+    expect(isLikelyUpdaterRecreateDisconnect(new Error("ECONNREFUSED"))).toBe(true);
+  });
+
+  it("does not treat ordinary updater errors as recreate disconnects", () => {
+    expect(
+      isLikelyUpdaterRecreateDisconnect(new Error("The updater sidecar is not configured.")),
+    ).toBe(false);
+    expect(isLikelyUpdaterRecreateDisconnect("failed to fetch")).toBe(false);
+    expect(isLikelyUpdaterRecreateDisconnect(null)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/updater-recreate.test.ts
+++ b/apps/web/src/lib/updater-recreate.test.ts
@@ -27,6 +27,8 @@ describe("confirmUpdaterRecreate", () => {
         beforeImageTag: "sha-aaa",
         afterImageTag: "sha-bbb",
         running: false,
+        supported: true,
+        installKind: "sidecar",
       }),
     ).toEqual({ confirmed: true, reason: "changed" });
     expect(
@@ -34,6 +36,8 @@ describe("confirmUpdaterRecreate", () => {
         beforeImageTag: "sha-aaa",
         afterImageTag: "sha-bbb",
         running: true,
+        supported: true,
+        installKind: "sidecar",
       }),
     ).toEqual({ confirmed: false, reason: "running" });
     expect(
@@ -41,7 +45,21 @@ describe("confirmUpdaterRecreate", () => {
         beforeImageTag: "sha-aaa",
         afterImageTag: "sha-aaa",
         running: false,
+        supported: true,
+        installKind: "sidecar",
       }),
     ).toEqual({ confirmed: false, reason: "unchanged" });
+  });
+
+  it("does not treat a compose fallback with a changed configured tag as success", () => {
+    expect(
+      confirmUpdaterRecreate({
+        beforeImageTag: "sha-aaa",
+        afterImageTag: "sha-bbb",
+        running: false,
+        supported: false,
+        installKind: "compose",
+      }),
+    ).toEqual({ confirmed: false, reason: "waiting" });
   });
 });

--- a/apps/web/src/lib/updater-recreate.ts
+++ b/apps/web/src/lib/updater-recreate.ts
@@ -1,0 +1,20 @@
+/**
+ * Apply/rollback recreate the API container mid-request. ORPC then surfaces a generic transport
+ * failure instead of the sidecar's completed run. Treat those as "wait for the new API".
+ */
+export function isLikelyUpdaterRecreateDisconnect(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("failed to fetch") ||
+    message.includes("networkerror") ||
+    message.includes("network request failed") ||
+    message.includes("load failed") ||
+    message.includes("fetch failed") ||
+    message.includes("econnreset") ||
+    message.includes("econnrefused") ||
+    message.includes("socket hang up") ||
+    message.includes("aborted") ||
+    message.includes("the operation was aborted")
+  );
+}

--- a/apps/web/src/lib/updater-recreate.ts
+++ b/apps/web/src/lib/updater-recreate.ts
@@ -19,12 +19,21 @@ export function isLikelyUpdaterRecreateDisconnect(error: unknown): boolean {
   );
 }
 
-/** After reconnect, only claim success when the image tag actually moved and the sidecar is idle. */
+/**
+ * After reconnect, only claim success from a live sidecar status: supported sidecar install,
+ * idle run lock, and an image tag that actually moved. A compose/source fallback with a changed
+ * configured tag is not proof the update finished.
+ */
 export function confirmUpdaterRecreate(input: {
   beforeImageTag: string | null;
   afterImageTag: string | null;
   running: boolean;
-}): { confirmed: boolean; reason: "running" | "unchanged" | "changed" } {
+  supported: boolean;
+  installKind: string;
+}): { confirmed: boolean; reason: "waiting" | "running" | "unchanged" | "changed" } {
+  if (input.supported !== true || input.installKind !== "sidecar") {
+    return { confirmed: false, reason: "waiting" };
+  }
   if (input.running) return { confirmed: false, reason: "running" };
   if (input.beforeImageTag && input.afterImageTag && input.afterImageTag !== input.beforeImageTag) {
     return { confirmed: true, reason: "changed" };

--- a/apps/web/src/lib/updater-recreate.ts
+++ b/apps/web/src/lib/updater-recreate.ts
@@ -1,5 +1,5 @@
 /**
- * Apply/rollback recreate the API container mid-request. ORPC then surfaces a generic transport
+ * Apply recreates the API container mid-request. ORPC then surfaces a generic transport
  * failure instead of the sidecar's completed run. Treat those as "wait for the new API".
  */
 export function isLikelyUpdaterRecreateDisconnect(error: unknown): boolean {

--- a/apps/web/src/lib/updater-recreate.ts
+++ b/apps/web/src/lib/updater-recreate.ts
@@ -19,10 +19,19 @@ export function isLikelyUpdaterRecreateDisconnect(error: unknown): boolean {
   );
 }
 
+export type RecreateLastRun = {
+  ok: boolean;
+  fromTag: string | null;
+  toTag: string | null;
+  finishedAt: string | null;
+  error: string | null;
+  restartAdvice: string;
+};
+
 /**
- * After reconnect, only claim success from a live sidecar status: supported sidecar install,
- * idle run lock, and an image tag that actually moved. A compose/source fallback with a changed
- * configured tag is not proof the update finished.
+ * After reconnect, only claim success from a finished sidecar run that started from the
+ * pre-action tag. A changed env pin alone is not enough: recreate can fail, restore the prior
+ * image, and still leave `RAKAZO_IMAGE_TAG` pointing at the target.
  */
 export function confirmUpdaterRecreate(input: {
   beforeImageTag: string | null;
@@ -30,12 +39,27 @@ export function confirmUpdaterRecreate(input: {
   running: boolean;
   supported: boolean;
   installKind: string;
-}): { confirmed: boolean; reason: "waiting" | "running" | "unchanged" | "changed" } {
+  lastRun: RecreateLastRun | null;
+}): {
+  confirmed: boolean;
+  reason: "waiting" | "running" | "unchanged" | "changed" | "failed";
+} {
   if (input.supported !== true || input.installKind !== "sidecar") {
     return { confirmed: false, reason: "waiting" };
   }
   if (input.running) return { confirmed: false, reason: "running" };
-  if (input.beforeImageTag && input.afterImageTag && input.afterImageTag !== input.beforeImageTag) {
+
+  const run = input.lastRun;
+  if (!run || run.finishedAt === null) {
+    return { confirmed: false, reason: "waiting" };
+  }
+  if (!input.beforeImageTag || run.fromTag !== input.beforeImageTag) {
+    return { confirmed: false, reason: "unchanged" };
+  }
+  if (!run.ok) {
+    return { confirmed: false, reason: "failed" };
+  }
+  if (run.toTag && input.afterImageTag === run.toTag && run.toTag !== input.beforeImageTag) {
     return { confirmed: true, reason: "changed" };
   }
   return { confirmed: false, reason: "unchanged" };

--- a/apps/web/src/lib/updater-recreate.ts
+++ b/apps/web/src/lib/updater-recreate.ts
@@ -40,3 +40,20 @@ export function confirmUpdaterRecreate(input: {
   }
   return { confirmed: false, reason: "unchanged" };
 }
+
+/** Timeout copy after recreate reconnect polling. */
+export function recreateWaitTimeoutError(input: {
+  sawApi: boolean;
+  sawSidecar: boolean;
+  lastError?: unknown;
+}): Error {
+  if (input.sawSidecar) {
+    return new Error("The updater was still running when the wait timed out.");
+  }
+  if (input.sawApi) {
+    return new Error("The updater sidecar was unavailable after reconnect.");
+  }
+  return input.lastError instanceof Error
+    ? input.lastError
+    : new Error("The API did not come back after the update.");
+}

--- a/apps/web/src/lib/updater-recreate.ts
+++ b/apps/web/src/lib/updater-recreate.ts
@@ -18,3 +18,16 @@ export function isLikelyUpdaterRecreateDisconnect(error: unknown): boolean {
     message.includes("the operation was aborted")
   );
 }
+
+/** After reconnect, only claim success when the image tag actually moved and the sidecar is idle. */
+export function confirmUpdaterRecreate(input: {
+  beforeImageTag: string | null;
+  afterImageTag: string | null;
+  running: boolean;
+}): { confirmed: boolean; reason: "running" | "unchanged" | "changed" } {
+  if (input.running) return { confirmed: false, reason: "running" };
+  if (input.beforeImageTag && input.afterImageTag && input.afterImageTag !== input.beforeImageTag) {
+    return { confirmed: true, reason: "changed" };
+  }
+  return { confirmed: false, reason: "unchanged" };
+}

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { ApprovalRulesSettings } from "../components/ApprovalRulesSettings";
+import { SoftwareUpdateSection } from "../components/SoftwareUpdateSection";
 import { getActiveUiLocale, setUiLocale } from "../lib/i18n";
 import { UI_LOCALE_LABELS, UI_LOCALES, type UiLocale } from "../lib/ui-locale";
 
@@ -20,6 +21,7 @@ export function AccountSettingsOverlay({
   focusUsage,
   avatarStyle,
   onAvatarStyleChange,
+  isDeploymentOwner = false,
   onClose,
 }: {
   email?: string | null;
@@ -28,6 +30,7 @@ export function AccountSettingsOverlay({
   focusUsage?: boolean;
   avatarStyle: AvatarStyle;
   onAvatarStyleChange: (style: AvatarStyle) => Promise<void>;
+  isDeploymentOwner?: boolean;
   onClose: () => void;
 }) {
   const { t } = useLingui();
@@ -186,6 +189,8 @@ export function AccountSettingsOverlay({
             <Trans>Model spend uses your provider keys.</Trans>
           </p>
         </div>
+
+        <SoftwareUpdateSection isDeploymentOwner={isDeploymentOwner} />
 
         <details
           data-testid="advanced-settings"

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -102,9 +102,6 @@ export function AccountSettingsOverlay({
             <h2 id="account-settings-title" className="text-2xl font-medium text-[#F1F1F2]">
               <Trans>Settings</Trans>
             </h2>
-            <p className="mt-1 text-[13.5px] text-[#7A7A80]">
-              <Trans>Account preferences apply across all your bots.</Trans>
-            </p>
           </div>
           <button
             type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2853,6 +2853,7 @@ export function ShellPage() {
             usage={usage}
             focusUsage={accountSettingsFocusUsage}
             avatarStyle={bootstrapMe?.avatarStyle ?? "robot"}
+            isDeploymentOwner={bootstrapMe?.isDeploymentOwner === true}
             onAvatarStyleChange={async (avatarStyle) => {
               const nextMe = await rpc.preferences.update({ avatarStyle });
               setBootstrapMe(nextMe);

--- a/infra/updater/src/index.test.ts
+++ b/infra/updater/src/index.test.ts
@@ -245,6 +245,13 @@ describe("updater orchestration", () => {
     expect(await readFile(path.join(fixture.deployDir, ".env"), "utf8")).toContain(
       "RAKAZO_IMAGE_TAG=v1.0.0",
     );
+
+    const state = await subject.request("/state", { method: "GET", headers: authorized });
+    expect(state.status).toBe(200);
+    await expect(state.json()).resolves.toMatchObject({
+      running: false,
+      lastRun: { ok: false, fromTag: "v1.0.0", toTag: `sha-${targetCommit}` },
+    });
   });
 
   it("resets a fork checkout when recreate fails after the fast-forward", async () => {

--- a/infra/updater/src/index.ts
+++ b/infra/updater/src/index.ts
@@ -154,7 +154,7 @@ export function createUpdaterApp(
   };
   let running = false;
   let planInFlight: Promise<unknown> | null = null;
-  /** Survives API recreate so Settings can confirm apply/rollback after the proxy drops. */
+  /** Survives API recreate so Settings can confirm apply after the proxy drops. */
   let lastRun: ServerUpdateRun | null = null;
 
   app.get("/health", (c) => c.json({ ok: true, service: "updater", image: config.image }));

--- a/infra/updater/src/index.ts
+++ b/infra/updater/src/index.ts
@@ -154,6 +154,8 @@ export function createUpdaterApp(
   };
   let running = false;
   let planInFlight: Promise<unknown> | null = null;
+  /** Survives API recreate so Settings can confirm apply/rollback after the proxy drops. */
+  let lastRun: ServerUpdateRun | null = null;
 
   app.get("/health", (c) => c.json({ ok: true, service: "updater", image: config.image }));
 
@@ -178,6 +180,7 @@ export function createUpdaterApp(
         image: config.image,
         imageRef: imageRef(config.image, tags.currentTag),
         running,
+        lastRun,
         ...tags,
         checkout,
       });
@@ -463,12 +466,12 @@ export function createUpdaterApp(
       targetCommit = target.commit;
       releaseTag = target.releaseTag;
       if (targetTag === tags.currentTag) {
-        return upToDateRecord(request, targetTag, "pull", targetCommit);
+        return rememberRun(upToDateRecord(request, targetTag, "pull", targetCommit));
       }
     } else {
       const remoteHead = await resolveRemoteHead(request);
       if (upToDateForBuild(tags.currentTag, checkout.commit, remoteHead)) {
-        return upToDateRecord(request, tags.currentTag, "build", checkout.commit);
+        return rememberRun(upToDateRecord(request, tags.currentTag, "build", checkout.commit));
       }
     }
 
@@ -485,27 +488,29 @@ export function createUpdaterApp(
               repoIdentity(checkout.remoteUrl) !== repoIdentity(request.repoUrl),
           });
 
-    return execute({
-      request,
-      strategy: decision.strategy,
-      fromTag: tags.currentTag,
-      originalPreviousTag: tags.previousTag,
-      toTag: targetTag,
-      fromCommit: checkout.commit,
-      fromBranch: checkout.branch,
-      toCommit: targetCommit,
-      restoreRemoteUrl:
-        decision.strategy === "build" &&
-        checkout.remoteUrl !== null &&
-        repoIdentity(checkout.remoteUrl) !== repoIdentity(request.repoUrl)
-          ? checkout.remoteUrl
-          : null,
-      steps,
-      restartAdvice:
-        decision.strategy === "pull"
-          ? `The updater deployed ${releaseTag ?? targetTag} from its full source-commit image tag and recreated the API, worker, and web containers. Migrations ran inside the new API container before it became healthy.`
-          : "The updater built the fork and recreated the API, worker, and web containers. Migrations ran inside the new API container before it started serving.",
-    });
+    return rememberRun(
+      await execute({
+        request,
+        strategy: decision.strategy,
+        fromTag: tags.currentTag,
+        originalPreviousTag: tags.previousTag,
+        toTag: targetTag,
+        fromCommit: checkout.commit,
+        fromBranch: checkout.branch,
+        toCommit: targetCommit,
+        restoreRemoteUrl:
+          decision.strategy === "build" &&
+          checkout.remoteUrl !== null &&
+          repoIdentity(checkout.remoteUrl) !== repoIdentity(request.repoUrl)
+            ? checkout.remoteUrl
+            : null,
+        steps,
+        restartAdvice:
+          decision.strategy === "pull"
+            ? `The updater deployed ${releaseTag ?? targetTag} from its full source-commit image tag and recreated the API, worker, and web containers. Migrations ran inside the new API container before it became healthy.`
+            : "The updater built the fork and recreated the API, worker, and web containers. Migrations ran inside the new API container before it started serving.",
+      }),
+    );
   }
 
   async function rollback(): Promise<ServerUpdateRun> {
@@ -517,19 +522,26 @@ export function createUpdaterApp(
     const steps = composeUpdatePlan({ strategy: "pull", target: composeTarget }).filter(
       (step) => step.id !== "pull",
     );
-    return execute({
-      request: { repoUrl: "", branch: "" },
-      strategy: "pull",
-      fromTag: tags.currentTag,
-      originalPreviousTag: tags.previousTag,
-      toTag: decision.tag,
-      fromCommit: checkout.commit,
-      fromBranch: checkout.branch,
-      toCommit: null,
-      restoreRemoteUrl: null,
-      steps,
-      restartAdvice: `Rolled back to ${decision.tag}. Database migrations are not reversed: if the newer version added a migration, roll forward again or restore a database backup.`,
-    });
+    return rememberRun(
+      await execute({
+        request: { repoUrl: "", branch: "" },
+        strategy: "pull",
+        fromTag: tags.currentTag,
+        originalPreviousTag: tags.previousTag,
+        toTag: decision.tag,
+        fromCommit: checkout.commit,
+        fromBranch: checkout.branch,
+        toCommit: null,
+        restoreRemoteUrl: null,
+        steps,
+        restartAdvice: `Rolled back to ${decision.tag}. Database migrations are not reversed: if the newer version added a migration, roll forward again or restore a database backup.`,
+      }),
+    );
+  }
+
+  function rememberRun(record: ServerUpdateRun): ServerUpdateRun {
+    lastRun = record;
+    return record;
   }
 
   /**

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -726,6 +726,15 @@ export type ServerUpdateStrategy = z.infer<typeof ServerUpdateStrategySchema>;
 export const ServerUpdateModeSchema = z.enum(["sidecar", "checkout", "unavailable"]);
 export type ServerUpdateMode = z.infer<typeof ServerUpdateModeSchema>;
 
+/**
+ * What Settings should render for a deployment owner.
+ * `sidecar`: Check / Update / Rollback through the updater sidecar.
+ * `compose`: Compose install without a reachable sidecar; show host pull/up commands.
+ * `source`: git checkout / `pnpm dev`; show terminal commands, never a fake Apply.
+ */
+export const ServerUpdateInstallKindSchema = z.enum(["sidecar", "compose", "source"]);
+export type ServerUpdateInstallKind = z.infer<typeof ServerUpdateInstallKindSchema>;
+
 export const ServerUpdateRunSchema = z.object({
   startedAt: z.iso.datetime(),
   finishedAt: z.iso.datetime().nullable(),
@@ -751,6 +760,9 @@ export type ServerUpdateRun = z.infer<typeof ServerUpdateRunSchema>;
 export const ServerUpdateStatusSchema = z.object({
   supported: z.boolean(),
   unsupportedReason: z.string().nullable(),
+  installKind: ServerUpdateInstallKindSchema,
+  /** Host commands to run when `installKind` is not `sidecar`. Empty when the sidecar applies. */
+  manualCommands: z.array(z.string()),
   mode: ServerUpdateModeSchema,
   strategy: ServerUpdateStrategySchema.nullable(),
   strategyNote: z.string().nullable(),
@@ -780,9 +792,16 @@ export const ServerUpdateCheckSchema = z.object({
   changed: z.array(z.string()),
   commit: z.string().nullable(),
   targetCommit: z.string().nullable(),
+  targetTag: z.string().nullable(),
   behindBy: z.number().int().nonnegative(),
 });
 export type ServerUpdateCheck = z.infer<typeof ServerUpdateCheckSchema>;
+
+export const ServerUpdateRequestSchema = z.object({
+  repoUrl: z.string().max(400).optional(),
+  branch: z.string().max(200).optional(),
+});
+export type ServerUpdateRequest = z.infer<typeof ServerUpdateRequestSchema>;
 
 export const MeSchema = z.object({
   userId: Id,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -135,14 +135,13 @@ export const appContract = {
   },
   /**
    * Deployment-owner product updates. When the Compose updater sidecar is reachable, these proxy
-   * to its `/state` `/plan` `/apply` `/rollback` contract. Otherwise they only report install kind
-   * and the documented host commands. Never git-fetch from the API process.
+   * to its `/state` `/plan` `/apply` contract. Rollback stays on the sidecar for ops only and is
+   * not exposed here. Never git-fetch from the API process.
    */
   updater: {
     status: oc.output(ServerUpdateStatusSchema),
     check: oc.input(ServerUpdateRequestSchema).output(ServerUpdateCheckSchema),
     apply: oc.input(ServerUpdateRequestSchema).output(ServerUpdateRunSchema),
-    rollback: oc.output(ServerUpdateRunSchema),
   },
   models: {
     list: oc.output(z.array(ModelCatalogEntrySchema)),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -39,6 +39,10 @@ import {
   RoutineSchema,
   ScratchpadItemSchema,
   ScratchpadItemStatusSchema,
+  ServerUpdateCheckSchema,
+  ServerUpdateRequestSchema,
+  ServerUpdateRunSchema,
+  ServerUpdateStatusSchema,
   SkillPlaybookSchema,
   TaughtSkillSchema,
   TeachRecordingEventSchema,
@@ -128,6 +132,17 @@ export const appContract = {
         }),
       )
       .output(DeploymentSettingsSchema),
+  },
+  /**
+   * Deployment-owner product updates. When the Compose updater sidecar is reachable, these proxy
+   * to its `/state` `/plan` `/apply` `/rollback` contract. Otherwise they only report install kind
+   * and the documented host commands. Never git-fetch from the API process.
+   */
+  updater: {
+    status: oc.output(ServerUpdateStatusSchema),
+    check: oc.input(ServerUpdateRequestSchema).output(ServerUpdateCheckSchema),
+    apply: oc.input(ServerUpdateRequestSchema).output(ServerUpdateRunSchema),
+    rollback: oc.output(ServerUpdateRunSchema),
   },
   models: {
     list: oc.output(z.array(ModelCatalogEntrySchema)),

--- a/packages/core/src/compose-update.test.ts
+++ b/packages/core/src/compose-update.test.ts
@@ -188,7 +188,20 @@ describe("strategy and mode selection", () => {
     });
     expect(source.kind).toBe("source");
     expect(source.mode).toBe("checkout");
-    expect(manualUpgradeCommands("compose")).toEqual([...COMPOSE_MANUAL_UPGRADE_COMMANDS]);
+    expect(manualUpgradeCommands("compose")).toEqual([
+      "# Published release tag",
+      ...COMPOSE_MANUAL_UPGRADE_COMMANDS,
+      "# Local tag (rebuild from checkout)",
+      "git pull",
+      "GIT_SHA=$(git rev-parse HEAD) docker compose --env-file .env -f infra/compose/docker-compose.prod.yml up -d --wait --pull never --build api worker web",
+    ]);
+    expect(manualUpgradeCommands("compose", { imageTag: "local" })).toEqual([
+      "git pull",
+      "GIT_SHA=$(git rev-parse HEAD) docker compose --env-file .env -f infra/compose/docker-compose.prod.yml up -d --wait --pull never --build api worker web",
+    ]);
+    expect(manualUpgradeCommands("compose", { imageTag: "sha-abc" })).toEqual([
+      ...COMPOSE_MANUAL_UPGRADE_COMMANDS,
+    ]);
     expect(manualUpgradeCommands("source")).toEqual([...SOURCE_MANUAL_UPGRADE_COMMANDS]);
     expect(manualUpgradeCommands("sidecar")).toEqual([]);
   });

--- a/packages/core/src/compose-update.test.ts
+++ b/packages/core/src/compose-update.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  COMPOSE_MANUAL_UPGRADE_COMMANDS,
   chooseUpdateStrategy,
   commitImageTag,
   compareReleaseTags,
@@ -19,6 +20,7 @@ import {
   isValidComposeProjectName,
   isValidImageName,
   isValidImageTag,
+  manualUpgradeCommands,
   OFFICIAL_SERVER_IMAGE,
   parseGitNameOnly,
   parseLsRemoteReleases,
@@ -27,8 +29,10 @@ import {
   RECREATED_SERVICES,
   resolveComposeProjectName,
   resolveExecutionMode,
+  resolveInstallKind,
   resolveTrackedDirtyPaths,
   rollbackTarget,
+  SOURCE_MANUAL_UPGRADE_COMMANDS,
   selectLatestRelease,
   selectLatestReleaseTag,
   upsertEnvAssignments,
@@ -163,6 +167,30 @@ describe("strategy and mode selection", () => {
     const off = resolveExecutionMode({ hasUpdater: true, disabled: true });
     expect(off.mode).toBe("unavailable");
     expect(off.reason).toMatch(/switched off/);
+  });
+
+  it("detects sidecar, compose-without-sidecar, and source install kinds", () => {
+    expect(
+      resolveInstallKind({ updaterUrlConfigured: true, updaterReachable: true, hasCheckout: true }),
+    ).toEqual({ kind: "sidecar", mode: "sidecar", reason: null });
+    const compose = resolveInstallKind({
+      updaterUrlConfigured: true,
+      updaterReachable: false,
+      hasCheckout: true,
+    });
+    expect(compose.kind).toBe("compose");
+    expect(compose.mode).toBe("unavailable");
+    expect(compose.reason).toMatch(/sidecar/);
+    const source = resolveInstallKind({
+      updaterUrlConfigured: false,
+      updaterReachable: false,
+      hasCheckout: true,
+    });
+    expect(source.kind).toBe("source");
+    expect(source.mode).toBe("checkout");
+    expect(manualUpgradeCommands("compose")).toEqual([...COMPOSE_MANUAL_UPGRADE_COMMANDS]);
+    expect(manualUpgradeCommands("source")).toEqual([...SOURCE_MANUAL_UPGRADE_COMMANDS]);
+    expect(manualUpgradeCommands("sidecar")).toEqual([]);
   });
 });
 

--- a/packages/core/src/compose-update.ts
+++ b/packages/core/src/compose-update.ts
@@ -280,6 +280,89 @@ export function resolveExecutionMode(input: {
   };
 }
 
+/**
+ * What the deployment-owner Settings UI should show. Distinct from {@link resolveExecutionMode}:
+ * Compose without the opt-in sidecar is still a Compose install, and source checkouts must never
+ * look like they can one-click apply from the API process (no `.git` in the app image; no Docker
+ * socket either).
+ */
+export type InstallKind = "sidecar" | "compose" | "source";
+
+export interface InstallKindDecision {
+  kind: InstallKind;
+  /** Maps onto ServerUpdateMode for contracts that already use that enum. */
+  mode: ExecutionMode;
+  reason: string | null;
+}
+
+/**
+ * `updaterUrlConfigured` means the API was given `RAKAZO_UPDATER_URL` (Compose prod always sets
+ * this). Reachability requires both URL and token and a live sidecar. A source checkout is only
+ * claimed when there is no Compose updater wiring and `.git` is present on disk.
+ */
+export function resolveInstallKind(input: {
+  updaterUrlConfigured?: boolean;
+  updaterReachable?: boolean;
+  hasCheckout?: boolean;
+  disabled?: boolean;
+}): InstallKindDecision {
+  if (input.disabled === true) {
+    return {
+      kind:
+        input.updaterUrlConfigured === true
+          ? "compose"
+          : input.hasCheckout === true
+            ? "source"
+            : "compose",
+      mode: "unavailable",
+      reason: "Self-update is switched off for this deployment.",
+    };
+  }
+  if (input.updaterReachable === true) {
+    return { kind: "sidecar", mode: "sidecar", reason: null };
+  }
+  if (input.updaterUrlConfigured === true) {
+    return {
+      kind: "compose",
+      mode: "unavailable",
+      reason:
+        "The updater sidecar is not reachable. Start the opt-in `updater` profile, or upgrade from the host with the Compose commands below.",
+    };
+  }
+  if (input.hasCheckout === true) {
+    return {
+      kind: "source",
+      mode: "checkout",
+      reason: "This is a source checkout. Upgrade from a terminal; Settings cannot apply it.",
+    };
+  }
+  return {
+    kind: "compose",
+    mode: "unavailable",
+    reason:
+      "This deployment has no updater sidecar. Upgrade from the host with the Compose commands below, or enable the `updater` profile.",
+  };
+}
+
+/** Exact host commands from docs/self-host.md for Compose deployments without the sidecar. */
+export const COMPOSE_MANUAL_UPGRADE_COMMANDS = [
+  "docker compose --env-file .env -f infra/compose/docker-compose.prod.yml pull api worker web",
+  "docker compose --env-file .env -f infra/compose/docker-compose.prod.yml up -d --wait --pull never api worker web",
+] as const;
+
+/** Exact host commands from docs/self-host.md for source / `pnpm dev` installs. */
+export const SOURCE_MANUAL_UPGRADE_COMMANDS = [
+  "git pull",
+  "pnpm --filter @rakazo/db migrate",
+  "# Restart the API and worker processes",
+] as const;
+
+export function manualUpgradeCommands(kind: InstallKind): readonly string[] {
+  if (kind === "source") return SOURCE_MANUAL_UPGRADE_COMMANDS;
+  if (kind === "compose") return COMPOSE_MANUAL_UPGRADE_COMMANDS;
+  return [];
+}
+
 export interface ComposeInvocation {
   command: string;
   args: string[];

--- a/packages/core/src/compose-update.ts
+++ b/packages/core/src/compose-update.ts
@@ -344,11 +344,20 @@ export function resolveInstallKind(input: {
   };
 }
 
-/** Exact host commands from docs/self-host.md for Compose deployments without the sidecar. */
-export const COMPOSE_MANUAL_UPGRADE_COMMANDS = [
+/** Exact host commands from docs/self-host.md for Compose on a published release tag. */
+export const COMPOSE_PULL_UPGRADE_COMMANDS = [
   "docker compose --env-file .env -f infra/compose/docker-compose.prod.yml pull api worker web",
   "docker compose --env-file .env -f infra/compose/docker-compose.prod.yml up -d --wait --pull never api worker web",
 ] as const;
+
+/** Exact host commands from docs/self-host.md for Compose on the default `local` tag. */
+export const COMPOSE_LOCAL_BUILD_UPGRADE_COMMANDS = [
+  "git pull",
+  "GIT_SHA=$(git rev-parse HEAD) docker compose --env-file .env -f infra/compose/docker-compose.prod.yml up -d --wait --pull never --build api worker web",
+] as const;
+
+/** @deprecated Prefer {@link COMPOSE_PULL_UPGRADE_COMMANDS}; kept for call-site clarity in tests. */
+export const COMPOSE_MANUAL_UPGRADE_COMMANDS = COMPOSE_PULL_UPGRADE_COMMANDS;
 
 /** Exact host commands from docs/self-host.md for source / `pnpm dev` installs. */
 export const SOURCE_MANUAL_UPGRADE_COMMANDS = [
@@ -357,10 +366,26 @@ export const SOURCE_MANUAL_UPGRADE_COMMANDS = [
   "# Restart the API and worker processes",
 ] as const;
 
-export function manualUpgradeCommands(kind: InstallKind): readonly string[] {
+/**
+ * Host commands Settings should show when the sidecar cannot apply.
+ * Compose picks pull vs rebuild from the current image tag when known; otherwise both documented
+ * paths from self-host.md so a `local` install is not told to `pull` a tag the registry never serves.
+ */
+export function manualUpgradeCommands(
+  kind: InstallKind,
+  options: { imageTag?: string | null } = {},
+): readonly string[] {
   if (kind === "source") return SOURCE_MANUAL_UPGRADE_COMMANDS;
-  if (kind === "compose") return COMPOSE_MANUAL_UPGRADE_COMMANDS;
-  return [];
+  if (kind !== "compose") return [];
+  const tag = options.imageTag?.trim() ?? "";
+  if (tag !== "" && isLocalImageTag(tag)) return COMPOSE_LOCAL_BUILD_UPGRADE_COMMANDS;
+  if (tag !== "" && !isLocalImageTag(tag)) return COMPOSE_PULL_UPGRADE_COMMANDS;
+  return [
+    "# Published release tag",
+    ...COMPOSE_PULL_UPGRADE_COMMANDS,
+    "# Local tag (rebuild from checkout)",
+    ...COMPOSE_LOCAL_BUILD_UPGRADE_COMMANDS,
+  ];
 }
 
 export interface ComposeInvocation {

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -57,7 +57,6 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["updater/status"],
       ["updater/check", {}],
       ["updater/apply", {}],
-      ["updater/rollback"],
       ["models/list"],
       ["models/credentials"],
       ["models/connect", { provider: "test", apiKey: "not-a-real-key" }],
@@ -767,7 +766,6 @@ describeWithDatabase("API authorization and resource isolation", () => {
     await expectDenied(app, other, "updater/status", {});
     await expectDenied(app, other, "updater/check", {});
     await expectDenied(app, other, "updater/apply", {});
-    await expectDenied(app, other, "updater/rollback", {});
     expect(
       await handles.prisma.deploymentSettings.findUniqueOrThrow({ where: { id: "default" } }),
     ).toMatchObject({ signupsEnabled: true, signupAllowlist: "" });

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -54,6 +54,10 @@ describeWithDatabase("API authorization and resource isolation", () => {
       ["me"],
       ["deployment/get"],
       ["deployment/update", { signupsEnabled: true }],
+      ["updater/status"],
+      ["updater/check", {}],
+      ["updater/apply", {}],
+      ["updater/rollback"],
       ["models/list"],
       ["models/credentials"],
       ["models/connect", { provider: "test", apiKey: "not-a-real-key" }],
@@ -760,6 +764,10 @@ describeWithDatabase("API authorization and resource isolation", () => {
       signupsEnabled: false,
       signupAllowlist: ["attacker@example.test"],
     });
+    await expectDenied(app, other, "updater/status", {});
+    await expectDenied(app, other, "updater/check", {});
+    await expectDenied(app, other, "updater/apply", {});
+    await expectDenied(app, other, "updater/rollback", {});
     expect(
       await handles.prisma.deploymentSettings.findUniqueOrThrow({ where: { id: "default" } }),
     ).toMatchObject({ signupsEnabled: true, signupAllowlist: "" });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires deployment-owner **Settings → Software update** to the existing opt-in updater sidecar (`infra/updater`, Compose `updater` profile). Replaces the rejected #335 approach (in-API git fetch / fast-forward). The API still never runs git apply.

Owner RPCs proxy `/state`, `/plan`, and `/apply` over the private control network and keep `RAKAZO_UPDATER_TOKEN` server-side. Sidecar `/rollback` remains for ops only and is not exposed in the product.

## Settings UI

- One **Check for updates** control
- **Update** appears only when a check finds an available update
- No Rollback, no image-sha chrome, no sidecar explainer copy, no host-command dumps
- Compose-without-sidecar and source installs: section hidden
- Non-owners never see it

## Desktop / clients

Electron and Expo are clients of the same API. Desktop already has signed auto-update for the shell; this Settings path updates the server deployment only and does not refresh the Mac app.

## Tests

- Install-kind detection (`resolveInstallKind`, status reader)
- Owner gate on `updater/status|check|apply` (+ authorization harness coverage)
- Sidecar bearer proxy (token sent, never returned)
- No-git-apply when sidecar is off
- Recreate reconnect confirmation via sidecar `lastRun` (not tag alone)

## Screenshots

No agent-captured screenshots on this PR. Use CI Web E2E artifacts if visual proof is needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d737db4d-b403-430c-9ba9-4d2f16d43b21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d737db4d-b403-430c-9ba9-4d2f16d43b21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an owner-only Software Updates panel in account settings.
  - Owners can view status, check for updates, apply updates, and roll back changes.
  - Displays installation type, available revisions or tags, results, and manual upgrade commands when automatic updates are unavailable.
  - Added support for updater-managed deployments and installation-specific upgrade instructions.
  - Update and rollback operations handle temporary service restarts and confirm successful image updates.

- **Security**
  - Restricted update operations to authenticated deployment owners.
  - Prevented update credentials from appearing in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->