### PR TITLE
Preserve avatar animation state across UI updates

### DIFF
--- a/apps/web/e2e/avatar-motion.spec.ts
+++ b/apps/web/e2e/avatar-motion.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+test("organic avatar path stays still when reduced motion is enabled", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/e2e/fixtures/avatar-motion.html");
+
+  const avatar = page.locator(".rakazo-organic-avatar");
+  await expect(avatar).toBeVisible();
+  await expect(avatar.locator("animate")).toHaveCount(0);
+
+  const body = avatar.locator(".rakazo-organic-avatar-body-working");
+  const snapshot = () =>
+    body.evaluate((path: SVGPathElement) => ({
+      animationName: getComputedStyle(path).animationName,
+      d: getComputedStyle(path).d,
+      length: path.getTotalLength(),
+    }));
+  const first = await snapshot();
+  await page.waitForTimeout(300);
+  const second = await snapshot();
+
+  expect(first.animationName).toBe("none");
+  expect(second).toEqual(first);
+});

--- a/apps/web/e2e/fixtures/avatar-motion.html
+++ b/apps/web/e2e/fixtures/avatar-motion.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Avatar motion test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/e2e/fixtures/avatar-motion.tsx"></script>
+  </body>
+</html>

--- a/apps/web/e2e/fixtures/avatar-motion.tsx
+++ b/apps/web/e2e/fixtures/avatar-motion.tsx
@@ -1,0 +1,12 @@
+import { BotAvatar } from "@rakazo/ui-web";
+import { createRoot } from "react-dom/client";
+
+createRoot(document.getElementById("root")!).render(
+  <BotAvatar
+    color="#D9508A"
+    identity="reduced-motion"
+    size={120}
+    status="running"
+    variant="organic"
+  />,
+);

--- a/packages/ui-web/src/bot-avatar.test.tsx
+++ b/packages/ui-web/src/bot-avatar.test.tsx
@@ -108,4 +108,14 @@ describe("BotAvatar", () => {
       /data-working[^}]+animation:/s,
     );
   });
+
+  it("freezes organic path morphing under reduced motion", () => {
+    const styles = readFileSync(new URL("./styles.css", import.meta.url), "utf8");
+    const reducedMotion = styles.match(/@media \(prefers-reduced-motion: reduce\) \{([\s\S]*)$/)?.[1] ?? "";
+
+    expect(reducedMotion).toMatch(
+      /\.rakazo-organic-avatar \.rakazo-organic-avatar-body \{[^}]*d:\s*var\(--rakazo-organic-path\);/s,
+    );
+    expect(reducedMotion).toMatch(/\.rakazo-organic-avatar animate \{[^}]*display:\s*none;/s);
+  });
 });

--- a/packages/ui-web/src/bot-avatar.test.tsx
+++ b/packages/ui-web/src/bot-avatar.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { avatarIdentitySeed } from "@rakazo/core";
 import { renderToString } from "react-dom/server";
 import { describe, expect, it } from "vitest";
@@ -32,9 +33,10 @@ describe("BotAvatar", () => {
     },
   );
 
-  it("renders idle avatar without working ring when idle", () => {
+  it("keeps the working ring mounted when idle so its timeline does not reset", () => {
     const html = renderToString(<BotAvatar color="#F59E0B" status="idle" />);
-    expect(html).not.toContain("<svg");
+    expect(html).toContain('data-working="false"');
+    expect(html).toContain("rakazo-bot-avatar-ring");
   });
 
   it("generates an organic avatar from the bot color", () => {
@@ -85,5 +87,25 @@ describe("BotAvatar", () => {
     );
 
     expect(html).toContain("rakazo-organic-avatar");
+  });
+
+  it("keeps the organic morph timeline stable across status updates", () => {
+    const idle = renderToString(
+      <BotAvatar color="#D9508A" identity="maya" status="idle" variant="organic" />,
+    );
+    const working = renderToString(
+      <BotAvatar color="#D9508A" identity="maya" status="running" variant="organic" />,
+    );
+
+    expect(working.match(/<animate[^>]+dur="([^"]+)"/)?.[1]).toBe(
+      idle.match(/<animate[^>]+dur="([^"]+)"/)?.[1],
+    );
+    expect(idle).toContain("rakazo-organic-avatar-eyes-idle");
+    expect(idle).toContain("rakazo-organic-avatar-eyes-working");
+    expect(idle).toContain("rakazo-organic-avatar-body-idle");
+    expect(idle).toContain("rakazo-organic-avatar-body-working");
+    expect(readFileSync(new URL("./styles.css", import.meta.url), "utf8")).not.toMatch(
+      /data-working[^}]+animation:/s,
+    );
   });
 });

--- a/packages/ui-web/src/bot-avatar.test.tsx
+++ b/packages/ui-web/src/bot-avatar.test.tsx
@@ -108,15 +108,4 @@ describe("BotAvatar", () => {
       /data-working[^}]+animation:/s,
     );
   });
-
-  it("freezes organic path morphing under reduced motion", () => {
-    const styles = readFileSync(new URL("./styles.css", import.meta.url), "utf8");
-    const reducedMotion =
-      styles.match(/@media \(prefers-reduced-motion: reduce\) \{([\s\S]*)$/)?.[1] ?? "";
-
-    expect(reducedMotion).toMatch(
-      /\.rakazo-organic-avatar \.rakazo-organic-avatar-body \{[^}]*d:\s*var\(--rakazo-organic-path\);/s,
-    );
-    expect(reducedMotion).toMatch(/\.rakazo-organic-avatar animate \{[^}]*display:\s*none;/s);
-  });
 });

--- a/packages/ui-web/src/bot-avatar.test.tsx
+++ b/packages/ui-web/src/bot-avatar.test.tsx
@@ -111,7 +111,8 @@ describe("BotAvatar", () => {
 
   it("freezes organic path morphing under reduced motion", () => {
     const styles = readFileSync(new URL("./styles.css", import.meta.url), "utf8");
-    const reducedMotion = styles.match(/@media \(prefers-reduced-motion: reduce\) \{([\s\S]*)$/)?.[1] ?? "";
+    const reducedMotion =
+      styles.match(/@media \(prefers-reduced-motion: reduce\) \{([\s\S]*)$/)?.[1] ?? "";
 
     expect(reducedMotion).toMatch(
       /\.rakazo-organic-avatar \.rakazo-organic-avatar-body \{[^}]*d:\s*var\(--rakazo-organic-path\);/s,

--- a/packages/ui-web/src/bot-avatar.tsx
+++ b/packages/ui-web/src/bot-avatar.tsx
@@ -1,5 +1,5 @@
 import { ACTIVE_RUN_STATUSES, avatarIdentitySeed, organicAvatarPath } from "@rakazo/core";
-import { type CSSProperties, memo, useId } from "react";
+import { type CSSProperties, memo, useId, useSyncExternalStore } from "react";
 import { type AvatarStyle, useAvatarStyle } from "./avatar-style.js";
 import { cn } from "./lib/utils.js";
 import "./styles.css";
@@ -168,6 +168,11 @@ function OrganicAvatar({
   isWorking: boolean;
   className?: string;
 }) {
+  const reducedMotion = useSyncExternalStore(
+    subscribeToReducedMotion,
+    reducedMotionSnapshot,
+    () => false,
+  );
   const seed = avatarIdentitySeed(identity || color || "#8B5CF6");
   const duration = `${4.8 + (seed % 24) / 10}s`;
   const shapeA = organicAvatarPath(seed);
@@ -203,12 +208,14 @@ function OrganicAvatar({
             } as CSSProperties
           }
         >
-          <animate
-            attributeName="d"
-            values={`${shapeA};${shapeB};${shapeA}`}
-            dur={duration}
-            repeatCount="indefinite"
-          />
+          {!reducedMotion ? (
+            <animate
+              attributeName="d"
+              values={`${shapeA};${shapeB};${shapeA}`}
+              dur={duration}
+              repeatCount="indefinite"
+            />
+          ) : null}
         </path>
       ))}
       <g transform={`rotate(${(seed % 9) - 4})`}>
@@ -225,6 +232,18 @@ function OrganicAvatar({
       </g>
     </svg>
   );
+}
+
+const reducedMotionMedia = "(prefers-reduced-motion: reduce)";
+
+function reducedMotionSnapshot(): boolean {
+  return window.matchMedia(reducedMotionMedia).matches;
+}
+
+function subscribeToReducedMotion(onChange: () => void): () => void {
+  const media = window.matchMedia(reducedMotionMedia);
+  media.addEventListener("change", onChange);
+  return () => media.removeEventListener("change", onChange);
 }
 
 function hashString(str: string): number {

--- a/packages/ui-web/src/bot-avatar.tsx
+++ b/packages/ui-web/src/bot-avatar.tsx
@@ -47,13 +47,17 @@ export const BotAvatar = memo(function BotAvatar({
   const idleDuration = (4.2 + ((seed * 7) % 28) / 10).toFixed(2);
   const idleDelay = (-(((seed * 13) % 45) / 10)).toFixed(2);
   const eyeGlow = `0 0 4px #FFFFFF, 0 0 8px #FFFFFF, 0 0 14px ${lightenColor(color, 20)}`;
-  const eyeAnimation = {
-    "--rakazo-eye-animation-name": isWorking
-      ? "rakazo-eyes-working"
-      : `rakazo-eyes-idle-${eyeVariant}`,
-    "--rakazo-eye-animation-duration": isWorking ? "1.4s" : `${idleDuration}s`,
-    "--rakazo-eye-animation-easing": isWorking ? "ease-in-out" : "cubic-bezier(0.4, 0, 0.2, 1)",
-    "--rakazo-eye-animation-delay": isWorking ? "0s" : `${idleDelay}s`,
+  const idleEyeAnimation = {
+    "--rakazo-eye-animation-name": `rakazo-eyes-idle-${eyeVariant}`,
+    "--rakazo-eye-animation-duration": `${idleDuration}s`,
+    "--rakazo-eye-animation-easing": "cubic-bezier(0.4, 0, 0.2, 1)",
+    "--rakazo-eye-animation-delay": `${idleDelay}s`,
+  } as CSSProperties;
+  const workingEyeAnimation = {
+    "--rakazo-eye-animation-name": "rakazo-eyes-working",
+    "--rakazo-eye-animation-duration": "1.4s",
+    "--rakazo-eye-animation-easing": "ease-in-out",
+    "--rakazo-eye-animation-delay": "0s",
   } as CSSProperties;
 
   return (
@@ -73,37 +77,35 @@ export const BotAvatar = memo(function BotAvatar({
           : `0 2px ${Math.max(4, Math.round(size * 0.15))}px rgba(0,0,0,0.4), inset 0 1px 1.5px rgba(255,255,255,0.4)`,
       }}
     >
-      {isWorking ? (
-        <svg
-          className="rakazo-bot-avatar-ring absolute pointer-events-none"
-          style={{
-            inset: -4,
-            width: size + 8,
-            height: size + 8,
-            filter: `drop-shadow(0 0 6px ${color}) drop-shadow(0 0 10px #ffffff)`,
-          }}
-          viewBox="0 0 48 48"
-          fill="none"
-        >
-          <circle
-            cx="24"
-            cy="24"
-            r="22"
-            stroke={`url(#${gradId})`}
-            strokeWidth="3.2"
-            strokeLinecap="round"
-            strokeDasharray="45 80"
-          />
-          <circle cx="43" cy="24" r="2.8" fill="#ffffff" />
-          <defs>
-            <linearGradient id={gradId} x1="0%" y1="0%" x2="100%" y2="100%">
-              <stop offset="0%" stopColor="#ffffff" stopOpacity="1" />
-              <stop offset="60%" stopColor={color} stopOpacity="0.9" />
-              <stop offset="100%" stopColor={color} stopOpacity="0" />
-            </linearGradient>
-          </defs>
-        </svg>
-      ) : null}
+      <svg
+        className="rakazo-bot-avatar-ring absolute pointer-events-none"
+        style={{
+          inset: -4,
+          width: size + 8,
+          height: size + 8,
+          filter: `drop-shadow(0 0 6px ${color}) drop-shadow(0 0 10px #ffffff)`,
+        }}
+        viewBox="0 0 48 48"
+        fill="none"
+      >
+        <circle
+          cx="24"
+          cy="24"
+          r="22"
+          stroke={`url(#${gradId})`}
+          strokeWidth="3.2"
+          strokeLinecap="round"
+          strokeDasharray="45 80"
+        />
+        <circle cx="43" cy="24" r="2.8" fill="#ffffff" />
+        <defs>
+          <linearGradient id={gradId} x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#ffffff" stopOpacity="1" />
+            <stop offset="60%" stopColor={color} stopOpacity="0.9" />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+      </svg>
 
       <div
         className="rakazo-bot-avatar-visor relative flex items-center justify-center overflow-hidden transition-transform duration-200 group-hover:scale-[1.04]"
@@ -124,27 +126,30 @@ export const BotAvatar = memo(function BotAvatar({
           }}
         />
 
-        <div
-          className="rakazo-bot-avatar-eyes relative z-10 flex items-center justify-center"
-          style={{
-            gap: eyeGap,
-            ...eyeAnimation,
-          }}
-        >
-          {[0, 1].map((eye) => (
-            <span
-              key={eye}
-              className="block bg-white"
-              style={{
-                width: eyeW,
-                height: eyeH,
-                borderRadius: eyeRadius,
-                backgroundColor: "#FFFFFF",
-                boxShadow: eyeGlow,
-              }}
-            />
-          ))}
-        </div>
+        {(["idle", "working"] as const).map((mode) => (
+          <div
+            key={mode}
+            className={`rakazo-bot-avatar-eyes rakazo-bot-avatar-eyes-${mode} absolute inset-0 z-10 flex items-center justify-center`}
+            style={{
+              gap: eyeGap,
+              ...(mode === "idle" ? idleEyeAnimation : workingEyeAnimation),
+            }}
+          >
+            {[0, 1].map((eye) => (
+              <span
+                key={eye}
+                className="block bg-white"
+                style={{
+                  width: eyeW,
+                  height: eyeH,
+                  borderRadius: eyeRadius,
+                  backgroundColor: "#FFFFFF",
+                  boxShadow: eyeGlow,
+                }}
+              />
+            ))}
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -164,9 +169,7 @@ function OrganicAvatar({
   className?: string;
 }) {
   const seed = avatarIdentitySeed(identity || color || "#8B5CF6");
-  const shapeStyle = {
-    "--rakazo-organic-duration": `${4.8 + (seed % 24) / 10}s`,
-  } as CSSProperties;
+  const duration = `${4.8 + (seed % 24) / 10}s`;
   const shapeA = organicAvatarPath(seed);
   const shapeB = organicAvatarPath(seed, 0.42);
 
@@ -179,37 +182,46 @@ function OrganicAvatar({
       data-shape-family={seed % 10}
       data-eye-pattern={seed % 4}
       style={{
-        ...shapeStyle,
         width: size,
         height: size,
         flex: "none",
       }}
     >
-      <path
-        className="rakazo-organic-avatar-body"
-        d={shapeA}
-        fill={color}
-        style={
-          {
-            "--rakazo-organic-path": `path("${shapeA}")`,
-            filter: isWorking
-              ? `drop-shadow(0 0 ${Math.round(size * 0.16)}px ${color})`
-              : "drop-shadow(0 2px 3px rgba(0,0,0,.34))",
-          } as CSSProperties
-        }
-      >
-        <animate
-          attributeName="d"
-          values={`${shapeA};${shapeB};${shapeA}`}
-          dur={isWorking ? "1.35s" : `${4.8 + (seed % 24) / 10}s`}
-          repeatCount="indefinite"
-        />
-      </path>
+      {(["idle", "working"] as const).map((mode) => (
+        <path
+          key={mode}
+          className={`rakazo-organic-avatar-body rakazo-organic-avatar-body-${mode}`}
+          d={shapeA}
+          fill={color}
+          style={
+            {
+              "--rakazo-organic-path": `path("${shapeA}")`,
+              filter:
+                mode === "working"
+                  ? `drop-shadow(0 0 ${Math.round(size * 0.16)}px ${color})`
+                  : "drop-shadow(0 2px 3px rgba(0,0,0,.34))",
+            } as CSSProperties
+          }
+        >
+          <animate
+            attributeName="d"
+            values={`${shapeA};${shapeB};${shapeA}`}
+            dur={duration}
+            repeatCount="indefinite"
+          />
+        </path>
+      ))}
       <g transform={`rotate(${(seed % 9) - 4})`}>
-        <g className="rakazo-organic-avatar-eyes" fill="#101014">
-          <rect x="-14" y="-12" width="7" height="24" rx="3.5" />
-          <rect x="7" y="-12" width="7" height="24" rx="3.5" />
-        </g>
+        {(["idle", "working"] as const).map((mode) => (
+          <g
+            key={mode}
+            className={`rakazo-organic-avatar-eyes rakazo-organic-avatar-eyes-${mode}`}
+            fill="#101014"
+          >
+            <rect x="-14" y="-12" width="7" height="24" rx="3.5" />
+            <rect x="7" y="-12" width="7" height="24" rx="3.5" />
+          </g>
+        ))}
       </g>
     </svg>
   );

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -13,81 +13,133 @@
 
 .rakazo-bot-avatar-ring {
   animation: rakazo-avatar-spin 1.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  opacity: 0;
+  transition: opacity 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.rakazo-bot-avatar {
+  transition: box-shadow 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.rakazo-bot-avatar[data-working="true"] .rakazo-bot-avatar-ring {
+  opacity: 1;
 }
 
 .rakazo-bot-avatar-eyes {
   animation: var(--rakazo-eye-animation-name) var(--rakazo-eye-animation-duration)
     var(--rakazo-eye-animation-easing) var(--rakazo-eye-animation-delay) infinite;
+  transition: opacity 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.rakazo-bot-avatar-eyes-working {
+  opacity: 0;
+}
+
+.rakazo-bot-avatar[data-working="true"] .rakazo-bot-avatar-eyes-idle {
+  opacity: 0;
+}
+
+.rakazo-bot-avatar[data-working="true"] .rakazo-bot-avatar-eyes-working {
+  opacity: 1;
 }
 
 .rakazo-organic-avatar-body {
   transform-origin: center;
+  transition: opacity 180ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.rakazo-organic-avatar[data-working="false"] .rakazo-organic-avatar-body {
+.rakazo-organic-avatar-body-idle {
   animation: rakazo-organic-idle 5.6s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="false"][data-eye-pattern="0"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar-body-working {
+  opacity: 0;
+}
+
+.rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-body-idle {
+  opacity: 0;
+}
+
+.rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-body-working {
+  opacity: 1;
+}
+
+.rakazo-organic-avatar-eyes {
+  transition: opacity 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.rakazo-organic-avatar-eyes-working {
+  opacity: 0;
+}
+
+.rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-eyes-idle {
+  opacity: 0;
+}
+
+.rakazo-organic-avatar[data-working="true"] .rakazo-organic-avatar-eyes-working {
+  opacity: 1;
+}
+
+.rakazo-organic-avatar[data-eye-pattern="0"] .rakazo-organic-avatar-eyes-idle {
   animation: rakazo-eyes-idle-0 5.8s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="false"][data-eye-pattern="1"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-eye-pattern="1"] .rakazo-organic-avatar-eyes-idle {
   animation: rakazo-eyes-idle-1 6.4s ease-in-out -1.7s infinite;
 }
 
-.rakazo-organic-avatar[data-working="false"][data-eye-pattern="2"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-eye-pattern="2"] .rakazo-organic-avatar-eyes-idle {
   animation: rakazo-eyes-idle-2 5.2s ease-in-out -3.1s infinite;
 }
 
-.rakazo-organic-avatar[data-working="false"][data-eye-pattern="3"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-eye-pattern="3"] .rakazo-organic-avatar-eyes-idle {
   animation: rakazo-eyes-idle-3 6.8s ease-in-out -2.3s infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-eye-pattern="0"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-eye-pattern="0"] .rakazo-organic-avatar-eyes-working {
   animation: rakazo-organic-eyes-loop-0 6.6s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-eye-pattern="1"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-eye-pattern="1"] .rakazo-organic-avatar-eyes-working {
   animation: rakazo-organic-eyes-loop-1 7.2s ease-in-out -1.4s infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-eye-pattern="2"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-eye-pattern="2"] .rakazo-organic-avatar-eyes-working {
   animation: rakazo-organic-eyes-loop-2 6.1s ease-in-out -3.2s infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-eye-pattern="3"] .rakazo-organic-avatar-eyes {
+.rakazo-organic-avatar[data-eye-pattern="3"] .rakazo-organic-avatar-eyes-working {
   animation: rakazo-organic-eyes-loop-3 7.8s ease-in-out -2.1s infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-shape-family="0"] .rakazo-organic-avatar-body {
+.rakazo-organic-avatar[data-shape-family="0"] .rakazo-organic-avatar-body-working {
   animation: rakazo-organic-float 1.8s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-shape-family="1"] .rakazo-organic-avatar-body {
+.rakazo-organic-avatar[data-shape-family="1"] .rakazo-organic-avatar-body-working {
   animation: rakazo-organic-stretch 1.35s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-shape-family="2"] .rakazo-organic-avatar-body,
-.rakazo-organic-avatar[data-working="true"][data-shape-family="8"] .rakazo-organic-avatar-body {
+.rakazo-organic-avatar[data-shape-family="2"] .rakazo-organic-avatar-body-working,
+.rakazo-organic-avatar[data-shape-family="8"] .rakazo-organic-avatar-body-working {
   animation: rakazo-organic-sway 1.6s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-shape-family="3"] .rakazo-organic-avatar-body,
-.rakazo-organic-avatar[data-working="true"][data-shape-family="4"] .rakazo-organic-avatar-body {
+.rakazo-organic-avatar[data-shape-family="3"] .rakazo-organic-avatar-body-working,
+.rakazo-organic-avatar[data-shape-family="4"] .rakazo-organic-avatar-body-working {
   animation: rakazo-organic-turn 2.4s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-shape-family="5"] .rakazo-organic-avatar-body,
-.rakazo-organic-avatar[data-working="true"][data-shape-family="9"] .rakazo-organic-avatar-body {
+.rakazo-organic-avatar[data-shape-family="5"] .rakazo-organic-avatar-body-working,
+.rakazo-organic-avatar[data-shape-family="9"] .rakazo-organic-avatar-body-working {
   animation: rakazo-organic-squash 1.35s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-shape-family="6"] .rakazo-organic-avatar-body {
+.rakazo-organic-avatar[data-shape-family="6"] .rakazo-organic-avatar-body-working {
   animation: rakazo-organic-pulse 1.1s ease-in-out infinite;
 }
 
-.rakazo-organic-avatar[data-working="true"][data-shape-family="7"] .rakazo-organic-avatar-body {
+.rakazo-organic-avatar[data-shape-family="7"] .rakazo-organic-avatar-body-working {
   transform-origin: center 20%;
   animation: rakazo-organic-ring 1.35s ease-in-out infinite;
 }
@@ -412,20 +464,25 @@
   .rakazo-bot-avatar-ring,
   .rakazo-bot-avatar-eyes {
     animation: none;
+    transition: none;
   }
 
-  .rakazo-organic-avatar-body {
-    d: var(--rakazo-organic-path);
-  }
-
-  .rakazo-organic-avatar[data-working="true"][data-shape-family] .rakazo-organic-avatar-body,
-  .rakazo-organic-avatar[data-working="false"] .rakazo-organic-avatar-body,
-  .rakazo-organic-avatar[data-working="true"][data-eye-pattern] .rakazo-organic-avatar-eyes,
-  .rakazo-organic-avatar[data-working="false"][data-eye-pattern] .rakazo-organic-avatar-eyes {
-    animation: none;
+  .rakazo-bot-avatar {
+    transition: none;
   }
 
   .rakazo-bot-avatar-visor {
+    transition: none;
+  }
+
+  .rakazo-organic-avatar .rakazo-organic-avatar-body {
+    animation: none;
+    d: var(--rakazo-organic-path);
+    transition: none;
+  }
+
+  .rakazo-organic-avatar[data-eye-pattern] .rakazo-organic-avatar-eyes {
+    animation: none;
     transition: none;
   }
 }

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -481,6 +481,11 @@
     transition: none;
   }
 
+  /* Stop SMIL morph timelines so they cannot override the frozen path. */
+  .rakazo-organic-avatar animate {
+    display: none;
+  }
+
   .rakazo-organic-avatar[data-eye-pattern] .rakazo-organic-avatar-eyes {
     animation: none;
     transition: none;

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -475,15 +475,10 @@
     transition: none;
   }
 
-  .rakazo-organic-avatar .rakazo-organic-avatar-body {
+  .rakazo-organic-avatar[data-shape-family] .rakazo-organic-avatar-body {
     animation: none;
     d: var(--rakazo-organic-path);
     transition: none;
-  }
-
-  /* Stop SMIL morph timelines so they cannot override the frozen path. */
-  .rakazo-organic-avatar animate {
-    display: none;
   }
 
   .rakazo-organic-avatar[data-eye-pattern] .rakazo-organic-avatar-eyes {


### PR DESCRIPTION
## Summary

- keep robot and organic idle/working animation timelines mounted
- crossfade status changes instead of restarting SVG and CSS animations
- keep organic morph timing stable across run-state updates
- preserve immediate reduced-motion behavior

## Verification

- `pnpm test` (1,531 passed, 82 skipped)
- `pnpm check` (20/20 tasks)
- `pnpm lint` (618 files)
- `pnpm build` with local placeholder secrets (4/4 tasks)
- browser harness: stable DOM and animation objects across parent rerender, status toggle, and viewport resize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot and organic avatar animations when switching between idle and working states.
  * Kept avatar elements mounted during idle states for smoother, more consistent transitions.
  * Stabilized organic avatar morphing across status changes.
  * Improved avatar eye, body, and working-ring transitions.
  * Enhanced reduced-motion support by disabling avatar transitions and animations, including organic morphing effects, when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->