### PR TITLE
Filter automatic successful Playwright screenshots

### DIFF
--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -3,6 +3,7 @@ import type { Dirent } from "node:fs";
 import { copyFile, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
+  classifyPlaywrightScreenshot,
   compareScreenshotsWithBaseline,
   createScreenshotManifest,
   type PlaywrightScreenshot,
@@ -103,9 +104,9 @@ async function collectScreenshots(
   resultsPath: string,
   outputPath: string,
 ): Promise<Array<Omit<PlaywrightScreenshot, "comparison">>> {
-  const files = (await findPngFiles(resultsPath)).sort((left, right) =>
-    path.basename(left).localeCompare(path.basename(right)),
-  );
+  const files = (await findPngFiles(resultsPath))
+    .filter((file) => classifyPlaywrightScreenshot(file) !== undefined)
+    .sort((left, right) => path.basename(left).localeCompare(path.basename(right)));
   if (files.length > MAX_SCREENSHOT_COUNT) {
     throw new Error(
       `Playwright artifact contains ${files.length} screenshots; maximum is ${MAX_SCREENSHOT_COUNT}`,
@@ -122,11 +123,13 @@ async function collectScreenshots(
     }
     const screenshot = await readFile(file);
     validatePngScreenshot(screenshot, file);
+    const captureType = classifyPlaywrightScreenshot(file);
+    if (captureType === undefined) continue;
     const source = path.relative(resultsPath, file);
     const fileName = `${String(index + 1).padStart(3, "0")}-${sanitizeFileName(path.basename(file))}`;
     await copyFile(file, path.join(imagePath, fileName));
     screenshots.push({
-      captureType: isFailureCapture(file) ? "failure" : "checkpoint",
+      captureType,
       fileName: `images/${fileName}`,
       hash: createHash("sha256").update(screenshot).digest("hex"),
       source,
@@ -177,10 +180,6 @@ function titleFromFileName(fileName: string): string {
     .replace(/\.png$/i, "")
     .replace(/^\d+-/, "")
     .replaceAll(/[-_]+/g, " ");
-}
-
-function isFailureCapture(fileName: string): boolean {
-  return /^test-failed(?:-\d+)?\.png$/i.test(path.basename(fileName));
 }
 
 function testIdFromSource(source: string): string {

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyPlaywrightScreenshot,
   compareScreenshotsWithBaseline,
   createScreenshotManifest,
   type PlaywrightRun,
@@ -9,6 +10,18 @@ import {
   shouldPublishStableMainBaseline,
   updatePlaywrightHistory,
 } from "./playwright-report-dashboard.js";
+
+describe("classifyPlaywrightScreenshot", () => {
+  it("excludes automatic successful-test captures from visual review", () => {
+    expect(classifyPlaywrightScreenshot("test-finished-1.png")).toBeUndefined();
+    expect(classifyPlaywrightScreenshot("nested/test-finished-12.PNG")).toBeUndefined();
+  });
+
+  it("keeps intentional checkpoints and automatic failure captures", () => {
+    expect(classifyPlaywrightScreenshot("01-onboarding-complete.png")).toBe("checkpoint");
+    expect(classifyPlaywrightScreenshot("nested/test-failed-1.png")).toBe("failure");
+  });
+});
 
 describe("compareScreenshotsWithBaseline", () => {
   it("marks matching, changed, and new screenshots using source and SHA-256", () => {

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -47,6 +47,14 @@ export type PlaywrightScreenshotManifest = {
 
 export type PlaywrightScreenshotMetadata = Omit<PlaywrightScreenshot, "comparison" | "fileName">;
 
+export function classifyPlaywrightScreenshot(
+  fileName: string,
+): PlaywrightScreenshot["captureType"] | undefined {
+  const baseName = fileName.split(/[\\/]/).at(-1) ?? fileName;
+  if (/^test-finished(?:-\d+)?\.png$/i.test(baseName)) return undefined;
+  return /^test-failed(?:-\d+)?\.png$/i.test(baseName) ? "failure" : "checkpoint";
+}
+
 export function createScreenshotManifest(
   screenshots: PlaywrightScreenshot[],
   run?: { attempt: number; id: string },


### PR DESCRIPTION
## Summary
- exclude Playwright `test-finished-*.png` captures from published visual galleries
- preserve explicit checkpoints and automatic failure screenshots
- add regression coverage for Unix and nested screenshot paths

## Tests
- `pnpm exec vitest run packages/testkit/src/playwright-report-dashboard.test.ts`
- `pnpm --filter @rakazo/testkit test`
- `pnpm --filter @rakazo/testkit check`
- `pnpm exec biome check packages/testkit/src/playwright-report-dashboard.ts packages/testkit/src/playwright-report-dashboard.test.ts packages/testkit/src/cli/generate-playwright-report-dashboard.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot classification in the Playwright report dashboard.
  * Automatic successful-test screenshots are now excluded from visual review.
  * Failure captures and intentional checkpoints are labeled more accurately.
  * Screenshot recognition now handles case-insensitive file extensions and common path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->