### PR TITLE
Fix: do not activate recurring routines on routine save

### DIFF
--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2815,9 +2815,7 @@ export function ShellPage() {
                             name: routineDraft.name || t`Routine`,
                             prompt: routineDraft.prompt || t`Check in.`,
                             crons,
-                            ...(!targetRoutine.active && !targetRoutine.lastRunAt
-                              ? { active: true }
-                              : {}),
+                            ...(armOneShot ? { active: true } : {}),
                             ...(runAt ? { runAt } : {}),
                           });
                         } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #327.

Greptile P1: saving an inactive recurring routine was sending `active: true`, which scheduled it without an explicit enable.

Now `active: true` is only sent when arming a never-run one-shot (`armOneShot`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5628b8f3-a195-4bd2-a3c2-228bd9e56c65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5628b8f3-a195-4bd2-a3c2-228bd9e56c65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Routine updates now activate routines only when their schedules require a one-shot arm.
  * Inactive routines without a prior run are no longer activated automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->