### PR TITLE
Assert updater authorization failures precisely

### DIFF
--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -763,9 +763,9 @@ describeWithDatabase("API authorization and resource isolation", () => {
       signupsEnabled: false,
       signupAllowlist: ["attacker@example.test"],
     });
-    await expectDenied(app, other, "updater/status", {});
-    await expectDenied(app, other, "updater/check", {});
-    await expectDenied(app, other, "updater/apply", {});
+    await expectForbidden(app, other, "updater/status", {});
+    await expectForbidden(app, other, "updater/check", {});
+    await expectForbidden(app, other, "updater/apply", {});
     expect(
       await handles.prisma.deploymentSettings.findUniqueOrThrow({ where: { id: "default" } }),
     ).toMatchObject({ signupsEnabled: true, signupAllowlist: "" });
@@ -895,6 +895,12 @@ async function expectDenied(app: App, cookie: string, procedure: string, body: u
     return;
   }
   expect(response.status, procedure).toBeGreaterThanOrEqual(400);
+}
+
+async function expectForbidden(app: App, cookie: string, procedure: string, body: unknown) {
+  const response = await raw(app, cookie, procedure, body);
+  expect(response.status, procedure).toBe(403);
+  expect(await response.text(), procedure).toMatch(/forbidden/i);
 }
 
 interface Actor {


### PR DESCRIPTION
Follow-up to #343 for the final CodeRabbit finding that arrived after that PR was merged. The deployment-owner integration test now requires updater status, check, and apply calls from a non-owner to return HTTP 403 with a forbidden response, instead of accepting any error. Local router tests, all 20 typecheck tasks, and Biome lint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened authorization coverage to verify that unauthorized updater requests return HTTP 403 Forbidden responses with the expected error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->