### PR TITLE
fix(mcp): report an allowlist entry the server no longer offers

### DIFF
--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -82,5 +82,6 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await captureScreenshot(page, testInfo, "40-restored-auth-session");
   await composer.press("Enter");
   await expect(composer).toHaveValue("");
-  await expect(page.getByText(message, { exact: true })).toBeVisible();
+  // Scope to the transcript: the sidebar activity row can echo the same text.
+  await expect(page.getByTestId("transcript").getByText(message, { exact: true })).toBeVisible();
 });

--- a/packages/adapters/src/mcp-connector.test.ts
+++ b/packages/adapters/src/mcp-connector.test.ts
@@ -204,10 +204,20 @@ describe("allowlistDrift", () => {
     expect(allowlistDrift(["echo", "vanished_tool"], offered)).toEqual({
       missing: ["vanished_tool"],
       offered: 2,
+      stringAllowedCount: 2,
     });
     expect(allowlistDrift(["echo"], offered).missing).toEqual([]);
     // allowedTools is a Json column, so it can hold anything: it must not throw.
-    expect(allowlistDrift(null, offered).missing).toEqual([]);
-    expect(allowlistDrift([42, "vanished_tool"], offered).missing).toEqual(["vanished_tool"]);
+    expect(allowlistDrift(null, offered)).toEqual({
+      missing: [],
+      offered: 2,
+      stringAllowedCount: 0,
+    });
+    // Non-string JSON values are ignored for both missing and the warning ratio.
+    expect(allowlistDrift([42, "vanished_tool"], offered)).toEqual({
+      missing: ["vanished_tool"],
+      offered: 2,
+      stringAllowedCount: 1,
+    });
   });
 });

--- a/packages/adapters/src/mcp-connector.test.ts
+++ b/packages/adapters/src/mcp-connector.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { McpConnector } from "./mcp-connector.js";
+import { allowlistDrift, McpConnector } from "./mcp-connector.js";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -195,5 +195,19 @@ describe("MCP connector session cache", () => {
     expect(state.initializations).toBe(3);
 
     await connector.close();
+  });
+});
+
+describe("allowlistDrift", () => {
+  it("names the allowed tools the server no longer offers", () => {
+    const offered = [{ name: "echo" }, { name: "upper" }];
+    expect(allowlistDrift(["echo", "vanished_tool"], offered)).toEqual({
+      missing: ["vanished_tool"],
+      offered: 2,
+    });
+    expect(allowlistDrift(["echo"], offered).missing).toEqual([]);
+    // allowedTools is a Json column, so it can hold anything: it must not throw.
+    expect(allowlistDrift(null, offered).missing).toEqual([]);
+    expect(allowlistDrift([42, "vanished_tool"], offered).missing).toEqual(["vanished_tool"]);
   });
 });

--- a/packages/adapters/src/mcp-connector.ts
+++ b/packages/adapters/src/mcp-connector.ts
@@ -16,6 +16,47 @@ type SessionEntry = { session: McpSession; revision: number };
 type PendingSession = { revision: number; promise: Promise<McpSession> };
 
 /** Runtime MCP connector. Authorization is re-checked against the bot assignment on every call. */
+/**
+ * An allowlist entry the server does not offer is silently filtered out below — the tool
+ * simply never reaches the model, with no error anywhere. An allowlist is written once, by
+ * hand, against the tool names a server offered that day; the server keeps shipping. A
+ * renamed or removed tool therefore turns into a capability the bot quietly lost, and the
+ * only symptom is the model no longer doing something it used to do.
+ *
+ * The comparison is free: discovery already holds the server's real tool list.
+ */
+export function allowlistDrift(
+  allowedTools: unknown,
+  offered: Array<{ name: string }>,
+): { missing: string[]; offered: number } {
+  const names = new Set(offered.map((tool) => tool.name));
+  const allowed = Array.isArray(allowedTools) ? allowedTools : [];
+  return {
+    missing: allowed.filter((name): name is string => typeof name === "string" && !names.has(name)),
+    offered: names.size,
+  };
+}
+
+function reportAllowlistDrift(
+  assignment: { allowAllTools: boolean; allowedTools: unknown; server: { slug: string } },
+  offered: Array<{ name: string }>,
+  context: { workspaceId: string; botId?: string },
+): void {
+  if (assignment.allowAllTools) return;
+  const drift = allowlistDrift(assignment.allowedTools, offered);
+  if (drift.missing.length === 0) return;
+  const allowed = Array.isArray(assignment.allowedTools) ? assignment.allowedTools.length : 0;
+  console.warn(
+    `mcp allowlist drift on ${assignment.server.slug}: ${drift.missing.length}/${allowed} allowed tools are not offered (server offers ${drift.offered})`,
+    {
+      workspaceId: context.workspaceId,
+      botId: context.botId,
+      // Cap the list: the point is to name the drift, not to print an allowlist.
+      missing: drift.missing.slice(0, 10),
+    },
+  );
+}
+
 export class McpConnector implements ConnectorProvider {
   private readonly sessions = new Map<string, SessionEntry>();
   private readonly connecting = new Map<string, PendingSession>();
@@ -55,6 +96,7 @@ export class McpConnector implements ConnectorProvider {
         try {
           const session = await this.sessionFor(assignment.server, context);
           const listed = await session.listTools({ signal: context.signal });
+          reportAllowlistDrift(assignment, listed.tools, context);
           return listed.tools
             .filter(
               (tool) =>

--- a/packages/adapters/src/mcp-connector.ts
+++ b/packages/adapters/src/mcp-connector.ts
@@ -17,23 +17,21 @@ type PendingSession = { revision: number; promise: Promise<McpSession> };
 
 /** Runtime MCP connector. Authorization is re-checked against the bot assignment on every call. */
 /**
- * An allowlist entry the server does not offer is silently filtered out below — the tool
- * simply never reaches the model, with no error anywhere. An allowlist is written once, by
- * hand, against the tool names a server offered that day; the server keeps shipping. A
- * renamed or removed tool therefore turns into a capability the bot quietly lost, and the
- * only symptom is the model no longer doing something it used to do.
- *
- * The comparison is free: discovery already holds the server's real tool list.
+ * Stale allowlist entries are filtered out below with no error. Discovery already has the
+ * live tool list, so compare once and warn when string allowlist names are missing from the
+ * server. Non-string JSON values are ignored for both the missing list and the ratio.
  */
 export function allowlistDrift(
   allowedTools: unknown,
   offered: Array<{ name: string }>,
-): { missing: string[]; offered: number } {
+): { missing: string[]; offered: number; stringAllowedCount: number } {
   const names = new Set(offered.map((tool) => tool.name));
   const allowed = Array.isArray(allowedTools) ? allowedTools : [];
+  const stringAllowed = allowed.filter((name): name is string => typeof name === "string");
   return {
-    missing: allowed.filter((name): name is string => typeof name === "string" && !names.has(name)),
+    missing: stringAllowed.filter((name) => !names.has(name)),
     offered: names.size,
+    stringAllowedCount: stringAllowed.length,
   };
 }
 
@@ -45,9 +43,8 @@ function reportAllowlistDrift(
   if (assignment.allowAllTools) return;
   const drift = allowlistDrift(assignment.allowedTools, offered);
   if (drift.missing.length === 0) return;
-  const allowed = Array.isArray(assignment.allowedTools) ? assignment.allowedTools.length : 0;
   console.warn(
-    `mcp allowlist drift on ${assignment.server.slug}: ${drift.missing.length}/${allowed} allowed tools are not offered (server offers ${drift.offered})`,
+    `mcp allowlist drift on ${assignment.server.slug}: ${drift.missing.length}/${drift.stringAllowedCount} allowed tools are not offered (server offers ${drift.offered})`,
     {
       workspaceId: context.workspaceId,
       botId: context.botId,


### PR DESCRIPTION
## Problem

A `bot_mcp_servers` allowlist is written once, by hand, against the tool names a server offered that day. The server keeps shipping. When a tool is renamed or removed, `discoverTools` filters the stale name out of the live list and the bot silently loses a capability:

```ts
return listed.tools.filter(
  (tool) => assignment.allowAllTools || (assignment.allowedTools as unknown[]).includes(tool.name),
)
```

No error, no log, nothing on the thread — the only symptom is the model no longer doing something it used to do, and the only way to find it is comparing the allowlist against the server by hand. It gets worse the longer an allowlist lives, and worse again when the allowlist is written by a provisioning job rather than a person watching the result.

## Change

Discovery already holds both lists, so the comparison costs nothing and adds no request: warn once per discovery naming the entries the server did not offer.

```
mcp allowlist drift on <slug>: 1/6 allowed tools are not offered (server offers 42)
  { workspaceId, botId, missing: ["vanished_tool"] }
```

Behaviour is unchanged: the same tools are returned, the filter is untouched, and a server with `allowAllTools` is not inspected at all. The missing list is capped at ten — the point is to name the drift, not to print an allowlist.

`allowlistDrift` is exported as a pure function so the case that matters is testable directly, including the non-array shapes the `allowedTools` Json column can legally hold (`null`, numbers) which must not throw.

## Testing

- `pnpm lint` clean, `pnpm check` 20/20, `pnpm test` 1594 passed.
- The single failure, `desktop-sandbox-write-containment › keeps writes on the opened inode when the final name is replaced after lstat`, fails identically on an unmodified tree here (macOS), so it is not from this change.
- Not run locally: `pnpm test:integration` / `pnpm test:e2e` (no Docker in this environment). No schema, migration or UI changes.

## Note

This reports the drift rather than fixing it, deliberately. Repairing an allowlist automatically — widening it to whatever the server now offers — is a different decision with a prompt-size cost, and it belongs to whoever owns that allowlist, not to discovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection and reporting when configured MCP tools are unavailable from the connected server.
  * Reports the number of available tools and missing configured tools.
  * Warning ratios now remain accurate when invalid allowlist entries are present.
  * Invalid or non-string allowlist entries are handled safely.

* **Tests**
  * Added coverage for tool availability, counts, warning accuracy, malformed allowlist entries, and transcript message verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->