### PR TITLE
Add pull-based Compose self-host path (no clone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/d
 curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/.env.images.example
 cp .env.images.example .env
 # set POSTGRES_PASSWORD, BETTER_AUTH_SECRET, ENCRYPTION_KEY, SCREEN_PROXY_SECRET, E2B_API_KEY
+# on arm64, pin RAKAZO_IMAGE_TAG to a release (latest / vX.Y.Z); edge is amd64-only
 docker compose --env-file .env -f docker-compose.images.yml up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ your first bot.
 For an agent-assisted installation, use [SETUP_PROMPT.md](./SETUP_PROMPT.md). For deployment,
 provider selection, backups, and upgrades, see the [self-hosting guide](./docs/self-host.md).
 
+### Self-host from published images
+
+No clone required. Create a folder, drop the compose file and env example, set secrets, then pull
+and start:
+
+```bash
+mkdir rakazo && cd rakazo
+curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/docker-compose.images.yml
+curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/.env.images.example
+cp .env.images.example .env
+# set POSTGRES_PASSWORD, BETTER_AUTH_SECRET, ENCRYPTION_KEY, SCREEN_PROXY_SECRET, E2B_API_KEY
+docker compose --env-file .env -f docker-compose.images.yml up -d
+```
+
+Details and tag choices: [self-hosting guide](./docs/self-host.md#published-images-no-checkout).
+
 ## Desktop and mobile
 
 The Electron and Expo apps are clients of the same Rakazo API used by the web app.

--- a/apps/web/e2e/voice.spec.ts
+++ b/apps/web/e2e/voice.spec.ts
@@ -49,14 +49,16 @@ test("voice settings connect a key, speak a reply, and open a call", async ({ pa
   const composer = page.getByPlaceholder(/Message/);
   await composer.fill("say hello");
   await page.keyboard.press("Enter");
-  await expect(page.getByRole("button", { name: "Speak this reply" })).toBeVisible({
+  // A reply can render more than one text bubble; speak the latest one.
+  const speakReply = page.getByRole("button", { name: "Speak this reply" }).last();
+  await expect(speakReply).toBeVisible({
     timeout: 30_000,
   });
 
   const replySpoken = page.waitForResponse(
     (response) => response.url().includes("/api/voice/speak") && response.ok(),
   );
-  await page.getByRole("button", { name: "Speak this reply" }).click();
+  await speakReply.click();
   await replySpoken;
 
   await page.getByRole("button", { name: "Call" }).click();

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -19,8 +19,9 @@ cp .env.images.example .env
 
 Set `POSTGRES_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, and `SCREEN_PROXY_SECRET`. Add
 `E2B_API_KEY` (default computer provider) and an optional model key such as `OPENROUTER_API_KEY`.
-Pin `RAKAZO_IMAGE_TAG` to a release (`latest` or `vX.Y.Z`) when you want a fixed version; the
-example defaults to `edge` (main). See [Published images and tags](#published-images-and-tags).
+The example defaults to `edge` (main builds, `linux/amd64` only). On arm64 hosts, or when you want
+a fixed version, pin `RAKAZO_IMAGE_TAG` to a release (`latest` or `vX.Y.Z`; those publish
+amd64+arm64). See [Published images and tags](#published-images-and-tags).
 
 ```bash
 docker compose --env-file .env -f docker-compose.images.yml pull
@@ -284,6 +285,10 @@ your CI cannot publish into someone else's.
 | `latest` | stable `vX.Y.Z` tags only (not prereleases) | yes, to the newest stable release |
 | `sha-<full-commit>` | every push and manual run | source-addressed; used by the updater sidecar |
 | `edge` | pushes to main | yes, to the newest main build |
+
+`edge` from everyday main merges is `linux/amd64` only. Release tags (`v*`) and manual
+`workflow_dispatch` publishes are multi-arch (`amd64` + `arm64`). On arm64 hosts, pin a release
+tag rather than `edge`.
 
 The updater resolves the newest stable `vX.Y.Z` source tag but deploys its `sha-<full-commit>` image,
 not `latest` or a moving minor tag. A registry tag is not an OCI digest and GHCR package writers can

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -6,6 +6,32 @@ The signed-in product is a long-running API, a Graphile Worker, Postgres, and a 
 
 Same as the README quick start: `.env` from `.env.example`, Postgres via Compose, `pnpm sandbox:build`, `pnpm dev`, then [http://127.0.0.1:5173](http://127.0.0.1:5173). Electron: `pnpm --filter @rakazo/desktop dev` while that stack is up.
 
+## Published images (no checkout)
+
+Pull Postgres and `ghcr.io/elie222/rakazo/app` into any empty folder. No clone or image build.
+
+```bash
+mkdir rakazo && cd rakazo
+curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/docker-compose.images.yml
+curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/.env.images.example
+cp .env.images.example .env
+```
+
+Set `POSTGRES_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, and `SCREEN_PROXY_SECRET`. Add
+`E2B_API_KEY` (default computer provider) and an optional model key such as `OPENROUTER_API_KEY`.
+Pin `RAKAZO_IMAGE_TAG` to a release (`latest` or `vX.Y.Z`) when you want a fixed version; the
+example defaults to `edge` (main). See [Published images and tags](#published-images-and-tags).
+
+```bash
+docker compose --env-file .env -f docker-compose.images.yml pull
+docker compose --env-file .env -f docker-compose.images.yml up -d
+```
+
+Open [http://127.0.0.1:5173](http://127.0.0.1:5173). The first registered user becomes the
+deployment owner. Put TLS in front of `:5173` for a public host and set the three public origins to
+that HTTPS URL. For Docker sandboxes on the same machine, or automatic HTTPS via Caddy, use the
+Compose paths below (those still expect a checkout).
+
 ## Docker Compose (single machine)
 
 1. Copy `.env.example` to `.env` and set `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, and `SCREEN_PROXY_SECRET` to independent long random strings (32+ characters; 64 hex for `ENCRYPTION_KEY`). Docker sandboxes also need a dedicated `SANDBOX_SUPERVISOR_TOKEN`. Keep existing `ENCRYPTION_KEY` values so stored credentials stay decryptable.
@@ -242,6 +268,10 @@ this repository that is:
 | --- | --- |
 | `ghcr.io/elie222/rakazo/app` | api, worker, and web — one image, three commands |
 | `ghcr.io/elie222/rakazo/updater` | the updater sidecar, plus the Docker CLI |
+
+`infra/compose/docker-compose.images.yml` is the no-checkout path for those app tags plus Postgres.
+Production Compose (`docker-compose.prod.yml`) can also pull the same tags once
+`RAKAZO_IMAGE_TAG` is set to a published value.
 
 If you deploy from your own fork, set `RAKAZO_IMAGE` and `RAKAZO_UPDATER_IMAGE` to your namespace —
 your CI cannot publish into someone else's.

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -1,0 +1,39 @@
+# Copy to .env next to docker-compose.images.yml and fill in the values below.
+# Secrets must be independent long random strings (32+ characters; 64 hex for ENCRYPTION_KEY).
+# Use URL-safe characters for POSTGRES_PASSWORD (it is interpolated into DATABASE_URL).
+
+NODE_ENV=production
+POSTGRES_USER=rakazo
+POSTGRES_PASSWORD=replace-with-url-safe-password
+POSTGRES_DB=rakazo
+
+BETTER_AUTH_SECRET=replace-with-32-plus-character-secret
+ENCRYPTION_KEY=replace-with-64-random-hex-characters
+SCREEN_PROXY_SECRET=replace-with-32-plus-character-screen-proxy-secret
+
+# Public origin the browser uses. For a VPS, put TLS in front of :5173 and use https://…
+BETTER_AUTH_URL=http://127.0.0.1:5173
+WEB_ORIGIN=http://127.0.0.1:5173
+API_URL=http://127.0.0.1:5173
+RAKAZO_HOST=localhost
+
+SIGNUPS_ENABLED=true
+SIGNUP_ALLOWLIST=
+
+# Published image tag. edge tracks main; pin latest or vX.Y.Z for a release.
+RAKAZO_IMAGE=ghcr.io/elie222/rakazo/app
+RAKAZO_IMAGE_TAG=edge
+
+# Remote computers (no Docker socket on this host). Set the matching provider key.
+SANDBOX_PROVIDER=e2b
+E2B_API_KEY=
+# DAYTONA_API_KEY=
+# BOX_API_KEY=
+
+AGENT_RUNTIME=pi
+WAKEUP_DRIVER=graphile
+DATA_DIR=/data
+
+# Optional model / integration keys
+OPENROUTER_API_KEY=
+COMPOSIO_API_KEY=

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -20,7 +20,8 @@ RAKAZO_HOST=localhost
 SIGNUPS_ENABLED=true
 SIGNUP_ALLOWLIST=
 
-# Published image tag. edge tracks main; pin latest or vX.Y.Z for a release.
+# Published image tag. edge tracks main (amd64 only). Pin latest or vX.Y.Z for a
+# release (amd64+arm64) or when you want a fixed version on any host.
 RAKAZO_IMAGE=ghcr.io/elie222/rakazo/app
 RAKAZO_IMAGE_TAG=edge
 

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -1,9 +1,10 @@
 # Pull-based self-host: published GHCR images + Postgres. No source checkout required.
-# Drop this file and .env into any directory, then: docker compose --env-file .env up -d
+# Drop this file and .env into any directory, then:
+#   docker compose --env-file .env -f docker-compose.images.yml up -d
 #
 # Tag contract matches docs/self-host.md (edge from main; latest / vX.Y.Z from stable releases).
-# Default is edge because that tag is published on every main build; pin a release tag in
-# production when you want a fixed version.
+# Default is edge because that tag is published on every main build (linux/amd64 only).
+# Pin a release tag (latest or vX.Y.Z) for multi-arch amd64+arm64 and for a fixed version.
 name: rakazo
 
 services:

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -1,0 +1,139 @@
+# Pull-based self-host: published GHCR images + Postgres. No source checkout required.
+# Drop this file and .env into any directory, then: docker compose --env-file .env up -d
+#
+# Tag contract matches docs/self-host.md (edge from main; latest / vX.Y.Z from stable releases).
+# Default is edge because that tag is published on every main build; pin a release tag in
+# production when you want a fixed version.
+name: rakazo
+
+services:
+  postgres:
+    image: postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 200
+    mem_limit: 2g
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-rakazo}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-rakazo}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-rakazo} -d ${POSTGRES_DB:-rakazo}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  api:
+    image: ${RAKAZO_IMAGE:-ghcr.io/elie222/rakazo/app}:${RAKAZO_IMAGE_TAG:-edge}
+    restart: unless-stopped
+    command:
+      - bash
+      - -lc
+      - pnpm --filter @rakazo/db exec prisma migrate deploy && pnpm --filter @rakazo/api start
+    init: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 256
+    mem_limit: 1536m
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+      API_HOST: "0.0.0.0"
+      DATABASE_URL: postgres://${POSTGRES_USER:-rakazo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-rakazo}
+      DATA_DIR: /data
+      SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-e2b}
+      WAKEUP_DRIVER: graphile
+      AGENT_RUNTIME: pi
+    ports:
+      - "127.0.0.1:3100:3100"
+    volumes:
+      - appdata:/data
+    networks:
+      - app
+      - data
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - fetch('http://127.0.0.1:3100/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  worker:
+    image: ${RAKAZO_IMAGE:-ghcr.io/elie222/rakazo/app}:${RAKAZO_IMAGE_TAG:-edge}
+    restart: unless-stopped
+    command: ["pnpm", "--filter", "@rakazo/worker", "start"]
+    init: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 512
+    mem_limit: 2g
+    env_file:
+      - .env
+    environment:
+      BETTER_AUTH_SECRET: ""
+      NODE_ENV: production
+      DATABASE_URL: postgres://${POSTGRES_USER:-rakazo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-rakazo}
+      DATA_DIR: /data
+      SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-e2b}
+      SCREEN_PROXY_SECRET: ""
+      WAKEUP_DRIVER: graphile
+      AGENT_RUNTIME: pi
+    volumes:
+      - appdata:/data
+    networks:
+      - app
+      - data
+    depends_on:
+      postgres:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+
+  web:
+    image: ${RAKAZO_IMAGE:-ghcr.io/elie222/rakazo/app}:${RAKAZO_IMAGE_TAG:-edge}
+    restart: unless-stopped
+    command: ["pnpm", "--filter", "@rakazo/web", "preview", "--host", "0.0.0.0", "--port", "5173"]
+    init: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 128
+    mem_limit: 512m
+    environment:
+      NODE_ENV: production
+      API_PROXY_TARGET: http://api:3100
+      RAKAZO_HOST: ${RAKAZO_HOST:-localhost}
+      SCREEN_PROXY_SECRET: ${SCREEN_PROXY_SECRET:?Set SCREEN_PROXY_SECRET in .env}
+    ports:
+      - "127.0.0.1:5173:5173"
+    networks:
+      - app
+    depends_on:
+      api:
+        condition: service_healthy
+
+volumes:
+  pgdata:
+  appdata:
+
+networks:
+  app:
+  data:
+    internal: true

--- a/infra/updater/src/compose-images.test.ts
+++ b/infra/updater/src/compose-images.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+interface ComposeService {
+  image?: string;
+  build?: unknown;
+  env_file?: unknown;
+  volumes?: string[];
+  ports?: unknown[];
+}
+
+const composeFile = path.resolve(import.meta.dirname, "../../compose/docker-compose.images.yml");
+const compose = parse(readFileSync(composeFile, "utf8")) as {
+  services: Record<string, ComposeService>;
+};
+
+const appServices = ["api", "worker", "web"] as const;
+
+/**
+ * The images compose file is the no-checkout happy path. It must stay pull-only and self-contained
+ * so operators can drop it next to a .env outside any git worktree.
+ */
+describe("the images compose file", () => {
+  it("runs postgres and the three app roles from published images", () => {
+    expect(Object.keys(compose.services).sort()).toEqual(["api", "postgres", "web", "worker"]);
+    for (const service of appServices) {
+      expect(compose.services[service]?.image).toContain("ghcr.io/elie222/rakazo/app");
+      expect(compose.services[service]?.image).toContain("RAKAZO_IMAGE_TAG");
+    }
+    expect(compose.services.postgres?.image).toMatch(/^postgres:16@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("never builds from a checkout", () => {
+    for (const service of Object.values(compose.services)) {
+      expect(service.build).toBeUndefined();
+    }
+  });
+
+  it("loads secrets from a colocated .env", () => {
+    expect(compose.services.api?.env_file).toEqual([".env"]);
+    expect(compose.services.worker?.env_file).toEqual([".env"]);
+  });
+
+  it("does not attach a Docker socket", () => {
+    for (const service of Object.values(compose.services)) {
+      expect((service.volumes ?? []).some((volume) => volume.includes("docker.sock"))).toBe(false);
+    }
+  });
+
+  it("publishes the web UI on loopback only", () => {
+    expect(compose.services.web?.ports).toEqual(["127.0.0.1:5173:5173"]);
+    expect(compose.services.postgres?.ports).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a no-checkout self-host path that pulls published GHCR images instead of cloning and building.

## Changes

- `infra/compose/docker-compose.images.yml`: Postgres + api/worker/web from `ghcr.io/elie222/rakazo/app` (existing tag contract; default `edge`, amd64-only; pin a release tag for multi-arch)
- `infra/compose/.env.images.example`: minimal secrets/host/provider env for a standalone folder
- Short install steps in README and `docs/self-host.md`
- Guardrail test that the images compose file stays pull-only (no `build`, no Docker socket)
- Tiny voice E2E locator fix (`.last()`) so Playwright strict mode does not flake when a reply renders multiple Speak buttons; that failure hit CI on this branch

## Happy path

```bash
mkdir rakazo && cd rakazo
curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/docker-compose.images.yml
curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/.env.images.example
cp .env.images.example .env
# set secrets + E2B_API_KEY
docker compose --env-file .env -f docker-compose.images.yml up -d
```

Does not change the production image toolchain or the existing checkout-based Compose files.

Closes #279

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfe13134-2d5d-4e6e-8ea9-65b95b3cb0b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfe13134-2d5d-4e6e-8ea9-65b95b3cb0b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

