### PR TITLE
fix(sandbox): boot a fresh sandbox when a reconnect cannot reach the old one

### DIFF
--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -19,6 +19,31 @@ describe("E2B computer backend", () => {
     expect(shouldSkipPortableWorkspaceFile(".browser-profiles/chromium/SingletonLock")).toBe(true);
   });
 
+  it("boots a fresh sandbox when reconnecting to a dead one fails with fetch failed", async () => {
+    const desktop = { sandboxId: "fresh-e2b-box" } as unknown as Sandbox;
+    const sdk: E2BSandboxSdk = {
+      create: vi.fn(async () => desktop),
+      connect: vi.fn(async () => {
+        throw new Error("fetch failed", {
+          cause: Object.assign(new Error("getaddrinfo ENOTFOUND dead-e2b-box.e2b.app"), {
+            code: "ENOTFOUND",
+          }),
+        });
+      }),
+      pause: vi.fn(async () => undefined),
+    };
+    const provider = new E2BSandboxProvider("test-key", sdk);
+
+    const computer = await provider.provision(
+      { botId: "bot-1", homePath: "/unused", providerRef: "dead-e2b-box", providerKind: "e2b" },
+      context,
+    );
+
+    expect(sdk.create).toHaveBeenCalledTimes(1);
+    expect(computer.providerRef).toBe("fresh-e2b-box");
+    expect(computer.fresh).toBe(true);
+  });
+
   it("prepares a reused computer idempotently", async () => {
     let profilesConfigured = false;
     const command = vi.fn(async (value: string) => {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -70,11 +70,41 @@ export function e2bCreateOptions(botId: string, apiKey: string) {
   };
 }
 
+// A sandbox that has expired stops resolving as a host, so reaching it fails at the socket
+// rather than with a 404. undici reports every one of those as a bare "fetch failed" and
+// hides the errno on the cause chain.
+const SANDBOX_UNREACHABLE_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+function isUnreachableTransportError(error: unknown): boolean {
+  for (let current = error; current instanceof Error; current = current.cause) {
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && SANDBOX_UNREACHABLE_CODES.has(code)) return true;
+    if (current.message === "fetch failed") return true;
+  }
+  return false;
+}
+
+/**
+ * True when the sandbox this error came from cannot be reached again, so the caller should
+ * boot a fresh one. A reconnect that fails must never be fatal: rethrowing left the bot
+ * dialling the same dead sandbox on all 25 retries, with no way out.
+ */
 export function isUnrecoverableSandboxError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /not found|does not exist|404|not_found|killed|doesn't exist|sandbox not found/i.test(
-    message,
-  );
+  if (
+    /not found|does not exist|404|not_found|killed|doesn't exist|sandbox not found/i.test(message)
+  )
+    return true;
+  return isUnreachableTransportError(error);
 }
 
 export const E2B_BROWSER_APPS = ["google-chrome", "firefox", "chromium"] as const;

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2583,10 +2583,18 @@ export function createRunExecutor(deps: ExecutorDeps) {
       } catch (setupError) {
         const computerBusy = setupError instanceof ComputerBusyError;
         if (!computerBusy) {
+          // undici collapses every network failure to "fetch failed"; the cause names the
+          // host and errno, which is the only part worth paging over.
+          const causeMessage =
+            setupError instanceof Error && setupError.cause instanceof Error
+              ? `: ${setupError.cause.message}`
+              : "";
           console.error(
             "run setup failed",
             redactSecrets(
-              setupError instanceof Error ? setupError.message : String(setupError),
+              setupError instanceof Error
+                ? `${setupError.message}${causeMessage}`
+                : String(setupError),
               runSecrets,
             ),
           );


### PR DESCRIPTION
## Problem

`E2BSandboxProvider.provision()` reconnects to an existing sandbox when the computer row still carries a `providerRef`. If that reconnect throws, it only falls through to `sdk.create()` when `isUnrecoverableSandboxError()` says so — otherwise it rethrows.

That predicate matches on message wording (`not found|404|killed|…`). But a sandbox that has expired stops resolving as a host, so reaching it fails at the socket, and undici reports every one of those as a bare `fetch failed` with the errno hidden on the cause chain. Nothing matches, so the run rethrows, `continueRun` records `run setup failed`, and the bot redials the same dead sandbox on all 25 retries with no way out.

## Change

- Classify by walking the `cause` chain for a transport errno (`ENOTFOUND`, `ECONNREFUSED`, `EAI_AGAIN`, `UND_ERR_*`, …) instead of trusting the provider's message wording.
- Log `error.cause` next to `run setup failed`, so an opaque `fetch failed` names its host and errno.

A reconnect is an optimisation; failing it should cost a fresh boot, never wedge the bot permanently. On a genuine outage `sdk.create()` fails on the next line anyway, so no sandbox is leaked.

## Test

`packages/adapters/src/e2b-sandbox.test.ts` — a reconnect that fails with `fetch failed` (cause `ENOTFOUND`) must boot a fresh sandbox. Verified both ways: the test fails against the previous predicate and passes with this one. 32 tests pass across `e2b-sandbox` and `sandbox-faults`.

Found while chasing an unrelated `run setup failed fetch failed` on our deployment — that turned out to be a misconfigured sandbox provider, but the reconnect path is a real trap independent of it, and the missing `cause` in the log is what made it expensive to find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically starts a fresh sandbox when reconnecting fails because the existing sandbox is unreachable.
  * Recognizes additional network and connection failures, including DNS lookup failures and connection timeouts.
  * Error messages now include underlying network details when available, improving troubleshooting for failed runs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->