### PR TITLE
fix(sandbox): keep transport errors out of replaceComputer

### DIFF
--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SANDBOX_IDLE_MS, sandboxIdleMs, sleepComputerIfIdle } from "./c
 import {
   e2bCreateOptions,
   isUnrecoverableSandboxError,
+  isUnreachableTransportError,
   openDesktopBrowser,
   openDesktopUrl,
 } from "./e2b-sandbox.js";
@@ -105,6 +106,13 @@ describe("e2b create options", () => {
   it("only recreates when the sandbox is actually gone", () => {
     expect(isUnrecoverableSandboxError(new Error("sandbox not found"))).toBe(true);
     expect(isUnrecoverableSandboxError(new Error("ECONNRESET"))).toBe(false);
+    // Transient transport codes must not satisfy the replaceComputer predicate: otherwise
+    // update mode swallows a checkpoint blip, destroys the old box, and drops uncommitted work.
+    const reset = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    expect(isUnrecoverableSandboxError(reset)).toBe(false);
+    expect(isUnreachableTransportError(reset)).toBe(true);
+    expect(isUnrecoverableSandboxError(new Error("fetch failed"))).toBe(false);
+    expect(isUnreachableTransportError(new Error("fetch failed"))).toBe(true);
   });
 
   it("opens a browser on a new desktop", async () => {

--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_SANDBOX_IDLE_MS, sandboxIdleMs, sleepComputerIfIdle } from "./computer-idle.js";
 import {
   e2bCreateOptions,
-  isUnrecoverableSandboxError,
   isUnreachableTransportError,
+  isUnrecoverableSandboxError,
   openDesktopBrowser,
   openDesktopUrl,
 } from "./e2b-sandbox.js";

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -72,7 +72,9 @@ export function e2bCreateOptions(botId: string, apiKey: string) {
 
 // A sandbox that has expired stops resolving as a host, so reaching it fails at the socket
 // rather than with a 404. undici reports every one of those as a bare "fetch failed" and
-// hides the errno on the cause chain.
+// hides the errno on the cause chain. Used only by provision reconnect: replaceComputer must
+// not treat these as permanent, or an update-mode checkpoint blip destroys the old box
+// without committing workspace changes that exist only there.
 const SANDBOX_UNREACHABLE_CODES = new Set([
   "ECONNREFUSED",
   "ECONNRESET",
@@ -84,7 +86,7 @@ const SANDBOX_UNREACHABLE_CODES = new Set([
   "UND_ERR_SOCKET",
 ]);
 
-function isUnreachableTransportError(error: unknown): boolean {
+export function isUnreachableTransportError(error: unknown): boolean {
   for (let current = error; current instanceof Error; current = current.cause) {
     const code = (current as { code?: unknown }).code;
     if (typeof code === "string" && SANDBOX_UNREACHABLE_CODES.has(code)) return true;
@@ -94,17 +96,16 @@ function isUnreachableTransportError(error: unknown): boolean {
 }
 
 /**
- * True when the sandbox this error came from cannot be reached again, so the caller should
- * boot a fresh one. A reconnect that fails must never be fatal: rethrowing left the bot
- * dialling the same dead sandbox on all 25 retries, with no way out.
+ * True when the sandbox is permanently gone (404 / killed / not found). Used by
+ * replaceComputer to decide whether to swallow checkpoint/destroy failures.
+ * Transient transport errors stay recoverable so update/reset can abort without
+ * discarding an uncommitted workspace on a still-reachable box.
  */
 export function isUnrecoverableSandboxError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  if (
-    /not found|does not exist|404|not_found|killed|doesn't exist|sandbox not found/i.test(message)
-  )
-    return true;
-  return isUnreachableTransportError(error);
+  return /not found|does not exist|404|not_found|killed|doesn't exist|sandbox not found/i.test(
+    message,
+  );
 }
 
 export const E2B_BROWSER_APPS = ["google-chrome", "firefox", "chromium"] as const;
@@ -257,7 +258,10 @@ export class E2BSandboxProvider implements SandboxProvider {
         };
       } catch (error) {
         this.boxes.delete(request.providerRef);
-        if (!isUnrecoverableSandboxError(error)) throw error;
+        // Permanent gone (404/killed) or unreachable transport: boot fresh. Other errors rethrow.
+        if (!isUnrecoverableSandboxError(error) && !isUnreachableTransportError(error)) {
+          throw error;
+        }
       }
     }
     const desktop = await this.sdk.create(e2bCreateOptions(request.botId, this.apiKey));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #351. Do not reopen that PR.

## Problem

#351 folded unreachable-transport detection into `isUnrecoverableSandboxError`. `replaceComputer` uses that predicate on checkpoint/destroy failures. In `update` mode, a transient transport error (ECONNRESET, `fetch failed`, …) was treated as permanent: the checkpoint error was swallowed, the old sandbox destroyed, and a new one provisioned without committing workspace changes that existed only on the old box.

## Change

- Keep transport detection as `isUnreachableTransportError` (cause-chain errno + bare `fetch failed`).
- Use it only in `E2BSandboxProvider.provision()` reconnect fallback, alongside the permanent predicate.
- Restore `isUnrecoverableSandboxError` to the original 404/killed/not-found message check so replaceComputer is unchanged from pre-#351 for transport blips.

## Test

- `computer-idle.test.ts`: ECONNRESET `code` and bare `fetch failed` do not satisfy the replace predicate; they do satisfy the transport helper.
- Existing #351 reconnect test still expects a fresh boot on `fetch failed` + ENOTFOUND.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fca9f75-5c1c-44de-8ff7-9dde7c601c0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fca9f75-5c1c-44de-8ff7-9dde7c601c0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox recovery when network connections are reset or fetch requests fail.
  * Prevented temporary transport errors from being treated as permanent sandbox failures.
  * Enhanced reconnect behavior by starting a fresh sandbox when recovery is not possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->