### PR TITLE
fix(sandbox): give E2B screen setup commands a real timeout

### DIFF
--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -1,5 +1,6 @@
 import { type Sandbox, TimeoutError } from "@e2b/desktop";
 import { describe, expect, it, vi } from "vitest";
+import { ComputerScreenUnavailableError } from "./computer-screens.js";
 import { shouldSkipPortableWorkspaceFile } from "./computer-workspace.js";
 import { E2BSandboxProvider, type E2BSandboxSdk } from "./e2b-sandbox.js";
 
@@ -42,6 +43,46 @@ describe("E2B computer backend", () => {
     expect(sdk.create).toHaveBeenCalledTimes(1);
     expect(computer.providerRef).toBe("fresh-e2b-box");
     expect(computer.fresh).toBe(true);
+  });
+
+  it("gives screen setup commands a real timeout and surfaces a failed one as unavailable", async () => {
+    const run = vi.fn(async (_command: string, opts?: { timeoutMs?: number }) => {
+      // The SDK throws on a non-zero exit rather than returning the result, and caps the
+      // command at 60s unless a timeout is passed.
+      if ((opts?.timeoutMs ?? 60_000) <= 60_000) {
+        throw Object.assign(new Error("signal: terminated"), {
+          name: "CommandExitError",
+          result: { exitCode: -1, stdout: "", stderr: "", error: "signal: terminated" },
+        });
+      }
+      throw Object.assign(new Error("boom"), {
+        name: "CommandExitError",
+        result: { exitCode: 1, stdout: "", stderr: "boom", error: "boom" },
+      });
+    });
+    const desktop = {
+      sandboxId: "screen-e2b-box",
+      display: ":0",
+      commands: { run },
+    } as unknown as Sandbox;
+    const sdk: E2BSandboxSdk = {
+      create: vi.fn(async () => desktop),
+      connect: vi.fn(async () => desktop),
+      pause: vi.fn(async () => undefined),
+    };
+    const provider = new E2BSandboxProvider("test-key", sdk);
+    const computer = {
+      id: "screen-e2b-box",
+      botId: "bot-1",
+      kind: "e2b" as const,
+      providerRef: "screen-e2b-box",
+      fresh: false,
+    };
+
+    await expect(provider.connectScreen(computer, { view: "stream" }, context)).rejects.toThrow(
+      ComputerScreenUnavailableError,
+    );
+    expect(run.mock.calls[0]?.[1]?.timeoutMs).toBeGreaterThan(60_000);
   });
 
   it("prepares a reused computer idempotently", async () => {

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -85,6 +85,34 @@ describe("E2B computer backend", () => {
     expect(run.mock.calls[0]?.[1]?.timeoutMs).toBeGreaterThan(60_000);
   });
 
+  it("surfaces a setup TimeoutError as ComputerScreenUnavailableError", async () => {
+    const run = vi.fn(async () => {
+      throw new TimeoutError("the operation timed out");
+    });
+    const desktop = {
+      sandboxId: "timeout-e2b-box",
+      display: ":0",
+      commands: { run },
+    } as unknown as Sandbox;
+    const sdk: E2BSandboxSdk = {
+      create: vi.fn(async () => desktop),
+      connect: vi.fn(async () => desktop),
+      pause: vi.fn(async () => undefined),
+    };
+    const provider = new E2BSandboxProvider("test-key", sdk);
+    const computer = {
+      id: "timeout-e2b-box",
+      botId: "bot-1",
+      kind: "e2b" as const,
+      providerRef: "timeout-e2b-box",
+      fresh: false,
+    };
+
+    await expect(provider.connectScreen(computer, { view: "stream" }, context)).rejects.toThrow(
+      ComputerScreenUnavailableError,
+    );
+  });
+
   it("prepares a reused computer idempotently", async () => {
     let profilesConfigured = false;
     const command = vi.fn(async (value: string) => {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -659,6 +659,14 @@ export class E2BSandboxProvider implements SandboxProvider {
         timeoutMs: boundedSandboxCommandTimeoutMs(undefined),
       });
     } catch (error) {
+      if (error instanceof TimeoutError) {
+        return {
+          exitCode: 124,
+          stdout: "",
+          stderr: error.message,
+          error: error.message,
+        };
+      }
       const result = (error as { result?: CommandResult }).result;
       if (result) return result;
       throw error;

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { setTimeout as delay } from "node:timers/promises";
-import { Sandbox, TimeoutError } from "@e2b/desktop";
+import { type CommandResult, Sandbox, TimeoutError } from "@e2b/desktop";
 import type {
   AdapterContext,
   CommandRequest,
@@ -647,8 +647,29 @@ export class E2BSandboxProvider implements SandboxProvider {
     }
   }
 
+  /** Apply the deployment timeout (SDK default is 60s) and return failed results instead of throwing. */
+  private async runSetupCommand(
+    desktop: Sandbox,
+    command: string,
+    signal?: AbortSignal,
+  ): Promise<CommandResult> {
+    try {
+      return await desktop.commands.run(command, {
+        ...(signal ? { signal } : {}),
+        timeoutMs: boundedSandboxCommandTimeoutMs(undefined),
+      });
+    } catch (error) {
+      const result = (error as { result?: CommandResult }).result;
+      if (result) return result;
+      throw error;
+    }
+  }
+
   private async resolveLayout(desktop: Sandbox, screenKey: string, leaseId?: string) {
-    const allocation = await desktop.commands.run(allocateExtraDisplayCommand(screenKey, leaseId));
+    const allocation = await this.runSetupCommand(
+      desktop,
+      allocateExtraDisplayCommand(screenKey, leaseId),
+    );
     if (allocation.exitCode !== 0) throw new ComputerScreenUnavailableError();
     const index = parseAllocatedExtraDisplay(allocation.stdout);
     return extraDisplayLayout(index, desktop.display ?? ":0");
@@ -660,7 +681,8 @@ export class E2BSandboxProvider implements SandboxProvider {
     context: AdapterContext,
   ): Promise<string> {
     if (layout.isPrimary) throw new Error("primary display does not use an extra view password");
-    const result = await desktop.commands.run(
+    const result = await this.runSetupCommand(
+      desktop,
       ensureExtraDisplayCommand(
         layout,
         {
@@ -669,7 +691,7 @@ export class E2BSandboxProvider implements SandboxProvider {
         },
         randomBytes(9).toString("base64url"),
       ),
-      { signal: context.signal },
+      context.signal,
     );
     if (result.exitCode !== 0) throw new ComputerScreenUnavailableError();
     return parseExtraDisplayViewPassword(result.stdout);
@@ -706,10 +728,11 @@ export class E2BSandboxProvider implements SandboxProvider {
         `for i in $(seq 1 50); do netstat -tuln | grep -q ':${proxyPort} ' && exit 0; sleep 0.1; done`,
         "exit 1",
       ].join(" && ");
-      const result = await desktop.commands.run(command);
+      const result = await this.runSetupCommand(desktop, command);
       if (result.exitCode !== 0) throw new Error(result.stderr || "control stream failed to start");
     } else {
-      const result = await desktop.commands.run(
+      const result = await this.runSetupCommand(
+        desktop,
         extraDisplayControlStartCommand(layout, controlToken, password),
       );
       if (result.exitCode !== 0) throw new Error(result.stderr || "control stream failed to start");


### PR DESCRIPTION
## Problem

Opening a bot's screen on an E2B computer returned a bare 500. The real error, recovered by driving `connectScreen()` directly against a live sandbox:

```
CommandExitError: signal: terminated
    at CommandHandle.wait (e2b/src/sandbox/commands/commandHandle.ts:178)
    at E2BSandboxProvider.ensureExtraDisplay (packages/adapters/src/e2b-sandbox.ts)
    at E2BSandboxProvider.connectScreen (packages/adapters/src/e2b-sandbox.ts)
```

and, on the interactive path, the SDK naming the cause itself:

> the operation timed out ... exceeding `timeoutMs` ... It can be modified by passing `timeoutMs` when making the request.

Two defects:

1. **No timeout is passed.** `CommandStartOpts.timeoutMs` defaults to `60_000`. `ensureExtraDisplayCommand` starts Xvfb, fluxbox, `cp -a` of a chromium profile, a browser, x11vnc and noVNC — that outgrows 60s, envd terminates it, and the screen never comes up. It degrades over time as the copied profile grows. The repo already has `boundedSandboxCommandTimeoutMs` (5 min default, `SANDBOX_COMMAND_TIMEOUT_MS`), but only the agent `exec` path used it.

2. **The error branches were unreachable.** `commands.run` throws `CommandExitError` from `wait()` on a non-zero exit rather than returning the result, so `if (result.exitCode !== 0) throw new ComputerScreenUnavailableError()` never ran in `resolveLayout`, `ensureExtraDisplay` or `startControlStream` — a raw SDK error escaped instead of the domain error, and the API turned it into an opaque 500.

## Change

One `runSetupCommand` helper for the display and control setup commands: applies the deployment's bounded timeout, and returns the result of a failed command so the existing `exitCode !== 0` branches run again.

## Test

`packages/adapters/src/e2b-sandbox.test.ts` — a setup command that fails must surface `ComputerScreenUnavailableError`, and the command must be given more than the SDK's 60s default. Verified both ways: fails without the fix, passes with it.

Found on a live deployment; independent of #351, though both are cases of an E2B failure surfacing as something opaque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen setup reliability by allowing setup commands to use appropriate timeouts beyond the previous 60-second limit.
  * Screen connection failures now surface as a clear unavailable-screen error when setup commands fail or time out.
  * Improved handling of command failures during display and control-stream setup.
  * Sandboxes now recover more reliably by starting a fresh sandbox when reconnecting to an unreachable or unrecoverable sandbox fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->