### PR TITLE
fix(docker): survive restrictive host umask in image builds

### DIFF
--- a/infra/compose/Dockerfile
+++ b/infra/compose/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:22-bookworm@sha256:0557ac14e0d45d02ed563067b82856ca5e7aa3437fa28d98d4350ea9c3d9494a
 RUN corepack enable
 WORKDIR /app
-COPY . .
+# Normalize modes: a restrictive host umask (e.g. 077 on hardened hosts) would otherwise
+# leave the copied tree unreadable to USER node at runtime.
+COPY --chmod=755 . .
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @rakazo/db generate
 RUN RAKAZO_ALLOW_DEV_SECRETS=1 pnpm --filter @rakazo/web build

--- a/infra/compose/Dockerfile.topology
+++ b/infra/compose/Dockerfile.topology
@@ -2,7 +2,9 @@ FROM node:22-bookworm
 
 RUN corepack enable
 WORKDIR /app
-COPY . .
+# Normalize modes: a restrictive host umask (e.g. 077 on hardened hosts) would otherwise
+# leave the copied tree unreadable to USER node at runtime.
+COPY --chmod=755 . .
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @rakazo/db generate
 RUN RAKAZO_ALLOW_DEV_SECRETS=1 pnpm --filter @rakazo/web build

--- a/infra/sandboxes/computer/Dockerfile
+++ b/infra/sandboxes/computer/Dockerfile
@@ -43,19 +43,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV DISPLAY=:1
 ENV HOME=/home/rakazo
 WORKDIR /home/rakazo
-COPY start.sh /usr/local/bin/rakazo-computer
-COPY control.py /usr/local/bin/rakazo-computer-control
+# --chmod normalizes modes: a restrictive host umask (e.g. 077 on hardened hosts) would
+# otherwise leave these files unreadable to USER 1000 at runtime.
+COPY --chmod=755 start.sh /usr/local/bin/rakazo-computer
+COPY --chmod=755 control.py /usr/local/bin/rakazo-computer-control
 COPY --from=capture-builder /build/librakazo-xcapture.so /usr/local/lib/librakazo-xcapture.so
-COPY rakazo-browser /usr/local/bin/rakazo-browser
-COPY fluxbox.init /etc/rakazo/fluxbox/init
-COPY fluxbox.apps /etc/rakazo/fluxbox/apps
-COPY fluxbox.menu /etc/rakazo/fluxbox/menu
-COPY embed.html /usr/share/novnc/embed.html
+COPY --chmod=755 rakazo-browser /usr/local/bin/rakazo-browser
+COPY --chmod=644 fluxbox.init /etc/rakazo/fluxbox/init
+COPY --chmod=644 fluxbox.apps /etc/rakazo/fluxbox/apps
+COPY --chmod=644 fluxbox.menu /etc/rakazo/fluxbox/menu
+COPY --chmod=644 embed.html /usr/share/novnc/embed.html
 # Strip CR so shebangs work even if the build context came from a CRLF checkout.
 RUN ldconfig \
   && sed -i 's/\r$//' /usr/local/bin/rakazo-computer /usr/local/bin/rakazo-computer-control /usr/local/bin/rakazo-browser \
-    /etc/rakazo/fluxbox/init /etc/rakazo/fluxbox/apps /etc/rakazo/fluxbox/menu \
-  && chmod +x /usr/local/bin/rakazo-computer /usr/local/bin/rakazo-computer-control /usr/local/bin/rakazo-browser
+    /etc/rakazo/fluxbox/init /etc/rakazo/fluxbox/apps /etc/rakazo/fluxbox/menu
 EXPOSE 7070 6080 6081 6082 6083 6084 6085 6086 6087 6088 6089 6090 6091 6092 6093 6094 6095
 USER 1000:1000
 CMD ["/usr/local/bin/rakazo-computer"]


### PR DESCRIPTION
A checkout cloned with a restrictive umask (e.g. root with umask 077 on a hardened host) has 600/700 modes, which COPY preserves. The build succeeds because build steps run as root, but the app image then crash-loops at runtime with a misleading corepack "EACCES: open '/app/package.json'" once it drops to USER node, and the computer image's scripts and fluxbox config are unreadable to USER 1000.

Use BuildKit's COPY --chmod to normalize modes during the copy (no extra layer), and drop the now-redundant chmod +x in the computer image.

Repro: umask 077 clone + docker compose up --build on Docker 29; verified COPY --chmod restores readability for a non-root user on the same host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup reliability by ensuring application files and scripts have consistent permissions at build time.
  * Prevented restrictive host umasks from causing runtime access or execution issues.
  * Preserved appropriate read-only permissions for configuration and web content files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->