### PR TITLE
feat(api): log the RPC errors that become an opaque 500

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import { rm } from "node:fs/promises";
+import { ORPCError, onError } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
 import type {
   JobPublisher,
@@ -279,7 +280,9 @@ export async function createApp(
       imageTag: env.imageTag,
     },
   });
-  const rpc = new RPCHandler(router);
+  const rpc = new RPCHandler(router, {
+    clientInterceptors: [onError((error, { path }) => logUnexpectedRpcError(error, path))],
+  });
   const app = new Hono();
   app.use(
     "*",
@@ -371,4 +374,27 @@ function sessionHeaders(request: Request) {
     headers.set("cookie", `better-auth.session_token=${authz.slice(7).trim()}`);
   }
   return headers;
+}
+
+/**
+ * An ORPCError is a decision the router made (BAD_REQUEST, UNAUTHORIZED, ...) and reaches the
+ * caller intact. Everything else is flattened into an opaque "Internal server error", so
+ * unless it is logged here the only record of what actually broke is gone.
+ *
+ * The cause chain matters as much as the message: undici and most SDKs report a bare
+ * "fetch failed" and keep the host and errno one level down.
+ */
+export function logUnexpectedRpcError(error: unknown, path: readonly string[]): void {
+  if (error instanceof ORPCError) return;
+  const where = `rpc ${path.join("/")} failed`;
+  if (!(error instanceof Error)) {
+    console.error(where, String(error));
+    return;
+  }
+  const chain: string[] = [];
+  for (let current: unknown = error; current instanceof Error && chain.length < 4; ) {
+    chain.push(`${current.name}: ${current.message}`);
+    current = current.cause;
+  }
+  console.error(where, chain.join(" <- "), error.stack ?? "");
 }

--- a/apps/api/src/log-unexpected-rpc-error.test.ts
+++ b/apps/api/src/log-unexpected-rpc-error.test.ts
@@ -1,8 +1,12 @@
 import { ORPCError } from "@orpc/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { logUnexpectedRpcError } from "./app.js";
 
 describe("logUnexpectedRpcError", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("stays quiet for an error the router chose to return", () => {
     const logError = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
@@ -12,7 +16,6 @@ describe("logUnexpectedRpcError", () => {
     ]);
 
     expect(logError).not.toHaveBeenCalled();
-    logError.mockRestore();
   });
 
   it("names the procedure and every cause behind an opaque failure", () => {
@@ -29,6 +32,5 @@ describe("logUnexpectedRpcError", () => {
     expect(logged).toContain("rpc computer/screenUrl failed");
     expect(logged).toContain("fetch failed");
     expect(logged).toContain("connect ECONNREFUSED 127.0.0.1:7091");
-    logError.mockRestore();
   });
 });

--- a/apps/api/src/log-unexpected-rpc-error.test.ts
+++ b/apps/api/src/log-unexpected-rpc-error.test.ts
@@ -1,0 +1,34 @@
+import { ORPCError } from "@orpc/server";
+import { describe, expect, it, vi } from "vitest";
+import { logUnexpectedRpcError } from "./app.js";
+
+describe("logUnexpectedRpcError", () => {
+  it("stays quiet for an error the router chose to return", () => {
+    const logError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    logUnexpectedRpcError(new ORPCError("BAD_REQUEST", { message: "file is too large" }), [
+      "computer",
+      "readFile",
+    ]);
+
+    expect(logError).not.toHaveBeenCalled();
+    logError.mockRestore();
+  });
+
+  it("names the procedure and every cause behind an opaque failure", () => {
+    const logError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const error = new Error("fetch failed", {
+      cause: Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:7091"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+
+    logUnexpectedRpcError(error, ["computer", "screenUrl"]);
+
+    const logged = logError.mock.calls[0]?.join(" ") ?? "";
+    expect(logged).toContain("rpc computer/screenUrl failed");
+    expect(logged).toContain("fetch failed");
+    expect(logged).toContain("connect ECONNREFUSED 127.0.0.1:7091");
+    logError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Problem

An unexpected throw inside a handler is flattened into

```json
{ "defined": false, "code": "INTERNAL_SERVER_ERROR", "status": 500, "message": "Internal server error" }
```

and nothing is written anywhere. Chasing a real 500 on `computer/screenUrl`, the API log held only the access lines — the exception had to be recovered by driving the adapter by hand against a live sandbox. Both bugs behind it (#351 and #354) were minutes of work once the stack trace existed.

## Change

A client interceptor on the RPC handler logs errors that are *not* an `ORPCError` — an `ORPCError` is a decision the router made (`BAD_REQUEST`, `UNAUTHORIZED`, …) and reaches the caller intact, so it needs no log. The log names the procedure path and walks the `cause` chain, capped at four links: undici and most SDKs report a bare `fetch failed` and keep the host and errno one level down.

## Test

`apps/api/src/log-unexpected-rpc-error.test.ts` — an `ORPCError` stays quiet; an opaque `fetch failed` logs the procedure path and the `ECONNREFUSED` cause underneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unexpected RPC failures are now logged with the procedure path, error details, and relevant underlying causes.
  - Expected router-handled errors, such as invalid requests or unauthorized access, are excluded from unexpected-error logging.

- **Tests**
  - Added coverage for expected errors remaining quiet and unexpected errors including cause-chain details in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->