### PR TITLE
fix(mcp): preserve credentials for configured localhost servers

### DIFF
--- a/packages/adapters/src/mcp-connector.test.ts
+++ b/packages/adapters/src/mcp-connector.test.ts
@@ -89,7 +89,7 @@ describe("MCP connector session cache", () => {
     await connector.close();
   });
 
-  it("does not send stored credentials to a localhost HTTP server", async () => {
+  it("sends stored credentials to an explicitly configured localhost HTTP server", async () => {
     const state = { failNext: false, initializations: 0, headers: [] as Record<string, string>[] };
     const localAssignment = {
       ...ASSIGNMENT,
@@ -118,8 +118,8 @@ describe("MCP connector session cache", () => {
       signal: new AbortController().signal,
     } as never);
 
-    expect(state.headers[0]?.authorization).toBeUndefined();
-    expect(state.headers[0]?.["x-api-key"]).toBeUndefined();
+    expect(state.headers[0]?.authorization).toBe("Bearer local-token");
+    expect(state.headers[0]?.["x-api-key"]).toBe("local-key");
     await connector.close();
   });
 

--- a/packages/adapters/src/mcp-connector.ts
+++ b/packages/adapters/src/mcp-connector.ts
@@ -256,10 +256,10 @@ export class McpConnector implements ConnectorProvider {
         };
         await session.connectRemote({
           url: server.endpoint,
-          urlPolicy: { allowHttpLocalhost: true },
+          urlPolicy: { allowHttpLocalhost: true, allowLocalHttpCredentials: localHttp },
           transport: server.transport === "sse" ? "sse" : "streamable-http",
           allowLegacySse: server.transport === "sse",
-          headerPolicy: localHttp ? undefined : { headers },
+          headerPolicy: { headers },
           fallbackToSse: false,
           authProvider,
           network: this.options.network,

--- a/packages/adapters/src/mcp-transport.ts
+++ b/packages/adapters/src/mcp-transport.ts
@@ -23,6 +23,8 @@ export interface McpUrlPolicy {
   maxUrlLength?: number;
   /** Permit plain HTTP only for explicitly local hosts. */
   allowHttpLocalhost?: boolean;
+  /** Permit configured credentials on an explicitly local HTTP endpoint. */
+  allowLocalHttpCredentials?: boolean;
   /** Hosts allowed after redirects (redirects are rejected by default). */
   allowedHosts?: readonly string[];
 }
@@ -119,7 +121,7 @@ export function secureFetch(
     const url = validateUrl(source.url, urlPolicy);
     const headers = new Headers(source.headers);
     const localHttp = url.protocol === "http:" && isLocalMcpHost(url.hostname);
-    if (localHttp) {
+    if (localHttp && urlPolicy.allowLocalHttpCredentials !== true) {
       for (const name of [...headers.keys()]) {
         if (localCredentialHeaders.has(name.toLowerCase())) headers.delete(name);
       }
@@ -128,7 +130,12 @@ export function secureFetch(
       for (const [name, value] of configured) headers.set(name, value);
     }
     for (const [name, value] of new Headers(init?.headers)) {
-      if (localHttp && localCredentialHeaders.has(name.toLowerCase())) continue;
+      if (
+        localHttp &&
+        urlPolicy.allowLocalHttpCredentials !== true &&
+        localCredentialHeaders.has(name.toLowerCase())
+      )
+        continue;
       if (allowed.has(name.toLowerCase())) headers.set(name, value);
     }
     // Buffer the body: a re-wrapped Request body is a stream without a replayable


### PR DESCRIPTION
## Summary

- preserve configured MCP credentials for explicitly configured localhost HTTP endpoints
- keep remote endpoint handling and the default local credential stripping secure
- update the deterministic connector regression test

## Why

The localhost HTTP transport is intentionally restrictive, but authenticated local MCP servers such as Home Assistant need their configured bearer and API-key headers. The connector opts into this only after classifying the configured endpoint as local HTTP.

## Validation

- `npx pnpm@9.15.0 exec vitest run packages/adapters/src/mcp-connector.test.ts packages/adapters/src/mcp-transport.test.ts packages/contracts/src/index.test.ts`
- `npx pnpm@9.15.0 exec biome check packages/adapters/src/mcp-transport.ts packages/adapters/src/mcp-connector.ts packages/adapters/src/mcp-connector.test.ts`
- `npx pnpm@9.15.0 --filter @rakazo/contracts check`
- `npx pnpm@9.15.0 --filter @rakazo/adapters check`
- Live Home Assistant MCP probe: 23 tools discovered and `GetDateTime` returned successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Local MCP connections now support sending stored authentication credentials, including bearer tokens and custom API key headers.
  - Credential headers remain protected by default for local HTTP requests unless explicitly permitted by the connection policy.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->