### PR TITLE
fix(computer): drop stale Chromium singleton locks on boot

### DIFF
--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -49,6 +49,10 @@ EOF
 chmod +x /tmp/fluxbox-home/.fluxbox/startup
 HOME=/tmp/fluxbox-home /tmp/fluxbox-home/.fluxbox/startup >/tmp/rakazo/fluxbox.log 2>&1 &
 
+rm -f "$AGENT_HOME/.browser-profiles/chromium/SingletonLock" \
+  "$AGENT_HOME/.browser-profiles/chromium/SingletonCookie" \
+  "$AGENT_HOME/.browser-profiles/chromium/SingletonSocket"
+
 HOME="$AGENT_HOME" rakazo-browser >/tmp/rakazo/browser.log 2>&1 &
 browser_up=0
 for _ in $(seq 1 40); do

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -119,6 +119,7 @@ describe("graphical computer spec", () => {
     expect(dockerfile).toMatch(/USER 1000:1000/);
     expect(start).toMatch(/rakazo-computer-control/);
     expect(start).toMatch(/rakazo-browser/);
+    expect(start).toMatch(/SingletonLock/);
     expect(start).toMatch(/x11vnc .* -viewonly /);
     expect(browser).toMatch(/\.browser-profiles\/chromium/);
     expect(start).not.toMatch(/windowsize 1280 800/);


### PR DESCRIPTION
## Problem
After a Docker computer recreate, Chromium often fails to start. The profile is still on the bind-mount (cookies included), but `SingletonLock` names the old container hostname. `start.sh` then falls back to xterm, so Recover looks like “the login died.”

Extra screens already clear these three files. The primary desktop did not.

## Change
Immediately before `rakazo-browser`, remove only:
- `.browser-profiles/chromium/SingletonLock`
- `SingletonCookie`
- `SingletonSocket`

Do not touch Cookies, History, or other profile data. Do not change browser flags.

The existing image contract test now requires `start.sh` to mention `SingletonLock`.

## Test plan
- [x] `pnpm exec vitest run infra/sandboxes/supervisor/src/computer-spec.test.ts`
- Recover (not Reset) a Docker computer whose Chromium profile already has cookies
- Active window is Chromium, not Terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser startup by automatically removing stale lock files that could prevent Chromium from launching.
  - Ensures the browser desktop starts reliably instead of displaying startup errors caused by leftover session data.

- **Tests**
  - Added coverage to verify stale browser lock-file cleanup is included in the startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->