### PR TITLE
fix(web): support file drops in chat composer

### DIFF
--- a/apps/web/src/lib/pending-attachments.test.ts
+++ b/apps/web/src/lib/pending-attachments.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it, vi } from "vitest";
-import { revokePendingAttachmentPreviews } from "./pending-attachments.js";
+import { isFileDrag, revokePendingAttachmentPreviews } from "./pending-attachments.js";
+
+function dragData(types: string[], itemKinds: string[] = []) {
+  return {
+    types,
+    items: itemKinds.map((kind) => ({ kind })),
+  } as unknown as DataTransfer;
+}
+
+describe("isFileDrag", () => {
+  it("recognizes files advertised by the drag data", () => {
+    expect(isFileDrag(dragData(["Files"]))).toBe(true);
+  });
+
+  it("recognizes file items when the Files type is not exposed", () => {
+    expect(isFileDrag(dragData([], ["file"]))).toBe(true);
+  });
+
+  it("ignores text and other drags", () => {
+    expect(isFileDrag(dragData(["text/plain"], ["string"]))).toBe(false);
+    expect(isFileDrag(null)).toBe(false);
+  });
+});
 
 describe("revokePendingAttachmentPreviews", () => {
   it("revokes each preview URL and skips entries without one", () => {

--- a/apps/web/src/lib/pending-attachments.ts
+++ b/apps/web/src/lib/pending-attachments.ts
@@ -2,6 +2,14 @@ export type PendingAttachmentPreview = {
   previewUrl?: string;
 };
 
+export function isFileDrag(dataTransfer: Pick<DataTransfer, "types" | "items"> | null): boolean {
+  if (!dataTransfer) return false;
+  return (
+    Array.from(dataTransfer.types).includes("Files") ||
+    Array.from(dataTransfer.items).some((item) => item.kind === "file")
+  );
+}
+
 export function revokePendingAttachmentPreviews(
   attachments: readonly PendingAttachmentPreview[],
 ): void {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -87,6 +87,7 @@ import {
   X,
 } from "lucide-react";
 import {
+  type DragEvent,
   lazy,
   type MutableRefObject,
   memo,
@@ -124,7 +125,7 @@ import { chartViewport } from "../lib/chart-viewport";
 import { dictation } from "../lib/dictation";
 import { localTimezone } from "../lib/local-timezone";
 import { connectMcpOauth } from "../lib/mcp-connect";
-import { revokePendingAttachmentPreviews } from "../lib/pending-attachments";
+import { isFileDrag, revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
 import { rpc } from "../lib/rpc";
 import {
@@ -3590,6 +3591,8 @@ const Composer = memo(function Composer({
   const [selectedSkill, setSelectedSkill] = useState<AgentSkillCatalogEntry | null>(null);
   const [selectedMentions, setSelectedMentions] = useState<ComposerMention[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const dragDepth = useRef(0);
+  const [draggingFiles, setDraggingFiles] = useState(false);
   const canSend =
     draft.trim().length > 0 ||
     selectedSkill !== null ||
@@ -3708,12 +3711,68 @@ const Composer = memo(function Composer({
     void onSend(text, mentions);
   }
 
+  function handleDragEnter(event: DragEvent<HTMLFieldSetElement>) {
+    const dataTransfer = event.dataTransfer;
+    if (!isFileDrag(dataTransfer)) return;
+    event.preventDefault();
+    if (disabled) {
+      dragDepth.current = 0;
+      setDraggingFiles(false);
+      return;
+    }
+    dragDepth.current += 1;
+    setDraggingFiles(true);
+  }
+
+  function handleDragOver(event: DragEvent<HTMLFieldSetElement>) {
+    const dataTransfer = event.dataTransfer;
+    if (!isFileDrag(dataTransfer)) return;
+    event.preventDefault();
+    dataTransfer.dropEffect = disabled ? "none" : "copy";
+    if (disabled) {
+      dragDepth.current = 0;
+      setDraggingFiles(false);
+      return;
+    }
+    setDraggingFiles(true);
+  }
+
+  function handleDragLeave(event: DragEvent<HTMLFieldSetElement>) {
+    if (!isFileDrag(event.dataTransfer)) return;
+    if (disabled) {
+      dragDepth.current = 0;
+      setDraggingFiles(false);
+      return;
+    }
+    dragDepth.current = Math.max(0, dragDepth.current - 1);
+    if (dragDepth.current === 0) setDraggingFiles(false);
+  }
+
+  function handleDrop(event: DragEvent<HTMLFieldSetElement>) {
+    const dataTransfer = event.dataTransfer;
+    if (!isFileDrag(dataTransfer)) return;
+    event.preventDefault();
+    dragDepth.current = 0;
+    setDraggingFiles(false);
+    if (!disabled) void onAttachmentPick(dataTransfer.files);
+  }
+
   const showComposerPlaceholder =
     draft.length === 0 && selectedSkill === null && selectedMentions.length === 0;
   const replyName = replyTarget ? (replyTargetName ?? previewMessageText(replyTarget)) : "";
 
   return (
-    <div className="relative z-30 px-3 pb-4 pt-3 md:px-6 md:pb-6">
+    <fieldset
+      aria-label={t`Message composer`}
+      data-dragging={draggingFiles ? "files" : undefined}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className={`relative z-30 m-0 border-0 px-3 pb-4 pt-3 md:px-6 md:pb-6 ${
+        draggingFiles ? "rounded-[14px] ring-2 ring-inset ring-[#8B5CF6]" : ""
+      }`}
+    >
       {sendError || dictationError || runError ? (
         <div
           role="alert"
@@ -3999,7 +4058,7 @@ const Composer = memo(function Composer({
           </button>
         )}
       </div>
-    </div>
+    </fieldset>
   );
 });
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3769,7 +3769,7 @@ const Composer = memo(function Composer({
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
-      className={`relative z-30 m-0 border-0 px-3 pb-4 pt-3 md:px-6 md:pb-6 ${
+      className={`relative z-30 m-0 min-w-0 border-0 px-3 pb-4 pt-3 md:px-6 md:pb-6 ${
         draggingFiles ? "rounded-[14px] ring-2 ring-inset ring-[#8B5CF6]" : ""
       }`}
     >


### PR DESCRIPTION
## Summary

- detect file drags in the browser chat composer
- handle drag enter/over/leave/drop without intercepting non-file drags
- reuse the existing attachment picker validation and upload flow
- prevent browser navigation on file drops and safely reject drops while disabled

## Tests

- `corepack pnpm exec vitest run apps/web/src/lib/pending-attachments.test.ts` (4 passed)
- full web tests (142 passed)
- `corepack pnpm --filter @rakazo/web check`
- `corepack pnpm --filter @rakazo/web build`
- `corepack pnpm exec biome check apps/web/src/lib/pending-attachments.ts apps/web/src/lib/pending-attachments.test.ts apps/web/src/pages/Shell.tsx`

## Notes

The regression test covers the file-drag classifier; the production build and full web suite cover integration. No manual OS-to-browser drag was run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added drag-and-drop file attachments to the message composer.
  - The composer highlights when files are dragged over it.
  - File drops are ignored when attachments are disabled.

- **Bug Fixes**
  - Improved detection of file drags, including cases where file types are not explicitly exposed.
  - Preserved line breaks in user message text for more readable formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->