### PR TITLE
fix(web): preserve user message line breaks

### DIFF
--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -77,6 +77,13 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   const heightWithNewline = await composer.evaluate((el) => el.getBoundingClientRect().height);
   expect(heightWithNewline).toBeGreaterThan(heightBeforeNewline);
 
+  await composer.press("Enter");
+  const multilineMessage = page
+    .getByTestId("transcript")
+    .getByText("line one\nline two", { exact: true });
+  await expect(multilineMessage).toBeVisible();
+  await expect(multilineMessage).toHaveCSS("white-space", "pre-wrap");
+
   const message = "Fake composer regression check.";
   await composer.fill(message);
   await captureScreenshot(page, testInfo, "40-restored-auth-session");

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4546,7 +4546,7 @@ const MessageView = memo(function MessageView({
           return (
             <div key={i} className="flex justify-end">
               <div
-                className="max-w-[70%] rounded-[20px] bg-[#F1F1EF] px-[18px] py-3 text-[15.5px] leading-[1.45] text-[#1A1A1A]"
+                className="max-w-[70%] whitespace-pre-wrap rounded-[20px] bg-[#F1F1EF] px-[18px] py-3 text-[15.5px] leading-[1.45] text-[#1A1A1A]"
                 dir="auto"
               >
                 {block.text}


### PR DESCRIPTION
## Summary

- preserve submitted line breaks in browser-rendered user messages with native `white-space: pre-wrap`
- keep user text raw rather than changing it to Markdown
- add a browser regression assertion for submitted multiline text and computed whitespace behavior

## Tests

- `corepack pnpm --filter @rakazo/web check`
- `corepack pnpm --filter @rakazo/web build`
- existing ChatMarkdown tests (4 passed)
- `corepack pnpm --filter @rakazo/web exec playwright test e2e/auth-lifecycle.spec.ts --list` (1 test discovered)
- `git diff --check`

## Notes

The focused Playwright test compiles and is discovered locally; executing it requires the repository API/database E2E stack, so CI is the authoritative browser run.
