### PR TITLE
fix(web): add browser run notifications

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -129,6 +129,7 @@ import {
   sendThreadMessage,
   setThreadUnreadState,
   stopThreadRuns,
+  threadHead,
   threadSnapshot,
 } from "./thread-target.js";
 import {
@@ -945,6 +946,10 @@ export function createRouter(deps: RouterDeps) {
       ),
     },
     threads: {
+      head: authed.threads.head.handler(async ({ context, input }) => {
+        const target = await resolveThreadTarget(deps.prisma, context.actor, input);
+        return threadHead(deps.prisma, target);
+      }),
       get: authed.threads.get.handler(async ({ context, input }) => {
         const target = await resolveThreadTarget(deps.prisma, context.actor, input);
         return threadSnapshot(deps, target);

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -2,7 +2,25 @@ import type { SandboxProvider } from "@rakazo/adapter-kit";
 import type { Actor } from "@rakazo/contracts";
 import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
-import { stopThreadRuns, type ThreadTarget, threadSnapshot } from "./thread-target.js";
+import { stopThreadRuns, type ThreadTarget, threadHead, threadSnapshot } from "./thread-target.js";
+
+describe("threadHead", () => {
+  it("returns the durable cursor without loading a snapshot", async () => {
+    const findFirst = vi.fn().mockResolvedValue({ seq: 12 });
+    const prisma = { event: { findFirst } } as unknown as PrismaClient;
+    const target = { threadId: "thread-1" } as ThreadTarget;
+
+    await expect(threadHead(prisma, target)).resolves.toEqual({
+      threadId: "thread-1",
+      cursor: 12,
+    });
+    expect(findFirst).toHaveBeenCalledWith({
+      where: { threadId: "thread-1" },
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+  });
+});
 
 describe("threadSnapshot", () => {
   it("reloads tool-only live messages for an active run", async () => {

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -259,6 +259,15 @@ export async function resolveThreadTarget(
   throw new IsolationError();
 }
 
+export async function threadHead(prisma: PrismaClient, target: ThreadTarget) {
+  const latest = await prisma.event.findFirst({
+    where: { threadId: target.threadId },
+    orderBy: { seq: "desc" },
+    select: { seq: true },
+  });
+  return { threadId: target.threadId, cursor: latest?.seq ?? -1 };
+}
+
 export async function threadSnapshot(
   deps: { prisma: PrismaClient },
   target: ThreadTarget,

--- a/apps/web/src/lib/browser-notifications.test.ts
+++ b/apps/web/src/lib/browser-notifications.test.ts
@@ -44,9 +44,9 @@ describe("browser run notifications", () => {
       "{name} failed": "Chief failed",
       "{name} finished": "Chief finished",
       "{name} stopped": "Chief stopped",
-      "Your bot run failed.": "Your bot run failed.",
-      "Your bot run was stopped.": "Your bot run was stopped.",
-      "Your bot finished its work.": "Your bot finished its work.",
+      "Failed.": "Failed.",
+      "Stopped.": "Stopped.",
+      "Finished.": "Finished.",
     });
     i18n.activate("en");
   });
@@ -75,11 +75,15 @@ describe("browser run notifications", () => {
   it("keeps terminal copy stable for the native Notification API", () => {
     expect(browserNotificationMessage(event(), "Chief")).toEqual({
       title: "Chief finished",
-      body: "Your bot finished its work.",
+      body: "Finished.",
     });
     expect(browserNotificationMessage(event({ type: "run.failed" }), "Chief")).toEqual({
       title: "Chief failed",
-      body: "Your bot run failed.",
+      body: "Failed.",
+    });
+    expect(browserNotificationMessage(event({ type: "run.cancelled" }), "Chief")).toEqual({
+      title: "Chief stopped",
+      body: "Stopped.",
     });
   });
 

--- a/apps/web/src/lib/browser-notifications.test.ts
+++ b/apps/web/src/lib/browser-notifications.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  type BrowserNotificationApi,
   type BrowserNotificationContext,
   browserNotificationMessage,
+  requestBrowserNotificationPermission,
   shouldNotifyBrowser,
 } from "./browser-notifications.js";
 
@@ -66,5 +68,25 @@ describe("browser run notifications", () => {
       title: "Chief failed",
       body: "Your bot run failed.",
     });
+  });
+
+  it("allows a later send gesture to retry a dismissed permission prompt", async () => {
+    let resolvePermission: ((permission: "default") => void) | undefined;
+    const requestPermission = vi.fn(
+      () =>
+        new Promise<"default">((resolve) => {
+          resolvePermission = resolve;
+        }),
+    );
+    const api: BrowserNotificationApi = { permission: "default", requestPermission };
+
+    requestBrowserNotificationPermission(api);
+    requestBrowserNotificationPermission(api);
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+
+    resolvePermission?.("default");
+    await Promise.resolve();
+    requestBrowserNotificationPermission(api);
+    expect(requestPermission).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/lib/browser-notifications.test.ts
+++ b/apps/web/src/lib/browser-notifications.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type BrowserNotificationApi,
   type BrowserNotificationContext,
@@ -6,6 +6,7 @@ import {
   requestBrowserNotificationPermission,
   shouldNotifyBrowser,
 } from "./browser-notifications.js";
+import { i18n } from "./i18n.js";
 
 function event(
   overrides: Partial<{
@@ -38,6 +39,18 @@ function context(overrides: Partial<BrowserNotificationContext> = {}): BrowserNo
 }
 
 describe("browser run notifications", () => {
+  beforeEach(() => {
+    i18n.load("en", {
+      "{name} failed": "Chief failed",
+      "{name} finished": "Chief finished",
+      "{name} stopped": "Chief stopped",
+      "Your bot run failed.": "Your bot run failed.",
+      "Your bot run was stopped.": "Your bot run was stopped.",
+      "Your bot finished its work.": "Your bot finished its work.",
+    });
+    i18n.activate("en");
+  });
+
   it("only accepts a new terminal event for the hidden or unfocused subscribed thread", () => {
     expect(shouldNotifyBrowser(event(), context())).toBe(true);
     expect(shouldNotifyBrowser(event({ type: "run.started" }), context())).toBe(false);

--- a/apps/web/src/lib/browser-notifications.test.ts
+++ b/apps/web/src/lib/browser-notifications.test.ts
@@ -3,6 +3,7 @@ import {
   type BrowserNotificationApi,
   type BrowserNotificationContext,
   browserNotificationMessage,
+  deliverBrowserRunNotification,
   requestBrowserNotificationPermission,
   shouldNotifyBrowser,
 } from "./browser-notifications.js";
@@ -85,6 +86,30 @@ describe("browser run notifications", () => {
       title: "Chief stopped",
       body: "Stopped.",
     });
+  });
+
+  it("dedupes only after a notification is delivered", () => {
+    const notifiedRunIds = new Set<string>();
+    const show = vi.fn().mockImplementationOnce(() => {
+      throw new Error("notification construction failed");
+    });
+    const delivery = (permission: "default" | "granted") =>
+      deliverBrowserRunNotification(event(), "Chief", {
+        enabled: true,
+        pageVisible: false,
+        windowFocused: false,
+        permission,
+        notifiedRunIds,
+        show,
+      });
+
+    expect(delivery("default")).toBe("pending");
+    expect(delivery("granted")).toBe("pending");
+    expect(notifiedRunIds).toEqual(new Set());
+    expect(delivery("granted")).toBe("delivered");
+    expect(notifiedRunIds).toEqual(new Set(["run-1"]));
+    expect(delivery("granted")).toBe("discarded");
+    expect(show).toHaveBeenCalledTimes(2);
   });
 
   it("allows a later send gesture to retry a dismissed permission prompt", async () => {

--- a/apps/web/src/lib/browser-notifications.test.ts
+++ b/apps/web/src/lib/browser-notifications.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  type BrowserNotificationContext,
+  browserNotificationMessage,
+  shouldNotifyBrowser,
+} from "./browser-notifications.js";
+
+function event(
+  overrides: Partial<{
+    type: "run.completed" | "run.failed" | "run.cancelled" | "run.started";
+    threadId: string;
+    runId: string;
+    seq: number;
+  }> = {},
+) {
+  return {
+    type: "run.completed" as const,
+    threadId: "thread-1",
+    runId: "run-1",
+    seq: 8,
+    ...overrides,
+  };
+}
+
+function context(overrides: Partial<BrowserNotificationContext> = {}): BrowserNotificationContext {
+  return {
+    subscribedThreadId: "thread-1",
+    initialCursor: 7,
+    streamReady: true,
+    pageVisible: false,
+    windowFocused: false,
+    permission: "granted",
+    notifiedRunIds: new Set(),
+    ...overrides,
+  };
+}
+
+describe("browser run notifications", () => {
+  it("only accepts a new terminal event for the hidden or unfocused subscribed thread", () => {
+    expect(shouldNotifyBrowser(event(), context())).toBe(true);
+    expect(shouldNotifyBrowser(event({ type: "run.started" }), context())).toBe(false);
+    expect(shouldNotifyBrowser(event({ threadId: "other-thread" }), context())).toBe(false);
+    expect(shouldNotifyBrowser(event({ seq: 7 }), context())).toBe(false);
+    expect(shouldNotifyBrowser(event(), context({ pageVisible: true, windowFocused: false }))).toBe(
+      true,
+    );
+    expect(shouldNotifyBrowser(event(), context({ pageVisible: false, windowFocused: true }))).toBe(
+      true,
+    );
+    expect(shouldNotifyBrowser(event(), context({ streamReady: false }))).toBe(false);
+    expect(shouldNotifyBrowser(event(), context({ pageVisible: true, windowFocused: true }))).toBe(
+      false,
+    );
+    expect(shouldNotifyBrowser(event(), context({ permission: "default" }))).toBe(false);
+    expect(shouldNotifyBrowser(event(), context({ notifiedRunIds: new Set(["run-1"]) }))).toBe(
+      false,
+    );
+  });
+
+  it("keeps terminal copy stable for the native Notification API", () => {
+    expect(browserNotificationMessage(event(), "Chief")).toEqual({
+      title: "Chief finished",
+      body: "Your bot finished its work.",
+    });
+    expect(browserNotificationMessage(event({ type: "run.failed" }), "Chief")).toEqual({
+      title: "Chief failed",
+      body: "Your bot run failed.",
+    });
+  });
+});

--- a/apps/web/src/lib/browser-notifications.ts
+++ b/apps/web/src/lib/browser-notifications.ts
@@ -9,23 +9,31 @@ export type BrowserNotificationApi = {
   requestPermission(): Promise<BrowserNotificationPermission>;
 };
 
-let permissionRequestPending = false;
+let permissionRequest: Promise<BrowserNotificationPermission> | null = null;
 
 export function requestBrowserNotificationPermission(
   api: BrowserNotificationApi | undefined = typeof Notification === "undefined"
     ? undefined
     : Notification,
-): void {
-  if (permissionRequestPending || !api || api.permission !== "default") return;
-  permissionRequestPending = true;
-  const clearPending = () => {
-    permissionRequestPending = false;
-  };
+): Promise<BrowserNotificationPermission> | undefined {
+  if (!api) return undefined;
+  if (api.permission !== "default") return Promise.resolve(api.permission);
+  if (permissionRequest) return permissionRequest;
   try {
-    void api.requestPermission().then(clearPending, clearPending);
+    permissionRequest = api.requestPermission().then(
+      (permission) => {
+        permissionRequest = null;
+        return permission;
+      },
+      () => {
+        permissionRequest = null;
+        return api.permission;
+      },
+    );
   } catch {
-    clearPending();
+    return Promise.resolve(api.permission);
   }
+  return permissionRequest;
 }
 
 export type BrowserNotificationContext = {
@@ -75,4 +83,37 @@ export function browserNotificationMessage(
     title: i18n._({ id: "{name} finished", message: "{name} finished", values: { name } }),
     body: i18n._({ id: "Finished.", message: "Finished." }),
   };
+}
+
+export function deliverBrowserRunNotification(
+  event: Pick<ProductEvent, "type" | "runId">,
+  botName: string,
+  context: {
+    enabled: boolean;
+    pageVisible: boolean;
+    windowFocused: boolean;
+    permission: BrowserNotificationPermission;
+    notifiedRunIds: Set<string>;
+    show: (title: string, body: string) => void;
+  },
+): "delivered" | "pending" | "discarded" {
+  const runId = event.runId;
+  if (
+    typeof runId !== "string" ||
+    !context.enabled ||
+    (context.pageVisible && context.windowFocused) ||
+    context.notifiedRunIds.has(runId) ||
+    context.permission === "denied"
+  ) {
+    return "discarded";
+  }
+  if (context.permission === "default") return "pending";
+  const message = browserNotificationMessage(event, botName);
+  try {
+    context.show(message.title, message.body);
+    context.notifiedRunIds.add(runId);
+    return "delivered";
+  } catch {
+    return "pending";
+  }
 }

--- a/apps/web/src/lib/browser-notifications.ts
+++ b/apps/web/src/lib/browser-notifications.ts
@@ -62,20 +62,17 @@ export function browserNotificationMessage(
   if (event.type === "run.failed") {
     return {
       title: i18n._({ id: "{name} failed", message: "{name} failed", values: { name } }),
-      body: i18n._({ id: "Your bot run failed.", message: "Your bot run failed." }),
+      body: i18n._({ id: "Failed.", message: "Failed." }),
     };
   }
   if (event.type === "run.cancelled") {
     return {
       title: i18n._({ id: "{name} stopped", message: "{name} stopped", values: { name } }),
-      body: i18n._({
-        id: "Your bot run was stopped.",
-        message: "Your bot run was stopped.",
-      }),
+      body: i18n._({ id: "Stopped.", message: "Stopped." }),
     };
   }
   return {
     title: i18n._({ id: "{name} finished", message: "{name} finished", values: { name } }),
-    body: i18n._({ id: "Your bot finished its work.", message: "Your bot finished its work." }),
+    body: i18n._({ id: "Finished.", message: "Finished." }),
   };
 }

--- a/apps/web/src/lib/browser-notifications.ts
+++ b/apps/web/src/lib/browser-notifications.ts
@@ -1,5 +1,6 @@
 import type { ProductEvent } from "@rakazo/contracts";
 import { isRunTerminalEvent } from "@rakazo/core";
+import { i18n } from "./i18n";
 
 export type BrowserNotificationPermission = "default" | "denied" | "granted";
 
@@ -57,12 +58,24 @@ export function browserNotificationMessage(
   event: Pick<ProductEvent, "type">,
   botName: string,
 ): { title: string; body: string } {
-  const name = botName.trim() || "Bot";
+  const name = botName.trim() || i18n._({ id: "Bot", message: "Bot" });
   if (event.type === "run.failed") {
-    return { title: `${name} failed`, body: "Your bot run failed." };
+    return {
+      title: i18n._({ id: "{name} failed", message: "{name} failed", values: { name } }),
+      body: i18n._({ id: "Your bot run failed.", message: "Your bot run failed." }),
+    };
   }
   if (event.type === "run.cancelled") {
-    return { title: `${name} stopped`, body: "Your bot run was stopped." };
+    return {
+      title: i18n._({ id: "{name} stopped", message: "{name} stopped", values: { name } }),
+      body: i18n._({
+        id: "Your bot run was stopped.",
+        message: "Your bot run was stopped.",
+      }),
+    };
   }
-  return { title: `${name} finished`, body: "Your bot finished its work." };
+  return {
+    title: i18n._({ id: "{name} finished", message: "{name} finished", values: { name } }),
+    body: i18n._({ id: "Your bot finished its work.", message: "Your bot finished its work." }),
+  };
 }

--- a/apps/web/src/lib/browser-notifications.ts
+++ b/apps/web/src/lib/browser-notifications.ts
@@ -1,0 +1,44 @@
+import type { ProductEvent } from "@rakazo/contracts";
+import { isRunTerminalEvent } from "@rakazo/core";
+
+export type BrowserNotificationPermission = "default" | "denied" | "granted";
+
+export type BrowserNotificationContext = {
+  subscribedThreadId: string;
+  initialCursor: number;
+  streamReady: boolean;
+  pageVisible: boolean;
+  windowFocused: boolean;
+  permission: BrowserNotificationPermission;
+  notifiedRunIds: ReadonlySet<string>;
+};
+
+export function shouldNotifyBrowser(
+  event: Pick<ProductEvent, "type" | "threadId" | "runId" | "seq">,
+  context: BrowserNotificationContext,
+): boolean {
+  return (
+    context.streamReady &&
+    isRunTerminalEvent(event) &&
+    event.threadId === context.subscribedThreadId &&
+    event.seq > context.initialCursor &&
+    (!context.pageVisible || !context.windowFocused) &&
+    context.permission === "granted" &&
+    typeof event.runId === "string" &&
+    !context.notifiedRunIds.has(event.runId)
+  );
+}
+
+export function browserNotificationMessage(
+  event: Pick<ProductEvent, "type">,
+  botName: string,
+): { title: string; body: string } {
+  const name = botName.trim() || "Bot";
+  if (event.type === "run.failed") {
+    return { title: `${name} failed`, body: "Your bot run failed." };
+  }
+  if (event.type === "run.cancelled") {
+    return { title: `${name} stopped`, body: "Your bot run was stopped." };
+  }
+  return { title: `${name} finished`, body: "Your bot finished its work." };
+}

--- a/apps/web/src/lib/browser-notifications.ts
+++ b/apps/web/src/lib/browser-notifications.ts
@@ -3,6 +3,30 @@ import { isRunTerminalEvent } from "@rakazo/core";
 
 export type BrowserNotificationPermission = "default" | "denied" | "granted";
 
+export type BrowserNotificationApi = {
+  readonly permission: BrowserNotificationPermission;
+  requestPermission(): Promise<BrowserNotificationPermission>;
+};
+
+let permissionRequestPending = false;
+
+export function requestBrowserNotificationPermission(
+  api: BrowserNotificationApi | undefined = typeof Notification === "undefined"
+    ? undefined
+    : Notification,
+): void {
+  if (permissionRequestPending || !api || api.permission !== "default") return;
+  permissionRequestPending = true;
+  const clearPending = () => {
+    permissionRequestPending = false;
+  };
+  try {
+    void api.requestPermission().then(clearPending, clearPending);
+  } catch {
+    clearPending();
+  }
+}
+
 export type BrowserNotificationContext = {
   subscribedThreadId: string;
   initialCursor: number;

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -2902,13 +2902,13 @@ msgid "{name} stopped"
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run failed."
+msgid "Failed."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run was stopped."
+msgid "Stopped."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot finished its work."
+msgid "Finished."
 msgstr ""

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -2888,3 +2888,27 @@ msgstr "Dein Name"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Dein Team aus jederzeit verfügbaren Agents<0/>für echte Aufgaben."
+
+#: src/lib/browser-notifications.ts
+msgid "{name} failed"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} finished"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} stopped"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run failed."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run was stopped."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot finished its work."
+msgstr ""

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -2891,24 +2891,24 @@ msgstr "Dein Team aus jederzeit verfügbaren Agents<0/>für echte Aufgaben."
 
 #: src/lib/browser-notifications.ts
 msgid "{name} failed"
-msgstr ""
+msgstr "{name} ist fehlgeschlagen"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} finished"
-msgstr ""
+msgstr "{name} ist fertig"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} stopped"
-msgstr ""
+msgstr "{name} wurde gestoppt"
 
 #: src/lib/browser-notifications.ts
 msgid "Failed."
-msgstr ""
+msgstr "Fehlgeschlagen."
 
 #: src/lib/browser-notifications.ts
 msgid "Stopped."
-msgstr ""
+msgstr "Gestoppt."
 
 #: src/lib/browser-notifications.ts
 msgid "Finished."
-msgstr ""
+msgstr "Fertig."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -2888,3 +2888,27 @@ msgstr "Your name"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Your team of always-on agents<0/>that you can give real work to."
+
+#: src/lib/browser-notifications.ts
+msgid "{name} failed"
+msgstr "{name} failed"
+
+#: src/lib/browser-notifications.ts
+msgid "{name} finished"
+msgstr "{name} finished"
+
+#: src/lib/browser-notifications.ts
+msgid "{name} stopped"
+msgstr "{name} stopped"
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run failed."
+msgstr "Your bot run failed."
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run was stopped."
+msgstr "Your bot run was stopped."
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot finished its work."
+msgstr "Your bot finished its work."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -2902,13 +2902,13 @@ msgid "{name} stopped"
 msgstr "{name} stopped"
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run failed."
-msgstr "Your bot run failed."
+msgid "Failed."
+msgstr "Failed."
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run was stopped."
-msgstr "Your bot run was stopped."
+msgid "Stopped."
+msgstr "Stopped."
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot finished its work."
-msgstr "Your bot finished its work."
+msgid "Finished."
+msgstr "Finished."

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -2902,13 +2902,13 @@ msgid "{name} stopped"
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run failed."
+msgid "Failed."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run was stopped."
+msgid "Stopped."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot finished its work."
+msgid "Finished."
 msgstr ""

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -2888,3 +2888,27 @@ msgstr "आपका नाम"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "हमेशा चालू रहने वाले एजेंटों की आपकी टीम<0/>जिन्हें आप असली काम सौंप सकते हैं।"
+
+#: src/lib/browser-notifications.ts
+msgid "{name} failed"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} finished"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} stopped"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run failed."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run was stopped."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot finished its work."
+msgstr ""

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -2891,24 +2891,24 @@ msgstr "हमेशा चालू रहने वाले एजेंट�
 
 #: src/lib/browser-notifications.ts
 msgid "{name} failed"
-msgstr ""
+msgstr "{name} विफल रहा"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} finished"
-msgstr ""
+msgstr "{name} पूरा हुआ"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} stopped"
-msgstr ""
+msgstr "{name} रोक दिया गया"
 
 #: src/lib/browser-notifications.ts
 msgid "Failed."
-msgstr ""
+msgstr "विफल।"
 
 #: src/lib/browser-notifications.ts
 msgid "Stopped."
-msgstr ""
+msgstr "रोक दिया गया।"
 
 #: src/lib/browser-notifications.ts
 msgid "Finished."
-msgstr ""
+msgstr "पूरा हुआ।"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -2902,13 +2902,13 @@ msgid "{name} stopped"
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run failed."
+msgid "Failed."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run was stopped."
+msgid "Stopped."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot finished its work."
+msgid "Finished."
 msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -2888,3 +2888,27 @@ msgstr "이름"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "언제든 실제 작업을 맡길 수 있는<0/>나만의 Agent 팀"
+
+#: src/lib/browser-notifications.ts
+msgid "{name} failed"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} finished"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} stopped"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run failed."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run was stopped."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot finished its work."
+msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -2891,24 +2891,24 @@ msgstr "언제든 실제 작업을 맡길 수 있는<0/>나만의 Agent 팀"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} failed"
-msgstr ""
+msgstr "{name} 실패"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} finished"
-msgstr ""
+msgstr "{name} 완료"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} stopped"
-msgstr ""
+msgstr "{name} 중지됨"
 
 #: src/lib/browser-notifications.ts
 msgid "Failed."
-msgstr ""
+msgstr "실패했습니다."
 
 #: src/lib/browser-notifications.ts
 msgid "Stopped."
-msgstr ""
+msgstr "중지되었습니다."
 
 #: src/lib/browser-notifications.ts
 msgid "Finished."
-msgstr ""
+msgstr "완료되었습니다."

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -2902,13 +2902,13 @@ msgid "{name} stopped"
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run failed."
+msgid "Failed."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run was stopped."
+msgid "Stopped."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot finished its work."
+msgid "Finished."
 msgstr ""

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -2888,3 +2888,27 @@ msgstr "O seu nome"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Sua equipe de agentes sempre ativos<0/>, a quem você pode dar trabalho de verdade."
+
+#: src/lib/browser-notifications.ts
+msgid "{name} failed"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} finished"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} stopped"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run failed."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run was stopped."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot finished its work."
+msgstr ""

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -2891,24 +2891,24 @@ msgstr "Sua equipe de agentes sempre ativos<0/>, a quem você pode dar trabalho 
 
 #: src/lib/browser-notifications.ts
 msgid "{name} failed"
-msgstr ""
+msgstr "{name} falhou"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} finished"
-msgstr ""
+msgstr "{name} terminou"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} stopped"
-msgstr ""
+msgstr "{name} foi interrompido"
 
 #: src/lib/browser-notifications.ts
 msgid "Failed."
-msgstr ""
+msgstr "Falhou."
 
 #: src/lib/browser-notifications.ts
 msgid "Stopped."
-msgstr ""
+msgstr "Interrompido."
 
 #: src/lib/browser-notifications.ts
 msgid "Finished."
-msgstr ""
+msgstr "Concluído."

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -2902,13 +2902,13 @@ msgid "{name} stopped"
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run failed."
+msgid "Failed."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot run was stopped."
+msgid "Stopped."
 msgstr ""
 
 #: src/lib/browser-notifications.ts
-msgid "Your bot finished its work."
+msgid "Finished."
 msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -2888,3 +2888,27 @@ msgstr "Adın"
 #: src/pages/Welcome.tsx:21
 msgid "Your team of always-on agents<0/>that you can give real work to."
 msgstr "Gerçek işler verebileceğin,<0/>her zaman açık agent takımın."
+
+#: src/lib/browser-notifications.ts
+msgid "{name} failed"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} finished"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "{name} stopped"
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run failed."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot run was stopped."
+msgstr ""
+
+#: src/lib/browser-notifications.ts
+msgid "Your bot finished its work."
+msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -2895,7 +2895,7 @@ msgstr "{name} başarısız oldu"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} finished"
-msgstr "{name} tamamlandı"
+msgstr "{name} çalışmasını tamamladı"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} stopped"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -2891,24 +2891,24 @@ msgstr "Gerçek işler verebileceğin,<0/>her zaman açık agent takımın."
 
 #: src/lib/browser-notifications.ts
 msgid "{name} failed"
-msgstr ""
+msgstr "{name} başarısız oldu"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} finished"
-msgstr ""
+msgstr "{name} tamamlandı"
 
 #: src/lib/browser-notifications.ts
 msgid "{name} stopped"
-msgstr ""
+msgstr "{name} durduruldu"
 
 #: src/lib/browser-notifications.ts
 msgid "Failed."
-msgstr ""
+msgstr "Başarısız oldu."
 
 #: src/lib/browser-notifications.ts
 msgid "Stopped."
-msgstr ""
+msgstr "Durduruldu."
 
 #: src/lib/browser-notifications.ts
 msgid "Finished."
-msgstr ""
+msgstr "Tamamlandı."

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -120,7 +120,11 @@ import { readActivityMode, writeActivityMode } from "../lib/activity-mode";
 import { type ArtifactTarget, decodeArtifactBase64 } from "../lib/artifact-open";
 import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
-import { browserNotificationMessage, shouldNotifyBrowser } from "../lib/browser-notifications";
+import {
+  browserNotificationMessage,
+  requestBrowserNotificationPermission,
+  shouldNotifyBrowser,
+} from "../lib/browser-notifications";
 import { chartViewport } from "../lib/chart-viewport";
 import { dictation } from "../lib/dictation";
 import { localTimezone } from "../lib/local-timezone";
@@ -215,24 +219,6 @@ type PendingAttachment = {
 };
 
 const ATTACHMENT_ACCEPT = ATTACHMENT_ALLOWED_MIME_TYPES.join(",");
-
-let browserNotificationPermissionRequested = false;
-
-function requestBrowserNotificationPermission(): void {
-  if (
-    browserNotificationPermissionRequested ||
-    typeof Notification === "undefined" ||
-    Notification.permission !== "default"
-  ) {
-    return;
-  }
-  browserNotificationPermissionRequested = true;
-  try {
-    void Notification.requestPermission().catch(() => undefined);
-  } catch {
-    // Browsers can reject permission requests outside a secure context.
-  }
-}
 
 function collapsedSidebarSectionsStorageKey(userId: string | null | undefined): string | null {
   if (!userId) return null;
@@ -681,9 +667,9 @@ export function ShellPage() {
       snapTranscriptToEndAfterFrame();
     }
     const [routines, skills] = await Promise.all([
-      rpc.routines.list({ botId: id }),
-      rpc.skills.list({ botId: id }),
-      refreshComputerScreen(id),
+      rpc.routines.list({ botId: id }).catch(() => null),
+      rpc.skills.list({ botId: id }).catch(() => null),
+      refreshComputerScreen(id).catch(() => null),
     ]);
     if (
       activeBotId.current !== id ||
@@ -692,10 +678,14 @@ export function ShellPage() {
     ) {
       return snap;
     }
-    setRoutines(routines);
-    setRoutinesBotId(id);
-    setTaughtSkills(skills);
-    setTaughtSkillsBotId(id);
+    if (routines) {
+      setRoutines(routines);
+      setRoutinesBotId(id);
+    }
+    if (skills) {
+      setTaughtSkills(skills);
+      setTaughtSkillsBotId(id);
+    }
     return snap;
   }
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -120,6 +120,7 @@ import { readActivityMode, writeActivityMode } from "../lib/activity-mode";
 import { type ArtifactTarget, decodeArtifactBase64 } from "../lib/artifact-open";
 import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
+import { browserNotificationMessage, shouldNotifyBrowser } from "../lib/browser-notifications";
 import { chartViewport } from "../lib/chart-viewport";
 import { dictation } from "../lib/dictation";
 import { localTimezone } from "../lib/local-timezone";
@@ -215,6 +216,24 @@ type PendingAttachment = {
 
 const ATTACHMENT_ACCEPT = ATTACHMENT_ALLOWED_MIME_TYPES.join(",");
 
+let browserNotificationPermissionRequested = false;
+
+function requestBrowserNotificationPermission(): void {
+  if (
+    browserNotificationPermissionRequested ||
+    typeof Notification === "undefined" ||
+    Notification.permission !== "default"
+  ) {
+    return;
+  }
+  browserNotificationPermissionRequested = true;
+  try {
+    void Notification.requestPermission().catch(() => undefined);
+  } catch {
+    // Browsers can reject permission requests outside a secure context.
+  }
+}
+
 function collapsedSidebarSectionsStorageKey(userId: string | null | undefined): string | null {
   if (!userId) return null;
   return `rakazo:collapsed-sidebar-sections:${userId}`;
@@ -248,6 +267,8 @@ export function ShellPage() {
   const userId = session.data?.user.id;
   const [groups, setGroups] = useState<Group[]>([]);
   const [bots, setBots] = useState<Bot[]>([]);
+  const botsRef = useRef(bots);
+  botsRef.current = bots;
   const [botSections, setBotSections] = useState<BotSection[]>([]);
   const [archivedBots, setArchivedBots] = useState<Bot[]>([]);
   const [archivedGroups, setArchivedGroups] = useState<Group[]>([]);
@@ -415,6 +436,7 @@ export function ShellPage() {
   } | null>(null);
   const manuallyUnread = useRef(new Set<string>());
   const readVisibleGroups = useRef(new Set<string>());
+  const notifiedBrowserRuns = useRef(new Set<string>());
   const computerVisible = useRef(false);
   computerVisible.current = panel === "computer" || computerOpen;
   const autoSpoken = useRef<string | null>(null);
@@ -485,6 +507,45 @@ export function ShellPage() {
       }
     },
     [markBotRead],
+  );
+  const notifyBrowserForTerminalEvent = useCallback(
+    (
+      event: Pick<ProductEvent, "type" | "threadId" | "runId" | "seq">,
+      subscribedThreadId: string | undefined,
+      initialCursor: number,
+      streamReady: boolean,
+      botName: string,
+      notifyOnFinish: boolean,
+    ) => {
+      const runId = event.runId;
+      if (typeof runId !== "string") return;
+      const permission = typeof Notification === "undefined" ? "denied" : Notification.permission;
+      const shouldNotify = shouldNotifyBrowser(event, {
+        subscribedThreadId: subscribedThreadId ?? "",
+        initialCursor,
+        streamReady,
+        pageVisible: document.visibilityState === "visible",
+        windowFocused: document.hasFocus(),
+        permission,
+        notifiedRunIds: notifiedBrowserRuns.current,
+      });
+      if (
+        streamReady &&
+        isRunTerminalEvent(event) &&
+        event.threadId === subscribedThreadId &&
+        event.seq > initialCursor
+      ) {
+        notifiedBrowserRuns.current.add(runId);
+      }
+      if (!shouldNotify || !notifyOnFinish || typeof Notification === "undefined") return;
+      const message = browserNotificationMessage(event, botName);
+      try {
+        new Notification(message.title, { body: message.body });
+      } catch {
+        // Permission can change between the check and construction.
+      }
+    },
+    [],
   );
 
   const refreshBots = useCallback(
@@ -891,15 +952,28 @@ export function ShellPage() {
       const primed = bootstrappedThread.current;
       bootstrappedThread.current = null;
       // Pending search jumps load the around-page separately; avoid replacing it with latest.
-      const snap =
+      let snap =
         primed?.botId === active.id
           ? primed
           : pendingJump
             ? await rpc.threads.get({ botId: active.id }).catch(() => null)
             : await refreshThread(active.id).catch(() => null);
       if (abort.signal.aborted) return;
-      let cursor = snap?.cursor ?? -1;
+      if (snap === null) {
+        snap = await refreshThread(active.id).catch(() => null);
+        if (abort.signal.aborted) return;
+      }
       let retryMs = 250;
+      while (snap === null && !abort.signal.aborted) {
+        await abortableDelay(retryMs, abort.signal);
+        snap = await refreshThread(active.id).catch(() => null);
+        retryMs = Math.min(retryMs * 2, 5_000);
+      }
+      if (!snap || abort.signal.aborted) return;
+      const subscribedThreadId = snap.threadId;
+      const initialCursor = snap.cursor;
+      let cursor = initialCursor;
+      retryMs = 250;
       while (!abort.signal.aborted) {
         try {
           const events = await rpc.threads.subscribe(
@@ -911,6 +985,14 @@ export function ShellPage() {
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
             applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+            notifyBrowserForTerminalEvent(
+              event,
+              subscribedThreadId,
+              initialCursor,
+              true,
+              active.name,
+              active.notifyOnFinish,
+            );
             if (event.type === "thread.cleared") {
               expandedHistoryThread.current = null;
               pinnedAroundRef.current = null;
@@ -957,7 +1039,7 @@ export function ShellPage() {
     return () => {
       abort.abort();
     };
-  }, [active?.id, markBotReadIfVisible]);
+  }, [active?.id, markBotReadIfVisible, notifyBrowserForTerminalEvent]);
 
   useEffect(() => {
     if (!groupId || !activeGroup) return;
@@ -997,12 +1079,25 @@ export function ShellPage() {
     historyEpoch.current += 1;
     const abort = new AbortController();
     void (async () => {
-      const snap = pendingJump
+      let snap = pendingJump
         ? await rpc.threads.get({ groupId }).catch(() => null)
         : await refreshGroupThread(groupId).catch(() => null);
       if (abort.signal.aborted) return;
-      let cursor = snap?.cursor ?? -1;
+      if (snap === null) {
+        snap = await refreshGroupThread(groupId).catch(() => null);
+        if (abort.signal.aborted) return;
+      }
       let retryMs = 250;
+      while (snap === null && !abort.signal.aborted) {
+        await abortableDelay(retryMs, abort.signal);
+        snap = await refreshGroupThread(groupId).catch(() => null);
+        retryMs = Math.min(retryMs * 2, 5_000);
+      }
+      if (!snap || abort.signal.aborted) return;
+      const subscribedThreadId = snap.threadId;
+      const initialCursor = snap.cursor;
+      let cursor = initialCursor;
+      retryMs = 250;
       while (!abort.signal.aborted) {
         try {
           const events = await rpc.threads.subscribe({ groupId, cursor }, { signal: abort.signal });
@@ -1011,6 +1106,15 @@ export function ShellPage() {
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
             applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+            const eventBot = botsRef.current.find((bot) => bot.id === event.botId);
+            notifyBrowserForTerminalEvent(
+              event,
+              subscribedThreadId,
+              initialCursor,
+              true,
+              eventBot?.name ?? activeGroup.name,
+              eventBot?.notifyOnFinish ?? true,
+            );
             if (event.type === "thread.message.created" && event.payload.role === "bot") {
               readVisibleGroups.current.delete(groupId);
               markVisibleGroupRead();
@@ -1037,7 +1141,7 @@ export function ShellPage() {
       document.removeEventListener("visibilitychange", markVisibleGroupRead);
       abort.abort();
     };
-  }, [activeGroup?.id, groupId]);
+  }, [activeGroup?.id, groupId, notifyBrowserForTerminalEvent]);
 
   const filtered = useMemo(
     () =>
@@ -1491,6 +1595,12 @@ export function ShellPage() {
       );
       const groupTarget = plan.rerouteGroupId ?? initialGroupTarget;
       const botTarget = reroutedToGroup ? undefined : initialBotTarget;
+      if (
+        plan.shouldSend &&
+        (groupTarget || botsRef.current.find((bot) => bot.id === botTarget)?.notifyOnFinish)
+      ) {
+        requestBrowserNotificationPermission();
+      }
       const trimmed = plan.trimmed;
       setSending(true);
       setSendError(null);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -121,7 +121,7 @@ import { type ArtifactTarget, decodeArtifactBase64 } from "../lib/artifact-open"
 import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
 import {
-  browserNotificationMessage,
+  deliverBrowserRunNotification,
   requestBrowserNotificationPermission,
   shouldNotifyBrowser,
 } from "../lib/browser-notifications";
@@ -216,6 +216,12 @@ type PendingAttachment = {
   threadKey: string;
   file: File;
   previewUrl?: string;
+};
+
+type PendingBrowserNotification = {
+  event: Pick<ProductEvent, "type" | "runId" | "botId">;
+  botId: string;
+  botName: string;
 };
 
 const ATTACHMENT_ACCEPT = ATTACHMENT_ALLOWED_MIME_TYPES.join(",");
@@ -423,6 +429,7 @@ export function ShellPage() {
   const manuallyUnread = useRef(new Set<string>());
   const readVisibleGroups = useRef(new Set<string>());
   const notifiedBrowserRuns = useRef(new Set<string>());
+  const pendingBrowserNotifications = useRef(new Map<string, PendingBrowserNotification>());
   const computerVisible = useRef(false);
   computerVisible.current = panel === "computer" || computerOpen;
   const autoSpoken = useRef<string | null>(null);
@@ -494,44 +501,66 @@ export function ShellPage() {
     },
     [markBotRead],
   );
+  const deliverBrowserNotification = useCallback((pending: PendingBrowserNotification): boolean => {
+    const runId = pending.event.runId;
+    if (typeof runId !== "string") return true;
+    const currentBot = botsRef.current.find((bot) => bot.id === pending.botId);
+    if (!currentBot || typeof Notification === "undefined") return true;
+    const result = deliverBrowserRunNotification(
+      pending.event,
+      currentBot.name || pending.botName,
+      {
+        enabled: currentBot.notifyOnFinish,
+        pageVisible: document.visibilityState === "visible",
+        windowFocused: document.hasFocus(),
+        permission: Notification.permission,
+        notifiedRunIds: notifiedBrowserRuns.current,
+        show: (title, body) => new Notification(title, { body }),
+      },
+    );
+    return result !== "pending";
+  }, []);
+  const flushPendingBrowserNotifications = useCallback(() => {
+    for (const [runId, pending] of pendingBrowserNotifications.current) {
+      if (deliverBrowserNotification(pending)) {
+        pendingBrowserNotifications.current.delete(runId);
+      }
+    }
+  }, [deliverBrowserNotification]);
   const notifyBrowserForTerminalEvent = useCallback(
     (
-      event: Pick<ProductEvent, "type" | "threadId" | "runId" | "seq">,
+      event: Pick<ProductEvent, "type" | "threadId" | "runId" | "seq" | "botId">,
       subscribedThreadId: string | undefined,
       initialCursor: number,
       streamReady: boolean,
       botName: string,
-      notifyOnFinish: boolean,
     ) => {
       const runId = event.runId;
-      if (typeof runId !== "string") return;
-      const permission = typeof Notification === "undefined" ? "denied" : Notification.permission;
-      const shouldNotify = shouldNotifyBrowser(event, {
+      const botId = event.botId;
+      if (typeof runId !== "string" || typeof botId !== "string") return;
+      const eligible = shouldNotifyBrowser(event, {
         subscribedThreadId: subscribedThreadId ?? "",
         initialCursor,
         streamReady,
         pageVisible: document.visibilityState === "visible",
         windowFocused: document.hasFocus(),
-        permission,
+        permission: "granted",
         notifiedRunIds: notifiedBrowserRuns.current,
       });
-      if (
-        streamReady &&
-        isRunTerminalEvent(event) &&
-        event.threadId === subscribedThreadId &&
-        event.seq > initialCursor
-      ) {
-        notifiedBrowserRuns.current.add(runId);
+      if (!eligible || !botsRef.current.find((bot) => bot.id === botId)?.notifyOnFinish) return;
+      const pending = { event, botId, botName } satisfies PendingBrowserNotification;
+      if (typeof Notification === "undefined" || Notification.permission === "denied") return;
+      if (Notification.permission === "default") {
+        pendingBrowserNotifications.current.set(runId, pending);
+        return;
       }
-      if (!shouldNotify || !notifyOnFinish || typeof Notification === "undefined") return;
-      const message = browserNotificationMessage(event, botName);
-      try {
-        new Notification(message.title, { body: message.body });
-      } catch {
-        // Permission can change between the check and construction.
+      if (deliverBrowserNotification(pending)) {
+        pendingBrowserNotifications.current.delete(runId);
+      } else {
+        pendingBrowserNotifications.current.set(runId, pending);
       }
     },
-    [],
+    [deliverBrowserNotification],
   );
 
   const refreshBots = useCallback(
@@ -961,10 +990,30 @@ export function ShellPage() {
         retryMs = Math.min(retryMs * 2, 5_000);
       }
       if (abort.signal.aborted) return;
-      const streamReady = Boolean(snap?.threadId);
-      const subscribedThreadId = snap?.threadId;
-      const initialCursor = snap?.cursor ?? -1;
+      let streamReady = Boolean(snap?.threadId);
+      let subscribedThreadId = snap?.threadId;
+      let initialCursor = snap?.cursor ?? -1;
       let cursor = initialCursor;
+      if (!streamReady) {
+        void (async () => {
+          let snapshotRetryMs = 250;
+          while (!streamReady && !abort.signal.aborted) {
+            try {
+              await abortableDelay(snapshotRetryMs, abort.signal);
+            } catch {
+              return;
+            }
+            const refreshed = await refreshThread(active.id).catch(() => null);
+            if (refreshed?.threadId) {
+              subscribedThreadId = refreshed.threadId;
+              initialCursor = Math.max(cursor, refreshed.cursor);
+              streamReady = true;
+              return;
+            }
+            snapshotRetryMs = Math.min(snapshotRetryMs * 2, 5_000);
+          }
+        })();
+      }
       retryMs = 250;
       while (!abort.signal.aborted) {
         try {
@@ -984,7 +1033,6 @@ export function ShellPage() {
               initialCursor,
               streamReady,
               currentBot?.name ?? active.name,
-              currentBot?.notifyOnFinish ?? active.notifyOnFinish,
             );
             if (event.type === "thread.cleared") {
               expandedHistoryThread.current = null;
@@ -1088,10 +1136,30 @@ export function ShellPage() {
         retryMs = Math.min(retryMs * 2, 5_000);
       }
       if (abort.signal.aborted) return;
-      const streamReady = Boolean(snap?.threadId);
-      const subscribedThreadId = snap?.threadId;
-      const initialCursor = snap?.cursor ?? -1;
+      let streamReady = Boolean(snap?.threadId);
+      let subscribedThreadId = snap?.threadId;
+      let initialCursor = snap?.cursor ?? -1;
       let cursor = initialCursor;
+      if (!streamReady) {
+        void (async () => {
+          let snapshotRetryMs = 250;
+          while (!streamReady && !abort.signal.aborted) {
+            try {
+              await abortableDelay(snapshotRetryMs, abort.signal);
+            } catch {
+              return;
+            }
+            const refreshed = await refreshGroupThread(groupId).catch(() => null);
+            if (refreshed?.threadId) {
+              subscribedThreadId = refreshed.threadId;
+              initialCursor = Math.max(cursor, refreshed.cursor);
+              streamReady = true;
+              return;
+            }
+            snapshotRetryMs = Math.min(snapshotRetryMs * 2, 5_000);
+          }
+        })();
+      }
       retryMs = 250;
       while (!abort.signal.aborted) {
         try {
@@ -1108,7 +1176,6 @@ export function ShellPage() {
               initialCursor,
               streamReady,
               eventBot?.name ?? activeGroup.name,
-              eventBot?.notifyOnFinish ?? true,
             );
             if (event.type === "thread.message.created" && event.payload.role === "bot") {
               readVisibleGroups.current.delete(groupId);
@@ -1594,7 +1661,8 @@ export function ShellPage() {
         plan.shouldSend &&
         (groupTarget || botsRef.current.find((bot) => bot.id === botTarget)?.notifyOnFinish)
       ) {
-        requestBrowserNotificationPermission();
+        const permissionRequest = requestBrowserNotificationPermission();
+        if (permissionRequest) void permissionRequest.then(flushPendingBrowserNotifications);
       }
       const trimmed = plan.trimmed;
       setSending(true);
@@ -1687,7 +1755,14 @@ export function ShellPage() {
         setSending(false);
       }
     },
-    [activeReplyTarget?.id, navigate, pendingAttachments, sending, t],
+    [
+      activeReplyTarget?.id,
+      flushPendingBrowserNotifications,
+      navigate,
+      pendingAttachments,
+      sending,
+      t,
+    ],
   );
   const followUpMessage = useCallback(async (text: string) => {
     const id = activeBotId.current;

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -225,6 +225,11 @@ type PendingBrowserNotification = {
 };
 
 const ATTACHMENT_ACCEPT = ATTACHMENT_ALLOWED_MIME_TYPES.join(",");
+const THREAD_SNAPSHOT_TIMEOUT_MS = 2_000;
+
+function threadSnapshotSignal(parent: AbortSignal): AbortSignal {
+  return AbortSignal.any([parent, AbortSignal.timeout(THREAD_SNAPSHOT_TIMEOUT_MS)]);
+}
 
 function collapsedSidebarSectionsStorageKey(userId: string | null | undefined): string | null {
   if (!userId) return null;
@@ -633,12 +638,12 @@ export function ShellPage() {
     });
   }
 
-  async function refreshGroupThread(id: string) {
+  async function refreshGroupThread(id: string, signal?: AbortSignal) {
     const scrollElement = messageScroll.current;
     const stickToEnd = !scrollElement || transcriptIsNearEnd(scrollElement);
     markOnce("rk:renderer:thread-request-start");
     const request = ++groupRefreshEpoch.current;
-    const snap = await rpc.threads.get({ groupId: id });
+    const snap = await rpc.threads.get({ groupId: id }, signal ? { signal } : undefined);
     markOnce("rk:renderer:thread-response");
     if (activeGroupId.current !== id || request !== groupRefreshEpoch.current) return snap;
     const reconciled = reconcileRefreshedThread(
@@ -662,7 +667,7 @@ export function ShellPage() {
     return snap;
   }
 
-  async function refreshThread(id: string) {
+  async function refreshThread(id: string, signal?: AbortSignal) {
     const scrollElement = messageScroll.current;
     const stickToEnd = !scrollElement || transcriptIsNearEnd(scrollElement);
     markOnce("rk:renderer:thread-request-start");
@@ -670,7 +675,7 @@ export function ShellPage() {
     const request = ++threadRefreshEpoch.current;
     // Apply threads.get as soon as it returns so stop/takeover status is not held behind
     // routines/skills/screen fetches (progress can advance the cursor meanwhile).
-    const snap = await rpc.threads.get({ botId: id });
+    const snap = await rpc.threads.get({ botId: id }, signal ? { signal } : undefined);
     markOnce("rk:renderer:thread-response");
     if (
       activeBotId.current !== id ||
@@ -695,26 +700,27 @@ export function ShellPage() {
     ) {
       snapTranscriptToEndAfterFrame();
     }
-    const [routines, skills] = await Promise.all([
+    void Promise.all([
       rpc.routines.list({ botId: id }).catch(() => null),
       rpc.skills.list({ botId: id }).catch(() => null),
       refreshComputerScreen(id).catch(() => null),
-    ]);
-    if (
-      activeBotId.current !== id ||
-      epoch !== historyEpoch.current ||
-      request !== threadRefreshEpoch.current
-    ) {
-      return snap;
-    }
-    if (routines) {
-      setRoutines(routines);
-      setRoutinesBotId(id);
-    }
-    if (skills) {
-      setTaughtSkills(skills);
-      setTaughtSkillsBotId(id);
-    }
+    ]).then(([routines, skills]) => {
+      if (
+        activeBotId.current !== id ||
+        epoch !== historyEpoch.current ||
+        request !== threadRefreshEpoch.current
+      ) {
+        return;
+      }
+      if (routines) {
+        setRoutines(routines);
+        setRoutinesBotId(id);
+      }
+      if (skills) {
+        setTaughtSkills(skills);
+        setTaughtSkillsBotId(id);
+      }
+    });
     return snap;
   }
 
@@ -971,50 +977,66 @@ export function ShellPage() {
       const primed = bootstrappedThread.current;
       bootstrappedThread.current = null;
       // Pending search jumps load the around-page separately; avoid replacing it with latest.
-      let snap =
+      const snap =
         primed?.botId === active.id
           ? primed
           : pendingJump
-            ? await rpc.threads.get({ botId: active.id }).catch(() => null)
-            : await refreshThread(active.id).catch(() => null);
+            ? await rpc.threads
+                .get({ botId: active.id }, { signal: threadSnapshotSignal(abort.signal) })
+                .catch(() => null)
+            : await refreshThread(active.id, threadSnapshotSignal(abort.signal)).catch(() => null);
       if (abort.signal.aborted) return;
-      if (snap === null) {
-        snap = await refreshThread(active.id).catch(() => null);
-        if (abort.signal.aborted) return;
-      }
-      let retryMs = 250;
-      // Short retries for a better initial snap; then subscribe even without one.
-      while (snap === null && !abort.signal.aborted && retryMs < 5_000) {
-        await abortableDelay(retryMs, abort.signal);
-        snap = await refreshThread(active.id).catch(() => null);
-        retryMs = Math.min(retryMs * 2, 5_000);
-      }
-      if (abort.signal.aborted) return;
-      let streamReady = Boolean(snap?.threadId);
       let subscribedThreadId = snap?.threadId;
       let initialCursor = snap?.cursor ?? -1;
+      let headRetryMs = 250;
+      while (!subscribedThreadId && !abort.signal.aborted) {
+        const head = await rpc.threads
+          .head({ botId: active.id }, { signal: threadSnapshotSignal(abort.signal) })
+          .catch(() => null);
+        if (head) {
+          subscribedThreadId = head.threadId;
+          initialCursor = head.cursor;
+          break;
+        }
+        try {
+          await abortableDelay(headRetryMs, abort.signal);
+        } catch {
+          return;
+        }
+        headRetryMs = Math.min(headRetryMs * 2, 5_000);
+      }
+      if (!subscribedThreadId || abort.signal.aborted) return;
       let cursor = initialCursor;
-      if (!streamReady) {
+      let snapshotReady = snapshotRef.current?.threadId === subscribedThreadId;
+      const pendingSnapshotEvents: ProductEvent[] = [];
+      if (!snapshotReady) {
         void (async () => {
           let snapshotRetryMs = 250;
-          while (!streamReady && !abort.signal.aborted) {
+          while (!snapshotReady && !abort.signal.aborted) {
             try {
               await abortableDelay(snapshotRetryMs, abort.signal);
             } catch {
               return;
             }
-            const refreshed = await refreshThread(active.id).catch(() => null);
-            if (refreshed?.threadId) {
-              subscribedThreadId = refreshed.threadId;
-              initialCursor = Math.max(cursor, refreshed.cursor);
-              streamReady = true;
+            await refreshThread(active.id, threadSnapshotSignal(abort.signal)).catch(() => null);
+            if (abort.signal.aborted) return;
+            const committed = snapshotRef.current;
+            if (committed?.threadId === subscribedThreadId) {
+              snapshotReady = true;
+              const pending = pendingSnapshotEvents.splice(0);
+              for (const event of pending) {
+                if (event.seq > committed.cursor) {
+                  applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+                }
+              }
               return;
             }
             snapshotRetryMs = Math.min(snapshotRetryMs * 2, 5_000);
           }
         })();
       }
-      retryMs = 250;
+      const streamReady = true;
+      let retryMs = 250;
       while (!abort.signal.aborted) {
         try {
           const events = await rpc.threads.subscribe(
@@ -1025,7 +1047,11 @@ export function ShellPage() {
             if (abort.signal.aborted) break;
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
-            applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+            if (snapshotReady && snapshotRef.current?.threadId === event.threadId) {
+              applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+            } else {
+              pendingSnapshotEvents.push(event);
+            }
             const currentBot = botsRef.current.find((bot) => bot.id === active.id);
             notifyBrowserForTerminalEvent(
               event,
@@ -1072,7 +1098,7 @@ export function ShellPage() {
           // The durable cursor below makes reconnects safe after a transient network failure.
         }
         if (abort.signal.aborted) break;
-        await refreshThread(active.id).catch(() => null);
+        await refreshThread(active.id, threadSnapshotSignal(abort.signal)).catch(() => null);
         await abortableDelay(retryMs, abort.signal);
         retryMs = Math.min(retryMs * 2, 5_000);
       }
@@ -1120,47 +1146,63 @@ export function ShellPage() {
     historyEpoch.current += 1;
     const abort = new AbortController();
     void (async () => {
-      let snap = pendingJump
-        ? await rpc.threads.get({ groupId }).catch(() => null)
-        : await refreshGroupThread(groupId).catch(() => null);
+      const snap = pendingJump
+        ? await rpc.threads
+            .get({ groupId }, { signal: threadSnapshotSignal(abort.signal) })
+            .catch(() => null)
+        : await refreshGroupThread(groupId, threadSnapshotSignal(abort.signal)).catch(() => null);
       if (abort.signal.aborted) return;
-      if (snap === null) {
-        snap = await refreshGroupThread(groupId).catch(() => null);
-        if (abort.signal.aborted) return;
-      }
-      let retryMs = 250;
-      // Short retries for a better initial snap; then subscribe even without one.
-      while (snap === null && !abort.signal.aborted && retryMs < 5_000) {
-        await abortableDelay(retryMs, abort.signal);
-        snap = await refreshGroupThread(groupId).catch(() => null);
-        retryMs = Math.min(retryMs * 2, 5_000);
-      }
-      if (abort.signal.aborted) return;
-      let streamReady = Boolean(snap?.threadId);
       let subscribedThreadId = snap?.threadId;
       let initialCursor = snap?.cursor ?? -1;
+      let headRetryMs = 250;
+      while (!subscribedThreadId && !abort.signal.aborted) {
+        const head = await rpc.threads
+          .head({ groupId }, { signal: threadSnapshotSignal(abort.signal) })
+          .catch(() => null);
+        if (head) {
+          subscribedThreadId = head.threadId;
+          initialCursor = head.cursor;
+          break;
+        }
+        try {
+          await abortableDelay(headRetryMs, abort.signal);
+        } catch {
+          return;
+        }
+        headRetryMs = Math.min(headRetryMs * 2, 5_000);
+      }
+      if (!subscribedThreadId || abort.signal.aborted) return;
       let cursor = initialCursor;
-      if (!streamReady) {
+      let snapshotReady = snapshotRef.current?.threadId === subscribedThreadId;
+      const pendingSnapshotEvents: ProductEvent[] = [];
+      if (!snapshotReady) {
         void (async () => {
           let snapshotRetryMs = 250;
-          while (!streamReady && !abort.signal.aborted) {
+          while (!snapshotReady && !abort.signal.aborted) {
             try {
               await abortableDelay(snapshotRetryMs, abort.signal);
             } catch {
               return;
             }
-            const refreshed = await refreshGroupThread(groupId).catch(() => null);
-            if (refreshed?.threadId) {
-              subscribedThreadId = refreshed.threadId;
-              initialCursor = Math.max(cursor, refreshed.cursor);
-              streamReady = true;
+            await refreshGroupThread(groupId, threadSnapshotSignal(abort.signal)).catch(() => null);
+            if (abort.signal.aborted) return;
+            const committed = snapshotRef.current;
+            if (committed?.threadId === subscribedThreadId) {
+              snapshotReady = true;
+              const pending = pendingSnapshotEvents.splice(0);
+              for (const event of pending) {
+                if (event.seq > committed.cursor) {
+                  applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+                }
+              }
               return;
             }
             snapshotRetryMs = Math.min(snapshotRetryMs * 2, 5_000);
           }
         })();
       }
-      retryMs = 250;
+      const streamReady = true;
+      let retryMs = 250;
       while (!abort.signal.aborted) {
         try {
           const events = await rpc.threads.subscribe({ groupId, cursor }, { signal: abort.signal });
@@ -1168,7 +1210,11 @@ export function ShellPage() {
             if (abort.signal.aborted) break;
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
-            applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+            if (snapshotReady && snapshotRef.current?.threadId === event.threadId) {
+              applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+            } else {
+              pendingSnapshotEvents.push(event);
+            }
             const eventBot = botsRef.current.find((bot) => bot.id === event.botId);
             notifyBrowserForTerminalEvent(
               event,
@@ -1193,7 +1239,7 @@ export function ShellPage() {
           // reconnect safely
         }
         if (abort.signal.aborted) break;
-        await refreshGroupThread(groupId).catch(() => null);
+        await refreshGroupThread(groupId, threadSnapshotSignal(abort.signal)).catch(() => null);
         await abortableDelay(retryMs, abort.signal);
         retryMs = Math.min(retryMs * 2, 5_000);
       }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -954,14 +954,16 @@ export function ShellPage() {
         if (abort.signal.aborted) return;
       }
       let retryMs = 250;
-      while (snap === null && !abort.signal.aborted) {
+      // Short retries for a better initial snap; then subscribe even without one.
+      while (snap === null && !abort.signal.aborted && retryMs < 5_000) {
         await abortableDelay(retryMs, abort.signal);
         snap = await refreshThread(active.id).catch(() => null);
         retryMs = Math.min(retryMs * 2, 5_000);
       }
-      if (!snap || abort.signal.aborted) return;
-      const subscribedThreadId = snap.threadId;
-      const initialCursor = snap.cursor;
+      if (abort.signal.aborted) return;
+      const streamReady = Boolean(snap?.threadId);
+      const subscribedThreadId = snap?.threadId;
+      const initialCursor = snap?.cursor ?? -1;
       let cursor = initialCursor;
       retryMs = 250;
       while (!abort.signal.aborted) {
@@ -975,13 +977,14 @@ export function ShellPage() {
             cursor = Math.max(cursor, event.seq);
             retryMs = 250;
             applyThreadEvent(event, commitSnapshot, commitComputer, snapshotRef, computerRef);
+            const currentBot = botsRef.current.find((bot) => bot.id === active.id);
             notifyBrowserForTerminalEvent(
               event,
               subscribedThreadId,
               initialCursor,
-              true,
-              active.name,
-              active.notifyOnFinish,
+              streamReady,
+              currentBot?.name ?? active.name,
+              currentBot?.notifyOnFinish ?? active.notifyOnFinish,
             );
             if (event.type === "thread.cleared") {
               expandedHistoryThread.current = null;
@@ -1078,14 +1081,16 @@ export function ShellPage() {
         if (abort.signal.aborted) return;
       }
       let retryMs = 250;
-      while (snap === null && !abort.signal.aborted) {
+      // Short retries for a better initial snap; then subscribe even without one.
+      while (snap === null && !abort.signal.aborted && retryMs < 5_000) {
         await abortableDelay(retryMs, abort.signal);
         snap = await refreshGroupThread(groupId).catch(() => null);
         retryMs = Math.min(retryMs * 2, 5_000);
       }
-      if (!snap || abort.signal.aborted) return;
-      const subscribedThreadId = snap.threadId;
-      const initialCursor = snap.cursor;
+      if (abort.signal.aborted) return;
+      const streamReady = Boolean(snap?.threadId);
+      const subscribedThreadId = snap?.threadId;
+      const initialCursor = snap?.cursor ?? -1;
       let cursor = initialCursor;
       retryMs = 250;
       while (!abort.signal.aborted) {
@@ -1101,7 +1106,7 @@ export function ShellPage() {
               event,
               subscribedThreadId,
               initialCursor,
-              true,
+              streamReady,
               eventBot?.name ?? activeGroup.name,
               eventBot?.notifyOnFinish ?? true,
             );

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -224,6 +224,12 @@ export const appContract = {
       .output(BotSectionSchema),
   },
   threads: {
+    head: oc.input(threadTarget).output(
+      z.object({
+        threadId: Id,
+        cursor: z.number().int().min(-1),
+      }),
+    ),
     get: oc.input(threadTarget).output(ThreadSnapshotSchema),
     messages: oc
       .input(


### PR DESCRIPTION
## Summary

- add localized browser notifications for terminal bot run events in the active subscribed thread
- request notification permission only from a relevant chat send gesture and allow retries after dismissed prompts
- suppress replay/duplicate notifications and notifications while the page is visible and focused
- retry initial thread snapshots before subscribing, without letting secondary UI fetches block live events

## Tests

- `corepack pnpm exec vitest run apps/web/src/lib/browser-notifications.test.ts apps/web/src/lib/thread-events.test.ts` (52 passed)
- `corepack pnpm --filter @rakazo/web intl:compile`
- `corepack pnpm --filter @rakazo/web check`
- `corepack pnpm --filter @rakazo/web build`
- `corepack pnpm exec biome check apps/web/src/lib/browser-notifications.ts apps/web/src/lib/browser-notifications.test.ts apps/web/src/pages/Shell.tsx`

## Notes

The full web test run exposes the existing i18n catalog expectation failure for the uncompiled `alle {intervalAmountSelect}...` fixture; focused notification/thread tests, catalog compilation, typecheck, lint, and production build pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added browser notifications for completed, stopped, or failed runs when the app is hidden or unfocused.
  - Notifications include bot names and localized status details for bot and group conversations.
  - Added permission handling with safe retries, delivery deduplication, and pending notification recovery.
- **Bug Fixes**
  - Improved conversation loading resilience when initial data or supporting resources are temporarily unavailable.
  - Enhanced subscription recovery with automatic retries, event buffering, and more reliable thread updates.
  - Preserved line breaks and whitespace in user message bubbles.
- **Localization**
  - Added translated notification messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->