### PR TITLE
fix(adapters): canonicalize Composio toolkit slugs

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -152,17 +152,23 @@ async function reconcilePendingConnections(
   connectorId: string,
   connectedProviders: string[],
 ): Promise<void> {
-  const rows = await prisma.connection.findMany({
-    where: {
-      workspaceId: owner.workspaceId,
-      userId: owner.userId,
-      connectorId,
-      provider: { in: connectedProviders },
-      status: { in: ["pending", "connected"] },
-    },
-    select: { id: true, provider: true, displayName: true, status: true },
-    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-  });
+  const connectedProviderKeys = new Set(
+    connectedProviders.map((provider) => provider.trim().toLowerCase()),
+  );
+  const rows = (
+    await prisma.connection.findMany({
+      where: {
+        workspaceId: owner.workspaceId,
+        userId: owner.userId,
+        connectorId,
+        status: { in: ["pending", "connected"] },
+      },
+      select: { id: true, provider: true, displayName: true, status: true },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    })
+  ).filter((row: { provider: string }) =>
+    connectedProviderKeys.has(row.provider.trim().toLowerCase()),
+  );
   const sync = planLiveConnectionSync(rows, connectedProviders);
   const updates = [
     ...(sync.connectIds.length > 0

--- a/packages/adapters/src/composio-catalog-cache.test.ts
+++ b/packages/adapters/src/composio-catalog-cache.test.ts
@@ -58,7 +58,7 @@ describe("composio toolkit directory cache", () => {
         { slug: "github", name: "GitHub", logo: null, noAuth: false },
         { slug: "hackernews", name: "Hacker News", logo: null, noAuth: true },
       ],
-      ["hackernews"],
+      ["HACKERNEWS"],
     );
     expect(items.find((item) => item.slug === "github")?.connected).toBe(false);
     expect(items.find((item) => item.slug === "hackernews")?.connected).toBe(true);

--- a/packages/adapters/src/composio-catalog-cache.ts
+++ b/packages/adapters/src/composio-catalog-cache.ts
@@ -13,10 +13,10 @@ export function mergeCatalogWithConnected(
   directory: ToolkitDirectoryEntry[],
   connectedSlugs: Iterable<string>,
 ): ToolkitCatalogEntry[] {
-  const connected = new Set(connectedSlugs);
+  const connected = new Set([...connectedSlugs].map((slug) => slug.trim().toLowerCase()));
   return directory.map((item) => ({
     ...item,
-    connected: connected.has(item.slug),
+    connected: connected.has(item.slug.trim().toLowerCase()),
   }));
 }
 

--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -1,7 +1,9 @@
 import type { AdapterContext, ConnectorEvent, ConnectorTool } from "@rakazo/adapter-kit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { composioToolkitDirectory } from "./composio-catalog-cache.js";
 import {
   asConnectorTools,
+  ComposioConnector,
   CompositeConnector,
   collectLogIds,
   collectPages,
@@ -15,6 +17,99 @@ import {
   sanitizeComposioError,
 } from "./composio-connector.js";
 import { DestinationEmulator } from "./destination-emulator.js";
+
+const composioSdkState = vi.hoisted(() => ({
+  created: [] as Array<{ userId: string; config: Record<string, unknown> }>,
+  directoryFails: false,
+  executions: [] as Array<{ tool: string; args: Record<string, unknown> }>,
+  sessions: new Map<
+    string,
+    {
+      sessionId: string;
+      toolkits?: () => Promise<{
+        items: Array<{
+          slug: string;
+          name: string;
+          logo: string | null;
+          isNoAuth: boolean;
+          connection?: { isActive?: boolean; connectedAccount?: { id: string } };
+        }>;
+        cursor?: string;
+      }>;
+      tools?: () => Promise<unknown[]>;
+      execute?: (
+        tool: string,
+        args: Record<string, unknown>,
+      ) => Promise<{
+        data: Record<string, unknown>;
+        error: null;
+        logId: string;
+      }>;
+    }
+  >(),
+}));
+
+vi.mock("@composio/core", () => ({
+  Composio: class {
+    readonly sessions = {
+      use: async (sessionId: string) => {
+        const session = composioSdkState.sessions.get(sessionId);
+        if (!session) throw new Error(`unknown session ${sessionId}`);
+        return session;
+      },
+    };
+
+    async create(userId: string, config: Record<string, unknown>) {
+      composioSdkState.created.push({ userId, config });
+      const toolkits = Array.isArray(config.toolkits) ? config.toolkits : [];
+      if (toolkits.length === 0) {
+        const session = {
+          sessionId: "catalog-session",
+          toolkits: async () => {
+            if (composioSdkState.directoryFails) throw new Error("directory unavailable");
+            return {
+              items: [
+                {
+                  slug: "GITHUB",
+                  name: "GitHub",
+                  logo: null,
+                  isNoAuth: false,
+                  connection: { isActive: true, connectedAccount: { id: "ca-github" } },
+                },
+              ],
+            };
+          },
+        };
+        composioSdkState.sessions.set(session.sessionId, session);
+        return session;
+      }
+
+      const scopedToCanonicalGithub = toolkits.includes("GITHUB");
+      const session = {
+        sessionId: scopedToCanonicalGithub ? "github-session" : "unscoped-session",
+        tools: async () =>
+          scopedToCanonicalGithub
+            ? [
+                {
+                  type: "function",
+                  function: {
+                    name: "GITHUB_GET_REPOS",
+                    description: "List GitHub repositories",
+                    parameters: { type: "object", properties: {} },
+                  },
+                },
+              ]
+            : [],
+        execute: async (tool: string, args: Record<string, unknown>) => {
+          composioSdkState.executions.push({ tool, args });
+          return { data: { ok: true }, error: null, logId: "log-github" };
+        },
+      };
+      composioSdkState.sessions.set(session.sessionId, session);
+      return session;
+    }
+  },
+}));
 
 describe("composio tool mapping", () => {
   it("maps OpenAI-style session tools and raw slugs", () => {
@@ -114,7 +209,98 @@ describe("composio tool mapping", () => {
 
   it("keys execute sessions by sorted unique toolkits", () => {
     expect(executeSessionKey(["hackernews", "gmail", "hackernews"])).toBe("gmail,hackernews");
+    expect(executeSessionKey(["github", "GITHUB"])).toBe("github");
     expect(executeSessionKey([])).toBe("");
+  });
+
+  it("uses catalog-canonical toolkit slugs for direct-tool sessions", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.executions.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+
+    const connector = new ComposioConnector();
+    const context: AdapterContext = {
+      operationId: "composio-canonical-slug",
+      traceId: "composio-canonical-slug",
+      workspaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: "connection-github",
+          connectorId: "composio",
+          externalId: "github",
+          displayName: "GitHub",
+        },
+      ],
+    };
+
+    await expect(connector.discoverTools(context)).resolves.toContainEqual(
+      expect.objectContaining({ name: "GITHUB_GET_REPOS" }),
+    );
+    expect(
+      composioSdkState.created.map(({ userId, config }) => ({
+        userId,
+        toolkits: config.toolkits,
+        sessionPreset: config.sessionPreset,
+      })),
+    ).toEqual([
+      { userId: "__rakazo_catalog__", toolkits: undefined, sessionPreset: undefined },
+      { userId: "user-1", toolkits: ["GITHUB"], sessionPreset: "direct_tools" },
+    ]);
+
+    const events: ConnectorEvent[] = [];
+    for await (const event of connector.execute(
+      {
+        tool: "GITHUB_GET_REPOS",
+        args: { owner: "composio" },
+        executionId: "composio-canonical-execution",
+      },
+      context,
+    )) {
+      events.push(event);
+    }
+    expect(events).toContainEqual(expect.objectContaining({ type: "result" }));
+    expect(composioSdkState.executions).toEqual([
+      { tool: "GITHUB_GET_REPOS", args: { owner: "composio" } },
+    ]);
+    await expect(connector.connectionReady(context, "github")).resolves.toBe(true);
+    await expect(connector.connectedAccountId("user-1", "github")).resolves.toBe("ca-github");
+  });
+
+  it("uses Composio slug casing when the toolkit directory is unavailable", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.sessions.clear();
+    composioSdkState.directoryFails = true;
+    composioToolkitDirectory.invalidate();
+
+    try {
+      const connector = new ComposioConnector();
+      const context = {
+        operationId: "composio-directory-fallback",
+        traceId: "composio-directory-fallback",
+        workspaceId: "workspace",
+        userId: "user-1",
+        signal: new AbortController().signal,
+        connectedConnections: [
+          {
+            id: "connection-github",
+            connectorId: "composio",
+            externalId: "github",
+            displayName: "GitHub",
+          },
+        ],
+      } satisfies AdapterContext;
+
+      await expect(connector.discoverTools(context)).resolves.toContainEqual(
+        expect.objectContaining({ name: "GITHUB_GET_REPOS" }),
+      );
+      expect(composioSdkState.created.at(-1)?.config.toolkits).toEqual(["GITHUB"]);
+    } finally {
+      composioSdkState.directoryFails = false;
+      composioToolkitDirectory.invalidate();
+    }
   });
 
   it("merges live Composio slugs onto pending DB plugin rows", () => {
@@ -130,6 +316,21 @@ describe("composio tool mapping", () => {
       { provider: "github", displayName: "GitHub" },
       { provider: "gmail", displayName: "Gmail" },
     ]);
+  });
+
+  it("reconciles Composio slugs without case sensitivity", () => {
+    expect(
+      mergeConnectedPlugins(
+        [{ provider: "github", displayName: "GitHub", status: "pending" }],
+        ["GITHUB"],
+      ),
+    ).toEqual([{ provider: "github", displayName: "GitHub" }]);
+    expect(
+      planLiveConnectionSync(
+        [{ id: "row-gh", provider: "github", status: "pending", displayName: "GitHub" }],
+        ["GITHUB"],
+      ),
+    ).toEqual({ connectIds: ["row-gh"], revokeIds: [] });
   });
 
   it("only fetches live Composio slugs when a Rakazo row is still pending or errored", () => {

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -100,8 +100,18 @@ export async function collectPages<T>(
   return items;
 }
 
+function composioSlugKey(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
 export function executeSessionKey(toolkits: string[]): string {
-  return [...new Set(toolkits.map((slug) => slug.trim()).filter(Boolean))].sort().join(",");
+  const unique = new Map<string, string>();
+  for (const slug of toolkits) {
+    const trimmed = slug.trim();
+    const key = composioSlugKey(trimmed);
+    if (key && !unique.has(key)) unique.set(key, trimmed);
+  }
+  return [...unique.values()].sort().join(",");
 }
 
 export type PluginConnectionRow = {
@@ -119,16 +129,21 @@ export function mergeConnectedPlugins(
   rows: { provider: string; displayName: string; status?: string }[],
   liveSlugs: string[],
 ): { provider: string; displayName: string }[] {
-  const live = new Set(liveSlugs.filter(Boolean));
+  const live = new Set(liveSlugs.map((slug) => composioSlugKey(slug)).filter(Boolean));
   const byProvider = new Map<string, { provider: string; displayName: string }>();
   for (const row of rows) {
     if (!row.provider) continue;
     const include =
-      row.status === "connected" || row.status === undefined || live.has(row.provider);
+      row.status === "connected" ||
+      row.status === undefined ||
+      live.has(composioSlugKey(row.provider));
     if (!include) continue;
-    const current = byProvider.get(row.provider);
-    if (!current || current.displayName === row.provider) {
-      byProvider.set(row.provider, { provider: row.provider, displayName: row.displayName });
+    const current = byProvider.get(composioSlugKey(row.provider));
+    if (!current || composioSlugKey(current.displayName) === composioSlugKey(current.provider)) {
+      byProvider.set(composioSlugKey(row.provider), {
+        provider: row.provider,
+        displayName: row.displayName,
+      });
     }
   }
   return [...byProvider.values()];
@@ -138,14 +153,14 @@ export function planLiveConnectionSync(
   rows: PluginConnectionRow[],
   liveSlugs: string[],
 ): { connectIds: string[]; revokeIds: string[] } {
-  const live = new Set(liveSlugs.filter(Boolean));
+  const live = new Set(liveSlugs.map(composioSlugKey).filter(Boolean));
   const connectIds: string[] = [];
   const connectedProviders = new Set(
-    rows.filter((row) => row.status === "connected").map((row) => row.provider),
+    rows.filter((row) => row.status === "connected").map((row) => composioSlugKey(row.provider)),
   );
   for (const slug of live) {
     if (connectedProviders.has(slug)) continue;
-    const matches = rows.filter((row) => row.provider === slug);
+    const matches = rows.filter((row) => composioSlugKey(row.provider) === slug);
     const reusable =
       matches.find((row) => row.status === "pending" || row.status === "error") ??
       matches.find((row) => row.status === "revoked") ??
@@ -196,7 +211,8 @@ export class ComposioConnector implements ComposioProvider {
   }
 
   async sessionForExecute(userId: string, toolkits: string[]): Promise<ComposioSession> {
-    const key = executeSessionKey(toolkits);
+    const canonicalToolkits = await this.canonicalizeToolkits(toolkits);
+    const key = executeSessionKey(canonicalToolkits);
     if (!key) return this.sessionFor(userId);
     const composio = this.sdk();
     const existing = this.executeSessions.get(userId);
@@ -210,7 +226,7 @@ export class ComposioConnector implements ComposioProvider {
     const session = await composio.create(userId, {
       manageConnections: false,
       sandbox: { enable: false },
-      toolkits: key.split(","),
+      toolkits: canonicalToolkits,
       sessionPreset: "direct_tools",
     });
     this.executeSessions.set(userId, { sessionId: session.sessionId, key });
@@ -229,6 +245,20 @@ export class ComposioConnector implements ComposioProvider {
 
   async warmDirectory(): Promise<void> {
     await this.directory();
+  }
+
+  private async canonicalizeToolkits(toolkits: string[]): Promise<string[]> {
+    const directory = await this.directory().catch(() => []);
+    const canonical = new Map(directory.map((item) => [composioSlugKey(item.slug), item.slug]));
+    const unique = new Map<string, string>();
+    for (const toolkit of toolkits) {
+      const trimmed = toolkit.trim();
+      const key = composioSlugKey(trimmed);
+      if (key && !unique.has(key)) {
+        unique.set(key, canonical.get(key) ?? trimmed.toUpperCase());
+      }
+    }
+    return [...unique.values()].sort();
   }
 
   private async directory(): Promise<ToolkitDirectoryEntry[]> {
@@ -317,7 +347,7 @@ export class ComposioConnector implements ComposioProvider {
   async connectionReady(context: AdapterContext, slug: string): Promise<boolean> {
     const session = await this.sessionFor(context.userId);
     const page = await session.toolkits({ search: slug, limit: 50 });
-    const match = page.items.find((item) => item.slug === slug);
+    const match = page.items.find((item) => composioSlugKey(item.slug) === composioSlugKey(slug));
     if (!match) return false;
     return Boolean(match.connection?.isActive) || Boolean(match.isNoAuth);
   }
@@ -337,7 +367,8 @@ export class ComposioConnector implements ComposioProvider {
   async connectedAccountId(userId: string, slug: string): Promise<string | undefined> {
     const session = await this.sessionFor(userId);
     const toolkits = await session.toolkits({ isConnected: true });
-    return toolkits.items.find((item) => item.slug === slug)?.connection?.connectedAccount?.id;
+    return toolkits.items.find((item) => composioSlugKey(item.slug) === composioSlugKey(slug))
+      ?.connection?.connectedAccount?.id;
   }
 
   private sdk(): Composio {


### PR DESCRIPTION
## Summary

- canonicalize stored Composio toolkit slugs against the toolkit directory before creating direct-tool sessions
- reconcile toolkit and account comparisons case-insensitively across catalog, readiness, and connection lookup paths
- retain Composio's uppercase slug convention if the directory is temporarily unavailable
- add regression coverage for lowercase authenticated GitHub rows and directory failure

## Tests

- `corepack pnpm exec vitest run packages/adapters/src/composio-connector.test.ts packages/adapters/src/composio-catalog-cache.test.ts packages/adapters/src/composio-emulator.test.ts` (26 passed)
- `corepack pnpm exec vitest run apps/api/src/router.test.ts` (11 passed)
- `corepack pnpm --filter @rakazo/adapters check`
- `corepack pnpm --filter @rakazo/api check`
- `corepack pnpm exec biome check packages/adapters/src/composio-connector.ts packages/adapters/src/composio-connector.test.ts`

## Notes

Tests are deterministic and offline; no live Composio credentials were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recognition for toolkit identifiers regardless of capitalization or extra whitespace.
  * Standardized toolkit names when creating and executing sessions, reducing duplicate or mismatched connections.
  * Preserved canonical toolkit naming when available, with reliable fallback handling when directory data is unavailable.
  * Improved synchronization and connected-account resolution for differently formatted toolkit identifiers.
  * Added coverage for case-insensitive matching, canonical naming, and directory fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->