### PR TITLE
fix(computer): route Docker browsers through Rakazo wrapper

### DIFF
--- a/infra/sandboxes/computer/Dockerfile
+++ b/infra/sandboxes/computer/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     fonts-dejavu-core \
     dbus-x11 \
+    xdg-utils \
   && rm -rf /var/lib/apt/lists/* \
   && groupadd --gid 1000 rakazo \
   && useradd --uid 1000 --gid rakazo --create-home --shell /bin/bash rakazo \
@@ -49,6 +50,7 @@ COPY --chmod=755 start.sh /usr/local/bin/rakazo-computer
 COPY --chmod=755 control.py /usr/local/bin/rakazo-computer-control
 COPY --from=capture-builder /build/librakazo-xcapture.so /usr/local/lib/librakazo-xcapture.so
 COPY --chmod=755 rakazo-browser /usr/local/bin/rakazo-browser
+COPY --chmod=644 rakazo-browser.desktop /usr/share/applications/rakazo-browser.desktop
 COPY --chmod=644 fluxbox.init /etc/rakazo/fluxbox/init
 COPY --chmod=644 fluxbox.apps /etc/rakazo/fluxbox/apps
 COPY --chmod=644 fluxbox.menu /etc/rakazo/fluxbox/menu

--- a/infra/sandboxes/computer/control.py
+++ b/infra/sandboxes/computer/control.py
@@ -18,11 +18,6 @@ MAX_ARGV = 32
 MAX_ARG_LEN = 16_384
 KNOWN_LAUNCH = frozenset(
     {
-        "chromium",
-        "chromium-browser",
-        "firefox",
-        "google-chrome",
-        "google-chrome-stable",
         "rakazo-browser",
         "xterm",
     }

--- a/infra/sandboxes/computer/rakazo-browser
+++ b/infra/sandboxes/computer/rakazo-browser
@@ -1,23 +1,24 @@
 #!/bin/sh
 set -eu
 RAKAZO_HOME="${HOME:-/home/rakazo}"
-PROFILE="$RAKAZO_HOME/.browser-profiles/chromium"
+case "${DISPLAY:-:1}" in
+  :[2-9]|:[1-9][0-9]*) PROFILE="$RAKAZO_HOME/.browser-profiles/chromium-screen-${DISPLAY#:}" ;;
+  *) PROFILE="$RAKAZO_HOME/.browser-profiles/chromium" ;;
+esac
 mkdir -p "$PROFILE"
 BIN="$(command -v chromium || command -v chromium-browser || true)"
 if [ -z "$BIN" ]; then
   echo "chromium is not installed" >&2
   exit 1
 fi
-exec "$BIN" \
-  --test-type \
-  --no-sandbox \
-  --disable-dev-shm-usage \
-  --disable-gpu \
-  --disable-software-rasterizer \
-  --no-first-run \
-  --no-default-browser-check \
-  --disable-session-crashed-bubble \
-  --password-store=basic \
-  --user-data-dir="$PROFILE" \
-  --start-maximized \
-  "$@"
+USER_DATA_DIR_SET=0
+for arg in "$@"; do
+  case "$arg" in
+    --user-data-dir|--user-data-dir=*) USER_DATA_DIR_SET=1 ;;
+  esac
+done
+FLAGS="--test-type --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer --no-first-run --no-default-browser-check --disable-session-crashed-bubble --password-store=basic --start-maximized"
+if [ "$USER_DATA_DIR_SET" -eq 0 ]; then
+  exec "$BIN" $FLAGS --user-data-dir="$PROFILE" "$@"
+fi
+exec "$BIN" $FLAGS "$@"

--- a/infra/sandboxes/computer/rakazo-browser.desktop
+++ b/infra/sandboxes/computer/rakazo-browser.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Rakazo Browser
+Comment=Chromium with Rakazo container flags and profile isolation
+Exec=/usr/local/bin/rakazo-browser %U
+Terminal=false
+Categories=Network;WebBrowser;
+MimeType=x-scheme-handler/http;x-scheme-handler/https;text/html;
+StartupNotify=false

--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -49,10 +49,22 @@ EOF
 chmod +x /tmp/fluxbox-home/.fluxbox/startup
 HOME=/tmp/fluxbox-home /tmp/fluxbox-home/.fluxbox/startup >/tmp/rakazo/fluxbox.log 2>&1 &
 
-xdg-mime default rakazo-browser.desktop x-scheme-handler/http >/dev/null 2>&1 || true
-xdg-mime default rakazo-browser.desktop x-scheme-handler/https >/dev/null 2>&1 || true
-xdg-mime default rakazo-browser.desktop text/html >/dev/null 2>&1 || true
-xdg-settings set default-web-browser rakazo-browser.desktop >/dev/null 2>&1 || true
+register_browser_handler() {
+  local mime="$1"
+  if ! xdg-mime default rakazo-browser.desktop "$mime" >/dev/null 2>&1 \
+    || [[ "$(xdg-mime query default "$mime" 2>/dev/null || true)" != "rakazo-browser.desktop" ]]; then
+    echo "failed to register rakazo-browser for $mime" >&2
+    exit 1
+  fi
+}
+register_browser_handler x-scheme-handler/http
+register_browser_handler x-scheme-handler/https
+register_browser_handler text/html
+if ! xdg-settings set default-web-browser rakazo-browser.desktop >/dev/null 2>&1 \
+  || [[ "$(xdg-settings get default-web-browser 2>/dev/null || true)" != "rakazo-browser.desktop" ]]; then
+  echo "failed to set default web browser to rakazo-browser" >&2
+  exit 1
+fi
 
 rm -f "$AGENT_HOME/.browser-profiles/chromium/SingletonLock" \
   "$AGENT_HOME/.browser-profiles/chromium/SingletonCookie" \

--- a/infra/sandboxes/computer/start.sh
+++ b/infra/sandboxes/computer/start.sh
@@ -49,6 +49,11 @@ EOF
 chmod +x /tmp/fluxbox-home/.fluxbox/startup
 HOME=/tmp/fluxbox-home /tmp/fluxbox-home/.fluxbox/startup >/tmp/rakazo/fluxbox.log 2>&1 &
 
+xdg-mime default rakazo-browser.desktop x-scheme-handler/http >/dev/null 2>&1 || true
+xdg-mime default rakazo-browser.desktop x-scheme-handler/https >/dev/null 2>&1 || true
+xdg-mime default rakazo-browser.desktop text/html >/dev/null 2>&1 || true
+xdg-settings set default-web-browser rakazo-browser.desktop >/dev/null 2>&1 || true
+
 rm -f "$AGENT_HOME/.browser-profiles/chromium/SingletonLock" \
   "$AGENT_HOME/.browser-profiles/chromium/SingletonCookie" \
   "$AGENT_HOME/.browser-profiles/chromium/SingletonSocket"

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -131,9 +131,7 @@ describe("graphical computer spec", () => {
     expect(start).toMatch(/failed to register rakazo-browser/);
     expect(start).toMatch(/failed to set default web browser/);
     expect(start).toMatch(/xdg-settings set default-web-browser rakazo-browser\.desktop/);
-    expect(start).not.toMatch(
-      /xdg-mime default rakazo-browser\.desktop .*\|\| true/,
-    );
+    expect(start).not.toMatch(/xdg-mime default rakazo-browser\.desktop .*\|\| true/);
     expect(start).toMatch(/x11vnc .* -viewonly /);
     expect(browser).toMatch(/\.browser-profiles\/chromium/);
     expect(browser).toMatch(/chromium-screen-\$\{DISPLAY/);

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -123,9 +123,17 @@ describe("graphical computer spec", () => {
     expect(start).toMatch(/rakazo-computer-control/);
     expect(start).toMatch(/rakazo-browser/);
     expect(start).toMatch(/SingletonLock/);
-    expect(start).toMatch(/xdg-mime default rakazo-browser\.desktop x-scheme-handler\/http/);
-    expect(start).toMatch(/xdg-mime default rakazo-browser\.desktop x-scheme-handler\/https/);
-    expect(start).toMatch(/xdg-mime default rakazo-browser\.desktop text\/html/);
+    expect(start).toMatch(/xdg-mime default rakazo-browser\.desktop/);
+    expect(start).toMatch(/register_browser_handler x-scheme-handler\/http/);
+    expect(start).toMatch(/register_browser_handler x-scheme-handler\/https/);
+    expect(start).toMatch(/register_browser_handler text\/html/);
+    expect(start).toMatch(/xdg-mime query default/);
+    expect(start).toMatch(/failed to register rakazo-browser/);
+    expect(start).toMatch(/failed to set default web browser/);
+    expect(start).toMatch(/xdg-settings set default-web-browser rakazo-browser\.desktop/);
+    expect(start).not.toMatch(
+      /xdg-mime default rakazo-browser\.desktop .*\|\| true/,
+    );
     expect(start).toMatch(/x11vnc .* -viewonly /);
     expect(browser).toMatch(/\.browser-profiles\/chromium/);
     expect(browser).toMatch(/chromium-screen-\$\{DISPLAY/);

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -114,16 +115,68 @@ describe("graphical computer spec", () => {
     const dockerfile = readFileSync(path.join(root, "Dockerfile"), "utf8");
     const start = readFileSync(path.join(root, "start.sh"), "utf8");
     const browser = readFileSync(path.join(root, "rakazo-browser"), "utf8");
+    const desktop = readFileSync(path.join(root, "rakazo-browser.desktop"), "utf8");
     expect(dockerfile).toMatch(/chromium/);
+    expect(dockerfile).toMatch(/rakazo-browser\.desktop/);
     expect(dockerfile).toMatch(/control.py/);
     expect(dockerfile).toMatch(/USER 1000:1000/);
     expect(start).toMatch(/rakazo-computer-control/);
     expect(start).toMatch(/rakazo-browser/);
     expect(start).toMatch(/SingletonLock/);
+    expect(start).toMatch(/xdg-mime default rakazo-browser\.desktop x-scheme-handler\/http/);
+    expect(start).toMatch(/xdg-mime default rakazo-browser\.desktop x-scheme-handler\/https/);
+    expect(start).toMatch(/xdg-mime default rakazo-browser\.desktop text\/html/);
     expect(start).toMatch(/x11vnc .* -viewonly /);
     expect(browser).toMatch(/\.browser-profiles\/chromium/);
+    expect(browser).toMatch(/chromium-screen-\$\{DISPLAY/);
+    expect(browser).toMatch(/USER_DATA_DIR_SET/);
+    expect(desktop).toMatch(/Exec=\/usr\/local\/bin\/rakazo-browser %U/);
+    expect(desktop).toMatch(/x-scheme-handler\/http/);
+    expect(desktop).toMatch(/x-scheme-handler\/https/);
     expect(start).not.toMatch(/windowsize 1280 800/);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "selects a display-specific browser profile and preserves explicit profiles",
+    () => {
+      const root = path.resolve(import.meta.dirname, "../../computer");
+      const temp = mkdtempSync(path.join(tmpdir(), "rakazo-browser-wrapper-"));
+      const bin = path.join(temp, "bin");
+      const capture = path.join(temp, "args");
+      const home = path.join(temp, "home");
+      const chromium = path.join(bin, "chromium");
+      mkdirSync(bin);
+      writeFileSync(chromium, '#!/bin/sh\nprintf "%s\\n" "$@" > "$RAKAZO_TEST_ARGS"\n');
+      chmodSync(chromium, 0o755);
+
+      const run = (display: string, args: string[] = []) => {
+        const result = spawnSync("bash", [path.join(root, "rakazo-browser"), ...args], {
+          env: {
+            ...process.env,
+            DISPLAY: display,
+            HOME: home,
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+            RAKAZO_TEST_ARGS: capture,
+          },
+          encoding: "utf8",
+        });
+        expect(result.status, result.error?.message ?? result.stderr).toBe(0);
+        return readFileSync(capture, "utf8").trim().split(/\r?\n/);
+      };
+
+      try {
+        expect(run(":1")).toContain(`--user-data-dir=${home}/.browser-profiles/chromium`);
+        expect(run(":2")).toContain(`--user-data-dir=${home}/.browser-profiles/chromium-screen-2`);
+        const explicit = run(":3", [`--user-data-dir=${home}/custom-profile`]);
+        expect(explicit).toContain(`--user-data-dir=${home}/custom-profile`);
+        expect(explicit).not.toContain(
+          `--user-data-dir=${home}/.browser-profiles/chromium-screen-3`,
+        );
+      } finally {
+        rmSync(temp, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("keeps container names stable so a bot can resume", () => {
     expect(containerNameFor("bot_1")).toBe("rakazo-bot-bot_1");
@@ -262,8 +315,10 @@ describe("graphical computer spec", () => {
           "assert allow(['env', 'DISPLAY=:1', 'xdotool', 'click', '--repeat', '3', '4'], ':1')",
           "assert allow(['env', 'DISPLAY=:1', 'xdotool', 'type', '--clearmodifiers', '--', 'hi'], ':1')",
           "assert allow(['env', 'DISPLAY=:2', 'xdg-open', 'https://example.com'], ':2')",
-          "assert allow(['env', 'DISPLAY=:1', 'chromium', 'https://example.com'], ':1')",
           "assert allow(['env', 'DISPLAY=:1', 'rakazo-browser'], ':1')",
+          "assert allow(['env', 'DISPLAY=:2', 'rakazo-browser', 'https://example.com'], ':2')",
+          "assert allow(['env', 'DISPLAY=:1', 'xterm'], ':1')",
+          "assert not allow(['env', 'DISPLAY=:1', 'chromium', 'https://example.com'], ':1')",
           "assert not allow(['bash', '-c', 'id'], ':1')",
           "assert not allow(['env', 'DISPLAY=:1', 'bash', '-c', 'id'], ':1')",
           "assert not allow(['env', 'DISPLAY=:1', '/bin/sh', '-c', 'id'], ':1')",

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -12,6 +12,8 @@ import {
   completeReleasedScreen,
   computerControlTimeoutMs,
   containerActionStep,
+  containerActionSteps,
+  DOCKER_BROWSER_ALIASES,
   demuxDockerStream,
   ensureScreenCommand,
   hasValidBearerToken,
@@ -201,6 +203,29 @@ describe("sandbox supervisor input containment", () => {
     expect(containerActionStep({ kind: "scroll", direction: "up", amount: 99 })).toEqual({
       argv: ["env", "DISPLAY=:1", "xdotool", "click", "--repeat", "20", "4"],
     });
+  });
+
+  it("routes Docker browser aliases through the safe wrapper on every display", () => {
+    for (const application of DOCKER_BROWSER_ALIASES) {
+      expect(
+        containerActionStep({ kind: "launch", application, uri: "https://example.com" }, ":2"),
+      ).toEqual({
+        argv: ["env", "DISPLAY=:2", "rakazo-browser", "https://example.com"],
+      });
+    }
+    expect(containerActionStep({ kind: "launch", application: "xterm" }, ":3")).toEqual({
+      argv: ["env", "DISPLAY=:3", "xterm"],
+    });
+    expect(containerActionStep({ kind: "open", path: "https://example.com" }, ":3")).toEqual({
+      argv: ["env", "DISPLAY=:3", "xdg-open", "https://example.com"],
+    });
+  });
+
+  it("keeps browser routing argv identical for control and Docker exec fallback", () => {
+    const action = { kind: "launch" as const, application: "chromium", uri: "https://example.com" };
+    expect(containerActionSteps([action], ":2")).toEqual([
+      { argv: ["env", "DISPLAY=:2", "rakazo-browser", "https://example.com"] },
+    ]);
   });
 
   it("falls back to docker-exec when computer control fails", async () => {

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -221,6 +221,19 @@ describe("sandbox supervisor input containment", () => {
     });
   });
 
+  it("routes mixed-case Docker browser aliases through the safe wrapper", () => {
+    for (const application of ["Chrome", "Firefox", "Chromium", "Google-Chrome"]) {
+      expect(
+        containerActionStep({ kind: "launch", application, uri: "https://example.com" }, ":2"),
+      ).toEqual({
+        argv: ["env", "DISPLAY=:2", "rakazo-browser", "https://example.com"],
+      });
+    }
+    expect(containerActionStep({ kind: "launch", application: "XTerm" }, ":3")).toEqual({
+      argv: ["env", "DISPLAY=:3", "XTerm"],
+    });
+  });
+
   it("keeps browser routing argv identical for control and Docker exec fallback", () => {
     const action = { kind: "launch" as const, application: "chromium", uri: "https://example.com" };
     expect(containerActionSteps([action], ":2")).toEqual([

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -38,7 +38,7 @@ import {
   completeReleasedScreen,
   computerActionSchema,
   computerControlTimeoutMs,
-  containerActionStep,
+  containerActionSteps,
   demuxDockerStream,
   ensureScreenCommand,
   hasValidBearerToken,
@@ -624,6 +624,7 @@ async function ensureComputerImage() {
             "control.py",
             "xcapture.c",
             "rakazo-browser",
+            "rakazo-browser.desktop",
             "embed.html",
             "clipboard-bridge.js",
             "fluxbox.init",
@@ -736,7 +737,7 @@ async function controlDesktop(
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        steps: actions.map((action) => containerActionStep(action, display)),
+        steps: containerActionSteps(actions, display),
         display,
         observe,
         settleMs,
@@ -1038,7 +1039,7 @@ async function applyContainerActions(
     "python3",
     "-c",
     script,
-    JSON.stringify(actions.map((action) => containerActionStep(action, display))),
+    JSON.stringify(containerActionSteps(actions, display)),
   ]);
   if (result.code !== 0) throw new Error(result.stderr || "computer action failed");
 }

--- a/infra/sandboxes/supervisor/src/supervisor-logic.ts
+++ b/infra/sandboxes/supervisor/src/supervisor-logic.ts
@@ -311,7 +311,7 @@ export function containerActionStep(
       : workspaceTarget(normalizeWorkspaceRelative(action.path));
     argv = ["env", `DISPLAY=${display}`, "xdg-open", target];
   } else {
-    const application = DOCKER_BROWSER_ALIASES.has(action.application)
+    const application = DOCKER_BROWSER_ALIASES.has(action.application.toLowerCase())
       ? "rakazo-browser"
       : action.application;
     argv = ["env", `DISPLAY=${display}`, application, ...(action.uri ? [action.uri] : [])];

--- a/infra/sandboxes/supervisor/src/supervisor-logic.ts
+++ b/infra/sandboxes/supervisor/src/supervisor-logic.ts
@@ -29,6 +29,17 @@ export const computerActionSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("launch"), application: z.string(), uri: z.string().optional() }),
 ]);
 
+export const DOCKER_BROWSER_ALIASES = new Set([
+  "browser",
+  "chrome",
+  "chromium",
+  "chromium-browser",
+  "firefox",
+  "google-chrome",
+  "google-chrome-stable",
+  "rakazo-browser",
+]);
+
 export function assertRequestIdentity(
   botId: string | undefined,
   workspaceId: string | undefined,
@@ -300,9 +311,19 @@ export function containerActionStep(
       : workspaceTarget(normalizeWorkspaceRelative(action.path));
     argv = ["env", `DISPLAY=${display}`, "xdg-open", target];
   } else {
-    argv = ["env", `DISPLAY=${display}`, action.application, ...(action.uri ? [action.uri] : [])];
+    const application = DOCKER_BROWSER_ALIASES.has(action.application)
+      ? "rakazo-browser"
+      : action.application;
+    argv = ["env", `DISPLAY=${display}`, application, ...(action.uri ? [action.uri] : [])];
   }
   return { argv };
+}
+
+export function containerActionSteps(
+  actions: Array<z.infer<typeof computerActionSchema>>,
+  display = ":1",
+) {
+  return actions.map((action) => containerActionStep(action, display));
 }
 
 export function normalizeWorkspaceRelative(value: string) {


### PR DESCRIPTION
Fixes #375

Docker browser actions could bypass `rakazo-browser` in two ways: `xdg-open` resolved to Chromium's desktop handler, and `launch_app` accepted browser aliases that executed the raw binaries directly. In the container that drops the required browser flags and profile handling.

Register `rakazo-browser` as the Docker image's HTTP/HTTPS/HTML XDG handler and canonicalize browser launch aliases through the same wrapper for both the computer-control path and Docker-exec fallback.

The wrapper also selects the existing per-display Chromium profile for Team Computer screens while preserving an explicit `--user-data-dir`. Non-browser launches such as `xterm` are unchanged.

Verification:
- focused tests: 82 passed, 1 skipped on Windows
- supervisor typecheck passed
- changed-path Biome check passed
- shell/Python syntax checks passed
- `git diff --check` passed
- `pnpm check` passed

Full `pnpm test` and repository-wide lint still hit pre-existing Windows/environment failures. A Docker image build was attempted, but Docker Desktop was not running in the local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rakazo Browser as the default handler for web links and HTML files.
  * Added isolated browser profiles for different displays.
  * Browser launch aliases now route through the supported Rakazo Browser launcher.

* **Bug Fixes**
  * Prevented direct launches of unsupported browsers.
  * Preserved explicitly provided browser profile settings.
  * Startup now reports errors if default browser registration fails.

* **Tests**
  * Added coverage for browser routing, profile isolation, default handlers, and batch actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->