### PR TITLE
Fix Playwright report publication for growing screenshot suites

### DIFF
--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -11,13 +11,12 @@ import {
   renderScreenshotGallery,
   shouldPublishStableMainBaseline,
   updatePlaywrightHistory,
+  validatePlaywrightScreenshotBudget,
 } from "../playwright-report-dashboard.js";
 import { MAX_PNG_SCREENSHOT_BYTES, validatePngScreenshot } from "../png-validation.js";
 
 const [historyPath, dashboardPath, testResultsPath, galleryPath, baselineManifestPath] =
   process.argv.slice(2);
-const MAX_SCREENSHOT_COUNT = 250;
-const MAX_TOTAL_SCREENSHOT_BYTES = 250 * 1024 * 1024;
 const MAX_ARTIFACT_ENTRIES = 2_000;
 const MAX_ARTIFACT_DEPTH = 12;
 
@@ -108,11 +107,7 @@ async function collectScreenshots(
   const files = (await findPngFiles(resultsPath))
     .filter((file) => classifyPlaywrightScreenshot(file) !== undefined)
     .sort((left, right) => path.basename(left).localeCompare(path.basename(right)));
-  if (files.length > MAX_SCREENSHOT_COUNT) {
-    throw new Error(
-      `Playwright artifact contains ${files.length} screenshots; maximum is ${MAX_SCREENSHOT_COUNT}`,
-    );
-  }
+  validatePlaywrightScreenshotBudget(files.length, 0);
   const imagePath = path.join(outputPath, "images");
   await mkdir(imagePath, { recursive: true });
 
@@ -124,11 +119,7 @@ async function collectScreenshots(
       throw new Error(`Invalid screenshot size for ${file}`);
     }
     totalScreenshotBytes += info.size;
-    if (totalScreenshotBytes > MAX_TOTAL_SCREENSHOT_BYTES) {
-      throw new Error(
-        `Playwright screenshots exceed maximum total size of ${MAX_TOTAL_SCREENSHOT_BYTES} bytes`,
-      );
-    }
+    validatePlaywrightScreenshotBudget(files.length, totalScreenshotBytes);
     const screenshot = await readFile(file);
     validatePngScreenshot(screenshot, file);
     const captureType = classifyPlaywrightScreenshot(file);

--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -16,7 +16,8 @@ import { MAX_PNG_SCREENSHOT_BYTES, validatePngScreenshot } from "../png-validati
 
 const [historyPath, dashboardPath, testResultsPath, galleryPath, baselineManifestPath] =
   process.argv.slice(2);
-const MAX_SCREENSHOT_COUNT = 100;
+const MAX_SCREENSHOT_COUNT = 250;
+const MAX_TOTAL_SCREENSHOT_BYTES = 250 * 1024 * 1024;
 const MAX_ARTIFACT_ENTRIES = 2_000;
 const MAX_ARTIFACT_DEPTH = 12;
 
@@ -116,10 +117,17 @@ async function collectScreenshots(
   await mkdir(imagePath, { recursive: true });
 
   const screenshots: Array<Omit<PlaywrightScreenshot, "comparison">> = [];
+  let totalScreenshotBytes = 0;
   for (const [index, file] of files.entries()) {
     const info = await stat(file);
     if (!info.isFile() || info.size <= 0 || info.size > MAX_PNG_SCREENSHOT_BYTES) {
       throw new Error(`Invalid screenshot size for ${file}`);
+    }
+    totalScreenshotBytes += info.size;
+    if (totalScreenshotBytes > MAX_TOTAL_SCREENSHOT_BYTES) {
+      throw new Error(
+        `Playwright screenshots exceed maximum total size of ${MAX_TOTAL_SCREENSHOT_BYTES} bytes`,
+      );
     }
     const screenshot = await readFile(file);
     validatePngScreenshot(screenshot, file);

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -3,13 +3,36 @@ import {
   classifyPlaywrightScreenshot,
   compareScreenshotsWithBaseline,
   createScreenshotManifest,
+  MAX_PLAYWRIGHT_SCREENSHOT_BYTES,
+  MAX_PLAYWRIGHT_SCREENSHOT_COUNT,
   type PlaywrightRun,
   type PlaywrightScreenshot,
   renderPlaywrightDashboard,
   renderScreenshotGallery,
   shouldPublishStableMainBaseline,
   updatePlaywrightHistory,
+  validatePlaywrightScreenshotBudget,
 } from "./playwright-report-dashboard.js";
+
+describe("validatePlaywrightScreenshotBudget", () => {
+  it("accepts the exact screenshot count and aggregate byte limits", () => {
+    expect(() =>
+      validatePlaywrightScreenshotBudget(
+        MAX_PLAYWRIGHT_SCREENSHOT_COUNT,
+        MAX_PLAYWRIGHT_SCREENSHOT_BYTES,
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects the first screenshot and byte beyond their limits", () => {
+    expect(() =>
+      validatePlaywrightScreenshotBudget(MAX_PLAYWRIGHT_SCREENSHOT_COUNT + 1, 0),
+    ).toThrow(/251 screenshots; maximum is 250/);
+    expect(() =>
+      validatePlaywrightScreenshotBudget(1, MAX_PLAYWRIGHT_SCREENSHOT_BYTES + 1),
+    ).toThrow(/maximum total size of 262144000 bytes/);
+  });
+});
 
 describe("classifyPlaywrightScreenshot", () => {
   it("excludes automatic successful-test captures from visual review", () => {

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -1,4 +1,6 @@
 const MAX_HISTORY_LENGTH = 100;
+export const MAX_PLAYWRIGHT_SCREENSHOT_COUNT = 250;
+export const MAX_PLAYWRIGHT_SCREENSHOT_BYTES = 250 * 1024 * 1024;
 const SHARED_PAGE_STYLES = `
     :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #09090b; color: #fafafa; }
     * { box-sizing: border-box; }
@@ -46,6 +48,19 @@ export type PlaywrightScreenshotManifest = {
 };
 
 export type PlaywrightScreenshotMetadata = Omit<PlaywrightScreenshot, "comparison" | "fileName">;
+
+export function validatePlaywrightScreenshotBudget(count: number, totalBytes: number): void {
+  if (count > MAX_PLAYWRIGHT_SCREENSHOT_COUNT) {
+    throw new Error(
+      `Playwright artifact contains ${count} screenshots; maximum is ${MAX_PLAYWRIGHT_SCREENSHOT_COUNT}`,
+    );
+  }
+  if (totalBytes > MAX_PLAYWRIGHT_SCREENSHOT_BYTES) {
+    throw new Error(
+      `Playwright screenshots exceed maximum total size of ${MAX_PLAYWRIGHT_SCREENSHOT_BYTES} bytes`,
+    );
+  }
+}
 
 export function classifyPlaywrightScreenshot(
   fileName: string,


### PR DESCRIPTION
## Summary
- raise the trusted Playwright gallery limit from 100 to 250 screenshots
- cap the aggregate screenshot payload at 250 MiB while retaining per-file validation
- centralize and regression-test the exact count and byte boundaries
- unblock the repeated report-publication failures caused by the current 102-screen suite

## Verification
- generated a dashboard from the exact artifact in Actions run 33256407170: 102 screenshots
- `pnpm --filter @rakazo/testkit check`
- `pnpm exec vitest run packages/testkit/src/playwright-report-dashboard.test.ts packages/testkit/src/png-validation.test.ts` (24 tests)
- `pnpm exec biome check packages/testkit/src/cli/generate-playwright-report-dashboard.ts packages/testkit/src/playwright-report-dashboard.ts packages/testkit/src/playwright-report-dashboard.test.ts`
- `git diff --check`

## CI and review
- all PR checks passed, including Web E2E and Postgres journeys
- Greptile re-review: 5/5, safe to merge
- CodeRabbit: no actionable comments