### PR TITLE
Simplify the published-image quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ https://github.com/user-attachments/assets/dccdeddb-2134-4a56-8eed-b2e591736b1c
 You need Docker Engine, the Compose plugin, curl, and OpenSSL. No clone or Node install.
 
 ```bash
-mkdir rakazo && cd rakazo
-curl -fsSLO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/install-images.sh
+mkdir -p rakazo && cd rakazo &&
+curl -fsSLO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/install-images.sh &&
 bash install-images.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,29 +41,16 @@ https://github.com/user-attachments/assets/dccdeddb-2134-4a56-8eed-b2e591736b1c
 
 ## Quick start (published images)
 
-You need Docker Engine and the Compose plugin. No clone or Node install.
+You need Docker Engine, the Compose plugin, curl, and OpenSSL. No clone or Node install.
 
 ```bash
-mkdir rakazo && cd rakazo &&
-curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/docker-compose.images.yml &&
-curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/.env.images.example &&
-cp .env.images.example .env &&
-POSTGRES_PASSWORD=$(openssl rand -hex 16) &&
-BETTER_AUTH_SECRET=$(openssl rand -hex 32) &&
-ENCRYPTION_KEY=$(openssl rand -hex 32) &&
-SCREEN_PROXY_SECRET=$(openssl rand -hex 32) &&
-SANDBOX_SUPERVISOR_TOKEN=$(openssl rand -hex 32) &&
-: "${POSTGRES_PASSWORD:?}" "${BETTER_AUTH_SECRET:?}" "${ENCRYPTION_KEY:?}" "${SCREEN_PROXY_SECRET:?}" "${SANDBOX_SUPERVISOR_TOKEN:?}" &&
-sed -i.bak \
-  -e "s/^POSTGRES_PASSWORD=$/POSTGRES_PASSWORD=${POSTGRES_PASSWORD}/" \
-  -e "s/^BETTER_AUTH_SECRET=$/BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}/" \
-  -e "s/^ENCRYPTION_KEY=$/ENCRYPTION_KEY=${ENCRYPTION_KEY}/" \
-  -e "s/^SCREEN_PROXY_SECRET=$/SCREEN_PROXY_SECRET=${SCREEN_PROXY_SECRET}/" \
-  -e "s/^SANDBOX_SUPERVISOR_TOKEN=$/SANDBOX_SUPERVISOR_TOKEN=${SANDBOX_SUPERVISOR_TOKEN}/" \
-  .env && rm -f .env.bak &&
-docker compose --env-file .env -f docker-compose.images.yml pull &&
-docker compose --env-file .env -f docker-compose.images.yml up -d
+mkdir rakazo && cd rakazo
+curl -fsSLO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/install-images.sh
+bash install-images.sh
 ```
+
+The installer downloads the Compose files, creates `.env` with random secrets, and starts Rakazo.
+It preserves an existing `.env` when rerun.
 
 Open [http://127.0.0.1:5173](http://127.0.0.1:5173), create an account, and connect a model.
 Local Docker computers are on by default. Optional remote providers: `e2b`, `daytona`, or `box`

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -37,14 +37,14 @@ Preflight:
 Setup:
 
 1. Create the directory if needed and enter it.
-2. Download only these two files (do not clone the repository):
-   - https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/docker-compose.images.yml
-   - https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/.env.images.example
-3. If `.env` does not exist, copy `.env.images.example` to `.env`. Generate secrets with openssl into shell variables (including `SANDBOX_SUPERVISOR_TOKEN`), abort if any are empty (`: "${VAR:?}"`), then write them into `.env` with portable `sed -i.bak` (see comments in the example file). Keep `SANDBOX_PROVIDER=docker` unless I chose a remote computer provider. Add only the model key I selected.
-4. Run:
-   `docker compose --env-file .env -f docker-compose.images.yml pull`
-   `docker compose --env-file .env -f docker-compose.images.yml up -d`
-5. Wait until api, web, and supervisor are healthy. Default image tag is `edge` (amd64). Do not pin `latest` unless that tag exists in GHCR.
+2. Download and inspect this installer (do not clone the repository):
+   https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/install-images.sh
+3. Run `bash install-images.sh --prepare-only`. It downloads the Compose and environment example
+   files, then creates `.env` with all required random secrets when one does not already exist.
+4. Preserve existing values. Keep `SANDBOX_PROVIDER=docker` unless I chose a remote computer
+   provider, and add only the provider or model keys I selected.
+5. Run `bash install-images.sh`. It preserves `.env`, pulls the images, and starts the stack.
+6. Wait until api, web, and supervisor are healthy. Default image tag is `edge` (amd64). Do not pin `latest` unless that tag exists in GHCR.
 
 Verification:
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -12,8 +12,8 @@ Pull Postgres and `ghcr.io/elie222/rakazo/app` into any empty folder. No clone o
 Requires Docker Engine, the Compose plugin, curl, and OpenSSL.
 
 ```bash
-mkdir rakazo && cd rakazo
-curl -fsSLO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/install-images.sh
+mkdir -p rakazo && cd rakazo &&
+curl -fsSLO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/install-images.sh &&
 bash install-images.sh
 ```
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -9,32 +9,18 @@ Same as the README quick start: `.env` from `.env.example`, Postgres via Compose
 ## Published images (no checkout)
 
 Pull Postgres and `ghcr.io/elie222/rakazo/app` into any empty folder. No clone or image build.
-Requires Docker Engine and the Compose plugin.
+Requires Docker Engine, the Compose plugin, curl, and OpenSSL.
 
 ```bash
 mkdir rakazo && cd rakazo
-curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/docker-compose.images.yml
-curl -fsSO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/.env.images.example
-cp .env.images.example .env
+curl -fsSLO https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/install-images.sh
+bash install-images.sh
 ```
 
-Generate secrets and write them into `.env` (after `cp .env.images.example .env`):
-
-```bash
-POSTGRES_PASSWORD=$(openssl rand -hex 16) &&
-BETTER_AUTH_SECRET=$(openssl rand -hex 32) &&
-ENCRYPTION_KEY=$(openssl rand -hex 32) &&
-SCREEN_PROXY_SECRET=$(openssl rand -hex 32) &&
-SANDBOX_SUPERVISOR_TOKEN=$(openssl rand -hex 32) &&
-: "${POSTGRES_PASSWORD:?}" "${BETTER_AUTH_SECRET:?}" "${ENCRYPTION_KEY:?}" "${SCREEN_PROXY_SECRET:?}" "${SANDBOX_SUPERVISOR_TOKEN:?}" &&
-sed -i.bak \
-  -e "s/^POSTGRES_PASSWORD=$/POSTGRES_PASSWORD=${POSTGRES_PASSWORD}/" \
-  -e "s/^BETTER_AUTH_SECRET=$/BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}/" \
-  -e "s/^ENCRYPTION_KEY=$/ENCRYPTION_KEY=${ENCRYPTION_KEY}/" \
-  -e "s/^SCREEN_PROXY_SECRET=$/SCREEN_PROXY_SECRET=${SCREEN_PROXY_SECRET}/" \
-  -e "s/^SANDBOX_SUPERVISOR_TOKEN=$/SANDBOX_SUPERVISOR_TOKEN=${SANDBOX_SUPERVISOR_TOKEN}/" \
-  .env && rm -f .env.bak
-```
+The installer downloads `docker-compose.images.yml` and `.env.images.example`, creates `.env` with
+random secrets, then pulls and starts the images. It preserves an existing `.env` when rerun. To
+customize the public URL, image tag, or optional providers before startup, run
+`bash install-images.sh --prepare-only`, edit `.env`, then run `bash install-images.sh`.
 
 `SANDBOX_PROVIDER` defaults to `docker`. The images Compose file runs a sandbox supervisor
 (from the app image, on the internal network only) and pulls `ghcr.io/elie222/rakazo/computer`.
@@ -49,11 +35,6 @@ The example defaults to `edge` (main builds, `linux/amd64` only). On arm64 hosts
 when one exists (see [Published images and tags](#published-images-and-tags)). Changing only
 `RAKAZO_IMAGE_TAG` leaves the computer service on amd64-only `edge`. Do not assume `latest` is
 published.
-
-```bash
-docker compose --env-file .env -f docker-compose.images.yml pull
-docker compose --env-file .env -f docker-compose.images.yml up -d
-```
 
 Open [http://127.0.0.1:5173](http://127.0.0.1:5173). The first registered user becomes the
 deployment owner. Put TLS in front of `:5173` for a public host and set the three public origins to

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -1,18 +1,5 @@
 # Copy to .env next to docker-compose.images.yml.
-# Generate secrets (URL-safe password; 64 hex for ENCRYPTION_KEY). After copying to .env:
-#   POSTGRES_PASSWORD=$(openssl rand -hex 16) &&
-#   BETTER_AUTH_SECRET=$(openssl rand -hex 32) &&
-#   ENCRYPTION_KEY=$(openssl rand -hex 32) &&
-#   SCREEN_PROXY_SECRET=$(openssl rand -hex 32) &&
-#   SANDBOX_SUPERVISOR_TOKEN=$(openssl rand -hex 32) &&
-#   : "${POSTGRES_PASSWORD:?}" "${BETTER_AUTH_SECRET:?}" "${ENCRYPTION_KEY:?}" "${SCREEN_PROXY_SECRET:?}" "${SANDBOX_SUPERVISOR_TOKEN:?}" &&
-#   sed -i.bak \
-#     -e "s/^POSTGRES_PASSWORD=$/POSTGRES_PASSWORD=${POSTGRES_PASSWORD}/" \
-#     -e "s/^BETTER_AUTH_SECRET=$/BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}/" \
-#     -e "s/^ENCRYPTION_KEY=$/ENCRYPTION_KEY=${ENCRYPTION_KEY}/" \
-#     -e "s/^SCREEN_PROXY_SECRET=$/SCREEN_PROXY_SECRET=${SCREEN_PROXY_SECRET}/" \
-#     -e "s/^SANDBOX_SUPERVISOR_TOKEN=$/SANDBOX_SUPERVISOR_TOKEN=${SANDBOX_SUPERVISOR_TOKEN}/" \
-#     .env && rm -f .env.bak
+# install-images.sh creates that file and fills the required secrets automatically.
 
 POSTGRES_USER=rakazo
 POSTGRES_PASSWORD=

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -79,7 +79,7 @@ create_env() {
 }
 
 validate_required_secrets() {
-  if ! docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" config --environment | awk '
+  if ! docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" -f - config --environment <<'YAML' | awk '
     BEGIN {
       required["POSTGRES_PASSWORD"] = 1
       required["BETTER_AUTH_SECRET"] = 1
@@ -91,18 +91,29 @@ validate_required_secrets() {
       name = $0
       sub(/=.*/, "", name)
       if (!(name in required)) next
+      seen[name]++
 
       value = $0
       sub(/^[^=]*=/, "", value)
       gsub(/[[:space:]]/, "", value)
-      if (value != "") present[name] = 1
+      if (value != "") nonempty[name]++
     }
     END {
       for (name in required) {
-        if (!(name in present)) exit 1
+        if (seen[name] != 1 || nonempty[name] != 1) exit 1
       }
     }
-  '; then
+  '
+services:
+  api:
+    environment:
+      _RAKAZO_VALIDATE_POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      _RAKAZO_VALIDATE_BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in .env}
+      _RAKAZO_VALIDATE_ENCRYPTION_KEY: ${ENCRYPTION_KEY:?Set ENCRYPTION_KEY in .env}
+      _RAKAZO_VALIDATE_SCREEN_PROXY_SECRET: ${SCREEN_PROXY_SECRET:?Set SCREEN_PROXY_SECRET in .env}
+      _RAKAZO_VALIDATE_SANDBOX_SUPERVISOR_TOKEN: ${SANDBOX_SUPERVISOR_TOKEN:?Set SANDBOX_SUPERVISOR_TOKEN in .env}
+YAML
+  then
     fail "set every required secret in .env to a non-empty value."
   fi
 }

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly DOWNLOAD_BASE="https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose"
+readonly COMPOSE_FILE="docker-compose.images.yml"
+readonly ENV_EXAMPLE=".env.images.example"
+readonly ENV_FILE=".env"
+
+prepare_only=false
+if [[ "${1:-}" == "--prepare-only" && $# -eq 1 ]]; then
+  prepare_only=true
+elif [[ $# -ne 0 ]]; then
+  echo "Usage: bash install-images.sh [--prepare-only]" >&2
+  exit 2
+fi
+
+temporary_file=""
+cleanup() {
+  if [[ -n "$temporary_file" ]]; then
+    rm -f -- "$temporary_file"
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  echo "Rakazo setup failed: $*" >&2
+  exit 1
+}
+
+for command_name in curl docker openssl; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "'$command_name' is required."
+done
+
+docker compose version >/dev/null 2>&1 || fail "the Docker Compose plugin is required."
+
+download() {
+  local filename="$1"
+
+  temporary_file=$(mktemp "./${filename}.tmp.XXXXXX")
+  if ! curl -fsSL "${DOWNLOAD_BASE}/${filename}" -o "$temporary_file"; then
+    fail "could not download ${filename}."
+  fi
+  mv -- "$temporary_file" "$filename"
+  temporary_file=""
+}
+
+create_env() {
+  umask 077
+  temporary_file=$(mktemp "./${ENV_FILE}.tmp.XXXXXX")
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      "POSTGRES_PASSWORD=")
+        printf 'POSTGRES_PASSWORD=%s\n' "$(openssl rand -hex 16)"
+        ;;
+      "BETTER_AUTH_SECRET=")
+        printf 'BETTER_AUTH_SECRET=%s\n' "$(openssl rand -hex 32)"
+        ;;
+      "ENCRYPTION_KEY=")
+        printf 'ENCRYPTION_KEY=%s\n' "$(openssl rand -hex 32)"
+        ;;
+      "SCREEN_PROXY_SECRET=")
+        printf 'SCREEN_PROXY_SECRET=%s\n' "$(openssl rand -hex 32)"
+        ;;
+      "SANDBOX_SUPERVISOR_TOKEN=")
+        printf 'SANDBOX_SUPERVISOR_TOKEN=%s\n' "$(openssl rand -hex 32)"
+        ;;
+      *)
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done < "$ENV_EXAMPLE" > "$temporary_file"
+
+  chmod 600 "$temporary_file"
+  mv -- "$temporary_file" "$ENV_FILE"
+  temporary_file=""
+  echo "Created .env with random secrets."
+}
+
+require_env_value() {
+  local name="$1"
+  grep -Eq "^${name}=.+$" "$ENV_FILE" || fail "set ${name} in .env."
+}
+
+download "$COMPOSE_FILE"
+download "$ENV_EXAMPLE"
+
+if [[ -e "$ENV_FILE" ]]; then
+  echo "Keeping existing .env."
+else
+  create_env
+fi
+
+for secret_name in \
+  POSTGRES_PASSWORD \
+  BETTER_AUTH_SECRET \
+  ENCRYPTION_KEY \
+  SCREEN_PROXY_SECRET \
+  SANDBOX_SUPERVISOR_TOKEN; do
+  require_env_value "$secret_name"
+done
+
+if [[ "$prepare_only" == true ]]; then
+  echo "Rakazo files are ready. Edit .env, then run: bash install-images.sh"
+  exit 0
+fi
+
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
+
+echo "Rakazo is starting at http://127.0.0.1:5173"

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -78,9 +78,33 @@ create_env() {
   echo "Created .env with random secrets."
 }
 
-require_env_value() {
-  local name="$1"
-  grep -Eq "^${name}=.+$" "$ENV_FILE" || fail "set ${name} in .env."
+validate_required_secrets() {
+  if ! docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" config --environment | awk '
+    BEGIN {
+      required["POSTGRES_PASSWORD"] = 1
+      required["BETTER_AUTH_SECRET"] = 1
+      required["ENCRYPTION_KEY"] = 1
+      required["SCREEN_PROXY_SECRET"] = 1
+      required["SANDBOX_SUPERVISOR_TOKEN"] = 1
+    }
+    {
+      name = $0
+      sub(/=.*/, "", name)
+      if (!(name in required)) next
+
+      value = $0
+      sub(/^[^=]*=/, "", value)
+      gsub(/[[:space:]]/, "", value)
+      if (value != "") present[name] = 1
+    }
+    END {
+      for (name in required) {
+        if (!(name in present)) exit 1
+      }
+    }
+  '; then
+    fail "set every required secret in .env to a non-empty value."
+  fi
 }
 
 download "$COMPOSE_FILE"
@@ -92,14 +116,7 @@ else
   create_env
 fi
 
-for secret_name in \
-  POSTGRES_PASSWORD \
-  BETTER_AUTH_SECRET \
-  ENCRYPTION_KEY \
-  SCREEN_PROXY_SECRET \
-  SANDBOX_SUPERVISOR_TOKEN; do
-  require_env_value "$secret_name"
-done
+validate_required_secrets
 
 if [[ "$prepare_only" == true ]]; then
   echo "Rakazo files are ready. Edit .env, then run: bash install-images.sh"


### PR DESCRIPTION
Replaces the README shell wall with a three-command published-image install.

Adds a reusable installer that securely creates `.env`, preserves existing configuration, supports prepare-only customization, and starts Compose. Updates the self-hosting guide, environment example, and agent setup prompt to use the same path.

Validation: `bash -n`, isolated installer behavior checks, `git diff --check`, and a public-diff secret scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a streamlined installer for setting up Rakazo from published container images.
  - Automatically downloads configuration, generates missing secrets, pulls images, and starts the application.
  - Supports preparation-only mode for reviewing or customizing settings before startup.
  - Preserves existing environment configuration when rerun.

- **Documentation**
  - Updated setup instructions and prerequisites to include Docker, Compose, curl, and OpenSSL.
  - Replaced manual configuration and secret-generation steps with the installer workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->