### PR TITLE
fix(adapters): avoid Composio tool preload limit

### DIFF
--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -1,3 +1,4 @@
+import console from "node:console";
 import type { AdapterContext, ConnectorEvent, ConnectorTool } from "@rakazo/adapter-kit";
 import { describe, expect, it, vi } from "vitest";
 import { composioToolkitDirectory } from "./composio-catalog-cache.js";
@@ -167,6 +168,33 @@ describe("composio tool mapping", () => {
     expect(events).toEqual([{ type: "result", data: { provider: "composio" } }]);
   });
 
+  it("logs sanitized connector discovery failures", async () => {
+    const destination = new DestinationEmulator();
+    const failing = {
+      describe: () => ({ ...destination.describe(), id: "failing" }),
+      discoverTools: async () => {
+        throw new Error("denied ak_secretvaluehere");
+      },
+      execute: async function* () {},
+    } as never;
+    const connector = new CompositeConnector(destination, [failing]);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      await expect(connector.discoverTools({ userId: "u" } as AdapterContext)).resolves.toEqual([
+        expect.objectContaining({ name: "destination.write" }),
+      ]);
+      expect(error).toHaveBeenCalledWith(
+        "connector discovery failed",
+        "failing",
+        expect.stringContaining("[redacted]"),
+      );
+      expect(error.mock.calls.flat().join(" ")).not.toContain("ak_secretvaluehere");
+    } finally {
+      error.mockRestore();
+    }
+  });
+
   it("redacts project keys from errors", () => {
     expect(sanitizeComposioError("denied ak_secretvaluehere")).toContain("[redacted]");
     expect(sanitizeComposioError("denied ak_secretvaluehere")).not.toContain("ak_secret");
@@ -213,7 +241,7 @@ describe("composio tool mapping", () => {
     expect(executeSessionKey([])).toBe("");
   });
 
-  it("uses catalog-canonical toolkit slugs for direct-tool sessions", async () => {
+  it("uses catalog-canonical toolkit slugs without preloading every tool", async () => {
     composioSdkState.created.length = 0;
     composioSdkState.executions.length = 0;
     composioSdkState.sessions.clear();
@@ -247,7 +275,7 @@ describe("composio tool mapping", () => {
       })),
     ).toEqual([
       { userId: "__rakazo_catalog__", toolkits: undefined, sessionPreset: undefined },
-      { userId: "user-1", toolkits: ["GITHUB"], sessionPreset: "direct_tools" },
+      { userId: "user-1", toolkits: ["GITHUB"], sessionPreset: undefined },
     ]);
 
     const events: ConnectorEvent[] = [];

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -1,3 +1,4 @@
+import console from "node:console";
 import { Composio } from "@composio/core";
 import type {
   AdapterContext,
@@ -227,7 +228,6 @@ export class ComposioConnector implements ComposioProvider {
       manageConnections: false,
       sandbox: { enable: false },
       toolkits: canonicalToolkits,
-      sessionPreset: "direct_tools",
     });
     this.executeSessions.set(userId, { sessionId: session.sessionId, key });
     return session;
@@ -417,7 +417,8 @@ export class ConnectorRegistry implements ConnectorProvider {
       [...this.providers].map(async ([connectorId, provider]) => {
         try {
           return [connectorId, await provider.discoverTools(context)] as const;
-        } catch {
+        } catch (error) {
+          console.error("connector discovery failed", connectorId, sanitizeComposioError(error));
           return [connectorId, []] as const;
         }
       }),


### PR DESCRIPTION
## Summary

- stop creating Composio `direct_tools` sessions that preload every action from every connected toolkit
- retain toolkit scoping while using ToolRouter's default search/execute tools
- log sanitized connector discovery failures instead of silently returning an empty catalog

Closes #382

## Testing

- `pnpm check` (20/20 package checks passed)
- `pnpm lint` (648 files passed)
- `pnpm exec vitest run packages/adapters/src/composio-connector.test.ts` (20 passed)
- `pnpm --filter @rakazo/adapters test` (695 passed, 6 skipped, 1 unrelated failure in `desktop-sandbox-write-containment.test.ts`; reproduced on the baseline checkout)

## Risk

Bots now receive Composio's bounded search/execute meta-tools instead of every connected action as a direct tool. Toolkit filtering and session reuse remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connector discovery failures are now reported in logs with sensitive information redacted.
  * Improved session execution behavior by removing an unnecessary session configuration option.
  * Updated automated coverage to verify safe error logging and the revised session configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->