### PR TITLE
fix(web): notify for bot messages

### DIFF
--- a/apps/web/src/lib/browser-notifications.test.ts
+++ b/apps/web/src/lib/browser-notifications.test.ts
@@ -3,7 +3,7 @@ import {
   type BrowserNotificationApi,
   type BrowserNotificationContext,
   browserNotificationMessage,
-  deliverBrowserRunNotification,
+  deliverBrowserNotification,
   requestBrowserNotificationPermission,
   shouldNotifyBrowser,
 } from "./browser-notifications.js";
@@ -11,17 +11,26 @@ import { i18n } from "./i18n.js";
 
 function event(
   overrides: Partial<{
-    type: "run.completed" | "run.failed" | "run.cancelled" | "run.started";
+    type:
+      | "thread.message.created"
+      | "run.completed"
+      | "run.failed"
+      | "run.cancelled"
+      | "run.started";
     threadId: string;
+    id: string;
     runId: string;
     seq: number;
+    payload: Record<string, unknown>;
   }> = {},
 ) {
   return {
-    type: "run.completed" as const,
+    type: "thread.message.created" as const,
+    id: "event-1",
     threadId: "thread-1",
     runId: "run-1",
     seq: 8,
+    payload: { role: "bot", blocks: [{ kind: "text", text: "The pool is balanced." }] },
     ...overrides,
   };
 }
@@ -34,12 +43,12 @@ function context(overrides: Partial<BrowserNotificationContext> = {}): BrowserNo
     pageVisible: false,
     windowFocused: false,
     permission: "granted",
-    notifiedRunIds: new Set(),
+    notifiedEventIds: new Set(),
     ...overrides,
   };
 }
 
-describe("browser run notifications", () => {
+describe("browser notifications", () => {
   beforeEach(() => {
     i18n.load("en", {
       "{name} failed": "Chief failed",
@@ -52,9 +61,15 @@ describe("browser run notifications", () => {
     i18n.activate("en");
   });
 
-  it("only accepts a new terminal event for the hidden or unfocused subscribed thread", () => {
+  it("only accepts a new bot message for the hidden or unfocused subscribed thread", () => {
     expect(shouldNotifyBrowser(event(), context())).toBe(true);
     expect(shouldNotifyBrowser(event({ type: "run.started" }), context())).toBe(false);
+    expect(shouldNotifyBrowser(event({ type: "run.failed" }), context())).toBe(true);
+    expect(shouldNotifyBrowser(event({ type: "run.cancelled" }), context())).toBe(true);
+    expect(shouldNotifyBrowser(event({ payload: { role: "user", blocks: [] } }), context())).toBe(
+      false,
+    );
+    expect(shouldNotifyBrowser(event({ type: "run.completed" }), context())).toBe(false);
     expect(shouldNotifyBrowser(event({ threadId: "other-thread" }), context())).toBe(false);
     expect(shouldNotifyBrowser(event({ seq: 7 }), context())).toBe(false);
     expect(shouldNotifyBrowser(event(), context({ pageVisible: true, windowFocused: false }))).toBe(
@@ -68,15 +83,15 @@ describe("browser run notifications", () => {
       false,
     );
     expect(shouldNotifyBrowser(event(), context({ permission: "default" }))).toBe(false);
-    expect(shouldNotifyBrowser(event(), context({ notifiedRunIds: new Set(["run-1"]) }))).toBe(
+    expect(shouldNotifyBrowser(event(), context({ notifiedEventIds: new Set(["event-1"]) }))).toBe(
       false,
     );
   });
 
-  it("keeps terminal copy stable for the native Notification API", () => {
+  it("puts the bot message in the native notification", () => {
     expect(browserNotificationMessage(event(), "Chief")).toEqual({
-      title: "Chief finished",
-      body: "Finished.",
+      title: "Chief",
+      body: "The pool is balanced.",
     });
     expect(browserNotificationMessage(event({ type: "run.failed" }), "Chief")).toEqual({
       title: "Chief failed",
@@ -88,28 +103,29 @@ describe("browser run notifications", () => {
     });
   });
 
-  it("dedupes only after a notification is delivered", () => {
-    const notifiedRunIds = new Set<string>();
+  it("dedupes a replay but delivers another message from the same run", () => {
+    const notifiedEventIds = new Set<string>();
     const show = vi.fn().mockImplementationOnce(() => {
       throw new Error("notification construction failed");
     });
-    const delivery = (permission: "default" | "granted") =>
-      deliverBrowserRunNotification(event(), "Chief", {
+    const delivery = (permission: "default" | "granted", nextEvent = event()) =>
+      deliverBrowserNotification(nextEvent, "Chief", {
         enabled: true,
         pageVisible: false,
         windowFocused: false,
         permission,
-        notifiedRunIds,
+        notifiedEventIds,
         show,
       });
 
     expect(delivery("default")).toBe("pending");
     expect(delivery("granted")).toBe("pending");
-    expect(notifiedRunIds).toEqual(new Set());
+    expect(notifiedEventIds).toEqual(new Set());
     expect(delivery("granted")).toBe("delivered");
-    expect(notifiedRunIds).toEqual(new Set(["run-1"]));
+    expect(notifiedEventIds).toEqual(new Set(["event-1"]));
     expect(delivery("granted")).toBe("discarded");
-    expect(show).toHaveBeenCalledTimes(2);
+    expect(delivery("granted", event({ id: "event-2" }))).toBe("delivered");
+    expect(show).toHaveBeenCalledTimes(3);
   });
 
   it("allows a later send gesture to retry a dismissed permission prompt", async () => {

--- a/apps/web/src/lib/browser-notifications.ts
+++ b/apps/web/src/lib/browser-notifications.ts
@@ -1,5 +1,4 @@
 import type { ProductEvent } from "@rakazo/contracts";
-import { isRunTerminalEvent } from "@rakazo/core";
 import { i18n } from "./i18n";
 
 export type BrowserNotificationPermission = "default" | "denied" | "granted";
@@ -43,30 +42,46 @@ export type BrowserNotificationContext = {
   pageVisible: boolean;
   windowFocused: boolean;
   permission: BrowserNotificationPermission;
-  notifiedRunIds: ReadonlySet<string>;
+  notifiedEventIds: ReadonlySet<string>;
 };
 
 export function shouldNotifyBrowser(
-  event: Pick<ProductEvent, "type" | "threadId" | "runId" | "seq">,
+  event: Pick<ProductEvent, "id" | "type" | "threadId" | "seq" | "payload">,
   context: BrowserNotificationContext,
 ): boolean {
+  const notifiable =
+    (event.type === "thread.message.created" && event.payload.role === "bot") ||
+    event.type === "run.failed" ||
+    event.type === "run.cancelled";
   return (
     context.streamReady &&
-    isRunTerminalEvent(event) &&
+    notifiable &&
     event.threadId === context.subscribedThreadId &&
     event.seq > context.initialCursor &&
     (!context.pageVisible || !context.windowFocused) &&
     context.permission === "granted" &&
-    typeof event.runId === "string" &&
-    !context.notifiedRunIds.has(event.runId)
+    !context.notifiedEventIds.has(event.id)
   );
 }
 
 export function browserNotificationMessage(
-  event: Pick<ProductEvent, "type">,
+  event: Pick<ProductEvent, "type" | "payload">,
   botName: string,
 ): { title: string; body: string } {
   const name = botName.trim() || i18n._({ id: "Bot", message: "Bot" });
+  if (event.type === "thread.message.created") {
+    const blocks = Array.isArray(event.payload.blocks) ? event.payload.blocks : [];
+    const body = blocks
+      .map((block) =>
+        block && typeof block === "object" && "text" in block && typeof block.text === "string"
+          ? block.text
+          : "",
+      )
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+    return { title: name, body: body || i18n._({ id: "Message", message: "Message" }) };
+  }
   if (event.type === "run.failed") {
     return {
       title: i18n._({ id: "{name} failed", message: "{name} failed", values: { name } }),
@@ -85,24 +100,22 @@ export function browserNotificationMessage(
   };
 }
 
-export function deliverBrowserRunNotification(
-  event: Pick<ProductEvent, "type" | "runId">,
+export function deliverBrowserNotification(
+  event: Pick<ProductEvent, "id" | "type" | "payload">,
   botName: string,
   context: {
     enabled: boolean;
     pageVisible: boolean;
     windowFocused: boolean;
     permission: BrowserNotificationPermission;
-    notifiedRunIds: Set<string>;
+    notifiedEventIds: Set<string>;
     show: (title: string, body: string) => void;
   },
 ): "delivered" | "pending" | "discarded" {
-  const runId = event.runId;
   if (
-    typeof runId !== "string" ||
     !context.enabled ||
     (context.pageVisible && context.windowFocused) ||
-    context.notifiedRunIds.has(runId) ||
+    context.notifiedEventIds.has(event.id) ||
     context.permission === "denied"
   ) {
     return "discarded";
@@ -111,7 +124,7 @@ export function deliverBrowserRunNotification(
   const message = browserNotificationMessage(event, botName);
   try {
     context.show(message.title, message.body);
-    context.notifiedRunIds.add(runId);
+    context.notifiedEventIds.add(event.id);
     return "delivered";
   } catch {
     return "pending";

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -122,7 +122,7 @@ import { type ArtifactTarget, decodeArtifactBase64 } from "../lib/artifact-open"
 import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
 import {
-  deliverBrowserRunNotification,
+  deliverBrowserNotification as deliverNativeBrowserNotification,
   requestBrowserNotificationPermission,
   shouldNotifyBrowser,
 } from "../lib/browser-notifications";
@@ -220,7 +220,7 @@ type PendingAttachment = {
 };
 
 type PendingBrowserNotification = {
-  event: Pick<ProductEvent, "type" | "runId" | "botId">;
+  event: Pick<ProductEvent, "id" | "type" | "botId" | "payload">;
   botId: string;
   botName: string;
 };
@@ -434,7 +434,7 @@ export function ShellPage() {
   } | null>(null);
   const manuallyUnread = useRef(new Set<string>());
   const readVisibleGroups = useRef(new Set<string>());
-  const notifiedBrowserRuns = useRef(new Set<string>());
+  const notifiedBrowserEvents = useRef(new Set<string>());
   const pendingBrowserNotifications = useRef(new Map<string, PendingBrowserNotification>());
   const computerVisible = useRef(false);
   computerVisible.current = panel === "computer" || computerOpen;
@@ -508,11 +508,9 @@ export function ShellPage() {
     [markBotRead],
   );
   const deliverBrowserNotification = useCallback((pending: PendingBrowserNotification): boolean => {
-    const runId = pending.event.runId;
-    if (typeof runId !== "string") return true;
     const currentBot = botsRef.current.find((bot) => bot.id === pending.botId);
     if (!currentBot || typeof Notification === "undefined") return true;
-    const result = deliverBrowserRunNotification(
+    const result = deliverNativeBrowserNotification(
       pending.event,
       currentBot.name || pending.botName,
       {
@@ -520,30 +518,29 @@ export function ShellPage() {
         pageVisible: document.visibilityState === "visible",
         windowFocused: document.hasFocus(),
         permission: Notification.permission,
-        notifiedRunIds: notifiedBrowserRuns.current,
+        notifiedEventIds: notifiedBrowserEvents.current,
         show: (title, body) => new Notification(title, { body }),
       },
     );
     return result !== "pending";
   }, []);
   const flushPendingBrowserNotifications = useCallback(() => {
-    for (const [runId, pending] of pendingBrowserNotifications.current) {
+    for (const [eventId, pending] of pendingBrowserNotifications.current) {
       if (deliverBrowserNotification(pending)) {
-        pendingBrowserNotifications.current.delete(runId);
+        pendingBrowserNotifications.current.delete(eventId);
       }
     }
   }, [deliverBrowserNotification]);
-  const notifyBrowserForTerminalEvent = useCallback(
+  const notifyBrowserForEvent = useCallback(
     (
-      event: Pick<ProductEvent, "type" | "threadId" | "runId" | "seq" | "botId">,
+      event: Pick<ProductEvent, "id" | "type" | "threadId" | "seq" | "botId" | "payload">,
       subscribedThreadId: string | undefined,
       initialCursor: number,
       streamReady: boolean,
       botName: string,
     ) => {
-      const runId = event.runId;
       const botId = event.botId;
-      if (typeof runId !== "string" || typeof botId !== "string") return;
+      if (typeof botId !== "string") return;
       const eligible = shouldNotifyBrowser(event, {
         subscribedThreadId: subscribedThreadId ?? "",
         initialCursor,
@@ -551,19 +548,19 @@ export function ShellPage() {
         pageVisible: document.visibilityState === "visible",
         windowFocused: document.hasFocus(),
         permission: "granted",
-        notifiedRunIds: notifiedBrowserRuns.current,
+        notifiedEventIds: notifiedBrowserEvents.current,
       });
       if (!eligible || !botsRef.current.find((bot) => bot.id === botId)?.notifyOnFinish) return;
       const pending = { event, botId, botName } satisfies PendingBrowserNotification;
       if (typeof Notification === "undefined" || Notification.permission === "denied") return;
       if (Notification.permission === "default") {
-        pendingBrowserNotifications.current.set(runId, pending);
+        pendingBrowserNotifications.current.set(event.id, pending);
         return;
       }
       if (deliverBrowserNotification(pending)) {
-        pendingBrowserNotifications.current.delete(runId);
+        pendingBrowserNotifications.current.delete(event.id);
       } else {
-        pendingBrowserNotifications.current.set(runId, pending);
+        pendingBrowserNotifications.current.set(event.id, pending);
       }
     },
     [deliverBrowserNotification],
@@ -1054,7 +1051,7 @@ export function ShellPage() {
               pendingSnapshotEvents.push(event);
             }
             const currentBot = botsRef.current.find((bot) => bot.id === active.id);
-            notifyBrowserForTerminalEvent(
+            notifyBrowserForEvent(
               event,
               subscribedThreadId,
               initialCursor,
@@ -1107,7 +1104,7 @@ export function ShellPage() {
     return () => {
       abort.abort();
     };
-  }, [active?.id, markBotReadIfVisible, notifyBrowserForTerminalEvent]);
+  }, [active?.id, markBotReadIfVisible, notifyBrowserForEvent]);
 
   useEffect(() => {
     if (!groupId || !activeGroup) return;
@@ -1217,7 +1214,7 @@ export function ShellPage() {
               pendingSnapshotEvents.push(event);
             }
             const eventBot = botsRef.current.find((bot) => bot.id === event.botId);
-            notifyBrowserForTerminalEvent(
+            notifyBrowserForEvent(
               event,
               subscribedThreadId,
               initialCursor,
@@ -1250,7 +1247,7 @@ export function ShellPage() {
       document.removeEventListener("visibilitychange", markVisibleGroupRead);
       abort.abort();
     };
-  }, [activeGroup?.id, groupId, notifyBrowserForTerminalEvent]);
+  }, [activeGroup?.id, groupId, notifyBrowserForEvent]);
 
   const filtered = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- trigger native notifications from durable bot message events instead of run completion
- include the bot message text in the notification body
- dedupe replayed events while allowing multiple messages from one run
- retain failure and cancellation alerts

## Verification
- `corepack pnpm --filter @rakazo/web test` (23 files, 146 tests)
- `corepack pnpm --filter @rakazo/web check`
- `corepack pnpm --filter @rakazo/web build`
- `corepack pnpm exec biome check apps/web/src/lib/browser-notifications.ts apps/web/src/lib/browser-notifications.test.ts apps/web/src/pages/Shell.tsx`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser notifications now include the content of eligible bot messages.
  * Separate messages from the same conversation can each generate notifications.
  * Notifications continue to support run failures and cancellations with appropriate messaging.

* **Bug Fixes**
  * Prevented duplicate notifications and notifications for incomplete or ineligible events.
  * Failed notification attempts can be retried instead of being incorrectly marked as delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->