### PR TITLE
Fix delegated reply surfacing

### DIFF
--- a/packages/adapters/src/bot-messages.test.ts
+++ b/packages/adapters/src/bot-messages.test.ts
@@ -276,6 +276,34 @@ describe("messaging another bot", () => {
     );
   });
 
+  it("does not inherit a request reply link for an FYI to the requester", async () => {
+    const harness = deps({
+      hopBlocks: [
+        {
+          kind: "bot_message_received",
+          fromBotId: "bot-target",
+          fromBotName: "Analyst",
+          text: "check Gmail",
+          hop: 1,
+          intent: "request",
+          returnToMessageId: "message-request",
+        },
+      ],
+    });
+
+    await messageBot(harness.deps, { ...run, sourceMessageId: "message-source" }, sender, {
+      bot_id: "bot-target",
+      message: "unrelated update",
+      intent: "fyi",
+    });
+
+    expect(harness.tx.message.create).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ replyToMessageId: undefined }),
+      }),
+    );
+  });
+
   it("does not exempt a terminal reply to another terminal reply", async () => {
     const harness = deps({
       hopBlocks: [

--- a/packages/adapters/src/bot-messages.test.ts
+++ b/packages/adapters/src/bot-messages.test.ts
@@ -244,6 +244,38 @@ describe("messaging another bot", () => {
     );
   });
 
+  it("does not inherit a request reply link when messaging another bot", async () => {
+    const harness = deps({
+      bots: [
+        { id: "bot-target", name: "Analyst", title: "", thread: { id: "thread-target" } },
+        { id: "bot-other", name: "Writer", title: "", thread: { id: "thread-other" } },
+      ],
+      hopBlocks: [
+        {
+          kind: "bot_message_received",
+          fromBotId: "bot-target",
+          fromBotName: "Analyst",
+          text: "check Gmail",
+          hop: 1,
+          intent: "request",
+          returnToMessageId: "message-request",
+        },
+      ],
+    });
+
+    await messageBot(harness.deps, { ...run, sourceMessageId: "message-source" }, sender, {
+      bot_id: "bot-other",
+      message: "unrelated update",
+      intent: "fyi",
+    });
+
+    expect(harness.tx.message.create).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ replyToMessageId: undefined }),
+      }),
+    );
+  });
+
   it("does not exempt a terminal reply to another terminal reply", async () => {
     const harness = deps({
       hopBlocks: [

--- a/packages/adapters/src/bot-messages.test.ts
+++ b/packages/adapters/src/bot-messages.test.ts
@@ -367,10 +367,24 @@ describe("hop lookup", () => {
               intent: "fyi",
             },
           ],
+          replyTo: {
+            blocks: [
+              {
+                kind: "bot_message_sent",
+                toBotId: "b",
+                toBotName: "B",
+                text: "check Gmail",
+                intent: "request",
+              },
+            ],
+          },
         }),
       },
     } as unknown as PrismaClient;
-    expect(await loadBotMessageContext(prisma, "message-old")).toMatchObject({ intent: "fyi" });
+    expect(await loadBotMessageContext(prisma, "message-old")).toMatchObject({
+      intent: "fyi",
+      repliesToRequest: true,
+    });
     expect(prisma.message.findUnique).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "message-old" } }),
     );

--- a/packages/adapters/src/bot-messages.ts
+++ b/packages/adapters/src/bot-messages.ts
@@ -225,7 +225,9 @@ export async function messageBot(
           role: "user",
           blocks: [inboundBlock],
           replyToMessageId:
-            sourceContext?.fromBotId === target.id ? sourceContext.returnToMessageId : undefined,
+            sourceContext?.fromBotId === target.id && intent !== "fyi"
+              ? sourceContext.returnToMessageId
+              : undefined,
           clientNonce: deliveryKey,
           markUnread: true,
         });

--- a/packages/adapters/src/bot-messages.ts
+++ b/packages/adapters/src/bot-messages.ts
@@ -224,7 +224,8 @@ export async function messageBot(
           threadId: targetThreadId,
           role: "user",
           blocks: [inboundBlock],
-          replyToMessageId: sourceContext?.returnToMessageId,
+          replyToMessageId:
+            sourceContext?.fromBotId === target.id ? sourceContext.returnToMessageId : undefined,
           clientNonce: deliveryKey,
           markUnread: true,
         });

--- a/packages/adapters/src/bot-messages.ts
+++ b/packages/adapters/src/bot-messages.ts
@@ -41,9 +41,21 @@ export async function loadBotMessageContext(
   if (!sourceMessageId) return undefined;
   const source = await prisma.message.findUnique({
     where: { id: sourceMessageId },
-    select: { blocks: true },
+    select: { blocks: true, replyTo: { select: { blocks: true } } },
   });
-  return botMessageContext(Array.isArray(source?.blocks) ? (source.blocks as MessageBlock[]) : []);
+  const context = botMessageContext(
+    Array.isArray(source?.blocks) ? (source.blocks as MessageBlock[]) : [],
+  );
+  if (!context) return undefined;
+  const replyBlocks = Array.isArray(source?.replyTo?.blocks)
+    ? (source.replyTo.blocks as MessageBlock[])
+    : [];
+  const repliesToRequest = replyBlocks.some(
+    (block) =>
+      block.kind === "bot_message_sent" &&
+      (block.intent === undefined || block.intent === "request" || block.intent === "question"),
+  );
+  return { ...context, repliesToRequest };
 }
 
 export async function messageBot(

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -839,11 +839,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
           })),
           run.sourceMessageId,
         );
-        const allowSilentPeerMessage = botMessageAllowsSilence(peerMessage?.intent);
+        const allowSilentPeerMessage = botMessageAllowsSilence(
+          peerMessage?.intent,
+          peerMessage?.repliesToRequest,
+        );
         const emptyResponseText = peerMessage
           ? peerMessage.intent === "result" ||
             peerMessage.intent === "status" ||
-            peerMessage.intent === "question"
+            peerMessage.intent === "question" ||
+            peerMessage.repliesToRequest
             ? `Update from ${peerMessage.fromBotName}: ${peerMessage.text}`
             : "The delegated bot completed its turn without a written summary."
           : undefined;

--- a/packages/core/src/bot-messages.test.ts
+++ b/packages/core/src/bot-messages.test.ts
@@ -4,6 +4,7 @@ import {
   BOT_DIRECTORY_DESCRIPTIONS_MAX_LENGTH,
   BOT_MESSAGE_MAX_HOPS,
   BOT_MESSAGE_MAX_LENGTH,
+  botMessageAllowsSilence,
   botMessageHopExhausted,
   buildBotMessageWakePrompt,
   clampBotMessage,
@@ -28,6 +29,13 @@ describe("bot message text", () => {
     const clamped = clampBotMessage("x".repeat(BOT_MESSAGE_MAX_LENGTH + 500));
     expect(clamped).toHaveLength(BOT_MESSAGE_MAX_LENGTH);
     expect(clamped.endsWith("…")).toBe(true);
+  });
+});
+
+describe("bot message silence", () => {
+  it("surfaces an FYI when it replies to a delegated request", () => {
+    expect(botMessageAllowsSilence("fyi", true)).toBe(false);
+    expect(botMessageAllowsSilence("fyi")).toBe(true);
   });
 });
 

--- a/packages/core/src/bot-messages.ts
+++ b/packages/core/src/bot-messages.ts
@@ -45,8 +45,11 @@ export function botMessageContext(blocks: readonly MessageBlock[]): BotMessageCo
   return blocks.find((block): block is BotMessageContext => block.kind === "bot_message_received");
 }
 
-export function botMessageAllowsSilence(intent: BotMessageIntent | undefined): boolean {
-  return intent === "fyi";
+export function botMessageAllowsSilence(
+  intent: BotMessageIntent | undefined,
+  repliesToRequest = false,
+): boolean {
+  return intent === "fyi" && !repliesToRequest;
 }
 
 /** Resolve a target by id first, then by exact name, then case-insensitively. */


### PR DESCRIPTION
## Summary

- treat the durable reply link as authoritative when a peer mislabels a requested answer as FYI
- keep unsolicited FYIs eligible for silence
- use the peer reply itself as the fallback when the coordinator emits no text

## Diagnosis

The silence policy trusted the sending model's `intent: fyi` label without checking whether the message replied to an earlier request. That let a valid delegated answer complete with no user-visible text.

## Testing

- 95 focused delegated-message tests
- Core and Adapters TypeScript checks
- Biome on all changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of delegated bot-message replies.
  * Messages replying to requests now produce an appropriate response instead of being treated as optional FYI updates.
  * Empty-response fallback behavior is applied consistently when a bot message answers a request.
  * Prevented FYI messages from inheriting unrelated reply links, including when exchanged between different bots.
  * Improved recognition of request replies when the relationship is indicated through the original message’s reply details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->