### PR TITLE
fix(web): stack peer messages on mobile

### DIFF
--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -172,8 +172,8 @@ export function PeerMessagesOverlay({
             </Trans>
           </div>
         ) : (
-          <div className="mt-5 flex min-h-0 flex-1 gap-4 px-6 pb-6 sm:px-8 sm:pb-7">
-            <div className="w-[240px] shrink-0 overflow-y-auto">
+          <div className="mt-5 flex min-h-0 flex-1 flex-col gap-4 px-6 pb-6 sm:flex-row sm:px-8 sm:pb-7">
+            <div className="max-h-40 w-full shrink-0 overflow-y-auto sm:max-h-none sm:w-[240px]">
               {conversations.map((conversation) => {
                 const active = conversation.peerBotId === selected?.peerBotId;
                 return (


### PR DESCRIPTION
## Summary
- stack the peer list above message details below the `sm` breakpoint
- cap the mobile list height so message content keeps the remaining space
- preserve the existing desktop split layout

## Verification
- `corepack pnpm exec biome check apps/web/src/pages/PeerMessagesOverlay.tsx`
- `corepack pnpm --filter @rakazo/web check`
- `corepack pnpm --filter @rakazo/web build`
- production CSS rendered at 390x844: 308px list/detail width, 482px detail height, no horizontal overflow
- production CSS rendered at 1280x800: 240px list and 558px detail split

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the peer-conversation overlay layout for smaller screens.
  * Conversation lists now scroll vertically when content exceeds the available height.
  * Updated larger-screen layouts to display the conversation list alongside messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->