### PR TITLE
fix(desktop): make conversation header draggable

### DIFF
--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -59,6 +59,16 @@ describe("window chrome", () => {
     expect(shell).not.toContain("FF5F57");
     expect(welcome).not.toContain("FF5F57");
   });
+
+  it("makes the conversation header draggable without swallowing its controls", () => {
+    const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "../pages");
+    const shell = readFileSync(path.join(root, "Shell.tsx"), "utf8");
+    expect(shell).toContain(
+      'className="app-drag flex items-center justify-between border-b border-[#141416]',
+    );
+    expect(shell).toContain('className="app-no-drag flex min-w-0 items-center gap-3"');
+    expect(shell.match(/className="app-no-drag grid h-\[30px\] w-\[34px\]/g)).toHaveLength(2);
+  });
 });
 
 describe("captured OAuth callbacks", () => {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2536,13 +2536,13 @@ export function ShellPage() {
       </aside>
 
       <main className="flex min-w-0 flex-1 flex-col bg-[#0D0D0E]">
-        <div className="flex items-center justify-between border-b border-[#141416] px-3 py-[17px] md:px-[22px]">
+        <div className="app-drag flex items-center justify-between border-b border-[#141416] px-3 py-[17px] md:px-[22px]">
           <div className="flex min-w-0 items-center gap-2">
             <button
               type="button"
               aria-label={t`Open navigation`}
               onClick={() => setMobileSidebarOpen(true)}
-              className="grid h-8 w-8 shrink-0 place-items-center rounded-lg text-[#A8A8AD] hover:bg-[#1B1B1E] md:hidden"
+              className="app-no-drag grid h-8 w-8 shrink-0 place-items-center rounded-lg text-[#A8A8AD] hover:bg-[#1B1B1E] md:hidden"
             >
               <Menu size={19} strokeWidth={1.7} />
             </button>
@@ -2550,7 +2550,7 @@ export function ShellPage() {
               type="button"
               data-testid="bot-settings-trigger"
               onClick={() => setPanel(inGroup ? "group-settings" : "settings")}
-              className="flex min-w-0 items-center gap-3"
+              className="app-no-drag flex min-w-0 items-center gap-3"
             >
               {inGroup ? (
                 <GroupAvatar
@@ -2587,7 +2587,7 @@ export function ShellPage() {
                   }
                   setCallOpen(true);
                 }}
-                className="grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-[#1B1B1E]"
+                className="app-no-drag grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-[#1B1B1E]"
                 style={{ background: callOpen ? "#1B1B1E" : "transparent" }}
               >
                 <Phone size={16} strokeWidth={1.6} className="text-[#A8A8AD]" />
@@ -2605,7 +2605,7 @@ export function ShellPage() {
                     void refreshThread(active.id).catch(() => undefined);
                   }
                 }}
-                className="grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-[#1B1B1E]"
+                className="app-no-drag grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-[#1B1B1E]"
                 style={{ background: panel ? "#1B1B1E" : "transparent" }}
               >
                 <Monitor size={18} strokeWidth={1.6} className="text-[#A8A8AD]" />


### PR DESCRIPTION
## Summary
- make the blank conversation header area an Electron drag region
- keep navigation, bot settings, call, and computer controls clickable
- add focused regression coverage for the drag/no-drag boundary

## Verification
- `pnpm exec vitest run apps/web/src/lib/desktop.test.ts`
- `pnpm --filter @rakazo/web test` (147 passed)
- `pnpm --filter @rakazo/desktop test` (106 passed)
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/desktop check`
- `pnpm --filter @rakazo/web build`
- `pnpm exec biome check apps/web/src/pages/Shell.tsx apps/web/src/lib/desktop.test.ts`

## Residual verification
- isolated Electron gesture smoke was attempted, but the downloaded Electron process terminated before a live drag gesture could be exercised; the Electron CSS boundary is covered by source-level regression tests and the production build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved desktop window dragging by making the conversation header draggable.
  * Preserved interaction with navigation, settings, calling, and computer controls while dragging the window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->