### PR TITLE
fix(adapters): expose schedule tools in group chats

### DIFF
--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -10,6 +10,8 @@ describe("createRunExecutor", () => {
     const cancel = vi.fn(async () => undefined);
     const append = vi.fn(async () => undefined);
     const updateMany = vi.fn(async () => ({ count: 1 }));
+    const taskCreate = vi.fn(async () => ({ id: "task-1" }));
+    const runCreate = vi.fn(async () => ({ id: "run-1" }));
     const prisma = {
       routine: {
         findUnique: vi.fn(async () => ({
@@ -22,6 +24,7 @@ describe("createRunExecutor", () => {
           timezone: "UTC",
           active: true,
           nextRunAt: scheduledAt,
+          threadId: "group-thread-1",
         })),
       },
       bot: {
@@ -30,14 +33,17 @@ describe("createRunExecutor", () => {
           thread: { id: "thread-1" },
         })),
       },
+      thread: {
+        findFirst: vi.fn(async () => ({ id: "group-thread-1" })),
+      },
       agentSkill: {
         findMany: vi.fn(async () => []),
       },
       $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
         callback({
           routine: { updateMany },
-          task: { create: vi.fn(async () => ({ id: "task-1" })) },
-          run: { create: vi.fn(async () => ({ id: "run-1" })) },
+          task: { create: taskCreate },
+          run: { create: runCreate },
         }),
       ),
     } as unknown as PrismaClient;
@@ -57,8 +63,18 @@ describe("createRunExecutor", () => {
     expect(cancel).toHaveBeenCalledWith("routine:routine-1");
     expect(enqueue).toHaveBeenCalledTimes(1);
     expect(enqueue).toHaveBeenCalledWith(expect.objectContaining({ name: "run.continue" }));
+    expect(taskCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ threadId: "group-thread-1" }) }),
+    );
+    expect(runCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ threadId: "group-thread-1" }) }),
+    );
     expect(append).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "routine.fired", runId: "run-1" }),
+      expect.objectContaining({
+        type: "routine.fired",
+        runId: "run-1",
+        threadId: "group-thread-1",
+      }),
     );
   });
 

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -78,6 +78,136 @@ describe("createRunExecutor", () => {
     );
   });
 
+  it("wakes a tool-created group routine into the group thread, not the bot DM", async () => {
+    const scheduledAt = new Date(Date.now() - 1_000);
+    const taskCreate = vi.fn(async () => ({ id: "task-1" }));
+    const runCreate = vi.fn(async () => ({ id: "run-1" }));
+    const append = vi.fn(async () => undefined);
+    const findFirst = vi.fn(async () => ({ id: "group-thread-1" }));
+    const prisma = {
+      routine: {
+        findUnique: vi.fn(async () => ({
+          id: "routine-1",
+          workspaceId: "ws-1",
+          botId: "bot-1",
+          userId: "user-1",
+          prompt: "remind the group",
+          crons: [ONCE_ROUTINE_CRON],
+          timezone: "UTC",
+          active: true,
+          nextRunAt: scheduledAt,
+          threadId: "group-thread-1",
+        })),
+      },
+      bot: {
+        findUnique: vi.fn(async () => ({
+          id: "bot-1",
+          thread: { id: "dm-thread-1" },
+        })),
+      },
+      thread: { findFirst },
+      agentSkill: { findMany: vi.fn(async () => []) },
+      $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+        callback({
+          routine: { updateMany: vi.fn(async () => ({ count: 1 })) },
+          task: { create: taskCreate },
+          run: { create: runCreate },
+        }),
+      ),
+    } as unknown as PrismaClient;
+    const executor = createRunExecutor({
+      prisma,
+      jobs: {
+        enqueue: vi.fn(async () => undefined),
+        cancel: vi.fn(async () => undefined),
+        close: vi.fn(async () => undefined),
+      },
+      events: { append },
+    } as unknown as Parameters<typeof createRunExecutor>[0]);
+
+    await executor.wakeRoutine("routine-1", scheduledAt.toISOString());
+
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "group-thread-1", workspaceId: "ws-1" }),
+      }),
+    );
+    expect(taskCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ threadId: "group-thread-1" }) }),
+    );
+    expect(runCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ threadId: "group-thread-1" }) }),
+    );
+    expect(append).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "routine.fired", threadId: "group-thread-1" }),
+    );
+  });
+
+  it("wakes a tool-created 1:1 routine into the bot DM thread", async () => {
+    const scheduledAt = new Date(Date.now() - 1_000);
+    const taskCreate = vi.fn(async () => ({ id: "task-1" }));
+    const runCreate = vi.fn(async () => ({ id: "run-1" }));
+    const append = vi.fn(async () => undefined);
+    const findFirst = vi.fn(async () => ({ id: "dm-thread-1" }));
+    const prisma = {
+      routine: {
+        findUnique: vi.fn(async () => ({
+          id: "routine-1",
+          workspaceId: "ws-1",
+          botId: "bot-1",
+          userId: "user-1",
+          prompt: "remind me",
+          crons: [ONCE_ROUTINE_CRON],
+          timezone: "UTC",
+          active: true,
+          nextRunAt: scheduledAt,
+          threadId: "dm-thread-1",
+        })),
+      },
+      bot: {
+        findUnique: vi.fn(async () => ({
+          id: "bot-1",
+          thread: { id: "dm-thread-1" },
+        })),
+      },
+      thread: { findFirst },
+      agentSkill: { findMany: vi.fn(async () => []) },
+      $transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+        callback({
+          routine: { updateMany: vi.fn(async () => ({ count: 1 })) },
+          task: { create: taskCreate },
+          run: { create: runCreate },
+        }),
+      ),
+    } as unknown as PrismaClient;
+    const executor = createRunExecutor({
+      prisma,
+      jobs: {
+        enqueue: vi.fn(async () => undefined),
+        cancel: vi.fn(async () => undefined),
+        close: vi.fn(async () => undefined),
+      },
+      events: { append },
+    } as unknown as Parameters<typeof createRunExecutor>[0]);
+
+    await executor.wakeRoutine("routine-1", scheduledAt.toISOString());
+
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "dm-thread-1", workspaceId: "ws-1" }),
+      }),
+    );
+    expect(taskCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ threadId: "dm-thread-1" }) }),
+    );
+    expect(runCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ threadId: "dm-thread-1" }) }),
+    );
+    expect(append).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "routine.fired", threadId: "dm-thread-1" }),
+    );
+  });
+
   it("expands @skill mentions in the routine prompt at fire time", async () => {
     const scheduledAt = new Date(Date.now() - 1_000);
     const enqueue = vi.fn(async () => undefined);

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1763,6 +1763,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               workspaceId: run.workspaceId,
               botId: bot.id,
               userId: run.userId,
+              ...(thread.groupId ? { threadId: thread.id } : {}),
             });
           }
           if (name === "schedule_cancel") {
@@ -1770,6 +1771,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               workspaceId: run.workspaceId,
               botId: bot.id,
               userId: run.userId,
+              ...(thread.groupId ? { threadId: thread.id } : {}),
               routineId: args.routineId ? String(args.routineId) : undefined,
               name: args.name ? String(args.name) : undefined,
             });

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -492,6 +492,25 @@ export function createRunExecutor(deps: ExecutorDeps) {
         include: { thread: true },
       });
       if (!bot?.thread) return;
+      const targetThread = routine.threadId
+        ? await deps.prisma.thread.findFirst({
+            where: {
+              id: routine.threadId,
+              workspaceId: routine.workspaceId,
+              OR: [
+                { botId: bot.id },
+                {
+                  group: {
+                    archivedAt: null,
+                    members: { some: { botId: bot.id } },
+                  },
+                },
+              ],
+            },
+            select: { id: true },
+          })
+        : null;
+      const thread = targetThread ?? bot.thread;
       // A schedule with no valid parseable cron among its crons (e.g. a
       // legacy row accepted before cron validation was added) fires the
       // already-due run once, then nextRunAt stays null and the routine
@@ -523,7 +542,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           data: {
             workspaceId: routine.workspaceId,
             botId: bot.id,
-            threadId: bot.thread!.id,
+            threadId: thread.id,
             userId: routine.userId,
             prompt: routinePrompt,
             status: "queued",
@@ -533,7 +552,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           data: {
             workspaceId: routine.workspaceId,
             botId: bot.id,
-            threadId: bot.thread!.id,
+            threadId: thread.id,
             taskId: task.id,
             userId: routine.userId,
             status: "queued",
@@ -569,7 +588,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
       try {
         await deps.events.append({
           workspaceId: routine.workspaceId,
-          threadId: bot.thread.id,
+          threadId: thread.id,
           botId: bot.id,
           type: "routine.fired",
           runId: claimed.id,

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -56,6 +56,7 @@ export * from "./remote-mcp.js";
 export * from "./run-secret.js";
 export * from "./sandbox-factory.js";
 export * from "./sandbox-provider-env.js";
+export * from "./schedule-tools.js";
 export * from "./scratchpad-context.js";
 export * from "./scratchpad-tools.js";
 export * from "./scripted-runtime.js";

--- a/packages/adapters/src/schedule-tools.test.ts
+++ b/packages/adapters/src/schedule-tools.test.ts
@@ -155,6 +155,7 @@ describe("schedule tool persistence", () => {
         data: expect.objectContaining({
           workspaceId: "ws-1",
           userId: "user-1",
+          threadId: "thread-1",
           crons: ["*/1 * * * *"],
           active: true,
         }),

--- a/packages/adapters/src/schedule-tools.test.ts
+++ b/packages/adapters/src/schedule-tools.test.ts
@@ -325,7 +325,7 @@ describe("schedule tool persistence", () => {
     ).rejects.toThrow("deactivate failed");
   });
 
-  it("scopes list and cancel to workspace and user", async () => {
+  it("scopes group list and cancel to the current thread without narrowing DMs", async () => {
     const findMany = vi.fn(async () => []);
     const findFirst = vi.fn(async () => null);
     const deps = {
@@ -336,10 +336,20 @@ describe("schedule tool persistence", () => {
       jobs: { enqueue: vi.fn(async () => undefined), cancel: vi.fn(async () => undefined) },
     } as unknown as Parameters<typeof cancelScheduleFromTool>[0];
 
-    await listSchedulesFromTool(deps, { workspaceId: "ws-1", botId: "bot-1", userId: "user-1" });
+    await listSchedulesFromTool(deps, {
+      workspaceId: "ws-1",
+      botId: "bot-1",
+      userId: "user-1",
+      threadId: "group-thread-1",
+    });
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { workspaceId: "ws-1", botId: "bot-1", userId: "user-1" },
+        where: {
+          workspaceId: "ws-1",
+          botId: "bot-1",
+          userId: "user-1",
+          threadId: "group-thread-1",
+        },
       }),
     );
 
@@ -347,9 +357,37 @@ describe("schedule tool persistence", () => {
       workspaceId: "ws-1",
       botId: "bot-1",
       userId: "user-1",
+      threadId: "group-thread-1",
       routineId: "routine-1",
     });
     expect(cancelled).toEqual({ error: "Schedule not found." });
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          workspaceId: "ws-1",
+          botId: "bot-1",
+          userId: "user-1",
+          threadId: "group-thread-1",
+          id: "routine-1",
+        },
+      }),
+    );
+
+    findMany.mockClear();
+    await listSchedulesFromTool(deps, { workspaceId: "ws-1", botId: "bot-1", userId: "user-1" });
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { workspaceId: "ws-1", botId: "bot-1", userId: "user-1" },
+      }),
+    );
+
+    findFirst.mockClear();
+    await cancelScheduleFromTool(deps, {
+      workspaceId: "ws-1",
+      botId: "bot-1",
+      userId: "user-1",
+      routineId: "routine-1",
+    });
     expect(findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { workspaceId: "ws-1", botId: "bot-1", userId: "user-1", id: "routine-1" },

--- a/packages/adapters/src/schedule-tools.test.ts
+++ b/packages/adapters/src/schedule-tools.test.ts
@@ -94,9 +94,10 @@ describe("filterBuiltinToolsForThread", () => {
     { name: "remember" },
   ];
 
-  it("keeps handoff only in groups and hides schedule tools outside 1:1", () => {
+  it("keeps handoff and schedule tools in groups", () => {
     expect(filterBuiltinToolsForThread(tools, "group-1").map((tool) => tool.name)).toEqual([
       "handoff_to_bot",
+      "schedule_create",
       "remember",
     ]);
     expect(filterBuiltinToolsForThread(tools, null).map((tool) => tool.name)).toEqual([
@@ -109,6 +110,7 @@ describe("filterBuiltinToolsForThread", () => {
   it("covers every schedule tool name", () => {
     for (const name of SCHEDULE_TOOL_NAMES) {
       expect(filterBuiltinToolsForThread([{ name }, { name: "remember" }], "group-1")).toEqual([
+        { name },
         { name: "remember" },
       ]);
     }

--- a/packages/adapters/src/schedule-tools.ts
+++ b/packages/adapters/src/schedule-tools.ts
@@ -22,8 +22,7 @@ export function filterBuiltinToolsForThread<T extends { name: string }>(
       (groupId || tool.name !== "handoff_to_bot") &&
       // In a group the room is the shared surface: hand the stage to a member
       // rather than starting a private thread off to one side.
-      (!groupId || tool.name !== "message_bot") &&
-      (!groupId || !SCHEDULE_TOOL_NAMES.has(tool.name)),
+      (!groupId || tool.name !== "message_bot"),
   );
 }
 

--- a/packages/adapters/src/schedule-tools.ts
+++ b/packages/adapters/src/schedule-tools.ts
@@ -165,6 +165,7 @@ export interface ScheduleToolDeps {
   jobs: JobPublisher;
 }
 
+/** Persist and enqueue a bot routine that wakes in the originating thread. */
 export async function createScheduleFromTool(
   deps: ScheduleToolDeps,
   input: {
@@ -240,12 +241,18 @@ export async function createScheduleFromTool(
   };
 }
 
+/** List bot routines, optionally restricted to the current group thread. */
 export async function listSchedulesFromTool(
   deps: Pick<ScheduleToolDeps, "prisma">,
-  input: { workspaceId: string; botId: string; userId: string },
+  input: { workspaceId: string; botId: string; userId: string; threadId?: string },
 ) {
   const rows = await deps.prisma.routine.findMany({
-    where: { workspaceId: input.workspaceId, botId: input.botId, userId: input.userId },
+    where: {
+      workspaceId: input.workspaceId,
+      botId: input.botId,
+      userId: input.userId,
+      ...(input.threadId ? { threadId: input.threadId } : {}),
+    },
     orderBy: { createdAt: "desc" },
   });
   return {
@@ -261,12 +268,14 @@ export async function listSchedulesFromTool(
   };
 }
 
+/** Cancel a bot routine, optionally restricted to the current group thread. */
 export async function cancelScheduleFromTool(
   deps: ScheduleToolDeps,
   input: {
     workspaceId: string;
     botId: string;
     userId: string;
+    threadId?: string;
     routineId?: string;
     name?: string;
   },
@@ -282,6 +291,7 @@ export async function cancelScheduleFromTool(
       workspaceId: input.workspaceId,
       botId: input.botId,
       userId: input.userId,
+      ...(input.threadId ? { threadId: input.threadId } : {}),
       ...(routineId ? { id: routineId } : { name: name! }),
     },
   });

--- a/packages/adapters/src/schedule-tools.ts
+++ b/packages/adapters/src/schedule-tools.ts
@@ -13,6 +13,7 @@ export { isOneShotRoutineCron, ONCE_ROUTINE_CRON };
 
 export const SCHEDULE_TOOL_NAMES = new Set(["schedule_create", "schedule_list", "schedule_cancel"]);
 
+/** Keep cross-bot messaging thread-specific while exposing schedules in DMs and groups. */
 export function filterBuiltinToolsForThread<T extends { name: string }>(
   tools: T[],
   groupId: string | null | undefined,
@@ -191,6 +192,7 @@ export async function createScheduleFromTool(
       workspaceId: input.workspaceId,
       botId: input.botId,
       userId: input.userId,
+      threadId: input.threadId,
       name,
       prompt,
       crons: [resolved.cron],

--- a/packages/db/prisma/migrations/20260830010000_routine_thread_target_fkey_not_valid/migration.sql
+++ b/packages/db/prisma/migrations/20260830010000_routine_thread_target_fkey_not_valid/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "routines" ADD COLUMN "threadId" TEXT;
+
+ALTER TABLE "routines" ADD CONSTRAINT "routines_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "threads"("id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID;

--- a/packages/db/prisma/migrations/20260830010001_routine_thread_target_fkey_validate/migration.sql
+++ b/packages/db/prisma/migrations/20260830010001_routine_thread_target_fkey_validate/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "routines" VALIDATE CONSTRAINT "routines_threadId_fkey";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -369,6 +369,7 @@ model Thread {
   events                  Event[]
   tasks                   Task[]
   runs                    Run[]
+  routines                Routine[]
 
   @@index([workspaceId])
   @@map("threads")
@@ -524,6 +525,8 @@ model Routine {
   botId          String
   bot            Bot       @relation(fields: [botId], references: [id], onDelete: Cascade)
   userId         String
+  threadId       String?
+  thread         Thread?   @relation(fields: [threadId], references: [id], onDelete: SetNull)
   name           String
   prompt         String
   crons          String[]

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -3,11 +3,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   ComposioEmulator,
+  createScheduleFromTool,
   DesktopSandboxProvider,
   FakeSandboxProvider,
   handoffToGroupBot,
   ManagedSandboxEmulator,
 } from "@rakazo/adapters";
+import { ONCE_ROUTINE_CRON } from "@rakazo/core";
 import {
   appendEvent,
   createThreadEvents,
@@ -916,6 +918,128 @@ describeJourneys("required product journeys", () => {
     expect(await prisma.run.count({ where: { botId: bot.id, trigger: "routine" } })).toBe(
       legacyRunsBefore + 1,
     );
+  });
+
+  it("5b: tool-created schedules wake in the creating group or 1:1 thread", async () => {
+    const cookie = await signup(app, `schedule-dest-j-${stamp}@rakazo.test`, "Schedule Dest");
+    const me = await rpc<Me>(app, cookie, "me");
+    const bot = await rpc<Bot>(app, cookie, "bots/create", {
+      name: "Scheduler",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const peer = await rpc<Bot>(app, cookie, "bots/create", {
+      name: "Peer",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: false,
+    });
+    const dmThread = await prisma.thread.findUniqueOrThrow({ where: { botId: bot.id } });
+    const group = await rpc<{ id: string; threadId: string }>(app, cookie, "groups/create", {
+      name: "Schedule room",
+      botIds: [bot.id, peer.id],
+    });
+    const events = createThreadEvents(prisma);
+    const scheduleDeps = { prisma, events, jobs };
+
+    const groupCreated = await createScheduleFromTool(scheduleDeps, {
+      workspaceId: me.workspaceId,
+      botId: bot.id,
+      userId: me.userId,
+      threadId: group.threadId,
+      name: "Group ping",
+      prompt: "say group-reminder-ok",
+      schedule: { delaySeconds: 30 },
+    });
+    expect(groupCreated).toMatchObject({ ok: true });
+    if (!("ok" in groupCreated) || !groupCreated.ok)
+      throw new Error("group schedule create failed");
+    const groupRoutine = await prisma.routine.findUniqueOrThrow({
+      where: { id: groupCreated.routineId },
+    });
+    expect(groupRoutine.threadId).toBe(group.threadId);
+    expect(groupRoutine.crons).toEqual([ONCE_ROUTINE_CRON]);
+
+    const groupDueAt = new Date(Date.now() - 1_000);
+    await prisma.routine.update({
+      where: { id: groupRoutine.id },
+      data: { nextRunAt: groupDueAt },
+    });
+    await executor.wakeRoutine(groupRoutine.id, groupDueAt.toISOString());
+    await waitForDatabase(async () => {
+      const run = await prisma.run.findFirst({
+        where: { routineId: groupRoutine.id, trigger: "routine" },
+      });
+      return run?.threadId === group.threadId;
+    });
+    const groupRun = await prisma.run.findFirstOrThrow({
+      where: { routineId: groupRoutine.id, trigger: "routine" },
+    });
+    expect(groupRun.threadId).toBe(group.threadId);
+    expect(groupRun.threadId).not.toBe(dmThread.id);
+    expect(
+      await prisma.event.count({
+        where: {
+          threadId: group.threadId,
+          type: "routine.fired",
+          runId: groupRun.id,
+        },
+      }),
+    ).toBe(1);
+    expect(
+      await prisma.event.count({
+        where: {
+          threadId: dmThread.id,
+          type: "routine.fired",
+          runId: groupRun.id,
+        },
+      }),
+    ).toBe(0);
+
+    const dmCreated = await createScheduleFromTool(scheduleDeps, {
+      workspaceId: me.workspaceId,
+      botId: bot.id,
+      userId: me.userId,
+      threadId: dmThread.id,
+      name: "DM ping",
+      prompt: "say dm-reminder-ok",
+      schedule: { delaySeconds: 30 },
+    });
+    expect(dmCreated).toMatchObject({ ok: true });
+    if (!("ok" in dmCreated) || !dmCreated.ok) throw new Error("dm schedule create failed");
+    const dmRoutine = await prisma.routine.findUniqueOrThrow({
+      where: { id: dmCreated.routineId },
+    });
+    expect(dmRoutine.threadId).toBe(dmThread.id);
+
+    const dmDueAt = new Date(Date.now() - 1_000);
+    await prisma.routine.update({
+      where: { id: dmRoutine.id },
+      data: { nextRunAt: dmDueAt },
+    });
+    await executor.wakeRoutine(dmRoutine.id, dmDueAt.toISOString());
+    await waitForDatabase(async () => {
+      const run = await prisma.run.findFirst({
+        where: { routineId: dmRoutine.id, trigger: "routine" },
+      });
+      return run?.threadId === dmThread.id;
+    });
+    const dmRun = await prisma.run.findFirstOrThrow({
+      where: { routineId: dmRoutine.id, trigger: "routine" },
+    });
+    expect(dmRun.threadId).toBe(dmThread.id);
+    expect(
+      await prisma.event.count({
+        where: {
+          threadId: dmThread.id,
+          type: "routine.fired",
+          runId: dmRun.id,
+        },
+      }),
+    ).toBe(1);
   });
 
   it("allocates event and message cursors atomically under concurrent writes", async () => {


### PR DESCRIPTION
## Summary

- expose schedule_create, schedule_list, and schedule_cancel in group-chat tool registries
- persist the originating thread for tool-created routines so group schedules wake back into the group
- re-authorize the stored target at wake time and fall back to the bot DM if the group is gone, archived, or no longer contains the bot
- preserve existing behavior for old and UI-created routines without a stored thread

## Root cause

The shared built-in tool filter explicitly removed every schedule tool from group threads. The schedule persistence path also discarded the originating thread, so simply removing that filter would have sent later wakeups to the bot DM.

## Verification

- focused schedule/executor tests: 28 passed
- @rakazo/db and @rakazo/adapters TypeScript checks: passed
- Prisma schema validation: passed
- Biome on changed TypeScript files: passed

## Migration safety

The nullable thread target keeps existing rows compatible. Its foreign key is added NOT VALID and validated in a separate migration to avoid holding the stronger add-constraint lock during the validation scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduling tools now work in group conversations.
  * Routines can target specific conversation threads.
  * Routine wakeups, tasks, and notifications use the configured thread when valid, with a fallback to the default thread.
  * Schedule lists and cancellations are scoped to the active conversation when applicable.

* **Bug Fixes**
  * Improved handling when a target thread is unavailable or inactive.
  * Routine data remains associated with its conversation thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->