### PR TITLE
fix(desktop): keep active conversation header draggable

### DIFF
--- a/apps/desktop/e2e/window-drag.spec.ts
+++ b/apps/desktop/e2e/window-drag.spec.ts
@@ -7,6 +7,7 @@ const fixture = `<!doctype html>
 <html lang="en">
   <head><meta charset="utf-8"><title>Rakazo window drag</title><style>${styles}</style></head>
   <body>
+    <main>Desktop fixture ready</main>
     <header class="app-drag" id="conversation-header">
       <span>Chief</span>
       <button class="app-no-drag" id="bot-settings">Bot settings</button>

--- a/apps/desktop/e2e/window-drag.spec.ts
+++ b/apps/desktop/e2e/window-drag.spec.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { _electron as electron, expect, test } from "@playwright/test";
+
+const styles = readFileSync(path.resolve(import.meta.dirname, "../../web/src/styles.css"), "utf8");
+const fixture = `<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Rakazo window drag</title><style>${styles}</style></head>
+  <body>
+    <header class="app-drag" id="conversation-header">
+      <span>Chief</span>
+      <button class="app-no-drag" id="bot-settings">Bot settings</button>
+    </header>
+    <output id="result"></output>
+    <script>
+      document.querySelector('#bot-settings').addEventListener('click', () => {
+        document.querySelector('#result').textContent = 'opened';
+      });
+    </script>
+  </body>
+</html>`;
+
+test("an active Electron window keeps header dragging selection-free and controls clickable", async () => {
+  const app = await electron.launch({
+    args: ["."],
+    cwd: path.resolve(import.meta.dirname, ".."),
+    env: {
+      ...process.env,
+      RAKAZO_WEB_URL: `data:text/html;charset=utf-8,${encodeURIComponent(fixture)}`,
+    },
+  });
+
+  try {
+    const page = await app.firstWindow();
+    const active = await app.evaluate(({ BrowserWindow }) => {
+      const window = BrowserWindow.getAllWindows()[0];
+      window?.show();
+      window?.focus();
+      return window?.isFocused();
+    });
+    expect(active).toBe(true);
+
+    const regions = await page.evaluate(() => {
+      const header = document.querySelector("#conversation-header");
+      const settings = document.querySelector("#bot-settings");
+      if (!(header instanceof HTMLElement) || !(settings instanceof HTMLElement)) {
+        throw new Error("missing window chrome fixture");
+      }
+      const headerStyle = getComputedStyle(header);
+      const settingsStyle = getComputedStyle(settings);
+      return {
+        header: {
+          appRegion: headerStyle.getPropertyValue("-webkit-app-region"),
+          userSelect: headerStyle.userSelect,
+        },
+        settings: settingsStyle.getPropertyValue("-webkit-app-region"),
+      };
+    });
+
+    expect(regions).toEqual({
+      header: { appRegion: "drag", userSelect: "none" },
+      settings: "no-drag",
+    });
+    await page.getByRole("button", { name: "Bot settings" }).click();
+    await expect(page.locator("#result")).toHaveText("opened");
+  } finally {
+    await app.close();
+  }
+});

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -60,12 +60,22 @@ describe("window chrome", () => {
     expect(welcome).not.toContain("FF5F57");
   });
 
-  it("makes the conversation header draggable without swallowing its controls", () => {
+  it("keeps the active conversation header draggable instead of selecting its contents", () => {
+    const styles = readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), "../styles.css"),
+      "utf8",
+    );
+    expect(styles).toMatch(/\.app-drag\s*{[^}]*-webkit-app-region:\s*drag;/);
+    expect(styles).toMatch(/\.app-drag\s*{[^}]*user-select:\s*none;/);
+  });
+
+  it("keeps conversation header controls clickable", () => {
     const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "../pages");
     const shell = readFileSync(path.join(root, "Shell.tsx"), "utf8");
     expect(shell).toContain(
       'className="app-drag flex items-center justify-between border-b border-[#141416]',
     );
+    expect(shell).toContain('className="app-no-drag grid h-8 w-8');
     expect(shell).toContain('className="app-no-drag flex min-w-0 items-center gap-3"');
     expect(shell.match(/className="app-no-drag grid h-\[30px\] w-\[34px\]/g)).toHaveLength(2);
   });

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -60,15 +60,6 @@ describe("window chrome", () => {
     expect(welcome).not.toContain("FF5F57");
   });
 
-  it("keeps the active conversation header draggable instead of selecting its contents", () => {
-    const styles = readFileSync(
-      path.join(path.dirname(fileURLToPath(import.meta.url)), "../styles.css"),
-      "utf8",
-    );
-    expect(styles).toMatch(/\.app-drag\s*{[^}]*-webkit-app-region:\s*drag;/);
-    expect(styles).toMatch(/\.app-drag\s*{[^}]*user-select:\s*none;/);
-  });
-
   it("keeps conversation header controls clickable", () => {
     const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "../pages");
     const shell = readFileSync(path.join(root, "Shell.tsx"), "utf8");

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -36,6 +36,7 @@ body,
 
 .app-drag {
   -webkit-app-region: drag;
+  user-select: none;
 }
 
 .app-no-drag {


### PR DESCRIPTION
## Summary

- prevent text selection from competing with Electron window dragging when the conversation header is already active
- preserve explicit no-drag regions for navigation, bot settings, call, and computer controls
- add a focused Electron regression that activates the window and verifies computed drag regions plus control clicks

## Root cause

PR #390 added the correct drag region, but the region remained text-selectable. In an active Electron window, Chromium could begin a selection gesture instead of handing the drag to the native window. An inactive-window click first activates the window, which masked the conflict.

## Verification

- `pnpm exec vitest run apps/web/src/lib/desktop.test.ts` - 11 passed
- `pnpm --filter @rakazo/desktop exec playwright test e2e/window-drag.spec.ts --config e2e/playwright.config.ts` - 1 passed
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web build`
- `pnpm --filter @rakazo/desktop check`
- `pnpm --filter @rakazo/desktop build`
- `pnpm exec biome check apps/web/src/lib/desktop.test.ts apps/desktop/e2e/window-drag.spec.ts`

The regression test was also run with `user-select: none` temporarily removed and failed with `userSelect: "auto"`, proving it detects the old behavior.

## Residual verification

Playwright verifies a focused Electron window's rendered drag/no-drag CSS and interactive controls. CDP cannot conclusively prove that a physical macOS pointer drag changes native `NSWindow` bounds, so a brief manual drag remains the final native gesture check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop window dragging so draggable areas no longer allow text selection.
  - Preserved clickable behavior for controls within the conversation header.

- **Tests**
  - Added coverage for window focus, draggable header behavior, non-draggable controls, and button interactions.
  - Updated conversation-header checks to reflect the current control layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->