### PR TITLE
feat(web): show chat message timestamps on hover

### DIFF
--- a/apps/web/src/components/MessageHoverMetadata.test.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.test.tsx
@@ -1,9 +1,18 @@
+import { i18n } from "@lingui/core";
+import { afterEach, describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
 import { MessageHoverMetadata } from "./MessageHoverMetadata";
 
 describe("MessageHoverMetadata", () => {
+  afterEach(() => {
+    i18n.load("en", {});
+    i18n.activate("en");
+  });
+
   it("shows the message's creation time beside its actions on hover or focus", () => {
+    i18n.load("en", {});
+    i18n.activate("en");
+
     const createdAt = new Date(2026, 7, 21, 18, 14).toISOString();
     const html = renderToStaticMarkup(
       <MessageHoverMetadata createdAt={createdAt}>
@@ -17,5 +26,21 @@ describe("MessageHoverMetadata", () => {
     expect(html.indexOf("<time")).toBeLessThan(html.indexOf('data-testid="message-actions-pill"'));
     expect(html).toContain("group-hover/message:opacity-100");
     expect(html).toContain("focus-within:opacity-100");
+  });
+
+  it("formats the displayed time with the active i18n locale", () => {
+    i18n.load("de", {});
+    i18n.activate("de");
+
+    const createdAt = new Date(2026, 7, 21, 18, 14).toISOString();
+    const html = renderToStaticMarkup(
+      <MessageHoverMetadata createdAt={createdAt}>
+        <div data-testid="message-actions-pill" />
+      </MessageHoverMetadata>,
+    );
+
+    expect(html).toContain(`dateTime="${createdAt}"`);
+    expect(html).toContain(">18:14</time>");
+    expect(html).not.toContain("6:14 PM");
   });
 });

--- a/apps/web/src/components/MessageHoverMetadata.test.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.test.tsx
@@ -1,6 +1,6 @@
 import { i18n } from "@lingui/core";
-import { afterEach, describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it } from "vitest";
 import { MessageHoverMetadata } from "./MessageHoverMetadata";
 
 describe("MessageHoverMetadata", () => {

--- a/apps/web/src/components/MessageHoverMetadata.test.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.test.tsx
@@ -1,0 +1,21 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MessageHoverMetadata } from "./MessageHoverMetadata";
+
+describe("MessageHoverMetadata", () => {
+  it("shows the message's creation time beside its actions on hover or focus", () => {
+    const createdAt = new Date(2026, 7, 21, 18, 14).toISOString();
+    const html = renderToStaticMarkup(
+      <MessageHoverMetadata createdAt={createdAt}>
+        <div data-testid="message-actions-pill" />
+      </MessageHoverMetadata>,
+    );
+
+    expect(html).toContain(
+      `<time dateTime="${createdAt}" class="text-[11px] tabular-nums text-[#85858A]">6:14 PM</time>`,
+    );
+    expect(html.indexOf("<time")).toBeLessThan(html.indexOf('data-testid="message-actions-pill"'));
+    expect(html).toContain("group-hover/message:opacity-100");
+    expect(html).toContain("focus-within:opacity-100");
+  });
+});

--- a/apps/web/src/components/MessageHoverMetadata.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export function MessageHoverMetadata({
+  createdAt,
+  children,
+}: {
+  createdAt: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="pointer-events-none absolute end-0 top-0 z-10 flex items-center gap-1.5 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+      <time dateTime={createdAt} className="text-[11px] tabular-nums text-[#85858A]">
+        {new Date(createdAt).toLocaleTimeString("en-US", {
+          hour: "numeric",
+          minute: "2-digit",
+        })}
+      </time>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/MessageHoverMetadata.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.tsx
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import type { ReactNode } from "react";
 
 export function MessageHoverMetadata({
@@ -10,7 +11,7 @@ export function MessageHoverMetadata({
   return (
     <div className="pointer-events-none absolute end-0 top-0 z-10 flex items-center gap-1.5 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
       <time dateTime={createdAt} className="text-[11px] tabular-nums text-[#85858A]">
-        {new Date(createdAt).toLocaleTimeString("en-US", {
+        {new Date(createdAt).toLocaleTimeString(i18n.locale || "en", {
           hour: "numeric",
           minute: "2-digit",
         })}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -114,6 +114,7 @@ import {
   ComputersUnavailableHint,
   computersAreUnavailable,
 } from "../components/ComputersUnavailableHint";
+import { MessageHoverMetadata } from "../components/MessageHoverMetadata";
 import { SkillDraftCard } from "../components/teach/SkillDraftCard";
 import { TeachCaptureOverlay } from "../components/teach/TeachCaptureOverlay";
 import { TeachComputerSection } from "../components/teach/TeachComputerSection";
@@ -4512,27 +4513,29 @@ function MessageHoverActions({
   }
 
   return (
-    <div
-      data-testid="message-hover-actions"
-      className="pointer-events-none absolute end-0 top-0 z-10 flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 opacity-0 shadow-[0_1px_4px_rgba(0,0,0,0.45)] transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
-    >
-      <button
-        type="button"
-        aria-label={t`Reply`}
-        onClick={() => onReply(message)}
-        className="grid h-7 w-7 place-items-center rounded-full text-[#C9C9CE] hover:bg-[#2A2A2F] hover:text-[#ECECEE]"
+    <MessageHoverMetadata createdAt={message.createdAt}>
+      <div
+        data-testid="message-hover-actions"
+        className="flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 shadow-[0_1px_4px_rgba(0,0,0,0.45)]"
       >
-        <Reply size={14} strokeWidth={1.8} />
-      </button>
-      <button
-        type="button"
-        aria-label={t`Copy`}
-        onClick={copyMessage}
-        className="grid h-7 w-7 place-items-center rounded-full text-[#C9C9CE] hover:bg-[#2A2A2F] hover:text-[#ECECEE]"
-      >
-        <Copy size={14} strokeWidth={1.8} />
-      </button>
-    </div>
+        <button
+          type="button"
+          aria-label={t`Reply`}
+          onClick={() => onReply(message)}
+          className="grid h-7 w-7 place-items-center rounded-full text-[#C9C9CE] hover:bg-[#2A2A2F] hover:text-[#ECECEE]"
+        >
+          <Reply size={14} strokeWidth={1.8} />
+        </button>
+        <button
+          type="button"
+          aria-label={t`Copy`}
+          onClick={copyMessage}
+          className="grid h-7 w-7 place-items-center rounded-full text-[#C9C9CE] hover:bg-[#2A2A2F] hover:text-[#ECECEE]"
+        >
+          <Copy size={14} strokeWidth={1.8} />
+        </button>
+      </div>
+    </MessageHoverMetadata>
   );
 }
 


### PR DESCRIPTION
## Summary

- show each chat message's real creation time beside the existing reply/copy pill
- reveal the timestamp on message hover and when the action controls receive keyboard focus
- keep the metadata subdued and semantic with a `<time>` element

## Verification

- `NODE_ENV=test pnpm exec vitest run apps/web/src/components/MessageHoverMetadata.test.tsx` - 1 passed
- `pnpm --filter @rakazo/web check` - passed
- isolated Playwright render at the committed revision confirmed:
  - `6:14 PM` formatting from the real `createdAt`
  - opacity 0 initially, 1 on hover, and 1 on keyboard focus
  - 6px spacing between timestamp and action pill
  - no clipping or overlap in the isolated fixture

The regression test was first run before implementation and failed because the expected timestamp was absent.

## Residual verification

The local API was unavailable during visual QA, so the render used an isolated message fixture rather than an authenticated live transcript. A fresh parent Biome invocation was also terminated by the local host without returning diagnostics; repository CI remains the authoritative lint gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message timestamps now appear alongside Reply and Copy actions when hovering over or focusing a message.
  * Metadata visibility and positioning are presented consistently around message actions.
  * Timestamps follow the active language and regional formatting settings.

* **Bug Fixes**
  * Corrected localized time display while retaining the underlying date and time information.

* **Tests**
  * Added coverage for English and German timestamp formatting, metadata ordering, and hover/focus visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->