### PR TITLE
fix(adapters): prevent routine schedule recursion

### DIFF
--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -1,7 +1,40 @@
 import { ONCE_ROUTINE_CRON } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
-import { createRunExecutor, runNotificationsEnabled, threadContextForRun } from "./executor.js";
+import {
+  createRunExecutor,
+  runNotificationsEnabled,
+  selectBuiltinToolsForRun,
+  threadContextForRun,
+} from "./executor.js";
+
+describe("run tool selection", () => {
+  const toolNames = (trigger: string, groupId: string | null = null) =>
+    selectBuiltinToolsForRun({
+      graphicalToolsAllowed: true,
+      groupId,
+      trigger,
+      semanticMemoryEnabled: false,
+    }).map((tool) => tool.name);
+
+  it("withholds schedule creation only from routine-triggered runs", () => {
+    expect(toolNames("routine")).not.toContain("schedule_create");
+    expect(toolNames("routine")).toEqual(
+      expect.arrayContaining(["schedule_list", "schedule_cancel"]),
+    );
+    expect(toolNames("user")).toContain("schedule_create");
+  });
+
+  it("keeps schedule tools in group chats and still blocks create on routines", () => {
+    expect(toolNames("user", "group-1")).toEqual(
+      expect.arrayContaining(["schedule_create", "schedule_list", "schedule_cancel"]),
+    );
+    expect(toolNames("routine", "group-1")).not.toContain("schedule_create");
+    expect(toolNames("routine", "group-1")).toEqual(
+      expect.arrayContaining(["schedule_list", "schedule_cancel"]),
+    );
+  });
+});
 
 describe("run notification preference", () => {
   it("silences direct messages but leaves group notifications enabled", async () => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -184,6 +184,7 @@ import {
 import {
   cancelScheduleFromTool,
   createScheduleFromTool,
+  filterBuiltinToolsForRun,
   filterBuiltinToolsForThread,
   listSchedulesFromTool,
 } from "./schedule-tools.js";
@@ -1008,12 +1009,13 @@ export function createRunExecutor(deps: ExecutorDeps) {
               .join("\n\n")
           : undefined;
         const graphicalToolsAllowed = graphical && acceptsImages;
-        const availableBuiltins = filterBuiltinToolsForThread(
-          filterImageReturningComputerTools(builtinAgentTools, graphicalToolsAllowed),
-          thread.groupId,
-        );
         const builtins = [
-          ...selectMemoryTools(availableBuiltins, semanticMemoryEnabled),
+          ...selectBuiltinToolsForRun({
+            graphicalToolsAllowed,
+            groupId: thread.groupId,
+            trigger: run.trigger,
+            semanticMemoryEnabled,
+          }),
           // Cross-owner agent connections only exist for phone-linked bots.
           ...(hasPhoneIdentity ? agentConnectionTools : []),
         ];
@@ -3034,6 +3036,24 @@ async function renewRunLease(
 
 function computerRetryDelay(fence: number): number {
   return Math.min(10_000, 250 * 2 ** Math.min(Math.max(fence - 1, 0), 5));
+}
+
+export function selectBuiltinToolsForRun(options: {
+  graphicalToolsAllowed: boolean;
+  groupId: string | null;
+  trigger: string;
+  semanticMemoryEnabled: boolean;
+}) {
+  return selectMemoryTools(
+    filterBuiltinToolsForRun(
+      filterBuiltinToolsForThread(
+        filterImageReturningComputerTools(builtinAgentTools, options.graphicalToolsAllowed),
+        options.groupId,
+      ),
+      options.trigger,
+    ),
+    options.semanticMemoryEnabled,
+  );
 }
 
 export function threadContextForRun<T>(

--- a/packages/adapters/src/schedule-tools.test.ts
+++ b/packages/adapters/src/schedule-tools.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   cancelScheduleFromTool,
   createScheduleFromTool,
+  filterBuiltinToolsForRun,
   filterBuiltinToolsForThread,
   isOneShotRoutineCron,
   listSchedulesFromTool,
@@ -91,6 +92,8 @@ describe("filterBuiltinToolsForThread", () => {
     { name: "handoff_to_bot" },
     { name: "message_bot" },
     { name: "schedule_create" },
+    { name: "schedule_list" },
+    { name: "schedule_cancel" },
     { name: "remember" },
   ];
 
@@ -98,13 +101,43 @@ describe("filterBuiltinToolsForThread", () => {
     expect(filterBuiltinToolsForThread(tools, "group-1").map((tool) => tool.name)).toEqual([
       "handoff_to_bot",
       "schedule_create",
+      "schedule_list",
+      "schedule_cancel",
       "remember",
     ]);
     expect(filterBuiltinToolsForThread(tools, null).map((tool) => tool.name)).toEqual([
       "message_bot",
       "schedule_create",
+      "schedule_list",
+      "schedule_cancel",
       "remember",
     ]);
+  });
+
+  it("hides schedule creation from routine runs without removing schedule management", () => {
+    expect(filterBuiltinToolsForRun(tools, "routine").map((tool) => tool.name)).toEqual([
+      "handoff_to_bot",
+      "message_bot",
+      "schedule_list",
+      "schedule_cancel",
+      "remember",
+    ]);
+    expect(filterBuiltinToolsForRun(tools, "user").map((tool) => tool.name)).toContain(
+      "schedule_create",
+    );
+  });
+
+  it("composes thread then run filters without dropping group schedule tools", () => {
+    const groupTools = filterBuiltinToolsForRun(
+      filterBuiltinToolsForThread(tools, "group-1"),
+      "routine",
+    ).map((tool) => tool.name);
+    expect(groupTools).toEqual(["handoff_to_bot", "schedule_list", "schedule_cancel", "remember"]);
+    expect(
+      filterBuiltinToolsForRun(filterBuiltinToolsForThread(tools, "group-1"), "user").map(
+        (tool) => tool.name,
+      ),
+    ).toContain("schedule_create");
   });
 
   it("covers every schedule tool name", () => {

--- a/packages/adapters/src/schedule-tools.ts
+++ b/packages/adapters/src/schedule-tools.ts
@@ -13,6 +13,13 @@ export { isOneShotRoutineCron, ONCE_ROUTINE_CRON };
 
 export const SCHEDULE_TOOL_NAMES = new Set(["schedule_create", "schedule_list", "schedule_cancel"]);
 
+export function filterBuiltinToolsForRun<T extends { name: string }>(
+  tools: T[],
+  runTrigger: string,
+): T[] {
+  return runTrigger === "routine" ? tools.filter((tool) => tool.name !== "schedule_create") : tools;
+}
+
 /** Keep cross-bot messaging thread-specific while exposing schedules in DMs and groups. */
 export function filterBuiltinToolsForThread<T extends { name: string }>(
   tools: T[],


### PR DESCRIPTION
## Summary

- hide `schedule_create` from routine-triggered runs
- keep `schedule_list` and `schedule_cancel` available for routine inspection and control
- preserve schedule creation for user-triggered runs

## Why

A scheduled routine received the same scheduling tools as a user turn. If the model called `schedule_create` while executing the routine, each firing could create another copy of itself and multiply future runs.

The executor’s built-in tool selection is the single exposure boundary, so this change applies a run-trigger filter after the existing thread filter and removes only `schedule_create` when `trigger === "routine"`.

## Verification

- focused Vitest suites — 32/32 pass (`schedule-tools.test.ts`, `executor.test.ts`)
- sabotage check — removing the routine guard fails both policy and executor-level regressions
- adapters TypeScript check — pass
- `pnpm run lint` — pass
- `pnpm run check` — pass (20/20 packages)
- `pnpm run build` — pass
- `pnpm run test` — 1,915 pass, 97 skipped, 1 known failure in untouched `packages/adapters/src/desktop-sandbox-write-containment.test.ts`

## Risk / compatibility

User-triggered runs can still create schedules. Routine-triggered runs can list and cancel schedules but cannot create new ones.

No schema or dependency changes.

Related: #391 changes group-chat scheduling in the same filter. The policies are compatible: group/user turns may create schedules, but routine-triggered turns may not. If #391 lands first, retain this trigger guard while resolving the small filter/test conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Routine-triggered runs no longer offer the option to create new schedules.
  * Schedule listing and cancellation remain available during routine runs.
  * User-triggered runs continue to support schedule creation.

* **Tests**
  * Added coverage to verify schedule tool availability across different run types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->