### PR TITLE
fix(desktop): open external links in default browser

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -28,6 +28,7 @@ import {
   sessionPartitionForServerUrl,
 } from "./setup-config.js";
 import { clearSetup, readSetup, writeSetup } from "./setup-store.js";
+import { shouldOpenInAppPopup } from "./window-open.js";
 import { browserWindowOptions, setupWindowOptions, warmWindowTtlMs } from "./window-options.js";
 
 const PERFORMANCE_USER_DATA = process.env.RAKAZO_PERFORMANCE_USER_DATA;
@@ -195,24 +196,13 @@ function createWindow(url: string, partition: string | null) {
   });
   mainWindow = win;
   const targetOrigin = safeOrigin(url);
-  // OAuth flows open the provider's authorize page via window.open; give that
-  // popup a normal framed window. Non-http(s) targets stay closed; other http(s)
-  // origins open in the system browser so a connected server cannot navigate us away.
+  // Intentional OAuth flows open the provider's authorize page via a named
+  // window; give those and same-origin popups a normal frame. Everything else
+  // opens in the system browser so a connected server cannot navigate us away.
   // Hoisted for loopback OAuth capture so MCP/in-app localhost callbacks are skipped.
   const appOrigin = targetOrigin ?? safeOrigin(url);
-  win.webContents.setWindowOpenHandler(({ url: childUrl }) => {
-    let target: URL;
-    try {
-      target = new URL(childUrl);
-    } catch {
-      return { action: "deny" };
-    }
-    const sameOrigin = appOrigin !== null && target.origin === appOrigin;
-    // Same-origin http(s) and third-party https (OAuth) get a framed popup.
-    if (
-      (sameOrigin && (target.protocol === "http:" || target.protocol === "https:")) ||
-      (!sameOrigin && target.protocol === "https:")
-    ) {
+  win.webContents.setWindowOpenHandler(({ url: childUrl, frameName }) => {
+    if (shouldOpenInAppPopup(appOrigin, childUrl, frameName)) {
       return {
         action: "allow",
         overrideBrowserWindowOptions: oauthPopupWindowOptions(),
@@ -225,6 +215,8 @@ function createWindow(url: string, partition: string | null) {
   win.webContents.on("will-navigate", (event, navigationUrl) => {
     if (targetOrigin !== null && safeOrigin(navigationUrl) === targetOrigin) return;
     event.preventDefault();
+    const external = safeExternalUrl(navigationUrl);
+    if (external !== null) void shell.openExternal(external);
   });
   // The popup has no address bar, so a loopback redirect would otherwise strand
   // the user on a blank window holding the authorization code in a URL they

--- a/apps/desktop/src/window-open.test.ts
+++ b/apps/desktop/src/window-open.test.ts
@@ -14,14 +14,16 @@ describe("desktop child windows", () => {
     ).toBe(false);
   });
 
-  it.each(["rakazo-model-oauth", "rakazo-mcp-oauth", "rakazo-app-connect"])(
-    "keeps the intentional %s flow in an Electron popup",
-    (frameName) => {
-      expect(
-        shouldOpenInAppPopup(appOrigin, "https://provider.example.com/authorize", frameName),
-      ).toBe(true);
-    },
-  );
+  it.each([
+    "rakazo-model-oauth",
+    "rakazo-mcp-oauth",
+    "rakazo-app-connect",
+    "rakazo-plugin-connect",
+  ])("keeps the intentional %s flow in an Electron popup", (frameName) => {
+    expect(
+      shouldOpenInAppPopup(appOrigin, "https://provider.example.com/authorize", frameName),
+    ).toBe(true);
+  });
 
   it("rejects malformed URLs and non-HTTPS third-party targets", () => {
     expect(shouldOpenInAppPopup(appOrigin, "not a url", "rakazo-model-oauth")).toBe(false);

--- a/apps/desktop/src/window-open.test.ts
+++ b/apps/desktop/src/window-open.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { shouldOpenInAppPopup } from "./window-open.js";
+
+const appOrigin = "https://rakazo.example.com";
+
+describe("desktop child windows", () => {
+  it("keeps same-origin app routes in Electron", () => {
+    expect(shouldOpenInAppPopup(appOrigin, `${appOrigin}/mcp/oauth/callback`, "_blank")).toBe(true);
+  });
+
+  it("opens ordinary external links outside Electron", () => {
+    expect(
+      shouldOpenInAppPopup(appOrigin, "https://github.com/elie222/rakazo/pull/395", "_blank"),
+    ).toBe(false);
+  });
+
+  it.each(["rakazo-model-oauth", "rakazo-mcp-oauth", "rakazo-app-connect"])(
+    "keeps the intentional %s flow in an Electron popup",
+    (frameName) => {
+      expect(
+        shouldOpenInAppPopup(appOrigin, "https://provider.example.com/authorize", frameName),
+      ).toBe(true);
+    },
+  );
+
+  it("rejects malformed URLs and non-HTTPS third-party targets", () => {
+    expect(shouldOpenInAppPopup(appOrigin, "not a url", "rakazo-model-oauth")).toBe(false);
+    expect(
+      shouldOpenInAppPopup(appOrigin, "http://provider.example.com", "rakazo-model-oauth"),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/window-open.ts
+++ b/apps/desktop/src/window-open.ts
@@ -1,4 +1,9 @@
-const OAUTH_POPUP_NAMES = new Set(["rakazo-app-connect", "rakazo-mcp-oauth", "rakazo-model-oauth"]);
+const OAUTH_POPUP_NAMES = new Set([
+  "rakazo-app-connect",
+  "rakazo-mcp-oauth",
+  "rakazo-model-oauth",
+  "rakazo-plugin-connect",
+]);
 
 export function shouldOpenInAppPopup(
   appOrigin: string | null,

--- a/apps/desktop/src/window-open.ts
+++ b/apps/desktop/src/window-open.ts
@@ -1,0 +1,18 @@
+const OAUTH_POPUP_NAMES = new Set(["rakazo-app-connect", "rakazo-mcp-oauth", "rakazo-model-oauth"]);
+
+export function shouldOpenInAppPopup(
+  appOrigin: string | null,
+  childUrl: string,
+  frameName: string,
+) {
+  let target: URL;
+  try {
+    target = new URL(childUrl);
+  } catch {
+    return false;
+  }
+
+  const isHttp = target.protocol === "http:" || target.protocol === "https:";
+  if (appOrigin !== null && target.origin === appOrigin) return isHttp;
+  return target.protocol === "https:" && OAUTH_POPUP_NAMES.has(frameName);
+}

--- a/apps/web/src/lib/use-model-oauth-signin.ts
+++ b/apps/web/src/lib/use-model-oauth-signin.ts
@@ -145,7 +145,7 @@ export function useModelOAuthSignIn(options: {
           oauthStateOf(started.verificationUri),
         );
       }
-      window.open(started.verificationUri, "_blank", "noopener,noreferrer");
+      window.open(started.verificationUri, "rakazo-model-oauth", "noopener,noreferrer");
       waitingForCode = started.mode === "auth-url";
       if (!waitingForCode) await finishSubscriptionSignIn(started.loginId, controller);
     } catch (err) {

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -117,7 +117,7 @@ export function PluginsOverlay({
         displayName: item.name,
       });
       if (started.authorizationUrl)
-        window.open(started.authorizationUrl, "_blank", "noopener,noreferrer");
+        window.open(started.authorizationUrl, "rakazo-app-connect", "noopener,noreferrer");
       if (item.noAuth && !started.authorizationUrl) {
         if (controller.signal.aborted) return;
         setItemConnected(item, true);

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -117,7 +117,7 @@ export function PluginsOverlay({
         displayName: item.name,
       });
       if (started.authorizationUrl)
-        window.open(started.authorizationUrl, "rakazo-app-connect", "noopener,noreferrer");
+        window.open(started.authorizationUrl, "rakazo-plugin-connect", "noopener,noreferrer");
       if (item.noAuth && !started.authorizationUrl) {
         if (controller.signal.aborted) return;
         setItemConnected(item, true);


### PR DESCRIPTION
## Summary
- open ordinary external links with Electron `shell.openExternal` instead of child `BrowserWindow`s
- reserve in-app popups for same-origin routes and explicitly named OAuth flows
- route same-tab external navigations to the system browser too

## Verification
- `pnpm --filter @rakazo/desktop test` (112 passed)
- `pnpm --filter @rakazo/desktop check`
- `pnpm --filter @rakazo/desktop build`
- `biome check` on all changed files

## Known repository baseline
The full test suite currently has unrelated failures in Lingui catalog compilation, API router contract fixtures, and a sandbox containment race. The web workspace check/build is also blocked locally because installed workspace links resolve core/contracts into other Rakazo worktrees; the changed web lines only name the intentional OAuth windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved handling of OAuth and plugin connection popups, including reuse of existing popup windows.
  * Kept supported app routes in-app while opening approved external links in the system browser.
  * Added support for plugin connection authorization popups.
  * Blocked malformed or insecure external popup destinations for safer navigation.

* **Bug Fixes**
  * Prevented blocked navigations from being silently discarded by opening safe external destinations in the system browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->