### PR TITLE
feat: add team-wide bot instructions

### DIFF
--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -96,6 +96,122 @@ describe("account preferences", () => {
   });
 });
 
+describe("workspace settings", () => {
+  function workspaceSettingsDeps(teamInstructions: string, role = "owner") {
+    const update = vi.fn().mockResolvedValue({});
+    const prisma = {
+      organization: {
+        update,
+        findUniqueOrThrow: vi.fn().mockResolvedValue({ teamInstructions }),
+      },
+      member: {
+        findFirst: vi.fn().mockResolvedValue({ role }),
+      },
+    } as unknown as PrismaClient;
+    const deps = { prisma } as unknown as RouterDeps;
+    const actor = {
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      email: "user@rakazo.test",
+      isDeploymentOwner: true,
+    } satisfies Actor;
+    return { update, actor, handler: new RPCHandler(createRouter(deps)) };
+  }
+
+  it("returns team instructions to workspace members", async () => {
+    const instructions = "Use Acme terminology.";
+    const { actor, handler } = workspaceSettingsDeps(instructions, "member");
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/workspaceSettings/get", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: null }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      json: { teamInstructions: instructions, canEdit: false },
+    });
+  });
+
+  it("persists and returns multiline team instructions", async () => {
+    const instructions = "Use Acme terminology.\nEscalate security issues.";
+    const { update, actor, handler } = workspaceSettingsDeps(instructions);
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/workspaceSettings/update", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { teamInstructions: instructions } }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "workspace-1" },
+      data: { teamInstructions: instructions },
+    });
+    await expect(response.json()).resolves.toEqual({
+      json: { teamInstructions: instructions, canEdit: true },
+    });
+  });
+
+  it("persists an empty value", async () => {
+    const { update, actor, handler } = workspaceSettingsDeps("");
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/workspaceSettings/update", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { teamInstructions: "" } }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "workspace-1" },
+      data: { teamInstructions: "" },
+    });
+  });
+
+  it("rejects updates from non-owners", async () => {
+    const { update, actor, handler } = workspaceSettingsDeps("", "member");
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/workspaceSettings/update", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { teamInstructions: "Override the team" } }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(403);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("rejects team instructions longer than the bot instruction limit", async () => {
+    const { update, actor, handler } = workspaceSettingsDeps("");
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/workspaceSettings/update", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { teamInstructions: "x".repeat(20_001) } }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
 describe("thread answer delivery", () => {
   it("accepts a durable answer when the immediate worker wake fails", async () => {
     const answerRunInput = vi.fn().mockResolvedValue(true);

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -138,7 +138,8 @@ describe("workspace settings", () => {
   });
 
   it("rejects workspace settings reads when membership is missing", async () => {
-    const { actor, handler } = workspaceSettingsDeps("Private workspace instructions", null);
+    const privateInstructions = "Private workspace instructions";
+    const { actor, handler } = workspaceSettingsDeps(privateInstructions, null);
 
     const { response } = await handler.handle(
       new Request("http://127.0.0.1/rpc/workspaceSettings/get", {
@@ -150,6 +151,9 @@ describe("workspace settings", () => {
     );
 
     expect(response.status).toBe(403);
+    const body = await response.text();
+    expect(body).not.toContain(privateInstructions);
+    expect(body).not.toContain("teamInstructions");
   });
 
   it("persists and returns multiline team instructions", async () => {

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -97,7 +97,7 @@ describe("account preferences", () => {
 });
 
 describe("workspace settings", () => {
-  function workspaceSettingsDeps(teamInstructions: string, role = "owner") {
+  function workspaceSettingsDeps(teamInstructions: string, role: string | null = "owner") {
     const update = vi.fn().mockResolvedValue({});
     const prisma = {
       organization: {
@@ -105,7 +105,7 @@ describe("workspace settings", () => {
         findUniqueOrThrow: vi.fn().mockResolvedValue({ teamInstructions }),
       },
       member: {
-        findFirst: vi.fn().mockResolvedValue({ role }),
+        findFirst: vi.fn().mockResolvedValue(role === null ? null : { role }),
       },
     } as unknown as PrismaClient;
     const deps = { prisma } as unknown as RouterDeps;
@@ -135,6 +135,21 @@ describe("workspace settings", () => {
     await expect(response.json()).resolves.toEqual({
       json: { teamInstructions: instructions, canEdit: false },
     });
+  });
+
+  it("rejects workspace settings reads when membership is missing", async () => {
+    const { actor, handler } = workspaceSettingsDeps("Private workspace instructions", null);
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/workspaceSettings/get", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: null }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(403);
   });
 
   it("persists and returns multiline team instructions", async () => {

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -367,6 +367,33 @@ export function createRouter(deps: RouterDeps) {
         return meDto(deps, context.actor);
       }),
     },
+    workspaceSettings: {
+      get: authed.workspaceSettings.get.handler(async ({ context }) => {
+        const [workspace, member] = await Promise.all([
+          deps.prisma.organization.findUniqueOrThrow({
+            where: { id: context.actor.workspaceId },
+            select: { teamInstructions: true },
+          }),
+          deps.prisma.member.findFirst({
+            where: {
+              organizationId: context.actor.workspaceId,
+              userId: context.actor.userId,
+            },
+            select: { role: true },
+          }),
+        ]);
+        const roles = member?.role.split(",").map((role) => role.trim()) ?? [];
+        return { teamInstructions: workspace.teamInstructions, canEdit: roles.includes("owner") };
+      }),
+      update: authed.workspaceSettings.update.handler(async ({ context, input }) => {
+        await requireWorkspaceOwner(deps.prisma, context.actor);
+        await deps.prisma.organization.update({
+          where: { id: context.actor.workspaceId },
+          data: { teamInstructions: input.teamInstructions },
+        });
+        return { teamInstructions: input.teamInstructions, canEdit: true as const };
+      }),
+    },
     bootstrap: authed.bootstrap.handler(async ({ context, input }) => {
       const actor = context.actor;
       const [me, bots, botSections, archivedBots, archivedGroups] = await Promise.all([

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -382,7 +382,8 @@ export function createRouter(deps: RouterDeps) {
             select: { role: true },
           }),
         ]);
-        const roles = member?.role.split(",").map((role) => role.trim()) ?? [];
+        if (!member) throw new ORPCError("FORBIDDEN");
+        const roles = member.role.split(",").map((role) => role.trim());
         return { teamInstructions: workspace.teamInstructions, canEdit: roles.includes("owner") };
       }),
       update: authed.workspaceSettings.update.handler(async ({ context, input }) => {

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -2914,7 +2914,7 @@ msgid "Finished."
 msgstr "Fertig."
 
 #: src/pages/AccountSettingsOverlay.tsx
-msgid "Add instructions that should apply to every bot on the team"
+msgid "Applies to every bot"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx
@@ -2937,6 +2937,3 @@ msgstr ""
 msgid "Team instructions"
 msgstr ""
 
-#: src/pages/AccountSettingsOverlay.tsx
-msgid "These instructions are added before every bot's individual instructions."
-msgstr ""

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -2912,3 +2912,31 @@ msgstr "Gestoppt."
 #: src/lib/browser-notifications.ts
 msgid "Finished."
 msgstr "Fertig."
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Add instructions that should apply to every bot on the team"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't load team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't save team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Loading team instructions…"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Only workspace owners can edit team instructions."
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "These instructions are added before every bot's individual instructions."
+msgstr ""

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -2912,3 +2912,31 @@ msgstr "Stopped."
 #: src/lib/browser-notifications.ts
 msgid "Finished."
 msgstr "Finished."
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Add instructions that should apply to every bot on the team"
+msgstr "Add instructions that should apply to every bot on the team"
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't load team instructions"
+msgstr "Couldn't load team instructions"
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't save team instructions"
+msgstr "Couldn't save team instructions"
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Loading team instructions…"
+msgstr "Loading team instructions…"
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Only workspace owners can edit team instructions."
+msgstr "Only workspace owners can edit team instructions."
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Team instructions"
+msgstr "Team instructions"
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "These instructions are added before every bot's individual instructions."
+msgstr "These instructions are added before every bot's individual instructions."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -2914,8 +2914,8 @@ msgid "Finished."
 msgstr "Finished."
 
 #: src/pages/AccountSettingsOverlay.tsx
-msgid "Add instructions that should apply to every bot on the team"
-msgstr "Add instructions that should apply to every bot on the team"
+msgid "Applies to every bot"
+msgstr "Applies to every bot"
 
 #: src/pages/AccountSettingsOverlay.tsx
 msgid "Couldn't load team instructions"
@@ -2936,7 +2936,3 @@ msgstr "Only workspace owners can edit team instructions."
 #: src/pages/AccountSettingsOverlay.tsx
 msgid "Team instructions"
 msgstr "Team instructions"
-
-#: src/pages/AccountSettingsOverlay.tsx
-msgid "These instructions are added before every bot's individual instructions."
-msgstr "These instructions are added before every bot's individual instructions."

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -2912,3 +2912,31 @@ msgstr "रोक दिया गया।"
 #: src/lib/browser-notifications.ts
 msgid "Finished."
 msgstr "पूरा हुआ।"
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Add instructions that should apply to every bot on the team"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't load team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't save team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Loading team instructions…"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Only workspace owners can edit team instructions."
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "These instructions are added before every bot's individual instructions."
+msgstr ""

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -2914,7 +2914,7 @@ msgid "Finished."
 msgstr "पूरा हुआ।"
 
 #: src/pages/AccountSettingsOverlay.tsx
-msgid "Add instructions that should apply to every bot on the team"
+msgid "Applies to every bot"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx
@@ -2937,6 +2937,3 @@ msgstr ""
 msgid "Team instructions"
 msgstr ""
 
-#: src/pages/AccountSettingsOverlay.tsx
-msgid "These instructions are added before every bot's individual instructions."
-msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -2914,7 +2914,7 @@ msgid "Finished."
 msgstr "완료되었습니다."
 
 #: src/pages/AccountSettingsOverlay.tsx
-msgid "Add instructions that should apply to every bot on the team"
+msgid "Applies to every bot"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx
@@ -2937,6 +2937,3 @@ msgstr ""
 msgid "Team instructions"
 msgstr ""
 
-#: src/pages/AccountSettingsOverlay.tsx
-msgid "These instructions are added before every bot's individual instructions."
-msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -2912,3 +2912,31 @@ msgstr "중지되었습니다."
 #: src/lib/browser-notifications.ts
 msgid "Finished."
 msgstr "완료되었습니다."
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Add instructions that should apply to every bot on the team"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't load team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't save team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Loading team instructions…"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Only workspace owners can edit team instructions."
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "These instructions are added before every bot's individual instructions."
+msgstr ""

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -2914,7 +2914,7 @@ msgid "Finished."
 msgstr "Concluído."
 
 #: src/pages/AccountSettingsOverlay.tsx
-msgid "Add instructions that should apply to every bot on the team"
+msgid "Applies to every bot"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx
@@ -2937,6 +2937,3 @@ msgstr ""
 msgid "Team instructions"
 msgstr ""
 
-#: src/pages/AccountSettingsOverlay.tsx
-msgid "These instructions are added before every bot's individual instructions."
-msgstr ""

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -2912,3 +2912,31 @@ msgstr "Interrompido."
 #: src/lib/browser-notifications.ts
 msgid "Finished."
 msgstr "Concluído."
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Add instructions that should apply to every bot on the team"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't load team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't save team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Loading team instructions…"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Only workspace owners can edit team instructions."
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "These instructions are added before every bot's individual instructions."
+msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -2912,3 +2912,31 @@ msgstr "Durduruldu."
 #: src/lib/browser-notifications.ts
 msgid "Finished."
 msgstr "Tamamlandı."
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Add instructions that should apply to every bot on the team"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't load team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Couldn't save team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Loading team instructions…"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Only workspace owners can edit team instructions."
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "Team instructions"
+msgstr ""
+
+#: src/pages/AccountSettingsOverlay.tsx
+msgid "These instructions are added before every bot's individual instructions."
+msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -2914,7 +2914,7 @@ msgid "Finished."
 msgstr "Tamamlandı."
 
 #: src/pages/AccountSettingsOverlay.tsx
-msgid "Add instructions that should apply to every bot on the team"
+msgid "Applies to every bot"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx
@@ -2937,6 +2937,3 @@ msgstr ""
 msgid "Team instructions"
 msgstr ""
 
-#: src/pages/AccountSettingsOverlay.tsx
-msgid "These instructions are added before every bot's individual instructions."
-msgstr ""

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -16,6 +16,7 @@ import {
 } from "../components/ComputersUnavailableHint";
 import { SoftwareUpdateSection } from "../components/SoftwareUpdateSection";
 import { getActiveUiLocale, setUiLocale } from "../lib/i18n";
+import { rpc } from "../lib/rpc";
 import { UI_LOCALE_LABELS, UI_LOCALES, type UiLocale } from "../lib/ui-locale";
 
 export function AccountSettingsOverlay({
@@ -52,6 +53,31 @@ export function AccountSettingsOverlay({
   const localeRequestRef = useRef(0);
   const [avatarPending, setAvatarPending] = useState(false);
   const [avatarError, setAvatarError] = useState<string | null>(null);
+  const [teamInstructions, setTeamInstructions] = useState("");
+  const [savedTeamInstructions, setSavedTeamInstructions] = useState("");
+  const [canEditTeamInstructions, setCanEditTeamInstructions] = useState(false);
+  const [teamInstructionsStatus, setTeamInstructionsStatus] = useState<
+    "loading" | "idle" | "saving" | "saved" | "load-error" | "save-error"
+  >("loading");
+
+  useEffect(() => {
+    let active = true;
+    void rpc.workspaceSettings
+      .get()
+      .then((settings) => {
+        if (!active) return;
+        setTeamInstructions(settings.teamInstructions);
+        setSavedTeamInstructions(settings.teamInstructions);
+        setCanEditTeamInstructions(settings.canEdit);
+        setTeamInstructionsStatus("idle");
+      })
+      .catch(() => {
+        if (active) setTeamInstructionsStatus("load-error");
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     const previousFocus =
@@ -96,6 +122,19 @@ export function AccountSettingsOverlay({
     }
   }
 
+  async function saveTeamInstructions() {
+    if (!canEditTeamInstructions || teamInstructionsStatus === "saving") return;
+    setTeamInstructionsStatus("saving");
+    try {
+      const settings = await rpc.workspaceSettings.update({ teamInstructions });
+      setTeamInstructions(settings.teamInstructions);
+      setSavedTeamInstructions(settings.teamInstructions);
+      setTeamInstructionsStatus("saved");
+    } catch {
+      setTeamInstructionsStatus("save-error");
+    }
+  }
+
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-[rgba(4,4,5,.62)] p-4 sm:p-10">
       <div
@@ -131,6 +170,61 @@ export function AccountSettingsOverlay({
           {email ? <p className="mt-1 text-[13px] text-[#7A7A80]">{email}</p> : null}
         </section>
 
+        <section className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4">
+          <h3 className="text-[15px] font-medium text-[#ECECEE]">
+            <Trans>Team instructions</Trans>
+          </h3>
+          <p className="mt-2 text-[12.5px] text-[#7A7A80]">
+            <Trans>These instructions are added before every bot's individual instructions.</Trans>
+          </p>
+          <textarea
+            value={teamInstructions}
+            onChange={(event) => {
+              setTeamInstructions(event.target.value);
+              setTeamInstructionsStatus("idle");
+            }}
+            maxLength={20_000}
+            rows={6}
+            readOnly={!canEditTeamInstructions}
+            disabled={
+              teamInstructionsStatus === "loading" ||
+              teamInstructionsStatus === "saving" ||
+              !canEditTeamInstructions
+            }
+            aria-label={t`Team instructions`}
+            className="mt-3 w-full resize-y rounded-[12px] border border-[#303034] bg-[#0B0B0D] px-3 py-2.5 text-[13.5px] leading-5 text-[#ECECEE] outline-none focus:border-[#5A5A62] disabled:opacity-50"
+            placeholder={t`Add instructions that should apply to every bot on the team`}
+          />
+          <div className="mt-3 flex items-center justify-between gap-3">
+            <p className="text-[12px] text-[#7A7A80]" role="status">
+              {teamInstructionsStatus === "loading" ? (
+                <Trans>Loading team instructions…</Trans>
+              ) : teamInstructionsStatus === "load-error" ? (
+                <Trans>Couldn't load team instructions</Trans>
+              ) : teamInstructionsStatus === "save-error" ? (
+                <Trans>Couldn't save team instructions</Trans>
+              ) : teamInstructionsStatus === "saved" ? (
+                <Trans>Saved</Trans>
+              ) : !canEditTeamInstructions ? (
+                <Trans>Only workspace owners can edit team instructions.</Trans>
+              ) : null}
+            </p>
+            {canEditTeamInstructions ? (
+              <button
+                type="button"
+                onClick={() => void saveTeamInstructions()}
+                disabled={
+                  teamInstructionsStatus === "loading" ||
+                  teamInstructionsStatus === "saving" ||
+                  teamInstructions === savedTeamInstructions
+                }
+                className="rounded-full bg-[#ECECEE] px-4 py-2 text-[13px] font-medium text-[#151517] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {teamInstructionsStatus === "saving" ? <Trans>Saving…</Trans> : <Trans>Save</Trans>}
+              </button>
+            ) : null}
+          </div>
+        </section>
         {phoneEnabled && onOpenPhone ? (
           <section className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4">
             <h3 className="text-[15px] font-medium text-[#ECECEE]">

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -175,9 +175,6 @@ export function AccountSettingsOverlay({
           <h3 className="text-[15px] font-medium text-[#ECECEE]">
             <Trans>Team instructions</Trans>
           </h3>
-          <p className="mt-2 text-[12.5px] text-[#7A7A80]">
-            <Trans>These instructions are added before every bot's individual instructions.</Trans>
-          </p>
           <textarea
             value={teamInstructions}
             onChange={(event) => {
@@ -190,7 +187,7 @@ export function AccountSettingsOverlay({
             disabled={teamInstructionsStatus === "loading" || teamInstructionsStatus === "saving"}
             aria-label={t`Team instructions`}
             className="mt-3 w-full resize-y rounded-[12px] border border-[#303034] bg-[#0B0B0D] px-3 py-2.5 text-[13.5px] leading-5 text-[#ECECEE] outline-none focus:border-[#5A5A62] disabled:opacity-50"
-            placeholder={t`Add instructions that should apply to every bot on the team`}
+            placeholder={t`Applies to every bot`}
           />
           <div className="mt-3 flex items-center justify-between gap-3">
             <p className="text-[12px] text-[#7A7A80]" role="status">

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { ApprovalRulesSettings } from "../components/ApprovalRulesSettings";
+import { BuiButton, BuiCard } from "../components/beautiful-ui/primitives";
 import {
   ComputersUnavailableHint,
   computersAreUnavailable,
@@ -170,7 +171,7 @@ export function AccountSettingsOverlay({
           {email ? <p className="mt-1 text-[13px] text-[#7A7A80]">{email}</p> : null}
         </section>
 
-        <section className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4">
+        <BuiCard className="mt-5 border border-[#26262A] bg-[#101012] px-4 py-4">
           <h3 className="text-[15px] font-medium text-[#ECECEE]">
             <Trans>Team instructions</Trans>
           </h3>
@@ -186,11 +187,7 @@ export function AccountSettingsOverlay({
             maxLength={20_000}
             rows={6}
             readOnly={!canEditTeamInstructions}
-            disabled={
-              teamInstructionsStatus === "loading" ||
-              teamInstructionsStatus === "saving" ||
-              !canEditTeamInstructions
-            }
+            disabled={teamInstructionsStatus === "loading" || teamInstructionsStatus === "saving"}
             aria-label={t`Team instructions`}
             className="mt-3 w-full resize-y rounded-[12px] border border-[#303034] bg-[#0B0B0D] px-3 py-2.5 text-[13.5px] leading-5 text-[#ECECEE] outline-none focus:border-[#5A5A62] disabled:opacity-50"
             placeholder={t`Add instructions that should apply to every bot on the team`}
@@ -210,21 +207,20 @@ export function AccountSettingsOverlay({
               ) : null}
             </p>
             {canEditTeamInstructions ? (
-              <button
-                type="button"
+              <BuiButton
+                tone="accent"
                 onClick={() => void saveTeamInstructions()}
                 disabled={
                   teamInstructionsStatus === "loading" ||
                   teamInstructionsStatus === "saving" ||
                   teamInstructions === savedTeamInstructions
                 }
-                className="rounded-full bg-[#ECECEE] px-4 py-2 text-[13px] font-medium text-[#151517] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {teamInstructionsStatus === "saving" ? <Trans>Saving…</Trans> : <Trans>Save</Trans>}
-              </button>
+              </BuiButton>
             ) : null}
           </div>
-        </section>
+        </BuiCard>
         {phoneEnabled && onOpenPhone ? (
           <section className="mt-5 rounded-[14px] border border-[#26262A] bg-[#101012] px-4 py-4">
             <h3 className="text-[15px] font-medium text-[#ECECEE]">

--- a/packages/adapters/src/executor-runtime-tool-guard.test.ts
+++ b/packages/adapters/src/executor-runtime-tool-guard.test.ts
@@ -1,0 +1,262 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  AgentRunRequest,
+  AgentRuntime,
+  AgentRuntimeEvent,
+  ConnectorProvider,
+  MemoryStore,
+} from "@rakazo/adapter-kit";
+import type { PrismaClient } from "@rakazo/db";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRunExecutor } from "./executor.js";
+import { FakeSandboxProvider } from "./fake-sandbox.js";
+import { LocalAgentHomeStore } from "./home.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+function defectiveRuntime(options: {
+  scripted: boolean;
+  toolName: "recall_memory" | "save_memory";
+  results: unknown[];
+}): AgentRuntime {
+  return {
+    describe: () => ({
+      id: options.scripted ? "defective-scripted" : "defective-callback",
+      contractVersion: "1",
+      adapterVersion: "test",
+      capabilities: {
+        streaming: true,
+        compaction: false,
+        tools: true,
+        scripted: options.scripted,
+      },
+    }),
+    abort: vi.fn(async () => undefined),
+    async *run(request: AgentRunRequest): AsyncIterable<AgentRuntimeEvent> {
+      const args =
+        options.toolName === "recall_memory" ? { query: "launch" } : { content: "launch" };
+      const executionId = `run-1:${options.toolName}:0`;
+      if (options.scripted) {
+        yield { type: "tool", name: options.toolName, args, executionId };
+      } else {
+        options.results.push(await request.executeTool!(options.toolName, args, executionId));
+      }
+      yield { type: "done", text: "done" };
+    },
+  };
+}
+
+async function executorFixture(runtime: AgentRuntime) {
+  const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-runtime-tool-guard-"));
+  temporaryDirectories.push(dataDir);
+  const run = {
+    id: "run-1",
+    workspaceId: "workspace-1",
+    userId: "user-1",
+    botId: "bot-1",
+    threadId: "thread-1",
+    taskId: "task-1",
+    status: "queued",
+    trigger: "user",
+    routineId: null,
+    sourceMessageId: null,
+    checkpoint: null,
+    leaseFence: 0,
+  };
+  const computer = {
+    id: "computer-1",
+    homeKey: "bot-1",
+    providerRef: "computer-1",
+    kind: "fake",
+    scope: "dedicated",
+    state: "running",
+    controlLeaseId: null,
+    controlLeaseExpiresAt: null,
+  };
+  const bot = {
+    id: "bot-1",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    name: "Guard Bot",
+    title: "Tester",
+    description: "Tests runtime boundaries",
+    instructions: "Follow the request.",
+    modelProvider: null,
+    modelId: null,
+    thinkingLevel: null,
+    memoryScope: null,
+    computer,
+  };
+  const thread = {
+    id: "thread-1",
+    groupId: null,
+    historyCompactionSummary: null,
+    historyCompactedUpToSeq: null,
+    historyCompactionGeneration: 0,
+    nextMessageSeq: 1,
+  };
+  const runUpdateMany = vi.fn(async () => ({ count: 1 }));
+  const approvalRuleFindMany = vi.fn(async () => []);
+  const autoReviewFindUnique = vi.fn(async () => null);
+  const effectFindUnique = vi.fn(async () => null);
+  const effectCreate = vi.fn();
+  const effectUpdate = vi.fn();
+  const effectUpdateMany = vi.fn();
+  const prisma = {
+    run: {
+      findUnique: vi.fn(async (args: { select?: unknown }) =>
+        args.select ? { status: "running", leaseOwner: "worker-1", leaseFence: 1 } : run,
+      ),
+      findUniqueOrThrow: vi.fn(async () => ({ ...run, status: "leased", startedAt: null })),
+      updateMany: runUpdateMany,
+    },
+    bot: {
+      findUniqueOrThrow: vi.fn(async (args: { include?: unknown }) =>
+        args.include ? bot : { computerId: computer.id, computerSwitching: false },
+      ),
+      findMany: vi.fn(async () => []),
+    },
+    computer: {
+      findUniqueOrThrow: vi.fn(async () => computer),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+      update: vi.fn(async () => computer),
+    },
+    attempt: {
+      create: vi.fn(async () => ({ id: "attempt-1" })),
+      update: vi.fn(async () => ({ id: "attempt-1" })),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
+    thread: { findUniqueOrThrow: vi.fn(async () => thread) },
+    message: {
+      findMany: vi.fn(async () => []),
+      findUnique: vi.fn(async () => null),
+    },
+    task: { findUniqueOrThrow: vi.fn(async () => ({ id: "task-1", prompt: "test" })) },
+    connection: { findMany: vi.fn(async () => []) },
+    userModelCredential: { findFirst: vi.fn(async () => null) },
+    deploymentSettings: { findUnique: vi.fn(async () => null) },
+    organization: { findUniqueOrThrow: vi.fn(async () => ({ teamInstructions: "" })) },
+    taughtSkill: { findMany: vi.fn(async () => []) },
+    agentSkill: { findMany: vi.fn(async () => []) },
+    scratchpadItem: { findMany: vi.fn(async () => []) },
+    externalEffect: {
+      findMany: vi.fn(async () => []),
+      findUnique: effectFindUnique,
+      create: effectCreate,
+      update: effectUpdate,
+      updateMany: effectUpdateMany,
+    },
+    actionApprovalRule: { findMany: approvalRuleFindMany },
+    actionAutoReviewPreference: { findUnique: autoReviewFindUnique },
+  } as unknown as PrismaClient;
+  const finalizeRun = vi.fn(async () => true);
+  const events = {
+    append: vi.fn(async () => undefined),
+    notify: vi.fn(async () => undefined),
+    finalizeRun,
+  };
+  const memoryCommit = vi.fn();
+  const memory = {
+    read: vi.fn(async () => ({ documents: [] })),
+    commit: memoryCommit,
+  } as unknown as MemoryStore;
+  const connectorExecute = vi.fn(async function* () {
+    yield { type: "error" as const, message: "must not execute" };
+  });
+  const connector = {
+    discoverTools: vi.fn(async () => []),
+    execute: connectorExecute,
+  } as unknown as ConnectorProvider;
+  const executor = createRunExecutor({
+    prisma,
+    runtime,
+    sandbox: new FakeSandboxProvider(),
+    home: new LocalAgentHomeStore(dataDir),
+    memory,
+    memoryProviders: { resolve: vi.fn(async () => null) },
+    connector,
+    events: events as never,
+    jobs: {
+      enqueue: vi.fn(async () => undefined),
+      cancel: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    },
+    secrets: [],
+    secretStore: {} as never,
+    dataDir,
+  });
+
+  return {
+    executor,
+    finalizeRun,
+    memoryCommit,
+    connectorExecute,
+    approvalRuleFindMany,
+    autoReviewFindUnique,
+    effectFindUnique,
+    effectCreate,
+    effectUpdate,
+    effectUpdateMany,
+  };
+}
+
+function expectNoDispatchSideEffects(fixture: Awaited<ReturnType<typeof executorFixture>>): void {
+  expect(fixture.memoryCommit).not.toHaveBeenCalled();
+  expect(fixture.connectorExecute).not.toHaveBeenCalled();
+  expect(fixture.approvalRuleFindMany).not.toHaveBeenCalled();
+  expect(fixture.autoReviewFindUnique).not.toHaveBeenCalled();
+  expect(fixture.effectFindUnique).not.toHaveBeenCalled();
+  expect(fixture.effectCreate).not.toHaveBeenCalled();
+  expect(fixture.effectUpdate).not.toHaveBeenCalled();
+  expect(fixture.effectUpdateMany).not.toHaveBeenCalled();
+}
+
+describe("createRunExecutor runtime tool allowlist", () => {
+  it.each(["recall_memory", "save_memory"] as const)(
+    "contains a defective scripted %s event at the executor boundary",
+    async (toolName) => {
+      const runtimeResults: unknown[] = [];
+      const fixture = await executorFixture(
+        defectiveRuntime({ scripted: true, toolName, results: runtimeResults }),
+      );
+
+      await fixture.executor.continueRun("run-1", "worker-1");
+
+      expect(runtimeResults).toEqual([]);
+      expect(fixture.finalizeRun).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: "completed" }),
+      );
+      expectNoDispatchSideEffects(fixture);
+    },
+  );
+
+  it.each(["recall_memory", "save_memory"] as const)(
+    "returns a structured error when a defective non-scripted runtime invokes %s",
+    async (toolName) => {
+      const runtimeResults: unknown[] = [];
+      const fixture = await executorFixture(
+        defectiveRuntime({ scripted: false, toolName, results: runtimeResults }),
+      );
+
+      await fixture.executor.continueRun("run-1", "worker-1");
+
+      expect(runtimeResults).toEqual([
+        { error: `Tool "${toolName}" is not available for this run.` },
+      ]);
+      expect(fixture.finalizeRun).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: "completed" }),
+      );
+      expectNoDispatchSideEffects(fixture);
+    },
+  );
+});

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -1,7 +1,37 @@
 import { ONCE_ROUTINE_CRON } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
-import { createRunExecutor, runNotificationsEnabled, threadContextForRun } from "./executor.js";
+import {
+  composeBotInstructions,
+  createRunExecutor,
+  runNotificationsEnabled,
+  threadContextForRun,
+} from "./executor.js";
+
+describe("bot instruction composition", () => {
+  it("prepends team instructions exactly once before individual bot instructions", () => {
+    const teamInstructions = ["Use team terminology.", "Escalate security issues."].join(
+      String.fromCharCode(10),
+    );
+    const botInstructions = "Write concise release notes.";
+
+    const composed = composeBotInstructions(teamInstructions, botInstructions);
+
+    expect(composed).toBe([teamInstructions, botInstructions].join(String.fromCharCode(10, 10)));
+    expect(composed.split("Use team terminology.")).toHaveLength(2);
+  });
+
+  it("omits empty team instructions without changing individual bot instructions", () => {
+    expect(composeBotInstructions("", "  Keep this spacing.  ")).toBe("  Keep this spacing.  ");
+    expect(
+      composeBotInstructions([" ", " "].join(String.fromCharCode(10)), "Bot instructions"),
+    ).toBe("Bot instructions");
+  });
+
+  it("returns team instructions when individual bot instructions are empty", () => {
+    expect(composeBotInstructions("Team instructions", "")).toBe("Team instructions");
+  });
+});
 
 describe("run notification preference", () => {
   it("silences direct messages but leaves group notifications enabled", async () => {

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -33,14 +33,14 @@ describe("bot instruction composition", () => {
     expect(composeBotInstructions("Team instructions", "")).toBe("Team instructions");
   });
 
-  it("caps combined instructions at the bot instruction limit", () => {
-    const teamInstructions = "T".repeat(BOT_INSTRUCTIONS_MAX_LENGTH - 10);
+  it("preserves full team and bot instructions when both reach their limits", () => {
+    const teamInstructions = "T".repeat(BOT_INSTRUCTIONS_MAX_LENGTH);
     const botInstructions = "B".repeat(BOT_INSTRUCTIONS_MAX_LENGTH);
 
     const composed = composeBotInstructions(teamInstructions, botInstructions);
 
-    expect(composed).toHaveLength(BOT_INSTRUCTIONS_MAX_LENGTH);
-    expect(composed).toBe(`${teamInstructions}\n\n${"B".repeat(8)}`);
+    expect(composed).toHaveLength(BOT_INSTRUCTIONS_MAX_LENGTH * 2 + 2);
+    expect(composed).toBe(`${teamInstructions}\n\n${botInstructions}`);
   });
 });
 

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -1,3 +1,4 @@
+import { BOT_INSTRUCTIONS_MAX_LENGTH } from "@rakazo/contracts";
 import { ONCE_ROUTINE_CRON } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
@@ -30,6 +31,16 @@ describe("bot instruction composition", () => {
 
   it("returns team instructions when individual bot instructions are empty", () => {
     expect(composeBotInstructions("Team instructions", "")).toBe("Team instructions");
+  });
+
+  it("caps combined instructions at the bot instruction limit", () => {
+    const teamInstructions = "T".repeat(BOT_INSTRUCTIONS_MAX_LENGTH - 10);
+    const botInstructions = "B".repeat(BOT_INSTRUCTIONS_MAX_LENGTH);
+
+    const composed = composeBotInstructions(teamInstructions, botInstructions);
+
+    expect(composed).toHaveLength(BOT_INSTRUCTIONS_MAX_LENGTH);
+    expect(composed).toBe(`${teamInstructions}\n\n${"B".repeat(8)}`);
   });
 });
 

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -23,7 +23,11 @@ import {
   runContinueJob,
 } from "@rakazo/adapter-kit";
 import type { MessageBlock, RunStatus } from "@rakazo/contracts";
-import { ATTACHMENT_MAX_BYTES, isAttachmentImageMimeType } from "@rakazo/contracts";
+import {
+  ATTACHMENT_MAX_BYTES,
+  BOT_INSTRUCTIONS_MAX_LENGTH,
+  isAttachmentImageMimeType,
+} from "@rakazo/contracts";
 import {
   type ActionApprovalRule,
   appendTextSegment,
@@ -303,12 +307,13 @@ function tokenizeProtectedShellCommand(command: string): string[] | "dynamic" {
   }
 }
 
+/** Prepend workspace guidance without exceeding the bot-instruction payload limit. */
 export function composeBotInstructions(teamInstructions: string, botInstructions: string): string {
   if (!teamInstructions.trim()) return botInstructions;
   if (!botInstructions) return teamInstructions;
   return `${teamInstructions}
 
-${botInstructions}`;
+${botInstructions}`.slice(0, BOT_INSTRUCTIONS_MAX_LENGTH);
 }
 
 export function isProtectedComputerLifecycleCommand(command: string): boolean {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -23,11 +23,7 @@ import {
   runContinueJob,
 } from "@rakazo/adapter-kit";
 import type { MessageBlock, RunStatus } from "@rakazo/contracts";
-import {
-  ATTACHMENT_MAX_BYTES,
-  BOT_INSTRUCTIONS_MAX_LENGTH,
-  isAttachmentImageMimeType,
-} from "@rakazo/contracts";
+import { ATTACHMENT_MAX_BYTES, isAttachmentImageMimeType } from "@rakazo/contracts";
 import {
   type ActionApprovalRule,
   appendTextSegment,
@@ -307,13 +303,12 @@ function tokenizeProtectedShellCommand(command: string): string[] | "dynamic" {
   }
 }
 
-/** Prepend workspace guidance without exceeding the bot-instruction payload limit. */
 export function composeBotInstructions(teamInstructions: string, botInstructions: string): string {
   if (!teamInstructions.trim()) return botInstructions;
   if (!botInstructions) return teamInstructions;
   return `${teamInstructions}
 
-${botInstructions}`.slice(0, BOT_INSTRUCTIONS_MAX_LENGTH);
+${botInstructions}`;
 }
 
 export function isProtectedComputerLifecycleCommand(command: string): boolean {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -303,6 +303,14 @@ function tokenizeProtectedShellCommand(command: string): string[] | "dynamic" {
   }
 }
 
+export function composeBotInstructions(teamInstructions: string, botInstructions: string): string {
+  if (!teamInstructions.trim()) return botInstructions;
+  if (!botInstructions) return teamInstructions;
+  return `${teamInstructions}
+
+${botInstructions}`;
+}
+
 export function isProtectedComputerLifecycleCommand(command: string): boolean {
   const words = tokenizeProtectedShellCommand(command);
   if (words === "dynamic") return true;
@@ -742,6 +750,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           storedConnections,
           defaultCredential,
           settings,
+          workspace,
           configuredMemory,
           savedSkills,
           agentSkills,
@@ -774,6 +783,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
           }),
           findDefaultModelCredential(deps.prisma, run),
           deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
+          deps.prisma.organization.findUniqueOrThrow({
+            where: { id: run.workspaceId },
+            select: { teamInstructions: true },
+          }),
           deps.memoryProviders.resolve(run.workspaceId),
           deps.prisma.taughtSkill.findMany({
             where: { botId: run.botId, workspaceId: run.workspaceId, status: "saved" },
@@ -2463,7 +2476,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
               runId,
               prompt,
               instructions: [
-                bot.instructions || `${bot.name}: ${bot.title}\n${bot.description}`,
+                composeBotInstructions(
+                  workspace.teamInstructions,
+                  bot.instructions || `${bot.name}: ${bot.title}\n${bot.description}`,
+                ),
                 groupContext,
                 phoneContext,
                 memoryContext ? redactSecrets(memoryContext, runSecrets) : undefined,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -312,6 +312,18 @@ export function composeBotInstructions(teamInstructions: string, botInstructions
 ${botInstructions}`;
 }
 
+function createSelectedToolDispatcher(
+  selectedToolNames: ReadonlySet<string>,
+  dispatch: (name: string, args: Record<string, unknown>, executionId: string) => Promise<unknown>,
+) {
+  return async (name: string, args: Record<string, unknown>, executionId: string) => {
+    if (!selectedToolNames.has(name)) {
+      return { error: `Tool "${name}" is not available for this run.` };
+    }
+    return dispatch(name, args, executionId);
+  };
+}
+
 export function isProtectedComputerLifecycleCommand(command: string): boolean {
   const words = tokenizeProtectedShellCommand(command);
   if (words === "dynamic") return true;
@@ -1069,6 +1081,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           return autoReviewPreferencePromise;
         };
         const tools = [...builtins, ...exposedConnectorTools];
+        const selectedToolNames = new Set(tools.map((tool) => tool.name));
         const approvedEffects = await deps.prisma.externalEffect.findMany({
           where: { runId, status: "approved" },
           orderBy: APPROVED_EFFECT_REPLAY_ORDER,
@@ -1152,7 +1165,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           return secretPausedToolResult();
         };
 
-        const applyTool = async (
+        const dispatchTool = async (
           name: string,
           args: Record<string, unknown>,
           executionId: string,
@@ -2390,6 +2403,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           }
           return finish({ error: `unknown tool ${name}` });
         };
+        const applyTool = createSelectedToolDispatcher(selectedToolNames, dispatchTool);
 
         const pluginLine =
           connectedPlugins.length > 0

--- a/packages/adapters/src/scripted-runtime.test.ts
+++ b/packages/adapters/src/scripted-runtime.test.ts
@@ -41,25 +41,27 @@ describe("ScriptedAgentRuntime executionIds", () => {
   it("rejects scripted calls to tools that were not selected for the run", async () => {
     const runtime = new ScriptedAgentRuntime();
 
-    await expect(async () => {
-      for await (const _event of runtime.run({
-        botId: "bot-1",
-        threadId: "thread-1",
-        runId: "run-unselected-tool",
-        prompt: "ping",
-        instructions: "",
-        history: [],
-        tools: [],
-        model: { provider: "scripted", id: "scripted" },
-        script: [
-          {
-            toolCalls: [{ name: "recall_memory", args: { query: "private context" } }],
-            complete: true,
-          },
-        ],
-      })) {
-        // Consume the stream so runtime errors are observed.
-      }
-    }).rejects.toThrow('Scripted tool "recall_memory" is not available for this run');
+    await expect(
+      (async () => {
+        for await (const _event of runtime.run({
+          botId: "bot-1",
+          threadId: "thread-1",
+          runId: "run-unselected-tool",
+          prompt: "ping",
+          instructions: "",
+          history: [],
+          tools: [],
+          model: { provider: "scripted", id: "scripted" },
+          script: [
+            {
+              toolCalls: [{ name: "recall_memory", args: { query: "private context" } }],
+              complete: true,
+            },
+          ],
+        })) {
+          // Consume the stream so runtime errors are observed.
+        }
+      })(),
+    ).rejects.toThrow('Scripted tool "recall_memory" is not available for this run');
   });
 });

--- a/packages/adapters/src/scripted-runtime.test.ts
+++ b/packages/adapters/src/scripted-runtime.test.ts
@@ -2,6 +2,8 @@ import type { AgentRuntimeEvent } from "@rakazo/adapter-kit";
 import { describe, expect, it } from "vitest";
 import { ScriptedAgentRuntime } from "./scripted-runtime.js";
 
+const tool = (name: string) => ({ name, description: name, inputSchema: {} });
+
 describe("ScriptedAgentRuntime executionIds", () => {
   it("gives repeated tools distinct executionIds within a run", async () => {
     const runtime = new ScriptedAgentRuntime();
@@ -13,7 +15,7 @@ describe("ScriptedAgentRuntime executionIds", () => {
       prompt: "ping",
       instructions: "",
       history: [],
-      tools: [],
+      tools: [tool("message_agent")],
       model: { provider: "scripted", id: "scripted" },
       script: [
         {
@@ -34,5 +36,30 @@ describe("ScriptedAgentRuntime executionIds", () => {
       )
       .map((event) => event.executionId);
     expect(toolIds).toEqual(["run-1:message_agent:0", "run-1:message_agent:1"]);
+  });
+
+  it("rejects scripted calls to tools that were not selected for the run", async () => {
+    const runtime = new ScriptedAgentRuntime();
+
+    await expect(async () => {
+      for await (const _event of runtime.run({
+        botId: "bot-1",
+        threadId: "thread-1",
+        runId: "run-unselected-tool",
+        prompt: "ping",
+        instructions: "",
+        history: [],
+        tools: [],
+        model: { provider: "scripted", id: "scripted" },
+        script: [
+          {
+            toolCalls: [{ name: "recall_memory", args: { query: "private context" } }],
+            complete: true,
+          },
+        ],
+      })) {
+        // Consume the stream so runtime errors are observed.
+      }
+    }).rejects.toThrow('Scripted tool "recall_memory" is not available for this run');
   });
 });

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -44,6 +44,7 @@ export class ScriptedAgentRuntime implements AgentRuntime {
         return;
       }
       const script = request.script ?? inferScript(request.prompt, request.resumeFromCheckpoint);
+      const availableToolNames = new Set(request.tools.map((tool) => tool.name));
       // Per-run call index so repeated tools (e.g. message_agent) get distinct
       // executionIds — delivery keys and effect replays key off this value.
       let toolCallSeq = 0;
@@ -57,6 +58,9 @@ export class ScriptedAgentRuntime implements AgentRuntime {
           yield { type: "text", text: turn.assistant };
         }
         for (const call of turn.toolCalls ?? []) {
+          if (!availableToolNames.has(call.name)) {
+            throw new Error(`Scripted tool "${call.name}" is not available for this run`);
+          }
           const executionId = `${request.runId}:${call.name}:${toolCallSeq++}`;
           if (call.name === "run_subagent") {
             const agentId = `${request.runId}:subagent`;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -10,6 +10,7 @@ import {
   ArtifactSchema,
   ArtifactWithContentSchema,
   AvatarStyleSchema,
+  BOT_INSTRUCTIONS_MAX_LENGTH,
   BotMcpServerSchema,
   BotSchema,
   BotSectionSchema,
@@ -124,6 +125,12 @@ export const appContract = {
   me: oc.output(MeSchema),
   preferences: {
     update: oc.input(z.object({ avatarStyle: AvatarStyleSchema })).output(MeSchema),
+  },
+  workspaceSettings: {
+    get: oc.output(z.object({ teamInstructions: z.string(), canEdit: z.boolean() })),
+    update: oc
+      .input(z.object({ teamInstructions: z.string().max(BOT_INSTRUCTIONS_MAX_LENGTH) }))
+      .output(z.object({ teamInstructions: z.string(), canEdit: z.literal(true) })),
   },
   bootstrap: oc.input(z.object({ botId: Id.optional() })).output(AppBootstrapSchema),
   deployment: {

--- a/packages/db/prisma/migrations/20260830191000_team_instructions/migration.sql
+++ b/packages/db/prisma/migrations/20260830191000_team_instructions/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organization" ADD COLUMN "teamInstructions" TEXT NOT NULL DEFAULT '';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -83,6 +83,7 @@ model Verification {
 
 model Organization {
   id          String       @id
+  teamInstructions String   @default("")
   name        String
   slug        String
   logo        String?


### PR DESCRIPTION
## Summary
- add workspace-scoped team instructions that are prepended to every bot's individual instructions at run time
- add a **Team instructions** text area to Settings
- allow workspace owners to edit the value while other workspace members can view it read-only
- keep existing behavior unchanged when the setting is empty

## Behavior and UX
- stored once per workspace/team on `Organization.teamInstructions`
- capped at the existing 20,000-character bot-instruction limit
- fetched when Settings opens and saved explicitly with loading, saved, and error states
- composed as `team instructions`, a blank line, then the bot's own instructions
- changes apply to subsequent runs; they do not rewrite individual bot records or existing transcripts
- a migration adds the non-null column with an empty-string default, so existing workspaces remain unaffected

## Authorization
- all workspace members can read the team instructions
- only members with the workspace `owner` role can update them
- the API re-checks ownership server-side; the disabled/read-only UI is not the authorization boundary

## Tests
- `pnpm exec vitest run apps/api/src/router.test.ts packages/adapters/src/executor.test.ts --reporter=dot` — 33 passed
- `pnpm exec vitest run apps/web/src/lib/i18n-catalog.test.ts --reporter=dot` — 3 passed
- `pnpm db:generate`
- `pnpm check` — 20/20 tasks passed
- Biome check on changed TypeScript/Prisma files — passed
- `git diff --check` — passed

## Notes
- new UI strings are registered in every shipped locale catalog; untranslated locales use the existing source-string fallback
- this PR is intentionally draft-only for product/UX review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace-level team instructions in Account Settings.
  - Workspace owners can create, edit, and save instructions; other members can view them.
  - Team instructions are applied before each bot’s individual instructions.
  - Added loading, saving, and error feedback.
  - Instructions support multiline text, empty values, and up to 20,000 characters.

- **Bug Fixes**
  - Prevented unauthorized access without workspace membership.
  - Prevented runs from invoking unselected tools.

- **Tests**
  - Added coverage for permissions, persistence, validation, and instruction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->