### PR TITLE
fix: persist replaced providerRef in reconnectComputer

### DIFF
--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -100,6 +100,64 @@ describe("computer provisioning", () => {
     }
   });
 
+  it("updates computer providerRef if reconnect provisions a different ref", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-provision-reconnect-update-"));
+    const ref = {
+      id: "provider-2",
+      botId: "bot-1",
+      kind: "cloud" as const,
+      providerRef: "provider-2",
+      fresh: false,
+    };
+    const prepare = vi.fn().mockResolvedValue(undefined);
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "provider-1",
+          kind: "cloud",
+          scope: "dedicated",
+          state: "running",
+          controlLeaseId: null,
+        }),
+        updateMany: vi.fn(),
+        update: vi.fn(),
+      },
+    } as unknown as PrismaClient;
+    const sandbox = {
+      provision: vi.fn().mockResolvedValue(ref),
+      prepare,
+    } as unknown as SandboxProvider;
+
+    try {
+      await expect(
+        provisionComputer(
+          {
+            prisma,
+            sandbox,
+            home: {} as AgentHomeStore,
+            jobs: {} as JobPublisher,
+            events: {} as ThreadEvents,
+            dataDir,
+          },
+          "computer-1",
+          context,
+        ),
+      ).resolves.toEqual(ref);
+      expect(prepare).toHaveBeenCalledWith(ref, context);
+      expect(prisma.computer.update).toHaveBeenCalledWith({
+        where: { id: "computer-1" },
+        data: {
+          providerRef: "provider-2",
+          kind: "cloud",
+        },
+      });
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     { fresh: true, cleanup: "destroy" as const },
     { fresh: false, cleanup: "stop" as const },
@@ -308,6 +366,7 @@ describe("computer provisioning", () => {
           controlLeaseId: null,
         }),
         updateMany: vi.fn(),
+        update: vi.fn(),
       },
     } as unknown as PrismaClient;
     const sandbox = {
@@ -332,6 +391,7 @@ describe("computer provisioning", () => {
       ).resolves.toEqual(ref);
       expect(prepare).toHaveBeenCalledWith(ref, context);
       expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+      expect(prisma.computer.update).not.toHaveBeenCalled();
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -161,11 +161,13 @@ export async function provisionComputer(
 
 async function reconnectComputer(
   deps: {
+    prisma: PrismaClient;
     sandbox: SandboxProvider;
     home: AgentHomeStore;
     dataDir?: string;
   },
   computer: {
+    id: string;
     homeKey: string;
     providerRef: string | null;
     kind: string;
@@ -191,6 +193,15 @@ async function reconnectComputer(
     context.botId,
     context,
   );
+  if (ref.providerRef !== computer.providerRef || ref.kind !== computer.kind) {
+    await deps.prisma.computer.update({
+      where: { id: computer.id },
+      data: {
+        providerRef: ref.providerRef,
+        kind: ref.kind,
+      },
+    });
+  }
   return ref;
 }
 


### PR DESCRIPTION
Root cause: When a docker container is rebuilt and provisioned, the supervisor creates a new container (with a new container ID) but `reconnectComputer` never writes the newly provisioned container ID (the `providerRef`) back to the database. This leads to subsequent 404s when attempting to control the computer since the stored ID becomes stale.
Fix: Modified `reconnectComputer` in `packages/adapters/src/computer-lifecycle.ts` to take `prisma` and the computer's `id`. We then compare the old `providerRef` and `kind` to the newly provisioned ones. If they differ, an explicit update is made to persist the changes. Tests were updated and added.
Validation: pnpm check, pnpm lint, pnpm test
Fixes https://github.com/elie222/rakazo/issues/396

Fixes #396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved computer reconnection handling when the provisioning provider returns updated computer details.
  * Ensured refreshed provider information is saved so subsequent lifecycle operations use the latest configuration.
  * Avoided unnecessary updates when the computer’s existing provider details are already current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->