### PR TITLE
fix: suppress Chromium restore pages bubble on crash

### DIFF
--- a/infra/sandboxes/computer/rakazo-browser
+++ b/infra/sandboxes/computer/rakazo-browser
@@ -25,15 +25,22 @@ for arg in "$@"; do
   esac
 done
 
+clear_crash_state() {
+  f="$1"
+  [ -f "$f" ] || return 0
+  sed -E \
+    's/"exit_type"[[:space:]]*:[[:space:]]*"Crashed"/"exit_type":"Normal"/g; s/"exited_cleanly"[[:space:]]*:[[:space:]]*false/"exited_cleanly":true/g' \
+    "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+}
+
 if [ -d "$ACTUAL_PROFILE" ]; then
-  # Silence errors with 2>/dev/null in case directory is unreadable or find fails
-  find "$ACTUAL_PROFILE" -name "Preferences" -type f 2>/dev/null | while read -r pref_file; do
-    sed 's/"exit_type":"Crashed"/"exit_type":"Normal"/g; s/"exited_cleanly":false/"exited_cleanly":true/g' "$pref_file" > "${pref_file}.tmp"
-    mv "${pref_file}.tmp" "$pref_file"
-  done
+  find "$ACTUAL_PROFILE" \( -name Preferences -o -name 'Local State' \) -type f 2>/dev/null |
+    while IFS= read -r f; do
+      clear_crash_state "$f" 2>/dev/null || rm -f "${f}.tmp"
+    done || true
 fi
 
-FLAGS="--test-type --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer --no-first-run --no-default-browser-check --disable-session-crashed-bubble --password-store=basic --start-maximized"
+FLAGS="--test-type --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer --no-first-run --no-default-browser-check --disable-session-crashed-bubble --hide-crash-restore-bubble --password-store=basic --start-maximized"
 if [ "$USER_DATA_DIR_SET" -eq 0 ]; then
   exec "$BIN" $FLAGS --user-data-dir="$PROFILE" "$@"
 fi

--- a/infra/sandboxes/computer/rakazo-browser
+++ b/infra/sandboxes/computer/rakazo-browser
@@ -33,7 +33,7 @@ clear_crash_state() {
     "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
 }
 
-if [ -d "$ACTUAL_PROFILE" ]; then
+if [ -d "$ACTUAL_PROFILE" ] && [ ! -e "$ACTUAL_PROFILE/SingletonLock" ]; then
   find "$ACTUAL_PROFILE" \( -name Preferences -o -name 'Local State' \) -type f 2>/dev/null |
     while IFS= read -r f; do
       clear_crash_state "$f" 2>/dev/null || rm -f "${f}.tmp"

--- a/infra/sandboxes/computer/rakazo-browser
+++ b/infra/sandboxes/computer/rakazo-browser
@@ -33,7 +33,7 @@ clear_crash_state() {
     "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
 }
 
-if [ -d "$ACTUAL_PROFILE" ] && [ ! -e "$ACTUAL_PROFILE/SingletonLock" ]; then
+if [ -d "$ACTUAL_PROFILE" ] && [ ! -e "$ACTUAL_PROFILE/SingletonLock" ] && [ ! -L "$ACTUAL_PROFILE/SingletonLock" ]; then
   find "$ACTUAL_PROFILE" \( -name Preferences -o -name 'Local State' \) -type f 2>/dev/null |
     while IFS= read -r f; do
       clear_crash_state "$f" 2>/dev/null || rm -f "${f}.tmp"

--- a/infra/sandboxes/computer/rakazo-browser
+++ b/infra/sandboxes/computer/rakazo-browser
@@ -12,11 +12,27 @@ if [ -z "$BIN" ]; then
   exit 1
 fi
 USER_DATA_DIR_SET=0
+ACTUAL_PROFILE="$PROFILE"
+PREV_ARG_WAS_USER_DATA_DIR=0
 for arg in "$@"; do
+  if [ "$PREV_ARG_WAS_USER_DATA_DIR" -eq 1 ]; then
+    ACTUAL_PROFILE="$arg"
+    PREV_ARG_WAS_USER_DATA_DIR=0
+  fi
   case "$arg" in
-    --user-data-dir|--user-data-dir=*) USER_DATA_DIR_SET=1 ;;
+    --user-data-dir=*) ACTUAL_PROFILE="${arg#*=}"; USER_DATA_DIR_SET=1 ;;
+    --user-data-dir) PREV_ARG_WAS_USER_DATA_DIR=1; USER_DATA_DIR_SET=1 ;;
   esac
 done
+
+if [ -d "$ACTUAL_PROFILE" ]; then
+  # Silence errors with 2>/dev/null in case directory is unreadable or find fails
+  find "$ACTUAL_PROFILE" -name "Preferences" -type f 2>/dev/null | while read -r pref_file; do
+    sed 's/"exit_type":"Crashed"/"exit_type":"Normal"/g; s/"exited_cleanly":false/"exited_cleanly":true/g' "$pref_file" > "${pref_file}.tmp"
+    mv "${pref_file}.tmp" "$pref_file"
+  done
+fi
+
 FLAGS="--test-type --no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer --no-first-run --no-default-browser-check --disable-session-crashed-bubble --password-store=basic --start-maximized"
 if [ "$USER_DATA_DIR_SET" -eq 0 ]; then
   exec "$BIN" $FLAGS --user-data-dir="$PROFILE" "$@"

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -251,6 +251,22 @@ describe("graphical computer spec", () => {
           encoding: "utf8",
         });
         expect(skipped.status, skipped.error?.message ?? skipped.stderr).toBe(0);
+        expect(readFileSync(prefsPath, "utf8")).toContain("Crashed");
+
+        rmSync(path.join(profile, "SingletonLock"), { force: true });
+        writeFileSync(prefsPath, '{\n  "profile": {\n    "exit_type": "Crashed"\n  }\n}\n');
+        symlinkSync("testhost-12345", path.join(profile, "SingletonLock"));
+        const skippedLink = spawnSync("bash", [path.join(root, "rakazo-browser")], {
+          env: {
+            ...process.env,
+            DISPLAY: ":1",
+            HOME: home,
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+            RAKAZO_TEST_ARGS: capture,
+          },
+          encoding: "utf8",
+        });
+        expect(skippedLink.status, skippedLink.error?.message ?? skippedLink.stderr).toBe(0);
         expect(readFileSync(prefsPath, "utf8")).toContain("Crashed");
       } finally {
         rmSync(temp, { recursive: true, force: true });

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -184,42 +184,64 @@ describe("graphical computer spec", () => {
     },
   );
 
-  it("clears crashed state from Chromium preferences", () => {
-    const root = path.resolve(import.meta.dirname, "../../computer");
-    const temp = mkdtempSync(path.join(tmpdir(), "rakazo-browser-crash-"));
-    const bin = path.join(temp, "bin");
-    const home = path.join(temp, "home");
-    const chromium = path.join(bin, "chromium");
-    mkdirSync(bin);
-    writeFileSync(chromium, "#!/bin/sh\nexit 0\n");
-    chmodSync(chromium, 0o755);
+  it.skipIf(process.platform === "win32")(
+    "clears crashed state from Chromium preferences and Local State",
+    () => {
+      const root = path.resolve(import.meta.dirname, "../../computer");
+      const temp = mkdtempSync(path.join(tmpdir(), "rakazo-browser-crash-"));
+      const bin = path.join(temp, "bin");
+      const home = path.join(temp, "home");
+      const chromium = path.join(bin, "chromium");
+      const capture = path.join(temp, "args");
+      mkdirSync(bin);
+      writeFileSync(chromium, '#!/bin/sh\nprintf "%s\\n" "$@" > "$RAKAZO_TEST_ARGS"\n');
+      chmodSync(chromium, 0o755);
 
-    const prefsDir = path.join(home, ".browser-profiles/chromium/Default");
-    mkdirSync(prefsDir, { recursive: true });
-    const prefsPath = path.join(prefsDir, "Preferences");
-    writeFileSync(prefsPath, '{"profile":{"exit_type":"Crashed","exited_cleanly":false}}');
+      const profile = path.join(home, ".browser-profiles/chromium");
+      const prefsDir = path.join(profile, "Default");
+      mkdirSync(prefsDir, { recursive: true });
+      const prefsPath = path.join(prefsDir, "Preferences");
+      const localStatePath = path.join(profile, "Local State");
+      writeFileSync(
+        prefsPath,
+        '{\n  "profile": {\n    "exit_type": "Crashed",\n    "exited_cleanly": false\n  }\n}\n',
+      );
+      writeFileSync(
+        localStatePath,
+        '{\n  "profile": {\n    "exited_cleanly": false\n  }\n}\n',
+      );
 
-    try {
-      const result = spawnSync("bash", [path.join(root, "rakazo-browser")], {
-        env: {
-          ...process.env,
-          DISPLAY: ":1",
-          HOME: home,
-          PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
-        },
-        encoding: "utf8",
-      });
-      expect(result.status, result.error?.message ?? result.stderr).toBe(0);
+      try {
+        const result = spawnSync("bash", [path.join(root, "rakazo-browser")], {
+          env: {
+            ...process.env,
+            DISPLAY: ":1",
+            HOME: home,
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+            RAKAZO_TEST_ARGS: capture,
+          },
+          encoding: "utf8",
+        });
+        expect(result.status, result.error?.message ?? result.stderr).toBe(0);
 
-      const updatedPrefs = readFileSync(prefsPath, "utf8");
-      expect(updatedPrefs).toContain('"exit_type":"Normal"');
-      expect(updatedPrefs).toContain('"exited_cleanly":true');
-      expect(updatedPrefs).not.toContain('"exit_type":"Crashed"');
-      expect(updatedPrefs).not.toContain('"exited_cleanly":false');
-    } finally {
-      rmSync(temp, { recursive: true, force: true });
-    }
-  });
+        const flags = readFileSync(capture, "utf8");
+        expect(flags).toMatch(/--hide-crash-restore-bubble/);
+        expect(flags).toMatch(/--disable-session-crashed-bubble/);
+
+        const updatedPrefs = readFileSync(prefsPath, "utf8");
+        expect(updatedPrefs).toContain('"exit_type":"Normal"');
+        expect(updatedPrefs).toContain('"exited_cleanly":true');
+        expect(updatedPrefs).not.toContain("Crashed");
+        expect(updatedPrefs).not.toMatch(/"exited_cleanly"\s*:\s*false/);
+
+        const updatedLocalState = readFileSync(localStatePath, "utf8");
+        expect(updatedLocalState).toContain('"exited_cleanly":true');
+        expect(updatedLocalState).not.toMatch(/"exited_cleanly"\s*:\s*false/);
+      } finally {
+        rmSync(temp, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("keeps container names stable so a bot can resume", () => {
     expect(containerNameFor("bot_1")).toBe("rakazo-bot-bot_1");

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -184,6 +184,43 @@ describe("graphical computer spec", () => {
     },
   );
 
+  it("clears crashed state from Chromium preferences", () => {
+    const root = path.resolve(import.meta.dirname, "../../computer");
+    const temp = mkdtempSync(path.join(tmpdir(), "rakazo-browser-crash-"));
+    const bin = path.join(temp, "bin");
+    const home = path.join(temp, "home");
+    const chromium = path.join(bin, "chromium");
+    mkdirSync(bin);
+    writeFileSync(chromium, "#!/bin/sh\nexit 0\n");
+    chmodSync(chromium, 0o755);
+
+    const prefsDir = path.join(home, ".browser-profiles/chromium/Default");
+    mkdirSync(prefsDir, { recursive: true });
+    const prefsPath = path.join(prefsDir, "Preferences");
+    writeFileSync(prefsPath, '{"profile":{"exit_type":"Crashed","exited_cleanly":false}}');
+
+    try {
+      const result = spawnSync("bash", [path.join(root, "rakazo-browser")], {
+        env: {
+          ...process.env,
+          DISPLAY: ":1",
+          HOME: home,
+          PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+        encoding: "utf8",
+      });
+      expect(result.status, result.error?.message ?? result.stderr).toBe(0);
+
+      const updatedPrefs = readFileSync(prefsPath, "utf8");
+      expect(updatedPrefs).toContain('"exit_type":"Normal"');
+      expect(updatedPrefs).toContain('"exited_cleanly":true');
+      expect(updatedPrefs).not.toContain('"exit_type":"Crashed"');
+      expect(updatedPrefs).not.toContain('"exited_cleanly":false');
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
   it("keeps container names stable so a bot can resume", () => {
     expect(containerNameFor("bot_1")).toBe("rakazo-bot-bot_1");
     expect(containerNameFor("bot_1")).toBe(containerNameFor("bot_1"));

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -244,7 +244,7 @@ describe("graphical computer spec", () => {
         expect(updatedLocalState).not.toMatch(/"exited_cleanly"\s*:\s*false/);
 
         writeFileSync(prefsPath, '{\n  "profile": {\n    "exit_type": "Crashed"\n  }\n}\n');
-        writeFileSync(path.join(profile, "SingletonLock"), "");
+        symlinkSync("testhost-12345", path.join(profile, "SingletonLock"));
         const skipped = spawnSync("bash", [path.join(root, "rakazo-browser")], {
           env: {
             ...process.env,
@@ -256,22 +256,6 @@ describe("graphical computer spec", () => {
           encoding: "utf8",
         });
         expect(skipped.status, skipped.error?.message ?? skipped.stderr).toBe(0);
-        expect(readFileSync(prefsPath, "utf8")).toContain("Crashed");
-
-        rmSync(path.join(profile, "SingletonLock"), { force: true });
-        writeFileSync(prefsPath, '{\n  "profile": {\n    "exit_type": "Crashed"\n  }\n}\n');
-        symlinkSync("testhost-12345", path.join(profile, "SingletonLock"));
-        const skippedLink = spawnSync("bash", [path.join(root, "rakazo-browser")], {
-          env: {
-            ...process.env,
-            DISPLAY: ":1",
-            HOME: home,
-            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
-            RAKAZO_TEST_ARGS: capture,
-          },
-          encoding: "utf8",
-        });
-        expect(skippedLink.status, skippedLink.error?.message ?? skippedLink.stderr).toBe(0);
         expect(readFileSync(prefsPath, "utf8")).toContain("Crashed");
       } finally {
         rmSync(temp, { recursive: true, force: true });

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -206,10 +214,7 @@ describe("graphical computer spec", () => {
         prefsPath,
         '{\n  "profile": {\n    "exit_type": "Crashed",\n    "exited_cleanly": false\n  }\n}\n',
       );
-      writeFileSync(
-        localStatePath,
-        '{\n  "profile": {\n    "exited_cleanly": false\n  }\n}\n',
-      );
+      writeFileSync(localStatePath, '{\n  "profile": {\n    "exited_cleanly": false\n  }\n}\n');
 
       try {
         const result = spawnSync("bash", [path.join(root, "rakazo-browser")], {

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -237,6 +237,21 @@ describe("graphical computer spec", () => {
         const updatedLocalState = readFileSync(localStatePath, "utf8");
         expect(updatedLocalState).toContain('"exited_cleanly":true');
         expect(updatedLocalState).not.toMatch(/"exited_cleanly"\s*:\s*false/);
+
+        writeFileSync(prefsPath, '{\n  "profile": {\n    "exit_type": "Crashed"\n  }\n}\n');
+        writeFileSync(path.join(profile, "SingletonLock"), "");
+        const skipped = spawnSync("bash", [path.join(root, "rakazo-browser")], {
+          env: {
+            ...process.env,
+            DISPLAY: ":1",
+            HOME: home,
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+            RAKAZO_TEST_ARGS: capture,
+          },
+          encoding: "utf8",
+        });
+        expect(skipped.status, skipped.error?.message ?? skipped.stderr).toBe(0);
+        expect(readFileSync(prefsPath, "utf8")).toContain("Crashed");
       } finally {
         rmSync(temp, { recursive: true, force: true });
       }


### PR DESCRIPTION
Root cause: Chromium does not reliably suppress the "Restore pages? Chromium didn't shut down correctly" bubble with `--disable-session-crashed-bubble` when using a persistent profile across container recreations/crashes.
Fix: Modified `rakazo-browser` wrapper script to locate the active `Preferences` file and forcefully use `sed` to reset `"exit_type":"Crashed"` to `"Normal"` and `"exited_cleanly":false` to `true` before starting Chromium.
Validation: Ran `pnpm check`, `pnpm lint`, and `pnpm test`, adding a test suite in `infra/sandboxes/supervisor/src/computer-spec.test.ts` to verify the state cleanup logic behavior.

Fixes https://github.com/elie222/rakazo/issues/398

Fixes #398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser startup recovery by clearing stale crash-session status from existing profiles.
  * Updates profile and browser state to prevent unnecessary crash-restore prompts.
  * Supports both standard forms of the user-data directory option.
  * Preserves crash information when another browser instance is using the profile, including cases with dangling lock links.
  * Suppresses the crash-restore bubble during launch.

* **Tests**
  * Added coverage for startup flags, profile recovery, and active-profile safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->