### PR TITLE
fix: allow Tailscale MagicDNS hosts in integration URLs

### DIFF
--- a/packages/adapters/src/network-address.ts
+++ b/packages/adapters/src/network-address.ts
@@ -5,12 +5,12 @@ export type ResolveHostname = (hostname: string) => Promise<ResolvedAddress[]>;
 
 export function createAddressCheckedLookup(
   resolve: ResolveHostname,
-  validate: (addresses: ResolvedAddress[]) => void,
+  validate: (addresses: ResolvedAddress[], hostname: string) => void,
 ): LookupFunction {
   return (hostname, options, callback) => {
     void resolve(hostname)
       .then((addresses) => {
-        validate(addresses);
+        validate(addresses, hostname);
         if (options.all) {
           callback(null, addresses);
           return;

--- a/packages/adapters/src/remote-mcp.test.ts
+++ b/packages/adapters/src/remote-mcp.test.ts
@@ -60,6 +60,24 @@ describe("remote MCP URL policy", () => {
     ).rejects.toThrow(/private host/i);
   });
 
+  it("rejects MagicDNS hosts that resolve outside Tailscale CGNAT", async () => {
+    await expect(
+      assertSafeRemoteUrl("https://api.tail12345.ts.net/openapi.json", async () => [
+        { address: "127.0.0.1", family: 4 as const },
+      ]),
+    ).rejects.toThrow("private address");
+    await expect(
+      assertSafeRemoteUrl("https://api.tail12345.ts.net/openapi.json", async () => [
+        { address: "10.1.2.3", family: 4 as const },
+      ]),
+    ).rejects.toThrow("private address");
+    await expect(
+      assertSafeRemoteUrl("https://api.tail12345.ts.net/openapi.json", async () => [
+        { address: "169.254.169.254", family: 4 as const },
+      ]),
+    ).rejects.toThrow("private address");
+  });
+
   it("rejects private addresses in the lookup used by the network connection", async () => {
     const safeLookup = createSafeLookup(async () => [{ address: "10.1.2.3", family: 4 }]);
     const error = await new Promise<Error | null>((resolve) => {

--- a/packages/adapters/src/remote-mcp.test.ts
+++ b/packages/adapters/src/remote-mcp.test.ts
@@ -38,6 +38,28 @@ describe("remote MCP URL policy", () => {
     ).rejects.toThrow("private address");
   });
 
+  it("allows Tailscale MagicDNS hosts that resolve to CGNAT addresses", async () => {
+    const magicDns = "https://api.tail12345.ts.net/openapi.json";
+    await expect(
+      assertSafeRemoteUrl(magicDns, async () => [{ address: "100.64.1.2", family: 4 as const }]),
+    ).resolves.toEqual(new URL(magicDns));
+
+    const safeLookup = createSafeLookup(async () => [{ address: "100.119.57.55", family: 4 }]);
+    const result = await new Promise<{ address: string; family?: number }>((resolve, reject) => {
+      safeLookup("box.tail12345.ts.net", { family: 0, all: false }, (error, address, family) => {
+        if (error) reject(error);
+        else resolve({ address: String(address), family });
+      });
+    });
+    expect(result).toEqual({ address: "100.119.57.55", family: 4 });
+  });
+
+  it("still rejects raw Tailscale CGNAT IP literals", async () => {
+    await expect(
+      assertSafeRemoteUrl("https://100.64.1.2/openapi.json", publicResolver),
+    ).rejects.toThrow(/private host/i);
+  });
+
   it("rejects private addresses in the lookup used by the network connection", async () => {
     const safeLookup = createSafeLookup(async () => [{ address: "10.1.2.3", family: 4 }]);
     const error = await new Promise<Error | null>((resolve) => {

--- a/packages/adapters/src/remote-mcp.test.ts
+++ b/packages/adapters/src/remote-mcp.test.ts
@@ -39,7 +39,7 @@ describe("remote MCP URL policy", () => {
   });
 
   it("allows Tailscale MagicDNS hosts that resolve to CGNAT addresses", async () => {
-    const magicDns = "https://api.tail12345.ts.net/openapi.json";
+    const magicDns = "https://box.tail12345.ts.net/openapi.json";
     await expect(
       assertSafeRemoteUrl(magicDns, async () => [{ address: "100.64.1.2", family: 4 as const }]),
     ).resolves.toEqual(new URL(magicDns));
@@ -62,17 +62,17 @@ describe("remote MCP URL policy", () => {
 
   it("rejects MagicDNS hosts that resolve outside Tailscale CGNAT", async () => {
     await expect(
-      assertSafeRemoteUrl("https://api.tail12345.ts.net/openapi.json", async () => [
+      assertSafeRemoteUrl("https://box.tail12345.ts.net/openapi.json", async () => [
         { address: "127.0.0.1", family: 4 as const },
       ]),
     ).rejects.toThrow("private address");
     await expect(
-      assertSafeRemoteUrl("https://api.tail12345.ts.net/openapi.json", async () => [
+      assertSafeRemoteUrl("https://box.tail12345.ts.net/openapi.json", async () => [
         { address: "10.1.2.3", family: 4 as const },
       ]),
     ).rejects.toThrow("private address");
     await expect(
-      assertSafeRemoteUrl("https://api.tail12345.ts.net/openapi.json", async () => [
+      assertSafeRemoteUrl("https://box.tail12345.ts.net/openapi.json", async () => [
         { address: "169.254.169.254", family: 4 as const },
       ]),
     ).rejects.toThrow("private address");

--- a/packages/adapters/src/remote-mcp.ts
+++ b/packages/adapters/src/remote-mcp.ts
@@ -128,7 +128,7 @@ export async function assertSafeRemoteUrl(
   if (url.hash) throw new Error("Connector URL must not contain a fragment");
   const hostname = url.hostname.replace(/^\[|\]$/g, "");
   if (isPrivateHostname(hostname)) throw new Error("Connector URL targets a private host");
-  assertPublicAddresses(await resolve(hostname));
+  assertPublicAddresses(await resolve(hostname), hostname);
   return url;
 }
 
@@ -161,8 +161,15 @@ export function createSafeLookup(resolve: ResolveHostname = resolveHostname): Lo
   return createAddressCheckedLookup(resolve, assertPublicAddresses);
 }
 
+/** Tailscale MagicDNS names (*.ts.net) are public DNS names, not private IP literals. */
+function isTailscaleMagicDnsHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/, "");
+  return normalized === "ts.net" || normalized.endsWith(".ts.net");
+}
+
 function isPrivateHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/\.$/, "");
+  if (isTailscaleMagicDnsHostname(normalized)) return false;
   return (
     normalized === "localhost" ||
     normalized.endsWith(".localhost") ||
@@ -173,7 +180,13 @@ function isPrivateHostname(hostname: string): boolean {
   );
 }
 
-function assertPublicAddresses(addresses: ResolvedAddress[]): void {
+function assertPublicAddresses(addresses: ResolvedAddress[], hostname?: string): void {
+  if (hostname && isTailscaleMagicDnsHostname(hostname)) {
+    if (addresses.length === 0) {
+      throw new Error("Connector URL resolves to a private address");
+    }
+    return;
+  }
   if (addresses.length === 0 || addresses.some((entry) => isPrivateAddress(entry.address))) {
     throw new Error("Connector URL resolves to a private address");
   }

--- a/packages/adapters/src/remote-mcp.ts
+++ b/packages/adapters/src/remote-mcp.ts
@@ -167,6 +167,16 @@ function isTailscaleMagicDnsHostname(hostname: string): boolean {
   return normalized === "ts.net" || normalized.endsWith(".ts.net");
 }
 
+/** Tailscale assigns CGNAT 100.64.0.0/10; MagicDNS may resolve there. */
+function isTailscaleCgnatAddress(address: string): boolean {
+  const value = address.toLowerCase().replace(/^\[|\]$/g, "");
+  const mapped = value.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1];
+  const ipv4 = mapped ?? (isIP(value) === 4 ? value : undefined);
+  if (!ipv4) return false;
+  const [a, b] = ipv4.split(".").map(Number);
+  return a === 100 && b != null && b >= 64 && b <= 127;
+}
+
 function isPrivateHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/\.$/, "");
   if (isTailscaleMagicDnsHostname(normalized)) return false;
@@ -181,13 +191,17 @@ function isPrivateHostname(hostname: string): boolean {
 }
 
 function assertPublicAddresses(addresses: ResolvedAddress[], hostname?: string): void {
-  if (hostname && isTailscaleMagicDnsHostname(hostname)) {
-    if (addresses.length === 0) {
-      throw new Error("Connector URL resolves to a private address");
-    }
-    return;
+  if (addresses.length === 0) {
+    throw new Error("Connector URL resolves to a private address");
   }
-  if (addresses.length === 0 || addresses.some((entry) => isPrivateAddress(entry.address))) {
+  const magicDns = hostname != null && isTailscaleMagicDnsHostname(hostname);
+  if (
+    addresses.some((entry) => {
+      if (!isPrivateAddress(entry.address)) return false;
+      // Allow only Tailscale CGNAT for MagicDNS; keep other private ranges blocked.
+      return !(magicDns && isTailscaleCgnatAddress(entry.address));
+    })
+  ) {
     throw new Error("Connector URL resolves to a private address");
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
OpenAPI/MCP/Treg connector URL checks treated Tailscale MagicDNS names (`*.ts.net`) like private hosts once DNS returned CGNAT addresses.

This change recognizes `*.ts.net` as public DNS names so those integrations can be added, while still rejecting raw private/link-local/loopback IP literals, `file://`, and non-http(s) URLs.

Fixes #421

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1d5f53d-5aed-48c4-ad54-0f3ed06d31a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1d5f53d-5aed-48c4-ad54-0f3ed06d31a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote MCP connections now support Tailscale MagicDNS hostnames, including those resolving to CGNAT addresses.
  * Hostname validation now receives the hostname for more context during address checks.

* **Bug Fixes**
  * Raw CGNAT IP addresses continue to be blocked, preserving remote URL safety protections.

* **Tests**
  * Added coverage for accepted Tailscale MagicDNS hostnames and rejected CGNAT IP literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->