### PR TITLE
fix: do not persist split UTF-16 surrogates in stream events

### DIFF
--- a/packages/core/src/events.test.ts
+++ b/packages/core/src/events.test.ts
@@ -9,6 +9,8 @@ import {
   isRunTerminalEvent,
   projectMessages,
   runFailureError,
+  sanitizeJsonValue,
+  sanitizeUtf16ForJson,
   trackToolCallStreak,
   trackToolNameStreak,
 } from "./events.js";
@@ -639,5 +641,42 @@ describe("createStreamingRedactor", () => {
     const redactor = createStreamingRedactor([]);
     expect(redactor.push("hello")).toBe("hello");
     expect(redactor.finish()).toBe("");
+  });
+
+  it("buffers a trailing UTF-16 high surrogate until the next chunk completes the emoji", () => {
+    const redactor = createStreamingRedactor([]);
+    const high = "\uD83D";
+    const low = "\uDE00";
+    expect(redactor.push(`hello ${high}`)).toBe("hello ");
+    expect(redactor.push(`${low} world`)).toBe("😀 world");
+    expect(redactor.finish()).toBe("");
+  });
+
+  it("does not emit a high surrogate when the secret hold window would split an emoji pair", () => {
+    const redactor = createStreamingRedactor(["abcdefghij"]); // length 10
+    const high = "\uD83D";
+    const low = "\uDE00";
+    // safeStartLimit lands between high and low; the pair must stay buffered together.
+    expect(redactor.push(`x${high}${low}abcdefgh`)).toBe("x");
+    expect(redactor.push("ij done")).toBe("😀[redacted]");
+    expect(redactor.finish()).toBe(" done");
+  });
+
+  it("replaces an orphaned high surrogate at end of stream", () => {
+    const redactor = createStreamingRedactor([]);
+    expect(redactor.push("end\uD83D")).toBe("end");
+    expect(redactor.finish()).toBe("\uFFFD");
+  });
+});
+
+describe("sanitizeUtf16ForJson", () => {
+  it("keeps complete surrogate pairs and replaces unpaired surrogates", () => {
+    expect(sanitizeUtf16ForJson("😀")).toBe("😀");
+    expect(sanitizeUtf16ForJson("a\uD83D")).toBe("a\uFFFD");
+    expect(sanitizeUtf16ForJson("\uDE00b")).toBe("\uFFFDb");
+    expect(sanitizeJsonValue({ delta: "x\uD83D", nested: ["\uDE00"] })).toEqual({
+      delta: "x\uFFFD",
+      nested: ["\uFFFD"],
+    });
   });
 });

--- a/packages/core/src/events.test.ts
+++ b/packages/core/src/events.test.ts
@@ -679,4 +679,20 @@ describe("sanitizeUtf16ForJson", () => {
       nested: ["\uFFFD"],
     });
   });
+
+  it("sanitizes nested object keys and disambiguates collisions after replacement", () => {
+    expect(
+      sanitizeJsonValue({
+        outer: {
+          ["meta\uD83D"]: "ok",
+          ["meta\uDE00"]: "also",
+        },
+      }),
+    ).toEqual({
+      outer: {
+        "meta\uFFFD": "ok",
+        "meta\uFFFD#2": "also",
+      },
+    });
+  });
 });

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -323,32 +323,107 @@ export function containsSecret(value: unknown, secrets: string[]): boolean {
   return secrets.some((secret) => secret.length > 0 && text.includes(secret));
 }
 
+/** UTF-16 high surrogates (0xD800–0xDBFF) must be paired with a low surrogate for valid JSON. */
+const HIGH_SURROGATE_START = 0xd800;
+const HIGH_SURROGATE_END = 0xdbff;
+const LOW_SURROGATE_START = 0xdc00;
+const LOW_SURROGATE_END = 0xdfff;
+
+function isHighSurrogate(code: number): boolean {
+  return code >= HIGH_SURROGATE_START && code <= HIGH_SURROGATE_END;
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= LOW_SURROGATE_START && code <= LOW_SURROGATE_END;
+}
+
+function endsWithHighSurrogate(value: string): boolean {
+  return value.length > 0 && isHighSurrogate(value.charCodeAt(value.length - 1));
+}
+
+/**
+ * Replace unpaired UTF-16 surrogates so the string is safe for JSON (Postgres rejects them).
+ */
+export function sanitizeUtf16ForJson(value: string): string {
+  let result = "";
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (isHighSurrogate(code)) {
+      const next = i + 1 < value.length ? value.charCodeAt(i + 1) : -1;
+      if (isLowSurrogate(next)) {
+        result += value[i]! + value[i + 1]!;
+        i += 1;
+      } else {
+        result += "\uFFFD";
+      }
+    } else if (isLowSurrogate(code)) {
+      result += "\uFFFD";
+    } else {
+      result += value[i]!;
+    }
+  }
+  return result;
+}
+
+/** Deep-sanitize string leaves so event payloads never carry unpaired surrogates into JSON. */
+export function sanitizeJsonValue<T>(value: T): T {
+  if (typeof value === "string") return sanitizeUtf16ForJson(value) as T;
+  if (Array.isArray(value)) return value.map((item) => sanitizeJsonValue(item)) as T;
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = sanitizeJsonValue(nested);
+    }
+    return out as T;
+  }
+  return value;
+}
+
 export function createStreamingRedactor(secrets: string[]) {
   const values = [...new Set(secrets.filter(Boolean))].sort((a, b) => b.length - a.length);
   const maxLength = values[0]?.length ?? 0;
   let buffer = "";
 
   const drain = (final: boolean) => {
+    let output: string;
     if (values.length === 0) {
-      const output = buffer;
+      output = buffer;
       buffer = "";
-      return output;
-    }
-    const safeStartLimit = final ? buffer.length : Math.max(0, buffer.length - maxLength + 1);
-    let offset = 0;
-    let output = "";
-    while (offset < safeStartLimit) {
-      const secret = values.find((value) => buffer.startsWith(value, offset));
-      if (secret) {
-        output += "[redacted]";
-        offset += secret.length;
-      } else {
+    } else {
+      const safeStartLimit = final ? buffer.length : Math.max(0, buffer.length - maxLength + 1);
+      let offset = 0;
+      output = "";
+      while (offset < safeStartLimit) {
+        const secret = values.find((value) => buffer.startsWith(value, offset));
+        if (secret) {
+          output += "[redacted]";
+          offset += secret.length;
+          continue;
+        }
+        const code = buffer.charCodeAt(offset);
+        if (isHighSurrogate(code)) {
+          const hasNext = offset + 1 < buffer.length;
+          const next = hasNext ? buffer.charCodeAt(offset + 1) : -1;
+          if (hasNext && isLowSurrogate(next)) {
+            // Keep the pair together; hold both if the low unit is outside this drain window.
+            if (!final && offset + 1 >= safeStartLimit) break;
+            output += buffer[offset]! + buffer[offset + 1]!;
+            offset += 2;
+            continue;
+          }
+          if (!final && !hasNext) break; // trailing high surrogate — wait for the next chunk
+        }
         output += buffer[offset];
         offset += 1;
       }
+      buffer = buffer.slice(offset);
     }
-    buffer = buffer.slice(offset);
-    return output;
+    // No-secret path emits the whole buffer; hold a trailing high until the next chunk.
+    if (!final && endsWithHighSurrogate(output)) {
+      buffer = output.slice(-1) + buffer;
+      output = output.slice(0, -1);
+    }
+    return sanitizeUtf16ForJson(output);
   };
 
   return {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -371,8 +371,14 @@ export function sanitizeJsonValue<T>(value: T): T {
   if (Array.isArray(value)) return value.map((item) => sanitizeJsonValue(item)) as T;
   if (value && typeof value === "object") {
     const out: Record<string, unknown> = {};
+    const used = new Map<string, number>();
     for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
-      out[key] = sanitizeJsonValue(nested);
+      let safeKey = sanitizeUtf16ForJson(key);
+      const seen = used.get(safeKey) ?? 0;
+      used.set(safeKey, seen + 1);
+      // Deterministic collision handling when sanitizing collapses distinct keys.
+      if (seen > 0) safeKey = `${safeKey}#${seen + 1}`;
+      out[safeKey] = sanitizeJsonValue(nested);
     }
     return out as T;
   }

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -1199,4 +1199,49 @@ describe("appendEvent", () => {
     expect(tx.event.create).toHaveBeenCalled();
     expect(publish).toHaveBeenCalled();
   });
+
+  it("does not persist a split-emoji high surrogate that would crash JSON insert", async () => {
+    const fanout = new TestFanout();
+    const created = {
+      ...event(3),
+      type: "thread.progress",
+      runId: "run-3",
+      payload: { delta: "hello \uFFFD", streaming: true },
+    };
+    const tx = {
+      thread: { update: vi.fn().mockResolvedValue({ nextEventSeq: 4 }) },
+      run: { findUnique: vi.fn().mockResolvedValue({ status: "running" }) },
+      event: { create: vi.fn().mockResolvedValue(created) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    // Orphaned UTF-16 high surrogate (e.g. 😀 split across stream chunks as \uD83D alone).
+    const orphanedHigh = "hello \uD83D";
+    await expect(
+      appendEvent(
+        prisma,
+        {
+          workspaceId: "workspace-1",
+          threadId: "thread-1",
+          botId: "bot-1",
+          type: "thread.progress",
+          runId: "run-3",
+          payload: { delta: orphanedHigh, streaming: true },
+        },
+        fanout,
+      ),
+    ).resolves.toMatchObject({ type: "thread.progress", runId: "run-3" });
+
+    expect(tx.event.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        payload: { delta: "hello \uFFFD", streaming: true },
+      }),
+    });
+    const persisted = tx.event.create.mock.calls[0]![0].data.payload as { delta: string };
+    // Postgres rejects unpaired surrogates in json; the sanitized form must not contain any.
+    expect(persisted.delta).not.toMatch(/[\uD800-\uDFFF]/);
+    expect(() => JSON.stringify(persisted)).not.toThrow();
+  });
 });

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -4,7 +4,7 @@ import {
   MessageBlock as MessageBlockSchema,
   type ProductEvent,
 } from "@rakazo/contracts";
-import { isApprovalAskBlock, isSecretAskBlock } from "@rakazo/core";
+import { isApprovalAskBlock, isSecretAskBlock, sanitizeJsonValue } from "@rakazo/core";
 import type { Prisma, PrismaClient } from "./client.js";
 import {
   assertRunCanWriteHistory,
@@ -832,6 +832,8 @@ export async function appendEventInTransaction(
     select: { nextEventSeq: true },
   });
   await assertRunCanWriteHistory(tx, input.runId);
+  // Unpaired UTF-16 surrogates (e.g. a split emoji high half) are invalid JSON for Postgres.
+  const payload = sanitizeJsonValue(input.payload);
   return tx.event.create({
     data: {
       workspaceId: input.workspaceId,
@@ -839,7 +841,7 @@ export async function appendEventInTransaction(
       botId: input.botId,
       seq: thread.nextEventSeq - 1,
       type: input.type,
-      payload: input.payload as Prisma.InputJsonValue,
+      payload: payload as Prisma.InputJsonValue,
       runId: input.runId,
     },
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Streamed `thread.progress` deltas can end on an orphaned UTF-16 high surrogate when an emoji is split across chunks. Postgres then rejects the event payload JSON (`Unicode low surrogate must follow a high surrogate`).

This change:
- Buffers a trailing high surrogate in `createStreamingRedactor` until the next chunk (or replaces it at end of stream)
- Sanitizes event payloads before JSON persist in `appendEventInTransaction`
- Adds unit tests covering a split emoji on the redactor and on event write

Fixes #416

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-311518cb-8e49-4dd7-a349-e4fafb9f89d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-311518cb-8e49-4dd7-a349-e4fafb9f89d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed text containing split or incomplete emoji characters.
  * Replaces invalid Unicode surrogate characters with a safe replacement character.
  * Prevents event data from failing during persistence when it contains malformed Unicode.
  * Applies Unicode sanitization consistently across nested objects and arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->