### PR TITLE
fix(chat): hide inter-bot exchanges from transcript

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -125,7 +125,7 @@ import {
   UpdaterProxyError,
 } from "./server-update.js";
 import { assertTeachingSendAllowed, createTaughtSkillsService } from "./taught-skills.js";
-import { loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
+import { isPeerRun, loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
 import {
   resolveThreadTarget,
   sendThreadMessage,
@@ -976,15 +976,18 @@ export function createRouter(deps: RouterDeps) {
           input.before,
           THREAD_MESSAGE_PAGE_SIZE,
           input.around,
+          input.includePeerRuns,
         );
       }),
       subscribe: authed.threads.subscribe.handler(async function* ({ context, input }) {
         const target = await resolveThreadTarget(deps.prisma, context.actor, input);
+        const peerRunCache = new Map<string, Promise<boolean>>();
         for await (const event of deps.events.follow(
           target.threadId,
           input.cursor,
           context.signal,
         )) {
+          if (await isPeerRun(deps.prisma, event.runId, peerRunCache)) continue;
           yield event;
         }
       }),

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -2,6 +2,16 @@ import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import { loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
 
+function prismaWithMessages(
+  message: Partial<PrismaClient["message"]>,
+  runFindMany: PrismaClient["run"]["findMany"] = vi.fn(async () => []),
+) {
+  return {
+    message,
+    run: { findMany: runFindMany },
+  } as unknown as PrismaClient;
+}
+
 describe("thread message pages", () => {
   it("queries before the cursor and returns an ascending bounded page", async () => {
     const findMany = vi.fn(async () =>
@@ -15,7 +25,7 @@ describe("thread message pages", () => {
         createdAt: new Date(`2026-08-16T00:00:0${seq}.000Z`),
       })),
     );
-    const prisma = { message: { findMany } } as unknown as PrismaClient;
+    const prisma = prismaWithMessages({ findMany });
 
     const page = await loadMessagePage(prisma, "thread-1", 6, 2);
 
@@ -40,7 +50,7 @@ describe("thread message pages", () => {
         createdAt: new Date("2026-08-16T00:00:00.000Z"),
       },
     ]);
-    const prisma = { message: { findMany } } as unknown as PrismaClient;
+    const prisma = prismaWithMessages({ findMany });
 
     const page = await loadMessagePage(prisma, "thread-1", 1, 2);
 
@@ -83,9 +93,7 @@ describe("thread message pages", () => {
       ])
       .mockResolvedValueOnce(1);
     const count = vi.fn(async () => 1);
-    const prisma = {
-      message: { findFirst, findMany, count },
-    } as unknown as PrismaClient;
+    const prisma = prismaWithMessages({ findFirst, findMany, count });
 
     const page = await loadMessagePage(prisma, "thread-1", undefined, 4, { seq: 5 });
 
@@ -113,11 +121,57 @@ describe("thread message pages", () => {
       .mockResolvedValueOnce([row(4), row(3), row(2)])
       .mockResolvedValueOnce([row(2), row(1), row(0)])
       .mockResolvedValueOnce([row(0)]);
-    const prisma = { message: { findMany } } as unknown as PrismaClient;
+    const prisma = prismaWithMessages({ findMany });
 
     const messages = await loadAllMessages(prisma, "thread-1", 2);
 
     expect(messages.map((message) => message.seq)).toEqual([0, 1, 2, 3, 4]);
     expect(findMany.mock.calls.map(([query]) => query.where.seq?.lt)).toEqual([undefined, 3, 1]);
+  });
+
+  it("attaches runTrigger so peer runs are classifiable without a receipt in-page", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        id: "message-2",
+        threadId: "thread-1",
+        seq: 2,
+        role: "bot",
+        blocks: [{ kind: "text", text: "peer reply" }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-peer",
+        createdAt: new Date("2026-08-16T00:00:02.000Z"),
+      },
+      {
+        id: "message-1",
+        threadId: "thread-1",
+        seq: 1,
+        role: "bot",
+        blocks: [{ kind: "text", text: "user answer" }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-user",
+        createdAt: new Date("2026-08-16T00:00:01.000Z"),
+      },
+    ]);
+    const runFindMany = vi.fn(async () => [
+      { id: "run-peer", trigger: "bot_message" },
+      { id: "run-user", trigger: "user" },
+    ]);
+    const prisma = prismaWithMessages({ findMany }, runFindMany);
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
+
+    expect(runFindMany).toHaveBeenCalledWith({
+      where: { id: { in: expect.arrayContaining(["run-peer", "run-user"]) } },
+      select: { id: true, trigger: true },
+    });
+    expect(runFindMany.mock.calls[0][0].where.id.in).toHaveLength(2);
+    expect(
+      page.messages.map((message) => ({ id: message.id, runTrigger: message.runTrigger })),
+    ).toEqual([
+      { id: "message-1", runTrigger: "user" },
+      { id: "message-2", runTrigger: "bot_message" },
+    ]);
   });
 });

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -1,8 +1,106 @@
 import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
-import { loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
+import { isPeerRun, loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
 
 describe("thread message pages", () => {
+  it("caches peer-run classification for live events", async () => {
+    const findUnique = vi.fn(async () => ({ trigger: "bot_message" }));
+    const prisma = { run: { findUnique } } as unknown as PrismaClient;
+    const cache = new Map<string, Promise<boolean>>();
+
+    await expect(isPeerRun(prisma, "run-peer", cache)).resolves.toBe(true);
+    await expect(isPeerRun(prisma, "run-peer", cache)).resolves.toBe(true);
+    expect(findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters peer-run output when its receipt is outside the loaded page", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        id: "message-peer",
+        threadId: "thread-1",
+        seq: 2,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Echoed peer reply" }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-peer",
+        createdAt: new Date("2026-08-16T00:00:02.000Z"),
+      },
+      {
+        id: "message-user",
+        threadId: "thread-1",
+        seq: 1,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Visible answer" }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-user",
+        createdAt: new Date("2026-08-16T00:00:01.000Z"),
+      },
+    ]);
+    const prisma = {
+      message: { findMany },
+      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+    } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
+
+    expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
+  });
+
+  it("returns peer-run output for the dedicated bot messages view", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        id: "message-peer",
+        threadId: "thread-1",
+        seq: 1,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Peer reply" }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-peer",
+        createdAt: new Date("2026-08-16T00:00:01.000Z"),
+      },
+    ]);
+    const prisma = { message: { findMany } } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 2, undefined, true);
+
+    expect(page.messages.map((message) => message.id)).toEqual(["message-peer"]);
+  });
+
+  it("scans past a page containing only peer-run output", async () => {
+    const row = (seq: number, runId: string) => ({
+      id: `message-${seq}`,
+      threadId: "thread-1",
+      seq,
+      role: "bot",
+      blocks: [{ kind: "text", text: String(seq) }],
+      botId: "bot-1",
+      replyToMessageId: null,
+      runId,
+      createdAt: new Date("2026-08-16T00:00:00.000Z"),
+    });
+    const findMany = vi
+      .fn()
+      .mockResolvedValueOnce([row(4, "run-peer"), row(3, "run-peer"), row(2, "run-peer")])
+      .mockResolvedValueOnce([row(1, "run-user")]);
+    const prisma = {
+      message: { findMany },
+      run: {
+        findMany: vi
+          .fn()
+          .mockResolvedValueOnce([{ id: "run-peer" }])
+          .mockResolvedValueOnce([]),
+      },
+    } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
+
+    expect(page.messages.map((message) => message.id)).toEqual(["message-1"]);
+    expect(findMany).toHaveBeenCalledTimes(2);
+  });
+
   it("queries before the cursor and returns an ascending bounded page", async () => {
     const findMany = vi.fn(async () =>
       [5, 4, 3].map((seq) => ({

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -3,6 +3,18 @@ import type { Prisma, PrismaClient } from "@rakazo/db";
 
 type MessageDb = PrismaClient | Prisma.TransactionClient;
 
+type MessageRow = {
+  id: string;
+  threadId: string;
+  seq: number;
+  role: string;
+  blocks: Prisma.JsonValue;
+  botId: string | null;
+  replyToMessageId: string | null;
+  runId: string | null;
+  createdAt: Date;
+};
+
 export async function loadMessagePage(
   prisma: MessageDb,
   threadId: string,
@@ -34,7 +46,7 @@ export async function loadMessagePage(
         : false;
       return {
         threadId,
-        messages: rows.map(toThreadMessage),
+        messages: await toThreadMessages(prisma, rows),
         olderCursor: hasOlder ? (first?.seq ?? null) : null,
       };
     }
@@ -49,7 +61,7 @@ export async function loadMessagePage(
     take: pageSize + 1,
   });
   const hasOlder = rows.length > pageSize;
-  const messages = rows.slice(0, pageSize).reverse().map(toThreadMessage);
+  const messages = await toThreadMessages(prisma, rows.slice(0, pageSize).reverse());
   return {
     threadId,
     messages,
@@ -72,17 +84,24 @@ export async function loadAllMessages(
   return pages.reverse().flat();
 }
 
-function toThreadMessage(row: {
-  id: string;
-  threadId: string;
-  seq: number;
-  role: string;
-  blocks: Prisma.JsonValue;
-  botId: string | null;
-  replyToMessageId: string | null;
-  runId: string | null;
-  createdAt: Date;
-}): ThreadMessage {
+async function toThreadMessages(prisma: MessageDb, rows: MessageRow[]): Promise<ThreadMessage[]> {
+  const runIds = [
+    ...new Set(rows.map((row) => row.runId).filter((runId): runId is string => Boolean(runId))),
+  ];
+  const triggers = new Map(
+    runIds.length === 0
+      ? []
+      : (
+          await prisma.run.findMany({
+            where: { id: { in: runIds } },
+            select: { id: true, trigger: true },
+          })
+        ).map((run) => [run.id, run.trigger] as const),
+  );
+  return rows.map((row) => toThreadMessage(row, row.runId ? triggers.get(row.runId) : undefined));
+}
+
+function toThreadMessage(row: MessageRow, runTrigger?: string): ThreadMessage {
   return {
     id: row.id,
     threadId: row.threadId,
@@ -92,6 +111,7 @@ function toThreadMessage(row: {
     botId: row.botId ?? undefined,
     replyToMessageId: row.replyToMessageId ?? undefined,
     runId: row.runId ?? undefined,
+    runTrigger,
     createdAt: row.createdAt.toISOString(),
   };
 }

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -9,6 +9,7 @@ export async function loadMessagePage(
   before: number | undefined,
   pageSize: number,
   around?: { messageId?: string; seq?: number },
+  includePeerRuns = false,
 ): Promise<ThreadMessagePage> {
   if (around) {
     let targetSeq = around.seq;
@@ -32,29 +33,39 @@ export async function loadMessagePage(
       const hasOlder = first
         ? (await prisma.message.count({ where: { threadId, seq: { lt: first.seq } } })) > 0
         : false;
+      const messages = includePeerRuns ? rows : await withoutPeerRunMessages(prisma, rows);
       return {
         threadId,
-        messages: rows.map(toThreadMessage),
+        messages: messages.map(toThreadMessage),
         olderCursor: hasOlder ? (first?.seq ?? null) : null,
       };
     }
   }
 
-  const rows = await prisma.message.findMany({
-    where: {
-      threadId,
-      ...(before === undefined ? {} : { seq: { lt: before } }),
-    },
-    orderBy: { seq: "desc" },
-    take: pageSize + 1,
-  });
-  const hasOlder = rows.length > pageSize;
-  const messages = rows.slice(0, pageSize).reverse().map(toThreadMessage);
-  return {
-    threadId,
-    messages,
-    olderCursor: hasOlder ? (messages[0]?.seq ?? null) : null,
-  };
+  let cursor = before;
+  while (true) {
+    const rows = await prisma.message.findMany({
+      where: {
+        threadId,
+        ...(cursor === undefined ? {} : { seq: { lt: cursor } }),
+      },
+      orderBy: { seq: "desc" },
+      take: pageSize + 1,
+    });
+    const hasOlder = rows.length > pageSize;
+    const pageRows = rows.slice(0, pageSize).reverse();
+    const visibleRows = includePeerRuns ? pageRows : await withoutPeerRunMessages(prisma, pageRows);
+    if (visibleRows.length > 0 || !hasOlder || includePeerRuns) {
+      return {
+        threadId,
+        messages: visibleRows.map(toThreadMessage),
+        olderCursor: hasOlder ? (pageRows[0]?.seq ?? null) : null,
+      };
+    }
+    // ponytail: only scan again when a raw page is entirely peer output; add a run relation if
+    // long peer-only histories make this path hot.
+    cursor = pageRows[0]?.seq;
+  }
 }
 
 export async function loadAllMessages(
@@ -65,11 +76,41 @@ export async function loadAllMessages(
   const pages: ThreadMessage[][] = [];
   let before: number | undefined;
   do {
-    const page = await loadMessagePage(prisma, threadId, before, pageSize);
+    const page = await loadMessagePage(prisma, threadId, before, pageSize, undefined, true);
     pages.push(page.messages);
     before = page.olderCursor ?? undefined;
   } while (before !== undefined);
   return pages.reverse().flat();
+}
+
+async function withoutPeerRunMessages<T extends { runId: string | null }>(
+  prisma: MessageDb,
+  rows: T[],
+): Promise<T[]> {
+  const runIds = [...new Set(rows.flatMap((row) => (row.runId ? [row.runId] : [])))];
+  if (runIds.length === 0) return rows;
+  const peerRuns = await prisma.run.findMany({
+    where: { id: { in: runIds }, trigger: "bot_message" },
+    select: { id: true },
+  });
+  const peerRunIds = new Set(peerRuns.map((run) => run.id));
+  return rows.filter((row) => !row.runId || !peerRunIds.has(row.runId));
+}
+
+export async function isPeerRun(
+  prisma: MessageDb,
+  runId: string | undefined,
+  cache: Map<string, Promise<boolean>>,
+): Promise<boolean> {
+  if (!runId) return false;
+  let peerRun = cache.get(runId);
+  if (!peerRun) {
+    peerRun = prisma.run
+      .findUnique({ where: { id: runId }, select: { trigger: true } })
+      .then((run) => run?.trigger === "bot_message");
+    cache.set(runId, peerRun);
+  }
+  return peerRun;
 }
 
 function toThreadMessage(row: {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -28,6 +28,7 @@ import {
   sessionPartitionForServerUrl,
 } from "./setup-config.js";
 import { clearSetup, readSetup, writeSetup } from "./setup-store.js";
+import { shouldOpenInAppPopup } from "./window-open.js";
 import { browserWindowOptions, setupWindowOptions, warmWindowTtlMs } from "./window-options.js";
 
 const PERFORMANCE_USER_DATA = process.env.RAKAZO_PERFORMANCE_USER_DATA;
@@ -195,24 +196,13 @@ function createWindow(url: string, partition: string | null) {
   });
   mainWindow = win;
   const targetOrigin = safeOrigin(url);
-  // OAuth flows open the provider's authorize page via window.open; give that
-  // popup a normal framed window. Non-http(s) targets stay closed; other http(s)
-  // origins open in the system browser so a connected server cannot navigate us away.
+  // Intentional OAuth flows open the provider's authorize page via a named
+  // window; give those and same-origin popups a normal frame. Everything else
+  // opens in the system browser so a connected server cannot navigate us away.
   // Hoisted for loopback OAuth capture so MCP/in-app localhost callbacks are skipped.
   const appOrigin = targetOrigin ?? safeOrigin(url);
-  win.webContents.setWindowOpenHandler(({ url: childUrl }) => {
-    let target: URL;
-    try {
-      target = new URL(childUrl);
-    } catch {
-      return { action: "deny" };
-    }
-    const sameOrigin = appOrigin !== null && target.origin === appOrigin;
-    // Same-origin http(s) and third-party https (OAuth) get a framed popup.
-    if (
-      (sameOrigin && (target.protocol === "http:" || target.protocol === "https:")) ||
-      (!sameOrigin && target.protocol === "https:")
-    ) {
+  win.webContents.setWindowOpenHandler(({ url: childUrl, frameName }) => {
+    if (shouldOpenInAppPopup(appOrigin, childUrl, frameName)) {
       return {
         action: "allow",
         overrideBrowserWindowOptions: oauthPopupWindowOptions(),
@@ -225,6 +215,8 @@ function createWindow(url: string, partition: string | null) {
   win.webContents.on("will-navigate", (event, navigationUrl) => {
     if (targetOrigin !== null && safeOrigin(navigationUrl) === targetOrigin) return;
     event.preventDefault();
+    const external = safeExternalUrl(navigationUrl);
+    if (external !== null) void shell.openExternal(external);
   });
   // The popup has no address bar, so a loopback redirect would otherwise strand
   // the user on a blank window holding the authorization code in a URL they

--- a/apps/desktop/src/window-open.test.ts
+++ b/apps/desktop/src/window-open.test.ts
@@ -14,14 +14,16 @@ describe("desktop child windows", () => {
     ).toBe(false);
   });
 
-  it.each(["rakazo-model-oauth", "rakazo-mcp-oauth", "rakazo-app-connect"])(
-    "keeps the intentional %s flow in an Electron popup",
-    (frameName) => {
-      expect(
-        shouldOpenInAppPopup(appOrigin, "https://provider.example.com/authorize", frameName),
-      ).toBe(true);
-    },
-  );
+  it.each([
+    "rakazo-model-oauth",
+    "rakazo-mcp-oauth",
+    "rakazo-app-connect",
+    "rakazo-plugin-connect",
+  ])("keeps the intentional %s flow in an Electron popup", (frameName) => {
+    expect(
+      shouldOpenInAppPopup(appOrigin, "https://provider.example.com/authorize", frameName),
+    ).toBe(true);
+  });
 
   it("rejects malformed URLs and non-HTTPS third-party targets", () => {
     expect(shouldOpenInAppPopup(appOrigin, "not a url", "rakazo-model-oauth")).toBe(false);

--- a/apps/desktop/src/window-open.test.ts
+++ b/apps/desktop/src/window-open.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { shouldOpenInAppPopup } from "./window-open.js";
+
+const appOrigin = "https://rakazo.example.com";
+
+describe("desktop child windows", () => {
+  it("keeps same-origin app routes in Electron", () => {
+    expect(shouldOpenInAppPopup(appOrigin, `${appOrigin}/mcp/oauth/callback`, "_blank")).toBe(true);
+  });
+
+  it("opens ordinary external links outside Electron", () => {
+    expect(
+      shouldOpenInAppPopup(appOrigin, "https://github.com/elie222/rakazo/pull/395", "_blank"),
+    ).toBe(false);
+  });
+
+  it.each(["rakazo-model-oauth", "rakazo-mcp-oauth", "rakazo-app-connect"])(
+    "keeps the intentional %s flow in an Electron popup",
+    (frameName) => {
+      expect(
+        shouldOpenInAppPopup(appOrigin, "https://provider.example.com/authorize", frameName),
+      ).toBe(true);
+    },
+  );
+
+  it("rejects malformed URLs and non-HTTPS third-party targets", () => {
+    expect(shouldOpenInAppPopup(appOrigin, "not a url", "rakazo-model-oauth")).toBe(false);
+    expect(
+      shouldOpenInAppPopup(appOrigin, "http://provider.example.com", "rakazo-model-oauth"),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/window-open.ts
+++ b/apps/desktop/src/window-open.ts
@@ -1,4 +1,9 @@
-const OAUTH_POPUP_NAMES = new Set(["rakazo-app-connect", "rakazo-mcp-oauth", "rakazo-model-oauth"]);
+const OAUTH_POPUP_NAMES = new Set([
+  "rakazo-app-connect",
+  "rakazo-mcp-oauth",
+  "rakazo-model-oauth",
+  "rakazo-plugin-connect",
+]);
 
 export function shouldOpenInAppPopup(
   appOrigin: string | null,

--- a/apps/desktop/src/window-open.ts
+++ b/apps/desktop/src/window-open.ts
@@ -1,0 +1,18 @@
+const OAUTH_POPUP_NAMES = new Set(["rakazo-app-connect", "rakazo-mcp-oauth", "rakazo-model-oauth"]);
+
+export function shouldOpenInAppPopup(
+  appOrigin: string | null,
+  childUrl: string,
+  frameName: string,
+) {
+  let target: URL;
+  try {
+    target = new URL(childUrl);
+  } catch {
+    return false;
+  }
+
+  const isHttp = target.protocol === "http:" || target.protocol === "https:";
+  if (appOrigin !== null && target.origin === appOrigin) return isHttp;
+  return target.protocol === "https:" && OAUTH_POPUP_NAMES.has(frameName);
+}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -21,6 +21,7 @@ import {
   type SlashActionId,
   serializeComposerPrompt,
   truncateSlashDescription,
+  userVisibleMessages,
 } from "@rakazo/core";
 import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useHeaderHeight } from "expo-router/react-navigation";
@@ -195,7 +196,10 @@ export default function Thread() {
     null,
   );
   const visibleMessages = useMemo(
-    () => (snap?.messages ?? []).filter((message) => hasVisibleMessagePresentation(message.blocks)),
+    () =>
+      userVisibleMessages(snap?.messages ?? []).filter((message) =>
+        hasVisibleMessagePresentation(message.blocks),
+      ),
     [snap?.messages],
   );
   const latestMessageId = visibleMessages.at(-1)?.id ?? null;

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -197,7 +197,7 @@ export default function Thread() {
   );
   const visibleMessages = useMemo(
     () =>
-      userVisibleMessages(snap?.messages ?? []).filter((message) =>
+      userVisibleMessages(snap?.messages ?? [], { includePeerReceipts: true }).filter((message) =>
         hasVisibleMessagePresentation(message.blocks),
       ),
     [snap?.messages],

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -68,7 +68,7 @@ describe("window chrome", () => {
     );
     expect(shell).toContain('className="app-no-drag grid h-8 w-8');
     expect(shell).toContain('className="app-no-drag flex min-w-0 items-center gap-3"');
-    expect(shell.match(/className="app-no-drag grid h-\[30px\] w-\[34px\]/g)).toHaveLength(2);
+    expect(shell.match(/className="app-no-drag grid h-\[30px\] w-\[34px\]/g)).toHaveLength(3);
   });
 });
 

--- a/apps/web/src/lib/use-model-oauth-signin.ts
+++ b/apps/web/src/lib/use-model-oauth-signin.ts
@@ -145,7 +145,7 @@ export function useModelOAuthSignIn(options: {
           oauthStateOf(started.verificationUri),
         );
       }
-      window.open(started.verificationUri, "_blank", "noopener,noreferrer");
+      window.open(started.verificationUri, "rakazo-model-oauth", "noopener,noreferrer");
       waitingForCode = started.mode === "auth-url";
       if (!waitingForCode) await finishSubscriptionSignIn(started.loginId, controller);
     } catch (err) {

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -16,21 +16,18 @@ const FOCUSABLE =
 export function PeerMessagesOverlay({
   botId,
   botName,
-  messages: initialMessages,
-  olderCursor: initialOlderCursor,
   initialPeerBotId,
   onClose,
 }: {
   botId: string;
   botName: string;
-  messages: readonly ThreadMessage[];
-  olderCursor: number | null;
   initialPeerBotId?: string | null;
   onClose: () => void;
 }) {
   const { t } = useLingui();
-  const [messages, setMessages] = useState<readonly ThreadMessage[]>(initialMessages);
-  const [historyReady, setHistoryReady] = useState(initialOlderCursor == null);
+  const [messages, setMessages] = useState<readonly ThreadMessage[]>([]);
+  const [historyReady, setHistoryReady] = useState(false);
+  const [historyFailed, setHistoryFailed] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(initialPeerBotId ?? null);
   const conversations = useMemo(
     () => (historyReady ? peerConversations(messages) : []),
@@ -41,34 +38,30 @@ export function PeerMessagesOverlay({
   const panelRef = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
-  // Overlay remounts each time it opens; page older history once from that snapshot.
-  const loadRef = useRef({ botId, initialMessages, initialOlderCursor });
+  // Overlay remounts each time it opens; load the dedicated raw peer history once.
+  const loadRef = useRef({ botId });
 
   useEffect(() => {
     let cancelled = false;
-    const { botId: id, initialMessages: seed, initialOlderCursor: older } = loadRef.current;
-    if (older == null) {
-      setMessages(seed);
-      setHistoryReady(true);
-      return;
-    }
+    const { botId: id } = loadRef.current;
     setHistoryReady(false);
+    setHistoryFailed(false);
     void (async () => {
-      let before: number | null = older;
-      let collected: ThreadMessage[] = [...seed];
-      while (before != null) {
-        const page = await rpc.threads.messages({ botId: id, before });
+      let before: number | undefined;
+      let collected: ThreadMessage[] = [];
+      do {
+        const page = await rpc.threads.messages({ botId: id, before, includePeerRuns: true });
         if (cancelled) return;
         collected = [...page.messages, ...collected];
-        before = page.olderCursor;
-      }
+        before = page.olderCursor ?? undefined;
+      } while (before !== undefined);
       if (cancelled) return;
       setMessages(collected);
       setHistoryReady(true);
     })().catch(() => {
       if (cancelled) return;
-      // Fall back to whatever the thread already has rather than claiming none.
-      setMessages(seed);
+      // Leave the empty state visible rather than showing a partial transcript-derived history.
+      setHistoryFailed(true);
       setHistoryReady(true);
     });
     return () => {
@@ -143,6 +136,8 @@ export function PeerMessagesOverlay({
             <p className="mt-1 text-[13.5px] text-[#7A7A80]">
               {!historyReady ? (
                 <Trans>Loading peer messages…</Trans>
+              ) : historyFailed ? (
+                <Trans>Could not load bot messages.</Trans>
               ) : conversations.length === 0 ? (
                 t`${botName} has not messaged another bot yet.`
               ) : (

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -126,7 +126,7 @@ export function PeerMessagesOverlay({
   }, []);
 
   return (
-    <div className="absolute inset-0 z-30 flex items-center justify-center bg-[rgba(4,4,5,.62)] p-4 sm:p-10">
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-[#040405] p-4 sm:p-10">
       <div
         ref={panelRef}
         role="dialog"

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -117,7 +117,7 @@ export function PluginsOverlay({
         displayName: item.name,
       });
       if (started.authorizationUrl)
-        window.open(started.authorizationUrl, "_blank", "noopener,noreferrer");
+        window.open(started.authorizationUrl, "rakazo-app-connect", "noopener,noreferrer");
       if (item.noAuth && !started.authorizationUrl) {
         if (controller.signal.aborted) return;
         setItemConnected(item, true);

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -117,7 +117,7 @@ export function PluginsOverlay({
         displayName: item.name,
       });
       if (started.authorizationUrl)
-        window.open(started.authorizationUrl, "rakazo-app-connect", "noopener,noreferrer");
+        window.open(started.authorizationUrl, "rakazo-plugin-connect", "noopener,noreferrer");
       if (item.noAuth && !started.authorizationUrl) {
         if (controller.signal.aborted) return;
         setItemConnected(item, true);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2708,13 +2708,7 @@ export function ShellPage() {
             </button>
           </div>
           <div className="flex items-center gap-1">
-            {!inGroup &&
-            activeSnapshot?.messages.some((message) =>
-              message.blocks.some(
-                (block) =>
-                  block.kind === "bot_message_sent" || block.kind === "bot_message_received",
-              ),
-            ) ? (
+            {!inGroup && active ? (
               <button
                 type="button"
                 title={t`Bot messages`}
@@ -3489,8 +3483,6 @@ export function ShellPage() {
           <PeerMessagesOverlay
             botId={active.id}
             botName={active.name}
-            messages={activeSnapshot?.messages ?? []}
-            olderCursor={activeSnapshot?.olderCursor ?? null}
             initialPeerBotId={peerMessagesFocusId}
             onClose={() => {
               setPeerMessagesOpen(false);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -76,6 +76,7 @@ import {
   Gauge,
   LogOut,
   Menu,
+  MessagesSquare,
   Mic,
   Monitor,
   Paperclip,
@@ -2707,6 +2708,24 @@ export function ShellPage() {
             </button>
           </div>
           <div className="flex items-center gap-1">
+            {!inGroup &&
+            activeSnapshot?.messages.some((message) =>
+              message.blocks.some(
+                (block) =>
+                  block.kind === "bot_message_sent" || block.kind === "bot_message_received",
+              ),
+            ) ? (
+              <button
+                type="button"
+                title={t`Bot messages`}
+                aria-label={t`Bot messages`}
+                onClick={() => setPeerMessagesOpen(true)}
+                className="app-no-drag grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-[#1B1B1E]"
+                style={{ background: peerMessagesOpen ? "#1B1B1E" : "transparent" }}
+              >
+                <MessagesSquare size={17} strokeWidth={1.6} className="text-[#A8A8AD]" />
+              </button>
+            ) : null}
             {!inGroup && active ? (
               <button
                 type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2708,13 +2708,7 @@ export function ShellPage() {
             </button>
           </div>
           <div className="flex items-center gap-1">
-            {!inGroup &&
-            activeSnapshot?.messages.some((message) =>
-              message.blocks.some(
-                (block) =>
-                  block.kind === "bot_message_sent" || block.kind === "bot_message_received",
-              ),
-            ) ? (
+            {!inGroup && active ? (
               <button
                 type="button"
                 title={t`Bot messages`}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -55,6 +55,7 @@ import {
   serializeComposerPrompt,
   speechFromBlocks,
   truncateSlashDescription,
+  userVisibleMessages,
 } from "@rakazo/core";
 import {
   AvatarStyleProvider,
@@ -2748,7 +2749,7 @@ export function ShellPage() {
           key={activeSnapshot?.threadId}
           scrollRef={messageScroll}
           artifactTarget={transcriptArtifactTarget}
-          messages={activeSnapshot?.messages ?? []}
+          messages={userVisibleMessages(activeSnapshot?.messages ?? [])}
           olderCursor={activeSnapshot?.olderCursor ?? null}
           loadingOlder={loadingOlder}
           answerableAskMessageId={answerableAskMessageId}

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -254,6 +254,8 @@ export const ThreadMessageSchema = z.object({
   botId: Id.optional(),
   replyToMessageId: Id.optional(),
   runId: Id.optional(),
+  /** Present on paged loads; used to hide peer runs without the receipt in-window. */
+  runTrigger: z.string().optional(),
   createdAt: z.string(),
 });
 export type ThreadMessage = z.infer<typeof ThreadMessageSchema>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -240,6 +240,7 @@ export const appContract = {
       .input(
         threadTarget.safeExtend({
           before: z.number().int().nonnegative().optional(),
+          includePeerRuns: z.boolean().optional(),
           around: z
             .object({
               messageId: Id.optional(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from "./featured-connectors.js";
 export * from "./group-mentions.js";
 export * from "./mcp.js";
 export * from "./message-pages.js";
+export * from "./message-visibility.js";
 export * from "./model-oauth.js";
 export * from "./phone-commands.js";
 export * from "./phone-prompts.js";

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -1,6 +1,6 @@
 import type { ThreadMessage } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
-import { userVisibleMessages } from "./message-visibility.js";
+import { latestUserVisibleMessage, userVisibleMessages } from "./message-visibility.js";
 
 function message(id: string, runId: string, blocks: ThreadMessage["blocks"]): ThreadMessage {
   return {
@@ -14,13 +14,46 @@ function message(id: string, runId: string, blocks: ThreadMessage["blocks"]): Th
   };
 }
 
+const peerExchange = [
+  message("user", "run-user", [{ kind: "text", text: "Please ask Coder." }]),
+  message("sent", "run-user", [
+    { kind: "bot_message_sent", toBotId: "coder", toBotName: "Coder", text: "Check this." },
+  ]),
+  message("received", "run-peer", [
+    {
+      kind: "bot_message_received",
+      fromBotId: "coder",
+      fromBotName: "Coder",
+      text: "Done.",
+    },
+  ]),
+  message("activity", "run-peer", [{ kind: "steps", steps: [{ label: "Message bot", count: 1 }] }]),
+  message("reply", "run-peer", [{ kind: "text", text: "Sent Coder the endpoints." }]),
+  message("answer", "run-user", [{ kind: "text", text: "Coder is checking it." }]),
+];
+
 describe("user-visible messages", () => {
   it("keeps bot-to-bot exchanges out of the user transcript", () => {
+    expect(userVisibleMessages(peerExchange).map((item) => item.id)).toEqual(["user", "answer"]);
+  });
+
+  it("keeps compact peer receipts when includePeerReceipts is set", () => {
+    expect(
+      userVisibleMessages(peerExchange, { includePeerReceipts: true }).map((item) => item.id),
+    ).toEqual(["user", "sent", "received", "answer"]);
+  });
+
+  it("keeps a user-run answer that never received a peer message", () => {
     const messages = [
-      message("user", "run-user", [{ kind: "text", text: "Please ask Coder." }]),
-      message("sent", "run-user", [
-        { kind: "bot_message_sent", toBotId: "coder", toBotName: "Coder", text: "Check this." },
-      ]),
+      message("user", "run-user", [{ kind: "text", text: "Summarize the doc." }]),
+      message("answer", "run-user", [{ kind: "text", text: "Here is the summary." }]),
+    ];
+    expect(userVisibleMessages(messages).map((item) => item.id)).toEqual(["user", "answer"]);
+  });
+
+  it("picks the newest visible message from a newest-first preview window", () => {
+    const newestFirst = [
+      message("reply", "run-peer", [{ kind: "text", text: "Echoed peer reply" }]),
       message("received", "run-peer", [
         {
           kind: "bot_message_received",
@@ -29,13 +62,8 @@ describe("user-visible messages", () => {
           text: "Done.",
         },
       ]),
-      message("activity", "run-peer", [
-        { kind: "steps", steps: [{ label: "Message bot", count: 1 }] },
-      ]),
-      message("reply", "run-peer", [{ kind: "text", text: "Sent Coder the endpoints." }]),
-      message("answer", "run-user", [{ kind: "text", text: "Coder is checking it." }]),
+      message("answer", "run-user", [{ kind: "text", text: "Visible answer" }]),
     ];
-
-    expect(userVisibleMessages(messages).map((item) => item.id)).toEqual(["user", "answer"]);
+    expect(latestUserVisibleMessage(newestFirst)?.id).toBe("answer");
   });
 });

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -1,0 +1,41 @@
+import type { ThreadMessage } from "@rakazo/contracts";
+import { describe, expect, it } from "vitest";
+import { userVisibleMessages } from "./message-visibility.js";
+
+function message(id: string, runId: string, blocks: ThreadMessage["blocks"]): ThreadMessage {
+  return {
+    id,
+    threadId: "thread-1",
+    seq: 1,
+    role: "bot",
+    blocks,
+    runId,
+    createdAt: "2026-08-30T22:00:00.000Z",
+  };
+}
+
+describe("user-visible messages", () => {
+  it("keeps bot-to-bot exchanges out of the user transcript", () => {
+    const messages = [
+      message("user", "run-user", [{ kind: "text", text: "Please ask Coder." }]),
+      message("sent", "run-user", [
+        { kind: "bot_message_sent", toBotId: "coder", toBotName: "Coder", text: "Check this." },
+      ]),
+      message("received", "run-peer", [
+        {
+          kind: "bot_message_received",
+          fromBotId: "coder",
+          fromBotName: "Coder",
+          text: "Done.",
+        },
+      ]),
+      message("activity", "run-peer", [
+        { kind: "steps", steps: [{ label: "Message bot", count: 1 }] },
+      ]),
+      message("reply", "run-peer", [{ kind: "text", text: "Sent Coder the endpoints." }]),
+      message("answer", "run-user", [{ kind: "text", text: "Coder is checking it." }]),
+    ];
+
+    expect(userVisibleMessages(messages).map((item) => item.id)).toEqual(["user", "answer"]);
+  });
+});

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -38,4 +38,13 @@ describe("user-visible messages", () => {
 
     expect(userVisibleMessages(messages).map((item) => item.id)).toEqual(["user", "answer"]);
   });
+
+  it("uses authoritative peer run ids when the receipt is outside the loaded page", () => {
+    const messages = [
+      message("reply", "run-peer", [{ kind: "text", text: "Echoed peer reply" }]),
+      message("answer", "run-user", [{ kind: "text", text: "Visible answer" }]),
+    ];
+
+    expect(userVisibleMessages(messages, ["run-peer"]).map((item) => item.id)).toEqual(["answer"]);
+  });
 });

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -66,4 +66,18 @@ describe("user-visible messages", () => {
     ];
     expect(latestUserVisibleMessage(newestFirst)?.id).toBe("answer");
   });
+
+  it("hides peer-run tails when knownPeerRunIds supplies the run without a receipt", () => {
+    const newestFirst = [
+      message("reply", "run-peer", [{ kind: "text", text: "Echoed peer reply" }]),
+      message("activity", "run-peer", [
+        { kind: "steps", steps: [{ label: "Message bot", count: 1 }] },
+      ]),
+      message("answer", "run-user", [{ kind: "text", text: "Visible answer" }]),
+    ];
+    expect(latestUserVisibleMessage(newestFirst, { knownPeerRunIds: ["run-peer"] })?.id).toBe(
+      "answer",
+    );
+    expect(latestUserVisibleMessage(newestFirst)?.id).toBe("reply");
+  });
 });

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -80,4 +80,16 @@ describe("user-visible messages", () => {
     );
     expect(latestUserVisibleMessage(newestFirst)?.id).toBe("reply");
   });
+
+  it("hides peer-run tails when runTrigger marks the run without a receipt", () => {
+    const messages = [
+      message("user", "run-user", [{ kind: "text", text: "Please ask Coder." }]),
+      {
+        ...message("reply", "run-peer", [{ kind: "text", text: "Sent Coder the endpoints." }]),
+        runTrigger: "bot_message",
+      },
+      message("answer", "run-user", [{ kind: "text", text: "Coder is checking it." }]),
+    ];
+    expect(userVisibleMessages(messages).map((item) => item.id)).toEqual(["user", "answer"]);
+  });
 });

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -1,0 +1,22 @@
+import type { MessageBlock } from "@rakazo/contracts";
+
+type PresentableMessage = {
+  runId?: string;
+  blocks: readonly MessageBlock[];
+};
+
+export function userVisibleMessages<T extends PresentableMessage>(messages: readonly T[]): T[] {
+  const peerRunIds = new Set(
+    messages
+      .filter((message) => message.blocks.some((block) => block.kind === "bot_message_received"))
+      .flatMap((message) => (message.runId ? [message.runId] : [])),
+  );
+
+  return messages.filter(
+    (message) =>
+      !message.blocks.some(
+        (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",
+      ) &&
+      (!message.runId || !peerRunIds.has(message.runId)),
+  );
+}

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -11,6 +11,11 @@ export type UserVisibleMessagesOptions = {
    * Web hides them because PeerMessagesOverlay covers that history.
    */
   includePeerReceipts?: boolean;
+  /**
+   * Extra peer-run ids (e.g. from `run.trigger === "bot_message"`) when the
+   * receipt may fall outside the loaded message window.
+   */
+  knownPeerRunIds?: ReadonlySet<string> | readonly string[];
 };
 
 function isPeerReceipt(blocks: readonly MessageBlock[]): boolean {
@@ -19,12 +24,18 @@ function isPeerReceipt(blocks: readonly MessageBlock[]): boolean {
   );
 }
 
-function peerRunIdsOf(messages: readonly PresentableMessage[]): Set<string> {
-  return new Set(
+function peerRunIdsOf(
+  messages: readonly PresentableMessage[],
+  knownPeerRunIds?: ReadonlySet<string> | readonly string[],
+): Set<string> {
+  const peerRunIds = new Set(
     messages
       .filter((message) => message.blocks.some((block) => block.kind === "bot_message_received"))
       .flatMap((message) => (message.runId ? [message.runId] : [])),
   );
+  if (!knownPeerRunIds) return peerRunIds;
+  for (const runId of knownPeerRunIds) peerRunIds.add(runId);
+  return peerRunIds;
 }
 
 /** Drop peer-run activity/replies; optionally keep sent/received receipt rows. */
@@ -32,7 +43,7 @@ export function userVisibleMessages<T extends PresentableMessage>(
   messages: readonly T[],
   options: UserVisibleMessagesOptions = {},
 ): T[] {
-  const peerRunIds = peerRunIdsOf(messages);
+  const peerRunIds = peerRunIdsOf(messages, options.knownPeerRunIds);
   const includePeerReceipts = options.includePeerReceipts === true;
 
   return messages.filter((message) => {
@@ -43,7 +54,7 @@ export function userVisibleMessages<T extends PresentableMessage>(
 
 /**
  * Newest-first scan for the first user-visible message (sidebar preview).
- * Callers should pass a short newest-desc window; peer classification is limited to that window.
+ * Prefer passing knownPeerRunIds when the receipt may sit outside the window.
  */
 export function latestUserVisibleMessage<T extends PresentableMessage>(
   messagesNewestFirst: readonly T[],

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -5,12 +5,16 @@ type PresentableMessage = {
   blocks: readonly MessageBlock[];
 };
 
-export function userVisibleMessages<T extends PresentableMessage>(messages: readonly T[]): T[] {
-  const peerRunIds = new Set(
-    messages
+export function userVisibleMessages<T extends PresentableMessage>(
+  messages: readonly T[],
+  knownPeerRunIds: Iterable<string> = [],
+): T[] {
+  const peerRunIds = new Set([
+    ...knownPeerRunIds,
+    ...messages
       .filter((message) => message.blocks.some((block) => block.kind === "bot_message_received"))
       .flatMap((message) => (message.runId ? [message.runId] : [])),
-  );
+  ]);
 
   return messages.filter(
     (message) =>

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -2,6 +2,8 @@ import type { MessageBlock } from "@rakazo/contracts";
 
 type PresentableMessage = {
   runId?: string;
+  /** When set to `bot_message`, treat the run as peer even without a receipt in-window. */
+  runTrigger?: string;
   blocks: readonly MessageBlock[];
 };
 
@@ -29,9 +31,14 @@ function peerRunIdsOf(
   knownPeerRunIds?: ReadonlySet<string> | readonly string[],
 ): Set<string> {
   const peerRunIds = new Set(
-    messages
-      .filter((message) => message.blocks.some((block) => block.kind === "bot_message_received"))
-      .flatMap((message) => (message.runId ? [message.runId] : [])),
+    messages.flatMap((message) => {
+      if (!message.runId) return [];
+      if (message.runTrigger === "bot_message") return [message.runId];
+      if (message.blocks.some((block) => block.kind === "bot_message_received")) {
+        return [message.runId];
+      }
+      return [];
+    }),
   );
   if (!knownPeerRunIds) return peerRunIds;
   for (const runId of knownPeerRunIds) peerRunIds.add(runId);

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -5,18 +5,49 @@ type PresentableMessage = {
   blocks: readonly MessageBlock[];
 };
 
-export function userVisibleMessages<T extends PresentableMessage>(messages: readonly T[]): T[] {
-  const peerRunIds = new Set(
+export type UserVisibleMessagesOptions = {
+  /**
+   * Keep `bot_message_sent` / `bot_message_received` rows (mobile compact cards).
+   * Web hides them because PeerMessagesOverlay covers that history.
+   */
+  includePeerReceipts?: boolean;
+};
+
+function isPeerReceipt(blocks: readonly MessageBlock[]): boolean {
+  return blocks.some(
+    (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",
+  );
+}
+
+function peerRunIdsOf(messages: readonly PresentableMessage[]): Set<string> {
+  return new Set(
     messages
       .filter((message) => message.blocks.some((block) => block.kind === "bot_message_received"))
       .flatMap((message) => (message.runId ? [message.runId] : [])),
   );
+}
 
-  return messages.filter(
-    (message) =>
-      !message.blocks.some(
-        (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",
-      ) &&
-      (!message.runId || !peerRunIds.has(message.runId)),
-  );
+/** Drop peer-run activity/replies; optionally keep sent/received receipt rows. */
+export function userVisibleMessages<T extends PresentableMessage>(
+  messages: readonly T[],
+  options: UserVisibleMessagesOptions = {},
+): T[] {
+  const peerRunIds = peerRunIdsOf(messages);
+  const includePeerReceipts = options.includePeerReceipts === true;
+
+  return messages.filter((message) => {
+    if (isPeerReceipt(message.blocks)) return includePeerReceipts;
+    return !message.runId || !peerRunIds.has(message.runId);
+  });
+}
+
+/**
+ * Newest-first scan for the first user-visible message (sidebar preview).
+ * Callers should pass a short newest-desc window; peer classification is limited to that window.
+ */
+export function latestUserVisibleMessage<T extends PresentableMessage>(
+  messagesNewestFirst: readonly T[],
+  options: UserVisibleMessagesOptions = {},
+): T | undefined {
+  return userVisibleMessages(messagesNewestFirst, options)[0];
 }

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -57,40 +57,52 @@ describe("createRepos.listBots", () => {
   });
 
   it("keeps bot-to-bot run output out of sidebar previews", async () => {
-    const prisma = {
-      bot: {
-        findMany: vi.fn(async () => [
-          {
-            ...baseBot,
-            thread: {
-              ...baseBot.thread,
-              messages: [
+    const findMany = vi.fn(async () => [
+      {
+        ...baseBot,
+        thread: {
+          ...baseBot.thread,
+          messages: [
+            {
+              runId: "run-peer",
+              blocks: [{ kind: "text", text: "Echoed peer reply" }],
+            },
+            {
+              runId: "run-peer",
+              blocks: [
                 {
-                  runId: "run-peer",
-                  blocks: [{ kind: "text", text: "Echoed peer reply" }],
+                  kind: "bot_message_received",
+                  fromBotId: "bot-2",
+                  fromBotName: "Coder",
+                  text: "Peer result",
                 },
-                {
-                  runId: "run-peer",
-                  blocks: [
-                    {
-                      kind: "bot_message_received",
-                      fromBotId: "bot-2",
-                      fromBotName: "Coder",
-                      text: "Peer result",
-                    },
-                  ],
-                },
-                { runId: "run-user", blocks: [{ kind: "text", text: "Visible answer" }] },
               ],
             },
-          },
-        ]),
+            { runId: "run-user", blocks: [{ kind: "text", text: "Visible answer" }] },
+          ],
+        },
+      },
+    ]);
+    const prisma = {
+      bot: {
+        findMany,
       },
     };
 
     await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([
       expect.objectContaining({ preview: "Visible answer" }),
     ]);
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({
+          thread: {
+            include: {
+              messages: { orderBy: { seq: "desc" }, take: 16 },
+            },
+          },
+        }),
+      }),
+    );
   });
 });
 

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -55,6 +55,43 @@ describe("createRepos.listBots", () => {
       expect.objectContaining({ memoryScope: "shared" }),
     ]);
   });
+
+  it("keeps bot-to-bot run output out of sidebar previews", async () => {
+    const prisma = {
+      bot: {
+        findMany: vi.fn(async () => [
+          {
+            ...baseBot,
+            thread: {
+              ...baseBot.thread,
+              messages: [
+                {
+                  runId: "run-peer",
+                  blocks: [{ kind: "text", text: "Echoed peer reply" }],
+                },
+                {
+                  runId: "run-peer",
+                  blocks: [
+                    {
+                      kind: "bot_message_received",
+                      fromBotId: "bot-2",
+                      fromBotName: "Coder",
+                      text: "Peer result",
+                    },
+                  ],
+                },
+                { runId: "run-user", blocks: [{ kind: "text", text: "Visible answer" }] },
+              ],
+            },
+          },
+        ]),
+      },
+    };
+
+    await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([
+      expect.objectContaining({ preview: "Visible answer" }),
+    ]);
+  });
 });
 
 describe("createRepos.reorderBots", () => {

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -86,6 +86,9 @@ describe("createRepos.listBots", () => {
           },
         ]),
       },
+      run: {
+        findMany: vi.fn(async () => [{ id: "run-peer" }]),
+      },
     };
 
     await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -39,6 +39,9 @@ function reposFor(memoryScope: string | null) {
     bot: {
       findMany: vi.fn(async () => [{ ...baseBot, memoryScope }]),
     },
+    run: {
+      findMany: vi.fn(async () => []),
+    },
   };
   return createRepos(prisma as unknown as PrismaClient);
 }
@@ -83,9 +86,13 @@ describe("createRepos.listBots", () => {
         },
       },
     ]);
+    const runFindMany = vi.fn(async () => [{ id: "run-peer" }]);
     const prisma = {
       bot: {
         findMany,
+      },
+      run: {
+        findMany: runFindMany,
       },
     };
 
@@ -103,6 +110,39 @@ describe("createRepos.listBots", () => {
         }),
       }),
     );
+    expect(runFindMany).toHaveBeenCalledWith({
+      where: { id: { in: ["run-peer", "run-user"] }, trigger: "bot_message" },
+      select: { id: true },
+    });
+  });
+
+  it("skips a peer-run preview tail when the receipt is outside the window", async () => {
+    const prisma = {
+      bot: {
+        findMany: vi.fn(async () => [
+          {
+            ...baseBot,
+            thread: {
+              ...baseBot.thread,
+              messages: [
+                {
+                  runId: "run-peer",
+                  blocks: [{ kind: "text", text: "Echoed peer reply" }],
+                },
+                { runId: "run-user", blocks: [{ kind: "text", text: "Visible answer" }] },
+              ],
+            },
+          },
+        ]),
+      },
+      run: {
+        findMany: vi.fn(async () => [{ id: "run-peer" }]),
+      },
+    };
+
+    await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([
+      expect.objectContaining({ preview: "Visible answer" }),
+    ]);
   });
 });
 

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -5,6 +5,7 @@ import {
   type BotSection,
   type MessageBlock,
 } from "@rakazo/contracts";
+import { userVisibleMessages } from "@rakazo/core";
 import type { PrismaClient } from "./client.js";
 import { type ComputerMode, ensureComputerRecord, parseComputerMode } from "./computers.js";
 import { createThreadMessageInTransaction } from "./messages.js";
@@ -165,7 +166,7 @@ export function createRepos(prisma: PrismaClient) {
         include: {
           thread: {
             include: {
-              messages: { orderBy: { seq: "desc" }, take: 1 },
+              messages: { orderBy: { seq: "desc" }, take: 100 },
             },
           },
           runs: {
@@ -180,7 +181,14 @@ export function createRepos(prisma: PrismaClient) {
         orderBy: [{ pinned: "desc" }, { position: "asc" }, { createdAt: "asc" }],
       });
       return bots.map((bot) => {
-        const blocks = (bot.thread?.messages[0]?.blocks ?? []) as Array<{
+        const visible = userVisibleMessages(
+          (bot.thread?.messages ?? []).map((message) => ({
+            ...message,
+            blocks: message.blocks as MessageBlock[],
+            runId: message.runId ?? undefined,
+          })),
+        );
+        const blocks = (visible[0]?.blocks ?? []) as Array<{
           kind?: string;
           text?: string;
         }>;

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -5,11 +5,14 @@ import {
   type BotSection,
   type MessageBlock,
 } from "@rakazo/contracts";
-import { userVisibleMessages } from "@rakazo/core";
+import { latestUserVisibleMessage } from "@rakazo/core";
 import type { PrismaClient } from "./client.js";
 import { type ComputerMode, ensureComputerRecord, parseComputerMode } from "./computers.js";
 import { createThreadMessageInTransaction } from "./messages.js";
 import { IsolationError } from "./scope.js";
+
+/** Newest messages loaded for sidebar preview; enough to skip a short peer-run tail. */
+const SIDEBAR_PREVIEW_MESSAGE_WINDOW = 16;
 
 function mapBot(
   bot: {
@@ -166,7 +169,7 @@ export function createRepos(prisma: PrismaClient) {
         include: {
           thread: {
             include: {
-              messages: { orderBy: { seq: "desc" }, take: 100 },
+              messages: { orderBy: { seq: "desc" }, take: SIDEBAR_PREVIEW_MESSAGE_WINDOW },
             },
           },
           runs: {
@@ -181,14 +184,14 @@ export function createRepos(prisma: PrismaClient) {
         orderBy: [{ pinned: "desc" }, { position: "asc" }, { createdAt: "asc" }],
       });
       return bots.map((bot) => {
-        const visible = userVisibleMessages(
+        const newest = latestUserVisibleMessage(
           (bot.thread?.messages ?? []).map((message) => ({
             ...message,
             blocks: message.blocks as MessageBlock[],
             runId: message.runId ?? undefined,
           })),
         );
-        const blocks = (visible[0]?.blocks ?? []) as Array<{
+        const blocks = (newest?.blocks ?? []) as Array<{
           kind?: string;
           text?: string;
         }>;

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -183,6 +183,27 @@ export function createRepos(prisma: PrismaClient) {
         },
         orderBy: [{ pinned: "desc" }, { position: "asc" }, { createdAt: "asc" }],
       });
+      // Classify peer runs by trigger so a preview window that misses the receipt
+      // still skips bot_message tails (Message has no Run relation to include).
+      const previewRunIds = [
+        ...new Set(
+          bots.flatMap((bot) =>
+            (bot.thread?.messages ?? [])
+              .map((message) => message.runId)
+              .filter((runId): runId is string => Boolean(runId)),
+          ),
+        ),
+      ];
+      const knownPeerRunIds = new Set(
+        previewRunIds.length === 0
+          ? []
+          : (
+              await prisma.run.findMany({
+                where: { id: { in: previewRunIds }, trigger: "bot_message" },
+                select: { id: true },
+              })
+            ).map((run) => run.id),
+      );
       return bots.map((bot) => {
         const newest = latestUserVisibleMessage(
           (bot.thread?.messages ?? []).map((message) => ({
@@ -190,6 +211,7 @@ export function createRepos(prisma: PrismaClient) {
             blocks: message.blocks as MessageBlock[],
             runId: message.runId ?? undefined,
           })),
+          { knownPeerRunIds },
         );
         const blocks = (newest?.blocks ?? []) as Array<{
           kind?: string;

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -180,6 +180,22 @@ export function createRepos(prisma: PrismaClient) {
         },
         orderBy: [{ pinned: "desc" }, { position: "asc" }, { createdAt: "asc" }],
       });
+      const candidateRunIds = [
+        ...new Set(
+          bots.flatMap((bot) =>
+            (bot.thread?.messages ?? []).flatMap((message) =>
+              message.runId ? [message.runId] : [],
+            ),
+          ),
+        ),
+      ];
+      const peerRuns = candidateRunIds.length
+        ? await prisma.run.findMany({
+            where: { id: { in: candidateRunIds }, trigger: "bot_message" },
+            select: { id: true },
+          })
+        : [];
+      const peerRunIds = peerRuns.map((run) => run.id);
       return bots.map((bot) => {
         const visible = userVisibleMessages(
           (bot.thread?.messages ?? []).map((message) => ({
@@ -187,6 +203,7 @@ export function createRepos(prisma: PrismaClient) {
             blocks: message.blocks as MessageBlock[],
             runId: message.runId ?? undefined,
           })),
+          peerRunIds,
         );
         const blocks = (visible[0]?.blocks ?? []) as Array<{
           kind?: string;


### PR DESCRIPTION
## Summary

- hide bot-to-bot receipts, activity, and peer-triggered replies from the normal web and mobile transcripts
- keep peer exchanges available through a dedicated Bot messages control
- prevent hidden peer replies from leaking through sidebar previews

## Verification

- `pnpm vitest run packages/core/src/message-visibility.test.ts packages/db/src/repos.test.ts`
- `pnpm run check`
- `pnpm run build`
- `./node_modules/.bin/biome check .`
- served-surface QA at 1440×900 and 390×844 with isolated fake peer exchanges; no transcript leaks, overflow, console errors, or failed requests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated peer-messages view that loads complete conversation history and reports loading failures clearly.
  * Added controls to open peer messages from active conversations.
  * Authorization popups now reuse a consistent window instead of opening duplicates.

* **Bug Fixes**
  * External links and navigation now open in the system browser when appropriate.
  * Hidden bot-to-bot activity is excluded from user-facing transcripts, previews, and live updates.
  * Improved handling of peer-message history and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->