### PR TITLE
feat: add OrcaRouter as a first-class model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ SANDBOX_COMMAND_TIMEOUT_MS=300000
 MAX_TOOL_CALLS_PER_TURN=
 # Deployment-wide fallback model. PI_DEFAULT_PROVIDER picks which key below is used.
 OPENROUTER_API_KEY=
+ORCAROUTER_API_KEY=
 ANTHROPIC_API_KEY=
 PI_DEFAULT_PROVIDER=openrouter
 # Text-only by default. Computer use (screenshots via computer_observe / computer_act)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ cp .env.example .env
 
 Set `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, and `SCREEN_PROXY_SECRET` in `.env` to independent
 long random values. Docker sandboxes also need a dedicated `SANDBOX_SUPERVISOR_TOKEN`. You can
-also set `OPENROUTER_API_KEY`, or connect a supported model provider during onboarding.
+also set `OPENROUTER_API_KEY` or `ORCAROUTER_API_KEY`, or connect a supported model provider
+during onboarding.
 
 Managed app catalogs are optional. Set `COMPOSIO_API_KEY` for Composio, or the
 `PIPEDREAM_CLIENT_ID`, `PIPEDREAM_CLIENT_SECRET`, and `PIPEDREAM_PROJECT_ID` trio for Pipedream

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -22,7 +22,7 @@ Before making changes, ask me these concise questions:
 
 1. Which directory should contain the Rakazo folder (or use the current directory)?
 2. How should models be connected?
-   - Add a deployment-wide `OPENROUTER_API_KEY` to `.env`.
+   - Add a deployment-wide `OPENROUTER_API_KEY` or `ORCAROUTER_API_KEY` to `.env`.
    - Connect during Rakazo onboarding with a provider API key or with ChatGPT Plus/Pro, GitHub Copilot, or SuperGrok / X Premium.
    - Defer model setup and verify infrastructure only. Make clear that bots cannot answer until a model is connected.
 3. Do I want remote computers instead of local Docker? If yes, choose E2B (`E2B_API_KEY`), Daytona (`DAYTONA_API_KEY`), or Box (`BOX_API_KEY`) and set `SANDBOX_PROVIDER` accordingly. If no, keep the default `SANDBOX_PROVIDER=docker` (local computers via the in-stack supervisor).
@@ -78,7 +78,7 @@ Before making changes, ask me these concise questions:
 
 1. Should you clone into the current directory, or what parent directory should contain `rakazo`? If you are already inside a Rakazo checkout, offer to use it without recloning.
 2. How should models be connected?
-   - Add a deployment-wide `OPENROUTER_API_KEY` to `.env`.
+   - Add a deployment-wide `OPENROUTER_API_KEY` or `ORCAROUTER_API_KEY` to `.env`.
    - Connect during Rakazo onboarding with a provider API key or with ChatGPT Plus/Pro, GitHub Copilot, or SuperGrok / X Premium.
    - Defer model setup and verify infrastructure only. Make clear that bots cannot answer until a model is connected.
 3. Do I want a managed app catalog? If yes, choose Composio (`COMPOSIO_API_KEY`) or Pipedream Connect (`PIPEDREAM_CLIENT_ID`, `PIPEDREAM_CLIENT_SECRET`, and `PIPEDREAM_PROJECT_ID`); otherwise leave them empty. Explain that this is optional and that users can still add Treg, HTTPS MCP, or OpenAPI sources in the app.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -28,7 +28,7 @@ Signup and local Docker computers work without an E2B account. Optional remote p
 `SANDBOX_PROVIDER` to `e2b`, `daytona`, or `box` and add the matching API key. Compose requires
 `SANDBOX_SUPERVISOR_TOKEN` for the Docker path; leave it empty and `compose up` fails closed.
 
-Optional: set `OPENROUTER_API_KEY` or connect a model in the UI after signup.
+Optional: set `OPENROUTER_API_KEY` or `ORCAROUTER_API_KEY`, or connect a model in the UI after signup.
 
 The example defaults to `edge` (main builds, `linux/amd64` only). On arm64 hosts, set both
 `RAKAZO_IMAGE_TAG` and `RAKAZO_COMPUTER_IMAGE_TAG` to the same published multi-arch release tag
@@ -45,7 +45,7 @@ production Compose path below.
 ## Docker Compose (single machine)
 
 1. Copy `.env.example` to `.env` and set `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, and `SCREEN_PROXY_SECRET` to independent long random strings (32+ characters; 64 hex for `ENCRYPTION_KEY`). Docker sandboxes also need a dedicated `SANDBOX_SUPERVISOR_TOKEN`. Keep existing `ENCRYPTION_KEY` values so stored credentials stay decryptable.
-2. Set `OPENROUTER_API_KEY` (and `COMPOSIO_API_KEY` if you want Plugins).
+2. Set `OPENROUTER_API_KEY` or `ORCAROUTER_API_KEY` (and `COMPOSIO_API_KEY` if you want Plugins).
 3. Build the computer image: `pnpm sandbox:build` (Compose also builds it via the `computer` service).
 4. `docker compose --env-file .env -f infra/compose/docker-compose.yml up --build`
 5. Open the web origin (`http://127.0.0.1:5173` by default). The first registered user becomes the deployment owner.
@@ -179,7 +179,7 @@ container logs, default no-new-privileges, and the kernel NAT path instead of Do
    whenever Cloudflare publishes a change. A Cloudflare Tunnel can replace the public web listeners.
 2. Clone the repository on the VM and create a root `.env` with production-only values. At minimum set
    `POSTGRES_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `SCREEN_PROXY_SECRET`,
-   `E2B_API_KEY`, `OPENROUTER_API_KEY`,
+   `E2B_API_KEY`, `OPENROUTER_API_KEY` (or `ORCAROUTER_API_KEY`),
    `RAKAZO_HOST`, and the three public origins. Set `RAKAZO_DEPLOY_DIR` when the checkout is not at
    the supported Linux default, `/srv/rakazo`. Use URL-safe random values for database credentials.
    If you enable the `updater` profile, also set a dedicated `RAKAZO_UPDATER_TOKEN` (at least 32

--- a/packages/adapters/src/auto-review.ts
+++ b/packages/adapters/src/auto-review.ts
@@ -86,6 +86,7 @@ export function isAutoReviewCheckerConfigured(input: {
   const deployment = resolveDeploymentModel(env);
   if (checker.provider === deployment.provider && deployment.key) return true;
   if (env.OPENROUTER_API_KEY?.trim() && checker.provider === "openrouter") return true;
+  if (env.ORCAROUTER_API_KEY?.trim() && checker.provider === "orcarouter") return true;
   if (env.ANTHROPIC_API_KEY?.trim() && checker.provider === "anthropic") return true;
   return Boolean(input.hasUserCredentialForProvider?.(checker.provider));
 }

--- a/packages/adapters/src/deployment-model.test.ts
+++ b/packages/adapters/src/deployment-model.test.ts
@@ -20,4 +20,19 @@ describe("resolveDeploymentModel", () => {
       resolveDeploymentModel({ OPENROUTER_API_KEY: "or-key", PI_DEFAULT_PROVIDER: "anthropic" }),
     ).toEqual({ provider: "anthropic", model: "claude-sonnet-5", key: undefined });
   });
+
+  it("pairs the OrcaRouter deployment key with the orcarouter provider", () => {
+    const env = { ORCAROUTER_API_KEY: "orc-key", OPENROUTER_API_KEY: "or-key" };
+    expect(resolveDeploymentModel({ ...env, PI_DEFAULT_PROVIDER: "orcarouter" })).toEqual({
+      provider: "orcarouter",
+      model: "orcarouter/auto",
+      key: "orc-key",
+    });
+    // OpenRouter keeps its own key when it is the default provider.
+    expect(resolveDeploymentModel(env)).toEqual({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash-0731",
+      key: "or-key",
+    });
+  });
 });

--- a/packages/adapters/src/deployment-model.ts
+++ b/packages/adapters/src/deployment-model.ts
@@ -11,10 +11,12 @@ export function resolveDeploymentModel(env: NodeJS.ProcessEnv = process.env) {
   // vendor's, which a ternary on one provider would not give.
   const keys: Record<string, string | undefined> = {
     openrouter: env.OPENROUTER_API_KEY,
+    orcarouter: env.ORCAROUTER_API_KEY,
     anthropic: env.ANTHROPIC_API_KEY,
   };
   const models: Record<string, string> = {
     openrouter: "deepseek/deepseek-v4-flash-0731",
+    orcarouter: "orcarouter/auto",
     anthropic: "claude-sonnet-5",
   };
   return {

--- a/packages/adapters/src/executor-approval-pi.test.ts
+++ b/packages/adapters/src/executor-approval-pi.test.ts
@@ -68,6 +68,11 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
+vi.mock("./pi-orca-router-provider.js", () => ({
+  ORCAROUTER_PROVIDER_ID: "orcarouter",
+  registerOrcaRouterCatalog: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime } from "./pi-runtime.js";
 
 const destinationTool: ConnectorTool = {

--- a/packages/adapters/src/executor-secret-pi.test.ts
+++ b/packages/adapters/src/executor-secret-pi.test.ts
@@ -66,6 +66,11 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
+vi.mock("./pi-orca-router-provider.js", () => ({
+  ORCAROUTER_PROVIDER_ID: "orcarouter",
+  registerOrcaRouterCatalog: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime } from "./pi-runtime.js";
 
 const secretTool: ConnectorTool = {

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -54,6 +54,7 @@ export * from "./phone-delivery.js";
 export * from "./pi-models.js";
 export * from "./pi-oauth.js";
 export * from "./pi-openai-compatible-provider.js";
+export * from "./pi-orca-router-provider.js";
 export * from "./pi-runtime.js";
 export * from "./pipedream-connector.js";
 export * from "./realtime.js";

--- a/packages/adapters/src/model-vision.ts
+++ b/packages/adapters/src/model-vision.ts
@@ -5,6 +5,7 @@ import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
   registerOpenAiCompatibleCatalog,
 } from "./pi-openai-compatible-provider.js";
+import { ORCAROUTER_PROVIDER_ID, registerOrcaRouterCatalog } from "./pi-orca-router-provider.js";
 
 /** Computer tools whose results include screenshots for the model. */
 export const IMAGE_RETURNING_COMPUTER_TOOLS = new Set([
@@ -21,7 +22,9 @@ const SCRIPTED_DEFAULT_MODEL_ID = "deepseek/deepseek-v4-flash-0731";
 let catalogModelsCache: Models | undefined;
 
 function catalogModels(): Models {
-  catalogModelsCache ??= registerOpenAiCompatibleCatalog(registerLocalProvider(builtinModels()));
+  catalogModelsCache ??= registerOpenAiCompatibleCatalog(
+    registerLocalProvider(registerOrcaRouterCatalog(builtinModels())),
+  );
   return catalogModelsCache;
 }
 
@@ -59,6 +62,7 @@ export function modelAcceptsImageInput(provider: string, modelId: string): boole
   if (
     !model &&
     resolved.provider !== "openrouter" &&
+    resolved.provider !== ORCAROUTER_PROVIDER_ID &&
     resolved.provider !== OPENAI_COMPATIBLE_PROVIDER_ID
   ) {
     model = models.getModel("openrouter", resolved.id);

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -49,6 +49,39 @@ describe("Pi model catalog", () => {
     expect(openAiCompatible).toMatchObject({ id: "custom", placeholder: true });
   });
 
+  it("lists OrcaRouter as a first-class gateway provider", () => {
+    const catalog = listPiCatalog();
+    const orca = catalog.filter((entry) => entry.provider === "orcarouter");
+    expect(orca.length).toBeGreaterThan(0);
+    expect(orca[0]).toMatchObject({
+      provider: "orcarouter",
+      providerName: "OrcaRouter",
+      auth: "api-key",
+    });
+    expect(catalog.find((entry) => entry.id === "orcarouter/auto")).toMatchObject({
+      provider: "orcarouter",
+      reasoning: true,
+    });
+    const vision = catalog.find((entry) => entry.id === "openai/gpt-4o");
+    // The OrcaRouter catalog carries its own vision-capable models.
+    expect(orca.some((entry) => entry.id === "orcarouter/auto")).toBe(true);
+    expect(vision).toBeDefined();
+  });
+
+  it("adds a configured OrcaRouter model that is newer than the static catalog", async () => {
+    vi.stubEnv("PI_DEFAULT_PROVIDER", " orcarouter ");
+    vi.stubEnv("PI_DEFAULT_MODEL", " orca-test/future-model ");
+    vi.resetModules();
+
+    const { listPiCatalog: listConfiguredCatalog } = await import("./pi-models.js");
+    expect(listConfiguredCatalog()[0]).toMatchObject({
+      provider: "orcarouter",
+      providerName: "OrcaRouter",
+      id: "orca-test/future-model",
+      label: "orca-test/future-model",
+    });
+  });
+
   it("adds a configured OpenRouter model that is newer than the static catalog", async () => {
     vi.stubEnv("PI_DEFAULT_PROVIDER", " openrouter ");
     vi.stubEnv("PI_DEFAULT_MODEL", " rakazo-test/unknown-future-model ");

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -8,6 +8,7 @@ import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
   registerOpenAiCompatibleCatalog,
 } from "./pi-openai-compatible-provider.js";
+import { ORCAROUTER_PROVIDER_ID, registerOrcaRouterCatalog } from "./pi-orca-router-provider.js";
 
 export type PiCatalogAuth = "api-key" | "oauth" | "both";
 
@@ -35,7 +36,9 @@ export function listPiCatalog(): PiCatalogEntry[] {
 let cachedCatalog: PiCatalogEntry[] | undefined;
 
 function buildPiCatalog(): PiCatalogEntry[] {
-  const models = registerOpenAiCompatibleCatalog(registerLocalProvider(builtinModels()));
+  const models = registerOpenAiCompatibleCatalog(
+    registerLocalProvider(registerOrcaRouterCatalog(builtinModels())),
+  );
   const entries: PiCatalogEntry[] = [];
   for (const provider of models.getProviders()) {
     const apiKey = Boolean(provider.auth.apiKey);
@@ -72,14 +75,17 @@ function buildPiCatalog(): PiCatalogEntry[] {
 
   const envDefaultModel = process.env.PI_DEFAULT_MODEL?.trim();
   const envDefaultProvider = process.env.PI_DEFAULT_PROVIDER?.trim() || "openrouter";
+  // A gateway provider configured with a model newer than its static catalog
+  // still needs a selectable entry. OpenRouter and OrcaRouter share the
+  // provider/model namespace and can both synthesize one.
   if (
-    envDefaultProvider === "openrouter" &&
+    (envDefaultProvider === "openrouter" || envDefaultProvider === ORCAROUTER_PROVIDER_ID) &&
     envDefaultModel &&
-    !models.getModel("openrouter", envDefaultModel)
+    !models.getModel(envDefaultProvider, envDefaultModel)
   ) {
     entries.unshift({
-      provider: "openrouter",
-      providerName: "OpenRouter",
+      provider: envDefaultProvider,
+      providerName: envDefaultProvider === ORCAROUTER_PROVIDER_ID ? "OrcaRouter" : "OpenRouter",
       id: envDefaultModel,
       label: envDefaultModel,
       billing: `Configured via PI_DEFAULT_MODEL (${envDefaultModel}).`,

--- a/packages/adapters/src/pi-orca-router-provider.ts
+++ b/packages/adapters/src/pi-orca-router-provider.ts
@@ -1,0 +1,112 @@
+import {
+  createProvider,
+  envApiKeyAuth,
+  type Model,
+  type MutableModels,
+  type Provider,
+} from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+/**
+ * OrcaRouter is an OpenAI-compatible AI gateway that mirrors the
+ * provider/model namespace OpenRouter exposes, so it slots into the same
+ * catalog as a first-class provider instead of an anonymous custom base URL.
+ * The base URL is fixed and the model list is curated from the gateway's
+ * /models endpoint (the same public models any OrcaRouter key can call).
+ */
+export const ORCAROUTER_PROVIDER_ID = "orcarouter";
+
+const ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1";
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 32_768;
+
+type OrcaRouterModelOptions = {
+  /** Models that do their own reasoning before answering must not start at "off". */
+  reasoning?: boolean;
+  /** Models that accept image input. */
+  vision?: boolean;
+};
+
+function orcaRouterModel(
+  id: string,
+  options: OrcaRouterModelOptions = {},
+): Model<"openai-completions"> {
+  return {
+    id,
+    name: id,
+    api: "openai-completions",
+    provider: ORCAROUTER_PROVIDER_ID,
+    baseUrl: ORCAROUTER_BASE_URL,
+    reasoning: options.reasoning ?? false,
+    input: options.vision ? ["text", "image"] : ["text"],
+    // Billed through the gateway key; Rakazo does not pay for model usage.
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+  };
+}
+
+function orcaRouterModels(): Model<"openai-completions">[] {
+  return [
+    // Adaptive routing and OrcaRouter's own model namespace.
+    orcaRouterModel("orcarouter/auto", { reasoning: true }),
+    orcaRouterModel("orcarouter/free"),
+    orcaRouterModel("orcarouter/fusion", { reasoning: true }),
+    orcaRouterModel("orcarouter/fusion-flash"),
+    orcaRouterModel("orcarouter/fusion-mini"),
+    orcaRouterModel("orcarouter/orcacode-review", { reasoning: true }),
+    orcaRouterModel("orcarouter/open-code", { reasoning: true }),
+    // Anthropic
+    orcaRouterModel("anthropic/claude-fable-5", { reasoning: true, vision: true }),
+    orcaRouterModel("anthropic/claude-opus-4.8", { reasoning: true, vision: true }),
+    orcaRouterModel("anthropic/claude-sonnet-5", { reasoning: true, vision: true }),
+    orcaRouterModel("anthropic/claude-haiku-4.5", { reasoning: true, vision: true }),
+    // DeepSeek
+    orcaRouterModel("deepseek/deepseek-v4-flash-0731"),
+    orcaRouterModel("deepseek/deepseek-v4-pro-0813", { reasoning: true }),
+    orcaRouterModel("deepseek/deepseek-reasoner", { reasoning: true }),
+    // Google
+    orcaRouterModel("google/gemini-3.5-flash", { vision: true }),
+    orcaRouterModel("google/gemini-3.1-pro-preview", { reasoning: true, vision: true }),
+    orcaRouterModel("google/gemini-2.5-flash", { vision: true }),
+    // Grok
+    orcaRouterModel("grok/grok-4.6", { vision: true }),
+    // OpenAI
+    orcaRouterModel("openai/gpt-5.5", { reasoning: true }),
+    orcaRouterModel("openai/gpt-5.4", { reasoning: true }),
+    orcaRouterModel("openai/gpt-5.2", { reasoning: true }),
+    orcaRouterModel("openai/gpt-5.6-luna", { reasoning: true }),
+    orcaRouterModel("openai/gpt-4o", { vision: true }),
+    orcaRouterModel("openai/gpt-4o-mini", { vision: true }),
+    // Qwen
+    orcaRouterModel("qwen/qwen3.8-flash"),
+    orcaRouterModel("qwen/qwen3.8-max", { reasoning: true }),
+    orcaRouterModel("qwen/qwen3-vl-235b-a22b-instruct", { vision: true }),
+    // Z.ai
+    orcaRouterModel("z-ai/glm-5.3", { reasoning: true }),
+    orcaRouterModel("z-ai/glm-5.2"),
+    // Kimi
+    orcaRouterModel("kimi/kimi-k2.7-code", { reasoning: true }),
+    // Meta
+    orcaRouterModel("meta/muse-spark-1.2", { reasoning: true }),
+  ];
+}
+
+export function orcaRouterProvider(): Provider {
+  return createProvider({
+    id: ORCAROUTER_PROVIDER_ID,
+    name: "OrcaRouter",
+    baseUrl: ORCAROUTER_BASE_URL,
+    auth: {
+      apiKey: envApiKeyAuth("OrcaRouter API key", ["ORCAROUTER_API_KEY"]),
+    },
+    models: orcaRouterModels(),
+    api: openAICompletionsApi(),
+  });
+}
+
+/** Register the OrcaRouter provider on a Models collection. */
+export function registerOrcaRouterCatalog(models: MutableModels): MutableModels {
+  models.setProvider(orcaRouterProvider());
+  return models;
+}

--- a/packages/adapters/src/pi-runtime-attachments.test.ts
+++ b/packages/adapters/src/pi-runtime-attachments.test.ts
@@ -39,6 +39,11 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
+vi.mock("./pi-orca-router-provider.js", () => ({
+  ORCAROUTER_PROVIDER_ID: "orcarouter",
+  registerOrcaRouterCatalog: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime } from "./pi-runtime.js";
 
 describe("Pi runtime attachments", () => {

--- a/packages/adapters/src/pi-runtime-computer.test.ts
+++ b/packages/adapters/src/pi-runtime-computer.test.ts
@@ -62,6 +62,11 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
+vi.mock("./pi-orca-router-provider.js", () => ({
+  ORCAROUTER_PROVIDER_ID: "orcarouter",
+  registerOrcaRouterCatalog: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime, pruneComputerScreenshotContext } from "./pi-runtime.js";
 
 const computerObserve: ConnectorTool = {

--- a/packages/adapters/src/pi-runtime-error.test.ts
+++ b/packages/adapters/src/pi-runtime-error.test.ts
@@ -28,6 +28,11 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
+vi.mock("./pi-orca-router-provider.js", () => ({
+  ORCAROUTER_PROVIDER_ID: "orcarouter",
+  registerOrcaRouterCatalog: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime } from "./pi-runtime.js";
 
 describe("Pi runtime errors", () => {

--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -84,6 +84,11 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
+vi.mock("./pi-orca-router-provider.js", () => ({
+  ORCAROUTER_PROVIDER_ID: "orcarouter",
+  registerOrcaRouterCatalog: (models: unknown) => models,
+}));
+
 import { PiAgentRuntime } from "./pi-runtime.js";
 
 async function runWithModel(

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -113,6 +113,11 @@ vi.mock("./pi-openai-compatible-provider.js", () => ({
   registerOpenAiCompatibleRuntime: (models: unknown) => models,
 }));
 
+vi.mock("./pi-orca-router-provider.js", () => ({
+  ORCAROUTER_PROVIDER_ID: "orcarouter",
+  registerOrcaRouterCatalog: (models: unknown) => models,
+}));
+
 import { maxToolCallsPerTurn, PiAgentRuntime } from "./pi-runtime.js";
 
 const destinationTool: ConnectorTool = {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -26,6 +26,7 @@ import {
   registerOpenAiCompatibleCatalog,
   registerOpenAiCompatibleRuntime,
 } from "./pi-openai-compatible-provider.js";
+import { ORCAROUTER_PROVIDER_ID, registerOrcaRouterCatalog } from "./pi-orca-router-provider.js";
 import { textContentArg } from "./tool-text.js";
 
 const running = new Map<string, AbortController>();
@@ -34,7 +35,9 @@ const running = new Map<string, AbortController>();
 // would run before .env is loaded and miss the local provider entirely.
 let catalogModelsCache: Models | undefined;
 function catalogModels(): Models {
-  catalogModelsCache ??= registerOpenAiCompatibleCatalog(registerLocalProvider(builtinModels()));
+  catalogModelsCache ??= registerOpenAiCompatibleCatalog(
+    registerLocalProvider(registerOrcaRouterCatalog(builtinModels())),
+  );
   return catalogModelsCache;
 }
 const MAX_PARALLEL_SUBAGENTS = 4;
@@ -101,16 +104,17 @@ export class PiAgentRuntime implements AgentRuntime {
             : request.model.id.trim();
         const models = modelsForRequest(request, provider);
         let model = models.getModel(provider, modelId);
-        if (!model && provider !== "openrouter" && provider !== OPENAI_COMPATIBLE_PROVIDER_ID) {
+        const isGatewayProvider = provider === "openrouter" || provider === ORCAROUTER_PROVIDER_ID;
+        if (!model && !isGatewayProvider && provider !== OPENAI_COMPATIBLE_PROVIDER_ID) {
           model = models.getModel("openrouter", modelId);
         }
         if (
           !model &&
-          provider === "openrouter" &&
-          envDefaultProvider === "openrouter" &&
+          isGatewayProvider &&
+          envDefaultProvider === provider &&
           modelId === envDefaultModel
         ) {
-          model = configuredOpenRouterModel(modelId);
+          model = configuredGatewayModel(provider, modelId);
         }
         if (!model) {
           queue.push({ type: "text", text: `Unknown model ${provider}/${modelId}` });
@@ -122,10 +126,15 @@ export class PiAgentRuntime implements AgentRuntime {
           ? undefined
           : request.model.provider === OPENAI_COMPATIBLE_PROVIDER_ID
             ? request.model.apiKey || "local"
-            : // Only OpenRouter may fall back to the OpenRouter env key. Handing it to
-              // another provider would ship our key to a vendor it was not issued for.
+            : // Only gateway providers may fall back to their own env key. Handing
+              // the OpenRouter key to another provider would ship our key to a
+              // vendor it was not issued for; OrcaRouter has its own.
               (request.model.apiKey ??
-              (provider === "openrouter" ? process.env.OPENROUTER_API_KEY : undefined));
+              (provider === "openrouter"
+                ? process.env.OPENROUTER_API_KEY
+                : provider === ORCAROUTER_PROVIDER_ID
+                  ? process.env.ORCAROUTER_API_KEY
+                  : undefined));
         const toolDefs = request.tools.length ? request.tools : builtinAgentTools;
         const nestedAgents = new Set<Agent>();
         const host: ToolHost = {
@@ -285,17 +294,21 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 }
 
-function configuredOpenRouterModel(id: string): Model<"openai-completions"> {
+function configuredGatewayModel(provider: string, id: string): Model<"openai-completions"> {
   // A configured model can intentionally be newer than Pi's static catalog. Keep
-  // pricing conservative, but enable reasoning: unknown OpenRouter endpoints
+  // pricing conservative, but enable reasoning: unknown gateway endpoints
   // (e.g. gemini-3.7-flash before the snapshot catches up) often mandate it, and
   // thinkingLevel "off" becomes effort "none" which those endpoints reject.
+  const baseUrl =
+    provider === ORCAROUTER_PROVIDER_ID
+      ? "https://api.orcarouter.ai/v1"
+      : "https://openrouter.ai/api/v1";
   return {
     id,
     name: id,
     api: "openai-completions",
-    provider: "openrouter",
-    baseUrl: "https://openrouter.ai/api/v1",
+    provider,
+    baseUrl,
     reasoning: true,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -313,13 +326,15 @@ export function modelsForRequest(
     const persist = oauth.persist;
     return registerOpenAiCompatibleCatalog(
       registerLocalProvider(
-        builtinModels({
-          credentials: new PiRuntimeCredentialStore(
-            provider,
-            toOAuthCredential(oauth.credential),
-            persist ? (next) => persist(next) : undefined,
-          ),
-        }),
+        registerOrcaRouterCatalog(
+          builtinModels({
+            credentials: new PiRuntimeCredentialStore(
+              provider,
+              toOAuthCredential(oauth.credential),
+              persist ? (next) => persist(next) : undefined,
+            ),
+          }),
+        ),
       ),
     );
   }

--- a/packages/testkit/src/cli/canary.ts
+++ b/packages/testkit/src/cli/canary.ts
@@ -4,9 +4,10 @@ import { PostgreSqlContainer } from "@testcontainers/postgresql";
 
 async function main() {
   const runOpenRouter = Boolean(process.env.OPENROUTER_API_KEY);
-  if (!process.env.E2B_API_KEY && !process.env.BOX_API_KEY && !runOpenRouter) {
+  const runOrcaRouter = Boolean(process.env.ORCAROUTER_API_KEY);
+  if (!process.env.E2B_API_KEY && !process.env.BOX_API_KEY && !runOpenRouter && !runOrcaRouter) {
     throw new Error(
-      "E2B_API_KEY, BOX_API_KEY, or OPENROUTER_API_KEY is required for live provider canaries",
+      "E2B_API_KEY, BOX_API_KEY, OPENROUTER_API_KEY, or ORCAROUTER_API_KEY is required for live provider canaries",
     );
   }
 

--- a/packages/testkit/src/providers.canary.test.ts
+++ b/packages/testkit/src/providers.canary.test.ts
@@ -24,11 +24,13 @@ loadEnvFile();
 const liveE2b = Boolean(process.env.VERIFY_PROVIDERS && process.env.E2B_API_KEY);
 const liveBox = Boolean(process.env.VERIFY_PROVIDERS && process.env.BOX_API_KEY);
 const livePi = Boolean(process.env.VERIFY_PROVIDERS && process.env.OPENROUTER_API_KEY);
+const liveOrca = Boolean(process.env.VERIFY_PROVIDERS && process.env.ORCAROUTER_API_KEY);
 const livePiApp = Boolean(livePi && process.env.DATABASE_URL);
 
 const describeE2b = liveE2b ? describe : describe.skip;
 const describeBox = liveBox ? describe : describe.skip;
 const describePi = livePi ? describe : describe.skip;
+const describeOrca = liveOrca ? describe : describe.skip;
 const describePiApp = livePiApp ? describe : describe.skip;
 
 describeE2b("live E2B canary", () => {
@@ -137,6 +139,41 @@ describePi("live OpenRouter / Pi canary", () => {
     }
     expect(text.toLowerCase()).toMatch(/pong/);
     expect(text).not.toMatch(/sk-or-|OPENROUTER_API_KEY/i);
+  }, 90_000);
+});
+
+describeOrca("live OrcaRouter / Pi canary", () => {
+  it("streams a reply from orcarouter/auto", async () => {
+    const runtime = new PiAgentRuntime();
+    let text = "";
+    for await (const event of runtime.run(
+      {
+        botId: "canary",
+        threadId: "canary",
+        runId: `orca-${Date.now()}`,
+        prompt: "Reply with exactly the word pong and nothing else.",
+        instructions: "You are a concise test bot. Do not call tools.",
+        history: [],
+        tools: [],
+        model: {
+          provider: "orcarouter",
+          id: "orcarouter/auto",
+          apiKey: process.env.ORCAROUTER_API_KEY,
+        },
+      },
+      {
+        operationId: "canary",
+        traceId: "canary",
+        workspaceId: "canary",
+        userId: "canary",
+        signal: new AbortController().signal,
+      },
+    )) {
+      if (event.type === "text") text += event.text;
+      if (event.type === "done" && event.text && !text) text = event.text;
+    }
+    expect(text.toLowerCase()).toMatch(/pong/);
+    expect(text).not.toMatch(/ORCAROUTER_API_KEY/i);
   }, 90_000);
 });
 


### PR DESCRIPTION
Rakazo users who bring their own model credentials through Pi can now select **OrcaRouter** as a first-class provider and paste an `ORCAROUTER_API_KEY`, the same way they already do for OpenRouter — instead of fitting the gateway behind a custom OpenAI-compatible base URL. That single key turns on OrcaRouter's adaptive routing, automatic failover, observability, and guardrails across the same model namespace Pi already speaks (`provider/model` ids like `orcarouter/auto`), so persistent AI teammates get the whole stack without any app-level code changes.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The change mirrors Rakazo's existing OpenRouter wiring exactly: a `pi-orca-router-provider.ts` registers a fixed-base-URL provider on the Pi catalog, `deployment-model.ts` pairs `ORCAROUTER_API_KEY` with the provider so a deployment default never hands one vendor's key to another, the runtime falls back to the OrcaRouter env key for `orcarouter` runs, and `model-vision.ts` / `auto-review.ts` gate vision and safety-check the same way they do for OpenRouter. `PI_DEFAULT_PROVIDER=orcarouter` also synthesizes a selectable entry when `PI_DEFAULT_MODEL` names a model newer than the static catalog.

Verified: `pnpm test` (2002 passing), `pnpm check`, and `pnpm lint` are green, and the new live canary in `packages/testkit/src/providers.canary.test.ts` streams a reply from `orcarouter/auto` through the real gateway. Docs updated in `.env.example`, `README.md`, `docs/self-host.md`, and `SETUP_PROMPT.md`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Orca Router as a supported model provider.
  * Added support for configuring Orca Router with `ORCAROUTER_API_KEY`.
  * Added access to Orca Router’s reasoning and vision-capable models, including the `orcarouter/auto` default.
  * Added provider support to deployment configuration, model selection, runtime features, and live connectivity checks.

* **Documentation**
  * Updated local setup and self-hosting instructions to include Orca Router configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->