### PR TITLE
feat(chat): persist thumbs-up message reactions

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -136,6 +136,7 @@ import {
 import { assertTeachingSendAllowed, createTaughtSkillsService } from "./taught-skills.js";
 import { isPeerRun, loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
 import {
+  reactToThreadMessage,
   resolveThreadTarget,
   sendThreadMessage,
   setThreadUnreadState,
@@ -1059,6 +1060,27 @@ export function createRouter(deps: RouterDeps) {
           await assertTeachingSendAllowed(deps.prisma, context.actor.spaceId, target.botId);
         }
         return sendThreadMessage(deps, context.actor, target, input);
+      }),
+      react: authed.threads.react.handler(async ({ context, input }) => {
+        const target = await resolveThreadTarget(deps.prisma, context.actor, input);
+        const result = await reactToThreadMessage(
+          deps,
+          context.actor,
+          target,
+          input.messageId,
+          input.thumbsUp,
+        );
+        if (result.eventSeq != null) {
+          await deps.events.notify(target.threadId, result.eventSeq).catch((error) => {
+            console.error("thread reaction realtime notification", error);
+          });
+        }
+        if (result.runId) {
+          await deps.jobs.enqueue(runContinueJob(result.runId)).catch((error) => {
+            console.error("thread reaction enqueue", error);
+          });
+        }
+        return { ok: true as const };
       }),
       stop: authed.threads.stop.handler(async ({ context, input }) => {
         const target = await resolveThreadTarget(deps.prisma, context.actor, input);

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -402,6 +402,7 @@ describe("thread message pages", () => {
         role: "bot",
         blocks: [{ kind: "text", text: String(seq) }],
         runId: null,
+        thumbsUp: seq === 4,
         createdAt: new Date(`2026-08-16T00:00:0${seq}.000Z`),
       })),
     );
@@ -415,6 +416,7 @@ describe("thread message pages", () => {
       take: 3,
     });
     expect(page.messages.map((message) => message.seq)).toEqual([4, 5]);
+    expect(page.messages[0]?.thumbsUp).toBe(true);
     expect(page.olderCursor).toBe(4);
   });
 

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -139,6 +139,7 @@ function toThreadMessage(row: {
   botId: string | null;
   replyToMessageId: string | null;
   runId: string | null;
+  thumbsUp: boolean;
   createdAt: Date;
 }): ThreadMessage {
   return {
@@ -150,6 +151,7 @@ function toThreadMessage(row: {
     botId: row.botId ?? undefined,
     replyToMessageId: row.replyToMessageId ?? undefined,
     runId: row.runId ?? undefined,
+    thumbsUp: row.thumbsUp,
     createdAt: row.createdAt.toISOString(),
   };
 }

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -113,6 +113,10 @@ describe("message thumbs-up", () => {
 
     expect(tx.task.create).toHaveBeenCalledOnce();
     expect(tx.run.create).toHaveBeenCalledOnce();
+    expect(String(tx.$queryRaw.mock.calls[0]?.[0])).toContain("SELECT id FROM threads");
+    expect(String(tx.$queryRaw.mock.calls[1]?.[0])).toContain(
+      'SELECT id, "thumbsUp" FROM messages',
+    );
     expect(tx.run.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ sourceMessageId: "message-1", trigger: "follow_up" }),

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -30,10 +30,10 @@ describe("threadHead", () => {
 });
 
 describe("queued run supersession", () => {
-  it("only cancels queued runs started by a user message", async () => {
+  it("only cancels queued runs started by user messages or reactions", async () => {
     const tx = {
       run: {
-        findMany: vi.fn().mockResolvedValue([]),
+        findMany: vi.fn().mockResolvedValue([{ id: "run-old", taskId: "task-old" }]),
         updateMany: vi.fn(),
       },
       task: { updateMany: vi.fn() },
@@ -46,11 +46,17 @@ describe("queued run supersession", () => {
     expect(tx.run.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          trigger: "user",
-          sourceMessage: { role: "user" },
+          OR: [{ trigger: "user", sourceMessage: { role: "user" } }, { trigger: "reaction" }],
         }),
       }),
     );
+    expect(tx.run.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: ["run-old"] } } }),
+    );
+    expect(tx.task.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["task-old"] } },
+      data: { status: "cancelled" },
+    });
   });
 });
 
@@ -121,7 +127,7 @@ describe("message thumbs-up", () => {
     expect(String(tx.$queryRaw.mock.calls[1]?.[0])).toContain("FOR UPDATE");
     expect(tx.run.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ sourceMessageId: "message-1", trigger: "follow_up" }),
+        data: expect.objectContaining({ sourceMessageId: "message-1", trigger: "reaction" }),
       }),
     );
     expect(tx.event.create).toHaveBeenCalledTimes(3);

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -114,9 +114,11 @@ describe("message thumbs-up", () => {
     expect(tx.task.create).toHaveBeenCalledOnce();
     expect(tx.run.create).toHaveBeenCalledOnce();
     expect(String(tx.$queryRaw.mock.calls[0]?.[0])).toContain("SELECT id FROM threads");
+    expect(String(tx.$queryRaw.mock.calls[0]?.[0])).toContain("FOR UPDATE");
     expect(String(tx.$queryRaw.mock.calls[1]?.[0])).toContain(
       'SELECT id, "thumbsUp" FROM messages',
     );
+    expect(String(tx.$queryRaw.mock.calls[1]?.[0])).toContain("FOR UPDATE");
     expect(tx.run.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ sourceMessageId: "message-1", trigger: "follow_up" }),

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import {
   cancelSupersededQueuedRuns,
+  reactToThreadMessage,
   stopThreadRuns,
   type ThreadTarget,
   threadHead,
@@ -50,6 +51,83 @@ describe("queued run supersession", () => {
         }),
       }),
     );
+  });
+});
+
+describe("message thumbs-up", () => {
+  it("wakes once on add and not on replay or removal", async () => {
+    let thumbsUp = false;
+    let busy = false;
+    let eventSeq = 0;
+    const tx = {
+      $queryRaw: vi.fn(async () => [
+        { id: "message-1", role: "bot", blocks: [{ kind: "text", text: "Done" }], thumbsUp },
+      ]),
+      message: {
+        update: vi.fn(async ({ data }: { data: { thumbsUp: boolean } }) => {
+          thumbsUp = data.thumbsUp;
+          return { id: "message-1" };
+        }),
+      },
+      run: {
+        findFirst: vi.fn(async () => (busy ? { id: "run-active" } : null)),
+        create: vi.fn().mockResolvedValue({ id: "run-1", status: "queued" }),
+        findUnique: vi.fn().mockResolvedValue({ status: "queued" }),
+      },
+      task: { create: vi.fn().mockResolvedValue({ id: "task-1" }) },
+      thread: {
+        update: vi.fn(async () => ({ nextEventSeq: ++eventSeq })),
+      },
+      event: {
+        create: vi.fn(async ({ data }: { data: Record<string, unknown> }) => ({
+          id: `event-${eventSeq}`,
+          createdAt: new Date(),
+          ...data,
+        })),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+    const actor = { workspaceId: "workspace-1", userId: "user-1" } as Actor;
+    const target = {
+      kind: "bot",
+      botId: "bot-1",
+      threadId: "thread-1",
+      bot: { computer: null },
+    } as ThreadTarget;
+
+    await expect(
+      reactToThreadMessage({ prisma }, actor, target, "message-1", true),
+    ).resolves.toEqual(expect.objectContaining({ changed: true, runId: "run-1" }));
+    await expect(
+      reactToThreadMessage({ prisma }, actor, target, "message-1", true),
+    ).resolves.toEqual(expect.objectContaining({ changed: false, runId: null }));
+    await expect(
+      reactToThreadMessage({ prisma }, actor, target, "message-1", false),
+    ).resolves.toEqual(expect.objectContaining({ changed: true, runId: null }));
+    busy = true;
+    await expect(
+      reactToThreadMessage({ prisma }, actor, target, "message-1", true),
+    ).resolves.toEqual(expect.objectContaining({ changed: true, runId: null }));
+
+    expect(tx.task.create).toHaveBeenCalledOnce();
+    expect(tx.run.create).toHaveBeenCalledOnce();
+    expect(tx.run.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ sourceMessageId: "message-1", trigger: "follow_up" }),
+      }),
+    );
+    expect(tx.event.create).toHaveBeenCalledTimes(3);
+    expect(tx.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: "thread.message.reaction",
+          payload: { messageId: "message-1", thumbsUp: true },
+        }),
+      }),
+    );
+    expect(thumbsUp).toBe(true);
   });
 });
 

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -89,7 +89,7 @@ describe("message thumbs-up", () => {
     const prisma = {
       $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
     } as unknown as PrismaClient;
-    const actor = { workspaceId: "workspace-1", userId: "user-1" } as Actor;
+    const actor = { spaceId: "workspace-1", userId: "user-1" } as Actor;
     const target = {
       kind: "bot",
       botId: "bot-1",

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -175,8 +175,7 @@ export async function cancelSupersededQueuedRuns(
       threadId: input.threadId,
       botId: { in: input.botIds },
       status: "queued",
-      trigger: "user",
-      sourceMessage: { role: "user" },
+      OR: [{ trigger: "user", sourceMessage: { role: "user" } }, { trigger: "reaction" }],
       id: { notIn: input.keepRunIds },
     },
     select: { id: true, taskId: true },
@@ -702,7 +701,7 @@ export async function reactToThreadMessage(
             taskId: task.id,
             userId: actor.userId,
             status: "queued",
-            trigger: "follow_up",
+            trigger: "reaction",
             sourceMessageId: message.id,
           },
         });

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -664,6 +664,7 @@ export async function reactToThreadMessage(
   thumbsUp: boolean,
 ) {
   return deps.prisma.$transaction(async (tx) => {
+    await tx.$queryRaw`SELECT id FROM threads WHERE id = ${target.threadId} FOR UPDATE`;
     const [message] = await tx.$queryRaw<
       Array<{ id: string; thumbsUp: boolean }>
     >`SELECT id, "thumbsUp" FROM messages WHERE id = ${messageId} AND "threadId" = ${target.threadId} FOR UPDATE`;

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -656,6 +656,70 @@ export async function sendThreadMessage(
   return sendResult(committed.message, committed.runs);
 }
 
+export async function reactToThreadMessage(
+  deps: { prisma: PrismaClient },
+  actor: Actor,
+  target: ThreadTarget,
+  messageId: string,
+  thumbsUp: boolean,
+) {
+  return deps.prisma.$transaction(async (tx) => {
+    const [message] = await tx.$queryRaw<
+      Array<{ id: string; thumbsUp: boolean }>
+    >`SELECT id, "thumbsUp" FROM messages WHERE id = ${messageId} AND "threadId" = ${target.threadId} FOR UPDATE`;
+    if (!message) throw new IsolationError();
+    if (message.thumbsUp === thumbsUp) {
+      return { changed: false, eventSeq: null, runId: null };
+    }
+
+    await tx.message.update({ where: { id: message.id }, data: { thumbsUp } });
+    const botId = target.kind === "bot" ? target.botId : target.memberBotIds[0];
+    if (!botId) throw new IsolationError();
+
+    let run: { id: string; status: string } | null = null;
+    if (thumbsUp && target.kind === "bot") {
+      const busy = await tx.run.findFirst({
+        where: { botId, status: { in: ["running", "queued", "leased"] } },
+        select: { id: true },
+      });
+      if (!busy) {
+        const task = await tx.task.create({
+          data: {
+            spaceId: actor.spaceId,
+            botId,
+            threadId: target.threadId,
+            userId: actor.userId,
+            prompt: "The user gave this message a thumbs-up.",
+            status: "queued",
+          },
+        });
+        run = await tx.run.create({
+          data: {
+            spaceId: actor.spaceId,
+            botId,
+            threadId: target.threadId,
+            taskId: task.id,
+            userId: actor.userId,
+            status: "queued",
+            trigger: "follow_up",
+            sourceMessageId: message.id,
+          },
+        });
+      }
+    }
+
+    const event = await appendEventInTransaction(tx, {
+      spaceId: actor.spaceId,
+      threadId: target.threadId,
+      botId,
+      type: "thread.message.reaction",
+      payload: { messageId: message.id, thumbsUp },
+      runId: run?.id,
+    });
+    return { changed: true, eventSeq: event.seq, runId: run?.id ?? null };
+  });
+}
+
 export async function stopThreadRuns(
   deps: {
     prisma: PrismaClient;

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -723,6 +723,7 @@ function Thread() {
                 event.type === "agent.tool.called" ||
                 event.type === "thread.message.created" ||
                 event.type === "thread.message.updated" ||
+                event.type === "thread.message.reaction" ||
                 event.type === "thread.subagent" ||
                 event.type === "thread.cleared" ||
                 event.type === "run.waiting_input" ||
@@ -1082,6 +1083,19 @@ function Thread() {
     );
   }
 
+  async function reactToMessage(message: MobileMessage) {
+    if (!botId && !groupId) return;
+    try {
+      await rpc("threads/react", {
+        ...(groupId ? { groupId } : { botId: botId! }),
+        messageId: message.id,
+        thumbsUp: !message.thumbsUp,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not update reaction");
+    }
+  }
+
   function renderMessageRow(message: MobileMessage, options?: { enableJump?: boolean }) {
     const ownerId = toolOwnerId(message, inGroup);
     const activityBotId =
@@ -1144,16 +1158,28 @@ function Thread() {
             flexShrink: 1,
           }}
         >
-          <Pressable
-            accessibilityLabel="Reply"
-            onPress={() => setReplyTarget(message)}
+          <View
             style={{
               alignSelf: message.role === "user" ? "flex-end" : "flex-start",
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 12,
               marginBottom: 4,
             }}
           >
-            <Text style={{ color: "#6C6C70", fontSize: 12 }}>Reply</Text>
-          </Pressable>
+            <Pressable accessibilityLabel="Reply" onPress={() => setReplyTarget(message)}>
+              <Text style={{ color: "#6C6C70", fontSize: 12 }}>Reply</Text>
+            </Pressable>
+            <Pressable
+              accessibilityLabel={message.thumbsUp ? "Remove thumbs-up" : "Add thumbs-up"}
+              accessibilityState={{ selected: Boolean(message.thumbsUp) }}
+              onPress={() => void reactToMessage(message)}
+            >
+              <Text style={{ color: message.thumbsUp ? "#E9C46A" : "#6C6C70", fontSize: 13 }}>
+                👍
+              </Text>
+            </Pressable>
+          </View>
           <MessageBubble
             botId={botId ?? snap?.members?.[0]?.botId ?? ""}
             groupId={groupId}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -6,6 +6,7 @@ import type {
   MessageBlock,
   Routine,
 } from "@rakazo/contracts";
+import { canReactToThreadMessage } from "@rakazo/contracts";
 import {
   abortableDelay,
   attachmentsForThread,
@@ -1170,15 +1171,17 @@ function Thread() {
             <Pressable accessibilityLabel="Reply" onPress={() => setReplyTarget(message)}>
               <Text style={{ color: "#6C6C70", fontSize: 12 }}>Reply</Text>
             </Pressable>
-            <Pressable
-              accessibilityLabel={message.thumbsUp ? "Remove thumbs-up" : "Add thumbs-up"}
-              accessibilityState={{ selected: Boolean(message.thumbsUp) }}
-              onPress={() => void reactToMessage(message)}
-            >
-              <Text style={{ color: message.thumbsUp ? "#E9C46A" : "#6C6C70", fontSize: 13 }}>
-                👍
-              </Text>
-            </Pressable>
+            {canReactToThreadMessage(message) ? (
+              <Pressable
+                accessibilityLabel={message.thumbsUp ? "Remove thumbs-up" : "Add thumbs-up"}
+                accessibilityState={{ selected: Boolean(message.thumbsUp) }}
+                onPress={() => void reactToMessage(message)}
+              >
+                <Text style={{ color: message.thumbsUp ? "#E9C46A" : "#6C6C70", fontSize: 13 }}>
+                  👍
+                </Text>
+              </Pressable>
+            ) : null}
           </View>
           <MessageBubble
             botId={botId ?? snap?.members?.[0]?.botId ?? ""}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1085,14 +1085,17 @@ function Thread() {
   }
 
   async function reactToMessage(message: MobileMessage) {
-    if (!botId && !groupId) return;
+    const targetBotId = botId;
+    const targetGroupId = groupId;
+    if (!targetBotId && !targetGroupId) return;
     try {
       await rpc("threads/react", {
-        ...(groupId ? { groupId } : { botId: botId! }),
+        ...(targetGroupId ? { groupId: targetGroupId } : { botId: targetBotId! }),
         messageId: message.id,
         thumbsUp: !message.thumbsUp,
       });
     } catch (err) {
+      if (!isCurrentTarget(targetBotId, targetGroupId)) return;
       setError(err instanceof Error ? err.message : "Could not update reaction");
     }
   }

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -692,6 +692,19 @@ describe("mobile thread refresh targeting", () => {
 });
 
 describe("mobile thread event reduction", () => {
+  it("applies a persisted thumbs-up event to its message", () => {
+    const initial = snapshot([mobileMessage("message-1", [{ kind: "text", text: "Done" }])]);
+
+    const next = applyMobileThreadEvent(initial, {
+      type: "thread.message.reaction",
+      seq: 4,
+      payload: { messageId: "message-1", thumbsUp: true },
+    });
+
+    expect(next?.messages[0]?.thumbsUp).toBe(true);
+    expect(next?.cursor).toBe(4);
+  });
+
   it("prepends ordered history pages without duplicating the boundary message", () => {
     const initial = snapshot([mobileMessage("m-2", [], 2), mobileMessage("m-3", [], 3)], 2);
 

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -402,6 +402,7 @@ export type MobileMessage = {
   role: "user" | "bot" | "system";
   botId?: string;
   replyToMessageId?: string;
+  thumbsUp?: boolean;
   blocks: MessageBlock[];
 };
 
@@ -693,6 +694,18 @@ export function applyMobileThreadEvent(
       messages: [...prev.messages.filter((message) => message.id !== streaming.id), streaming],
     };
   }
+  if (event.type === "thread.message.reaction") {
+    const messageId = String(event.payload?.messageId ?? "");
+    return {
+      ...prev,
+      cursor: event.seq ?? prev.cursor,
+      messages: prev.messages.map((message) =>
+        message.id === messageId
+          ? { ...message, thumbsUp: event.payload?.thumbsUp === true }
+          : message,
+      ),
+    };
+  }
   if (event.type === "thread.message.created" || event.type === "thread.message.updated") {
     const { remaining } = takeMobileLiveMessage(prev, progressMessageId(event));
     const next: MobileMessage = {
@@ -704,6 +717,7 @@ export function applyMobileThreadEvent(
       replyToMessageId: event.payload?.replyToMessageId
         ? String(event.payload.replyToMessageId)
         : undefined,
+      thumbsUp: event.payload?.thumbsUp === true,
     };
     return {
       ...prev,

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -23,6 +23,8 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   await expect(toolbar).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Reply" })).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Copy" })).toBeVisible();
+  const thumbsUp = toolbar.getByRole("button", { name: "Add thumbs-up" });
+  await expect(thumbsUp).toBeVisible();
 
   // Pill must float above the bubble text, not cover the first line.
   const bubble = parentRow.locator("div").filter({ hasText: parentText }).last();
@@ -63,6 +65,14 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   });
   await testInfo.attach("message-hover-toolbar", { contentType: "image/png", path: hoverPath });
 
+  await thumbsUp.click();
+  const reactionChip = parentRow
+    .getByRole("button", { name: "Remove thumbs-up" })
+    .filter({ hasText: "👍" });
+  await expect(reactionChip).toBeVisible();
+  await captureScreenshot(page, testInfo, "message-thumbs-up");
+
+  await parentRow.hover();
   await toolbar.getByRole("button", { name: "Copy" }).click();
   await expect
     .poll(async () => page.evaluate(() => navigator.clipboard.readText()))

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -22,6 +22,22 @@ import {
 } from "./thread-events.js";
 
 describe("thread event reduction", () => {
+  it("applies a persisted thumbs-up event to its message", () => {
+    const initial = snapshot([message("message-1", [{ kind: "text", text: "Done" }], 1)]);
+
+    const next = reduceThreadSnapshot(
+      initial,
+      event({
+        type: "thread.message.reaction",
+        seq: 4,
+        payload: { messageId: "message-1", thumbsUp: true },
+      }),
+    );
+
+    expect(next?.messages[0]?.thumbsUp).toBe(true);
+    expect(next?.cursor).toBe(4);
+  });
+
   it("prepends older pages in order, removes overlaps, and advances the history cursor", () => {
     const initial = snapshot([message("m-2", [], 2), message("m-3", [], 3)], 2);
 

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -218,6 +218,7 @@ export function isThreadSnapshotEvent(event: ProductEvent): boolean {
     event.type === "agent.tool.called" ||
     event.type === "thread.message.created" ||
     event.type === "thread.message.updated" ||
+    event.type === "thread.message.reaction" ||
     event.type === "run.started" ||
     event.type === "run.waiting_input" ||
     event.type === "computer.takeover.requested" ||
@@ -391,6 +392,18 @@ export function reduceThreadSnapshot(
     }
     return { ...prev, cursor: event.seq, messages: [...without, next, ...kept] };
   }
+  if (event.type === "thread.message.reaction") {
+    const messageId = String(event.payload.messageId ?? "");
+    return {
+      ...prev,
+      cursor: event.seq,
+      messages: prev.messages.map((message) =>
+        message.id === messageId
+          ? { ...message, thumbsUp: event.payload.thumbsUp === true }
+          : message,
+      ),
+    };
+  }
   if (event.type === "thread.message.created" || event.type === "thread.message.updated") {
     const role = (event.payload.role as ThreadMessage["role"]) ?? "bot";
     const blocks = (event.payload.blocks as ThreadMessage["blocks"]) ?? [];
@@ -402,6 +415,7 @@ export function reduceThreadSnapshot(
       blocks,
       botId: event.botId,
       runId: event.runId,
+      thumbsUp: event.payload.thumbsUp === true,
       createdAt: event.createdAt,
     };
     const replacedSubagentIds = new Set(

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -225,6 +225,10 @@ msgstr "OpenAPI hinzufügen"
 msgid "Add remote MCP server"
 msgstr "Remote-MCP-Server hinzufügen"
 
+#: src/pages/Shell.tsx:4572
+msgid "Add thumbs-up"
+msgstr ""
+
 #: src/pages/McpServersOverlay.tsx:363
 msgid "Add server"
 msgstr "Server hinzufügen"
@@ -2232,6 +2236,11 @@ msgstr "Freigeben"
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "Entfernen"
+
+#: src/pages/Shell.tsx:3895
+#: src/pages/Shell.tsx:4572
+msgid "Remove thumbs-up"
+msgstr ""
 
 #. placeholder {0}: attachment.file.name
 #: src/pages/Shell.tsx:4229

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -225,6 +225,10 @@ msgstr "Add OpenAPI"
 msgid "Add remote MCP server"
 msgstr "Add remote MCP server"
 
+#: src/pages/Shell.tsx:4572
+msgid "Add thumbs-up"
+msgstr "Add thumbs-up"
+
 #: src/pages/McpServersOverlay.tsx:363
 msgid "Add server"
 msgstr "Add server"
@@ -2232,6 +2236,11 @@ msgstr "Release"
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "Remove"
+
+#: src/pages/Shell.tsx:3895
+#: src/pages/Shell.tsx:4572
+msgid "Remove thumbs-up"
+msgstr "Remove thumbs-up"
 
 #. placeholder {0}: attachment.file.name
 #: src/pages/Shell.tsx:4229

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -225,6 +225,10 @@ msgstr "OpenAPI जोड़ें"
 msgid "Add remote MCP server"
 msgstr "रिमोट MCP सर्वर जोड़ें"
 
+#: src/pages/Shell.tsx:4572
+msgid "Add thumbs-up"
+msgstr ""
+
 #: src/pages/McpServersOverlay.tsx:363
 msgid "Add server"
 msgstr "सर्वर जोड़ें"
@@ -2232,6 +2236,11 @@ msgstr "नियंत्रण छोड़ें"
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "हटाएं"
+
+#: src/pages/Shell.tsx:3895
+#: src/pages/Shell.tsx:4572
+msgid "Remove thumbs-up"
+msgstr ""
 
 #. placeholder {0}: attachment.file.name
 #: src/pages/Shell.tsx:4229

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -225,6 +225,10 @@ msgstr "OpenAPI 추가"
 msgid "Add remote MCP server"
 msgstr "원격 MCP 서버 추가"
 
+#: src/pages/Shell.tsx:4572
+msgid "Add thumbs-up"
+msgstr ""
+
 #: src/pages/McpServersOverlay.tsx:363
 msgid "Add server"
 msgstr "서버 추가"
@@ -2232,6 +2236,11 @@ msgstr "제어권 돌려주기"
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "삭제"
+
+#: src/pages/Shell.tsx:3895
+#: src/pages/Shell.tsx:4572
+msgid "Remove thumbs-up"
+msgstr ""
 
 #. placeholder {0}: attachment.file.name
 #: src/pages/Shell.tsx:4229

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -225,6 +225,10 @@ msgstr "Adicionar OpenAPI"
 msgid "Add remote MCP server"
 msgstr "Adicionar servidor MCP remoto"
 
+#: src/pages/Shell.tsx:4572
+msgid "Add thumbs-up"
+msgstr ""
+
 #: src/pages/McpServersOverlay.tsx:363
 msgid "Add server"
 msgstr "Adicionar servidor"
@@ -2232,6 +2236,11 @@ msgstr "Libere"
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "Remover"
+
+#: src/pages/Shell.tsx:3895
+#: src/pages/Shell.tsx:4572
+msgid "Remove thumbs-up"
+msgstr ""
 
 #. placeholder {0}: attachment.file.name
 #: src/pages/Shell.tsx:4229

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -225,6 +225,10 @@ msgstr "OpenAPI ekle"
 msgid "Add remote MCP server"
 msgstr "Uzak MCP sunucusu ekle"
 
+#: src/pages/Shell.tsx:4572
+msgid "Add thumbs-up"
+msgstr ""
+
 #: src/pages/McpServersOverlay.tsx:363
 msgid "Add server"
 msgstr "Sunucu ekle"
@@ -2232,6 +2236,11 @@ msgstr "Bırak"
 #: src/pages/ScratchpadSection.tsx:162
 msgid "Remove"
 msgstr "Kaldır"
+
+#: src/pages/Shell.tsx:3895
+#: src/pages/Shell.tsx:4572
+msgid "Remove thumbs-up"
+msgstr ""
 
 #. placeholder {0}: attachment.file.name
 #: src/pages/Shell.tsx:4229

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1828,6 +1828,10 @@ export function ShellPage() {
           thumbsUp: !message.thumbsUp,
         });
       } catch (error) {
+        const stillHere = groupId
+          ? activeGroupId.current === groupId
+          : activeBotId.current === botId;
+        if (!stillHere) return;
         setSendError(error instanceof Error ? error.message : t`Could not update reaction`);
       }
     },

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -35,6 +35,7 @@ import {
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
   BOT_TITLE_MAX_LENGTH,
+  canReactToThreadMessage,
   normalizeCreateBotProfile,
 } from "@rakazo/contracts";
 import {
@@ -4707,17 +4708,19 @@ function MessageHoverActions({
         >
           <Reply size={14} strokeWidth={1.8} />
         </button>
-        <button
-          type="button"
-          aria-label={message.thumbsUp ? t`Remove thumbs-up` : t`Add thumbs-up`}
-          aria-pressed={Boolean(message.thumbsUp)}
-          onClick={() => void onReact(message)}
-          className={`grid h-7 w-7 place-items-center rounded-full hover:bg-[#2A2A2F] hover:text-[#ECECEE] ${
-            message.thumbsUp ? "text-[#E9C46A]" : "text-[#C9C9CE]"
-          }`}
-        >
-          <ThumbsUp size={14} strokeWidth={1.8} />
-        </button>
+        {canReactToThreadMessage(message) ? (
+          <button
+            type="button"
+            aria-label={message.thumbsUp ? t`Remove thumbs-up` : t`Add thumbs-up`}
+            aria-pressed={Boolean(message.thumbsUp)}
+            onClick={() => void onReact(message)}
+            className={`grid h-7 w-7 place-items-center rounded-full hover:bg-[#2A2A2F] hover:text-[#ECECEE] ${
+              message.thumbsUp ? "text-[#E9C46A]" : "text-[#C9C9CE]"
+            }`}
+          >
+            <ThumbsUp size={14} strokeWidth={1.8} />
+          </button>
+        ) : null}
         <button
           type="button"
           aria-label={t`Copy`}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -89,6 +89,7 @@ import {
   Reply,
   Settings,
   Square,
+  ThumbsUp,
   Volume2,
   X,
 } from "lucide-react";
@@ -1814,6 +1815,23 @@ export function ShellPage() {
       await refreshThreadRef.current(botId);
     }
   }, []);
+  const reactToMessage = useCallback(
+    async (message: ThreadMessage) => {
+      const botId = activeBotId.current;
+      const groupId = activeGroupId.current;
+      if (!botId && !groupId) return;
+      try {
+        await rpc.threads.react({
+          ...(groupId ? { groupId } : { botId: botId! }),
+          messageId: message.id,
+          thumbsUp: !message.thumbsUp,
+        });
+      } catch (error) {
+        setSendError(error instanceof Error ? error.message : t`Could not update reaction`);
+      }
+    },
+    [t],
+  );
   const onAttachmentPick = useCallback(
     async (files: FileList | null) => {
       const threadKey = activeGroupId.current ?? activeBotId.current;
@@ -2882,6 +2900,7 @@ export function ShellPage() {
           onOpenBot={openBot}
           onAnswer={answerMessage}
           onReply={setReplyTarget}
+          onReact={reactToMessage}
           onJumpToMessage={jumpToReplyMessage}
           onOpenPeerMessages={(peer) => {
             setPeerConversation(peer);
@@ -3802,6 +3821,7 @@ const Transcript = memo(function Transcript({
   onOpenBot,
   onAnswer,
   onReply,
+  onReact,
   onJumpToMessage,
   onOpenPeerMessages,
   memberName,
@@ -3825,6 +3845,7 @@ const Transcript = memo(function Transcript({
   onOpenBot: (botId: string) => void;
   onAnswer: (message: ThreadMessage, text: string) => Promise<void>;
   onReply: (message: ThreadMessage) => void;
+  onReact: (message: ThreadMessage) => Promise<void>;
   onJumpToMessage: (messageId: string) => void;
   onOpenPeerMessages: (peer: { peerBotId: string; peerBotName: string }) => void;
   memberName?: (botId: string | undefined) => string | undefined;
@@ -3977,7 +3998,9 @@ const Transcript = memo(function Transcript({
               data-message-id={message.id}
               className={peerReceipt ? "relative py-0.5" : "group/message relative pt-9 hover:z-20"}
             >
-              {peerReceipt ? null : <MessageHoverActions message={message} onReply={onReply} />}
+              {peerReceipt ? null : (
+                <MessageHoverActions message={message} onReply={onReply} onReact={onReact} />
+              )}
               <MessageView
                 artifactTarget={artifactTarget}
                 message={message}
@@ -4006,6 +4029,18 @@ const Transcript = memo(function Transcript({
                 speaking={speakingMessageId === message.id}
                 onSpeak={() => onSpeak(message)}
               />
+              {!peerReceipt && message.thumbsUp ? (
+                <button
+                  type="button"
+                  aria-label={t`Remove thumbs-up`}
+                  onClick={() => void onReact(message)}
+                  className={`mt-1 rounded-full border border-[#303034] bg-[#1A1A1D] px-2 py-0.5 text-xs ${
+                    message.role === "user" ? "ml-auto block" : ""
+                  }`}
+                >
+                  👍
+                </button>
+              ) : null}
             </div>
           );
         })}
@@ -4642,9 +4677,11 @@ function previewMessageText(message: ThreadMessage): string {
 function MessageHoverActions({
   message,
   onReply,
+  onReact,
 }: {
   message: ThreadMessage;
   onReply: (message: ThreadMessage) => void;
+  onReact: (message: ThreadMessage) => Promise<void>;
 }) {
   const { t } = useLingui();
   // Streaming progress bubbles keep hover free for selection / stop clicks.
@@ -4669,6 +4706,17 @@ function MessageHoverActions({
           className="grid h-7 w-7 place-items-center rounded-full text-[#C9C9CE] hover:bg-[#2A2A2F] hover:text-[#ECECEE]"
         >
           <Reply size={14} strokeWidth={1.8} />
+        </button>
+        <button
+          type="button"
+          aria-label={message.thumbsUp ? t`Remove thumbs-up` : t`Add thumbs-up`}
+          aria-pressed={Boolean(message.thumbsUp)}
+          onClick={() => void onReact(message)}
+          className={`grid h-7 w-7 place-items-center rounded-full hover:bg-[#2A2A2F] hover:text-[#ECECEE] ${
+            message.thumbsUp ? "text-[#E9C46A]" : "text-[#C9C9CE]"
+          }`}
+        >
+          <ThumbsUp size={14} strokeWidth={1.8} />
         </button>
         <button
           type="button"

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -647,6 +647,7 @@ export const RunSchema = z.object({
     "routine",
     "resume",
     "follow_up",
+    "reaction",
     "spawn",
     "skill",
     "bot_message",

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -267,3 +267,11 @@ export const ThreadMessageSchema = z.object({
   createdAt: z.string(),
 });
 export type ThreadMessage = z.infer<typeof ThreadMessageSchema>;
+
+export function canReactToThreadMessage(message: Pick<ThreadMessage, "id" | "blocks">): boolean {
+  return (
+    !message.id.startsWith("progress:") &&
+    !message.id.startsWith("subagent:") &&
+    !message.blocks.some((block) => block.kind === "phone_channel_message")
+  );
+}

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -6,6 +6,7 @@ export const ProductEventType = z.enum([
   "thread.message.created",
   "thread.cleared",
   "thread.message.updated",
+  "thread.message.reaction",
   "thread.progress",
   "thread.artifact",
   "thread.ask",
@@ -262,6 +263,7 @@ export const ThreadMessageSchema = z.object({
   botId: Id.optional(),
   replyToMessageId: Id.optional(),
   runId: Id.optional(),
+  thumbsUp: z.boolean().optional(),
   createdAt: z.string(),
 });
 export type ThreadMessage = z.infer<typeof ThreadMessageSchema>;

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   BOT_TITLE_MAX_LENGTH,
   CreateBotInput,
   CreateGroupInput,
+  canReactToThreadMessage,
   McpServerConfigInput,
   MessageBlock,
   ModelOAuthBeginSchema,
@@ -19,6 +20,29 @@ import {
 } from "./index.js";
 
 describe("contracts", () => {
+  it("limits reactions to persisted non-phone messages", () => {
+    expect(
+      canReactToThreadMessage({ id: "message-1", blocks: [{ kind: "text", text: "hi" }] }),
+    ).toBe(true);
+    expect(
+      canReactToThreadMessage({ id: "subagent:agent-1", blocks: [{ kind: "text", text: "hi" }] }),
+    ).toBe(false);
+    expect(
+      canReactToThreadMessage({
+        id: "message-2",
+        blocks: [
+          {
+            kind: "phone_channel_message",
+            channelId: "channel-1",
+            fromNumber: "+15555550100",
+            fromLabel: "Pat",
+            text: "hi",
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it("parses bot create input", () => {
     const parsed = CreateBotInput.parse({ name: "Chief" });
     expect(parsed.title).toBe("");

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -268,6 +268,14 @@ export const appContract = {
         runIds: z.array(Id).optional(),
       }),
     ),
+    react: oc
+      .input(
+        threadTarget.safeExtend({
+          messageId: Id,
+          thumbsUp: z.boolean(),
+        }),
+      )
+      .output(z.object({ ok: z.literal(true) })),
     stop: oc.input(threadTarget).output(z.object({ ok: z.literal(true) })),
     followUp: oc
       .input(threadTarget.safeExtend({ text: z.string().min(1) }))

--- a/packages/contracts/src/runs.ts
+++ b/packages/contracts/src/runs.ts
@@ -14,6 +14,7 @@ export const RunActivityRowSchema = z.object({
     "routine",
     "resume",
     "follow_up",
+    "reaction",
     "spawn",
     "skill",
     "bot_message",

--- a/packages/db/prisma/migrations/20260831090000_message_thumbs_up/migration.sql
+++ b/packages/db/prisma/migrations/20260831090000_message_thumbs_up/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messages" ADD COLUMN "thumbsUp" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -467,6 +467,7 @@ model Message {
   replies          Message[] @relation("MessageReplies")
   runId            String?
   clientNonce      String?
+  thumbsUp         Boolean   @default(false)
   sourceRuns       Run[]     @relation("RunSourceMessage")
   createdAt        DateTime  @default(now())
 


### PR DESCRIPTION
## Problem

Thumbs-up feedback was not attached to a persisted message and could not participate in the server event/run pipeline.

Fixes #407

## Approach

- persist one `thumbsUp` state on the target message with an additive migration
- expose an authenticated thread reaction mutation that locks and verifies the message belongs to the resolved thread
- emit durable `thread.message.reaction` events for actual state changes
- create and enqueue one existing `follow_up` task/run only for a new add while the owning bot is idle
- project persisted and live reaction state in web/Electron and Expo mobile

## Tests

- RED: focused API regression failed before implementation because `reactToThreadMessage` did not exist
- GREEN: 110 focused API/contract/web/mobile tests pass
- mutation proof: bypassing the state transition made the regression fail; restoring it returned the focused set to green
- `pnpm run check` — 20/20 tasks pass
- `RAYON_NUM_THREADS=2 node_modules/.bin/biome check .` — passes (two pre-existing informational suggestions)
- `pnpm run format` — passes
- `pnpm run build` — 4/4 build tasks pass
- `pnpm --filter @rakazo/db exec prisma validate` — passes
- `pnpm run test` — 2003 pass, 98 skip, 1 unrelated existing failure in `desktop-sandbox-write-containment.test.ts`; the isolated untouched test fails identically on rerun

## Risk

- additive boolean column defaults existing messages to no reaction
- row locking and state comparison make duplicate/replayed mutations event- and wake-idempotent
- wake creation preserves the existing `onlyIfIdle` active-status check and durable enqueue recovery behavior
- group reactions persist and propagate but intentionally do not select an arbitrary member bot to wake

## Exclusions

- no generalized reaction framework or additional emoji
- no reaction counts or per-user reaction sets
- phone/iMessage is an explicit safe degradation: the transport cannot target a Rakazo message ID, so it does not expose or synthesize this interaction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added thumbs-up reactions to eligible thread messages on web and mobile.
  - Reaction status is displayed and synchronized in real time.
  - Thumbs-up reactions on bot messages can trigger follow-up responses.
  - Reactions can be removed and reapplied.

- **Bug Fixes**
  - Preserved reaction status when loading or updating message history.
  - Prevented stale error messages after switching threads.

- **Tests**
  - Added coverage for reaction persistence, synchronization, eligibility, and follow-up behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->