### PR TITLE
Fix golden E2E bot selector blocking production deploys

### DIFF
--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -9,7 +9,9 @@ import {
 } from "./helpers";
 
 function sidebarBotButton(page: Page, name: RegExp | string) {
-  return page.locator("[data-sidebar-group]").getByRole("button", { name });
+  return page.locator("[data-sidebar-group] [data-roster-bot-id]").filter({
+    has: page.locator("[data-roster-bot-name]").filter({ hasText: name }),
+  });
 }
 
 test.describe.configure({ mode: "serial" });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2408,6 +2408,7 @@ export function ShellPage() {
                             <div className="flex items-baseline justify-between gap-2">
                               <span
                                 dir="auto"
+                                data-roster-bot-name={item.kind === "bot" ? "" : undefined}
                                 className={`truncate text-[15px] text-[#ECECEE] ${
                                   item.chat.unread ? "font-semibold" : "font-medium"
                                 }`}


### PR DESCRIPTION
## Summary
- scope golden roster lookups to the bot name element
- prevent message previews from making unrelated bot rows match

## Verification
- `pnpm test:e2e -- --spec=e2e/golden.spec.ts --grep="sign-in, spawn, and stop work in the shell"`
- `pnpm exec biome check apps/web/e2e/golden.spec.ts apps/web/src/pages/Shell.tsx`
- `pnpm --filter @rakazo/web check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved sidebar bot identification in automated testing for more reliable bot selection by name.

* **Bug Fixes**
  * Added a stable identifier to bot names in the sidebar, improving consistency when locating bot entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->