### PR TITLE
fix(web): keyboard completion for composer @mention picker

### DIFF
--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -63,7 +63,7 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await page.waitForURL((url) => url.pathname === protectedBotPath, {
     timeout: 20_000,
   });
-  const composer = page.getByRole("textbox", { name: "Message Chief" });
+  const composer = page.getByRole("combobox", { name: "Message Chief" });
   await expect(composer).toHaveAttribute("name", "chat-message");
   await expect(composer).toHaveAttribute("autocomplete", "off");
   await expect(composer).toHaveAttribute("aria-label", "Message Chief");

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -15,7 +15,7 @@ async function createBot(page: import("@playwright/test").Page, name: string) {
   await page.locator("label:has-text('Name') input").fill(name);
   await page.getByRole("button", { name: "Create", exact: true }).click();
   await expect(botList.getByRole("button", { name: new RegExp(`^${name}`) })).toBeVisible();
-  await expect(page.getByRole("textbox", { name: `Message ${name}` })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: `Message ${name}` })).toBeVisible();
   await page.waitForURL(/\/app\/[^/]+$/);
   return activeBotId(page);
 }
@@ -56,7 +56,7 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   });
   await page.reload();
   await expect(page).toHaveURL(groupUrl);
-  await expect(page.getByRole("textbox", { name: "Message Draft team" })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Message Draft team" })).toBeVisible();
 
   const groups = await rpc<
     Array<{
@@ -129,22 +129,22 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await desktopSettings.getByRole("button", { name: "Save", exact: true }).click();
 
   await page
-    .getByRole("textbox", { name: "Message Draft team" })
+    .getByRole("combobox", { name: "Message Draft team" })
     .fill("@Researcher unfinished draft");
   await sidebar.getByRole("button", { name: /^Review team/ }).click();
-  await expect(page.getByRole("textbox", { name: "Message Review team" })).toHaveValue("");
+  await expect(page.getByRole("combobox", { name: "Message Review team" })).toHaveValue("");
   await sidebar.getByRole("button", { name: /^Draft team/ }).click();
-  await expect(page.getByRole("textbox", { name: "Message Draft team" })).toHaveValue("");
+  await expect(page.getByRole("combobox", { name: "Message Draft team" })).toHaveValue("");
 
-  const composer = page.getByRole("textbox", { name: "Message Draft team" });
+  const composer = page.getByRole("combobox", { name: "Message Draft team" });
   await composer.fill("@Res");
   await captureScreenshot(page, testInfo, "group-mention-picker");
-  await page.getByRole("button", { name: "@Research Writer", exact: true }).click();
+  await page.getByRole("option", { name: "@Research Writer", exact: true }).click();
   await expect(
     page.getByTestId("mention-chip").filter({ hasText: "Research Writer" }),
   ).toBeVisible();
   await composer.fill("turn the sources into a draft. @Res");
-  await page.getByRole("button", { name: "@Researcher", exact: true }).click();
+  await page.getByRole("option", { name: "@Researcher", exact: true }).click();
   await expect(page.getByTestId("mention-chip").filter({ hasText: "Researcher" })).toBeVisible();
   await composer.fill(`${await composer.inputValue()}gather sources.`);
   await composer.press("Enter");
@@ -166,7 +166,7 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await captureScreenshot(page, testInfo, "group-transcript");
 
   await composer.fill("@Res");
-  await page.getByRole("button", { name: "@Research Writer", exact: true }).click();
+  await page.getByRole("option", { name: "@Research Writer", exact: true }).click();
   await expect(
     page.getByTestId("mention-chip").filter({ hasText: "Research Writer" }),
   ).toBeVisible();
@@ -179,7 +179,7 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   const cityAsk = page.locator("p").filter({ hasText: /^Which city should I use\?$/ });
   if ((await cityAsk.count()) === 0) {
     await page.reload({ waitUntil: "domcontentloaded" });
-    await expect(page.getByRole("textbox", { name: "Message Draft team" })).toBeVisible({
+    await expect(page.getByRole("combobox", { name: "Message Draft team" })).toBeVisible({
       timeout: 15_000,
     });
   }
@@ -219,7 +219,7 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await expect(page).toHaveURL(new RegExp(`/app/g/${reviewGroup.id}$`));
   await expect(page.getByTestId("transcript")).not.toContainText("Answered: Paris");
   releaseReviewSnapshot();
-  await expect(page.getByRole("textbox", { name: "Message Review team" })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Message Review team" })).toBeVisible();
   await page.unroute("**/rpc/threads/get");
   await sidebar.getByRole("button", { name: /^Draft team/ }).click();
   await expect(page.getByText("Answered: Paris", { exact: true })).toBeVisible();
@@ -250,5 +250,5 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   await rpc(page, "groups/remove", { groupId: reviewGroup.id });
   await page.goto(`/app/g/${reviewGroup.id}`);
   await page.waitForURL(/\/app\/(?!g\/)[^/]+$/);
-  await expect(page.getByRole("textbox", { name: /Message/ })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: /Message/ })).toBeVisible();
 });

--- a/apps/web/e2e/mention-picker-keyboard.spec.ts
+++ b/apps/web/e2e/mention-picker-keyboard.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+import { activeBotId, captureScreenshot, completeOnboarding, openNewBot, signup } from "./helpers";
+
+async function createBot(page: import("@playwright/test").Page, name: string) {
+  const botList = page.locator("aside").first();
+  await openNewBot(page);
+  await expect(page.getByText("New bot", { exact: true })).toBeVisible();
+  await page.locator("label:has-text('Name') input").fill(name);
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  await expect(botList.getByRole("button", { name: new RegExp(`^${name}`) })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: `Message ${name}` })).toBeVisible();
+  await page.waitForURL(/\/app\/[^/]+$/);
+  return activeBotId(page);
+}
+
+test("mention picker completes with Enter and Tab", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `mention-keys-${stamp}@rakazo.test`, "password12", "Mention Keys");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  const researcherId = await createBot(page, "Researcher");
+  const writerId = await createBot(page, "Research Writer");
+  expect(researcherId).toBeTruthy();
+  expect(writerId).toBeTruthy();
+
+  await page.getByTitle("Create").click();
+  await page.getByRole("button", { name: "New group" }).click();
+  await page.locator("label:has-text('Name') input").fill("Mention keys team");
+  const panel = page.getByTestId("side-panel");
+  await panel.getByRole("button", { name: "Researcher" }).click();
+  await panel.getByRole("button", { name: "Research Writer" }).click();
+  await page.getByRole("button", { name: "Create group", exact: true }).click();
+  await page.waitForURL(/\/app\/g\/[^/]+$/);
+
+  const composer = page.getByRole("combobox", { name: "Message Mention keys team" });
+  await expect(composer).toBeVisible();
+
+  await composer.fill("@Res");
+  const picker = page.getByTestId("mention-picker");
+  await expect(picker).toBeVisible();
+  await expect(picker.getByRole("option").first()).toHaveAttribute("aria-selected", "true");
+  await expect(composer).toHaveAttribute("aria-expanded", "true");
+  await captureScreenshot(page, testInfo, "mention-picker-keyboard-open");
+
+  await composer.press("ArrowDown");
+  await expect(picker.getByRole("option", { name: "@Research Writer" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await composer.press("Enter");
+  await expect(page.getByTestId("mention-picker")).toHaveCount(0);
+  await expect(
+    page.getByTestId("mention-chip").filter({ hasText: "Research Writer" }),
+  ).toBeVisible();
+  await expect(composer).toBeFocused();
+  await expect(composer).toHaveAttribute("aria-expanded", "false");
+  await captureScreenshot(page, testInfo, "mention-picker-keyboard-completed");
+
+  await page.getByRole("button", { name: "Remove mention Research Writer" }).click();
+  await composer.fill("@Res");
+  await expect(page.getByTestId("mention-picker")).toBeVisible();
+  await composer.press("Tab");
+  await expect(page.getByTestId("mention-picker")).toHaveCount(0);
+  await expect(page.getByTestId("mention-chip").filter({ hasText: "Researcher" })).toBeVisible();
+  await expect(composer).toBeFocused();
+
+  await page.getByRole("button", { name: "Remove mention Researcher" }).click();
+  await composer.fill("@Res");
+  await expect(page.getByTestId("mention-picker")).toBeVisible();
+  await composer.press("Escape");
+  await expect(page.getByTestId("mention-picker")).toHaveCount(0);
+  await expect(composer).toHaveValue("@Res");
+  await expect(page.getByTestId("mention-chip")).toHaveCount(0);
+  await expect(composer).toBeFocused();
+
+  await composer.fill("hello without a picker");
+  await composer.press("Enter");
+  await expect(page.getByTestId("transcript")).toContainText("hello without a picker", {
+    timeout: 60_000,
+  });
+});

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -9,7 +9,7 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
 
   const parentText = `hover-parent-${stamp}`;
   const replyText = `hover-reply-${stamp}`;
-  const composer = page.getByRole("textbox", { name: /^Message/ });
+  const composer = page.getByRole("combobox", { name: /^Message/ });
   await expect(composer).toBeVisible();
   await composer.fill(parentText);
   await composer.press("Enter");
@@ -106,7 +106,7 @@ test("reply preview jumps to parent outside the loaded page", async ({ page }) =
 
   const parentText = `page-parent-${stamp}`;
   const replyText = `page-reply-${stamp}`;
-  const composer = page.getByRole("textbox", { name: /^Message/ });
+  const composer = page.getByRole("combobox", { name: /^Message/ });
   await expect(composer).toBeVisible();
   await composer.fill(parentText);
   await composer.press("Enter");
@@ -169,7 +169,7 @@ test("reply preview jumps to parent outside the loaded page", async ({ page }) =
   });
 
   await page.reload({ waitUntil: "domcontentloaded" });
-  await expect(page.getByRole("textbox", { name: /^Message/ })).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByRole("combobox", { name: /^Message/ })).toBeVisible({ timeout: 20_000 });
   await expect(page.locator(`[data-message-id="${parentId}"]`)).toHaveCount(0);
   const offlinePreview = page
     .locator(`[data-message-id]`)

--- a/apps/web/e2e/peer-messages.spec.ts
+++ b/apps/web/e2e/peer-messages.spec.ts
@@ -17,9 +17,9 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
     notifyOnFinish: true,
   });
   await page.reload();
-  await expect(page.getByRole("textbox", { name: "Message Chief" })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Message Chief" })).toBeVisible();
 
-  const composer = page.getByRole("textbox", { name: "Message Chief" });
+  const composer = page.getByRole("combobox", { name: "Message Chief" });
   await composer.fill("message the bot named Researcher saying peer-exchange-alpha");
   await composer.press("Enter");
   await expect(page.getByText("messaging that bot now.").first()).toBeVisible({

--- a/apps/web/e2e/slash-skills.spec.ts
+++ b/apps/web/e2e/slash-skills.spec.ts
@@ -16,7 +16,7 @@ test("composer / picker lists skills above actions", async ({ page }, testInfo) 
   });
 
   // aria-label stays available when skill/mention chips hide the placeholder.
-  const composer = page.getByRole("textbox", { name: /^Message/ });
+  const composer = page.getByRole("combobox", { name: /^Message/ });
   await expect(composer).toBeVisible();
   await composer.fill("/");
 

--- a/apps/web/e2e/spaces.spec.ts
+++ b/apps/web/e2e/spaces.spec.ts
@@ -21,7 +21,7 @@ test("spaces stay invisible by default and chat creation requires approval", asy
   await captureScreenshot(page, testInfo, "new-space-dialog");
   await dialog.getByRole("button", { name: "Cancel" }).click();
 
-  const composer = page.getByRole("textbox", { name: "Message Chief" });
+  const composer = page.getByRole("combobox", { name: "Message Chief" });
   await composer.fill("Create a space named Customer support");
   await composer.press("Enter");
   await expect(page.getByRole("button", { name: "Create space", exact: true })).toBeVisible({

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4608,6 +4608,7 @@ const Composer = memo(function Composer({
               const action = resolveMentionPickerKey({
                 key: event.key,
                 shiftKey: event.shiftKey,
+                isComposing: event.nativeEvent.isComposing || event.keyCode === 229,
                 optionCount: mentionOptions.length,
                 highlightedIndex: activeMentionIndex,
               });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -43,6 +43,7 @@ import {
   attachmentsForThread,
   buildComposerMentionOptions,
   type ComposerMention,
+  clampMentionHighlightIndex,
   cronFromPreset,
   groupBotsForSidebar,
   inferAttachmentMimeType,
@@ -53,6 +54,7 @@ import {
   mentionChipKey,
   reorderBotTo,
   resolveComposerSendPlan,
+  resolveMentionPickerKey,
   SLASH_ACTIONS,
   type SlashActionId,
   searchHitThreadTarget,
@@ -103,6 +105,7 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -4134,10 +4137,12 @@ const Composer = memo(function Composer({
   const { t } = useLingui();
   const [draft, setDraft] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [mentionHighlightIndex, setMentionHighlightIndex] = useState(0);
   const [slashQuery, setSlashQuery] = useState<string | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<AgentSkillCatalogEntry | null>(null);
   const [selectedMentions, setSelectedMentions] = useState<ComposerMention[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const mentionListboxId = useId();
   const dragDepth = useRef(0);
   const [draggingFiles, setDraggingFiles] = useState(false);
   const canSend =
@@ -4182,14 +4187,20 @@ const Composer = memo(function Composer({
     setSlashQuery(nextSlash);
   }
 
+  function focusComposer() {
+    textareaRef.current?.focus();
+  }
+
   function insertMention(mention: ComposerMention) {
     setDraft((current) => current.replace(/@([\w-]*)$/, ""));
     setMentionQuery(null);
+    setMentionHighlightIndex(0);
     setSelectedMentions((current) =>
       current.some((selected) => mentionChipKey(selected) === mentionChipKey(mention))
         ? current
         : [...current, mention],
     );
+    focusComposer();
   }
 
   function insertSkill(skill: AgentSkillCatalogEntry) {
@@ -4219,6 +4230,19 @@ const Composer = memo(function Composer({
       .filter((target) => !query || target.name.toLowerCase().startsWith(query))
       .slice(0, 10);
   }, [mentionQuery, mentionTargets]);
+
+  useEffect(() => {
+    setMentionHighlightIndex(0);
+  }, [mentionQuery, mentionOptions]);
+
+  const activeMentionIndex = clampMentionHighlightIndex(
+    mentionHighlightIndex,
+    mentionOptions.length,
+  );
+  const mentionPickerOpen = mentionOptions.length > 0;
+  const activeMentionOptionId = mentionPickerOpen
+    ? `${mentionListboxId}-option-${activeMentionIndex}`
+    : undefined;
 
   const slashSkillOptions = useMemo(() => {
     if (slashQuery === null) return [];
@@ -4251,6 +4275,7 @@ const Composer = memo(function Composer({
     const text = serializeComposerPrompt(draft, selectedSkill, selectedMentions);
     setDraft("");
     setMentionQuery(null);
+    setMentionHighlightIndex(0);
     setSlashQuery(null);
     setSelectedSkill(null);
     const mentions = selectedMentions;
@@ -4390,32 +4415,46 @@ const Composer = memo(function Composer({
           ))}
         </div>
       ) : null}
-      {mentionOptions.length ? (
+      {mentionPickerOpen ? (
         <div
+          id={mentionListboxId}
+          role="listbox"
+          aria-label={t`Mentions`}
           data-testid="mention-picker"
           className="mb-2 overflow-hidden rounded-[14px] border border-[#26262A] bg-[#17171A]"
         >
-          {mentionOptions.map((mention) => (
-            <button
-              key={mentionChipKey(mention)}
-              type="button"
-              aria-label={t`@${mention.name}`}
-              onClick={() => insertMention(mention)}
-              className="flex w-full items-start gap-3 px-4 py-2.5 text-start hover:bg-[#1F1F22]"
-            >
-              <MentionOptionIcon mention={mention} />
-              <span className="min-w-0">
-                <span dir="auto" className="block text-[14px] text-[#ECECEE]">
-                  @{mention.name}
-                </span>
-                {mention.subtitle ? (
-                  <span dir="auto" className="block truncate text-[12.5px] text-[#85858A]">
-                    {mention.subtitle}
+          {mentionOptions.map((mention, index) => {
+            const optionId = `${mentionListboxId}-option-${index}`;
+            const highlighted = index === activeMentionIndex;
+            return (
+              <button
+                id={optionId}
+                key={mentionChipKey(mention)}
+                type="button"
+                role="option"
+                aria-selected={highlighted}
+                aria-label={t`@${mention.name}`}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => insertMention(mention)}
+                onMouseEnter={() => setMentionHighlightIndex(index)}
+                className={`flex w-full items-start gap-3 px-4 py-2.5 text-start hover:bg-[#1F1F22] ${
+                  highlighted ? "bg-[#1F1F22]" : ""
+                }`}
+              >
+                <MentionOptionIcon mention={mention} />
+                <span className="min-w-0">
+                  <span dir="auto" className="block text-[14px] text-[#ECECEE]">
+                    @{mention.name}
                   </span>
-                ) : null}
-              </span>
-            </button>
-          ))}
+                  {mention.subtitle ? (
+                    <span dir="auto" className="block truncate text-[12.5px] text-[#85858A]">
+                      {mention.subtitle}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
         </div>
       ) : null}
       {showSlashPicker ? (
@@ -4566,7 +4605,31 @@ const Composer = memo(function Composer({
                 removeLastChip();
                 return;
               }
-              if (event.key === "Enter" && !event.shiftKey) {
+              const action = resolveMentionPickerKey({
+                key: event.key,
+                shiftKey: event.shiftKey,
+                optionCount: mentionOptions.length,
+                highlightedIndex: activeMentionIndex,
+              });
+              if (action.type === "complete") {
+                const mention = mentionOptions[action.index];
+                if (!mention) return;
+                event.preventDefault();
+                insertMention(mention);
+                return;
+              }
+              if (action.type === "move") {
+                event.preventDefault();
+                setMentionHighlightIndex(action.index);
+                return;
+              }
+              if (action.type === "dismiss") {
+                event.preventDefault();
+                setMentionQuery(null);
+                setMentionHighlightIndex(0);
+                return;
+              }
+              if (action.type === "send") {
                 event.preventDefault();
                 send();
               }
@@ -4580,6 +4643,12 @@ const Composer = memo(function Composer({
                 : undefined
             }
             aria-label={activeName ? t`Message ${activeName}` : t`Message`}
+            role="combobox"
+            aria-autocomplete="list"
+            aria-haspopup="listbox"
+            aria-expanded={mentionPickerOpen}
+            aria-controls={mentionPickerOpen ? mentionListboxId : undefined}
+            aria-activedescendant={activeMentionOptionId}
             name="chat-message"
             autoComplete="off"
             dir="auto"

--- a/packages/core/src/composer-mention-picker.test.ts
+++ b/packages/core/src/composer-mention-picker.test.ts
@@ -90,4 +90,23 @@ describe("resolveMentionPickerKey", () => {
       }),
     ).toEqual({ type: "none" });
   });
+
+  it("ignores keys while IME composition is active", () => {
+    expect(
+      resolveMentionPickerKey({
+        key: "Enter",
+        isComposing: true,
+        optionCount: 2,
+        highlightedIndex: 0,
+      }),
+    ).toEqual({ type: "none" });
+    expect(
+      resolveMentionPickerKey({
+        key: "Enter",
+        isComposing: true,
+        optionCount: 0,
+        highlightedIndex: 0,
+      }),
+    ).toEqual({ type: "none" });
+  });
 });

--- a/packages/core/src/composer-mention-picker.test.ts
+++ b/packages/core/src/composer-mention-picker.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampMentionHighlightIndex,
+  resolveMentionPickerKey,
+  wrapMentionHighlightIndex,
+} from "./composer-mention-picker.js";
+
+describe("wrapMentionHighlightIndex", () => {
+  it("wraps past the ends of the list", () => {
+    expect(wrapMentionHighlightIndex(0, 3)).toBe(0);
+    expect(wrapMentionHighlightIndex(2, 3)).toBe(2);
+    expect(wrapMentionHighlightIndex(3, 3)).toBe(0);
+    expect(wrapMentionHighlightIndex(-1, 3)).toBe(2);
+  });
+
+  it("returns 0 when there are no options", () => {
+    expect(wrapMentionHighlightIndex(2, 0)).toBe(0);
+  });
+});
+
+describe("clampMentionHighlightIndex", () => {
+  it("keeps the index inside the list", () => {
+    expect(clampMentionHighlightIndex(1, 3)).toBe(1);
+    expect(clampMentionHighlightIndex(5, 3)).toBe(2);
+    expect(clampMentionHighlightIndex(-2, 3)).toBe(0);
+    expect(clampMentionHighlightIndex(0, 0)).toBe(0);
+  });
+});
+
+describe("resolveMentionPickerKey", () => {
+  it("completes the highlighted mention on Enter and Tab", () => {
+    expect(resolveMentionPickerKey({ key: "Enter", optionCount: 2, highlightedIndex: 1 })).toEqual({
+      type: "complete",
+      index: 1,
+    });
+    expect(resolveMentionPickerKey({ key: "Tab", optionCount: 2, highlightedIndex: 0 })).toEqual({
+      type: "complete",
+      index: 0,
+    });
+  });
+
+  it("moves the highlight with Arrow Up and Down and wraps", () => {
+    expect(
+      resolveMentionPickerKey({ key: "ArrowDown", optionCount: 3, highlightedIndex: 2 }),
+    ).toEqual({ type: "move", index: 0 });
+    expect(
+      resolveMentionPickerKey({ key: "ArrowUp", optionCount: 3, highlightedIndex: 0 }),
+    ).toEqual({ type: "move", index: 2 });
+  });
+
+  it("dismisses the picker on Escape without sending", () => {
+    expect(resolveMentionPickerKey({ key: "Escape", optionCount: 2, highlightedIndex: 0 })).toEqual(
+      { type: "dismiss" },
+    );
+  });
+
+  it("sends on Enter when the picker is closed or empty", () => {
+    expect(resolveMentionPickerKey({ key: "Enter", optionCount: 0, highlightedIndex: 0 })).toEqual({
+      type: "send",
+    });
+  });
+
+  it("ignores Shift+Enter and Shift+Tab while the picker is open", () => {
+    expect(
+      resolveMentionPickerKey({
+        key: "Enter",
+        shiftKey: true,
+        optionCount: 2,
+        highlightedIndex: 0,
+      }),
+    ).toEqual({ type: "none" });
+    expect(
+      resolveMentionPickerKey({
+        key: "Tab",
+        shiftKey: true,
+        optionCount: 2,
+        highlightedIndex: 0,
+      }),
+    ).toEqual({ type: "none" });
+  });
+
+  it("does not send on Shift+Enter when the picker is closed", () => {
+    expect(
+      resolveMentionPickerKey({
+        key: "Enter",
+        shiftKey: true,
+        optionCount: 0,
+        highlightedIndex: 0,
+      }),
+    ).toEqual({ type: "none" });
+  });
+});

--- a/packages/core/src/composer-mention-picker.test.ts
+++ b/packages/core/src/composer-mention-picker.test.ts
@@ -61,7 +61,7 @@ describe("resolveMentionPickerKey", () => {
     });
   });
 
-  it("ignores Shift+Enter and Shift+Tab while the picker is open", () => {
+  it("ignores Shift+Enter while completing on Tab and Shift+Tab", () => {
     expect(
       resolveMentionPickerKey({
         key: "Enter",
@@ -77,7 +77,7 @@ describe("resolveMentionPickerKey", () => {
         optionCount: 2,
         highlightedIndex: 0,
       }),
-    ).toEqual({ type: "none" });
+    ).toEqual({ type: "complete", index: 0 });
   });
 
   it("does not send on Shift+Enter when the picker is closed", () => {

--- a/packages/core/src/composer-mention-picker.ts
+++ b/packages/core/src/composer-mention-picker.ts
@@ -48,7 +48,7 @@ export function resolveMentionPickerKey(input: {
     if (key === "Enter" && !shiftKey) {
       return { type: "complete", index: highlightedIndex };
     }
-    if (key === "Tab" && !shiftKey) {
+    if (key === "Tab") {
       return { type: "complete", index: highlightedIndex };
     }
     if (key === "Escape") {

--- a/packages/core/src/composer-mention-picker.ts
+++ b/packages/core/src/composer-mention-picker.ts
@@ -24,13 +24,17 @@ export function clampMentionHighlightIndex(index: number, count: number): number
 /**
  * Resolve composer key handling while (or after) the mention picker is open.
  * When `optionCount` is 0 the picker is closed or empty: Enter sends (unless Shift).
+ * While IME composition is active, returns `none` so Enter confirms text instead.
  */
 export function resolveMentionPickerKey(input: {
   key: string;
   shiftKey?: boolean;
+  isComposing?: boolean;
   optionCount: number;
   highlightedIndex: number;
 }): MentionPickerKeyAction {
+  if (input.isComposing) return { type: "none" };
+
   const { key, shiftKey = false, optionCount } = input;
   const highlightedIndex = clampMentionHighlightIndex(input.highlightedIndex, optionCount);
 

--- a/packages/core/src/composer-mention-picker.ts
+++ b/packages/core/src/composer-mention-picker.ts
@@ -1,0 +1,60 @@
+/** Keyboard actions for the composer `@` mention picker. */
+
+export type MentionPickerKeyAction =
+  | { type: "complete"; index: number }
+  | { type: "move"; index: number }
+  | { type: "dismiss" }
+  | { type: "send" }
+  | { type: "none" };
+
+/** Wrap highlight within `[0, count)`. Returns `0` when the list is empty. */
+export function wrapMentionHighlightIndex(index: number, count: number): number {
+  if (count <= 0) return 0;
+  return ((index % count) + count) % count;
+}
+
+/** Keep a stored highlight valid after the option list shrinks or grows. */
+export function clampMentionHighlightIndex(index: number, count: number): number {
+  if (count <= 0) return 0;
+  if (index < 0) return 0;
+  if (index >= count) return count - 1;
+  return index;
+}
+
+/**
+ * Resolve composer key handling while (or after) the mention picker is open.
+ * When `optionCount` is 0 the picker is closed or empty: Enter sends (unless Shift).
+ */
+export function resolveMentionPickerKey(input: {
+  key: string;
+  shiftKey?: boolean;
+  optionCount: number;
+  highlightedIndex: number;
+}): MentionPickerKeyAction {
+  const { key, shiftKey = false, optionCount } = input;
+  const highlightedIndex = clampMentionHighlightIndex(input.highlightedIndex, optionCount);
+
+  if (optionCount > 0) {
+    if (key === "ArrowDown") {
+      return { type: "move", index: wrapMentionHighlightIndex(highlightedIndex + 1, optionCount) };
+    }
+    if (key === "ArrowUp") {
+      return { type: "move", index: wrapMentionHighlightIndex(highlightedIndex - 1, optionCount) };
+    }
+    if (key === "Enter" && !shiftKey) {
+      return { type: "complete", index: highlightedIndex };
+    }
+    if (key === "Tab" && !shiftKey) {
+      return { type: "complete", index: highlightedIndex };
+    }
+    if (key === "Escape") {
+      return { type: "dismiss" };
+    }
+    return { type: "none" };
+  }
+
+  if (key === "Enter" && !shiftKey) {
+    return { type: "send" };
+  }
+  return { type: "none" };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./avatar-shape.js";
 export * from "./bot-messages.js";
 export * from "./bot-sections.js";
 export * from "./compose-update.js";
+export * from "./composer-mention-picker.js";
 export * from "./composer-mentions.js";
 export * from "./composer-slash.js";
 export * from "./cron.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Typing `@` opened the mention picker, but Enter still sent the incomplete draft and Tab did nothing. The web Shell composer treated Enter as send even while mention suggestions were visible.

This adds keyboard completion for the group-chat composer:

- First match is highlighted when the picker opens
- Enter and Tab insert the highlighted mention (no send)
- Arrow Up/Down move the highlight with wrap
- Escape dismisses without changing or sending the draft
- Enter sends normally when the picker is closed or empty
- Click-to-select still works; focus stays in the composer
- Combobox/listbox semantics (`aria-expanded`, listbox options, `aria-activedescendant`)
- IME composition Enter is ignored so composition can finish normally

## Mobile

Left alone. Mobile uses a multiline `TextInput` with tap-to-select and no Enter-to-send path on the mention picker, so it is not the same keyboard hole.

## Tests

- Unit tests for Enter, Tab, arrows, Escape, IME, and normal send when closed
- Playwright E2E opens the mention picker and covers Enter, Tab, Escape, and send-after-close, with CI screenshot checkpoints of the open picker and completed mention

Closes #431

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76a9f027-d636-4dca-96ab-1573368e592f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76a9f027-d636-4dca-96ab-1573368e592f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation for mention suggestions, including Arrow keys, Tab, Enter, and Escape.
  * Added accessible combobox, listbox, and option semantics to the message composer.
  * Highlighted mention options are now visibly and programmatically indicated.

* **Bug Fixes**
  * Updated messaging interactions to reliably target the composer and mention options.

* **Tests**
  * Added coverage for keyboard-based mention selection, dismissal, and message sending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->