### PR TITLE
feat(chat): add tappable choice prompts

### DIFF
--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -111,13 +111,14 @@ function newClientNonce(): string {
 
 function formatApprovalAnswer(answer: string | undefined, actions?: AskAction[]): string {
   if (!answer) return "Answered";
-  const outcome = actions?.find((action) => action.id === answer)?.outcome;
+  const selectedAction = actions?.find((action) => action.id === answer);
+  const outcome = selectedAction?.outcome;
   if (outcome === "created") return "Created";
   if (outcome === "cancelled") return "Cancelled";
   if (answer === "allow") return "Allowed once";
   if (answer === "always") return "Always allowed";
   if (answer === "deny") return "Denied";
-  return `Answered: ${answer}`;
+  return `Answered: ${selectedAction?.label ?? answer}`;
 }
 
 function isWorkingStatus(status: string | undefined): boolean {
@@ -2074,7 +2075,9 @@ const MessageBubble = memo(function MessageBubble({
       </View>
     );
   }
-  const askBlock = message.blocks.find(isApprovalAskBlock);
+  const askBlock = message.blocks.find(
+    (block) => block.kind === "ask" && Boolean(block.actions?.length),
+  );
   if (askBlock?.kind === "ask" && askBlock.actions?.length) {
     return (
       <View style={{ gap: 8, width: "100%" }}>

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -20,6 +20,7 @@ import {
   resolveComposerSendPlan,
   SLASH_ACTIONS,
   type SlashActionId,
+  selectedAskActionLabel,
   serializeComposerPrompt,
   truncateSlashDescription,
   userVisibleMessages,
@@ -109,16 +110,20 @@ function newClientNonce(): string {
   return `m-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-function formatApprovalAnswer(answer: string | undefined, actions?: AskAction[]): string {
+function formatApprovalAnswer(
+  answer: string | undefined,
+  actions: AskAction[] | undefined,
+  approval: boolean,
+): string {
   if (!answer) return "Answered";
   const selectedAction = actions?.find((action) => action.id === answer);
   const outcome = selectedAction?.outcome;
-  if (outcome === "created") return "Created";
-  if (outcome === "cancelled") return "Cancelled";
-  if (answer === "allow") return "Allowed once";
-  if (answer === "always") return "Always allowed";
-  if (answer === "deny") return "Denied";
-  return `Answered: ${selectedAction?.label ?? answer}`;
+  if (approval && outcome === "created") return "Created";
+  if (approval && outcome === "cancelled") return "Cancelled";
+  if (approval && answer === "allow") return "Allowed once";
+  if (approval && answer === "always") return "Always allowed";
+  if (approval && answer === "deny") return "Denied";
+  return `Answered: ${selectedAskActionLabel(answer, actions)}`;
 }
 
 function isWorkingStatus(status: string | undefined): boolean {
@@ -1903,7 +1908,7 @@ const MessageBubble = memo(function MessageBubble({
   );
   const ask = message.blocks.find(
     (block): block is Extract<MessageBlock, { kind: "ask" }> =>
-      block.kind === "ask" && !isApprovalAskBlock(block),
+      block.kind === "ask" && !isApprovalAskBlock(block) && !block.actions?.length,
   );
   if (ask) {
     return (
@@ -2119,7 +2124,11 @@ const MessageBubble = memo(function MessageBubble({
                 fontWeight: "600",
               }}
             >
-              {formatApprovalAnswer(askBlock.answer, askBlock.actions)}
+              {formatApprovalAnswer(
+                askBlock.answer,
+                askBlock.actions,
+                isApprovalAskBlock(askBlock),
+              )}
             </Text>
           ) : canAnswer && onAnswer ? (
             <AskActions

--- a/apps/web/e2e/choice-card.spec.ts
+++ b/apps/web/e2e/choice-card.spec.ts
@@ -7,13 +7,11 @@ test("renders tappable choice buttons and submits the offered action id", async 
   const stamp = Date.now();
   await signup(page, `choice-card-${stamp}@rakazo.test`, "password12", "Choice Card");
   await completeOnboarding(page);
-  await page.goto("/app");
-  await page.waitForURL(/\/app\/[^/]+$/);
 
   const botId = activeBotId(page);
-  const composer = page.getByRole("textbox", { name: /Message/ });
+  const composer = page.getByPlaceholder(/Message/);
   await composer.fill("pick from these cities with tappable choices");
-  await composer.press("Enter");
+  await page.keyboard.press("Enter");
 
   await expect
     .poll(
@@ -27,10 +25,11 @@ test("renders tappable choice buttons and submits the offered action id", async 
     )
     .toBe("waiting_input");
 
+  // threads/get can observe waiting_input before the shell realtime feed paints the ask card.
   const prompt = page.locator("p").filter({ hasText: /^Which city should I use\?$/ });
   if ((await prompt.count()) === 0) {
     await page.reload({ waitUntil: "domcontentloaded" });
-    await expect(composer).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByPlaceholder(/Message/)).toBeVisible({ timeout: 15_000 });
   }
   await expect(prompt).toBeVisible({ timeout: 15_000 });
 

--- a/apps/web/e2e/choice-card.spec.ts
+++ b/apps/web/e2e/choice-card.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+import { activeBotId, captureScreenshot, completeOnboarding, rpc, signup } from "./helpers";
+
+test("renders tappable choice buttons and submits the offered action id", async ({
+  page,
+}, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `choice-card-${stamp}@rakazo.test`, "password12", "Choice Card");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  const botId = activeBotId(page);
+  const composer = page.getByRole("textbox", { name: /Message/ });
+  await composer.fill("pick from these cities with tappable choices");
+  await composer.press("Enter");
+
+  await expect
+    .poll(
+      async () => {
+        const snapshot = await rpc<{ run?: { status: string } | null }>(page, "threads/get", {
+          botId,
+        });
+        return snapshot.run?.status ?? null;
+      },
+      { timeout: 60_000 },
+    )
+    .toBe("waiting_input");
+
+  const prompt = page.locator("p").filter({ hasText: /^Which city should I use\?$/ });
+  if ((await prompt.count()) === 0) {
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(composer).toBeVisible({ timeout: 15_000 });
+  }
+  await expect(prompt).toBeVisible({ timeout: 15_000 });
+
+  const berlin = page.getByRole("button", { name: "Berlin", exact: true });
+  const seoul = page.getByRole("button", { name: "Seoul", exact: true });
+  const toronto = page.getByRole("button", { name: "Toronto", exact: true });
+  const lisbon = page.getByRole("button", { name: "Lisbon", exact: true });
+  await expect(berlin).toBeVisible();
+  await expect(seoul).toBeVisible();
+  await expect(toronto).toBeVisible();
+  await expect(lisbon).toBeVisible();
+  await captureScreenshot(page, testInfo, "choice-card");
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(berlin).toBeVisible();
+  await expect(lisbon).toBeVisible();
+  // Wrapped buttons stay fully tappable on a narrow card.
+  await expect(lisbon).toBeEnabled();
+  await captureScreenshot(page, testInfo, "choice-card-narrow");
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await seoul.click();
+
+  await expect(page.getByText("Answered: Seoul", { exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByRole("button", { name: "Seoul", exact: true })).toHaveCount(0);
+
+  await expect
+    .poll(
+      async () => {
+        const history = await rpc<{
+          messages: Array<{
+            blocks: Array<{
+              kind: string;
+              status?: string;
+              answer?: string;
+              actions?: Array<{ id: string; label: string }>;
+            }>;
+          }>;
+        }>(page, "threads/messages", { botId });
+        const answered = history.messages
+          .flatMap((message) => message.blocks)
+          .find(
+            (block) =>
+              block.kind === "ask" &&
+              block.status === "answered" &&
+              Array.isArray(block.actions) &&
+              block.actions.some((action) => action.id === "choice-2"),
+          );
+        return answered?.answer ?? null;
+      },
+      { timeout: 30_000 },
+    )
+    .toBe("choice-2");
+
+  await captureScreenshot(page, testInfo, "choice-card-answered");
+});

--- a/apps/web/src/components/AskCard.test.tsx
+++ b/apps/web/src/components/AskCard.test.tsx
@@ -1,12 +1,12 @@
+import { selectedAskActionLabel } from "@rakazo/core";
 import { describe, expect, it } from "vitest";
-import { selectedAskActionLabel } from "./ask-card-state.js";
 
 describe("selectedAskActionLabel", () => {
   it("maps a choice answer id to its user-facing label", () => {
     expect(
-      selectedAskActionLabel("seoul", [
-        { id: "berlin", label: "Berlin" },
-        { id: "seoul", label: "Seoul" },
+      selectedAskActionLabel("choice-2", [
+        { id: "choice-1", label: "Berlin" },
+        { id: "choice-2", label: "Seoul" },
       ]),
     ).toBe("Seoul");
   });

--- a/apps/web/src/components/AskCard.test.tsx
+++ b/apps/web/src/components/AskCard.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { selectedAskActionLabel } from "./ask-card-state.js";
+
+describe("selectedAskActionLabel", () => {
+  it("maps a choice answer id to its user-facing label", () => {
+    expect(
+      selectedAskActionLabel("seoul", [
+        { id: "berlin", label: "Berlin" },
+        { id: "seoul", label: "Seoul" },
+      ]),
+    ).toBe("Seoul");
+  });
+
+  it("falls back to the answer when an action is unavailable", () => {
+    expect(selectedAskActionLabel("custom", undefined)).toBe("custom");
+  });
+});

--- a/apps/web/src/components/AskCard.tsx
+++ b/apps/web/src/components/AskCard.tsx
@@ -4,6 +4,7 @@ import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type { ThreadMessage } from "@rakazo/contracts";
 import { isApprovalAskBlock, isSecretAskBlock } from "@rakazo/core";
 import { useState } from "react";
+import { selectedAskActionLabel } from "./ask-card-state";
 
 export type AskBlock = Extract<ThreadMessage["blocks"][number], { kind: "ask" }>;
 
@@ -12,10 +13,11 @@ function formatAnsweredState(
   approval: boolean,
   secret: boolean,
   outcome?: "created" | "cancelled",
+  actions?: AskBlock["actions"],
 ): string {
   if (secret) return t`Submitted`;
   if (!answer) return t`Answered`;
-  if (!approval) return t`Answered: ${answer}`;
+  if (!approval) return t`Answered: ${selectedAskActionLabel(answer, actions)}`;
   if (outcome === "created") return t`Created`;
   if (outcome === "cancelled") return t`Cancelled`;
   if (answer === "allow") return t`Allowed once`;
@@ -53,6 +55,7 @@ export function AskCard({
   const [error, setError] = useState<string | null>(null);
   const submitting = pendingAction !== null;
   const approvalActions = isApprovalAskBlock(block) ? block.actions : undefined;
+  const askActions = block.actions;
   const secretInput = isSecretAskBlock(block);
 
   async function submitAnswer(value: string) {
@@ -87,30 +90,33 @@ export function AskCard({
             Boolean(approvalActions),
             secretInput,
             approvalActions?.find((action) => action.id === block.answer)?.outcome,
+            askActions,
           )}
         </div>
       ) : !canAnswer ? (
         <div className="mt-3.5 text-[13.5px] font-medium text-[#85858A]">
           <Trans>No longer active</Trans>
         </div>
-      ) : approvalActions ? (
+      ) : askActions?.length ? (
         <div className="mt-3.5 flex gap-2">
-          {approvalActions.map((action) => (
+          {askActions.map((action) => (
             <button
               key={action.id}
               type="button"
               disabled={submitting}
               onClick={() => void submitAnswer(action.id)}
               className={
-                action.id === "allow"
+                approvalActions && action.id === "allow"
                   ? "rounded-[11px] bg-[#F1F1EF] px-[17px] py-2 text-[14.5px] font-medium text-[#17171A] disabled:opacity-50"
                   : "rounded-[11px] border border-[#26262A] px-[17px] py-2 text-[14.5px] text-[#C9C9CE] disabled:opacity-50"
               }
             >
               {pendingAction === action.id ? (
                 <Trans>Sending…</Trans>
-              ) : (
+              ) : approvalActions ? (
                 approvalActionLabel(action.id, action.label, action.outcome)
+              ) : (
+                action.label
               )}
             </button>
           ))}

--- a/apps/web/src/components/AskCard.tsx
+++ b/apps/web/src/components/AskCard.tsx
@@ -97,7 +97,7 @@ export function AskCard({
           <Trans>No longer active</Trans>
         </div>
       ) : askActions?.length ? (
-        <div className="mt-3.5 flex gap-2">
+        <div className="mt-3.5 flex flex-wrap gap-2">
           {askActions.map((action) => (
             <button
               key={action.id}

--- a/apps/web/src/components/AskCard.tsx
+++ b/apps/web/src/components/AskCard.tsx
@@ -2,9 +2,8 @@ import { t } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type { ThreadMessage } from "@rakazo/contracts";
-import { isApprovalAskBlock, isSecretAskBlock } from "@rakazo/core";
+import { isApprovalAskBlock, isSecretAskBlock, selectedAskActionLabel } from "@rakazo/core";
 import { useState } from "react";
-import { selectedAskActionLabel } from "./ask-card-state";
 
 export type AskBlock = Extract<ThreadMessage["blocks"][number], { kind: "ask" }>;
 

--- a/apps/web/src/components/ask-card-state.ts
+++ b/apps/web/src/components/ask-card-state.ts
@@ -1,0 +1,6 @@
+export function selectedAskActionLabel(
+  answer: string,
+  actions?: Array<{ id: string; label: string }>,
+): string {
+  return actions?.find((action) => action.id === answer)?.label ?? answer;
+}

--- a/apps/web/src/components/ask-card-state.ts
+++ b/apps/web/src/components/ask-card-state.ts
@@ -1,6 +1,0 @@
-export function selectedAskActionLabel(
-  answer: string,
-  actions?: Array<{ id: string; label: string }>,
-): string {
-  return actions?.find((action) => action.id === answer)?.label ?? answer;
-}

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -343,7 +343,7 @@ export interface AgentRunRequest {
 export interface ScriptedTurn {
   assistant?: string;
   toolCalls?: Array<{ name: string; args: Record<string, unknown> }>;
-  ask?: { text: string; detail?: string };
+  ask?: { text: string; detail?: string; actions?: Array<{ id: string; label: string }> };
   takeover?: { reason: string };
   files?: Array<{ path: string; content: string }>;
   memory?: Array<{ scope: "bot" | "user"; path: string; content: string }>;
@@ -354,7 +354,12 @@ export type AgentRuntimeEvent =
   | { type: "text"; text: string }
   | { type: "progress"; text: string }
   | { type: "tool"; name: string; args: Record<string, unknown>; executionId: string }
-  | { type: "ask"; text: string; detail?: string }
+  | {
+      type: "ask";
+      text: string;
+      detail?: string;
+      actions?: Array<{ id: string; label: string }>;
+    }
   | { type: "takeover"; reason: string }
   | { type: "usage"; inputTokens: number; outputTokens: number; provider: string; model: string }
   | { type: "checkpoint"; blob: string }

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -141,6 +141,25 @@ export const builtinAgentTools: ConnectorTool[] = [
     },
   },
   {
+    name: "ask_user",
+    description:
+      "Ask the user one short multiple-choice question with tappable options, then wait for their selection. Use this instead of asking them to type when two to four concise choices are enough.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        question: { type: "string", maxLength: 240 },
+        options: {
+          type: "array",
+          items: { type: "string", minLength: 1, maxLength: 80 },
+          minItems: 2,
+          maxItems: 4,
+          uniqueItems: true,
+        },
+      },
+      required: ["question", "options"],
+    },
+  },
+  {
     name: "request_secret",
     description:
       "Collect a one-shot OTP, password, or API key in a masked field that never reaches the chat transcript or model. For website logins, CAPTCHA, passkeys, or anything that needs the live desktop, call request_takeover instead.",

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2602,7 +2602,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 ? redactSecrets(event.detail, runSecrets)
                 : event.detail;
               const safeActions = event.actions?.map((action) => ({
-                id: redactSecrets(action.id, runSecrets),
+                id: action.id,
                 label: redactSecrets(action.label, runSecrets),
               }));
               await checkpointAndRecordComputerWorkspace(deps, storedComputer, computer, context);

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2601,6 +2601,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
               const safeDetail = event.detail
                 ? redactSecrets(event.detail, runSecrets)
                 : event.detail;
+              const safeActions = event.actions?.map((action) => ({
+                id: redactSecrets(action.id, runSecrets),
+                label: redactSecrets(action.label, runSecrets),
+              }));
               await checkpointAndRecordComputerWorkspace(deps, storedComputer, computer, context);
               const paused = await deps.events.pauseRunForInput({
                 spaceId: run.spaceId,
@@ -2610,7 +2614,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 attemptId: attempt.id,
                 leaseOwner: workerId,
                 leaseFence: fence,
-                blocks: [{ kind: "ask", text: safeText, detail: safeDetail, status: "pending" }],
+                blocks: [
+                  {
+                    kind: "ask",
+                    text: safeText,
+                    detail: safeDetail,
+                    status: "pending",
+                    actions: safeActions,
+                  },
+                ],
               });
               if (!paused) return;
               await notifyRun(deps, run, {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2623,6 +2623,8 @@ export function createRunExecutor(deps: ExecutorDeps) {
                     actions: safeActions,
                   },
                 ],
+                // Keep unredacted labels on the run for resume; message blocks stay redacted.
+                offeredActions: event.actions,
               });
               if (!paused) return;
               await notifyRun(deps, run, {

--- a/packages/adapters/src/index.test.ts
+++ b/packages/adapters/src/index.test.ts
@@ -171,6 +171,7 @@ describe("builtin tools", () => {
         "shell",
         "remember",
         "request_takeover",
+        "ask_user",
         "request_secret",
         "run_subagent",
         "create_space",

--- a/packages/adapters/src/pi-runtime-choice.test.ts
+++ b/packages/adapters/src/pi-runtime-choice.test.ts
@@ -1,0 +1,116 @@
+import type { ConnectorTool } from "@rakazo/adapter-kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fakeAgentState = vi.hoisted(() => ({
+  tools: [] as Array<{
+    name: string;
+    execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+  }>,
+}));
+
+vi.mock("@earendil-works/pi-agent-core", () => ({
+  Agent: class {
+    state = { errorMessage: undefined, messages: [] };
+    private readonly tools: typeof fakeAgentState.tools;
+
+    constructor(options: { initialState: { tools: typeof fakeAgentState.tools } }) {
+      this.tools = options.initialState.tools;
+      fakeAgentState.tools = this.tools;
+    }
+
+    subscribe(_listener: unknown) {}
+
+    async prompt() {
+      const askUser = this.tools.find((tool) => tool.name === "ask_user");
+      if (!askUser) throw new Error("ask_user tool missing");
+      await askUser.execute("call-choice-1", {
+        question: "Which city should I use?",
+        options: ["Berlin", "Seoul", "Toronto"],
+      });
+    }
+
+    async waitForIdle() {}
+
+    abort() {}
+  },
+}));
+
+vi.mock("@earendil-works/pi-ai/providers/all", () => ({
+  builtinModels: () => ({
+    getModel: (_provider: string, modelId: string) =>
+      modelId === "choice-pi-model" ? { provider: "test", id: modelId } : undefined,
+    streamSimple: () => {
+      throw new Error("the fake agent must not call a provider");
+    },
+  }),
+}));
+
+vi.mock("./pi-local-provider.js", () => ({
+  registerLocalProvider: (models: unknown) => models,
+}));
+
+vi.mock("./pi-openai-compatible-provider.js", () => ({
+  OPENAI_COMPATIBLE_PROVIDER_ID: "openai-compatible",
+  registerOpenAiCompatibleCatalog: (models: unknown) => models,
+  registerOpenAiCompatibleRuntime: (models: unknown) => models,
+}));
+
+import { PiAgentRuntime } from "./pi-runtime.js";
+
+const choiceTool: ConnectorTool = {
+  name: "ask_user",
+  description: "Ask a short multiple-choice question",
+  inputSchema: {
+    type: "object",
+    properties: {
+      question: { type: "string" },
+      options: { type: "array", items: { type: "string" } },
+    },
+    required: ["question", "options"],
+  },
+};
+
+const runContext = {
+  operationId: "choice-pi",
+  traceId: "choice-pi",
+  spaceId: "space",
+  userId: "user",
+  signal: new AbortController().signal,
+};
+
+const runRequest = {
+  botId: "bot",
+  threadId: "thread",
+  runId: "run",
+  prompt: "ask me which city to use",
+  instructions: "Use ask_user for a short list of options.",
+  history: [],
+  tools: [choiceTool],
+  model: { provider: "test", id: "choice-pi-model" },
+};
+
+describe("Pi choice asks", () => {
+  beforeEach(() => {
+    fakeAgentState.tools = [];
+  });
+
+  it("emits a tappable ask and stops without a finished-work fallback", async () => {
+    const runtime = new PiAgentRuntime();
+    const events = [];
+
+    for await (const event of runtime.run(runRequest, runContext)) events.push(event);
+
+    expect(events).toContainEqual({
+      type: "ask",
+      text: "Which city should I use?",
+      actions: [
+        { id: "Berlin", label: "Berlin" },
+        { id: "Seoul", label: "Seoul" },
+        { id: "Toronto", label: "Toronto" },
+      ],
+    });
+    expect(
+      events.some((event) => event.type === "text" && event.text.includes("I finished the work.")),
+    ).toBe(false);
+  });
+});

--- a/packages/adapters/src/pi-runtime-choice.test.ts
+++ b/packages/adapters/src/pi-runtime-choice.test.ts
@@ -1,7 +1,8 @@
-import type { ConnectorTool } from "@rakazo/adapter-kit";
+import type { AgentRuntimeEvent, ConnectorTool } from "@rakazo/adapter-kit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakeAgentState = vi.hoisted(() => ({
+  options: ["Berlin", "Seoul", "Toronto"],
   tools: [] as Array<{
     name: string;
     execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
@@ -25,7 +26,7 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
       if (!askUser) throw new Error("ask_user tool missing");
       await askUser.execute("call-choice-1", {
         question: "Which city should I use?",
-        options: ["Berlin", "Seoul", "Toronto"],
+        options: fakeAgentState.options,
       });
     }
 
@@ -92,11 +93,12 @@ const runRequest = {
 describe("Pi choice asks", () => {
   beforeEach(() => {
     fakeAgentState.tools = [];
+    fakeAgentState.options = ["Berlin", "Seoul", "Toronto"];
   });
 
   it("emits a tappable ask and stops without a finished-work fallback", async () => {
     const runtime = new PiAgentRuntime();
-    const events = [];
+    const events: AgentRuntimeEvent[] = [];
 
     for await (const event of runtime.run(runRequest, runContext)) events.push(event);
 
@@ -104,13 +106,24 @@ describe("Pi choice asks", () => {
       type: "ask",
       text: "Which city should I use?",
       actions: [
-        { id: "Berlin", label: "Berlin" },
-        { id: "Seoul", label: "Seoul" },
-        { id: "Toronto", label: "Toronto" },
+        { id: "choice-1", label: "Berlin" },
+        { id: "choice-2", label: "Seoul" },
+        { id: "choice-3", label: "Toronto" },
       ],
     });
     expect(
       events.some((event) => event.type === "text" && event.text.includes("I finished the work.")),
     ).toBe(false);
+  });
+
+  it("rejects an empty choice set before emitting an ask", async () => {
+    fakeAgentState.options = [];
+    const runtime = new PiAgentRuntime();
+    const events: AgentRuntimeEvent[] = [];
+
+    await expect(async () => {
+      for await (const event of runtime.run(runRequest, runContext)) events.push(event);
+    }).rejects.toThrow("ask_user requires two to four unique, non-empty options");
+    expect(events.some((event) => event.type === "ask")).toBe(false);
   });
 });

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -561,16 +561,22 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
         };
       }
       if (tool.name === "ask_user") {
+        const options = Array.isArray(args.options)
+          ? args.options.map((option) => String(option).trim())
+          : [];
+        if (
+          options.length < 2 ||
+          options.length > 4 ||
+          options.some((option) => option.length === 0 || option.length > 80) ||
+          new Set(options).size !== options.length
+        ) {
+          throw new Error("ask_user requires two to four unique, non-empty options");
+        }
         host.pausePending = true;
         host.queue.push({
           type: "ask",
           text: String(args.question ?? "What should I use?"),
-          actions: Array.isArray(args.options)
-            ? args.options.map((option) => {
-                const label = String(option);
-                return { id: label, label };
-              })
-            : [],
+          actions: options.map((label, index) => ({ id: `choice-${index + 1}`, label })),
         });
         return {
           content: [{ type: "text", text: "Waiting for the user's choice." }],
@@ -790,6 +796,16 @@ function parametersFor(tool: ConnectorTool) {
       label: Type.String(),
       purpose: Type.Union([Type.Literal("otp"), Type.Literal("password"), Type.Literal("api_key")]),
       connectionId: Type.Optional(Type.String()),
+    });
+  }
+  if (tool.name === "ask_user") {
+    return Type.Object({
+      question: Type.String({ maxLength: 240 }),
+      options: Type.Array(Type.String({ minLength: 1, maxLength: 80 }), {
+        minItems: 2,
+        maxItems: 4,
+        uniqueItems: true,
+      }),
     });
   }
   if (tool.name === "remember") {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -476,6 +476,12 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
       if (tool.name === "request_takeover") {
         return { reason: String(raw.reason ?? "I need you on the screen.") };
       }
+      if (tool.name === "ask_user") {
+        return {
+          question: String(raw.question ?? "What should I use?"),
+          options: Array.isArray(raw.options) ? raw.options.map(String) : [],
+        };
+      }
       if (tool.name === "request_secret") {
         return {
           label: String(raw.label ?? "Code"),
@@ -550,6 +556,24 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
         });
         return {
           content: [{ type: "text", text: "Takeover requested." }],
+          details: args,
+          terminate: true,
+        };
+      }
+      if (tool.name === "ask_user") {
+        host.pausePending = true;
+        host.queue.push({
+          type: "ask",
+          text: String(args.question ?? "What should I use?"),
+          actions: Array.isArray(args.options)
+            ? args.options.map((option) => {
+                const label = String(option);
+                return { id: label, label };
+              })
+            : [],
+        });
+        return {
+          content: [{ type: "text", text: "Waiting for the user's choice." }],
           details: args,
           terminate: true,
         };

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -477,9 +477,12 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
         return { reason: String(raw.reason ?? "I need you on the screen.") };
       }
       if (tool.name === "ask_user") {
+        const options = Array.isArray(raw.options) ? raw.options.map(String) : raw.options;
         return {
           question: String(raw.question ?? "What should I use?"),
-          options: Array.isArray(raw.options) ? raw.options.map(String) : [],
+          // Keep a missing/invalid options value as-is so schema minItems can reject it;
+          // do not coerce to [] (that used to look like a valid empty list upstream).
+          options,
         };
       }
       if (tool.name === "request_secret") {
@@ -925,7 +928,17 @@ function jsonField(spec: unknown): ReturnType<typeof Type.String> {
   const type = "type" in definition ? String(definition.type) : "string";
   if (type === "number" || type === "integer") return Type.Number() as never;
   if (type === "boolean") return Type.Boolean() as never;
-  if (type === "array") return Type.Array(jsonField(definition.items)) as never;
+  if (type === "array") {
+    const options: {
+      minItems?: number;
+      maxItems?: number;
+      uniqueItems?: boolean;
+    } = {};
+    if (typeof definition.minItems === "number") options.minItems = definition.minItems;
+    if (typeof definition.maxItems === "number") options.maxItems = definition.maxItems;
+    if (definition.uniqueItems === true) options.uniqueItems = true;
+    return Type.Array(jsonField(definition.items), options) as never;
+  }
   if (type === "object") return jsonSchemaParameters(definition) as never;
   return Type.String();
 }

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -174,6 +174,27 @@ export function inferScript(
     ];
   }
   if (
+    lower.includes("tappable choices") ||
+    lower.includes("choice buttons") ||
+    lower.includes("pick from these cities")
+  ) {
+    return [
+      {
+        assistant: "pick one to continue.",
+        ask: {
+          text: "Which city should I use?",
+          detail: "Tap one option.",
+          actions: [
+            { id: "choice-1", label: "Berlin" },
+            { id: "choice-2", label: "Seoul" },
+            { id: "choice-3", label: "Toronto" },
+            { id: "choice-4", label: "Lisbon" },
+          ],
+        },
+      },
+    ];
+  }
+  if (
     lower.includes("ask me") ||
     lower.includes("which city") ||
     lower.includes("need a decision")

--- a/packages/adapters/src/scripted-runtime.ts
+++ b/packages/adapters/src/scripted-runtime.ts
@@ -94,7 +94,12 @@ export class ScriptedAgentRuntime implements AgentRuntime {
           };
         }
         if (turn.ask) {
-          yield { type: "ask", text: turn.ask.text, detail: turn.ask.detail };
+          yield {
+            type: "ask",
+            text: turn.ask.text,
+            detail: turn.ask.detail,
+            actions: turn.ask.actions,
+          };
           return;
         }
         if (turn.takeover) {

--- a/packages/core/src/answerable-ask.test.ts
+++ b/packages/core/src/answerable-ask.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { latestAnswerableAskMessageId } from "./answerable-ask.js";
+import { latestAnswerableAskMessageId, selectedAskActionLabel } from "./answerable-ask.js";
 
 describe("latestAnswerableAskMessageId", () => {
   it("finds a waiting prompt even when a newer group run is active", () => {
@@ -34,5 +34,20 @@ describe("latestAnswerableAskMessageId", () => {
         messages: [{ id: "ask-1", runId: "run-1", blocks: [{ kind: "ask", status: "answered" }] }],
       }),
     ).toBeNull();
+  });
+});
+
+describe("selectedAskActionLabel", () => {
+  it("maps a choice answer id to its user-facing label", () => {
+    expect(
+      selectedAskActionLabel("choice-2", [
+        { id: "choice-1", label: "Berlin" },
+        { id: "choice-2", label: "Seoul" },
+      ]),
+    ).toBe("Seoul");
+  });
+
+  it("falls back to the answer when an action is unavailable", () => {
+    expect(selectedAskActionLabel("custom", undefined)).toBe("custom");
   });
 });

--- a/packages/core/src/answerable-ask.ts
+++ b/packages/core/src/answerable-ask.ts
@@ -24,3 +24,10 @@ export function latestAnswerableAskMessageId(snapshot: AskSnapshot | null): stri
   }
   return null;
 }
+
+export function selectedAskActionLabel(
+  answer: string,
+  actions?: readonly { id: string; label: string }[],
+): string {
+  return actions?.find((action) => action.id === answer)?.label ?? answer;
+}

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -275,6 +275,89 @@ describe("pauseRunForInput", () => {
     ]);
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 8 }));
   });
+
+  it("stores offered choice actions on the run checkpoint for resume", async () => {
+    const fanout = new TestFanout();
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      run: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUnique: vi.fn().mockResolvedValue({
+          status: "running",
+          createdAt: new Date("2026-08-16T12:00:00.000Z"),
+          threadId: "thread-1",
+        }),
+      },
+      attempt: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      thread: {
+        update: vi
+          .fn()
+          .mockResolvedValueOnce({ nextMessageSeq: 4 })
+          .mockResolvedValueOnce({ nextEventSeq: 8 })
+          .mockResolvedValueOnce({ nextEventSeq: 9 }),
+      },
+      message: { create: vi.fn().mockResolvedValue({ id: "message-1" }) },
+      event: {
+        create: vi.fn(async ({ data }: { data: { seq: number; type: string } }) => ({
+          ...event(data.seq),
+          type: data.type,
+        })),
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      pauseRunForInput(
+        prisma,
+        {
+          spaceId: "workspace-1",
+          threadId: "thread-1",
+          botId: "bot-1",
+          runId: "run-1",
+          attemptId: "attempt-1",
+          leaseOwner: "worker-1",
+          leaseFence: 3,
+          blocks: [
+            {
+              kind: "ask",
+              text: "Which token?",
+              status: "pending",
+              actions: [
+                { id: "choice-1", label: "use [redacted]" },
+                { id: "choice-2", label: "use plain" },
+              ],
+            },
+          ],
+          offeredActions: [
+            { id: "choice-1", label: "use sk-live-choice-secret" },
+            { id: "choice-2", label: "use plain" },
+          ],
+        },
+        fanout,
+      ),
+    ).resolves.toBe(true);
+
+    expect(tx.run.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          status: "waiting_input",
+          leaseOwner: null,
+          leaseExpiresAt: null,
+          checkpoint: JSON.stringify({
+            kind: "choice_ask_v1",
+            actions: [
+              { id: "choice-1", label: "use sk-live-choice-secret" },
+              { id: "choice-2", label: "use plain" },
+            ],
+          }),
+        },
+      }),
+    );
+  });
 });
 
 describe("pauseRunForTakeover", () => {
@@ -409,7 +492,7 @@ describe("answerRunInput", () => {
     expect(tx.run.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ status: "waiting_input" }),
-        data: { status: "queued" },
+        data: { status: "queued", checkpoint: null },
       }),
     );
     expect(tx.message.update).toHaveBeenCalledWith({
@@ -439,6 +522,104 @@ describe("answerRunInput", () => {
       }),
     );
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 9 }));
+  });
+
+  it("resumes with the offered choice label when the persisted label was redacted", async () => {
+    const fanout = new TestFanout();
+    const secret = "sk-live-choice-secret";
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      message: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "message-1",
+          blocks: [
+            {
+              kind: "ask",
+              text: "Which token?",
+              status: "pending",
+              actions: [
+                { id: "choice-1", label: `use [redacted]` },
+                { id: "choice-2", label: "use plain" },
+              ],
+            },
+          ],
+        }),
+        update: vi.fn().mockResolvedValue({ id: "message-1" }),
+      },
+      run: {
+        findFirst: vi.fn().mockResolvedValue({
+          botId: "bot-2",
+          userId: "user-1",
+          checkpoint: JSON.stringify({
+            kind: "choice_ask_v1",
+            actions: [
+              { id: "choice-1", label: `use ${secret}` },
+              { id: "choice-2", label: "use plain" },
+            ],
+          }),
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUnique: vi.fn().mockResolvedValue({
+          status: "queued",
+          createdAt: new Date("2026-08-16T12:00:00.000Z"),
+          threadId: "thread-1",
+        }),
+      },
+      task: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      thread: { update: vi.fn().mockResolvedValue({ nextEventSeq: 11 }) },
+      event: {
+        create: vi.fn(async ({ data }: { data: { seq: number; type: string } }) => ({
+          ...event(data.seq),
+          type: data.type,
+        })),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      answerRunInput(
+        prisma,
+        {
+          spaceId: "workspace-1",
+          threadId: "thread-1",
+          runId: "run-1",
+          messageId: "message-1",
+          answeredByUserId: "user-1",
+          answer: "choice-1",
+        },
+        fanout,
+      ),
+    ).resolves.toBe(true);
+
+    expect(tx.task.updateMany).toHaveBeenCalledWith({
+      where: { runs: { some: { id: "run-1" } } },
+      data: { prompt: `Selected choice choice-1: use ${secret}` },
+    });
+    expect(tx.message.update).toHaveBeenCalledWith({
+      where: { id: "message-1" },
+      data: {
+        blocks: [
+          {
+            kind: "ask",
+            text: "Which token?",
+            status: "answered",
+            answer: "choice-1",
+            actions: [
+              { id: "choice-1", label: "use [redacted]" },
+              { id: "choice-2", label: "use plain" },
+            ],
+          },
+        ],
+      },
+    });
+    expect(tx.run.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { status: "queued", checkpoint: null },
+      }),
+    );
   });
 
   it("does not queue a run for a choice the card did not offer", async () => {

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -416,6 +416,50 @@ describe("answerRunInput", () => {
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 9 }));
   });
 
+  it("does not queue a run for a choice the card did not offer", async () => {
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      message: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "message-1",
+          blocks: [
+            {
+              kind: "ask",
+              text: "Which city?",
+              status: "pending",
+              actions: [
+                { id: "Berlin", label: "Berlin" },
+                { id: "Seoul", label: "Seoul" },
+              ],
+            },
+          ],
+        }),
+      },
+      run: {
+        findFirst: vi.fn().mockResolvedValue({ botId: "bot-2", userId: "user-1" }),
+        updateMany: vi.fn(),
+      },
+      task: { updateMany: vi.fn() },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      answerRunInput(prisma, {
+        spaceId: "workspace-1",
+        threadId: "thread-1",
+        runId: "run-1",
+        messageId: "message-1",
+        answeredByUserId: "user-1",
+        answer: "Toronto",
+      }),
+    ).resolves.toBe(false);
+
+    expect(tx.run.updateMany).not.toHaveBeenCalled();
+    expect(tx.task.updateMany).not.toHaveBeenCalled();
+  });
+
   it("approves consequential actions without overwriting the task prompt", async () => {
     const fanout = new TestFanout();
     const tx = {

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -431,7 +431,7 @@ describe("answerRunInput", () => {
     });
     expect(tx.task.updateMany).toHaveBeenCalledWith({
       where: { runs: { some: { id: "run-1" } } },
-      data: { prompt: "Paris" },
+      data: { prompt: "Selected choice choice-2: Paris" },
     });
     expect(tx.event.create).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -354,7 +354,17 @@ describe("answerRunInput", () => {
       message: {
         findFirst: vi.fn().mockResolvedValue({
           id: "message-1",
-          blocks: [{ kind: "ask", text: "Which city?", status: "pending" }],
+          blocks: [
+            {
+              kind: "ask",
+              text: "Which city?",
+              status: "pending",
+              actions: [
+                { id: "choice-1", label: "Berlin" },
+                { id: "choice-2", label: "Paris" },
+              ],
+            },
+          ],
         }),
         update: vi.fn().mockResolvedValue({ id: "message-1" }),
       },
@@ -390,7 +400,7 @@ describe("answerRunInput", () => {
           runId: "run-1",
           messageId: "message-1",
           answeredByUserId: "user-1",
-          answer: "Paris",
+          answer: "choice-2",
         },
         fanout,
       ),
@@ -405,8 +415,23 @@ describe("answerRunInput", () => {
     expect(tx.message.update).toHaveBeenCalledWith({
       where: { id: "message-1" },
       data: {
-        blocks: [{ kind: "ask", text: "Which city?", status: "answered", answer: "Paris" }],
+        blocks: [
+          {
+            kind: "ask",
+            text: "Which city?",
+            status: "answered",
+            answer: "choice-2",
+            actions: [
+              { id: "choice-1", label: "Berlin" },
+              { id: "choice-2", label: "Paris" },
+            ],
+          },
+        ],
       },
+    });
+    expect(tx.task.updateMany).toHaveBeenCalledWith({
+      where: { runs: { some: { id: "run-1" } } },
+      data: { prompt: "Paris" },
     });
     expect(tx.event.create).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -414,7 +414,10 @@ export async function answerRunInput(
     const approvalAsk = isApprovalAskBlock(pendingAsk);
     const secretAsk = isSecretAskBlock(pendingAsk);
     const choiceAsk = !approvalAsk && !secretAsk && Boolean(pendingAsk.actions?.length);
-    if (choiceAsk && !pendingAsk.actions?.some((action) => action.id === input.answer)) return null;
+    const selectedChoice = choiceAsk
+      ? pendingAsk.actions?.find((action) => action.id === input.answer)
+      : undefined;
+    if (choiceAsk && !selectedChoice) return null;
     if (secretAsk && !runSecretWriter) return null;
     let approvalEffect: { id: string; kind: string } | null = null;
     let approvalUserId: string | null = null;
@@ -494,7 +497,7 @@ export async function answerRunInput(
     } else {
       const task = await tx.task.updateMany({
         where: { runs: { some: { id: input.runId } } },
-        data: { prompt: input.answer },
+        data: { prompt: selectedChoice?.label ?? input.answer },
       });
       if (task.count !== 1) throw new Error("Run task was not available to answer");
     }

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -91,6 +91,39 @@ export interface PauseRunForInput {
   leaseOwner: string;
   leaseFence: number;
   blocks: MessageBlock[];
+  /**
+   * Unredacted choice actions for resume. Persisted only on the run checkpoint
+   * (not in message blocks) so clients still see redacted labels.
+   */
+  offeredActions?: Array<{ id: string; label: string }>;
+}
+
+const CHOICE_ASK_CHECKPOINT_KIND = "choice_ask_v1";
+
+function choiceAskCheckpoint(actions: Array<{ id: string; label: string }>): string {
+  return JSON.stringify({ kind: CHOICE_ASK_CHECKPOINT_KIND, actions });
+}
+
+function resumeChoiceLabel(
+  selected: { id: string; label: string },
+  checkpoint: string | null | undefined,
+): string {
+  if (!checkpoint) return selected.label;
+  try {
+    const parsed = JSON.parse(checkpoint) as {
+      kind?: string;
+      actions?: Array<{ id?: unknown; label?: unknown }>;
+    };
+    if (parsed.kind !== CHOICE_ASK_CHECKPOINT_KIND || !Array.isArray(parsed.actions)) {
+      return selected.label;
+    }
+    const offered = parsed.actions.find((action) => action.id === selected.id);
+    return typeof offered?.label === "string" && offered.label.length > 0
+      ? offered.label
+      : selected.label;
+  } catch {
+    return selected.label;
+  }
 }
 
 export interface PauseRunForTakeover {
@@ -394,7 +427,7 @@ export async function answerRunInput(
         threadId: input.threadId,
         status: "waiting_input",
       },
-      select: { botId: true, userId: true },
+      select: { botId: true, userId: true, checkpoint: true },
     });
     if (!run) return null;
     const message = await tx.message.findFirst({
@@ -446,7 +479,10 @@ export async function answerRunInput(
         threadId: input.threadId,
         status: "waiting_input",
       },
-      data: { status: "queued" },
+      data: {
+        status: "queued",
+        ...(choiceAsk ? { checkpoint: null } : {}),
+      },
     });
     if (queued.count !== 1) return null;
 
@@ -495,11 +531,14 @@ export async function answerRunInput(
         data: { status: "approved" },
       });
     } else {
+      const resumeLabel = selectedChoice
+        ? resumeChoiceLabel(selectedChoice, run.checkpoint)
+        : undefined;
       const task = await tx.task.updateMany({
         where: { runs: { some: { id: input.runId } } },
         data: {
           prompt: selectedChoice
-            ? `Selected choice ${selectedChoice.id}: ${selectedChoice.label}`
+            ? `Selected choice ${selectedChoice.id}: ${resumeLabel}`
             : input.answer,
         },
       });
@@ -551,7 +590,14 @@ export async function pauseRunForInput(
         leaseOwner: input.leaseOwner,
         leaseFence: input.leaseFence,
       },
-      data: { status: "waiting_input", leaseOwner: null, leaseExpiresAt: null },
+      data: {
+        status: "waiting_input",
+        leaseOwner: null,
+        leaseExpiresAt: null,
+        ...(input.offeredActions?.length
+          ? { checkpoint: choiceAskCheckpoint(input.offeredActions) }
+          : {}),
+      },
     });
     if (paused.count !== 1) return null;
 

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -497,7 +497,11 @@ export async function answerRunInput(
     } else {
       const task = await tx.task.updateMany({
         where: { runs: { some: { id: input.runId } } },
-        data: { prompt: selectedChoice?.label ?? input.answer },
+        data: {
+          prompt: selectedChoice
+            ? `Selected choice ${selectedChoice.id}: ${selectedChoice.label}`
+            : input.answer,
+        },
       });
       if (task.count !== 1) throw new Error("Run task was not available to answer");
     }

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -413,6 +413,8 @@ export async function answerRunInput(
     if (pendingAsk?.kind !== "ask") return null;
     const approvalAsk = isApprovalAskBlock(pendingAsk);
     const secretAsk = isSecretAskBlock(pendingAsk);
+    const choiceAsk = !approvalAsk && !secretAsk && Boolean(pendingAsk.actions?.length);
+    if (choiceAsk && !pendingAsk.actions?.some((action) => action.id === input.answer)) return null;
     if (secretAsk && !runSecretWriter) return null;
     let approvalEffect: { id: string; kind: string } | null = null;
     let approvalUserId: string | null = null;


### PR DESCRIPTION
## Problem

Bots can pause for free-text or protected input, but they cannot present a short set of tappable choices in a normal chat turn.

Closes #402

## Approach

- add a provider-neutral `ask_user` tool for two to four concise options
- carry choice actions through runtime ask events and persist them on the existing ask block
- pause the run without emitting the empty-turn fallback, then resume from the selected option
- render non-approval ask actions as tappable buttons on web/Electron and Expo mobile
- reject answers that were not offered by the choice card
- redact option IDs and labels before persistence alongside the existing ask text/detail redaction

## Tests

- RED: `pi-runtime-choice.test.ts` initially emitted only the tool event and empty-turn fallback instead of a choice ask
- GREEN: final focused set passes: 5 files / 47 tests
- `pnpm --filter @rakazo/adapters test` — 844 passed, 7 skipped
- `pnpm --filter @rakazo/mobile test` — 129 passed
- `pnpm run lint` — passed (2 pre-existing informational surrogate-key suggestions)
- `pnpm run build` — passed
- `pnpm run test` — 2,042 passed, 103 skipped, 1 pre-existing failure in `apps/web/src/lib/i18n-catalog.test.ts`; the same isolated test fails in the pre-existing checkout
- affected package typechecks pass; the full `pnpm run check` reaches the existing `packages/db/src/events.test.ts` `workspaceId` error, which also fails the current `origin/main` Typecheck check

## Risk

The new tool reuses the existing waiting-input transaction and ask-card resume path. Option counts and lengths are bounded by the tool schema, persisted choices are redacted, and the server accepts only an offered action ID.

## Exclusions

- no changes to onboarding's separate `choice` block
- no multi-select or free-form fallback inside the choice card
- no schema migration or dependency change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multiple-choice questions with two to four selectable options.
  - Choice options now appear as tappable actions on mobile and web.
  - Selected options display their user-facing labels after answering.

- **Bug Fixes**
  - Improved routing and display for action-based questions.
  - Invalid, duplicate, or unavailable choices are rejected safely.
  - Approval-specific labels and styling no longer affect regular choice questions.
  - Choice questions now enforce supported option and question length limits.
  - Choice selections now resume reliably with the correct option label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->