### PR TITLE
fix(web): anchor routine toggle thumb

### DIFF
--- a/apps/web/e2e/routine-crud.spec.ts
+++ b/apps/web/e2e/routine-crud.spec.ts
@@ -18,6 +18,48 @@ async function saveAndReturn(page: Page, procedure: "routines/create" | "routine
   await page.getByRole("button", { name: "Back" }).click();
 }
 
+test("routine active switch keeps its thumb inside the track", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `routine-toggle-${stamp}@rakazo.test`, "password12", "Routine Toggle");
+  await completeOnboarding(page);
+  await page.getByTitle("Agent computer").click();
+  await page.getByRole("button", { name: "New routine" }).click();
+
+  const toggle = page.getByRole("switch", { name: "Active" });
+  const thumb = toggle.locator("span");
+  async function expectThumbInsets(left: number, right: number) {
+    await thumb.evaluate((element) =>
+      Promise.all(element.getAnimations().map(({ finished }) => finished)),
+    );
+    const [trackBox, thumbBox] = await Promise.all([toggle.boundingBox(), thumb.boundingBox()]);
+    expect(trackBox).not.toBeNull();
+    expect(thumbBox).not.toBeNull();
+    expect(thumbBox!.x - trackBox!.x).toBeCloseTo(left, 1);
+    expect(trackBox!.x + trackBox!.width - thumbBox!.x - thumbBox!.width).toBeCloseTo(right, 1);
+  }
+
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+  await expectThumbInsets(20, 2);
+  await captureScreenshot(page, testInfo, "routine-toggle-desktop-active");
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+  await expectThumbInsets(2, 20);
+  await captureScreenshot(page, testInfo, "routine-toggle-desktop-inactive");
+
+  await toggle.focus();
+  await page.keyboard.press("Space");
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+  expect(await toggle.evaluate((element) => getComputedStyle(element).outlineStyle)).not.toBe(
+    "none",
+  );
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expectThumbInsets(20, 2);
+  await captureScreenshot(page, testInfo, "routine-toggle-mobile-active");
+  await toggle.click();
+  await expectThumbInsets(2, 20);
+  await captureScreenshot(page, testInfo, "routine-toggle-mobile-inactive");
+});
+
 test("routine editing updates in place, preserves timezone, and deletion persists", async ({
   page,
 }, testInfo) => {

--- a/apps/web/src/pages/RoutineEditor.tsx
+++ b/apps/web/src/pages/RoutineEditor.tsx
@@ -263,7 +263,7 @@ export function RoutineEditor({
             }`}
           >
             <span
-              className={`absolute top-[2px] h-[18px] w-[18px] rounded-full bg-white transition-transform ${
+              className={`absolute top-[2px] left-0 h-[18px] w-[18px] rounded-full bg-white transition-transform ${
                 draft.active ? "translate-x-[20px]" : "translate-x-[2px]"
               }`}
             />


### PR DESCRIPTION
## Summary

- anchor the routine editor switch thumb to the track before applying its existing transforms
- keep the existing 40×22 track, 18×18 thumb, colors, 2px inset, and native button semantics
- add a Playwright geometry regression covering active/inactive states at desktop and 390px viewports

## Root cause

The absolutely positioned thumb had vertical positioning but no horizontal anchor. Its static-position origin shifted before `translate-x-[2px]` / `translate-x-[20px]` was applied, putting the active thumb outside the 40px track.

## Verification

- regression test fails before the fix: active left offset measured 40px instead of 20px
- `pnpm test:e2e -- --sandbox=fake --spec=e2e/routine-crud.spec.ts` (5 passed)
- `pnpm run test` (2,065 passed; 103 skipped)
- `pnpm run lint`
- `pnpm run check`
- `pnpm run build`
- `pnpm run format`

The new E2E test captures active and inactive states at desktop and 390×844.

### CI screenshots

- [Gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/434/index.html)
- Desktop: [active](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33411647074-1/screenshots/images/102-routine-toggle-desktop-active.png) · [inactive](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33411647074-1/screenshots/images/103-routine-toggle-desktop-inactive.png)
- 390×844: [active](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33411647074-1/screenshots/images/104-routine-toggle-mobile-active.png) · [inactive](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33411647074-1/screenshots/images/105-routine-toggle-mobile-inactive.png)

## Risk

Low. This is a one-class positioning fix on the existing switch; no component, dependency, behavior, color, or API changes.
