### PR TITLE
fix(adapters): keep computers awake for background work

### DIFF
--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -1,7 +1,15 @@
+import { spawn } from "node:child_process";
+import { unlinkSync } from "node:fs";
 import type { AgentHomeStore, JobPublisher, SandboxProvider } from "@rakazo/adapter-kit";
 import type { PrismaClient, ThreadEvents } from "@rakazo/db";
-import { describe, expect, it, vi } from "vitest";
-import { DEFAULT_SANDBOX_IDLE_MS, sandboxIdleMs, sleepComputerIfIdle } from "./computer-idle.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BACKGROUND_WORK_LAUNCH,
+  BACKGROUND_WORK_PROBE,
+  DEFAULT_SANDBOX_IDLE_MS,
+  sandboxIdleMs,
+  sleepComputerIfIdle,
+} from "./computer-idle.js";
 import {
   e2bCreateOptions,
   isUnreachableTransportError,
@@ -43,6 +51,21 @@ describe("sandbox idle", () => {
     expect(harness.sandbox.stop).not.toHaveBeenCalled();
     expect(harness.sandbox.keepAlive).toHaveBeenCalledOnce();
     expect(harness.jobs.enqueue).toHaveBeenCalledOnce();
+  });
+
+  it("probes background work with the database computer id, not providerRef", async () => {
+    const harness = idleHarness({ backgroundWorkProbeCode: 0 });
+
+    await sleepComputerIfIdle(harness.deps, harness.computer.id);
+
+    expect(harness.sandbox.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ id: harness.computer.providerRef }),
+      expect.objectContaining({
+        argv: ["bash", "-c", BACKGROUND_WORK_PROBE, "rakazo-background-probe", harness.computer.id],
+      }),
+      expect.anything(),
+    );
+    expect(harness.computer.id).not.toBe(harness.computer.providerRef);
   });
 
   it("fails closed when the provider cannot inspect background work", async () => {
@@ -124,6 +147,46 @@ describe("sandbox idle", () => {
     expect(harness.sandbox.stop).not.toHaveBeenCalled();
     expect(harness.prisma.computer.update).not.toHaveBeenCalled();
   });
+});
+
+describe("background work launch and probe", () => {
+  const children: ReturnType<typeof spawn>[] = [];
+  const markers = new Set<string>();
+
+  afterEach(() => {
+    for (const child of children.splice(0)) {
+      child.kill("SIGKILL");
+    }
+    for (const marker of markers) {
+      try {
+        unlinkSync(marker);
+      } catch {
+        // Marker may already be cleaned by an idle probe.
+      }
+    }
+    markers.clear();
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "detects active work only when launch and probe share the same marker id",
+    async () => {
+      const databaseId = "computer-db-id";
+      const providerRef = "provider-ref";
+      markers.add(`/tmp/rakazo-background-${databaseId}`);
+      markers.add(`/tmp/rakazo-background-${providerRef}`);
+
+      const launched = spawn(
+        "bash",
+        ["-c", BACKGROUND_WORK_LAUNCH, "rakazo-background-launch", databaseId, "sleep 30"],
+        { stdio: "ignore" },
+      );
+      children.push(launched);
+
+      await expect.poll(() => probeBackgroundWork(databaseId)).toBe(0);
+      // ComputerRef.id is providerRef today; probing that path must not see the DB-id marker.
+      expect(await probeBackgroundWork(providerRef)).toBe(1);
+    },
+  );
 });
 
 describe("e2b create options", () => {
@@ -267,4 +330,16 @@ function idleHarness(
       events: events as unknown as ThreadEvents,
     },
   };
+}
+
+function probeBackgroundWork(markerId: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "bash",
+      ["-c", BACKGROUND_WORK_PROBE, "rakazo-background-probe", markerId],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? 1));
+  });
 }

--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -34,6 +34,37 @@ describe("sandbox idle", () => {
     expect(harness.jobs.enqueue).toHaveBeenCalledOnce();
   });
 
+  it("does not suspend a computer while bot-launched background work is active", async () => {
+    const harness = idleHarness({ backgroundWorkProbeCode: 0 });
+
+    await sleepComputerIfIdle(harness.deps, harness.computer.id);
+
+    expect(harness.home.commit).not.toHaveBeenCalled();
+    expect(harness.sandbox.stop).not.toHaveBeenCalled();
+    expect(harness.sandbox.keepAlive).toHaveBeenCalledOnce();
+    expect(harness.jobs.enqueue).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when the provider cannot inspect background work", async () => {
+    const harness = idleHarness({ backgroundWorkProbeCode: 2 });
+
+    await sleepComputerIfIdle(harness.deps, harness.computer.id);
+
+    expect(harness.sandbox.stop).not.toHaveBeenCalled();
+    expect(harness.sandbox.keepAlive).toHaveBeenCalledOnce();
+    expect(harness.jobs.enqueue).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when the provider reports a command failure as exit one", async () => {
+    const harness = idleHarness({ backgroundWorkProbeFailed: true });
+
+    await sleepComputerIfIdle(harness.deps, harness.computer.id);
+
+    expect(harness.sandbox.stop).not.toHaveBeenCalled();
+    expect(harness.sandbox.keepAlive).toHaveBeenCalledOnce();
+    expect(harness.jobs.enqueue).toHaveBeenCalledOnce();
+  });
+
   it("does not let an abandoned waiting takeover prevent idle suspension", async () => {
     const harness = idleHarness();
     harness.prisma.run.findFirst.mockImplementation(async ({ where }) =>
@@ -158,7 +189,13 @@ describe("e2b create options", () => {
   });
 });
 
-function idleHarness(options: { exportError?: Error } = {}) {
+function idleHarness(
+  options: {
+    backgroundWorkProbeCode?: number;
+    backgroundWorkProbeFailed?: boolean;
+    exportError?: Error;
+  } = {},
+) {
   const computer = {
     id: "computer-id",
     homeKey: "team-workspace",
@@ -192,6 +229,14 @@ function idleHarness(options: { exportError?: Error } = {}) {
     },
   };
   const sandbox = {
+    execute: vi.fn(async function* () {
+      const code = options.backgroundWorkProbeCode ?? 1;
+      if (code === 1 && !options.backgroundWorkProbeFailed) {
+        yield { type: "stdout", data: "rakazo-background-idle\n" } as const;
+      }
+      yield { type: "exit", code } as const;
+    }),
+    keepAlive: vi.fn().mockResolvedValue(undefined),
     exportWorkspace: vi.fn(async function* () {
       if (options.exportError) throw options.exportError;
       yield { path: "notes/result.txt", content: new TextEncoder().encode("durable") };

--- a/packages/adapters/src/computer-idle.ts
+++ b/packages/adapters/src/computer-idle.ts
@@ -21,7 +21,7 @@ export const BACKGROUND_WORK_LAUNCH = [
   'exec bash -lc "$2"',
 ].join("\n");
 
-const BACKGROUND_WORK_PROBE = [
+export const BACKGROUND_WORK_PROBE = [
   `marker="${BACKGROUND_WORK_MARKER_PREFIX}$1"`,
   `idle() { printf '${BACKGROUND_WORK_IDLE_SENTINEL}\\n'; exit 1; }`,
   '[ -e "$marker" ] || idle',

--- a/packages/adapters/src/computer-idle.ts
+++ b/packages/adapters/src/computer-idle.ts
@@ -1,4 +1,5 @@
 import {
+  type AdapterContext,
   type AgentHomeStore,
   computerSleepJob,
   type JobPublisher,
@@ -11,6 +12,35 @@ import { toComputerRef } from "./computer-lifecycle.js";
 import { checkpointComputerWorkspace } from "./computer-workspace.js";
 
 export const DEFAULT_SANDBOX_IDLE_MS = 10 * 60 * 1000;
+const BACKGROUND_WORK_MARKER_PREFIX = "/tmp/rakazo-background-";
+const BACKGROUND_WORK_IDLE_SENTINEL = "rakazo-background-idle";
+
+export const BACKGROUND_WORK_LAUNCH = [
+  `marker="${BACKGROUND_WORK_MARKER_PREFIX}$1"`,
+  'exec 9>>"$marker"',
+  'exec bash -lc "$2"',
+].join("\n");
+
+const BACKGROUND_WORK_PROBE = [
+  `marker="${BACKGROUND_WORK_MARKER_PREFIX}$1"`,
+  `idle() { printf '${BACKGROUND_WORK_IDLE_SENTINEL}\\n'; exit 1; }`,
+  '[ -e "$marker" ] || idle',
+  "if [ -d /proc ]; then",
+  "  command -v readlink >/dev/null 2>&1 || exit 2",
+  "  for fd in /proc/[0-9]*/fd/*; do",
+  '    [ "$(readlink "$fd" 2>/dev/null)" = "$marker" ] && exit 0',
+  "  done",
+  '  rm -f -- "$marker"',
+  "  idle",
+  "fi",
+  'if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then',
+  "  command -v lsof >/dev/null 2>&1 || exit 2",
+  '  lsof -t -- "$marker" >/dev/null 2>&1 && exit 0',
+  '  rm -f -- "$marker"',
+  "  idle",
+  "fi",
+  "exit 2",
+].join("\n");
 
 export function sandboxIdleMs(): number {
   const raw = Number(process.env.SANDBOX_IDLE_MS ?? DEFAULT_SANDBOX_IDLE_MS);
@@ -57,7 +87,8 @@ export async function sleepComputerIfIdle(
     return;
   }
 
-  const ctx = {
+  const ref = toComputerRef(computer);
+  const ctx: AdapterContext = {
     operationId: "computer.sleep",
     traceId: "computer.sleep",
     spaceId: computer.spaceId,
@@ -65,7 +96,12 @@ export async function sleepComputerIfIdle(
     botId: computer.controlBotId ?? undefined,
     signal: new AbortController().signal,
   };
-  const ref = toComputerRef(computer);
+  if (await hasActiveBackgroundWork(deps.sandbox, ref, ctx, computerId)) {
+    scheduleComputerSleep(deps.jobs, computerId);
+    await deps.sandbox.keepAlive?.(ref);
+    return;
+  }
+
   const revision = await checkpointComputerWorkspace(
     deps.home,
     deps.sandbox,
@@ -182,4 +218,31 @@ function findActiveRun(prisma: PrismaClient, computerId: string, statuses: reado
     },
     select: { id: true },
   });
+}
+
+async function hasActiveBackgroundWork(
+  sandbox: SandboxProvider,
+  computer: ReturnType<typeof toComputerRef>,
+  context: AdapterContext,
+  computerId: string,
+): Promise<boolean> {
+  let exitCode: number | undefined;
+  let stdout = "";
+  try {
+    for await (const event of sandbox.execute(
+      computer,
+      {
+        argv: ["bash", "-c", BACKGROUND_WORK_PROBE, "rakazo-background-probe", computerId],
+        timeoutMs: 10_000,
+      },
+      context,
+    )) {
+      if (event.type === "stdout") stdout += event.data;
+      if (event.type === "exit") exitCode = event.code;
+    }
+  } catch {
+    return true;
+  }
+  // Only the probe's explicit idle result permits suspension; unsupported or failed probes retry.
+  return exitCode !== 1 || stdout.trim() !== BACKGROUND_WORK_IDLE_SENTINEL;
 }

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -113,7 +113,7 @@ import {
   type PluginConnectionRow,
   planLiveConnectionSync,
 } from "./composio-connector.js";
-import { scheduleComputerSleep } from "./computer-idle.js";
+import { BACKGROUND_WORK_LAUNCH, scheduleComputerSleep } from "./computer-idle.js";
 import {
   acquireComputerExecutionLease,
   ComputerBusyError,
@@ -1690,7 +1690,14 @@ export function createRunExecutor(deps: ExecutorDeps) {
             const result = await runSandboxCommand(
               deps.sandbox,
               computer,
-              ["bash", "-lc", command],
+              [
+                "bash",
+                "-c",
+                BACKGROUND_WORK_LAUNCH,
+                "rakazo-background-launch",
+                computer.id,
+                command,
+              ],
               cwd,
               context,
             );

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1695,7 +1695,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 "-c",
                 BACKGROUND_WORK_LAUNCH,
                 "rakazo-background-launch",
-                computer.id,
+                // Marker id must match sleepComputerIfIdle's probe (DB id), not ComputerRef.id
+                // (providerRef via toComputerRef).
+                storedComputer.id,
                 command,
               ],
               cwd,


### PR DESCRIPTION
## Summary

- tag each bot shell command tree with an inherited marker file descriptor
- check that marker before idle checkpoint/suspension on Linux and macOS
- reschedule sleep and refresh the provider timeout while background work is active
- fail closed when the provider cannot inspect background work
- preserve the existing graphical computer lifecycle-command guard unchanged

## Regression coverage

- proves active bot-launched background work prevents checkpoint/stop and reschedules idle sleep
- proves unsupported process inspection also reschedules rather than risking data loss
- preserves the existing genuinely-idle checkpoint-and-stop coverage
- exercises the real launch/probe boundary and proves launch uses the same database computer id as idle probing
- confirmed the new regression fails against the pre-fix behavior

## Verification

- `pnpm exec vitest run packages/adapters/src/computer-idle.test.ts --maxWorkers=5`
- `pnpm --filter @rakazo/adapters check`
- `pnpm run test -- --maxWorkers=5`
- `pnpm run lint`
- `pnpm run check`
- `pnpm run build`
- `pnpm run format`
- `git diff --check`
- live inherited-FD probe smoke on macOS: active `0`, idle `1`
- live inherited-FD probe smoke in `rakazo/computer:local` Linux image: active `0`, idle `1`

## Scope and residual risk

This intentionally does not change the shell lifecycle safety guard or claim to repair recovery after a previously interrupted suspension. Descendants that explicitly close inherited non-standard file descriptors cannot be observed by this mechanism; unsupported inspection fails closed and keeps the computer running.
