### PR TITLE
Improve mobile authentication flow

### DIFF
--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -74,9 +74,6 @@ export default function SignIn() {
         <Text style={{ color: "#1B1B1E", fontSize: 32, fontWeight: "500", textAlign: "center" }}>
           Sign in to Rakazo
         </Text>
-        <Text style={{ color: "#6E6E68", marginTop: 8, textAlign: "center" }}>
-          Same Better Auth session as the web app.
-        </Text>
         <TextInput
           autoCapitalize="none"
           keyboardType="email-address"


### PR DESCRIPTION
## Summary

- remove the Better Auth implementation detail from the mobile sign-in screen
- label the primary action clearly as **Sign in** and add native email/password sign-up
- keep authentication actions reachable with keyboard avoidance and scrolling
- dismiss the keyboard by tapping outside the inputs or dragging the form
- document the native-only screenshot exception in `AGENTS.md`

## Validation

- `pnpm --filter @rakazo/mobile check`
- `pnpm exec biome check apps/mobile/app/sign-in.tsx apps/mobile/lib/api.ts apps/mobile/lib/api.test.ts apps/mobile/lib/android-platform-contract.test.ts`
- `pnpm --filter @rakazo/mobile test` (132 tests)
- `pnpm lint`
- parsed `apps/mobile/.maestro/smoke.yaml` successfully

The opt-in Maestro flow opens this screen and now dismisses the keyboard with an outside tap before submitting. It was not run locally because no simulator was booted.

## Screenshot

This is a native Expo-only screen; the repository’s CI Playwright gallery exercises the web app and cannot capture this route. Per the updated repository guidance, no unrelated web screenshot is linked.