### PR TITLE
fix: suppress roster attention for silent routines

### DIFF
--- a/packages/adapters/src/executor-completion.test.ts
+++ b/packages/adapters/src/executor-completion.test.ts
@@ -78,15 +78,13 @@ describe("completionMarksUnread", () => {
     expect(completionMarksUnread("user", "")).toBe(true);
   });
 
-  it("keeps the empty-run done. fallback visible without routine attention", () => {
-    const originalSegments: never[] = [];
-    const unreadText = completionNotificationBody("", originalSegments).trim();
-    const segments = completionMessageSegments(originalSegments);
+  it("keeps empty-run done. fallback unread and notifying", () => {
+    const segments = completionMessageSegments([]);
     const text = completionNotificationBody("", segments);
     expect(segments).toEqual([{ kind: "text", text: "done." }]);
     expect(text).toBe("done.");
-    expect(completionMarksUnread("routine", unreadText)).toBe(false);
-    expect(completionMarksUnread("user", unreadText)).toBe(true);
+    expect(completionMarksUnread("routine", text)).toBe(true);
+    expect(completionMarksUnread("user", text)).toBe(true);
   });
 
   it("does not invent done. unread for a routine whose only activity is a completed subagent", () => {

--- a/packages/adapters/src/executor-completion.test.ts
+++ b/packages/adapters/src/executor-completion.test.ts
@@ -78,13 +78,15 @@ describe("completionMarksUnread", () => {
     expect(completionMarksUnread("user", "")).toBe(true);
   });
 
-  it("keeps empty-run done. fallback unread and notifying", () => {
-    const segments = completionMessageSegments([]);
+  it("keeps the empty-run done. fallback visible without routine attention", () => {
+    const originalSegments: never[] = [];
+    const unreadText = completionNotificationBody("", originalSegments).trim();
+    const segments = completionMessageSegments(originalSegments);
     const text = completionNotificationBody("", segments);
     expect(segments).toEqual([{ kind: "text", text: "done." }]);
     expect(text).toBe("done.");
-    expect(completionMarksUnread("routine", text)).toBe(true);
-    expect(completionMarksUnread("user", text)).toBe(true);
+    expect(completionMarksUnread("routine", unreadText)).toBe(false);
+    expect(completionMarksUnread("user", unreadText)).toBe(true);
   });
 
   it("does not invent done. unread for a routine whose only activity is a completed subagent", () => {

--- a/packages/adapters/src/executor-completion.test.ts
+++ b/packages/adapters/src/executor-completion.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { completionMessageSegments, completionNotificationBody } from "./executor.js";
+import {
+  completionMarksUnread,
+  completionMessageSegments,
+  completionNotificationBody,
+  subagentMarksUnread,
+} from "./executor.js";
 
 describe("completionMessageSegments", () => {
   it("keeps visible tool activity without appending a generic completion claim", () => {
@@ -63,5 +68,21 @@ describe("completionNotificationBody", () => {
 
   it("uses the empty-run text when that is all the run produced", () => {
     expect(completionNotificationBody("", completionMessageSegments([]))).toBe("done.");
+  });
+});
+
+describe("completionMarksUnread", () => {
+  it("ignores silent routine activity but keeps routine comments and manual replies unread", () => {
+    expect(completionMarksUnread("routine", "")).toBe(false);
+    expect(completionMarksUnread("routine", "Daily report ready")).toBe(true);
+    expect(completionMarksUnread("user", "")).toBe(true);
+  });
+});
+
+describe("subagentMarksUnread", () => {
+  it("ignores completed routine activity but preserves failures and manual activity", () => {
+    expect(subagentMarksUnread("routine", "completed")).toBe(false);
+    expect(subagentMarksUnread("routine", "failed")).toBe(true);
+    expect(subagentMarksUnread("user", "completed")).toBe(true);
   });
 });

--- a/packages/adapters/src/executor-completion.test.ts
+++ b/packages/adapters/src/executor-completion.test.ts
@@ -77,6 +77,26 @@ describe("completionMarksUnread", () => {
     expect(completionMarksUnread("routine", "Daily report ready")).toBe(true);
     expect(completionMarksUnread("user", "")).toBe(true);
   });
+
+  it("keeps empty-run done. fallback unread and notifying", () => {
+    const segments = completionMessageSegments([]);
+    const text = completionNotificationBody("", segments);
+    expect(segments).toEqual([{ kind: "text", text: "done." }]);
+    expect(text).toBe("done.");
+    expect(completionMarksUnread("routine", text)).toBe(true);
+    expect(completionMarksUnread("user", text)).toBe(true);
+  });
+
+  it("does not invent done. unread for a routine whose only activity is a completed subagent", () => {
+    // Terminal subagent rows are published separately; skipEmptyFallback mirrors that durable
+    // activity so completion does not synthesize "done." (which would mark unread + notify).
+    const segments = completionMessageSegments([], { skipEmptyFallback: true });
+    const text = completionNotificationBody("", segments);
+    expect(segments).toEqual([]);
+    expect(text).toBe("");
+    expect(completionMarksUnread("routine", text)).toBe(false);
+    expect(completionMarksUnread("user", text)).toBe(true);
+  });
 });
 
 describe("subagentMarksUnread", () => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1080,6 +1080,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
         let assembled = "";
         let currentTextSegment = "";
         let messageSegments: MessageBlock[] = [];
+        // Terminal subagent rows are published as their own messages (not appended to
+        // messageSegments). Treat that like tool/step durable activity so we do not invent
+        // an empty-run "done." completion afterward.
+        let publishedTerminalSubagent = false;
         // Tool calls that land mid-sentence wait here until the narration catches up to a
         // sentence boundary, so the step chips never render in the middle of a clause.
         let pendingToolNames: string[] = [];
@@ -2754,6 +2758,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 },
               });
               if (event.status === "completed" || event.status === "failed") {
+                publishedTerminalSubagent = true;
                 await publishMessage(
                   deps,
                   run,
@@ -2841,6 +2846,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               allowSilentEmpty: allowSilentPeerMessage || phoneChannelRun,
               emptyResponseText,
               suppressOutput: handedOff,
+              skipEmptyFallback: publishedTerminalSubagent,
             });
           }
           const blocks = handedOff ? [] : redactBlocks(messageSegments, runSecrets);
@@ -3121,7 +3127,12 @@ export function threadContextForRun<T>(
 
 export function completionMessageSegments(
   segments: MessageBlock[],
-  options?: { allowSilentEmpty?: boolean; emptyResponseText?: string; suppressOutput?: boolean },
+  options?: {
+    allowSilentEmpty?: boolean;
+    emptyResponseText?: string;
+    suppressOutput?: boolean;
+    skipEmptyFallback?: boolean;
+  },
 ): MessageBlock[] {
   if (options?.suppressOutput) return [];
   const fallback = options?.emptyResponseText?.trim() || "done.";
@@ -3135,7 +3146,7 @@ export function completionMessageSegments(
     }
     return segments;
   }
-  if (options?.allowSilentEmpty) return [];
+  if (options?.allowSilentEmpty || options?.skipEmptyFallback) return [];
   return [{ kind: "text", text: fallback }];
 }
 

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2758,7 +2758,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 },
               });
               if (event.status === "completed" || event.status === "failed") {
-                publishedTerminalSubagent = true;
+                publishedTerminalSubagent ||= !subagentMarksUnread(run.trigger, event.status);
                 await publishMessage(
                   deps,
                   run,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2841,9 +2841,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
           terminalCheckpointComplete = true;
 
           flushPendingTools();
-          const unreadText = handedOff
-            ? ""
-            : completionNotificationBody(assembled, messageSegments).trim();
           if (!assembled) {
             messageSegments = completionMessageSegments(messageSegments, {
               allowSilentEmpty: allowSilentPeerMessage || phoneChannelRun,
@@ -2871,7 +2868,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             leaseFence: fence,
             outcome: "completed",
             blocks,
-            markUnread: completionMarksUnread(run.trigger, unreadText),
+            markUnread: completionMarksUnread(run.trigger, text),
           });
           if (!completed) return;
           if (run.trigger === "bot_message" && text) {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2841,6 +2841,9 @@ export function createRunExecutor(deps: ExecutorDeps) {
           terminalCheckpointComplete = true;
 
           flushPendingTools();
+          const unreadText = handedOff
+            ? ""
+            : completionNotificationBody(assembled, messageSegments).trim();
           if (!assembled) {
             messageSegments = completionMessageSegments(messageSegments, {
               allowSilentEmpty: allowSilentPeerMessage || phoneChannelRun,
@@ -2868,7 +2871,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             leaseFence: fence,
             outcome: "completed",
             blocks,
-            markUnread: completionMarksUnread(run.trigger, text),
+            markUnread: completionMarksUnread(run.trigger, unreadText),
           });
           if (!completed) return;
           if (run.trigger === "bot_message" && text) {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2754,17 +2754,23 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 },
               });
               if (event.status === "completed" || event.status === "failed") {
-                await publishMessage(deps, run, "bot", [
-                  {
-                    kind: "subagent",
-                    agentId: event.agentId,
-                    name: event.name,
-                    task: safeTask,
-                    status: event.status,
-                    progress: safeProgress,
-                    result: safeResult,
-                  },
-                ]);
+                await publishMessage(
+                  deps,
+                  run,
+                  "bot",
+                  [
+                    {
+                      kind: "subagent",
+                      agentId: event.agentId,
+                      name: event.name,
+                      task: safeTask,
+                      status: event.status,
+                      progress: safeProgress,
+                      result: safeResult,
+                    },
+                  ],
+                  subagentMarksUnread(run.trigger, event.status),
+                );
               }
             } else if (event.type === "usage") {
               await deps.prisma.usageRecord.create({
@@ -2856,6 +2862,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             leaseFence: fence,
             outcome: "completed",
             blocks,
+            markUnread: completionMarksUnread(run.trigger, text),
           });
           if (!completed) return;
           if (run.trigger === "bot_message" && text) {
@@ -3141,6 +3148,14 @@ export function completionNotificationBody(assembled: string, blocks: MessageBlo
     .join("");
 }
 
+export function completionMarksUnread(trigger: string, text: string): boolean {
+  return trigger !== "routine" || Boolean(text);
+}
+
+export function subagentMarksUnread(trigger: string, status: "running" | "completed" | "failed") {
+  return status === "failed" || trigger !== "routine";
+}
+
 function computerRunRequeueData(
   resumeCheckpoint: TakeoverResumeCheckpoint | null,
   error: string | null = null,
@@ -3189,9 +3204,10 @@ async function publishMessage(
   run: { id: string; spaceId: string; threadId: string; botId: string },
   role: "user" | "bot" | "system",
   blocks: MessageBlock[],
+  markUnread?: boolean,
 ) {
   const committed = await deps.prisma.$transaction((tx) =>
-    persistMessageInTransaction(tx, run, role, blocks),
+    persistMessageInTransaction(tx, run, role, blocks, markUnread),
   );
   await deps.events.notify(run.threadId, committed.eventSeq).catch((error) => {
     console.error("thread message realtime notification", error);
@@ -3204,6 +3220,7 @@ async function persistMessageInTransaction(
   run: { id: string; spaceId: string; threadId: string; botId: string },
   role: "user" | "bot" | "system",
   blocks: MessageBlock[],
+  markUnread?: boolean,
 ) {
   const message = await createThreadMessageInTransaction(tx, {
     threadId: run.threadId,
@@ -3211,6 +3228,7 @@ async function persistMessageInTransaction(
     blocks,
     botId: run.botId,
     runId: run.id,
+    markUnread,
   });
   const event = await appendEventInTransaction(tx, {
     spaceId: run.spaceId,

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -80,7 +80,10 @@ interface FinalizeRunBase {
 }
 
 export type FinalizeRunInput = FinalizeRunBase &
-  ({ outcome: "completed"; blocks: MessageBlock[] } | { outcome: "failed"; error: string });
+  (
+    | { outcome: "completed"; blocks: MessageBlock[]; markUnread?: boolean }
+    | { outcome: "failed"; error: string }
+  );
 
 export interface PauseRunForInput {
   spaceId: string;
@@ -794,6 +797,7 @@ export async function finalizeRun(
         blocks: input.blocks,
         botId: input.botId,
         runId: input.runId,
+        markUnread: input.markUnread,
       });
       await appendEventInTransaction(tx, {
         spaceId: input.spaceId,

--- a/packages/db/src/messages.test.ts
+++ b/packages/db/src/messages.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Prisma } from "./client.js";
+import { createThreadMessageInTransaction } from "./messages.js";
+
+function transaction() {
+  return {
+    thread: { update: vi.fn().mockResolvedValue({ nextMessageSeq: 1 }) },
+    run: { findUnique: vi.fn().mockResolvedValue({ status: "running" }) },
+    message: { create: vi.fn().mockResolvedValue({ id: "message-1" }) },
+  };
+}
+
+describe("createThreadMessageInTransaction", () => {
+  it("allows an automated bot message to opt out of unread without changing the default", async () => {
+    const silent = transaction();
+    await createThreadMessageInTransaction(silent as unknown as Prisma.TransactionClient, {
+      threadId: "thread-1",
+      role: "bot",
+      blocks: [{ kind: "steps", steps: [{ label: "Checked status", count: 1 }] }],
+      markUnread: false,
+    });
+    expect(silent.thread.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ unread: undefined }) }),
+    );
+
+    const visible = transaction();
+    await createThreadMessageInTransaction(visible as unknown as Prisma.TransactionClient, {
+      threadId: "thread-1",
+      role: "bot",
+      blocks: [{ kind: "text", text: "Daily report ready" }],
+    });
+    expect(visible.thread.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ unread: true }) }),
+    );
+  });
+});

--- a/packages/db/src/messages.ts
+++ b/packages/db/src/messages.ts
@@ -26,7 +26,7 @@ export async function createThreadMessageInTransaction(
     where: { id: input.threadId },
     data: {
       nextMessageSeq: { increment: 1 },
-      unread: input.role === "bot" || input.markUnread ? true : undefined,
+      unread: (input.markUnread ?? input.role === "bot") ? true : undefined,
     },
     select: { nextMessageSeq: true },
   });


### PR DESCRIPTION
## Summary

- keep silent automated routine completions from setting roster unread attention
- retain unread attention when a routine emits a user-visible text comment
- preserve existing unread behavior for manual runs, questions/approvals, and other bot messages

## Root cause

Every persisted bot-role message unconditionally set `Thread.unread`, including routine completions containing only durable tool/step activity and successful subagent status rows. Both web/Electron and mobile roster dots render that shared field, so the UI correctly displayed an attention dot for state that did not contain a user-visible bot comment.

The executor already derives user-facing completion text for notifications. This change reuses that classification for routine completion unread policy and adds an explicit false override to the transactional message writer. False means “do not set unread”; it never clears an already-unread thread.

## Behavior matrix

| Run/output | Roster attention |
| --- | --- |
| Automated routine, tool/step activity only | Not newly marked unread |
| Automated routine, successful subagent activity only | Not newly marked unread |
| Automated routine, visible bot text comment | Marked unread |
| Automated routine, failed subagent | Marked unread |
| Manual/user-triggered bot completion | Existing unread behavior preserved |
| Question/approval message | Existing unread behavior preserved |
| Failed run/error | Existing failure behavior preserved |
| Thread already unread before silent routine | Remains unread |

## Tests

- regression test proven red against old behavior (`markUnread: false` still wrote `unread: true`)
- targeted: 15 passed
- adapter package: 862 passed, 6 skipped
- database package: 57 passed, 6 skipped
- format: passed
- lint: passed (2 pre-existing informational notices)
- typecheck: 20/20 Turbo tasks passed with cache forced off
- full tests excluding one confirmed current-main baseline failure: 2,089 passed, 103 skipped
- build: 4/4 Turbo tasks passed with cache forced off

Current `origin/main` also fails `apps/web/src/lib/i18n-catalog.test.ts` (`formats ICU cron-style messages with reordered placeholders`), unchanged by this diff.

## Surface coverage

Web and Electron share `apps/web/src/pages/Shell.tsx`; mobile uses `apps/mobile/app/index.tsx`. All roster renderers consume the same API `unread` field, and this fix changes that backend source of truth rather than adding renderer-specific guards. No rendered component changed, so screenshot QA is not applicable.

## Risk

Low. The override is scoped to completed routine runs with no derived user-facing text. Existing unread state is never cleared, and all other message paths retain the bot-role default.

## Exclusions

- no notification settings changes
- no activity or transcript hiding
- no roster component changes
- no schema migration or dependency changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread message indicators for routine activity, manual replies, failures, and completed subagent tasks.
  * Prevented an unnecessary “done.” message when a routine run only produces a successful subagent result.
  * Added support for explicitly suppressing unread status on applicable messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->