### PR TITLE
Collapse bot tool activity in chat

### DIFF
--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -2268,7 +2268,11 @@ const MessageBubble = memo(function MessageBubble({
     <View style={{ gap: 8, width: "100%" }}>
       {segments.map((segment, index) =>
         segment.kind === "tool" ? (
-          <ExpandableToolBlock key={`${message.id}-tools-${index}`} block={segment.block} />
+          <ExpandableToolBlock
+            key={`${message.id}-${message.id.startsWith("progress:") ? "working" : "actions"}-${index}`}
+            block={segment.block}
+            live={message.id.startsWith("progress:")}
+          />
         ) : (
           <MessageTextCard
             key={`${message.id}-content-${index}`}
@@ -2383,8 +2387,10 @@ function AgentEventLabel({
 
 function ExpandableToolBlock({
   block,
+  live,
 }: {
   block: Extract<MessageBlock, { kind: "progress" | "steps" }>;
+  live: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const provider =
@@ -2398,7 +2404,7 @@ function ExpandableToolBlock({
             : []),
           ...(block.pendingToolNames ?? []),
         ].filter(Boolean);
-  const title = provider ? `Using ${provider}` : "Tools";
+  const title = live ? "Working…" : "Actions";
 
   return (
     <View
@@ -2409,7 +2415,9 @@ function ExpandableToolBlock({
     >
       <Pressable
         accessibilityRole="button"
-        accessibilityLabel={expanded ? "Hide tool details" : "Show tool details"}
+        accessibilityLabel={`${expanded ? "Hide" : "Show"} ${title}`}
+        accessibilityState={{ expanded }}
+        hitSlop={10}
         onPress={() => setExpanded((current) => !current)}
         style={{
           flexDirection: "row",
@@ -2418,7 +2426,9 @@ function ExpandableToolBlock({
           paddingVertical: 2,
         }}
       >
-        <Text style={{ color: "#85858A", fontSize: 12.5, fontWeight: "600" }}>{title}</Text>
+        <Text style={{ color: live ? "#C9C9CE" : "#85858A", fontSize: 12.5, fontWeight: "600" }}>
+          {title}
+        </Text>
         <Text style={{ color: "#6C6C70", fontSize: 12 }}>{expanded ? "⌃" : "⌄"}</Text>
       </Pressable>
       {expanded ? (

--- a/apps/web/e2e/fixtures/tool-activity-disclosure.html
+++ b/apps/web/e2e/fixtures/tool-activity-disclosure.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tool activity disclosure</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module">
+      import { createElement as h } from "react";
+      import { createRoot } from "react-dom/client";
+      import { ToolActivityDisclosure, ToolSteps } from "../../src/components/ToolActivityDisclosure.tsx";
+      import "../../src/styles.css";
+
+      const live = new URLSearchParams(location.search).get("live") === "1";
+      const steps = [
+        { label: "Launch app", count: 1 },
+        { label: "Computer observe", count: 1 },
+        { label: "Computer act", count: 1 },
+        { label: "Shell", count: 1 },
+        { label: "Shell", count: 2 },
+      ];
+      const disclosure = h(
+        ToolActivityDisclosure,
+        { live, label: live ? "Working…" : "Actions" },
+        h(ToolSteps, { steps, currentIndex: live ? steps.length - 1 : undefined }),
+      );
+      const response = live
+        ? null
+        : h("div", { "data-testid": "final-response" }, "Terminal is open and ready.");
+      const bubble = h(
+        "div",
+        {
+          className:
+            "max-w-[74%] space-y-2.5 rounded-[20px] bg-[#1A1A1D] px-[18px] py-3 text-[15.5px] leading-[1.5] text-[#DFDFE2]",
+        },
+        disclosure,
+        response,
+      );
+      createRoot(document.getElementById("root")).render(
+        h(
+          "main",
+          {
+            className:
+              "flex min-h-screen items-end bg-[#101012] px-4 py-6 md:px-8 md:py-8",
+          },
+          h("div", { className: "flex w-full justify-start" }, bubble),
+        ),
+      );
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/tool-activity-disclosure.spec.ts
+++ b/apps/web/e2e/tool-activity-disclosure.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot } from "./helpers";
+
+const viewports = [
+  { name: "desktop-1440x900", width: 1440, height: 900 },
+  { name: "mobile-390x844", width: 390, height: 844 },
+];
+const states = [
+  { name: "active", live: true, label: "Working…" },
+  { name: "complete", live: false, label: "Actions" },
+];
+
+test("tool activity stays collapsed until disclosed", async ({ page }, testInfo) => {
+  for (const viewport of viewports) {
+    await page.setViewportSize(viewport);
+    for (const state of states) {
+      await page.goto(`/e2e/fixtures/tool-activity-disclosure.html?live=${state.live ? 1 : 0}`);
+      const details = page.getByTestId("tool-activity");
+      const summary = details.locator("summary");
+      const rows = page.getByTestId("tool-rows");
+
+      await expect(summary).toHaveText(state.label);
+      await expect(details).not.toHaveAttribute("open", "");
+      await expect(rows).not.toBeVisible();
+      await expect(page.getByTestId("final-response")).toHaveCount(state.live ? 0 : 1);
+      await captureScreenshot(page, testInfo, `${state.name}-collapsed-${viewport.name}`);
+
+      await summary.click();
+      await expect(details).toHaveAttribute("open", "");
+      await summary.click();
+      await summary.focus();
+      await page.keyboard.press("Enter");
+      await expect(details).toHaveAttribute("open", "");
+      await expect(rows).toBeVisible();
+      await expect(summary).toBeFocused();
+      await expect(page.locator("body")).toHaveJSProperty("scrollWidth", viewport.width);
+      if (!state.live) {
+        const rowBox = await rows.boundingBox();
+        const responseBox = await page.getByTestId("final-response").boundingBox();
+        expect(rowBox).not.toBeNull();
+        expect(responseBox).not.toBeNull();
+        expect(responseBox?.y).toBeGreaterThan((rowBox?.y ?? 0) + (rowBox?.height ?? 0));
+      }
+      await captureScreenshot(page, testInfo, `${state.name}-expanded-${viewport.name}`);
+    }
+  }
+});

--- a/apps/web/src/components/ToolActivityDisclosure.test.tsx
+++ b/apps/web/src/components/ToolActivityDisclosure.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ToolActivityDisclosure } from "./ToolActivityDisclosure";
+
+describe("ToolActivityDisclosure", () => {
+  it.each([
+    [true, "Working…"],
+    [false, "Actions"],
+  ])("defaults collapsed with the %s state label", (live, label) => {
+    const html = renderToStaticMarkup(
+      <ToolActivityDisclosure live={live} label={label}>
+        <span>Shell ×2</span>
+      </ToolActivityDisclosure>,
+    );
+
+    expect(html).toContain("<details");
+    expect(html).not.toMatch(/<details[^>]* open/);
+    expect(html).toContain(`<summary`);
+    expect(html).toContain(label);
+    expect(html).toContain("Shell ×2");
+  });
+
+  it("collapses again when live work completes", () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const render = (live: boolean) =>
+      flushSync(() =>
+        root.render(
+          <ToolActivityDisclosure live={live} label={live ? "Working…" : "Actions"}>
+            <span>Shell ×2</span>
+          </ToolActivityDisclosure>,
+        ),
+      );
+
+    render(true);
+    container.querySelector("summary")?.click();
+    expect(container.querySelector("details")?.open).toBe(true);
+
+    render(false);
+    expect(container.querySelector("details")?.open).toBe(false);
+    expect(container.querySelector("summary")?.textContent).toContain("Actions");
+    root.unmount();
+  });
+});

--- a/apps/web/src/components/ToolActivityDisclosure.tsx
+++ b/apps/web/src/components/ToolActivityDisclosure.tsx
@@ -14,7 +14,7 @@ export function ToolSteps({
       {steps.map((step, index) => {
         const isCurrent = index === currentIndex;
         return (
-          <div key={index} className="flex items-center gap-2">
+          <div key={index} className="flex min-w-0 items-center gap-2">
             <span
               className="text-[13px]"
               style={{
@@ -25,7 +25,7 @@ export function ToolSteps({
               {isCurrent ? "◷" : "✓"}
             </span>
             <span
-              className="truncate text-[14px]"
+              className="min-w-0 flex-1 truncate text-[14px]"
               style={{ color: isCurrent ? "#DFDFE2" : "#85858A" }}
             >
               {step.label}

--- a/apps/web/src/components/ToolActivityDisclosure.tsx
+++ b/apps/web/src/components/ToolActivityDisclosure.tsx
@@ -1,0 +1,73 @@
+import type { ThreadMessage } from "@rakazo/contracts";
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function ToolSteps({
+  steps,
+  currentIndex,
+}: {
+  steps: Extract<ThreadMessage["blocks"][number], { kind: "steps" }>["steps"];
+  currentIndex?: number;
+}) {
+  return (
+    <div className="space-y-1.5" data-testid="tool-rows">
+      {steps.map((step, index) => {
+        const isCurrent = index === currentIndex;
+        return (
+          <div key={index} className="flex items-center gap-2">
+            <span
+              className="text-[13px]"
+              style={{
+                color: isCurrent ? "#F5A03C" : "#4ECB71",
+                animation: isCurrent ? "rkPulse 1.2s ease-in-out infinite" : undefined,
+              }}
+            >
+              {isCurrent ? "◷" : "✓"}
+            </span>
+            <span
+              className="truncate text-[14px]"
+              style={{ color: isCurrent ? "#DFDFE2" : "#85858A" }}
+            >
+              {step.label}
+              {step.count > 1 ? ` ×${step.count}` : ""}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function ToolActivityDisclosure({
+  live,
+  label,
+  children,
+}: {
+  live: boolean;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <details
+      key={live ? "working" : "actions"}
+      data-testid="tool-activity"
+      data-live={live || undefined}
+      className="group"
+    >
+      <summary
+        className={`flex min-h-6 w-fit cursor-pointer list-none items-center gap-1 rounded-md py-0.5 pe-1.5 text-[13px] font-medium outline-none hover:text-[#C9C9CE] focus-visible:ring-2 focus-visible:ring-[#85858A] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1A1A1D] ${
+          live ? "text-[#C9C9CE]" : "text-[#85858A]"
+        }`}
+      >
+        <ChevronRight
+          aria-hidden
+          size={14}
+          strokeWidth={1.8}
+          className="transition-transform duration-150 group-open:rotate-90 motion-reduce:transition-none"
+        />
+        {label}
+      </summary>
+      <div className="mt-1.5 ps-1">{children}</div>
+    </details>
+  );
+}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -126,6 +126,7 @@ import {
   computersAreUnavailable,
 } from "../components/ComputersUnavailableHint";
 import { MessageHoverMetadata } from "../components/MessageHoverMetadata";
+import { ToolActivityDisclosure, ToolSteps } from "../components/ToolActivityDisclosure";
 import { SkillDraftCard } from "../components/teach/SkillDraftCard";
 import { TeachCaptureOverlay } from "../components/teach/TeachCaptureOverlay";
 import { TeachComputerSection } from "../components/teach/TeachComputerSection";
@@ -4860,42 +4861,6 @@ function ComputerReleaseActions({
   );
 }
 
-function ToolSteps({
-  steps,
-  currentIndex,
-}: {
-  steps: Extract<ThreadMessage["blocks"][number], { kind: "steps" }>["steps"];
-  currentIndex?: number;
-}) {
-  return (
-    <div className="space-y-1.5">
-      {steps.map((step, index) => {
-        const isCurrent = index === currentIndex;
-        return (
-          <div key={index} className="flex items-center gap-2">
-            <span
-              className="text-[13px]"
-              style={{
-                color: isCurrent ? "#F5A03C" : "#4ECB71",
-                animation: isCurrent ? "rkPulse 1.2s ease-in-out infinite" : undefined,
-              }}
-            >
-              {isCurrent ? "◷" : "✓"}
-            </span>
-            <span
-              className="truncate text-[14px]"
-              style={{ color: isCurrent ? "#DFDFE2" : "#85858A" }}
-            >
-              {step.label}
-              {step.count > 1 ? ` ×${step.count}` : ""}
-            </span>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
 const MessageView = memo(function MessageView({
   artifactTarget,
   canAnswer,
@@ -4978,12 +4943,16 @@ const MessageView = memo(function MessageView({
               if (block.kind === "steps") {
                 const isCurrentBlock = isLive && i === message.blocks.length - 1;
                 return (
-                  <div key={i} dir="ltr">
+                  <ToolActivityDisclosure
+                    key={i}
+                    live={isLive}
+                    label={isLive ? t`Working…` : t`Actions`}
+                  >
                     <ToolSteps
                       steps={block.steps}
                       currentIndex={isCurrentBlock ? block.steps.length - 1 : undefined}
                     />
-                  </div>
+                  </ToolActivityDisclosure>
                 );
               }
               if (block.kind === "text" || block.kind === "progress") {
@@ -5101,10 +5070,12 @@ const MessageView = memo(function MessageView({
                 className="max-w-[74%] space-y-1.5 rounded-[20px] bg-[#1A1A1D] px-[18px] py-3"
                 dir="ltr"
               >
-                <ToolSteps
-                  steps={block.steps}
-                  currentIndex={isLive ? block.steps.length - 1 : undefined}
-                />
+                <ToolActivityDisclosure live={isLive} label={isLive ? t`Working…` : t`Actions`}>
+                  <ToolSteps
+                    steps={block.steps}
+                    currentIndex={isLive ? block.steps.length - 1 : undefined}
+                  />
+                </ToolActivityDisclosure>
               </div>
             </div>
           );


### PR DESCRIPTION
## Summary

- Collapse live bot tool activity behind a native `Working…` disclosure by default.
- Replace it with a faint, collapsed `Actions` disclosure when the run completes, preserving the final response below it.
- Preserve existing action order, grouping, counts, and status styling when expanded.
- Apply matching behavior to the shared web/Electron renderer and the Expo mobile renderer.

## Behavior / state matrix

| Surface | State | Default | Expanded content | Transition |
| --- | --- | --- | --- | --- |
| Web + Electron | Active | Collapsed `Working…` | Existing live action rows, still updating | Completion remounts collapsed `Actions` |
| Web + Electron | Complete | Collapsed faint `Actions` | Existing completed rows | Final response remains visible below |
| Expo mobile | Active | Collapsed `Working…` | Existing live tool rows | Progress→message identity/state resets collapse |
| Expo mobile | Complete | Collapsed faint `Actions` | Existing completed tool rows | Final response remains a separate content card |

The web control uses native `<details>/<summary>` semantics, visible `:focus-visible` styling, and an accurate native expanded state. Expo uses a `Pressable` button with `accessibilityState.expanded`, an explicit accessible label, and enlarged hit slop.

## Tests

- `node_modules/.bin/vitest run apps/web/src/components/ToolActivityDisclosure.test.tsx apps/mobile/lib/message-presentation.test.ts --maxWorkers=2` — 7 passed.
- `node_modules/.bin/biome check .` — passed (2 pre-existing informational suggestions in `packages/core/src/events.test.ts`).
- `pnpm run check` — 20/20 tasks passed.
- `pnpm run build` — 4/4 tasks passed.
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:4173 pnpm --filter @rakazo/web exec playwright test e2e/tool-activity-disclosure.spec.ts --workers=1` — passed.
- `pnpm run test -- --maxWorkers=5` — 2,089 passed, 103 skipped, 1 failed: pre-existing `apps/web/src/lib/i18n-catalog.test.ts` uncompiled German ICU catalog assertion. The same focused test fails on pristine `origin/main`.

The regression test was sabotage-checked: removing the state-dependent disclosure key made the live→complete collapse assertion fail; restoring it made the test pass.

## Visual QA

Current-revision Playwright evidence covers all four states at 1440×900 and 390×844 responsive-web viewports:

- active collapsed / expanded
- complete collapsed / expanded
- click and keyboard expansion
- visible keyboard focus
- no horizontal overflow or clipping
- preserved action order/grouping/status visuals
- final response below completed actions

Local evidence is saved under `/tmp/rakazo-collapsible-actions-qa/final/`. CI ran the same checked-in Playwright fixture/spec for commit `45f09ee`: [open the screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/440/index.html).

Electron hosts the web UI, so the web evidence covers Electron's renderer. Expo mobile uses a separate native renderer and is covered by the implementation/typecheck; a native-device screenshot is excluded because this repository has no authenticated deterministic mobile transcript fixture in CI.

## Risk

Low. The change wraps existing rows without changing event reduction, action grouping, ordering, or final-response rendering. The main state risk—an expanded live disclosure staying open after completion—has focused regression coverage.

## Exclusions

- Errors, approvals, questions, and final responses are not collapsed.
- No event, orchestration, persistence, or API behavior changes.
- No new dependency or speculative shared abstraction.
- No native-device screenshot fixture added solely for this small presentation change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expandable tool activity sections labeled “Working…” while tasks are in progress and “Actions” when complete.
  * Added step-by-step activity details, including current-step indicators and repetition counts.
  * Added accessible keyboard and focus interactions for expanding and collapsing activity details.
  * Updated mobile and web displays to consistently show tool activity states.

* **Bug Fixes**
  * Improved handling of long tool labels to prevent layout overflow.
  * Completed activity sections now collapse appropriately when live work finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->