### PR TITLE
fix(chat): restore peer transcript markers

### DIFF
--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1959,6 +1959,7 @@ const MessageBubble = memo(function MessageBubble({
           width: "100%",
           paddingVertical: 4,
           alignItems: "center",
+          justifyContent: "center",
           flexDirection: "row",
           gap: 6,
         }}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1965,7 +1965,9 @@ const MessageBubble = memo(function MessageBubble({
         }}
       >
         <BotAvatar color={peerColor} identity={peerBotId} size={16} />
-        <Text style={{ color: "#85858A", fontSize: 13.5, flexShrink: 1 }}>{label}</Text>
+        <Text numberOfLines={1} style={{ color: "#85858A", fontSize: 13.5, flexShrink: 1 }}>
+          {label}
+        </Text>
       </View>
     );
   }

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1959,13 +1959,13 @@ const MessageBubble = memo(function MessageBubble({
           width: "100%",
           paddingVertical: 4,
           alignItems: "center",
-          justifyContent: "center",
+          justifyContent: "flex-start",
           flexDirection: "row",
           gap: 6,
         }}
       >
         <BotAvatar color={peerColor} identity={peerBotId} size={16} />
-        <Text style={{ color: "#85858A", fontSize: 13.5 }}>{label}</Text>
+        <Text style={{ color: "#85858A", fontSize: 13.5, flexShrink: 1 }}>{label}</Text>
       </View>
     );
   }

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1191,6 +1191,7 @@ function Thread() {
             groupId={groupId}
             message={message}
             botName={name}
+            bots={mentionBots}
             members={snap?.members}
             replyPreview={
               message.replyToMessageId ? messagesById.get(message.replyToMessageId) : undefined
@@ -1871,6 +1872,7 @@ async function speakMessage(botId: string, message: MobileMessage) {
 const MessageBubble = memo(function MessageBubble({
   botId,
   botName,
+  bots,
   groupId,
   message,
   members,
@@ -1883,6 +1885,7 @@ const MessageBubble = memo(function MessageBubble({
 }: {
   botId: string;
   botName?: string;
+  bots: MobileBot[];
   groupId?: string;
   message: MobileMessage;
   members?: MobileSnapshot["members"];
@@ -1940,13 +1943,28 @@ const MessageBubble = memo(function MessageBubble({
   if (peerMessage) {
     const sent = peerMessage.kind === "bot_message_sent";
     const peer = sent ? peerMessage.toBotName : peerMessage.fromBotName;
+    const peerBotId = sent ? peerMessage.toBotId : peerMessage.fromBotId;
+    const label = sent ? `Messaged ${peer}` : `Message from ${peer}`;
+    const peerColor =
+      bots.find((bot) => bot.id === peerBotId)?.color ??
+      members?.find((member) => member.botId === peerBotId)?.color ??
+      "#85858A";
     // Compact receipt only: peer bodies stay out of the human thread.
     // Full view-only peer chat is web-first; mobile keeps the chip without expand.
     return (
-      <View style={{ width: "100%", paddingVertical: 4, alignItems: "center" }}>
-        <Text style={{ color: "#85858A", fontSize: 13.5, textAlign: "center" }}>
-          {sent ? `Messaged ${peer}` : `Message from ${peer}`}
-        </Text>
+      <View
+        accessible
+        accessibilityLabel={label}
+        style={{
+          width: "100%",
+          paddingVertical: 4,
+          alignItems: "center",
+          flexDirection: "row",
+          gap: 6,
+        }}
+      >
+        <BotAvatar color={peerColor} identity={peerBotId} size={16} />
+        <Text style={{ color: "#85858A", fontSize: 13.5 }}>{label}</Text>
       </View>
     );
   }

--- a/apps/web/e2e/peer-messages.spec.ts
+++ b/apps/web/e2e/peer-messages.spec.ts
@@ -60,18 +60,16 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
   // User bubble still contains the phrase; peer body must not appear outside the chip.
   await expect(chip).not.toContainText("peer-exchange-alpha");
   await expect(transcript.getByText("peer-exchange-alpha")).toHaveCount(1);
-  const assertChipCentered = async () => {
+  const assertChipLeftAligned = async () => {
     const transcriptBox = await transcript.boundingBox();
     const chipBox = await chip.boundingBox();
     expect(transcriptBox).not.toBeNull();
     expect(chipBox).not.toBeNull();
-    const transcriptCenter = transcriptBox!.x + transcriptBox!.width / 2;
-    const chipCenter = chipBox!.x + chipBox!.width / 2;
-    // Status-row chips sit near horizontal center (not left-rail like messages).
-    expect(Math.abs(chipCenter - transcriptCenter)).toBeLessThan(transcriptBox!.width * 0.2);
+    expect(chipBox!.x).toBeLessThan(transcriptBox!.x + transcriptBox!.width / 3);
+    expect(chipBox!.width).toBeLessThan(transcriptBox!.width / 2);
   };
 
-  await assertChipCentered();
+  await assertChipLeftAligned();
   await expect(composer).toBeVisible();
   await captureScreenshot(page, testInfo, "peer-chip-desktop");
 
@@ -79,7 +77,7 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
   await chip.scrollIntoViewIfNeeded();
   await expect(chip).toBeVisible();
   await expect(composer).toBeVisible();
-  await assertChipCentered();
+  await assertChipLeftAligned();
   await captureScreenshot(page, testInfo, "peer-chip-mobile");
 
   await chip.focus();
@@ -94,5 +92,16 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
   });
   await expect(view.getByRole("textbox")).toHaveCount(0);
   await expect(view.getByText("Loading")).toHaveCount(0);
+  const peerTranscript = view.getByTestId("peer-conversation-transcript");
+  await peerTranscript.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect
+    .poll(() =>
+      peerTranscript.evaluate(
+        (element) => element.scrollTop + element.clientHeight >= element.scrollHeight - 1,
+      ),
+    )
+    .toBe(true);
   await captureScreenshot(page, testInfo, "peer-view-only");
 });

--- a/apps/web/e2e/peer-messages.spec.ts
+++ b/apps/web/e2e/peer-messages.spec.ts
@@ -60,11 +60,18 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
   // User bubble still contains the phrase; peer body must not appear outside the chip.
   await expect(chip).not.toContainText("peer-exchange-alpha");
   await expect(transcript.getByText("peer-exchange-alpha")).toHaveCount(1);
-  const desktopTranscriptBox = await transcript.boundingBox();
-  const desktopChipBox = await chip.boundingBox();
-  expect(desktopTranscriptBox).not.toBeNull();
-  expect(desktopChipBox).not.toBeNull();
-  expect(desktopChipBox!.x).toBeLessThan(desktopTranscriptBox!.x + desktopTranscriptBox!.width / 3);
+  const assertChipCentered = async () => {
+    const transcriptBox = await transcript.boundingBox();
+    const chipBox = await chip.boundingBox();
+    expect(transcriptBox).not.toBeNull();
+    expect(chipBox).not.toBeNull();
+    const transcriptCenter = transcriptBox!.x + transcriptBox!.width / 2;
+    const chipCenter = chipBox!.x + chipBox!.width / 2;
+    // Status-row chips sit near horizontal center (not left-rail like messages).
+    expect(Math.abs(chipCenter - transcriptCenter)).toBeLessThan(transcriptBox!.width * 0.2);
+  };
+
+  await assertChipCentered();
   await expect(composer).toBeVisible();
   await captureScreenshot(page, testInfo, "peer-chip-desktop");
 
@@ -72,11 +79,7 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
   await chip.scrollIntoViewIfNeeded();
   await expect(chip).toBeVisible();
   await expect(composer).toBeVisible();
-  const mobileTranscriptBox = await transcript.boundingBox();
-  const mobileChipBox = await chip.boundingBox();
-  expect(mobileTranscriptBox).not.toBeNull();
-  expect(mobileChipBox).not.toBeNull();
-  expect(mobileChipBox!.x).toBeLessThan(mobileTranscriptBox!.x + mobileTranscriptBox!.width / 3);
+  await assertChipCentered();
   await captureScreenshot(page, testInfo, "peer-chip-mobile");
 
   await chip.focus();

--- a/apps/web/e2e/peer-messages.spec.ts
+++ b/apps/web/e2e/peer-messages.spec.ts
@@ -65,7 +65,8 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
     const chipBox = await chip.boundingBox();
     expect(transcriptBox).not.toBeNull();
     expect(chipBox).not.toBeNull();
-    expect(chipBox!.x).toBeLessThan(transcriptBox!.x + transcriptBox!.width / 3);
+    // Transcript padding is 16px mobile / 28px desktop; centering must fail this assertion.
+    expect(chipBox!.x - transcriptBox!.x).toBeLessThanOrEqual(32);
     expect(chipBox!.width).toBeLessThan(transcriptBox!.width / 2);
   };
 

--- a/apps/web/e2e/peer-messages.spec.ts
+++ b/apps/web/e2e/peer-messages.spec.ts
@@ -54,12 +54,34 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
     .first();
   await expect(chip).toBeVisible({ timeout: 30_000 });
   await expect(chip.getByText(/Messaged|Message from/)).toBeVisible();
+  await expect(chip).toHaveAccessibleName(/Messaged Researcher|Message from Researcher/);
+  await expect(chip.locator(".rakazo-bot-avatar")).toBeVisible();
+  await expect(chip).not.toContainText("{peer}");
   // User bubble still contains the phrase; peer body must not appear outside the chip.
   await expect(chip).not.toContainText("peer-exchange-alpha");
   await expect(transcript.getByText("peer-exchange-alpha")).toHaveCount(1);
-  await captureScreenshot(page, testInfo, "peer-chip-in-thread");
+  const desktopTranscriptBox = await transcript.boundingBox();
+  const desktopChipBox = await chip.boundingBox();
+  expect(desktopTranscriptBox).not.toBeNull();
+  expect(desktopChipBox).not.toBeNull();
+  expect(desktopChipBox!.x).toBeLessThan(desktopTranscriptBox!.x + desktopTranscriptBox!.width / 3);
+  await expect(composer).toBeVisible();
+  await captureScreenshot(page, testInfo, "peer-chip-desktop");
 
-  await chip.getByRole("button", { name: /Messaged Researcher|Message from Researcher/ }).click();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await chip.scrollIntoViewIfNeeded();
+  await expect(chip).toBeVisible();
+  await expect(composer).toBeVisible();
+  const mobileTranscriptBox = await transcript.boundingBox();
+  const mobileChipBox = await chip.boundingBox();
+  expect(mobileTranscriptBox).not.toBeNull();
+  expect(mobileChipBox).not.toBeNull();
+  expect(mobileChipBox!.x).toBeLessThan(mobileTranscriptBox!.x + mobileTranscriptBox!.width / 3);
+  await captureScreenshot(page, testInfo, "peer-chip-mobile");
+
+  await chip.focus();
+  await expect(chip).toBeFocused();
+  await chip.press("Enter");
   const view = page.getByTestId("peer-conversation-view");
   await expect(view).toBeVisible();
   await expect(view.getByRole("heading", { name: /Chief · Researcher/ })).toBeVisible();

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { ActiveBotGlyph, CollaborationMarker } from "./CollaborationMarker";
 
 describe("collaboration transcript markers", () => {
-  it("shows a centered peer event with its avatar and full label", () => {
+  it("shows a left-aligned peer event with its avatar and full label", () => {
     const html = renderToString(
       <CollaborationMarker
         ariaLabel="Message from Research"
@@ -16,12 +16,12 @@ describe("collaboration transcript markers", () => {
 
     expect(html).toContain('data-testid="peer-receipt-chip"');
     expect(html).toContain('aria-label="Message from Research"');
-    expect(html).toContain('class="flex justify-center self-center"');
+    expect(html).toContain('class="flex justify-start"');
+    expect(html).toContain('class="inline-flex max-w-full');
+    expect(html).toContain('class="truncate"');
     expect(html).toContain("rakazo-bot-avatar");
     expect(html).toContain("Message from Research");
     expect(html).not.toContain("{peer}");
-    expect(html).not.toContain("justify-start");
-    expect(html).not.toContain("self-start");
   });
 
   it("animates the active bot glyph from its run status", () => {

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { ActiveBotGlyph, CollaborationMarker } from "./CollaborationMarker";
 
 describe("collaboration transcript markers", () => {
-  it("shows a left-aligned peer event with its avatar and full label", () => {
+  it("shows a centered peer event with its avatar and full label", () => {
     const html = renderToString(
       <CollaborationMarker
         ariaLabel="Message from Research"
@@ -16,10 +16,12 @@ describe("collaboration transcript markers", () => {
 
     expect(html).toContain('data-testid="peer-receipt-chip"');
     expect(html).toContain('aria-label="Message from Research"');
-    expect(html).toContain('class="flex items-center justify-start');
+    expect(html).toContain('class="flex justify-center self-center"');
     expect(html).toContain("rakazo-bot-avatar");
     expect(html).toContain("Message from Research");
     expect(html).not.toContain("{peer}");
+    expect(html).not.toContain("justify-start");
+    expect(html).not.toContain("self-start");
   });
 
   it("animates the active bot glyph from its run status", () => {

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.test.tsx
@@ -1,27 +1,25 @@
 import { renderToString } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { ActiveBotGlyph, CollaborationMarker, PeerBotChip } from "./CollaborationMarker";
+import { ActiveBotGlyph, CollaborationMarker } from "./CollaborationMarker";
 
 describe("collaboration transcript markers", () => {
-  it("shows a centered Message from label and clickable bot chip", () => {
+  it("shows a left-aligned peer event with its avatar and full label", () => {
     const html = renderToString(
-      <CollaborationMarker>
-        Message from{" "}
-        <PeerBotChip
-          ariaLabel="Message from Research"
-          color="#14B8A6"
-          identity="research"
-          botName="Research"
-          onClick={() => undefined}
-        />
-      </CollaborationMarker>,
+      <CollaborationMarker
+        ariaLabel="Message from Research"
+        color="#14B8A6"
+        identity="research"
+        label="Message from Research"
+        onClick={() => undefined}
+      />,
     );
 
     expect(html).toContain('data-testid="peer-receipt-chip"');
     expect(html).toContain('aria-label="Message from Research"');
-    expect(html).toContain("Message from");
+    expect(html).toContain('class="flex items-center justify-start');
     expect(html).toContain("rakazo-bot-avatar");
-    expect(html).toContain("Research");
+    expect(html).toContain("Message from Research");
+    expect(html).not.toContain("{peer}");
   });
 
   it("animates the active bot glyph from its run status", () => {

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
@@ -1,45 +1,31 @@
 import { BotAvatar, GroupAvatar, type GroupAvatarMember } from "@rakazo/ui-web";
-import type { ReactNode } from "react";
 import { LoadingState } from "./primitives";
 
-/** Clickable peer bot chip embedded in a Messaged / Message from label. */
-export function PeerBotChip({
+/** Lightweight peer event shown without exposing the exchanged message body. */
+export function CollaborationMarker({
   ariaLabel,
   color,
   identity,
-  botName,
+  label,
   onClick,
 }: {
   ariaLabel: string;
   color: string;
   identity: string;
-  botName: string;
+  label: string;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
+      data-testid="peer-receipt-chip"
       aria-label={ariaLabel}
       onClick={onClick}
-      className="inline-flex max-w-full items-center gap-1.5 rounded-full bg-[#1C1C1F] px-2.5 py-1 text-[13px] text-[#ECECEE] transition-colors hover:bg-[#242428]"
+      className="flex items-center justify-start gap-1.5 self-start rounded-full px-2.5 py-1 text-[13px] text-[#85858A] transition-colors hover:bg-[#161618] hover:text-[#B8B8BD]"
     >
       <BotAvatar color={color} identity={identity} size={16} />
-      <span dir="auto" className="truncate">
-        {botName}
-      </span>
+      <span dir="auto">{label}</span>
     </button>
-  );
-}
-
-/** Centered status line with a peer-aware translated label (chip replaces {peer}). */
-export function CollaborationMarker({ children }: { children: ReactNode }) {
-  return (
-    <div
-      data-testid="peer-receipt-chip"
-      className="flex items-center justify-center gap-2 self-center py-1 text-[13.5px] text-[#85858A]"
-    >
-      {children}
-    </div>
   );
 }
 

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
@@ -16,16 +16,18 @@ export function CollaborationMarker({
   onClick: () => void;
 }) {
   return (
-    <div className="flex justify-center self-center">
+    <div className="flex justify-start">
       <button
         type="button"
         data-testid="peer-receipt-chip"
         aria-label={ariaLabel}
         onClick={onClick}
-        className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[13px] text-[#85858A] transition-colors hover:bg-[#161618] hover:text-[#B8B8BD]"
+        className="inline-flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1 text-[13px] text-[#85858A] transition-colors hover:bg-[#161618] hover:text-[#B8B8BD]"
       >
         <BotAvatar color={color} identity={identity} size={16} />
-        <span dir="auto">{label}</span>
+        <span dir="auto" className="truncate">
+          {label}
+        </span>
       </button>
     </div>
   );

--- a/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
+++ b/apps/web/src/components/beautiful-ui/CollaborationMarker.tsx
@@ -16,16 +16,18 @@ export function CollaborationMarker({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      data-testid="peer-receipt-chip"
-      aria-label={ariaLabel}
-      onClick={onClick}
-      className="flex items-center justify-start gap-1.5 self-start rounded-full px-2.5 py-1 text-[13px] text-[#85858A] transition-colors hover:bg-[#161618] hover:text-[#B8B8BD]"
-    >
-      <BotAvatar color={color} identity={identity} size={16} />
-      <span dir="auto">{label}</span>
-    </button>
+    <div className="flex justify-center self-center">
+      <button
+        type="button"
+        data-testid="peer-receipt-chip"
+        aria-label={ariaLabel}
+        onClick={onClick}
+        className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[13px] text-[#85858A] transition-colors hover:bg-[#161618] hover:text-[#B8B8BD]"
+      >
+        <BotAvatar color={color} identity={identity} size={16} />
+        <span dir="auto">{label}</span>
+      </button>
+    </div>
   );
 }
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1,5 +1,4 @@
 import { t } from "@lingui/core/macro";
-import { Trans as RichTrans } from "@lingui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type {
@@ -117,7 +116,6 @@ import { AskCard } from "../components/AskCard";
 import {
   ActiveBotGlyph,
   CollaborationMarker,
-  PeerBotChip,
 } from "../components/beautiful-ui/CollaborationMarker";
 import { BuiButton, BuiCard, SuccessPop } from "../components/beautiful-ui/primitives";
 import { ComputerMaintenanceActions } from "../components/ComputerMaintenanceActions";
@@ -5033,30 +5031,16 @@ const MessageView = memo(function MessageView({
           const sent = block.kind === "bot_message_sent";
           const peer = sent ? block.toBotName : block.fromBotName;
           const peerBotId = sent ? block.toBotId : block.fromBotId;
-          const ariaLabel = sent ? t`Messaged ${peer}` : t`Message from ${peer}`;
-          const peerChipProps = {
-            ariaLabel,
-            color: peerBot(peerBotId)?.color ?? "#85858A",
-            identity: peerBotId,
-            botName: peer,
-            onClick: () => onOpenPeerMessages({ peerBotId, peerBotName: peer }),
-          };
+          const label = sent ? t`Messaged ${peer}` : t`Message from ${peer}`;
           return (
-            <CollaborationMarker key={i}>
-              {sent ? (
-                <RichTrans
-                  id="Messaged {peer}"
-                  message="Messaged {peer}"
-                  values={{ peer: <PeerBotChip {...peerChipProps} /> }}
-                />
-              ) : (
-                <RichTrans
-                  id="Message from {peer}"
-                  message="Message from {peer}"
-                  values={{ peer: <PeerBotChip {...peerChipProps} /> }}
-                />
-              )}
-            </CollaborationMarker>
+            <CollaborationMarker
+              key={i}
+              ariaLabel={label}
+              color={peerBot(peerBotId)?.color ?? "#85858A"}
+              identity={peerBotId}
+              label={label}
+              onClick={() => onOpenPeerMessages({ peerBotId, peerBotName: peer })}
+            />
           );
         }
         if (block.kind === "phone_channel_message") {


### PR DESCRIPTION
## Findings

PR #426’s peer-marker i18n follow-up passed a React element through Lingui’s scalar `values` interpolation. Lingui rendered `{peer}` literally while the avatar/name chip became a separate element; the preceding peer-chip change also centered the marker. The combined regression landed in squash commit `3988d3f`.

## Fix

- restore one lightweight, left-aligned event button containing the real peer avatar and the fully translated `Messaged …` / `Message from …` label
- keep peer exchange bodies filtered from the normal transcript and preserve the view-only peer conversation
- align Expo-native receipts with the same avatar/name/left-rail presentation
- cover real identity, avatar, alignment, keyboard activation, responsive layout, composer placement, and no peer-body echo

## Supplied before/after oracle

- **Expected / before:** `Screenshot 2026-08-31 at 4.01.22 PM.png` — compact left-aligned rows such as “Message from Charles” and “Messaged Coder,” each with the real peer avatar and name; exchange bodies remain hidden.
- **Regressed / current:** `Screenshot 2026-08-31 at 4.01.42 PM.png` — avatars disappear, `{peer}` renders literally in a detached far-right column, and generic `Message` pills no longer read as one event marker.

## Verification

- regression test observed RED against the pre-fix shared marker, then GREEN after the fix
- `pnpm run test` — 2,140 passed, 103 skipped
- `./node_modules/.bin/biome check .`
- `pnpm run check`
- `pnpm run build`
- `pnpm run format`
- focused PostgreSQL + scripted-runtime Playwright E2E — desktop 1280×720 and responsive 390×844 captures; keyboard activation; real names/avatars; left alignment; composer visible; no hidden-body echo

## Visual evidence

- Exact head: `1926cadd6fd84bcc41f2f119fe38f656c83be204`
- [Playwright screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/443/index.html) — desktop, responsive 390×844, and view-only peer conversation captures
- [Exact-head CI run](https://github.com/elie222/rakazo/actions/runs/33439447883)
