### PR TITLE
fix(api): stop resurfacing a failed run after a newer run finishes

### DIFF
--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -230,7 +230,11 @@ describe("threadSnapshot", () => {
       createdAt: new Date("2026-08-23T00:00:00.000Z"),
     };
     const findManyEvents = vi.fn();
-    const findFirstRun = vi.fn().mockResolvedValueOnce(run).mockResolvedValueOnce(null);
+    const findFirstRun = vi
+      .fn()
+      .mockResolvedValueOnce(run)
+      // The failure is itself the newest terminal run, so it stays visible.
+      .mockResolvedValueOnce({ id: run.id });
     const tx = {
       $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
       message: { findMany: vi.fn().mockResolvedValue([]) },
@@ -320,10 +324,9 @@ describe("threadSnapshot", () => {
       expect.objectContaining({
         where: expect.objectContaining({
           trigger: { not: "bot_message" },
-          status: { in: ["completed", "cancelled"] },
-          createdAt: { gte: failed.createdAt },
-          id: { not: failed.id },
+          status: { in: ["failed", "completed", "cancelled"] },
         }),
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       }),
     );
     expect(snapshot.run).toBeNull();

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -230,7 +230,7 @@ describe("threadSnapshot", () => {
       createdAt: new Date("2026-08-23T00:00:00.000Z"),
     };
     const findManyEvents = vi.fn();
-    const findFirstRun = vi.fn().mockResolvedValue(run);
+    const findFirstRun = vi.fn().mockResolvedValueOnce(run).mockResolvedValueOnce(null);
     const tx = {
       $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
       message: { findMany: vi.fn().mockResolvedValue([]) },
@@ -272,6 +272,59 @@ describe("threadSnapshot", () => {
       }),
     );
     expect(findManyEvents).not.toHaveBeenCalled();
+  });
+
+  it("drops a failed run once a newer run has finished", async () => {
+    const failed = {
+      id: "run-failed",
+      botId: "bot-1",
+      threadId: "thread-1",
+      taskId: "task-1",
+      status: "failed",
+      trigger: "user",
+      modelProvider: "openrouter",
+      modelId: "openrouter/unknown",
+      error: "This operation was aborted",
+      startedAt: null,
+      completedAt: new Date("2026-08-23T00:00:01.000Z"),
+      createdAt: new Date("2026-08-23T00:00:00.000Z"),
+    };
+    const findFirstRun = vi
+      .fn()
+      .mockResolvedValueOnce(failed)
+      // The supersession probe finds a newer completed run.
+      .mockResolvedValueOnce({ id: "run-completed" });
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      message: { findMany: vi.fn().mockResolvedValue([]) },
+      event: {
+        findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn(),
+      },
+      run: { findFirst: findFirstRun },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+    const target = {
+      kind: "bot",
+      botId: "bot-1",
+      threadId: "thread-1",
+      bot: { computer: null },
+    } as ThreadTarget;
+
+    const snapshot = await threadSnapshot({ prisma }, target);
+
+    expect(findFirstRun).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["completed", "cancelled"] },
+          createdAt: { gt: failed.createdAt },
+        }),
+      }),
+    );
+    expect(snapshot.run).toBeNull();
   });
 
   it("does not return a cancelled or completed run", async () => {

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -319,6 +319,7 @@ describe("threadSnapshot", () => {
       2,
       expect.objectContaining({
         where: expect.objectContaining({
+          trigger: { not: "bot_message" },
           status: { in: ["completed", "cancelled"] },
           createdAt: { gt: failed.createdAt },
         }),

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -321,7 +321,8 @@ describe("threadSnapshot", () => {
         where: expect.objectContaining({
           trigger: { not: "bot_message" },
           status: { in: ["completed", "cancelled"] },
-          createdAt: { gt: failed.createdAt },
+          createdAt: { gte: failed.createdAt },
+          id: { not: failed.id },
         }),
       }),
     );

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -303,18 +303,34 @@ export async function threadSnapshot(
             orderBy: { createdAt: "desc" },
           }),
         ]);
+        // A failed run is only the thread's word while nothing has finished
+        // after it; otherwise a stale failure would resurface in the composer
+        // error strip on every load, forever.
+        const supersededFailure =
+          run?.status === "failed"
+            ? await tx.run.findFirst({
+                where: {
+                  botId: target.botId,
+                  threadId: target.threadId,
+                  status: { in: ["completed", "cancelled"] },
+                  createdAt: { gt: run.createdAt },
+                },
+                select: { id: true },
+              })
+            : null;
+        const currentRun = supersededFailure ? null : run;
         const liveEvents =
-          run && isActive(run.status as RunStatus)
+          currentRun && isActive(currentRun.status as RunStatus)
             ? await tx.event.findMany({
                 where: {
                   threadId: target.threadId,
-                  runId: run.id,
+                  runId: currentRun.id,
                   type: { in: ["thread.progress", "thread.subagent", "agent.tool.called"] },
                 },
                 orderBy: { seq: "asc" },
               })
             : [];
-        return { messagePage, last, run, liveEvents };
+        return { messagePage, last, run: currentRun, liveEvents };
       }),
     ]);
     return {

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -300,13 +300,18 @@ export async function threadSnapshot(
               trigger: { not: "bot_message" },
               status: { in: [...ACTIVE_RUN_STATUSES, "failed"] },
             },
-            orderBy: { createdAt: "desc" },
+            // The id tiebreak keeps ordering deterministic under equal
+            // timestamps, matching the supersession probe below.
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
           }),
         ]);
-        // A failed run is only the thread's word while nothing has finished
-        // after it; otherwise a stale failure would resurface in the composer
-        // error strip on every load, forever.
-        const supersededFailure =
+        // A failed run is only the thread's word while it is still the newest
+        // terminal run; otherwise a stale failure would resurface in the
+        // composer error strip on every load, forever. Instead of comparing
+        // timestamps (equal createdAt values reverse under gt/gte), ask for
+        // the newest terminal run under the same deterministic ordering and
+        // check whether it is this failure.
+        const newestTerminal =
           run?.status === "failed"
             ? await tx.run.findFirst({
                 where: {
@@ -314,16 +319,13 @@ export async function threadSnapshot(
                   threadId: target.threadId,
                   // Match the selection query — peer bot_message runs must not bury a user-visible failure.
                   trigger: { not: "bot_message" },
-                  status: { in: ["completed", "cancelled"] },
-                  // gte + self-exclusion: a terminal run created in the same
-                  // millisecond as the failure still supersedes it.
-                  createdAt: { gte: run.createdAt },
-                  id: { not: run.id },
+                  status: { in: ["failed", "completed", "cancelled"] },
                 },
+                orderBy: [{ createdAt: "desc" }, { id: "desc" }],
                 select: { id: true },
               })
             : null;
-        const currentRun = supersededFailure ? null : run;
+        const currentRun = run?.status === "failed" && newestTerminal?.id !== run.id ? null : run;
         const liveEvents =
           currentRun && isActive(currentRun.status as RunStatus)
             ? await tx.event.findMany({

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -315,7 +315,10 @@ export async function threadSnapshot(
                   // Match the selection query — peer bot_message runs must not bury a user-visible failure.
                   trigger: { not: "bot_message" },
                   status: { in: ["completed", "cancelled"] },
-                  createdAt: { gt: run.createdAt },
+                  // gte + self-exclusion: a terminal run created in the same
+                  // millisecond as the failure still supersedes it.
+                  createdAt: { gte: run.createdAt },
+                  id: { not: run.id },
                 },
                 select: { id: true },
               })

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -312,6 +312,8 @@ export async function threadSnapshot(
                 where: {
                   botId: target.botId,
                   threadId: target.threadId,
+                  // Match the selection query — peer bot_message runs must not bury a user-visible failure.
+                  trigger: { not: "bot_message" },
                   status: { in: ["completed", "cancelled"] },
                   createdAt: { gt: run.createdAt },
                 },


### PR DESCRIPTION
## The bug

`threadSnapshot` selects the newest run whose status is active **or `failed`** — completed runs are invisible to that query. So once a thread contains a failed run, it is served as `snapshot.run` forever: no number of later successful runs can displace it.

Since #362 started surfacing run failures in the composer error strip, this shows up as a phantom error: a days-old failure (in our case, an `AbortError` — literally "This operation was aborted" — from a server restart mid-run) reappears on **every page load**, because `dismissedRunErrorIds` is session-local state. The X dismisses it until the next reload, forever.

## Repro

1. Have any run in a thread end in `failed` (kill the API mid-run works)
2. Send more messages; runs complete normally
3. Reload → the old failure's error banner is back above the composer

## The fix

A failed run now yields to any newer `completed`/`cancelled` run in the same thread — a failure surfaces until the next run finishes, then stays buried. The supersession probe runs inside the existing snapshot transaction, only when the selected run is `failed` (one extra indexed `findFirst` on that path, nothing on the happy path).

Includes a test pinning the supersession behavior, and the existing "returns the latest failed run" test now distinguishes the two `findFirst` calls.

No UI change — the visible effect is the composer error strip no longer showing stale failures (its intended behavior per #362).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFfurtPJ3LRnMYYAeJqkhp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated failed runs from appearing after a newer run has completed or been cancelled.
  * Ensured live updates are shown only for the current, unsuperseded run.
  * Preserved visibility of relevant errors when no newer run exists.
  * Prevented background bot-triggered runs from hiding user-visible failures.
  * Correctly handled runs created at the same time, ensuring the latest terminal result takes precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->