### PR TITLE
fix(web): stop seen run errors returning after reload

### DIFF
--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -50,8 +50,12 @@ test("a failed run is visible once without returning after reload", async ({ pag
   await expect(error).toBeVisible({ timeout: 30_000 });
   await expect(error).toContainText("Scripted run failure");
 
-  await page.getByTestId("composer-error-dismiss").click();
+  const dismissError = page.getByTestId("composer-error-dismiss");
+  await dismissError.focus();
+  await expect(dismissError).toBeFocused();
+  await dismissError.press("Enter");
   await expect(error).toBeHidden();
+  await expect(page.getByPlaceholder(/^Message /)).toBeFocused();
 });
 
 test("a covered run error is not remembered until it is presented", async ({ page }, testInfo) => {

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
-import { completeOnboarding, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
 
-test("a failed run tells the user why instead of going quiet", async ({ page }) => {
+test("a failed run is visible once without returning after reload", async ({ page }, testInfo) => {
   const stamp = Date.now();
   await signup(page, `run-failure-${stamp}@rakazo.test`, "password12", "Run Failure");
   await completeOnboarding(page);
@@ -14,6 +14,19 @@ test("a failed run tells the user why instead of going quiet", async ({ page }) 
   const error = page.getByTestId("composer-error");
   await expect(error).toBeVisible({ timeout: 30_000 });
   await expect(error).not.toBeEmpty();
+  await captureScreenshot(page, testInfo, "new-run-error-visible");
+
+  await page.reload();
+  await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
+  await expect(
+    page.getByTestId("transcript").getByText("fail this run", { exact: true }),
+  ).toBeVisible();
+  await expect(error).toBeHidden();
+  await captureScreenshot(page, testInfo, "seen-run-error-hidden-after-reload");
+
+  await page.getByPlaceholder(/^Message /).fill("fail this run");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(error).toBeVisible({ timeout: 30_000 });
 
   await page.getByTestId("composer-error-dismiss").click();
   await expect(error).toBeHidden();

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -99,4 +99,25 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   await page.reload();
   await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
   await expect(error).toBeHidden();
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.getByPlaceholder(/^Message /).fill("fail this run");
+  const modalSendButton = await page.getByRole("button", { name: "Send" }).elementHandle();
+  if (!modalSendButton) throw new Error("Send button not found");
+  await page.getByTitle("Create").click();
+  await page.getByRole("button", { name: "New space" }).click();
+  const newSpaceDialog = page.getByRole("dialog", { name: "New space" });
+  await expect(newSpaceDialog).toBeVisible();
+  await modalSendButton.evaluate((button) => (button as HTMLButtonElement).click());
+  await expect(error).toContainText("Scripted run failure", { timeout: 30_000 });
+  expect(await isPresented(error)).toBe(false);
+  await expect.poll(() => seenRunErrorCount(page)).toBe(recordedErrorCount + 1);
+
+  await newSpaceDialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(newSpaceDialog).toHaveCount(0);
+  await expect.poll(() => isPresented(error)).toBe(true);
+  await expect.poll(() => seenRunErrorCount(page)).toBe(recordedErrorCount + 2);
+  await page.reload();
+  await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
+  await expect(error).toBeHidden();
 });

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -101,6 +101,8 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   await expect(error).toBeHidden();
 
   await page.setViewportSize({ width: 1280, height: 720 });
+  await expect(page.locator("main")).not.toHaveAttribute("aria-hidden", "true");
+  await expect(page.locator("main")).toHaveJSProperty("inert", false);
   await page.getByPlaceholder(/^Message /).fill("fail this run");
   const modalSendButton = await page.getByRole("button", { name: "Send" }).elementHandle();
   if (!modalSendButton) throw new Error("Send button not found");

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -58,4 +58,28 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   await page.reload();
   await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
   await expect(error).toBeHidden();
+
+  await page.getByPlaceholder(/^Message /).fill("fail this run");
+  const nextSendButton = await page.getByRole("button", { name: "Send" }).elementHandle();
+  if (!nextSendButton) throw new Error("Send button not found");
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  await nextSendButton.evaluate((button) => (button as HTMLButtonElement).click());
+  await expect(error).not.toBeEmpty({ timeout: 30_000 });
+
+  const drawerClosed = page
+    .locator("aside")
+    .first()
+    .evaluate(
+      (drawer) =>
+        new Promise<void>((resolve) => {
+          drawer.addEventListener("transitionend", () => resolve(), { once: true });
+        }),
+    );
+  await page.getByRole("button", { name: "Close navigation" }).click();
+  await drawerClosed;
+  await captureScreenshot(page, testInfo, "covered-run-error-presented-after-drawer-close");
+
+  await page.reload();
+  await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
+  await expect(error).toBeHidden();
 });

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -34,7 +34,7 @@ test("a failed run is visible once without returning after reload", async ({ pag
 
   const error = page.getByTestId("composer-error");
   await expect(error).toBeVisible({ timeout: 30_000 });
-  await expect(error).not.toBeEmpty();
+  await expect(error).toContainText("Scripted run failure");
   await captureScreenshot(page, testInfo, "new-run-error-visible");
 
   await page.reload();
@@ -48,6 +48,7 @@ test("a failed run is visible once without returning after reload", async ({ pag
   await page.getByPlaceholder(/^Message /).fill("fail this run");
   await page.getByRole("button", { name: "Send" }).click();
   await expect(error).toBeVisible({ timeout: 30_000 });
+  await expect(error).toContainText("Scripted run failure");
 
   await page.getByTestId("composer-error-dismiss").click();
   await expect(error).toBeHidden();
@@ -69,7 +70,7 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   await sendButton.evaluate((button) => (button as HTMLButtonElement).click());
 
   const error = page.getByTestId("composer-error");
-  await expect(error).not.toBeEmpty({ timeout: 30_000 });
+  await expect(error).toContainText("Scripted run failure", { timeout: 30_000 });
   expect(await isPresented(error)).toBe(false);
   await captureScreenshot(page, testInfo, "run-error-covered-by-mobile-navigation");
   await page.reload();
@@ -88,7 +89,7 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   if (!nextSendButton) throw new Error("Send button not found");
   await page.getByRole("button", { name: "Open navigation" }).click();
   await nextSendButton.evaluate((button) => (button as HTMLButtonElement).click());
-  await expect(error).not.toBeEmpty({ timeout: 30_000 });
+  await expect(error).toContainText("Scripted run failure", { timeout: 30_000 });
 
   await page.getByRole("button", { name: "Close navigation" }).click();
   await expect.poll(() => isPresented(error)).toBe(true);

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -100,6 +100,8 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
   await expect(error).toBeHidden();
 
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  await expect(page.locator("main")).toHaveJSProperty("inert", true);
   await page.setViewportSize({ width: 1280, height: 720 });
   await expect(page.locator("main")).not.toHaveAttribute("aria-hidden", "true");
   await expect(page.locator("main")).toHaveJSProperty("inert", false);

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -31,3 +31,31 @@ test("a failed run is visible once without returning after reload", async ({ pag
   await page.getByTestId("composer-error-dismiss").click();
   await expect(error).toBeHidden();
 });
+
+test("a covered run error is not remembered until it is presented", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `covered-run-failure-${stamp}@rakazo.test`, "password12", "Covered Failure");
+  await completeOnboarding(page);
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  await page.getByPlaceholder(/^Message /).fill("fail this run");
+  const sendButton = await page.getByRole("button", { name: "Send" }).elementHandle();
+  if (!sendButton) throw new Error("Send button not found");
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  await expect(page.getByRole("button", { name: "Close navigation" })).toBeVisible();
+  await expect(page.locator("main")).toHaveAttribute("aria-hidden", "true");
+  await expect(page.locator("main")).toHaveJSProperty("inert", true);
+  await sendButton.evaluate((button) => (button as HTMLButtonElement).click());
+
+  const error = page.getByTestId("composer-error");
+  await expect(error).not.toBeEmpty({ timeout: 30_000 });
+  await captureScreenshot(page, testInfo, "run-error-covered-by-mobile-navigation");
+  await page.reload();
+  await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
+  await expect(error).toBeVisible();
+  await captureScreenshot(page, testInfo, "covered-run-error-presented-after-reload");
+
+  await page.reload();
+  await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
+  await expect(error).toBeHidden();
+});

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -1,5 +1,16 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Locator, test } from "@playwright/test";
 import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+function isPresented(error: Locator) {
+  return error.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const topElement = document.elementFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2,
+    );
+    return topElement === element || (topElement !== null && element.contains(topElement));
+  });
+}
 
 test("a failed run is visible once without returning after reload", async ({ page }, testInfo) => {
   const stamp = Date.now();
@@ -49,10 +60,12 @@ test("a covered run error is not remembered until it is presented", async ({ pag
 
   const error = page.getByTestId("composer-error");
   await expect(error).not.toBeEmpty({ timeout: 30_000 });
+  expect(await isPresented(error)).toBe(false);
   await captureScreenshot(page, testInfo, "run-error-covered-by-mobile-navigation");
   await page.reload();
   await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
   await expect(error).toBeVisible();
+  expect(await isPresented(error)).toBe(true);
   await captureScreenshot(page, testInfo, "covered-run-error-presented-after-reload");
 
   await page.reload();
@@ -77,6 +90,7 @@ test("a covered run error is not remembered until it is presented", async ({ pag
     );
   await page.getByRole("button", { name: "Close navigation" }).click();
   await drawerClosed;
+  expect(await isPresented(error)).toBe(true);
   await captureScreenshot(page, testInfo, "covered-run-error-presented-after-drawer-close");
 
   await page.reload();

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import { captureScreenshot, completeOnboarding, signup } from "./helpers";
 
 function isPresented(error: Locator) {
@@ -9,6 +9,16 @@ function isPresented(error: Locator) {
       rect.top + rect.height / 2,
     );
     return topElement === element || (topElement !== null && element.contains(topElement));
+  });
+}
+
+function seenRunErrorCount(page: Page) {
+  return page.evaluate(() => {
+    let count = 0;
+    for (let index = 0; index < localStorage.length; index += 1) {
+      if (localStorage.key(index)?.startsWith("rakazo:seen-run-error:")) count += 1;
+    }
+    return count;
   });
 }
 
@@ -72,6 +82,7 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   await expect(page.getByTestId("shell-root")).toHaveAttribute("data-ready", "true");
   await expect(error).toBeHidden();
 
+  const recordedErrorCount = await seenRunErrorCount(page);
   await page.getByPlaceholder(/^Message /).fill("fail this run");
   const nextSendButton = await page.getByRole("button", { name: "Send" }).elementHandle();
   if (!nextSendButton) throw new Error("Send button not found");
@@ -79,18 +90,9 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   await nextSendButton.evaluate((button) => (button as HTMLButtonElement).click());
   await expect(error).not.toBeEmpty({ timeout: 30_000 });
 
-  const drawerClosed = page
-    .locator("aside")
-    .first()
-    .evaluate(
-      (drawer) =>
-        new Promise<void>((resolve) => {
-          drawer.addEventListener("transitionend", () => resolve(), { once: true });
-        }),
-    );
   await page.getByRole("button", { name: "Close navigation" }).click();
-  await drawerClosed;
-  expect(await isPresented(error)).toBe(true);
+  await expect.poll(() => isPresented(error)).toBe(true);
+  await expect.poll(() => seenRunErrorCount(page)).toBe(recordedErrorCount + 1);
   await captureScreenshot(page, testInfo, "covered-run-error-presented-after-drawer-close");
 
   await page.reload();

--- a/apps/web/src/lib/run-error-storage.test.ts
+++ b/apps/web/src/lib/run-error-storage.test.ts
@@ -1,5 +1,5 @@
 import type { ThreadSnapshot } from "@rakazo/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   readSeenRunErrorIds,
   rememberSeenRunErrorId,
@@ -7,10 +7,14 @@ import {
 } from "./run-error-storage";
 import { threadRunError } from "./thread-events";
 
-function storage() {
-  const values = new Map<string, string>();
+function storage(values = new Map<string, string>()) {
   return {
+    get length() {
+      return values.size;
+    },
     getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => [...values.keys()][index] ?? null,
+    removeItem: (key: string) => values.delete(key),
     setItem: (key: string, value: string) => values.set(key, value),
   };
 }
@@ -84,5 +88,41 @@ describe("seen run error storage", () => {
     expect(reloaded).toHaveLength(SEEN_RUN_ERROR_LIMIT);
     expect(reloaded.has("run-0")).toBe(false);
     expect(reloaded.has(`run-${SEEN_RUN_ERROR_LIMIT}`)).toBe(true);
+  });
+
+  it("does not lose an ID when another tab writes from a stale read", () => {
+    const values = new Map<string, string>();
+    const currentTab = storage(values);
+    const staleTab = {
+      get length() {
+        return currentTab.length;
+      },
+      getItem: () => null,
+      key: currentTab.key,
+      removeItem: currentTab.removeItem,
+      setItem: currentTab.setItem,
+    };
+
+    rememberSeenRunErrorId("run-current", currentTab);
+    rememberSeenRunErrorId("run-stale", staleTab);
+
+    expect(readSeenRunErrorIds(currentTab)).toEqual(new Set(["run-current", "run-stale"]));
+  });
+
+  it("retains the ID just seen when stored timestamps tie", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1);
+    const localStorage = storage();
+    try {
+      for (let index = 0; index < SEEN_RUN_ERROR_LIMIT; index += 1) {
+        rememberSeenRunErrorId(`z-run-${index}`, localStorage);
+      }
+      rememberSeenRunErrorId("a-new-run", localStorage);
+
+      const reloaded = readSeenRunErrorIds(localStorage);
+      expect(reloaded).toHaveLength(SEEN_RUN_ERROR_LIMIT);
+      expect(reloaded.has("a-new-run")).toBe(true);
+    } finally {
+      now.mockRestore();
+    }
   });
 });

--- a/apps/web/src/lib/run-error-storage.test.ts
+++ b/apps/web/src/lib/run-error-storage.test.ts
@@ -1,0 +1,88 @@
+import type { ThreadSnapshot } from "@rakazo/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  readSeenRunErrorIds,
+  rememberSeenRunErrorId,
+  SEEN_RUN_ERROR_LIMIT,
+} from "./run-error-storage";
+import { threadRunError } from "./thread-events";
+
+function storage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+}
+
+function failedSnapshot(id: string): ThreadSnapshot {
+  return {
+    botId: "bot-1",
+    threadId: "thread-1",
+    cursor: 1,
+    messages: [],
+    olderCursor: null,
+    run: {
+      id,
+      botId: "bot-1",
+      threadId: "thread-1",
+      taskId: "task-1",
+      status: "failed",
+      trigger: "user",
+      routineId: null,
+      modelProvider: null,
+      modelId: null,
+      error: "connection refused",
+      startedAt: null,
+      completedAt: null,
+      createdAt: "2026-08-31T00:00:00.000Z",
+    },
+  };
+}
+
+describe("seen run error storage", () => {
+  it("keeps the shell usable when browser storage access is blocked", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get: () => {
+        throw new DOMException("blocked", "SecurityError");
+      },
+    });
+
+    try {
+      expect(() => readSeenRunErrorIds()).not.toThrow();
+      expect(() => rememberSeenRunErrorId("run-1")).not.toThrow();
+    } finally {
+      if (descriptor) Object.defineProperty(globalThis, "localStorage", descriptor);
+      else Reflect.deleteProperty(globalThis, "localStorage");
+    }
+  });
+
+  it("shows a new failure once, then suppresses the same stored failure after reload", () => {
+    const localStorage = storage();
+    const failed = failedSnapshot("run-old");
+
+    const firstLoad = readSeenRunErrorIds(localStorage);
+    expect(threadRunError(failed, firstLoad)).toBe("connection refused");
+
+    rememberSeenRunErrorId("run-old", localStorage);
+    expect(threadRunError(failed, firstLoad)).toBe("connection refused");
+
+    const reloaded = readSeenRunErrorIds(localStorage);
+    expect(threadRunError(failed, reloaded)).toBeNull();
+    expect(threadRunError(failedSnapshot("run-new"), reloaded)).toBe("connection refused");
+  });
+
+  it("bounds persisted failures to the newest IDs", () => {
+    const localStorage = storage();
+    for (let index = 0; index <= SEEN_RUN_ERROR_LIMIT; index += 1) {
+      rememberSeenRunErrorId(`run-${index}`, localStorage);
+    }
+
+    const reloaded = readSeenRunErrorIds(localStorage);
+    expect(reloaded).toHaveLength(SEEN_RUN_ERROR_LIMIT);
+    expect(reloaded.has("run-0")).toBe(false);
+    expect(reloaded.has(`run-${SEEN_RUN_ERROR_LIMIT}`)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/run-error-storage.test.ts
+++ b/apps/web/src/lib/run-error-storage.test.ts
@@ -109,6 +109,22 @@ describe("seen run error storage", () => {
     expect(readSeenRunErrorIds(currentTab)).toEqual(new Set(["run-current", "run-stale"]));
   });
 
+  it("does not refresh or prune an ID that is already recorded", () => {
+    const values = new Map<string, string>();
+    for (let index = 0; index < SEEN_RUN_ERROR_LIMIT; index += 1) {
+      values.set(`rakazo:seen-run-error:run-${index}`, String(index + 1));
+    }
+    const currentStorage = storage(values);
+    const setItem = vi.fn(currentStorage.setItem);
+    const removeItem = vi.fn(currentStorage.removeItem);
+
+    rememberSeenRunErrorId("run-0", { ...currentStorage, setItem, removeItem });
+
+    expect(setItem).not.toHaveBeenCalled();
+    expect(removeItem).not.toHaveBeenCalled();
+    expect(readSeenRunErrorIds(currentStorage)).toHaveLength(SEEN_RUN_ERROR_LIMIT);
+  });
+
   it("retains the ID just seen when stored timestamps tie", () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(1);
     const localStorage = storage();

--- a/apps/web/src/lib/run-error-storage.ts
+++ b/apps/web/src/lib/run-error-storage.ts
@@ -1,0 +1,44 @@
+export const SEEN_RUN_ERROR_LIMIT = 100;
+const SEEN_RUN_ERROR_STORAGE_KEY = "rakazo:seen-run-error-ids";
+
+type RunErrorStorage = Pick<Storage, "getItem" | "setItem">;
+
+function browserStorage(): RunErrorStorage | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readSeenRunErrorIds(
+  storage: Pick<RunErrorStorage, "getItem"> | null = browserStorage(),
+): Set<string> {
+  if (!storage) return new Set();
+  try {
+    const value: unknown = JSON.parse(storage.getItem(SEEN_RUN_ERROR_STORAGE_KEY) ?? "[]");
+    return new Set(
+      (Array.isArray(value) ? value : [])
+        .filter((id): id is string => typeof id === "string")
+        .slice(-SEEN_RUN_ERROR_LIMIT),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+export function rememberSeenRunErrorId(
+  id: string,
+  storage: RunErrorStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const ids = [...readSeenRunErrorIds(storage)].filter((candidate) => candidate !== id);
+    storage.setItem(
+      SEEN_RUN_ERROR_STORAGE_KEY,
+      JSON.stringify([...ids, id].slice(-SEEN_RUN_ERROR_LIMIT)),
+    );
+  } catch {
+    // Keep the current-session error behavior when storage is unavailable.
+  }
+}

--- a/apps/web/src/lib/run-error-storage.ts
+++ b/apps/web/src/lib/run-error-storage.ts
@@ -1,7 +1,7 @@
 export const SEEN_RUN_ERROR_LIMIT = 100;
-const SEEN_RUN_ERROR_STORAGE_KEY = "rakazo:seen-run-error-ids";
+const SEEN_RUN_ERROR_STORAGE_KEY_PREFIX = "rakazo:seen-run-error:";
 
-type RunErrorStorage = Pick<Storage, "getItem" | "setItem">;
+type RunErrorStorage = Pick<Storage, "getItem" | "key" | "length" | "removeItem" | "setItem">;
 
 function browserStorage(): RunErrorStorage | null {
   try {
@@ -12,16 +12,18 @@ function browserStorage(): RunErrorStorage | null {
 }
 
 export function readSeenRunErrorIds(
-  storage: Pick<RunErrorStorage, "getItem"> | null = browserStorage(),
+  storage: RunErrorStorage | null = browserStorage(),
 ): Set<string> {
   if (!storage) return new Set();
   try {
-    const value: unknown = JSON.parse(storage.getItem(SEEN_RUN_ERROR_STORAGE_KEY) ?? "[]");
-    return new Set(
-      (Array.isArray(value) ? value : [])
-        .filter((id): id is string => typeof id === "string")
-        .slice(-SEEN_RUN_ERROR_LIMIT),
-    );
+    const ids = new Set<string>();
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key?.startsWith(SEEN_RUN_ERROR_STORAGE_KEY_PREFIX)) {
+        ids.add(key.slice(SEEN_RUN_ERROR_STORAGE_KEY_PREFIX.length));
+      }
+    }
+    return ids;
   } catch {
     return new Set();
   }
@@ -33,11 +35,25 @@ export function rememberSeenRunErrorId(
 ): void {
   if (!storage) return;
   try {
-    const ids = [...readSeenRunErrorIds(storage)].filter((candidate) => candidate !== id);
-    storage.setItem(
-      SEEN_RUN_ERROR_STORAGE_KEY,
-      JSON.stringify([...ids, id].slice(-SEEN_RUN_ERROR_LIMIT)),
-    );
+    const currentKey = `${SEEN_RUN_ERROR_STORAGE_KEY_PREFIX}${id}`;
+    const entries: Array<{ key: string; seenAt: number }> = [];
+    let newestSeenAt = 0;
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key?.startsWith(SEEN_RUN_ERROR_STORAGE_KEY_PREFIX)) {
+        const storedSeenAt = Number(storage.getItem(key));
+        const seenAt = Number.isFinite(storedSeenAt) ? storedSeenAt : 0;
+        entries.push({ key, seenAt });
+        newestSeenAt = Math.max(newestSeenAt, seenAt);
+      }
+    }
+    const seenAt = Math.max(Date.now(), newestSeenAt + 1);
+    storage.setItem(currentKey, String(seenAt));
+    const currentEntry = entries.find((entry) => entry.key === currentKey);
+    if (currentEntry) currentEntry.seenAt = seenAt;
+    else entries.push({ key: currentKey, seenAt });
+    entries.sort((left, right) => right.seenAt - left.seenAt || right.key.localeCompare(left.key));
+    for (const { key } of entries.slice(SEEN_RUN_ERROR_LIMIT)) storage.removeItem(key);
   } catch {
     // Keep the current-session error behavior when storage is unavailable.
   }

--- a/apps/web/src/lib/run-error-storage.ts
+++ b/apps/web/src/lib/run-error-storage.ts
@@ -36,6 +36,7 @@ export function rememberSeenRunErrorId(
   if (!storage) return;
   try {
     const currentKey = `${SEEN_RUN_ERROR_STORAGE_KEY_PREFIX}${id}`;
+    if (storage.getItem(currentKey) !== null) return;
     const entries: Array<{ key: string; seenAt: number }> = [];
     let newestSeenAt = 0;
     for (let index = 0; index < storage.length; index += 1) {
@@ -49,9 +50,7 @@ export function rememberSeenRunErrorId(
     }
     const seenAt = Math.max(Date.now(), newestSeenAt + 1);
     storage.setItem(currentKey, String(seenAt));
-    const currentEntry = entries.find((entry) => entry.key === currentKey);
-    if (currentEntry) currentEntry.seenAt = seenAt;
-    else entries.push({ key: currentKey, seenAt });
+    entries.push({ key: currentKey, seenAt });
     entries.sort((left, right) => right.seenAt - left.seenAt || right.key.localeCompare(left.key));
     for (const { key } of entries.slice(SEEN_RUN_ERROR_LIMIT)) storage.removeItem(key);
   } catch {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -147,6 +147,7 @@ import { providerLabel } from "../lib/messaging";
 import { isFileDrag, revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
 import { clearSpaceSelection, rpc, selectedSpaceId, selectSpace } from "../lib/rpc";
+import { readSeenRunErrorIds, rememberSeenRunErrorId } from "../lib/run-error-storage";
 import {
   activeThreadRuns,
   clearActiveThreadRuns,
@@ -396,9 +397,8 @@ export function ShellPage() {
   const [speakingMessageId, setSpeakingMessageId] = useState<string | null>(null);
   const [dictating, setDictating] = useState(false);
   const [dictationError, setDictationError] = useState<string | null>(null);
-  const [dismissedRunErrorIds, setDismissedRunErrorIds] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
+  const [dismissedRunErrorIds, setDismissedRunErrorIds] =
+    useState<ReadonlySet<string>>(readSeenRunErrorIds);
   const [menuOpen, setMenuOpen] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [draggedBotId, setDraggedBotId] = useState<string | null>(null);
@@ -1613,6 +1613,11 @@ export function ShellPage() {
   const transcriptRunning = workingRuns.length > 0;
   const composerRunning = currentRuns.some((run) => isActive(run.status));
   const runError = threadRunError(activeSnapshot, dismissedRunErrorIds);
+  const displayedRunError = !sendError && !dictationError ? runError : null;
+  useEffect(() => {
+    const failedRunId = displayedRunError ? activeSnapshot?.run?.id : null;
+    if (failedRunId) rememberSeenRunErrorId(failedRunId);
+  }, [activeSnapshot?.run?.id, displayedRunError]);
   const transcriptMessages = useMemo(
     () => userVisibleMessages(activeSnapshot?.messages ?? [], { includePeerReceipts: true }),
     [activeSnapshot?.messages],
@@ -2273,10 +2278,13 @@ export function ShellPage() {
   function dismissComposerError() {
     // The strip shows one message at a time, so only dismiss the run failure when it is the
     // one on screen; otherwise a live run would be silenced before it has even failed.
-    const failedRunId = !sendError && !dictationError && runError ? activeSnapshot?.run?.id : null;
+    const failedRunId = displayedRunError ? activeSnapshot?.run?.id : null;
     setSendError(null);
     setDictationError(null);
-    if (failedRunId) setDismissedRunErrorIds((current) => new Set(current).add(failedRunId));
+    if (failedRunId) {
+      rememberSeenRunErrorId(failedRunId);
+      setDismissedRunErrorIds((current) => new Set(current).add(failedRunId));
+    }
   }
 
   const embeddedScreenUrl = embeddableScreenUrl(screenUrl);
@@ -2938,7 +2946,7 @@ export function ShellPage() {
           attachmentNotice={attachmentNotice}
           sendError={sendError}
           dictationError={dictationError}
-          runError={runError}
+          runError={displayedRunError}
           onDismissError={dismissComposerError}
           sending={sending}
           fileInputRef={fileInputRef}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4423,7 +4423,10 @@ const Composer = memo(function Composer({
             type="button"
             aria-label={t`Dismiss error`}
             data-testid="composer-error-dismiss"
-            onClick={onDismissError}
+            onClick={() => {
+              onDismissError();
+              window.requestAnimationFrame(() => textareaRef.current?.focus());
+            }}
             className="shrink-0 text-[#F1A8A8] hover:text-[#ECECEE]"
           >
             <X size={13} strokeWidth={2} />

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4195,10 +4195,13 @@ const Composer = memo(function Composer({
       });
     }
     recordIfPresented();
+    const observer = new MutationObserver(recordIfPresented);
+    observer.observe(document.body, { childList: true, subtree: true });
     document.addEventListener("transitionend", recordIfPresented);
     document.addEventListener("visibilitychange", recordIfPresented);
     return () => {
       cancelAnimationFrame(frame);
+      observer.disconnect();
       document.removeEventListener("transitionend", recordIfPresented);
       document.removeEventListener("visibilitychange", recordIfPresented);
     };

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -404,6 +404,16 @@ export function ShellPage() {
   const [draggedBotId, setDraggedBotId] = useState<string | null>(null);
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
   const [newSpaceOpen, setNewSpaceOpen] = useState(false);
+
+  useEffect(() => {
+    const desktop = window.matchMedia("(min-width: 768px)");
+    function closeMobileSidebar() {
+      if (desktop.matches) setMobileSidebarOpen(false);
+    }
+    closeMobileSidebar();
+    desktop.addEventListener("change", closeMobileSidebar);
+    return () => desktop.removeEventListener("change", closeMobileSidebar);
+  }, []);
   const [activityMode, setActivityMode] = useState(readActivityMode);
   const toggleActivityMode = useCallback(() => {
     setActivityMode((on) => {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1614,6 +1614,10 @@ export function ShellPage() {
   const composerRunning = currentRuns.some((run) => isActive(run.status));
   const runError = threadRunError(activeSnapshot, dismissedRunErrorIds);
   const displayedRunError = !sendError && !dictationError ? runError : null;
+  const displayedRunErrorId = displayedRunError ? (activeSnapshot?.run?.id ?? null) : null;
+  const handleRunErrorPresented = useCallback((runId: string) => {
+    rememberSeenRunErrorId(runId);
+  }, []);
   const transcriptMessages = useMemo(
     () => userVisibleMessages(activeSnapshot?.messages ?? [], { includePeerReceipts: true }),
     [activeSnapshot?.messages],
@@ -2274,7 +2278,7 @@ export function ShellPage() {
   function dismissComposerError() {
     // The strip shows one message at a time, so only dismiss the run failure when it is the
     // one on screen; otherwise a live run would be silenced before it has even failed.
-    const failedRunId = displayedRunError ? activeSnapshot?.run?.id : null;
+    const failedRunId = displayedRunErrorId;
     setSendError(null);
     setDictationError(null);
     if (failedRunId) {
@@ -2947,10 +2951,8 @@ export function ShellPage() {
           sendError={sendError}
           dictationError={dictationError}
           runError={displayedRunError}
-          onRunErrorPresented={() => {
-            const failedRunId = displayedRunError ? activeSnapshot?.run?.id : null;
-            if (failedRunId) rememberSeenRunErrorId(failedRunId);
-          }}
+          runErrorId={displayedRunErrorId}
+          onRunErrorPresented={handleRunErrorPresented}
           onDismissError={dismissComposerError}
           sending={sending}
           fileInputRef={fileInputRef}
@@ -4102,6 +4104,7 @@ const Composer = memo(function Composer({
   sendError,
   dictationError,
   runError,
+  runErrorId,
   onRunErrorPresented,
   onDismissError,
   sending,
@@ -4130,7 +4133,8 @@ const Composer = memo(function Composer({
   sendError: string | null;
   dictationError: string | null;
   runError: string | null;
-  onRunErrorPresented: () => void;
+  runErrorId: string | null;
+  onRunErrorPresented: (runId: string) => void;
   onDismissError: () => void;
   sending: boolean;
   fileInputRef: RefObject<HTMLInputElement | null>;
@@ -4159,6 +4163,7 @@ const Composer = memo(function Composer({
   const [selectedMentions, setSelectedMentions] = useState<ComposerMention[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const runErrorRef = useRef<HTMLDivElement>(null);
+  const presentedRunErrorIdRef = useRef<string | null>(null);
   const mentionListboxId = useId();
   const dragDepth = useRef(0);
   const [draggingFiles, setDraggingFiles] = useState(false);
@@ -4169,7 +4174,8 @@ const Composer = memo(function Composer({
     pendingAttachments.length > 0;
 
   useEffect(() => {
-    if (!runError) return;
+    if (!runError || !runErrorId) return;
+    const currentRunErrorId = runErrorId;
     let frame = 0;
     function recordIfPresented() {
       cancelAnimationFrame(frame);
@@ -4182,7 +4188,9 @@ const Composer = memo(function Composer({
           rect.top + rect.height / 2,
         );
         if (topElement && (topElement === element || element.contains(topElement))) {
-          onRunErrorPresented();
+          if (presentedRunErrorIdRef.current === currentRunErrorId) return;
+          presentedRunErrorIdRef.current = currentRunErrorId;
+          onRunErrorPresented(currentRunErrorId);
         }
       });
     }
@@ -4194,7 +4202,7 @@ const Composer = memo(function Composer({
       document.removeEventListener("transitionend", recordIfPresented);
       document.removeEventListener("visibilitychange", recordIfPresented);
     };
-  }, [onRunErrorPresented, runError]);
+  }, [onRunErrorPresented, runError, runErrorId]);
 
   useLayoutEffect(() => {
     const el = textareaRef.current;

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1614,10 +1614,6 @@ export function ShellPage() {
   const composerRunning = currentRuns.some((run) => isActive(run.status));
   const runError = threadRunError(activeSnapshot, dismissedRunErrorIds);
   const displayedRunError = !sendError && !dictationError ? runError : null;
-  useEffect(() => {
-    const failedRunId = displayedRunError ? activeSnapshot?.run?.id : null;
-    if (failedRunId) rememberSeenRunErrorId(failedRunId);
-  }, [activeSnapshot?.run?.id, displayedRunError]);
   const transcriptMessages = useMemo(
     () => userVisibleMessages(activeSnapshot?.messages ?? [], { includePeerReceipts: true }),
     [activeSnapshot?.messages],
@@ -2826,7 +2822,11 @@ export function ShellPage() {
         </div>
       </aside>
 
-      <main className="flex min-w-0 flex-1 flex-col bg-[#0D0D0E]">
+      <main
+        aria-hidden={mobileSidebarOpen || undefined}
+        inert={mobileSidebarOpen}
+        className="flex min-w-0 flex-1 flex-col bg-[#0D0D0E]"
+      >
         <div className="app-drag flex items-center justify-between border-b border-[#141416] px-3 py-[17px] md:px-[22px]">
           <div className="flex min-w-0 items-center gap-2">
             <button
@@ -2947,6 +2947,10 @@ export function ShellPage() {
           sendError={sendError}
           dictationError={dictationError}
           runError={displayedRunError}
+          onRunErrorPresented={() => {
+            const failedRunId = displayedRunError ? activeSnapshot?.run?.id : null;
+            if (failedRunId) rememberSeenRunErrorId(failedRunId);
+          }}
           onDismissError={dismissComposerError}
           sending={sending}
           fileInputRef={fileInputRef}
@@ -4098,6 +4102,7 @@ const Composer = memo(function Composer({
   sendError,
   dictationError,
   runError,
+  onRunErrorPresented,
   onDismissError,
   sending,
   fileInputRef,
@@ -4125,6 +4130,7 @@ const Composer = memo(function Composer({
   sendError: string | null;
   dictationError: string | null;
   runError: string | null;
+  onRunErrorPresented: () => void;
   onDismissError: () => void;
   sending: boolean;
   fileInputRef: RefObject<HTMLInputElement | null>;
@@ -4152,6 +4158,7 @@ const Composer = memo(function Composer({
   const [selectedSkill, setSelectedSkill] = useState<AgentSkillCatalogEntry | null>(null);
   const [selectedMentions, setSelectedMentions] = useState<ComposerMention[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const runErrorRef = useRef<HTMLDivElement>(null);
   const mentionListboxId = useId();
   const dragDepth = useRef(0);
   const [draggingFiles, setDraggingFiles] = useState(false);
@@ -4160,6 +4167,32 @@ const Composer = memo(function Composer({
     selectedSkill !== null ||
     selectedMentions.length > 0 ||
     pendingAttachments.length > 0;
+
+  useEffect(() => {
+    if (!runError) return;
+    let frame = 0;
+    function recordIfPresented() {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const element = runErrorRef.current;
+        if (!element || document.visibilityState !== "visible") return;
+        const rect = element.getBoundingClientRect();
+        const topElement = document.elementFromPoint(
+          rect.left + rect.width / 2,
+          rect.top + rect.height / 2,
+        );
+        if (topElement && (topElement === element || element.contains(topElement))) {
+          onRunErrorPresented();
+        }
+      });
+    }
+    recordIfPresented();
+    document.addEventListener("visibilitychange", recordIfPresented);
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("visibilitychange", recordIfPresented);
+    };
+  }, [onRunErrorPresented, runError]);
 
   useLayoutEffect(() => {
     const el = textareaRef.current;
@@ -4357,6 +4390,7 @@ const Composer = memo(function Composer({
     >
       {sendError || dictationError || runError ? (
         <div
+          ref={runErrorRef}
           role="alert"
           data-testid="composer-error"
           className="mb-3 flex items-center gap-2 rounded-[14px] border border-[#5A2A2A] bg-[#2A1717] px-4 py-2 text-[13px] text-[#F1A8A8]"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4187,9 +4187,11 @@ const Composer = memo(function Composer({
       });
     }
     recordIfPresented();
+    document.addEventListener("transitionend", recordIfPresented);
     document.addEventListener("visibilitychange", recordIfPresented);
     return () => {
       cancelAnimationFrame(frame);
+      document.removeEventListener("transitionend", recordIfPresented);
       document.removeEventListener("visibilitychange", recordIfPresented);
     };
   }, [onRunErrorPresented, runError]);


### PR DESCRIPTION
## Summary

- persist IDs of run failures once they have actually been presented or dismissed, reusing browser `localStorage`
- keep a newly occurring failure visible for the current session while suppressing that same stored failure after reload/relaunch
- use independent, idempotent per-run keys so concurrent tabs cannot overwrite or refresh an ID into a stale-pruning race; bound retention to 100 entries
- avoid marking alerts hidden behind mobile navigation as seen, and make covered main content inert to pointer, keyboard, and assistive technology
- keep presentation callbacks stable and extend the run-failure journey with explicit hit-test and persistence oracles

## Root cause

`threads.get` intentionally returns the latest failed run so a failed turn remains explainable. On startup/reload, `ShellPage` fed that stored snapshot into `threadRunError`, but its dismissed-run IDs existed only in React state. Therefore the same historical failure became visible again on every reload, including in Electron because it hosts the same web UI.

This does not change API persistence or terminal-run semantics. A new run ID still produces the alert immediately. Once the alert has actually been presented, its ID is remembered without hiding it in the current session; the persisted ID only suppresses it on a later load (or immediately when the user dismisses it).

## Regression proof

On untouched base `826650cfbbf1760019768eadbeca81f6b3890dd9`, the strengthened E2E fails after the transcript fully reloads:

```text
expect(getByTestId('composer-error')).toBeHidden()
Expected: hidden
Received: visible
```

Additional regressions prove:

- stale same-origin tab writes cannot discard another tab's seen ID
- existing IDs are idempotent and do not rewrite timestamps or trigger pruning
- equal timestamps or a backward clock cannot evict the ID just recorded
- an error covered by mobile navigation is not center-hit-test presented, while uncovered errors are
- presentation persistence completes before the post-transition reload assertion
- covered main content is `inert` and `aria-hidden`

## Verification

Exact local/fork/PR head: `a7ab3a9185a43820d45daf50b3c42fe9594aa97d`

- `pnpm exec vitest run apps/web/src/lib/run-error-storage.test.ts apps/web/src/lib/thread-events.test.ts apps/api/src/thread-target.test.ts` — 72 passed
- `pnpm test:e2e -- --spec=run-failure.spec.ts` — 2 passed; transition path also passed three consecutive stability runs before the final storage-only change
- `pnpm test` — 2,149 passed, 103 skipped
- `pnpm lint` — passed (2 pre-existing informational `useLiteralKeys` diagnostics)
- `pnpm check` — 20/20 tasks passed
- `pnpm build` — 4/4 tasks passed
- `pnpm format` — passed
- exact-head GitHub CI — all applicable checks passed

## Review status

- Greptile reviewed exact head `a7ab3a9185a43820d45daf50b3c42fe9594aa97d`: 5/5, safe to merge, no blockers
- CodeRabbit reviewed exact final delta `96c681b32ac7d2d444228071bc14906e2ea96c46..a7ab3a9185a43820d45daf50b3c42fe9594aa97d` with no actionable comments
- unresolved review threads: 0
- PR intentionally remains draft and unmerged

## Visual evidence

Exact-head Playwright captures were inspected at desktop and mobile sizes:

- `new-run-error-visible` — new failure fully visible
- `seen-run-error-hidden-after-reload` — transcript retained, historical banner absent
- `run-error-covered-by-mobile-navigation` — technical error not meaningfully visible behind the drawer
- `covered-run-error-presented-after-reload` — previously covered error fully visible after reload
- `covered-run-error-presented-after-drawer-close` — new failure fully visible after the drawer transition

Local exact-head evidence: `/tmp/rakazo-stale-run-error-a7ab3a9185a43820d45daf50b3c42fe9594aa97d/`

Exact-head CI screenshot gallery: https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/449/index.html

## Upstream refusal

The original proxy refusal was not independently reproduced. Both supplied screenshots show a fully loaded app and transcript with the refusal rendered as a run-error banner, supporting the stale-presentation diagnosis but not identifying which upstream endpoint refused the original connection.

This PR only fixes stale presentation. A separate issue is warranted if a newly submitted run reproduces the refusal after this change, with provider/gateway request logs attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed-run messages remain visible after reload without repeatedly reappearing.
  * Errors covered by navigation or dialogs are marked as seen only after becoming visible.
  * Run-error history is more reliable across reloads and browser storage limitations.
  * Covered main content is handled correctly when navigation or dialogs are open.
  * Mobile navigation closes automatically when switching to a desktop layout.
  * Dismissing a run error restores focus to the message composer.
  * Channel messages now display the correct provider label.

* **Tests**
  * Added coverage for error visibility, reload behavior, covered messages, storage retention, and browser storage failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->