### PR TITLE
Don't fail every turn on an MCP tool enum TypeBox can't express

### DIFF
--- a/packages/adapters/src/pi-runtime-tool-schema.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { jsonSchemaParameters } from "./pi-runtime.js";
+
+describe("jsonSchemaParameters", () => {
+  it("keeps primitive enums as literal unions", () => {
+    const schema = jsonSchemaParameters({
+      type: "object",
+      properties: { mode: { type: "string", enum: ["fast", "slow"] } },
+      required: ["mode"],
+    }) as unknown as { properties: { mode: { anyOf: { const: unknown }[] } } };
+    expect(schema.properties.mode.anyOf.map((member) => member.const)).toEqual(["fast", "slow"]);
+  });
+
+  it("accepts a nullable enum without throwing", () => {
+    expect(() =>
+      jsonSchemaParameters({
+        type: "object",
+        properties: { cursor: { type: ["string", "null"], enum: ["a", "b", null] } },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts enums whose members are objects or arrays", () => {
+    expect(() =>
+      jsonSchemaParameters({
+        type: "object",
+        properties: { filter: { type: "object", enum: [{ kind: "all" }, ["x"]] } },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -748,6 +748,21 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
 }
 
 function parametersFor(tool: ConnectorTool) {
+  return builtinParameters(tool) ?? safeJsonSchemaParameters(tool);
+}
+
+/** A remote MCP server controls its own schemas, so a shape TypeBox cannot express must
+ * degrade to a permissive object instead of failing every turn for the whole bot. */
+function safeJsonSchemaParameters(tool: ConnectorTool) {
+  try {
+    return jsonSchemaParameters(tool.inputSchema);
+  } catch (error) {
+    console.error(`unsupported input schema for tool ${tool.name}`, error);
+    return Type.Object({});
+  }
+}
+
+function builtinParameters(tool: ConnectorTool) {
   if (tool.name === "write_file") {
     return Type.Object({ path: Type.String(), content: Type.String() });
   }
@@ -801,7 +816,7 @@ function parametersFor(tool: ConnectorTool) {
       bot_id: Type.Optional(Type.String()),
     });
   }
-  return jsonSchemaParameters(tool.inputSchema);
+  return undefined;
 }
 
 /** Keep recent visual state without repeatedly resending every earlier full screenshot. */
@@ -864,7 +879,7 @@ function isAgentToolExecutionResult(result: unknown): result is AgentToolExecuti
   );
 }
 
-function jsonSchemaParameters(schema: Record<string, unknown>) {
+export function jsonSchemaParameters(schema: Record<string, unknown>) {
   const properties = (schema.properties ?? {}) as Record<string, unknown>;
   const required = new Set(Array.isArray(schema.required) ? schema.required.map(String) : []);
   const fields: Record<string, ReturnType<typeof Type.Optional>> = {};
@@ -877,10 +892,24 @@ function jsonSchemaParameters(schema: Record<string, unknown>) {
   return Type.Object(fields);
 }
 
+/** TypeBox only builds literals from primitives; anything else throws while the tool list is
+ * being assembled, which would take down the whole turn. */
+function enumUnion(values: readonly unknown[]) {
+  const members = values.map((value) =>
+    value === null
+      ? Type.Null()
+      : typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+        ? Type.Literal(value)
+        : undefined,
+  );
+  return members.every((member) => member !== undefined) ? Type.Union(members) : undefined;
+}
+
 function jsonField(spec: unknown): ReturnType<typeof Type.String> {
   const definition = spec && typeof spec === "object" ? (spec as Record<string, unknown>) : {};
   if (Array.isArray(definition.enum) && definition.enum.length > 0) {
-    return Type.Union(definition.enum.map((value) => Type.Literal(value))) as never;
+    const union = enumUnion(definition.enum);
+    if (union) return union as never;
   }
   const type = "type" in definition ? String(definition.type) : "string";
   if (type === "number" || type === "integer") return Type.Number() as never;


### PR DESCRIPTION
## Problem

`jsonField` builds a TypeBox union from a tool's JSON Schema `enum` by mapping every member through `Type.Literal`:

```ts
if (Array.isArray(definition.enum) && definition.enum.length > 0) {
  return Type.Union(definition.enum.map((value) => Type.Literal(value))) as never;
}
```

`Type.Literal()` only accepts `string | number | boolean | bigint`. Anything else throws a bare `Invalid Literal value`:

```
[null]      -> THROWS: Invalid Literal value
["a",null]  -> THROWS: Invalid Literal value
[{"a":1}]   -> THROWS: Invalid Literal value
["a","b"]   -> ok
```

`enum: ["a", "b", null]` is ordinary JSON Schema for a nullable enum, and remote tool schemas reach this code unvalidated — `mcp-connector.ts` passes `tool.inputSchema` straight through from the server.

The failure is worse than a broken tool. `parametersFor` runs inside `toAgentTools`, **before** the agent starts, so a single unrepresentable schema on a single tool aborts the entire turn. The symptom is confusing: the MCP connection card still reports "Connected", and then every message to that bot fails with `Invalid Literal value` and no indication of which server or tool caused it. It affects the default configuration (`AGENT_RUNTIME` defaults to `pi`) and is unrelated to deployment topology.

## Fix

1. **`enumUnion`** maps `null` to `Type.Null()`, keeps `Type.Literal` for primitives, and returns `undefined` for members TypeBox cannot express so `jsonField` falls through to its existing type-based inference instead of throwing.

2. **`safeJsonSchemaParameters`** wraps the conversion. A third-party server should not be able to take down every turn for a bot, so an unrepresentable schema now logs the offending tool name and degrades to a permissive object. `parametersFor` splits into `builtinParameters` + the guarded JSON Schema path; the built-in branches are unchanged.

The log line also makes this diagnosable — the current failure gives you no way to tell which tool is responsible.

## Tests

New `pi-runtime-tool-schema.test.ts` covers primitive enums (unchanged behavior), nullable enums, and object/array members. All three fail on `main` and pass here.

`pnpm test` (2145 passed), `pnpm check`, and `biome check` are clean.

## Note

I hit this against a remote MCP server whose tools would not load. I confirmed the code path throws on valid JSON Schema, which the tests demonstrate directly, but I could not capture that specific server's schema to confirm it as the trigger — its OAuth grant had expired by the time I had the diagnostic logging in place. The fix stands on the schema handling itself rather than on that anecdote.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool input schemas, including nullable and complex enum values.
  * Prevented unsupported schemas from interrupting tool processing by safely falling back to an empty parameter definition.
  * Preserved built-in parameter definitions when available.

* **Tests**
  * Added coverage for string, nullable, object, and array enum scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->