### PR TITLE
feat(chat): deliver steering messages while bots work

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1150,7 +1150,6 @@ export function createRouter(deps: RouterDeps) {
             blocks: [{ kind: "text", text: input.text }],
             prompt: input.text,
             trigger: "follow_up",
-            onlyIfIdle: true,
           });
           if (sent.runId) {
             await deps.jobs.enqueue(runContinueJob(sent.runId)).catch((error) => {
@@ -1180,7 +1179,8 @@ export function createRouter(deps: RouterDeps) {
           const active = await tx.run.findFirst({
             where: {
               threadId: target.threadId,
-              status: { in: ["running", "queued", "leased"] },
+              botId,
+              status: { in: [...ACTIVE_RUN_STATUSES] },
             },
             select: { id: true },
           });
@@ -1210,6 +1210,10 @@ export function createRouter(deps: RouterDeps) {
               select: { id: true },
             });
             await tx.message.update({ where: { id: message.id }, data: { runId: run.id } });
+          } else {
+            await tx.steeringMessage.create({
+              data: { messageId: message.id, botId, userId: context.actor.userId },
+            });
           }
           const event = await appendEventInTransaction(tx, {
             spaceId: context.actor.spaceId,

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1151,7 +1151,7 @@ export function createRouter(deps: RouterDeps) {
             prompt: input.text,
             trigger: "follow_up",
           });
-          if (sent.runId) {
+          if (sent.taskId && sent.runId) {
             await deps.jobs.enqueue(runContinueJob(sent.runId)).catch((error) => {
               console.error("follow-up enqueue", error);
             });
@@ -1212,15 +1212,21 @@ export function createRouter(deps: RouterDeps) {
             await tx.message.update({ where: { id: message.id }, data: { runId: run.id } });
           } else {
             await tx.steeringMessage.create({
-              data: { messageId: message.id, botId, userId: context.actor.userId },
+              data: {
+                messageId: message.id,
+                botId,
+                userId: context.actor.userId,
+                runId: active.id,
+              },
             });
+            await tx.message.update({ where: { id: message.id }, data: { runId: active.id } });
           }
           const event = await appendEventInTransaction(tx, {
             spaceId: context.actor.spaceId,
             threadId: target.threadId,
             botId,
             type: "thread.message.created",
-            runId: run?.id,
+            runId: run?.id ?? active?.id,
             payload: { messageId: message.id, role: "user", blocks },
           });
           await touchGroupUpdatedAt(tx, target.groupId);

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -689,7 +689,8 @@ function groupTarget() {
 describe("stopThreadRuns", () => {
   it("releases every active group member screen immediately", async () => {
     const releaseScreen = vi.fn().mockResolvedValue(undefined);
-    const prisma = {
+    const transaction = {
+      $queryRaw: vi.fn(),
       run: {
         findMany: vi.fn().mockResolvedValue([
           { id: "run-a", botId: "bot-a" },
@@ -697,6 +698,12 @@ describe("stopThreadRuns", () => {
         ]),
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
       },
+      steeringMessage: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof transaction) => unknown) =>
+        callback(transaction),
+      ),
       computer: {
         findMany: vi.fn().mockResolvedValue([
           {

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -139,8 +139,35 @@ async function replayExistingSend(
 ) {
   if (!clientNonce) return null;
   const message = await findSendReceipt(deps.prisma, threadId, clientNonce);
-  if (!message || message.sourceRuns.length === 0) return null;
-  await enqueueRunsNeedingContinue(deps.jobs, message.sourceRuns);
+  if (!message) return null;
+  const receiptEvent = await deps.prisma.event.findFirst({
+    where: {
+      threadId,
+      type: "thread.message.created",
+      payload: { path: ["messageId"], equals: message.id },
+    },
+    orderBy: { seq: "desc" },
+    select: { payload: true },
+  });
+  const receiptRunIds = sendEventRunIds(receiptEvent?.payload);
+  const receiptRuns = receiptRunIds.length
+    ? await deps.prisma.run.findMany({ where: { id: { in: receiptRunIds } } })
+    : [];
+  const receiptRunById = new Map(receiptRuns.map((run) => [run.id, run]));
+  const orderedReceiptRuns = receiptRunIds.flatMap((id) => {
+    const run = receiptRunById.get(id);
+    return run ? [run] : [];
+  });
+  const linkedRun =
+    message.sourceRuns[0] ??
+    (message.runId ? await deps.prisma.run.findUnique({ where: { id: message.runId } }) : null);
+  if (!linkedRun && orderedReceiptRuns.length === 0) return null;
+  const runs = orderedReceiptRuns.length
+    ? orderedReceiptRuns
+    : message.sourceRuns.length
+      ? message.sourceRuns
+      : [linkedRun!];
+  await enqueueRunsNeedingContinue(deps.jobs, runs);
   const latestEvent = await deps.prisma.event.findFirst({
     where: { threadId },
     orderBy: { seq: "desc" },
@@ -152,7 +179,13 @@ async function replayExistingSend(
       console.error("thread send realtime notification", error);
     });
   }
-  return sendResult(message, message.sourceRuns);
+  return sendResult(message, runs);
+}
+
+function sendEventRunIds(payload: Prisma.JsonValue | undefined): string[] {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return [];
+  const runIds = (payload as { runIds?: unknown }).runIds;
+  return Array.isArray(runIds) ? runIds.filter((id): id is string => typeof id === "string") : [];
 }
 
 function sendResult(message: { seq: number }, runs: Array<{ id: string; taskId: string }>) {
@@ -516,6 +549,39 @@ export async function sendThreadMessage(
           replyToMessageId: input.replyToMessageId,
           clientNonce: input.clientNonce,
         });
+        const active = await tx.run.findFirst({
+          where: {
+            threadId: target.threadId,
+            botId: target.botId,
+            status: { in: [...ACTIVE_RUN_STATUSES] },
+          },
+          select: { id: true, taskId: true, status: true },
+        });
+        if (active) {
+          await tx.steeringMessage.create({
+            data: {
+              messageId: message.id,
+              botId: target.botId,
+              userId: actor.userId,
+              runId: active.id,
+            },
+          });
+          await tx.message.update({ where: { id: message.id }, data: { runId: active.id } });
+          const event = await appendEventInTransaction(tx, {
+            spaceId: actor.spaceId,
+            threadId: target.threadId,
+            botId: target.botId,
+            type: "thread.message.created",
+            runId: active.id,
+            payload: {
+              messageId: message.id,
+              role: "user",
+              blocks,
+              replyToMessageId: input.replyToMessageId,
+            },
+          });
+          return { message, runs: [active], eventSeq: event.seq };
+        }
         const task = await tx.task.create({
           data: {
             spaceId: actor.spaceId,
@@ -555,6 +621,7 @@ export async function sendThreadMessage(
             messageId: message.id,
             role: "user",
             blocks,
+            runIds: [run.id],
             replyToMessageId: input.replyToMessageId,
           },
         });
@@ -589,8 +656,25 @@ export async function sendThreadMessage(
         replyToMessageId: input.replyToMessageId,
         clientNonce: input.clientNonce,
       });
+      const activeRuns = await tx.run.findMany({
+        where: {
+          threadId: target.threadId,
+          botId: { in: targetBotIds },
+          status: { in: [...ACTIVE_RUN_STATUSES] },
+        },
+        select: { id: true, taskId: true, botId: true, status: true },
+      });
+      const activeByBotId = new Map(activeRuns.map((run) => [run.botId, run]));
       const runs: Array<{ id: string; taskId: string; botId: string; status: string }> = [];
       for (const botId of targetBotIds) {
+        const active = activeByBotId.get(botId);
+        if (active) {
+          await tx.steeringMessage.create({
+            data: { messageId: message.id, botId, userId: actor.userId, runId: active.id },
+          });
+          runs.push(active);
+          continue;
+        }
         const task = await tx.task.create({
           data: {
             spaceId: actor.spaceId,
@@ -617,24 +701,31 @@ export async function sendThreadMessage(
         runs.push(run);
       }
       const firstRun = runs[0];
-      if (!firstRun) throw new IsolationError("Group send did not resolve a target");
-      await tx.message.update({ where: { id: message.id }, data: { runId: firstRun.id } });
-      await cancelSupersededQueuedRuns(tx, {
-        threadId: target.threadId,
-        botIds: targetBotIds,
-        keepRunIds: runs.map((run) => run.id),
-      });
+      const eventBotId = firstRun?.botId ?? targetBotIds[0];
+      if (!eventBotId) throw new IsolationError("Group send did not resolve a target");
+      if (firstRun) {
+        await tx.message.update({ where: { id: message.id }, data: { runId: firstRun.id } });
+        const createdRuns = runs.filter((run) => !activeByBotId.has(run.botId));
+        if (createdRuns.length) {
+          await cancelSupersededQueuedRuns(tx, {
+            threadId: target.threadId,
+            botIds: createdRuns.map((run) => run.botId),
+            keepRunIds: createdRuns.map((run) => run.id),
+          });
+        }
+      }
       await touchGroupUpdatedAt(tx, target.groupId);
       const event = await appendEventInTransaction(tx, {
         spaceId: actor.spaceId,
         threadId: target.threadId,
-        botId: firstRun.botId,
+        botId: eventBotId,
         type: "thread.message.created",
-        runId: firstRun.id,
+        runId: firstRun?.id ?? activeRuns[0]?.id,
         payload: {
           messageId: message.id,
           role: "user",
           blocks,
+          runIds: runs.map((run) => run.id),
           replyToMessageId: input.replyToMessageId,
         },
       });
@@ -728,18 +819,28 @@ export async function stopThreadRuns(
   actor: Actor,
   target: ThreadTarget,
 ) {
-  const runIds = (
-    await deps.prisma.run.findMany({
+  const runIds = await deps.prisma.$transaction(async (tx) => {
+    await tx.$queryRaw`SELECT id FROM threads WHERE id = ${target.threadId} FOR UPDATE`;
+    const ids = (
+      await tx.run.findMany({
+        where: {
+          threadId: target.threadId,
+          status: { in: [...ACTIVE_RUN_STATUSES] },
+        },
+        select: { id: true },
+      })
+    ).map((run) => run.id);
+    await tx.run.updateMany({
+      where: { id: { in: ids }, status: { in: [...ACTIVE_RUN_STATUSES] } },
+      data: { status: "cancelled", completedAt: new Date() },
+    });
+    await tx.steeringMessage.deleteMany({
       where: {
-        threadId: target.threadId,
-        status: { in: [...ACTIVE_RUN_STATUSES] },
+        botId: { in: target.kind === "bot" ? [target.botId] : target.memberBotIds },
+        message: { threadId: target.threadId },
       },
-      select: { id: true },
-    })
-  ).map((run) => run.id);
-  await deps.prisma.run.updateMany({
-    where: { id: { in: runIds } },
-    data: { status: "cancelled", completedAt: new Date() },
+    });
+    return ids;
   });
   const computers = runIds.length
     ? await deps.prisma.computer.findMany({

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1009,9 +1009,16 @@ function Thread() {
     setError(null);
     try {
       await rpc("threads/stop", groupId ? { groupId } : { botId: botId! });
-      await refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to stop work");
+      setSending(false);
+      return;
+    }
+    try {
+      await refresh();
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : "Failed to refresh";
+      setError(`Work stopped, but the thread could not refresh: ${detail}`);
     } finally {
       setSending(false);
     }

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1004,21 +1004,30 @@ function Thread() {
   }
 
   async function stop() {
-    if ((!botId && !groupId) || sending) return;
+    const targetBotId = botId;
+    const targetGroupId = groupId;
+    if ((!targetBotId && !targetGroupId) || sending) return;
     setSending(true);
     setError(null);
     try {
-      await rpc("threads/stop", groupId ? { groupId } : { botId: botId! });
+      await rpc(
+        "threads/stop",
+        targetGroupId ? { groupId: targetGroupId } : { botId: targetBotId! },
+      );
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to stop work");
+      if (isCurrentTarget(targetBotId, targetGroupId)) {
+        setError(err instanceof Error ? err.message : "Failed to stop work");
+      }
       setSending(false);
       return;
     }
     try {
       await refresh();
     } catch (err) {
-      const detail = err instanceof Error ? err.message : "Failed to refresh";
-      setError(`Work stopped, but the thread could not refresh: ${detail}`);
+      if (isCurrentTarget(targetBotId, targetGroupId)) {
+        const detail = err instanceof Error ? err.message : "Failed to refresh";
+        setError(`Work stopped, but the thread could not refresh: ${detail}`);
+      }
     } finally {
       setSending(false);
     }

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -128,7 +128,13 @@ function formatApprovalAnswer(
 }
 
 function isWorkingStatus(status: string | undefined): boolean {
-  return status === "queued" || status === "leased" || status === "running";
+  return (
+    status === "queued" ||
+    status === "leased" ||
+    status === "running" ||
+    status === "waiting_input" ||
+    status === "waiting_takeover"
+  );
 }
 
 type NotificationRouteState = "loading" | "ready" | "failed";
@@ -343,6 +349,7 @@ function Thread() {
       return [{ ...member, status: run.status }];
     });
   }, [inGroup, snap?.activeRuns, snap?.members, snap?.run]);
+  const working = inGroup ? workingGroupBots.length > 0 : isWorkingStatus(currentBotStatus);
 
   useEffect(() => {
     void rpc<AgentSkillCatalogEntry[]>("agentSkills/list")
@@ -947,11 +954,13 @@ function Thread() {
         });
         artifactIds.push(artifact.id);
       }
+      const clientNonce = newClientNonce();
       await rpc(
         "threads/send",
         groupTarget
           ? {
               groupId: groupTarget,
+              clientNonce,
               text: trimmed || undefined,
               mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
               artifactIds: artifactIds.length ? artifactIds : undefined,
@@ -959,6 +968,7 @@ function Thread() {
             }
           : {
               botId: botTarget!,
+              clientNonce,
               text: trimmed || undefined,
               mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
               artifactIds: artifactIds.length ? artifactIds : undefined,
@@ -988,6 +998,20 @@ function Thread() {
       } else if (isCurrentTarget(botTarget, groupTarget)) {
         setError(err instanceof Error ? err.message : "Failed to send message");
       }
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function stop() {
+    if ((!botId && !groupId) || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      await rpc("threads/stop", groupId ? { groupId } : { botId: botId! });
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to stop work");
     } finally {
       setSending(false);
     }
@@ -1572,11 +1596,19 @@ function Thread() {
             ))}
           </View>
         ) : null}
+        {working ? (
+          <Text
+            accessibilityLiveRegion="polite"
+            style={{ color: "#85858A", fontSize: 12, marginTop: 12, marginHorizontal: 8 }}
+          >
+            Messages sent now guide the next turn.
+          </Text>
+        ) : null}
         <View
           style={{
             flexDirection: "row",
             gap: 8,
-            marginTop: 16,
+            marginTop: working ? 8 : 16,
             alignItems: "flex-end",
           }}
         >
@@ -1673,7 +1705,7 @@ function Thread() {
             <TextInput
               value={draft}
               onChangeText={updateDraft}
-              accessibilityLabel="Message"
+              accessibilityLabel={working ? `Steer ${name ?? "bot"}` : "Message"}
               onKeyPress={(event) => {
                 if (
                   event.nativeEvent.key === "Backspace" &&
@@ -1683,7 +1715,13 @@ function Thread() {
                   removeLastChip();
                 }
               }}
-              placeholder={selectedSkill || selectedMentions.length ? undefined : "Message…"}
+              placeholder={
+                selectedSkill || selectedMentions.length
+                  ? undefined
+                  : working
+                    ? `Steer ${name ?? "bot"}`
+                    : "Message…"
+              }
               placeholderTextColor="#6C6C70"
               keyboardAppearance="dark"
               multiline
@@ -1701,6 +1739,7 @@ function Thread() {
             />
           </View>
           <Pressable
+            accessibilityLabel={working ? "Send steering message" : "Send"}
             disabled={sending || !canSend}
             onPress={() => void send()}
             style={{
@@ -1715,6 +1754,25 @@ function Thread() {
           >
             <NativeSymbol ios="arrow.up" android="arrow-up" size={18} color="#17171A" />
           </Pressable>
+          {working ? (
+            <Pressable
+              accessibilityLabel="Stop"
+              disabled={sending}
+              onPress={() => void stop()}
+              style={{
+                borderColor: "#34343A",
+                borderWidth: 1,
+                borderRadius: 22,
+                width: 44,
+                height: 44,
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: sending ? 0.5 : 1,
+              }}
+            >
+              <NativeSymbol ios="stop.fill" android="stop" size={15} color="#C9C9CE" />
+            </Pressable>
+          ) : null}
         </View>
         {!inGroup ? (
           <Link

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -157,6 +157,14 @@ describe("Android mobile platform contract", () => {
     expect(thread).toContain("agents working");
   });
 
+  it("keeps send and stop separate while steering active work", () => {
+    const thread = readFileSync(resolve(mobileRoot, "app/thread.tsx"), "utf8");
+    expect(thread).toContain('accessibilityLabel={working ? "Send steering message" : "Send"}');
+    expect(thread).toContain('accessibilityLabel="Stop"');
+    expect(thread).toContain("Messages sent now guide the next turn.");
+    expect(thread).toContain("const clientNonce = newClientNonce()");
+  });
+
   it("shows agent notification silence in the menu, inbox avatar, and DM header only", () => {
     const index = readFileSync(resolve(mobileRoot, "app/index.tsx"), "utf8");
     const thread = readFileSync(resolve(mobileRoot, "app/thread.tsx"), "utf8");

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -159,12 +159,25 @@ describe("Android mobile platform contract", () => {
 
   it("keeps send and stop separate while steering active work", () => {
     const thread = readFileSync(resolve(mobileRoot, "app/thread.tsx"), "utf8");
+    const stopStart = thread.indexOf("async function stop()");
+    const stopSource = thread.slice(stopStart, thread.indexOf("const answerMessage", stopStart));
+    expect(stopStart).toBeGreaterThan(-1);
     expect(thread).toContain('accessibilityLabel={working ? "Send steering message" : "Send"}');
     expect(thread).toContain('accessibilityLabel="Stop"');
     expect(thread).toContain("Messages sent now guide the next turn.");
     expect(thread).toContain("const clientNonce = newClientNonce()");
     expect(thread).toContain("Work stopped, but the thread could not refresh");
-    expect(thread).toContain("isCurrentTarget(targetBotId, targetGroupId)");
+    expect(stopSource).toContain("const targetBotId = botId;");
+    expect(stopSource).toContain("const targetGroupId = groupId;");
+    expect(stopSource).toContain(
+      "targetGroupId ? { groupId: targetGroupId } : { botId: targetBotId! },",
+    );
+    expect(stopSource).toMatch(
+      /if \(isCurrentTarget\(targetBotId, targetGroupId\)\) \{\s*setError\(err instanceof Error \? err\.message : "Failed to stop work"\);/,
+    );
+    expect(stopSource).toMatch(
+      /if \(isCurrentTarget\(targetBotId, targetGroupId\)\) \{\s*(?:const detail = [^\n]+;\s*)?setError\(`Work stopped, but the thread could not refresh: \$\{detail\}`\);/,
+    );
   });
 
   it("shows agent notification silence in the menu, inbox avatar, and DM header only", () => {

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -163,6 +163,7 @@ describe("Android mobile platform contract", () => {
     expect(thread).toContain('accessibilityLabel="Stop"');
     expect(thread).toContain("Messages sent now guide the next turn.");
     expect(thread).toContain("const clientNonce = newClientNonce()");
+    expect(thread).toContain("Work stopped, but the thread could not refresh");
   });
 
   it("shows agent notification silence in the menu, inbox avatar, and DM header only", () => {

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -164,6 +164,7 @@ describe("Android mobile platform contract", () => {
     expect(thread).toContain("Messages sent now guide the next turn.");
     expect(thread).toContain("const clientNonce = newClientNonce()");
     expect(thread).toContain("Work stopped, but the thread could not refresh");
+    expect(thread).toContain("isCurrentTarget(targetBotId, targetGroupId)");
   });
 
   it("shows agent notification silence in the menu, inbox avatar, and DM header only", () => {

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -300,14 +300,16 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   expect(browserErrors).toEqual([]);
   expect(failedRequests).toEqual([]);
   let releaseStopRequest: () => void = () => undefined;
+  let markStopRequestStarted: () => void = () => undefined;
   const stopRequestStarted = new Promise<void>((resolve) => {
-    void page.route("**/rpc/threads/stop", async (route) => {
-      resolve();
-      await new Promise<void>((release) => {
-        releaseStopRequest = release;
-      });
-      await route.continue();
+    markStopRequestStarted = resolve;
+  });
+  await page.route("**/rpc/threads/stop", async (route) => {
+    markStopRequestStarted();
+    await new Promise<void>((release) => {
+      releaseStopRequest = release;
     });
+    await route.continue();
   });
   await page.getByRole("button", { name: "Stop", exact: true }).click();
   await stopRequestStarted;

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -257,6 +257,12 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   const email = `shell-${stamp}@rakazo.test`;
   await signup(page, email, "password12", "Shell");
   await completeOnboarding(page);
+  await page.evaluate(() => {
+    Object.defineProperty(globalThis.crypto, "randomUUID", {
+      value: undefined,
+      configurable: true,
+    });
+  });
 
   const composer = page.locator('textarea[name="chat-message"]');
   await composer.fill("spawn a bot named Scout to research venues");
@@ -293,7 +299,21 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await page.setViewportSize({ width: 1280, height: 720 });
   expect(browserErrors).toEqual([]);
   expect(failedRequests).toEqual([]);
+  let releaseStopRequest: () => void = () => undefined;
+  const stopRequestStarted = new Promise<void>((resolve) => {
+    void page.route("**/rpc/threads/stop", async (route) => {
+      resolve();
+      await new Promise<void>((release) => {
+        releaseStopRequest = release;
+      });
+      await route.continue();
+    });
+  });
   await page.getByRole("button", { name: "Stop", exact: true }).click();
+  await stopRequestStarted;
+  await expect(page.getByRole("button", { name: "Send steering message" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeDisabled();
+  releaseStopRequest();
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
 
   await page.context().clearCookies();

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -242,12 +242,23 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
 });
 
 test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) => {
+  const browserErrors: string[] = [];
+  const failedRequests: string[] = [];
+  page.on("pageerror", (error) => browserErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(message.text());
+  });
+  page.on("requestfailed", (request) => {
+    failedRequests.push(
+      `${request.method()} ${request.url()} ${request.failure()?.errorText ?? ""}`,
+    );
+  });
   const stamp = Date.now();
   const email = `shell-${stamp}@rakazo.test`;
   await signup(page, email, "password12", "Shell");
   await completeOnboarding(page);
 
-  const composer = page.getByPlaceholder(/Message/);
+  const composer = page.locator('textarea[name="chat-message"]');
   await composer.fill("spawn a bot named Scout to research venues");
   await page.keyboard.press("Enter");
   await expect(sidebarBotButton(page, /Scout/)).toBeVisible({
@@ -262,7 +273,26 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await composer.fill("keep working until I stop you");
   await page.keyboard.press("Enter");
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("composer-steering-status")).toHaveText(
+    "Messages sent now guide the next turn.",
+  );
+  await expect(page.getByRole("button", { name: "Send steering message" })).toBeVisible();
+  await composer.fill("Use the newer report and keep the answer short.");
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "Send steering message" })).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(
+    page.getByTestId("transcript").getByText("Use the newer report and keep the answer short."),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "14-active-bot-work");
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.getByRole("button", { name: "Send steering message" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "14-active-bot-work-mobile");
+  await page.setViewportSize({ width: 1280, height: 720 });
+  expect(browserErrors).toEqual([]);
+  expect(failedRequests).toEqual([]);
   await page.getByRole("button", { name: "Stop", exact: true }).click();
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
 

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3152,3 +3152,15 @@ msgstr "Link zum Zurücksetzen senden"
 #: src/pages/Auth.tsx:261
 msgid "This reset link is invalid or expired"
 msgstr "Dieser Link zum Zurücksetzen ist ungültig oder abgelaufen"
+
+#: src/pages/Shell.tsx
+msgid "Messages sent now guide the next turn."
+msgstr "Jetzt gesendete Nachrichten steuern den nächsten Durchgang."
+
+#: src/pages/Shell.tsx
+msgid "Steer {activeName}"
+msgstr "{activeName} Anweisungen geben"
+
+#: src/pages/Shell.tsx
+msgid "Send steering message"
+msgstr "Zusätzliche Anweisung senden"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3152,3 +3152,15 @@ msgstr "Send reset link"
 #: src/pages/Auth.tsx:261
 msgid "This reset link is invalid or expired"
 msgstr "This reset link is invalid or expired"
+
+#: src/pages/Shell.tsx
+msgid "Messages sent now guide the next turn."
+msgstr "Messages sent now guide the next turn."
+
+#: src/pages/Shell.tsx
+msgid "Steer {activeName}"
+msgstr "Steer {activeName}"
+
+#: src/pages/Shell.tsx
+msgid "Send steering message"
+msgstr "Send steering message"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3152,3 +3152,15 @@ msgstr "रीसेट लिंक भेजें"
 #: src/pages/Auth.tsx:261
 msgid "This reset link is invalid or expired"
 msgstr "यह रीसेट लिंक अमान्य है या इसकी समय-सीमा समाप्त हो गई है"
+
+#: src/pages/Shell.tsx
+msgid "Messages sent now guide the next turn."
+msgstr "अभी भेजे गए संदेश अगले चरण का मार्गदर्शन करते हैं।"
+
+#: src/pages/Shell.tsx
+msgid "Steer {activeName}"
+msgstr "{activeName} को निर्देश दें"
+
+#: src/pages/Shell.tsx
+msgid "Send steering message"
+msgstr "अतिरिक्त निर्देश भेजें"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3152,3 +3152,15 @@ msgstr "재설정 링크 보내기"
 #: src/pages/Auth.tsx:261
 msgid "This reset link is invalid or expired"
 msgstr "이 재설정 링크는 유효하지 않거나 만료되었습니다"
+
+#: src/pages/Shell.tsx
+msgid "Messages sent now guide the next turn."
+msgstr "지금 보내는 메시지는 다음 응답에 반영됩니다."
+
+#: src/pages/Shell.tsx
+msgid "Steer {activeName}"
+msgstr "{activeName}에게 지시하기"
+
+#: src/pages/Shell.tsx
+msgid "Send steering message"
+msgstr "추가 지시 보내기"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3152,3 +3152,15 @@ msgstr "Enviar link de redefinição"
 #: src/pages/Auth.tsx:261
 msgid "This reset link is invalid or expired"
 msgstr "Este link de redefinição é inválido ou expirou"
+
+#: src/pages/Shell.tsx
+msgid "Messages sent now guide the next turn."
+msgstr "As mensagens enviadas agora orientam a próxima etapa."
+
+#: src/pages/Shell.tsx
+msgid "Steer {activeName}"
+msgstr "Orientar {activeName}"
+
+#: src/pages/Shell.tsx
+msgid "Send steering message"
+msgstr "Enviar orientação adicional"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3159,7 +3159,7 @@ msgstr "Şimdi gönderilen mesajlar bir sonraki adımı yönlendirir."
 
 #: src/pages/Shell.tsx
 msgid "Steer {activeName}"
-msgstr "{activeName} botunu yönlendir"
+msgstr "{activeName} için yönlendir"
 
 #: src/pages/Shell.tsx
 msgid "Send steering message"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3152,3 +3152,15 @@ msgstr "Sıfırlama bağlantısı gönder"
 #: src/pages/Auth.tsx:261
 msgid "This reset link is invalid or expired"
 msgstr "Bu sıfırlama bağlantısı geçersiz veya süresi dolmuş"
+
+#: src/pages/Shell.tsx
+msgid "Messages sent now guide the next turn."
+msgstr "Şimdi gönderilen mesajlar bir sonraki adımı yönlendirir."
+
+#: src/pages/Shell.tsx
+msgid "Steer {activeName}"
+msgstr "{activeName} botunu yönlendir"
+
+#: src/pages/Shell.tsx
+msgid "Send steering message"
+msgstr "Yönlendirme mesajı gönder"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1952,9 +1952,11 @@ export function ShellPage() {
           );
           artifactIds.push(artifact.id);
         }
+        const clientNonce = crypto.randomUUID();
         if (groupTarget) {
           await rpc.threads.send({
             groupId: groupTarget,
+            clientNonce,
             text: trimmed || undefined,
             mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
             artifactIds: artifactIds.length ? artifactIds : undefined,
@@ -1963,6 +1965,7 @@ export function ShellPage() {
         } else if (botTarget) {
           await rpc.threads.send({
             botId: botTarget,
+            clientNonce,
             text: trimmed || undefined,
             mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
             artifactIds: artifactIds.length ? artifactIds : undefined,
@@ -4500,6 +4503,15 @@ const Composer = memo(function Composer({
           })}
         </div>
       ) : null}
+      {running ? (
+        <p
+          className="mb-2 px-3 text-[12px] text-[#85858A]"
+          data-testid="composer-steering-status"
+          aria-live="polite"
+        >
+          Messages sent now guide the next turn.
+        </p>
+      ) : null}
       <div
         data-testid="composer-bar"
         className="flex items-center gap-3.5 rounded-full border border-[#202023] bg-[#131315] py-[9px] pe-2.5 ps-3"
@@ -4641,11 +4653,15 @@ const Composer = memo(function Composer({
             placeholder={
               showComposerPlaceholder
                 ? activeName
-                  ? t`Message ${activeName}`
+                  ? running
+                    ? `Steer ${activeName}`
+                    : t`Message ${activeName}`
                   : t`Message…`
                 : undefined
             }
-            aria-label={activeName ? t`Message ${activeName}` : t`Message`}
+            aria-label={
+              activeName ? (running ? `Steer ${activeName}` : t`Message ${activeName}`) : t`Message`
+            }
             role="combobox"
             aria-autocomplete="list"
             aria-haspopup="listbox"
@@ -4660,14 +4676,25 @@ const Composer = memo(function Composer({
           />
         </div>
         {running ? (
-          <button
-            type="button"
-            aria-label={t`Stop`}
-            onClick={() => void onStop()}
-            className="grid h-9 w-9 place-items-center rounded-full bg-[#F1F1EF] text-[#17171A]"
-          >
-            <Square size={12} strokeWidth={0} fill="currentColor" />
-          </button>
+          <>
+            <button
+              type="button"
+              aria-label="Send steering message"
+              disabled={sending || !canSend || disabled}
+              onClick={send}
+              className="grid h-10 w-10 place-items-center rounded-full bg-[#F1F1EF] text-[#17171A] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD] disabled:opacity-50"
+            >
+              <ArrowUp size={18} strokeWidth={2} />
+            </button>
+            <button
+              type="button"
+              aria-label={t`Stop`}
+              onClick={() => void onStop()}
+              className="grid h-10 w-10 place-items-center rounded-full border border-[#34343A] text-[#C9C9CE] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD]"
+            >
+              <Square size={12} strokeWidth={0} fill="currentColor" />
+            </button>
+          </>
         ) : (
           <button
             type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1910,7 +1910,7 @@ export function ShellPage() {
       setSendError(null);
       try {
         if (plan.shouldRunRoutines) {
-          const sendNonce = crypto.randomUUID();
+          const sendNonce = newClientNonce();
           await Promise.all(
             plan.routineIds.map((routineId) =>
               rpc.routines.testRun({
@@ -1952,7 +1952,7 @@ export function ShellPage() {
           );
           artifactIds.push(artifact.id);
         }
-        const clientNonce = crypto.randomUUID();
+        const clientNonce = newClientNonce();
         if (groupTarget) {
           await rpc.threads.send({
             groupId: groupTarget,
@@ -2015,52 +2015,57 @@ export function ShellPage() {
     await refreshThreadRef.current(id);
   }, []);
   const stopRun = useCallback(async () => {
-    const botTarget = activeBotId.current;
-    const groupTarget = activeGroupId.current;
-    if (groupTarget) {
+    if (sending) return;
+    setSending(true);
+    try {
+      const botTarget = activeBotId.current;
+      const groupTarget = activeGroupId.current;
+      if (groupTarget) {
+        setSendError(null);
+        try {
+          await rpc.threads.stop({ groupId: groupTarget });
+        } catch (error) {
+          if (activeGroupId.current === groupTarget) {
+            setSendError(error instanceof Error ? error.message : t`Failed to stop`);
+          }
+          return;
+        }
+        // Stop has no terminal event; clear run UI before refresh races with in-flight gets.
+        if (activeGroupId.current === groupTarget) {
+          updateSnapshot((prev) =>
+            prev && prev.groupId === groupTarget ? clearActiveThreadRuns(prev) : prev,
+          );
+        }
+        await refreshGroupThreadRef.current(groupTarget).catch(() => undefined);
+        return;
+      }
+      if (!botTarget) return;
       setSendError(null);
       try {
-        await rpc.threads.stop({ groupId: groupTarget });
+        await rpc.threads.stop({ botId: botTarget });
       } catch (error) {
-        if (activeGroupId.current === groupTarget) {
+        if (activeBotId.current === botTarget) {
           setSendError(error instanceof Error ? error.message : t`Failed to stop`);
         }
         return;
       }
-      // Stop has no terminal event; clear run UI before refresh races with in-flight gets.
-      if (activeGroupId.current === groupTarget) {
-        updateSnapshot((prev) =>
-          prev && prev.groupId === groupTarget ? clearActiveThreadRuns(prev) : prev,
-        );
-      }
-      await refreshGroupThreadRef.current(groupTarget).catch(() => undefined);
-      return;
-    }
-    if (!botTarget) return;
-    setSendError(null);
-    try {
-      await rpc.threads.stop({ botId: botTarget });
-    } catch (error) {
+      // Stop does not emit a terminal thread event. Clear local run/busy immediately so a
+      // superseded in-flight refresh (older cursor) cannot leave Stop enabled / Take control
+      // blocked while the API is already idle.
       if (activeBotId.current === botTarget) {
-        setSendError(error instanceof Error ? error.message : t`Failed to stop`);
+        updateSnapshot((prev) =>
+          !prev || (prev.botId !== botTarget && prev.botId) ? prev : clearActiveThreadRuns(prev),
+        );
+        const currentComputer = computerRef.current;
+        if (currentComputer?.busyBotName) {
+          commitComputer({ ...currentComputer, busyBotName: null });
+        }
       }
-      return;
+      await refreshThreadRef.current(botTarget).catch(() => undefined);
+    } finally {
+      setSending(false);
     }
-    // Stop does not emit a terminal thread event. Clear local run/busy immediately so a
-    // superseded in-flight refresh (older cursor) cannot leave Stop enabled / Take control
-    // blocked while the API is already idle.
-    if (activeBotId.current === botTarget) {
-      updateSnapshot((prev) => {
-        if (!prev || (prev.botId !== botTarget && prev.botId)) return prev;
-        return clearActiveThreadRuns(prev);
-      });
-      const currentComputer = computerRef.current;
-      if (currentComputer?.busyBotName) {
-        commitComputer({ ...currentComputer, busyBotName: null });
-      }
-    }
-    await refreshThreadRef.current(botTarget).catch(() => undefined);
-  }, [t]);
+  }, [sending, t]);
   const stopTeaching = useCallback(async () => {
     const id = activeBotId.current;
     if (!id || teachBusy) return;
@@ -4509,7 +4514,7 @@ const Composer = memo(function Composer({
           data-testid="composer-steering-status"
           aria-live="polite"
         >
-          Messages sent now guide the next turn.
+          {t`Messages sent now guide the next turn.`}
         </p>
       ) : null}
       <div
@@ -4654,13 +4659,17 @@ const Composer = memo(function Composer({
               showComposerPlaceholder
                 ? activeName
                   ? running
-                    ? `Steer ${activeName}`
+                    ? t`Steer ${activeName}`
                     : t`Message ${activeName}`
                   : t`Message…`
                 : undefined
             }
             aria-label={
-              activeName ? (running ? `Steer ${activeName}` : t`Message ${activeName}`) : t`Message`
+              activeName
+                ? running
+                  ? t`Steer ${activeName}`
+                  : t`Message ${activeName}`
+                : t`Message`
             }
             role="combobox"
             aria-autocomplete="list"
@@ -4679,7 +4688,7 @@ const Composer = memo(function Composer({
           <>
             <button
               type="button"
-              aria-label="Send steering message"
+              aria-label={t`Send steering message`}
               disabled={sending || !canSend || disabled}
               onClick={send}
               className="grid h-10 w-10 place-items-center rounded-full bg-[#F1F1EF] text-[#17171A] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD] disabled:opacity-50"
@@ -4689,8 +4698,9 @@ const Composer = memo(function Composer({
             <button
               type="button"
               aria-label={t`Stop`}
+              disabled={sending}
               onClick={() => void onStop()}
-              className="grid h-10 w-10 place-items-center rounded-full border border-[#34343A] text-[#C9C9CE] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD]"
+              className="grid h-10 w-10 place-items-center rounded-full border border-[#34343A] text-[#C9C9CE] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD] disabled:opacity-50"
             >
               <Square size={12} strokeWidth={0} fill="currentColor" />
             </button>
@@ -6794,6 +6804,14 @@ function ArtifactImage({
       ) : null}
     </div>
   );
+}
+
+function newClientNonce(): string {
+  const webCrypto = globalThis.crypto;
+  if (webCrypto && typeof webCrypto.randomUUID === "function") {
+    return webCrypto.randomUUID();
+  }
+  return `m-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 function readFileAsBase64(file: File): Promise<string> {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3735,6 +3735,7 @@ export function ShellPage() {
                   aria-label={t`Stop`}
                   data-testid="computer-overlay-stop"
                   onClick={() => void stopRun()}
+                  disabled={sending}
                 >
                   <Trans>Stop</Trans>
                 </Button>

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -341,6 +341,8 @@ export interface AgentRunRequest {
     executionId: string,
     route?: ConnectorRoute,
   ) => Promise<unknown>;
+  /** Atomically claim durable user steering at the runtime's next safe turn boundary. */
+  claimSteering?: (seenIds: string[]) => Promise<Array<{ id: string; text: string }>>;
 }
 
 export interface ScriptedTurn {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -308,6 +308,7 @@ export interface AgentInputImage {
 
 export interface AgentSteeringMessage {
   id: string;
+  messageId: string;
   text: string;
   /** Persisted history text before attachment paths are appended. */
   historyText?: string;
@@ -318,9 +319,10 @@ export interface AgentRunRequest {
   botId: string;
   threadId: string;
   runId: string;
+  sourceMessageId?: string | null;
   prompt: string;
   instructions: string;
-  history: Array<{ role: "user" | "assistant" | "system"; content: string }>;
+  history: Array<{ id?: string; role: "user" | "assistant" | "system"; content: string }>;
   currentTurnImages?: AgentInputImage[];
   tools: ConnectorTool[];
   model: {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -300,6 +300,20 @@ export interface SemanticMemoryPurgeHistoryRequest {
   generations: number[];
 }
 
+export interface AgentInputImage {
+  name: string;
+  mimeType: "image/jpeg" | "image/png" | "image/webp" | "image/gif";
+  data: Uint8Array;
+}
+
+export interface AgentSteeringMessage {
+  id: string;
+  text: string;
+  /** Persisted history text before attachment paths are appended. */
+  historyText?: string;
+  images?: AgentInputImage[];
+}
+
 export interface AgentRunRequest {
   botId: string;
   threadId: string;
@@ -307,11 +321,7 @@ export interface AgentRunRequest {
   prompt: string;
   instructions: string;
   history: Array<{ role: "user" | "assistant" | "system"; content: string }>;
-  currentTurnImages?: Array<{
-    name: string;
-    mimeType: "image/jpeg" | "image/png" | "image/webp" | "image/gif";
-    data: Uint8Array;
-  }>;
+  currentTurnImages?: AgentInputImage[];
   tools: ConnectorTool[];
   model: {
     provider: string;
@@ -342,7 +352,7 @@ export interface AgentRunRequest {
     route?: ConnectorRoute,
   ) => Promise<unknown>;
   /** Atomically claim durable user steering at the runtime's next safe turn boundary. */
-  claimSteering?: (seenIds: string[]) => Promise<Array<{ id: string; text: string }>>;
+  claimSteering?: (seenIds: string[]) => Promise<AgentSteeringMessage[]>;
 }
 
 export interface ScriptedTurn {

--- a/packages/adapters/src/background-job-handlers.test.ts
+++ b/packages/adapters/src/background-job-handlers.test.ts
@@ -2,6 +2,7 @@ import type {
   AgentHomeStore,
   AgentRuntime,
   JobPublisher,
+  MessagingSurface,
   SandboxProvider,
 } from "@rakazo/adapter-kit";
 import type { PrismaClient, ThreadEvents } from "@rakazo/db";
@@ -9,11 +10,55 @@ import { describe, expect, it, vi } from "vitest";
 import { createBackgroundJobHandlers } from "./background-job-handlers.js";
 import { createRunExecutor } from "./executor.js";
 import { compactHistory } from "./history-compaction.js";
+import { deliverMessagingOutbound, mirrorMessagingOutbound } from "./messaging-delivery.js";
 import type { EncryptedSecretStore } from "./secrets.js";
 
 vi.mock("./history-compaction.js", () => ({ compactHistory: vi.fn(async () => undefined) }));
+vi.mock("./messaging-delivery.js", () => ({
+  deliverMessagingOutbound: vi.fn(async () => undefined),
+  mirrorMessagingOutbound: vi.fn(async () => undefined),
+}));
 
 describe("createBackgroundJobHandlers", () => {
+  it("delivers directly when shutdown rejects a completed run's mirror job", async () => {
+    const enqueueError = new Error("Background job publisher is closing");
+    const jobs = {
+      enqueue: vi.fn(async () => {
+        throw enqueueError;
+      }),
+    } as unknown as JobPublisher;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const handlers = createBackgroundJobHandlers({
+      executor: {
+        continueRun: vi.fn(async () => undefined),
+      } as unknown as ReturnType<typeof createRunExecutor>,
+      prisma: {} as unknown as PrismaClient,
+      sandbox: {} as unknown as SandboxProvider,
+      home: {} as unknown as AgentHomeStore,
+      jobs,
+      events: {} as unknown as ThreadEvents,
+      workerId: "worker-1",
+      runtime: {} as unknown as AgentRuntime,
+      secretStore: {} as unknown as EncryptedSecretStore,
+      memoryProviders: { resolve: vi.fn(async () => null) },
+      messaging: {} as unknown as MessagingSurface,
+    });
+
+    await handlers["run.continue"]({ runId: "run-1" });
+
+    expect(mirrorMessagingOutbound).toHaveBeenCalledWith(
+      expect.objectContaining({ prisma: expect.anything(), messaging: expect.anything(), jobs }),
+      "run-1",
+    );
+    expect(deliverMessagingOutbound).toHaveBeenCalledWith(
+      expect.objectContaining({ prisma: expect.anything(), messaging: expect.anything(), jobs }),
+      { runId: undefined },
+      expect.objectContaining({ operationId: "messaging.deliver:drain" }),
+    );
+    expect(consoleError).toHaveBeenCalledWith("messaging.deliver enqueue error", enqueueError);
+    consoleError.mockRestore();
+  });
+
   it("compacts the requested thread with the runtime, job publisher, and model key it was given", async () => {
     const prisma = {} as unknown as PrismaClient;
     const runtime = {} as unknown as AgentRuntime;

--- a/packages/adapters/src/background-job-handlers.ts
+++ b/packages/adapters/src/background-job-handlers.ts
@@ -13,7 +13,7 @@ import { scheduleComputerSleep, sleepComputerIfIdle } from "./computer-idle.js";
 import type { createRunExecutor } from "./executor.js";
 import { compactHistory } from "./history-compaction.js";
 import type { MemoryProviderResolver } from "./memory-provider-factory.js";
-import { deliverMessagingOutbound } from "./messaging-delivery.js";
+import { deliverMessagingOutbound, mirrorMessagingOutbound } from "./messaging-delivery.js";
 import type { EncryptedSecretStore } from "./secrets.js";
 import { expireTaughtSkillTeaching } from "./teaching-session.js";
 
@@ -31,30 +31,39 @@ export function createBackgroundJobHandlers(deps: {
   deploymentModelKey?: string;
   messaging?: MessagingSurface;
 }): BackgroundJobHandlers {
+  const deliverMessaging = async (runId?: string) => {
+    if (!deps.messaging) return;
+    await deliverMessagingOutbound(
+      { prisma: deps.prisma, messaging: deps.messaging, events: deps.events, jobs: deps.jobs },
+      { runId },
+      {
+        operationId: `messaging.deliver:${runId ?? "drain"}`,
+        traceId: `messaging.deliver:${runId ?? "drain"}`,
+        spaceId: "",
+        userId: "",
+        signal: new AbortController().signal,
+      },
+    );
+  };
+
   return {
     "run.continue": async (payload) => {
       await deps.executor.continueRun(payload.runId, deps.workerId);
       // Automatic messaging mirror: once the run's bot messages are durable,
       // copy them into the outbox. Never let mirror failures fail the run.
       if (deps.messaging) {
-        await deps.jobs.enqueue(messagingDeliverJob(payload.runId)).catch((error) => {
+        await mirrorMessagingOutbound(
+          { prisma: deps.prisma, messaging: deps.messaging, events: deps.events, jobs: deps.jobs },
+          payload.runId,
+        );
+        await deps.jobs.enqueue(messagingDeliverJob()).catch(async (error) => {
           console.error("messaging.deliver enqueue error", error);
+          await deliverMessaging();
         });
       }
     },
     "messaging.deliver": async (payload) => {
-      if (!deps.messaging) return;
-      await deliverMessagingOutbound(
-        { prisma: deps.prisma, messaging: deps.messaging, events: deps.events, jobs: deps.jobs },
-        payload,
-        {
-          operationId: `messaging.deliver:${payload.runId ?? "drain"}`,
-          traceId: `messaging.deliver:${payload.runId ?? "drain"}`,
-          spaceId: "",
-          userId: "",
-          signal: new AbortController().signal,
-        },
-      );
+      await deliverMessaging(payload.runId);
     },
     "routine.wakeup": async (payload) => {
       await deps.executor.wakeRoutine(payload.routineId, payload.scheduledFor);

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -5,6 +5,7 @@ import {
   createRunExecutor,
   runNotificationsEnabled,
   selectBuiltinToolsForRun,
+  settleSteeringAttachmentLoads,
   threadContextForRun,
 } from "./executor.js";
 
@@ -33,6 +34,24 @@ describe("run tool selection", () => {
     expect(toolNames("routine", "group-1")).toEqual(
       expect.arrayContaining(["schedule_list", "schedule_cancel"]),
     );
+  });
+});
+
+describe("steering attachment hydration", () => {
+  it("keeps successful attachment parts when another part is unavailable", async () => {
+    const withoutImage = await settleSteeringAttachmentLoads(
+      Promise.reject(new Error("image missing")),
+      Promise.resolve(["attachment.pdf"]),
+    );
+    expect(withoutImage).toMatchObject({ images: undefined, files: ["attachment.pdf"] });
+    expect(withoutImage.unavailableInstruction).toContain("do not guess its contents");
+
+    const withoutFile = await settleSteeringAttachmentLoads(
+      Promise.resolve(["image.png"]),
+      Promise.reject(new Error("file missing")),
+    );
+    expect(withoutFile).toMatchObject({ images: ["image.png"], files: [] });
+    expect(withoutFile.unavailableInstruction).toContain("do not guess its contents");
   });
 });
 

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -115,6 +115,49 @@ describe("steering attachment hydration", () => {
     expect(withoutExpectedImages.unavailableInstruction).toBe("");
   });
 
+  it("treats unreadable image bytes as missing instead of failing hydration", async () => {
+    const blocks: MessageBlock[] = [
+      { kind: "image", artifactId: "image-1", name: "one.png", mimeType: "image/png" },
+      { kind: "image", artifactId: "image-2", name: "two.png", mimeType: "image/png" },
+    ];
+    const images = await loadCurrentTurnImages(
+      {
+        artifacts: {
+          get: vi.fn(async (storageKey: string) => {
+            if (storageKey === "bad.png") throw new Error("read failed");
+            return new Uint8Array([1]);
+          }),
+        },
+        prisma: {
+          artifact: {
+            findMany: vi.fn(async () => [
+              { id: "image-1", storageKey: "one.png" },
+              { id: "image-2", storageKey: "bad.png" },
+            ]),
+          },
+        },
+      } as never,
+      blocks,
+      {
+        operationId: "run-1",
+        traceId: "run-1",
+        spaceId: "space-1",
+        userId: "user-1",
+        botId: "bot-1",
+        runId: "run-1",
+        signal: new AbortController().signal,
+      },
+    );
+    expect(images).toHaveLength(1);
+    expect(missingTurnImagesInstruction(blocks, images)).toContain("do not guess its contents");
+    const settled = await settleSteeringAttachmentLoads(
+      Promise.resolve(images),
+      Promise.resolve([]),
+      blocks,
+    );
+    expect(settled.unavailableInstruction).toContain("do not guess its contents");
+  });
+
   it("warns when an ordinary turn expects more images than were loaded", () => {
     const blocks: MessageBlock[] = [
       { kind: "image", artifactId: "image-1", name: "one.png", mimeType: "image/png" },

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -3,6 +3,8 @@ import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import {
   createRunExecutor,
+  type ExecutorDeps,
+  loadCurrentTurnImages,
   runNotificationsEnabled,
   selectBuiltinToolsForRun,
   settleSteeringAttachmentLoads,
@@ -52,6 +54,43 @@ describe("steering attachment hydration", () => {
     );
     expect(withoutFile).toMatchObject({ images: ["image.png"], files: [] });
     expect(withoutFile.unavailableInstruction).toContain("do not guess its contents");
+  });
+
+  it("treats a missing steering image artifact row as unavailable, not an empty success", async () => {
+    const findMany = vi.fn(async () => []);
+    const get = vi.fn();
+    const deps = {
+      prisma: { artifact: { findMany } },
+      artifacts: { get },
+    } as unknown as ExecutorDeps;
+    const context = {
+      operationId: "op-1",
+      traceId: "trace-1",
+      spaceId: "space-1",
+      userId: "user-1",
+      botId: "bot-1",
+      runId: "run-1",
+      signal: new AbortController().signal,
+    };
+    const missingImage = {
+      kind: "image" as const,
+      artifactId: "missing-artifact",
+      name: "steer.png",
+      mimeType: "image/png",
+    };
+
+    await expect(loadCurrentTurnImages(deps, [missingImage], context)).rejects.toThrow(
+      "Attached image is unavailable: steer.png",
+    );
+
+    const settled = await settleSteeringAttachmentLoads(
+      loadCurrentTurnImages(deps, [missingImage], context),
+      Promise.resolve(["ok.pdf"]),
+    );
+    expect(get).not.toHaveBeenCalled();
+    expect(findMany).toHaveBeenCalled();
+    expect(settled).toMatchObject({ images: undefined, files: ["ok.pdf"] });
+    expect(settled.unavailableInstruction).toContain("do not guess its contents");
   });
 });
 

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createRunExecutor,
   loadCurrentTurnImages,
+  missingTurnImagesInstruction,
   runNotificationsEnabled,
   selectBuiltinToolsForRun,
   settleSteeringAttachmentLoads,
@@ -112,6 +113,24 @@ describe("steering attachment hydration", () => {
       Promise.resolve([]),
     );
     expect(withoutExpectedImages.unavailableInstruction).toBe("");
+  });
+
+  it("warns when an ordinary turn expects more images than were loaded", () => {
+    const blocks: MessageBlock[] = [
+      { kind: "image", artifactId: "image-1", name: "one.png", mimeType: "image/png" },
+      { kind: "image", artifactId: "image-2", name: "two.png", mimeType: "image/png" },
+    ];
+    expect(missingTurnImagesInstruction(blocks, [{ name: "one.png" } as never])).toContain(
+      "do not guess its contents",
+    );
+    expect(
+      missingTurnImagesInstruction(blocks, [
+        { name: "one.png" } as never,
+        { name: "two.png" } as never,
+      ]),
+    ).toBe("");
+    expect(missingTurnImagesInstruction(blocks, undefined)).toContain("do not guess its contents");
+    expect(missingTurnImagesInstruction(undefined, undefined)).toBe("");
   });
 });
 

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -1,9 +1,9 @@
+import type { MessageBlock } from "@rakazo/contracts";
 import { ONCE_ROUTINE_CRON } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import {
   createRunExecutor,
-  type ExecutorDeps,
   loadCurrentTurnImages,
   runNotificationsEnabled,
   selectBuiltinToolsForRun,
@@ -41,6 +41,10 @@ describe("run tool selection", () => {
 
 describe("steering attachment hydration", () => {
   it("keeps successful attachment parts when another part is unavailable", async () => {
+    const imageBlocks: MessageBlock[] = [
+      { kind: "image", artifactId: "image-1", name: "one.png", mimeType: "image/png" },
+      { kind: "image", artifactId: "image-2", name: "two.png", mimeType: "image/png" },
+    ];
     const withoutImage = await settleSteeringAttachmentLoads(
       Promise.reject(new Error("image missing")),
       Promise.resolve(["attachment.pdf"]),
@@ -54,43 +58,60 @@ describe("steering attachment hydration", () => {
     );
     expect(withoutFile).toMatchObject({ images: ["image.png"], files: [] });
     expect(withoutFile.unavailableInstruction).toContain("do not guess its contents");
-  });
 
-  it("treats a missing steering image artifact row as unavailable, not an empty success", async () => {
-    const findMany = vi.fn(async () => []);
-    const get = vi.fn();
-    const deps = {
-      prisma: { artifact: { findMany } },
-      artifacts: { get },
-    } as unknown as ExecutorDeps;
-    const context = {
-      operationId: "op-1",
-      traceId: "trace-1",
-      spaceId: "space-1",
-      userId: "user-1",
-      botId: "bot-1",
-      runId: "run-1",
-      signal: new AbortController().signal,
-    };
-    const missingImage = {
-      kind: "image" as const,
-      artifactId: "missing-artifact",
-      name: "steer.png",
-      mimeType: "image/png",
-    };
-
-    await expect(loadCurrentTurnImages(deps, [missingImage], context)).rejects.toThrow(
-      "Attached image is unavailable: steer.png",
+    const partiallyHydratedImages = await loadCurrentTurnImages(
+      {
+        artifacts: { get: vi.fn(async () => new Uint8Array([1])) },
+        prisma: {
+          artifact: {
+            findMany: vi.fn(async () => [{ id: "image-1", storageKey: "one.png" }]),
+          },
+        },
+      } as never,
+      imageBlocks,
+      {
+        operationId: "run-1",
+        traceId: "run-1",
+        spaceId: "space-1",
+        userId: "user-1",
+        botId: "bot-1",
+        runId: "run-1",
+        signal: new AbortController().signal,
+      },
+    );
+    expect(partiallyHydratedImages).toHaveLength(1);
+    const withPartiallyMissingImages = await settleSteeringAttachmentLoads(
+      Promise.resolve(partiallyHydratedImages),
+      Promise.resolve([]),
+      imageBlocks,
+    );
+    expect(withPartiallyMissingImages).toMatchObject({
+      images: partiallyHydratedImages,
+      files: [],
+    });
+    expect(withPartiallyMissingImages.unavailableInstruction).toContain(
+      "do not guess its contents",
     );
 
-    const settled = await settleSteeringAttachmentLoads(
-      loadCurrentTurnImages(deps, [missingImage], context),
-      Promise.resolve(["ok.pdf"]),
+    const withAllImagesMissing = await settleSteeringAttachmentLoads(
+      Promise.resolve(undefined),
+      Promise.resolve([]),
+      imageBlocks.slice(0, 1),
     );
-    expect(get).not.toHaveBeenCalled();
-    expect(findMany).toHaveBeenCalled();
-    expect(settled).toMatchObject({ images: undefined, files: ["ok.pdf"] });
-    expect(settled.unavailableInstruction).toContain("do not guess its contents");
+    expect(withAllImagesMissing.unavailableInstruction).toContain("do not guess its contents");
+
+    const withoutMissingImages = await settleSteeringAttachmentLoads(
+      Promise.resolve(["image.png"]),
+      Promise.resolve([]),
+      imageBlocks.slice(0, 1),
+    );
+    expect(withoutMissingImages.unavailableInstruction).toBe("");
+
+    const withoutExpectedImages = await settleSteeringAttachmentLoads(
+      Promise.resolve(undefined),
+      Promise.resolve([]),
+    );
+    expect(withoutExpectedImages.unavailableInstruction).toBe("");
   });
 });
 

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -3853,12 +3853,14 @@ export async function loadCurrentTurnImages(
   for (const block of imageBlocks) {
     const row = byId.get(block.artifactId);
     if (!row || !isAttachmentImageMimeType(block.mimeType)) continue;
-    const bytes = await deps.artifacts.get(row.storageKey, context);
-    images.push({
-      name: block.name,
-      mimeType: block.mimeType as "image/jpeg" | "image/png" | "image/webp" | "image/gif",
-      data: bytes,
-    });
+    try {
+      const bytes = await deps.artifacts.get(row.storageKey, context);
+      images.push({
+        name: block.name,
+        mimeType: block.mimeType as "image/jpeg" | "image/png" | "image/webp" | "image/gif",
+        data: bytes,
+      });
+    } catch {}
   }
 
   return images.length ? images : undefined;

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2802,6 +2802,17 @@ export function createRunExecutor(deps: ExecutorDeps) {
               allowSilentEmpty: allowSilentPeerMessage || messagingChannelRun,
               emptyResponseText,
               executeTool: scripted ? undefined : applyTool,
+              claimSteering: scripted
+                ? undefined
+                : (seenIds) =>
+                    deps.events.claimSteering({
+                      threadId: thread.id,
+                      botId: bot.id,
+                      runId,
+                      leaseOwner: workerId,
+                      leaseFence: fence,
+                      seenIds,
+                    }),
             },
             context,
           )) {
@@ -2984,6 +2995,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
                   blocks: [{ kind: "text", text: stuckText }],
                 });
                 if (!stopped) return;
+                if (stopped.continuationRunId) {
+                  await deps.jobs
+                    .enqueue(runContinueJob(stopped.continuationRunId))
+                    .catch((error) => console.error("steering continuation enqueue", error));
+                }
                 if (run.trigger === "bot_message") {
                   await returnBotMessageOutcome(
                     deps,
@@ -3134,6 +3150,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
             markUnread: completionMarksUnread(run.trigger, text),
           });
           if (!completed) return;
+          if (completed.continuationRunId) {
+            await deps.jobs
+              .enqueue(runContinueJob(completed.continuationRunId))
+              .catch((error) => console.error("steering continuation enqueue", error));
+          }
           if (run.trigger === "bot_message" && text) {
             await returnBotMessageOutcome(
               deps,
@@ -3142,7 +3163,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               text,
             ).catch((error) => console.error("bot message result return", error));
           }
-          if (text) {
+          if (text && !completed.continuationRunId) {
             await notifyRun(deps, run, {
               kind: "completion",
               title: `${bot.name} finished`,
@@ -3201,6 +3222,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
             error: message,
           });
           if (!failed) return;
+          if (failed.continuationRunId) {
+            await deps.jobs
+              .enqueue(runContinueJob(failed.continuationRunId))
+              .catch((error) => console.error("steering continuation enqueue", error));
+          }
           if (run.trigger === "bot_message") {
             await returnBotMessageOutcome(
               deps,
@@ -3210,13 +3236,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
               "status",
             ).catch((returnError) => console.error("bot message failure return", returnError));
           }
-          await notifyRun(deps, run, {
-            kind: "failure",
-            title: `${bot.name} failed`,
-            body: message.slice(0, 180),
-            botId: bot.id,
-            threadId: thread.id,
-          });
+          if (!failed.continuationRunId) {
+            await notifyRun(deps, run, {
+              kind: "failure",
+              title: `${bot.name} failed`,
+              body: message.slice(0, 180),
+              botId: bot.id,
+              threadId: thread.id,
+            });
+          }
         }
       } catch (setupError) {
         const computerBusy = setupError instanceof ComputerBusyError;

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -259,6 +259,8 @@ const READ_ONLY_AGENT_TOOLS = new Set([
   "web_fetch",
 ]);
 const MAX_MODEL_FILE_BYTES = 250_000;
+const STEERING_ATTACHMENT_UNAVAILABLE =
+  "An attachment in this steering message could not be loaded. Tell the user the attachment was unavailable and do not guess its contents.";
 const BUILTIN_AGENT_TOOL_NAMES = new Set(builtinAgentTools.map((tool) => tool.name));
 
 const SHELL_INTERPRETER_NAMES = /^(?:bash|sh|dash|zsh|ksh|fish)$/;
@@ -2821,26 +2823,29 @@ export function createRunExecutor(deps: ExecutorDeps) {
                     });
                     return Promise.all(
                       steering.map(async (item) => {
-                        const [images, files] = await Promise.all([
-                          loadCurrentTurnImages(deps, item.blocks, context),
-                          deps.artifacts
-                            ? materializeCurrentTurnFiles(
-                                {
-                                  prisma: deps.prisma,
-                                  artifacts: deps.artifacts,
-                                  sandbox: deps.sandbox,
-                                },
-                                item.blocks,
-                                { context, computer, computerMode },
-                              )
-                            : [],
-                        ]);
+                        const { images, files, unavailableInstruction } =
+                          await settleSteeringAttachmentLoads(
+                            loadCurrentTurnImages(deps, item.blocks, context),
+                            deps.artifacts
+                              ? materializeCurrentTurnFiles(
+                                  {
+                                    prisma: deps.prisma,
+                                    artifacts: deps.artifacts,
+                                    sandbox: deps.sandbox,
+                                  },
+                                  item.blocks,
+                                  { context, computer, computerMode },
+                                )
+                              : Promise.resolve([]),
+                          );
                         const filesInstruction = currentTurnFilesInstruction(files);
                         return {
                           id: item.id,
                           messageId: item.messageId,
                           historyText: item.text,
-                          text: [item.text, filesInstruction].filter(Boolean).join("\n\n"),
+                          text: [item.text, filesInstruction, unavailableInstruction]
+                            .filter(Boolean)
+                            .join("\n\n"),
                           images,
                         };
                       }),
@@ -3485,6 +3490,23 @@ export function completionNotificationBody(assembled: string, blocks: MessageBlo
 
 export function completionMarksUnread(trigger: string, text: string): boolean {
   return trigger !== "routine" || Boolean(text);
+}
+
+export async function settleSteeringAttachmentLoads<TImage, TFile>(
+  images: Promise<TImage[] | undefined>,
+  files: Promise<TFile[]>,
+): Promise<{
+  images: TImage[] | undefined;
+  files: TFile[];
+  unavailableInstruction: string;
+}> {
+  const [loadedImages, loadedFiles] = await Promise.allSettled([images, files]);
+  const unavailable = loadedImages.status === "rejected" || loadedFiles.status === "rejected";
+  return {
+    images: loadedImages.status === "fulfilled" ? loadedImages.value : undefined,
+    files: loadedFiles.status === "fulfilled" ? loadedFiles.value : [],
+    unavailableInstruction: unavailable ? STEERING_ATTACHMENT_UNAVAILABLE : "",
+  };
 }
 
 export function subagentMarksUnread(trigger: string, status: "running" | "completed" | "failed") {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -939,6 +939,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           : Promise.resolve([]);
         const threadContext = threadContextForRun(run.trigger, {
           messages: [...messages].reverse().map((m) => ({
+            id: m.id,
             seq: m.seq,
             role: (m.role === "user" ? "user" : m.role === "system" ? "system" : "assistant") as
               | "user"
@@ -954,7 +955,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
           summary: threadContext.summary,
           historyCompactedUpToSeq: threadContext.historyCompactedUpToSeq,
         });
-        let history = compactedHistory.history.map(({ role, content }) => ({ role, content }));
+        let history = compactedHistory.history.map(({ id, role, content }) => ({
+          id,
+          role,
+          content,
+        }));
         const turnBlocks = userTurnBlocksForRun(
           run.trigger,
           runId,
@@ -2753,6 +2758,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               botId: bot.id,
               threadId: thread.id,
               runId,
+              sourceMessageId: run.sourceMessageId,
               prompt,
               instructions: [
                 bot.instructions || `${bot.name}: ${bot.title}\n${bot.description}`,
@@ -2832,6 +2838,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                         const filesInstruction = currentTurnFilesInstruction(files);
                         return {
                           id: item.id,
+                          messageId: item.messageId,
                           historyText: item.text,
                           text: [item.text, filesInstruction].filter(Boolean).join("\n\n"),
                           images,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -3798,7 +3798,7 @@ async function withModelCredentialLock<T>(key: string, fn: () => Promise<T>): Pr
   }
 }
 
-async function loadCurrentTurnImages(
+export async function loadCurrentTurnImages(
   deps: ExecutorDeps,
   blocks: MessageBlock[] | undefined,
   context: {
@@ -3829,8 +3829,9 @@ async function loadCurrentTurnImages(
     [];
 
   for (const block of imageBlocks) {
+    if (!isAttachmentImageMimeType(block.mimeType)) continue;
     const row = byId.get(block.artifactId);
-    if (!row || !isAttachmentImageMimeType(block.mimeType)) continue;
+    if (!row) throw new Error(`Attached image is unavailable: ${block.name}`);
     const bytes = await deps.artifacts.get(row.storageKey, context);
     images.push({
       name: block.name,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2804,15 +2804,41 @@ export function createRunExecutor(deps: ExecutorDeps) {
               executeTool: scripted ? undefined : applyTool,
               claimSteering: scripted
                 ? undefined
-                : (seenIds) =>
-                    deps.events.claimSteering({
+                : async (seenIds) => {
+                    const steering = await deps.events.claimSteering({
                       threadId: thread.id,
                       botId: bot.id,
                       runId,
                       leaseOwner: workerId,
                       leaseFence: fence,
                       seenIds,
-                    }),
+                    });
+                    return Promise.all(
+                      steering.map(async (item) => {
+                        const [images, files] = await Promise.all([
+                          loadCurrentTurnImages(deps, item.blocks, context),
+                          deps.artifacts
+                            ? materializeCurrentTurnFiles(
+                                {
+                                  prisma: deps.prisma,
+                                  artifacts: deps.artifacts,
+                                  sandbox: deps.sandbox,
+                                },
+                                item.blocks,
+                                { context, computer, computerMode },
+                              )
+                            : [],
+                        ]);
+                        const filesInstruction = currentTurnFilesInstruction(files);
+                        return {
+                          id: item.id,
+                          historyText: item.text,
+                          text: [item.text, filesInstruction].filter(Boolean).join("\n\n"),
+                          images,
+                        };
+                      }),
+                    );
+                  },
             },
             context,
           )) {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -259,8 +259,9 @@ const READ_ONLY_AGENT_TOOLS = new Set([
   "web_fetch",
 ]);
 const MAX_MODEL_FILE_BYTES = 250_000;
-const STEERING_ATTACHMENT_UNAVAILABLE =
-  "An attachment in this steering message could not be loaded. Tell the user the attachment was unavailable and do not guess its contents.";
+const TURN_ATTACHMENT_UNAVAILABLE =
+  "An attachment in this message could not be loaded. Tell the user the attachment was unavailable and do not guess its contents.";
+const STEERING_ATTACHMENT_UNAVAILABLE = TURN_ATTACHMENT_UNAVAILABLE;
 const BUILTIN_AGENT_TOOL_NAMES = new Set(builtinAgentTools.map((tool) => tool.name));
 
 const SHELL_INTERPRETER_NAMES = /^(?:bash|sh|dash|zsh|ksh|fish)$/;
@@ -2691,8 +2692,12 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 )}\nWhen the user asks to run a taught skill by name, follow that skill's playbook exactly. The full playbook is included in the user task when they invoke it.`
             : undefined;
         const agentSkillsLine = formatSkillsCatalogInstruction(agentSkills);
+        const missingImagesInstruction = missingTurnImagesInstruction(
+          turnBlocks,
+          currentTurnImages,
+        );
         const taskPrompt = expandSkillReferencesInPrompt(
-          [task.prompt, attachedFilesPrompt].filter(Boolean).join("\n\n"),
+          [task.prompt, attachedFilesPrompt, missingImagesInstruction].filter(Boolean).join("\n\n"),
           agentSkills,
         );
         const invokedSkill = savedSkills.find((skill) =>
@@ -3491,6 +3496,15 @@ export function completionNotificationBody(assembled: string, blocks: MessageBlo
 
 export function completionMarksUnread(trigger: string, text: string): boolean {
   return trigger !== "routine" || Boolean(text);
+}
+
+export function missingTurnImagesInstruction(
+  blocks: MessageBlock[] | undefined,
+  images: { length: number } | undefined,
+): string {
+  const expected = blocks?.filter((block) => block.kind === "image").length ?? 0;
+  const loaded = images?.length ?? 0;
+  return expected > 0 && loaded < expected ? TURN_ATTACHMENT_UNAVAILABLE : "";
 }
 
 export async function settleSteeringAttachmentLoads<TImage, TFile>(

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2837,6 +2837,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                                   { context, computer, computerMode },
                                 )
                               : Promise.resolve([]),
+                            item.blocks,
                           );
                         const filesInstruction = currentTurnFilesInstruction(files);
                         return {
@@ -3495,13 +3496,20 @@ export function completionMarksUnread(trigger: string, text: string): boolean {
 export async function settleSteeringAttachmentLoads<TImage, TFile>(
   images: Promise<TImage[] | undefined>,
   files: Promise<TFile[]>,
+  blocks?: MessageBlock[],
 ): Promise<{
   images: TImage[] | undefined;
   files: TFile[];
   unavailableInstruction: string;
 }> {
   const [loadedImages, loadedFiles] = await Promise.allSettled([images, files]);
-  const unavailable = loadedImages.status === "rejected" || loadedFiles.status === "rejected";
+  const expectedImageCount = blocks?.filter((block) => block.kind === "image").length ?? 0;
+  const loadedImageCount =
+    loadedImages.status === "fulfilled" ? (loadedImages.value?.length ?? 0) : 0;
+  const unavailable =
+    loadedImages.status === "rejected" ||
+    loadedFiles.status === "rejected" ||
+    loadedImageCount < expectedImageCount;
   return {
     images: loadedImages.status === "fulfilled" ? loadedImages.value : undefined,
     files: loadedFiles.status === "fulfilled" ? loadedFiles.value : [],
@@ -3829,9 +3837,8 @@ export async function loadCurrentTurnImages(
     [];
 
   for (const block of imageBlocks) {
-    if (!isAttachmentImageMimeType(block.mimeType)) continue;
     const row = byId.get(block.artifactId);
-    if (!row) throw new Error(`Attached image is unavailable: ${block.name}`);
+    if (!row || !isAttachmentImageMimeType(block.mimeType)) continue;
     const bytes = await deps.artifacts.get(row.storageKey, context);
     images.push({
       name: block.name,

--- a/packages/adapters/src/history-compaction.ts
+++ b/packages/adapters/src/history-compaction.ts
@@ -42,6 +42,7 @@ export const MAX_COMPACTED_SUMMARY_CHARS = 20_000;
 export const MAX_RECALLED_MEMORIES = 5;
 
 export type CompactedHistoryMessage = {
+  id?: string;
   seq: number;
   role: "user" | "assistant" | "system";
   content: string;

--- a/packages/adapters/src/job-reconciler.test.ts
+++ b/packages/adapters/src/job-reconciler.test.ts
@@ -35,10 +35,54 @@ function fakePrisma(
     run: { findMany: vi.fn(async () => runs) },
     routine: { findMany: vi.fn(async () => routines) },
     computer: { findMany: vi.fn(async () => controls) },
+    messagingOutbound: { findFirst: vi.fn(async () => null) },
   } as unknown as PrismaClient;
 }
 
 describe("createJobReconciler", () => {
+  it("restores a due pending messaging outbox drain", async () => {
+    const prisma = fakePrisma();
+    vi.mocked(prisma.messagingOutbound.findFirst).mockResolvedValue({ id: "outbound-1" } as never);
+    const { jobs, enqueue } = publisher();
+
+    await createJobReconciler({ prisma, jobs }).reconcileOnce();
+
+    expect(prisma.messagingOutbound.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: "pending",
+        OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: expect.any(Date) } }],
+      },
+      select: { id: true },
+    });
+    expect(enqueue).toHaveBeenCalledWith({
+      name: "messaging.deliver",
+      payload: {},
+      replaceKey: "messaging.deliver:drain",
+    });
+  });
+
+  it("restores a completed messaging run that was not durably mirrored", async () => {
+    const prisma = fakePrisma();
+    vi.mocked(prisma.run.findMany)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "run-unmirrored" }] as never);
+    const { jobs, enqueue } = publisher();
+
+    await createJobReconciler({ prisma, jobs }).reconcileOnce();
+
+    expect(prisma.run.findMany).toHaveBeenCalledWith({
+      where: { trigger: "messaging", status: "completed", messagingMirroredAt: null },
+      orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+      take: 100,
+      select: { id: true },
+    });
+    expect(enqueue).toHaveBeenCalledWith({
+      name: "messaging.deliver",
+      payload: { runId: "run-unmirrored" },
+      replaceKey: "messaging.deliver:run-unmirrored",
+    });
+  });
+
   it("restores queued runs and near-due routines with stable replacement keys", async () => {
     const scheduledFor = new Date(Date.now() + 30_000);
     const controlExpiresAt = new Date(Date.now() + 15_000);
@@ -134,6 +178,7 @@ describe("createJobReconciler", () => {
       run: { findMany: vi.fn(async () => []) },
       routine: { findMany: vi.fn(async () => []) },
       computer: { findMany: computerFindMany },
+      messagingOutbound: { findFirst: vi.fn(async () => null) },
     } as unknown as PrismaClient;
     const { jobs, enqueue } = publisher();
     const reconciler = createJobReconciler({ prisma, jobs }, { batchSize: 2 });
@@ -182,11 +227,11 @@ describe("createJobReconciler", () => {
       id: `routine-${index + 1}`,
       nextRunAt: new Date(at.getTime() + index),
     }));
-    const runFindMany = vi
-      .fn()
-      .mockResolvedValueOnce(runs.slice(0, 2))
-      .mockResolvedValueOnce(runs.slice(2, 4))
-      .mockResolvedValueOnce(runs.slice(4));
+    const runPages = [runs.slice(0, 2), runs.slice(2, 4), runs.slice(4)];
+    let runPage = 0;
+    const runFindMany = vi.fn(async (args: { where?: Record<string, unknown> } = {}) =>
+      args.where?.messagingMirroredAt === null ? [] : (runPages[runPage++] ?? []),
+    );
     const routineFindMany = vi
       .fn()
       .mockResolvedValueOnce(routines.slice(0, 2))
@@ -196,6 +241,7 @@ describe("createJobReconciler", () => {
       run: { findMany: runFindMany },
       routine: { findMany: routineFindMany },
       computer: { findMany: vi.fn(async () => []) },
+      messagingOutbound: { findFirst: vi.fn(async () => null) },
     } as unknown as PrismaClient;
     const { jobs, enqueue } = publisher();
     const reconciler = createJobReconciler({ prisma, jobs }, { batchSize: 2 });
@@ -217,7 +263,7 @@ describe("createJobReconciler", () => {
       "run:run-5",
       "routine:routine-5",
     ]);
-    expect(runFindMany.mock.calls[1]?.[0]).toMatchObject({
+    expect(runFindMany.mock.calls[2]?.[0]).toMatchObject({
       orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
       where: {
         AND: [
@@ -262,6 +308,7 @@ describe("createJobReconciler", () => {
     expect(prisma.run.findMany).not.toHaveBeenCalled();
     expect(prisma.routine.findMany).not.toHaveBeenCalled();
     expect(prisma.computer.findMany).not.toHaveBeenCalled();
+    expect(prisma.messagingOutbound.findFirst).not.toHaveBeenCalled();
     expect(enqueue).not.toHaveBeenCalled();
     expect(leadership.release).toHaveBeenCalledOnce();
   });
@@ -278,18 +325,20 @@ describe("createJobReconciler", () => {
       error: null,
       bot: { name: "Researcher" },
     };
-    const runFindMany = vi
-      .fn()
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([terminalRun])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([terminalRun]);
+    let terminalScan = 0;
+    const runFindMany = vi.fn(async (args: { where?: Record<string, unknown> } = {}) => {
+      if (args.where?.messagingMirroredAt === null) return [];
+      if (args.where?.trigger === "bot_message") {
+        terminalScan += 1;
+        return terminalScan === 2 ? [] : [terminalRun];
+      }
+      return [];
+    });
     const prisma = {
       run: { findMany: runFindMany, updateMany: vi.fn(async () => ({ count: 1 })) },
       routine: { findMany: vi.fn(async () => []) },
       computer: { findMany: vi.fn(async () => []) },
+      messagingOutbound: { findFirst: vi.fn(async () => null) },
       message: {
         findFirst: vi.fn(async () => ({ blocks: [{ kind: "text", text: "Finished." }] })),
       },
@@ -305,7 +354,7 @@ describe("createJobReconciler", () => {
     await reconciler.reconcileOnce();
 
     expect(runFindMany).toHaveBeenNthCalledWith(
-      2,
+      3,
       expect.objectContaining({
         orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
         where: {

--- a/packages/adapters/src/job-reconciler.ts
+++ b/packages/adapters/src/job-reconciler.ts
@@ -1,4 +1,9 @@
-import { type JobPublisher, routineWakeupJob, runContinueJob } from "@rakazo/adapter-kit";
+import {
+  type JobPublisher,
+  messagingDeliverJob,
+  routineWakeupJob,
+  runContinueJob,
+} from "@rakazo/adapter-kit";
 import type { MessageBlock } from "@rakazo/contracts";
 import type { Pool, PrismaClient, ThreadEvents } from "@rakazo/db";
 import type { PoolClient } from "pg";
@@ -146,7 +151,7 @@ export function createJobReconciler(
             }
           : { controlLeaseExpiresAt: null, id: { gt: controlCursor.id } }
         : undefined;
-      const [runs, routines, controls] = await Promise.all([
+      const [runs, routines, controls, dueOutbound, unmirroredMessagingRuns] = await Promise.all([
         deps.prisma.run.findMany({
           where: {
             AND: [
@@ -205,6 +210,19 @@ export function createJobReconciler(
             controlLeaseId: true,
             controlLeaseExpiresAt: true,
           },
+        }),
+        deps.prisma.messagingOutbound.findFirst({
+          where: {
+            status: "pending",
+            OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: now } }],
+          },
+          select: { id: true },
+        }),
+        deps.prisma.run.findMany({
+          where: { trigger: "messaging", status: "completed", messagingMirroredAt: null },
+          orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+          take: batchSize,
+          select: { id: true },
         }),
       ]);
 
@@ -284,6 +302,8 @@ export function createJobReconciler(
               ]
             : [],
         ),
+        ...(dueOutbound ? [deps.jobs.enqueue(messagingDeliverJob())] : []),
+        ...unmirroredMessagingRuns.map((run) => deps.jobs.enqueue(messagingDeliverJob(run.id))),
       ]);
 
       const lastRun = runs.at(-1);

--- a/packages/adapters/src/messaging-delivery.test.ts
+++ b/packages/adapters/src/messaging-delivery.test.ts
@@ -75,7 +75,10 @@ function createDeps(overrides: {
   const identityRow =
     overrides.identity === null ? null : { ...identity, ...(overrides.identity ?? {}) };
   const prisma = {
-    run: { findUnique: vi.fn(async () => overrides.run ?? messagingRun) },
+    run: {
+      findUnique: vi.fn(async () => overrides.run ?? messagingRun),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
     message: {
       findMany: vi.fn(
         async () =>
@@ -203,6 +206,10 @@ describe("deliverMessagingOutbound", () => {
     expect(deps.prisma.messagingIdentity.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: { outboundSinceInbound: { increment: 1 } } }),
     );
+    expect(deps.prisma.run.updateMany).toHaveBeenCalledWith({
+      where: { id: "run-1", trigger: "messaging" },
+      data: { messagingMirroredAt: expect.any(Date) },
+    });
   });
 
   it("resolves the DM thread once and caches it when the identity has none", async () => {
@@ -630,7 +637,10 @@ function createChannelDeps(
     },
   };
   const prisma = {
-    run: { findUnique: vi.fn(async () => channelRun) },
+    run: {
+      findUnique: vi.fn(async () => channelRun),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
     message: {
       findMany: vi.fn(
         async () => overrides.messages ?? [{ id: "m-1", blocks: [{ kind: "text", text }] }],

--- a/packages/adapters/src/messaging-delivery.ts
+++ b/packages/adapters/src/messaging-delivery.ts
@@ -50,9 +50,20 @@ export async function deliverMessagingOutbound(
   context: AdapterContext,
 ): Promise<void> {
   if (input.runId) {
-    await mirrorRun(deps, input.runId);
+    await mirrorMessagingOutbound(deps, input.runId);
   }
   await drain(deps, context);
+}
+
+export async function mirrorMessagingOutbound(
+  deps: MessagingDeliveryDeps,
+  runId: string,
+): Promise<void> {
+  await mirrorRun(deps, runId);
+  await deps.prisma.run.updateMany({
+    where: { id: runId, trigger: "messaging" },
+    data: { messagingMirroredAt: new Date() },
+  });
 }
 
 async function mirrorRun(deps: MessagingDeliveryDeps, runId: string): Promise<void> {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -200,8 +200,8 @@ describe("Pi connector tool dispatch", () => {
       return claimCount === 1
         ? []
         : [
-            { id: "steering-1", text: "Use the newer customer totals." },
-            { id: "steering-2", text: "Keep the original date range." },
+            { id: "steering-1", messageId: "message-1", text: "Use the newer customer totals." },
+            { id: "steering-2", messageId: "message-2", text: "Keep the original date range." },
           ];
     });
     const runtime = new PiAgentRuntime();
@@ -238,8 +238,8 @@ describe("Pi connector tool dispatch", () => {
       claimCount += 1;
       if (claimCount === 1) return [];
       return claimCount === 2
-        ? [{ id: "steering-1", text: "First boundary context." }]
-        : [{ id: "steering-2", text: "Next boundary context." }];
+        ? [{ id: "steering-1", messageId: "message-1", text: "First boundary context." }]
+        : [{ id: "steering-2", messageId: "message-2", text: "Next boundary context." }];
     });
     const runtime = new PiAgentRuntime();
 
@@ -272,8 +272,8 @@ describe("Pi connector tool dispatch", () => {
   it("consumes pending continuation steering once in the first prompt", async () => {
     fakeAgentState.mode = "empty";
     const steering = [
-      { id: "steering-1", text: "Use the newer customer totals." },
-      { id: "steering-2", text: "Keep the original date range." },
+      { id: "steering-1", messageId: "message-1", text: "Use the newer customer totals." },
+      { id: "steering-2", messageId: "message-2", text: "Keep the original date range." },
     ];
     const claimSteering = vi.fn(async (seenIds: string[]) => (seenIds.length ? [] : steering));
     const runtime = new PiAgentRuntime();
@@ -286,8 +286,8 @@ describe("Pi connector tool dispatch", () => {
         prompt: "Respond to the user's steering context.",
         instructions: "Follow the user's instructions.",
         history: [
-          { role: "user", content: steering[0]!.text },
-          { role: "user", content: steering[1]!.text },
+          { id: steering[0]!.messageId, role: "user", content: steering[0]!.text },
+          { id: steering[1]!.messageId, role: "user", content: steering[1]!.text },
           { role: "assistant", content: "Here is the first result." },
         ],
         tools: [],
@@ -316,6 +316,7 @@ describe("Pi connector tool dispatch", () => {
         return [
           {
             id: "initial-image",
+            messageId: "initial-image-message",
             text: "Inspect the first image.",
             images: [
               {
@@ -330,6 +331,7 @@ describe("Pi connector tool dispatch", () => {
       return [
         {
           id: "boundary-image",
+          messageId: "boundary-image-message",
           text: "Compare the second image.",
           images: [
             { name: "second.png", mimeType: "image/png" as const, data: new Uint8Array([4, 5, 6]) },

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -2,7 +2,7 @@ import type { ConnectorTool } from "@rakazo/adapter-kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakeAgentState = vi.hoisted(() => ({
-  mode: "dispatch" as "dispatch" | "empty" | "subagent-limit" | "parent-limit",
+  mode: "dispatch" as "dispatch" | "empty" | "two-boundaries" | "subagent-limit" | "parent-limit",
   abortCount: 0,
   tools: [] as Array<{
     name: string;
@@ -14,6 +14,9 @@ const fakeAgentState = vi.hoisted(() => ({
     args: { collection: "notes", title: "Result", body: "Done" } as Record<string, unknown>,
   },
   preparedMessages: [] as unknown[],
+  steeredMessages: [] as unknown[],
+  initialMessages: [] as unknown[],
+  promptInputs: [] as string[],
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
@@ -27,7 +30,7 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     private aborted = false;
 
     constructor(options: {
-      initialState: { tools: typeof fakeAgentState.tools };
+      initialState: { tools: typeof fakeAgentState.tools; messages: unknown[] };
       prepareNextTurnWithContext?: (input: {
         context: { messages: unknown[] };
       }) => Promise<{ context?: { messages: unknown[] } } | undefined>;
@@ -35,16 +38,21 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
       this.tools = options.initialState.tools;
       this.prepareNextTurnWithContext = options.prepareNextTurnWithContext;
       fakeAgentState.tools = this.tools;
+      fakeAgentState.initialMessages = options.initialState.messages;
     }
 
     subscribe(listener: (event: Record<string, unknown>) => void) {
       this.listeners.push(listener);
     }
 
-    async prompt() {
-      if (fakeAgentState.mode === "empty") {
-        const prepared = await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
-        fakeAgentState.preparedMessages = prepared?.context?.messages ?? [];
+    async prompt(prompt: string) {
+      fakeAgentState.promptInputs.push(prompt);
+      if (fakeAgentState.mode === "empty" || fakeAgentState.mode === "two-boundaries") {
+        await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
+        if (fakeAgentState.mode === "two-boundaries") {
+          await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
+        }
+        fakeAgentState.preparedMessages = [...fakeAgentState.steeredMessages];
         return;
       }
 
@@ -90,6 +98,10 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     }
 
     async waitForIdle() {}
+
+    steer(message: unknown) {
+      fakeAgentState.steeredMessages.push(message);
+    }
 
     abort() {
       this.aborted = true;
@@ -167,6 +179,9 @@ describe("Pi connector tool dispatch", () => {
     fakeAgentState.abortCount = 0;
     fakeAgentState.tools = [];
     fakeAgentState.preparedMessages = [];
+    fakeAgentState.steeredMessages = [];
+    fakeAgentState.initialMessages = [];
+    fakeAgentState.promptInputs = [];
     fakeAgentState.invoke = {
       name: "destination_write",
       args: { collection: "notes", title: "Result", body: "Done" },
@@ -176,10 +191,16 @@ describe("Pi connector tool dispatch", () => {
 
   it("injects durable steering at Pi's next safe turn boundary", async () => {
     fakeAgentState.mode = "empty";
-    const claimSteering = vi.fn(async () => [
-      { id: "steering-1", text: "Use the newer customer totals." },
-      { id: "steering-2", text: "Keep the original date range." },
-    ]);
+    let claimCount = 0;
+    const claimSteering = vi.fn(async () => {
+      claimCount += 1;
+      return claimCount === 1
+        ? []
+        : [
+            { id: "steering-1", text: "Use the newer customer totals." },
+            { id: "steering-2", text: "Keep the original date range." },
+          ];
+    });
     const runtime = new PiAgentRuntime();
 
     for await (const _event of runtime.run(
@@ -199,11 +220,88 @@ describe("Pi connector tool dispatch", () => {
       // Exhaust the runtime event stream.
     }
 
-    expect(claimSteering).toHaveBeenCalledWith([]);
+    expect(claimSteering).toHaveBeenNthCalledWith(1, []);
+    expect(claimSteering).toHaveBeenNthCalledWith(2, []);
     expect(fakeAgentState.preparedMessages).toEqual([
       expect.objectContaining({ role: "user", content: "Use the newer customer totals." }),
       expect.objectContaining({ role: "user", content: "Keep the original date range." }),
     ]);
+  });
+
+  it("defers steering arriving during a continuation to the following boundary", async () => {
+    fakeAgentState.mode = "two-boundaries";
+    let claimCount = 0;
+    const claimSteering = vi.fn(async () => {
+      claimCount += 1;
+      if (claimCount === 1) return [];
+      return claimCount === 2
+        ? [{ id: "steering-1", text: "First boundary context." }]
+        : [{ id: "steering-2", text: "Next boundary context." }];
+    });
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "r",
+        prompt: "continue",
+        instructions: "Follow the user's instructions.",
+        history: [],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(claimSteering).toHaveBeenNthCalledWith(1, []);
+    expect(claimSteering).toHaveBeenNthCalledWith(2, []);
+    expect(claimSteering).toHaveBeenNthCalledWith(3, ["steering-1"]);
+    expect(fakeAgentState.preparedMessages).toEqual([
+      expect.objectContaining({ content: "First boundary context." }),
+      expect.objectContaining({ content: "Next boundary context." }),
+    ]);
+  });
+
+  it("consumes pending continuation steering once in the first prompt", async () => {
+    fakeAgentState.mode = "empty";
+    const steering = [
+      { id: "steering-1", text: "Use the newer customer totals." },
+      { id: "steering-2", text: "Keep the original date range." },
+    ];
+    const claimSteering = vi.fn(async (seenIds: string[]) => (seenIds.length ? [] : steering));
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "continuation",
+        prompt: "Respond to the user's steering context.",
+        instructions: "Follow the user's instructions.",
+        history: [
+          { role: "user", content: steering[0]!.text },
+          { role: "user", content: steering[1]!.text },
+          { role: "assistant", content: "Here is the first result." },
+        ],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(fakeAgentState.promptInputs).toHaveLength(1);
+    for (const item of steering) {
+      expect(fakeAgentState.promptInputs[0]?.split(item.text)).toHaveLength(2);
+      expect(JSON.stringify(fakeAgentState.initialMessages)).not.toContain(item.text);
+    }
+    expect(fakeAgentState.steeredMessages).toEqual([]);
   });
 
   afterEach(() => {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -17,6 +17,7 @@ const fakeAgentState = vi.hoisted(() => ({
   steeredMessages: [] as unknown[],
   initialMessages: [] as unknown[],
   promptInputs: [] as string[],
+  promptImages: [] as unknown[][],
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
@@ -45,8 +46,9 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
       this.listeners.push(listener);
     }
 
-    async prompt(prompt: string) {
+    async prompt(prompt: string, images?: unknown[]) {
       fakeAgentState.promptInputs.push(prompt);
+      fakeAgentState.promptImages.push(images ?? []);
       if (fakeAgentState.mode === "empty" || fakeAgentState.mode === "two-boundaries") {
         await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
         if (fakeAgentState.mode === "two-boundaries") {
@@ -182,6 +184,7 @@ describe("Pi connector tool dispatch", () => {
     fakeAgentState.steeredMessages = [];
     fakeAgentState.initialMessages = [];
     fakeAgentState.promptInputs = [];
+    fakeAgentState.promptImages = [];
     fakeAgentState.invoke = {
       name: "destination_write",
       args: { collection: "notes", title: "Result", body: "Done" },
@@ -302,6 +305,68 @@ describe("Pi connector tool dispatch", () => {
       expect(JSON.stringify(fakeAgentState.initialMessages)).not.toContain(item.text);
     }
     expect(fakeAgentState.steeredMessages).toEqual([]);
+  });
+
+  it("delivers images attached to initial and boundary steering", async () => {
+    fakeAgentState.mode = "empty";
+    let claimCount = 0;
+    const claimSteering = vi.fn(async () => {
+      claimCount += 1;
+      if (claimCount === 1) {
+        return [
+          {
+            id: "initial-image",
+            text: "Inspect the first image.",
+            images: [
+              {
+                name: "first.png",
+                mimeType: "image/png" as const,
+                data: new Uint8Array([1, 2, 3]),
+              },
+            ],
+          },
+        ];
+      }
+      return [
+        {
+          id: "boundary-image",
+          text: "Compare the second image.",
+          images: [
+            { name: "second.png", mimeType: "image/png" as const, data: new Uint8Array([4, 5, 6]) },
+          ],
+        },
+      ];
+    });
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "image-steering",
+        prompt: "continue",
+        instructions: "Inspect attached images.",
+        history: [],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(fakeAgentState.promptImages).toEqual([
+      [{ type: "image", data: "AQID", mimeType: "image/png" }],
+    ]);
+    expect(fakeAgentState.steeredMessages).toContainEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "Compare the second image." },
+        { type: "image", data: "BAUG", mimeType: "image/png" },
+      ],
+      timestamp: expect.any(Number),
+    });
   });
 
   afterEach(() => {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -13,6 +13,7 @@ const fakeAgentState = vi.hoisted(() => ({
     name: "destination_write",
     args: { collection: "notes", title: "Result", body: "Done" } as Record<string, unknown>,
   },
+  preparedMessages: [] as unknown[],
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
@@ -20,10 +21,19 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     state = { errorMessage: undefined as string | undefined, messages: [] as unknown[] };
     private readonly tools: typeof fakeAgentState.tools;
     private readonly listeners: Array<(event: Record<string, unknown>) => void> = [];
+    private readonly prepareNextTurnWithContext?: (input: {
+      context: { messages: unknown[] };
+    }) => Promise<{ context?: { messages: unknown[] } } | undefined>;
     private aborted = false;
 
-    constructor(options: { initialState: { tools: typeof fakeAgentState.tools } }) {
+    constructor(options: {
+      initialState: { tools: typeof fakeAgentState.tools };
+      prepareNextTurnWithContext?: (input: {
+        context: { messages: unknown[] };
+      }) => Promise<{ context?: { messages: unknown[] } } | undefined>;
+    }) {
       this.tools = options.initialState.tools;
+      this.prepareNextTurnWithContext = options.prepareNextTurnWithContext;
       fakeAgentState.tools = this.tools;
     }
 
@@ -33,6 +43,8 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
 
     async prompt() {
       if (fakeAgentState.mode === "empty") {
+        const prepared = await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
+        fakeAgentState.preparedMessages = prepared?.context?.messages ?? [];
         return;
       }
 
@@ -154,11 +166,44 @@ describe("Pi connector tool dispatch", () => {
     fakeAgentState.mode = "dispatch";
     fakeAgentState.abortCount = 0;
     fakeAgentState.tools = [];
+    fakeAgentState.preparedMessages = [];
     fakeAgentState.invoke = {
       name: "destination_write",
       args: { collection: "notes", title: "Result", body: "Done" },
     };
     delete process.env.MAX_TOOL_CALLS_PER_TURN;
+  });
+
+  it("injects durable steering at Pi's next safe turn boundary", async () => {
+    fakeAgentState.mode = "empty";
+    const claimSteering = vi.fn(async () => [
+      { id: "steering-1", text: "Use the newer customer totals." },
+      { id: "steering-2", text: "Keep the original date range." },
+    ]);
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "r",
+        prompt: "prepare the report",
+        instructions: "Follow the user's instructions.",
+        history: [],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(claimSteering).toHaveBeenCalledWith([]);
+    expect(fakeAgentState.preparedMessages).toEqual([
+      expect.objectContaining({ role: "user", content: "Use the newer customer totals." }),
+      expect.objectContaining({ role: "user", content: "Keep the original date range." }),
+    ]);
   });
 
   afterEach(() => {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -144,13 +144,43 @@ export class PiAgentRuntime implements AgentRuntime {
           pausePending: false,
         };
         const tools = toAgentTools(toolDefs, host);
-        const history = toHistory(request.history, request.prompt);
+        const seenSteeringIds: string[] = [];
+        const initialSteering = request.claimSteering ? await request.claimSteering([]) : [];
+        seenSteeringIds.push(...initialSteering.map((item) => item.id));
+        const history = toHistory(
+          withoutSteeringMessages(
+            request.history,
+            initialSteering.map((item) => item.text),
+          ),
+          request.prompt,
+        );
+        const initialPrompt = initialSteering.length
+          ? `${request.prompt}\n\nAdditional user context:\n${initialSteering
+              .map((item) => item.text)
+              .join("\n")}`
+          : request.prompt;
 
-        const agent = new Agent({
+        let agent: Agent;
+        agent = new Agent({
+          steeringMode: "all",
           streamFn: (m, ctx, options) =>
             models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
           getApiKey: async () => apiKey,
           transformContext: async (messages) => pruneComputerScreenshotContext(messages),
+          prepareNextTurnWithContext: async () => {
+            if (!request.claimSteering) return undefined;
+            try {
+              const steering = await request.claimSteering([...seenSteeringIds]);
+              if (steering.length === 0) return undefined;
+              seenSteeringIds.push(...steering.map((item) => item.id));
+              for (const item of steering) {
+                agent.steer({ role: "user", content: item.text, timestamp: Date.now() });
+              }
+            } catch {
+              // Durable steering remains claimable at the next boundary or retry.
+            }
+            return undefined;
+          },
           initialState: {
             systemPrompt:
               request.instructions ||
@@ -231,7 +261,7 @@ export class PiAgentRuntime implements AgentRuntime {
           mimeType: image.mimeType,
         }));
         try {
-          await agent.prompt(request.prompt, images?.length ? images : undefined);
+          await agent.prompt(initialPrompt, images?.length ? images : undefined);
           await agent.waitForIdle();
         } finally {
           signal.removeEventListener("abort", onAbort);
@@ -444,8 +474,18 @@ function stableToolNameHash(name: string): string {
 }
 
 function toHistory(history: AgentRunRequest["history"], prompt: string) {
-  const last = history.at(-1);
-  const prior = last?.role === "user" && last.content === prompt ? history.slice(0, -1) : history;
+  let duplicatePromptIndex = -1;
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index];
+    if (message?.role === "user" && message.content === prompt) {
+      duplicatePromptIndex = index;
+      break;
+    }
+  }
+  const prior =
+    duplicatePromptIndex < 0
+      ? history
+      : history.filter((_, index) => index !== duplicatePromptIndex);
   return prior
     .filter((m) => m.role === "user" || m.role === "assistant")
     .map((m) =>
@@ -453,6 +493,25 @@ function toHistory(history: AgentRunRequest["history"], prompt: string) {
         ? { role: "user" as const, content: `Assistant: ${m.content}`, timestamp: Date.now() }
         : { role: "user" as const, content: m.content, timestamp: Date.now() },
     );
+}
+
+function withoutSteeringMessages(
+  history: AgentRunRequest["history"],
+  steering: string[],
+): AgentRunRequest["history"] {
+  if (steering.length === 0) return history;
+  const result = [...history];
+  let beforeIndex = result.length - 1;
+  for (let steeringIndex = steering.length - 1; steeringIndex >= 0; steeringIndex -= 1) {
+    for (let index = beforeIndex; index >= 0; index -= 1) {
+      const message = result[index];
+      if (message?.role !== "user" || message.content !== steering[steeringIndex]) continue;
+      result.splice(index, 1);
+      beforeIndex = index - 1;
+      break;
+    }
+  }
+  return result;
 }
 
 function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): AgentTool {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -150,7 +150,7 @@ export class PiAgentRuntime implements AgentRuntime {
         const history = toHistory(
           withoutSteeringMessages(
             request.history,
-            initialSteering.map((item) => item.text),
+            initialSteering.map((item) => item.historyText ?? item.text),
           ),
           request.prompt,
         );
@@ -169,15 +169,16 @@ export class PiAgentRuntime implements AgentRuntime {
           transformContext: async (messages) => pruneComputerScreenshotContext(messages),
           prepareNextTurnWithContext: async () => {
             if (!request.claimSteering) return undefined;
-            try {
-              const steering = await request.claimSteering([...seenSteeringIds]);
-              if (steering.length === 0) return undefined;
-              seenSteeringIds.push(...steering.map((item) => item.id));
-              for (const item of steering) {
-                agent.steer({ role: "user", content: item.text, timestamp: Date.now() });
-              }
-            } catch {
-              // Durable steering remains claimable at the next boundary or retry.
+            const steering = await request.claimSteering([...seenSteeringIds]);
+            if (steering.length === 0) return undefined;
+            seenSteeringIds.push(...steering.map((item) => item.id));
+            for (const item of steering) {
+              const images = toPiImages(item.images);
+              agent.steer({
+                role: "user",
+                content: images.length ? [{ type: "text", text: item.text }, ...images] : item.text,
+                timestamp: Date.now(),
+              });
             }
             return undefined;
           },
@@ -255,11 +256,10 @@ export class PiAgentRuntime implements AgentRuntime {
 
         // No "working…" progress push here: the shell already renders its own
         // placeholder while a run is active, and emitting one here shows two.
-        const images = request.currentTurnImages?.map((image) => ({
-          type: "image" as const,
-          data: Buffer.from(image.data).toString("base64"),
-          mimeType: image.mimeType,
-        }));
+        const images = toPiImages([
+          ...(request.currentTurnImages ?? []),
+          ...initialSteering.flatMap((item) => item.images ?? []),
+        ]);
         try {
           await agent.prompt(initialPrompt, images?.length ? images : undefined);
           await agent.waitForIdle();
@@ -313,6 +313,14 @@ export class PiAgentRuntime implements AgentRuntime {
       running.delete(request.runId);
     }
   }
+}
+
+function toPiImages(images: AgentRunRequest["currentTurnImages"]) {
+  return (images ?? []).map((image) => ({
+    type: "image" as const,
+    data: Buffer.from(image.data).toString("base64"),
+    mimeType: image.mimeType,
+  }));
 }
 
 function configuredOpenRouterModel(id: string): Model<"openai-completions"> {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -14,6 +14,7 @@ import type {
   AgentRunRequest,
   AgentRuntime,
   AgentRuntimeEvent,
+  AgentSteeringMessage,
   AgentToolExecutionResult,
   ConnectorTool,
 } from "@rakazo/adapter-kit";
@@ -148,11 +149,9 @@ export class PiAgentRuntime implements AgentRuntime {
         const initialSteering = request.claimSteering ? await request.claimSteering([]) : [];
         seenSteeringIds.push(...initialSteering.map((item) => item.id));
         const history = toHistory(
-          withoutSteeringMessages(
-            request.history,
-            initialSteering.map((item) => item.historyText ?? item.text),
-          ),
+          withoutSteeringMessages(request.history, initialSteering),
           request.prompt,
+          request.sourceMessageId,
         );
         const initialPrompt = initialSteering.length
           ? `${request.prompt}\n\nAdditional user context:\n${initialSteering
@@ -481,11 +480,18 @@ function stableToolNameHash(name: string): string {
   return (hash >>> 0).toString(36);
 }
 
-function toHistory(history: AgentRunRequest["history"], prompt: string) {
+function toHistory(
+  history: AgentRunRequest["history"],
+  prompt: string,
+  sourceMessageId?: string | null,
+) {
   let duplicatePromptIndex = -1;
   for (let index = history.length - 1; index >= 0; index -= 1) {
     const message = history[index];
-    if (message?.role === "user" && message.content === prompt) {
+    if (
+      message?.role === "user" &&
+      (sourceMessageId ? message.id === sourceMessageId : message.content === prompt)
+    ) {
       duplicatePromptIndex = index;
       break;
     }
@@ -505,15 +511,23 @@ function toHistory(history: AgentRunRequest["history"], prompt: string) {
 
 function withoutSteeringMessages(
   history: AgentRunRequest["history"],
-  steering: string[],
+  steering: AgentSteeringMessage[],
 ): AgentRunRequest["history"] {
   if (steering.length === 0) return history;
   const result = [...history];
   let beforeIndex = result.length - 1;
   for (let steeringIndex = steering.length - 1; steeringIndex >= 0; steeringIndex -= 1) {
+    const steeringMessage = steering[steeringIndex];
     for (let index = beforeIndex; index >= 0; index -= 1) {
       const message = result[index];
-      if (message?.role !== "user" || message.content !== steering[steeringIndex]) continue;
+      if (
+        message?.role !== "user" ||
+        (message.id
+          ? message.id !== steeringMessage?.messageId
+          : message.content !== (steeringMessage?.historyText ?? steeringMessage?.text))
+      ) {
+        continue;
+      }
       result.splice(index, 1);
       beforeIndex = index - 1;
       break;

--- a/packages/adapters/src/wakeup.test.ts
+++ b/packages/adapters/src/wakeup.test.ts
@@ -168,6 +168,33 @@ describe("InMemoryJobQueue", () => {
     await expect(enqueue).rejects.toThrow("Background job publisher is closed");
   });
 
+  it("rejects a keyed enqueue that resumes after stop", async () => {
+    const queue = new InMemoryJobQueue();
+    await queue.start(handlers());
+    let releaseCancel: () => void = () => undefined;
+    let markCancelling: () => void = () => undefined;
+    const cancelling = new Promise<void>((resolve) => {
+      markCancelling = resolve;
+    });
+    vi.spyOn(queue, "cancel").mockImplementationOnce(async () => {
+      markCancelling();
+      await new Promise<void>((resolve) => {
+        releaseCancel = resolve;
+      });
+    });
+
+    const enqueue = queue.enqueue({
+      name: "computer.sleep",
+      payload: { computerId: "computer-1" },
+      replaceKey: "computer:computer-1",
+    });
+    await cancelling;
+    await queue.stop();
+    releaseCancel();
+
+    await expect(enqueue).rejects.toThrow("Background job publisher is stopped");
+  });
+
   it("drains an accepted immediate timer during close", async () => {
     const queue = new InMemoryJobQueue();
     const target = handlers();

--- a/packages/adapters/src/wakeup.test.ts
+++ b/packages/adapters/src/wakeup.test.ts
@@ -79,10 +79,18 @@ describe("InMemoryJobQueue", () => {
     let markStarted: () => void = () => undefined;
     let nestedEnqueueFailed = false;
     let delayedEnqueueFailed = false;
+    let chainedEnqueueFailed = false;
     const started = new Promise<void>((resolve) => {
       markStarted = resolve;
     });
     const target = handlers();
+    target["computer.sleep"] = vi.fn(async () => {
+      try {
+        await queue.enqueue({ name: "run.continue", payload: { runId: "chained-run" } });
+      } catch {
+        chainedEnqueueFailed = true;
+      }
+    });
     target["run.continue"] = vi.fn(async () => {
       markStarted();
       await new Promise<void>((resolve) => {
@@ -127,7 +135,9 @@ describe("InMemoryJobQueue", () => {
     expect(closeState).toBe("waiting");
     expect(nestedEnqueueFailed).toBe(false);
     expect(delayedEnqueueFailed).toBe(false);
+    expect(chainedEnqueueFailed).toBe(true);
     expect(target["computer.sleep"]).toHaveBeenCalledTimes(1);
+    expect(target["run.continue"]).toHaveBeenCalledTimes(1);
     expect(target["routine.wakeup"]).not.toHaveBeenCalled();
     await queue.close();
   });
@@ -156,5 +166,32 @@ describe("InMemoryJobQueue", () => {
     releaseCancel();
 
     await expect(enqueue).rejects.toThrow("Background job publisher is closed");
+  });
+
+  it("drains an accepted immediate timer during close", async () => {
+    const queue = new InMemoryJobQueue();
+    const target = handlers();
+    await queue.start(target);
+
+    await queue.enqueue({ name: "computer.sleep", payload: { computerId: "computer-1" } });
+    await queue.close();
+
+    expect(target["computer.sleep"]).toHaveBeenCalledOnce();
+  });
+
+  it("rejects jobs after stop until the worker restarts", async () => {
+    const queue = new InMemoryJobQueue();
+    const target = handlers();
+    await queue.start(target);
+    await queue.stop();
+
+    await expect(
+      queue.enqueue({ name: "computer.sleep", payload: { computerId: "computer-1" } }),
+    ).rejects.toThrow("Background job publisher is stopped");
+
+    await queue.start(target);
+    await queue.enqueue({ name: "computer.sleep", payload: { computerId: "computer-1" } });
+    await queue.close();
+    expect(target["computer.sleep"]).toHaveBeenCalledOnce();
   });
 });

--- a/packages/adapters/src/wakeup.test.ts
+++ b/packages/adapters/src/wakeup.test.ts
@@ -68,11 +68,17 @@ describe("InMemoryJobQueue", () => {
     await queue.close();
   });
 
-  it("waits for an active handler before closing", async () => {
+  it.each([
+    ["stop", "stop"],
+    ["close", "close"],
+    ["stop", "close"],
+    ["close", "stop"],
+  ] as const)("waits for an active handler before %s/%s", async (first, second) => {
     const queue = new InMemoryJobQueue();
     let releaseHandler: () => void = () => undefined;
     let markStarted: () => void = () => undefined;
     let nestedEnqueueFailed = false;
+    let delayedEnqueueFailed = false;
     const started = new Promise<void>((resolve) => {
       markStarted = resolve;
     });
@@ -83,16 +89,35 @@ describe("InMemoryJobQueue", () => {
         releaseHandler = resolve;
       });
       try {
-        await queue.enqueue({ name: "computer.sleep", payload: { computerId: "computer-1" } });
+        await queue.enqueue({
+          name: "computer.sleep",
+          payload: { computerId: "computer-1" },
+          replaceKey: "keep-during-close",
+        });
+        await queue.enqueue({
+          name: "computer.sleep",
+          payload: { computerId: "cancelled-computer" },
+          replaceKey: "cancel-during-close",
+        });
+        await queue.cancel("cancel-during-close");
       } catch {
         nestedEnqueueFailed = true;
+      }
+      try {
+        await queue.enqueue({
+          name: "routine.wakeup",
+          payload: { routineId: "routine-1", scheduledFor: "2099-01-01T00:00:00.000Z" },
+          availableAt: new Date("2099-01-01T00:00:00.000Z"),
+        });
+      } catch {
+        delayedEnqueueFailed = true;
       }
     });
     await queue.start(target);
     await queue.enqueue({ name: "run.continue", payload: { runId: "run-1" } });
     await started;
 
-    const closing = queue.close();
+    const closing = Promise.all([queue[first](), queue[second]()] as const);
     const closeState = await Promise.race([
       closing.then(() => "closed" as const),
       new Promise<"waiting">((resolve) => setTimeout(() => resolve("waiting"), 5)),
@@ -101,5 +126,35 @@ describe("InMemoryJobQueue", () => {
     await closing;
     expect(closeState).toBe("waiting");
     expect(nestedEnqueueFailed).toBe(false);
+    expect(delayedEnqueueFailed).toBe(false);
+    expect(target["computer.sleep"]).toHaveBeenCalledTimes(1);
+    expect(target["routine.wakeup"]).not.toHaveBeenCalled();
+    await queue.close();
+  });
+
+  it("rejects a keyed enqueue that resumes after close", async () => {
+    const queue = new InMemoryJobQueue();
+    let releaseCancel: () => void = () => undefined;
+    let markCancelling: () => void = () => undefined;
+    const cancelling = new Promise<void>((resolve) => {
+      markCancelling = resolve;
+    });
+    vi.spyOn(queue, "cancel").mockImplementationOnce(async () => {
+      markCancelling();
+      await new Promise<void>((resolve) => {
+        releaseCancel = resolve;
+      });
+    });
+
+    const enqueue = queue.enqueue({
+      name: "computer.sleep",
+      payload: { computerId: "computer-1" },
+      replaceKey: "computer:computer-1",
+    });
+    await cancelling;
+    await queue.close();
+    releaseCancel();
+
+    await expect(enqueue).rejects.toThrow("Background job publisher is closed");
   });
 });

--- a/packages/adapters/src/wakeup.test.ts
+++ b/packages/adapters/src/wakeup.test.ts
@@ -67,4 +67,39 @@ describe("InMemoryJobQueue", () => {
     expect(target["computer.sleep"]).toHaveBeenCalledTimes(1);
     await queue.close();
   });
+
+  it("waits for an active handler before closing", async () => {
+    const queue = new InMemoryJobQueue();
+    let releaseHandler: () => void = () => undefined;
+    let markStarted: () => void = () => undefined;
+    let nestedEnqueueFailed = false;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const target = handlers();
+    target["run.continue"] = vi.fn(async () => {
+      markStarted();
+      await new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
+      try {
+        await queue.enqueue({ name: "computer.sleep", payload: { computerId: "computer-1" } });
+      } catch {
+        nestedEnqueueFailed = true;
+      }
+    });
+    await queue.start(target);
+    await queue.enqueue({ name: "run.continue", payload: { runId: "run-1" } });
+    await started;
+
+    const closing = queue.close();
+    const closeState = await Promise.race([
+      closing.then(() => "closed" as const),
+      new Promise<"waiting">((resolve) => setTimeout(() => resolve("waiting"), 5)),
+    ]);
+    releaseHandler();
+    await closing;
+    expect(closeState).toBe("waiting");
+    expect(nestedEnqueueFailed).toBe(false);
+  });
 });

--- a/packages/adapters/src/wakeup.ts
+++ b/packages/adapters/src/wakeup.ts
@@ -101,6 +101,7 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
     if (job.replaceKey) {
       await this.cancel(job.replaceKey);
       if (this.closed) throw new Error("Background job publisher is closed");
+      if (this.stopped) throw new Error("Background job publisher is stopped");
       if (this.closing) {
         this.enqueueWhileClosing(job);
         return;

--- a/packages/adapters/src/wakeup.ts
+++ b/packages/adapters/src/wakeup.ts
@@ -80,16 +80,20 @@ export class GraphileJobWorkerHost implements JobWorkerHost {
 export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
   private handlers: BackgroundJobHandlers | undefined;
   private readonly timers = new Set<ReturnType<typeof setTimeout>>();
+  private readonly scheduled = new Map<ReturnType<typeof setTimeout>, BackgroundJob>();
   private readonly keyed = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly active = new Set<Promise<void>>();
   private readonly closingJobs: BackgroundJob[] = [];
   private draining: Promise<void> | undefined;
   private closed = false;
+  private stopped = false;
   private closing = false;
+  private acceptingClosingJobs = false;
   private closeRequested = false;
 
   async enqueue(job: BackgroundJob): Promise<void> {
     if (this.closed) throw new Error("Background job publisher is closed");
+    if (this.stopped) throw new Error("Background job publisher is stopped");
     if (this.closing) {
       this.enqueueWhileClosing(job);
       return;
@@ -105,6 +109,7 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
     const delay = job.availableAt ? Math.max(0, job.availableAt.getTime() - Date.now()) : 0;
     const timer = setTimeout(() => {
       this.timers.delete(timer);
+      this.scheduled.delete(timer);
       if (job.replaceKey && this.keyed.get(job.replaceKey) === timer) {
         this.keyed.delete(job.replaceKey);
       }
@@ -113,6 +118,7 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
       void this.dispatch(handlers, job);
     }, delay);
     this.timers.add(timer);
+    this.scheduled.set(timer, job);
     if (job.replaceKey) this.keyed.set(job.replaceKey, timer);
   }
 
@@ -124,10 +130,12 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
     clearTimeout(timer);
     this.keyed.delete(replaceKey);
     this.timers.delete(timer);
+    this.scheduled.delete(timer);
   }
 
   async start(handlers: BackgroundJobHandlers): Promise<void> {
     this.handlers = handlers;
+    this.stopped = false;
   }
 
   async stop(): Promise<void> {
@@ -159,6 +167,7 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
       // schedulers reconcile them after restart. Never run them early.
       return;
     }
+    if (!this.acceptingClosingJobs) throw new Error("Background job publisher is closing");
     this.closingJobs.push(job);
   }
 
@@ -175,17 +184,29 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
 
   private async performDrain(): Promise<void> {
     this.closing = true;
-    for (const timer of this.timers) clearTimeout(timer);
-    this.timers.clear();
-    this.keyed.clear();
-    while (this.active.size > 0 || this.closingJobs.length > 0) {
-      await Promise.all(this.active);
-      const handlers = this.handlers;
-      if (!handlers) throw new Error("Background job publisher is closing");
-      for (const job of this.closingJobs.splice(0)) void this.dispatch(handlers, job);
+    this.acceptingClosingJobs = true;
+    for (const timer of this.timers) {
+      clearTimeout(timer);
+      const job = this.scheduled.get(timer);
+      if (job) this.enqueueWhileClosing(job);
     }
+    this.timers.clear();
+    this.scheduled.clear();
+    this.keyed.clear();
+    await Promise.all(this.active);
+    this.acceptingClosingJobs = false;
+    const handlers = this.handlers;
+    const closingJobs = this.closingJobs.splice(0);
+    if (!handlers && closingJobs.length > 0) {
+      throw new Error("Background job publisher is closing");
+    }
+    if (handlers) {
+      for (const job of closingJobs) void this.dispatch(handlers, job);
+    }
+    await Promise.all(this.active);
     this.handlers = undefined;
     this.closed = this.closeRequested;
+    this.stopped = !this.closeRequested;
     this.closing = false;
   }
 }

--- a/packages/adapters/src/wakeup.ts
+++ b/packages/adapters/src/wakeup.ts
@@ -82,13 +82,26 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
   private readonly timers = new Set<ReturnType<typeof setTimeout>>();
   private readonly keyed = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly active = new Set<Promise<void>>();
+  private readonly closingJobs: BackgroundJob[] = [];
+  private draining: Promise<void> | undefined;
   private closed = false;
   private closing = false;
+  private closeRequested = false;
 
   async enqueue(job: BackgroundJob): Promise<void> {
     if (this.closed) throw new Error("Background job publisher is closed");
-    if (this.closing) return;
-    if (job.replaceKey) await this.cancel(job.replaceKey);
+    if (this.closing) {
+      this.enqueueWhileClosing(job);
+      return;
+    }
+    if (job.replaceKey) {
+      await this.cancel(job.replaceKey);
+      if (this.closed) throw new Error("Background job publisher is closed");
+      if (this.closing) {
+        this.enqueueWhileClosing(job);
+        return;
+      }
+    }
     const delay = job.availableAt ? Math.max(0, job.availableAt.getTime() - Date.now()) : 0;
     const timer = setTimeout(() => {
       this.timers.delete(timer);
@@ -97,21 +110,19 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
       }
       const handlers = this.handlers;
       if (!handlers) return;
-      const active = dispatchBackgroundJob(handlers, job.name, job.payload).catch((error) => {
-        console.error(job.name, error);
-      });
-      this.active.add(active);
-      void active.finally(() => this.active.delete(active));
+      void this.dispatch(handlers, job);
     }, delay);
     this.timers.add(timer);
     if (job.replaceKey) this.keyed.set(job.replaceKey, timer);
   }
 
-  async cancel(key: string): Promise<void> {
-    const timer = this.keyed.get(key);
+  async cancel(replaceKey: string): Promise<void> {
+    const closing = this.closingJobs.findIndex((job) => job.replaceKey === replaceKey);
+    if (closing >= 0) this.closingJobs.splice(closing, 1);
+    const timer = this.keyed.get(replaceKey);
     if (!timer) return;
     clearTimeout(timer);
-    this.keyed.delete(key);
+    this.keyed.delete(replaceKey);
     this.timers.delete(timer);
   }
 
@@ -120,18 +131,61 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
   }
 
   async stop(): Promise<void> {
-    this.handlers = undefined;
-    for (const timer of this.timers) clearTimeout(timer);
-    this.timers.clear();
-    this.keyed.clear();
-    await Promise.all(this.active);
+    await this.drain();
+  }
+
+  private dispatch(handlers: BackgroundJobHandlers, job: BackgroundJob): Promise<void> {
+    const active = dispatchBackgroundJob(handlers, job.name, job.payload).catch((error) => {
+      console.error(job.name, error);
+    });
+    this.active.add(active);
+    void active.finally(() => this.active.delete(active));
+    return active;
   }
 
   async close(): Promise<void> {
     if (this.closed) return;
+    this.closeRequested = true;
+    await this.drain();
+  }
+
+  private enqueueWhileClosing(job: BackgroundJob): void {
+    if (job.replaceKey) {
+      const existing = this.closingJobs.findIndex((queued) => queued.replaceKey === job.replaceKey);
+      if (existing >= 0) this.closingJobs.splice(existing, 1);
+    }
+    if (job.availableAt && job.availableAt.getTime() > Date.now()) {
+      // Delayed in-memory jobs are intentionally discarded on shutdown; durable
+      // schedulers reconcile them after restart. Never run them early.
+      return;
+    }
+    this.closingJobs.push(job);
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining) return this.draining;
+    const draining = this.performDrain();
+    this.draining = draining;
+    try {
+      await draining;
+    } finally {
+      if (this.draining === draining) this.draining = undefined;
+    }
+  }
+
+  private async performDrain(): Promise<void> {
     this.closing = true;
-    await this.stop();
-    this.closed = true;
+    for (const timer of this.timers) clearTimeout(timer);
+    this.timers.clear();
+    this.keyed.clear();
+    while (this.active.size > 0 || this.closingJobs.length > 0) {
+      await Promise.all(this.active);
+      const handlers = this.handlers;
+      if (!handlers) throw new Error("Background job publisher is closing");
+      for (const job of this.closingJobs.splice(0)) void this.dispatch(handlers, job);
+    }
+    this.handlers = undefined;
+    this.closed = this.closeRequested;
     this.closing = false;
   }
 }

--- a/packages/adapters/src/wakeup.ts
+++ b/packages/adapters/src/wakeup.ts
@@ -81,10 +81,13 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
   private handlers: BackgroundJobHandlers | undefined;
   private readonly timers = new Set<ReturnType<typeof setTimeout>>();
   private readonly keyed = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly active = new Set<Promise<void>>();
   private closed = false;
+  private closing = false;
 
   async enqueue(job: BackgroundJob): Promise<void> {
     if (this.closed) throw new Error("Background job publisher is closed");
+    if (this.closing) return;
     if (job.replaceKey) await this.cancel(job.replaceKey);
     const delay = job.availableAt ? Math.max(0, job.availableAt.getTime() - Date.now()) : 0;
     const timer = setTimeout(() => {
@@ -94,9 +97,11 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
       }
       const handlers = this.handlers;
       if (!handlers) return;
-      void dispatchBackgroundJob(handlers, job.name, job.payload).catch((error) =>
-        console.error(job.name, error),
-      );
+      const active = dispatchBackgroundJob(handlers, job.name, job.payload).catch((error) => {
+        console.error(job.name, error);
+      });
+      this.active.add(active);
+      void active.finally(() => this.active.delete(active));
     }, delay);
     this.timers.add(timer);
     if (job.replaceKey) this.keyed.set(job.replaceKey, timer);
@@ -119,11 +124,14 @@ export class InMemoryJobQueue implements JobPublisher, JobWorkerHost {
     for (const timer of this.timers) clearTimeout(timer);
     this.timers.clear();
     this.keyed.clear();
+    await Promise.all(this.active);
   }
 
   async close(): Promise<void> {
     if (this.closed) return;
-    this.closed = true;
+    this.closing = true;
     await this.stop();
+    this.closed = true;
+    this.closing = false;
   }
 }

--- a/packages/db/prisma/migrations/20260831235900_steering_messages/migration.sql
+++ b/packages/db/prisma/migrations/20260831235900_steering_messages/migration.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "steering_messages" (
+    "id" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "botId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "runId" TEXT,
+    "claimedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "steering_messages_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "steering_messages_messageId_botId_key"
+ON "steering_messages"("messageId", "botId");
+
+CREATE INDEX "steering_messages_botId_runId_createdAt_idx"
+ON "steering_messages"("botId", "runId", "createdAt");
+
+CREATE INDEX "steering_messages_runId_idx" ON "steering_messages"("runId");
+
+ALTER TABLE "steering_messages"
+ADD CONSTRAINT "steering_messages_messageId_fkey"
+FOREIGN KEY ("messageId") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "steering_messages"
+ADD CONSTRAINT "steering_messages_botId_fkey"
+FOREIGN KEY ("botId") REFERENCES "bots"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "steering_messages"
+ADD CONSTRAINT "steering_messages_runId_fkey"
+FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260901040000_messaging_mirror_recovery/migration.sql
+++ b/packages/db/prisma/migrations/20260901040000_messaging_mirror_recovery/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "runs" ADD COLUMN "messagingMirroredAt" TIMESTAMP(3);
+
+-- Existing completed messaging runs predate the recovery marker and must not
+-- be replayed on deploy. Include the legacy trigger because this migration
+-- sorts before the phone-to-messaging vocabulary migration on a fresh database.
+UPDATE "runs"
+SET "messagingMirroredAt" = COALESCE("completedAt", "updatedAt")
+WHERE "trigger" IN ('phone', 'messaging') AND "status" = 'completed';

--- a/packages/db/prisma/migrations/20260901040001_messaging_mirror_recovery_idx_concurrent/migration.sql
+++ b/packages/db/prisma/migrations/20260901040001_messaging_mirror_recovery_idx_concurrent/migration.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY "runs_trigger_status_messagingMirroredAt_updatedAt_idx"
+ON "runs"("trigger", "status", "messagingMirroredAt", "updatedAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -352,6 +352,7 @@ model Bot {
   usageRecords      UsageRecord[]
   tasks             Task[]
   runs              Run[]
+  steeringMessages  SteeringMessage[]
   mcpServers        BotMcpServer[]
   groupMembers      ChatGroupMember[]
 
@@ -469,6 +470,7 @@ model Message {
   clientNonce      String?
   thumbsUp         Boolean   @default(false)
   sourceRuns       Run[]     @relation("RunSourceMessage")
+  steeringMessages SteeringMessage[]
   createdAt        DateTime  @default(now())
 
   @@unique([threadId, seq])
@@ -550,6 +552,7 @@ model Run {
   attempts             Attempt[]
   effects              ExternalEffect[]
   usageRecords         UsageRecord[]
+  steeringMessages     SteeringMessage[]
 
   @@unique([spaceId, clientNonce])
   @@index([status, leaseExpiresAt])
@@ -560,6 +563,24 @@ model Run {
   @@index([threadId, status, createdAt])
   @@index([routineId])
   @@map("runs")
+}
+
+model SteeringMessage {
+  id        String   @id @default(cuid())
+  messageId String
+  message   Message  @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  botId     String
+  bot       Bot      @relation(fields: [botId], references: [id], onDelete: Cascade)
+  userId    String
+  runId     String?
+  run       Run?     @relation(fields: [runId], references: [id], onDelete: SetNull)
+  claimedAt DateTime?
+  createdAt DateTime @default(now())
+
+  @@unique([messageId, botId])
+  @@index([botId, runId, createdAt])
+  @@index([runId])
+  @@map("steering_messages")
 }
 
 model Attempt {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -547,6 +547,7 @@ model Run {
   startedAt            DateTime?
   completedAt          DateTime?
   botOutcomeReturnedAt DateTime?
+  messagingMirroredAt  DateTime?
   createdAt            DateTime         @default(now())
   updatedAt            DateTime         @updatedAt
   attempts             Attempt[]
@@ -558,6 +559,7 @@ model Run {
   @@index([status, leaseExpiresAt])
   @@index([status, updatedAt, id])
   @@index([botOutcomeReturnedAt, status])
+  @@index([trigger, status, messagingMirroredAt, updatedAt])
   @@index([spaceId, botId])
   @@index([sourceMessageId])
   @@index([threadId, status, createdAt])

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -1216,7 +1216,7 @@ describe("sendUserMessage", () => {
       steeringMessage: { create: vi.fn() },
       task: { create: vi.fn() },
       run: {
-        findFirst: vi.fn().mockResolvedValue({ id: "run-0" }),
+        findFirst: vi.fn().mockResolvedValue({ id: "run-0", taskId: "task-0" }),
         findUnique: vi.fn().mockResolvedValue({ status: "running" }),
         create: vi.fn(),
       },
@@ -1241,7 +1241,7 @@ describe("sendUserMessage", () => {
         prompt: "hello",
         trigger: "follow_up",
       }),
-    ).resolves.toEqual({ messageId: "message-1", seq: 4, taskId: null, runId: null });
+    ).resolves.toEqual({ messageId: "message-1", seq: 4, taskId: "task-0", runId: "run-0" });
 
     expect(tx.task.create).not.toHaveBeenCalled();
     expect(tx.run.create).not.toHaveBeenCalled();
@@ -1264,6 +1264,7 @@ describe("claimSteering", () => {
         findMany: vi.fn().mockResolvedValue([
           {
             id: "steer-1",
+            messageId: "message-1",
             message: {
               seq: 5,
               blocks: [
@@ -1277,7 +1278,11 @@ describe("claimSteering", () => {
               ],
             },
           },
-          { id: "steer-2", message: { seq: 6, blocks: [{ kind: "text", text: "Second" }] } },
+          {
+            id: "steer-2",
+            messageId: "message-2",
+            message: { seq: 6, blocks: [{ kind: "text", text: "Second" }] },
+          },
         ]),
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
       },
@@ -1298,6 +1303,7 @@ describe("claimSteering", () => {
     ).resolves.toEqual([
       {
         id: "steer-1",
+        messageId: "message-1",
         text: "First\n[image: chart.png]",
         blocks: [
           { kind: "text", text: "First" },
@@ -1309,7 +1315,12 @@ describe("claimSteering", () => {
           },
         ],
       },
-      { id: "steer-2", text: "Second", blocks: [{ kind: "text", text: "Second" }] },
+      {
+        id: "steer-2",
+        messageId: "message-2",
+        text: "Second",
+        blocks: [{ kind: "text", text: "Second" }],
+      },
     ]);
     expect(tx.run.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -1262,7 +1262,21 @@ describe("claimSteering", () => {
       run: { findFirst: vi.fn().mockResolvedValue({ id: "run-1" }) },
       steeringMessage: {
         findMany: vi.fn().mockResolvedValue([
-          { id: "steer-1", message: { seq: 5, blocks: [{ kind: "text", text: "First" }] } },
+          {
+            id: "steer-1",
+            message: {
+              seq: 5,
+              blocks: [
+                { kind: "text", text: "First" },
+                {
+                  kind: "image",
+                  artifactId: "artifact-1",
+                  name: "chart.png",
+                  mimeType: "image/png",
+                },
+              ],
+            },
+          },
           { id: "steer-2", message: { seq: 6, blocks: [{ kind: "text", text: "Second" }] } },
         ]),
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
@@ -1282,8 +1296,20 @@ describe("claimSteering", () => {
         seenIds: [],
       }),
     ).resolves.toEqual([
-      { id: "steer-1", text: "First" },
-      { id: "steer-2", text: "Second" },
+      {
+        id: "steer-1",
+        text: "First\n[image: chart.png]",
+        blocks: [
+          { kind: "text", text: "First" },
+          {
+            kind: "image",
+            artifactId: "artifact-1",
+            name: "chart.png",
+            mimeType: "image/png",
+          },
+        ],
+      },
+      { id: "steer-2", text: "Second", blocks: [{ kind: "text", text: "Second" }] },
     ]);
     expect(tx.run.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from "./client.js";
 import {
   answerRunInput,
   appendEvent,
+  claimSteering,
   clearThread,
   finalizeComputerControlRelease,
   followThreadEvents,
@@ -1145,6 +1146,7 @@ describe("sendUserMessage", () => {
       task: { create: vi.fn().mockResolvedValue({ id: "task-1" }) },
       run: {
         create: vi.fn().mockResolvedValue({ id: "run-1" }),
+        findFirst: vi.fn().mockResolvedValue(null),
         findUnique: vi.fn().mockResolvedValue({ status: "queued" }),
       },
       event: {
@@ -1199,7 +1201,7 @@ describe("sendUserMessage", () => {
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 8 }));
   });
 
-  it("skips run creation when the bot is already busy and onlyIfIdle is set", async () => {
+  it("persists steering instead of starting a parallel run when the bot is busy", async () => {
     const tx = {
       thread: {
         update: vi
@@ -1209,12 +1211,13 @@ describe("sendUserMessage", () => {
       },
       message: {
         create: vi.fn().mockResolvedValue({ id: "message-1", seq: 4 }),
-        update: vi.fn(),
+        update: vi.fn().mockResolvedValue({ id: "message-1" }),
       },
       steeringMessage: { create: vi.fn() },
       task: { create: vi.fn() },
       run: {
         findFirst: vi.fn().mockResolvedValue({ id: "run-0" }),
+        findUnique: vi.fn().mockResolvedValue({ status: "running" }),
         create: vi.fn(),
       },
       event: {
@@ -1237,15 +1240,59 @@ describe("sendUserMessage", () => {
         blocks: [{ kind: "text", text: "hello" }],
         prompt: "hello",
         trigger: "follow_up",
-        onlyIfIdle: true,
       }),
     ).resolves.toEqual({ messageId: "message-1", seq: 4, taskId: null, runId: null });
 
     expect(tx.task.create).not.toHaveBeenCalled();
     expect(tx.run.create).not.toHaveBeenCalled();
-    expect(tx.message.update).not.toHaveBeenCalled();
+    expect(tx.message.update).toHaveBeenCalledWith({
+      where: { id: "message-1" },
+      data: { runId: "run-0" },
+    });
     expect(tx.steeringMessage.create).toHaveBeenCalledWith({
-      data: { messageId: "message-1", botId: "bot-1" },
+      data: { messageId: "message-1", botId: "bot-1", userId: "user-1", runId: "run-0" },
+    });
+  });
+});
+
+describe("claimSteering", () => {
+  it("claims pending messages for the fenced run in message order", async () => {
+    const tx = {
+      $queryRaw: vi.fn(),
+      run: { findFirst: vi.fn().mockResolvedValue({ id: "run-1" }) },
+      steeringMessage: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "steer-1", message: { seq: 5, blocks: [{ kind: "text", text: "First" }] } },
+          { id: "steer-2", message: { seq: 6, blocks: [{ kind: "text", text: "Second" }] } },
+        ]),
+        updateMany: vi.fn().mockResolvedValue({ count: 2 }),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      claimSteering(prisma, {
+        threadId: "thread-1",
+        botId: "bot-1",
+        runId: "run-1",
+        leaseOwner: "worker-1",
+        leaseFence: 2,
+        seenIds: [],
+      }),
+    ).resolves.toEqual([
+      { id: "steer-1", text: "First" },
+      { id: "steer-2", text: "Second" },
+    ]);
+    expect(tx.run.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ leaseOwner: "worker-1", leaseFence: 2 }),
+      }),
+    );
+    expect(tx.steeringMessage.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["steer-1", "steer-2"] }, claimedAt: null },
+      data: { runId: "run-1", claimedAt: expect.any(Date) },
     });
   });
 });

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -1211,6 +1211,7 @@ describe("sendUserMessage", () => {
         create: vi.fn().mockResolvedValue({ id: "message-1", seq: 4 }),
         update: vi.fn(),
       },
+      steeringMessage: { create: vi.fn() },
       task: { create: vi.fn() },
       run: {
         findFirst: vi.fn().mockResolvedValue({ id: "run-0" }),
@@ -1243,6 +1244,9 @@ describe("sendUserMessage", () => {
     expect(tx.task.create).not.toHaveBeenCalled();
     expect(tx.run.create).not.toHaveBeenCalled();
     expect(tx.message.update).not.toHaveBeenCalled();
+    expect(tx.steeringMessage.create).toHaveBeenCalledWith({
+      data: { messageId: "message-1", botId: "bot-1" },
+    });
   });
 });
 

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -1241,7 +1241,7 @@ describe("sendUserMessage", () => {
         prompt: "hello",
         trigger: "follow_up",
       }),
-    ).resolves.toEqual({ messageId: "message-1", seq: 4, taskId: "task-0", runId: "run-0" });
+    ).resolves.toEqual({ messageId: "message-1", seq: 4, taskId: null, runId: "run-0" });
 
     expect(tx.task.create).not.toHaveBeenCalled();
     expect(tx.run.create).not.toHaveBeenCalled();

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -86,6 +86,7 @@ export interface ClaimSteeringInput {
 export interface ClaimedSteeringMessage {
   id: string;
   text: string;
+  blocks: MessageBlock[];
 }
 
 export interface FinalizeRunResult {
@@ -486,6 +487,7 @@ export async function claimSteering(
     return steering.map((item) => ({
       id: item.id,
       text: blocksToAgentHistoryText(item.message.blocks as MessageBlock[]),
+      blocks: item.message.blocks as MessageBlock[],
     }));
   });
 }

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -350,13 +350,14 @@ export async function sendUserMessage(
       include: { sourceRuns: { orderBy: { createdAt: "asc" }, take: 1 } },
     });
     if (!message) return null;
+    const created = message.sourceRuns[0];
     const run =
-      message.sourceRuns[0] ??
+      created ??
       (message.runId ? await prisma.run.findUnique({ where: { id: message.runId } }) : null);
     return {
       messageId: message.id,
       seq: message.seq,
-      taskId: run?.taskId ?? null,
+      taskId: created?.taskId ?? null,
       runId: run?.id ?? null,
     };
   };
@@ -447,7 +448,7 @@ export async function sendUserMessage(
   return {
     messageId: committed.message.id,
     seq: committed.message.seq,
-    taskId: committed.task?.id ?? committed.busy?.taskId ?? null,
+    taskId: committed.task?.id ?? null,
     runId: committed.run?.id ?? committed.busy?.id ?? null,
   };
 }

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -4,7 +4,12 @@ import {
   MessageBlock as MessageBlockSchema,
   type ProductEvent,
 } from "@rakazo/contracts";
-import { isApprovalAskBlock, isSecretAskBlock, sanitizeJsonValue } from "@rakazo/core";
+import {
+  blocksToAgentHistoryText,
+  isApprovalAskBlock,
+  isSecretAskBlock,
+  sanitizeJsonValue,
+} from "@rakazo/core";
 import type { Prisma, PrismaClient } from "./client.js";
 import {
   assertRunCanWriteHistory,
@@ -28,11 +33,12 @@ export interface AppendEventInput {
 export interface ThreadEvents {
   answerRunInput(input: AnswerRunInput): Promise<boolean>;
   append(input: AppendEventInput): Promise<ProductEvent>;
+  claimSteering(input: ClaimSteeringInput): Promise<ClaimedSteeringMessage[]>;
   clearThread(input: ClearThreadInput): Promise<ClearThreadResult>;
   finalizeComputerControlRelease(
     input: FinalizeComputerControlReleaseInput,
   ): Promise<FinalizeComputerControlReleaseResult | false>;
-  finalizeRun(input: FinalizeRunInput): Promise<boolean>;
+  finalizeRun(input: FinalizeRunInput): Promise<FinalizeRunResult | false>;
   notify(threadId: string, seq: number): Promise<void>;
   pauseRunForInput(input: PauseRunForInput): Promise<boolean>;
   pauseRunForTakeover(input: PauseRunForTakeover): Promise<boolean>;
@@ -66,6 +72,24 @@ export interface FinalizeComputerControlReleaseInput {
 
 export interface FinalizeComputerControlReleaseResult {
   runId: string | null;
+}
+
+export interface ClaimSteeringInput {
+  threadId: string;
+  botId: string;
+  runId: string;
+  leaseOwner: string;
+  leaseFence: number;
+  seenIds: string[];
+}
+
+export interface ClaimedSteeringMessage {
+  id: string;
+  text: string;
+}
+
+export interface FinalizeRunResult {
+  continuationRunId: string | null;
 }
 
 interface FinalizeRunBase {
@@ -158,8 +182,6 @@ export interface SendUserMessageInput {
   prompt: string;
   trigger: "user" | "follow_up" | "webhook" | "messaging";
   clientNonce?: string;
-  /** Skip task/run creation when the bot already has active work (follow-up behavior). */
-  onlyIfIdle?: boolean;
   linkMessageToRun?: boolean;
 }
 
@@ -188,6 +210,7 @@ export function createThreadEvents(
   return {
     answerRunInput: (input) => answerRunInput(prisma, input, realtime, options.runSecretWriter),
     append: (input) => appendEvent(prisma, input, realtime),
+    claimSteering: (input) => claimSteering(prisma, input),
     clearThread: (input) => clearThread(prisma, input, realtime),
     finalizeComputerControlRelease: (input) =>
       finalizeComputerControlRelease(prisma, input, realtime),
@@ -325,7 +348,9 @@ export async function sendUserMessage(
       include: { sourceRuns: { orderBy: { createdAt: "asc" }, take: 1 } },
     });
     if (!message) return null;
-    const run = message.sourceRuns[0] ?? null;
+    const run =
+      message.sourceRuns[0] ??
+      (message.runId ? await prisma.run.findUnique({ where: { id: message.runId } }) : null);
     return {
       messageId: message.id,
       seq: message.seq,
@@ -349,12 +374,14 @@ export async function sendUserMessage(
         blocks: input.blocks,
         clientNonce: input.clientNonce,
       });
-      const busy = input.onlyIfIdle
-        ? await tx.run.findFirst({
-            where: { botId: input.botId, status: { in: ["running", "queued", "leased"] } },
-            select: { id: true },
-          })
-        : null;
+      const busy = await tx.run.findFirst({
+        where: {
+          threadId: input.threadId,
+          botId: input.botId,
+          status: { in: ["running", "queued", "leased", "waiting_input", "waiting_takeover"] },
+        },
+        select: { id: true },
+      });
       let task = null;
       let run = null;
       if (!busy) {
@@ -384,13 +411,23 @@ export async function sendUserMessage(
         if (input.linkMessageToRun) {
           await tx.message.update({ where: { id: message.id }, data: { runId: run.id } });
         }
+      } else {
+        await tx.steeringMessage.create({
+          data: {
+            messageId: message.id,
+            botId: input.botId,
+            userId: input.userId,
+            runId: busy.id,
+          },
+        });
+        await tx.message.update({ where: { id: message.id }, data: { runId: busy.id } });
       }
       const event = await appendEventInTransaction(tx, {
         spaceId: input.spaceId,
         threadId: input.threadId,
         botId: input.botId,
         type: "thread.message.created",
-        runId: run?.id,
+        runId: run?.id ?? busy?.id,
         payload: { messageId: message.id, role: "user", blocks: input.blocks },
       });
       return { message, task, run, event };
@@ -411,6 +448,46 @@ export async function sendUserMessage(
     taskId: committed.task?.id ?? null,
     runId: committed.run?.id ?? null,
   };
+}
+
+export async function claimSteering(
+  prisma: PrismaClient,
+  input: ClaimSteeringInput,
+): Promise<ClaimedSteeringMessage[]> {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.$queryRaw`SELECT id FROM threads WHERE id = ${input.threadId} FOR UPDATE`;
+    const run = await tx.run.findFirst({
+      where: {
+        id: input.runId,
+        threadId: input.threadId,
+        botId: input.botId,
+        status: "running",
+        leaseOwner: input.leaseOwner,
+        leaseFence: input.leaseFence,
+      },
+      select: { id: true },
+    });
+    if (!run) return [];
+    const steering = await tx.steeringMessage.findMany({
+      where: {
+        botId: input.botId,
+        id: input.seenIds.length ? { notIn: input.seenIds } : undefined,
+        OR: [{ runId: null }, { runId: input.runId }],
+        message: { threadId: input.threadId },
+      },
+      include: { message: { select: { blocks: true, seq: true } } },
+      orderBy: [{ message: { seq: "asc" } }, { id: "asc" }],
+    });
+    if (steering.length === 0) return [];
+    await tx.steeringMessage.updateMany({
+      where: { id: { in: steering.map((item) => item.id) }, claimedAt: null },
+      data: { runId: input.runId, claimedAt: new Date() },
+    });
+    return steering.map((item) => ({
+      id: item.id,
+      text: blocksToAgentHistoryText(item.message.blocks as MessageBlock[]),
+    }));
+  });
 }
 
 export async function answerRunInput(
@@ -788,7 +865,7 @@ export async function finalizeRun(
   prisma: PrismaClient,
   input: FinalizeRunInput,
   realtime?: RealtimeFanout,
-): Promise<boolean> {
+): Promise<FinalizeRunResult | false> {
   const committed = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     await tx.$queryRaw`SELECT id FROM threads WHERE id = ${input.threadId} FOR UPDATE`;
     try {
@@ -872,13 +949,81 @@ export async function finalizeRun(
       payload: input.outcome === "completed" ? {} : { error: input.error },
     });
     await tx.event.deleteMany({ where: { runId: input.runId, type: "thread.progress" } });
+    if (input.outcome === "completed") {
+      await tx.steeringMessage.deleteMany({
+        where: { runId: input.runId, claimedAt: { not: null } },
+      });
+      await tx.steeringMessage.updateMany({
+        where: { runId: input.runId },
+        data: { runId: null },
+      });
+    } else {
+      await tx.steeringMessage.updateMany({
+        where: { runId: input.runId },
+        data: { runId: null },
+      });
+    }
+    const continuationRunId = await createSteeringContinuation(tx, input);
     await tx.bot.update({ where: { id: input.botId }, data: { updatedAt: now } });
-    return { threadId: lastEvent.threadId, seq: lastEvent.seq };
+    return { threadId: lastEvent.threadId, seq: lastEvent.seq, continuationRunId };
   });
 
   if (!committed) return false;
   await notifyRealtime(realtime, committed.threadId, committed.seq);
-  return true;
+  return { continuationRunId: committed.continuationRunId };
+}
+
+async function createSteeringContinuation(
+  tx: Prisma.TransactionClient,
+  input: FinalizeRunBase,
+): Promise<string | null> {
+  const active = await tx.run.findFirst({
+    where: {
+      threadId: input.threadId,
+      botId: input.botId,
+      status: { in: ["queued", "leased", "running", "waiting_input", "waiting_takeover"] },
+    },
+    select: { id: true },
+  });
+  if (active) return null;
+  const pending = await tx.steeringMessage.findMany({
+    where: {
+      botId: input.botId,
+      runId: null,
+      message: { threadId: input.threadId },
+    },
+    include: { message: { select: { id: true, blocks: true, seq: true } } },
+    orderBy: [{ message: { seq: "asc" } }, { id: "asc" }],
+  });
+  if (pending.length === 0) return null;
+  const last = pending.at(-1)!;
+  const task = await tx.task.create({
+    data: {
+      spaceId: input.spaceId,
+      botId: input.botId,
+      threadId: input.threadId,
+      userId: pending[0]!.userId,
+      prompt: "Respond to the user's steering context.",
+      status: "queued",
+    },
+  });
+  const run = await tx.run.create({
+    data: {
+      spaceId: input.spaceId,
+      botId: input.botId,
+      threadId: input.threadId,
+      taskId: task.id,
+      userId: pending[0]!.userId,
+      status: "queued",
+      trigger: "follow_up",
+      sourceMessageId: last.message.id,
+    },
+  });
+  await tx.steeringMessage.updateMany({
+    where: { id: { in: pending.map((item) => item.id) }, runId: null },
+    data: { runId: run.id, claimedAt: null },
+  });
+  return run.id;
 }
 
 export async function appendEventInTransaction(

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -85,6 +85,7 @@ export interface ClaimSteeringInput {
 
 export interface ClaimedSteeringMessage {
   id: string;
+  messageId: string;
   text: string;
   blocks: MessageBlock[];
 }
@@ -381,7 +382,7 @@ export async function sendUserMessage(
           botId: input.botId,
           status: { in: ["running", "queued", "leased", "waiting_input", "waiting_takeover"] },
         },
-        select: { id: true },
+        select: { id: true, taskId: true },
       });
       let task = null;
       let run = null;
@@ -431,7 +432,7 @@ export async function sendUserMessage(
         runId: run?.id ?? busy?.id,
         payload: { messageId: message.id, role: "user", blocks: input.blocks },
       });
-      return { message, task, run, event };
+      return { message, task, run, busy, event };
     });
   const committed = await commit().catch(async (error) => {
     const winner = await replay();
@@ -446,8 +447,8 @@ export async function sendUserMessage(
   return {
     messageId: committed.message.id,
     seq: committed.message.seq,
-    taskId: committed.task?.id ?? null,
-    runId: committed.run?.id ?? null,
+    taskId: committed.task?.id ?? committed.busy?.taskId ?? null,
+    runId: committed.run?.id ?? committed.busy?.id ?? null,
   };
 }
 
@@ -486,6 +487,7 @@ export async function claimSteering(
     });
     return steering.map((item) => ({
       id: item.id,
+      messageId: item.messageId,
       text: blocksToAgentHistoryText(item.message.blocks as MessageBlock[]),
       blocks: item.message.blocks as MessageBlock[],
     }));

--- a/packages/testkit/src/executor-lifecycle.test.ts
+++ b/packages/testkit/src/executor-lifecycle.test.ts
@@ -200,7 +200,8 @@ describeIntegration("run executor lifecycle", () => {
 
     const results = await Promise.all([events.finalizeRun(input), events.finalizeRun(input)]);
 
-    expect(results.sort()).toEqual([false, true]);
+    expect(results.filter((result) => result === false)).toHaveLength(1);
+    expect(results.filter(Boolean)).toEqual([{ continuationRunId: null }]);
     const [run, storedAttempt, task, messages, terminalEvents] = await Promise.all([
       handles.prisma.run.findUniqueOrThrow({ where: { id: seeded.run.id } }),
       handles.prisma.attempt.findUniqueOrThrow({ where: { id: attempt.id } }),
@@ -263,6 +264,274 @@ describeIntegration("run executor lifecycle", () => {
     ).resolves.toMatchObject({ status: "queued" });
     expect(await handles.prisma.message.count({ where: { runId: seeded.run.id } })).toBe(0);
     expect(await handles.prisma.event.count({ where: { runId: seeded.run.id } })).toBe(0);
+  });
+
+  it("coalesces steering that races finalization into one durable continuation", async () => {
+    const seeded = await seedRun("steering-race", "start the analysis", {
+      status: "running",
+      leaseOwner: "steering-worker",
+      leaseFence: 3,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+    const attempt = await handles.prisma.attempt.create({
+      data: { runId: seeded.run.id, fence: 3, status: "running" },
+    });
+    const events = createThreadEvents(handles.prisma);
+    for (const text of ["Use the revised data.", "Keep it concise."]) {
+      await events.sendUserMessage({
+        spaceId: seeded.me.spaceId,
+        threadId: seeded.thread.id,
+        botId: seeded.bot.id,
+        userId: seeded.me.userId,
+        blocks: [{ kind: "text", text }],
+        prompt: text,
+        trigger: "follow_up",
+      });
+    }
+
+    const finalized = await events.finalizeRun({
+      spaceId: seeded.me.spaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      runId: seeded.run.id,
+      taskId: seeded.task.id,
+      attemptId: attempt.id,
+      leaseOwner: "steering-worker",
+      leaseFence: 3,
+      outcome: "completed",
+      blocks: [{ kind: "text", text: "Initial answer" }],
+    });
+
+    if (!finalized) throw new Error("Expected the active run to finalize");
+    const continuationRunId = finalized.continuationRunId;
+    expect(continuationRunId).toEqual(expect.any(String));
+    const [continuation, steering] = await Promise.all([
+      handles.prisma.run.findUniqueOrThrow({
+        where: { id: continuationRunId! },
+        include: { task: true },
+      }),
+      handles.prisma.steeringMessage.findMany({
+        where: { botId: seeded.bot.id },
+        orderBy: { message: { seq: "asc" } },
+      }),
+    ]);
+    expect(continuation).toMatchObject({ status: "queued", trigger: "follow_up" });
+    expect(continuation.task.prompt).toBe("Respond to the user's steering context.");
+    expect(steering).toHaveLength(2);
+    expect(steering).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ runId: continuationRunId, claimedAt: null }),
+        expect.objectContaining({ runId: continuationRunId, claimedAt: null }),
+      ]),
+    );
+    const userMessages = await handles.prisma.message.findMany({
+      where: { threadId: seeded.thread.id, role: "user" },
+      orderBy: { seq: "asc" },
+    });
+    expect(userMessages).toHaveLength(2);
+    expect(userMessages[0]!.seq).toBeLessThan(userMessages[1]!.seq);
+  });
+
+  it("requeues steering claimed by a failed attempt without duplicating it", async () => {
+    const seeded = await seedRun("steering-failure", "start the analysis", {
+      status: "running",
+      leaseOwner: "failure-worker",
+      leaseFence: 4,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+    const attempt = await handles.prisma.attempt.create({
+      data: { runId: seeded.run.id, fence: 4, status: "running" },
+    });
+    const events = createThreadEvents(handles.prisma);
+    await events.sendUserMessage({
+      spaceId: seeded.me.spaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      userId: seeded.me.userId,
+      blocks: [{ kind: "text", text: "Recover this context." }],
+      prompt: "Recover this context.",
+      trigger: "follow_up",
+    });
+    await expect(
+      events.claimSteering({
+        threadId: seeded.thread.id,
+        botId: seeded.bot.id,
+        runId: seeded.run.id,
+        leaseOwner: "failure-worker",
+        leaseFence: 4,
+        seenIds: [],
+      }),
+    ).resolves.toHaveLength(1);
+
+    const finalized = await events.finalizeRun({
+      spaceId: seeded.me.spaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      runId: seeded.run.id,
+      taskId: seeded.task.id,
+      attemptId: attempt.id,
+      leaseOwner: "failure-worker",
+      leaseFence: 4,
+      outcome: "failed",
+      error: "provider failed",
+    });
+    if (!finalized) throw new Error("Expected the failed run to finalize");
+    const continuationRunId = finalized.continuationRunId;
+    expect(continuationRunId).toEqual(expect.any(String));
+    await expect(
+      handles.prisma.run.findUniqueOrThrow({
+        where: { id: continuationRunId! },
+        include: { task: true },
+      }),
+    ).resolves.toMatchObject({
+      status: "queued",
+      trigger: "follow_up",
+      task: { prompt: "Respond to the user's steering context." },
+    });
+    await expect(
+      handles.prisma.steeringMessage.findFirstOrThrow({ where: { botId: seeded.bot.id } }),
+    ).resolves.toMatchObject({ runId: continuationRunId, claimedAt: null });
+  });
+
+  it("discards pending steering when the user stops active work", async () => {
+    const seeded = await seedRun("steering-stop", "keep working", {
+      status: "running",
+      leaseOwner: "stop-worker",
+      leaseFence: 1,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+    await rpc(seeded.cookie, "threads/send", {
+      botId: seeded.bot.id,
+      text: "Context that should stop with the run.",
+      clientNonce: `stop-steering-${stamp}`,
+    });
+
+    await rpc(seeded.cookie, "threads/stop", { botId: seeded.bot.id });
+
+    await expect(
+      handles.prisma.run.findUniqueOrThrow({ where: { id: seeded.run.id } }),
+    ).resolves.toMatchObject({ status: "cancelled" });
+    expect(await handles.prisma.steeringMessage.count({ where: { botId: seeded.bot.id } })).toBe(0);
+    expect(await handles.prisma.run.count({ where: { threadId: seeded.thread.id } })).toBe(1);
+  });
+
+  it("turns a regular bot-thread send during active work into steering", async () => {
+    const seeded = await seedRun("bot-steering-send", "keep working", {
+      status: "running",
+      leaseOwner: "busy-worker",
+      leaseFence: 1,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+
+    const steeringInput = {
+      botId: seeded.bot.id,
+      text: "Use this additional context.",
+      clientNonce: `bot-steering-${stamp}`,
+    };
+    await rpc(seeded.cookie, "threads/send", steeringInput);
+    await rpc(seeded.cookie, "threads/send", steeringInput);
+
+    expect(await handles.prisma.run.count({ where: { threadId: seeded.thread.id } })).toBe(1);
+    expect(
+      await handles.prisma.message.count({
+        where: { threadId: seeded.thread.id, clientNonce: steeringInput.clientNonce },
+      }),
+    ).toBe(1);
+    await expect(
+      handles.prisma.steeringMessage.findFirstOrThrow({
+        where: { botId: seeded.bot.id, message: { threadId: seeded.thread.id } },
+      }),
+    ).resolves.toMatchObject({ runId: seeded.run.id, claimedAt: null });
+  });
+
+  it("applies the same no-parallel-run rule to the targeted group member", async () => {
+    const cookie = await signup(
+      `executor-group-steering-${stamp}@rakazo.test`,
+      "Executor group steering",
+    );
+    const me = await rpc<{ userId: string; spaceId: string }>(cookie, "me");
+    const botA = await rpc<{ id: string }>(cookie, "bots/create", {
+      name: "Group lead",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: false,
+    });
+    const botB = await rpc<{ id: string }>(cookie, "bots/create", {
+      name: "Group helper",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: false,
+    });
+    const group = await rpc<{ id: string }>(cookie, "groups/create", {
+      name: "Steering group",
+      botIds: [botA.id, botB.id],
+    });
+    const thread = await handles.prisma.thread.findUniqueOrThrow({ where: { groupId: group.id } });
+    const member = await handles.prisma.chatGroupMember.findFirstOrThrow({
+      where: { groupId: group.id },
+      orderBy: { createdAt: "asc" },
+    });
+    const task = await handles.prisma.task.create({
+      data: {
+        spaceId: me.spaceId,
+        botId: member.botId,
+        threadId: thread.id,
+        userId: me.userId,
+        prompt: "keep working",
+        status: "queued",
+      },
+    });
+    const activeRun = await handles.prisma.run.create({
+      data: {
+        spaceId: me.spaceId,
+        botId: member.botId,
+        threadId: thread.id,
+        taskId: task.id,
+        userId: me.userId,
+        status: "running",
+        trigger: "user",
+        leaseOwner: "group-worker",
+        leaseFence: 1,
+        leaseExpiresAt: new Date(Date.now() + 60_000),
+        startedAt: new Date(),
+      },
+    });
+
+    await rpc(cookie, "threads/send", {
+      groupId: group.id,
+      text: "Use this group context.",
+      mentions: [{ kind: "bot", id: member.botId }],
+      clientNonce: `group-steering-${stamp}`,
+    });
+
+    expect(await handles.prisma.run.count({ where: { threadId: thread.id } })).toBe(1);
+    await expect(
+      handles.prisma.steeringMessage.findFirstOrThrow({
+        where: { botId: member.botId, message: { threadId: thread.id } },
+      }),
+    ).resolves.toMatchObject({ runId: activeRun.id, claimedAt: null });
+
+    const otherBotId = botA.id === member.botId ? botB.id : botA.id;
+    const mixedInput = {
+      groupId: group.id,
+      text: "Use both agents.",
+      mentions: [
+        { kind: "bot", id: member.botId },
+        { kind: "bot", id: otherBotId },
+      ],
+      clientNonce: `group-mixed-${stamp}`,
+    };
+    const first = await rpc<{ runIds: string[] }>(cookie, "threads/send", mixedInput);
+    const replay = await rpc<{ runIds: string[] }>(cookie, "threads/send", mixedInput);
+    expect(first.runIds).toHaveLength(2);
+    expect(replay.runIds).toEqual(first.runIds);
+    expect(await handles.prisma.run.count({ where: { threadId: thread.id } })).toBe(2);
   });
 
   async function seedRun(

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -1776,7 +1776,12 @@ describeJourneys("required product journeys", () => {
       where: { threadId_clientNonce: { threadId: group.threadId, clientNonce: replayNonce } },
       include: { sourceRuns: true },
     });
-    expect(replayMessage.sourceRuns).toHaveLength(2);
+    expect(replayMessage.sourceRuns).toHaveLength(1);
+    await expect(
+      prisma.steeringMessage.findUniqueOrThrow({
+        where: { messageId_botId: { messageId: replayMessage.id, botId: botB.id } },
+      }),
+    ).resolves.toMatchObject({ runId: staleRun.id, claimedAt: null });
     expect(
       await prisma.message.count({ where: { threadId: group.threadId, clientNonce: replayNonce } }),
     ).toBe(1);


### PR DESCRIPTION
## Summary

- persist messages sent while a bot is busy as durable steering records instead of starting parallel work
- consume steering through Pi's native safe-turn steering queue, with a durable coalesced continuation for finalization races and retries
- apply the same no-parallel rule to targeted group members and expose a keyboard/mobile-accessible steering composer while keeping Stop separate

## Semantics

A user message is still written to the thread immediately and receives the next message sequence. If the target bot already has queued, leased, running, waiting-input, or waiting-takeover work, the send links to that run and creates a durable steering record instead of another run.

The running executor claims steering under its lease fence before the first model call and at Pi's `prepareNextTurnWithContext` boundary. Initial steering is included once in the first prompt; later steering feeds Pi's native `steer` queue in message order. Claimed records retain their source message IDs and attachment blocks: images are delivered as image input and files are materialized through the existing thread-artifact path before the steering turn. Busy sends and nonce replays return the active `runId` with `taskId: null`, keeping follow-up enqueueing reserved for newly created runs; group steering records and realtime events carry the same active-run linkage. Messages that arrive after the last boundary are atomically coalesced into one queued `follow_up` continuation during finalization. Messages arriving while that continuation runs remain queued for its following safe boundary.

Successful runs delete steering they consumed. Failed attempts requeue claimed steering into a durable continuation. If one steering attachment cannot be loaded, the executor preserves the steering text and any successfully loaded sibling attachments, tells the model not to guess the unavailable content, and consumes the steering normally instead of creating an unbounded failed-continuation loop. Explicit Stop cancels active work and deletes pending steering under the same thread lock, so it cannot race finalization into a surprise continuation. Ask/takeover runs remain active and are not bypassed by a generic parallel run.

## Races and durability

- thread-row locks serialize send, finalization, Stop, and clear
- lease owner/fence checks prevent the wrong executor from claiming steering
- `claimedAt` distinguishes context already handed to a live run from context that arrived after its last boundary
- finalization creates at most one continuation and assigns its pending steering rows in the same transaction; successful consumption deletes them, while failure requeues them
- message client nonces remain idempotent and replay against the linked active run
- durable jobs/reconciliation cover a missed continuation wake and any completed messaging run that crashes before outbox mirroring
- in-memory shutdown drains active work plus one accepted immediate generation, rechecks stop state after keyed cancellation, rejects post-stop enqueueing until restart, and leaves future durable work to reconciliation

## UI

While work is active, the web and Expo composers say `Steer <bot>`, show `Messages sent now guide the next turn.`, and present separate Send-steering and Stop controls. The controls retain keyboard focus, accessible names, mobile-sized targets, and localized web copy. Send and Stop cannot race each other while either request is in flight, and mobile distinguishes a successful Stop from a later refresh failure. The responsive web layout was exercised at desktop and 390×844 sizes; the native Expo contract is typechecked and source-tested but not rendered in CI.

## Non-goal: multiple assistant messages

Multiple finished assistant messages inside one turn are separate work tracked in #406. This PR does not implement, partially implement, resolve, or close that issue. Its scope ends at durably delivering user steering to an active run and safely continuing that run; assistant-message rendering and turn modeling are unchanged.

## Tests

Observed locally:

- focused DB/API/Pi/mobile tests: pass; latest exact-head set is 62/62
- focused attachment/runtime/shutdown tests: 45/45; RED checks failed before the permanent attachment-failure settlement and stop-during-keyed-cancel fixes, then passed after restoration
- adapter suite: 944 passed, 6 skipped; shutdown regressions cover direct close, worker stop→close, concurrent lifecycle calls, accepted immediate timers, bounded nested delivery, cancellation, future-job handling, stop-during-keyed-cancel rejection, post-stop rejection/restart, durable completed-run mirroring, direct drain fallback, and due pending outbox reconciliation
- isolated PostgreSQL lifecycle tests for coalescing, bot/group no-parallel sends, failure recovery, cancellation, and nonce replay: pass
- same-nonce mixed active/idle group replay regression: pass on fresh PostgreSQL (1/1)
- PostgreSQL migration verification: all 69 migrations apply fresh, and both new earlier-sorting migrations apply after the existing 67-migration baseline; the concurrent recovery index succeeds; upgrade simulation backfills historical phone/messaging completions without marking queued work; targeted integration file passes (2/2)
- sabotage check: the Pi steering regression fails when the boundary claim hook is removed, then passes after restoration
- `pnpm run check`: pass (20/20 package tasks)
- `./node_modules/.bin/biome check .`: pass (two existing informational suggestions)
- `pnpm run build`: pass
- targeted Playwright golden flow: pass at desktop and 390×844 mobile; keyboard focus, separate Stop, and zero captured console/request failures asserted

Rendered evidence from exact final head `9748bf4`:

- [Playwright screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/453/index.html)
- [desktop active-work steering composer](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33490136927-1/screenshots/images/024-14-active-bot-work.png)
- [390×844 mobile-web active-work steering composer](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33490136927-1/screenshots/images/023-14-active-bot-work-mobile.png)

The native Expo composer is covered by source/contract tests and typecheck; CI does not render that native-only surface.

Known baseline/infrastructure failures, reproduced independently of this diff:

- `pnpm run test`: 2,192 passed, 109 skipped, 1 existing Lingui raw-catalog failure (`alle {intervalAmountSelect} {intervalUnitSelect}`); the same test fails on `origin/main` at `92904b6`
- `pnpm run test:integration`: 23 passed, 53 failed after Better Auth put unrelated signup requests into one shared per-path rate-limit bucket and returned HTTP 429; it completed without teardown timeout, and the new steering lifecycle cases pass in isolated fresh-Postgres runs
- `pnpm run lint`: exits 254 with `Linter process terminated abnormally`; direct repository-wide Biome passes with only two existing informational suggestions

## Risks and exclusions

- Core-model/API behavior for multiple assistant messages is intentionally unchanged and out of scope.
- Steering copy is intentionally minimal and uses existing composer styles; there is no broader chat redesign.
- No dependency was added.
- PR #453 was merged by the maintainer while the final worker gate was still running. The remaining post-merge fixes continue in draft PR #459, which is unmerged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send guidance to an active bot or group run without interrupting it; messages are applied to the next turn.
  * Added steering-mode composer controls, status hints, and separate Stop and Send buttons.
  * Steering messages can include images and files, with attachment availability guidance.
  * Interactive questions can offer selectable actions.
* **Bug Fixes**
  * Improved run continuation, replay, stopping, and delivery recovery to prevent duplicate or stale updates.
* **Localization**
  * Added steering-related translations for supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
