### PR TITLE
fix(ci): restore computer image GHCR publishing

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -13,6 +13,7 @@ on:
       - ".github/workflows/publish-server-image.yml"
       - "apps/**"
       - "infra/compose/**"
+      - "infra/sandboxes/computer/**"
       - "infra/updater/**"
       - "packages/**"
       - "package.json"
@@ -45,8 +46,13 @@ jobs:
         include:
           - name: app
             dockerfile: infra/compose/Dockerfile
+            context: .
           - name: updater
             dockerfile: infra/updater/Dockerfile
+            context: .
+          - name: computer
+            dockerfile: infra/sandboxes/computer/Dockerfile
+            context: infra/sandboxes/computer
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -59,12 +65,12 @@ jobs:
           tags: type=sha,prefix=sha-
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          context: .
+          context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: GIT_SHA=${{ github.sha }}
+          build-args: ${{ matrix.name == 'app' && format('GIT_SHA={0}', github.sha) || '' }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=pr-${{ github.event.pull_request.number }}-${{ matrix.name }}
           provenance: false
@@ -87,10 +93,16 @@ jobs:
       matrix:
         include:
           # Only the updater image contains the Docker CLI; the application image stays unprivileged.
+          # The supervisor is not a separate published image: it runs from `app` on the internal network.
           - name: app
             dockerfile: infra/compose/Dockerfile
+            context: .
           - name: updater
             dockerfile: infra/updater/Dockerfile
+            context: .
+          - name: computer
+            dockerfile: infra/sandboxes/computer/Dockerfile
+            context: infra/sandboxes/computer
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -120,7 +132,7 @@ jobs:
       - id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
-          context: .
+          context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -128,7 +140,7 @@ jobs:
           # Main→edge stays native amd64. Tags and workflow_dispatch publish amd64+arm64.
           platforms: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           # GET /health can report the exact source commit without a deployment-supplied override.
-          build-args: GIT_SHA=${{ github.sha }}
+          build-args: ${{ matrix.name == 'app' && format('GIT_SHA={0}', github.sha) || '' }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           provenance: mode=max

--- a/infra/updater/src/compose-images.test.ts
+++ b/infra/updater/src/compose-images.test.ts
@@ -15,12 +15,30 @@ interface ComposeService {
   restart?: string;
 }
 
-const composeFile = path.resolve(import.meta.dirname, "../../compose/docker-compose.images.yml");
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const composeFile = path.resolve(repoRoot, "infra/compose/docker-compose.images.yml");
+const publishWorkflowFile = path.resolve(repoRoot, ".github/workflows/publish-server-image.yml");
 const compose = parse(readFileSync(composeFile, "utf8")) as {
   services: Record<string, ComposeService>;
 };
+const publishWorkflow = parse(readFileSync(publishWorkflowFile, "utf8")) as {
+  jobs?: {
+    publish?: {
+      strategy?: {
+        matrix?: {
+          include?: Array<{ name?: string }>;
+        };
+      };
+    };
+  };
+};
 
 const appServices = ["api", "worker", "web", "supervisor"] as const;
+const FIRST_PARTY_IMAGE = /ghcr\.io\/elie222\/rakazo\/([a-z0-9][a-z0-9._-]*)/g;
+
+function firstPartyImageNames(text: string): string[] {
+  return [...text.matchAll(FIRST_PARTY_IMAGE)].map((match) => match[1] ?? "");
+}
 
 /**
  * The images compose file is the no-checkout happy path. It must stay pull-only and self-contained
@@ -45,6 +63,32 @@ describe("the images compose file", () => {
     expect(compose.services.computer?.image).toContain("ghcr.io/elie222/rakazo/computer");
     expect(compose.services.computer?.image).toContain("RAKAZO_COMPUTER_IMAGE_TAG");
     expect(compose.services.postgres?.image).toMatch(/^postgres:16@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("only references first-party images that the publish matrix publishes", () => {
+    const published = new Set(
+      (publishWorkflow.jobs?.publish?.strategy?.matrix?.include ?? [])
+        .map((entry) => entry.name)
+        .filter((name): name is string => typeof name === "string" && name.length > 0),
+    );
+    const referenced = new Set<string>();
+    for (const service of Object.values(compose.services)) {
+      for (const name of firstPartyImageNames(service.image ?? "")) {
+        referenced.add(name);
+      }
+      for (const value of Object.values(service.environment ?? {})) {
+        for (const name of firstPartyImageNames(value)) {
+          referenced.add(name);
+        }
+      }
+    }
+    expect(published.size).toBeGreaterThan(0);
+    expect(referenced.has("computer")).toBe(true);
+    for (const name of referenced) {
+      expect(published.has(name), `${name} referenced by images compose but omitted from publish matrix`).toBe(
+        true,
+      );
+    }
   });
 
   it("never builds from a checkout", () => {

--- a/infra/updater/src/compose-images.test.ts
+++ b/infra/updater/src/compose-images.test.ts
@@ -85,9 +85,10 @@ describe("the images compose file", () => {
     expect(published.size).toBeGreaterThan(0);
     expect(referenced.has("computer")).toBe(true);
     for (const name of referenced) {
-      expect(published.has(name), `${name} referenced by images compose but omitted from publish matrix`).toBe(
-        true,
-      );
+      expect(
+        published.has(name),
+        `${name} referenced by images compose but omitted from publish matrix`,
+      ).toBe(true);
     }
   });
 

--- a/infra/updater/src/compose-images.test.ts
+++ b/infra/updater/src/compose-images.test.ts
@@ -8,7 +8,8 @@ interface ComposeService {
   build?: unknown;
   command?: unknown;
   env_file?: unknown;
-  environment?: Record<string, string>;
+  /** YAML may parse unquoted scalars as null/number/boolean. */
+  environment?: Record<string, unknown>;
   volumes?: string[];
   ports?: unknown[];
   user?: string;
@@ -36,8 +37,9 @@ const publishWorkflow = parse(readFileSync(publishWorkflowFile, "utf8")) as {
 const appServices = ["api", "worker", "web", "supervisor"] as const;
 const FIRST_PARTY_IMAGE = /ghcr\.io\/elie222\/rakazo\/([a-z0-9][a-z0-9._-]*)/g;
 
-function firstPartyImageNames(text: string): string[] {
-  return [...text.matchAll(FIRST_PARTY_IMAGE)].map((match) => match[1] ?? "");
+function firstPartyImageNames(value: unknown): string[] {
+  if (typeof value !== "string") return [];
+  return [...value.matchAll(FIRST_PARTY_IMAGE)].map((match) => match[1] ?? "");
 }
 
 /**
@@ -65,6 +67,13 @@ describe("the images compose file", () => {
     expect(compose.services.postgres?.image).toMatch(/^postgres:16@sha256:[0-9a-f]{64}$/);
   });
 
+  it("skips non-string Compose environment scalars when collecting image names", () => {
+    expect(firstPartyImageNames(null)).toEqual([]);
+    expect(firstPartyImageNames(true)).toEqual([]);
+    expect(firstPartyImageNames(7091)).toEqual([]);
+    expect(firstPartyImageNames("ghcr.io/elie222/rakazo/computer:edge")).toEqual(["computer"]);
+  });
+
   it("only references first-party images that the publish matrix publishes", () => {
     const published = new Set(
       (publishWorkflow.jobs?.publish?.strategy?.matrix?.include ?? [])
@@ -73,7 +82,7 @@ describe("the images compose file", () => {
     );
     const referenced = new Set<string>();
     for (const service of Object.values(compose.services)) {
-      for (const name of firstPartyImageNames(service.image ?? "")) {
+      for (const name of firstPartyImageNames(service.image)) {
         referenced.add(name);
       }
       for (const value of Object.values(service.environment ?? {})) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores automated GHCR publishing for `ghcr.io/elie222/rakazo/computer`, which self-host Compose still pulls as `computer:edge` while the publish workflow only covered `app` and `updater` after an accidental regression.

## Changes

- Re-add `computer` to the PR validation and main/tag/manual publish matrices in `.github/workflows/publish-server-image.yml`
- Restore `infra/sandboxes/computer` build context, path filter, and app-only `GIT_SHA` build-arg (same pattern as #361)
- Keep release/`workflow_dispatch` multi-arch behavior aligned with `app` and `updater`
- Add a lightweight compose↔publish-matrix contract check in `infra/updater/src/compose-images.test.ts` so images Compose cannot reference a first-party published image the matrix omits
- Harden that check against non-string YAML environment scalars (CodeRabbit)

## Out of scope

- No Docker/compose redesign beyond restoring publish
- Does not republish `computer:edge` until this merges to `main` (or a manual workflow run)

Fixes #442

## Test plan

- [x] `pnpm --filter @rakazo/updater test`
- [x] CI: validate computer image job on this PR
- [ ] After merge: confirm `computer:edge` publishes from main

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94b371a7-be2e-4576-9160-053c21397fb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94b371a7-be2e-4576-9160-053c21397fb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the computer sandbox image to validation and publishing workflows.
  * The computer image is now available alongside other supported application images.

* **Bug Fixes**
  * Improved image builds by applying the correct context and configuration for each image.
  * Added validation to ensure images referenced by sandbox configurations are included in publishing.
  * Expanded configuration validation to handle null, Boolean, and numeric environment values safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->