### PR TITLE
fix(chat): harden steering send, stop, and history stripping

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1150,7 +1150,6 @@ export function createRouter(deps: RouterDeps) {
             blocks: [{ kind: "text", text: input.text }],
             prompt: input.text,
             trigger: "follow_up",
-            onlyIfIdle: true,
           });
           if (sent.runId) {
             await deps.jobs.enqueue(runContinueJob(sent.runId)).catch((error) => {
@@ -1180,7 +1179,8 @@ export function createRouter(deps: RouterDeps) {
           const active = await tx.run.findFirst({
             where: {
               threadId: target.threadId,
-              status: { in: ["running", "queued", "leased"] },
+              botId,
+              status: { in: [...ACTIVE_RUN_STATUSES] },
             },
             select: { id: true },
           });
@@ -1210,6 +1210,10 @@ export function createRouter(deps: RouterDeps) {
               select: { id: true },
             });
             await tx.message.update({ where: { id: message.id }, data: { runId: run.id } });
+          } else {
+            await tx.steeringMessage.create({
+              data: { messageId: message.id, botId, userId: context.actor.userId },
+            });
           }
           const event = await appendEventInTransaction(tx, {
             spaceId: context.actor.spaceId,

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -689,7 +689,8 @@ function groupTarget() {
 describe("stopThreadRuns", () => {
   it("releases every active group member screen immediately", async () => {
     const releaseScreen = vi.fn().mockResolvedValue(undefined);
-    const prisma = {
+    const transaction = {
+      $queryRaw: vi.fn(),
       run: {
         findMany: vi.fn().mockResolvedValue([
           { id: "run-a", botId: "bot-a" },
@@ -697,6 +698,12 @@ describe("stopThreadRuns", () => {
         ]),
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
       },
+      steeringMessage: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof transaction) => unknown) =>
+        callback(transaction),
+      ),
       computer: {
         findMany: vi.fn().mockResolvedValue([
           {

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -139,8 +139,35 @@ async function replayExistingSend(
 ) {
   if (!clientNonce) return null;
   const message = await findSendReceipt(deps.prisma, threadId, clientNonce);
-  if (!message || message.sourceRuns.length === 0) return null;
-  await enqueueRunsNeedingContinue(deps.jobs, message.sourceRuns);
+  if (!message) return null;
+  const receiptEvent = await deps.prisma.event.findFirst({
+    where: {
+      threadId,
+      type: "thread.message.created",
+      payload: { path: ["messageId"], equals: message.id },
+    },
+    orderBy: { seq: "desc" },
+    select: { payload: true },
+  });
+  const receiptRunIds = sendEventRunIds(receiptEvent?.payload);
+  const receiptRuns = receiptRunIds.length
+    ? await deps.prisma.run.findMany({ where: { id: { in: receiptRunIds } } })
+    : [];
+  const receiptRunById = new Map(receiptRuns.map((run) => [run.id, run]));
+  const orderedReceiptRuns = receiptRunIds.flatMap((id) => {
+    const run = receiptRunById.get(id);
+    return run ? [run] : [];
+  });
+  const linkedRun =
+    message.sourceRuns[0] ??
+    (message.runId ? await deps.prisma.run.findUnique({ where: { id: message.runId } }) : null);
+  if (!linkedRun && orderedReceiptRuns.length === 0) return null;
+  const runs = orderedReceiptRuns.length
+    ? orderedReceiptRuns
+    : message.sourceRuns.length
+      ? message.sourceRuns
+      : [linkedRun!];
+  await enqueueRunsNeedingContinue(deps.jobs, runs);
   const latestEvent = await deps.prisma.event.findFirst({
     where: { threadId },
     orderBy: { seq: "desc" },
@@ -152,7 +179,13 @@ async function replayExistingSend(
       console.error("thread send realtime notification", error);
     });
   }
-  return sendResult(message, message.sourceRuns);
+  return sendResult(message, runs);
+}
+
+function sendEventRunIds(payload: Prisma.JsonValue | undefined): string[] {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return [];
+  const runIds = (payload as { runIds?: unknown }).runIds;
+  return Array.isArray(runIds) ? runIds.filter((id): id is string => typeof id === "string") : [];
 }
 
 function sendResult(message: { seq: number }, runs: Array<{ id: string; taskId: string }>) {
@@ -516,6 +549,39 @@ export async function sendThreadMessage(
           replyToMessageId: input.replyToMessageId,
           clientNonce: input.clientNonce,
         });
+        const active = await tx.run.findFirst({
+          where: {
+            threadId: target.threadId,
+            botId: target.botId,
+            status: { in: [...ACTIVE_RUN_STATUSES] },
+          },
+          select: { id: true, taskId: true, status: true },
+        });
+        if (active) {
+          await tx.steeringMessage.create({
+            data: {
+              messageId: message.id,
+              botId: target.botId,
+              userId: actor.userId,
+              runId: active.id,
+            },
+          });
+          await tx.message.update({ where: { id: message.id }, data: { runId: active.id } });
+          const event = await appendEventInTransaction(tx, {
+            spaceId: actor.spaceId,
+            threadId: target.threadId,
+            botId: target.botId,
+            type: "thread.message.created",
+            runId: active.id,
+            payload: {
+              messageId: message.id,
+              role: "user",
+              blocks,
+              replyToMessageId: input.replyToMessageId,
+            },
+          });
+          return { message, runs: [active], eventSeq: event.seq };
+        }
         const task = await tx.task.create({
           data: {
             spaceId: actor.spaceId,
@@ -555,6 +621,7 @@ export async function sendThreadMessage(
             messageId: message.id,
             role: "user",
             blocks,
+            runIds: [run.id],
             replyToMessageId: input.replyToMessageId,
           },
         });
@@ -589,8 +656,25 @@ export async function sendThreadMessage(
         replyToMessageId: input.replyToMessageId,
         clientNonce: input.clientNonce,
       });
+      const activeRuns = await tx.run.findMany({
+        where: {
+          threadId: target.threadId,
+          botId: { in: targetBotIds },
+          status: { in: [...ACTIVE_RUN_STATUSES] },
+        },
+        select: { id: true, taskId: true, botId: true, status: true },
+      });
+      const activeByBotId = new Map(activeRuns.map((run) => [run.botId, run]));
       const runs: Array<{ id: string; taskId: string; botId: string; status: string }> = [];
       for (const botId of targetBotIds) {
+        const active = activeByBotId.get(botId);
+        if (active) {
+          await tx.steeringMessage.create({
+            data: { messageId: message.id, botId, userId: actor.userId, runId: active.id },
+          });
+          runs.push(active);
+          continue;
+        }
         const task = await tx.task.create({
           data: {
             spaceId: actor.spaceId,
@@ -617,24 +701,31 @@ export async function sendThreadMessage(
         runs.push(run);
       }
       const firstRun = runs[0];
-      if (!firstRun) throw new IsolationError("Group send did not resolve a target");
-      await tx.message.update({ where: { id: message.id }, data: { runId: firstRun.id } });
-      await cancelSupersededQueuedRuns(tx, {
-        threadId: target.threadId,
-        botIds: targetBotIds,
-        keepRunIds: runs.map((run) => run.id),
-      });
+      const eventBotId = firstRun?.botId ?? targetBotIds[0];
+      if (!eventBotId) throw new IsolationError("Group send did not resolve a target");
+      if (firstRun) {
+        await tx.message.update({ where: { id: message.id }, data: { runId: firstRun.id } });
+        const createdRuns = runs.filter((run) => !activeByBotId.has(run.botId));
+        if (createdRuns.length) {
+          await cancelSupersededQueuedRuns(tx, {
+            threadId: target.threadId,
+            botIds: createdRuns.map((run) => run.botId),
+            keepRunIds: createdRuns.map((run) => run.id),
+          });
+        }
+      }
       await touchGroupUpdatedAt(tx, target.groupId);
       const event = await appendEventInTransaction(tx, {
         spaceId: actor.spaceId,
         threadId: target.threadId,
-        botId: firstRun.botId,
+        botId: eventBotId,
         type: "thread.message.created",
-        runId: firstRun.id,
+        runId: firstRun?.id ?? activeRuns[0]?.id,
         payload: {
           messageId: message.id,
           role: "user",
           blocks,
+          runIds: runs.map((run) => run.id),
           replyToMessageId: input.replyToMessageId,
         },
       });
@@ -728,18 +819,28 @@ export async function stopThreadRuns(
   actor: Actor,
   target: ThreadTarget,
 ) {
-  const runIds = (
-    await deps.prisma.run.findMany({
+  const runIds = await deps.prisma.$transaction(async (tx) => {
+    await tx.$queryRaw`SELECT id FROM threads WHERE id = ${target.threadId} FOR UPDATE`;
+    const ids = (
+      await tx.run.findMany({
+        where: {
+          threadId: target.threadId,
+          status: { in: [...ACTIVE_RUN_STATUSES] },
+        },
+        select: { id: true },
+      })
+    ).map((run) => run.id);
+    await tx.run.updateMany({
+      where: { id: { in: ids }, status: { in: [...ACTIVE_RUN_STATUSES] } },
+      data: { status: "cancelled", completedAt: new Date() },
+    });
+    await tx.steeringMessage.deleteMany({
       where: {
-        threadId: target.threadId,
-        status: { in: [...ACTIVE_RUN_STATUSES] },
+        botId: { in: target.kind === "bot" ? [target.botId] : target.memberBotIds },
+        message: { threadId: target.threadId },
       },
-      select: { id: true },
-    })
-  ).map((run) => run.id);
-  await deps.prisma.run.updateMany({
-    where: { id: { in: runIds } },
-    data: { status: "cancelled", completedAt: new Date() },
+    });
+    return ids;
   });
   const computers = runIds.length
     ? await deps.prisma.computer.findMany({

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1003,9 +1003,15 @@ function Thread() {
     setError(null);
     try {
       await rpc("threads/stop", groupId ? { groupId } : { botId: botId! });
-      await refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to stop work");
+      setSending(false);
+      return;
+    }
+    try {
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to refresh after stop");
     } finally {
       setSending(false);
     }

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -122,7 +122,13 @@ function formatApprovalAnswer(answer: string | undefined, actions?: AskAction[])
 }
 
 function isWorkingStatus(status: string | undefined): boolean {
-  return status === "queued" || status === "leased" || status === "running";
+  return (
+    status === "queued" ||
+    status === "leased" ||
+    status === "running" ||
+    status === "waiting_input" ||
+    status === "waiting_takeover"
+  );
 }
 
 type NotificationRouteState = "loading" | "ready" | "failed";
@@ -337,6 +343,7 @@ function Thread() {
       return [{ ...member, status: run.status }];
     });
   }, [inGroup, snap?.activeRuns, snap?.members, snap?.run]);
+  const working = inGroup ? workingGroupBots.length > 0 : isWorkingStatus(currentBotStatus);
 
   useEffect(() => {
     void rpc<AgentSkillCatalogEntry[]>("agentSkills/list")
@@ -941,11 +948,13 @@ function Thread() {
         });
         artifactIds.push(artifact.id);
       }
+      const clientNonce = newClientNonce();
       await rpc(
         "threads/send",
         groupTarget
           ? {
               groupId: groupTarget,
+              clientNonce,
               text: trimmed || undefined,
               mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
               artifactIds: artifactIds.length ? artifactIds : undefined,
@@ -953,6 +962,7 @@ function Thread() {
             }
           : {
               botId: botTarget!,
+              clientNonce,
               text: trimmed || undefined,
               mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
               artifactIds: artifactIds.length ? artifactIds : undefined,
@@ -982,6 +992,20 @@ function Thread() {
       } else if (isCurrentTarget(botTarget, groupTarget)) {
         setError(err instanceof Error ? err.message : "Failed to send message");
       }
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function stop() {
+    if ((!botId && !groupId) || sending) return;
+    setSending(true);
+    setError(null);
+    try {
+      await rpc("threads/stop", groupId ? { groupId } : { botId: botId! });
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to stop work");
     } finally {
       setSending(false);
     }
@@ -1566,11 +1590,19 @@ function Thread() {
             ))}
           </View>
         ) : null}
+        {working ? (
+          <Text
+            accessibilityLiveRegion="polite"
+            style={{ color: "#85858A", fontSize: 12, marginTop: 12, marginHorizontal: 8 }}
+          >
+            Messages sent now guide the next turn.
+          </Text>
+        ) : null}
         <View
           style={{
             flexDirection: "row",
             gap: 8,
-            marginTop: 16,
+            marginTop: working ? 8 : 16,
             alignItems: "flex-end",
           }}
         >
@@ -1667,7 +1699,7 @@ function Thread() {
             <TextInput
               value={draft}
               onChangeText={updateDraft}
-              accessibilityLabel="Message"
+              accessibilityLabel={working ? `Steer ${name ?? "bot"}` : "Message"}
               onKeyPress={(event) => {
                 if (
                   event.nativeEvent.key === "Backspace" &&
@@ -1677,7 +1709,13 @@ function Thread() {
                   removeLastChip();
                 }
               }}
-              placeholder={selectedSkill || selectedMentions.length ? undefined : "Message…"}
+              placeholder={
+                selectedSkill || selectedMentions.length
+                  ? undefined
+                  : working
+                    ? `Steer ${name ?? "bot"}`
+                    : "Message…"
+              }
               placeholderTextColor="#6C6C70"
               keyboardAppearance="dark"
               multiline
@@ -1695,6 +1733,7 @@ function Thread() {
             />
           </View>
           <Pressable
+            accessibilityLabel={working ? "Send steering message" : "Send"}
             disabled={sending || !canSend}
             onPress={() => void send()}
             style={{
@@ -1709,6 +1748,25 @@ function Thread() {
           >
             <NativeSymbol ios="arrow.up" android="arrow-up" size={18} color="#17171A" />
           </Pressable>
+          {working ? (
+            <Pressable
+              accessibilityLabel="Stop"
+              disabled={sending}
+              onPress={() => void stop()}
+              style={{
+                borderColor: "#34343A",
+                borderWidth: 1,
+                borderRadius: 22,
+                width: 44,
+                height: 44,
+                alignItems: "center",
+                justifyContent: "center",
+                opacity: sending ? 0.5 : 1,
+              }}
+            >
+              <NativeSymbol ios="stop.fill" android="stop" size={15} color="#C9C9CE" />
+            </Pressable>
+          ) : null}
         </View>
         {!inGroup ? (
           <Link

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -157,6 +157,14 @@ describe("Android mobile platform contract", () => {
     expect(thread).toContain("agents working");
   });
 
+  it("keeps send and stop separate while steering active work", () => {
+    const thread = readFileSync(resolve(mobileRoot, "app/thread.tsx"), "utf8");
+    expect(thread).toContain('accessibilityLabel={working ? "Send steering message" : "Send"}');
+    expect(thread).toContain('accessibilityLabel="Stop"');
+    expect(thread).toContain("Messages sent now guide the next turn.");
+    expect(thread).toContain("const clientNonce = newClientNonce()");
+  });
+
   it("shows agent notification silence in the menu, inbox avatar, and DM header only", () => {
     const index = readFileSync(resolve(mobileRoot, "app/index.tsx"), "utf8");
     const thread = readFileSync(resolve(mobileRoot, "app/thread.tsx"), "utf8");

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -242,12 +242,23 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
 });
 
 test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) => {
+  const browserErrors: string[] = [];
+  const failedRequests: string[] = [];
+  page.on("pageerror", (error) => browserErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(message.text());
+  });
+  page.on("requestfailed", (request) => {
+    failedRequests.push(
+      `${request.method()} ${request.url()} ${request.failure()?.errorText ?? ""}`,
+    );
+  });
   const stamp = Date.now();
   const email = `shell-${stamp}@rakazo.test`;
   await signup(page, email, "password12", "Shell");
   await completeOnboarding(page);
 
-  const composer = page.getByPlaceholder(/Message/);
+  const composer = page.locator('textarea[name="chat-message"]');
   await composer.fill("spawn a bot named Scout to research venues");
   await page.keyboard.press("Enter");
   await expect(sidebarBotButton(page, /Scout/)).toBeVisible({
@@ -262,7 +273,26 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await composer.fill("keep working until I stop you");
   await page.keyboard.press("Enter");
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("composer-steering-status")).toHaveText(
+    "Messages sent now guide the next turn.",
+  );
+  await expect(page.getByRole("button", { name: "Send steering message" })).toBeVisible();
+  await composer.fill("Use the newer report and keep the answer short.");
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "Send steering message" })).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(
+    page.getByTestId("transcript").getByText("Use the newer report and keep the answer short."),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "14-active-bot-work");
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.getByRole("button", { name: "Send steering message" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "14-active-bot-work-mobile");
+  await page.setViewportSize({ width: 1280, height: 720 });
+  expect(browserErrors).toEqual([]);
+  expect(failedRequests).toEqual([]);
   await page.getByRole("button", { name: "Stop", exact: true }).click();
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1952,9 +1952,11 @@ export function ShellPage() {
           );
           artifactIds.push(artifact.id);
         }
+        const clientNonce = crypto.randomUUID();
         if (groupTarget) {
           await rpc.threads.send({
             groupId: groupTarget,
+            clientNonce,
             text: trimmed || undefined,
             mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
             artifactIds: artifactIds.length ? artifactIds : undefined,
@@ -1963,6 +1965,7 @@ export function ShellPage() {
         } else if (botTarget) {
           await rpc.threads.send({
             botId: botTarget,
+            clientNonce,
             text: trimmed || undefined,
             mentions: plan.mentionPayload.length ? plan.mentionPayload : undefined,
             artifactIds: artifactIds.length ? artifactIds : undefined,
@@ -4500,6 +4503,15 @@ const Composer = memo(function Composer({
           })}
         </div>
       ) : null}
+      {running ? (
+        <p
+          className="mb-2 px-3 text-[12px] text-[#85858A]"
+          data-testid="composer-steering-status"
+          aria-live="polite"
+        >
+          Messages sent now guide the next turn.
+        </p>
+      ) : null}
       <div
         data-testid="composer-bar"
         className="flex items-center gap-3.5 rounded-full border border-[#202023] bg-[#131315] py-[9px] pe-2.5 ps-3"
@@ -4641,11 +4653,15 @@ const Composer = memo(function Composer({
             placeholder={
               showComposerPlaceholder
                 ? activeName
-                  ? t`Message ${activeName}`
+                  ? running
+                    ? `Steer ${activeName}`
+                    : t`Message ${activeName}`
                   : t`Message…`
                 : undefined
             }
-            aria-label={activeName ? t`Message ${activeName}` : t`Message`}
+            aria-label={
+              activeName ? (running ? `Steer ${activeName}` : t`Message ${activeName}`) : t`Message`
+            }
             role="combobox"
             aria-autocomplete="list"
             aria-haspopup="listbox"
@@ -4660,14 +4676,25 @@ const Composer = memo(function Composer({
           />
         </div>
         {running ? (
-          <button
-            type="button"
-            aria-label={t`Stop`}
-            onClick={() => void onStop()}
-            className="grid h-9 w-9 place-items-center rounded-full bg-[#F1F1EF] text-[#17171A]"
-          >
-            <Square size={12} strokeWidth={0} fill="currentColor" />
-          </button>
+          <>
+            <button
+              type="button"
+              aria-label="Send steering message"
+              disabled={sending || !canSend || disabled}
+              onClick={send}
+              className="grid h-10 w-10 place-items-center rounded-full bg-[#F1F1EF] text-[#17171A] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD] disabled:opacity-50"
+            >
+              <ArrowUp size={18} strokeWidth={2} />
+            </button>
+            <button
+              type="button"
+              aria-label={t`Stop`}
+              onClick={() => void onStop()}
+              className="grid h-10 w-10 place-items-center rounded-full border border-[#34343A] text-[#C9C9CE] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD]"
+            >
+              <Square size={12} strokeWidth={0} fill="currentColor" />
+            </button>
+          </>
         ) : (
           <button
             type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4670,7 +4670,11 @@ const Composer = memo(function Composer({
                 : undefined
             }
             aria-label={
-              activeName ? (running ? t`Steer ${activeName}` : t`Message ${activeName}`) : t`Message`
+              activeName
+                ? running
+                  ? t`Steer ${activeName}`
+                  : t`Message ${activeName}`
+                : t`Message`
             }
             role="combobox"
             aria-autocomplete="list"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -248,6 +248,14 @@ type PendingBrowserNotification = {
 const ATTACHMENT_ACCEPT = ATTACHMENT_ALLOWED_MIME_TYPES.join(",");
 const THREAD_SNAPSHOT_TIMEOUT_MS = 2_000;
 
+function newClientNonce(): string {
+  const webCrypto = globalThis.crypto;
+  if (webCrypto && typeof webCrypto.randomUUID === "function") {
+    return webCrypto.randomUUID();
+  }
+  return `m-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function threadSnapshotSignal(parent: AbortSignal): AbortSignal {
   return AbortSignal.any([parent, AbortSignal.timeout(THREAD_SNAPSHOT_TIMEOUT_MS)]);
 }
@@ -1910,7 +1918,7 @@ export function ShellPage() {
       setSendError(null);
       try {
         if (plan.shouldRunRoutines) {
-          const sendNonce = crypto.randomUUID();
+          const sendNonce = newClientNonce();
           await Promise.all(
             plan.routineIds.map((routineId) =>
               rpc.routines.testRun({
@@ -1952,7 +1960,7 @@ export function ShellPage() {
           );
           artifactIds.push(artifact.id);
         }
-        const clientNonce = crypto.randomUUID();
+        const clientNonce = newClientNonce();
         if (groupTarget) {
           await rpc.threads.send({
             groupId: groupTarget,
@@ -2015,6 +2023,7 @@ export function ShellPage() {
     await refreshThreadRef.current(id);
   }, []);
   const stopRun = useCallback(async () => {
+    if (sending) return;
     const botTarget = activeBotId.current;
     const groupTarget = activeGroupId.current;
     if (groupTarget) {
@@ -2060,7 +2069,7 @@ export function ShellPage() {
       }
     }
     await refreshThreadRef.current(botTarget).catch(() => undefined);
-  }, [t]);
+  }, [sending, t]);
   const stopTeaching = useCallback(async () => {
     const id = activeBotId.current;
     if (!id || teachBusy) return;
@@ -3729,6 +3738,7 @@ export function ShellPage() {
                   size="sm"
                   aria-label={t`Stop`}
                   data-testid="computer-overlay-stop"
+                  disabled={sending}
                   onClick={() => void stopRun()}
                 >
                   <Trans>Stop</Trans>
@@ -4509,7 +4519,7 @@ const Composer = memo(function Composer({
           data-testid="composer-steering-status"
           aria-live="polite"
         >
-          Messages sent now guide the next turn.
+          <Trans>Messages sent now guide the next turn.</Trans>
         </p>
       ) : null}
       <div
@@ -4654,13 +4664,13 @@ const Composer = memo(function Composer({
               showComposerPlaceholder
                 ? activeName
                   ? running
-                    ? `Steer ${activeName}`
+                    ? t`Steer ${activeName}`
                     : t`Message ${activeName}`
                   : t`Message…`
                 : undefined
             }
             aria-label={
-              activeName ? (running ? `Steer ${activeName}` : t`Message ${activeName}`) : t`Message`
+              activeName ? (running ? t`Steer ${activeName}` : t`Message ${activeName}`) : t`Message`
             }
             role="combobox"
             aria-autocomplete="list"
@@ -4679,7 +4689,7 @@ const Composer = memo(function Composer({
           <>
             <button
               type="button"
-              aria-label="Send steering message"
+              aria-label={t`Send steering message`}
               disabled={sending || !canSend || disabled}
               onClick={send}
               className="grid h-10 w-10 place-items-center rounded-full bg-[#F1F1EF] text-[#17171A] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD] disabled:opacity-50"
@@ -4689,8 +4699,9 @@ const Composer = memo(function Composer({
             <button
               type="button"
               aria-label={t`Stop`}
+              disabled={sending}
               onClick={() => void onStop()}
-              className="grid h-10 w-10 place-items-center rounded-full border border-[#34343A] text-[#C9C9CE] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD]"
+              className="grid h-10 w-10 place-items-center rounded-full border border-[#34343A] text-[#C9C9CE] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD] disabled:opacity-50"
             >
               <Square size={12} strokeWidth={0} fill="currentColor" />
             </button>

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -341,6 +341,8 @@ export interface AgentRunRequest {
     executionId: string,
     route?: ConnectorRoute,
   ) => Promise<unknown>;
+  /** Atomically claim durable user steering at the runtime's next safe turn boundary. */
+  claimSteering?: (seenIds: string[]) => Promise<Array<{ id: string; text: string }>>;
 }
 
 export interface ScriptedTurn {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -300,6 +300,20 @@ export interface SemanticMemoryPurgeHistoryRequest {
   generations: number[];
 }
 
+export interface AgentInputImage {
+  name: string;
+  mimeType: "image/jpeg" | "image/png" | "image/webp" | "image/gif";
+  data: Uint8Array;
+}
+
+export interface AgentSteeringMessage {
+  id: string;
+  text: string;
+  /** Persisted history text before attachment paths are appended. */
+  historyText?: string;
+  images?: AgentInputImage[];
+}
+
 export interface AgentRunRequest {
   botId: string;
   threadId: string;
@@ -307,11 +321,7 @@ export interface AgentRunRequest {
   prompt: string;
   instructions: string;
   history: Array<{ role: "user" | "assistant" | "system"; content: string }>;
-  currentTurnImages?: Array<{
-    name: string;
-    mimeType: "image/jpeg" | "image/png" | "image/webp" | "image/gif";
-    data: Uint8Array;
-  }>;
+  currentTurnImages?: AgentInputImage[];
   tools: ConnectorTool[];
   model: {
     provider: string;
@@ -342,7 +352,7 @@ export interface AgentRunRequest {
     route?: ConnectorRoute,
   ) => Promise<unknown>;
   /** Atomically claim durable user steering at the runtime's next safe turn boundary. */
-  claimSteering?: (seenIds: string[]) => Promise<Array<{ id: string; text: string }>>;
+  claimSteering?: (seenIds: string[]) => Promise<AgentSteeringMessage[]>;
 }
 
 export interface ScriptedTurn {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -308,6 +308,8 @@ export interface AgentInputImage {
 
 export interface AgentSteeringMessage {
   id: string;
+  /** Originating user message id when the steering came from a durable thread message. */
+  messageId?: string;
   text: string;
   /** Persisted history text before attachment paths are appended. */
   historyText?: string;
@@ -319,8 +321,10 @@ export interface AgentRunRequest {
   threadId: string;
   runId: string;
   prompt: string;
+  /** Source user message id for the prompt, used to strip duplicates from history. */
+  promptMessageId?: string;
   instructions: string;
-  history: Array<{ role: "user" | "assistant" | "system"; content: string }>;
+  history: Array<{ role: "user" | "assistant" | "system"; content: string; messageId?: string }>;
   currentTurnImages?: AgentInputImage[];
   tools: ConnectorTool[];
   model: {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2804,15 +2804,41 @@ export function createRunExecutor(deps: ExecutorDeps) {
               executeTool: scripted ? undefined : applyTool,
               claimSteering: scripted
                 ? undefined
-                : (seenIds) =>
-                    deps.events.claimSteering({
+                : async (seenIds) => {
+                    const steering = await deps.events.claimSteering({
                       threadId: thread.id,
                       botId: bot.id,
                       runId,
                       leaseOwner: workerId,
                       leaseFence: fence,
                       seenIds,
-                    }),
+                    });
+                    return Promise.all(
+                      steering.map(async (item) => {
+                        const [images, files] = await Promise.all([
+                          loadCurrentTurnImages(deps, item.blocks, context),
+                          deps.artifacts
+                            ? materializeCurrentTurnFiles(
+                                {
+                                  prisma: deps.prisma,
+                                  artifacts: deps.artifacts,
+                                  sandbox: deps.sandbox,
+                                },
+                                item.blocks,
+                                { context, computer, computerMode },
+                              )
+                            : [],
+                        ]);
+                        const filesInstruction = currentTurnFilesInstruction(files);
+                        return {
+                          id: item.id,
+                          historyText: item.text,
+                          text: [item.text, filesInstruction].filter(Boolean).join("\n\n"),
+                          images,
+                        };
+                      }),
+                    );
+                  },
             },
             context,
           )) {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -940,6 +940,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const threadContext = threadContextForRun(run.trigger, {
           messages: [...messages].reverse().map((m) => ({
             seq: m.seq,
+            id: m.id,
             role: (m.role === "user" ? "user" : m.role === "system" ? "system" : "assistant") as
               | "user"
               | "assistant"
@@ -954,7 +955,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
           summary: threadContext.summary,
           historyCompactedUpToSeq: threadContext.historyCompactedUpToSeq,
         });
-        let history = compactedHistory.history.map(({ role, content }) => ({ role, content }));
+        let history = compactedHistory.history.map(({ role, content, id }) => ({
+          role,
+          content,
+          messageId: id,
+        }));
         const turnBlocks = userTurnBlocksForRun(
           run.trigger,
           runId,
@@ -2754,6 +2759,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               threadId: thread.id,
               runId,
               prompt,
+              promptMessageId: run.sourceMessageId ?? undefined,
               instructions: [
                 bot.instructions || `${bot.name}: ${bot.title}\n${bot.description}`,
                 groupContext,
@@ -2832,6 +2838,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                         const filesInstruction = currentTurnFilesInstruction(files);
                         return {
                           id: item.id,
+                          messageId: item.messageId,
                           historyText: item.text,
                           text: [item.text, filesInstruction].filter(Boolean).join("\n\n"),
                           images,

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2802,6 +2802,17 @@ export function createRunExecutor(deps: ExecutorDeps) {
               allowSilentEmpty: allowSilentPeerMessage || messagingChannelRun,
               emptyResponseText,
               executeTool: scripted ? undefined : applyTool,
+              claimSteering: scripted
+                ? undefined
+                : (seenIds) =>
+                    deps.events.claimSteering({
+                      threadId: thread.id,
+                      botId: bot.id,
+                      runId,
+                      leaseOwner: workerId,
+                      leaseFence: fence,
+                      seenIds,
+                    }),
             },
             context,
           )) {
@@ -2970,6 +2981,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
                   blocks: [{ kind: "text", text: stuckText }],
                 });
                 if (!stopped) return;
+                if (stopped.continuationRunId) {
+                  await deps.jobs
+                    .enqueue(runContinueJob(stopped.continuationRunId))
+                    .catch((error) => console.error("steering continuation enqueue", error));
+                }
                 if (run.trigger === "bot_message") {
                   await returnBotMessageOutcome(
                     deps,
@@ -3120,6 +3136,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
             markUnread: completionMarksUnread(run.trigger, text),
           });
           if (!completed) return;
+          if (completed.continuationRunId) {
+            await deps.jobs
+              .enqueue(runContinueJob(completed.continuationRunId))
+              .catch((error) => console.error("steering continuation enqueue", error));
+          }
           if (run.trigger === "bot_message" && text) {
             await returnBotMessageOutcome(
               deps,
@@ -3128,7 +3149,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               text,
             ).catch((error) => console.error("bot message result return", error));
           }
-          if (text) {
+          if (text && !completed.continuationRunId) {
             await notifyRun(deps, run, {
               kind: "completion",
               title: `${bot.name} finished`,
@@ -3187,6 +3208,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
             error: message,
           });
           if (!failed) return;
+          if (failed.continuationRunId) {
+            await deps.jobs
+              .enqueue(runContinueJob(failed.continuationRunId))
+              .catch((error) => console.error("steering continuation enqueue", error));
+          }
           if (run.trigger === "bot_message") {
             await returnBotMessageOutcome(
               deps,
@@ -3196,13 +3222,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
               "status",
             ).catch((returnError) => console.error("bot message failure return", returnError));
           }
-          await notifyRun(deps, run, {
-            kind: "failure",
-            title: `${bot.name} failed`,
-            body: message.slice(0, 180),
-            botId: bot.id,
-            threadId: thread.id,
-          });
+          if (!failed.continuationRunId) {
+            await notifyRun(deps, run, {
+              kind: "failure",
+              title: `${bot.name} failed`,
+              body: message.slice(0, 180),
+              botId: bot.id,
+              threadId: thread.id,
+            });
+          }
         }
       } catch (setupError) {
         const computerBusy = setupError instanceof ComputerBusyError;

--- a/packages/adapters/src/history-compaction.ts
+++ b/packages/adapters/src/history-compaction.ts
@@ -43,6 +43,7 @@ export const MAX_RECALLED_MEMORIES = 5;
 
 export type CompactedHistoryMessage = {
   seq: number;
+  id?: string;
   role: "user" | "assistant" | "system";
   content: string;
 };

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -2,7 +2,7 @@ import type { ConnectorTool } from "@rakazo/adapter-kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakeAgentState = vi.hoisted(() => ({
-  mode: "dispatch" as "dispatch" | "empty" | "subagent-limit" | "parent-limit",
+  mode: "dispatch" as "dispatch" | "empty" | "two-boundaries" | "subagent-limit" | "parent-limit",
   abortCount: 0,
   tools: [] as Array<{
     name: string;
@@ -14,6 +14,9 @@ const fakeAgentState = vi.hoisted(() => ({
     args: { collection: "notes", title: "Result", body: "Done" } as Record<string, unknown>,
   },
   preparedMessages: [] as unknown[],
+  steeredMessages: [] as unknown[],
+  initialMessages: [] as unknown[],
+  promptInputs: [] as string[],
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
@@ -27,7 +30,7 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     private aborted = false;
 
     constructor(options: {
-      initialState: { tools: typeof fakeAgentState.tools };
+      initialState: { tools: typeof fakeAgentState.tools; messages: unknown[] };
       prepareNextTurnWithContext?: (input: {
         context: { messages: unknown[] };
       }) => Promise<{ context?: { messages: unknown[] } } | undefined>;
@@ -35,16 +38,21 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
       this.tools = options.initialState.tools;
       this.prepareNextTurnWithContext = options.prepareNextTurnWithContext;
       fakeAgentState.tools = this.tools;
+      fakeAgentState.initialMessages = options.initialState.messages;
     }
 
     subscribe(listener: (event: Record<string, unknown>) => void) {
       this.listeners.push(listener);
     }
 
-    async prompt() {
-      if (fakeAgentState.mode === "empty") {
-        const prepared = await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
-        fakeAgentState.preparedMessages = prepared?.context?.messages ?? [];
+    async prompt(prompt: string) {
+      fakeAgentState.promptInputs.push(prompt);
+      if (fakeAgentState.mode === "empty" || fakeAgentState.mode === "two-boundaries") {
+        await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
+        if (fakeAgentState.mode === "two-boundaries") {
+          await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
+        }
+        fakeAgentState.preparedMessages = [...fakeAgentState.steeredMessages];
         return;
       }
 
@@ -90,6 +98,10 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     }
 
     async waitForIdle() {}
+
+    steer(message: unknown) {
+      fakeAgentState.steeredMessages.push(message);
+    }
 
     abort() {
       this.aborted = true;
@@ -167,6 +179,9 @@ describe("Pi connector tool dispatch", () => {
     fakeAgentState.abortCount = 0;
     fakeAgentState.tools = [];
     fakeAgentState.preparedMessages = [];
+    fakeAgentState.steeredMessages = [];
+    fakeAgentState.initialMessages = [];
+    fakeAgentState.promptInputs = [];
     fakeAgentState.invoke = {
       name: "destination_write",
       args: { collection: "notes", title: "Result", body: "Done" },
@@ -176,10 +191,16 @@ describe("Pi connector tool dispatch", () => {
 
   it("injects durable steering at Pi's next safe turn boundary", async () => {
     fakeAgentState.mode = "empty";
-    const claimSteering = vi.fn(async () => [
-      { id: "steering-1", text: "Use the newer customer totals." },
-      { id: "steering-2", text: "Keep the original date range." },
-    ]);
+    let claimCount = 0;
+    const claimSteering = vi.fn(async () => {
+      claimCount += 1;
+      return claimCount === 1
+        ? []
+        : [
+            { id: "steering-1", text: "Use the newer customer totals." },
+            { id: "steering-2", text: "Keep the original date range." },
+          ];
+    });
     const runtime = new PiAgentRuntime();
 
     for await (const _event of runtime.run(
@@ -199,11 +220,88 @@ describe("Pi connector tool dispatch", () => {
       // Exhaust the runtime event stream.
     }
 
-    expect(claimSteering).toHaveBeenCalledWith([]);
+    expect(claimSteering).toHaveBeenNthCalledWith(1, []);
+    expect(claimSteering).toHaveBeenNthCalledWith(2, []);
     expect(fakeAgentState.preparedMessages).toEqual([
       expect.objectContaining({ role: "user", content: "Use the newer customer totals." }),
       expect.objectContaining({ role: "user", content: "Keep the original date range." }),
     ]);
+  });
+
+  it("defers steering arriving during a continuation to the following boundary", async () => {
+    fakeAgentState.mode = "two-boundaries";
+    let claimCount = 0;
+    const claimSteering = vi.fn(async () => {
+      claimCount += 1;
+      if (claimCount === 1) return [];
+      return claimCount === 2
+        ? [{ id: "steering-1", text: "First boundary context." }]
+        : [{ id: "steering-2", text: "Next boundary context." }];
+    });
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "r",
+        prompt: "continue",
+        instructions: "Follow the user's instructions.",
+        history: [],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(claimSteering).toHaveBeenNthCalledWith(1, []);
+    expect(claimSteering).toHaveBeenNthCalledWith(2, []);
+    expect(claimSteering).toHaveBeenNthCalledWith(3, ["steering-1"]);
+    expect(fakeAgentState.preparedMessages).toEqual([
+      expect.objectContaining({ content: "First boundary context." }),
+      expect.objectContaining({ content: "Next boundary context." }),
+    ]);
+  });
+
+  it("consumes pending continuation steering once in the first prompt", async () => {
+    fakeAgentState.mode = "empty";
+    const steering = [
+      { id: "steering-1", text: "Use the newer customer totals." },
+      { id: "steering-2", text: "Keep the original date range." },
+    ];
+    const claimSteering = vi.fn(async (seenIds: string[]) => (seenIds.length ? [] : steering));
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "continuation",
+        prompt: "Respond to the user's steering context.",
+        instructions: "Follow the user's instructions.",
+        history: [
+          { role: "user", content: steering[0]!.text },
+          { role: "user", content: steering[1]!.text },
+          { role: "assistant", content: "Here is the first result." },
+        ],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(fakeAgentState.promptInputs).toHaveLength(1);
+    for (const item of steering) {
+      expect(fakeAgentState.promptInputs[0]?.split(item.text)).toHaveLength(2);
+      expect(JSON.stringify(fakeAgentState.initialMessages)).not.toContain(item.text);
+    }
+    expect(fakeAgentState.steeredMessages).toEqual([]);
   });
 
   afterEach(() => {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -17,6 +17,7 @@ const fakeAgentState = vi.hoisted(() => ({
   steeredMessages: [] as unknown[],
   initialMessages: [] as unknown[],
   promptInputs: [] as string[],
+  promptImages: [] as unknown[][],
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
@@ -45,8 +46,9 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
       this.listeners.push(listener);
     }
 
-    async prompt(prompt: string) {
+    async prompt(prompt: string, images?: unknown[]) {
       fakeAgentState.promptInputs.push(prompt);
+      fakeAgentState.promptImages.push(images ?? []);
       if (fakeAgentState.mode === "empty" || fakeAgentState.mode === "two-boundaries") {
         await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
         if (fakeAgentState.mode === "two-boundaries") {
@@ -182,6 +184,7 @@ describe("Pi connector tool dispatch", () => {
     fakeAgentState.steeredMessages = [];
     fakeAgentState.initialMessages = [];
     fakeAgentState.promptInputs = [];
+    fakeAgentState.promptImages = [];
     fakeAgentState.invoke = {
       name: "destination_write",
       args: { collection: "notes", title: "Result", body: "Done" },
@@ -302,6 +305,68 @@ describe("Pi connector tool dispatch", () => {
       expect(JSON.stringify(fakeAgentState.initialMessages)).not.toContain(item.text);
     }
     expect(fakeAgentState.steeredMessages).toEqual([]);
+  });
+
+  it("delivers images attached to initial and boundary steering", async () => {
+    fakeAgentState.mode = "empty";
+    let claimCount = 0;
+    const claimSteering = vi.fn(async () => {
+      claimCount += 1;
+      if (claimCount === 1) {
+        return [
+          {
+            id: "initial-image",
+            text: "Inspect the first image.",
+            images: [
+              {
+                name: "first.png",
+                mimeType: "image/png" as const,
+                data: new Uint8Array([1, 2, 3]),
+              },
+            ],
+          },
+        ];
+      }
+      return [
+        {
+          id: "boundary-image",
+          text: "Compare the second image.",
+          images: [
+            { name: "second.png", mimeType: "image/png" as const, data: new Uint8Array([4, 5, 6]) },
+          ],
+        },
+      ];
+    });
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "image-steering",
+        prompt: "continue",
+        instructions: "Inspect attached images.",
+        history: [],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(fakeAgentState.promptImages).toEqual([
+      [{ type: "image", data: "AQID", mimeType: "image/png" }],
+    ]);
+    expect(fakeAgentState.steeredMessages).toContainEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "Compare the second image." },
+        { type: "image", data: "BAUG", mimeType: "image/png" },
+      ],
+      timestamp: expect.any(Number),
+    });
   });
 
   afterEach(() => {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -13,6 +13,7 @@ const fakeAgentState = vi.hoisted(() => ({
     name: "destination_write",
     args: { collection: "notes", title: "Result", body: "Done" } as Record<string, unknown>,
   },
+  preparedMessages: [] as unknown[],
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => ({
@@ -20,10 +21,19 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
     state = { errorMessage: undefined as string | undefined, messages: [] as unknown[] };
     private readonly tools: typeof fakeAgentState.tools;
     private readonly listeners: Array<(event: Record<string, unknown>) => void> = [];
+    private readonly prepareNextTurnWithContext?: (input: {
+      context: { messages: unknown[] };
+    }) => Promise<{ context?: { messages: unknown[] } } | undefined>;
     private aborted = false;
 
-    constructor(options: { initialState: { tools: typeof fakeAgentState.tools } }) {
+    constructor(options: {
+      initialState: { tools: typeof fakeAgentState.tools };
+      prepareNextTurnWithContext?: (input: {
+        context: { messages: unknown[] };
+      }) => Promise<{ context?: { messages: unknown[] } } | undefined>;
+    }) {
       this.tools = options.initialState.tools;
+      this.prepareNextTurnWithContext = options.prepareNextTurnWithContext;
       fakeAgentState.tools = this.tools;
     }
 
@@ -33,6 +43,8 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
 
     async prompt() {
       if (fakeAgentState.mode === "empty") {
+        const prepared = await this.prepareNextTurnWithContext?.({ context: { messages: [] } });
+        fakeAgentState.preparedMessages = prepared?.context?.messages ?? [];
         return;
       }
 
@@ -154,11 +166,44 @@ describe("Pi connector tool dispatch", () => {
     fakeAgentState.mode = "dispatch";
     fakeAgentState.abortCount = 0;
     fakeAgentState.tools = [];
+    fakeAgentState.preparedMessages = [];
     fakeAgentState.invoke = {
       name: "destination_write",
       args: { collection: "notes", title: "Result", body: "Done" },
     };
     delete process.env.MAX_TOOL_CALLS_PER_TURN;
+  });
+
+  it("injects durable steering at Pi's next safe turn boundary", async () => {
+    fakeAgentState.mode = "empty";
+    const claimSteering = vi.fn(async () => [
+      { id: "steering-1", text: "Use the newer customer totals." },
+      { id: "steering-2", text: "Keep the original date range." },
+    ]);
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "r",
+        prompt: "prepare the report",
+        instructions: "Follow the user's instructions.",
+        history: [],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(claimSteering).toHaveBeenCalledWith([]);
+    expect(fakeAgentState.preparedMessages).toEqual([
+      expect.objectContaining({ role: "user", content: "Use the newer customer totals." }),
+      expect.objectContaining({ role: "user", content: "Keep the original date range." }),
+    ]);
   });
 
   afterEach(() => {

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -269,6 +269,64 @@ describe("Pi connector tool dispatch", () => {
     ]);
   });
 
+  it("strips prompt and claimed steering by messageId when texts collide", async () => {
+    fakeAgentState.mode = "empty";
+    const shared = "Same text for both bots.";
+    const steering = [
+      { id: "steering-keep", messageId: "msg-steer-keep", text: shared },
+      { id: "steering-drop", messageId: "msg-steer-drop", text: shared },
+    ];
+    const claimSteering = vi.fn(async (seenIds: string[]) =>
+      seenIds.length ? [] : [steering[1]!],
+    );
+    const runtime = new PiAgentRuntime();
+
+    for await (const _event of runtime.run(
+      {
+        botId: "b",
+        threadId: "t",
+        runId: "collision",
+        prompt: shared,
+        promptMessageId: "msg-prompt",
+        instructions: "Follow the user's instructions.",
+        history: [
+          { role: "user", content: shared, messageId: "msg-other-bot" },
+          { role: "user", content: shared, messageId: "msg-steer-drop" },
+          { role: "user", content: shared, messageId: "msg-prompt" },
+          { role: "assistant", content: "Earlier answer." },
+        ],
+        tools: [],
+        model: { provider: "test", id: "dispatch-test-model" },
+        claimSteering,
+      },
+      { signal: new AbortController().signal },
+    )) {
+      // Exhaust the runtime event stream.
+    }
+
+    expect(fakeAgentState.promptInputs).toHaveLength(1);
+    expect(fakeAgentState.promptInputs[0]).toContain(shared);
+    // Only the claimed steering message and the prompt were removed; the earlier
+    // identical user message for the other bot stays in history.
+    expect(fakeAgentState.initialMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: "user", content: shared }),
+        expect.objectContaining({ role: "user", content: "Assistant: Earlier answer." }),
+      ]),
+    );
+    expect(
+      fakeAgentState.initialMessages.filter(
+        (message) =>
+          typeof message === "object" &&
+          message !== null &&
+          "role" in message &&
+          "content" in message &&
+          message.role === "user" &&
+          message.content === shared,
+      ),
+    ).toHaveLength(1);
+  });
+
   it("consumes pending continuation steering once in the first prompt", async () => {
     fakeAgentState.mode = "empty";
     const steering = [

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -144,13 +144,43 @@ export class PiAgentRuntime implements AgentRuntime {
           pausePending: false,
         };
         const tools = toAgentTools(toolDefs, host);
-        const history = toHistory(request.history, request.prompt);
+        const seenSteeringIds: string[] = [];
+        const initialSteering = request.claimSteering ? await request.claimSteering([]) : [];
+        seenSteeringIds.push(...initialSteering.map((item) => item.id));
+        const history = toHistory(
+          withoutSteeringMessages(
+            request.history,
+            initialSteering.map((item) => item.text),
+          ),
+          request.prompt,
+        );
+        const initialPrompt = initialSteering.length
+          ? `${request.prompt}\n\nAdditional user context:\n${initialSteering
+              .map((item) => item.text)
+              .join("\n")}`
+          : request.prompt;
 
-        const agent = new Agent({
+        let agent: Agent;
+        agent = new Agent({
+          steeringMode: "all",
           streamFn: (m, ctx, options) =>
             models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
           getApiKey: async () => apiKey,
           transformContext: async (messages) => pruneComputerScreenshotContext(messages),
+          prepareNextTurnWithContext: async () => {
+            if (!request.claimSteering) return undefined;
+            try {
+              const steering = await request.claimSteering([...seenSteeringIds]);
+              if (steering.length === 0) return undefined;
+              seenSteeringIds.push(...steering.map((item) => item.id));
+              for (const item of steering) {
+                agent.steer({ role: "user", content: item.text, timestamp: Date.now() });
+              }
+            } catch {
+              // Durable steering remains claimable at the next boundary or retry.
+            }
+            return undefined;
+          },
           initialState: {
             systemPrompt:
               request.instructions ||
@@ -231,7 +261,7 @@ export class PiAgentRuntime implements AgentRuntime {
           mimeType: image.mimeType,
         }));
         try {
-          await agent.prompt(request.prompt, images?.length ? images : undefined);
+          await agent.prompt(initialPrompt, images?.length ? images : undefined);
           await agent.waitForIdle();
         } finally {
           signal.removeEventListener("abort", onAbort);
@@ -444,8 +474,18 @@ function stableToolNameHash(name: string): string {
 }
 
 function toHistory(history: AgentRunRequest["history"], prompt: string) {
-  const last = history.at(-1);
-  const prior = last?.role === "user" && last.content === prompt ? history.slice(0, -1) : history;
+  let duplicatePromptIndex = -1;
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index];
+    if (message?.role === "user" && message.content === prompt) {
+      duplicatePromptIndex = index;
+      break;
+    }
+  }
+  const prior =
+    duplicatePromptIndex < 0
+      ? history
+      : history.filter((_, index) => index !== duplicatePromptIndex);
   return prior
     .filter((m) => m.role === "user" || m.role === "assistant")
     .map((m) =>
@@ -453,6 +493,25 @@ function toHistory(history: AgentRunRequest["history"], prompt: string) {
         ? { role: "user" as const, content: `Assistant: ${m.content}`, timestamp: Date.now() }
         : { role: "user" as const, content: m.content, timestamp: Date.now() },
     );
+}
+
+function withoutSteeringMessages(
+  history: AgentRunRequest["history"],
+  steering: string[],
+): AgentRunRequest["history"] {
+  if (steering.length === 0) return history;
+  const result = [...history];
+  let beforeIndex = result.length - 1;
+  for (let steeringIndex = steering.length - 1; steeringIndex >= 0; steeringIndex -= 1) {
+    for (let index = beforeIndex; index >= 0; index -= 1) {
+      const message = result[index];
+      if (message?.role !== "user" || message.content !== steering[steeringIndex]) continue;
+      result.splice(index, 1);
+      beforeIndex = index - 1;
+      break;
+    }
+  }
+  return result;
 }
 
 function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): AgentTool {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -150,7 +150,7 @@ export class PiAgentRuntime implements AgentRuntime {
         const history = toHistory(
           withoutSteeringMessages(
             request.history,
-            initialSteering.map((item) => item.text),
+            initialSteering.map((item) => item.historyText ?? item.text),
           ),
           request.prompt,
         );
@@ -169,15 +169,16 @@ export class PiAgentRuntime implements AgentRuntime {
           transformContext: async (messages) => pruneComputerScreenshotContext(messages),
           prepareNextTurnWithContext: async () => {
             if (!request.claimSteering) return undefined;
-            try {
-              const steering = await request.claimSteering([...seenSteeringIds]);
-              if (steering.length === 0) return undefined;
-              seenSteeringIds.push(...steering.map((item) => item.id));
-              for (const item of steering) {
-                agent.steer({ role: "user", content: item.text, timestamp: Date.now() });
-              }
-            } catch {
-              // Durable steering remains claimable at the next boundary or retry.
+            const steering = await request.claimSteering([...seenSteeringIds]);
+            if (steering.length === 0) return undefined;
+            seenSteeringIds.push(...steering.map((item) => item.id));
+            for (const item of steering) {
+              const images = toPiImages(item.images);
+              agent.steer({
+                role: "user",
+                content: images.length ? [{ type: "text", text: item.text }, ...images] : item.text,
+                timestamp: Date.now(),
+              });
             }
             return undefined;
           },
@@ -255,11 +256,10 @@ export class PiAgentRuntime implements AgentRuntime {
 
         // No "working…" progress push here: the shell already renders its own
         // placeholder while a run is active, and emitting one here shows two.
-        const images = request.currentTurnImages?.map((image) => ({
-          type: "image" as const,
-          data: Buffer.from(image.data).toString("base64"),
-          mimeType: image.mimeType,
-        }));
+        const images = toPiImages([
+          ...(request.currentTurnImages ?? []),
+          ...initialSteering.flatMap((item) => item.images ?? []),
+        ]);
         try {
           await agent.prompt(initialPrompt, images?.length ? images : undefined);
           await agent.waitForIdle();
@@ -313,6 +313,14 @@ export class PiAgentRuntime implements AgentRuntime {
       running.delete(request.runId);
     }
   }
+}
+
+function toPiImages(images: AgentRunRequest["currentTurnImages"]) {
+  return (images ?? []).map((image) => ({
+    type: "image" as const,
+    data: Buffer.from(image.data).toString("base64"),
+    mimeType: image.mimeType,
+  }));
 }
 
 function configuredOpenRouterModel(id: string): Model<"openai-completions"> {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -485,11 +485,7 @@ function stableToolNameHash(name: string): string {
   return (hash >>> 0).toString(36);
 }
 
-function toHistory(
-  history: AgentRunRequest["history"],
-  prompt: string,
-  promptMessageId?: string,
-) {
+function toHistory(history: AgentRunRequest["history"], prompt: string, promptMessageId?: string) {
   let duplicatePromptIndex = -1;
   for (let index = history.length - 1; index >= 0; index -= 1) {
     const message = history[index];

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -150,9 +150,13 @@ export class PiAgentRuntime implements AgentRuntime {
         const history = toHistory(
           withoutSteeringMessages(
             request.history,
-            initialSteering.map((item) => item.historyText ?? item.text),
+            initialSteering.map((item) => ({
+              messageId: item.messageId,
+              text: item.historyText ?? item.text,
+            })),
           ),
           request.prompt,
+          request.promptMessageId,
         );
         const initialPrompt = initialSteering.length
           ? `${request.prompt}\n\nAdditional user context:\n${initialSteering
@@ -481,14 +485,21 @@ function stableToolNameHash(name: string): string {
   return (hash >>> 0).toString(36);
 }
 
-function toHistory(history: AgentRunRequest["history"], prompt: string) {
+function toHistory(
+  history: AgentRunRequest["history"],
+  prompt: string,
+  promptMessageId?: string,
+) {
   let duplicatePromptIndex = -1;
   for (let index = history.length - 1; index >= 0; index -= 1) {
     const message = history[index];
-    if (message?.role === "user" && message.content === prompt) {
-      duplicatePromptIndex = index;
-      break;
-    }
+    if (message?.role !== "user") continue;
+    const matches = promptMessageId
+      ? message.messageId === promptMessageId
+      : message.content === prompt;
+    if (!matches) continue;
+    duplicatePromptIndex = index;
+    break;
   }
   const prior =
     duplicatePromptIndex < 0
@@ -505,15 +516,20 @@ function toHistory(history: AgentRunRequest["history"], prompt: string) {
 
 function withoutSteeringMessages(
   history: AgentRunRequest["history"],
-  steering: string[],
+  steering: Array<{ messageId?: string; text: string }>,
 ): AgentRunRequest["history"] {
   if (steering.length === 0) return history;
   const result = [...history];
   let beforeIndex = result.length - 1;
   for (let steeringIndex = steering.length - 1; steeringIndex >= 0; steeringIndex -= 1) {
+    const item = steering[steeringIndex]!;
     for (let index = beforeIndex; index >= 0; index -= 1) {
       const message = result[index];
-      if (message?.role !== "user" || message.content !== steering[steeringIndex]) continue;
+      if (message?.role !== "user") continue;
+      const matches = item.messageId
+        ? message.messageId === item.messageId
+        : message.content === item.text;
+      if (!matches) continue;
       result.splice(index, 1);
       beforeIndex = index - 1;
       break;

--- a/packages/db/prisma/migrations/20260831235900_steering_messages/migration.sql
+++ b/packages/db/prisma/migrations/20260831235900_steering_messages/migration.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "steering_messages" (
+    "id" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "botId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "runId" TEXT,
+    "claimedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "steering_messages_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "steering_messages_messageId_botId_key"
+ON "steering_messages"("messageId", "botId");
+
+CREATE INDEX "steering_messages_botId_runId_createdAt_idx"
+ON "steering_messages"("botId", "runId", "createdAt");
+
+CREATE INDEX "steering_messages_runId_idx" ON "steering_messages"("runId");
+
+ALTER TABLE "steering_messages"
+ADD CONSTRAINT "steering_messages_messageId_fkey"
+FOREIGN KEY ("messageId") REFERENCES "messages"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "steering_messages"
+ADD CONSTRAINT "steering_messages_botId_fkey"
+FOREIGN KEY ("botId") REFERENCES "bots"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "steering_messages"
+ADD CONSTRAINT "steering_messages_runId_fkey"
+FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -352,6 +352,7 @@ model Bot {
   usageRecords      UsageRecord[]
   tasks             Task[]
   runs              Run[]
+  steeringMessages  SteeringMessage[]
   mcpServers        BotMcpServer[]
   groupMembers      ChatGroupMember[]
 
@@ -469,6 +470,7 @@ model Message {
   clientNonce      String?
   thumbsUp         Boolean   @default(false)
   sourceRuns       Run[]     @relation("RunSourceMessage")
+  steeringMessages SteeringMessage[]
   createdAt        DateTime  @default(now())
 
   @@unique([threadId, seq])
@@ -550,6 +552,7 @@ model Run {
   attempts             Attempt[]
   effects              ExternalEffect[]
   usageRecords         UsageRecord[]
+  steeringMessages     SteeringMessage[]
 
   @@unique([spaceId, clientNonce])
   @@index([status, leaseExpiresAt])
@@ -560,6 +563,24 @@ model Run {
   @@index([threadId, status, createdAt])
   @@index([routineId])
   @@map("runs")
+}
+
+model SteeringMessage {
+  id        String   @id @default(cuid())
+  messageId String
+  message   Message  @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  botId     String
+  bot       Bot      @relation(fields: [botId], references: [id], onDelete: Cascade)
+  userId    String
+  runId     String?
+  run       Run?     @relation(fields: [runId], references: [id], onDelete: SetNull)
+  claimedAt DateTime?
+  createdAt DateTime @default(now())
+
+  @@unique([messageId, botId])
+  @@index([botId, runId, createdAt])
+  @@index([runId])
+  @@map("steering_messages")
 }
 
 model Attempt {

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -1012,7 +1012,21 @@ describe("claimSteering", () => {
       run: { findFirst: vi.fn().mockResolvedValue({ id: "run-1" }) },
       steeringMessage: {
         findMany: vi.fn().mockResolvedValue([
-          { id: "steer-1", message: { seq: 5, blocks: [{ kind: "text", text: "First" }] } },
+          {
+            id: "steer-1",
+            message: {
+              seq: 5,
+              blocks: [
+                { kind: "text", text: "First" },
+                {
+                  kind: "image",
+                  artifactId: "artifact-1",
+                  name: "chart.png",
+                  mimeType: "image/png",
+                },
+              ],
+            },
+          },
           { id: "steer-2", message: { seq: 6, blocks: [{ kind: "text", text: "Second" }] } },
         ]),
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
@@ -1032,8 +1046,20 @@ describe("claimSteering", () => {
         seenIds: [],
       }),
     ).resolves.toEqual([
-      { id: "steer-1", text: "First" },
-      { id: "steer-2", text: "Second" },
+      {
+        id: "steer-1",
+        text: "First\n[image: chart.png]",
+        blocks: [
+          { kind: "text", text: "First" },
+          {
+            kind: "image",
+            artifactId: "artifact-1",
+            name: "chart.png",
+            mimeType: "image/png",
+          },
+        ],
+      },
+      { id: "steer-2", text: "Second", blocks: [{ kind: "text", text: "Second" }] },
     ]);
     expect(tx.run.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from "./client.js";
 import {
   answerRunInput,
   appendEvent,
+  claimSteering,
   clearThread,
   finalizeComputerControlRelease,
   followThreadEvents,
@@ -895,6 +896,7 @@ describe("sendUserMessage", () => {
       task: { create: vi.fn().mockResolvedValue({ id: "task-1" }) },
       run: {
         create: vi.fn().mockResolvedValue({ id: "run-1" }),
+        findFirst: vi.fn().mockResolvedValue(null),
         findUnique: vi.fn().mockResolvedValue({ status: "queued" }),
       },
       event: {
@@ -949,7 +951,7 @@ describe("sendUserMessage", () => {
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 8 }));
   });
 
-  it("skips run creation when the bot is already busy and onlyIfIdle is set", async () => {
+  it("persists steering instead of starting a parallel run when the bot is busy", async () => {
     const tx = {
       thread: {
         update: vi
@@ -959,12 +961,13 @@ describe("sendUserMessage", () => {
       },
       message: {
         create: vi.fn().mockResolvedValue({ id: "message-1", seq: 4 }),
-        update: vi.fn(),
+        update: vi.fn().mockResolvedValue({ id: "message-1" }),
       },
       steeringMessage: { create: vi.fn() },
       task: { create: vi.fn() },
       run: {
         findFirst: vi.fn().mockResolvedValue({ id: "run-0" }),
+        findUnique: vi.fn().mockResolvedValue({ status: "running" }),
         create: vi.fn(),
       },
       event: {
@@ -987,15 +990,59 @@ describe("sendUserMessage", () => {
         blocks: [{ kind: "text", text: "hello" }],
         prompt: "hello",
         trigger: "follow_up",
-        onlyIfIdle: true,
       }),
     ).resolves.toEqual({ messageId: "message-1", seq: 4, taskId: null, runId: null });
 
     expect(tx.task.create).not.toHaveBeenCalled();
     expect(tx.run.create).not.toHaveBeenCalled();
-    expect(tx.message.update).not.toHaveBeenCalled();
+    expect(tx.message.update).toHaveBeenCalledWith({
+      where: { id: "message-1" },
+      data: { runId: "run-0" },
+    });
     expect(tx.steeringMessage.create).toHaveBeenCalledWith({
-      data: { messageId: "message-1", botId: "bot-1" },
+      data: { messageId: "message-1", botId: "bot-1", userId: "user-1", runId: "run-0" },
+    });
+  });
+});
+
+describe("claimSteering", () => {
+  it("claims pending messages for the fenced run in message order", async () => {
+    const tx = {
+      $queryRaw: vi.fn(),
+      run: { findFirst: vi.fn().mockResolvedValue({ id: "run-1" }) },
+      steeringMessage: {
+        findMany: vi.fn().mockResolvedValue([
+          { id: "steer-1", message: { seq: 5, blocks: [{ kind: "text", text: "First" }] } },
+          { id: "steer-2", message: { seq: 6, blocks: [{ kind: "text", text: "Second" }] } },
+        ]),
+        updateMany: vi.fn().mockResolvedValue({ count: 2 }),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      claimSteering(prisma, {
+        threadId: "thread-1",
+        botId: "bot-1",
+        runId: "run-1",
+        leaseOwner: "worker-1",
+        leaseFence: 2,
+        seenIds: [],
+      }),
+    ).resolves.toEqual([
+      { id: "steer-1", text: "First" },
+      { id: "steer-2", text: "Second" },
+    ]);
+    expect(tx.run.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ leaseOwner: "worker-1", leaseFence: 2 }),
+      }),
+    );
+    expect(tx.steeringMessage.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["steer-1", "steer-2"] }, claimedAt: null },
+      data: { runId: "run-1", claimedAt: expect.any(Date) },
     });
   });
 });

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -966,7 +966,7 @@ describe("sendUserMessage", () => {
       steeringMessage: { create: vi.fn() },
       task: { create: vi.fn() },
       run: {
-        findFirst: vi.fn().mockResolvedValue({ id: "run-0" }),
+        findFirst: vi.fn().mockResolvedValue({ id: "run-0", taskId: "task-0" }),
         findUnique: vi.fn().mockResolvedValue({ status: "running" }),
         create: vi.fn(),
       },
@@ -991,7 +991,7 @@ describe("sendUserMessage", () => {
         prompt: "hello",
         trigger: "follow_up",
       }),
-    ).resolves.toEqual({ messageId: "message-1", seq: 4, taskId: null, runId: null });
+    ).resolves.toEqual({ messageId: "message-1", seq: 4, taskId: "task-0", runId: "run-0" });
 
     expect(tx.task.create).not.toHaveBeenCalled();
     expect(tx.run.create).not.toHaveBeenCalled();
@@ -1015,6 +1015,7 @@ describe("claimSteering", () => {
           {
             id: "steer-1",
             message: {
+              id: "message-5",
               seq: 5,
               blocks: [
                 { kind: "text", text: "First" },
@@ -1027,7 +1028,10 @@ describe("claimSteering", () => {
               ],
             },
           },
-          { id: "steer-2", message: { seq: 6, blocks: [{ kind: "text", text: "Second" }] } },
+          {
+            id: "steer-2",
+            message: { id: "message-6", seq: 6, blocks: [{ kind: "text", text: "Second" }] },
+          },
         ]),
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
       },
@@ -1048,6 +1052,7 @@ describe("claimSteering", () => {
     ).resolves.toEqual([
       {
         id: "steer-1",
+        messageId: "message-5",
         text: "First\n[image: chart.png]",
         blocks: [
           { kind: "text", text: "First" },
@@ -1059,7 +1064,12 @@ describe("claimSteering", () => {
           },
         ],
       },
-      { id: "steer-2", text: "Second", blocks: [{ kind: "text", text: "Second" }] },
+      {
+        id: "steer-2",
+        messageId: "message-6",
+        text: "Second",
+        blocks: [{ kind: "text", text: "Second" }],
+      },
     ]);
     expect(tx.run.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -961,6 +961,7 @@ describe("sendUserMessage", () => {
         create: vi.fn().mockResolvedValue({ id: "message-1", seq: 4 }),
         update: vi.fn(),
       },
+      steeringMessage: { create: vi.fn() },
       task: { create: vi.fn() },
       run: {
         findFirst: vi.fn().mockResolvedValue({ id: "run-0" }),
@@ -993,6 +994,9 @@ describe("sendUserMessage", () => {
     expect(tx.task.create).not.toHaveBeenCalled();
     expect(tx.run.create).not.toHaveBeenCalled();
     expect(tx.message.update).not.toHaveBeenCalled();
+    expect(tx.steeringMessage.create).toHaveBeenCalledWith({
+      data: { messageId: "message-1", botId: "bot-1" },
+    });
   });
 });
 

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -86,6 +86,7 @@ export interface ClaimSteeringInput {
 export interface ClaimedSteeringMessage {
   id: string;
   text: string;
+  blocks: MessageBlock[];
 }
 
 export interface FinalizeRunResult {
@@ -453,6 +454,7 @@ export async function claimSteering(
     return steering.map((item) => ({
       id: item.id,
       text: blocksToAgentHistoryText(item.message.blocks as MessageBlock[]),
+      blocks: item.message.blocks as MessageBlock[],
     }));
   });
 }

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -85,6 +85,7 @@ export interface ClaimSteeringInput {
 
 export interface ClaimedSteeringMessage {
   id: string;
+  messageId: string;
   text: string;
   blocks: MessageBlock[];
 }
@@ -348,7 +349,7 @@ export async function sendUserMessage(
           botId: input.botId,
           status: { in: ["running", "queued", "leased", "waiting_input", "waiting_takeover"] },
         },
-        select: { id: true },
+        select: { id: true, taskId: true },
       });
       let task = null;
       let run = null;
@@ -398,7 +399,7 @@ export async function sendUserMessage(
         runId: run?.id ?? busy?.id,
         payload: { messageId: message.id, role: "user", blocks: input.blocks },
       });
-      return { message, task, run, event };
+      return { message, task, run, busy, event };
     });
   const committed = await commit().catch(async (error) => {
     const winner = await replay();
@@ -413,8 +414,8 @@ export async function sendUserMessage(
   return {
     messageId: committed.message.id,
     seq: committed.message.seq,
-    taskId: committed.task?.id ?? null,
-    runId: committed.run?.id ?? null,
+    taskId: committed.task?.id ?? committed.busy?.taskId ?? null,
+    runId: committed.run?.id ?? committed.busy?.id ?? null,
   };
 }
 
@@ -443,7 +444,7 @@ export async function claimSteering(
         OR: [{ runId: null }, { runId: input.runId }],
         message: { threadId: input.threadId },
       },
-      include: { message: { select: { blocks: true, seq: true } } },
+      include: { message: { select: { id: true, blocks: true, seq: true } } },
       orderBy: [{ message: { seq: "asc" } }, { id: "asc" }],
     });
     if (steering.length === 0) return [];
@@ -453,6 +454,7 @@ export async function claimSteering(
     });
     return steering.map((item) => ({
       id: item.id,
+      messageId: item.message.id,
       text: blocksToAgentHistoryText(item.message.blocks as MessageBlock[]),
       blocks: item.message.blocks as MessageBlock[],
     }));

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -4,7 +4,12 @@ import {
   MessageBlock as MessageBlockSchema,
   type ProductEvent,
 } from "@rakazo/contracts";
-import { isApprovalAskBlock, isSecretAskBlock, sanitizeJsonValue } from "@rakazo/core";
+import {
+  blocksToAgentHistoryText,
+  isApprovalAskBlock,
+  isSecretAskBlock,
+  sanitizeJsonValue,
+} from "@rakazo/core";
 import type { Prisma, PrismaClient } from "./client.js";
 import {
   assertRunCanWriteHistory,
@@ -28,11 +33,12 @@ export interface AppendEventInput {
 export interface ThreadEvents {
   answerRunInput(input: AnswerRunInput): Promise<boolean>;
   append(input: AppendEventInput): Promise<ProductEvent>;
+  claimSteering(input: ClaimSteeringInput): Promise<ClaimedSteeringMessage[]>;
   clearThread(input: ClearThreadInput): Promise<ClearThreadResult>;
   finalizeComputerControlRelease(
     input: FinalizeComputerControlReleaseInput,
   ): Promise<FinalizeComputerControlReleaseResult | false>;
-  finalizeRun(input: FinalizeRunInput): Promise<boolean>;
+  finalizeRun(input: FinalizeRunInput): Promise<FinalizeRunResult | false>;
   notify(threadId: string, seq: number): Promise<void>;
   pauseRunForInput(input: PauseRunForInput): Promise<boolean>;
   pauseRunForTakeover(input: PauseRunForTakeover): Promise<boolean>;
@@ -66,6 +72,24 @@ export interface FinalizeComputerControlReleaseInput {
 
 export interface FinalizeComputerControlReleaseResult {
   runId: string | null;
+}
+
+export interface ClaimSteeringInput {
+  threadId: string;
+  botId: string;
+  runId: string;
+  leaseOwner: string;
+  leaseFence: number;
+  seenIds: string[];
+}
+
+export interface ClaimedSteeringMessage {
+  id: string;
+  text: string;
+}
+
+export interface FinalizeRunResult {
+  continuationRunId: string | null;
 }
 
 interface FinalizeRunBase {
@@ -125,8 +149,6 @@ export interface SendUserMessageInput {
   prompt: string;
   trigger: "user" | "follow_up" | "webhook" | "messaging";
   clientNonce?: string;
-  /** Skip task/run creation when the bot already has active work (follow-up behavior). */
-  onlyIfIdle?: boolean;
   linkMessageToRun?: boolean;
 }
 
@@ -155,6 +177,7 @@ export function createThreadEvents(
   return {
     answerRunInput: (input) => answerRunInput(prisma, input, realtime, options.runSecretWriter),
     append: (input) => appendEvent(prisma, input, realtime),
+    claimSteering: (input) => claimSteering(prisma, input),
     clearThread: (input) => clearThread(prisma, input, realtime),
     finalizeComputerControlRelease: (input) =>
       finalizeComputerControlRelease(prisma, input, realtime),
@@ -292,7 +315,9 @@ export async function sendUserMessage(
       include: { sourceRuns: { orderBy: { createdAt: "asc" }, take: 1 } },
     });
     if (!message) return null;
-    const run = message.sourceRuns[0] ?? null;
+    const run =
+      message.sourceRuns[0] ??
+      (message.runId ? await prisma.run.findUnique({ where: { id: message.runId } }) : null);
     return {
       messageId: message.id,
       seq: message.seq,
@@ -316,12 +341,14 @@ export async function sendUserMessage(
         blocks: input.blocks,
         clientNonce: input.clientNonce,
       });
-      const busy = input.onlyIfIdle
-        ? await tx.run.findFirst({
-            where: { botId: input.botId, status: { in: ["running", "queued", "leased"] } },
-            select: { id: true },
-          })
-        : null;
+      const busy = await tx.run.findFirst({
+        where: {
+          threadId: input.threadId,
+          botId: input.botId,
+          status: { in: ["running", "queued", "leased", "waiting_input", "waiting_takeover"] },
+        },
+        select: { id: true },
+      });
       let task = null;
       let run = null;
       if (!busy) {
@@ -351,13 +378,23 @@ export async function sendUserMessage(
         if (input.linkMessageToRun) {
           await tx.message.update({ where: { id: message.id }, data: { runId: run.id } });
         }
+      } else {
+        await tx.steeringMessage.create({
+          data: {
+            messageId: message.id,
+            botId: input.botId,
+            userId: input.userId,
+            runId: busy.id,
+          },
+        });
+        await tx.message.update({ where: { id: message.id }, data: { runId: busy.id } });
       }
       const event = await appendEventInTransaction(tx, {
         spaceId: input.spaceId,
         threadId: input.threadId,
         botId: input.botId,
         type: "thread.message.created",
-        runId: run?.id,
+        runId: run?.id ?? busy?.id,
         payload: { messageId: message.id, role: "user", blocks: input.blocks },
       });
       return { message, task, run, event };
@@ -378,6 +415,46 @@ export async function sendUserMessage(
     taskId: committed.task?.id ?? null,
     runId: committed.run?.id ?? null,
   };
+}
+
+export async function claimSteering(
+  prisma: PrismaClient,
+  input: ClaimSteeringInput,
+): Promise<ClaimedSteeringMessage[]> {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.$queryRaw`SELECT id FROM threads WHERE id = ${input.threadId} FOR UPDATE`;
+    const run = await tx.run.findFirst({
+      where: {
+        id: input.runId,
+        threadId: input.threadId,
+        botId: input.botId,
+        status: "running",
+        leaseOwner: input.leaseOwner,
+        leaseFence: input.leaseFence,
+      },
+      select: { id: true },
+    });
+    if (!run) return [];
+    const steering = await tx.steeringMessage.findMany({
+      where: {
+        botId: input.botId,
+        id: input.seenIds.length ? { notIn: input.seenIds } : undefined,
+        OR: [{ runId: null }, { runId: input.runId }],
+        message: { threadId: input.threadId },
+      },
+      include: { message: { select: { blocks: true, seq: true } } },
+      orderBy: [{ message: { seq: "asc" } }, { id: "asc" }],
+    });
+    if (steering.length === 0) return [];
+    await tx.steeringMessage.updateMany({
+      where: { id: { in: steering.map((item) => item.id) }, claimedAt: null },
+      data: { runId: input.runId, claimedAt: new Date() },
+    });
+    return steering.map((item) => ({
+      id: item.id,
+      text: blocksToAgentHistoryText(item.message.blocks as MessageBlock[]),
+    }));
+  });
 }
 
 export async function answerRunInput(
@@ -733,7 +810,7 @@ export async function finalizeRun(
   prisma: PrismaClient,
   input: FinalizeRunInput,
   realtime?: RealtimeFanout,
-): Promise<boolean> {
+): Promise<FinalizeRunResult | false> {
   const committed = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     await tx.$queryRaw`SELECT id FROM threads WHERE id = ${input.threadId} FOR UPDATE`;
     try {
@@ -817,13 +894,81 @@ export async function finalizeRun(
       payload: input.outcome === "completed" ? {} : { error: input.error },
     });
     await tx.event.deleteMany({ where: { runId: input.runId, type: "thread.progress" } });
+    if (input.outcome === "completed") {
+      await tx.steeringMessage.deleteMany({
+        where: { runId: input.runId, claimedAt: { not: null } },
+      });
+      await tx.steeringMessage.updateMany({
+        where: { runId: input.runId },
+        data: { runId: null },
+      });
+    } else {
+      await tx.steeringMessage.updateMany({
+        where: { runId: input.runId },
+        data: { runId: null },
+      });
+    }
+    const continuationRunId = await createSteeringContinuation(tx, input);
     await tx.bot.update({ where: { id: input.botId }, data: { updatedAt: now } });
-    return { threadId: lastEvent.threadId, seq: lastEvent.seq };
+    return { threadId: lastEvent.threadId, seq: lastEvent.seq, continuationRunId };
   });
 
   if (!committed) return false;
   await notifyRealtime(realtime, committed.threadId, committed.seq);
-  return true;
+  return { continuationRunId: committed.continuationRunId };
+}
+
+async function createSteeringContinuation(
+  tx: Prisma.TransactionClient,
+  input: FinalizeRunBase,
+): Promise<string | null> {
+  const active = await tx.run.findFirst({
+    where: {
+      threadId: input.threadId,
+      botId: input.botId,
+      status: { in: ["queued", "leased", "running", "waiting_input", "waiting_takeover"] },
+    },
+    select: { id: true },
+  });
+  if (active) return null;
+  const pending = await tx.steeringMessage.findMany({
+    where: {
+      botId: input.botId,
+      runId: null,
+      message: { threadId: input.threadId },
+    },
+    include: { message: { select: { id: true, blocks: true, seq: true } } },
+    orderBy: [{ message: { seq: "asc" } }, { id: "asc" }],
+  });
+  if (pending.length === 0) return null;
+  const last = pending.at(-1)!;
+  const task = await tx.task.create({
+    data: {
+      spaceId: input.spaceId,
+      botId: input.botId,
+      threadId: input.threadId,
+      userId: pending[0]!.userId,
+      prompt: "Respond to the user's steering context.",
+      status: "queued",
+    },
+  });
+  const run = await tx.run.create({
+    data: {
+      spaceId: input.spaceId,
+      botId: input.botId,
+      threadId: input.threadId,
+      taskId: task.id,
+      userId: pending[0]!.userId,
+      status: "queued",
+      trigger: "follow_up",
+      sourceMessageId: last.message.id,
+    },
+  });
+  await tx.steeringMessage.updateMany({
+    where: { id: { in: pending.map((item) => item.id) }, runId: null },
+    data: { runId: run.id, claimedAt: null },
+  });
+  return run.id;
 }
 
 export async function appendEventInTransaction(

--- a/packages/testkit/src/executor-lifecycle.test.ts
+++ b/packages/testkit/src/executor-lifecycle.test.ts
@@ -200,7 +200,8 @@ describeIntegration("run executor lifecycle", () => {
 
     const results = await Promise.all([events.finalizeRun(input), events.finalizeRun(input)]);
 
-    expect(results.sort()).toEqual([false, true]);
+    expect(results.filter((result) => result === false)).toHaveLength(1);
+    expect(results.filter(Boolean)).toEqual([{ continuationRunId: null }]);
     const [run, storedAttempt, task, messages, terminalEvents] = await Promise.all([
       handles.prisma.run.findUniqueOrThrow({ where: { id: seeded.run.id } }),
       handles.prisma.attempt.findUniqueOrThrow({ where: { id: attempt.id } }),
@@ -263,6 +264,274 @@ describeIntegration("run executor lifecycle", () => {
     ).resolves.toMatchObject({ status: "queued" });
     expect(await handles.prisma.message.count({ where: { runId: seeded.run.id } })).toBe(0);
     expect(await handles.prisma.event.count({ where: { runId: seeded.run.id } })).toBe(0);
+  });
+
+  it("coalesces steering that races finalization into one durable continuation", async () => {
+    const seeded = await seedRun("steering-race", "start the analysis", {
+      status: "running",
+      leaseOwner: "steering-worker",
+      leaseFence: 3,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+    const attempt = await handles.prisma.attempt.create({
+      data: { runId: seeded.run.id, fence: 3, status: "running" },
+    });
+    const events = createThreadEvents(handles.prisma);
+    for (const text of ["Use the revised data.", "Keep it concise."]) {
+      await events.sendUserMessage({
+        spaceId: seeded.me.spaceId,
+        threadId: seeded.thread.id,
+        botId: seeded.bot.id,
+        userId: seeded.me.userId,
+        blocks: [{ kind: "text", text }],
+        prompt: text,
+        trigger: "follow_up",
+      });
+    }
+
+    const finalized = await events.finalizeRun({
+      spaceId: seeded.me.spaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      runId: seeded.run.id,
+      taskId: seeded.task.id,
+      attemptId: attempt.id,
+      leaseOwner: "steering-worker",
+      leaseFence: 3,
+      outcome: "completed",
+      blocks: [{ kind: "text", text: "Initial answer" }],
+    });
+
+    if (!finalized) throw new Error("Expected the active run to finalize");
+    const continuationRunId = finalized.continuationRunId;
+    expect(continuationRunId).toEqual(expect.any(String));
+    const [continuation, steering] = await Promise.all([
+      handles.prisma.run.findUniqueOrThrow({
+        where: { id: continuationRunId! },
+        include: { task: true },
+      }),
+      handles.prisma.steeringMessage.findMany({
+        where: { botId: seeded.bot.id },
+        orderBy: { message: { seq: "asc" } },
+      }),
+    ]);
+    expect(continuation).toMatchObject({ status: "queued", trigger: "follow_up" });
+    expect(continuation.task.prompt).toBe("Respond to the user's steering context.");
+    expect(steering).toHaveLength(2);
+    expect(steering).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ runId: continuationRunId, claimedAt: null }),
+        expect.objectContaining({ runId: continuationRunId, claimedAt: null }),
+      ]),
+    );
+    const userMessages = await handles.prisma.message.findMany({
+      where: { threadId: seeded.thread.id, role: "user" },
+      orderBy: { seq: "asc" },
+    });
+    expect(userMessages).toHaveLength(2);
+    expect(userMessages[0]!.seq).toBeLessThan(userMessages[1]!.seq);
+  });
+
+  it("requeues steering claimed by a failed attempt without duplicating it", async () => {
+    const seeded = await seedRun("steering-failure", "start the analysis", {
+      status: "running",
+      leaseOwner: "failure-worker",
+      leaseFence: 4,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+    const attempt = await handles.prisma.attempt.create({
+      data: { runId: seeded.run.id, fence: 4, status: "running" },
+    });
+    const events = createThreadEvents(handles.prisma);
+    await events.sendUserMessage({
+      spaceId: seeded.me.spaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      userId: seeded.me.userId,
+      blocks: [{ kind: "text", text: "Recover this context." }],
+      prompt: "Recover this context.",
+      trigger: "follow_up",
+    });
+    await expect(
+      events.claimSteering({
+        threadId: seeded.thread.id,
+        botId: seeded.bot.id,
+        runId: seeded.run.id,
+        leaseOwner: "failure-worker",
+        leaseFence: 4,
+        seenIds: [],
+      }),
+    ).resolves.toHaveLength(1);
+
+    const finalized = await events.finalizeRun({
+      spaceId: seeded.me.spaceId,
+      threadId: seeded.thread.id,
+      botId: seeded.bot.id,
+      runId: seeded.run.id,
+      taskId: seeded.task.id,
+      attemptId: attempt.id,
+      leaseOwner: "failure-worker",
+      leaseFence: 4,
+      outcome: "failed",
+      error: "provider failed",
+    });
+    if (!finalized) throw new Error("Expected the failed run to finalize");
+    const continuationRunId = finalized.continuationRunId;
+    expect(continuationRunId).toEqual(expect.any(String));
+    await expect(
+      handles.prisma.run.findUniqueOrThrow({
+        where: { id: continuationRunId! },
+        include: { task: true },
+      }),
+    ).resolves.toMatchObject({
+      status: "queued",
+      trigger: "follow_up",
+      task: { prompt: "Respond to the user's steering context." },
+    });
+    await expect(
+      handles.prisma.steeringMessage.findFirstOrThrow({ where: { botId: seeded.bot.id } }),
+    ).resolves.toMatchObject({ runId: continuationRunId, claimedAt: null });
+  });
+
+  it("discards pending steering when the user stops active work", async () => {
+    const seeded = await seedRun("steering-stop", "keep working", {
+      status: "running",
+      leaseOwner: "stop-worker",
+      leaseFence: 1,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+    await rpc(seeded.cookie, "threads/send", {
+      botId: seeded.bot.id,
+      text: "Context that should stop with the run.",
+      clientNonce: `stop-steering-${stamp}`,
+    });
+
+    await rpc(seeded.cookie, "threads/stop", { botId: seeded.bot.id });
+
+    await expect(
+      handles.prisma.run.findUniqueOrThrow({ where: { id: seeded.run.id } }),
+    ).resolves.toMatchObject({ status: "cancelled" });
+    expect(await handles.prisma.steeringMessage.count({ where: { botId: seeded.bot.id } })).toBe(0);
+    expect(await handles.prisma.run.count({ where: { threadId: seeded.thread.id } })).toBe(1);
+  });
+
+  it("turns a regular bot-thread send during active work into steering", async () => {
+    const seeded = await seedRun("bot-steering-send", "keep working", {
+      status: "running",
+      leaseOwner: "busy-worker",
+      leaseFence: 1,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      startedAt: new Date(),
+    });
+
+    const steeringInput = {
+      botId: seeded.bot.id,
+      text: "Use this additional context.",
+      clientNonce: `bot-steering-${stamp}`,
+    };
+    await rpc(seeded.cookie, "threads/send", steeringInput);
+    await rpc(seeded.cookie, "threads/send", steeringInput);
+
+    expect(await handles.prisma.run.count({ where: { threadId: seeded.thread.id } })).toBe(1);
+    expect(
+      await handles.prisma.message.count({
+        where: { threadId: seeded.thread.id, clientNonce: steeringInput.clientNonce },
+      }),
+    ).toBe(1);
+    await expect(
+      handles.prisma.steeringMessage.findFirstOrThrow({
+        where: { botId: seeded.bot.id, message: { threadId: seeded.thread.id } },
+      }),
+    ).resolves.toMatchObject({ runId: seeded.run.id, claimedAt: null });
+  });
+
+  it("applies the same no-parallel-run rule to the targeted group member", async () => {
+    const cookie = await signup(
+      `executor-group-steering-${stamp}@rakazo.test`,
+      "Executor group steering",
+    );
+    const me = await rpc<{ userId: string; spaceId: string }>(cookie, "me");
+    const botA = await rpc<{ id: string }>(cookie, "bots/create", {
+      name: "Group lead",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: false,
+    });
+    const botB = await rpc<{ id: string }>(cookie, "bots/create", {
+      name: "Group helper",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: false,
+    });
+    const group = await rpc<{ id: string }>(cookie, "groups/create", {
+      name: "Steering group",
+      botIds: [botA.id, botB.id],
+    });
+    const thread = await handles.prisma.thread.findUniqueOrThrow({ where: { groupId: group.id } });
+    const member = await handles.prisma.chatGroupMember.findFirstOrThrow({
+      where: { groupId: group.id },
+      orderBy: { createdAt: "asc" },
+    });
+    const task = await handles.prisma.task.create({
+      data: {
+        spaceId: me.spaceId,
+        botId: member.botId,
+        threadId: thread.id,
+        userId: me.userId,
+        prompt: "keep working",
+        status: "queued",
+      },
+    });
+    const activeRun = await handles.prisma.run.create({
+      data: {
+        spaceId: me.spaceId,
+        botId: member.botId,
+        threadId: thread.id,
+        taskId: task.id,
+        userId: me.userId,
+        status: "running",
+        trigger: "user",
+        leaseOwner: "group-worker",
+        leaseFence: 1,
+        leaseExpiresAt: new Date(Date.now() + 60_000),
+        startedAt: new Date(),
+      },
+    });
+
+    await rpc(cookie, "threads/send", {
+      groupId: group.id,
+      text: "Use this group context.",
+      mentions: [{ kind: "bot", id: member.botId }],
+      clientNonce: `group-steering-${stamp}`,
+    });
+
+    expect(await handles.prisma.run.count({ where: { threadId: thread.id } })).toBe(1);
+    await expect(
+      handles.prisma.steeringMessage.findFirstOrThrow({
+        where: { botId: member.botId, message: { threadId: thread.id } },
+      }),
+    ).resolves.toMatchObject({ runId: activeRun.id, claimedAt: null });
+
+    const otherBotId = botA.id === member.botId ? botB.id : botA.id;
+    const mixedInput = {
+      groupId: group.id,
+      text: "Use both agents.",
+      mentions: [
+        { kind: "bot", id: member.botId },
+        { kind: "bot", id: otherBotId },
+      ],
+      clientNonce: `group-mixed-${stamp}`,
+    };
+    const first = await rpc<{ runIds: string[] }>(cookie, "threads/send", mixedInput);
+    const replay = await rpc<{ runIds: string[] }>(cookie, "threads/send", mixedInput);
+    expect(first.runIds).toHaveLength(2);
+    expect(replay.runIds).toEqual(first.runIds);
+    expect(await handles.prisma.run.count({ where: { threadId: thread.id } })).toBe(2);
   });
 
   async function seedRun(

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -1776,7 +1776,12 @@ describeJourneys("required product journeys", () => {
       where: { threadId_clientNonce: { threadId: group.threadId, clientNonce: replayNonce } },
       include: { sourceRuns: true },
     });
-    expect(replayMessage.sourceRuns).toHaveLength(2);
+    expect(replayMessage.sourceRuns).toHaveLength(1);
+    await expect(
+      prisma.steeringMessage.findUniqueOrThrow({
+        where: { messageId_botId: { messageId: replayMessage.id, botId: botB.id } },
+      }),
+    ).resolves.toMatchObject({ runId: staleRun.id, claimedAt: null });
     expect(
       await prisma.message.count({ where: { threadId: group.threadId, clientNonce: replayNonce } }),
     ).toBe(1);

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -1692,8 +1692,7 @@ describeJourneys("required product journeys", () => {
         userId: adaMe.userId,
         status: "running",
         trigger: "user",
-        createdAt: new Date(Date.now() + 1_000),
-      },
+                createdAt: new Date(Date.now() + 60_000),,
     });
     const askSnapshot = await rpc<Snap>(app, ada, "threads/get", { groupId: group.id });
     expect(askSnapshot.run?.id).toBe(concurrentRun.id);

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -1692,7 +1692,8 @@ describeJourneys("required product journeys", () => {
         userId: adaMe.userId,
         status: "running",
         trigger: "user",
-                createdAt: new Date(Date.now() + 60_000),,
+        createdAt: new Date(Date.now() + 60_000),
+      },
     });
     const askSnapshot = await rpc<Snap>(app, ada, "threads/get", { groupId: group.id });
     expect(askSnapshot.run?.id).toBe(concurrentRun.id);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Review fixes for steering while bots work. Fork branch `davidrobertson/rakazo:feat/steering-messages` (#453) is not writable from this agent, so this draft PR carries the steering work plus the review fixes on `elie222/rakazo`.

## Fixes

1. **i18n** – Wrap web composer steering strings with Lingui `t` / `Trans` (status hint, Steer placeholder/aria-label, Send steering message aria-label).
2. **Stop vs send race** – While a send is in flight, disable Stop and make `stopRun` a no-op.
3. **`randomUUID` fallback** – Use a mobile-style client nonce helper when `crypto.randomUUID` is missing.
4. **Mobile stop** – If `threads/stop` succeeds but refresh fails, show a refresh error instead of “Failed to stop work”.
5. **History stripping** – Prefer `messageId` when removing the prompt and claimed steering so identical group texts cannot strip the wrong message.
6. **Busy send response** – When steering is recorded against a busy run, return that run’s `runId` / `taskId` for idempotent first-response consistency.

## Status

- CI green on `b6223aa` (lint, typecheck, unit, postgres journeys, web E2E)
- Kept as draft per request; CodeRabbit skips draft PRs by default
- Confirm #453 remains the human-owned fork PR; merge path TBD by maintainers

## Test plan

- [x] `vitest run packages/db/src/events.test.ts packages/adapters/src/pi-runtime-tool-dispatch.test.ts`
- [x] CI on this PR
- [ ] Human review / merge path vs #453

Keeps PR draft. Does not redesign steering or implement multi-bubble turns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39f0c8a1-fed9-421d-99f7-19ea09b641ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39f0c8a1-fed9-421d-99f7-19ea09b641ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

