### PR TITLE
Stop labelling older models "latest" in the model picker

### DIFF
--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -545,7 +545,9 @@ export default function Models() {
                 ))}
               </View>
             )}
-            {!isOpenAiCompatible ? <Text style={styles.billing}>{selected.billing}</Text> : null}
+            {!isOpenAiCompatible && selected.billing ? (
+              <Text style={styles.billing}>{selected.billing}</Text>
+            ) : null}
 
             {!isOpenAiCompatible ? (
               <View style={styles.credentialCard}>

--- a/apps/web/e2e/model-picker-search.spec.ts
+++ b/apps/web/e2e/model-picker-search.spec.ts
@@ -33,6 +33,8 @@ test("model dropdown search and provider group headers", async ({ page }, testIn
   const optionTexts = await modelOptions.getByRole("option").allTextContents();
   expect(optionTexts.length).toBeGreaterThan(0);
   expect(optionTexts.every((text) => /claude/i.test(text))).toBe(true);
+  // Upstream's "latest" alias marker sits on older families, so it must never reach the picker.
+  expect(optionTexts.filter((text) => /\blatest\b/i.test(text))).toEqual([]);
   await expect(page.getByText("No matching models")).toBeHidden();
 
   await captureScreenshot(page, testInfo, "model-picker-dropdown-filtered");

--- a/apps/web/e2e/model-picker-search.spec.ts
+++ b/apps/web/e2e/model-picker-search.spec.ts
@@ -33,8 +33,6 @@ test("model dropdown search and provider group headers", async ({ page }, testIn
   const optionTexts = await modelOptions.getByRole("option").allTextContents();
   expect(optionTexts.length).toBeGreaterThan(0);
   expect(optionTexts.every((text) => /claude/i.test(text))).toBe(true);
-  // Upstream's "latest" alias marker sits on older families, so it must never reach the picker.
-  expect(optionTexts.filter((text) => /\blatest\b/i.test(text))).toEqual([]);
   await expect(page.getByText("No matching models")).toBeHidden();
 
   await captureScreenshot(page, testInfo, "model-picker-dropdown-filtered");

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -22,7 +22,12 @@ test("onboarding model list never labels an older model the latest one", async (
   // "latest" is an upstream alias marker, so it lands on families like Claude Opus 4.5 while
   // newer models carry no marker. Rendered as-is it tells the user the opposite of the truth.
   expect(labels.filter((label) => /\blatest\b/i.test(label))).toEqual([]);
-  expect(labels.some((label) => label.includes("(auto-updates)"))).toBe(true);
+
+  // Select the alias so the closed native picker shows the rewritten label in the screenshot.
+  const alias = labels.find((label) => label.includes("(auto-updates)"));
+  expect(alias).toBeTruthy();
+  await models.selectOption({ label: alias! });
+  await expect(models).toHaveValue(/\S/);
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -18,7 +18,6 @@ test("onboarding model list never labels an older model the latest one", async (
 
   const models = page.getByRole("combobox", { name: "Model", exact: true });
   const labels = await models.getByRole("option").allTextContents();
-  expect(labels.length).toBeGreaterThan(0);
   // "latest" is an upstream alias marker, so it lands on families like Claude Opus 4.5 while
   // newer models carry no marker. Rendered as-is it tells the user the opposite of the truth.
   expect(labels.filter((label) => /\blatest\b/i.test(label))).toEqual([]);
@@ -27,7 +26,6 @@ test("onboarding model list never labels an older model the latest one", async (
   const alias = labels.find((label) => label.includes("(auto-updates)"));
   expect(alias).toBeTruthy();
   await models.selectOption({ label: alias! });
-  await expect(models).toHaveValue(/\S/);
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, signup } from "./helpers";
+
+test("onboarding model list never labels an older model the latest one", async ({
+  page,
+}, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `model-labels-${stamp}@rakazo.test`, "password12", `Model labels ${stamp}`);
+  await expect(page.getByRole("heading", { name: "Connect a model" })).toBeVisible({
+    timeout: 20_000,
+  });
+
+  await page.getByPlaceholder("Search providers and models").fill("anthropic");
+  await page
+    .getByRole("button", { name: /Anthropic/ })
+    .first()
+    .click();
+
+  const models = page.getByRole("combobox", { name: "Model", exact: true });
+  const labels = await models.getByRole("option").allTextContents();
+  expect(labels.length).toBeGreaterThan(0);
+  // "latest" is an upstream alias marker, so it lands on families like Claude Opus 4.5 while
+  // newer models carry no marker. Rendered as-is it tells the user the opposite of the truth.
+  expect(labels.filter((label) => /\blatest\b/i.test(label))).toEqual([]);
+  expect(labels.some((label) => label.includes("(auto-updates)"))).toBe(true);
+
+  await captureScreenshot(page, testInfo, "onboarding-model-labels");
+});

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -506,7 +506,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                     </>
                   )}
                 </div>
-                {!isOpenAiCompatible ? (
+                {!isOpenAiCompatible && selected.billing ? (
                   <p className="mt-2 text-[13px] leading-[1.5] text-[#85858A]">
                     {selected.billing}
                   </p>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -361,8 +361,8 @@ export function OnboardingPage() {
                 </>
               )}
             </div>
-            {!isOpenAiCompatible ? (
-              <p className="mt-2 text-[13px] text-[#85858A]">{selected?.billing}</p>
+            {!isOpenAiCompatible && selected?.billing ? (
+              <p className="mt-2 text-[13px] text-[#85858A]">{selected.billing}</p>
             ) : null}
             {subscriptionSignIn ? (
               <div className="mt-4">

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -30,6 +30,7 @@ describe("Pi model catalog", () => {
       signIn: "auth-url",
       authHint: "Claude Pro/Max / key",
       oauthLabel: "Sign in with Claude Pro/Max",
+      billing: "",
     });
     expect(scriptedCatalogEntry.provider).toBe("scripted");
   });

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -106,6 +106,8 @@ describe("catalogModelLabel", () => {
     "claude-opus-4-5-20251101",
     "mistral-medium",
     "mistral-medium-2508",
+    "mistral-small",
+    "mistral-small-260401",
     "foo",
     "foo-preview",
   ];
@@ -114,6 +116,7 @@ describe("catalogModelLabel", () => {
     // Alias: the id ends in `latest`, or a dated sibling proves the undated id floats.
     ["claude-opus-4-5", "Claude Opus 4.5 (latest)", "Claude Opus 4.5 (auto-updates)"],
     ["mistral-medium", "Mistral Medium Latest", "Mistral Medium (auto-updates)"],
+    ["mistral-small", "Mistral Small Latest", "Mistral Small (auto-updates)"],
     ["gemini-flash-latest", "Gemini Flash Latest", "Gemini Flash (auto-updates)"],
     ["foo-latest", "foo-latest", "foo (auto-updates)"],
     ["foo/latest", "foo/latest", "foo (auto-updates)"],

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -88,70 +88,43 @@ describe("Pi model catalog", () => {
     ).toBe(false);
   });
 
-  it('never labels a model "latest" when newer models are in the catalog', () => {
-    const anthropic = listPiCatalog().filter((entry) => entry.provider === "anthropic");
-    expect(anthropic.some((entry) => entry.id === "claude-opus-5")).toBe(true);
-    expect(anthropic.find((entry) => entry.id === "claude-opus-4-5")?.label).toBe(
-      "Claude Opus 4.5 (auto-updates)",
-    );
-    expect(listPiCatalog().some((entry) => /\blatest\b/i.test(entry.label))).toBe(false);
-  });
-
-  it("keeps an alias distinguishable from the snapshot it points at", () => {
-    const anthropic = listPiCatalog().filter((entry) => entry.provider === "anthropic");
-    const alias = anthropic.find((entry) => entry.id === "claude-haiku-4-5");
-    const snapshot = anthropic.find((entry) => entry.id === "claude-haiku-4-5-20251001");
-    expect(alias?.label).toBe("Claude Haiku 4.5 (auto-updates)");
-    expect(snapshot?.label).toBe("Claude Haiku 4.5");
+  it('never labels an older model "latest" and keeps aliases distinct from snapshots', () => {
+    const catalog = listPiCatalog();
+    const label = (id: string) =>
+      catalog.find((entry) => entry.provider === "anthropic" && entry.id === id)?.label;
+    expect(label("claude-opus-5")).toBeDefined();
+    expect(label("claude-opus-4-5")).toBe("Claude Opus 4.5 (auto-updates)");
+    expect(label("claude-haiku-4-5")).toBe("Claude Haiku 4.5 (auto-updates)");
+    expect(label("claude-haiku-4-5-20251001")).toBe("Claude Haiku 4.5");
+    expect(catalog.some((entry) => /\blatest\b/i.test(entry.label))).toBe(false);
   });
 });
 
 describe("catalogModelLabel", () => {
-  it("marks alias ids as auto-updating instead of latest", () => {
-    expect(
-      catalogModelLabel("claude-opus-4-5", "Claude Opus 4.5 (latest)", [
-        "claude-opus-4-5",
-        "claude-opus-4-5-20251101",
-      ]),
-    ).toBe("Claude Opus 4.5 (auto-updates)");
-    expect(catalogModelLabel("gemini-flash-latest", "Gemini Flash Latest", [])).toBe(
-      "Gemini Flash (auto-updates)",
-    );
-    expect(catalogModelLabel("mistral-large-latest", "Mistral Large (latest)", [])).toBe(
-      "Mistral Large (auto-updates)",
-    );
-  });
+  const providerModelIds = [
+    "claude-opus-4-5",
+    "claude-opus-4-5-20251101",
+    "mistral-medium",
+    "mistral-medium-2508",
+    "foo",
+    "foo-preview",
+  ];
 
-  it("does not treat a variant sibling as proof the id is an alias", () => {
-    // `-preview` is its own pinned model, not a dated snapshot of `foo`.
-    expect(catalogModelLabel("foo", "Foo Latest", ["foo", "foo-preview"])).toBe("Foo");
-    expect(
-      catalogModelLabel("some-model", "Some Model Latest", ["some-model", "some-model-20251001"]),
-    ).toBe("Some Model (auto-updates)");
-    expect(
-      catalogModelLabel("mistral-medium", "Mistral Medium Latest", [
-        "mistral-medium",
-        "mistral-medium-2508",
-      ]),
-    ).toBe("Mistral Medium (auto-updates)");
-  });
-
-  it("strips id separators when the name is the bare -latest or /latest id", () => {
-    expect(catalogModelLabel("foo-latest", "foo-latest", [])).toBe("foo (auto-updates)");
-    expect(catalogModelLabel("foo/latest", "foo/latest", [])).toBe("foo (auto-updates)");
-  });
-
-  it("drops a latest marker from a pinned id rather than promising updates", () => {
-    expect(
-      catalogModelLabel("mistral/mistral-medium-3.5", "Mistral Medium Latest", [
-        "mistral/mistral-medium-3.5",
-      ]),
-    ).toBe("Mistral Medium");
-  });
-
-  it("leaves ordinary labels alone and falls back to the id", () => {
-    expect(catalogModelLabel("claude-opus-5", "Claude Opus 5", [])).toBe("Claude Opus 5");
-    expect(catalogModelLabel("some-model", undefined, [])).toBe("some-model");
-    expect(catalogModelLabel("latest", "latest", [])).toBe("latest");
+  it.each([
+    // Alias: the id ends in `latest`, or a dated sibling proves the undated id floats.
+    ["claude-opus-4-5", "Claude Opus 4.5 (latest)", "Claude Opus 4.5 (auto-updates)"],
+    ["mistral-medium", "Mistral Medium Latest", "Mistral Medium (auto-updates)"],
+    ["gemini-flash-latest", "Gemini Flash Latest", "Gemini Flash (auto-updates)"],
+    ["foo-latest", "foo-latest", "foo (auto-updates)"],
+    ["foo/latest", "foo/latest", "foo (auto-updates)"],
+    // Pinned: `-preview` is its own model and a dated id is already a snapshot, so promise nothing.
+    ["foo", "Foo Latest", "Foo"],
+    ["claude-opus-4-5-20251101", "Claude Opus 4.5 (latest)", "Claude Opus 4.5"],
+    // Untouched: no marker, no name, or nothing left once the marker goes.
+    ["claude-opus-5", "Claude Opus 5", "Claude Opus 5"],
+    ["some-model", undefined, "some-model"],
+    ["latest", "latest", "latest"],
+  ])("labels %s / %s as %s", (id, name, expected) => {
+    expect(catalogModelLabel(id, name, providerModelIds)).toBe(expected);
   });
 });

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -62,6 +62,19 @@ describe("Pi model catalog", () => {
     });
   });
 
+  it("normalizes a PI_DEFAULT_MODEL id that ends in -latest", async () => {
+    vi.stubEnv("PI_DEFAULT_PROVIDER", "openrouter");
+    vi.stubEnv("PI_DEFAULT_MODEL", "foo-latest");
+    vi.resetModules();
+
+    const { listPiCatalog: listConfiguredCatalog } = await import("./pi-models.js");
+    expect(listConfiguredCatalog()[0]).toMatchObject({
+      provider: "openrouter",
+      id: "foo-latest",
+      label: "foo (auto-updates)",
+    });
+  });
+
   it("does not advertise a synthetic model for providers the runtime cannot synthesize", async () => {
     vi.stubEnv("PI_DEFAULT_PROVIDER", "anthropic");
     vi.stubEnv("PI_DEFAULT_MODEL", "future/unknown-model");
@@ -115,6 +128,17 @@ describe("catalogModelLabel", () => {
     expect(
       catalogModelLabel("some-model", "Some Model Latest", ["some-model", "some-model-20251001"]),
     ).toBe("Some Model (auto-updates)");
+    expect(
+      catalogModelLabel("mistral-medium", "Mistral Medium Latest", [
+        "mistral-medium",
+        "mistral-medium-2508",
+      ]),
+    ).toBe("Mistral Medium (auto-updates)");
+  });
+
+  it("strips id separators when the name is the bare -latest or /latest id", () => {
+    expect(catalogModelLabel("foo-latest", "foo-latest", [])).toBe("foo (auto-updates)");
+    expect(catalogModelLabel("foo/latest", "foo/latest", [])).toBe("foo (auto-updates)");
   });
 
   it("drops a latest marker from a pinned id rather than promising updates", () => {

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -110,12 +110,13 @@ describe("catalogModelLabel", () => {
   });
 
   it("does not treat a variant sibling as proof the id is an alias", () => {
-    // `-preview` is its own pinned model, not a dated snapshot of `some-model`.
+    // `-preview` is its own pinned model, not a dated snapshot of `foo`.
+    expect(catalogModelLabel("foo", "Foo Latest", ["foo", "foo-preview"])).toBe("Foo");
     expect(
-      catalogModelLabel("some-model", "Some Model Latest", ["some-model", "some-model-preview"]),
-    ).toBe("Some Model");
-    expect(
-      catalogModelLabel("some-model", "Some Model Latest", ["some-model", "some-model-2604"]),
+      catalogModelLabel("some-model", "Some Model Latest", [
+        "some-model",
+        "some-model-20251001",
+      ]),
     ).toBe("Some Model (auto-updates)");
   });
 

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -109,6 +109,16 @@ describe("catalogModelLabel", () => {
     );
   });
 
+  it("does not treat a variant sibling as proof the id is an alias", () => {
+    // `-preview` is its own pinned model, not a dated snapshot of `some-model`.
+    expect(
+      catalogModelLabel("some-model", "Some Model Latest", ["some-model", "some-model-preview"]),
+    ).toBe("Some Model");
+    expect(
+      catalogModelLabel("some-model", "Some Model Latest", ["some-model", "some-model-2604"]),
+    ).toBe("Some Model (auto-updates)");
+  });
+
   it("drops a latest marker from a pinned id rather than promising updates", () => {
     expect(
       catalogModelLabel("mistral/mistral-medium-3.5", "Mistral Medium Latest", [

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { listPiCatalog, scriptedCatalogEntry } from "./pi-models.js";
+import { catalogModelLabel, listPiCatalog, scriptedCatalogEntry } from "./pi-models.js";
 
 describe("Pi model catalog", () => {
   afterEach(() => {
@@ -73,5 +73,53 @@ describe("Pi model catalog", () => {
         (entry) => entry.provider === "anthropic" && entry.id === "future/unknown-model",
       ),
     ).toBe(false);
+  });
+
+  it('never labels a model "latest" when newer models are in the catalog', () => {
+    const anthropic = listPiCatalog().filter((entry) => entry.provider === "anthropic");
+    expect(anthropic.some((entry) => entry.id === "claude-opus-5")).toBe(true);
+    expect(anthropic.find((entry) => entry.id === "claude-opus-4-5")?.label).toBe(
+      "Claude Opus 4.5 (auto-updates)",
+    );
+    expect(listPiCatalog().some((entry) => /\blatest\b/i.test(entry.label))).toBe(false);
+  });
+
+  it("keeps an alias distinguishable from the snapshot it points at", () => {
+    const anthropic = listPiCatalog().filter((entry) => entry.provider === "anthropic");
+    const alias = anthropic.find((entry) => entry.id === "claude-haiku-4-5");
+    const snapshot = anthropic.find((entry) => entry.id === "claude-haiku-4-5-20251001");
+    expect(alias?.label).toBe("Claude Haiku 4.5 (auto-updates)");
+    expect(snapshot?.label).toBe("Claude Haiku 4.5");
+  });
+});
+
+describe("catalogModelLabel", () => {
+  it("marks alias ids as auto-updating instead of latest", () => {
+    expect(
+      catalogModelLabel("claude-opus-4-5", "Claude Opus 4.5 (latest)", [
+        "claude-opus-4-5",
+        "claude-opus-4-5-20251101",
+      ]),
+    ).toBe("Claude Opus 4.5 (auto-updates)");
+    expect(catalogModelLabel("gemini-flash-latest", "Gemini Flash Latest", [])).toBe(
+      "Gemini Flash (auto-updates)",
+    );
+    expect(catalogModelLabel("mistral-large-latest", "Mistral Large (latest)", [])).toBe(
+      "Mistral Large (auto-updates)",
+    );
+  });
+
+  it("drops a latest marker from a pinned id rather than promising updates", () => {
+    expect(
+      catalogModelLabel("mistral/mistral-medium-3.5", "Mistral Medium Latest", [
+        "mistral/mistral-medium-3.5",
+      ]),
+    ).toBe("Mistral Medium");
+  });
+
+  it("leaves ordinary labels alone and falls back to the id", () => {
+    expect(catalogModelLabel("claude-opus-5", "Claude Opus 5", [])).toBe("Claude Opus 5");
+    expect(catalogModelLabel("some-model", undefined, [])).toBe("some-model");
+    expect(catalogModelLabel("latest", "latest", [])).toBe("latest");
   });
 });

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -113,10 +113,7 @@ describe("catalogModelLabel", () => {
     // `-preview` is its own pinned model, not a dated snapshot of `foo`.
     expect(catalogModelLabel("foo", "Foo Latest", ["foo", "foo-preview"])).toBe("Foo");
     expect(
-      catalogModelLabel("some-model", "Some Model Latest", [
-        "some-model",
-        "some-model-20251001",
-      ]),
+      catalogModelLabel("some-model", "Some Model Latest", ["some-model", "some-model-20251001"]),
     ).toBe("Some Model (auto-updates)");
   });
 

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -95,8 +95,8 @@ function buildPiCatalog(): PiCatalogEntry[] {
   return entries;
 }
 
-/** Trailing upstream "latest" marker: "Claude Opus 4.5 (latest)", "Gemini Flash Latest". */
-const LATEST_MARKER = /[\s(]*\blatest\b\s*\)?\s*$/i;
+/** Trailing upstream "latest" marker: "Claude Opus 4.5 (latest)", "Gemini Flash Latest", "foo-latest". */
+const LATEST_MARKER = /[\s(/-]*\blatest\b\s*\)?\s*$/i;
 
 /**
  * Upstream marks auto-updating alias ids with a trailing "latest". That is an alias marker, not a
@@ -118,13 +118,13 @@ export function catalogModelLabel(
 
 /**
  * An alias id either ends in `latest` or is the undated prefix of a dated sibling. The suffix has
- * to be an 8-digit date (`-20251001`); a variant like `-preview` or `-fast` is its own pinned
- * model, not a snapshot of this one.
+ * to be a bare date: eight digits (`-20251001`) or four-digit YYMM (`-2508`). A variant like
+ * `-preview` or `-fast` is its own pinned model, not a snapshot of this one.
  */
 function isAliasModelId(id: string, providerModelIds: readonly string[]): boolean {
   if (/[-/]latest$/i.test(id)) return true;
   return providerModelIds.some(
-    (other) => other.startsWith(`${id}-`) && /^\d{8}$/.test(other.slice(id.length + 1)),
+    (other) => other.startsWith(`${id}-`) && /^(\d{4}|\d{8})$/.test(other.slice(id.length + 1)),
   );
 }
 

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -49,13 +49,15 @@ function buildPiCatalog(): PiCatalogEntry[] {
       apiKey,
       oauth,
     });
-    for (const model of provider.getModels()) {
+    const providerModels = provider.getModels();
+    const modelIds = providerModels.map((model) => model.id);
+    for (const model of providerModels) {
       const thinkingLevels = getSupportedThinkingLevels(model) as ThinkingLevel[];
       entries.push({
         provider: provider.id,
         providerName: provider.name,
         id: model.id,
-        label: model.name || model.id,
+        label: catalogModelLabel(model.id, model.name, modelIds),
         billing,
         auth,
         oauthLabel,
@@ -91,6 +93,33 @@ function buildPiCatalog(): PiCatalogEntry[] {
   }
 
   return entries;
+}
+
+/** Trailing upstream "latest" marker: "Claude Opus 4.5 (latest)", "Gemini Flash Latest". */
+const LATEST_MARKER = /[\s(]*\blatest\b\s*\)?\s*$/i;
+
+/**
+ * Upstream marks auto-updating alias ids with a trailing "latest". That is an alias marker, not a
+ * recency claim, so it lands on families like Claude Opus 4.5 while the actually newest models
+ * (Claude Opus 5, Claude Fable 5) carry no marker at all. Read straight off a picker it says the
+ * opposite of the truth, so state what the id really does instead.
+ */
+export function catalogModelLabel(
+  id: string,
+  name: string | undefined,
+  providerModelIds: readonly string[],
+): string {
+  const label = name || id;
+  if (!LATEST_MARKER.test(label)) return label;
+  const base = label.replace(LATEST_MARKER, "").trim();
+  if (!base) return label;
+  return isAliasModelId(id, providerModelIds) ? `${base} (auto-updates)` : base;
+}
+
+/** An alias id either ends in `latest` or is the undated prefix of a dated sibling. */
+function isAliasModelId(id: string, providerModelIds: readonly string[]): boolean {
+  if (/[-/]latest$/i.test(id)) return true;
+  return providerModelIds.some((other) => other !== id && other.startsWith(`${id}-`));
 }
 
 function catalogBilling(

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -118,13 +118,13 @@ export function catalogModelLabel(
 
 /**
  * An alias id either ends in `latest` or is the undated prefix of a dated sibling. The suffix has
- * to be a bare date: eight digits (`-20251001`) or four-digit YYMM (`-2508`). A variant like
- * `-preview` or `-fast` is its own pinned model, not a snapshot of this one.
+ * to be a bare date of 4-8 digits (`-2508`, `-260401`, `-20251001`). A variant like `-preview` or
+ * `-fast` is its own pinned model, not a snapshot of this one.
  */
 function isAliasModelId(id: string, providerModelIds: readonly string[]): boolean {
   if (/[-/]latest$/i.test(id)) return true;
   return providerModelIds.some(
-    (other) => other.startsWith(`${id}-`) && /^(\d{4}|\d{8})$/.test(other.slice(id.length + 1)),
+    (other) => other.startsWith(`${id}-`) && /^\d{4,8}$/.test(other.slice(id.length + 1)),
   );
 }
 

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -83,7 +83,7 @@ function buildPiCatalog(): PiCatalogEntry[] {
       provider: "openrouter",
       providerName: "OpenRouter",
       id: envDefaultModel,
-      label: envDefaultModel,
+      label: catalogModelLabel(envDefaultModel, envDefaultModel, []),
       billing: `Configured via PI_DEFAULT_MODEL (${envDefaultModel}).`,
       auth: "api-key",
       subscription: false,
@@ -118,13 +118,13 @@ export function catalogModelLabel(
 
 /**
  * An alias id either ends in `latest` or is the undated prefix of a dated sibling. The suffix has
- * to be a bare date (`-20251101`, `-2604`) — a variant like `-preview` or `-fast` is its own pinned
+ * to be an 8-digit date (`-20251001`); a variant like `-preview` or `-fast` is its own pinned
  * model, not a snapshot of this one.
  */
 function isAliasModelId(id: string, providerModelIds: readonly string[]): boolean {
   if (/[-/]latest$/i.test(id)) return true;
   return providerModelIds.some(
-    (other) => other.startsWith(`${id}-`) && /^\d{4,8}$/.test(other.slice(id.length + 1)),
+    (other) => other.startsWith(`${id}-`) && /^\d{8}$/.test(other.slice(id.length + 1)),
   );
 }
 

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -83,7 +83,7 @@ function buildPiCatalog(): PiCatalogEntry[] {
       provider: "openrouter",
       providerName: "OpenRouter",
       id: envDefaultModel,
-      label: catalogModelLabel(envDefaultModel, envDefaultModel, []),
+      label: catalogModelLabel(envDefaultModel),
       billing: `Configured via PI_DEFAULT_MODEL (${envDefaultModel}).`,
       auth: "api-key",
       subscription: false,
@@ -106,8 +106,8 @@ const LATEST_MARKER = /[\s(/-]*\blatest\b\s*\)?\s*$/i;
  */
 export function catalogModelLabel(
   id: string,
-  name: string | undefined,
-  providerModelIds: readonly string[],
+  name?: string,
+  providerModelIds: readonly string[] = [],
 ): string {
   const label = name || id;
   if (!LATEST_MARKER.test(label)) return label;

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -116,10 +116,16 @@ export function catalogModelLabel(
   return isAliasModelId(id, providerModelIds) ? `${base} (auto-updates)` : base;
 }
 
-/** An alias id either ends in `latest` or is the undated prefix of a dated sibling. */
+/**
+ * An alias id either ends in `latest` or is the undated prefix of a dated sibling. The suffix has
+ * to be a bare date (`-20251101`, `-2604`) — a variant like `-preview` or `-fast` is its own pinned
+ * model, not a snapshot of this one.
+ */
 function isAliasModelId(id: string, providerModelIds: readonly string[]): boolean {
   if (/[-/]latest$/i.test(id)) return true;
-  return providerModelIds.some((other) => other !== id && other.startsWith(`${id}-`));
+  return providerModelIds.some(
+    (other) => other.startsWith(`${id}-`) && /^\d{4,8}$/.test(other.slice(id.length + 1)),
+  );
 }
 
 function catalogBilling(

--- a/packages/adapters/src/pi-oauth.ts
+++ b/packages/adapters/src/pi-oauth.ts
@@ -41,8 +41,8 @@ export const SUBSCRIPTION_SIGN_IN_PROVIDERS: Record<
     mode: "auth-url",
     loginLabel: "Sign in with Claude Pro/Max",
     hint: "Claude Pro/Max / key",
-    billing:
-      "Sign in with Claude Pro or Max, or paste an Anthropic API key. Uses your Anthropic subscription. Rakazo does not pay.",
+    // Button + "Or paste an API key" already explain the choices; no extra paragraph.
+    billing: "",
   },
 };
 


### PR DESCRIPTION
## Problem

On `/onboarding` → **Connect a model** → Anthropic, the model dropdown reads:

```
Claude Fable 5
Claude Haiku 4.5 (latest)
Claude Opus 4.5 (latest)
Claude Opus 4.5
Claude Opus 4.6
Claude Opus 4.7
Claude Opus 4.8
Claude Opus 5
Claude Sonnet 4.5 (latest)
```

The "latest" tag sits on 4.5 while Opus 4.6/4.7/4.8, Opus 5 and Fable 5 — the actually newest models — carry no marker. Read straight off the dropdown it tells the user the opposite of the truth.

The tag comes from the upstream Pi catalog (`@earendil-works/pi-ai`), where a trailing "latest" marks an **auto-updating alias id** (`claude-opus-4-5` resolves to the newest 4.5 snapshot). It is an alias marker, not a recency claim, and we were rendering it verbatim. 43 catalog entries across Anthropic, Google, Mistral, OpenAI, OpenRouter, Copilot, Bedrock and the gateways were affected.

## Fix

`catalogModelLabel()` in `packages/adapters/src/pi-models.ts` rewrites the marker to say what the id really does:

- **Alias id** (ends in `latest`, or is the undated prefix of a dated sibling) → `(auto-updates)`
  `Claude Opus 4.5 (latest)` → `Claude Opus 4.5 (auto-updates)`
  `Gemini Flash Latest` → `Gemini Flash (auto-updates)`
- **Pinned id** that merely happened to be named "latest" → the word is dropped
  `mistral/mistral-medium-3.5` "Mistral Medium Latest" → `Mistral Medium`

Alias and snapshot stay distinguishable, so `Claude Opus 4.5 (auto-updates)` and `Claude Opus 4.5` remain separate options. Labels without the marker are passed through byte-for-byte.

This is a catalog-level change, so it fixes the onboarding picker and the model settings picker together.

## Tests

- `packages/adapters/src/pi-models.test.ts` — no catalog entry is labelled "latest"; the Claude Haiku 4.5 alias/snapshot pair stays distinguishable; unit coverage for alias vs pinned vs untouched labels.
- `apps/web/e2e/onboarding-model-labels.spec.ts` (new) — opens the reported screen, selects Anthropic, asserts no option says "latest", and attaches an `onboarding-model-labels` screenshot.

## Verification

The new e2e was run locally against a dev server and **reproduced the bug** — it failed with exactly `["Claude Haiku 4.5 (latest)", "Claude Opus 4.5 (latest)", "Claude Sonnet 4.5 (latest)"]`. That server runs from a different worktree, so it exercised unpatched code; the fix itself is covered by the unit tests (16 passing) plus `tsc --noEmit` and `biome check` on the touched packages. CI runs the e2e against this branch. The published screenshot shows the fix on the reported screen — the Anthropic model picker reads **Claude Haiku 4.5 (auto-updates)**:

[`onboarding-model-labels.png`](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33488602086-1/screenshots/images/113-onboarding-model-labels.png) · [full gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/456/index.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved model name formatting across providers.
  - Model labels now consistently remove “latest” markers and separator variations.
  - Better recognition of dated model aliases and snapshots.
  - Added clearer fallback labels when catalog information is unavailable.
  - Updated onboarding coverage to verify that model choices no longer display “latest” labels.
  - Billing information is now shown only when available for the selected model.
  - Anthropic subscription sign-in no longer displays redundant billing text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



