### PR TITLE
Highlight PR-relevant Playwright frames in CI comments

### DIFF
--- a/.github/workflows/publish-playwright-report.yml
+++ b/.github/workflows/publish-playwright-report.yml
@@ -147,9 +147,25 @@ jobs:
           fi
           public_base_url="${PLAYWRIGHT_PUBLIC_BASE_URL%/}"
           gallery_url="$public_base_url/prs/$PR_NUMBER/index.html"
+          review_path="$GITHUB_WORKSPACE/.tmp/playwright-dashboard/screenshots/review.json"
+          if [[ ! -f "$review_path" ]]; then
+            echo "Missing Playwright review manifest at $review_path." >&2
+            exit 1
+          fi
+          changed_paths_file="$(mktemp)"
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[].filename' > "$changed_paths_file"
+          body="$(
+            PLAYWRIGHT_GALLERY_URL="$gallery_url" \
+            PLAYWRIGHT_DASHBOARD_URL="$public_base_url/index.html" \
+            PLAYWRIGHT_RUN_URL="$RUN_URL" \
+            PLAYWRIGHT_SHA="$SHA" \
+              pnpm exec tsx packages/testkit/src/cli/build-playwright-pr-screenshot-comment.ts \
+                "$review_path" \
+                "$changed_paths_file"
+          )"
           marker="<!-- rakazo-playwright-screenshots -->"
-          body="$(printf '%s\n### Playwright screenshots\n[Open screenshot gallery](%s) · [Dashboard](%s/index.html) · [CI run](%s)\n\nUpdated for commit `%s`.' \
-            "$marker" "$gallery_url" "$public_base_url" "$RUN_URL" "${SHA:0:7}")"
           comment_id="$(gh api --paginate --slurp \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" | \
             jq -r --arg marker "$marker" \

--- a/packages/testkit/src/cli/build-playwright-pr-screenshot-comment.ts
+++ b/packages/testkit/src/cli/build-playwright-pr-screenshot-comment.ts
@@ -24,8 +24,12 @@ const changedPaths = (await readFile(changedPathsPath, "utf8"))
 if (!Array.isArray(review.screenshots)) {
   throw new Error("review.json must include a screenshots array");
 }
-if (typeof review.screenshotsUrl !== "string" || !URL.canParse(review.screenshotsUrl)) {
-  throw new Error("review.json must include a screenshotsUrl");
+if (
+  typeof review.screenshotsUrl !== "string" ||
+  !URL.canParse(review.screenshotsUrl) ||
+  new URL(review.screenshotsUrl).protocol !== "https:"
+) {
+  throw new Error("review.json must include an https screenshotsUrl");
 }
 
 const galleryUrl = getRequiredHttpsEnvironmentVariable("PLAYWRIGHT_GALLERY_URL");

--- a/packages/testkit/src/cli/build-playwright-pr-screenshot-comment.ts
+++ b/packages/testkit/src/cli/build-playwright-pr-screenshot-comment.ts
@@ -1,0 +1,60 @@
+import { readFile } from "node:fs/promises";
+import {
+  buildPlaywrightPrScreenshotComment,
+  type PlaywrightPrCommentScreenshot,
+} from "../playwright-pr-screenshot-comment.js";
+
+const [reviewPath, changedPathsPath] = process.argv.slice(2);
+
+if (!reviewPath || !changedPathsPath) {
+  throw new Error(
+    "Usage: build-playwright-pr-screenshot-comment <review-json-path> <changed-paths-file>",
+  );
+}
+
+const review = JSON.parse(await readFile(reviewPath, "utf8")) as {
+  screenshots?: PlaywrightPrCommentScreenshot[];
+  screenshotsUrl?: string;
+};
+const changedPaths = (await readFile(changedPathsPath, "utf8"))
+  .split(/\r?\n/)
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+if (!Array.isArray(review.screenshots)) {
+  throw new Error("review.json must include a screenshots array");
+}
+if (typeof review.screenshotsUrl !== "string" || !URL.canParse(review.screenshotsUrl)) {
+  throw new Error("review.json must include a screenshotsUrl");
+}
+
+const galleryUrl = getRequiredHttpsEnvironmentVariable("PLAYWRIGHT_GALLERY_URL");
+const dashboardUrl = getRequiredHttpsEnvironmentVariable("PLAYWRIGHT_DASHBOARD_URL");
+const runUrl = getRequiredHttpsEnvironmentVariable("PLAYWRIGHT_RUN_URL");
+const sha = getRequiredEnvironmentVariable("PLAYWRIGHT_SHA");
+
+process.stdout.write(
+  `${buildPlaywrightPrScreenshotComment({
+    changedPaths,
+    dashboardUrl,
+    galleryUrl,
+    runUrl,
+    screenshots: review.screenshots,
+    screenshotsUrl: review.screenshotsUrl,
+    sha,
+  })}\n`,
+);
+
+function getRequiredEnvironmentVariable(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function getRequiredHttpsEnvironmentVariable(name: string): string {
+  const value = getRequiredEnvironmentVariable(name);
+  if (!URL.canParse(value) || new URL(value).protocol !== "https:") {
+    throw new Error(`${name} must use HTTPS`);
+  }
+  return value;
+}

--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -129,7 +129,8 @@ async function collectScreenshots(
     const captureType = classifyPlaywrightScreenshot(file);
     if (captureType === undefined) continue;
     const source = path.relative(resultsPath, file);
-    const fileName = `${String(index + 1).padStart(3, "0")}-${sanitizeFileName(path.basename(file))}`;
+    const baseName = sanitizeFileName(path.basename(file));
+    const fileName = `${String(index + 1).padStart(3, "0")}-${baseName}`;
     await copyFile(file, path.join(imagePath, fileName));
     screenshots.push({
       captureType,
@@ -137,7 +138,7 @@ async function collectScreenshots(
       hash: createHash("sha256").update(screenshot).digest("hex"),
       source,
       testId: testIdFromSource(source),
-      title: titleFromFileName(fileName),
+      title: titleFromFileName(baseName),
     });
   }
   return screenshots;

--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -137,7 +137,7 @@ async function collectScreenshots(
       hash: createHash("sha256").update(screenshot).digest("hex"),
       source,
       testId: testIdFromSource(source),
-      title: titleFromFileName(path.basename(file)),
+      title: titleFromFileName(fileName),
     });
   }
   return screenshots;

--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -95,6 +95,10 @@ await writeFile(
     sha,
   }),
 );
+await writeFile(
+  path.join(galleryPath, "review.json"),
+  `${JSON.stringify({ screenshots, screenshotsUrl }, null, 2)}\n`,
+);
 
 console.log(
   `Playwright dashboard generated with ${history.length} runs and ${screenshots.length} screenshots.`,

--- a/packages/testkit/src/playwright-pr-screenshot-comment.test.ts
+++ b/packages/testkit/src/playwright-pr-screenshot-comment.test.ts
@@ -277,6 +277,27 @@ describe("buildPlaywrightPrScreenshotComment", () => {
     expect(body).not.toContain("frame 9");
     expect(body).toContain("- +2 more in the gallery");
   });
+
+  it("neutralizes Markdown syntax in contributor-controlled titles", () => {
+    const body = buildPlaywrightPrScreenshotComment({
+      ...urls,
+      changedPaths: [],
+      screenshots: [
+        screenshot({
+          comparison: "new",
+          fileName: "images/010-crafted.png",
+          source: "tool-activity-shell-x/crafted.png",
+          title: "evil]\n**bold** `code` _em_ #heading [link]",
+        }),
+      ],
+    });
+
+    expect(body).toContain(
+      "- [evil\\] \\*\\*bold\\*\\* \\`code\\` \\_em\\_ \\#heading \\[link\\]](https://example.com/playwright/runs/1-1/screenshots/images/010-crafted.png) (new)",
+    );
+    expect(body).not.toContain("\n**bold**");
+    expect(body).not.toContain("`code`");
+  });
 });
 
 function screenshot(

--- a/packages/testkit/src/playwright-pr-screenshot-comment.test.ts
+++ b/packages/testkit/src/playwright-pr-screenshot-comment.test.ts
@@ -278,7 +278,7 @@ describe("buildPlaywrightPrScreenshotComment", () => {
     expect(body).toContain("- +2 more in the gallery");
   });
 
-  it("neutralizes Markdown syntax in contributor-controlled titles", () => {
+  it("neutralizes Markdown and HTML syntax in contributor-controlled titles", () => {
     const body = buildPlaywrightPrScreenshotComment({
       ...urls,
       changedPaths: [],
@@ -287,16 +287,17 @@ describe("buildPlaywrightPrScreenshotComment", () => {
           comparison: "new",
           fileName: "images/010-crafted.png",
           source: "tool-activity-shell-x/crafted.png",
-          title: "evil]\n**bold** `code` _em_ #heading [link]",
+          title: "evil]\n**bold** `code` _em_ #heading [link] <details>&",
         }),
       ],
     });
 
     expect(body).toContain(
-      "- [evil\\] \\*\\*bold\\*\\* \\`code\\` \\_em\\_ \\#heading \\[link\\]](https://example.com/playwright/runs/1-1/screenshots/images/010-crafted.png) (new)",
+      "- [evil\\] \\*\\*bold\\*\\* \\`code\\` \\_em\\_ \\#heading \\[link\\] &lt;details&gt;&amp;](https://example.com/playwright/runs/1-1/screenshots/images/010-crafted.png) (new)",
     );
     expect(body).not.toContain("\n**bold**");
     expect(body).not.toContain("`code`");
+    expect(body).not.toContain("<details>");
   });
 });
 

--- a/packages/testkit/src/playwright-pr-screenshot-comment.test.ts
+++ b/packages/testkit/src/playwright-pr-screenshot-comment.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPlaywrightPrScreenshotComment,
+  PLAYWRIGHT_PR_SCREENSHOT_COMMENT_MARKER,
+  type PlaywrightPrCommentScreenshot,
+  screenshotMatchesSpecStem,
+  selectPlaywrightPrFeatureFrames,
+  specStemsFromChangedPaths,
+} from "./playwright-pr-screenshot-comment.js";
+
+describe("specStemsFromChangedPaths", () => {
+  it("extracts Playwright spec stems from changed paths", () => {
+    expect(
+      specStemsFromChangedPaths([
+        "apps/web/e2e/tool-activity-shell.spec.ts",
+        "apps/web/src/components/ToolActivity.tsx",
+        "apps/web/e2e/tool-activity-disclosure.spec.ts",
+        "README.md",
+      ]),
+    ).toEqual(["tool-activity-disclosure", "tool-activity-shell"]);
+  });
+});
+
+describe("screenshotMatchesSpecStem", () => {
+  it("matches Playwright output directories that start with the spec stem", () => {
+    expect(
+      screenshotMatchesSpecStem(
+        "tool-activity-shell-produc-bb211-n-in-every-disclosure-state-chromium/shell.png",
+        "tool-activity-shell",
+      ),
+    ).toBe(true);
+    expect(
+      screenshotMatchesSpecStem(
+        "tool-activity-disclosure-t-f2d47-s-collapsed-until-disclosed-chromium/complete.png",
+        "tool-activity-disclosure",
+      ),
+    ).toBe(true);
+    expect(
+      screenshotMatchesSpecStem(
+        "onboarding-conversation-fo-bf02c-rves-a-completed-connection-chromium/01.png",
+        "tool-activity-shell",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("selectPlaywrightPrFeatureFrames", () => {
+  it("prefers NEW checkpoints over everything else", () => {
+    const selection = selectPlaywrightPrFeatureFrames({
+      changedPaths: [],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          fileName: "images/001-onboarding.png",
+          source: "onboarding-x/01.png",
+          title: "onboarding drift",
+        }),
+        screenshot({
+          comparison: "new",
+          fileName: "images/002-shell-live.png",
+          source: "tool-activity-shell-x/shell-live.png",
+          title: "shell live",
+        }),
+      ],
+    });
+
+    expect(selection).toEqual({
+      frames: [
+        expect.objectContaining({
+          kind: "new",
+          title: "shell live",
+        }),
+      ],
+      omittedCount: 0,
+    });
+  });
+
+  it("includes CHANGED checkpoints only when their spec is in the PR diff", () => {
+    const selection = selectPlaywrightPrFeatureFrames({
+      changedPaths: ["apps/web/e2e/tool-activity-disclosure.spec.ts"],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          fileName: "images/001-complete.png",
+          source: "tool-activity-disclosure-t-f2d47-chromium/complete.png",
+          title: "complete collapsed",
+        }),
+        screenshot({
+          comparison: "changed",
+          fileName: "images/002-onboarding.png",
+          source: "onboarding-conversation-fo-bf02c-chromium/01.png",
+          title: "onboarding",
+        }),
+        screenshot({
+          comparison: "unchanged",
+          fileName: "images/003-other.png",
+          source: "tool-activity-disclosure-t-f2d47-chromium/other.png",
+          title: "other",
+        }),
+      ],
+    });
+
+    expect(selection.frames).toEqual([
+      expect.objectContaining({
+        kind: "changed",
+        title: "complete collapsed",
+      }),
+    ]);
+    expect(selection.omittedCount).toBe(0);
+  });
+
+  it("returns an empty selection for suite-vs-main drift only", () => {
+    const selection = selectPlaywrightPrFeatureFrames({
+      changedPaths: ["apps/web/src/components/ToolActivity.tsx"],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          fileName: "images/001-onboarding.png",
+          source: "onboarding-x/01.png",
+          title: "onboarding",
+        }),
+        screenshot({
+          comparison: "changed",
+          fileName: "images/002-settings.png",
+          source: "settings-x/01.png",
+          title: "settings",
+        }),
+      ],
+    });
+
+    expect(selection).toEqual({ frames: [], omittedCount: 0 });
+  });
+
+  it("caps the named list and reports how many were omitted", () => {
+    const screenshots = Array.from({ length: 10 }, (_, index) =>
+      screenshot({
+        comparison: "new",
+        fileName: `images/${String(index + 1).padStart(3, "0")}-frame.png`,
+        source: `tool-activity-shell-x/frame-${index}.png`,
+        title: `frame ${index + 1}`,
+      }),
+    );
+
+    const selection = selectPlaywrightPrFeatureFrames({
+      changedPaths: ["apps/web/e2e/tool-activity-shell.spec.ts"],
+      limit: 8,
+      screenshots,
+    });
+
+    expect(selection.frames).toHaveLength(8);
+    expect(selection.frames.map((frame) => frame.title)).toEqual([
+      "frame 1",
+      "frame 2",
+      "frame 3",
+      "frame 4",
+      "frame 5",
+      "frame 6",
+      "frame 7",
+      "frame 8",
+    ]);
+    expect(selection.omittedCount).toBe(2);
+  });
+});
+
+describe("buildPlaywrightPrScreenshotComment", () => {
+  const urls = {
+    dashboardUrl: "https://example.com/playwright/index.html",
+    galleryUrl: "https://example.com/playwright/prs/452/index.html",
+    runUrl: "https://github.com/example/rakazo/actions/runs/1",
+    screenshotsUrl: "https://example.com/playwright/runs/1-1/screenshots/index.html",
+    sha: "abcdef1234567890",
+  };
+
+  it("names NEW frames with direct PNG links and keeps gallery links secondary", () => {
+    const body = buildPlaywrightPrScreenshotComment({
+      ...urls,
+      changedPaths: ["apps/web/e2e/tool-activity-shell.spec.ts"],
+      screenshots: [
+        screenshot({
+          comparison: "new",
+          fileName: "images/010-shell-live-collapsed-desktop-1440x900.png",
+          source: "tool-activity-shell-x/shell-live-collapsed-desktop-1440x900.png",
+          title: "shell live collapsed desktop 1440x900",
+        }),
+      ],
+    });
+
+    expect(body).toContain(PLAYWRIGHT_PR_SCREENSHOT_COMMENT_MARKER);
+    expect(body).toContain("### Playwright screenshots");
+    expect(body).toContain("Feature frames for this PR:");
+    expect(body).toContain(
+      "- [shell live collapsed desktop 1440x900](https://example.com/playwright/runs/1-1/screenshots/images/010-shell-live-collapsed-desktop-1440x900.png) (new)",
+    );
+    expect(body).toContain(
+      "[Open screenshot gallery](https://example.com/playwright/prs/452/index.html) · [Dashboard](https://example.com/playwright/index.html) · [CI run](https://github.com/example/rakazo/actions/runs/1)",
+    );
+    expect(body).toContain("Updated for commit `abcdef1`.");
+    expect(body).not.toContain("![");
+    expect(body).not.toContain("—");
+  });
+
+  it("includes spec-touched CHANGED frames after NEW frames", () => {
+    const body = buildPlaywrightPrScreenshotComment({
+      ...urls,
+      changedPaths: ["apps/web/e2e/tool-activity-disclosure.spec.ts"],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          fileName: "images/020-complete-collapsed-desktop-1440x900.png",
+          source:
+            "tool-activity-disclosure-t-f2d47-chromium/complete-collapsed-desktop-1440x900.png",
+          title: "complete collapsed desktop 1440x900",
+        }),
+        screenshot({
+          comparison: "new",
+          fileName: "images/010-shell-live.png",
+          source: "tool-activity-shell-x/shell-live.png",
+          title: "shell live",
+        }),
+        screenshot({
+          comparison: "changed",
+          fileName: "images/030-onboarding.png",
+          source: "onboarding-x/01.png",
+          title: "onboarding",
+        }),
+      ],
+    });
+
+    expect(body).toContain(
+      "- [shell live](https://example.com/playwright/runs/1-1/screenshots/images/010-shell-live.png) (new)",
+    );
+    expect(body).toContain(
+      "- [complete collapsed desktop 1440x900](https://example.com/playwright/runs/1-1/screenshots/images/020-complete-collapsed-desktop-1440x900.png) (changed)",
+    );
+    expect(body).not.toContain("onboarding");
+  });
+
+  it("says so in one line when only suite drift remains", () => {
+    const body = buildPlaywrightPrScreenshotComment({
+      ...urls,
+      changedPaths: ["apps/web/src/components/ToolActivity.tsx"],
+      screenshots: [
+        screenshot({
+          comparison: "changed",
+          fileName: "images/001-onboarding.png",
+          source: "onboarding-x/01.png",
+          title: "onboarding",
+        }),
+      ],
+    });
+
+    expect(body).toContain("No new feature frames; gallery is suite-vs-main drift.");
+    expect(body).not.toContain("Feature frames for this PR:");
+    expect(body).not.toContain("onboarding");
+    expect(body).toContain("[Open screenshot gallery]");
+  });
+
+  it("caps named frames and points to the gallery for the rest", () => {
+    const screenshots = Array.from({ length: 10 }, (_, index) =>
+      screenshot({
+        comparison: "new",
+        fileName: `images/${String(index + 1).padStart(3, "0")}-frame.png`,
+        source: `tool-activity-shell-x/frame-${index}.png`,
+        title: `frame ${index + 1}`,
+      }),
+    );
+
+    const body = buildPlaywrightPrScreenshotComment({
+      ...urls,
+      changedPaths: ["apps/web/e2e/tool-activity-shell.spec.ts"],
+      screenshots,
+    });
+
+    expect(body).toContain(
+      "- [frame 8](https://example.com/playwright/runs/1-1/screenshots/images/008-frame.png) (new)",
+    );
+    expect(body).not.toContain("frame 9");
+    expect(body).toContain("- +2 more in the gallery");
+  });
+});
+
+function screenshot(
+  overrides: Partial<PlaywrightPrCommentScreenshot> = {},
+): PlaywrightPrCommentScreenshot {
+  return {
+    captureType: "checkpoint",
+    comparison: "new",
+    fileName: "images/001-checkpoint.png",
+    source: "golden-chromium/checkpoint.png",
+    title: "checkpoint",
+    ...overrides,
+  };
+}

--- a/packages/testkit/src/playwright-pr-screenshot-comment.ts
+++ b/packages/testkit/src/playwright-pr-screenshot-comment.ts
@@ -1,0 +1,111 @@
+import type { PlaywrightScreenshot } from "./playwright-report-dashboard.js";
+
+export const PLAYWRIGHT_PR_SCREENSHOT_COMMENT_MARKER = "<!-- rakazo-playwright-screenshots -->";
+export const PLAYWRIGHT_PR_FEATURE_FRAME_LIMIT = 8;
+
+export type PlaywrightPrCommentScreenshot = Pick<
+  PlaywrightScreenshot,
+  "captureType" | "comparison" | "fileName" | "source" | "title"
+>;
+
+export type PlaywrightPrFeatureFrame = PlaywrightPrCommentScreenshot & {
+  kind: "changed" | "new";
+};
+
+export type PlaywrightPrFeatureFrameSelection = {
+  frames: PlaywrightPrFeatureFrame[];
+  omittedCount: number;
+};
+
+const SPEC_FILE_PATTERN = /^(.*)\.spec\.[cm]?[jt]sx?$/i;
+
+export function specStemsFromChangedPaths(changedPaths: readonly string[]): string[] {
+  const stems = new Set<string>();
+  for (const changedPath of changedPaths) {
+    const baseName = changedPath.split(/[\\/]/).at(-1) ?? changedPath;
+    const match = SPEC_FILE_PATTERN.exec(baseName);
+    if (match?.[1]) stems.add(match[1].toLowerCase());
+  }
+  return [...stems].sort();
+}
+
+export function screenshotMatchesSpecStem(source: string, specStem: string): boolean {
+  const directory = (source.split(/[\\/]/)[0] ?? source).toLowerCase();
+  const stem = specStem.toLowerCase();
+  return directory === stem || directory.startsWith(`${stem}-`);
+}
+
+export function selectPlaywrightPrFeatureFrames(input: {
+  changedPaths: readonly string[];
+  limit?: number;
+  screenshots: readonly PlaywrightPrCommentScreenshot[];
+}): PlaywrightPrFeatureFrameSelection {
+  const limit = input.limit ?? PLAYWRIGHT_PR_FEATURE_FRAME_LIMIT;
+  const stems = specStemsFromChangedPaths(input.changedPaths);
+  const checkpoints = input.screenshots.filter(
+    (screenshot) => screenshot.captureType === "checkpoint",
+  );
+  const frames: PlaywrightPrFeatureFrame[] = [
+    ...checkpoints
+      .filter((screenshot) => screenshot.comparison === "new")
+      .map((screenshot) => ({ ...screenshot, kind: "new" as const })),
+    ...checkpoints
+      .filter(
+        (screenshot) =>
+          screenshot.comparison === "changed" &&
+          stems.some((stem) => screenshotMatchesSpecStem(screenshot.source, stem)),
+      )
+      .map((screenshot) => ({ ...screenshot, kind: "changed" as const })),
+  ];
+
+  return {
+    frames: frames.slice(0, limit),
+    omittedCount: Math.max(0, frames.length - limit),
+  };
+}
+
+export function buildPlaywrightPrScreenshotComment(input: {
+  changedPaths: readonly string[];
+  dashboardUrl: string;
+  galleryUrl: string;
+  limit?: number;
+  runUrl: string;
+  screenshots: readonly PlaywrightPrCommentScreenshot[];
+  screenshotsUrl: string;
+  sha: string;
+}): string {
+  const { frames, omittedCount } = selectPlaywrightPrFeatureFrames(input);
+  const galleryBaseUrl = new URL(".", input.screenshotsUrl);
+  const secondaryLinks = [
+    `[Open screenshot gallery](${input.galleryUrl})`,
+    `[Dashboard](${input.dashboardUrl})`,
+    `[CI run](${input.runUrl})`,
+  ].join(" · ");
+
+  const featureSection =
+    frames.length === 0
+      ? "No new feature frames; gallery is suite-vs-main drift."
+      : [
+          "Feature frames for this PR:",
+          ...frames.map((frame) => {
+            const imageUrl = new URL(frame.fileName, galleryBaseUrl).toString();
+            return `- [${escapeMarkdownLinkLabel(frame.title)}](${imageUrl}) (${frame.kind})`;
+          }),
+          ...(omittedCount > 0 ? [`- +${omittedCount} more in the gallery`] : []),
+        ].join("\n");
+
+  return [
+    PLAYWRIGHT_PR_SCREENSHOT_COMMENT_MARKER,
+    "### Playwright screenshots",
+    "",
+    featureSection,
+    "",
+    secondaryLinks,
+    "",
+    `Updated for commit \`${input.sha.slice(0, 7)}\`.`,
+  ].join("\n");
+}
+
+function escapeMarkdownLinkLabel(value: string): string {
+  return value.replaceAll("[", "\\[").replaceAll("]", "\\]");
+}

--- a/packages/testkit/src/playwright-pr-screenshot-comment.ts
+++ b/packages/testkit/src/playwright-pr-screenshot-comment.ts
@@ -110,6 +110,9 @@ function escapeMarkdownLinkLabel(value: string): string {
   const normalized = value.replaceAll(/\s+/g, " ").trim();
   const label = normalized.length > 0 ? normalized : "screenshot";
   return label
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
     .replaceAll("\\", "\\\\")
     .replaceAll("[", "\\[")
     .replaceAll("]", "\\]")

--- a/packages/testkit/src/playwright-pr-screenshot-comment.ts
+++ b/packages/testkit/src/playwright-pr-screenshot-comment.ts
@@ -107,5 +107,14 @@ export function buildPlaywrightPrScreenshotComment(input: {
 }
 
 function escapeMarkdownLinkLabel(value: string): string {
-  return value.replaceAll("[", "\\[").replaceAll("]", "\\]");
+  const normalized = value.replaceAll(/\s+/g, " ").trim();
+  const label = normalized.length > 0 ? normalized : "screenshot";
+  return label
+    .replaceAll("\\", "\\\\")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]")
+    .replaceAll("`", "\\`")
+    .replaceAll("*", "\\*")
+    .replaceAll("_", "\\_")
+    .replaceAll("#", "\\#");
 }

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -294,7 +294,8 @@ describe("renderScreenshotGallery", () => {
     expect(html).toContain("initialColumns = localStorage.getItem(storageKey) || initialColumns");
     expect(html).toContain('<span class="badge checkpoint">CHECKPOINT</span>');
     expect(html).toContain('<span class="badge new">NEW</span>');
-    expect(html).toContain('data-filter="review" aria-pressed="true"');
+    expect(html).toContain('data-filter="new" aria-pressed="true"');
+    expect(html).toContain('data-filter="review" aria-pressed="false"');
     expect(html).toContain("Compared with latest successful main run");
     expect(html).toContain(`@media (max-width: 900px) {
       header { align-items: start; flex-direction: column; }

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -386,6 +386,7 @@ export function renderScreenshotGallery(input: {
       screenshot.comparison === "changed" ||
       screenshot.comparison === "new",
   ).length;
+  const defaultFilter = !input.baselineAvailable ? "all" : counts.new > 0 ? "new" : "review";
   const screenshots = input.screenshots
     .map((screenshot, index) => {
       const imageUrl = new URL(screenshot.fileName, galleryBaseUrl).toString();
@@ -518,9 +519,9 @@ export function renderScreenshotGallery(input: {
     ${
       screenshots
         ? `<nav class="filters" aria-label="Screenshot filters">
-      <button class="filter" type="button" data-filter="all" aria-pressed="${String(!input.baselineAvailable)}">All (${input.screenshots.length})</button>
-      <button class="filter" type="button" data-filter="review" aria-pressed="${String(input.baselineAvailable)}">Review changes (${reviewCount})</button>
-      <button class="filter" type="button" data-filter="new" aria-pressed="false" ${input.baselineAvailable ? "" : "disabled"}>New (${counts.new})</button>
+      <button class="filter" type="button" data-filter="all" aria-pressed="${String(defaultFilter === "all")}">All (${input.screenshots.length})</button>
+      <button class="filter" type="button" data-filter="review" aria-pressed="${String(defaultFilter === "review")}">Review changes (${reviewCount})</button>
+      <button class="filter" type="button" data-filter="new" aria-pressed="${String(defaultFilter === "new")}" ${input.baselineAvailable ? "" : "disabled"}>New (${counts.new})</button>
       <button class="filter" type="button" data-filter="changed" aria-pressed="false" ${input.baselineAvailable ? "" : "disabled"}>Changed (${counts.changed})</button>
       <button class="filter" type="button" data-filter="failed" aria-pressed="false">Failed (${counts.failed})</button>
     </nav>`
@@ -578,7 +579,7 @@ export function renderScreenshotGallery(input: {
       if (filterEmpty) filterEmpty.hidden = visible !== 0;
     }
 
-    setFilter(${JSON.stringify(input.baselineAvailable ? "review" : "all")});
+    setFilter(${JSON.stringify(defaultFilter)});
     for (const filter of filters) {
       filter.addEventListener("click", () => setFilter(filter.dataset.filter));
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Playwright PR comments now name **NEW** checkpoints first, then **CHANGED** checkpoints whose `*.spec.ts` is in the PR diff, each with a direct PNG link.
- If neither exists, the comment says the gallery is suite-vs-main drift instead of dumping unrelated CHANGED names.
- Gallery / dashboard / CI links stay secondary. Named list capped at 8 with `+N more in the gallery`.
- Gallery default filter is **New** when any NEW frames exist.
- Titles are sanitized/escaped (Markdown + HTML); `screenshotsUrl` must be HTTPS.

## Note on this PR’s bot comment
`publish-playwright-report.yml` always runs trusted `main` code, so the screenshot comment on this PR still uses the old generator. After merge, later PRs get the new format.

## Comment format

Feature frames:

```markdown
<!-- rakazo-playwright-screenshots -->
### Playwright screenshots

Feature frames for this PR:
- [shell live collapsed desktop 1440x900](https://…/runs/…/screenshots/images/120-….png) (new)
- [complete collapsed desktop 1440x900](https://…/runs/…/screenshots/images/110-….png) (changed)
- +2 more in the gallery

[Open screenshot gallery](…) · [Dashboard](…) · [CI run](…)

Updated for commit `b6ac0c6`.
```

Suite drift only:

```markdown
<!-- rakazo-playwright-screenshots -->
### Playwright screenshots

No new feature frames; gallery is suite-vs-main drift.

[Open screenshot gallery](…) · [Dashboard](…) · [CI run](…)

Updated for commit `deadbee`.
```

## Review follow-ups addressed
- Greptile: Markdown + HTML escaping for titles
- CodeRabbit: HTTPS `screenshotsUrl`; keep source title normalization without gallery index prefix

## Test plan
- [x] Unit tests: new-only, spec-touched changed, suite-drift-only, cap, crafted-title escaping
- [x] Gallery New-default test
- [x] CI green on tip (`295e6ab`)
- [x] Greptile 5/5 / safe to merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f1319ae-d905-4dbd-8a6d-1a98f0cb7fbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f1319ae-d905-4dbd-8a6d-1a98f0cb7fbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request screenshot comments now highlight relevant new and changed screenshots, with direct links to images, galleries, dashboards, and CI runs.
  * Screenshot galleries automatically open with the most relevant filter selected.
  * Playwright reports now include review metadata for improved screenshot browsing.

* **Bug Fixes**
  * Improved screenshot selection to avoid unrelated changes and limit lengthy comments.
  * Screenshot links now require secure HTTPS URLs.

* **Tests**
  * Added coverage for screenshot selection, comment formatting, links, filtering, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->