### PR TITLE
fix(adapters): preserve cancellation and retry finalization

### DIFF
--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -158,6 +158,35 @@ describe("steering attachment hydration", () => {
     expect(settled.unavailableInstruction).toContain("do not guess its contents");
   });
 
+  it("does not swallow image hydration cancellation", async () => {
+    const controller = new AbortController();
+    const cancellation = new Error("cancelled");
+    controller.abort(cancellation);
+
+    await expect(
+      loadCurrentTurnImages(
+        {
+          artifacts: { get: vi.fn(async () => Promise.reject(cancellation)) },
+          prisma: {
+            artifact: {
+              findMany: vi.fn(async () => [{ id: "image-1", storageKey: "one.png" }]),
+            },
+          },
+        } as never,
+        [{ kind: "image", artifactId: "image-1", name: "one.png", mimeType: "image/png" }],
+        {
+          operationId: "run-1",
+          traceId: "run-1",
+          spaceId: "space-1",
+          userId: "user-1",
+          botId: "bot-1",
+          runId: "run-1",
+          signal: controller.signal,
+        },
+      ),
+    ).rejects.toBe(cancellation);
+  });
+
   it("warns when an ordinary turn expects more images than were loaded", () => {
     const blocks: MessageBlock[] = [
       { kind: "image", artifactId: "image-1", name: "one.png", mimeType: "image/png" },

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -115,6 +115,21 @@ describe("steering attachment hydration", () => {
     expect(withoutExpectedImages.unavailableInstruction).toBe("");
   });
 
+  it("propagates cancellation while steering attachments settle", async () => {
+    const controller = new AbortController();
+    const cancellation = new Error("cancelled");
+    controller.abort();
+
+    await expect(
+      settleSteeringAttachmentLoads(
+        Promise.reject(cancellation),
+        Promise.resolve([]),
+        undefined,
+        controller.signal,
+      ),
+    ).rejects.toBe(cancellation);
+  });
+
   it("treats unreadable image bytes as missing instead of failing hydration", async () => {
     const blocks: MessageBlock[] = [
       { kind: "image", artifactId: "image-1", name: "one.png", mimeType: "image/png" },

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -3860,7 +3860,9 @@ export async function loadCurrentTurnImages(
         mimeType: block.mimeType as "image/jpeg" | "image/png" | "image/webp" | "image/gif",
         data: bytes,
       });
-    } catch {}
+    } catch (error) {
+      if (context.signal.aborted) throw error;
+    }
   }
 
   return images.length ? images : undefined;

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2843,6 +2843,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                                 )
                               : Promise.resolve([]),
                             item.blocks,
+                            context.signal,
                           );
                         const filesInstruction = currentTurnFilesInstruction(files);
                         return {
@@ -3511,12 +3512,17 @@ export async function settleSteeringAttachmentLoads<TImage, TFile>(
   images: Promise<TImage[] | undefined>,
   files: Promise<TFile[]>,
   blocks?: MessageBlock[],
+  signal?: AbortSignal,
 ): Promise<{
   images: TImage[] | undefined;
   files: TFile[];
   unavailableInstruction: string;
 }> {
   const [loadedImages, loadedFiles] = await Promise.allSettled([images, files]);
+  if (signal?.aborted) {
+    if (loadedImages.status === "rejected") throw loadedImages.reason;
+    if (loadedFiles.status === "rejected") throw loadedFiles.reason;
+  }
   const expectedImageCount = blocks?.filter((block) => block.kind === "image").length ?? 0;
   const loadedImageCount =
     loadedImages.status === "fulfilled" ? (loadedImages.value?.length ?? 0) : 0;

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -7,6 +7,7 @@ import {
   claimSteering,
   clearThread,
   finalizeComputerControlRelease,
+  finalizeRun,
   followThreadEvents,
   pauseRunForInput,
   pauseRunForTakeover,
@@ -55,6 +56,57 @@ function event(seq: number) {
     createdAt: new Date("2026-08-15T12:00:00.000Z"),
   };
 }
+
+describe("finalizeRun", () => {
+  it("retries a transaction conflict without duplicating the terminal event or notification", async () => {
+    const conflict = Object.assign(new Error("serialization conflict"), { code: "P2034" });
+    const createEvent = vi.fn(async () => ({ threadId: "thread-1", seq: 0 }));
+    const tx = {
+      $queryRaw: vi.fn(async () => []),
+      run: {
+        findUnique: vi.fn(async () => ({ status: "running" })),
+        findFirst: vi.fn(async () => null),
+        updateMany: vi.fn(async () => ({ count: 1 })),
+      },
+      attempt: { updateMany: vi.fn(async () => ({ count: 1 })) },
+      task: { updateMany: vi.fn(async () => ({ count: 1 })) },
+      thread: { update: vi.fn(async () => ({ nextEventSeq: 1 })) },
+      event: { create: createEvent, deleteMany: vi.fn(async () => ({ count: 0 })) },
+      steeringMessage: {
+        findMany: vi.fn(async () => []),
+        updateMany: vi.fn(async () => ({ count: 0 })),
+      },
+      bot: { update: vi.fn(async () => ({})) },
+    };
+    const transaction = vi
+      .fn()
+      .mockRejectedValueOnce(conflict)
+      .mockImplementation(async (operation: (client: typeof tx) => unknown) => operation(tx));
+    const publish = vi.fn(async () => undefined);
+
+    await expect(
+      finalizeRun(
+        { $transaction: transaction } as unknown as PrismaClient,
+        {
+          spaceId: "space-1",
+          threadId: "thread-1",
+          botId: "bot-1",
+          runId: "run-1",
+          taskId: "task-1",
+          attemptId: "attempt-1",
+          leaseOwner: "worker-1",
+          leaseFence: 1,
+          outcome: "failed",
+          error: "failed",
+        },
+        { publish } as never,
+      ),
+    ).resolves.toEqual({ continuationRunId: null });
+    expect(transaction).toHaveBeenCalledTimes(2);
+    expect(createEvent).toHaveBeenCalledOnce();
+    expect(publish).toHaveBeenCalledOnce();
+  });
+});
 
 describe("followThreadEvents", () => {
   it("does not lose a notification that arrives while querying", async () => {

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -16,6 +16,7 @@ import {
   createThreadMessageInTransaction,
   RunHistoryWriteError,
 } from "./messages.js";
+import { withTransactionRetry } from "./transaction-retry.js";
 
 const EVENT_BATCH_SIZE = 200;
 const PUSH_CATCH_UP_MS = 30_000;
@@ -871,7 +872,17 @@ export async function finalizeRun(
   input: FinalizeRunInput,
   realtime?: RealtimeFanout,
 ): Promise<FinalizeRunResult | false> {
-  const committed = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+  const committed = await withTransactionRetry(() => finalizeRunOnce(prisma, input));
+  if (!committed) return false;
+  await notifyRealtime(realtime, committed.threadId, committed.seq);
+  return { continuationRunId: committed.continuationRunId };
+}
+
+async function finalizeRunOnce(
+  prisma: PrismaClient,
+  input: FinalizeRunInput,
+): Promise<{ threadId: string; seq: number; continuationRunId: string | null } | null> {
+  return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     await tx.$queryRaw`SELECT id FROM threads WHERE id = ${input.threadId} FOR UPDATE`;
     try {
       await assertRunCanWriteHistory(tx, input.runId);
@@ -972,10 +983,6 @@ export async function finalizeRun(
     await tx.bot.update({ where: { id: input.botId }, data: { updatedAt: now } });
     return { threadId: lastEvent.threadId, seq: lastEvent.seq, continuationRunId };
   });
-
-  if (!committed) return false;
-  await notifyRealtime(realtime, committed.threadId, committed.seq);
-  return { continuationRunId: committed.continuationRunId };
 }
 
 async function createSteeringContinuation(


### PR DESCRIPTION
## Why this follow-up exists

PR #453 was merged by another actor while its final blocker verification was still running. This draft carries the two remaining exact-head fixes found and reproduced during that gate.

## Changes

- preserve successful ordinary-turn image siblings and treat unreadable bytes as unavailable, while still propagating run cancellation instead of swallowing it
- retry fenced run finalization on PostgreSQL serialization/deadlock conflicts so a transient `40P01` does not become a durable user-visible failed run

## RED / GREEN evidence

- Ordinary hydration cancellation RED: `packages/adapters/src/executor.test.ts` failed because byte-read cancellation resolved `undefined` instead of rejecting; GREEN after the image-loader signal guard.
- Steering settlement cancellation RED: the exact steering settlement test resolved an unavailable payload instead of rejecting after abort; GREEN after passing the run signal through settlement and rethrowing the rejected reason.
- Journey 54 RED: repeated fresh-PostgreSQL runs reproduced the CI mismatch and exposed a failed `follow_up` run with `40P01: deadlock detected` from `prisma.thread.update()` during finalization.
- Journey 54 GREEN: the unchanged run-ID assertion passed 50/50 isolated attempts after transaction retry; the full fresh-PostgreSQL integration gate then passed 76/76.

## Verification

- focused adapter/Pi/DB/retry tests: 69/69
- fresh PostgreSQL integration: 76/76
- repository tests: 2,259 passed, 109 skipped
- `pnpm run lint`: pass (two pre-existing informational suggestions)
- `pnpm run check`: 20/20 tasks
- `pnpm run build`: 4/4 tasks
- `pnpm run format`: pass; no extra files changed
- `git diff --check`: pass

## Scope

No schema, dependency, UI, or product-scope change. Multiple-assistant-message work remains separate and is not implemented here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling so aborted image and file loading operations stop promptly and preserve the cancellation error.
  - Increased reliability when finalizing runs by automatically retrying transient transaction conflicts.
  - Prevented duplicate completion events and notifications during transaction retries.

- **Tests**
  - Added coverage for cancellation propagation and transaction retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->