### PR TITLE
fix(chat): remove steering composer helper copy

### DIFF
--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1612,19 +1612,11 @@ function Thread() {
             ))}
           </View>
         ) : null}
-        {working ? (
-          <Text
-            accessibilityLiveRegion="polite"
-            style={{ color: "#85858A", fontSize: 12, marginTop: 12, marginHorizontal: 8 }}
-          >
-            Messages sent now guide the next turn.
-          </Text>
-        ) : null}
         <View
           style={{
             flexDirection: "row",
             gap: 8,
-            marginTop: working ? 8 : 16,
+            marginTop: 16,
             alignItems: "flex-end",
           }}
         >

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1713,7 +1713,7 @@ function Thread() {
             <TextInput
               value={draft}
               onChangeText={updateDraft}
-              accessibilityLabel={working ? `Steer ${name ?? "bot"}` : "Message"}
+              accessibilityLabel={name ? `Message ${name}` : "Message"}
               onKeyPress={(event) => {
                 if (
                   event.nativeEvent.key === "Backspace" &&
@@ -1726,8 +1726,8 @@ function Thread() {
               placeholder={
                 selectedSkill || selectedMentions.length
                   ? undefined
-                  : working
-                    ? `Steer ${name ?? "bot"}`
+                  : name
+                    ? `Message ${name}`
                     : "Message…"
               }
               placeholderTextColor="#6C6C70"
@@ -1747,7 +1747,7 @@ function Thread() {
             />
           </View>
           <Pressable
-            accessibilityLabel={working ? "Send steering message" : "Send"}
+            accessibilityLabel="Send"
             disabled={sending || !canSend}
             onPress={() => void send()}
             style={{

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -164,7 +164,8 @@ describe("Android mobile platform contract", () => {
     expect(stopStart).toBeGreaterThan(-1);
     expect(thread).toContain('accessibilityLabel={working ? "Send steering message" : "Send"}');
     expect(thread).toContain('accessibilityLabel="Stop"');
-    expect(thread).toContain("Messages sent now guide the next turn.");
+    expect(thread).not.toContain("Messages sent now guide the next turn.");
+    expect(thread).toContain("`Steer ${name ?? \"bot\"}`");
     expect(thread).toContain("const clientNonce = newClientNonce()");
     expect(thread).toContain("Work stopped, but the thread could not refresh");
     expect(stopSource).toContain("const targetBotId = botId;");

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -162,10 +162,12 @@ describe("Android mobile platform contract", () => {
     const stopStart = thread.indexOf("async function stop()");
     const stopSource = thread.slice(stopStart, thread.indexOf("const answerMessage", stopStart));
     expect(stopStart).toBeGreaterThan(-1);
-    expect(thread).toContain('accessibilityLabel={working ? "Send steering message" : "Send"}');
+    expect(thread).toContain('accessibilityLabel="Send"');
     expect(thread).toContain('accessibilityLabel="Stop"');
     expect(thread).not.toContain("Messages sent now guide the next turn.");
-    expect(thread).toContain("`Steer ${name ?? \"bot\"}`");
+    expect(thread).not.toContain("Steer ");
+    expect(thread).not.toContain("steering message");
+    expect(thread).toContain("`Message ${name}`");
     expect(thread).toContain("const clientNonce = newClientNonce()");
     expect(thread).toContain("Work stopped, but the thread could not refresh");
     expect(stopSource).toContain("const targetBotId = botId;");

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -281,11 +281,13 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
   await expect(page.getByTestId("composer-steering-status")).toHaveCount(0);
   await expect(page.getByText("Messages sent now guide the next turn.")).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "Send steering message" })).toBeVisible();
-  await expect(composer).toHaveAttribute("placeholder", /Steer /);
+  await expect(page.getByText(/^Steer /)).toHaveCount(0);
+  await expect(composer).toHaveAttribute("placeholder", "Message Chief");
+  await expect(page.getByRole("button", { name: "Send", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
   await composer.fill("Use the newer report and keep the answer short.");
   await page.keyboard.press("Tab");
-  await expect(page.getByRole("button", { name: "Send steering message" })).toBeFocused();
+  await expect(page.getByRole("button", { name: "Send", exact: true })).toBeFocused();
   await page.keyboard.press("Enter");
   await expect(
     page.getByTestId("transcript").getByText("Use the newer report and keep the answer short."),
@@ -293,8 +295,9 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "14-active-bot-work");
   await page.setViewportSize({ width: 390, height: 844 });
-  await expect(page.getByRole("button", { name: "Send steering message" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Send", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
+  await expect(composer).toHaveAttribute("placeholder", "Message Chief");
   await captureScreenshot(page, testInfo, "14-active-bot-work-mobile");
   await page.setViewportSize({ width: 1280, height: 720 });
   expect(browserErrors).toEqual([]);
@@ -313,10 +316,13 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   });
   await page.getByRole("button", { name: "Stop", exact: true }).click();
   await stopRequestStarted;
-  await expect(page.getByRole("button", { name: "Send steering message" })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "Send", exact: true })).toBeDisabled();
   await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeDisabled();
   releaseStopRequest();
-  await expect(page.getByRole("button", { name: "Send" })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "Send", exact: true })).toBeEnabled({
+    timeout: 30_000,
+  });
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toHaveCount(0);
 
   await page.context().clearCookies();
   await page.goto("/sign-in");

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -279,10 +279,10 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await composer.fill("keep working until I stop you");
   await page.keyboard.press("Enter");
   await expect(page.getByText("still working").first()).toBeVisible({ timeout: 30_000 });
-  await expect(page.getByTestId("composer-steering-status")).toHaveText(
-    "Messages sent now guide the next turn.",
-  );
+  await expect(page.getByTestId("composer-steering-status")).toHaveCount(0);
+  await expect(page.getByText("Messages sent now guide the next turn.")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Send steering message" })).toBeVisible();
+  await expect(composer).toHaveAttribute("placeholder", /Steer /);
   await composer.fill("Use the newer report and keep the answer short.");
   await page.keyboard.press("Tab");
   await expect(page.getByRole("button", { name: "Send steering message" })).toBeFocused();

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -319,10 +319,11 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await expect(page.getByRole("button", { name: "Send", exact: true })).toBeDisabled();
   await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeDisabled();
   releaseStopRequest();
-  await expect(page.getByRole("button", { name: "Send", exact: true })).toBeEnabled({
+  // Idle Send stays disabled with an empty draft; wait for Stop to leave instead.
+  await expect(page.getByRole("button", { name: "Stop", exact: true })).toHaveCount(0, {
     timeout: 30_000,
   });
-  await expect(page.getByRole("button", { name: "Stop", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Send", exact: true })).toBeVisible();
 
   await page.context().clearCookies();
   await page.goto("/sign-in");

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3154,10 +3154,6 @@ msgid "This reset link is invalid or expired"
 msgstr "Dieser Link zum Zurücksetzen ist ungültig oder abgelaufen"
 
 #: src/pages/Shell.tsx
-msgid "Messages sent now guide the next turn."
-msgstr "Jetzt gesendete Nachrichten steuern den nächsten Durchgang."
-
-#: src/pages/Shell.tsx
 msgid "Steer {activeName}"
 msgstr "{activeName} Anweisungen geben"
 

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3153,10 +3153,3 @@ msgstr "Link zum Zurücksetzen senden"
 msgid "This reset link is invalid or expired"
 msgstr "Dieser Link zum Zurücksetzen ist ungültig oder abgelaufen"
 
-#: src/pages/Shell.tsx
-msgid "Steer {activeName}"
-msgstr "{activeName} Anweisungen geben"
-
-#: src/pages/Shell.tsx
-msgid "Send steering message"
-msgstr "Zusätzliche Anweisung senden"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3154,10 +3154,6 @@ msgid "This reset link is invalid or expired"
 msgstr "This reset link is invalid or expired"
 
 #: src/pages/Shell.tsx
-msgid "Messages sent now guide the next turn."
-msgstr "Messages sent now guide the next turn."
-
-#: src/pages/Shell.tsx
 msgid "Steer {activeName}"
 msgstr "Steer {activeName}"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3153,10 +3153,3 @@ msgstr "Send reset link"
 msgid "This reset link is invalid or expired"
 msgstr "This reset link is invalid or expired"
 
-#: src/pages/Shell.tsx
-msgid "Steer {activeName}"
-msgstr "Steer {activeName}"
-
-#: src/pages/Shell.tsx
-msgid "Send steering message"
-msgstr "Send steering message"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3154,10 +3154,6 @@ msgid "This reset link is invalid or expired"
 msgstr "यह रीसेट लिंक अमान्य है या इसकी समय-सीमा समाप्त हो गई है"
 
 #: src/pages/Shell.tsx
-msgid "Messages sent now guide the next turn."
-msgstr "अभी भेजे गए संदेश अगले चरण का मार्गदर्शन करते हैं।"
-
-#: src/pages/Shell.tsx
 msgid "Steer {activeName}"
 msgstr "{activeName} को निर्देश दें"
 

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3153,10 +3153,3 @@ msgstr "रीसेट लिंक भेजें"
 msgid "This reset link is invalid or expired"
 msgstr "यह रीसेट लिंक अमान्य है या इसकी समय-सीमा समाप्त हो गई है"
 
-#: src/pages/Shell.tsx
-msgid "Steer {activeName}"
-msgstr "{activeName} को निर्देश दें"
-
-#: src/pages/Shell.tsx
-msgid "Send steering message"
-msgstr "अतिरिक्त निर्देश भेजें"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3153,10 +3153,3 @@ msgstr "재설정 링크 보내기"
 msgid "This reset link is invalid or expired"
 msgstr "이 재설정 링크는 유효하지 않거나 만료되었습니다"
 
-#: src/pages/Shell.tsx
-msgid "Steer {activeName}"
-msgstr "{activeName}에게 지시하기"
-
-#: src/pages/Shell.tsx
-msgid "Send steering message"
-msgstr "추가 지시 보내기"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3154,10 +3154,6 @@ msgid "This reset link is invalid or expired"
 msgstr "이 재설정 링크는 유효하지 않거나 만료되었습니다"
 
 #: src/pages/Shell.tsx
-msgid "Messages sent now guide the next turn."
-msgstr "지금 보내는 메시지는 다음 응답에 반영됩니다."
-
-#: src/pages/Shell.tsx
 msgid "Steer {activeName}"
 msgstr "{activeName}에게 지시하기"
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3153,10 +3153,3 @@ msgstr "Enviar link de redefinição"
 msgid "This reset link is invalid or expired"
 msgstr "Este link de redefinição é inválido ou expirou"
 
-#: src/pages/Shell.tsx
-msgid "Steer {activeName}"
-msgstr "Orientar {activeName}"
-
-#: src/pages/Shell.tsx
-msgid "Send steering message"
-msgstr "Enviar orientação adicional"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3154,10 +3154,6 @@ msgid "This reset link is invalid or expired"
 msgstr "Este link de redefinição é inválido ou expirou"
 
 #: src/pages/Shell.tsx
-msgid "Messages sent now guide the next turn."
-msgstr "As mensagens enviadas agora orientam a próxima etapa."
-
-#: src/pages/Shell.tsx
 msgid "Steer {activeName}"
 msgstr "Orientar {activeName}"
 

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3153,10 +3153,3 @@ msgstr "Sıfırlama bağlantısı gönder"
 msgid "This reset link is invalid or expired"
 msgstr "Bu sıfırlama bağlantısı geçersiz veya süresi dolmuş"
 
-#: src/pages/Shell.tsx
-msgid "Steer {activeName}"
-msgstr "{activeName} için yönlendir"
-
-#: src/pages/Shell.tsx
-msgid "Send steering message"
-msgstr "Yönlendirme mesajı gönder"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3154,10 +3154,6 @@ msgid "This reset link is invalid or expired"
 msgstr "Bu sıfırlama bağlantısı geçersiz veya süresi dolmuş"
 
 #: src/pages/Shell.tsx
-msgid "Messages sent now guide the next turn."
-msgstr "Şimdi gönderilen mesajlar bir sonraki adımı yönlendirir."
-
-#: src/pages/Shell.tsx
 msgid "Steer {activeName}"
 msgstr "{activeName} için yönlendir"
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4718,19 +4718,11 @@ const Composer = memo(function Composer({
             placeholder={
               showComposerPlaceholder
                 ? activeName
-                  ? running
-                    ? t`Steer ${activeName}`
-                    : t`Message ${activeName}`
+                  ? t`Message ${activeName}`
                   : t`Message…`
                 : undefined
             }
-            aria-label={
-              activeName
-                ? running
-                  ? t`Steer ${activeName}`
-                  : t`Message ${activeName}`
-                : t`Message`
-            }
+            aria-label={activeName ? t`Message ${activeName}` : t`Message`}
             role="combobox"
             aria-autocomplete="list"
             aria-haspopup="listbox"
@@ -4748,7 +4740,7 @@ const Composer = memo(function Composer({
           <>
             <button
               type="button"
-              aria-label={t`Send steering message`}
+              aria-label={t`Send`}
               disabled={sending || !canSend || disabled}
               onClick={send}
               className="grid h-10 w-10 place-items-center rounded-full bg-[#F1F1EF] text-[#17171A] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#A6A6AD] disabled:opacity-50"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4577,15 +4577,6 @@ const Composer = memo(function Composer({
           })}
         </div>
       ) : null}
-      {running ? (
-        <p
-          className="mb-2 px-3 text-[12px] text-[#85858A]"
-          data-testid="composer-steering-status"
-          aria-live="polite"
-        >
-          {t`Messages sent now guide the next turn.`}
-        </p>
-      ) : null}
       <div
         data-testid="composer-bar"
         className="flex items-center gap-3.5 rounded-full border border-[#202023] bg-[#131315] py-[9px] pe-2.5 ps-3"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Removes the gray helper line above the composer ("Messages sent now guide the next turn.") from #453, and drops user-visible "Steer" / "steering" copy. While work is active the composer stays `Message {name}` (same as idle), with a normal Send control and a separate Stop.

## Changes
- Web Shell: no helper paragraph; placeholder/aria stay `Message {name}`; send aria is `Send`
- Expo thread: same user-facing copy; Stop remains separate
- Locales: remove `Steer {activeName}` and `Send steering message` msgids
- Playwright golden: assert no helper / no Steer; active-work frames show `Message Chief` + Send + Stop
- Mobile contract: assert Steer / steering message strings are absent

## Screenshots (CI E2E)
From the golden active-bot-work path ([gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/460/index.html), [run](https://github.com/elie222/rakazo/actions/runs/33507706858)):

- Desktop: [active bot work](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33507706858-1/screenshots/images/024-14-active-bot-work.png)
- Mobile: [active bot work mobile](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33507706858-1/screenshots/images/023-14-active-bot-work-mobile.png)

<img alt="Active bot work desktop" src="https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33507706858-1/screenshots/images/024-14-active-bot-work.png" />
<img alt="Active bot work mobile" src="https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33507706858-1/screenshots/images/023-14-active-bot-work-mobile.png" />

Co-authored-by: Elie Steinbock &lt;elie222@users.noreply.github.com&gt;
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71f23326-21ca-4784-99c9-611dbff52760?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71f23326-21ca-4784-99c9-611dbff52760&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Simplified the message composer with consistent “Message” and “Send” labels during active runs.
  * Removed the steering-status hint and dedicated steering-message wording.
  * Standardized composer spacing across working states.
  * Updated mobile and web interaction checks for the unified messaging experience.
  * Removed obsolete steering-message translations from supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->