### PR TITLE
fix(chat): show wall-clock worked duration

### DIFF
--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -22,6 +22,7 @@ import {
   type SlashActionId,
   selectedAskActionLabel,
   serializeComposerPrompt,
+  toolActivityLabel,
   truncateSlashDescription,
   userVisibleMessages,
 } from "@rakazo/core";
@@ -2513,7 +2514,7 @@ function ExpandableToolBlock({
             : []),
           ...(block.pendingToolNames ?? []),
         ].filter(Boolean);
-  const title = live ? "Working…" : "Actions";
+  const title = toolActivityLabel(block.kind === "steps" ? block.durationMs : undefined, live);
 
   return (
     <View

--- a/apps/web/e2e/fixtures/tool-activity-disclosure.html
+++ b/apps/web/e2e/fixtures/tool-activity-disclosure.html
@@ -23,7 +23,7 @@
       ];
       const disclosure = h(
         ToolActivityDisclosure,
-        { live, label: live ? "Working…" : "Actions" },
+        { live, label: live ? "Working…" : "Worked for 1m 43s" },
         h(ToolSteps, { steps, currentIndex: live ? steps.length - 1 : undefined }),
       );
       const response = live

--- a/apps/web/e2e/tool-activity-disclosure.spec.ts
+++ b/apps/web/e2e/tool-activity-disclosure.spec.ts
@@ -7,7 +7,7 @@ const viewports = [
 ];
 const states = [
   { name: "active", live: true, label: "Working…" },
-  { name: "complete", live: false, label: "Actions" },
+  { name: "complete", live: false, label: "Worked for 1m 43s" },
 ];
 
 test("tool activity stays collapsed until disclosed", async ({ page }, testInfo) => {

--- a/apps/web/src/components/ToolActivityDisclosure.test.tsx
+++ b/apps/web/src/components/ToolActivityDisclosure.test.tsx
@@ -9,7 +9,7 @@ import { ToolActivityDisclosure } from "./ToolActivityDisclosure";
 describe("ToolActivityDisclosure", () => {
   it.each([
     [true, "Working…"],
-    [false, "Actions"],
+    [false, "Worked for 1m 43s"],
   ])("defaults collapsed with the %s state label", (live, label) => {
     const html = renderToStaticMarkup(
       <ToolActivityDisclosure live={live} label={label}>
@@ -30,7 +30,7 @@ describe("ToolActivityDisclosure", () => {
     const render = (live: boolean) =>
       flushSync(() =>
         root.render(
-          <ToolActivityDisclosure live={live} label={live ? "Working…" : "Actions"}>
+          <ToolActivityDisclosure live={live} label={live ? "Working…" : "Worked for 1m 43s"}>
             <span>Shell ×2</span>
           </ToolActivityDisclosure>,
         ),
@@ -42,7 +42,7 @@ describe("ToolActivityDisclosure", () => {
 
     render(false);
     expect(container.querySelector("details")?.open).toBe(false);
-    expect(container.querySelector("summary")?.textContent).toContain("Actions");
+    expect(container.querySelector("summary")?.textContent).toContain("Worked for 1m 43s");
     root.unmount();
   });
 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -5052,7 +5052,7 @@ const MessageView = memo(function MessageView({
                   <ToolActivityDisclosure
                     key={i}
                     live={isLive}
-                    label={toolActivityLabel(block.durationMs, isLive)}
+                    label={isLive ? t`Working…` : toolActivityLabel(block.durationMs, false)}
                   >
                     <ToolSteps
                       steps={block.steps}
@@ -5164,7 +5164,7 @@ const MessageView = memo(function MessageView({
               >
                 <ToolActivityDisclosure
                   live={isLive}
-                  label={toolActivityLabel(block.durationMs, isLive)}
+                  label={isLive ? t`Working…` : toolActivityLabel(block.durationMs, false)}
                 >
                   <ToolSteps
                     steps={block.steps}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -59,6 +59,7 @@ import {
   searchHitThreadTarget,
   serializeComposerPrompt,
   speechFromBlocks,
+  toolActivityLabel,
   truncateSlashDescription,
   userVisibleMessages,
 } from "@rakazo/core";
@@ -5051,7 +5052,7 @@ const MessageView = memo(function MessageView({
                   <ToolActivityDisclosure
                     key={i}
                     live={isLive}
-                    label={isLive ? t`Working…` : t`Actions`}
+                    label={toolActivityLabel(block.durationMs, isLive)}
                   >
                     <ToolSteps
                       steps={block.steps}
@@ -5161,7 +5162,10 @@ const MessageView = memo(function MessageView({
                 className="max-w-[74%] space-y-1.5 rounded-[20px] bg-[#1A1A1D] px-[18px] py-3"
                 dir="ltr"
               >
-                <ToolActivityDisclosure live={isLive} label={isLive ? t`Working…` : t`Actions`}>
+                <ToolActivityDisclosure
+                  live={isLive}
+                  label={toolActivityLabel(block.durationMs, isLive)}
+                >
                   <ToolSteps
                     steps={block.steps}
                     currentIndex={isLive ? block.steps.length - 1 : undefined}

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -144,6 +144,7 @@ export const MessageBlock = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("steps"),
     steps: z.array(z.object({ label: z.string(), count: z.number().int().positive() })),
+    durationMs: z.number().int().nonnegative().optional(),
   }),
   z.object({
     kind: z.literal("subagent"),

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -20,6 +20,19 @@ import {
 } from "./index.js";
 
 describe("contracts", () => {
+  it("accepts optional persisted duration only on valid steps blocks", () => {
+    expect(
+      MessageBlock.parse({
+        kind: "steps",
+        steps: [{ label: "Run tests", count: 1 }],
+        durationMs: 103_000,
+      }),
+    ).toMatchObject({ durationMs: 103_000 });
+    expect(MessageBlock.safeParse({ kind: "steps", steps: [], durationMs: -1 }).success).toBe(
+      false,
+    );
+  });
+
   it("limits reactions to persisted non-channel messages", () => {
     expect(
       canReactToThreadMessage({ id: "message-1", blocks: [{ kind: "text", text: "hi" }] }),

--- a/packages/core/src/duration.test.ts
+++ b/packages/core/src/duration.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { formatDurationMs, toolActivityLabel } from "./duration.js";
+
+describe("tool activity duration", () => {
+  it.each([
+    [0, "0s"],
+    [42_400, "42s"],
+    [103_000, "1m 43s"],
+    [3_723_000, "1h 2m 3s"],
+  ])("formats %i milliseconds as %s", (durationMs, expected) => {
+    expect(formatDurationMs(durationMs)).toBe(expected);
+  });
+
+  it("keeps live and legacy labels sensible", () => {
+    expect(toolActivityLabel(undefined, true)).toBe("Working…");
+    expect(toolActivityLabel(undefined, false)).toBe("Worked");
+    expect(toolActivityLabel(103_000, false)).toBe("Worked for 1m 43s");
+  });
+});

--- a/packages/core/src/duration.ts
+++ b/packages/core/src/duration.ts
@@ -1,0 +1,17 @@
+/** Formats a wall-clock duration as compact whole seconds. */
+export function formatDurationMs(durationMs: number | undefined): string | null {
+  if (durationMs === undefined || !Number.isFinite(durationMs) || durationMs < 0) return null;
+  const totalSeconds = Math.round(durationMs / 1_000);
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  return [hours ? `${hours}h` : "", minutes || hours ? `${minutes}m` : "", `${seconds}s`]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function toolActivityLabel(durationMs: number | undefined, live: boolean): string {
+  if (live) return "Working…";
+  const duration = formatDurationMs(durationMs);
+  return duration ? `Worked for ${duration}` : "Worked";
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from "./composer-mention-picker.js";
 export * from "./composer-mentions.js";
 export * from "./composer-slash.js";
 export * from "./cron.js";
+export * from "./duration.js";
 export * from "./events.js";
 export * from "./featured-connectors.js";
 export * from "./group-mentions.js";

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -6,6 +6,7 @@ import {
   appendEvent,
   claimSteering,
   clearThread,
+  completedRunBlocks,
   finalizeComputerControlRelease,
   finalizeRun,
   followThreadEvents,
@@ -58,6 +59,23 @@ function event(seq: number) {
 }
 
 describe("finalizeRun", () => {
+  it("stamps the final steps block with wall-clock run duration", () => {
+    const blocks = [
+      { kind: "steps" as const, steps: [{ label: "Read file", count: 1 }] },
+      { kind: "text" as const, text: "Then I checked it." },
+      { kind: "steps" as const, steps: [{ label: "Run tests", count: 1 }] },
+    ];
+
+    expect(
+      completedRunBlocks(
+        blocks,
+        new Date("2026-09-01T12:00:00.000Z"),
+        new Date("2026-09-01T12:01:43.000Z"),
+      ),
+    ).toEqual([blocks[0], blocks[1], { ...blocks[2], durationMs: 103_000 }]);
+    expect(completedRunBlocks(blocks, null, new Date())).toBe(blocks);
+  });
+
   it("retries a transaction conflict without duplicating the terminal event or notification", async () => {
     const conflict = Object.assign(new Error("serialization conflict"), { code: "P2034" });
     const createEvent = vi.fn(async () => ({ threadId: "thread-1", seq: 0 }));

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -878,14 +878,33 @@ export async function finalizeRun(
   return { continuationRunId: committed.continuationRunId };
 }
 
+/** Stamps one turn-level wall-clock duration on the final tool block. */
+export function completedRunBlocks(
+  blocks: MessageBlock[],
+  startedAt: Date | null,
+  completedAt: Date,
+): MessageBlock[] {
+  if (!startedAt) return blocks;
+  const durationMs = completedAt.getTime() - startedAt.getTime();
+  if (!Number.isFinite(durationMs) || durationMs < 0) return blocks;
+  const index = blocks.findLastIndex((block) => block.kind === "steps");
+  if (index < 0) return blocks;
+  return blocks.map((block, blockIndex) =>
+    blockIndex === index && block.kind === "steps"
+      ? { ...block, durationMs: Math.round(durationMs) }
+      : block,
+  );
+}
+
 async function finalizeRunOnce(
   prisma: PrismaClient,
   input: FinalizeRunInput,
 ): Promise<{ threadId: string; seq: number; continuationRunId: string | null } | null> {
   return prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     await tx.$queryRaw`SELECT id FROM threads WHERE id = ${input.threadId} FOR UPDATE`;
+    let writableRun: { startedAt: Date | null } | undefined;
     try {
-      await assertRunCanWriteHistory(tx, input.runId);
+      writableRun = await assertRunCanWriteHistory(tx, input.runId);
     } catch (error) {
       if (error instanceof RunHistoryWriteError) return null;
       throw error;
@@ -938,23 +957,26 @@ async function finalizeRunOnce(
     });
     if (task.count !== 1) throw new Error("Run task was not available to finalize");
 
-    if (input.outcome === "completed" && input.blocks.length > 0) {
-      const message = await createThreadMessageInTransaction(tx, {
-        threadId: input.threadId,
-        role: "bot",
-        blocks: input.blocks,
-        botId: input.botId,
-        runId: input.runId,
-        markUnread: input.markUnread,
-      });
-      await appendEventInTransaction(tx, {
-        spaceId: input.spaceId,
-        threadId: input.threadId,
-        botId: input.botId,
-        type: "thread.message.created",
-        runId: input.runId,
-        payload: { messageId: message.id, role: "bot", blocks: input.blocks },
-      });
+    if (input.outcome === "completed") {
+      const completedBlocks = completedRunBlocks(input.blocks, writableRun?.startedAt ?? null, now);
+      if (completedBlocks.length > 0) {
+        const message = await createThreadMessageInTransaction(tx, {
+          threadId: input.threadId,
+          role: "bot",
+          blocks: completedBlocks,
+          botId: input.botId,
+          runId: input.runId,
+          markUnread: input.markUnread,
+        });
+        await appendEventInTransaction(tx, {
+          spaceId: input.spaceId,
+          threadId: input.threadId,
+          botId: input.botId,
+          type: "thread.message.created",
+          runId: input.runId,
+          payload: { messageId: message.id, role: "bot", blocks: completedBlocks },
+        });
+      }
     }
     const lastEvent = await appendEventInTransaction(tx, {
       spaceId: input.spaceId,

--- a/packages/db/src/messages.ts
+++ b/packages/db/src/messages.ts
@@ -55,13 +55,14 @@ export class RunHistoryWriteError extends Error {
 export async function assertRunCanWriteHistory(
   tx: Prisma.TransactionClient,
   runId?: string,
-): Promise<void> {
+): Promise<{ status: string; startedAt: Date | null } | undefined> {
   if (!runId) return;
   const run = await tx.run.findUnique({
     where: { id: runId },
-    select: { status: true },
+    select: { status: true, startedAt: true },
   });
   if (!run || run.status === "cancelled") {
     throw new RunHistoryWriteError();
   }
+  return run;
 }


### PR DESCRIPTION
## Summary

- replaces closed #452 with the minimal wall-clock implementation
- persists optional `steps.durationMs` from the existing run `startedAt` and completion timestamp
- shows live work as `Working…`, completed work as `Worked for 1m 43s`, and legacy/invalid data as `Worked`
- uses the shared web surface for web/Electron and the same formatter on native mobile
- removes the production `t\`Actions\`` lookup that could render Lingui ID `7LO1XJ`

## Scope

This intentionally does not add attempt interval accounting, database-clock machinery, lease/retry changes, migrations, localization architecture, focus-transfer systems, or unrelated hardening. Duration is simple wall-clock time from the persisted run start through successful finalization, including waits and retries.

## Verification

- `NODE_ENV=test /opt/homebrew/bin/pnpm vitest run packages/core/src/duration.test.ts packages/contracts/src/index.test.ts packages/db/src/events.test.ts apps/web/src/components/ToolActivityDisclosure.test.tsx apps/mobile/lib/message-presentation.test.ts --maxWorkers=5 --reporter=dot` — 55 passed
- sabotage run with duration stamping removed — new database regression failed as intended; restored run passed 28/28
- `NODE_ENV=test /opt/homebrew/bin/pnpm run test:e2e -- --sandbox=fake --spec=e2e/tool-activity-disclosure.spec.ts` — 1 passed
- `NODE_ENV=test /opt/homebrew/bin/pnpm vitest run --maxWorkers=5 --reporter=dot` — 2,266 passed, 109 skipped
- `corepack pnpm run format` — completed; two pre-existing informational suggestions only
- `/opt/homebrew/bin/pnpm biome check . --max-diagnostics=20` — passed; same two informational suggestions
- `/opt/homebrew/bin/pnpm turbo check --concurrency=5` — 20/20 tasks
- `/opt/homebrew/bin/pnpm turbo build --concurrency=5` — 4/4 tasks

## Risk

Low. The persisted field is optional/backward-compatible, only the final `steps` block receives the turn duration, and missing or invalid timestamps preserve the legacy `Worked` fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool activity panels now show completed work durations, such as “Worked for 1m 43s.”
  * Live activity continues to display “Working…,” while completed activity without timing shows “Worked.”
  * Completed tool activity records elapsed time for supported steps.

* **Bug Fixes**
  * Improved handling of missing, invalid, or negative duration values to prevent misleading labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->