### PR TITLE
fix(ui): unify error red across web and mobile

### DIFF
--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -147,7 +147,7 @@ export default function BotSettingsScreen() {
             setComputer(status);
           }}
         />
-        {error ? <Text style={{ color: "#E65707", marginTop: 16 }}>{error}</Text> : null}
+        {error ? <Text style={{ color: "#EF4444", marginTop: 16 }}>{error}</Text> : null}
         <Pressable
           onPress={() => void save()}
           disabled={!name.trim() || pending || !bot}

--- a/apps/mobile/app/new-space.tsx
+++ b/apps/mobile/app/new-space.tsx
@@ -81,7 +81,7 @@ export default function NewSpace() {
               fontSize: 16,
             }}
           />
-          {error ? <Text style={{ color: "#FF5364", marginTop: 14 }}>{error}</Text> : null}
+          {error ? <Text style={{ color: "#EF4444", marginTop: 14 }}>{error}</Text> : null}
           <Pressable
             onPress={() => void create()}
             disabled={!name.trim() || pending}

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -121,7 +121,7 @@ export default function NewBot() {
           }}
         />
         <ComputerModePicker value={computerMode} onChange={setComputerMode} />
-        {error ? <Text style={{ color: "#E65707", marginTop: 16 }}>{error}</Text> : null}
+        {error ? <Text style={{ color: "#EF4444", marginTop: 16 }}>{error}</Text> : null}
         <Pressable
           onPress={() => void create()}
           disabled={!name.trim() || pending}

--- a/apps/mobile/app/routine.tsx
+++ b/apps/mobile/app/routine.tsx
@@ -50,7 +50,7 @@ export default function RoutineDetail() {
     >
       <Stack.Screen options={{ title: routine?.name ?? "Routine" }} />
       {loading ? <ActivityIndicator color="#85858A" /> : null}
-      {error ? <Text style={{ color: "#E65707", fontSize: 15 }}>{error}</Text> : null}
+      {error ? <Text style={{ color: "#EF4444", fontSize: 15 }}>{error}</Text> : null}
       {routine ? (
         <>
           <View

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -227,7 +227,7 @@ export default function SignIn() {
                       }}
                     />
                   ) : null}
-                  {error ? <Text style={{ color: "#C94244", marginTop: 12 }}>{error}</Text> : null}
+                  {error ? <Text style={{ color: "#EF4444", marginTop: 12 }}>{error}</Text> : null}
                   <Pressable
                     accessibilityRole="button"
                     onPress={() => void submit()}
@@ -443,7 +443,7 @@ function ServerSheet({
           {warning ? (
             <Text style={{ color: "#8C8C86", marginTop: 12, fontSize: 13 }}>{warning}</Text>
           ) : null}
-          {error ? <Text style={{ color: "#C94244", marginTop: 12 }}>{error}</Text> : null}
+          {error ? <Text style={{ color: "#EF4444", marginTop: 12 }}>{error}</Text> : null}
           {usesCustomApiBase(current) || draft.trim() !== current ? (
             <Pressable
               onPress={() => void restoreDefault()}

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -227,7 +227,7 @@ export default function SignIn() {
                       }}
                     />
                   ) : null}
-                  {error ? <Text style={{ color: "#EF4444", marginTop: 12 }}>{error}</Text> : null}
+                  {error ? <Text style={{ color: "#B91C1C", marginTop: 12 }}>{error}</Text> : null}
                   <Pressable
                     accessibilityRole="button"
                     onPress={() => void submit()}
@@ -443,7 +443,7 @@ function ServerSheet({
           {warning ? (
             <Text style={{ color: "#8C8C86", marginTop: 12, fontSize: 13 }}>{warning}</Text>
           ) : null}
-          {error ? <Text style={{ color: "#EF4444", marginTop: 12 }}>{error}</Text> : null}
+          {error ? <Text style={{ color: "#B91C1C", marginTop: 12 }}>{error}</Text> : null}
           {usesCustomApiBase(current) || draft.trim() !== current ? (
             <Pressable
               onPress={() => void restoreDefault()}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1328,7 +1328,7 @@ function Thread() {
       style={{ flex: 1, backgroundColor: "#000", paddingHorizontal: 20 }}
     >
       {error ? <Text style={{ color: "#8E8E93", marginTop: 12 }}>{error}</Text> : null}
-      {runError ? <Text style={{ color: "#E65707", marginTop: 12 }}>{runError}</Text> : null}
+      {runError ? <Text style={{ color: "#EF4444", marginTop: 12 }}>{runError}</Text> : null}
       <View style={{ flex: 1, position: "relative" }}>
         {showPinnedPage ? (
           <ScrollView
@@ -2088,7 +2088,7 @@ const MessageBubble = memo(function MessageBubble({
           </Text>
           <Text
             style={{
-              color: failed ? "#E65707" : running ? "#F5A03C" : "#4ECB71",
+              color: failed ? "#EF4444" : running ? "#F5A03C" : "#4ECB71",
               fontSize: 13,
             }}
           >
@@ -2135,7 +2135,7 @@ const MessageBubble = memo(function MessageBubble({
           <Text style={{ color: "#ECECEE", fontSize: 15, fontWeight: "600" }}>
             {special.name || "Bot"}
           </Text>
-          <Text style={{ color: removed ? "#E65707" : "#4ECB71", fontSize: 13 }}>
+          <Text style={{ color: removed ? "#EF4444" : "#4ECB71", fontSize: 13 }}>
             {special.status === "archived"
               ? "archived"
               : special.status === "deleted"
@@ -2649,7 +2649,7 @@ function AskBlock({
       ) : (
         <Text style={{ color: "#85858A", fontSize: 13.5 }}>Waiting for this bot’s response.</Text>
       )}
-      {error ? <Text style={{ color: "#E65707", fontSize: 13 }}>{error}</Text> : null}
+      {error ? <Text style={{ color: "#EF4444", fontSize: 13 }}>{error}</Text> : null}
     </View>
   );
 }

--- a/apps/mobile/app/voice.tsx
+++ b/apps/mobile/app/voice.tsx
@@ -213,7 +213,7 @@ const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: "#000" },
   content: { padding: 20, gap: 10 },
   lede: { color: "#85858A", fontSize: 14, lineHeight: 20, marginBottom: 8 },
-  error: { color: "#C94244", marginBottom: 8 },
+  error: { color: "#EF4444", marginBottom: 8 },
   notice: { color: "#4ECB71", marginBottom: 8 },
   card: {
     borderRadius: 14,

--- a/apps/mobile/components/bot-organize-modal.tsx
+++ b/apps/mobile/components/bot-organize-modal.tsx
@@ -257,7 +257,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
   error: {
-    color: "#FF5364",
+    color: "#EF4444",
     fontSize: 13,
     paddingHorizontal: 10,
     paddingTop: 8,

--- a/apps/mobile/components/computer-maintenance-actions.tsx
+++ b/apps/mobile/components/computer-maintenance-actions.tsx
@@ -78,7 +78,7 @@ export function ComputerMaintenanceActions({
           </Text>
         </Pressable>
       ) : null}
-      {error ? <Text style={{ color: "#E65707", fontSize: 13 }}>{error}</Text> : null}
+      {error ? <Text style={{ color: "#EF4444", fontSize: 13 }}>{error}</Text> : null}
     </View>
   );
 }

--- a/apps/mobile/components/markdown-artifact-preview.tsx
+++ b/apps/mobile/components/markdown-artifact-preview.tsx
@@ -117,7 +117,7 @@ export function MarkdownArtifactPreview({
                 padding: 14,
               }}
             >
-              <Text style={{ color: "#F1A8A8", fontSize: 15 }}>{state.message}</Text>
+              <Text style={{ color: "#FCA5A5", fontSize: 15 }}>{state.message}</Text>
             </View>
           ) : (
             <ChatMarkdown>{state.markdown}</ChatMarkdown>

--- a/apps/web/src/components/ApprovalRulesSettings.tsx
+++ b/apps/web/src/components/ApprovalRulesSettings.tsx
@@ -153,7 +153,7 @@ export function ApprovalRulesSettings() {
           ) : null}
         </span>
       </label>
-      {error ? <p className="mt-3 text-[13px] text-[#E65707]">{error}</p> : null}
+      {error ? <p className="mt-3 text-[13px] text-[#EF4444]">{error}</p> : null}
       {loading ? (
         <p className="mt-4 text-[13px] text-[#85858A]">
           <Trans>Loading rules…</Trans>

--- a/apps/web/src/components/ArtifactFileCard.tsx
+++ b/apps/web/src/components/ArtifactFileCard.tsx
@@ -238,7 +238,7 @@ function MarkdownPreview({
                 <Trans>Loading preview…</Trans>
               </div>
             ) : state.status === "error" ? (
-              <div className="rounded-[14px] border border-[#5A2A2A] bg-[#2A1717] px-4 py-3 text-[#F1A8A8]">
+              <div className="rounded-[14px] border border-[#5A2A2A] bg-[#2A1717] px-4 py-3 text-[#FCA5A5]">
                 {state.message}
               </div>
             ) : (
@@ -253,7 +253,7 @@ function MarkdownPreview({
 
 function DownloadError({ message }: { message: string }) {
   return (
-    <div role="alert" className="mt-2 text-left text-[13px] text-[#F1A8A8]">
+    <div role="alert" className="mt-2 text-left text-[13px] text-[#EF4444]">
       {message}
     </div>
   );

--- a/apps/web/src/components/AskCard.tsx
+++ b/apps/web/src/components/AskCard.tsx
@@ -201,7 +201,7 @@ export function AskCard({
           </button>
         </div>
       )}
-      {error ? <p className="mt-3 text-[13px] text-[#E65707]">{error}</p> : null}
+      {error ? <p className="mt-3 text-[13px] text-[#EF4444]">{error}</p> : null}
     </div>
   );
 }

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -83,7 +83,7 @@ export function ComputerMaintenanceActions({
           </Trans>
         </p>
       ) : null}
-      {error && !confirmReset ? <p className="text-[13px] text-[#E65707]">{error}</p> : null}
+      {error && !confirmReset ? <p className="text-[13px] text-[#EF4444]">{error}</p> : null}
       {confirmReset ? (
         <div
           className="fixed inset-0 z-50 grid place-items-center bg-[rgba(4,4,5,.72)] px-6"
@@ -102,7 +102,7 @@ export function ComputerMaintenanceActions({
             >
               <Trans>Restore the last saved workspace. Unsaved work on the computer is lost.</Trans>
             </p>
-            {error ? <p className="mt-2 text-[13px] text-[#E65707]">{error}</p> : null}
+            {error ? <p className="mt-2 text-[13px] text-[#EF4444]">{error}</p> : null}
             <div className="mt-4 flex justify-end gap-2">
               <BuiButton onClick={() => setConfirmReset(false)}>
                 <Trans>Cancel</Trans>

--- a/apps/web/src/components/SoftwareUpdateSection.tsx
+++ b/apps/web/src/components/SoftwareUpdateSection.tsx
@@ -78,7 +78,7 @@ export function SoftwareUpdatePanel({
       </div>
       {check ? <CheckSummary check={check} /> : null}
       {error ? (
-        <p role="alert" className="text-[12.5px] text-[#F1A8A8]">
+        <p role="alert" className="text-[12.5px] text-[#EF4444]">
           {error}
         </p>
       ) : null}
@@ -133,7 +133,7 @@ export function SoftwareUpdateSection({ isDeploymentOwner }: { isDeploymentOwner
         <h3 className="text-[15px] font-medium text-[#ECECEE]">
           <Trans>Software update</Trans>
         </h3>
-        <p role="alert" className="mt-3 text-[12.5px] text-[#F1A8A8]">
+        <p role="alert" className="mt-3 text-[12.5px] text-[#EF4444]">
           {error}
         </p>
       </section>
@@ -257,12 +257,12 @@ function CheckSummary({ check }: { check: ServerUpdateCheck }) {
   }
   if (check.status === "dirty") {
     return (
-      <p className="text-[12.5px] text-[#F1A8A8]">
+      <p className="text-[12.5px] text-[#EF4444]">
         <Trans>Checkout has local changes. Clean it before updating.</Trans>
       </p>
     );
   }
   return (
-    <p className="text-[12.5px] text-[#F1A8A8]">{check.reason ?? <Trans>Unavailable</Trans>}</p>
+    <p className="text-[12.5px] text-[#EF4444]">{check.reason ?? <Trans>Unavailable</Trans>}</p>
   );
 }

--- a/apps/web/src/components/teach/TeachRecordingChrome.tsx
+++ b/apps/web/src/components/teach/TeachRecordingChrome.tsx
@@ -45,7 +45,7 @@ export function TeachRecordingChrome({
         <div className="text-[12px] text-[#85858A]">
           <Trans>{remaining} left · bot is watching, not acting</Trans>
         </div>
-        <div className="text-[12px] text-[#E65707]">
+        <div className="text-[12px] text-[#EF4444]">
           <Trans>Do not type passwords into the demo. Use Take control for credentials.</Trans>
         </div>
       </div>
@@ -63,7 +63,7 @@ export function TeachRecordingChrome({
       <div className="mt-1 text-[13px] text-[#85858A]">
         <Trans>{remaining} left · bot is watching, not acting</Trans>
       </div>
-      <div className="mt-2 text-[13px] text-[#E65707]">
+      <div className="mt-2 text-[13px] text-[#EF4444]">
         <Trans>Do not type passwords into the demo. Use Take control for credentials.</Trans>
       </div>
       <Button

--- a/apps/web/src/components/teach/TeachRecordingChrome.tsx
+++ b/apps/web/src/components/teach/TeachRecordingChrome.tsx
@@ -45,7 +45,7 @@ export function TeachRecordingChrome({
         <div className="text-[12px] text-[#85858A]">
           <Trans>{remaining} left · bot is watching, not acting</Trans>
         </div>
-        <div className="text-[12px] text-[#EF4444]">
+        <div className="text-[12px] text-[#E65707]">
           <Trans>Do not type passwords into the demo. Use Take control for credentials.</Trans>
         </div>
       </div>
@@ -63,7 +63,7 @@ export function TeachRecordingChrome({
       <div className="mt-1 text-[13px] text-[#85858A]">
         <Trans>{remaining} left · bot is watching, not acting</Trans>
       </div>
-      <div className="mt-2 text-[13px] text-[#EF4444]">
+      <div className="mt-2 text-[13px] text-[#E65707]">
         <Trans>Do not type passwords into the demo. Use Take control for credentials.</Trans>
       </div>
       <Button

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -192,7 +192,7 @@ export function AccountSettingsOverlay({
             })}
           </div>
           {avatarError ? (
-            <p role="alert" className="mt-3 text-[12.5px] text-[#F1A8A8]">
+            <p role="alert" className="mt-3 text-[12.5px] text-[#EF4444]">
               {avatarError}
             </p>
           ) : null}
@@ -324,7 +324,7 @@ function ChangePasswordSection() {
         />
       </div>
       {error ? (
-        <p role="alert" className="mt-3 text-[12.5px] text-[#F1A8A8]">
+        <p role="alert" className="mt-3 text-[12.5px] text-[#EF4444]">
           {error}
         </p>
       ) : null}

--- a/apps/web/src/pages/ActivityList.tsx
+++ b/apps/web/src/pages/ActivityList.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import { rpc } from "../lib/rpc";
 
 function statusColor(status: RunActivityRow["status"]): string {
-  if (status === "failed") return "#FF5364";
+  if (status === "failed") return "#EF4444";
   if (status === "cancelled") return "#85858A";
   if (status === "completed") return "#4ECB71";
   if (status === "waiting_input" || status === "waiting_takeover") return "#F5A03C";

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -206,7 +206,11 @@ export function AuthPage({ mode }: { mode: AuthMode }) {
                 ) : null}
               </div>
             ) : null}
-            {error ? <p className="mt-3 w-full text-sm text-[#C94244]">{error}</p> : null}
+            {error ? (
+              <p role="alert" className="mt-3 w-full text-sm text-[#EF4444]">
+                {error}
+              </p>
+            ) : null}
             <button
               type="submit"
               disabled={pending}
@@ -320,7 +324,7 @@ export function PasswordResetPage() {
               className="mt-4"
             />
             {error ? (
-              <p role="alert" className="mt-3 w-full text-sm text-[#C94244]">
+              <p role="alert" className="mt-3 w-full text-sm text-[#EF4444]">
                 {error}
               </p>
             ) : null}

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -207,7 +207,7 @@ export function AuthPage({ mode }: { mode: AuthMode }) {
               </div>
             ) : null}
             {error ? (
-              <p role="alert" className="mt-3 w-full text-sm text-[#EF4444]">
+              <p role="alert" className="mt-3 w-full text-sm text-[#B91C1C]">
                 {error}
               </p>
             ) : null}
@@ -324,7 +324,7 @@ export function PasswordResetPage() {
               className="mt-4"
             />
             {error ? (
-              <p role="alert" className="mt-3 w-full text-sm text-[#EF4444]">
+              <p role="alert" className="mt-3 w-full text-sm text-[#B91C1C]">
                 {error}
               </p>
             ) : null}

--- a/apps/web/src/pages/BotContextMenu.tsx
+++ b/apps/web/src/pages/BotContextMenu.tsx
@@ -158,7 +158,7 @@ function MenuItem({
       role="menuitem"
       aria-expanded={expanded}
       className={`flex w-full items-center gap-3 rounded-[11px] px-3 py-2.5 text-start text-[15px] outline-none hover:bg-[#29292D] focus-visible:bg-[#29292D] ${
-        tone === "danger" ? "text-[#FF5364]" : "text-[#ECECEE]"
+        tone === "danger" ? "text-[#EF4444]" : "text-[#ECECEE]"
       }`}
       onClick={onSelect}
     >

--- a/apps/web/src/pages/CallView.tsx
+++ b/apps/web/src/pages/CallView.tsx
@@ -245,7 +245,7 @@ export function CallView({
         <p className="mt-3 min-h-[3.2em] text-[14.5px] leading-[1.5] text-[#85858A]">
           {phase === "listening" ? heard || t`Say something. Silence sends it.` : caption}
         </p>
-        {error ? <p className="mt-2 text-[13px] text-[#C94244]">{error}</p> : null}
+        {error ? <p className="mt-2 text-[13px] text-[#EF4444]">{error}</p> : null}
         <div className="mt-6 flex justify-center gap-3">
           <button
             type="button"
@@ -257,7 +257,7 @@ export function CallView({
           <button
             type="button"
             onClick={hangUp}
-            className="rounded-full bg-[#FF5364] px-4 py-2 text-[14px] font-medium text-white"
+            className="rounded-full bg-[#DC2626] px-4 py-2 text-[14px] font-medium text-white"
           >
             <Trans>Hang up</Trans>
           </button>

--- a/apps/web/src/pages/GroupPanel.tsx
+++ b/apps/web/src/pages/GroupPanel.tsx
@@ -102,7 +102,7 @@ export function CreateGroupForm({
         </button>
       </div>
       {error ? (
-        <p role="alert" className="mb-3 text-[13px] text-[#C94244]">
+        <p role="alert" className="mb-3 text-[13px] text-[#EF4444]">
           {error}
         </p>
       ) : null}
@@ -193,7 +193,7 @@ export function GroupSettings({
         </span>
       </div>
       {error ? (
-        <p role="alert" className="mb-3 text-[13px] text-[#C94244]">
+        <p role="alert" className="mb-3 text-[13px] text-[#EF4444]">
           {error}
         </p>
       ) : null}

--- a/apps/web/src/pages/HostComputerPrompt.tsx
+++ b/apps/web/src/pages/HostComputerPrompt.tsx
@@ -64,7 +64,7 @@ export function HostComputerPrompt({ initialMe }: { initialMe?: Me }) {
             </Trans>
           )}
         </p>
-        {error ? <p className="mt-3 text-sm text-[#E65707]">{error}</p> : null}
+        {error ? <p className="mt-3 text-sm text-[#EF4444]">{error}</p> : null}
         <div className="mt-5 flex flex-col gap-2">
           <button
             type="button"

--- a/apps/web/src/pages/MemorySettingsOverlay.tsx
+++ b/apps/web/src/pages/MemorySettingsOverlay.tsx
@@ -151,7 +151,7 @@ export function MemorySettingsOverlay({
         </div>
 
         <div className="rk-scroll min-h-0 flex-1 overflow-y-auto px-6 py-6 sm:px-8">
-          {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
+          {error ? <p className="mb-4 text-sm text-[#EF4444]">{error}</p> : null}
 
           {config === undefined ? (
             <p className="text-sm text-[#85858A]">
@@ -214,7 +214,7 @@ export function MemorySettingsOverlay({
               <registration.SettingsForm busy={busy} onConnect={connect} />
             </>
           ) : (
-            <p className="text-sm text-[#C94244]">
+            <p className="text-sm text-[#EF4444]">
               <Trans>The selected memory provider is not available in this build.</Trans>
             </p>
           )}

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -390,7 +390,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
           </div>
 
           <div ref={detailScrollRef} className="rk-scroll min-h-0 min-w-0 flex-1 overflow-y-auto">
-            {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
+            {error ? <p className="mb-4 text-sm text-[#EF4444]">{error}</p> : null}
             {notice ? <p className="mb-4 text-sm text-[#4ECB71]">{notice}</p> : null}
             {selected ? (
               <>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -481,7 +481,7 @@ export function OnboardingPage() {
               </p>
             )}
             {notice ? <p className="mt-3 text-sm text-[#4ECB71]">{notice}</p> : null}
-            {error ? <p className="mt-3 text-sm text-[#E65707]">{error}</p> : null}
+            {error ? <p className="mt-3 text-sm text-[#EF4444]">{error}</p> : null}
             <div className="mt-6 flex gap-3">
               <button
                 type="button"
@@ -537,7 +537,7 @@ export function OnboardingPage() {
                 className="mt-2 w-full rounded-[11px] border border-[#26262A] bg-transparent px-3.5 py-3 text-[#ECECEE]"
               />
             </label>
-            {error ? <p className="mt-3 text-sm text-[#E65707]">{error}</p> : null}
+            {error ? <p className="mt-3 text-sm text-[#EF4444]">{error}</p> : null}
             <button
               type="button"
               disabled={!name.trim()}

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -257,7 +257,7 @@ export function PluginsOverlay({
         </div>
 
         <div id="integration-list" className="rk-scroll flex-1 overflow-y-auto px-8 py-6">
-          {catalogError ? <p className="mb-4 text-sm text-[#C94244]">{catalogError}</p> : null}
+          {catalogError ? <p className="mb-4 text-sm text-[#EF4444]">{catalogError}</p> : null}
           {loading ? (
             <p className="text-[#6C6C70]">
               <Trans>Loading integrations…</Trans>
@@ -441,7 +441,7 @@ export function PluginsOverlay({
                 </Button>
               </div>
 
-              {sourceError ? <p className="text-sm text-[#C94244]">{sourceError}</p> : null}
+              {sourceError ? <p className="text-sm text-[#EF4444]">{sourceError}</p> : null}
 
               {sourceKind ? (
                 <div className="space-y-3 rounded-[16px] border border-[#2C2C30] bg-[#101012] p-5">

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2684,7 +2684,7 @@ export function ShellPage() {
                         type="button"
                         aria-label={t`Delete ${bot.name}`}
                         onClick={() => setDeleteTarget(bot)}
-                        className="text-[12.5px] text-[#FF5364]"
+                        className="text-[12.5px] text-[#EF4444]"
                       >
                         <Trans>Delete</Trans>
                       </button>
@@ -2714,7 +2714,7 @@ export function ShellPage() {
                         type="button"
                         aria-label={t`Delete ${group.name}`}
                         onClick={() => setDeleteGroupTarget(group)}
-                        className="text-[12.5px] text-[#FF5364]"
+                        className="text-[12.5px] text-[#EF4444]"
                       >
                         <Trans>Delete</Trans>
                       </button>
@@ -2955,7 +2955,7 @@ export function ShellPage() {
           onSpeak={speakMessage}
         />
         {recordingSkill ? (
-          <div className="px-6 pb-2 text-center text-[13px] text-[#E65707]">
+          <div className="px-6 pb-2 text-center text-[13px] text-[#EF4444]">
             <Trans>Teaching in progress — stop teaching before sending a new message.</Trans>
           </div>
         ) : null}
@@ -3798,7 +3798,7 @@ export function ShellPage() {
           {sendError ? (
             <div
               role="alert"
-              className="border-b border-[#5A2A2A] bg-[#2A1717] px-[18px] py-2 text-[13px] text-[#F1A8A8]"
+              className="border-b border-[#5A2A2A] bg-[#2A1717] px-[18px] py-2 text-[13px] text-[#FCA5A5]"
             >
               {sendError}
             </div>
@@ -4425,7 +4425,7 @@ const Composer = memo(function Composer({
           ref={runErrorRef}
           role="alert"
           data-testid="composer-error"
-          className="mb-3 flex items-center gap-2 rounded-[14px] border border-[#5A2A2A] bg-[#2A1717] px-4 py-2 text-[13px] text-[#F1A8A8]"
+          className="mb-3 flex items-center gap-2 rounded-[14px] border border-[#5A2A2A] bg-[#2A1717] px-4 py-2 text-[13px] text-[#FCA5A5]"
         >
           <span className="min-w-0 flex-1">{sendError ?? dictationError ?? runError}</span>
           <button
@@ -4436,7 +4436,7 @@ const Composer = memo(function Composer({
               onDismissError();
               window.requestAnimationFrame(() => textareaRef.current?.focus());
             }}
-            className="shrink-0 text-[#F1A8A8] hover:text-[#ECECEE]"
+            className="shrink-0 text-[#FCA5A5] hover:text-[#ECECEE]"
           >
             <X size={13} strokeWidth={2} />
           </button>
@@ -5174,7 +5174,7 @@ const MessageView = memo(function MessageView({
                       : running
                         ? "rgba(245,160,60,.14)"
                         : "rgba(48,162,75,.14)",
-                    color: failed ? "#E65707" : running ? "#F5A03C" : "#4ECB71",
+                    color: failed ? "#EF4444" : running ? "#F5A03C" : "#4ECB71",
                     animation: running ? "rkPulse 1.2s ease-in-out infinite" : undefined,
                   }}
                 >
@@ -5210,7 +5210,7 @@ const MessageView = memo(function MessageView({
                   className="rounded-full px-[11px] py-1 text-[13px]"
                   style={{
                     background: removed ? "rgba(230,87,7,.14)" : "rgba(48,162,75,.14)",
-                    color: removed ? "#E65707" : "#4ECB71",
+                    color: removed ? "#EF4444" : "#4ECB71",
                   }}
                 >
                   {block.status === "archived" ? (
@@ -5467,7 +5467,7 @@ function CreateBotForm({
         </button>
       </div>
       {error ? (
-        <p role="alert" data-testid="create-bot-error" className="mb-3 text-[13px] text-[#C94244]">
+        <p role="alert" data-testid="create-bot-error" className="mb-3 text-[13px] text-[#EF4444]">
           {error}
         </p>
       ) : null}
@@ -5776,7 +5776,7 @@ function BotSettings({
           </label>
         ) : null}
       </details>
-      {error ? <p className="mt-2 text-[13px] text-[#E65707]">{error}</p> : null}
+      {error ? <p className="mt-2 text-[13px] text-[#EF4444]">{error}</p> : null}
       <div className="mt-5 flex flex-col items-start gap-3">
         <button
           type="button"
@@ -5820,7 +5820,7 @@ function BotSettings({
         >
           <Trans>Export</Trans>
         </button>
-        <button type="button" onClick={onClear} className="text-[14px] text-[#E65707]">
+        <button type="button" onClick={onClear} className="text-[14px] text-[#EF4444]">
           <Trans>Clear conversation</Trans>
         </button>
         <ComputerMaintenanceActions
@@ -5928,7 +5928,7 @@ function NewSpaceDialog({
             className="mt-2 w-full rounded-[11px] border border-[#343438] bg-[#101012] px-3.5 py-2.5 text-[14.5px] text-[#ECECEE] outline-none focus:border-[#66666D]"
           />
         </label>
-        {error ? <p className="mt-3 text-[13.5px] text-[#FF5364]">{error}</p> : null}
+        {error ? <p className="mt-3 text-[13.5px] text-[#EF4444]">{error}</p> : null}
         <div className="mt-5 flex justify-end gap-2.5">
           <BuiButton disabled={saving} onClick={onCancel}>
             <Trans>Cancel</Trans>
@@ -6005,7 +6005,7 @@ function NewBotSectionDialog({
             className="mt-2 w-full rounded-[11px] border border-[#343438] bg-[#101012] px-3.5 py-2.5 text-[14.5px] text-[#ECECEE] outline-none focus:border-[#66666D]"
           />
         </label>
-        {error ? <p className="mt-3 text-[13.5px] text-[#FF5364]">{error}</p> : null}
+        {error ? <p className="mt-3 text-[13.5px] text-[#EF4444]">{error}</p> : null}
         <div className="mt-5 flex justify-end gap-2.5">
           <button
             type="button"
@@ -6077,7 +6077,7 @@ function ClearConversationDialog({
             available.
           </Trans>
         </p>
-        {error ? <p className="mt-3 text-[13.5px] text-[#FF5364]">{error}</p> : null}
+        {error ? <p className="mt-3 text-[13.5px] text-[#EF4444]">{error}</p> : null}
         <div className="mt-5 flex justify-end gap-2.5">
           <button
             type="button"
@@ -6098,7 +6098,7 @@ function ClearConversationDialog({
                 setClearing(false);
               });
             }}
-            className="rounded-[10px] bg-[#FF5364] px-3.5 py-2 text-[14px] font-medium text-white disabled:opacity-40"
+            className="rounded-[10px] bg-[#DC2626] px-3.5 py-2 text-[14px] font-medium text-white disabled:opacity-40"
           >
             {clearing ? <Trans>Clearing…</Trans> : <Trans>Clear</Trans>}
           </button>
@@ -6192,7 +6192,7 @@ function DeleteBotDialog({
             </span>
           </label>
         </fieldset>
-        {error ? <p className="mt-3 text-[13.5px] text-[#FF5364]">{error}</p> : null}
+        {error ? <p className="mt-3 text-[13.5px] text-[#EF4444]">{error}</p> : null}
         <div className="mt-5 flex justify-end gap-2.5">
           <button
             type="button"
@@ -6213,7 +6213,7 @@ function DeleteBotDialog({
                 setDeleting(false);
               });
             }}
-            className="rounded-[10px] bg-[#FF5364] px-3.5 py-2 text-[14px] font-medium text-white disabled:opacity-40"
+            className="rounded-[10px] bg-[#DC2626] px-3.5 py-2 text-[14px] font-medium text-white disabled:opacity-40"
           >
             {deleting ? <Trans>Deleting…</Trans> : <Trans>Delete</Trans>}
           </button>
@@ -6268,7 +6268,7 @@ function DeleteItemDialog({
         <p id="delete-item-description" className="mt-2 text-[14px] leading-6 text-[#9A9AA0]">
           <Trans>This cannot be undone.</Trans>
         </p>
-        {error ? <p className="mt-3 text-[13.5px] text-[#FF5364]">{error}</p> : null}
+        {error ? <p className="mt-3 text-[13.5px] text-[#EF4444]">{error}</p> : null}
         <div className="mt-5 flex justify-end gap-2.5">
           <button
             type="button"
@@ -6295,7 +6295,7 @@ function DeleteItemDialog({
                 setDeleting(false);
               });
             }}
-            className="rounded-[10px] bg-[#FF5364] px-3.5 py-2 text-[14px] font-medium text-white disabled:opacity-40"
+            className="rounded-[10px] bg-[#DC2626] px-3.5 py-2 text-[14px] font-medium text-white disabled:opacity-40"
           >
             {deleting ? <Trans>Deleting…</Trans> : <Trans>Delete</Trans>}
           </button>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -5170,7 +5170,7 @@ const MessageView = memo(function MessageView({
                   className="rounded-full px-[11px] py-1 text-[13px]"
                   style={{
                     background: failed
-                      ? "rgba(230,87,7,.14)"
+                      ? "rgba(239,68,68,.14)"
                       : running
                         ? "rgba(245,160,60,.14)"
                         : "rgba(48,162,75,.14)",
@@ -5209,7 +5209,7 @@ const MessageView = memo(function MessageView({
                 <span
                   className="rounded-full px-[11px] py-1 text-[13px]"
                   style={{
-                    background: removed ? "rgba(230,87,7,.14)" : "rgba(48,162,75,.14)",
+                    background: removed ? "rgba(239,68,68,.14)" : "rgba(48,162,75,.14)",
                     color: removed ? "#EF4444" : "#4ECB71",
                   }}
                 >

--- a/apps/web/src/pages/VoiceSettingsOverlay.tsx
+++ b/apps/web/src/pages/VoiceSettingsOverlay.tsx
@@ -209,7 +209,7 @@ export function VoiceSettingsOverlay({ onClose }: { onClose: () => void }) {
           </div>
 
           <div className="rk-scroll min-h-0 min-w-0 flex-1 overflow-y-auto">
-            {error ? <p className="mb-4 text-sm text-[#C94244]">{error}</p> : null}
+            {error ? <p className="mb-4 text-sm text-[#EF4444]">{error}</p> : null}
             {notice ? <p className="mb-4 text-sm text-[#4ECB71]">{notice}</p> : null}
             {selected ? (
               <>

--- a/packages/testkit/src/cli/desktop-performance.ts
+++ b/packages/testkit/src/cli/desktop-performance.ts
@@ -268,7 +268,7 @@ async function prepareAuthenticatedProfile(benchmark: BenchmarkContext, profile:
       })
       .catch(async (error) => {
         const message = await page
-          .locator("form p.text-\\[\\#C94244\\]")
+          .locator('form p[role="alert"]')
           .textContent()
           .catch(() => null);
         throw new Error(

--- a/packages/ui-tokens/src/index.ts
+++ b/packages/ui-tokens/src/index.ts
@@ -14,7 +14,9 @@ export const tokens = {
   cream: "#F1F1EF",
   creamInk: "#1A1A1A",
   accent: "#3EC5A8",
-  danger: "#E65707",
+  danger: "#EF4444",
+  dangerStrong: "#DC2626",
+  dangerSoft: "#FCA5A5",
   success: "#30A24B",
   successSoft: "#4ECB71",
 } as const;

--- a/packages/ui-tokens/src/tokens.css
+++ b/packages/ui-tokens/src/tokens.css
@@ -29,7 +29,7 @@
   --muted-foreground: 240 4% 54%;
   --accent: 240 5% 14%;
   --accent-foreground: 240 6% 93%;
-  --destructive: 16 94% 46%;
+  --destructive: 0 84% 60%;
   --border: 240 6% 12%;
   --input: 240 6% 14%;
   --ring: 240 5% 64%;


### PR DESCRIPTION
## Problem

Error states use four interchangeable colours for one semantic:

| hex | sites | where |
|---|---|---|
| `#E65707` | 20 | the `danger` token — an orange at hue 16° |
| `#C94244` | 16 | Auth, PluginsOverlay, MemorySettingsOverlay, GroupPanel, sign-in |
| `#FF5364` | 15 | Shell (×10), CallView, BotContextMenu, ActivityList |
| `#F1A8A8` | 12 | SoftwareUpdateSection, AccountSettingsOverlay, ArtifactFileCard |

Three of them appear in `Shell.tsx` alone. The identical
`{error ? <p className="… text-[X]">{error}</p> : null}` pattern renders in all
four depending on which file you land in:

- `AskCard.tsx:204` → `#E65707`
- `Shell.tsx:5931` → `#FF5364`
- `MemorySettingsOverlay.tsx:154` → `#C94244`
- `SoftwareUpdateSection.tsx:266` → `#F1A8A8`

None of the four is a standard error red — the token value is an orange.

## Change

Standardise on the Tailwind red scale:

| hex | scale | role | sites |
|---|---|---|---|
| `#EF4444` | red-500 | error text, icons, status | 53 |
| `#DC2626` | red-600 | danger button background | 4 |
| `#FCA5A5` | red-300 | text on the `#2A1717` error banner | 5 |

Text and button background are separate values because **neither passes WCAG AA
alone** on this dark UI:

| candidate | as text on `--rk-main` | under white button text |
|---|---|---|
| red-600 `#DC2626` | 3.98:1 ✗ | 4.84:1 ✓ |
| red-500 `#EF4444` | 5.12:1 ✓ | 3.76:1 ✗ |

Split, both roles pass. This mirrors the existing `success`/`successSoft` pair
rather than introducing a new convention. The banner text is 9.1:1 on its
surface. The previous `#E65707` was 5.26:1 as text, so contrast is held, not
traded for hue.

Colours stay as **hex literals**, matching how every other colour in the product
is expressed. `ui-tokens` is updated to record the new values, but note it has
no consumers today (35 of its 40 vars are unreferenced, and there is no `@theme`
block wiring the shadcn set into Tailwind v4), so it documents rather than
enforces. Wiring that up is a separate job, deliberately not bundled here.

## Left orange on purpose

Three `#E65707` sites are not error states and would be wrong in red:

- `Shell.tsx:5123` — the `◷` pending glyph
- `RoutineEditor.tsx:150` — the "Running · Stop" pill
- `ScratchpadSection.tsx:121` — the checkbox tick

## Also

`packages/testkit/src/cli/desktop-performance.ts:271` selected
`form p.text-\[\#C94244\]` — a Playwright locator on a Tailwind class string,
which any colour change silently breaks. Repointed to `form p[role="alert"]`,
and added the missing `role="alert"` to the sign-in error in `Auth.tsx` (the
sign-up error already had one). It will not break on the next colour change.

## Verification

- `biome check .` — 1 warning, 2 infos, all pre-existing in untouched files
- `turbo check` — 20/20 packages typecheck
- `vitest run` — 248 files, 2258 tests, 0 failed

Screenshots: this is a colour-only change to existing error surfaces, so no new
screens are involved. I will link the CI E2E frames covering the affected error
states (composer error, create-bot error, sign-up error) once the Playwright job
publishes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized error and status messages across mobile and web screens with clearer red tones.
  * Improved readability of sign-in, authentication, and password-reset errors.
  * Updated destructive actions and failure indicators with more consistent visual emphasis.
  * Added distinct color shades for standard, strong, and soft error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->