### PR TITLE
fix(sandbox): reach computer control from host-run supervisors on Docker Desktop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ SANDBOX_PROVIDER=docker
 # //./pipe/docker_engine (Windows). Set for rootless Docker, Colima, or custom paths.
 # DOCKER_HOST takes precedence over DOCKER_SOCKET when both are set.
 # DOCKER_SOCKET=
+# Required for a host-run supervisor on Docker Desktop (macOS/Windows): those
+# hosts cannot route to container IPs, so computer control is published to a
+# random token-guarded loopback port instead. Leave unset on Linux and in
+# Compose deployments, where the supervisor reaches containers directly.
+# SANDBOX_CONTROL_VIA_LOOPBACK=true
 DAYTONA_API_KEY=
 DAYTONA_API_URL=
 DAYTONA_TARGET=

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -351,6 +351,21 @@ describe("graphical computer spec", () => {
     expect(JSON.stringify(options.HostConfig.PortBindings)).not.toMatch(/7070/);
   });
 
+  it("publishes the control port to loopback only when explicitly opted in", () => {
+    const options = containerCreateOptions({
+      name: "rakazo-bot-ctrl",
+      image: COMPUTER_IMAGE,
+      botId: "ctrl",
+      spaceId: "ws",
+      homePath: "/var/rakazo/homes/ctrl",
+      publishControlPort: true,
+    });
+    expect(options.ExposedPorts["7070/tcp"]).toEqual({});
+    expect(options.HostConfig.PortBindings["7070/tcp"]).toEqual([
+      { HostIp: "127.0.0.1", HostPort: "0" },
+    ]);
+  });
+
   it("resolves computer control through the container network IP, never a host mapping", () => {
     const networkMode = "rakazo_default";
     expect(
@@ -379,6 +394,26 @@ describe("graphical computer spec", () => {
         token: "secret",
         networkMode,
         networks: {},
+      }),
+    ).toBeUndefined();
+  });
+
+  it("resolves computer control through a published loopback port when provided", () => {
+    const networkMode = "rakazo_default";
+    expect(
+      resolveComputerControlEndpoint({
+        token: "secret",
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        publishedHostPort: "55101",
+      }),
+    ).toEqual({ url: "http://127.0.0.1:55101/v1/desktop", token: "secret" });
+    expect(
+      resolveComputerControlEndpoint({
+        token: undefined,
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        publishedHostPort: "55101",
       }),
     ).toBeUndefined();
   });

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -36,7 +36,7 @@ export function screenPorts(index: number) {
   };
 }
 
-export function computerPortBindings() {
+export function computerPortBindings(publishControlPort = false) {
   const ExposedPorts: Record<string, object> = {};
   const PortBindings: Record<string, Array<{ HostIp: string; HostPort: string }>> = {};
   for (let index = 0; index < TEAM_SCREEN_LIMIT; index += 1) {
@@ -47,7 +47,13 @@ export function computerPortBindings() {
     PortBindings[`${ports.controlPort}/tcp`] = [{ HostIp: "127.0.0.1", HostPort: "0" }];
   }
   // Control stays on the container network only (0.0.0.0 inside the container).
-  // Do not publish 7070 to the host.
+  // Do not publish 7070 to the host, except via SANDBOX_CONTROL_VIA_LOOPBACK:
+  // a host-run supervisor on Docker Desktop (macOS/Windows) has no route to
+  // container IPs, so control must go through a token-guarded loopback mapping.
+  if (publishControlPort) {
+    ExposedPorts[`${COMPUTER_CONTROL_PORT}/tcp`] = {};
+    PortBindings[`${COMPUTER_CONTROL_PORT}/tcp`] = [{ HostIp: "127.0.0.1", HostPort: "0" }];
+  }
   return { ExposedPorts, PortBindings };
 }
 
@@ -60,6 +66,7 @@ export interface ComputerCreateInput {
   user?: string;
   controlToken?: string;
   networkMode?: string;
+  publishControlPort?: boolean;
 }
 
 interface PointerInput {
@@ -76,7 +83,7 @@ export type SandboxInput =
   | { kind: "clipboard"; text: string };
 
 export function containerCreateOptions(input: ComputerCreateInput) {
-  const ports = computerPortBindings();
+  const ports = computerPortBindings(input.publishControlPort);
   return {
     Image: input.image,
     name: input.name,
@@ -189,8 +196,15 @@ export function resolveComputerControlEndpoint(input: {
   token: string | undefined;
   networkMode: string | null | undefined;
   networks: Record<string, { IPAddress?: string } | undefined> | null | undefined;
+  publishedHostPort?: string;
 }): { url: string; token: string } | undefined {
   if (!input.token) return undefined;
+  if (input.publishedHostPort) {
+    return {
+      url: `http://127.0.0.1:${input.publishedHostPort}/v1/desktop`,
+      token: input.token,
+    };
+  }
   const address =
     (input.networkMode ? input.networks?.[input.networkMode]?.IPAddress : undefined) ||
     Object.values(input.networks ?? {}).find((network) => network?.IPAddress)?.IPAddress;

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -11,6 +11,7 @@ import Docker from "dockerode";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
+  COMPUTER_CONTROL_PORT,
   COMPUTER_GID,
   COMPUTER_IMAGE,
   COMPUTER_UID,
@@ -72,6 +73,9 @@ let imageReady: Promise<void> | undefined;
 let supervisorInfo: Docker.ContainerInspectInfo | undefined;
 const supervisorToken = resolveSupervisorToken(process.env);
 const screenNetworkMode = resolveScreenNetworkMode(process.env.SANDBOX_SCREEN_NETWORK);
+// Host-run supervisors on Docker Desktop (macOS/Windows) cannot reach container
+// IPs, so computer control must use a published loopback port instead.
+const controlViaLoopback = process.env.SANDBOX_CONTROL_VIA_LOOPBACK === "true";
 const computerScreens = new Map<string, Map<string, ScreenAssignment>>();
 
 const app = new Hono();
@@ -179,6 +183,7 @@ app.post("/computers", async (c) => {
           user: computerUser,
           networkMode,
           controlToken: randomUUID(),
+          publishControlPort: controlViaLoopback,
         }),
       );
       await container.start();
@@ -711,10 +716,14 @@ function computerControlEndpoint(info: Docker.ContainerInspectInfo) {
   const token = info.Config.Env?.find((value) =>
     value.startsWith("RAKAZO_COMPUTER_CONTROL_TOKEN="),
   )?.slice("RAKAZO_COMPUTER_CONTROL_TOKEN=".length);
+  const publishedHostPort = controlViaLoopback
+    ? info.NetworkSettings?.Ports?.[`${COMPUTER_CONTROL_PORT}/tcp`]?.[0]?.HostPort
+    : undefined;
   return resolveComputerControlEndpoint({
     token,
     networkMode: info.HostConfig.NetworkMode,
     networks: info.NetworkSettings?.Networks,
+    publishedHostPort,
   });
 }
 


### PR DESCRIPTION
## Problem

Running the dev stack on the host (`pnpm dev`) with `SANDBOX_PROVIDER=docker` on macOS (and Windows) breaks all graphical computer use. The supervisor resolves the in-container control service via the container's Docker network IP (`http://172.x.x.x:7070/v1/desktop`), but Docker Desktop provides no route from the host to container IPs. Every `computer_act` fails with `500 {"error":"fetch failed"}`, while screenshots keep working because observation goes through `docker exec`.

Reproduce: macOS + Docker Desktop, `pnpm dev`, create a bot with a Docker computer, send any pointer/key action. The control fetch fails; `curl http://<container-ip>:7070/...` from the host confirms the IP is unroutable, while the same request from inside the Docker network succeeds.

## Fix

New opt-in `SANDBOX_CONTROL_VIA_LOOPBACK=true`:

- `computerPortBindings` additionally publishes control port 7070 to a random `127.0.0.1` port on each computer container (same pattern as the screen ports).
- `resolveComputerControlEndpoint` accepts the published host port and, when present, targets `http://127.0.0.1:<port>/v1/desktop` instead of the container IP.

Default behavior is unchanged: without the flag, control stays unpublished on the container network only. The mapping is loopback-only and still guarded by the per-container `RAKAZO_COMPUTER_CONTROL_TOKEN` bearer check. Linux hosts and Compose deployments (supervisor inside the Docker network) should keep the flag unset.

## Verification

- Existing supervisor tests still pass, including the assertions that 7070 is never published by default; added tests for the opt-in binding and the loopback endpoint resolution (71 passed).
- `pnpm --filter @rakazo/sandbox-supervisor check` and Biome clean.
- Manually verified on macOS 15 / Docker Desktop 28.1.1: without the flag, host → `172.21.0.2:7070` is unreachable; with the flag, the published port answers 401 to an untokened probe, and `POST /computers/:id/actions` through the supervisor returns `{"completed":1}` with the pointer visibly moving on the sandbox display. Not a UI change, so no E2E screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional loopback-based computer control for Docker Desktop on macOS and Windows.
  * Control services can now be accessed through a host-local port when enabled.

* **Documentation**
  * Updated the example configuration with guidance for enabling loopback control and when to leave it disabled.

* **Tests**
  * Added coverage for loopback port publishing and endpoint resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->