### PR TITLE
DO NOT MERGE — close me; follow-up belongs on #468

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ SANDBOX_PROVIDER=docker
 # //./pipe/docker_engine (Windows). Set for rootless Docker, Colima, or custom paths.
 # DOCKER_HOST takes precedence over DOCKER_SOCKET when both are set.
 # DOCKER_SOCKET=
+# Required for a host-run supervisor on Docker Desktop (macOS/Windows): those
+# hosts cannot route to container IPs, so computer control is published to a
+# random token-guarded loopback port instead. Leave unset on Linux and in
+# Compose deployments, where the supervisor reaches containers directly.
+# SANDBOX_CONTROL_VIA_LOOPBACK=true
 DAYTONA_API_KEY=
 DAYTONA_API_URL=
 DAYTONA_TARGET=

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -351,6 +351,21 @@ describe("graphical computer spec", () => {
     expect(JSON.stringify(options.HostConfig.PortBindings)).not.toMatch(/7070/);
   });
 
+  it("publishes the control port to loopback only when explicitly opted in", () => {
+    const options = containerCreateOptions({
+      name: "rakazo-bot-ctrl",
+      image: COMPUTER_IMAGE,
+      botId: "ctrl",
+      spaceId: "ws",
+      homePath: "/var/rakazo/homes/ctrl",
+      publishControlPort: true,
+    });
+    expect(options.ExposedPorts["7070/tcp"]).toEqual({});
+    expect(options.HostConfig.PortBindings["7070/tcp"]).toEqual([
+      { HostIp: "127.0.0.1", HostPort: "0" },
+    ]);
+  });
+
   it("resolves computer control through the container network IP, never a host mapping", () => {
     const networkMode = "rakazo_default";
     expect(
@@ -379,6 +394,26 @@ describe("graphical computer spec", () => {
         token: "secret",
         networkMode,
         networks: {},
+      }),
+    ).toBeUndefined();
+  });
+
+  it("resolves computer control through a published loopback port when provided", () => {
+    const networkMode = "rakazo_default";
+    expect(
+      resolveComputerControlEndpoint({
+        token: "secret",
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        publishedHostPort: "55101",
+      }),
+    ).toEqual({ url: "http://127.0.0.1:55101/v1/desktop", token: "secret" });
+    expect(
+      resolveComputerControlEndpoint({
+        token: undefined,
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        publishedHostPort: "55101",
       }),
     ).toBeUndefined();
   });

--- a/infra/sandboxes/supervisor/src/computer-spec.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.test.ts
@@ -17,6 +17,7 @@ import {
   computerNetworkNamesForCleanup,
   containerCreateOptions,
   containerNameFor,
+  containerPublishesControlPort,
   hostComputerUser,
   legacyNetworkOwnedSolelyBy,
   resolveComputerControlEndpoint,
@@ -416,6 +417,47 @@ describe("graphical computer spec", () => {
         publishedHostPort: "55101",
       }),
     ).toBeUndefined();
+  });
+
+  it("detects whether a container publishes the control port for resume", () => {
+    expect(containerPublishesControlPort(undefined)).toBe(false);
+    expect(containerPublishesControlPort({})).toBe(false);
+    expect(
+      containerPublishesControlPort({
+        "6080/tcp": [{ HostIp: "127.0.0.1", HostPort: "0" }],
+      }),
+    ).toBe(false);
+    expect(
+      containerPublishesControlPort({
+        "7070/tcp": [{ HostIp: "127.0.0.1", HostPort: "0" }],
+      }),
+    ).toBe(true);
+    expect(
+      containerPublishesControlPort({
+        "7070/tcp": [{ HostIp: "127.0.0.1", HostPort: "55101" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not fall back to the container IP when a published control port is required", () => {
+    const networkMode = "rakazo_default";
+    expect(
+      resolveComputerControlEndpoint({
+        token: "secret",
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        requirePublishedHostPort: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveComputerControlEndpoint({
+        token: "secret",
+        networkMode,
+        networks: { [networkMode]: { IPAddress: "172.18.0.4" } },
+        publishedHostPort: "55101",
+        requirePublishedHostPort: true,
+      }),
+    ).toEqual({ url: "http://127.0.0.1:55101/v1/desktop", token: "secret" });
   });
 
   it("restricts computer control argv to supervisor shapes", () => {

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -188,15 +188,30 @@ export function resolveScreenPublishTarget(input: {
 }
 
 /**
- * Resolve the in-container control service via its Docker network IP.
- * Control is never host-published; the supervisor reaches 7070 on the
- * container network while the process binds 0.0.0.0 inside the sandbox.
+ * True when the container was created with a published mapping for 7070.
+ * Prefer HostConfig.PortBindings so stopped containers still report correctly.
+ */
+export function containerPublishesControlPort(
+  portBindings:
+    | Record<string, Array<{ HostIp?: string; HostPort?: string }> | null>
+    | null
+    | undefined,
+): boolean {
+  const binding = portBindings?.[`${COMPUTER_CONTROL_PORT}/tcp`]?.[0];
+  return Boolean(binding?.HostPort);
+}
+
+/**
+ * Resolve the computer control service. Prefer a published loopback HostPort
+ * when provided; otherwise use the Docker network IP. When requirePublishedHostPort
+ * is set, never fall back to the container IP (unreachable from Docker Desktop hosts).
  */
 export function resolveComputerControlEndpoint(input: {
   token: string | undefined;
   networkMode: string | null | undefined;
   networks: Record<string, { IPAddress?: string } | undefined> | null | undefined;
   publishedHostPort?: string;
+  requirePublishedHostPort?: boolean;
 }): { url: string; token: string } | undefined {
   if (!input.token) return undefined;
   if (input.publishedHostPort) {
@@ -205,6 +220,7 @@ export function resolveComputerControlEndpoint(input: {
       token: input.token,
     };
   }
+  if (input.requirePublishedHostPort) return undefined;
   const address =
     (input.networkMode ? input.networks?.[input.networkMode]?.IPAddress : undefined) ||
     Object.values(input.networks ?? {}).find((network) => network?.IPAddress)?.IPAddress;

--- a/infra/sandboxes/supervisor/src/computer-spec.ts
+++ b/infra/sandboxes/supervisor/src/computer-spec.ts
@@ -36,7 +36,7 @@ export function screenPorts(index: number) {
   };
 }
 
-export function computerPortBindings() {
+export function computerPortBindings(publishControlPort = false) {
   const ExposedPorts: Record<string, object> = {};
   const PortBindings: Record<string, Array<{ HostIp: string; HostPort: string }>> = {};
   for (let index = 0; index < TEAM_SCREEN_LIMIT; index += 1) {
@@ -47,7 +47,13 @@ export function computerPortBindings() {
     PortBindings[`${ports.controlPort}/tcp`] = [{ HostIp: "127.0.0.1", HostPort: "0" }];
   }
   // Control stays on the container network only (0.0.0.0 inside the container).
-  // Do not publish 7070 to the host.
+  // Do not publish 7070 to the host, except via SANDBOX_CONTROL_VIA_LOOPBACK:
+  // a host-run supervisor on Docker Desktop (macOS/Windows) has no route to
+  // container IPs, so control must go through a token-guarded loopback mapping.
+  if (publishControlPort) {
+    ExposedPorts[`${COMPUTER_CONTROL_PORT}/tcp`] = {};
+    PortBindings[`${COMPUTER_CONTROL_PORT}/tcp`] = [{ HostIp: "127.0.0.1", HostPort: "0" }];
+  }
   return { ExposedPorts, PortBindings };
 }
 
@@ -60,6 +66,7 @@ export interface ComputerCreateInput {
   user?: string;
   controlToken?: string;
   networkMode?: string;
+  publishControlPort?: boolean;
 }
 
 interface PointerInput {
@@ -76,7 +83,7 @@ export type SandboxInput =
   | { kind: "clipboard"; text: string };
 
 export function containerCreateOptions(input: ComputerCreateInput) {
-  const ports = computerPortBindings();
+  const ports = computerPortBindings(input.publishControlPort);
   return {
     Image: input.image,
     name: input.name,
@@ -189,8 +196,15 @@ export function resolveComputerControlEndpoint(input: {
   token: string | undefined;
   networkMode: string | null | undefined;
   networks: Record<string, { IPAddress?: string } | undefined> | null | undefined;
+  publishedHostPort?: string;
 }): { url: string; token: string } | undefined {
   if (!input.token) return undefined;
+  if (input.publishedHostPort) {
+    return {
+      url: `http://127.0.0.1:${input.publishedHostPort}/v1/desktop`,
+      token: input.token,
+    };
+  }
   const address =
     (input.networkMode ? input.networks?.[input.networkMode]?.IPAddress : undefined) ||
     Object.values(input.networks ?? {}).find((network) => network?.IPAddress)?.IPAddress;

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -20,6 +20,7 @@ import {
   computerNetworkNamesForCleanup,
   containerCreateOptions,
   containerNameFor,
+  containerPublishesControlPort,
   hostComputerUser,
   legacyNetworkOwnedSolelyBy,
   resolveComputerControlEndpoint,
@@ -138,10 +139,15 @@ app.post("/computers", async (c) => {
       if (existing) {
         const info = await existing.inspect();
         const desired = await docker.getImage(COMPUTER_IMAGE).inspect();
+        // When loopback control is opted in, only resume containers that already
+        // publish 7070; otherwise replace so create gets publishControlPort.
+        const controlPublishOk =
+          !controlViaLoopback || containerPublishesControlPort(info.HostConfig.PortBindings);
         if (
           info.Image === desired.Id &&
           (!networkMode || info.HostConfig.NetworkMode === networkMode) &&
-          info.Config.User === computerUser
+          info.Config.User === computerUser &&
+          controlPublishOk
         ) {
           if (!info.State.Running) await existing.start();
           const screenUrl = await publishedScreenUrl(
@@ -724,6 +730,7 @@ function computerControlEndpoint(info: Docker.ContainerInspectInfo) {
     networkMode: info.HostConfig.NetworkMode,
     networks: info.NetworkSettings?.Networks,
     publishedHostPort,
+    requirePublishedHostPort: controlViaLoopback,
   });
 }
 

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -11,6 +11,7 @@ import Docker from "dockerode";
 import { Hono } from "hono";
 import { z } from "zod";
 import {
+  COMPUTER_CONTROL_PORT,
   COMPUTER_GID,
   COMPUTER_IMAGE,
   COMPUTER_UID,
@@ -72,6 +73,9 @@ let imageReady: Promise<void> | undefined;
 let supervisorInfo: Docker.ContainerInspectInfo | undefined;
 const supervisorToken = resolveSupervisorToken(process.env);
 const screenNetworkMode = resolveScreenNetworkMode(process.env.SANDBOX_SCREEN_NETWORK);
+// Host-run supervisors on Docker Desktop (macOS/Windows) cannot reach container
+// IPs, so computer control must use a published loopback port instead.
+const controlViaLoopback = process.env.SANDBOX_CONTROL_VIA_LOOPBACK === "true";
 const computerScreens = new Map<string, Map<string, ScreenAssignment>>();
 
 const app = new Hono();
@@ -179,6 +183,7 @@ app.post("/computers", async (c) => {
           user: computerUser,
           networkMode,
           controlToken: randomUUID(),
+          publishControlPort: controlViaLoopback,
         }),
       );
       await container.start();
@@ -711,10 +716,14 @@ function computerControlEndpoint(info: Docker.ContainerInspectInfo) {
   const token = info.Config.Env?.find((value) =>
     value.startsWith("RAKAZO_COMPUTER_CONTROL_TOKEN="),
   )?.slice("RAKAZO_COMPUTER_CONTROL_TOKEN=".length);
+  const publishedHostPort = controlViaLoopback
+    ? info.NetworkSettings?.Ports?.[`${COMPUTER_CONTROL_PORT}/tcp`]?.[0]?.HostPort
+    : undefined;
   return resolveComputerControlEndpoint({
     token,
     networkMode: info.HostConfig.NetworkMode,
     networks: info.NetworkSettings?.Networks,
+    publishedHostPort,
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**DO NOT REVIEW / DO NOT MERGE — opened by mistake.**

Close this PR. The Greptile/CodeRabbit follow-up must land on https://github.com/elie222/rakazo/pull/468 (`EchoBorn:fix/macos-host-supervisor-control`).

Head branch for this PR has been deleted again.

Agent cannot push to EchoBorn’s fork: #468 is closed, head ref deleted, `maintainer_can_modify=false` for this GitHub App token (`ghs_`), and `git push` to `EchoBorn/rakazo` is rejected. Fix commit ready for handoff: `6139d905bcea300173cffaafe83c064075e3bb68` on `elie222/rakazo` ref `cursor/pr468-fix-handoff-0bf9` (not a PR).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d36b9c6b-e529-4358-9b5e-0d5d34690bf9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d36b9c6b-e529-4358-9b5e-0d5d34690bf9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

