### PR TITLE
fix(chat): move message actions below bubbles

### DIFF
--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -7,6 +7,28 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   await completeOnboarding(page);
   await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
 
+  const transcript = page.getByTestId("transcript");
+  const botRow = transcript.locator(`[data-message-id]`).first();
+  await expect(botRow).toBeVisible();
+  await botRow.hover();
+  const botToolbar = botRow.getByTestId("message-hover-actions");
+  const botTime = botRow.locator("time");
+  await expect(botToolbar).toBeVisible();
+  await expect
+    .poll(async () => {
+      const toolbarBox = await botToolbar.boundingBox();
+      const timeBox = await botTime.boundingBox();
+      if (!toolbarBox || !timeBox) return null;
+      return toolbarBox.x + toolbarBox.width <= timeBox.x;
+    })
+    .toBe(true);
+  await botToolbar.evaluate((el) => {
+    const node = el as HTMLElement;
+    node.style.opacity = "1";
+    node.style.pointerEvents = "auto";
+  });
+  await captureScreenshot(page, testInfo, "message-bot-actions-desktop");
+
   const parentText = `hover-parent-${stamp}`;
   const replyText = `hover-reply-${stamp}`;
   const composer = page.getByRole("combobox", { name: /^Message/ });
@@ -14,7 +36,6 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   await composer.fill(parentText);
   await composer.press("Enter");
 
-  const transcript = page.getByTestId("transcript");
   const parentRow = transcript.locator(`[data-message-id]`).filter({ hasText: parentText }).first();
   await expect(parentRow).toBeVisible({ timeout: 20_000 });
 
@@ -103,6 +124,14 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
 
   await parentPreview.click();
   await expect(parentRow).toBeInViewport();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await botRow.scrollIntoViewIfNeeded();
+  await botRow.hover();
+  await captureScreenshot(page, testInfo, "message-bot-actions-mobile");
+  await parentRow.scrollIntoViewIfNeeded();
+  await parentRow.hover();
+  await captureScreenshot(page, testInfo, "message-user-actions-mobile");
 });
 
 test("reply preview jumps to parent outside the loaded page", async ({ page }) => {

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -28,6 +28,7 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
     node.style.pointerEvents = "auto";
   });
   await captureScreenshot(page, testInfo, "message-bot-actions-desktop");
+  await botToolbar.evaluate((el) => el.removeAttribute("style"));
 
   const parentText = `hover-parent-${stamp}`;
   const replyText = `hover-reply-${stamp}`;
@@ -91,6 +92,7 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
     path: hoverPath,
   });
   await testInfo.attach("message-hover-toolbar", { contentType: "image/png", path: hoverPath });
+  await toolbar.evaluate((el) => el.removeAttribute("style"));
 
   await thumbsUp.click();
   const reactionChip = parentRow
@@ -128,10 +130,14 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   await page.setViewportSize({ width: 390, height: 844 });
   await botRow.scrollIntoViewIfNeeded();
   await botRow.hover();
+  await botToolbar.evaluate((el) => el.setAttribute("style", "opacity:1;pointer-events:auto"));
   await captureScreenshot(page, testInfo, "message-bot-actions-mobile");
+  await botToolbar.evaluate((el) => el.removeAttribute("style"));
   await parentRow.scrollIntoViewIfNeeded();
   await parentRow.hover();
+  await toolbar.evaluate((el) => el.setAttribute("style", "opacity:1;pointer-events:auto"));
   await captureScreenshot(page, testInfo, "message-user-actions-mobile");
+  await toolbar.evaluate((el) => el.removeAttribute("style"));
 });
 
 test("reply preview jumps to parent outside the loaded page", async ({ page }) => {

--- a/apps/web/e2e/message-hover-actions.spec.ts
+++ b/apps/web/e2e/message-hover-actions.spec.ts
@@ -26,16 +26,20 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   const thumbsUp = toolbar.getByRole("button", { name: "Add thumbs-up" });
   await expect(thumbsUp).toBeVisible();
 
-  // Pill must float above the bubble text, not cover the first line.
+  // Pill must sit below the bubble text and align with its right edge.
   const bubble = parentRow.locator("div").filter({ hasText: parentText }).last();
   await expect
     .poll(async () => {
       const toolbarBox = await toolbar.boundingBox();
       const bubbleBox = await bubble.boundingBox();
       if (!toolbarBox || !bubbleBox) return null;
-      return toolbarBox.y + toolbarBox.height <= bubbleBox.y + 1;
+      return {
+        below: toolbarBox.y >= bubbleBox.y + bubbleBox.height - 1,
+        rightAligned:
+          Math.abs(toolbarBox.x + toolbarBox.width - (bubbleBox.x + bubbleBox.width)) <= 1,
+      };
     })
-    .toBe(true);
+    .toEqual({ below: true, rightAligned: true });
 
   // Keep the pill visible for the artifact (full-page shots can drop :hover).
   await toolbar.evaluate((el) => {
@@ -47,14 +51,16 @@ test("message hover shows Reply and Copy; reply links to parent", async ({ page 
   const bubbleBox = await bubble.boundingBox();
   if (!toolbarBox || !bubbleBox) throw new Error("missing hover toolbar geometry");
   const pad = 16;
+  const top = Math.min(toolbarBox.y, bubbleBox.y);
   const clip = {
     x: Math.max(0, Math.min(toolbarBox.x, bubbleBox.x) - pad),
-    y: Math.max(0, toolbarBox.y - pad),
+    y: Math.max(0, top - pad),
     width:
       Math.max(toolbarBox.x + toolbarBox.width, bubbleBox.x + bubbleBox.width) -
       Math.min(toolbarBox.x, bubbleBox.x) +
       pad * 2,
-    height: bubbleBox.y + bubbleBox.height - toolbarBox.y + pad * 2,
+    height:
+      Math.max(toolbarBox.y + toolbarBox.height, bubbleBox.y + bubbleBox.height) - top + pad * 2,
   };
   const hoverPath = testInfo.outputPath("message-hover-toolbar.png");
   await page.screenshot({

--- a/apps/web/src/components/MessageHoverMetadata.test.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.test.tsx
@@ -9,13 +9,13 @@ describe("MessageHoverMetadata", () => {
     i18n.activate("en");
   });
 
-  it("shows the message's creation time beside its actions on hover or focus", () => {
+  it("shows the message's creation time beside its actions below the message", () => {
     i18n.load("en", {});
     i18n.activate("en");
 
     const createdAt = new Date(2026, 7, 21, 18, 14).toISOString();
     const html = renderToStaticMarkup(
-      <MessageHoverMetadata createdAt={createdAt}>
+      <MessageHoverMetadata align="end" createdAt={createdAt}>
         <div data-testid="message-actions-pill" />
       </MessageHoverMetadata>,
     );
@@ -26,6 +26,23 @@ describe("MessageHoverMetadata", () => {
     expect(html.indexOf("<time")).toBeLessThan(html.indexOf('data-testid="message-actions-pill"'));
     expect(html).toContain("group-hover/message:opacity-100");
     expect(html).toContain("focus-within:opacity-100");
+    expect(html).toContain("bottom-0");
+    expect(html).toContain("end-0");
+    expect(html).not.toContain("top-0");
+  });
+
+  it("aligns bot metadata with the start of the message", () => {
+    i18n.load("en", {});
+    i18n.activate("en");
+
+    const html = renderToStaticMarkup(
+      <MessageHoverMetadata align="start" createdAt={new Date().toISOString()}>
+        <div data-testid="message-actions-pill" />
+      </MessageHoverMetadata>,
+    );
+
+    expect(html).toContain("start-0");
+    expect(html).not.toContain("end-0");
   });
 
   it("formats the displayed time with the active i18n locale", () => {
@@ -34,7 +51,7 @@ describe("MessageHoverMetadata", () => {
 
     const createdAt = new Date(2026, 7, 21, 18, 14).toISOString();
     const html = renderToStaticMarkup(
-      <MessageHoverMetadata createdAt={createdAt}>
+      <MessageHoverMetadata align="end" createdAt={createdAt}>
         <div data-testid="message-actions-pill" />
       </MessageHoverMetadata>,
     );

--- a/apps/web/src/components/MessageHoverMetadata.test.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.test.tsx
@@ -9,13 +9,13 @@ describe("MessageHoverMetadata", () => {
     i18n.activate("en");
   });
 
-  it("shows the message's creation time beside its actions below the message", () => {
+  it("shows user metadata below the message with the time before the actions", () => {
     i18n.load("en", {});
     i18n.activate("en");
 
     const createdAt = new Date(2026, 7, 21, 18, 14).toISOString();
     const html = renderToStaticMarkup(
-      <MessageHoverMetadata align="end" createdAt={createdAt}>
+      <MessageHoverMetadata actionsFirst={false} align="end" createdAt={createdAt}>
         <div data-testid="message-actions-pill" />
       </MessageHoverMetadata>,
     );
@@ -31,18 +31,19 @@ describe("MessageHoverMetadata", () => {
     expect(html).not.toContain("top-0");
   });
 
-  it("aligns bot metadata with the start of the message", () => {
+  it("aligns bot metadata with the start and puts actions before the time", () => {
     i18n.load("en", {});
     i18n.activate("en");
 
     const html = renderToStaticMarkup(
-      <MessageHoverMetadata align="start" createdAt={new Date().toISOString()}>
+      <MessageHoverMetadata actionsFirst align="start" createdAt={new Date().toISOString()}>
         <div data-testid="message-actions-pill" />
       </MessageHoverMetadata>,
     );
 
     expect(html).toContain("start-0");
     expect(html).not.toContain("end-0");
+    expect(html.indexOf('data-testid="message-actions-pill"')).toBeLessThan(html.indexOf("<time"));
   });
 
   it("formats the displayed time with the active i18n locale", () => {
@@ -51,7 +52,7 @@ describe("MessageHoverMetadata", () => {
 
     const createdAt = new Date(2026, 7, 21, 18, 14).toISOString();
     const html = renderToStaticMarkup(
-      <MessageHoverMetadata align="end" createdAt={createdAt}>
+      <MessageHoverMetadata actionsFirst={false} align="end" createdAt={createdAt}>
         <div data-testid="message-actions-pill" />
       </MessageHoverMetadata>,
     );

--- a/apps/web/src/components/MessageHoverMetadata.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.tsx
@@ -2,14 +2,18 @@ import { i18n } from "@lingui/core";
 import type { ReactNode } from "react";
 
 export function MessageHoverMetadata({
+  align,
   createdAt,
   children,
 }: {
+  align: "start" | "end";
   createdAt: string;
   children: ReactNode;
 }) {
   return (
-    <div className="pointer-events-none absolute end-0 top-0 z-10 flex items-center gap-1.5 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+    <div
+      className={`pointer-events-none absolute bottom-0 z-10 flex items-center gap-1.5 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 ${align === "start" ? "start-0" : "end-0"}`}
+    >
       <time dateTime={createdAt} className="text-[11px] tabular-nums text-[#85858A]">
         {new Date(createdAt).toLocaleTimeString(i18n.locale || "en", {
           hour: "numeric",

--- a/apps/web/src/components/MessageHoverMetadata.tsx
+++ b/apps/web/src/components/MessageHoverMetadata.tsx
@@ -2,10 +2,12 @@ import { i18n } from "@lingui/core";
 import type { ReactNode } from "react";
 
 export function MessageHoverMetadata({
+  actionsFirst,
   align,
   createdAt,
   children,
 }: {
+  actionsFirst: boolean;
   align: "start" | "end";
   createdAt: string;
   children: ReactNode;
@@ -14,13 +16,14 @@ export function MessageHoverMetadata({
     <div
       className={`pointer-events-none absolute bottom-0 z-10 flex items-center gap-1.5 opacity-0 transition-opacity group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 ${align === "start" ? "start-0" : "end-0"}`}
     >
+      {actionsFirst ? children : null}
       <time dateTime={createdAt} className="text-[11px] tabular-nums text-[#85858A]">
         {new Date(createdAt).toLocaleTimeString(i18n.locale || "en", {
           hour: "numeric",
           minute: "2-digit",
         })}
       </time>
-      {children}
+      {actionsFirst ? null : children}
     </div>
   );
 }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4860,6 +4860,7 @@ function MessageHoverActions({
 
   return (
     <MessageHoverMetadata
+      actionsFirst={message.role === "bot"}
       align={message.role === "bot" ? "start" : "end"}
       createdAt={message.createdAt}
     >

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4040,7 +4040,7 @@ const Transcript = memo(function Transcript({
             <div
               key={message.id}
               data-message-id={message.id}
-              className={peerReceipt ? "relative py-0.5" : "group/message relative pt-9 hover:z-20"}
+              className={peerReceipt ? "relative py-0.5" : "group/message relative pb-9 hover:z-20"}
             >
               {peerReceipt ? null : (
                 <MessageHoverActions message={message} onReply={onReply} onReact={onReact} />
@@ -4859,7 +4859,10 @@ function MessageHoverActions({
   }
 
   return (
-    <MessageHoverMetadata createdAt={message.createdAt}>
+    <MessageHoverMetadata
+      align={message.role === "bot" ? "start" : "end"}
+      createdAt={message.createdAt}
+    >
       <div
         data-testid="message-hover-actions"
         className="flex items-center gap-0.5 rounded-full bg-[#1C1C1F] p-0.5 shadow-[0_1px_4px_rgba(0,0,0,0.45)]"


### PR DESCRIPTION
## Summary
- move message timestamps and action pills below each message
- keep user metadata right-aligned and bot metadata left-aligned
- update the hover-action E2E geometry assertion and screenshot crop

## Verification
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web build`
- `pnpm test:e2e -- --spec=message-hover-actions.spec.ts` (2 passed)
- `pnpm exec vitest run --maxWorkers=5 --exclude apps/web/src/lib/i18n-catalog.test.ts` (2264 passed, 109 skipped)
- direct Biome check of changed files and full repository (passes; existing warnings only)

## Known baseline
- The full unit command has one unrelated failure in `apps/web/src/lib/i18n-catalog.test.ts` for an uncompiled German ICU message; the same focused test fails on untouched `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message hover metadata positioning so it appears below message bubbles.
  * Aligned metadata with the appropriate edge of each message bubble.
  * Adjusted the order of timestamps and action buttons for user and bot messages.
  * Updated hover-action behavior and screenshot coverage across desktop and mobile layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->