### PR TITLE
Keep connector tools when one toolkit exceeds Composio's preload cap

### DIFF
--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -22,6 +22,7 @@ import { DestinationEmulator } from "./destination-emulator.js";
 const composioSdkState = vi.hoisted(() => ({
   created: [] as Array<{ userId: string; config: Record<string, unknown> }>,
   directoryFails: false,
+  toolkitsPerSessionCap: null as number | null,
   executions: [] as Array<{ tool: string; args: Record<string, unknown> }>,
   sessions: new Map<
     string,
@@ -83,6 +84,15 @@ vi.mock("@composio/core", () => ({
         };
         composioSdkState.sessions.set(session.sessionId, session);
         return session;
+      }
+
+      if (
+        composioSdkState.toolkitsPerSessionCap !== null &&
+        toolkits.length > composioSdkState.toolkitsPerSessionCap
+      ) {
+        throw new Error(
+          '400 {"error":{"message":"preload.tools=\\"all\\" supports up to 1000 tools. Narrow the toolkits/tools/tags scope and try again.","code":4300,"slug":"ToolRouterV2_BadRequest","status":400}}',
+        );
       }
 
       const scopedToCanonicalGithub = toolkits.includes("GITHUB");
@@ -446,5 +456,35 @@ describe("Composio during pnpm test", () => {
   it("does not construct a live Platform client under Vitest", () => {
     expect(process.env.VITEST).toBeTruthy();
     expect(isComposioEnabled("ck_must_not_call_live")).toBe(false);
+  });
+});
+
+describe("composio tool preload cap", () => {
+  it("drops trailing toolkits until Composio accepts the session", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.toolkitsPerSessionCap = 1;
+    try {
+      const connector = new ComposioConnector();
+      const session = await connector.sessionForExecute("user-1", ["github", "linear", "slack"]);
+      expect(session.sessionId).toBe("github-session");
+      const attempted = composioSdkState.created
+        .filter((entry) => Array.isArray(entry.config.toolkits))
+        .map((entry) => (entry.config.toolkits as string[]).length);
+      expect(attempted).toEqual([3, 2, 1]);
+    } finally {
+      composioSdkState.toolkitsPerSessionCap = null;
+    }
+  });
+
+  it("rethrows when a single toolkit still exceeds the cap", async () => {
+    composioSdkState.toolkitsPerSessionCap = 0;
+    try {
+      const connector = new ComposioConnector();
+      await expect(connector.sessionForExecute("user-1", ["github"])).rejects.toThrow(
+        /ToolRouterV2_BadRequest/,
+      );
+    } finally {
+      composioSdkState.toolkitsPerSessionCap = null;
+    }
   });
 });

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -224,13 +224,40 @@ export class ComposioConnector implements ComposioProvider {
         this.executeSessions.delete(userId);
       }
     }
-    const session = await composio.create(userId, {
-      manageConnections: false,
-      sandbox: { enable: false },
-      toolkits: canonicalToolkits,
-    });
+    const session = await this.createSessionWithinToolCap(userId, canonicalToolkits);
     this.executeSessions.set(userId, { sessionId: session.sessionId, key });
     return session;
+  }
+
+  /** Composio refuses a session whose toolkits preload more than 1000 tools, and a single
+   * large toolkit can exceed that on its own. The request is all-or-nothing, so without this
+   * one oversized toolkit costs every other connected app its tools. Drop trailing toolkits
+   * until Composio accepts the session and name what was left out. */
+  private async createSessionWithinToolCap(
+    userId: string,
+    toolkits: string[],
+  ): Promise<ComposioSession> {
+    const composio = this.sdk();
+    let attempt = toolkits;
+    for (;;) {
+      try {
+        const session = await composio.create(userId, {
+          manageConnections: false,
+          sandbox: { enable: false },
+          toolkits: attempt,
+        });
+        if (attempt.length !== toolkits.length) {
+          console.error(
+            "composio toolkits exceeded the tool preload cap; excluded",
+            toolkits.slice(attempt.length).join(", "),
+          );
+        }
+        return session;
+      } catch (error) {
+        if (attempt.length <= 1 || !isToolPreloadCapError(error)) throw error;
+        attempt = attempt.slice(0, -1);
+      }
+    }
   }
 
   async catalog(context: AdapterContext, query?: string): Promise<ConnectorCatalogItem[]> {
@@ -480,6 +507,12 @@ function isManagedConnectorProvider(
     typeof candidate.listConnectedExternalIds === "function" &&
     typeof candidate.revoke === "function"
   );
+}
+
+/** Composio reports the per-session tool preload ceiling as a ToolRouterV2_BadRequest. */
+function isToolPreloadCapError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("ToolRouterV2_BadRequest") || message.includes("supports up to 1000");
 }
 
 function connectedComposioExternalIds(context: AdapterContext): string[] {


### PR DESCRIPTION
## Problem

Composio refuses a session whose toolkits preload more than 1000 tools:

```
400 {"error":{"message":"preload.tools=\"all\" supports up to 1000 tools. Narrow the
toolkits/tools/tags scope and try again.","code":4300,"slug":"ToolRouterV2_BadRequest"}}
```

`sessionForExecute` asks for every connected toolkit in one call, and the request is all-or-nothing. A single large toolkit can blow the ceiling by itself, so connecting one app silently costs **every** other connected app its tools.

Measured against a live workspace, one toolkit per session:

| toolkit | tools |
|---|---|
| github | 871 |
| slack | 158 |
| gmail | 61 |
| notion | 53 |
| linear | 46 |
| googlecalendar | 45 |
| **total** | **1234** |

Connecting GitHub took the workspace from 363 working tools to zero. The failure is quiet from the operator's side: `connections` rows still read `connected`, the plugins panel still shows the apps, and the agent's system prompt still lists them under "Connected plugins", but no plugin tool reaches the model. The only trace is the single line from `ConnectorRegistry.discoverTools`'s catch, which names the connector but not which toolkit is responsible.

I found this only by re-running discovery with that catch removed.

## Fix

Drop trailing toolkits until Composio accepts the session, and log which ones were excluded. Partial tools beat none, and the log line tells the operator to narrow scope deliberately rather than guessing.

The session cache key still reflects the *requested* toolkits, so a later identical request reuses the reduced session instead of re-attempting the rejected one every turn.

Applying it to `sessionForExecute` rather than to `discoverTools` keeps discovery and execution on the same session, so a tool that is discovered is also callable.

## Tradeoff worth a maintainer's opinion

Dropping from the end is deterministic but arbitrary — it follows connection order, not toolkit size, so the app that loses out may not be the oversized one. Dropping the *largest* would need a tool count per toolkit that isn't known before session creation. I kept the simple version and made the exclusion loud rather than guessing at a smarter policy; happy to change it if you would rather it probe sizes, or surface the condition in the UI instead of the log.

## Tests

`composio tool preload cap` in `composio-connector.test.ts`, using the existing `@composio/core` mock with a configurable ceiling: one test asserts the retry sequence (3 → 2 → 1 toolkits) and one asserts a single over-cap toolkit still throws rather than looping. The first fails on `main`.

`pnpm test`, `pnpm check`, and `biome check` are clean. Unrelated: `voice-http.test.ts > voiceDeadline` is flaky on `main` for me (failed 1 of 3 runs, untouched by this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execute-session creation when the selected toolkits exceed the platform’s per-session limit.
  * Automatically removes trailing toolkits and retries until a valid session can be created.
  * Provides clearer handling when an individual toolkit still exceeds the allowed limit, while preserving the original error.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->