### PR TITLE
feat: reconnect in place and classify self-host origins

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@rakazo/contracts": "workspace:*",
+    "@rakazo/core": "workspace:*",
     "electron-updater": "^6.8.9"
   },
   "devDependencies": {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -26,6 +26,7 @@ import {
   safeExternalUrl,
   servesBundledRenderer,
   sessionPartitionForServerUrl,
+  setupReachabilityDetail,
 } from "./setup-config.js";
 import { clearSetup, readSetup, writeSetup } from "./setup-store.js";
 import { shouldOpenInAppPopup } from "./window-open.js";
@@ -599,6 +600,11 @@ function fromSetupWindow(event: Electron.IpcMainInvokeEvent) {
   );
 }
 
+function withReachabilityDetail(url: string, error: string): string {
+  const detail = setupReachabilityDetail(url);
+  return detail ? `${error} ${detail}` : error;
+}
+
 async function probeServer(rawUrl: string): Promise<DesktopReachability> {
   const url = normalizeServerUrl(rawUrl);
   if (url === null) return { ok: false, error: "Enter a valid http:// or https:// address." };
@@ -618,7 +624,10 @@ async function probeServer(rawUrl: string): Promise<DesktopReachability> {
         ok: false,
         status: response.status,
         url,
-        error: "That address redirects elsewhere. Enter the final Rakazo server address.",
+        error: withReachabilityDetail(
+          url,
+          "That address redirects elsewhere. Enter the final Rakazo server address.",
+        ),
       };
     }
     if (!response.ok) {
@@ -626,7 +635,7 @@ async function probeServer(rawUrl: string): Promise<DesktopReachability> {
         ok: false,
         status: response.status,
         url,
-        error: `The server answered with HTTP ${response.status}.`,
+        error: withReachabilityDetail(url, `The server answered with HTTP ${response.status}.`),
       };
     }
     const health = await limitedJson(response);
@@ -635,16 +644,18 @@ async function probeServer(rawUrl: string): Promise<DesktopReachability> {
         ok: false,
         status: response.status,
         url,
-        error: "That address did not respond like a Rakazo server.",
+        error: withReachabilityDetail(url, "That address did not respond like a Rakazo server."),
       };
     }
+    const detail = setupReachabilityDetail(url, { includeHint: false }) ?? undefined;
     return {
       ok: true,
       status: response.status,
       url,
+      detail,
     };
   } catch (error) {
-    return { ok: false, url, error: probeFailureMessage(error) };
+    return { ok: false, url, error: withReachabilityDetail(url, probeFailureMessage(error)) };
   }
 }
 

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -42,6 +42,14 @@ describe("server address normalization", () => {
     expect(normalizeServerUrl("http://[fd00::1]:3100")).toBe("http://[fd00::1]:3100");
   });
 
+  it("permits overlay CGNAT HTTP and requires HTTPS for MagicDNS", () => {
+    expect(normalizeServerUrl("http://100.64.0.1:3100")).toBe("http://100.64.0.1:3100");
+    expect(normalizeServerUrl("100.64.1.8:5173")).toBe("http://100.64.1.8:5173");
+    expect(normalizeServerUrl("http://machine.ts.net")).toBeNull();
+    expect(normalizeServerUrl("machine.ts.net")).toBe("https://machine.ts.net");
+    expect(normalizeServerUrl("https://box.tail12345.ts.net")).toBe("https://box.tail12345.ts.net");
+  });
+
   it("rejects cleartext link-local addresses used by cloud metadata endpoints", () => {
     expect(normalizeServerUrl("http://169.254.169.254")).toBeNull();
     expect(normalizeServerUrl("http://169.254.1.1:80")).toBeNull();

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -11,6 +11,7 @@ import {
   serializeSetup,
   servesBundledRenderer,
   sessionPartitionForServerUrl,
+  setupReachabilityDetail,
 } from "./setup-config.js";
 
 describe("server address normalization", () => {
@@ -202,5 +203,16 @@ describe("probe failures", () => {
     ["something else entirely", "Could not reach that address."],
   ])("explains %s", (message, expected) => {
     expect(probeFailureMessage(new Error(message))).toBe(expected);
+  });
+
+  it("appends origin class and overlay hints", () => {
+    expect(setupReachabilityDetail("https://app.example.com")).toBe(
+      "app.example.com · https · public",
+    );
+    expect(setupReachabilityDetail("http://machine.ts.net")).toMatch(/MagicDNS/);
+    expect(setupReachabilityDetail("http://100.64.0.1:3100")).toMatch(/private overlay/);
+    expect(setupReachabilityDetail("https://machine.ts.net", { includeHint: false })).toBe(
+      "machine.ts.net · https · private overlay",
+    );
   });
 });

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -43,9 +43,10 @@ describe("server address normalization", () => {
     expect(normalizeServerUrl("http://[fd00::1]:3100")).toBe("http://[fd00::1]:3100");
   });
 
-  it("permits overlay CGNAT HTTP and requires HTTPS for MagicDNS", () => {
-    expect(normalizeServerUrl("http://100.64.0.1:3100")).toBe("http://100.64.0.1:3100");
-    expect(normalizeServerUrl("100.64.1.8:5173")).toBe("http://100.64.1.8:5173");
+  it("requires HTTPS for overlay CGNAT and MagicDNS", () => {
+    expect(normalizeServerUrl("http://100.64.0.1:3100")).toBeNull();
+    expect(normalizeServerUrl("100.64.1.8:5173")).toBe("https://100.64.1.8:5173");
+    expect(normalizeServerUrl("https://100.64.0.1:3100")).toBe("https://100.64.0.1:3100");
     expect(normalizeServerUrl("http://machine.ts.net")).toBeNull();
     expect(normalizeServerUrl("machine.ts.net")).toBe("https://machine.ts.net");
     expect(normalizeServerUrl("https://box.tail12345.ts.net")).toBe("https://box.tail12345.ts.net");
@@ -210,7 +211,8 @@ describe("probe failures", () => {
       "app.example.com · https · public",
     );
     expect(setupReachabilityDetail("http://machine.ts.net")).toMatch(/MagicDNS/);
-    expect(setupReachabilityDetail("http://100.64.0.1:3100")).toMatch(/private overlay/);
+    expect(setupReachabilityDetail("http://100.64.0.1:3100")).toMatch(/Overlay IPs need https/);
+    expect(setupReachabilityDetail("https://100.64.0.1:3100")).toMatch(/private overlay/);
     expect(setupReachabilityDetail("https://machine.ts.net", { includeHint: false })).toBe(
       "machine.ts.net · https · private overlay",
     );

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { isIP } from "node:net";
 import type { DesktopSetup } from "@rakazo/contracts";
+import { allowsCleartextHttp, isLoopbackHost } from "@rakazo/core";
 
 /** Where `pnpm dev` serves the Rakazo web app on this machine. */
 export const DEFAULT_LOCAL_WEB_URL = "http://127.0.0.1:5173";
@@ -28,7 +28,7 @@ export function normalizeServerUrl(input: string): string | null {
       url = new URL(trimmed);
     } else {
       const candidate = new URL(`http://${trimmed}`);
-      url = isLocalNetworkHost(candidate.hostname) ? candidate : new URL(`https://${trimmed}`);
+      url = allowsCleartextHttp(candidate.hostname) ? candidate : new URL(`https://${trimmed}`);
     }
   } catch {
     return null;
@@ -39,7 +39,7 @@ export function normalizeServerUrl(input: string): string | null {
   // Embedded credentials would be written to disk in cleartext.
   if (url.username !== "" || url.password !== "") return null;
   // Public login cookies and API traffic must never cross a cleartext connection.
-  if (url.protocol === "http:" && !isLocalNetworkHost(url.hostname)) return null;
+  if (url.protocol === "http:" && !allowsCleartextHttp(url.hostname)) return null;
 
   // Rakazo serves its renderer, RPC, and auth routes from one origin. Keeping a
   // user-supplied path would make the setup probe and the loaded app disagree.
@@ -151,55 +151,4 @@ export function isRakazoHealth(value: unknown): boolean {
     (json as { ok?: unknown }).ok === true &&
     typeof (json as { version?: unknown }).version === "string"
   );
-}
-
-function isLoopbackHost(hostname: string) {
-  const host = unbracketedHost(hostname);
-  if (host === "localhost" || host.endsWith(".localhost")) return true;
-  if (isIP(host) === 4) return host.startsWith("127.");
-  return isIP(host) === 6 && host === "::1";
-}
-
-/**
- * Link-local addresses (IPv4 169.254/16, IPv6 fe80::/10) often host cloud
- * metadata endpoints. Cleartext HTTP to them is never a legitimate Rakazo
- * deploy target, so they stay out of the private-network HTTP allowlist.
- */
-function isLinkLocalHost(hostname: string) {
-  const host = unbracketedHost(hostname);
-  if (isIP(host) === 4) {
-    const [first, second] = host.split(".").map(Number);
-    return first === 169 && second === 254;
-  }
-  if (isIP(host) === 6) {
-    const first = host.split(":", 1)[0] ?? "";
-    return /^fe[89ab]/.test(first);
-  }
-  return false;
-}
-
-function isLocalNetworkHost(hostname: string) {
-  const host = unbracketedHost(hostname);
-  if (isLoopbackHost(host) || host.endsWith(".local")) return true;
-  if (isLinkLocalHost(host)) return false;
-
-  if (isIP(host) === 4) {
-    const [first, second] = host.split(".").map(Number);
-    return (
-      first === 10 ||
-      (first === 172 && second !== undefined && second >= 16 && second <= 31) ||
-      (first === 192 && second === 168)
-    );
-  }
-
-  if (isIP(host) === 6) {
-    const first = host.split(":", 1)[0] ?? "";
-    // Unique-local only (fc00::/7). Link-local is rejected above.
-    return /^f[cd]/.test(first);
-  }
-  return false;
-}
-
-function unbracketedHost(hostname: string) {
-  return hostname.replace(/^\[|\]$/g, "").toLowerCase();
 }

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -1,6 +1,11 @@
 import { createHash } from "node:crypto";
 import type { DesktopSetup } from "@rakazo/contracts";
-import { allowsCleartextHttp, isLoopbackHost } from "@rakazo/core";
+import {
+  allowsCleartextHttp,
+  connectionHintForOrigin,
+  describeConnectionOrigin,
+  isLoopbackHost,
+} from "@rakazo/core";
 
 /** Where `pnpm dev` serves the Rakazo web app on this machine. */
 export const DEFAULT_LOCAL_WEB_URL = "http://127.0.0.1:5173";
@@ -112,6 +117,16 @@ export function probeFailureMessage(error: unknown): string {
     return "The server's HTTPS certificate was rejected.";
   }
   return "Could not reach that address.";
+}
+
+export function setupReachabilityDetail(
+  url: string,
+  options?: { includeHint?: boolean },
+): string | null {
+  const summary = describeConnectionOrigin(url);
+  const hint = options?.includeHint === false ? null : connectionHintForOrigin(url);
+  if (summary && hint) return `${summary}. ${hint}`;
+  return hint ?? summary;
 }
 
 /** The bundled renderer only stands in for a real http(s) origin. */

--- a/apps/desktop/src/setup.js
+++ b/apps/desktop/src/setup.js
@@ -51,7 +51,12 @@
       const result = await bridge.test(value);
       if (result.ok) {
         activeField().value = result.url;
-        setStatus(`Rakazo answered at ${result.url}.`, "ok");
+        setStatus(
+          result.detail
+            ? `Rakazo answered at ${result.url} (${result.detail}).`
+            : `Rakazo answered at ${result.url}.`,
+          "ok",
+        );
       } else {
         setStatus(result.error ?? "Could not reach that address.", "error");
       }

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -15,6 +15,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import {
+  apiBaseSummary,
   apiBaseWarning,
   currentApiBase,
   defaultApiBase,
@@ -347,6 +348,7 @@ function ServerSheet({
 
   const parsedDraft = normalizeApiBase(draft);
   const warning = parsedDraft.ok ? apiBaseWarning(parsedDraft.url) : null;
+  const summary = parsedDraft.ok ? apiBaseSummary(parsedDraft.url) : null;
 
   async function save() {
     setPending(true);
@@ -440,8 +442,13 @@ function ServerSheet({
               fontSize: 16,
             }}
           />
+          {summary ? (
+            <Text style={{ color: "#8C8C86", marginTop: 12, fontSize: 13 }}>{summary}</Text>
+          ) : null}
           {warning ? (
-            <Text style={{ color: "#8C8C86", marginTop: 12, fontSize: 13 }}>{warning}</Text>
+            <Text style={{ color: "#8C8C86", marginTop: summary ? 6 : 12, fontSize: 13 }}>
+              {warning}
+            </Text>
           ) : null}
           {error ? <Text style={{ color: "#B91C1C", marginTop: 12 }}>{error}</Text> : null}
           {usesCustomApiBase(current) || draft.trim() !== current ? (

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -93,7 +93,7 @@ import {
   pickFromLibrary,
   takePhoto,
 } from "../lib/pick-attachments";
-import { threadRefreshDelayMs } from "../lib/refresh";
+import { subscribeRetryDelayMs } from "../lib/refresh";
 import {
   type ThreadScrollAction,
   ThreadScrollBehavior,
@@ -725,7 +725,7 @@ function Thread() {
           });
       if (abort.signal.aborted) return;
       let cursor = next?.cursor ?? -1;
-      let retryMs = 250;
+      let retryAttempt = 0;
       while (!abort.signal.aborted) {
         try {
           await subscribeThread(
@@ -733,7 +733,7 @@ function Thread() {
             cursor,
             (event) => {
               cursor = Math.max(cursor, event.seq ?? -1);
-              retryMs = 250;
+              retryAttempt = 0;
               if (
                 event.type === "thread.progress" ||
                 event.type === "agent.tool.called" ||
@@ -771,38 +771,14 @@ function Thread() {
         if (!jumpScrollTarget.current && !expandedHistoryThread.current) {
           await refresh().catch(() => undefined);
         }
-        await abortableDelay(retryMs, abort.signal);
-        retryMs = Math.min(retryMs * 2, 5_000);
+        await abortableDelay(subscribeRetryDelayMs(retryAttempt), abort.signal);
+        retryAttempt += 1;
       }
     })();
     return () => {
       abort.abort();
     };
   }, [botId, groupId, markReadIfVisible]);
-
-  useEffect(() => {
-    if (!botId && !groupId) return;
-    let cancelled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const tick = async () => {
-      if (
-        AppState.currentState === "active" &&
-        navigation.isFocused() &&
-        !jumpScrollTarget.current &&
-        !expandedHistoryThread.current
-      ) {
-        await refresh().catch(() => undefined);
-      }
-      if (!cancelled) {
-        timer = setTimeout(() => void tick(), threadRefreshDelayMs(snap?.run?.status));
-      }
-    };
-    timer = setTimeout(() => void tick(), threadRefreshDelayMs(snap?.run?.status));
-    return () => {
-      cancelled = true;
-      if (timer !== undefined) clearTimeout(timer);
-    };
-  }, [botId, groupId, navigation, snap?.run?.status]);
 
   useEffect(() => {
     if ((!botId && !groupId) || !messageId) return;

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -59,6 +59,8 @@ describe("Android mobile platform contract", () => {
     expect(allowlist).toContain("isAllowedNotificationEndpoint");
     expect(allowlist).toContain('scheme == "https"');
     expect(allowlist).toContain("isLanOrLocalHost");
+    expect(allowlist).toContain("allowsCleartextHttp");
+    expect(allowlist).toContain("12[0-7]");
     expect(live).toContain("normalizeApiBase(endpoint)");
     expect(live).toMatch(
       /export async function resumeLiveNotifications[\s\S]*normalizeApiBase\(endpoint\)[\s\S]*nativeNotifications\.resume\(parsed\.url/,

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -60,7 +60,9 @@ describe("Android mobile platform contract", () => {
     expect(allowlist).toContain('scheme == "https"');
     expect(allowlist).toContain("isLanOrLocalHost");
     expect(allowlist).toContain("allowsCleartextHttp");
-    expect(allowlist).toContain("12[0-7]");
+    // CGNAT 100.64/10 is HTTPS-only (same as packages/core); do not allow cleartext.
+    expect(allowlist).toContain("CGNAT");
+    expect(allowlist).not.toContain("12[0-7]");
     expect(live).toContain("normalizeApiBase(endpoint)");
     expect(live).toMatch(
       /export async function resumeLiveNotifications[\s\S]*normalizeApiBase\(endpoint\)[\s\S]*nativeNotifications\.resume\(parsed\.url/,

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -761,7 +761,7 @@ describe("mobile thread subscription", () => {
     }
   });
 
-  it("does not treat SSE comments as activity for the idle timeout", async () => {
+  it("does not treat SSE keepalives as activity for the idle timeout", async () => {
     vi.useFakeTimers();
     vi.stubGlobal(
       "fetch",
@@ -769,7 +769,11 @@ describe("mobile thread subscription", () => {
         const signal = init?.signal as AbortSignal | undefined;
         const stream = new ReadableStream<Uint8Array>({
           start(controller) {
-            controller.enqueue(new TextEncoder().encode(": keepalive\n\n"));
+            const encoder = new TextEncoder();
+            controller.enqueue(encoder.encode(": keepalive\n\n"));
+            controller.enqueue(encoder.encode("data: \n\n"));
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.enqueue(encoder.encode("data: not-json\n\n"));
             const fail = () =>
               controller.error(
                 signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -730,6 +730,37 @@ describe("mobile thread subscription", () => {
     );
   });
 
+  it("aborts a silent open stream after the idle timeout", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url, init) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            // Hang until the subscribe idle/parent signal aborts, then error the body
+            // so reader.read() rejects the same way a real aborted fetch would.
+            const fail = () =>
+              controller.error(
+                signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+              );
+            if (signal?.aborted) fail();
+            else signal?.addEventListener("abort", fail, { once: true });
+          },
+        });
+        return new Response(stream, { status: 200 });
+      }),
+    );
+    try {
+      const done = subscribeThread({ botId: "bot-1" }, -1, vi.fn(), new AbortController().signal, 1_000);
+      const expectation = expect(done).rejects.toMatchObject({ name: "AbortError" });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects responses that are unsuccessful or have no stream body", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -752,7 +752,13 @@ describe("mobile thread subscription", () => {
       }),
     );
     try {
-      const done = subscribeThread({ botId: "bot-1" }, -1, vi.fn(), new AbortController().signal, 1_000);
+      const done = subscribeThread(
+        { botId: "bot-1" },
+        -1,
+        vi.fn(),
+        new AbortController().signal,
+        1_000,
+      );
       const expectation = expect(done).rejects.toMatchObject({ name: "AbortError" });
       await vi.advanceTimersByTimeAsync(1_000);
       await expectation;

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -761,6 +761,42 @@ describe("mobile thread subscription", () => {
     }
   });
 
+  it("does not treat SSE comments as activity for the idle timeout", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url, init) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(": keepalive\n\n"));
+            const fail = () =>
+              controller.error(
+                signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+              );
+            if (signal?.aborted) fail();
+            else signal?.addEventListener("abort", fail, { once: true });
+          },
+        });
+        return new Response(stream, { status: 200 });
+      }),
+    );
+    try {
+      const done = subscribeThread(
+        { botId: "bot-1" },
+        -1,
+        vi.fn(),
+        new AbortController().signal,
+        1_000,
+      );
+      const expectation = expect(done).rejects.toMatchObject({ name: "AbortError" });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expectation;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects responses that are unsuccessful or have no stream body", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -631,7 +631,6 @@ export async function subscribeThread(
     while (!idle.signal.aborted) {
       const { done, value } = await reader.read();
       if (done) break;
-      bumpIdle();
       buffer += decoder.decode(value, { stream: true });
       const chunks = buffer.split("\n\n");
       buffer = chunks.pop() ?? "";
@@ -644,7 +643,10 @@ export async function subscribeThread(
         if (!data || data === "[DONE]") continue;
         try {
           const parsed = JSON.parse(data) as { json?: ThreadEvent; error?: { message?: string } };
-          if (parsed.json?.type) onEvent(parsed.json);
+          if (parsed.json?.type) {
+            bumpIdle();
+            onEvent(parsed.json);
+          }
         } catch {
           // ignore keepalives and partial frames
         }

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -795,6 +795,7 @@ export function applyMobileThreadEvent(
 }
 
 export {
+  apiBaseSummary,
   apiBaseWarning,
   defaultApiBase,
   displayApiHost,

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -23,6 +23,7 @@ import {
 import * as SecureStore from "expo-secure-store";
 import { defaultApiBase, type EndpointResult, normalizeApiBase } from "./endpoint";
 import { resumeLiveNotifications } from "./live-notifications";
+import { SUBSCRIBE_IDLE_TIMEOUT_MS } from "./refresh";
 import {
   clearSessionToken,
   loadSessionToken,
@@ -31,7 +32,6 @@ import {
   snapshotSessionToken,
   tokenFromAuthResponse,
 } from "./session";
-import { SUBSCRIBE_IDLE_TIMEOUT_MS } from "./refresh";
 
 const ENDPOINT_KEY = "rakazo.api_base";
 const SPACE_KEY = "rakazo.space_id";

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -31,6 +31,7 @@ import {
   snapshotSessionToken,
   tokenFromAuthResponse,
 } from "./session";
+import { SUBSCRIBE_IDLE_TIMEOUT_MS } from "./refresh";
 
 const ENDPOINT_KEY = "rakazo.api_base";
 const SPACE_KEY = "rakazo.space_id";
@@ -588,42 +589,74 @@ export async function subscribeThread(
   cursor: number,
   onEvent: (event: ThreadEvent) => void,
   signal: AbortSignal,
+  idleTimeoutMs: number = SUBSCRIBE_IDLE_TIMEOUT_MS,
 ) {
-  const res = await fetch(`${currentApiBase()}/rpc/threads/subscribe`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      accept: "text/event-stream",
-      origin: "rakazo://",
-      ...(await authHeaders()),
-    },
-    body: JSON.stringify({ json: { ...target, cursor } }),
-    signal,
-  });
-  if (!res.ok || !res.body) throw new Error(`rpc threads/subscribe failed (${res.status})`);
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  while (!signal.aborted) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    const chunks = buffer.split("\n\n");
-    buffer = chunks.pop() ?? "";
-    for (const chunk of chunks) {
-      const data = chunk
-        .split("\n")
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice(5).trim())
-        .join("");
-      if (!data || data === "[DONE]") continue;
-      try {
-        const parsed = JSON.parse(data) as { json?: ThreadEvent; error?: { message?: string } };
-        if (parsed.json?.type) onEvent(parsed.json);
-      } catch {
-        // ignore keepalives and partial frames
+  const idle = new AbortController();
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  const clearIdle = () => {
+    if (idleTimer !== undefined) clearTimeout(idleTimer);
+    idleTimer = undefined;
+  };
+  const bumpIdle = () => {
+    clearIdle();
+    if (idleTimeoutMs <= 0 || idle.signal.aborted) return;
+    idleTimer = setTimeout(() => idle.abort(), idleTimeoutMs);
+  };
+  const onParentAbort = () => {
+    clearIdle();
+    idle.abort();
+  };
+  if (signal.aborted) {
+    idle.abort();
+  } else {
+    signal.addEventListener("abort", onParentAbort, { once: true });
+    bumpIdle();
+  }
+  try {
+    const res = await fetch(`${currentApiBase()}/rpc/threads/subscribe`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        origin: "rakazo://",
+        ...(await authHeaders()),
+      },
+      body: JSON.stringify({ json: { ...target, cursor } }),
+      signal: idle.signal,
+    });
+    if (!res.ok || !res.body) throw new Error(`rpc threads/subscribe failed (${res.status})`);
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!idle.signal.aborted) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bumpIdle();
+      buffer += decoder.decode(value, { stream: true });
+      const chunks = buffer.split("\n\n");
+      buffer = chunks.pop() ?? "";
+      for (const chunk of chunks) {
+        const data = chunk
+          .split("\n")
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice(5).trim())
+          .join("");
+        if (!data || data === "[DONE]") continue;
+        try {
+          const parsed = JSON.parse(data) as { json?: ThreadEvent; error?: { message?: string } };
+          if (parsed.json?.type) onEvent(parsed.json);
+        } catch {
+          // ignore keepalives and partial frames
+        }
       }
     }
+    if (idle.signal.aborted && !signal.aborted) {
+      await reader.cancel().catch(() => undefined);
+      throw new DOMException("SSE idle timeout", "AbortError");
+    }
+  } finally {
+    clearIdle();
+    signal.removeEventListener("abort", onParentAbort);
   }
 }
 

--- a/apps/mobile/lib/endpoint.test.ts
+++ b/apps/mobile/lib/endpoint.test.ts
@@ -79,6 +79,8 @@ describe("display and warnings", () => {
     expect(apiBaseWarning("http://100.119.57.55:3100")).toBeNull();
     expect(apiBaseWarning("http://100.127.255.255:3100")).toBeNull();
     expect(apiBaseWarning("http://app.example.com")).toMatch(/https/i);
+    expect(apiBaseWarning("http://machine.ts.net")).toMatch(/https/i);
+    expect(apiBaseWarning("https://machine.ts.net")).toBeNull();
   });
 
   it("treats the compile-time default as not custom", () => {

--- a/apps/mobile/lib/endpoint.test.ts
+++ b/apps/mobile/lib/endpoint.test.ts
@@ -31,8 +31,12 @@ describe("normalizeApiBase", () => {
       error: "Public servers need https://",
     });
     expect(normalizeApiBase("http://100.64.0.1:3100")).toEqual({
+      ok: false,
+      error: "Public servers need https://",
+    });
+    expect(normalizeApiBase("https://100.64.0.1:3100")).toEqual({
       ok: true,
-      url: "http://100.64.0.1:3100",
+      url: "https://100.64.0.1:3100",
     });
     expect(normalizeApiBase("http://machine.ts.net")).toEqual({
       ok: false,
@@ -84,9 +88,9 @@ describe("display and warnings", () => {
     expect(apiBaseWarning("https://app.example.com")).toBeNull();
     expect(apiBaseWarning("http://127.0.0.1:3100")).toBeNull();
     expect(apiBaseWarning("http://192.168.1.20:3100")).toBeNull();
-    expect(apiBaseWarning("http://100.64.0.1:3100")).toMatch(/Tailscale or EasyTier/);
-    expect(apiBaseWarning("http://100.119.57.55:3100")).toMatch(/Tailscale or EasyTier/);
-    expect(apiBaseWarning("http://100.127.255.255:3100")).toMatch(/Tailscale or EasyTier/);
+    expect(apiBaseWarning("http://100.64.0.1:3100")).toMatch(/https/i);
+    expect(apiBaseWarning("http://100.119.57.55:3100")).toMatch(/https/i);
+    expect(apiBaseWarning("https://100.64.0.1:3100")).toMatch(/Tailscale or EasyTier/);
     expect(apiBaseWarning("http://app.example.com")).toMatch(/https/i);
     expect(apiBaseWarning("http://machine.ts.net")).toMatch(/https/i);
     expect(apiBaseWarning("https://machine.ts.net")).toMatch(/Tailscale or EasyTier/);

--- a/apps/mobile/lib/endpoint.test.ts
+++ b/apps/mobile/lib/endpoint.test.ts
@@ -30,6 +30,14 @@ describe("normalizeApiBase", () => {
       ok: false,
       error: "Public servers need https://",
     });
+    expect(normalizeApiBase("http://100.64.0.1:3100")).toEqual({
+      ok: true,
+      url: "http://100.64.0.1:3100",
+    });
+    expect(normalizeApiBase("http://machine.ts.net")).toEqual({
+      ok: false,
+      error: "Public servers need https://",
+    });
   });
 
   it("rejects empty, non-http, and malformed values", () => {

--- a/apps/mobile/lib/endpoint.test.ts
+++ b/apps/mobile/lib/endpoint.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
+  apiBaseSummary,
   apiBaseWarning,
   defaultApiBase,
   displayApiHost,
@@ -75,12 +76,19 @@ describe("display and warnings", () => {
     expect(apiBaseWarning("https://app.example.com")).toBeNull();
     expect(apiBaseWarning("http://127.0.0.1:3100")).toBeNull();
     expect(apiBaseWarning("http://192.168.1.20:3100")).toBeNull();
-    expect(apiBaseWarning("http://100.64.0.1:3100")).toBeNull();
-    expect(apiBaseWarning("http://100.119.57.55:3100")).toBeNull();
-    expect(apiBaseWarning("http://100.127.255.255:3100")).toBeNull();
+    expect(apiBaseWarning("http://100.64.0.1:3100")).toMatch(/Tailscale or EasyTier/);
+    expect(apiBaseWarning("http://100.119.57.55:3100")).toMatch(/Tailscale or EasyTier/);
+    expect(apiBaseWarning("http://100.127.255.255:3100")).toMatch(/Tailscale or EasyTier/);
     expect(apiBaseWarning("http://app.example.com")).toMatch(/https/i);
     expect(apiBaseWarning("http://machine.ts.net")).toMatch(/https/i);
-    expect(apiBaseWarning("https://machine.ts.net")).toBeNull();
+    expect(apiBaseWarning("https://machine.ts.net")).toMatch(/Tailscale or EasyTier/);
+  });
+
+  it("summarizes origin, scheme, and network class", () => {
+    expect(apiBaseSummary("https://app.example.com")).toBe("app.example.com · https · public");
+    expect(apiBaseSummary("http://192.168.1.20:3100")).toBe(
+      "192.168.1.20:3100 · http · local network",
+    );
   });
 
   it("treats the compile-time default as not custom", () => {
@@ -121,6 +129,7 @@ describe("mobile custom server UI", () => {
     const signIn = readFileSync(path.join(dir, "../app/sign-in.tsx"), "utf8");
     const api = readFileSync(path.join(dir, "api.ts"), "utf8");
     expect(signIn).toContain("Use a custom server");
+    expect(signIn).toContain("apiBaseSummary");
     expect(signIn).toContain("saveApiBase");
     expect(signIn).toContain("probeApiBase");
     expect(api).toContain("currentApiBase()");

--- a/apps/mobile/lib/endpoint.ts
+++ b/apps/mobile/lib/endpoint.ts
@@ -1,4 +1,8 @@
-import { allowsCleartextHttp } from "@rakazo/core";
+import {
+  allowsCleartextHttp,
+  connectionHintForOrigin,
+  describeConnectionOrigin,
+} from "@rakazo/core";
 
 const LOCAL_API = "http://127.0.0.1:3100";
 const DEFAULT_API = process.env.EXPO_PUBLIC_API_URL ?? LOCAL_API;
@@ -52,7 +56,11 @@ export function apiBaseWarning(url: string): string | null {
   } catch {
     return null;
   }
-  return null;
+  return connectionHintForOrigin(url);
+}
+
+export function apiBaseSummary(url: string): string | null {
+  return describeConnectionOrigin(url);
 }
 
 export async function probeApiBase(

--- a/apps/mobile/lib/endpoint.ts
+++ b/apps/mobile/lib/endpoint.ts
@@ -27,7 +27,7 @@ export function normalizeApiBase(input: string): EndpointResult {
     return { ok: false, error: "Use an http or https URL" };
   }
   if (!parsed.hostname) return { ok: false, error: "That URL is missing a host" };
-  if (parsed.protocol === "http:" && !isLanOrLocalHost(parsed.hostname)) {
+  if (parsed.protocol === "http:" && !allowsCleartextHttp(parsed.hostname)) {
     return { ok: false, error: "Public servers need https://" };
   }
   const url = `${parsed.protocol}//${parsed.host}`;

--- a/apps/mobile/lib/endpoint.ts
+++ b/apps/mobile/lib/endpoint.ts
@@ -1,3 +1,5 @@
+import { allowsCleartextHttp } from "@rakazo/core";
+
 const LOCAL_API = "http://127.0.0.1:3100";
 const DEFAULT_API = process.env.EXPO_PUBLIC_API_URL ?? LOCAL_API;
 
@@ -44,7 +46,7 @@ export function usesCustomApiBase(url: string, fallback = defaultApiBase()) {
 export function apiBaseWarning(url: string): string | null {
   try {
     const parsed = new URL(url);
-    if (parsed.protocol === "http:" && !isLanOrLocalHost(parsed.hostname)) {
+    if (parsed.protocol === "http:" && !allowsCleartextHttp(parsed.hostname)) {
       return "Public servers need https://. HTTP only works on your local network.";
     }
   } catch {
@@ -86,15 +88,4 @@ export async function probeApiBase(
 function originOnly(value: string) {
   const parsed = normalizeApiBase(value);
   return parsed.ok ? parsed.url : null;
-}
-
-function isLanOrLocalHost(hostname: string) {
-  const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
-  if (host === "localhost" || host === "127.0.0.1" || host === "::1") return true;
-  if (host.endsWith(".local")) return true;
-  if (/^10(?:\.\d{1,3}){3}$/.test(host)) return true;
-  if (/^192\.168(?:\.\d{1,3}){2}$/.test(host)) return true;
-  if (/^172\.(1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2}$/.test(host)) return true;
-  if (/^100\.(6[4-9]|[7-9]\d|1[0-1]\d|12[0-7])(?:\.\d{1,3}){2}$/.test(host)) return true;
-  return false;
 }

--- a/apps/mobile/lib/refresh.test.ts
+++ b/apps/mobile/lib/refresh.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { subscribeRetryDelayMs } from "./refresh";
+import { SUBSCRIBE_IDLE_TIMEOUT_MS, subscribeRetryDelayMs } from "./refresh";
 
 describe("thread subscribe reconnect", () => {
   it("backs off after a dropped stream and caps at five seconds", () => {
@@ -10,6 +10,10 @@ describe("thread subscribe reconnect", () => {
     expect(subscribeRetryDelayMs(1)).toBe(500);
     expect(subscribeRetryDelayMs(2)).toBe(1_000);
     expect(subscribeRetryDelayMs(20)).toBe(5_000);
+  });
+
+  it("defines a finite idle timeout so silent SSE streams recover", () => {
+    expect(SUBSCRIBE_IDLE_TIMEOUT_MS).toBe(45_000);
   });
 
   it("keeps the open thread on SSE instead of polling snapshots", () => {

--- a/apps/mobile/lib/refresh.test.ts
+++ b/apps/mobile/lib/refresh.test.ts
@@ -1,10 +1,22 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { threadRefreshDelayMs } from "./refresh";
+import { subscribeRetryDelayMs } from "./refresh";
 
-describe("thread refresh cadence", () => {
-  it("polls active work quickly and idle chats quietly", () => {
-    expect(threadRefreshDelayMs("running")).toBe(1_500);
-    expect(threadRefreshDelayMs("waiting_input")).toBe(5_000);
-    expect(threadRefreshDelayMs(undefined)).toBe(5_000);
+describe("thread subscribe reconnect", () => {
+  it("backs off after a dropped stream and caps at five seconds", () => {
+    expect(subscribeRetryDelayMs(0)).toBe(250);
+    expect(subscribeRetryDelayMs(1)).toBe(500);
+    expect(subscribeRetryDelayMs(2)).toBe(1_000);
+    expect(subscribeRetryDelayMs(20)).toBe(5_000);
+  });
+
+  it("keeps the open thread on SSE instead of polling snapshots", () => {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const thread = readFileSync(path.join(dir, "../app/thread.tsx"), "utf8");
+    expect(thread).toContain("subscribeThread");
+    expect(thread).not.toContain("threadRefreshDelayMs");
+    expect(thread).not.toMatch(/setTimeout\(\(\) => void tick\(\)/);
   });
 });

--- a/apps/mobile/lib/refresh.ts
+++ b/apps/mobile/lib/refresh.ts
@@ -1,6 +1,13 @@
 const SUBSCRIBE_RETRY_BASE_MS = 250;
 const SUBSCRIBE_RETRY_MAX_MS = 5_000;
 
+/**
+ * Abort an open SSE body after this much silence. Quiet streams send no
+ * keepalive bytes, so a hung `reader.read()` never rejects on its own; the
+ * subscribe loop then refreshes the snapshot and resubscribes.
+ */
+export const SUBSCRIBE_IDLE_TIMEOUT_MS = 45_000;
+
 /** Backoff after a dropped SSE subscribe, matching the web shell. */
 export function subscribeRetryDelayMs(attempt: number): number {
   const exponent = Math.max(0, attempt);

--- a/apps/mobile/lib/refresh.ts
+++ b/apps/mobile/lib/refresh.ts
@@ -1,5 +1,8 @@
-const ACTIVE_REFRESH_STATUSES = new Set(["queued", "leased", "running"]);
+const SUBSCRIBE_RETRY_BASE_MS = 250;
+const SUBSCRIBE_RETRY_MAX_MS = 5_000;
 
-export function threadRefreshDelayMs(runStatus: string | undefined): number {
-  return ACTIVE_REFRESH_STATUSES.has(runStatus ?? "") ? 1_500 : 5_000;
+/** Backoff after a dropped SSE subscribe, matching the web shell. */
+export function subscribeRetryDelayMs(attempt: number): number {
+  const exponent = Math.max(0, attempt);
+  return Math.min(SUBSCRIBE_RETRY_MAX_MS, SUBSCRIBE_RETRY_BASE_MS * 2 ** exponent);
 }

--- a/apps/mobile/modules/rakazo-notifications/android/src/main/java/com/rakazo/notifications/EndpointAllowlist.kt
+++ b/apps/mobile/modules/rakazo-notifications/android/src/main/java/com/rakazo/notifications/EndpointAllowlist.kt
@@ -20,6 +20,6 @@ private fun isLanOrLocalHost(host: String): Boolean {
   if (Regex("""^10(?:\.\d{1,3}){3}$""").matches(host)) return true
   if (Regex("""^192\.168(?:\.\d{1,3}){2}$""").matches(host)) return true
   if (Regex("""^172\.(1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2}$""").matches(host)) return true
-  if (Regex("""^100\.(6[4-9]|[7-9]\d|1[0-1]\d|12[0-7])(?:\.\d{1,3}){2}$""").matches(host)) return true
+  // CGNAT 100.64/10 requires HTTPS — same policy as packages/core network-host.
   return false
 }

--- a/apps/mobile/modules/rakazo-notifications/android/src/main/java/com/rakazo/notifications/EndpointAllowlist.kt
+++ b/apps/mobile/modules/rakazo-notifications/android/src/main/java/com/rakazo/notifications/EndpointAllowlist.kt
@@ -2,6 +2,8 @@ package com.rakazo.notifications
 
 import java.net.URI
 
+/** Keep in sync with `allowsCleartextHttp` in packages/core/src/network-host.ts. */
+
 internal fun isAllowedNotificationEndpoint(endpoint: String): Boolean {
   val uri = runCatching { URI(endpoint) }.getOrNull() ?: return false
   val scheme = uri.scheme?.lowercase() ?: return false

--- a/apps/web/e2e/session-reconnect.spec.ts
+++ b/apps/web/e2e/session-reconnect.spec.ts
@@ -40,6 +40,9 @@ test("shows the reconnect banner after a live session lookup fails", async ({ pa
   await expect(banner).toBeVisible({ timeout: 15_000 });
   await expect(banner.getByRole("button", { name: "Retry now" })).toBeVisible();
   await expect(page.getByText("Can't reach the server.")).toBeVisible();
+  // Banner must keep the mounted workspace, not replace it with a full-page wait.
+  await expect(page.getByTestId("shell-root")).toBeVisible();
+  await expect(page.getByText("Chief").first()).toBeVisible();
   await captureScreenshot(page, testInfo, "session-reconnect-banner");
 });
 

--- a/apps/web/e2e/session-reconnect.spec.ts
+++ b/apps/web/e2e/session-reconnect.spec.ts
@@ -1,0 +1,61 @@
+import { expect, type Page, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+async function failSessionLookups(page: Page) {
+  await page.route("**/api/auth/get-session*", async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "unavailable" }),
+    });
+  });
+}
+
+/** Better Auth rate-limits focus refetch to once per 5s; wait then poke visibility. */
+async function triggerSessionRefetch(page: Page) {
+  await page.waitForTimeout(5_500);
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+test("shows the reconnect banner after a live session lookup fails", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `reconnect-banner-${stamp}@rakazo.test`, "password12", "Reconnect Banner");
+  await completeOnboarding(page);
+
+  await failSessionLookups(page);
+  await triggerSessionRefetch(page);
+
+  const banner = page.locator('[data-rakazo-reconnect="banner"]');
+  await expect(banner).toBeVisible({ timeout: 15_000 });
+  await expect(banner.getByRole("button", { name: "Retry now" })).toBeVisible();
+  await expect(page.getByText("Can't reach the server.")).toBeVisible();
+  await captureScreenshot(page, testInfo, "session-reconnect-banner");
+});
+
+test("shows the blocking reconnect screen on a cold unreachable load", async ({
+  page,
+}, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `reconnect-blocking-${stamp}@rakazo.test`, "password12", "Reconnect Blocking");
+  await completeOnboarding(page);
+
+  await failSessionLookups(page);
+  await page.reload();
+
+  const blocking = page.locator('[data-rakazo-reconnect="blocking"]');
+  await expect(blocking).toBeVisible({ timeout: 15_000 });
+  await expect(blocking.getByRole("button", { name: "Retry now" })).toBeVisible();
+  await expect(page.getByText("Can't reach the server.")).toBeVisible();
+  await captureScreenshot(page, testInfo, "session-reconnect-blocking");
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { connectionHintForOrigin, describeConnectionOrigin } from "@rakazo/core";
 import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { BuiButton, LoadingState } from "./components/beautiful-ui/primitives";
@@ -151,6 +152,8 @@ function useSessionRetry(refetch: () => Promise<void>) {
 function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
   const { t } = useLingui();
   const retryNow = useSessionRetry(refetch);
+  const origin = describeConnectionOrigin(window.location.origin);
+  const hint = connectionHintForOrigin(window.location.origin);
 
   return (
     <div
@@ -162,6 +165,8 @@ function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
         <p className="mt-3 text-[13.5px] text-[#6C6C70]">
           <Trans>Can&apos;t reach the server.</Trans>
         </p>
+        {origin ? <p className="mt-1 font-mono text-[12px] text-[#6C6C70]">{origin}</p> : null}
+        {hint ? <p className="mt-1 text-[12px] text-[#85858A]">{hint}</p> : null}
         <div className="mt-4">
           <BuiButton onClick={retryNow}>
             <Trans>Retry now</Trans>
@@ -174,16 +179,20 @@ function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
 
 function SessionReconnectBar({ refetch }: { refetch: () => Promise<void> }) {
   const retryNow = useSessionRetry(refetch);
+  const origin = describeConnectionOrigin(window.location.origin);
+  const hint = connectionHintForOrigin(window.location.origin);
 
   return (
     <div
-      className="flex shrink-0 items-center justify-center gap-3 border-b border-[#26262A] bg-[#121214] px-4 py-2"
+      className="flex shrink-0 flex-wrap items-center justify-center gap-x-3 gap-y-1 border-b border-[#26262A] bg-[#121214] px-4 py-2"
       data-rakazo-reconnect="banner"
       role="status"
     >
       <p className="text-[13px] text-[#9A9AA0]">
         <Trans>Can&apos;t reach the server.</Trans>
       </p>
+      {origin ? <p className="font-mono text-[12px] text-[#6C6C70]">{origin}</p> : null}
+      {hint ? <p className="text-[12px] text-[#85858A]">{hint}</p> : null}
       <BuiButton onClick={retryNow}>
         <Trans>Retry now</Trans>
       </BuiButton>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,7 +35,7 @@ export function App() {
   const [sawWorkspace, setSawWorkspace] = useState(false);
   const nextHolding = holdUnreachableGate(gate, holdingUnreachable);
   if (nextHolding !== holdingUnreachable) setHoldingUnreachable(nextHolding);
-  const nextMounted = workspaceMounted(gate, sawWorkspace);
+  const nextMounted = workspaceMounted(gate, sawWorkspace, nextHolding);
   if (nextMounted !== sawWorkspace) setSawWorkspace(nextMounted);
   const reconnect = sessionReconnectKind(session, nextHolding, nextMounted);
   const lastUser = useRef<unknown>(null);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,7 +10,6 @@ import {
   sessionGate,
   sessionReconnectKind,
   sessionRetryDelayMs,
-  workspaceMounted,
 } from "./lib/session-gate";
 import { McpOAuthCallbackPage } from "./pages/McpOAuthCallback";
 import { ShellPage } from "./pages/Shell";
@@ -32,15 +31,9 @@ export function App() {
   const session = authClient.useSession();
   const gate = sessionGate(session);
   const [holdingUnreachable, setHoldingUnreachable] = useState(false);
-  const [sawWorkspace, setSawWorkspace] = useState(false);
   const nextHolding = holdUnreachableGate(gate, holdingUnreachable);
   if (nextHolding !== holdingUnreachable) setHoldingUnreachable(nextHolding);
-  const nextMounted = workspaceMounted(gate, sawWorkspace, nextHolding);
-  if (nextMounted !== sawWorkspace) setSawWorkspace(nextMounted);
-  const reconnect = sessionReconnectKind(session, nextHolding, nextMounted);
-  const lastUser = useRef<unknown>(null);
-  if (session.data?.user) lastUser.current = session.data.user;
-  else if (!nextMounted) lastUser.current = null;
+  const reconnect = sessionReconnectKind(session, nextHolding);
 
   useLayoutEffect(() => {
     if (session.isPending) return;
@@ -64,7 +57,7 @@ export function App() {
     );
   }
 
-  const user = session.data?.user ?? (reconnect === "banner" ? lastUser.current : null);
+  const user = session.data?.user;
   return (
     <div className="flex h-full flex-col" data-rakazo-app-state="ready">
       {reconnect === "banner" ? <SessionReconnectBar refetch={session.refetch} /> : null}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import {
   sessionGate,
   sessionReconnectKind,
   sessionRetryDelayMs,
+  workspaceMounted,
 } from "./lib/session-gate";
 import { McpOAuthCallbackPage } from "./pages/McpOAuthCallback";
 import { ShellPage } from "./pages/Shell";
@@ -34,12 +35,12 @@ export function App() {
   const [sawWorkspace, setSawWorkspace] = useState(false);
   const nextHolding = holdUnreachableGate(gate, holdingUnreachable);
   if (nextHolding !== holdingUnreachable) setHoldingUnreachable(nextHolding);
-  const reconnect = sessionReconnectKind(session, nextHolding, sawWorkspace);
+  const nextMounted = workspaceMounted(gate, sawWorkspace);
+  if (nextMounted !== sawWorkspace) setSawWorkspace(nextMounted);
+  const reconnect = sessionReconnectKind(session, nextHolding, nextMounted);
   const lastUser = useRef<unknown>(null);
-  if (session.data?.user) {
-    lastUser.current = session.data.user;
-    if (!sawWorkspace) setSawWorkspace(true);
-  }
+  if (session.data?.user) lastUser.current = session.data.user;
+  else if (!nextMounted) lastUser.current = null;
 
   useLayoutEffect(() => {
     if (session.isPending) return;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,8 +7,8 @@ import { markAfterPaint, markOnce } from "./lib/performance";
 import {
   holdUnreachableGate,
   sessionGate,
+  sessionReconnectKind,
   sessionRetryDelayMs,
-  showSessionUnavailable,
 } from "./lib/session-gate";
 import { McpOAuthCallbackPage } from "./pages/McpOAuthCallback";
 import { ShellPage } from "./pages/Shell";
@@ -30,8 +30,15 @@ export function App() {
   const session = authClient.useSession();
   const gate = sessionGate(session);
   const [holdingUnreachable, setHoldingUnreachable] = useState(false);
+  const [sawWorkspace, setSawWorkspace] = useState(false);
   const nextHolding = holdUnreachableGate(gate, holdingUnreachable);
   if (nextHolding !== holdingUnreachable) setHoldingUnreachable(nextHolding);
+  const reconnect = sessionReconnectKind(session, nextHolding, sawWorkspace);
+  const lastUser = useRef<unknown>(null);
+  if (session.data?.user) {
+    lastUser.current = session.data.user;
+    if (!sawWorkspace) setSawWorkspace(true);
+  }
 
   useLayoutEffect(() => {
     if (session.isPending) return;
@@ -39,10 +46,10 @@ export function App() {
     markAfterPaint("rk:renderer:session-painted");
   }, [session.isPending]);
 
-  if (showSessionUnavailable(gate, nextHolding)) {
+  if (reconnect === "blocking") {
     return <SessionUnavailable refetch={session.refetch} />;
   }
-  if (gate === "loading") {
+  if (gate === "loading" && reconnect === "none") {
     return window.location.pathname.startsWith("/app") ? (
       <ShellSkeleton />
     ) : (
@@ -55,46 +62,54 @@ export function App() {
     );
   }
 
-  const user = session.data?.user;
+  const user = session.data?.user ?? (reconnect === "banner" ? lastUser.current : null);
   return (
-    <div className="h-full" data-rakazo-app-state="ready">
-      <Suspense fallback={<div className="h-full bg-[#050506]" />}>
-        <Routes>
-          <Route path="/" element={user ? <Navigate to="/app" replace /> : <WelcomePage />} />
-          <Route
-            path="/sign-in"
-            element={user ? <Navigate to="/app" replace /> : <AuthPage key="in" mode="in" />}
-          />
-          <Route
-            path="/sign-up"
-            element={user ? <Navigate to="/onboarding" replace /> : <AuthPage key="up" mode="up" />}
-          />
-          <Route
-            path="/forgot-password"
-            element={
-              user ? <Navigate to="/app" replace /> : <AuthPage key="forgot" mode="forgot" />
-            }
-          />
-          <Route path="/reset-password" element={<PasswordResetPage />} />
-          <Route
-            path="/onboarding"
-            element={user ? <OnboardingPage /> : <Navigate to="/sign-in" replace />}
-          />
-          <Route
-            path="/mcp/oauth/callback"
-            element={user ? <McpOAuthCallbackPage /> : <Navigate to="/sign-in" replace />}
-          />
-          <Route path="/app" element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />} />
-          <Route
-            path="/app/g/:groupId"
-            element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
-          />
-          <Route
-            path="/app/:botId"
-            element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
-          />
-        </Routes>
-      </Suspense>
+    <div className="flex h-full flex-col" data-rakazo-app-state="ready">
+      {reconnect === "banner" ? <SessionReconnectBar refetch={session.refetch} /> : null}
+      <div className="min-h-0 flex-1">
+        <Suspense fallback={<div className="h-full bg-[#050506]" />}>
+          <Routes>
+            <Route path="/" element={user ? <Navigate to="/app" replace /> : <WelcomePage />} />
+            <Route
+              path="/sign-in"
+              element={user ? <Navigate to="/app" replace /> : <AuthPage key="in" mode="in" />}
+            />
+            <Route
+              path="/sign-up"
+              element={
+                user ? <Navigate to="/onboarding" replace /> : <AuthPage key="up" mode="up" />
+              }
+            />
+            <Route
+              path="/forgot-password"
+              element={
+                user ? <Navigate to="/app" replace /> : <AuthPage key="forgot" mode="forgot" />
+              }
+            />
+            <Route path="/reset-password" element={<PasswordResetPage />} />
+            <Route
+              path="/onboarding"
+              element={user ? <OnboardingPage /> : <Navigate to="/sign-in" replace />}
+            />
+            <Route
+              path="/mcp/oauth/callback"
+              element={user ? <McpOAuthCallbackPage /> : <Navigate to="/sign-in" replace />}
+            />
+            <Route
+              path="/app"
+              element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
+            />
+            <Route
+              path="/app/g/:groupId"
+              element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
+            />
+            <Route
+              path="/app/:botId"
+              element={user ? <ShellPage /> : <Navigate to="/sign-in" replace />}
+            />
+          </Routes>
+        </Suspense>
+      </div>
     </div>
   );
 }
@@ -104,8 +119,7 @@ export function App() {
  * waits and retries here instead of routing to sign-in and stranding a signed-in
  * user. Better Auth only polls once a session exists, so the retry lives here.
  */
-function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
-  const { t } = useLingui();
+function useSessionRetry(refetch: () => Promise<void>) {
   const [attempt, setAttempt] = useState(0);
   const [retryKey, setRetryKey] = useState(0);
   const retryImmediately = useRef(false);
@@ -127,25 +141,52 @@ function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
     };
   }, [attempt, retryKey]);
 
+  return () => {
+    retryImmediately.current = true;
+    setAttempt(0);
+    setRetryKey((key) => key + 1);
+  };
+}
+
+function SessionUnavailable({ refetch }: { refetch: () => Promise<void> }) {
+  const { t } = useLingui();
+  const retryNow = useSessionRetry(refetch);
+
   return (
-    <div className="grid h-full place-items-center bg-[#050506] px-6 text-center">
+    <div
+      className="grid h-full place-items-center bg-[#050506] px-6 text-center"
+      data-rakazo-reconnect="blocking"
+    >
       <div className="flex flex-col items-center">
         <LoadingState label={t`Reconnecting`} />
         <p className="mt-3 text-[13.5px] text-[#6C6C70]">
           <Trans>Can&apos;t reach the server.</Trans>
         </p>
         <div className="mt-4">
-          <BuiButton
-            onClick={() => {
-              retryImmediately.current = true;
-              setAttempt(0);
-              setRetryKey((key) => key + 1);
-            }}
-          >
+          <BuiButton onClick={retryNow}>
             <Trans>Retry now</Trans>
           </BuiButton>
         </div>
       </div>
+    </div>
+  );
+}
+
+function SessionReconnectBar({ refetch }: { refetch: () => Promise<void> }) {
+  const retryNow = useSessionRetry(refetch);
+
+  return (
+    <div
+      className="flex shrink-0 items-center justify-center gap-3 border-b border-[#26262A] bg-[#121214] px-4 py-2"
+      data-rakazo-reconnect="banner"
+      role="status"
+    >
+      <p className="text-[13px] text-[#9A9AA0]">
+        <Trans>Can&apos;t reach the server.</Trans>
+      </p>
+      <BuiButton onClick={retryNow}>
+        <Trans>Retry now</Trans>
+      </BuiButton>
     </div>
   );
 }

--- a/apps/web/src/lib/session-gate.test.ts
+++ b/apps/web/src/lib/session-gate.test.ts
@@ -5,6 +5,7 @@ import {
   sessionReconnectKind,
   sessionRetryDelayMs,
   showSessionUnavailable,
+  workspaceMounted,
 } from "./session-gate.js";
 
 const user = { user: { id: "u_1" } };
@@ -71,6 +72,15 @@ describe("session gate", () => {
     expect(
       sessionReconnectKind({ data: null, isPending: false, error: { status: 401 } }, false, false),
     ).toBe("none");
+  });
+
+  it("forgets a mounted workspace after sign-out", () => {
+    expect(workspaceMounted("authenticated", false)).toBe(true);
+    expect(workspaceMounted("anonymous", true)).toBe(false);
+    expect(workspaceMounted("unreachable", true)).toBe(true);
+    expect(workspaceMounted("loading", true)).toBe(true);
+    const down = { data: null, isPending: false, error: { status: 503 } };
+    expect(sessionReconnectKind(down, false, workspaceMounted("anonymous", true))).toBe("blocking");
   });
 
   it("backs off between retries and stops growing", () => {

--- a/apps/web/src/lib/session-gate.test.ts
+++ b/apps/web/src/lib/session-gate.test.ts
@@ -5,7 +5,6 @@ import {
   sessionReconnectKind,
   sessionRetryDelayMs,
   showSessionUnavailable,
-  workspaceMounted,
 } from "./session-gate.js";
 
 const user = { user: { id: "u_1" } };
@@ -50,41 +49,22 @@ describe("session gate", () => {
     expect(showSessionUnavailable("loading", false)).toBe(false);
   });
 
-  it("blocks a cold unreachable load and banners once the workspace has mounted", () => {
+  it("blocks an unreachable load that has no session user", () => {
     const down = { data: null, isPending: false, error: { status: 503 } };
-    expect(sessionReconnectKind(down, false, false)).toBe("blocking");
-    expect(sessionReconnectKind(down, false, true)).toBe("banner");
-    expect(sessionReconnectKind({ data: null, isPending: true, error: null }, true, true)).toBe(
-      "banner",
-    );
-    expect(sessionReconnectKind({ data: null, isPending: true, error: null }, true, false)).toBe(
+    expect(sessionReconnectKind(down, false)).toBe("blocking");
+    expect(sessionReconnectKind({ data: null, isPending: true, error: null }, true)).toBe(
       "blocking",
     );
   });
 
   it("banners a live session whose refresh could not reach the server", () => {
     expect(
-      sessionReconnectKind({ data: user, isPending: false, error: { status: 500 } }, false, true),
+      sessionReconnectKind({ data: user, isPending: false, error: { status: 500 } }, false),
     ).toBe("banner");
-    expect(sessionReconnectKind({ data: user, isPending: false, error: null }, false, true)).toBe(
-      "none",
-    );
+    expect(sessionReconnectKind({ data: user, isPending: false, error: null }, false)).toBe("none");
     expect(
-      sessionReconnectKind({ data: null, isPending: false, error: { status: 401 } }, false, false),
+      sessionReconnectKind({ data: null, isPending: false, error: { status: 401 } }, false),
     ).toBe("none");
-  });
-
-  it("forgets a mounted workspace after sign-out", () => {
-    expect(workspaceMounted("authenticated", false)).toBe(true);
-    expect(workspaceMounted("anonymous", true)).toBe(false);
-    expect(workspaceMounted("loading", true, false)).toBe(false);
-    expect(workspaceMounted("loading", true, true)).toBe(true);
-    expect(workspaceMounted("unreachable", true, true)).toBe(true);
-    const down = { data: null, isPending: false, error: { status: 503 } };
-    expect(sessionReconnectKind(down, false, workspaceMounted("anonymous", true))).toBe("blocking");
-    expect(sessionReconnectKind(down, false, workspaceMounted("loading", true, false))).toBe(
-      "blocking",
-    );
   });
 
   it("backs off between retries and stops growing", () => {

--- a/apps/web/src/lib/session-gate.test.ts
+++ b/apps/web/src/lib/session-gate.test.ts
@@ -77,10 +77,14 @@ describe("session gate", () => {
   it("forgets a mounted workspace after sign-out", () => {
     expect(workspaceMounted("authenticated", false)).toBe(true);
     expect(workspaceMounted("anonymous", true)).toBe(false);
-    expect(workspaceMounted("unreachable", true)).toBe(true);
-    expect(workspaceMounted("loading", true)).toBe(true);
+    expect(workspaceMounted("loading", true, false)).toBe(false);
+    expect(workspaceMounted("loading", true, true)).toBe(true);
+    expect(workspaceMounted("unreachable", true, true)).toBe(true);
     const down = { data: null, isPending: false, error: { status: 503 } };
     expect(sessionReconnectKind(down, false, workspaceMounted("anonymous", true))).toBe("blocking");
+    expect(sessionReconnectKind(down, false, workspaceMounted("loading", true, false))).toBe(
+      "blocking",
+    );
   });
 
   it("backs off between retries and stops growing", () => {

--- a/apps/web/src/lib/session-gate.test.ts
+++ b/apps/web/src/lib/session-gate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   holdUnreachableGate,
   sessionGate,
+  sessionReconnectKind,
   sessionRetryDelayMs,
   showSessionUnavailable,
 } from "./session-gate.js";
@@ -46,6 +47,30 @@ describe("session gate", () => {
     expect(holdUnreachableGate("anonymous", true)).toBe(false);
     expect(showSessionUnavailable("loading", true)).toBe(true);
     expect(showSessionUnavailable("loading", false)).toBe(false);
+  });
+
+  it("blocks a cold unreachable load and banners once the workspace has mounted", () => {
+    const down = { data: null, isPending: false, error: { status: 503 } };
+    expect(sessionReconnectKind(down, false, false)).toBe("blocking");
+    expect(sessionReconnectKind(down, false, true)).toBe("banner");
+    expect(sessionReconnectKind({ data: null, isPending: true, error: null }, true, true)).toBe(
+      "banner",
+    );
+    expect(sessionReconnectKind({ data: null, isPending: true, error: null }, true, false)).toBe(
+      "blocking",
+    );
+  });
+
+  it("banners a live session whose refresh could not reach the server", () => {
+    expect(
+      sessionReconnectKind({ data: user, isPending: false, error: { status: 500 } }, false, true),
+    ).toBe("banner");
+    expect(sessionReconnectKind({ data: user, isPending: false, error: null }, false, true)).toBe(
+      "none",
+    );
+    expect(
+      sessionReconnectKind({ data: null, isPending: false, error: { status: 401 } }, false, false),
+    ).toBe("none");
   });
 
   it("backs off between retries and stops growing", () => {

--- a/apps/web/src/lib/session-gate.ts
+++ b/apps/web/src/lib/session-gate.ts
@@ -9,7 +9,7 @@ export type SessionGate = "loading" | "unreachable" | "authenticated" | "anonymo
 /**
  * A failed session fetch is not a sign-out. Better Auth keeps the last known
  * session on a network error, but a cold load has nothing to keep, and its
- * refresh manager only polls once a session exists — so a request that fails
+ * refresh manager only polls once a session exists, so a request that fails
  * before the first success never retries. Routing that state to sign-in signs
  * out a user whose cookie is still valid, so it is reported separately.
  */
@@ -50,7 +50,7 @@ export function workspaceMounted(gate: SessionGate, mounted: boolean, holding = 
 /**
  * Cold loads that never reached the server still need a full-page wait so we
  * do not dump a signed-in cookie onto the sign-in screen. Once the workspace
- * has mounted, keep it and show a reconnect bar — including when Better Auth
+ * has mounted, keep it and show a reconnect bar, including when Better Auth
  * still holds the last user while a refresh fails.
  */
 export function sessionReconnectKind(

--- a/apps/web/src/lib/session-gate.ts
+++ b/apps/web/src/lib/session-gate.ts
@@ -37,6 +37,27 @@ export function showSessionUnavailable(gate: SessionGate, holding: boolean): boo
   return gate === "unreachable" || (holding && gate === "loading");
 }
 
+export type SessionReconnectKind = "none" | "blocking" | "banner";
+
+/**
+ * Cold loads that never reached the server still need a full-page wait so we
+ * do not dump a signed-in cookie onto the sign-in screen. Once the workspace
+ * has mounted, keep it and show a reconnect bar — including when Better Auth
+ * still holds the last user while a refresh fails.
+ */
+export function sessionReconnectKind(
+  session: SessionGateInput,
+  holding: boolean,
+  sawWorkspace: boolean,
+): SessionReconnectKind {
+  const gate = sessionGate(session);
+  if (gate === "authenticated") {
+    return session.error && session.error.status !== 401 ? "banner" : "none";
+  }
+  if (!showSessionUnavailable(gate, holding)) return "none";
+  return sawWorkspace ? "banner" : "blocking";
+}
+
 const RETRY_BASE_MS = 1_000;
 const RETRY_MAX_MS = 15_000;
 

--- a/apps/web/src/lib/session-gate.ts
+++ b/apps/web/src/lib/session-gate.ts
@@ -39,19 +39,20 @@ export function showSessionUnavailable(gate: SessionGate, holding: boolean): boo
 
 export type SessionReconnectKind = "none" | "blocking" | "banner";
 
+/** Drop a mounted workspace after sign-out, including a pending logout refetch. */
+export function workspaceMounted(gate: SessionGate, mounted: boolean, holding = false): boolean {
+  if (gate === "authenticated") return true;
+  if (gate === "anonymous") return false;
+  if (gate === "loading" && !holding) return false;
+  return mounted;
+}
+
 /**
  * Cold loads that never reached the server still need a full-page wait so we
  * do not dump a signed-in cookie onto the sign-in screen. Once the workspace
  * has mounted, keep it and show a reconnect bar — including when Better Auth
  * still holds the last user while a refresh fails.
  */
-/** Drop a mounted workspace after a real sign-out so reconnect cannot reuse it. */
-export function workspaceMounted(gate: SessionGate, mounted: boolean): boolean {
-  if (gate === "authenticated") return true;
-  if (gate === "anonymous") return false;
-  return mounted;
-}
-
 export function sessionReconnectKind(
   session: SessionGateInput,
   holding: boolean,

--- a/apps/web/src/lib/session-gate.ts
+++ b/apps/web/src/lib/session-gate.ts
@@ -45,6 +45,13 @@ export type SessionReconnectKind = "none" | "blocking" | "banner";
  * has mounted, keep it and show a reconnect bar — including when Better Auth
  * still holds the last user while a refresh fails.
  */
+/** Drop a mounted workspace after a real sign-out so reconnect cannot reuse it. */
+export function workspaceMounted(gate: SessionGate, mounted: boolean): boolean {
+  if (gate === "authenticated") return true;
+  if (gate === "anonymous") return false;
+  return mounted;
+}
+
 export function sessionReconnectKind(
   session: SessionGateInput,
   holding: boolean,

--- a/apps/web/src/lib/session-gate.ts
+++ b/apps/web/src/lib/session-gate.ts
@@ -39,31 +39,21 @@ export function showSessionUnavailable(gate: SessionGate, holding: boolean): boo
 
 export type SessionReconnectKind = "none" | "blocking" | "banner";
 
-/** Drop a mounted workspace after sign-out, including a pending logout refetch. */
-export function workspaceMounted(gate: SessionGate, mounted: boolean, holding = false): boolean {
-  if (gate === "authenticated") return true;
-  if (gate === "anonymous") return false;
-  if (gate === "loading" && !holding) return false;
-  return mounted;
-}
-
 /**
  * Cold loads that never reached the server still need a full-page wait so we
- * do not dump a signed-in cookie onto the sign-in screen. Once the workspace
- * has mounted, keep it and show a reconnect bar, including when Better Auth
- * still holds the last user while a refresh fails.
+ * do not dump a signed-in cookie onto the sign-in screen. Banner only when
+ * Better Auth still holds the user; never restore a signed-out identity.
  */
 export function sessionReconnectKind(
   session: SessionGateInput,
   holding: boolean,
-  sawWorkspace: boolean,
 ): SessionReconnectKind {
   const gate = sessionGate(session);
   if (gate === "authenticated") {
     return session.error && session.error.status !== 401 ? "banner" : "none";
   }
   if (!showSessionUnavailable(gate, holding)) return "none";
-  return sawWorkspace ? "banner" : "blocking";
+  return "blocking";
 }
 
 const RETRY_BASE_MS = 1_000;

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -158,7 +158,7 @@ the clients at that origin. Prefer TLS whenever a hostname is involved.
 2. **Tailscale or Headscale.** Join the Rakazo host and each device to the same tailnet. Use
    `https://<machine>.ts.net` (MagicDNS requires HTTPS; desktop and mobile reject `http://*.ts.net`).
    CGNAT addresses (`100.64.0.0/10`) may use HTTP on a trusted overlay, the same way LAN IPs do.
-   Install the official Tailscale app on iPhone — Rakazo cannot start a tunnel inside the iOS client.
+   Install the official Tailscale app on iPhone. Rakazo cannot start a tunnel inside the iOS client.
 3. **EasyTier (optional sidecar).** Run `easytier-core` as a separate binary or Compose service on
    the host (LGPL-3.0; do not statically link it into Rakazo). Join from Windows / macOS / Linux /
    Android / iPhone / iPad with the official EasyTier client. Clients may use the virtual IP over

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -157,12 +157,13 @@ the clients at that origin. Prefer TLS whenever a hostname is involved.
    Production Compose already documents Caddy and an optional Tunnel in place of ports 80/443.
 2. **Tailscale or Headscale.** Join the Rakazo host and each device to the same tailnet. Use
    `https://<machine>.ts.net` (MagicDNS requires HTTPS; desktop and mobile reject `http://*.ts.net`).
-   CGNAT addresses (`100.64.0.0/10`) may use HTTP on a trusted overlay, the same way LAN IPs do.
+   CGNAT addresses (`100.64.0.0/10`) also require HTTPS — that range is used by ordinary ISP CGNAT,
+   so the IP alone does not prove a trusted overlay. Prefer MagicDNS or terminate TLS on the node.
    Install the official Tailscale app on iPhone. Rakazo cannot start a tunnel inside the iOS client.
 3. **EasyTier (optional sidecar).** Run `easytier-core` as a separate binary or Compose service on
    the host (LGPL-3.0; do not statically link it into Rakazo). Join from Windows / macOS / Linux /
-   Android / iPhone / iPad with the official EasyTier client. Clients may use the virtual IP over
-   HTTP when it is RFC1918 or CGNAT. Tunnel or Tailscale still work if you prefer a public hostname.
+   Android / iPhone / iPad with the official EasyTier client. Clients may use an RFC1918 virtual IP
+   over HTTP; CGNAT virtual IPs need HTTPS. Tunnel or Tailscale still work if you prefer a public hostname.
 
 Do not bundle EasyTier or Tailscale into Electron or Expo. Detecting a system install and suggesting
 an origin is fine; creating a TUN device inside Rakazo is not.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -161,8 +161,8 @@ the clients at that origin. Prefer TLS whenever a hostname is involved.
    Install the official Tailscale app on iPhone — Rakazo cannot start a tunnel inside the iOS client.
 3. **EasyTier (optional sidecar).** Run `easytier-core` as a separate binary or Compose service on
    the host (LGPL-3.0; do not statically link it into Rakazo). Join from Windows / macOS / Linux /
-   Android with the official EasyTier client. There is no iOS EasyTier; use Tailscale or a Tunnel
-   for iPhone. Clients may use the virtual IP over HTTP when it is RFC1918 or CGNAT.
+   Android / iPhone / iPad with the official EasyTier client. Clients may use the virtual IP over
+   HTTP when it is RFC1918 or CGNAT. Tunnel or Tailscale still work if you prefer a public hostname.
 
 Do not bundle EasyTier or Tailscale into Electron or Expo. Detecting a system install and suggesting
 an origin is fine; creating a TUN device inside Rakazo is not.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -146,6 +146,27 @@ rejected.
 
 Do not commit `.env`. Never put `COMPOSIO_API_KEY`, OpenRouter keys, or provider tokens in git, logs, or chat.
 
+## Connecting without a public IP
+
+Rakazo clients (web, Electron, iOS, Android) speak HTTPS to one origin. They do not embed a VPN.
+When the API host has no public address, pick an overlay **outside** the Rakazo process, then point
+the clients at that origin. Prefer TLS whenever a hostname is involved.
+
+1. **Cloudflare Tunnel or Caddy (recommended).** Terminate HTTPS on a public hostname and set
+   `WEB_ORIGIN` / `BETTER_AUTH_URL` / `API_URL` to that URL. Phones and desktops need nothing extra.
+   Production Compose already documents Caddy and an optional Tunnel in place of ports 80/443.
+2. **Tailscale or Headscale.** Join the Rakazo host and each device to the same tailnet. Use
+   `https://<machine>.ts.net` (MagicDNS requires HTTPS; desktop and mobile reject `http://*.ts.net`).
+   CGNAT addresses (`100.64.0.0/10`) may use HTTP on a trusted overlay, the same way LAN IPs do.
+   Install the official Tailscale app on iPhone — Rakazo cannot start a tunnel inside the iOS client.
+3. **EasyTier (optional sidecar).** Run `easytier-core` as a separate binary or Compose service on
+   the host (LGPL-3.0; do not statically link it into Rakazo). Join from Windows / macOS / Linux /
+   Android with the official EasyTier client. There is no iOS EasyTier; use Tailscale or a Tunnel
+   for iPhone. Clients may use the virtual IP over HTTP when it is RFC1918 or CGNAT.
+
+Do not bundle EasyTier or Tailscale into Electron or Expo. Detecting a system install and suggesting
+an origin is fine; creating a TUN device inside Rakazo is not.
+
 ## Choosing a computer provider
 
 The Electron desktop app is a client of the same API. Docker and E2B still apply. On first launch, Electron asks the deployment owner whether bots should keep using Docker or run on this Mac as you. `SANDBOX_PROVIDER=desktop` is a separate, explicit provider that always runs commands on the service host.

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -75,6 +75,8 @@ export interface DesktopReachability {
   status?: number;
   /** Normalized URL that was probed, absent when the input was not a usable URL. */
   url?: string;
+  /** Origin class and overlay hint, when the URL could be classified. */
+  detail?: string;
   error?: string;
 }
 

--- a/packages/core/src/connection-kind.test.ts
+++ b/packages/core/src/connection-kind.test.ts
@@ -36,7 +36,8 @@ describe("connection kind", () => {
     expect(connectionHintForOrigin("https://machine.ts.net")).toBe(
       "Join the same Tailscale or EasyTier network as the server.",
     );
-    expect(connectionHintForOrigin("http://100.64.0.1:3100")).toBe(
+    expect(connectionHintForOrigin("http://100.64.0.1:3100")).toBe("Overlay IPs need https://.");
+    expect(connectionHintForOrigin("https://100.64.0.1:3100")).toBe(
       "Join the same Tailscale or EasyTier network as the server.",
     );
     expect(connectionHintForOrigin("https://app.example.com")).toBeNull();

--- a/packages/core/src/connection-kind.test.ts
+++ b/packages/core/src/connection-kind.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  connectionHintForOrigin,
+  connectionKindForHost,
+  describeConnectionOrigin,
+} from "./connection-kind.js";
+
+describe("connection kind", () => {
+  it("classifies loopback, LAN, overlay, and public hosts", () => {
+    expect(connectionKindForHost("127.0.0.1")).toBe("loopback");
+    expect(connectionKindForHost("localhost")).toBe("loopback");
+    expect(connectionKindForHost("192.168.1.20")).toBe("lan");
+    expect(connectionKindForHost("10.0.0.8")).toBe("lan");
+    expect(connectionKindForHost("rakazo.local")).toBe("lan");
+    expect(connectionKindForHost("100.64.0.1")).toBe("overlay");
+    expect(connectionKindForHost("machine.ts.net")).toBe("overlay");
+    expect(connectionKindForHost("app.example.com")).toBe("public");
+  });
+
+  it("summarizes an origin for reconnect copy", () => {
+    expect(describeConnectionOrigin("https://app.example.com/app")).toBe(
+      "app.example.com · https · public",
+    );
+    expect(describeConnectionOrigin("http://192.168.1.20:3100")).toBe(
+      "192.168.1.20:3100 · http · local network",
+    );
+    expect(describeConnectionOrigin("https://box.tail12345.ts.net")).toBe(
+      "box.tail12345.ts.net · https · private overlay",
+    );
+    expect(describeConnectionOrigin("ftp://files.example.com")).toBeNull();
+  });
+
+  it("hints when HTTPS or an overlay client is required", () => {
+    expect(connectionHintForOrigin("http://app.example.com")).toBe("Public servers need https://.");
+    expect(connectionHintForOrigin("http://machine.ts.net")).toBe("MagicDNS needs https://.");
+    expect(connectionHintForOrigin("https://machine.ts.net")).toBe(
+      "Join the same Tailscale or EasyTier network as the server.",
+    );
+    expect(connectionHintForOrigin("http://100.64.0.1:3100")).toBe(
+      "Join the same Tailscale or EasyTier network as the server.",
+    );
+    expect(connectionHintForOrigin("https://app.example.com")).toBeNull();
+    expect(connectionHintForOrigin("http://192.168.1.20:3100")).toBeNull();
+  });
+});

--- a/packages/core/src/connection-kind.ts
+++ b/packages/core/src/connection-kind.ts
@@ -1,29 +1,11 @@
 import {
   allowsCleartextHttp,
+  isCgnatHost,
   isLoopbackHost,
   isTailscaleMagicDnsHost,
-  unbracketedHost,
 } from "./network-host.js";
 
 export type ConnectionKind = "loopback" | "lan" | "overlay" | "public";
-
-function ipv4Octets(host: string): [number, number, number, number] | undefined {
-  const parts = host.split(".");
-  if (parts.length !== 4) return undefined;
-  const octets = parts.map((part) => {
-    if (!/^\d{1,3}$/.test(part)) return Number.NaN;
-    return Number(part);
-  });
-  if (octets.some((value) => !Number.isInteger(value) || value < 0 || value > 255)) {
-    return undefined;
-  }
-  return octets as [number, number, number, number];
-}
-
-function isCgnatHost(hostname: string): boolean {
-  const octets = ipv4Octets(unbracketedHost(hostname));
-  return octets !== undefined && octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127;
-}
 
 export function connectionKindForHost(hostname: string): ConnectionKind {
   if (isLoopbackHost(hostname)) return "loopback";
@@ -56,6 +38,9 @@ export function connectionHintForOrigin(url: string): string | null {
     const parsed = new URL(url);
     if (parsed.protocol === "http:" && isTailscaleMagicDnsHost(parsed.hostname)) {
       return "MagicDNS needs https://.";
+    }
+    if (parsed.protocol === "http:" && isCgnatHost(parsed.hostname)) {
+      return "Overlay IPs need https://.";
     }
     if (parsed.protocol === "http:" && !allowsCleartextHttp(parsed.hostname)) {
       return "Public servers need https://.";

--- a/packages/core/src/connection-kind.ts
+++ b/packages/core/src/connection-kind.ts
@@ -1,0 +1,70 @@
+import {
+  allowsCleartextHttp,
+  isLoopbackHost,
+  isTailscaleMagicDnsHost,
+  unbracketedHost,
+} from "./network-host.js";
+
+export type ConnectionKind = "loopback" | "lan" | "overlay" | "public";
+
+function ipv4Octets(host: string): [number, number, number, number] | undefined {
+  const parts = host.split(".");
+  if (parts.length !== 4) return undefined;
+  const octets = parts.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) return Number.NaN;
+    return Number(part);
+  });
+  if (octets.some((value) => !Number.isInteger(value) || value < 0 || value > 255)) {
+    return undefined;
+  }
+  return octets as [number, number, number, number];
+}
+
+function isCgnatHost(hostname: string): boolean {
+  const octets = ipv4Octets(unbracketedHost(hostname));
+  return octets !== undefined && octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127;
+}
+
+export function connectionKindForHost(hostname: string): ConnectionKind {
+  if (isLoopbackHost(hostname)) return "loopback";
+  if (isTailscaleMagicDnsHost(hostname) || isCgnatHost(hostname)) return "overlay";
+  if (allowsCleartextHttp(hostname)) return "lan";
+  return "public";
+}
+
+export function connectionKindLabel(kind: ConnectionKind): string {
+  if (kind === "loopback") return "this computer";
+  if (kind === "lan") return "local network";
+  if (kind === "overlay") return "private overlay";
+  return "public";
+}
+
+/** Compact origin + scheme + network class for reconnect and server-setup copy. */
+export function describeConnectionOrigin(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    const scheme = parsed.protocol === "https:" ? "https" : "http";
+    return `${parsed.host} · ${scheme} · ${connectionKindLabel(connectionKindForHost(parsed.hostname))}`;
+  } catch {
+    return null;
+  }
+}
+
+export function connectionHintForOrigin(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:" && isTailscaleMagicDnsHost(parsed.hostname)) {
+      return "MagicDNS needs https://.";
+    }
+    if (parsed.protocol === "http:" && !allowsCleartextHttp(parsed.hostname)) {
+      return "Public servers need https://.";
+    }
+    if (connectionKindForHost(parsed.hostname) === "overlay") {
+      return "Join the same Tailscale or EasyTier network as the server.";
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export * from "./message-visibility.js";
 export * from "./messaging-commands.js";
 export * from "./messaging-prompts.js";
 export * from "./model-oauth.js";
+export * from "./network-host.js";
 export * from "./run-state.js";
 export * from "./sandbox-command.js";
 export * from "./screen-lease.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export * from "./compose-update.js";
 export * from "./composer-mention-picker.js";
 export * from "./composer-mentions.js";
 export * from "./composer-slash.js";
+export * from "./connection-kind.js";
 export * from "./cron.js";
 export * from "./duration.js";
 export * from "./events.js";

--- a/packages/core/src/network-host.test.ts
+++ b/packages/core/src/network-host.test.ts
@@ -28,6 +28,7 @@ describe("network host policy", () => {
     expect(isLinkLocalHost("169.254.1.1")).toBe(true);
     expect(isLinkLocalHost("[fe80::1]")).toBe(true);
     expect(isLinkLocalHost("fe80::1")).toBe(true);
+    expect(isLinkLocalHost("fe80.example.com")).toBe(false);
     expect(isLinkLocalHost("10.0.0.1")).toBe(false);
   });
 
@@ -53,6 +54,8 @@ describe("network host policy", () => {
 
   it("rejects cleartext HTTP to public DNS, MagicDNS, and link-local", () => {
     expect(allowsCleartextHttp("app.example.com")).toBe(false);
+    expect(allowsCleartextHttp("fd.example.com")).toBe(false);
+    expect(allowsCleartextHttp("fc-host.example.com")).toBe(false);
     expect(allowsCleartextHttp("machine.ts.net")).toBe(false);
     expect(allowsCleartextHttp("169.254.169.254")).toBe(false);
     expect(allowsCleartextHttp("[fe80::1]")).toBe(false);

--- a/packages/core/src/network-host.test.ts
+++ b/packages/core/src/network-host.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  allowsCleartextHttp,
+  isLinkLocalHost,
+  isLoopbackHost,
+  isTailscaleMagicDnsHost,
+  unbracketedHost,
+} from "./network-host.js";
+
+describe("network host policy", () => {
+  it("normalizes IPv6 brackets", () => {
+    expect(unbracketedHost("[fd00::1]")).toBe("fd00::1");
+    expect(unbracketedHost("LOCALHOST")).toBe("localhost");
+  });
+
+  it("detects loopback", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("127.1.2.3")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("dev.localhost")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("[::1]")).toBe(true);
+    expect(isLoopbackHost("10.0.0.1")).toBe(false);
+  });
+
+  it("detects link-local metadata ranges", () => {
+    expect(isLinkLocalHost("169.254.169.254")).toBe(true);
+    expect(isLinkLocalHost("169.254.1.1")).toBe(true);
+    expect(isLinkLocalHost("[fe80::1]")).toBe(true);
+    expect(isLinkLocalHost("fe80::1")).toBe(true);
+    expect(isLinkLocalHost("10.0.0.1")).toBe(false);
+  });
+
+  it("detects Tailscale MagicDNS names", () => {
+    expect(isTailscaleMagicDnsHost("machine.ts.net")).toBe(true);
+    expect(isTailscaleMagicDnsHost("box.tail12345.ts.net")).toBe(true);
+    expect(isTailscaleMagicDnsHost("ts.net")).toBe(true);
+    expect(isTailscaleMagicDnsHost("notts.net")).toBe(false);
+    expect(isTailscaleMagicDnsHost("example.com")).toBe(false);
+  });
+
+  it("allows cleartext HTTP on LAN, loopback, CGNAT, ULA, and .local", () => {
+    expect(allowsCleartextHttp("127.0.0.1")).toBe(true);
+    expect(allowsCleartextHttp("10.0.0.8")).toBe(true);
+    expect(allowsCleartextHttp("192.168.1.20")).toBe(true);
+    expect(allowsCleartextHttp("172.16.0.2")).toBe(true);
+    expect(allowsCleartextHttp("100.64.0.1")).toBe(true);
+    expect(allowsCleartextHttp("100.119.57.55")).toBe(true);
+    expect(allowsCleartextHttp("rakazo.local")).toBe(true);
+    expect(allowsCleartextHttp("[fd00::1]")).toBe(true);
+    expect(allowsCleartextHttp("fc00::2")).toBe(true);
+  });
+
+  it("rejects cleartext HTTP to public DNS, MagicDNS, and link-local", () => {
+    expect(allowsCleartextHttp("app.example.com")).toBe(false);
+    expect(allowsCleartextHttp("machine.ts.net")).toBe(false);
+    expect(allowsCleartextHttp("169.254.169.254")).toBe(false);
+    expect(allowsCleartextHttp("[fe80::1]")).toBe(false);
+    expect(allowsCleartextHttp("8.8.8.8")).toBe(false);
+  });
+});

--- a/packages/core/src/network-host.test.ts
+++ b/packages/core/src/network-host.test.ts
@@ -55,6 +55,7 @@ describe("network host policy", () => {
   it("rejects cleartext HTTP to public DNS, MagicDNS, and link-local", () => {
     expect(allowsCleartextHttp("app.example.com")).toBe(false);
     expect(allowsCleartextHttp("fd.example.com")).toBe(false);
+    expect(allowsCleartextHttp("fc.evil.com")).toBe(false);
     expect(allowsCleartextHttp("fc-host.example.com")).toBe(false);
     expect(allowsCleartextHttp("machine.ts.net")).toBe(false);
     expect(allowsCleartextHttp("169.254.169.254")).toBe(false);

--- a/packages/core/src/network-host.test.ts
+++ b/packages/core/src/network-host.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   allowsCleartextHttp,
+  isCgnatHost,
   isLinkLocalHost,
   isLoopbackHost,
   isTailscaleMagicDnsHost,
@@ -40,24 +41,33 @@ describe("network host policy", () => {
     expect(isTailscaleMagicDnsHost("example.com")).toBe(false);
   });
 
-  it("allows cleartext HTTP on LAN, loopback, CGNAT, ULA, and .local", () => {
+  it("detects CGNAT 100.64/10 hosts", () => {
+    expect(isCgnatHost("100.64.0.1")).toBe(true);
+    expect(isCgnatHost("100.119.57.55")).toBe(true);
+    expect(isCgnatHost("100.127.255.255")).toBe(true);
+    expect(isCgnatHost("100.63.255.255")).toBe(false);
+    expect(isCgnatHost("100.128.0.1")).toBe(false);
+    expect(isCgnatHost("10.0.0.1")).toBe(false);
+  });
+
+  it("allows cleartext HTTP on LAN, loopback, ULA, and .local", () => {
     expect(allowsCleartextHttp("127.0.0.1")).toBe(true);
     expect(allowsCleartextHttp("10.0.0.8")).toBe(true);
     expect(allowsCleartextHttp("192.168.1.20")).toBe(true);
     expect(allowsCleartextHttp("172.16.0.2")).toBe(true);
-    expect(allowsCleartextHttp("100.64.0.1")).toBe(true);
-    expect(allowsCleartextHttp("100.119.57.55")).toBe(true);
     expect(allowsCleartextHttp("rakazo.local")).toBe(true);
     expect(allowsCleartextHttp("[fd00::1]")).toBe(true);
     expect(allowsCleartextHttp("fc00::2")).toBe(true);
   });
 
-  it("rejects cleartext HTTP to public DNS, MagicDNS, and link-local", () => {
+  it("rejects cleartext HTTP to public DNS, MagicDNS, CGNAT, and link-local", () => {
     expect(allowsCleartextHttp("app.example.com")).toBe(false);
     expect(allowsCleartextHttp("fd.example.com")).toBe(false);
     expect(allowsCleartextHttp("fc.evil.com")).toBe(false);
     expect(allowsCleartextHttp("fc-host.example.com")).toBe(false);
     expect(allowsCleartextHttp("machine.ts.net")).toBe(false);
+    expect(allowsCleartextHttp("100.64.0.1")).toBe(false);
+    expect(allowsCleartextHttp("100.119.57.55")).toBe(false);
     expect(allowsCleartextHttp("169.254.169.254")).toBe(false);
     expect(allowsCleartextHttp("[fe80::1]")).toBe(false);
     expect(allowsCleartextHttp("8.8.8.8")).toBe(false);

--- a/packages/core/src/network-host.ts
+++ b/packages/core/src/network-host.ts
@@ -32,6 +32,7 @@ export function isLinkLocalHost(hostname: string): boolean {
   const host = unbracketedHost(hostname);
   const ipv4 = ipv4Octets(host);
   if (ipv4) return ipv4[0] === 169 && ipv4[1] === 254;
+  if (!host.includes(":")) return false;
   const first = host.split(":", 1)[0] ?? "";
   return /^fe[89ab]/.test(first);
 }
@@ -65,6 +66,7 @@ export function allowsCleartextHttp(hostname: string): boolean {
     );
   }
 
+  if (!host.includes(":")) return false;
   const first = host.split(":", 1)[0] ?? "";
   return /^f[cd]/.test(first);
 }

--- a/packages/core/src/network-host.ts
+++ b/packages/core/src/network-host.ts
@@ -1,0 +1,70 @@
+/** Strip IPv6 brackets and lowercase a hostname from a URL. */
+export function unbracketedHost(hostname: string): string {
+  return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+}
+
+function ipv4Octets(host: string): [number, number, number, number] | undefined {
+  const parts = host.split(".");
+  if (parts.length !== 4) return undefined;
+  const octets = parts.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) return Number.NaN;
+    return Number(part);
+  });
+  if (octets.some((value) => !Number.isInteger(value) || value < 0 || value > 255)) {
+    return undefined;
+  }
+  return octets as [number, number, number, number];
+}
+
+export function isLoopbackHost(hostname: string): boolean {
+  const host = unbracketedHost(hostname);
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1") return true;
+  const ipv4 = ipv4Octets(host);
+  return ipv4?.[0] === 127;
+}
+
+/**
+ * Link-local addresses (IPv4 169.254/16, IPv6 fe80::/10) often host cloud
+ * metadata endpoints. Cleartext HTTP to them is never a legitimate Rakazo origin.
+ */
+export function isLinkLocalHost(hostname: string): boolean {
+  const host = unbracketedHost(hostname);
+  const ipv4 = ipv4Octets(host);
+  if (ipv4) return ipv4[0] === 169 && ipv4[1] === 254;
+  const first = host.split(":", 1)[0] ?? "";
+  return /^fe[89ab]/.test(first);
+}
+
+/** Tailscale MagicDNS names. They resolve to CGNAT; the hostname itself is public DNS. */
+export function isTailscaleMagicDnsHost(hostname: string): boolean {
+  const host = unbracketedHost(hostname).replace(/\.$/, "");
+  return host === "ts.net" || host.endsWith(".ts.net");
+}
+
+/**
+ * Whether a Rakazo client may use cleartext HTTP to this host.
+ *
+ * Allowed: loopback, RFC1918, CGNAT 100.64/10 (Tailscale and similar overlays),
+ * IPv6 unique-local, and *.local. MagicDNS (*.ts.net) requires HTTPS. Link-local
+ * is never allowed.
+ */
+export function allowsCleartextHttp(hostname: string): boolean {
+  const host = unbracketedHost(hostname);
+  if (isLinkLocalHost(host) || isTailscaleMagicDnsHost(host)) return false;
+  if (isLoopbackHost(host) || host.endsWith(".local")) return true;
+
+  const ipv4 = ipv4Octets(host);
+  if (ipv4) {
+    const [first, second] = ipv4;
+    return (
+      first === 10 ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168) ||
+      (first === 100 && second >= 64 && second <= 127)
+    );
+  }
+
+  const first = host.split(":", 1)[0] ?? "";
+  return /^f[cd]/.test(first);
+}

--- a/packages/core/src/network-host.ts
+++ b/packages/core/src/network-host.ts
@@ -44,15 +44,26 @@ export function isTailscaleMagicDnsHost(hostname: string): boolean {
 }
 
 /**
+ * Carrier-grade NAT 100.64/10. Tailscale and similar overlays use this range, but
+ * so can ordinary ISP CGNAT — the address alone does not prove a trusted overlay.
+ */
+export function isCgnatHost(hostname: string): boolean {
+  const octets = ipv4Octets(unbracketedHost(hostname));
+  return octets !== undefined && octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127;
+}
+
+/**
  * Whether a Rakazo client may use cleartext HTTP to this host.
  *
- * Allowed: loopback, RFC1918, CGNAT 100.64/10 (Tailscale and similar overlays),
- * IPv6 unique-local, and *.local. MagicDNS (*.ts.net) requires HTTPS. Link-local
- * is never allowed.
+ * Allowed: loopback, RFC1918, IPv6 unique-local, and *.local. CGNAT 100.64/10 and
+ * MagicDNS (*.ts.net) require HTTPS — the IP/DNS label alone cannot prove a
+ * trusted overlay path. Link-local is never allowed.
  */
 export function allowsCleartextHttp(hostname: string): boolean {
   const host = unbracketedHost(hostname);
-  if (isLinkLocalHost(host) || isTailscaleMagicDnsHost(host)) return false;
+  if (isLinkLocalHost(host) || isTailscaleMagicDnsHost(host) || isCgnatHost(host)) {
+    return false;
+  }
   if (isLoopbackHost(host) || host.endsWith(".local")) return true;
 
   const ipv4 = ipv4Octets(host);
@@ -61,8 +72,7 @@ export function allowsCleartextHttp(hostname: string): boolean {
     return (
       first === 10 ||
       (first === 172 && second >= 16 && second <= 31) ||
-      (first === 192 && second === 168) ||
-      (first === 100 && second >= 64 && second <= 127)
+      (first === 192 && second === 168)
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@rakazo/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
+      '@rakazo/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       electron-updater:
         specifier: ^6.8.9
         version: 6.8.9


### PR DESCRIPTION
## Summary

- Share overlay host policy across desktop, mobile, and the Android allowlist: CGNAT (`100.64/10`) may use HTTP; Tailscale MagicDNS (`*.ts.net`) requires HTTPS
- Keep the web workspace mounted after a session has loaded; show a compact reconnect bar instead of unmounting the shell
- Drop mobile snapshot polling on an open thread. SSE subscribe with cursor reconnect is the live path; refresh the snapshot only when the stream drops
- Classify loopback / LAN / overlay / public origins so reconnect and custom-server setup can say which network the client is using
- Document Tunnel, Tailscale, and EasyTier sidecar paths without bundling a VPN

## Why

Self-hosted clients on Tailscale or EasyTier mixed public DNS (MagicDNS) with overlay IPs. Desktop previously rejected CGNAT HTTP. An unreachable API also unmounted the workspace (and a cold load that never reached the server looked like sign-out).

## How tested

- `pnpm exec vitest run` on `connection-kind`, `network-host`, `setup-config`, `endpoint`, `refresh`, `session-gate`, and `android-platform-contract` (78 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer connection-origin details and setup guidance for desktop and mobile server connections.
  * Improved support for local networks, CGNAT, overlay networks, and Tailscale addresses with appropriate HTTP/HTTPS handling.
  * Added reconnect banners and blocking reconnect screens for web session interruptions.
  * Added server URL summaries to the mobile sign-in screen.
* **Bug Fixes**
  * Improved mobile thread subscription recovery with capped retry backoff and idle-stream detection.
* **Documentation**
  * Added guidance for connecting to self-hosted deployments without a public IP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->