### PR TITLE
fix(adapters): keep versioned OpenAI-compatible API roots

### DIFF
--- a/packages/adapters/src/openai-compatible-url.test.ts
+++ b/packages/adapters/src/openai-compatible-url.test.ts
@@ -26,6 +26,37 @@ describe("openai-compatible URL policy", () => {
     );
   });
 
+  it("treats any /vN versioned API root as complete (no /v1 append)", () => {
+    expect(normalizeOpenAiCompatibleBaseUrl("http://127.0.0.1:8000/v4")).toBe(
+      "http://127.0.0.1:8000/v4",
+    );
+    expect(normalizeOpenAiCompatibleBaseUrl("http://127.0.0.1:8000/v2")).toBe(
+      "http://127.0.0.1:8000/v2",
+    );
+    expect(normalizeOpenAiCompatibleBaseUrl("http://127.0.0.1:8000/v3")).toBe(
+      "http://127.0.0.1:8000/v3",
+    );
+    expect(normalizeOpenAiCompatibleBaseUrl("http://127.0.0.1:8000/v10")).toBe(
+      "http://127.0.0.1:8000/v10",
+    );
+    expect(normalizeOpenAiCompatibleBaseUrl("https://open.bigmodel.cn/api/paas/v4")).toBe(
+      "https://open.bigmodel.cn/api/paas/v4",
+    );
+    expect(normalizeOpenAiCompatibleBaseUrl("https://open.bigmodel.cn/api/paas/v4/")).toBe(
+      "https://open.bigmodel.cn/api/paas/v4",
+    );
+    expect(normalizeOpenAiCompatibleBaseUrl("http://127.0.0.1:8000/api")).toBe(
+      "http://127.0.0.1:8000/api/v1",
+    );
+  });
+
+  it("allows public bigmodel host when ALLOW_PUBLIC=1 without rewriting /v4", () => {
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    expect(assertAllowedOpenAiCompatibleUrl("https://open.bigmodel.cn/api/paas/v4").href).toBe(
+      "https://open.bigmodel.cn/api/paas/v4",
+    );
+  });
+
   it("validates request URLs without changing their path", () => {
     expect(
       assertAllowedOpenAiCompatibleRequestUrl("http://127.0.0.1:8000/v1/chat/completions").href,

--- a/packages/adapters/src/openai-compatible-url.ts
+++ b/packages/adapters/src/openai-compatible-url.ts
@@ -25,7 +25,8 @@ export function normalizeOpenAiCompatibleBaseUrl(raw: string): string {
     throw new Error("Base URL must not contain credentials");
   }
   let path = url.pathname.replace(/\/+$/, "") || "";
-  if (!path.endsWith("/v1")) {
+  const VERSIONED_API_ROOT = /\/v\d+$/;
+  if (!VERSIONED_API_ROOT.test(path)) {
     path = path ? `${path}/v1` : "/v1";
   }
   return `${url.origin}${path}`;


### PR DESCRIPTION
## Why

OpenAI-compatible base URL normalization previously treated only `/v1` as a complete API root. Bases that already end in another version root (`/v2`, `/v3`, `/v4`, `/v10`, or nested paths like `/api/paas/v4`) were incorrectly rewritten to append `/v1` (e.g. `/api/paas/v4` → `/api/paas/v4/v1`), which breaks callers that use a non-`v1` OpenAI-compatible root.

## What

Broaden `normalizeOpenAiCompatibleBaseUrl` so any path ending in `/v` + digits is treated as a complete root. Unversioned bases still get `/v1` appended as before. Host allow/block and `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC` are unchanged. No vendor-specific providers or presets.

## Tests

- Extended `openai-compatible-url.test.ts` for `/v2`–`/v10`, `/api/paas/v4`, and unversioned `/api` → `/api/v1`.
- Focused vitest + adapters package tests green after rebase onto current `main`.

## Scope

- `packages/adapters/src/openai-compatible-url.ts`
- `packages/adapters/src/openai-compatible-url.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI-compatible API URLs with versioned paths such as `/v2`, `/v3`, `/v4`, or `/v10` are now preserved without an incorrect `/v1` suffix.
  * Unversioned API paths continue to receive the expected `/v1` suffix.
  * Public BigModel API URLs are supported when public access is enabled, with their versioned paths preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->