### PR TITLE
fix(compose): allow generic installer download base override

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ with the matching API key.
 Default image tag is `edge` (main builds, `linux/amd64`). Details and tags:
 [self-hosting guide](./docs/self-host.md#published-images-no-checkout).
 
+On restricted networks, override the installer download base (`RAKAZO_DOWNLOAD_BASE`), skip
+existing Compose files (`--local` / `RAKAZO_DOWNLOAD_SKIP_EXISTING`), or mirror the bootstrap
+script URL — see
+[Restricted networks / mirror downloads](./docs/self-host.md#restricted-networks--mirror-downloads).
+
 For an agent-assisted install, use [SETUP_PROMPT.md](./SETUP_PROMPT.md).
 
 ## Local development (source checkout)

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -39,8 +39,13 @@ Setup:
 1. Create the directory if needed and enter it.
 2. Download and inspect this installer (do not clone the repository):
    https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose/install-images.sh
+   If that host is unreachable, use a mirror URL (e.g. set `RAKAZO_INSTALLER_URL` to
+   `https://example.com/mirror/rakazo/infra/compose/install-images.sh` and curl that instead).
 3. Run `bash install-images.sh --prepare-only`. It downloads the Compose and environment example
    files, then creates `.env` with all required random secrets when one does not already exist.
+   Optional: set `RAKAZO_DOWNLOAD_BASE` to a generic mirror of `infra/compose`, and/or use
+   `--local` / `RAKAZO_DOWNLOAD_SKIP_EXISTING=1` when Compose files are already present locally.
+   See docs/self-host.md (Restricted networks / mirror downloads).
 4. Preserve existing values. Keep `SANDBOX_PROVIDER=docker` unless I chose a remote computer
    provider, and add only the provider or model keys I selected.
 5. Run `bash install-images.sh`. It preserves `.env`, pulls the images, and starts the stack.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -34,8 +34,8 @@ export RAKAZO_DOWNLOAD_BASE=https://example.com/mirror/rakazo/infra/compose
 bash install-images.sh
 ```
 
-Trailing slashes on `RAKAZO_DOWNLOAD_BASE` are trimmed. Downloads use finite curl retries
-(`--retry 3 --retry-delay 2 --retry-all-errors` when supported).
+Trailing slashes on `RAKAZO_DOWNLOAD_BASE` are trimmed; non-HTTPS bases are rejected. Downloads
+use finite curl retries (`--retry 3 --retry-delay 2 --retry-all-errors` when supported).
 
 To reuse files already present in the working directory (skip curl when the target exists), set
 `RAKAZO_DOWNLOAD_SKIP_EXISTING=1` and/or pass `--local`:

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -21,6 +21,44 @@ The installer downloads `docker-compose.images.yml` and `.env.images.example`, c
 random secrets, then pulls and starts the images. It preserves an existing `.env` when rerun. To
 customize the public URL, image tag, or optional providers before startup, run
 `bash install-images.sh --prepare-only`, edit `.env`, then run `bash install-images.sh`.
+Flags may be combined in either order: `--prepare-only`, `--local`.
+
+### Restricted networks / mirror downloads
+
+Stage B of the installer (Compose YAML and `.env.images.example`) downloads from
+`DOWNLOAD_BASE`. Override it with a generic HTTPS mirror of `infra/compose` — do not rely on
+vendor-specific CDN defaults:
+
+```bash
+export RAKAZO_DOWNLOAD_BASE=https://example.com/mirror/rakazo/infra/compose
+bash install-images.sh
+```
+
+Trailing slashes on `RAKAZO_DOWNLOAD_BASE` are trimmed. Downloads use finite curl retries
+(`--retry 3 --retry-delay 2 --retry-all-errors` when supported).
+
+To reuse files already present in the working directory (skip curl when the target exists), set
+`RAKAZO_DOWNLOAD_SKIP_EXISTING=1` and/or pass `--local`:
+
+```bash
+# after placing docker-compose.images.yml and .env.images.example locally
+bash install-images.sh --local --prepare-only
+# or
+RAKAZO_DOWNLOAD_SKIP_EXISTING=1 bash install-images.sh --prepare-only
+```
+
+If skip mode is on and a required file is missing, the installer still downloads it (or fails with
+the URL in the error).
+
+Stage A (fetching `install-images.sh` itself) is separate. When raw GitHub is unreachable, point the
+bootstrap curl at your mirror of the installer script, for example:
+
+```bash
+export RAKAZO_INSTALLER_URL=https://example.com/mirror/rakazo/infra/compose/install-images.sh
+mkdir -p rakazo && cd rakazo &&
+curl -fsSLO "${RAKAZO_INSTALLER_URL}" &&
+bash install-images.sh
+```
 
 `SANDBOX_PROVIDER` defaults to `docker`. The images Compose file runs a sandbox supervisor
 (from the app image, on the internal network only) and pulls `ghcr.io/elie222/rakazo/computer`.

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -3,7 +3,16 @@
 set -Eeuo pipefail
 
 DOWNLOAD_BASE="${RAKAZO_DOWNLOAD_BASE:-https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose}"
-DOWNLOAD_BASE="${DOWNLOAD_BASE%/}"
+while [[ "$DOWNLOAD_BASE" == */ ]]; do
+  DOWNLOAD_BASE="${DOWNLOAD_BASE%/}"
+done
+case "$DOWNLOAD_BASE" in
+  https://*) ;;
+  *)
+    echo "Rakazo setup failed: RAKAZO_DOWNLOAD_BASE must use https." >&2
+    exit 1
+    ;;
+esac
 readonly DOWNLOAD_BASE
 
 readonly COMPOSE_FILE="docker-compose.images.yml"
@@ -57,13 +66,13 @@ curl_download() {
   local max_attempts=3
 
   if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
-    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "$url" -o "$out"
+    curl -fsSL --proto-redir =https --retry 3 --retry-delay 2 --retry-all-errors "$url" -o "$out"
     return $?
   fi
 
   attempt=1
   while [[ "$attempt" -le "$max_attempts" ]]; do
-    if curl -fsSL "$url" -o "$out"; then
+    if curl -fsSL --proto-redir =https "$url" -o "$out"; then
       return 0
     fi
     if [[ "$attempt" -eq "$max_attempts" ]]; then

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -2,18 +2,34 @@
 
 set -Eeuo pipefail
 
-readonly DOWNLOAD_BASE="https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose"
+DOWNLOAD_BASE="${RAKAZO_DOWNLOAD_BASE:-https://raw.githubusercontent.com/elie222/rakazo/main/infra/compose}"
+DOWNLOAD_BASE="${DOWNLOAD_BASE%/}"
+readonly DOWNLOAD_BASE
+
 readonly COMPOSE_FILE="docker-compose.images.yml"
 readonly ENV_EXAMPLE=".env.images.example"
 readonly ENV_FILE=".env"
 
 prepare_only=false
-if [[ "${1:-}" == "--prepare-only" && $# -eq 1 ]]; then
-  prepare_only=true
-elif [[ $# -ne 0 ]]; then
-  echo "Usage: bash install-images.sh [--prepare-only]" >&2
-  exit 2
+skip_existing=false
+if [[ "${RAKAZO_DOWNLOAD_SKIP_EXISTING:-}" == "1" ]]; then
+  skip_existing=true
 fi
+
+for arg in "$@"; do
+  case "$arg" in
+    --prepare-only)
+      prepare_only=true
+      ;;
+    --local)
+      skip_existing=true
+      ;;
+    *)
+      echo "Usage: bash install-images.sh [--prepare-only] [--local]" >&2
+      exit 2
+      ;;
+  esac
+done
 
 temporary_file=""
 cleanup() {
@@ -34,12 +50,43 @@ done
 
 docker compose version >/dev/null 2>&1 || fail "the Docker Compose plugin is required."
 
+curl_download() {
+  local url="$1"
+  local out="$2"
+  local attempt
+  local max_attempts=3
+
+  if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "$url" -o "$out"
+    return $?
+  fi
+
+  attempt=1
+  while [[ "$attempt" -le "$max_attempts" ]]; do
+    if curl -fsSL "$url" -o "$out"; then
+      return 0
+    fi
+    if [[ "$attempt" -eq "$max_attempts" ]]; then
+      return 1
+    fi
+    sleep 2
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
 download() {
   local filename="$1"
+  local url="${DOWNLOAD_BASE}/${filename}"
+
+  if [[ "$skip_existing" == true && -e "$filename" ]]; then
+    echo "Using local ${filename}"
+    return 0
+  fi
 
   temporary_file=$(mktemp "./${filename}.tmp.XXXXXX")
-  if ! curl -fsSL "${DOWNLOAD_BASE}/${filename}" -o "$temporary_file"; then
-    fail "could not download ${filename}."
+  if ! curl_download "$url" "$temporary_file"; then
+    fail "could not download ${filename} from ${url}."
   fi
   mv -- "$temporary_file" "$filename"
   temporary_file=""


### PR DESCRIPTION
## Why

Published-image quick start downloads Compose assets from a hardcoded raw.githubusercontent.com base with a single curl and no local-file skip. On restricted networks that host is often unreachable, so Stage B of install-images.sh fails even when the operator already has files locally or can reach a generic mirror.

## What

- RAKAZO_DOWNLOAD_BASE overrides the Compose asset download base (default unchanged; trailing slash trimmed)
- Finite curl retries (--retry when supported, else bash loop)
- Explicit skip of existing files via --local and/or RAKAZO_DOWNLOAD_SKIP_EXISTING=1
- Docs for generic HTTPS mirrors only (example.com) plus Stage A installer URL note
- No regional CDN defaults; RAKAZO_IMAGE* defaults unchanged

## Scope

- infra/compose/install-images.sh
- docs/self-host.md
- README.md
- SETUP_PROMPT.md

## Tests

- bash -n on installer
- default base unchanged; trailing-slash trim
- --local / skip-existing with unreachable override still succeeds when files present
- missing file under skip still attempts download and fails with URL after retries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for mirrored installer and Compose file downloads for restricted networks.
  - Added `--local` and `RAKAZO_DOWNLOAD_SKIP_EXISTING=1` options to reuse existing Compose files.
  - Added configurable download sources with retry handling and clearer download failure URLs.
  - Added support for combining `--prepare-only` and `--local` options.

- **Documentation**
  - Updated setup and self-hosting guides with installer options, mirror configuration, local-file behavior, and restricted-network guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->