### PR TITLE
docs(self-host): document Stage C image registry override for restricted networks

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -60,6 +60,27 @@ curl -fsSLO "${RAKAZO_INSTALLER_URL}" &&
 bash install-images.sh
 ```
 
+Stage C (`docker compose pull`) uses `RAKAZO_IMAGE`, `RAKAZO_IMAGE_TAG`,
+`RAKAZO_COMPUTER_IMAGE`, and `RAKAZO_COMPUTER_IMAGE_TAG` (defaults
+`ghcr.io/elie222/rakazo/{app,computer}`). When GHCR is unreachable, override those
+four in `.env` to a registry you control — keep app and computer on the same
+mirror. Do not rely on vendor-specific CDN defaults:
+
+```env
+RAKAZO_IMAGE=registry.example.com/mirror/elie222/rakazo/app
+RAKAZO_IMAGE_TAG=edge
+RAKAZO_COMPUTER_IMAGE=registry.example.com/mirror/elie222/rakazo/computer
+RAKAZO_COMPUTER_IMAGE_TAG=edge
+```
+
+After `--prepare-only`, edit `.env` then rerun `bash install-images.sh` (or
+`docker compose --env-file .env -f docker-compose.images.yml pull`). Arm64 tag
+pairing is unchanged — set both tags to the same published multi-arch release
+(see [Published images and tags](#published-images-and-tags)).
+
+`postgres:16` and `busybox:1` still pull from Docker Hub. Stage C does not cover
+them; configure the Docker daemon `registry-mirrors` or vendor those images.
+
 `SANDBOX_PROVIDER` defaults to `docker`. The images Compose file runs a sandbox supervisor
 (from the app image, on the internal network only) and pulls `ghcr.io/elie222/rakazo/computer`.
 Signup and local Docker computers work without an E2B account. Optional remote providers: set

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -24,6 +24,8 @@ SIGNUP_ALLOWLIST=
 SMTP_URL=
 EMAIL_FROM=
 
+# Restricted-network / registry-mirror escape hatch: override these four when
+# GHCR is unreachable. Keep app + computer on the same mirror. Defaults stay GHCR.
 # edge tracks main (amd64 only). Pin a published release tag when you need arm64 or a fixed version.
 RAKAZO_IMAGE=ghcr.io/elie222/rakazo/app
 RAKAZO_IMAGE_TAG=edge


### PR DESCRIPTION
## Why

After #484, Restricted networks docs cover Stage A (`RAKAZO_INSTALLER_URL`) and Stage B (`RAKAZO_DOWNLOAD_BASE` / `--local`). Stage C — `docker compose pull` for app/computer images — already supports `RAKAZO_IMAGE` / `RAKAZO_COMPUTER_IMAGE` (+ tags) but was not documented as a restricted-network / GHCR-unreachable escape hatch.

## What

- Docs-only: extend `docs/self-host.md` Restricted networks with Stage C (generic registry mirror example; no regional CDN brands)
- Comments in `infra/compose/.env.images.example` above the four image vars
- Caveat that `postgres` / `busybox` still come from Docker Hub unless the operator configures daemon mirrors

## Out of scope

- No compose/runtime/default changes
- No install-images.sh changes
- No Feishu/messaging (#486)

## Test

Docs review only; no code path change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added self-hosting guidance for configuring alternate container registries when GHCR is inaccessible.
  * Documented environment variables for overriding app and computer image names and tags.
  * Clarified that PostgreSQL and BusyBox images continue to use Docker Hub.
  * Added an example configuration for registry overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->