### PR TITLE
chore(sync): fork-sync check 2026-09-02 — diverged, 5018ceb absent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,11 @@ SENDBLUE_API_KEY_ID=
 SENDBLUE_API_SECRET=
 SENDBLUE_SIGNING_SECRET=
 SENDBLUE_PHONE_NUMBER=
+# Messaging transport selection: sendblue (default) | chat-sdk.
+MESSAGING_PROVIDER=sendblue
+# chat-sdk adapter registry name. Required only with MESSAGING_PROVIDER=chat-sdk;
+# the adapter itself is registered in the composition roots by its vendor package.
+MESSAGING_CHATSDK_ADAPTER=
 SUPERMEMORY_API_KEY=
 # Optional. Defaults to https://api.supermemory.ai. Self-hosted: http://localhost:6767
 SUPERMEMORY_API_URL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Generic chat-sdk messaging transport behind the messaging provider contract: `MESSAGING_PROVIDER` selects sendblue (default) or chat-sdk, and `MESSAGING_CHATSDK_ADAPTER` names the registered adapter. Phone surfaces stay disabled until a concrete adapter is configured.
 - Voice mode: speak replies, hold-to-talk dictation, and half-duplex calls. Speech sits behind a `VoiceProvider` interface (ElevenLabs, OpenAI, Cartesia) so the product is not tied to one vendor. Keys stay on the server.
 - Electron first-run: Docker (default) or this Mac. This Mac runs the bot shell as you, with working directories under your home folder. macOS does not show its own permission dialog; the consent is Rakazo's. The choice is owner-only and is refused when `SANDBOX_PROVIDER` is not `docker` (so E2B and test fakes cannot enable it).
 - GitHub Copilot and SuperGrok / X Premium sign-in via Pi device-code OAuth (`openai-codex`, `github-copilot`, `xai`). Claude Pro is still omitted because Pi's Claude login uses a localhost callback that does not work from the web app.

--- a/FORK_SYNC_REPORT.md
+++ b/FORK_SYNC_REPORT.md
@@ -1,0 +1,87 @@
+# Fork Sync Report — 2026-09-02
+
+Worktree: `fm/rakazo-upstream-sync` @ `/Users/timoteosousa/.treehouse/rakazo-da74b8/1/rakazo`
+Remotes: `origin` = Timoteohss/rakazo, `upstream` = elie222/rakazo
+
+## Fetches
+```
+git fetch upstream
+git fetch origin
+```
+Both succeeded. upstream/main advanced 478f104..c983641 (27 new commits).
+
+## Comparison
+
+### origin/main..upstream/main (what upstream has that origin doesn't) — 27 commits
+```
+c983641 fix(compose): allow generic installer download base override (#484)
+26ae909 Match Grok Bot: teach in chrome, muted Routines +, simpler sidepanel (#481)
+5029a13 fix(adapters): keep versioned OpenAI-compatible API roots (#482)
+b59408c feat(web): add Simplified Chinese UI locale (#480)
+de5b1e5 Require PR descriptions to state why a change exists (#477)
+f72bd16 Reuse Pi provider sessions across bot turns (#466)
+7387f95 fix(chat): show wall-clock worked duration (#461)
+6e003a2 fix(ui): unify error red across web and mobile (#462)
+211c30f fix(mobile): align Expo SDK 57 package versions (#467)
+b81cabf fix(chat): remove steering composer helper copy (#460)
+1b3687d fix(adapters): settle steering cancel and finalizeRun retries (#459)
+0366353 feat(chat): deliver steering messages while bots work (#453)
+35aecc1 ci: name PR-relevant Playwright frames in screenshot comments (#457)
+de73adc fix(web): stop seen run errors returning after reload (#449)
+bc37939 fix(api): stop resurfacing a failed run after a newer run finishes (#447)
+af9de9f fix(ci): restore computer image GHCR publishing (#454)
+9c7e9f9 Stop labelling older models "latest" in the model picker (#456)
+17ed9bc Add password reset and provider-neutral email (#446)
+2565cfa Don't fail every turn on an MCP tool enum TypeBox can't express (#450)
+920a0ef feat(chat): add tappable choice prompts (#433)
+92904b6 Multi-platform chat surface on Chat SDK (Slack, WhatsApp, Telegram + iMessage) (#444)
+7e1ef9e Collapse bot tool activity in chat (#440)
+826650c fix(chat): restore peer transcript markers (#443)
+89f45cc feat(adapters): lazily load large tool schemas (#429)
+cec819f fix: suppress roster attention for silent routines (#439)
+28e1ba1 Publish compatible mobile changes with EAS Update (#441)
+56f4b8a fix(web): keyboard completion for composer @mention picker (#432)
+```
+Count: `git rev-list origin/main..upstream/main --count` = 27
+
+### upstream/main..origin/main (what origin has that upstream doesn't — fork-specific) — 3 commits
+```
+002fd4b Merge pull request #1 from Timoteohss/fm/rakazo-chatsdk
+f2c9e5f no-mistakes(document): Fix stale messaging doc comments and changelog entry
+7053799 feat(adapters): add chat-sdk generic messaging transport
+```
+Count: `git rev-list upstream/main..origin/main --count` = 3
+Merge-base: `d2f2cef138c93ebdee58df668656638c8c31dbef` — `d2f2cef Improve mobile authentication flow (#437)`
+
+## Decision
+Fork has diverged (origin/main has 3 commits upstream lacks). Per task §4, **STOP** — no fast-forward, no force-push, no silent merge/rebase. Requires captain decision on reconciliation (merge upstream into origin/main, rebase fork commits on upstream, or other).
+
+`origin/main` was NOT updated to `upstream/main` in this run.
+
+## Commit 5018ceb Verification
+
+Target: `5018ceb3692cbec3929d6f2c3789d4f5f193e9b7` — `fix(messaging): sendblue-only DM cap; drop phone.deliver alias`
+
+Checks:
+```
+git log origin/main --oneline | grep 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7  → no match (exit 1)
+git merge-base --is-ancestor 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7 origin/main  → exit 1 (not ancestor)
+git log upstream/main --oneline | grep 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7 → no match (exit 1)
+git merge-base --is-ancestor 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7 upstream/main → exit 1 (not ancestor)
+git show --no-patch --oneline 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7 → commit exists locally (fetched)
+git branch -a --contains 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7 → only remotes/upstream/chatsdk-multi-platform-chat
+```
+
+**Result: NO — commit 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7 is NOT present on `origin/main` (and not on `upstream/main` either). It lives only on `upstream/chatsdk-multi-platform-chat` (merge-base with main is 826650c). Even after syncing with upstream, it would still be absent because it is not on upstream/main.**
+
+## Reproduction Commands
+```
+git fetch upstream
+git fetch origin
+git log origin/main..upstream/main --oneline
+git log upstream/main..origin/main --oneline
+git log origin/main --oneline | grep 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7
+git merge-base --is-ancestor 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7 origin/main; echo $?
+git merge-base --is-ancestor 5018ceb3692cbec3929d6f2c3789d4f5f193e9b7 upstream/main; echo $?
+```
+

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -11,11 +11,14 @@ import type {
 } from "@rakazo/adapter-kit";
 import {
   applyPhoneOutboundStatus,
+  ChatSdkMessagingProvider,
   type ComposioProvider,
   type ConnectorRegistry,
+  chatSdkConfigFromEnv,
   createBackgroundJobHandlers,
   createConnectorStack,
   createJobReconciler,
+  createMessagingProvider,
   createPhoneContextLoader,
   createRunExecutor,
   createRunSandbox,
@@ -30,7 +33,6 @@ import {
   InMemoryRealtimeFanout,
   InstalledConnectorProvider,
   isComposioEnabled,
-  isPhoneSurfaceEnabled,
   isPipedreamEnabled,
   LocalAgentHomeStore,
   LocalArtifactStore,
@@ -45,7 +47,6 @@ import {
   pushTokenPath,
   type RemoteConnectorDependencies,
   ScriptedAgentRuntime,
-  SendBlueMessagingProvider,
   SpaceMemoryProviderResolver,
   sendBlueConfigFromEnv,
 } from "@rakazo/adapters";
@@ -179,11 +180,21 @@ export async function createApp(
     pipedreamOverride ??
     (isPipedreamEnabled(pipedreamConfig) ? new PipedreamConnector(pipedreamConfig) : undefined);
   const sendBlueConfig = sendBlueConfigFromEnv(env);
+  const chatSdkConfig = chatSdkConfigFromEnv({
+    messagingChatSdkAdapter: env.messagingChatSdkAdapter,
+  });
   const messaging =
     messagingOverride ??
-    (isPhoneSurfaceEnabled(sendBlueConfig, env.deploymentModelKey)
-      ? new SendBlueMessagingProvider(sendBlueConfig)
-      : undefined);
+    createMessagingProvider({
+      provider: env.messagingProvider,
+      deploymentModelKey: env.deploymentModelKey,
+      sendBlueConfig,
+      chatSdkConfig,
+    });
+  if (messaging instanceof ChatSdkMessagingProvider) {
+    // Fail fast on a misconfigured adapter instead of at first webhook.
+    await messaging.initialize();
+  }
   const installed = new InstalledConnectorProvider(prisma, secrets, remoteConnectors);
   const stack = createConnectorStack(isComposioEnabled(env.composioApiKey), composioOverride, [
     installed,
@@ -344,6 +355,7 @@ export async function createApp(
     if (matched) return c.newResponse(response.body, response);
     await next();
   });
+  mountWebhookHttpRoutes(app, { prisma, secrets, events, jobs });
   mountVoiceHttpRoutes(app, { prisma, secrets }, async (c) => {
     const session = await auth.api.getSession({ headers: sessionHeaders(c.req.raw) });
     if (!session?.user) return null;
@@ -351,9 +363,44 @@ export async function createApp(
       () => null,
     );
   });
-  mountWebhookHttpRoutes(app, { prisma, secrets, events, jobs });
-  // The phone webhook only exists when the messaging surface is enabled.
-  if (messaging && env.sendblueSigningSecret) {
+  const sendTyping = (toNumber: string) => {
+    // Keep the raw phone number out of trace ids — those reach logs
+    // and telemetry, a different trust boundary than the database.
+    const operationId = `phone.typing:${randomUUID()}`;
+    return (
+      messaging?.sendTypingIndicator?.(
+        { to: toNumber },
+        {
+          operationId,
+          traceId: operationId,
+          spaceId: "",
+          userId: "",
+          // Cosmetic side call: bound it so a stalled vendor response
+          // can never pin the webhook handler's event loop slot.
+          signal: AbortSignal.timeout(2000),
+        },
+      ) ?? Promise.resolve()
+    );
+  };
+  if (messaging instanceof ChatSdkMessagingProvider) {
+    messaging.onInbound(
+      createPhoneInboundHandler({
+        prisma,
+        events,
+        jobs,
+        provision: (phoneE164, policyEnv) => provisionPhoneIdentity(prisma, phoneE164, policyEnv),
+        signupPolicy: {
+          signupsEnabled: env.signupsEnabled,
+          signupAllowlist: env.signupAllowlist,
+        },
+        lineNumber: "",
+        typing: sendTyping,
+      }),
+    );
+    // chat-sdk owns webhook verification and parsing; the route delegates
+    // GET (challenge) and POST events to the transport unchanged.
+    mountPhoneWebhookRoutes(app, { delegate: (request) => messaging.handleWebhook(request) });
+  } else if (messaging && env.sendblueSigningSecret) {
     mountPhoneWebhookRoutes(app, {
       signingSecret: env.sendblueSigningSecret,
       signingHeader: "sb-signing-secret",
@@ -369,25 +416,7 @@ export async function createApp(
           signupAllowlist: env.signupAllowlist,
         },
         lineNumber: env.sendbluePhoneNumber ?? "",
-        typing: (toNumber) => {
-          // Keep the raw phone number out of trace ids — those reach logs
-          // and telemetry, a different trust boundary than the database.
-          const operationId = `phone.typing:${randomUUID()}`;
-          return (
-            messaging.sendTypingIndicator?.(
-              { to: toNumber },
-              {
-                operationId,
-                traceId: operationId,
-                spaceId: "",
-                userId: "",
-                // Cosmetic side call: bound it so a stalled vendor response
-                // can never pin the webhook handler's event loop slot.
-                signal: AbortSignal.timeout(2000),
-              },
-            ) ?? Promise.resolve()
-          );
-        },
+        typing: sendTyping,
       }),
     });
   }

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -41,6 +41,10 @@ export interface AppEnv {
   sendblueApiSecret: string | undefined;
   sendblueSigningSecret: string | undefined;
   sendbluePhoneNumber: string | undefined;
+  /** `MESSAGING_PROVIDER`: sendblue (default) | chat-sdk. */
+  messagingProvider: "sendblue" | "chat-sdk";
+  /** `MESSAGING_CHATSDK_ADAPTER`: registry name of the configured chat-sdk adapter. */
+  messagingChatSdkAdapter: string | undefined;
   defaultProvider: string;
   defaultModel: string;
   wakeupDriver: string;
@@ -98,6 +102,8 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     sendblueApiSecret: optional(source.SENDBLUE_API_SECRET),
     sendblueSigningSecret: optional(source.SENDBLUE_SIGNING_SECRET),
     sendbluePhoneNumber: optional(source.SENDBLUE_PHONE_NUMBER),
+    messagingProvider: source.MESSAGING_PROVIDER === "chat-sdk" ? "chat-sdk" : "sendblue",
+    messagingChatSdkAdapter: optional(source.MESSAGING_CHATSDK_ADAPTER),
     defaultProvider: deploymentModel.provider,
     defaultModel: deploymentModel.model,
     wakeupDriver: source.WAKEUP_DRIVER ?? "graphile",

--- a/apps/api/src/phone-webhook.test.ts
+++ b/apps/api/src/phone-webhook.test.ts
@@ -167,3 +167,42 @@ describe("phone webhook HTTP route", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 });
+
+describe("phone webhook delegate mode", () => {
+  it("delegates both GET and POST to the transport and returns its response", async () => {
+    const delegate = vi.fn(async (request: Request) =>
+      request.method === "GET"
+        ? new Response("challenge-echo", { status: 200 })
+        : new Response(null, { status: 200 }),
+    );
+    const app = new Hono();
+    mountPhoneWebhookRoutes(app, { delegate });
+
+    const getResponse = await app.request(PHONE_WEBHOOK_PATH, { method: "GET" });
+    expect(getResponse.status).toBe(200);
+    expect(await getResponse.text()).toBe("challenge-echo");
+
+    const postResponse = await app.request(PHONE_WEBHOOK_PATH, {
+      method: "POST",
+      body: receivePayload,
+      headers: { "content-type": "application/json" },
+    });
+    expect(postResponse.status).toBe(200);
+
+    expect(delegate).toHaveBeenCalledTimes(2);
+    expect(delegate.mock.calls[0]![0]).toBeInstanceOf(Request);
+  });
+
+  it("surfaces a transport failure as 5xx so platform retries see the failure", async () => {
+    const delegate = vi.fn(async () => {
+      throw new Error("transport exploded");
+    });
+    const app = new Hono();
+    mountPhoneWebhookRoutes(app, { delegate });
+
+    // Hono's default error handler converts the rejection into a 500; the
+    // platform only needs a non-2xx to retry.
+    const response = await app.request(PHONE_WEBHOOK_PATH, { method: "POST", body: "{}" });
+    expect(response.status).toBe(500);
+  });
+});

--- a/apps/api/src/phone-webhook.ts
+++ b/apps/api/src/phone-webhook.ts
@@ -29,10 +29,12 @@ export type PhoneWebhookDeps =
     };
 
 /**
- * Deployment phone-line inbound webhook. Verification is a static shared
- * secret (no HMAC available from the vendor), compared in constant time;
- * replay safety comes from the `phone:{message_handle}` client nonce
- * downstream. Mounted only when the phone surface is enabled.
+ * Deployment phone-line inbound webhook. In static-secret mode (SendBlue),
+ * verification is a shared secret (no HMAC available from the vendor),
+ * compared in constant time; replay safety comes from the `phone:{message_handle}`
+ * client nonce downstream. In delegate mode (chat-sdk) the transport owns
+ * verification (challenge handshake, signature checks) and parsing. Mounted
+ * only when the phone surface is enabled.
  */
 export function mountPhoneWebhookRoutes(app: Hono, deps: PhoneWebhookDeps) {
   if ("delegate" in deps) {

--- a/apps/api/src/phone-webhook.ts
+++ b/apps/api/src/phone-webhook.ts
@@ -9,15 +9,24 @@ import { readBoundedBody, WEBHOOK_MAX_BODY_BYTES } from "./webhook.js";
 
 export const PHONE_WEBHOOK_PATH = "/api/v1/phone/webhook";
 
-export type PhoneWebhookDeps = {
-  signingSecret: string;
-  /** Vendor auth header name (wired at the composition root). */
-  signingHeader: string;
-  /** Vendor-specific parse stays at the composition root / adapter boundary. */
-  parseInbound: (payload: unknown) => MessagingInboundEvent | null;
-  handle: (event: MessagingInboundMessage) => Promise<void>;
-  handleStatus?: (event: MessagingOutboundStatus) => Promise<void>;
-};
+export type PhoneWebhookDeps =
+  | {
+      /**
+       * chat-sdk mode: the transport owns verification (challenge handshake,
+       * signature checks) and payload parsing, so the raw request — GET and
+       * POST — is delegated unchanged.
+       */
+      delegate: (request: Request) => Promise<Response>;
+    }
+  | {
+      signingSecret: string;
+      /** Vendor auth header name (wired at the composition root). */
+      signingHeader: string;
+      /** Vendor-specific parse stays at the composition root / adapter boundary. */
+      parseInbound: (payload: unknown) => MessagingInboundEvent | null;
+      handle: (event: MessagingInboundMessage) => Promise<void>;
+      handleStatus?: (event: MessagingOutboundStatus) => Promise<void>;
+    };
 
 /**
  * Deployment phone-line inbound webhook. Verification is a static shared
@@ -26,6 +35,10 @@ export type PhoneWebhookDeps = {
  * downstream. Mounted only when the phone surface is enabled.
  */
 export function mountPhoneWebhookRoutes(app: Hono, deps: PhoneWebhookDeps) {
+  if ("delegate" in deps) {
+    app.all(PHONE_WEBHOOK_PATH, (c) => deps.delegate(c.req.raw));
+    return;
+  }
   app.post(PHONE_WEBHOOK_PATH, async (c) => {
     // Uniform 401: missing and wrong secrets are indistinguishable.
     if (!timingSafeStringEqual(c.req.header(deps.signingHeader), deps.signingSecret)) {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -4,9 +4,12 @@ import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 loadRootEnv();
 
 import {
+  ChatSdkMessagingProvider,
+  chatSdkConfigFromEnv,
   createBackgroundJobHandlers,
   createConnectorStack,
   createJobReconciler,
+  createMessagingProvider,
   createPhoneContextLoader,
   createPostgresReconciliationLeadership,
   createRunExecutor,
@@ -20,7 +23,6 @@ import {
   InMemoryJobQueue,
   InstalledConnectorProvider,
   isComposioEnabled,
-  isPhoneSurfaceEnabled,
   isPipedreamEnabled,
   LocalAgentHomeStore,
   LocalArtifactStore,
@@ -33,7 +35,6 @@ import {
   resolveDeploymentModel,
   resolveSandboxProvider,
   ScriptedAgentRuntime,
-  SendBlueMessagingProvider,
   SpaceMemoryProviderResolver,
   sendBlueConfigFromEnv,
 } from "@rakazo/adapters";
@@ -100,9 +101,17 @@ async function main() {
     sendblueSigningSecret: process.env.SENDBLUE_SIGNING_SECRET,
     sendbluePhoneNumber: process.env.SENDBLUE_PHONE_NUMBER,
   });
-  const messaging = isPhoneSurfaceEnabled(sendBlueConfig, deploymentModelKey)
-    ? new SendBlueMessagingProvider(sendBlueConfig)
-    : undefined;
+  const messaging = createMessagingProvider({
+    provider: process.env.MESSAGING_PROVIDER,
+    deploymentModelKey,
+    sendBlueConfig,
+    chatSdkConfig: chatSdkConfigFromEnv({
+      messagingChatSdkAdapter: process.env.MESSAGING_CHATSDK_ADAPTER,
+    }),
+  });
+  if (messaging instanceof ChatSdkMessagingProvider) {
+    await messaging.initialize();
+  }
   const stack = createConnectorStack(isComposioEnabled(process.env.COMPOSIO_API_KEY), undefined, [
     new InstalledConnectorProvider(prisma, secrets),
     ...(pipedream ? [pipedream] : []),

--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -283,8 +283,9 @@ export interface VoiceProvider {
 
 /**
  * Deployment-wide text messaging surface (one phone line for the whole
- * deployment). Webhook parsing/verification stays an exported pure function
- * on the vendor module — that is HTTP shape, not transport.
+ * deployment). Webhook parsing/verification is owned either by an exported
+ * pure function on the vendor module or by the transport in delegate mode —
+ * that is HTTP shape, not transport.
  */
 export interface MessagingProvider {
   describe(): AdapterDescriptor<MessagingCapabilities>;

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@asciidev/box-sdk": "^0.0.28",
+    "@chat-adapter/state-memory": "4.39.0",
     "@composio/core": "0.16.0",
     "@daytona/sdk": "^0.204.1",
     "@e2b/desktop": "^2.3.1",
@@ -24,6 +25,7 @@
     "@rakazo/contracts": "workspace:*",
     "@rakazo/core": "workspace:*",
     "@rakazo/db": "workspace:*",
+    "chat": "4.39.0",
     "d3-dsv": "^3.0.1",
     "graphile-worker": "^0.17.3",
     "jsdom": "^30.0.1",

--- a/packages/adapters/src/chatsdk-emulator.test.ts
+++ b/packages/adapters/src/chatsdk-emulator.test.ts
@@ -1,0 +1,117 @@
+import type { AdapterContext, MessagingInboundMessage } from "@rakazo/adapter-kit";
+import { describe, expect, it, vi } from "vitest";
+import { ChatSdkMessagingProvider } from "./chatsdk.js";
+import { ChatSdkEmulator } from "./chatsdk-emulator.js";
+
+const context: AdapterContext = {
+  spaceId: "ws-1",
+  userId: "user-1",
+  botId: "bot-1",
+  runId: "run-1",
+  operationId: "op-1",
+  traceId: "trace-1",
+  signal: new AbortController().signal,
+};
+
+function createProvider() {
+  const emulator = new ChatSdkEmulator();
+  const provider = new ChatSdkMessagingProvider({
+    adapters: { emulated: emulator },
+    adapterName: "emulated",
+  });
+  return { emulator, provider };
+}
+
+describe("ChatSdkEmulator", () => {
+  it("serves the provider over the injected adapter and records sends", async () => {
+    const { emulator, provider } = createProvider();
+
+    const dm = await provider.sendDirect({ to: "+15551234567", body: "hello there" }, context);
+    expect(dm.handle).toBeTruthy();
+    expect(emulator.sent).toEqual([{ to: "+15551234567", body: "hello there", handle: dm.handle }]);
+  });
+
+  it("records typing indicators", async () => {
+    const { emulator, provider } = createProvider();
+
+    await provider.sendTypingIndicator({ to: "+15551234567" }, context);
+    expect(emulator.typingIndicators).toEqual(["+15551234567"]);
+  });
+
+  it("fails the next N sends on demand and recovers afterwards", async () => {
+    const { emulator, provider } = createProvider();
+    emulator.failNextSends(2);
+
+    await expect(provider.sendDirect({ to: "+15551234567", body: "a" }, context)).rejects.toThrow(
+      /emulated chat network failure/,
+    );
+    await expect(provider.sendDirect({ to: "+15551234567", body: "b" }, context)).rejects.toThrow(
+      /emulated chat network failure/,
+    );
+    await provider.sendDirect({ to: "+15551234567", body: "c" }, context);
+    expect(emulator.sent.map((send) => send.body)).toEqual(["c"]);
+  });
+
+  it("delivers inbound DMs through the Chat runtime to the registered handler", async () => {
+    const { emulator, provider } = createProvider();
+    const inbound = vi.fn<(event: MessagingInboundMessage) => Promise<void>>();
+    provider.onInbound(inbound);
+    await provider.initialize();
+
+    await emulator.deliverInbound({ from: "+15551234567", text: "ping" });
+
+    expect(inbound).toHaveBeenCalledTimes(1);
+    expect(inbound.mock.calls[0]![0]).toEqual({
+      type: "message",
+      handle: expect.any(String),
+      fromNumber: "+15551234567",
+      groupId: null,
+      groupName: null,
+      participants: [],
+      content: "ping",
+      mediaUrl: null,
+    });
+  });
+
+  it("drops a replayed inbound handle through chat-sdk's dedupe", async () => {
+    const { emulator, provider } = createProvider();
+    const inbound = vi.fn<(event: MessagingInboundMessage) => Promise<void>>();
+    provider.onInbound(inbound);
+    await provider.initialize();
+
+    await emulator.deliverInbound({ from: "+15551234567", text: "once", handle: "fixed-1" });
+    await emulator.deliverInbound({ from: "+15551234567", text: "twice", handle: "fixed-1" });
+
+    expect(inbound).toHaveBeenCalledTimes(1);
+  });
+
+  it("round-trips the emulator's inbound message through the neutral parser", async () => {
+    const { emulator, provider } = createProvider();
+    let captured: MessagingInboundMessage | null = null;
+    provider.onInbound(async (event) => {
+      captured = event;
+    });
+    await provider.initialize();
+
+    await emulator.deliverInbound({ from: "+15557654321", text: "structured" });
+
+    // The provider maps the normalized chat-sdk Message via parseChatSdkInbound.
+    expect(captured).toEqual({
+      type: "message",
+      handle: expect.any(String),
+      fromNumber: "+15557654321",
+      groupId: null,
+      groupName: null,
+      participants: [],
+      content: "structured",
+      mediaUrl: null,
+    });
+  });
+
+  it("rejects inbound delivery before the Chat runtime is initialized", async () => {
+    const emulator = new ChatSdkEmulator();
+    await expect(emulator.deliverInbound({ from: "u-1", text: "hi" })).rejects.toThrow(
+      /not attached/,
+    );
+  });
+});

--- a/packages/adapters/src/chatsdk-emulator.ts
+++ b/packages/adapters/src/chatsdk-emulator.ts
@@ -1,0 +1,192 @@
+import {
+  type AdapterPostableMessage,
+  BaseFormatConverter,
+  type ChatInstance,
+  type Adapter as ChatSdkAdapter,
+  type FetchOptions,
+  type FetchResult,
+  type FormattedContent,
+  Message,
+  parseMarkdown,
+  type RawMessage,
+  stringifyMarkdown,
+  type ThreadInfo,
+} from "chat";
+
+interface EmulatedThread {
+  userId: string;
+}
+
+interface EmulatedSend {
+  to: string;
+  body: string;
+  handle: string;
+}
+
+export interface ChatSdkEmulatorInboundInput {
+  from: string;
+  text: string;
+  /** Fixed handle to exercise replay/dedupe behavior. */
+  handle?: string;
+}
+
+class PlainTextConverter extends BaseFormatConverter {
+  toAst(platformText: string): ReturnType<typeof parseMarkdown> {
+    return parseMarkdown(platformText);
+  }
+
+  fromAst(ast: FormattedContent): string {
+    return stringifyMarkdown(ast);
+  }
+}
+
+/**
+ * Deterministic in-memory chat network for the chat-sdk transport. The
+ * emulator IS the chat-sdk adapter: no real platform package is needed, so
+ * the whole bridge — outbound sends, typing, inbound delivery through the
+ * Chat runtime's DM dispatch — runs offline over injected configuration.
+ */
+export class ChatSdkEmulator implements ChatSdkAdapter {
+  readonly name = "emulated";
+  readonly userName = "rakazo-emulated";
+  readonly sent: EmulatedSend[] = [];
+  readonly typingIndicators: string[] = [];
+  private handleCounter = 0;
+  private failRemaining = 0;
+  private chat: ChatInstance | null = null;
+  private readonly converter = new PlainTextConverter();
+
+  // --- chat-sdk Adapter surface -------------------------------------------------
+
+  async initialize(chat: ChatInstance): Promise<void> {
+    this.chat = chat;
+  }
+
+  encodeThreadId(data: EmulatedThread): string {
+    return `emulated:dm:${data.userId}`;
+  }
+
+  decodeThreadId(threadId: string): EmulatedThread {
+    const parts = threadId.split(":");
+    if (parts.length !== 3 || parts[0] !== "emulated" || parts[1] !== "dm") {
+      throw new Error(`Invalid emulated thread ID: ${threadId}`);
+    }
+    return { userId: parts[2]! };
+  }
+
+  channelIdFromThreadId(threadId: string): string {
+    const { userId } = this.decodeThreadId(threadId);
+    return `emulated:dm:${userId}`;
+  }
+
+  async openDM(userId: string): Promise<string> {
+    return this.encodeThreadId({ userId });
+  }
+
+  async postMessage(
+    threadId: string,
+    message: AdapterPostableMessage,
+  ): Promise<RawMessage<unknown>> {
+    if (this.failRemaining > 0) {
+      this.failRemaining -= 1;
+      throw new Error("emulated chat network failure");
+    }
+    const body = this.converter.renderPostable(message);
+    const handle = this.nextHandle();
+    const { userId } = this.decodeThreadId(threadId);
+    this.sent.push({ to: userId, body, handle });
+    return { raw: { handle }, id: handle, threadId };
+  }
+
+  isDM(): boolean {
+    // The emulated network only carries DMs; group support awaits the
+    // adapter decision that is still open.
+    return true;
+  }
+
+  async startTyping(threadId: string): Promise<void> {
+    const { userId } = this.decodeThreadId(threadId);
+    this.typingIndicators.push(userId);
+  }
+
+  parseMessage(raw: { id: string; threadId: string; text: string; from: string }): Message {
+    return new Message({
+      id: raw.id,
+      threadId: raw.threadId,
+      text: raw.text,
+      formatted: parseMarkdown(raw.text),
+      raw,
+      author: {
+        userId: raw.from,
+        userName: raw.from,
+        fullName: raw.from,
+        isBot: false,
+        isMe: false,
+      },
+      metadata: { dateSent: new Date(), edited: false },
+      attachments: [],
+    });
+  }
+
+  async fetchMessages(_threadId: string, _options?: FetchOptions): Promise<FetchResult<unknown>> {
+    return { messages: [], nextCursor: undefined };
+  }
+
+  async fetchThread(threadId: string): Promise<ThreadInfo> {
+    return {
+      channelId: threadId,
+      id: threadId,
+      isDM: true,
+      metadata: {},
+    };
+  }
+
+  renderFormatted(content: FormattedContent): string {
+    return stringifyMarkdown(content);
+  }
+
+  async handleWebhook(): Promise<Response> {
+    // The emulated network has no HTTP transport; inbound arrives via
+    // deliverInbound. Real adapters own webhook verification and parsing.
+    return new Response("emulated adapter has no webhook transport", { status: 501 });
+  }
+
+  async addReaction(): Promise<void> {}
+  async removeReaction(): Promise<void> {}
+  async deleteMessage(): Promise<void> {}
+
+  async editMessage(threadId: string, messageId: string): Promise<RawMessage<unknown>> {
+    return { raw: {}, id: messageId, threadId };
+  }
+
+  // --- test controls ------------------------------------------------------------
+
+  /** Next N postMessage calls fail, exercising the drain's retry path. */
+  failNextSends(count: number): void {
+    this.failRemaining = count;
+  }
+
+  /**
+   * Deliver an inbound DM through the Chat runtime's normal dispatch, exactly
+   * as a verified platform webhook would: onDirectMessage handlers fire and
+   * the provider's inbound mapping sees a normalized chat-sdk Message.
+   */
+  async deliverInbound(input: ChatSdkEmulatorInboundInput): Promise<void> {
+    if (!this.chat) {
+      throw new Error("emulated network is not attached to a Chat runtime yet");
+    }
+    const threadId = this.encodeThreadId({ userId: input.from });
+    const message = this.parseMessage({
+      id: input.handle ?? this.nextHandle(),
+      threadId,
+      text: input.text,
+      from: input.from,
+    });
+    await this.chat.processMessage(this, threadId, message);
+  }
+
+  nextHandle(): string {
+    this.handleCounter += 1;
+    return `emulated-msg-${this.handleCounter}`;
+  }
+}

--- a/packages/adapters/src/chatsdk.test.ts
+++ b/packages/adapters/src/chatsdk.test.ts
@@ -1,0 +1,253 @@
+import type { AdapterContext, MessagingProvider } from "@rakazo/adapter-kit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ChatSdkAdapter,
+  type ChatSdkInboundInput,
+  ChatSdkMessagingProvider,
+  chatSdkConfigFromEnv,
+  createChatSdkAdapter,
+  createMessagingProvider,
+  isChatSdkEnabled,
+  parseChatSdkInbound,
+  registerChatSdkAdapter,
+} from "./chatsdk.js";
+import { ChatSdkEmulator } from "./chatsdk-emulator.js";
+import { SendBlueMessagingProvider } from "./sendblue.js";
+
+const context: AdapterContext = {
+  spaceId: "ws-1",
+  userId: "user-1",
+  botId: "bot-1",
+  runId: "run-1",
+  operationId: "op-1",
+  traceId: "trace-1",
+  signal: new AbortController().signal,
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("parseChatSdkInbound", () => {
+  it("maps a normalized DM message onto the neutral event", () => {
+    expect(
+      parseChatSdkInbound({
+        id: "wamid-1",
+        text: "hello there",
+        threadId: "emulated:dm:+15551234567",
+        author: { userId: "+15551234567" },
+        attachments: [],
+      }),
+    ).toEqual({
+      type: "message",
+      handle: "wamid-1",
+      fromNumber: "+15551234567",
+      groupId: null,
+      groupName: null,
+      participants: [],
+      content: "hello there",
+      mediaUrl: null,
+    });
+  });
+
+  it("passes the sender identifier through without platform-specific normalization", () => {
+    const event = parseChatSdkInbound({ id: "m-1", author: { userId: "US.123456" } });
+    expect(event).toEqual(
+      expect.objectContaining({ type: "message", fromNumber: "US.123456", content: "" }),
+    );
+  });
+
+  it("maps the first attachment URL onto mediaUrl", () => {
+    const event = parseChatSdkInbound({
+      id: "m-2",
+      author: { userId: "u-1" },
+      attachments: [{ url: "https://cdn.test/a.png" }, { url: "https://cdn.test/b.png" }],
+    });
+    expect(event).toEqual(expect.objectContaining({ mediaUrl: "https://cdn.test/a.png" }));
+  });
+
+  it("returns null for unusable input", () => {
+    expect(parseChatSdkInbound(null)).toBeNull();
+    expect(parseChatSdkInbound(undefined)).toBeNull();
+    expect(parseChatSdkInbound("nope" as unknown as ChatSdkInboundInput)).toBeNull();
+    expect(parseChatSdkInbound({})).toBeNull();
+    expect(parseChatSdkInbound({ id: "", author: { userId: "u-1" } })).toBeNull();
+    expect(parseChatSdkInbound({ id: "m-1" })).toBeNull();
+    expect(parseChatSdkInbound({ id: "m-1", author: { userId: "" } })).toBeNull();
+  });
+});
+
+describe("isChatSdkEnabled", () => {
+  const emulator = new ChatSdkEmulator();
+
+  it("requires the named adapter to be present in the configuration", () => {
+    vi.stubEnv("VITEST", "");
+    expect(isChatSdkEnabled({ adapters: { emulated: emulator }, adapterName: "emulated" })).toBe(
+      true,
+    );
+    expect(isChatSdkEnabled({ adapters: { emulated: emulator }, adapterName: "other" })).toBe(
+      false,
+    );
+    expect(isChatSdkEnabled({ adapters: {}, adapterName: "emulated" })).toBe(false);
+    expect(isChatSdkEnabled(undefined)).toBe(false);
+  });
+
+  it("is disabled under vitest even with a full config", () => {
+    expect(process.env.VITEST).toBeTruthy();
+    expect(isChatSdkEnabled({ adapters: { emulated: emulator }, adapterName: "emulated" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("chat-sdk adapter registry", () => {
+  it("constructs registered adapters by configuration name", () => {
+    const emulator = new ChatSdkEmulator();
+    registerChatSdkAdapter("registry-test", () => emulator);
+    expect(createChatSdkAdapter("registry-test")).toBe(emulator);
+    expect(createChatSdkAdapter("unknown")).toBeUndefined();
+  });
+});
+
+describe("chatSdkConfigFromEnv", () => {
+  it("returns undefined without an adapter name or a registered adapter", () => {
+    expect(chatSdkConfigFromEnv({ messagingChatSdkAdapter: undefined })).toBeUndefined();
+    expect(chatSdkConfigFromEnv({ messagingChatSdkAdapter: "  " })).toBeUndefined();
+    expect(chatSdkConfigFromEnv({ messagingChatSdkAdapter: "never-registered" })).toBeUndefined();
+  });
+
+  it("resolves a registered adapter into the configuration", () => {
+    const emulator = new ChatSdkEmulator();
+    registerChatSdkAdapter("env-test", () => emulator);
+    expect(chatSdkConfigFromEnv({ messagingChatSdkAdapter: "env-test" })).toEqual({
+      adapters: { "env-test": emulator },
+      adapterName: "env-test",
+    });
+  });
+});
+
+describe("ChatSdkMessagingProvider", () => {
+  it("rejects construction when the configured adapter is missing", () => {
+    expect(() => new ChatSdkMessagingProvider({ adapters: {}, adapterName: "emulated" })).toThrow(
+      /not configured/,
+    );
+  });
+
+  it("derives capabilities from the configured adapter instance", () => {
+    const full = new ChatSdkMessagingProvider({
+      adapters: { emulated: new ChatSdkEmulator() },
+      adapterName: "emulated",
+    });
+    expect(full.describe().capabilities).toEqual({ direct: true, groups: false, typing: true });
+
+    const minimalAdapter = {
+      name: "minimal",
+      userName: "minimal-bot",
+      startTyping: undefined,
+    } as unknown as ChatSdkAdapter;
+    const minimal = new ChatSdkMessagingProvider({
+      adapters: { minimal: minimalAdapter },
+      adapterName: "minimal",
+    });
+    expect(minimal.describe().capabilities).toEqual({
+      direct: false,
+      groups: false,
+      typing: false,
+    });
+  });
+
+  it("describes itself with the adapter name in the id", () => {
+    const provider = new ChatSdkMessagingProvider({
+      adapters: { emulated: new ChatSdkEmulator() },
+      adapterName: "emulated",
+    });
+    expect(provider.describe()).toEqual(
+      expect.objectContaining({ id: "chatsdk-emulated", contractVersion: "1" }),
+    );
+  });
+
+  it("throws on the unsupported group surface", async () => {
+    const provider = new ChatSdkMessagingProvider({
+      adapters: { emulated: new ChatSdkEmulator() },
+      adapterName: "emulated",
+    });
+    await expect(provider.sendGroup({ groupId: "grp-1", body: "hi" }, context)).rejects.toThrow(
+      /group sends/,
+    );
+    await expect(provider.getGroup("grp-1", context)).rejects.toThrow(/group lookups/);
+  });
+});
+
+describe("createMessagingProvider", () => {
+  const sendBlueConfig = {
+    apiKeyId: "key-id",
+    apiSecret: "secret",
+    signingSecret: "signing",
+    phoneNumber: "+15550009999",
+  };
+
+  it("selects SendBlue by default and preserves the phone-surface gate", () => {
+    vi.stubEnv("VITEST", "");
+    const provider = createMessagingProvider({
+      provider: undefined,
+      deploymentModelKey: "model-key",
+      sendBlueConfig,
+      chatSdkConfig: undefined,
+    });
+    expect(provider).toBeInstanceOf(SendBlueMessagingProvider);
+
+    expect(
+      createMessagingProvider({
+        provider: undefined,
+        deploymentModelKey: undefined,
+        sendBlueConfig,
+        chatSdkConfig: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("selects chat-sdk only when an adapter is configured and the model key is present", () => {
+    vi.stubEnv("VITEST", "");
+    const chatSdkConfig = {
+      adapters: { emulated: new ChatSdkEmulator() },
+      adapterName: "emulated",
+    };
+    const provider = createMessagingProvider({
+      provider: "chat-sdk",
+      deploymentModelKey: "model-key",
+      sendBlueConfig,
+      chatSdkConfig,
+    });
+    expect(provider).toBeInstanceOf(ChatSdkMessagingProvider);
+
+    // No adapter configured: the surface stays disabled.
+    expect(
+      createMessagingProvider({
+        provider: "chat-sdk",
+        deploymentModelKey: "model-key",
+        sendBlueConfig,
+        chatSdkConfig: undefined,
+      }),
+    ).toBeUndefined();
+
+    // Phone-created users need the deployment model key regardless of transport.
+    expect(
+      createMessagingProvider({
+        provider: "chat-sdk",
+        deploymentModelKey: undefined,
+        sendBlueConfig,
+        chatSdkConfig,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps chat-sdk disabled under vitest even with full configuration", () => {
+    const provider: MessagingProvider | undefined = createMessagingProvider({
+      provider: "chat-sdk",
+      deploymentModelKey: "model-key",
+      sendBlueConfig,
+      chatSdkConfig: { adapters: { emulated: new ChatSdkEmulator() }, adapterName: "emulated" },
+    });
+    expect(provider).toBeUndefined();
+  });
+});

--- a/packages/adapters/src/chatsdk.ts
+++ b/packages/adapters/src/chatsdk.ts
@@ -1,0 +1,270 @@
+import { createMemoryState } from "@chat-adapter/state-memory";
+import type {
+  AdapterContext,
+  AdapterDescriptor,
+  MessagingCapabilities,
+  MessagingDirectRequest,
+  MessagingGroup,
+  MessagingGroupRequest,
+  MessagingInboundEvent,
+  MessagingInboundMessage,
+  MessagingProvider,
+  MessagingSendResult,
+  MessagingTypingRequest,
+} from "@rakazo/adapter-kit";
+import { Chat, type Adapter as ChatSdkAdapter } from "chat";
+import {
+  isPhoneSurfaceEnabled,
+  type SendBlueConfig,
+  SendBlueMessagingProvider,
+} from "./sendblue.js";
+
+export type { ChatSdkAdapter };
+
+/**
+ * Generic chat-sdk transport configuration. No chat network is baked in: the
+ * platform adapter (WhatsApp, Telegram, ...) is constructed elsewhere and
+ * selected here by name. Concrete adapters register themselves via
+ * `registerChatSdkAdapter` — this module stays adapter-agnostic.
+ */
+export interface ChatSdkConfig {
+  /** chat-sdk platform adapters available to this deployment, keyed by name. */
+  adapters: Record<string, ChatSdkAdapter>;
+  /** Which registered adapter the deployment's phone line runs on. */
+  adapterName: string;
+  /** Default bot username across the Chat runtime. */
+  userName?: string;
+}
+
+export interface ChatSdkEnvironmentValues {
+  /** `MESSAGING_CHATSDK_ADAPTER` — registry name of the configured adapter. */
+  messagingChatSdkAdapter: string | undefined;
+}
+
+const adapterFactories = new Map<string, () => ChatSdkAdapter>();
+
+/**
+ * Register a chat-sdk platform adapter factory under its configuration name.
+ * Adapters carry vendor credentials and platform packages, so they live in
+ * composition roots; the transport bridge only resolves them by name.
+ */
+export function registerChatSdkAdapter(name: string, create: () => ChatSdkAdapter): void {
+  adapterFactories.set(name, create);
+}
+
+/** Instantiate a registered adapter, or undefined when the name is unknown. */
+export function createChatSdkAdapter(name: string): ChatSdkAdapter | undefined {
+  return adapterFactories.get(name)?.();
+}
+
+export function chatSdkConfigFromEnv(values: ChatSdkEnvironmentValues): ChatSdkConfig | undefined {
+  const adapterName = values.messagingChatSdkAdapter?.trim();
+  if (!adapterName) return undefined;
+  const adapter = createChatSdkAdapter(adapterName);
+  if (!adapter) return undefined;
+  return { adapters: { [adapterName]: adapter }, adapterName };
+}
+
+/** The named adapter is actually registered, and never live under the test runner. */
+export function isChatSdkEnabled(
+  config: Partial<ChatSdkConfig> | undefined,
+): config is ChatSdkConfig {
+  return Boolean(
+    config?.adapterName && config.adapters?.[config.adapterName] && !process.env.VITEST,
+  );
+}
+
+/**
+ * One provider per deployment, selected by `MESSAGING_PROVIDER` (default
+ * `sendblue`). The chat-sdk branch constructs only when a concrete adapter is
+ * registered under `MESSAGING_CHATSDK_ADAPTER`; otherwise the phone surface
+ * stays disabled exactly as when SendBlue config is missing.
+ */
+export function createMessagingProvider(options: {
+  provider: string | undefined;
+  deploymentModelKey: string | undefined;
+  sendBlueConfig: SendBlueConfig;
+  chatSdkConfig: ChatSdkConfig | undefined;
+}): MessagingProvider | undefined {
+  if (options.provider === "chat-sdk") {
+    if (!isChatSdkEnabled(options.chatSdkConfig)) return undefined;
+    if (!options.deploymentModelKey) return undefined;
+    return new ChatSdkMessagingProvider(options.chatSdkConfig);
+  }
+  return isPhoneSurfaceEnabled(options.sendBlueConfig, options.deploymentModelKey)
+    ? new SendBlueMessagingProvider(options.sendBlueConfig)
+    : undefined;
+}
+
+/**
+ * Structural shape of a chat-sdk normalized `Message`. Duck-typed like the
+ * SendBlue parser's payload so the mapping stays unit-testable and stable
+ * across chat-sdk minor versions.
+ */
+export interface ChatSdkInboundInput {
+  id?: unknown;
+  text?: unknown;
+  threadId?: unknown;
+  author?: { userId?: unknown } | undefined;
+  attachments?: ReadonlyArray<{ url?: unknown } | undefined> | undefined;
+}
+
+/**
+ * Map a chat-sdk normalized inbound message onto the neutral event. The
+ * sender identifier passes through untouched: phone-number normalization
+ * (wa_id → E.164, BSUID handling) is platform-specific and belongs to the
+ * adapter layer, not this transport. Group identity is not derivable from a
+ * DM message, and group support awaits the still-open adapter decision.
+ */
+export function parseChatSdkInbound(
+  message: ChatSdkInboundInput | null | undefined,
+): MessagingInboundEvent | null {
+  if (typeof message !== "object" || message === null) return null;
+  if (typeof message.id !== "string" || !message.id) return null;
+  if (typeof message.author?.userId !== "string" || !message.author.userId) return null;
+  const mediaUrl = (message.attachments ?? []).find((attachment): attachment is { url: string } => {
+    return Boolean(attachment) && typeof attachment?.url === "string" && attachment.url !== "";
+  });
+  return {
+    type: "message",
+    handle: message.id,
+    fromNumber: message.author.userId,
+    groupId: null,
+    groupName: null,
+    participants: [],
+    content: typeof message.text === "string" ? message.text : "",
+    mediaUrl: mediaUrl?.url ?? null,
+  };
+}
+
+/**
+ * chat-sdk-backed `MessagingProvider`. The `Chat` runtime is constructed with
+ * whatever adapter the configuration selected; verification, payload parsing,
+ * and platform auth live inside chat-sdk and its adapter, so this class only
+ * bridges between chat-sdk threads/messages and the neutral surface.
+ */
+export class ChatSdkMessagingProvider implements MessagingProvider {
+  private readonly bot: Chat;
+  private readonly adapter: ChatSdkAdapter;
+  private readonly adapterName: string;
+  private initialized = false;
+  private inboundHandler?: (event: MessagingInboundMessage) => Promise<void>;
+
+  constructor(config: ChatSdkConfig) {
+    const adapter = config.adapters[config.adapterName];
+    if (!adapter) {
+      throw new Error(`chat-sdk adapter "${config.adapterName}" is not configured`);
+    }
+    this.adapter = adapter;
+    this.adapterName = config.adapterName;
+    this.bot = new Chat({
+      userName: config.userName ?? "rakazo",
+      adapters: config.adapters,
+      state: createMemoryState(),
+      // rakazo's run/job model owns ordering; dropping overlapping inbound
+      // messages would lose texts the outbox already mirrors.
+      concurrency: "concurrent",
+    });
+    // Inbound DMs flow: adapter webhook → chat-sdk verification/parse →
+    // onDirectMessage → parseChatSdkInbound → the handler wired at the
+    // composition root. chat-sdk filters self-messages before dispatch.
+    this.bot.onDirectMessage(async (_thread, message) => {
+      const event = parseChatSdkInbound(message);
+      if (event?.type === "message") await this.inboundHandler?.(event);
+    });
+  }
+
+  /**
+   * Initialize the Chat runtime (connects the state adapter and calls the
+   * adapter's `initialize`). Webhook handling initializes lazily inside
+   * chat-sdk; calling this at startup fails fast on a misconfigured adapter.
+   */
+  async initialize(): Promise<void> {
+    if (!this.initialized) {
+      await this.bot.initialize();
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Wire the composition root's inbound handler. chat-sdk dispatches only
+   * DMs here; group events require the adapter decision that is still open.
+   */
+  onInbound(handler: (event: MessagingInboundMessage) => Promise<void>): void {
+    this.inboundHandler = handler;
+  }
+
+  /**
+   * Handle an inbound webhook request for the configured adapter. Signature
+   * verification and parsing happen inside chat-sdk; the API route delegates
+   * the raw request (GET challenge and POST events) unchanged.
+   */
+  handleWebhook(request: Request): Promise<Response> {
+    const handler = this.bot.webhooks[this.adapterName];
+    if (!handler) {
+      throw new Error(`chat-sdk adapter "${this.adapterName}" exposes no webhook handler`);
+    }
+    return handler(request);
+  }
+
+  describe(): AdapterDescriptor<MessagingCapabilities> {
+    return {
+      id: `chatsdk-${this.adapterName}`,
+      contractVersion: "1",
+      adapterVersion: "0.1.0",
+      // chat-sdk's Adapter interface carries no capability metadata, so
+      // capabilities are derived from the configured adapter instance: the
+      // optional `openDM` method is the only honest signal for direct sends,
+      // `startTyping` for typing. chat-sdk has no cross-adapter group-send
+      // surface, so groups stay false until an adapter provides one.
+      capabilities: {
+        direct: typeof this.adapter.openDM === "function",
+        groups: false,
+        typing: typeof this.adapter.startTyping === "function",
+      },
+    };
+  }
+
+  async sendDirect(
+    request: MessagingDirectRequest,
+    _context: AdapterContext,
+  ): Promise<MessagingSendResult> {
+    await this.initialize();
+    const threadId = await this.openDM(request.to);
+    const sent = await this.bot.thread(threadId).post(request.body);
+    return { handle: sent.id };
+  }
+
+  async sendTypingIndicator(
+    request: MessagingTypingRequest,
+    _context: AdapterContext,
+  ): Promise<void> {
+    await this.initialize();
+    const threadId = await this.openDM(request.to);
+    // Best effort by contract: chat-sdk no-ops on platforms without typing.
+    await this.bot.thread(threadId).startTyping();
+  }
+
+  /**
+   * Groups are not part of the generic chat-sdk surface; capabilities report
+   * false so the outbox drain never routes group rows here.
+   */
+  async sendGroup(
+    _request: MessagingGroupRequest,
+    _context: AdapterContext,
+  ): Promise<MessagingSendResult> {
+    throw new Error(`chat-sdk adapter "${this.adapterName}" does not support group sends`);
+  }
+
+  async getGroup(_groupId: string, _context: AdapterContext): Promise<MessagingGroup> {
+    throw new Error(`chat-sdk adapter "${this.adapterName}" does not support group lookups`);
+  }
+
+  private openDM(to: string): Promise<string> {
+    const openDM = this.adapter.openDM;
+    if (!openDM) {
+      throw new Error(`chat-sdk adapter "${this.adapterName}" does not support direct messages`);
+    }
+    return openDM.call(this.adapter, to);
+  }
+}

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -8,6 +8,8 @@ export * from "./box-sandbox.js";
 export * from "./builtin-skills.js";
 export * from "./builtin-tools.js";
 export * from "./cartesia-voice.js";
+export * from "./chatsdk.js";
+export * from "./chatsdk-emulator.js";
 export * from "./child-bots.js";
 export * from "./composio-catalog-cache.js";
 export * from "./composio-connector.js";

--- a/packages/adapters/src/phone-delivery.test.ts
+++ b/packages/adapters/src/phone-delivery.test.ts
@@ -41,6 +41,7 @@ function createDeps(overrides: {
   existingOutbox?: unknown;
   sendError?: Error;
   connectionStatus?: string | null;
+  groupsCapable?: boolean;
 }) {
   const rows = [...(overrides.outboundRows ?? [])] as Array<Record<string, unknown>>;
   const sendDirect = vi.fn(async () => ({ handle: "handle-out-1" }));
@@ -53,8 +54,7 @@ function createDeps(overrides: {
     describe: () => ({
       id: "sendblue",
       contractVersion: "1",
-      adapterVersion: "0.1.0",
-      capabilities: { direct: true, groups: true },
+      capabilities: { direct: true, groups: overrides.groupsCapable ?? true, typing: true },
     }),
     sendDirect,
     sendGroup,
@@ -280,6 +280,49 @@ describe("deliverPhoneOutbound", () => {
       { to: "+15551234567", body: "pending earlier" },
       context,
     );
+    expect(deps.rows[0]).toEqual(expect.objectContaining({ status: "sent" }));
+  });
+
+  it("fails group rows terminally when the provider reports no group support", async () => {
+    const deps = createDeps({
+      run: null,
+      groupsCapable: false,
+      outboundRows: [
+        {
+          id: "out-10",
+          idempotencyKey: "intro:ch-1",
+          kind: "intro",
+          providerGroupId: "grp-1",
+          body: "intro body",
+          status: "pending",
+          providerHandle: null,
+        },
+      ],
+    });
+    await deliverPhoneOutbound(deps, {}, context);
+
+    expect(deps.sendGroup).not.toHaveBeenCalled();
+    expect(deps.rows[0]).toEqual(expect.objectContaining({ status: "failed" }));
+  });
+
+  it("still sends group rows through the provider when groups are supported", async () => {
+    const deps = createDeps({
+      run: null,
+      outboundRows: [
+        {
+          id: "out-11",
+          idempotencyKey: "intro:ch-2",
+          kind: "intro",
+          providerGroupId: "grp-2",
+          body: "intro body",
+          status: "pending",
+          providerHandle: null,
+        },
+      ],
+    });
+    await deliverPhoneOutbound(deps, {}, context);
+
+    expect(deps.sendGroup).toHaveBeenCalledWith({ groupId: "grp-2", body: "intro body" }, context);
     expect(deps.rows[0]).toEqual(expect.objectContaining({ status: "sent" }));
   });
 

--- a/packages/adapters/src/phone-delivery.ts
+++ b/packages/adapters/src/phone-delivery.ts
@@ -297,6 +297,7 @@ async function drain(deps: PhoneDeliveryDeps, context: AdapterContext): Promise<
   });
   const groupsSupported = deps.messaging.describe().capabilities.groups;
   for (const row of pending) {
+    // Claim before sending: concurrent drains (job keys are per runId) and
     // crash retries must never deliver the same iMessage twice.
     const claim = await deps.prisma.phoneOutbound.updateMany({
       where: { id: row.id, status: "pending" },

--- a/packages/adapters/src/phone-delivery.ts
+++ b/packages/adapters/src/phone-delivery.ts
@@ -295,8 +295,8 @@ async function drain(deps: PhoneDeliveryDeps, context: AdapterContext): Promise<
     },
     orderBy: { createdAt: "asc" },
   });
+  const groupsSupported = deps.messaging.describe().capabilities.groups;
   for (const row of pending) {
-    // Claim before sending: concurrent drains (job keys are per runId) and
     // crash retries must never deliver the same iMessage twice.
     const claim = await deps.prisma.phoneOutbound.updateMany({
       where: { id: row.id, status: "pending" },
@@ -305,7 +305,10 @@ async function drain(deps: PhoneDeliveryDeps, context: AdapterContext): Promise<
     if (claim.count === 0) continue;
     try {
       if (row.kind === "group" || row.kind === "intro") {
-        if (!row.providerGroupId) {
+        // A provider without group support (capabilities.groups false) can
+        // never deliver these rows: fail them terminally instead of burning
+        // the retry budget on calls that are known to be unsupported.
+        if (!row.providerGroupId || !groupsSupported) {
           await deps.prisma.phoneOutbound.update({
             where: { id: row.id },
             data: { status: "failed" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,9 @@ importers:
       '@asciidev/box-sdk':
         specifier: ^0.0.28
         version: 0.0.28
+      '@chat-adapter/state-memory':
+        specifier: 4.39.0
+        version: 4.39.0(zod@4.4.3)
       '@composio/core':
         specifier: 0.16.0
         version: 0.16.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.0)(ws@8.21.3)(zod@4.4.3)
@@ -507,6 +510,9 @@ importers:
       '@rakazo/db':
         specifier: workspace:*
         version: link:../db
+      chat:
+        specifier: 4.39.0
+        version: 4.39.0(zod@4.4.3)
       d3-dsv:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1613,6 +1619,10 @@ packages:
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
     engines: {node: '>=18'}
+
+  '@chat-adapter/state-memory@4.39.0':
+    resolution: {integrity: sha512-sTslMdRA9MG2MYUF9anD+eatZ1o3Nu64TkQCJ9GrGWfRCefM8DnIG/Op+Ej9XS6XjqOORb3eDJvy6IpvWrfT4A==}
+    engines: {node: '>=20'}
 
   '@clack/core@1.4.3':
     resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
@@ -4295,6 +4305,9 @@ packages:
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   '@xmldom/xmldom@0.8.14':
     resolution: {integrity: sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==}
     engines: {node: '>=10.0.0'}
@@ -4862,6 +4875,21 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  chat@4.39.0:
+    resolution: {integrity: sha512-o7D+oAbQAYFVoc9+OH8wya11609ybRThNTF3s/5C1LAABGGi6IrxoQQEN/aIe+4h5pmKYzUjXeqTcuOZcpIAZA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ai: ^6.0.182 || ^7.0.0
+      workflow: ^5.0.0-beta.35
+      zod: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+      workflow:
+        optional: true
+      zod:
+        optional: true
 
   chokidar@3.5.1:
     resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
@@ -8220,6 +8248,9 @@ packages:
   remeda@2.33.4:
     resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
 
+  remend@1.3.1:
+    resolution: {integrity: sha512-N3DiY5qbRPoa5vkxn1oDLMyXOVTeo6Hp+XOj6SIqJAYUgLS0Q587gILPMom/qm86AQ/ZrcOdwEIzCz8V3J0nxQ==}
+
   request-light@0.5.8:
     resolution: {integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==}
 
@@ -10677,6 +10708,15 @@ snapshots:
   '@capsizecss/unpack@4.0.1':
     dependencies:
       fontkitten: 1.0.3
+
+  '@chat-adapter/state-memory@4.39.0(zod@4.4.3)':
+    dependencies:
+      chat: 4.39.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - ai
+      - supports-color
+      - workflow
+      - zod
 
   '@clack/core@1.4.3':
     dependencies:
@@ -13951,6 +13991,8 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
+  '@workflow/serde@4.1.0-beta.2': {}
+
   '@xmldom/xmldom@0.8.14': {}
 
   '@xmldom/xmldom@0.9.11': {}
@@ -14676,6 +14718,20 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  chat@4.39.0(zod@4.4.3):
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.1
+      unified: 11.0.5
+    optionalDependencies:
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   chokidar@3.5.1:
     dependencies:
@@ -18680,6 +18736,8 @@ snapshots:
       unified: 11.0.5
 
   remeda@2.33.4: {}
+
+  remend@1.3.1: {}
 
   request-light@0.5.8: {}
 


### PR DESCRIPTION
## Summary

Fork-sync check per firstmate task — **no push to `origin/main`** due to divergence.

## Fetches

```
git fetch upstream   # upstream/main: 478f104..c983641 (27 commits)
git fetch origin     # origin/main: 002fd4b
```

## Comparison

### `origin/main..upstream/main` — 27 commits upstream has that origin doesn't
```
c983641 fix(compose): allow generic installer download base override (#484)
26ae909 Match Grok Bot: teach in chrome, muted Routines +, simpler sidepanel (#481)
5029a13 fix(adapters): keep versioned OpenAI-compatible API roots (#482)
b59408c feat(web): add Simplified Chinese UI locale (#480)
de5b1e5 Require PR descriptions to state why a change exists (#477)
f72bd16 Reuse Pi provider sessions across bot turns (#466)
7387f95 fix(chat): show wall-clock worked duration (#461)
6e003a2 fix(ui): unify error red across web and mobile (#462)
211c30f fix(mobile): align Expo SDK 57 package versions (#467)
b81cabf fix(chat): remove steering composer helper copy (#460)
1b3687d fix(adapters): settle steering cancel and finalizeRun retries (#459)
0366353 feat(chat): deliver steering messages while bots work (#453)
35aecc1 ci: name PR-relevant Playwright frames in screenshot comments (#457)
de73adc fix(web): stop seen run errors returning after reload (#449)
bc37939 fix(api): stop resurfacing a failed run after a newer run finishes (#447)
af9de9f fix(ci): restore computer image GHCR publishing (#454)
9c7e9f9 Stop labelling older models "latest" in the model picker (#456)
17ed9bc Add password reset and provider-neutral email (#446)
2565cfa Don't fail every turn on an MCP tool enum TypeBox can't express (#450)
920a0ef feat(chat): add tappable choice prompts (#433)
92904b6 Multi-platform chat surface on Chat SDK (Slack, WhatsApp, Telegram + iMessage) (#444)
7e1ef9e Collapse bot tool activity in chat (#440)
826650c fix(chat): restore peer transcript markers (#443)
89f45cc feat(adapters): lazily load large tool schemas (#429)
cec819f fix: suppress roster attention for silent routines (#439)
28e1ba1 Publish compatible mobile changes with EAS Update (#441)
56f4b8a fix(web): keyboard completion for composer @mention picker (#432)
```

### `upstream/main..origin/main` — 3 fork-specific commits (divergence)
```
002fd4b Merge pull request #1 from Timoteohss/fm/rakazo-chatsdk
f2c9e5f no-mistakes(document): Fix stale messaging doc comments and changelog entry
7053799 feat(adapters): add chat-sdk generic messaging transport
```
`git rev-list upstream/main..origin/main --count` = 3  
Merge-base: `d2f2cef Improve mobile authentication flow (#437)`

## Decision

**Fork has diverged — origin/main has 3 commits upstream lacks.** Per task rule §4, **STOP before pushing anything** to `origin/main`. No fast-forward, no force-push, no silent merge/rebase. `origin/main` was **NOT** updated.

Captain needs to decide reconciliation:
- **Merge** `upstream/main` into `origin/main` (preserves both histories, merge commit)
- **Rebase** fork commits (`7053799`, `f2c9e5f`, `002fd4b`) on top of `upstream/main` (linear, rewrites fork history)
- Or other (e.g., keep fork diverged intentionally)

## Commit 5018ceb Verification

Target: `5018ceb3692cbec3929d6f2c3789d4f5f193e9b7` — `fix(messaging): sendblue-only DM cap; drop phone.deliver alias`

```
git log origin/main --oneline | grep 5018ceb  → no match
git merge-base --is-ancestor 5018ceb origin/main → exit 1
git log upstream/main --oneline | grep 5018ceb → no match
git merge-base --is-ancestor 5018ceb upstream/main → exit 1
git branch -a --contains 5018ceb → only remotes/upstream/chatsdk-multi-platform-chat
```

**Answer: NO — commit 5018ceb is NOT present on `origin/main` (and NOT on `upstream/main` either).** It lives only on `upstream/chatsdk-multi-platform-chat` (merge-base with main is `826650c`). Even after a future sync with `upstream/main`, it would still be absent because it is not on `upstream/main`.

Full report committed as `FORK_SYNC_REPORT.md` in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable messaging transport support for SendBlue and chat-sdk providers.
  * Added adapter-based support for direct messages, typing indicators, inbound messages, and webhook handling.
  * Added provider capability reporting, including group messaging support.
* **Bug Fixes**
  * Group and introduction messages now fail clearly when the selected provider does not support group messaging.
  * Webhook delegate mode now forwards requests and returns transport responses correctly.
* **Documentation**
  * Added configuration guidance and an unreleased changelog entry for chat-sdk messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->