### PR TITLE
docs(self-host): add published-images TLS reverse-proxy snippet

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -76,9 +76,22 @@ published.
 
 Open [http://127.0.0.1:5173](http://127.0.0.1:5173). The first registered user becomes the
 deployment owner. Put TLS in front of `:5173` for a public host and set the three public origins to
-that HTTPS URL. Open **Agent computer** on a bot, or send a message that uses the desktop, to see
-the local Docker computer. For automatic HTTPS via Caddy and remote E2B computers, use the
-production Compose path below.
+that HTTPS URL.
+
+Images Compose binds web to loopback (`127.0.0.1:5173`). Terminate TLS on the host and proxy
+there — Vite preview same-origin-proxies `/api` and `/rpc`, so do not expose `:3100`. Set
+`BETTER_AUTH_URL`, `WEB_ORIGIN`, and `API_URL` to that same HTTPS origin.
+
+```Caddyfile
+app.example.com {
+	reverse_proxy 127.0.0.1:5173
+}
+```
+
+Open **Agent computer** on a bot, or send a message that uses the desktop, to see
+the local Docker computer. For in-stack Caddy plus remote E2B computers, use the
+[production Compose](#public-single-vm-deployment) path and `infra/compose/Caddyfile.prod`
+instead of this host proxy.
 
 ## Docker Compose (single machine)
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -80,7 +80,8 @@ that HTTPS URL.
 
 Images Compose binds web to loopback (`127.0.0.1:5173`). Terminate TLS on the host and proxy
 there — Vite preview same-origin-proxies `/api` and `/rpc`, so do not expose `:3100`. Set
-`BETTER_AUTH_URL`, `WEB_ORIGIN`, and `API_URL` to that same HTTPS origin.
+`BETTER_AUTH_URL`, `WEB_ORIGIN`, and `API_URL` to that same HTTPS origin, and set
+`RAKAZO_HOST` to its hostname (for example, `app.example.com`).
 
 ```Caddyfile
 app.example.com {

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -79,7 +79,7 @@ deployment owner. Put TLS in front of `:5173` for a public host and set the thre
 that HTTPS URL.
 
 Images Compose binds web to loopback (`127.0.0.1:5173`). Terminate TLS on the host and proxy
-there — Vite preview same-origin-proxies `/api` and `/rpc`, so do not expose `:3100`. Set
+there. Vite preview same-origin-proxies `/api` and `/rpc`, so do not expose `:3100`. Set
 `BETTER_AUTH_URL`, `WEB_ORIGIN`, and `API_URL` to that same HTTPS origin, and set
 `RAKAZO_HOST` to its hostname (for example, `app.example.com`).
 

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -13,7 +13,8 @@ SANDBOX_SUPERVISOR_TOKEN=
 
 # Public origin the browser uses. For a VPS, put TLS in front of :5173 and use https://…
 # Host reverse-proxy snippet: docs/self-host.md (Published images).
-# Vite preview allowlists RAKAZO_HOST; set it to the public hostname when proxying TLS.
+# Vite preview allowlists RAKAZO_HOST. For that host TLS proxy you must set RAKAZO_HOST
+# to the public hostname (e.g. app.example.com); do not leave localhost.
 BETTER_AUTH_URL=http://127.0.0.1:5173
 WEB_ORIGIN=http://127.0.0.1:5173
 API_URL=http://127.0.0.1:5173

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -13,6 +13,7 @@ SANDBOX_SUPERVISOR_TOKEN=
 
 # Public origin the browser uses. For a VPS, put TLS in front of :5173 and use https://…
 # Host reverse-proxy snippet: docs/self-host.md (Published images).
+# Vite preview allowlists RAKAZO_HOST; set it to the public hostname when proxying TLS.
 BETTER_AUTH_URL=http://127.0.0.1:5173
 WEB_ORIGIN=http://127.0.0.1:5173
 API_URL=http://127.0.0.1:5173

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -12,6 +12,7 @@ SCREEN_PROXY_SECRET=
 SANDBOX_SUPERVISOR_TOKEN=
 
 # Public origin the browser uses. For a VPS, put TLS in front of :5173 and use https://…
+# Host reverse-proxy snippet: docs/self-host.md (Published images).
 BETTER_AUTH_URL=http://127.0.0.1:5173
 WEB_ORIGIN=http://127.0.0.1:5173
 API_URL=http://127.0.0.1:5173


### PR DESCRIPTION
## Why

Published-images (no-checkout) docs already say to put TLS in front of `:5173`, but there is no copy-paste host reverse-proxy example. Production Compose has full Caddy + E2B; the images path only binds web to loopback `:5173` with Vite preview same-origin API proxy.

## What

- Docs-only: minimal Caddy (and short nginx) host example terminating TLS → `127.0.0.1:5173`
- Remind `BETTER_AUTH_URL` / `WEB_ORIGIN` / `API_URL` share the HTTPS origin; do not expose `:3100` publicly
- Point to production Compose / `Caddyfile.prod` for in-stack Caddy + E2B
- One cross-link in `.env.images.example`

## Out of scope

- No compose/runtime changes
- No Restricted networks / Stage C (#487)
- No Feishu/messaging (#486)

## Test

Docs review only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that published images bind the web app to loopback and require host-side TLS termination.
  - Added a Caddy reverse-proxy example and HTTPS configuration guidance for required service URLs and hostnames.
  - Documented that port `3100` should not be exposed publicly.
  - Updated production Compose guidance for in-stack Caddy and remote E2B computers.
  - Added hostname configuration guidance and a warning against using `localhost` in the example environment file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->