### PR TITLE
feat(messaging): add Postgres-backed Baileys auth state store

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -28,6 +28,8 @@
     "@rakazo/contracts": "workspace:*",
     "@rakazo/core": "workspace:*",
     "@rakazo/db": "workspace:*",
+    "async-mutex": "^0.5.0",
+    "baileys": "7.0.0-rc14",
     "chat": "4.39.0",
     "chat-adapter-sendblue": "0.2.0",
     "d3-dsv": "^3.0.1",

--- a/packages/adapters/src/baileys-auth-state.test.ts
+++ b/packages/adapters/src/baileys-auth-state.test.ts
@@ -1,8 +1,11 @@
+import type { SignalDataSet } from "baileys";
 import { BufferJSON, initAuthCreds } from "baileys";
 import { describe, expect, it } from "vitest";
 import { createPostgresAuthState } from "./baileys-auth-state.js";
 
 type Row = { id: string; scope: string; creds: unknown; keys: unknown; status: string };
+
+const TEST_ENCRYPTION_KEY = "test-baileys-encryption-key-32-chars-long!!";
 
 function createInMemoryPrisma() {
   const store = new Map<string, Row>();
@@ -54,7 +57,6 @@ function createInMemoryPrisma() {
       }) => {
         for (const r of store.values()) {
           if (r.scope === where.scope) {
-            // apply update if any
             Object.assign(r, update);
             return { ...r };
           }
@@ -86,12 +88,10 @@ function createInMemoryPrisma() {
         if (!target) throw new Error(`row not found for ${JSON.stringify(where)}`);
         if ("creds" in data) target.creds = data.creds;
         if ("keys" in data) target.keys = data.keys;
-        // also bump any other fields if provided
         Object.assign(target, data);
         return { ...target };
       },
     },
-    // expose for inspection
     __store: store,
   };
   return api;
@@ -99,7 +99,6 @@ function createInMemoryPrisma() {
 
 function realisticFixture() {
   const creds = initAuthCreds();
-  // Make deterministic, add binary fields
   (creds as unknown as Record<string, unknown>).me = {
     id: "1234567890@s.whatsapp.net",
     name: "Test User",
@@ -139,14 +138,11 @@ function realisticFixture() {
 describe("baileys-auth-state Postgres store", () => {
   it("round-trips BufferJSON serialize/deserialize for a realistic fixture", async () => {
     const { creds, keys } = realisticFixture();
-    // Direct BufferJSON round-trip check (proves codec handles our fixture)
     const serialized = JSON.parse(JSON.stringify(creds, BufferJSON.replacer));
     const deserialized = JSON.parse(JSON.stringify(serialized), BufferJSON.reviver);
-    // Buffers survive
     expect(deserialized.noiseKey.public).toBeInstanceOf(Buffer);
     expect(deserialized.noiseKey.private).toBeInstanceOf(Buffer);
     expect(deserialized.signedIdentityKey.public).toBeInstanceOf(Buffer);
-    // Keys fixture buffers survive too
     const keysSer = JSON.parse(JSON.stringify(keys, BufferJSON.replacer));
     const keysDes = JSON.parse(JSON.stringify(keysSer), BufferJSON.reviver) as typeof keys;
     expect((keysDes["pre-key"] as Record<string, { public: Buffer }>)["1"]!.public).toBeInstanceOf(
@@ -163,30 +159,25 @@ describe("baileys-auth-state Postgres store", () => {
     >[0];
     const scope = "test-restart-scope";
 
-    const a = await createPostgresAuthState(prisma, scope);
-    // Mutate creds like Baileys does
+    const a = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
     (a.state.creds as unknown as Record<string, unknown>).me = {
       id: " restart-me@s.whatsapp.net",
       name: "Restart",
     };
     (a.state.creds as unknown as Record<string, unknown>).registered = true;
-    // Add a deterministic noiseKey mutation via Buffer
-    a.state.creds.noiseKey = {
+    (a.state.creds as unknown as Record<string, unknown>).noiseKey = {
       public: Buffer.from("restart-public"),
       private: Buffer.from("restart-private"),
-    } as unknown as typeof a.state.creds.noiseKey;
+    };
     await a.saveCreds();
-    // Flush keys also (ensure destroy flushes)
     await a.destroy();
 
-    // Fresh instance should see identical creds
-    const b = await createPostgresAuthState(prisma, scope);
+    const b = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
     expect(b.state.creds.me).toEqual({ id: " restart-me@s.whatsapp.net", name: "Restart" });
     expect(b.state.creds.registered).toBe(true);
     expect(Buffer.isBuffer(b.state.creds.noiseKey.public)).toBe(true);
     expect(Buffer.from(b.state.creds.noiseKey.public).toString()).toBe("restart-public");
     expect(Buffer.from(b.state.creds.noiseKey.private).toString()).toBe("restart-private");
-    // Cleanup
     await b.destroy();
   });
 
@@ -196,21 +187,19 @@ describe("baileys-auth-state Postgres store", () => {
     >[0];
     const scope = "test-keys-write-through";
 
-    const a = await createPostgresAuthState(prisma, scope);
+    const a = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
     const payload = {
       "pre-key": {
         "42": { public: Buffer.from("pk42-public"), private: Buffer.from("pk42-private") },
       },
       session: { "peer@s.whatsapp.net.0": Buffer.from("session-xyz") },
-    } as unknown as import("baileys").SignalDataSet;
+    } as unknown as SignalDataSet;
 
     await a.state.keys.set(payload);
-    // Wait for debounced flush (40ms) plus margin
     await new Promise((r) => setTimeout(r, 80));
-    // Also flush via destroy to ensure persistence if debounce missed
     await a.destroy();
 
-    const b = await createPostgresAuthState(prisma, scope);
+    const b = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
     const got = (await b.state.keys.get("pre-key", ["42"])) as Record<string, unknown>;
     expect(got["42"]).toBeTruthy();
     expect(Buffer.isBuffer((got["42"] as { public: Buffer }).public)).toBe(true);
@@ -230,28 +219,25 @@ describe("baileys-auth-state Postgres store", () => {
     >[0];
     const scope = "test-concurrent-flush";
 
-    const a = await createPostgresAuthState(prisma, scope);
+    const a = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
 
-    // Two saves in quick succession, overlapping
     const p1 = a.state.keys.set({
       "pre-key": { "100": { public: Buffer.from("c100"), private: Buffer.from("c100p") } },
-    } as unknown as import("baileys").SignalDataSet);
+    } as unknown as SignalDataSet);
     const p2 = a.state.keys.set({
       session: { "concurrent@s.whatsapp.net.0": Buffer.from("concurrent-session") },
-    } as unknown as import("baileys").SignalDataSet);
+    } as unknown as SignalDataSet);
     await Promise.all([p1, p2]);
 
-    // Wait for debounce to coalesce and flush
     await new Promise((r) => setTimeout(r, 100));
     await a.destroy();
 
-    const b = await createPostgresAuthState(prisma, scope);
+    const b = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
     const pre = (await b.state.keys.get("pre-key", ["100"])) as Record<string, unknown>;
     const sess = (await b.state.keys.get("session", ["concurrent@s.whatsapp.net.0"])) as Record<
       string,
       Buffer
     >;
-    // Neither write was lost
     expect(pre["100"]).toBeTruthy();
     expect(sess["concurrent@s.whatsapp.net.0"]).toBeTruthy();
     expect(Buffer.from(sess["concurrent@s.whatsapp.net.0"]!).toString()).toBe("concurrent-session");
@@ -263,16 +249,107 @@ describe("baileys-auth-state Postgres store", () => {
       typeof createPostgresAuthState
     >[0];
     const scope = "test-destroy-flush";
-    const a = await createPostgresAuthState(prisma, scope);
+    const a = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
     await a.state.keys.set({
       "pre-key": { "999": { public: Buffer.from("pending"), private: Buffer.from("pending-p") } },
-    } as unknown as import("baileys").SignalDataSet);
-    // No wait — destroy should force flush
+    } as unknown as SignalDataSet);
     await a.destroy();
 
-    const b = await createPostgresAuthState(prisma, scope);
+    const b = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
     const got = (await b.state.keys.get("pre-key", ["999"])) as Record<string, unknown>;
     expect(got["999"]).toBeTruthy();
     await b.destroy();
+  });
+
+  it("stores creds and keys encrypted at rest, not plaintext JSON", async () => {
+    const prisma = createInMemoryPrisma() as unknown as Parameters<
+      typeof createPostgresAuthState
+    >[0];
+    const scope = "test-encrypted-at-rest";
+    const a = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
+    (a.state.creds as unknown as Record<string, unknown>).me = {
+      id: "encrypt-me@s.whatsapp.net",
+      name: "Encrypted",
+    };
+    await a.saveCreds();
+    await a.state.keys.set({
+      "pre-key": {
+        "555": { public: Buffer.from("secret-key"), private: Buffer.from("secret-priv") },
+      },
+    } as unknown as SignalDataSet);
+    await new Promise((r) => setTimeout(r, 80));
+    await a.destroy();
+
+    // Inspect raw stored bytes in the in-memory prisma — must be ciphertext string
+    const rawRow = [
+      ...(prisma as unknown as ReturnType<typeof createInMemoryPrisma>).__store.values(),
+    ].find((r) => r.scope === scope)!;
+    expect(rawRow).toBeTruthy();
+    // Both columns must be strings starting with v2: (EncryptedSecretStore format)
+    expect(typeof rawRow.creds).toBe("string");
+    expect(typeof rawRow.keys).toBe("string");
+    expect((rawRow.creds as string).startsWith("v2:")).toBe(true);
+    expect((rawRow.keys as string).startsWith("v2:")).toBe(true);
+    // Must NOT contain plaintext fragments
+    expect(rawRow.creds as string).not.toContain("encrypt-me");
+    expect(rawRow.creds as string).not.toContain("Encrypted");
+    expect(rawRow.keys as string).not.toContain("secret-key");
+    expect(rawRow.keys as string).not.toContain("555");
+    // But a fresh instance with the same key decrypts correctly
+    const b = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
+    const got = (await b.state.keys.get("pre-key", ["555"])) as unknown as Record<
+      string,
+      { public: Buffer }
+    >;
+    expect(got["555"]).toBeTruthy();
+    expect(Buffer.from(got["555"]!.public).toString()).toBe("secret-key");
+    await b.destroy();
+  });
+
+  it("reads legacy plaintext rows (pre-encryption) without data loss", async () => {
+    const prisma = createInMemoryPrisma() as unknown as Parameters<
+      typeof createPostgresAuthState
+    >[0];
+    const scope = "test-legacy-plaintext";
+    // Manually insert a legacy plaintext row (object, not ciphertext) as the old code did
+    const legacyCreds = initAuthCreds();
+    (legacyCreds as unknown as Record<string, unknown>).me = {
+      id: "legacy@s.whatsapp.net",
+      name: "Legacy",
+    };
+    const legacyKeys = {
+      "pre-key": {
+        "7": { public: Buffer.from("legacy-pub"), private: Buffer.from("legacy-priv") },
+      },
+    };
+    const serializedCreds = JSON.parse(JSON.stringify(legacyCreds, BufferJSON.replacer));
+    const serializedKeys = JSON.parse(JSON.stringify(legacyKeys, BufferJSON.replacer));
+    // Directly push into store as legacy plaintext objects
+    const store = (prisma as unknown as ReturnType<typeof createInMemoryPrisma>).__store;
+    store.set("mbs_legacy", {
+      id: "mbs_legacy",
+      scope,
+      status: "unpaired",
+      creds: serializedCreds,
+      keys: serializedKeys,
+    });
+
+    const auth = await createPostgresAuthState(prisma, scope, TEST_ENCRYPTION_KEY);
+    expect(auth.state.creds.me).toEqual({ id: "legacy@s.whatsapp.net", name: "Legacy" });
+    const got = (await auth.state.keys.get("pre-key", ["7"])) as unknown as Record<
+      string,
+      { public: Buffer }
+    >;
+    expect(got["7"]).toBeTruthy();
+    expect(Buffer.from(got["7"]!.public).toString()).toBe("legacy-pub");
+    await auth.saveCreds();
+    await auth.state.keys.set({
+      session: { "new@s.whatsapp.net.0": Buffer.from("new-session") },
+    } as unknown as SignalDataSet);
+    await new Promise((r) => setTimeout(r, 80));
+    await auth.destroy();
+    const rawRow = [...store.values()].find((r) => r.scope === scope)!;
+    expect(typeof rawRow.creds).toBe("string");
+    expect((rawRow.creds as string).startsWith("v2:")).toBe(true);
   });
 });

--- a/packages/adapters/src/baileys-auth-state.test.ts
+++ b/packages/adapters/src/baileys-auth-state.test.ts
@@ -1,0 +1,278 @@
+import { BufferJSON, initAuthCreds } from "baileys";
+import { describe, expect, it } from "vitest";
+import { createPostgresAuthState } from "./baileys-auth-state.js";
+
+type Row = { id: string; scope: string; creds: unknown; keys: unknown; status: string };
+
+function createInMemoryPrisma() {
+  const store = new Map<string, Row>();
+  let nextId = 1;
+
+  const api = {
+    messagingBaileysSession: {
+      findUnique: async ({ where }: { where: { scope?: string; id?: string } }) => {
+        if (where.scope) {
+          for (const r of store.values()) if (r.scope === where.scope) return { ...r };
+          return null;
+        }
+        if (where.id) {
+          const r = store.get(where.id);
+          return r ? { ...r } : null;
+        }
+        return null;
+      },
+      findFirst: async ({ where }: { where: { OR?: Array<{ scope?: string; id?: string }> } }) => {
+        const ors = where.OR ?? [];
+        for (const r of store.values()) {
+          for (const cond of ors) {
+            if (cond.scope && r.scope === cond.scope) return { ...r };
+            if (cond.id && r.id === cond.id) return { ...r };
+          }
+        }
+        return null;
+      },
+      create: async ({ data }: { data: { scope: string; status?: string } }) => {
+        const id = `mbs_${nextId++}`;
+        const row: Row = {
+          id,
+          scope: data.scope,
+          status: data.status ?? "unpaired",
+          creds: null,
+          keys: null,
+        };
+        store.set(id, row);
+        return { ...row };
+      },
+      upsert: async ({
+        where,
+        create,
+        update,
+      }: {
+        where: { scope: string };
+        create: { scope: string; status?: string };
+        update: Record<string, unknown>;
+      }) => {
+        for (const r of store.values()) {
+          if (r.scope === where.scope) {
+            // apply update if any
+            Object.assign(r, update);
+            return { ...r };
+          }
+        }
+        const id = `mbs_${nextId++}`;
+        const row: Row = {
+          id,
+          scope: create.scope,
+          status: create.status ?? "unpaired",
+          creds: null,
+          keys: null,
+        };
+        store.set(id, row);
+        return { ...row };
+      },
+      update: async ({
+        where,
+        data,
+      }: {
+        where: { scope?: string; id?: string };
+        data: { creds?: unknown; keys?: unknown };
+      }) => {
+        let target: Row | undefined;
+        if (where.scope) {
+          for (const r of store.values()) if (r.scope === where.scope) target = r;
+        } else if (where.id) {
+          target = store.get(where.id);
+        }
+        if (!target) throw new Error(`row not found for ${JSON.stringify(where)}`);
+        if ("creds" in data) target.creds = data.creds;
+        if ("keys" in data) target.keys = data.keys;
+        // also bump any other fields if provided
+        Object.assign(target, data);
+        return { ...target };
+      },
+    },
+    // expose for inspection
+    __store: store,
+  };
+  return api;
+}
+
+function realisticFixture() {
+  const creds = initAuthCreds();
+  // Make deterministic, add binary fields
+  (creds as unknown as Record<string, unknown>).me = {
+    id: "1234567890@s.whatsapp.net",
+    name: "Test User",
+  };
+  creds.account = undefined;
+  creds.signalIdentities = [
+    {
+      identifier: { name: "1234567890@s.whatsapp.net", deviceId: 0 },
+      identifierKey: Buffer.from("identifierKey-data"),
+    },
+  ];
+  creds.myAppStateKeyId = "test-key-id";
+  creds.registered = true;
+
+  const keys = {
+    "pre-key": {
+      "1": { public: Buffer.from("prekey-public-1"), private: Buffer.from("prekey-private-1") },
+      "2": { public: new Uint8Array([1, 2, 3, 4]), private: new Uint8Array([5, 6, 7, 8]) },
+    },
+    session: {
+      "123@s.whatsapp.net.0": Buffer.from("session-data-blob"),
+    },
+    "sender-key": {
+      "group123@s.whatsapp.net": Buffer.from("sender-key-data"),
+    },
+    "app-state-sync-key": {
+      testKeyId: {
+        keyData: Buffer.from("app-state-key"),
+        fingerprint: { currentIndex: 1 },
+      } as unknown as never,
+    },
+  } as unknown as Record<string, Record<string, unknown>>;
+
+  return { creds, keys };
+}
+
+describe("baileys-auth-state Postgres store", () => {
+  it("round-trips BufferJSON serialize/deserialize for a realistic fixture", async () => {
+    const { creds, keys } = realisticFixture();
+    // Direct BufferJSON round-trip check (proves codec handles our fixture)
+    const serialized = JSON.parse(JSON.stringify(creds, BufferJSON.replacer));
+    const deserialized = JSON.parse(JSON.stringify(serialized), BufferJSON.reviver);
+    // Buffers survive
+    expect(deserialized.noiseKey.public).toBeInstanceOf(Buffer);
+    expect(deserialized.noiseKey.private).toBeInstanceOf(Buffer);
+    expect(deserialized.signedIdentityKey.public).toBeInstanceOf(Buffer);
+    // Keys fixture buffers survive too
+    const keysSer = JSON.parse(JSON.stringify(keys, BufferJSON.replacer));
+    const keysDes = JSON.parse(JSON.stringify(keysSer), BufferJSON.reviver) as typeof keys;
+    expect((keysDes["pre-key"] as Record<string, { public: Buffer }>)["1"]!.public).toBeInstanceOf(
+      Buffer,
+    );
+    expect((keysDes.session as Record<string, Buffer>)["123@s.whatsapp.net.0"]).toBeInstanceOf(
+      Buffer,
+    );
+  });
+
+  it("persists creds and restores them on fresh instance (process restart simulation)", async () => {
+    const prisma = createInMemoryPrisma() as unknown as Parameters<
+      typeof createPostgresAuthState
+    >[0];
+    const scope = "test-restart-scope";
+
+    const a = await createPostgresAuthState(prisma, scope);
+    // Mutate creds like Baileys does
+    (a.state.creds as unknown as Record<string, unknown>).me = {
+      id: " restart-me@s.whatsapp.net",
+      name: "Restart",
+    };
+    (a.state.creds as unknown as Record<string, unknown>).registered = true;
+    // Add a deterministic noiseKey mutation via Buffer
+    a.state.creds.noiseKey = {
+      public: Buffer.from("restart-public"),
+      private: Buffer.from("restart-private"),
+    } as unknown as typeof a.state.creds.noiseKey;
+    await a.saveCreds();
+    // Flush keys also (ensure destroy flushes)
+    await a.destroy();
+
+    // Fresh instance should see identical creds
+    const b = await createPostgresAuthState(prisma, scope);
+    expect(b.state.creds.me).toEqual({ id: " restart-me@s.whatsapp.net", name: "Restart" });
+    expect(b.state.creds.registered).toBe(true);
+    expect(Buffer.isBuffer(b.state.creds.noiseKey.public)).toBe(true);
+    expect(Buffer.from(b.state.creds.noiseKey.public).toString()).toBe("restart-public");
+    expect(Buffer.from(b.state.creds.noiseKey.private).toString()).toBe("restart-private");
+    // Cleanup
+    await b.destroy();
+  });
+
+  it("keys.set writes through and subsequent read reflects it", async () => {
+    const prisma = createInMemoryPrisma() as unknown as Parameters<
+      typeof createPostgresAuthState
+    >[0];
+    const scope = "test-keys-write-through";
+
+    const a = await createPostgresAuthState(prisma, scope);
+    const payload = {
+      "pre-key": {
+        "42": { public: Buffer.from("pk42-public"), private: Buffer.from("pk42-private") },
+      },
+      session: { "peer@s.whatsapp.net.0": Buffer.from("session-xyz") },
+    } as unknown as import("baileys").SignalDataSet;
+
+    await a.state.keys.set(payload);
+    // Wait for debounced flush (40ms) plus margin
+    await new Promise((r) => setTimeout(r, 80));
+    // Also flush via destroy to ensure persistence if debounce missed
+    await a.destroy();
+
+    const b = await createPostgresAuthState(prisma, scope);
+    const got = (await b.state.keys.get("pre-key", ["42"])) as Record<string, unknown>;
+    expect(got["42"]).toBeTruthy();
+    expect(Buffer.isBuffer((got["42"] as { public: Buffer }).public)).toBe(true);
+
+    const sess = (await b.state.keys.get("session", ["peer@s.whatsapp.net.0"])) as Record<
+      string,
+      Buffer
+    >;
+    expect(sess["peer@s.whatsapp.net.0"]).toBeTruthy();
+    expect(Buffer.from(sess["peer@s.whatsapp.net.0"]!).toString()).toBe("session-xyz");
+    await b.destroy();
+  });
+
+  it("concurrent flushes do not corrupt or lose data", async () => {
+    const prisma = createInMemoryPrisma() as unknown as Parameters<
+      typeof createPostgresAuthState
+    >[0];
+    const scope = "test-concurrent-flush";
+
+    const a = await createPostgresAuthState(prisma, scope);
+
+    // Two saves in quick succession, overlapping
+    const p1 = a.state.keys.set({
+      "pre-key": { "100": { public: Buffer.from("c100"), private: Buffer.from("c100p") } },
+    } as unknown as import("baileys").SignalDataSet);
+    const p2 = a.state.keys.set({
+      session: { "concurrent@s.whatsapp.net.0": Buffer.from("concurrent-session") },
+    } as unknown as import("baileys").SignalDataSet);
+    await Promise.all([p1, p2]);
+
+    // Wait for debounce to coalesce and flush
+    await new Promise((r) => setTimeout(r, 100));
+    await a.destroy();
+
+    const b = await createPostgresAuthState(prisma, scope);
+    const pre = (await b.state.keys.get("pre-key", ["100"])) as Record<string, unknown>;
+    const sess = (await b.state.keys.get("session", ["concurrent@s.whatsapp.net.0"])) as Record<
+      string,
+      Buffer
+    >;
+    // Neither write was lost
+    expect(pre["100"]).toBeTruthy();
+    expect(sess["concurrent@s.whatsapp.net.0"]).toBeTruthy();
+    expect(Buffer.from(sess["concurrent@s.whatsapp.net.0"]!).toString()).toBe("concurrent-session");
+    await b.destroy();
+  });
+
+  it("destroy flushes pending writes even if called immediately after set", async () => {
+    const prisma = createInMemoryPrisma() as unknown as Parameters<
+      typeof createPostgresAuthState
+    >[0];
+    const scope = "test-destroy-flush";
+    const a = await createPostgresAuthState(prisma, scope);
+    await a.state.keys.set({
+      "pre-key": { "999": { public: Buffer.from("pending"), private: Buffer.from("pending-p") } },
+    } as unknown as import("baileys").SignalDataSet);
+    // No wait — destroy should force flush
+    await a.destroy();
+
+    const b = await createPostgresAuthState(prisma, scope);
+    const got = (await b.state.keys.get("pre-key", ["999"])) as Record<string, unknown>;
+    expect(got["999"]).toBeTruthy();
+    await b.destroy();
+  });
+});

--- a/packages/adapters/src/baileys-auth-state.ts
+++ b/packages/adapters/src/baileys-auth-state.ts
@@ -6,6 +6,7 @@ import type {
   SignalKeyStore,
 } from "baileys";
 import { BufferJSON, initAuthCreds, makeCacheableSignalKeyStore } from "baileys";
+import { EncryptedSecretStore } from "./secrets.js";
 
 // Re-export for callers that need the type.
 export type { AuthenticationCreds, AuthenticationState, SignalDataSet, SignalKeyStore };
@@ -14,6 +15,11 @@ export interface BaileysAuthState {
   state: AuthenticationState;
   saveCreds: () => Promise<void>;
   destroy: () => Promise<void>;
+}
+
+export interface BaileysAuthStateOptions {
+  encryptionKey?: string;
+  secrets?: EncryptedSecretStore;
 }
 
 type PrismaLike = {
@@ -35,21 +41,16 @@ type Row = {
 
 const FLUSH_DEBOUNCE_MS = 40;
 
-function serialize(obj: unknown): unknown {
-  return JSON.parse(
-    JSON.stringify(obj, BufferJSON.replacer as unknown as (k: string, v: unknown) => unknown),
-  );
-}
-
-function deserialize(stored: unknown): unknown {
-  if (stored == null) return null;
-  if (typeof stored === "string") {
-    return JSON.parse(stored, BufferJSON.reviver as unknown as (k: string, v: unknown) => unknown);
+function resolveSecrets(optsOrKey?: string | BaileysAuthStateOptions): EncryptedSecretStore {
+  if (optsOrKey && typeof optsOrKey === "object" && "secrets" in optsOrKey && optsOrKey.secrets) {
+    return optsOrKey.secrets;
   }
-  return JSON.parse(
-    JSON.stringify(stored),
-    BufferJSON.reviver as unknown as (k: string, v: unknown) => unknown,
-  );
+  const keyFromOpts =
+    typeof optsOrKey === "string"
+      ? optsOrKey
+      : (optsOrKey as BaileysAuthStateOptions | undefined)?.encryptionKey;
+  const key = keyFromOpts ?? process.env.ENCRYPTION_KEY ?? "dev-encryption-key";
+  return new EncryptedSecretStore(key);
 }
 
 async function loadRow(prisma: PrismaLike, scope: string): Promise<Row | null> {
@@ -117,10 +118,11 @@ async function ensureRow(prisma: PrismaLike, scope: string): Promise<Row> {
  *
  * Each `scope` maps to one `messaging_baileys_sessions` row (`scope` unique,
  * default for now). Creds and keys are serialized with Baileys' BufferJSON
- * codec into the jsonb columns. The signal key store is wrapped with
- * `makeCacheableSignalKeyStore` for in-memory cache + write-through semantics;
- * writes are debounced and coalesced, with an explicit `destroy()` flush hook
- * for disconnect / shutdown callers.
+ * codec, then encrypted with EncryptedSecretStore (AES-256-GCM, scrypt,
+ * versioned `v2:` format) before being written to the jsonb columns. The
+ * signal key store is wrapped with `makeCacheableSignalKeyStore` for in-memory
+ * cache + write-through semantics; writes are debounced and coalesced, with an
+ * explicit `destroy()` flush hook for disconnect / shutdown callers.
  *
  * The returned `state.creds` object is the live mutable reference Baileys
  * mutates; call `saveCreds()` after Baileys signals creds have changed.
@@ -128,23 +130,70 @@ async function ensureRow(prisma: PrismaLike, scope: string): Promise<Row> {
 export async function createPostgresAuthState(
   prisma: PrismaLike,
   sessionId = "default",
+  optsOrKey?: string | BaileysAuthStateOptions,
 ): Promise<BaileysAuthState> {
   const scope = sessionId || "default";
+  const secrets = resolveSecrets(optsOrKey);
+  const credsRecordId = `baileys:${scope}:creds`;
+  const keysRecordId = `baileys:${scope}:keys`;
+
+  function encryptValue(obj: unknown, recordId: string): string {
+    const plaintext = JSON.stringify(
+      obj,
+      BufferJSON.replacer as unknown as (k: string, v: unknown) => unknown,
+    );
+    return secrets.encrypt(plaintext, recordId);
+  }
+
+  function decryptValue(stored: unknown, recordId: string): unknown {
+    if (stored == null) return null;
+    if (typeof stored === "string") {
+      // Ciphertext from EncryptedSecretStore always starts with v2:, but also
+      // handle legacy base64 without prefix.
+      const maybeCipher = stored.trim();
+      if (maybeCipher.startsWith("v2:") || /^[A-Za-z0-9+/=]+$/.test(maybeCipher)) {
+        try {
+          const plain = secrets.load(maybeCipher, recordId);
+          return JSON.parse(
+            plain,
+            BufferJSON.reviver as unknown as (k: string, v: unknown) => unknown,
+          );
+        } catch {
+          // Not actually ciphertext — fall through to plain JSON parse below
+        }
+      }
+      try {
+        return JSON.parse(
+          stored,
+          BufferJSON.reviver as unknown as (k: string, v: unknown) => unknown,
+        );
+      } catch {
+        return null;
+      }
+    }
+    // Legacy plaintext JSONB object (pre-encryption rows)
+    return JSON.parse(
+      JSON.stringify(stored),
+      BufferJSON.reviver as unknown as (k: string, v: unknown) => unknown,
+    );
+  }
+
   const row = await ensureRow(prisma, scope);
 
   let creds: AuthenticationCreds;
   const rawCreds = row.creds;
-  if (rawCreds != null) {
-    creds = deserialize(rawCreds) as AuthenticationCreds;
+  const decryptedCreds = decryptValue(rawCreds, credsRecordId);
+  if (decryptedCreds != null) {
+    creds = decryptedCreds as AuthenticationCreds;
   } else {
     creds = initAuthCreds();
   }
 
   let keysData: SignalDataSet = {};
   const rawKeys = row.keys;
-  if (rawKeys != null) {
-    const parsed = deserialize(rawKeys) as SignalDataSet;
-    if (parsed && typeof parsed === "object") keysData = parsed as SignalDataSet;
+  const decryptedKeys = decryptValue(rawKeys, keysRecordId);
+  if (decryptedKeys != null && typeof decryptedKeys === "object") {
+    keysData = decryptedKeys as SignalDataSet;
   }
 
   const mutex = new Mutex();
@@ -164,7 +213,7 @@ export async function createPostgresAuthState(
       pendingTimer = null;
     }
     await mutex.runExclusive(async () => {
-      const payload = serialize(keysData);
+      const payload = encryptValue(keysData, keysRecordId);
       const upd = delegate.update;
       if (!upd) throw new Error("prisma delegate missing update");
       try {
@@ -234,7 +283,7 @@ export async function createPostgresAuthState(
 
   async function saveCreds(): Promise<void> {
     await mutex.runExclusive(async () => {
-      const payload = serialize(state.creds);
+      const payload = encryptValue(state.creds, credsRecordId);
       const upd = delegate.update;
       if (!upd) throw new Error("prisma delegate missing update");
       try {
@@ -252,7 +301,7 @@ export async function createPostgresAuthState(
       pendingTimer = null;
     }
     await mutex.runExclusive(async () => {
-      const payload = serialize(keysData);
+      const payload = encryptValue(keysData, keysRecordId);
       const upd = delegate.update;
       if (!upd) return;
       try {

--- a/packages/adapters/src/baileys-auth-state.ts
+++ b/packages/adapters/src/baileys-auth-state.ts
@@ -1,0 +1,271 @@
+import { Mutex } from "async-mutex";
+import type {
+  AuthenticationCreds,
+  AuthenticationState,
+  SignalDataSet,
+  SignalKeyStore,
+} from "baileys";
+import { BufferJSON, initAuthCreds, makeCacheableSignalKeyStore } from "baileys";
+
+// Re-export for callers that need the type.
+export type { AuthenticationCreds, AuthenticationState, SignalDataSet, SignalKeyStore };
+
+export interface BaileysAuthState {
+  state: AuthenticationState;
+  saveCreds: () => Promise<void>;
+  destroy: () => Promise<void>;
+}
+
+type PrismaLike = {
+  messagingBaileysSession: {
+    findUnique?: (args: unknown) => Promise<unknown>;
+    findFirst?: (args: unknown) => Promise<unknown>;
+    create?: (args: unknown) => Promise<unknown>;
+    update?: (args: unknown) => Promise<unknown>;
+    upsert?: (args: unknown) => Promise<unknown>;
+  };
+};
+
+type Row = {
+  id: string;
+  scope: string;
+  creds: unknown;
+  keys: unknown;
+};
+
+const FLUSH_DEBOUNCE_MS = 40;
+
+function serialize(obj: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(obj, BufferJSON.replacer as unknown as (k: string, v: unknown) => unknown),
+  );
+}
+
+function deserialize(stored: unknown): unknown {
+  if (stored == null) return null;
+  if (typeof stored === "string") {
+    return JSON.parse(stored, BufferJSON.reviver as unknown as (k: string, v: unknown) => unknown);
+  }
+  return JSON.parse(
+    JSON.stringify(stored),
+    BufferJSON.reviver as unknown as (k: string, v: unknown) => unknown,
+  );
+}
+
+async function loadRow(prisma: PrismaLike, scope: string): Promise<Row | null> {
+  const delegate = prisma.messagingBaileysSession as unknown as Record<
+    string,
+    (a: unknown) => Promise<unknown>
+  >;
+  if (delegate.findUnique) {
+    try {
+      const byScope = (await delegate.findUnique({ where: { scope } })) as Row | null;
+      if (byScope) return byScope;
+    } catch {
+      // ignore
+    }
+    try {
+      const byId = (await delegate.findUnique({ where: { id: scope } })) as Row | null;
+      if (byId) return byId;
+    } catch {
+      // ignore
+    }
+  }
+  if (delegate.findFirst) {
+    try {
+      const row = (await delegate.findFirst({
+        where: { OR: [{ scope }, { id: scope }] },
+      })) as Row | null;
+      if (row) return row;
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}
+
+async function ensureRow(prisma: PrismaLike, scope: string): Promise<Row> {
+  const existing = await loadRow(prisma, scope);
+  if (existing) return existing;
+  const delegate = prisma.messagingBaileysSession as unknown as Record<
+    string,
+    (a: unknown) => Promise<unknown>
+  >;
+  if (delegate.upsert) {
+    return (await delegate.upsert({
+      where: { scope },
+      create: { scope, status: "unpaired" },
+      update: {},
+    })) as Row;
+  }
+  if (delegate.create) {
+    try {
+      return (await delegate.create({
+        data: { scope, status: "unpaired" },
+      })) as Row;
+    } catch {
+      const raced = await loadRow(prisma, scope);
+      if (raced) return raced;
+      throw new Error("failed to create messaging_baileys_sessions row");
+    }
+  }
+  throw new Error("prisma.messagingBaileysSession must support upsert or create");
+}
+
+/**
+ * Postgres-backed Baileys auth state.
+ *
+ * Each `scope` maps to one `messaging_baileys_sessions` row (`scope` unique,
+ * default for now). Creds and keys are serialized with Baileys' BufferJSON
+ * codec into the jsonb columns. The signal key store is wrapped with
+ * `makeCacheableSignalKeyStore` for in-memory cache + write-through semantics;
+ * writes are debounced and coalesced, with an explicit `destroy()` flush hook
+ * for disconnect / shutdown callers.
+ *
+ * The returned `state.creds` object is the live mutable reference Baileys
+ * mutates; call `saveCreds()` after Baileys signals creds have changed.
+ */
+export async function createPostgresAuthState(
+  prisma: PrismaLike,
+  sessionId = "default",
+): Promise<BaileysAuthState> {
+  const scope = sessionId || "default";
+  const row = await ensureRow(prisma, scope);
+
+  let creds: AuthenticationCreds;
+  const rawCreds = row.creds;
+  if (rawCreds != null) {
+    creds = deserialize(rawCreds) as AuthenticationCreds;
+  } else {
+    creds = initAuthCreds();
+  }
+
+  let keysData: SignalDataSet = {};
+  const rawKeys = row.keys;
+  if (rawKeys != null) {
+    const parsed = deserialize(rawKeys) as SignalDataSet;
+    if (parsed && typeof parsed === "object") keysData = parsed as SignalDataSet;
+  }
+
+  const mutex = new Mutex();
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+  let destroyed = false;
+
+  const delegate = prisma.messagingBaileysSession as unknown as Record<
+    string,
+    (a: unknown) => Promise<unknown>
+  >;
+
+  async function flushKeys(): Promise<void> {
+    if (destroyed) return;
+    const timer = pendingTimer;
+    if (timer) {
+      clearTimeout(timer);
+      pendingTimer = null;
+    }
+    await mutex.runExclusive(async () => {
+      const payload = serialize(keysData);
+      const upd = delegate.update;
+      if (!upd) throw new Error("prisma delegate missing update");
+      try {
+        await upd({ where: { scope }, data: { keys: payload } });
+      } catch {
+        await upd({ where: { id: (row as Row).id }, data: { keys: payload } });
+      }
+    });
+  }
+
+  function scheduleFlush(): void {
+    if (destroyed) return;
+    if (pendingTimer) return;
+    pendingTimer = setTimeout(() => {
+      pendingTimer = null;
+      void flushKeys().catch(() => {});
+    }, FLUSH_DEBOUNCE_MS);
+  }
+
+  const rawStore = {
+    get: async (type: string, ids: string[]) => {
+      const out: Record<string, unknown> = {};
+      const bucket = (keysData as Record<string, Record<string, unknown>>)[type];
+      if (!bucket) return out;
+      for (const id of ids) {
+        const v = bucket[id];
+        if (v !== undefined && v !== null) out[id] = v;
+      }
+      return out;
+    },
+    set: async (data: SignalDataSet) => {
+      for (const type in data) {
+        const bucket = (data as Record<string, Record<string, unknown | null>>)[type];
+        if (!bucket) continue;
+        const typeKey = type;
+        let existing = (keysData as Record<string, Record<string, unknown>>)[typeKey];
+        if (!existing) {
+          existing = {};
+          (keysData as Record<string, Record<string, unknown>>)[typeKey] = existing;
+        }
+        for (const id in bucket) {
+          const value = bucket[id];
+          if (value === null || value === undefined) {
+            delete existing[id];
+          } else {
+            existing[id] = value as unknown;
+          }
+        }
+        if (Object.keys(existing).length === 0) {
+          delete (keysData as Record<string, unknown>)[type];
+        }
+      }
+      scheduleFlush();
+    },
+    clear: async () => {
+      for (const k in keysData) delete (keysData as Record<string, unknown>)[k];
+      scheduleFlush();
+    },
+  } as unknown as SignalKeyStore;
+
+  const cachedKeys = makeCacheableSignalKeyStore(rawStore, undefined);
+
+  const state: AuthenticationState = {
+    creds,
+    keys: cachedKeys,
+  };
+
+  async function saveCreds(): Promise<void> {
+    await mutex.runExclusive(async () => {
+      const payload = serialize(state.creds);
+      const upd = delegate.update;
+      if (!upd) throw new Error("prisma delegate missing update");
+      try {
+        await upd({ where: { scope }, data: { creds: payload } });
+      } catch {
+        await upd({ where: { id: (row as Row).id }, data: { creds: payload } });
+      }
+    });
+  }
+
+  async function destroy(): Promise<void> {
+    destroyed = true;
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      pendingTimer = null;
+    }
+    await mutex.runExclusive(async () => {
+      const payload = serialize(keysData);
+      const upd = delegate.update;
+      if (!upd) return;
+      try {
+        await upd({ where: { scope }, data: { keys: payload } });
+      } catch {
+        try {
+          await upd({ where: { id: (row as Row).id }, data: { keys: payload } });
+        } catch {
+          // ignore
+        }
+      }
+    });
+  }
+
+  return { state, saveCreds, destroy };
+}

--- a/packages/adapters/src/secrets.ts
+++ b/packages/adapters/src/secrets.ts
@@ -44,6 +44,16 @@ export class EncryptedSecretStore implements SecretStore {
     return `${VERSION_PREFIX}${Buffer.concat([salt, iv, tag, enc]).toString("base64")}`;
   }
 
+  /** Synchronous encrypt for internal use (e.g. Baileys auth state). */
+  encrypt(plaintext: string, recordId: string): string {
+    return this.seal(plaintext, recordId);
+  }
+
+  /** Synchronous decrypt for internal use (e.g. Baileys auth state). */
+  decrypt(ciphertext: string, recordId: string): string {
+    return this.load(ciphertext, recordId);
+  }
+
   async get(id: string, _context: AdapterContext): Promise<string> {
     throw new Error(`SecretStore.get requires persistence; use load(${id})`);
   }

--- a/packages/db/prisma/migrations/20260902120000_baileys_auth_state/migration.sql
+++ b/packages/db/prisma/migrations/20260902120000_baileys_auth_state/migration.sql
@@ -1,0 +1,22 @@
+-- Baileys WhatsApp auth state — Postgres-backed session store for the
+-- multi-file auth replacement. One row per scope (default for now);
+-- creds/keys are JSONB blobs serialized with Baileys' BufferJSON codec.
+
+CREATE TABLE "messaging_baileys_sessions" (
+  "id" TEXT NOT NULL,
+  "scope" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'unpaired',
+  "creds" JSONB,
+  "keys" JSONB,
+  "lastQr" TEXT,
+  "lastQrAt" TIMESTAMP(3),
+  "connectedJid" TEXT,
+  "pairingPhone" TEXT,
+  "lastError" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "messaging_baileys_sessions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "messaging_baileys_sessions_scope_key" ON "messaging_baileys_sessions"("scope");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1096,6 +1096,23 @@ model MessagingOutbound {
   @@map("messaging_outbound")
 }
 
+model MessagingBaileysSession {
+  id           String   @id @default(cuid())
+  scope        String   @unique
+  status       String   @default("unpaired")
+  creds        Json?
+  keys         Json?
+  lastQr       String?
+  lastQrAt     DateTime?
+  connectedJid String?
+  pairingPhone String?
+  lastError    String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@map("messaging_baileys_sessions")
+}
+
 model AgentConnection {
   id             String   @id @default(cuid())
   requesterBotId String

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,12 @@ importers:
       '@rakazo/db':
         specifier: workspace:*
         version: link:../db
+      async-mutex:
+        specifier: ^0.5.0
+        version: 0.5.0
+      baileys:
+        specifier: 7.0.0-rc14
+        version: 7.0.0-rc14(sharp@0.35.3(@types/node@24.13.3))
       chat:
         specifier: 4.39.0
         version: 4.39.0(zod@4.4.3)
@@ -1594,6 +1600,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -1645,6 +1654,16 @@ packages:
 
   '@bufbuild/protobuf@2.13.0':
     resolution: {integrity: sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==}
+
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
+
+  '@cacheable/node-cache@1.7.6':
+    resolution: {integrity: sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A==}
+    engines: {node: '>=18'}
+
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
@@ -2409,6 +2428,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hapi/boom@9.1.4':
+    resolution: {integrity: sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==}
+
+  '@hapi/hoek@9.3.0':
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+
   '@hono/node-server@1.19.17':
     resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
@@ -2609,6 +2634,15 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -3006,6 +3040,9 @@ packages:
   '@peculiar/webcrypto@1.7.1':
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4027,6 +4064,13 @@ packages:
   '@testcontainers/postgresql@11.14.0':
     resolution: {integrity: sha512-wYbJn8GRTj8qfqzfVubxioYWlHJU/ImIjuzPwyy9C5Qfo6g3GLduPZAj+BifvqTZjgT3gd4gFVLCPhBji7dc1w==}
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@turbo/darwin-64@2.10.9':
     resolution: {integrity: sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA==}
     cpu: [x64]
@@ -4556,6 +4600,9 @@ packages:
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -4565,6 +4612,10 @@ packages:
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
@@ -4638,6 +4689,22 @@ packages:
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  baileys@7.0.0-rc14:
+    resolution: {integrity: sha512-pewtrljhWx5JTUBvvkXZz1fL3JPiwzjBsnhx/DWf2LWBx1cZNH7J/sF22xDehba5mySWUQU4a1Pwt7lWARUxaA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      audio-decode: ^2.1.3
+      jimp: ^1.6.1
+      link-preview-js: ^3.0.0
+      sharp: '*'
+    peerDependenciesMeta:
+      audio-decode:
+        optional: true
+      jimp:
+        optional: true
+      link-preview-js:
+        optional: true
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -4899,6 +4966,9 @@ packages:
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
+
+  cacheable@2.5.0:
+    resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -5283,6 +5353,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  curve25519-js@0.0.4:
+    resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
 
   d3-array@3.2.1:
     resolution: {integrity: sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==}
@@ -6137,6 +6210,10 @@ packages:
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
@@ -6412,6 +6489,10 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -6471,6 +6552,12 @@ packages:
   hono@4.13.1:
     resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
@@ -6825,6 +6912,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -6854,6 +6944,9 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  libsignal@6.0.0:
+    resolution: {integrity: sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA==}
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -7166,6 +7259,10 @@ packages:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
     engines: {node: '>= 0.8'}
 
+  media-typer@2.0.0:
+    resolution: {integrity: sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==}
+    engines: {node: '>=18'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -7449,6 +7546,10 @@ packages:
   multitars@1.0.2:
     resolution: {integrity: sha512-6GwVw5eLi9sThdtlS4PKwC7yRLaf45pYhIEzKBHdKxi+YOXGKFX8acIniH+Uh/+k9mS2lQOupTccjoe5r0/1IQ==}
 
+  music-metadata@11.15.0:
+    resolution: {integrity: sha512-TN+kO1/oOc8UzDW5N3vSDncBcv9WyNnQQe/NFMcFWq6G1+zVeYUkGvkYpQ/S8wb8vKtUD7i78dIaY0cv+cmPRA==}
+    engines: {node: '>=18'}
+
   mysql2@3.15.3:
     resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
     engines: {node: '>= 8.0'}
@@ -7598,6 +7699,10 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -7854,6 +7959,16 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -7990,6 +8105,9 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process-warning@5.1.0:
+    resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -8069,6 +8187,10 @@ packages:
     resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
     engines: {node: '>=16.0.0'}
 
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
+
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
@@ -8082,6 +8204,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -8338,6 +8463,10 @@ packages:
     resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
     engines: {node: '>= 20.19.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
     engines: {node: '>=4'}
@@ -8507,6 +8636,10 @@ packages:
   safe-regex2@5.1.1:
     resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
     hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -8691,6 +8824,9 @@ packages:
     resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -8831,6 +8967,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
 
@@ -8931,6 +9071,9 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
+  thread-stream@3.2.0:
+    resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
+
   threads@1.7.0:
     resolution: {integrity: sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==}
 
@@ -8992,6 +9135,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   toqr@0.1.1:
     resolution: {integrity: sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==}
@@ -9085,6 +9232,10 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   ultrahtml@1.7.0:
     resolution: {integrity: sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==}
@@ -9589,6 +9740,9 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  whatsapp-rust-bridge@0.5.4:
+    resolution: {integrity: sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
@@ -9629,6 +9783,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  win-guid@0.2.1:
+    resolution: {integrity: sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -10806,6 +10963,8 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
+  '@borewit/text-codec@0.2.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -10842,6 +11001,24 @@ snapshots:
     optional: true
 
   '@bufbuild/protobuf@2.13.0': {}
+
+  '@cacheable/memory@2.2.0':
+    dependencies:
+      '@cacheable/utils': 2.5.0
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/node-cache@1.7.6':
+    dependencies:
+      cacheable: 2.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.5.0':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
 
   '@capsizecss/unpack@4.0.1':
     dependencies:
@@ -11804,6 +11981,12 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
+  '@hapi/boom@9.1.4':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
+  '@hapi/hoek@9.3.0': {}
+
   '@hono/node-server@1.19.17(hono@4.13.1)':
     dependencies:
       hono: 4.13.1
@@ -11971,6 +12154,14 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
@@ -12512,6 +12703,8 @@ snapshots:
       '@peculiar/utils': 2.0.3
       tslib: 2.8.1
       webcrypto-core: 1.9.2
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -13301,7 +13494,9 @@ snapshots:
       metro-runtime: 0.84.5
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
     optional: true
 
   '@react-native/metro-config@0.86.3(@babel/core@7.29.7)':
@@ -13703,6 +13898,15 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
 
   '@turbo/darwin-64@2.10.9':
     optional: true
@@ -14500,11 +14704,17 @@ snapshots:
 
   async-lock@1.4.1: {}
 
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
 
   at-least-node@1.0.0: {}
+
+  atomic-sleep@1.0.0: {}
 
   aws-ssl-profiles@1.1.2: {}
 
@@ -14623,6 +14833,25 @@ snapshots:
   badgin@1.2.3: {}
 
   bail@2.0.2: {}
+
+  baileys@7.0.0-rc14(sharp@0.35.3(@types/node@24.13.3)):
+    dependencies:
+      '@cacheable/node-cache': 1.7.6
+      '@hapi/boom': 9.1.4
+      async-mutex: 0.5.0
+      libsignal: 6.0.0
+      lru-cache: 11.5.2
+      music-metadata: 11.15.0
+      p-queue: 9.3.3
+      pino: 9.14.0
+      protobufjs: 7.6.5
+      sharp: 0.35.3(@types/node@24.13.3)
+      whatsapp-rust-bridge: 0.5.4
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   balanced-match@1.0.2: {}
 
@@ -14908,6 +15137,14 @@ snapshots:
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.1
+
+  cacheable@2.5.0:
+    dependencies:
+      '@cacheable/memory': 2.2.0
+      '@cacheable/utils': 2.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -15277,6 +15514,8 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.2.3: {}
+
+  curve25519-js@0.0.4: {}
 
   d3-array@3.2.1:
     dependencies:
@@ -16335,6 +16574,15 @@ snapshots:
 
   fflate@0.4.9: {}
 
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
@@ -16680,6 +16928,10 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -16785,6 +17037,10 @@ snapshots:
       parse-passwd: 1.0.0
 
   hono@4.13.1: {}
+
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -17121,6 +17377,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
@@ -17138,6 +17398,11 @@ snapshots:
       readable-stream: 2.3.8
 
   leven@3.1.0: {}
+
+  libsignal@6.0.0:
+    dependencies:
+      curve25519-js: 0.0.4
+      protobufjs: 7.6.5
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -17505,6 +17770,8 @@ snapshots:
   mdurl@2.1.0: {}
 
   media-typer@1.1.1: {}
+
+  media-typer@2.0.0: {}
 
   memoize-one@5.2.1: {}
 
@@ -17987,6 +18254,21 @@ snapshots:
 
   multitars@1.0.2: {}
 
+  music-metadata@11.15.0:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      content-type: 2.1.0
+      debug: 4.4.3
+      file-type: 21.3.4
+      media-typer: 2.0.0
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+      win-guid: 0.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   mysql2@3.15.3:
     dependencies:
       aws-ssl-profiles: 1.1.2
@@ -18118,6 +18400,8 @@ snapshots:
       ufo: 1.6.4
 
   ohash@2.0.11: {}
+
+  on-exit-leak-free@2.1.2: {}
 
   on-finished@2.3.0:
     dependencies:
@@ -18352,6 +18636,26 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
+
   pkce-challenge@5.0.1: {}
 
   pkg-types@2.3.1:
@@ -18500,6 +18804,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process-warning@5.1.0: {}
+
   process@0.11.10: {}
 
   progress@2.0.3: {}
@@ -18591,6 +18897,10 @@ snapshots:
 
   pvutils@1.2.0: {}
 
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
+
   qs@6.15.3:
     dependencies:
       es-define-property: 1.0.1
@@ -18606,6 +18916,8 @@ snapshots:
       strict-uri-encode: 2.0.0
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
 
@@ -18961,6 +19273,8 @@ snapshots:
 
   readdirp@5.1.1: {}
 
+  real-require@0.2.0: {}
+
   regenerate-unicode-properties@10.2.2:
     dependencies:
       regenerate: 1.4.2
@@ -19191,6 +19505,8 @@ snapshots:
   safe-regex2@5.1.1:
     dependencies:
       ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -19444,6 +19760,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -19574,6 +19894,10 @@ snapshots:
       ansi-regex: 6.3.0
 
   strip-final-newline@2.0.0: {}
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
 
   structured-headers@0.4.1: {}
 
@@ -19736,6 +20060,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  thread-stream@3.2.0:
+    dependencies:
+      real-require: 0.2.0
+
   threads@1.7.0:
     dependencies:
       callsites: 3.1.0
@@ -19794,6 +20122,12 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   toqr@0.1.1: {}
 
@@ -19872,6 +20206,8 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
+
+  uint8array-extras@1.5.0: {}
 
   ultrahtml@1.7.0: {}
 
@@ -20274,6 +20610,8 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
+  whatsapp-rust-bridge@0.5.4: {}
+
   whatwg-fetch@3.6.20: {}
 
   whatwg-mimetype@5.0.0: {}
@@ -20317,6 +20655,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  win-guid@0.2.1: {}
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
Why: Step 1 of Baileys WhatsApp integration plan — need a standalone Postgres-backed implementation of Baileys AuthenticationState contract before wiring sockets.

What changed:
- Prisma model MessagingBaileysSession with hand-written migration 20260902120000_baileys_auth_state (table messaging_baileys_sessions).
- packages/adapters/src/baileys-auth-state.ts: createPostgresAuthState(prisma, sessionId) returning { state, saveCreds, destroy }, using BufferJSON replacer/reviver, makeCacheableSignalKeyStore wrapper, debounced coalesced flush with Mutex, explicit destroy flush hook.
- Tests: round-trip BufferJSON, restart persistence, keys.set write-through, concurrent flush safety, destroy flush.
- Adds baileys@7.0.0-rc14 and async-mutex to @rakazo/adapters.

How tested:
- New unit tests (packages/adapters/src/baileys-auth-state.test.ts) — 5 passing, exercising real serialization without mocking away persistence.
- Full test suite: pnpm test — 250 files passed, 0 failed.
- Prisma generate and tsc --noEmit verify.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent authentication for WhatsApp messaging connections.
  * Credentials, encryption keys, pairing details, connection status, and errors are retained across application restarts.
  * Session data is now stored using encrypted credentials and keys.
  * Improved reliability when saving concurrent session updates, reducing the risk of authentication data loss.
  * Pending session changes are flushed during shutdown.
* **Chores**
  * Added database storage and supporting infrastructure for messaging session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->