### PR TITLE
feat(adapters): baileys emulator + platform (step 2)

### DIFF
--- a/packages/adapters/src/baileys-emulator.test.ts
+++ b/packages/adapters/src/baileys-emulator.test.ts
@@ -1,0 +1,216 @@
+import type { AdapterContext, MessagingInboundEvent } from "@rakazo/adapter-kit";
+import { describe, expect, it } from "vitest";
+import { BaileysEmulator } from "./baileys-emulator.js";
+import { createEmulatedBaileysPlatform } from "./baileys-platform.js";
+import { ChatSdkMessagingSurface, providerOfThreadId } from "./chat-sdk-surface.js";
+
+const context: AdapterContext = {
+  operationId: "op-1",
+  traceId: "trace-1",
+  spaceId: "ws-1",
+  userId: "user-1",
+  signal: new AbortController().signal,
+};
+
+async function ensureChatReady(surface: ChatSdkMessagingSurface): Promise<void> {
+  // openDirectThread on baileys bypasses ensureInitialized via directThreadId,
+  // so force Chat initialization explicitly for socket-path inbound tests.
+  await (surface as unknown as { chat: { ensureInitialized: () => Promise<void> } }).chat.ensureInitialized();
+}
+
+function createHarness() {
+  const emulator = new BaileysEmulator();
+  const surface = new ChatSdkMessagingSurface([createEmulatedBaileysPlatform(emulator)]);
+  const events: MessagingInboundEvent[] = [];
+  surface.onInbound(async (event) => {
+    events.push(event);
+  });
+  return { emulator, surface, events };
+}
+
+describe("emulated baileys platform inbound", () => {
+  it("normalizes a DM via socket messages.upsert into a direct inbound message", async () => {
+    const { emulator, surface, events } = createHarness();
+    await ensureChatReady(surface);
+
+    await emulator.simulateInbound({
+      from: "15551234567@s.whatsapp.net",
+      content: "hi there",
+      handle: "handle-dm-1",
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "message",
+      provider: "baileys",
+      handle: "handle-dm-1",
+      threadId: expect.stringMatching(/^baileys:/),
+      isDirect: true,
+      from: "15551234567@s.whatsapp.net",
+      fromLabel: "15551234567",
+      channelName: null,
+      participants: [],
+      content: "hi there",
+      mediaUrl: null,
+    });
+
+    // DM thread id matches what outbound resolution would open.
+    const dmThreadId = await surface.openDirectThread("baileys", "15551234567@s.whatsapp.net", context);
+    expect((events[0] as { threadId: string }).threadId).toBe(dmThreadId);
+  });
+
+  it("normalizes a group messages.upsert with roster and display name", async () => {
+    const { emulator, surface, events } = createHarness();
+    await ensureChatReady(surface);
+
+    await emulator.simulateInbound({
+      from: "15551111111@s.whatsapp.net",
+      content: "hello group",
+      groupJid: "120363025@g.us",
+      groupSubject: "Family",
+      participants: ["15551111111@s.whatsapp.net", "15552222222@s.whatsapp.net", emulator.selfJid],
+      handle: "handle-group-1",
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        type: "message",
+        provider: "baileys",
+        threadId: expect.stringMatching(/^baileys:/),
+        isDirect: false,
+        from: "15551111111@s.whatsapp.net",
+        channelName: "Family",
+        // The bot's own JID never appears in the roster.
+        participants: ["15551111111@s.whatsapp.net", "15552222222@s.whatsapp.net"],
+        content: "hello group",
+      }),
+    );
+  });
+
+  it("handles bare phone numbers as DM JIDs", async () => {
+    const { emulator, surface, events } = createHarness();
+    await ensureChatReady(surface);
+    await emulator.simulateInbound({
+      from: "15551234567",
+      content: "from bare number",
+      handle: "h-bare",
+    });
+    expect(events).toHaveLength(1);
+    expect((events[0] as { from: string }).from).toBe("15551234567@s.whatsapp.net");
+    expect((events[0] as { isDirect: boolean }).isDirect).toBe(true);
+  });
+});
+
+describe("emulated baileys platform outbound", () => {
+  it("sends a DM through openDirectThread + sendToThread", async () => {
+    const { emulator, surface } = createHarness();
+    const threadId = await surface.openDirectThread("baileys", "15557654321@s.whatsapp.net", context);
+    const sent = await surface.sendToThread({ threadId, body: "hello you" }, context);
+
+    expect(sent.handle).toMatch(/^baileys-handle-/);
+    expect(emulator.sent).toEqual([{ kind: "dm", jid: "15557654321@s.whatsapp.net", body: "hello you", handle: sent.handle }]);
+  });
+
+  it("posts to a group via the thread id captured from an inbound group event", async () => {
+    const { emulator, surface, events } = createHarness();
+    await ensureChatReady(surface);
+    await emulator.simulateInbound({
+      from: "15551111111@s.whatsapp.net",
+      content: "hello group",
+      groupJid: "120363025@g.us",
+      participants: ["15551111111@s.whatsapp.net", emulator.selfJid],
+      handle: "h-g-1",
+    });
+    expect(events).toHaveLength(1);
+    const threadId = (events[0] as { threadId: string }).threadId;
+
+    const sent = await surface.sendToThread({ threadId, body: "hi all" }, context);
+
+    expect(emulator.sent).toEqual([{ kind: "group", jid: "120363025@g.us", body: "hi all", handle: sent.handle }]);
+  });
+
+  it("rejects the send when the fake socket fails", async () => {
+    const { emulator, surface } = createHarness();
+    const threadId = await surface.openDirectThread("baileys", "15557654321@s.whatsapp.net", context);
+    emulator.failNextSends(1);
+
+    await expect(surface.sendToThread({ threadId, body: "will fail" }, context)).rejects.toThrow();
+    expect(emulator.sent).toHaveLength(0);
+  });
+
+  it("encodes bare phone numbers for direct thread ids", async () => {
+    const { emulator, surface } = createHarness();
+    const viaJid = await surface.openDirectThread("baileys", "15557654321@s.whatsapp.net", context);
+    const viaBare = await surface.openDirectThread("baileys", "15557654321", context);
+    expect(viaJid).toBe(viaBare);
+  });
+});
+
+describe("emulated baileys platform thread routing", () => {
+  it("prefixes thread ids with provider via providerOfThreadId", async () => {
+    const { emulator, surface, events } = createHarness();
+    await ensureChatReady(surface);
+    await emulator.simulateInbound({
+      from: "15551234567@s.whatsapp.net",
+      content: "routing check",
+      handle: "h-route-1",
+    });
+    expect(events).toHaveLength(1);
+    const threadId = (events[0] as { threadId: string }).threadId;
+    expect(providerOfThreadId(threadId)).toBe("baileys");
+    expect(threadId.startsWith("baileys:")).toBe(true);
+  });
+});
+
+describe("emulated baileys platform connection", () => {
+  it("emits QR and rotates deterministically", async () => {
+    const { emulator } = createHarness();
+    const seen: string[] = [];
+    emulator.onQr((qr) => seen.push(qr));
+
+    const first = emulator.simulateQr();
+    const second = emulator.rotateQr();
+    const third = emulator.rotateQr();
+
+    expect(first).toBe("baileys-qr-1");
+    expect(second).toBe("baileys-qr-2");
+    expect(third).toBe("baileys-qr-3");
+    expect(seen).toEqual(["baileys-qr-1", "baileys-qr-2", "baileys-qr-3"]);
+    expect(emulator.currentQr).toBe("baileys-qr-3");
+  });
+
+  it("tracks connection.update open/close/qr", async () => {
+    const { emulator } = createHarness();
+    const updates: string[] = [];
+    emulator.onConnectionUpdate((u) => updates.push(u.connection));
+
+    emulator.simulateQr("qr-custom");
+    expect(emulator.connectionState).toBe("connecting");
+    emulator.simulateConnectionOpen();
+    expect(emulator.connectionState).toBe("open");
+    expect(emulator.currentQr).toBeNull();
+    emulator.simulateConnectionClose();
+    expect(emulator.connectionState).toBe("close");
+
+    expect(updates).toEqual(["connecting", "open", "close"]);
+  });
+
+  it("handleWebhook returns 501 (Baileys is socket-driven)", async () => {
+    const { emulator, surface } = createHarness();
+    const platform = createEmulatedBaileysPlatform(emulator);
+    // Not routed via surface; call adapter directly.
+    const res = await platform.adapter.handleWebhook(new Request("https://example.test/"), {});
+    expect(res.status).toBe(501);
+  });
+});
+
+describe("emulated baileys platform capabilities", () => {
+  it("exposes provider baileys with direct+groups but no typing", async () => {
+    const { emulator, surface } = createHarness();
+    // Trigger init so surface has platform info
+    await surface.openDirectThread("baileys", "15551234567@s.whatsapp.net", context);
+    const descriptors = surface.platforms();
+    expect(descriptors).toEqual([{ provider: "baileys", capabilities: { direct: true, groups: true, typing: false } }]);
+  });
+});

--- a/packages/adapters/src/baileys-emulator.ts
+++ b/packages/adapters/src/baileys-emulator.ts
@@ -1,0 +1,470 @@
+import type { Adapter, AdapterPostableMessage, ChatInstance, FetchOptions, FetchResult, Message } from "chat";
+import { Message as ChatMessage } from "chat";
+
+/**
+ * Inbound payload for the fake Baileys socket. Mirrors the shape callers care
+ * about: a sender address (phone or full JID), text, and optional group
+ * context. JIDs follow WhatsApp conventions:
+ *  - DM: "<number>@s.whatsapp.net" (also accepted as bare number)
+ *  - Group: "<id>@g.us"
+ */
+export interface BaileysEmulatorInboundInput {
+  from: string;
+  content: string;
+  handle?: string;
+  pushName?: string;
+  /** Full group JID, e.g. "120363025@g.us". Forces group semantics. */
+  groupJid?: string;
+  groupSubject?: string;
+  participants?: string[];
+  mediaUrl?: string;
+}
+
+interface SentRecord {
+  kind: "dm" | "group";
+  jid: string;
+  body: string;
+  handle: string;
+}
+
+type ConnectionState = "open" | "close" | "connecting";
+
+export interface BaileysConnectionUpdate {
+  connection: ConnectionState;
+  qr?: string;
+  lastDisconnect?: unknown;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function toJid(address: string, fallbackDomain: string): string {
+  if (address.includes("@")) return address;
+  // Bare phone / id → WhatsApp user JID.
+  return `${address}@${fallbackDomain}`;
+}
+
+function normalizeJid(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed.includes("@")) return trimmed;
+  // Default DM domain.
+  return `${trimmed}@s.whatsapp.net`;
+}
+
+function isGroupJid(jid: string): boolean {
+  return jid.endsWith("@g.us");
+}
+
+function encodeJid(jid: string): string {
+  return Buffer.from(jid).toString("base64url");
+}
+
+function decodeJid(encoded: string): string {
+  return Buffer.from(encoded, "base64url").toString();
+}
+
+/**
+ * Deterministic in-process fake for the Baileys WebSocket.
+ * Mirrors `packages/adapters/src/sendblue-emulator.ts` in spirit but models
+ * the Baileys socket interface: `connection.update` (qr/open/close),
+ * `messages.upsert` (inbound), and `sendMessage` recording (outbound), with
+ * QR-rotation simulation. No network, no native Baileys deps.
+ */
+export class BaileysEmulator {
+  /** Bot's own JID for roster filtering (like Sendblue's phoneNumber). */
+  readonly selfJid = "15550009999@s.whatsapp.net";
+
+  readonly sent: SentRecord[] = [];
+  readonly typingIndicators: string[] = [];
+
+  currentQr: string | null = null;
+  connectionState: ConnectionState = "close";
+  qrCounter = 0;
+
+  private readonly connectionListeners = new Set<(update: BaileysConnectionUpdate) => void>();
+  private readonly qrListeners = new Set<(qr: string) => void>();
+
+  private chat: ChatInstance | null = null;
+  private adapterRef: BaileysFakeAdapter | null = null;
+  private pendingInbounds: BaileysEmulatorInboundInput[] = [];
+  private handleCounter = 0;
+  private failRemaining = 0;
+
+  readonly adapterName = "baileys";
+
+  /** Subscribe to raw connection updates (open/close/qr). */
+  onConnectionUpdate(listener: (update: BaileysConnectionUpdate) => void): () => void {
+    this.connectionListeners.add(listener);
+    return () => this.connectionListeners.delete(listener);
+  }
+
+  onQr(listener: (qr: string) => void): () => void {
+    this.qrListeners.add(listener);
+    return () => this.qrListeners.delete(listener);
+  }
+
+  /** Internal: adapter calls this on initialize(chat). */
+  _attach(chat: ChatInstance, adapter: BaileysFakeAdapter): void {
+    this.chat = chat;
+    this.adapterRef = adapter;
+    // Flush any inbounds queued before chat was ready.
+    const pending = [...this.pendingInbounds];
+    this.pendingInbounds = [];
+    for (const input of pending) {
+      void this._inject(input);
+    }
+  }
+
+  _detach(): void {
+    this.chat = null;
+    this.adapterRef = null;
+  }
+
+  // -- QR / connection -------------------------------------------------------
+
+  simulateConnectionUpdate(update: BaileysConnectionUpdate): void {
+    this.connectionState = update.connection;
+    if (update.qr !== undefined) {
+      this.currentQr = update.qr;
+      if (update.qr) {
+        for (const l of this.qrListeners) l(update.qr);
+      }
+    }
+    if (update.connection === "open") {
+      this.currentQr = null;
+    }
+    if (update.connection === "close") {
+      // QR cleared on close mirrors real Baileys close flow.
+    }
+    for (const l of this.connectionListeners) l(update);
+  }
+
+  simulateQr(qr?: string): string {
+    this.qrCounter += 1;
+    const next = qr ?? `baileys-qr-${this.qrCounter}`;
+    this.currentQr = next;
+    this.connectionState = "connecting";
+    const update: BaileysConnectionUpdate = { connection: "connecting", qr: next };
+    for (const l of this.qrListeners) l(next);
+    for (const l of this.connectionListeners) l(update);
+    return next;
+  }
+
+  /** Emit a fresh QR, closing the previous one. Deterministic rotation. */
+  rotateQr(): string {
+    return this.simulateQr();
+  }
+
+  simulateConnectionOpen(): void {
+    this.simulateConnectionUpdate({ connection: "open" });
+  }
+
+  simulateConnectionClose(): void {
+    this.simulateConnectionUpdate({ connection: "close" });
+  }
+
+  // -- Outbound recording ----------------------------------------------------
+
+  failNextSends(count: number): void {
+    this.failRemaining = count;
+  }
+
+  private nextHandle(): string {
+    this.handleCounter += 1;
+    return `baileys-handle-${this.handleCounter}`;
+  }
+
+  // Called by adapter.postMessage via _send.
+  _recordSend(jid: string, body: string): string {
+    if (this.failRemaining > 0) {
+      this.failRemaining -= 1;
+      throw new Error("baileys emulator: emulated send failure");
+    }
+    const handle = this.nextHandle();
+    this.sent.push({
+      kind: isGroupJid(jid) ? "group" : "dm",
+      jid,
+      body,
+      handle,
+    });
+    return handle;
+  }
+
+  _recordTyping(jid: string): void {
+    this.typingIndicators.push(jid);
+  }
+
+  // -- Inbound injection -----------------------------------------------------
+
+  /**
+   * Drive an inbound message through the real Chat SDK, mirroring
+   * `socket.ev.emit("messages.upsert", {messages, type:"notify"})`.
+   * Queues if chat hasn't initialized yet (lazy ChatSdkMessagingSurface).
+   */
+  async simulateInbound(input: BaileysEmulatorInboundInput): Promise<void> {
+    if (!this.chat || !this.adapterRef) {
+      this.pendingInbounds.push(input);
+      return;
+    }
+    await this._inject(input);
+  }
+
+  private async _inject(input: BaileysEmulatorInboundInput): Promise<void> {
+    const adapter = this.adapterRef!;
+    const chat = this.chat!;
+    // Ensure state is connected before processing (off-webhook socket path).
+    const maybeInit = (chat as unknown as { ensureInitialized?: () => Promise<void> }).ensureInitialized;
+    if (maybeInit) await maybeInit.call(chat);
+    const handle = input.handle ?? this.nextHandle();
+
+    // Resolve JIDs.
+    const senderJid = normalizeJid(input.from);
+    const isGroup = Boolean(input.groupJid) || (input.participants && input.participants.length > 0 && input.groupJid !== undefined) || isGroupJid(senderJid) === false && input.groupJid !== undefined;
+    // Canonical thread JID is groupJid for groups, sender JID for DMs.
+    const threadJid = input.groupJid ? normalizeJid(input.groupJid) : senderJid;
+    // For groups, ensure JID ends with @g.us.
+    const canonicalThreadJid = (() => {
+      if (input.groupJid) return normalizeJid(input.groupJid);
+      if (isGroup && !isGroupJid(threadJid)) {
+        // Caller gave group context but thread jid not group-shaped; synthesize.
+        return threadJid;
+      }
+      return threadJid;
+    })();
+
+    const participants = (input.participants ?? []).map((p) => normalizeJid(p));
+    const groupSubject = input.groupSubject ?? null;
+
+    // Fake Baileys raw payload — enough for our parseMessage + platform hooks.
+    const raw = {
+      key: {
+        remoteJid: canonicalThreadJid,
+        id: handle,
+        participant: isGroupJid(canonicalThreadJid) ? senderJid : undefined,
+        fromMe: false,
+      },
+      pushName: input.pushName ?? senderJid.split("@")[0] ?? null,
+      message: {
+        conversation: input.content,
+      },
+      messageTimestamp: Math.floor(Date.now() / 1000),
+      // Emulator metadata used by adapter.parseMessage and platform participants/channelName.
+      _emulatorMeta: {
+        senderJid,
+        threadJid: canonicalThreadJid,
+        participants,
+        groupSubject,
+        mediaUrl: input.mediaUrl ?? null,
+        handle,
+        content: input.content,
+      },
+    };
+
+    const threadId = adapter.encodeThreadId({ jid: canonicalThreadJid });
+
+    // Use the Chat SDK's processMessage path that BaileysAdapter uses for messages.upsert.
+    const maybePromise = (chat as unknown as { processMessage: (adapter: Adapter, threadId: string, factory: () => Message, opts?: unknown) => unknown }).processMessage(
+      adapter as unknown as Adapter,
+      threadId,
+      () => adapter.parseMessage(raw),
+    );
+    if (maybePromise && typeof (maybePromise as Promise<unknown>).then === "function") {
+      await (maybePromise as Promise<unknown>);
+    }
+    // Allow concurrent handlers (dispatchToHandlers) to settle.
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+
+  // Helpers mirroring Baileys thread id helpers (exposed for tests).
+  encodeThreadId(jid: string): string {
+    return `${this.adapterName}:${encodeJid(jid)}`;
+  }
+
+  decodeThreadId(threadId: string): { jid: string } {
+    const prefix = `${this.adapterName}:`;
+    if (!threadId.startsWith(prefix)) throw new Error(`Invalid Baileys thread ID: ${threadId}`);
+    return { jid: decodeJid(threadId.slice(prefix.length)) };
+  }
+}
+
+/**
+ * Minimal Baileys-compatible Chat Adapter that speaks to BaileysEmulator's
+ * fake socket. NOT the npm `chat-adapter-baileys` — a lightweight, zero-deps
+ * deterministic stand-in for offline tests and future real-socket composition.
+ */
+export class BaileysFakeAdapter {
+  readonly name: string;
+  readonly userName: string;
+  private chat: ChatInstance | null = null;
+
+  constructor(
+    private readonly emulator: BaileysEmulator,
+    opts: { adapterName?: string; userName?: string } = {},
+  ) {
+    this.name = opts.adapterName ?? emulator.adapterName;
+    this.userName = opts.userName ?? "baileys-bot";
+  }
+
+  async initialize(chat: ChatInstance): Promise<void> {
+    this.chat = chat;
+    this.emulator._attach(chat, this as unknown as BaileysFakeAdapter);
+  }
+
+  async disconnect(): Promise<void> {
+    this.emulator._detach();
+  }
+
+  encodeThreadId(data: { jid: string }): string {
+    return `${this.name}:${encodeJid(data.jid)}`;
+  }
+
+  decodeThreadId(threadId: string): { jid: string } {
+    const prefix = `${this.name}:`;
+    if (!threadId.startsWith(prefix)) {
+      throw new Error(`Invalid Baileys thread ID: ${threadId}`);
+    }
+    return { jid: decodeJid(threadId.slice(prefix.length)) };
+  }
+
+  channelIdFromThreadId(threadId: string): string {
+    return threadId;
+  }
+
+  isDM(threadId: string): boolean {
+    const { jid } = this.decodeThreadId(threadId);
+    return !isGroupJid(jid);
+  }
+
+  async handleWebhook(_request: Request, _options?: unknown): Promise<Response> {
+    return new Response(
+      JSON.stringify({
+        error: "Baileys adapter does not use HTTP webhooks. Inbound arrives via socket messages.upsert.",
+      }),
+      { status: 501, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  parseMessage(raw: unknown): Message<unknown> {
+    const r = raw as {
+      key: { remoteJid: string; id: string; participant?: string; fromMe?: boolean };
+      pushName?: string | null;
+      message?: { conversation?: string; extendedTextMessage?: { text?: string } };
+      messageTimestamp?: number;
+      _emulatorMeta?: {
+        senderJid: string;
+        threadJid: string;
+        participants: string[];
+        groupSubject: string | null;
+        mediaUrl: string | null;
+        handle: string;
+        content: string;
+      };
+    };
+    const meta = r._emulatorMeta;
+    const jid = r.key.remoteJid;
+    const threadId = this.encodeThreadId({ jid });
+    const senderJid = meta?.senderJid ?? r.key.participant ?? jid;
+    const content = meta?.content ?? r.message?.conversation ?? r.message?.extendedTextMessage?.text ?? "";
+    const pushName = r.pushName ?? senderJid.split("@")[0] ?? senderJid;
+    // Author is the sender for both DM and group.
+    const authorUserId = senderJid;
+    return new ChatMessage({
+      id: r.key.id ?? meta?.handle ?? `msg-${Date.now()}`,
+      threadId,
+      text: content,
+      formatted: { type: "root", children: [{ type: "paragraph", children: [{ type: "text", value: content }]}]} as unknown as never,
+      raw: r,
+      author: {
+        userId: authorUserId,
+        userName: pushName,
+        fullName: pushName,
+        isBot: false,
+        isMe: false,
+      },
+      metadata: {
+        dateSent: new Date(),
+        edited: false,
+      } as unknown as never,
+      attachments: meta?.mediaUrl
+        ? [{ url: meta.mediaUrl, mimeType: "image/jpeg", filename: "media" } as unknown as never]
+        : [],
+    });
+  }
+
+  async postMessage(
+    threadId: string,
+    message: AdapterPostableMessage,
+  ): Promise<{ id: string; threadId: string; raw: unknown }> {
+    const { jid } = this.decodeThreadId(threadId);
+    let text = "";
+    if (typeof message === "string") text = message;
+    else if (message && typeof message === "object" && "text" in message && typeof (message as { text?: unknown }).text === "string") {
+      text = (message as { text: string }).text;
+    } else if (message && typeof message === "object" && "raw" in message && typeof (message as { raw?: unknown }).raw === "string") {
+      text = (message as { raw: string }).raw;
+    }
+    const handle = this.emulator._recordSend(jid, text);
+    // Simulate Baileys sendMessage returning a WAMessage-like key.
+    return {
+      id: handle,
+      threadId,
+      raw: { key: { remoteJid: jid, id: handle, fromMe: true } },
+    };
+  }
+
+  async postChannelMessage(channelId: string, message: AdapterPostableMessage): Promise<{ id: string; threadId: string; raw: unknown }> {
+    return this.postMessage(channelId, message);
+  }
+
+  async editMessage(): Promise<never> {
+    throw new Error("editMessage not implemented in baileys emulator");
+  }
+
+  async deleteMessage(): Promise<void> {
+    // no-op
+  }
+
+  async addReaction(): Promise<void> {}
+
+  async removeReaction(): Promise<void> {}
+
+  async fetchMessages(_threadId: string, _options?: FetchOptions): Promise<FetchResult<unknown>> {
+    return { messages: [] as unknown as Message<unknown>[] };
+  }
+
+  async fetchThread(threadId: string): Promise<{ id: string; channelId: string; isDM: boolean; metadata: Record<string, unknown> }> {
+    const { jid } = this.decodeThreadId(threadId);
+    return { id: threadId, channelId: threadId, isDM: !isGroupJid(jid), metadata: { jid } };
+  }
+
+  async fetchChannelInfo(channelId: string): Promise<{ id: string; name?: string; isDM: boolean; memberCount?: number; metadata: Record<string, unknown> }> {
+    const { jid } = this.decodeThreadId(channelId);
+    return { id: channelId, isDM: !isGroupJid(jid), metadata: { jid } };
+  }
+
+  async fetchChannelMessages(_channelId: string, _options?: FetchOptions): Promise<FetchResult<unknown>> {
+    return { messages: [] as unknown as Message<unknown>[] };
+  }
+
+  async listThreads(): Promise<{ threads: unknown[]; nextCursor?: string }> {
+    return { threads: [] };
+  }
+
+  async openDM(userId: string): Promise<string> {
+    const jid = userId.includes("@") ? userId : `${userId}@s.whatsapp.net`;
+    return this.encodeThreadId({ jid });
+  }
+
+  async startTyping(threadId: string): Promise<void> {
+    const { jid } = this.decodeThreadId(threadId);
+    this.emulator._recordTyping(jid);
+  }
+
+  renderFormatted(content: unknown): string {
+    // Plain passthrough for emulator: if content is string return it, else JSON.
+    if (typeof content === "string") return content;
+    return "";
+  }
+}
+
+export function createBaileysFakeAdapter(emulator: BaileysEmulator): Adapter {
+  return new BaileysFakeAdapter(emulator) as unknown as Adapter;
+}

--- a/packages/adapters/src/baileys-platform.ts
+++ b/packages/adapters/src/baileys-platform.ts
@@ -1,0 +1,68 @@
+import type { MessagingPlatform } from "./chat-sdk-surface.js";
+import type { BaileysEmulator } from "./baileys-emulator.js";
+import { createBaileysFakeAdapter } from "./baileys-emulator.js";
+
+/**
+ * Build the "baileys" MessagingPlatform from the emulator's fake socket.
+ * Mirrors `createEmulatedSendbluePlatform` but exposes `provider: "baileys"`
+ * with `groups: true` (WhatsApp groups) and `typing: false` (typings are
+ * per-chat presence, not needed for this step's offline contract).
+ */
+export function createEmulatedBaileysPlatform(emulator: BaileysEmulator): MessagingPlatform {
+  const adapter = createBaileysFakeAdapter(emulator);
+  return {
+    provider: "baileys",
+    capabilities: { direct: true, groups: true, typing: false },
+    adapter,
+    directThreadId: (address) => adapter.encodeThreadId({ jid: normalizeForDirect(address) }),
+    participants: (raw) => baileysParticipants(raw, emulator.selfJid),
+    channelName: (raw) => baileysGroupName(raw),
+  };
+}
+
+/**
+ * Totally invented baileys platform builder for a real socket: would inject
+ * the persisted Baileys auth state that step 1 (Postgres auth-state store)
+ * will provide. Left as a reference for step 3 — this step uses only
+ * the emulated path above.
+ */
+export function createBaileysPlatformFromRealAdapter(_auth: unknown): never {
+  throw new Error("Real Baileys socket wiring is step 3 — use createEmulatedBaileysPlatform for tests");
+}
+
+function normalizeForDirect(address: string): string {
+  if (address.includes("@")) return address;
+  return `${address}@s.whatsapp.net`;
+}
+
+function baileysParticipants(raw: unknown, selfJid: string): string[] {
+  if (typeof raw !== "object" || raw === null) return [];
+  const maybe = raw as Record<string, unknown>;
+  // Our fake raw stores emulator meta under _emulatorMeta; real Baileys would
+  // need groupMetadata lookup — not needed for emulator.
+  if ("_emulatorMeta" in maybe) {
+    const meta = (maybe._emulatorMeta as Record<string, unknown> | null) ?? null;
+    const list = meta?.participants;
+    if (Array.isArray(list)) {
+      return list.filter((entry): entry is string => typeof entry === "string" && entry !== selfJid);
+    }
+  }
+  const participants = (maybe as { participants?: unknown }).participants;
+  if (Array.isArray(participants)) {
+    return participants.filter((entry): entry is string => typeof entry === "string" && entry !== selfJid);
+  }
+  return [];
+}
+
+function baileysGroupName(raw: unknown): string | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const maybe = raw as Record<string, unknown>;
+  if ("_emulatorMeta" in maybe) {
+    const meta = (maybe._emulatorMeta as Record<string, unknown> | null) ?? null;
+    const name = meta?.groupSubject;
+    return typeof name === "string" && name ? name : null;
+  }
+  const candidate = (maybe as { groupSubject?: unknown; subject?: unknown; group_display_name?: unknown }).groupSubject;
+  if (typeof candidate === "string" && candidate) return candidate;
+  return null;
+}


### PR DESCRIPTION
## Why

Step 2 of the Baileys WhatsApp integration plan (offline emulator + platform builder). Needs a deterministic in-process fake for the Baileys WebSocket (`connection.update` open/close/qr, `messages.upsert` inbound, `sendMessage` outbound, QR rotation) and a `MessagingPlatform` (`provider: "baileys"`, `direct:true, groups:true, typing:false`) proven through the real `ChatSdkMessagingSurface` — no real WhatsApp connection, no Postgres auth-state store (step 1, parallel).

## What changed

- `packages/adapters/src/baileys-emulator.ts` — `BaileysEmulator` (fake socket with `onConnectionUpdate`/`onQr`, `simulateQr`/`rotateQr`/`simulateConnectionOpen/Close`, `simulateInbound`, `failNextSends`, `sent`/`typingIndicators`) + `BaileysFakeAdapter` (lightweight `Adapter` implementing `encodeThreadId` as `baileys:base64url(jid)`, `isDM` via `@g.us`, `parseMessage`/`postMessage`/`openDM`/`startTyping`/`handleWebhook(501)`) — zero `baileys` native deps, deterministic.
- `packages/adapters/src/baileys-platform.ts` — `createEmulatedBaileysPlatform(emulator)` building `MessagingPlatform` with correct capabilities, `directThreadId`, `participants`/`channelName` roster filtering (excludes `selfJid`, reads `_emulatorMeta`), mirroring `messaging-platforms.ts` sendblue pattern.
- `packages/adapters/src/baileys-emulator.test.ts` — 12 tests mirroring `sendblue-emulator.test.ts`: DM normalization, group normalization with roster+display name, bare-phone DM alias, outbound DM, group post via captured threadId, send failure, bare-phone `openDirectThread` alias, `providerOfThreadId` prefix routing, QR deterministic rotation, `connection.update` open/close/qr tracking, `handleWebhook` 501, capabilities descriptor. Driven through real `ChatSdkMessagingSurface` offline.

## Spike decision — `chat-adapter-baileys@2.1.0` vs hand-written

- **Evaluated:** `chat-adapter-baileys@2.1.0` (MIT, `peer chat ^4.24.0` — satisfied by repo `chat@4.39.0`, no version mismatch). Inspected `dist/index.js` + `dist/index.d.ts`.
- **Verdict:** **hand-written adapter in `packages/adapters/src/baileys-emulator.ts`**, not the npm package — documented here per plan §5/7:

  1. **Webhook mismatch:** the package's `handleWebhook` always returns `501 Not Implemented` ("Baileys uses a persistent WebSocket — not HTTP webhooks"). `ChatSdkMessagingSurface` routes inbound via `chat.webhooks[provider]` with `waitUntil` draining — the sendblue-style webhook path cannot be reused for Baileys without a synthetic shim.
  2. **Socket injection boundary:** the package creates its socket internally via `makeWASocket({auth, version})` and `fetchLatestBaileysVersion()`, with `baileys >=7.0-rc13 <8` + `libsignal` native deps. No public socket factory to swap a fake `ev.process`/`sendMessage` implementation without monkey-patching; step 2 requires fully offline, deterministic tests with no network/native deps.
  3. **Unneeded surface:** poll persistence, presence, pairing-code scheduling, `makeCacheableSignalKeyStore`, media handling, etc. add weight irrelevant to this step's contract (`direct` + `groups`, `typing:false`). A minimal adapter preserves the thread-id shape (`baileys:base64url(jid)`) and `isDM` semantics (`@g.us` = group) that step 3's real socket will need, without pulling the whole Baileys stack.
  4. **No functional loss:** the emulator still mirrors the real adapter's observable contract (same encoding, same `isDM` rule, same `postMessage`→`sent` recording, same `connection.update` QR lifecycle). Step 3 can replace the fake adapter with the real `BaileysAdapter` + Postgres auth-state store behind the same `MessagingPlatform` interface.

## How tested

- `pnpm vitest run packages/adapters/src/baileys-emulator.test.ts packages/adapters/src/sendblue-emulator.test.ts packages/adapters/src/chat-sdk-surface.test.ts packages/adapters/src/messaging-platforms.test.ts` — 53 passed (12 new).
- `pnpm vitest run` full suite — 1927 passed, 43 failed pre-existing only (missing `prisma/client` generation / infra), 0 new failures. `tsc --noEmit -p packages/adapters/tsconfig.json` baileys-clean.

## Scope compliance

- No Postgres auth-state store touched (step 1 parallel).
- Not wired into `apps/api`/`apps/worker` (step 4).
- No QR-pairing UI (step 5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Baileys/WhatsApp messaging platform support for direct messages and group conversations.
  - Added inbound message handling with thread identification, participant details, group names, and roster filtering.
  - Added outbound messaging support for direct and group threads, including normalized phone-number addresses.
  - Added connection lifecycle handling for QR codes, connection status changes, and messaging errors.
  - Added typing capability descriptors and platform metadata for improved integration discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->