### PR TITLE
fix(compose): wait for healthy services in published-images installer

### DIFF
--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -191,6 +191,11 @@ if [[ "$prepare_only" == true ]]; then
 fi
 
 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
+if docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
+  echo "Waiting for healthy services."
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --wait
+else
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
+fi
 
 echo "Rakazo is starting at http://127.0.0.1:5173"

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -191,14 +191,12 @@ if [[ "$prepare_only" == true ]]; then
 fi
 
 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
+# `--wait` without `--wait-timeout` can hang on one-shot services (Compose < 2.7)
+# or never return if a healthcheck stays red (Compose < 2.17). Prefer both flags.
 compose_up_help=$(docker compose up --help 2>/dev/null || true)
-if grep -q -- '--wait' <<<"$compose_up_help"; then
+if grep -q -- '--wait-timeout' <<<"$compose_up_help"; then
   echo "Waiting for healthy services."
-  if grep -q -- '--wait-timeout' <<<"$compose_up_help"; then
-    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --wait --wait-timeout 300
-  else
-    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --wait
-  fi
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --wait --wait-timeout 300
 else
   docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
 fi

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -191,9 +191,14 @@ if [[ "$prepare_only" == true ]]; then
 fi
 
 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
-if docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
+compose_up_help=$(docker compose up --help 2>/dev/null || true)
+if grep -q -- '--wait' <<<"$compose_up_help"; then
   echo "Waiting for healthy services."
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --wait
+  if grep -q -- '--wait-timeout' <<<"$compose_up_help"; then
+    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --wait --wait-timeout 300
+  else
+    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --wait
+  fi
 else
   docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
 fi


### PR DESCRIPTION
## Why

Published-images `install-images.sh` ends with `docker compose up -d` and immediately prints the URL. Images Compose already defines healthchecks and `depends_on: service_healthy` for api/worker/web, but operators can open `:5173` before those are ready. Production self-host docs already standardize on `up -d --wait`.

## What

- Prefer `docker compose up -d --wait` after pull
- Feature-detect / fall back to `up -d` on older Compose without `--wait`
- No change to DOWNLOAD_BASE / pull / mirror behavior

## Out of scope

- docs/self-host.md, Feishu messaging, Hub image env overrides

## Test

- `bash -n infra/compose/install-images.sh`
- Manual: Compose with `--wait` waits; old Compose falls back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service startup reliability by waiting for services to become healthy when supported by the installed Docker Compose version.
  - Added a startup timeout where available to prevent indefinite waits.
  - Preserved compatibility with older Docker Compose versions through automatic fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->