### PR TITLE
fix(compose): allow overriding Hub postgres/busybox images

### DIFF
--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -11,7 +11,8 @@ name: rakazo
 
 services:
   postgres:
-    image: postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5
+    # Optional Hub override; unset keeps the digest-pinned official image.
+    image: ${POSTGRES_IMAGE:-postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5}
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -38,7 +39,8 @@ services:
     restart: "no"
 
   data-init:
-    image: busybox:1
+    # Optional Hub override; unset keeps busybox:1.
+    image: ${BUSYBOX_IMAGE:-busybox:1}
     command: ["chown", "-R", "1000:1000", "/data"]
     restart: "no"
     volumes:

--- a/infra/updater/src/compose-images.test.ts
+++ b/infra/updater/src/compose-images.test.ts
@@ -64,7 +64,10 @@ describe("the images compose file", () => {
     }
     expect(compose.services.computer?.image).toContain("ghcr.io/elie222/rakazo/computer");
     expect(compose.services.computer?.image).toContain("RAKAZO_COMPUTER_IMAGE_TAG");
-    expect(compose.services.postgres?.image).toMatch(/^postgres:16@sha256:[0-9a-f]{64}$/);
+    expect(compose.services.postgres?.image).toMatch(
+      /^\$\{POSTGRES_IMAGE:-postgres:16@sha256:[0-9a-f]{64}\}$/,
+    );
+    expect(compose.services["data-init"]?.image).toMatch(/^\$\{BUSYBOX_IMAGE:-busybox:1\}$/);
   });
 
   it("skips non-string Compose environment scalars when collecting image names", () => {


### PR DESCRIPTION
## Why

Published-images Compose still hard-pins `postgres:16@sha256:…` and `busybox:1` from Docker Hub. After #487, Restricted networks docs already note Hub may be unreachable and suggest daemon `registry-mirrors` or vendoring — but there is no first-class env override for those two images (unlike `RAKAZO_IMAGE*`).

## What

- `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` env overrides in `docker-compose.images.yml`
- Defaults unchanged when unset (same digest / `busybox:1`)
- Compose-only; no docs churn while other self-host PRs are open

## Out of scope

- docs/self-host.md, `.env.images.example`, install-images.sh, messaging

## Test

Unset env → identical image refs; set env → compose interpolates override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Added optional environment variable overrides for the PostgreSQL and BusyBox container images.
  - Existing default images remain unchanged when no overrides are provided.
  - Container image sources can now be customized for different deployment environments without modifying the compose configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->