### PR TITLE
fix(compose): allow overriding Hub postgres/caddy images on prod path

### DIFF
--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -2,7 +2,7 @@ name: rakazo-prod
 
 services:
   postgres:
-    image: postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5
+    image: ${POSTGRES_IMAGE:-postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5}
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -221,7 +221,7 @@ services:
       retries: 10
 
   caddy:
-    image: caddy:2@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d
+    image: ${CADDY_IMAGE:-caddy:2@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d}
     restart: unless-stopped
     read_only: true
     security_opt:

--- a/infra/updater/src/compose-service.test.ts
+++ b/infra/updater/src/compose-service.test.ts
@@ -95,8 +95,12 @@ describe("the updater compose service", () => {
   it("uses the official registry namespace and digest-pins third-party runtime images", () => {
     expect(updater.image).toContain("ghcr.io/elie222/rakazo/updater");
     expect(compose.services.api?.image).toContain("ghcr.io/elie222/rakazo/app");
-    expect(compose.services.postgres?.image).toMatch(/^postgres:16@sha256:[0-9a-f]{64}$/);
-    expect(compose.services.caddy?.image).toMatch(/^caddy:2@sha256:[0-9a-f]{64}$/);
+    expect(compose.services.postgres?.image).toMatch(
+      /^\$\{POSTGRES_IMAGE:-postgres:16@sha256:e17e86066e5ef83e0952a9347f5c792b7ece00972e2aa787a6986f471b3dd3d5\}$/,
+    );
+    expect(compose.services.caddy?.image).toMatch(
+      /^\$\{CADDY_IMAGE:-caddy:2@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d\}$/,
+    );
   });
 
   it("injects the actual Compose project name into the updater container", () => {


### PR DESCRIPTION
## Summary
- Prod Compose: `POSTGRES_IMAGE` / `CADDY_IMAGE` env overrides with unchanged digest defaults
- Update `compose-service.test.ts` to assert the `${VAR:-digest}` form (same shape as #493 for images path)

Complements #493 (published-images Hub postgres/busybox) for the **production** Compose path. Helps Mainland / restricted-network self-host without shipping regional CDN defaults.

## Test plan
- [ ] Unit: updater `compose-service` expectations pass
- [ ] Unset env → image refs identical to prior digest pins
- [ ] Set `POSTGRES_IMAGE` / `CADDY_IMAGE` → compose resolves overrides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL and Caddy container images can now be configured through environment variables.
  * Pinned image versions remain the default when no overrides are provided, supporting consistent deployments.
  * Deployment configurations can use alternative image sources when needed.

* **Tests**
  * Updated deployment checks to verify the exact configurable image settings and pinned default versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->