### PR TITLE
fix(compose): retry published-images compose pull

### DIFF
--- a/infra/compose/install-images-pull-retry.smoke.sh
+++ b/infra/compose/install-images-pull-retry.smoke.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+src="$root/install-images.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+eval "$(awk '
+  /^pull_images\(\) \{/ { p = 1 }
+  p { print }
+  p && /^\}/ { exit }
+' "$src")"
+
+ENV_FILE=".env"
+COMPOSE_FILE="docker-compose.images.yml"
+attempts=0
+sleeps=0
+fail_until=2
+
+docker() {
+  attempts=$((attempts + 1))
+  ((attempts > fail_until))
+}
+
+sleep() {
+  [[ "$1" == "2" ]] || fail "unexpected retry delay: $1"
+  sleeps=$((sleeps + 1))
+}
+
+pull_images 2>/dev/null || fail "third pull attempt should succeed"
+[[ "$attempts" -eq 3 ]] || fail "expected 3 pull attempts, got $attempts"
+[[ "$sleeps" -eq 2 ]] || fail "expected 2 retry delays, got $sleeps"
+
+attempts=0
+sleeps=0
+fail_until=3
+if pull_images 2>/dev/null; then
+  fail "three failed pull attempts should fail"
+fi
+[[ "$attempts" -eq 3 ]] || fail "expected 3 failed pull attempts, got $attempts"
+[[ "$sleeps" -eq 2 ]] || fail "expected 2 retry delays on failure, got $sleeps"
+
+echo "ok"

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -288,9 +288,27 @@ if [[ "$prepare_only" == true ]]; then
 fi
 
 prepare_proxy_env
-if ! docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull; then
-  fail "could not pull images. Shell HTTP_PROXY often does not reach the Docker daemon. Configure daemon proxy/registry-mirrors, set image env vars to a reachable registry, or preload images then compose up with --pull never."
+# Stage C image pull: finite retries for flaky GHCR/Hub (no regional CDN defaults).
+pull_images() {
+  local max_attempts=3
+  local retry_delay=2
+  local attempt
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull; then
+      return 0
+    fi
+    if ((attempt < max_attempts)); then
+      echo "docker compose pull failed (attempt ${attempt}/${max_attempts}); retrying in ${retry_delay}s…" >&2
+      sleep "$retry_delay"
+    fi
+  done
+  return 1
+}
+
+if ! pull_images; then
+  fail "could not pull images after 3 attempts. Shell HTTP_PROXY often does not reach the Docker daemon. Configure daemon proxy/registry-mirrors, set image env vars to a reachable registry, or preload images then compose up with --pull never."
 fi
+
 # `--wait` without `--wait-timeout` can hang on one-shot services (Compose < 2.7)
 # or never return if a healthcheck stays red (Compose < 2.17). Prefer both flags.
 compose_up_help=$(docker compose up --help 2>/dev/null || true)


### PR DESCRIPTION
## Why
Transient registry failures currently abort the published-image installer after one pull attempt. A short, bounded retry lets self-hosted installations recover without restarting setup.

## What changed
- Retry `docker compose pull` up to three total attempts, with two seconds between failures.
- Stop installation if every pull fails; preserve healthy-service waiting and older Compose startup behavior after success.
- Add an offline smoke test, automatically included by the existing compose-installer unit test.

This change is limited to image-pull retries. Proxy loading is already on main. It has no dependency on #494 or #486 and introduces no web, desktop, or mobile UI changes.

The failure-only console messages are:
- `docker compose pull failed (attempt ${attempt}/${max_attempts}); retrying in ${retry_delay}s…`
- `Rakazo setup failed: could not pull images after 3 attempts. Shell HTTP_PROXY often does not reach the Docker daemon. Configure daemon proxy/registry-mirrors, set image env vars to a reachable registry, or preload images then compose up with --pull never.`

These messages appear only after a failed pull: the first explains the pause, and the final message explains exhaustion and recovery. Removing them would leave the retry delay and installer failure unexplained.

## Validation
- Bash syntax validation and all compose smoke scripts passed.
- Additional offline installer-entrypoint checks passed for first-, second-, and third-attempt success, retry exhaustion preventing startup, healthy-service waiting, and legacy Compose startup.
- All six required CI checks passed, along with container-image validation. CodeRabbit and Greptile completed; there are no unresolved review threads.
- CodeRabbit's outside-diff proxy warning concerns unchanged proxy handling already on main; this PR adds no proxy configuration or credential transmission.
- The optional Vercel preview remains blocked on contributor authorization; it is not a required branch-protection check.
