### PR TITLE
fix(compose): warn on arm64 hosts using edge image tags

### DIFF
--- a/infra/compose/install-images-fallback.smoke.sh
+++ b/infra/compose/install-images-fallback.smoke.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Offline smoke for the arm64-warn fallback in install-images.sh:
+# unset vs empty shell, .env, and ${NAME:-def} / ${NAME-def}.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")" && pwd)"
+src="$root/install-images.sh"
+
+extract_fn() {
+  local name="$1"
+  awk -v s="$name" '
+    $0 ~ "^    " s "\\(\\) \\{" { p = 1 }
+    p { print substr($0, 5) }
+    p && $0 ~ /^    }$/ { exit }
+  ' "$src"
+}
+
+eval "$(extract_fn normalize_env_tag)"
+eval "$(extract_fn resolve_env_default)"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+expect() {
+  local got="$1" want="$2" msg="$3"
+  [[ "$got" == "$want" ]] || fail "$msg (got '$got' want '$want')"
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+ENV_FILE="$tmp/.env"
+
+unset BASE_TAG || true
+printf '%s\n' 'BASE_TAG=fromenv' >"$ENV_FILE"
+expect "$(resolve_env_default '${BASE_TAG:-def}')" "fromenv" "unset shell + .env + :-"
+expect "$(resolve_env_default '${BASE_TAG-def}')" "fromenv" "unset shell + .env + -"
+
+BASE_TAG=""
+printf '%s\n' 'BASE_TAG=fromenv' >"$ENV_FILE"
+expect "$(resolve_env_default '${BASE_TAG:-def}')" "def" "empty shell + :- uses default, not .env"
+expect "$(resolve_env_default '${BASE_TAG-def}')" "" "empty shell + - preserves empty, not .env"
+
+BASE_TAG="shell"
+printf '%s\n' 'BASE_TAG=fromenv' >"$ENV_FILE"
+expect "$(resolve_env_default '${BASE_TAG:-def}')" "shell" "set shell + :-"
+expect "$(resolve_env_default '${BASE_TAG-def}')" "shell" "set shell + -"
+
+unset BASE_TAG || true
+printf '%s\n' 'BASE_TAG=' >"$ENV_FILE"
+expect "$(resolve_env_default '${BASE_TAG:-def}')" "def" "unset shell + empty .env + :-"
+expect "$(resolve_env_default '${BASE_TAG-def}')" "" "unset shell + empty .env + -"
+
+unset BASE_TAG || true
+printf '%s\n' 'OTHER=x' >"$ENV_FILE"
+expect "$(resolve_env_default '${BASE_TAG:-def}')" "def" "unset both + :-"
+expect "$(resolve_env_default '${BASE_TAG-def}')" "def" "unset both + -"
+
+lookup_shell_or_dotenv() {
+  local name="$1"
+  if [[ -n "${!name+x}" ]]; then
+    printf '%s' "${!name}"
+    return 0
+  fi
+  awk -F= -v k="$name" '
+    $0 ~ "^[[:space:]]*" k "=" {
+      sub(/^[^=]*=/, "")
+      print
+      exit
+    }
+  ' "$ENV_FILE" 2>/dev/null || true
+}
+
+printf '%s\n' 'RAKAZO_IMAGE_TAG=fromenv' >"$ENV_FILE"
+unset RAKAZO_IMAGE_TAG || true
+expect "$(lookup_shell_or_dotenv RAKAZO_IMAGE_TAG)" "fromenv" "outer unset shell uses .env"
+RAKAZO_IMAGE_TAG=""
+expect "$(lookup_shell_or_dotenv RAKAZO_IMAGE_TAG)" "" "outer empty shell does not use .env"
+RAKAZO_IMAGE_TAG="shell"
+expect "$(lookup_shell_or_dotenv RAKAZO_IMAGE_TAG)" "shell" "outer set shell wins"
+
+grep -Fq 'if [[ -n "${RAKAZO_IMAGE_TAG+x}" ]]' "$src" || fail "RAKAZO_IMAGE_TAG lookup must use +x"
+grep -Fq 'if [[ -n "${RAKAZO_COMPUTER_IMAGE_TAG+x}" ]]' "$src" || fail "RAKAZO_COMPUTER_IMAGE_TAG lookup must use +x"
+grep -Fq 'if [[ -n "${!name+x}" ]]' "$src" || fail "resolve_env_default must use +x for set-vs-unset"
+if grep -Fq 'if [[ -n "${!name:-}" ]]' "$src"; then
+  fail "resolve_env_default still treats empty as unset"
+fi
+if grep -Fq 'if [[ -n "${RAKAZO_IMAGE_TAG:-}" ]]' "$src"; then
+  fail "outer RAKAZO_IMAGE_TAG lookup still treats empty as unset"
+fi
+
+echo "ok"

--- a/infra/compose/install-images-fallback.smoke.sh
+++ b/infra/compose/install-images-fallback.smoke.sh
@@ -16,6 +16,7 @@ extract_fn() {
 }
 
 eval "$(extract_fn normalize_env_tag)"
+eval "$(extract_fn lookup_env_value)"
 eval "$(extract_fn resolve_env_default)"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
@@ -53,6 +54,21 @@ printf '%s\n' 'OTHER=x' >"$ENV_FILE"
 expect "$(resolve_env_default '${BASE_TAG:-def}')" "def" "unset both + :-"
 expect "$(resolve_env_default '${BASE_TAG-def}')" "def" "unset both + -"
 
+# Concatenated interpolation (Greptile P1): ${PREFIX}edge must resolve to edge
+# when PREFIX is unset, matching Compose, so the arm64 warn can fire.
+unset PREFIX || true
+printf '%s\n' 'OTHER=x' >"$ENV_FILE"
+expect "$(resolve_env_default '${PREFIX}edge')" "edge" "unset PREFIX + concat edge"
+PREFIX=""
+expect "$(resolve_env_default '${PREFIX}edge')" "edge" "empty PREFIX + concat edge"
+PREFIX="pre"
+expect "$(resolve_env_default '${PREFIX}edge')" "preedge" "set PREFIX + concat"
+unset PREFIX SUFFIX || true
+expect "$(resolve_env_default '${PREFIX}${SUFFIX}')" "" "two bare unset → empty"
+unset BASE_TAG || true
+printf '%s\n' 'BASE_TAG=fromenv' >"$ENV_FILE"
+expect "$(resolve_env_default 'x${BASE_TAG:-def}y')" "xfromenvy" "embedded :- with .env"
+
 lookup_shell_or_dotenv() {
   local name="$1"
   if [[ -n "${!name+x}" ]]; then
@@ -78,7 +94,9 @@ expect "$(lookup_shell_or_dotenv RAKAZO_IMAGE_TAG)" "shell" "outer set shell win
 
 grep -Fq 'if [[ -n "${RAKAZO_IMAGE_TAG+x}" ]]' "$src" || fail "RAKAZO_IMAGE_TAG lookup must use +x"
 grep -Fq 'if [[ -n "${RAKAZO_COMPUTER_IMAGE_TAG+x}" ]]' "$src" || fail "RAKAZO_COMPUTER_IMAGE_TAG lookup must use +x"
-grep -Fq 'if [[ -n "${!name+x}" ]]' "$src" || fail "resolve_env_default must use +x for set-vs-unset"
+grep -Fq 'if [[ -n "${!name+x}" ]]' "$src" || fail "lookup_env_value must use +x for set-vs-unset"
+grep -Fq 'lookup_env_value()' "$src" || fail "missing lookup_env_value helper"
+grep -Fq 'concatenated forms like' "$src" || fail "resolve_env_default must document concat expansion"
 if grep -Fq 'if [[ -n "${!name:-}" ]]' "$src"; then
   fail "resolve_env_default still treats empty as unset"
 fi

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -202,36 +202,77 @@ warn_arm64_edge_tags() {
       v="${v%"${v##*[![:space:]]}"}"
       printf '%s' "$v"
     }
-    resolve_env_default() {
-      local v name op def cur env_raw
-      v="$(normalize_env_tag "$1")"
-      if [[ "$v" =~ ^\$\{([A-Za-z_][A-Za-z0-9_]*)(:?-)([^}]*)\}$ ]]; then
-        name="${BASH_REMATCH[1]}"
-        op="${BASH_REMATCH[2]}"
-        def="${BASH_REMATCH[3]}"
-        if [[ -n "${!name+x}" ]]; then
-          cur="${!name}"
-        elif env_raw="$(awk -F= -v k="$name" '
-          $0 ~ "^[[:space:]]*" k "=" {
-            sub(/^[^=]*=/, "")
-            print
-            found=1
-            exit
-          }
-          END { if (!found) exit 2 }
-        ' "$ENV_FILE" 2>/dev/null)"; then
-          cur="$(normalize_env_tag "$env_raw")"
-        else
-          printf '%s' "$def"
-          return 0
-        fi
-        if [[ "$op" == ":-" && -z "$cur" ]]; then
-          printf '%s' "$def"
-        else
-          printf '%s' "$cur"
-        fi
+    # Shell overrides .env; return 0 when set in either, 1 when unset in both.
+    lookup_env_value() {
+      local name="$1" env_raw
+      if [[ -n "${!name+x}" ]]; then
+        printf '%s' "${!name}"
         return 0
       fi
+      if env_raw="$(awk -F= -v k="$name" '
+        $0 ~ "^[[:space:]]*" k "=" {
+          sub(/^[^=]*=/, "")
+          print
+          found=1
+          exit
+        }
+        END { if (!found) exit 2 }
+      ' "$ENV_FILE" 2>/dev/null)"; then
+        printf '%s' "$(normalize_env_tag "$env_raw")"
+        return 0
+      fi
+      return 1
+    }
+    # Expand Compose-style ${NAME}, ${NAME:-def}, ${NAME-def}, including
+    # concatenated forms like ${PREFIX}edge (Greptile: literal left the warn).
+    resolve_env_default() {
+      local v prefix rest expr suffix name op def cur resolved i
+      v="$(normalize_env_tag "$1")"
+      i=0
+      while [[ "$v" == *'${'*'}'* ]]; do
+        i=$((i + 1))
+        if [[ "$i" -gt 20 ]]; then
+          break
+        fi
+        prefix="${v%%\$\{*}"
+        rest="${v#*\$\{}"
+        case "$rest" in
+          *\}*) ;;
+          *) break ;;
+        esac
+        expr="${rest%%\}*}"
+        suffix="${rest#*\}}"
+        op=""
+        def=""
+        if [[ "$expr" =~ ^([A-Za-z_][A-Za-z0-9_]*)(:-)(.*)$ ]]; then
+          name="${BASH_REMATCH[1]}"
+          op=":-"
+          def="${BASH_REMATCH[3]}"
+        elif [[ "$expr" =~ ^([A-Za-z_][A-Za-z0-9_]*)-(.*)$ ]]; then
+          name="${BASH_REMATCH[1]}"
+          op="-"
+          def="${BASH_REMATCH[2]}"
+        elif [[ "$expr" =~ ^([A-Za-z_][A-Za-z0-9_]*)$ ]]; then
+          name="${BASH_REMATCH[1]}"
+        else
+          break
+        fi
+        if cur="$(lookup_env_value "$name")"; then
+          if [[ "$op" == ":-" && -z "$cur" ]]; then
+            resolved="$def"
+          else
+            resolved="$cur"
+          fi
+        else
+          if [[ "$op" == ":-" || "$op" == "-" ]]; then
+            resolved="$def"
+          else
+            # bare ${NAME} unset → empty, matching Compose interpolation
+            resolved=""
+          fi
+        fi
+        v="${prefix}${resolved}${suffix}"
+      done
       printf '%s' "$v"
     }
     if [[ -n "${RAKAZO_IMAGE_TAG+x}" ]]; then

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -175,29 +175,36 @@ YAML
 }
 
 warn_arm64_edge_tags() {
-  local arch app_tag computer_tag
+  local arch app_tag computer_tag compose_env
   arch="$(uname -m)"
   case "$arch" in
     arm64 | aarch64) ;;
     *) return 0 ;;
   esac
-  # .env values may be quoted, commented, or padded; compare the bare tag.
-  normalize_env_tag() {
-    local v="$1"
-    v="${v%%#*}"
-    v="${v#"${v%%[![:space:]]*}"}"
-    v="${v%"${v##*[![:space:]]}"}"
-    if [[ "$v" == \"*\" ]]; then v="${v#\"}"; v="${v%\"}"; fi
-    if [[ "$v" == \'*\' ]]; then v="${v#\'}"; v="${v%\'}"; fi
-    v="${v#"${v%%[![:space:]]*}"}"
-    v="${v%"${v##*[![:space:]]}"}"
-    printf '%s' "$v"
-  }
+  # Prefer Compose effective env (quotes, interpolation, shell overrides) so the
+  # warning matches what `docker compose pull` will actually resolve.
+  if compose_env="$(docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" config --environment 2>/dev/null)"; then
+    app_tag="$(printf '%s\n' "$compose_env" | awk -F= '$1 == "RAKAZO_IMAGE_TAG" { print substr($0, index($0, "=") + 1); exit }')"
+    computer_tag="$(printf '%s\n' "$compose_env" | awk -F= '$1 == "RAKAZO_COMPUTER_IMAGE_TAG" { print substr($0, index($0, "=") + 1); exit }')"
+  else
+    # Older Compose without `config --environment`: best-effort raw .env parse.
+    normalize_env_tag() {
+      local v="$1"
+      v="${v%%#*}"
+      v="${v#"${v%%[![:space:]]*}"}"
+      v="${v%"${v##*[![:space:]]}"}"
+      if [[ "$v" == \"*\" ]]; then v="${v#\"}"; v="${v%\"}"; fi
+      if [[ "$v" == \'*\' ]]; then v="${v#\'}"; v="${v%\'}"; fi
+      v="${v#"${v%%[![:space:]]*}"}"
+      v="${v%"${v##*[![:space:]]}"}"
+      printf '%s' "$v"
+    }
+    app_tag="$(awk -F= '/^[[:space:]]*RAKAZO_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
+    computer_tag="$(awk -F= '/^[[:space:]]*RAKAZO_COMPUTER_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
+    app_tag="$(normalize_env_tag "$app_tag")"
+    computer_tag="$(normalize_env_tag "$computer_tag")"
+  fi
   # Defaults match .env.images.example (edge = amd64-only main builds).
-  app_tag="$(awk -F= '/^[[:space:]]*RAKAZO_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
-  computer_tag="$(awk -F= '/^[[:space:]]*RAKAZO_COMPUTER_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
-  app_tag="$(normalize_env_tag "$app_tag")"
-  computer_tag="$(normalize_env_tag "$computer_tag")"
   app_tag="${app_tag:-edge}"
   computer_tag="${computer_tag:-edge}"
   if [[ "$app_tag" == "edge" || "$computer_tag" == "edge" ]]; then

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -187,7 +187,8 @@ warn_arm64_edge_tags() {
     app_tag="$(printf '%s\n' "$compose_env" | awk -F= '$1 == "RAKAZO_IMAGE_TAG" { print substr($0, index($0, "=") + 1); exit }')"
     computer_tag="$(printf '%s\n' "$compose_env" | awk -F= '$1 == "RAKAZO_COMPUTER_IMAGE_TAG" { print substr($0, index($0, "=") + 1); exit }')"
   else
-    # Older Compose without `config --environment`: best-effort raw .env parse.
+    # Older Compose without `config --environment`: shell env overrides .env
+    # (same precedence as `docker compose pull`).
     normalize_env_tag() {
       local v="$1"
       v="${v%%#*}"
@@ -199,10 +200,18 @@ warn_arm64_edge_tags() {
       v="${v%"${v##*[![:space:]]}"}"
       printf '%s' "$v"
     }
-    app_tag="$(awk -F= '/^[[:space:]]*RAKAZO_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
-    computer_tag="$(awk -F= '/^[[:space:]]*RAKAZO_COMPUTER_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
-    app_tag="$(normalize_env_tag "$app_tag")"
-    computer_tag="$(normalize_env_tag "$computer_tag")"
+    if [[ -n "${RAKAZO_IMAGE_TAG:-}" ]]; then
+      app_tag="$RAKAZO_IMAGE_TAG"
+    else
+      app_tag="$(awk -F= '/^[[:space:]]*RAKAZO_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
+      app_tag="$(normalize_env_tag "$app_tag")"
+    fi
+    if [[ -n "${RAKAZO_COMPUTER_IMAGE_TAG:-}" ]]; then
+      computer_tag="$RAKAZO_COMPUTER_IMAGE_TAG"
+    else
+      computer_tag="$(awk -F= '/^[[:space:]]*RAKAZO_COMPUTER_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
+      computer_tag="$(normalize_env_tag "$computer_tag")"
+    fi
   fi
   # Defaults match .env.images.example (edge = amd64-only main builds).
   app_tag="${app_tag:-edge}"

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -174,6 +174,23 @@ YAML
   fi
 }
 
+warn_arm64_edge_tags() {
+  local arch app_tag computer_tag
+  arch="$(uname -m)"
+  case "$arch" in
+    arm64 | aarch64) ;;
+    *) return 0 ;;
+  esac
+  # Defaults match .env.images.example (edge = amd64-only main builds).
+  app_tag="$(awk -F= '/^[[:space:]]*RAKAZO_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
+  computer_tag="$(awk -F= '/^[[:space:]]*RAKAZO_COMPUTER_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
+  app_tag="${app_tag:-edge}"
+  computer_tag="${computer_tag:-edge}"
+  if [[ "$app_tag" == "edge" || "$computer_tag" == "edge" ]]; then
+    echo "warning: host is ${arch}; edge image tags are linux/amd64-only. Pin both RAKAZO_IMAGE_TAG and RAKAZO_COMPUTER_IMAGE_TAG to the same multi-arch release tag (see docs/self-host.md)." >&2
+  fi
+}
+
 download "$COMPOSE_FILE"
 download "$ENV_EXAMPLE"
 
@@ -184,6 +201,8 @@ else
 fi
 
 validate_required_secrets
+
+warn_arm64_edge_tags
 
 if [[ "$prepare_only" == true ]]; then
   echo "Rakazo files are ready. Edit .env, then run: bash install-images.sh"

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -188,7 +188,9 @@ warn_arm64_edge_tags() {
     computer_tag="$(printf '%s\n' "$compose_env" | awk -F= '$1 == "RAKAZO_COMPUTER_IMAGE_TAG" { print substr($0, index($0, "=") + 1); exit }')"
   else
     # Older Compose without `config --environment`: shell env overrides .env
-    # (same precedence as `docker compose pull`), then trivial ${NAME:-default}.
+    # (same precedence as `docker compose pull`), then ${NAME:-default} /
+    # ${NAME-default}. ${name+x} treats empty as set (unlike ${name:-}).
+    # ${NAME:-def} defaults unset-or-empty; ${NAME-def} defaults only unset.
     normalize_env_tag() {
       local v="$1"
       v="${v%%#*}"
@@ -201,38 +203,43 @@ warn_arm64_edge_tags() {
       printf '%s' "$v"
     }
     resolve_env_default() {
-      local v name def cur
+      local v name op def cur env_raw
       v="$(normalize_env_tag "$1")"
       if [[ "$v" =~ ^\$\{([A-Za-z_][A-Za-z0-9_]*)(:?-)([^}]*)\}$ ]]; then
         name="${BASH_REMATCH[1]}"
+        op="${BASH_REMATCH[2]}"
         def="${BASH_REMATCH[3]}"
-        if [[ -n "${!name:-}" ]]; then
-          printf '%s' "${!name}"
-          return 0
-        fi
-        cur="$(awk -F= -v k="$name" '
+        if [[ -n "${!name+x}" ]]; then
+          cur="${!name}"
+        elif env_raw="$(awk -F= -v k="$name" '
           $0 ~ "^[[:space:]]*" k "=" {
             sub(/^[^=]*=/, "")
             print
+            found=1
             exit
           }
-        ' "$ENV_FILE" 2>/dev/null || true)"
-        cur="$(normalize_env_tag "$cur")"
-        if [[ -n "$cur" ]]; then
-          printf '%s' "$cur"
+          END { if (!found) exit 2 }
+        ' "$ENV_FILE" 2>/dev/null)"; then
+          cur="$(normalize_env_tag "$env_raw")"
         else
           printf '%s' "$def"
+          return 0
+        fi
+        if [[ "$op" == ":-" && -z "$cur" ]]; then
+          printf '%s' "$def"
+        else
+          printf '%s' "$cur"
         fi
         return 0
       fi
       printf '%s' "$v"
     }
-    if [[ -n "${RAKAZO_IMAGE_TAG:-}" ]]; then
+    if [[ -n "${RAKAZO_IMAGE_TAG+x}" ]]; then
       app_tag="$RAKAZO_IMAGE_TAG"
     else
       app_tag="$(awk -F= '/^[[:space:]]*RAKAZO_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
     fi
-    if [[ -n "${RAKAZO_COMPUTER_IMAGE_TAG:-}" ]]; then
+    if [[ -n "${RAKAZO_COMPUTER_IMAGE_TAG+x}" ]]; then
       computer_tag="$RAKAZO_COMPUTER_IMAGE_TAG"
     else
       computer_tag="$(awk -F= '/^[[:space:]]*RAKAZO_COMPUTER_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -188,7 +188,7 @@ warn_arm64_edge_tags() {
     computer_tag="$(printf '%s\n' "$compose_env" | awk -F= '$1 == "RAKAZO_COMPUTER_IMAGE_TAG" { print substr($0, index($0, "=") + 1); exit }')"
   else
     # Older Compose without `config --environment`: shell env overrides .env
-    # (same precedence as `docker compose pull`).
+    # (same precedence as `docker compose pull`), then trivial ${NAME:-default}.
     normalize_env_tag() {
       local v="$1"
       v="${v%%#*}"
@@ -200,18 +200,45 @@ warn_arm64_edge_tags() {
       v="${v%"${v##*[![:space:]]}"}"
       printf '%s' "$v"
     }
+    resolve_env_default() {
+      local v name def cur
+      v="$(normalize_env_tag "$1")"
+      if [[ "$v" =~ ^\$\{([A-Za-z_][A-Za-z0-9_]*)(:?-)([^}]*)\}$ ]]; then
+        name="${BASH_REMATCH[1]}"
+        def="${BASH_REMATCH[3]}"
+        if [[ -n "${!name:-}" ]]; then
+          printf '%s' "${!name}"
+          return 0
+        fi
+        cur="$(awk -F= -v k="$name" '
+          $0 ~ "^[[:space:]]*" k "=" {
+            sub(/^[^=]*=/, "")
+            print
+            exit
+          }
+        ' "$ENV_FILE" 2>/dev/null || true)"
+        cur="$(normalize_env_tag "$cur")"
+        if [[ -n "$cur" ]]; then
+          printf '%s' "$cur"
+        else
+          printf '%s' "$def"
+        fi
+        return 0
+      fi
+      printf '%s' "$v"
+    }
     if [[ -n "${RAKAZO_IMAGE_TAG:-}" ]]; then
       app_tag="$RAKAZO_IMAGE_TAG"
     else
       app_tag="$(awk -F= '/^[[:space:]]*RAKAZO_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
-      app_tag="$(normalize_env_tag "$app_tag")"
     fi
     if [[ -n "${RAKAZO_COMPUTER_IMAGE_TAG:-}" ]]; then
       computer_tag="$RAKAZO_COMPUTER_IMAGE_TAG"
     else
       computer_tag="$(awk -F= '/^[[:space:]]*RAKAZO_COMPUTER_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
-      computer_tag="$(normalize_env_tag "$computer_tag")"
     fi
+    app_tag="$(resolve_env_default "$app_tag")"
+    computer_tag="$(resolve_env_default "$computer_tag")"
   fi
   # Defaults match .env.images.example (edge = amd64-only main builds).
   app_tag="${app_tag:-edge}"

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -190,7 +190,24 @@ if [[ "$prepare_only" == true ]]; then
   exit 0
 fi
 
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
+# Stage C image pull: finite retries for flaky GHCR/Hub (no regional CDN defaults).
+pull_attempts=3
+pull_delay=2
+pull_ok=false
+for ((pull_i=1; pull_i<=pull_attempts; pull_i++)); do
+  if docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull; then
+    pull_ok=true
+    break
+  fi
+  if (( pull_i < pull_attempts )); then
+    echo "docker compose pull failed (attempt ${pull_i}/${pull_attempts}); retrying in ${pull_delay}s…" >&2
+    sleep "$pull_delay"
+  fi
+done
+if [[ "$pull_ok" != true ]]; then
+  fail "docker compose pull failed after ${pull_attempts} attempts (check registry reachability / RAKAZO_IMAGE* overrides)."
+fi
+
 # `--wait` without `--wait-timeout` can hang on one-shot services (Compose < 2.7)
 # or never return if a healthcheck stays red (Compose < 2.17). Prefer both flags.
 compose_up_help=$(docker compose up --help 2>/dev/null || true)

--- a/infra/compose/install-images.sh
+++ b/infra/compose/install-images.sh
@@ -181,9 +181,23 @@ warn_arm64_edge_tags() {
     arm64 | aarch64) ;;
     *) return 0 ;;
   esac
+  # .env values may be quoted, commented, or padded; compare the bare tag.
+  normalize_env_tag() {
+    local v="$1"
+    v="${v%%#*}"
+    v="${v#"${v%%[![:space:]]*}"}"
+    v="${v%"${v##*[![:space:]]}"}"
+    if [[ "$v" == \"*\" ]]; then v="${v#\"}"; v="${v%\"}"; fi
+    if [[ "$v" == \'*\' ]]; then v="${v#\'}"; v="${v%\'}"; fi
+    v="${v#"${v%%[![:space:]]*}"}"
+    v="${v%"${v##*[![:space:]]}"}"
+    printf '%s' "$v"
+  }
   # Defaults match .env.images.example (edge = amd64-only main builds).
   app_tag="$(awk -F= '/^[[:space:]]*RAKAZO_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
   computer_tag="$(awk -F= '/^[[:space:]]*RAKAZO_COMPUTER_IMAGE_TAG=/{ sub(/^[^=]*=/, ""); print; exit }' "$ENV_FILE" 2>/dev/null || true)"
+  app_tag="$(normalize_env_tag "$app_tag")"
+  computer_tag="$(normalize_env_tag "$computer_tag")"
   app_tag="${app_tag:-edge}"
   computer_tag="${computer_tag:-edge}"
   if [[ "$app_tag" == "edge" || "$computer_tag" == "edge" ]]; then


### PR DESCRIPTION
## Summary
- On `arm64`/`aarch64`, warn if `RAKAZO_IMAGE_TAG` or `RAKAZO_COMPUTER_IMAGE_TAG` is still `edge` (amd64-only), pointing at `docs/self-host.md`
- Script-only; no CDN defaults

**Note:** Branch is rebased onto #495 (`fix/installer-compose-pull-retry`) so both installer knives share one linear history. Prefer merge **#495 first**, then this PR (or merge this after #495 lands on main and we rebase). Diff vs main currently includes #495 pull-retry commits until that lands.

## Test plan
- [ ] `bash -n infra/compose/install-images.sh`
- [ ] arm64 + edge tags → stderr warning
- [ ] arm64 + pinned tags → silent
- [ ] amd64 host → silent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ARM64 image compatibility warnings by accurately detecting effective Docker Compose image tags.
  * Shell-exported image-tag values now take precedence when Compose environment resolution is unavailable, including intentionally empty values.
  * Improved fallback handling for `.env` values, quoted or commented entries, whitespace, and chained or concatenated default expressions.
  * Preserved image-pull retry behavior, with up to three attempts and a two-second delay between attempts.

* **Tests**
  * Added coverage for environment precedence, empty values, and fallback expansion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->