### PR TITLE
docs(compose): document Hub postgres/busybox image overrides

### DIFF
--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -35,6 +35,12 @@ RAKAZO_IMAGE_TAG=edge
 RAKAZO_COMPUTER_IMAGE=ghcr.io/elie222/rakazo/computer
 RAKAZO_COMPUTER_IMAGE_TAG=edge
 
+# Optional Hub postgres/busybox overrides for published-images compose.
+# Unset keeps Docker Hub defaults (digest-pinned postgres:16, busybox:1).
+# On restricted networks, point these at a mirror that already has the images:
+# POSTGRES_IMAGE=registry.example.com/library/postgres:16
+# BUSYBOX_IMAGE=registry.example.com/library/busybox:1
+
 # docker = local computers via the in-stack supervisor (default). Optional remote: e2b, daytona, box.
 # none boots the UI without computers when Docker/supervisor is not configured.
 SANDBOX_PROVIDER=docker


### PR DESCRIPTION
## Summary
- Document optional `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` in `.env.images.example` (already supported by #493 on published-images compose)
- Generic mirror example only — no regional CDN brand defaults

Orthogonal to open installer (#495/#496), prod Hub (#494), and Feishu (#486).

## Test plan
- [ ] Diff is comments-only in `.env.images.example`
- [ ] Defaults unchanged when vars unset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the published-images Compose environment example to clarify that leaving values unset uses Docker Hub defaults.
  * Clarified registry mirror syntax for PostgreSQL and BusyBox images.
  * Removed empty placeholder variable lines from the example configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->