### PR TITLE
fix(compose): allow overriding Hub postgres/busybox images on dev path

### DIFF
--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: ${POSTGRES_IMAGE:-postgres:16}
     environment:
       POSTGRES_USER: rakazo
       POSTGRES_PASSWORD: rakazo
@@ -49,7 +49,7 @@ services:
     restart: "no"
 
   data-init:
-    image: busybox:1
+    image: ${BUSYBOX_IMAGE:-busybox:1}
     command: ["chown", "-R", "1000:1000", "/data"]
     restart: "no"
     volumes:


### PR DESCRIPTION
## Summary
- Dev `docker-compose.yml`: `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` env overrides with unchanged defaults (`postgres:16`, `busybox:1`)
- Complements #493 (published-images) and open #494 (prod); this is the local/dev compose path

Helps Mainland / restricted-network developers without shipping regional CDN defaults.

## Test plan
- [ ] Unset env → same image refs as before
- [ ] Set overrides → compose resolves them
- [ ] No collision with open installer/Feishu/prod PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added deployment configuration options for selecting the PostgreSQL and BusyBox container images.
  - PostgreSQL deployments now default to version 16, while the data initialization service defaults to BusyBox version 1.
  - Existing defaults remain available while allowing deployment environments to override the selected images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->