### PR TITLE
Wire ui-tokens into mobile screen backgrounds

### DIFF
--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -13,6 +13,7 @@ import { ComputerMaintenanceActions } from "../components/computer-maintenance-a
 import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
+import { tokens } from "../lib/theme";
 
 type BotSettingsRecord = MobileBot & {
   description?: string;
@@ -87,7 +88,7 @@ export default function BotSettingsScreen() {
     <>
       <Stack.Screen options={{ title: t("Chat settings") }} />
       <ScrollView
-        style={{ flex: 1, backgroundColor: "#050506" }}
+        style={{ flex: 1, backgroundColor: tokens.page }}
         contentContainerStyle={{ padding: 24 }}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"

--- a/apps/mobile/app/computer.tsx
+++ b/apps/mobile/app/computer.tsx
@@ -23,6 +23,7 @@ import {
   SCREEN_URL_OPEN_ATTEMPTS,
 } from "../lib/computer";
 import { useI18n } from "../lib/i18n";
+import { tokens } from "../lib/theme";
 
 export default function Computer() {
   const { t } = useI18n();
@@ -319,7 +320,7 @@ export default function Computer() {
               </View>
             </SafeAreaView>
           ) : (
-            <View style={{ flex: 1, backgroundColor: "#050506" }}>
+            <View style={{ flex: 1, backgroundColor: tokens.page }}>
               <SafeAreaView
                 edges={["top", "left", "right"]}
                 style={{

--- a/apps/mobile/app/group-settings.tsx
+++ b/apps/mobile/app/group-settings.tsx
@@ -5,6 +5,7 @@ import { Alert, Pressable, ScrollView, Text, TextInput } from "react-native";
 import { BotAvatar } from "../components/bot-avatar";
 import { type MobileBot, type MobileGroup, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
+import { tokens } from "../lib/theme";
 
 export default function GroupSettingsScreen() {
   const { t } = useI18n();
@@ -85,7 +86,7 @@ export default function GroupSettingsScreen() {
     <>
       <Stack.Screen options={{ title: t("Group settings") }} />
       <ScrollView
-        style={{ flex: 1, backgroundColor: "#050506" }}
+        style={{ flex: 1, backgroundColor: tokens.page }}
         contentContainerStyle={{ padding: 24 }}
       >
         <Text style={{ color: "#85858A", fontSize: 14 }}>{t("Name")}</Text>

--- a/apps/mobile/app/new-group.tsx
+++ b/apps/mobile/app/new-group.tsx
@@ -5,6 +5,7 @@ import { Pressable, ScrollView, Text, TextInput } from "react-native";
 import { BotAvatar } from "../components/bot-avatar";
 import { type MobileBot, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
+import { tokens } from "../lib/theme";
 
 export default function NewGroup() {
   const { t } = useI18n();
@@ -59,7 +60,7 @@ export default function NewGroup() {
     <>
       <Stack.Screen options={{ title: t("New group") }} />
       <ScrollView
-        style={{ flex: 1, backgroundColor: "#050506" }}
+        style={{ flex: 1, backgroundColor: tokens.page }}
         contentContainerStyle={{ padding: 24 }}
       >
         <Text style={{ color: "#85858A", fontSize: 14 }}>{t("Name")}</Text>

--- a/apps/mobile/app/new-space.tsx
+++ b/apps/mobile/app/new-space.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Alert, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { rpc, selectSpace } from "../lib/api";
 import { useI18n } from "../lib/i18n";
+import { tokens } from "../lib/theme";
 
 export default function NewSpace() {
   const { t } = useI18n();
@@ -50,7 +51,7 @@ export default function NewSpace() {
         }}
       />
       <ScrollView
-        style={{ flex: 1, backgroundColor: "#050506" }}
+        style={{ flex: 1, backgroundColor: tokens.page }}
         contentContainerStyle={{ padding: 24 }}
         keyboardShouldPersistTaps="handled"
       >

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -11,6 +11,7 @@ import { Pressable, ScrollView, Text, TextInput } from "react-native";
 import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
+import { tokens } from "../lib/theme";
 
 export default function NewBot() {
   const { t } = useI18n();
@@ -69,7 +70,7 @@ export default function NewBot() {
         }}
       />
       <ScrollView
-        style={{ flex: 1, backgroundColor: "#050506" }}
+        style={{ flex: 1, backgroundColor: tokens.page }}
         contentContainerStyle={{ padding: 24 }}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"

--- a/apps/mobile/app/routine.tsx
+++ b/apps/mobile/app/routine.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
 import { rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
+import { tokens } from "../lib/theme";
 
 export default function RoutineDetail() {
   const { t } = useI18n();
@@ -47,7 +48,7 @@ export default function RoutineDetail() {
 
   return (
     <ScrollView
-      style={{ flex: 1, backgroundColor: "#050506" }}
+      style={{ flex: 1, backgroundColor: tokens.page }}
       contentContainerStyle={{ padding: 24, gap: 18 }}
     >
       <Stack.Screen options={{ title: routine?.name ?? t("Routine") }} />

--- a/apps/mobile/lib/theme.test.ts
+++ b/apps/mobile/lib/theme.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { botColors, tokens } from "./theme.js";
+
+describe("mobile theme tokens", () => {
+  it("exposes the shared product page color used by screen backgrounds", () => {
+    expect(tokens.page).toBe("#050506");
+    expect(tokens.ink).toBe("#ECECEE");
+    expect(tokens.cream).toBe("#F1F1EF");
+    expect(tokens.accent).toBe("#3EC5A8");
+  });
+
+  it("re-exports botColors for identity accents", () => {
+    expect(botColors.length).toBeGreaterThan(0);
+    expect(botColors[0]).toBe(tokens.accent);
+  });
+});

--- a/apps/mobile/lib/theme.ts
+++ b/apps/mobile/lib/theme.ts
@@ -1,0 +1,3 @@
+/** Product palette for Expo. Prefer these over hardcoded Rakazo hexes.
+ * System chrome (nav bars, fills, labels) stays in `./native` via PlatformColor. */
+export { botColors, tokens } from "@rakazo/ui-tokens";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Expo was hardcoding the product page color (`#050506`) on several screens while `@rakazo/ui-tokens` already owns that palette. Share tokens/behavior with web (issue #504)—not components, not shadcn.

## What

- Add `apps/mobile/lib/theme.ts` re-exporting `tokens` / `botColors` from `@rakazo/ui-tokens`
- Use `tokens.page` on the seven screens that shared that hex: bot-settings, computer, group-settings, new-group, new-space, new, routine
- Unit test for the shared page/ink/cream/accent values
- System chrome stays on `PlatformColor` via `lib/native`

## Rebase

Rebased onto current `origin/main` to clear CONFLICTING/DIRTY. Kept zh-CN / `useI18n` wiring from main together with tokenized backgrounds. `package.json` / lockfile deps for ui-tokens were already on main (Appearance), so those PR hunks dropped out cleanly.

## Exceptions

- `apps/mobile/app.json` still has `#050506` for Expo splash/native config (not a screen background this PR targeted).

## Test plan

- [x] `pnpm --filter @rakazo/mobile test` (includes `theme.test.ts`)
- [x] `biome check` on touched files
- Native Expo screens: skip web E2E screenshots (CI does not open these)

**UI:** Native Expo only — no web E2E screenshot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-780bd122-d238-4323-93ee-be270bff951e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-780bd122-d238-4323-93ee-be270bff951e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Localized the bot settings screen’s title, labels, placeholders, button text, and fallback error messages.
  - Updated mobile screens to use shared theme colors for more consistent backgrounds across settings, creation, routine, and computer views.

- **Tests**
  - Added coverage to verify mobile theme colors and bot color configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->