### PR TITLE
feat(desktop): downloadable app that starts a local server (#507)

### DIFF
--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -83,6 +83,8 @@ test("first run asks whether to use a local or existing instance", async () => {
   await expect(setup.getByRole("radio", { name: /This computer/ })).toBeChecked();
   await expect(setup.locator("#local-url")).toHaveValue("http://127.0.0.1:5173");
   await expect(setup.locator("#panel-existing")).toBeHidden();
+  await expect(setup.getByText(/Starts a local server with Docker/i)).toBeVisible();
+  await expect(setup.locator("#panel-new")).not.toContainText(/pnpm/);
 
   await setup.screenshot({
     path: path.join(import.meta.dirname, "screenshots", "01-setup-new-instance.png"),

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -40,6 +40,14 @@
       {
         "from": "../web/dist",
         "to": "web"
+      },
+      {
+        "from": "../../infra/compose/docker-compose.images.yml",
+        "to": "local-stack/docker-compose.images.yml"
+      },
+      {
+        "from": "../../infra/compose/.env.images.example",
+        "to": "local-stack/.env.images.example"
       }
     ],
     "extraMetadata": {

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -131,7 +131,7 @@ describe("ensureLocalStack", () => {
     expect(progress[0]).toContain("Docker");
   });
 
-  it("uses --wait when Compose help has no --wait-timeout", async () => {
+  it("polls health when Compose has --wait but no --wait-timeout", async () => {
     dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-data-"));
     templateDir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-template-"));
     await writeFile(path.join(templateDir, LOCAL_STACK_COMPOSE_FILE), "name: rakazo\n", "utf8");
@@ -146,15 +146,25 @@ describe("ensureLocalStack", () => {
       return { code: 0, stdout: args.includes("ps") ? "" : "ok", stderr: "" };
     };
 
-    const result = await ensureLocalStack({
-      userDataDir: dir,
-      templateDir,
-      runner,
-    });
-    expect(result.ok).toBe(true);
-    expect(
-      calls.some((call) => call.includes("up -d --wait") && !call.includes("--wait-timeout")),
-    ).toBe(true);
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ json: { ok: true, version: "0.1.0" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    try {
+      const result = await ensureLocalStack({
+        userDataDir: dir,
+        templateDir,
+        runner,
+      });
+      expect(result.ok).toBe(true);
+      // Avoid bare --wait: it can hang forever without --wait-timeout.
+      expect(calls.some((call) => call.includes("up -d") && !call.includes("--wait"))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("polls health when Compose cannot wait on startup", async () => {

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -153,10 +153,7 @@ describe("ensureLocalStack", () => {
     });
     expect(result.ok).toBe(true);
     expect(
-      calls.some(
-        (call) =>
-          call.includes("up -d --wait") && !call.includes("--wait-timeout"),
-      ),
+      calls.some((call) => call.includes("up -d --wait") && !call.includes("--wait-timeout")),
     ).toBe(true);
   });
 

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -1,0 +1,158 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_LOCAL_WEB_URL } from "./setup-config.js";
+import {
+  detectDocker,
+  ensureLocalStack,
+  ensureLocalStackFiles,
+  fillLocalStackEnv,
+  isDefaultLocalStackUrl,
+  LOCAL_STACK_COMPOSE_FILE,
+  LOCAL_STACK_ENV_EXAMPLE,
+  LOCAL_STACK_ENV_FILE,
+  type LocalStackRunner,
+} from "./local-stack.js";
+
+const EXAMPLE = `# example
+POSTGRES_PASSWORD=
+BETTER_AUTH_SECRET=
+ENCRYPTION_KEY=
+SCREEN_PROXY_SECRET=
+SANDBOX_SUPERVISOR_TOKEN=
+BETTER_AUTH_URL=http://127.0.0.1:5173
+`;
+
+describe("local stack helpers", () => {
+  it("recognizes the default loopback stack URL", () => {
+    expect(isDefaultLocalStackUrl(DEFAULT_LOCAL_WEB_URL)).toBe(true);
+    expect(isDefaultLocalStackUrl("http://127.0.0.1:5173/")).toBe(true);
+    expect(isDefaultLocalStackUrl("http://127.0.0.1:9999")).toBe(false);
+    expect(isDefaultLocalStackUrl("https://rakazo.example.com")).toBe(false);
+  });
+
+  it("fills blank secrets and keeps existing ones", () => {
+    const first = fillLocalStackEnv(EXAMPLE, null);
+    expect(first).toMatch(/POSTGRES_PASSWORD=[0-9a-f]{32}/);
+    expect(first).toMatch(/BETTER_AUTH_SECRET=[0-9a-f]{64}/);
+    expect(first).toContain("BETTER_AUTH_URL=http://127.0.0.1:5173");
+
+    const password = /^POSTGRES_PASSWORD=(.*)$/m.exec(first)?.[1];
+    const second = fillLocalStackEnv(EXAMPLE, first);
+    expect(second).toContain(`POSTGRES_PASSWORD=${password}`);
+  });
+});
+
+describe("ensureLocalStackFiles", () => {
+  let dir: string | undefined;
+  let templateDir: string | undefined;
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+    if (templateDir) await rm(templateDir, { recursive: true, force: true });
+    dir = undefined;
+    templateDir = undefined;
+  });
+
+  it("copies compose files and writes a secret-filled .env once", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-data-"));
+    templateDir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-template-"));
+    await writeFile(path.join(templateDir, LOCAL_STACK_COMPOSE_FILE), "name: rakazo\n", "utf8");
+    await writeFile(path.join(templateDir, LOCAL_STACK_ENV_EXAMPLE), EXAMPLE, "utf8");
+
+    await ensureLocalStackFiles({ dataDir: dir, templateDir });
+    const env = await readFile(path.join(dir, LOCAL_STACK_ENV_FILE), "utf8");
+    expect(env).toMatch(/BETTER_AUTH_SECRET=[0-9a-f]{64}/);
+    expect(await readFile(path.join(dir, LOCAL_STACK_COMPOSE_FILE), "utf8")).toContain("name: rakazo");
+
+    const password = /^POSTGRES_PASSWORD=(.*)$/m.exec(env)?.[1];
+    await ensureLocalStackFiles({ dataDir: dir, templateDir });
+    const again = await readFile(path.join(dir, LOCAL_STACK_ENV_FILE), "utf8");
+    expect(again).toContain(`POSTGRES_PASSWORD=${password}`);
+  });
+});
+
+describe("ensureLocalStack", () => {
+  let dir: string | undefined;
+  let templateDir: string | undefined;
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+    if (templateDir) await rm(templateDir, { recursive: true, force: true });
+    dir = undefined;
+    templateDir = undefined;
+  });
+
+  it("explains how to install Docker when it is missing", async () => {
+    const runner: LocalStackRunner = async () => {
+      throw new Error("ENOENT");
+    };
+    const result = await detectDocker(runner);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Docker Desktop");
+      expect(result.error).toMatch(/docker\.com/);
+    }
+  });
+
+  it("pulls and starts compose when Docker is available", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-data-"));
+    templateDir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-template-"));
+    await writeFile(path.join(templateDir, LOCAL_STACK_COMPOSE_FILE), "name: rakazo\n", "utf8");
+    await writeFile(path.join(templateDir, LOCAL_STACK_ENV_EXAMPLE), EXAMPLE, "utf8");
+
+    const calls: string[] = [];
+    const runner: LocalStackRunner = async ({ args }) => {
+      calls.push(args.join(" "));
+      if (args[0] === "version" || args[0] === "compose") {
+        if (args.includes("ps")) return { code: 0, stdout: "", stderr: "" };
+        if (args.includes("up") && args.includes("--help")) {
+          return { code: 0, stdout: "--wait-timeout", stderr: "" };
+        }
+        return { code: 0, stdout: "ok", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+
+    const progress: string[] = [];
+    const result = await ensureLocalStack({
+      userDataDir: dir,
+      templateDir,
+      runner,
+      onProgress: (message) => progress.push(message),
+    });
+
+    expect(result).toEqual({ ok: true, url: DEFAULT_LOCAL_WEB_URL, attached: false });
+    expect(calls.some((call) => call.includes("pull"))).toBe(true);
+    expect(calls.some((call) => call.includes("up -d --wait --wait-timeout 300"))).toBe(true);
+    expect(progress[0]).toContain("Docker");
+  });
+
+  it("skips pull when the stack is already running", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-data-"));
+    templateDir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-template-"));
+    await writeFile(path.join(templateDir, LOCAL_STACK_COMPOSE_FILE), "name: rakazo\n", "utf8");
+    await writeFile(path.join(templateDir, LOCAL_STACK_ENV_EXAMPLE), EXAMPLE, "utf8");
+
+    const calls: string[] = [];
+    const runner: LocalStackRunner = async ({ args }) => {
+      calls.push(args.join(" "));
+      if (args.includes("ps")) return { code: 0, stdout: "abc123\n", stderr: "" };
+      if (args.includes("up") && args.includes("--help")) {
+        return { code: 0, stdout: "--wait-timeout", stderr: "" };
+      }
+      return { code: 0, stdout: "ok", stderr: "" };
+    };
+
+    const result = await ensureLocalStack({
+      userDataDir: dir,
+      templateDir,
+      runner,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.attached).toBe(true);
+    expect(calls.some((call) => call.includes("pull"))).toBe(false);
+  });
+});

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -110,7 +110,7 @@ describe("ensureLocalStack", () => {
       if (args[0] === "version" || args[0] === "compose") {
         if (args.includes("ps")) return { code: 0, stdout: "", stderr: "" };
         if (args.includes("up") && args.includes("--help")) {
-          return { code: 0, stdout: "--wait-timeout", stderr: "" };
+          return { code: 0, stdout: "--wait --wait-timeout", stderr: "" };
         }
         return { code: 0, stdout: "ok", stderr: "" };
       }
@@ -131,6 +131,41 @@ describe("ensureLocalStack", () => {
     expect(progress[0]).toContain("Docker");
   });
 
+  it("polls health when Compose cannot wait on startup", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-data-"));
+    templateDir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-template-"));
+    await writeFile(path.join(templateDir, LOCAL_STACK_COMPOSE_FILE), "name: rakazo\n", "utf8");
+    await writeFile(path.join(templateDir, LOCAL_STACK_ENV_EXAMPLE), EXAMPLE, "utf8");
+
+    const calls: string[] = [];
+    const runner: LocalStackRunner = async ({ args }) => {
+      calls.push(args.join(" "));
+      if (args.includes("up") && args.includes("--help")) {
+        return { code: 0, stdout: "Usage: docker compose up", stderr: "" };
+      }
+      return { code: 0, stdout: args.includes("ps") ? "" : "ok", stderr: "" };
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ json: { ok: true, version: "0.1.0" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    try {
+      const result = await ensureLocalStack({
+        userDataDir: dir,
+        templateDir,
+        runner,
+      });
+      expect(result.ok).toBe(true);
+      expect(calls.some((call) => call.includes("up -d") && !call.includes("--wait"))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("skips pull when the stack is already running", async () => {
     dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-data-"));
     templateDir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-template-"));
@@ -142,7 +177,7 @@ describe("ensureLocalStack", () => {
       calls.push(args.join(" "));
       if (args.includes("ps")) return { code: 0, stdout: "abc123\n", stderr: "" };
       if (args.includes("up") && args.includes("--help")) {
-        return { code: 0, stdout: "--wait-timeout", stderr: "" };
+        return { code: 0, stdout: "--wait --wait-timeout", stderr: "" };
       }
       return { code: 0, stdout: "ok", stderr: "" };
     };

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -2,7 +2,6 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { DEFAULT_LOCAL_WEB_URL } from "./setup-config.js";
 import {
   detectDocker,
   ensureLocalStack,
@@ -14,6 +13,7 @@ import {
   LOCAL_STACK_ENV_FILE,
   type LocalStackRunner,
 } from "./local-stack.js";
+import { DEFAULT_LOCAL_WEB_URL } from "./setup-config.js";
 
 const EXAMPLE = `# example
 POSTGRES_PASSWORD=
@@ -64,7 +64,9 @@ describe("ensureLocalStackFiles", () => {
     await ensureLocalStackFiles({ dataDir: dir, templateDir });
     const env = await readFile(path.join(dir, LOCAL_STACK_ENV_FILE), "utf8");
     expect(env).toMatch(/BETTER_AUTH_SECRET=[0-9a-f]{64}/);
-    expect(await readFile(path.join(dir, LOCAL_STACK_COMPOSE_FILE), "utf8")).toContain("name: rakazo");
+    expect(await readFile(path.join(dir, LOCAL_STACK_COMPOSE_FILE), "utf8")).toContain(
+      "name: rakazo",
+    );
 
     const password = /^POSTGRES_PASSWORD=(.*)$/m.exec(env)?.[1];
     await ensureLocalStackFiles({ dataDir: dir, templateDir });

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -131,6 +131,35 @@ describe("ensureLocalStack", () => {
     expect(progress[0]).toContain("Docker");
   });
 
+  it("uses --wait when Compose help has no --wait-timeout", async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-data-"));
+    templateDir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-template-"));
+    await writeFile(path.join(templateDir, LOCAL_STACK_COMPOSE_FILE), "name: rakazo\n", "utf8");
+    await writeFile(path.join(templateDir, LOCAL_STACK_ENV_EXAMPLE), EXAMPLE, "utf8");
+
+    const calls: string[] = [];
+    const runner: LocalStackRunner = async ({ args }) => {
+      calls.push(args.join(" "));
+      if (args.includes("up") && args.includes("--help")) {
+        return { code: 0, stdout: "Usage: docker compose up\n--wait\n", stderr: "" };
+      }
+      return { code: 0, stdout: args.includes("ps") ? "" : "ok", stderr: "" };
+    };
+
+    const result = await ensureLocalStack({
+      userDataDir: dir,
+      templateDir,
+      runner,
+    });
+    expect(result.ok).toBe(true);
+    expect(
+      calls.some(
+        (call) =>
+          call.includes("up -d --wait") && !call.includes("--wait-timeout"),
+      ),
+    ).toBe(true);
+  });
+
   it("polls health when Compose cannot wait on startup", async () => {
     dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-data-"));
     templateDir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-template-"));

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -186,7 +186,8 @@ export async function detectDocker(
     if (compose.code !== 0) {
       return {
         ok: false,
-        error: "Docker Compose is required for This computer. Update Docker Desktop, then try again.",
+        error:
+          "Docker Compose is required for This computer. Update Docker Desktop, then try again.",
       };
     }
     return { ok: true };
@@ -272,7 +273,10 @@ export async function ensureLocalStack(deps: LocalStackDeps): Promise<LocalStack
     if (pull.code !== 0) {
       return {
         ok: false,
-        error: summarizeDockerFailure("Could not download Rakazo images.", pull.stderr || pull.stdout),
+        error: summarizeDockerFailure(
+          "Could not download Rakazo images.",
+          pull.stderr || pull.stdout,
+        ),
       };
     }
   }
@@ -300,7 +304,10 @@ export async function ensureLocalStack(deps: LocalStackDeps): Promise<LocalStack
   if (up.code !== 0) {
     return {
       ok: false,
-      error: summarizeDockerFailure("Could not start the local Rakazo server.", up.stderr || up.stdout),
+      error: summarizeDockerFailure(
+        "Could not start the local Rakazo server.",
+        up.stderr || up.stdout,
+      ),
     };
   }
 

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { access, copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { DEFAULT_LOCAL_WEB_URL } from "./setup-config.js";
+import { DEFAULT_LOCAL_WEB_URL, isRakazoHealth } from "./setup-config.js";
 
 export const LOCAL_STACK_DIR_NAME = "local-stack";
 export const LOCAL_STACK_PROJECT_NAME = "rakazo-desktop";
@@ -291,11 +291,14 @@ export async function ensureLocalStack(deps: LocalStackDeps): Promise<LocalStack
     args: ["compose", "up", "--help"],
     cwd: dataDir,
   });
-  const supportsWaitTimeout =
-    upHelp.stdout.includes("--wait-timeout") || upHelp.stderr.includes("--wait-timeout");
+  const helpText = `${upHelp.stdout}\n${upHelp.stderr}`;
+  const supportsWait = helpText.includes("--wait");
+  const supportsWaitTimeout = helpText.includes("--wait-timeout");
   const upArgs = supportsWaitTimeout
     ? [...composeArgs, "up", "-d", "--wait", "--wait-timeout", "300"]
-    : [...composeArgs, "up", "-d"];
+    : supportsWait
+      ? [...composeArgs, "up", "-d", "--wait"]
+      : [...composeArgs, "up", "-d"];
   const up = await runner({
     command: "docker",
     args: upArgs,
@@ -311,7 +314,54 @@ export async function ensureLocalStack(deps: LocalStackDeps): Promise<LocalStack
     };
   }
 
+  // Older Compose builds can start containers without blocking on healthchecks.
+  if (!supportsWait) {
+    onProgress("Waiting for the local server to become healthy…");
+    const healthy = await waitForLocalStackHealthy(DEFAULT_LOCAL_WEB_URL, onProgress);
+    if (!healthy) {
+      return {
+        ok: false,
+        error:
+          "The local server started, but health checks did not pass in time. Open Docker Desktop, wait for Rakazo to finish starting, then try Continue again.",
+      };
+    }
+  }
+
   return { ok: true, url: DEFAULT_LOCAL_WEB_URL, attached: alreadyRunning };
+}
+
+const HEALTH_WAIT_TIMEOUT_MS = 300_000;
+const HEALTH_POLL_INTERVAL_MS = 2_000;
+
+async function waitForLocalStackHealthy(
+  url: string,
+  onProgress: LocalStackProgress,
+): Promise<boolean> {
+  const deadline = Date.now() + HEALTH_WAIT_TIMEOUT_MS;
+  let lastLog = 0;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${url}/rpc/health`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: {} }),
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (response.ok) {
+        const body: unknown = await response.json();
+        if (isRakazoHealth(body)) return true;
+      }
+    } catch {
+      // Keep polling while Compose finishes pulling and booting services.
+    }
+    const now = Date.now();
+    if (now - lastLog >= 15_000) {
+      onProgress("Still waiting for the local server…");
+      lastLog = now;
+    }
+    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
+  }
+  return false;
 }
 
 function summarizeDockerFailure(prefix: string, detail: string): string {

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -1,0 +1,315 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { access, copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { DEFAULT_LOCAL_WEB_URL } from "./setup-config.js";
+
+export const LOCAL_STACK_DIR_NAME = "local-stack";
+export const LOCAL_STACK_PROJECT_NAME = "rakazo-desktop";
+export const LOCAL_STACK_COMPOSE_FILE = "docker-compose.images.yml";
+export const LOCAL_STACK_ENV_EXAMPLE = ".env.images.example";
+export const LOCAL_STACK_ENV_FILE = ".env";
+
+const REQUIRED_SECRETS = [
+  "POSTGRES_PASSWORD",
+  "BETTER_AUTH_SECRET",
+  "ENCRYPTION_KEY",
+  "SCREEN_PROXY_SECRET",
+  "SANDBOX_SUPERVISOR_TOKEN",
+] as const;
+
+export type LocalStackProgress = (message: string) => void;
+
+export type LocalStackResult =
+  | { ok: true; url: string; attached: boolean }
+  | { ok: false; error: string };
+
+export type LocalStackRunner = (input: {
+  command: string;
+  args: string[];
+  cwd: string;
+}) => Promise<{ code: number; stdout: string; stderr: string }>;
+
+export type LocalStackDeps = {
+  userDataDir: string;
+  templateDir?: string;
+  packaged?: boolean;
+  resourcesPath?: string;
+  platform?: NodeJS.Platform;
+  runner?: LocalStackRunner;
+  onProgress?: LocalStackProgress;
+};
+
+/** True when the address is the default published-images loopback URL. */
+export function isDefaultLocalStackUrl(url: string): boolean {
+  try {
+    return new URL(url).origin === new URL(DEFAULT_LOCAL_WEB_URL).origin;
+  } catch {
+    return false;
+  }
+}
+
+export function dockerDesktopInstallUrl(platform: NodeJS.Platform = process.platform): string {
+  if (platform === "linux") return "https://docs.docker.com/engine/install/";
+  return "https://www.docker.com/products/docker-desktop/";
+}
+
+export function resolveLocalStackTemplateDir(input: {
+  packaged?: boolean;
+  resourcesPath?: string;
+  moduleDir?: string;
+}): string {
+  if (input.packaged) {
+    return path.join(input.resourcesPath ?? process.resourcesPath, LOCAL_STACK_DIR_NAME);
+  }
+  const moduleDir = input.moduleDir ?? path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(moduleDir, "../../../infra/compose");
+}
+
+export function localStackDataDir(userDataDir: string): string {
+  return path.join(userDataDir, LOCAL_STACK_DIR_NAME);
+}
+
+/** Fill blank required secrets from the published-images env example. */
+export function fillLocalStackEnv(example: string, existing: string | null): string {
+  const prior = new Map<string, string>();
+  if (existing !== null) {
+    for (const line of existing.split(/\r?\n/)) {
+      const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+      if (match) prior.set(match[1]!, match[2]!);
+    }
+  }
+
+  const secrets = new Map<string, string>();
+  for (const name of REQUIRED_SECRETS) {
+    const kept = prior.get(name)?.trim();
+    secrets.set(
+      name,
+      kept && kept.length > 0
+        ? kept
+        : randomBytes(name === "POSTGRES_PASSWORD" ? 16 : 32).toString("hex"),
+    );
+  }
+
+  const source = existing !== null && existing.trim() !== "" ? existing : example;
+  const lines = source.split(/\r?\n/).map((line) => {
+    for (const name of REQUIRED_SECRETS) {
+      if (line === `${name}=` || line.startsWith(`${name}=`)) {
+        const current = line.slice(name.length + 1).trim();
+        if (current === "") return `${name}=${secrets.get(name)}`;
+      }
+    }
+    return line;
+  });
+
+  for (const name of REQUIRED_SECRETS) {
+    if (!lines.some((line) => line.startsWith(`${name}=`))) {
+      lines.push(`${name}=${secrets.get(name)}`);
+    }
+  }
+
+  return `${lines.join("\n").replace(/\n*$/, "")}\n`;
+}
+
+export async function ensureLocalStackFiles(input: {
+  dataDir: string;
+  templateDir: string;
+}): Promise<void> {
+  await mkdir(input.dataDir, { recursive: true });
+  const composeDest = path.join(input.dataDir, LOCAL_STACK_COMPOSE_FILE);
+  const exampleDest = path.join(input.dataDir, LOCAL_STACK_ENV_EXAMPLE);
+  const envDest = path.join(input.dataDir, LOCAL_STACK_ENV_FILE);
+
+  await copyFile(path.join(input.templateDir, LOCAL_STACK_COMPOSE_FILE), composeDest);
+  await copyFile(path.join(input.templateDir, LOCAL_STACK_ENV_EXAMPLE), exampleDest);
+
+  const example = await readFile(exampleDest, "utf8");
+  let existing: string | null = null;
+  try {
+    existing = await readFile(envDest, "utf8");
+  } catch {
+    existing = null;
+  }
+  const next = fillLocalStackEnv(example, existing);
+  if (existing !== next) {
+    await writeFile(envDest, next, { encoding: "utf8", mode: 0o600 });
+  }
+}
+
+async function defaultRunner(input: {
+  command: string;
+  args: string[];
+  cwd: string;
+}): Promise<{ code: number; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(input.command, input.args, {
+      cwd: input.cwd,
+      env: process.env,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+export async function detectDocker(
+  runner: LocalStackRunner,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const version = await runner({
+      command: "docker",
+      args: ["version", "--format", "{{.Server.Version}}"],
+      cwd: process.cwd(),
+    });
+    if (version.code !== 0) {
+      return {
+        ok: false,
+        error: `Docker is required for This computer. Install Docker Desktop, then try again. ${dockerDesktopInstallUrl()}`,
+      };
+    }
+    const compose = await runner({
+      command: "docker",
+      args: ["compose", "version"],
+      cwd: process.cwd(),
+    });
+    if (compose.code !== 0) {
+      return {
+        ok: false,
+        error: "Docker Compose is required for This computer. Update Docker Desktop, then try again.",
+      };
+    }
+    return { ok: true };
+  } catch {
+    return {
+      ok: false,
+      error: `Docker is required for This computer. Install Docker Desktop, then try again. ${dockerDesktopInstallUrl()}`,
+    };
+  }
+}
+
+/**
+ * Ensure the published-images Compose stack is running on this machine.
+ * Attaches when containers already exist; creates secrets and pulls on first use.
+ */
+export async function ensureLocalStack(deps: LocalStackDeps): Promise<LocalStackResult> {
+  const onProgress = deps.onProgress ?? (() => undefined);
+  const runner = deps.runner ?? defaultRunner;
+  const platform = deps.platform ?? process.platform;
+  const dataDir = localStackDataDir(deps.userDataDir);
+  const templateDir =
+    deps.templateDir ??
+    resolveLocalStackTemplateDir({
+      packaged: deps.packaged,
+      resourcesPath: deps.resourcesPath,
+    });
+
+  onProgress("Checking Docker…");
+  const docker = await detectDocker(runner);
+  if (!docker.ok) {
+    const installUrl = dockerDesktopInstallUrl(platform);
+    return {
+      ok: false,
+      error: docker.error.includes(installUrl) ? docker.error : `${docker.error} ${installUrl}`,
+    };
+  }
+
+  try {
+    await access(path.join(templateDir, LOCAL_STACK_COMPOSE_FILE));
+    await access(path.join(templateDir, LOCAL_STACK_ENV_EXAMPLE));
+  } catch {
+    return {
+      ok: false,
+      error: "Desktop is missing the local server bundle. Reinstall Rakazo, then try again.",
+    };
+  }
+
+  onProgress("Preparing local server files…");
+  try {
+    await ensureLocalStackFiles({ dataDir, templateDir });
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Could not prepare the local server. ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const composeArgs = [
+    "compose",
+    "-p",
+    LOCAL_STACK_PROJECT_NAME,
+    "--env-file",
+    LOCAL_STACK_ENV_FILE,
+    "-f",
+    LOCAL_STACK_COMPOSE_FILE,
+  ];
+
+  onProgress("Checking for a running local server…");
+  const ps = await runner({
+    command: "docker",
+    args: [...composeArgs, "ps", "-q"],
+    cwd: dataDir,
+  });
+  const alreadyRunning = ps.code === 0 && ps.stdout.trim() !== "";
+
+  if (!alreadyRunning) {
+    onProgress("Pulling Rakazo images. This can take a few minutes the first time…");
+    const pull = await runner({
+      command: "docker",
+      args: [...composeArgs, "pull"],
+      cwd: dataDir,
+    });
+    if (pull.code !== 0) {
+      return {
+        ok: false,
+        error: summarizeDockerFailure("Could not download Rakazo images.", pull.stderr || pull.stdout),
+      };
+    }
+  }
+
+  onProgress(
+    alreadyRunning
+      ? "Starting local server…"
+      : "Starting local server and waiting until it is healthy…",
+  );
+  const upHelp = await runner({
+    command: "docker",
+    args: ["compose", "up", "--help"],
+    cwd: dataDir,
+  });
+  const supportsWaitTimeout =
+    upHelp.stdout.includes("--wait-timeout") || upHelp.stderr.includes("--wait-timeout");
+  const upArgs = supportsWaitTimeout
+    ? [...composeArgs, "up", "-d", "--wait", "--wait-timeout", "300"]
+    : [...composeArgs, "up", "-d"];
+  const up = await runner({
+    command: "docker",
+    args: upArgs,
+    cwd: dataDir,
+  });
+  if (up.code !== 0) {
+    return {
+      ok: false,
+      error: summarizeDockerFailure("Could not start the local Rakazo server.", up.stderr || up.stdout),
+    };
+  }
+
+  return { ok: true, url: DEFAULT_LOCAL_WEB_URL, attached: alreadyRunning };
+}
+
+function summarizeDockerFailure(prefix: string, detail: string): string {
+  const trimmed = detail.trim().replace(/\s+/g, " ");
+  if (trimmed === "") return prefix;
+  const short = trimmed.length > 240 ? `${trimmed.slice(0, 240)}…` : trimmed;
+  return `${prefix} ${short}`;
+}

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -292,13 +292,12 @@ export async function ensureLocalStack(deps: LocalStackDeps): Promise<LocalStack
     cwd: dataDir,
   });
   const helpText = `${upHelp.stdout}\n${upHelp.stderr}`;
-  const supportsWait = helpText.includes("--wait");
+  // Only use Compose --wait when --wait-timeout is also available. Bare --wait
+  // can hang forever if a service never becomes healthy.
   const supportsWaitTimeout = helpText.includes("--wait-timeout");
   const upArgs = supportsWaitTimeout
     ? [...composeArgs, "up", "-d", "--wait", "--wait-timeout", "300"]
-    : supportsWait
-      ? [...composeArgs, "up", "-d", "--wait"]
-      : [...composeArgs, "up", "-d"];
+    : [...composeArgs, "up", "-d"];
   const up = await runner({
     command: "docker",
     args: upArgs,
@@ -314,8 +313,8 @@ export async function ensureLocalStack(deps: LocalStackDeps): Promise<LocalStack
     };
   }
 
-  // Older Compose builds can start containers without blocking on healthchecks.
-  if (!supportsWait) {
+  // Without a timed Compose wait, poll health with our own deadline.
+  if (!supportsWaitTimeout) {
     onProgress("Waiting for the local server to become healthy…");
     const healthy = await waitForLocalStackHealthy(DEFAULT_LOCAL_WEB_URL, onProgress);
     if (!healthy) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -8,6 +8,7 @@ import {
   type ElectronAutoUpdater,
   LAUNCH_CHECK_DELAY_MS,
 } from "./auto-update.js";
+import { ensureLocalStack, isDefaultLocalStackUrl } from "./local-stack.js";
 import { oauthCallbackFrom } from "./oauth-callback.js";
 import {
   bundledRendererCandidates,
@@ -28,7 +29,6 @@ import {
   sessionPartitionForServerUrl,
 } from "./setup-config.js";
 import { clearSetup, readSetup, writeSetup } from "./setup-store.js";
-import { ensureLocalStack, isDefaultLocalStackUrl } from "./local-stack.js";
 import { shouldOpenInAppPopup } from "./window-open.js";
 import { browserWindowOptions, setupWindowOptions, warmWindowTtlMs } from "./window-options.js";
 
@@ -600,16 +600,13 @@ function fromSetupWindow(event: Electron.IpcMainInvokeEvent) {
   );
 }
 
-
 function emitSetupProgress(message: string) {
   if (setupWindow !== null && !setupWindow.isDestroyed()) {
     setupWindow.webContents.send("desktop.setup.progress", message);
   }
 }
 
-async function ensureReachableServer(
-  setup: DesktopSetup,
-): Promise<DesktopReachability> {
+async function ensureReachableServer(setup: DesktopSetup): Promise<DesktopReachability> {
   let reachability = await probeServer(setup.serverUrl);
   if (reachability.ok) return reachability;
   if (setup.mode !== "new" || !isDefaultLocalStackUrl(setup.serverUrl)) {
@@ -627,7 +624,9 @@ async function ensureReachableServer(
   }
 
   emitSetupProgress(
-    started.attached ? "Local server is running. Connecting…" : "Local server is ready. Connecting…",
+    started.attached
+      ? "Local server is running. Connecting…"
+      : "Local server is ready. Connecting…",
   );
   reachability = await probeServer(setup.serverUrl);
   return reachability;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -28,6 +28,7 @@ import {
   sessionPartitionForServerUrl,
 } from "./setup-config.js";
 import { clearSetup, readSetup, writeSetup } from "./setup-store.js";
+import { ensureLocalStack, isDefaultLocalStackUrl } from "./local-stack.js";
 import { shouldOpenInAppPopup } from "./window-open.js";
 import { browserWindowOptions, setupWindowOptions, warmWindowTtlMs } from "./window-options.js";
 
@@ -599,6 +600,39 @@ function fromSetupWindow(event: Electron.IpcMainInvokeEvent) {
   );
 }
 
+
+function emitSetupProgress(message: string) {
+  if (setupWindow !== null && !setupWindow.isDestroyed()) {
+    setupWindow.webContents.send("desktop.setup.progress", message);
+  }
+}
+
+async function ensureReachableServer(
+  setup: DesktopSetup,
+): Promise<DesktopReachability> {
+  let reachability = await probeServer(setup.serverUrl);
+  if (reachability.ok) return reachability;
+  if (setup.mode !== "new" || !isDefaultLocalStackUrl(setup.serverUrl)) {
+    return reachability;
+  }
+
+  const started = await ensureLocalStack({
+    userDataDir: app.getPath("userData"),
+    packaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    onProgress: emitSetupProgress,
+  });
+  if (!started.ok) {
+    return { ok: false, url: setup.serverUrl, error: started.error };
+  }
+
+  emitSetupProgress(
+    started.attached ? "Local server is running. Connecting…" : "Local server is ready. Connecting…",
+  );
+  reachability = await probeServer(setup.serverUrl);
+  return reachability;
+}
+
 async function probeServer(rawUrl: string): Promise<DesktopReachability> {
   const url = normalizeServerUrl(rawUrl);
   if (url === null) return { ok: false, error: "Enter a valid http:// or https:// address." };
@@ -926,7 +960,7 @@ app.whenReady().then(async () => {
         };
       }
 
-      const reachability = await probeServer(setup.serverUrl);
+      const reachability = await ensureReachableServer(setup);
       if (!reachability.ok) return { ok: false, error: reachability.error };
 
       // Open before persisting so a failed renderer load keeps the last working setup.
@@ -1009,7 +1043,8 @@ app.whenReady().then(async () => {
   if (target.kind === "setup") {
     showSetupWindow();
   } else if (target.source === "saved") {
-    const reachability = await probeServer(target.url);
+    const savedSetup = currentSetup ?? { mode: "existing" as const, serverUrl: target.url };
+    const reachability = await ensureReachableServer(savedSetup);
     if (reachability.ok) {
       if (await openApp(target.url)) {
         commitPendingAppSwitch();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -628,7 +628,13 @@ async function ensureReachableServer(setup: DesktopSetup): Promise<DesktopReacha
       ? "Local server is running. Connecting…"
       : "Local server is ready. Connecting…",
   );
-  reachability = await probeServer(setup.serverUrl);
+  // Give the web origin a short window after Compose reports ready.
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    reachability = await probeServer(setup.serverUrl);
+    if (reachability.ok) return reachability;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
   return reachability;
 }
 

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -94,7 +94,7 @@ describe("setup preload bridge", () => {
     expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
     const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoSetup];
     expect(globalName).toBe("rakazoSetup");
-    expect(Object.keys(bridge).sort()).toEqual(["quit", "save", "state", "test"]);
+    expect(Object.keys(bridge).sort()).toEqual(["onProgress", "quit", "save", "state", "test"]);
 
     await bridge.state();
     await bridge.test("http://127.0.0.1:5173");

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { isIP } from "node:net";
 import type { DesktopSetup } from "@rakazo/contracts";
 
-/** Where `pnpm dev` serves the Rakazo web app on this machine. */
+/** Default loopback origin for a local Rakazo server on this machine. */
 export const DEFAULT_LOCAL_WEB_URL = "http://127.0.0.1:5173";
 
 export const SETUP_FILE_NAME = "setup.json";

--- a/apps/desktop/src/setup-preload.cjs
+++ b/apps/desktop/src/setup-preload.cjs
@@ -5,4 +5,11 @@ contextBridge.exposeInMainWorld("rakazoSetup", {
   test: (url) => ipcRenderer.invoke("desktop.setup.test", url),
   save: (setup) => ipcRenderer.invoke("desktop.setup.save", setup),
   quit: () => ipcRenderer.invoke("desktop.setup.quit"),
+  onProgress: (listener) => {
+    const handler = (_event, message) => {
+      if (typeof message === "string") listener(message);
+    };
+    ipcRenderer.on("desktop.setup.progress", handler);
+    return () => ipcRenderer.removeListener("desktop.setup.progress", handler);
+  },
 });

--- a/apps/desktop/src/setup.html
+++ b/apps/desktop/src/setup.html
@@ -43,7 +43,7 @@
         <section id="panel-new" class="panel">
           <label class="field-label" for="local-url">Local address</label>
           <input id="local-url" class="field" type="text" spellcheck="false" autocomplete="off" />
-          <p class="hint">If it isn’t running yet, start with <code>pnpm dev</code>.</p>
+          <p class="hint">Starts a local server with Docker if one is not already running.</p>
         </section>
 
         <section id="panel-existing" class="panel" hidden>

--- a/apps/desktop/src/setup.js
+++ b/apps/desktop/src/setup.js
@@ -86,13 +86,20 @@
     const value = activeField().value;
 
     setBusy(true);
-    setStatus("Connecting…");
+    setStatus(mode === "new" ? "Starting local server…" : "Connecting…");
+    const stopProgress =
+      typeof bridge.onProgress === "function"
+        ? bridge.onProgress((message) => {
+            setStatus(message);
+          })
+        : null;
     try {
       const saved = await bridge.save({ mode, serverUrl: value });
       if (!saved.ok) setStatus(saved.error ?? "Could not save that address.", "error");
     } catch {
       setStatus("Could not save that address. Try again.", "error");
     } finally {
+      stopProgress?.();
       setBusy(false);
     }
   });

--- a/apps/www/e2e/marketing-homepage.spec.ts
+++ b/apps/www/e2e/marketing-homepage.spec.ts
@@ -19,9 +19,13 @@ test.describe("marketing homepage", () => {
     const selfHost = page.locator("#selfhost");
     await expect(selfHost).toBeVisible();
     await expect(selfHost.getByRole("heading", { level: 2 })).toBeVisible();
+    await expect(selfHost.getByRole("link", { name: /Download/i })).toBeVisible();
     await expect(selfHost.getByRole("button", { name: /Get started/i })).toBeVisible();
-    await expect(selfHost.getByRole("link", { name: /View on GitHub/i })).toBeVisible();
     await expect(selfHost.getByRole("link", { name: /Read the docs/i })).toBeVisible();
+    await expect(selfHost.getByRole("link", { name: /Download/i })).toHaveAttribute(
+      "href",
+      /github\.com\/elie222\/rakazo\/releases/,
+    );
 
     await expect(selfHost.locator("pre")).toHaveCount(0);
     await expect(selfHost).not.toContainText(

--- a/apps/www/src/components/HomePage.astro
+++ b/apps/www/src/components/HomePage.astro
@@ -15,6 +15,7 @@ import {
 import { fetchGithubStars, formatStarCount } from "../github";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import {
+  CHANGELOG_URL,
   DOCS_URL,
   GITHUB_URL,
   SETUP_PROMPT_URL,
@@ -131,6 +132,7 @@ const structuredData = {
           <button class="button button--primary" type="button" data-get-started-open>
             {copy.hero.getStarted}
           </button>
+          <Button href={CHANGELOG_URL} variant="secondary" external>{copy.hero.download}</Button>
           <Button href={GITHUB_URL} variant="secondary" external>{copy.hero.viewOnGithub}</Button>
         </div>
         <div class="hero__agent-setup">
@@ -165,10 +167,10 @@ const structuredData = {
           </p>
         </div>
         <div class="selfhost-cta">
-          <button class="button button--primary" type="button" data-get-started-open>
+          <Button href={CHANGELOG_URL} variant="primary" external>{copy.hero.download}</Button>
+          <button class="button button--secondary" type="button" data-get-started-open>
             {copy.hero.getStarted}
           </button>
-          <Button href={GITHUB_URL} variant="secondary" external>{copy.hero.viewOnGithub}</Button>
           <Button href={DOCS_URL} variant="secondary" external>{copy.openSource.readTheDocs}</Button>
         </div>
         <div class="card-grid-3">

--- a/apps/www/src/i18n/home.ts
+++ b/apps/www/src/i18n/home.ts
@@ -25,6 +25,7 @@ export type HomeCopy = {
     heading: string;
     lead: string;
     getStarted: string;
+    download: string;
     viewOnGithub: string;
     setupWithAgent: string;
     copiedForAgent: string;
@@ -225,6 +226,7 @@ const HOME_COPY: Record<Locale, HomeCopy> = {
       heading: "AI teammates you actually own",
       lead: "Rakazo is an open source Grok Bot alternative. Give a bot real work. It signs in to your tools, uses them the way you do, and comes back when it needs you.",
       getStarted: "Get started",
+      download: "Download",
       viewOnGithub: "View on GitHub",
       setupWithAgent: "Set up with your agent",
       copiedForAgent: "Copied for your agent",
@@ -300,7 +302,7 @@ const HOME_COPY: Record<Locale, HomeCopy> = {
       title: "How do you want to start?",
       copy: "Self-host on your machine, or join the Cloud waitlist.",
       selfHostNow: "Self-host now",
-      selfHostHint: "Install steps are in the docs.",
+      selfHostHint: "Download the desktop app, or see the docs.",
       cloudWaitlist: "Cloud waitlist",
       cloudHint: "Hosted Rakazo is coming. Leave your email.",
       back: "Back",
@@ -349,6 +351,7 @@ const HOME_COPY: Record<Locale, HomeCopy> = {
       heading: "KI-Teamkollegen, die dir wirklich gehören",
       lead: "Rakazo ist eine Open-Source-Alternative zu Grok Bot. Gib einem Bot echte Arbeit. Er meldet sich in deinen Tools an, nutzt sie wie du — und kommt zurück, wenn er dich braucht.",
       getStarted: "Loslegen",
+      download: "Download",
       viewOnGithub: "Auf GitHub ansehen",
       setupWithAgent: "Mit deinem Agenten einrichten",
       copiedForAgent: "Für deinen Agenten kopiert",
@@ -424,7 +427,7 @@ const HOME_COPY: Record<Locale, HomeCopy> = {
       title: "Wie willst du starten?",
       copy: "Self-host auf deiner Maschine, oder auf die Cloud-Warteliste.",
       selfHostNow: "Jetzt self-hosten",
-      selfHostHint: "Installationsschritte stehen in den Docs.",
+      selfHostHint: "Desktop-App herunterladen oder Docs lesen.",
       cloudWaitlist: "Cloud-Warteliste",
       cloudHint: "Gehostetes Rakazo kommt. Hinterlasse deine E-Mail.",
       back: "Zurück",
@@ -472,6 +475,7 @@ const HOME_COPY: Record<Locale, HomeCopy> = {
       heading: "진짜로 내 것인 AI 팀원",
       lead: "Rakazo는 오픈소스 Grok Bot 대안입니다. 봇에게 실제 업무를 맡기세요. 봇이 도구에 로그인하고, 당신처럼 사용하며, 필요할 때 돌아와 묻습니다.",
       getStarted: "시작하기",
+      download: "다운로드",
       viewOnGithub: "GitHub에서 보기",
       setupWithAgent: "에이전트로 설정하기",
       copiedForAgent: "에이전트용으로 복사됨",
@@ -547,7 +551,7 @@ const HOME_COPY: Record<Locale, HomeCopy> = {
       title: "어떻게 시작할까요?",
       copy: "당신 머신에서 셀프 호스트하거나, Cloud 대기열에 등록하세요.",
       selfHostNow: "지금 셀프 호스트",
-      selfHostHint: "설치 단계는 문서에 있습니다.",
+      selfHostHint: "데스크톱 앱을 받거나 문서를 보세요.",
       cloudWaitlist: "Cloud 대기열",
       cloudHint: "호스팅 Rakazo가 곧 옵니다. 이메일을 남겨 주세요.",
       back: "뒤로",

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -2,6 +2,14 @@
 
 The signed-in product is a long-running API, a Graphile Worker, Postgres, and a computer provider (Docker supervisor, E2B, Daytona, or Box). It is not a static site. The marketing site in `apps/www` can be hosted separately.
 
+## Desktop app
+
+Download the Mac, Windows, or Linux installer from [GitHub Releases](https://github.com/elie222/rakazo/releases).
+On first launch, choose **This computer** to start a local server with Docker, or connect to a server you already run.
+After the app opens, create an account and add model keys in Settings if you want them.
+
+Install details for a headless server stay below. Do not put Compose one-liners on the marketing homepage.
+
 ## Local (source checkout)
 
 Same as the README quick start: `.env` from `.env.example`, Postgres via Compose, `pnpm sandbox:build`, `pnpm dev`, then [http://127.0.0.1:5173](http://127.0.0.1:5173). Electron: `pnpm --filter @rakazo/desktop dev` while that stack is up.

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -87,4 +87,6 @@ export interface RakazoSetup {
   test: (url: string) => Promise<DesktopReachability>;
   save: (setup: DesktopSetup) => Promise<{ ok: boolean; error?: string }>;
   quit: () => Promise<void>;
+  /** Status lines while This computer starts or attaches to the local stack. */
+  onProgress: (listener: (message: string) => void) => () => void;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Discord (insurgent25 / Elie): users should download a desktop app, and choosing This computer should run the server on the same machine without a separate remote. Getting started should not ask people to run openssl/sed/curl by hand.

Closes #507.

## What changed

- **This computer** on first launch starts or attaches to the published-images Compose stack via Docker, generating secrets automatically. If Docker is missing, the UI says so and points at Docker Desktop install docs.
- **Connect to an existing server** is unchanged (HTTPS public; HTTP loopback/private LAN).
- Desktop packages the Compose template + env example into `extraResources` for packaged builds.
- Homepage/docs get a short **Download** CTA to GitHub Releases (no Compose one-liner on rakazo.com).
- Setup copy no longer tells users to run `pnpm --filter`.
- Desktop updater stays electron-updater against GitHub Releases. No production `vX.Y.Z` tag from this PR.

Bot computers: Docker remains the default isolated desktop when available; This Mac / this-computer host provider stays the explicit HostComputerPrompt choice.

## How tested

- `pnpm --filter @rakazo/desktop check`
- `pnpm --filter @rakazo/desktop test` (includes local-stack unit tests + Compose `--wait` without `--wait-timeout` regression)
- `pnpm --filter @rakazo/desktop test:e2e` (first-launch setup UI asserts Docker hint; existing-server path unchanged)
- `pnpm --filter @rakazo/www check`
- `pnpm --filter @rakazo/contracts test`
- CI: Lint, Typecheck, Unit tests, Postgres journeys, Production builds (includes Electron e2e), Web E2E

## Screenshots

Marketing Download CTA from Web E2E ([run 33686882020](https://github.com/elie222/rakazo/actions/runs/33686882020)):

<img alt="Marketing self-host Download CTA" src="https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33686882020-1/screenshots/images/002-01-marketing-homepage-selfhost.png" />

<img alt="Marketing get started dialog" src="https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33686882020-1/screenshots/images/008-02-marketing-get-started.png" />

[Screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/509/index.html)

Desktop first-launch setup is covered by Electron e2e in Production builds; those frames are not published in the web Playwright gallery, so no desktop setup image is linked here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b710765-947d-4c98-ad32-728d6aa1f725?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b710765-947d-4c98-ad32-728d6aa1f725&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Desktop setup can automatically start the local server with Docker when no server is detected.
  - Setup displays live progress while starting or connecting to the local server.
  - The packaged app includes the files needed to run the local stack.
  - Marketing pages now feature download and changelog links.

- **Documentation**
  - Added desktop app installation and self-hosting guidance.
  - Updated setup messaging and localized self-hosting hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->