### PR TITLE
Align sidebar Search to selected conversation row width

### DIFF
--- a/apps/web/e2e/ui-appearance.spec.ts
+++ b/apps/web/e2e/ui-appearance.spec.ts
@@ -1,5 +1,48 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+async function captureSidebarSearchSelected(
+  page: Page,
+  testInfo: Parameters<typeof captureScreenshot>[1],
+  name: string,
+) {
+  const aside = page.locator("aside").first();
+  const search = aside.getByTestId("sidebar-search");
+  const selected = aside.getByRole("button", { name: /^Chief/ }).first();
+  await expect(search).toBeVisible();
+  await expect(selected).toBeVisible();
+  await search.scrollIntoViewIfNeeded();
+
+  const searchBox = await search.boundingBox();
+  const selectedBox = await selected.boundingBox();
+  expect(searchBox).toBeTruthy();
+  expect(selectedBox).toBeTruthy();
+  if (searchBox && selectedBox) {
+    expect(Math.abs(searchBox.x - selectedBox.x)).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(searchBox.x + searchBox.width - (selectedBox.x + selectedBox.width)),
+    ).toBeLessThanOrEqual(1);
+  }
+
+  const box = await aside.boundingBox();
+  if (box) {
+    const screenshotPath = testInfo.outputPath(`${name}.png`);
+    await page.screenshot({
+      animations: "disabled",
+      caret: "hide",
+      path: screenshotPath,
+      clip: {
+        x: Math.max(0, box.x),
+        y: Math.max(0, box.y),
+        width: Math.min(box.width + 24, 360),
+        height: Math.min(Math.max(box.height * 0.45, 280), 420),
+      },
+    });
+    await testInfo.attach(name, { contentType: "image/png", path: screenshotPath });
+    return;
+  }
+  await captureScreenshot(page, testInfo, name);
+}
 
 test("account settings appearance control switches to light mode", async ({ page }, testInfo) => {
   const stamp = Date.now();
@@ -25,4 +68,15 @@ test("account settings appearance control switches to light mode", async ({ page
   await expect(settings).toBeHidden();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   await captureScreenshot(page, testInfo, "ui-appearance-light-shell");
+  await captureSidebarSearchSelected(page, testInfo, "sidebar-search-selected-light");
+
+  await page.getByTestId("user-menu-trigger").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await expect(settings).toBeVisible();
+  await settings.getByTestId("ui-appearance-dark").click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await settings.getByRole("button", { name: "Close user settings" }).click();
+  await expect(settings).toBeHidden();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await captureSidebarSearchSelected(page, testInfo, "sidebar-search-selected-dark");
 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2421,7 +2421,10 @@ export function ShellPage() {
             ) : null}
           </div>
         </div>
-        <div className="mx-3.5 mb-3 flex items-center gap-2.5 rounded-xl border border-[var(--rk-hairline-strong)] bg-[var(--rk-surface)] px-3 py-2 text-[14px] text-[var(--rk-body)]">
+        <div
+          data-testid="sidebar-search"
+          className="mx-2.5 mb-3 flex items-center gap-2.5 rounded-xl border border-[var(--rk-hairline-strong)] bg-[var(--rk-surface)] px-3 py-2 text-[14px] text-[var(--rk-body)]"
+        >
           <span aria-hidden="true">⌕</span>
           <input
             value={query}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

In light mode, the sidebar Search field is inset more than the selected conversation pill (Chief). They should share the same outer width and horizontal inset.

## What changed

- Search container horizontal margin: `mx-3.5` → `mx-2.5` to match the roster list `px-2.5` (align Search to the selected-row pill)
- `data-testid="sidebar-search"` for E2E
- Extended `ui-appearance` web E2E: assert Search and selected Chief share left/right edges; capture clipped sidebar frames in light and dark

Beautiful UI hand-ports unchanged; no shadcn; AGENTS.md untouched.

## How tested

- Layout assertion in `ui-appearance` E2E (light + dark)
- CI Web E2E ([run 33692688340](https://github.com/elie222/rakazo/actions/runs/33692688340)) on head `b7c6831` (rebased onto `main`)

## CI E2E frames

- [sidebar-search-selected-light](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33692688340-1/screenshots/images/140-sidebar-search-selected-light.png)
- [sidebar-search-selected-dark](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33692688340-1/screenshots/images/139-sidebar-search-selected-dark.png)

[Screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/511/index.html)

Hold merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc70be55-1be7-4c27-868a-be5ff3de5710?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc70be55-1be7-4c27-868a-be5ff3de5710&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the sidebar search spacing for a more compact appearance.
  - Improved visual consistency of the sidebar search across light and dark themes.

- **Tests**
  - Expanded appearance checks to verify sidebar search alignment and selection states in both light and dark themes.
  - Added visual captures to help detect future layout regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->