### PR TITLE
fix: clear stale user computer control blocking reset (#500)

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -26,6 +26,7 @@ import {
   type ComputerExecutionLease,
   type ConnectorRegistry,
   checkpointAndRecordComputerWorkspace,
+  clearInactiveUserComputerControl,
   computerSupportsUpdate,
   createVoiceProvider,
   deletePushToken,
@@ -1534,13 +1535,12 @@ export function createRouter(deps: RouterDeps) {
         if (!bot.computer) throw new IsolationError();
         const controlBotId = bot.computer.controlBotId;
         const controlLeaseId = bot.computer.controlLeaseId;
-        if (
-          !hasActiveComputerControl(bot.computer) ||
-          bot.computer.controlHolder !== "user" ||
-          !controlBotId ||
-          !controlLeaseId ||
-          controlBotId !== bot.id
-        ) {
+        if (bot.computer.controlHolder !== "user" || !controlBotId || controlBotId !== bot.id) {
+          return { ok: true as const };
+        }
+        if (!hasActiveComputerControl(bot.computer) || !controlLeaseId) {
+          // Stale controlHolder=user with no live lease: clear so reset/release recover without DB edits.
+          await clearInactiveUserComputerControl(deps.prisma, bot.computer.id);
           return { ok: true as const };
         }
         if (bot.computer.providerRef) {
@@ -3739,13 +3739,20 @@ async function runComputerReplace(
 async function expireStaleComputerControl(
   deps: RouterDeps,
   computer:
-    | (NonNullable<Parameters<typeof hasActiveComputerControl>[0]> & { id: string })
+    | (NonNullable<Parameters<typeof hasActiveComputerControl>[0]> & {
+        id: string;
+        controlHolder?: string;
+      })
     | null
     | undefined,
 ): Promise<boolean> {
-  const leaseId = computer?.controlLeaseId;
-  if (!leaseId || hasActiveComputerControl(computer)) return false;
-  await expireComputerControl(deps, computer.id, leaseId).catch(() => undefined);
+  if (!computer || hasActiveComputerControl(computer)) return false;
+  if (computer.controlHolder !== "user") return false;
+  const leaseId = computer.controlLeaseId;
+  if (leaseId) {
+    await expireComputerControl(deps, computer.id, leaseId).catch(() => undefined);
+  }
+  await clearInactiveUserComputerControl(deps.prisma, computer.id).catch(() => undefined);
   return true;
 }
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -3756,10 +3756,12 @@ async function expireStaleComputerControl(
   if (!computer || hasActiveComputerControl(computer)) return false;
   if (computer.controlHolder !== "user") return false;
   const leaseId = computer.controlLeaseId;
+  // Keep a failed revoke's lease id so reconciliation can retry provider shutdown.
   if (leaseId) {
     await expireComputerControl(deps, computer.id, leaseId).catch(() => undefined);
+  } else {
+    await clearInactiveUserComputerControl(deps.prisma, computer.id).catch(() => undefined);
   }
-  await clearInactiveUserComputerControl(deps.prisma, computer.id).catch(() => undefined);
   return true;
 }
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1539,7 +1539,12 @@ export function createRouter(deps: RouterDeps) {
           return { ok: true as const };
         }
         if (!hasActiveComputerControl(bot.computer) || !controlLeaseId) {
-          // Stale controlHolder=user with no live lease: clear so reset/release recover without DB edits.
+          // Stale controlHolder=user: revoke provider control when a lease id remains, then clear.
+          if (controlLeaseId) {
+            await expireComputerControl(deps, bot.computer.id, controlLeaseId).catch(
+              () => undefined,
+            );
+          }
           await clearInactiveUserComputerControl(deps.prisma, bot.computer.id);
           return { ok: true as const };
         }

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -3759,10 +3759,9 @@ async function expireStaleComputerControl(
   // Keep a failed revoke's lease id so reconciliation can retry provider shutdown.
   if (leaseId) {
     await expireComputerControl(deps, computer.id, leaseId).catch(() => undefined);
-  } else {
-    await clearInactiveUserComputerControl(deps.prisma, computer.id).catch(() => undefined);
+    return true;
   }
-  return true;
+  return clearInactiveUserComputerControl(deps.prisma, computer.id).catch(() => false);
 }
 
 async function computerScreenContext(

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1539,13 +1539,15 @@ export function createRouter(deps: RouterDeps) {
           return { ok: true as const };
         }
         if (!hasActiveComputerControl(bot.computer) || !controlLeaseId) {
-          // Stale controlHolder=user: revoke provider control when a lease id remains, then clear.
+          // Stale controlHolder=user. Prefer expiry (revokes provider control). If a lease id
+          // remains after a failed revoke, keep it so reconciliation can retry.
           if (controlLeaseId) {
             await expireComputerControl(deps, bot.computer.id, controlLeaseId).catch(
               () => undefined,
             );
+          } else {
+            await clearInactiveUserComputerControl(deps.prisma, bot.computer.id);
           }
-          await clearInactiveUserComputerControl(deps.prisma, bot.computer.id);
           return { ok: true as const };
         }
         if (bot.computer.providerRef) {

--- a/apps/web/e2e/teach-task.spec.ts
+++ b/apps/web/e2e/teach-task.spec.ts
@@ -28,8 +28,9 @@ test("teach a task records interaction and saves a draft", async ({ page }, test
 
   await openButton.click();
   await expect(page.getByRole("button", { name: "Close computer" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Release", exact: true })).toHaveCount(0);
   const chrome = page.getByTestId("computer-chrome");
+  await expect(chrome.getByText("You have control", { exact: true })).toBeVisible();
+  await expect(chrome.getByRole("button", { name: "Release", exact: true })).toBeVisible();
   await expect(chrome.getByTestId("teach-start-button")).toBeVisible();
   const more = chrome.getByTestId("computer-more-button");
   if (await more.isVisible().catch(() => false)) {

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -202,8 +202,11 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
   await expect(page.getByRole("button", { name: "Close computer" })).toBeVisible();
   await expect(chrome.getByText("You have control", { exact: true })).toBeVisible();
   await expect(chrome.getByRole("button", { name: /Take control/i })).toHaveCount(0);
+  await expect(chrome.getByRole("button", { name: "Release", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "49-team-computer-open-after-stop");
-  await rpc(page, "computer/release", { botId: chiefId });
+  await chrome.getByRole("button", { name: "Release", exact: true }).click();
+  // Release closes the overlay and clears control without a DB edit.
+  await expect(page.getByRole("button", { name: "Close computer" })).toHaveCount(0);
 });
 
 async function createBot(page: Page, name: string, mode: "team" | "dedicated") {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3744,8 +3744,11 @@ export function ShellPage() {
               ) : null}
               {recordingSkill ? (
                 <TeachStopButton busy={teachBusy} onStop={stopTeaching} />
-              ) : hasControl && computer?.takeoverRequested ? (
-                <ComputerReleaseActions takeoverRequested onRelease={releaseComputer} />
+              ) : hasControl ? (
+                <ComputerReleaseActions
+                  takeoverRequested={Boolean(computer?.takeoverRequested)}
+                  onRelease={releaseComputer}
+                />
               ) : null}
               {active && !recordingSkill ? (
                 <TeachComputerOverlayControl

--- a/packages/adapters/src/computer-control.test.ts
+++ b/packages/adapters/src/computer-control.test.ts
@@ -190,9 +190,15 @@ describe("computer control leases", () => {
     });
   });
 
-  it("clears orphaned user control when expiry has no control bot id", async () => {
+  it("revokes then clears orphaned user control when expiry has no control bot id", async () => {
     const harness = controlHarness({ controlBotId: null });
     await expect(expireComputerControl(harness.deps, "computer-id", "lease-1")).resolves.toBe(true);
+    expect(harness.setScreenControl).toHaveBeenCalledWith(
+      expect.objectContaining({ providerRef: "computer" }),
+      false,
+      expect.objectContaining({ operationId: "computer.control-expire" }),
+      "lease-1",
+    );
     expect(harness.prisma.computer.updateMany).toHaveBeenCalledWith({
       where: {
         id: "computer-id",
@@ -211,7 +217,17 @@ describe("computer control leases", () => {
         controlRunId: null,
       },
     });
-    expect(harness.setScreenControl).not.toHaveBeenCalled();
+  });
+
+  it("keeps an orphaned lease when provider revocation fails", async () => {
+    const harness = controlHarness({
+      controlBotId: null,
+      revokeError: new Error("provider unavailable"),
+    });
+    await expect(expireComputerControl(harness.deps, "computer-id", "lease-1")).resolves.toBe(
+      false,
+    );
+    expect(harness.prisma.computer.updateMany).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/adapters/src/computer-control.test.ts
+++ b/packages/adapters/src/computer-control.test.ts
@@ -228,6 +228,7 @@ describe("computer control leases", () => {
       false,
     );
     expect(harness.prisma.computer.updateMany).not.toHaveBeenCalled();
+    expect(harness.enqueue).toHaveBeenCalled();
   });
 });
 

--- a/packages/adapters/src/computer-control.test.ts
+++ b/packages/adapters/src/computer-control.test.ts
@@ -202,12 +202,7 @@ describe("computer control leases", () => {
     expect(harness.prisma.computer.updateMany).toHaveBeenCalledWith({
       where: {
         id: "computer-id",
-        controlHolder: "user",
-        OR: [
-          { controlLeaseId: null },
-          { controlLeaseExpiresAt: null },
-          { controlLeaseExpiresAt: { lte: expect.any(Date) } },
-        ],
+        controlLeaseId: "lease-1",
       },
       data: {
         controlHolder: "none",

--- a/packages/adapters/src/computer-control.test.ts
+++ b/packages/adapters/src/computer-control.test.ts
@@ -2,6 +2,7 @@ import type { BackgroundJob, JobPublisher, SandboxProvider } from "@rakazo/adapt
 import type { PrismaClient, ThreadEvents } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import {
+  clearInactiveUserComputerControl,
   DEFAULT_TAKEOVER_LEASE_MS,
   expireComputerControl,
   extendActiveComputerControl,
@@ -162,6 +163,56 @@ describe("computer control leases", () => {
     expect(harness.setScreenControl).not.toHaveBeenCalled();
     expect(harness.prisma.computer.updateMany).not.toHaveBeenCalled();
   });
+
+  it("clears stale user control when the lease is empty or expired", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const prisma = { computer: { updateMany } } as unknown as PrismaClient;
+    const now = new Date("2026-01-01T00:00:00.000Z");
+
+    await expect(clearInactiveUserComputerControl(prisma, "computer-1", now)).resolves.toBe(true);
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "computer-1",
+        controlHolder: "user",
+        OR: [
+          { controlLeaseId: null },
+          { controlLeaseExpiresAt: null },
+          { controlLeaseExpiresAt: { lte: now } },
+        ],
+      },
+      data: {
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlBotId: null,
+        controlRunId: null,
+      },
+    });
+  });
+
+  it("clears orphaned user control when expiry has no control bot id", async () => {
+    const harness = controlHarness({ controlBotId: null });
+    await expect(expireComputerControl(harness.deps, "computer-id", "lease-1")).resolves.toBe(true);
+    expect(harness.prisma.computer.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "computer-id",
+        controlHolder: "user",
+        OR: [
+          { controlLeaseId: null },
+          { controlLeaseExpiresAt: null },
+          { controlLeaseExpiresAt: { lte: expect.any(Date) } },
+        ],
+      },
+      data: {
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlBotId: null,
+        controlRunId: null,
+      },
+    });
+    expect(harness.setScreenControl).not.toHaveBeenCalled();
+  });
 });
 
 describe("teaching control lease extension", () => {
@@ -218,6 +269,7 @@ function controlHarness(
   options: {
     controlLeaseId?: string;
     controlLeaseExpiresAt?: Date | null;
+    controlBotId?: string | null;
     revokeError?: Error;
     finalizeError?: Error;
     enqueueError?: Error;
@@ -234,7 +286,7 @@ function controlHarness(
     state: "running",
     controlHolder: "user",
     controlLeaseId: options.controlLeaseId ?? "lease-1",
-    controlBotId: "bot",
+    controlBotId: options.controlBotId === undefined ? "bot" : options.controlBotId,
     controlRunId: options.controlRunId ?? options.waitingRunId ?? null,
     executionRunId: options.executionRunId ?? null,
     controlLeaseExpiresAt:

--- a/packages/adapters/src/computer-control.test.ts
+++ b/packages/adapters/src/computer-control.test.ts
@@ -230,6 +230,21 @@ describe("computer control leases", () => {
     expect(harness.prisma.computer.updateMany).not.toHaveBeenCalled();
     expect(harness.enqueue).toHaveBeenCalled();
   });
+
+  it("keeps an orphaned lease when revoke and reschedule both fail", async () => {
+    const harness = controlHarness({
+      controlBotId: null,
+      revokeError: new Error("provider unavailable"),
+      enqueueError: new Error("queue unavailable"),
+    });
+    const logError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await expect(expireComputerControl(harness.deps, "computer-id", "lease-1")).resolves.toBe(
+      false,
+    );
+    expect(harness.prisma.computer.updateMany).not.toHaveBeenCalled();
+    expect(logError).toHaveBeenCalled();
+    logError.mockRestore();
+  });
 });
 
 describe("teaching control lease extension", () => {

--- a/packages/adapters/src/computer-control.ts
+++ b/packages/adapters/src/computer-control.ts
@@ -138,7 +138,10 @@ export async function expireComputerControl(
   if (!computer || computer.controlLeaseId !== leaseId) return false;
   const botId = computer.controlBotId;
   if (!botId) {
-    if (computer.controlLeaseExpiresAt && computer.controlLeaseExpiresAt.getTime() > now.getTime()) {
+    if (
+      computer.controlLeaseExpiresAt &&
+      computer.controlLeaseExpiresAt.getTime() > now.getTime()
+    ) {
       await scheduleComputerControlExpiry(
         deps.jobs,
         computer.id,

--- a/packages/adapters/src/computer-control.ts
+++ b/packages/adapters/src/computer-control.ts
@@ -150,13 +150,18 @@ export async function expireComputerControl(
       try {
         await deps.sandbox.setScreenControl?.(toComputerRef(computer), false, context, leaseId);
       } catch {
-        // Keep the lease id and reschedule; reconciler ignores leases without a control bot.
-        await scheduleComputerControlExpiry(
-          deps.jobs,
-          computer.id,
-          leaseId,
-          new Date(now.getTime() + 30_000),
-        );
+        // Keep the lease id and try to reschedule. Reconciler ignores leases without a
+        // control bot, so a failed enqueue must not escape and clear the lease elsewhere.
+        try {
+          await scheduleComputerControlExpiry(
+            deps.jobs,
+            computer.id,
+            leaseId,
+            new Date(now.getTime() + 30_000),
+          );
+        } catch (error) {
+          console.error("orphan computer control expiry reschedule", error);
+        }
         return false;
       }
     }

--- a/packages/adapters/src/computer-control.ts
+++ b/packages/adapters/src/computer-control.ts
@@ -96,6 +96,33 @@ export async function extendActiveComputerControl(
   return true;
 }
 
+/** Clears controlHolder=user when no live control lease remains (stale / orphaned rows). */
+export async function clearInactiveUserComputerControl(
+  prisma: PrismaClient,
+  computerId: string,
+  now = new Date(),
+): Promise<boolean> {
+  const cleared = await prisma.computer.updateMany({
+    where: {
+      id: computerId,
+      controlHolder: "user",
+      OR: [
+        { controlLeaseId: null },
+        { controlLeaseExpiresAt: null },
+        { controlLeaseExpiresAt: { lte: now } },
+      ],
+    },
+    data: {
+      controlHolder: "none",
+      controlLeaseId: null,
+      controlLeaseExpiresAt: null,
+      controlBotId: null,
+      controlRunId: null,
+    },
+  });
+  return cleared.count === 1;
+}
+
 export async function expireComputerControl(
   deps: {
     prisma: PrismaClient;
@@ -110,7 +137,10 @@ export async function expireComputerControl(
   const computer = await deps.prisma.computer.findUnique({ where: { id: computerId } });
   if (!computer || computer.controlLeaseId !== leaseId) return false;
   const botId = computer.controlBotId;
-  if (!botId) return false;
+  if (!botId) {
+    // Orphaned user control without a bot id cannot revoke the provider or emit events.
+    return clearInactiveUserComputerControl(deps.prisma, computer.id, now);
+  }
 
   if (computer.controlLeaseExpiresAt && computer.controlLeaseExpiresAt.getTime() > now.getTime()) {
     await scheduleComputerControlExpiry(

--- a/packages/adapters/src/computer-control.ts
+++ b/packages/adapters/src/computer-control.ts
@@ -138,7 +138,16 @@ export async function expireComputerControl(
   if (!computer || computer.controlLeaseId !== leaseId) return false;
   const botId = computer.controlBotId;
   if (!botId) {
-    // Orphaned user control: still revoke the provider stream before clearing the lease id.
+    if (computer.controlLeaseExpiresAt && computer.controlLeaseExpiresAt.getTime() > now.getTime()) {
+      await scheduleComputerControlExpiry(
+        deps.jobs,
+        computer.id,
+        leaseId,
+        computer.controlLeaseExpiresAt,
+      );
+      return false;
+    }
+    // Orphaned user control: revoke the provider stream, then clear this lease id.
     if (computer.providerRef) {
       const context: AdapterContext = {
         operationId: "computer.control-expire",
@@ -150,8 +159,7 @@ export async function expireComputerControl(
       try {
         await deps.sandbox.setScreenControl?.(toComputerRef(computer), false, context, leaseId);
       } catch {
-        // Keep the lease id and try to reschedule. Reconciler ignores leases without a
-        // control bot, so a failed enqueue must not escape and clear the lease elsewhere.
+        // Keep the lease id and try to reschedule so reconciler/status can retry.
         try {
           await scheduleComputerControlExpiry(
             deps.jobs,
@@ -165,7 +173,17 @@ export async function expireComputerControl(
         return false;
       }
     }
-    return clearInactiveUserComputerControl(deps.prisma, computer.id, now);
+    const cleared = await deps.prisma.computer.updateMany({
+      where: { id: computer.id, controlLeaseId: leaseId },
+      data: {
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlBotId: null,
+        controlRunId: null,
+      },
+    });
+    return cleared.count === 1;
   }
 
   if (computer.controlLeaseExpiresAt && computer.controlLeaseExpiresAt.getTime() > now.getTime()) {

--- a/packages/adapters/src/computer-control.ts
+++ b/packages/adapters/src/computer-control.ts
@@ -150,7 +150,13 @@ export async function expireComputerControl(
       try {
         await deps.sandbox.setScreenControl?.(toComputerRef(computer), false, context, leaseId);
       } catch {
-        // Keep the lease id so reconciliation can retry provider revocation.
+        // Keep the lease id and reschedule; reconciler ignores leases without a control bot.
+        await scheduleComputerControlExpiry(
+          deps.jobs,
+          computer.id,
+          leaseId,
+          new Date(now.getTime() + 30_000),
+        );
         return false;
       }
     }

--- a/packages/adapters/src/computer-control.ts
+++ b/packages/adapters/src/computer-control.ts
@@ -138,7 +138,22 @@ export async function expireComputerControl(
   if (!computer || computer.controlLeaseId !== leaseId) return false;
   const botId = computer.controlBotId;
   if (!botId) {
-    // Orphaned user control without a bot id cannot revoke the provider or emit events.
+    // Orphaned user control: still revoke the provider stream before clearing the lease id.
+    if (computer.providerRef) {
+      const context: AdapterContext = {
+        operationId: "computer.control-expire",
+        traceId: "computer.control-expire",
+        spaceId: computer.spaceId,
+        userId: computer.userId,
+        signal: new AbortController().signal,
+      };
+      try {
+        await deps.sandbox.setScreenControl?.(toComputerRef(computer), false, context, leaseId);
+      } catch {
+        // Keep the lease id so reconciliation can retry provider revocation.
+        return false;
+      }
+    }
     return clearInactiveUserComputerControl(deps.prisma, computer.id, now);
   }
 

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -903,8 +903,11 @@ describe("computer replacement", () => {
       computer: { findUniqueOrThrow, findUnique, updateMany: vi.fn() },
       run: { findFirst: vi.fn() },
     } as unknown as PrismaClient;
-    const sandbox = new FakeSandboxProvider();
-    sandbox.setScreenControl = vi.fn().mockRejectedValue(new Error("provider unavailable"));
+    const sandbox = Object.assign(new FakeSandboxProvider(), {
+      setScreenControl: async () => {
+        throw new Error("provider unavailable");
+      },
+    }) as SandboxProvider;
 
     await expect(
       replaceComputer(

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -817,6 +817,71 @@ describe("computer replacement", () => {
     ).rejects.toBeInstanceOf(ComputerBusyError);
   });
 
+  it("does not treat stale user control without a lease as busy during reset", async () => {
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 1 }) // clearInactiveUserComputerControl
+      .mockResolvedValueOnce({ count: 0 }); // suspending claim races
+    const findUniqueOrThrow = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: "computer-1",
+        homeKey: "bot-1",
+        providerRef: "provider-1",
+        kind: "fake",
+        scope: "dedicated",
+        state: "running",
+        controlHolder: "user",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlBotId: "bot-1",
+      })
+      .mockResolvedValueOnce({
+        id: "computer-1",
+        homeKey: "bot-1",
+        providerRef: "provider-1",
+        kind: "fake",
+        scope: "dedicated",
+        state: "running",
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlBotId: null,
+      });
+    const prisma = {
+      computer: {
+        findUniqueOrThrow,
+        updateMany,
+      },
+      run: { findFirst: vi.fn() },
+    } as unknown as PrismaClient;
+
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "reset",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+
+    expect(updateMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "computer-1", controlHolder: "user" }),
+        data: expect.objectContaining({ controlHolder: "none" }),
+      }),
+    );
+    expect(updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.run.findFirst).not.toHaveBeenCalled();
+  });
+
   it("rejects replacement when control is claimed before the suspending lock", async () => {
     const prisma = {
       computer: {

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -882,6 +882,47 @@ describe("computer replacement", () => {
     expect(prisma.run.findFirst).not.toHaveBeenCalled();
   });
 
+  it("blocks reset while expired control revocation is still in progress", async () => {
+    const computer = {
+      id: "computer-1",
+      homeKey: "bot-1",
+      providerRef: "provider-1",
+      kind: "fake",
+      scope: "dedicated",
+      state: "running",
+      controlHolder: "user",
+      controlLeaseId: "lease-1",
+      controlLeaseExpiresAt: new Date(Date.now() - 60_000),
+      controlBotId: null,
+      spaceId: "space-1",
+      userId: "user-1",
+    };
+    const findUniqueOrThrow = vi.fn().mockResolvedValue(computer);
+    const findUnique = vi.fn().mockResolvedValue(computer);
+    const prisma = {
+      computer: { findUniqueOrThrow, findUnique, updateMany: vi.fn() },
+      run: { findFirst: vi.fn() },
+    } as unknown as PrismaClient;
+    const sandbox = new FakeSandboxProvider();
+    sandbox.setScreenControl = vi.fn().mockRejectedValue(new Error("provider unavailable"));
+
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox,
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "reset",
+        context,
+      ),
+    ).rejects.toThrow("computer control revocation is still in progress");
+    expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+  });
+
   it("rejects replacement when control is claimed before the suspending lock", async () => {
     const prisma = {
       computer: {

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -915,7 +915,7 @@ describe("computer replacement", () => {
           prisma,
           sandbox,
           home: {} as AgentHomeStore,
-          jobs: {} as JobPublisher,
+          jobs: { enqueue: vi.fn().mockResolvedValue(undefined) } as unknown as JobPublisher,
           events: {} as ThreadEvents,
         },
         "computer-1",

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -8,7 +8,11 @@ import type {
 } from "@rakazo/adapter-kit";
 import { ACTIVE_RUN_STATUSES, screenLeaseId } from "@rakazo/core";
 import { type PrismaClient, parseComputerMode, type ThreadEvents } from "@rakazo/db";
-import { expireComputerControl, hasActiveComputerControl } from "./computer-control.js";
+import {
+  clearInactiveUserComputerControl,
+  expireComputerControl,
+  hasActiveComputerControl,
+} from "./computer-control.js";
 import { toComputerRef } from "./computer-support.js";
 import {
   checkpointAndRecordComputerWorkspace,
@@ -410,7 +414,12 @@ export async function replaceComputer(
   if (existing.controlLeaseId && !hasActiveComputerControl(existing)) {
     await expireComputerControl(deps, existing.id, existing.controlLeaseId);
     existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
-    if (existing.controlLeaseId && !hasActiveComputerControl(existing)) {
+  }
+  // Stale controlHolder=user with an empty/expired lease must not block reset/recover.
+  if (existing.controlHolder === "user" && !hasActiveComputerControl(existing)) {
+    await clearInactiveUserComputerControl(deps.prisma, existing.id);
+    existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
+    if (existing.controlHolder === "user" && !hasActiveComputerControl(existing)) {
       throw new Error("computer control revocation is still in progress");
     }
   }

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -412,11 +412,19 @@ export async function replaceComputer(
 ): Promise<ComputerRef> {
   let existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
   if (existing.controlLeaseId && !hasActiveComputerControl(existing)) {
-    await expireComputerControl(deps, existing.id, existing.controlLeaseId);
+    const expired = await expireComputerControl(deps, existing.id, existing.controlLeaseId);
     existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
+    // Failed provider revoke keeps the lease for retry; do not wipe it and continue reset.
+    if (!expired && existing.controlLeaseId && !hasActiveComputerControl(existing)) {
+      throw new Error("computer control revocation is still in progress");
+    }
   }
-  // Stale controlHolder=user with an empty/expired lease must not block reset/recover.
-  if (existing.controlHolder === "user" && !hasActiveComputerControl(existing)) {
+  // Orphaned controlHolder=user with no lease id can be cleared for reset/recover.
+  if (
+    existing.controlHolder === "user" &&
+    !hasActiveComputerControl(existing) &&
+    !existing.controlLeaseId
+  ) {
     await clearInactiveUserComputerControl(deps.prisma, existing.id);
     existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
     if (existing.controlHolder === "user" && !hasActiveComputerControl(existing)) {

--- a/packages/adapters/src/job-reconciler.test.ts
+++ b/packages/adapters/src/job-reconciler.test.ts
@@ -139,6 +139,33 @@ describe("createJobReconciler", () => {
     );
   });
 
+  it("restores expiry for orphaned user-control leases without a control bot", async () => {
+    const controlExpiresAt = new Date(Date.now() - 5_000);
+    const prisma = fakePrisma(
+      [],
+      [],
+      [
+        {
+          id: "computer-orphan",
+          controlBotId: null,
+          controlLeaseId: "lease-orphan",
+          controlLeaseExpiresAt: controlExpiresAt,
+          updatedAt: new Date(),
+        },
+      ],
+    );
+    const { jobs, enqueue } = publisher();
+
+    await createJobReconciler({ prisma, jobs }).reconcileOnce();
+
+    expect(enqueue).toHaveBeenCalledWith({
+      name: "computer.control-expire",
+      payload: { computerId: "computer-orphan", leaseId: "lease-orphan" },
+      availableAt: controlExpiresAt,
+      replaceKey: "computer.control-expire:computer-orphan:lease-orphan",
+    });
+  });
+
   it("finishes a frozen control scan before admitting leases ahead of its cursor", async () => {
     const firstExpiry = new Date(Date.now() + 10_000);
     const secondExpiry = new Date(Date.now() + 20_000);

--- a/packages/adapters/src/job-reconciler.ts
+++ b/packages/adapters/src/job-reconciler.ts
@@ -291,12 +291,12 @@ export function createJobReconciler(
             : [],
         ),
         ...controls.flatMap((computer) =>
-          computer.controlBotId
+          computer.controlLeaseId
             ? [
                 scheduleComputerControlExpiry(
                   deps.jobs,
                   computer.id,
-                  computer.controlLeaseId!,
+                  computer.controlLeaseId,
                   computer.controlLeaseExpiresAt ?? now,
                 ),
               ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes #500.

A computer could stay `controlHolder=user` after the human was no longer controlling it, even with an empty/expired control lease. Reset then failed with "Computer is busy", and Release only appeared when a bot had requested takeover, so recovery required a Postgres edit.

This change:
- Clears inactive `controlHolder=user` before reset/recover, so a stale holder without a live lease no longer blocks replacement
- Makes `computer/release` clear that same stale state for the owning bot, and still revoke provider screen control when a lease id remains
- Expires/clears orphaned user control when status refresh finds no active lease
- Shows Release whenever the user holds control (not only after `takeoverRequested`)

## Test plan
- [x] `vitest` for `computer-control.test.ts` and `computer-lifecycle.test.ts` (43 tests)
- [x] Typecheck `@rakazo/adapters` and `@rakazo/api`
- [ ] CI web E2E: `team-computer.spec.ts` asserts Release after Open; `teach-task.spec.ts` expects Release while teaching chrome has control (CI frames; no agent screenshots)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dac5ef22-ea2a-4d9e-b274-d5a721bb23d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dac5ef22-ea2a-4d9e-b274-d5a721bb23d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an always-available **Release** button while you hold computer control.
  - When a takeover is pending, the overlay provides **Skip** and **I’m done** actions.

- **Bug Fixes**
  - Fixed stale computer-control states that could block release, replacement, or recovery.
  - Improved cleanup of inactive and expired user control.
  - Preserved active leases while provider-side revocation or cleanup is in progress.
  - Updated overlay behavior after stopping an active Team bot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->