### PR TITLE
feat(adapters): add local-mlx provider for self-hosted MLX OpenAI-compatible servers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ RAKAZO_LOCAL_MODELS=
 RAKAZO_LOCAL_MODELS_URL=http://127.0.0.1:11434/v1
 RAKAZO_LOCAL_CONTEXT_WINDOW=32768
 RAKAZO_LOCAL_MAX_TOKENS=4096
+# Optional dedicated MLX server (mlx-openai-server / Rapid MLX) under its own provider id
+# ("local-mlx"), separate from RAKAZO_LOCAL_MODELS above so an MLX endpoint and an Ollama
+# endpoint can coexist. LOCAL_MLX_MODEL_ID is the model id exactly as the server lists it
+# (typically a filesystem path). Leave LOCAL_MLX_MODEL_ID blank to disable the provider.
+LOCAL_MLX_BASE_URL=http://127.0.0.1:8081/v1
+LOCAL_MLX_MODEL_ID=
 # Allow user-connected OpenAI-compatible endpoints on public hostnames (default: private/loopback only).
 RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=
 E2B_API_KEY=

--- a/packages/adapters/src/executor-approval-pi.test.ts
+++ b/packages/adapters/src/executor-approval-pi.test.ts
@@ -60,6 +60,7 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
 
 vi.mock("./pi-local-provider.js", () => ({
   registerLocalProvider: (models: unknown) => models,
+  registerLocalMlxProvider: (models: unknown) => models,
 }));
 
 vi.mock("./pi-openai-compatible-provider.js", () => ({

--- a/packages/adapters/src/executor-secret-pi.test.ts
+++ b/packages/adapters/src/executor-secret-pi.test.ts
@@ -58,6 +58,7 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
 
 vi.mock("./pi-local-provider.js", () => ({
   registerLocalProvider: (models: unknown) => models,
+  registerLocalMlxProvider: (models: unknown) => models,
 }));
 
 vi.mock("./pi-openai-compatible-provider.js", () => ({

--- a/packages/adapters/src/pi-local-provider.test.ts
+++ b/packages/adapters/src/pi-local-provider.test.ts
@@ -1,8 +1,11 @@
+import { hasApi } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  LOCAL_MLX_PROVIDER_ID,
   LOCAL_PROVIDER_ID,
   localBaseUrl,
+  localMlxProvider,
   localProvider,
   registerLocalProvider,
 } from "./pi-local-provider.js";
@@ -12,6 +15,8 @@ const ENV_KEYS = [
   "RAKAZO_LOCAL_MODELS_URL",
   "RAKAZO_LOCAL_CONTEXT_WINDOW",
   "RAKAZO_LOCAL_MAX_TOKENS",
+  "LOCAL_MLX_BASE_URL",
+  "LOCAL_MLX_MODEL_ID",
 ] as const;
 
 const saved = new Map<string, string | undefined>();
@@ -113,5 +118,33 @@ describe("local model provider", () => {
     setModels("qwen3:4b");
     const withLocal = registerLocalProvider(builtinModels());
     expect(withLocal.getModel(LOCAL_PROVIDER_ID, "qwen3:4b")).toBeDefined();
+  });
+});
+
+describe("local-mlx provider", () => {
+  it("registers a reasoning-capable model at the configured endpoint", () => {
+    process.env.LOCAL_MLX_MODEL_ID = "/models/qwen3.8-27b-4bit";
+    process.env.LOCAL_MLX_BASE_URL = "http://127.0.0.1:8090/v1";
+    const provider = localMlxProvider();
+    expect(provider?.id).toBe(LOCAL_MLX_PROVIDER_ID);
+    const model = provider?.getModels()[0];
+    expect(model?.id).toBe("/models/qwen3.8-27b-4bit");
+    expect(model?.baseUrl).toBe("http://127.0.0.1:8090/v1");
+    expect(model?.reasoning).toBe(true);
+  });
+
+  it("uses the 'system' role and Qwen thinking format mlx-openai-server expects", () => {
+    process.env.LOCAL_MLX_MODEL_ID = "/models/qwen3.8-27b-4bit";
+    const model = localMlxProvider()?.getModels()[0];
+    if (!model || !hasApi(model, "openai-completions")) {
+      throw new Error("expected an openai-completions local-mlx model");
+    }
+    expect(model.compat?.supportsDeveloperRole).toBe(false);
+    expect(model.compat?.thinkingFormat).toBe("qwen-chat-template");
+  });
+
+  it("stays absent when no MLX model id is configured", () => {
+    delete process.env.LOCAL_MLX_MODEL_ID;
+    expect(localMlxProvider()).toBeUndefined();
   });
 });

--- a/packages/adapters/src/pi-local-provider.ts
+++ b/packages/adapters/src/pi-local-provider.ts
@@ -106,6 +106,11 @@ export function registerLocalProvider(models: MutableModels): MutableModels {
   return models;
 }
 
+/**
+ * Provider id for a self-hosted MLX OpenAI-compatible server (mlx-openai-server /
+ * Rapid MLX). Separate from `local` so an MLX endpoint and an Ollama endpoint can
+ * coexist. The endpoint is keyless: `resolve` returns a placeholder header.
+ */
 export const LOCAL_MLX_PROVIDER_ID = "local-mlx";
 
 const LOCAL_MLX_DEFAULT_BASE_URL = "http://127.0.0.1:8081/v1";
@@ -113,13 +118,8 @@ const LOCAL_MLX_CONTEXT_WINDOW = 128_000;
 const LOCAL_MLX_MAX_TOKENS = 8_192;
 
 /**
- * Self-hosted MLX OpenAI-compatible server (e.g. mlx-openai-server / Rapid MLX).
- *
- * Kept as its own provider id so an MLX endpoint can coexist with the generic
- * `local` provider rather than being folded into it. Configured through
- * `LOCAL_MLX_BASE_URL` / `LOCAL_MLX_MODEL_ID`, exactly as before the local-provider
- * refactor. The endpoint is keyless: `resolve` returns a placeholder because the
- * server ignores the header.
+ * The MLX server base URL from `LOCAL_MLX_BASE_URL`, validated to be an absolute
+ * HTTP(S) URL. Defaults to a local mlx-openai-server port.
  */
 function localMlxBaseUrl(): string {
   const value = (process.env.LOCAL_MLX_BASE_URL ?? LOCAL_MLX_DEFAULT_BASE_URL).replace(/\/+$/, "");
@@ -140,6 +140,7 @@ function localMlxModelId(): string {
   return (process.env.LOCAL_MLX_MODEL_ID ?? "").trim();
 }
 
+/** A reasoning-capable openai-completions model with Qwen chat-template thinking. */
 function localMlxModel(id: string, baseUrl: string): Model<"openai-completions"> {
   return {
     id,

--- a/packages/adapters/src/pi-local-provider.ts
+++ b/packages/adapters/src/pi-local-provider.ts
@@ -105,3 +105,91 @@ export function registerLocalProvider(models: MutableModels): MutableModels {
   if (provider) models.setProvider(provider);
   return models;
 }
+
+export const LOCAL_MLX_PROVIDER_ID = "local-mlx";
+
+const LOCAL_MLX_DEFAULT_BASE_URL = "http://127.0.0.1:8081/v1";
+const LOCAL_MLX_CONTEXT_WINDOW = 128_000;
+const LOCAL_MLX_MAX_TOKENS = 8_192;
+
+/**
+ * Self-hosted MLX OpenAI-compatible server (e.g. mlx-openai-server / Rapid MLX).
+ *
+ * Kept as its own provider id so an MLX endpoint can coexist with the generic
+ * `local` provider rather than being folded into it. Configured through
+ * `LOCAL_MLX_BASE_URL` / `LOCAL_MLX_MODEL_ID`, exactly as before the local-provider
+ * refactor. The endpoint is keyless: `resolve` returns a placeholder because the
+ * server ignores the header.
+ */
+function localMlxBaseUrl(): string {
+  const value = (process.env.LOCAL_MLX_BASE_URL ?? LOCAL_MLX_DEFAULT_BASE_URL).replace(/\/+$/, "");
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("LOCAL_MLX_BASE_URL must be an absolute HTTP(S) URL");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("LOCAL_MLX_BASE_URL must be an absolute HTTP(S) URL");
+  }
+  return value;
+}
+
+/** The model id exactly as the MLX server names it, from the environment. */
+function localMlxModelId(): string {
+  return (process.env.LOCAL_MLX_MODEL_ID ?? "").trim();
+}
+
+function localMlxModel(id: string, baseUrl: string): Model<"openai-completions"> {
+  return {
+    id,
+    name: id,
+    api: "openai-completions",
+    provider: LOCAL_MLX_PROVIDER_ID,
+    baseUrl,
+    reasoning: true,
+    compat: {
+      // mlx-openai-server rejects pi's default "developer" system role outright (422);
+      // "system" is the role every such server understands.
+      supportsDeveloperRole: false,
+      // Qwen chat templates read chat_template_kwargs.enable_thinking; without this
+      // the server defaults to reasoning_effort "xhigh" and can burn the whole
+      // maxTokens budget on thinking before ever reaching an answer.
+      thinkingFormat: "qwen-chat-template",
+    },
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: LOCAL_MLX_CONTEXT_WINDOW,
+    maxTokens: LOCAL_MLX_MAX_TOKENS,
+  };
+}
+
+/** The provider, or undefined when no MLX model id is configured. */
+export function localMlxProvider(): Provider | undefined {
+  const modelId = localMlxModelId();
+  if (!modelId) return undefined;
+  const baseUrl = localMlxBaseUrl();
+  return createProvider({
+    id: LOCAL_MLX_PROVIDER_ID,
+    name: "Local MLX server",
+    baseUrl,
+    auth: {
+      apiKey: {
+        name: "Local MLX server",
+        resolve: async () => ({
+          auth: { apiKey: "not-required", baseUrl },
+          source: "local MLX server",
+        }),
+      },
+    },
+    models: [localMlxModel(modelId, baseUrl)],
+    api: openAICompletionsApi(),
+  });
+}
+
+/** Register the local-mlx provider on a Models collection. No-op when unconfigured. */
+export function registerLocalMlxProvider(models: MutableModels): MutableModels {
+  const provider = localMlxProvider();
+  if (provider) models.setProvider(provider);
+  return models;
+}

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -63,6 +63,20 @@ describe("Pi model catalog", () => {
     });
   });
 
+  it("lists a configured local-mlx model in the client catalog", async () => {
+    vi.stubEnv("LOCAL_MLX_MODEL_ID", "/models/qwen3.8-27b-4bit");
+    vi.stubEnv("LOCAL_MLX_BASE_URL", "http://127.0.0.1:8090/v1");
+    vi.resetModules();
+
+    const { listPiCatalog: listConfiguredCatalog } = await import("./pi-models.js");
+    const entries = listConfiguredCatalog().filter((entry) => entry.provider === "local-mlx");
+    expect(entries.map((entry) => entry.id)).toEqual(["/models/qwen3.8-27b-4bit"]);
+    expect(entries[0]).toMatchObject({
+      reasoning: true,
+      billing: expect.stringContaining("MLX server"),
+    });
+  });
+
   it("normalizes a PI_DEFAULT_MODEL id that ends in -latest", async () => {
     vi.stubEnv("PI_DEFAULT_PROVIDER", "openrouter");
     vi.stubEnv("PI_DEFAULT_MODEL", "foo-latest");

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -1,7 +1,12 @@
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import type { ModelOAuthSignInMode, ThinkingLevel } from "@rakazo/contracts";
-import { LOCAL_PROVIDER_ID, registerLocalProvider } from "./pi-local-provider.js";
+import {
+  LOCAL_MLX_PROVIDER_ID,
+  LOCAL_PROVIDER_ID,
+  registerLocalMlxProvider,
+  registerLocalProvider,
+} from "./pi-local-provider.js";
 import { SUBSCRIPTION_SIGN_IN_PROVIDERS } from "./pi-oauth.js";
 import {
   OPENAI_COMPATIBLE_CATALOG_MODEL_ID,
@@ -35,7 +40,9 @@ export function listPiCatalog(): PiCatalogEntry[] {
 let cachedCatalog: PiCatalogEntry[] | undefined;
 
 function buildPiCatalog(): PiCatalogEntry[] {
-  const models = registerOpenAiCompatibleCatalog(registerLocalProvider(builtinModels()));
+  const models = registerOpenAiCompatibleCatalog(
+    registerLocalMlxProvider(registerLocalProvider(builtinModels())),
+  );
   const entries: PiCatalogEntry[] = [];
   for (const provider of models.getProviders()) {
     const apiKey = Boolean(provider.auth.apiKey);
@@ -137,6 +144,9 @@ function catalogBilling(
   if (signInMeta) return signInMeta.billing;
   if (providerId === LOCAL_PROVIDER_ID) {
     return "Runs on infrastructure configured by the deployment owner. No model charges from Rakazo.";
+  }
+  if (providerId === LOCAL_MLX_PROVIDER_ID) {
+    return "Runs on an MLX server configured by the deployment owner. No model charges from Rakazo.";
   }
   if (providerId === OPENAI_COMPATIBLE_PROVIDER_ID) {
     return "Runs on a URL you control. Rakazo does not pay for model usage.";

--- a/packages/adapters/src/pi-runtime-attachments.test.ts
+++ b/packages/adapters/src/pi-runtime-attachments.test.ts
@@ -31,6 +31,7 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
 
 vi.mock("./pi-local-provider.js", () => ({
   registerLocalProvider: (models: unknown) => models,
+  registerLocalMlxProvider: (models: unknown) => models,
 }));
 
 vi.mock("./pi-openai-compatible-provider.js", () => ({

--- a/packages/adapters/src/pi-runtime-choice.test.ts
+++ b/packages/adapters/src/pi-runtime-choice.test.ts
@@ -48,6 +48,7 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
 
 vi.mock("./pi-local-provider.js", () => ({
   registerLocalProvider: (models: unknown) => models,
+  registerLocalMlxProvider: (models: unknown) => models,
 }));
 
 vi.mock("./pi-openai-compatible-provider.js", () => ({

--- a/packages/adapters/src/pi-runtime-computer.test.ts
+++ b/packages/adapters/src/pi-runtime-computer.test.ts
@@ -54,6 +54,7 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
 
 vi.mock("./pi-local-provider.js", () => ({
   registerLocalProvider: (models: unknown) => models,
+  registerLocalMlxProvider: (models: unknown) => models,
 }));
 
 vi.mock("./pi-openai-compatible-provider.js", () => ({

--- a/packages/adapters/src/pi-runtime-error.test.ts
+++ b/packages/adapters/src/pi-runtime-error.test.ts
@@ -20,6 +20,7 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
 
 vi.mock("./pi-local-provider.js", () => ({
   registerLocalProvider: (models: unknown) => models,
+  registerLocalMlxProvider: (models: unknown) => models,
 }));
 
 vi.mock("./pi-openai-compatible-provider.js", () => ({

--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -79,6 +79,7 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
 
 vi.mock("./pi-local-provider.js", () => ({
   registerLocalProvider: (models: unknown) => models,
+  registerLocalMlxProvider: (models: unknown) => models,
 }));
 
 vi.mock("./pi-openai-compatible-provider.js", () => ({

--- a/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
+++ b/packages/adapters/src/pi-runtime-tool-dispatch.test.ts
@@ -131,6 +131,7 @@ vi.mock("@earendil-works/pi-ai/providers/all", () => ({
 
 vi.mock("./pi-local-provider.js", () => ({
   registerLocalProvider: (models: unknown) => models,
+  registerLocalMlxProvider: (models: unknown) => models,
 }));
 
 vi.mock("./pi-openai-compatible-provider.js", () => ({

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -21,7 +21,7 @@ import type {
 import { isToolPauseResult } from "./approval-effect.js";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
 import { PiRuntimeCredentialStore, toOAuthCredential } from "./pi-credentials.js";
-import { registerLocalProvider } from "./pi-local-provider.js";
+import { registerLocalMlxProvider, registerLocalProvider } from "./pi-local-provider.js";
 import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
   registerOpenAiCompatibleCatalog,
@@ -35,7 +35,9 @@ const running = new Map<string, AbortController>();
 // would run before .env is loaded and miss the local provider entirely.
 let catalogModelsCache: Models | undefined;
 function catalogModels(): Models {
-  catalogModelsCache ??= registerOpenAiCompatibleCatalog(registerLocalProvider(builtinModels()));
+  catalogModelsCache ??= registerOpenAiCompatibleCatalog(
+    registerLocalMlxProvider(registerLocalProvider(builtinModels())),
+  );
   return catalogModelsCache;
 }
 const MAX_PARALLEL_SUBAGENTS = 4;


### PR DESCRIPTION
## Why

Rakazo's generic `local` provider (`RAKAZO_LOCAL_MODELS` / `RAKAZO_LOCAL_MODELS_URL`) and the per-user `openai-compatible` connect both target OpenAI-compatible servers, but neither encodes the compatibility settings MLX servers actually require:

- `mlx-openai-server` (and Rapid-MLX) rejects pi's default `"developer"` system role with a `422`; it only accepts `"system"`.
- Qwen chat templates read `chat_template_kwargs.enable_thinking`. Without a thinking-format hint, those servers default to `reasoning_effort: "xhigh"` and can burn the entire `maxTokens` budget on thinking before reaching an answer.

The generic `local` provider sets `reasoning: false` and no `compat`; the `openai-compatible` provider sets `supportsDeveloperRole: false` but disables reasoning and has no thinking-format option. Pointing either at an MLX model misbehaves out of the box. This adds a dedicated, deployment-wide `local-mlx` provider so an MLX endpoint and an Ollama endpoint can coexist, each with the right settings.

## What changed

- `packages/adapters/src/pi-local-provider.ts`: new `local-mlx` provider driven by `LOCAL_MLX_BASE_URL` / `LOCAL_MLX_MODEL_ID`, with `reasoning: true`, `compat: { supportsDeveloperRole: false, thinkingFormat: "qwen-chat-template" }`, a 128k context window, and keyless auth.
- `packages/adapters/src/pi-runtime.ts`: registers the provider in the model catalog alongside the existing providers.
- `.env.example`: documents the two new variables.
- Tests: new cases in `pi-local-provider.test.ts`; eight existing `pi-runtime`/executor test files updated so their `pi-local-provider.js` mocks expose the new export.

## How tested

- `pnpm --filter @rakazo/adapters check` (typecheck) passes.
- Full `@rakazo/adapters` vitest suite passes (982 tests).
- `biome check` clean.
- Manually verified against a running `mlx-openai-server` endpoint (reachable from the containers, generation completes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an optional self-hosted MLX provider with OpenAI-compatible endpoints.
  - Configure it with `LOCAL_MLX_BASE_URL` and `LOCAL_MLX_MODEL_ID`.
  - MLX and Ollama local model providers can run alongside each other.
  - Added reasoning support and MLX-compatible chat formatting.
  - Configured MLX models now appear in the model catalog with dedicated provider labeling.

- **Tests**
  - Added coverage for MLX configuration, registration, model mapping, reasoning support, and disabled-provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->