### PR TITLE
docs(self-host): offline / air-gap boundaries for bootstrap

### DIFF
--- a/docs/self-host-offline-boundaries.md
+++ b/docs/self-host-offline-boundaries.md
@@ -40,12 +40,15 @@ bash install-images.sh --local --prepare-only
 ```
 
 With images already loaded (or pointed at an internal registry you can reach),
-start Compose yourself instead of re-running the installer:
+start Compose yourself instead of re-running the installer. Compose defaults
+Postgres to a digest pin; if you loaded a digest-less tag (for example
+`postgres:16`), set `POSTGRES_IMAGE` (and `BUSYBOX_IMAGE` / `RAKAZO_*` as
+needed) in `.env` to those exact local refs so `up` does not try to pull.
 
 ```bash
-docker compose --env-file .env -f docker-compose.images.yml up -d
+docker compose --env-file .env -f docker-compose.images.yml up -d --pull never
 # When your Compose plugin supports it:
-# docker compose --env-file .env -f docker-compose.images.yml up -d --wait --wait-timeout 300
+# docker compose --env-file .env -f docker-compose.images.yml up -d --pull never --wait --wait-timeout 300
 ```
 
 `RAKAZO_DOWNLOAD_BASE` must be `https://…` (non-HTTPS is rejected). Trailing
@@ -88,9 +91,11 @@ containers may themselves lack egress; that is a separate network policy.
 1. On a connected machine: save installer + Compose + env example; `docker pull`
    (or build) the four image refs you will pin; `docker save` → tape/USB.
 2. On the air-gapped host: `docker load`; place Compose files; set
-   `RAKAZO_*_IMAGE*` / Hub overrides to local tags or an internal registry;
-   `bash install-images.sh --local --prepare-only`; fill secrets; then
-   `docker compose --env-file .env -f docker-compose.images.yml up -d`
+   `RAKAZO_*_IMAGE*` / `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` to the exact local
+   tags you loaded (digest-less Hub tags if that is what you saved) or to an
+   internal registry; `bash install-images.sh --local --prepare-only`; fill
+   secrets; then
+   `docker compose --env-file .env -f docker-compose.images.yml up -d --pull never`
    (add `--wait --wait-timeout 300` when Compose supports it). Do not re-run
    the installer for bring-up; it always runs `docker compose pull`.
 3. Verify with `curl -fsS http://127.0.0.1:3100/health` (see health-checks doc

--- a/docs/self-host-offline-boundaries.md
+++ b/docs/self-host-offline-boundaries.md
@@ -43,15 +43,17 @@ bash install-images.sh --local --prepare-only
 # prepare-only still validates an existing .env.
 ```
 
-With images already loaded (or pointed at an internal registry you can reach),
-start Compose yourself instead of re-running the installer. Compose defaults
-Postgres to a digest pin; if you loaded a digest-less tag (for example
-`postgres:16`), set `POSTGRES_IMAGE=postgres:16` (and `BUSYBOX_IMAGE` as
-needed). App/computer refs are split: set repository and tag separately
-(`RAKAZO_IMAGE` + `RAKAZO_IMAGE_TAG`, `RAKAZO_COMPUTER_IMAGE` +
-`RAKAZO_COMPUTER_IMAGE_TAG`). Do not put `repo:tag` into the repository
-variable; Compose appends `:${RAKAZO_IMAGE_TAG}` and a combined value becomes
-`repo:tag:tag`.
+With images already on the daemon (`docker load`), or after you have pulled
+them from an internal registry you can reach, start Compose yourself instead
+of re-running the installer. If refs point at an internal registry and the
+images are not local yet, pull those four images first; `--pull never` will
+not fetch missing ones. Compose defaults Postgres to a digest pin; if you
+loaded a digest-less tag (for example `postgres:16`), set
+`POSTGRES_IMAGE=postgres:16` (and `BUSYBOX_IMAGE` as needed). App/computer
+refs are split: set repository and tag separately (`RAKAZO_IMAGE` +
+`RAKAZO_IMAGE_TAG`, `RAKAZO_COMPUTER_IMAGE` + `RAKAZO_COMPUTER_IMAGE_TAG`).
+Do not put `repo:tag` into the repository variable; Compose appends
+`:${RAKAZO_IMAGE_TAG}` and a combined value becomes `repo:tag:tag`.
 
 ```bash
 docker compose --env-file .env -f docker-compose.images.yml up -d --pull never

--- a/docs/self-host-offline-boundaries.md
+++ b/docs/self-host-offline-boundaries.md
@@ -1,7 +1,7 @@
 # Self-host offline / air-gap boundaries
 
 What you can **pre-stage or mirror** for a restricted network, versus what still
-needs **live egress** after the stack is up. New file only — does not edit
+needs **live egress** after the stack is up. New file only; does not edit
 `docs/self-host.md`.
 
 Project policy: escape hatches are **generic** HTTPS bases and registry
@@ -12,7 +12,7 @@ docs as recommended endpoints.
 ## Reality check
 
 Rakazo is not a fully air-gapped appliance. Published-images install can be
-made to **bootstrap and pull** with zero public GitHub/GHCR/Hub reachability
+made to **bootstrap and start** with zero public GitHub/GHCR/Hub reachability
 *if* you pre-place files and images. Day-2 product use (models, optional
 catalogs, remote sandboxes, email, ACME) usually still needs outbound HTTPS
 unless you deliberately disable those features.
@@ -23,17 +23,29 @@ Treat “offline install” and “offline operation” as separate goals.
 
 | Stage | Default touch | Offline / mirror option |
 | --- | --- | --- |
-| **A** — fetch `install-images.sh` | `raw.githubusercontent.com` | Pre-copy the script, or `curl` via `RAKAZO_INSTALLER_URL` (HTTPS mirror **you** host) |
-| **B** — Compose YAML + `.env.images.example` | Same GitHub raw tree under `infra/compose` | `RAKAZO_DOWNLOAD_BASE` → HTTPS mirror of that directory; or `--local` / `RAKAZO_DOWNLOAD_SKIP_EXISTING=1` when files already sit in the working directory |
-| **C** — `docker compose pull` | `ghcr.io/elie222/rakazo/{app,computer}` plus Hub `postgres` / `busybox` | Pre-load images into the daemon, or override `RAKAZO_IMAGE*` / `RAKAZO_COMPUTER_IMAGE*` and `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` to a registry **you** control (prefer **digest-less** tags on mirrors). Daemon `registry-mirrors` is an alternative for Hub only |
+| **A** - fetch `install-images.sh` | `raw.githubusercontent.com` | Pre-copy the script, or `curl` via `RAKAZO_INSTALLER_URL` (HTTPS mirror **you** host) |
+| **B** - Compose YAML + `.env.images.example` | Same GitHub raw tree under `infra/compose` | `RAKAZO_DOWNLOAD_BASE` → HTTPS mirror of that directory; or `--local` / `RAKAZO_DOWNLOAD_SKIP_EXISTING=1` when files already sit in the working directory |
+| **C** - images on the host | `ghcr.io/elie222/rakazo/{app,computer}` plus Hub `postgres` / `busybox` | Pull from a registry **you** control (`RAKAZO_IMAGE*` / `RAKAZO_COMPUTER_IMAGE*` and `POSTGRES_IMAGE` / `BUSYBOX_IMAGE`; prefer **digest-less** tags on mirrors), **or** `docker load` pre-staged images and start with Compose (no pull). Daemon `registry-mirrors` is an alternative for Hub only |
 
 Installer flags that help air-gapped **bootstrap** (not day-2):
+
+`--local` only skips GitHub file downloads when Compose/env files are already
+on disk. It does **not** skip `docker compose pull`. A full installer run still
+needs registry access unless you bypass the installer after prepare.
 
 ```bash
 # Files already on disk next to the script:
 bash install-images.sh --local --prepare-only
-# edit .env (secrets, image overrides), then:
-bash install-images.sh --local
+# edit .env (secrets, image overrides)
+```
+
+With images already loaded (or pointed at an internal registry you can reach),
+start Compose yourself instead of re-running the installer:
+
+```bash
+docker compose --env-file .env -f docker-compose.images.yml up -d
+# When your Compose plugin supports it:
+# docker compose --env-file .env -f docker-compose.images.yml up -d --wait --wait-timeout 300
 ```
 
 `RAKAZO_DOWNLOAD_BASE` must be `https://…` (non-HTTPS is rejected). Trailing
@@ -45,12 +57,12 @@ Safe to vend into the air-gap **before** cutover:
 
 1. `install-images.sh`, `docker-compose.images.yml`, `.env.images.example`
 2. OCI images for app, computer, Postgres, busybox (and prod: Caddy / updater
-   if you use that path) — `docker load` or a private registry
+   if you use that path): `docker load` or a private registry
 3. Operator-written `.env` with locally generated secrets (`openssl`)
 4. Optional: host TLS certs / Caddyfile if you terminate TLS yourself (skip
    public ACME)
 
-After images and Compose files are local, Stage A–C need no public GitHub.
+After images and Compose files are local, Stage A-C need no public GitHub.
 
 ## What still wants live network (day-2)
 
@@ -69,7 +81,7 @@ you turn them off or replace them:
 
 Local Docker computers (`SANDBOX_PROVIDER=docker`) still need the **computer
 image** present locally; they do not need E2B. Desktops inside those
-containers may themselves lack egress — that is a separate network policy.
+containers may themselves lack egress; that is a separate network policy.
 
 ## Minimal “pull offline, run local” checklist
 
@@ -77,8 +89,10 @@ containers may themselves lack egress — that is a separate network policy.
    (or build) the four image refs you will pin; `docker save` → tape/USB.
 2. On the air-gapped host: `docker load`; place Compose files; set
    `RAKAZO_*_IMAGE*` / Hub overrides to local tags or an internal registry;
-   `bash install-images.sh --local --prepare-only`; fill secrets; run without
-   needing GitHub.
+   `bash install-images.sh --local --prepare-only`; fill secrets; then
+   `docker compose --env-file .env -f docker-compose.images.yml up -d`
+   (add `--wait --wait-timeout 300` when Compose supports it). Do not re-run
+   the installer for bring-up; it always runs `docker compose pull`.
 3. Verify with `curl -fsS http://127.0.0.1:3100/health` (see health-checks doc
    when present). Expect `sandbox: "docker"` if that is your path.
 4. Do **not** expect model replies until a provider route exists inside the
@@ -90,8 +104,8 @@ containers may themselves lack egress — that is a separate network policy.
   installer or Compose defaults
 - Claiming “full air-gap including LLM” without an in-boundary model endpoint
 - Editing this guide into `docs/self-host.md` while that file is a hot merge
-  surface — link from ops notes instead
+  surface; link from ops notes instead
 
 Related operator docs (when merged on your tree): pull diagnostics, outbound
-HTTP proxy, health checks — each is a separate file so restricted-network
+HTTP proxy, health checks; each is a separate file so restricted-network
 topics can land without colliding.

--- a/docs/self-host-offline-boundaries.md
+++ b/docs/self-host-offline-boundaries.md
@@ -38,7 +38,9 @@ needs registry access unless you bypass the installer after prepare.
 ```bash
 # Files already on disk next to the script:
 bash install-images.sh --local --prepare-only
-# edit .env (secrets, image overrides)
+# edit .env (image overrides; installer wrote secrets if it created .env)
+# If you already had a hand-written .env, fill required secrets before --prepare-only;
+# prepare-only still validates an existing .env.
 ```
 
 With images already loaded (or pointed at an internal registry you can reach),
@@ -97,12 +99,14 @@ containers may themselves lack egress; that is a separate network policy.
 
 1. On a connected machine: save installer + Compose + env example; `docker pull`
    (or build) the four image refs you will pin; `docker save` → tape/USB.
-2. On the air-gapped host: `docker load`; place Compose files; set
-   `RAKAZO_IMAGE` / `RAKAZO_IMAGE_TAG` and `RAKAZO_COMPUTER_IMAGE` /
-   `RAKAZO_COMPUTER_IMAGE_TAG` to the repository and tag you loaded (separate
-   vars), plus `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` to full digest-less refs if
-   that is what you saved (or point all of them at an internal registry);
-   `bash install-images.sh --local --prepare-only`; fill secrets; then
+2. On the air-gapped host: `docker load`; place Compose files; run
+   `bash install-images.sh --local --prepare-only` first (creates `.env` with
+   secrets when missing; if `.env` already exists, fill required secrets
+   before that command). Then set `RAKAZO_IMAGE` / `RAKAZO_IMAGE_TAG` and
+   `RAKAZO_COMPUTER_IMAGE` / `RAKAZO_COMPUTER_IMAGE_TAG` to the repository and
+   tag you loaded (separate vars), plus `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` to
+   full digest-less refs if that is what you saved (or point all of them at an
+   internal registry). Then
    `docker compose --env-file .env -f docker-compose.images.yml up -d --pull never`
    (add `--wait --wait-timeout 300` when Compose supports it). Do not re-run
    the installer for bring-up; it always runs `docker compose pull`.

--- a/docs/self-host-offline-boundaries.md
+++ b/docs/self-host-offline-boundaries.md
@@ -11,11 +11,13 @@ docs as recommended endpoints.
 
 ## Reality check
 
-Rakazo is not a fully air-gapped appliance. Published-images install can be
-made to **bootstrap and start** with zero public GitHub/GHCR/Hub reachability
-*if* you pre-place files and images. Day-2 product use (models, optional
-catalogs, remote sandboxes, email, ACME) usually still needs outbound HTTPS
-unless you deliberately disable those features.
+Rakazo is not a fully air-gapped appliance. On supported image architectures
+(default `edge` tags are linux/amd64 only; arm64 needs a multi-arch release
+tag or matching pre-staged images), published-images install can be made to
+**bootstrap and start** with zero public GitHub/GHCR/Hub reachability *if* you
+pre-place files and images. Day-2 product use (models, optional catalogs,
+remote sandboxes, email, ACME) usually still needs outbound HTTPS unless you
+deliberately disable those features.
 
 Treat “offline install” and “offline operation” as separate goals.
 
@@ -42,8 +44,12 @@ bash install-images.sh --local --prepare-only
 With images already loaded (or pointed at an internal registry you can reach),
 start Compose yourself instead of re-running the installer. Compose defaults
 Postgres to a digest pin; if you loaded a digest-less tag (for example
-`postgres:16`), set `POSTGRES_IMAGE` (and `BUSYBOX_IMAGE` / `RAKAZO_*` as
-needed) in `.env` to those exact local refs so `up` does not try to pull.
+`postgres:16`), set `POSTGRES_IMAGE=postgres:16` (and `BUSYBOX_IMAGE` as
+needed). App/computer refs are split: set repository and tag separately
+(`RAKAZO_IMAGE` + `RAKAZO_IMAGE_TAG`, `RAKAZO_COMPUTER_IMAGE` +
+`RAKAZO_COMPUTER_IMAGE_TAG`). Do not put `repo:tag` into the repository
+variable; Compose appends `:${RAKAZO_IMAGE_TAG}` and a combined value becomes
+`repo:tag:tag`.
 
 ```bash
 docker compose --env-file .env -f docker-compose.images.yml up -d --pull never
@@ -59,8 +65,9 @@ slashes are trimmed.
 Safe to vend into the air-gap **before** cutover:
 
 1. `install-images.sh`, `docker-compose.images.yml`, `.env.images.example`
-2. OCI images for app, computer, Postgres, busybox (and prod: Caddy / updater
-   if you use that path): `docker load` or a private registry
+2. OCI images for app, computer, Postgres, busybox: `docker load` or a private
+   registry (this checklist is the published-images Compose path; production
+   Compose with Caddy/updater is a separate staging set)
 3. Operator-written `.env` with locally generated secrets (`openssl`)
 4. Optional: host TLS certs / Caddyfile if you terminate TLS yourself (skip
    public ACME)
@@ -91,10 +98,11 @@ containers may themselves lack egress; that is a separate network policy.
 1. On a connected machine: save installer + Compose + env example; `docker pull`
    (or build) the four image refs you will pin; `docker save` → tape/USB.
 2. On the air-gapped host: `docker load`; place Compose files; set
-   `RAKAZO_*_IMAGE*` / `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` to the exact local
-   tags you loaded (digest-less Hub tags if that is what you saved) or to an
-   internal registry; `bash install-images.sh --local --prepare-only`; fill
-   secrets; then
+   `RAKAZO_IMAGE` / `RAKAZO_IMAGE_TAG` and `RAKAZO_COMPUTER_IMAGE` /
+   `RAKAZO_COMPUTER_IMAGE_TAG` to the repository and tag you loaded (separate
+   vars), plus `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` to full digest-less refs if
+   that is what you saved (or point all of them at an internal registry);
+   `bash install-images.sh --local --prepare-only`; fill secrets; then
    `docker compose --env-file .env -f docker-compose.images.yml up -d --pull never`
    (add `--wait --wait-timeout 300` when Compose supports it). Do not re-run
    the installer for bring-up; it always runs `docker compose pull`.

--- a/docs/self-host-offline-boundaries.md
+++ b/docs/self-host-offline-boundaries.md
@@ -1,0 +1,97 @@
+# Self-host offline / air-gap boundaries
+
+What you can **pre-stage or mirror** for a restricted network, versus what still
+needs **live egress** after the stack is up. New file only — does not edit
+`docs/self-host.md`.
+
+Project policy: escape hatches are **generic** HTTPS bases and registry
+overrides you control. Do **not** bake vendor CDN / 镜像站 hostnames
+(阿里云、腾讯云、ghproxy、npmmirror, …) into Compose, installer defaults, or
+docs as recommended endpoints.
+
+## Reality check
+
+Rakazo is not a fully air-gapped appliance. Published-images install can be
+made to **bootstrap and pull** with zero public GitHub/GHCR/Hub reachability
+*if* you pre-place files and images. Day-2 product use (models, optional
+catalogs, remote sandboxes, email, ACME) usually still needs outbound HTTPS
+unless you deliberately disable those features.
+
+Treat “offline install” and “offline operation” as separate goals.
+
+## Install stages (what can be mirrored)
+
+| Stage | Default touch | Offline / mirror option |
+| --- | --- | --- |
+| **A** — fetch `install-images.sh` | `raw.githubusercontent.com` | Pre-copy the script, or `curl` via `RAKAZO_INSTALLER_URL` (HTTPS mirror **you** host) |
+| **B** — Compose YAML + `.env.images.example` | Same GitHub raw tree under `infra/compose` | `RAKAZO_DOWNLOAD_BASE` → HTTPS mirror of that directory; or `--local` / `RAKAZO_DOWNLOAD_SKIP_EXISTING=1` when files already sit in the working directory |
+| **C** — `docker compose pull` | `ghcr.io/elie222/rakazo/{app,computer}` plus Hub `postgres` / `busybox` | Pre-load images into the daemon, or override `RAKAZO_IMAGE*` / `RAKAZO_COMPUTER_IMAGE*` and `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` to a registry **you** control (prefer **digest-less** tags on mirrors). Daemon `registry-mirrors` is an alternative for Hub only |
+
+Installer flags that help air-gapped **bootstrap** (not day-2):
+
+```bash
+# Files already on disk next to the script:
+bash install-images.sh --local --prepare-only
+# edit .env (secrets, image overrides), then:
+bash install-images.sh --local
+```
+
+`RAKAZO_DOWNLOAD_BASE` must be `https://…` (non-HTTPS is rejected). Trailing
+slashes are trimmed.
+
+## What you can fully pre-stage
+
+Safe to vend into the air-gap **before** cutover:
+
+1. `install-images.sh`, `docker-compose.images.yml`, `.env.images.example`
+2. OCI images for app, computer, Postgres, busybox (and prod: Caddy / updater
+   if you use that path) — `docker load` or a private registry
+3. Operator-written `.env` with locally generated secrets (`openssl`)
+4. Optional: host TLS certs / Caddyfile if you terminate TLS yourself (skip
+   public ACME)
+
+After images and Compose files are local, Stage A–C need no public GitHub.
+
+## What still wants live network (day-2)
+
+Even with a successful offline pull/up, these features expect egress unless
+you turn them off or replace them:
+
+| Surface | Why | Offline stance |
+| --- | --- | --- |
+| Model providers (`OPENROUTER_API_KEY`, onboarding OAuth to ChatGPT/Copilot/Grok, etc.) | Bot replies | Defer models; UI can come up, chats fail until a reachable provider exists |
+| Remote sandboxes (`e2b` / `daytona` / `box`) | Provider APIs | Keep `SANDBOX_PROVIDER=docker` and local computer image |
+| Composio / Pipedream | External catalogs | Leave keys empty |
+| SMTP password recovery | Outbound mail | Leave `SMTP_URL` empty |
+| Let’s Encrypt / public ACME via Caddy | Certificate issuance | Use your own certs or an internal CA |
+| Updater checking GHCR for newer tags | Registry pull | Disable updater profile or point image refs at an internal registry you refresh out-of-band |
+| Marketing / docs links in the UI | Browser to the public internet | Cosmetics only |
+
+Local Docker computers (`SANDBOX_PROVIDER=docker`) still need the **computer
+image** present locally; they do not need E2B. Desktops inside those
+containers may themselves lack egress — that is a separate network policy.
+
+## Minimal “pull offline, run local” checklist
+
+1. On a connected machine: save installer + Compose + env example; `docker pull`
+   (or build) the four image refs you will pin; `docker save` → tape/USB.
+2. On the air-gapped host: `docker load`; place Compose files; set
+   `RAKAZO_*_IMAGE*` / Hub overrides to local tags or an internal registry;
+   `bash install-images.sh --local --prepare-only`; fill secrets; run without
+   needing GitHub.
+3. Verify with `curl -fsS http://127.0.0.1:3100/health` (see health-checks doc
+   when present). Expect `sandbox: "docker"` if that is your path.
+4. Do **not** expect model replies until a provider route exists inside the
+   boundary.
+
+## Explicitly out of scope / forbidden defaults
+
+- Shipping 阿里云 / DaoCloud / ghproxy / npmmirror (or any vendor) URLs as
+  installer or Compose defaults
+- Claiming “full air-gap including LLM” without an in-boundary model endpoint
+- Editing this guide into `docs/self-host.md` while that file is a hot merge
+  surface — link from ops notes instead
+
+Related operator docs (when merged on your tree): pull diagnostics, outbound
+HTTP proxy, health checks — each is a separate file so restricted-network
+topics can land without colliding.


### PR DESCRIPTION
## Summary
- New `docs/self-host-offline-boundaries.md`
- What Stage A/B/C can mirror vs day-2 still-online needs
- New file only; no vendor CDN defaults

## Test plan
- [ ] Skim mirror vs must-online split

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for installing and running Rakazo in offline or limited-connectivity environments.
  - Documented pre-staging installation assets and container images.
  - Added instructions for installer options, manual Compose startup, mirrors, image overrides, and readiness checks.
  - Clarified architecture support, ongoing network requirements, and limitations around fully air-gapped deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->