### PR TITLE
docs(self-host): arm64 vs amd64-only edge image tags

### DIFF
--- a/docs/self-host-arm64.md
+++ b/docs/self-host-arm64.md
@@ -2,8 +2,7 @@
 
 Published-images defaults assume **`edge` is `linux/amd64` only**. On arm64
 hosts that mismatch shows up as pull errors, exec format errors, or a working
-API with a broken computer container. This page is a **new** operator guide so
-it does not edit the hot `docs/self-host.md` surface.
+API with a broken computer container.
 
 ## Check the host
 
@@ -13,9 +12,24 @@ uname -m
 # x86_64 / amd64  → default `edge` tags are fine
 ```
 
+## Where to run commands
+
+CDN/install downloads land in the current working directory
+(`docker-compose.images.yml`, `.env.images.example`, `install-images.sh`).
+From that install directory:
+
+```bash
+bash install-images.sh
+docker compose --env-file .env -f docker-compose.images.yml pull
+docker compose --env-file .env -f docker-compose.images.yml up -d
+```
+
+From a repo checkout, `cd infra/compose` first (those files live there).
+
 ## The pairing rule (both tags together)
 
-Published images Compose uses four related settings (defaults shown):
+`infra/compose/.env.images.example` defaults both tags to `edge` and notes that
+`edge` is amd64-only:
 
 ```env
 RAKAZO_IMAGE=ghcr.io/elie222/rakazo/app
@@ -32,17 +46,15 @@ On arm64:
    published **multi-arch** release tag (for example a `vX.Y.Z` or a
    multi-arch `workflow_dispatch` build).
 3. Changing **only** `RAKAZO_IMAGE_TAG` leaves the computer service on
-   amd64-only `edge` — a common partial-fix footgun.
+   amd64-only `edge`. That partial pin is a common footgun.
 
-Example after `--prepare-only` (replace the tag with one that exists in GHCR
-for **both** app and computer):
+Replace `v0.0.0` with a real multi-arch GHCR tag for **both** images, then
+pull/up from the install directory (or `infra/compose`):
 
 ```env
 RAKAZO_IMAGE_TAG=v0.0.0
 RAKAZO_COMPUTER_IMAGE_TAG=v0.0.0
 ```
-
-Then:
 
 ```bash
 bash install-images.sh
@@ -61,12 +73,13 @@ docker compose --env-file .env -f docker-compose.images.yml up -d
 | `sha-*` | varies | Pin only when you know that digest/tag is multi-arch |
 
 List tags on GHCR (or your mirror) before pinning. If no multi-arch release
-exists yet, arm64 hosts cannot use the default `edge` path without emulation
-or building from source (`local` / checkout Compose).
+exists yet, arm64 hosts cannot use default `edge` without emulation or
+building from source (`local` / checkout Compose). See
+[docs/self-host.md](./self-host.md#published-images-and-tags).
 
 ## Restricted networks + arm64
 
-Image **registry** overrides and **tag** pairing compose:
+Registry overrides and tag pairing compose:
 
 ```env
 RAKAZO_IMAGE=registry.example.com/mirror/elie222/rakazo/app
@@ -77,21 +90,21 @@ RAKAZO_COMPUTER_IMAGE_TAG=v0.0.0
 
 Keep app and computer on the **same mirror** and the **same multi-arch tag**.
 Hub Postgres/busybox overrides (`POSTGRES_IMAGE` / `BUSYBOX_IMAGE`) are
-independent; prefer digest-less tags on mirrors. See restricted-network /
-pull-diagnostics docs when present on your tree.
+independent; prefer digest-less tags on mirrors. Registry override details:
+[docs/self-host.md](./self-host.md).
 
-Installer versions that warn when the host is arm64 and tags resolve to
-`edge` are complementary — the fix is still to pin both tags, not to ignore
-the warning.
+Installer warnings when the host is arm64 and tags resolve to `edge` are
+complementary. The fix is still to pin both tags.
 
 ## Source checkout / prod `local`
 
-Dev and first production deploys that **build** with `RAKAZO_IMAGE_TAG=local`
-produce host-native images from your checkout (including arm64). That path
-does not use GHCR `edge`. Switching later to published tags re-introduces the
-pairing rule above.
+Builds with `RAKAZO_IMAGE_TAG=local` produce host-native images from your
+checkout (including arm64). That path does not use GHCR `edge`. Switching
+later to published tags re-introduces the pairing rule above.
 
 ## Verify
+
+From the install directory (or `infra/compose`):
 
 ```bash
 docker compose --env-file .env -f docker-compose.images.yml images
@@ -100,5 +113,5 @@ docker image inspect "$(docker compose --env-file .env -f docker-compose.images.
 curl -fsS http://127.0.0.1:3100/health
 ```
 
-Architecture should be `arm64` (or your host arch). Health expectations are in
-`docs/self-host-health-checks.md` when that file exists on your release.
+Architecture should be `arm64` (or your host arch). Health notes:
+[docs/self-host.md](./self-host.md).

--- a/docs/self-host-arm64.md
+++ b/docs/self-host-arm64.md
@@ -46,7 +46,7 @@ On arm64:
    published **multi-arch** release tag (for example a `vX.Y.Z` or a
    multi-arch `workflow_dispatch` build).
 3. Changing **only** `RAKAZO_IMAGE_TAG` leaves the computer service on
-   amd64-only `edge`. That partial pin is a common footgun.
+   amd64-only `edge`. That partial pin is a common configuration error.
 
 Replace `v0.0.0` with a real multi-arch GHCR tag for **both** images, then
 pull/up from the install directory (or `infra/compose`):
@@ -89,9 +89,11 @@ RAKAZO_COMPUTER_IMAGE_TAG=v0.0.0
 ```
 
 Keep app and computer on the **same mirror** and the **same multi-arch tag**.
+Prefer **digest-pinned** refs when the mirror serves them (immutable content).
 Hub Postgres/busybox overrides (`POSTGRES_IMAGE` / `BUSYBOX_IMAGE`) are
-independent; prefer digest-less tags on mirrors. Registry override details:
-[docs/self-host.md](./self-host.md).
+independent — keep digests when available; use digest-less tags only if the
+mirror rejects digests, then verify the pulled digest before deploy. Registry
+override details: [docs/self-host.md](./self-host.md).
 
 Installer warnings when the host is arm64 and tags resolve to `edge` are
 complementary. The fix is still to pin both tags.

--- a/docs/self-host-arm64.md
+++ b/docs/self-host-arm64.md
@@ -91,7 +91,7 @@ RAKAZO_COMPUTER_IMAGE_TAG=v0.0.0
 Keep app and computer on the **same mirror** and the **same multi-arch tag**.
 Prefer **digest-pinned** refs when the mirror serves them (immutable content).
 Hub Postgres/busybox overrides (`POSTGRES_IMAGE` / `BUSYBOX_IMAGE`) are
-independent — keep digests when available; use digest-less tags only if the
+independent. Keep digests when available; use digest-less tags only if the
 mirror rejects digests, then verify the pulled digest before deploy. Registry
 override details: [docs/self-host.md](./self-host.md).
 

--- a/docs/self-host-arm64.md
+++ b/docs/self-host-arm64.md
@@ -108,10 +108,12 @@ From the install directory (or `infra/compose`):
 
 ```bash
 docker compose --env-file .env -f docker-compose.images.yml images
-docker image inspect "$(docker compose --env-file .env -f docker-compose.images.yml images -q api | head -1)" \
-  --format '{{.Architecture}}'
+for service in api computer; do
+  docker image inspect "$(docker compose --env-file .env -f docker-compose.images.yml images -q "$service" | head -1)" \
+    --format "$service: {{.Architecture}}"
+done
 curl -fsS http://127.0.0.1:3100/health
 ```
 
-Architecture should be `arm64` (or your host arch). Health notes:
+Both should report `arm64` (or your host arch). Health notes:
 [docs/self-host.md](./self-host.md).

--- a/docs/self-host-arm64.md
+++ b/docs/self-host-arm64.md
@@ -1,0 +1,104 @@
+# Self-host on arm64 (Apple Silicon / aarch64)
+
+Published-images defaults assume **`edge` is `linux/amd64` only**. On arm64
+hosts that mismatch shows up as pull errors, exec format errors, or a working
+API with a broken computer container. This page is a **new** operator guide so
+it does not edit the hot `docs/self-host.md` surface.
+
+## Check the host
+
+```bash
+uname -m
+# arm64 / aarch64 → follow this page
+# x86_64 / amd64  → default `edge` tags are fine
+```
+
+## The pairing rule (both tags together)
+
+Published images Compose uses four related settings (defaults shown):
+
+```env
+RAKAZO_IMAGE=ghcr.io/elie222/rakazo/app
+RAKAZO_IMAGE_TAG=edge
+RAKAZO_COMPUTER_IMAGE=ghcr.io/elie222/rakazo/computer
+RAKAZO_COMPUTER_IMAGE_TAG=edge
+```
+
+On arm64:
+
+1. Do **not** leave both on `edge` unless you intentionally run amd64 images
+   under emulation (slow, often fragile).
+2. Set **`RAKAZO_IMAGE_TAG` and `RAKAZO_COMPUTER_IMAGE_TAG` to the same**
+   published **multi-arch** release tag (for example a `vX.Y.Z` or a
+   multi-arch `workflow_dispatch` build).
+3. Changing **only** `RAKAZO_IMAGE_TAG` leaves the computer service on
+   amd64-only `edge` — a common partial-fix footgun.
+
+Example after `--prepare-only` (replace the tag with one that exists in GHCR
+for **both** app and computer):
+
+```env
+RAKAZO_IMAGE_TAG=v0.0.0
+RAKAZO_COMPUTER_IMAGE_TAG=v0.0.0
+```
+
+Then:
+
+```bash
+bash install-images.sh
+# or
+docker compose --env-file .env -f docker-compose.images.yml pull
+docker compose --env-file .env -f docker-compose.images.yml up -d
+```
+
+## Tag availability
+
+| Tag | Typical arch | Notes |
+| --- | --- | --- |
+| `edge` | amd64 only | Tracks main; default in `.env.images.example` |
+| `v*` / release / some manual publishes | amd64 + arm64 | Prefer these on arm64 hosts |
+| `latest` | do not assume | May be missing; never invent it |
+| `sha-*` | varies | Pin only when you know that digest/tag is multi-arch |
+
+List tags on GHCR (or your mirror) before pinning. If no multi-arch release
+exists yet, arm64 hosts cannot use the default `edge` path without emulation
+or building from source (`local` / checkout Compose).
+
+## Restricted networks + arm64
+
+Image **registry** overrides and **tag** pairing compose:
+
+```env
+RAKAZO_IMAGE=registry.example.com/mirror/elie222/rakazo/app
+RAKAZO_COMPUTER_IMAGE=registry.example.com/mirror/elie222/rakazo/computer
+RAKAZO_IMAGE_TAG=v0.0.0
+RAKAZO_COMPUTER_IMAGE_TAG=v0.0.0
+```
+
+Keep app and computer on the **same mirror** and the **same multi-arch tag**.
+Hub Postgres/busybox overrides (`POSTGRES_IMAGE` / `BUSYBOX_IMAGE`) are
+independent; prefer digest-less tags on mirrors. See restricted-network /
+pull-diagnostics docs when present on your tree.
+
+Installer versions that warn when the host is arm64 and tags resolve to
+`edge` are complementary — the fix is still to pin both tags, not to ignore
+the warning.
+
+## Source checkout / prod `local`
+
+Dev and first production deploys that **build** with `RAKAZO_IMAGE_TAG=local`
+produce host-native images from your checkout (including arm64). That path
+does not use GHCR `edge`. Switching later to published tags re-introduces the
+pairing rule above.
+
+## Verify
+
+```bash
+docker compose --env-file .env -f docker-compose.images.yml images
+docker image inspect "$(docker compose --env-file .env -f docker-compose.images.yml images -q api | head -1)" \
+  --format '{{.Architecture}}'
+curl -fsS http://127.0.0.1:3100/health
+```
+
+Architecture should be `arm64` (or your host arch). Health expectations are in
+`docs/self-host-health-checks.md` when that file exists on your release.


### PR DESCRIPTION
## Summary
- New `docs/self-host-arm64.md` explaining `edge` is amd64-only and arm64 hosts must pin app+computer to the same multi-arch release.
- Orthogonal to installer warn script work (#496); does not touch `docs/self-host.md` or installer scripts.

## Test plan
- [ ] Skim against published image tag docs
- [ ] Confirm single-file docs-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for self-hosting on ARM64 hosts, including Apple Silicon and aarch64 systems.
  * Documented architecture checks, multi-architecture tag availability, and the requirement to pin matching tags for API and computer services.
  * Clarified that the `edge` tag supports amd64 only.
  * Added instructions for restricted-network registry overrides, digest-pinned mirror references, and local builds from a source checkout.
  * Expanded verification steps to report the architecture of both services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->