### PR TITLE
docs(self-host): SANDBOX_PROVIDER modes for operators

### DIFF
--- a/docs/self-host-sandbox-providers.md
+++ b/docs/self-host-sandbox-providers.md
@@ -1,0 +1,66 @@
+# Self-host sandbox / computer providers
+
+How `SANDBOX_PROVIDER` chooses where each bot's **computer** runs. New file
+only — does not edit `docs/self-host.md`.
+
+`GET /health` reports the effective provider as `sandbox` (see
+`docs/self-host-health-checks.md` when present).
+
+## Quick pick
+
+| Goal | Set | Also need |
+| --- | --- | --- |
+| Default self-host (local Docker desktop per bot) | `SANDBOX_PROVIDER=docker` | `SANDBOX_SUPERVISOR_TOKEN`, computer image, Docker socket for supervisor |
+| UI only, no computers | `SANDBOX_PROVIDER=none` | — |
+| Managed remote desktop | `e2b` / `daytona` / `box` | Matching API key (and optional URL knobs for Daytona/Box) |
+
+Published-images `.env.images.example` defaults to **`docker`**.
+
+## `docker` (in-stack supervisor)
+
+Compose starts a **sandbox supervisor** (from the app image) on the internal
+network (port `7091` in published-images). It creates sibling **computer**
+containers from `RAKAZO_COMPUTER_IMAGE` + `RAKAZO_COMPUTER_IMAGE_TAG`.
+
+Requirements:
+
+- Non-empty `SANDBOX_SUPERVISOR_TOKEN` (distinct from auth / screen / encryption secrets)
+- Reachable computer image (GHCR default or your mirror; on arm64 pin multi-arch tags for both app and computer)
+- Docker Engine available to the supervisor (socket mount on the Compose path)
+
+Verify:
+
+```bash
+curl -fsS http://127.0.0.1:3100/health
+# expect sandbox: docker
+```
+
+Missing supervisor token is a **setup failure**: do not treat `sandbox: "none"` as success for this path.
+
+Signup and local Docker computers work **without** an E2B (or other remote) account.
+
+## `none`
+
+Boots API/web without computer provisioning. Use when Docker/supervisor is
+unavailable and you only need the control plane.
+
+## Remote providers
+
+Set `SANDBOX_PROVIDER` to exactly one of:
+
+| Value | Credential | Notes |
+| --- | --- | --- |
+| `e2b` | `E2B_API_KEY` | Hosted sandboxes |
+| `daytona` | `DAYTONA_API_KEY` | Optional `DAYTONA_API_URL`, `DAYTONA_TARGET` |
+| `box` | `BOX_API_KEY` | Optional `BOX_API_URL` (see `.env.example`) |
+
+Remote paths still need a working API/worker; they do not replace Postgres or
+the web UI. They require egress to the provider. For air-gapped hosts prefer
+`docker` with pre-loaded images, or `none`.
+
+After changing provider or keys:
+
+```bash
+docker compose --env-file .env -f docker-compose.images.yml up -d
+curl -fsS http://127.0.0.1:3100/health
+```


### PR DESCRIPTION
## Summary
- New `docs/self-host-sandbox-providers.md` covering `SANDBOX_PROVIDER=docker|none|e2b|daytona|box`, supervisor token / health expectations, and remote egress notes.
- New file only — avoids hot `docs/self-host.md`.

## Test plan
- [ ] Skim against env / health sandbox field
- [ ] Confirm single-file docs-only