### PR TITLE
docs(self-host): SANDBOX_PROVIDER modes for operators

### DIFF
--- a/docs/self-host-sandbox-providers.md
+++ b/docs/self-host-sandbox-providers.md
@@ -1,0 +1,77 @@
+# Self-host sandbox / computer providers
+
+How `SANDBOX_PROVIDER` chooses where each bot's **computer** runs. New file
+only; does not edit `docs/self-host.md`.
+
+`GET /health` reports the effective provider as `sandbox` (see
+`docs/self-host-health-checks.md` when present). HTTP 200 alone is not enough:
+confirm the JSON `sandbox` field matches the provider you set. A missing or
+invalid remote key can leave `sandbox: "none"` while `/health` still returns 200.
+
+## Quick pick
+
+| Goal | Set | Also need |
+| --- | --- | --- |
+| Default self-host (local Docker desktop per bot) | `SANDBOX_PROVIDER=docker` | `SANDBOX_SUPERVISOR_TOKEN`, computer image, Docker socket for supervisor |
+| UI only, no computers | `SANDBOX_PROVIDER=none` | (none) |
+| Managed remote desktop | `e2b` / `daytona` / `box` | `SANDBOX_SUPERVISOR_TOKEN` (published-images Compose), matching API key (and optional URL knobs for Daytona/Box) |
+
+Published-images `infra/compose/.env.images.example` defaults to **`docker`**.
+
+## `docker` (in-stack supervisor)
+
+Compose starts a **sandbox supervisor** (from the app image) on the internal
+network (port `7091` in published-images). It creates sibling **computer**
+containers from `RAKAZO_COMPUTER_IMAGE` + `RAKAZO_COMPUTER_IMAGE_TAG`.
+
+Requirements:
+
+- Non-empty `SANDBOX_SUPERVISOR_TOKEN` (distinct from auth / screen / encryption secrets)
+- Reachable computer image (GHCR default or your mirror; on arm64 pin multi-arch tags for both app and computer)
+- Docker Engine available to the supervisor (socket mount on the Compose path)
+
+Verify:
+
+```bash
+curl -fsS http://127.0.0.1:3100/health
+# expect sandbox: docker
+```
+
+Missing supervisor token is a **setup failure**: do not treat `sandbox: "none"` as success for this path.
+
+Signup and local Docker computers work **without** an E2B (or other remote) account.
+
+## `none`
+
+Boots API/web without computer provisioning. Use when Docker/supervisor is
+unavailable and you only need the control plane.
+
+## Remote providers
+
+Set `SANDBOX_PROVIDER` to exactly one of:
+
+| Value | Credential | Notes |
+| --- | --- | --- |
+| `e2b` | `E2B_API_KEY` | Hosted sandboxes |
+| `daytona` | `DAYTONA_API_KEY` | Optional `DAYTONA_API_URL`, `DAYTONA_TARGET` |
+| `box` | `BOX_API_KEY` | Optional `BOX_API_URL` (see `.env.example`) |
+
+Remote paths still need a working API/worker; they do not replace Postgres or
+the web UI. They require egress to the provider. For air-gapped hosts prefer
+`docker` with pre-loaded images, or `none`.
+
+Published-images Compose (`docker-compose.images.yml`) still requires
+`SANDBOX_SUPERVISOR_TOKEN` and always starts the supervisor service (api/worker
+depend on it). The token is a Compose stack requirement; it does not replace
+the remote API key.
+
+After changing provider or keys:
+
+```bash
+docker compose --env-file .env -f docker-compose.images.yml up -d
+curl -fsS http://127.0.0.1:3100/health
+```
+
+Confirm `sandbox` equals the intended provider (`e2b`, `daytona`, or `box`).
+HTTP 200 with `sandbox: "none"` means computers are disabled (missing or invalid
+remote key), not a successful remote setup.

--- a/docs/self-host-sandbox-providers.md
+++ b/docs/self-host-sandbox-providers.md
@@ -15,7 +15,7 @@ not catch that until provisioning fails.
 | Goal | Set | Also need |
 | --- | --- | --- |
 | Default self-host (local Docker desktop per bot) | `SANDBOX_PROVIDER=docker` | `SANDBOX_SUPERVISOR_TOKEN`, computer image, Docker socket for supervisor |
-| UI only, no computers | `SANDBOX_PROVIDER=none` | `SANDBOX_SUPERVISOR_TOKEN` (published-images Compose) |
+| UI only, no computers | `SANDBOX_PROVIDER=none` | No provider credential; published-images Compose still requires `SANDBOX_SUPERVISOR_TOKEN` |
 | Managed remote desktop | `e2b` / `daytona` / `box` | `SANDBOX_SUPERVISOR_TOKEN` (published-images Compose), matching API key (and optional URL knobs for Daytona/Box) |
 
 Published-images `infra/compose/.env.images.example` defaults to **`docker`**.
@@ -70,7 +70,8 @@ Published-images Compose (`docker-compose.images.yml`) still requires
 depend on it). The token is a Compose stack requirement; it does not replace
 the remote API key.
 
-After changing provider or keys:
+After changing provider or keys (from the published-images drop directory that
+holds `docker-compose.images.yml` and `.env`):
 
 ```bash
 docker compose --env-file .env -f docker-compose.images.yml up -d

--- a/docs/self-host-sandbox-providers.md
+++ b/docs/self-host-sandbox-providers.md
@@ -5,15 +5,17 @@ only; does not edit `docs/self-host.md`.
 
 `GET /health` reports the effective provider as `sandbox` (see
 `docs/self-host-health-checks.md` when present). HTTP 200 alone is not enough:
-confirm the JSON `sandbox` field matches the provider you set. A missing or
-invalid remote key can leave `sandbox: "none"` while `/health` still returns 200.
+confirm the JSON `sandbox` field matches the provider you set. A **missing**
+remote key falls back to `sandbox: "none"` while `/health` still returns 200.
+A present but **invalid** key still reports the chosen provider; `/health` will
+not catch that until provisioning fails.
 
 ## Quick pick
 
 | Goal | Set | Also need |
 | --- | --- | --- |
 | Default self-host (local Docker desktop per bot) | `SANDBOX_PROVIDER=docker` | `SANDBOX_SUPERVISOR_TOKEN`, computer image, Docker socket for supervisor |
-| UI only, no computers | `SANDBOX_PROVIDER=none` | (none) |
+| UI only, no computers | `SANDBOX_PROVIDER=none` | `SANDBOX_SUPERVISOR_TOKEN` (published-images Compose) |
 | Managed remote desktop | `e2b` / `daytona` / `box` | `SANDBOX_SUPERVISOR_TOKEN` (published-images Compose), matching API key (and optional URL knobs for Daytona/Box) |
 
 Published-images `infra/compose/.env.images.example` defaults to **`docker`**.
@@ -46,6 +48,9 @@ Signup and local Docker computers work **without** an E2B (or other remote) acco
 Boots API/web without computer provisioning. Use when Docker/supervisor is
 unavailable and you only need the control plane.
 
+Published-images Compose still requires `SANDBOX_SUPERVISOR_TOKEN` and starts
+the supervisor service even when `SANDBOX_PROVIDER=none`.
+
 ## Remote providers
 
 Set `SANDBOX_PROVIDER` to exactly one of:
@@ -73,5 +78,6 @@ curl -fsS http://127.0.0.1:3100/health
 ```
 
 Confirm `sandbox` equals the intended provider (`e2b`, `daytona`, or `box`).
-HTTP 200 with `sandbox: "none"` means computers are disabled (missing or invalid
-remote key), not a successful remote setup.
+HTTP 200 with `sandbox: "none"` means computers are disabled because the remote
+key is missing, not a successful remote setup. A present but invalid key still
+reports the chosen provider on `/health`; provisioning fails later.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `docs/self-host-sandbox-providers.md`, an operator guide for `SANDBOX_PROVIDER` modes (`docker`, `none`, `e2b`, `daytona`, `box`), supervisor token / health expectations, and remote egress notes. New file only; does not edit `docs/self-host.md`.

**Supersedes #522** (fork branch `fetw882:docs/self-host-sandbox-providers`). Original author: Zhang Ning ([@fetw882](https://github.com/fetw882)).

### Accuracy fixes vs #522 / Greptile

- Quick-pick remote and `none` rows list `SANDBOX_SUPERVISOR_TOKEN` for the published-images Compose path (Compose always requires it and always starts supervisor).
- `/health`: HTTP 200 alone is not enough. A **missing** remote key falls back to `sandbox: "none"`; a present but **invalid** key still reports the chosen provider and fails later at provisioning.
- Remote section notes that published-images Compose still needs `SANDBOX_SUPERVISOR_TOKEN`; it does not replace the remote API key.
- Dropped em dashes; kept prose short.
- Documented that `.env.images.example` defaults to `SANDBOX_PROVIDER=docker`.

## Test plan

- [x] Skim against `infra/compose/docker-compose.images.yml` (`:?` on `SANDBOX_SUPERVISOR_TOKEN`, supervisor always started)
- [x] Skim against `resolveSandboxProvider` (missing remote key → `none`; invalid key still selected)
- [x] Confirm single-file docs-only change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99926844-51d7-4fb8-a55e-4ddedb87b32c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99926844-51d7-4fb8-a55e-4ddedb87b32c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring sandbox providers through the `SANDBOX_PROVIDER` environment variable.
  - Documented Docker, control-plane-only, and remote provider options, including required credentials and optional URLs.
  - Added instructions for verifying the active sandbox provider through the health endpoint.
  - Clarified that missing remote credentials result in no sandbox being configured, while invalid credentials are reported as the selected provider and fail during provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->