### PR TITLE
docs(self-host): restricted-network operator index

### DIFF
--- a/docs/self-host-restricted-network.md
+++ b/docs/self-host-restricted-network.md
@@ -24,6 +24,14 @@ Stage A bootstrap discoverability is also summarized in the [README](../README.m
 5. Stack is up but bots cannot call models / remote sandboxes → day-2 egress and [computer provider](./self-host.md#choosing-a-computer-provider) choice; local `SANDBOX_PROVIDER=docker` still needs a computer image.
 6. Arm host + mysterious computer crash → pin both image tags to one multi-arch release ([Published images and tags](./self-host.md#published-images-and-tags)).
 
+For Hub pulls, prefer `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` when you can vendor those images. If you need a daemon mirror instead, merge a `registry-mirrors` array into your Docker daemon JSON (start from [docker-daemon.json](../infra/compose/docker-daemon.json); do not commit vendor CDN hostnames as repo defaults):
+
+```json
+{
+  "registry-mirrors": ["https://mirror.example.com"]
+}
+```
+
 ## Related guides
 
 Focused `docs/self-host-*.md` satellites may land later. Until then, use these existing pages:

--- a/docs/self-host-restricted-network.md
+++ b/docs/self-host-restricted-network.md
@@ -19,7 +19,7 @@ Stage A bootstrap discoverability is also summarized in the [README](../README.m
 
 1. Cannot download the installer script → Stage A mirror / local copy.
 2. Installer runs but cannot fetch Compose YAML → Stage B base or `--local`.
-3. Compose pull fails on app/computer → GHCR mirror env (`RAKAZO_IMAGE*`).
+3. Compose pull fails on app/computer → GHCR mirror env (`RAKAZO_IMAGE`, `RAKAZO_IMAGE_TAG`, `RAKAZO_COMPUTER_IMAGE`, `RAKAZO_COMPUTER_IMAGE_TAG`).
 4. Pull fails only on Postgres/busybox → Hub overrides (`POSTGRES_IMAGE` / `BUSYBOX_IMAGE`) or daemon `registry-mirrors`.
 5. Stack is up but bots cannot call models / remote sandboxes → day-2 egress and [computer provider](./self-host.md#choosing-a-computer-provider) choice; local `SANDBOX_PROVIDER=docker` still needs a computer image.
 6. Arm host + mysterious computer crash → pin both image tags to one multi-arch release ([Published images and tags](./self-host.md#published-images-and-tags)).

--- a/docs/self-host-restricted-network.md
+++ b/docs/self-host-restricted-network.md
@@ -1,0 +1,40 @@
+# Self-host restricted-network map
+
+Operator map for Mainland / corporate / flaky-registry installs.
+Do not bake vendor CDN hostnames into defaults.
+
+Canonical detail lives in [self-host.md](./self-host.md), especially
+[Restricted networks / mirror downloads](./self-host.md#restricted-networks--mirror-downloads).
+Stage A bootstrap discoverability is also summarized in the [README](../README.md).
+
+## Install stages (A → C)
+
+| Stage | Failure looks like | First move |
+| --- | --- | --- |
+| A: fetch installer | curl to raw GitHub fails | [`RAKAZO_INSTALLER_URL`](./self-host.md#restricted-networks--mirror-downloads) or pre-copy the script ([README](../README.md)) |
+| B: Compose + env example | curl under `infra/compose` fails | [`RAKAZO_DOWNLOAD_BASE`](./self-host.md#restricted-networks--mirror-downloads), [`--local`](./self-host.md#restricted-networks--mirror-downloads), or [`RAKAZO_DOWNLOAD_SKIP_EXISTING=1`](./self-host.md#restricted-networks--mirror-downloads) |
+| C: image pull | GHCR / Hub pull fails | [`RAKAZO_*_IMAGE*`](./self-host.md#restricted-networks--mirror-downloads), [`POSTGRES_IMAGE`](../infra/compose/docker-compose.images.yml) / [`BUSYBOX_IMAGE`](../infra/compose/docker-compose.images.yml); optional daemon [`registry-mirrors`](../infra/compose/docker-daemon.json) |
+
+## Decision tree
+
+1. Cannot download the installer script → Stage A mirror / local copy.
+2. Installer runs but cannot fetch Compose YAML → Stage B base or `--local`.
+3. Compose pull fails on app/computer → GHCR mirror env (`RAKAZO_IMAGE*`).
+4. Pull fails only on Postgres/busybox → Hub overrides (`POSTGRES_IMAGE` / `BUSYBOX_IMAGE`) or daemon `registry-mirrors`.
+5. Stack is up but bots cannot call models / remote sandboxes → day-2 egress and [computer provider](./self-host.md#choosing-a-computer-provider) choice; local `SANDBOX_PROVIDER=docker` still needs a computer image.
+6. Arm host + mysterious computer crash → pin both image tags to one multi-arch release ([Published images and tags](./self-host.md#published-images-and-tags)).
+
+## Related guides
+
+Focused `docs/self-host-*.md` satellites may land later. Until then, use these existing pages:
+
+| Topic | Doc |
+| --- | --- |
+| Restricted networks / Stages A-C | [Restricted networks / mirror downloads](./self-host.md#restricted-networks--mirror-downloads) |
+| Published images (no checkout) | [Published images (no checkout)](./self-host.md#published-images-no-checkout) |
+| Tags, arm64 pairing, digests | [Published images and tags](./self-host.md#published-images-and-tags) |
+| Sandbox / computer providers | [Choosing a computer provider](./self-host.md#choosing-a-computer-provider) |
+| Stage A installer discoverability | [README](../README.md) |
+| Compose image overrides (`POSTGRES_IMAGE`, `BUSYBOX_IMAGE`, app/computer) | [docker-compose.images.yml](../infra/compose/docker-compose.images.yml) |
+| Example Docker daemon config | [docker-daemon.json](../infra/compose/docker-daemon.json) |
+| Full self-host narrative | [self-host.md](./self-host.md) |

--- a/docs/self-host-restricted-network.md
+++ b/docs/self-host-restricted-network.md
@@ -24,7 +24,7 @@ Stage A bootstrap discoverability is also summarized in the [README](../README.m
 5. Stack is up but bots cannot call models / remote sandboxes → day-2 egress and [computer provider](./self-host.md#choosing-a-computer-provider) choice; local `SANDBOX_PROVIDER=docker` still needs a computer image.
 6. Arm host + mysterious computer crash → pin both image tags to one multi-arch release ([Published images and tags](./self-host.md#published-images-and-tags)).
 
-For Hub pulls, prefer `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` when you can vendor those images. If you need a daemon mirror instead, merge a `registry-mirrors` array into your Docker daemon JSON (start from [docker-daemon.json](../infra/compose/docker-daemon.json); do not commit vendor CDN hostnames as repo defaults):
+For Hub pulls, prefer `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` when you can vendor those images. If you need a daemon mirror instead, merge a `registry-mirrors` array into your Docker daemon JSON (start from [docker-daemon.json](../infra/compose/docker-daemon.json); do not commit vendor CDN hostnames as repo defaults), then restart Docker so the change takes effect:
 
 ```json
 {

--- a/docs/self-host-restricted-network.md
+++ b/docs/self-host-restricted-network.md
@@ -13,7 +13,7 @@ Stage A bootstrap discoverability is also summarized in the [README](../README.m
 | --- | --- | --- |
 | A: fetch installer | curl to raw GitHub fails | [`RAKAZO_INSTALLER_URL`](./self-host.md#restricted-networks--mirror-downloads) or pre-copy the script ([README](../README.md)) |
 | B: Compose + env example | curl under `infra/compose` fails | [`RAKAZO_DOWNLOAD_BASE`](./self-host.md#restricted-networks--mirror-downloads), [`--local`](./self-host.md#restricted-networks--mirror-downloads), or [`RAKAZO_DOWNLOAD_SKIP_EXISTING=1`](./self-host.md#restricted-networks--mirror-downloads) |
-| C: image pull | GHCR / Hub pull fails | [`RAKAZO_*_IMAGE*`](./self-host.md#restricted-networks--mirror-downloads), [`POSTGRES_IMAGE`](../infra/compose/docker-compose.images.yml) / [`BUSYBOX_IMAGE`](../infra/compose/docker-compose.images.yml); optional daemon [`registry-mirrors`](../infra/compose/docker-daemon.json) |
+| C: image pull | GHCR / Hub pull fails | [`RAKAZO_*_IMAGE*`](./self-host.md#restricted-networks--mirror-downloads), [`POSTGRES_IMAGE`](../infra/compose/docker-compose.images.yml) / [`BUSYBOX_IMAGE`](../infra/compose/docker-compose.images.yml); optional daemon `registry-mirrors` ([how](./self-host.md#restricted-networks--mirror-downloads); base example [docker-daemon.json](../infra/compose/docker-daemon.json)) |
 
 ## Decision tree
 
@@ -36,5 +36,5 @@ Focused `docs/self-host-*.md` satellites may land later. Until then, use these e
 | Sandbox / computer providers | [Choosing a computer provider](./self-host.md#choosing-a-computer-provider) |
 | Stage A installer discoverability | [README](../README.md) |
 | Compose image overrides (`POSTGRES_IMAGE`, `BUSYBOX_IMAGE`, app/computer) | [docker-compose.images.yml](../infra/compose/docker-compose.images.yml) |
-| Example Docker daemon config | [docker-daemon.json](../infra/compose/docker-daemon.json) |
+| Example Docker daemon config (add `registry-mirrors` locally if Hub is blocked) | [docker-daemon.json](../infra/compose/docker-daemon.json) |
 | Full self-host narrative | [self-host.md](./self-host.md) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `docs/self-host-restricted-network.md`: a Stage A/B/C operator map, short decision tree, and related-guides index for Mainland / corporate / flaky-registry installs. New file only (does not edit `docs/self-host.md`).

**Supersedes #523.** Original author: [@fetw882](https://github.com/fetw882) / Zhang Ning (attribution preserved via Co-authored-by).

**Greptile fix:** the related-guides table no longer lists nonexistent satellite docs or a phantom `docker-daemon.registry-mirrors.example.json`. Links point at existing material (`./self-host.md`, README, `infra/compose/docker-daemon.json`, `docker-compose.images.yml`) with navigable relative markdown.

## Test plan

- [x] Confirm only `docs/self-host-restricted-network.md` is added
- [x] Confirm every Doc / path link resolves on current `main`
- [x] No vendor CDN hostnames in defaults; no PR-number refs; no em dashes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47474b25-9834-4ba5-bf7b-9e75c11a5306?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47474b25-9834-4ba5-bf7b-9e75c11a5306&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for self-hosting in restricted or unreliable network environments.
  * Documented a three-stage installation process with configuration options for diagnosing failures.
  * Added a troubleshooting decision tree covering installation and runtime issues.
  * Included instructions for configuring Docker registry mirrors.
  * Added links to related self-hosting documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->