### PR TITLE
docs(self-host): opt-in Compose updater profile

### DIFF
--- a/docs/self-host-updater.md
+++ b/docs/self-host-updater.md
@@ -1,0 +1,49 @@
+# Self-host updater sidecar
+
+Opt-in production **updater** sidecar (Compose profile `updater`).
+
+Published-images path (`install-images.sh` / `docker-compose.images.yml`) does not include this sidecar. This page is for production Compose (`infra/compose/docker-compose.prod.yml`). For the short recipe in the main guide, see [Updater sidecar](self-host.md#updater-sidecar).
+
+## Why it is opt-in
+
+The updater mounts the host Docker socket (root-equivalent) and the deploy directory.
+It is the process that pulls/recreates app services; it does not recreate itself.
+Leave the profile disabled unless you accept that privilege boundary.
+
+## Enable
+
+1. Set a dedicated `RAKAZO_UPDATER_TOKEN` (≥32 chars in production), distinct from `BETTER_AUTH_SECRET`, `SANDBOX_SUPERVISOR_TOKEN`, and `SCREEN_PROXY_SECRET`.
+2. Set `RAKAZO_UPDATER_URL` for the API (Compose wires `http://updater:7092` on the control network when the profile is on).
+3. Ensure `RAKAZO_DEPLOY_DIR` matches the checkout path the Docker daemon sees (default `/srv/rakazo` on Linux).
+4. Start with the profile, building the updater when needed:
+
+```bash
+docker compose --env-file .env -f infra/compose/docker-compose.prod.yml \
+  --profile updater up -d --build updater
+```
+
+Image knobs: `RAKAZO_UPDATER_IMAGE` / `RAKAZO_UPDATER_IMAGE_TAG` (defaults `ghcr.io/elie222/rakazo/updater` + `local`). Moving the updater version is an operator action; updates do not roll the sidecar underneath itself.
+
+## Network and exposure
+
+- No host `ports`: nothing published on the host by default.
+- Shares the Compose `control` network with the API only.
+- Caddy has no public route to the updater (ingress reverse proxy must not expose it).
+- `/health` on the sidecar is open (liveness); other updater routes require the shared bearer token.
+
+## Health
+
+Compose healthcheck hits `http://127.0.0.1:7092/health` inside the updater container.
+Expect JSON shaped like `{ "ok": true, "service": "updater", ... }`.
+API `/health` is separate; the public single-VM recipe checks it at `https://$RAKAZO_HOST/health` (see [Public single-VM deployment](self-host.md#public-single-vm-deployment)).
+
+## Restricted networks
+
+Pulling a newer app tag still needs GHCR (or your `RAKAZO_IMAGE` mirror) reachable from the daemon.
+If Stage C pulls already fail, fix registry overrides first; enabling the updater does not bypass that.
+See [Restricted networks / mirror downloads](self-host.md#restricted-networks--mirror-downloads).
+
+## Related
+
+- Token distinctness and privilege scope: [The updater's privileges](self-host.md#the-updaters-privileges)
+- Sandbox / computer provider (orthogonal): [Choosing a computer provider](self-host.md#choosing-a-computer-provider)

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -476,8 +476,9 @@ and refuses the official path until a stable `vX.Y.Z` exists.
 ### Updater sidecar
 
 Compose production deployments offer an opt-in `updater` profile on a private `control` network.
-Normal deployments do not start it or require its credential. To enable it, set a dedicated
-`RAKAZO_UPDATER_TOKEN` and explicitly start the profile:
+Normal deployments do not start it or require its credential. Longer notes on the privilege
+boundary, env knobs, and network exposure live in [Self-host updater sidecar](self-host-updater.md).
+To enable it, set a dedicated `RAKAZO_UPDATER_TOKEN` and explicitly start the profile:
 
 ```bash
 docker compose --env-file .env -f infra/compose/docker-compose.prod.yml \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Follow-up that supersedes contributor PR #524 (fetw882). Their head branch lives only on the fork, so this ports the useful updater-sidecar guide onto `elie222/rakazo` with link and discoverability fixes.

Credit: [@fetw882](https://github.com/fetw882) via #524 (`docs: add self-host updater sidecar guide`).

## What changed

- Add `docs/self-host-updater.md` covering the opt-in Compose `updater` profile (socket privilege boundary, token/URL/deploy dir, image knobs, no host ports / control network / no Caddy route, healthcheck, restricted-network registry note).
- Rewrite Health / Restricted networks / Related to point at real anchors in `docs/self-host.md` (the draft linked nonexistent sibling docs).
- Add a one-sentence inbound link under the existing [Updater sidecar](docs/self-host.md#updater-sidecar) section; leave that section in place.
- Drop meta process lines ("new file only…").
- Align the enable command with the existing `--profile updater … --build updater` recipe.
- Facts checked against `infra/compose/docker-compose.prod.yml`.

## Test plan

- [x] Skim against compose updater profile / env names
- [x] Confirm dead sibling links are gone; inbound link from `self-host.md` works
- [ ] Docs-only; no runtime tests

Supersedes #524.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69297ff4-8818-4dd8-b410-52f47184da91?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69297ff4-8818-4dd8-b410-52f47184da91&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

