### PR TITLE
fix(desktop): use macOS-safe icon for the dev dock

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,7 +29,12 @@ import {
 } from "./setup-config.js";
 import { clearSetup, readSetup, writeSetup } from "./setup-store.js";
 import { shouldOpenInAppPopup } from "./window-open.js";
-import { browserWindowOptions, setupWindowOptions, warmWindowTtlMs } from "./window-options.js";
+import {
+  browserWindowOptions,
+  developmentIconFile,
+  setupWindowOptions,
+  warmWindowTtlMs,
+} from "./window-options.js";
 
 const PERFORMANCE_USER_DATA = process.env.RAKAZO_PERFORMANCE_USER_DATA;
 const PROBE_TIMEOUT_MS = 8_000;
@@ -81,7 +86,7 @@ function fromMainWindow(event: Electron.IpcMainInvokeEvent) {
 
 function developmentIcon() {
   if (app.isPackaged) return undefined;
-  const icon = path.join(app.getAppPath(), "assets", "icon.png");
+  const icon = path.join(app.getAppPath(), "assets", developmentIconFile(process.platform));
   return existsSync(icon) ? icon : undefined;
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -84,6 +84,7 @@ function fromMainWindow(event: Electron.IpcMainInvokeEvent) {
   return mainWindow !== null && windowFrom(event) === mainWindow;
 }
 
+/** Dock/taskbar icon for unpackaged launches; packaged builds get theirs from electron-builder. */
 function developmentIcon() {
   if (app.isPackaged) return undefined;
   const icon = path.join(app.getAppPath(), "assets", developmentIconFile(process.platform));

--- a/apps/desktop/src/window-options.test.ts
+++ b/apps/desktop/src/window-options.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   browserWindowOptions,
   DEFAULT_WARM_WINDOW_TTL_MS,
+  developmentIconFile,
   setupWindowOptions,
   warmWindowTtlMs,
 } from "./window-options.js";
@@ -55,4 +56,16 @@ describe("warm window lifetime", () => {
       expect(warmWindowTtlMs(value)).toBe(DEFAULT_WARM_WINDOW_TTL_MS);
     },
   );
+});
+
+describe("development icon", () => {
+  it("uses the squircle asset on macOS because the dock draws the file unmasked", () => {
+    expect(developmentIconFile("darwin")).toBe("icon-macos.png");
+  });
+
+  it("keeps the full-bleed icon elsewhere", () => {
+    for (const platform of ["win32", "linux"] as const) {
+      expect(developmentIconFile(platform)).toBe("icon.png");
+    }
+  });
 });

--- a/apps/desktop/src/window-options.ts
+++ b/apps/desktop/src/window-options.ts
@@ -25,6 +25,14 @@ export function browserWindowOptions(platform: NodeJS.Platform) {
   return { width: 1440, height: 900, ...windowChrome(platform) };
 }
 
+/**
+ * Unpackaged (dev) launches set the dock/taskbar icon by hand. macOS draws the file as-is,
+ * so it needs the squircle-with-margins asset; packaged builds already use icon.icns.
+ */
+export function developmentIconFile(platform: NodeJS.Platform) {
+  return platform === "darwin" ? "icon-macos.png" : "icon.png";
+}
+
 /** The first-run setup window is smaller and keeps the same frameless chrome. */
 export function setupWindowOptions(platform: NodeJS.Platform) {
   return { width: 720, height: 700, minWidth: 480, minHeight: 560, ...windowChrome(platform) };


### PR DESCRIPTION
## Why
Running `pnpm --filter @rakazo/desktop dev` on macOS shows a hard-edged blue square in the Dock. `developmentIcon()` loads `assets/icon.png`, a 1024px full-bleed image with no alpha channel, and macOS draws Dock icons exactly as supplied. 797461c7 fixed packaged builds by regenerating `icon.icns` from `assets/icon-macos.png` (transparent squircle margins), but the unpackaged/dev path kept pointing at the square asset.

## What changed
- `apps/desktop/src/window-options.ts`: new `developmentIconFile(platform)` helper, `icon-macos.png` on darwin, `icon.png` elsewhere.
- `apps/desktop/src/main.ts`: `developmentIcon()` uses the helper.
- `apps/desktop/src/window-options.test.ts`: covers both branches.

Packaged builds are unaffected; they already use `assets/icon.icns`.

## How it was tested
- `pnpm --filter @rakazo/desktop check` and `pnpm --filter @rakazo/desktop test` (115 passing), Biome clean.
- Relaunched `pnpm --filter @rakazo/desktop dev` on macOS 26 and confirmed the Dock shows the rounded icon.

Dev-only, non-UI-route change, so no E2E screenshot applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Qt4w8NTC3SXxmYpZSzKvZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Development builds now display the correct application icon on macOS.
  * Windows and Linux development builds continue using the standard development icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->