### PR TITLE
test(eval): Chief-of-Staff release-watch tools-vs-browser (#505)

### DIFF
--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -412,7 +412,8 @@ export const builtinAgentTools: ConnectorTool[] = [
         name: { type: "string", description: "Short label shown in Routines." },
         prompt: {
           type: "string",
-          description: "What the bot should do when the schedule fires.",
+          description:
+            "Concrete steps for when the schedule fires: name the connected plugin tools to call (e.g. GITHUB_LIST_RELEASES for owner/repo), what to extract, and how to report. Prefer plugin tools over computer browser or web search for app data.",
         },
         cron: { type: "string", description: "5-field cron for repeating schedules." },
         every: { type: "number", description: "Repeat interval amount for repeating schedules." },

--- a/packages/adapters/src/composio-emulator.test.ts
+++ b/packages/adapters/src/composio-emulator.test.ts
@@ -7,6 +7,8 @@ const context = {
   traceId: "test",
   spaceId: "workspace",
   userId: "user-1",
+  botId: "bot-1",
+  runId: "run-1",
   signal: new AbortController().signal,
 };
 
@@ -75,9 +77,56 @@ describe("ComposioEmulator", () => {
     expect(emulator.executions).toEqual([
       {
         userId: context.userId,
+        botId: context.botId,
+        runId: context.runId,
         tool: "GMAIL_EMULATED_ACTION",
         args: { value: "ok" },
+        result: { ok: true, tool: "GMAIL_EMULATED_ACTION", args: { value: "ok" } },
       },
     ]);
+  });
+
+  it("exposes seeded GitHub release tools without live OAuth", async () => {
+    const emulator = new ComposioEmulator();
+    const connectedContext = {
+      ...context,
+      connectedConnections: [
+        {
+          id: "connection-github",
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "GitHub",
+        },
+      ],
+    };
+
+    const tools = await emulator.discoverTools(connectedContext);
+    expect(tools.map((tool) => tool.name)).toEqual(["GITHUB_LIST_RELEASES", "GITHUB_GET_RELEASE"]);
+    expect(tools.map((tool) => tool.name)).not.toContain("GITHUB_EMULATED_ACTION");
+
+    const events = [];
+    for await (const event of emulator.execute(
+      {
+        tool: "GITHUB_LIST_RELEASES",
+        args: { owner: "elie222", repo: "rakazo" },
+        executionId: "github-list-releases",
+      },
+      connectedContext,
+    )) {
+      events.push(event);
+    }
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "result",
+        data: expect.objectContaining({
+          ok: true,
+          releases: expect.arrayContaining([
+            expect.objectContaining({ tag: "v0.4.2" }),
+            expect.objectContaining({ tag: "v0.4.1" }),
+          ]),
+        }),
+      }),
+    );
+    expect(emulator.listGithubReleases()[0]?.tag).toBe("v0.4.2");
   });
 });

--- a/packages/adapters/src/composio-emulator.ts
+++ b/packages/adapters/src/composio-emulator.ts
@@ -9,6 +9,11 @@ import {
   type ComposioProvider,
   filterCatalog,
 } from "./composio-connector.js";
+import {
+  DEFAULT_RAKAZO_EMULATED_RELEASES,
+  type EmulatedGithubRelease,
+  RELEASE_WATCH_GITHUB_TOOL_NAMES,
+} from "./release-watch.js";
 
 const DEFAULT_CATALOG: ReadonlyArray<Omit<ComposioCatalogItem, "connected">> = [
   { slug: "GMAIL", name: "Gmail", logo: null, noAuth: false },
@@ -22,10 +27,14 @@ const DEFAULT_CATALOG: ReadonlyArray<Omit<ComposioCatalogItem, "connected">> = [
 /** Deterministic, offline Composio catalog and connection emulator for product tests. */
 export class ComposioEmulator implements ComposioProvider {
   private readonly connectedByUser = new Map<string, Set<string>>();
+  private githubReleases: EmulatedGithubRelease[] = [...DEFAULT_RAKAZO_EMULATED_RELEASES];
   readonly executions: Array<{
     userId: string;
+    botId?: string;
+    runId?: string;
     tool: string;
     args: Record<string, unknown>;
+    result: Record<string, unknown>;
   }> = [];
 
   constructor(
@@ -33,6 +42,15 @@ export class ComposioEmulator implements ComposioProvider {
       Omit<ComposioCatalogItem, "connected">
     > = DEFAULT_CATALOG,
   ) {}
+
+  /** Replace seeded GitHub releases (no live GitHub OAuth). */
+  seedGithubReleases(releases: readonly EmulatedGithubRelease[]): void {
+    this.githubReleases = [...releases];
+  }
+
+  listGithubReleases(): readonly EmulatedGithubRelease[] {
+    return this.githubReleases;
+  }
 
   describe() {
     return {
@@ -68,19 +86,39 @@ export class ComposioEmulator implements ComposioProvider {
         .map((connection) => connection.externalId) ??
       context.connectedProviders ??
       [];
-    return [...new Set(connected)].map((slug) => ({
-      name: `${slug}_EMULATED_ACTION`,
-      description: `Run a deterministic ${slug} action`,
-      inputSchema: {
-        type: "object",
-        properties: { value: { type: "string" } },
-      },
-    }));
+    const tools: ConnectorTool[] = [];
+    for (const slug of new Set(connected)) {
+      if (slug === "GITHUB") {
+        tools.push(...githubReleaseTools());
+        continue;
+      }
+      tools.push({
+        name: `${slug}_EMULATED_ACTION`,
+        description: `Run a deterministic ${slug} action`,
+        inputSchema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+        },
+      });
+    }
+    return tools;
   }
 
   async *execute(call: ConnectorCall, context: AdapterContext): AsyncIterable<ConnectorEvent> {
-    this.executions.push({ userId: context.userId, tool: call.tool, args: call.args });
-    yield { type: "result", data: { ok: true, tool: call.tool, args: call.args } };
+    const result =
+      (RELEASE_WATCH_GITHUB_TOOL_NAMES as readonly string[]).includes(call.tool) ||
+      call.tool === "GITHUB_EMULATED_ACTION"
+        ? this.executeGithub(call.tool, call.args)
+        : { ok: true, tool: call.tool, args: call.args };
+    this.executions.push({
+      userId: context.userId,
+      botId: context.botId,
+      runId: context.runId,
+      tool: call.tool,
+      args: call.args,
+      result,
+    });
+    yield { type: "result", data: result };
   }
 
   async begin(
@@ -107,4 +145,74 @@ export class ComposioEmulator implements ComposioProvider {
   async revoke(connectionRef: string, context: AdapterContext): Promise<void> {
     this.connectedByUser.get(context.userId)?.delete(connectionRef);
   }
+
+  private executeGithub(tool: string, args: Record<string, unknown>): Record<string, unknown> {
+    const owner = String(args.owner ?? args.owner_name ?? "elie222");
+    const repo = String(args.repo ?? args.repository ?? "rakazo");
+    const matched = this.githubReleases.filter(
+      (release) =>
+        release.owner.toLowerCase() === owner.toLowerCase() &&
+        release.repo.toLowerCase() === repo.toLowerCase(),
+    );
+    if (tool === "GITHUB_LIST_RELEASES" || tool === "GITHUB_EMULATED_ACTION") {
+      return {
+        ok: true,
+        tool,
+        owner,
+        repo,
+        releases: matched.map((release) => ({
+          tag: release.tag,
+          name: release.name,
+          body: release.body,
+          publishedAt: release.publishedAt,
+          htmlUrl: release.htmlUrl,
+        })),
+      };
+    }
+    if (tool === "GITHUB_GET_RELEASE") {
+      const tag = args.tag ? String(args.tag) : undefined;
+      const release = tag
+        ? matched.find((row) => row.tag === tag)
+        : [...matched].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt))[0];
+      if (!release) {
+        return { ok: false, tool, error: `No release found for ${owner}/${repo}` };
+      }
+      return { ok: true, tool, release };
+    }
+    return { ok: false, tool, error: `unknown GitHub tool ${tool}` };
+  }
+}
+
+function githubReleaseTools(): ConnectorTool[] {
+  return [
+    {
+      name: "GITHUB_LIST_RELEASES",
+      description:
+        "List releases for a GitHub repository (owner + repo). Prefer this over browsing github.com or web search when GitHub is connected.",
+      readOnly: true,
+      inputSchema: {
+        type: "object",
+        properties: {
+          owner: { type: "string", description: "Repository owner, e.g. elie222" },
+          repo: { type: "string", description: "Repository name, e.g. rakazo" },
+        },
+        required: ["owner", "repo"],
+      },
+    },
+    {
+      name: "GITHUB_GET_RELEASE",
+      description:
+        "Get one GitHub release by tag for owner/repo, or the latest release when tag is omitted. Prefer this over a computer browser.",
+      readOnly: true,
+      inputSchema: {
+        type: "object",
+        properties: {
+          owner: { type: "string" },
+          repo: { type: "string" },
+          tag: { type: "string", description: "Release tag; omit for latest." },
+        },
+        required: ["owner", "repo"],
+      },
+    },
+  ];
 }

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2676,7 +2676,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
 
         const pluginLine =
           connectedPlugins.length > 0
-            ? `Connected plugins: ${connectedPlugins.map((row) => `${row.displayName} (${row.connectorId}:${row.provider})`).join(", ")}. Use those plugin tools when the user asks about those apps.`
+            ? `Connected plugins: ${connectedPlugins.map((row) => `${row.displayName} (${row.connectorId}:${row.provider})`).join(", ")}. Prefer those plugin tools over the computer browser or web search when reading app data (repos, releases, mail, calendar, and similar).`
             : "No plugins are connected yet.";
         const taughtSkillIndex = savedSkills.slice(0, 20);
         const taughtSkillsLine =

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -60,6 +60,7 @@ export * from "./pi-openai-compatible-provider.js";
 export * from "./pi-runtime.js";
 export * from "./pipedream-connector.js";
 export * from "./realtime.js";
+export * from "./release-watch.js";
 export * from "./remote-mcp.js";
 export * from "./run-secret.js";
 export * from "./sandbox-factory.js";

--- a/packages/adapters/src/release-watch-guidance.test.ts
+++ b/packages/adapters/src/release-watch-guidance.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { builtinAgentTools } from "./builtin-tools.js";
+
+describe("release-watch guidance", () => {
+  it("tells schedule_create prompts to name plugin tools instead of browsing", () => {
+    const tool = builtinAgentTools.find((entry) => entry.name === "schedule_create");
+    expect(tool).toBeTruthy();
+    const prompt = (
+      tool?.inputSchema as { properties?: { prompt?: { description?: string } } } | undefined
+    )?.properties?.prompt;
+    expect(prompt?.description ?? "").toContain("GITHUB_LIST_RELEASES");
+    expect(prompt?.description ?? "").toMatch(/Prefer plugin tools over computer browser/i);
+  });
+});

--- a/packages/adapters/src/release-watch.test.ts
+++ b/packages/adapters/src/release-watch.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessReleaseWatchRoutinePrompt,
+  diagnoseReleaseWatchRun,
+  githubToolResultHasSeededRelease,
+  RELEASE_WATCH_EVAL_DEFAULT_MODEL_ID,
+  RELEASE_WATCH_EVAL_MODEL_LABEL,
+  RELEASE_WATCH_GITHUB_TOOL_NAMES,
+  resolveReleaseWatchEvalModelId,
+} from "./release-watch.js";
+
+describe("release-watch diagnosis", () => {
+  it("maps GPT 5.6 Luna to the in-repo OpenRouter/Pi model id without inventing a lock", () => {
+    expect(RELEASE_WATCH_EVAL_MODEL_LABEL).toBe("GPT 5.6 Luna");
+    expect(RELEASE_WATCH_EVAL_DEFAULT_MODEL_ID).toBe("openai/gpt-5.6-luna");
+    expect(resolveReleaseWatchEvalModelId({}).modelId).toBe("openai/gpt-5.6-luna");
+    expect(
+      resolveReleaseWatchEvalModelId({ RELEASE_WATCH_EVAL_MODEL: " provider/custom-luna " })
+        .modelId,
+    ).toBe("provider/custom-luna");
+  });
+
+  it("flags vague routine prompts and accepts concrete GitHub tool steps", () => {
+    expect(assessReleaseWatchRoutinePrompt("check updates").diagnosis).toBe("vague_routine_prompt");
+    expect(
+      assessReleaseWatchRoutinePrompt(
+        "Open Bing and search for rakazo releases on the computer browser.",
+      ).diagnosis,
+    ).toBe("browser_used_instead_of_integrations");
+
+    const good = assessReleaseWatchRoutinePrompt(
+      [
+        "Daily: use GITHUB_LIST_RELEASES for owner elie222 repo rakazo.",
+        "Summarize new release tags and capability notes from release bodies.",
+        "Prefer the GitHub plugin tools; do not browse or Bing-search.",
+      ].join(" "),
+    );
+    expect(good).toMatchObject({ ok: true, diagnosis: "ok" });
+  });
+
+  it("diagnoses missing tools, browser fallback, and missing release info distinctly", () => {
+    const missingTools = diagnoseReleaseWatchRun({
+      availableToolNames: ["computer_observe", "computer_act"],
+      calledToolNames: ["computer_act"],
+      routinePrompt: "Stay current on rakazo somehow.",
+      resultText: "I searched Bing and hit an error.",
+      seededReleaseTags: ["v0.4.2"],
+    });
+    expect(missingTools.pass).toBe(false);
+    expect(missingTools.diagnoses).toEqual(
+      expect.arrayContaining([
+        "vague_routine_prompt",
+        "missing_tools",
+        "browser_used_instead_of_integrations",
+        "no_release_info_retrieved",
+      ]),
+    );
+    expect(missingTools.summary).toMatch(/vague_routine_prompt/);
+    expect(missingTools.summary).toMatch(/missing_tools/);
+    expect(missingTools.summary).toMatch(/browser_used_instead_of_integrations/);
+
+    const emptyGithubCall = diagnoseReleaseWatchRun({
+      availableToolNames: [...RELEASE_WATCH_GITHUB_TOOL_NAMES],
+      calledToolNames: ["GITHUB_LIST_RELEASES"],
+      routinePrompt:
+        "Call GITHUB_LIST_RELEASES for elie222/rakazo and summarize new releases and capabilities.",
+      resultText: "GitHub returned no releases.",
+      seededReleaseTags: ["v0.4.2"],
+    });
+    expect(emptyGithubCall.pass).toBe(false);
+    expect(emptyGithubCall.diagnoses).toContain("no_release_info_retrieved");
+
+    const pass = diagnoseReleaseWatchRun({
+      availableToolNames: [...RELEASE_WATCH_GITHUB_TOOL_NAMES],
+      calledToolNames: ["GITHUB_LIST_RELEASES"],
+      routinePrompt:
+        "Call GITHUB_LIST_RELEASES for elie222/rakazo and summarize new releases and capabilities.",
+      resultText: "Latest is v0.4.2 with routine tools + connector emulators.",
+      seededReleaseTags: ["v0.4.2"],
+    });
+    expect(pass).toEqual({
+      pass: true,
+      diagnoses: ["ok"],
+      summary: "Release watch used GitHub tools successfully.",
+    });
+
+    const failedPayload = diagnoseReleaseWatchRun({
+      availableToolNames: [...RELEASE_WATCH_GITHUB_TOOL_NAMES],
+      calledToolNames: ["GITHUB_LIST_RELEASES"],
+      routinePrompt:
+        "Call GITHUB_LIST_RELEASES for elie222/rakazo and summarize new releases and capabilities.",
+      resultText: "Tool finished without useful output.",
+      seededReleaseTags: ["v0.4.2"],
+      githubToolResults: [{ ok: false, tool: "GITHUB_LIST_RELEASES", error: "upstream failed" }],
+    });
+    expect(failedPayload.pass).toBe(false);
+    expect(failedPayload.diagnoses).toContain("no_release_info_retrieved");
+
+    const emptyPayload = diagnoseReleaseWatchRun({
+      availableToolNames: [...RELEASE_WATCH_GITHUB_TOOL_NAMES],
+      calledToolNames: ["GITHUB_LIST_RELEASES"],
+      routinePrompt:
+        "Call GITHUB_LIST_RELEASES for elie222/rakazo and summarize new releases and capabilities.",
+      resultText: "Tool finished without useful output.",
+      seededReleaseTags: ["v0.4.2"],
+      githubToolResults: [{ ok: true, tool: "GITHUB_LIST_RELEASES", releases: [] }],
+    });
+    expect(emptyPayload.pass).toBe(false);
+    expect(emptyPayload.diagnoses).toContain("no_release_info_retrieved");
+    expect(
+      githubToolResultHasSeededRelease(
+        { ok: true, releases: [{ tag: "v0.4.2", name: "v0.4.2" }] },
+        ["v0.4.2"],
+      ),
+    ).toBe(true);
+    expect(githubToolResultHasSeededRelease({ releases: [{ tag: "v0.4.2" }] }, ["v0.4.2"])).toBe(
+      false,
+    );
+    expect(
+      githubToolResultHasSeededRelease({ ok: false, error: "v0.4.2 unavailable" }, ["v0.4.2"]),
+    ).toBe(false);
+    expect(
+      githubToolResultHasSeededRelease(
+        { ok: true, note: "mentions v0.4.2", releases: [{ tag: "v9.9.9" }] },
+        ["v0.4.2"],
+      ),
+    ).toBe(false);
+
+    const tagOnlyAfterFailedPayload = diagnoseReleaseWatchRun({
+      availableToolNames: [...RELEASE_WATCH_GITHUB_TOOL_NAMES],
+      calledToolNames: ["GITHUB_LIST_RELEASES"],
+      routinePrompt:
+        "Call GITHUB_LIST_RELEASES for elie222/rakazo and summarize new releases and capabilities.",
+      resultText: "Latest is v0.4.2 with routine tools + connector emulators.",
+      seededReleaseTags: ["v0.4.2"],
+      githubToolResults: [{ ok: false, tool: "GITHUB_LIST_RELEASES", error: "upstream failed" }],
+    });
+    expect(tagOnlyAfterFailedPayload.pass).toBe(false);
+    expect(tagOnlyAfterFailedPayload.diagnoses).toContain("no_release_info_retrieved");
+
+    const passViaPayload = diagnoseReleaseWatchRun({
+      availableToolNames: [...RELEASE_WATCH_GITHUB_TOOL_NAMES],
+      calledToolNames: ["GITHUB_LIST_RELEASES"],
+      routinePrompt:
+        "Call GITHUB_LIST_RELEASES for elie222/rakazo and summarize new releases and capabilities.",
+      resultText: "Checked GitHub releases.",
+      seededReleaseTags: ["v0.4.2"],
+      githubToolResults: [
+        {
+          ok: true,
+          tool: "GITHUB_LIST_RELEASES",
+          releases: [{ tag: "v0.4.2", name: "v0.4.2 — routine tools" }],
+        },
+      ],
+    });
+    expect(passViaPayload).toEqual({
+      pass: true,
+      diagnoses: ["ok"],
+      summary: "Release watch used GitHub tools successfully.",
+    });
+  });
+});

--- a/packages/adapters/src/release-watch.ts
+++ b/packages/adapters/src/release-watch.ts
@@ -1,0 +1,224 @@
+/**
+ * Provider-neutral helpers for the release-watch routine eval (GitHub issue about
+ * Chief-of-Staff daily release monitoring falling back to a computer browser).
+ *
+ * Offline pieces run in normal CI. The live LLM path maps Elie's "GPT 5.6 Luna"
+ * name to a concrete model id without locking the product to one vendor.
+ */
+
+/** Elie's name for the eval model. */
+export const RELEASE_WATCH_EVAL_MODEL_LABEL = "GPT 5.6 Luna";
+
+/**
+ * Default OpenRouter / Pi model string for GPT 5.6 Luna.
+ * Override with `RELEASE_WATCH_EVAL_MODEL` (or the host's usual default-model env).
+ */
+export const RELEASE_WATCH_EVAL_DEFAULT_MODEL_ID = "openai/gpt-5.6-luna";
+
+/** Composio-style GitHub tools the emulator exposes for release watching. */
+export const RELEASE_WATCH_GITHUB_TOOL_NAMES = [
+  "GITHUB_LIST_RELEASES",
+  "GITHUB_GET_RELEASE",
+] as const;
+
+export type ReleaseWatchGithubToolName = (typeof RELEASE_WATCH_GITHUB_TOOL_NAMES)[number];
+
+export type ReleaseWatchDiagnosis =
+  | "ok"
+  | "vague_routine_prompt"
+  | "missing_tools"
+  | "browser_used_instead_of_integrations"
+  | "no_release_info_retrieved";
+
+export type EmulatedGithubRelease = {
+  owner: string;
+  repo: string;
+  tag: string;
+  name: string;
+  body: string;
+  publishedAt: string;
+  htmlUrl: string;
+};
+
+/** Seeded rakazo releases so evals succeed without the public internet. */
+export const DEFAULT_RAKAZO_EMULATED_RELEASES: readonly EmulatedGithubRelease[] = [
+  {
+    owner: "elie222",
+    repo: "rakazo",
+    tag: "v0.4.2",
+    name: "v0.4.2 — routine tools + connector emulators",
+    body: "Routines can bind connector tools. Composio emulator covers GitHub releases offline.",
+    publishedAt: "2026-08-28T12:00:00.000Z",
+    htmlUrl: "https://github.com/elie222/rakazo/releases/tag/v0.4.2",
+  },
+  {
+    owner: "elie222",
+    repo: "rakazo",
+    tag: "v0.4.1",
+    name: "v0.4.1 — computer + plugin guidance",
+    body: "Prefer connected plugins over browsing when reading app data.",
+    publishedAt: "2026-08-20T12:00:00.000Z",
+    htmlUrl: "https://github.com/elie222/rakazo/releases/tag/v0.4.1",
+  },
+];
+
+const COMPUTER_OR_BROWSER_TOOLS = new Set([
+  "computer_observe",
+  "computer_act",
+  "open_path",
+  "launch_app",
+]);
+
+export function resolveReleaseWatchEvalModelId(env: NodeJS.ProcessEnv = process.env): {
+  label: string;
+  modelId: string;
+} {
+  const modelId =
+    env.RELEASE_WATCH_EVAL_MODEL?.trim() ||
+    env.PI_DEFAULT_MODEL?.trim() ||
+    RELEASE_WATCH_EVAL_DEFAULT_MODEL_ID;
+  return { label: RELEASE_WATCH_EVAL_MODEL_LABEL, modelId };
+}
+
+/** Heuristic: a useful release-watch routine names the repo, releases, and GitHub tools. */
+export function assessReleaseWatchRoutinePrompt(prompt: string): {
+  ok: boolean;
+  diagnosis: ReleaseWatchDiagnosis;
+  details: string;
+} {
+  const text = prompt.trim();
+  if (text.length < 48) {
+    return {
+      ok: false,
+      diagnosis: "vague_routine_prompt",
+      details: "Routine prompt is too short to encode concrete steps.",
+    };
+  }
+
+  const mentionsRepo = /rakazo|elie222/i.test(text);
+  const mentionsReleases = /release/i.test(text);
+  const mentionsGithubTool =
+    /GITHUB_LIST_RELEASES|GITHUB_GET_RELEASE|list(?:\s+\w+){0,4}\s+releases|github\s+(tool|integration|plugin|connector|api)/i.test(
+      text,
+    );
+  const steersToBrowser =
+    /\b(bing|google search|search the web|open (a |the )?browser|computer_act|computer_observe)\b/i.test(
+      text,
+    ) && !mentionsGithubTool;
+
+  if (steersToBrowser) {
+    return {
+      ok: false,
+      diagnosis: "browser_used_instead_of_integrations",
+      details: "Routine prompt steers toward browser/search instead of GitHub tools.",
+    };
+  }
+
+  if (!mentionsRepo || !mentionsReleases || !mentionsGithubTool) {
+    const missing = [
+      !mentionsRepo ? "repo (elie222/rakazo)" : null,
+      !mentionsReleases ? "releases" : null,
+      !mentionsGithubTool ? "GitHub/releases tool steps" : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return {
+      ok: false,
+      diagnosis: "vague_routine_prompt",
+      details: `Routine prompt is missing: ${missing}.`,
+    };
+  }
+
+  return { ok: true, diagnosis: "ok", details: "Routine prompt encodes concrete GitHub steps." };
+}
+
+/** True when a GitHub tool payload is successful, non-empty, and includes a seeded tag. */
+export function githubToolResultHasSeededRelease(
+  result: unknown,
+  seededReleaseTags: readonly string[],
+): boolean {
+  if (!result || typeof result !== "object") return false;
+  const row = result as Record<string, unknown>;
+  if (row.ok !== true) return false;
+  const releases = Array.isArray(row.releases)
+    ? row.releases
+    : "release" in row
+      ? [row.release]
+      : [];
+  if (releases.length === 0) return false;
+  const seeded = new Set(seededReleaseTags.map((tag) => tag.toLowerCase()));
+  return releases.some((release) => {
+    if (!release || typeof release !== "object") return false;
+    const tag = (release as Record<string, unknown>).tag;
+    return typeof tag === "string" && seeded.has(tag.toLowerCase());
+  });
+}
+
+export function diagnoseReleaseWatchRun(input: {
+  availableToolNames: readonly string[];
+  calledToolNames: readonly string[];
+  routinePrompt: string;
+  resultText: string;
+  seededReleaseTags: readonly string[];
+  /** Successful GitHub tool payloads from the run (failed/empty calls do not count). */
+  githubToolResults?: readonly unknown[];
+}): { pass: boolean; diagnoses: ReleaseWatchDiagnosis[]; summary: string } {
+  const diagnoses: ReleaseWatchDiagnosis[] = [];
+  const prompt = assessReleaseWatchRoutinePrompt(input.routinePrompt);
+  if (!prompt.ok) diagnoses.push(prompt.diagnosis);
+
+  const hasGithubTools = RELEASE_WATCH_GITHUB_TOOL_NAMES.some((name) =>
+    input.availableToolNames.includes(name),
+  );
+  if (!hasGithubTools) diagnoses.push("missing_tools");
+
+  const calledGithub = input.calledToolNames.some((name) =>
+    (RELEASE_WATCH_GITHUB_TOOL_NAMES as readonly string[]).includes(name),
+  );
+  const calledComputer = input.calledToolNames.some((name) => COMPUTER_OR_BROWSER_TOOLS.has(name));
+  if (calledComputer && !calledGithub) {
+    diagnoses.push("browser_used_instead_of_integrations");
+  }
+
+  // Calling a GitHub tool is not enough: empty or ok:false results must still fail.
+  // When githubToolResults is provided, only a successful non-empty seeded payload counts
+  // (avoids hallucinated tags after a failed/empty call). Otherwise seeded tags in resultText count.
+  const blob = input.resultText.toLowerCase();
+  const sawInText = input.seededReleaseTags.some((tag) => blob.includes(tag.toLowerCase()));
+  const sawInPayload = (input.githubToolResults ?? []).some((result) =>
+    githubToolResultHasSeededRelease(result, input.seededReleaseTags),
+  );
+  const sawRelease =
+    input.githubToolResults !== undefined ? sawInPayload : sawInText || sawInPayload;
+  if (!sawRelease) diagnoses.push("no_release_info_retrieved");
+
+  const unique = [...new Set(diagnoses)];
+  if (unique.length === 0) {
+    return {
+      pass: true,
+      diagnoses: ["ok"],
+      summary: "Release watch used GitHub tools successfully.",
+    };
+  }
+
+  return {
+    pass: false,
+    diagnoses: unique,
+    summary: unique
+      .map((diagnosis) => {
+        switch (diagnosis) {
+          case "vague_routine_prompt":
+            return `vague_routine_prompt: ${prompt.details}`;
+          case "missing_tools":
+            return "missing_tools: GITHUB_LIST_RELEASES / GITHUB_GET_RELEASE were not available to the run.";
+          case "browser_used_instead_of_integrations":
+            return "browser_used_instead_of_integrations: computer/browser tools were used without GitHub release tools.";
+          case "no_release_info_retrieved":
+            return "no_release_info_retrieved: run never obtained seeded release/capability info.";
+          default:
+            return diagnosis;
+        }
+      })
+      .join("\n"),
+  };
+}

--- a/packages/testkit/src/cli/canary.ts
+++ b/packages/testkit/src/cli/canary.ts
@@ -37,7 +37,7 @@ async function main() {
       });
     }
     execSync(
-      "pnpm exec vitest run --no-file-parallelism packages/testkit/src/providers.canary.test.ts",
+      "pnpm exec vitest run --no-file-parallelism packages/testkit/src/providers.canary.test.ts packages/testkit/src/release-watch.canary.test.ts",
       { stdio: "inherit", env },
     );
   } finally {

--- a/packages/testkit/src/release-watch.canary.test.ts
+++ b/packages/testkit/src/release-watch.canary.test.ts
@@ -1,0 +1,252 @@
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  ComposioEmulator,
+  diagnoseReleaseWatchRun,
+  githubToolResultHasSeededRelease,
+  RELEASE_WATCH_GITHUB_TOOL_NAMES,
+  resolveReleaseWatchEvalModelId,
+} from "@rakazo/adapters";
+import { afterAll, describe, expect, it } from "vitest";
+import { sessionCookieHeader } from "./index.js";
+
+function loadEnvFile() {
+  const file = path.resolve(".env");
+  if (!existsSync(file)) return;
+  for (const line of readFileSync(file, "utf8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq);
+    const value = trimmed.slice(eq + 1).replace(/^["']|["']$/g, "");
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+loadEnvFile();
+
+const live = Boolean(
+  process.env.VERIFY_PROVIDERS && process.env.OPENROUTER_API_KEY && process.env.DATABASE_URL,
+);
+const describeLive = live ? describe : describe.skip;
+
+describeLive("live release-watch eval (GPT 5.6 Luna + GitHub emulator)", () => {
+  let stop: (() => Promise<void>) | undefined;
+  const composio = new ComposioEmulator();
+
+  afterAll(async () => {
+    await stop?.();
+  });
+
+  it("writes a concrete routine and reads seeded releases via GitHub tools, not the browser", async () => {
+    const { modelId, label } = resolveReleaseWatchEvalModelId(process.env);
+    process.env.PI_DEFAULT_MODEL = modelId;
+
+    const { createApp } = await import("../../../apps/api/src/app.ts");
+    const dataDir = mkdtempSync(path.join(tmpdir(), "rakazo-release-watch-"));
+    const handles = await createApp({
+      databaseUrl: process.env.DATABASE_URL!,
+      dataDir,
+      sandboxProvider: "fake",
+      agentRuntime: "pi",
+      composio,
+    });
+    stop = handles.stop;
+
+    const stamp = Date.now();
+    const signup = await handles.app.request("/api/auth/sign-up/email", {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "http://127.0.0.1:5173" },
+      body: JSON.stringify({
+        email: `release-watch-${stamp}@rakazo.test`,
+        password: "password12",
+        name: "Release Watch",
+      }),
+    });
+    expect(signup.status).toBeLessThan(400);
+    const cookie = sessionCookieHeader(signup);
+
+    const me = await rpc<{ spaceId: string; userId: string }>(handles.app, cookie, "me");
+    const started = await rpc<{ connectionId: string; authorizationUrl: null }>(
+      handles.app,
+      cookie,
+      "connections/begin",
+      { connectorId: "composio", provider: "GITHUB", displayName: "GitHub" },
+    );
+    expect(started.authorizationUrl).toBeNull();
+
+    const discoveredGithubTools = await composio.discoverTools({
+      operationId: "release-watch-canary",
+      traceId: "release-watch-canary",
+      spaceId: me.spaceId,
+      userId: me.userId,
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: started.connectionId,
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "GitHub",
+        },
+      ],
+    });
+    expect(discoveredGithubTools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining([...RELEASE_WATCH_GITHUB_TOOL_NAMES]),
+    );
+
+    const bot = await rpc<{ id: string }>(handles.app, cookie, "bots/create", {
+      name: "Chief",
+      title: "Chief of staff",
+      description: "Release watch eval",
+      instructions: "You are a chief of staff.",
+      notifyOnFinish: true,
+    });
+
+    // Mirror the Discord user ask: no tool names, no Bing/browser coaching.
+    // schedule_create + connected-plugin guidance should steer the model.
+    await rpc(handles.app, cookie, "threads/send", {
+      botId: bot.id,
+      text: [
+        "Create a daily task to watch for new releases of elie222/rakazo",
+        "and stay current on the project's capabilities.",
+      ].join(" "),
+    });
+
+    await waitFor(handles.app, cookie, bot.id, 180_000);
+
+    const routines = await rpc<Array<{ id: string; name: string; prompt: string }>>(
+      handles.app,
+      cookie,
+      "routines/list",
+      { botId: bot.id },
+    );
+    expect(routines.length).toBeGreaterThan(0);
+    const routine =
+      routines.find((row) => /rakazo|release/i.test(`${row.name}\n${row.prompt}`)) ?? routines[0]!;
+
+    const dueAt = new Date(Date.now() - 1_000);
+    await handles.prisma.routine.update({
+      where: { id: routine.id },
+      data: { nextRunAt: dueAt, active: true },
+    });
+    composio.executions.length = 0;
+    const priorToolEvent = await handles.prisma.event.findFirst({
+      where: { botId: bot.id, type: "agent.tool.called" },
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+    const routineToolSeqFloor = priorToolEvent?.seq ?? -1;
+    await handles.jobs.enqueue({
+      name: "routine.wakeup",
+      payload: { routineId: routine.id, scheduledFor: dueAt.toISOString() },
+    });
+
+    const snap = await waitFor(handles.app, cookie, bot.id, 180_000, { requireSeenRun: true });
+    const routineRunId = snap.run?.id;
+    const toolEvents = await handles.prisma.event.findMany({
+      where: {
+        botId: bot.id,
+        type: "agent.tool.called",
+        seq: { gt: routineToolSeqFloor },
+        ...(routineRunId ? { runId: routineRunId } : {}),
+      },
+      orderBy: { seq: "asc" },
+    });
+    const calledFromEvents = toolEvents.map((event) => {
+      const payload = event.payload as { name?: string };
+      return String(payload.name ?? "");
+    });
+    const routineExecutions = composio.executions.filter(
+      (row) => row.botId === bot.id && (routineRunId ? row.runId === routineRunId : true),
+    );
+    const calledToolNames = [...calledFromEvents, ...routineExecutions.map((row) => row.tool)];
+    const seededReleaseTags = composio.listGithubReleases().map((release) => release.tag);
+    const resultText = JSON.stringify(snap);
+    const githubToolResults = routineExecutions
+      .filter((row) => (RELEASE_WATCH_GITHUB_TOOL_NAMES as readonly string[]).includes(row.tool))
+      .map((row) => row.result);
+    const diagnosis = diagnoseReleaseWatchRun({
+      // Use tools the bot actually discovered — do not hardcode availability.
+      availableToolNames: discoveredGithubTools.map((tool) => tool.name),
+      calledToolNames,
+      routinePrompt: routine.prompt,
+      resultText,
+      seededReleaseTags,
+      githubToolResults,
+    });
+
+    if (!diagnosis.pass) {
+      throw new Error(
+        [
+          "release-watch eval failed",
+          `model=${label} (${modelId})`,
+          `routinePrompt=${JSON.stringify(routine.prompt)}`,
+          `calledTools=${JSON.stringify(calledToolNames)}`,
+          `discoveredGithubTools=${JSON.stringify(discoveredGithubTools.map((tool) => tool.name))}`,
+          diagnosis.summary,
+        ].join("\n"),
+      );
+    }
+
+    expect(
+      githubToolResults.some((result) =>
+        githubToolResultHasSeededRelease(result, seededReleaseTags),
+      ),
+    ).toBe(true);
+  }, 420_000);
+});
+
+type App = { request: (input: string, init?: RequestInit) => Promise<Response> };
+type Snap = {
+  messages: Array<{ role: string; blocks: unknown[] }>;
+  run: {
+    id: string;
+    status: string;
+    botId?: string;
+    trigger?: string;
+    routineId?: string | null;
+  } | null;
+};
+
+async function rpc<T>(app: App, cookie: string, proc: string, body: unknown = {}): Promise<T> {
+  const res = await app.request(`/rpc/${proc}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", cookie, origin: "http://127.0.0.1:5173" },
+    body: JSON.stringify({ json: body }),
+  });
+  const parsed = (await res.json()) as { json?: T; error?: { message?: string } };
+  if (res.status >= 400 || parsed.error) {
+    throw new Error(`${proc} ${res.status}: ${parsed.error?.message ?? "failed"}`);
+  }
+  return parsed.json as T;
+}
+
+async function waitFor(
+  app: App,
+  cookie: string,
+  botId: string,
+  ms: number,
+  options?: { requireSeenRun?: boolean },
+): Promise<Snap> {
+  const start = Date.now();
+  let last: Snap | null = null;
+  let seenRun = false;
+  let lastSeenRun: Snap["run"] = null;
+  while (Date.now() - start < ms) {
+    last = await rpc<Snap>(app, cookie, "threads/get", { botId });
+    if (last.run) {
+      seenRun = true;
+      lastSeenRun = last.run;
+    }
+    const terminal = !!last.run && ["completed", "failed", "cancelled"].includes(last.run.status);
+    // Keep lastSeenRun for tool attribution if the active run slot clears after completion.
+    if (terminal) return { ...last, run: last.run ?? lastSeenRun };
+    if (!last.run && (!options?.requireSeenRun || seenRun)) {
+      return { ...last, run: lastSeenRun };
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`timeout waiting for live model turn: ${JSON.stringify(last)}`);
+}


### PR DESCRIPTION
Fixes #505. Adds release-watch eval path: Composio GitHub release tools simulation, diagnostics (vague/missing_tools/browser/no_release), offline unit tests, and canary hook for openai/gpt-5.6-luna (skips without key).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release-watch evaluation support for checking GitHub releases through connected plugin tools.
  * Added GitHub release emulation for offline testing, including seeded release data and release lookup tools.
  * Added diagnostics for identifying missing tools, browser fallback, incomplete results, and successful release checks.

* **Improvements**
  * Updated scheduling guidance to require concrete steps and recommend plugin tools over browser browsing or web search.
  * Canary checks now include release-watch evaluations alongside provider checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->