### PR TITLE
fix(compose): pass through HTTP(S)_PROXY / NO_PROXY to api and worker

### DIFF
--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -45,3 +45,10 @@ SANDBOX_PROVIDER=docker
 # Optional model / integration keys
 OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
+
+# Optional outbound HTTP(S) proxy for api/worker containers (Mainland / corporate).
+# Leave blank unless you need egress through a proxy. Include internal Compose
+# names in NO_PROXY (postgres, supervisor, localhost, 127.0.0.1).
+# HTTP_PROXY=
+# HTTPS_PROXY=
+# NO_PROXY=localhost,127.0.0.1,postgres,supervisor,api,worker,web

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -47,8 +47,8 @@ OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
 
 # Optional outbound HTTP(S) proxy for api/worker containers (Mainland / corporate).
-# Leave blank unless you need egress through a proxy. Include internal Compose
-# names in NO_PROXY (postgres, supervisor, localhost, 127.0.0.1).
+# Leave blank unless you need egress through a proxy. Uppercase or lowercase keys work.
+# Include internal Compose names in NO_PROXY (postgres, supervisor, localhost, 127.0.0.1).
 # HTTP_PROXY=
 # HTTPS_PROXY=
 # NO_PROXY=localhost,127.0.0.1,postgres,supervisor,api,worker,web

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -113,13 +113,13 @@ services:
       SANDBOX_SUPERVISOR_URL: http://supervisor:7091
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
-      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
-      HTTP_PROXY: ${HTTP_PROXY:-}
-      HTTPS_PROXY: ${HTTPS_PROXY:-}
-      NO_PROXY: ${NO_PROXY:-}
-      http_proxy: ${HTTP_PROXY:-}
-      https_proxy: ${HTTPS_PROXY:-}
-      no_proxy: ${NO_PROXY:-}
+      # Optional egress proxy (Mainland / corporate). Empty = unset; either case works.
+      HTTP_PROXY: ${HTTP_PROXY:-${http_proxy:-}}
+      HTTPS_PROXY: ${HTTPS_PROXY:-${https_proxy:-}}
+      NO_PROXY: ${NO_PROXY:-${no_proxy:-}}
+      http_proxy: ${http_proxy:-${HTTP_PROXY:-}}
+      https_proxy: ${https_proxy:-${HTTPS_PROXY:-}}
+      no_proxy: ${no_proxy:-${NO_PROXY:-}}
     ports:
       - "127.0.0.1:3100:3100"
     volumes:
@@ -167,13 +167,13 @@ services:
       SCREEN_PROXY_SECRET: ""
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
-      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
-      HTTP_PROXY: ${HTTP_PROXY:-}
-      HTTPS_PROXY: ${HTTPS_PROXY:-}
-      NO_PROXY: ${NO_PROXY:-}
-      http_proxy: ${HTTP_PROXY:-}
-      https_proxy: ${HTTPS_PROXY:-}
-      no_proxy: ${NO_PROXY:-}
+      # Optional egress proxy (Mainland / corporate). Empty = unset; either case works.
+      HTTP_PROXY: ${HTTP_PROXY:-${http_proxy:-}}
+      HTTPS_PROXY: ${HTTPS_PROXY:-${https_proxy:-}}
+      NO_PROXY: ${NO_PROXY:-${no_proxy:-}}
+      http_proxy: ${http_proxy:-${HTTP_PROXY:-}}
+      https_proxy: ${https_proxy:-${HTTPS_PROXY:-}}
+      no_proxy: ${no_proxy:-${NO_PROXY:-}}
     volumes:
       - appdata:/data
     networks:

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -113,6 +113,13 @@ services:
       SANDBOX_SUPERVISOR_URL: http://supervisor:7091
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
+      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
+      HTTP_PROXY: ${HTTP_PROXY:-}
+      HTTPS_PROXY: ${HTTPS_PROXY:-}
+      NO_PROXY: ${NO_PROXY:-}
+      http_proxy: ${HTTP_PROXY:-}
+      https_proxy: ${HTTPS_PROXY:-}
+      no_proxy: ${NO_PROXY:-}
     ports:
       - "127.0.0.1:3100:3100"
     volumes:
@@ -160,6 +167,13 @@ services:
       SCREEN_PROXY_SECRET: ""
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
+      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
+      HTTP_PROXY: ${HTTP_PROXY:-}
+      HTTPS_PROXY: ${HTTPS_PROXY:-}
+      NO_PROXY: ${NO_PROXY:-}
+      http_proxy: ${HTTP_PROXY:-}
+      https_proxy: ${HTTPS_PROXY:-}
+      no_proxy: ${NO_PROXY:-}
     volumes:
       - appdata:/data
     networks:

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -57,6 +57,13 @@ services:
       SANDBOX_PROVIDER: e2b
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
+      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
+      HTTP_PROXY: ${HTTP_PROXY:-}
+      HTTPS_PROXY: ${HTTPS_PROXY:-}
+      NO_PROXY: ${NO_PROXY:-}
+      http_proxy: ${HTTP_PROXY:-}
+      https_proxy: ${HTTPS_PROXY:-}
+      no_proxy: ${NO_PROXY:-}
       RAKAZO_UPDATER_URL: http://updater:7092
     expose:
       - "3100"
@@ -106,6 +113,13 @@ services:
       SCREEN_PROXY_SECRET: ""
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
+      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
+      HTTP_PROXY: ${HTTP_PROXY:-}
+      HTTPS_PROXY: ${HTTPS_PROXY:-}
+      NO_PROXY: ${NO_PROXY:-}
+      http_proxy: ${HTTP_PROXY:-}
+      https_proxy: ${HTTPS_PROXY:-}
+      no_proxy: ${NO_PROXY:-}
     volumes:
       - appdata:/data
     networks:

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -57,13 +57,13 @@ services:
       SANDBOX_PROVIDER: e2b
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
-      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
-      HTTP_PROXY: ${HTTP_PROXY:-}
-      HTTPS_PROXY: ${HTTPS_PROXY:-}
-      NO_PROXY: ${NO_PROXY:-}
-      http_proxy: ${HTTP_PROXY:-}
-      https_proxy: ${HTTPS_PROXY:-}
-      no_proxy: ${NO_PROXY:-}
+      # Optional egress proxy (Mainland / corporate). Empty = unset; either case works.
+      HTTP_PROXY: ${HTTP_PROXY:-${http_proxy:-}}
+      HTTPS_PROXY: ${HTTPS_PROXY:-${https_proxy:-}}
+      NO_PROXY: ${NO_PROXY:-${no_proxy:-}}
+      http_proxy: ${http_proxy:-${HTTP_PROXY:-}}
+      https_proxy: ${https_proxy:-${HTTPS_PROXY:-}}
+      no_proxy: ${no_proxy:-${NO_PROXY:-}}
       RAKAZO_UPDATER_URL: http://updater:7092
     expose:
       - "3100"
@@ -113,13 +113,13 @@ services:
       SCREEN_PROXY_SECRET: ""
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
-      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
-      HTTP_PROXY: ${HTTP_PROXY:-}
-      HTTPS_PROXY: ${HTTPS_PROXY:-}
-      NO_PROXY: ${NO_PROXY:-}
-      http_proxy: ${HTTP_PROXY:-}
-      https_proxy: ${HTTPS_PROXY:-}
-      no_proxy: ${NO_PROXY:-}
+      # Optional egress proxy (Mainland / corporate). Empty = unset; either case works.
+      HTTP_PROXY: ${HTTP_PROXY:-${http_proxy:-}}
+      HTTPS_PROXY: ${HTTPS_PROXY:-${https_proxy:-}}
+      NO_PROXY: ${NO_PROXY:-${no_proxy:-}}
+      http_proxy: ${http_proxy:-${HTTP_PROXY:-}}
+      https_proxy: ${https_proxy:-${HTTPS_PROXY:-}}
+      no_proxy: ${no_proxy:-${NO_PROXY:-}}
     volumes:
       - appdata:/data
     networks:

--- a/infra/updater/src/compose-images.test.ts
+++ b/infra/updater/src/compose-images.test.ts
@@ -107,12 +107,12 @@ describe("the images compose file", () => {
   it("passes optional HTTP(S)_PROXY / NO_PROXY into api and worker", () => {
     for (const name of ["api", "worker"] as const) {
       const env = compose.services[name]?.environment ?? {};
-      expect(env.HTTP_PROXY).toBe("${HTTP_PROXY:-}");
-      expect(env.HTTPS_PROXY).toBe("${HTTPS_PROXY:-}");
-      expect(env.NO_PROXY).toBe("${NO_PROXY:-}");
-      expect(env.http_proxy).toBe("${HTTP_PROXY:-}");
-      expect(env.https_proxy).toBe("${HTTPS_PROXY:-}");
-      expect(env.no_proxy).toBe("${NO_PROXY:-}");
+      expect(env.HTTP_PROXY).toBe("${HTTP_PROXY:-${http_proxy:-}}");
+      expect(env.HTTPS_PROXY).toBe("${HTTPS_PROXY:-${https_proxy:-}}");
+      expect(env.NO_PROXY).toBe("${NO_PROXY:-${no_proxy:-}}");
+      expect(env.http_proxy).toBe("${http_proxy:-${HTTP_PROXY:-}}");
+      expect(env.https_proxy).toBe("${https_proxy:-${HTTPS_PROXY:-}}");
+      expect(env.no_proxy).toBe("${no_proxy:-${NO_PROXY:-}}");
     }
   });
 

--- a/infra/updater/src/compose-images.test.ts
+++ b/infra/updater/src/compose-images.test.ts
@@ -104,6 +104,18 @@ describe("the images compose file", () => {
     }
   });
 
+  it("passes optional HTTP(S)_PROXY / NO_PROXY into api and worker", () => {
+    for (const name of ["api", "worker"] as const) {
+      const env = compose.services[name]?.environment ?? {};
+      expect(env.HTTP_PROXY).toBe("${HTTP_PROXY:-}");
+      expect(env.HTTPS_PROXY).toBe("${HTTPS_PROXY:-}");
+      expect(env.NO_PROXY).toBe("${NO_PROXY:-}");
+      expect(env.http_proxy).toBe("${HTTP_PROXY:-}");
+      expect(env.https_proxy).toBe("${HTTPS_PROXY:-}");
+      expect(env.no_proxy).toBe("${NO_PROXY:-}");
+    }
+  });
+
   it("never builds from a checkout", () => {
     for (const service of Object.values(compose.services)) {
       expect(service.build).toBeUndefined();


### PR DESCRIPTION
Optional egress proxy env for published-images and prod Compose: HTTP_PROXY, HTTPS_PROXY, NO_PROXY (and lowercase). Documented in .env.images.example; compose-images tests cover the wiring. Orthogonal to docs-only outbound-proxy guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional HTTP/HTTPS proxy configuration for API and worker containers.
  - Supports uppercase and lowercase proxy environment variable formats.
  - Added guidance for excluding internal Compose services with `NO_PROXY`.
  - Proxy settings remain unset by default and can be supplied through environment configuration.

- **Tests**
  - Updated coverage to verify proxy settings are resolved correctly for API and worker services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->