### PR TITLE
fix(compose): pass through HTTP(S)_PROXY on local/dev Compose

### DIFF
--- a/infra/compose/docker-compose.topology.yml
+++ b/infra/compose/docker-compose.topology.yml
@@ -80,6 +80,13 @@ services:
       WAKEUP_DRIVER: graphile
       SANDBOX_PROVIDER: docker
       AGENT_RUNTIME: scripted
+      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
+      HTTP_PROXY: ${HTTP_PROXY:-}
+      HTTPS_PROXY: ${HTTPS_PROXY:-}
+      NO_PROXY: ${NO_PROXY:-}
+      http_proxy: ${HTTP_PROXY:-}
+      https_proxy: ${HTTPS_PROXY:-}
+      no_proxy: ${NO_PROXY:-}
       API_PORT: "3100"
       API_HOST: "0.0.0.0"
     ports:

--- a/infra/compose/docker-compose.topology.yml
+++ b/infra/compose/docker-compose.topology.yml
@@ -80,13 +80,13 @@ services:
       WAKEUP_DRIVER: graphile
       SANDBOX_PROVIDER: docker
       AGENT_RUNTIME: scripted
-      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
-      HTTP_PROXY: ${HTTP_PROXY:-}
-      HTTPS_PROXY: ${HTTPS_PROXY:-}
-      NO_PROXY: ${NO_PROXY:-}
-      http_proxy: ${HTTP_PROXY:-}
-      https_proxy: ${HTTPS_PROXY:-}
-      no_proxy: ${NO_PROXY:-}
+      # Optional egress proxy (Mainland / corporate). Empty = unset; either case works.
+      HTTP_PROXY: ${HTTP_PROXY:-${http_proxy:-}}
+      HTTPS_PROXY: ${HTTPS_PROXY:-${https_proxy:-}}
+      NO_PROXY: ${NO_PROXY:-${no_proxy:-}}
+      http_proxy: ${http_proxy:-${HTTP_PROXY:-}}
+      https_proxy: ${https_proxy:-${HTTPS_PROXY:-}}
+      no_proxy: ${no_proxy:-${NO_PROXY:-}}
       API_PORT: "3100"
       API_HOST: "0.0.0.0"
     ports:

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -64,13 +64,13 @@ services:
       WAKEUP_DRIVER: graphile
       SANDBOX_PROVIDER: docker
       AGENT_RUNTIME: pi
-      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
-      HTTP_PROXY: ${HTTP_PROXY:-}
-      HTTPS_PROXY: ${HTTPS_PROXY:-}
-      NO_PROXY: ${NO_PROXY:-}
-      http_proxy: ${HTTP_PROXY:-}
-      https_proxy: ${HTTPS_PROXY:-}
-      no_proxy: ${NO_PROXY:-}
+      # Optional egress proxy (Mainland / corporate). Empty = unset; either case works.
+      HTTP_PROXY: ${HTTP_PROXY:-${http_proxy:-}}
+      HTTPS_PROXY: ${HTTPS_PROXY:-${https_proxy:-}}
+      NO_PROXY: ${NO_PROXY:-${no_proxy:-}}
+      http_proxy: ${http_proxy:-${HTTP_PROXY:-}}
+      https_proxy: ${https_proxy:-${HTTPS_PROXY:-}}
+      no_proxy: ${no_proxy:-${NO_PROXY:-}}
     ports:
       - "127.0.0.1:3100:3100"
     volumes:
@@ -97,13 +97,13 @@ services:
       SANDBOX_PROVIDER: docker
       SCREEN_PROXY_SECRET: ""
       AGENT_RUNTIME: pi
-      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
-      HTTP_PROXY: ${HTTP_PROXY:-}
-      HTTPS_PROXY: ${HTTPS_PROXY:-}
-      NO_PROXY: ${NO_PROXY:-}
-      http_proxy: ${HTTP_PROXY:-}
-      https_proxy: ${HTTPS_PROXY:-}
-      no_proxy: ${NO_PROXY:-}
+      # Optional egress proxy (Mainland / corporate). Empty = unset; either case works.
+      HTTP_PROXY: ${HTTP_PROXY:-${http_proxy:-}}
+      HTTPS_PROXY: ${HTTPS_PROXY:-${https_proxy:-}}
+      NO_PROXY: ${NO_PROXY:-${no_proxy:-}}
+      http_proxy: ${http_proxy:-${HTTP_PROXY:-}}
+      https_proxy: ${https_proxy:-${HTTPS_PROXY:-}}
+      no_proxy: ${no_proxy:-${NO_PROXY:-}}
     volumes:
       - ../../data:/data
     depends_on:

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -64,6 +64,13 @@ services:
       WAKEUP_DRIVER: graphile
       SANDBOX_PROVIDER: docker
       AGENT_RUNTIME: pi
+      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
+      HTTP_PROXY: ${HTTP_PROXY:-}
+      HTTPS_PROXY: ${HTTPS_PROXY:-}
+      NO_PROXY: ${NO_PROXY:-}
+      http_proxy: ${HTTP_PROXY:-}
+      https_proxy: ${HTTPS_PROXY:-}
+      no_proxy: ${NO_PROXY:-}
     ports:
       - "127.0.0.1:3100:3100"
     volumes:
@@ -90,6 +97,13 @@ services:
       SANDBOX_PROVIDER: docker
       SCREEN_PROXY_SECRET: ""
       AGENT_RUNTIME: pi
+      # Optional egress proxy (Mainland / corporate). Empty = unset; prefer .env values.
+      HTTP_PROXY: ${HTTP_PROXY:-}
+      HTTPS_PROXY: ${HTTPS_PROXY:-}
+      NO_PROXY: ${NO_PROXY:-}
+      http_proxy: ${HTTP_PROXY:-}
+      https_proxy: ${HTTPS_PROXY:-}
+      no_proxy: ${NO_PROXY:-}
     volumes:
       - ../../data:/data
     depends_on:

--- a/infra/updater/src/compose-dev-proxy.test.ts
+++ b/infra/updater/src/compose-dev-proxy.test.ts
@@ -16,12 +16,12 @@ function loadCompose(rel: string) {
 }
 
 function expectProxyPassthrough(env: Record<string, unknown> | undefined) {
-  expect(env?.HTTP_PROXY).toBe("${HTTP_PROXY:-}");
-  expect(env?.HTTPS_PROXY).toBe("${HTTPS_PROXY:-}");
-  expect(env?.NO_PROXY).toBe("${NO_PROXY:-}");
-  expect(env?.http_proxy).toBe("${HTTP_PROXY:-}");
-  expect(env?.https_proxy).toBe("${HTTPS_PROXY:-}");
-  expect(env?.no_proxy).toBe("${NO_PROXY:-}");
+  expect(env?.HTTP_PROXY).toBe("${HTTP_PROXY:-${http_proxy:-}}");
+  expect(env?.HTTPS_PROXY).toBe("${HTTPS_PROXY:-${https_proxy:-}}");
+  expect(env?.NO_PROXY).toBe("${NO_PROXY:-${no_proxy:-}}");
+  expect(env?.http_proxy).toBe("${http_proxy:-${HTTP_PROXY:-}}");
+  expect(env?.https_proxy).toBe("${https_proxy:-${HTTPS_PROXY:-}}");
+  expect(env?.no_proxy).toBe("${no_proxy:-${NO_PROXY:-}}");
 }
 
 describe("local and topology compose proxy passthrough", () => {

--- a/infra/updater/src/compose-dev-proxy.test.ts
+++ b/infra/updater/src/compose-dev-proxy.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+interface ComposeService {
+  environment?: Record<string, unknown>;
+}
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+function loadCompose(rel: string) {
+  return parse(readFileSync(path.resolve(repoRoot, rel), "utf8")) as {
+    services: Record<string, ComposeService>;
+  };
+}
+
+function expectProxyPassthrough(env: Record<string, unknown> | undefined) {
+  expect(env?.HTTP_PROXY).toBe("${HTTP_PROXY:-}");
+  expect(env?.HTTPS_PROXY).toBe("${HTTPS_PROXY:-}");
+  expect(env?.NO_PROXY).toBe("${NO_PROXY:-}");
+  expect(env?.http_proxy).toBe("${HTTP_PROXY:-}");
+  expect(env?.https_proxy).toBe("${HTTPS_PROXY:-}");
+  expect(env?.no_proxy).toBe("${NO_PROXY:-}");
+}
+
+describe("local and topology compose proxy passthrough", () => {
+  it("passes optional HTTP(S)_PROXY / NO_PROXY into docker-compose.yml api/worker", () => {
+    const compose = loadCompose("infra/compose/docker-compose.yml");
+    for (const name of ["api", "worker"] as const) {
+      expectProxyPassthrough(compose.services[name]?.environment);
+    }
+  });
+
+  it("passes the same knobs through topology app-environment (api + worker)", () => {
+    const compose = loadCompose("infra/compose/docker-compose.topology.yml");
+    for (const name of ["api", "worker"] as const) {
+      expectProxyPassthrough(compose.services[name]?.environment);
+    }
+  });
+});


### PR DESCRIPTION
Companion to #531 (images/prod). Wires HTTP_PROXY/HTTPS_PROXY/NO_PROXY (and lowercase) into local docker-compose.yml api/worker via topology shared app-environment. Adds compose-dev-proxy tests. Dupe-checked: only #531 covers images/prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP, HTTPS, and no-proxy configuration for API and worker services.
  * Proxy settings support both uppercase and lowercase environment variable names.
  * Configuration works with standard and topology-based deployment setups, preferring explicitly configured values and defaulting to empty when unset.

* **Tests**
  * Added coverage verifying proxy settings are passed correctly to API and worker services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->