### PR TITLE
Harden Slack team chat bridge delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,7 @@ TELEGRAM_WEBHOOK_SECRET_TOKEN=
 # Bot events: app_mention, message.im, message.channels, message.groups, message.mpim.
 SLACK_APP_TOKEN=
 SLACK_BOT_TOKEN=
+SLACK_WORKSPACE_ID=
 SLACK_RAKAZO_BOT_ID=
 # Optional lower-cost model for ambient Slack judgments. Configure both or neither.
 TEAM_CHAT_JUDGE_PROVIDER=

--- a/apps/api/src/team-chat-bridge.test.ts
+++ b/apps/api/src/team-chat-bridge.test.ts
@@ -103,9 +103,9 @@ describe("team chat bridge", () => {
           records.push(record);
           return record;
         }),
-        findMany: vi.fn(async ({ where }: { where: { status: string } }) =>
+        findMany: vi.fn(async ({ where }: { where: { status: string | { in: string[] } } }) =>
           records
-            .filter((record) => record.status === where.status)
+            .filter((record) => matchesStatus(record.status, where.status))
             .map((record) => ({
               ...record,
               externalConversation: conversation,
@@ -120,7 +120,29 @@ describe("team chat bridge", () => {
             return record;
           },
         ),
-        updateMany: vi.fn(async () => ({ count: 0 })),
+        updateMany: vi.fn(
+          async ({
+            where,
+            data,
+          }: {
+            where: { id?: string | { in?: string[] }; status?: string | { in: string[] } };
+            data: Record<string, unknown>;
+          }) => {
+            const ids =
+              typeof where.id === "string" ? [where.id] : (where.id as { in?: string[] })?.in;
+            let count = 0;
+            for (const record of records) {
+              if (
+                (!ids || ids.includes(String(record.id))) &&
+                matchesStatus(record.status, where.status)
+              ) {
+                Object.assign(record, data);
+                count += 1;
+              }
+            }
+            return { count };
+          },
+        ),
       },
       run: { findMany: vi.fn(async () => []) },
       message: {
@@ -198,6 +220,7 @@ describe("team chat bridge", () => {
         conversationId: "C-1",
         replyThreadId: "100.1",
         content: "The launch plan is ready.",
+        idempotencyKey: "external-message:external-1",
       },
     ]);
     expect(records[0]).toMatchObject({
@@ -355,6 +378,7 @@ describe("team chat bridge", () => {
         conversationId: "C-1",
         replyThreadId: "100.1",
         content: "Research found that the launch should move.",
+        idempotencyKey: "team-chat-run:run-arthur-result",
       },
     ]);
     expect(prisma.run.updateMany).toHaveBeenCalledWith({
@@ -476,6 +500,118 @@ describe("team chat bridge", () => {
       }),
     );
     expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not discard an elected ambient trigger before promoting it", async () => {
+    const records: Array<Record<string, unknown>> = [];
+    const sendUserMessage = vi.fn(async (input: { createRun?: boolean }) =>
+      input.createRun === false
+        ? { messageId: "message-visible", taskId: null, runId: null }
+        : { messageId: "message-prompt", taskId: "task-ambient", runId: "run-ambient" },
+    );
+    const judge = {
+      decide: vi.fn(async () => ({
+        act: true,
+        reason: "A committed launch date changed.",
+        askedByEventId: "Ev-ambient",
+      })),
+    };
+    const conversation = {
+      id: "conversation-ambient",
+      provider: "slack",
+      workspaceId: "T-1",
+      externalKey: "channel:C-1",
+      conversationId: "C-1",
+      displayName: "launch",
+      spaceId: "space-1",
+      botId: "bot-1",
+      userId: "owner-1",
+      thread: { id: "thread-ambient" },
+    };
+    const prisma = ambientPrisma(records, conversation, true) as unknown as PrismaClient;
+    const bridge = new TeamChatBridge({
+      prisma,
+      events: { sendUserMessage },
+      jobs: { enqueue: vi.fn(async () => undefined) },
+      provider: new FakeTeamChatProvider(),
+      judge,
+      botId: "bot-1",
+      ambientDebounceMs: 0,
+      reconcileIntervalMs: 60_000,
+    });
+
+    await bridge.start();
+    await bridge.receive(ambientMessage());
+    await bridge.stop();
+
+    expect(prisma.externalMessage.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "external-1", status: "observed" },
+        data: expect.objectContaining({ status: "received" }),
+      }),
+    );
+    expect(prisma.externalMessage.updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["external-1"] }, status: "observed" },
+        data: expect.objectContaining({ status: "ignored" }),
+      }),
+    );
+  });
+
+  it("does not resend a completed run when delivery was already reserved", async () => {
+    const provider = new FakeTeamChatProvider();
+    const prisma = {
+      bot: {
+        findFirst: vi.fn(async () => ({
+          id: "bot-1",
+          spaceId: "space-1",
+          userId: "owner-1",
+          name: "Arthur",
+        })),
+      },
+      externalMessage: {
+        findMany: vi.fn(async ({ where }: { where: { status?: { in: string[] } | string } }) =>
+          where.status && matchesStatus("delivering", where.status)
+            ? [
+                {
+                  id: "external-1",
+                  status: "delivering",
+                  attempts: 0,
+                  kind: "mention",
+                  runId: "run-1",
+                  replyThreadId: "100.1",
+                  run: { id: "run-1", status: "completed" },
+                  externalConversation: {
+                    provider: "slack",
+                    botId: "bot-1",
+                    conversationId: "C-1",
+                  },
+                },
+              ]
+            : [],
+        ),
+        updateMany: vi.fn(async () => ({ count: 0 })),
+      },
+      run: { findMany: vi.fn(async () => []) },
+      message: {
+        findFirst: vi.fn(async () => ({
+          blocks: [{ kind: "text", text: "Already being sent." }],
+        })),
+      },
+    } as unknown as PrismaClient;
+    const bridge = new TeamChatBridge({
+      prisma,
+      events: { sendUserMessage: vi.fn() },
+      jobs: { enqueue: vi.fn(async () => undefined) },
+      provider,
+      botId: "bot-1",
+      reconcileIntervalMs: 60_000,
+    });
+
+    await bridge.start();
+    await bridge.stop();
+
+    expect(provider.sent).toEqual([]);
   });
 
   it("uses room listening and guidance instead of Arthur's defaults", async () => {
@@ -746,9 +882,9 @@ function ambientPrisma(
         records.push(record);
         return record;
       }),
-      findMany: vi.fn(async ({ where }: { where: { status: string } }) =>
+      findMany: vi.fn(async ({ where }: { where: { status: string | { in: string[] } } }) =>
         records
-          .filter((record) => record.status === where.status)
+          .filter((record) => matchesStatus(record.status, where.status))
           .map((record) => ({
             ...record,
             externalConversation: conversation,
@@ -764,15 +900,17 @@ function ambientPrisma(
           data: Record<string, unknown>;
         }) => {
           const ids = (where.id as { in?: string[] } | undefined)?.in;
+          let count = 0;
           for (const record of records) {
             if (
               (!ids || ids.includes(String(record.id))) &&
-              record.status === (where.status ?? record.status)
+              matchesStatus(record.status, where.status ?? String(record.status))
             ) {
               Object.assign(record, data);
+              count += 1;
             }
           }
-          return { count: records.length };
+          return { count };
         },
       ),
       update: vi.fn(
@@ -787,6 +925,12 @@ function ambientPrisma(
     run: { findMany: vi.fn(async () => []) },
     message: { findFirst: vi.fn(async () => null) },
   };
+}
+
+function matchesStatus(value: unknown, status: string | { in: string[] } | undefined): boolean {
+  if (!status) return true;
+  const current = String(value);
+  return typeof status === "string" ? current === status : status.in.includes(current);
 }
 
 class FakeTeamChatProvider implements TeamChatProvider {

--- a/apps/api/src/team-chat-bridge.ts
+++ b/apps/api/src/team-chat-bridge.ts
@@ -11,6 +11,7 @@ const BATCH_SIZE = 20;
 const AMBIENT_BATCH_SIZE = 100;
 const AMBIENT_CONTEXT_MESSAGES = 20;
 const AMBIENT_CONTEXT_MESSAGE_CHARS = 2_000;
+const DELIVERY_RESERVATION_MS = 2 * 60_000;
 
 interface TeamChatBridgeDeps {
   prisma: PrismaClient;
@@ -269,6 +270,7 @@ export class TeamChatBridge {
     for (const message of received)
       await this.queue(message).catch((error) => this.retry(message, error));
 
+    await this.recoverStaleDeliveries(now);
     const running = await this.deps.prisma.externalMessage.findMany({
       where: {
         status: "running",
@@ -338,6 +340,7 @@ export class TeamChatBridge {
           conversationId: origin.externalConversation.conversationId,
           replyThreadId: origin.replyThreadId,
           content,
+          idempotencyKey: `team-chat-run:${run.id}`,
         });
       }
       await this.markTeamChatMirrored(run.id);
@@ -478,29 +481,43 @@ export class TeamChatBridge {
       const trigger =
         judgedMessages.find((message) => message.providerEventId === decision.askedByEventId) ??
         latest;
-      await this.markAmbientIgnored(evaluated, now);
-      if (!decision.act) continue;
-      await this.deps.prisma.externalMessage.update({
-        where: { id: trigger.id },
-        data: {
-          status: "received",
-          judgedAt: now,
-          engagementReason: decision.reason ?? null,
-          batchContext: teamChatAmbientPrompt({
-            provider: this.deps.provider.id,
-            channelId: latest.externalConversation.conversationId,
-            channelName: latest.externalConversation.displayName,
-            rules,
-            reason: decision.reason,
-            messages: judgedMessages.map((message) => ({
-              senderId: message.senderId,
-              senderName: message.senderName,
-              content: message.content,
-            })),
-          }),
-        },
+      if (!decision.act) {
+        await this.markAmbientIgnored(evaluated, now);
+        continue;
+      }
+      const promoted = await this.promoteAmbientTrigger(trigger.id, {
+        judgedAt: now,
+        engagementReason: decision.reason ?? null,
+        batchContext: teamChatAmbientPrompt({
+          provider: this.deps.provider.id,
+          channelId: latest.externalConversation.conversationId,
+          channelName: latest.externalConversation.displayName,
+          rules,
+          reason: decision.reason,
+          messages: judgedMessages.map((message) => ({
+            senderId: message.senderId,
+            senderName: message.senderName,
+            content: message.content,
+          })),
+        }),
       });
+      if (promoted)
+        await this.markAmbientIgnored(
+          evaluated.filter(({ id }) => id !== trigger.id),
+          now,
+        );
     }
+  }
+
+  private async promoteAmbientTrigger(
+    id: string,
+    data: { judgedAt: Date; engagementReason: string | null; batchContext: string },
+  ): Promise<boolean> {
+    const result = await this.deps.prisma.externalMessage.updateMany({
+      where: { id, status: "observed" },
+      data: { status: "received", ...data },
+    });
+    return result.count === 1;
   }
 
   private async markAmbientIgnored(messages: Array<{ id: string }>, judgedAt: Date): Promise<void> {
@@ -610,10 +627,13 @@ export class TeamChatBridge {
       await this.markDelivered(message.id, "silent");
       return;
     }
+    const reserved = await this.reserveDelivery(message.id);
+    if (!reserved) return;
     const sent = await this.deps.provider.send({
       conversationId: message.externalConversation.conversationId,
       replyThreadId: message.replyThreadId,
       content,
+      idempotencyKey: `external-message:${message.id}`,
     });
     await this.markDelivered(message.id, sent.handle);
   }
@@ -628,12 +648,33 @@ export class TeamChatBridge {
       await this.markDelivered(message.id, "silent-failure");
       return;
     }
+    const reserved = await this.reserveDelivery(message.id);
+    if (!reserved) return;
     const sent = await this.deps.provider.send({
       conversationId: message.externalConversation.conversationId,
       replyThreadId: message.replyThreadId,
       content: `${this.target?.name ?? "The agent"} could not complete that request. Open Rakazo for details.`,
+      idempotencyKey: `external-message:${message.id}:failure`,
     });
     await this.markDelivered(message.id, sent.handle);
+  }
+
+  private async reserveDelivery(id: string): Promise<boolean> {
+    const result = await this.deps.prisma.externalMessage.updateMany({
+      where: { id, status: "running" },
+      data: {
+        status: "delivering",
+        nextAttemptAt: new Date(Date.now() + DELIVERY_RESERVATION_MS),
+      },
+    });
+    return result.count === 1;
+  }
+
+  private async recoverStaleDeliveries(now: Date): Promise<void> {
+    await this.deps.prisma.externalMessage.updateMany({
+      where: { status: "delivering", nextAttemptAt: { lte: now } },
+      data: { status: "running", nextAttemptAt: null },
+    });
   }
 
   private async markDelivered(id: string, handle: string): Promise<void> {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -540,6 +540,8 @@ export interface TeamChatSendRequest {
   conversationId: string;
   replyThreadId: string | null;
   content: string;
+  /** Stable retry key the provider can use to dedupe externally accepted sends. */
+  idempotencyKey?: string;
 }
 
 export interface TeamChatSendResult {

--- a/packages/adapters/src/slack-team-chat.test.ts
+++ b/packages/adapters/src/slack-team-chat.test.ts
@@ -106,6 +106,31 @@ describe("Slack team chat adapter", () => {
     });
   });
 
+  it("rejects messages from an unconfigured Slack workspace", () => {
+    const parsed = parseSlackSocketEnvelope(
+      {
+        envelope_id: "env-cross-workspace",
+        type: "events_api",
+        payload: {
+          event_id: "Ev-cross-workspace",
+          team_id: "T-OTHER",
+          event: {
+            type: "app_mention",
+            user: "U-1",
+            channel: "C-1",
+            text: "<@U-ARTHUR> please summarize this",
+            ts: "100.001",
+          },
+        },
+      },
+      "U-ARTHUR",
+      undefined,
+      "T-AUTHORIZED",
+    );
+
+    expect(parsed).toEqual({ envelopeId: "env-cross-workspace" });
+  });
+
   it("keeps third-party bot posts for room policy evaluation", () => {
     const parsed = parseSlackSocketEnvelope(
       {
@@ -240,8 +265,9 @@ describe("Slack team chat adapter", () => {
       slackTeamChatConfigFromEnv({
         SLACK_APP_TOKEN: " xapp-test ",
         SLACK_BOT_TOKEN: " xoxb-test ",
+        SLACK_WORKSPACE_ID: " T-1 ",
       }),
-    ).toEqual({ appToken: "xapp-test", botToken: "xoxb-test" });
+    ).toEqual({ appToken: "xapp-test", botToken: "xoxb-test", workspaceId: "T-1" });
   });
 
   it("extracts every participant from a multi-person direct message", () => {
@@ -296,6 +322,7 @@ describe("Slack team chat adapter", () => {
         conversationId: "C-1",
         replyThreadId: "100.1",
         content: "abcdefghij",
+        idempotencyKey: "reply-key",
       }),
     ).resolves.toEqual({ handle: "reply-ij" });
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -303,6 +330,7 @@ describe("Slack team chat adapter", () => {
       Object.fromEntries(new URLSearchParams(String(fetchMock.mock.calls[0]?.[1]?.body))),
     ).toEqual({
       channel: "C-1",
+      client_msg_id: "reply-key:0",
       text: "abcd",
       thread_ts: "100.1",
     });

--- a/packages/adapters/src/slack-team-chat.ts
+++ b/packages/adapters/src/slack-team-chat.ts
@@ -12,6 +12,7 @@ const DEFAULT_MAX_MESSAGE_CHARS = 39_000;
 export interface SlackTeamChatConfig {
   appToken: string;
   botToken: string;
+  workspaceId?: string;
 }
 
 type Fetch = typeof fetch;
@@ -30,10 +31,11 @@ export function slackTeamChatConfigFromEnv(
 ): SlackTeamChatConfig | null {
   const appToken = source.SLACK_APP_TOKEN?.trim();
   const botToken = source.SLACK_BOT_TOKEN?.trim();
+  const workspaceId = source.SLACK_WORKSPACE_ID?.trim();
   if (!appToken && !botToken) return null;
   if (!appToken) throw new Error("SLACK_APP_TOKEN is required when Slack is enabled");
   if (!botToken) throw new Error("SLACK_BOT_TOKEN is required when Slack is enabled");
-  return { appToken, botToken };
+  return { appToken, botToken, ...(workspaceId ? { workspaceId } : {}) };
 }
 
 export function splitSlackMessage(content: string, maxChars = DEFAULT_MAX_MESSAGE_CHARS): string[] {
@@ -67,6 +69,7 @@ export function parseSlackSocketEnvelope(
   value: unknown,
   botUserId: string,
   ownBotId?: string,
+  authorizedWorkspaceId?: string,
 ): { envelopeId?: string; message?: TeamChatInboundMessage } {
   if (!isRecord(value)) return {};
   const envelopeId = stringValue(value.envelope_id);
@@ -109,6 +112,7 @@ export function parseSlackSocketEnvelope(
   const workspaceId = stringValue(payload.team_id);
   const eventTimestamp = stringValue(event.ts);
   if (!eventId || !workspaceId || !eventTimestamp) return { envelopeId };
+  if (authorizedWorkspaceId && workspaceId !== authorizedWorkspaceId) return { envelopeId };
   const rootThreadId = stringValue(event.thread_ts) ?? eventTimestamp;
   return {
     envelopeId,
@@ -141,6 +145,7 @@ export class SlackTeamChatProvider implements TeamChatProvider {
   private stopped = true;
   private botUserId = "";
   private botId = "";
+  private authorizedWorkspaceId = "";
   private handle: ((message: TeamChatInboundMessage) => Promise<void>) | undefined;
   private readonly userNames = new Map<string, string>();
   private readonly conversationMetadata = new Map<
@@ -166,6 +171,11 @@ export class SlackTeamChatProvider implements TeamChatProvider {
     const auth = await this.call("auth.test", this.config.botToken);
     this.botUserId = requiredSlackString(auth, "user_id", "auth.test");
     this.botId = stringValue(auth.bot_id) ?? "";
+    const tokenWorkspaceId = requiredSlackString(auth, "team_id", "auth.test");
+    if (this.config.workspaceId && this.config.workspaceId !== tokenWorkspaceId) {
+      throw new Error("SLACK_WORKSPACE_ID does not match the Slack bot token workspace");
+    }
+    this.authorizedWorkspaceId = this.config.workspaceId ?? tokenWorkspaceId;
     await this.connect();
   }
 
@@ -179,10 +189,17 @@ export class SlackTeamChatProvider implements TeamChatProvider {
 
   async send(request: TeamChatSendRequest): Promise<TeamChatSendResult> {
     let handle = "";
-    for (const text of splitSlackMessage(request.content, this.maxMessageChars)) {
+    const chunks = splitSlackMessage(request.content, this.maxMessageChars);
+    for (const [index, text] of chunks.entries()) {
       const response = await this.call("chat.postMessage", this.config.botToken, {
         channel: request.conversationId,
         text,
+        ...(request.idempotencyKey
+          ? {
+              client_msg_id:
+                chunks.length === 1 ? request.idempotencyKey : `${request.idempotencyKey}:${index}`,
+            }
+          : {}),
         ...(request.replyThreadId ? { thread_ts: request.replyThreadId } : {}),
       });
       handle = requiredSlackString(response, "ts", "chat.postMessage");
@@ -223,7 +240,12 @@ export class SlackTeamChatProvider implements TeamChatProvider {
     } catch {
       return;
     }
-    const parsed = parseSlackSocketEnvelope(value, this.botUserId, this.botId);
+    const parsed = parseSlackSocketEnvelope(
+      value,
+      this.botUserId,
+      this.botId,
+      this.authorizedWorkspaceId,
+    );
     if (parsed.envelopeId && this.socket?.readyState === WebSocket.OPEN) {
       this.socket.send(JSON.stringify({ envelope_id: parsed.envelopeId }));
     }


### PR DESCRIPTION
## Why

Greptile flagged recoverability/security issues on #538 before it goes to production. This ports the targeted hardening patch onto the #538 branch.

## What changed

- Pins Slack Socket Mode events to the authorized Slack workspace from `auth.test`, with optional `SLACK_WORKSPACE_ID` validation.
- Adds provider-neutral send idempotency keys and maps them to Slack `client_msg_id` values.
- Reserves external-message delivery before Slack sends so retries are explicit and idempotent.
- Promotes elected ambient messages from `observed` to `received` before marking the rest ignored, avoiding a crash window that could discard the trigger.
- Adds regression coverage for workspace rejection, outbound idempotency, delivery reservation, and ambient trigger promotion.

## Tested

- `pnpm exec biome check .env.example apps/api/src/team-chat-bridge.ts apps/api/src/team-chat-bridge.test.ts packages/adapter-kit/src/types.ts packages/adapters/src/slack-team-chat.ts packages/adapters/src/slack-team-chat.test.ts`
- `pnpm check`
- `pnpm exec vitest run apps/api/src/team-chat-bridge.test.ts packages/adapters/src/slack-team-chat.test.ts apps/api/src/env.test.ts packages/contracts/src/index.test.ts`
