### PR TITLE
Harden Slack team chat bridge delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,7 @@ TELEGRAM_WEBHOOK_SECRET_TOKEN=
 # Bot events: app_mention, message.im, message.channels, message.groups, message.mpim.
 SLACK_APP_TOKEN=
 SLACK_BOT_TOKEN=
+SLACK_WORKSPACE_ID=
 SLACK_RAKAZO_BOT_ID=
 # Optional lower-cost model for ambient Slack judgments. Configure both or neither.
 TEAM_CHAT_JUDGE_PROVIDER=

--- a/apps/api/src/team-chat-bridge.test.ts
+++ b/apps/api/src/team-chat-bridge.test.ts
@@ -103,9 +103,9 @@ describe("team chat bridge", () => {
           records.push(record);
           return record;
         }),
-        findMany: vi.fn(async ({ where }: { where: { status: string } }) =>
+        findMany: vi.fn(async ({ where }: { where: { status: string | { in: string[] } } }) =>
           records
-            .filter((record) => record.status === where.status)
+            .filter((record) => matchesStatus(record.status, where.status))
             .map((record) => ({
               ...record,
               externalConversation: conversation,
@@ -120,7 +120,29 @@ describe("team chat bridge", () => {
             return record;
           },
         ),
-        updateMany: vi.fn(async () => ({ count: 0 })),
+        updateMany: vi.fn(
+          async ({
+            where,
+            data,
+          }: {
+            where: { id?: string | { in?: string[] }; status?: string | { in: string[] } };
+            data: Record<string, unknown>;
+          }) => {
+            const ids =
+              typeof where.id === "string" ? [where.id] : (where.id as { in?: string[] })?.in;
+            let count = 0;
+            for (const record of records) {
+              if (
+                (!ids || ids.includes(String(record.id))) &&
+                matchesStatus(record.status, where.status)
+              ) {
+                Object.assign(record, data);
+                count += 1;
+              }
+            }
+            return { count };
+          },
+        ),
       },
       run: { findMany: vi.fn(async () => []) },
       message: {
@@ -198,6 +220,7 @@ describe("team chat bridge", () => {
         conversationId: "C-1",
         replyThreadId: "100.1",
         content: "The launch plan is ready.",
+        idempotencyKey: "external-message:external-1",
       },
     ]);
     expect(records[0]).toMatchObject({
@@ -355,6 +378,7 @@ describe("team chat bridge", () => {
         conversationId: "C-1",
         replyThreadId: "100.1",
         content: "Research found that the launch should move.",
+        idempotencyKey: "team-chat-run:run-arthur-result",
       },
     ]);
     expect(prisma.run.updateMany).toHaveBeenCalledWith({
@@ -476,6 +500,118 @@ describe("team chat bridge", () => {
       }),
     );
     expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not discard an elected ambient trigger before promoting it", async () => {
+    const records: Array<Record<string, unknown>> = [];
+    const sendUserMessage = vi.fn(async (input: { createRun?: boolean }) =>
+      input.createRun === false
+        ? { messageId: "message-visible", taskId: null, runId: null }
+        : { messageId: "message-prompt", taskId: "task-ambient", runId: "run-ambient" },
+    );
+    const judge = {
+      decide: vi.fn(async () => ({
+        act: true,
+        reason: "A committed launch date changed.",
+        askedByEventId: "Ev-ambient",
+      })),
+    };
+    const conversation = {
+      id: "conversation-ambient",
+      provider: "slack",
+      workspaceId: "T-1",
+      externalKey: "channel:C-1",
+      conversationId: "C-1",
+      displayName: "launch",
+      spaceId: "space-1",
+      botId: "bot-1",
+      userId: "owner-1",
+      thread: { id: "thread-ambient" },
+    };
+    const prisma = ambientPrisma(records, conversation, true) as unknown as PrismaClient;
+    const bridge = new TeamChatBridge({
+      prisma,
+      events: { sendUserMessage },
+      jobs: { enqueue: vi.fn(async () => undefined) },
+      provider: new FakeTeamChatProvider(),
+      judge,
+      botId: "bot-1",
+      ambientDebounceMs: 0,
+      reconcileIntervalMs: 60_000,
+    });
+
+    await bridge.start();
+    await bridge.receive(ambientMessage());
+    await bridge.stop();
+
+    expect(prisma.externalMessage.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "external-1", status: "observed" },
+        data: expect.objectContaining({ status: "received" }),
+      }),
+    );
+    expect(prisma.externalMessage.updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["external-1"] }, status: "observed" },
+        data: expect.objectContaining({ status: "ignored" }),
+      }),
+    );
+  });
+
+  it("does not resend a completed run when delivery was already reserved", async () => {
+    const provider = new FakeTeamChatProvider();
+    const prisma = {
+      bot: {
+        findFirst: vi.fn(async () => ({
+          id: "bot-1",
+          spaceId: "space-1",
+          userId: "owner-1",
+          name: "Arthur",
+        })),
+      },
+      externalMessage: {
+        findMany: vi.fn(async ({ where }: { where: { status?: { in: string[] } | string } }) =>
+          where.status && matchesStatus("delivering", where.status)
+            ? [
+                {
+                  id: "external-1",
+                  status: "delivering",
+                  attempts: 0,
+                  kind: "mention",
+                  runId: "run-1",
+                  replyThreadId: "100.1",
+                  run: { id: "run-1", status: "completed" },
+                  externalConversation: {
+                    provider: "slack",
+                    botId: "bot-1",
+                    conversationId: "C-1",
+                  },
+                },
+              ]
+            : [],
+        ),
+        updateMany: vi.fn(async () => ({ count: 0 })),
+      },
+      run: { findMany: vi.fn(async () => []) },
+      message: {
+        findFirst: vi.fn(async () => ({
+          blocks: [{ kind: "text", text: "Already being sent." }],
+        })),
+      },
+    } as unknown as PrismaClient;
+    const bridge = new TeamChatBridge({
+      prisma,
+      events: { sendUserMessage: vi.fn() },
+      jobs: { enqueue: vi.fn(async () => undefined) },
+      provider,
+      botId: "bot-1",
+      reconcileIntervalMs: 60_000,
+    });
+
+    await bridge.start();
+    await bridge.stop();
+
+    expect(provider.sent).toEqual([]);
   });
 
   it("uses room listening and guidance instead of Arthur's defaults", async () => {
@@ -746,9 +882,9 @@ function ambientPrisma(
         records.push(record);
         return record;
       }),
-      findMany: vi.fn(async ({ where }: { where: { status: string } }) =>
+      findMany: vi.fn(async ({ where }: { where: { status: string | { in: string[] } } }) =>
         records
-          .filter((record) => record.status === where.status)
+          .filter((record) => matchesStatus(record.status, where.status))
           .map((record) => ({
             ...record,
             externalConversation: conversation,
@@ -764,15 +900,17 @@ function ambientPrisma(
           data: Record<string, unknown>;
         }) => {
           const ids = (where.id as { in?: string[] } | undefined)?.in;
+          let count = 0;
           for (const record of records) {
             if (
               (!ids || ids.includes(String(record.id))) &&
-              record.status === (where.status ?? record.status)
+              matchesStatus(record.status, where.status ?? String(record.status))
             ) {
               Object.assign(record, data);
+              count += 1;
             }
           }
-          return { count: records.length };
+          return { count };
         },
       ),
       update: vi.fn(
@@ -787,6 +925,12 @@ function ambientPrisma(
     run: { findMany: vi.fn(async () => []) },
     message: { findFirst: vi.fn(async () => null) },
   };
+}
+
+function matchesStatus(value: unknown, status: string | { in: string[] } | undefined): boolean {
+  if (!status) return true;
+  const current = String(value);
+  return typeof status === "string" ? current === status : status.in.includes(current);
 }
 
 class FakeTeamChatProvider implements TeamChatProvider {

--- a/apps/api/src/team-chat-bridge.test.ts
+++ b/apps/api/src/team-chat-bridge.test.ts
@@ -558,8 +558,24 @@ describe("team chat bridge", () => {
     );
   });
 
-  it("does not resend a completed run when delivery was already reserved", async () => {
+  it("does not resend when delivery is already reserved with a future lease", async () => {
     const provider = new FakeTeamChatProvider();
+    const futureLease = new Date(Date.now() + 60_000);
+    const record = {
+      id: "external-1",
+      status: "delivering",
+      attempts: 0,
+      kind: "mention",
+      runId: "run-1",
+      replyThreadId: "100.1",
+      nextAttemptAt: futureLease,
+      run: { id: "run-1", status: "completed" },
+      externalConversation: {
+        provider: "slack",
+        botId: "bot-1",
+        conversationId: "C-1",
+      },
+    };
     const prisma = {
       bot: {
         findFirst: vi.fn(async () => ({
@@ -570,27 +586,12 @@ describe("team chat bridge", () => {
         })),
       },
       externalMessage: {
-        findMany: vi.fn(async ({ where }: { where: { status?: { in: string[] } | string } }) =>
-          where.status && matchesStatus("delivering", where.status)
-            ? [
-                {
-                  id: "external-1",
-                  status: "delivering",
-                  attempts: 0,
-                  kind: "mention",
-                  runId: "run-1",
-                  replyThreadId: "100.1",
-                  run: { id: "run-1", status: "completed" },
-                  externalConversation: {
-                    provider: "slack",
-                    botId: "bot-1",
-                    conversationId: "C-1",
-                  },
-                },
-              ]
-            : [],
+        findMany: vi.fn(async ({ where }: { where: Record<string, unknown> }) =>
+          matchesDeliveryCandidate(record, where) ? [record] : [],
         ),
-        updateMany: vi.fn(async () => ({ count: 0 })),
+        updateMany: vi.fn(async ({ where }: { where: Record<string, unknown> }) => ({
+          count: matchesReserveWhere(record, where) ? 1 : 0,
+        })),
       },
       run: { findMany: vi.fn(async () => []) },
       message: {
@@ -612,6 +613,118 @@ describe("team chat bridge", () => {
     await bridge.stop();
 
     expect(provider.sent).toEqual([]);
+    expect(prisma.externalMessage.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("reclaims abandoned delivering messages with a past or null lease once", async () => {
+    const provider = new FakeTeamChatProvider();
+    for (const nextAttemptAt of [new Date(Date.now() - 60_000), null] as const) {
+      provider.sent.length = 0;
+      const record = {
+        id: "external-1",
+        status: "delivering",
+        attempts: 0,
+        kind: "mention",
+        runId: "run-1",
+        replyThreadId: "100.1",
+        nextAttemptAt: nextAttemptAt as Date | null,
+        run: { id: "run-1", status: "completed" },
+        externalConversation: {
+          provider: "slack",
+          botId: "bot-1",
+          conversationId: "C-1",
+        },
+      };
+      const prisma = {
+        bot: {
+          findFirst: vi.fn(async () => ({
+            id: "bot-1",
+            spaceId: "space-1",
+            userId: "owner-1",
+            name: "Arthur",
+          })),
+        },
+        externalMessage: {
+          findMany: vi.fn(async ({ where }: { where: Record<string, unknown> }) =>
+            matchesDeliveryCandidate(record, where) ? [record] : [],
+          ),
+          updateMany: vi.fn(
+            async ({
+              where,
+              data,
+            }: {
+              where: Record<string, unknown>;
+              data: Record<string, unknown>;
+            }) => {
+              if (!matchesReserveWhere(record, where)) return { count: 0 };
+              Object.assign(record, data);
+              return { count: 1 };
+            },
+          ),
+          update: vi.fn(
+            async ({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+              if (where.id === record.id) Object.assign(record, data);
+              return record;
+            },
+          ),
+        },
+        run: { findMany: vi.fn(async () => []) },
+        message: {
+          findFirst: vi.fn(async () => ({
+            blocks: [{ kind: "text", text: "Recovered send." }],
+          })),
+        },
+      } as unknown as PrismaClient;
+      const bridge = new TeamChatBridge({
+        prisma,
+        events: { sendUserMessage: vi.fn() },
+        jobs: { enqueue: vi.fn(async () => undefined) },
+        provider,
+        botId: "bot-1",
+        reconcileIntervalMs: 60_000,
+      });
+
+      await bridge.start();
+      await bridge.stop();
+
+      expect(provider.sent).toEqual([
+        {
+          conversationId: "C-1",
+          replyThreadId: "100.1",
+          content: "Recovered send.",
+          idempotencyKey: "external-message:external-1",
+        },
+      ]);
+      expect(prisma.externalMessage.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: "external-1",
+            status: "delivering",
+            OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: expect.any(Date) } }],
+          }),
+          data: expect.objectContaining({
+            status: "delivering",
+            nextAttemptAt: expect.any(Date),
+          }),
+        }),
+      );
+
+      // Simulate a second instance that already observed the row before the lease refresh:
+      // reclaim must fail while the fresh lease is held.
+      record.status = "delivering";
+      record.nextAttemptAt = new Date(Date.now() + 120_000);
+      (prisma.externalMessage.findMany as ReturnType<typeof vi.fn>).mockImplementation(
+        async ({ where }: { where: Record<string, unknown> }) =>
+          where.status &&
+          matchesStatus(record.status, where.status as string | { in: string[] } | undefined)
+            ? [record]
+            : [],
+      );
+      provider.sent.length = 0;
+      await bridge.start();
+      await bridge.stop();
+      expect(provider.sent).toEqual([]);
+    }
   });
 
   it("uses room listening and guidance instead of Arthur's defaults", async () => {
@@ -931,6 +1044,43 @@ function matchesStatus(value: unknown, status: string | { in: string[] } | undef
   if (!status) return true;
   const current = String(value);
   return typeof status === "string" ? current === status : status.in.includes(current);
+}
+
+function matchesNextAttemptAt(
+  value: Date | null | undefined,
+  where: Record<string, unknown>,
+): boolean {
+  const clause = where.OR as Array<Record<string, unknown>> | undefined;
+  if (!clause) return true;
+  const now = Date.now();
+  return clause.some((entry) => {
+    if ("nextAttemptAt" in entry && entry.nextAttemptAt === null) return value == null;
+    const lte = (entry.nextAttemptAt as { lte?: Date } | undefined)?.lte;
+    if (lte) return value != null && value.getTime() <= lte.getTime();
+    if (value == null) return true;
+    return value.getTime() <= now;
+  });
+}
+
+function matchesDeliveryCandidate(
+  record: { status: string; nextAttemptAt?: Date | null },
+  where: Record<string, unknown>,
+): boolean {
+  if (!where.status) return false;
+  return (
+    matchesStatus(record.status, where.status as string | { in: string[] } | undefined) &&
+    matchesNextAttemptAt(record.nextAttemptAt, where)
+  );
+}
+
+function matchesReserveWhere(
+  record: { id: string; status: string; nextAttemptAt?: Date | null },
+  where: Record<string, unknown>,
+): boolean {
+  if (where.id !== record.id) return false;
+  if (!matchesStatus(record.status, where.status as string | { in: string[] } | undefined))
+    return false;
+  return matchesNextAttemptAt(record.nextAttemptAt, where);
 }
 
 class FakeTeamChatProvider implements TeamChatProvider {

--- a/apps/api/src/team-chat-bridge.ts
+++ b/apps/api/src/team-chat-bridge.ts
@@ -11,6 +11,7 @@ const BATCH_SIZE = 20;
 const AMBIENT_BATCH_SIZE = 100;
 const AMBIENT_CONTEXT_MESSAGES = 20;
 const AMBIENT_CONTEXT_MESSAGE_CHARS = 2_000;
+const DELIVERY_RESERVATION_MS = 2 * 60_000;
 
 interface TeamChatBridgeDeps {
   prisma: PrismaClient;
@@ -269,6 +270,7 @@ export class TeamChatBridge {
     for (const message of received)
       await this.queue(message).catch((error) => this.retry(message, error));
 
+    await this.recoverStaleDeliveries(now);
     const running = await this.deps.prisma.externalMessage.findMany({
       where: {
         status: "running",
@@ -338,6 +340,7 @@ export class TeamChatBridge {
           conversationId: origin.externalConversation.conversationId,
           replyThreadId: origin.replyThreadId,
           content,
+          idempotencyKey: `team-chat-run:${run.id}`,
         });
       }
       await this.markTeamChatMirrored(run.id);
@@ -478,29 +481,43 @@ export class TeamChatBridge {
       const trigger =
         judgedMessages.find((message) => message.providerEventId === decision.askedByEventId) ??
         latest;
-      await this.markAmbientIgnored(evaluated, now);
-      if (!decision.act) continue;
-      await this.deps.prisma.externalMessage.update({
-        where: { id: trigger.id },
-        data: {
-          status: "received",
-          judgedAt: now,
-          engagementReason: decision.reason ?? null,
-          batchContext: teamChatAmbientPrompt({
-            provider: this.deps.provider.id,
-            channelId: latest.externalConversation.conversationId,
-            channelName: latest.externalConversation.displayName,
-            rules,
-            reason: decision.reason,
-            messages: judgedMessages.map((message) => ({
-              senderId: message.senderId,
-              senderName: message.senderName,
-              content: message.content,
-            })),
-          }),
-        },
+      if (!decision.act) {
+        await this.markAmbientIgnored(evaluated, now);
+        continue;
+      }
+      const promoted = await this.promoteAmbientTrigger(trigger.id, {
+        judgedAt: now,
+        engagementReason: decision.reason ?? null,
+        batchContext: teamChatAmbientPrompt({
+          provider: this.deps.provider.id,
+          channelId: latest.externalConversation.conversationId,
+          channelName: latest.externalConversation.displayName,
+          rules,
+          reason: decision.reason,
+          messages: judgedMessages.map((message) => ({
+            senderId: message.senderId,
+            senderName: message.senderName,
+            content: message.content,
+          })),
+        }),
       });
+      if (promoted)
+        await this.markAmbientIgnored(
+          evaluated.filter(({ id }) => id !== trigger.id),
+          now,
+        );
     }
+  }
+
+  private async promoteAmbientTrigger(
+    id: string,
+    data: { judgedAt: Date; engagementReason: string | null; batchContext: string },
+  ): Promise<boolean> {
+    const result = await this.deps.prisma.externalMessage.updateMany({
+      where: { id, status: "observed" },
+      data: { status: "received", ...data },
+    });
+    return result.count === 1;
   }
 
   private async markAmbientIgnored(messages: Array<{ id: string }>, judgedAt: Date): Promise<void> {
@@ -610,10 +627,13 @@ export class TeamChatBridge {
       await this.markDelivered(message.id, "silent");
       return;
     }
+    const reserved = await this.reserveDelivery(message.id);
+    if (!reserved) return;
     const sent = await this.deps.provider.send({
       conversationId: message.externalConversation.conversationId,
       replyThreadId: message.replyThreadId,
       content,
+      idempotencyKey: `external-message:${message.id}`,
     });
     await this.markDelivered(message.id, sent.handle);
   }
@@ -628,12 +648,33 @@ export class TeamChatBridge {
       await this.markDelivered(message.id, "silent-failure");
       return;
     }
+    const reserved = await this.reserveDelivery(message.id);
+    if (!reserved) return;
     const sent = await this.deps.provider.send({
       conversationId: message.externalConversation.conversationId,
       replyThreadId: message.replyThreadId,
       content: `${this.target?.name ?? "The agent"} could not complete that request. Open Rakazo for details.`,
+      idempotencyKey: `external-message:${message.id}:failure`,
     });
     await this.markDelivered(message.id, sent.handle);
+  }
+
+  private async reserveDelivery(id: string): Promise<boolean> {
+    const result = await this.deps.prisma.externalMessage.updateMany({
+      where: { id, status: "running" },
+      data: {
+        status: "delivering",
+        nextAttemptAt: new Date(Date.now() + DELIVERY_RESERVATION_MS),
+      },
+    });
+    return result.count === 1;
+  }
+
+  private async recoverStaleDeliveries(now: Date): Promise<void> {
+    await this.deps.prisma.externalMessage.updateMany({
+      where: { status: "delivering", nextAttemptAt: { lte: now } },
+      data: { status: "running", nextAttemptAt: null },
+    });
   }
 
   private async markDelivered(id: string, handle: string): Promise<void> {

--- a/apps/api/src/team-chat-bridge.ts
+++ b/apps/api/src/team-chat-bridge.ts
@@ -270,10 +270,9 @@ export class TeamChatBridge {
     for (const message of received)
       await this.queue(message).catch((error) => this.retry(message, error));
 
-    await this.recoverStaleDeliveries(now);
     const running = await this.deps.prisma.externalMessage.findMany({
       where: {
-        status: "running",
+        status: { in: ["running", "delivering"] },
         OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: now } }],
         externalConversation: {
           provider: this.deps.provider.id,
@@ -660,21 +659,29 @@ export class TeamChatBridge {
   }
 
   private async reserveDelivery(id: string): Promise<boolean> {
-    const result = await this.deps.prisma.externalMessage.updateMany({
+    const now = new Date();
+    const leaseUntil = new Date(now.getTime() + DELIVERY_RESERVATION_MS);
+    const claimed = await this.deps.prisma.externalMessage.updateMany({
       where: { id, status: "running" },
       data: {
         status: "delivering",
-        nextAttemptAt: new Date(Date.now() + DELIVERY_RESERVATION_MS),
+        nextAttemptAt: leaseUntil,
       },
     });
-    return result.count === 1;
-  }
+    if (claimed.count === 1) return true;
 
-  private async recoverStaleDeliveries(now: Date): Promise<void> {
-    await this.deps.prisma.externalMessage.updateMany({
-      where: { status: "delivering", nextAttemptAt: { lte: now } },
-      data: { status: "running", nextAttemptAt: null },
+    const reclaimed = await this.deps.prisma.externalMessage.updateMany({
+      where: {
+        id,
+        status: "delivering",
+        OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: now } }],
+      },
+      data: {
+        status: "delivering",
+        nextAttemptAt: leaseUntil,
+      },
     });
+    return reclaimed.count === 1;
   }
 
   private async markDelivered(id: string, handle: string): Promise<void> {

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -540,6 +540,8 @@ export interface TeamChatSendRequest {
   conversationId: string;
   replyThreadId: string | null;
   content: string;
+  /** Stable retry key the provider can use to dedupe externally accepted sends. */
+  idempotencyKey?: string;
 }
 
 export interface TeamChatSendResult {

--- a/packages/adapters/src/slack-team-chat.test.ts
+++ b/packages/adapters/src/slack-team-chat.test.ts
@@ -106,6 +106,31 @@ describe("Slack team chat adapter", () => {
     });
   });
 
+  it("rejects messages from an unconfigured Slack workspace", () => {
+    const parsed = parseSlackSocketEnvelope(
+      {
+        envelope_id: "env-cross-workspace",
+        type: "events_api",
+        payload: {
+          event_id: "Ev-cross-workspace",
+          team_id: "T-OTHER",
+          event: {
+            type: "app_mention",
+            user: "U-1",
+            channel: "C-1",
+            text: "<@U-ARTHUR> please summarize this",
+            ts: "100.001",
+          },
+        },
+      },
+      "U-ARTHUR",
+      undefined,
+      "T-AUTHORIZED",
+    );
+
+    expect(parsed).toEqual({ envelopeId: "env-cross-workspace" });
+  });
+
   it("keeps third-party bot posts for room policy evaluation", () => {
     const parsed = parseSlackSocketEnvelope(
       {
@@ -240,8 +265,9 @@ describe("Slack team chat adapter", () => {
       slackTeamChatConfigFromEnv({
         SLACK_APP_TOKEN: " xapp-test ",
         SLACK_BOT_TOKEN: " xoxb-test ",
+        SLACK_WORKSPACE_ID: " T-1 ",
       }),
-    ).toEqual({ appToken: "xapp-test", botToken: "xoxb-test" });
+    ).toEqual({ appToken: "xapp-test", botToken: "xoxb-test", workspaceId: "T-1" });
   });
 
   it("extracts every participant from a multi-person direct message", () => {
@@ -296,6 +322,7 @@ describe("Slack team chat adapter", () => {
         conversationId: "C-1",
         replyThreadId: "100.1",
         content: "abcdefghij",
+        idempotencyKey: "reply-key",
       }),
     ).resolves.toEqual({ handle: "reply-ij" });
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -303,6 +330,7 @@ describe("Slack team chat adapter", () => {
       Object.fromEntries(new URLSearchParams(String(fetchMock.mock.calls[0]?.[1]?.body))),
     ).toEqual({
       channel: "C-1",
+      client_msg_id: "reply-key:0",
       text: "abcd",
       thread_ts: "100.1",
     });

--- a/packages/adapters/src/slack-team-chat.ts
+++ b/packages/adapters/src/slack-team-chat.ts
@@ -12,6 +12,7 @@ const DEFAULT_MAX_MESSAGE_CHARS = 39_000;
 export interface SlackTeamChatConfig {
   appToken: string;
   botToken: string;
+  workspaceId?: string;
 }
 
 type Fetch = typeof fetch;
@@ -30,10 +31,11 @@ export function slackTeamChatConfigFromEnv(
 ): SlackTeamChatConfig | null {
   const appToken = source.SLACK_APP_TOKEN?.trim();
   const botToken = source.SLACK_BOT_TOKEN?.trim();
+  const workspaceId = source.SLACK_WORKSPACE_ID?.trim();
   if (!appToken && !botToken) return null;
   if (!appToken) throw new Error("SLACK_APP_TOKEN is required when Slack is enabled");
   if (!botToken) throw new Error("SLACK_BOT_TOKEN is required when Slack is enabled");
-  return { appToken, botToken };
+  return { appToken, botToken, ...(workspaceId ? { workspaceId } : {}) };
 }
 
 export function splitSlackMessage(content: string, maxChars = DEFAULT_MAX_MESSAGE_CHARS): string[] {
@@ -67,6 +69,7 @@ export function parseSlackSocketEnvelope(
   value: unknown,
   botUserId: string,
   ownBotId?: string,
+  authorizedWorkspaceId?: string,
 ): { envelopeId?: string; message?: TeamChatInboundMessage } {
   if (!isRecord(value)) return {};
   const envelopeId = stringValue(value.envelope_id);
@@ -109,6 +112,7 @@ export function parseSlackSocketEnvelope(
   const workspaceId = stringValue(payload.team_id);
   const eventTimestamp = stringValue(event.ts);
   if (!eventId || !workspaceId || !eventTimestamp) return { envelopeId };
+  if (authorizedWorkspaceId && workspaceId !== authorizedWorkspaceId) return { envelopeId };
   const rootThreadId = stringValue(event.thread_ts) ?? eventTimestamp;
   return {
     envelopeId,
@@ -141,6 +145,7 @@ export class SlackTeamChatProvider implements TeamChatProvider {
   private stopped = true;
   private botUserId = "";
   private botId = "";
+  private authorizedWorkspaceId = "";
   private handle: ((message: TeamChatInboundMessage) => Promise<void>) | undefined;
   private readonly userNames = new Map<string, string>();
   private readonly conversationMetadata = new Map<
@@ -166,6 +171,11 @@ export class SlackTeamChatProvider implements TeamChatProvider {
     const auth = await this.call("auth.test", this.config.botToken);
     this.botUserId = requiredSlackString(auth, "user_id", "auth.test");
     this.botId = stringValue(auth.bot_id) ?? "";
+    const tokenWorkspaceId = requiredSlackString(auth, "team_id", "auth.test");
+    if (this.config.workspaceId && this.config.workspaceId !== tokenWorkspaceId) {
+      throw new Error("SLACK_WORKSPACE_ID does not match the Slack bot token workspace");
+    }
+    this.authorizedWorkspaceId = this.config.workspaceId ?? tokenWorkspaceId;
     await this.connect();
   }
 
@@ -179,10 +189,17 @@ export class SlackTeamChatProvider implements TeamChatProvider {
 
   async send(request: TeamChatSendRequest): Promise<TeamChatSendResult> {
     let handle = "";
-    for (const text of splitSlackMessage(request.content, this.maxMessageChars)) {
+    const chunks = splitSlackMessage(request.content, this.maxMessageChars);
+    for (const [index, text] of chunks.entries()) {
       const response = await this.call("chat.postMessage", this.config.botToken, {
         channel: request.conversationId,
         text,
+        ...(request.idempotencyKey
+          ? {
+              client_msg_id:
+                chunks.length === 1 ? request.idempotencyKey : `${request.idempotencyKey}:${index}`,
+            }
+          : {}),
         ...(request.replyThreadId ? { thread_ts: request.replyThreadId } : {}),
       });
       handle = requiredSlackString(response, "ts", "chat.postMessage");
@@ -223,7 +240,12 @@ export class SlackTeamChatProvider implements TeamChatProvider {
     } catch {
       return;
     }
-    const parsed = parseSlackSocketEnvelope(value, this.botUserId, this.botId);
+    const parsed = parseSlackSocketEnvelope(
+      value,
+      this.botUserId,
+      this.botId,
+      this.authorizedWorkspaceId,
+    );
     if (parsed.envelopeId && this.socket?.readyState === WebSocket.OPEN) {
       this.socket.send(JSON.stringify({ envelope_id: parsed.envelopeId }));
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Supersedes fork PR #540 ([Harden Slack team chat bridge delivery](https://github.com/elie222/rakazo/pull/540)) from @wflanagan (William Flanagan / `omalab/rakazo`). That fork tip was unpushable (403 even with `maintainerCanModify`), so this re-hosts the work on `elie222/rakazo` onto the same #538 base (`cursor/supersede-pr-536-slack-bridge-09de`).

Greptile flagged a delivery-reservation race on the original hardening: reclaiming `delivering` without an exclusive lease could let two instances both send.

## What changed

- Cherry-picks William’s hardening (`6ca8792`): Slack workspace pinning, `idempotencyKey` → `client_msg_id`, ambient promote-before-ignore, and delivery reservation.
- Fixes reservation reclaim: exclusive `running` → `delivering` with a ~2-minute `nextAttemptAt` lease; abandoned `delivering` rows are reclaimed only when `nextAttemptAt` is null or ≤ now, refreshing the lease in the same update so only one instance wins.
- Regression tests: future lease does not send; past/null lease reclaims once.

## Tested

- `pnpm exec vitest run apps/api/src/team-chat-bridge.test.ts packages/adapters/src/slack-team-chat.test.ts` (26 passed)
- `pnpm exec biome check` on touched files

No UI changes (no screenshots).

Credit: William Flanagan (@wflanagan). Do not merge until review is complete.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15a10f14-bcf9-4f66-b978-5ad48d4b7bb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15a10f14-bcf9-4f66-b978-5ad48d4b7bb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

