### PR TITLE
Fix inline code contrast in light mode

### DIFF
--- a/apps/web/e2e/ui-appearance.spec.ts
+++ b/apps/web/e2e/ui-appearance.spec.ts
@@ -73,8 +73,11 @@ test("account settings appearance control switches to light mode", async ({ page
   const composer = page.getByRole("combobox", { name: /^Message/ });
   await composer.fill("Please review `shared/PROJECT_CHECKPOINT_WRAPUP.md`.");
   await composer.press("Enter");
-  const inlinePath = page
+  const assistantReply = page
     .getByTestId("transcript")
+    .locator("[data-message-id]")
+    .filter({ hasText: "done. i handled:" });
+  const inlinePath = assistantReply
     .locator("code")
     .filter({ hasText: "shared/PROJECT_CHECKPOINT_WRAPUP.md" });
   await expect(inlinePath).toBeVisible({ timeout: 30_000 });

--- a/apps/web/e2e/ui-appearance.spec.ts
+++ b/apps/web/e2e/ui-appearance.spec.ts
@@ -70,6 +70,17 @@ test("account settings appearance control switches to light mode", async ({ page
   await captureScreenshot(page, testInfo, "ui-appearance-light-shell");
   await captureSidebarSearchSelected(page, testInfo, "sidebar-search-selected-light");
 
+  const composer = page.getByRole("combobox", { name: /^Message/ });
+  await composer.fill("Please review `shared/PROJECT_CHECKPOINT_WRAPUP.md`.");
+  await composer.press("Enter");
+  const inlinePath = page
+    .getByTestId("transcript")
+    .locator("code")
+    .filter({ hasText: "shared/PROJECT_CHECKPOINT_WRAPUP.md" });
+  await expect(inlinePath).toBeVisible({ timeout: 30_000 });
+  await expect(inlinePath).toHaveCSS("color", "rgb(243, 243, 244)");
+  await captureScreenshot(page, testInfo, "inline-code-light");
+
   await page.getByTestId("user-menu-trigger").click();
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   await expect(settings).toBeVisible();

--- a/packages/chat-ui/src/markdown.web.css
+++ b/packages/chat-ui/src/markdown.web.css
@@ -90,6 +90,7 @@
   border: 1px solid #34343a;
   border-radius: 0.35em;
   background: #101012;
+  color: #f3f3f4;
   padding: 0.08em 0.32em;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.88em;


### PR DESCRIPTION
## Why

Inline Markdown paths used a dark chip background but inherited the surrounding light-mode text color, making filenames nearly invisible unless selected.

## What changed

- Give inline and fenced Markdown code an explicit high-contrast foreground.
- Extend the appearance E2E flow with a real assistant reply containing an inline path, a computed-color assertion, and a light-mode screenshot.

## Testing

- `pnpm check`
- `pnpm lint` (passes with existing repository warnings)
- `pnpm --filter @rakazo/chat-ui test`
- `pnpm test:e2e -- --spec=e2e/ui-appearance.spec.ts`

Full `pnpm test` result: 2,302 passed, 109 skipped, and one unrelated macOS background-process teardown test timed out; the same test also times out in isolation.

## Screenshot

[CI E2E screenshot: inline code light](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33748801573-1/screenshots/images/111-inline-code-light.png)
