### PR TITLE
docs: add a Run on a server section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ script URL — see
 
 For an agent-assisted install, use [SETUP_PROMPT.md](./SETUP_PROMPT.md).
 
+## Run on a server
+
+Bots stay on when the backend runs on a server. Use the same installer on a VPS, then connect from
+the desktop app, the mobile app, or a browser.
+
+```bash
+bash install-images.sh --prepare-only
+# edit .env: SANDBOX_PROVIDER=box (or e2b / daytona) with its API key, RAKAZO_HOST=your.domain
+bash install-images.sh
+```
+
+Put HTTPS in front of port 5173; [docs/self-host.md](./docs/self-host.md#public-single-vm-deployment)
+covers the Caddy setup and host hardening. In the desktop app choose **Existing instance** and enter
+the `https://` address.
+
 ## Local development (source checkout)
 
 You need Node.js 22+, pnpm 9, and Docker.


### PR DESCRIPTION
## Why
People who want always-on bots should run the backend on a server and connect the desktop or mobile app to it. That path already works through **Existing instance**, but the README only described local Docker and source checkouts; the VPS instructions were spread across `docs/self-host.md`.

## What changed
- README: a short **Run on a server** section right after Quick start: same installer with `--prepare-only`, set the remote sandbox provider and `RAKAZO_HOST` in `.env`, put HTTPS in front of 5173, then pick **Existing instance** in the desktop app. Links to the public single-VM section of the self-host guide.

No UI change: the setup dialog already shows only the two choices.

## How it was tested
Docs only. Biome clean; desktop unit tests still pass (183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Qt4w8NTC3SXxmYpZSzKvZ
