### PR TITLE
ci: build server images natively per architecture instead of under QEMU

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -80,7 +80,8 @@ jobs:
     name: Build ${{ matrix.name }} ${{ matrix.arch }}
     if: github.event_name != 'pull_request'
     # Each architecture builds natively on its own runner and pushes by digest only.
-    # No QEMU: emulated arm64 took hours for the desktop-sized computer image.
+    # No QEMU: GitHub hosts native arm64 runners, and emulated arm64 took hours for the
+    # desktop-sized computer image. See docs/self-host.md (Published images and tags).
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -76,21 +76,21 @@ jobs:
           provenance: false
           sbom: false
 
-  publish:
-    name: Publish ${{ matrix.name }} image
+  build:
+    name: Build ${{ matrix.name }} ${{ matrix.arch }}
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    # QEMU arm64 is slow; keep everyday main→edge publishes at 90m. Multi-arch
-    # (v* tags + workflow_dispatch) needs the longer budget.
-    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')) && 180 || 90 }}
+    # Each architecture builds natively on its own runner and pushes by digest only.
+    # No QEMU: emulated arm64 took hours for the desktop-sized computer image.
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
-      id-token: write
-      attestations: write
     strategy:
       fail-fast: false
       matrix:
+        name: [app, updater, computer]
+        arch: [amd64, arm64]
         include:
           # Only the updater image contains the Docker CLI; the application image stays unprivileged.
           # The supervisor is not a separate published image: it runs from `app` on the internal network.
@@ -103,13 +103,80 @@ jobs:
           - name: computer
             dockerfile: infra/sandboxes/computer/Dockerfile
             context: infra/sandboxes/computer
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-      # Emulated arm64 only for releases and manual runs — not the ~10x/day main merge train.
-      - if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          # Labels only; the tagged manifest is assembled in the publish job.
+          images: ghcr.io/${{ github.repository }}/${{ matrix.name }}
+          tags: type=sha,prefix=sha-
+      - id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # A fork can publish only to its own namespace; no credential can redirect this value.
+          outputs: type=image,name=ghcr.io/${{ github.repository }}/${{ matrix.name }},push-by-digest=true,name-canonical=true,push=true
+          # GET /health can report the exact source commit without a deployment-supplied override.
+          build-args: ${{ matrix.name == 'app' && format('GIT_SHA={0}', github.sha) || '' }}
+          cache-from: type=gha,scope=${{ matrix.name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}-${{ matrix.arch }}
+          provenance: mode=max
+          sbom: true
+      - name: Record the architecture digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: digest-${{ matrix.name }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish ${{ matrix.name }} image
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: app
+          - name: updater
+          - name: computer
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: digest-${{ matrix.name }}-*
+          path: /tmp/digests
+          merge-multiple: true
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -129,25 +196,38 @@ jobs:
             type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
             # Stable releases only: a hyphen marks a prerelease (v1.0.0-rc.1) that must not move latest.
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
-      - id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Main→edge stays native amd64. Tags and workflow_dispatch publish amd64+arm64.
-          platforms: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          # GET /health can report the exact source commit without a deployment-supplied override.
-          build-args: ${{ matrix.name == 'app' && format('GIT_SHA={0}', github.sha) || '' }}
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
-          provenance: mode=max
-          sbom: true
+      - name: Assemble and verify the multi-arch manifest
+        id: manifest
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.name }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          tag_args=()
+          while IFS= read -r tag; do
+            [[ -n "$tag" ]] && tag_args+=(-t "$tag")
+          done <<< "$TAGS"
+          sources=()
+          for digest in *; do
+            sources+=("${IMAGE}@sha256:${digest}")
+          done
+          if [[ "${#sources[@]}" -ne 2 ]]; then
+            echo "Expected one digest per architecture, found ${#sources[@]}." >&2
+            exit 1
+          fi
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+
+          first_tag="$(head -n 1 <<< "$TAGS")"
+          platforms="$(docker buildx imagetools inspect "$first_tag" \
+            --format '{{range .Manifest.Manifests}}{{.Platform.OS}}/{{.Platform.Architecture}}{{"\n"}}{{end}}')"
+          for want in linux/amd64 linux/arm64; do
+            grep -Fqx "$want" <<< "$platforms" || { echo "$first_tag is missing $want" >&2; exit 1; }
+          done
+          echo "digest=$(docker buildx imagetools inspect "$first_tag" --format '{{.Manifest.Digest}}')" >> "$GITHUB_OUTPUT"
       - name: Attest the published image
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/${{ github.repository }}/${{ matrix.name }}
-          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
           push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Open [http://127.0.0.1:5173](http://127.0.0.1:5173), create an account, and conn
 Local Docker computers are on by default. Optional remote providers: `e2b`, `daytona`, or `box`
 with the matching API key.
 
-Default image tag is `edge` (main builds, `linux/amd64`). Details and tags:
+Default image tag is `edge` (main builds, `linux/amd64` + `linux/arm64`). Details and tags:
 [self-hosting guide](./docs/self-host.md#published-images-no-checkout).
 
 On restricted networks, override the installer download base (`RAKAZO_DOWNLOAD_BASE`), skip

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -49,7 +49,7 @@ Setup:
 4. Preserve existing values. Keep `SANDBOX_PROVIDER=docker` unless I chose a remote computer
    provider, and add only the provider or model keys I selected.
 5. Run `bash install-images.sh`. It preserves `.env`, pulls the images, and starts the stack.
-6. Wait until api, web, and supervisor are healthy. Default image tag is `edge` (amd64). Do not pin `latest` unless that tag exists in GHCR.
+6. Wait until api, web, and supervisor are healthy. Default image tag is `edge` (amd64 + arm64). Do not pin `latest` unless that tag exists in GHCR.
 
 Verification:
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -89,11 +89,8 @@ Signup and local Docker computers work without an E2B account. Optional remote p
 
 Optional: set `OPENROUTER_API_KEY` or connect a model in the UI after signup.
 
-The example defaults to `edge` (main builds, `linux/amd64` only). On arm64 hosts, set both
-`RAKAZO_IMAGE_TAG` and `RAKAZO_COMPUTER_IMAGE_TAG` to the same published multi-arch release tag
-when one exists (see [Published images and tags](#published-images-and-tags)). Changing only
-`RAKAZO_IMAGE_TAG` leaves the computer service on amd64-only `edge`. Do not assume `latest` is
-published.
+The example defaults to `edge` (main builds). Every publish is multi-arch (`amd64` + `arm64`), so
+arm64 hosts need no special tag. Do not assume `latest` is present until a stable release exists.
 
 Open [http://127.0.0.1:5173](http://127.0.0.1:5173). The first registered user becomes the
 deployment owner. Put TLS in front of `:5173` for a public host and set the three public origins to
@@ -449,10 +446,8 @@ your CI cannot publish into someone else's.
 | `sha-<full-commit>` | every push and manual run | source-addressed; used by the updater sidecar |
 | `edge` | pushes to main | yes, to the newest main build |
 
-`edge` from everyday main merges is `linux/amd64` only. Release tags (`v*`) and manual
-`workflow_dispatch` publishes are multi-arch (`amd64` + `arm64`). On arm64 hosts, set both
-`RAKAZO_IMAGE_TAG` and `RAKAZO_COMPUTER_IMAGE_TAG` to the same published release tag rather than
-`edge`. Changing only `RAKAZO_IMAGE_TAG` leaves the computer service on amd64-only `edge`. Until a
+Every publish, including `edge` from main merges, is multi-arch (`amd64` + `arm64`): each
+architecture builds natively on its own runner and one manifest is assembled per image. Until a
 stable `vX.Y.Z` has been published, GHCR may only have `edge` and `sha-*` tags; do not pin
 `latest` unless that tag exists in the registry.
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -451,6 +451,13 @@ architecture builds natively on its own runner and one manifest is assembled per
 stable `vX.Y.Z` has been published, GHCR may only have `edge` and `sha-*` tags; do not pin
 `latest` unless that tag exists in the registry.
 
+Building the images yourself does not need QEMU. `docker compose up --build` builds for the host's
+own architecture, and a fork publishing multi-arch images should do what `publish-server-image.yml`
+does: build each architecture on a native runner (GitHub Actions provides `ubuntu-24.04-arm` for
+public repositories) and merge the digests into one manifest. QEMU emulation
+(`docker/setup-qemu-action`, `binfmt`) still works if you have no native arm64 machine, but it is
+many times slower, hours rather than minutes for the `computer` image.
+
 The updater resolves the newest stable `vX.Y.Z` source tag but deploys its `sha-<full-commit>` image,
 not `latest` or a moving minor tag. A registry tag is not an OCI digest and GHCR package writers can
 replace it, so the trust boundary remains this repository's publishing credentials. The workflow

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -29,7 +29,7 @@ EMAIL_FROM=
 
 # Restricted-network / registry-mirror escape hatch: override these four when
 # GHCR is unreachable. Keep app + computer on the same mirror. Defaults stay GHCR.
-# edge tracks main (amd64 only). Pin a published release tag when you need arm64 or a fixed version.
+# edge tracks main (amd64 + arm64). Pin a published release tag when you need a fixed version.
 RAKAZO_IMAGE=ghcr.io/elie222/rakazo/app
 RAKAZO_IMAGE_TAG=edge
 RAKAZO_COMPUTER_IMAGE=ghcr.io/elie222/rakazo/computer

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -3,8 +3,8 @@
 #   docker compose --env-file .env -f docker-compose.images.yml up -d
 #
 # Tag contract matches docs/self-host.md (edge from main; release tags when published).
-# Default is edge because that tag is published on every main build (linux/amd64 only).
-# Pin a published release tag (vX.Y.Z or latest, when present) for multi-arch and fixed versions.
+# Default is edge because that tag is published on every main build (linux/amd64 + linux/arm64).
+# Pin a published release tag (vX.Y.Z or latest, when present) for a fixed version.
 # Default SANDBOX_PROVIDER=docker boots a local computer via the in-stack supervisor (no E2B key).
 # Optional: set e2b / daytona / box plus the matching API key for remote computers.
 name: rakazo

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -4,7 +4,7 @@
 #
 # Tag contract matches docs/self-host.md (edge from main; release tags when published).
 # Default is edge because that tag is published on every main build (linux/amd64 + linux/arm64).
-# Pin a published release tag (vX.Y.Z or latest, when present) for a fixed version.
+# Pin a published vX.Y.Z tag for a fixed version; `latest` moves to each new stable release.
 # Default SANDBOX_PROVIDER=docker boots a local computer via the in-stack supervisor (no E2B key).
 # Optional: set e2b / daytona / box plus the matching API key for remote computers.
 name: rakazo

--- a/infra/updater/src/publish-workflow.test.ts
+++ b/infra/updater/src/publish-workflow.test.ts
@@ -15,13 +15,15 @@ interface WorkflowJob {
 }
 
 const workflow = parse(workflowText) as {
-  jobs: { validate: WorkflowJob; build: WorkflowJob; publish: WorkflowJob };
+  jobs: Record<string, WorkflowJob>;
 };
 
 describe("server image publish workflow", () => {
   it("builds every architecture natively instead of emulating arm64", () => {
     expect(workflowText).not.toContain("setup-qemu-action");
     const build = workflow.jobs.build;
+    expect(build).toBeDefined();
+    if (!build) throw new Error("expected build job");
     expect(build["runs-on"]).toContain("matrix.runner");
     expect(build.strategy?.matrix?.arch).toEqual(["amd64", "arm64"]);
     const runners = Object.fromEntries(
@@ -33,7 +35,10 @@ describe("server image publish workflow", () => {
   });
 
   it("publishes one verified multi-arch manifest per image after both builds", () => {
-    expect(workflow.jobs.publish.needs).toBe("build");
+    const publish = workflow.jobs.publish;
+    expect(publish).toBeDefined();
+    if (!publish) throw new Error("expected publish job");
+    expect(publish.needs).toBe("build");
     expect(workflowText).toContain("push-by-digest=true");
     expect(workflowText).toContain("docker buildx imagetools create");
     expect(workflowText).toContain("for want in linux/amd64 linux/arm64");
@@ -41,9 +46,16 @@ describe("server image publish workflow", () => {
   });
 
   it("keeps pull requests read-only and every action pinned to a commit", () => {
-    expect(workflow.jobs.validate.if).toBe("github.event_name == 'pull_request'");
-    expect(workflow.jobs.build.if).toBe("github.event_name != 'pull_request'");
-    expect(workflow.jobs.publish.if).toBe("github.event_name != 'pull_request'");
+    const validate = workflow.jobs.validate;
+    const build = workflow.jobs.build;
+    const publish = workflow.jobs.publish;
+    expect(validate).toBeDefined();
+    expect(build).toBeDefined();
+    expect(publish).toBeDefined();
+    if (!validate || !build || !publish) throw new Error("expected validate, build, and publish jobs");
+    expect(validate.if).toBe("github.event_name == 'pull_request'");
+    expect(build.if).toBe("github.event_name != 'pull_request'");
+    expect(publish.if).toBe("github.event_name != 'pull_request'");
     expect(workflowText).toContain("push: false");
     for (const match of workflowText.matchAll(/uses:\s+([^\s#]+)/g)) {
       expect(match[1], match[1]).toMatch(/@[0-9a-f]{40}$/);

--- a/infra/updater/src/publish-workflow.test.ts
+++ b/infra/updater/src/publish-workflow.test.ts
@@ -7,17 +7,15 @@ const workflowText = readFileSync(
   path.resolve(import.meta.dirname, "../../../.github/workflows/publish-server-image.yml"),
   "utf8",
 );
+interface WorkflowJob {
+  if?: string;
+  needs?: string;
+  "runs-on"?: string;
+  strategy?: { matrix?: { arch?: string[]; include?: Array<Record<string, string>> } };
+}
+
 const workflow = parse(workflowText) as {
-  jobs: Record<
-    string,
-    {
-      if?: string;
-      needs?: string;
-      "runs-on"?: string;
-      strategy?: { matrix?: { arch?: string[]; include?: Array<Record<string, string>> } };
-      steps?: Array<Record<string, unknown>>;
-    }
-  >;
+  jobs: { validate: WorkflowJob; build: WorkflowJob; publish: WorkflowJob };
 };
 
 describe("server image publish workflow", () => {

--- a/infra/updater/src/publish-workflow.test.ts
+++ b/infra/updater/src/publish-workflow.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const workflowText = readFileSync(
+  path.resolve(import.meta.dirname, "../../../.github/workflows/publish-server-image.yml"),
+  "utf8",
+);
+const workflow = parse(workflowText) as {
+  jobs: Record<
+    string,
+    {
+      if?: string;
+      needs?: string;
+      "runs-on"?: string;
+      strategy?: { matrix?: { arch?: string[]; include?: Array<Record<string, string>> } };
+      steps?: Array<Record<string, unknown>>;
+    }
+  >;
+};
+
+describe("server image publish workflow", () => {
+  it("builds every architecture natively instead of emulating arm64", () => {
+    expect(workflowText).not.toContain("setup-qemu-action");
+    const build = workflow.jobs.build;
+    expect(build["runs-on"]).toContain("matrix.runner");
+    expect(build.strategy?.matrix?.arch).toEqual(["amd64", "arm64"]);
+    const runners = Object.fromEntries(
+      (build.strategy?.matrix?.include ?? [])
+        .filter((entry) => entry.arch !== undefined)
+        .map((entry) => [entry.arch, entry.runner]),
+    );
+    expect(runners).toEqual({ amd64: "ubuntu-latest", arm64: "ubuntu-24.04-arm" });
+  });
+
+  it("publishes one verified multi-arch manifest per image after both builds", () => {
+    expect(workflow.jobs.publish.needs).toBe("build");
+    expect(workflowText).toContain("push-by-digest=true");
+    expect(workflowText).toContain("docker buildx imagetools create");
+    expect(workflowText).toContain("for want in linux/amd64 linux/arm64");
+    expect(workflowText).toContain("actions/attest-build-provenance@");
+  });
+
+  it("keeps pull requests read-only and every action pinned to a commit", () => {
+    expect(workflow.jobs.validate.if).toBe("github.event_name == 'pull_request'");
+    expect(workflow.jobs.build.if).toBe("github.event_name != 'pull_request'");
+    expect(workflow.jobs.publish.if).toBe("github.event_name != 'pull_request'");
+    expect(workflowText).toContain("push: false");
+    for (const match of workflowText.matchAll(/uses:\s+([^\s#]+)/g)) {
+      expect(match[1], match[1]).toMatch(/@[0-9a-f]{40}$/);
+    }
+  });
+});

--- a/infra/updater/src/publish-workflow.test.ts
+++ b/infra/updater/src/publish-workflow.test.ts
@@ -15,15 +15,13 @@ interface WorkflowJob {
 }
 
 const workflow = parse(workflowText) as {
-  jobs: Record<string, WorkflowJob>;
+  jobs: { validate: WorkflowJob; build: WorkflowJob; publish: WorkflowJob };
 };
 
 describe("server image publish workflow", () => {
   it("builds every architecture natively instead of emulating arm64", () => {
     expect(workflowText).not.toContain("setup-qemu-action");
     const build = workflow.jobs.build;
-    expect(build).toBeDefined();
-    if (!build) throw new Error("expected build job");
     expect(build["runs-on"]).toContain("matrix.runner");
     expect(build.strategy?.matrix?.arch).toEqual(["amd64", "arm64"]);
     const runners = Object.fromEntries(
@@ -36,8 +34,6 @@ describe("server image publish workflow", () => {
 
   it("publishes one verified multi-arch manifest per image after both builds", () => {
     const publish = workflow.jobs.publish;
-    expect(publish).toBeDefined();
-    if (!publish) throw new Error("expected publish job");
     expect(publish.needs).toBe("build");
     expect(workflowText).toContain("push-by-digest=true");
     expect(workflowText).toContain("docker buildx imagetools create");
@@ -49,10 +45,6 @@ describe("server image publish workflow", () => {
     const validate = workflow.jobs.validate;
     const build = workflow.jobs.build;
     const publish = workflow.jobs.publish;
-    expect(validate).toBeDefined();
-    expect(build).toBeDefined();
-    expect(publish).toBeDefined();
-    if (!validate || !build || !publish) throw new Error("expected validate, build, and publish jobs");
     expect(validate.if).toBe("github.event_name == 'pull_request'");
     expect(build.if).toBe("github.event_name != 'pull_request'");
     expect(publish.if).toBe("github.event_name != 'pull_request'");


### PR DESCRIPTION
## Why
`publish-server-image.yml` emulated `linux/arm64` with QEMU on an amd64 runner. For release tags that meant up to three hours, mostly spent on the `computer` image (a full Linux desktop), and it was the reason `edge` stayed amd64-only. GitHub's native arm64 runners (`ubuntu-24.04-arm`, free for public repos) remove the emulation entirely.

## What changed
- **`build` job**: matrix of image × architecture (6 jobs). amd64 runs on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`. Each pushes by digest only (`push-by-digest=true`) with a per-image, per-arch GHA cache scope. `setup-qemu-action` is gone.
- **`publish` job** (one per image, `needs: build`): downloads the two digests, runs `docker buildx imagetools create` with the same tag set as before (`vX.Y.Z`, `vX.Y`, `sha-*`, `edge` on main, `latest` on stable tags), then **verifies** the manifest lists both `linux/amd64` and `linux/arm64` before attesting the index digest with `attest-build-provenance`.
- **Every publish is now multi-arch**, including main→edge, at no extra wall-clock cost. Docs and Compose comments that said "edge is amd64-only, pin a release tag on arm64" are updated (README, SETUP_PROMPT, self-host guide, `docker-compose.images.yml`, `.env.images.example`).
- **`validate` job** (PR-only, `push: false`, amd64) is unchanged, so fork PRs stay cheap and read-only.
- New `infra/updater/src/publish-workflow.test.ts` asserts no QEMU, native runners per arch, publish depends on build, manifest verification present, PR job stays read-only, and every action is SHA-pinned. The existing `compose-images.test.ts` still reads the publish matrix names.

## How it was tested
- Workflow parses with the repo's `yaml` package; `pnpm exec vitest run infra/updater/src` passes (59 tests); Biome clean.
- The first push to main after merge is the real proof: expect the longest job (computer arm64) to finish in roughly the amd64 time instead of hours, and `docker buildx imagetools inspect ghcr.io/elie222/rakazo/app:edge` to list both architectures.

## Notes
- Per-arch cache scopes start cold once; later runs warm up.
- Labels are still applied per image via `metadata-action`; tags are applied on the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Qt4w8NTC3SXxmYpZSzKvZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published `edge` container images now support both `linux/amd64` and `linux/arm64` architectures.
  * Main-branch image updates now publish multi-architecture manifests automatically.

* **Documentation**
  * Updated quick-start, setup, self-hosting, and Compose guidance to reflect multi-architecture `edge` images.
  * Clarified that self-built images can use native architecture builds without QEMU; QEMU remains supported but is slower.
  * Documented that release tags refer to fixed versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->