### PR TITLE
fix(desktop): name the Linux executable so the AppImage builds

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -70,6 +70,7 @@
       "verifyUpdateCodeSignature": true
     },
     "linux": {
+      "executableName": "rakazo",
       "icon": "assets/icon.png",
       "target": [
         "AppImage"


### PR DESCRIPTION
## Why

The first `v0.1.0` release run failed in the Linux job: electron-builder derives the executable name from the package name and rejects the `@` in `@rakazo/desktop` ("executableName contains characters that cannot be safely used in file paths").

## What changed

`linux.executableName` is set to `rakazo` in the desktop electron-builder config. macOS and Windows keep using `productName`.

## How it was tested

Built the x64 AppImage locally with the workflow's command. The build succeeds, the unpacked executable is named `rakazo`, and the workflow's Linux feed checks (GitHub provider, owner, repo, and version in `latest-linux.yml`) pass on the output.

No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013r2B2i8r34FkkBGx5JpRpx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux desktop builds now use the executable name `rakazo`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->