### PR TITLE
Keep macOS controls clear of the setup title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -30,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -47,6 +51,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -73,6 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -90,6 +98,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,32 +68,6 @@ jobs:
           path: apps/desktop/e2e/screenshots
           if-no-files-found: ignore
 
-  desktop-macos-screenshot:
-    name: macOS setup screenshot
-    runs-on: macos-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @rakazo/desktop build
-      - name: Capture native macOS setup window
-        run: >-
-          pnpm --filter @rakazo/desktop exec playwright test
-          --config e2e/playwright.config.ts setup.spec.ts
-          --grep "first run asks whether to use a local or existing instance"
-      - name: Upload native macOS setup screenshot
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: desktop-e2e-macos-screenshot
-          path: apps/desktop/e2e/screenshots/08-setup-macos-native-controls.png
-          if-no-files-found: error
-
   test:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,32 @@ jobs:
           path: apps/desktop/e2e/screenshots
           if-no-files-found: ignore
 
+  desktop-macos-screenshot:
+    name: macOS setup screenshot
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @rakazo/desktop build
+      - name: Capture native macOS setup window
+        run: >-
+          pnpm --filter @rakazo/desktop exec playwright test
+          --config e2e/playwright.config.ts setup.spec.ts
+          --grep "first run asks whether to use a local or existing instance"
+      - name: Upload native macOS setup screenshot
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: desktop-e2e-macos-screenshot
+          path: apps/desktop/e2e/screenshots/08-setup-macos-native-controls.png
+          if-no-files-found: error
+
   test:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop-macos-screenshot.yml
+++ b/.github/workflows/desktop-macos-screenshot.yml
@@ -1,0 +1,49 @@
+name: desktop-macos-screenshot
+on:
+  push:
+    branches: [main]
+    paths: &desktop-setup-paths
+      - ".github/workflows/desktop-macos-screenshot.yml"
+      - "apps/desktop/e2e/setup.spec.ts"
+      - "apps/desktop/package.json"
+      - "apps/desktop/scripts/copy-static.mjs"
+      - "apps/desktop/src/setup*"
+      - "apps/desktop/src/window-options.ts"
+      - "packages/contracts/src/desktop.ts"
+  pull_request:
+    paths: *desktop-setup-paths
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-macos-screenshot-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  screenshot:
+    name: macOS setup screenshot
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @rakazo/desktop build
+      - name: Capture native macOS setup window
+        run: >-
+          pnpm --filter @rakazo/desktop exec playwright test
+          --config e2e/playwright.config.ts setup.spec.ts
+          --grep "first run asks whether to use a local or existing instance"
+      - name: Upload native macOS setup screenshot
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: desktop-e2e-macos-screenshot
+          path: apps/desktop/e2e/screenshots/08-setup-macos-native-controls.png
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/desktop-macos-screenshot.yml
+++ b/.github/workflows/desktop-macos-screenshot.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -90,6 +90,17 @@ test("first run asks whether to use a local or existing instance", async () => {
   await setup.screenshot({
     path: path.join(import.meta.dirname, "screenshots", "01-setup-new-instance.png"),
   });
+
+  // Linux CI cannot draw macOS traffic lights, so apply the same platform state to
+  // verify and capture the gutter that keeps the native controls clear of the title.
+  await setup.evaluate(() => {
+    document.documentElement.dataset.platform = "darwin";
+  });
+  await expect(setup.locator(".titlebar")).toHaveCSS("padding-left", "88px");
+  expect((await setup.locator(".titlebar-name").boundingBox())?.x).toBeGreaterThanOrEqual(88);
+  await setup.screenshot({
+    path: path.join(import.meta.dirname, "screenshots", "08-setup-macos-titlebar-clearance.png"),
+  });
 });
 
 test("connecting to an existing instance verifies, saves, and opens it", async () => {

--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -1,10 +1,13 @@
+import { execFile } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { type ElectronApplication, _electron as electron, expect, test } from "@playwright/test";
 
 const APP_MARKER = "Existing Rakazo instance ready";
+const execFileAsync = promisify(execFile);
 
 let server: Server;
 let serverUrl: string;
@@ -91,16 +94,27 @@ test("first run asks whether to use a local or existing instance", async () => {
     path: path.join(import.meta.dirname, "screenshots", "01-setup-new-instance.png"),
   });
 
-  // Linux CI cannot draw macOS traffic lights, so apply the same platform state to
-  // verify and capture the gutter that keeps the native controls clear of the title.
+  // Linux CI verifies the layout state; the macOS CI job also captures the native controls.
   await setup.evaluate(() => {
     document.documentElement.dataset.platform = "darwin";
   });
   await expect(setup.locator(".titlebar")).toHaveCSS("padding-left", "88px");
   expect((await setup.locator(".titlebar-name").boundingBox())?.x).toBeGreaterThanOrEqual(88);
-  await setup.screenshot({
-    path: path.join(import.meta.dirname, "screenshots", "08-setup-macos-titlebar-clearance.png"),
-  });
+  if (process.platform === "darwin") {
+    await app.evaluate(({ BrowserWindow }) => {
+      const window = BrowserWindow.getAllWindows()[0];
+      if (window === undefined) throw new Error("Setup window is unavailable");
+      window.setBounds({ x: 40, y: 40, width: 720, height: 700 });
+      window.show();
+      window.focus();
+    });
+    await setup.waitForTimeout(500);
+    await execFileAsync("screencapture", [
+      "-x",
+      "-R40,40,720,700",
+      path.join(import.meta.dirname, "screenshots", "08-setup-macos-native-controls.png"),
+    ]);
+  }
 });
 
 test("connecting to an existing instance verifies, saves, and opens it", async () => {

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -94,8 +94,10 @@ describe("setup preload bridge", () => {
     expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
     const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoSetup];
     expect(globalName).toBe("rakazoSetup");
+    expect(bridge.platform).toBe("linux");
     expect(Object.keys(bridge).sort()).toEqual([
       "openLink",
+      "platform",
       "quit",
       "save",
       "stack",

--- a/apps/desktop/src/setup-preload.cjs
+++ b/apps/desktop/src/setup-preload.cjs
@@ -1,6 +1,7 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("rakazoSetup", {
+  platform: process.platform,
   state: () => ipcRenderer.invoke("desktop.setup.state"),
   test: (url) => ipcRenderer.invoke("desktop.setup.test", url),
   save: (setup) => ipcRenderer.invoke("desktop.setup.save", setup),

--- a/apps/desktop/src/setup.css
+++ b/apps/desktop/src/setup.css
@@ -55,6 +55,10 @@ body {
   flex: none;
 }
 
+html[data-platform="darwin"] .titlebar {
+  padding-left: 88px;
+}
+
 .titlebar-name {
   font-size: 12px;
   letter-spacing: 0.08em;

--- a/apps/desktop/src/setup.js
+++ b/apps/desktop/src/setup.js
@@ -1,5 +1,6 @@
 (() => {
   const bridge = window.rakazoSetup;
+  document.documentElement.dataset.platform = bridge?.platform ?? "browser";
 
   const form = document.getElementById("setup");
   const serverUrl = document.getElementById("server-url");

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -115,6 +115,8 @@ export type DesktopSetupLink = "docker-desktop" | "orbstack" | "docker-engine";
  * narrower `rakazoDesktop` bridge so a connected server can never re-point the app.
  */
 export interface RakazoSetup {
+  /** Used only to reserve space for native window controls in the local setup UI. */
+  platform: string;
   state: () => Promise<DesktopSetupState>;
   test: (url: string) => Promise<DesktopReachability>;
   save: (setup: DesktopSetup) => Promise<{ ok: boolean; error?: string }>;


### PR DESCRIPTION
## Why

The native macOS traffic lights overlap the Rakazo label in the first-run desktop setup window.

## What changed

- expose the desktop platform to the setup-only preload bridge
- reserve the native-control gutter only on macOS
- cover the bridge contract and capture the setup window with native controls in a path-filtered macOS workflow
- disable checkout credential persistence in pull-request jobs after automated security review

## Testing

- desktop unit suite (185 tests)
- desktop TypeScript check
- desktop production build
- Electron setup test is compiled locally and runs in CI because it opens real windows locally
- native macOS setup capture passed in CI

## Screenshot

- [Native macOS CI screenshot](https://github.com/elie222/rakazo/actions/runs/33763629181/artifacts/9896599393) — `08-setup-macos-native-controls.png` shows the traffic lights clear of the setup title.