### PR TITLE
Fix connector card spacing and authorize hover feedback

### DIFF
--- a/apps/web/e2e/onboarding-conversation.spec.ts
+++ b/apps/web/e2e/onboarding-conversation.spec.ts
@@ -26,14 +26,31 @@ test("focus choice suggests apps and preserves a completed connection", async ({
   await expect(page.getByPlaceholder("Message Chief")).toBeVisible();
   await expect(page.getByText("Slack", { exact: true })).toBeVisible();
   await expect(page.getByText("Gmail", { exact: true })).toBeVisible();
+  const connectionCards = page.getByRole("group", { name: / connection$/ });
+  await expect(connectionCards).toHaveCount(3);
+  const cardBoxes = await connectionCards.evaluateAll((cards) =>
+    cards.map((card) => {
+      const { bottom, top } = card.getBoundingClientRect();
+      return { bottom, top };
+    }),
+  );
+  expect(cardBoxes[1].top - cardBoxes[0].bottom).toBeGreaterThanOrEqual(8);
+  expect(cardBoxes[2].top - cardBoxes[1].bottom).toBeGreaterThanOrEqual(8);
   await page
     .getByTestId("transcript")
     .getByText("Hit those three and I’ll start pulling the picture.")
     .scrollIntoViewIfNeeded();
-  await page.mouse.move(1, 1);
-  await captureScreenshot(page, testInfo, "02-app-suggestions");
+  const authorizeButton = slackCard(page).getByRole("button", { name: "Authorize" });
+  const restingBackground = await authorizeButton.evaluate(
+    (button) => getComputedStyle(button).backgroundColor,
+  );
+  await authorizeButton.hover();
+  await expect
+    .poll(() => authorizeButton.evaluate((button) => getComputedStyle(button).backgroundColor))
+    .not.toBe(restingBackground);
+  await captureScreenshot(page, testInfo, "02-app-suggestions-authorize-hover");
 
-  await slackCard(page).getByRole("button", { name: "Authorize" }).click();
+  await authorizeButton.click();
   await expect(slackCard(page).getByText("Connected", { exact: true })).toBeVisible();
   await expect(slackCard(page).getByText("Connected", { exact: true })).toHaveCSS("opacity", "1");
   await expect

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -5240,7 +5240,7 @@ const MessageView = memo(function MessageView({
           const botId = "botId" in artifactTarget ? artifactTarget.botId : message.botId;
           if (!botId) return null;
           return (
-            <div key={i} className="flex justify-start">
+            <div key={i} className="flex justify-start py-1">
               <AppConnectCard botId={botId} block={block} />
             </div>
           );

--- a/apps/web/src/pages/shell/message-cards.tsx
+++ b/apps/web/src/pages/shell/message-cards.tsx
@@ -158,7 +158,7 @@ export function AppConnectCard({
         ) : (
           <Button
             variant="secondary"
-            className="rounded-full"
+            className="rounded-full hover:bg-primary hover:text-primary-foreground"
             disabled={busy}
             onClick={() => void authorize()}
           >


### PR DESCRIPTION
## Why

Connector suggestion cards visually ran into each other, and the Authorize action lacked sufficiently clear hover feedback.

## What changed

- add consistent vertical separation between connector cards
- give the Authorize button a clear semantic-token hover state
- extend the onboarding browser test to verify card gaps and hover feedback, and capture the updated state

## Testing

- Web typecheck passed
- Web unit tests passed (174 tests)
- Focused onboarding browser test passed
- Web production build passed
- Repository lint passed with pre-existing warnings only

## Screenshot

[Connector spacing and Authorize hover state](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33766411165-1/screenshots/images/004-02-app-suggestions-authorize-hover.png)