### PR TITLE
Default new visitors to sign up

### DIFF
--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -148,7 +148,7 @@ export default function Account() {
     try {
       await signOut();
       router.dismissAll();
-      router.replace("/sign-in");
+      router.replace({ pathname: "/sign-in", params: { mode: "in" } });
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not sign out"));
       setPending(false);

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -32,6 +32,7 @@ import {
   setAppearancePreference,
   subscribeAppearance,
 } from "../lib/appearance";
+import { explicitSignInRoute } from "../lib/auth-routing";
 import { confirmDeleteBot } from "../lib/bot-lifecycle";
 import { setUiLocale, useI18n } from "../lib/i18n";
 import {
@@ -148,7 +149,7 @@ export default function Account() {
     try {
       await signOut();
       router.dismissAll();
-      router.replace({ pathname: "/sign-in", params: { mode: "in" } });
+      router.replace(explicitSignInRoute);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not sign out"));
       setPending(false);

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -31,13 +31,14 @@ import {
   signUp,
   usesCustomApiBase,
 } from "../lib/api";
+import { type AuthMode, initialAuthMode } from "../lib/auth-routing";
 import { useI18n } from "../lib/i18n";
 
 export default function SignIn() {
   const { t } = useI18n();
   const router = useRouter();
-  const { mode: requestedMode } = useLocalSearchParams<{ mode?: string }>();
-  const [mode, setMode] = useState<"in" | "up" | "forgot">(requestedMode === "in" ? "in" : "up");
+  const { mode: requestedMode } = useLocalSearchParams<{ mode?: string | string[] }>();
+  const [mode, setMode] = useState<AuthMode>(() => initialAuthMode(requestedMode));
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -1,4 +1,4 @@
-import { Redirect, useRouter } from "expo-router";
+import { Redirect, useLocalSearchParams, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useState } from "react";
 import {
@@ -36,7 +36,8 @@ import { useI18n } from "../lib/i18n";
 export default function SignIn() {
   const { t } = useI18n();
   const router = useRouter();
-  const [mode, setMode] = useState<"in" | "up" | "forgot">("in");
+  const { mode: requestedMode } = useLocalSearchParams<{ mode?: string }>();
+  const [mode, setMode] = useState<"in" | "up" | "forgot">(requestedMode === "in" ? "in" : "up");
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -8,9 +8,6 @@ const mobileRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 describe("Android mobile platform contract", () => {
   it("keeps authentication actions reachable while the keyboard is open", () => {
     const signIn = readFileSync(resolve(mobileRoot, "app/sign-in.tsx"), "utf8");
-    const account = readFileSync(resolve(mobileRoot, "app/account.tsx"), "utf8");
-    expect(signIn).toContain('requestedMode === "in" ? "in" : "up"');
-    expect(account).toContain('params: { mode: "in" }');
     expect(signIn).toContain("KeyboardAvoidingView");
     expect(signIn).toContain("Keyboard.dismiss");
     expect(signIn).toContain("keyboardDismissMode");

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -8,6 +8,9 @@ const mobileRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 describe("Android mobile platform contract", () => {
   it("keeps authentication actions reachable while the keyboard is open", () => {
     const signIn = readFileSync(resolve(mobileRoot, "app/sign-in.tsx"), "utf8");
+    const account = readFileSync(resolve(mobileRoot, "app/account.tsx"), "utf8");
+    expect(signIn).toContain('requestedMode === "in" ? "in" : "up"');
+    expect(account).toContain('params: { mode: "in" }');
     expect(signIn).toContain("KeyboardAvoidingView");
     expect(signIn).toContain("Keyboard.dismiss");
     expect(signIn).toContain("keyboardDismissMode");

--- a/apps/mobile/lib/auth-routing.test.ts
+++ b/apps/mobile/lib/auth-routing.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { explicitSignInRoute, initialAuthMode } from "./auth-routing.js";
+
+describe("mobile authentication routing", () => {
+  it("defaults ordinary logged-out visitors to sign-up", () => {
+    expect(initialAuthMode()).toBe("up");
+  });
+
+  it("honors the explicit sign-in route used after logout", () => {
+    expect(explicitSignInRoute).toEqual({ pathname: "/sign-in", params: { mode: "in" } });
+    expect(initialAuthMode(explicitSignInRoute.params.mode)).toBe("in");
+  });
+});

--- a/apps/mobile/lib/auth-routing.ts
+++ b/apps/mobile/lib/auth-routing.ts
@@ -1,0 +1,10 @@
+export type AuthMode = "in" | "up" | "forgot";
+
+export const explicitSignInRoute = {
+  pathname: "/sign-in",
+  params: { mode: "in" },
+} as const;
+
+export function initialAuthMode(requestedMode?: string | string[]): AuthMode {
+  return requestedMode === "in" ? "in" : "up";
+}

--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -32,7 +32,10 @@ test("logout protects bot deep links and sign-in restores the session", async ({
   await expect(page.getByRole("heading", { name: "Sign in to Rakazo" })).toBeVisible();
   await page.goto("/");
   await expect(page.getByText(/Your team of always-on agents/)).toBeVisible();
-  await expect(page.getByRole("button", { name: /Sign in/ })).toBeVisible();
+  await page.getByRole("button", { name: /Sign up/ }).click();
+  await expect(page).toHaveURL(/\/sign-up$/);
+  await expect(page.getByRole("heading", { name: "Create your Rakazo" })).toBeVisible();
+  await page.goto("/");
   await captureScreenshot(page, testInfo, "37-logged-out-welcome");
 
   await page.goto(protectedBotPath);

--- a/apps/web/src/pages/Welcome.tsx
+++ b/apps/web/src/pages/Welcome.tsx
@@ -26,10 +26,10 @@ export function WelcomePage() {
         </p>
         <button
           type="button"
-          onClick={() => navigate("/sign-in")}
+          onClick={() => navigate("/sign-up")}
           className="app-no-drag rounded-full bg-accent px-[34px] py-[15px] text-[19px] text-foreground transition hover:scale-[1.04] hover:bg-accent"
         >
-          <Trans>Sign in&nbsp;&nbsp;→</Trans>
+          <Trans>Sign up</Trans>&nbsp;&nbsp;→
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Why

New visitors should enter the account-creation flow by default, while returning users who explicitly sign out should still land on sign-in.

## What changed

- Changed the web welcome action to open sign-up.
- Made sign-up the default mobile authentication mode.
- Preserved an explicit mobile sign-in route after logout.
- Added regression coverage for both entry paths.

## Testing

- Web and mobile type checks pass.
- All web unit tests pass.
- All mobile unit tests pass.
- Formatting checks pass.
- The Rakazo Web E2E suite passes in CI.

## Screenshot

- [CI E2E: logged-out welcome with sign-up action](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33767362705-2/screenshots/images/063-37-logged-out-welcome.png)