### PR TITLE
Require a model before starting runs

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -326,6 +326,7 @@ export async function createApp(
       openSignup: env.messagingOpenSignup,
     },
     env: {
+      agentRuntime: env.agentRuntime,
       defaultProvider: env.defaultProvider,
       defaultModel: env.defaultModel,
       deploymentModelKey: env.deploymentModelKey,

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -96,6 +96,96 @@ describe("account preferences", () => {
   });
 });
 
+describe("model setup gate", () => {
+  function modelGateDeps(options: { agentRuntime: string; deploymentModelKey?: string }) {
+    const prisma = {
+      user: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          email: "user@rakazo.test",
+          name: "Test User",
+          avatarStyle: "robot",
+        }),
+      },
+      spaceModelPreference: { findFirst: vi.fn().mockResolvedValue(null) },
+      deploymentSettings: { findUnique: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+    const deps = {
+      prisma,
+      env: {
+        agentRuntime: options.agentRuntime,
+        defaultProvider: "openrouter",
+        defaultModel: "test-model",
+        deploymentModelKey: options.deploymentModelKey,
+        webOrigin: "http://127.0.0.1:5173",
+        screenProxySecret: "fake-test-secret",
+        sandboxProvider: "fake",
+      },
+      dataDir: "/tmp/rakazo-router-test",
+    } as unknown as RouterDeps;
+    const actor = {
+      spaceId: "workspace-1",
+      userId: "user-1",
+      email: "user@rakazo.test",
+      isDeploymentOwner: true,
+    } satisfies Actor;
+    return { actor, handler: new RPCHandler(createRouter(deps)) };
+  }
+
+  async function call(handler: RPCHandler<never>, actor: Actor, path: string, body: unknown) {
+    const { response } = await handler.handle(
+      new Request(`http://127.0.0.1/rpc/${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: body }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+    return response;
+  }
+
+  it("refuses to start a run when no model is configured", async () => {
+    const { actor, handler } = modelGateDeps({ agentRuntime: "pi" });
+
+    const response = await call(handler, actor, "threads/send", {
+      botId: "bot-1",
+      text: "hello",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      json: expect.objectContaining({
+        code: "BAD_REQUEST",
+        message: "Connect a model to start a run.",
+      }),
+    });
+  });
+
+  it("does not require a model credential for the scripted test runtime", async () => {
+    const { actor, handler } = modelGateDeps({ agentRuntime: "scripted" });
+
+    const response = await call(handler, actor, "me", null);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      json: expect.objectContaining({ needsModel: false }),
+    });
+  });
+
+  it("accepts a deployment model key as model configuration", async () => {
+    const { actor, handler } = modelGateDeps({
+      agentRuntime: "pi",
+      deploymentModelKey: "fake-deployment-key",
+    });
+
+    const response = await call(handler, actor, "me", null);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      json: expect.objectContaining({ needsModel: false }),
+    });
+  });
+});
+
 describe("thread answer delivery", () => {
   it("accepts a durable answer when the immediate worker wake fails", async () => {
     const answerRunInput = vi.fn().mockResolvedValue(true);

--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -97,7 +97,11 @@ describe("account preferences", () => {
 });
 
 describe("model setup gate", () => {
-  function modelGateDeps(options: { agentRuntime: string; deploymentModelKey?: string }) {
+  function modelGateDeps(options: {
+    agentRuntime: string;
+    deploymentModelKey?: string;
+    deploymentModelCredentialCipher?: string;
+  }) {
     const prisma = {
       user: {
         findUniqueOrThrow: vi.fn().mockResolvedValue({
@@ -107,7 +111,15 @@ describe("model setup gate", () => {
         }),
       },
       spaceModelPreference: { findFirst: vi.fn().mockResolvedValue(null) },
-      deploymentSettings: { findUnique: vi.fn().mockResolvedValue(null) },
+      deploymentSettings: {
+        findUnique: vi
+          .fn()
+          .mockResolvedValue(
+            options.deploymentModelCredentialCipher
+              ? { deploymentModelCredentialCipher: options.deploymentModelCredentialCipher }
+              : null,
+          ),
+      },
     } as unknown as PrismaClient;
     const deps = {
       prisma,
@@ -182,6 +194,20 @@ describe("model setup gate", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       json: expect.objectContaining({ needsModel: false }),
+    });
+  });
+
+  it("does not accept a stored deployment cipher the executor cannot use", async () => {
+    const { actor, handler } = modelGateDeps({
+      agentRuntime: "pi",
+      deploymentModelCredentialCipher: "legacy-ciphertext",
+    });
+
+    const response = await call(handler, actor, "me", null);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      json: expect.objectContaining({ needsModel: true }),
     });
   });
 });

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -3704,9 +3704,7 @@ async function modelSetup(deps: RouterDeps, actor: Actor) {
     findDefaultModelCredential(deps.prisma, actor),
     deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
   ]);
-  const hasDeployment = Boolean(
-    settings?.deploymentModelCredentialCipher || deps.env.deploymentModelKey,
-  );
+  const hasDeployment = Boolean(deps.env.deploymentModelKey);
   return {
     credential,
     settings,

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -336,6 +336,7 @@ export interface RouterDeps {
   /** Present when the external messaging surface is enabled. */
   messaging?: { enabled: boolean; providers: string[]; openSignup: boolean };
   env: {
+    agentRuntime: string;
     defaultProvider: string;
     defaultModel: string;
     deploymentModelKey?: string;
@@ -1074,6 +1075,9 @@ export function createRouter(deps: RouterDeps) {
         }
       }),
       send: authed.threads.send.handler(async ({ context, input }) => {
+        if ((await modelSetup(deps, context.actor)).needsModel) {
+          throw new ORPCError("BAD_REQUEST", { message: "Connect a model to start a run." });
+        }
         const target = await resolveThreadTarget(deps.prisma, context.actor, input);
         if (target.kind === "bot") {
           await assertTeachingSendAllowed(deps.prisma, context.actor.spaceId, target.botId);
@@ -3671,8 +3675,32 @@ async function loadAutoReviewSettings(deps: RouterDeps, actor: Actor) {
 }
 
 async function meDto(deps: RouterDeps, actor: Actor): Promise<Me> {
-  const [user, cred, settings] = await Promise.all([
+  const [user, setup] = await Promise.all([
     deps.prisma.user.findUniqueOrThrow({ where: { id: actor.userId } }),
+    modelSetup(deps, actor),
+  ]);
+  return {
+    userId: actor.userId,
+    email: user.email,
+    name: user.name,
+    spaceId: actor.spaceId,
+    isDeploymentOwner: actor.isDeploymentOwner,
+    needsModel: setup.needsModel,
+    defaultProvider:
+      setup.credential?.provider ??
+      setup.settings?.defaultModelProvider ??
+      deps.env.defaultProvider,
+    defaultModel:
+      setup.credential?.defaultModel ?? setup.settings?.defaultModelId ?? deps.env.defaultModel,
+    computerHost: computerHostFor(setup.settings?.computerHost, deps.env.sandboxProvider),
+    canChooseHostComputer: actor.isDeploymentOwner && deps.env.sandboxProvider === "docker",
+    sandboxProvider: deps.env.sandboxProvider,
+    avatarStyle: user.avatarStyle === "organic" ? "organic" : "robot",
+  };
+}
+
+async function modelSetup(deps: RouterDeps, actor: Actor) {
+  const [credential, settings] = await Promise.all([
     findDefaultModelCredential(deps.prisma, actor),
     deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
   ]);
@@ -3680,18 +3708,9 @@ async function meDto(deps: RouterDeps, actor: Actor): Promise<Me> {
     settings?.deploymentModelCredentialCipher || deps.env.deploymentModelKey,
   );
   return {
-    userId: actor.userId,
-    email: user.email,
-    name: user.name,
-    spaceId: actor.spaceId,
-    isDeploymentOwner: actor.isDeploymentOwner,
-    needsModel: !cred && !hasDeployment,
-    defaultProvider: cred?.provider ?? settings?.defaultModelProvider ?? deps.env.defaultProvider,
-    defaultModel: cred?.defaultModel ?? settings?.defaultModelId ?? deps.env.defaultModel,
-    computerHost: computerHostFor(settings?.computerHost, deps.env.sandboxProvider),
-    canChooseHostComputer: actor.isDeploymentOwner && deps.env.sandboxProvider === "docker",
-    sandboxProvider: deps.env.sandboxProvider,
-    avatarStyle: user.avatarStyle === "organic" ? "organic" : "robot",
+    credential,
+    settings,
+    needsModel: deps.env.agentRuntime !== "scripted" && !credential && !hasDeployment,
   };
 }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rakazo/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/main.js",

--- a/apps/web/e2e/onboarding-model-required.spec.ts
+++ b/apps/web/e2e/onboarding-model-required.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, signup } from "./helpers";
+
+test("onboarding requires a model when the deployment has none", async ({ page }, testInfo) => {
+  await page.route("**/rpc/me", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as { json: Record<string, unknown> };
+    await route.fulfill({
+      response,
+      json: { json: { ...body.json, needsModel: true } },
+    });
+  });
+
+  const stamp = Date.now();
+  await signup(
+    page,
+    `model-required-${stamp}@rakazo.test`,
+    "password12",
+    `Model required ${stamp}`,
+  );
+  await expect(page.getByRole("heading", { name: "Connect a model" })).toBeVisible({
+    timeout: 20_000,
+  });
+
+  await expect(page.getByRole("button", { name: "Skip for now" })).toBeHidden();
+  await captureScreenshot(page, testInfo, "onboarding-model-required");
+});

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -31,6 +31,7 @@ export function OnboardingPage() {
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [needsModel, setNeedsModel] = useState(false);
   const probeRequestIdRef = useRef(0);
 
   const {
@@ -53,6 +54,7 @@ export function OnboardingPage() {
     void Promise.all([rpc.me(), rpc.models.list().catch(() => [])])
       .then(([me, models]) => {
         setCatalog(models);
+        setNeedsModel(me.needsModel);
         const preferred =
           models.find(
             (entry) => entry.provider === me.defaultProvider && entry.id === me.defaultModel,
@@ -481,16 +483,18 @@ export function OnboardingPage() {
               >
                 <Trans>Continue</Trans>
               </Button>
-              <Button
-                variant="ghost"
-                className="text-muted-foreground"
-                onClick={() => {
-                  cancelOAuthAttempt();
-                  setStep("bot");
-                }}
-              >
-                <Trans>Skip for now</Trans>
-              </Button>
+              {needsModel ? null : (
+                <Button
+                  variant="ghost"
+                  className="text-muted-foreground"
+                  onClick={() => {
+                    cancelOAuthAttempt();
+                    setStep("bot");
+                  }}
+                >
+                  <Trans>Skip for now</Trans>
+                </Button>
+              )}
             </div>
           </div>
         ) : null}

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -773,6 +773,98 @@ description: Prepare standup notes
     expect(enqueue).toHaveBeenCalledOnce();
   });
 
+  it("fails a run clearly without calling the real runtime when no model is configured", async () => {
+    let status = "queued";
+    const runtimeRun = vi.fn();
+    const finalizeRun = vi.fn(async () => {
+      status = "failed";
+      return { continuationRunId: null };
+    });
+    const run = {
+      id: "run-1",
+      botId: "bot-1",
+      threadId: "thread-1",
+      taskId: "task-1",
+      userId: "user-1",
+      spaceId: "ws-1",
+      status: "queued",
+      trigger: "user",
+      routineId: null,
+      sourceMessageId: null,
+      checkpoint: null,
+      leaseFence: 0,
+    };
+    const botLookup = vi.fn(async (args: { select?: { computerId?: boolean } }) =>
+      args.select?.computerId
+        ? { computerId: "computer-1", computerSwitching: false }
+        : {
+            id: "bot-1",
+            name: "Assistant",
+            modelProvider: null,
+            modelId: null,
+            thinkingLevel: null,
+            memoryScope: "isolated",
+            computer: { id: "computer-1", scope: "private" },
+          },
+    );
+    const prisma = {
+      run: {
+        findUnique: vi.fn(async () => run),
+        findUniqueOrThrow: vi.fn(async () => ({ status: "leased", startedAt: null })),
+        updateMany: vi.fn(async () => ({ count: 1 })),
+      },
+      bot: { findUniqueOrThrow: botLookup },
+      computer: {
+        findUniqueOrThrow: vi.fn(async () => ({ scope: "private", state: "running" })),
+      },
+      attempt: {
+        create: vi.fn(async () => ({ id: "attempt-1" })),
+        updateMany: vi.fn(async () => ({ count: 1 })),
+      },
+      thread: {
+        findUniqueOrThrow: vi.fn(async () => ({
+          id: "thread-1",
+          groupId: null,
+          historyCompactionSummary: null,
+          historyCompactedUpToSeq: null,
+          historyCompactionGeneration: 0,
+        })),
+      },
+      message: { findMany: vi.fn(async () => []) },
+      task: { findUniqueOrThrow: vi.fn(async () => ({ id: "task-1", prompt: "hello" })) },
+      connection: { findMany: vi.fn(async () => []) },
+      spaceModelPreference: { findFirst: vi.fn(async () => null) },
+      userModelCredential: { findFirst: vi.fn(async () => null) },
+      deploymentSettings: { findUnique: vi.fn(async () => null) },
+      taughtSkill: { findMany: vi.fn(async () => []) },
+      agentSkill: { findMany: vi.fn(async () => []) },
+      scratchpadItem: { findMany: vi.fn(async () => []) },
+    } as unknown as PrismaClient;
+    const executor = createRunExecutor({
+      prisma,
+      runtime: {
+        describe: () => ({ capabilities: { scripted: false } }),
+        run: runtimeRun,
+      },
+      memoryProviders: { resolve: vi.fn(async () => null) },
+      memory: { read: vi.fn(async () => ({ documents: [] })) },
+      events: { append: vi.fn(async () => undefined), finalizeRun },
+      jobs: { enqueue: vi.fn(async () => undefined) },
+      secrets: [],
+    } as unknown as Parameters<typeof createRunExecutor>[0]);
+
+    await executor.continueRun("run-1", "worker-1");
+
+    expect(status).toBe("failed");
+    expect(finalizeRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "failed",
+        error: "Connect a model in Settings before running bots.",
+      }),
+    );
+    expect(runtimeRun).not.toHaveBeenCalled();
+  });
+
   it("resolves a per-bot model override with that provider’s credential", async () => {
     const findFirst = vi.fn(
       async (args: { where: { credential?: { provider?: string }; isDefault?: boolean } }) => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -372,6 +372,11 @@ export function isProtectedComputerLifecycleCommand(command: string): boolean {
 
 /** Cap the roster so a large Space cannot flood the prompt. */
 const BOT_DIRECTORY_LIMIT = 40;
+const MISSING_MODEL_MESSAGE = "Connect a model in Settings before running bots.";
+
+function runtimeFallbackModel(runtime: AgentRuntime) {
+  return runtime.describe().capabilities.scripted ? { provider: "scripted", id: "scripted" } : null;
+}
 
 export interface ExecutorDeps {
   prisma: PrismaClient;
@@ -551,18 +556,22 @@ export function createRunExecutor(deps: ExecutorDeps) {
       const useOverride = Boolean(hasOverride && overrideCredential);
       const credential = useOverride ? overrideCredential : defaultCredential;
       const deployment = deps.deploymentModelKey ? resolveDeploymentModel() : null;
-      const provider =
+      let provider =
         (useOverride ? override!.modelProvider : null) ??
         credential?.provider ??
         settings?.defaultModelProvider ??
-        deployment?.provider ??
-        "scripted";
-      const id =
+        deployment?.provider;
+      let id =
         (useOverride ? override!.modelId : null) ??
         credential?.defaultModel ??
         settings?.defaultModelId ??
-        deployment?.model ??
-        "scripted";
+        deployment?.model;
+      if (!provider || !id) {
+        const runtimeFallback = runtimeFallbackModel(deps.runtime);
+        provider ??= runtimeFallback?.provider;
+        id ??= runtimeFallback?.id;
+      }
+      if (!provider || !id) throw new Error(MISSING_MODEL_MESSAGE);
       // The key is resolved for the provider that won above, not before it is known.
       const resolved = await resolveModelKey(
         deps,
@@ -1034,18 +1043,58 @@ export function createRunExecutor(deps: ExecutorDeps) {
           );
         }
         const runDeployment = deps.deploymentModelKey ? resolveDeploymentModel() : null;
+        const runtimeFallback = runtimeFallbackModel(deps.runtime);
         const runModelProvider =
           (useModelOverride ? bot.modelProvider : null) ??
           credential?.provider ??
           settings?.defaultModelProvider ??
           runDeployment?.provider ??
-          "scripted";
+          runtimeFallback?.provider;
         const runModelId =
           (useModelOverride ? bot.modelId : null) ??
           credential?.defaultModel ??
           settings?.defaultModelId ??
           runDeployment?.model ??
-          "scripted";
+          runtimeFallback?.id;
+        if (!runModelProvider || !runModelId) {
+          const failed = await deps.events.finalizeRun({
+            spaceId: run.spaceId,
+            threadId: thread.id,
+            botId: bot.id,
+            runId,
+            taskId: run.taskId,
+            attemptId: attempt.id,
+            leaseOwner: workerId,
+            leaseFence: fence,
+            outcome: "failed",
+            error: MISSING_MODEL_MESSAGE,
+          });
+          if (!failed) return;
+          if (failed.continuationRunId) {
+            await deps.jobs
+              .enqueue(runContinueJob(failed.continuationRunId))
+              .catch((error) => console.error("steering continuation enqueue", error));
+          }
+          if (run.trigger === "bot_message") {
+            await returnBotMessageOutcome(
+              deps,
+              { ...run, sourceMessageId: run.sourceMessageId },
+              { id: bot.id, name: bot.name },
+              `Could not complete the delegated request: ${MISSING_MODEL_MESSAGE}`,
+              "status",
+            ).catch((error) => console.error("bot message failure return", error));
+          }
+          if (!failed.continuationRunId) {
+            await notifyRun(deps, run, {
+              kind: "failure",
+              title: `${bot.name} failed`,
+              body: MISSING_MODEL_MESSAGE,
+              botId: bot.id,
+              threadId: thread.id,
+            });
+          }
+          return;
+        }
         const resolved = await resolveModelKey(
           deps,
           run.userId,


### PR DESCRIPTION
## Why

A fresh desktop install could skip model setup even when neither the user nor the deployment had a usable model. The resulting run fell through to a test-only provider and failed later with an opaque authentication error.

## What changed

- Hide the onboarding skip action when model setup is required.
- Reject new thread runs with a clear model-setup message before creating work.
- Keep the deterministic scripted fallback only for the scripted test runtime.
- Fail non-UI run paths clearly without invoking a provider when no model exists.
- Add API, executor, and browser coverage for the required-model state.
- Bump the desktop release version to 0.1.1.

## How it was tested

The affected API and adapter tests pass, all workspace packages typecheck, and the focused onboarding browser test passes. The full unit suite passed aside from two timing-sensitive tests hitting their default timeout; both passed when rerun independently.

The CI browser screenshot link will be added when the visual report finishes.