### PR TITLE
Simplify password reset confirmation

### DIFF
--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -2,6 +2,7 @@ import { Redirect, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useState } from "react";
 import {
+  AccessibilityInfo,
   Keyboard,
   KeyboardAvoidingView,
   Modal,
@@ -69,6 +70,10 @@ export default function SignIn() {
     };
   }, [apiBase]);
 
+  useEffect(() => {
+    if (resetSent) AccessibilityInfo.announceForAccessibility(t("Check your email"));
+  }, [resetSent, t]);
+
   if (!ready) {
     return (
       <View style={{ flex: 1, backgroundColor: "#F7F7F4", justifyContent: "center", padding: 24 }}>
@@ -127,6 +132,7 @@ export default function SignIn() {
               keyboardShouldPersistTaps="handled"
             >
               <Text
+                accessibilityRole="header"
                 style={{
                   color: "#1B1B1E",
                   fontSize: 32,

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -138,23 +138,18 @@ export default function SignIn() {
                   ? t("Sign in to Rakazo")
                   : mode === "up"
                     ? t("Sign up for Rakazo")
-                    : t("Reset your password")}
+                    : resetSent
+                      ? t("Check your email")
+                      : t("Reset your password")}
               </Text>
               {resetSent ? (
                 <View style={{ alignItems: "center", marginTop: 28 }}>
-                  <Text style={{ color: "#1B1B1E", fontSize: 17 }}>{t("Check your email")}</Text>
-                  <Text
-                    style={{ color: "#6E6E68", fontSize: 15, marginTop: 10, textAlign: "center" }}
-                  >
-                    {t("If an account exists for that address, we sent a password reset link.")}
-                  </Text>
                   <Pressable
                     accessibilityRole="button"
                     onPress={() => {
                       setMode("in");
                       setResetSent(false);
                     }}
-                    style={{ marginTop: 22 }}
                   >
                     <Text style={{ color: "#1B1B1E", fontSize: 15, fontWeight: "600" }}>
                       {t("Back to sign in")}

--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -125,7 +125,8 @@ test("changes and recovers an email password", async ({ page }, testInfo) => {
   await page.getByLabel("Email").fill(email);
   await expect(page.getByLabel("Email")).toHaveValue(email);
   await page.getByRole("button", { name: "Send reset link" }).click();
-  await expect(page.getByText("Check your email")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Check your email" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Reset your password" })).not.toBeVisible();
   await captureScreenshot(page, testInfo, "42-password-reset-requested");
 
   const emailApi = process.env.API_URL ?? "http://127.0.0.1:3110";

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -29,6 +29,8 @@ export function AuthPage({ mode }: { mode: AuthMode }) {
       <Trans>Sign in to Rakazo</Trans>
     ) : mode === "up" ? (
       <Trans>Create your Rakazo</Trans>
+    ) : sent ? (
+      <Trans>Check your email</Trans>
     ) : (
       <Trans>Reset your password</Trans>
     );
@@ -95,14 +97,8 @@ export function AuthPage({ mode }: { mode: AuthMode }) {
   return (
     <AuthFrame onSubmit={submit} title={title}>
       {sent ? (
-        <div role="status" className="w-full text-center">
-          <p className="text-lg text-foreground">
-            <Trans>Check your email</Trans>
-          </p>
-          <p className="mt-3 text-[15px] leading-relaxed text-muted-foreground">
-            <Trans>If an account exists for that address, we sent a password reset link.</Trans>
-          </p>
-          <Link to="/sign-in" className="mt-6 inline-block font-medium text-foreground">
+        <div className="w-full text-center">
+          <Link to="/sign-in" className="font-medium text-foreground">
             <Trans>Back to sign in</Trans>
           </Link>
         </div>
@@ -321,7 +317,9 @@ function AuthFrame({
           <span className="h-5 w-[9px] rounded-full bg-primary" />
           <span className="h-5 w-[9px] rounded-full bg-primary" />
         </div>
-        <h1 className="mb-9 mt-7 text-4xl font-medium tracking-tight">{title}</h1>
+        <h1 aria-live="polite" className="mb-9 mt-7 text-4xl font-medium tracking-tight">
+          {title}
+        </h1>
         {children}
       </form>
     </div>


### PR DESCRIPTION
## Why

The password-reset confirmation repeated the previous screen title and stacked several explanatory text styles around a simple completion state.

## What changed

- replace the reset title with “Check your email” after submission
- remove the duplicate confirmation label and explanatory paragraph
- keep web and mobile confirmation states aligned
- announce the mobile completion state to screen-reader users
- update the existing web journey assertion and screenshot coverage

## Testing

- formatting check passed for the changed files
- web and mobile TypeScript checks passed
- all web unit tests passed
- focused password-recovery browser journey passed
- full CI suite passed

## Screenshot

[Password reset requested](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33768187221-1/screenshots/images/070-42-password-reset-requested.png)