### PR TITLE
Align open work controls

### DIFF
--- a/apps/web/src/pages/ScratchpadSection.tsx
+++ b/apps/web/src/pages/ScratchpadSection.tsx
@@ -106,7 +106,7 @@ export function ScratchpadSection({ botId }: { botId: string }) {
         <Trans>Open work</Trans>
       </div>
       {items.length === 0 ? (
-        <div className="px-2.5 py-1 text-[13.5px] text-muted-foreground/80">
+        <div className="py-1 text-[13.5px] text-muted-foreground/80">
           <Trans>None yet</Trans>
         </div>
       ) : (
@@ -173,7 +173,7 @@ export function ScratchpadSection({ botId }: { botId: string }) {
         ))
       )}
       <form
-        className="mt-2 flex items-center gap-2 px-2.5"
+        className="mt-2 flex items-center gap-2"
         onSubmit={(event) => {
           event.preventDefault();
           void addItem();
@@ -196,7 +196,7 @@ export function ScratchpadSection({ botId }: { botId: string }) {
           <Trans>Add</Trans>
         </Button>
       </form>
-      {error ? <div className="mt-2 px-2.5 text-[13px] text-destructive">{error}</div> : null}
+      {error ? <div className="mt-2 text-[13px] text-destructive">{error}</div> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Why

The empty state and add form in bot settings were inset from the surrounding fields, making the open-work section look misaligned.

## What changed

- Removed the extra horizontal inset from the empty state and add form.
- Aligned scratchpad errors with the same panel edge.
- Preserved task-row padding for checkbox spacing and hover treatment.

## Testing

- TypeScript web check passed.
- All 174 web unit tests passed.
- CI lint, typecheck, unit tests, production builds, Postgres journeys, image validation, and full Playwright E2E passed.

## Screenshot

- [Bot settings E2E screenshot (`27a-bot-settings-model.png`)](https://github.com/elie222/rakazo/actions/runs/33767282248/artifacts/9898541039)