### PR TITLE
Soften authorize button hover feedback

### DIFF
--- a/apps/web/e2e/onboarding-conversation.spec.ts
+++ b/apps/web/e2e/onboarding-conversation.spec.ts
@@ -44,10 +44,19 @@ test("focus choice suggests apps and preserves a completed connection", async ({
   const restingBackground = await authorizeButton.evaluate(
     (button) => getComputedStyle(button).backgroundColor,
   );
+  const accentBackground = await authorizeButton.evaluate((button) => {
+    const probe = document.createElement("span");
+    probe.style.backgroundColor = "var(--accent)";
+    button.append(probe);
+    const backgroundColor = getComputedStyle(probe).backgroundColor;
+    probe.remove();
+    return backgroundColor;
+  });
+  expect(accentBackground).not.toBe(restingBackground);
   await authorizeButton.hover();
   await expect
     .poll(() => authorizeButton.evaluate((button) => getComputedStyle(button).backgroundColor))
-    .not.toBe(restingBackground);
+    .toBe(accentBackground);
   await captureScreenshot(page, testInfo, "02-app-suggestions-authorize-hover");
 
   await authorizeButton.click();

--- a/apps/web/src/pages/shell/message-cards.tsx
+++ b/apps/web/src/pages/shell/message-cards.tsx
@@ -158,7 +158,7 @@ export function AppConnectCard({
         ) : (
           <Button
             variant="secondary"
-            className="rounded-full hover:bg-primary hover:text-primary-foreground"
+            className="rounded-full hover:border-border hover:bg-accent hover:text-foreground"
             disabled={busy}
             onClick={() => void authorize()}
           >


### PR DESCRIPTION
## Why

The high-contrast Authorize hover introduced in the connector-card spacing change was too strong for this secondary action.

## What changed

- replace the inverted hover with the semantic accent surface and border tokens
- tighten the onboarding browser test to require the accent-token background rather than accepting any color change

## Testing

- Web typecheck passed
- Web unit tests passed (174 tests)
- Focused onboarding browser test passed
- Web production build passed
- Repository lint passed with pre-existing warnings only

## Screenshot

[Subtle Authorize hover state](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33767382644-1/screenshots/images/004-02-app-suggestions-authorize-hover.png)