### PR TITLE
Hide computer maintenance actions from bot settings

### DIFF
--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -1,4 +1,3 @@
-import type { ComputerStatus } from "@rakazo/contracts";
 import {
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
@@ -9,7 +8,6 @@ import {
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Pressable, ScrollView, Text, TextInput } from "react-native";
-import { ComputerMaintenanceActions } from "../components/computer-maintenance-actions";
 import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
@@ -28,23 +26,18 @@ export default function BotSettingsScreen() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [computerMode, setComputerMode] = useState<ComputerMode>("team");
-  const [computer, setComputer] = useState<ComputerStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
   useEffect(() => {
     if (!botId) return;
-    void Promise.all([
-      rpc<BotSettingsRecord>("bots/get", { botId }),
-      rpc<ComputerStatus>("computer/status", { botId }).catch(() => null),
-    ])
-      .then(([next, status]) => {
+    void rpc<BotSettingsRecord>("bots/get", { botId })
+      .then((next) => {
         setBot(next);
         setName(next.name);
         setTitle(next.title);
         setDescription(next.description ?? "");
         setComputerMode(next.computerMode);
-        setComputer(status);
       })
       .catch((err) => setError(err instanceof Error ? err.message : t("Could not load bot")));
   }, [botId]);
@@ -142,14 +135,6 @@ export default function BotSettingsScreen() {
           }}
         />
         <ComputerModePicker value={computerMode} onChange={setComputerMode} />
-        <ComputerMaintenanceActions
-          botId={botId}
-          computer={computer}
-          onChanged={async () => {
-            const status = await rpc<ComputerStatus>("computer/status", { botId });
-            setComputer(status);
-          }}
-        />
         {error ? <Text style={{ color: "#EF4444", marginTop: 16 }}>{error}</Text> : null}
         <Pressable
           onPress={() => void save()}

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -68,6 +68,9 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   await expect(modelSelect).toBeHidden();
   await expect(openWork).toBeHidden();
   await expect(settings.getByRole("button", { name: "Save", exact: true })).toBeVisible();
+  await expect(settings.getByRole("button", { name: "Recover computer" })).toHaveCount(0);
+  await expect(settings.getByRole("button", { name: "Reset computer" })).toHaveCount(0);
+  await expect(settings.getByRole("button", { name: "Update computer" })).toHaveCount(0);
   await captureScreenshot(page, testInfo, "27a-settings-panel");
   await settings.getByText("Advanced", { exact: true }).click();
   await expect(teamComputer).toBeVisible();

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -116,7 +116,7 @@ export function ComputerMaintenanceActions({
           data-testid="computer-more-button"
           aria-label={t`More computer actions`}
           disabled={busy && pending === null}
-          render={<Button variant="ghost" size="icon" className="text-muted-foreground" />}
+          render={<Button variant="ghost" size="icon-sm" className="text-muted-foreground" />}
         >
           <MoreHorizontal />
         </DropdownMenuTrigger>

--- a/apps/web/src/components/ComputerMaintenanceActions.tsx
+++ b/apps/web/src/components/ComputerMaintenanceActions.tsx
@@ -25,15 +25,10 @@ export function ComputerMaintenanceActions({
   botId,
   computer,
   onChanged,
-  compact = false,
-  variant = "panel",
 }: {
   botId: string;
   computer: ComputerStatus | null;
   onChanged: () => Promise<void>;
-  compact?: boolean;
-  /** `menu` hides Recover/Reset/Update behind a More control (full computer chrome). */
-  variant?: "panel" | "menu";
 }) {
   const { t } = useLingui();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -108,109 +103,55 @@ export function ComputerMaintenanceActions({
     </AlertDialog>
   );
 
-  if (variant === "menu") {
-    return (
-      <>
-        <DropdownMenu
-          open={menuOpen}
-          onOpenChange={(open) => {
-            if (open) setError(null);
-            setMenuOpen(open);
-          }}
-        >
-          <DropdownMenuTrigger
-            data-testid="computer-more-button"
-            aria-label={t`More computer actions`}
-            disabled={busy && pending === null}
-            render={<Button variant="ghost" size="icon" className="text-muted-foreground" />}
-          >
-            <MoreHorizontal />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="end"
-            data-testid="computer-more-menu"
-            className="w-auto min-w-44"
-          >
-            {showRecover ? (
-              <DropdownMenuItem
-                closeOnClick={false}
-                disabled={busy || pending !== null}
-                onClick={() => void run("recover")}
-              >
-                {pending === "recover" ? (
-                  <Trans>Recovering…</Trans>
-                ) : (
-                  <Trans>Recover computer</Trans>
-                )}
-              </DropdownMenuItem>
-            ) : null}
-            {showReset ? (
-              <DropdownMenuItem disabled={busy || pending !== null} onClick={openResetConfirm}>
-                {pending === "reset" ? <Trans>Resetting…</Trans> : <Trans>Reset computer</Trans>}
-              </DropdownMenuItem>
-            ) : null}
-            {showUpdate ? (
-              <DropdownMenuItem
-                closeOnClick={false}
-                disabled={busy || pending !== null}
-                onClick={() => void run("update")}
-              >
-                {pending === "update" ? <Trans>Updating…</Trans> : <Trans>Update computer</Trans>}
-              </DropdownMenuItem>
-            ) : null}
-            {error ? <p className="px-1.5 py-1 text-[12.5px] text-destructive">{error}</p> : null}
-          </DropdownMenuContent>
-        </DropdownMenu>
-        {resetDialog}
-      </>
-    );
-  }
-
   return (
-    <div className={compact ? "flex flex-col items-start gap-2" : "mt-4 flex flex-col gap-3"}>
-      <div className={compact ? "flex flex-wrap gap-2" : "flex flex-col gap-2"}>
-        {showRecover ? (
-          <Button
-            variant="secondary"
-            className="rounded-full"
-            disabled={busy || pending !== null}
-            onClick={() => void run("recover")}
-          >
-            {pending === "recover" ? <Trans>Recovering…</Trans> : <Trans>Recover computer</Trans>}
-          </Button>
-        ) : null}
-        {showReset ? (
-          <Button
-            variant="secondary"
-            className="rounded-full"
-            disabled={busy || pending !== null}
-            onClick={openResetConfirm}
-          >
-            {pending === "reset" ? <Trans>Resetting…</Trans> : <Trans>Reset computer</Trans>}
-          </Button>
-        ) : null}
-        {showUpdate ? (
-          <Button
-            variant="secondary"
-            className="rounded-full"
-            disabled={busy || pending !== null}
-            onClick={() => void run("update")}
-          >
-            {pending === "update" ? <Trans>Updating…</Trans> : <Trans>Update computer</Trans>}
-          </Button>
-        ) : null}
-      </div>
-      {!compact ? (
-        <p className="text-[13px] leading-[1.45] text-muted-foreground/80">
-          <Trans>
-            Recover replaces an unreachable computer and keeps files in the saved workspace. Reset
-            restores the last saved workspace and loses unsaved work. Update rebuilds with the
-            latest image and keeps the saved workspace.
-          </Trans>
-        </p>
-      ) : null}
-      {error && !confirmReset ? <p className="text-[13px] text-destructive">{error}</p> : null}
+    <>
+      <DropdownMenu
+        open={menuOpen}
+        onOpenChange={(open) => {
+          if (open) setError(null);
+          setMenuOpen(open);
+        }}
+      >
+        <DropdownMenuTrigger
+          data-testid="computer-more-button"
+          aria-label={t`More computer actions`}
+          disabled={busy && pending === null}
+          render={<Button variant="ghost" size="icon" className="text-muted-foreground" />}
+        >
+          <MoreHorizontal />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          data-testid="computer-more-menu"
+          className="w-auto min-w-44"
+        >
+          {showRecover ? (
+            <DropdownMenuItem
+              closeOnClick={false}
+              disabled={busy || pending !== null}
+              onClick={() => void run("recover")}
+            >
+              {pending === "recover" ? <Trans>Recovering…</Trans> : <Trans>Recover computer</Trans>}
+            </DropdownMenuItem>
+          ) : null}
+          {showReset ? (
+            <DropdownMenuItem disabled={busy || pending !== null} onClick={openResetConfirm}>
+              {pending === "reset" ? <Trans>Resetting…</Trans> : <Trans>Reset computer</Trans>}
+            </DropdownMenuItem>
+          ) : null}
+          {showUpdate ? (
+            <DropdownMenuItem
+              closeOnClick={false}
+              disabled={busy || pending !== null}
+              onClick={() => void run("update")}
+            >
+              {pending === "update" ? <Trans>Updating…</Trans> : <Trans>Update computer</Trans>}
+            </DropdownMenuItem>
+          ) : null}
+          {error ? <p className="px-1.5 py-1 text-[12.5px] text-destructive">{error}</p> : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
       {resetDialog}
-    </div>
+    </>
   );
 }

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -10,6 +10,7 @@ import {
   clearActiveThreadRuns,
   computerPanelAutoBoot,
   computerPanelAutoUsesBoot,
+  computerPanelNeedsMaintenance,
   computerTakeoverBlocked,
   isThreadSnapshotEvent,
   mergeThreadSnapshot,
@@ -1317,6 +1318,14 @@ describe("computer event reduction", () => {
     expect(computerPanelAutoUsesBoot("recover-screen")).toBe(true);
     expect(computerPanelAutoUsesBoot("boot")).toBe(true);
     expect(computerPanelAutoUsesBoot("wait")).toBe(false);
+  });
+
+  it("shows maintenance only after a stopped or errored computer finishes booting", () => {
+    expect(computerPanelNeedsMaintenance("error", false)).toBe(true);
+    expect(computerPanelNeedsMaintenance("stopped", false)).toBe(true);
+    expect(computerPanelNeedsMaintenance("error", true)).toBe(false);
+    expect(computerPanelNeedsMaintenance("running", false)).toBe(false);
+    expect(computerPanelNeedsMaintenance(undefined, false)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -476,6 +476,13 @@ export function computerPanelAutoUsesBoot(
   return action === "boot" || action === "recover-screen";
 }
 
+export function computerPanelNeedsMaintenance(
+  state: ComputerStatus["state"] | undefined,
+  booting: boolean,
+): boolean {
+  return !booting && (state === "error" || state === "stopped");
+}
+
 export function reduceComputerStatus(
   prev: ComputerStatus | null,
   event: ProductEvent,

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -148,6 +148,7 @@ import {
   clearActiveThreadRuns,
   computerPanelAutoBoot,
   computerPanelAutoUsesBoot,
+  computerPanelNeedsMaintenance,
   computerTakeoverBlocked,
   isComputerStatusEvent,
   isThreadSnapshotEvent,
@@ -3074,6 +3075,17 @@ export function ShellPage() {
                   )}
                 </span>
                 <div className="flex gap-1">
+                  {active &&
+                  panel === "computer" &&
+                  computerPanelNeedsMaintenance(computer?.state, booting) ? (
+                    <ComputerMaintenanceActions
+                      botId={active.id}
+                      computer={computer}
+                      onChanged={async () => {
+                        await refreshThread(active.id);
+                      }}
+                    />
+                  ) : null}
                   {active ? (
                     <Button
                       variant="ghost"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3223,7 +3223,6 @@ export function ShellPage() {
               <BotSettings
                 key={active.id}
                 bot={active}
-                computer={computer}
                 memoryProviderConfigured={memoryProviderConfig != null}
                 onSave={async ({ computerMode, ...patch }) => {
                   if (computerMode !== active.computerMode) {
@@ -3248,9 +3247,6 @@ export function ShellPage() {
                   URL.revokeObjectURL(url);
                 }}
                 onClear={() => setClearTarget({ kind: "bot", chat: active })}
-                onComputerChanged={async () => {
-                  await refreshThread(active.id);
-                }}
               />
             ) : null}
             {panel === "routine" && active ? (
@@ -3773,7 +3769,6 @@ export function ShellPage() {
                 <ComputerMaintenanceActions
                   botId={active.id}
                   computer={computer}
-                  variant="menu"
                   onChanged={async () => {
                     await refreshThread(active.id);
                   }}

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -3,7 +3,6 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import type {
   Bot,
   ComputerMode,
-  ComputerStatus,
   Me,
   ModelCatalogEntry,
   ModelCredential,
@@ -27,7 +26,6 @@ import {
 } from "@rakazo/ui-web";
 import { X } from "lucide-react";
 import { lazy, Suspense, useEffect, useId, useState } from "react";
-import { ComputerMaintenanceActions } from "../../components/ComputerMaintenanceActions";
 import { rpc } from "../../lib/rpc";
 
 const ScratchpadSection = lazy(() =>
@@ -168,15 +166,12 @@ export function CreateBotForm({
 
 export function BotSettings({
   bot,
-  computer,
   memoryProviderConfigured,
   onSave,
   onExport,
   onClear,
-  onComputerChanged,
 }: {
   bot: Bot;
-  computer: ComputerStatus | null;
   memoryProviderConfigured: boolean;
   onSave: (patch: {
     name?: string;
@@ -193,7 +188,6 @@ export function BotSettings({
   }) => Promise<void>;
   onExport: () => Promise<void>;
   onClear: () => void;
-  onComputerChanged: () => Promise<void>;
 }) {
   const { t } = useLingui();
   const ids = useId();
@@ -484,11 +478,6 @@ export function BotSettings({
         >
           <Trans>Clear conversation</Trans>
         </Button>
-        <ComputerMaintenanceActions
-          botId={bot.id}
-          computer={computer}
-          onChanged={onComputerChanged}
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Why

Rare computer recovery actions were always visible in bot settings alongside dense copy explaining backend lifecycle details. This made a routine settings screen feel more complex than necessary.

## What changed

- remove Recover, Reset, and Update from web and mobile bot settings
- keep the actions available behind the computer view’s existing More menu
- show that compact menu in the web computer panel only after boot ends in a stopped or error state, preserving failed-boot recovery
- keep mobile recovery controls on the computer screen when the computer is unavailable
- remove the redundant web panel variant and its explanatory paragraph
- cover settings visibility and failed-boot maintenance visibility

## Testing

- Web and mobile typechecks passed
- Web and mobile unit suites passed
- Web production build passed
- Changed files pass Biome
- CI lint, typecheck, unit, database journey, production build, image validation, and web E2E jobs passed
- Greptile completed at 5/5 with no blocking issues

## Screenshot

[CI E2E screenshot: simplified bot settings](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33768533479-1/screenshots/images/053-27a-settings-panel.png)

[Full screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/562/index.html)