### PR TITLE
Fix Electron development app name

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@rakazo/desktop",
+  "productName": "Rakazo",
   "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
@@ -28,7 +29,6 @@
   },
   "build": {
     "appId": "dev.rakazo.desktop",
-    "productName": "Rakazo",
     "directories": {
       "output": "out",
       "buildResources": "assets"

--- a/apps/desktop/src/package-metadata.test.ts
+++ b/apps/desktop/src/package-metadata.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const packageJson = JSON.parse(
+  readFileSync(path.resolve(import.meta.dirname, "../package.json"), "utf8"),
+) as {
+  productName?: string;
+  build?: { productName?: string };
+};
+
+describe("desktop package metadata", () => {
+  it("shares the customer-facing name between Electron and electron-builder", () => {
+    expect(packageJson.productName).toBe("Rakazo");
+    expect(packageJson.build?.productName).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Electron development launches fell back to the scoped npm package name, so native macOS menu roles displayed `@rakazo/desktop` instead of the product name.

This moves `productName` to standard top-level package metadata so Electron and electron-builder share one value, and adds a regression test for that contract.

Tested with the desktop typecheck, 187 desktop unit tests, formatting checks, and a desktop build.

This affects native macOS menu metadata, which the web E2E screenshot flow cannot capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated desktop application packaging configuration to read the product name from the standard top-level setting.

* **Tests**
  * Added coverage verifying the application is named “Rakazo” and the legacy packaging location is not used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->