### PR TITLE
Improve onboarding provider picker

### DIFF
--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -31,6 +31,13 @@ test("onboarding model list never labels an older model the latest one", async (
     "aria-pressed",
     "true",
   );
+  await page.getByPlaceholder("Search providers and models").fill("no-provider-or-model");
+  await expect(page.getByRole("button", { name: /Anthropic.*Selected/ })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.getByText("No providers found")).toBeVisible();
+  await page.getByPlaceholder("Search providers and models").fill("anthropic");
 
   const models = page.getByRole("combobox", { name: "Model", exact: true });
   const labels = await models.getByRole("option").allTextContents();

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -10,11 +10,23 @@ test("onboarding model list never labels an older model the latest one", async (
     timeout: 20_000,
   });
 
+  await expect(page.getByRole("button", { name: /OpenRouter/ })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.getByRole("button", { name: /ChatGPT.*ChatGPT Plus\/Pro/ })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Vercel AI Gateway/ })).toBeVisible();
+  await captureScreenshot(page, testInfo, "onboarding-popular-providers");
+  await page.getByRole("button", { name: "Show all providers" }).click();
   await page.getByPlaceholder("Search providers and models").fill("anthropic");
   await page
     .getByRole("button", { name: /Anthropic/ })
     .first()
     .click();
+  await expect(page.getByRole("button", { name: /Anthropic/ }).first()).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
 
   const models = page.getByRole("combobox", { name: "Model", exact: true });
   const labels = await models.getByRole("option").allTextContents();

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -19,6 +19,10 @@ test("onboarding model list never labels an older model the latest one", async (
   await captureScreenshot(page, testInfo, "onboarding-popular-providers");
   await page.getByRole("button", { name: "Show all providers" }).click();
   await page.getByPlaceholder("Search providers and models").fill("anthropic");
+  await expect(page.getByRole("button", { name: /OpenRouter/ })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
   await page
     .getByRole("button", { name: /Anthropic/ })
     .first()

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -31,13 +31,6 @@ test("onboarding model list never labels an older model the latest one", async (
     "aria-pressed",
     "true",
   );
-  await page.getByPlaceholder("Search providers and models").fill("no-provider-or-model");
-  await expect(page.getByRole("button", { name: /Anthropic.*Selected/ })).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
-  await expect(page.getByText("No providers found")).toBeVisible();
-  await page.getByPlaceholder("Search providers and models").fill("anthropic");
 
   const models = page.getByRole("combobox", { name: "Model", exact: true });
   const labels = await models.getByRole("option").allTextContents();
@@ -45,10 +38,19 @@ test("onboarding model list never labels an older model the latest one", async (
   // newer models carry no marker. Rendered as-is it tells the user the opposite of the truth.
   expect(labels.filter((label) => /\blatest\b/i.test(label))).toEqual([]);
 
-  // Select the alias so the closed native picker shows the rewritten label in the screenshot.
+  // Select a non-default model before filtering the active provider out of the results.
   const alias = labels.find((label) => label.includes("(auto-updates)"));
   expect(alias).toBeTruthy();
   await models.selectOption({ label: alias! });
+  const selectedModelId = await models.inputValue();
+
+  await page.getByPlaceholder("Search providers and models").fill("no-provider-or-model");
+  const selectedProvider = page.getByRole("button", { name: /Anthropic.*Selected/ });
+  await expect(selectedProvider).toHaveAttribute("aria-pressed", "true");
+  await expect(page.getByText("No providers found")).toBeVisible();
+  await selectedProvider.click();
+  await expect(models).toHaveValue(selectedModelId);
+  await page.getByPlaceholder("Search providers and models").fill("anthropic");
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/src/lib/onboarding-providers.test.ts
+++ b/apps/web/src/lib/onboarding-providers.test.ts
@@ -1,6 +1,9 @@
 import type { ModelCatalogEntry } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
-import { featuredModelProviders, keepSelectedProviderVisible } from "./onboarding-providers";
+import {
+  featuredModelProviders,
+  selectedProviderOutsideSearchResults,
+} from "./onboarding-providers";
 
 function provider(provider: string): ModelCatalogEntry {
   return {
@@ -72,24 +75,20 @@ describe("featuredModelProviders", () => {
   });
 });
 
-describe("keepSelectedProviderVisible", () => {
-  it("pins the active provider above unrelated search results", () => {
+describe("selectedProviderOutsideSearchResults", () => {
+  it("returns the active provider separately from unrelated search results", () => {
     const providers = [provider("openrouter"), provider("anthropic"), provider("bedrock")];
 
     expect(
-      keepSelectedProviderVisible(providers.slice(1), providers, "openrouter").map(
-        (entry) => entry.provider,
-      ),
-    ).toEqual(["openrouter", "anthropic", "bedrock"]);
+      selectedProviderOutsideSearchResults(providers.slice(1), providers, "openrouter"),
+    ).toMatchObject({ provider: "openrouter" });
   });
 
-  it("does not duplicate an active provider that matches the search", () => {
+  it("returns nothing when the active provider matches the search", () => {
     const providers = [provider("openrouter"), provider("anthropic")];
 
     expect(
-      keepSelectedProviderVisible(providers, providers, "openrouter").map(
-        (entry) => entry.provider,
-      ),
-    ).toEqual(["openrouter", "anthropic"]);
+      selectedProviderOutsideSearchResults(providers, providers, "openrouter"),
+    ).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/onboarding-providers.test.ts
+++ b/apps/web/src/lib/onboarding-providers.test.ts
@@ -1,0 +1,73 @@
+import type { ModelCatalogEntry } from "@rakazo/contracts";
+import { describe, expect, it } from "vitest";
+import { featuredModelProviders } from "./onboarding-providers";
+
+function provider(provider: string): ModelCatalogEntry {
+  return {
+    provider,
+    providerName: provider,
+    id: `${provider}-model`,
+    label: `${provider} model`,
+    billing: "",
+  };
+}
+
+describe("featuredModelProviders", () => {
+  it("shows popular providers in a stable order", () => {
+    const providers = [
+      provider("azure"),
+      provider("vercel-ai-gateway"),
+      provider("google"),
+      provider("openai"),
+      provider("anthropic"),
+      provider("openai-codex"),
+      provider("openrouter"),
+    ];
+
+    expect(featuredModelProviders(providers, "openrouter").map((entry) => entry.provider)).toEqual([
+      "openrouter",
+      "openai-codex",
+      "anthropic",
+      "openai",
+      "google",
+      "vercel-ai-gateway",
+    ]);
+  });
+
+  it("fills missing popular slots from the catalog", () => {
+    const providers = [
+      provider("azure"),
+      provider("openrouter"),
+      provider("bedrock"),
+      provider("anthropic"),
+    ];
+
+    expect(featuredModelProviders(providers, "openrouter").map((entry) => entry.provider)).toEqual([
+      "openrouter",
+      "anthropic",
+      "azure",
+      "bedrock",
+    ]);
+  });
+
+  it("keeps a non-featured selected provider visible", () => {
+    const providers = [
+      provider("openrouter"),
+      provider("openai-codex"),
+      provider("anthropic"),
+      provider("openai"),
+      provider("google"),
+      provider("vercel-ai-gateway"),
+      provider("local"),
+    ];
+
+    expect(featuredModelProviders(providers, "local").map((entry) => entry.provider)).toEqual([
+      "openrouter",
+      "openai-codex",
+      "anthropic",
+      "openai",
+      "google",
+      "local",
+    ]);
+  });
+});

--- a/apps/web/src/lib/onboarding-providers.test.ts
+++ b/apps/web/src/lib/onboarding-providers.test.ts
@@ -1,6 +1,6 @@
 import type { ModelCatalogEntry } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
-import { featuredModelProviders } from "./onboarding-providers";
+import { featuredModelProviders, keepSelectedProviderVisible } from "./onboarding-providers";
 
 function provider(provider: string): ModelCatalogEntry {
   return {
@@ -69,5 +69,27 @@ describe("featuredModelProviders", () => {
       "google",
       "local",
     ]);
+  });
+});
+
+describe("keepSelectedProviderVisible", () => {
+  it("pins the active provider above unrelated search results", () => {
+    const providers = [provider("openrouter"), provider("anthropic"), provider("bedrock")];
+
+    expect(
+      keepSelectedProviderVisible(providers.slice(1), providers, "openrouter").map(
+        (entry) => entry.provider,
+      ),
+    ).toEqual(["openrouter", "anthropic", "bedrock"]);
+  });
+
+  it("does not duplicate an active provider that matches the search", () => {
+    const providers = [provider("openrouter"), provider("anthropic")];
+
+    expect(
+      keepSelectedProviderVisible(providers, providers, "openrouter").map(
+        (entry) => entry.provider,
+      ),
+    ).toEqual(["openrouter", "anthropic"]);
   });
 });

--- a/apps/web/src/lib/onboarding-providers.ts
+++ b/apps/web/src/lib/onboarding-providers.ts
@@ -31,15 +31,14 @@ export function featuredModelProviders(
   return [...featured.slice(0, DEFAULT_PROVIDER_COUNT - 1), selected];
 }
 
-/** Search results still show the active choice, even when its text does not match the query. */
-export function keepSelectedProviderVisible(
+/** Return the active choice separately when it is not one of the search results. */
+export function selectedProviderOutsideSearchResults(
   filteredProviders: readonly ModelCatalogEntry[],
   allProviders: readonly ModelCatalogEntry[],
   selectedProvider: string,
-): ModelCatalogEntry[] {
+): ModelCatalogEntry | undefined {
   if (filteredProviders.some((entry) => entry.provider === selectedProvider)) {
-    return [...filteredProviders];
+    return undefined;
   }
-  const selected = allProviders.find((entry) => entry.provider === selectedProvider);
-  return selected ? [selected, ...filteredProviders] : [...filteredProviders];
+  return allProviders.find((entry) => entry.provider === selectedProvider);
 }

--- a/apps/web/src/lib/onboarding-providers.ts
+++ b/apps/web/src/lib/onboarding-providers.ts
@@ -1,0 +1,32 @@
+import type { ModelCatalogEntry } from "@rakazo/contracts";
+
+export const POPULAR_MODEL_PROVIDER_IDS = [
+  "openrouter",
+  "openai-codex",
+  "anthropic",
+  "openai",
+  "google",
+  "vercel-ai-gateway",
+] as const;
+
+const DEFAULT_PROVIDER_COUNT = POPULAR_MODEL_PROVIDER_IDS.length;
+const POPULAR_MODEL_PROVIDER_ID_SET = new Set<string>(POPULAR_MODEL_PROVIDER_IDS);
+
+/** Keep onboarding short while ensuring a deployment's current default is never hidden. */
+export function featuredModelProviders(
+  providers: readonly ModelCatalogEntry[],
+  selectedProvider: string,
+): ModelCatalogEntry[] {
+  const byId = new Map(providers.map((entry) => [entry.provider, entry]));
+  const ordered = [
+    ...POPULAR_MODEL_PROVIDER_IDS.map((id) => byId.get(id)).filter(
+      (entry): entry is ModelCatalogEntry => entry !== undefined,
+    ),
+    ...providers.filter((entry) => !POPULAR_MODEL_PROVIDER_ID_SET.has(entry.provider)),
+  ];
+  const featured = ordered.slice(0, DEFAULT_PROVIDER_COUNT);
+  const selected = byId.get(selectedProvider);
+
+  if (!selected || featured.some((entry) => entry.provider === selectedProvider)) return featured;
+  return [...featured.slice(0, DEFAULT_PROVIDER_COUNT - 1), selected];
+}

--- a/apps/web/src/lib/onboarding-providers.ts
+++ b/apps/web/src/lib/onboarding-providers.ts
@@ -30,3 +30,16 @@ export function featuredModelProviders(
   if (!selected || featured.some((entry) => entry.provider === selectedProvider)) return featured;
   return [...featured.slice(0, DEFAULT_PROVIDER_COUNT - 1), selected];
 }
+
+/** Search results still show the active choice, even when its text does not match the query. */
+export function keepSelectedProviderVisible(
+  filteredProviders: readonly ModelCatalogEntry[],
+  allProviders: readonly ModelCatalogEntry[],
+  selectedProvider: string,
+): ModelCatalogEntry[] {
+  if (filteredProviders.some((entry) => entry.provider === selectedProvider)) {
+    return [...filteredProviders];
+  }
+  const selected = allProviders.find((entry) => entry.provider === selectedProvider);
+  return selected ? [selected, ...filteredProviders] : [...filteredProviders];
+}

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -288,6 +288,7 @@ export function OnboardingPage() {
                     type="button"
                     aria-pressed={isSelected}
                     onClick={() => {
+                      if (isSelected) return;
                       cancelOAuthAttempt();
                       setProvider(entry.provider);
                       setModelId(

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -10,7 +10,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { localizedProviderHint } from "../lib/localized-provider-hint";
 import type { ModelCatalogEntry } from "../lib/model-auth";
-import { featuredModelProviders } from "../lib/onboarding-providers";
+import { featuredModelProviders, keepSelectedProviderVisible } from "../lib/onboarding-providers";
 import { rpc } from "../lib/rpc";
 import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 
@@ -98,7 +98,10 @@ export function OnboardingPage() {
   }, [catalog, providers, query]);
 
   const displayedProviders = useMemo(
-    () => (showAllProviders ? filteredProviders : featuredModelProviders(providers, provider)),
+    () =>
+      showAllProviders
+        ? keepSelectedProviderVisible(filteredProviders, providers, provider)
+        : featuredModelProviders(providers, provider),
     [filteredProviders, provider, providers, showAllProviders],
   );
 

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -10,7 +10,10 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { localizedProviderHint } from "../lib/localized-provider-hint";
 import type { ModelCatalogEntry } from "../lib/model-auth";
-import { featuredModelProviders, keepSelectedProviderVisible } from "../lib/onboarding-providers";
+import {
+  featuredModelProviders,
+  selectedProviderOutsideSearchResults,
+} from "../lib/onboarding-providers";
 import { rpc } from "../lib/rpc";
 import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 
@@ -98,12 +101,21 @@ export function OnboardingPage() {
   }, [catalog, providers, query]);
 
   const displayedProviders = useMemo(
-    () =>
-      showAllProviders
-        ? keepSelectedProviderVisible(filteredProviders, providers, provider)
-        : featuredModelProviders(providers, provider),
+    () => (showAllProviders ? filteredProviders : featuredModelProviders(providers, provider)),
     [filteredProviders, provider, providers, showAllProviders],
   );
+
+  const selectedProviderOutsideResults = useMemo(
+    () =>
+      showAllProviders
+        ? selectedProviderOutsideSearchResults(filteredProviders, providers, provider)
+        : undefined,
+    [filteredProviders, provider, providers, showAllProviders],
+  );
+
+  const providerRows = selectedProviderOutsideResults
+    ? [selectedProviderOutsideResults, ...displayedProviders]
+    : displayedProviders;
 
   const modelsForProvider = useMemo(
     () => catalog.filter((entry) => entry.provider === provider),
@@ -266,8 +278,10 @@ export function OnboardingPage() {
                 showAllProviders ? "max-h-64" : ""
               }`}
             >
-              {displayedProviders.map((entry) => {
+              {providerRows.map((entry) => {
                 const isSelected = entry.provider === provider;
+                const isOutsideSearchResults =
+                  entry.provider === selectedProviderOutsideResults?.provider;
                 return (
                   <button
                     key={entry.provider}
@@ -290,12 +304,19 @@ export function OnboardingPage() {
                       isSelected ? "bg-muted" : "hover:bg-accent"
                     }`}
                   >
-                    <span
-                      className={`min-w-0 flex-1 text-[15px] text-foreground ${isSelected ? "font-medium" : ""}`}
-                    >
-                      {entry.provider === "openai-codex"
-                        ? "ChatGPT"
-                        : (entry.providerName ?? entry.provider)}
+                    <span className="flex min-w-0 flex-1 items-center gap-2">
+                      <span
+                        className={`truncate text-[15px] text-foreground ${isSelected ? "font-medium" : ""}`}
+                      >
+                        {entry.provider === "openai-codex"
+                          ? "ChatGPT"
+                          : (entry.providerName ?? entry.provider)}
+                      </span>
+                      {isOutsideSearchResults ? (
+                        <span className="shrink-0 text-[11px] text-muted-foreground">
+                          <Trans>Selected</Trans>
+                        </span>
+                      ) : null}
                     </span>
                     <span className="text-[12px] text-muted-foreground">
                       {localizedProviderHint(entry)}

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -5,10 +5,12 @@ import {
   openAiCompatibleProbeSuccessMessage,
 } from "@rakazo/contracts";
 import { Button, Input, NativeSelect, NativeSelectOption, Textarea } from "@rakazo/ui-web";
+import { Check } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { localizedProviderHint } from "../lib/localized-provider-hint";
 import type { ModelCatalogEntry } from "../lib/model-auth";
+import { featuredModelProviders } from "../lib/onboarding-providers";
 import { rpc } from "../lib/rpc";
 import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 
@@ -19,6 +21,7 @@ export function OnboardingPage() {
   const [step, setStep] = useState<"loading" | "model" | "bot">("loading");
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
   const [query, setQuery] = useState("");
+  const [showAllProviders, setShowAllProviders] = useState(false);
   const [provider, setProvider] = useState("openrouter");
   const [modelId, setModelId] = useState("deepseek/deepseek-v4-flash-0731");
   const [apiKey, setApiKey] = useState("");
@@ -93,6 +96,11 @@ export function OnboardingPage() {
     );
     return providers.filter((entry) => matching.has(entry.provider));
   }, [catalog, providers, query]);
+
+  const displayedProviders = useMemo(
+    () => (showAllProviders ? filteredProviders : featuredModelProviders(providers, provider)),
+    [filteredProviders, provider, providers, showAllProviders],
+  );
 
   const modelsForProvider = useMemo(
     () => catalog.filter((entry) => entry.provider === provider),
@@ -208,8 +216,8 @@ export function OnboardingPage() {
   }
 
   return (
-    <div className="flex min-h-full items-center justify-center bg-background px-6">
-      <div className="w-[560px]">
+    <div className="min-h-full bg-background px-6 py-12">
+      <div className="mx-auto w-full max-w-[560px]">
         {step === "loading" ? (
           <p className="text-muted-foreground">
             <Trans>Loading…</Trans>
@@ -220,51 +228,95 @@ export function OnboardingPage() {
             <h1 className="text-[32px] font-medium text-foreground">
               <Trans>Connect a model</Trans>
             </h1>
-            <p className="mt-2 text-muted-foreground">
-              <Trans>Choose a model to get started.</Trans>
-            </p>
-            <Input
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              aria-label={t`Search providers and models`}
-              placeholder={t`Search providers and models`}
-              className="mt-8"
-            />
-            <div className="mt-3 max-h-48 overflow-y-auto rounded-lg border border-border">
-              {filteredProviders.map((entry) => (
-                <button
-                  key={entry.provider}
-                  type="button"
-                  onClick={() => {
-                    cancelOAuthAttempt();
-                    setProvider(entry.provider);
-                    setModelId(
-                      entry.provider === OPENAI_COMPATIBLE_PROVIDER_ID
-                        ? ""
-                        : (catalog.find((item) => item.provider === entry.provider)?.id ?? ""),
-                    );
-                    setBaseUrl("");
-                    resetOpenAiCompatibleProbe();
-                    setError(null);
-                    setNotice(null);
-                  }}
-                  className={`flex w-full items-center justify-between border-b border-border px-3.5 py-2.5 text-left last:border-0 ${
-                    entry.provider === provider ? "bg-muted" : "hover:bg-accent"
-                  }`}
-                >
-                  <span className="text-[15px] text-foreground">
-                    {entry.providerName ?? entry.provider}
-                  </span>
-                  <span className="text-[12px] text-muted-foreground">
-                    {localizedProviderHint(entry)}
-                  </span>
-                </button>
-              ))}
+            <div className="mt-8 flex items-center justify-between gap-4">
+              <p className="text-sm font-medium text-foreground">
+                <Trans>Provider</Trans>
+              </p>
+              <Button
+                variant="link"
+                size="xs"
+                className="px-0 text-muted-foreground"
+                onClick={() => {
+                  setShowAllProviders((current) => !current);
+                  setQuery("");
+                }}
+              >
+                {showAllProviders ? (
+                  <Trans>Show popular providers</Trans>
+                ) : (
+                  <Trans>Show all providers</Trans>
+                )}
+              </Button>
             </div>
-            <div className="mt-4 block text-sm text-muted-foreground">
+            {showAllProviders ? (
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                aria-label={t`Search providers and models`}
+                placeholder={t`Search providers and models`}
+                className="mt-3"
+              />
+            ) : null}
+            <fieldset
+              aria-label={t`Model providers`}
+              className={`mt-3 overflow-y-auto rounded-xl border border-border ${
+                showAllProviders ? "max-h-64" : ""
+              }`}
+            >
+              {displayedProviders.map((entry) => {
+                const isSelected = entry.provider === provider;
+                return (
+                  <button
+                    key={entry.provider}
+                    type="button"
+                    aria-pressed={isSelected}
+                    onClick={() => {
+                      cancelOAuthAttempt();
+                      setProvider(entry.provider);
+                      setModelId(
+                        entry.provider === OPENAI_COMPATIBLE_PROVIDER_ID
+                          ? ""
+                          : (catalog.find((item) => item.provider === entry.provider)?.id ?? ""),
+                      );
+                      setBaseUrl("");
+                      resetOpenAiCompatibleProbe();
+                      setError(null);
+                      setNotice(null);
+                    }}
+                    className={`flex min-h-11 w-full items-center gap-3 border-b border-border px-3.5 py-2.5 text-left last:border-0 ${
+                      isSelected ? "bg-muted" : "hover:bg-accent"
+                    }`}
+                  >
+                    <span
+                      className={`min-w-0 flex-1 text-[15px] text-foreground ${isSelected ? "font-medium" : ""}`}
+                    >
+                      {entry.provider === "openai-codex"
+                        ? "ChatGPT"
+                        : (entry.providerName ?? entry.provider)}
+                    </span>
+                    <span className="text-[12px] text-muted-foreground">
+                      {localizedProviderHint(entry)}
+                    </span>
+                    <span className="flex size-5 shrink-0 items-center justify-center" aria-hidden>
+                      {isSelected ? (
+                        <span className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                          <Check className="size-3" strokeWidth={2.5} />
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+                );
+              })}
+              {displayedProviders.length === 0 ? (
+                <p className="px-3.5 py-6 text-center text-sm text-muted-foreground">
+                  <Trans>No providers found</Trans>
+                </p>
+              ) : null}
+            </fieldset>
+            <div className="mt-6 block text-sm text-foreground">
               {isOpenAiCompatible ? (
                 <>
-                  <label htmlFor={`${fieldId}-base-url`} className="block">
+                  <label htmlFor={`${fieldId}-base-url`} className="block font-medium">
                     <Trans>Server URL</Trans>
                     <Input
                       id={`${fieldId}-base-url`}
@@ -294,7 +346,7 @@ export function OnboardingPage() {
                     </Button>
                   </div>
                   <div className="mt-4 block">
-                    <span>
+                    <span className="font-medium">
                       <Trans>Model</Trans>
                     </span>
                     {probeModels.length && probeModels.includes(modelId) ? (
@@ -336,7 +388,7 @@ export function OnboardingPage() {
                 </>
               ) : (
                 <>
-                  <span>
+                  <span className="font-medium">
                     <Trans>Model</Trans>
                   </span>
                   <NativeSelect
@@ -357,9 +409,6 @@ export function OnboardingPage() {
                 </>
               )}
             </div>
-            {!isOpenAiCompatible && selected?.billing ? (
-              <p className="mt-2 text-[13px] text-muted-foreground">{selected.billing}</p>
-            ) : null}
             {subscriptionSignIn ? (
               <div className="mt-4">
                 {oauth ? (
@@ -450,7 +499,7 @@ export function OnboardingPage() {
               ) : (
                 <label
                   htmlFor={`${fieldId}-api-key`}
-                  className="mt-4 block text-sm text-muted-foreground"
+                  className="mt-4 block text-sm font-medium text-foreground"
                 >
                   {subscriptionSignIn ? <Trans>Or paste an API key</Trans> : <Trans>API key</Trans>}
                   <Input

--- a/apps/www/e2e/marketing-homepage.spec.ts
+++ b/apps/www/e2e/marketing-homepage.spec.ts
@@ -14,6 +14,7 @@ async function captureScreenshot(page: Page, testInfo: TestInfo, name: string) {
 test.describe("marketing homepage", () => {
   test("self-host is short CTAs, not an install script", async ({ page }, testInfo) => {
     await page.goto("/");
+    await page.waitForLoadState("load");
 
     await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
     const selfHost = page.locator("#selfhost");
@@ -31,9 +32,11 @@ test.describe("marketing homepage", () => {
     await selfHost.scrollIntoViewIfNeeded();
     await captureScreenshot(page, testInfo, "01-marketing-homepage-selfhost");
 
-    await selfHost.getByRole("button", { name: /Get started/i }).click();
-    const dialog = page.locator("[data-get-started-dialog]");
-    await expect(dialog).toBeVisible();
+    await expect(async () => {
+      await selfHost.getByRole("button", { name: /Get started/i }).click();
+      await expect(page.getByRole("dialog")).toBeVisible();
+    }).toPass();
+    const dialog = page.getByRole("dialog");
     await expect(dialog.getByRole("heading")).toBeVisible();
     await expect(dialog).not.toContainText(
       /openssl|docker-compose\.images|POSTGRES_PASSWORD|BETTER_AUTH_SECRET|mkdir rakazo/i,
@@ -43,6 +46,7 @@ test.describe("marketing homepage", () => {
 
   test("zh homepage matches the simplified self-host CTAs", async ({ page }, testInfo) => {
     await page.goto("/zh/");
+    await page.waitForLoadState("load");
 
     await expect(page.getByRole("heading", { level: 1 })).toHaveText("真正属于你的 AI 队友");
     const selfHost = page.locator("#selfhost");
@@ -60,9 +64,11 @@ test.describe("marketing homepage", () => {
     await selfHost.scrollIntoViewIfNeeded();
     await captureScreenshot(page, testInfo, "03-marketing-homepage-zh-selfhost");
 
-    await selfHost.getByRole("button", { name: "开始使用" }).click();
-    const dialog = page.locator("[data-get-started-dialog]");
-    await expect(dialog).toBeVisible();
+    await expect(async () => {
+      await selfHost.getByRole("button", { name: "开始使用" }).click();
+      await expect(page.getByRole("dialog")).toBeVisible();
+    }).toPass();
+    const dialog = page.getByRole("dialog");
     await expect(dialog.getByRole("heading")).toHaveText("你想如何开始？");
     await expect(dialog).not.toContainText(
       /openssl|docker-compose\.images|POSTGRES_PASSWORD|BETTER_AUTH_SECRET|mkdir rakazo/i,


### PR DESCRIPTION
The onboarding model step currently presents an overwhelming catalog, obscures the active provider, and includes low-value explanatory copy.

This change features six common providers, including ChatGPT subscription login and Vercel AI Gateway, adds an explicit selected state, and moves full-catalog search behind Show all providers while keeping selection and empty-search semantics clear. It also removes redundant helper and billing copy, makes the page responsive, and hardens the marketing homepage E2E against a dialog-hydration race observed in CI.

Tested with web TypeScript checks, focused provider-ordering unit tests, a production web build, and isolated Chromium onboarding E2E; the full CI suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a streamlined provider-selection experience during onboarding, highlighting popular providers and keeping the selected provider visible.
  - Added “Show all providers” and “Show popular providers” controls.
  - Added provider search with a clear “No providers found” state.
  - Added clearer selected-provider indicators, including a checkmark and “Selected” badge.

- **Bug Fixes**
  - Preserved the selected model when switching providers during onboarding.

- **Style**
  - Improved onboarding layout, spacing, and label readability.
  - Removed per-provider billing hint text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->