### PR TITLE
test(e2e): restore resting app-suggestions screenshot checkpoint

### DIFF
--- a/apps/web/e2e/onboarding-conversation.spec.ts
+++ b/apps/web/e2e/onboarding-conversation.spec.ts
@@ -40,6 +40,8 @@ test("focus choice suggests apps and preserves a completed connection", async ({
     .getByTestId("transcript")
     .getByText("Hit those three and I’ll start pulling the picture.")
     .scrollIntoViewIfNeeded();
+  await page.mouse.move(1, 1);
+  await captureScreenshot(page, testInfo, "02-app-suggestions");
   const authorizeButton = slackCard(page).getByRole("button", { name: "Authorize" });
   const restingBackground = await authorizeButton.evaluate(
     (button) => getComputedStyle(button).backgroundColor,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR #554 repointed the onboarding connector-suggestion checkpoint to capture the Authorize-button hover state, which closed a coverage gap for hover feedback but removed CI's only screenshot of the plain resting connector-suggestion screen. The screenshot gallery should show both the default layout and the hover affordance.

## What changed

- In `apps/web/e2e/onboarding-conversation.spec.ts`, re-add the `02-app-suggestions` checkpoint (mouse moved away, before any hover) while keeping the existing `02-app-suggestions-authorize-hover` checkpoint from #554.

## How tested

- Test-only change; no product code touched.
- CI Playwright run should publish both screenshots to the PR gallery.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54e67de5-1fd3-45b4-b6fd-a9297512cfa5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54e67de5-1fd3-45b4-b6fd-a9297512cfa5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an onboarding conversation screenshot checkpoint after scrolling the transcript into view.
  * Improved end-to-end test coverage for the app suggestions flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->