### PR TITLE
fix(desktop): simplify first-run setup layout

### DIFF
--- a/apps/desktop/e2e/setup.spec.ts
+++ b/apps/desktop/e2e/setup.spec.ts
@@ -79,8 +79,10 @@ test("first run asks whether to use a local or existing instance", async () => {
   const setup = await app.firstWindow();
 
   await expect(setup.getByRole("heading", { name: "Welcome to Rakazo" })).toBeVisible();
+  await expect(setup.getByText("Choose which server this app should use.")).toBeVisible();
   await expect(setup.getByText("This computer")).toBeVisible();
   await expect(setup.getByText("Existing instance")).toBeVisible();
+  await expect(setup.locator(".card")).toHaveCount(0);
 
   // A new instance is the default: the app runs the stack itself at the local address.
   await expect(setup.getByRole("radio", { name: /This computer/ })).toBeChecked();

--- a/apps/desktop/scripts/copy-static.mjs
+++ b/apps/desktop/scripts/copy-static.mjs
@@ -5,11 +5,16 @@ import { fileURLToPath } from "node:url";
 // tsc only emits the TypeScript sources; the preload bridges and the setup
 // window's static assets have to be copied into dist alongside them.
 const STATIC_FILES = ["preload.cjs", "setup-preload.cjs", "setup.html", "setup.css", "setup.js"];
+const TOKENS_FILE = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../packages/ui-tokens/src/tokens.css",
+);
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const dist = path.join(root, "dist");
 
 await mkdir(dist, { recursive: true });
-await Promise.all(
-  STATIC_FILES.map((file) => copyFile(path.join(root, "src", file), path.join(dist, file))),
-);
+await Promise.all([
+  ...STATIC_FILES.map((file) => copyFile(path.join(root, "src", file), path.join(dist, file))),
+  copyFile(TOKENS_FILE, path.join(dist, "tokens.css")),
+]);

--- a/apps/desktop/src/setup.css
+++ b/apps/desktop/src/setup.css
@@ -1,18 +1,3 @@
-:root {
-  color-scheme: dark;
-  --bg: #050506;
-  --panel: #0f0f12;
-  --panel-raised: #17171c;
-  --border: #26262e;
-  --border-strong: #3a3a46;
-  --text: #f4f4f6;
-  --text-muted: #9a9aa8;
-  --accent: #2563eb;
-  --accent-hover: #3b76f2;
-  --danger: #f87171;
-  --ok: #4ade80;
-}
-
 * {
   box-sizing: border-box;
 }
@@ -24,8 +9,8 @@ body {
 
 body {
   margin: 0;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--background);
+  color: var(--foreground);
   font-family:
     "Segoe UI", -apple-system, BlinkMacSystemFont, Inter, Roboto, Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -63,14 +48,14 @@ html[data-platform="darwin"] .titlebar {
   font-size: 12px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--muted-foreground);
 }
 
 .titlebar-quit {
   -webkit-app-region: no-drag;
   background: none;
   border: 0;
-  color: var(--text-muted);
+  color: var(--muted-foreground);
   font: inherit;
   font-size: 12px;
   cursor: pointer;
@@ -79,8 +64,8 @@ html[data-platform="darwin"] .titlebar {
 }
 
 .titlebar-quit:hover {
-  color: var(--text);
-  background: var(--panel-raised);
+  color: var(--foreground);
+  background: var(--accent);
 }
 
 .shell {
@@ -102,15 +87,8 @@ html[data-platform="darwin"] .titlebar {
 }
 
 .subheading {
-  margin: 0 0 24px;
-  color: var(--text-muted);
-}
-
-.card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 20px;
+  margin: 0 0 20px;
+  color: var(--muted-foreground);
 }
 
 .choices {
@@ -127,28 +105,28 @@ html[data-platform="darwin"] .titlebar {
   align-items: center;
   padding: 14px;
   border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--panel-raised);
+  border-radius: calc(var(--radius) - 2px);
+  background: var(--card);
   cursor: pointer;
 }
 
 .choice:hover {
-  border-color: var(--border-strong);
+  border-color: var(--input);
 }
 
 .choice:has(input:checked) {
-  border-color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, var(--panel-raised));
+  border-color: var(--primary);
+  background: var(--accent);
 }
 
 .choice:has(input:focus-visible) {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--ring);
   outline-offset: 2px;
 }
 
 .choice input {
   margin: 0;
-  accent-color: var(--accent);
+  accent-color: var(--primary);
   flex: none;
 }
 
@@ -166,41 +144,41 @@ html[data-platform="darwin"] .titlebar {
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--muted-foreground);
   margin-bottom: 6px;
 }
 
 .field {
   width: 100%;
   padding: 10px 12px;
-  border-radius: 9px;
-  border: 1px solid var(--border-strong);
-  background: #08080a;
-  color: var(--text);
+  border-radius: calc(var(--radius) - 3px);
+  border: 1px solid var(--input);
+  background: var(--background);
+  color: var(--foreground);
   font: inherit;
   font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
   font-size: 13px;
 }
 
 .field:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--ring);
   outline-offset: 1px;
-  border-color: var(--accent);
+  border-color: var(--ring);
 }
 
 .stack-phase {
   margin: 0;
   min-height: 20px;
   font-size: 13px;
-  color: var(--text);
+  color: var(--foreground);
 }
 
 .stack-phase[data-tone="error"] {
-  color: var(--danger);
+  color: var(--destructive);
 }
 
 .stack-phase[data-tone="ok"] {
-  color: var(--ok);
+  color: var(--success);
 }
 
 .stack-output {
@@ -208,10 +186,10 @@ html[data-platform="darwin"] .titlebar {
   max-height: 160px;
   overflow: auto;
   padding: 10px 12px;
-  border-radius: 9px;
+  border-radius: calc(var(--radius) - 3px);
   border: 1px solid var(--border);
-  background: #08080a;
-  color: var(--text-muted);
+  background: var(--background);
+  color: var(--muted-foreground);
   font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Menlo, monospace;
   font-size: 12px;
   line-height: 1.45;
@@ -232,18 +210,18 @@ html[data-platform="darwin"] .titlebar {
   padding: 0;
   font: inherit;
   font-size: 13px;
-  color: var(--accent-hover);
+  color: var(--link);
   cursor: pointer;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .link:hover {
-  color: var(--text);
+  color: var(--foreground);
 }
 
 .link:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--ring);
   outline-offset: 2px;
   border-radius: 3px;
 }
@@ -252,15 +230,15 @@ html[data-platform="darwin"] .titlebar {
   margin: 14px 0 0;
   min-height: 20px;
   font-size: 13px;
-  color: var(--text-muted);
+  color: var(--muted-foreground);
 }
 
 .status[data-tone="ok"] {
-  color: var(--ok);
+  color: var(--success);
 }
 
 .status[data-tone="error"] {
-  color: var(--danger);
+  color: var(--destructive);
 }
 
 .actions {
@@ -274,7 +252,7 @@ html[data-platform="darwin"] .titlebar {
   font: inherit;
   font-weight: 600;
   padding: 9px 18px;
-  border-radius: 9px;
+  border-radius: calc(var(--radius) - 3px);
   cursor: pointer;
   border: 1px solid transparent;
 }
@@ -285,27 +263,27 @@ html[data-platform="darwin"] .titlebar {
 }
 
 .button:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: 2px solid var(--ring);
   outline-offset: 2px;
 }
 
 .button-primary {
-  background: var(--accent);
-  color: #fff;
+  background: var(--primary);
+  color: var(--primary-foreground);
 }
 
 .button-primary:hover:not(:disabled) {
-  background: var(--accent-hover);
+  background: color-mix(in srgb, var(--primary) 88%, var(--foreground));
 }
 
 .button-secondary {
-  background: var(--panel-raised);
-  color: var(--text);
-  border-color: var(--border-strong);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  border-color: var(--input);
 }
 
 .button-secondary:hover:not(:disabled) {
-  border-color: var(--text-muted);
+  border-color: var(--muted-foreground);
 }
 
 /* Last so it wins over the flex layouts above at equal specificity. */

--- a/apps/desktop/src/setup.html
+++ b/apps/desktop/src/setup.html
@@ -7,6 +7,7 @@
       content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; form-action 'none'; base-uri 'none'"
     />
     <title>Set up Rakazo</title>
+    <link rel="stylesheet" href="tokens.css" />
     <link rel="stylesheet" href="setup.css" />
   </head>
   <body>
@@ -19,7 +20,7 @@
       <h1 class="heading">Welcome to Rakazo</h1>
       <p class="subheading">Choose which server this app should use.</p>
 
-      <form id="setup" class="card" novalidate>
+      <form id="setup" novalidate>
         <fieldset class="choices">
           <legend class="sr-only">Instance</legend>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

On first run, "Choose which server this app should use." sat above a bordered card that only wrapped the This computer / Existing instance radios. The question felt disconnected from the choices, and the outer box added no grouping value.

## What

Dropped the redundant outer card. The subtitle now leads straight into the two bordered option rows, which already provide enough structure at this width. I chose this over moving the question inside a card because each option is already its own selectable surface; a second wrapper would still split the prompt from the controls.

Setup styling now loads `@rakazo/ui-tokens` semantic tokens (`tokens.css` copied into `dist` at build time) instead of local hex palette variables.

## How tested

- `pnpm --filter @rakazo/desktop build`
- `pnpm --filter @rakazo/desktop test` (187 unit tests)
- CI Production builds: all 25 desktop Electron tests passed, including `setup.spec.ts`
- CI macOS setup screenshot job passed

## Screenshot

- [Native macOS CI screenshot](https://github.com/elie222/rakazo/actions/runs/33772565528/artifacts/9900304109) — `08-setup-macos-native-controls.png` shows the subtitle flowing directly into the server choice rows with no outer wrapper card.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4013b40a-43a7-4e46-9232-3897d4f13278?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4013b40a-43a7-4e46-9232-3897d4f13278&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

