### PR TITLE
fix(www): de-flake self-host Get started dialog E2E

### DIFF
--- a/apps/www/e2e/marketing-homepage.spec.ts
+++ b/apps/www/e2e/marketing-homepage.spec.ts
@@ -32,11 +32,10 @@ test.describe("marketing homepage", () => {
     await selfHost.scrollIntoViewIfNeeded();
     await captureScreenshot(page, testInfo, "01-marketing-homepage-selfhost");
 
-    await expect(async () => {
-      await selfHost.getByRole("button", { name: /Get started/i }).click();
-      await expect(page.getByRole("dialog")).toBeVisible();
-    }).toPass();
-    const dialog = page.getByRole("dialog");
+    await expect(page.locator("html")).toHaveAttribute("data-get-started-ready", "");
+    await selfHost.getByRole("button", { name: /Get started/i }).click();
+    const dialog = page.locator("[data-get-started-dialog]");
+    await expect(dialog).toBeVisible();
     await expect(dialog.getByRole("heading")).toBeVisible();
     await expect(dialog).not.toContainText(
       /openssl|docker-compose\.images|POSTGRES_PASSWORD|BETTER_AUTH_SECRET|mkdir rakazo/i,
@@ -64,11 +63,10 @@ test.describe("marketing homepage", () => {
     await selfHost.scrollIntoViewIfNeeded();
     await captureScreenshot(page, testInfo, "03-marketing-homepage-zh-selfhost");
 
-    await expect(async () => {
-      await selfHost.getByRole("button", { name: "开始使用" }).click();
-      await expect(page.getByRole("dialog")).toBeVisible();
-    }).toPass();
-    const dialog = page.getByRole("dialog");
+    await expect(page.locator("html")).toHaveAttribute("data-get-started-ready", "");
+    await selfHost.getByRole("button", { name: "开始使用" }).click();
+    const dialog = page.locator("[data-get-started-dialog]");
+    await expect(dialog).toBeVisible();
     await expect(dialog.getByRole("heading")).toHaveText("你想如何开始？");
     await expect(dialog).not.toContainText(
       /openssl|docker-compose\.images|POSTGRES_PASSWORD|BETTER_AUTH_SECRET|mkdir rakazo/i,

--- a/apps/www/src/components/GetStartedDialog.astro
+++ b/apps/www/src/components/GetStartedDialog.astro
@@ -79,67 +79,81 @@ const { copy, waitlist } = Astro.props;
   </div>
 </dialog>
 
-<script>
-  const dialog = document.querySelector<HTMLDialogElement>("[data-get-started-dialog]");
-  const openers = document.querySelectorAll<HTMLButtonElement>("[data-get-started-open]");
-  const closeButtons = dialog?.querySelectorAll<HTMLButtonElement>("[data-get-started-close]");
-  const choice = dialog?.querySelector<HTMLElement>("[data-get-started-choice]");
-  const signup = dialog?.querySelector<HTMLElement>("[data-get-started-signup]");
-  const success = dialog?.querySelector<HTMLElement>("[data-get-started-success]");
-  const successTitle = dialog?.querySelector<HTMLElement>("[data-get-started-success-title]");
-  const email = dialog?.querySelector<HTMLInputElement>("input[type='email']");
-  const selfHostBtn = dialog?.querySelector<HTMLButtonElement>("[data-get-started-selfhost]");
-  const cloudBtn = dialog?.querySelector<HTMLButtonElement>("[data-get-started-cloud]");
-  const backBtn = dialog?.querySelector<HTMLButtonElement>("[data-get-started-back]");
+<script is:inline>
+  (function () {
+    const dialog = document.querySelector("[data-get-started-dialog]");
+    if (!dialog) return;
 
-  function showChoice() {
-    if (!choice || !signup || !success) return;
-    choice.hidden = false;
-    signup.hidden = true;
-    success.hidden = true;
-    dialog?.setAttribute("aria-labelledby", "get-started-title");
-  }
+    const choice = dialog.querySelector("[data-get-started-choice]");
+    const signup = dialog.querySelector("[data-get-started-signup]");
+    const success = dialog.querySelector("[data-get-started-success]");
+    const successTitle = dialog.querySelector("[data-get-started-success-title]");
+    const email = dialog.querySelector("input[type='email']");
+    const selfHostBtn = dialog.querySelector("[data-get-started-selfhost]");
 
-  function showCloud() {
-    if (!choice || !signup || !success) return;
-    choice.hidden = true;
-    signup.hidden = false;
-    success.hidden = true;
-    dialog?.setAttribute("aria-labelledby", "get-started-cloud-title");
-    window.requestAnimationFrame(() => email?.focus());
-  }
+    function showChoice() {
+      if (!choice || !signup || !success) return;
+      choice.hidden = false;
+      signup.hidden = true;
+      success.hidden = true;
+      dialog.setAttribute("aria-labelledby", "get-started-title");
+    }
 
-  openers.forEach((opener) => {
-    opener.addEventListener("click", () => {
-      if (!dialog || dialog.open) return;
-      showChoice();
-      dialog.showModal();
-      window.requestAnimationFrame(() => selfHostBtn?.focus());
+    function showCloud() {
+      if (!choice || !signup || !success) return;
+      choice.hidden = true;
+      signup.hidden = false;
+      success.hidden = true;
+      dialog.setAttribute("aria-labelledby", "get-started-cloud-title");
+      window.requestAnimationFrame(() => email?.focus());
+    }
+
+    document.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      if (target.closest("[data-get-started-open]")) {
+        if (dialog.open) return;
+        showChoice();
+        dialog.showModal();
+        window.requestAnimationFrame(() => selfHostBtn?.focus());
+        return;
+      }
+
+      if (target.closest("[data-get-started-close]")) {
+        dialog.close();
+        return;
+      }
+
+      if (target.closest("[data-get-started-selfhost]")) {
+        dialog.close();
+        document.getElementById("selfhost")?.scrollIntoView({ behavior: "smooth" });
+        return;
+      }
+
+      if (target.closest("[data-get-started-cloud]")) {
+        showCloud();
+        return;
+      }
+
+      if (target.closest("[data-get-started-back]")) {
+        showChoice();
+      }
     });
-  });
 
-  selfHostBtn?.addEventListener("click", () => {
-    dialog?.close();
-    document.getElementById("selfhost")?.scrollIntoView({ behavior: "smooth" });
-  });
+    dialog.addEventListener("click", (event) => {
+      if (event.target === dialog) dialog.close();
+    });
 
-  cloudBtn?.addEventListener("click", () => showCloud());
-  backBtn?.addEventListener("click", () => showChoice());
+    dialog.addEventListener("waitlist:joined", () => {
+      if (!choice || !signup || !success) return;
+      choice.hidden = true;
+      signup.hidden = true;
+      success.hidden = false;
+      dialog.setAttribute("aria-labelledby", "get-started-success-title");
+      successTitle?.focus();
+    });
 
-  closeButtons?.forEach((button) => {
-    button.addEventListener("click", () => dialog?.close());
-  });
-
-  dialog?.addEventListener("click", (event) => {
-    if (event.target === dialog) dialog.close();
-  });
-
-  dialog?.addEventListener("waitlist:joined", () => {
-    if (!choice || !signup || !success) return;
-    choice.hidden = true;
-    signup.hidden = true;
-    success.hidden = false;
-    dialog.setAttribute("aria-labelledby", "get-started-success-title");
-    successTitle?.focus();
-  });
+    document.documentElement.dataset.getStartedReady = "";
+  })();
 </script>

--- a/apps/www/src/components/HomePage.astro
+++ b/apps/www/src/components/HomePage.astro
@@ -123,6 +123,8 @@ const structuredData = {
     <Header locale={locale} copy={copy.nav} starsLabel={starsLabel} homeHref={homeHref} />
 
     <main id="main">
+      <GetStartedDialog copy={copy.getStartedDialog} waitlist={copy.waitlist} />
+
       <section class="hero">
         <a class="hero__pill" href="#selfhost">
           <span class="hero__badge">{copy.hero.badge}</span>
@@ -279,8 +281,6 @@ const structuredData = {
           }
         </div>
       </section>
-
-      <GetStartedDialog copy={copy.getStartedDialog} waitlist={copy.waitlist} />
     </main>
 
     <Footer


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The `Web E2E` marketing homepage test intermittently fails on `main` (~2/3 of recent runs). Playwright clicks the self-host **Get started** button, but the `<dialog>` stays hidden because `showModal()` never runs.

## Root cause

This was a real page bug, not just a test-timing quirk.

The marketing homepage renders **Get started** buttons immediately from SSR, but `GetStartedDialog.astro` wired them with an Astro `<script>` block. Astro bundles those as **deferred ES modules** at the bottom of the page. Until that module executed, clicks on visible buttons were no-ops.

The English test runs first in the file and often clicked before the deferred script loaded. The zh variant usually passed because it runs second, after the module had already executed in the same browser session.

## What changed

1. **Page fix** — Move `<GetStartedDialog />` to the top of `<main>` and replace the deferred module with an inline script that:
   - uses document-level click delegation (works for buttons rendered later in the page)
   - calls `showModal()` synchronously when wiring completes
   - sets `data-get-started-ready` on `<html>` once interactive
2. **Test hardening** — Wait for `html[data-get-started-ready]` before clicking, so the test asserts the dialog is actually wired up.

Self-host copy assertions (no install-script text like `openssl`, `POSTGRES_PASSWORD`, etc.) are unchanged.

## How tested

- `pnpm lint`
- `pnpm --filter @rakazo/www check`
- `pnpm --filter @rakazo/www e2e e2e/marketing-homepage.spec.ts` — **8 consecutive passes** (2 tests each run, 16 total)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df045f70-ad13-4799-8e5c-c574a92c54dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df045f70-ad13-4799-8e5c-c574a92c54dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the self-host “Get started” dialog.
  * Ensured dialog controls consistently support choosing cloud or self-host options, navigating back, closing the dialog, and focusing relevant fields.
  * Improved dialog behavior when the component is unavailable.

* **Tests**
  * Updated marketing homepage tests to wait for dialog readiness and use more precise dialog targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->