### PR TITLE
Open Move to as a nested submenu

### DIFF
--- a/apps/web/e2e/bot-organization.spec.ts
+++ b/apps/web/e2e/bot-organization.spec.ts
@@ -22,11 +22,10 @@ test("pinned bots and sidebar sections persist", async ({ page }, testInfo) => {
 
   await bot.click({ button: "right" });
   await page.getByRole("menuitem", { name: "Move to", exact: true }).hover();
+  const moveMenu = page.getByRole("menu", { name: "Move to", exact: true });
+  await expect(moveMenu).toBeVisible();
   await captureScreenshot(page, testInfo, "move-to-section-menu");
-  await page
-    .getByRole("menu", { name: /Move Chief to section/ })
-    .getByText("New section")
-    .click();
+  await moveMenu.getByText("New section").click();
   const dialog = page.getByRole("dialog", { name: "New section" });
   await dialog.getByLabel("Name").fill("Projects");
   await dialog.getByRole("button", { name: "Create" }).click();
@@ -43,7 +42,7 @@ test("pinned bots and sidebar sections persist", async ({ page }, testInfo) => {
   await bot.click({ button: "right" });
   await page.getByRole("menuitem", { name: "Move to", exact: true }).hover();
   await page
-    .getByRole("menu", { name: /Move Chief to section/ })
+    .getByRole("menu", { name: "Move to", exact: true })
     .getByRole("menuitem", { name: "Unassigned", exact: true })
     .click();
   await expect(sidebar.locator('[data-sidebar-group="unassigned"]')).toContainText("Chief");
@@ -233,7 +232,7 @@ test("group chats share every context-menu action", async ({ page }, testInfo) =
   await group.click({ button: "right" });
   await page.getByRole("menuitem", { name: "Move to", exact: true }).hover();
   await page
-    .getByRole("menu", { name: /Move Group menu to section/ })
+    .getByRole("menu", { name: "Move to", exact: true })
     .getByRole("menuitem", { name: "New section", exact: true })
     .click();
   const sectionDialog = page.getByRole("dialog", { name: "New section" });

--- a/apps/web/e2e/bot-organization.spec.ts
+++ b/apps/web/e2e/bot-organization.spec.ts
@@ -21,7 +21,7 @@ test("pinned bots and sidebar sections persist", async ({ page }, testInfo) => {
   await expect(sidebar.locator('[data-sidebar-group="pinned"]')).toHaveCount(0);
 
   await bot.click({ button: "right" });
-  await page.getByRole("menuitem", { name: "Move to", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Move to", exact: true }).hover();
   await captureScreenshot(page, testInfo, "move-to-section-menu");
   await page
     .getByRole("menu", { name: /Move Chief to section/ })
@@ -41,7 +41,7 @@ test("pinned bots and sidebar sections persist", async ({ page }, testInfo) => {
   await expect(projects).toContainText("Chief");
 
   await bot.click({ button: "right" });
-  await page.getByRole("menuitem", { name: "Move to", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Move to", exact: true }).hover();
   await page
     .getByRole("menu", { name: /Move Chief to section/ })
     .getByRole("menuitem", { name: "Unassigned", exact: true })
@@ -231,7 +231,7 @@ test("group chats share every context-menu action", async ({ page }, testInfo) =
   await group.click({ button: "right" });
   await page.getByRole("menuitem", { name: "Unpin", exact: true }).click();
   await group.click({ button: "right" });
-  await page.getByRole("menuitem", { name: "Move to", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Move to", exact: true }).hover();
   await page
     .getByRole("menu", { name: /Move Group menu to section/ })
     .getByRole("menuitem", { name: "New section", exact: true })

--- a/apps/web/e2e/collapsible-sidebar-sections.spec.ts
+++ b/apps/web/e2e/collapsible-sidebar-sections.spec.ts
@@ -13,10 +13,7 @@ test("titled sidebar section expands and collapses", async ({ page }, testInfo) 
 
   await bot.click({ button: "right" });
   await page.getByRole("menuitem", { name: "Move to", exact: true }).hover();
-  await page
-    .getByRole("menu", { name: /Move Chief to section/ })
-    .getByText("New section")
-    .click();
+  await page.getByRole("menu", { name: "Move to", exact: true }).getByText("New section").click();
   const dialog = page.getByRole("dialog", { name: "New section" });
   await dialog.getByLabel("Name").fill("Projects");
   await dialog.getByRole("button", { name: "Create" }).click();

--- a/apps/web/e2e/collapsible-sidebar-sections.spec.ts
+++ b/apps/web/e2e/collapsible-sidebar-sections.spec.ts
@@ -12,7 +12,7 @@ test("titled sidebar section expands and collapses", async ({ page }, testInfo) 
   const bot = sidebar.getByRole("button", { name: /^Chief/ });
 
   await bot.click({ button: "right" });
-  await page.getByRole("menuitem", { name: "Move to", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Move to", exact: true }).hover();
   await page
     .getByRole("menu", { name: /Move Chief to section/ })
     .getByText("New section")

--- a/apps/web/src/pages/BotContextMenu.tsx
+++ b/apps/web/src/pages/BotContextMenu.tsx
@@ -93,10 +93,7 @@ export function BotContextMenu({
             <Folder />
             {t`Move to`}
           </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent
-            aria-label={t`Move ${bot.name} to section`}
-            className="max-h-[min(420px,calc(100vh-16px))] min-w-[180px] overflow-y-auto"
-          >
+          <DropdownMenuSubContent className="max-h-[min(420px,calc(100vh-16px))] min-w-[180px] overflow-y-auto">
             {sections.map((section) => (
               <DropdownMenuItem key={section.id} onClick={() => onMoveToSection(section.id)}>
                 <Folder />

--- a/apps/web/src/pages/BotContextMenu.tsx
+++ b/apps/web/src/pages/BotContextMenu.tsx
@@ -5,15 +5,16 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@rakazo/ui-web";
 import {
   Archive,
-  ArrowLeft,
   Bell,
   BellDot,
   Check,
-  ChevronRight,
   Copy,
   Eraser,
   Folder,
@@ -22,7 +23,6 @@ import {
   Pin,
   Trash2,
 } from "lucide-react";
-import { useState } from "react";
 
 export type ContextMenuPosition = { x: number; y: number };
 
@@ -58,9 +58,6 @@ export function BotContextMenu({
   onDelete: () => void;
 }) {
   const { t } = useLingui();
-  // "Move to" swaps the menu's contents in place instead of opening a hover
-  // submenu, so the section list is reachable with a single click or tap.
-  const [view, setView] = useState<"actions" | "move">("actions");
 
   return (
     <DropdownMenu
@@ -82,18 +79,24 @@ export function BotContextMenu({
         }
       />
       <DropdownMenuContent
-        aria-label={view === "move" ? t`Move ${bot.name} to section` : t`Actions for ${bot.name}`}
+        aria-label={t`Actions for ${bot.name}`}
         align="start"
         sideOffset={0}
         className="max-h-[min(420px,calc(100vh-16px))] w-[264px] overflow-y-auto"
       >
-        {view === "move" ? (
-          <>
-            <DropdownMenuItem closeOnClick={false} onClick={() => setView("actions")}>
-              <ArrowLeft />
-              {t`Back`}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onTogglePinned}>
+          <Pin />
+          {bot.pinned ? t`Unpin` : t`Pin`}
+        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <Folder />
+            {t`Move to`}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent
+            aria-label={t`Move ${bot.name} to section`}
+            className="max-h-[min(420px,calc(100vh-16px))] min-w-[180px] overflow-y-auto"
+          >
             {sections.map((section) => (
               <DropdownMenuItem key={section.id} onClick={() => onMoveToSection(section.id)}>
                 <Folder />
@@ -111,46 +114,34 @@ export function BotContextMenu({
               <FolderPlus />
               {t`New section`}
             </DropdownMenuItem>
-          </>
-        ) : (
-          <>
-            <DropdownMenuItem onClick={onTogglePinned}>
-              <Pin />
-              {bot.pinned ? t`Unpin` : t`Pin`}
-            </DropdownMenuItem>
-            <DropdownMenuItem closeOnClick={false} onClick={() => setView("move")}>
-              <Folder />
-              {t`Move to`}
-              <ChevronRight className="ms-auto" />
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={onToggleUnread}>
-              {bot.unread ? <BellDot /> : <Bell />}
-              {bot.unread ? t`Mark as Read` : t`Mark as Unread`}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onEdit}>
-              <Pencil />
-              {t`Edit Profile`}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={onDuplicate}>
-              <Copy />
-              {t`Duplicate`}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onClear}>
-              <Eraser />
-              {t`Clear conversation`}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={onArchive}>
-              <Archive />
-              {t`Archive`}
-            </DropdownMenuItem>
-            <DropdownMenuItem variant="destructive" onClick={onDelete}>
-              <Trash2 />
-              {t`Delete`}
-            </DropdownMenuItem>
-          </>
-        )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuItem onClick={onToggleUnread}>
+          {bot.unread ? <BellDot /> : <Bell />}
+          {bot.unread ? t`Mark as Read` : t`Mark as Unread`}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onEdit}>
+          <Pencil />
+          {t`Edit Profile`}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onDuplicate}>
+          <Copy />
+          {t`Duplicate`}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onClear}>
+          <Eraser />
+          {t`Clear conversation`}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onArchive}>
+          <Archive />
+          {t`Archive`}
+        </DropdownMenuItem>
+        <DropdownMenuItem variant="destructive" onClick={onDelete}>
+          <Trash2 />
+          {t`Delete`}
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
The bot context menu required a click before showing move destinations, which did not match the standard menu interaction. This replaces the custom in-place view with the shared shadcn/Base UI submenu so destinations open on hover and remain keyboard accessible, and updates the web E2E flows to exercise that behavior. Tested locally with the web TypeScript check, Biome, all 181 web unit tests, and the three affected E2E journeys; the full CI suite passes. [CI E2E screenshot: nested Move to submenu](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33778280630-1/screenshots/images/131-move-to-section-menu.png).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hover-based “Move to” submenu in bot context menus.
  * The submenu provides access to sections, “Unassigned,” and “New section” actions.

* **Bug Fixes**
  * Improved the interaction flow for moving bots, including pinned bots, reordered bots, and group chats.
  * Updated end-to-end coverage for the revised submenu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->