### PR TITLE
Fix computer screen connections and workspace recovery

### DIFF
--- a/apps/web/e2e/computer-screen-error.spec.ts
+++ b/apps/web/e2e/computer-screen-error.spec.ts
@@ -1,9 +1,14 @@
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+import { activeBotId, captureScreenshot, completeOnboarding, rpc, signup } from "./helpers";
 
 test("screen connection failures stay visible and can be retried", async ({ page }, testInfo) => {
   await signup(page, `screen-error-${Date.now()}@rakazo.test`, "password12", "Screen Error");
   await completeOnboarding(page);
+  const botId = activeBotId(page);
+  await rpc(page, "computer/boot", { botId });
+  await expect(rpc<{ state: string }>(page, "computer/status", { botId })).resolves.toMatchObject({
+    state: "running",
+  });
 
   let failScreen = true;
   const screenUrl = "https://screen.example/vnc.html";

--- a/apps/web/e2e/computer-screen-error.spec.ts
+++ b/apps/web/e2e/computer-screen-error.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+test("screen connection failures stay visible and can be retried", async ({ page }, testInfo) => {
+  await signup(page, `screen-error-${Date.now()}@rakazo.test`, "password12", "Screen Error");
+  await completeOnboarding(page);
+
+  let failScreen = true;
+  const screenUrl = "https://screen.example/vnc.html";
+  await page.route("https://screen.example/**", (route) =>
+    route.fulfill({
+      contentType: "text/html",
+      body: "<!doctype html><title>Test desktop</title><p>Desktop connected</p>",
+    }),
+  );
+  await page.route("**/rpc/computer/screenUrl", (route) =>
+    route.fulfill({
+      status: failScreen ? 500 : 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        failScreen
+          ? {
+              json: {
+                defined: false,
+                code: "INTERNAL_SERVER_ERROR",
+                status: 500,
+                message: "Computer screen could not connect",
+              },
+            }
+          : { json: { url: screenUrl } },
+      ),
+    }),
+  );
+
+  await page.getByTitle("Agent computer").click();
+  const preview = page.getByTestId("computer-preview");
+  await expect(preview.getByRole("alert")).toContainText("Computer screen could not connect");
+  await expect(preview.getByTestId("computer-preview-open")).toHaveCount(0);
+  await captureScreenshot(page, testInfo, "computer-screen-connection-error");
+
+  failScreen = false;
+  await preview.getByRole("button", { name: "Retry screen" }).click();
+  await expect(preview.locator("iframe")).toHaveAttribute("src", screenUrl);
+  await expect(preview.getByRole("alert")).toHaveCount(0);
+
+  failScreen = true;
+  await preview.hover();
+  await preview.getByTestId("computer-preview-open").click();
+  await expect(page.getByRole("button", { name: "Close computer" })).toBeVisible();
+  await expect(page.getByRole("alert")).toContainText("Computer screen could not connect");
+  await captureScreenshot(page, testInfo, "computer-full-screen-connection-error");
+
+  failScreen = false;
+  await page.getByRole("button", { name: "Retry screen" }).click();
+  await expect(page.locator('iframe[title="Bot screen"]')).toHaveAttribute("src", screenUrl);
+  await expect(page.getByRole("alert")).toHaveCount(0);
+});

--- a/apps/web/src/lib/computer-screen.test.ts
+++ b/apps/web/src/lib/computer-screen.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadComputerScreen } from "./computer-screen";
+
+describe("computer screen requests", () => {
+  it("shows connection failures and lets a successful retry clear them", async () => {
+    const commit = vi.fn();
+    const options = {
+      isCurrent: () => true,
+      commit,
+      fallbackError: "Could not connect",
+    };
+    await loadComputerScreen({
+      ...options,
+      load: async () => {
+        throw new Error("Control stream failed to start");
+      },
+    });
+    expect(commit).toHaveBeenLastCalledWith({
+      url: null,
+      error: "Control stream failed to start",
+    });
+
+    await expect(
+      loadComputerScreen({
+        ...options,
+        load: async () => ({ url: "https://screen.example/vnc.html" }),
+      }),
+    ).resolves.toBe("https://screen.example/vnc.html");
+    expect(commit).toHaveBeenLastCalledWith({
+      url: "https://screen.example/vnc.html",
+      error: null,
+    });
+  });
+
+  it.each(["success", "failure"])(
+    "ignores a stale %s after a newer screen failure",
+    async (outcome) => {
+      let finish!: (screen: { url: string | null }) => void;
+      let fail!: (error: Error) => void;
+      const deferred = new Promise<{ url: string | null }>((resolve, reject) => {
+        finish = resolve;
+        fail = reject;
+      });
+      let current = 1;
+      const commit = vi.fn();
+      const stale = loadComputerScreen({
+        load: () => deferred,
+        isCurrent: () => current === 1,
+        commit,
+        fallbackError: "Could not connect",
+      });
+      current = 2;
+      await loadComputerScreen({
+        load: async () => {
+          throw new Error("Latest connection failed");
+        },
+        isCurrent: () => current === 2,
+        commit,
+        fallbackError: "Could not connect",
+      });
+      if (outcome === "success") finish({ url: "https://stale.example/vnc.html" });
+      else fail(new Error("Stale connection failed"));
+      await expect(stale).resolves.toBeNull();
+      expect(commit).toHaveBeenCalledExactlyOnceWith({
+        url: null,
+        error: "Latest connection failed",
+      });
+    },
+  );
+
+  it("uses the visible fallback for errors without a message", async () => {
+    const commit = vi.fn();
+    await loadComputerScreen({
+      load: async () => Promise.reject(null),
+      isCurrent: () => true,
+      commit,
+      fallbackError: "Could not connect",
+    });
+    expect(commit).toHaveBeenCalledExactlyOnceWith({ url: null, error: "Could not connect" });
+  });
+});

--- a/apps/web/src/lib/computer-screen.ts
+++ b/apps/web/src/lib/computer-screen.ts
@@ -1,0 +1,26 @@
+export interface ComputerScreenResult {
+  url: string | null;
+  error: string | null;
+}
+
+/** Only the latest request for the visible computer may replace its screen or error. */
+export async function loadComputerScreen(options: {
+  load: () => Promise<{ url: string | null }>;
+  isCurrent: () => boolean;
+  commit: (result: ComputerScreenResult) => void;
+  fallbackError: string;
+}): Promise<string | null> {
+  let result: ComputerScreenResult;
+  try {
+    const screen = await options.load();
+    result = { url: screen.url, error: null };
+  } catch (error) {
+    result = {
+      url: null,
+      error: error instanceof Error && error.message ? error.message : options.fallbackError,
+    };
+  }
+  if (!options.isCurrent()) return null;
+  options.commit(result);
+  return result.url;
+}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -134,6 +134,7 @@ import {
   requestBrowserNotificationPermission,
   shouldNotifyBrowser,
 } from "../lib/browser-notifications";
+import { loadComputerScreen } from "../lib/computer-screen";
 import { dictation } from "../lib/dictation";
 import { localTimezone } from "../lib/local-timezone";
 import { copyableMessageText } from "../lib/message-text";
@@ -464,7 +465,7 @@ export function ShellPage() {
   const [routineError, setRoutineError] = useState<string | null>(null);
   const [screenUrl, setScreenUrl] = useState<string | null>(null);
   const [computerOpen, setComputerOpen] = useState(false);
-  const [, setComputerError] = useState<string | null>(null);
+  const [computerError, setComputerError] = useState<string | null>(null);
   useEffect(() => {
     if (!session.data?.user) return;
     let cancelled = false;
@@ -808,17 +809,17 @@ export function ShellPage() {
   async function refreshComputerScreen(id: string) {
     if (!computerVisible.current) return null;
     const request = ++screenRequest.current;
-    const screen = await rpc.computer.screenUrl({ botId: id }).catch(() => ({ url: null }));
-    if (
-      request !== screenRequest.current ||
-      activeBotId.current !== id ||
-      !computerVisible.current
-    ) {
-      return null;
-    }
-    setScreenUrl(screen.url);
-    cacheComputerFor(id, { screenUrl: screen.url });
-    return screen.url;
+    return loadComputerScreen({
+      load: () => rpc.computer.screenUrl({ botId: id }),
+      isCurrent: () =>
+        request === screenRequest.current && activeBotId.current === id && computerVisible.current,
+      commit: (screen) => {
+        setScreenUrl(screen.url);
+        setComputerError(screen.error);
+        cacheComputerFor(id, { screenUrl: screen.url });
+      },
+      fallbackError: t`Could not connect to the computer screen`,
+    });
   }
 
   async function loadOlderMessages() {
@@ -1044,6 +1045,7 @@ export function ShellPage() {
       pinnedAroundRef.current = null;
     }
     screenRequest.current += 1;
+    setComputerError(null);
     const cached = computerCacheRef.current.get(active.id);
     if (cached) {
       // Paint the last-known computer instantly; refreshThread/refreshComputerScreen
@@ -2196,11 +2198,11 @@ export function ShellPage() {
     if (!active) return;
     const needsBoot = force || computer?.state !== "running" || !screenUrl;
     if (overlay && needsBoot) setBooting(true);
+    setComputerError(null);
     try {
       if (needsBoot) await rpc.computer.boot({ botId: active.id });
       if (takeControl) await rpc.computer.takeover({ botId: active.id });
       await refreshThread(active.id);
-      setComputerError(null);
     } catch (error) {
       setComputerError(error instanceof Error ? error.message : t`Could not take control`);
       throw error;
@@ -2335,6 +2337,18 @@ export function ShellPage() {
 
   const embeddedScreenUrl = embeddableScreenUrl(screenUrl);
   const hasControl = userHoldsComputerControl(computer, active?.id);
+  const computerScreenError = computerError ? (
+    <div role="alert" className="flex flex-col items-center gap-3 px-6 text-center text-sm">
+      <p className="text-destructive">{computerError}</p>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => active && void refreshComputerScreen(active.id)}
+      >
+        <Trans>Retry screen</Trans>
+      </Button>
+    </div>
+  ) : null;
 
   const userName = session.data?.user.name ?? t`You`;
   const initials = userName
@@ -3136,29 +3150,32 @@ export function ShellPage() {
                     />
                   ) : (
                     <div className="grid h-full place-items-center px-6 text-center text-sm text-muted-foreground/80">
-                      {computersAreUnavailable(bootstrapMe?.sandboxProvider) ? (
-                        <ComputersUnavailableHint />
-                      ) : (
-                        computerPlaceholder(
-                          computer?.state,
-                          booting,
-                          computerLabel(computer?.mode, active.name),
-                        )
-                      )}
+                      {computerScreenError ??
+                        (computersAreUnavailable(bootstrapMe?.sandboxProvider) ? (
+                          <ComputersUnavailableHint />
+                        ) : (
+                          computerPlaceholder(
+                            computer?.state,
+                            booting,
+                            computerLabel(computer?.mode, active.name),
+                          )
+                        ))}
                     </div>
                   )}
-                  <button
-                    type="button"
-                    data-testid="computer-preview-open"
-                    className="absolute inset-0 flex cursor-pointer items-center justify-center bg-overlay/40 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                    aria-label={t`Open`}
-                    onClick={() => void openComputer()}
-                  >
-                    <span className="inline-flex items-center gap-2 rounded-full bg-overlay px-3.5 py-2 text-[14px] text-foreground shadow-md">
-                      <Maximize2 size={15} strokeWidth={1.9} aria-hidden />
-                      <Trans>Open</Trans>
-                    </span>
-                  </button>
+                  {!computerError ? (
+                    <button
+                      type="button"
+                      data-testid="computer-preview-open"
+                      className="absolute inset-0 flex cursor-pointer items-center justify-center bg-overlay/40 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                      aria-label={t`Open`}
+                      onClick={() => void openComputer()}
+                    >
+                      <span className="inline-flex items-center gap-2 rounded-full bg-overlay px-3.5 py-2 text-[14px] text-foreground shadow-md">
+                        <Maximize2 size={15} strokeWidth={1.9} aria-hidden />
+                        <Trans>Open</Trans>
+                      </span>
+                    </button>
+                  ) : null}
                 </div>
                 <p className="mt-2 truncate text-[13.5px] text-muted-foreground" dir="auto">
                   {t`${active.name}'s screen`}
@@ -3837,9 +3854,10 @@ export function ShellPage() {
               </>
             ) : (
               <div className="grid h-full place-items-center text-sm text-muted-foreground/80">
-                {computer?.state === "suspended"
-                  ? t`Computer is asleep`
-                  : computerLabel(computer?.mode, active.name)}
+                {computerScreenError ??
+                  (computer?.state === "suspended"
+                    ? t`Computer is asleep`
+                    : computerLabel(computer?.mode, active.name))}
               </div>
             )}
           </div>

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -279,7 +279,7 @@ container logs, default no-new-privileges, and the kernel NAT path instead of Do
    whenever Cloudflare publishes a change. A Cloudflare Tunnel can replace the public web listeners.
 2. Clone the repository on the VM and create a root `.env` with production-only values. At minimum set
    `POSTGRES_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `SCREEN_PROXY_SECRET`,
-   `E2B_API_KEY`, `OPENROUTER_API_KEY`,
+   `OPENROUTER_API_KEY`, the API key for your selected sandbox provider,
    `RAKAZO_HOST`, and the three public origins. Set `RAKAZO_DEPLOY_DIR` when the checkout is not at
    the supported Linux default, `/srv/rakazo`. Use URL-safe random values for database credentials.
    If you enable the `updater` profile, also set a dedicated `RAKAZO_UPDATER_TOKEN` (at least 32
@@ -297,7 +297,7 @@ WEB_ORIGIN=https://app.example.com
 API_URL=https://app.example.com
 SIGNUPS_ENABLED=true
 SIGNUP_ALLOWLIST=owner@example.com,reviewer@example.com
-SANDBOX_PROVIDER=e2b
+SANDBOX_PROVIDER=e2b # Production default; or daytona / box with the matching API key.
 AGENT_RUNTIME=pi
 WAKEUP_DRIVER=graphile
 DATA_DIR=/data

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -54,7 +54,7 @@ services:
       API_HOST: "0.0.0.0"
       DATABASE_URL: postgres://${POSTGRES_USER:-rakazo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-rakazo}
       DATA_DIR: /data
-      SANDBOX_PROVIDER: e2b
+      SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-e2b}
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi
       RAKAZO_UPDATER_URL: http://updater:7092
@@ -102,7 +102,7 @@ services:
       NODE_ENV: production
       DATABASE_URL: postgres://${POSTGRES_USER:-rakazo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-rakazo}
       DATA_DIR: /data
-      SANDBOX_PROVIDER: e2b
+      SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-e2b}
       SCREEN_PROXY_SECRET: ""
       WAKEUP_DRIVER: graphile
       AGENT_RUNTIME: pi

--- a/infra/updater/src/compose-service.test.ts
+++ b/infra/updater/src/compose-service.test.ts
@@ -23,6 +23,14 @@ const compose = parse(readFileSync(composeFile, "utf8")) as {
 };
 const updater = compose.services.updater as ComposeService;
 
+describe("the production computer provider", () => {
+  it.each(["api", "worker"])("lets .env select the %s provider with an E2B default", (name) => {
+    expect(compose.services[name]?.env_file).toEqual(["../../.env"]);
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: this is the literal Compose expression
+    expect(compose.services[name]?.environment?.SANDBOX_PROVIDER).toBe("${SANDBOX_PROVIDER:-e2b}");
+  });
+});
+
 /**
  * The updater holds the Docker socket, which is root-equivalent on the host. These are the
  * properties that keep that from being reachable by anything but the API, and they are easy to

--- a/packages/adapters/src/box-errors.test.ts
+++ b/packages/adapters/src/box-errors.test.ts
@@ -1,0 +1,107 @@
+import { ResponseError } from "@asciidev/box-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { boxResponseError, wrapBoxCall } from "./box-errors.js";
+import { BoxSandboxProvider, isUnrecoverableBoxError } from "./box-sandbox.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Box API errors", () => {
+  it("reports the upstream failure through the real SDK-backed file operation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          {
+            code: "box_direct_failed",
+            message: "File is too large for read_file. Use artifact download instead.",
+            requestId: "req_example",
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+    const provider = new BoxSandboxProvider({ apiKey: "fake-box-key" });
+    await expect(
+      provider.readFile(
+        { id: "box-test", providerRef: "box-test", botId: "bot-test", kind: "box" },
+        "data.bin",
+        {
+          operationId: "test",
+          traceId: "test",
+          spaceId: "test",
+          userId: "test",
+          signal: new AbortController().signal,
+        },
+      ),
+    ).rejects.toThrow(
+      "Box API request failed (HTTP 400, box_direct_failed): File is too large for read_file. Use artifact download instead. (request req_example)",
+    );
+  });
+
+  it("preserves 404 recovery and does not retry failed commands", async () => {
+    const call = vi.fn(async () => {
+      throw new ResponseError(Response.json({ message: "Box not found" }, { status: 404 }));
+    });
+    const error = await wrapBoxCall(call, "fake-key")().catch((failure: unknown) => failure);
+    expect(error).toBeInstanceOf(ResponseError);
+    expect(isUnrecoverableBoxError(error)).toBe(true);
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replace cancellation and network errors", async () => {
+    const cancelled = new DOMException("Cancelled", "AbortError");
+    const call = wrapBoxCall(async () => {
+      throw cancelled;
+    }, "fake-key");
+    await expect(call()).rejects.toBe(cancelled);
+  });
+
+  it("redacts credentials and signed URLs while retaining the useful diagnosis", async () => {
+    const error = await boxResponseError(
+      Response.json(
+        {
+          code: "unauthorized",
+          message:
+            "Rejected fake-box-key; Bearer other-credential; see https://box.example/desktop?token=private-value",
+        },
+        { status: 401 },
+      ),
+      "fake-box-key",
+    );
+    expect(error.message).toContain("HTTP 401, unauthorized");
+    for (const secret of ["fake-box-key", "other-credential", "private-value"]) {
+      expect(error.message).not.toContain(secret);
+    }
+  });
+
+  it.each(["upstream HTML", "null", "[]", '{"message":42}'])(
+    "uses an HTTP fallback for malformed or unstructured errors: %s",
+    async (body) => {
+      const error = await boxResponseError(new Response(body, { status: 502 }), "fake-key");
+      expect(error.message).toBe("Box API request failed (HTTP 502)");
+    },
+  );
+
+  it("caps upstream detail and stops reading oversized error bodies", async () => {
+    const error = await boxResponseError(
+      Response.json({ message: "x".repeat(1_000) }, { status: 400 }),
+      "fake-key",
+    );
+    expect(error.message.length).toBeLessThan(600);
+
+    const cancel = vi.fn();
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(20_000));
+        },
+        cancel,
+      }),
+      { status: 503 },
+    );
+    expect((await boxResponseError(response, "fake-key")).message).toBe(
+      "Box API request failed (HTTP 503)",
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/adapters/src/box-errors.ts
+++ b/packages/adapters/src/box-errors.ts
@@ -1,0 +1,69 @@
+import { ResponseError } from "@asciidev/box-sdk";
+import { redactSecrets } from "@rakazo/core";
+
+/** Keep HTTP failures actionable without changing the SDK's status-based recovery contract. */
+export function wrapBoxCall<Args extends unknown[], Result>(
+  call: (...args: Args) => Promise<Result>,
+  apiKey: string,
+): (...args: Args) => Promise<Result> {
+  return async (...args) => {
+    try {
+      return await call(...args);
+    } catch (error) {
+      if (error instanceof ResponseError) throw await boxResponseError(error.response, apiKey);
+      throw error;
+    }
+  };
+}
+
+export async function boxResponseError(response: Response, apiKey: string): Promise<ResponseError> {
+  const body = await readErrorBody(response);
+  const code = safeIdentifier(body?.code);
+  const requestId = safeIdentifier(body?.requestId);
+  const prefix = `Box API request failed (HTTP ${response.status}${code ? `, ${code}` : ""})`;
+  const detail =
+    typeof body?.message === "string"
+      ? redactSecrets(body.message, [apiKey])
+          .replace(/https?:\/\/[^\s<>"']+/gi, "[redacted URL]")
+          .replace(/Bearer\s+[^\s,;]+/gi, "Bearer [redacted]")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 512)
+      : "";
+  return new ResponseError(
+    response,
+    redactSecrets(
+      `${prefix}${detail ? `: ${detail}` : ""}${requestId ? ` (request ${requestId})` : ""}`,
+      [apiKey],
+    ),
+  );
+}
+
+function safeIdentifier(value: unknown): string | undefined {
+  return typeof value === "string" && /^[a-zA-Z0-9_.-]{1,128}$/.test(value) ? value : undefined;
+}
+
+async function readErrorBody(response: Response): Promise<Record<string, unknown> | undefined> {
+  const reader = response.body?.getReader();
+  if (!reader) return undefined;
+  try {
+    const chunks: Uint8Array[] = [];
+    let size = 0;
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > 16_384) return undefined;
+      chunks.push(value);
+    }
+    const body: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    return body !== null && typeof body === "object" && !Array.isArray(body)
+      ? (body as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}

--- a/packages/adapters/src/box-sandbox.test.ts
+++ b/packages/adapters/src/box-sandbox.test.ts
@@ -117,6 +117,121 @@ describe("BoxSandboxProvider", () => {
     expect(replacement).toMatchObject({ providerRef: "bx_testbox2", fresh: true });
   });
 
+  it("downloads binary files over the JSON endpoint limit through the SDK artifact route", async () => {
+    const content = Buffer.alloc(6 * 1024 * 1024, 0xff);
+    content[0] = 0;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(content, { headers: { "content-length": String(content.byteLength) } }),
+      );
+    try {
+      const provider = new BoxSandboxProvider({
+        apiKey: "test-key",
+        apiUrl: "https://box.test/api/box/v1",
+      });
+      const computer = {
+        id: "bx_testbox2",
+        providerRef: "bx_testbox2",
+        kind: "box" as const,
+        botId: "bot-a",
+      };
+      const filePath = "notes/a file & more.bin";
+      const downloaded = await provider.readFile(computer, filePath, context);
+
+      expect(Buffer.from(downloaded).equals(content)).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [request, init] = fetchMock.mock.calls[0]!;
+      const url = new URL(String(request));
+      expect(url.pathname).toBe("/api/box/v1/boxes/bx_testbox2/artifacts");
+      expect(url.searchParams.get("path")).toBe(`/home/user/rakazo-home/${filePath}`);
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer test-key");
+      expect(init?.signal).toBe(context.signal);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("exports browser profile files over 5 MiB without losing their bytes", async () => {
+    const fixture = boxFixture();
+    const content = Buffer.alloc(6 * 1024 * 1024, 0xab);
+    fixture.files.set("/home/user/rakazo-home/.browser-profiles/chrome/Default/History", content);
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+    const exported = [];
+    for await (const file of provider.exportWorkspace(computer, context)) exported.push(file);
+
+    expect(exported).toHaveLength(1);
+    expect(exported[0]?.path).toBe(".browser-profiles/chrome/Default/History");
+    expect(Buffer.from(exported[0]!.content).equals(content)).toBe(true);
+    expect(fixture.artifactRaw).toHaveBeenCalledWith(
+      {
+        boxId: computer.id,
+        path: "/home/user/rakazo-home/.browser-profiles/chrome/Default/History",
+      },
+      { signal: context.signal },
+    );
+  });
+
+  it.each([undefined, "1", "20"])(
+    "cancels oversized downloads with content-length %s",
+    async (contentLength) => {
+      const fixture = boxFixture();
+      const cancel = vi.fn();
+      const pull = vi.fn((controller: ReadableStreamDefaultController<Uint8Array>) => {
+        controller.enqueue(Uint8Array.from([1, 2, 3]));
+      });
+      const body = new ReadableStream({ pull, cancel }, { highWaterMark: 0 });
+      fixture.artifactRaw.mockResolvedValueOnce({
+        raw: new Response(body, {
+          headers: contentLength ? { "content-length": contentLength } : undefined,
+        }),
+      });
+      const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
+      const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+
+      await expect(
+        provider.readFile(computer, "large.bin", context, { maxBytes: 4 }),
+      ).rejects.toThrow("computer file exceeds 4 bytes");
+      expect(pull).toHaveBeenCalledTimes(contentLength === "20" ? 0 : 2);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(body.locked).toBe(false);
+    },
+  );
+
+  it("accepts empty files and files exactly at the download limit", async () => {
+    const fixture = boxFixture();
+    fixture.files.set("/home/user/rakazo-home/exact.bin", Uint8Array.from([0, 255]));
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+
+    expect(await provider.readFile(computer, "empty.bin", context, { maxBytes: 0 })).toHaveLength(
+      0,
+    );
+    expect(await provider.readFile(computer, "exact.bin", context, { maxBytes: 2 })).toEqual(
+      Uint8Array.from([0, 255]),
+    );
+  });
+
+  it("propagates interrupted downloads instead of returning partial files", async () => {
+    const fixture = boxFixture();
+    const aborted = new DOMException("download aborted", "AbortError");
+    let first = true;
+    const body = new ReadableStream({
+      pull(controller) {
+        if (first) controller.enqueue(Uint8Array.from([1, 2, 3]));
+        else controller.error(aborted);
+        first = false;
+      },
+    });
+    fixture.artifactRaw.mockResolvedValueOnce({ raw: new Response(body) });
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+
+    await expect(provider.readFile(computer, "partial.bin", context)).rejects.toBe(aborted);
+    expect(body.locked).toBe(false);
+  });
+
   it("captures the desktop, exposes a private view, and enforces one screen", async () => {
     const fixture = boxFixture();
     const provider = new BoxSandboxProvider({ apiKey: "test-key" }, fixture.client);
@@ -269,22 +384,14 @@ function boxFixture(options: { state?: string } = {}) {
         };
       },
     ),
-    readFile: vi.fn(async ({ path }: { path: string }) => {
+    artifactRaw: vi.fn(async ({ path }: { path: string }) => {
       const content = path.startsWith("/tmp/rakazo-observe-")
         ? Uint8Array.from([137, 80, 78, 71])
         : (files.get(path) ?? new Uint8Array());
-      return {
-        ok: true,
-        type: "file.read" as const,
-        success: true,
-        path,
-        encoding: "base64" as const,
-        size: content.byteLength,
-        content: Buffer.from(content).toString("base64"),
-      };
+      return { raw: new Response(Buffer.from(content)) };
     }),
   };
-  return { ...fixture, client: fixture as unknown as BoxSandboxSdk };
+  return { ...fixture, files, client: fixture as unknown as BoxSandboxSdk };
 }
 
 function box(id: string, state: string) {

--- a/packages/adapters/src/box-sandbox.ts
+++ b/packages/adapters/src/box-sandbox.ts
@@ -26,6 +26,7 @@ import type {
   ScreenSession,
 } from "@rakazo/adapter-kit";
 import { boundedSandboxCommandTimeoutMs, canReleaseScreenLease } from "@rakazo/core";
+import { boxResponseError, wrapBoxCall } from "./box-errors.js";
 import { SingleScreenClaimTracker } from "./computer-screens.js";
 import {
   boundedComputerActions,
@@ -52,12 +53,12 @@ const BOX_SCREEN_LEASE_PATH = "/tmp/rakazo-screen-lease";
 
 export type BoxSandboxSdk = Pick<
   BoxApi,
+  | "artifactRaw"
   | "command"
   | "commandStatus"
   | "create"
   | "desktop"
   | "get"
-  | "readFile"
   | "resume"
   | "stop"
   | "update"
@@ -400,18 +401,12 @@ export class BoxSandboxProvider implements SandboxProvider {
     context: AdapterContext,
     options?: { maxBytes?: number },
   ): Promise<Uint8Array> {
-    const response = await this.client.readFile(
-      {
-        boxId: this.id(computer),
-        path: workspacePath(BOX_WORKSPACE, filePath),
-        encoding: "base64",
-      },
-      { signal: context.signal },
+    return this.readRemoteFile(
+      this.id(computer),
+      workspacePath(BOX_WORKSPACE, filePath),
+      context.signal,
+      options?.maxBytes,
     );
-    if (options?.maxBytes !== undefined && response.size > options.maxBytes) {
-      throw new Error(`computer file exceeds ${options.maxBytes} bytes`);
-    }
-    return Uint8Array.from(Buffer.from(response.content, "base64"));
   }
 
   async writeFile(computer: ComputerRef, file: PortableFile, context: AdapterContext) {
@@ -715,12 +710,43 @@ export class BoxSandboxProvider implements SandboxProvider {
     id: string,
     filePath: string,
     signal?: AbortSignal,
+    maxBytes?: number,
   ): Promise<Uint8Array> {
-    const response = await this.client.readFile(
-      { boxId: id, path: filePath, encoding: "base64" },
+    // The JSON/base64 file endpoint rejects files over 5 MiB, including browser profiles.
+    const { raw: response } = await this.client.artifactRaw(
+      { boxId: id, path: filePath },
       signal ? { signal } : undefined,
     );
-    return Uint8Array.from(Buffer.from(response.content, "base64"));
+    const reader = response.body?.getReader();
+    const chunks: Uint8Array[] = [];
+    let size = 0;
+    try {
+      if (maxBytes !== undefined && Number(response.headers.get("content-length")) > maxBytes) {
+        throw new Error(`computer file exceeds ${maxBytes} bytes`);
+      }
+      if (!reader) return new Uint8Array();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        size += value.byteLength;
+        if (maxBytes !== undefined && size > maxBytes) {
+          throw new Error(`computer file exceeds ${maxBytes} bytes`);
+        }
+        chunks.push(value);
+      }
+      const content = new Uint8Array(size);
+      let offset = 0;
+      for (const chunk of chunks) {
+        content.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      return content;
+    } catch (error) {
+      await reader?.cancel().catch(() => undefined);
+      throw error;
+    } finally {
+      reader?.releaseLock();
+    }
   }
 
   private async runCommand(
@@ -852,16 +878,16 @@ function createBoxSdk(config: { apiKey: string; apiUrl?: string }): BoxSandboxSd
     }),
   );
   return {
-    command: api.command.bind(api),
-    commandStatus: api.commandStatus.bind(api),
-    create: api.create.bind(api),
-    desktop: api.desktop.bind(api),
-    get: api.get.bind(api),
-    readFile: api.readFile.bind(api),
-    resume: api.resume.bind(api),
-    stop: api.stop.bind(api),
-    update: api.update.bind(api),
-    writeFile: api.writeFile.bind(api),
+    artifactRaw: wrapBoxCall(api.artifactRaw.bind(api), config.apiKey),
+    command: wrapBoxCall(api.command.bind(api), config.apiKey),
+    commandStatus: wrapBoxCall(api.commandStatus.bind(api), config.apiKey),
+    create: wrapBoxCall(api.create.bind(api), config.apiKey),
+    desktop: wrapBoxCall(api.desktop.bind(api), config.apiKey),
+    get: wrapBoxCall(api.get.bind(api), config.apiKey),
+    resume: wrapBoxCall(api.resume.bind(api), config.apiKey),
+    stop: wrapBoxCall(api.stop.bind(api), config.apiKey),
+    update: wrapBoxCall(api.update.bind(api), config.apiKey),
+    writeFile: wrapBoxCall(api.writeFile.bind(api), config.apiKey),
     deleteBox: async (boxId: string) => {
       const url = `${apiUrl}/boxes/${encodeURIComponent(boxId)}`;
       const headers = { Authorization: `Bearer ${config.apiKey}` };
@@ -874,37 +900,20 @@ function createBoxSdk(config: { apiKey: string; apiUrl?: string }): BoxSandboxSd
       });
       if (response.status === 404) return;
       if (!response.ok) {
-        const message = await boxErrorMessage(response);
-        const error = new Error(message) as Error & { status: number };
-        error.status = response.status;
-        throw error;
+        throw await boxResponseError(response, config.apiKey);
       }
       const deadline = Date.now() + 60_000;
       while (Date.now() < deadline) {
         const status = await fetch(url, { headers });
         if (status.status === 404) return;
         if (!status.ok) {
-          const message = await boxErrorMessage(status);
-          const error = new Error(message) as Error & { status: number };
-          error.status = status.status;
-          throw error;
+          throw await boxResponseError(status, config.apiKey);
         }
         await delay(500);
       }
       throw new Error(`Box ${boxId} was not deleted within 60 seconds`);
     },
   };
-}
-
-async function boxErrorMessage(response: Response): Promise<string> {
-  const fallback = `Box API request failed with ${response.status}`;
-  try {
-    const body = (await response.json()) as { message?: unknown; requestId?: unknown };
-    const message = typeof body.message === "string" ? body.message : fallback;
-    return typeof body.requestId === "string" ? `${message} (${body.requestId})` : message;
-  } catch {
-    return fallback;
-  }
 }
 
 function timeoutCommand(command: string, timeoutMs: number, marker: string): string {

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -100,63 +100,154 @@ describe("computer provisioning", () => {
     }
   });
 
-  it("updates computer providerRef if reconnect provisions a different ref", async () => {
-    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-provision-reconnect-update-"));
-    const ref = {
-      id: "provider-2",
-      botId: "bot-1",
-      kind: "cloud" as const,
-      providerRef: "provider-2",
-      fresh: false,
-    };
-    const prepare = vi.fn().mockResolvedValue(undefined);
-    const prisma = {
-      computer: {
-        findUniqueOrThrow: vi.fn().mockResolvedValue({
-          id: "computer-1",
-          homeKey: "bot-1",
-          providerRef: "provider-1",
-          kind: "cloud",
-          scope: "dedicated",
-          state: "running",
-          controlLeaseId: null,
-        }),
-        updateMany: vi.fn(),
-        update: vi.fn(),
-      },
-    } as unknown as PrismaClient;
-    const sandbox = {
-      provision: vi.fn().mockResolvedValue(ref),
-      prepare,
-    } as unknown as SandboxProvider;
+  it.each([
+    { stage: "prepare", rollbackFails: false },
+    { stage: "restore", rollbackFails: false },
+    { stage: "record", rollbackFails: false },
+    { stage: "restore", rollbackFails: true },
+  ])(
+    "preserves the original computer when reconnect $stage fails (rollbackFails=$rollbackFails)",
+    async ({ stage, rollbackFails }) => {
+      const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-reconnect-rollback-"));
+      const failure = new Error(`${stage} failed`);
+      const rollbackError = new Error("replacement deletion failed");
+      const original = {
+        id: "computer-1",
+        homeKey: "bot-1",
+        providerRef: "provider-1",
+        kind: "box",
+        scope: "dedicated",
+        state: "running",
+        controlLeaseId: null,
+      };
+      const ref = {
+        id: "provider-2",
+        botId: "bot-1",
+        kind: "e2b" as const,
+        providerRef: "provider-2",
+        fresh: true,
+      };
+      const prisma = {
+        computer: {
+          findUniqueOrThrow: vi.fn().mockResolvedValue(original),
+          update: vi.fn().mockRejectedValue(failure),
+          updateMany: vi.fn(),
+        },
+      } as unknown as PrismaClient;
+      const sandbox = {
+        provision: vi.fn().mockResolvedValue(ref),
+        prepare: stage === "prepare" ? vi.fn().mockRejectedValue(failure) : vi.fn(),
+        importWorkspace: stage === "restore" ? vi.fn().mockRejectedValue(failure) : vi.fn(),
+        releaseScreen: vi.fn().mockResolvedValue(undefined),
+        destroy: rollbackFails ? vi.fn().mockRejectedValue(rollbackError) : vi.fn(),
+        stop: vi.fn(),
+      } as unknown as SandboxProvider;
 
-    try {
-      await expect(
-        provisionComputer(
+      try {
+        const result = provisionComputer(
           {
             prisma,
             sandbox,
-            home: {} as AgentHomeStore,
+            home: new LocalAgentHomeStore(dataDir),
             jobs: {} as JobPublisher,
             events: {} as ThreadEvents,
             dataDir,
           },
           "computer-1",
           context,
-        ),
-      ).resolves.toEqual(ref);
-      expect(prepare).toHaveBeenCalledWith(ref, context);
-      expect(prisma.computer.update).toHaveBeenCalledWith({
-        where: { id: "computer-1" },
-        data: {
-          providerRef: "provider-2",
-          kind: "cloud",
+        );
+        if (rollbackFails) {
+          await expect(result).rejects.toMatchObject({ errors: [failure, rollbackError] });
+        } else {
+          await expect(result).rejects.toBe(failure);
+        }
+        expect(sandbox.releaseScreen).toHaveBeenCalledExactlyOnceWith(ref, context);
+        expect(sandbox.destroy).toHaveBeenCalledExactlyOnceWith(ref, context);
+        expect(sandbox.stop).not.toHaveBeenCalled();
+        expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+        if (stage !== "record") expect(prisma.computer.update).not.toHaveBeenCalled();
+        expect(original).toMatchObject({
+          state: "running",
+          kind: "box",
+          providerRef: "provider-1",
+        });
+      } finally {
+        await rm(dataDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    { kind: "e2b" as const, providerRef: "provider-2", fresh: true },
+    { kind: "box" as const, providerRef: "provider-2", fresh: false },
+    { kind: "e2b" as const, providerRef: "provider-1", fresh: false },
+    { kind: "box" as const, providerRef: "provider-1", fresh: true },
+  ])(
+    "restores saved files before reconnecting to $kind/$providerRef (fresh=$fresh)",
+    async (next) => {
+      const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-provision-reconnect-update-"));
+      const home = new LocalAgentHomeStore(dataDir);
+      const sandbox = new FakeSandboxProvider();
+      const ref = {
+        ...(await sandbox.provision({ botId: "bot-1", homePath: dataDir }, context)),
+        ...next,
+      };
+      vi.spyOn(sandbox, "provision").mockResolvedValue(ref);
+      const prepare = vi.spyOn(sandbox, "prepare");
+      const destroy = vi.spyOn(sandbox, "destroy");
+      const stop = vi.spyOn(sandbox, "stop");
+      const saved = new TextEncoder().encode("saved work");
+      const prisma = {
+        computer: {
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
+            id: "computer-1",
+            homeKey: "bot-1",
+            providerRef: "provider-1",
+            kind: "box",
+            scope: "dedicated",
+            state: "running",
+            controlLeaseId: null,
+          }),
+          updateMany: vi.fn(),
+          update: vi.fn(async () => {
+            expect(await sandbox.readFile(ref, "notes/keep.txt", context)).toEqual(saved);
+          }),
         },
-      });
-    } finally {
-      await rm(dataDir, { recursive: true, force: true });
-    }
-  });
+      } as unknown as PrismaClient;
+
+      try {
+        await home.writeFile("bot-1", "notes/keep.txt", "saved work", context);
+        await expect(
+          provisionComputer(
+            {
+              prisma,
+              sandbox,
+              home,
+              jobs: {} as JobPublisher,
+              events: {} as ThreadEvents,
+              dataDir,
+            },
+            "computer-1",
+            context,
+          ),
+        ).resolves.toEqual(ref);
+        expect(prepare).toHaveBeenCalledWith(ref, context);
+        expect(await sandbox.readFile(ref, "notes/keep.txt", context)).toEqual(saved);
+        if (next.providerRef === "provider-1" && next.kind === "box") {
+          expect(prisma.computer.update).not.toHaveBeenCalled();
+        } else {
+          expect(prisma.computer.update).toHaveBeenCalledWith({
+            where: { id: "computer-1" },
+            data: { providerRef: next.providerRef, kind: next.kind },
+          });
+        }
+        expect(destroy).not.toHaveBeenCalled();
+        expect(stop).not.toHaveBeenCalled();
+      } finally {
+        await rm(dataDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.each([
     { fresh: true, cleanup: "destroy" as const },
@@ -344,39 +435,45 @@ describe("computer provisioning", () => {
     }
   });
 
-  it("reconnects a running computer and still prepares the provider", async () => {
-    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-provision-reconnect-"));
-    const ref = {
-      id: "provider-1",
-      botId: "bot-1",
-      kind: "cloud" as const,
-      providerRef: "provider-1",
-      fresh: false,
-    };
-    const prepare = vi.fn().mockResolvedValue(undefined);
-    const prisma = {
-      computer: {
-        findUniqueOrThrow: vi.fn().mockResolvedValue({
-          id: "computer-1",
-          homeKey: "bot-1",
-          providerRef: "provider-1",
-          kind: "cloud",
-          scope: "dedicated",
-          state: "running",
-          controlLeaseId: null,
-        }),
-        updateMany: vi.fn(),
-        update: vi.fn(),
-      },
-    } as unknown as PrismaClient;
-    const sandbox = {
-      provision: vi.fn().mockResolvedValue(ref),
-      prepare,
-    } as unknown as SandboxProvider;
+  it.each([false, true])(
+    "preserves a running computer's files on ordinary reconnect (prepare fails=%s)",
+    async (prepareFails) => {
+      const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-provision-reconnect-"));
+      const ref = {
+        id: "provider-1",
+        botId: "bot-1",
+        kind: "cloud" as const,
+        providerRef: "provider-1",
+        fresh: false,
+      };
+      const prepare = prepareFails
+        ? vi.fn().mockRejectedValue(new Error("provider preparation failed"))
+        : vi.fn().mockResolvedValue(undefined);
+      const prisma = {
+        computer: {
+          findUniqueOrThrow: vi.fn().mockResolvedValue({
+            id: "computer-1",
+            homeKey: "bot-1",
+            providerRef: "provider-1",
+            kind: "cloud",
+            scope: "dedicated",
+            state: "running",
+            controlLeaseId: null,
+          }),
+          updateMany: vi.fn(),
+          update: vi.fn(),
+        },
+      } as unknown as PrismaClient;
+      const sandbox = {
+        provision: vi.fn().mockResolvedValue(ref),
+        prepare,
+        importWorkspace: vi.fn(),
+        destroy: vi.fn(),
+        stop: vi.fn(),
+      } as unknown as SandboxProvider;
 
-    try {
-      await expect(
-        provisionComputer(
+      try {
+        const result = provisionComputer(
           {
             prisma,
             sandbox,
@@ -387,15 +484,23 @@ describe("computer provisioning", () => {
           },
           "computer-1",
           context,
-        ),
-      ).resolves.toEqual(ref);
-      expect(prepare).toHaveBeenCalledWith(ref, context);
-      expect(prisma.computer.updateMany).not.toHaveBeenCalled();
-      expect(prisma.computer.update).not.toHaveBeenCalled();
-    } finally {
-      await rm(dataDir, { recursive: true, force: true });
-    }
-  });
+        );
+        if (prepareFails) {
+          await expect(result).rejects.toThrow("provider preparation failed");
+        } else {
+          await expect(result).resolves.toEqual(ref);
+        }
+        expect(prepare).toHaveBeenCalledWith(ref, context);
+        expect(sandbox.importWorkspace).not.toHaveBeenCalled();
+        expect(sandbox.destroy).not.toHaveBeenCalled();
+        expect(sandbox.stop).not.toHaveBeenCalled();
+        expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+        expect(prisma.computer.update).not.toHaveBeenCalled();
+      } finally {
+        await rm(dataDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("computer execution leases", () => {

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -189,22 +189,41 @@ async function reconnectComputer(
     },
     context,
   );
-  await deps.sandbox.prepare(ref, context);
-  await ensureComputerWorkspaceLayout(
-    deps.sandbox,
-    ref,
-    parseComputerMode(computer.scope),
-    context.botId,
-    context,
-  );
-  if (ref.providerRef !== computer.providerRef || ref.kind !== computer.kind) {
-    await deps.prisma.computer.update({
-      where: { id: computer.id },
-      data: {
-        providerRef: ref.providerRef,
-        kind: ref.kind,
-      },
-    });
+  const changedProvider = ref.providerRef !== computer.providerRef || ref.kind !== computer.kind;
+  const replacement = ref.fresh === true || changedProvider;
+  try {
+    await deps.sandbox.prepare(ref, context);
+    if (replacement) {
+      await restoreComputerWorkspace(deps.home, deps.sandbox, computer.homeKey, ref, context);
+    }
+    await ensureComputerWorkspaceLayout(
+      deps.sandbox,
+      ref,
+      parseComputerMode(computer.scope),
+      context.botId,
+      context,
+    );
+    if (changedProvider) {
+      await deps.prisma.computer.update({
+        where: { id: computer.id },
+        data: {
+          providerRef: ref.providerRef,
+          kind: ref.kind,
+        },
+      });
+    }
+  } catch (error) {
+    // A failed replacement must not overwrite or tear down the original computer.
+    const rollbackError = replacement
+      ? await rollbackProvisionedComputer(deps.sandbox, ref, context, error)
+      : undefined;
+    if (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "Computer reconnection failed and its replacement could not be rolled back",
+      );
+    }
+    throw error;
   }
   return ref;
 }

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -475,7 +475,7 @@ describe("E2B computer backend", () => {
     ).toHaveLength(1);
     expect(control.url).toMatch(/^https:\/\/6081-desktop\.test\/vnc\.html\?/);
     const startControl = command.mock.calls
-      .map(([value]) => String(value))
+      .map(([value]) => unwrapSetupCommand(String(value)))
       .find((value) => value.includes("novnc_proxy") && value.includes("-rfbport 5901"));
     expect(startControl).toBeDefined();
     expect(startControl).toContain("pkill -f '(^|/)x11vnc .* -rfbport 5901'");
@@ -708,7 +708,7 @@ describe("E2B computer backend", () => {
     );
     expect(control.url).toMatch(/6083-desktop\.test/);
     const startControl = command.mock.calls
-      .map(([value]) => String(value))
+      .map(([value]) => unwrapSetupCommand(String(value)))
       .find((value) => value.includes("-rfbport 5903") && value.includes("novnc_proxy"));
     expect(startControl).toBeDefined();
     expect(startControl).toContain("pkill -f '(^|/)x11vnc .* -rfbport 5903'");
@@ -846,3 +846,7 @@ describe("sandbox-gone detection", () => {
     expect(revived.setTimeout).toHaveBeenCalledTimes(1);
   });
 });
+
+function unwrapSetupCommand(command: string): string {
+  return command.startsWith("bash -c '") ? command.slice(9, -1).replaceAll(`'"'"'`, "'") : command;
+}

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -5,9 +5,11 @@ import { shouldSkipPortableWorkspaceFile } from "./computer-workspace.js";
 import {
   E2BSandboxProvider,
   type E2BSandboxSdk,
+  ensureE2BPrimaryViewCommand,
   isSandboxGoneError,
   isUnrecoverableSandboxError,
 } from "./e2b-sandbox.js";
+import { noVncProxyProcessPattern } from "./extra-displays.js";
 
 const context = {
   operationId: "e2b-test",
@@ -18,6 +20,75 @@ const context = {
 };
 
 describe("E2B computer backend", () => {
+  it("reconnects concurrent primary viewers without using the SDK's global VNC lifecycle", async () => {
+    const command = vi.fn(async (value: string) => ({
+      stdout: value.includes("RAKAZO_SCREEN_INDEX=")
+        ? "RAKAZO_SCREEN_INDEX=0\n"
+        : "RAKAZO_SCREEN_PASSWORD=savedkey\n",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const globalStream = vi.fn(async () => {
+      throw new Error("Stream is already running");
+    });
+    const sdk = {
+      connect: vi.fn(async () => ({
+        sandboxId: "existing",
+        display: ":0",
+        getHost: (port: number) => `${port}-desktop.test`,
+        commands: { run: command },
+        stream: { start: globalStream, stop: globalStream },
+      })),
+    } as unknown as E2BSandboxSdk;
+    const computer = {
+      id: "existing",
+      providerRef: "existing",
+      kind: "e2b" as const,
+      botId: "bot",
+    };
+    const provider = new E2BSandboxProvider("test-key", sdk);
+    const [first, second] = await Promise.all([
+      provider.connectScreen(computer, { view: "stream" }, context),
+      provider.connectScreen(computer, { view: "stream" }, context),
+      provider.provision({ ...computer, providerKind: "e2b", homePath: "/unused" }, context),
+    ]);
+    expect(sdk.connect).toHaveBeenCalledTimes(1);
+    expect(first.url).toBe(second.url);
+    expect(new URL(first.url!).searchParams.get("password")).toBe("savedkey");
+    expect(new URL(first.url!).searchParams.get("view_only")).toBe("true");
+
+    const restarted = new E2BSandboxProvider("test-key", sdk);
+    const restored = await restarted.connectScreen(computer, { view: "stream" }, context);
+    expect(restored.url).toBe(first.url);
+    const commandsBeforeClose = command.mock.calls.length;
+    await first.close();
+    expect(command).toHaveBeenCalledTimes(commandsBeforeClose);
+    expect(globalStream).not.toHaveBeenCalled();
+  });
+
+  it("keeps primary view authentication and cleanup isolated from takeover and other displays", () => {
+    const command = ensureE2BPrimaryViewCommand(":0", "savedkey");
+    expect(command).toContain("flock 8");
+    expect(command).toContain("-viewonly -listen 127.0.0.1 -rfbport 5900 -rfbauth");
+    expect(command).toContain("8>&-");
+    const patterns = [...command.matchAll(/pkill -f '([^']+)'/g)].map(
+      (match) => new RegExp(match[1]!),
+    );
+    expect(patterns.length).toBeGreaterThan(0);
+    for (const pattern of patterns) {
+      expect(`/bin/bash -l -c ${command}`).not.toMatch(pattern);
+      for (const port of [5901, 5902, 5903]) {
+        expect(`x11vnc -bg -display :2 -forever -shared -rfbport ${port}`).not.toMatch(pattern);
+      }
+      for (const port of [6081, 6082, 6083]) {
+        expect(`bash ./novnc_proxy --vnc localhost:5901 --listen ${port}`).not.toMatch(pattern);
+      }
+    }
+    expect(patterns.some((pattern) => pattern.test("x11vnc -bg -display :0 -rfbport 5900"))).toBe(
+      true,
+    );
+  });
+
   it("only filters transient cache files inside portable browser profiles", () => {
     expect(shouldSkipPortableWorkspaceFile("project/Cache/important.txt")).toBe(false);
     expect(shouldSkipPortableWorkspaceFile("project/lock")).toBe(false);
@@ -227,6 +298,9 @@ describe("E2B computer backend", () => {
           exitCode: 0,
         };
       }
+      if (value.includes("primary-view.lock")) {
+        return { stdout: "RAKAZO_SCREEN_PASSWORD=screen-key\n", stderr: "", exitCode: 0 };
+      }
       if (value.includes("hang")) {
         throw new TimeoutError("command timed out");
       }
@@ -373,26 +447,44 @@ describe("E2B computer backend", () => {
       provider.connectScreen(computer, { view: "stream" }, context),
       provider.connectScreen(computer, { view: "stream" }, context),
     ]);
-    expect(screen.url).toBe("https://desktop.test/vnc.html");
-    expect(desktop.stream.start).toHaveBeenCalledWith({ requireAuth: true });
-    expect(desktop.stream.start).toHaveBeenCalledTimes(1);
-    expect(getStreamUrl).toHaveBeenCalledWith(
-      expect.objectContaining({ viewOnly: true, authKey: "screen-key" }),
-    );
-    expect(command).toHaveBeenCalledWith("x11vnc -R viewonly");
+    expect(new URL(screen.url!).searchParams.get("password")).toBe("screen-key");
+    expect(new URL(screen.url!).searchParams.get("view_only")).toBe("true");
+    expect(desktop.stream.start).not.toHaveBeenCalled();
+    expect(getStreamUrl).not.toHaveBeenCalled();
+    expect(
+      command.mock.calls.filter(([value]) => value.includes("primary-view.lock")),
+    ).toHaveLength(1);
 
-    const control = await provider.connectScreen(
-      computer,
-      { view: "stream", interactive: true, controlToken: "lease-1" },
-      context,
-    );
+    const [control, concurrentControl] = await Promise.all([
+      provider.connectScreen(
+        computer,
+        { view: "stream", interactive: true, controlToken: "lease-1" },
+        context,
+      ),
+      provider.connectScreen(
+        computer,
+        { view: "stream", interactive: true, controlToken: "lease-1" },
+        context,
+      ),
+    ]);
+    expect(concurrentControl.url).toBe(control.url);
+    expect(
+      command.mock.calls.filter(
+        ([value]) => value.includes("novnc_proxy") && value.includes("-rfbport 5901"),
+      ),
+    ).toHaveLength(1);
     expect(control.url).toMatch(/^https:\/\/6081-desktop\.test\/vnc\.html\?/);
     const startControl = command.mock.calls
       .map(([value]) => String(value))
       .find((value) => value.includes("novnc_proxy") && value.includes("-rfbport 5901"));
     expect(startControl).toBeDefined();
     expect(startControl).toContain("pkill -f '(^|/)x11vnc .* -rfbport 5901'");
-    expect(startControl).toContain("pkill -f 'novnc_proxy.*--listen 6081'");
+    const proxyPattern = noVncProxyProcessPattern(6081);
+    expect(startControl).toContain(`pkill -f '${proxyPattern}'`);
+    expect(`/bin/bash -l -c ${startControl}`).not.toMatch(new RegExp(proxyPattern));
+    expect("bash ./novnc_proxy --vnc localhost:5901 --listen 6081 --web /opt/noVNC").toMatch(
+      new RegExp(proxyPattern),
+    );
     // After stop: wait until VNC port is free (or fail) before storing a new password.
     expect(startControl).toMatch(
       /pkill -f '\(\^\|\/\)x11vnc \.\* -rfbport 5901'[\s\S]*for i in \$\(seq 1 50\); do netstat -tuln \| grep -q ':5901 ' \|\| break[\s\S]*if netstat -tuln \| grep -q ':5901 '; then exit 1; fi[\s\S]*x11vnc -storepasswd/,
@@ -441,21 +533,28 @@ describe("E2B computer backend", () => {
     expect(stillCurrent.url).toBe(replacementControl.url);
 
     await screen.close();
+    expect(streamStop).not.toHaveBeenCalled();
     let finishStart!: () => void;
-    streamStart.mockImplementationOnce(
-      () =>
-        new Promise<undefined>((resolve) => {
-          finishStart = () => resolve(undefined);
-        }),
-    );
+    const originalCommand = command.getMockImplementation()!;
+    command.mockImplementation((value, options) => {
+      if (!value.includes("primary-view.lock")) return originalCommand(value, options);
+      return new Promise((resolve) => {
+        finishStart = () =>
+          resolve({
+            stdout: "RAKAZO_SCREEN_PASSWORD=screen-key\n",
+            stderr: "",
+            exitCode: 0,
+          });
+      });
+    });
     const connecting = provider.connectScreen(computer, { view: "stream" }, context);
-    await vi.waitFor(() => expect(desktop.stream.start).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(finishStart).toBeTypeOf("function"));
     const stopping = provider.stop(computer, context);
     finishStart();
     await expect(connecting).rejects.toThrow(/teardown/);
     await stopping;
     expect(desktop.pause).toHaveBeenCalled();
-    expect(streamStop).toHaveBeenCalled();
+    expect(streamStop).not.toHaveBeenCalled();
   });
 
   it("gives Team bots distinct E2B screens and shared files", async () => {
@@ -508,6 +607,9 @@ describe("E2B computer backend", () => {
           stderr: "",
           exitCode: 0,
         };
+      }
+      if (value.includes("primary-view.lock")) {
+        return { stdout: "RAKAZO_SCREEN_PASSWORD=primary-key\n", stderr: "", exitCode: 0 };
       }
       if (value.includes("xdotool")) return { stdout: "", stderr: "", exitCode: 0 };
       if (value.includes("pkill -x x11vnc")) {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -41,12 +41,12 @@ import {
   extraDisplayControlStopCommand,
   extraDisplayInputCommand,
   extraDisplayLayout,
+  noVncProxyProcessPattern,
   observeExtraDisplayCommand,
   parseAllocatedExtraDisplay,
   parseExtraDisplayObservation,
   parseExtraDisplayViewPassword,
   parseReleasedExtraDisplay,
-  primaryStreamCleanupCommand,
   releaseExtraDisplayCommand,
   screenControlKey,
 } from "./extra-displays.js";
@@ -179,10 +179,11 @@ export async function openDesktopUrl(
 
 export class E2BSandboxProvider implements SandboxProvider {
   private readonly boxes = new Map<string, Sandbox>();
+  private readonly connections = new Map<string, Promise<Sandbox>>();
   private readonly lastTouchedAt = new Map<string, number>();
-  private readonly streamReady = new Set<string>();
-  private readonly streamStarts = new Map<string, Promise<void>>();
+  private readonly streamStarts = new Map<string, Promise<string>>();
   private readonly controlStreams = new Map<string, { password: string; controlToken: string }>();
+  private readonly controlStarts = new Map<string, Promise<string>>();
 
   constructor(
     private readonly apiKey: string,
@@ -221,25 +222,35 @@ export class E2BSandboxProvider implements SandboxProvider {
         this.lastTouchedAt.set(id, Date.now());
         return existing;
       }
-      this.forget(id);
+      if (this.boxes.get(id) === existing) this.forget(id);
     }
-    const connected = await this.sdk.connect(id, {
-      apiKey: this.apiKey,
-      timeoutMs: sandboxIdleMs(),
-    });
-    this.boxes.set(connected.sandboxId, connected);
-    this.lastTouchedAt.set(connected.sandboxId, Date.now());
-    return connected;
+    const pending = this.connections.get(id);
+    if (pending) return pending;
+    let connection!: Promise<Sandbox>;
+    connection = this.sdk
+      .connect(id, { apiKey: this.apiKey, timeoutMs: sandboxIdleMs() })
+      .then((connected) => {
+        if (this.connections.get(id) !== connection) {
+          throw new Error("computer connection stopped during teardown");
+        }
+        this.boxes.set(connected.sandboxId, connected);
+        this.lastTouchedAt.set(connected.sandboxId, Date.now());
+        return connected;
+      })
+      .finally(() => {
+        if (this.connections.get(id) === connection) this.connections.delete(id);
+      });
+    this.connections.set(id, connection);
+    return connection;
   }
 
   private async startStream(desktop: Sandbox) {
     if (this.boxes.get(desktop.sandboxId) !== desktop) {
       throw new Error("screen stream stopped during computer teardown");
     }
-    if (this.streamReady.has(desktop.sandboxId)) return;
     const pending = this.streamStarts.get(desktop.sandboxId);
     if (pending) return pending;
-    let start!: Promise<void>;
+    let start!: Promise<string>;
     start = this.initializeStream(desktop).finally(() => {
       if (this.streamStarts.get(desktop.sandboxId) === start) {
         this.streamStarts.delete(desktop.sandboxId);
@@ -249,21 +260,18 @@ export class E2BSandboxProvider implements SandboxProvider {
     return start;
   }
 
-  private async initializeStream(desktop: Sandbox) {
-    await desktop.commands.run(primaryStreamCleanupCommand()).catch(() => undefined);
-    await desktop.stream.start({ requireAuth: true });
-    try {
-      await desktop.commands.run("x11vnc -R viewonly");
-    } catch (error) {
-      await desktop.stream.stop().catch(() => undefined);
-      throw error;
+  private async initializeStream(desktop: Sandbox): Promise<string> {
+    const result = await this.runSetupCommand(
+      desktop,
+      ensureE2BPrimaryViewCommand(desktop.display ?? ":0", randomBytes(6).toString("base64url")),
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `screen stream failed to start (exit ${result.exitCode})`);
     }
-    const current = this.boxes.get(desktop.sandboxId);
-    if (current !== desktop) {
-      if (!current) await desktop.stream.stop().catch(() => undefined);
+    if (this.boxes.get(desktop.sandboxId) !== desktop) {
       throw new Error("screen stream stopped during computer teardown");
     }
-    this.streamReady.add(desktop.sandboxId);
+    return parseExtraDisplayViewPassword(result.stdout);
   }
 
   async provision(
@@ -277,12 +285,12 @@ export class E2BSandboxProvider implements SandboxProvider {
   ): Promise<ComputerRef> {
     if (request.providerRef && request.providerKind === "e2b") {
       try {
-        const desktop = await this.sdk.connect(request.providerRef, {
-          apiKey: this.apiKey,
-          timeoutMs: sandboxIdleMs(),
+        const desktop = await this.box({
+          id: request.providerRef,
+          providerRef: request.providerRef,
+          kind: "e2b",
+          botId: request.botId,
         });
-        this.boxes.set(desktop.sandboxId, desktop);
-        this.lastTouchedAt.set(desktop.sandboxId, Date.now());
         return {
           id: desktop.sandboxId,
           botId: request.botId,
@@ -358,7 +366,6 @@ export class E2BSandboxProvider implements SandboxProvider {
     const screenKey = screenSessionKey(context);
     const layout = await this.resolveLayout(desktop, screenKey, context.screenLeaseId);
     if (layout.isPrimary) {
-      await this.startStream(desktop);
       if (request.interactive) {
         if (!request.controlToken) throw new Error("interactive screen requires a control token");
         const password = await this.startControlStream(desktop, request.controlToken, screenKey);
@@ -372,28 +379,16 @@ export class E2BSandboxProvider implements SandboxProvider {
           close: async () => undefined,
         };
       }
-      let authKey: string | undefined;
-      try {
-        authKey = desktop.stream.getAuthKey();
-      } catch {
-        authKey = undefined;
-      }
-      const url =
-        typeof desktop.stream.getUrl === "function"
-          ? desktop.stream.getUrl({
-              autoConnect: true,
-              viewOnly: true,
-              resize: "scale",
-              ...(authKey ? { authKey } : {}),
-            })
-          : null;
+      const password = await this.startStream(desktop);
+      const url = new URL(`https://${desktop.getHost(layout.viewPort)}/vnc.html`);
+      url.searchParams.set("autoconnect", "true");
+      url.searchParams.set("resize", "scale");
+      url.searchParams.set("view_only", "true");
+      url.searchParams.set("password", password);
       return {
-        url,
+        url: url.toString(),
         mimeType: "text/html",
-        close: async () => {
-          await desktop.stream.stop().catch(() => undefined);
-          this.streamReady.delete(desktop.sandboxId);
-        },
+        close: async () => undefined,
       };
     }
     const viewPassword = await this.ensureExtraDisplay(desktop, layout, context);
@@ -665,7 +660,12 @@ export class E2BSandboxProvider implements SandboxProvider {
 
   async stop(computer: ComputerRef, _context: AdapterContext): Promise<void> {
     const id = computer.providerRef || computer.id;
-    const pending = this.streamStarts.get(id);
+    const pending = Promise.all([
+      this.streamStarts.get(id),
+      ...[...this.controlStarts]
+        .filter(([key]) => key.startsWith(`${id}:`))
+        .map(([, start]) => start),
+    ]);
     const desktop = this.boxes.get(id);
     this.forget(id);
     await settleForTeardown(pending);
@@ -679,7 +679,12 @@ export class E2BSandboxProvider implements SandboxProvider {
   async destroy(computer: ComputerRef, _context: AdapterContext): Promise<void> {
     const id = computer.providerRef || computer.id;
     const desktop = this.boxes.get(id) ?? (await this.box(computer).catch(() => undefined));
-    const pending = this.streamStarts.get(id);
+    const pending = Promise.all([
+      this.streamStarts.get(id),
+      ...[...this.controlStarts]
+        .filter(([key]) => key.startsWith(`${id}:`))
+        .map(([, start]) => start),
+    ]);
     this.forget(id);
     await settleForTeardown(pending);
     await desktop?.kill();
@@ -687,11 +692,14 @@ export class E2BSandboxProvider implements SandboxProvider {
 
   private forget(id: string): void {
     this.boxes.delete(id);
+    this.connections.delete(id);
     this.lastTouchedAt.delete(id);
-    this.streamReady.delete(id);
     this.streamStarts.delete(id);
     for (const key of [...this.controlStreams.keys()]) {
       if (key.startsWith(`${id}:`)) this.controlStreams.delete(key);
+    }
+    for (const key of [...this.controlStarts.keys()]) {
+      if (key.startsWith(`${id}:`)) this.controlStarts.delete(key);
     }
   }
 
@@ -760,8 +768,27 @@ export class E2BSandboxProvider implements SandboxProvider {
     layout = extraDisplayLayout(0, desktop.display ?? ":0"),
   ): Promise<string> {
     const controlKey = screenControlKey(desktop.sandboxId, screenKey);
+    const pending = this.controlStarts.get(controlKey);
+    if (pending) {
+      await pending;
+      return this.startControlStream(desktop, controlToken, screenKey, layout);
+    }
     const existing = this.controlStreams.get(controlKey);
     if (existing?.controlToken === controlToken) return existing.password;
+    let start!: Promise<string>;
+    start = this.initializeControlStream(desktop, controlToken, controlKey, layout).finally(() => {
+      if (this.controlStarts.get(controlKey) === start) this.controlStarts.delete(controlKey);
+    });
+    this.controlStarts.set(controlKey, start);
+    return start;
+  }
+
+  private async initializeControlStream(
+    desktop: Sandbox,
+    controlToken: string,
+    controlKey: string,
+    layout: ReturnType<typeof extraDisplayLayout>,
+  ): Promise<string> {
     const password = randomBytes(6).toString("base64url");
     if (layout.isPrimary) {
       const passwordFile = "/tmp/rakazo-control.vncpass";
@@ -785,13 +812,24 @@ export class E2BSandboxProvider implements SandboxProvider {
         "exit 1",
       ].join(" && ");
       const result = await this.runSetupCommand(desktop, command);
-      if (result.exitCode !== 0) throw new Error(result.stderr || "control stream failed to start");
+      if (result.exitCode !== 0) {
+        throw new Error(
+          result.stderr || `control stream failed to start (exit ${result.exitCode})`,
+        );
+      }
     } else {
       const result = await this.runSetupCommand(
         desktop,
         extraDisplayControlStartCommand(layout, controlToken, password),
       );
-      if (result.exitCode !== 0) throw new Error(result.stderr || "control stream failed to start");
+      if (result.exitCode !== 0) {
+        throw new Error(
+          result.stderr || `control stream failed to start (exit ${result.exitCode})`,
+        );
+      }
+    }
+    if (this.boxes.get(desktop.sandboxId) !== desktop) {
+      throw new Error("control stream stopped during computer teardown");
     }
     this.controlStreams.set(controlKey, { password, controlToken });
     return password;
@@ -804,6 +842,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     layout = extraDisplayLayout(0, desktop.display ?? ":0"),
   ): Promise<void> {
     const controlKey = screenControlKey(desktop.sandboxId, screenKey);
+    await this.controlStarts.get(controlKey)?.catch(() => undefined);
     if (layout.isPrimary) {
       await desktop.commands.run(controlStreamStopCommand(controlToken));
     } else {
@@ -816,7 +855,33 @@ export class E2BSandboxProvider implements SandboxProvider {
   }
 }
 
-async function settleForTeardown(pending: Promise<void> | undefined): Promise<void> {
+/** Reuse primary view credentials across API restarts without touching other VNC servers. */
+export function ensureE2BPrimaryViewCommand(display: string, password: string): string {
+  const passwordFile = "/tmp/rakazo/primary-view.password";
+  const authFile = "/tmp/rakazo-primary-view.vncpass";
+  return [
+    "set -eu",
+    "umask 077",
+    "mkdir -p /tmp/rakazo",
+    "exec 8>/tmp/rakazo/primary-view.lock",
+    "flock 8",
+    `if [ -s ${passwordFile} ] && [ -s ${authFile} ] && pgrep -f '(^|/)x11vnc .* -viewonly .* -rfbport 5900 -rfbauth ${authFile}( |$)' >/dev/null && (echo >/dev/tcp/127.0.0.1/5900) >/dev/null 2>&1 && (echo >/dev/tcp/127.0.0.1/6080) >/dev/null 2>&1; then printf 'RAKAZO_SCREEN_PASSWORD=%s\\n' "$(cat ${passwordFile})"; exit 0; fi`,
+    "pkill -f '(^|/)x11vnc .* -rfbport 5900( |$)' || true",
+    `pkill -f '${noVncProxyProcessPattern(6080)}' || true`,
+    "pkill -f '^/usr/bin/python3 .*websockify.*[ :]6080( |$)' || true",
+    "for i in $(seq 1 50); do if ! (echo >/dev/tcp/127.0.0.1/5900) >/dev/null 2>&1 && ! (echo >/dev/tcp/127.0.0.1/6080) >/dev/null 2>&1; then break; fi; sleep 0.1; done",
+    "if (echo >/dev/tcp/127.0.0.1/5900) >/dev/null 2>&1 || (echo >/dev/tcp/127.0.0.1/6080) >/dev/null 2>&1; then exit 1; fi",
+    `if [ -s ${passwordFile} ]; then password=$(cat ${passwordFile}); else password=${shellQuote(password)}; printf %s "$password" >${passwordFile}; fi`,
+    `x11vnc -storepasswd "$password" ${authFile} >/dev/null`,
+    `x11vnc -bg -display ${shellQuote(display)} -forever -wait 50 -shared -viewonly -listen 127.0.0.1 -rfbport 5900 -rfbauth ${authFile} 8>&- >/tmp/rakazo-primary-view-x11vnc.log 2>&1`,
+    "cd /opt/noVNC/utils",
+    "(nohup ./novnc_proxy --vnc localhost:5900 --listen 6080 --web /opt/noVNC 8>&- >/tmp/rakazo-primary-view-novnc.log 2>&1 &)",
+    `for i in $(seq 1 50); do if (echo >/dev/tcp/127.0.0.1/5900) >/dev/null 2>&1 && (echo >/dev/tcp/127.0.0.1/6080) >/dev/null 2>&1; then printf 'RAKAZO_SCREEN_PASSWORD=%s\\n' "$password"; exit 0; fi; sleep 0.1; done`,
+    "exit 1",
+  ].join("\n");
+}
+
+async function settleForTeardown(pending: Promise<unknown> | undefined): Promise<void> {
   if (!pending) return;
   await Promise.race([pending.catch(() => undefined), delay(5_000, undefined, { ref: false })]);
 }
@@ -828,7 +893,7 @@ function controlStreamStopCommand(controlToken?: string) {
   const stop = [
     "pkill -f '(^|/)x11vnc .* -rfbport 5901' || true",
     "pkill -f '^/usr/bin/python3 .*websockify.*6081' || true",
-    "pkill -f 'novnc_proxy.*--listen 6081' || true",
+    `pkill -f '${noVncProxyProcessPattern(6081)}' || true`,
     "rm -f /tmp/rakazo-control.vncpass",
     "rm -f /tmp/rakazo-control.token",
   ].join("; ");

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -49,6 +49,7 @@ import {
   parseReleasedExtraDisplay,
   releaseExtraDisplayCommand,
   screenControlKey,
+  websockifyProcessPattern,
 } from "./extra-displays.js";
 
 const E2B_WORKSPACE = "/home/user/rakazo-home";
@@ -266,7 +267,9 @@ export class E2BSandboxProvider implements SandboxProvider {
       ensureE2BPrimaryViewCommand(desktop.display ?? ":0", randomBytes(6).toString("base64url")),
     );
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || `screen stream failed to start (exit ${result.exitCode})`);
+      throw new Error(
+        `screen stream failed to start (exit ${result.exitCode})${result.stderr ? `: ${result.stderr}` : ""}`,
+      );
     }
     if (this.boxes.get(desktop.sandboxId) !== desktop) {
       throw new Error("screen stream stopped during computer teardown");
@@ -710,7 +713,8 @@ export class E2BSandboxProvider implements SandboxProvider {
     signal?: AbortSignal,
   ): Promise<CommandResult> {
     try {
-      return await desktop.commands.run(command, {
+      // E2B's outer login shell can fail its logout hook under `set -e`, even after `exit 0`.
+      return await desktop.commands.run(`bash -c ${shellQuote(command)}`, {
         ...(signal ? { signal } : {}),
         timeoutMs: boundedSandboxCommandTimeoutMs(undefined),
       });
@@ -868,11 +872,11 @@ export function ensureE2BPrimaryViewCommand(display: string, password: string): 
     `if [ -s ${passwordFile} ] && [ -s ${authFile} ] && pgrep -f '(^|/)x11vnc .* -viewonly .* -rfbport 5900 -rfbauth ${authFile}( |$)' >/dev/null && (echo >/dev/tcp/127.0.0.1/5900) >/dev/null 2>&1 && (echo >/dev/tcp/127.0.0.1/6080) >/dev/null 2>&1; then printf 'RAKAZO_SCREEN_PASSWORD=%s\\n' "$(cat ${passwordFile})"; exit 0; fi`,
     "pkill -f '(^|/)x11vnc .* -rfbport 5900( |$)' || true",
     `pkill -f '${noVncProxyProcessPattern(6080)}' || true`,
-    "pkill -f '^/usr/bin/python3 .*websockify.*[ :]6080( |$)' || true",
+    `pkill -f '${websockifyProcessPattern(6080)}' || true`,
     "for i in $(seq 1 50); do if ! (echo >/dev/tcp/127.0.0.1/5900) >/dev/null 2>&1 && ! (echo >/dev/tcp/127.0.0.1/6080) >/dev/null 2>&1; then break; fi; sleep 0.1; done",
     "if (echo >/dev/tcp/127.0.0.1/5900) >/dev/null 2>&1 || (echo >/dev/tcp/127.0.0.1/6080) >/dev/null 2>&1; then exit 1; fi",
     `if [ -s ${passwordFile} ]; then password=$(cat ${passwordFile}); else password=${shellQuote(password)}; printf %s "$password" >${passwordFile}; fi`,
-    `x11vnc -storepasswd "$password" ${authFile} >/dev/null`,
+    `x11vnc -storepasswd "$password" ${authFile} >/dev/null 2>&1`,
     `x11vnc -bg -display ${shellQuote(display)} -forever -wait 50 -shared -viewonly -listen 127.0.0.1 -rfbport 5900 -rfbauth ${authFile} 8>&- >/tmp/rakazo-primary-view-x11vnc.log 2>&1`,
     "cd /opt/noVNC/utils",
     "(nohup ./novnc_proxy --vnc localhost:5900 --listen 6080 --web /opt/noVNC 8>&- >/tmp/rakazo-primary-view-novnc.log 2>&1 &)",
@@ -892,7 +896,7 @@ function controlStreamStopCommand(controlToken?: string) {
   // would pkill the runner itself.
   const stop = [
     "pkill -f '(^|/)x11vnc .* -rfbport 5901' || true",
-    "pkill -f '^/usr/bin/python3 .*websockify.*6081' || true",
+    `pkill -f '${websockifyProcessPattern(6081)}' || true`,
     `pkill -f '${noVncProxyProcessPattern(6081)}' || true`,
     "rm -f /tmp/rakazo-control.vncpass",
     "rm -f /tmp/rakazo-control.token",

--- a/packages/adapters/src/extra-displays.test.ts
+++ b/packages/adapters/src/extra-displays.test.ts
@@ -10,6 +10,7 @@ import {
   parseExtraDisplayViewPassword,
   parseReleasedExtraDisplay,
   releaseExtraDisplayCommand,
+  websockifyProcessPattern,
 } from "./extra-displays.js";
 
 describe("extra display ports", () => {
@@ -42,6 +43,21 @@ describe("extra display ports", () => {
       }
       expect(`bash ./novnc_proxy --vnc localhost:5900 --listen ${port}0`).not.toMatch(pattern);
       expect(`bash ./novnc_proxy --vnc localhost:5900 --listen ${port + 1}`).not.toMatch(pattern);
+    }
+  });
+
+  it("targets module and executable websockify children on only the intended port", () => {
+    const pattern = new RegExp(websockifyProcessPattern(6080));
+    for (const command of [
+      "python3 -m websockify --web /opt/noVNC 6080 localhost:5900",
+      "/usr/bin/python3 -m websockify --web /opt/noVNC 6080 localhost:5900",
+      "/usr/bin/python3 /opt/noVNC/utils/websockify/run --web /opt/noVNC 6080 localhost:5900",
+      "/usr/bin/python3 /usr/bin/websockify --web=/usr/share/novnc 0.0.0.0:6080 127.0.0.1:5900",
+    ]) {
+      expect(command).toMatch(pattern);
+      expect(`/bin/bash -l -c ${command}`).not.toMatch(pattern);
+      expect(command.replace(/6080/g, "6081")).not.toMatch(pattern);
+      expect(command.replace(/6080/g, "60800")).not.toMatch(pattern);
     }
   });
 

--- a/packages/adapters/src/extra-displays.test.ts
+++ b/packages/adapters/src/extra-displays.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { ComputerScreenUnavailableError } from "./computer-screens.js";
 import {
   allocateExtraDisplayCommand,
+  ensureExtraDisplayCommand,
+  extraDisplayControlStartCommand,
   extraDisplayLayout,
+  noVncProxyProcessPattern,
   parseAllocatedExtraDisplay,
   parseExtraDisplayViewPassword,
   parseReleasedExtraDisplay,
@@ -10,6 +13,38 @@ import {
 } from "./extra-displays.js";
 
 describe("extra display ports", () => {
+  it("targets noVNC proxy processes without matching E2B's enclosing bash runner", () => {
+    const layout = extraDisplayLayout(1, ":0");
+    const commands = [
+      ensureExtraDisplayCommand(
+        layout,
+        { homeDir: "/home/user", browserProfilesDir: "/home/user/.browser-profiles" },
+        "test-password",
+      ),
+      extraDisplayControlStartCommand(layout, "test-control", "test-password"),
+      releaseExtraDisplayCommand("test-bot", "test-lease:1"),
+    ];
+    for (const port of [layout.viewPort, layout.controlPort]) {
+      const pattern = new RegExp(noVncProxyProcessPattern(port));
+      for (const executable of [
+        "./novnc_proxy",
+        "/opt/noVNC/utils/novnc_proxy",
+        "bash ./novnc_proxy",
+        "/bin/bash /opt/noVNC/utils/novnc_proxy",
+        "/usr/bin/bash ./novnc_proxy",
+      ]) {
+        expect(`${executable} --vnc localhost:5900 --listen ${port} --web /opt/noVNC`).toMatch(
+          pattern,
+        );
+      }
+      for (const command of commands) {
+        expect(`/bin/bash -l -c ${command}`).not.toMatch(pattern);
+      }
+      expect(`bash ./novnc_proxy --vnc localhost:5900 --listen ${port}0`).not.toMatch(pattern);
+      expect(`bash ./novnc_proxy --vnc localhost:5900 --listen ${port + 1}`).not.toMatch(pattern);
+    }
+  });
+
   it("keeps the vendor primary on index 0 and shifts extra screens by two", () => {
     expect(extraDisplayLayout(0, ":0")).toMatchObject({
       display: ":0",

--- a/packages/adapters/src/extra-displays.ts
+++ b/packages/adapters/src/extra-displays.ts
@@ -29,6 +29,10 @@ export function noVncProxyProcessPattern(port: number | string): string {
   return `^(([^ ]*/)?(bash|sh) +)?([^ ]*/)?novnc_proxy +.*--listen +${port}( |$)`;
 }
 
+export function websockifyProcessPattern(port: number | string): string {
+  return `^([^ ]*/)?python[0-9.]* +(-m +websockify|[^ ]*websockify[^ ]*) +.*[ :]${port}( |$)`;
+}
+
 export function allocateExtraDisplayCommand(screenKey: string, leaseId?: string): string {
   const key = createHash("sha256").update(screenKey).digest("hex");
   const owner = leaseId ?? "";
@@ -75,7 +79,7 @@ export function releaseExtraDisplayCommand(screenKey: string, leaseId?: string):
     // biome-ignore lint/suspicious/noTemplateCurlyInString: POSIX parameter expansion in the remote shell script
     'case "$current" in *:*) rest=${current##*:}; case "$rest" in \'\'|*[!0-9]*) ;; *) current_fence=$rest; current_owner=${current%:*}; esac ;; esac',
     '[ -z "$owner" ] || [ "$current" = "$owner" ] || { [ "$incoming_owner" = "$current_owner" ] && [ "$incoming_fence" -ge "$current_fence" ]; } || { printf \'RAKAZO_SCREEN_RELEASE=stale\\n\'; exit 0; }',
-    `if [ "$index" -ne 0 ]; then display_number=$((index + 1)); view_port=$((6080 + index * 2)); control_port=$((6081 + index * 2)); view_vnc_port=$((5900 + index * 2)); control_vnc_port=$((5901 + index * 2)); pkill -f "Xvfb :$display_number -screen" || true; pkill -f "HOME=/tmp/fluxbox-home-$display_number DISPLAY=:$display_number fluxbox" || true; pkill -f -- "chromium-screen-$display_number" || true; pkill -f "(^|/)x11vnc .* -rfbport $view_vnc_port" || true; pkill -f "(^|/)x11vnc .* -rfbport $control_vnc_port" || true; pkill -f "^/usr/bin/python3 .*websockify.*$view_port" || true; pkill -f "${noVncProxyProcessPattern("$view_port")}" || true; pkill -f "^/usr/bin/python3 .*websockify.*$control_port" || true; pkill -f "${noVncProxyProcessPattern("$control_port")}" || true; rm -f "/tmp/.X$display_number-lock" "/tmp/.X11-unix/X$display_number" "/tmp/rakazo/control-token-$display_number" "/tmp/rakazo/view-password-$display_number" "/tmp/rakazo-view-$display_number.vncpass" "/tmp/rakazo-control-$display_number.vncpass" "/tmp/rakazo/screen-$display_number.lock"; fi`,
+    `if [ "$index" -ne 0 ]; then display_number=$((index + 1)); view_port=$((6080 + index * 2)); control_port=$((6081 + index * 2)); view_vnc_port=$((5900 + index * 2)); control_vnc_port=$((5901 + index * 2)); pkill -f "Xvfb :$display_number -screen" || true; pkill -f "HOME=/tmp/fluxbox-home-$display_number DISPLAY=:$display_number fluxbox" || true; pkill -f -- "chromium-screen-$display_number" || true; pkill -f "(^|/)x11vnc .* -rfbport $view_vnc_port" || true; pkill -f "(^|/)x11vnc .* -rfbport $control_vnc_port" || true; pkill -f "${websockifyProcessPattern("$view_port")}" || true; pkill -f "${noVncProxyProcessPattern("$view_port")}" || true; pkill -f "${websockifyProcessPattern("$control_port")}" || true; pkill -f "${noVncProxyProcessPattern("$control_port")}" || true; rm -f "/tmp/.X$display_number-lock" "/tmp/.X11-unix/X$display_number" "/tmp/rakazo/control-token-$display_number" "/tmp/rakazo/view-password-$display_number" "/tmp/rakazo-view-$display_number.vncpass" "/tmp/rakazo-control-$display_number.vncpass" "/tmp/rakazo/screen-$display_number.lock"; fi`,
     'rm -f "$slot"',
     "printf 'RAKAZO_SCREEN_RELEASE=%s\\n' \"$index\"",
   ].join("; ");
@@ -168,7 +172,7 @@ export function ensureExtraDisplayCommand(
     `  done`,
     `fi`,
     `pkill -f '(^|/)x11vnc .* -rfbport ${layout.viewVncPort}' || true`,
-    `pkill -f '^/usr/bin/python3 .*websockify.*${layout.viewPort}' || true`,
+    `pkill -f '${websockifyProcessPattern(layout.viewPort)}' || true`,
     `pkill -f '${noVncProxyProcessPattern(layout.viewPort)}' || true`,
     `x11vnc -storepasswd "$view_password" ${shellQuote(passwordAuthFile)} >/dev/null`,
     `x11vnc -display ${layout.display} -forever -shared -viewonly -rfbauth ${shellQuote(passwordAuthFile)} -listen 127.0.0.1 -rfbport ${layout.viewVncPort} -xkb -ncache 0 >${log}-x11vnc.log 2>&1 &`,
@@ -232,7 +236,7 @@ export function extraDisplayControlStopCommand(
   const stop = [
     // Anchor to the x11vnc binary (path-prefixed OK); avoid unanchored matches that hit the runner argv.
     `pkill -f '(^|/)x11vnc .* -rfbport ${layout.controlVncPort}' || true`,
-    `pkill -f '^/usr/bin/python3 .*websockify.*${layout.controlPort}' || true`,
+    `pkill -f '${websockifyProcessPattern(layout.controlPort)}' || true`,
     `pkill -f '${noVncProxyProcessPattern(layout.controlPort)}' || true`,
     `rm -f /tmp/rakazo-control-${layout.displayNumber}.vncpass`,
     `rm -f /tmp/rakazo/control-token-${layout.displayNumber}`,
@@ -335,7 +339,7 @@ export function primaryStreamCleanupCommand(primaryViewPort = 6080): string {
   return [
     "pkill -f '(^|/)x11vnc .* -R viewonly' || true",
     `pkill -f '${noVncProxyProcessPattern(primaryViewPort)}' || true`,
-    `pkill -f '[w]ebsockify.*${primaryViewPort}' || true`,
+    `pkill -f '${websockifyProcessPattern(primaryViewPort)}' || true`,
   ].join("; ");
 }
 

--- a/packages/adapters/src/extra-displays.ts
+++ b/packages/adapters/src/extra-displays.ts
@@ -23,6 +23,12 @@ export interface ExtraDisplayEnvironment {
 
 const SCREEN_REGISTRY = "/tmp/rakazo/screen-assignments";
 
+// The SDK puts setup scripts in bash's argv. Only match a proxy executable,
+// never the enclosing runner whose script contains the same launch command.
+export function noVncProxyProcessPattern(port: number | string): string {
+  return `^(([^ ]*/)?(bash|sh) +)?([^ ]*/)?novnc_proxy +.*--listen +${port}( |$)`;
+}
+
 export function allocateExtraDisplayCommand(screenKey: string, leaseId?: string): string {
   const key = createHash("sha256").update(screenKey).digest("hex");
   const owner = leaseId ?? "";
@@ -69,7 +75,7 @@ export function releaseExtraDisplayCommand(screenKey: string, leaseId?: string):
     // biome-ignore lint/suspicious/noTemplateCurlyInString: POSIX parameter expansion in the remote shell script
     'case "$current" in *:*) rest=${current##*:}; case "$rest" in \'\'|*[!0-9]*) ;; *) current_fence=$rest; current_owner=${current%:*}; esac ;; esac',
     '[ -z "$owner" ] || [ "$current" = "$owner" ] || { [ "$incoming_owner" = "$current_owner" ] && [ "$incoming_fence" -ge "$current_fence" ]; } || { printf \'RAKAZO_SCREEN_RELEASE=stale\\n\'; exit 0; }',
-    'if [ "$index" -ne 0 ]; then display_number=$((index + 1)); view_port=$((6080 + index * 2)); control_port=$((6081 + index * 2)); view_vnc_port=$((5900 + index * 2)); control_vnc_port=$((5901 + index * 2)); pkill -f "Xvfb :$display_number -screen" || true; pkill -f "HOME=/tmp/fluxbox-home-$display_number DISPLAY=:$display_number fluxbox" || true; pkill -f -- "chromium-screen-$display_number" || true; pkill -f "(^|/)x11vnc .* -rfbport $view_vnc_port" || true; pkill -f "(^|/)x11vnc .* -rfbport $control_vnc_port" || true; pkill -f "^/usr/bin/python3 .*websockify.*$view_port" || true; pkill -f "novnc_proxy.*--listen $view_port" || true; pkill -f "^/usr/bin/python3 .*websockify.*$control_port" || true; pkill -f "novnc_proxy.*--listen $control_port" || true; rm -f "/tmp/.X$display_number-lock" "/tmp/.X11-unix/X$display_number" "/tmp/rakazo/control-token-$display_number" "/tmp/rakazo/view-password-$display_number" "/tmp/rakazo-view-$display_number.vncpass" "/tmp/rakazo-control-$display_number.vncpass" "/tmp/rakazo/screen-$display_number.lock"; fi',
+    `if [ "$index" -ne 0 ]; then display_number=$((index + 1)); view_port=$((6080 + index * 2)); control_port=$((6081 + index * 2)); view_vnc_port=$((5900 + index * 2)); control_vnc_port=$((5901 + index * 2)); pkill -f "Xvfb :$display_number -screen" || true; pkill -f "HOME=/tmp/fluxbox-home-$display_number DISPLAY=:$display_number fluxbox" || true; pkill -f -- "chromium-screen-$display_number" || true; pkill -f "(^|/)x11vnc .* -rfbport $view_vnc_port" || true; pkill -f "(^|/)x11vnc .* -rfbport $control_vnc_port" || true; pkill -f "^/usr/bin/python3 .*websockify.*$view_port" || true; pkill -f "${noVncProxyProcessPattern("$view_port")}" || true; pkill -f "^/usr/bin/python3 .*websockify.*$control_port" || true; pkill -f "${noVncProxyProcessPattern("$control_port")}" || true; rm -f "/tmp/.X$display_number-lock" "/tmp/.X11-unix/X$display_number" "/tmp/rakazo/control-token-$display_number" "/tmp/rakazo/view-password-$display_number" "/tmp/rakazo-view-$display_number.vncpass" "/tmp/rakazo-control-$display_number.vncpass" "/tmp/rakazo/screen-$display_number.lock"; fi`,
     'rm -f "$slot"',
     "printf 'RAKAZO_SCREEN_RELEASE=%s\\n' \"$index\"",
   ].join("; ");
@@ -163,7 +169,7 @@ export function ensureExtraDisplayCommand(
     `fi`,
     `pkill -f '(^|/)x11vnc .* -rfbport ${layout.viewVncPort}' || true`,
     `pkill -f '^/usr/bin/python3 .*websockify.*${layout.viewPort}' || true`,
-    `pkill -f 'novnc_proxy.*--listen ${layout.viewPort}' || true`,
+    `pkill -f '${noVncProxyProcessPattern(layout.viewPort)}' || true`,
     `x11vnc -storepasswd "$view_password" ${shellQuote(passwordAuthFile)} >/dev/null`,
     `x11vnc -display ${layout.display} -forever -shared -viewonly -rfbauth ${shellQuote(passwordAuthFile)} -listen 127.0.0.1 -rfbport ${layout.viewVncPort} -xkb -ncache 0 >${log}-x11vnc.log 2>&1 &`,
     `if command -v websockify >/dev/null 2>&1; then`,
@@ -227,7 +233,7 @@ export function extraDisplayControlStopCommand(
     // Anchor to the x11vnc binary (path-prefixed OK); avoid unanchored matches that hit the runner argv.
     `pkill -f '(^|/)x11vnc .* -rfbport ${layout.controlVncPort}' || true`,
     `pkill -f '^/usr/bin/python3 .*websockify.*${layout.controlPort}' || true`,
-    `pkill -f 'novnc_proxy.*--listen ${layout.controlPort}' || true`,
+    `pkill -f '${noVncProxyProcessPattern(layout.controlPort)}' || true`,
     `rm -f /tmp/rakazo-control-${layout.displayNumber}.vncpass`,
     `rm -f /tmp/rakazo/control-token-${layout.displayNumber}`,
   ].join("; ");
@@ -328,7 +334,7 @@ export function extraDisplayInputCommand(layout: ExtraDisplayLayout, input: Comp
 export function primaryStreamCleanupCommand(primaryViewPort = 6080): string {
   return [
     "pkill -f '(^|/)x11vnc .* -R viewonly' || true",
-    `pkill -f '[n]ovnc_proxy.*${primaryViewPort}' || true`,
+    `pkill -f '${noVncProxyProcessPattern(primaryViewPort)}' || true`,
     `pkill -f '[w]ebsockify.*${primaryViewPort}' || true`,
   ].join("; ");
 }


### PR DESCRIPTION
Computer screen startup could terminate its own shell process, and concurrent E2B reconnects could replace an active sandbox handle. Users saw an empty panel because screen connection errors were discarded. Box checkpoints could also fail when browser files exceeded the JSON file API limit.

This change scopes E2B stream cleanup to the intended processes, reuses authenticated view streams across reconnects, serializes competing connection requests, and shows screen failures with a retry action. Box workspace transfers use the binary artifact endpoint with bounded downloads and safe error details. Replacing a computer restores its saved workspace, and production honors the configured sandbox provider.

Validation: targeted adapter, lifecycle, configuration, and web unit tests pass; type checks and the web production build pass. A targeted Chromium E2E passes with a fake provider and disposable database, covering preview/full-window errors and recovery. The live E2B desktop and mouse control were verified after deployment. CI screenshot coverage is included in the new screen connection error test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer computer-screen error states in preview and full-screen views, with a **Retry screen** option.
  * Improved support for large file transfers through the Box sandbox provider.
  * Added flexible sandbox-provider configuration for production deployments.
* **Bug Fixes**
  * Improved computer reconnect reliability, workspace restoration, and cleanup after failed reconnects.
  * Improved screen and control-stream startup reliability when multiple views are active.
  * Sanitized provider error messages to prevent credentials, tokens, and sensitive URLs from being exposed.
* **Tests**
  * Expanded coverage for screen failures, reconnect scenarios, large files, provider errors, and display handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

CI screenshots: [Preview error](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33776774786-1/screenshots/images/103-computer-screen-connection-error.png) · [Full-window error](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33776774786-1/screenshots/images/102-computer-full-screen-connection-error.png).
