### PR TITLE
Simplify onboarding: one-click first bot and compact model Select

### DIFF
--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -336,8 +336,13 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await expect(composer).toHaveAttribute("placeholder", "Message Chief");
   await expect(page.getByRole("button", { name: "Send", exact: true })).toBeVisible();
   await composer.fill("Use the newer report and keep the answer short.");
+  const send = page.getByRole("button", { name: "Send", exact: true });
+  // While a run is active, Stop sits in the tab order before Send.
   await page.keyboard.press("Tab");
-  await expect(page.getByRole("button", { name: "Send", exact: true })).toBeFocused();
+  if (!(await send.evaluate((el) => el === document.activeElement).catch(() => false))) {
+    await page.keyboard.press("Tab");
+  }
+  await expect(send).toBeFocused();
   await page.keyboard.press("Enter");
   await expect(
     page.getByTestId("transcript").getByText("Use the newer report and keep the answer short."),

--- a/apps/web/e2e/onboarding-first-bot.spec.ts
+++ b/apps/web/e2e/onboarding-first-bot.spec.ts
@@ -47,6 +47,7 @@ test("first bot continues with a prefilled name in one click", async ({ page }, 
 
   const created = page.waitForResponse(
     (response) => response.url().includes("/rpc/bots/create") && response.ok(),
+    { timeout: 20_000 },
   );
   await page.getByRole("button", { name: "Continue" }).click();
   await created;

--- a/apps/web/e2e/onboarding-first-bot.spec.ts
+++ b/apps/web/e2e/onboarding-first-bot.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, signup } from "./helpers";
+
+test("connect model uses a compact provider Select", async ({ page }, testInfo) => {
+  await page.route("**/rpc/me", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as { json: Record<string, unknown> };
+    await route.fulfill({
+      response,
+      json: { json: { ...body.json, needsModel: true } },
+    });
+  });
+
+  const stamp = Date.now();
+  await signup(page, `connect-model-${stamp}@rakazo.test`, "password12", `Connect model ${stamp}`);
+
+  await expect(page.getByRole("heading", { name: "Connect a model" })).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByRole("combobox", { name: "Provider" })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Model", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Show all providers" })).toBeHidden();
+  await captureScreenshot(page, testInfo, "01-connect-model");
+});
+
+test("first bot continues with a prefilled name in one click", async ({ page }, testInfo) => {
+  await page.route("**/rpc/me", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as { json: Record<string, unknown> };
+    await route.fulfill({
+      response,
+      json: { json: { ...body.json, needsModel: false } },
+    });
+  });
+
+  const stamp = Date.now();
+  await signup(page, `first-bot-${stamp}@rakazo.test`, "password12", `First bot ${stamp}`);
+
+  await expect(page.getByRole("heading", { name: "Create your first bot" })).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByRole("heading", { name: "Connect a model" })).toBeHidden();
+  const name = page.locator("label:has-text('Name') input");
+  await expect(name).toHaveValue("Assistant");
+  await expect(page.getByRole("button", { name: "Continue" })).toBeEnabled();
+  await captureScreenshot(page, testInfo, "02-create-first-bot");
+
+  const created = page.waitForResponse(
+    (response) => response.url().includes("/rpc/bots/create") && response.ok(),
+  );
+  await page.getByRole("button", { name: "Continue" }).click();
+  await created;
+  await page.waitForURL(/\/app\//, { timeout: 20_000 });
+  await expect(page.getByText("Assistant").first()).toBeVisible();
+  await captureScreenshot(page, testInfo, "03-onboarding-complete");
+});

--- a/apps/web/e2e/onboarding-model-auto-skip.spec.ts
+++ b/apps/web/e2e/onboarding-model-auto-skip.spec.ts
@@ -26,5 +26,6 @@ test("onboarding skips model connect when a default model is already available",
   });
   await expect(page.getByRole("heading", { name: "Connect a model" })).toBeHidden();
   await expect(page.getByRole("button", { name: "Skip for now" })).toBeHidden();
+  await expect(page.locator("label:has-text('Name') input")).toHaveValue("Assistant");
   await captureScreenshot(page, testInfo, "onboarding-model-auto-skip");
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -19,47 +19,21 @@ test("onboarding model list never labels an older model the latest one", async (
     timeout: 20_000,
   });
 
-  await expect(page.getByRole("button", { name: /OpenRouter/ })).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
-  await expect(page.getByRole("button", { name: /ChatGPT.*ChatGPT Plus\/Pro/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Vercel AI Gateway/ })).toBeVisible();
-  await captureScreenshot(page, testInfo, "onboarding-popular-providers");
-  await page.getByRole("button", { name: "Show all providers" }).click();
-  await page.getByPlaceholder("Search providers and models").fill("anthropic");
-  await expect(page.getByRole("button", { name: /OpenRouter/ })).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
-  await page
-    .getByRole("button", { name: /Anthropic/ })
-    .first()
-    .click();
-  await expect(page.getByRole("button", { name: /Anthropic/ }).first()).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
+  await page.getByRole("combobox", { name: "Provider" }).click();
+  await page.getByRole("option", { name: "Anthropic" }).click();
 
   const models = page.getByRole("combobox", { name: "Model", exact: true });
-  const labels = await models.getByRole("option").allTextContents();
+  await models.click();
+  const options = page.getByRole("listbox").getByRole("option");
+  const labels = await options.allTextContents();
   // "latest" is an upstream alias marker, so it lands on families like Claude Opus 4.5 while
   // newer models carry no marker. Rendered as-is it tells the user the opposite of the truth.
   expect(labels.filter((label) => /\blatest\b/i.test(label))).toEqual([]);
 
-  // Select a non-default model before filtering the active provider out of the results.
+  // Select the alias so the closed picker shows the rewritten label in the screenshot.
   const alias = labels.find((label) => label.includes("(auto-updates)"));
   expect(alias).toBeTruthy();
-  await models.selectOption({ label: alias! });
-  const selectedModelId = await models.inputValue();
-
-  await page.getByPlaceholder("Search providers and models").fill("no-provider-or-model");
-  const selectedProvider = page.getByRole("button", { name: /Anthropic.*Selected/ });
-  await expect(selectedProvider).toHaveAttribute("aria-pressed", "true");
-  await expect(page.getByText("No providers found")).toBeVisible();
-  await selectedProvider.click();
-  await expect(models).toHaveValue(selectedModelId);
-  await page.getByPlaceholder("Search providers and models").fill("anthropic");
+  await options.filter({ hasText: alias! }).click();
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3322,3 +3322,9 @@ msgstr "Executor verbinden"
 msgid "Executor token"
 msgstr "Executor-Token"
 
+
+msgid "Assistant"
+msgstr "Assistent"
+
+msgid "Choose a model to get started."
+msgstr "Wähle zunächst ein Modell aus."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3322,3 +3322,9 @@ msgstr "Connect Executor"
 msgid "Executor token"
 msgstr "Executor token"
 
+
+msgid "Assistant"
+msgstr "Assistant"
+
+msgid "Choose a model to get started."
+msgstr "Choose a model to get started."

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3282,3 +3282,9 @@ msgstr "Conectar Executor"
 msgid "Executor token"
 msgstr "Token de Executor"
 
+
+msgid "Assistant"
+msgstr "Asistente"
+
+msgid "Choose a model to get started."
+msgstr "Elige un modelo para empezar."

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3322,3 +3322,9 @@ msgstr "Executor कनेक्ट करें"
 msgid "Executor token"
 msgstr "Executor टोकन"
 
+
+msgid "Assistant"
+msgstr "सहायक"
+
+msgid "Choose a model to get started."
+msgstr "शुरू करने के लिए एक मॉडल चुनें।"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3322,3 +3322,9 @@ msgstr "Executor 연결"
 msgid "Executor token"
 msgstr "Executor 토큰"
 
+
+msgid "Assistant"
+msgstr "어시스턴트"
+
+msgid "Choose a model to get started."
+msgstr "먼저 사용할 AI 모델을 선택하세요."

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3322,3 +3322,9 @@ msgstr "Conectar Executor"
 msgid "Executor token"
 msgstr "Token do Executor"
 
+
+msgid "Assistant"
+msgstr "Assistente"
+
+msgid "Choose a model to get started."
+msgstr "Escolha um modelo para começar."

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3322,3 +3322,9 @@ msgstr "Executor'a bağlan"
 msgid "Executor token"
 msgstr "Executor belirteci"
 
+
+msgid "Assistant"
+msgstr "Asistan"
+
+msgid "Choose a model to get started."
+msgstr "Başlamak için bir model seç."

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3322,3 +3322,9 @@ msgstr "连接 Executor"
 msgid "Executor token"
 msgstr "Executor 令牌"
 
+
+msgid "Assistant"
+msgstr "助手"
+
+msgid "Choose a model to get started."
+msgstr "选择一个模型开始。"

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -4,27 +4,27 @@ import {
   openAiCompatibleConnectReady,
   openAiCompatibleProbeSuccessMessage,
 } from "@rakazo/contracts";
-import {
-  createModelProbe,
-  featuredModelProviders,
-  initialModelProbeState,
-  selectedProviderOutsideSearchResults,
-} from "@rakazo/core";
+import { createModelProbe, initialModelProbeState } from "@rakazo/core";
 import {
   Button,
   Input,
   ModelThinkingOptions,
-  NativeSelect,
-  NativeSelectOption,
-  Textarea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@rakazo/ui-web";
-import { Check } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { localizedProviderHint } from "../lib/localized-provider-hint";
 import type { ModelCatalogEntry } from "../lib/model-auth";
 import { rpc } from "../lib/rpc";
 import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
+
+function providerLabel(entry: ModelCatalogEntry): string {
+  if (entry.provider === "openai-codex") return "ChatGPT";
+  return entry.providerName ?? entry.provider;
+}
 
 export function OnboardingPage() {
   const { t } = useLingui();
@@ -32,8 +32,6 @@ export function OnboardingPage() {
   const fieldId = useId();
   const [step, setStep] = useState<"loading" | "model" | "bot">("loading");
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
-  const [query, setQuery] = useState("");
-  const [showAllProviders, setShowAllProviders] = useState(false);
   const [provider, setProvider] = useState("openrouter");
   const [modelId, setModelId] = useState("deepseek/deepseek-v4-flash-0731");
   const [apiKey, setApiKey] = useState("");
@@ -43,9 +41,7 @@ export function OnboardingPage() {
     useState(initialModelProbeState);
   const [modelProbe] = useState(() => createModelProbe(setProbe));
   const resetOpenAiCompatibleProbe = modelProbe.reset;
-  const [name, setName] = useState("");
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
+  const [name, setName] = useState(() => t`Assistant`);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -95,41 +91,36 @@ export function OnboardingPage() {
     return [...seen.values()];
   }, [catalog]);
 
-  const filteredProviders = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return providers;
-    const matching = new Set(
-      catalog
-        .filter((entry) =>
-          `${entry.provider} ${entry.providerName ?? ""} ${entry.label} ${entry.id} ${entry.billing} ${entry.oauthLabel ?? ""}`
-            .toLowerCase()
-            .includes(q),
-        )
-        .map((entry) => entry.provider),
-    );
-    return providers.filter((entry) => matching.has(entry.provider));
-  }, [catalog, providers, query]);
-
-  const displayedProviders = useMemo(
-    () => (showAllProviders ? filteredProviders : featuredModelProviders(providers, provider)),
-    [filteredProviders, provider, providers, showAllProviders],
-  );
-
-  const selectedProviderOutsideResults = useMemo(
+  const providerItems = useMemo(
     () =>
-      showAllProviders
-        ? selectedProviderOutsideSearchResults(filteredProviders, providers, provider)
-        : undefined,
-    [filteredProviders, provider, providers, showAllProviders],
+      providers.map((entry) => ({
+        value: entry.provider,
+        label: providerLabel(entry),
+      })),
+    [providers],
   );
-
-  const providerRows = selectedProviderOutsideResults
-    ? [selectedProviderOutsideResults, ...displayedProviders]
-    : displayedProviders;
 
   const modelsForProvider = useMemo(
     () => catalog.filter((entry) => entry.provider === provider),
     [catalog, provider],
+  );
+
+  const modelItems = useMemo(
+    () =>
+      modelsForProvider.map((entry) => ({
+        value: entry.id,
+        label: entry.label,
+      })),
+    [modelsForProvider],
+  );
+
+  const otherProbeModelValue = "__other__";
+  const probeModelItems = useMemo(
+    () => [
+      ...probeModels.map((id) => ({ value: id, label: id })),
+      { value: otherProbeModelValue, label: t`Other model…` },
+    ],
+    [probeModels, t],
   );
 
   const selected = modelsForProvider.find((entry) => entry.id === modelId) ?? modelsForProvider[0];
@@ -142,6 +133,23 @@ export function OnboardingPage() {
     modelId,
     probedBaseUrl,
   });
+
+  function selectProvider(nextProvider: string | null) {
+    if (!nextProvider || nextProvider === provider) return;
+    cancelOAuthAttempt();
+    setProvider(nextProvider);
+    setApiKey("");
+    setModelId(
+      nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID
+        ? ""
+        : (catalog.find((item) => item.provider === nextProvider)?.id ?? ""),
+    );
+    setBaseUrl("");
+    setReasoning(false);
+    resetOpenAiCompatibleProbe();
+    setError(null);
+    setNotice(null);
+  }
 
   function updateBaseUrl(nextBaseUrl: string) {
     setBaseUrl(nextBaseUrl);
@@ -211,9 +219,9 @@ export function OnboardingPage() {
     try {
       const bot = await rpc.bots.create({
         name: name.trim(),
-        title,
-        description,
-        instructions: description,
+        title: "",
+        description: "",
+        instructions: "",
         notifyOnFinish: true,
       });
       // Onboarding continues conversationally in the thread: greeting first,
@@ -244,103 +252,31 @@ export function OnboardingPage() {
             <h1 className="text-[32px] font-medium text-foreground">
               <Trans>Connect a model</Trans>
             </h1>
-            <div className="mt-8 flex items-center justify-between gap-4">
-              <p className="text-sm font-medium text-foreground">
+            <p className="mt-2 text-muted-foreground">
+              <Trans>Choose a model to get started.</Trans>
+            </p>
+            <div className="mt-8 block text-sm text-foreground">
+              <span className="font-medium">
                 <Trans>Provider</Trans>
-              </p>
-              <Button
-                variant="link"
-                size="xs"
-                className="px-0 text-muted-foreground"
-                onClick={() => {
-                  setShowAllProviders((current) => !current);
-                  setQuery("");
-                }}
+              </span>
+              <Select
+                items={providerItems}
+                value={provider}
+                onValueChange={(value) => selectProvider(value)}
               >
-                {showAllProviders ? (
-                  <Trans>Show popular providers</Trans>
-                ) : (
-                  <Trans>Show all providers</Trans>
-                )}
-              </Button>
+                <SelectTrigger aria-label={t`Provider`} className="mt-2 w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent alignItemWithTrigger={false}>
+                  {providerItems.map((entry) => (
+                    <SelectItem key={entry.value} value={entry.value}>
+                      {entry.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
-            {showAllProviders ? (
-              <Input
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                aria-label={t`Search providers and models`}
-                placeholder={t`Search providers and models`}
-                className="mt-3"
-              />
-            ) : null}
-            <fieldset
-              aria-label={t`Model providers`}
-              className={`mt-3 overflow-y-auto rounded-xl border border-border ${
-                showAllProviders ? "max-h-64" : ""
-              }`}
-            >
-              {providerRows.map((entry) => {
-                const isSelected = entry.provider === provider;
-                const isOutsideSearchResults =
-                  entry.provider === selectedProviderOutsideResults?.provider;
-                return (
-                  <button
-                    key={entry.provider}
-                    type="button"
-                    aria-pressed={isSelected}
-                    onClick={() => {
-                      if (isSelected) return;
-                      cancelOAuthAttempt();
-                      setProvider(entry.provider);
-                      setModelId(
-                        entry.provider === OPENAI_COMPATIBLE_PROVIDER_ID
-                          ? ""
-                          : (catalog.find((item) => item.provider === entry.provider)?.id ?? ""),
-                      );
-                      setBaseUrl("");
-                      setReasoning(false);
-                      resetOpenAiCompatibleProbe();
-                      setError(null);
-                      setNotice(null);
-                    }}
-                    className={`flex min-h-11 w-full items-center gap-3 border-b border-border px-3.5 py-2.5 text-left last:border-0 ${
-                      isSelected ? "bg-muted" : "hover:bg-accent"
-                    }`}
-                  >
-                    <span className="flex min-w-0 flex-1 items-center gap-2">
-                      <span
-                        className={`truncate text-[15px] text-foreground ${isSelected ? "font-medium" : ""}`}
-                      >
-                        {entry.provider === "openai-codex"
-                          ? "ChatGPT"
-                          : (entry.providerName ?? entry.provider)}
-                      </span>
-                      {isOutsideSearchResults ? (
-                        <span className="shrink-0 text-[11px] text-muted-foreground">
-                          <Trans>Selected</Trans>
-                        </span>
-                      ) : null}
-                    </span>
-                    <span className="text-[12px] text-muted-foreground">
-                      {localizedProviderHint(entry)}
-                    </span>
-                    <span className="flex size-5 shrink-0 items-center justify-center" aria-hidden>
-                      {isSelected ? (
-                        <span className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                          <Check className="size-3" strokeWidth={2.5} />
-                        </span>
-                      ) : null}
-                    </span>
-                  </button>
-                );
-              })}
-              {displayedProviders.length === 0 ? (
-                <p className="px-3.5 py-6 text-center text-sm text-muted-foreground">
-                  <Trans>No providers found</Trans>
-                </p>
-              ) : null}
-            </fieldset>
-            <div className="mt-6 block text-sm text-foreground">
+            <div className="mt-4 block text-sm text-foreground">
               {isOpenAiCompatible ? (
                 <>
                   <label htmlFor={`${fieldId}-base-url`} className="block font-medium">
@@ -377,21 +313,28 @@ export function OnboardingPage() {
                       <Trans>Model</Trans>
                     </span>
                     {probeModels.length && probeModels.includes(modelId) ? (
-                      <NativeSelect
+                      <Select
+                        items={probeModelItems}
                         value={modelId}
-                        onChange={(e) => setModelId(e.target.value)}
-                        aria-label={t`Models from server`}
-                        className="mt-2 w-full"
+                        onValueChange={(value) => {
+                          if (!value || value === otherProbeModelValue) {
+                            setModelId("");
+                            return;
+                          }
+                          setModelId(value);
+                        }}
                       >
-                        {probeModels.map((id) => (
-                          <NativeSelectOption key={id} value={id}>
-                            {id}
-                          </NativeSelectOption>
-                        ))}
-                        <NativeSelectOption value="">
-                          <Trans>Other model…</Trans>
-                        </NativeSelectOption>
-                      </NativeSelect>
+                        <SelectTrigger aria-label={t`Models from server`} className="mt-2 w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent alignItemWithTrigger={false}>
+                          {probeModelItems.map((entry) => (
+                            <SelectItem key={entry.value} value={entry.value}>
+                              {entry.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     ) : (
                       <Input
                         value={modelId}
@@ -424,21 +367,26 @@ export function OnboardingPage() {
                   <span className="font-medium">
                     <Trans>Model</Trans>
                   </span>
-                  <NativeSelect
+                  <Select
+                    items={modelItems}
                     value={selected?.id ?? modelId}
-                    onChange={(e) => {
+                    onValueChange={(value) => {
+                      if (!value) return;
                       cancelOAuthAttempt();
-                      setModelId(e.target.value);
+                      setModelId(value);
                     }}
-                    aria-label={t`Model`}
-                    className="mt-2 w-full"
                   >
-                    {modelsForProvider.map((entry) => (
-                      <NativeSelectOption key={`${entry.provider}:${entry.id}`} value={entry.id}>
-                        {entry.label}
-                      </NativeSelectOption>
-                    ))}
-                  </NativeSelect>
+                    <SelectTrigger aria-label={t`Model`} className="mt-2 w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent alignItemWithTrigger={false}>
+                      {modelItems.map((entry) => (
+                        <SelectItem key={entry.value} value={entry.value}>
+                          {entry.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </>
               )}
             </div>
@@ -578,33 +526,6 @@ export function OnboardingPage() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t`Name this bot`}
-                className="mt-2"
-              />
-            </label>
-            <label
-              htmlFor={`${fieldId}-title`}
-              className="mt-4 block text-sm text-muted-foreground"
-            >
-              <Trans>Title</Trans>
-              <Input
-                id={`${fieldId}-title`}
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder={t`Describe what this bot does`}
-                className="mt-2"
-              />
-            </label>
-            <label
-              htmlFor={`${fieldId}-description`}
-              className="mt-4 block text-sm text-muted-foreground"
-            >
-              <Trans>Description</Trans>
-              <Textarea
-                id={`${fieldId}-description`}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder={t`What this bot is for`}
-                rows={4}
                 className="mt-2"
               />
             </label>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

First-run onboarding still asked new users to fill a blank bot form and pick a model from a heavy provider list. That slows people down before they ever talk to a bot. Prefilling a sensible name and swapping the list for a compact Select gets them into chat faster with less visual noise.

Fixes #553.

## What changed

- First bot: default name is `Assistant` (localized). Continue works without typing. Name stays editable. Title and description fields removed from this step.
- Model step: replaced the featured/search provider list with the existing shadcn `Select` for provider and model. Short line: "Choose a model to get started." Clears the API key when the provider changes.
- Kept `#569` behavior: when a default model already exists, skip Connect a model and land on Create your first bot.
- Kept conversational start/`promptFocus` after create so first-run still lands in chat. `#707` computer-mode picker is unchanged (post-onboarding create only).
- Advanced thinking options stay behind progressive disclosure for OpenAI-compatible servers.
- E2E: `onboarding-first-bot.spec.ts` covers connect-model Select frames and one-click first bot into chat. Model-labels and auto-skip specs updated for Select and prefilled Assistant.

## How tested

- `pnpm --filter @rakazo/web check`
- `pnpm exec biome check` on touched files
- Locale catalogs updated for Assistant and model-step copy
- CI Web E2E green on tip `ada28fe7` (81 passed)

## Screenshots

Gallery: [PR #574 screenshots](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/574/index.html)

- Connect model (Select): [01-connect-model](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34046509543-1/screenshots/images/001-01-connect-model.png)
- Create first bot (prefilled): [02-create-first-bot](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34046509543-1/screenshots/images/008-02-create-first-bot.png)
- Onboarding complete: [03-onboarding-complete](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34046509543-1/screenshots/images/018-03-onboarding-complete.png)

<img alt="Connect model" src="https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34046509543-1/screenshots/images/001-01-connect-model.png" />
<img alt="Create first bot" src="https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34046509543-1/screenshots/images/008-02-create-first-bot.png" />

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34568689-03d0-422c-ba91-2514cc67e2e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34568689-03d0-422c-ba91-2514cc67e2e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Simplified onboarding with provider and model dropdowns.
  - Bot creation now starts with the localized name “Assistant.”
  - Added localized onboarding text, including model-selection guidance, across supported languages.
  - Switching providers clears the previously entered API key.

- **Changes**
  - Streamlined bot setup by removing title and description fields; these values now start empty.
  - Removed provider search and the option to show all providers.

- **Tests**
  - Expanded onboarding coverage for model selection, automatic skipping, default bot naming, and bot creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->