### PR TITLE
docs(self-host): slim OpenAI-compatible public gate note

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -170,19 +170,16 @@ RAKAZO_LOCAL_CONTEXT_WINDOW=32768
 RAKAZO_LOCAL_MAX_TOKENS=4096
 ```
 
-The loopback default is suitable when running Rakazo from a source checkout. In Docker Compose,
-use the model server's Compose service name or another address reachable from the containers.
+The loopback default is suitable when running Rakazo from a source checkout. From containers,
+prefer `host.docker.internal` or a stable LAN RFC1918 address (not Compose service DNS alone).
 Only configure an endpoint you control: prompts, attachments, and tool results sent to that model
 leave Rakazo through this URL. Leave `RAKAZO_LOCAL_MODELS` blank to disable the provider.
 
 Each user can also connect their own OpenAI-compatible endpoint from **Connect a model** /
 **Settings → Models** on web and mobile. Choose **OpenAI-compatible**, enter the server base URL
-(for example `http://127.0.0.1:8000/v1` for Rapid-MLX, Ollama, LM Studio, llama.cpp, or vLLM),
-the exact model id from that server, and an optional API key. By default Rakazo only allows
-loopback, RFC1918, and `host.docker.internal` targets. To permit public hostnames, set
-`RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1` in the deployment environment. Public hostnames must resolve
-only to public addresses; redirects and DNS answers that reach private or link-local networks are
-rejected.
+(for example `http://127.0.0.1:8000/v1`), the exact model id, and an optional API key.
+Public hosts need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1`. Private, loopback, and
+`host.docker.internal` targets do not.
 
 For servers that accept standard `reasoning_effort`, enable **Supports thinking** under
 **Advanced** when connecting. The setting is saved on the connection (no env var or restart).

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -51,6 +51,8 @@ SANDBOX_PROVIDER=docker
 # Optional model / integration keys
 OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
+# User-connected public OpenAI-compatible hosts need =1 (default: private/loopback only).
+# RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=
 
 # Optional outbound HTTP(S) proxy for api/worker containers (Mainland / corporate).
 # Leave blank unless you need egress through a proxy. Uppercase or lowercase keys work.


### PR DESCRIPTION
## Summary
- Self-host operators can already connect OpenAI-compatible models in the UI. Public hostnames stay blocked unless `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1` (SSRF).
- Published-images `.env` templates do not mention that gate, so a working VPS can still fail with “Public model endpoints are blocked”.
- Adds one operator page only. No runtime, default, or compose change.

## How to use
1. Set `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1` on the deployment when you need a **public** endpoint (explicit operator choice).
2. Connect a model → OpenAI-compatible → base URL + model id + optional API key.
3. Examples use only `https://api.example.com/v1` and `my-model-id`. If the URL already ends with `/vN`, Rakazo does not append another `/v1`.
4. Private reverse proxies (RFC1918 / localhost / `host.docker.internal`) do **not** need the gate.

## Out of scope
- Messaging surfaces
- Image pull / installer / compose
- Vendor presets or regional SKUs
- Changing the default SSRF gate

## Test plan
- [x] Diff is a single new Markdown file
- [x] No vendor hostnames / CDN / mirror domains
- [x] Gate documented as default-off with SSRF rationale
- [x] Private proxy path documented without the gate
- [x] Docs-only CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated self-hosting guidance for configuring local and user-connected OpenAI-compatible endpoints.
  - Clarified container endpoint recommendations and when public hostnames require explicit permission.
  - Added the public-endpoint setting to the example environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->