### PR TITLE
Recover stale web assets after deploys

### DIFF
--- a/apps/web/src/lib/preload-recovery.test.ts
+++ b/apps/web/src/lib/preload-recovery.test.ts
@@ -23,7 +23,7 @@ describe("preload recovery", () => {
     return { listener: () => listener, reload };
   }
 
-  it("reloads once and suppresses failures during the same navigation", () => {
+  it("reloads once without suppressing another failure during navigation", () => {
     const { listener, reload } = createTarget();
     const first = new Event("vite:preloadError", { cancelable: true });
     const second = new Event("vite:preloadError", { cancelable: true });
@@ -31,7 +31,7 @@ describe("preload recovery", () => {
     listener()?.(second);
 
     expect(first.defaultPrevented).toBe(true);
-    expect(second.defaultPrevented).toBe(true);
+    expect(second.defaultPrevented).toBe(false);
     expect(reload).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/src/lib/preload-recovery.test.ts
+++ b/apps/web/src/lib/preload-recovery.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { installPreloadRecovery } from "./preload-recovery";
+
+describe("preload recovery", () => {
+  it("reloads once when a stale lazy chunk fails", () => {
+    let listener: EventListener | undefined;
+    const store = new Map<string, string>();
+    const reload = vi.fn();
+    const target = {
+      addEventListener: (_type: string, next: EventListener) => {
+        listener = next;
+      },
+      clearTimeout: vi.fn(),
+      removeEventListener: vi.fn(),
+      location: { reload },
+      sessionStorage: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => store.set(key, value),
+        removeItem: (key: string) => store.delete(key),
+      },
+      setTimeout: vi.fn(() => 1),
+    };
+
+    installPreloadRecovery(target as unknown as Window);
+    const first = new Event("vite:preloadError", { cancelable: true });
+    listener?.(first);
+    listener?.(new Event("vite:preloadError", { cancelable: true }));
+
+    expect(first.defaultPrevented).toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/lib/preload-recovery.test.ts
+++ b/apps/web/src/lib/preload-recovery.test.ts
@@ -23,10 +23,12 @@ describe("preload recovery", () => {
 
     installPreloadRecovery(target as unknown as Window);
     const first = new Event("vite:preloadError", { cancelable: true });
+    const second = new Event("vite:preloadError", { cancelable: true });
     listener?.(first);
-    listener?.(new Event("vite:preloadError", { cancelable: true }));
+    listener?.(second);
 
     expect(first.defaultPrevented).toBe(true);
+    expect(second.defaultPrevented).toBe(false);
     expect(reload).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/lib/preload-recovery.test.ts
+++ b/apps/web/src/lib/preload-recovery.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import { installPreloadRecovery } from "./preload-recovery";
 
 describe("preload recovery", () => {
-  it("reloads once when a stale lazy chunk fails", () => {
+  function createTarget(store = new Map<string, string>()) {
     let listener: EventListener | undefined;
-    const store = new Map<string, string>();
     const reload = vi.fn();
     const target = {
       addEventListener: (_type: string, next: EventListener) => {
@@ -20,15 +19,30 @@ describe("preload recovery", () => {
       },
       setTimeout: vi.fn(() => 1),
     };
-
     installPreloadRecovery(target as unknown as Window);
+    return { listener: () => listener, reload };
+  }
+
+  it("reloads once and suppresses failures during the same navigation", () => {
+    const { listener, reload } = createTarget();
     const first = new Event("vite:preloadError", { cancelable: true });
     const second = new Event("vite:preloadError", { cancelable: true });
-    listener?.(first);
-    listener?.(second);
+    listener()?.(first);
+    listener()?.(second);
 
     expect(first.defaultPrevented).toBe(true);
-    expect(second.defaultPrevented).toBe(false);
+    expect(second.defaultPrevented).toBe(true);
     expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("does not suppress a new failure after the recovery reload", () => {
+    const store = new Map([["rk:preload-recovery", "1"]]);
+    const { listener, reload } = createTarget(store);
+    const nextPageFailure = new Event("vite:preloadError", { cancelable: true });
+
+    listener()?.(nextPageFailure);
+
+    expect(nextPageFailure.defaultPrevented).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/preload-recovery.ts
+++ b/apps/web/src/lib/preload-recovery.ts
@@ -1,0 +1,35 @@
+const PRELOAD_RECOVERY_KEY = "rk:preload-recovery";
+const PRELOAD_RECOVERY_COOLDOWN_MS = 30_000;
+
+type PreloadRecoveryWindow = Pick<
+  Window,
+  | "addEventListener"
+  | "clearTimeout"
+  | "location"
+  | "removeEventListener"
+  | "sessionStorage"
+  | "setTimeout"
+>;
+
+/**
+ * Vite emits this event when a lazy chunk from an older deployment no longer
+ * exists. Reload once so the browser receives the current asset manifest.
+ */
+export function installPreloadRecovery(target: PreloadRecoveryWindow = window): () => void {
+  const clearRecovery = target.setTimeout(
+    () => target.sessionStorage.removeItem(PRELOAD_RECOVERY_KEY),
+    PRELOAD_RECOVERY_COOLDOWN_MS,
+  );
+  const onPreloadError = (event: Event) => {
+    event.preventDefault();
+    if (target.sessionStorage.getItem(PRELOAD_RECOVERY_KEY)) return;
+    target.sessionStorage.setItem(PRELOAD_RECOVERY_KEY, "1");
+    target.location.reload();
+  };
+
+  target.addEventListener("vite:preloadError", onPreloadError);
+  return () => {
+    target.clearTimeout(clearRecovery);
+    target.removeEventListener("vite:preloadError", onPreloadError);
+  };
+}

--- a/apps/web/src/lib/preload-recovery.ts
+++ b/apps/web/src/lib/preload-recovery.ts
@@ -21,8 +21,8 @@ export function installPreloadRecovery(target: PreloadRecoveryWindow = window): 
     PRELOAD_RECOVERY_COOLDOWN_MS,
   );
   const onPreloadError = (event: Event) => {
-    event.preventDefault();
     if (target.sessionStorage.getItem(PRELOAD_RECOVERY_KEY)) return;
+    event.preventDefault();
     target.sessionStorage.setItem(PRELOAD_RECOVERY_KEY, "1");
     target.location.reload();
   };

--- a/apps/web/src/lib/preload-recovery.ts
+++ b/apps/web/src/lib/preload-recovery.ts
@@ -16,13 +16,18 @@ type PreloadRecoveryWindow = Pick<
  * exists. Reload once so the browser receives the current asset manifest.
  */
 export function installPreloadRecovery(target: PreloadRecoveryWindow = window): () => void {
+  let reloading = false;
   const clearRecovery = target.setTimeout(
     () => target.sessionStorage.removeItem(PRELOAD_RECOVERY_KEY),
     PRELOAD_RECOVERY_COOLDOWN_MS,
   );
   const onPreloadError = (event: Event) => {
-    if (target.sessionStorage.getItem(PRELOAD_RECOVERY_KEY)) return;
+    if (target.sessionStorage.getItem(PRELOAD_RECOVERY_KEY)) {
+      if (reloading) event.preventDefault();
+      return;
+    }
     event.preventDefault();
+    reloading = true;
     target.sessionStorage.setItem(PRELOAD_RECOVERY_KEY, "1");
     target.location.reload();
   };

--- a/apps/web/src/lib/preload-recovery.ts
+++ b/apps/web/src/lib/preload-recovery.ts
@@ -16,18 +16,13 @@ type PreloadRecoveryWindow = Pick<
  * exists. Reload once so the browser receives the current asset manifest.
  */
 export function installPreloadRecovery(target: PreloadRecoveryWindow = window): () => void {
-  let reloading = false;
   const clearRecovery = target.setTimeout(
     () => target.sessionStorage.removeItem(PRELOAD_RECOVERY_KEY),
     PRELOAD_RECOVERY_COOLDOWN_MS,
   );
   const onPreloadError = (event: Event) => {
-    if (target.sessionStorage.getItem(PRELOAD_RECOVERY_KEY)) {
-      if (reloading) event.preventDefault();
-      return;
-    }
+    if (target.sessionStorage.getItem(PRELOAD_RECOVERY_KEY)) return;
     event.preventDefault();
-    reloading = true;
     target.sessionStorage.setItem(PRELOAD_RECOVERY_KEY, "1");
     target.location.reload();
   };

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2625
+#: src/pages/Shell.tsx:2639
 msgid " (unread)"
 msgstr " (ungelesen)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# Modell} other {# Modelle}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1885
+#: src/pages/Shell.tsx:1887
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (maximal {ATTACHMENT_MAX_COUNT} Anhänge)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1889
+#: src/pages/Shell.tsx:1891
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (über 10 MiB)"
 
@@ -63,16 +63,16 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:210
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2870
 msgid "{0} runs · {1} tokens"
 msgstr "{0} Läufe · {1} Tokens"
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3164
+#: src/pages/Shell.tsx:3181
 msgid "{0}'s screen"
 msgstr "{0}s Bildschirm"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "{botName}’s computer"
 msgstr "Computer von {botName}"
 
@@ -116,12 +116,12 @@ msgstr "{size} B"
 msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
-#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:3937
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} arbeitet"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4517
+#: src/pages/Shell.tsx:4535
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -158,8 +158,8 @@ msgstr "Aktives Modell"
 msgid "Active voice"
 msgstr "Aktive Stimme"
 
-#: src/pages/Shell.tsx:2374
-#: src/pages/Shell.tsx:2376
+#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2390
 msgid "Activity"
 msgstr "Aktivität"
 
@@ -173,7 +173,7 @@ msgstr "Hinzufügen"
 msgid "Add a model in Settings to use this."
 msgstr ""
 
-#: src/pages/Shell.tsx:3326
+#: src/pages/Shell.tsx:3343
 msgid "Add a run time for this one-shot."
 msgstr ""
 
@@ -181,7 +181,7 @@ msgstr ""
 msgid "Add a schedule or webhook to run this routine."
 msgstr ""
 
-#: src/pages/Shell.tsx:3298
+#: src/pages/Shell.tsx:3315
 msgid "Add a schedule or webhook trigger"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgstr "Remote-MCP-Server hinzufügen"
 msgid "Add server"
 msgstr "Server hinzufügen"
 
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4900
 msgid "Add thumbs-up"
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr "Erweitert"
 msgid "Advanced..."
 msgstr ""
 
-#: src/pages/Shell.tsx:2944
+#: src/pages/Shell.tsx:2958
 msgid "Agent computer"
 msgstr "Agent-Computer"
 
@@ -261,7 +261,7 @@ msgid "Agent connections"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:385
-#: src/pages/McpServersOverlay.tsx:448
+#: src/pages/McpServersOverlay.tsx:452
 msgid "Agents:"
 msgstr "Agents:"
 
@@ -333,9 +333,9 @@ msgstr ""
 #: src/pages/ModelSettingsOverlay.tsx:640
 #: src/pages/ModelSettingsOverlay.tsx:643
 #: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/Onboarding.tsx:440
-#: src/pages/Onboarding.tsx:443
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:514
+#: src/pages/Onboarding.tsx:517
+#: src/pages/Onboarding.tsx:531
 #: src/pages/VoiceSettingsOverlay.tsx:258
 msgid "API key"
 msgstr "API-Schlüssel"
@@ -367,15 +367,15 @@ msgstr "Genehmige diesen Server, damit dein Agent seine Tools verwenden kann."
 msgid "Archive"
 msgstr "Archivieren"
 
-#: src/pages/Shell.tsx:5220
+#: src/pages/Shell.tsx:5238
 msgid "archived"
 msgstr "archiviert"
 
-#: src/pages/Shell.tsx:2694
+#: src/pages/Shell.tsx:2708
 msgid "Archived"
 msgstr "Archiviert"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5249
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archiviert. Chat, Erinnerungen und Dateien bleiben erhalten."
 
@@ -425,16 +425,16 @@ msgstr "um {0}"
 msgid "at {timeSelect}"
 msgstr "um {timeSelect}"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4615
 msgid "Attach file"
 msgstr "Datei anhängen"
 
-#: src/pages/Shell.tsx:4841
+#: src/pages/Shell.tsx:4859
 msgid "Attachment"
 msgstr "Anhang"
 
 #: src/pages/ModelSettingsOverlay.tsx:573
-#: src/pages/Onboarding.tsx:389
+#: src/pages/Onboarding.tsx:463
 msgid "Authorization code or callback URL"
 msgstr "Autorisierungscode oder Callback-URL"
 
@@ -474,23 +474,19 @@ msgstr "Basis-URL"
 msgid "Bearer token"
 msgstr "Bearer-Token"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5446
 msgid "Booting live desktop…"
 msgstr "Live-Desktop wird gestartet…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3712
+#: src/pages/Shell.tsx:3729
 msgid "Booting up {0}’s computer"
 msgstr "Computer von {0} wird gestartet"
 
-#: src/pages/Shell.tsx:5080
-#: src/pages/Shell.tsx:5081
-#: src/pages/Shell.tsx:5224
+#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5099
+#: src/pages/Shell.tsx:5242
 msgid "bot"
-msgstr "Bot"
-
-#: src/pages/Shell.tsx:1680
-msgid "Bot"
 msgstr "Bot"
 
 #. js-lingui-explicit-id
@@ -498,11 +494,15 @@ msgstr "Bot"
 msgid "Bot"
 msgstr ""
 
-#: src/pages/Shell.tsx:3819
+#: src/pages/Shell.tsx:1682
+msgid "Bot"
+msgstr "Bot"
+
+#: src/pages/Shell.tsx:3836
 msgid "Bot screen"
 msgstr "Bot-Bildschirm"
 
-#: src/pages/Shell.tsx:3130
+#: src/pages/Shell.tsx:3144
 msgid "Bot screen preview"
 msgstr "Bot-Bildschirmvorschau"
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first. These preferences apply across all your bots."
 msgstr "Bots handeln standardmäßig ohne Nachfrage. Füge nur dann eine Ausnahme hinzu, wenn du eine Aktionsart zuerst prüfen möchtest. Diese Einstellungen gelten für alle deine Bots."
 
-#: src/pages/Shell.tsx:3920
+#: src/pages/Shell.tsx:3938
 msgid "Bots are working"
 msgstr "Bots arbeiten"
 
@@ -523,8 +523,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Verwende deinen eigenen Schlüssel. Der Anbieter ist austauschbar; die Schaltflächen zum Sprechen und Anrufen deiner Bots bleiben gleich."
 
 #: src/pages/CallView.tsx:241
-#: src/pages/Shell.tsx:2926
-#: src/pages/Shell.tsx:2927
+#: src/pages/Shell.tsx:2940
+#: src/pages/Shell.tsx:2941
 msgid "Call"
 msgstr "Anrufen"
 
@@ -553,7 +553,7 @@ msgstr "Neuen Bot abbrechen"
 msgid "Cancel new group"
 msgstr "Neue Gruppe abbrechen"
 
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4473
 msgid "Cancel reply"
 msgstr "Antwort abbrechen"
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Chat apps, group channels, and agent connections."
 msgstr ""
 
-#: src/pages/Shell.tsx:4784
+#: src/pages/Shell.tsx:4802
 msgid "Chat Settings"
 msgstr "Chat-Einstellungen"
 
@@ -598,8 +598,8 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: src/pages/Shell.tsx:3339
-#: src/pages/Shell.tsx:3349
+#: src/pages/Shell.tsx:3356
+#: src/pages/Shell.tsx:3366
 msgid "Check in."
 msgstr "Melde dich."
 
@@ -618,10 +618,6 @@ msgstr ""
 #: src/pages/MessagingSettingsOverlay.tsx:152
 msgid "Choose a bot…"
 msgstr ""
-
-#: src/pages/Onboarding.tsx:226
-msgid "Choose a model to get started."
-msgstr "Wähle zunächst ein Modell aus."
 
 #: src/pages/Auth.tsx:257
 msgid "Choose a new password"
@@ -661,7 +657,7 @@ msgstr "Schließen"
 msgid "Close chart"
 msgstr "Diagramm schließen"
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3810
 msgid "Close computer"
 msgstr "Computer schließen"
 
@@ -689,11 +685,11 @@ msgstr ""
 msgid "Close model settings"
 msgstr "Modelleinstellungen schließen"
 
-#: src/pages/Shell.tsx:2359
+#: src/pages/Shell.tsx:2373
 msgid "Close navigation"
 msgstr "Navigation schließen"
 
-#: src/pages/Shell.tsx:3103
+#: src/pages/Shell.tsx:3117
 msgid "Close panel"
 msgstr "Panel schließen"
 
@@ -719,7 +715,7 @@ msgid "Code"
 msgstr ""
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2509
 msgid "Collapse {0}"
 msgstr ""
 
@@ -735,24 +731,24 @@ msgstr "Befehl"
 msgid "Complete"
 msgstr "Abschließen"
 
-#: src/pages/Shell.tsx:5378
+#: src/pages/Shell.tsx:5396
 #: src/pages/shell/bot-panel.tsx:47
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5431
+#: src/pages/Shell.tsx:5449
 msgid "Computer failed to boot"
 msgstr "Computer konnte nicht gestartet werden"
 
-#: src/pages/Shell.tsx:3841
+#: src/pages/Shell.tsx:3859
 msgid "Computer is asleep"
 msgstr "Computer ist im Ruhezustand"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5448
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5432
+#: src/pages/Shell.tsx:5450
 msgid "Computer is stopped"
 msgstr "Computer ist gestoppt"
 
@@ -772,7 +768,7 @@ msgstr "Durch die Bereitstellung konfiguriert"
 msgid "Configured servers"
 msgstr "Konfigurierte Server"
 
-#: src/pages/McpServersOverlay.tsx:502
+#: src/pages/McpServersOverlay.tsx:506
 msgid "Confirm delete"
 msgstr "Löschen bestätigen"
 
@@ -786,7 +782,7 @@ msgstr "Passwort bestätigen"
 msgid "Connect"
 msgstr "Verbinden"
 
-#: src/pages/Onboarding.tsx:223
+#: src/pages/Onboarding.tsx:246
 msgid "Connect a model"
 msgstr "Modell verbinden"
 
@@ -857,8 +853,8 @@ msgstr "Verbindung wird hergestellt…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "Die Verbindung zu {0} steht noch aus. Du kannst dieses Fenster schließen und später erneut nachsehen."
 
-#: src/pages/Onboarding.tsx:484
-#: src/pages/Onboarding.tsx:545
+#: src/pages/Onboarding.tsx:558
+#: src/pages/Onboarding.tsx:619
 msgid "Continue"
 msgstr "Weiter"
 
@@ -866,7 +862,7 @@ msgstr "Weiter"
 msgid "Continue with email"
 msgstr "Mit E-Mail fortfahren"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4912
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -923,6 +919,10 @@ msgstr "Anbieter konnte nicht verbunden werden"
 msgid "Could not connect this voice provider"
 msgstr "Stimmanbieter konnte nicht verbunden werden"
 
+#: src/pages/Shell.tsx:821
+msgid "Could not connect to the computer screen"
+msgstr ""
+
 #: src/pages/Auth.tsx:85
 msgid "Could not continue"
 msgstr "Fortfahren fehlgeschlagen"
@@ -943,7 +943,7 @@ msgstr "Abschnitt konnte nicht erstellt werden"
 msgid "Could not create space"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:208
+#: src/pages/Onboarding.tsx:231
 msgid "Could not create your bot"
 msgstr "Dein Bot konnte nicht erstellt werden"
 
@@ -1027,7 +1027,7 @@ msgid "Could not reach the server"
 msgstr "Server konnte nicht erreicht werden"
 
 #: src/pages/ModelSettingsOverlay.tsx:232
-#: src/pages/Onboarding.tsx:154
+#: src/pages/Onboarding.tsx:177
 msgid "Could not reach this model server"
 msgstr "Modellserver konnte nicht erreicht werden"
 
@@ -1059,7 +1059,7 @@ msgstr "Passwort konnte nicht zurückgesetzt werden"
 msgid "Could not revoke connection"
 msgstr "Verbindung konnte nicht widerrufen werden"
 
-#: src/pages/Shell.tsx:3401
+#: src/pages/Shell.tsx:3418
 msgid "Could not run routine"
 msgstr ""
 
@@ -1075,11 +1075,11 @@ msgstr ""
 msgid "Could not save group"
 msgstr "Gruppe konnte nicht gespeichert werden"
 
-#: src/pages/Onboarding.tsx:181
+#: src/pages/Onboarding.tsx:204
 msgid "Could not save model"
 msgstr "Modell konnte nicht gespeichert werden"
 
-#: src/pages/Shell.tsx:3372
+#: src/pages/Shell.tsx:3389
 msgid "Could not save routine"
 msgstr "Routine konnte nicht gespeichert werden"
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "Antwort konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:2205
+#: src/pages/Shell.tsx:2207
 msgid "Could not take control"
 msgstr "Kontrolle konnte nicht übernommen werden"
 
@@ -1135,7 +1135,7 @@ msgstr "Agent-Zugriff konnte nicht aktualisiert werden"
 msgid "Could not update computer"
 msgstr ""
 
-#: src/pages/Shell.tsx:1871
+#: src/pages/Shell.tsx:1873
 msgid "Could not update reaction"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Couldn't update messaging settings"
 msgstr ""
 
-#: src/pages/Shell.tsx:2395
+#: src/pages/Shell.tsx:2409
 #: src/pages/shell/bot-panel.tsx:161
 #: src/pages/shell/dialogs.tsx:155
 msgid "Create"
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Create space"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:504
+#: src/pages/Onboarding.tsx:578
 msgid "Create your first bot"
 msgstr "Ersten Bot erstellen"
 
@@ -1254,10 +1254,10 @@ msgid "Default scope"
 msgstr "Standardbereich"
 
 #: src/pages/BotContextMenu.tsx:150
-#: src/pages/McpServersOverlay.tsx:504
+#: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:272
-#: src/pages/Shell.tsx:2730
-#: src/pages/Shell.tsx:2761
+#: src/pages/Shell.tsx:2744
+#: src/pages/Shell.tsx:2775
 #: src/pages/shell/dialogs.tsx:298
 #: src/pages/shell/dialogs.tsx:355
 msgid "Delete"
@@ -1265,8 +1265,8 @@ msgstr "Löschen"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2727
-#: src/pages/Shell.tsx:2758
+#: src/pages/Shell.tsx:2741
+#: src/pages/Shell.tsx:2772
 msgid "Delete {0}"
 msgstr "{0} löschen"
 
@@ -1285,7 +1285,7 @@ msgstr "Gruppe löschen"
 msgid "Delete memories too"
 msgstr "Erinnerungen ebenfalls löschen"
 
-#: src/pages/Shell.tsx:5222
+#: src/pages/Shell.tsx:5240
 msgid "deleted"
 msgstr "gelöscht"
 
@@ -1307,22 +1307,22 @@ msgstr "Ablehnen"
 msgid "Deployment default"
 msgstr "Bereitstellungsstandard"
 
-#: src/pages/Onboarding.tsx:525
+#: src/pages/Onboarding.tsx:599
 #: src/pages/shell/bot-panel.tsx:139
 msgid "Describe what this bot does"
 msgstr "Beschreibe, was dieser Bot macht"
 
-#: src/pages/Onboarding.tsx:533
+#: src/pages/Onboarding.tsx:607
 #: src/pages/shell/bot-panel.tsx:144
 #: src/pages/shell/bot-panel.tsx:308
 msgid "Description"
 msgstr "Beschreibung"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Dictate"
 msgstr "Diktieren"
 
-#: src/pages/McpServersOverlay.tsx:489
+#: src/pages/McpServersOverlay.tsx:493
 #: src/pages/MemorySettingsOverlay.tsx:207
 msgid "Disconnect"
 msgstr "Trennen"
@@ -1335,7 +1335,7 @@ msgstr "Verbindung wird getrennt…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4453
 msgid "Dismiss error"
 msgstr ""
 
@@ -1365,8 +1365,8 @@ msgid "Don’t have an account?"
 msgstr "Du hast noch kein Konto?"
 
 #: src/pages/ActivityList.tsx:157
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Done"
 msgstr "Fertig"
 
@@ -1389,7 +1389,7 @@ msgstr "Skill-Entwurf"
 msgid "Duplicate"
 msgstr "Duplizieren"
 
-#: src/pages/Shell.tsx:5021
+#: src/pages/Shell.tsx:5039
 msgid "Earlier message"
 msgstr "Frühere Nachricht"
 
@@ -1407,7 +1407,7 @@ msgstr "E-Mail"
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
 #: src/pages/ModelSettingsOverlay.tsx:596
-#: src/pages/Onboarding.tsx:408
+#: src/pages/Onboarding.tsx:482
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Gib diesen Code unter <0>{0}</0> ein"
 
@@ -1450,7 +1450,7 @@ msgid "Expand"
 msgstr "Erweitern"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2494
+#: src/pages/Shell.tsx:2508
 msgid "Expand {0}"
 msgstr ""
 
@@ -1470,14 +1470,14 @@ msgstr "Sehr hoch"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: src/pages/Shell.tsx:2023
 #: src/pages/Shell.tsx:2025
 #: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2029
 msgid "Failed to send message"
 msgstr "Nachricht konnte nicht gesendet werden"
 
-#: src/pages/Shell.tsx:2060
-#: src/pages/Shell.tsx:2079
+#: src/pages/Shell.tsx:2062
+#: src/pages/Shell.tsx:2081
 msgid "Failed to stop"
 msgstr "Stoppen fehlgeschlagen"
 
@@ -1491,18 +1491,18 @@ msgid "Failure handling"
 msgstr "Fehlerbehandlung"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Find models"
 msgstr "Modelle suchen"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Finding…"
 msgstr "Suche läuft…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
 #: src/pages/ModelSettingsOverlay.tsx:556
-#: src/pages/Onboarding.tsx:372
+#: src/pages/Onboarding.tsx:446
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "Schließe die Anmeldung unter <0>{0}</0> ab. Die letzte Seite wird möglicherweise nicht geladen; füge ihre URL oder den Code hier ein."
 
@@ -1536,8 +1536,8 @@ msgid "Git event"
 msgstr ""
 
 #: src/pages/MessagingSettingsOverlay.tsx:198
-#: src/pages/Shell.tsx:2916
-#: src/pages/Shell.tsx:3073
+#: src/pages/Shell.tsx:2930
+#: src/pages/Shell.tsx:3087
 msgid "Group"
 msgstr "Gruppe"
 
@@ -1587,11 +1587,11 @@ msgstr ""
 msgid "High"
 msgstr "Hoch"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk"
 msgstr "Zum Sprechen gedrückt halten"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk (on-device dictation)"
 msgstr "Zum Sprechen gedrückt halten (Diktat auf dem Gerät)"
 
@@ -1611,7 +1611,7 @@ msgstr "Wie oft"
 msgid "How to check"
 msgstr "So wird geprüft"
 
-#: src/pages/Shell.tsx:4951
+#: src/pages/Shell.tsx:4969
 msgid "I’m done"
 msgstr "Ich bin fertig"
 
@@ -1640,7 +1640,7 @@ msgid "Instruction"
 msgstr "Anweisung"
 
 #: src/pages/PluginsOverlay.tsx:247
-#: src/pages/Shell.tsx:2779
+#: src/pages/Shell.tsx:2793
 msgid "Integrations"
 msgstr "Integrationen"
 
@@ -1670,11 +1670,11 @@ msgstr "Isoliert"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Seine Unterhaltung, Dateien und Routinen werden dauerhaft gelöscht. Von ihm erstellte Bots bleiben in deiner Liste."
 
-#: src/pages/Shell.tsx:4105
+#: src/pages/Shell.tsx:4123
 msgid "Jump to latest"
 msgstr "Zur neuesten Nachricht springen"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5034
 msgid "Jump to replied message"
 msgstr "Zur beantworteten Nachricht springen"
 
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "Hört zu…"
 
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Load earlier messages"
 msgstr "Frühere Nachrichten laden"
 
@@ -1754,9 +1754,9 @@ msgid "Loading voice providers…"
 msgstr "Stimmanbieter werden geladen…"
 
 #: src/App.tsx:54
-#: src/pages/Onboarding.tsx:217
+#: src/pages/Onboarding.tsx:240
 #: src/pages/PeerMessagesOverlay.tsx:99
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Loading…"
 msgstr "Wird geladen…"
 
@@ -1764,7 +1764,7 @@ msgstr "Wird geladen…"
 msgid "Local"
 msgstr "Lokal"
 
-#: src/pages/Shell.tsx:2872
+#: src/pages/Shell.tsx:2886
 msgid "Log out"
 msgstr "Abmelden"
 
@@ -1810,7 +1810,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Mitglieder ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} auswählen)"
 
 #: src/pages/MemorySettingsOverlay.tsx:157
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2845
 msgid "Memory"
 msgstr "Erinnerungen"
 
@@ -1818,38 +1818,38 @@ msgstr "Erinnerungen"
 msgid "Memory scope"
 msgstr "Erinnerungsbereich"
 
-#: src/pages/Shell.tsx:4503
+#: src/pages/Shell.tsx:4521
 msgid "Mentions"
 msgstr ""
-
-#: src/pages/Shell.tsx:4729
-#: src/pages/Shell.tsx:4843
-msgid "Message"
-msgstr "Nachricht"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:83
 msgid "Message"
 msgstr ""
 
-#: src/pages/Shell.tsx:4725
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4861
+msgid "Message"
+msgstr "Nachricht"
+
+#: src/pages/Shell.tsx:4743
+#: src/pages/Shell.tsx:4747
 msgid "Message {activeName}"
 msgstr "Nachricht an {activeName}"
 
-#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4433
 msgid "Message composer"
 msgstr ""
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Message from {peer}"
 msgstr "Nachricht von {peer}"
 
-#: src/pages/Shell.tsx:4726
+#: src/pages/Shell.tsx:4744
 msgid "Message…"
 msgstr "Nachricht…"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Messaged {peer}"
 msgstr "Nachricht an {peer} gesendet"
 
@@ -1881,21 +1881,25 @@ msgstr "Minuten"
 #: src/pages/ModelSettingsOverlay.tsx:449
 #: src/pages/ModelSettingsOverlay.tsx:503
 #: src/pages/ModelSettingsOverlay.tsx:932
-#: src/pages/Onboarding.tsx:300
-#: src/pages/Onboarding.tsx:342
-#: src/pages/Onboarding.tsx:350
+#: src/pages/Onboarding.tsx:377
+#: src/pages/Onboarding.tsx:419
+#: src/pages/Onboarding.tsx:427
 #: src/pages/shell/bot-panel.tsx:332
 msgid "Model"
 msgstr "Modell"
 
 #: src/pages/ModelSettingsOverlay.tsx:483
-#: src/pages/Onboarding.tsx:322
+#: src/pages/Onboarding.tsx:399
 msgid "Model id"
 msgstr "Modell-ID"
 
 #: src/pages/ModelSettingsOverlay.tsx:968
 msgid "Model options"
 msgstr "Modelloptionen"
+
+#: src/pages/Onboarding.tsx:278
+msgid "Model providers"
+msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:216
 msgid "Model spend uses your provider keys."
@@ -1906,12 +1910,12 @@ msgid "Model updated."
 msgstr "Modell aktualisiert."
 
 #: src/pages/ModelSettingsOverlay.tsx:323
-#: src/pages/Shell.tsx:2820
+#: src/pages/Shell.tsx:2834
 msgid "Models"
 msgstr "Modelle"
 
 #: src/pages/ModelSettingsOverlay.tsx:462
-#: src/pages/Onboarding.tsx:306
+#: src/pages/Onboarding.tsx:383
 msgid "Models from server"
 msgstr "Modelle vom Server"
 
@@ -1940,7 +1944,7 @@ msgstr "Verschieben nach"
 #: src/pages/Auth.tsx:110
 #: src/pages/GroupPanel.tsx:119
 #: src/pages/GroupPanel.tsx:212
-#: src/pages/Onboarding.tsx:507
+#: src/pages/Onboarding.tsx:581
 #: src/pages/RoutineEditor.tsx:281
 #: src/pages/shell/bot-panel.tsx:122
 #: src/pages/shell/bot-panel.tsx:288
@@ -1949,7 +1953,7 @@ msgstr "Verschieben nach"
 msgid "Name"
 msgstr "Name"
 
-#: src/pages/Onboarding.tsx:512
+#: src/pages/Onboarding.tsx:586
 #: src/pages/shell/bot-panel.tsx:128
 msgid "Name this bot"
 msgstr "Bot benennen"
@@ -1970,13 +1974,13 @@ msgstr "Eingabe erforderlich"
 msgid "Needs takeover"
 msgstr "Übernahme erforderlich"
 
-#: src/pages/Shell.tsx:2413
+#: src/pages/Shell.tsx:2427
 #: src/pages/shell/bot-panel.tsx:106
 msgid "New bot"
 msgstr "Neuer Bot"
 
 #: src/pages/GroupPanel.tsx:101
-#: src/pages/Shell.tsx:2423
+#: src/pages/Shell.tsx:2437
 msgid "New group"
 msgstr "Neue Gruppe"
 
@@ -1994,7 +1998,7 @@ msgstr "Neues Passwort"
 msgid "New section"
 msgstr "Neuer Abschnitt"
 
-#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2449
 #: src/pages/shell/dialogs.tsx:68
 msgid "New space"
 msgstr ""
@@ -2059,6 +2063,10 @@ msgstr "Noch keine Nachrichten mit {peerBotName}."
 #: src/pages/ModelSettingsOverlay.tsx:733
 msgid "No model catalog is available."
 msgstr "Kein Modellkatalog verfügbar."
+
+#: src/pages/Onboarding.tsx:339
+msgid "No providers found"
+msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:402
 msgid "No providers found."
@@ -2132,21 +2140,21 @@ msgid "on the 1st at {0}"
 msgstr "am 1. um {0}"
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3154
-#: src/pages/Shell.tsx:3159
+#: src/pages/Shell.tsx:3170
+#: src/pages/Shell.tsx:3175
 msgid "Open"
 msgstr "Öffnen"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2492
+#: src/pages/Shell.tsx:2506
 msgid "Open {0}"
 msgstr ""
 
-#: src/pages/Shell.tsx:3119
+#: src/pages/Shell.tsx:3133
 msgid "Open in full window"
 msgstr "In vollständigem Fenster öffnen"
 
-#: src/pages/Shell.tsx:2888
+#: src/pages/Shell.tsx:2902
 msgid "Open navigation"
 msgstr "Navigation öffnen"
 
@@ -2155,11 +2163,11 @@ msgid "Open work"
 msgstr "Offene Arbeit"
 
 #: src/pages/ModelSettingsOverlay.tsx:422
-#: src/pages/Onboarding.tsx:275
+#: src/pages/Onboarding.tsx:352
 msgid "OpenAI-compatible server URL"
 msgstr "URL eines OpenAI-kompatiblen Servers"
 
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5251
 msgid "Opened its thread."
 msgstr "Thread geöffnet."
 
@@ -2168,7 +2176,7 @@ msgid "Opening your Space…"
 msgstr "Dein Arbeitsbereich wird geöffnet…"
 
 #: src/pages/ModelSettingsOverlay.tsx:646
-#: src/pages/Onboarding.tsx:446
+#: src/pages/Onboarding.tsx:520
 msgid "Optional"
 msgstr "Optional"
 
@@ -2184,7 +2192,7 @@ msgstr "Optionaler Header-Wert"
 msgid "Or connect an API key"
 msgstr "Oder einen API-Schlüssel verbinden"
 
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:531
 msgid "Or paste an API key"
 msgstr "Oder einen API-Schlüssel einfügen"
 
@@ -2197,7 +2205,7 @@ msgid "Organization API key"
 msgstr "Organisations-API-Schlüssel"
 
 #: src/pages/ModelSettingsOverlay.tsx:470
-#: src/pages/Onboarding.tsx:315
+#: src/pages/Onboarding.tsx:392
 msgid "Other model…"
 msgstr "Anderes Modell…"
 
@@ -2235,7 +2243,7 @@ msgid "Paste a replacement key"
 msgstr "Ersatzschlüssel einfügen"
 
 #: src/pages/ModelSettingsOverlay.tsx:433
-#: src/pages/Onboarding.tsx:286
+#: src/pages/Onboarding.tsx:363
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Füge die OpenAI-kompatible Adresse deines Servers ein. Rakazo ergänzt /v1 bei Bedarf."
 
@@ -2278,6 +2286,7 @@ msgid "Private"
 msgstr "Privat"
 
 #: src/pages/MemorySettingsOverlay.tsx:216
+#: src/pages/Onboarding.tsx:250
 msgid "Provider"
 msgstr "Anbieter"
 
@@ -2342,7 +2351,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:4959
 msgid "Release"
 msgstr "Freigeben"
 
@@ -2355,12 +2364,12 @@ msgid "Remove"
 msgstr "Entfernen"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4489
+#: src/pages/Shell.tsx:4507
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4681
 msgid "Remove mention {0}"
 msgstr "Erwähnung von {0} entfernen"
 
@@ -2369,12 +2378,12 @@ msgid "Remove schedule"
 msgstr ""
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4660
 msgid "Remove skill {0}"
 msgstr "Skill {0} entfernen"
 
-#: src/pages/Shell.tsx:4080
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4900
 msgid "Remove thumbs-up"
 msgstr ""
 
@@ -2382,7 +2391,7 @@ msgstr ""
 msgid "Remove webhook"
 msgstr ""
 
-#: src/pages/Shell.tsx:5232
+#: src/pages/Shell.tsx:5250
 msgid "Removed with chat, computer, and memory."
 msgstr "Zusammen mit Chat, Computer und Erinnerungen entfernt."
 
@@ -2410,11 +2419,11 @@ msgstr "API-Schlüssel ersetzen"
 msgid "Replace key"
 msgstr "Schlüssel ersetzen"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4891
 msgid "Reply"
 msgstr "Antworten"
 
-#: src/pages/Shell.tsx:4452
+#: src/pages/Shell.tsx:4470
 msgid "Replying to {replyName}"
 msgstr "Antwort an {replyName}"
 
@@ -2443,8 +2452,8 @@ msgstr "Setze dein Passwort zurück"
 msgid "Resetting…"
 msgstr ""
 
-#: src/pages/Shell.tsx:2721
-#: src/pages/Shell.tsx:2752
+#: src/pages/Shell.tsx:2735
+#: src/pages/Shell.tsx:2766
 msgid "Restore"
 msgstr "Wiederherstellen"
 
@@ -2455,6 +2464,10 @@ msgstr ""
 #: src/App.tsx:148
 msgid "Retry now"
 msgstr "Jetzt erneut versuchen"
+
+#: src/pages/Shell.tsx:2348
+msgid "Retry screen"
+msgstr ""
 
 #: src/pages/McpOAuthCallback.tsx:62
 msgid "Return to Rakazo"
@@ -2473,8 +2486,8 @@ msgid "Rotate key"
 msgstr ""
 
 #: src/pages/RoutineEditor.tsx:236
-#: src/pages/Shell.tsx:3338
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3355
+#: src/pages/Shell.tsx:3365
 msgid "Routine"
 msgstr "Routine"
 
@@ -2491,7 +2504,7 @@ msgstr ""
 msgid "Run history"
 msgstr ""
 
-#: src/pages/Shell.tsx:3331
+#: src/pages/Shell.tsx:3348
 msgid "Run time must be in the future."
 msgstr ""
 
@@ -2549,7 +2562,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "Antworte mit Ja oder Nein oder in einem Satz."
 
 #: src/pages/ModelSettingsOverlay.tsx:957
-#: src/pages/Shell.tsx:2449
+#: src/pages/Shell.tsx:2463
 msgid "Search"
 msgstr "Suchen"
 
@@ -2567,8 +2580,8 @@ msgstr "Modelle suchen"
 msgid "Search providers"
 msgstr "Anbieter suchen"
 
-#: src/pages/Onboarding.tsx:231
-#: src/pages/Onboarding.tsx:232
+#: src/pages/Onboarding.tsx:272
+#: src/pages/Onboarding.tsx:273
 msgid "Search providers and models"
 msgstr "Anbieter und Modelle suchen"
 
@@ -2576,12 +2589,16 @@ msgstr "Anbieter und Modelle suchen"
 msgid "Searching…"
 msgstr "Suche…"
 
-#: src/pages/Shell.tsx:2917
+#: src/pages/Shell.tsx:2931
 msgid "Select a bot"
 msgstr "Bot auswählen"
 
-#: src/pages/Shell.tsx:4747
-#: src/pages/Shell.tsx:4768
+#: src/pages/Onboarding.tsx:320
+msgid "Selected"
+msgstr ""
+
+#: src/pages/Shell.tsx:4765
+#: src/pages/Shell.tsx:4786
 msgid "Send"
 msgstr "Senden"
 
@@ -2618,31 +2635,31 @@ msgstr "Servername"
 
 #: src/pages/McpServersOverlay.tsx:329
 #: src/pages/ModelSettingsOverlay.tsx:417
-#: src/pages/Onboarding.tsx:270
+#: src/pages/Onboarding.tsx:347
 msgid "Server URL"
 msgstr "Server-URL"
 
-#: src/pages/Shell.tsx:2926
+#: src/pages/Shell.tsx:2940
 msgid "Set up voice to call"
 msgstr "Stimme für Anrufe einrichten"
 
 #: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2801
-#: src/pages/Shell.tsx:2809
-#: src/pages/Shell.tsx:3069
+#: src/pages/Shell.tsx:2815
+#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:3083
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4804
 msgid "Settings: General"
 msgstr "Einstellungen: Allgemein"
 
-#: src/pages/Shell.tsx:4788
+#: src/pages/Shell.tsx:4806
 msgid "Settings: Usage"
 msgstr "Einstellungen: Nutzung"
 
 #: src/pages/ModelSettingsOverlay.tsx:430
-#: src/pages/Onboarding.tsx:283
+#: src/pages/Onboarding.tsx:360
 msgid "Setup help"
 msgstr "Einrichtungshilfe"
 
@@ -2651,7 +2668,11 @@ msgstr "Einrichtungshilfe"
 msgid "Shared"
 msgstr "Geteilt"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:264
+msgid "Show all providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show computer"
 msgstr "Computer anzeigen"
 
@@ -2663,7 +2684,11 @@ msgstr "Mehr anzeigen"
 msgid "Show password"
 msgstr ""
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:262
+msgid "Show popular providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show settings"
 msgstr "Einstellungen anzeigen"
 
@@ -2671,7 +2696,7 @@ msgstr "Einstellungen anzeigen"
 #: src/pages/Auth.tsx:206
 #: src/pages/Auth.tsx:264
 #: src/pages/ModelSettingsOverlay.tsx:628
-#: src/pages/Onboarding.tsx:108
+#: src/pages/Onboarding.tsx:131
 msgid "Sign in"
 msgstr "Anmelden"
 
@@ -2685,15 +2710,15 @@ msgid "Sign up"
 msgstr "Registrieren"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4550
+#: src/pages/Shell.tsx:4568
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:4948
+#: src/pages/Shell.tsx:4966
 msgid "Skip"
 msgstr "Überspringen"
 
-#: src/pages/Onboarding.tsx:495
+#: src/pages/Onboarding.tsx:569
 msgid "Skip for now"
 msgstr "Vorerst überspringen"
 
@@ -2702,7 +2727,7 @@ msgid "Skip or deploy key"
 msgstr "Überspringen oder Deploy-Key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1905
+#: src/pages/Shell.tsx:1907
 msgid "Skipped {0}"
 msgstr "{0} übersprungen"
 
@@ -2723,8 +2748,8 @@ msgstr "Space-Standard"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Leertaste unterbricht · Esc legt auf"
 
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Speak"
 msgstr "Vorlesen"
 
@@ -2736,8 +2761,8 @@ msgstr "Sprechen + transkribieren"
 msgid "Speak only"
 msgstr "Nur sprechen"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Speak this reply"
 msgstr "Diese Antwort vorlesen"
 
@@ -2755,7 +2780,7 @@ msgstr "Startet"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
 #: src/pages/ModelSettingsOverlay.tsx:626
-#: src/pages/Onboarding.tsx:431
+#: src/pages/Onboarding.tsx:505
 msgid "Starting…"
 msgstr "Wird gestartet…"
 
@@ -2763,20 +2788,20 @@ msgstr "Wird gestartet…"
 msgid "Steps"
 msgstr "Schritte"
 
-#: src/pages/Shell.tsx:3755
-#: src/pages/Shell.tsx:3760
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:3772
+#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Stop"
 msgstr "Stoppen"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Stop dictation"
 msgstr "Diktat stoppen"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Stop speaking"
 msgstr "Vorlesen stoppen"
 
@@ -2794,13 +2819,13 @@ msgstr "Gestoppt."
 msgid "Stored encrypted"
 msgstr "Verschlüsselt gespeichert"
 
-#: src/pages/Shell.tsx:5186
+#: src/pages/Shell.tsx:5204
 msgid "subagent"
 msgstr "Subagent"
 
 #: src/components/AskCard.tsx:140
 #: src/pages/ModelSettingsOverlay.tsx:586
-#: src/pages/Onboarding.tsx:398
+#: src/pages/Onboarding.tsx:472
 msgid "Submit"
 msgstr "Absenden"
 
@@ -2821,7 +2846,7 @@ msgstr "System"
 msgid "Teach a task"
 msgstr "Aufgabe anlernen"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3005
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachricht sendest."
 
@@ -2829,7 +2854,7 @@ msgstr "Aufgabe wird angelernt – beende das Anlernen, bevor du eine neue Nachr
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "Team Computer"
 msgstr "Team-Computer"
 
@@ -2857,11 +2882,11 @@ msgstr "Der ausgewählte Erinnerungsanbieter ist in diesem Build nicht verfügba
 msgid "Thinking"
 msgstr "Denkmodus"
 
-#: src/pages/Shell.tsx:3123
+#: src/pages/Shell.tsx:3137
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Dieser Bot wird auf diesem Computer und nicht auf einem Linux-Desktop ausgeführt. Shell und Dateien verwenden deinen persönlichen Ordner."
 
-#: src/pages/Shell.tsx:3811
+#: src/pages/Shell.tsx:3828
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Dieser Bot wird auf diesem Computer ausgeführt. Es gibt keinen separaten Linux-Desktop. Bitte ihn, die Shell zu verwenden; Arbeitsverzeichnisse in deinem persönlichen Ordner sind zulässig."
 
@@ -2898,7 +2923,7 @@ msgstr "Dieser Mac führt Shell-Befehle mit deinem Konto aus und kann auf Dateie
 msgid "This permanently removes every message and stops current work. The chat remains available."
 msgstr ""
 
-#: src/pages/Onboarding.tsx:471
+#: src/pages/Onboarding.tsx:545
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bei diesem Anbieter kann hier kein Schlüssel eingefügt werden. Überspringe diesen Schritt, wenn die Bereitstellung bereits Zugangsdaten enthält."
 
@@ -2930,7 +2955,7 @@ msgstr "Diese Abonnementanmeldung ist in Rakazo noch nicht verfügbar. Verwende 
 msgid "Time of day"
 msgstr "Uhrzeit"
 
-#: src/pages/Onboarding.tsx:520
+#: src/pages/Onboarding.tsx:594
 #: src/pages/shell/bot-panel.tsx:133
 #: src/pages/shell/bot-panel.tsx:298
 msgid "Title"
@@ -2965,7 +2990,7 @@ msgid "Unpin"
 msgstr "Lösen"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1978
 msgid "Unsupported file type: {0}"
 msgstr "Nicht unterstützter Dateityp: {0}"
 
@@ -3005,7 +3030,7 @@ msgid "Updating…"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:206
-#: src/pages/Shell.tsx:2852
+#: src/pages/Shell.tsx:2866
 msgid "Usage"
 msgstr "Nutzung"
 
@@ -3014,7 +3039,7 @@ msgid "Use {hostLabel}"
 msgstr "{hostLabel} verwenden"
 
 #: src/pages/ModelSettingsOverlay.tsx:495
-#: src/pages/Onboarding.tsx:334
+#: src/pages/Onboarding.tsx:411
 msgid "Use a found model"
 msgstr "Gefundenes Modell verwenden"
 
@@ -3030,7 +3055,7 @@ msgstr "Prüfen und hinzufügen"
 msgid "Verifying…"
 msgstr "Wird geprüft…"
 
-#: src/pages/Shell.tsx:2842
+#: src/pages/Shell.tsx:2856
 #: src/pages/shell/bot-panel.tsx:418
 #: src/pages/VoiceSettingsOverlay.tsx:145
 #: src/pages/VoiceSettingsOverlay.tsx:288
@@ -3039,8 +3064,8 @@ msgstr "Stimme"
 
 #: src/pages/ModelSettingsOverlay.tsx:590
 #: src/pages/ModelSettingsOverlay.tsx:612
-#: src/pages/Onboarding.tsx:402
-#: src/pages/Onboarding.tsx:424
+#: src/pages/Onboarding.tsx:476
+#: src/pages/Onboarding.tsx:498
 msgid "Waiting for sign-in…"
 msgstr "Warten auf Anmeldung…"
 
@@ -3074,7 +3099,7 @@ msgstr "Welches Ergebnis wirst du vorführen?"
 msgid "What should this routine do each time it runs?"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:538
+#: src/pages/Onboarding.tsx:612
 #: src/pages/shell/bot-panel.tsx:150
 msgid "What this bot is for"
 msgstr "Wofür dieser Bot gedacht ist"
@@ -3103,13 +3128,13 @@ msgstr "Wo sollen Bots ausgeführt werden?"
 #: src/pages/Auth.tsx:185
 #: src/pages/Auth.tsx:293
 #: src/pages/CallView.tsx:251
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Working…"
 msgstr "Wird verarbeitet…"
 
-#: src/pages/Shell.tsx:1679
-#: src/pages/Shell.tsx:2339
+#: src/pages/Shell.tsx:1681
+#: src/pages/Shell.tsx:2353
 msgid "You"
 msgstr "Du"
 
@@ -3121,7 +3146,7 @@ msgstr "Du kannst diesen Tab schließen, wenn du nicht automatisch weitergeleite
 msgid "You can close this window."
 msgstr "Du kannst dieses Fenster schließen."
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3762
 msgid "You have control"
 msgstr "Du hast die Kontrolle"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2625
+#: src/pages/Shell.tsx:2639
 msgid " (unread)"
 msgstr " (unread)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# model} other {# models}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1885
+#: src/pages/Shell.tsx:1887
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1889
+#: src/pages/Shell.tsx:1891
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (over 10 MiB)"
 
@@ -63,16 +63,16 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:210
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2870
 msgid "{0} runs · {1} tokens"
 msgstr "{0} runs · {1} tokens"
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3164
+#: src/pages/Shell.tsx:3181
 msgid "{0}'s screen"
 msgstr "{0}'s screen"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "{botName}’s computer"
 msgstr "{botName}’s computer"
 
@@ -116,12 +116,12 @@ msgstr "{size} B"
 msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
-#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:3937
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} is working"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4517
+#: src/pages/Shell.tsx:4535
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -158,8 +158,8 @@ msgstr "Active model"
 msgid "Active voice"
 msgstr "Active voice"
 
-#: src/pages/Shell.tsx:2374
-#: src/pages/Shell.tsx:2376
+#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2390
 msgid "Activity"
 msgstr "Activity"
 
@@ -173,7 +173,7 @@ msgstr "Add"
 msgid "Add a model in Settings to use this."
 msgstr "Add a model in Settings to use this."
 
-#: src/pages/Shell.tsx:3326
+#: src/pages/Shell.tsx:3343
 msgid "Add a run time for this one-shot."
 msgstr "Add a run time for this one-shot."
 
@@ -181,7 +181,7 @@ msgstr "Add a run time for this one-shot."
 msgid "Add a schedule or webhook to run this routine."
 msgstr "Add a schedule or webhook to run this routine."
 
-#: src/pages/Shell.tsx:3298
+#: src/pages/Shell.tsx:3315
 msgid "Add a schedule or webhook trigger"
 msgstr "Add a schedule or webhook trigger"
 
@@ -218,7 +218,7 @@ msgstr "Add remote MCP server"
 msgid "Add server"
 msgstr "Add server"
 
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4900
 msgid "Add thumbs-up"
 msgstr "Add thumbs-up"
 
@@ -252,7 +252,7 @@ msgstr "Advanced"
 msgid "Advanced..."
 msgstr "Advanced..."
 
-#: src/pages/Shell.tsx:2944
+#: src/pages/Shell.tsx:2958
 msgid "Agent computer"
 msgstr "Agent computer"
 
@@ -261,7 +261,7 @@ msgid "Agent connections"
 msgstr "Agent connections"
 
 #: src/pages/McpServersOverlay.tsx:385
-#: src/pages/McpServersOverlay.tsx:448
+#: src/pages/McpServersOverlay.tsx:452
 msgid "Agents:"
 msgstr "Agents:"
 
@@ -333,9 +333,9 @@ msgstr "API is back, but the update did not finish. Check the host logs."
 #: src/pages/ModelSettingsOverlay.tsx:640
 #: src/pages/ModelSettingsOverlay.tsx:643
 #: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/Onboarding.tsx:440
-#: src/pages/Onboarding.tsx:443
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:514
+#: src/pages/Onboarding.tsx:517
+#: src/pages/Onboarding.tsx:531
 #: src/pages/VoiceSettingsOverlay.tsx:258
 msgid "API key"
 msgstr "API key"
@@ -367,15 +367,15 @@ msgstr "Approve this server to let your agent use its tools."
 msgid "Archive"
 msgstr "Archive"
 
-#: src/pages/Shell.tsx:5220
+#: src/pages/Shell.tsx:5238
 msgid "archived"
 msgstr "archived"
 
-#: src/pages/Shell.tsx:2694
+#: src/pages/Shell.tsx:2708
 msgid "Archived"
 msgstr "Archived"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5249
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Archived. Chat, memory, and files kept."
 
@@ -425,16 +425,16 @@ msgstr "at {0}"
 msgid "at {timeSelect}"
 msgstr "at {timeSelect}"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4615
 msgid "Attach file"
 msgstr "Attach file"
 
-#: src/pages/Shell.tsx:4841
+#: src/pages/Shell.tsx:4859
 msgid "Attachment"
 msgstr "Attachment"
 
 #: src/pages/ModelSettingsOverlay.tsx:573
-#: src/pages/Onboarding.tsx:389
+#: src/pages/Onboarding.tsx:463
 msgid "Authorization code or callback URL"
 msgstr "Authorization code or callback URL"
 
@@ -474,35 +474,35 @@ msgstr "Base URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5446
 msgid "Booting live desktop…"
 msgstr "Booting live desktop…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3712
+#: src/pages/Shell.tsx:3729
 msgid "Booting up {0}’s computer"
 msgstr "Booting up {0}’s computer"
 
-#: src/pages/Shell.tsx:5080
-#: src/pages/Shell.tsx:5081
-#: src/pages/Shell.tsx:5224
+#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5099
+#: src/pages/Shell.tsx:5242
 msgid "bot"
 msgstr "bot"
-
-#: src/pages/Shell.tsx:1680
-msgid "Bot"
-msgstr "Bot"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:71
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3819
+#: src/pages/Shell.tsx:1682
+msgid "Bot"
+msgstr "Bot"
+
+#: src/pages/Shell.tsx:3836
 msgid "Bot screen"
 msgstr "Bot screen"
 
-#: src/pages/Shell.tsx:3130
+#: src/pages/Shell.tsx:3144
 msgid "Bot screen preview"
 msgstr "Bot screen preview"
 
@@ -514,7 +514,7 @@ msgstr "Bot to link"
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first. These preferences apply across all your bots."
 msgstr "Bots act without asking by default. Add an exception only when you want to review a type of action first. These preferences apply across all your bots."
 
-#: src/pages/Shell.tsx:3920
+#: src/pages/Shell.tsx:3938
 msgid "Bots are working"
 msgstr "Bots are working"
 
@@ -523,8 +523,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Bring your own key. The provider is swappable; your bots keep the same speak and call buttons."
 
 #: src/pages/CallView.tsx:241
-#: src/pages/Shell.tsx:2926
-#: src/pages/Shell.tsx:2927
+#: src/pages/Shell.tsx:2940
+#: src/pages/Shell.tsx:2941
 msgid "Call"
 msgstr "Call"
 
@@ -553,7 +553,7 @@ msgstr "Cancel new bot"
 msgid "Cancel new group"
 msgstr "Cancel new group"
 
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4473
 msgid "Cancel reply"
 msgstr "Cancel reply"
 
@@ -586,7 +586,7 @@ msgstr "Chat apps"
 msgid "Chat apps, group channels, and agent connections."
 msgstr "Chat apps, group channels, and agent connections."
 
-#: src/pages/Shell.tsx:4784
+#: src/pages/Shell.tsx:4802
 msgid "Chat Settings"
 msgstr "Chat Settings"
 
@@ -598,8 +598,8 @@ msgstr "Check failed"
 msgid "Check for updates"
 msgstr "Check for updates"
 
-#: src/pages/Shell.tsx:3339
-#: src/pages/Shell.tsx:3349
+#: src/pages/Shell.tsx:3356
+#: src/pages/Shell.tsx:3366
 msgid "Check in."
 msgstr "Check in."
 
@@ -618,10 +618,6 @@ msgstr "Checkout has local changes. Clean it before updating."
 #: src/pages/MessagingSettingsOverlay.tsx:152
 msgid "Choose a bot…"
 msgstr "Choose a bot…"
-
-#: src/pages/Onboarding.tsx:226
-msgid "Choose a model to get started."
-msgstr "Choose a model to get started."
 
 #: src/pages/Auth.tsx:257
 msgid "Choose a new password"
@@ -661,7 +657,7 @@ msgstr "Close"
 msgid "Close chart"
 msgstr "Close chart"
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3810
 msgid "Close computer"
 msgstr "Close computer"
 
@@ -689,11 +685,11 @@ msgstr "Close messaging settings"
 msgid "Close model settings"
 msgstr "Close model settings"
 
-#: src/pages/Shell.tsx:2359
+#: src/pages/Shell.tsx:2373
 msgid "Close navigation"
 msgstr "Close navigation"
 
-#: src/pages/Shell.tsx:3103
+#: src/pages/Shell.tsx:3117
 msgid "Close panel"
 msgstr "Close panel"
 
@@ -719,7 +715,7 @@ msgid "Code"
 msgstr "Code"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2509
 msgid "Collapse {0}"
 msgstr "Collapse {0}"
 
@@ -735,24 +731,24 @@ msgstr "Command"
 msgid "Complete"
 msgstr "Complete"
 
-#: src/pages/Shell.tsx:5378
+#: src/pages/Shell.tsx:5396
 #: src/pages/shell/bot-panel.tsx:47
 msgid "Computer"
 msgstr "Computer"
 
-#: src/pages/Shell.tsx:5431
+#: src/pages/Shell.tsx:5449
 msgid "Computer failed to boot"
 msgstr "Computer failed to boot"
 
-#: src/pages/Shell.tsx:3841
+#: src/pages/Shell.tsx:3859
 msgid "Computer is asleep"
 msgstr "Computer is asleep"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5448
 msgid "Computer is asleep. Open it to wake."
 msgstr "Computer is asleep. Open it to wake."
 
-#: src/pages/Shell.tsx:5432
+#: src/pages/Shell.tsx:5450
 msgid "Computer is stopped"
 msgstr "Computer is stopped"
 
@@ -772,7 +768,7 @@ msgstr "Configured by deployment"
 msgid "Configured servers"
 msgstr "Configured servers"
 
-#: src/pages/McpServersOverlay.tsx:502
+#: src/pages/McpServersOverlay.tsx:506
 msgid "Confirm delete"
 msgstr "Confirm delete"
 
@@ -786,7 +782,7 @@ msgstr "Confirm password"
 msgid "Connect"
 msgstr "Connect"
 
-#: src/pages/Onboarding.tsx:223
+#: src/pages/Onboarding.tsx:246
 msgid "Connect a model"
 msgstr "Connect a model"
 
@@ -857,8 +853,8 @@ msgstr "Connecting…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "Connection to {0} is still pending. You can close this and check again."
 
-#: src/pages/Onboarding.tsx:484
-#: src/pages/Onboarding.tsx:545
+#: src/pages/Onboarding.tsx:558
+#: src/pages/Onboarding.tsx:619
 msgid "Continue"
 msgstr "Continue"
 
@@ -866,7 +862,7 @@ msgstr "Continue"
 msgid "Continue with email"
 msgstr "Continue with email"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4912
 msgid "Copy"
 msgstr "Copy"
 
@@ -923,6 +919,10 @@ msgstr "Could not connect this provider"
 msgid "Could not connect this voice provider"
 msgstr "Could not connect this voice provider"
 
+#: src/pages/Shell.tsx:821
+msgid "Could not connect to the computer screen"
+msgstr "Could not connect to the computer screen"
+
 #: src/pages/Auth.tsx:85
 msgid "Could not continue"
 msgstr "Could not continue"
@@ -943,7 +943,7 @@ msgstr "Could not create section"
 msgid "Could not create space"
 msgstr "Could not create space"
 
-#: src/pages/Onboarding.tsx:208
+#: src/pages/Onboarding.tsx:231
 msgid "Could not create your bot"
 msgstr "Could not create your bot"
 
@@ -1027,7 +1027,7 @@ msgid "Could not reach the server"
 msgstr "Could not reach the server"
 
 #: src/pages/ModelSettingsOverlay.tsx:232
-#: src/pages/Onboarding.tsx:154
+#: src/pages/Onboarding.tsx:177
 msgid "Could not reach this model server"
 msgstr "Could not reach this model server"
 
@@ -1059,7 +1059,7 @@ msgstr "Could not reset password"
 msgid "Could not revoke connection"
 msgstr "Could not revoke connection"
 
-#: src/pages/Shell.tsx:3401
+#: src/pages/Shell.tsx:3418
 msgid "Could not run routine"
 msgstr "Could not run routine"
 
@@ -1075,11 +1075,11 @@ msgstr "Could not save Auto Review"
 msgid "Could not save group"
 msgstr "Could not save group"
 
-#: src/pages/Onboarding.tsx:181
+#: src/pages/Onboarding.tsx:204
 msgid "Could not save model"
 msgstr "Could not save model"
 
-#: src/pages/Shell.tsx:3372
+#: src/pages/Shell.tsx:3389
 msgid "Could not save routine"
 msgstr "Could not save routine"
 
@@ -1119,7 +1119,7 @@ msgstr "Could not start teaching"
 msgid "Could not submit this answer"
 msgstr "Could not submit this answer"
 
-#: src/pages/Shell.tsx:2205
+#: src/pages/Shell.tsx:2207
 msgid "Could not take control"
 msgstr "Could not take control"
 
@@ -1135,7 +1135,7 @@ msgstr "Could not update agent access"
 msgid "Could not update computer"
 msgstr "Could not update computer"
 
-#: src/pages/Shell.tsx:1871
+#: src/pages/Shell.tsx:1873
 msgid "Could not update reaction"
 msgstr "Could not update reaction"
 
@@ -1155,7 +1155,7 @@ msgstr "Couldn't update avatars"
 msgid "Couldn't update messaging settings"
 msgstr "Couldn't update messaging settings"
 
-#: src/pages/Shell.tsx:2395
+#: src/pages/Shell.tsx:2409
 #: src/pages/shell/bot-panel.tsx:161
 #: src/pages/shell/dialogs.tsx:155
 msgid "Create"
@@ -1184,7 +1184,7 @@ msgstr "Create Routine"
 msgid "Create space"
 msgstr "Create space"
 
-#: src/pages/Onboarding.tsx:504
+#: src/pages/Onboarding.tsx:578
 msgid "Create your first bot"
 msgstr "Create your first bot"
 
@@ -1254,10 +1254,10 @@ msgid "Default scope"
 msgstr "Default scope"
 
 #: src/pages/BotContextMenu.tsx:150
-#: src/pages/McpServersOverlay.tsx:504
+#: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:272
-#: src/pages/Shell.tsx:2730
-#: src/pages/Shell.tsx:2761
+#: src/pages/Shell.tsx:2744
+#: src/pages/Shell.tsx:2775
 #: src/pages/shell/dialogs.tsx:298
 #: src/pages/shell/dialogs.tsx:355
 msgid "Delete"
@@ -1265,8 +1265,8 @@ msgstr "Delete"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2727
-#: src/pages/Shell.tsx:2758
+#: src/pages/Shell.tsx:2741
+#: src/pages/Shell.tsx:2772
 msgid "Delete {0}"
 msgstr "Delete {0}"
 
@@ -1285,7 +1285,7 @@ msgstr "Delete group"
 msgid "Delete memories too"
 msgstr "Delete memories too"
 
-#: src/pages/Shell.tsx:5222
+#: src/pages/Shell.tsx:5240
 msgid "deleted"
 msgstr "deleted"
 
@@ -1307,22 +1307,22 @@ msgstr "Deny"
 msgid "Deployment default"
 msgstr "Deployment default"
 
-#: src/pages/Onboarding.tsx:525
+#: src/pages/Onboarding.tsx:599
 #: src/pages/shell/bot-panel.tsx:139
 msgid "Describe what this bot does"
 msgstr "Describe what this bot does"
 
-#: src/pages/Onboarding.tsx:533
+#: src/pages/Onboarding.tsx:607
 #: src/pages/shell/bot-panel.tsx:144
 #: src/pages/shell/bot-panel.tsx:308
 msgid "Description"
 msgstr "Description"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Dictate"
 msgstr "Dictate"
 
-#: src/pages/McpServersOverlay.tsx:489
+#: src/pages/McpServersOverlay.tsx:493
 #: src/pages/MemorySettingsOverlay.tsx:207
 msgid "Disconnect"
 msgstr "Disconnect"
@@ -1335,7 +1335,7 @@ msgstr "Disconnecting…"
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4453
 msgid "Dismiss error"
 msgstr "Dismiss error"
 
@@ -1365,8 +1365,8 @@ msgid "Don’t have an account?"
 msgstr "Don’t have an account?"
 
 #: src/pages/ActivityList.tsx:157
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Done"
 msgstr "Done"
 
@@ -1389,7 +1389,7 @@ msgstr "Draft skill"
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/pages/Shell.tsx:5021
+#: src/pages/Shell.tsx:5039
 msgid "Earlier message"
 msgstr "Earlier message"
 
@@ -1407,7 +1407,7 @@ msgstr "Email"
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
 #: src/pages/ModelSettingsOverlay.tsx:596
-#: src/pages/Onboarding.tsx:408
+#: src/pages/Onboarding.tsx:482
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Enter this code at <0>{0}</0>"
 
@@ -1450,7 +1450,7 @@ msgid "Expand"
 msgstr "Expand"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2494
+#: src/pages/Shell.tsx:2508
 msgid "Expand {0}"
 msgstr "Expand {0}"
 
@@ -1470,14 +1470,14 @@ msgstr "Extra high"
 msgid "Failed"
 msgstr "Failed"
 
-#: src/pages/Shell.tsx:2023
 #: src/pages/Shell.tsx:2025
 #: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2029
 msgid "Failed to send message"
 msgstr "Failed to send message"
 
-#: src/pages/Shell.tsx:2060
-#: src/pages/Shell.tsx:2079
+#: src/pages/Shell.tsx:2062
+#: src/pages/Shell.tsx:2081
 msgid "Failed to stop"
 msgstr "Failed to stop"
 
@@ -1491,18 +1491,18 @@ msgid "Failure handling"
 msgstr "Failure handling"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Find models"
 msgstr "Find models"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Finding…"
 msgstr "Finding…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
 #: src/pages/ModelSettingsOverlay.tsx:556
-#: src/pages/Onboarding.tsx:372
+#: src/pages/Onboarding.tsx:446
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 
@@ -1536,8 +1536,8 @@ msgid "Git event"
 msgstr "Git event"
 
 #: src/pages/MessagingSettingsOverlay.tsx:198
-#: src/pages/Shell.tsx:2916
-#: src/pages/Shell.tsx:3073
+#: src/pages/Shell.tsx:2930
+#: src/pages/Shell.tsx:3087
 msgid "Group"
 msgstr "Group"
 
@@ -1587,11 +1587,11 @@ msgstr "Hide password"
 msgid "High"
 msgstr "High"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk"
 msgstr "Hold to talk"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk (on-device dictation)"
 msgstr "Hold to talk (on-device dictation)"
 
@@ -1611,7 +1611,7 @@ msgstr "How often"
 msgid "How to check"
 msgstr "How to check"
 
-#: src/pages/Shell.tsx:4951
+#: src/pages/Shell.tsx:4969
 msgid "I’m done"
 msgstr "I’m done"
 
@@ -1640,7 +1640,7 @@ msgid "Instruction"
 msgstr "Instruction"
 
 #: src/pages/PluginsOverlay.tsx:247
-#: src/pages/Shell.tsx:2779
+#: src/pages/Shell.tsx:2793
 msgid "Integrations"
 msgstr "Integrations"
 
@@ -1670,11 +1670,11 @@ msgstr "Isolated"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 
-#: src/pages/Shell.tsx:4105
+#: src/pages/Shell.tsx:4123
 msgid "Jump to latest"
 msgstr "Jump to latest"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5034
 msgid "Jump to replied message"
 msgstr "Jump to replied message"
 
@@ -1720,7 +1720,7 @@ msgstr "Link a chat app"
 msgid "Listening…"
 msgstr "Listening…"
 
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Load earlier messages"
 msgstr "Load earlier messages"
 
@@ -1754,9 +1754,9 @@ msgid "Loading voice providers…"
 msgstr "Loading voice providers…"
 
 #: src/App.tsx:54
-#: src/pages/Onboarding.tsx:217
+#: src/pages/Onboarding.tsx:240
 #: src/pages/PeerMessagesOverlay.tsx:99
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -1764,7 +1764,7 @@ msgstr "Loading…"
 msgid "Local"
 msgstr "Local"
 
-#: src/pages/Shell.tsx:2872
+#: src/pages/Shell.tsx:2886
 msgid "Log out"
 msgstr "Log out"
 
@@ -1810,7 +1810,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/MemorySettingsOverlay.tsx:157
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2845
 msgid "Memory"
 msgstr "Memory"
 
@@ -1818,38 +1818,38 @@ msgstr "Memory"
 msgid "Memory scope"
 msgstr "Memory scope"
 
-#: src/pages/Shell.tsx:4503
+#: src/pages/Shell.tsx:4521
 msgid "Mentions"
 msgstr "Mentions"
-
-#: src/pages/Shell.tsx:4729
-#: src/pages/Shell.tsx:4843
-msgid "Message"
-msgstr "Message"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:83
 msgid "Message"
 msgstr "Message"
 
-#: src/pages/Shell.tsx:4725
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4861
+msgid "Message"
+msgstr "Message"
+
+#: src/pages/Shell.tsx:4743
+#: src/pages/Shell.tsx:4747
 msgid "Message {activeName}"
 msgstr "Message {activeName}"
 
-#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4433
 msgid "Message composer"
 msgstr "Message composer"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Message from {peer}"
 msgstr "Message from {peer}"
 
-#: src/pages/Shell.tsx:4726
+#: src/pages/Shell.tsx:4744
 msgid "Message…"
 msgstr "Message…"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Messaged {peer}"
 msgstr "Messaged {peer}"
 
@@ -1881,21 +1881,25 @@ msgstr "minutes"
 #: src/pages/ModelSettingsOverlay.tsx:449
 #: src/pages/ModelSettingsOverlay.tsx:503
 #: src/pages/ModelSettingsOverlay.tsx:932
-#: src/pages/Onboarding.tsx:300
-#: src/pages/Onboarding.tsx:342
-#: src/pages/Onboarding.tsx:350
+#: src/pages/Onboarding.tsx:377
+#: src/pages/Onboarding.tsx:419
+#: src/pages/Onboarding.tsx:427
 #: src/pages/shell/bot-panel.tsx:332
 msgid "Model"
 msgstr "Model"
 
 #: src/pages/ModelSettingsOverlay.tsx:483
-#: src/pages/Onboarding.tsx:322
+#: src/pages/Onboarding.tsx:399
 msgid "Model id"
 msgstr "Model id"
 
 #: src/pages/ModelSettingsOverlay.tsx:968
 msgid "Model options"
 msgstr "Model options"
+
+#: src/pages/Onboarding.tsx:278
+msgid "Model providers"
+msgstr "Model providers"
 
 #: src/pages/AccountSettingsOverlay.tsx:216
 msgid "Model spend uses your provider keys."
@@ -1906,12 +1910,12 @@ msgid "Model updated."
 msgstr "Model updated."
 
 #: src/pages/ModelSettingsOverlay.tsx:323
-#: src/pages/Shell.tsx:2820
+#: src/pages/Shell.tsx:2834
 msgid "Models"
 msgstr "Models"
 
 #: src/pages/ModelSettingsOverlay.tsx:462
-#: src/pages/Onboarding.tsx:306
+#: src/pages/Onboarding.tsx:383
 msgid "Models from server"
 msgstr "Models from server"
 
@@ -1940,7 +1944,7 @@ msgstr "Move to"
 #: src/pages/Auth.tsx:110
 #: src/pages/GroupPanel.tsx:119
 #: src/pages/GroupPanel.tsx:212
-#: src/pages/Onboarding.tsx:507
+#: src/pages/Onboarding.tsx:581
 #: src/pages/RoutineEditor.tsx:281
 #: src/pages/shell/bot-panel.tsx:122
 #: src/pages/shell/bot-panel.tsx:288
@@ -1949,7 +1953,7 @@ msgstr "Move to"
 msgid "Name"
 msgstr "Name"
 
-#: src/pages/Onboarding.tsx:512
+#: src/pages/Onboarding.tsx:586
 #: src/pages/shell/bot-panel.tsx:128
 msgid "Name this bot"
 msgstr "Name this bot"
@@ -1970,13 +1974,13 @@ msgstr "Needs input"
 msgid "Needs takeover"
 msgstr "Needs takeover"
 
-#: src/pages/Shell.tsx:2413
+#: src/pages/Shell.tsx:2427
 #: src/pages/shell/bot-panel.tsx:106
 msgid "New bot"
 msgstr "New bot"
 
 #: src/pages/GroupPanel.tsx:101
-#: src/pages/Shell.tsx:2423
+#: src/pages/Shell.tsx:2437
 msgid "New group"
 msgstr "New group"
 
@@ -1994,7 +1998,7 @@ msgstr "New password"
 msgid "New section"
 msgstr "New section"
 
-#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2449
 #: src/pages/shell/dialogs.tsx:68
 msgid "New space"
 msgstr "New space"
@@ -2059,6 +2063,10 @@ msgstr "No messages with {peerBotName} yet."
 #: src/pages/ModelSettingsOverlay.tsx:733
 msgid "No model catalog is available."
 msgstr "No model catalog is available."
+
+#: src/pages/Onboarding.tsx:339
+msgid "No providers found"
+msgstr "No providers found"
 
 #: src/pages/ModelSettingsOverlay.tsx:402
 msgid "No providers found."
@@ -2132,21 +2140,21 @@ msgid "on the 1st at {0}"
 msgstr "on the 1st at {0}"
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3154
-#: src/pages/Shell.tsx:3159
+#: src/pages/Shell.tsx:3170
+#: src/pages/Shell.tsx:3175
 msgid "Open"
 msgstr "Open"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2492
+#: src/pages/Shell.tsx:2506
 msgid "Open {0}"
 msgstr "Open {0}"
 
-#: src/pages/Shell.tsx:3119
+#: src/pages/Shell.tsx:3133
 msgid "Open in full window"
 msgstr "Open in full window"
 
-#: src/pages/Shell.tsx:2888
+#: src/pages/Shell.tsx:2902
 msgid "Open navigation"
 msgstr "Open navigation"
 
@@ -2155,11 +2163,11 @@ msgid "Open work"
 msgstr "Open work"
 
 #: src/pages/ModelSettingsOverlay.tsx:422
-#: src/pages/Onboarding.tsx:275
+#: src/pages/Onboarding.tsx:352
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-compatible server URL"
 
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5251
 msgid "Opened its thread."
 msgstr "Opened its thread."
 
@@ -2168,7 +2176,7 @@ msgid "Opening your Space…"
 msgstr "Opening your Space…"
 
 #: src/pages/ModelSettingsOverlay.tsx:646
-#: src/pages/Onboarding.tsx:446
+#: src/pages/Onboarding.tsx:520
 msgid "Optional"
 msgstr "Optional"
 
@@ -2184,7 +2192,7 @@ msgstr "Optional header value"
 msgid "Or connect an API key"
 msgstr "Or connect an API key"
 
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:531
 msgid "Or paste an API key"
 msgstr "Or paste an API key"
 
@@ -2197,7 +2205,7 @@ msgid "Organization API key"
 msgstr "Organization API key"
 
 #: src/pages/ModelSettingsOverlay.tsx:470
-#: src/pages/Onboarding.tsx:315
+#: src/pages/Onboarding.tsx:392
 msgid "Other model…"
 msgstr "Other model…"
 
@@ -2235,7 +2243,7 @@ msgid "Paste a replacement key"
 msgstr "Paste a replacement key"
 
 #: src/pages/ModelSettingsOverlay.tsx:433
-#: src/pages/Onboarding.tsx:286
+#: src/pages/Onboarding.tsx:363
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 
@@ -2278,6 +2286,7 @@ msgid "Private"
 msgstr "Private"
 
 #: src/pages/MemorySettingsOverlay.tsx:216
+#: src/pages/Onboarding.tsx:250
 msgid "Provider"
 msgstr "Provider"
 
@@ -2342,7 +2351,7 @@ msgstr "Refresh view"
 msgid "Refreshing…"
 msgstr "Refreshing…"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:4959
 msgid "Release"
 msgstr "Release"
 
@@ -2355,12 +2364,12 @@ msgid "Remove"
 msgstr "Remove"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4489
+#: src/pages/Shell.tsx:4507
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4681
 msgid "Remove mention {0}"
 msgstr "Remove mention {0}"
 
@@ -2369,12 +2378,12 @@ msgid "Remove schedule"
 msgstr "Remove schedule"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4660
 msgid "Remove skill {0}"
 msgstr "Remove skill {0}"
 
-#: src/pages/Shell.tsx:4080
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4900
 msgid "Remove thumbs-up"
 msgstr "Remove thumbs-up"
 
@@ -2382,7 +2391,7 @@ msgstr "Remove thumbs-up"
 msgid "Remove webhook"
 msgstr "Remove webhook"
 
-#: src/pages/Shell.tsx:5232
+#: src/pages/Shell.tsx:5250
 msgid "Removed with chat, computer, and memory."
 msgstr "Removed with chat, computer, and memory."
 
@@ -2410,11 +2419,11 @@ msgstr "Replace API key"
 msgid "Replace key"
 msgstr "Replace key"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4891
 msgid "Reply"
 msgstr "Reply"
 
-#: src/pages/Shell.tsx:4452
+#: src/pages/Shell.tsx:4470
 msgid "Replying to {replyName}"
 msgstr "Replying to {replyName}"
 
@@ -2443,8 +2452,8 @@ msgstr "Reset your password"
 msgid "Resetting…"
 msgstr "Resetting…"
 
-#: src/pages/Shell.tsx:2721
-#: src/pages/Shell.tsx:2752
+#: src/pages/Shell.tsx:2735
+#: src/pages/Shell.tsx:2766
 msgid "Restore"
 msgstr "Restore"
 
@@ -2455,6 +2464,10 @@ msgstr "Restore the last saved workspace. Unsaved work on the computer is lost."
 #: src/App.tsx:148
 msgid "Retry now"
 msgstr "Retry now"
+
+#: src/pages/Shell.tsx:2348
+msgid "Retry screen"
+msgstr "Retry screen"
 
 #: src/pages/McpOAuthCallback.tsx:62
 msgid "Return to Rakazo"
@@ -2473,8 +2486,8 @@ msgid "Rotate key"
 msgstr "Rotate key"
 
 #: src/pages/RoutineEditor.tsx:236
-#: src/pages/Shell.tsx:3338
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3355
+#: src/pages/Shell.tsx:3365
 msgid "Routine"
 msgstr "Routine"
 
@@ -2491,7 +2504,7 @@ msgstr "Run at"
 msgid "Run history"
 msgstr "Run history"
 
-#: src/pages/Shell.tsx:3331
+#: src/pages/Shell.tsx:3348
 msgid "Run time must be in the future."
 msgstr "Run time must be in the future."
 
@@ -2549,7 +2562,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "Say yes or no, or answer in a sentence."
 
 #: src/pages/ModelSettingsOverlay.tsx:957
-#: src/pages/Shell.tsx:2449
+#: src/pages/Shell.tsx:2463
 msgid "Search"
 msgstr "Search"
 
@@ -2567,8 +2580,8 @@ msgstr "Search models"
 msgid "Search providers"
 msgstr "Search providers"
 
-#: src/pages/Onboarding.tsx:231
-#: src/pages/Onboarding.tsx:232
+#: src/pages/Onboarding.tsx:272
+#: src/pages/Onboarding.tsx:273
 msgid "Search providers and models"
 msgstr "Search providers and models"
 
@@ -2576,12 +2589,16 @@ msgstr "Search providers and models"
 msgid "Searching…"
 msgstr "Searching…"
 
-#: src/pages/Shell.tsx:2917
+#: src/pages/Shell.tsx:2931
 msgid "Select a bot"
 msgstr "Select a bot"
 
-#: src/pages/Shell.tsx:4747
-#: src/pages/Shell.tsx:4768
+#: src/pages/Onboarding.tsx:320
+msgid "Selected"
+msgstr "Selected"
+
+#: src/pages/Shell.tsx:4765
+#: src/pages/Shell.tsx:4786
 msgid "Send"
 msgstr "Send"
 
@@ -2618,31 +2635,31 @@ msgstr "Server name"
 
 #: src/pages/McpServersOverlay.tsx:329
 #: src/pages/ModelSettingsOverlay.tsx:417
-#: src/pages/Onboarding.tsx:270
+#: src/pages/Onboarding.tsx:347
 msgid "Server URL"
 msgstr "Server URL"
 
-#: src/pages/Shell.tsx:2926
+#: src/pages/Shell.tsx:2940
 msgid "Set up voice to call"
 msgstr "Set up voice to call"
 
 #: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2801
-#: src/pages/Shell.tsx:2809
-#: src/pages/Shell.tsx:3069
+#: src/pages/Shell.tsx:2815
+#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:3083
 msgid "Settings"
 msgstr "Settings"
 
-#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4804
 msgid "Settings: General"
 msgstr "Settings: General"
 
-#: src/pages/Shell.tsx:4788
+#: src/pages/Shell.tsx:4806
 msgid "Settings: Usage"
 msgstr "Settings: Usage"
 
 #: src/pages/ModelSettingsOverlay.tsx:430
-#: src/pages/Onboarding.tsx:283
+#: src/pages/Onboarding.tsx:360
 msgid "Setup help"
 msgstr "Setup help"
 
@@ -2651,7 +2668,11 @@ msgstr "Setup help"
 msgid "Shared"
 msgstr "Shared"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:264
+msgid "Show all providers"
+msgstr "Show all providers"
+
+#: src/pages/Shell.tsx:3107
 msgid "Show computer"
 msgstr "Show computer"
 
@@ -2663,7 +2684,11 @@ msgstr "Show more"
 msgid "Show password"
 msgstr "Show password"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:262
+msgid "Show popular providers"
+msgstr "Show popular providers"
+
+#: src/pages/Shell.tsx:3107
 msgid "Show settings"
 msgstr "Show settings"
 
@@ -2671,7 +2696,7 @@ msgstr "Show settings"
 #: src/pages/Auth.tsx:206
 #: src/pages/Auth.tsx:264
 #: src/pages/ModelSettingsOverlay.tsx:628
-#: src/pages/Onboarding.tsx:108
+#: src/pages/Onboarding.tsx:131
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -2685,15 +2710,15 @@ msgid "Sign up"
 msgstr "Sign up"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4550
+#: src/pages/Shell.tsx:4568
 msgid "Skill {0}"
 msgstr "Skill {0}"
 
-#: src/pages/Shell.tsx:4948
+#: src/pages/Shell.tsx:4966
 msgid "Skip"
 msgstr "Skip"
 
-#: src/pages/Onboarding.tsx:495
+#: src/pages/Onboarding.tsx:569
 msgid "Skip for now"
 msgstr "Skip for now"
 
@@ -2702,7 +2727,7 @@ msgid "Skip or deploy key"
 msgstr "Skip or deploy key"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1905
+#: src/pages/Shell.tsx:1907
 msgid "Skipped {0}"
 msgstr "Skipped {0}"
 
@@ -2723,8 +2748,8 @@ msgstr "Space default"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space interrupts · Esc hangs up"
 
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Speak"
 msgstr "Speak"
 
@@ -2736,8 +2761,8 @@ msgstr "Speak + transcribe"
 msgid "Speak only"
 msgstr "Speak only"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Speak this reply"
 msgstr "Speak this reply"
 
@@ -2755,7 +2780,7 @@ msgstr "Starting"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
 #: src/pages/ModelSettingsOverlay.tsx:626
-#: src/pages/Onboarding.tsx:431
+#: src/pages/Onboarding.tsx:505
 msgid "Starting…"
 msgstr "Starting…"
 
@@ -2763,20 +2788,20 @@ msgstr "Starting…"
 msgid "Steps"
 msgstr "Steps"
 
-#: src/pages/Shell.tsx:3755
-#: src/pages/Shell.tsx:3760
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:3772
+#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Stop"
 msgstr "Stop"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Stop dictation"
 msgstr "Stop dictation"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Stop speaking"
 msgstr "Stop speaking"
 
@@ -2794,13 +2819,13 @@ msgstr "Stopped."
 msgid "Stored encrypted"
 msgstr "Stored encrypted"
 
-#: src/pages/Shell.tsx:5186
+#: src/pages/Shell.tsx:5204
 msgid "subagent"
 msgstr "subagent"
 
 #: src/components/AskCard.tsx:140
 #: src/pages/ModelSettingsOverlay.tsx:586
-#: src/pages/Onboarding.tsx:398
+#: src/pages/Onboarding.tsx:472
 msgid "Submit"
 msgstr "Submit"
 
@@ -2821,7 +2846,7 @@ msgstr "System"
 msgid "Teach a task"
 msgstr "Teach a task"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3005
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Teaching in progress — stop teaching before sending a new message."
 
@@ -2829,7 +2854,7 @@ msgstr "Teaching in progress — stop teaching before sending a new message."
 msgid "Team"
 msgstr "Team"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "Team Computer"
 msgstr "Team Computer"
 
@@ -2857,11 +2882,11 @@ msgstr "The selected memory provider is not available in this build."
 msgid "Thinking"
 msgstr "Thinking"
 
-#: src/pages/Shell.tsx:3123
+#: src/pages/Shell.tsx:3137
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 
-#: src/pages/Shell.tsx:3811
+#: src/pages/Shell.tsx:3828
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 
@@ -2898,7 +2923,7 @@ msgstr "This Mac runs shell commands with your account, including files in your 
 msgid "This permanently removes every message and stops current work. The chat remains available."
 msgstr "This permanently removes every message and stops current work. The chat remains available."
 
-#: src/pages/Onboarding.tsx:471
+#: src/pages/Onboarding.tsx:545
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "This provider cannot paste a key here. Skip if this deployment already has credentials."
 
@@ -2930,7 +2955,7 @@ msgstr "This subscription sign-in is not available in Rakazo yet. Use a deployme
 msgid "Time of day"
 msgstr "Time of day"
 
-#: src/pages/Onboarding.tsx:520
+#: src/pages/Onboarding.tsx:594
 #: src/pages/shell/bot-panel.tsx:133
 #: src/pages/shell/bot-panel.tsx:298
 msgid "Title"
@@ -2965,7 +2990,7 @@ msgid "Unpin"
 msgstr "Unpin"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1978
 msgid "Unsupported file type: {0}"
 msgstr "Unsupported file type: {0}"
 
@@ -3005,7 +3030,7 @@ msgid "Updating…"
 msgstr "Updating…"
 
 #: src/pages/AccountSettingsOverlay.tsx:206
-#: src/pages/Shell.tsx:2852
+#: src/pages/Shell.tsx:2866
 msgid "Usage"
 msgstr "Usage"
 
@@ -3014,7 +3039,7 @@ msgid "Use {hostLabel}"
 msgstr "Use {hostLabel}"
 
 #: src/pages/ModelSettingsOverlay.tsx:495
-#: src/pages/Onboarding.tsx:334
+#: src/pages/Onboarding.tsx:411
 msgid "Use a found model"
 msgstr "Use a found model"
 
@@ -3030,7 +3055,7 @@ msgstr "Verify and add"
 msgid "Verifying…"
 msgstr "Verifying…"
 
-#: src/pages/Shell.tsx:2842
+#: src/pages/Shell.tsx:2856
 #: src/pages/shell/bot-panel.tsx:418
 #: src/pages/VoiceSettingsOverlay.tsx:145
 #: src/pages/VoiceSettingsOverlay.tsx:288
@@ -3039,8 +3064,8 @@ msgstr "Voice"
 
 #: src/pages/ModelSettingsOverlay.tsx:590
 #: src/pages/ModelSettingsOverlay.tsx:612
-#: src/pages/Onboarding.tsx:402
-#: src/pages/Onboarding.tsx:424
+#: src/pages/Onboarding.tsx:476
+#: src/pages/Onboarding.tsx:498
 msgid "Waiting for sign-in…"
 msgstr "Waiting for sign-in…"
 
@@ -3074,7 +3099,7 @@ msgstr "What result will you demonstrate?"
 msgid "What should this routine do each time it runs?"
 msgstr "What should this routine do each time it runs?"
 
-#: src/pages/Onboarding.tsx:538
+#: src/pages/Onboarding.tsx:612
 #: src/pages/shell/bot-panel.tsx:150
 msgid "What this bot is for"
 msgstr "What this bot is for"
@@ -3103,13 +3128,13 @@ msgstr "Where should bots run?"
 #: src/pages/Auth.tsx:185
 #: src/pages/Auth.tsx:293
 #: src/pages/CallView.tsx:251
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Working…"
 msgstr "Working…"
 
-#: src/pages/Shell.tsx:1679
-#: src/pages/Shell.tsx:2339
+#: src/pages/Shell.tsx:1681
+#: src/pages/Shell.tsx:2353
 msgid "You"
 msgstr "You"
 
@@ -3121,7 +3146,7 @@ msgstr "You can close this tab if it does not redirect automatically."
 msgid "You can close this window."
 msgstr "You can close this window."
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3762
 msgid "You have control"
 msgstr "You have control"
 

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2625
+#: src/pages/Shell.tsx:2639
 msgid " (unread)"
 msgstr " (अपठित)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# मॉडल} other {# मॉडल}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1885
+#: src/pages/Shell.tsx:1887
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (अधिकतम {ATTACHMENT_MAX_COUNT} अटैचमेंट)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1889
+#: src/pages/Shell.tsx:1891
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB से अधिक)"
 
@@ -63,16 +63,16 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:210
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2870
 msgid "{0} runs · {1} tokens"
 msgstr "{0} रन · {1} टोकन"
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3164
+#: src/pages/Shell.tsx:3181
 msgid "{0}'s screen"
 msgstr ""
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "{botName}’s computer"
 msgstr "{botName} का कंप्यूटर"
 
@@ -116,12 +116,12 @@ msgstr "{size} B"
 msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
-#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:3937
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} काम कर रहा है"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4517
+#: src/pages/Shell.tsx:4535
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -158,8 +158,8 @@ msgstr "सक्रिय मॉडल"
 msgid "Active voice"
 msgstr "सक्रिय आवाज़"
 
-#: src/pages/Shell.tsx:2374
-#: src/pages/Shell.tsx:2376
+#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2390
 msgid "Activity"
 msgstr "गतिविधि"
 
@@ -173,7 +173,7 @@ msgstr "जोड़ें"
 msgid "Add a model in Settings to use this."
 msgstr ""
 
-#: src/pages/Shell.tsx:3326
+#: src/pages/Shell.tsx:3343
 msgid "Add a run time for this one-shot."
 msgstr ""
 
@@ -181,7 +181,7 @@ msgstr ""
 msgid "Add a schedule or webhook to run this routine."
 msgstr ""
 
-#: src/pages/Shell.tsx:3298
+#: src/pages/Shell.tsx:3315
 msgid "Add a schedule or webhook trigger"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgstr "रिमोट MCP सर्वर जोड़ें"
 msgid "Add server"
 msgstr "सर्वर जोड़ें"
 
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4900
 msgid "Add thumbs-up"
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr "उन्नत"
 msgid "Advanced..."
 msgstr ""
 
-#: src/pages/Shell.tsx:2944
+#: src/pages/Shell.tsx:2958
 msgid "Agent computer"
 msgstr "एजेंट कंप्यूटर"
 
@@ -261,7 +261,7 @@ msgid "Agent connections"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:385
-#: src/pages/McpServersOverlay.tsx:448
+#: src/pages/McpServersOverlay.tsx:452
 msgid "Agents:"
 msgstr "एजेंट:"
 
@@ -333,9 +333,9 @@ msgstr ""
 #: src/pages/ModelSettingsOverlay.tsx:640
 #: src/pages/ModelSettingsOverlay.tsx:643
 #: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/Onboarding.tsx:440
-#: src/pages/Onboarding.tsx:443
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:514
+#: src/pages/Onboarding.tsx:517
+#: src/pages/Onboarding.tsx:531
 #: src/pages/VoiceSettingsOverlay.tsx:258
 msgid "API key"
 msgstr "API कुंजी"
@@ -367,15 +367,15 @@ msgstr "अपने एजेंट को इसके टूल उपयो�
 msgid "Archive"
 msgstr "आर्काइव करें"
 
-#: src/pages/Shell.tsx:5220
+#: src/pages/Shell.tsx:5238
 msgid "archived"
 msgstr "आर्काइव किया गया"
 
-#: src/pages/Shell.tsx:2694
+#: src/pages/Shell.tsx:2708
 msgid "Archived"
 msgstr "आर्काइव किया गया"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5249
 msgid "Archived. Chat, memory, and files kept."
 msgstr "आर्काइव किया गया। चैट, मेमोरी और फ़ाइलें सुरक्षित रखी गईं।"
 
@@ -425,16 +425,16 @@ msgstr "{0} बजे"
 msgid "at {timeSelect}"
 msgstr "{timeSelect} बजे"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4615
 msgid "Attach file"
 msgstr "फ़ाइल संलग्न करें"
 
-#: src/pages/Shell.tsx:4841
+#: src/pages/Shell.tsx:4859
 msgid "Attachment"
 msgstr "अटैचमेंट"
 
 #: src/pages/ModelSettingsOverlay.tsx:573
-#: src/pages/Onboarding.tsx:389
+#: src/pages/Onboarding.tsx:463
 msgid "Authorization code or callback URL"
 msgstr "ऑथराइज़ेशन कोड या कॉलबैक URL"
 
@@ -474,23 +474,19 @@ msgstr "बेस URL"
 msgid "Bearer token"
 msgstr "बियरर टोकन"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5446
 msgid "Booting live desktop…"
 msgstr "लाइव डेस्कटॉप शुरू हो रहा है…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3712
+#: src/pages/Shell.tsx:3729
 msgid "Booting up {0}’s computer"
 msgstr "{0} का कंप्यूटर शुरू हो रहा है"
 
-#: src/pages/Shell.tsx:5080
-#: src/pages/Shell.tsx:5081
-#: src/pages/Shell.tsx:5224
+#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5099
+#: src/pages/Shell.tsx:5242
 msgid "bot"
-msgstr "बॉट"
-
-#: src/pages/Shell.tsx:1680
-msgid "Bot"
 msgstr "बॉट"
 
 #. js-lingui-explicit-id
@@ -498,11 +494,15 @@ msgstr "बॉट"
 msgid "Bot"
 msgstr ""
 
-#: src/pages/Shell.tsx:3819
+#: src/pages/Shell.tsx:1682
+msgid "Bot"
+msgstr "बॉट"
+
+#: src/pages/Shell.tsx:3836
 msgid "Bot screen"
 msgstr "बॉट स्क्रीन"
 
-#: src/pages/Shell.tsx:3130
+#: src/pages/Shell.tsx:3144
 msgid "Bot screen preview"
 msgstr "बॉट स्क्रीन प्रीव्यू"
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first. These preferences apply across all your bots."
 msgstr "बॉट डिफ़ॉल्ट रूप से बिना पूछे कार्रवाई करते हैं। अपवाद तभी जोड़ें जब आप किसी प्रकार की कार्रवाई की पहले समीक्षा करना चाहते हों। ये प्राथमिकताएं आपके सभी बॉट्स पर लागू होती हैं।"
 
-#: src/pages/Shell.tsx:3920
+#: src/pages/Shell.tsx:3938
 msgid "Bots are working"
 msgstr "बॉट काम कर रहे हैं"
 
@@ -523,8 +523,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "अपनी कुंजी स्वयं लाएं। प्रोवाइडर बदला जा सकता है; आपके बॉट्स के बोलने और कॉल करने वाले बटन वही रहते हैं।"
 
 #: src/pages/CallView.tsx:241
-#: src/pages/Shell.tsx:2926
-#: src/pages/Shell.tsx:2927
+#: src/pages/Shell.tsx:2940
+#: src/pages/Shell.tsx:2941
 msgid "Call"
 msgstr "कॉल"
 
@@ -553,7 +553,7 @@ msgstr "नया बॉट रद्द करें"
 msgid "Cancel new group"
 msgstr "नया समूह रद्द करें"
 
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4473
 msgid "Cancel reply"
 msgstr "उत्तर रद्द करें"
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Chat apps, group channels, and agent connections."
 msgstr ""
 
-#: src/pages/Shell.tsx:4784
+#: src/pages/Shell.tsx:4802
 msgid "Chat Settings"
 msgstr "चैट सेटिंग्स"
 
@@ -598,8 +598,8 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: src/pages/Shell.tsx:3339
-#: src/pages/Shell.tsx:3349
+#: src/pages/Shell.tsx:3356
+#: src/pages/Shell.tsx:3366
 msgid "Check in."
 msgstr "जांच करें।"
 
@@ -618,10 +618,6 @@ msgstr ""
 #: src/pages/MessagingSettingsOverlay.tsx:152
 msgid "Choose a bot…"
 msgstr ""
-
-#: src/pages/Onboarding.tsx:226
-msgid "Choose a model to get started."
-msgstr "शुरू करने के लिए एक मॉडल चुनें।"
 
 #: src/pages/Auth.tsx:257
 msgid "Choose a new password"
@@ -661,7 +657,7 @@ msgstr "बंद करें"
 msgid "Close chart"
 msgstr "चार्ट बंद करें"
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3810
 msgid "Close computer"
 msgstr "कंप्यूटर बंद करें"
 
@@ -689,11 +685,11 @@ msgstr ""
 msgid "Close model settings"
 msgstr "मॉडल सेटिंग्स बंद करें"
 
-#: src/pages/Shell.tsx:2359
+#: src/pages/Shell.tsx:2373
 msgid "Close navigation"
 msgstr "नेविगेशन बंद करें"
 
-#: src/pages/Shell.tsx:3103
+#: src/pages/Shell.tsx:3117
 msgid "Close panel"
 msgstr "पैनल बंद करें"
 
@@ -719,7 +715,7 @@ msgid "Code"
 msgstr ""
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2509
 msgid "Collapse {0}"
 msgstr ""
 
@@ -735,24 +731,24 @@ msgstr "कमांड"
 msgid "Complete"
 msgstr "पूर्ण"
 
-#: src/pages/Shell.tsx:5378
+#: src/pages/Shell.tsx:5396
 #: src/pages/shell/bot-panel.tsx:47
 msgid "Computer"
 msgstr "कंप्यूटर"
 
-#: src/pages/Shell.tsx:5431
+#: src/pages/Shell.tsx:5449
 msgid "Computer failed to boot"
 msgstr "कंप्यूटर शुरू नहीं हो सका"
 
-#: src/pages/Shell.tsx:3841
+#: src/pages/Shell.tsx:3859
 msgid "Computer is asleep"
 msgstr "कंप्यूटर निष्क्रिय है"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5448
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5432
+#: src/pages/Shell.tsx:5450
 msgid "Computer is stopped"
 msgstr "कंप्यूटर रुका हुआ है"
 
@@ -772,7 +768,7 @@ msgstr "डिप्लॉयमेंट द्वारा कॉन्फ़�
 msgid "Configured servers"
 msgstr "कॉन्फ़िगर किए गए सर्वर"
 
-#: src/pages/McpServersOverlay.tsx:502
+#: src/pages/McpServersOverlay.tsx:506
 msgid "Confirm delete"
 msgstr "डिलीट की पुष्टि करें"
 
@@ -786,7 +782,7 @@ msgstr "पासवर्ड की पुष्टि करें"
 msgid "Connect"
 msgstr "कनेक्ट करें"
 
-#: src/pages/Onboarding.tsx:223
+#: src/pages/Onboarding.tsx:246
 msgid "Connect a model"
 msgstr "एक मॉडल कनेक्ट करें"
 
@@ -857,8 +853,8 @@ msgstr "कनेक्ट हो रहा है…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "{0} से कनेक्शन अभी लंबित है। आप इसे बंद करके बाद में जांच सकते हैं।"
 
-#: src/pages/Onboarding.tsx:484
-#: src/pages/Onboarding.tsx:545
+#: src/pages/Onboarding.tsx:558
+#: src/pages/Onboarding.tsx:619
 msgid "Continue"
 msgstr "जारी रखें"
 
@@ -866,7 +862,7 @@ msgstr "जारी रखें"
 msgid "Continue with email"
 msgstr "ईमेल से जारी रखें"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4912
 msgid "Copy"
 msgstr "कॉपी करें"
 
@@ -923,6 +919,10 @@ msgstr "यह प्रोवाइडर कनेक्ट नहीं ह�
 msgid "Could not connect this voice provider"
 msgstr "यह आवाज़ प्रोवाइडर कनेक्ट नहीं हो सका"
 
+#: src/pages/Shell.tsx:821
+msgid "Could not connect to the computer screen"
+msgstr ""
+
 #: src/pages/Auth.tsx:85
 msgid "Could not continue"
 msgstr "जारी नहीं रखा जा सका"
@@ -943,7 +943,7 @@ msgstr "सेक्शन नहीं बनाया जा सका"
 msgid "Could not create space"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:208
+#: src/pages/Onboarding.tsx:231
 msgid "Could not create your bot"
 msgstr "आपका बॉट नहीं बनाया जा सका"
 
@@ -1027,7 +1027,7 @@ msgid "Could not reach the server"
 msgstr "सर्वर से संपर्क नहीं हो सका"
 
 #: src/pages/ModelSettingsOverlay.tsx:232
-#: src/pages/Onboarding.tsx:154
+#: src/pages/Onboarding.tsx:177
 msgid "Could not reach this model server"
 msgstr "इस मॉडल सर्वर तक नहीं पहुंचा जा सका"
 
@@ -1059,7 +1059,7 @@ msgstr "पासवर्ड रीसेट नहीं किया जा �
 msgid "Could not revoke connection"
 msgstr "कनेक्शन रद्द नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:3401
+#: src/pages/Shell.tsx:3418
 msgid "Could not run routine"
 msgstr ""
 
@@ -1075,11 +1075,11 @@ msgstr ""
 msgid "Could not save group"
 msgstr "समूह सहेजा नहीं जा सका"
 
-#: src/pages/Onboarding.tsx:181
+#: src/pages/Onboarding.tsx:204
 msgid "Could not save model"
 msgstr "मॉडल सहेजा नहीं जा सका"
 
-#: src/pages/Shell.tsx:3372
+#: src/pages/Shell.tsx:3389
 msgid "Could not save routine"
 msgstr "रूटीन सहेजा नहीं जा सका"
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "यह उत्तर सबमिट नहीं किया जा सका"
 
-#: src/pages/Shell.tsx:2205
+#: src/pages/Shell.tsx:2207
 msgid "Could not take control"
 msgstr "नियंत्रण नहीं लिया जा सका"
 
@@ -1135,7 +1135,7 @@ msgstr "एजेंट एक्सेस अपडेट नहीं हो �
 msgid "Could not update computer"
 msgstr "कंप्यूटर अपडेट नहीं हो सका"
 
-#: src/pages/Shell.tsx:1871
+#: src/pages/Shell.tsx:1873
 msgid "Could not update reaction"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Couldn't update messaging settings"
 msgstr ""
 
-#: src/pages/Shell.tsx:2395
+#: src/pages/Shell.tsx:2409
 #: src/pages/shell/bot-panel.tsx:161
 #: src/pages/shell/dialogs.tsx:155
 msgid "Create"
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Create space"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:504
+#: src/pages/Onboarding.tsx:578
 msgid "Create your first bot"
 msgstr "अपना पहला बॉट बनाएं"
 
@@ -1254,10 +1254,10 @@ msgid "Default scope"
 msgstr "डिफ़ॉल्ट स्कोप"
 
 #: src/pages/BotContextMenu.tsx:150
-#: src/pages/McpServersOverlay.tsx:504
+#: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:272
-#: src/pages/Shell.tsx:2730
-#: src/pages/Shell.tsx:2761
+#: src/pages/Shell.tsx:2744
+#: src/pages/Shell.tsx:2775
 #: src/pages/shell/dialogs.tsx:298
 #: src/pages/shell/dialogs.tsx:355
 msgid "Delete"
@@ -1265,8 +1265,8 @@ msgstr "डिलीट करें"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2727
-#: src/pages/Shell.tsx:2758
+#: src/pages/Shell.tsx:2741
+#: src/pages/Shell.tsx:2772
 msgid "Delete {0}"
 msgstr "{0} डिलीट करें"
 
@@ -1285,7 +1285,7 @@ msgstr "समूह डिलीट करें"
 msgid "Delete memories too"
 msgstr "मेमोरी भी डिलीट करें"
 
-#: src/pages/Shell.tsx:5222
+#: src/pages/Shell.tsx:5240
 msgid "deleted"
 msgstr "डिलीट किया गया"
 
@@ -1307,22 +1307,22 @@ msgstr "अस्वीकार करें"
 msgid "Deployment default"
 msgstr "डिप्लॉयमेंट डिफ़ॉल्ट"
 
-#: src/pages/Onboarding.tsx:525
+#: src/pages/Onboarding.tsx:599
 #: src/pages/shell/bot-panel.tsx:139
 msgid "Describe what this bot does"
 msgstr "बताएं कि यह बॉट क्या करता है"
 
-#: src/pages/Onboarding.tsx:533
+#: src/pages/Onboarding.tsx:607
 #: src/pages/shell/bot-panel.tsx:144
 #: src/pages/shell/bot-panel.tsx:308
 msgid "Description"
 msgstr "विवरण"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Dictate"
 msgstr "बोलकर लिखें"
 
-#: src/pages/McpServersOverlay.tsx:489
+#: src/pages/McpServersOverlay.tsx:493
 #: src/pages/MemorySettingsOverlay.tsx:207
 msgid "Disconnect"
 msgstr "डिस्कनेक्ट करें"
@@ -1335,7 +1335,7 @@ msgstr "डिस्कनेक्ट हो रहा है…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4453
 msgid "Dismiss error"
 msgstr ""
 
@@ -1365,8 +1365,8 @@ msgid "Don’t have an account?"
 msgstr "खाता नहीं है?"
 
 #: src/pages/ActivityList.tsx:157
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Done"
 msgstr "पूर्ण"
 
@@ -1389,7 +1389,7 @@ msgstr "ड्राफ़्ट स्किल"
 msgid "Duplicate"
 msgstr "डुप्लिकेट"
 
-#: src/pages/Shell.tsx:5021
+#: src/pages/Shell.tsx:5039
 msgid "Earlier message"
 msgstr "पुराना संदेश"
 
@@ -1407,7 +1407,7 @@ msgstr "ईमेल"
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
 #: src/pages/ModelSettingsOverlay.tsx:596
-#: src/pages/Onboarding.tsx:408
+#: src/pages/Onboarding.tsx:482
 msgid "Enter this code at <0>{0}</0>"
 msgstr "यह कोड <0>{0}</0> पर दर्ज करें"
 
@@ -1450,7 +1450,7 @@ msgid "Expand"
 msgstr "विस्तृत करें"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2494
+#: src/pages/Shell.tsx:2508
 msgid "Expand {0}"
 msgstr ""
 
@@ -1470,14 +1470,14 @@ msgstr "अतिरिक्त उच्च"
 msgid "Failed"
 msgstr "विफल"
 
-#: src/pages/Shell.tsx:2023
 #: src/pages/Shell.tsx:2025
 #: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2029
 msgid "Failed to send message"
 msgstr "संदेश भेजने में विफल"
 
-#: src/pages/Shell.tsx:2060
-#: src/pages/Shell.tsx:2079
+#: src/pages/Shell.tsx:2062
+#: src/pages/Shell.tsx:2081
 msgid "Failed to stop"
 msgstr "रोकने में विफल"
 
@@ -1491,18 +1491,18 @@ msgid "Failure handling"
 msgstr "विफलता प्रबंधन"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Find models"
 msgstr "मॉडल खोजें"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Finding…"
 msgstr "खोजा जा रहा है…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
 #: src/pages/ModelSettingsOverlay.tsx:556
-#: src/pages/Onboarding.tsx:372
+#: src/pages/Onboarding.tsx:446
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "<0>{0}</0> पर साइन इन पूरा करें। अंतिम पेज शायद लोड न हो; उसका URL या कोड यहां पेस्ट करें।"
 
@@ -1536,8 +1536,8 @@ msgid "Git event"
 msgstr ""
 
 #: src/pages/MessagingSettingsOverlay.tsx:198
-#: src/pages/Shell.tsx:2916
-#: src/pages/Shell.tsx:3073
+#: src/pages/Shell.tsx:2930
+#: src/pages/Shell.tsx:3087
 msgid "Group"
 msgstr "समूह"
 
@@ -1587,11 +1587,11 @@ msgstr ""
 msgid "High"
 msgstr "उच्च"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk"
 msgstr "बोलने के लिए दबाए रखें"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk (on-device dictation)"
 msgstr "बोलने के लिए दबाए रखें (डिवाइस पर ही श्रुतलेखन)"
 
@@ -1611,7 +1611,7 @@ msgstr "कितनी बार"
 msgid "How to check"
 msgstr "जांच कैसे करें"
 
-#: src/pages/Shell.tsx:4951
+#: src/pages/Shell.tsx:4969
 msgid "I’m done"
 msgstr "मेरा काम हो गया"
 
@@ -1640,7 +1640,7 @@ msgid "Instruction"
 msgstr "निर्देश"
 
 #: src/pages/PluginsOverlay.tsx:247
-#: src/pages/Shell.tsx:2779
+#: src/pages/Shell.tsx:2793
 msgid "Integrations"
 msgstr "इंटीग्रेशन"
 
@@ -1670,11 +1670,11 @@ msgstr "पृथक"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "इसकी बातचीत, फ़ाइलें और रूटीन स्थायी रूप से डिलीट कर दिए जाएंगे। इसके बनाए बॉट आपकी सूची में बने रहेंगे।"
 
-#: src/pages/Shell.tsx:4105
+#: src/pages/Shell.tsx:4123
 msgid "Jump to latest"
 msgstr "नवीनतम संदेश पर जाएँ"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5034
 msgid "Jump to replied message"
 msgstr "जिस संदेश का उत्तर दिया गया उस पर जाएं"
 
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "सुना जा रहा है…"
 
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Load earlier messages"
 msgstr "पुराने संदेश लोड करें"
 
@@ -1754,9 +1754,9 @@ msgid "Loading voice providers…"
 msgstr "आवाज़ प्रोवाइडर्स लोड हो रहे हैं…"
 
 #: src/App.tsx:54
-#: src/pages/Onboarding.tsx:217
+#: src/pages/Onboarding.tsx:240
 #: src/pages/PeerMessagesOverlay.tsx:99
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Loading…"
 msgstr "लोड हो रहा है…"
 
@@ -1764,7 +1764,7 @@ msgstr "लोड हो रहा है…"
 msgid "Local"
 msgstr "लोकल"
 
-#: src/pages/Shell.tsx:2872
+#: src/pages/Shell.tsx:2886
 msgid "Log out"
 msgstr "लॉग आउट"
 
@@ -1810,7 +1810,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "सदस्य ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} चुनें)"
 
 #: src/pages/MemorySettingsOverlay.tsx:157
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2845
 msgid "Memory"
 msgstr "मेमोरी"
 
@@ -1818,38 +1818,38 @@ msgstr "मेमोरी"
 msgid "Memory scope"
 msgstr "मेमोरी स्कोप"
 
-#: src/pages/Shell.tsx:4503
+#: src/pages/Shell.tsx:4521
 msgid "Mentions"
 msgstr ""
-
-#: src/pages/Shell.tsx:4729
-#: src/pages/Shell.tsx:4843
-msgid "Message"
-msgstr "संदेश"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:83
 msgid "Message"
 msgstr ""
 
-#: src/pages/Shell.tsx:4725
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4861
+msgid "Message"
+msgstr "संदेश"
+
+#: src/pages/Shell.tsx:4743
+#: src/pages/Shell.tsx:4747
 msgid "Message {activeName}"
 msgstr "{activeName} को संदेश भेजें"
 
-#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4433
 msgid "Message composer"
 msgstr ""
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Message from {peer}"
 msgstr "{peer} का संदेश"
 
-#: src/pages/Shell.tsx:4726
+#: src/pages/Shell.tsx:4744
 msgid "Message…"
 msgstr "संदेश…"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Messaged {peer}"
 msgstr "{peer} को संदेश भेजा"
 
@@ -1881,21 +1881,25 @@ msgstr "मिनट"
 #: src/pages/ModelSettingsOverlay.tsx:449
 #: src/pages/ModelSettingsOverlay.tsx:503
 #: src/pages/ModelSettingsOverlay.tsx:932
-#: src/pages/Onboarding.tsx:300
-#: src/pages/Onboarding.tsx:342
-#: src/pages/Onboarding.tsx:350
+#: src/pages/Onboarding.tsx:377
+#: src/pages/Onboarding.tsx:419
+#: src/pages/Onboarding.tsx:427
 #: src/pages/shell/bot-panel.tsx:332
 msgid "Model"
 msgstr "मॉडल"
 
 #: src/pages/ModelSettingsOverlay.tsx:483
-#: src/pages/Onboarding.tsx:322
+#: src/pages/Onboarding.tsx:399
 msgid "Model id"
 msgstr "मॉडल आईडी"
 
 #: src/pages/ModelSettingsOverlay.tsx:968
 msgid "Model options"
 msgstr "मॉडल विकल्प"
+
+#: src/pages/Onboarding.tsx:278
+msgid "Model providers"
+msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:216
 msgid "Model spend uses your provider keys."
@@ -1906,12 +1910,12 @@ msgid "Model updated."
 msgstr "मॉडल अपडेट किया गया।"
 
 #: src/pages/ModelSettingsOverlay.tsx:323
-#: src/pages/Shell.tsx:2820
+#: src/pages/Shell.tsx:2834
 msgid "Models"
 msgstr "मॉडल्स"
 
 #: src/pages/ModelSettingsOverlay.tsx:462
-#: src/pages/Onboarding.tsx:306
+#: src/pages/Onboarding.tsx:383
 msgid "Models from server"
 msgstr "सर्वर से मॉडल"
 
@@ -1940,7 +1944,7 @@ msgstr "यहां ले जाएं"
 #: src/pages/Auth.tsx:110
 #: src/pages/GroupPanel.tsx:119
 #: src/pages/GroupPanel.tsx:212
-#: src/pages/Onboarding.tsx:507
+#: src/pages/Onboarding.tsx:581
 #: src/pages/RoutineEditor.tsx:281
 #: src/pages/shell/bot-panel.tsx:122
 #: src/pages/shell/bot-panel.tsx:288
@@ -1949,7 +1953,7 @@ msgstr "यहां ले जाएं"
 msgid "Name"
 msgstr "नाम"
 
-#: src/pages/Onboarding.tsx:512
+#: src/pages/Onboarding.tsx:586
 #: src/pages/shell/bot-panel.tsx:128
 msgid "Name this bot"
 msgstr "इस बॉट को नाम दें"
@@ -1970,13 +1974,13 @@ msgstr "इनपुट चाहिए"
 msgid "Needs takeover"
 msgstr "नियंत्रण लेना ज़रूरी"
 
-#: src/pages/Shell.tsx:2413
+#: src/pages/Shell.tsx:2427
 #: src/pages/shell/bot-panel.tsx:106
 msgid "New bot"
 msgstr "नया बॉट"
 
 #: src/pages/GroupPanel.tsx:101
-#: src/pages/Shell.tsx:2423
+#: src/pages/Shell.tsx:2437
 msgid "New group"
 msgstr "नया समूह"
 
@@ -1994,7 +1998,7 @@ msgstr "नया पासवर्ड"
 msgid "New section"
 msgstr "नया सेक्शन"
 
-#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2449
 #: src/pages/shell/dialogs.tsx:68
 msgid "New space"
 msgstr ""
@@ -2059,6 +2063,10 @@ msgstr "{peerBotName} के साथ अभी कोई संदेश न�
 #: src/pages/ModelSettingsOverlay.tsx:733
 msgid "No model catalog is available."
 msgstr "कोई मॉडल कैटलॉग उपलब्ध नहीं है।"
+
+#: src/pages/Onboarding.tsx:339
+msgid "No providers found"
+msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:402
 msgid "No providers found."
@@ -2132,21 +2140,21 @@ msgid "on the 1st at {0}"
 msgstr "1 तारीख को {0} बजे"
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3154
-#: src/pages/Shell.tsx:3159
+#: src/pages/Shell.tsx:3170
+#: src/pages/Shell.tsx:3175
 msgid "Open"
 msgstr "खोलें"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2492
+#: src/pages/Shell.tsx:2506
 msgid "Open {0}"
 msgstr ""
 
-#: src/pages/Shell.tsx:3119
+#: src/pages/Shell.tsx:3133
 msgid "Open in full window"
 msgstr "पूरी विंडो में खोलें"
 
-#: src/pages/Shell.tsx:2888
+#: src/pages/Shell.tsx:2902
 msgid "Open navigation"
 msgstr "नेविगेशन खोलें"
 
@@ -2155,11 +2163,11 @@ msgid "Open work"
 msgstr "खुला कार्य"
 
 #: src/pages/ModelSettingsOverlay.tsx:422
-#: src/pages/Onboarding.tsx:275
+#: src/pages/Onboarding.tsx:352
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI-संगत सर्वर URL"
 
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5251
 msgid "Opened its thread."
 msgstr "इसका थ्रेड खोला।"
 
@@ -2168,7 +2176,7 @@ msgid "Opening your Space…"
 msgstr "आपका वर्कस्पेस खुल रहा है…"
 
 #: src/pages/ModelSettingsOverlay.tsx:646
-#: src/pages/Onboarding.tsx:446
+#: src/pages/Onboarding.tsx:520
 msgid "Optional"
 msgstr "वैकल्पिक"
 
@@ -2184,7 +2192,7 @@ msgstr "वैकल्पिक हेडर मान"
 msgid "Or connect an API key"
 msgstr "या एक API कुंजी कनेक्ट करें"
 
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:531
 msgid "Or paste an API key"
 msgstr "या एक API कुंजी पेस्ट करें"
 
@@ -2197,7 +2205,7 @@ msgid "Organization API key"
 msgstr "संगठन API कुंजी"
 
 #: src/pages/ModelSettingsOverlay.tsx:470
-#: src/pages/Onboarding.tsx:315
+#: src/pages/Onboarding.tsx:392
 msgid "Other model…"
 msgstr "अन्य मॉडल…"
 
@@ -2235,7 +2243,7 @@ msgid "Paste a replacement key"
 msgstr "बदलने के लिए नई कुंजी पेस्ट करें"
 
 #: src/pages/ModelSettingsOverlay.tsx:433
-#: src/pages/Onboarding.tsx:286
+#: src/pages/Onboarding.tsx:363
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "अपने सर्वर से OpenAI-संगत पता पेस्ट करें। ज़रूरत होने पर Rakazo /v1 जोड़ देता है।"
 
@@ -2278,6 +2286,7 @@ msgid "Private"
 msgstr "निजी"
 
 #: src/pages/MemorySettingsOverlay.tsx:216
+#: src/pages/Onboarding.tsx:250
 msgid "Provider"
 msgstr "प्रोवाइडर"
 
@@ -2342,7 +2351,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:4959
 msgid "Release"
 msgstr "नियंत्रण छोड़ें"
 
@@ -2355,12 +2364,12 @@ msgid "Remove"
 msgstr "हटाएं"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4489
+#: src/pages/Shell.tsx:4507
 msgid "Remove {0}"
 msgstr "{0} हटाएं"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4681
 msgid "Remove mention {0}"
 msgstr "उल्लेख {0} हटाएं"
 
@@ -2369,12 +2378,12 @@ msgid "Remove schedule"
 msgstr ""
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4660
 msgid "Remove skill {0}"
 msgstr "स्किल {0} हटाएं"
 
-#: src/pages/Shell.tsx:4080
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4900
 msgid "Remove thumbs-up"
 msgstr ""
 
@@ -2382,7 +2391,7 @@ msgstr ""
 msgid "Remove webhook"
 msgstr ""
 
-#: src/pages/Shell.tsx:5232
+#: src/pages/Shell.tsx:5250
 msgid "Removed with chat, computer, and memory."
 msgstr "चैट, कंप्यूटर और मेमोरी सहित हटाया गया।"
 
@@ -2410,11 +2419,11 @@ msgstr "API कुंजी बदलें"
 msgid "Replace key"
 msgstr "कुंजी बदलें"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4891
 msgid "Reply"
 msgstr "उत्तर दें"
 
-#: src/pages/Shell.tsx:4452
+#: src/pages/Shell.tsx:4470
 msgid "Replying to {replyName}"
 msgstr "{replyName} को उत्तर दे रहे हैं"
 
@@ -2443,8 +2452,8 @@ msgstr "अपना पासवर्ड रीसेट करें"
 msgid "Resetting…"
 msgstr "रीसेट हो रहा है…"
 
-#: src/pages/Shell.tsx:2721
-#: src/pages/Shell.tsx:2752
+#: src/pages/Shell.tsx:2735
+#: src/pages/Shell.tsx:2766
 msgid "Restore"
 msgstr "बहाल करें"
 
@@ -2455,6 +2464,10 @@ msgstr "अंतिम सहेजे गए वर्कस्पेस क�
 #: src/App.tsx:148
 msgid "Retry now"
 msgstr "अभी पुनः प्रयास करें"
+
+#: src/pages/Shell.tsx:2348
+msgid "Retry screen"
+msgstr ""
 
 #: src/pages/McpOAuthCallback.tsx:62
 msgid "Return to Rakazo"
@@ -2473,8 +2486,8 @@ msgid "Rotate key"
 msgstr ""
 
 #: src/pages/RoutineEditor.tsx:236
-#: src/pages/Shell.tsx:3338
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3355
+#: src/pages/Shell.tsx:3365
 msgid "Routine"
 msgstr "रूटीन"
 
@@ -2491,7 +2504,7 @@ msgstr ""
 msgid "Run history"
 msgstr ""
 
-#: src/pages/Shell.tsx:3331
+#: src/pages/Shell.tsx:3348
 msgid "Run time must be in the future."
 msgstr ""
 
@@ -2549,7 +2562,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "हां या ना कहें, या एक वाक्य में उत्तर दें।"
 
 #: src/pages/ModelSettingsOverlay.tsx:957
-#: src/pages/Shell.tsx:2449
+#: src/pages/Shell.tsx:2463
 msgid "Search"
 msgstr "खोजें"
 
@@ -2567,8 +2580,8 @@ msgstr ""
 msgid "Search providers"
 msgstr "प्रोवाइडर्स खोजें"
 
-#: src/pages/Onboarding.tsx:231
-#: src/pages/Onboarding.tsx:232
+#: src/pages/Onboarding.tsx:272
+#: src/pages/Onboarding.tsx:273
 msgid "Search providers and models"
 msgstr "प्रोवाइडर्स और मॉडल खोजें"
 
@@ -2576,12 +2589,16 @@ msgstr "प्रोवाइडर्स और मॉडल खोजें"
 msgid "Searching…"
 msgstr "खोजा जा रहा है…"
 
-#: src/pages/Shell.tsx:2917
+#: src/pages/Shell.tsx:2931
 msgid "Select a bot"
 msgstr "एक बॉट चुनें"
 
-#: src/pages/Shell.tsx:4747
-#: src/pages/Shell.tsx:4768
+#: src/pages/Onboarding.tsx:320
+msgid "Selected"
+msgstr ""
+
+#: src/pages/Shell.tsx:4765
+#: src/pages/Shell.tsx:4786
 msgid "Send"
 msgstr "भेजें"
 
@@ -2618,31 +2635,31 @@ msgstr "सर्वर का नाम"
 
 #: src/pages/McpServersOverlay.tsx:329
 #: src/pages/ModelSettingsOverlay.tsx:417
-#: src/pages/Onboarding.tsx:270
+#: src/pages/Onboarding.tsx:347
 msgid "Server URL"
 msgstr "सर्वर URL"
 
-#: src/pages/Shell.tsx:2926
+#: src/pages/Shell.tsx:2940
 msgid "Set up voice to call"
 msgstr "कॉल के लिए आवाज़ सेट करें"
 
 #: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2801
-#: src/pages/Shell.tsx:2809
-#: src/pages/Shell.tsx:3069
+#: src/pages/Shell.tsx:2815
+#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:3083
 msgid "Settings"
 msgstr "सेटिंग्स"
 
-#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4804
 msgid "Settings: General"
 msgstr "सेटिंग्स: सामान्य"
 
-#: src/pages/Shell.tsx:4788
+#: src/pages/Shell.tsx:4806
 msgid "Settings: Usage"
 msgstr "सेटिंग्स: उपयोग"
 
 #: src/pages/ModelSettingsOverlay.tsx:430
-#: src/pages/Onboarding.tsx:283
+#: src/pages/Onboarding.tsx:360
 msgid "Setup help"
 msgstr "सेटअप सहायता"
 
@@ -2651,7 +2668,11 @@ msgstr "सेटअप सहायता"
 msgid "Shared"
 msgstr "साझा"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:264
+msgid "Show all providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show computer"
 msgstr "कंप्यूटर दिखाएं"
 
@@ -2663,7 +2684,11 @@ msgstr "और दिखाएँ"
 msgid "Show password"
 msgstr ""
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:262
+msgid "Show popular providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show settings"
 msgstr "सेटिंग्स दिखाएं"
 
@@ -2671,7 +2696,7 @@ msgstr "सेटिंग्स दिखाएं"
 #: src/pages/Auth.tsx:206
 #: src/pages/Auth.tsx:264
 #: src/pages/ModelSettingsOverlay.tsx:628
-#: src/pages/Onboarding.tsx:108
+#: src/pages/Onboarding.tsx:131
 msgid "Sign in"
 msgstr "साइन इन करें"
 
@@ -2685,15 +2710,15 @@ msgid "Sign up"
 msgstr "साइन अप करें"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4550
+#: src/pages/Shell.tsx:4568
 msgid "Skill {0}"
 msgstr "स्किल {0}"
 
-#: src/pages/Shell.tsx:4948
+#: src/pages/Shell.tsx:4966
 msgid "Skip"
 msgstr "छोड़ें"
 
-#: src/pages/Onboarding.tsx:495
+#: src/pages/Onboarding.tsx:569
 msgid "Skip for now"
 msgstr "अभी के लिए छोड़ें"
 
@@ -2702,7 +2727,7 @@ msgid "Skip or deploy key"
 msgstr "छोड़ें या डिप्लॉय कुंजी दें"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1905
+#: src/pages/Shell.tsx:1907
 msgid "Skipped {0}"
 msgstr "{0} को छोड़ा गया"
 
@@ -2723,8 +2748,8 @@ msgstr "स्पेस डिफ़ॉल्ट"
 msgid "Space interrupts · Esc hangs up"
 msgstr "स्पेस से बीच में रोकें · Esc से कॉल समाप्त करें"
 
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Speak"
 msgstr "बोलें"
 
@@ -2736,8 +2761,8 @@ msgstr "बोलें + लिप्यंतरण करें"
 msgid "Speak only"
 msgstr "केवल बोलें"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Speak this reply"
 msgstr "यह उत्तर बोलकर सुनाएं"
 
@@ -2755,7 +2780,7 @@ msgstr "शुरू हो रहा है"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
 #: src/pages/ModelSettingsOverlay.tsx:626
-#: src/pages/Onboarding.tsx:431
+#: src/pages/Onboarding.tsx:505
 msgid "Starting…"
 msgstr "शुरू हो रहा है…"
 
@@ -2763,20 +2788,20 @@ msgstr "शुरू हो रहा है…"
 msgid "Steps"
 msgstr "चरण"
 
-#: src/pages/Shell.tsx:3755
-#: src/pages/Shell.tsx:3760
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:3772
+#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Stop"
 msgstr "रोकें"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Stop dictation"
 msgstr "श्रुतलेखन रोकें"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Stop speaking"
 msgstr "बोलना रोकें"
 
@@ -2794,13 +2819,13 @@ msgstr "रोक दिया गया।"
 msgid "Stored encrypted"
 msgstr "एन्क्रिप्टेड रूप में संग्रहीत"
 
-#: src/pages/Shell.tsx:5186
+#: src/pages/Shell.tsx:5204
 msgid "subagent"
 msgstr "सबएजेंट"
 
 #: src/components/AskCard.tsx:140
 #: src/pages/ModelSettingsOverlay.tsx:586
-#: src/pages/Onboarding.tsx:398
+#: src/pages/Onboarding.tsx:472
 msgid "Submit"
 msgstr "सबमिट करें"
 
@@ -2821,7 +2846,7 @@ msgstr "सिस्टम"
 msgid "Teach a task"
 msgstr "कोई कार्य सिखाएं"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3005
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "सिखाना जारी है — नया संदेश भेजने से पहले सिखाना रोकें।"
 
@@ -2829,7 +2854,7 @@ msgstr "सिखाना जारी है — नया संदेश भ
 msgid "Team"
 msgstr "टीम"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "Team Computer"
 msgstr "टीम कंप्यूटर"
 
@@ -2857,11 +2882,11 @@ msgstr "चयनित मेमोरी प्रोवाइडर इस �
 msgid "Thinking"
 msgstr "सोच रहा है"
 
-#: src/pages/Shell.tsx:3123
+#: src/pages/Shell.tsx:3137
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "यह बॉट इसी कंप्यूटर पर चलता है, किसी Linux डेस्कटॉप पर नहीं। शेल और फ़ाइलें आपके होम फ़ोल्डर का उपयोग करती हैं।"
 
-#: src/pages/Shell.tsx:3811
+#: src/pages/Shell.tsx:3828
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "यह बॉट इसी कंप्यूटर पर चलता है। कोई अलग Linux डेस्कटॉप नहीं है। इससे शेल का उपयोग करने को कहें; आपके होम फ़ोल्डर के अंदर की वर्किंग डायरेक्ट्री की अनुमति है।"
 
@@ -2898,7 +2923,7 @@ msgstr "यह Mac आपके खाते से शेल कमांड �
 msgid "This permanently removes every message and stops current work. The chat remains available."
 msgstr ""
 
-#: src/pages/Onboarding.tsx:471
+#: src/pages/Onboarding.tsx:545
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "यह प्रोवाइडर यहां कुंजी पेस्ट नहीं कर सकता। यदि इस डिप्लॉयमेंट में पहले से क्रेडेंशियल हैं तो छोड़ दें।"
 
@@ -2930,7 +2955,7 @@ msgstr "यह सब्सक्रिप्शन साइन-इन अभ�
 msgid "Time of day"
 msgstr "दिन का समय"
 
-#: src/pages/Onboarding.tsx:520
+#: src/pages/Onboarding.tsx:594
 #: src/pages/shell/bot-panel.tsx:133
 #: src/pages/shell/bot-panel.tsx:298
 msgid "Title"
@@ -2965,7 +2990,7 @@ msgid "Unpin"
 msgstr "पिन हटाएं"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1978
 msgid "Unsupported file type: {0}"
 msgstr "असमर्थित फ़ाइल प्रकार: {0}"
 
@@ -3005,7 +3030,7 @@ msgid "Updating…"
 msgstr "अपडेट हो रहा है…"
 
 #: src/pages/AccountSettingsOverlay.tsx:206
-#: src/pages/Shell.tsx:2852
+#: src/pages/Shell.tsx:2866
 msgid "Usage"
 msgstr "उपयोग"
 
@@ -3014,7 +3039,7 @@ msgid "Use {hostLabel}"
 msgstr "{hostLabel} का उपयोग करें"
 
 #: src/pages/ModelSettingsOverlay.tsx:495
-#: src/pages/Onboarding.tsx:334
+#: src/pages/Onboarding.tsx:411
 msgid "Use a found model"
 msgstr "मिला हुआ मॉडल उपयोग करें"
 
@@ -3030,7 +3055,7 @@ msgstr "पुष्टि करके जोड़ें"
 msgid "Verifying…"
 msgstr "पुष्टि की जा रही है…"
 
-#: src/pages/Shell.tsx:2842
+#: src/pages/Shell.tsx:2856
 #: src/pages/shell/bot-panel.tsx:418
 #: src/pages/VoiceSettingsOverlay.tsx:145
 #: src/pages/VoiceSettingsOverlay.tsx:288
@@ -3039,8 +3064,8 @@ msgstr "आवाज़"
 
 #: src/pages/ModelSettingsOverlay.tsx:590
 #: src/pages/ModelSettingsOverlay.tsx:612
-#: src/pages/Onboarding.tsx:402
-#: src/pages/Onboarding.tsx:424
+#: src/pages/Onboarding.tsx:476
+#: src/pages/Onboarding.tsx:498
 msgid "Waiting for sign-in…"
 msgstr "साइन-इन की प्रतीक्षा…"
 
@@ -3074,7 +3099,7 @@ msgstr "आप कौन-सा परिणाम दिखाकर बता�
 msgid "What should this routine do each time it runs?"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:538
+#: src/pages/Onboarding.tsx:612
 #: src/pages/shell/bot-panel.tsx:150
 msgid "What this bot is for"
 msgstr "यह बॉट किस लिए है"
@@ -3103,13 +3128,13 @@ msgstr "बॉट कहां चलने चाहिए?"
 #: src/pages/Auth.tsx:185
 #: src/pages/Auth.tsx:293
 #: src/pages/CallView.tsx:251
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Working…"
 msgstr "काम चल रहा है…"
 
-#: src/pages/Shell.tsx:1679
-#: src/pages/Shell.tsx:2339
+#: src/pages/Shell.tsx:1681
+#: src/pages/Shell.tsx:2353
 msgid "You"
 msgstr "आप"
 
@@ -3121,7 +3146,7 @@ msgstr "अगर यह अपने आप रीडायरेक्ट न 
 msgid "You can close this window."
 msgstr "आप यह विंडो बंद कर सकते हैं।"
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3762
 msgid "You have control"
 msgstr "नियंत्रण आपके पास है"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2625
+#: src/pages/Shell.tsx:2639
 msgid " (unread)"
 msgstr " (읽지 않음)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {모델 #개} other {모델 #개}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1885
+#: src/pages/Shell.tsx:1887
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (첨부 파일 최대 {ATTACHMENT_MAX_COUNT}개)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1889
+#: src/pages/Shell.tsx:1891
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB 초과)"
 
@@ -63,16 +63,16 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:210
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2870
 msgid "{0} runs · {1} tokens"
 msgstr "{0}회 실행 · 토큰 {1}개"
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3164
+#: src/pages/Shell.tsx:3181
 msgid "{0}'s screen"
 msgstr "{0}의 화면"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "{botName}’s computer"
 msgstr "{botName}의 컴퓨터"
 
@@ -116,12 +116,12 @@ msgstr "{size} B"
 msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
-#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:3937
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} 작업 중"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4517
+#: src/pages/Shell.tsx:4535
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -158,8 +158,8 @@ msgstr "현재 모델"
 msgid "Active voice"
 msgstr "현재 목소리"
 
-#: src/pages/Shell.tsx:2374
-#: src/pages/Shell.tsx:2376
+#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2390
 msgid "Activity"
 msgstr "활동"
 
@@ -173,7 +173,7 @@ msgstr "추가"
 msgid "Add a model in Settings to use this."
 msgstr "이 기능을 사용하려면 설정에서 모델을 추가하세요."
 
-#: src/pages/Shell.tsx:3326
+#: src/pages/Shell.tsx:3343
 msgid "Add a run time for this one-shot."
 msgstr "이 일회성 실행의 시간을 추가하세요."
 
@@ -181,7 +181,7 @@ msgstr "이 일회성 실행의 시간을 추가하세요."
 msgid "Add a schedule or webhook to run this routine."
 msgstr "이 루틴을 실행할 일정 또는 웹훅을 추가하세요."
 
-#: src/pages/Shell.tsx:3298
+#: src/pages/Shell.tsx:3315
 msgid "Add a schedule or webhook trigger"
 msgstr "일정 또는 웹훅 트리거 추가"
 
@@ -218,7 +218,7 @@ msgstr "원격 MCP 서버 추가"
 msgid "Add server"
 msgstr "서버 추가"
 
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4900
 msgid "Add thumbs-up"
 msgstr "좋아요 추가"
 
@@ -252,7 +252,7 @@ msgstr "고급 설정"
 msgid "Advanced..."
 msgstr "고급..."
 
-#: src/pages/Shell.tsx:2944
+#: src/pages/Shell.tsx:2958
 msgid "Agent computer"
 msgstr "Agent 컴퓨터"
 
@@ -261,7 +261,7 @@ msgid "Agent connections"
 msgstr "Agent 연결"
 
 #: src/pages/McpServersOverlay.tsx:385
-#: src/pages/McpServersOverlay.tsx:448
+#: src/pages/McpServersOverlay.tsx:452
 msgid "Agents:"
 msgstr "사용 Bot:"
 
@@ -333,9 +333,9 @@ msgstr "API가 다시 작동하지만 업데이트가 완료되지 않았습니�
 #: src/pages/ModelSettingsOverlay.tsx:640
 #: src/pages/ModelSettingsOverlay.tsx:643
 #: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/Onboarding.tsx:440
-#: src/pages/Onboarding.tsx:443
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:514
+#: src/pages/Onboarding.tsx:517
+#: src/pages/Onboarding.tsx:531
 #: src/pages/VoiceSettingsOverlay.tsx:258
 msgid "API key"
 msgstr "API 키"
@@ -367,15 +367,15 @@ msgstr "이 서버를 승인하면 Bot이 제공되는 도구를 사용할 수 �
 msgid "Archive"
 msgstr "보관"
 
-#: src/pages/Shell.tsx:5220
+#: src/pages/Shell.tsx:5238
 msgid "archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:2694
+#: src/pages/Shell.tsx:2708
 msgid "Archived"
 msgstr "보관됨"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5249
 msgid "Archived. Chat, memory, and files kept."
 msgstr "보관되었습니다. 대화, 기억, 파일은 유지됩니다."
 
@@ -425,16 +425,16 @@ msgstr "{0}에"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}에"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4615
 msgid "Attach file"
 msgstr "파일 첨부"
 
-#: src/pages/Shell.tsx:4841
+#: src/pages/Shell.tsx:4859
 msgid "Attachment"
 msgstr "첨부 파일"
 
 #: src/pages/ModelSettingsOverlay.tsx:573
-#: src/pages/Onboarding.tsx:389
+#: src/pages/Onboarding.tsx:463
 msgid "Authorization code or callback URL"
 msgstr "인증 코드 또는 돌아온 페이지 주소"
 
@@ -474,35 +474,35 @@ msgstr "서버 주소"
 msgid "Bearer token"
 msgstr "Bearer 토큰"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5446
 msgid "Booting live desktop…"
 msgstr "라이브 데스크톱 시작 중…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3712
+#: src/pages/Shell.tsx:3729
 msgid "Booting up {0}’s computer"
 msgstr "{0}의 컴퓨터를 켜는 중"
 
-#: src/pages/Shell.tsx:5080
-#: src/pages/Shell.tsx:5081
-#: src/pages/Shell.tsx:5224
+#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5099
+#: src/pages/Shell.tsx:5242
 msgid "bot"
 msgstr "Bot"
-
-#: src/pages/Shell.tsx:1680
-msgid "Bot"
-msgstr "봇"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:71
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3819
+#: src/pages/Shell.tsx:1682
+msgid "Bot"
+msgstr "봇"
+
+#: src/pages/Shell.tsx:3836
 msgid "Bot screen"
 msgstr "Bot 화면"
 
-#: src/pages/Shell.tsx:3130
+#: src/pages/Shell.tsx:3144
 msgid "Bot screen preview"
 msgstr "Bot 화면 미리보기"
 
@@ -514,7 +514,7 @@ msgstr "연결할 Bot"
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first. These preferences apply across all your bots."
 msgstr "Bot은 기본적으로 묻지 않고 작업합니다. 먼저 확인하고 싶은 작업만 예외로 추가하세요. 이 설정은 모든 Bot에 적용됩니다."
 
-#: src/pages/Shell.tsx:3920
+#: src/pages/Shell.tsx:3938
 msgid "Bots are working"
 msgstr "봇 작업 중"
 
@@ -523,8 +523,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "사용 중인 서비스의 API 키를 연결하세요. 서비스를 바꿔도 Bot의 읽기·통화 기능은 그대로 유지됩니다."
 
 #: src/pages/CallView.tsx:241
-#: src/pages/Shell.tsx:2926
-#: src/pages/Shell.tsx:2927
+#: src/pages/Shell.tsx:2940
+#: src/pages/Shell.tsx:2941
 msgid "Call"
 msgstr "통화"
 
@@ -553,7 +553,7 @@ msgstr "새 Bot 만들기 취소"
 msgid "Cancel new group"
 msgstr "새 그룹 만들기 취소"
 
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4473
 msgid "Cancel reply"
 msgstr "답장 취소"
 
@@ -586,7 +586,7 @@ msgstr "채팅 앱"
 msgid "Chat apps, group channels, and agent connections."
 msgstr "채팅 앱, 그룹 채널 및 Agent 연결을 관리합니다."
 
-#: src/pages/Shell.tsx:4784
+#: src/pages/Shell.tsx:4802
 msgid "Chat Settings"
 msgstr "채팅 설정"
 
@@ -598,8 +598,8 @@ msgstr "확인 실패"
 msgid "Check for updates"
 msgstr "업데이트 확인"
 
-#: src/pages/Shell.tsx:3339
-#: src/pages/Shell.tsx:3349
+#: src/pages/Shell.tsx:3356
+#: src/pages/Shell.tsx:3366
 msgid "Check in."
 msgstr "확인해 주세요."
 
@@ -618,10 +618,6 @@ msgstr "체크아웃에 로컬 변경 사항이 있습니다. 업데이트하기
 #: src/pages/MessagingSettingsOverlay.tsx:152
 msgid "Choose a bot…"
 msgstr "Bot 선택…"
-
-#: src/pages/Onboarding.tsx:226
-msgid "Choose a model to get started."
-msgstr "먼저 사용할 AI 모델을 선택하세요."
 
 #: src/pages/Auth.tsx:257
 msgid "Choose a new password"
@@ -661,7 +657,7 @@ msgstr "닫기"
 msgid "Close chart"
 msgstr "차트 닫기"
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3810
 msgid "Close computer"
 msgstr "컴퓨터 닫기"
 
@@ -689,11 +685,11 @@ msgstr "메시징 설정 닫기"
 msgid "Close model settings"
 msgstr "AI 모델 설정 닫기"
 
-#: src/pages/Shell.tsx:2359
+#: src/pages/Shell.tsx:2373
 msgid "Close navigation"
 msgstr "메뉴 닫기"
 
-#: src/pages/Shell.tsx:3103
+#: src/pages/Shell.tsx:3117
 msgid "Close panel"
 msgstr "패널 닫기"
 
@@ -719,7 +715,7 @@ msgid "Code"
 msgstr "Code"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2509
 msgid "Collapse {0}"
 msgstr "{0} 접기"
 
@@ -735,24 +731,24 @@ msgstr "실행 명령"
 msgid "Complete"
 msgstr "완료"
 
-#: src/pages/Shell.tsx:5378
+#: src/pages/Shell.tsx:5396
 #: src/pages/shell/bot-panel.tsx:47
 msgid "Computer"
 msgstr "컴퓨터"
 
-#: src/pages/Shell.tsx:5431
+#: src/pages/Shell.tsx:5449
 msgid "Computer failed to boot"
 msgstr "컴퓨터를 시작하지 못했습니다"
 
-#: src/pages/Shell.tsx:3841
+#: src/pages/Shell.tsx:3859
 msgid "Computer is asleep"
 msgstr "컴퓨터가 절전 상태입니다"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5448
 msgid "Computer is asleep. Open it to wake."
 msgstr "컴퓨터가 절전 상태입니다. 열어 깨우세요."
 
-#: src/pages/Shell.tsx:5432
+#: src/pages/Shell.tsx:5450
 msgid "Computer is stopped"
 msgstr "컴퓨터가 중지됨"
 
@@ -772,7 +768,7 @@ msgstr "서버에서 설정됨"
 msgid "Configured servers"
 msgstr "연결된 서버"
 
-#: src/pages/McpServersOverlay.tsx:502
+#: src/pages/McpServersOverlay.tsx:506
 msgid "Confirm delete"
 msgstr "삭제 확인"
 
@@ -786,7 +782,7 @@ msgstr "비밀번호 확인"
 msgid "Connect"
 msgstr "연결"
 
-#: src/pages/Onboarding.tsx:223
+#: src/pages/Onboarding.tsx:246
 msgid "Connect a model"
 msgstr "AI 모델 연결"
 
@@ -857,8 +853,8 @@ msgstr "연결 중…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "{0} 연결이 아직 진행 중입니다. 이 창을 닫고 나중에 다시 확인할 수 있습니다."
 
-#: src/pages/Onboarding.tsx:484
-#: src/pages/Onboarding.tsx:545
+#: src/pages/Onboarding.tsx:558
+#: src/pages/Onboarding.tsx:619
 msgid "Continue"
 msgstr "계속"
 
@@ -866,7 +862,7 @@ msgstr "계속"
 msgid "Continue with email"
 msgstr "이메일로 계속하기"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4912
 msgid "Copy"
 msgstr "복사"
 
@@ -923,6 +919,10 @@ msgstr "AI 서비스에 연결하지 못했습니다."
 msgid "Could not connect this voice provider"
 msgstr "음성 서비스에 연결하지 못했습니다."
 
+#: src/pages/Shell.tsx:821
+msgid "Could not connect to the computer screen"
+msgstr ""
+
 #: src/pages/Auth.tsx:85
 msgid "Could not continue"
 msgstr "계속 진행하지 못했습니다."
@@ -943,7 +943,7 @@ msgstr "섹션을 만들지 못했습니다."
 msgid "Could not create space"
 msgstr "스페이스를 만들 수 없습니다"
 
-#: src/pages/Onboarding.tsx:208
+#: src/pages/Onboarding.tsx:231
 msgid "Could not create your bot"
 msgstr "Bot을 만들지 못했습니다."
 
@@ -1027,7 +1027,7 @@ msgid "Could not reach the server"
 msgstr "서버에 연결할 수 없습니다"
 
 #: src/pages/ModelSettingsOverlay.tsx:232
-#: src/pages/Onboarding.tsx:154
+#: src/pages/Onboarding.tsx:177
 msgid "Could not reach this model server"
 msgstr "모델 서버에 연결하지 못했습니다."
 
@@ -1059,7 +1059,7 @@ msgstr "비밀번호를 재설정할 수 없습니다"
 msgid "Could not revoke connection"
 msgstr "연결을 해제하지 못했습니다."
 
-#: src/pages/Shell.tsx:3401
+#: src/pages/Shell.tsx:3418
 msgid "Could not run routine"
 msgstr "루틴을 실행할 수 없습니다"
 
@@ -1075,11 +1075,11 @@ msgstr "자동 검토를 저장할 수 없습니다"
 msgid "Could not save group"
 msgstr "그룹을 저장하지 못했습니다."
 
-#: src/pages/Onboarding.tsx:181
+#: src/pages/Onboarding.tsx:204
 msgid "Could not save model"
 msgstr "AI 모델을 저장하지 못했습니다."
 
-#: src/pages/Shell.tsx:3372
+#: src/pages/Shell.tsx:3389
 msgid "Could not save routine"
 msgstr "자동 실행을 저장하지 못했습니다."
 
@@ -1119,7 +1119,7 @@ msgstr "가르치기를 시작하지 못했습니다."
 msgid "Could not submit this answer"
 msgstr "답변을 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:2205
+#: src/pages/Shell.tsx:2207
 msgid "Could not take control"
 msgstr "직접 조작으로 전환하지 못했습니다."
 
@@ -1135,7 +1135,7 @@ msgstr "Bot의 서버 사용 권한을 변경하지 못했습니다."
 msgid "Could not update computer"
 msgstr "컴퓨터를 업데이트할 수 없습니다"
 
-#: src/pages/Shell.tsx:1871
+#: src/pages/Shell.tsx:1873
 msgid "Could not update reaction"
 msgstr "반응을 업데이트할 수 없습니다"
 
@@ -1155,7 +1155,7 @@ msgstr "아바타를 업데이트할 수 없습니다"
 msgid "Couldn't update messaging settings"
 msgstr "메시징 설정을 업데이트할 수 없습니다"
 
-#: src/pages/Shell.tsx:2395
+#: src/pages/Shell.tsx:2409
 #: src/pages/shell/bot-panel.tsx:161
 #: src/pages/shell/dialogs.tsx:155
 msgid "Create"
@@ -1184,7 +1184,7 @@ msgstr "자동 실행 만들기"
 msgid "Create space"
 msgstr "스페이스 만들기"
 
-#: src/pages/Onboarding.tsx:504
+#: src/pages/Onboarding.tsx:578
 msgid "Create your first bot"
 msgstr "첫 Bot 만들기"
 
@@ -1254,10 +1254,10 @@ msgid "Default scope"
 msgstr "기본 기억 범위"
 
 #: src/pages/BotContextMenu.tsx:150
-#: src/pages/McpServersOverlay.tsx:504
+#: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:272
-#: src/pages/Shell.tsx:2730
-#: src/pages/Shell.tsx:2761
+#: src/pages/Shell.tsx:2744
+#: src/pages/Shell.tsx:2775
 #: src/pages/shell/dialogs.tsx:298
 #: src/pages/shell/dialogs.tsx:355
 msgid "Delete"
@@ -1265,8 +1265,8 @@ msgstr "삭제"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2727
-#: src/pages/Shell.tsx:2758
+#: src/pages/Shell.tsx:2741
+#: src/pages/Shell.tsx:2772
 msgid "Delete {0}"
 msgstr "{0} 삭제"
 
@@ -1285,7 +1285,7 @@ msgstr "그룹 삭제"
 msgid "Delete memories too"
 msgstr "기억도 함께 삭제"
 
-#: src/pages/Shell.tsx:5222
+#: src/pages/Shell.tsx:5240
 msgid "deleted"
 msgstr "삭제됨"
 
@@ -1307,22 +1307,22 @@ msgstr "거부"
 msgid "Deployment default"
 msgstr "서버 기본값"
 
-#: src/pages/Onboarding.tsx:525
+#: src/pages/Onboarding.tsx:599
 #: src/pages/shell/bot-panel.tsx:139
 msgid "Describe what this bot does"
 msgstr "이 Bot이 하는 일을 짧게 설명하세요"
 
-#: src/pages/Onboarding.tsx:533
+#: src/pages/Onboarding.tsx:607
 #: src/pages/shell/bot-panel.tsx:144
 #: src/pages/shell/bot-panel.tsx:308
 msgid "Description"
 msgstr "설명"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Dictate"
 msgstr "음성 입력"
 
-#: src/pages/McpServersOverlay.tsx:489
+#: src/pages/McpServersOverlay.tsx:493
 #: src/pages/MemorySettingsOverlay.tsx:207
 msgid "Disconnect"
 msgstr "연결 해제"
@@ -1335,7 +1335,7 @@ msgstr "연결 해제 중…"
 msgid "Dismiss"
 msgstr "닫기"
 
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4453
 msgid "Dismiss error"
 msgstr "오류 닫기"
 
@@ -1365,8 +1365,8 @@ msgid "Don’t have an account?"
 msgstr "계정이 없나요?"
 
 #: src/pages/ActivityList.tsx:157
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Done"
 msgstr "완료"
 
@@ -1389,7 +1389,7 @@ msgstr "작업 기술 초안"
 msgid "Duplicate"
 msgstr "복제"
 
-#: src/pages/Shell.tsx:5021
+#: src/pages/Shell.tsx:5039
 msgid "Earlier message"
 msgstr "이전 메시지"
 
@@ -1407,7 +1407,7 @@ msgstr "이메일"
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
 #: src/pages/ModelSettingsOverlay.tsx:596
-#: src/pages/Onboarding.tsx:408
+#: src/pages/Onboarding.tsx:482
 msgid "Enter this code at <0>{0}</0>"
 msgstr "<0>{0}</0>에서 이 코드를 입력하세요"
 
@@ -1450,7 +1450,7 @@ msgid "Expand"
 msgstr "펼치기"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2494
+#: src/pages/Shell.tsx:2508
 msgid "Expand {0}"
 msgstr "{0} 펼치기"
 
@@ -1470,14 +1470,14 @@ msgstr "매우 높음"
 msgid "Failed"
 msgstr "실패"
 
-#: src/pages/Shell.tsx:2023
 #: src/pages/Shell.tsx:2025
 #: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2029
 msgid "Failed to send message"
 msgstr "메시지를 보내지 못했습니다."
 
-#: src/pages/Shell.tsx:2060
-#: src/pages/Shell.tsx:2079
+#: src/pages/Shell.tsx:2062
+#: src/pages/Shell.tsx:2081
 msgid "Failed to stop"
 msgstr "작업을 중지하지 못했습니다."
 
@@ -1491,18 +1491,18 @@ msgid "Failure handling"
 msgstr "실패했을 때 처리"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Find models"
 msgstr "모델 찾기"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Finding…"
 msgstr "찾는 중…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
 #: src/pages/ModelSettingsOverlay.tsx:556
-#: src/pages/Onboarding.tsx:372
+#: src/pages/Onboarding.tsx:446
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "<0>{0}</0>에서 로그인을 마치세요. 마지막 페이지가 열리지 않아도 괜찮습니다. 그 페이지의 URL이나 코드를 여기에 붙여넣으세요."
 
@@ -1536,8 +1536,8 @@ msgid "Git event"
 msgstr "Git 이벤트"
 
 #: src/pages/MessagingSettingsOverlay.tsx:198
-#: src/pages/Shell.tsx:2916
-#: src/pages/Shell.tsx:3073
+#: src/pages/Shell.tsx:2930
+#: src/pages/Shell.tsx:3087
 msgid "Group"
 msgstr "그룹"
 
@@ -1587,11 +1587,11 @@ msgstr "비밀번호 숨기기"
 msgid "High"
 msgstr "높음"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk"
 msgstr "누르고 말하기"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk (on-device dictation)"
 msgstr "누르고 말하기(기기 내 음성 인식)"
 
@@ -1611,7 +1611,7 @@ msgstr "실행 주기"
 msgid "How to check"
 msgstr "완료 확인 방법"
 
-#: src/pages/Shell.tsx:4951
+#: src/pages/Shell.tsx:4969
 msgid "I’m done"
 msgstr "조작 끝내기"
 
@@ -1640,7 +1640,7 @@ msgid "Instruction"
 msgstr "실행할 내용"
 
 #: src/pages/PluginsOverlay.tsx:247
-#: src/pages/Shell.tsx:2779
+#: src/pages/Shell.tsx:2793
 msgid "Integrations"
 msgstr "앱·도구 연동"
 
@@ -1670,11 +1670,11 @@ msgstr "이 Bot만 사용"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "대화, 파일, 자동 실행이 영구 삭제됩니다. 이 Bot이 만든 다른 Bot은 목록에 남습니다."
 
-#: src/pages/Shell.tsx:4105
+#: src/pages/Shell.tsx:4123
 msgid "Jump to latest"
 msgstr "최신 메시지로 이동"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5034
 msgid "Jump to replied message"
 msgstr "답장한 메시지로 이동"
 
@@ -1720,7 +1720,7 @@ msgstr "채팅 앱 연결"
 msgid "Listening…"
 msgstr "듣는 중…"
 
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Load earlier messages"
 msgstr "이전 메시지 불러오기"
 
@@ -1754,9 +1754,9 @@ msgid "Loading voice providers…"
 msgstr "음성 서비스를 불러오는 중…"
 
 #: src/App.tsx:54
-#: src/pages/Onboarding.tsx:217
+#: src/pages/Onboarding.tsx:240
 #: src/pages/PeerMessagesOverlay.tsx:99
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Loading…"
 msgstr "불러오는 중…"
 
@@ -1764,7 +1764,7 @@ msgstr "불러오는 중…"
 msgid "Local"
 msgstr "로컬"
 
-#: src/pages/Shell.tsx:2872
+#: src/pages/Shell.tsx:2886
 msgid "Log out"
 msgstr "로그아웃"
 
@@ -1810,7 +1810,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "참여 Bot ({GROUP_MEMBER_MIN}~{GROUP_MEMBER_MAX}개 선택)"
 
 #: src/pages/MemorySettingsOverlay.tsx:157
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2845
 msgid "Memory"
 msgstr "기억"
 
@@ -1818,38 +1818,38 @@ msgstr "기억"
 msgid "Memory scope"
 msgstr "기억 사용 범위"
 
-#: src/pages/Shell.tsx:4503
+#: src/pages/Shell.tsx:4521
 msgid "Mentions"
 msgstr "멘션"
-
-#: src/pages/Shell.tsx:4729
-#: src/pages/Shell.tsx:4843
-msgid "Message"
-msgstr "메시지"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:83
 msgid "Message"
 msgstr "메시지"
 
-#: src/pages/Shell.tsx:4725
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4861
+msgid "Message"
+msgstr "메시지"
+
+#: src/pages/Shell.tsx:4743
+#: src/pages/Shell.tsx:4747
 msgid "Message {activeName}"
 msgstr "{activeName}에게 메시지 보내기"
 
-#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4433
 msgid "Message composer"
 msgstr "메시지 작성기"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Message from {peer}"
 msgstr "{peer}의 메시지"
 
-#: src/pages/Shell.tsx:4726
+#: src/pages/Shell.tsx:4744
 msgid "Message…"
 msgstr "메시지를 입력하세요"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Messaged {peer}"
 msgstr "{peer}에게 메시지 보냄"
 
@@ -1881,21 +1881,25 @@ msgstr "분"
 #: src/pages/ModelSettingsOverlay.tsx:449
 #: src/pages/ModelSettingsOverlay.tsx:503
 #: src/pages/ModelSettingsOverlay.tsx:932
-#: src/pages/Onboarding.tsx:300
-#: src/pages/Onboarding.tsx:342
-#: src/pages/Onboarding.tsx:350
+#: src/pages/Onboarding.tsx:377
+#: src/pages/Onboarding.tsx:419
+#: src/pages/Onboarding.tsx:427
 #: src/pages/shell/bot-panel.tsx:332
 msgid "Model"
 msgstr "모델"
 
 #: src/pages/ModelSettingsOverlay.tsx:483
-#: src/pages/Onboarding.tsx:322
+#: src/pages/Onboarding.tsx:399
 msgid "Model id"
 msgstr "모델 ID"
 
 #: src/pages/ModelSettingsOverlay.tsx:968
 msgid "Model options"
 msgstr "모델 선택지"
+
+#: src/pages/Onboarding.tsx:278
+msgid "Model providers"
+msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:216
 msgid "Model spend uses your provider keys."
@@ -1906,12 +1910,12 @@ msgid "Model updated."
 msgstr "모델이 변경되었습니다."
 
 #: src/pages/ModelSettingsOverlay.tsx:323
-#: src/pages/Shell.tsx:2820
+#: src/pages/Shell.tsx:2834
 msgid "Models"
 msgstr "AI 모델"
 
 #: src/pages/ModelSettingsOverlay.tsx:462
-#: src/pages/Onboarding.tsx:306
+#: src/pages/Onboarding.tsx:383
 msgid "Models from server"
 msgstr "서버에서 찾은 모델"
 
@@ -1940,7 +1944,7 @@ msgstr "섹션으로 이동"
 #: src/pages/Auth.tsx:110
 #: src/pages/GroupPanel.tsx:119
 #: src/pages/GroupPanel.tsx:212
-#: src/pages/Onboarding.tsx:507
+#: src/pages/Onboarding.tsx:581
 #: src/pages/RoutineEditor.tsx:281
 #: src/pages/shell/bot-panel.tsx:122
 #: src/pages/shell/bot-panel.tsx:288
@@ -1949,7 +1953,7 @@ msgstr "섹션으로 이동"
 msgid "Name"
 msgstr "이름"
 
-#: src/pages/Onboarding.tsx:512
+#: src/pages/Onboarding.tsx:586
 #: src/pages/shell/bot-panel.tsx:128
 msgid "Name this bot"
 msgstr "Bot 이름"
@@ -1970,13 +1974,13 @@ msgstr "입력 필요"
 msgid "Needs takeover"
 msgstr "인수 필요"
 
-#: src/pages/Shell.tsx:2413
+#: src/pages/Shell.tsx:2427
 #: src/pages/shell/bot-panel.tsx:106
 msgid "New bot"
 msgstr "새 Bot 만들기"
 
 #: src/pages/GroupPanel.tsx:101
-#: src/pages/Shell.tsx:2423
+#: src/pages/Shell.tsx:2437
 msgid "New group"
 msgstr "새 그룹 만들기"
 
@@ -1994,7 +1998,7 @@ msgstr "새 비밀번호"
 msgid "New section"
 msgstr "새 섹션"
 
-#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2449
 #: src/pages/shell/dialogs.tsx:68
 msgid "New space"
 msgstr "새 스페이스"
@@ -2059,6 +2063,10 @@ msgstr "{peerBotName}와의 메시지가 아직 없습니다."
 #: src/pages/ModelSettingsOverlay.tsx:733
 msgid "No model catalog is available."
 msgstr "사용 가능한 모델 목록이 없습니다."
+
+#: src/pages/Onboarding.tsx:339
+msgid "No providers found"
+msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:402
 msgid "No providers found."
@@ -2132,21 +2140,21 @@ msgid "on the 1st at {0}"
 msgstr "매월 1일 {0}에"
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3154
-#: src/pages/Shell.tsx:3159
+#: src/pages/Shell.tsx:3170
+#: src/pages/Shell.tsx:3175
 msgid "Open"
 msgstr "열기"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2492
+#: src/pages/Shell.tsx:2506
 msgid "Open {0}"
 msgstr "{0} 열기"
 
-#: src/pages/Shell.tsx:3119
+#: src/pages/Shell.tsx:3133
 msgid "Open in full window"
 msgstr "전체 창으로 열기"
 
-#: src/pages/Shell.tsx:2888
+#: src/pages/Shell.tsx:2902
 msgid "Open navigation"
 msgstr "메뉴 열기"
 
@@ -2155,11 +2163,11 @@ msgid "Open work"
 msgstr "진행 중인 작업"
 
 #: src/pages/ModelSettingsOverlay.tsx:422
-#: src/pages/Onboarding.tsx:275
+#: src/pages/Onboarding.tsx:352
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 호환 서버 주소"
 
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5251
 msgid "Opened its thread."
 msgstr "대화가 만들어졌습니다."
 
@@ -2168,7 +2176,7 @@ msgid "Opening your Space…"
 msgstr "작업공간을 여는 중…"
 
 #: src/pages/ModelSettingsOverlay.tsx:646
-#: src/pages/Onboarding.tsx:446
+#: src/pages/Onboarding.tsx:520
 msgid "Optional"
 msgstr "선택 사항"
 
@@ -2184,7 +2192,7 @@ msgstr "선택 사항인 헤더 값"
 msgid "Or connect an API key"
 msgstr "또는 API 키 연결"
 
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:531
 msgid "Or paste an API key"
 msgstr "또는 API 키 붙여넣기"
 
@@ -2197,7 +2205,7 @@ msgid "Organization API key"
 msgstr "조직 API 키"
 
 #: src/pages/ModelSettingsOverlay.tsx:470
-#: src/pages/Onboarding.tsx:315
+#: src/pages/Onboarding.tsx:392
 msgid "Other model…"
 msgstr "다른 모델 직접 입력…"
 
@@ -2235,7 +2243,7 @@ msgid "Paste a replacement key"
 msgstr "새 API 키를 붙여넣으세요"
 
 #: src/pages/ModelSettingsOverlay.tsx:433
-#: src/pages/Onboarding.tsx:286
+#: src/pages/Onboarding.tsx:363
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "서버의 OpenAI 호환 주소를 붙여넣으세요. 필요하면 Rakazo가 /v1을 추가합니다."
 
@@ -2278,6 +2286,7 @@ msgid "Private"
 msgstr "Bot 전용"
 
 #: src/pages/MemorySettingsOverlay.tsx:216
+#: src/pages/Onboarding.tsx:250
 msgid "Provider"
 msgstr "서비스"
 
@@ -2342,7 +2351,7 @@ msgstr "화면 새로고침"
 msgid "Refreshing…"
 msgstr "새로고침 중…"
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:4959
 msgid "Release"
 msgstr "제어권 돌려주기"
 
@@ -2355,12 +2364,12 @@ msgid "Remove"
 msgstr "삭제"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4489
+#: src/pages/Shell.tsx:4507
 msgid "Remove {0}"
 msgstr "{0} 삭제"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4681
 msgid "Remove mention {0}"
 msgstr "{0} 멘션 삭제"
 
@@ -2369,12 +2378,12 @@ msgid "Remove schedule"
 msgstr "일정 제거"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4660
 msgid "Remove skill {0}"
 msgstr "작업 기술 {0} 삭제"
 
-#: src/pages/Shell.tsx:4080
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4900
 msgid "Remove thumbs-up"
 msgstr "좋아요 제거"
 
@@ -2382,7 +2391,7 @@ msgstr "좋아요 제거"
 msgid "Remove webhook"
 msgstr "웹훅 제거"
 
-#: src/pages/Shell.tsx:5232
+#: src/pages/Shell.tsx:5250
 msgid "Removed with chat, computer, and memory."
 msgstr "대화, 컴퓨터, 기억과 함께 삭제되었습니다."
 
@@ -2410,11 +2419,11 @@ msgstr "API 키 교체"
 msgid "Replace key"
 msgstr "키 교체"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4891
 msgid "Reply"
 msgstr "답장"
 
-#: src/pages/Shell.tsx:4452
+#: src/pages/Shell.tsx:4470
 msgid "Replying to {replyName}"
 msgstr "{replyName}에게 답장"
 
@@ -2443,8 +2452,8 @@ msgstr "비밀번호를 재설정하세요"
 msgid "Resetting…"
 msgstr "재설정 중…"
 
-#: src/pages/Shell.tsx:2721
-#: src/pages/Shell.tsx:2752
+#: src/pages/Shell.tsx:2735
+#: src/pages/Shell.tsx:2766
 msgid "Restore"
 msgstr "복원"
 
@@ -2455,6 +2464,10 @@ msgstr "마지막으로 저장된 작업 공간을 복원합니다. 컴퓨터에
 #: src/App.tsx:148
 msgid "Retry now"
 msgstr "지금 다시 시도"
+
+#: src/pages/Shell.tsx:2348
+msgid "Retry screen"
+msgstr ""
 
 #: src/pages/McpOAuthCallback.tsx:62
 msgid "Return to Rakazo"
@@ -2473,8 +2486,8 @@ msgid "Rotate key"
 msgstr "key 교체"
 
 #: src/pages/RoutineEditor.tsx:236
-#: src/pages/Shell.tsx:3338
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3355
+#: src/pages/Shell.tsx:3365
 msgid "Routine"
 msgstr "자동 실행"
 
@@ -2491,7 +2504,7 @@ msgstr "실행 시간"
 msgid "Run history"
 msgstr "실행 기록"
 
-#: src/pages/Shell.tsx:3331
+#: src/pages/Shell.tsx:3348
 msgid "Run time must be in the future."
 msgstr "실행 시간은 미래여야 합니다."
 
@@ -2549,7 +2562,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "예 또는 아니요로 답하거나 문장으로 답해 주세요."
 
 #: src/pages/ModelSettingsOverlay.tsx:957
-#: src/pages/Shell.tsx:2449
+#: src/pages/Shell.tsx:2463
 msgid "Search"
 msgstr "검색"
 
@@ -2567,8 +2580,8 @@ msgstr "모델 검색"
 msgid "Search providers"
 msgstr "AI 서비스 검색"
 
-#: src/pages/Onboarding.tsx:231
-#: src/pages/Onboarding.tsx:232
+#: src/pages/Onboarding.tsx:272
+#: src/pages/Onboarding.tsx:273
 msgid "Search providers and models"
 msgstr "AI 서비스 또는 모델 검색"
 
@@ -2576,12 +2589,16 @@ msgstr "AI 서비스 또는 모델 검색"
 msgid "Searching…"
 msgstr "검색 중…"
 
-#: src/pages/Shell.tsx:2917
+#: src/pages/Shell.tsx:2931
 msgid "Select a bot"
 msgstr "대화할 Bot을 선택하세요"
 
-#: src/pages/Shell.tsx:4747
-#: src/pages/Shell.tsx:4768
+#: src/pages/Onboarding.tsx:320
+msgid "Selected"
+msgstr ""
+
+#: src/pages/Shell.tsx:4765
+#: src/pages/Shell.tsx:4786
 msgid "Send"
 msgstr "보내기"
 
@@ -2618,31 +2635,31 @@ msgstr "서버 이름"
 
 #: src/pages/McpServersOverlay.tsx:329
 #: src/pages/ModelSettingsOverlay.tsx:417
-#: src/pages/Onboarding.tsx:270
+#: src/pages/Onboarding.tsx:347
 msgid "Server URL"
 msgstr "서버 URL"
 
-#: src/pages/Shell.tsx:2926
+#: src/pages/Shell.tsx:2940
 msgid "Set up voice to call"
 msgstr "통화하려면 음성을 먼저 설정하세요"
 
 #: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2801
-#: src/pages/Shell.tsx:2809
-#: src/pages/Shell.tsx:3069
+#: src/pages/Shell.tsx:2815
+#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:3083
 msgid "Settings"
 msgstr "설정"
 
-#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4804
 msgid "Settings: General"
 msgstr "설정: 일반"
 
-#: src/pages/Shell.tsx:4788
+#: src/pages/Shell.tsx:4806
 msgid "Settings: Usage"
 msgstr "설정: 사용량"
 
 #: src/pages/ModelSettingsOverlay.tsx:430
-#: src/pages/Onboarding.tsx:283
+#: src/pages/Onboarding.tsx:360
 msgid "Setup help"
 msgstr "설정 도움말"
 
@@ -2651,7 +2668,11 @@ msgstr "설정 도움말"
 msgid "Shared"
 msgstr "함께 사용"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:264
+msgid "Show all providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show computer"
 msgstr "컴퓨터 보기"
 
@@ -2663,7 +2684,11 @@ msgstr "더 보기"
 msgid "Show password"
 msgstr "비밀번호 표시"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:262
+msgid "Show popular providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show settings"
 msgstr "설정 보기"
 
@@ -2671,7 +2696,7 @@ msgstr "설정 보기"
 #: src/pages/Auth.tsx:206
 #: src/pages/Auth.tsx:264
 #: src/pages/ModelSettingsOverlay.tsx:628
-#: src/pages/Onboarding.tsx:108
+#: src/pages/Onboarding.tsx:131
 msgid "Sign in"
 msgstr "로그인"
 
@@ -2685,15 +2710,15 @@ msgid "Sign up"
 msgstr "가입하기"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4550
+#: src/pages/Shell.tsx:4568
 msgid "Skill {0}"
 msgstr "작업 기술 {0}"
 
-#: src/pages/Shell.tsx:4948
+#: src/pages/Shell.tsx:4966
 msgid "Skip"
 msgstr "건너뛰기"
 
-#: src/pages/Onboarding.tsx:495
+#: src/pages/Onboarding.tsx:569
 msgid "Skip for now"
 msgstr "지금은 건너뛰기"
 
@@ -2702,7 +2727,7 @@ msgid "Skip or deploy key"
 msgstr "건너뛰거나 배포 키"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1905
+#: src/pages/Shell.tsx:1907
 msgid "Skipped {0}"
 msgstr "{0} 건너뜀"
 
@@ -2723,8 +2748,8 @@ msgstr "스페이스 기본값"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Space: 끼어들기 · Esc: 통화 종료"
 
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Speak"
 msgstr "읽기"
 
@@ -2736,8 +2761,8 @@ msgstr "음성 출력·받아쓰기"
 msgid "Speak only"
 msgstr "음성 출력만"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Speak this reply"
 msgstr "이 답변 읽기"
 
@@ -2755,7 +2780,7 @@ msgstr "시작 중"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
 #: src/pages/ModelSettingsOverlay.tsx:626
-#: src/pages/Onboarding.tsx:431
+#: src/pages/Onboarding.tsx:505
 msgid "Starting…"
 msgstr "시작하는 중…"
 
@@ -2763,20 +2788,20 @@ msgstr "시작하는 중…"
 msgid "Steps"
 msgstr "실행 단계"
 
-#: src/pages/Shell.tsx:3755
-#: src/pages/Shell.tsx:3760
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:3772
+#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Stop"
 msgstr "중지"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Stop dictation"
 msgstr "음성 입력 중지"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Stop speaking"
 msgstr "읽기 중지"
 
@@ -2794,13 +2819,13 @@ msgstr "중지되었습니다."
 msgid "Stored encrypted"
 msgstr "암호화해 저장"
 
-#: src/pages/Shell.tsx:5186
+#: src/pages/Shell.tsx:5204
 msgid "subagent"
 msgstr "보조 에이전트"
 
 #: src/components/AskCard.tsx:140
 #: src/pages/ModelSettingsOverlay.tsx:586
-#: src/pages/Onboarding.tsx:398
+#: src/pages/Onboarding.tsx:472
 msgid "Submit"
 msgstr "확인"
 
@@ -2821,7 +2846,7 @@ msgstr "시스템"
 msgid "Teach a task"
 msgstr "작업 가르치기"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3005
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼저 가르치기를 종료하세요."
 
@@ -2829,7 +2854,7 @@ msgstr "작업을 가르치는 중입니다. 새 메시지를 보내려면 먼�
 msgid "Team"
 msgstr "팀 공용"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "Team Computer"
 msgstr "팀 컴퓨터"
 
@@ -2857,11 +2882,11 @@ msgstr "선택한 기억 서비스는 현재 빌드에서 사용할 수 없습�
 msgid "Thinking"
 msgstr "생각 깊이"
 
-#: src/pages/Shell.tsx:3123
+#: src/pages/Shell.tsx:3137
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "이 Bot은 별도 Linux 화면이 아니라 현재 컴퓨터에서 실행됩니다. 터미널과 파일 작업은 홈 폴더를 사용합니다."
 
-#: src/pages/Shell.tsx:3811
+#: src/pages/Shell.tsx:3828
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "이 Bot은 현재 컴퓨터에서 실행되며 별도 Linux 화면은 없습니다. 터미널을 사용하도록 요청할 수 있고 홈 폴더 아래에서 작업합니다."
 
@@ -2898,7 +2923,7 @@ msgstr "이 Mac에서는 홈 폴더의 파일을 포함해 내 계정 권한으�
 msgid "This permanently removes every message and stops current work. The chat remains available."
 msgstr "모든 메시지를 영구적으로 삭제하고 진행 중인 작업을 중지합니다. 채팅은 계속 사용할 수 있습니다."
 
-#: src/pages/Onboarding.tsx:471
+#: src/pages/Onboarding.tsx:545
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "이 서비스는 여기에서 API 키를 입력할 수 없습니다. 서버에 이미 인증 정보가 있다면 건너뛰세요."
 
@@ -2930,7 +2955,7 @@ msgstr "이 구독 로그인 방식은 아직 Rakazo에서 지원되지 않습�
 msgid "Time of day"
 msgstr "실행 시각"
 
-#: src/pages/Onboarding.tsx:520
+#: src/pages/Onboarding.tsx:594
 #: src/pages/shell/bot-panel.tsx:133
 #: src/pages/shell/bot-panel.tsx:298
 msgid "Title"
@@ -2965,7 +2990,7 @@ msgid "Unpin"
 msgstr "고정 해제"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1978
 msgid "Unsupported file type: {0}"
 msgstr "지원하지 않는 파일 형식: {0}"
 
@@ -3005,7 +3030,7 @@ msgid "Updating…"
 msgstr "업데이트 중…"
 
 #: src/pages/AccountSettingsOverlay.tsx:206
-#: src/pages/Shell.tsx:2852
+#: src/pages/Shell.tsx:2866
 msgid "Usage"
 msgstr "사용량"
 
@@ -3014,7 +3039,7 @@ msgid "Use {hostLabel}"
 msgstr "{hostLabel} 사용"
 
 #: src/pages/ModelSettingsOverlay.tsx:495
-#: src/pages/Onboarding.tsx:334
+#: src/pages/Onboarding.tsx:411
 msgid "Use a found model"
 msgstr "찾은 모델 중에서 선택"
 
@@ -3030,7 +3055,7 @@ msgstr "확인 후 추가"
 msgid "Verifying…"
 msgstr "확인 중…"
 
-#: src/pages/Shell.tsx:2842
+#: src/pages/Shell.tsx:2856
 #: src/pages/shell/bot-panel.tsx:418
 #: src/pages/VoiceSettingsOverlay.tsx:145
 #: src/pages/VoiceSettingsOverlay.tsx:288
@@ -3039,8 +3064,8 @@ msgstr "음성"
 
 #: src/pages/ModelSettingsOverlay.tsx:590
 #: src/pages/ModelSettingsOverlay.tsx:612
-#: src/pages/Onboarding.tsx:402
-#: src/pages/Onboarding.tsx:424
+#: src/pages/Onboarding.tsx:476
+#: src/pages/Onboarding.tsx:498
 msgid "Waiting for sign-in…"
 msgstr "로그인 완료를 기다리는 중…"
 
@@ -3074,7 +3099,7 @@ msgstr "어떤 작업을 직접 보여줄까요?"
 msgid "What should this routine do each time it runs?"
 msgstr "이 루틴이 실행될 때마다 무엇을 해야 하나요?"
 
-#: src/pages/Onboarding.tsx:538
+#: src/pages/Onboarding.tsx:612
 #: src/pages/shell/bot-panel.tsx:150
 msgid "What this bot is for"
 msgstr "이 Bot을 언제, 어떤 일에 사용할지 적어주세요"
@@ -3103,13 +3128,13 @@ msgstr "Bot을 어디에서 실행할까요?"
 #: src/pages/Auth.tsx:185
 #: src/pages/Auth.tsx:293
 #: src/pages/CallView.tsx:251
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Working…"
 msgstr "처리 중…"
 
-#: src/pages/Shell.tsx:1679
-#: src/pages/Shell.tsx:2339
+#: src/pages/Shell.tsx:1681
+#: src/pages/Shell.tsx:2353
 msgid "You"
 msgstr "나"
 
@@ -3121,7 +3146,7 @@ msgstr "자동으로 이동하지 않으면 이 탭을 닫아도 됩니다."
 msgid "You can close this window."
 msgstr "이 창을 닫아도 됩니다."
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3762
 msgid "You have control"
 msgstr "직접 조작 중"
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/pages/Shell.tsx:2625
+#: src/pages/Shell.tsx:2639
 msgid " (unread)"
 msgstr " (não lido)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# modelo} other {# modelos}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1885
+#: src/pages/Shell.tsx:1887
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (máx. anexos {ATTACHMENT_MAX_COUNT})"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1889
+#: src/pages/Shell.tsx:1891
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (acima de 10 MiB)"
 
@@ -63,16 +63,16 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:210
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2870
 msgid "{0} runs · {1} tokens"
 msgstr "{0} execuções · {1} tokens"
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3164
+#: src/pages/Shell.tsx:3181
 msgid "{0}'s screen"
 msgstr ""
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "{botName}’s computer"
 msgstr "Computador do {botName}"
 
@@ -116,12 +116,12 @@ msgstr "{size} B"
 msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
-#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:3937
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} está trabalhando"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4517
+#: src/pages/Shell.tsx:4535
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -158,8 +158,8 @@ msgstr "Modelo ativo"
 msgid "Active voice"
 msgstr "Voz ativa"
 
-#: src/pages/Shell.tsx:2374
-#: src/pages/Shell.tsx:2376
+#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2390
 msgid "Activity"
 msgstr "Atividade"
 
@@ -173,7 +173,7 @@ msgstr "Adicionar"
 msgid "Add a model in Settings to use this."
 msgstr ""
 
-#: src/pages/Shell.tsx:3326
+#: src/pages/Shell.tsx:3343
 msgid "Add a run time for this one-shot."
 msgstr ""
 
@@ -181,7 +181,7 @@ msgstr ""
 msgid "Add a schedule or webhook to run this routine."
 msgstr ""
 
-#: src/pages/Shell.tsx:3298
+#: src/pages/Shell.tsx:3315
 msgid "Add a schedule or webhook trigger"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgstr "Adicionar servidor MCP remoto"
 msgid "Add server"
 msgstr "Adicionar servidor"
 
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4900
 msgid "Add thumbs-up"
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr "Avançado"
 msgid "Advanced..."
 msgstr ""
 
-#: src/pages/Shell.tsx:2944
+#: src/pages/Shell.tsx:2958
 msgid "Agent computer"
 msgstr "Computador do agente"
 
@@ -261,7 +261,7 @@ msgid "Agent connections"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:385
-#: src/pages/McpServersOverlay.tsx:448
+#: src/pages/McpServersOverlay.tsx:452
 msgid "Agents:"
 msgstr "Agentes:"
 
@@ -333,9 +333,9 @@ msgstr ""
 #: src/pages/ModelSettingsOverlay.tsx:640
 #: src/pages/ModelSettingsOverlay.tsx:643
 #: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/Onboarding.tsx:440
-#: src/pages/Onboarding.tsx:443
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:514
+#: src/pages/Onboarding.tsx:517
+#: src/pages/Onboarding.tsx:531
 #: src/pages/VoiceSettingsOverlay.tsx:258
 msgid "API key"
 msgstr "Chave de API"
@@ -367,15 +367,15 @@ msgstr "Aprove este servidor para permitir que seu agente use suas ferramentas."
 msgid "Archive"
 msgstr "Arquivar"
 
-#: src/pages/Shell.tsx:5220
+#: src/pages/Shell.tsx:5238
 msgid "archived"
 msgstr "arquivado"
 
-#: src/pages/Shell.tsx:2694
+#: src/pages/Shell.tsx:2708
 msgid "Archived"
 msgstr "Arquivado"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5249
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Arquivado. Chat, memória e arquivos mantidos."
 
@@ -425,16 +425,16 @@ msgstr "em {0}"
 msgid "at {timeSelect}"
 msgstr "em {timeSelect}"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4615
 msgid "Attach file"
 msgstr "Escolher arquivo"
 
-#: src/pages/Shell.tsx:4841
+#: src/pages/Shell.tsx:4859
 msgid "Attachment"
 msgstr "Anexo"
 
 #: src/pages/ModelSettingsOverlay.tsx:573
-#: src/pages/Onboarding.tsx:389
+#: src/pages/Onboarding.tsx:463
 msgid "Authorization code or callback URL"
 msgstr "Código de autorização ou URL de retorno de chamada"
 
@@ -474,35 +474,35 @@ msgstr "URL Base"
 msgid "Bearer token"
 msgstr "Token portador"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5446
 msgid "Booting live desktop…"
 msgstr "Iniciando a área de trabalho ao vivo..."
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3712
+#: src/pages/Shell.tsx:3729
 msgid "Booting up {0}’s computer"
 msgstr "Inicializando o computador do {0}"
 
-#: src/pages/Shell.tsx:5080
-#: src/pages/Shell.tsx:5081
-#: src/pages/Shell.tsx:5224
+#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5099
+#: src/pages/Shell.tsx:5242
 msgid "bot"
 msgstr "bot"
-
-#: src/pages/Shell.tsx:1680
-msgid "Bot"
-msgstr "Bot"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:71
 msgid "Bot"
 msgstr ""
 
-#: src/pages/Shell.tsx:3819
+#: src/pages/Shell.tsx:1682
+msgid "Bot"
+msgstr "Bot"
+
+#: src/pages/Shell.tsx:3836
 msgid "Bot screen"
 msgstr "Tela do bot"
 
-#: src/pages/Shell.tsx:3130
+#: src/pages/Shell.tsx:3144
 msgid "Bot screen preview"
 msgstr "Pré-visualização da tela"
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first. These preferences apply across all your bots."
 msgstr "Os bots agem sem perguntar por padrão. Adicione uma exceção apenas quando quiser analisar um tipo de ação primeiro. Essas preferências se aplicam a todos os seus bots."
 
-#: src/pages/Shell.tsx:3920
+#: src/pages/Shell.tsx:3938
 msgid "Bots are working"
 msgstr "Bots estão trabalhando"
 
@@ -523,8 +523,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Traga sua própria chave. O provedor pode ser trocado; seus bots mantêm os mesmos botões de fala e chamada."
 
 #: src/pages/CallView.tsx:241
-#: src/pages/Shell.tsx:2926
-#: src/pages/Shell.tsx:2927
+#: src/pages/Shell.tsx:2940
+#: src/pages/Shell.tsx:2941
 msgid "Call"
 msgstr "Ligar"
 
@@ -553,7 +553,7 @@ msgstr "Cancelar novo bot"
 msgid "Cancel new group"
 msgstr "Cancelar novo grupo"
 
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4473
 msgid "Cancel reply"
 msgstr "cancelar resposta"
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Chat apps, group channels, and agent connections."
 msgstr ""
 
-#: src/pages/Shell.tsx:4784
+#: src/pages/Shell.tsx:4802
 msgid "Chat Settings"
 msgstr "Configurações do chat"
 
@@ -598,8 +598,8 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: src/pages/Shell.tsx:3339
-#: src/pages/Shell.tsx:3349
+#: src/pages/Shell.tsx:3356
+#: src/pages/Shell.tsx:3366
 msgid "Check in."
 msgstr "Acompanhamento"
 
@@ -618,10 +618,6 @@ msgstr ""
 #: src/pages/MessagingSettingsOverlay.tsx:152
 msgid "Choose a bot…"
 msgstr ""
-
-#: src/pages/Onboarding.tsx:226
-msgid "Choose a model to get started."
-msgstr "Escolha um modelo para começar."
 
 #: src/pages/Auth.tsx:257
 msgid "Choose a new password"
@@ -661,7 +657,7 @@ msgstr "Fechar"
 msgid "Close chart"
 msgstr "Fechar gráfico"
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3810
 msgid "Close computer"
 msgstr "Fechar computador"
 
@@ -689,11 +685,11 @@ msgstr ""
 msgid "Close model settings"
 msgstr "Fechar configurações do modelo"
 
-#: src/pages/Shell.tsx:2359
+#: src/pages/Shell.tsx:2373
 msgid "Close navigation"
 msgstr "Fechar navegação"
 
-#: src/pages/Shell.tsx:3103
+#: src/pages/Shell.tsx:3117
 msgid "Close panel"
 msgstr "Fechar painel"
 
@@ -719,7 +715,7 @@ msgid "Code"
 msgstr ""
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2509
 msgid "Collapse {0}"
 msgstr ""
 
@@ -735,24 +731,24 @@ msgstr "Comando"
 msgid "Complete"
 msgstr "Concluir"
 
-#: src/pages/Shell.tsx:5378
+#: src/pages/Shell.tsx:5396
 #: src/pages/shell/bot-panel.tsx:47
 msgid "Computer"
 msgstr "Computador"
 
-#: src/pages/Shell.tsx:5431
+#: src/pages/Shell.tsx:5449
 msgid "Computer failed to boot"
 msgstr "Falha ao inicializar o computador"
 
-#: src/pages/Shell.tsx:3841
+#: src/pages/Shell.tsx:3859
 msgid "Computer is asleep"
 msgstr "O computador está dormindo"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5448
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5432
+#: src/pages/Shell.tsx:5450
 msgid "Computer is stopped"
 msgstr "O computador está parado"
 
@@ -772,7 +768,7 @@ msgstr "Configurado por implantação"
 msgid "Configured servers"
 msgstr "Servidores configurados"
 
-#: src/pages/McpServersOverlay.tsx:502
+#: src/pages/McpServersOverlay.tsx:506
 msgid "Confirm delete"
 msgstr "Confirmar exclusão"
 
@@ -786,7 +782,7 @@ msgstr "Confirmar senha"
 msgid "Connect"
 msgstr "Conectar"
 
-#: src/pages/Onboarding.tsx:223
+#: src/pages/Onboarding.tsx:246
 msgid "Connect a model"
 msgstr "Conectar um modelo"
 
@@ -857,8 +853,8 @@ msgstr "Conectando…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "A conexão com o {0} ainda está pendente. Você pode fechar isso e verificar novamente."
 
-#: src/pages/Onboarding.tsx:484
-#: src/pages/Onboarding.tsx:545
+#: src/pages/Onboarding.tsx:558
+#: src/pages/Onboarding.tsx:619
 msgid "Continue"
 msgstr "Continuar"
 
@@ -866,7 +862,7 @@ msgstr "Continuar"
 msgid "Continue with email"
 msgstr "Continuar com e-mail"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4912
 msgid "Copy"
 msgstr "Copiar"
 
@@ -923,6 +919,10 @@ msgstr "Não foi possível conectar este provedor"
 msgid "Could not connect this voice provider"
 msgstr "Não foi possível conectar este provedor de voz"
 
+#: src/pages/Shell.tsx:821
+msgid "Could not connect to the computer screen"
+msgstr ""
+
 #: src/pages/Auth.tsx:85
 msgid "Could not continue"
 msgstr "Não foi possível continuar"
@@ -943,7 +943,7 @@ msgstr "Não foi possível criar a seção"
 msgid "Could not create space"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:208
+#: src/pages/Onboarding.tsx:231
 msgid "Could not create your bot"
 msgstr "Não foi possível criar o seu bot"
 
@@ -1027,7 +1027,7 @@ msgid "Could not reach the server"
 msgstr "Não foi possível acessar o servidor"
 
 #: src/pages/ModelSettingsOverlay.tsx:232
-#: src/pages/Onboarding.tsx:154
+#: src/pages/Onboarding.tsx:177
 msgid "Could not reach this model server"
 msgstr "Não foi possível acessar este servidor modelo"
 
@@ -1059,7 +1059,7 @@ msgstr "Não foi possível redefinir a senha"
 msgid "Could not revoke connection"
 msgstr "Não foi possível revogar a conexão"
 
-#: src/pages/Shell.tsx:3401
+#: src/pages/Shell.tsx:3418
 msgid "Could not run routine"
 msgstr ""
 
@@ -1075,11 +1075,11 @@ msgstr ""
 msgid "Could not save group"
 msgstr "Não foi possível salvar o grupo"
 
-#: src/pages/Onboarding.tsx:181
+#: src/pages/Onboarding.tsx:204
 msgid "Could not save model"
 msgstr "Não foi possível salvar o modelo"
 
-#: src/pages/Shell.tsx:3372
+#: src/pages/Shell.tsx:3389
 msgid "Could not save routine"
 msgstr "Não foi possível salvar a rotina"
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "Não foi possível enviar esta resposta"
 
-#: src/pages/Shell.tsx:2205
+#: src/pages/Shell.tsx:2207
 msgid "Could not take control"
 msgstr "Não foi possível assumir o controle"
 
@@ -1135,7 +1135,7 @@ msgstr "Não foi possível atualizar o acesso do agente"
 msgid "Could not update computer"
 msgstr "Não foi possível atualizar o computador"
 
-#: src/pages/Shell.tsx:1871
+#: src/pages/Shell.tsx:1873
 msgid "Could not update reaction"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Couldn't update messaging settings"
 msgstr ""
 
-#: src/pages/Shell.tsx:2395
+#: src/pages/Shell.tsx:2409
 #: src/pages/shell/bot-panel.tsx:161
 #: src/pages/shell/dialogs.tsx:155
 msgid "Create"
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Create space"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:504
+#: src/pages/Onboarding.tsx:578
 msgid "Create your first bot"
 msgstr "Crie seu primeiro bot"
 
@@ -1254,10 +1254,10 @@ msgid "Default scope"
 msgstr "Escopo padrão"
 
 #: src/pages/BotContextMenu.tsx:150
-#: src/pages/McpServersOverlay.tsx:504
+#: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:272
-#: src/pages/Shell.tsx:2730
-#: src/pages/Shell.tsx:2761
+#: src/pages/Shell.tsx:2744
+#: src/pages/Shell.tsx:2775
 #: src/pages/shell/dialogs.tsx:298
 #: src/pages/shell/dialogs.tsx:355
 msgid "Delete"
@@ -1265,8 +1265,8 @@ msgstr "Excluir"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2727
-#: src/pages/Shell.tsx:2758
+#: src/pages/Shell.tsx:2741
+#: src/pages/Shell.tsx:2772
 msgid "Delete {0}"
 msgstr "Excluir {0}"
 
@@ -1285,7 +1285,7 @@ msgstr "Excluir o grupo"
 msgid "Delete memories too"
 msgstr "Excluir memórias também"
 
-#: src/pages/Shell.tsx:5222
+#: src/pages/Shell.tsx:5240
 msgid "deleted"
 msgstr "excluído"
 
@@ -1307,22 +1307,22 @@ msgstr "Negar"
 msgid "Deployment default"
 msgstr "Padrão de implantação"
 
-#: src/pages/Onboarding.tsx:525
+#: src/pages/Onboarding.tsx:599
 #: src/pages/shell/bot-panel.tsx:139
 msgid "Describe what this bot does"
 msgstr "Descreva o que este bot faz"
 
-#: src/pages/Onboarding.tsx:533
+#: src/pages/Onboarding.tsx:607
 #: src/pages/shell/bot-panel.tsx:144
 #: src/pages/shell/bot-panel.tsx:308
 msgid "Description"
 msgstr "Descrição"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Dictate"
 msgstr "Ditar"
 
-#: src/pages/McpServersOverlay.tsx:489
+#: src/pages/McpServersOverlay.tsx:493
 #: src/pages/MemorySettingsOverlay.tsx:207
 msgid "Disconnect"
 msgstr "Desconectar"
@@ -1335,7 +1335,7 @@ msgstr "Desconectando…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4453
 msgid "Dismiss error"
 msgstr ""
 
@@ -1365,8 +1365,8 @@ msgid "Don’t have an account?"
 msgstr "Não tem uma conta?"
 
 #: src/pages/ActivityList.tsx:157
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Done"
 msgstr "Concluído"
 
@@ -1389,7 +1389,7 @@ msgstr "Habilidade de rascunho"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/pages/Shell.tsx:5021
+#: src/pages/Shell.tsx:5039
 msgid "Earlier message"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr "E-mail"
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
 #: src/pages/ModelSettingsOverlay.tsx:596
-#: src/pages/Onboarding.tsx:408
+#: src/pages/Onboarding.tsx:482
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Digite este código em <0>{0}</0>"
 
@@ -1450,7 +1450,7 @@ msgid "Expand"
 msgstr "Expandir"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2494
+#: src/pages/Shell.tsx:2508
 msgid "Expand {0}"
 msgstr ""
 
@@ -1470,14 +1470,14 @@ msgstr "Extra alta"
 msgid "Failed"
 msgstr "Falha"
 
-#: src/pages/Shell.tsx:2023
 #: src/pages/Shell.tsx:2025
 #: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2029
 msgid "Failed to send message"
 msgstr "Ocorreu um erro ao enviar a mensagem"
 
-#: src/pages/Shell.tsx:2060
-#: src/pages/Shell.tsx:2079
+#: src/pages/Shell.tsx:2062
+#: src/pages/Shell.tsx:2081
 msgid "Failed to stop"
 msgstr "Não foi possível parar"
 
@@ -1491,18 +1491,18 @@ msgid "Failure handling"
 msgstr "Tratamento de falhas"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Find models"
 msgstr "Encontrar modelos"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Finding…"
 msgstr "Localizando…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
 #: src/pages/ModelSettingsOverlay.tsx:556
-#: src/pages/Onboarding.tsx:372
+#: src/pages/Onboarding.tsx:446
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "Conclua o login em <0>{0}</0>. A página final não pode ser carregada; cole seu URL ou código aqui."
 
@@ -1536,8 +1536,8 @@ msgid "Git event"
 msgstr ""
 
 #: src/pages/MessagingSettingsOverlay.tsx:198
-#: src/pages/Shell.tsx:2916
-#: src/pages/Shell.tsx:3073
+#: src/pages/Shell.tsx:2930
+#: src/pages/Shell.tsx:3087
 msgid "Group"
 msgstr "Grupo"
 
@@ -1587,11 +1587,11 @@ msgstr ""
 msgid "High"
 msgstr "Alto"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk"
 msgstr "Segure para falar"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk (on-device dictation)"
 msgstr "Segure para falar (ditado no dispositivo)"
 
@@ -1611,7 +1611,7 @@ msgstr "Com que frequência"
 msgid "How to check"
 msgstr "Como verificar"
 
-#: src/pages/Shell.tsx:4951
+#: src/pages/Shell.tsx:4969
 msgid "I’m done"
 msgstr "Eu terminei."
 
@@ -1640,7 +1640,7 @@ msgid "Instruction"
 msgstr "Instrução"
 
 #: src/pages/PluginsOverlay.tsx:247
-#: src/pages/Shell.tsx:2779
+#: src/pages/Shell.tsx:2793
 msgid "Integrations"
 msgstr "Integrações"
 
@@ -1670,11 +1670,11 @@ msgstr "Isolado"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Suas conversas, arquivos e rotinas serão excluídos permanentemente. Os bots criados ficam na sua lista."
 
-#: src/pages/Shell.tsx:4105
+#: src/pages/Shell.tsx:4123
 msgid "Jump to latest"
 msgstr "Ir para a mensagem mais recente"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5034
 msgid "Jump to replied message"
 msgstr "Ir para a mensagem respondida"
 
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "Ouvindo..."
 
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Load earlier messages"
 msgstr "Carregar mensagens anteriores..."
 
@@ -1754,9 +1754,9 @@ msgid "Loading voice providers…"
 msgstr "Carregando provedores de voz..."
 
 #: src/App.tsx:54
-#: src/pages/Onboarding.tsx:217
+#: src/pages/Onboarding.tsx:240
 #: src/pages/PeerMessagesOverlay.tsx:99
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Loading…"
 msgstr "Carregando..."
 
@@ -1764,7 +1764,7 @@ msgstr "Carregando..."
 msgid "Local"
 msgstr "Local"
 
-#: src/pages/Shell.tsx:2872
+#: src/pages/Shell.tsx:2886
 msgid "Log out"
 msgstr "Sair"
 
@@ -1810,7 +1810,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Membros (escolha {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 
 #: src/pages/MemorySettingsOverlay.tsx:157
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2845
 msgid "Memory"
 msgstr "Memória"
 
@@ -1818,38 +1818,38 @@ msgstr "Memória"
 msgid "Memory scope"
 msgstr "Escopo de memória"
 
-#: src/pages/Shell.tsx:4503
+#: src/pages/Shell.tsx:4521
 msgid "Mentions"
 msgstr ""
-
-#: src/pages/Shell.tsx:4729
-#: src/pages/Shell.tsx:4843
-msgid "Message"
-msgstr "Mensagem"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:83
 msgid "Message"
 msgstr ""
 
-#: src/pages/Shell.tsx:4725
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4861
+msgid "Message"
+msgstr "Mensagem"
+
+#: src/pages/Shell.tsx:4743
+#: src/pages/Shell.tsx:4747
 msgid "Message {activeName}"
 msgstr "Mensagem {activeName}"
 
-#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4433
 msgid "Message composer"
 msgstr ""
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Message from {peer}"
 msgstr "Mensagem de {peer}"
 
-#: src/pages/Shell.tsx:4726
+#: src/pages/Shell.tsx:4744
 msgid "Message…"
 msgstr "Mensagem…"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Messaged {peer}"
 msgstr "Enviou mensagem para {peer}"
 
@@ -1881,21 +1881,25 @@ msgstr "minutos"
 #: src/pages/ModelSettingsOverlay.tsx:449
 #: src/pages/ModelSettingsOverlay.tsx:503
 #: src/pages/ModelSettingsOverlay.tsx:932
-#: src/pages/Onboarding.tsx:300
-#: src/pages/Onboarding.tsx:342
-#: src/pages/Onboarding.tsx:350
+#: src/pages/Onboarding.tsx:377
+#: src/pages/Onboarding.tsx:419
+#: src/pages/Onboarding.tsx:427
 #: src/pages/shell/bot-panel.tsx:332
 msgid "Model"
 msgstr "Modelo"
 
 #: src/pages/ModelSettingsOverlay.tsx:483
-#: src/pages/Onboarding.tsx:322
+#: src/pages/Onboarding.tsx:399
 msgid "Model id"
 msgstr "ID do modelo"
 
 #: src/pages/ModelSettingsOverlay.tsx:968
 msgid "Model options"
 msgstr "Opções do modelo"
+
+#: src/pages/Onboarding.tsx:278
+msgid "Model providers"
+msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:216
 msgid "Model spend uses your provider keys."
@@ -1906,12 +1910,12 @@ msgid "Model updated."
 msgstr "Modelo Atualizado"
 
 #: src/pages/ModelSettingsOverlay.tsx:323
-#: src/pages/Shell.tsx:2820
+#: src/pages/Shell.tsx:2834
 msgid "Models"
 msgstr "Modelos"
 
 #: src/pages/ModelSettingsOverlay.tsx:462
-#: src/pages/Onboarding.tsx:306
+#: src/pages/Onboarding.tsx:383
 msgid "Models from server"
 msgstr "Modelos do servidor"
 
@@ -1940,7 +1944,7 @@ msgstr "Mover para"
 #: src/pages/Auth.tsx:110
 #: src/pages/GroupPanel.tsx:119
 #: src/pages/GroupPanel.tsx:212
-#: src/pages/Onboarding.tsx:507
+#: src/pages/Onboarding.tsx:581
 #: src/pages/RoutineEditor.tsx:281
 #: src/pages/shell/bot-panel.tsx:122
 #: src/pages/shell/bot-panel.tsx:288
@@ -1949,7 +1953,7 @@ msgstr "Mover para"
 msgid "Name"
 msgstr "Nome"
 
-#: src/pages/Onboarding.tsx:512
+#: src/pages/Onboarding.tsx:586
 #: src/pages/shell/bot-panel.tsx:128
 msgid "Name this bot"
 msgstr "Nomeie este bot"
@@ -1970,13 +1974,13 @@ msgstr "Precisa de entrada"
 msgid "Needs takeover"
 msgstr "Requer assumir o controle"
 
-#: src/pages/Shell.tsx:2413
+#: src/pages/Shell.tsx:2427
 #: src/pages/shell/bot-panel.tsx:106
 msgid "New bot"
 msgstr "Novo bot"
 
 #: src/pages/GroupPanel.tsx:101
-#: src/pages/Shell.tsx:2423
+#: src/pages/Shell.tsx:2437
 msgid "New group"
 msgstr "Novo grupo"
 
@@ -1994,7 +1998,7 @@ msgstr "Nova senha"
 msgid "New section"
 msgstr "Nova seção"
 
-#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2449
 #: src/pages/shell/dialogs.tsx:68
 msgid "New space"
 msgstr ""
@@ -2059,6 +2063,10 @@ msgstr "Ainda sem mensagens com {peerBotName}."
 #: src/pages/ModelSettingsOverlay.tsx:733
 msgid "No model catalog is available."
 msgstr "Nenhum catálogo de modelos está disponível."
+
+#: src/pages/Onboarding.tsx:339
+msgid "No providers found"
+msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:402
 msgid "No providers found."
@@ -2132,21 +2140,21 @@ msgid "on the 1st at {0}"
 msgstr "no dia 1º às {0}"
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3154
-#: src/pages/Shell.tsx:3159
+#: src/pages/Shell.tsx:3170
+#: src/pages/Shell.tsx:3175
 msgid "Open"
 msgstr "Abrir"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2492
+#: src/pages/Shell.tsx:2506
 msgid "Open {0}"
 msgstr ""
 
-#: src/pages/Shell.tsx:3119
+#: src/pages/Shell.tsx:3133
 msgid "Open in full window"
 msgstr "Abrir em janela cheia"
 
-#: src/pages/Shell.tsx:2888
+#: src/pages/Shell.tsx:2902
 msgid "Open navigation"
 msgstr "Abrir a navegação"
 
@@ -2155,11 +2163,11 @@ msgid "Open work"
 msgstr "Trabalho aberto"
 
 #: src/pages/ModelSettingsOverlay.tsx:422
-#: src/pages/Onboarding.tsx:275
+#: src/pages/Onboarding.tsx:352
 msgid "OpenAI-compatible server URL"
 msgstr "URL do servidor compatível com OpenAI"
 
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5251
 msgid "Opened its thread."
 msgstr "Abriu a conversa."
 
@@ -2168,7 +2176,7 @@ msgid "Opening your Space…"
 msgstr "Abrindo seu espaço de trabalho..."
 
 #: src/pages/ModelSettingsOverlay.tsx:646
-#: src/pages/Onboarding.tsx:446
+#: src/pages/Onboarding.tsx:520
 msgid "Optional"
 msgstr "Opcional"
 
@@ -2184,7 +2192,7 @@ msgstr "Valor de cabeçalho opcional"
 msgid "Or connect an API key"
 msgstr "Ou conecte uma chave de API"
 
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:531
 msgid "Or paste an API key"
 msgstr "Ou cole uma chave de API"
 
@@ -2197,7 +2205,7 @@ msgid "Organization API key"
 msgstr "Chave da API da organização"
 
 #: src/pages/ModelSettingsOverlay.tsx:470
-#: src/pages/Onboarding.tsx:315
+#: src/pages/Onboarding.tsx:392
 msgid "Other model…"
 msgstr "Outro modelo..."
 
@@ -2235,7 +2243,7 @@ msgid "Paste a replacement key"
 msgstr "Cole uma chave de substituição"
 
 #: src/pages/ModelSettingsOverlay.tsx:433
-#: src/pages/Onboarding.tsx:286
+#: src/pages/Onboarding.tsx:363
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Cole o endereço compatível com OpenAI do seu servidor. Rakazo adiciona /v1 se necessário."
 
@@ -2278,6 +2286,7 @@ msgid "Private"
 msgstr "Privado"
 
 #: src/pages/MemorySettingsOverlay.tsx:216
+#: src/pages/Onboarding.tsx:250
 msgid "Provider"
 msgstr "Provedor"
 
@@ -2342,7 +2351,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:4959
 msgid "Release"
 msgstr "Libere"
 
@@ -2355,12 +2364,12 @@ msgid "Remove"
 msgstr "Remover"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4489
+#: src/pages/Shell.tsx:4507
 msgid "Remove {0}"
 msgstr "Remover {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4681
 msgid "Remove mention {0}"
 msgstr "Remover menção {0}"
 
@@ -2369,12 +2378,12 @@ msgid "Remove schedule"
 msgstr ""
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4660
 msgid "Remove skill {0}"
 msgstr "Remover habilidade {0}"
 
-#: src/pages/Shell.tsx:4080
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4900
 msgid "Remove thumbs-up"
 msgstr ""
 
@@ -2382,7 +2391,7 @@ msgstr ""
 msgid "Remove webhook"
 msgstr ""
 
-#: src/pages/Shell.tsx:5232
+#: src/pages/Shell.tsx:5250
 msgid "Removed with chat, computer, and memory."
 msgstr "Removido com chat, computador e memória."
 
@@ -2410,11 +2419,11 @@ msgstr "Substituir chave de API"
 msgid "Replace key"
 msgstr "Substituir chave"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4891
 msgid "Reply"
 msgstr "Responder"
 
-#: src/pages/Shell.tsx:4452
+#: src/pages/Shell.tsx:4470
 msgid "Replying to {replyName}"
 msgstr "Respondendo a {replyName}"
 
@@ -2443,8 +2452,8 @@ msgstr "Redefina sua senha"
 msgid "Resetting…"
 msgstr "Redefinindo…"
 
-#: src/pages/Shell.tsx:2721
-#: src/pages/Shell.tsx:2752
+#: src/pages/Shell.tsx:2735
+#: src/pages/Shell.tsx:2766
 msgid "Restore"
 msgstr "Restaurar"
 
@@ -2455,6 +2464,10 @@ msgstr "Restaure o último espaço de trabalho salvo. O trabalho não salvo no c
 #: src/App.tsx:148
 msgid "Retry now"
 msgstr "Nova tentativa agora"
+
+#: src/pages/Shell.tsx:2348
+msgid "Retry screen"
+msgstr ""
 
 #: src/pages/McpOAuthCallback.tsx:62
 msgid "Return to Rakazo"
@@ -2473,8 +2486,8 @@ msgid "Rotate key"
 msgstr ""
 
 #: src/pages/RoutineEditor.tsx:236
-#: src/pages/Shell.tsx:3338
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3355
+#: src/pages/Shell.tsx:3365
 msgid "Routine"
 msgstr "Rotina"
 
@@ -2491,7 +2504,7 @@ msgstr ""
 msgid "Run history"
 msgstr ""
 
-#: src/pages/Shell.tsx:3331
+#: src/pages/Shell.tsx:3348
 msgid "Run time must be in the future."
 msgstr ""
 
@@ -2549,7 +2562,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "Diga sim ou não, ou responda em uma frase."
 
 #: src/pages/ModelSettingsOverlay.tsx:957
-#: src/pages/Shell.tsx:2449
+#: src/pages/Shell.tsx:2463
 msgid "Search"
 msgstr "Pesquisar"
 
@@ -2567,8 +2580,8 @@ msgstr ""
 msgid "Search providers"
 msgstr "Pesquisar provedores"
 
-#: src/pages/Onboarding.tsx:231
-#: src/pages/Onboarding.tsx:232
+#: src/pages/Onboarding.tsx:272
+#: src/pages/Onboarding.tsx:273
 msgid "Search providers and models"
 msgstr "Pesquisar fornecedores e modelos"
 
@@ -2576,12 +2589,16 @@ msgstr "Pesquisar fornecedores e modelos"
 msgid "Searching…"
 msgstr "Pesquisando…"
 
-#: src/pages/Shell.tsx:2917
+#: src/pages/Shell.tsx:2931
 msgid "Select a bot"
 msgstr "Selecione um bot"
 
-#: src/pages/Shell.tsx:4747
-#: src/pages/Shell.tsx:4768
+#: src/pages/Onboarding.tsx:320
+msgid "Selected"
+msgstr ""
+
+#: src/pages/Shell.tsx:4765
+#: src/pages/Shell.tsx:4786
 msgid "Send"
 msgstr "Enviar"
 
@@ -2618,31 +2635,31 @@ msgstr "Nome do servidor"
 
 #: src/pages/McpServersOverlay.tsx:329
 #: src/pages/ModelSettingsOverlay.tsx:417
-#: src/pages/Onboarding.tsx:270
+#: src/pages/Onboarding.tsx:347
 msgid "Server URL"
 msgstr "URL do servidor"
 
-#: src/pages/Shell.tsx:2926
+#: src/pages/Shell.tsx:2940
 msgid "Set up voice to call"
 msgstr "Configurar voz para ligar"
 
 #: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2801
-#: src/pages/Shell.tsx:2809
-#: src/pages/Shell.tsx:3069
+#: src/pages/Shell.tsx:2815
+#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:3083
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4804
 msgid "Settings: General"
 msgstr "Opções > Geral"
 
-#: src/pages/Shell.tsx:4788
+#: src/pages/Shell.tsx:4806
 msgid "Settings: Usage"
 msgstr "Configurações: Uso"
 
 #: src/pages/ModelSettingsOverlay.tsx:430
-#: src/pages/Onboarding.tsx:283
+#: src/pages/Onboarding.tsx:360
 msgid "Setup help"
 msgstr "Ajuda"
 
@@ -2651,7 +2668,11 @@ msgstr "Ajuda"
 msgid "Shared"
 msgstr "Compartilhado"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:264
+msgid "Show all providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show computer"
 msgstr "Mostrar computador"
 
@@ -2663,7 +2684,11 @@ msgstr "Mostrar mais"
 msgid "Show password"
 msgstr ""
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:262
+msgid "Show popular providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show settings"
 msgstr "Mostrar configurações"
 
@@ -2671,7 +2696,7 @@ msgstr "Mostrar configurações"
 #: src/pages/Auth.tsx:206
 #: src/pages/Auth.tsx:264
 #: src/pages/ModelSettingsOverlay.tsx:628
-#: src/pages/Onboarding.tsx:108
+#: src/pages/Onboarding.tsx:131
 msgid "Sign in"
 msgstr "Entrar"
 
@@ -2685,15 +2710,15 @@ msgid "Sign up"
 msgstr "Cadastre-se"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4550
+#: src/pages/Shell.tsx:4568
 msgid "Skill {0}"
 msgstr "Habilidade {0}"
 
-#: src/pages/Shell.tsx:4948
+#: src/pages/Shell.tsx:4966
 msgid "Skip"
 msgstr "Pular"
 
-#: src/pages/Onboarding.tsx:495
+#: src/pages/Onboarding.tsx:569
 msgid "Skip for now"
 msgstr "Ignorar por enquanto"
 
@@ -2702,7 +2727,7 @@ msgid "Skip or deploy key"
 msgstr "Ignorar ou implantar chave"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1905
+#: src/pages/Shell.tsx:1907
 msgid "Skipped {0}"
 msgstr "{0} ignorado"
 
@@ -2723,8 +2748,8 @@ msgstr "Padrão do espaço"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Interrupções de espaço · Esc desliga"
 
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Speak"
 msgstr "Falar"
 
@@ -2736,8 +2761,8 @@ msgstr "Falar + transcrever"
 msgid "Speak only"
 msgstr "Falar apenas"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Speak this reply"
 msgstr "Fale esta resposta"
 
@@ -2755,7 +2780,7 @@ msgstr "Iniciando"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
 #: src/pages/ModelSettingsOverlay.tsx:626
-#: src/pages/Onboarding.tsx:431
+#: src/pages/Onboarding.tsx:505
 msgid "Starting…"
 msgstr "Iniciando…"
 
@@ -2763,20 +2788,20 @@ msgstr "Iniciando…"
 msgid "Steps"
 msgstr "Passos"
 
-#: src/pages/Shell.tsx:3755
-#: src/pages/Shell.tsx:3760
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:3772
+#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Stop"
 msgstr "Parar"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Stop dictation"
 msgstr "Parar ditado"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Stop speaking"
 msgstr "Pare de Falar"
 
@@ -2794,13 +2819,13 @@ msgstr "Interrompido."
 msgid "Stored encrypted"
 msgstr "Armazenado criptografado"
 
-#: src/pages/Shell.tsx:5186
+#: src/pages/Shell.tsx:5204
 msgid "subagent"
 msgstr "subagente"
 
 #: src/components/AskCard.tsx:140
 #: src/pages/ModelSettingsOverlay.tsx:586
-#: src/pages/Onboarding.tsx:398
+#: src/pages/Onboarding.tsx:472
 msgid "Submit"
 msgstr "Enviar"
 
@@ -2821,7 +2846,7 @@ msgstr "Sistema"
 msgid "Teach a task"
 msgstr "Ensinar uma tarefa"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3005
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Ensino em andamento — pare de ensinar antes de enviar uma nova mensagem."
 
@@ -2829,7 +2854,7 @@ msgstr "Ensino em andamento — pare de ensinar antes de enviar uma nova mensage
 msgid "Team"
 msgstr "Equipe"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "Team Computer"
 msgstr "Computador da equipe"
 
@@ -2857,11 +2882,11 @@ msgstr "O provedor de memória selecionado não está disponível nesta compila�
 msgid "Thinking"
 msgstr "Pensando"
 
-#: src/pages/Shell.tsx:3123
+#: src/pages/Shell.tsx:3137
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Este bot é executado neste computador, não em um desktop Linux. Shell e arquivos usam sua pasta inicial."
 
-#: src/pages/Shell.tsx:3811
+#: src/pages/Shell.tsx:3828
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Este bot é executado neste computador. Não há uma área de trabalho Linux separada. Peça-lhe para usar o shell; diretórios de trabalho na sua pasta pessoal são permitidos."
 
@@ -2898,7 +2923,7 @@ msgstr "Este Mac executa comandos do shell com sua conta, incluindo arquivos em 
 msgid "This permanently removes every message and stops current work. The chat remains available."
 msgstr ""
 
-#: src/pages/Onboarding.tsx:471
+#: src/pages/Onboarding.tsx:545
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Este provedor não pode colar uma chave aqui. Ignore se esta implantação já tiver credenciais."
 
@@ -2930,7 +2955,7 @@ msgstr "Este login de assinatura ainda não está disponível no Rakazo. Use uma
 msgid "Time of day"
 msgstr "Hora do dia"
 
-#: src/pages/Onboarding.tsx:520
+#: src/pages/Onboarding.tsx:594
 #: src/pages/shell/bot-panel.tsx:133
 #: src/pages/shell/bot-panel.tsx:298
 msgid "Title"
@@ -2965,7 +2990,7 @@ msgid "Unpin"
 msgstr "Desafixar"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1978
 msgid "Unsupported file type: {0}"
 msgstr "Tipo de arquivo não suportado: {0}"
 
@@ -3005,7 +3030,7 @@ msgid "Updating…"
 msgstr "Atualizando…"
 
 #: src/pages/AccountSettingsOverlay.tsx:206
-#: src/pages/Shell.tsx:2852
+#: src/pages/Shell.tsx:2866
 msgid "Usage"
 msgstr "Uso"
 
@@ -3014,7 +3039,7 @@ msgid "Use {hostLabel}"
 msgstr "Usar {hostLabel}"
 
 #: src/pages/ModelSettingsOverlay.tsx:495
-#: src/pages/Onboarding.tsx:334
+#: src/pages/Onboarding.tsx:411
 msgid "Use a found model"
 msgstr "Usar um modelo encontrado"
 
@@ -3030,7 +3055,7 @@ msgstr "Verificar e adicionar"
 msgid "Verifying…"
 msgstr "Verificando…"
 
-#: src/pages/Shell.tsx:2842
+#: src/pages/Shell.tsx:2856
 #: src/pages/shell/bot-panel.tsx:418
 #: src/pages/VoiceSettingsOverlay.tsx:145
 #: src/pages/VoiceSettingsOverlay.tsx:288
@@ -3039,8 +3064,8 @@ msgstr "Voz"
 
 #: src/pages/ModelSettingsOverlay.tsx:590
 #: src/pages/ModelSettingsOverlay.tsx:612
-#: src/pages/Onboarding.tsx:402
-#: src/pages/Onboarding.tsx:424
+#: src/pages/Onboarding.tsx:476
+#: src/pages/Onboarding.tsx:498
 msgid "Waiting for sign-in…"
 msgstr "Aguardando login..."
 
@@ -3074,7 +3099,7 @@ msgstr "Que resultado você demonstrará?"
 msgid "What should this routine do each time it runs?"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:538
+#: src/pages/Onboarding.tsx:612
 #: src/pages/shell/bot-panel.tsx:150
 msgid "What this bot is for"
 msgstr "Para que serve este bot"
@@ -3103,13 +3128,13 @@ msgstr "Onde os bots devem ser executados?"
 #: src/pages/Auth.tsx:185
 #: src/pages/Auth.tsx:293
 #: src/pages/CallView.tsx:251
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Working…"
 msgstr "Funcionando"
 
-#: src/pages/Shell.tsx:1679
-#: src/pages/Shell.tsx:2339
+#: src/pages/Shell.tsx:1681
+#: src/pages/Shell.tsx:2353
 msgid "You"
 msgstr "Você"
 
@@ -3121,7 +3146,7 @@ msgstr "Você pode fechar esta guia se ela não for redirecionada automaticament
 msgid "You can close this window."
 msgstr "Você pode fechar esta janela."
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3762
 msgid "You have control"
 msgstr "Você tem o controle"
 

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2625
+#: src/pages/Shell.tsx:2639
 msgid " (unread)"
 msgstr " (okunmadı)"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# model} other {# model}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1885
+#: src/pages/Shell.tsx:1887
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0} (en fazla {ATTACHMENT_MAX_COUNT} ek)"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1889
+#: src/pages/Shell.tsx:1891
 msgid "{0} (over 10 MiB)"
 msgstr "{0} (10 MiB üzeri)"
 
@@ -63,16 +63,16 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:210
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2870
 msgid "{0} runs · {1} tokens"
 msgstr "{0} çalıştırma · {1} token"
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3164
+#: src/pages/Shell.tsx:3181
 msgid "{0}'s screen"
 msgstr ""
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "{botName}’s computer"
 msgstr "{botName} adlı botun bilgisayarı"
 
@@ -116,12 +116,12 @@ msgstr "{size} B"
 msgid "{title}, {label}"
 msgstr "{title}, {label}"
 
-#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:3937
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} çalışıyor"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4517
+#: src/pages/Shell.tsx:4535
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -158,8 +158,8 @@ msgstr "Etkin model"
 msgid "Active voice"
 msgstr "Etkin ses"
 
-#: src/pages/Shell.tsx:2374
-#: src/pages/Shell.tsx:2376
+#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2390
 msgid "Activity"
 msgstr "Etkinlik"
 
@@ -173,7 +173,7 @@ msgstr "Ekle"
 msgid "Add a model in Settings to use this."
 msgstr ""
 
-#: src/pages/Shell.tsx:3326
+#: src/pages/Shell.tsx:3343
 msgid "Add a run time for this one-shot."
 msgstr ""
 
@@ -181,7 +181,7 @@ msgstr ""
 msgid "Add a schedule or webhook to run this routine."
 msgstr ""
 
-#: src/pages/Shell.tsx:3298
+#: src/pages/Shell.tsx:3315
 msgid "Add a schedule or webhook trigger"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgstr "Uzak MCP sunucusu ekle"
 msgid "Add server"
 msgstr "Sunucu ekle"
 
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4900
 msgid "Add thumbs-up"
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr "Gelişmiş"
 msgid "Advanced..."
 msgstr ""
 
-#: src/pages/Shell.tsx:2944
+#: src/pages/Shell.tsx:2958
 msgid "Agent computer"
 msgstr "Agent bilgisayarı"
 
@@ -261,7 +261,7 @@ msgid "Agent connections"
 msgstr ""
 
 #: src/pages/McpServersOverlay.tsx:385
-#: src/pages/McpServersOverlay.tsx:448
+#: src/pages/McpServersOverlay.tsx:452
 msgid "Agents:"
 msgstr "Agent'lar:"
 
@@ -333,9 +333,9 @@ msgstr ""
 #: src/pages/ModelSettingsOverlay.tsx:640
 #: src/pages/ModelSettingsOverlay.tsx:643
 #: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/Onboarding.tsx:440
-#: src/pages/Onboarding.tsx:443
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:514
+#: src/pages/Onboarding.tsx:517
+#: src/pages/Onboarding.tsx:531
 #: src/pages/VoiceSettingsOverlay.tsx:258
 msgid "API key"
 msgstr "API anahtarı"
@@ -367,15 +367,15 @@ msgstr "Agent'ının bu sunucunun araçlarını kullanabilmesi için sunucuyu on
 msgid "Archive"
 msgstr "Arşivle"
 
-#: src/pages/Shell.tsx:5220
+#: src/pages/Shell.tsx:5238
 msgid "archived"
 msgstr "arşivlendi"
 
-#: src/pages/Shell.tsx:2694
+#: src/pages/Shell.tsx:2708
 msgid "Archived"
 msgstr "Arşivlendi"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5249
 msgid "Archived. Chat, memory, and files kept."
 msgstr "Arşivlendi. Sohbet, hafıza ve dosyalar korundu."
 
@@ -425,16 +425,16 @@ msgstr "saat {0}"
 msgid "at {timeSelect}"
 msgstr "saat {timeSelect}"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4615
 msgid "Attach file"
 msgstr "Dosya ekle"
 
-#: src/pages/Shell.tsx:4841
+#: src/pages/Shell.tsx:4859
 msgid "Attachment"
 msgstr "Ek"
 
 #: src/pages/ModelSettingsOverlay.tsx:573
-#: src/pages/Onboarding.tsx:389
+#: src/pages/Onboarding.tsx:463
 msgid "Authorization code or callback URL"
 msgstr "Yetkilendirme kodu veya callback URL'si"
 
@@ -474,35 +474,35 @@ msgstr "Temel URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5446
 msgid "Booting live desktop…"
 msgstr "Canlı masaüstü başlatılıyor…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3712
+#: src/pages/Shell.tsx:3729
 msgid "Booting up {0}’s computer"
 msgstr "{0} adlı botun bilgisayarı başlatılıyor"
 
-#: src/pages/Shell.tsx:5080
-#: src/pages/Shell.tsx:5081
-#: src/pages/Shell.tsx:5224
+#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5099
+#: src/pages/Shell.tsx:5242
 msgid "bot"
 msgstr "bot"
-
-#: src/pages/Shell.tsx:1680
-msgid "Bot"
-msgstr "Bot"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:71
 msgid "Bot"
 msgstr ""
 
-#: src/pages/Shell.tsx:3819
+#: src/pages/Shell.tsx:1682
+msgid "Bot"
+msgstr "Bot"
+
+#: src/pages/Shell.tsx:3836
 msgid "Bot screen"
 msgstr "Bot ekranı"
 
-#: src/pages/Shell.tsx:3130
+#: src/pages/Shell.tsx:3144
 msgid "Bot screen preview"
 msgstr "Bot ekranı önizlemesi"
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first. These preferences apply across all your bots."
 msgstr "Botlar varsayılan olarak sormadan hareket eder. Yalnızca belirli bir işlem türünü önce incelemek istediğinde istisna ekle. Bu tercihler tüm botlarında geçerlidir."
 
-#: src/pages/Shell.tsx:3920
+#: src/pages/Shell.tsx:3938
 msgid "Bots are working"
 msgstr "Botlar çalışıyor"
 
@@ -523,8 +523,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "Kendi anahtarını getir. Sağlayıcı değiştirilebilir; botlarındaki seslendirme ve arama düğmeleri aynı kalır."
 
 #: src/pages/CallView.tsx:241
-#: src/pages/Shell.tsx:2926
-#: src/pages/Shell.tsx:2927
+#: src/pages/Shell.tsx:2940
+#: src/pages/Shell.tsx:2941
 msgid "Call"
 msgstr "Ara"
 
@@ -553,7 +553,7 @@ msgstr "Yeni botu iptal et"
 msgid "Cancel new group"
 msgstr "Yeni grubu iptal et"
 
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4473
 msgid "Cancel reply"
 msgstr "Yanıtı iptal et"
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Chat apps, group channels, and agent connections."
 msgstr ""
 
-#: src/pages/Shell.tsx:4784
+#: src/pages/Shell.tsx:4802
 msgid "Chat Settings"
 msgstr "Sohbet Ayarları"
 
@@ -598,8 +598,8 @@ msgstr ""
 msgid "Check for updates"
 msgstr ""
 
-#: src/pages/Shell.tsx:3339
-#: src/pages/Shell.tsx:3349
+#: src/pages/Shell.tsx:3356
+#: src/pages/Shell.tsx:3366
 msgid "Check in."
 msgstr "Durum bildir."
 
@@ -618,10 +618,6 @@ msgstr ""
 #: src/pages/MessagingSettingsOverlay.tsx:152
 msgid "Choose a bot…"
 msgstr ""
-
-#: src/pages/Onboarding.tsx:226
-msgid "Choose a model to get started."
-msgstr "Başlamak için bir model seç."
 
 #: src/pages/Auth.tsx:257
 msgid "Choose a new password"
@@ -661,7 +657,7 @@ msgstr "Kapat"
 msgid "Close chart"
 msgstr "Grafiği kapat"
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3810
 msgid "Close computer"
 msgstr "Bilgisayarı kapat"
 
@@ -689,11 +685,11 @@ msgstr ""
 msgid "Close model settings"
 msgstr "Model ayarlarını kapat"
 
-#: src/pages/Shell.tsx:2359
+#: src/pages/Shell.tsx:2373
 msgid "Close navigation"
 msgstr "Gezinmeyi kapat"
 
-#: src/pages/Shell.tsx:3103
+#: src/pages/Shell.tsx:3117
 msgid "Close panel"
 msgstr "Paneli kapat"
 
@@ -719,7 +715,7 @@ msgid "Code"
 msgstr ""
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2509
 msgid "Collapse {0}"
 msgstr ""
 
@@ -735,24 +731,24 @@ msgstr "Komut"
 msgid "Complete"
 msgstr "Tamamlandı"
 
-#: src/pages/Shell.tsx:5378
+#: src/pages/Shell.tsx:5396
 #: src/pages/shell/bot-panel.tsx:47
 msgid "Computer"
 msgstr "Bilgisayar"
 
-#: src/pages/Shell.tsx:5431
+#: src/pages/Shell.tsx:5449
 msgid "Computer failed to boot"
 msgstr "Bilgisayar başlatılamadı"
 
-#: src/pages/Shell.tsx:3841
+#: src/pages/Shell.tsx:3859
 msgid "Computer is asleep"
 msgstr "Bilgisayar uykuda"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5448
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5432
+#: src/pages/Shell.tsx:5450
 msgid "Computer is stopped"
 msgstr "Bilgisayar durduruldu"
 
@@ -772,7 +768,7 @@ msgstr "Dağıtım tarafından yapılandırıldı"
 msgid "Configured servers"
 msgstr "Yapılandırılmış sunucular"
 
-#: src/pages/McpServersOverlay.tsx:502
+#: src/pages/McpServersOverlay.tsx:506
 msgid "Confirm delete"
 msgstr "Silmeyi onayla"
 
@@ -786,7 +782,7 @@ msgstr "Parolayı doğrulayın"
 msgid "Connect"
 msgstr "Bağlan"
 
-#: src/pages/Onboarding.tsx:223
+#: src/pages/Onboarding.tsx:246
 msgid "Connect a model"
 msgstr "Model bağla"
 
@@ -857,8 +853,8 @@ msgstr "Bağlanıyor…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "{0} bağlantısı hâlâ beklemede. Bunu kapatıp daha sonra tekrar kontrol edebilirsin."
 
-#: src/pages/Onboarding.tsx:484
-#: src/pages/Onboarding.tsx:545
+#: src/pages/Onboarding.tsx:558
+#: src/pages/Onboarding.tsx:619
 msgid "Continue"
 msgstr "Devam"
 
@@ -866,7 +862,7 @@ msgstr "Devam"
 msgid "Continue with email"
 msgstr "E-posta ile devam et"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4912
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -923,6 +919,10 @@ msgstr "Bu sağlayıcı bağlanamadı"
 msgid "Could not connect this voice provider"
 msgstr "Bu ses sağlayıcısı bağlanamadı"
 
+#: src/pages/Shell.tsx:821
+msgid "Could not connect to the computer screen"
+msgstr ""
+
 #: src/pages/Auth.tsx:85
 msgid "Could not continue"
 msgstr "Devam edilemedi"
@@ -943,7 +943,7 @@ msgstr "Bölüm oluşturulamadı"
 msgid "Could not create space"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:208
+#: src/pages/Onboarding.tsx:231
 msgid "Could not create your bot"
 msgstr "Botun oluşturulamadı"
 
@@ -1027,7 +1027,7 @@ msgid "Could not reach the server"
 msgstr "Sunucuya ulaşılamadı"
 
 #: src/pages/ModelSettingsOverlay.tsx:232
-#: src/pages/Onboarding.tsx:154
+#: src/pages/Onboarding.tsx:177
 msgid "Could not reach this model server"
 msgstr "Bu model sunucusuna ulaşılamadı"
 
@@ -1059,7 +1059,7 @@ msgstr "Parola sıfırlanamadı"
 msgid "Could not revoke connection"
 msgstr "Bağlantı iptal edilemedi"
 
-#: src/pages/Shell.tsx:3401
+#: src/pages/Shell.tsx:3418
 msgid "Could not run routine"
 msgstr ""
 
@@ -1075,11 +1075,11 @@ msgstr ""
 msgid "Could not save group"
 msgstr "Grup kaydedilemedi"
 
-#: src/pages/Onboarding.tsx:181
+#: src/pages/Onboarding.tsx:204
 msgid "Could not save model"
 msgstr "Model kaydedilemedi"
 
-#: src/pages/Shell.tsx:3372
+#: src/pages/Shell.tsx:3389
 msgid "Could not save routine"
 msgstr "Rutin kaydedilemedi"
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "Bu yanıt gönderilemedi"
 
-#: src/pages/Shell.tsx:2205
+#: src/pages/Shell.tsx:2207
 msgid "Could not take control"
 msgstr "Kontrol alınamadı"
 
@@ -1135,7 +1135,7 @@ msgstr "Agent erişimi güncellenemedi"
 msgid "Could not update computer"
 msgstr ""
 
-#: src/pages/Shell.tsx:1871
+#: src/pages/Shell.tsx:1873
 msgid "Could not update reaction"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Couldn't update messaging settings"
 msgstr ""
 
-#: src/pages/Shell.tsx:2395
+#: src/pages/Shell.tsx:2409
 #: src/pages/shell/bot-panel.tsx:161
 #: src/pages/shell/dialogs.tsx:155
 msgid "Create"
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Create space"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:504
+#: src/pages/Onboarding.tsx:578
 msgid "Create your first bot"
 msgstr "İlk botunu oluştur"
 
@@ -1254,10 +1254,10 @@ msgid "Default scope"
 msgstr "Varsayılan kapsam"
 
 #: src/pages/BotContextMenu.tsx:150
-#: src/pages/McpServersOverlay.tsx:504
+#: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:272
-#: src/pages/Shell.tsx:2730
-#: src/pages/Shell.tsx:2761
+#: src/pages/Shell.tsx:2744
+#: src/pages/Shell.tsx:2775
 #: src/pages/shell/dialogs.tsx:298
 #: src/pages/shell/dialogs.tsx:355
 msgid "Delete"
@@ -1265,8 +1265,8 @@ msgstr "Sil"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2727
-#: src/pages/Shell.tsx:2758
+#: src/pages/Shell.tsx:2741
+#: src/pages/Shell.tsx:2772
 msgid "Delete {0}"
 msgstr "{0} sil"
 
@@ -1285,7 +1285,7 @@ msgstr "Grubu sil"
 msgid "Delete memories too"
 msgstr "Hafızayı da sil"
 
-#: src/pages/Shell.tsx:5222
+#: src/pages/Shell.tsx:5240
 msgid "deleted"
 msgstr "silindi"
 
@@ -1307,22 +1307,22 @@ msgstr "Reddet"
 msgid "Deployment default"
 msgstr "Dağıtım varsayılanı"
 
-#: src/pages/Onboarding.tsx:525
+#: src/pages/Onboarding.tsx:599
 #: src/pages/shell/bot-panel.tsx:139
 msgid "Describe what this bot does"
 msgstr "Bu botun ne yaptığını açıkla"
 
-#: src/pages/Onboarding.tsx:533
+#: src/pages/Onboarding.tsx:607
 #: src/pages/shell/bot-panel.tsx:144
 #: src/pages/shell/bot-panel.tsx:308
 msgid "Description"
 msgstr "Açıklama"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Dictate"
 msgstr "Dikte et"
 
-#: src/pages/McpServersOverlay.tsx:489
+#: src/pages/McpServersOverlay.tsx:493
 #: src/pages/MemorySettingsOverlay.tsx:207
 msgid "Disconnect"
 msgstr "Bağlantıyı kes"
@@ -1335,7 +1335,7 @@ msgstr "Bağlantı kesiliyor…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4453
 msgid "Dismiss error"
 msgstr ""
 
@@ -1365,8 +1365,8 @@ msgid "Don’t have an account?"
 msgstr "Hesabın yok mu?"
 
 #: src/pages/ActivityList.tsx:157
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Done"
 msgstr "Bitti"
 
@@ -1389,7 +1389,7 @@ msgstr "Taslak beceri"
 msgid "Duplicate"
 msgstr "Çoğalt"
 
-#: src/pages/Shell.tsx:5021
+#: src/pages/Shell.tsx:5039
 msgid "Earlier message"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr "E-posta"
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
 #: src/pages/ModelSettingsOverlay.tsx:596
-#: src/pages/Onboarding.tsx:408
+#: src/pages/Onboarding.tsx:482
 msgid "Enter this code at <0>{0}</0>"
 msgstr "Bu kodu <0>{0}</0> adresinde gir"
 
@@ -1450,7 +1450,7 @@ msgid "Expand"
 msgstr "Genişlet"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2494
+#: src/pages/Shell.tsx:2508
 msgid "Expand {0}"
 msgstr ""
 
@@ -1470,14 +1470,14 @@ msgstr "Çok yüksek"
 msgid "Failed"
 msgstr "Başarısız"
 
-#: src/pages/Shell.tsx:2023
 #: src/pages/Shell.tsx:2025
 #: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2029
 msgid "Failed to send message"
 msgstr "Mesaj gönderilemedi"
 
-#: src/pages/Shell.tsx:2060
-#: src/pages/Shell.tsx:2079
+#: src/pages/Shell.tsx:2062
+#: src/pages/Shell.tsx:2081
 msgid "Failed to stop"
 msgstr "Durdurulamadı"
 
@@ -1491,18 +1491,18 @@ msgid "Failure handling"
 msgstr "Hata yönetimi"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Find models"
 msgstr "Model bul"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Finding…"
 msgstr "Aranıyor…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
 #: src/pages/ModelSettingsOverlay.tsx:556
-#: src/pages/Onboarding.tsx:372
+#: src/pages/Onboarding.tsx:446
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "<0>{0}</0> adresinde oturum açmayı tamamla. Son sayfa yüklenmeyebilir; URL'sini veya kodu buraya yapıştır."
 
@@ -1536,8 +1536,8 @@ msgid "Git event"
 msgstr ""
 
 #: src/pages/MessagingSettingsOverlay.tsx:198
-#: src/pages/Shell.tsx:2916
-#: src/pages/Shell.tsx:3073
+#: src/pages/Shell.tsx:2930
+#: src/pages/Shell.tsx:3087
 msgid "Group"
 msgstr "Grup"
 
@@ -1587,11 +1587,11 @@ msgstr ""
 msgid "High"
 msgstr "Yüksek"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk"
 msgstr "Konuşmak için basılı tut"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk (on-device dictation)"
 msgstr "Konuşmak için basılı tut (cihaz üzerinde dikte)"
 
@@ -1611,7 +1611,7 @@ msgstr "Ne sıklıkla"
 msgid "How to check"
 msgstr "Nasıl kontrol edilir"
 
-#: src/pages/Shell.tsx:4951
+#: src/pages/Shell.tsx:4969
 msgid "I’m done"
 msgstr "Bitirdim"
 
@@ -1640,7 +1640,7 @@ msgid "Instruction"
 msgstr "Talimat"
 
 #: src/pages/PluginsOverlay.tsx:247
-#: src/pages/Shell.tsx:2779
+#: src/pages/Shell.tsx:2793
 msgid "Integrations"
 msgstr "Entegrasyonlar"
 
@@ -1670,11 +1670,11 @@ msgstr "Yalıtılmış"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "Sohbeti, dosyaları ve rutinleri kalıcı olarak silinecek. Oluşturduğu botlar listende kalır."
 
-#: src/pages/Shell.tsx:4105
+#: src/pages/Shell.tsx:4123
 msgid "Jump to latest"
 msgstr "En son mesaja git"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5034
 msgid "Jump to replied message"
 msgstr "Yanıtlanan mesaja git"
 
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "Listening…"
 msgstr "Dinliyor…"
 
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Load earlier messages"
 msgstr "Önceki mesajları yükle"
 
@@ -1754,9 +1754,9 @@ msgid "Loading voice providers…"
 msgstr "Ses sağlayıcıları yükleniyor…"
 
 #: src/App.tsx:54
-#: src/pages/Onboarding.tsx:217
+#: src/pages/Onboarding.tsx:240
 #: src/pages/PeerMessagesOverlay.tsx:99
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Loading…"
 msgstr "Yükleniyor…"
 
@@ -1764,7 +1764,7 @@ msgstr "Yükleniyor…"
 msgid "Local"
 msgstr "Yerel"
 
-#: src/pages/Shell.tsx:2872
+#: src/pages/Shell.tsx:2886
 msgid "Log out"
 msgstr "Çıkış yap"
 
@@ -1810,7 +1810,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "Üyeler ({GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} seç)"
 
 #: src/pages/MemorySettingsOverlay.tsx:157
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2845
 msgid "Memory"
 msgstr "Hafıza"
 
@@ -1818,38 +1818,38 @@ msgstr "Hafıza"
 msgid "Memory scope"
 msgstr "Hafıza kapsamı"
 
-#: src/pages/Shell.tsx:4503
+#: src/pages/Shell.tsx:4521
 msgid "Mentions"
 msgstr ""
-
-#: src/pages/Shell.tsx:4729
-#: src/pages/Shell.tsx:4843
-msgid "Message"
-msgstr "Mesaj"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:83
 msgid "Message"
 msgstr ""
 
-#: src/pages/Shell.tsx:4725
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4861
+msgid "Message"
+msgstr "Mesaj"
+
+#: src/pages/Shell.tsx:4743
+#: src/pages/Shell.tsx:4747
 msgid "Message {activeName}"
 msgstr "{activeName} sohbetine yaz"
 
-#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4433
 msgid "Message composer"
 msgstr ""
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Message from {peer}"
 msgstr "{peer} botundan mesaj"
 
-#: src/pages/Shell.tsx:4726
+#: src/pages/Shell.tsx:4744
 msgid "Message…"
 msgstr "Mesaj…"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Messaged {peer}"
 msgstr "{peer} botuna mesaj gönderildi"
 
@@ -1881,21 +1881,25 @@ msgstr "dakika"
 #: src/pages/ModelSettingsOverlay.tsx:449
 #: src/pages/ModelSettingsOverlay.tsx:503
 #: src/pages/ModelSettingsOverlay.tsx:932
-#: src/pages/Onboarding.tsx:300
-#: src/pages/Onboarding.tsx:342
-#: src/pages/Onboarding.tsx:350
+#: src/pages/Onboarding.tsx:377
+#: src/pages/Onboarding.tsx:419
+#: src/pages/Onboarding.tsx:427
 #: src/pages/shell/bot-panel.tsx:332
 msgid "Model"
 msgstr "Model"
 
 #: src/pages/ModelSettingsOverlay.tsx:483
-#: src/pages/Onboarding.tsx:322
+#: src/pages/Onboarding.tsx:399
 msgid "Model id"
 msgstr "Model kimliği"
 
 #: src/pages/ModelSettingsOverlay.tsx:968
 msgid "Model options"
 msgstr "Model seçenekleri"
+
+#: src/pages/Onboarding.tsx:278
+msgid "Model providers"
+msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:216
 msgid "Model spend uses your provider keys."
@@ -1906,12 +1910,12 @@ msgid "Model updated."
 msgstr "Model güncellendi."
 
 #: src/pages/ModelSettingsOverlay.tsx:323
-#: src/pages/Shell.tsx:2820
+#: src/pages/Shell.tsx:2834
 msgid "Models"
 msgstr "Modeller"
 
 #: src/pages/ModelSettingsOverlay.tsx:462
-#: src/pages/Onboarding.tsx:306
+#: src/pages/Onboarding.tsx:383
 msgid "Models from server"
 msgstr "Sunucudan gelen modeller"
 
@@ -1940,7 +1944,7 @@ msgstr "Taşı"
 #: src/pages/Auth.tsx:110
 #: src/pages/GroupPanel.tsx:119
 #: src/pages/GroupPanel.tsx:212
-#: src/pages/Onboarding.tsx:507
+#: src/pages/Onboarding.tsx:581
 #: src/pages/RoutineEditor.tsx:281
 #: src/pages/shell/bot-panel.tsx:122
 #: src/pages/shell/bot-panel.tsx:288
@@ -1949,7 +1953,7 @@ msgstr "Taşı"
 msgid "Name"
 msgstr "Ad"
 
-#: src/pages/Onboarding.tsx:512
+#: src/pages/Onboarding.tsx:586
 #: src/pages/shell/bot-panel.tsx:128
 msgid "Name this bot"
 msgstr "Bota bir ad ver"
@@ -1970,13 +1974,13 @@ msgstr "Girdi bekliyor"
 msgid "Needs takeover"
 msgstr "Devralma bekliyor"
 
-#: src/pages/Shell.tsx:2413
+#: src/pages/Shell.tsx:2427
 #: src/pages/shell/bot-panel.tsx:106
 msgid "New bot"
 msgstr "Yeni bot"
 
 #: src/pages/GroupPanel.tsx:101
-#: src/pages/Shell.tsx:2423
+#: src/pages/Shell.tsx:2437
 msgid "New group"
 msgstr "Yeni grup"
 
@@ -1994,7 +1998,7 @@ msgstr "Yeni parola"
 msgid "New section"
 msgstr "Yeni bölüm"
 
-#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2449
 #: src/pages/shell/dialogs.tsx:68
 msgid "New space"
 msgstr ""
@@ -2059,6 +2063,10 @@ msgstr "{peerBotName} ile henüz mesaj yok."
 #: src/pages/ModelSettingsOverlay.tsx:733
 msgid "No model catalog is available."
 msgstr "Kullanılabilir model kataloğu yok."
+
+#: src/pages/Onboarding.tsx:339
+msgid "No providers found"
+msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:402
 msgid "No providers found."
@@ -2132,21 +2140,21 @@ msgid "on the 1st at {0}"
 msgstr "her ayın 1'inde saat {0}"
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3154
-#: src/pages/Shell.tsx:3159
+#: src/pages/Shell.tsx:3170
+#: src/pages/Shell.tsx:3175
 msgid "Open"
 msgstr "Aç"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2492
+#: src/pages/Shell.tsx:2506
 msgid "Open {0}"
 msgstr ""
 
-#: src/pages/Shell.tsx:3119
+#: src/pages/Shell.tsx:3133
 msgid "Open in full window"
 msgstr "Tam pencerede aç"
 
-#: src/pages/Shell.tsx:2888
+#: src/pages/Shell.tsx:2902
 msgid "Open navigation"
 msgstr "Gezinmeyi aç"
 
@@ -2155,11 +2163,11 @@ msgid "Open work"
 msgstr "Açık işler"
 
 #: src/pages/ModelSettingsOverlay.tsx:422
-#: src/pages/Onboarding.tsx:275
+#: src/pages/Onboarding.tsx:352
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI uyumlu sunucu URL'si"
 
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5251
 msgid "Opened its thread."
 msgstr "Sohbeti açıldı."
 
@@ -2168,7 +2176,7 @@ msgid "Opening your Space…"
 msgstr "Çalışma alanın açılıyor…"
 
 #: src/pages/ModelSettingsOverlay.tsx:646
-#: src/pages/Onboarding.tsx:446
+#: src/pages/Onboarding.tsx:520
 msgid "Optional"
 msgstr "İsteğe bağlı"
 
@@ -2184,7 +2192,7 @@ msgstr "İsteğe bağlı üstbilgi değeri"
 msgid "Or connect an API key"
 msgstr "Veya bir API anahtarı bağla"
 
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:531
 msgid "Or paste an API key"
 msgstr "Veya bir API anahtarı yapıştır"
 
@@ -2197,7 +2205,7 @@ msgid "Organization API key"
 msgstr "Kuruluş API anahtarı"
 
 #: src/pages/ModelSettingsOverlay.tsx:470
-#: src/pages/Onboarding.tsx:315
+#: src/pages/Onboarding.tsx:392
 msgid "Other model…"
 msgstr "Başka model…"
 
@@ -2235,7 +2243,7 @@ msgid "Paste a replacement key"
 msgstr "Yeni bir anahtar yapıştır"
 
 #: src/pages/ModelSettingsOverlay.tsx:433
-#: src/pages/Onboarding.tsx:286
+#: src/pages/Onboarding.tsx:363
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "Sunucundaki OpenAI uyumlu adresi yapıştır. Gerekirse Rakazo /v1 ekler."
 
@@ -2278,6 +2286,7 @@ msgid "Private"
 msgstr "Özel"
 
 #: src/pages/MemorySettingsOverlay.tsx:216
+#: src/pages/Onboarding.tsx:250
 msgid "Provider"
 msgstr "Sağlayıcı"
 
@@ -2342,7 +2351,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:4959
 msgid "Release"
 msgstr "Bırak"
 
@@ -2355,12 +2364,12 @@ msgid "Remove"
 msgstr "Kaldır"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4489
+#: src/pages/Shell.tsx:4507
 msgid "Remove {0}"
 msgstr "{0} kaldır"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4681
 msgid "Remove mention {0}"
 msgstr "{0} bahsini kaldır"
 
@@ -2369,12 +2378,12 @@ msgid "Remove schedule"
 msgstr ""
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4660
 msgid "Remove skill {0}"
 msgstr "{0} becerisini kaldır"
 
-#: src/pages/Shell.tsx:4080
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4900
 msgid "Remove thumbs-up"
 msgstr ""
 
@@ -2382,7 +2391,7 @@ msgstr ""
 msgid "Remove webhook"
 msgstr ""
 
-#: src/pages/Shell.tsx:5232
+#: src/pages/Shell.tsx:5250
 msgid "Removed with chat, computer, and memory."
 msgstr "Sohbeti, bilgisayarı ve hafızasıyla birlikte kaldırıldı."
 
@@ -2410,11 +2419,11 @@ msgstr "API anahtarını değiştir"
 msgid "Replace key"
 msgstr "Anahtarı değiştir"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4891
 msgid "Reply"
 msgstr "Yanıtla"
 
-#: src/pages/Shell.tsx:4452
+#: src/pages/Shell.tsx:4470
 msgid "Replying to {replyName}"
 msgstr "{replyName} yanıtlanıyor"
 
@@ -2443,8 +2452,8 @@ msgstr "Parolanızı sıfırlayın"
 msgid "Resetting…"
 msgstr ""
 
-#: src/pages/Shell.tsx:2721
-#: src/pages/Shell.tsx:2752
+#: src/pages/Shell.tsx:2735
+#: src/pages/Shell.tsx:2766
 msgid "Restore"
 msgstr "Geri yükle"
 
@@ -2455,6 +2464,10 @@ msgstr ""
 #: src/App.tsx:148
 msgid "Retry now"
 msgstr "Şimdi tekrar dene"
+
+#: src/pages/Shell.tsx:2348
+msgid "Retry screen"
+msgstr ""
 
 #: src/pages/McpOAuthCallback.tsx:62
 msgid "Return to Rakazo"
@@ -2473,8 +2486,8 @@ msgid "Rotate key"
 msgstr ""
 
 #: src/pages/RoutineEditor.tsx:236
-#: src/pages/Shell.tsx:3338
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3355
+#: src/pages/Shell.tsx:3365
 msgid "Routine"
 msgstr "Rutin"
 
@@ -2491,7 +2504,7 @@ msgstr ""
 msgid "Run history"
 msgstr ""
 
-#: src/pages/Shell.tsx:3331
+#: src/pages/Shell.tsx:3348
 msgid "Run time must be in the future."
 msgstr ""
 
@@ -2549,7 +2562,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "Evet ya da hayır de veya bir cümleyle yanıtla."
 
 #: src/pages/ModelSettingsOverlay.tsx:957
-#: src/pages/Shell.tsx:2449
+#: src/pages/Shell.tsx:2463
 msgid "Search"
 msgstr "Ara"
 
@@ -2567,8 +2580,8 @@ msgstr ""
 msgid "Search providers"
 msgstr "Sağlayıcı ara"
 
-#: src/pages/Onboarding.tsx:231
-#: src/pages/Onboarding.tsx:232
+#: src/pages/Onboarding.tsx:272
+#: src/pages/Onboarding.tsx:273
 msgid "Search providers and models"
 msgstr "Sağlayıcı ve model ara"
 
@@ -2576,12 +2589,16 @@ msgstr "Sağlayıcı ve model ara"
 msgid "Searching…"
 msgstr "Aranıyor…"
 
-#: src/pages/Shell.tsx:2917
+#: src/pages/Shell.tsx:2931
 msgid "Select a bot"
 msgstr "Bir bot seç"
 
-#: src/pages/Shell.tsx:4747
-#: src/pages/Shell.tsx:4768
+#: src/pages/Onboarding.tsx:320
+msgid "Selected"
+msgstr ""
+
+#: src/pages/Shell.tsx:4765
+#: src/pages/Shell.tsx:4786
 msgid "Send"
 msgstr "Gönder"
 
@@ -2618,31 +2635,31 @@ msgstr "Sunucu adı"
 
 #: src/pages/McpServersOverlay.tsx:329
 #: src/pages/ModelSettingsOverlay.tsx:417
-#: src/pages/Onboarding.tsx:270
+#: src/pages/Onboarding.tsx:347
 msgid "Server URL"
 msgstr "Sunucu URL'si"
 
-#: src/pages/Shell.tsx:2926
+#: src/pages/Shell.tsx:2940
 msgid "Set up voice to call"
 msgstr "Arama için sesi ayarla"
 
 #: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2801
-#: src/pages/Shell.tsx:2809
-#: src/pages/Shell.tsx:3069
+#: src/pages/Shell.tsx:2815
+#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:3083
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4804
 msgid "Settings: General"
 msgstr "Ayarlar: Genel"
 
-#: src/pages/Shell.tsx:4788
+#: src/pages/Shell.tsx:4806
 msgid "Settings: Usage"
 msgstr "Ayarlar: Kullanım"
 
 #: src/pages/ModelSettingsOverlay.tsx:430
-#: src/pages/Onboarding.tsx:283
+#: src/pages/Onboarding.tsx:360
 msgid "Setup help"
 msgstr "Kurulum yardımı"
 
@@ -2651,7 +2668,11 @@ msgstr "Kurulum yardımı"
 msgid "Shared"
 msgstr "Ortak"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:264
+msgid "Show all providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show computer"
 msgstr "Bilgisayarı göster"
 
@@ -2663,7 +2684,11 @@ msgstr "Daha fazla göster"
 msgid "Show password"
 msgstr ""
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:262
+msgid "Show popular providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show settings"
 msgstr "Ayarları göster"
 
@@ -2671,7 +2696,7 @@ msgstr "Ayarları göster"
 #: src/pages/Auth.tsx:206
 #: src/pages/Auth.tsx:264
 #: src/pages/ModelSettingsOverlay.tsx:628
-#: src/pages/Onboarding.tsx:108
+#: src/pages/Onboarding.tsx:131
 msgid "Sign in"
 msgstr "Oturum aç"
 
@@ -2685,15 +2710,15 @@ msgid "Sign up"
 msgstr "Kaydol"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4550
+#: src/pages/Shell.tsx:4568
 msgid "Skill {0}"
 msgstr "Beceri: {0}"
 
-#: src/pages/Shell.tsx:4948
+#: src/pages/Shell.tsx:4966
 msgid "Skip"
 msgstr "Atla"
 
-#: src/pages/Onboarding.tsx:495
+#: src/pages/Onboarding.tsx:569
 msgid "Skip for now"
 msgstr "Şimdilik atla"
 
@@ -2702,7 +2727,7 @@ msgid "Skip or deploy key"
 msgstr "Atla veya dağıtım anahtarı kullan"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1905
+#: src/pages/Shell.tsx:1907
 msgid "Skipped {0}"
 msgstr "{0} atlandı"
 
@@ -2723,8 +2748,8 @@ msgstr "Alan varsayılanı"
 msgid "Space interrupts · Esc hangs up"
 msgstr "Boşluk keser · Esc aramayı sonlandırır"
 
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Speak"
 msgstr "Seslendir"
 
@@ -2736,8 +2761,8 @@ msgstr "Seslendir + yazıya dök"
 msgid "Speak only"
 msgstr "Yalnızca seslendir"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Speak this reply"
 msgstr "Bu yanıtı seslendir"
 
@@ -2755,7 +2780,7 @@ msgstr "Başlıyor"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
 #: src/pages/ModelSettingsOverlay.tsx:626
-#: src/pages/Onboarding.tsx:431
+#: src/pages/Onboarding.tsx:505
 msgid "Starting…"
 msgstr "Başlatılıyor…"
 
@@ -2763,20 +2788,20 @@ msgstr "Başlatılıyor…"
 msgid "Steps"
 msgstr "Adımlar"
 
-#: src/pages/Shell.tsx:3755
-#: src/pages/Shell.tsx:3760
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:3772
+#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Stop"
 msgstr "Durdur"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Stop dictation"
 msgstr "Dikteyi durdur"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Stop speaking"
 msgstr "Seslendirmeyi durdur"
 
@@ -2794,13 +2819,13 @@ msgstr "Durduruldu."
 msgid "Stored encrypted"
 msgstr "Şifreli saklanıyor"
 
-#: src/pages/Shell.tsx:5186
+#: src/pages/Shell.tsx:5204
 msgid "subagent"
 msgstr "alt ajan"
 
 #: src/components/AskCard.tsx:140
 #: src/pages/ModelSettingsOverlay.tsx:586
-#: src/pages/Onboarding.tsx:398
+#: src/pages/Onboarding.tsx:472
 msgid "Submit"
 msgstr "Gönder"
 
@@ -2821,7 +2846,7 @@ msgstr "Sistem"
 msgid "Teach a task"
 msgstr "Görev öğret"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3005
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "Öğretme sürüyor — yeni mesaj göndermeden önce öğretmeyi durdur."
 
@@ -2829,7 +2854,7 @@ msgstr "Öğretme sürüyor — yeni mesaj göndermeden önce öğretmeyi durdur
 msgid "Team"
 msgstr "Takım"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "Team Computer"
 msgstr "Takım Bilgisayarı"
 
@@ -2857,11 +2882,11 @@ msgstr "Seçilen hafıza sağlayıcısı bu sürümde kullanılamıyor."
 msgid "Thinking"
 msgstr "Düşünüyor"
 
-#: src/pages/Shell.tsx:3123
+#: src/pages/Shell.tsx:3137
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "Bu bot bir Linux masaüstünde değil, bu bilgisayarda çalışır. Kabuk ve dosyalar senin kullanıcı klasörünü kullanır."
 
-#: src/pages/Shell.tsx:3811
+#: src/pages/Shell.tsx:3828
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "Bu bot bu bilgisayarda çalışır. Ayrı bir Linux masaüstü yoktur. Kabuğu kullanmasını isteyebilirsin; kullanıcı klasörünün altındaki çalışma dizinlerine izin verilir."
 
@@ -2898,7 +2923,7 @@ msgstr "Bu Mac kabuk komutlarını senin hesabınla çalıştırır; kullanıcı
 msgid "This permanently removes every message and stops current work. The chat remains available."
 msgstr ""
 
-#: src/pages/Onboarding.tsx:471
+#: src/pages/Onboarding.tsx:545
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "Bu sağlayıcı için buraya anahtar yapıştırılamaz. Bu dağıtımda kimlik bilgileri zaten varsa atla."
 
@@ -2930,7 +2955,7 @@ msgstr "Bu abonelik girişi Rakazo'da henüz kullanılamıyor. Bir dağıtım ki
 msgid "Time of day"
 msgstr "Günün saati"
 
-#: src/pages/Onboarding.tsx:520
+#: src/pages/Onboarding.tsx:594
 #: src/pages/shell/bot-panel.tsx:133
 #: src/pages/shell/bot-panel.tsx:298
 msgid "Title"
@@ -2965,7 +2990,7 @@ msgid "Unpin"
 msgstr "Sabitlemeyi kaldır"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1978
 msgid "Unsupported file type: {0}"
 msgstr "Desteklenmeyen dosya türü: {0}"
 
@@ -3005,7 +3030,7 @@ msgid "Updating…"
 msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:206
-#: src/pages/Shell.tsx:2852
+#: src/pages/Shell.tsx:2866
 msgid "Usage"
 msgstr "Kullanım"
 
@@ -3014,7 +3039,7 @@ msgid "Use {hostLabel}"
 msgstr "{hostLabel} kullan"
 
 #: src/pages/ModelSettingsOverlay.tsx:495
-#: src/pages/Onboarding.tsx:334
+#: src/pages/Onboarding.tsx:411
 msgid "Use a found model"
 msgstr "Bulunan bir modeli kullan"
 
@@ -3030,7 +3055,7 @@ msgstr "Doğrula ve ekle"
 msgid "Verifying…"
 msgstr "Doğrulanıyor…"
 
-#: src/pages/Shell.tsx:2842
+#: src/pages/Shell.tsx:2856
 #: src/pages/shell/bot-panel.tsx:418
 #: src/pages/VoiceSettingsOverlay.tsx:145
 #: src/pages/VoiceSettingsOverlay.tsx:288
@@ -3039,8 +3064,8 @@ msgstr "Ses"
 
 #: src/pages/ModelSettingsOverlay.tsx:590
 #: src/pages/ModelSettingsOverlay.tsx:612
-#: src/pages/Onboarding.tsx:402
-#: src/pages/Onboarding.tsx:424
+#: src/pages/Onboarding.tsx:476
+#: src/pages/Onboarding.tsx:498
 msgid "Waiting for sign-in…"
 msgstr "Oturum açma bekleniyor…"
 
@@ -3074,7 +3099,7 @@ msgstr "Hangi sonucu göstereceksin?"
 msgid "What should this routine do each time it runs?"
 msgstr ""
 
-#: src/pages/Onboarding.tsx:538
+#: src/pages/Onboarding.tsx:612
 #: src/pages/shell/bot-panel.tsx:150
 msgid "What this bot is for"
 msgstr "Bu botun amacı"
@@ -3103,13 +3128,13 @@ msgstr "Botlar nerede çalışsın?"
 #: src/pages/Auth.tsx:185
 #: src/pages/Auth.tsx:293
 #: src/pages/CallView.tsx:251
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Working…"
 msgstr "Çalışıyor…"
 
-#: src/pages/Shell.tsx:1679
-#: src/pages/Shell.tsx:2339
+#: src/pages/Shell.tsx:1681
+#: src/pages/Shell.tsx:2353
 msgid "You"
 msgstr "Sen"
 
@@ -3121,7 +3146,7 @@ msgstr "Otomatik yönlendirilmezsen bu sekmeyi kapatabilirsin."
 msgid "You can close this window."
 msgstr "Bu pencereyi kapatabilirsin."
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3762
 msgid "You have control"
 msgstr "Kontrol sende"
 

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/Shell.tsx:2625
+#: src/pages/Shell.tsx:2639
 msgid " (unread)"
 msgstr "（未读）"
 
@@ -31,12 +31,12 @@ msgid "{0, plural, one {# model} other {# models}}"
 msgstr "{0, plural, one {# 个模型} other {# 个模型}}"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1885
+#: src/pages/Shell.tsx:1887
 msgid "{0} (max {ATTACHMENT_MAX_COUNT} attachments)"
 msgstr "{0}（最多 {ATTACHMENT_MAX_COUNT} 个附件）"
 
 #. placeholder {0}: file.name
-#: src/pages/Shell.tsx:1889
+#: src/pages/Shell.tsx:1891
 msgid "{0} (over 10 MiB)"
 msgstr "{0}（超过 10 MiB）"
 
@@ -63,16 +63,16 @@ msgstr "{0} MB"
 #. placeholder {0}: usage.runs
 #. placeholder {1}: usage.inputTokens + usage.outputTokens
 #: src/pages/AccountSettingsOverlay.tsx:210
-#: src/pages/Shell.tsx:2856
+#: src/pages/Shell.tsx:2870
 msgid "{0} runs · {1} tokens"
 msgstr "{0} 次运行 · {1} tokens"
 
 #. placeholder {0}: active.name
-#: src/pages/Shell.tsx:3164
+#: src/pages/Shell.tsx:3181
 msgid "{0}'s screen"
 msgstr ""
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "{botName}’s computer"
 msgstr "{botName} 的电脑"
 
@@ -116,12 +116,12 @@ msgstr "{size} B"
 msgid "{title}, {label}"
 msgstr "{title}，{label}"
 
-#: src/pages/Shell.tsx:3919
+#: src/pages/Shell.tsx:3937
 msgid "{workingBotName} is working"
 msgstr "{workingBotName} 正在工作"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4517
+#: src/pages/Shell.tsx:4535
 msgid "@{0}"
 msgstr "@{0}"
 
@@ -158,8 +158,8 @@ msgstr "当前模型"
 msgid "Active voice"
 msgstr "当前语音"
 
-#: src/pages/Shell.tsx:2374
-#: src/pages/Shell.tsx:2376
+#: src/pages/Shell.tsx:2388
+#: src/pages/Shell.tsx:2390
 msgid "Activity"
 msgstr "动态"
 
@@ -173,7 +173,7 @@ msgstr "添加"
 msgid "Add a model in Settings to use this."
 msgstr "请在设置中添加模型后再使用。"
 
-#: src/pages/Shell.tsx:3326
+#: src/pages/Shell.tsx:3343
 msgid "Add a run time for this one-shot."
 msgstr "为此一次性任务添加运行时间。"
 
@@ -181,7 +181,7 @@ msgstr "为此一次性任务添加运行时间。"
 msgid "Add a schedule or webhook to run this routine."
 msgstr "添加计划或 Webhook 以运行此例行任务。"
 
-#: src/pages/Shell.tsx:3298
+#: src/pages/Shell.tsx:3315
 msgid "Add a schedule or webhook trigger"
 msgstr "添加计划或 Webhook 触发器"
 
@@ -218,7 +218,7 @@ msgstr "添加远程 MCP 服务器"
 msgid "Add server"
 msgstr "添加服务器"
 
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4900
 msgid "Add thumbs-up"
 msgstr "点赞"
 
@@ -252,7 +252,7 @@ msgstr "高级"
 msgid "Advanced..."
 msgstr "高级..."
 
-#: src/pages/Shell.tsx:2944
+#: src/pages/Shell.tsx:2958
 msgid "Agent computer"
 msgstr "Agent 电脑"
 
@@ -261,7 +261,7 @@ msgid "Agent connections"
 msgstr "Agent 连接"
 
 #: src/pages/McpServersOverlay.tsx:385
-#: src/pages/McpServersOverlay.tsx:448
+#: src/pages/McpServersOverlay.tsx:452
 msgid "Agents:"
 msgstr "Agent："
 
@@ -333,9 +333,9 @@ msgstr "API 已恢复，但更新未完成。请查看宿主日志。"
 #: src/pages/ModelSettingsOverlay.tsx:640
 #: src/pages/ModelSettingsOverlay.tsx:643
 #: src/pages/ModelSettingsOverlay.tsx:662
-#: src/pages/Onboarding.tsx:440
-#: src/pages/Onboarding.tsx:443
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:514
+#: src/pages/Onboarding.tsx:517
+#: src/pages/Onboarding.tsx:531
 #: src/pages/VoiceSettingsOverlay.tsx:258
 msgid "API key"
 msgstr "API 密钥"
@@ -367,15 +367,15 @@ msgstr "批准此服务器后，Agent 才能使用它的工具。"
 msgid "Archive"
 msgstr "归档"
 
-#: src/pages/Shell.tsx:5220
+#: src/pages/Shell.tsx:5238
 msgid "archived"
 msgstr "已归档"
 
-#: src/pages/Shell.tsx:2694
+#: src/pages/Shell.tsx:2708
 msgid "Archived"
 msgstr "已归档"
 
-#: src/pages/Shell.tsx:5231
+#: src/pages/Shell.tsx:5249
 msgid "Archived. Chat, memory, and files kept."
 msgstr "已归档。对话、记忆和文件保留。"
 
@@ -425,16 +425,16 @@ msgstr "{0}"
 msgid "at {timeSelect}"
 msgstr "{timeSelect}"
 
-#: src/pages/Shell.tsx:4597
+#: src/pages/Shell.tsx:4615
 msgid "Attach file"
 msgstr "附加文件"
 
-#: src/pages/Shell.tsx:4841
+#: src/pages/Shell.tsx:4859
 msgid "Attachment"
 msgstr "附件"
 
 #: src/pages/ModelSettingsOverlay.tsx:573
-#: src/pages/Onboarding.tsx:389
+#: src/pages/Onboarding.tsx:463
 msgid "Authorization code or callback URL"
 msgstr "授权码或回调 URL"
 
@@ -474,23 +474,19 @@ msgstr "Base URL"
 msgid "Bearer token"
 msgstr "Bearer token"
 
-#: src/pages/Shell.tsx:5428
+#: src/pages/Shell.tsx:5446
 msgid "Booting live desktop…"
 msgstr "正在启动实时桌面…"
 
 #. placeholder {0}: active?.name
-#: src/pages/Shell.tsx:3712
+#: src/pages/Shell.tsx:3729
 msgid "Booting up {0}’s computer"
 msgstr "正在启动 {0} 的电脑"
 
-#: src/pages/Shell.tsx:5080
-#: src/pages/Shell.tsx:5081
-#: src/pages/Shell.tsx:5224
+#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5099
+#: src/pages/Shell.tsx:5242
 msgid "bot"
-msgstr "Bot"
-
-#: src/pages/Shell.tsx:1680
-msgid "Bot"
 msgstr "Bot"
 
 #. js-lingui-explicit-id
@@ -498,11 +494,15 @@ msgstr "Bot"
 msgid "Bot"
 msgstr "Bot"
 
-#: src/pages/Shell.tsx:3819
+#: src/pages/Shell.tsx:1682
+msgid "Bot"
+msgstr "Bot"
+
+#: src/pages/Shell.tsx:3836
 msgid "Bot screen"
 msgstr "Bot 屏幕"
 
-#: src/pages/Shell.tsx:3130
+#: src/pages/Shell.tsx:3144
 msgid "Bot screen preview"
 msgstr "Bot 屏幕预览"
 
@@ -514,7 +514,7 @@ msgstr "要关联的 Bot"
 msgid "Bots act without asking by default. Add an exception only when you want to review a type of action first. These preferences apply across all your bots."
 msgstr "默认情况下 Bot 会直接执行。只有当你想先审核某类操作时，才添加例外。这些偏好会应用到所有 Bot。"
 
-#: src/pages/Shell.tsx:3920
+#: src/pages/Shell.tsx:3938
 msgid "Bots are working"
 msgstr "Bot 正在工作"
 
@@ -523,8 +523,8 @@ msgid "Bring your own key. The provider is swappable; your bots keep the same sp
 msgstr "使用你自己的密钥。提供方可更换，Bot 的朗读和通话按钮不变。"
 
 #: src/pages/CallView.tsx:241
-#: src/pages/Shell.tsx:2926
-#: src/pages/Shell.tsx:2927
+#: src/pages/Shell.tsx:2940
+#: src/pages/Shell.tsx:2941
 msgid "Call"
 msgstr "通话"
 
@@ -553,7 +553,7 @@ msgstr "取消新建 Bot"
 msgid "Cancel new group"
 msgstr "取消新建群组"
 
-#: src/pages/Shell.tsx:4455
+#: src/pages/Shell.tsx:4473
 msgid "Cancel reply"
 msgstr "取消回复"
 
@@ -586,7 +586,7 @@ msgstr "聊天应用"
 msgid "Chat apps, group channels, and agent connections."
 msgstr "聊天应用、群组频道和 Agent 连接。"
 
-#: src/pages/Shell.tsx:4784
+#: src/pages/Shell.tsx:4802
 msgid "Chat Settings"
 msgstr "聊天设置"
 
@@ -598,8 +598,8 @@ msgstr "检查失败"
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: src/pages/Shell.tsx:3339
-#: src/pages/Shell.tsx:3349
+#: src/pages/Shell.tsx:3356
+#: src/pages/Shell.tsx:3366
 msgid "Check in."
 msgstr "报到。"
 
@@ -618,10 +618,6 @@ msgstr "工作副本有本地更改。请先清理再更新。"
 #: src/pages/MessagingSettingsOverlay.tsx:152
 msgid "Choose a bot…"
 msgstr "选择 Bot…"
-
-#: src/pages/Onboarding.tsx:226
-msgid "Choose a model to get started."
-msgstr "选择一个模型开始。"
 
 #: src/pages/Auth.tsx:257
 msgid "Choose a new password"
@@ -661,7 +657,7 @@ msgstr "关闭"
 msgid "Close chart"
 msgstr "关闭图表"
 
-#: src/pages/Shell.tsx:3793
+#: src/pages/Shell.tsx:3810
 msgid "Close computer"
 msgstr "关闭电脑"
 
@@ -689,11 +685,11 @@ msgstr "关闭消息设置"
 msgid "Close model settings"
 msgstr "关闭模型设置"
 
-#: src/pages/Shell.tsx:2359
+#: src/pages/Shell.tsx:2373
 msgid "Close navigation"
 msgstr "关闭导航"
 
-#: src/pages/Shell.tsx:3103
+#: src/pages/Shell.tsx:3117
 msgid "Close panel"
 msgstr "关闭面板"
 
@@ -719,7 +715,7 @@ msgid "Code"
 msgstr "代码"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2495
+#: src/pages/Shell.tsx:2509
 msgid "Collapse {0}"
 msgstr "折叠 {0}"
 
@@ -735,24 +731,24 @@ msgstr "命令"
 msgid "Complete"
 msgstr "完成"
 
-#: src/pages/Shell.tsx:5378
+#: src/pages/Shell.tsx:5396
 #: src/pages/shell/bot-panel.tsx:47
 msgid "Computer"
 msgstr "电脑"
 
-#: src/pages/Shell.tsx:5431
+#: src/pages/Shell.tsx:5449
 msgid "Computer failed to boot"
 msgstr "电脑启动失败"
 
-#: src/pages/Shell.tsx:3841
+#: src/pages/Shell.tsx:3859
 msgid "Computer is asleep"
 msgstr "电脑已休眠"
 
-#: src/pages/Shell.tsx:5430
+#: src/pages/Shell.tsx:5448
 msgid "Computer is asleep. Open it to wake."
 msgstr ""
 
-#: src/pages/Shell.tsx:5432
+#: src/pages/Shell.tsx:5450
 msgid "Computer is stopped"
 msgstr "电脑已停止"
 
@@ -772,7 +768,7 @@ msgstr "由部署配置"
 msgid "Configured servers"
 msgstr "已配置的服务器"
 
-#: src/pages/McpServersOverlay.tsx:502
+#: src/pages/McpServersOverlay.tsx:506
 msgid "Confirm delete"
 msgstr "确认删除"
 
@@ -786,7 +782,7 @@ msgstr "确认密码"
 msgid "Connect"
 msgstr "连接"
 
-#: src/pages/Onboarding.tsx:223
+#: src/pages/Onboarding.tsx:246
 msgid "Connect a model"
 msgstr "连接模型"
 
@@ -857,8 +853,8 @@ msgstr "正在连接…"
 msgid "Connection to {0} is still pending. You can close this and check again."
 msgstr "与 {0} 的连接仍在等待。可以关闭此窗口稍后再看。"
 
-#: src/pages/Onboarding.tsx:484
-#: src/pages/Onboarding.tsx:545
+#: src/pages/Onboarding.tsx:558
+#: src/pages/Onboarding.tsx:619
 msgid "Continue"
 msgstr "继续"
 
@@ -866,7 +862,7 @@ msgstr "继续"
 msgid "Continue with email"
 msgstr "使用邮箱继续"
 
-#: src/pages/Shell.tsx:4894
+#: src/pages/Shell.tsx:4912
 msgid "Copy"
 msgstr "复制"
 
@@ -923,6 +919,10 @@ msgstr "无法连接此提供方"
 msgid "Could not connect this voice provider"
 msgstr "无法连接此语音提供方"
 
+#: src/pages/Shell.tsx:821
+msgid "Could not connect to the computer screen"
+msgstr ""
+
 #: src/pages/Auth.tsx:85
 msgid "Could not continue"
 msgstr "无法继续"
@@ -943,7 +943,7 @@ msgstr "无法创建分组"
 msgid "Could not create space"
 msgstr "无法创建工作区"
 
-#: src/pages/Onboarding.tsx:208
+#: src/pages/Onboarding.tsx:231
 msgid "Could not create your bot"
 msgstr "无法创建你的 Bot"
 
@@ -1027,7 +1027,7 @@ msgid "Could not reach the server"
 msgstr "无法连接服务器"
 
 #: src/pages/ModelSettingsOverlay.tsx:232
-#: src/pages/Onboarding.tsx:154
+#: src/pages/Onboarding.tsx:177
 msgid "Could not reach this model server"
 msgstr "无法访问此模型服务器"
 
@@ -1059,7 +1059,7 @@ msgstr "无法重置密码"
 msgid "Could not revoke connection"
 msgstr "无法撤销连接"
 
-#: src/pages/Shell.tsx:3401
+#: src/pages/Shell.tsx:3418
 msgid "Could not run routine"
 msgstr "无法运行例行任务"
 
@@ -1075,11 +1075,11 @@ msgstr "无法保存自动审核"
 msgid "Could not save group"
 msgstr "无法保存群组"
 
-#: src/pages/Onboarding.tsx:181
+#: src/pages/Onboarding.tsx:204
 msgid "Could not save model"
 msgstr "无法保存模型"
 
-#: src/pages/Shell.tsx:3372
+#: src/pages/Shell.tsx:3389
 msgid "Could not save routine"
 msgstr "无法保存例行任务"
 
@@ -1119,7 +1119,7 @@ msgstr ""
 msgid "Could not submit this answer"
 msgstr "无法提交此回答"
 
-#: src/pages/Shell.tsx:2205
+#: src/pages/Shell.tsx:2207
 msgid "Could not take control"
 msgstr "无法接管"
 
@@ -1135,7 +1135,7 @@ msgstr "无法更新 Agent 权限"
 msgid "Could not update computer"
 msgstr "无法更新电脑"
 
-#: src/pages/Shell.tsx:1871
+#: src/pages/Shell.tsx:1873
 msgid "Could not update reaction"
 msgstr "无法更新反应"
 
@@ -1155,7 +1155,7 @@ msgstr "无法更新头像"
 msgid "Couldn't update messaging settings"
 msgstr "无法更新消息设置"
 
-#: src/pages/Shell.tsx:2395
+#: src/pages/Shell.tsx:2409
 #: src/pages/shell/bot-panel.tsx:161
 #: src/pages/shell/dialogs.tsx:155
 msgid "Create"
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Create space"
 msgstr "创建工作区"
 
-#: src/pages/Onboarding.tsx:504
+#: src/pages/Onboarding.tsx:578
 msgid "Create your first bot"
 msgstr "创建你的第一个 Bot"
 
@@ -1254,10 +1254,10 @@ msgid "Default scope"
 msgstr "默认范围"
 
 #: src/pages/BotContextMenu.tsx:150
-#: src/pages/McpServersOverlay.tsx:504
+#: src/pages/McpServersOverlay.tsx:508
 #: src/pages/RoutineEditor.tsx:272
-#: src/pages/Shell.tsx:2730
-#: src/pages/Shell.tsx:2761
+#: src/pages/Shell.tsx:2744
+#: src/pages/Shell.tsx:2775
 #: src/pages/shell/dialogs.tsx:298
 #: src/pages/shell/dialogs.tsx:355
 msgid "Delete"
@@ -1265,8 +1265,8 @@ msgstr "删除"
 
 #. placeholder {0}: bot.name
 #. placeholder {0}: group.name
-#: src/pages/Shell.tsx:2727
-#: src/pages/Shell.tsx:2758
+#: src/pages/Shell.tsx:2741
+#: src/pages/Shell.tsx:2772
 msgid "Delete {0}"
 msgstr "删除 {0}"
 
@@ -1285,7 +1285,7 @@ msgstr "删除群组"
 msgid "Delete memories too"
 msgstr "同时删除记忆"
 
-#: src/pages/Shell.tsx:5222
+#: src/pages/Shell.tsx:5240
 msgid "deleted"
 msgstr "已删除"
 
@@ -1307,22 +1307,22 @@ msgstr "拒绝"
 msgid "Deployment default"
 msgstr "部署默认"
 
-#: src/pages/Onboarding.tsx:525
+#: src/pages/Onboarding.tsx:599
 #: src/pages/shell/bot-panel.tsx:139
 msgid "Describe what this bot does"
 msgstr "描述这个 Bot 做什么"
 
-#: src/pages/Onboarding.tsx:533
+#: src/pages/Onboarding.tsx:607
 #: src/pages/shell/bot-panel.tsx:144
 #: src/pages/shell/bot-panel.tsx:308
 msgid "Description"
 msgstr "描述"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Dictate"
 msgstr "口述"
 
-#: src/pages/McpServersOverlay.tsx:489
+#: src/pages/McpServersOverlay.tsx:493
 #: src/pages/MemorySettingsOverlay.tsx:207
 msgid "Disconnect"
 msgstr "断开"
@@ -1335,7 +1335,7 @@ msgstr "正在断开…"
 msgid "Dismiss"
 msgstr ""
 
-#: src/pages/Shell.tsx:4435
+#: src/pages/Shell.tsx:4453
 msgid "Dismiss error"
 msgstr "关闭错误"
 
@@ -1365,8 +1365,8 @@ msgid "Don’t have an account?"
 msgstr "还没有账户？"
 
 #: src/pages/ActivityList.tsx:157
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Done"
 msgstr "完成"
 
@@ -1389,7 +1389,7 @@ msgstr "技能草稿"
 msgid "Duplicate"
 msgstr "复制"
 
-#: src/pages/Shell.tsx:5021
+#: src/pages/Shell.tsx:5039
 msgid "Earlier message"
 msgstr "更早的消息"
 
@@ -1407,7 +1407,7 @@ msgstr "邮箱"
 
 #. placeholder {0}: oauth.verificationUri.replace(/^https:\/\//, "")
 #: src/pages/ModelSettingsOverlay.tsx:596
-#: src/pages/Onboarding.tsx:408
+#: src/pages/Onboarding.tsx:482
 msgid "Enter this code at <0>{0}</0>"
 msgstr "在 <0>{0}</0> 输入此代码"
 
@@ -1450,7 +1450,7 @@ msgid "Expand"
 msgstr "展开"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2494
+#: src/pages/Shell.tsx:2508
 msgid "Expand {0}"
 msgstr "展开 {0}"
 
@@ -1470,14 +1470,14 @@ msgstr "极高"
 msgid "Failed"
 msgstr "失败"
 
-#: src/pages/Shell.tsx:2023
 #: src/pages/Shell.tsx:2025
 #: src/pages/Shell.tsx:2027
+#: src/pages/Shell.tsx:2029
 msgid "Failed to send message"
 msgstr "发送消息失败"
 
-#: src/pages/Shell.tsx:2060
-#: src/pages/Shell.tsx:2079
+#: src/pages/Shell.tsx:2062
+#: src/pages/Shell.tsx:2081
 msgid "Failed to stop"
 msgstr "停止失败"
 
@@ -1491,18 +1491,18 @@ msgid "Failure handling"
 msgstr "失败处理"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Find models"
 msgstr "查找模型"
 
 #: src/pages/ModelSettingsOverlay.tsx:444
-#: src/pages/Onboarding.tsx:295
+#: src/pages/Onboarding.tsx:372
 msgid "Finding…"
 msgstr "正在查找…"
 
 #. placeholder {0}: new URL(oauth.verificationUri).hostname
 #: src/pages/ModelSettingsOverlay.tsx:556
-#: src/pages/Onboarding.tsx:372
+#: src/pages/Onboarding.tsx:446
 msgid "Finish signing in at <0>{0}</0>. The final page may not load; paste its URL or code here."
 msgstr "在 <0>{0}</0> 完成登录。最后一页可能无法加载；把 URL 或代码粘贴到这里。"
 
@@ -1536,8 +1536,8 @@ msgid "Git event"
 msgstr "Git 事件"
 
 #: src/pages/MessagingSettingsOverlay.tsx:198
-#: src/pages/Shell.tsx:2916
-#: src/pages/Shell.tsx:3073
+#: src/pages/Shell.tsx:2930
+#: src/pages/Shell.tsx:3087
 msgid "Group"
 msgstr "群组"
 
@@ -1587,11 +1587,11 @@ msgstr "隐藏密码"
 msgid "High"
 msgstr "高"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk"
 msgstr "按住说话"
 
-#: src/pages/Shell.tsx:4626
+#: src/pages/Shell.tsx:4644
 msgid "Hold to talk (on-device dictation)"
 msgstr "按住说话（设备端口述）"
 
@@ -1611,7 +1611,7 @@ msgstr "频率"
 msgid "How to check"
 msgstr "如何检查"
 
-#: src/pages/Shell.tsx:4951
+#: src/pages/Shell.tsx:4969
 msgid "I’m done"
 msgstr "我做完了"
 
@@ -1640,7 +1640,7 @@ msgid "Instruction"
 msgstr "指令"
 
 #: src/pages/PluginsOverlay.tsx:247
-#: src/pages/Shell.tsx:2779
+#: src/pages/Shell.tsx:2793
 msgid "Integrations"
 msgstr "集成"
 
@@ -1670,11 +1670,11 @@ msgstr "隔离"
 msgid "Its conversation, files, and routines will be permanently deleted. Bots it created stay in your list."
 msgstr "它的对话、文件和例行任务将被永久删除。它创建的 Bot 仍留在列表中。"
 
-#: src/pages/Shell.tsx:4105
+#: src/pages/Shell.tsx:4123
 msgid "Jump to latest"
 msgstr "跳到最新"
 
-#: src/pages/Shell.tsx:5016
+#: src/pages/Shell.tsx:5034
 msgid "Jump to replied message"
 msgstr "跳到被回复的消息"
 
@@ -1720,7 +1720,7 @@ msgstr "关联聊天应用"
 msgid "Listening…"
 msgstr "正在听…"
 
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Load earlier messages"
 msgstr "加载更早的消息"
 
@@ -1754,9 +1754,9 @@ msgid "Loading voice providers…"
 msgstr "正在加载语音提供方…"
 
 #: src/App.tsx:54
-#: src/pages/Onboarding.tsx:217
+#: src/pages/Onboarding.tsx:240
 #: src/pages/PeerMessagesOverlay.tsx:99
-#: src/pages/Shell.tsx:4035
+#: src/pages/Shell.tsx:4053
 msgid "Loading…"
 msgstr "加载中…"
 
@@ -1764,7 +1764,7 @@ msgstr "加载中…"
 msgid "Local"
 msgstr "本地"
 
-#: src/pages/Shell.tsx:2872
+#: src/pages/Shell.tsx:2886
 msgid "Log out"
 msgstr "退出登录"
 
@@ -1810,7 +1810,7 @@ msgid "Members (pick {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX})"
 msgstr "成员（选择 {GROUP_MEMBER_MIN}–{GROUP_MEMBER_MAX} 个）"
 
 #: src/pages/MemorySettingsOverlay.tsx:157
-#: src/pages/Shell.tsx:2831
+#: src/pages/Shell.tsx:2845
 msgid "Memory"
 msgstr "记忆"
 
@@ -1818,38 +1818,38 @@ msgstr "记忆"
 msgid "Memory scope"
 msgstr "记忆范围"
 
-#: src/pages/Shell.tsx:4503
+#: src/pages/Shell.tsx:4521
 msgid "Mentions"
 msgstr "提及"
-
-#: src/pages/Shell.tsx:4729
-#: src/pages/Shell.tsx:4843
-msgid "Message"
-msgstr "消息"
 
 #. js-lingui-explicit-id
 #: src/lib/browser-notifications.ts:83
 msgid "Message"
 msgstr "消息"
 
-#: src/pages/Shell.tsx:4725
-#: src/pages/Shell.tsx:4729
+#: src/pages/Shell.tsx:4747
+#: src/pages/Shell.tsx:4861
+msgid "Message"
+msgstr "消息"
+
+#: src/pages/Shell.tsx:4743
+#: src/pages/Shell.tsx:4747
 msgid "Message {activeName}"
 msgstr "给 {activeName} 发消息"
 
-#: src/pages/Shell.tsx:4415
+#: src/pages/Shell.tsx:4433
 msgid "Message composer"
 msgstr "消息输入框"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Message from {peer}"
 msgstr "来自 {peer} 的消息"
 
-#: src/pages/Shell.tsx:4726
+#: src/pages/Shell.tsx:4744
 msgid "Message…"
 msgstr "消息…"
 
-#: src/pages/Shell.tsx:5098
+#: src/pages/Shell.tsx:5116
 msgid "Messaged {peer}"
 msgstr "已发给 {peer}"
 
@@ -1881,21 +1881,25 @@ msgstr "分钟"
 #: src/pages/ModelSettingsOverlay.tsx:449
 #: src/pages/ModelSettingsOverlay.tsx:503
 #: src/pages/ModelSettingsOverlay.tsx:932
-#: src/pages/Onboarding.tsx:300
-#: src/pages/Onboarding.tsx:342
-#: src/pages/Onboarding.tsx:350
+#: src/pages/Onboarding.tsx:377
+#: src/pages/Onboarding.tsx:419
+#: src/pages/Onboarding.tsx:427
 #: src/pages/shell/bot-panel.tsx:332
 msgid "Model"
 msgstr "模型"
 
 #: src/pages/ModelSettingsOverlay.tsx:483
-#: src/pages/Onboarding.tsx:322
+#: src/pages/Onboarding.tsx:399
 msgid "Model id"
 msgstr "模型 ID"
 
 #: src/pages/ModelSettingsOverlay.tsx:968
 msgid "Model options"
 msgstr "模型选项"
+
+#: src/pages/Onboarding.tsx:278
+msgid "Model providers"
+msgstr ""
 
 #: src/pages/AccountSettingsOverlay.tsx:216
 msgid "Model spend uses your provider keys."
@@ -1906,12 +1910,12 @@ msgid "Model updated."
 msgstr "模型已更新。"
 
 #: src/pages/ModelSettingsOverlay.tsx:323
-#: src/pages/Shell.tsx:2820
+#: src/pages/Shell.tsx:2834
 msgid "Models"
 msgstr "模型"
 
 #: src/pages/ModelSettingsOverlay.tsx:462
-#: src/pages/Onboarding.tsx:306
+#: src/pages/Onboarding.tsx:383
 msgid "Models from server"
 msgstr "来自服务器的模型"
 
@@ -1940,7 +1944,7 @@ msgstr "移动到"
 #: src/pages/Auth.tsx:110
 #: src/pages/GroupPanel.tsx:119
 #: src/pages/GroupPanel.tsx:212
-#: src/pages/Onboarding.tsx:507
+#: src/pages/Onboarding.tsx:581
 #: src/pages/RoutineEditor.tsx:281
 #: src/pages/shell/bot-panel.tsx:122
 #: src/pages/shell/bot-panel.tsx:288
@@ -1949,7 +1953,7 @@ msgstr "移动到"
 msgid "Name"
 msgstr "名称"
 
-#: src/pages/Onboarding.tsx:512
+#: src/pages/Onboarding.tsx:586
 #: src/pages/shell/bot-panel.tsx:128
 msgid "Name this bot"
 msgstr "给这个 Bot 命名"
@@ -1970,13 +1974,13 @@ msgstr "需要输入"
 msgid "Needs takeover"
 msgstr "需要接管"
 
-#: src/pages/Shell.tsx:2413
+#: src/pages/Shell.tsx:2427
 #: src/pages/shell/bot-panel.tsx:106
 msgid "New bot"
 msgstr "新建 Bot"
 
 #: src/pages/GroupPanel.tsx:101
-#: src/pages/Shell.tsx:2423
+#: src/pages/Shell.tsx:2437
 msgid "New group"
 msgstr "新建群组"
 
@@ -1994,7 +1998,7 @@ msgstr "新密码"
 msgid "New section"
 msgstr "新建分组"
 
-#: src/pages/Shell.tsx:2435
+#: src/pages/Shell.tsx:2449
 #: src/pages/shell/dialogs.tsx:68
 msgid "New space"
 msgstr "新建工作区"
@@ -2059,6 +2063,10 @@ msgstr "还没有与 {peerBotName} 的消息。"
 #: src/pages/ModelSettingsOverlay.tsx:733
 msgid "No model catalog is available."
 msgstr "没有可用的模型目录。"
+
+#: src/pages/Onboarding.tsx:339
+msgid "No providers found"
+msgstr ""
 
 #: src/pages/ModelSettingsOverlay.tsx:402
 msgid "No providers found."
@@ -2132,21 +2140,21 @@ msgid "on the 1st at {0}"
 msgstr "每月 1 日 {0}"
 
 #: src/pages/ScratchpadSection.tsx:159
-#: src/pages/Shell.tsx:3154
-#: src/pages/Shell.tsx:3159
+#: src/pages/Shell.tsx:3170
+#: src/pages/Shell.tsx:3175
 msgid "Open"
 msgstr "打开"
 
 #. placeholder {0}: group.title
-#: src/pages/Shell.tsx:2492
+#: src/pages/Shell.tsx:2506
 msgid "Open {0}"
 msgstr "打开 {0}"
 
-#: src/pages/Shell.tsx:3119
+#: src/pages/Shell.tsx:3133
 msgid "Open in full window"
 msgstr "在完整窗口中打开"
 
-#: src/pages/Shell.tsx:2888
+#: src/pages/Shell.tsx:2902
 msgid "Open navigation"
 msgstr "打开导航"
 
@@ -2155,11 +2163,11 @@ msgid "Open work"
 msgstr "待办"
 
 #: src/pages/ModelSettingsOverlay.tsx:422
-#: src/pages/Onboarding.tsx:275
+#: src/pages/Onboarding.tsx:352
 msgid "OpenAI-compatible server URL"
 msgstr "OpenAI 兼容服务器 URL"
 
-#: src/pages/Shell.tsx:5233
+#: src/pages/Shell.tsx:5251
 msgid "Opened its thread."
 msgstr "已打开其对话。"
 
@@ -2168,7 +2176,7 @@ msgid "Opening your Space…"
 msgstr "正在打开工作区…"
 
 #: src/pages/ModelSettingsOverlay.tsx:646
-#: src/pages/Onboarding.tsx:446
+#: src/pages/Onboarding.tsx:520
 msgid "Optional"
 msgstr "可选"
 
@@ -2184,7 +2192,7 @@ msgstr "可选请求头值"
 msgid "Or connect an API key"
 msgstr "或连接 API 密钥"
 
-#: src/pages/Onboarding.tsx:457
+#: src/pages/Onboarding.tsx:531
 msgid "Or paste an API key"
 msgstr "或粘贴 API 密钥"
 
@@ -2197,7 +2205,7 @@ msgid "Organization API key"
 msgstr "组织 API 密钥"
 
 #: src/pages/ModelSettingsOverlay.tsx:470
-#: src/pages/Onboarding.tsx:315
+#: src/pages/Onboarding.tsx:392
 msgid "Other model…"
 msgstr "其他模型…"
 
@@ -2235,7 +2243,7 @@ msgid "Paste a replacement key"
 msgstr "粘贴替换密钥"
 
 #: src/pages/ModelSettingsOverlay.tsx:433
-#: src/pages/Onboarding.tsx:286
+#: src/pages/Onboarding.tsx:363
 msgid "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed."
 msgstr "粘贴服务器的 OpenAI 兼容地址。需要时 Rakazo 会补上 /v1。"
 
@@ -2278,6 +2286,7 @@ msgid "Private"
 msgstr "私有"
 
 #: src/pages/MemorySettingsOverlay.tsx:216
+#: src/pages/Onboarding.tsx:250
 msgid "Provider"
 msgstr "提供方"
 
@@ -2342,7 +2351,7 @@ msgstr ""
 msgid "Refreshing…"
 msgstr ""
 
-#: src/pages/Shell.tsx:4941
+#: src/pages/Shell.tsx:4959
 msgid "Release"
 msgstr "释放"
 
@@ -2355,12 +2364,12 @@ msgid "Remove"
 msgstr "移除"
 
 #. placeholder {0}: attachment.file.name
-#: src/pages/Shell.tsx:4489
+#: src/pages/Shell.tsx:4507
 msgid "Remove {0}"
 msgstr "移除 {0}"
 
 #. placeholder {0}: mention.name
-#: src/pages/Shell.tsx:4663
+#: src/pages/Shell.tsx:4681
 msgid "Remove mention {0}"
 msgstr "移除提及 {0}"
 
@@ -2369,12 +2378,12 @@ msgid "Remove schedule"
 msgstr "移除计划"
 
 #. placeholder {0}: selectedSkill.name
-#: src/pages/Shell.tsx:4642
+#: src/pages/Shell.tsx:4660
 msgid "Remove skill {0}"
 msgstr "移除技能 {0}"
 
-#: src/pages/Shell.tsx:4080
-#: src/pages/Shell.tsx:4882
+#: src/pages/Shell.tsx:4098
+#: src/pages/Shell.tsx:4900
 msgid "Remove thumbs-up"
 msgstr "取消点赞"
 
@@ -2382,7 +2391,7 @@ msgstr "取消点赞"
 msgid "Remove webhook"
 msgstr "移除 Webhook"
 
-#: src/pages/Shell.tsx:5232
+#: src/pages/Shell.tsx:5250
 msgid "Removed with chat, computer, and memory."
 msgstr "已连同对话、电脑和记忆一起移除。"
 
@@ -2410,11 +2419,11 @@ msgstr "替换 API 密钥"
 msgid "Replace key"
 msgstr "替换密钥"
 
-#: src/pages/Shell.tsx:4873
+#: src/pages/Shell.tsx:4891
 msgid "Reply"
 msgstr "回复"
 
-#: src/pages/Shell.tsx:4452
+#: src/pages/Shell.tsx:4470
 msgid "Replying to {replyName}"
 msgstr "正在回复 {replyName}"
 
@@ -2443,8 +2452,8 @@ msgstr "重置你的密码"
 msgid "Resetting…"
 msgstr "正在重置…"
 
-#: src/pages/Shell.tsx:2721
-#: src/pages/Shell.tsx:2752
+#: src/pages/Shell.tsx:2735
+#: src/pages/Shell.tsx:2766
 msgid "Restore"
 msgstr "恢复"
 
@@ -2455,6 +2464,10 @@ msgstr "还原上次保存的工作区。电脑上未保存的工作会丢失。
 #: src/App.tsx:148
 msgid "Retry now"
 msgstr "立即重试"
+
+#: src/pages/Shell.tsx:2348
+msgid "Retry screen"
+msgstr ""
 
 #: src/pages/McpOAuthCallback.tsx:62
 msgid "Return to Rakazo"
@@ -2473,8 +2486,8 @@ msgid "Rotate key"
 msgstr "轮换密钥"
 
 #: src/pages/RoutineEditor.tsx:236
-#: src/pages/Shell.tsx:3338
-#: src/pages/Shell.tsx:3348
+#: src/pages/Shell.tsx:3355
+#: src/pages/Shell.tsx:3365
 msgid "Routine"
 msgstr "例行任务"
 
@@ -2491,7 +2504,7 @@ msgstr "运行时间"
 msgid "Run history"
 msgstr "运行记录"
 
-#: src/pages/Shell.tsx:3331
+#: src/pages/Shell.tsx:3348
 msgid "Run time must be in the future."
 msgstr "运行时间必须是将来的时间。"
 
@@ -2549,7 +2562,7 @@ msgid "Say yes or no, or answer in a sentence."
 msgstr "回答是或否，或一句话说明。"
 
 #: src/pages/ModelSettingsOverlay.tsx:957
-#: src/pages/Shell.tsx:2449
+#: src/pages/Shell.tsx:2463
 msgid "Search"
 msgstr "搜索"
 
@@ -2567,8 +2580,8 @@ msgstr "搜索模型"
 msgid "Search providers"
 msgstr "搜索提供方"
 
-#: src/pages/Onboarding.tsx:231
-#: src/pages/Onboarding.tsx:232
+#: src/pages/Onboarding.tsx:272
+#: src/pages/Onboarding.tsx:273
 msgid "Search providers and models"
 msgstr "搜索提供方和模型"
 
@@ -2576,12 +2589,16 @@ msgstr "搜索提供方和模型"
 msgid "Searching…"
 msgstr "正在搜索…"
 
-#: src/pages/Shell.tsx:2917
+#: src/pages/Shell.tsx:2931
 msgid "Select a bot"
 msgstr "选择 Bot"
 
-#: src/pages/Shell.tsx:4747
-#: src/pages/Shell.tsx:4768
+#: src/pages/Onboarding.tsx:320
+msgid "Selected"
+msgstr ""
+
+#: src/pages/Shell.tsx:4765
+#: src/pages/Shell.tsx:4786
 msgid "Send"
 msgstr "发送"
 
@@ -2618,31 +2635,31 @@ msgstr "服务器名称"
 
 #: src/pages/McpServersOverlay.tsx:329
 #: src/pages/ModelSettingsOverlay.tsx:417
-#: src/pages/Onboarding.tsx:270
+#: src/pages/Onboarding.tsx:347
 msgid "Server URL"
 msgstr "服务器 URL"
 
-#: src/pages/Shell.tsx:2926
+#: src/pages/Shell.tsx:2940
 msgid "Set up voice to call"
 msgstr "设置通话语音"
 
 #: src/pages/AccountSettingsOverlay.tsx:114
-#: src/pages/Shell.tsx:2801
-#: src/pages/Shell.tsx:2809
-#: src/pages/Shell.tsx:3069
+#: src/pages/Shell.tsx:2815
+#: src/pages/Shell.tsx:2823
+#: src/pages/Shell.tsx:3083
 msgid "Settings"
 msgstr "设置"
 
-#: src/pages/Shell.tsx:4786
+#: src/pages/Shell.tsx:4804
 msgid "Settings: General"
 msgstr "设置：通用"
 
-#: src/pages/Shell.tsx:4788
+#: src/pages/Shell.tsx:4806
 msgid "Settings: Usage"
 msgstr "设置：用量"
 
 #: src/pages/ModelSettingsOverlay.tsx:430
-#: src/pages/Onboarding.tsx:283
+#: src/pages/Onboarding.tsx:360
 msgid "Setup help"
 msgstr "设置帮助"
 
@@ -2651,7 +2668,11 @@ msgstr "设置帮助"
 msgid "Shared"
 msgstr "共享"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:264
+msgid "Show all providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show computer"
 msgstr "显示电脑"
 
@@ -2663,7 +2684,11 @@ msgstr "显示更多"
 msgid "Show password"
 msgstr "显示密码"
 
-#: src/pages/Shell.tsx:3093
+#: src/pages/Onboarding.tsx:262
+msgid "Show popular providers"
+msgstr ""
+
+#: src/pages/Shell.tsx:3107
 msgid "Show settings"
 msgstr "显示设置"
 
@@ -2671,7 +2696,7 @@ msgstr "显示设置"
 #: src/pages/Auth.tsx:206
 #: src/pages/Auth.tsx:264
 #: src/pages/ModelSettingsOverlay.tsx:628
-#: src/pages/Onboarding.tsx:108
+#: src/pages/Onboarding.tsx:131
 msgid "Sign in"
 msgstr "登录"
 
@@ -2685,15 +2710,15 @@ msgid "Sign up"
 msgstr "注册"
 
 #. placeholder {0}: skill.name
-#: src/pages/Shell.tsx:4550
+#: src/pages/Shell.tsx:4568
 msgid "Skill {0}"
 msgstr "技能 {0}"
 
-#: src/pages/Shell.tsx:4948
+#: src/pages/Shell.tsx:4966
 msgid "Skip"
 msgstr "跳过"
 
-#: src/pages/Onboarding.tsx:495
+#: src/pages/Onboarding.tsx:569
 msgid "Skip for now"
 msgstr "暂时跳过"
 
@@ -2702,7 +2727,7 @@ msgid "Skip or deploy key"
 msgstr "跳过或使用部署密钥"
 
 #. placeholder {0}: skipped.join(", ")
-#: src/pages/Shell.tsx:1905
+#: src/pages/Shell.tsx:1907
 msgid "Skipped {0}"
 msgstr "已跳过 {0}"
 
@@ -2723,8 +2748,8 @@ msgstr "工作区默认"
 msgid "Space interrupts · Esc hangs up"
 msgstr "空格键打断 · Esc 挂断"
 
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Speak"
 msgstr "朗读"
 
@@ -2736,8 +2761,8 @@ msgstr "朗读 + 转写"
 msgid "Speak only"
 msgstr "仅朗读"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Speak this reply"
 msgstr "朗读这条回复"
 
@@ -2755,7 +2780,7 @@ msgstr "正在开始"
 
 #: src/components/teach/TeachComputerOverlay.tsx:248
 #: src/pages/ModelSettingsOverlay.tsx:626
-#: src/pages/Onboarding.tsx:431
+#: src/pages/Onboarding.tsx:505
 msgid "Starting…"
 msgstr "正在开始…"
 
@@ -2763,20 +2788,20 @@ msgstr "正在开始…"
 msgid "Steps"
 msgstr "步骤"
 
-#: src/pages/Shell.tsx:3755
-#: src/pages/Shell.tsx:3760
-#: src/pages/Shell.tsx:4757
-#: src/pages/Shell.tsx:5067
-#: src/pages/Shell.tsx:5330
+#: src/pages/Shell.tsx:3772
+#: src/pages/Shell.tsx:3777
+#: src/pages/Shell.tsx:4775
+#: src/pages/Shell.tsx:5085
+#: src/pages/Shell.tsx:5348
 msgid "Stop"
 msgstr "停止"
 
-#: src/pages/Shell.tsx:4607
+#: src/pages/Shell.tsx:4625
 msgid "Stop dictation"
 msgstr "停止口述"
 
-#: src/pages/Shell.tsx:5063
-#: src/pages/Shell.tsx:5326
+#: src/pages/Shell.tsx:5081
+#: src/pages/Shell.tsx:5344
 msgid "Stop speaking"
 msgstr "停止朗读"
 
@@ -2794,13 +2819,13 @@ msgstr "已停止。"
 msgid "Stored encrypted"
 msgstr "已加密存储"
 
-#: src/pages/Shell.tsx:5186
+#: src/pages/Shell.tsx:5204
 msgid "subagent"
 msgstr "子 Agent"
 
 #: src/components/AskCard.tsx:140
 #: src/pages/ModelSettingsOverlay.tsx:586
-#: src/pages/Onboarding.tsx:398
+#: src/pages/Onboarding.tsx:472
 msgid "Submit"
 msgstr "提交"
 
@@ -2821,7 +2846,7 @@ msgstr "系统"
 msgid "Teach a task"
 msgstr "示范任务"
 
-#: src/pages/Shell.tsx:2991
+#: src/pages/Shell.tsx:3005
 msgid "Teaching in progress — stop teaching before sending a new message."
 msgstr "正在示范，发送新消息前请先停止示范。"
 
@@ -2829,7 +2854,7 @@ msgstr "正在示范，发送新消息前请先停止示范。"
 msgid "Team"
 msgstr "团队"
 
-#: src/pages/Shell.tsx:5436
+#: src/pages/Shell.tsx:5454
 msgid "Team Computer"
 msgstr "团队电脑"
 
@@ -2857,11 +2882,11 @@ msgstr "所选记忆提供方在此构建中不可用。"
 msgid "Thinking"
 msgstr "思考"
 
-#: src/pages/Shell.tsx:3123
+#: src/pages/Shell.tsx:3137
 msgid "This bot runs on this computer, not a Linux desktop. Shell and files use your home folder."
 msgstr "此 Bot 运行在这台电脑上，而不是 Linux 桌面。Shell 和文件使用你的主目录。"
 
-#: src/pages/Shell.tsx:3811
+#: src/pages/Shell.tsx:3828
 msgid "This bot runs on this computer. There is no separate Linux desktop. Ask it to use the shell; working directories under your home folder are allowed."
 msgstr "此 Bot 运行在这台电脑上，没有单独的 Linux 桌面。让它使用 shell；主目录下的工作目录可用。"
 
@@ -2898,7 +2923,7 @@ msgstr "这台 Mac 会用你的账户运行 shell，包括主目录中的文件�
 msgid "This permanently removes every message and stops current work. The chat remains available."
 msgstr "将永久删除全部消息并停止当前工作。聊天仍可使用。"
 
-#: src/pages/Onboarding.tsx:471
+#: src/pages/Onboarding.tsx:545
 msgid "This provider cannot paste a key here. Skip if this deployment already has credentials."
 msgstr "此提供方不能在这里粘贴密钥。若部署已有凭据，请跳过。"
 
@@ -2930,7 +2955,7 @@ msgstr "此订阅登录在 Rakazo 中尚不可用。请使用部署凭据或选�
 msgid "Time of day"
 msgstr "时间"
 
-#: src/pages/Onboarding.tsx:520
+#: src/pages/Onboarding.tsx:594
 #: src/pages/shell/bot-panel.tsx:133
 #: src/pages/shell/bot-panel.tsx:298
 msgid "Title"
@@ -2965,7 +2990,7 @@ msgid "Unpin"
 msgstr "取消置顶"
 
 #. placeholder {0}: pending.file.name
-#: src/pages/Shell.tsx:1976
+#: src/pages/Shell.tsx:1978
 msgid "Unsupported file type: {0}"
 msgstr "不支持的文件类型：{0}"
 
@@ -3005,7 +3030,7 @@ msgid "Updating…"
 msgstr "正在更新…"
 
 #: src/pages/AccountSettingsOverlay.tsx:206
-#: src/pages/Shell.tsx:2852
+#: src/pages/Shell.tsx:2866
 msgid "Usage"
 msgstr "用量"
 
@@ -3014,7 +3039,7 @@ msgid "Use {hostLabel}"
 msgstr "使用 {hostLabel}"
 
 #: src/pages/ModelSettingsOverlay.tsx:495
-#: src/pages/Onboarding.tsx:334
+#: src/pages/Onboarding.tsx:411
 msgid "Use a found model"
 msgstr "使用找到的模型"
 
@@ -3030,7 +3055,7 @@ msgstr "校验并添加"
 msgid "Verifying…"
 msgstr "正在校验…"
 
-#: src/pages/Shell.tsx:2842
+#: src/pages/Shell.tsx:2856
 #: src/pages/shell/bot-panel.tsx:418
 #: src/pages/VoiceSettingsOverlay.tsx:145
 #: src/pages/VoiceSettingsOverlay.tsx:288
@@ -3039,8 +3064,8 @@ msgstr "语音"
 
 #: src/pages/ModelSettingsOverlay.tsx:590
 #: src/pages/ModelSettingsOverlay.tsx:612
-#: src/pages/Onboarding.tsx:402
-#: src/pages/Onboarding.tsx:424
+#: src/pages/Onboarding.tsx:476
+#: src/pages/Onboarding.tsx:498
 msgid "Waiting for sign-in…"
 msgstr "等待登录…"
 
@@ -3074,7 +3099,7 @@ msgstr "你要示范什么结果？"
 msgid "What should this routine do each time it runs?"
 msgstr "每次运行时，这个例行任务应做什么？"
 
-#: src/pages/Onboarding.tsx:538
+#: src/pages/Onboarding.tsx:612
 #: src/pages/shell/bot-panel.tsx:150
 msgid "What this bot is for"
 msgstr "这个 Bot 是做什么的"
@@ -3103,13 +3128,13 @@ msgstr "Bot 应在哪里运行？"
 #: src/pages/Auth.tsx:185
 #: src/pages/Auth.tsx:293
 #: src/pages/CallView.tsx:251
-#: src/pages/Shell.tsx:5042
-#: src/pages/Shell.tsx:5152
+#: src/pages/Shell.tsx:5060
+#: src/pages/Shell.tsx:5170
 msgid "Working…"
 msgstr "处理中…"
 
-#: src/pages/Shell.tsx:1679
-#: src/pages/Shell.tsx:2339
+#: src/pages/Shell.tsx:1681
+#: src/pages/Shell.tsx:2353
 msgid "You"
 msgstr "你"
 
@@ -3121,7 +3146,7 @@ msgstr "如果没有自动跳转，可以关闭此标签页。"
 msgid "You can close this window."
 msgstr "可以关闭此窗口。"
 
-#: src/pages/Shell.tsx:3745
+#: src/pages/Shell.tsx:3762
 msgid "You have control"
 msgstr "你已接管"
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,11 +5,13 @@ import { App } from "./App";
 import { I18nBootstrap } from "./components/I18nBootstrap";
 import { applyUiDirection } from "./lib/apply-ui-direction";
 import { markAfterPaint, markOnce } from "./lib/performance";
+import { installPreloadRecovery } from "./lib/preload-recovery";
 import { applyUiAppearance, watchSystemAppearance } from "./lib/ui-appearance";
 import { resolveUiLocale } from "./lib/ui-locale";
 import "./styles.css";
 
 markOnce("rk:renderer:module-evaluated");
+installPreloadRecovery();
 applyUiDirection(resolveUiLocale());
 applyUiAppearance();
 


### PR DESCRIPTION
## Why

Long-lived browser sessions can reference lazy chunks removed by a newer deployment, leaving the app blank when a settings overlay is opened. Recently added UI strings were also absent from the extracted catalogs, so message hashes could appear in the interface.

## What changed

- Reload once when Vite reports a stale lazy-chunk preload failure.
- Add a focused recovery test.
- Refresh the Lingui catalogs so new interface strings have source entries.

## Tested

- All web unit tests passed (186 tests).
- Web TypeScript checking passed.
- Production web build passed.
- Formatting and diff checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery from outdated browser assets by automatically refreshing the app when a preload error occurs.
  - Prevented repeated refreshes during the same recovery window.
  - Ensured later preload failures can be handled normally after recovery completes.

- **User Experience**
  - Added interface messages for screen connection failures, retry actions, provider discovery, provider filters, and selection states.
  - Updated localized message catalogs across supported languages to reflect current interface text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->