### PR TITLE
fix(adapters): require HTTPS for OpenAI-compatible when an API key is set

### DIFF
--- a/packages/adapters/src/openai-compatible-url.test.ts
+++ b/packages/adapters/src/openai-compatible-url.test.ts
@@ -128,7 +128,9 @@ describe("assertHttpsForKeyedOpenAiCompatibleUrl", () => {
   it("rejects public http when an API key is set", () => {
     process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
     const url = assertAllowedOpenAiCompatibleUrl("http://api.example.com/v1");
-    expect(() => assertHttpsForKeyedOpenAiCompatibleUrl(url, "secret-key")).toThrow(/must use HTTPS/);
+    expect(() => assertHttpsForKeyedOpenAiCompatibleUrl(url, "secret-key")).toThrow(
+      /must use HTTPS/,
+    );
   });
 
   it("allows public https when an API key is set", () => {

--- a/packages/adapters/src/openai-compatible-url.test.ts
+++ b/packages/adapters/src/openai-compatible-url.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   assertAllowedOpenAiCompatibleRequestUrl,
   assertAllowedOpenAiCompatibleUrl,
+  assertHttpsForKeyedOpenAiCompatibleUrl,
   normalizeOpenAiCompatibleBaseUrl,
   openAiCompatAllowPublicHosts,
 } from "./openai-compatible-url.js";
@@ -120,5 +121,33 @@ describe("openai-compatible URL policy", () => {
     expect(assertAllowedOpenAiCompatibleUrl("https://api.example.com/v1").href).toBe(
       "https://api.example.com/v1",
     );
+  });
+});
+
+describe("assertHttpsForKeyedOpenAiCompatibleUrl", () => {
+  it("rejects public http when an API key is set", () => {
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    const url = assertAllowedOpenAiCompatibleUrl("http://api.example.com/v1");
+    expect(() => assertHttpsForKeyedOpenAiCompatibleUrl(url, "secret-key")).toThrow(/must use HTTPS/);
+  });
+
+  it("allows public https when an API key is set", () => {
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    const url = assertAllowedOpenAiCompatibleUrl("https://api.example.com/v1");
+    expect(() => assertHttpsForKeyedOpenAiCompatibleUrl(url, "secret-key")).not.toThrow();
+  });
+
+  it("allows private http when an API key is set", () => {
+    const url = assertAllowedOpenAiCompatibleUrl("http://127.0.0.1:8000/v1");
+    expect(() => assertHttpsForKeyedOpenAiCompatibleUrl(url, "local-secret")).not.toThrow();
+    const lan = assertAllowedOpenAiCompatibleUrl("http://192.168.1.20:8080/v1");
+    expect(() => assertHttpsForKeyedOpenAiCompatibleUrl(lan, "local-secret")).not.toThrow();
+  });
+
+  it("skips the HTTPS check when no API key is set", () => {
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    const url = assertAllowedOpenAiCompatibleUrl("http://api.example.com/v1");
+    expect(() => assertHttpsForKeyedOpenAiCompatibleUrl(url, undefined)).not.toThrow();
+    expect(() => assertHttpsForKeyedOpenAiCompatibleUrl(url, "  ")).not.toThrow();
   });
 });

--- a/packages/adapters/src/openai-compatible-url.ts
+++ b/packages/adapters/src/openai-compatible-url.ts
@@ -69,6 +69,24 @@ export function assertAllowedOpenAiCompatibleUrl(
   return assertAllowedOpenAiCompatibleRequestUrl(normalized, opts);
 }
 
+/**
+ * When an API key will be sent, refuse public http:// endpoints so the Bearer
+ * token is not cleartext on the public internet. Private / loopback http stays
+ * allowed (local model servers). https:// is always fine for this check.
+ */
+export function assertHttpsForKeyedOpenAiCompatibleUrl(
+  url: URL,
+  apiKey: string | undefined | null,
+): void {
+  if (!apiKey?.trim()) return;
+  if (url.protocol === "https:") return;
+  const hostname = normalizeHostname(url.hostname);
+  if (isPrivateOpenAiCompatibleHostname(hostname)) return;
+  throw new Error(
+    "OpenAI-compatible endpoints that send an API key must use HTTPS. Use an https:// URL, or omit the API key on a private HTTP endpoint.",
+  );
+}
+
 export function assertAllowedOpenAiCompatibleRequestUrl(
   raw: string,
   opts?: { allowPublic?: boolean },

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -8,6 +8,7 @@ import {
   createOpenAiCompatibleLookup,
   OPENAI_COMPATIBLE_CATALOG_MODEL_ID,
   openAiCompatibleCatalogProvider,
+  prepareOpenAiCompatibleConnect,
   probeOpenAiCompatibleModels,
   registerOpenAiCompatibleRuntime,
 } from "./pi-openai-compatible-provider.js";
@@ -42,6 +43,67 @@ describe("model connect", () => {
     const parsed = parseModelSecret(serializeModelSecret(secret));
     expect(parsed).toEqual(secret);
     expect(secretValuesToRedact(parsed)).toEqual(["local-secret"]);
+  });
+
+  it("keeps private http openai-compatible connects when an API key is set", () => {
+    const plaintext = buildModelConnectPlaintext({
+      provider: OPENAI_COMPATIBLE_PROVIDER_ID,
+      baseUrl: "http://127.0.0.1:8000",
+      modelId: "local-model",
+      apiKey: "local-secret",
+    });
+    expect(parseModelSecret(plaintext)).toEqual({
+      kind: "openai_compatible",
+      baseUrl: "http://127.0.0.1:8000/v1",
+      apiKey: "local-secret",
+    });
+  });
+
+  it("rejects public http openai-compatible connects when an API key is set", () => {
+    const previous = process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    try {
+      expect(() =>
+        prepareOpenAiCompatibleConnect({
+          provider: OPENAI_COMPATIBLE_PROVIDER_ID,
+          baseUrl: "http://api.example.com/v1",
+          modelId: "my-model-id",
+          apiKey: "secret-key",
+        }),
+      ).toThrow(/must use HTTPS/);
+      expect(() =>
+        buildModelConnectPlaintext({
+          provider: OPENAI_COMPATIBLE_PROVIDER_ID,
+          baseUrl: "http://api.example.com/v1",
+          modelId: "my-model-id",
+          apiKey: "secret-key",
+        }),
+      ).toThrow(/must use HTTPS/);
+    } finally {
+      if (previous === undefined) delete process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+      else process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = previous;
+    }
+  });
+
+  it("allows public https openai-compatible connects when an API key is set", () => {
+    const previous = process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    try {
+      const prepared = prepareOpenAiCompatibleConnect({
+        provider: OPENAI_COMPATIBLE_PROVIDER_ID,
+        baseUrl: "https://api.example.com/v1",
+        modelId: "my-model-id",
+        apiKey: "secret-key",
+      });
+      expect(prepared).toEqual({
+        baseUrl: "https://api.example.com/v1",
+        modelId: "my-model-id",
+        apiKey: "secret-key",
+      });
+    } finally {
+      if (previous === undefined) delete process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+      else process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = previous;
+    }
   });
 });
 

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -5,6 +5,7 @@ import { buildModelConnectPlaintext } from "./model-connect.js";
 import { listPiCatalog } from "./pi-models.js";
 import { parseModelSecret, secretValuesToRedact, serializeModelSecret } from "./pi-oauth.js";
 import {
+  createOpenAiCompatibleFetch,
   createOpenAiCompatibleLookup,
   OPENAI_COMPATIBLE_CATALOG_MODEL_ID,
   openAiCompatibleCatalogProvider,
@@ -108,6 +109,25 @@ describe("model connect", () => {
 });
 
 describe("openai-compatible provider", () => {
+  it("does not treat replaced Request Authorization as keyed for public http", async () => {
+    const previous = process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+    process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";
+    try {
+      const request = new Request("http://api.example.com/v1/models", {
+        headers: { Authorization: "Bearer secret" },
+      });
+      const safeFetch = createOpenAiCompatibleFetch(
+        async () => new Response("{}", { status: 200 }),
+      );
+      await expect(
+        safeFetch(request, { headers: { Accept: "application/json" } }),
+      ).resolves.toMatchObject({ status: 200 });
+    } finally {
+      if (previous === undefined) delete process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
+      else process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = previous;
+    }
+  });
+
   it("rejects public hostnames that resolve to private addresses", async () => {
     const lookup = createOpenAiCompatibleLookup(
       new URL("https://models.example.test/v1"),

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -112,17 +112,15 @@ export function createOpenAiCompatibleLookup(
   });
 }
 
-
-function requestCarriesAuthorization(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-): boolean {
+function requestCarriesAuthorization(input: RequestInfo | URL, init?: RequestInit): boolean {
   if (input instanceof Request && input.headers.get("authorization")) return true;
   const headers = init?.headers;
   if (!headers) return false;
   if (headers instanceof Headers) return Boolean(headers.get("authorization"));
   if (Array.isArray(headers)) {
-    return headers.some(([name, value]) => name.toLowerCase() === "authorization" && Boolean(value));
+    return headers.some(
+      ([name, value]) => name.toLowerCase() === "authorization" && Boolean(value),
+    );
   }
   return Object.entries(headers).some(
     ([name, value]) => name.toLowerCase() === "authorization" && Boolean(value),

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -112,10 +112,7 @@ export function createOpenAiCompatibleLookup(
   });
 }
 
-function requestCarriesAuthorization(input: RequestInfo | URL, init?: RequestInit): boolean {
-  if (input instanceof Request && input.headers.get("authorization")) return true;
-  const headers = init?.headers;
-  if (!headers) return false;
+function headersCarryAuthorization(headers: HeadersInit): boolean {
   if (headers instanceof Headers) return Boolean(headers.get("authorization"));
   if (Array.isArray(headers)) {
     return headers.some(
@@ -125,6 +122,12 @@ function requestCarriesAuthorization(input: RequestInfo | URL, init?: RequestIni
   return Object.entries(headers).some(
     ([name, value]) => name.toLowerCase() === "authorization" && Boolean(value),
   );
+}
+
+/** Matches fetch: when init.headers is set it replaces Request headers entirely. */
+function requestCarriesAuthorization(input: RequestInfo | URL, init?: RequestInit): boolean {
+  if (init?.headers !== undefined) return headersCarryAuthorization(init.headers);
+  return input instanceof Request ? Boolean(input.headers.get("authorization")) : false;
 }
 
 export function createOpenAiCompatibleFetch(

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -18,6 +18,7 @@ import {
 import {
   assertAllowedOpenAiCompatibleRequestUrl,
   assertAllowedOpenAiCompatibleUrl,
+  assertHttpsForKeyedOpenAiCompatibleUrl,
   isPrivateOpenAiCompatibleHostname,
   normalizeOpenAiCompatibleBaseUrl,
   OPENAI_COMPATIBLE_PROVIDER_ID,
@@ -111,6 +112,23 @@ export function createOpenAiCompatibleLookup(
   });
 }
 
+
+function requestCarriesAuthorization(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): boolean {
+  if (input instanceof Request && input.headers.get("authorization")) return true;
+  const headers = init?.headers;
+  if (!headers) return false;
+  if (headers instanceof Headers) return Boolean(headers.get("authorization"));
+  if (Array.isArray(headers)) {
+    return headers.some(([name, value]) => name.toLowerCase() === "authorization" && Boolean(value));
+  }
+  return Object.entries(headers).some(
+    ([name, value]) => name.toLowerCase() === "authorization" && Boolean(value),
+  );
+}
+
 export function createOpenAiCompatibleFetch(
   baseFetch: typeof globalThis.fetch = globalThis.fetch,
   resolve: ResolveHostname = resolveHostname,
@@ -118,6 +136,9 @@ export function createOpenAiCompatibleFetch(
   return async (input, init) => {
     const rawUrl = input instanceof Request ? input.url : String(input);
     const url = assertAllowedOpenAiCompatibleRequestUrl(rawUrl);
+    if (requestCarriesAuthorization(input, init)) {
+      assertHttpsForKeyedOpenAiCompatibleUrl(url, "present");
+    }
     const hostname = url.hostname.replace(/^\[|\]$/g, "");
     const dispatcher =
       isIP(hostname) === 0
@@ -225,8 +246,10 @@ export function prepareOpenAiCompatibleConnect(input: OpenAiCompatibleConnectInp
   const modelId = input.modelId?.trim();
   if (!baseUrl) throw new Error("Base URL is required for OpenAI-compatible models");
   if (!modelId) throw new Error("Model id is required for OpenAI-compatible models");
-  const normalized = assertAllowedOpenAiCompatibleUrl(baseUrl).href;
+  const allowed = assertAllowedOpenAiCompatibleUrl(baseUrl);
   const apiKey = input.apiKey?.trim();
+  assertHttpsForKeyedOpenAiCompatibleUrl(allowed, apiKey);
+  const normalized = allowed.href;
   return apiKey ? { baseUrl: normalized, modelId, apiKey } : { baseUrl: normalized, modelId };
 }
 
@@ -288,6 +311,7 @@ export async function probeOpenAiCompatibleModels(
   signal?: AbortSignal,
 ): Promise<string[]> {
   const baseUrl = assertAllowedOpenAiCompatibleUrl(input.baseUrl);
+  assertHttpsForKeyedOpenAiCompatibleUrl(baseUrl, input.apiKey);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5_000);
   const merged = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal;


### PR DESCRIPTION
## Summary
- When an OpenAI-compatible connect/probe sends an API key, refuse **public** `http://` base URLs so the Bearer token is not cleartext on the public internet.
- Private / loopback `http://` with a key still allowed (local model servers).
- `https://` unchanged; `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC` default unchanged.
- Also re-check at fetch time if the request carries `Authorization`.

## Test plan
- [x] `vitest` `openai-compatible-url.test.ts` + `pi-openai-compatible-provider.test.ts` (28 passed)
- [ ] CI unit tests

Related: docs for the public-host gate are in #577 (orthogonal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enforced HTTPS for public OpenAI-compatible endpoints when an API key is used, preventing credentials from being sent over unencrypted connections.
  * Continued supporting HTTP for private or loopback endpoints, such as local model servers.
  * Public HTTPS endpoints and connections without an API key remain supported.
  * Improved authorization handling when request headers are replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->