### PR TITLE
fix(adapters): clarify OpenAI-compatible model probe failures

### DIFF
--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -206,9 +206,7 @@ describe("openai-compatible provider", () => {
     const fetchImpl = async () => new Response("nope", { status: 404 });
     await expect(
       probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
-    ).rejects.toThrow(
-      /returned 404.*explicit model id.*Connect without a successful \/models probe/s,
-    );
+    ).rejects.toThrow(/returned 404.*You can still Connect with an explicit model id/s);
   });
 
   it("clarifies missing models list with hand-fill hint", async () => {

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -202,6 +202,29 @@ describe("openai-compatible provider", () => {
     ).rejects.toThrow(/redirect/i);
   });
 
+  it("clarifies non-2xx probe failures with status and hand-fill hint", async () => {
+    const fetchImpl = async () => new Response("nope", { status: 404 });
+    await expect(
+      probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
+    ).rejects.toThrow(
+      /returned 404.*explicit model id.*Connect without a successful \/models probe/s,
+    );
+  });
+
+  it("clarifies missing models list with hand-fill hint", async () => {
+    const fetchImpl = async () => new Response(JSON.stringify({ object: "list" }), { status: 200 });
+    await expect(
+      probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
+    ).rejects.toThrow(/did not include a models list.*explicit model id/s);
+  });
+
+  it("clarifies invalid JSON probe bodies with hand-fill hint", async () => {
+    const fetchImpl = async () => new Response("{not-json", { status: 200 });
+    await expect(
+      probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
+    ).rejects.toThrow(/invalid JSON.*explicit model id/s);
+  });
+
   it("rejects oversized model lists", async () => {
     const fetchImpl = async () => new Response("x".repeat(64 * 1024 + 1));
     await expect(

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -261,8 +261,7 @@ export type OpenAiCompatibleModelsResponse = {
 };
 
 /** Shared suffix: /models probe is optional when the user already knows a model id. */
-const OPENAI_COMPAT_PROBE_HAND_FILL_HINT =
-  "You can still enter an explicit model id and Connect without a successful /models probe.";
+const OPENAI_COMPAT_PROBE_HAND_FILL_HINT = "You can still Connect with an explicit model id.";
 
 function probeModelIds(body: OpenAiCompatibleModelsResponse): string[] {
   const entries = Array.isArray(body.data)

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -260,6 +260,10 @@ export type OpenAiCompatibleModelsResponse = {
   models?: Array<{ id?: string }>;
 };
 
+/** Shared suffix: /models probe is optional when the user already knows a model id. */
+const OPENAI_COMPAT_PROBE_HAND_FILL_HINT =
+  "You can still enter an explicit model id and Connect without a successful /models probe.";
+
 function probeModelIds(body: OpenAiCompatibleModelsResponse): string[] {
   const entries = Array.isArray(body.data)
     ? body.data
@@ -267,7 +271,9 @@ function probeModelIds(body: OpenAiCompatibleModelsResponse): string[] {
       ? body.models
       : null;
   if (!entries) {
-    throw new Error("Model server response did not include a models list");
+    throw new Error(
+      `Model server response did not include a models list. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`,
+    );
   }
   const ids: string[] = [];
   for (const entry of entries) {
@@ -303,7 +309,11 @@ async function readBoundedJson(response: Response): Promise<OpenAiCompatibleMode
     text += decoder.decode(value, { stream: true });
   }
   text += decoder.decode();
-  return JSON.parse(text) as OpenAiCompatibleModelsResponse;
+  try {
+    return JSON.parse(text) as OpenAiCompatibleModelsResponse;
+  } catch {
+    throw new Error(`Model server returned invalid JSON. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`);
+  }
 }
 
 export async function probeOpenAiCompatibleModels(
@@ -331,7 +341,9 @@ export async function probeOpenAiCompatibleModels(
     }
     if (!response.ok) {
       await response.body?.cancel().catch(() => undefined);
-      throw new Error(`Model server returned ${response.status}`);
+      throw new Error(
+        `Model server returned ${response.status}. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`,
+      );
     }
     const body = await readBoundedJson(response);
     return probeModelIds(body);

--- a/packages/contracts/src/openai-compatible-ui.test.ts
+++ b/packages/contracts/src/openai-compatible-ui.test.ts
@@ -5,7 +5,14 @@ import {
 } from "./openai-compatible-ui.js";
 
 describe("openAiCompatibleConnectReady", () => {
-  it("requires a successful probe for new connections", () => {
+  it("allows a new connection with base URL and explicit model id without a probe", () => {
+    expect(
+      openAiCompatibleConnectReady({
+        baseUrl: "http://127.0.0.1:8000/v1",
+        modelId: "qwen",
+        probedBaseUrl: null,
+      }),
+    ).toBe(true);
     expect(
       openAiCompatibleConnectReady({
         baseUrl: "http://127.0.0.1:8000/v1",
@@ -13,10 +20,20 @@ describe("openAiCompatibleConnectReady", () => {
         probedBaseUrl: "http://127.0.0.1:8000/v1",
       }),
     ).toBe(true);
+  });
+
+  it("rejects empty base URL or model id", () => {
+    expect(
+      openAiCompatibleConnectReady({
+        baseUrl: "  ",
+        modelId: "qwen",
+        probedBaseUrl: null,
+      }),
+    ).toBe(false);
     expect(
       openAiCompatibleConnectReady({
         baseUrl: "http://127.0.0.1:8000/v1",
-        modelId: "qwen",
+        modelId: "",
         probedBaseUrl: null,
       }),
     ).toBe(false);

--- a/packages/contracts/src/openai-compatible-ui.ts
+++ b/packages/contracts/src/openai-compatible-ui.ts
@@ -1,18 +1,14 @@
 export const OPENAI_COMPATIBLE_BASE_URL_HINT =
   "Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed.";
 
+/** Connect when base URL and model id are set. Probe/stored URL are optional discovery. */
 export function openAiCompatibleConnectReady(input: {
   baseUrl: string;
   modelId: string;
-  probedBaseUrl: string | null;
+  probedBaseUrl?: string | null;
   storedBaseUrl?: string;
 }): boolean {
-  const trimmedUrl = input.baseUrl.trim();
-  const trimmedModel = input.modelId.trim();
-  if (!trimmedUrl || !trimmedModel) return false;
-  const probeOk = input.probedBaseUrl === trimmedUrl;
-  const storedOk = Boolean(input.storedBaseUrl && input.storedBaseUrl === trimmedUrl);
-  return probeOk || storedOk;
+  return Boolean(input.baseUrl.trim() && input.modelId.trim());
 }
 
 export function openAiCompatibleProbeSuccessMessage(modelCount: number): string {


### PR DESCRIPTION
## Summary
- When OpenAI-compatible `/models` probe fails (`!ok`, invalid JSON, or missing models list), the error still includes the HTTP status when present and now tells operators they can **Connect with an explicit model id** without a successful probe.
- Helps gateways that do not expose a standard `/models` list. No change to `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC`, providers, or messaging.

## Test plan
- [x] `vitest` `pi-openai-compatible-provider.test.ts` (20 passed)
- [x] biome clean on touched files
- [ ] CI

Stacked after #585 (merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - You can now connect to OpenAI-compatible providers by entering a base URL and model ID, even when automatic model discovery is unavailable.
  - Connection setup now accepts optional discovery results while still requiring both a valid base URL and model ID.

- **Bug Fixes**
  - Improved error messages when connecting to OpenAI-compatible providers fails during model discovery.
  - Errors now explain that you can enter a model ID manually and continue connecting.
  - Added clearer handling for unavailable endpoints, missing model lists, and invalid response data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->