### PR TITLE
Fix desktop local-stack ownership checks

### DIFF
--- a/apps/desktop/e2e/local-stack.spec.ts
+++ b/apps/desktop/e2e/local-stack.spec.ts
@@ -317,6 +317,50 @@ test("a saved local stack is reused only after its private identity matches", as
   expect(await readLog()).toEqual([]);
 });
 
+test("a saved local target is the exact origin authenticated before reuse", async () => {
+  const uncheckedServer = createServer((request, response) => {
+    if (request.url === "/rpc/health" && request.method === "POST") {
+      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end("<!doctype html><html><body>Unchecked listener</body></html>");
+  });
+  await new Promise<void>((resolve) => uncheckedServer.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = uncheckedServer.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("unchecked server has no port");
+    }
+    const stackDir = path.join(userData, "stack");
+    await mkdir(stackDir, { recursive: true });
+    await writeFile(path.join(stackDir, ".desktop-stack-token"), `${"ab".repeat(32)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await writeFile(
+      path.join(userData, "setup.json"),
+      `${JSON.stringify(
+        { mode: "new", serverUrl: `http://127.0.0.1:${address.port}` },
+        null,
+        2,
+      )}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+
+    app = await launch("ok");
+    const setup = await app.firstWindow();
+    await expect(setup.getByRole("radio", { name: /This computer/ })).toBeChecked();
+    await expect(setup.locator("#stack")).toBeVisible();
+    await expect(setup.getByText("Unchecked listener")).toHaveCount(0);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      uncheckedServer.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test("an existing stack .env is never rewritten", async () => {
   const stackDir = path.join(userData, "stack");
   await mkdir(stackDir, { recursive: true });

--- a/apps/desktop/e2e/local-stack.spec.ts
+++ b/apps/desktop/e2e/local-stack.spec.ts
@@ -6,6 +6,8 @@ import { type ElectronApplication, _electron as electron, expect, test } from "@
 
 const APP_MARKER = "Local Rakazo stack ready";
 const IMAGE_TAG = "v9.9.9";
+const STACK_PROBE_PATH = "/.well-known/rakazo-desktop-stack";
+const STACK_TOKEN_HEADER = "x-rakazo-desktop-stack-token";
 const COMPOSE_DIR = path.resolve(import.meta.dirname, "..", "..", "..", "infra", "compose");
 
 type FakeDockerMode = "ok" | "daemon-down" | "pull-fails";
@@ -19,7 +21,19 @@ let app: ElectronApplication | undefined;
 test.skip(process.platform === "win32", "fake docker needs a POSIX shell");
 
 test.beforeAll(async () => {
-  server = createServer((request, response) => {
+  server = createServer(async (request, response) => {
+    if (request.url === STACK_PROBE_PATH && request.method === "GET") {
+      const expected = await readFile(path.join(userData, "stack", ".desktop-stack-token"), "utf8")
+        .then((value) => value.trim())
+        .catch(() => null);
+      if (expected === null || request.headers[STACK_TOKEN_HEADER] !== expected) {
+        response.writeHead(404).end("Not found");
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      response.end(JSON.stringify({ ok: true, imageTag: IMAGE_TAG }));
+      return;
+    }
     if (request.url === "/rpc/health" && request.method === "POST") {
       response.writeHead(200, { "content-type": "application/json; charset=utf-8" });
       response.end(JSON.stringify({ json: { ok: true, version: "0.1.0" } }));
@@ -149,7 +163,10 @@ test("This computer installs and starts the stack, then opens the app", async ()
 
   const stackDir = path.join(userData, "stack");
   const envFile = path.join(stackDir, ".env");
+  const tokenFile = path.join(stackDir, ".desktop-stack-token");
   expect((await stat(envFile)).mode & 0o777).toBe(0o600);
+  expect((await stat(tokenFile)).mode & 0o777).toBe(0o600);
+  expect(await readFile(tokenFile, "utf8")).toMatch(/^[0-9a-f]{64}\n$/);
   const env = await readFile(envFile, "utf8");
   expect(env).toMatch(/^POSTGRES_PASSWORD=[0-9a-f]{32}$/m);
   expect(env).toMatch(/^BETTER_AUTH_SECRET=[0-9a-f]{64}$/m);
@@ -279,6 +296,25 @@ test("a saved local stack that is down is started again without asking", async (
   await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
   await expect.poll(savedSetup).toEqual({ mode: "new", serverUrl });
   expect((await readLog()).some((line) => line.includes(" pull"))).toBe(true);
+});
+
+test("a saved local stack is reused only after its private identity matches", async () => {
+  const stackDir = path.join(userData, "stack");
+  await mkdir(stackDir, { recursive: true });
+  await writeFile(path.join(stackDir, ".desktop-stack-token"), `${"ab".repeat(32)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await writeFile(
+    path.join(userData, "setup.json"),
+    `${JSON.stringify({ mode: "new", serverUrl }, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+
+  app = await launch("ok");
+  const appWindow = await app.firstWindow();
+  await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
+  expect(await readLog()).toEqual([]);
 });
 
 test("an existing stack .env is never rewritten", async () => {

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -355,8 +355,10 @@ describe("LocalStackController", () => {
       },
     });
 
+    await expect(stack.matchesDesiredStack()).resolves.toBe(true);
+    expect(probedUrls).toEqual(["http://127.0.0.1:5173"]);
     await expect(stack.matchesDesiredStack("http://127.0.0.1:5199")).resolves.toBe(true);
-    expect(probedUrls).toEqual(["http://127.0.0.1:5199"]);
+    expect(probedUrls).toEqual(["http://127.0.0.1:5173", "http://127.0.0.1:5199"]);
     expect(calls).toEqual([]);
   });
 

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -271,6 +271,7 @@ describe("LocalStackController", () => {
       exists: (file) => file === "/usr/bin/docker",
       stackDir: path.join(root, "stack"),
       resourceDir: COMPOSE_DIR,
+      localWebUrl: "http://127.0.0.1:5173",
       imageTag: "v1.2.3",
       randomHex: fakeHex,
       sleep: async () => undefined,
@@ -281,9 +282,9 @@ describe("LocalStackController", () => {
         phases.push(stack.state().phase);
         return run(binary, args, options);
       },
-      probe: (signal, token) => {
+      probe: (url, signal, token) => {
         phases.push(stack.state().phase);
-        return probe(signal, token);
+        return probe(url, signal, token);
       },
     };
     const stack = new LocalStackController(deps);
@@ -346,11 +347,16 @@ describe("LocalStackController", () => {
     const stackPath = path.join(root, "stack");
     await mkdir(stackPath, { recursive: true });
     const token = await ensureStackToken(stackPath, fakeHex);
+    const probedUrls: string[] = [];
     const stack = controller({
-      probe: async (_signal, supplied) => (supplied === token ? "v1.2.3" : null),
+      probe: async (url, _signal, supplied) => {
+        probedUrls.push(url);
+        return supplied === token ? "v1.2.3" : null;
+      },
     });
 
-    await expect(stack.matchesDesiredStack()).resolves.toBe(true);
+    await expect(stack.matchesDesiredStack("http://127.0.0.1:5199")).resolves.toBe(true);
+    expect(probedUrls).toEqual(["http://127.0.0.1:5199"]);
     expect(calls).toEqual([]);
   });
 
@@ -588,7 +594,7 @@ describe("LocalStackController", () => {
     });
     const stack = controller(
       {
-        probe: (signal) => {
+        probe: (_url, signal) => {
           probes += 1;
           if (probes > 1) return Promise.resolve("v1.2.3");
           markProbeStarted();
@@ -637,7 +643,7 @@ describe("LocalStackController", () => {
 
   it("does not wait out a slow health probe when stopped", async () => {
     const stack = controller({
-      probe: (signal) =>
+      probe: (_url, signal) =>
         signal.aborted
           ? Promise.resolve(null)
           : new Promise((resolve) => signal.addEventListener("abort", () => resolve(null))),

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -6,9 +6,11 @@ import type { RunDocker, RunDockerResult } from "./docker-cli.js";
 import {
   COMPOSE_WAIT_TIMEOUT_S,
   ensureStackEnv,
+  ensureStackToken,
   initialStackState,
   LocalStackController,
   type LocalStackDeps,
+  readStackToken,
   reduceStackState,
   renderStackEnv,
   resolveImageTag,
@@ -16,6 +18,7 @@ import {
   STACK_ENV_FILE,
   STACK_ENV_TEMPLATE,
   STACK_OUTPUT_LINES,
+  STACK_TOKEN_FILE,
   stackDir,
   stackFailureMessage,
   stackResourceDir,
@@ -108,6 +111,30 @@ describe("ensureStackEnv", () => {
     await writeFile(path.join(dir, STACK_ENV_FILE), "sentinel\n", "utf8");
     await expect(ensureStackEnv(dir, "POSTGRES_PASSWORD=\n", fakeHex)).resolves.toBe("kept");
     await expect(readFile(path.join(dir, STACK_ENV_FILE), "utf8")).resolves.toBe("sentinel\n");
+  });
+});
+
+describe("stack identity", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "rakazo-stack-token-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("creates one private token and reuses it", async () => {
+    const token = await ensureStackToken(dir, fakeHex);
+    await expect(ensureStackToken(dir, () => "cd".repeat(32))).resolves.toBe(token);
+    await expect(readStackToken(dir)).resolves.toBe(token);
+    if (process.platform !== "win32") {
+      expect((await stat(path.join(dir, STACK_TOKEN_FILE))).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("replaces an invalid legacy token", async () => {
+    await writeFile(path.join(dir, STACK_TOKEN_FILE), "not-a-token\n", "utf8");
+    await expect(ensureStackToken(dir, fakeHex)).resolves.toBe("ab".repeat(32));
   });
 });
 
@@ -237,7 +264,7 @@ describe("LocalStackController", () => {
 
   function controller(overrides: Partial<LocalStackDeps> = {}, script: Script = ok) {
     const run = fakeRun(calls, script);
-    const probe = overrides.probe ?? (async () => true);
+    const probe = overrides.probe ?? (async () => "v1.2.3");
     const deps: LocalStackDeps = {
       platform: "linux",
       env: { PATH: "/usr/bin", HOME: "/home/me", OPENROUTER_API_KEY: "sk-secret" },
@@ -254,9 +281,9 @@ describe("LocalStackController", () => {
         phases.push(stack.state().phase);
         return run(binary, args, options);
       },
-      probe: (signal) => {
+      probe: (signal, token) => {
         phases.push(stack.state().phase);
-        return probe(signal);
+        return probe(signal, token);
       },
     };
     const stack = new LocalStackController(deps);
@@ -301,6 +328,7 @@ describe("LocalStackController", () => {
       });
       expect(call.env).not.toHaveProperty("OPENROUTER_API_KEY");
     }
+    expect(calls.at(-1)?.env.RAKAZO_DESKTOP_STACK_TOKEN).toBe("ab".repeat(32));
 
     await expect(readFile(path.join(stackPath, STACK_COMPOSE_FILE), "utf8")).resolves.toBe(
       await readFile(path.join(COMPOSE_DIR, STACK_COMPOSE_FILE), "utf8"),
@@ -312,6 +340,31 @@ describe("LocalStackController", () => {
       expect((await stat(path.join(stackPath, STACK_ENV_FILE))).mode & 0o777).toBe(0o600);
       expect((await stat(stackPath)).mode & 0o777).toBe(0o700);
     }
+  });
+
+  it("reuses only the privately identified stack on the desired image", async () => {
+    const stackPath = path.join(root, "stack");
+    await mkdir(stackPath, { recursive: true });
+    const token = await ensureStackToken(stackPath, fakeHex);
+    const stack = controller({
+      probe: async (_signal, supplied) => (supplied === token ? "v1.2.3" : null),
+    });
+
+    await expect(stack.matchesDesiredStack()).resolves.toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects another listener and a managed stack from an older release", async () => {
+    const stackPath = path.join(root, "stack");
+    await mkdir(stackPath, { recursive: true });
+    await ensureStackToken(stackPath, fakeHex);
+
+    await expect(controller({ probe: async () => null }).matchesDesiredStack()).resolves.toBe(
+      false,
+    );
+    await expect(controller({ probe: async () => "v1.2.2" }).matchesDesiredStack()).resolves.toBe(
+      false,
+    );
   });
 
   it("uses a plain up -d for Compose plugins older than 2.17", async () => {
@@ -425,7 +478,7 @@ describe("LocalStackController", () => {
     const stack = controller({
       probe: async () => {
         probes += 1;
-        return false;
+        return null;
       },
     });
     const state = await stack.start();
@@ -529,18 +582,24 @@ describe("LocalStackController", () => {
       releaseStop = resolve;
     });
     let probes = 0;
+    let markProbeStarted: () => void = () => undefined;
+    const probeStarted = new Promise<void>((resolve) => {
+      markProbeStarted = resolve;
+    });
     const stack = controller(
       {
         probe: (signal) => {
           probes += 1;
-          if (probes > 1) return Promise.resolve(true);
-          return new Promise((resolve) => signal.addEventListener("abort", () => resolve(false)));
+          if (probes > 1) return Promise.resolve("v1.2.3");
+          markProbeStarted();
+          if (signal.aborted) return Promise.resolve(null);
+          return new Promise((resolve) => signal.addEventListener("abort", () => resolve(null)));
         },
       },
       (args) => (args[5] === "stop" ? { wait: stopGate } : ok(args)),
     );
     const first = stack.start();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await probeStarted;
     const stopping = stack.stop();
     const second = stack.start();
     expect(second).not.toBe(first);
@@ -579,7 +638,9 @@ describe("LocalStackController", () => {
   it("does not wait out a slow health probe when stopped", async () => {
     const stack = controller({
       probe: (signal) =>
-        new Promise((resolve) => signal.addEventListener("abort", () => resolve(false))),
+        signal.aborted
+          ? Promise.resolve(null)
+          : new Promise((resolve) => signal.addEventListener("abort", () => resolve(null))),
     });
     const started = stack.start();
     await new Promise((resolve) => setTimeout(resolve, 10));

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -16,6 +16,7 @@ export const STACK_DIR_NAME = "stack";
 export const STACK_COMPOSE_FILE = "docker-compose.images.yml";
 export const STACK_ENV_TEMPLATE = ".env.images.example";
 export const STACK_ENV_FILE = ".env";
+export const STACK_TOKEN_FILE = ".desktop-stack-token";
 export const STACK_OUTPUT_LINES = 20;
 export const STACK_HEALTH_TIMEOUT_MS = 120_000;
 export const COMPOSE_WAIT_TIMEOUT_S = 300;
@@ -104,6 +105,30 @@ export async function ensureStackEnv(
     await writePrivateFile(destination, renderStackEnv(template, randomHex));
     return "created";
   }
+}
+
+const STACK_TOKEN = /^[a-f0-9]{64}$/;
+
+export async function readStackToken(dir: string): Promise<string | null> {
+  try {
+    const token = (await readFile(path.join(dir, STACK_TOKEN_FILE), "utf8")).trim();
+    return STACK_TOKEN.test(token) ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Creates an app-private identity without placing it in the user-editable Compose env file. */
+export async function ensureStackToken(
+  dir: string,
+  randomHex: (bytes: number) => string,
+): Promise<string> {
+  const existing = await readStackToken(dir);
+  if (existing !== null) return existing;
+  const token = randomHex(32);
+  if (!STACK_TOKEN.test(token)) throw new Error("Stack token generator returned invalid data.");
+  await writePrivateFile(path.join(dir, STACK_TOKEN_FILE), `${token}\n`);
+  return token;
 }
 
 export type LocalStackEvent =
@@ -209,7 +234,8 @@ export interface LocalStackDeps {
   resourceDir: string;
   imageTag: string;
   /** Answers whether the web app is reachable; the final readiness gate. */
-  probe: (signal: AbortSignal) => Promise<boolean>;
+  /** Returns the authenticated running image tag, or null for any other listener. */
+  probe: (signal: AbortSignal, token: string) => Promise<string | null>;
   randomHex: (bytes: number) => string;
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
   healthTimeoutMs?: number;
@@ -234,6 +260,7 @@ function defaultSleep(ms: number, signal: AbortSignal) {
  */
 export class LocalStackController {
   private current: DesktopLocalStackState;
+  private currentStackToken: string | null = null;
   private running: Promise<DesktopLocalStackState> | null = null;
   private stopping: Promise<DesktopLocalStackState> | null = null;
   private inFlight: AbortController | null = null;
@@ -247,6 +274,21 @@ export class LocalStackController {
 
   state(): DesktopLocalStackState {
     return this.current;
+  }
+
+  /** Fast path for launch: only a stack with our private token and desired image may be reused. */
+  async matchesDesiredStack(): Promise<boolean> {
+    const token = await readStackToken(this.deps.stackDir);
+    if (token === null) return false;
+    this.currentStackToken = token;
+    try {
+      return (
+        (await this.deps.probe(AbortSignal.timeout(HEALTH_POLL_INTERVAL_MS), token)) ===
+        this.deps.imageTag
+      );
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -368,6 +410,8 @@ export class LocalStackController {
     );
     const template = await readFile(path.join(this.deps.resourceDir, STACK_ENV_TEMPLATE), "utf8");
     await ensureStackEnv(this.deps.stackDir, template, this.deps.randomHex);
+    const stackToken = await ensureStackToken(this.deps.stackDir, this.deps.randomHex);
+    this.currentStackToken = stackToken;
 
     this.push({ type: "pull-start" });
     const pulled = await this.compose(binary, ["pull"], PULL_TIMEOUT_MS, signal);
@@ -401,7 +445,7 @@ export class LocalStackController {
     const sleep = this.deps.sleep ?? defaultSleep;
     const deadline = Date.now() + (this.deps.healthTimeoutMs ?? STACK_HEALTH_TIMEOUT_MS);
     while (!signal.aborted) {
-      if (await this.deps.probe(signal)) {
+      if ((await this.deps.probe(signal, stackToken)) === this.deps.imageTag) {
         this.push({ type: "ready" });
         return;
       }
@@ -422,6 +466,9 @@ export class LocalStackController {
       env: dockerSpawnEnv(this.deps.platform, this.deps.env, binary, {
         RAKAZO_IMAGE_TAG: this.deps.imageTag,
         RAKAZO_COMPUTER_IMAGE_TAG: this.deps.imageTag,
+        ...(this.currentStackToken === null
+          ? {}
+          : { RAKAZO_DESKTOP_STACK_TOKEN: this.currentStackToken }),
         COMPOSE_PROGRESS: "plain",
       }),
       timeoutMs,

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -232,10 +232,10 @@ export interface LocalStackDeps {
   run: RunDocker;
   stackDir: string;
   resourceDir: string;
+  localWebUrl: string;
   imageTag: string;
-  /** Answers whether the web app is reachable; the final readiness gate. */
   /** Returns the authenticated running image tag, or null for any other listener. */
-  probe: (signal: AbortSignal, token: string) => Promise<string | null>;
+  probe: (url: string, signal: AbortSignal, token: string) => Promise<string | null>;
   randomHex: (bytes: number) => string;
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
   healthTimeoutMs?: number;
@@ -277,13 +277,13 @@ export class LocalStackController {
   }
 
   /** Fast path for launch: only a stack with our private token and desired image may be reused. */
-  async matchesDesiredStack(): Promise<boolean> {
+  async matchesDesiredStack(url = this.deps.localWebUrl): Promise<boolean> {
     const token = await readStackToken(this.deps.stackDir);
     if (token === null) return false;
     this.currentStackToken = token;
     try {
       return (
-        (await this.deps.probe(AbortSignal.timeout(HEALTH_POLL_INTERVAL_MS), token)) ===
+        (await this.deps.probe(url, AbortSignal.timeout(HEALTH_POLL_INTERVAL_MS), token)) ===
         this.deps.imageTag
       );
     } catch {
@@ -445,7 +445,9 @@ export class LocalStackController {
     const sleep = this.deps.sleep ?? defaultSleep;
     const deadline = Date.now() + (this.deps.healthTimeoutMs ?? STACK_HEALTH_TIMEOUT_MS);
     while (!signal.aborted) {
-      if ((await this.deps.probe(signal, stackToken)) === this.deps.imageTag) {
+      if (
+        (await this.deps.probe(this.deps.localWebUrl, signal, stackToken)) === this.deps.imageTag
+      ) {
         this.push({ type: "ready" });
         return;
       }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -897,12 +897,13 @@ app.whenReady().then(async () => {
       resourcesPath: process.resourcesPath,
       appPath: app.getAppPath(),
     }),
+    localWebUrl: LOCAL_WEB_URL,
     imageTag: resolveImageTag({
       version: app.getVersion(),
       packaged: app.isPackaged,
       override: process.env.RAKAZO_IMAGE_TAG,
     }),
-    probe: (signal, token) => probeManagedStack(LOCAL_WEB_URL, token, signal),
+    probe: (url, signal, token) => probeManagedStack(url, token, signal),
     randomHex: (bytes) => randomBytes(bytes).toString("hex"),
   });
   currentSetup = await readSetup(userDataDir);
@@ -1000,7 +1001,7 @@ app.whenReady().then(async () => {
         };
       }
 
-      if (setup.mode === "new" && !(await localStack.matchesDesiredStack())) {
+      if (setup.mode === "new" && !(await localStack.matchesDesiredStack(setup.serverUrl))) {
         return {
           ok: false,
           error: "The app-managed Rakazo services are not ready. Retry setup.",
@@ -1104,7 +1105,7 @@ app.whenReady().then(async () => {
     showSetupWindow();
   } else if (target.source === "saved") {
     const managedStackReady =
-      currentSetup?.mode === "new" ? await localStack.matchesDesiredStack() : null;
+      currentSetup?.mode === "new" ? await localStack.matchesDesiredStack(target.url) : null;
     const reachability = managedStackReady === null ? await probeServer(target.url) : null;
     if (managedStackReady === true || reachability?.ok === true) {
       if (await openApp(target.url)) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,6 +29,7 @@ import {
   desktopStackImageTag,
   isRakazoHealth,
   managedLocalOpenUrl,
+  maySendDesktopStackToken,
   normalizeServerUrl,
   parseSetupInput,
   probeFailureMessage,
@@ -686,7 +687,8 @@ async function probeManagedStack(
   signal?: AbortSignal,
 ): Promise<string | null> {
   const url = normalizeServerUrl(rawUrl);
-  if (url === null) return null;
+  // Never put the private stack token on a cleartext LAN or .local hop.
+  if (url === null || !maySendDesktopStackToken(url)) return null;
   const timeout = AbortSignal.timeout(PROBE_TIMEOUT_MS);
   try {
     const response = await net.fetch(`${url}${DESKTOP_STACK_PROBE_PATH}`, {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -26,6 +26,7 @@ import {
 } from "./renderer-assets.js";
 import {
   DEFAULT_LOCAL_WEB_URL,
+  desktopStackImageTag,
   isRakazoHealth,
   normalizeServerUrl,
   parseSetupInput,
@@ -49,6 +50,8 @@ const PERFORMANCE_USER_DATA = process.env.RAKAZO_PERFORMANCE_USER_DATA;
 const LOCAL_WEB_URL = process.env.RAKAZO_LOCAL_WEB_URL?.trim() || DEFAULT_LOCAL_WEB_URL;
 const PROBE_TIMEOUT_MS = 8_000;
 const PROBE_RESPONSE_LIMIT_BYTES = 64 * 1024;
+const DESKTOP_STACK_PROBE_PATH = "/.well-known/rakazo-desktop-stack";
+const DESKTOP_STACK_TOKEN_HEADER = "x-rakazo-desktop-stack-token";
 let mainWindow: BrowserWindow | null = null;
 let setupWindow: BrowserWindow | null = null;
 const bundledRendererInstallations = new Set<string>();
@@ -675,6 +678,31 @@ async function probeServer(rawUrl: string, signal?: AbortSignal): Promise<Deskto
   }
 }
 
+/** A public health response is not enough: another checkout may own the same fixed port. */
+async function probeManagedStack(
+  rawUrl: string,
+  token: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const url = normalizeServerUrl(rawUrl);
+  if (url === null) return null;
+  const timeout = AbortSignal.timeout(PROBE_TIMEOUT_MS);
+  try {
+    const response = await net.fetch(`${url}${DESKTOP_STACK_PROBE_PATH}`, {
+      method: "GET",
+      headers: { [DESKTOP_STACK_TOKEN_HEADER]: token },
+      cache: "no-store",
+      credentials: "omit",
+      redirect: "manual",
+      signal: signal ? AbortSignal.any([timeout, signal]) : timeout,
+    });
+    if (!response.ok) return null;
+    return desktopStackImageTag(await limitedJson(response));
+  } catch {
+    return null;
+  }
+}
+
 async function limitedJson(response: Response): Promise<unknown> {
   if (response.body === null) return null;
   const reader = response.body.getReader();
@@ -874,7 +902,7 @@ app.whenReady().then(async () => {
       packaged: app.isPackaged,
       override: process.env.RAKAZO_IMAGE_TAG,
     }),
-    probe: async (signal) => (await probeServer(LOCAL_WEB_URL, signal)).ok,
+    probe: (signal, token) => probeManagedStack(LOCAL_WEB_URL, token, signal),
     randomHex: (bytes) => randomBytes(bytes).toString("hex"),
   });
   currentSetup = await readSetup(userDataDir);
@@ -969,6 +997,13 @@ app.whenReady().then(async () => {
           ok: false,
           error:
             "Enter a valid server address. Public servers require HTTPS; a new local instance must use localhost.",
+        };
+      }
+
+      if (setup.mode === "new" && !(await localStack.matchesDesiredStack())) {
+        return {
+          ok: false,
+          error: "The app-managed Rakazo services are not ready. Retry setup.",
         };
       }
 
@@ -1068,19 +1103,21 @@ app.whenReady().then(async () => {
   if (target.kind === "setup") {
     showSetupWindow();
   } else if (target.source === "saved") {
-    const reachability = await probeServer(target.url);
-    if (reachability.ok) {
+    const managedStackReady =
+      currentSetup?.mode === "new" ? await localStack.matchesDesiredStack() : null;
+    const reachability = managedStackReady === null ? await probeServer(target.url) : null;
+    if (managedStackReady === true || reachability?.ok === true) {
       if (await openApp(target.url)) {
         commitPendingAppSwitch();
         destroySetupWindow();
       }
-    } else if (currentSetup?.mode === "new") {
-      // The app-managed stack is down (reboot, Docker quit): bring it back up and let
-      // the setup window follow along instead of asking for a server address again.
+    } else if (managedStackReady === false) {
+      // Missing, stale, or owned by another process: reconcile the app-managed stack
+      // before any API or computer traffic is allowed through this fixed origin.
       void localStack.start();
       showSetupWindow();
     } else {
-      showSetupWindow(`Could not reconnect to the saved server. ${reachability.error}`);
+      showSetupWindow(`Could not reconnect to the saved server. ${reachability?.error}`);
     }
   } else {
     if (await openApp(target.url)) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_LOCAL_WEB_URL,
   desktopStackImageTag,
   isRakazoHealth,
+  managedLocalOpenUrl,
   normalizeServerUrl,
   parseSetupInput,
   probeFailureMessage,
@@ -1001,19 +1002,25 @@ app.whenReady().then(async () => {
         };
       }
 
-      if (setup.mode === "new" && !(await localStack.matchesDesiredStack(setup.serverUrl))) {
-        return {
-          ok: false,
-          error: "The app-managed Rakazo services are not ready. Retry setup.",
-        };
+      // Managed stacks authenticate LOCAL_WEB_URL only; never open a different loopback.
+      let openSetup = setup;
+      if (setup.mode === "new") {
+        const managedUrl = managedLocalOpenUrl(setup.serverUrl, LOCAL_WEB_URL);
+        if (managedUrl === null || !(await localStack.matchesDesiredStack())) {
+          return {
+            ok: false,
+            error: "The app-managed Rakazo services are not ready. Retry setup.",
+          };
+        }
+        openSetup = { mode: "new", serverUrl: managedUrl };
       }
 
-      const reachability = await probeServer(setup.serverUrl);
+      const reachability = await probeServer(openSetup.serverUrl);
       if (!reachability.ok) return { ok: false, error: reachability.error };
 
       // Open before persisting so a failed renderer load keeps the last working setup.
-      currentSetup = setup;
-      const opened = await openApp(setup.serverUrl);
+      currentSetup = openSetup;
+      const opened = await openApp(openSetup.serverUrl);
       if (!opened) {
         currentSetup = previousSetup;
         return {
@@ -1028,7 +1035,7 @@ app.whenReady().then(async () => {
           ? watchRendererUntilCommitted(appWindow)
           : null;
       try {
-        await writeSetup(userDataDir, setup);
+        await writeSetup(userDataDir, openSetup);
         if (rendererWatch?.crashed()) {
           const message = await recoverFromCrashedSave(userDataDir, previousSetup, previousUrl);
           return { ok: false, error: message };
@@ -1104,21 +1111,31 @@ app.whenReady().then(async () => {
   if (target.kind === "setup") {
     showSetupWindow();
   } else if (target.source === "saved") {
-    const managedStackReady =
-      currentSetup?.mode === "new" ? await localStack.matchesDesiredStack(target.url) : null;
-    const reachability = managedStackReady === null ? await probeServer(target.url) : null;
-    if (managedStackReady === true || reachability?.ok === true) {
-      if (await openApp(target.url)) {
-        commitPendingAppSwitch();
-        destroySetupWindow();
+    if (currentSetup?.mode === "new") {
+      const managedUrl = managedLocalOpenUrl(target.url, LOCAL_WEB_URL);
+      const managedStackReady =
+        managedUrl !== null ? await localStack.matchesDesiredStack() : false;
+      if (managedStackReady && managedUrl !== null) {
+        if (await openApp(managedUrl)) {
+          commitPendingAppSwitch();
+          destroySetupWindow();
+        }
+      } else {
+        // Missing, stale, foreign, or owned by another process: reconcile the
+        // app-managed stack before any API or computer traffic is allowed.
+        void localStack.start();
+        showSetupWindow();
       }
-    } else if (managedStackReady === false) {
-      // Missing, stale, or owned by another process: reconcile the app-managed stack
-      // before any API or computer traffic is allowed through this fixed origin.
-      void localStack.start();
-      showSetupWindow();
     } else {
-      showSetupWindow(`Could not reconnect to the saved server. ${reachability?.error}`);
+      const reachability = await probeServer(target.url);
+      if (reachability.ok) {
+        if (await openApp(target.url)) {
+          commitPendingAppSwitch();
+          destroySetupWindow();
+        }
+      } else {
+        showSetupWindow(`Could not reconnect to the saved server. ${reachability.error}`);
+      }
     }
   } else {
     if (await openApp(target.url)) {

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -70,9 +70,9 @@ describe("managed local open URL", () => {
     expect(managedLocalOpenUrl("http://127.0.0.1:5173/", DEFAULT_LOCAL_WEB_URL)).toBe(
       "http://127.0.0.1:5173",
     );
-    expect(
-      managedLocalOpenUrl("http://127.0.0.1:5199", "http://127.0.0.1:5199/path?x=1"),
-    ).toBe("http://127.0.0.1:5199");
+    expect(managedLocalOpenUrl("http://127.0.0.1:5199", "http://127.0.0.1:5199/path?x=1")).toBe(
+      "http://127.0.0.1:5199",
+    );
   });
 
   it("rejects a different loopback origin even when both are local", () => {

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_LOCAL_WEB_URL,
   desktopStackImageTag,
   isRakazoHealth,
+  managedLocalOpenUrl,
   normalizeServerUrl,
   parseSetupInput,
   parseStoredSetup,
@@ -60,6 +61,23 @@ describe("server address normalization", () => {
 
   it("rejects embedded credentials rather than writing them to disk", () => {
     expect(normalizeServerUrl("https://user:secret@rakazo.example.com")).toBeNull();
+  });
+});
+
+describe("managed local open URL", () => {
+  it("returns the authenticated managed origin when the request matches", () => {
+    expect(managedLocalOpenUrl("http://127.0.0.1:5173/", DEFAULT_LOCAL_WEB_URL)).toBe(
+      "http://127.0.0.1:5173",
+    );
+    expect(
+      managedLocalOpenUrl("http://127.0.0.1:5199", "http://127.0.0.1:5199/path?x=1"),
+    ).toBe("http://127.0.0.1:5199");
+  });
+
+  it("rejects a different loopback origin even when both are local", () => {
+    expect(managedLocalOpenUrl("http://127.0.0.1:5199", DEFAULT_LOCAL_WEB_URL)).toBeNull();
+    expect(managedLocalOpenUrl("http://localhost:5173", DEFAULT_LOCAL_WEB_URL)).toBeNull();
+    expect(managedLocalOpenUrl("https://rakazo.example.com", DEFAULT_LOCAL_WEB_URL)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -4,6 +4,7 @@ import {
   desktopStackImageTag,
   isRakazoHealth,
   managedLocalOpenUrl,
+  maySendDesktopStackToken,
   normalizeServerUrl,
   parseSetupInput,
   parseStoredSetup,
@@ -78,6 +79,16 @@ describe("managed local open URL", () => {
     expect(managedLocalOpenUrl("http://127.0.0.1:5199", DEFAULT_LOCAL_WEB_URL)).toBeNull();
     expect(managedLocalOpenUrl("http://localhost:5173", DEFAULT_LOCAL_WEB_URL)).toBeNull();
     expect(managedLocalOpenUrl("https://rakazo.example.com", DEFAULT_LOCAL_WEB_URL)).toBeNull();
+  });
+});
+
+describe("desktop stack token transport", () => {
+  it("allows HTTPS and loopback HTTP only", () => {
+    expect(maySendDesktopStackToken("https://rakazo.example.com")).toBe(true);
+    expect(maySendDesktopStackToken("http://127.0.0.1:5173")).toBe(true);
+    expect(maySendDesktopStackToken("http://localhost:5173")).toBe(true);
+    expect(maySendDesktopStackToken("http://10.0.0.8:5173")).toBe(false);
+    expect(maySendDesktopStackToken("http://rakazo.local:5173")).toBe(false);
   });
 });
 

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_LOCAL_WEB_URL,
+  desktopStackImageTag,
   isRakazoHealth,
   normalizeServerUrl,
   parseSetupInput,
@@ -174,6 +175,15 @@ describe("Rakazo health response", () => {
     expect(isRakazoHealth({ json: { ok: true, version: "0.1.0" } })).toBe(true);
     expect(isRakazoHealth({ json: { ok: true } })).toBe(false);
     expect(isRakazoHealth({ ok: true, version: "0.1.0" })).toBe(false);
+  });
+});
+
+describe("managed stack response", () => {
+  it("returns only a non-empty authenticated image tag", () => {
+    expect(desktopStackImageTag({ ok: true, imageTag: "v0.2.0" })).toBe("v0.2.0");
+    expect(desktopStackImageTag({ ok: true, imageTag: "" })).toBeNull();
+    expect(desktopStackImageTag({ ok: false, imageTag: "v0.2.0" })).toBeNull();
+    expect(desktopStackImageTag({ json: { ok: true, imageTag: "v0.2.0" } })).toBeNull();
   });
 });
 

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -60,6 +60,22 @@ export function managedLocalOpenUrl(
   return managed;
 }
 
+/**
+ * The private managed-stack token may travel over HTTPS anywhere, or over HTTP
+ * only to loopback. Private-network and .local HTTP stay cleartext on a LAN, so
+ * they must not receive the token.
+ */
+export function maySendDesktopStackToken(serverUrl: string): boolean {
+  try {
+    const url = new URL(serverUrl);
+    if (url.protocol === "https:") return true;
+    if (url.protocol === "http:") return isLoopbackHost(url.hostname);
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 /** Validates an untrusted value (saved file or IPC payload) into a usable setup. */
 export function parseSetupInput(value: unknown): DesktopSetup | null {
   if (typeof value !== "object" || value === null) return null;

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -46,6 +46,20 @@ export function normalizeServerUrl(input: string): string | null {
   return url.origin;
 }
 
+/**
+ * Managed ("new") setups may only open the configured local stack origin.
+ * A saved or IPC URL that normalizes to a different loopback host/port is rejected.
+ */
+export function managedLocalOpenUrl(
+  requestedUrl: string,
+  localWebUrl: string,
+): string | null {
+  const managed = normalizeServerUrl(localWebUrl);
+  const requested = normalizeServerUrl(requestedUrl);
+  if (managed === null || requested === null || requested !== managed) return null;
+  return managed;
+}
+
 /** Validates an untrusted value (saved file or IPC payload) into a usable setup. */
 export function parseSetupInput(value: unknown): DesktopSetup | null {
   if (typeof value !== "object" || value === null) return null;

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -50,10 +50,7 @@ export function normalizeServerUrl(input: string): string | null {
  * Managed ("new") setups may only open the configured local stack origin.
  * A saved or IPC URL that normalizes to a different loopback host/port is rejected.
  */
-export function managedLocalOpenUrl(
-  requestedUrl: string,
-  localWebUrl: string,
-): string | null {
+export function managedLocalOpenUrl(requestedUrl: string, localWebUrl: string): string | null {
   const managed = normalizeServerUrl(localWebUrl);
   const requested = normalizeServerUrl(requestedUrl);
   if (managed === null || requested === null || requested !== managed) return null;

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { isIP } from "node:net";
-import type { DesktopSetup } from "@rakazo/contracts";
+import type { DesktopSetup, DesktopStackProbeResponse } from "@rakazo/contracts";
 
 /** Where `pnpm dev` serves the Rakazo web app on this machine. */
 export const DEFAULT_LOCAL_WEB_URL = "http://127.0.0.1:5173";
@@ -151,6 +151,12 @@ export function isRakazoHealth(value: unknown): boolean {
     (json as { ok?: unknown }).ok === true &&
     typeof (json as { version?: unknown }).version === "string"
   );
+}
+
+export function desktopStackImageTag(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  const { ok, imageTag } = value as Partial<DesktopStackProbeResponse>;
+  return ok === true && typeof imageTag === "string" && imageTag !== "" ? imageTag : null;
 }
 
 function isLoopbackHost(hostname: string) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,11 @@
+import { timingSafeEqual } from "node:crypto";
 import http from "node:http";
 import https from "node:https";
 import net from "node:net";
 import path from "node:path";
 import tls from "node:tls";
 import { lingui } from "@lingui/vite-plugin";
+import type { DesktopStackProbeResponse } from "@rakazo/contracts";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv, type PreviewServer, type ViteDevServer } from "vite";
@@ -16,6 +18,41 @@ import {
 } from "./src/screen-proxy.js";
 
 const webPort = Number(process.env.WEB_PORT ?? 5173);
+const DESKTOP_STACK_PROBE_PATH = "/.well-known/rakazo-desktop-stack";
+const DESKTOP_STACK_TOKEN_HEADER = "x-rakazo-desktop-stack-token";
+
+function equalStackToken(expected: string, supplied: string | string[] | undefined) {
+  if (expected === "" || typeof supplied !== "string") return false;
+  const expectedBytes = Buffer.from(expected);
+  const suppliedBytes = Buffer.from(supplied);
+  return (
+    expectedBytes.byteLength === suppliedBytes.byteLength &&
+    timingSafeEqual(expectedBytes, suppliedBytes)
+  );
+}
+
+function attachDesktopStackProbe(
+  server: ViteDevServer | PreviewServer,
+  token: string,
+  imageTag: string,
+) {
+  server.middlewares.use((req, res, next) => {
+    if (req.url?.split("?", 1)[0] !== DESKTOP_STACK_PROBE_PATH) {
+      next();
+      return;
+    }
+    if (!equalStackToken(token, req.headers[DESKTOP_STACK_TOKEN_HEADER])) {
+      res.statusCode = 404;
+      res.end("Not found");
+      return;
+    }
+    const body: DesktopStackProbeResponse = { ok: true, imageTag };
+    res.statusCode = 200;
+    res.setHeader("cache-control", "no-store");
+    res.setHeader("content-type", "application/json; charset=utf-8");
+    res.end(JSON.stringify(body));
+  });
+}
 
 function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string) {
   server.middlewares.use((req, res, next) => {
@@ -127,6 +164,9 @@ export default defineConfig(({ mode }) => {
       BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET ?? rootEnv.BETTER_AUTH_SECRET,
     });
   const performanceAssetDelayMs = Number(process.env.RAKAZO_PERFORMANCE_ASSET_DELAY_MS ?? 0);
+  const desktopStackToken =
+    process.env.RAKAZO_DESKTOP_STACK_TOKEN ?? rootEnv.RAKAZO_DESKTOP_STACK_TOKEN ?? "";
+  const imageTag = process.env.RAKAZO_IMAGE_TAG ?? rootEnv.RAKAZO_IMAGE_TAG ?? "edge";
   return {
     plugins: [
       react({
@@ -136,6 +176,12 @@ export default defineConfig(({ mode }) => {
       }),
       lingui(),
       tailwindcss(),
+      {
+        name: "rakazo-desktop-stack-probe",
+        configureServer: (server) => attachDesktopStackProbe(server, desktopStackToken, imageTag),
+        configurePreviewServer: (server) =>
+          attachDesktopStackProbe(server, desktopStackToken, imageTag),
+      },
       {
         name: "rakazo-performance-asset-delay",
         configurePreviewServer(server) {

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -204,6 +204,10 @@ services:
       NODE_ENV: production
       API_PROXY_TARGET: http://api:3100
       RAKAZO_HOST: ${RAKAZO_HOST:-localhost}
+      # Set only by the packaged desktop app. Its authenticated probe prevents a
+      # source dev server on the same host port from impersonating this stack.
+      RAKAZO_DESKTOP_STACK_TOKEN: ${RAKAZO_DESKTOP_STACK_TOKEN:-}
+      RAKAZO_IMAGE_TAG: ${RAKAZO_IMAGE_TAG:-edge}
       SCREEN_PROXY_SECRET: ${SCREEN_PROXY_SECRET:?Set SCREEN_PROXY_SECRET in .env}
     ports:
       - "127.0.0.1:5173:5173"

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -81,6 +81,11 @@ export interface DesktopReachability {
   error?: string;
 }
 
+export interface DesktopStackProbeResponse {
+  ok: true;
+  imageTag: string;
+}
+
 /**
  * Lifecycle of the Docker Compose stack the desktop app manages for mode `new`.
  * `docker-missing` and `docker-not-running` wait for the person to act; `ready` and


### PR DESCRIPTION
## Why

The packaged desktop app trusted any healthy service listening on its saved loopback port. A source development server could therefore supply API and computer-screen routes behind the bundled production renderer, and an older managed container stack could remain attached after an app update.

## What changed

- Give each app-managed Compose stack a private local identity token.
- Add a token-authenticated web probe that reports the running image tag.
- Reuse a saved local stack only when both its identity and expected release tag match.
- Reconcile missing, unrelated, or stale listeners before forwarding app traffic.
- Extend desktop unit and CI Electron fixtures for token creation, listener rejection, stale-version rejection, and valid-stack reuse.

## Testing

- Desktop unit suite passed (192 tests).
- Contracts unit suite passed (25 tests).
- Desktop, web, and contracts TypeScript checks passed.
- Production web build and packaged macOS directory build passed.
- Local HTTP boundary check confirmed an ordinary development listener is rejected, the matching managed preview is accepted, an invalid token returns 404, and an older image tag is rejected.
- Playwright discovered the updated desktop E2E coverage; the windowed suite is left to CI as required.
- The wider unit run passed 2,422 tests; one unrelated background-process cleanup test timed out locally and also timed out when retried alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop now securely identifies its managed local stack with a private token.
  * Compatible saved stacks are reused automatically when their identity and image version match.
  * Setup and reconnection verify the stack’s origin, authentication, and version before proceeding.
  * Stack status checks now report the running image version.

* **Bug Fixes**
  * Prevented unrelated, outdated, or unauthorized local servers from being mistaken for the desktop app’s stack.
  * Restricted private-token transmission to secure or local connections.
  * Improved handling when the managed stack is unavailable or mismatched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->