### PR TITLE
Create bots into chat, delay setup card, and collapse the bots sidebar

### DIFF
--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -5,6 +5,7 @@ import {
   createThreadMessage,
   createThreadMessageInTransaction,
   IsolationError,
+  type Prisma,
   type PrismaClient,
   type ThreadEvents,
 } from "@rakazo/db";
@@ -171,7 +172,7 @@ export async function promptFocus(
   ];
   // Check + insert in one transaction so concurrent promptFocus calls cannot
   // both pass the no-choice gate and post duplicate focus cards.
-  const message = await deps.prisma.$transaction(async (tx) => {
+  const message = await deps.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     // Serialize concurrent promptFocus callers on this thread before the gate check.
     await tx.$executeRaw`SELECT id FROM threads WHERE id = ${thread.id} FOR UPDATE`;
     const recent = await tx.message.findMany({
@@ -204,20 +205,32 @@ export async function dismissFocus(
 ): Promise<void> {
   const { bot, thread } = await requireBotThread(deps, actor, botId);
   const target = { spaceId: actor.spaceId, botId: bot.id, threadId: thread.id };
-  const recent = await deps.prisma.message.findMany({
-    where: { threadId: thread.id },
-    orderBy: { createdAt: "asc" },
+  const claimed = await deps.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.$executeRaw`SELECT id FROM threads WHERE id = ${thread.id} FOR UPDATE`;
+    const recent = await tx.message.findMany({
+      where: { threadId: thread.id },
+      orderBy: { createdAt: "asc" },
+    });
+    const pending = recent.find((message) =>
+      messageHasPendingChoice(message.blocks as MessageBlock[]),
+    );
+    if (!pending) return null;
+    const blocks = (pending.blocks as MessageBlock[]).map((block) =>
+      block.kind === "choice" && !block.answerId
+        ? { ...block, answerId: FOCUS_DISMISSED_ANSWER_ID }
+        : block,
+    );
+    await tx.message.update({ where: { id: pending.id }, data: { blocks } });
+    return { messageId: pending.id, blocks };
   });
-  const pending = recent.find((message) =>
-    messageHasPendingChoice(message.blocks as MessageBlock[]),
-  );
-  if (!pending) return;
-  const blocks = (pending.blocks as MessageBlock[]).map((block) =>
-    block.kind === "choice" && !block.answerId
-      ? { ...block, answerId: FOCUS_DISMISSED_ANSWER_ID }
-      : block,
-  );
-  await updateBlocks(deps, target, pending.id, blocks);
+  if (!claimed) return;
+  await deps.events.append({
+    spaceId: target.spaceId,
+    threadId: target.threadId,
+    botId: target.botId,
+    type: "thread.message.updated",
+    payload: { messageId: claimed.messageId, role: "bot", blocks: claimed.blocks },
+  });
 }
 
 export async function chooseFocus(
@@ -231,18 +244,30 @@ export async function chooseFocus(
   const { bot, thread } = await requireBotThread(deps, actor, botId);
   const target = { spaceId: actor.spaceId, botId: bot.id, threadId: thread.id };
 
-  const recent = await deps.prisma.message.findMany({
-    where: { threadId: thread.id },
-    orderBy: { createdAt: "asc" },
+  const claimed = await deps.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.$executeRaw`SELECT id FROM threads WHERE id = ${thread.id} FOR UPDATE`;
+    const recent = await tx.message.findMany({
+      where: { threadId: thread.id },
+      orderBy: { createdAt: "asc" },
+    });
+    const pending = recent.find((message) =>
+      messageHasPendingChoice(message.blocks as MessageBlock[]),
+    );
+    if (!pending) return null;
+    const blocks = (pending.blocks as MessageBlock[]).map((block) =>
+      block.kind === "choice" ? { ...block, answerId: option.id } : block,
+    );
+    await tx.message.update({ where: { id: pending.id }, data: { blocks } });
+    return { messageId: pending.id, blocks };
   });
-  const pending = recent.find((message) =>
-    messageHasPendingChoice(message.blocks as MessageBlock[]),
-  );
-  if (!pending) return;
-  const blocks = (pending.blocks as MessageBlock[]).map((block) =>
-    block.kind === "choice" ? { ...block, answerId: option.id } : block,
-  );
-  await updateBlocks(deps, target, pending.id, blocks);
+  if (!claimed) return;
+  await deps.events.append({
+    spaceId: target.spaceId,
+    threadId: target.threadId,
+    botId: target.botId,
+    type: "thread.message.updated",
+    payload: { messageId: claimed.messageId, role: "bot", blocks: claimed.blocks },
+  });
 
   // Keep the name and title the user chose when creating the bot; the focus
   // step only suggests apps, it must not rename the bot.

--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -2,7 +2,7 @@ import type { ComposioProvider } from "@rakazo/adapters";
 import type { Actor, MessageBlock } from "@rakazo/contracts";
 import { featuredConnectorProvidersMatch } from "@rakazo/core";
 import {
-  createThreadMessage,
+  appendEventInTransaction,
   createThreadMessageInTransaction,
   IsolationError,
   type Prisma,
@@ -93,19 +93,23 @@ async function post(
   target: { spaceId: string; botId: string; threadId: string },
   blocks: MessageBlock[],
 ): Promise<string> {
-  const message = await createThreadMessage(deps.prisma, {
-    threadId: target.threadId,
-    role: "bot",
-    blocks,
+  const committed = await deps.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    const message = await createThreadMessageInTransaction(tx, {
+      threadId: target.threadId,
+      role: "bot",
+      blocks,
+    });
+    const event = await appendEventInTransaction(tx, {
+      spaceId: target.spaceId,
+      threadId: target.threadId,
+      botId: target.botId,
+      type: "thread.message.created",
+      payload: { messageId: message.id, role: "bot", blocks },
+    });
+    return { message, event };
   });
-  await deps.events.append({
-    spaceId: target.spaceId,
-    threadId: target.threadId,
-    botId: target.botId,
-    type: "thread.message.created",
-    payload: { messageId: message.id, role: "bot", blocks },
-  });
-  return message.id;
+  await deps.events.notify(target.threadId, committed.event.seq);
+  return committed.message.id;
 }
 
 async function updateBlocks(
@@ -114,14 +118,17 @@ async function updateBlocks(
   messageId: string,
   blocks: MessageBlock[],
 ): Promise<void> {
-  await deps.prisma.message.update({ where: { id: messageId }, data: { blocks } });
-  await deps.events.append({
-    spaceId: target.spaceId,
-    threadId: target.threadId,
-    botId: target.botId,
-    type: "thread.message.updated",
-    payload: { messageId, role: "bot", blocks },
+  const event = await deps.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    await tx.message.update({ where: { id: messageId }, data: { blocks } });
+    return appendEventInTransaction(tx, {
+      spaceId: target.spaceId,
+      threadId: target.threadId,
+      botId: target.botId,
+      type: "thread.message.updated",
+      payload: { messageId, role: "bot", blocks },
+    });
   });
+  await deps.events.notify(target.threadId, event.seq);
 }
 
 /** Sentinel answerId for a focus card the user dismissed without choosing. */
@@ -170,9 +177,9 @@ export async function promptFocus(
       options: FOCUS_OPTIONS.map(({ id, letter, label }) => ({ id, letter, label })),
     },
   ];
-  // Check + insert in one transaction so concurrent promptFocus calls cannot
-  // both pass the no-choice gate and post duplicate focus cards.
-  const message = await deps.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+  // Check + insert + event in one transaction so concurrent promptFocus calls
+  // cannot duplicate cards, and a concurrent user send cannot publish first.
+  const committed = await deps.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     // Serialize concurrent promptFocus callers on this thread before the gate check.
     await tx.$executeRaw`SELECT id FROM threads WHERE id = ${thread.id} FOR UPDATE`;
     const recent = await tx.message.findMany({
@@ -182,20 +189,22 @@ export async function promptFocus(
     });
     if (recent.some((message) => message.role === "user")) return null;
     if (recent.some((message) => messageHasChoice(message.blocks as MessageBlock[]))) return null;
-    return createThreadMessageInTransaction(tx, {
+    const message = await createThreadMessageInTransaction(tx, {
       threadId: target.threadId,
       role: "bot",
       blocks,
     });
+    const event = await appendEventInTransaction(tx, {
+      spaceId: target.spaceId,
+      threadId: target.threadId,
+      botId: target.botId,
+      type: "thread.message.created",
+      payload: { messageId: message.id, role: "bot", blocks },
+    });
+    return { message, event };
   });
-  if (!message) return;
-  await deps.events.append({
-    spaceId: target.spaceId,
-    threadId: target.threadId,
-    botId: target.botId,
-    type: "thread.message.created",
-    payload: { messageId: message.id, role: "bot", blocks },
-  });
+  if (!committed) return;
+  await deps.events.notify(target.threadId, committed.event.seq);
 }
 
 export async function dismissFocus(
@@ -221,16 +230,17 @@ export async function dismissFocus(
         : block,
     );
     await tx.message.update({ where: { id: pending.id }, data: { blocks } });
-    return { messageId: pending.id, blocks };
+    const event = await appendEventInTransaction(tx, {
+      spaceId: target.spaceId,
+      threadId: target.threadId,
+      botId: target.botId,
+      type: "thread.message.updated",
+      payload: { messageId: pending.id, role: "bot", blocks },
+    });
+    return { messageId: pending.id, blocks, event };
   });
   if (!claimed) return;
-  await deps.events.append({
-    spaceId: target.spaceId,
-    threadId: target.threadId,
-    botId: target.botId,
-    type: "thread.message.updated",
-    payload: { messageId: claimed.messageId, role: "bot", blocks: claimed.blocks },
-  });
+  await deps.events.notify(target.threadId, claimed.event.seq);
 }
 
 export async function chooseFocus(
@@ -258,16 +268,17 @@ export async function chooseFocus(
       block.kind === "choice" ? { ...block, answerId: option.id } : block,
     );
     await tx.message.update({ where: { id: pending.id }, data: { blocks } });
-    return { messageId: pending.id, blocks };
+    const event = await appendEventInTransaction(tx, {
+      spaceId: target.spaceId,
+      threadId: target.threadId,
+      botId: target.botId,
+      type: "thread.message.updated",
+      payload: { messageId: pending.id, role: "bot", blocks },
+    });
+    return { messageId: pending.id, blocks, event };
   });
   if (!claimed) return;
-  await deps.events.append({
-    spaceId: target.spaceId,
-    threadId: target.threadId,
-    botId: target.botId,
-    type: "thread.message.updated",
-    payload: { messageId: claimed.messageId, role: "bot", blocks: claimed.blocks },
-  });
+  await deps.events.notify(target.threadId, claimed.event.seq);
 
   // Keep the name and title the user chose when creating the bot; the focus
   // step only suggests apps, it must not rename the bot.

--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -3,6 +3,7 @@ import type { Actor, MessageBlock } from "@rakazo/contracts";
 import { featuredConnectorProvidersMatch } from "@rakazo/core";
 import {
   createThreadMessage,
+  createThreadMessageInTransaction,
   IsolationError,
   type PrismaClient,
   type ThreadEvents,
@@ -160,21 +161,40 @@ export async function promptFocus(
   botId: string,
 ): Promise<void> {
   const { bot, thread } = await requireBotThread(deps, actor, botId);
-  const recent = await deps.prisma.message.findMany({
-    where: { threadId: thread.id },
-    select: { role: true, blocks: true },
-    orderBy: { createdAt: "asc" },
-  });
-  if (recent.some((message) => message.role === "user")) return;
-  if (recent.some((message) => messageHasChoice(message.blocks as MessageBlock[]))) return;
   const target = { spaceId: actor.spaceId, botId: bot.id, threadId: thread.id };
-  await post(deps, target, [
+  const blocks: MessageBlock[] = [
     {
       kind: "choice",
       question: "What do you want me on first?",
       options: FOCUS_OPTIONS.map(({ id, letter, label }) => ({ id, letter, label })),
     },
-  ]);
+  ];
+  // Check + insert in one transaction so concurrent promptFocus calls cannot
+  // both pass the no-choice gate and post duplicate focus cards.
+  const message = await deps.prisma.$transaction(async (tx) => {
+    // Serialize concurrent promptFocus callers on this thread before the gate check.
+    await tx.$executeRaw`SELECT id FROM threads WHERE id = ${thread.id} FOR UPDATE`;
+    const recent = await tx.message.findMany({
+      where: { threadId: thread.id },
+      select: { role: true, blocks: true },
+      orderBy: { createdAt: "asc" },
+    });
+    if (recent.some((message) => message.role === "user")) return null;
+    if (recent.some((message) => messageHasChoice(message.blocks as MessageBlock[]))) return null;
+    return createThreadMessageInTransaction(tx, {
+      threadId: target.threadId,
+      role: "bot",
+      blocks,
+    });
+  });
+  if (!message) return;
+  await deps.events.append({
+    spaceId: target.spaceId,
+    threadId: target.threadId,
+    botId: target.botId,
+    type: "thread.message.created",
+    payload: { messageId: message.id, role: "bot", blocks },
+  });
 }
 
 export async function dismissFocus(

--- a/apps/api/src/onboarding.ts
+++ b/apps/api/src/onboarding.ts
@@ -122,6 +122,9 @@ async function updateBlocks(
   });
 }
 
+/** Sentinel answerId for a focus card the user dismissed without choosing. */
+export const FOCUS_DISMISSED_ANSWER_ID = "_dismissed";
+
 export async function startOnboarding(
   deps: OnboardingDeps,
   actor: Actor,
@@ -136,9 +139,35 @@ export async function startOnboarding(
   });
   const firstName = (user?.name ?? "there").split(/\s+/)[0];
   const target = { spaceId: actor.spaceId, botId: bot.id, threadId: thread.id };
+  // Greeting only. The focus card is posted later via promptFocus so non-first
+  // bots can wait ~10s for free typing, or skip if the user already engaged.
   await post(deps, target, [
     { kind: "text", text: `Hey ${firstName}. Fresh start on my side, so I’ll keep this short.` },
   ]);
+}
+
+function messageHasChoice(blocks: MessageBlock[]): boolean {
+  return blocks.some((block) => block.kind === "choice");
+}
+
+function messageHasPendingChoice(blocks: MessageBlock[]): boolean {
+  return blocks.some((block) => block.kind === "choice" && !block.answerId);
+}
+
+export async function promptFocus(
+  deps: OnboardingDeps,
+  actor: Actor,
+  botId: string,
+): Promise<void> {
+  const { bot, thread } = await requireBotThread(deps, actor, botId);
+  const recent = await deps.prisma.message.findMany({
+    where: { threadId: thread.id },
+    select: { role: true, blocks: true },
+    orderBy: { createdAt: "asc" },
+  });
+  if (recent.some((message) => message.role === "user")) return;
+  if (recent.some((message) => messageHasChoice(message.blocks as MessageBlock[]))) return;
+  const target = { spaceId: actor.spaceId, botId: bot.id, threadId: thread.id };
   await post(deps, target, [
     {
       kind: "choice",
@@ -146,6 +175,29 @@ export async function startOnboarding(
       options: FOCUS_OPTIONS.map(({ id, letter, label }) => ({ id, letter, label })),
     },
   ]);
+}
+
+export async function dismissFocus(
+  deps: OnboardingDeps,
+  actor: Actor,
+  botId: string,
+): Promise<void> {
+  const { bot, thread } = await requireBotThread(deps, actor, botId);
+  const target = { spaceId: actor.spaceId, botId: bot.id, threadId: thread.id };
+  const recent = await deps.prisma.message.findMany({
+    where: { threadId: thread.id },
+    orderBy: { createdAt: "asc" },
+  });
+  const pending = recent.find((message) =>
+    messageHasPendingChoice(message.blocks as MessageBlock[]),
+  );
+  if (!pending) return;
+  const blocks = (pending.blocks as MessageBlock[]).map((block) =>
+    block.kind === "choice" && !block.answerId
+      ? { ...block, answerId: FOCUS_DISMISSED_ANSWER_ID }
+      : block,
+  );
+  await updateBlocks(deps, target, pending.id, blocks);
 }
 
 export async function chooseFocus(
@@ -164,7 +216,7 @@ export async function chooseFocus(
     orderBy: { createdAt: "asc" },
   });
   const pending = recent.find((message) =>
-    (message.blocks as MessageBlock[]).some((block) => block.kind === "choice" && !block.answerId),
+    messageHasPendingChoice(message.blocks as MessageBlock[]),
   );
   if (!pending) return;
   const blocks = (pending.blocks as MessageBlock[]).map((block) =>

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -127,7 +127,13 @@ import {
   toComputerStatus,
 } from "./computer-status.js";
 import { buildMcpUpdateMaterial } from "./mcp-material.js";
-import { chooseFocus, markAppConnected, startOnboarding } from "./onboarding.js";
+import {
+  chooseFocus,
+  dismissFocus,
+  markAppConnected,
+  promptFocus,
+  startOnboarding,
+} from "./onboarding.js";
 import { listSpaceRuns } from "./runs.js";
 import { addScreenProxyCapability } from "./screen-proxy.js";
 import { querySpaceSearch } from "./search.js";
@@ -2744,12 +2750,28 @@ export function createRouter(deps: RouterDeps) {
         );
         return { ok: true as const };
       }),
+      promptFocus: authed.onboarding.promptFocus.handler(async ({ context, input }) => {
+        await promptFocus(
+          { prisma: deps.prisma, events: deps.events, composio: deps.composio },
+          context.actor,
+          input.botId,
+        );
+        return { ok: true as const };
+      }),
       choose: authed.onboarding.choose.handler(async ({ context, input }) => {
         await chooseFocus(
           { prisma: deps.prisma, events: deps.events, composio: deps.composio },
           context.actor,
           input.botId,
           input.optionId,
+        );
+        return { ok: true as const };
+      }),
+      dismissFocus: authed.onboarding.dismissFocus.handler(async ({ context, input }) => {
+        await dismissFocus(
+          { prisma: deps.prisma, events: deps.events, composio: deps.composio },
+          context.actor,
+          input.botId,
         );
         return { ok: true as const };
       }),

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -98,6 +98,7 @@ export default function Home() {
   const activityRequestId = useRef(0);
   const inboxRequestId = useRef(0);
   const focusPromptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const creatingBotRef = useRef(false);
 
   useEffect(() => {
     void loadActivityMode().then(setActivityMode);
@@ -317,6 +318,9 @@ export default function Home() {
   const router = useRouter();
 
   const createQuickBot = useCallback(async () => {
+    if (creatingBotRef.current) return;
+    creatingBotRef.current = true;
+    // Prefer the loaded roster so a slow bots fetch does not treat later bots as first.
     const isFirstBot = bots.length === 0;
     try {
       const bot = await rpc<MobileBot>("bots/create", {
@@ -324,21 +328,28 @@ export default function Home() {
         notifyOnFinish: true,
         computerMode: "team",
       });
-      await rpc("onboarding/start", { botId: bot.id }).catch(() => undefined);
-      if (focusPromptTimerRef.current) clearTimeout(focusPromptTimerRef.current);
-      focusPromptTimerRef.current = null;
-      if (isFirstBot) {
-        await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
-      } else {
+      void refreshBots().catch(() => undefined);
+      router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
+      void (async () => {
+        const started = await rpc("onboarding/start", { botId: bot.id })
+          .then(() => true)
+          .catch(() => false);
+        if (!started) return;
+        if (focusPromptTimerRef.current) clearTimeout(focusPromptTimerRef.current);
+        focusPromptTimerRef.current = null;
+        if (isFirstBot) {
+          await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
+          return;
+        }
         focusPromptTimerRef.current = setTimeout(() => {
           focusPromptTimerRef.current = null;
           void rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
         }, 10_000);
-      }
-      await refreshBots().catch(() => undefined);
-      router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
+      })();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not create bot"));
+    } finally {
+      creatingBotRef.current = false;
     }
   }, [bots.length, refreshBots, router, t]);
 

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -315,8 +315,9 @@ export default function Home() {
     creatingBotRef.current = true;
     try {
       // Authoritative roster so a slow home fetch does not treat later bots as first.
-      const existing = await rpc<MobileBot[]>("bots/list").catch(() => bots);
-      const isFirstBot = existing.length === 0;
+      // A failed list is unknown — use the delayed path rather than assuming first.
+      const existing = await rpc<MobileBot[]>("bots/list").catch(() => null);
+      const isFirstBot = existing !== null && existing.length === 0;
       const bot = await rpc<MobileBot>("bots/create", {
         ...normalizeCreateBotProfile({ name: "New Bot", title: "", description: "" }),
         notifyOnFinish: true,
@@ -337,7 +338,7 @@ export default function Home() {
     } finally {
       creatingBotRef.current = false;
     }
-  }, [bots, refreshBots, router, t]);
+  }, [refreshBots, router, t]);
 
   if (!ready) {
     return (

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -143,29 +143,6 @@ export default function Home() {
     }
   }, [loadBots]);
 
-  const createQuickBot = useCallback(async () => {
-    const isFirstBot = bots.length === 0;
-    try {
-      const bot = await rpc<MobileBot>("bots/create", {
-        ...normalizeCreateBotProfile({ name: "New Bot", title: "", description: "" }),
-        notifyOnFinish: true,
-        computerMode: "team",
-      });
-      await rpc("onboarding/start", { botId: bot.id }).catch(() => undefined);
-      if (isFirstBot) {
-        await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
-      } else {
-        setTimeout(() => {
-          void rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
-        }, 10_000);
-      }
-      await refreshBots().catch(() => undefined);
-      router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : t("Could not create bot"));
-    }
-  }, [bots.length, refreshBots, router, t]);
-
   useEffect(() => {
     void loadSessionToken().then((token) => {
       setHasSession(Boolean(token));
@@ -330,6 +307,29 @@ export default function Home() {
     : null;
   const insets = useSafeAreaInsets();
   const router = useRouter();
+
+  const createQuickBot = useCallback(async () => {
+    const isFirstBot = bots.length === 0;
+    try {
+      const bot = await rpc<MobileBot>("bots/create", {
+        ...normalizeCreateBotProfile({ name: "New Bot", title: "", description: "" }),
+        notifyOnFinish: true,
+        computerMode: "team",
+      });
+      await rpc("onboarding/start", { botId: bot.id }).catch(() => undefined);
+      if (isFirstBot) {
+        await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
+      } else {
+        setTimeout(() => {
+          void rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
+        }, 10_000);
+      }
+      await refreshBots().catch(() => undefined);
+      router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("Could not create bot"));
+    }
+  }, [bots.length, refreshBots, router, t]);
 
   if (!ready) {
     return (

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,4 +1,10 @@
-import type { RunActivityRow, SearchHit, SpaceBot, SpaceGroup } from "@rakazo/contracts";
+import {
+  normalizeCreateBotProfile,
+  type RunActivityRow,
+  type SearchHit,
+  type SpaceBot,
+  type SpaceGroup,
+} from "@rakazo/contracts";
 import { groupBotsForSidebar } from "@rakazo/core";
 import { Redirect, useFocusEffect, useRouter } from "expo-router";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -136,6 +142,29 @@ export default function Home() {
       setRefreshing(false);
     }
   }, [loadBots]);
+
+  const createQuickBot = useCallback(async () => {
+    const isFirstBot = bots.length === 0;
+    try {
+      const bot = await rpc<MobileBot>("bots/create", {
+        ...normalizeCreateBotProfile({ name: "New Bot", title: "", description: "" }),
+        notifyOnFinish: true,
+        computerMode: "team",
+      });
+      await rpc("onboarding/start", { botId: bot.id }).catch(() => undefined);
+      if (isFirstBot) {
+        await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
+      } else {
+        setTimeout(() => {
+          void rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
+        }, 10_000);
+      }
+      await refreshBots().catch(() => undefined);
+      router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("Could not create bot"));
+    }
+  }, [bots.length, refreshBots, router, t]);
 
   useEffect(() => {
     void loadSessionToken().then((token) => {
@@ -347,7 +376,7 @@ export default function Home() {
             accessibilityLabel={t("Create")}
             onPress={() =>
               Alert.alert(t("Create"), undefined, [
-                { text: t("New bot"), onPress: () => router.push("/new") },
+                { text: t("New bot"), onPress: () => void createQuickBot() },
                 { text: t("New group"), onPress: () => router.push("/new-group") },
                 { text: t("New space"), onPress: () => router.push("/new-space") },
                 { text: t("Cancel"), style: "cancel" },

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -45,6 +45,7 @@ import {
   selectInitialSpace,
   selectSpace,
 } from "../lib/api";
+import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { t, useI18n } from "../lib/i18n";
 import { botTag, filterBots, formatThreadTime, userInitials } from "../lib/inbox";
 import { dismissThreadNotifications, resumeLiveNotifications } from "../lib/live-notifications";
@@ -97,19 +98,11 @@ export default function Home() {
   });
   const activityRequestId = useRef(0);
   const inboxRequestId = useRef(0);
-  const focusPromptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const creatingBotRef = useRef(false);
 
   useEffect(() => {
     void loadActivityMode().then(setActivityMode);
   }, []);
-
-  useEffect(
-    () => () => {
-      if (focusPromptTimerRef.current) clearTimeout(focusPromptTimerRef.current);
-    },
-    [],
-  );
 
   const toggleActivityMode = useCallback(() => {
     setActivityMode((on) => {
@@ -320,9 +313,10 @@ export default function Home() {
   const createQuickBot = useCallback(async () => {
     if (creatingBotRef.current) return;
     creatingBotRef.current = true;
-    // Prefer the loaded roster so a slow bots fetch does not treat later bots as first.
-    const isFirstBot = bots.length === 0;
     try {
+      // Authoritative roster so a slow home fetch does not treat later bots as first.
+      const existing = await rpc<MobileBot[]>("bots/list").catch(() => bots);
+      const isFirstBot = existing.length === 0;
       const bot = await rpc<MobileBot>("bots/create", {
         ...normalizeCreateBotProfile({ name: "New Bot", title: "", description: "" }),
         notifyOnFinish: true,
@@ -335,23 +329,14 @@ export default function Home() {
           .then(() => true)
           .catch(() => false);
         if (!started) return;
-        if (focusPromptTimerRef.current) clearTimeout(focusPromptTimerRef.current);
-        focusPromptTimerRef.current = null;
-        if (isFirstBot) {
-          await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
-          return;
-        }
-        focusPromptTimerRef.current = setTimeout(() => {
-          focusPromptTimerRef.current = null;
-          void rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
-        }, 10_000);
+        scheduleFocusPrompt(bot.id, isFirstBot);
       })();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not create bot"));
     } finally {
       creatingBotRef.current = false;
     }
-  }, [bots.length, refreshBots, router, t]);
+  }, [bots, refreshBots, router, t]);
 
   if (!ready) {
     return (

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -97,10 +97,18 @@ export default function Home() {
   });
   const activityRequestId = useRef(0);
   const inboxRequestId = useRef(0);
+  const focusPromptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     void loadActivityMode().then(setActivityMode);
   }, []);
+
+  useEffect(
+    () => () => {
+      if (focusPromptTimerRef.current) clearTimeout(focusPromptTimerRef.current);
+    },
+    [],
+  );
 
   const toggleActivityMode = useCallback(() => {
     setActivityMode((on) => {
@@ -317,10 +325,13 @@ export default function Home() {
         computerMode: "team",
       });
       await rpc("onboarding/start", { botId: bot.id }).catch(() => undefined);
+      if (focusPromptTimerRef.current) clearTimeout(focusPromptTimerRef.current);
+      focusPromptTimerRef.current = null;
       if (isFirstBot) {
         await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
       } else {
-        setTimeout(() => {
+        focusPromptTimerRef.current = setTimeout(() => {
+          focusPromptTimerRef.current = null;
           void rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
         }, 10_000);
       }

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -45,7 +45,7 @@ import {
   selectInitialSpace,
   selectSpace,
 } from "../lib/api";
-import { scheduleFocusPrompt } from "../lib/focus-prompt";
+import { allowFocusPrompt, scheduleFocusPrompt } from "../lib/focus-prompt";
 import { t, useI18n } from "../lib/i18n";
 import { botTag, filterBots, formatThreadTime, userInitials } from "../lib/inbox";
 import { dismissThreadNotifications, resumeLiveNotifications } from "../lib/live-notifications";
@@ -323,6 +323,7 @@ export default function Home() {
         computerMode: "team",
       });
       void refreshBots().catch(() => undefined);
+      allowFocusPrompt(bot.id);
       router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
       void (async () => {
         const started = await rpc("onboarding/start", { botId: bot.id })

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -45,6 +45,8 @@ export default function NewBot() {
         notifyOnFinish: true,
         computerMode,
       });
+      await rpc("onboarding/start", { botId: bot.id }).catch(() => undefined);
+      await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
       router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not create bot"));

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -53,13 +53,7 @@ export default function NewBot() {
           .then(() => true)
           .catch(() => false);
         if (!started) return;
-        if (isFirstBot) {
-          await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
-          return;
-        }
-        setTimeout(() => {
-          void rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
-        }, 10_000);
+        scheduleFocusPrompt(bot.id, isFirstBot);
       })();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not create bot"));

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { Pressable, ScrollView, Text, TextInput } from "react-native";
 import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
+import { allowFocusPrompt, scheduleFocusPrompt } from "../lib/focus-prompt";
 import { useI18n } from "../lib/i18n";
 import { tokens } from "../lib/theme";
 

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -40,14 +40,27 @@ export default function NewBot() {
     setPending(true);
     setError(null);
     try {
+      const existing = await rpc<MobileBot[]>("bots/list").catch(() => []);
+      const isFirstBot = existing.length === 0;
       const bot = await rpc<MobileBot>("bots/create", {
         ...normalizeCreateBotProfile({ name, title, description }),
         notifyOnFinish: true,
         computerMode,
       });
-      await rpc("onboarding/start", { botId: bot.id }).catch(() => undefined);
-      await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
       router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
+      void (async () => {
+        const started = await rpc("onboarding/start", { botId: bot.id })
+          .then(() => true)
+          .catch(() => false);
+        if (!started) return;
+        if (isFirstBot) {
+          await rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
+          return;
+        }
+        setTimeout(() => {
+          void rpc("onboarding/promptFocus", { botId: bot.id }).catch(() => undefined);
+        }, 10_000);
+      })();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not create bot"));
     } finally {

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -41,8 +41,9 @@ export default function NewBot() {
     setPending(true);
     setError(null);
     try {
-      const existing = await rpc<MobileBot[]>("bots/list").catch(() => []);
-      const isFirstBot = existing.length === 0;
+      // Failed list is unknown — delay focus rather than treating the bot as first.
+      const existing = await rpc<MobileBot[]>("bots/list").catch(() => null);
+      const isFirstBot = existing !== null && existing.length === 0;
       const bot = await rpc<MobileBot>("bots/create", {
         ...normalizeCreateBotProfile({ name, title, description }),
         notifyOnFinish: true,

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -47,6 +47,7 @@ export default function NewBot() {
         notifyOnFinish: true,
         computerMode,
       });
+      allowFocusPrompt(bot.id);
       router.replace({ pathname: "/thread", params: { botId: bot.id, name: bot.name } });
       void (async () => {
         const started = await rpc("onboarding/start", { botId: bot.id })

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -75,6 +75,7 @@ import {
 import { mobileTokens } from "../lib/appearance";
 import { type MobileArtifactTarget, openMobileArtifact } from "../lib/artifact-open";
 import { confirmDeleteBot } from "../lib/bot-lifecycle";
+import { cancelFocusPrompt } from "../lib/focus-prompt";
 import { t, useI18n } from "../lib/i18n";
 import { saveLastBotId } from "../lib/last-bot";
 import {
@@ -702,6 +703,7 @@ function Thread() {
       }
       markReadIfVisible();
       return () => {
+        if (botId) cancelFocusPrompt(botId);
         void setOpenNotificationThread(null).catch(() => undefined);
       };
     }, [botId, markReadIfVisible, notificationThreadId]),

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -706,6 +706,9 @@ function Thread() {
       if (botId) {
         focusPromptThreadActive(botId);
         void saveLastBotId(botId).catch(() => undefined);
+      } else {
+        // Group thread focus: prior bot screen may stay mounted, so clear any delayed setup.
+        cancelFocusPrompt();
       }
       if (AppState.currentState === "active" && notificationThreadId) {
         void setOpenNotificationThread({

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -691,6 +691,15 @@ function Thread() {
     void dismissThreadNotifications({ threadId: notificationThreadId }).catch(() => undefined);
   }, [botId, navigation, notificationThreadId]);
 
+  // Cancel delayed setup only when leaving this bot's thread (unmount or botId
+  // change). Blur alone is not leave — settings/computer push must keep the timer.
+  useEffect(() => {
+    if (!botId) return;
+    return () => {
+      cancelFocusPrompt(botId);
+    };
+  }, [botId]);
+
   // Covers returning from a pushed screen; the AppState listener covers returning from background.
   useFocusEffect(
     useCallback(() => {
@@ -703,7 +712,6 @@ function Thread() {
       }
       markReadIfVisible();
       return () => {
-        if (botId) cancelFocusPrompt(botId);
         void setOpenNotificationThread(null).catch(() => undefined);
       };
     }, [botId, markReadIfVisible, notificationThreadId]),

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -937,6 +937,9 @@ function Thread() {
     const groupTarget = plan.rerouteGroupId ?? initialGroupTarget;
     const botTarget = reroutedToGroup ? undefined : initialBotTarget;
     const trimmed = plan.trimmed;
+    // Sending (including group-mention reroute) is engagement — drop delayed setup
+    // even when the bot thread stays mounted under a pushed group screen.
+    if (initialBotTarget) cancelFocusPrompt(initialBotTarget);
     setSending(true);
     setError(null);
     try {

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -75,7 +75,7 @@ import {
 import { mobileTokens } from "../lib/appearance";
 import { type MobileArtifactTarget, openMobileArtifact } from "../lib/artifact-open";
 import { confirmDeleteBot } from "../lib/bot-lifecycle";
-import { cancelFocusPrompt } from "../lib/focus-prompt";
+import { cancelFocusPrompt, focusPromptThreadActive } from "../lib/focus-prompt";
 import { t, useI18n } from "../lib/i18n";
 import { saveLastBotId } from "../lib/last-bot";
 import {
@@ -703,7 +703,10 @@ function Thread() {
   // Covers returning from a pushed screen; the AppState listener covers returning from background.
   useFocusEffect(
     useCallback(() => {
-      if (botId) void saveLastBotId(botId).catch(() => undefined);
+      if (botId) {
+        focusPromptThreadActive(botId);
+        void saveLastBotId(botId).catch(() => undefined);
+      }
       if (AppState.currentState === "active" && notificationThreadId) {
         void setOpenNotificationThread({
           botId,

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -937,9 +937,11 @@ function Thread() {
     const groupTarget = plan.rerouteGroupId ?? initialGroupTarget;
     const botTarget = reroutedToGroup ? undefined : initialBotTarget;
     const trimmed = plan.trimmed;
-    // Sending (including group-mention reroute) is engagement — drop delayed setup
-    // even when the bot thread stays mounted under a pushed group screen.
-    if (initialBotTarget) cancelFocusPrompt(initialBotTarget);
+    const dropDelayedSetup = () => {
+      // Only after successful engagement so a failed upload/send keeps the setup card.
+      // Covers group-mention reroute while the bot thread stays mounted underneath.
+      if (initialBotTarget) cancelFocusPrompt(initialBotTarget);
+    };
     setSending(true);
     setError(null);
     try {
@@ -967,6 +969,7 @@ function Thread() {
         setAttachmentNotice(null);
       };
       if (!plan.shouldSend) {
+        dropDelayedSetup();
         clearOriginComposer();
         if (reroutedToGroup && groupTarget) {
           router.push({
@@ -1014,6 +1017,7 @@ function Thread() {
               replyToMessageId: replyTarget?.id,
             },
       );
+      dropDelayedSetup();
       void loadSessionToken()
         .then((token) => resumeLiveNotifications(currentApiBase(), token, selectedSpaceId() ?? ""))
         .catch(() => undefined);

--- a/apps/mobile/lib/focus-prompt.ts
+++ b/apps/mobile/lib/focus-prompt.ts
@@ -26,7 +26,8 @@ export function cancelFocusPrompt(botId?: string): void {
  * Schedule posting the focus choice card. Survives leaving the home screen so
  * navigating into the new bot's thread does not cancel the delay. Call
  * `allowFocusPrompt` before navigating, and `cancelFocusPrompt` when leaving
- * that bot's thread so a late `onboarding/start` cannot schedule after departure.
+ * that bot's thread (unmount / bot switch — not blur onto settings) so a late
+ * `onboarding/start` cannot schedule after departure.
  */
 export function scheduleFocusPrompt(botId: string, immediate: boolean): void {
   if (cancelledBotIds.has(botId)) return;

--- a/apps/mobile/lib/focus-prompt.ts
+++ b/apps/mobile/lib/focus-prompt.ts
@@ -1,0 +1,34 @@
+import { rpc } from "./api";
+
+/** Delay before the setup focus card for a non-first bot. */
+export const FOCUS_PROMPT_DELAY_MS = 10_000;
+
+let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingBotId: string | null = null;
+
+/** Cancel a scheduled focus prompt. Pass botId to cancel only that bot's timer. */
+export function cancelFocusPrompt(botId?: string): void {
+  if (botId && pendingBotId && pendingBotId !== botId) return;
+  if (pendingTimer) clearTimeout(pendingTimer);
+  pendingTimer = null;
+  pendingBotId = null;
+}
+
+/**
+ * Schedule posting the focus choice card. Survives leaving the home screen so
+ * navigating into the new bot's thread does not cancel the delay. Cancel when
+ * leaving that bot's thread or starting another create.
+ */
+export function scheduleFocusPrompt(botId: string, immediate: boolean): void {
+  cancelFocusPrompt();
+  if (immediate) {
+    void rpc("onboarding/promptFocus", { botId }).catch(() => undefined);
+    return;
+  }
+  pendingBotId = botId;
+  pendingTimer = setTimeout(() => {
+    pendingTimer = null;
+    pendingBotId = null;
+    void rpc("onboarding/promptFocus", { botId }).catch(() => undefined);
+  }, FOCUS_PROMPT_DELAY_MS);
+}

--- a/apps/mobile/lib/focus-prompt.ts
+++ b/apps/mobile/lib/focus-prompt.ts
@@ -8,18 +8,40 @@ let pendingBotId: string | null = null;
 /** Bot ids whose delayed prompt must not run after the user left the thread. */
 const cancelledBotIds = new Set<string>();
 
+/** Bot id currently allowed to schedule; cleared when another thread is focused. */
+let eligibleBotId: string | null = null;
+
 /** Allow a freshly created bot to schedule a focus prompt after navigation. */
 export function allowFocusPrompt(botId: string): void {
   cancelledBotIds.delete(botId);
+  eligibleBotId = botId;
 }
 
 /** Cancel a scheduled focus prompt. Pass botId to cancel only that bot. */
 export function cancelFocusPrompt(botId?: string): void {
-  if (botId) cancelledBotIds.add(botId);
+  if (botId) {
+    cancelledBotIds.add(botId);
+    if (eligibleBotId === botId) eligibleBotId = null;
+  } else {
+    eligibleBotId = null;
+  }
   if (botId && pendingBotId && pendingBotId !== botId) return;
   if (pendingTimer) clearTimeout(pendingTimer);
   pendingTimer = null;
   pendingBotId = null;
+}
+
+/**
+ * Call when a bot thread gains focus. Cancels another bot's delayed setup when
+ * the user pushed or switched here while the previous thread stayed mounted.
+ */
+export function focusPromptThreadActive(botId: string): void {
+  if (eligibleBotId && eligibleBotId !== botId) {
+    cancelFocusPrompt(eligibleBotId);
+  }
+  if (pendingBotId && pendingBotId !== botId) {
+    cancelFocusPrompt(pendingBotId);
+  }
 }
 
 /**
@@ -30,7 +52,7 @@ export function cancelFocusPrompt(botId?: string): void {
  * `onboarding/start` cannot schedule after departure.
  */
 export function scheduleFocusPrompt(botId: string, immediate: boolean): void {
-  if (cancelledBotIds.has(botId)) return;
+  if (cancelledBotIds.has(botId) || (eligibleBotId !== null && eligibleBotId !== botId)) return;
   if (pendingTimer) clearTimeout(pendingTimer);
   pendingTimer = null;
   pendingBotId = null;

--- a/apps/mobile/lib/focus-prompt.ts
+++ b/apps/mobile/lib/focus-prompt.ts
@@ -5,9 +5,17 @@ export const FOCUS_PROMPT_DELAY_MS = 10_000;
 
 let pendingTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingBotId: string | null = null;
+/** Bot ids whose delayed prompt must not run after the user left the thread. */
+const cancelledBotIds = new Set<string>();
 
-/** Cancel a scheduled focus prompt. Pass botId to cancel only that bot's timer. */
+/** Allow a freshly created bot to schedule a focus prompt after navigation. */
+export function allowFocusPrompt(botId: string): void {
+  cancelledBotIds.delete(botId);
+}
+
+/** Cancel a scheduled focus prompt. Pass botId to cancel only that bot. */
 export function cancelFocusPrompt(botId?: string): void {
+  if (botId) cancelledBotIds.add(botId);
   if (botId && pendingBotId && pendingBotId !== botId) return;
   if (pendingTimer) clearTimeout(pendingTimer);
   pendingTimer = null;
@@ -16,11 +24,15 @@ export function cancelFocusPrompt(botId?: string): void {
 
 /**
  * Schedule posting the focus choice card. Survives leaving the home screen so
- * navigating into the new bot's thread does not cancel the delay. Cancel when
- * leaving that bot's thread or starting another create.
+ * navigating into the new bot's thread does not cancel the delay. Call
+ * `allowFocusPrompt` before navigating, and `cancelFocusPrompt` when leaving
+ * that bot's thread so a late `onboarding/start` cannot schedule after departure.
  */
 export function scheduleFocusPrompt(botId: string, immediate: boolean): void {
-  cancelFocusPrompt();
+  if (cancelledBotIds.has(botId)) return;
+  if (pendingTimer) clearTimeout(pendingTimer);
+  pendingTimer = null;
+  pendingBotId = null;
   if (immediate) {
     void rpc("onboarding/promptFocus", { botId }).catch(() => undefined);
     return;
@@ -29,6 +41,7 @@ export function scheduleFocusPrompt(botId: string, immediate: boolean): void {
   pendingTimer = setTimeout(() => {
     pendingTimer = null;
     pendingBotId = null;
+    if (cancelledBotIds.has(botId)) return;
     void rpc("onboarding/promptFocus", { botId }).catch(() => undefined);
   }, FOCUS_PROMPT_DELAY_MS);
 }

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -17,11 +17,20 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   const botList = page.locator("aside").first();
   await expect(botList.getByRole("button", { name: /^Chief/ })).toBeVisible();
 
-  await page.route("**/rpc/bots/create", async (route) => route.abort("failed"));
+  let createFailed = false;
+  const createAborted = new Promise<void>((resolve) => {
+    void page.route("**/rpc/bots/create", async (route) => {
+      createFailed = true;
+      await route.abort("failed");
+      resolve();
+    });
+  });
   await openNewBot(page);
+  await createAborted;
   // Instant create stays in chat; failed create leaves the current bot open.
   await expect(page.getByPlaceholder("Message Chief")).toBeVisible();
   await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
+  expect(createFailed).toBe(true);
   await page.unroute("**/rpc/bots/create");
 
   let failedPostCreateRefresh = false;

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -18,12 +18,14 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   await expect(botList.getByRole("button", { name: /^Chief/ })).toBeVisible();
 
   let createFailed = false;
+  let resolveCreateAborted!: () => void;
   const createAborted = new Promise<void>((resolve) => {
-    void page.route("**/rpc/bots/create", async (route) => {
-      createFailed = true;
-      await route.abort("failed");
-      resolve();
-    });
+    resolveCreateAborted = resolve;
+  });
+  await page.route("**/rpc/bots/create", async (route) => {
+    createFailed = true;
+    await route.abort("failed");
+    resolveCreateAborted();
   });
   await openNewBot(page);
   await createAborted;

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -54,7 +54,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   const normalizedLongTitle = longTitle.trim();
   expect(longTitle.length).toBeGreaterThan(160);
   await nameInput.fill("Researcher");
-  await titleInput.fill(normalizedLongTitle);
+  await titleInput.fill(longTitle);
   await descriptionInput.fill("Finds reliable sources and turns them into concise briefs.");
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(botList.getByRole("button", { name: /^Researcher/ })).toBeVisible();

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -54,7 +54,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   const normalizedLongTitle = longTitle.trim();
   expect(longTitle.length).toBeGreaterThan(160);
   await nameInput.fill("Researcher");
-  await titleInput.fill(longTitle);
+  await titleInput.fill(normalizedLongTitle);
   await descriptionInput.fill("Finds reliable sources and turns them into concise briefs.");
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(botList.getByRole("button", { name: /^Researcher/ })).toBeVisible();

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, openNewBot, signup } from "./helpers";
+import {
+  captureScreenshot,
+  completeOnboarding,
+  createBotFromPicker,
+  openNewBot,
+  signup,
+} from "./helpers";
 
 test("bot creation, editing, and deletion persist", async ({ page }, testInfo) => {
   const stamp = Date.now();
@@ -11,23 +17,13 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   const botList = page.locator("aside").first();
   await expect(botList.getByRole("button", { name: /^Chief/ })).toBeVisible();
 
-  await openNewBot(page);
-  await expect(page.getByText("New bot", { exact: true })).toBeVisible();
-  await page.locator("label:has-text('Name') input").fill("Researcher");
-  const longTitle = `Market researcher ${"and source verifier ".repeat(9)}`;
-  const normalizedLongTitle = longTitle.trim();
-  expect(longTitle.length).toBeGreaterThan(160);
-  await page.locator("label:has-text('Title') input").fill(longTitle);
-  await page
-    .locator("label:has-text('Description') textarea")
-    .fill("Finds reliable sources and turns them into concise briefs.");
-  await captureScreenshot(page, testInfo, "26-new-bot-form");
   await page.route("**/rpc/bots/create", async (route) => route.abort("failed"));
-  await page.getByRole("button", { name: "Create", exact: true }).click();
-  await expect(page.getByTestId("create-bot-error")).toHaveText("Failed to fetch");
-  await expect(page.getByRole("button", { name: "Create", exact: true })).toBeEnabled();
-  await captureScreenshot(page, testInfo, "26a-new-bot-error");
+  await openNewBot(page);
+  // Instant create stays in chat; failed create leaves the current bot open.
+  await expect(page.getByPlaceholder("Message Chief")).toBeVisible();
+  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
   await page.unroute("**/rpc/bots/create");
+
   let failedPostCreateRefresh = false;
   await page.route("**/rpc/spaces/list", async (route) => {
     if (failedPostCreateRefresh) {
@@ -37,12 +33,11 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
     failedPostCreateRefresh = true;
     await route.abort("failed");
   });
-  await page.getByRole("button", { name: "Create", exact: true }).click();
-
-  await expect(botList.getByRole("button", { name: /^Researcher/ })).toBeVisible();
+  await createBotFromPicker(page);
+  await expect(page.getByPlaceholder("Message New Bot")).toBeVisible();
   expect(failedPostCreateRefresh).toBe(true);
   await page.unroute("**/rpc/spaces/list");
-  await expect(page.getByPlaceholder("Message Researcher")).toBeVisible();
+  await expect(botList.getByRole("button", { name: /^New Bot/ })).toBeVisible();
   await page.waitForURL(/\/app\/[^/]+$/);
   const deletedBotPath = new URL(page.url()).pathname;
   await page.evaluate(() => window.dispatchEvent(new Event("focus")));
@@ -50,11 +45,22 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   expect(new URL(page.url()).pathname).toBe(deletedBotPath);
   await captureScreenshot(page, testInfo, "27-created-bot");
 
-  await page.locator("main").getByRole("button", { name: "Researcher", exact: true }).click();
+  await page.locator("main").getByRole("button", { name: "New Bot", exact: true }).click();
   await expect(page.getByText("Settings", { exact: true })).toBeVisible();
   const nameInput = page.locator("label:has-text('Name') input");
   const titleInput = page.locator("label:has-text('Title') input");
   const descriptionInput = page.locator("label:has-text('Description') textarea");
+  const longTitle = `Market researcher ${"and source verifier ".repeat(9)}`;
+  const normalizedLongTitle = longTitle.trim();
+  expect(longTitle.length).toBeGreaterThan(160);
+  await nameInput.fill("Researcher");
+  await titleInput.fill(longTitle);
+  await descriptionInput.fill("Finds reliable sources and turns them into concise briefs.");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(botList.getByRole("button", { name: /^Researcher/ })).toBeVisible();
+  await expect(page.getByPlaceholder("Message Researcher")).toBeVisible();
+
+  await page.locator("main").getByRole("button", { name: "Researcher", exact: true }).click();
   await expect(nameInput).toHaveValue("Researcher");
   await expect(titleInput).toHaveValue(normalizedLongTitle);
   await expect(descriptionInput).toHaveValue(

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, createNamedBot, rpc, signup } from "./helpers";
+import {
+  captureScreenshot,
+  completeOnboarding,
+  createNamedBot,
+  openNewGroup,
+  rpc,
+  signup,
+} from "./helpers";
 
 async function createBot(page: import("@playwright/test").Page, name: string) {
   return createNamedBot(page, name);
@@ -15,8 +22,7 @@ test("create group from + and see two bots in one transcript", async ({ page }, 
   const researcherId = await createBot(page, "Researcher");
   const writerId = await createBot(page, "Research Writer");
 
-  await page.getByTitle("Create", { exact: true }).click();
-  await page.getByRole("button", { name: "New group" }).click();
+  await openNewGroup(page);
   await page.locator("label:has-text('Name') input").fill("Draft team");
   const panel = page.getByTestId("side-panel");
   await panel.getByRole("button", { name: "Researcher" }).click();

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -1,11 +1,5 @@
 import { expect, test } from "@playwright/test";
-import {
-  captureScreenshot,
-  completeOnboarding,
-  createNamedBot,
-  rpc,
-  signup,
-} from "./helpers";
+import { captureScreenshot, completeOnboarding, createNamedBot, rpc, signup } from "./helpers";
 
 async function createBot(page: import("@playwright/test").Page, name: string) {
   return createNamedBot(page, name);

--- a/apps/web/e2e/group-chats.spec.ts
+++ b/apps/web/e2e/group-chats.spec.ts
@@ -1,23 +1,14 @@
 import { expect, test } from "@playwright/test";
 import {
-  activeBotId,
   captureScreenshot,
   completeOnboarding,
-  openNewBot,
+  createNamedBot,
   rpc,
   signup,
 } from "./helpers";
 
 async function createBot(page: import("@playwright/test").Page, name: string) {
-  const botList = page.locator("aside").first();
-  await openNewBot(page);
-  await expect(page.getByText("New bot", { exact: true })).toBeVisible();
-  await page.locator("label:has-text('Name') input").fill(name);
-  await page.getByRole("button", { name: "Create", exact: true }).click();
-  await expect(botList.getByRole("button", { name: new RegExp(`^${name}`) })).toBeVisible();
-  await expect(page.getByRole("combobox", { name: `Message ${name}` })).toBeVisible();
-  await page.waitForURL(/\/app\/[^/]+$/);
-  return activeBotId(page);
+  return createNamedBot(page, name);
 }
 
 test("create group from + and see two bots in one transcript", async ({ page }, testInfo) => {

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -95,6 +95,16 @@ export async function openNewBot(page: Page) {
   await page.getByTestId("create-new-bot").click();
 }
 
+export async function openNewGroup(page: Page) {
+  await page.getByTestId("create-menu-trigger").click();
+  await page.getByTestId("create-new-group").click();
+}
+
+export async function openNewSpace(page: Page) {
+  await page.getByTestId("create-menu-trigger").click();
+  await page.getByTestId("create-new-space").click();
+}
+
 /** Instant-create a bot from the + picker and wait for its chat (side panel closed). */
 export async function createBotFromPicker(page: Page) {
   await openNewBot(page);

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -91,6 +91,31 @@ export async function captureScreenshot(page: Page, testInfo: TestInfo, name: st
 }
 
 export async function openNewBot(page: Page) {
-  await page.getByTitle("Create", { exact: true }).click();
-  await page.getByRole("button", { name: "New bot" }).click();
+  await page.getByTestId("create-menu-trigger").click();
+  await page.getByTestId("create-new-bot").click();
+}
+
+/** Instant-create a bot from the + picker and wait for its chat (side panel closed). */
+export async function createBotFromPicker(page: Page) {
+  await openNewBot(page);
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
+}
+
+/** Create a named bot via RPC for test setup (skips the + picker). */
+export async function createNamedBot(
+  page: Page,
+  name: string,
+  options: { computerMode?: "team" | "dedicated" } = {},
+) {
+  const bot = await rpc<{ id: string; name: string }>(page, "bots/create", {
+    name,
+    title: "",
+    description: "",
+    notifyOnFinish: true,
+    computerMode: options.computerMode ?? "team",
+  });
+  await page.goto(`/app/${bot.id}`);
+  await expect(page.getByPlaceholder(`Message ${name}`)).toBeVisible();
+  return bot.id;
 }

--- a/apps/web/e2e/mention-picker-keyboard.spec.ts
+++ b/apps/web/e2e/mention-picker-keyboard.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, createNamedBot, signup } from "./helpers";
+import {
+  captureScreenshot,
+  completeOnboarding,
+  createNamedBot,
+  openNewGroup,
+  signup,
+} from "./helpers";
 
 async function createBot(page: import("@playwright/test").Page, name: string) {
   return createNamedBot(page, name);
@@ -17,8 +23,7 @@ test("mention picker completes with Enter and Tab", async ({ page }, testInfo) =
   expect(researcherId).toBeTruthy();
   expect(writerId).toBeTruthy();
 
-  await page.getByTitle("Create", { exact: true }).click();
-  await page.getByRole("button", { name: "New group" }).click();
+  await openNewGroup(page);
   await page.locator("label:has-text('Name') input").fill("Mention keys team");
   const panel = page.getByTestId("side-panel");
   await panel.getByRole("button", { name: "Researcher" }).click();

--- a/apps/web/e2e/mention-picker-keyboard.spec.ts
+++ b/apps/web/e2e/mention-picker-keyboard.spec.ts
@@ -1,16 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { activeBotId, captureScreenshot, completeOnboarding, openNewBot, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, createNamedBot, signup } from "./helpers";
 
 async function createBot(page: import("@playwright/test").Page, name: string) {
-  const botList = page.locator("aside").first();
-  await openNewBot(page);
-  await expect(page.getByText("New bot", { exact: true })).toBeVisible();
-  await page.locator("label:has-text('Name') input").fill(name);
-  await page.getByRole("button", { name: "Create", exact: true }).click();
-  await expect(botList.getByRole("button", { name: new RegExp(`^${name}`) })).toBeVisible();
-  await expect(page.getByRole("combobox", { name: `Message ${name}` })).toBeVisible();
-  await page.waitForURL(/\/app\/[^/]+$/);
-  return activeBotId(page);
+  return createNamedBot(page, name);
 }
 
 test("mention picker completes with Enter and Tab", async ({ page }, testInfo) => {

--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+import {
+  captureScreenshot,
+  completeOnboarding,
+  createBotFromPicker,
+  openNewBot,
+  signup,
+} from "./helpers";
+
+test("create opens empty chat, picker lists bots, and sidebar collapses", async ({
+  page,
+}, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `new-bot-ux-${stamp}@rakazo.test`, "password12", "New Bot UX");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  await page.getByTestId("create-menu-trigger").click();
+  const picker = page.getByTestId("bot-create-picker");
+  await expect(picker).toBeVisible();
+  await expect(picker.getByTestId("create-new-bot")).toBeVisible();
+  await expect(picker.getByText("Chief", { exact: true })).toBeVisible();
+  await captureScreenshot(page, testInfo, "plus-picker-bots");
+  await page.keyboard.press("Escape");
+
+  await createBotFromPicker(page);
+  await expect(page.getByPlaceholder("Message New Bot")).toBeVisible();
+  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
+  await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
+  await captureScreenshot(page, testInfo, "create-chat-sidepanel-closed");
+
+  await page.getByTestId("minimize-bots-sidebar").click();
+  await expect(page.getByTestId("bots-sidebar")).toHaveAttribute("data-collapsed", "true");
+  const edge = page.getByTestId("bots-sidebar-edge");
+  await expect(edge).toBeVisible();
+  await captureScreenshot(page, testInfo, "bots-sidebar-collapsed");
+
+  const box = await edge.boundingBox();
+  expect(box).toBeTruthy();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box!.x + 80, box!.y + box!.height / 2, { steps: 8 });
+  await page.mouse.up();
+  await expect(page.getByTestId("bots-sidebar")).toHaveAttribute("data-collapsed", "false");
+  await captureScreenshot(page, testInfo, "bots-sidebar-expanded");
+});
+
+test("later bot waits before showing the focus card; sending cancels it", async ({ page }) => {
+  const stamp = Date.now();
+  await signup(page, `focus-delay-${stamp}@rakazo.test`, "password12", "Focus Delay");
+  await completeOnboarding(page);
+  // First bot from onboarding shows the focus card immediately.
+  await expect(page.getByText("What do you want me on first?", { exact: true })).toBeVisible();
+
+  await page.clock.install();
+  await openNewBot(page);
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await expect(page.getByPlaceholder("Message New Bot")).toBeVisible();
+  await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
+
+  await page.clock.fastForward(9_000);
+  await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
+  await page.clock.fastForward(1_500);
+  await expect(page.getByText("What do you want me on first?", { exact: true })).toBeVisible();
+
+  await openNewBot(page);
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
+  const composer = page.getByPlaceholder(/Message/);
+  await composer.fill("I'll set this up myself");
+  await page.keyboard.press("Enter");
+  await page.clock.fastForward(12_000);
+  await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
+});

--- a/apps/web/e2e/run-failure.spec.ts
+++ b/apps/web/e2e/run-failure.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, openNewSpace, signup } from "./helpers";
 
 function isPresented(error: Locator) {
   return error.evaluate((element) => {
@@ -112,8 +112,7 @@ test("a covered run error is not remembered until it is presented", async ({ pag
   await page.getByPlaceholder(/^Message /).fill("fail this run");
   const modalSendButton = await page.getByRole("button", { name: "Send" }).elementHandle();
   if (!modalSendButton) throw new Error("Send button not found");
-  await page.getByTitle("Create", { exact: true }).click();
-  await page.getByRole("button", { name: "New space" }).click();
+  await openNewSpace(page);
   const newSpaceDialog = page.getByRole("dialog", { name: "New space" });
   await expect(newSpaceDialog).toBeVisible();
   await modalSendButton.evaluate((button) => (button as HTMLButtonElement).click());

--- a/apps/web/e2e/spaces.spec.ts
+++ b/apps/web/e2e/spaces.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, openNewSpace, signup } from "./helpers";
 
 test("spaces stay invisible by default and chat creation requires approval", async ({
   page,
@@ -13,8 +13,7 @@ test("spaces stay invisible by default and chat creation requires approval", asy
   await expect(sidebar.getByRole("button", { name: /^Chief/ })).toHaveCount(1);
   await captureScreenshot(page, testInfo, "single-space-sidebar");
 
-  await page.getByTitle("Create", { exact: true }).click();
-  await page.getByRole("button", { name: "New space" }).click();
+  await openNewSpace(page);
   const dialog = page.getByRole("dialog", { name: "New space" });
   await expect(dialog.getByLabel("Name")).toBeVisible();
   await dialog.getByLabel("Name").fill("Customer support");

--- a/apps/web/e2e/team-computer.spec.ts
+++ b/apps/web/e2e/team-computer.spec.ts
@@ -3,7 +3,7 @@ import {
   activeBotId,
   captureScreenshot,
   completeOnboarding,
-  openNewBot,
+  createNamedBot,
   realSandboxTimeout,
   rpc,
   signup,
@@ -210,18 +210,7 @@ test("an active Team bot must be stopped before user takeover", async ({ page },
 });
 
 async function createBot(page: Page, name: string, mode: "team" | "dedicated") {
-  await openNewBot(page);
-  await expect(page.getByText("New bot", { exact: true })).toBeVisible();
-  const team = page.getByRole("button", { name: "Team", exact: true });
-  const privateComputer = page.getByRole("button", { name: "Private", exact: true });
-  await expect(team).toHaveAttribute("aria-pressed", "true");
-  if (mode === "dedicated") await privateComputer.click();
-  await expect(mode === "team" ? team : privateComputer).toHaveAttribute("aria-pressed", "true");
-  await page.getByPlaceholder("Name this bot").fill(name);
-  await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForURL(/\/app\/[^/]+$/);
-  await expect(page.getByPlaceholder(`Message ${name}`)).toBeVisible();
-  return activeBotId(page);
+  return createNamedBot(page, name, { computerMode: mode });
 }
 
 async function setComputerMode(

--- a/apps/web/src/lib/bots-sidebar-pref.test.ts
+++ b/apps/web/src/lib/bots-sidebar-pref.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  botsSidebarCollapsedStorageKey,
+  readBotsSidebarCollapsed,
+  writeBotsSidebarCollapsed,
+} from "./bots-sidebar-pref";
+
+describe("bots sidebar collapse preference", () => {
+  it("builds a per-user storage key", () => {
+    expect(botsSidebarCollapsedStorageKey(null)).toBeNull();
+    expect(botsSidebarCollapsedStorageKey("user-1")).toBe("rakazo:bots-sidebar-collapsed:user-1");
+  });
+
+  it("reads and writes collapsed state", () => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+      },
+    });
+    expect(readBotsSidebarCollapsed("user-1")).toBe(false);
+    writeBotsSidebarCollapsed("user-1", true);
+    expect(readBotsSidebarCollapsed("user-1")).toBe(true);
+    writeBotsSidebarCollapsed("user-1", false);
+    expect(readBotsSidebarCollapsed("user-1")).toBe(false);
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/lib/bots-sidebar-pref.ts
+++ b/apps/web/src/lib/bots-sidebar-pref.ts
@@ -1,0 +1,33 @@
+const STORAGE_PREFIX = "rakazo:bots-sidebar-collapsed:";
+
+export function botsSidebarCollapsedStorageKey(userId: string | null | undefined): string | null {
+  if (!userId) return null;
+  return `${STORAGE_PREFIX}${userId}`;
+}
+
+export function readBotsSidebarCollapsed(userId: string | null | undefined): boolean {
+  const storageKey = botsSidebarCollapsedStorageKey(userId);
+  if (!storageKey) return false;
+  try {
+    return window.localStorage.getItem(storageKey) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeBotsSidebarCollapsed(
+  userId: string | null | undefined,
+  collapsed: boolean,
+): void {
+  const storageKey = botsSidebarCollapsedStorageKey(userId);
+  if (!storageKey) return;
+  try {
+    if (collapsed) window.localStorage.setItem(storageKey, "1");
+    else window.localStorage.removeItem(storageKey);
+  } catch {
+    // Ignore quota / private-mode failures; in-memory state still applies.
+  }
+}
+
+/** Drag distance (px) before the edge handle commits expand/collapse. */
+export const BOTS_SIDEBAR_EDGE_DRAG_PX = 40;

--- a/apps/web/src/lib/focus-prompt.test.ts
+++ b/apps/web/src/lib/focus-prompt.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { FOCUS_PROMPT_DELAY_MS, scheduleFocusPrompt } from "./focus-prompt";
+
+describe("scheduleFocusPrompt", () => {
+  it("prompts immediately for the first bot", async () => {
+    const prompt = vi.fn(async () => undefined);
+    const controller = new AbortController();
+    await expect(
+      scheduleFocusPrompt({ immediate: true, signal: controller.signal, prompt }),
+    ).resolves.toBe("prompted");
+    expect(prompt).toHaveBeenCalledOnce();
+  });
+
+  it("waits before prompting a later bot", async () => {
+    vi.useFakeTimers();
+    const prompt = vi.fn(async () => undefined);
+    const controller = new AbortController();
+    const pending = scheduleFocusPrompt({
+      immediate: false,
+      signal: controller.signal,
+      prompt,
+    });
+    expect(prompt).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(FOCUS_PROMPT_DELAY_MS - 1);
+    expect(prompt).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBe("prompted");
+    expect(prompt).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+
+  it("cancels when the signal aborts before the delay", async () => {
+    vi.useFakeTimers();
+    const prompt = vi.fn(async () => undefined);
+    const controller = new AbortController();
+    const pending = scheduleFocusPrompt({
+      immediate: false,
+      signal: controller.signal,
+      prompt,
+    });
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBe("cancelled");
+    expect(prompt).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/lib/focus-prompt.ts
+++ b/apps/web/src/lib/focus-prompt.ts
@@ -1,0 +1,26 @@
+import { abortableDelay } from "@rakazo/core";
+
+/** Delay before the setup focus card for a non-first bot. */
+export const FOCUS_PROMPT_DELAY_MS = 10_000;
+
+/**
+ * Schedule posting the focus choice card. First bot shows immediately; later
+ * bots wait so the user can type freely. Abort the signal to cancel when the
+ * user has already engaged (sent a message, dismissed, or left the thread).
+ */
+export async function scheduleFocusPrompt(options: {
+  immediate: boolean;
+  signal: AbortSignal;
+  prompt: () => Promise<void>;
+}): Promise<"prompted" | "cancelled"> {
+  if (options.signal.aborted) return "cancelled";
+  const delayMs = options.immediate ? 0 : FOCUS_PROMPT_DELAY_MS;
+  try {
+    await abortableDelay(delayMs, options.signal);
+  } catch {
+    return "cancelled";
+  }
+  if (options.signal.aborted) return "cancelled";
+  await options.prompt();
+  return options.signal.aborted ? "cancelled" : "prompted";
+}

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -223,9 +223,10 @@ export function OnboardingPage() {
         instructions: description,
         notifyOnFinish: true,
       });
-      // Onboarding continues conversationally in the thread: greeting, focus
-      // choice, and Composio authorize cards.
+      // Onboarding continues conversationally in the thread: greeting first,
+      // then the focus choice (immediate for the first bot).
       await rpc.onboarding.start({ botId: bot.id }).catch(() => undefined);
+      await rpc.onboarding.promptFocus({ botId: bot.id }).catch(() => undefined);
       navigate(`/app/${bot.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : t`Could not create your bot`);

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -225,8 +225,13 @@ export function OnboardingPage() {
       });
       // Onboarding continues conversationally in the thread: greeting first,
       // then the focus choice (immediate for the first bot).
-      await rpc.onboarding.start({ botId: bot.id }).catch(() => undefined);
-      await rpc.onboarding.promptFocus({ botId: bot.id }).catch(() => undefined);
+      const started = await rpc.onboarding
+        .start({ botId: bot.id })
+        .then(() => true)
+        .catch(() => false);
+      if (started) {
+        await rpc.onboarding.promptFocus({ botId: bot.id }).catch(() => undefined);
+      }
       navigate(`/app/${bot.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : t`Could not create your bot`);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3060,9 +3060,7 @@ export function ShellPage() {
           const rtl =
             typeof document !== "undefined" &&
             document.documentElement.getAttribute("dir") === "rtl";
-          const delta = rtl
-            ? drag.startX - event.clientX
-            : event.clientX - drag.startX;
+          const delta = rtl ? drag.startX - event.clientX : event.clientX - drag.startX;
           if (drag.mode === "expand" && delta >= BOTS_SIDEBAR_EDGE_DRAG_PX) {
             botsSidebarEdgeDragRef.current = null;
             setBotsSidebarCollapsedPref(false);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -431,6 +431,7 @@ export function ShellPage() {
   const [botsSidebarCollapsed, setBotsSidebarCollapsed] = useState(false);
   const focusPromptAbortRef = useRef<AbortController | null>(null);
   const focusPromptBotIdRef = useRef<string | null>(null);
+  const creatingBotRef = useRef(false);
   const botsSidebarEdgeDragRef = useRef<{ startX: number; mode: "expand" | "collapse" } | null>(
     null,
   );
@@ -2265,12 +2266,17 @@ export function ShellPage() {
     );
     navigate(`/app/${bot.id}`);
     setPanel(null);
-    await rpc.onboarding.start({ botId: bot.id }).catch(() => undefined);
-    beginFocusPrompt(bot.id, isFirstBot);
+    const started = await rpc.onboarding
+      .start({ botId: bot.id })
+      .then(() => true)
+      .catch(() => false);
+    if (started) beginFocusPrompt(bot.id, isFirstBot);
     await refreshBots().catch(() => undefined);
   }
 
   async function createBotQuick() {
+    if (creatingBotRef.current) return;
+    creatingBotRef.current = true;
     try {
       await createBot({
         name: "New Bot",
@@ -2278,8 +2284,11 @@ export function ShellPage() {
         description: "",
         computerMode: "team",
       });
-    } catch {
-      // Keep the current chat open when create fails.
+    } catch (error) {
+      // Keep the current chat open when create fails, but surface the error.
+      setSendError(error instanceof Error ? error.message : t`Could not create bot`);
+    } finally {
+      creatingBotRef.current = false;
     }
   }
 
@@ -2501,6 +2510,7 @@ export function ShellPage() {
       <aside
         data-testid="bots-sidebar"
         data-collapsed={botsSidebarCollapsed ? "true" : "false"}
+        inert={botsSidebarCollapsed && !mobileSidebarOpen ? true : undefined}
         className={`absolute inset-y-0 start-0 z-40 flex w-[calc(100%-48px)] max-w-[316px] shrink-0 flex-col border-e border-sidebar-border bg-sidebar transition-[transform,width,opacity] md:static md:z-auto md:translate-x-0 ${
           mobileSidebarOpen ? "translate-x-0" : "-translate-x-full rtl:translate-x-full"
         } ${

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1976,9 +1976,12 @@ export function ShellPage() {
       const trimmed = plan.trimmed;
       setSending(true);
       setSendError(null);
-      if (botTarget && focusPromptBotIdRef.current === botTarget) {
-        cancelFocusPrompt();
-      }
+      const dropDelayedSetup = () => {
+        // Only after successful engagement so a failed upload/send keeps the setup card.
+        if (initialBotTarget && focusPromptBotIdRef.current === initialBotTarget) {
+          cancelFocusPrompt();
+        }
+      };
       try {
         if (plan.shouldRunRoutines) {
           const sendNonce = newClientNonce();
@@ -1992,6 +1995,7 @@ export function ShellPage() {
           );
         }
         if (!plan.shouldSend) {
+          dropDelayedSetup();
           setReplyTarget(null);
           revokePendingAttachmentPreviews(attachments);
           setPendingAttachments((current) =>
@@ -2056,6 +2060,7 @@ export function ShellPage() {
             );
           }
         }
+        dropDelayedSetup();
         setReplyTarget(null);
         revokePendingAttachmentPreviews(attachments);
         setPendingAttachments((current) =>

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2357,6 +2357,8 @@ export function ShellPage() {
     }
   }, [active?.id]);
 
+  useEffect(() => () => cancelFocusPrompt(), []);
+
   useEffect(() => {
     if (!computer?.busyBotName) {
       setComputerError(null);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2268,7 +2268,7 @@ export function ShellPage() {
       immediate: isFirstBot,
       signal: controller.signal,
       prompt: async () => {
-        if (focusPromptBotIdRef.current !== bot.id) return;
+        if (focusPromptBotIdRef.current !== bot.id || activeBotId.current !== bot.id) return;
         await rpc.onboarding.promptFocus({ botId: bot.id }).catch(() => undefined);
       },
     }).finally(() => {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3052,7 +3052,12 @@ export function ShellPage() {
         onPointerMove={(event) => {
           const drag = botsSidebarEdgeDragRef.current;
           if (!drag) return;
-          const delta = event.clientX - drag.startX;
+          const rtl =
+            typeof document !== "undefined" &&
+            document.documentElement.getAttribute("dir") === "rtl";
+          const delta = rtl
+            ? drag.startX - event.clientX
+            : event.clientX - drag.startX;
           if (drag.mode === "expand" && delta >= BOTS_SIDEBAR_EDGE_DRAG_PX) {
             botsSidebarEdgeDragRef.current = null;
             setBotsSidebarCollapsedPref(false);

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -85,6 +85,7 @@ import {
   Menu,
   Mic,
   Monitor,
+  PanelLeftClose,
   Paperclip,
   Phone,
   Plus,
@@ -141,6 +142,12 @@ import { copyableMessageText } from "../lib/message-text";
 import { providerLabel } from "../lib/messaging";
 import { isFileDrag, revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
+import {
+  BOTS_SIDEBAR_EDGE_DRAG_PX,
+  readBotsSidebarCollapsed,
+  writeBotsSidebarCollapsed,
+} from "../lib/bots-sidebar-pref";
+import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { clearSpaceSelection, rpc, selectedSpaceId, selectSpace } from "../lib/rpc";
 import { readSeenRunErrorIds, rememberSeenRunErrorId } from "../lib/run-error-storage";
 import {
@@ -181,6 +188,7 @@ import {
 } from "./RoutineEditor";
 import { SpaceSearchResults } from "./SpaceSearch";
 import { BotSettings, CreateBotForm } from "./shell/bot-panel";
+import { BotCreatePicker } from "./shell/bot-picker";
 import { CommandPalette, isCommandPaletteHotkey } from "./shell/command-palette";
 import {
   ClearConversationDialog,
@@ -313,6 +321,9 @@ export function ShellPage() {
   useEffect(() => {
     setCollapsedSidebarSections(readCollapsedSidebarSections(userId));
   }, [userId]);
+  useEffect(() => {
+    setBotsSidebarCollapsed(readBotsSidebarCollapsed(userId));
+  }, [userId]);
   const [query, setQuery] = useState("");
   const [searchHits, setSearchHits] = useState<SearchHit[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
@@ -418,6 +429,12 @@ export function ShellPage() {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [draggedBotId, setDraggedBotId] = useState<string | null>(null);
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
+  const [botsSidebarCollapsed, setBotsSidebarCollapsed] = useState(false);
+  const focusPromptAbortRef = useRef<AbortController | null>(null);
+  const focusPromptBotIdRef = useRef<string | null>(null);
+  const botsSidebarEdgeDragRef = useRef<{ startX: number; mode: "expand" | "collapse" } | null>(
+    null,
+  );
   const [newSpaceOpen, setNewSpaceOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
 
@@ -1959,6 +1976,9 @@ export function ShellPage() {
       const trimmed = plan.trimmed;
       setSending(true);
       setSendError(null);
+      if (botTarget && focusPromptBotIdRef.current === botTarget) {
+        cancelFocusPrompt();
+      }
       try {
         if (plan.shouldRunRoutines) {
           const sendNonce = newClientNonce();
@@ -2198,12 +2218,44 @@ export function ShellPage() {
     await refreshBots().catch(() => undefined);
   }
 
+  function cancelFocusPrompt() {
+    focusPromptAbortRef.current?.abort();
+    focusPromptAbortRef.current = null;
+    focusPromptBotIdRef.current = null;
+  }
+
+  function beginFocusPrompt(botId: string, immediate: boolean) {
+    cancelFocusPrompt();
+    const controller = new AbortController();
+    focusPromptAbortRef.current = controller;
+    focusPromptBotIdRef.current = botId;
+    void scheduleFocusPrompt({
+      immediate,
+      signal: controller.signal,
+      prompt: async () => {
+        if (focusPromptBotIdRef.current !== botId) return;
+        await rpc.onboarding.promptFocus({ botId }).catch(() => undefined);
+      },
+    }).finally(() => {
+      if (focusPromptAbortRef.current === controller) {
+        focusPromptAbortRef.current = null;
+        focusPromptBotIdRef.current = null;
+      }
+    });
+  }
+
+  function setBotsSidebarCollapsedPref(collapsed: boolean) {
+    setBotsSidebarCollapsed(collapsed);
+    writeBotsSidebarCollapsed(userId, collapsed);
+  }
+
   async function createBot(input: {
     name: string;
     title: string;
     description: string;
     computerMode: ComputerMode;
   }) {
+    const isFirstBot = botsRef.current.length === 0;
     const bot = await rpc.bots.create({
       ...normalizeCreateBotProfile(input),
       notifyOnFinish: true,
@@ -2214,7 +2266,22 @@ export function ShellPage() {
     );
     navigate(`/app/${bot.id}`);
     setPanel(null);
+    await rpc.onboarding.start({ botId: bot.id }).catch(() => undefined);
+    beginFocusPrompt(bot.id, isFirstBot);
     await refreshBots().catch(() => undefined);
+  }
+
+  async function createBotQuick() {
+    try {
+      await createBot({
+        name: "New Bot",
+        title: "",
+        description: "",
+        computerMode: "team",
+      });
+    } catch {
+      // Keep the current chat open when create fails.
+    }
   }
 
   async function bootComputer({
@@ -2283,6 +2350,12 @@ export function ShellPage() {
     setComputerOpen(false);
     setComputerError(null);
     setComputerErrorFromScreen(false);
+  }, [active?.id]);
+
+  useEffect(() => {
+    if (focusPromptBotIdRef.current && focusPromptBotIdRef.current !== active?.id) {
+      cancelFocusPrompt();
+    }
   }, [active?.id]);
 
   useEffect(() => {
@@ -2425,8 +2498,14 @@ export function ShellPage() {
         />
       ) : null}
       <aside
-        className={`absolute inset-y-0 start-0 z-40 flex w-[calc(100%-48px)] max-w-[316px] shrink-0 flex-col border-e border-sidebar-border bg-sidebar transition-transform md:static md:z-auto md:w-[316px] md:translate-x-0 ${
+        data-testid="bots-sidebar"
+        data-collapsed={botsSidebarCollapsed ? "true" : "false"}
+        className={`absolute inset-y-0 start-0 z-40 flex w-[calc(100%-48px)] max-w-[316px] shrink-0 flex-col border-e border-sidebar-border bg-sidebar transition-[transform,width,opacity] md:static md:z-auto md:translate-x-0 ${
           mobileSidebarOpen ? "translate-x-0" : "-translate-x-full rtl:translate-x-full"
+        } ${
+          botsSidebarCollapsed
+            ? "md:w-0 md:max-w-0 md:overflow-hidden md:border-e-0 md:opacity-0 md:pointer-events-none"
+            : "md:w-[316px]"
         }`}
       >
         <div className="app-drag flex items-center justify-between px-[18px] pb-3 pt-4">
@@ -2452,10 +2531,21 @@ export function ShellPage() {
                 aria-hidden="true"
               />
             </button>
+            <button
+              type="button"
+              className="app-no-drag hidden h-7 w-7 items-center justify-center rounded-full text-muted-foreground/70 hover:text-foreground/75 md:inline-flex"
+              aria-label={t`Minimize bots`}
+              title={t`Minimize bots`}
+              data-testid="minimize-bots-sidebar"
+              onClick={() => setBotsSidebarCollapsedPref(true)}
+            >
+              <PanelLeftClose size={15} strokeWidth={1.8} aria-hidden="true" />
+            </button>
             <Popover open={createMenuOpen} onOpenChange={setCreateMenuOpen}>
               <PopoverTrigger
                 className="app-no-drag text-[21px] text-muted-foreground/70 hover:text-foreground/75"
                 title={t`Create`}
+                data-testid="create-menu-trigger"
               >
                 +
               </PopoverTrigger>
@@ -2463,40 +2553,28 @@ export function ShellPage() {
               {createMenuOpen ? (
                 <PopoverContent
                   align="end"
-                  className="app-no-drag w-auto min-w-[160px] gap-0 p-1 data-closed:animate-none"
+                  className="app-no-drag w-auto gap-0 overflow-hidden p-0 data-closed:animate-none"
                 >
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start font-normal"
-                    onClick={() => {
+                  <BotCreatePicker
+                    bots={bots}
+                    onCreateBot={() => {
                       setCreateMenuOpen(false);
-                      setPanel("create");
+                      void createBotQuick();
                     }}
-                  >
-                    <Trans>New bot</Trans>
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start font-normal"
-                    onClick={() => {
+                    onOpenBot={(id) => {
+                      setCreateMenuOpen(false);
+                      setMobileSidebarOpen(false);
+                      navigate(`/app/${id}`);
+                    }}
+                    onCreateGroup={() => {
                       setCreateMenuOpen(false);
                       setPanel("create-group");
                     }}
-                  >
-                    <Trans>New group</Trans>
-                  </Button>
-                  <Separator className="my-1" />
-                  <Button
-                    variant="ghost"
-                    className="w-full justify-start font-normal"
-                    onClick={() => {
+                    onCreateSpace={() => {
                       setCreateMenuOpen(false);
                       setNewSpaceOpen(true);
                     }}
-                  >
-                    <Lock size={14} strokeWidth={1.8} aria-hidden="true" />
-                    <Trans>New space</Trans>
-                  </Button>
+                  />
                 </PopoverContent>
               ) : null}
             </Popover>
@@ -2938,6 +3016,43 @@ export function ShellPage() {
           ) : null}
         </Popover>
       </aside>
+
+      <div
+        data-testid="bots-sidebar-edge"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={botsSidebarCollapsed ? t`Show bots` : t`Hide bots`}
+        aria-valuenow={botsSidebarCollapsed ? 0 : 1}
+        className={`absolute inset-y-0 z-50 hidden w-2 cursor-ew-resize touch-none md:block ${
+          botsSidebarCollapsed ? "start-0" : "start-[308px]"
+        }`}
+        onPointerDown={(event) => {
+          event.currentTarget.setPointerCapture(event.pointerId);
+          botsSidebarEdgeDragRef.current = {
+            startX: event.clientX,
+            mode: botsSidebarCollapsed ? "expand" : "collapse",
+          };
+        }}
+        onPointerMove={(event) => {
+          const drag = botsSidebarEdgeDragRef.current;
+          if (!drag) return;
+          const delta = event.clientX - drag.startX;
+          if (drag.mode === "expand" && delta >= BOTS_SIDEBAR_EDGE_DRAG_PX) {
+            botsSidebarEdgeDragRef.current = null;
+            setBotsSidebarCollapsedPref(false);
+          } else if (drag.mode === "collapse" && delta <= -BOTS_SIDEBAR_EDGE_DRAG_PX) {
+            botsSidebarEdgeDragRef.current = null;
+            setBotsSidebarCollapsedPref(true);
+          }
+        }}
+        onPointerUp={() => {
+          botsSidebarEdgeDragRef.current = null;
+        }}
+        onPointerCancel={() => {
+          botsSidebarEdgeDragRef.current = null;
+        }}
+        onDoubleClick={() => setBotsSidebarCollapsedPref(!botsSidebarCollapsed)}
+      />
 
       <main
         aria-hidden={mobileSidebarOpen || undefined}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -67,7 +67,6 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-  Separator,
 } from "@rakazo/ui-web";
 import {
   ArrowDown,
@@ -131,23 +130,23 @@ import type { ArtifactTarget } from "../lib/artifact-open";
 import { authClient } from "../lib/auth";
 import { takeInitialBootstrap } from "../lib/bootstrap";
 import {
+  BOTS_SIDEBAR_EDGE_DRAG_PX,
+  readBotsSidebarCollapsed,
+  writeBotsSidebarCollapsed,
+} from "../lib/bots-sidebar-pref";
+import {
   deliverBrowserNotification as deliverNativeBrowserNotification,
   requestBrowserNotificationPermission,
   shouldNotifyBrowser,
 } from "../lib/browser-notifications";
 import { loadComputerScreen } from "../lib/computer-screen";
 import { dictation } from "../lib/dictation";
+import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { localTimezone } from "../lib/local-timezone";
 import { copyableMessageText } from "../lib/message-text";
 import { providerLabel } from "../lib/messaging";
 import { isFileDrag, revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
-import {
-  BOTS_SIDEBAR_EDGE_DRAG_PX,
-  readBotsSidebarCollapsed,
-  writeBotsSidebarCollapsed,
-} from "../lib/bots-sidebar-pref";
-import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { clearSpaceSelection, rpc, selectedSpaceId, selectSpace } from "../lib/rpc";
 import { readSeenRunErrorIds, rememberSeenRunErrorId } from "../lib/run-error-storage";
 import {
@@ -3017,13 +3016,12 @@ export function ShellPage() {
         </Popover>
       </aside>
 
-      <div
+      <button
+        type="button"
         data-testid="bots-sidebar-edge"
-        role="separator"
-        aria-orientation="vertical"
         aria-label={botsSidebarCollapsed ? t`Show bots` : t`Hide bots`}
-        aria-valuenow={botsSidebarCollapsed ? 0 : 1}
-        className={`absolute inset-y-0 z-50 hidden w-2 cursor-ew-resize touch-none md:block ${
+        aria-pressed={!botsSidebarCollapsed}
+        className={`absolute inset-y-0 z-50 hidden w-2 cursor-ew-resize touch-none border-0 bg-transparent p-0 md:block ${
           botsSidebarCollapsed ? "start-0" : "start-[308px]"
         }`}
         onPointerDown={(event) => {
@@ -3045,13 +3043,17 @@ export function ShellPage() {
             setBotsSidebarCollapsedPref(true);
           }
         }}
-        onPointerUp={() => {
+        onPointerUp={(event) => {
+          const drag = botsSidebarEdgeDragRef.current;
           botsSidebarEdgeDragRef.current = null;
+          if (!drag) return;
+          if (Math.abs(event.clientX - drag.startX) < BOTS_SIDEBAR_EDGE_DRAG_PX) {
+            setBotsSidebarCollapsedPref(!botsSidebarCollapsed);
+          }
         }}
         onPointerCancel={() => {
           botsSidebarEdgeDragRef.current = null;
         }}
-        onDoubleClick={() => setBotsSidebarCollapsedPref(!botsSidebarCollapsed)}
       />
 
       <main

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2224,26 +2224,6 @@ export function ShellPage() {
     focusPromptBotIdRef.current = null;
   }
 
-  function beginFocusPrompt(botId: string, immediate: boolean) {
-    cancelFocusPrompt();
-    const controller = new AbortController();
-    focusPromptAbortRef.current = controller;
-    focusPromptBotIdRef.current = botId;
-    void scheduleFocusPrompt({
-      immediate,
-      signal: controller.signal,
-      prompt: async () => {
-        if (focusPromptBotIdRef.current !== botId) return;
-        await rpc.onboarding.promptFocus({ botId }).catch(() => undefined);
-      },
-    }).finally(() => {
-      if (focusPromptAbortRef.current === controller) {
-        focusPromptAbortRef.current = null;
-        focusPromptBotIdRef.current = null;
-      }
-    });
-  }
-
   function setBotsSidebarCollapsedPref(collapsed: boolean) {
     setBotsSidebarCollapsed(collapsed);
     writeBotsSidebarCollapsed(userId, collapsed);
@@ -2266,11 +2246,37 @@ export function ShellPage() {
     );
     navigate(`/app/${bot.id}`);
     setPanel(null);
+    // Register cancellation before awaiting start so leaving the bot during
+    // startup cannot miss the abort and still schedule a late focus card.
+    cancelFocusPrompt();
+    const controller = new AbortController();
+    focusPromptAbortRef.current = controller;
+    focusPromptBotIdRef.current = bot.id;
     const started = await rpc.onboarding
       .start({ botId: bot.id })
       .then(() => true)
       .catch(() => false);
-    if (started) beginFocusPrompt(bot.id, isFirstBot);
+    if (!started || controller.signal.aborted || focusPromptBotIdRef.current !== bot.id) {
+      if (focusPromptAbortRef.current === controller) {
+        focusPromptAbortRef.current = null;
+        focusPromptBotIdRef.current = null;
+      }
+      await refreshBots().catch(() => undefined);
+      return;
+    }
+    void scheduleFocusPrompt({
+      immediate: isFirstBot,
+      signal: controller.signal,
+      prompt: async () => {
+        if (focusPromptBotIdRef.current !== bot.id) return;
+        await rpc.onboarding.promptFocus({ botId: bot.id }).catch(() => undefined);
+      },
+    }).finally(() => {
+      if (focusPromptAbortRef.current === controller) {
+        focusPromptAbortRef.current = null;
+        focusPromptBotIdRef.current = null;
+      }
+    });
     await refreshBots().catch(() => undefined);
   }
 

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -91,7 +91,12 @@ export function CreateBotForm({
     setError(null);
     setSubmitting(true);
     try {
-      await onCreate({ name, title, description, computerMode });
+      await onCreate({
+        name: name.trim(),
+        title: title.trim(),
+        description: description.trim(),
+        computerMode,
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : t`Could not create bot`);
     } finally {
@@ -440,11 +445,17 @@ export function BotSettings({
             setSaving(true);
             setError(null);
             const selected = modelKey ? parseModelOptionKey(modelKey) : null;
+            const nextName = name.trim();
+            const nextTitle = title.trim();
+            const nextDescription = description.trim();
+            setName(nextName);
+            setTitle(nextTitle);
+            setDescription(nextDescription);
             void onSave({
-              name,
-              title,
-              description,
-              instructions: description,
+              name: nextName,
+              title: nextTitle,
+              description: nextDescription,
+              instructions: nextDescription,
               computerMode,
               memoryScope,
               autoSpeak,

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -1,0 +1,102 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { Bot } from "@rakazo/contracts";
+import {
+  BotAvatar,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@rakazo/ui-web";
+import { Lock, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
+
+export function BotCreatePicker({
+  bots,
+  onCreateBot,
+  onOpenBot,
+  onCreateGroup,
+  onCreateSpace,
+}: {
+  bots: Bot[];
+  onCreateBot: () => void;
+  onOpenBot: (botId: string) => void;
+  onCreateGroup: () => void;
+  onCreateSpace: () => void;
+}) {
+  const { t } = useLingui();
+  const [query, setQuery] = useState("");
+  const needle = query.trim().toLowerCase();
+  const matched = useMemo(() => {
+    if (!needle) return bots;
+    return bots.filter(
+      (bot) =>
+        bot.name.toLowerCase().includes(needle) || bot.title.toLowerCase().includes(needle),
+    );
+  }, [bots, needle]);
+  const showCreate =
+    !needle ||
+    "create new bot".includes(needle) ||
+    needle.split(/\s+/).every((part) => "create new bot".includes(part));
+
+  return (
+    <div data-testid="bot-create-picker" className="w-[min(320px,calc(100vw-2rem))]">
+      <label className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <span className="shrink-0 text-[13px] text-muted-foreground">
+          <Trans>To:</Trans>
+        </span>
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={t`Search or create Bots`}
+          aria-label={t`Search or create Bots`}
+          className="min-w-0 flex-1 bg-transparent text-[14px] text-foreground outline-none placeholder:text-muted-foreground"
+          autoFocus
+        />
+      </label>
+      <Command shouldFilter={false} className="rounded-none border-0 bg-transparent p-0">
+        <CommandList className="max-h-72 p-1">
+          <CommandEmpty>
+            <Trans>No bots match</Trans>
+          </CommandEmpty>
+          <CommandGroup>
+            {showCreate ? (
+              <CommandItem
+                value="create-new-bot"
+                data-testid="create-new-bot"
+                onSelect={() => onCreateBot()}
+                className="gap-2"
+              >
+                <Plus size={16} strokeWidth={1.8} aria-hidden="true" />
+                <Trans>Create new Bot</Trans>
+              </CommandItem>
+            ) : null}
+            {matched.map((bot) => (
+              <CommandItem
+                key={bot.id}
+                value={bot.id}
+                data-testid={`picker-bot-${bot.id}`}
+                onSelect={() => onOpenBot(bot.id)}
+                className="gap-2"
+              >
+                <BotAvatar color={bot.color} identity={bot.id} size={22} status={bot.status} />
+                <span className="min-w-0 flex-1 truncate">{bot.name}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup>
+            <CommandItem value="create-group" onSelect={() => onCreateGroup()}>
+              <Trans>New group</Trans>
+            </CommandItem>
+            <CommandItem value="create-space" onSelect={() => onCreateSpace()} className="gap-2">
+              <Lock size={14} strokeWidth={1.8} aria-hidden="true" />
+              <Trans>New space</Trans>
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </div>
+  );
+}

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -85,10 +85,19 @@ export function BotCreatePicker({
           </CommandGroup>
           <CommandSeparator />
           <CommandGroup>
-            <CommandItem value="create-group" onSelect={() => onCreateGroup()}>
+            <CommandItem
+              value="create-group"
+              data-testid="create-new-group"
+              onSelect={() => onCreateGroup()}
+            >
               <Trans>New group</Trans>
             </CommandItem>
-            <CommandItem value="create-space" onSelect={() => onCreateSpace()} className="gap-2">
+            <CommandItem
+              value="create-space"
+              data-testid="create-new-space"
+              onSelect={() => onCreateSpace()}
+              className="gap-2"
+            >
               <Lock size={14} strokeWidth={1.8} aria-hidden="true" />
               <Trans>New space</Trans>
             </CommandItem>

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -31,8 +31,7 @@ export function BotCreatePicker({
   const matched = useMemo(() => {
     if (!needle) return bots;
     return bots.filter(
-      (bot) =>
-        bot.name.toLowerCase().includes(needle) || bot.title.toLowerCase().includes(needle),
+      (bot) => bot.name.toLowerCase().includes(needle) || bot.title.toLowerCase().includes(needle),
     );
   }, [bots, needle]);
   const showCreate =
@@ -52,7 +51,6 @@ export function BotCreatePicker({
           placeholder={t`Search or create Bots`}
           aria-label={t`Search or create Bots`}
           className="min-w-0 flex-1 bg-transparent text-[14px] text-foreground outline-none placeholder:text-muted-foreground"
-          autoFocus
         />
       </label>
       <Command shouldFilter={false} className="rounded-none border-0 bg-transparent p-0">

--- a/apps/web/src/pages/shell/message-cards.tsx
+++ b/apps/web/src/pages/shell/message-cards.tsx
@@ -22,7 +22,8 @@ export function ChoiceCard({
   const { t } = useLingui();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const dismissed = block.answerId === "_dismissed";
+  const [locallyDismissed, setLocallyDismissed] = useState(false);
+  const dismissed = locallyDismissed || block.answerId === "_dismissed";
 
   async function choose(optionId: string) {
     setPending(true);
@@ -41,7 +42,8 @@ export function ChoiceCard({
     setError(null);
     try {
       await rpc.onboarding.dismissFocus({ botId });
-      await onBotChanged().catch(() => undefined);
+      setLocallyDismissed(true);
+      void onBotChanged().catch(() => undefined);
     } catch (err) {
       setError(err instanceof Error ? err.message : t`Could not dismiss`);
       setPending(false);

--- a/apps/web/src/pages/shell/message-cards.tsx
+++ b/apps/web/src/pages/shell/message-cards.tsx
@@ -22,6 +22,7 @@ export function ChoiceCard({
   const { t } = useLingui();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const dismissed = block.answerId === "_dismissed";
 
   async function choose(optionId: string) {
     setPending(true);
@@ -35,10 +36,36 @@ export function ChoiceCard({
     }
   }
 
+  async function dismiss() {
+    setPending(true);
+    setError(null);
+    try {
+      await rpc.onboarding.dismissFocus({ botId });
+      await onBotChanged().catch(() => undefined);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t`Could not dismiss`);
+      setPending(false);
+    }
+  }
+
+  if (dismissed) return null;
+
   return (
     <div className="flex justify-start">
-      <div className="w-[min(420px,80%)] rounded-[20px] border border-border bg-card px-[18px] py-[14px]">
-        <div className="text-[15.5px] text-foreground/90">{block.question}</div>
+      <div className="relative w-[min(420px,80%)] rounded-[20px] border border-border bg-card px-[18px] py-[14px]">
+        {!block.answerId ? (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={t`Dismiss`}
+            disabled={pending}
+            onClick={() => void dismiss()}
+            className="absolute end-2 top-2 text-muted-foreground"
+          >
+            <X size={16} strokeWidth={1.8} />
+          </Button>
+        ) : null}
+        <div className="pe-8 text-[15.5px] text-foreground/90">{block.question}</div>
         {block.subtitle ? (
           <div className="mt-0.5 text-[13px] text-foreground/75">{block.subtitle}</div>
         ) : null}

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -211,9 +211,9 @@ export const UpdateBotInput = z
   .object({
     botId: Id,
     name: z.string().trim().min(1).max(BOT_NAME_MAX_LENGTH).optional(),
-    title: z.string().max(BOT_TITLE_MAX_LENGTH).optional(),
-    description: z.string().max(BOT_DESCRIPTION_MAX_LENGTH).optional(),
-    instructions: z.string().max(BOT_INSTRUCTIONS_MAX_LENGTH).optional(),
+    title: z.string().trim().max(BOT_TITLE_MAX_LENGTH).optional(),
+    description: z.string().trim().max(BOT_DESCRIPTION_MAX_LENGTH).optional(),
+    instructions: z.string().trim().max(BOT_INSTRUCTIONS_MAX_LENGTH).optional(),
     notifyOnFinish: z.boolean().optional(),
     color: z.string().optional(),
     pinned: z.boolean().optional(),

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -92,6 +92,12 @@ describe("contracts", () => {
   it("normalizes bot names and rejects whitespace-only values at the contract boundary", () => {
     expect(CreateBotInput.parse({ name: "  Chief  " }).name).toBe("Chief");
     expect(UpdateBotInput.parse({ botId: "bot-1", name: "  Atlas  " }).name).toBe("Atlas");
+    expect(UpdateBotInput.parse({ botId: "bot-1", title: "  Lead researcher  " }).title).toBe(
+      "Lead researcher",
+    );
+    expect(
+      UpdateBotInput.parse({ botId: "bot-1", description: "  Concise briefs.  " }).description,
+    ).toBe("Concise briefs.");
     expect(CreateBotInput.safeParse({ name: "   " }).success).toBe(false);
     expect(UpdateBotInput.safeParse({ botId: "bot-1", name: "   " }).success).toBe(false);
   });

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -527,12 +527,16 @@ export const appContract = {
     },
   },
   onboarding: {
-    /** Seed the first-run conversational onboarding into the bot's thread. */
+    /** Seed the first-run greeting into the bot's thread (focus card is separate). */
     start: oc.input(z.object({ botId: Id })).output(z.object({ ok: z.literal(true) })),
-    /** Answer the focus choice; renames the bot and posts the app cards. */
+    /** Post the focus choice card when the thread is still idle. */
+    promptFocus: oc.input(z.object({ botId: Id })).output(z.object({ ok: z.literal(true) })),
+    /** Answer the focus choice; posts the app cards. Does not rename the bot. */
     choose: oc
       .input(z.object({ botId: Id, optionId: z.string() }))
       .output(z.object({ ok: z.literal(true) })),
+    /** Dismiss the unanswered focus card without choosing an option. */
+    dismissFocus: oc.input(z.object({ botId: Id })).output(z.object({ ok: z.literal(true) })),
     /** Flip an app_connect card to connected after authorization completes. */
     appConnected: oc
       .input(z.object({ botId: Id, provider: z.string() }))

--- a/packages/testkit/src/connections.test.ts
+++ b/packages/testkit/src/connections.test.ts
@@ -122,7 +122,8 @@ describeWithDatabase("Composio catalog reconciliation", () => {
     const actor = await rpc<Actor>(app, cookie, "me");
     await connectRemote(composio, actor, "SLACK");
     const pending = await createConnection(actor, "SLACK");
-    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    // Keep the rejection sticky: catalog reconciliation may call findMany more
+    // than once, and a one-shot mock lets a later call mark the row connected.
     const failure = vi
       .spyOn(handles.prisma.connection, "findMany")
       .mockRejectedValue(new Error("simulated reconciliation failure"));
@@ -137,11 +138,6 @@ describeWithDatabase("Composio catalog reconciliation", () => {
     expect(catalog).toContainEqual(expect.objectContaining({ slug: "SLACK", connected: true }));
     failure.mockRestore();
     await expect(statuses([pending.id])).resolves.toEqual([{ id: pending.id, status: "pending" }]);
-    expect(log).toHaveBeenCalledWith(
-      "composio pending-connection reconciliation failed",
-      expect.any(Error),
-    );
-    log.mockRestore();
   });
 
   it("does not mutate local state when the provider catalog fails", async () => {

--- a/packages/testkit/src/connections.test.ts
+++ b/packages/testkit/src/connections.test.ts
@@ -122,19 +122,26 @@ describeWithDatabase("Composio catalog reconciliation", () => {
     const actor = await rpc<Actor>(app, cookie, "me");
     await connectRemote(composio, actor, "SLACK");
     const pending = await createConnection(actor, "SLACK");
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const failure = vi
       .spyOn(handles.prisma.connection, "findMany")
-      .mockRejectedValueOnce(new Error("simulated reconciliation failure"));
+      .mockRejectedValue(new Error("simulated reconciliation failure"));
 
     const catalog = await rpc<Array<{ slug: string; connected: boolean }>>(
       app,
       cookie,
       "connections/catalog",
+      { connectorId: "composio" },
     );
 
     expect(catalog).toContainEqual(expect.objectContaining({ slug: "SLACK", connected: true }));
-    await expect(statuses([pending.id])).resolves.toEqual([{ id: pending.id, status: "pending" }]);
     failure.mockRestore();
+    await expect(statuses([pending.id])).resolves.toEqual([{ id: pending.id, status: "pending" }]);
+    expect(log).toHaveBeenCalledWith(
+      "composio pending-connection reconciliation failed",
+      expect.any(Error),
+    );
+    log.mockRestore();
   });
 
   it("does not mutate local state when the provider catalog fails", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Creating a bot from `+` still dumped people into the sidepanel form, the setup focus card appeared immediately for every bot, and the bots sidebar could not collapse. New bots should open into an empty chat first, with setup delayed unless it is the first bot, and the bots list should be collapsible from an edge handle.

## What changed

- Creating a bot from `+` opens the empty chat conversation instead of the sidepanel create form
- Focus/setup card is delayed ~10s for non-first bots; first bot still prompts immediately
- `+` picker lists existing bots (search / create) via `BotCreatePicker`
- Bots sidebar can collapse and reopen from the edge drag handle
- Keeps main’s Cmd/Ctrl-K bot palette (#600), vertical ask options (#604), and VISION.md (#603); does not reintroduce Coming soon Cmd-K tabs or composer placeholder changes (#597)
- Focus-prompt cancellation hardened across web/mobile; bot title/description trimmed on update and in settings save

## Rebase

Rebased onto latest `main` (`766a2e1a`, includes #605/#601/#599). Conflict resolution:

- First rebase onto #600: `apps/web/src/pages/Shell.tsx` (kept both `BotCreatePicker` and `CommandPalette`)
- Second rebase onto #605: `packages/testkit/src/connections.test.ts` (kept flake-hardening for pending-connection reconciliation)

## How it was tested

- Unit tests for focus-prompt scheduling, bots-sidebar preference, and UpdateBotInput title trim
- Web e2e coverage in `new-bot-ux.spec.ts` for picker, delayed focus, and sidebar collapse
- Mobile `tsc` after focus-prompt import fix
- CI re-triggered after each rebase tip

Do not merge — parent will squash when CLEAN.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78d6a649-a68a-4bc2-b4d5-8e3554dc7ac6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78d6a649-a68a-4bc2-b4d5-8e3554dc7ac6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable creation picker for bots, groups, and spaces.
  * Added collapsible bot sidebars with saved preferences and desktop edge-drag controls.
  * Improved onboarding with greeting-first setup and dismissible focus prompts.
  * Added quick bot creation on web and mobile, with immediate prompts for first bots.
* **Bug Fixes**
  * Focus prompts now wait briefly for later bots and cancel when switching bots or chatting.
  * Improved first-bot detection reliability.
  * Bot names, titles, descriptions, and instructions now trim extra whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->