### PR TITLE
Strip HTTP/2 pseudo-headers from the screen proxy

### DIFF
--- a/apps/web/src/screen-proxy.test.ts
+++ b/apps/web/src/screen-proxy.test.ts
@@ -114,9 +114,23 @@ describe("noVNC proxy authorization", () => {
     ).toEqual({ upgrade: "websocket", "sec-websocket-key": "key" });
   });
 
+  it("does not forward HTTP/2 pseudo-headers to the HTTP/1 upstream", () => {
+    expect(
+      safeProxyHeaders({
+        ":method": "GET",
+        ":path": "/novnc/embed.html",
+        ":authority": "localhost:5173",
+        ":scheme": "https",
+        upgrade: "websocket",
+        "sec-websocket-key": "key",
+      }),
+    ).toEqual({ upgrade: "websocket", "sec-websocket-key": "key" });
+  });
+
   it("does not accept cookie or site-data mutations from a bot computer", () => {
     expect(
       safeProxyResponseHeaders({
+        ":status": "200",
         "content-type": "text/html",
         "set-cookie": ["session=attacker"],
         "clear-site-data": '"cookies"',

--- a/apps/web/src/screen-proxy.ts
+++ b/apps/web/src/screen-proxy.ts
@@ -118,10 +118,18 @@ function isAllowedTargetName(hostname: string) {
   );
 }
 
+function isHttp2PseudoHeader(key: string) {
+  return key.startsWith(":");
+}
+
 export function safeProxyHeaders(headers: IncomingHttpHeaders) {
   return Object.fromEntries(
     Object.entries(headers).filter(([key, value]) => {
-      return value != null && !SENSITIVE_FORWARD_HEADERS.has(key.toLowerCase());
+      return (
+        value != null &&
+        !isHttp2PseudoHeader(key) &&
+        !SENSITIVE_FORWARD_HEADERS.has(key.toLowerCase())
+      );
     }),
   );
 }
@@ -129,7 +137,11 @@ export function safeProxyHeaders(headers: IncomingHttpHeaders) {
 export function safeProxyResponseHeaders(headers: IncomingHttpHeaders) {
   return Object.fromEntries(
     Object.entries(headers).filter(([key, value]) => {
-      return value != null && !SENSITIVE_RESPONSE_HEADERS.has(key.toLowerCase());
+      return (
+        value != null &&
+        !isHttp2PseudoHeader(key) &&
+        !SENSITIVE_RESPONSE_HEADERS.has(key.toLowerCase())
+      );
     }),
   );
 }


### PR DESCRIPTION
## Why

Opening a computer screen over HTTP/2 crashed the Vite noVNC proxy. HTTP/2 pseudo-headers such as `:method` were copied onto the HTTP/1 upstream request, and Node rejected them with `Header name must be a valid HTTP token`.

## What changed

`safeProxyHeaders` and `safeProxyResponseHeaders` drop header names that start with `:`, so the screen proxy can forward HTTP/2 browser requests to the HTTP/1 noVNC upstream.

## How it was tested

Added a unit test that feeds `:method`, `:path`, `:authority`, `:scheme`, and `:status` through the sanitizers. The screen-proxy tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy handling by removing HTTP/2 pseudo-headers before forwarding requests and responses to HTTP/1 upstream services.
  * Preserved WebSocket upgrade headers during proxying.
  * Continued filtering sensitive headers while maintaining compatible request and response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->