### PR TITLE
Stack ask options as a vertical full-width list

### DIFF
--- a/apps/mobile/components/AskActions.tsx
+++ b/apps/mobile/components/AskActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Alert, Pressable, Text, View } from "react-native";
+import { mobileTokens } from "../lib/appearance";
 import { useI18n } from "../lib/i18n";
 
 type AskAction = { id: string; label: string };
@@ -20,6 +21,7 @@ export function AskActions({
   onAnswer: (answer: string) => Promise<void>;
 }) {
   const { t } = useI18n();
+  const tokens = mobileTokens();
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const submitting = pendingAction !== null;
 
@@ -39,38 +41,41 @@ export function AskActions({
   }
 
   return (
-    <View style={{ marginTop: 12, flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
-      {actions.map((action) => (
-        <Pressable
-          key={action.id}
-          disabled={disabled || submitting}
-          onPress={() => void submit(action.id)}
-          style={{
-            borderRadius: 11,
-            paddingHorizontal: 14,
-            paddingVertical: 8,
-            backgroundColor:
-              action.id === "allow" || action.id === "always" ? "#F1F1EF" : "transparent",
-            borderWidth: action.id === "deny" ? 1 : 0,
-            borderColor: "#26262A",
-            opacity: disabled || submitting ? 0.5 : 1,
-          }}
-        >
-          <Text
+    <View style={{ marginTop: 12, gap: 6 }}>
+      {actions.map((action) => {
+        const emphasized = action.id === "allow" || action.id === "always";
+        return (
+          <Pressable
+            key={action.id}
+            disabled={disabled || submitting}
+            onPress={() => void submit(action.id)}
             style={{
-              color: action.id === "allow" || action.id === "always" ? "#17171A" : "#C9C9CE",
-              fontSize: 14,
-              fontWeight: action.id === "allow" || action.id === "always" ? "600" : "400",
+              alignSelf: "stretch",
+              borderRadius: 12,
+              paddingHorizontal: 14,
+              paddingVertical: 12,
+              backgroundColor: emphasized ? tokens.muted : "transparent",
+              borderWidth: 1,
+              borderColor: tokens.border,
+              opacity: disabled || submitting ? 0.5 : 1,
             }}
           >
-            {pendingAction === action.id
-              ? t("Sending…")
-              : Object.hasOwn(KNOWN_ASK_ACTION_LABELS, action.id)
-                ? t(KNOWN_ASK_ACTION_LABELS[action.id]!)
-                : action.label}
-          </Text>
-        </Pressable>
-      ))}
+            <Text
+              style={{
+                color: tokens.foreground,
+                fontSize: 15,
+                fontWeight: emphasized ? "600" : "400",
+              }}
+            >
+              {pendingAction === action.id
+                ? t("Sending…")
+                : Object.hasOwn(KNOWN_ASK_ACTION_LABELS, action.id)
+                  ? t(KNOWN_ASK_ACTION_LABELS[action.id]!)
+                  : action.label}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }

--- a/apps/web/e2e/choice-card.spec.ts
+++ b/apps/web/e2e/choice-card.spec.ts
@@ -53,6 +53,10 @@ test("renders tappable choice buttons and submits the offered action id", async 
   expect(torontoBox!.y).toBeGreaterThan(seoulBox!.y + seoulBox!.height - 2);
   expect(Math.abs(berlinBox!.x - seoulBox!.x)).toBeLessThan(2);
   expect(Math.abs(berlinBox!.width - seoulBox!.width)).toBeLessThan(2);
+  const optionList = berlin.locator("xpath=ancestor::div[contains(@class,'space-y-1.5')][1]");
+  const listBox = await optionList.boundingBox();
+  expect(listBox).toBeTruthy();
+  expect(Math.abs(berlinBox!.width - listBox!.width)).toBeLessThan(2);
   await captureScreenshot(page, testInfo, "choice-card");
 
   await page.setViewportSize({ width: 390, height: 844 });

--- a/apps/web/e2e/choice-card.spec.ts
+++ b/apps/web/e2e/choice-card.spec.ts
@@ -41,12 +41,28 @@ test("renders tappable choice buttons and submits the offered action id", async 
   await expect(seoul).toBeVisible();
   await expect(toronto).toBeVisible();
   await expect(lisbon).toBeVisible();
+
+  // Options render as a vertical full-width list, not wrapping chips.
+  const berlinBox = await berlin.boundingBox();
+  const seoulBox = await seoul.boundingBox();
+  const torontoBox = await toronto.boundingBox();
+  expect(berlinBox).toBeTruthy();
+  expect(seoulBox).toBeTruthy();
+  expect(torontoBox).toBeTruthy();
+  expect(seoulBox!.y).toBeGreaterThan(berlinBox!.y + berlinBox!.height - 2);
+  expect(torontoBox!.y).toBeGreaterThan(seoulBox!.y + seoulBox!.height - 2);
+  expect(Math.abs(berlinBox!.x - seoulBox!.x)).toBeLessThan(2);
+  expect(Math.abs(berlinBox!.width - seoulBox!.width)).toBeLessThan(2);
   await captureScreenshot(page, testInfo, "choice-card");
 
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(berlin).toBeVisible();
   await expect(lisbon).toBeVisible();
-  // Wrapped buttons stay fully tappable on a narrow card.
+  const narrowBerlin = await berlin.boundingBox();
+  const narrowLisbon = await lisbon.boundingBox();
+  expect(narrowBerlin).toBeTruthy();
+  expect(narrowLisbon).toBeTruthy();
+  expect(narrowLisbon!.y).toBeGreaterThan(narrowBerlin!.y);
   await expect(lisbon).toBeEnabled();
   await captureScreenshot(page, testInfo, "choice-card-narrow");
 

--- a/apps/web/e2e/consequential-approval.spec.ts
+++ b/apps/web/e2e/consequential-approval.spec.ts
@@ -45,10 +45,20 @@ test("actions run by default while optional confirmations live in advanced user 
   });
 
   await requestDestinationWrite(page, "write this to the destination crm as a note again");
-  await expect(
-    page.getByRole("button", { name: "Always allow this tool", exact: true }),
-  ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Deny", exact: true })).toBeVisible();
+  const allowOnce = page.getByRole("button", { name: "Allow once", exact: true });
+  const alwaysAllow = page.getByRole("button", { name: "Always allow this tool", exact: true });
+  const deny = page.getByRole("button", { name: "Deny", exact: true });
+  await expect(alwaysAllow).toBeVisible();
+  await expect(deny).toBeVisible();
+  const allowBox = await allowOnce.boundingBox();
+  const alwaysBox = await alwaysAllow.boundingBox();
+  const denyBox = await deny.boundingBox();
+  expect(allowBox).toBeTruthy();
+  expect(alwaysBox).toBeTruthy();
+  expect(denyBox).toBeTruthy();
+  expect(alwaysBox!.y).toBeGreaterThan(allowBox!.y + allowBox!.height - 2);
+  expect(denyBox!.y).toBeGreaterThan(alwaysBox!.y + alwaysBox!.height - 2);
+  expect(Math.abs(allowBox!.x - alwaysBox!.x)).toBeLessThan(2);
   await captureScreenshot(page, testInfo, "53-action-confirmation-pending");
 
   await page.getByRole("button", { name: "Deny", exact: true }).click();

--- a/apps/web/e2e/consequential-approval.spec.ts
+++ b/apps/web/e2e/consequential-approval.spec.ts
@@ -59,6 +59,10 @@ test("actions run by default while optional confirmations live in advanced user 
   expect(alwaysBox!.y).toBeGreaterThan(allowBox!.y + allowBox!.height - 2);
   expect(denyBox!.y).toBeGreaterThan(alwaysBox!.y + alwaysBox!.height - 2);
   expect(Math.abs(allowBox!.x - alwaysBox!.x)).toBeLessThan(2);
+  const optionList = allowOnce.locator("xpath=ancestor::div[contains(@class,'space-y-1.5')][1]");
+  const listBox = await optionList.boundingBox();
+  expect(listBox).toBeTruthy();
+  expect(Math.abs(allowBox!.width - listBox!.width)).toBeLessThan(2);
   await captureScreenshot(page, testInfo, "53-action-confirmation-pending");
 
   await page.getByRole("button", { name: "Deny", exact: true }).click();

--- a/apps/web/src/components/AskCard.tsx
+++ b/apps/web/src/components/AskCard.tsx
@@ -98,11 +98,12 @@ export function AskCard({
           <Trans>No longer active</Trans>
         </div>
       ) : askActions?.length ? (
-        <div className="mt-3.5 flex flex-wrap gap-2">
+        <div className="mt-3.5 space-y-1.5">
           {askActions.map((action) => (
             <Button
               key={action.id}
               variant={approvalActions && action.id === "allow" ? "default" : "outline"}
+              className="h-auto w-full justify-start px-3.5 py-3 text-start font-normal"
               disabled={submitting}
               onClick={() => void submitAnswer(action.id)}
             >

--- a/apps/web/src/components/AskCard.tsx
+++ b/apps/web/src/components/AskCard.tsx
@@ -103,7 +103,7 @@ export function AskCard({
             <Button
               key={action.id}
               variant={approvalActions && action.id === "allow" ? "default" : "outline"}
-              className="h-auto w-full justify-start px-3.5 py-3 text-start font-normal"
+              className="h-auto w-full justify-start whitespace-normal px-3.5 py-3 text-start font-normal"
               disabled={submitting}
               onClick={() => void submitAnswer(action.id)}
             >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Ask cards with several options rendered as wrapping chips, so long labels sat side by side and wrapped awkwardly. Option asks should read as a clear vertical list of full-width rows, like onboarding ChoiceCard.

## What changed
- Web `AskCard`: pending option actions use `space-y-1.5` with full-width `Button` rows (`w-full justify-start whitespace-normal`) instead of `flex flex-wrap`
- Mobile `AskActions`: column stack of stretch rows; approval emphasis kept; colors via `mobileTokens`
- E2E: `choice-card` and `consequential-approval` assert stacked bounding boxes and full-width vs the option list container

Free-text / secret ask layouts are unchanged aside from the shared option-action container.

## CI screenshots
- [choice-card](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33866919620-1/screenshots/images/099-choice-card.png) — cities stacked as full-width rows
- [choice-card-narrow](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33866919620-1/screenshots/images/098-choice-card-narrow.png)
- [53-action-confirmation-pending](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33866919620-1/screenshots/images/087-53-action-confirmation-pending.png) — Allow once / Always / Deny stacked
- [Screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/604/index.html)

## Test plan
- [x] CI `choice-card` E2E screenshot shows stacked city options
- [x] CI `consequential-approval` pending frame shows Allow once / Always / Deny stacked
- [x] Web E2E geometry asserts for vertical + full-width rows passed
- [ ] Product UI review of long-label asks (hold merge)

## Hold
Do not merge until product UI review.

Tip: `3bf0fc02488b4a285b990160de81e49852f7b28f`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64bedf60-12fc-4f82-a5cc-42a86d0b0a2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64bedf60-12fc-4f82-a5cc-42a86d0b0a2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Ask-action buttons now appear as full-width, vertically stacked options on mobile and web.
  * Updated button spacing, alignment, borders, and colors for improved consistency and readability.
  * Preserved existing action labels and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->