### PR TITLE
fix(adapters): mention private reverse proxy in public endpoint block error

### DIFF
--- a/packages/adapters/src/openai-compatible-url.test.ts
+++ b/packages/adapters/src/openai-compatible-url.test.ts
@@ -114,7 +114,7 @@ describe("openai-compatible URL policy", () => {
     delete process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC;
     expect(openAiCompatAllowPublicHosts()).toBe(false);
     expect(() => assertAllowedOpenAiCompatibleUrl("https://api.example.com/v1")).toThrow(
-      /Public model endpoints are blocked/,
+      /Public model endpoints are blocked.*private reverse proxy.*RFC1918/s,
     );
 
     process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC = "1";

--- a/packages/adapters/src/openai-compatible-url.ts
+++ b/packages/adapters/src/openai-compatible-url.ts
@@ -111,7 +111,7 @@ export function assertAllowedOpenAiCompatibleRequestUrl(
   if (isPrivateOpenAiCompatibleHostname(hostname)) return url;
   if (!allowPublic) {
     throw new Error(
-      "Public model endpoints are blocked. Set RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1 to allow them.",
+      "Public model endpoints are blocked. Set RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1 to allow them. A private reverse proxy on localhost or an RFC1918 address does not need that gate.",
     );
   }
   return url;


### PR DESCRIPTION
## Summary
- When public OpenAI-compatible endpoints are blocked, the error now also notes that a private reverse proxy on localhost or an RFC1918 address does not need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC`.
- Behavior and allow-list defaults are unchanged; docs-only clarification in the thrown message + unit test.

## Test plan
- [x] `vitest run packages/adapters/src/openai-compatible-url.test.ts` (12 passed)
- [x] biome check on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified the error message shown when a public OpenAI-compatible endpoint is blocked.
  * Added guidance that private reverse proxies and RFC1918 addresses do not require the public-access override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->