### PR TITLE
fix(adapters): extend OpenAI-compat probe hand-fill hint

### DIFF
--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -266,7 +266,11 @@ describe("openai-compatible provider", () => {
       throw new DOMException("The operation was aborted.", "AbortError");
     };
     await expect(
-      probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl, caller.signal),
+      probeOpenAiCompatibleModels(
+        { baseUrl: "http://127.0.0.1:8000/v1" },
+        fetchImpl,
+        caller.signal,
+      ),
     ).rejects.toMatchObject({ name: "AbortError" });
   });
 

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -199,7 +199,7 @@ describe("openai-compatible provider", () => {
     };
     await expect(
       probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
-    ).rejects.toThrow(/redirect/i);
+    ).rejects.toThrow(/redirect.*explicit model id/is);
   });
 
   it("clarifies non-2xx probe failures with status and hand-fill hint", async () => {
@@ -227,7 +227,7 @@ describe("openai-compatible provider", () => {
     const fetchImpl = async () => new Response("x".repeat(64 * 1024 + 1));
     await expect(
       probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
-    ).rejects.toThrow(/too large/i);
+    ).rejects.toThrow(/too large.*explicit model id/is);
   });
 
   it("cancels model responses whose declared size exceeds the limit", async () => {
@@ -243,8 +243,31 @@ describe("openai-compatible provider", () => {
       );
     await expect(
       probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
-    ).rejects.toThrow(/too large/i);
+    ).rejects.toThrow(/too large.*explicit model id/is);
     expect(cancelled).toBe(true);
+  });
+
+  it("clarifies probe timeouts with hand-fill hint", async () => {
+    const fetchImpl: typeof fetch = async (_input, init) =>
+      new Promise((_, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    await expect(
+      probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
+    ).rejects.toThrow(/timed out.*explicit model id/is);
+  });
+
+  it("preserves caller AbortError without rewriting as timeout", async () => {
+    const caller = new AbortController();
+    caller.abort();
+    const fetchImpl: typeof fetch = async () => {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    };
+    await expect(
+      probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl, caller.signal),
+    ).rejects.toMatchObject({ name: "AbortError" });
   });
 
   it("lists openai-compatible in the catalog even without RAKAZO_LOCAL_MODELS", () => {

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -336,7 +336,9 @@ export async function probeOpenAiCompatibleModels(
     });
     if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
       await response.body?.cancel().catch(() => undefined);
-      throw new Error(`Model server redirects are not allowed. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`);
+      throw new Error(
+        `Model server redirects are not allowed. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`,
+      );
     }
     if (!response.ok) {
       await response.body?.cancel().catch(() => undefined);

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -290,7 +290,7 @@ async function readBoundedJson(response: Response): Promise<OpenAiCompatibleMode
   const declaredSize = Number(response.headers.get("content-length") ?? 0);
   if (declaredSize > MAX_MODELS_RESPONSE_BYTES) {
     await response.body?.cancel().catch(() => undefined);
-    throw new Error("Model server response is too large");
+    throw new Error(`Model server response is too large. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`);
   }
   if (!response.body) throw new Error("Model server returned an empty response");
   const reader = response.body.getReader();
@@ -303,7 +303,7 @@ async function readBoundedJson(response: Response): Promise<OpenAiCompatibleMode
     bytes += value.byteLength;
     if (bytes > MAX_MODELS_RESPONSE_BYTES) {
       await reader.cancel().catch(() => undefined);
-      throw new Error("Model server response is too large");
+      throw new Error(`Model server response is too large. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`);
     }
     text += decoder.decode(value, { stream: true });
   }
@@ -336,7 +336,7 @@ export async function probeOpenAiCompatibleModels(
     });
     if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
       await response.body?.cancel().catch(() => undefined);
-      throw new Error("Model server redirects are not allowed");
+      throw new Error(`Model server redirects are not allowed. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`);
     }
     if (!response.ok) {
       await response.body?.cancel().catch(() => undefined);
@@ -346,6 +346,18 @@ export async function probeOpenAiCompatibleModels(
     }
     const body = await readBoundedJson(response);
     return probeModelIds(body);
+  } catch (error) {
+    const aborted =
+      (error instanceof Error && error.name === "AbortError") ||
+      (typeof DOMException !== "undefined" &&
+        error instanceof DOMException &&
+        error.name === "AbortError");
+    if (aborted) {
+      // Caller-cancelled probes keep the original AbortError; the 5s probe budget gets a hint.
+      if (signal?.aborted) throw error;
+      throw new Error(`Model server probe timed out. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`);
+    }
+    throw error;
   } finally {
     clearTimeout(timeout);
   }


### PR DESCRIPTION
## Summary
- Extends the #586 `You can still Connect with an explicit model id` suffix to OpenAI-compatible `/models` probe failures for **timeout**, **redirect**, and **oversized** responses (same shape as non-2xx / invalid JSON / missing list).
- Caller-cancelled probes still surface the original `AbortError` (not rewritten as timeout).

## Test plan
- [x] `vitest` `packages/adapters/src/pi-openai-compatible-provider.test.ts` (22 passed)
- [ ] CI

Does not touch `openai-compatible-url.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for oversized responses and disallowed redirects by explaining that connections can still be made with an explicit model ID.
  - Probe timeouts now provide a clear timeout message and the same explicit-model-ID guidance.
  - Preserved caller-initiated cancellation errors instead of incorrectly reporting them as timeouts.
  - Added clearer feedback when model discovery cannot complete within the allotted time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->