### PR TITLE
fix(adapters): clarify empty OpenAI-compat probe response

### DIFF
--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -223,6 +223,13 @@ describe("openai-compatible provider", () => {
     ).rejects.toThrow(/invalid JSON.*explicit model id/s);
   });
 
+  it("clarifies empty probe responses with hand-fill hint", async () => {
+    const fetchImpl = async () => new Response(null, { status: 200 });
+    await expect(
+      probeOpenAiCompatibleModels({ baseUrl: "http://127.0.0.1:8000/v1" }, fetchImpl),
+    ).rejects.toThrow(/empty response.*explicit model id/s);
+  });
+
   it("rejects oversized model lists", async () => {
     const fetchImpl = async () => new Response("x".repeat(64 * 1024 + 1));
     await expect(

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -292,7 +292,11 @@ async function readBoundedJson(response: Response): Promise<OpenAiCompatibleMode
     await response.body?.cancel().catch(() => undefined);
     throw new Error("Model server response is too large");
   }
-  if (!response.body) throw new Error("Model server returned an empty response");
+  if (!response.body) {
+    throw new Error(
+      `Model server returned an empty response. ${OPENAI_COMPAT_PROBE_HAND_FILL_HINT}`,
+    );
+  }
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let bytes = 0;


### PR DESCRIPTION
## Summary
- When `/models` returns HTTP 200 with an empty body, append the same #586 hand-fill hint so probe failures stay actionable.
- Orthogonal to timeout/redirect/too-large probe hints; does not change public-block or ALLOW_PUBLIC behavior.

## Test plan
- [x] vitest packages/adapters/src/pi-openai-compatible-provider.test.ts (21 passed)
- [x] biome check on touched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when a model server returns an empty response.
  * Errors now include guidance to connect using an explicit model ID.
  * Added coverage to verify the updated error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->