### PR TITLE
fix(adapters): block cloud metadata model endpoints

### DIFF
--- a/packages/adapters/src/network-address.test.ts
+++ b/packages/adapters/src/network-address.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isLinkLocalAddress, isPrivateAddress } from "./network-address.js";
+import { isCloudMetadataAddress, isLinkLocalAddress, isPrivateAddress } from "./network-address.js";
 
 describe("network address classification", () => {
   it.each([
@@ -52,4 +52,23 @@ describe("network address classification", () => {
   ])("classifies %s as public", (address) => {
     expect(isPrivateAddress(address)).toBe(false);
   });
+
+  it.each([
+    "169.254.169.254",
+    "100.100.100.200",
+    "fd00:ec2::254",
+    "fd00:0ec2:0000:0000:0000:0000:0000:0254",
+    "::ffff:100.100.100.200",
+    "64:ff9b::6464:64c8",
+    "2002:6464:64c8::1",
+  ])("classifies %s as a cloud metadata address", (address) => {
+    expect(isCloudMetadataAddress(address)).toBe(true);
+  });
+
+  it.each(["10.0.0.1", "100.100.100.201", "fd00:ec2::255"])(
+    "does not classify %s as a cloud metadata address",
+    (address) => {
+      expect(isCloudMetadataAddress(address)).toBe(false);
+    },
+  );
 });

--- a/packages/adapters/src/network-address.ts
+++ b/packages/adapters/src/network-address.ts
@@ -3,6 +3,12 @@ import { isIP, type LookupFunction } from "node:net";
 export type ResolvedAddress = { address: string; family: number };
 export type ResolveHostname = (hostname: string) => Promise<ResolvedAddress[]>;
 
+const CLOUD_METADATA_IPV4 = new Set([
+  ipv4ToNumber("169.254.169.254"),
+  ipv4ToNumber("100.100.100.200"),
+]);
+const AWS_IMDS_IPV6 = 0xfd000ec2000000000000000000000254n;
+
 export function createAddressCheckedLookup(
   resolve: ResolveHostname,
   validate: (addresses: ResolvedAddress[], hostname: string) => void,
@@ -42,18 +48,8 @@ export function isPrivateAddress(address: string): boolean {
     if (topTenBits === 0x3fan || topTenBits === 0x3fbn) return true;
     // fc00::/7 unique local (ULA), including fd00::/8
     if (((ipv6 >> 120n) & 0xfen) === 0xfcn) return true;
-    // ::ffff:0:0/96 IPv4-mapped
-    if (ipv6 >> 32n === 0xffffn) return isPrivateIpv4Number(Number(ipv6 & 0xffffffffn));
-    // ::/96 IPv4-compatible (deprecated) and other low :: embeddings
-    if (ipv6 >> 32n === 0n) return true;
-    // 64:ff9b::/96 NAT64 well-known prefix — treat as private when the embedded v4 is
-    if (ipv6 >> 32n === 0x64ff9bn << 64n) {
-      return isPrivateIpv4Number(Number(ipv6 & 0xffffffffn));
-    }
-    // 2002::/16 6to4 — IPv4 lives in the next 32 bits after the 2002 prefix
-    if (ipv6 >> 112n === 0x2002n) {
-      return isPrivateIpv4Number(Number((ipv6 >> 80n) & 0xffffffffn));
-    }
+    const embeddedIpv4 = getEmbeddedIpv4Number(ipv6);
+    if (embeddedIpv4 !== undefined) return isPrivateIpv4Number(embeddedIpv4);
     return false;
   }
   const octets = ipv4.split(".").map(Number);
@@ -69,6 +65,19 @@ export function isPrivateAddress(address: string): boolean {
     (a === 198 && (b === 18 || b === 19)) ||
     (a != null && a >= 224)
   );
+}
+
+export function isCloudMetadataAddress(address: string): boolean {
+  const value = address.toLowerCase().replace(/^\[|\]$/g, "");
+  const mapped = value.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1];
+  const ipv4 = mapped ?? (isIP(value) === 4 ? value : undefined);
+  if (ipv4) return isCloudMetadataIpv4Number(ipv4ToNumber(ipv4));
+
+  const ipv6 = parseIpv6(value);
+  if (ipv6 === undefined) return false;
+  if (ipv6 === AWS_IMDS_IPV6) return true;
+  const embeddedIpv4 = getEmbeddedIpv4Number(ipv6);
+  return embeddedIpv4 !== undefined && isCloudMetadataIpv4Number(embeddedIpv4);
 }
 
 export function isLinkLocalAddress(address: string): boolean {
@@ -116,6 +125,25 @@ function replaceIpv4Tail(value: string, tail: string): string | undefined {
   const first = ((a << 8) | b).toString(16);
   const second = ((c << 8) | d).toString(16);
   return `${value.slice(0, value.lastIndexOf(":") + 1)}${first}:${second}`;
+}
+
+function ipv4ToNumber(value: string): number {
+  return value.split(".").reduce((result, octet) => (result << 8) | Number(octet), 0) >>> 0;
+}
+
+function getEmbeddedIpv4Number(ipv6: bigint): number | undefined {
+  const ipv4Prefix = ipv6 >> 32n;
+  // ::ffff:0:0/96 IPv4-mapped and ::/96 IPv4-compatible (deprecated).
+  if (ipv4Prefix === 0xffffn || ipv4Prefix === 0n) return Number(ipv6 & 0xffffffffn);
+  // 64:ff9b::/96 NAT64 well-known prefix.
+  if (ipv4Prefix === 0x64ff9bn << 64n) return Number(ipv6 & 0xffffffffn);
+  // 2002::/16 6to4 — IPv4 lives in the next 32 bits after the prefix.
+  if (ipv6 >> 112n === 0x2002n) return Number((ipv6 >> 80n) & 0xffffffffn);
+  return undefined;
+}
+
+function isCloudMetadataIpv4Number(value: number): boolean {
+  return CLOUD_METADATA_IPV4.has(value);
 }
 
 function isPrivateIpv4Number(value: number): boolean {

--- a/packages/adapters/src/openai-compatible-url.test.ts
+++ b/packages/adapters/src/openai-compatible-url.test.ts
@@ -108,6 +108,20 @@ describe("openai-compatible URL policy", () => {
     expect(() => assertAllowedOpenAiCompatibleUrl("http://metadata.google.internal/")).toThrow(
       /blocked metadata or link-local host/,
     );
+    expect(() =>
+      assertAllowedOpenAiCompatibleUrl("http://100.100.100.200/latest/meta-data/"),
+    ).toThrow(/blocked metadata or link-local host/);
+    expect(() =>
+      assertAllowedOpenAiCompatibleUrl("http://[::ffff:100.100.100.200]/latest/meta-data/"),
+    ).toThrow(/blocked metadata or link-local host/);
+    expect(() =>
+      assertAllowedOpenAiCompatibleUrl("http://[fd00:ec2::254]/latest/meta-data/"),
+    ).toThrow(/blocked metadata or link-local host/);
+    expect(() =>
+      assertAllowedOpenAiCompatibleUrl(
+        "http://[fd00:0ec2:0000:0000:0000:0000:0000:0254]/latest/meta-data/",
+      ),
+    ).toThrow(/blocked metadata or link-local host/);
   });
 
   it("rejects public hosts unless explicitly allowed", () => {

--- a/packages/adapters/src/openai-compatible-url.ts
+++ b/packages/adapters/src/openai-compatible-url.ts
@@ -1,10 +1,10 @@
 import { isIP } from "node:net";
 import { OPENAI_COMPATIBLE_PROVIDER_ID } from "@rakazo/contracts";
-import { isLinkLocalAddress, isPrivateAddress } from "./network-address.js";
+import { isCloudMetadataAddress, isLinkLocalAddress, isPrivateAddress } from "./network-address.js";
 
 export { OPENAI_COMPATIBLE_PROVIDER_ID };
 
-const METADATA_HOSTS = new Set(["metadata.google.internal", "metadata.goog", "169.254.169.254"]);
+const METADATA_HOSTS = new Set(["metadata.google.internal", "metadata.goog"]);
 
 export function openAiCompatAllowPublicHosts(): boolean {
   return process.env.RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC === "1";
@@ -57,7 +57,9 @@ export function isPrivateOpenAiCompatibleHostname(hostname: string): boolean {
 function isBlockedHostname(hostname: string): boolean {
   const normalized = normalizeHostname(hostname);
   return (
-    METADATA_HOSTS.has(normalized) || (isIP(normalized) !== 0 && isLinkLocalAddress(normalized))
+    METADATA_HOSTS.has(normalized) ||
+    (isIP(normalized) !== 0 &&
+      (isCloudMetadataAddress(normalized) || isLinkLocalAddress(normalized)))
   );
 }
 

--- a/packages/adapters/src/pi-openai-compatible-provider.test.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.test.ts
@@ -155,6 +155,21 @@ describe("openai-compatible provider", () => {
     });
   });
 
+  it.each([
+    ["100.100.100.200", 4],
+    ["fd00:ec2::254", 6],
+  ])("rejects local hostnames that resolve to metadata address %s", async (address, family) => {
+    const lookup = createOpenAiCompatibleLookup(new URL("http://localhost:8000/v1"), async () => [
+      { address, family },
+    ]);
+    const error = await new Promise<Error | null>((resolve) => {
+      lookup("localhost", { family: 0, all: false }, (lookupError) => resolve(lookupError));
+    });
+    expect(error).toMatchObject({
+      message: "Model server hostname resolved to a blocked metadata address",
+    });
+  });
+
   it("always exposes a catalog provider entry", () => {
     const provider = openAiCompatibleCatalogProvider();
     expect(provider.id).toBe(OPENAI_COMPATIBLE_PROVIDER_ID);

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -11,6 +11,7 @@ import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completio
 import { Agent } from "undici";
 import {
   createAddressCheckedLookup,
+  isCloudMetadataAddress,
   isLinkLocalAddress,
   isPrivateAddress,
   type ResolveHostname,
@@ -93,6 +94,9 @@ export function createOpenAiCompatibleLookup(
   const privateHostname = isPrivateOpenAiCompatibleHostname(hostname);
   return createAddressCheckedLookup(resolve, (addresses) => {
     if (addresses.length === 0) throw new Error("Model server did not resolve to an address");
+    if (addresses.some((entry) => isCloudMetadataAddress(entry.address))) {
+      throw new Error("Model server hostname resolved to a blocked metadata address");
+    }
     if (privateHostname) {
       if (
         addresses.some(


### PR DESCRIPTION
## Why

OpenAI-compatible endpoints intentionally allow private network addresses for self-hosted model servers. The AWS IMDS IPv6 address and Alibaba ECS metadata address also live in private address space, so a direct literal or private hostname alias could pass the local-model policy and reach instance metadata.

This keeps ordinary loopback, RFC1918, ULA, and CGNAT model endpoints available while separating known metadata addresses from other private addresses.

References: [AWS EC2 instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html), [Alibaba ECS instance metadata](https://www.alibabacloud.com/help/en/ecs/user-guide/view-instance-metadata/)

## What changed

- classify known cloud metadata IPv4 and IPv6 addresses separately from ordinary private addresses
- reject both direct metadata URLs and hostnames that resolve to metadata addresses
- cover equivalent IPv4-mapped, NAT64, and 6to4 address forms with deterministic offline tests

## Test plan

- adapters unit suite: 1,078 passed; 7 repository-defined skips
- adapters TypeScript check
- Biome check on all touched files
- staged diff whitespace check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Expanded protection against requests to cloud metadata endpoints across IPv4, IPv6, mapped, NAT64, and 6to4 address formats.
  * OpenAI-compatible integrations now block hostnames that resolve to cloud metadata addresses.
  * Added coverage for allowed and blocked metadata address variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->