### PR TITLE
Add opt-in Android screenshot catalog

### DIFF
--- a/.github/scripts/capture-mobile-android-screenshots.sh
+++ b/.github/scripts/capture-mobile-android-screenshots.sh
@@ -13,6 +13,7 @@ cleanup() {
   if [[ -n "$metro_pid" ]]; then
     kill "$metro_pid" 2>/dev/null || true
   fi
+  adb logcat -d -t 1000 > "$report_dir/android.log" 2>/dev/null || true
   cp "$run_log" "$report_dir/run.log" 2>/dev/null || true
   cp "$metro_log" "$report_dir/metro.log" 2>/dev/null || true
 }
@@ -20,7 +21,8 @@ trap cleanup EXIT
 
 adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
 adb reverse tcp:8081 tcp:8081
-pnpm --filter @rakazo/mobile exec expo start --port 8081 > "$metro_log" 2>&1 &
+EXPO_UNSTABLE_HEADLESS=1 pnpm --filter @rakazo/mobile exec expo start --port 8081 \
+  > "$metro_log" 2>&1 &
 metro_pid=$!
 
 for attempt in {1..60}; do

--- a/.github/scripts/capture-mobile-android-screenshots.sh
+++ b/.github/scripts/capture-mobile-android-screenshots.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+report_dir="test-report/mobile-screenshots"
+metro_log="${RUNNER_TEMP:?}/rakazo-mobile-metro.log"
+metro_pid=""
+
+mkdir -p "$report_dir"
+exec > >(tee "$report_dir/run.log") 2>&1
+
+cleanup() {
+  if [[ -n "$metro_pid" ]]; then
+    kill "$metro_pid" 2>/dev/null || true
+  fi
+  cp "$metro_log" "$report_dir/metro.log" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
+adb reverse tcp:8081 tcp:8081
+pnpm --filter @rakazo/mobile exec expo start --port 8081 > "$metro_log" 2>&1 &
+metro_pid=$!
+
+for attempt in {1..60}; do
+  if curl --fail --silent http://127.0.0.1:8081/status | grep -q running; then
+    break
+  fi
+  if [[ "$attempt" == 60 ]]; then
+    echo "Metro did not become ready." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+pnpm test:mobile-screenshots

--- a/.github/scripts/capture-mobile-android-screenshots.sh
+++ b/.github/scripts/capture-mobile-android-screenshots.sh
@@ -23,4 +23,4 @@ adb logcat -c
 adb logcat > "$android_log" &
 android_log_pid=$!
 
-pnpm test:mobile-screenshots
+timeout --signal=INT --kill-after=30s 10m pnpm test:mobile-screenshots

--- a/.github/scripts/capture-mobile-android-screenshots.sh
+++ b/.github/scripts/capture-mobile-android-screenshots.sh
@@ -2,38 +2,25 @@
 set -euo pipefail
 
 report_dir="test-report/mobile-screenshots"
-metro_log="${RUNNER_TEMP:?}/rakazo-mobile-metro.log"
 run_log="${RUNNER_TEMP:?}/rakazo-mobile-screenshots.log"
-metro_pid=""
+android_log="${RUNNER_TEMP:?}/rakazo-mobile-android.log"
+android_log_pid=""
 
 mkdir -p "$report_dir"
 exec > >(tee "$run_log") 2>&1
 
 cleanup() {
-  if [[ -n "$metro_pid" ]]; then
-    kill "$metro_pid" 2>/dev/null || true
+  if [[ -n "$android_log_pid" ]]; then
+    kill "$android_log_pid" 2>/dev/null || true
   fi
-  adb logcat -d -t 1000 > "$report_dir/android.log" 2>/dev/null || true
+  cp "$android_log" "$report_dir/android.log" 2>/dev/null || true
   cp "$run_log" "$report_dir/run.log" 2>/dev/null || true
-  cp "$metro_log" "$report_dir/metro.log" 2>/dev/null || true
 }
 trap cleanup EXIT
 
-adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
-adb reverse tcp:8081 tcp:8081
-EXPO_UNSTABLE_HEADLESS=1 pnpm --filter @rakazo/mobile exec expo start --port 8081 \
-  > "$metro_log" 2>&1 &
-metro_pid=$!
-
-for attempt in {1..60}; do
-  if curl --fail --silent http://127.0.0.1:8081/status | grep -q running; then
-    break
-  fi
-  if [[ "$attempt" == 60 ]]; then
-    echo "Metro did not become ready." >&2
-    exit 1
-  fi
-  sleep 1
-done
+adb install -r apps/mobile/android/app/build/outputs/apk/release/app-release.apk
+adb logcat -c
+adb logcat > "$android_log" &
+android_log_pid=$!
 
 pnpm test:mobile-screenshots

--- a/.github/scripts/capture-mobile-android-screenshots.sh
+++ b/.github/scripts/capture-mobile-android-screenshots.sh
@@ -3,15 +3,17 @@ set -euo pipefail
 
 report_dir="test-report/mobile-screenshots"
 metro_log="${RUNNER_TEMP:?}/rakazo-mobile-metro.log"
+run_log="${RUNNER_TEMP:?}/rakazo-mobile-screenshots.log"
 metro_pid=""
 
 mkdir -p "$report_dir"
-exec > >(tee "$report_dir/run.log") 2>&1
+exec > >(tee "$run_log") 2>&1
 
 cleanup() {
   if [[ -n "$metro_pid" ]]; then
     kill "$metro_pid" 2>/dev/null || true
   fi
+  cp "$run_log" "$report_dir/run.log" 2>/dev/null || true
   cp "$metro_log" "$report_dir/metro.log" 2>/dev/null || true
 }
 trap cleanup EXIT

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -66,7 +66,15 @@ jobs:
           "$HOME/.maestro/bin/maestro" --version
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
+      - name: Restore screenshot APK
+        id: screenshot-apk
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: apps/mobile/android/app/build/outputs/apk/release/app-release.apk
+          key: mobile-android-apk-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'pnpm-workspace.yaml', 'turbo.json', 'tsconfig*.json', 'apps/mobile/package.json', 'apps/mobile/app.json', 'apps/mobile/assets/**', 'apps/mobile/app/**', 'apps/mobile/components/**', 'apps/mobile/lib/**', 'apps/mobile/modules/**', 'apps/mobile/plugins/**', 'packages/**') }}
+
       - name: Generate Android project
+        if: steps.screenshot-apk.outputs.cache-hit != 'true'
         run: |
           pnpm --filter @rakazo/mobile exec expo prebuild --platform android --no-install
           sed -i 's/<application /<application android:usesCleartextTraffic="true" /' \
@@ -75,8 +83,16 @@ jobs:
             apps/mobile/android/gradle.properties
 
       - name: Build screenshot APK
+        if: steps.screenshot-apk.outputs.cache-hit != 'true'
         working-directory: apps/mobile/android
         run: ./gradlew app:packageRelease -PreactNativeArchitectures=x86_64 --no-daemon
+
+      - name: Save screenshot APK
+        if: steps.screenshot-apk.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: apps/mobile/android/app/build/outputs/apk/release/app-release.apk
+          key: ${{ steps.screenshot-apk.outputs.cache-primary-key }}
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -17,7 +17,7 @@ jobs:
   screenshots:
     name: Capture Android UI
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -68,15 +68,22 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.maestro
-          key: maestro-${{ runner.os }}-2.6.1
+          key: maestro-${{ runner.os }}-2.6.1-3440825f
 
       - name: Install pinned Maestro CLI
         if: steps.maestro-cache.outputs.cache-hit != 'true'
-        env:
-          MAESTRO_VERSION: 2.6.1
         run: |
           set -euo pipefail
-          curl --fail --silent --show-error --location https://get.maestro.mobile.dev | bash
+          maestro_tmp=$(mktemp -d)
+          trap 'rm -rf "$maestro_tmp"' EXIT
+          curl --fail --silent --show-error --location \
+            https://github.com/mobile-dev-inc/maestro/releases/download/cli-2.6.1/maestro.zip \
+            --output "$maestro_tmp/maestro.zip"
+          echo "3440825f514f537c6a96bcf5de995780c2a4a7f83a43208fdc95d4f1fecfad3b  $maestro_tmp/maestro.zip" |
+            sha256sum --check
+          unzip -q "$maestro_tmp/maestro.zip" -d "$maestro_tmp"
+          mkdir -p "$HOME/.maestro"
+          cp -R "$maestro_tmp/maestro/." "$HOME/.maestro/"
 
       - name: Configure Maestro CLI
         run: |

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: apps/mobile/android/app/build/outputs/apk/release/app-release.apk
-          key: mobile-android-apk-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'pnpm-workspace.yaml', 'turbo.json', 'tsconfig*.json', 'apps/mobile/package.json', 'apps/mobile/app.json', 'apps/mobile/assets/**', 'apps/mobile/app/**', 'apps/mobile/components/**', 'apps/mobile/lib/**', 'apps/mobile/modules/**', 'apps/mobile/plugins/**', 'packages/**') }}
+          key: mobile-android-apk-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'pnpm-workspace.yaml', 'turbo.json', 'tsconfig*.json', 'apps/mobile/package.json', 'apps/mobile/app.json', 'apps/mobile/assets/**', 'apps/mobile/app/**', 'apps/mobile/components/**', 'apps/mobile/lib/**', 'apps/mobile/modules/**', 'apps/mobile/plugins/**', 'packages/chat-ui/**', 'packages/contracts/**', 'packages/core/**', 'packages/ui-tokens/**') }}
 
       - name: Generate Android project
         if: steps.screenshot-apk.outputs.cache-hit != 'true'

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -51,6 +51,8 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
+        with:
+          cache-read-only: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -1,0 +1,120 @@
+name: mobile Android screenshots
+
+on:
+  push:
+    branches:
+      - mobile-screenshot-workflow
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-android-screenshots
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    name: Capture Android UI
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: rakazo
+          POSTGRES_PASSWORD: rakazo
+          POSTGRES_DB: rakazo
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U rakazo"
+          --health-interval 3s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      CI: "1"
+      DATABASE_URL: postgres://rakazo:rakazo@127.0.0.1:5433/rakazo
+      EXPO_PUBLIC_API_URL: http://10.0.2.2:3110
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install pinned Maestro CLI
+        env:
+          MAESTRO_VERSION: 2.6.1
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location https://get.maestro.mobile.dev | bash
+          "$HOME/.maestro/bin/maestro" --version
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Generate Android project
+        run: pnpm --filter @rakazo/mobile exec expo prebuild --platform android --no-install
+
+      - name: Build debug APK
+        working-directory: apps/mobile/android
+        run: ./gradlew assembleDebug --no-daemon
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm",GROUP="kvm",MODE="0666",OPTIONS+="static_node=kvm"' |
+            sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Capture screenshots
+        uses: reactivecircus/android-emulator-runner@c9c93e6ba9c4194322e114c40970d5983d9a07cc # v2.38.0
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          cores: 2
+          ram-size: 4096M
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          script: |
+            set -euo pipefail
+            mkdir -p test-report/mobile-screenshots
+            adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
+            adb reverse tcp:8081 tcp:8081
+            metro_log="$RUNNER_TEMP/rakazo-mobile-metro.log"
+            pnpm --filter @rakazo/mobile exec expo start --port 8081 > "$metro_log" 2>&1 &
+            metro_pid=$!
+            trap 'kill "$metro_pid" 2>/dev/null || true; mkdir -p test-report/mobile-screenshots; cp "$metro_log" test-report/mobile-screenshots/metro.log 2>/dev/null || true' EXIT
+            for attempt in {1..60}; do
+              if curl --fail --silent http://127.0.0.1:8081/status | grep -q running; then
+                break
+              fi
+              if [[ "$attempt" == 60 ]]; then
+                echo "Metro did not become ready." >&2
+                exit 1
+              fi
+              sleep 1
+            done
+            pnpm test:mobile-screenshots
+
+      - name: Upload screenshots and diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: mobile-android-screenshots-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-report/mobile-screenshots
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: apps/mobile/android/app/build/outputs/apk/release/app-release.apk
-          key: mobile-android-apk-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'pnpm-workspace.yaml', 'turbo.json', 'tsconfig*.json', 'apps/mobile/package.json', 'apps/mobile/app.json', 'apps/mobile/app.config.ts', 'apps/mobile/metro.config.js', 'apps/mobile/metro-resolver.js', 'apps/mobile/assets/**', 'apps/mobile/app/**', 'apps/mobile/components/**', 'apps/mobile/lib/**', 'apps/mobile/modules/**', 'apps/mobile/plugins/**', 'packages/chat-ui/**', 'packages/contracts/**', 'packages/core/**', 'packages/ui-tokens/**') }}
+          key: mobile-android-apk-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'pnpm-workspace.yaml', 'turbo.json', 'tsconfig*.json', '.github/workflows/mobile-android-screenshots.yml', 'apps/mobile/package.json', 'apps/mobile/app.json', 'apps/mobile/app.config.ts', 'apps/mobile/metro.config.js', 'apps/mobile/metro-resolver.js', 'apps/mobile/assets/**', 'apps/mobile/app/**', 'apps/mobile/components/**', 'apps/mobile/lib/**', 'apps/mobile/modules/**', 'apps/mobile/plugins/**', 'packages/chat-ui/**', 'packages/contracts/**', 'packages/core/**', 'packages/ui-tokens/**') }}
 
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build debug APK
         working-directory: apps/mobile/android
-        run: ./gradlew assembleDebug --no-daemon
+        run: ./gradlew app:assembleDebug -PreactNativeArchitectures=x86_64 --no-daemon
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -89,26 +89,7 @@ jobs:
           ram-size: 4096M
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          script: |
-            set -eu
-            mkdir -p test-report/mobile-screenshots
-            adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
-            adb reverse tcp:8081 tcp:8081
-            metro_log="$RUNNER_TEMP/rakazo-mobile-metro.log"
-            pnpm --filter @rakazo/mobile exec expo start --port 8081 > "$metro_log" 2>&1 &
-            metro_pid=$!
-            trap 'kill "$metro_pid" 2>/dev/null || true; mkdir -p test-report/mobile-screenshots; cp "$metro_log" test-report/mobile-screenshots/metro.log 2>/dev/null || true' EXIT
-            for attempt in $(seq 1 60); do
-              if curl --fail --silent http://127.0.0.1:8081/status | grep -q running; then
-                break
-              fi
-              if [ "$attempt" -eq 60 ]; then
-                echo "Metro did not become ready." >&2
-                exit 1
-              fi
-              sleep 1
-            done
-            pnpm test:mobile-screenshots
+          script: bash .github/scripts/capture-mobile-android-screenshots.sh
 
       - name: Upload screenshots and diagnostics
         if: always()

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -1,9 +1,6 @@
 name: mobile Android screenshots
 
 on:
-  push:
-    branches:
-      - mobile-screenshot-workflow
   workflow_dispatch:
 
 permissions:
@@ -41,6 +38,14 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
+
+      - name: Restore screenshot APK
+        id: screenshot-apk
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: apps/mobile/android/app/build/outputs/apk/release/app-release.apk
+          key: mobile-android-apk-v2-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'pnpm-workspace.yaml', 'turbo.json', 'tsconfig*.json', 'apps/mobile/package.json', 'apps/mobile/app.json', 'apps/mobile/app.config.ts', 'apps/mobile/metro.config.js', 'apps/mobile/metro-resolver.js', 'apps/mobile/assets/**', 'apps/mobile/app/**', 'apps/mobile/components/**', 'apps/mobile/lib/**', 'apps/mobile/modules/**', 'apps/mobile/plugins/**', 'packages/chat-ui/**', 'packages/contracts/**', 'packages/core/**', 'packages/ui-tokens/**') }}
+
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
@@ -51,27 +56,32 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
+        if: steps.screenshot-apk.outputs.cache-hit != 'true'
         with:
           cache-read-only: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Restore Maestro CLI
+        id: maestro-cache
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.maestro
+          key: maestro-${{ runner.os }}-2.6.1
+
       - name: Install pinned Maestro CLI
+        if: steps.maestro-cache.outputs.cache-hit != 'true'
         env:
           MAESTRO_VERSION: 2.6.1
         run: |
           set -euo pipefail
           curl --fail --silent --show-error --location https://get.maestro.mobile.dev | bash
+
+      - name: Configure Maestro CLI
+        run: |
           "$HOME/.maestro/bin/maestro" --version
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
-
-      - name: Restore screenshot APK
-        id: screenshot-apk
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: apps/mobile/android/app/build/outputs/apk/release/app-release.apk
-          key: mobile-android-apk-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'pnpm-workspace.yaml', 'turbo.json', 'tsconfig*.json', 'apps/mobile/package.json', 'apps/mobile/app.json', 'apps/mobile/assets/**', 'apps/mobile/app/**', 'apps/mobile/components/**', 'apps/mobile/lib/**', 'apps/mobile/modules/**', 'apps/mobile/plugins/**', 'packages/chat-ui/**', 'packages/contracts/**', 'packages/core/**', 'packages/ui-tokens/**') }}
 
       - name: Generate Android project
         if: steps.screenshot-apk.outputs.cache-hit != 'true'

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -65,11 +65,14 @@ jobs:
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
 
       - name: Generate Android project
-        run: pnpm --filter @rakazo/mobile exec expo prebuild --platform android --no-install
+        run: |
+          pnpm --filter @rakazo/mobile exec expo prebuild --platform android --no-install
+          sed -i 's/<application /<application android:usesCleartextTraffic="true" /' \
+            apps/mobile/android/app/src/main/AndroidManifest.xml
 
-      - name: Build debug APK
+      - name: Build screenshot APK
         working-directory: apps/mobile/android
-        run: ./gradlew app:assembleDebug -PreactNativeArchitectures=x86_64 --no-daemon
+        run: ./gradlew app:assembleRelease -PreactNativeArchitectures=x86_64 --no-daemon
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -76,11 +76,17 @@ jobs:
           set -euo pipefail
           maestro_tmp=$(mktemp -d)
           trap 'rm -rf "$maestro_tmp"' EXIT
+          base_url=https://github.com/mobile-dev-inc/maestro/releases/download/cli-2.6.1
           curl --fail --silent --show-error --location \
-            https://github.com/mobile-dev-inc/maestro/releases/download/cli-2.6.1/maestro.zip \
+            "$base_url/maestro.zip" \
             --output "$maestro_tmp/maestro.zip"
-          echo "3440825f514f537c6a96bcf5de995780c2a4a7f83a43208fdc95d4f1fecfad3b  $maestro_tmp/maestro.zip" |
-            sha256sum --check
+          curl --fail --silent --show-error --location \
+            "$base_url/checksums_sha256.txt" \
+            --output "$maestro_tmp/checksums_sha256.txt"
+          # Pin the expected digest in-repo so a swapped checksums file alone cannot pass.
+          echo "3440825f514f537c6a96bcf5de995780c2a4a7f83a43208fdc95d4f1fecfad3b  maestro.zip" |
+            (cd "$maestro_tmp" && sha256sum --check --strict -)
+          (cd "$maestro_tmp" && sha256sum --check --strict checksums_sha256.txt)
           unzip -q "$maestro_tmp/maestro.zip" -d "$maestro_tmp"
           mkdir -p "$HOME/.maestro"
           cp -R "$maestro_tmp/maestro/." "$HOME/.maestro/"

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -71,10 +71,12 @@ jobs:
           pnpm --filter @rakazo/mobile exec expo prebuild --platform android --no-install
           sed -i 's/<application /<application android:usesCleartextTraffic="true" /' \
             apps/mobile/android/app/src/main/AndroidManifest.xml
+          sed -i 's/MaxMetaspaceSize=512m/MaxMetaspaceSize=1g/' \
+            apps/mobile/android/gradle.properties
 
       - name: Build screenshot APK
         working-directory: apps/mobile/android
-        run: ./gradlew app:assembleRelease -PreactNativeArchitectures=x86_64 --no-daemon
+        run: ./gradlew app:packageRelease -PreactNativeArchitectures=x86_64 --no-daemon
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -90,7 +90,7 @@ jobs:
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
-            set -euo pipefail
+            set -eu
             mkdir -p test-report/mobile-screenshots
             adb install -r apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk
             adb reverse tcp:8081 tcp:8081
@@ -98,11 +98,11 @@ jobs:
             pnpm --filter @rakazo/mobile exec expo start --port 8081 > "$metro_log" 2>&1 &
             metro_pid=$!
             trap 'kill "$metro_pid" 2>/dev/null || true; mkdir -p test-report/mobile-screenshots; cp "$metro_log" test-report/mobile-screenshots/metro.log 2>/dev/null || true' EXIT
-            for attempt in {1..60}; do
+            for attempt in $(seq 1 60); do
               if curl --fail --silent http://127.0.0.1:8081/status | grep -q running; then
                 break
               fi
-              if [[ "$attempt" == 60 ]]; then
+              if [ "$attempt" -eq 60 ]; then
                 echo "Metro did not become ready." >&2
                 exit 1
               fi

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ apps/desktop/out
 apps/desktop/e2e/screenshots
 apps/mobile/.expo
 apps/mobile/dist
+apps/mobile/android
 apps/mobile/ios
 packages/db/src/generated
 infra/sandboxes/supervisor/dist

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -1,0 +1,131 @@
+appId: com.rakazo.app
+name: Rakazo mobile screenshots
+tags:
+  - screenshots
+---
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: deny
+
+- extendedWaitUntil:
+    visible: "Sign in to Rakazo"
+    timeout: 30000
+- takeScreenshot: "screenshots/01-sign-in"
+
+- tapOn: "Sign up"
+- assertVisible: "Sign up for Rakazo"
+- takeScreenshot: "screenshots/02-sign-up"
+- tapOn: "Sign in"
+- assertVisible: "Sign in to Rakazo"
+
+- tapOn: "Use a custom server"
+- assertVisible: "Server"
+- takeScreenshot: "screenshots/03-server"
+- tapOn: "Cancel"
+
+- tapOn: "Email"
+- inputText: ${RAKAZO_SCREENSHOT_EMAIL}
+- tapOn: "Password"
+- inputText: ${RAKAZO_SCREENSHOT_PASSWORD}
+- hideKeyboard
+- tapOn: "Sign in"
+
+- extendedWaitUntil:
+    visible: "Researcher"
+    timeout: 30000
+- takeScreenshot: "screenshots/04-inbox"
+
+- tapOn: "Activity"
+- extendedWaitUntil:
+    visible: "Recent"
+    timeout: 10000
+- takeScreenshot: "screenshots/05-activity"
+
+- tapOn: "Search"
+- inputText: "fixture"
+- hideKeyboard
+- extendedWaitUntil:
+    visible: "Weekly fixture review"
+    timeout: 10000
+- takeScreenshot: "screenshots/06-search-results"
+
+- openLink: "rakazo:///new"
+- assertVisible: "Name this bot"
+- takeScreenshot: "screenshots/07-new-bot"
+
+- openLink: "rakazo:///new-group"
+- assertVisible: "Name this group"
+- takeScreenshot: "screenshots/08-new-group"
+
+- openLink: "rakazo:///new-space"
+- assertVisible: "Customer support"
+- takeScreenshot: "screenshots/09-new-space"
+
+- openLink: "rakazo:///account"
+- extendedWaitUntil:
+    visible: "Password"
+    timeout: 10000
+- takeScreenshot: "screenshots/10-account"
+
+- openLink: "rakazo:///models"
+- extendedWaitUntil:
+    visible: "Active model"
+    timeout: 10000
+- takeScreenshot: "screenshots/11-models"
+
+- openLink: "rakazo:///voice"
+- extendedWaitUntil:
+    visible: "Scripted"
+    timeout: 10000
+- takeScreenshot: "screenshots/12-voice"
+
+- openLink: "rakazo:///integrations"
+- extendedWaitUntil:
+    visible: "Search apps"
+    timeout: 10000
+- takeScreenshot: "screenshots/13-integrations"
+- tapOn:
+    id: "integrations-advanced"
+- assertVisible: "Add MCP server"
+- takeScreenshot: "screenshots/14-integrations-advanced"
+
+- openLink: "rakazo:///thread?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
+- extendedWaitUntil:
+    visible: "The fixture workspace is ready."
+    timeout: 10000
+- takeScreenshot: "screenshots/15-thread"
+- tapOn: "Bot actions"
+- assertVisible: "Clear conversation"
+- takeScreenshot: "screenshots/16-bot-actions"
+- tapOn: "Cancel"
+
+- openLink: "rakazo:///bot-settings?botId=${RAKAZO_SCREENSHOT_BOT_ID}"
+- extendedWaitUntil:
+    visible: "Researcher"
+    timeout: 10000
+- takeScreenshot: "screenshots/17-bot-settings"
+
+- openLink: "rakazo:///computer?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
+- extendedWaitUntil:
+    visible: "Take control"
+    timeout: 10000
+- takeScreenshot: "screenshots/18-computer"
+
+- openLink: "rakazo:///group-thread?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}&name=Launch%20team"
+- extendedWaitUntil:
+    visible: "The fixture launch plan is ready."
+    timeout: 10000
+- takeScreenshot: "screenshots/19-group-thread"
+
+- openLink: "rakazo:///group-settings?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}"
+- extendedWaitUntil:
+    visible: "Delete group"
+    timeout: 10000
+- takeScreenshot: "screenshots/20-group-settings"
+
+- openLink: "rakazo:///routine?botId=${RAKAZO_SCREENSHOT_BOT_ID}&botName=Researcher&routineId=${RAKAZO_SCREENSHOT_ROUTINE_ID}"
+- extendedWaitUntil:
+    visible: "Weekly fixture review"
+    timeout: 10000
+- takeScreenshot: "screenshots/21-routine"

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -27,6 +27,9 @@ tags:
 - inputText: ${RAKAZO_SCREENSHOT_PASSWORD}
 - hideKeyboard
 - tapOn: "Sign in"
+- tapOn:
+    text: "Don’t allow"
+    optional: true
 
 - extendedWaitUntil:
     visible: "Researcher"

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -9,15 +9,12 @@ tags:
       notifications: deny
 
 - extendedWaitUntil:
-    visible: "Sign in to Rakazo"
+    visible: "Sign up for Rakazo"
     timeout: 30000
-- takeScreenshot: "screenshots/01-sign-in"
-
-- tapOn: "Sign up"
-- assertVisible: "Sign up for Rakazo"
 - takeScreenshot: "screenshots/02-sign-up"
 - tapOn: "Sign in"
 - assertVisible: "Sign in to Rakazo"
+- takeScreenshot: "screenshots/01-sign-in"
 
 - tapOn: "Use a custom server"
 - assertVisible: "Server"

--- a/apps/mobile/e2e/README.md
+++ b/apps/mobile/e2e/README.md
@@ -39,6 +39,3 @@ local session and endpoint data; it does not delete server-side bots.
 Run **Actions → mobile Android screenshots → Run workflow** to build the app, seed an isolated fake
 workspace, capture 21 Android emulator views, and upload the screenshots and Maestro report for
 seven days. It uses no repository secrets or hosted providers.
-
-The local equivalent is `pnpm test:mobile-screenshots`; it expects Postgres, an installed debug app,
-an Android emulator, and Metro on port 8081.

--- a/apps/mobile/e2e/README.md
+++ b/apps/mobile/e2e/README.md
@@ -33,3 +33,12 @@ pnpm --filter @rakazo/mobile test:e2e -- \
 
 Use a new bot name for each run if the backing database is persistent. `clearState` resets the app's
 local session and endpoint data; it does not delete server-side bots.
+
+## Screenshot catalog
+
+Run **Actions → mobile Android screenshots → Run workflow** to build the app, seed an isolated fake
+workspace, capture 21 Android emulator views, and upload the screenshots and Maestro report for
+seven days. It uses no repository secrets or hosted providers.
+
+The local equivalent is `pnpm test:mobile-screenshots`; it expects Postgres, an installed debug app,
+an Android emulator, and Metro on port 8081.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run",
     "test:integration": "tsx packages/testkit/src/cli/harness.ts --integration",
     "test:e2e": "tsx packages/testkit/src/cli/harness.ts --e2e",
-    "test:mobile-screenshots": "tsx packages/testkit/src/cli/mobile-screenshots.ts",
+    "test:mobile-screenshots": "pnpm --filter @rakazo/db generate && tsx packages/testkit/src/cli/mobile-screenshots.ts",
     "test:topology": "tsx packages/testkit/src/cli/topology.ts",
     "test:canary": "tsx packages/testkit/src/cli/canary.ts",
     "test:computer": "tsx packages/testkit/src/cli/computer.ts",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run",
     "test:integration": "tsx packages/testkit/src/cli/harness.ts --integration",
     "test:e2e": "tsx packages/testkit/src/cli/harness.ts --e2e",
+    "test:mobile-screenshots": "tsx packages/testkit/src/cli/mobile-screenshots.ts",
     "test:topology": "tsx packages/testkit/src/cli/topology.ts",
     "test:canary": "tsx packages/testkit/src/cli/canary.ts",
     "test:computer": "tsx packages/testkit/src/cli/computer.ts",

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -9,7 +9,7 @@ import {
   PipedreamConnector,
   ThirdPartyConnectorEmulator,
 } from "@rakazo/adapters";
-import { createThreadMessage, type PrismaClient } from "@rakazo/db";
+import type { PrismaClient } from "@rakazo/db";
 import { runProcess } from "./process.js";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
@@ -22,6 +22,7 @@ const API_PORT = 3110;
 const HOST_API_URL = `http://127.0.0.1:${API_PORT}`;
 
 type App = { request: (input: string, init?: RequestInit) => Response | Promise<Response> };
+type CreateThreadMessage = typeof import("@rakazo/db")["createThreadMessage"];
 
 async function main() {
   process.chdir(ROOT);
@@ -41,6 +42,7 @@ async function main() {
     env: process.env,
     stdio: "inherit",
   });
+  const { createThreadMessage } = await import("@rakazo/db");
 
   const thirdParties = new ThirdPartyConnectorEmulator();
   const pipedream = new PipedreamConnector(
@@ -68,7 +70,7 @@ async function main() {
     },
   });
 
-  const fixture = await seedFixture(handles.app, handles.prisma);
+  const fixture = await seedFixture(handles.app, handles.prisma, createThreadMessage);
   const server = serve({
     fetch: handles.app.fetch,
     hostname: "0.0.0.0",
@@ -141,7 +143,11 @@ function configureEnvironment() {
   });
 }
 
-async function seedFixture(app: App, prisma: PrismaClient) {
+async function seedFixture(
+  app: App,
+  prisma: PrismaClient,
+  createThreadMessage: CreateThreadMessage,
+) {
   const cookie = await signup(app);
   const researcher = await rpc<{ id: string }>(app, cookie, "bots/create", {
     name: "Researcher",

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -9,7 +9,7 @@ import {
   PipedreamConnector,
   ThirdPartyConnectorEmulator,
 } from "@rakazo/adapters";
-import type { PrismaClient } from "@rakazo/db";
+import { createThreadMessage, type PrismaClient } from "@rakazo/db";
 import { runProcess } from "./process.js";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
@@ -22,7 +22,6 @@ const API_PORT = 3110;
 const HOST_API_URL = `http://127.0.0.1:${API_PORT}`;
 
 type App = { request: (input: string, init?: RequestInit) => Response | Promise<Response> };
-type CreateThreadMessage = typeof import("@rakazo/db")["createThreadMessage"];
 
 async function main() {
   process.chdir(ROOT);
@@ -32,18 +31,11 @@ async function main() {
   await mkdir(REPORT_DIR, { recursive: true });
   await mkdir(DATA_DIR, { recursive: true });
 
-  execFileSync("pnpm", ["--filter", "@rakazo/db", "generate"], {
-    cwd: ROOT,
-    env: process.env,
-    stdio: "inherit",
-  });
   execFileSync("pnpm", ["--filter", "@rakazo/db", "exec", "prisma", "migrate", "deploy"], {
     cwd: path.join(ROOT, "packages", "db"),
     env: process.env,
     stdio: "inherit",
   });
-  const { createThreadMessage } = await import("@rakazo/db");
-
   const thirdParties = new ThirdPartyConnectorEmulator();
   const pipedream = new PipedreamConnector(
     {
@@ -70,7 +62,7 @@ async function main() {
     },
   });
 
-  const fixture = await seedFixture(handles.app, handles.prisma, createThreadMessage);
+  const fixture = await seedFixture(handles.app, handles.prisma);
   const server = serve({
     fetch: handles.app.fetch,
     hostname: "0.0.0.0",
@@ -143,11 +135,7 @@ function configureEnvironment() {
   });
 }
 
-async function seedFixture(
-  app: App,
-  prisma: PrismaClient,
-  createThreadMessage: CreateThreadMessage,
-) {
+async function seedFixture(app: App, prisma: PrismaClient) {
   const cookie = await signup(app);
   const researcher = await rpc<{ id: string }>(app, cookie, "bots/create", {
     name: "Researcher",

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -104,7 +104,10 @@ async function main() {
       `${JSON.stringify({ ok: true }, null, 2)}\n`,
     );
   } finally {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeAllConnections();
+    });
     await handles.stop().catch(() => undefined);
     await rm(DATA_DIR, { recursive: true, force: true });
   }

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -10,6 +10,7 @@ import {
   ThirdPartyConnectorEmulator,
 } from "@rakazo/adapters";
 import { createThreadMessage, type PrismaClient } from "@rakazo/db";
+import { sessionCookieHeader } from "../index.js";
 import { runProcess } from "./process.js";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
@@ -20,6 +21,7 @@ const EMAIL = "mobile-screenshots@example.test";
 const PASSWORD = "test-password-123";
 const API_PORT = 3110;
 const HOST_API_URL = `http://127.0.0.1:${API_PORT}`;
+const WEB_ORIGIN = "http://127.0.0.1:5180";
 
 type App = { request: (input: string, init?: RequestInit) => Response | Promise<Response> };
 
@@ -127,7 +129,7 @@ function configureEnvironment() {
     ENCRYPTION_KEY: "mobile-screenshot-encryption-key-32chars",
     SCREEN_PROXY_SECRET: "mobile-screenshot-screen-secret-32chars",
     BETTER_AUTH_URL: HOST_API_URL,
-    WEB_ORIGIN: "http://127.0.0.1:5180",
+    WEB_ORIGIN,
     API_HOST: "0.0.0.0",
     API_PORT: String(API_PORT),
     API_URL: HOST_API_URL,
@@ -242,15 +244,11 @@ async function seedFixture(app: App, prisma: PrismaClient) {
 async function signup(app: App) {
   const response = await app.request("/api/auth/sign-up/email", {
     method: "POST",
-    headers: { "content-type": "application/json", origin: "http://127.0.0.1:5180" },
+    headers: { "content-type": "application/json", origin: WEB_ORIGIN },
     body: JSON.stringify({ email: EMAIL, password: PASSWORD, name: "Screenshot User" }),
   });
   if (!response.ok) throw new Error(`Fixture signup failed with ${response.status}`);
-  const cookies = response.headers.getSetCookie?.() ?? [];
-  const cookie =
-    cookies.map((value) => value.split(";")[0]).join("; ") ||
-    response.headers.get("set-cookie")?.split(",")[0]?.split(";")[0] ||
-    "";
+  const cookie = sessionCookieHeader(response);
   if (!cookie) throw new Error("Fixture signup did not return a session cookie");
   return cookie;
 }
@@ -261,7 +259,7 @@ async function rpc<T>(app: App, cookie: string, procedure: string, body: unknown
     headers: {
       "content-type": "application/json",
       cookie,
-      origin: "http://127.0.0.1:5180",
+      origin: WEB_ORIGIN,
     },
     body: JSON.stringify({ json: body }),
   });

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -1,0 +1,298 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { serve } from "@hono/node-server";
+import {
+  ComposioEmulator,
+  EmailEmulator,
+  PipedreamConnector,
+  ThirdPartyConnectorEmulator,
+} from "@rakazo/adapters";
+import { createThreadMessage, type PrismaClient } from "@rakazo/db";
+import { runProcess } from "./process.js";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+const REPORT_DIR = path.join(ROOT, "test-report", "mobile-screenshots");
+const DATA_DIR = path.join(ROOT, ".tmp", "mobile-screenshots-data");
+const FLOW = path.join(ROOT, "apps", "mobile", ".maestro", "screenshots.yaml");
+const EMAIL = "mobile-screenshots@example.test";
+const PASSWORD = "test-password-123";
+const API_PORT = 3110;
+const HOST_API_URL = `http://127.0.0.1:${API_PORT}`;
+
+type App = { request: (input: string, init?: RequestInit) => Response | Promise<Response> };
+
+async function main() {
+  process.chdir(ROOT);
+  configureEnvironment();
+  await rm(REPORT_DIR, { recursive: true, force: true });
+  await rm(DATA_DIR, { recursive: true, force: true });
+  await mkdir(REPORT_DIR, { recursive: true });
+  await mkdir(DATA_DIR, { recursive: true });
+
+  execFileSync("pnpm", ["--filter", "@rakazo/db", "generate"], {
+    cwd: ROOT,
+    env: process.env,
+    stdio: "inherit",
+  });
+  execFileSync("pnpm", ["--filter", "@rakazo/db", "exec", "prisma", "migrate", "deploy"], {
+    cwd: path.join(ROOT, "packages", "db"),
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  const thirdParties = new ThirdPartyConnectorEmulator();
+  const pipedream = new PipedreamConnector(
+    {
+      clientId: "fake-client-id",
+      clientSecret: "fake-client-secret",
+      projectId: "fake-project-id",
+      environment: "development",
+      identitySecret: process.env.ENCRYPTION_KEY!,
+    },
+    { fetch: thirdParties.fetch, resolveHostname: thirdParties.resolveHostname },
+  );
+  const { createApp } = await import("../../../../apps/api/src/app.ts");
+  const handles = await createApp({
+    databaseUrl: process.env.DATABASE_URL!,
+    dataDir: DATA_DIR,
+    apiHost: "0.0.0.0",
+    apiUrl: HOST_API_URL,
+    composio: new ComposioEmulator(),
+    pipedream,
+    email: new EmailEmulator(),
+    remoteConnectors: {
+      fetch: thirdParties.fetch,
+      resolveHostname: thirdParties.resolveHostname,
+    },
+  });
+
+  const fixture = await seedFixture(handles.app, handles.prisma);
+  const server = serve({
+    fetch: handles.app.fetch,
+    hostname: "0.0.0.0",
+    port: API_PORT,
+  });
+
+  try {
+    await waitForHealth(`${HOST_API_URL}/health`, 15_000);
+    await runProcess(
+      "maestro",
+      [
+        "test",
+        "--no-ansi",
+        "--flatten-debug-output",
+        "--debug-output",
+        path.join(REPORT_DIR, "debug"),
+        "--test-output-dir",
+        REPORT_DIR,
+        "--format",
+        "HTML",
+        "--output",
+        path.join(REPORT_DIR, "report.html"),
+        "-e",
+        `RAKAZO_SCREENSHOT_EMAIL=${EMAIL}`,
+        "-e",
+        `RAKAZO_SCREENSHOT_PASSWORD=${PASSWORD}`,
+        "-e",
+        `RAKAZO_SCREENSHOT_BOT_ID=${fixture.botId}`,
+        "-e",
+        `RAKAZO_SCREENSHOT_GROUP_ID=${fixture.groupId}`,
+        "-e",
+        `RAKAZO_SCREENSHOT_ROUTINE_ID=${fixture.routineId}`,
+        FLOW,
+      ],
+      process.env,
+    );
+    await writeFile(
+      path.join(REPORT_DIR, "summary.json"),
+      `${JSON.stringify({ ok: true }, null, 2)}\n`,
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await handles.stop().catch(() => undefined);
+    await rm(DATA_DIR, { recursive: true, force: true });
+  }
+}
+
+function configureEnvironment() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL is required for the isolated mobile screenshot fixture");
+  }
+  Object.assign(process.env, {
+    NODE_ENV: "test",
+    WAKEUP_DRIVER: "memory",
+    SANDBOX_PROVIDER: "fake",
+    AGENT_RUNTIME: "scripted",
+    COMPOSIO_API_KEY: "",
+    BETTER_AUTH_SECRET: "mobile-screenshot-auth-secret-32chars",
+    ENCRYPTION_KEY: "mobile-screenshot-encryption-key-32chars",
+    SCREEN_PROXY_SECRET: "mobile-screenshot-screen-secret-32chars",
+    BETTER_AUTH_URL: HOST_API_URL,
+    WEB_ORIGIN: "http://127.0.0.1:5180",
+    API_HOST: "0.0.0.0",
+    API_PORT: String(API_PORT),
+    API_URL: HOST_API_URL,
+    DATA_DIR,
+    SIGNUPS_ENABLED: "true",
+    SIGNUP_ALLOWLIST: "",
+    CI: "1",
+  });
+}
+
+async function seedFixture(app: App, prisma: PrismaClient) {
+  const cookie = await signup(app);
+  const researcher = await rpc<{ id: string }>(app, cookie, "bots/create", {
+    name: "Researcher",
+    title: "Product research",
+    description: "Finds evidence and keeps fixture notes organized.",
+    instructions: "Find evidence and summarize it clearly.",
+    notifyOnFinish: true,
+  });
+  const writer = await rpc<{ id: string }>(app, cookie, "bots/create", {
+    name: "Writer",
+    title: "Clear writing",
+    description: "Turns research into concise drafts.",
+    instructions: "Write concise drafts from the available evidence.",
+    notifyOnFinish: true,
+  });
+  const support = await rpc<{ id: string }>(app, cookie, "bots/create", {
+    name: "Support",
+    title: "Customer support",
+    description: "Prepares friendly customer replies.",
+    instructions: "Prepare accurate and friendly customer replies.",
+    notifyOnFinish: false,
+  });
+  const archived = await rpc<{ id: string }>(app, cookie, "bots/create", {
+    name: "Archived fixture",
+    title: "Archived",
+    description: "A recoverable archived bot for account screenshots.",
+    instructions: "Remain archived.",
+    notifyOnFinish: true,
+  });
+  await rpc(app, cookie, "bots/archive", { botId: archived.id });
+
+  const group = await rpc<{ id: string }>(app, cookie, "groups/create", {
+    name: "Launch team",
+    botIds: [researcher.id, writer.id, support.id],
+  });
+  const routine = await rpc<{ id: string }>(app, cookie, "routines/create", {
+    botId: researcher.id,
+    name: "Weekly fixture review",
+    prompt: "Review the fixture launch notes and summarize the open questions.",
+    crons: ["0 9 * * 1"],
+    timezone: "UTC",
+    active: true,
+    notify: true,
+  });
+
+  const botThread = await prisma.thread.findUniqueOrThrow({ where: { botId: researcher.id } });
+  const groupThread = await prisma.thread.findUniqueOrThrow({ where: { groupId: group.id } });
+  const question = await createThreadMessage(prisma, {
+    threadId: botThread.id,
+    role: "user",
+    blocks: [{ kind: "text", text: "Summarize the fixture launch checklist." }],
+  });
+  await createThreadMessage(prisma, {
+    threadId: botThread.id,
+    role: "bot",
+    botId: researcher.id,
+    blocks: [{ kind: "text", text: "The fixture workspace is ready." }],
+  });
+  await createThreadMessage(prisma, {
+    threadId: groupThread.id,
+    role: "user",
+    blocks: [{ kind: "text", text: "Coordinate the fixture launch plan." }],
+  });
+  await createThreadMessage(prisma, {
+    threadId: groupThread.id,
+    role: "bot",
+    botId: writer.id,
+    blocks: [{ kind: "text", text: "The fixture launch plan is ready." }],
+  });
+
+  const task = await prisma.task.create({
+    data: {
+      spaceId: botThread.spaceId,
+      userId: botThread.userId,
+      botId: researcher.id,
+      threadId: botThread.id,
+      prompt: "Prepare the fixture workspace",
+      status: "completed",
+    },
+  });
+  await prisma.run.create({
+    data: {
+      spaceId: botThread.spaceId,
+      userId: botThread.userId,
+      botId: researcher.id,
+      threadId: botThread.id,
+      taskId: task.id,
+      status: "completed",
+      trigger: "user",
+      modelProvider: "scripted",
+      modelId: "scripted",
+      sourceMessageId: question.id,
+      startedAt: new Date(Date.now() - 2_000),
+      completedAt: new Date(),
+    },
+  });
+
+  return { botId: researcher.id, groupId: group.id, routineId: routine.id };
+}
+
+async function signup(app: App) {
+  const response = await app.request("/api/auth/sign-up/email", {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: "http://127.0.0.1:5180" },
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD, name: "Screenshot User" }),
+  });
+  if (!response.ok) throw new Error(`Fixture signup failed with ${response.status}`);
+  const cookies = response.headers.getSetCookie?.() ?? [];
+  const cookie =
+    cookies.map((value) => value.split(";")[0]).join("; ") ||
+    response.headers.get("set-cookie")?.split(",")[0]?.split(";")[0] ||
+    "";
+  if (!cookie) throw new Error("Fixture signup did not return a session cookie");
+  return cookie;
+}
+
+async function rpc<T>(app: App, cookie: string, procedure: string, body: unknown = {}): Promise<T> {
+  const response = await app.request(`/rpc/${procedure}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie,
+      origin: "http://127.0.0.1:5180",
+    },
+    body: JSON.stringify({ json: body }),
+  });
+  const text = await response.text();
+  const parsed = JSON.parse(text) as { json?: T; error?: { message?: string } };
+  if (!response.ok || parsed.error) {
+    throw new Error(`${procedure} ${response.status}: ${parsed.error?.message ?? text}`);
+  }
+  return parsed.json as T;
+}
+
+async function waitForHealth(url: string, timeoutMs: number) {
+  const startedAt = Date.now();
+  let lastError = "no response";
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Mobile screenshot API did not become ready: ${lastError}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

The web E2E suite cannot show native mobile regressions. Maintainers need an occasional, repeatable way to inspect Android UI without making it a required pull-request check or depending on a hosted testing vendor.

## What changed

- added a manual-only Android emulator workflow and Maestro catalog for 21 native views
- added an isolated fake fixture workspace with seeded bots, groups, messages, activity, and a routine
- cached Gradle state, the pinned Maestro CLI, and the built APK; unchanged reruns skip native compilation
- uploads screenshots, the Maestro report, and diagnostics for seven days

## Testing

- [manual Android run](https://github.com/elie222/rakazo/actions/runs/33891736643) passed and captured all 21 views using the cached APK path
- testkit typecheck and tests passed
- mobile TypeScript check and unit tests passed
- workflow and Maestro YAML plus the capture shell script validated
- pull-request lint, typecheck, unit, Postgres journey, production build, image validation, and web E2E checks passed

The catalog records the computer screen as-is; in the isolated fixture, its embedded page currently reports an unsupported URL scheme while the native controls render. This PR changes test tooling, not product UI.
