### PR TITLE
fix(adapters): enforce MCP request header policy

### DIFF
--- a/packages/adapters/src/mcp-transport.test.ts
+++ b/packages/adapters/src/mcp-transport.test.ts
@@ -362,6 +362,80 @@ describe("MCP transport seam", () => {
     expect(seen["x-api-key"]).toBe("stored-key");
   });
 
+  it("drops request headers outside the configured allowlist", async () => {
+    let seen: Record<string, string> = {};
+    const safeFetch = secureFetch(
+      new URL("https://mcp.example.test/mcp"),
+      {},
+      { allowedHeaders: ["accept"] },
+      {
+        resolveHostname: TEST_NETWORK.resolveHostname,
+        fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          seen = Object.fromEntries(request.headers.entries());
+          return Response.json({ ok: true });
+        }),
+      },
+    );
+
+    await safeFetch("https://mcp.example.test/mcp", {
+      headers: { Accept: "application/json", "X-Untrusted": "drop-me" },
+    });
+
+    expect(seen.accept).toBe("application/json");
+    expect(seen["x-untrusted"]).toBeUndefined();
+  });
+
+  it("honours init header replacement for Request inputs", async () => {
+    let seen: Record<string, string> = {};
+    const safeFetch = secureFetch(
+      new URL("https://mcp.example.test/mcp"),
+      {},
+      {},
+      {
+        resolveHostname: TEST_NETWORK.resolveHostname,
+        fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          seen = Object.fromEntries(request.headers.entries());
+          return Response.json({ ok: true });
+        }),
+      },
+    );
+    const request = new Request("https://mcp.example.test/mcp", {
+      headers: { Authorization: "Bearer stale", "Content-Type": "application/json" },
+    });
+
+    await safeFetch(request, { headers: { Accept: "application/json" } });
+
+    expect(seen.accept).toBe("application/json");
+    expect(seen.authorization).toBeUndefined();
+    expect(seen["content-type"]).toBeUndefined();
+  });
+
+  it("does not forward configured resource credentials to another origin", async () => {
+    let seen: Record<string, string> = {};
+    const safeFetch = secureFetch(
+      new URL("https://mcp.example.test/mcp"),
+      {},
+      { headers: { Authorization: "Bearer stored", "X-Api-Key": "stored-key" } },
+      {
+        resolveHostname: TEST_NETWORK.resolveHostname,
+        fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          seen = Object.fromEntries(request.headers.entries());
+          return Response.json({ ok: true });
+        }),
+      },
+    );
+
+    await safeFetch("https://auth.example.test/token", {
+      headers: { Authorization: "Bearer stored", "X-Api-Key": "stored-key" },
+    });
+
+    expect(seen.authorization).toBeUndefined();
+    expect(seen["x-api-key"]).toBeUndefined();
+  });
+
   it("never retries a failed write against the endpoint origin", async () => {
     const inner = vi.fn(async () => {
       throw new TypeError("fetch failed");

--- a/packages/adapters/src/mcp-transport.ts
+++ b/packages/adapters/src/mcp-transport.ts
@@ -30,7 +30,7 @@ export interface McpUrlPolicy {
 }
 
 export interface McpHeaderPolicy {
-  /** Headers are copied into requests only when named here. */
+  /** Additional SDK request headers allowed beyond defaults and configured headers. */
   allowedHeaders?: readonly string[];
   headers?: Record<string, string>;
 }
@@ -98,14 +98,19 @@ export function secureFetch(
   network: RemoteTransportDependencies = {},
 ): SafeRemoteFetch {
   const allowed = new Set(
-    (headerPolicy.allowedHeaders ?? DEFAULT_HEADERS).map((h) => h.toLowerCase()),
+    [
+      ...DEFAULT_HEADERS,
+      ...(headerPolicy.allowedHeaders ?? []),
+      ...Object.keys(headerPolicy.headers ?? {}),
+    ].map((header) => header.toLowerCase()),
   );
   const configured = Object.entries(headerPolicy.headers ?? {}).filter(([name]) =>
     allowed.has(name.toLowerCase()),
   );
-  const configuredNames = new Set(
-    Object.keys(headerPolicy.headers ?? {}).map((name) => name.toLowerCase()),
+  const configuredValues = new Map(
+    configured.map(([name, value]) => [name.toLowerCase(), value] as const),
   );
+  const configuredNames = new Set(configuredValues.keys());
   const localCredentialHeaders = new Set([
     ...configuredNames,
     "authorization",
@@ -117,9 +122,16 @@ export function secureFetch(
     network.resolveHostname,
   );
   const request = async (input: Request | URL | string, init?: RequestInit): Promise<Response> => {
-    const source = input instanceof Request ? input : new Request(input, init);
+    const source = new Request(input, init);
     const url = validateUrl(source.url, urlPolicy);
-    const headers = new Headers(source.headers);
+    const headers = new Headers();
+    for (const [name, value] of source.headers) {
+      const normalized = name.toLowerCase();
+      if (!allowed.has(normalized)) continue;
+      const configuredValue = configuredValues.get(normalized);
+      if (url.origin !== resourceUrl.origin && configuredValue === value) continue;
+      headers.set(name, value);
+    }
     const localHttp = url.protocol === "http:" && isLocalMcpHost(url.hostname);
     if (localHttp && urlPolicy.allowLocalHttpCredentials !== true) {
       for (const name of [...headers.keys()]) {
@@ -128,15 +140,6 @@ export function secureFetch(
     }
     if (!localHttp && url.origin === resourceUrl.origin) {
       for (const [name, value] of configured) headers.set(name, value);
-    }
-    for (const [name, value] of new Headers(init?.headers)) {
-      if (
-        localHttp &&
-        urlPolicy.allowLocalHttpCredentials !== true &&
-        localCredentialHeaders.has(name.toLowerCase())
-      )
-        continue;
-      if (allowed.has(name.toLowerCase())) headers.set(name, value);
     }
     // Buffer the body: a re-wrapped Request body is a stream without a replayable
     // source, and undici fails the whole request when a server answers 401 early


### PR DESCRIPTION
## Why

The MCP transport's header policy did not filter headers already present on the effective request. It also merged `Request` headers with `init.headers`, although Fetch semantics require `init.headers` to replace them. This could retain stale authorization values, forward unapproved headers, or carry configured resource credentials to a different origin.

## What changed

- construct the effective request with the standard `Request(input, init)` semantics
- allow only built-in transport headers, explicitly allowed SDK headers, and stored configured header names
- keep configured resource credential values scoped to the MCP endpoint origin
- preserve explicitly configured localhost HTTP credentials

## Test plan

- adapters unit suite: 1,081 passed; 7 repository-defined skips
- adapters TypeScript check
- Biome check on touched files
- staged diff whitespace check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved secure request handling to consistently preserve required default headers.
  - Expanded header filtering to honor configured header policies.
  - Prevented configured credentials from being sent when requests target a different origin.
  - Ensured headers from existing requests are safely filtered and rebuilt before transmission.
  - Improved handling of custom request headers to reduce unintended cross-origin credential exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->