### PR TITLE
fix(adapters): block metadata in Tailscale MCP resolution

### DIFF
--- a/packages/adapters/src/remote-mcp.test.ts
+++ b/packages/adapters/src/remote-mcp.test.ts
@@ -76,6 +76,11 @@ describe("remote MCP URL policy", () => {
         { address: "169.254.169.254", family: 4 as const },
       ]),
     ).rejects.toThrow("private address");
+    await expect(
+      assertSafeRemoteUrl("https://box.tail12345.ts.net/openapi.json", async () => [
+        { address: "100.100.100.200", family: 4 as const },
+      ]),
+    ).rejects.toThrow("private address");
   });
 
   it("rejects private addresses in the lookup used by the network connection", async () => {

--- a/packages/adapters/src/remote-mcp.ts
+++ b/packages/adapters/src/remote-mcp.ts
@@ -7,6 +7,7 @@ import { Agent } from "undici";
 import { combineSignals } from "./connector-safety.js";
 import {
   createAddressCheckedLookup,
+  isCloudMetadataAddress,
   isPrivateAddress,
   type ResolvedAddress,
   type ResolveHostname,
@@ -197,6 +198,7 @@ function assertPublicAddresses(addresses: ResolvedAddress[], hostname?: string):
   const magicDns = hostname != null && isTailscaleMagicDnsHostname(hostname);
   if (
     addresses.some((entry) => {
+      if (isCloudMetadataAddress(entry.address)) return true;
       if (!isPrivateAddress(entry.address)) return false;
       // Allow only Tailscale CGNAT for MagicDNS; keep other private ranges blocked.
       return !(magicDns && isTailscaleCgnatAddress(entry.address));


### PR DESCRIPTION
## Why

Tailscale MagicDNS endpoints intentionally allow addresses in the CGNAT range. Alibaba ECS metadata uses `100.100.100.200`, which is inside that range, so a MagicDNS hostname resolving to the metadata service could pass the remote MCP URL policy.

## What changed

- reject known cloud metadata addresses before applying the Tailscale CGNAT exception
- add an offline regression case for a MagicDNS hostname resolving to the Alibaba ECS metadata address

Follow-up to #609, reusing its shared cloud metadata address classification.

## Test plan

- adapters unit suite: 1,078 passed; 7 repository-defined skips
- adapters TypeScript check
- Biome check on touched files
- staged diff whitespace check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connector URL validation now blocks cloud metadata addresses, including MagicDNS hosts resolving to `100.100.100.200`.
  * Such addresses are treated as private and rejected to help prevent unsafe connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->