### PR TITLE
fix(logging): redact Error values in bindings

### DIFF
--- a/packages/logging/src/redaction.test.ts
+++ b/packages/logging/src/redaction.test.ts
@@ -49,6 +49,19 @@ describe("redaction", () => {
     expect(JSON.stringify(redacted.detail)).not.toMatch(/inner-secret|outer-secret/);
   });
 
+  it("redacts string Error causes", () => {
+    const error = new Error("request failed", { cause: "token=cause-secret" });
+
+    const redacted = redactBindings({ detail: error });
+
+    expect(redacted.detail).toMatchObject({
+      name: "Error",
+      message: "request failed",
+      cause: "token=[Redacted]",
+    });
+    expect(JSON.stringify(redacted.detail)).not.toContain("cause-secret");
+  });
+
   it("redacts secrets embedded in free text", () => {
     const redacted = redactSensitiveText(
       "user person@example.com used Bearer supersecret and token=abc123",

--- a/packages/logging/src/redaction.test.ts
+++ b/packages/logging/src/redaction.test.ts
@@ -35,6 +35,20 @@ describe("redaction", () => {
     expect(redacted.self).toBe("[Circular]");
   });
 
+  it("redacts Error values nested in bindings", () => {
+    const cause = new Error("password=inner-secret");
+    const error = new Error("request failed with token=outer-secret", { cause });
+
+    const redacted = redactBindings({ detail: error });
+
+    expect(redacted.detail).toMatchObject({
+      name: "Error",
+      message: "request failed with token=[Redacted]",
+      cause: { name: "Error", message: "password=[Redacted]" },
+    });
+    expect(JSON.stringify(redacted.detail)).not.toMatch(/inner-secret|outer-secret/);
+  });
+
   it("redacts secrets embedded in free text", () => {
     const redacted = redactSensitiveText(
       "user person@example.com used Bearer supersecret and token=abc123",

--- a/packages/logging/src/redaction.ts
+++ b/packages/logging/src/redaction.ts
@@ -29,7 +29,12 @@ function redactValue(value: unknown, seen = new WeakSet<object>()): unknown {
     if (typeof value.stack === "string" && value.stack.length > 0) {
       output.stack = redactSensitiveText(value.stack);
     }
-    if (value.cause !== undefined) output.cause = redactValue(value.cause, seen);
+    if (value.cause !== undefined) {
+      output.cause =
+        typeof value.cause === "string"
+          ? redactSensitiveText(value.cause)
+          : redactValue(value.cause, seen);
+    }
     return output;
   }
   if (value instanceof Date) return value;

--- a/packages/logging/src/redaction.ts
+++ b/packages/logging/src/redaction.ts
@@ -21,7 +21,17 @@ function redactValue(value: unknown, seen = new WeakSet<object>()): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => redactValue(item, seen));
   }
-  if (value instanceof Error) return value;
+  if (value instanceof Error) {
+    const output: Record<string, unknown> = {
+      name: value.name || "Error",
+      message: redactSensitiveText(value.message),
+    };
+    if (typeof value.stack === "string" && value.stack.length > 0) {
+      output.stack = redactSensitiveText(value.stack);
+    }
+    if (value.cause !== undefined) output.cause = redactValue(value.cause, seen);
+    return output;
+  }
   if (value instanceof Date) return value;
   const output: Record<string, unknown> = {};
   for (const [key, nested] of Object.entries(value)) {


### PR DESCRIPTION
## Why

Structured bindings redact sensitive keys and text, but nested `Error` objects passed through unchanged. The pretty console sink prints an Error's message directly, so credentials embedded in a binding error message or cause could reach logs.

## What changed

- convert Error binding values into plain structured error data
- redact message, stack, and nested cause text with the existing text redactor
- cover nested Error causes and verify the original credential text is absent

## Test plan

- logging unit suite: 34 passed
- logging TypeScript check
- Biome check on touched files
- staged diff whitespace check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive information in nested errors is now redacted, including error messages, stack traces, and causes.
  * Error details retain their structure while being safely sanitized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->