### PR TITLE
fix(adapters): bind MCP credentials to their origin

### DIFF
--- a/packages/adapters/src/mcp-transport.test.ts
+++ b/packages/adapters/src/mcp-transport.test.ts
@@ -436,6 +436,29 @@ describe("MCP transport seam", () => {
     expect(seen["x-api-key"]).toBeUndefined();
   });
 
+  it("does not forward configured credential values under another header name", async () => {
+    let seen: Record<string, string> = {};
+    const safeFetch = secureFetch(
+      new URL("https://mcp.example.test/mcp"),
+      {},
+      { headers: { "X-Api-Key": "stored-key" } },
+      {
+        resolveHostname: TEST_NETWORK.resolveHostname,
+        fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          seen = Object.fromEntries(request.headers.entries());
+          return Response.json({ ok: true });
+        }),
+      },
+    );
+
+    await safeFetch("https://auth.example.test/token", {
+      headers: { Authorization: "stored-key" },
+    });
+
+    expect(seen.authorization).toBeUndefined();
+  });
+
   it("never retries a failed write against the endpoint origin", async () => {
     const inner = vi.fn(async () => {
       throw new TypeError("fetch failed");

--- a/packages/adapters/src/mcp-transport.ts
+++ b/packages/adapters/src/mcp-transport.ts
@@ -110,6 +110,7 @@ export function secureFetch(
   const configuredValues = new Map(
     configured.map(([name, value]) => [name.toLowerCase(), value] as const),
   );
+  const configuredCredentialValues = new Set(configuredValues.values());
   const configuredNames = new Set(configuredValues.keys());
   const localCredentialHeaders = new Set([
     ...configuredNames,
@@ -128,8 +129,7 @@ export function secureFetch(
     for (const [name, value] of source.headers) {
       const normalized = name.toLowerCase();
       if (!allowed.has(normalized)) continue;
-      const configuredValue = configuredValues.get(normalized);
-      if (url.origin !== resourceUrl.origin && configuredValue === value) continue;
+      if (url.origin !== resourceUrl.origin && configuredCredentialValues.has(value)) continue;
       headers.set(name, value);
     }
     const localHttp = url.protocol === "http:" && isLocalMcpHost(url.hostname);


### PR DESCRIPTION
## Why

Follow-up to #611. Its origin check compared a cross-origin request header only with the configured value for the same header name. A configured credential could therefore be reused under another allowed header name and leave the MCP resource origin.

## What

- compare every cross-origin outgoing header value against all configured credential values
- keep same-origin configured header injection unchanged
- add a regression test for a configured `X-Api-Key` value reused as `Authorization`

## Test

- `pnpm exec vitest run --root ../.. packages/adapters/src/mcp-transport.test.ts` (16 passed)
- `pnpm --filter @rakazo/adapters test` (1082 passed, 7 skipped)
- `pnpm --filter @rakazo/adapters exec tsc --noEmit`
- `pnpm exec biome check packages/adapters/src/mcp-transport.ts packages/adapters/src/mcp-transport.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved cross-origin request protection by preventing configured credential values from being forwarded under a different header name.
  - Added coverage confirming credentials are stripped when sent in an unexpected authorization header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->