### PR TITLE
feat(adapters): let operators declare vision modalities on self-configured endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,10 @@ AGENT_RUNTIME=pi
 WAKEUP_DRIVER=graphile
 # Pause or stop computers after this many idle ms. Minimum 30000.
 SANDBOX_IDLE_MS=600000
+# Comma-separated model ids on the local / openai-compatible endpoints that accept images.
+# Declared ids get input ["text","image"] so screenshot computer tools stay available.
+RAKAZO_LOCAL_VISION_MODELS=
+RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS=
 SANDBOX_COMMAND_TIMEOUT_MS=300000
 # Optional per-turn tool-call fuse for the Pi agent runtime. Unset, empty, or 0
 # means unlimited (default). Set a positive integer to soft-stop a turn that

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -196,9 +196,9 @@ leave Rakazo through this URL. Leave `RAKAZO_LOCAL_MODELS` blank to disable the 
 Each user can also connect their own OpenAI-compatible endpoint from **Connect a model** /
 **Settings → Models** on web and mobile. Choose **OpenAI-compatible**, enter the server base URL
 (for example `http://127.0.0.1:8000/v1`), the exact model id, and an optional API key.
-Public hosts and ordinary hostnames need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1`. Literal private
-IP, loopback, and `host.docker.internal` targets do not. To mark user-connected openai-compatible
-model ids as vision-capable (so screenshot computer tools stay available), set
+Public hosts and ordinary hostnames need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1` and HTTPS.
+Literal private IP, loopback, and `host.docker.internal` targets do not. To mark user-connected
+openai-compatible model ids as vision-capable (so screenshot computer tools stay available), set
 `RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS=gpt4o-vision,llava`.
 
 For servers that accept standard `reasoning_effort`, enable **Supports thinking** under

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -179,7 +179,7 @@ To use an operator-controlled OpenAI-compatible server such as Ollama, LM Studio
 MLX, list its model IDs and an endpoint that both the API and worker processes can reach:
 
 ```env
-RAKAZO_LOCAL_MODELS=qwen3:4b,llama3.1:8b
+RAKAZO_LOCAL_MODELS=qwen3:4b,llama3.1:8b,qwen3-vl
 RAKAZO_LOCAL_MODELS_URL=http://127.0.0.1:11434/v1
 RAKAZO_LOCAL_CONTEXT_WINDOW=32768
 RAKAZO_LOCAL_MAX_TOKENS=4096

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -183,6 +183,8 @@ RAKAZO_LOCAL_MODELS=qwen3:4b,llama3.1:8b
 RAKAZO_LOCAL_MODELS_URL=http://127.0.0.1:11434/v1
 RAKAZO_LOCAL_CONTEXT_WINDOW=32768
 RAKAZO_LOCAL_MAX_TOKENS=4096
+# Optional: model ids on this endpoint that accept images (screenshot computer tools).
+RAKAZO_LOCAL_VISION_MODELS=qwen3-vl
 ```
 
 The loopback default is suitable when running Rakazo from a source checkout. From containers,
@@ -195,7 +197,9 @@ Each user can also connect their own OpenAI-compatible endpoint from **Connect a
 **Settings → Models** on web and mobile. Choose **OpenAI-compatible**, enter the server base URL
 (for example `http://127.0.0.1:8000/v1`), the exact model id, and an optional API key.
 Public hosts and ordinary hostnames need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1`. Literal private
-IP, loopback, and `host.docker.internal` targets do not.
+IP, loopback, and `host.docker.internal` targets do not. To mark user-connected openai-compatible
+model ids as vision-capable (so screenshot computer tools stay available), set
+`RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS=gpt4o-vision,llava`.
 
 For servers that accept standard `reasoning_effort`, enable **Supports thinking** under
 **Advanced** when connecting. The setting is saved on the connection (no env var or restart).

--- a/packages/adapters/src/model-modalities.test.ts
+++ b/packages/adapters/src/model-modalities.test.ts
@@ -1,0 +1,109 @@
+import { OPENAI_COMPATIBLE_PROVIDER_ID } from "@rakazo/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const VISION_ENV = "RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS";
+const LOCAL_VISION_ENV = "RAKAZO_LOCAL_VISION_MODELS";
+
+/**
+ * The vision gate memoizes its catalog at module scope, so every case has to
+ * start from a fresh module graph or it would read the previous case's env.
+ */
+async function withEnv<T>(env: Record<string, string | undefined>, fn: () => Promise<T>) {
+  const previous = new Map(Object.keys(env).map((k) => [k, process.env[k]]));
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  vi.resetModules();
+  try {
+    return await fn();
+  } finally {
+    for (const [k, v] of previous) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    vi.resetModules();
+  }
+}
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("operator-declared vision modalities", () => {
+  it("defaults openai-compatible models to text-only", async () => {
+    await withEnv({ [VISION_ENV]: undefined }, async () => {
+      const { modelAcceptsImageInput } = await import("./model-vision.js");
+      expect(modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision")).toBe(false);
+    });
+  });
+
+  it("lets the vision gate see a declared openai-compatible vision model", async () => {
+    await withEnv({ [VISION_ENV]: "gpt4o-vision, another-vision " }, async () => {
+      const { modelAcceptsImageInput } = await import("./model-vision.js");
+      expect(modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision")).toBe(true);
+      expect(modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "another-vision")).toBe(true);
+    });
+  });
+
+  it("leaves undeclared models on the same endpoint text-only", async () => {
+    await withEnv({ [VISION_ENV]: "gpt4o-vision" }, async () => {
+      const { modelAcceptsImageInput } = await import("./model-vision.js");
+      expect(modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "text-only-model")).toBe(false);
+    });
+  });
+
+  it("keeps the screenshot-returning computer tools when the model is declared", async () => {
+    await withEnv({ [VISION_ENV]: "gpt4o-vision" }, async () => {
+      const { modelAcceptsImageInput, filterImageReturningComputerTools } = await import(
+        "./model-vision.js"
+      );
+      const tools = [{ name: "computer_observe" }, { name: "computer_act" }, { name: "bash" }];
+      const accepts = modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision");
+      expect(filterImageReturningComputerTools(tools, accepts).map((t) => t.name)).toEqual([
+        "computer_observe",
+        "computer_act",
+        "bash",
+      ]);
+    });
+  });
+
+  it("strips them again when nothing is declared", async () => {
+    await withEnv({ [VISION_ENV]: undefined }, async () => {
+      const { modelAcceptsImageInput, filterImageReturningComputerTools } = await import(
+        "./model-vision.js"
+      );
+      const tools = [{ name: "computer_observe" }, { name: "bash" }];
+      const accepts = modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision");
+      expect(filterImageReturningComputerTools(tools, accepts).map((t) => t.name)).toEqual(["bash"]);
+    });
+  });
+
+  it("declares image input on the runtime-registered model", async () => {
+    await withEnv({ [VISION_ENV]: "gpt4o-vision" }, async () => {
+      const { builtinModels } = await import("@earendil-works/pi-ai/providers/all");
+      const { registerOpenAiCompatibleRuntime } = await import(
+        "./pi-openai-compatible-provider.js"
+      );
+      const models = registerOpenAiCompatibleRuntime(builtinModels(), {
+        modelId: "gpt4o-vision",
+        baseUrl: "http://127.0.0.1:4000/v1",
+      });
+      expect(
+        models.getModel(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision")?.input,
+      ).toContain("image");
+    });
+  });
+
+  it("applies the same declaration to the local provider", async () => {
+    await withEnv(
+      { RAKAZO_LOCAL_MODELS: "qwen3-vl,qwen3-text", [LOCAL_VISION_ENV]: "qwen3-vl" },
+      async () => {
+        const { localProvider } = await import("./pi-local-provider.js");
+        const models = localProvider()?.getModels() ?? [];
+        expect(models.find((m) => m.id === "qwen3-vl")?.input).toContain("image");
+        expect(models.find((m) => m.id === "qwen3-text")?.input).not.toContain("image");
+      },
+    );
+  });
+});

--- a/packages/adapters/src/model-modalities.test.ts
+++ b/packages/adapters/src/model-modalities.test.ts
@@ -106,4 +106,37 @@ describe("operator-declared vision modalities", () => {
       },
     );
   });
+
+  it("dedupes a repeated id in the comma-separated vision env", async () => {
+    await withEnv({ [VISION_ENV]: "gpt4o-vision, gpt4o-vision ,gpt4o-vision" }, async () => {
+      const { declaredVisionModelIds } = await import("./model-modalities.js");
+      const { openAiCompatibleCatalogProvider, OPENAI_COMPATIBLE_VISION_MODELS_ENV } =
+        await import("./pi-openai-compatible-provider.js");
+      const ids = declaredVisionModelIds(OPENAI_COMPATIBLE_VISION_MODELS_ENV);
+      expect([...ids]).toEqual(["gpt4o-vision"]);
+      const catalogIds = openAiCompatibleCatalogProvider()
+        .getModels()
+        .map((m) => m.id)
+        .filter((id) => id === "gpt4o-vision");
+      expect(catalogIds).toEqual(["gpt4o-vision"]);
+    });
+  });
+
+  it("upgrades the custom placeholder when it is declared vision-capable", async () => {
+    await withEnv({ [VISION_ENV]: "custom,gpt4o-vision" }, async () => {
+      const { openAiCompatibleCatalogProvider, OPENAI_COMPATIBLE_CATALOG_MODEL_ID } = await import(
+        "./pi-openai-compatible-provider.js"
+      );
+      const { modelAcceptsImageInput } = await import("./model-vision.js");
+      const models = openAiCompatibleCatalogProvider().getModels();
+      const customEntries = models.filter((m) => m.id === OPENAI_COMPATIBLE_CATALOG_MODEL_ID);
+      expect(customEntries).toHaveLength(1);
+      expect(customEntries[0]?.input).toContain("image");
+      expect(models.filter((m) => m.id === "gpt4o-vision")).toHaveLength(1);
+      expect(
+        modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, OPENAI_COMPATIBLE_CATALOG_MODEL_ID),
+      ).toBe(true);
+      expect(modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision")).toBe(true);
+    });
+  });
 });

--- a/packages/adapters/src/model-modalities.test.ts
+++ b/packages/adapters/src/model-modalities.test.ts
@@ -75,7 +75,9 @@ describe("operator-declared vision modalities", () => {
       );
       const tools = [{ name: "computer_observe" }, { name: "bash" }];
       const accepts = modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision");
-      expect(filterImageReturningComputerTools(tools, accepts).map((t) => t.name)).toEqual(["bash"]);
+      expect(filterImageReturningComputerTools(tools, accepts).map((t) => t.name)).toEqual([
+        "bash",
+      ]);
     });
   });
 
@@ -89,9 +91,9 @@ describe("operator-declared vision modalities", () => {
         modelId: "gpt4o-vision",
         baseUrl: "http://127.0.0.1:4000/v1",
       });
-      expect(
-        models.getModel(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision")?.input,
-      ).toContain("image");
+      expect(models.getModel(OPENAI_COMPATIBLE_PROVIDER_ID, "gpt4o-vision")?.input).toContain(
+        "image",
+      );
     });
   });
 
@@ -110,8 +112,9 @@ describe("operator-declared vision modalities", () => {
   it("dedupes a repeated id in the comma-separated vision env", async () => {
     await withEnv({ [VISION_ENV]: "gpt4o-vision, gpt4o-vision ,gpt4o-vision" }, async () => {
       const { declaredVisionModelIds } = await import("./model-modalities.js");
-      const { openAiCompatibleCatalogProvider, OPENAI_COMPATIBLE_VISION_MODELS_ENV } =
-        await import("./pi-openai-compatible-provider.js");
+      const { openAiCompatibleCatalogProvider, OPENAI_COMPATIBLE_VISION_MODELS_ENV } = await import(
+        "./pi-openai-compatible-provider.js"
+      );
       const ids = declaredVisionModelIds(OPENAI_COMPATIBLE_VISION_MODELS_ENV);
       expect([...ids]).toEqual(["gpt4o-vision"]);
       const catalogIds = openAiCompatibleCatalogProvider()

--- a/packages/adapters/src/model-modalities.test.ts
+++ b/packages/adapters/src/model-modalities.test.ts
@@ -122,6 +122,22 @@ describe("operator-declared vision modalities", () => {
     });
   });
 
+  it("keeps the custom placeholder text-only when nothing is declared", async () => {
+    await withEnv({ [VISION_ENV]: undefined }, async () => {
+      const { openAiCompatibleCatalogProvider, OPENAI_COMPATIBLE_CATALOG_MODEL_ID } = await import(
+        "./pi-openai-compatible-provider.js"
+      );
+      const { modelAcceptsImageInput } = await import("./model-vision.js");
+      const custom = openAiCompatibleCatalogProvider()
+        .getModels()
+        .find((m) => m.id === OPENAI_COMPATIBLE_CATALOG_MODEL_ID);
+      expect(custom?.input).not.toContain("image");
+      expect(
+        modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, OPENAI_COMPATIBLE_CATALOG_MODEL_ID),
+      ).toBe(false);
+    });
+  });
+
   it("upgrades the custom placeholder when it is declared vision-capable", async () => {
     await withEnv({ [VISION_ENV]: "custom,gpt4o-vision" }, async () => {
       const { openAiCompatibleCatalogProvider, OPENAI_COMPATIBLE_CATALOG_MODEL_ID } = await import(

--- a/packages/adapters/src/model-modalities.ts
+++ b/packages/adapters/src/model-modalities.ts
@@ -1,0 +1,29 @@
+/**
+ * Operator-declared input modalities for self-configured model endpoints.
+ *
+ * Pi's built-in catalog knows the modalities of hosted models, but a model
+ * reached through `local` or `openai-compatible` is whatever the operator
+ * points it at. Those providers therefore declare `["text"]`, which is the
+ * safe default: `modelAcceptsImageInput` gates the screenshot-returning
+ * computer tools on `input.includes("image")`, so guessing "image" for an
+ * endpoint that cannot see would send screenshots into a text-only model.
+ *
+ * Defaulting to text-only is right; having no way to say otherwise is not.
+ * An operator fronting a vision model through a gateway (LiteLLM, LM Studio,
+ * vLLM) knows it can see, and this is how they say so.
+ */
+
+/** Comma-separated model ids the operator declares vision-capable. */
+export function declaredVisionModelIds(envName: string): ReadonlySet<string> {
+  return new Set(
+    (process.env[envName] ?? "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+  );
+}
+
+/** The `input` modality list for a model, given whether it accepts images. */
+export function inputModalities(acceptsImages: boolean): ("text" | "image")[] {
+  return acceptsImages ? ["text", "image"] : ["text"];
+}

--- a/packages/adapters/src/pi-local-provider.ts
+++ b/packages/adapters/src/pi-local-provider.ts
@@ -6,10 +6,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 
-import {
-  declaredVisionModelIds,
-  inputModalities,
-} from "./model-modalities.js";
+import { declaredVisionModelIds, inputModalities } from "./model-modalities.js";
 /**
  * Local OpenAI-compatible model server (Ollama, LM Studio, llama.cpp, MLX).
  *

--- a/packages/adapters/src/pi-local-provider.ts
+++ b/packages/adapters/src/pi-local-provider.ts
@@ -6,6 +6,10 @@ import {
 } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 
+import {
+  declaredVisionModelIds,
+  inputModalities,
+} from "./model-modalities.js";
 /**
  * Local OpenAI-compatible model server (Ollama, LM Studio, llama.cpp, MLX).
  *
@@ -17,6 +21,13 @@ import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completio
  * its models.
  */
 export const LOCAL_PROVIDER_ID = "local";
+
+/** Model ids the local server serves with vision, declared by the operator. */
+export const LOCAL_VISION_MODELS_ENV = "RAKAZO_LOCAL_VISION_MODELS";
+
+export function localVisionModelIds(): ReadonlySet<string> {
+  return declaredVisionModelIds(LOCAL_VISION_MODELS_ENV);
+}
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = 32_768;
@@ -70,7 +81,7 @@ function localModel(id: string): Model<"openai-completions"> {
     baseUrl: localBaseUrl(),
     reasoning: false,
     compat: { supportsDeveloperRole: false, supportsReasoningEffort: false },
-    input: ["text"],
+    input: inputModalities(localVisionModelIds().has(id)),
     // Runs on the operator's own hardware, so there is nothing to bill.
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: tokenLimit("RAKAZO_LOCAL_CONTEXT_WINDOW", DEFAULT_CONTEXT_WINDOW),

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -9,6 +9,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { Agent } from "undici";
+import { declaredVisionModelIds, inputModalities } from "./model-modalities.js";
 import {
   createAddressCheckedLookup,
   isCloudMetadataAddress,
@@ -25,10 +26,6 @@ import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
 } from "./openai-compatible-url.js";
 
-import {
-  declaredVisionModelIds,
-  inputModalities,
-} from "./model-modalities.js";
 export { OPENAI_COMPATIBLE_PROVIDER_ID };
 
 /** Placeholder catalog model id; users enter the real id when connecting. */

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -231,12 +231,24 @@ export function openAiCompatibleCatalogProvider(): Provider {
   // The vision gate resolves against this catalog rather than the per-run
   // registry, so a model only declared at runtime would still read as
   // text-only. Register the operator's declared vision models here too.
-  const visionModels = [...openAiCompatibleVisionModelIds()].map((id) =>
-    openAiCompatibleModel(id, OPENAI_COMPAT_BASE, false, true),
-  );
+  //
+  // If the reserved placeholder id ("custom") is itself declared vision-
+  // capable, upgrade the placeholder entry rather than appending a second
+  // model with the same id — Models.getModel returns the first match, so a
+  // duplicate would leave the gate reading the text-only placeholder.
+  const visionIds = openAiCompatibleVisionModelIds();
+  const placeholderAcceptsImages = visionIds.has(OPENAI_COMPATIBLE_CATALOG_MODEL_ID);
+  const visionModels = [...visionIds]
+    .filter((id) => id !== OPENAI_COMPATIBLE_CATALOG_MODEL_ID)
+    .map((id) => openAiCompatibleModel(id, OPENAI_COMPAT_BASE, false, true));
   return openAiCompatibleProvider([
     {
-      ...openAiCompatibleModel(OPENAI_COMPATIBLE_CATALOG_MODEL_ID, OPENAI_COMPAT_BASE),
+      ...openAiCompatibleModel(
+        OPENAI_COMPATIBLE_CATALOG_MODEL_ID,
+        OPENAI_COMPAT_BASE,
+        false,
+        placeholderAcceptsImages,
+      ),
       name: "Custom model id",
     },
     ...visionModels,

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -25,10 +25,21 @@ import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
 } from "./openai-compatible-url.js";
 
+import {
+  declaredVisionModelIds,
+  inputModalities,
+} from "./model-modalities.js";
 export { OPENAI_COMPATIBLE_PROVIDER_ID };
 
 /** Placeholder catalog model id; users enter the real id when connecting. */
 export const OPENAI_COMPATIBLE_CATALOG_MODEL_ID = "custom";
+
+/** Model ids this endpoint serves with vision, declared by the operator. */
+export const OPENAI_COMPATIBLE_VISION_MODELS_ENV = "RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS";
+
+export function openAiCompatibleVisionModelIds(): ReadonlySet<string> {
+  return declaredVisionModelIds(OPENAI_COMPATIBLE_VISION_MODELS_ENV);
+}
 
 const DEFAULT_CONTEXT_WINDOW = 32_768;
 const DEFAULT_MAX_TOKENS = 4_096;
@@ -44,6 +55,7 @@ export function openAiCompatibleModel(
   id: string,
   baseUrl: string,
   reasoning = false,
+  acceptsImages = false,
 ): Model<"openai-completions"> {
   return {
     id,
@@ -58,7 +70,7 @@ export function openAiCompatibleModel(
       thinkingFormat: "openai",
     },
     thinkingLevelMap: { off: "none" },
-    input: ["text"],
+    input: inputModalities(acceptsImages),
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MAX_TOKENS,
@@ -216,11 +228,18 @@ async function closeDispatcherWithResponse(
 
 /** Always-visible catalog provider with a placeholder model entry. */
 export function openAiCompatibleCatalogProvider(): Provider {
+  // The vision gate resolves against this catalog rather than the per-run
+  // registry, so a model only declared at runtime would still read as
+  // text-only. Register the operator's declared vision models here too.
+  const visionModels = [...openAiCompatibleVisionModelIds()].map((id) =>
+    openAiCompatibleModel(id, OPENAI_COMPAT_BASE, false, true),
+  );
   return openAiCompatibleProvider([
     {
       ...openAiCompatibleModel(OPENAI_COMPATIBLE_CATALOG_MODEL_ID, OPENAI_COMPAT_BASE),
       name: "Custom model id",
     },
+    ...visionModels,
   ]);
 }
 
@@ -235,8 +254,12 @@ export function registerOpenAiCompatibleRuntime(
   opts: { modelId: string; baseUrl: string; reasoning?: boolean },
 ): MutableModels {
   const baseUrl = normalizeOpenAiCompatibleBaseUrl(opts.baseUrl);
+  const modelId = opts.modelId.trim();
+  const acceptsImages = openAiCompatibleVisionModelIds().has(modelId);
   models.setProvider(
-    openAiCompatibleProvider([openAiCompatibleModel(opts.modelId.trim(), baseUrl, opts.reasoning)]),
+    openAiCompatibleProvider([
+      openAiCompatibleModel(modelId, baseUrl, opts.reasoning, acceptsImages),
+    ]),
   );
   return models;
 }


### PR DESCRIPTION
## Why

`local` and `openai-compatible` models hardcode `input: ["text"]` (`pi-local-provider.ts:72`, `pi-openai-compatible-provider.ts:51`), and `modelAcceptsImageInput` gates the screenshot-returning computer tools on `input.includes("image")`.

A vision model reached through a gateway (LiteLLM, LM Studio, vLLM) therefore silently loses `computer_observe` / `computer_act` / `open_path` / `launch_app`, with no error surfaced. The bot cannot drive a computer at all, and nothing says why.

Defaulting to text-only is the right default: the catalog cannot know what an operator points these providers at, and guessing `image` would send screenshots into a model that cannot see. What was missing is a way for the operator to say otherwise.

## What changed

Two env vars, comma-separated model ids:

```
RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS=gpt4o-vision,llava
RAKAZO_LOCAL_VISION_MODELS=qwen3-vl
```

Declared ids get `input: ["text", "image"]`. Everything else is unchanged, and an empty or unset value is exactly today's behaviour.

The declaration is registered on the catalog provider as well as the per-run registry, because `modelAcceptsImageInput` resolves against the memoized catalog rather than the runtime one. Patching only the runtime path would leave the gate reading text-only and change nothing observable.

New `packages/adapters/src/model-modalities.ts` holds the parsing so both providers share one implementation.

## How I tested

- `pnpm check` clean.
- `pnpm test` on this branch: 2587 passed, 2 failed. Both failures are 30s timeouts in `packages/adapters/src/computer-idle.test.ts` (background shell launch and teardown). Running that file alone on unmodified `main` at 8ab993a2 in the same environment reproduces the timeout, so it is my machine, not this change. This diff touches no file in that suite.
- `pnpm lint`: I diffed the full biome diagnostic list on this branch against unmodified `main` at 8ab993a2. The two lists are byte-identical, so this diff adds zero diagnostics. (`main` currently reports a few of its own, including an unused import in `packages/ui-web/src/components/ui/scroll-area.tsx`.)
- New unit coverage in `model-modalities.test.ts` (109 lines): empty/unset, whitespace, duplicates, unknown ids, and both providers reporting `["text","image"]` only for declared ids.

Refs #199, #203.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options for identifying vision-capable local and OpenAI-compatible models.
  * Configured vision-capable models accept image inputs and can use screenshot-returning computer tools.
  * Runtime-registered models respect configured image-input capabilities.
  * Duplicate model declarations are consolidated into a single catalog entry.

* **Documentation**
  * Documented vision-model configuration, Docker resource limits, and compose deployment settings.

* **Tests**
  * Added coverage for vision configuration, image handling, model registration, and computer tool filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->