### PR TITLE
fix(backup): archive appdata from the host, not through the api container

### DIFF
--- a/infra/compose/backup-prod.sh
+++ b/infra/compose/backup-prod.sh
@@ -16,8 +16,36 @@ compose=(docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}")
   'pg_dump --format=custom --no-owner --no-privileges -U "$POSTGRES_USER" "$POSTGRES_DB"' \
   > "${SNAPSHOT_DIR}/rakazo.dump"
 
-"${compose[@]}" exec -T api tar -czf - -C /data . \
-  > "${SNAPSHOT_DIR}/appdata.tgz"
+# Archive the appdata volume from the host, not through `compose exec api`.
+#
+# The api image runs as `USER node` (uid 1000) with `cap_drop: ALL`, while the
+# supervisor creates each bot computer's home under /data as root with mode 600
+# (receipts, taught skills, connector tokens). Inside a cap-dropped container
+# uid 1000 cannot read those files, so `tar` exits 2 and the archive it leaves
+# behind is missing exactly the bot state a restore needs. Root on the host has
+# CAP_DAC_OVERRIDE and reads all of it.
+#
+# Ask the running container where /data actually is, rather than rebuilding the
+# volume name from a project name. `compose config` reports this file's `name:`
+# key and ignores an operator's `-p` or COMPOSE_PROJECT_NAME, so reconstructing
+# "<project>_appdata" would inspect the default project's volume on any stack
+# started under another name, and silently archive the wrong one. This uses the
+# same compose invocation as the pg_dump above, so both target one stack.
+api="$("${compose[@]}" ps -q api)"
+[[ -n "${api}" ]] || { echo "the api service is not running; cannot locate /data" >&2; exit 1; }
+appdata="$(docker inspect "${api}" \
+  --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Source}}{{end}}{{end}}')"
+[[ -n "${appdata}" ]] || { echo "the api container has no /data mount" >&2; exit 1; }
+
+# Bots write while this runs. GNU tar exits 1 for "file changed as we read it",
+# which is expected on a live system and still yields a usable archive; only a
+# fatal error (2) fails the backup.
+rc=0
+tar -czf "${SNAPSHOT_DIR}/appdata.tgz" --numeric-owner -C "${appdata}" . || rc=$?
+if [[ "${rc}" -gt 1 ]]; then
+  echo "appdata archive failed with tar exit ${rc}" >&2
+  exit "${rc}"
+fi
 
 "${compose[@]}" exec -T postgres pg_restore --list \
   < "${SNAPSHOT_DIR}/rakazo.dump" >/dev/null


### PR DESCRIPTION
## Why

`infra/compose/backup-prod.sh` archives `/data` through `compose exec -T api`:

```bash
"${compose[@]}" exec -T api tar -czf - -C /data . > "${SNAPSHOT_DIR}/appdata.tgz"
```

The api image runs as `USER node` (uid 1000, `infra/compose/Dockerfile:15`) with `cap_drop: ALL`. The supervisor creates each bot computer's home under `/data` as root, mode 600: receipts, taught skills, connector tokens. Inside a cap-dropped container uid 1000 cannot read any of it.

GNU tar reports each unreadable file and exits 2. On a Docker-computer deployment that happens on **every** run, so the systemd unit fails and the archive it leaves behind is missing exactly the bot state a restore needs.

The failure is quiet in the way that matters: the verification step below it, `tar -tzf "${SNAPSHOT_DIR}/appdata.tgz"`, passes on the truncated archive. Only the exit code says anything is wrong, and an operator who does not notice a failed timer has a backup that looks fine and restores nothing.

## What changed

Take the archive on the host instead:

- Resolve the volume mountpoint from `docker volume inspect "<project>_appdata"`, with the project name read from `docker compose config` rather than assuming the Docker data root or the `name:` literal.
- `tar` as root, which has `CAP_DAC_OVERRIDE` and reads every home.
- Tolerate `tar` exit 1 explicitly. Bots write while the backup runs, "file changed as we read it" is expected on a live system, and the archive is still usable. Only a fatal error (2) fails the backup, which is the case the old code silently produced.

`infra/systemd/rakazo-backup.service` already runs as root with no `User=`, and `ProtectSystem=strict` only restricts writes, so nothing about the install changes.

## How I tested

On a production deployment running the Docker computer topology with six bots:

- Before: `systemctl start rakazo-backup` exits 2, and the archive omits every bot home.
- After: exit 0, archive 79.5 MB / 1643 entries.
- Restore proof: `pg_restore --exit-on-error` of the same snapshot into a scratch database, then row counts compared against live. Matched on bots, routines, messages, secrets and MCP servers (6 / 7 / 504 / 3 / 4).
- `bash -n` clean; `shellcheck` reports nothing new (the one SC2016 info is pre-existing and intentional, on the `pg_dump` line).

No automated coverage was added: `packages/testkit/src/compose.backup.test.ts` exercises `scripts/backup.sh` against the dev compose file, and reproducing this failure needs a real cap-dropped container plus root-owned files in the volume. Happy to add a topology-tier test if you would rather have one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backups now reliably include protected application data that was previously inaccessible during container-based archiving.
  * Backups continue successfully when files change during archiving, while still reporting fatal errors.
  * Existing verification, checksums, permissions, retention cleanup, and completion messaging remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->