### PR TITLE
feat(updater): honour a Compose overlay and its extra services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,15 @@ GIT_SHA=
 # Docker Desktop on Windows (C:\Users\you\rakazo):
 #   RAKAZO_DEPLOY_DIR=/run/desktop/mnt/host/c/Users/you/rakazo
 RAKAZO_DEPLOY_DIR=
+# Compose files the updater reconciles, in overlay order, separated like Compose's own
+# COMPOSE_FILE (":" unless COMPOSE_PATH_SEPARATOR says otherwise). Leave unset for the base stack.
+#   RAKAZO_COMPOSE_FILE=infra/compose/docker-compose.prod.yml:ops/compose/overlay.yml
+RAKAZO_COMPOSE_FILE=
+# Extra services an update pulls, recreates and rolls back, comma separated. Name any overlay
+# service built from the application image, or it keeps running the previous code after an update.
+# Appended to api, worker, web; the updater itself is refused.
+#   RAKAZO_UPDATE_SERVICES=supervisor
+RAKAZO_UPDATE_SERVICES=
 # Published images (defaults match this repository). Tag `local` is built from the checkout.
 RAKAZO_IMAGE=ghcr.io/elie222/rakazo/app
 RAKAZO_IMAGE_TAG=local

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -543,6 +543,29 @@ not automatically put it in a container's environment, so the production file ex
 stack started with `-p something-else` would be left alone while a second project with a new empty
 Postgres volume came up beside it.
 
+### Deployments that layer a Compose overlay
+
+`RAKAZO_COMPOSE_FILE` takes a list, separated the way Compose's own `COMPOSE_FILE` is
+(`:` by default, or whatever `COMPOSE_PATH_SEPARATOR` says). Each entry becomes its own `--file`,
+in the order given, so the updater reconciles the same stack the operator runs by hand:
+
+```
+RAKAZO_COMPOSE_FILE=infra/compose/docker-compose.prod.yml:ops/compose/overlay.yml
+```
+
+Every entry is validated separately and must stay inside `RAKAZO_DEPLOY_DIR`.
+
+If the overlay adds a service built from the application image, name it in
+`RAKAZO_UPDATE_SERVICES` (comma separated) so it is pulled, recreated and rolled back with the
+rest. Otherwise an update leaves that service running the previous code:
+
+```
+RAKAZO_UPDATE_SERVICES=supervisor
+```
+
+These names are appended to the built-in `api`, `worker`, `web`, never substituted for them, so no
+value here can drop a core service from an update.
+
 The value therefore has to be the path **the daemon** sees, which is not always the path your shell
 sees:
 

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -198,7 +198,12 @@ services:
       # Must equal the host path it is mounted from, or every relative bind mount in this file would
       # resolve somewhere else. /srv/rakazo is the supported Linux production layout.
       RAKAZO_DEPLOY_DIR: ${RAKAZO_DEPLOY_DIR:-/srv/rakazo}
-      RAKAZO_COMPOSE_FILE: infra/compose/docker-compose.prod.yml
+      # A deployment that layers an overlay has to be reconciled with the same file list and the
+      # same services the operator runs by hand, so these are read from the environment rather
+      # than pinned to the base stack. Defaults reproduce the previous behaviour exactly.
+      RAKAZO_COMPOSE_FILE: ${RAKAZO_COMPOSE_FILE:-infra/compose/docker-compose.prod.yml}
+      RAKAZO_UPDATE_SERVICES: ${RAKAZO_UPDATE_SERVICES:-}
+      COMPOSE_PATH_SEPARATOR: ${COMPOSE_PATH_SEPARATOR:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       LOG_FORMAT: ${LOG_FORMAT:-}
       AXIOM_TOKEN: ${AXIOM_TOKEN:-}

--- a/infra/updater/src/compose-service.test.ts
+++ b/infra/updater/src/compose-service.test.ts
@@ -36,6 +36,9 @@ describe("the production computer provider", () => {
  * properties that keep that from being reachable by anything but the API, and they are easy to
  * break by accident in YAML, so they are asserted rather than reviewed.
  */
+/** The Compose interpolation this file is expected to carry, as Compose spells it. */
+const interpolated = (name: string, fallback = "") => `\${${name}:-${fallback}}`;
+
 describe("the updater compose service", () => {
   it("exists and runs the updater image", () => {
     expect(updater).toBeDefined();
@@ -97,6 +100,22 @@ describe("the updater compose service", () => {
     expect(compose.services.api?.image).toContain("ghcr.io/elie222/rakazo/app");
     expect(compose.services.postgres?.image).toMatch(/^postgres:16@sha256:[0-9a-f]{64}$/);
     expect(compose.services.caddy?.image).toMatch(/^caddy:2@sha256:[0-9a-f]{64}$/);
+  });
+
+  it("lets a deployment name its own Compose files and extra services", () => {
+    // resolveUpdaterConfig reads these from the sidecar's environment, and the sidecar's
+    // environment is exactly what this file declares. Pinning them here would make the documented
+    // variables inert: the operator sets them, the updater never sees them, and the overlay is
+    // dropped on every recreate.
+    expect(updater.environment?.RAKAZO_COMPOSE_FILE).toBe(
+      interpolated("RAKAZO_COMPOSE_FILE", "infra/compose/docker-compose.prod.yml"),
+    );
+    expect(updater.environment?.RAKAZO_UPDATE_SERVICES).toBe(
+      interpolated("RAKAZO_UPDATE_SERVICES"),
+    );
+    expect(updater.environment?.COMPOSE_PATH_SEPARATOR).toBe(
+      interpolated("COMPOSE_PATH_SEPARATOR"),
+    );
   });
 
   it("injects the actual Compose project name into the updater container", () => {

--- a/infra/updater/src/index.ts
+++ b/infra/updater/src/index.ts
@@ -152,9 +152,10 @@ export function createUpdaterApp(
   app.use("*", requestLogging(options.logger));
   const run = options.run ?? runCommand;
   const composeTarget = {
-    composeFile: config.composeFile,
+    composeFiles: config.composeFiles,
     envFiles: [config.envFile],
     projectName: config.projectName,
+    services: config.updateServices,
   };
   let running = false;
   let planInFlight: Promise<unknown> | null = null;
@@ -180,7 +181,7 @@ export function createUpdaterApp(
       const checkout = await readCheckout();
       return c.json({
         deployDir: config.deployDir,
-        composeFile: config.composeFile,
+        composeFiles: config.composeFiles,
         image: config.image,
         imageRef: imageRef(config.image, tags.currentTag),
         running,

--- a/infra/updater/src/updater-logic.test.ts
+++ b/infra/updater/src/updater-logic.test.ts
@@ -19,7 +19,8 @@ describe("resolveUpdaterConfig", () => {
     const config = resolveUpdaterConfig({ ...base });
     expect(config).toMatchObject({
       deployDir: "/srv/rakazo",
-      composeFile: `/srv/rakazo/${DEFAULT_COMPOSE_FILE}`,
+      composeFiles: [`/srv/rakazo/${DEFAULT_COMPOSE_FILE}`],
+      updateServices: ["api", "worker", "web"],
       envFile: "/srv/rakazo/.env",
       projectName: DEFAULT_COMPOSE_PROJECT_NAME,
       token: base.RAKAZO_UPDATER_TOKEN,
@@ -59,6 +60,68 @@ describe("resolveUpdaterConfig", () => {
       expect(() => resolveUpdaterConfig({ ...base, RAKAZO_COMPOSE_FILE: composeFile })).toThrow(
         /RAKAZO_COMPOSE_FILE/,
       );
+    }
+  });
+
+  it("resolves a Compose file list in order, against the deployment directory", () => {
+    expect(
+      resolveUpdaterConfig({
+        ...base,
+        RAKAZO_COMPOSE_FILE: "infra/compose/docker-compose.prod.yml:ops/overlay.yml",
+      }).composeFiles,
+    ).toEqual(["/srv/rakazo/infra/compose/docker-compose.prod.yml", "/srv/rakazo/ops/overlay.yml"]);
+  });
+
+  it("honours COMPOSE_PATH_SEPARATOR the way Compose does", () => {
+    expect(
+      resolveUpdaterConfig({
+        ...base,
+        COMPOSE_PATH_SEPARATOR: ",",
+        RAKAZO_COMPOSE_FILE: "a.yml,b.yml",
+      }).composeFiles,
+    ).toEqual(["/srv/rakazo/a.yml", "/srv/rakazo/b.yml"]);
+  });
+
+  it("checks every entry in a list, not just the first", () => {
+    expect(() =>
+      resolveUpdaterConfig({
+        ...base,
+        RAKAZO_COMPOSE_FILE: "infra/compose/docker-compose.prod.yml:../../etc/compose.yml",
+      }),
+    ).toThrow(/RAKAZO_COMPOSE_FILE/);
+    expect(() =>
+      resolveUpdaterConfig({
+        ...base,
+        RAKAZO_COMPOSE_FILE: "infra/compose/docker-compose.prod.yml:/etc/compose.yml",
+      }),
+    ).toThrow(/RAKAZO_COMPOSE_FILE/);
+  });
+
+  it("refuses a Compose file list that names nothing", () => {
+    expect(() => resolveUpdaterConfig({ ...base, RAKAZO_COMPOSE_FILE: ":  :" })).toThrow(
+      /RAKAZO_COMPOSE_FILE/,
+    );
+  });
+
+  it("appends the deployment's extra services to the built-in set", () => {
+    expect(
+      resolveUpdaterConfig({ ...base, RAKAZO_UPDATE_SERVICES: "supervisor, caddy" }).updateServices,
+    ).toEqual(["api", "worker", "web", "supervisor", "caddy"]);
+  });
+
+  it("cannot drop a built-in service, however RAKAZO_UPDATE_SERVICES is written", () => {
+    const services = resolveUpdaterConfig({
+      ...base,
+      RAKAZO_UPDATE_SERVICES: "web,supervisor",
+    }).updateServices;
+    expect(services).toEqual(["api", "worker", "web", "supervisor"]);
+  });
+
+  it("refuses a service name it would not hand to compose as one argument", () => {
+    for (const service of ["--build", "a b", "-f", "api;rm"]) {
+      expect(() =>
+        resolveUpdaterConfig({ ...base, RAKAZO_UPDATE_SERVICES: `supervisor,${service}` }),
+      ).toThrow(/RAKAZO_UPDATE_SERVICES/);
     }
   });
 

--- a/infra/updater/src/updater-logic.test.ts
+++ b/infra/updater/src/updater-logic.test.ts
@@ -117,6 +117,12 @@ describe("resolveUpdaterConfig", () => {
     expect(services).toEqual(["api", "worker", "web", "supervisor"]);
   });
 
+  it("refuses to recreate the updater, which would kill the run mid-flight", () => {
+    expect(() =>
+      resolveUpdaterConfig({ ...base, RAKAZO_UPDATE_SERVICES: "supervisor,updater" }),
+    ).toThrow(/updater/);
+  });
+
   it("refuses a service name it would not hand to compose as one argument", () => {
     for (const service of ["--build", "a b", "-f", "api;rm"]) {
       expect(() =>

--- a/infra/updater/src/updater-logic.ts
+++ b/infra/updater/src/updater-logic.ts
@@ -6,18 +6,25 @@ import {
   isValidImageTag,
   OFFICIAL_SERVER_IMAGE,
   PREVIOUS_IMAGE_TAG_ENV,
+  RECREATED_SERVICES,
   resolveComposeProjectName,
   resolveUpdaterToken,
 } from "@rakazo/core";
 
 export const DEFAULT_UPDATER_PORT = 7092;
 export const DEFAULT_COMPOSE_FILE = "infra/compose/docker-compose.prod.yml";
+/** Compose's own convention for a multi-file list, matching COMPOSE_FILE. */
+export const DEFAULT_COMPOSE_PATH_SEPARATOR = ":";
+const SERVICE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/;
 export const MAX_STEP_OUTPUT = 8_000;
 
 export interface UpdaterConfig {
   /** Bind-mounted at the same absolute path it has on the host, so Compose resolves identically. */
   deployDir: string;
-  composeFile: string;
+  /** Overlay order, absolute. Each becomes its own `--file`. */
+  composeFiles: readonly string[];
+  /** Services the update pulls, recreates and rolls back. */
+  updateServices: readonly string[];
   envFile: string;
   /** Passed as `docker compose -p`. Compose injects this into running services. */
   projectName: string;
@@ -41,17 +48,46 @@ export function resolveUpdaterConfig(env: NodeJS.ProcessEnv): UpdaterConfig {
   const image = env.RAKAZO_IMAGE?.trim() || OFFICIAL_SERVER_IMAGE;
   if (!isValidImageName(image))
     throw new Error(`RAKAZO_IMAGE is not a usable image name: ${image}`);
-  const composeFile = env.RAKAZO_COMPOSE_FILE?.trim() || DEFAULT_COMPOSE_FILE;
-  if (path.posix.isAbsolute(composeFile) || composeFile.split("/").includes("..")) {
-    throw new Error("RAKAZO_COMPOSE_FILE must be a path inside the deployment directory.");
+  // Compose itself takes a list here (COMPOSE_FILE with COMPOSE_PATH_SEPARATOR), and a deployment
+  // that layers an overlay must be reconciled with the same list the operator runs by hand. Every
+  // entry is validated separately: one bad path in a list is still a path escape.
+  const separator = env.COMPOSE_PATH_SEPARATOR?.trim() || DEFAULT_COMPOSE_PATH_SEPARATOR;
+  const composeFiles = (env.RAKAZO_COMPOSE_FILE?.trim() || DEFAULT_COMPOSE_FILE)
+    .split(separator)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== "");
+  if (composeFiles.length === 0) {
+    throw new Error("RAKAZO_COMPOSE_FILE must name at least one Compose file.");
   }
+  for (const composeFile of composeFiles) {
+    if (path.posix.isAbsolute(composeFile) || composeFile.split("/").includes("..")) {
+      throw new Error("RAKAZO_COMPOSE_FILE must list paths inside the deployment directory.");
+    }
+  }
+  // An overlay that adds a service built from the application image has to be recreated with the
+  // rest, or an update leaves it running the old code. These are appended to the built-in set
+  // rather than replacing it, so a typo cannot drop `api` from an update.
+  const extraServices = (env.RAKAZO_UPDATE_SERVICES ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== "");
+  for (const service of extraServices) {
+    if (!SERVICE_NAME.test(service)) {
+      throw new Error(`RAKAZO_UPDATE_SERVICES contains an unusable service name: ${service}`);
+    }
+  }
+  const updateServices = [
+    ...RECREATED_SERVICES,
+    ...extraServices.filter((service) => !RECREATED_SERVICES.includes(service as never)),
+  ];
   const port = Number(env.RAKAZO_UPDATER_PORT ?? DEFAULT_UPDATER_PORT);
   if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
     throw new Error("RAKAZO_UPDATER_PORT is not a port number.");
   }
   return {
     deployDir,
-    composeFile: path.posix.join(deployDir, composeFile),
+    composeFiles: composeFiles.map((composeFile) => path.posix.join(deployDir, composeFile)),
+    updateServices,
     envFile: path.posix.join(deployDir, ".env"),
     projectName: resolveComposeProjectName(env),
     image,

--- a/infra/updater/src/updater-logic.ts
+++ b/infra/updater/src/updater-logic.ts
@@ -16,6 +16,8 @@ export const DEFAULT_COMPOSE_FILE = "infra/compose/docker-compose.prod.yml";
 /** Compose's own convention for a multi-file list, matching COMPOSE_FILE. */
 export const DEFAULT_COMPOSE_PATH_SEPARATOR = ":";
 const SERVICE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/;
+/** The sidecar itself, which must never appear in the set of services an update recreates. */
+const UPDATER_SERVICE = "updater";
 export const MAX_STEP_OUTPUT = 8_000;
 
 export interface UpdaterConfig {
@@ -74,6 +76,14 @@ export function resolveUpdaterConfig(env: NodeJS.ProcessEnv): UpdaterConfig {
   for (const service of extraServices) {
     if (!SERVICE_NAME.test(service)) {
       throw new Error(`RAKAZO_UPDATE_SERVICES contains an unusable service name: ${service}`);
+    }
+    // The sidecar is the process running the update. Recreating it would kill the request
+    // mid-flight, so there would be nothing left to finish the run, report it, or recover from a
+    // failed step. RECREATED_SERVICES already excludes it on purpose; this keeps that true.
+    if (service === UPDATER_SERVICE) {
+      throw new Error(
+        "RAKAZO_UPDATE_SERVICES must not contain the updater: it cannot recreate itself mid-update.",
+      );
     }
   }
   const updateServices = [

--- a/packages/core/src/compose-update.test.ts
+++ b/packages/core/src/compose-update.test.ts
@@ -40,7 +40,7 @@ import {
 } from "./compose-update.js";
 
 const target = {
-  composeFile: "/srv/rakazo/infra/compose/docker-compose.prod.yml",
+  composeFiles: ["/srv/rakazo/infra/compose/docker-compose.prod.yml"],
   envFiles: ["/srv/rakazo/.env"],
 };
 
@@ -218,13 +218,81 @@ describe("compose argv construction", () => {
         "--env-file",
         "/srv/rakazo/.env",
         "--file",
-        target.composeFile,
+        ...target.composeFiles,
         "pull",
         "api",
         "worker",
         "web",
       ],
     });
+  });
+
+  it("passes one --file per Compose file, in overlay order", () => {
+    const overlaid = {
+      ...target,
+      composeFiles: [
+        "/srv/rakazo/infra/compose/docker-compose.prod.yml",
+        "/srv/rakazo/ops/compose/docker-compose.sandbox.yml",
+      ],
+    };
+    for (const invocation of [
+      composePullArgv(overlaid),
+      composeUpArgv(overlaid),
+      composePsArgv(overlaid),
+    ]) {
+      const files = invocation.args.flatMap((arg, index) =>
+        arg === "--file" ? [invocation.args[index + 1]] : [],
+      );
+      expect(files).toEqual(overlaid.composeFiles);
+    }
+  });
+
+  it("refuses a target with no Compose file rather than running against the default stack", () => {
+    expect(() => composePullArgv({ ...target, composeFiles: [] })).toThrow(/no Compose file/);
+  });
+
+  it("recreates and pulls the target's own services when an overlay adds one", () => {
+    const withSupervisor = { ...target, services: ["api", "worker", "web", "supervisor"] };
+    expect(composePullArgv(withSupervisor).args.slice(-4)).toEqual([
+      "api",
+      "worker",
+      "web",
+      "supervisor",
+    ]);
+    expect(composeUpArgv(withSupervisor).args.slice(-4)).toEqual([
+      "api",
+      "worker",
+      "web",
+      "supervisor",
+    ]);
+  });
+
+  it("falls back to the built-in services when the target names none", () => {
+    expect(composeUpArgv({ ...target, services: [] }).args.slice(-3)).toEqual([
+      "api",
+      "worker",
+      "web",
+    ]);
+  });
+
+  it("carries the overlay files and extra services into the update plan and its recovery", () => {
+    const overlaid = {
+      ...target,
+      composeFiles: [
+        "/srv/rakazo/infra/compose/docker-compose.prod.yml",
+        "/srv/rakazo/ops/compose/docker-compose.sandbox.yml",
+      ],
+      services: ["api", "worker", "web", "supervisor"],
+    };
+    for (const strategy of ["pull", "build"] as const) {
+      const steps = composeUpdatePlan({ strategy, target: overlaid });
+      const composeSteps = steps.filter((step) => step.command === "docker");
+      expect(composeSteps.length).toBeGreaterThan(0);
+      for (const step of composeSteps) {
+        expect(step.args.filter((arg) => arg === "--file")).toHaveLength(2);
+        expect(step.args).toContain("supervisor");
+      }
+    }
   });
 
   it("passes the project name as its own -p argument so a custom stack is the one updated", () => {

--- a/packages/core/src/compose-update.ts
+++ b/packages/core/src/compose-update.ts
@@ -394,10 +394,21 @@ export interface ComposeInvocation {
 }
 
 export interface ComposeTarget {
-  composeFile: string;
+  /**
+   * Compose files in overlay order, each passed as its own `--file`. A deployment that layers an
+   * overlay on the base file has to be reconciled with the same file list the operator uses, or an
+   * update recreates services without the overlay's wiring.
+   */
+  composeFiles: readonly string[];
   envFiles?: readonly string[];
   /** Passed as `docker compose -p <name>`. Defaults to {@link DEFAULT_COMPOSE_PROJECT_NAME}. */
   projectName?: string;
+  /**
+   * Services to pull, recreate and roll back. Defaults to {@link RECREATED_SERVICES}. A deployment
+   * whose overlay adds an app-image service has to recreate that one too, or the update leaves it
+   * running the old code.
+   */
+  services?: readonly string[];
 }
 
 function composeBase(target: ComposeTarget): string[] {
@@ -405,15 +416,23 @@ function composeBase(target: ComposeTarget): string[] {
   if (!isValidComposeProjectName(projectName)) {
     throw new Error(`Refusing an unusable Compose project name: ${projectName}`);
   }
+  if (target.composeFiles.length === 0) {
+    throw new Error("Refusing a Compose target with no Compose file.");
+  }
   const args = ["compose", "-p", projectName];
   for (const envFile of target.envFiles ?? []) args.push("--env-file", envFile);
-  args.push("--file", target.composeFile);
+  for (const composeFile of target.composeFiles) args.push("--file", composeFile);
   return args;
+}
+
+function targetServices(target: ComposeTarget): readonly string[] {
+  const services = target.services ?? [];
+  return services.length > 0 ? services : RECREATED_SERVICES;
 }
 
 export function composePullArgv(
   target: ComposeTarget,
-  services: readonly string[] = RECREATED_SERVICES,
+  services: readonly string[] = targetServices(target),
 ): ComposeInvocation {
   return { command: "docker", args: [...composeBase(target), "pull", ...services] };
 }
@@ -433,7 +452,7 @@ export function composeUpArgv(
     "never",
   ];
   args.push(options.build === true ? "--build" : "--no-build");
-  args.push(...(options.services ?? RECREATED_SERVICES));
+  args.push(...(options.services ?? targetServices(target)));
   return { command: "docker", args };
 }
 


### PR DESCRIPTION
## Why

A self-hosted deployment that layers an overlay on `docker-compose.prod.yml` cannot use the in-app updater today. Two things compound:

1. **`RAKAZO_COMPOSE_FILE` is one path.** `resolveUpdaterConfig` takes a single value and `composeBase` pushes a single `--file`, so the updater reconciles a *different* stack than the operator runs by hand. Every recreate drops the overlay's wiring, and the services that depend on it fail in setup.
2. **`RECREATED_SERVICES` is fixed to `api, worker, web`.** An overlay service built from the application image keeps running the previous code after an update, and rollback never touches it either, so the two halves of the deployment silently drift apart.

The result is that "Check for updates" is unusable on any stack that is not exactly the shipped one, and the failure mode is a half-updated runtime rather than a refusal.

## What changed

Both values now come from the deployment:

```
RAKAZO_COMPOSE_FILE=infra/compose/docker-compose.prod.yml:ops/compose/overlay.yml
RAKAZO_UPDATE_SERVICES=supervisor
```

- The file list uses Compose's own convention and honours `COMPOSE_PATH_SEPARATOR`, so it reads the same way `COMPOSE_FILE` does. Each entry becomes its own `--file`, in order.
- **Every entry is validated separately.** One bad path in a list is still a path escape; validating only the first would have been a hole, and there is a test that fails if it is reintroduced.
- Service names are matched against a conservative grammar before they can become argv, and are **appended** to the built-in set rather than replacing it, so no value here can drop `api` from an update.
- `composeFiles` and `services` live on `ComposeTarget`. The update plan, the rollback path and the post-failure recovery in `execute` therefore all pick them up from the one place the target is built, with no second list to keep in sync.

`ComposeTarget.composeFile: string` becomes `composeFiles: readonly string[]`. That is a type change rather than an added-alongside option deliberately: two ways to name the file would mean a precedence rule and a way to get it wrong. The only non-test call sites are in `infra/updater/src/index.ts`, both updated here.

Defaults are unchanged: one file, three services.

## How I tested

- `pnpm vitest run packages/core/src infra/updater/src`: 458 passed. New cases cover one `--file` per entry in order, the empty-target refusal, extra services in pull/up, the fallback when none are named, plan and recovery argv carrying both, `COMPOSE_PATH_SEPARATOR`, per-entry path validation, an empty list, appending rather than replacing, and rejection of `--build` / `-f` / `a b` / `api;rm` as service names.
- Negative controls, each reverting one behaviour and confirming the tests fail rather than pass vacuously: single `--file` → 2 fail; hardcoded `RECREATED_SERVICES` → 2 fail; validating only the first path entry → 1 fail.
- `pnpm check` clean.
- `pnpm lint`: full biome diagnostic list diffed against unmodified `main` at 8ab993a2, byte-identical, so this adds none.
- `docs/self-host.md` gains a short section next to the existing deploy-directory notes.

Related: #617 is the other thing blocking the updater on a real deployment (git refuses the bind-mounted checkout as root). They are independent.
