### PR TITLE
fix(logging): redact secrets in string bindings

### DIFF
--- a/packages/logging/src/redaction.test.ts
+++ b/packages/logging/src/redaction.test.ts
@@ -62,6 +62,18 @@ describe("redaction", () => {
     expect(JSON.stringify(redacted.detail)).not.toContain("cause-secret");
   });
 
+  it("redacts secrets embedded in string binding values", () => {
+    const redacted = redactBindings({
+      detail: "token=binding-secret",
+      nested: { note: "Bearer nested-secret" },
+    });
+
+    expect(redacted).toEqual({
+      detail: "token=[Redacted]",
+      nested: { note: "Bearer [Redacted]" },
+    });
+  });
+
   it("redacts secrets embedded in free text", () => {
     const redacted = redactSensitiveText(
       "user person@example.com used Bearer supersecret and token=abc123",

--- a/packages/logging/src/redaction.ts
+++ b/packages/logging/src/redaction.ts
@@ -15,6 +15,7 @@ const SECRET_KEY = /password|secret|token|authorization|cookie|credential|apikey
 
 function redactValue(value: unknown, seen = new WeakSet<object>()): unknown {
   if (value === null || value === undefined) return value;
+  if (typeof value === "string") return redactSensitiveText(value);
   if (typeof value !== "object") return value;
   if (seen.has(value)) return "[Circular]";
   seen.add(value);


### PR DESCRIPTION
## Why

Structured log bindings redacted sensitive keys and Error fields, but ordinary string values under non-sensitive keys bypassed the existing text redactor. A value such as `detail: "token=..."` could therefore reach console, JSON, or remote sinks unchanged.

## What

- pass string binding values through `redactSensitiveText`
- cover both top-level and nested string bindings
- keep non-string primitive and key-based behavior unchanged

## Test

- `pnpm exec vitest run --root ../.. packages/logging/src/redaction.test.ts` (8 passed)
- `pnpm --filter @rakazo/logging test` (36 passed)
- `pnpm --filter @rakazo/logging exec tsc --noEmit`
- `pnpm exec biome check packages/logging/src/redaction.ts packages/logging/src/redaction.test.ts`
- `git diff --check`
