### PR TITLE
fix(adapters): drop custom headers on cross-origin web redirects

### DIFF
--- a/packages/adapters/src/web-ssrf.test.ts
+++ b/packages/adapters/src/web-ssrf.test.ts
@@ -92,6 +92,35 @@ describe("web SSRF policy", () => {
     expect(result.body).toContain("hello");
   });
 
+  it("drops sensitive custom headers on cross-origin redirects", async () => {
+    let finalHeaders = new Headers();
+    const fetchMock: typeof fetch = async (input, init) => {
+      const url = new URL(String(input));
+      if (url.origin === "https://example.test") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://other.example.test/final" },
+        });
+      }
+      finalHeaders = new Headers(init?.headers);
+      return new Response("ok", { status: 200 });
+    };
+
+    await fetchSafeWebText("https://example.test/start", {
+      fetch: fetchMock,
+      resolveHostname: publicResolver,
+      headers: {
+        Authorization: "Bearer stored",
+        "X-Api-Key": "stored-key",
+        "X-Trace-Id": "trace-1",
+      },
+    });
+
+    expect(finalHeaders.get("authorization")).toBeNull();
+    expect(finalHeaders.get("x-api-key")).toBeNull();
+    expect(finalHeaders.get("x-trace-id")).toBe("trace-1");
+  });
+
   it("rejects oversized Content-Length before reading", async () => {
     const fetchMock: typeof fetch = async () =>
       new Response("ignored", {

--- a/packages/adapters/src/web-ssrf.test.ts
+++ b/packages/adapters/src/web-ssrf.test.ts
@@ -92,7 +92,7 @@ describe("web SSRF policy", () => {
     expect(result.body).toContain("hello");
   });
 
-  it("drops sensitive custom headers on cross-origin redirects", async () => {
+  it("drops caller-provided headers on cross-origin redirects", async () => {
     let finalHeaders = new Headers();
     const fetchMock: typeof fetch = async (input, init) => {
       const url = new URL(String(input));
@@ -118,7 +118,7 @@ describe("web SSRF policy", () => {
 
     expect(finalHeaders.get("authorization")).toBeNull();
     expect(finalHeaders.get("x-api-key")).toBeNull();
-    expect(finalHeaders.get("x-trace-id")).toBe("trace-1");
+    expect(finalHeaders.get("x-trace-id")).toBeNull();
   });
 
   it("rejects oversized Content-Length before reading", async () => {

--- a/packages/adapters/src/web-ssrf.ts
+++ b/packages/adapters/src/web-ssrf.ts
@@ -11,7 +11,6 @@ import {
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
-const SENSITIVE_HEADER = /authorization|cookie|credential|api[-_]?key|token|secret/i;
 
 export type { ResolveHostname } from "./network-address.js";
 
@@ -173,12 +172,7 @@ async function followRedirects(
       throw new Error("Redirect missing Location header");
     }
     const next = new URL(location, validated.href);
-    const headers =
-      next.origin === validated.origin
-        ? state.headers
-        : Object.fromEntries(
-            Object.entries(state.headers ?? {}).filter(([name]) => !SENSITIVE_HEADER.test(name)),
-          );
+    const headers = next.origin === validated.origin ? state.headers : undefined;
     // Release this hop before following — do not leave the body open across recursion.
     await cancelResponseBody(response, state.signal);
     return followRedirects(next.href, {

--- a/packages/adapters/src/web-ssrf.ts
+++ b/packages/adapters/src/web-ssrf.ts
@@ -11,6 +11,7 @@ import {
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
+const SENSITIVE_HEADER = /authorization|cookie|credential|api[-_]?key|token|secret/i;
 
 export type { ResolveHostname } from "./network-address.js";
 
@@ -171,11 +172,18 @@ async function followRedirects(
       await cancelResponseBody(response, state.signal);
       throw new Error("Redirect missing Location header");
     }
-    const next = new URL(location, validated.href).href;
+    const next = new URL(location, validated.href);
+    const headers =
+      next.origin === validated.origin
+        ? state.headers
+        : Object.fromEntries(
+            Object.entries(state.headers ?? {}).filter(([name]) => !SENSITIVE_HEADER.test(name)),
+          );
     // Release this hop before following — do not leave the body open across recursion.
     await cancelResponseBody(response, state.signal);
-    return followRedirects(next, {
+    return followRedirects(next.href, {
       ...state,
+      headers,
       redirectsRemaining: state.redirectsRemaining - 1,
     });
   }


### PR DESCRIPTION
## Why

Safe Web Fetch manually follows redirects and reused caller-provided headers at every hop. A public page could redirect to another origin and receive an `Authorization`, API-key, token, cookie, or other credential header intended only for the first origin.

## What

- remove all caller-provided custom headers when a redirect changes origin
- keep wrapper-generated headers such as `User-Agent` and `Accept` on every hop
- keep same-origin redirect behavior unchanged

## Test

- `pnpm exec vitest run --root ../.. packages/adapters/src/web-ssrf.test.ts` (27 passed)
- `pnpm --filter @rakazo/adapters test` (1083 passed, 7 skipped)
- `pnpm --filter @rakazo/adapters check`
- `pnpm exec biome check packages/adapters/src/web-ssrf.ts packages/adapters/src/web-ssrf.test.ts`
- `git diff --check`
