### PR TITLE
fix(adapters): validate MCP OAuth authorization URLs

### DIFF
--- a/packages/adapters/src/mcp-oauth.test.ts
+++ b/packages/adapters/src/mcp-oauth.test.ts
@@ -23,9 +23,12 @@ function oauthSessionStore() {
 describe("MCP OAuth", () => {
   it("rejects unsafe browser authorization URLs", async () => {
     const onAuthorization = vi.fn();
-    const provider = new StoredMcpOAuthProvider("server-1", {}, async () => undefined, {
-      onAuthorization,
-    });
+    const provider = new StoredMcpOAuthProvider(
+      "server-1",
+      { oauth: { tokens: { access_token: "working", token_type: "bearer" } } },
+      async () => undefined,
+      { onAuthorization },
+    );
 
     await expect(
       provider.redirectToAuthorization(new URL("http://auth.example.test/authorize")),
@@ -33,6 +36,7 @@ describe("MCP OAuth", () => {
 
     expect(provider.authorizationUrl).toBeUndefined();
     expect(onAuthorization).not.toHaveBeenCalled();
+    expect(provider.tokens()).toMatchObject({ access_token: "working" });
   });
 
   it("allows localhost HTTP browser authorization URLs", async () => {
@@ -46,6 +50,24 @@ describe("MCP OAuth", () => {
 
     expect(provider.authorizationUrl).toEqual(authorizationUrl);
     expect(onAuthorization).toHaveBeenCalledWith(authorizationUrl);
+  });
+
+  it("clears stale tokens when runtime authorization URL validation fails", async () => {
+    const persisted: { oauth?: { tokens?: unknown } }[] = [];
+    const provider = new StoredMcpOAuthProvider(
+      "server-1",
+      { oauth: { tokens: { access_token: "revoked", token_type: "bearer" } } },
+      async (material) => {
+        persisted.push(structuredClone(material));
+      },
+    );
+
+    await expect(
+      provider.redirectToAuthorization(new URL("http://auth.example.test/authorize")),
+    ).rejects.toThrow(/HTTPS/i);
+
+    expect(provider.tokens()).toBeUndefined();
+    expect(persisted.at(-1)?.oauth?.tokens).toBeUndefined();
   });
 
   it("persists SDK credentials and invalidates only the requested scope", async () => {

--- a/packages/adapters/src/mcp-oauth.test.ts
+++ b/packages/adapters/src/mcp-oauth.test.ts
@@ -21,6 +21,33 @@ function oauthSessionStore() {
 }
 
 describe("MCP OAuth", () => {
+  it("rejects unsafe browser authorization URLs", async () => {
+    const onAuthorization = vi.fn();
+    const provider = new StoredMcpOAuthProvider("server-1", {}, async () => undefined, {
+      onAuthorization,
+    });
+
+    await expect(
+      provider.redirectToAuthorization(new URL("http://auth.example.test/authorize")),
+    ).rejects.toThrow(/HTTPS/i);
+
+    expect(provider.authorizationUrl).toBeUndefined();
+    expect(onAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("allows localhost HTTP browser authorization URLs", async () => {
+    const onAuthorization = vi.fn();
+    const provider = new StoredMcpOAuthProvider("server-1", {}, async () => undefined, {
+      onAuthorization,
+    });
+    const authorizationUrl = new URL("http://127.0.0.1:5173/authorize");
+
+    await provider.redirectToAuthorization(authorizationUrl);
+
+    expect(provider.authorizationUrl).toEqual(authorizationUrl);
+    expect(onAuthorization).toHaveBeenCalledWith(authorizationUrl);
+  });
+
   it("persists SDK credentials and invalidates only the requested scope", async () => {
     const persisted: unknown[] = [];
     const provider = new StoredMcpOAuthProvider(

--- a/packages/adapters/src/mcp-oauth.ts
+++ b/packages/adapters/src/mcp-oauth.ts
@@ -104,7 +104,15 @@ export class StoredMcpOAuthProvider implements OAuthClientProvider {
     await this.persist();
   }
   async redirectToAuthorization(url: URL): Promise<void> {
-    const authorizationUrl = validateUrl(url, { allowHttpLocalhost: true });
+    let authorizationUrl: URL;
+    try {
+      authorizationUrl = validateUrl(url, { allowHttpLocalhost: true });
+    } catch (error) {
+      if (!this.options.onAuthorization) {
+        await this.invalidateCredentials("tokens");
+      }
+      throw error;
+    }
     this.authorizationUrl = authorizationUrl;
     if (this.options.onAuthorization) {
       this.options.onAuthorization(authorizationUrl);

--- a/packages/adapters/src/mcp-oauth.ts
+++ b/packages/adapters/src/mcp-oauth.ts
@@ -104,9 +104,10 @@ export class StoredMcpOAuthProvider implements OAuthClientProvider {
     await this.persist();
   }
   async redirectToAuthorization(url: URL): Promise<void> {
-    this.authorizationUrl = url;
+    const authorizationUrl = validateUrl(url, { allowHttpLocalhost: true });
+    this.authorizationUrl = authorizationUrl;
     if (this.options.onAuthorization) {
-      this.options.onAuthorization(url);
+      this.options.onAuthorization(authorizationUrl);
       return;
     }
     // Runtime re-auth needs the user; drop the dead tokens so status reads "reconnect".


### PR DESCRIPTION
## Why

An MCP server controls the OAuth authorization URL that Rakazo opens in the user's browser. The stored provider previously forwarded that URL without applying the transport URL policy, allowing a public cleartext HTTP authorization endpoint or another unsupported URL shape to reach the browser flow.

## What

- validate browser authorization URLs with the existing MCP URL policy
- require HTTPS for remote authorization endpoints
- preserve HTTP localhost authorization for local MCP development
- reject invalid URLs before storing them or invoking the browser callback
- clear stale tokens on invalid runtime re-authorization so status returns to reconnect
- preserve existing tokens during interactive authorization attempts

## Test

- `pnpm exec vitest run --root ../.. packages/adapters/src/mcp-oauth.test.ts` (12 passed)
- `pnpm --filter @rakazo/adapters test` (1085 passed, 7 skipped)
- `pnpm --filter @rakazo/adapters check`
- `pnpm exec biome check packages/adapters/src/mcp-oauth.ts packages/adapters/src/mcp-oauth.test.ts`
- `git diff --check`
