### PR TITLE
fix(adapters): redact nested secrets before auto-review

### DIFF
--- a/packages/adapters/src/auto-review.test.ts
+++ b/packages/adapters/src/auto-review.test.ts
@@ -122,6 +122,29 @@ describe("redactToolArgsForReview", () => {
       body: "[redacted] hello",
     });
   });
+
+  it("redacts sensitive keys recursively before sending args to the checker", () => {
+    expect(
+      redactToolArgsForReview(
+        {
+          credential: "top-level-credential",
+          config: {
+            label: "keep me",
+            password: "nested-password",
+            accounts: [{ token: "nested-token", name: "primary" }],
+          },
+        },
+        [],
+      ),
+    ).toEqual({
+      credential: "[redacted]",
+      config: {
+        label: "keep me",
+        password: "[redacted]",
+        accounts: [{ token: "[redacted]", name: "primary" }],
+      },
+    });
+  });
 });
 
 describe("buildAutoReviewPrompt", () => {

--- a/packages/adapters/src/auto-review.test.ts
+++ b/packages/adapters/src/auto-review.test.ts
@@ -145,6 +145,25 @@ describe("redactToolArgsForReview", () => {
       },
     });
   });
+
+  it("redacts known secrets used as property names", () => {
+    expect(
+      redactToolArgsForReview(
+        {
+          "sk-live-123": "keep the top-level value",
+          metadata: {
+            "key-live-456": "keep the nested value",
+          },
+        },
+        ["sk-live-123", "key-live-456"],
+      ),
+    ).toEqual({
+      "[redacted]": "keep the top-level value",
+      metadata: {
+        "[redacted]": "keep the nested value",
+      },
+    });
+  });
 });
 
 describe("buildAutoReviewPrompt", () => {

--- a/packages/adapters/src/auto-review.ts
+++ b/packages/adapters/src/auto-review.ts
@@ -9,6 +9,8 @@ const MAX_TASK_CHARS = 400;
 const MAX_BOT_CHARS = 240;
 const MAX_ARGS_CHARS = 1_200;
 const MAX_REASON_CHARS = 160;
+const SENSITIVE_REVIEW_ARG_KEY =
+  /password|secret|token|api[_-]?key|authorization|cookie|credential/i;
 
 export type AutoReviewChecker = {
   provider: string;
@@ -96,7 +98,7 @@ export function redactToolArgsForReview(
 ): Record<string, unknown> {
   const redacted: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(args)) {
-    if (/password|secret|token|api[_-]?key|authorization|cookie/i.test(key)) {
+    if (SENSITIVE_REVIEW_ARG_KEY.test(key)) {
       redacted[key] = "[redacted]";
       continue;
     }
@@ -109,7 +111,14 @@ export function redactToolArgsForReview(
       continue;
     }
     try {
-      redacted[key] = JSON.parse(redactSecrets(JSON.stringify(value), secrets));
+      redacted[key] = JSON.parse(
+        JSON.stringify(value, (nestedKey, nestedValue) => {
+          if (nestedKey && SENSITIVE_REVIEW_ARG_KEY.test(nestedKey)) return "[redacted]";
+          return typeof nestedValue === "string"
+            ? redactSecrets(nestedValue, secrets)
+            : nestedValue;
+        }),
+      );
     } catch {
       redacted[key] = "[unserializable]";
     }

--- a/packages/adapters/src/auto-review.ts
+++ b/packages/adapters/src/auto-review.ts
@@ -98,32 +98,46 @@ export function redactToolArgsForReview(
 ): Record<string, unknown> {
   const redacted: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(args)) {
+    const redactedKey = redactSecrets(key, secrets);
     if (SENSITIVE_REVIEW_ARG_KEY.test(key)) {
-      redacted[key] = "[redacted]";
+      redacted[redactedKey] = "[redacted]";
       continue;
     }
     if (typeof value === "string") {
-      redacted[key] = redactSecrets(value, secrets);
+      redacted[redactedKey] = redactSecrets(value, secrets);
       continue;
     }
     if (value == null || typeof value === "number" || typeof value === "boolean") {
-      redacted[key] = value;
+      redacted[redactedKey] = value;
       continue;
     }
     try {
-      redacted[key] = JSON.parse(
-        JSON.stringify(value, (nestedKey, nestedValue) => {
-          if (nestedKey && SENSITIVE_REVIEW_ARG_KEY.test(nestedKey)) return "[redacted]";
-          return typeof nestedValue === "string"
-            ? redactSecrets(nestedValue, secrets)
-            : nestedValue;
-        }),
-      );
+      const serialized = JSON.stringify(value);
+      redacted[redactedKey] =
+        serialized === undefined
+          ? "[unserializable]"
+          : redactNestedReviewValue(JSON.parse(serialized), secrets);
     } catch {
-      redacted[key] = "[unserializable]";
+      redacted[redactedKey] = "[unserializable]";
     }
   }
   return redacted;
+}
+
+function redactNestedReviewValue(value: unknown, secrets: string[]): unknown {
+  if (typeof value === "string") return redactSecrets(value, secrets);
+  if (Array.isArray(value)) {
+    return value.map((item) => redactNestedReviewValue(item, secrets));
+  }
+  if (value == null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [
+      redactSecrets(key, secrets),
+      SENSITIVE_REVIEW_ARG_KEY.test(key)
+        ? "[redacted]"
+        : redactNestedReviewValue(nestedValue, secrets),
+    ]),
+  );
 }
 
 function truncate(value: string, max: number): string {


### PR DESCRIPTION
## Why

Auto-review sends tool arguments to a separate checker model. Sensitive top-level argument names were redacted, but nested objects and arrays were only serialized and checked against already-known secret values. A connector argument such as \`config.password\` or \`accounts[].token\` could therefore reach the checker unchanged.

## What

- apply sensitive-key redaction recursively while serializing nested arguments
- cover \`credential\` fields in the sensitive-key policy
- retain existing exact-secret redaction for string values
- preserve non-sensitive nested context used by the checker

## Test

- \`pnpm exec vitest run packages/adapters/src/auto-review.test.ts\` (13 passed)
- \`pnpm --filter @rakazo/adapters test\` (1087 passed, 7 skipped)
- \`pnpm --filter @rakazo/adapters check\`
- \`pnpm exec biome check packages/adapters/src/auto-review.ts packages/adapters/src/auto-review.test.ts\`
- \`git diff upstream/main --check\`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic redaction of sensitive tool arguments during reviews.
  - Sensitive keys, including credential-related fields, are now consistently masked within nested objects and arrays.
  - Known secret values are also redacted when used as property names, while non-sensitive information remains available for review.
  - Unserializable values are handled safely during review.

- **Tests**
  - Added coverage for recursive redaction across nested objects and arrays, including sensitive keys and secret values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->