### PR TITLE
fix(core): harden production secret environment checks

### DIFF
--- a/packages/core/src/secrets-guard.test.ts
+++ b/packages/core/src/secrets-guard.test.ts
@@ -73,6 +73,36 @@ describe("secrets-guard", () => {
     ).toThrow(/SCREEN_PROXY_SECRET/);
   });
 
+  it("rejects blank and whitespace-padded placeholder secrets in production", () => {
+    expect(() => resolveAuthSecret({ NODE_ENV: "production", BETTER_AUTH_SECRET: "   " })).toThrow(
+      /BETTER_AUTH_SECRET/,
+    );
+    expect(() => resolveEncryptionKey({ NODE_ENV: "production", ENCRYPTION_KEY: "\t" })).toThrow(
+      /ENCRYPTION_KEY/,
+    );
+    expect(() =>
+      resolveAuthSecret({
+        NODE_ENV: "production",
+        BETTER_AUTH_SECRET: ` ${DEV_AUTH_SECRET_PLACEHOLDER}\n`,
+      }),
+    ).toThrow(/BETTER_AUTH_SECRET/);
+    expect(() =>
+      resolveEncryptionKey({
+        NODE_ENV: "production",
+        ENCRYPTION_KEY: `${DEV_ENCRYPTION_KEY_PLACEHOLDER} `,
+      }),
+    ).toThrow(/ENCRYPTION_KEY/);
+  });
+
+  it("does not treat disabled Vitest flags as a test environment", () => {
+    expect(() => resolveAuthSecret({ NODE_ENV: "production", VITEST: "0" })).toThrow(
+      /BETTER_AUTH_SECRET/,
+    );
+    expect(() => resolveEncryptionKey({ NODE_ENV: "production", VITEST: "false" })).toThrow(
+      /ENCRYPTION_KEY/,
+    );
+  });
+
   it("accepts real dedicated credentials in production", () => {
     expect(
       resolveSupervisorToken({

--- a/packages/core/src/secrets-guard.ts
+++ b/packages/core/src/secrets-guard.ts
@@ -19,18 +19,19 @@ const DEDICATED_SECRET_PLACEHOLDERS = new Set([
 
 export function isDevSecretAllowed(env: NodeJS.ProcessEnv = process.env): boolean {
   if (env.RAKAZO_ALLOW_DEV_SECRETS === "1") return true;
-  if (env.VITEST) return true;
+  if (env.VITEST === "true" || env.VITEST === "1") return true;
   const nodeEnv = env.NODE_ENV;
   return nodeEnv === "development" || nodeEnv === "test";
 }
 
 export function resolveAuthSecret(env: NodeJS.ProcessEnv = process.env): string {
   const value = env.BETTER_AUTH_SECRET;
-  if (!value) {
+  if (value === undefined || !value.trim()) {
     if (isDevSecretAllowed(env)) return DEV_AUTH_SECRET_PLACEHOLDER;
     throw new Error(RUNTIME_SECRETS_ERROR);
   }
-  if (!isDevSecretAllowed(env) && value === DEV_AUTH_SECRET_PLACEHOLDER) {
+  const normalized = value.trim();
+  if (!isDevSecretAllowed(env) && normalized === DEV_AUTH_SECRET_PLACEHOLDER) {
     throw new Error(RUNTIME_SECRETS_ERROR);
   }
   return value;
@@ -38,11 +39,12 @@ export function resolveAuthSecret(env: NodeJS.ProcessEnv = process.env): string 
 
 export function resolveEncryptionKey(env: NodeJS.ProcessEnv = process.env): string {
   const value = env.ENCRYPTION_KEY;
-  if (!value) {
+  if (value === undefined || !value.trim()) {
     if (isDevSecretAllowed(env)) return DEV_ENCRYPTION_KEY_PLACEHOLDER;
     throw new Error(RUNTIME_SECRETS_ERROR);
   }
-  if (!isDevSecretAllowed(env) && value === DEV_ENCRYPTION_KEY_PLACEHOLDER) {
+  const normalized = value.trim();
+  if (!isDevSecretAllowed(env) && normalized === DEV_ENCRYPTION_KEY_PLACEHOLDER) {
     throw new Error(RUNTIME_SECRETS_ERROR);
   }
   return value;


### PR DESCRIPTION
## Why

Production secret validation checked the raw environment strings. Whitespace-only values were treated as configured, and adding whitespace around a known development placeholder bypassed the placeholder check. Any non-empty \`VITEST\` value, including \`0\` or \`false\`, also enabled development-secret fallbacks.

## What

- reject whitespace-only auth and encryption secrets
- compare trimmed values when detecting known development placeholders
- recognize only explicit \`VITEST=true\` or \`VITEST=1\` test flags
- preserve the original value of valid non-placeholder secrets, including existing short encryption keys supported during upgrades

## Test

- \`pnpm exec vitest run packages/core/src/secrets-guard.test.ts\` (12 passed)
- \`pnpm --filter @rakazo/core test\` (378 passed)
- \`pnpm --filter @rakazo/core check\`
- \`pnpm exec biome check packages/core/src/secrets-guard.ts packages/core/src/secrets-guard.test.ts\`
- \`git diff upstream/main --check\`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production secret validation to reject placeholder values even when surrounded by whitespace.
  * Corrected test-environment detection so only explicitly enabled test flags permit development secrets.
  * Preserved configured secret values as provided after validation, avoiding unintended changes to valid credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->