### PR TITLE
fix(adapters): enforce MCP result limit in UTF-8 bytes

### DIFF
--- a/packages/adapters/src/remote-mcp.test.ts
+++ b/packages/adapters/src/remote-mcp.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { assertSafeRemoteUrl, createSafeLookup, createSafeRemoteFetch } from "./remote-mcp.js";
+import {
+  assertSafeRemoteUrl,
+  createSafeLookup,
+  createSafeRemoteFetch,
+  limitRemoteMcpPayload,
+} from "./remote-mcp.js";
 
 const publicResolver = async () => [{ address: "203.0.113.10", family: 4 as const }];
 
@@ -121,5 +126,16 @@ describe("remote MCP URL policy", () => {
     } finally {
       await safeFetch.close();
     }
+  });
+});
+
+describe("remote MCP result limits", () => {
+  it("applies the result budget in UTF-8 bytes instead of JavaScript characters", () => {
+    const value = { content: "界".repeat(400_000) };
+    const limited = limitRemoteMcpPayload(value) as { truncated: boolean; content: string };
+
+    expect(limited.truncated).toBe(true);
+    expect(Buffer.byteLength(limited.content, "utf8")).toBeLessThanOrEqual(1_000_000);
+    expect(limited.content).not.toContain("\uFFFD");
   });
 });

--- a/packages/adapters/src/remote-mcp.ts
+++ b/packages/adapters/src/remote-mcp.ts
@@ -74,7 +74,7 @@ export async function callRemoteMcpTool(
       signal,
       timeout: MCP_TIMEOUT_MS,
     });
-    return limitPayload({
+    return limitRemoteMcpPayload({
       content: result.content,
       structuredContent: result.structuredContent,
       isError: result.isError ?? false,
@@ -208,11 +208,26 @@ function assertPublicAddresses(addresses: ResolvedAddress[], hostname?: string):
   }
 }
 
-function limitPayload(value: unknown): unknown {
+export function limitRemoteMcpPayload(value: unknown): unknown {
   const serialized = JSON.stringify(value);
-  if (serialized.length <= MAX_RESULT_BYTES) return value;
+  if (serialized === undefined) return value;
+  const bytes = Buffer.from(serialized, "utf8");
+  if (bytes.byteLength <= MAX_RESULT_BYTES) return value;
   return {
     truncated: true,
-    content: serialized.slice(0, MAX_RESULT_BYTES),
+    content: decodeUtf8Prefix(bytes, MAX_RESULT_BYTES),
   };
+}
+
+function decodeUtf8Prefix(bytes: Uint8Array, maxBytes: number): string {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let end = Math.min(bytes.byteLength, maxBytes);
+  while (end > 0) {
+    try {
+      return decoder.decode(bytes.subarray(0, end));
+    } catch {
+      end -= 1;
+    }
+  }
+  return "";
 }


### PR DESCRIPTION
## Why

Remote MCP tool results are capped at one million bytes before they enter the agent context. The limiter compared JavaScript string length instead, so a result containing multi-byte UTF-8 text could exceed the intended byte budget by several times without being truncated.

## What

- measure the serialized result in UTF-8 bytes
- truncate oversized results at a valid UTF-8 boundary
- avoid emitting a replacement character when the byte boundary splits a multi-byte character
- keep results that fit the byte budget unchanged

## Test

- \`pnpm exec vitest run packages/adapters/src/remote-mcp.test.ts\` (17 passed)
- \`pnpm --filter @rakazo/adapters test\` (1087 passed, 7 skipped)
- \`pnpm --filter @rakazo/adapters check\`
- \`pnpm exec biome check packages/adapters/src/remote-mcp.ts packages/adapters/src/remote-mcp.test.ts\`
- \`git diff upstream/main --check\`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large remote tool-call results by enforcing limits based on UTF-8 byte size.
  * Prevented truncated text from containing invalid replacement characters.
  * Preserved values that cannot be serialized to JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->