### PR TITLE
fix(adapters): redact JSON-escaped connector secrets

### DIFF
--- a/packages/adapters/src/connector-safety.test.ts
+++ b/packages/adapters/src/connector-safety.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { redactConnectorPayload } from "./connector-safety.js";
+
+describe("redactConnectorPayload", () => {
+  it("redacts secrets that JSON escapes in property names and values", () => {
+    const secret = 'api"key';
+
+    expect(
+      redactConnectorPayload(
+        {
+          [secret]: `prefix ${secret} suffix`,
+          nested: { value: secret },
+        },
+        [secret],
+      ),
+    ).toEqual({
+      "[redacted]": "prefix [redacted] suffix",
+      nested: { value: "[redacted]" },
+    });
+  });
+
+  it("falls back to an inert result when the payload is not JSON serializable", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(redactConnectorPayload(circular, ["secret"])).toEqual({ ok: true });
+  });
+});

--- a/packages/adapters/src/connector-safety.ts
+++ b/packages/adapters/src/connector-safety.ts
@@ -17,8 +17,20 @@ export function sanitizeConnectorError(error: unknown, secrets: string[] = []): 
 export function redactConnectorPayload(value: unknown, secrets: string[]): unknown {
   if (secrets.length === 0) return value;
   try {
-    return JSON.parse(redactSecrets(JSON.stringify(value), secrets));
+    return redactPayloadValue(JSON.parse(JSON.stringify(value)), secrets);
   } catch {
     return { ok: true };
   }
+}
+
+function redactPayloadValue(value: unknown, secrets: string[]): unknown {
+  if (typeof value === "string") return redactSecrets(value, secrets);
+  if (Array.isArray(value)) return value.map((item) => redactPayloadValue(item, secrets));
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      redactSecrets(key, secrets),
+      redactPayloadValue(item, secrets),
+    ]),
+  );
 }


### PR DESCRIPTION
## Summary

- normalize connector results into JSON-safe values before redaction
- redact configured secrets structurally in both property names and string values
- retain the existing inert fallback for non-serializable payloads

## Why

The previous implementation redacted the serialized JSON text. JSON escaping changes secrets that contain characters such as quotes, so exact secret matching could miss them and return the credential to the model. Redacting after JSON normalization closes that gap without changing ordinary connector results.

## Tests

- added regression coverage for an escaped secret in keys, top-level values, and nested values
- added coverage for the existing circular-payload fallback
- adapters: 1089 passed, 7 skipped
- TypeScript check and Biome check pass