### PR TITLE
fix(adapters): honor explicit Vitest environment values

### DIFF
--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -449,4 +449,10 @@ describe("Composio during pnpm test", () => {
     expect(process.env.VITEST).toBeTruthy();
     expect(isComposioEnabled("ck_must_not_call_live")).toBe(false);
   });
+
+  it.each(["0", "false"])("does not treat VITEST=%s as an active test runner", (value) => {
+    vi.stubEnv("VITEST", value);
+    expect(isComposioEnabled("ck_configured")).toBe(true);
+    vi.unstubAllEnvs();
+  });
 });

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -15,11 +15,12 @@ import {
   type ToolkitDirectoryEntry,
 } from "./composio-catalog-cache.js";
 import { DestinationEmulator } from "./destination-emulator.js";
+import { isVitestRuntime } from "./test-runtime.js";
 
 type ComposioSession = Awaited<ReturnType<Composio["create"]>>;
 
 export function isComposioEnabled(apiKey: string | undefined): boolean {
-  return Boolean(apiKey) && !process.env.VITEST;
+  return Boolean(apiKey) && !isVitestRuntime();
 }
 
 export function asConnectorTools(input: unknown): ConnectorTool[] {

--- a/packages/adapters/src/messaging-platforms.test.ts
+++ b/packages/adapters/src/messaging-platforms.test.ts
@@ -155,6 +155,12 @@ describe("isMessagingEnabled", () => {
     expect(process.env.VITEST).toBeTruthy();
     expect(isMessagingEnabled(messagingPlatformsFromEnv(fullEnv))).toBe(false);
   });
+
+  it.each(["0", "false"])("does not treat VITEST=%s as an active test runner", (value) => {
+    vi.stubEnv("VITEST", value);
+    expect(isMessagingEnabled(messagingPlatformsFromEnv(fullEnv))).toBe(true);
+    vi.unstubAllEnvs();
+  });
 });
 
 describe("isMessagingSurfaceEnabled", () => {

--- a/packages/adapters/src/messaging-platforms.ts
+++ b/packages/adapters/src/messaging-platforms.ts
@@ -5,6 +5,7 @@ import type { MessagingOutboundStatus } from "@rakazo/adapter-kit";
 import type { Adapter } from "chat";
 import { createSendblueAdapter } from "chat-adapter-sendblue";
 import type { MessagingPlatform } from "./chat-sdk-surface.js";
+import { isVitestRuntime } from "./test-runtime.js";
 
 /**
  * Parsed platform credentials, filled from process.env at the composition
@@ -137,7 +138,7 @@ export function messagingPlatformsFromEnv(env: MessagingEnvironmentValues): Mess
 
 /** Never live under the test runner; tests build surfaces explicitly. */
 export function isMessagingEnabled(platforms: MessagingPlatform[]): boolean {
-  return platforms.length > 0 && !process.env.VITEST;
+  return platforms.length > 0 && !isVitestRuntime();
 }
 
 /**

--- a/packages/adapters/src/pipedream-connector.test.ts
+++ b/packages/adapters/src/pipedream-connector.test.ts
@@ -1,6 +1,10 @@
 import type { AdapterContext } from "@rakazo/adapter-kit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { PipedreamConnector, pipedreamConfigFromEnv } from "./pipedream-connector.js";
+import {
+  isPipedreamEnabled,
+  PipedreamConnector,
+  pipedreamConfigFromEnv,
+} from "./pipedream-connector.js";
 import { ThirdPartyConnectorEmulator } from "./third-party-connector-emulator.js";
 
 const context: AdapterContext = {
@@ -28,6 +32,20 @@ describe("pipedreamConfigFromEnv", () => {
       environment: "development",
       identitySecret: "identity-secret",
     });
+  });
+
+  it.each(["0", "false"])("does not treat VITEST=%s as an active test runner", (value) => {
+    vi.stubEnv("VITEST", value);
+    expect(
+      isPipedreamEnabled({
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        projectId: "project-id",
+        environment: "production",
+        identitySecret: "identity-secret",
+      }),
+    ).toBe(true);
+    vi.unstubAllEnvs();
   });
 });
 

--- a/packages/adapters/src/pipedream-connector.ts
+++ b/packages/adapters/src/pipedream-connector.ts
@@ -18,6 +18,7 @@ import {
   listRemoteMcpTools,
   type RemoteTransportDependencies,
 } from "./remote-mcp.js";
+import { isVitestRuntime } from "./test-runtime.js";
 
 const API_BASE = "https://api.pipedream.com";
 const MCP_ENDPOINT = "https://remote.mcp.pipedream.net/v3";
@@ -75,7 +76,7 @@ export function isPipedreamEnabled(config: Partial<PipedreamConnectorConfig>): b
       config.projectId &&
       config.environment &&
       config.identitySecret &&
-      !process.env.VITEST,
+      !isVitestRuntime(),
   );
 }
 

--- a/packages/adapters/src/test-runtime.ts
+++ b/packages/adapters/src/test-runtime.ts
@@ -1,0 +1,4 @@
+/** Vitest sets VITEST=true; false-like deployment values must not disable live adapters. */
+export function isVitestRuntime(value: string | undefined = process.env.VITEST): boolean {
+  return value === "true" || value === "1";
+}


### PR DESCRIPTION
## Summary

- recognize only VITEST=true and VITEST=1 as an active Vitest runtime
- share the predicate across Composio, Pipedream, and messaging enablement gates
- cover false-like deployment values for all three adapter paths

## Why

The existing Boolean check treats any non-empty value as test mode. Deployments that explicitly set VITEST=false or VITEST=0 therefore silently disable configured live integrations. This matches the explicit-value semantics already used by the core runtime guard.

## Tests

- added regression cases for VITEST=false and VITEST=0 across all affected gates
- adapters: 1093 passed, 7 skipped
- TypeScript check and Biome check pass