### PR TITLE
fix(adapters): preserve UTF-8 at API response limits

### DIFF
--- a/packages/adapters/src/installed-connectors.test.ts
+++ b/packages/adapters/src/installed-connectors.test.ts
@@ -214,6 +214,63 @@ describe("OpenAPI connector import", () => {
     expect(queue.assertDrained).not.toThrow();
   });
 
+  it("does not emit a replacement character when a response limit splits UTF-8", async () => {
+    const install = {
+      id: "api-utf8",
+      kind: "api",
+      source: "https://93.184.216.34",
+      secretId: null,
+      createdAt: new Date(0),
+      config: {
+        auth: { type: "none" },
+        operations: [
+          {
+            id: "read_text",
+            method: "GET",
+            path: "/text",
+            inputSchema: { type: "object" },
+            readOnly: true,
+          },
+        ],
+      },
+    };
+    const prisma = {
+      capabilityInstall: {
+        findMany: vi.fn().mockResolvedValue([install]),
+        findFirst: vi.fn().mockResolvedValue(install),
+      },
+    };
+    const prefix = "a".repeat(999_999);
+    const fetch = vi.fn().mockResolvedValue(new Response(`${prefix}€`));
+    const provider = new InstalledConnectorProvider(prisma as never, {} as never, { fetch });
+    const context = {
+      spaceId: "space-1",
+      userId: "user-1",
+      signal: new AbortController().signal,
+    } as never;
+    const [tool] = await provider.discoverTools(context);
+    const events = [];
+
+    for await (const event of provider.execute(
+      { tool: tool!.name, args: {}, executionId: "utf8", route: tool!.route },
+      context,
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(1);
+    const event = events[0] as {
+      type: string;
+      data: { status: number; data: string; truncated: boolean };
+    };
+    expect(event.type).toBe("result");
+    expect(event.data.status).toBe(200);
+    expect(event.data.truncated).toBe(true);
+    expect(event.data.data).toHaveLength(prefix.length);
+    expect(event.data.data.endsWith("a")).toBe(true);
+    expect(event.data.data.includes("\uFFFD")).toBe(false);
+  });
+
   it("keeps colliding OpenAPI operation names unique across installs", async () => {
     const installs = ["install-A", "install-B"].map((id, index) => ({
       id,

--- a/packages/adapters/src/installed-connectors.ts
+++ b/packages/adapters/src/installed-connectors.ts
@@ -633,7 +633,9 @@ async function readBoundedText(
     if (value.byteLength > remaining) {
       if (remaining > 0) text += decoder.decode(value.subarray(0, remaining), { stream: true });
       await reader.cancel().catch(() => undefined);
-      return { text: text + decoder.decode(), truncated: true };
+      // Do not flush an incomplete sequence at the byte boundary: TextDecoder
+      // would turn it into U+FFFD instead of returning the valid UTF-8 prefix.
+      return { text, truncated: true };
     }
     bytes += value.byteLength;
     text += decoder.decode(value, { stream: true });


### PR DESCRIPTION
## Summary

- avoid flushing an incomplete TextDecoder sequence when the API response byte cap is reached
- return the valid UTF-8 prefix while preserving the existing truncated marker
- add an end-to-end installed API regression at the one-megabyte boundary

## Why

When the byte limit split a multibyte character, flushing the streaming decoder emitted U+FFFD into the connector result. A bounded response should preserve valid text and omit only the incomplete trailing character introduced by truncation.

## Tests

- added coverage for a three-byte character split after byte 999999
- adapters: 1088 passed, 7 skipped
- TypeScript check and Biome check pass