### PR TITLE
fix(adapters): redact non-string connector secret leaves

### DIFF
--- a/packages/adapters/src/connector-safety.test.ts
+++ b/packages/adapters/src/connector-safety.test.ts
@@ -25,4 +25,10 @@ describe("redactConnectorPayload", () => {
 
     expect(redactConnectorPayload(circular, ["secret"])).toEqual({ ok: true });
   });
+
+  it("redacts secrets represented by non-string JSON leaves", () => {
+    expect(
+      redactConnectorPayload({ number: 123, boolean: true, empty: null }, ["123", "true", "null"]),
+    ).toEqual({ number: "[redacted]", boolean: "[redacted]", empty: "[redacted]" });
+  });
 });

--- a/packages/adapters/src/connector-safety.ts
+++ b/packages/adapters/src/connector-safety.ts
@@ -26,7 +26,11 @@ export function redactConnectorPayload(value: unknown, secrets: string[]): unkno
 function redactPayloadValue(value: unknown, secrets: string[]): unknown {
   if (typeof value === "string") return redactSecrets(value, secrets);
   if (Array.isArray(value)) return value.map((item) => redactPayloadValue(item, secrets));
-  if (!value || typeof value !== "object") return value;
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    const serialized = String(value);
+    return redactSecrets(serialized, secrets) === serialized ? value : "[redacted]";
+  }
+  if (typeof value !== "object") return value;
   return Object.fromEntries(
     Object.entries(value).map(([key, item]) => [
       redactSecrets(key, secrets),


### PR DESCRIPTION
## Summary

- redact numeric, boolean, and null connector result leaves when their serialized form contains a configured secret
- preserve non-string primitives when no secret matches
- add focused regression coverage for each JSON primitive case

## Why

This is the follow-up to the Greptile finding on #626. That PR was merged just before the review fix was pushed, so main still handled only string leaves after structural normalization. A numeric-only credential such as 123 could therefore remain visible when a connector returned it as a JSON number.

## Tests

- connector safety: 3 passed
- adapters: 1099 passed, 7 skipped
- TypeScript check and Biome check pass