### PR TITLE
fix(desktop): keep app alive while the hidden session probe window is torn down

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -166,7 +166,6 @@ function defaultSessionProfileExists() {
 
 /** Page storage in the default session means a pre-partition install for this origin. */
 async function defaultSessionHasOriginData(origin: string): Promise<boolean> {
-  liveProbeWindows++;
   const probe = new BrowserWindow({
     show: false,
     width: 1,
@@ -177,6 +176,9 @@ async function defaultSessionHasOriginData(origin: string): Promise<boolean> {
       sandbox: true,
     },
   });
+  // Increment only after construction succeeds so a throw cannot leave the
+  // counter stuck > 0 and permanently block quit on Windows/Linux.
+  liveProbeWindows++;
   try {
     await probe.loadURL(origin);
     return (await probe.webContents.executeJavaScript(`(async () => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -61,6 +61,10 @@ let openAppPromise: Promise<boolean> | null = null;
 let pendingPreviousWindow: BrowserWindow | null = null;
 let quitting = false;
 let warmWindowTimer: NodeJS.Timeout | undefined;
+// Number of short-lived hidden probe windows currently alive. On Windows/Linux,
+// destroying the last window fires "window-all-closed" -> app.quit(); a probe
+// that runs before the first real window exists must not count as "all closed".
+let liveProbeWindows = 0;
 const WARM_WINDOW_TTL_MS = warmWindowTtlMs(process.env.RAKAZO_WARM_WINDOW_TTL_MS);
 
 const updaterEnvironment = {
@@ -162,6 +166,7 @@ function defaultSessionProfileExists() {
 
 /** Page storage in the default session means a pre-partition install for this origin. */
 async function defaultSessionHasOriginData(origin: string): Promise<boolean> {
+  liveProbeWindows++;
   const probe = new BrowserWindow({
     show: false,
     width: 1,
@@ -194,6 +199,7 @@ async function defaultSessionHasOriginData(origin: string): Promise<boolean> {
     return false;
   } finally {
     if (!probe.isDestroyed()) probe.destroy();
+    liveProbeWindows--;
   }
 }
 
@@ -749,10 +755,13 @@ async function openAppOnce(targetUrl: string) {
     return true;
   } catch (error) {
     pendingPreviousWindow = null;
-    if (win !== null && !win.isDestroyed()) win.destroy();
     // Keep the previous app window so Cancel / close can restore it.
     if (previous !== null && !previous.isDestroyed()) mainWindow = previous;
+    // Show the setup window BEFORE destroying the failed one: on Windows/Linux,
+    // destroying the last window fires "window-all-closed" -> app.quit() before
+    // showSetupWindow() runs, so the app silently exits instead of showing this error.
     showSetupWindow(`Could not open that server. ${openFailureDetail(error)}`);
+    if (win !== null && !win.isDestroyed()) win.destroy();
     return false;
   }
 }
@@ -1091,6 +1100,9 @@ app.whenReady().then(async () => {
 });
 
 app.on("window-all-closed", () => {
+  // A hidden session probe (defaultSessionHasOriginData) can be the only window
+  // during startup; its teardown must not quit the app.
+  if (liveProbeWindows > 0) return;
   if (process.platform !== "darwin") app.quit();
 });
 


### PR DESCRIPTION
## Problem

On **Windows and Linux**, the desktop app exits silently about 1 second after launch whenever a saved server is configured (`setup.json` present, or `RAKAZO_WEB_URL` set). Exit code 0, no window, nothing logged. Removing `setup.json` makes the setup window appear, which made this look like a config problem — it is not.

Reproduced on Windows 11 with the 0.1.0 and 0.1.1 desktop builds against a healthy v0.1.1 server (`/rpc/health` OK, all assets 200). Not GPU related (`--disable-gpu`, `--use-gl=swiftshader` behave the same).

## Root cause

`resolveSessionForTarget()` calls `defaultSessionHasOriginData()`, which creates a hidden 1×1 `BrowserWindow` to check the default session for legacy storage, loads the server origin, and then `destroy()`s it. At that moment it is the **only window in the process**, so `window-all-closed` fires and `app.quit()` runs before the real app window is ever created.

Captured by wrapping `BrowserWindow.destroy` with a stack trace:

```
window DESTROY id=1 visible=false url=http://127.0.0.1:5175/
    at defaultSessionHasOriginData (main.js:165)
    at resolveSessionForTarget      (main.js:109)
    at openAppOnce                  (main.js:689)
window-all-closed: quitting (allWindows=0)
```

macOS is unaffected because the app does not quit on `window-all-closed` there, which is likely why this went unnoticed.

## Fix

- Track live probe windows (`liveProbeWindows`) around the probe in `defaultSessionHasOriginData()` and return early from the `window-all-closed` handler while one exists.
- In `openAppOnce()`'s failure path, call `showSetupWindow()` **before** `win.destroy()`. This is the same class of bug: when the app window failed to load, the last window was destroyed before the setup window existed, so the error message was never shown and the app just quit.

13 insertions, 1 deletion, `apps/desktop/src/main.ts` only.

## Verification

- Dev run (`electron .`) with a real profile and saved `setup.json`: window stays up.
- Packaged NSIS build installed and launched from the Start Menu shortcut, unelevated: alive after 30 s with the app window shown.
- `pnpm --filter @rakazo/desktop check` and `biome check` clean.
- `pnpm --filter @rakazo/desktop test`: 183 passed, 1 failed — `docker-cli.test.ts › checks the macOS install locations before PATH`. That failure is pre-existing on pristine `v0.1.1` when the suite is run on Windows (path separator expectation) and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HckUdc7Cn375k1Qribsxxu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the desktop app from quitting prematurely while checking session data during startup.
  * Ensured the setup window is restored correctly when opening the app fails, avoiding unexpected shutdowns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->