### PR TITLE
fix(core): detect JSON-escaped secrets structurally

### DIFF
--- a/packages/core/src/events.test.ts
+++ b/packages/core/src/events.test.ts
@@ -3,6 +3,7 @@ import {
   appendTextSegment,
   appendToolCallSegment,
   appendToolStep,
+  containsSecret,
   createStreamingRedactor,
   endsSentence,
   humanizeToolName,
@@ -15,6 +16,17 @@ import {
   trackToolCallStreak,
   trackToolNameStreak,
 } from "./events.js";
+
+describe("containsSecret", () => {
+  it("detects secrets that JSON escaping changes", () => {
+    expect(containsSecret({ 'api"key': { nested: 'api"key' } }, ['api"key'])).toBe(true);
+    expect(containsSecret({ nested: ["line\nbreak"] }, ["line\nbreak"])).toBe(true);
+  });
+
+  it("does not confuse escaped text with the original control character", () => {
+    expect(containsSecret({ value: "literal\\ntext" }, ["\n"])).toBe(false);
+  });
+});
 
 describe("isRunTerminalEvent", () => {
   it("recognizes every terminal run outcome", () => {

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -324,8 +324,34 @@ export function redactSecrets(value: string, secrets: string[]): string {
 }
 
 export function containsSecret(value: unknown, secrets: string[]): boolean {
-  const text = JSON.stringify(value);
-  return secrets.some((secret) => secret.length > 0 && text.includes(secret));
+  const active = secrets.filter((secret) => secret.length > 0);
+  if (active.length === 0) return false;
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) return false;
+  const pending: unknown[] = [JSON.parse(serialized)];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (typeof current === "string") {
+      if (active.some((secret) => current.includes(secret))) return true;
+      continue;
+    }
+    if (current === null || typeof current === "number" || typeof current === "boolean") {
+      const primitive = String(current);
+      if (active.some((secret) => primitive.includes(secret))) return true;
+      continue;
+    }
+    if (Array.isArray(current)) {
+      pending.push(...current);
+      continue;
+    }
+    if (current && typeof current === "object") {
+      for (const [key, nested] of Object.entries(current)) {
+        if (active.some((secret) => key.includes(secret))) return true;
+        pending.push(nested);
+      }
+    }
+  }
+  return false;
 }
 
 /** UTF-16 high surrogates (0xD800–0xDBFF) must be paired with a low surrogate for valid JSON. */


### PR DESCRIPTION
## Summary

- normalize JSON-safe values before checking for known secrets
- inspect property names, string values, arrays, objects, and primitive leaves iteratively
- avoid escaped-text false positives while detecting quotes and control characters accurately

## Why

containsSecret checked raw JSON.stringify output against the unescaped secret. Credentials containing quotes, newlines, or other JSON-escaped characters could therefore evade connector configuration validation and the post-run leak guard. Structural inspection compares the original normalized values instead.

## Tests

- added quote and newline regression cases in keys and nested values
- added a negative case distinguishing a literal backslash-n from a newline
- core: 380 passed
- TypeScript check and Biome check pass