### PR TITLE
fix(adapters): harden local private file storage

### DIFF
--- a/packages/adapters/src/artifacts.test.ts
+++ b/packages/adapters/src/artifacts.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { LocalArtifactStore } from "./artifacts.js";
+
+const dirs: string[] = [];
+const context = { spaceId: "space-1" } as never;
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("LocalArtifactStore", () => {
+  it("creates artifact files with owner-only permissions", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rakazo-artifacts-"));
+    dirs.push(root);
+    const store = new LocalArtifactStore(root);
+
+    const stored = await store.put(
+      { name: "private.txt", mimeType: "text/plain", bytes: new TextEncoder().encode("private") },
+      context,
+    );
+
+    const info = await stat(path.join(root, "artifacts", "space-1", stored.id));
+    expect(info.mode & 0o777).toBe(0o600);
+  });
+
+  it("does not follow a replacement symlink when reading an artifact", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "rakazo-artifacts-"));
+    dirs.push(root);
+    const store = new LocalArtifactStore(root);
+    const stored = await store.put(
+      { name: "private.txt", mimeType: "text/plain", bytes: new TextEncoder().encode("private") },
+      context,
+    );
+    const file = path.join(root, "artifacts", "space-1", stored.id);
+    const target = path.join(root, "outside.txt");
+    await writeFile(target, "outside");
+    await rm(file);
+    await symlink(target, file);
+
+    await expect(store.get(stored.id, context)).rejects.toThrow();
+  });
+});

--- a/packages/adapters/src/artifacts.ts
+++ b/packages/adapters/src/artifacts.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { mkdir, open, rm } from "node:fs/promises";
 import path from "node:path";
 import type {
   AdapterContext,
@@ -8,6 +9,8 @@ import type {
   NotificationMessage,
   NotificationProvider,
 } from "@rakazo/adapter-kit";
+
+const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
 
 export class LocalArtifactStore implements ArtifactStore {
   constructor(private readonly root: string) {}
@@ -26,17 +29,32 @@ export class LocalArtifactStore implements ArtifactStore {
     const dir = path.join(this.root, "artifacts", context.spaceId);
     await mkdir(dir, { recursive: true });
     const file = path.join(dir, id);
-    await writeFile(file, artifact.bytes);
+    const handle = await open(
+      file,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | O_NOFOLLOW,
+      0o600,
+    );
+    try {
+      await handle.writeFile(artifact.bytes);
+    } finally {
+      await handle.close();
+    }
     return { id, hash: String(artifact.bytes.byteLength) };
   }
 
   async get(id: string, context: AdapterContext) {
-    const { readFile } = await import("node:fs/promises");
-    return new Uint8Array(await readFile(path.join(this.root, "artifacts", context.spaceId, id)));
+    const handle = await open(
+      path.join(this.root, "artifacts", context.spaceId, id),
+      constants.O_RDONLY | O_NOFOLLOW,
+    );
+    try {
+      return new Uint8Array(await handle.readFile());
+    } finally {
+      await handle.close();
+    }
   }
 
   async remove(id: string, context: AdapterContext) {
-    const { rm } = await import("node:fs/promises");
     await rm(path.join(this.root, "artifacts", context.spaceId, id), { force: true });
   }
 }

--- a/packages/adapters/src/expo-push.test.ts
+++ b/packages/adapters/src/expo-push.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -53,6 +53,34 @@ describe("expo push tickets", () => {
 });
 
 describe("expo push", () => {
+  it("keeps refreshed push tokens owner-only", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-push-"));
+    dirs.push(dataDir);
+    const tokenFile = path.join(dataDir, "push-tokens", "user-1.txt");
+    await savePushToken(dataDir, "user-1", "ExponentPushToken[old]");
+    await chmod(tokenFile, 0o644);
+
+    await savePushToken(dataDir, "user-1", "ExponentPushToken[new]");
+
+    expect((await stat(tokenFile)).mode & 0o777).toBe(0o600);
+  });
+
+  it("does not follow a token-file symlink for reads or writes", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-push-"));
+    dirs.push(dataDir);
+    const tokenDir = path.join(dataDir, "push-tokens");
+    const tokenFile = path.join(tokenDir, "user-1.txt");
+    const target = path.join(dataDir, "outside.txt");
+    await savePushToken(dataDir, "user-1", "ExponentPushToken[old]");
+    await writeFile(target, "not-a-push-token");
+    await rm(tokenFile);
+    await symlink(target, tokenFile);
+
+    await expect(loadPushToken(dataDir, "user-1")).resolves.toBeUndefined();
+    await expect(savePushToken(dataDir, "user-1", "ExponentPushToken[new]")).rejects.toThrow();
+    await expect(readFile(target, "utf8")).resolves.toBe("not-a-push-token");
+  });
+
   it("removes a registered token", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-push-"));
     dirs.push(dataDir);

--- a/packages/adapters/src/expo-push.ts
+++ b/packages/adapters/src/expo-push.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { mkdir, open, unlink } from "node:fs/promises";
 import path from "node:path";
 import type {
   AdapterContext,
@@ -7,22 +8,40 @@ import type {
 } from "@rakazo/adapter-kit";
 import { getLogger } from "@rakazo/logging";
 
+const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
+
 export function pushTokenPath(dataDir: string, userId: string) {
   return path.join(dataDir, "push-tokens", `${userId}.txt`);
 }
 
 export async function loadPushToken(dataDir: string, userId: string): Promise<string | undefined> {
   try {
-    const token = (await readFile(pushTokenPath(dataDir, userId), "utf8")).trim();
-    return token || undefined;
+    const handle = await open(pushTokenPath(dataDir, userId), constants.O_RDONLY | O_NOFOLLOW);
+    try {
+      const token = (await handle.readFile("utf8")).trim();
+      return token || undefined;
+    } finally {
+      await handle.close();
+    }
   } catch {
     return undefined;
   }
 }
 
 export async function savePushToken(dataDir: string, userId: string, token: string): Promise<void> {
-  await mkdir(path.dirname(pushTokenPath(dataDir, userId)), { recursive: true });
-  await writeFile(pushTokenPath(dataDir, userId), token.trim(), "utf8");
+  const file = pushTokenPath(dataDir, userId);
+  await mkdir(path.dirname(file), { recursive: true });
+  const handle = await open(
+    file,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    await handle.chmod(0o600);
+    await handle.writeFile(token.trim(), "utf8");
+  } finally {
+    await handle.close();
+  }
 }
 
 export async function deletePushToken(dataDir: string, userId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- create local artifact files with owner-only 0600 permissions and exclusive, no-follow opens
- read artifact and Expo push-token files without following a replacement symlink
- restore 0600 permissions whenever an existing push token is refreshed

## Why

Local artifacts can contain user documents, and Expo token files are credentials. They were created with the default 0666 mode, normally becoming 0644, and ordinary reads/writes followed symbolic links. This made private data unnecessarily readable to other local users and let a replaced leaf path redirect file access.

## Tests

- added artifact mode and replacement-symlink regression coverage
- added push-token refresh mode plus no-follow read/write coverage
- adapters: 1102 passed, 7 skipped
- TypeScript check and Biome check pass