### PR TITLE
fix(adapters): require HTTPS Pipedream connect links

### DIFF
--- a/packages/adapters/src/pipedream-connector.test.ts
+++ b/packages/adapters/src/pipedream-connector.test.ts
@@ -52,6 +52,36 @@ describe("pipedreamConfigFromEnv", () => {
 describe("PipedreamConnector", () => {
   afterEach(() => vi.unstubAllGlobals());
 
+  it.each([
+    "javascript:alert(document.domain)",
+    "http://pipedream.example.test/connect",
+    "https://user:password@pipedream.example.test/connect",
+  ])("rejects an unsafe provider connect URL: %s", async (connectUrl) => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ access_token: "fake-access-token", expires_in: 3_600 }),
+      )
+      .mockResolvedValueOnce(Response.json({ connect_link_url: connectUrl }));
+    const connector = new PipedreamConnector(
+      {
+        clientId: "fake-client-id",
+        clientSecret: "fake-client-secret",
+        projectId: "fake-project-id",
+        environment: "development",
+        identitySecret: "fake-identity-secret",
+      },
+      { fetch },
+    );
+
+    await expect(
+      connector.begin(
+        { provider: "gmail", redirectUrl: "https://rakazo.example.test/app" },
+        context,
+      ),
+    ).rejects.toThrow("secure HTTPS connect URL");
+  });
+
   it("uses one opaque external identity across the app catalog and account flow", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal(
@@ -143,7 +173,10 @@ describe("PipedreamConnector", () => {
         { provider: "linear", redirectUrl: "https://rakazo.example.test/app" },
         context,
       ),
-    ).resolves.toEqual({ authorizationUrl: "about:blank?app=linear", state: "linear" });
+    ).resolves.toEqual({
+      authorizationUrl: "https://pipedream.example.test/connect?app=linear",
+      state: "linear",
+    });
     await expect(connector.connectionReady(context, "linear")).resolves.toBe(true);
 
     const connectedContext = {

--- a/packages/adapters/src/pipedream-connector.ts
+++ b/packages/adapters/src/pipedream-connector.ts
@@ -80,6 +80,19 @@ export function isPipedreamEnabled(config: Partial<PipedreamConnectorConfig>): b
   );
 }
 
+function securePipedreamConnectUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Pipedream did not return a secure HTTPS connect URL");
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new Error("Pipedream did not return a secure HTTPS connect URL");
+  }
+  return url;
+}
+
 export class PipedreamConnector implements ManagedConnectorProvider {
   private accessToken?: { value: string; expiresAt: number };
   private accessTokenRequest?: Promise<string>;
@@ -206,7 +219,7 @@ export class PipedreamConnector implements ManagedConnectorProvider {
       },
       context.signal,
     );
-    const url = new URL(response.connect_link_url);
+    const url = securePipedreamConnectUrl(response.connect_link_url);
     url.searchParams.set("app", request.provider);
     return { authorizationUrl: url.toString(), state: request.provider };
   }

--- a/packages/adapters/src/third-party-connector-emulator.ts
+++ b/packages/adapters/src/third-party-connector-emulator.ts
@@ -45,7 +45,7 @@ export class ThirdPartyConnectorEmulator {
       const externalUserId = String(body.external_user_id ?? "");
       this.pendingUsers.add(externalUserId);
       this.records.push({ provider: "pipedream", operation: "begin" });
-      return Response.json({ connect_link_url: "about:blank" });
+      return Response.json({ connect_link_url: "https://pipedream.example.test/connect" });
     }
     if (url.pathname.endsWith("/accounts") && method === "GET") {
       const externalUserId = url.searchParams.get("external_user_id") ?? "";

--- a/packages/testkit/src/connections.test.ts
+++ b/packages/testkit/src/connections.test.ts
@@ -230,7 +230,7 @@ describeWithDatabase("Composio catalog reconciliation", () => {
       "connections/begin",
       { connectorId: "pipedream", provider: "linear", displayName: "Linear" },
     );
-    expect(started.authorizationUrl).toBe("about:blank?app=linear");
+    expect(started.authorizationUrl).toBe("https://pipedream.example.test/connect?app=linear");
     await expect(
       rpc<{ status: string }>(app, cookie, "connections/complete", {
         connectionId: started.connectionId,


### PR DESCRIPTION
## Summary

- validate Pipedream connect links before returning them to the web client
- require HTTPS and reject URLs with embedded username/password credentials
- keep the protocol emulator on the same secure-link contract

## Why

The provider response was passed through new URL and then opened by the frontend. That accepted javascript URLs, cleartext HTTP, and credential-bearing URLs. A connect flow should only hand the browser a secure HTTPS destination.

## Tests

- added rejection coverage for javascript, HTTP, and embedded-credential links
- retained successful begin-flow coverage with an HTTPS link
- adapters: 1101 passed, 7 skipped
- TypeScript check and Biome check pass