### PR TITLE
fix(adapters): bound Supermemory recall responses

### DIFF
--- a/packages/adapters/src/supermemory-client.test.ts
+++ b/packages/adapters/src/supermemory-client.test.ts
@@ -3,6 +3,7 @@ import {
   deleteSupermemoryContainer,
   MAX_MEMORY_CONTENT_CHARS,
   MAX_RECALLED_MEMORIES,
+  MAX_SUPERMEMORY_RESPONSE_BYTES,
   probeSupermemory,
   saveSupermemoryMemory,
   saveSupermemoryMemoryToContainers,
@@ -92,6 +93,57 @@ describe("searchSupermemory", () => {
     const result = await searchSupermemory("anything", "rakazo:bot-123", config);
 
     expect(result).toEqual({ ok: true, results: [{ memory: "kept", similarity: 0 }] });
+    vi.unstubAllGlobals();
+  });
+
+  it("bounds each recalled memory to the provider content limit", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ results: [{ memory: `kept${"x".repeat(20_000)}` }] })),
+        ),
+    );
+
+    const result = await searchSupermemory("anything", "rakazo:bot-123", config);
+
+    expect(result.ok && result.results[0]?.memory).toHaveLength(MAX_MEMORY_CONTENT_CHARS);
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects an oversized search response before buffering it", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({
+          "content-length": String(MAX_SUPERMEMORY_RESPONSE_BYTES + 1),
+        }),
+        body: { cancel },
+      }),
+    );
+
+    const result = await searchSupermemory("anything", "rakazo:bot-123", config);
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining("response is too large"),
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+    vi.unstubAllGlobals();
+  });
+
+  it("caps a chunked search response without a content length", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(new Uint8Array(MAX_SUPERMEMORY_RESPONSE_BYTES + 1))),
+    );
+
+    const result = await searchSupermemory("anything", "rakazo:bot-123", config);
+
+    expect(result).toEqual({ ok: false, error: "Supermemory response is too large." });
     vi.unstubAllGlobals();
   });
 });

--- a/packages/adapters/src/supermemory-client.ts
+++ b/packages/adapters/src/supermemory-client.ts
@@ -1,4 +1,9 @@
+import { readBodyCapped } from "./web-ssrf.js";
+
 const SUPERMEMORY_TIMEOUT_MS = 15_000;
+
+/** Search responses contain at most five bounded memories plus small metadata. */
+export const MAX_SUPERMEMORY_RESPONSE_BYTES = 1024 * 1024;
 
 /** How many recalled memories a search asks for, and the most that are ever injected into a run. */
 export const MAX_RECALLED_MEMORIES = 5;
@@ -56,7 +61,7 @@ function parseSearchResults(data: unknown): SupermemoryResult[] {
     };
     const text =
       typeof row.memory === "string" ? row.memory : typeof row.chunk === "string" ? row.chunk : "";
-    const memory = text.trim();
+    const memory = text.trim().slice(0, MAX_MEMORY_CONTENT_CHARS);
     if (!memory) continue;
     parsed.push({
       memory,
@@ -75,6 +80,7 @@ export async function searchSupermemory(
   signal?: AbortSignal,
 ): Promise<SupermemorySearchResponse> {
   try {
+    const requestAbort = requestSignal(signal);
     const response = await fetch(`${config.baseUrl}/v4/search`, {
       method: "POST",
       headers: authHeaders(config),
@@ -85,15 +91,39 @@ export async function searchSupermemory(
         limit: boundedRecallLimit(limit),
       }),
       redirect: "error",
-      signal: requestSignal(signal),
+      signal: requestAbort,
     });
     if (!response.ok) {
       return { ok: false, error: `Supermemory search failed: ${response.status}` };
     }
-    return { ok: true, results: parseSearchResults(await response.json()) };
+    return {
+      ok: true,
+      results: parseSearchResults(await readSupermemoryJson(response, requestAbort)),
+    };
   } catch (error) {
+    if (error instanceof Error && error.message === "Supermemory response is too large.") {
+      return { ok: false, error: error.message };
+    }
     return { ok: false, error: unreachableError(error) };
   }
+}
+
+async function readSupermemoryJson(response: Response, signal?: AbortSignal): Promise<unknown> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > MAX_SUPERMEMORY_RESPONSE_BYTES) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error("Supermemory response is too large.");
+  }
+  let bytes: Uint8Array;
+  try {
+    bytes = await readBodyCapped(response, MAX_SUPERMEMORY_RESPONSE_BYTES, signal);
+  } catch (error) {
+    if (error instanceof Error && error.message === "Response is too large") {
+      throw new Error("Supermemory response is too large.");
+    }
+    throw error;
+  }
+  return JSON.parse(new TextDecoder().decode(bytes));
 }
 
 export async function searchSupermemoryContainers(


### PR DESCRIPTION
## Why

A configured Supermemory service could return an unbounded search body or an oversized memory string. That response was parsed whole and recalled text could then flow into an agent run beyond the same content limit enforced when saving memories.

## What changed

- cap Supermemory search responses at 1 MiB for both declared and streamed bodies
- cancel oversized responses before further reading
- share the request deadline with the body read
- bound every recalled memory to the existing 10,000-character memory limit
- return a specific size error instead of classifying it as an unreachable service

## Tests

- focused Supermemory tests: 18 passed
- full adapters suite: 1105 passed, 7 skipped
- adapters TypeScript check passed
- Biome check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent oversized Supermemory search responses from being processed.
  * Limited recalled memory content to 10,000 characters.
  * Improved cancellation when responses exceed the allowed size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->