### PR TITLE
fix(adapters): cap hosted voice responses

### DIFF
--- a/packages/adapters/src/cartesia-voice.ts
+++ b/packages/adapters/src/cartesia-voice.ts
@@ -59,7 +59,7 @@ export class CartesiaVoiceProvider implements VoiceProvider {
       headers: cartesiaHeaders(apiKey),
       signal: voiceDeadline(context.signal, 20_000),
     });
-    const body = await readVoiceJson(res);
+    const body = await readVoiceJson(res, { requireValid: res.ok });
     if (!res.ok) throw new Error(voiceHttpError(res.status, "Cartesia", "listing voices", body));
     const voices = voicesFrom(body);
     return voices

--- a/packages/adapters/src/cartesia-voice.ts
+++ b/packages/adapters/src/cartesia-voice.ts
@@ -8,7 +8,13 @@ import type {
   VoiceSynthesizeRequest,
   VoiceVerifyResult,
 } from "@rakazo/adapter-kit";
-import { readVoiceJson, requireOk, voiceDeadline, voiceHttpError } from "./voice-http.js";
+import {
+  readVoiceAudio,
+  readVoiceJson,
+  requireOk,
+  voiceDeadline,
+  voiceHttpError,
+} from "./voice-http.js";
 
 const API = "https://api.cartesia.ai";
 const VERSION = "2024-06-10";
@@ -66,6 +72,7 @@ export class CartesiaVoiceProvider implements VoiceProvider {
   }
 
   async synthesize(request: VoiceSynthesizeRequest, context: AdapterContext): Promise<SpeechClip> {
+    const signal = voiceDeadline(request.signal ?? context.signal, 60_000);
     const res = await fetch(`${API}/tts/bytes`, {
       method: "POST",
       headers: {
@@ -78,10 +85,10 @@ export class CartesiaVoiceProvider implements VoiceProvider {
         voice: { mode: "id", id: request.voiceId },
         output_format: { container: "mp3", encoding: "mp3", sample_rate: 44100 },
       }),
-      signal: voiceDeadline(request.signal ?? context.signal, 60_000),
+      signal,
     });
     await requireOk(res, "Cartesia", "speaking");
-    return { bytes: new Uint8Array(await res.arrayBuffer()), mimeType: "audio/mpeg" };
+    return { bytes: await readVoiceAudio(res, signal), mimeType: "audio/mpeg" };
   }
 }
 

--- a/packages/adapters/src/elevenlabs-voice.ts
+++ b/packages/adapters/src/elevenlabs-voice.ts
@@ -10,6 +10,7 @@ import type {
   VoiceVerifyResult,
 } from "@rakazo/adapter-kit";
 import {
+  readVoiceAudio,
   readVoiceJson,
   requireOk,
   speechUploadName,
@@ -77,6 +78,7 @@ export class ElevenLabsVoiceProvider implements VoiceProvider {
   }
 
   async synthesize(request: VoiceSynthesizeRequest, context: AdapterContext): Promise<SpeechClip> {
+    const signal = voiceDeadline(request.signal ?? context.signal, 60_000);
     const res = await fetch(
       `${API}/text-to-speech/${encodeURIComponent(request.voiceId)}?output_format=${FORMAT}`,
       {
@@ -87,11 +89,11 @@ export class ElevenLabsVoiceProvider implements VoiceProvider {
           accept: "audio/mpeg",
         },
         body: JSON.stringify({ text: request.text, model_id: MODEL }),
-        signal: voiceDeadline(request.signal ?? context.signal, 60_000),
+        signal,
       },
     );
     await requireOk(res, "ElevenLabs", "speaking");
-    return { bytes: new Uint8Array(await res.arrayBuffer()), mimeType: "audio/mpeg" };
+    return { bytes: await readVoiceAudio(res, signal), mimeType: "audio/mpeg" };
   }
 
   async transcribe(

--- a/packages/adapters/src/elevenlabs-voice.ts
+++ b/packages/adapters/src/elevenlabs-voice.ts
@@ -62,7 +62,7 @@ export class ElevenLabsVoiceProvider implements VoiceProvider {
       headers: { "xi-api-key": apiKey },
       signal: voiceDeadline(context.signal, 20_000),
     });
-    const body = await readVoiceJson(res);
+    const body = await readVoiceJson(res, { requireValid: res.ok });
     if (!res.ok) throw new Error(voiceHttpError(res.status, "ElevenLabs", "listing voices", body));
     const voices = (body as { voices?: Array<Record<string, unknown>> } | null)?.voices ?? [];
     return voices
@@ -113,7 +113,7 @@ export class ElevenLabsVoiceProvider implements VoiceProvider {
       body: form,
       signal: voiceDeadline(request.signal ?? context.signal, 60_000),
     });
-    const body = await readVoiceJson(res);
+    const body = await readVoiceJson(res, { requireValid: res.ok });
     if (!res.ok) throw new Error(voiceHttpError(res.status, "ElevenLabs", "transcribing", body));
     const text = String((body as { text?: unknown } | null)?.text ?? "").trim();
     return { text };

--- a/packages/adapters/src/openai-voice.ts
+++ b/packages/adapters/src/openai-voice.ts
@@ -111,7 +111,7 @@ export class OpenAIVoiceProvider implements VoiceProvider {
       body: form,
       signal: voiceDeadline(request.signal ?? context.signal, 60_000),
     });
-    const body = await readVoiceJson(res);
+    const body = await readVoiceJson(res, { requireValid: res.ok });
     if (!res.ok) throw new Error(voiceHttpError(res.status, "OpenAI", "transcribing", body));
     return { text: String((body as { text?: unknown } | null)?.text ?? "").trim() };
   }

--- a/packages/adapters/src/openai-voice.ts
+++ b/packages/adapters/src/openai-voice.ts
@@ -10,6 +10,7 @@ import type {
   VoiceVerifyResult,
 } from "@rakazo/adapter-kit";
 import {
+  readVoiceAudio,
   readVoiceJson,
   requireOk,
   speechUploadName,
@@ -74,6 +75,7 @@ export class OpenAIVoiceProvider implements VoiceProvider {
   }
 
   async synthesize(request: VoiceSynthesizeRequest, context: AdapterContext): Promise<SpeechClip> {
+    const signal = voiceDeadline(request.signal ?? context.signal, 60_000);
     const res = await fetch(`${API}/audio/speech`, {
       method: "POST",
       headers: {
@@ -86,10 +88,10 @@ export class OpenAIVoiceProvider implements VoiceProvider {
         input: request.text,
         response_format: "mp3",
       }),
-      signal: voiceDeadline(request.signal ?? context.signal, 60_000),
+      signal,
     });
     await requireOk(res, "OpenAI", "speaking");
-    return { bytes: new Uint8Array(await res.arrayBuffer()), mimeType: "audio/mpeg" };
+    return { bytes: await readVoiceAudio(res, signal), mimeType: "audio/mpeg" };
   }
 
   async transcribe(

--- a/packages/adapters/src/voice-factory.test.ts
+++ b/packages/adapters/src/voice-factory.test.ts
@@ -14,6 +14,7 @@ import {
   listVoiceCatalog,
   VOICE_CATALOG,
 } from "./voice-factory.js";
+import { MAX_SYNTHESIZED_AUDIO_BYTES } from "./voice-http.js";
 
 const ctx = {
   operationId: "voice",
@@ -89,10 +90,7 @@ describe("ElevenLabsVoiceProvider", () => {
   it("transcribes through Scribe", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ text: "hello there" }),
-      }),
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ text: "hello there" }))),
     );
     const provider = new ElevenLabsVoiceProvider();
     await expect(
@@ -126,10 +124,7 @@ describe("OpenAIVoiceProvider", () => {
   });
 
   it("names Firefox ogg recordings from the mime type", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ text: "hello" }),
-    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ text: "hello" })));
     vi.stubGlobal("fetch", fetchMock);
     await new OpenAIVoiceProvider().transcribe!(
       { audio: new Uint8Array([1]), mimeType: "audio/ogg;codecs=opus", apiKey: "sk-test" },
@@ -145,10 +140,11 @@ describe("CartesiaVoiceProvider", () => {
   it("maps the voices list from either array or { data } payloads", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ data: [{ id: "sonic", name: "Katie" }] }),
-      }),
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ data: [{ id: "sonic", name: "Katie" }] })),
+        ),
     );
     const provider = new CartesiaVoiceProvider();
     const voices = await provider.listVoices("sk-test", ctx);
@@ -168,6 +164,34 @@ describe("CartesiaVoiceProvider", () => {
     expect([...clip.bytes]).toEqual([4, 5]);
     expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/tts/bytes");
   });
+});
+
+describe("hosted voice response limits", () => {
+  it.each([
+    ["ElevenLabs", () => new ElevenLabsVoiceProvider(), "voice"],
+    ["OpenAI", () => new OpenAIVoiceProvider(), "alloy"],
+    ["Cartesia", () => new CartesiaVoiceProvider(), "sonic"],
+  ])(
+    "rejects an oversized %s speech response before buffering it",
+    async (_name, create, voiceId) => {
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          headers: new Headers({
+            "content-length": String(MAX_SYNTHESIZED_AUDIO_BYTES + 1),
+          }),
+          body: { cancel },
+        }),
+      );
+
+      await expect(
+        create().synthesize({ text: "Hi", voiceId, apiKey: "sk-test" }, ctx),
+      ).rejects.toThrow("Voice response is too large.");
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
 });
 
 describe("ScriptedVoiceProvider", () => {

--- a/packages/adapters/src/voice-http.test.ts
+++ b/packages/adapters/src/voice-http.test.ts
@@ -52,4 +52,14 @@ describe("readVoiceJson", () => {
     await expect(readVoiceJson(response)).rejects.toThrow("Voice response is too large.");
     expect(cancel).toHaveBeenCalledOnce();
   });
+
+  it("rejects malformed successful JSON when the caller requires a payload", async () => {
+    await expect(readVoiceJson(new Response("not json"), { requireValid: true })).rejects.toThrow(
+      "Voice provider returned invalid JSON.",
+    );
+  });
+
+  it("keeps malformed error bodies optional", async () => {
+    await expect(readVoiceJson(new Response("not json"))).resolves.toBeNull();
+  });
 });

--- a/packages/adapters/src/voice-http.test.ts
+++ b/packages/adapters/src/voice-http.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { speechUploadName, voiceDeadline } from "./voice-http.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  MAX_VOICE_JSON_BYTES,
+  readVoiceJson,
+  speechUploadName,
+  voiceDeadline,
+} from "./voice-http.js";
 
 describe("voiceDeadline", () => {
   it("aborts when the client signal aborts", () => {
@@ -34,5 +39,17 @@ describe("speechUploadName", () => {
 
   it("maps Firefox ogg capture to an ogg filename", () => {
     expect(speechUploadName("audio/ogg; codecs=opus")).toBe("speech.ogg");
+  });
+});
+
+describe("readVoiceJson", () => {
+  it("rejects an oversized provider response before buffering it", async () => {
+    const response = new Response("oversized", {
+      headers: { "content-length": String(MAX_VOICE_JSON_BYTES + 1) },
+    });
+    const cancel = vi.spyOn(response.body!, "cancel");
+
+    await expect(readVoiceJson(response)).rejects.toThrow("Voice response is too large.");
+    expect(cancel).toHaveBeenCalledOnce();
   });
 });

--- a/packages/adapters/src/voice-http.ts
+++ b/packages/adapters/src/voice-http.ts
@@ -43,17 +43,22 @@ export function speechUploadName(mimeType?: string): string {
   return "speech.webm";
 }
 
-export async function readVoiceJson(res: Response): Promise<unknown> {
+export async function readVoiceJson(
+  res: Response,
+  options: { requireValid?: boolean } = {},
+): Promise<unknown> {
   let bytes: Uint8Array;
   try {
     bytes = await readVoiceBytes(res, MAX_VOICE_JSON_BYTES);
   } catch (error) {
     if (error instanceof Error && error.message === "Voice response is too large.") throw error;
+    if (options.requireValid) throw new Error("Voice provider response could not be read.");
     return null;
   }
   try {
     return JSON.parse(new TextDecoder().decode(bytes));
   } catch {
+    if (options.requireValid) throw new Error("Voice provider returned invalid JSON.");
     return null;
   }
 }

--- a/packages/adapters/src/voice-http.ts
+++ b/packages/adapters/src/voice-http.ts
@@ -1,6 +1,36 @@
+import { readBodyCapped } from "./web-ssrf.js";
+
+/** A 2,000-character utterance should stay far below this, even at high MP3 bitrates. */
+export const MAX_SYNTHESIZED_AUDIO_BYTES = 16 * 1024 * 1024;
+export const MAX_VOICE_JSON_BYTES = 1024 * 1024;
+
 /** Client disconnect plus a hard deadline — `context.signal` is always set. */
 export function voiceDeadline(signal: AbortSignal, ms: number): AbortSignal {
   return AbortSignal.any([signal, AbortSignal.timeout(ms)]);
+}
+
+export async function readVoiceAudio(res: Response, signal?: AbortSignal): Promise<Uint8Array> {
+  return readVoiceBytes(res, MAX_SYNTHESIZED_AUDIO_BYTES, signal);
+}
+
+async function readVoiceBytes(
+  res: Response,
+  maxBytes: number,
+  signal?: AbortSignal,
+): Promise<Uint8Array> {
+  const declared = Number(res.headers?.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    await res.body?.cancel().catch(() => undefined);
+    throw new Error("Voice response is too large.");
+  }
+  try {
+    return await readBodyCapped(res, maxBytes, signal);
+  } catch (error) {
+    if (error instanceof Error && error.message === "Response is too large") {
+      throw new Error("Voice response is too large.");
+    }
+    throw error;
+  }
 }
 
 export function speechUploadName(mimeType?: string): string {
@@ -14,8 +44,15 @@ export function speechUploadName(mimeType?: string): string {
 }
 
 export async function readVoiceJson(res: Response): Promise<unknown> {
+  let bytes: Uint8Array;
   try {
-    return await res.json();
+    bytes = await readVoiceBytes(res, MAX_VOICE_JSON_BYTES);
+  } catch (error) {
+    if (error instanceof Error && error.message === "Voice response is too large.") throw error;
+    return null;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Why

Hosted voice endpoints were buffered without a size limit. A faulty upstream could make verification, transcription, voice listing, or speech synthesis consume unbounded memory, and synthesized body reads did not explicitly share the request deadline.

## What changed

- cap hosted voice JSON responses at 1 MiB
- cap synthesized MP3 responses at 16 MiB
- reject oversized declared and streamed bodies while cancelling the response
- carry the request deadline through each synthesized audio body read
- require valid JSON from successful metadata and transcription responses while retaining generic fallbacks for malformed error bodies
- apply the same behavior to OpenAI, ElevenLabs, and Cartesia

## Tests

- focused voice tests: 21 passed
- adapters TypeScript check passed
- Biome check passed
- full adapters run reached 1106 passed and 7 skipped; its only unrelated extra-display process timing failure passed on isolated rerun (8/8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice synthesis, transcription, and voice-list responses now enforce size limits to prevent oversized responses from affecting the application.
  * Oversized audio or JSON responses are rejected with a clear error, and response processing is cancelled promptly.
  * Voice providers now handle response data more consistently, including deadline cancellation while audio is being received and improved handling of invalid error responses.

* **Tests**
  * Added coverage for response-size limits, cancellation behavior, invalid responses, and oversized synthesis responses across hosted voice providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->