### PR TITLE
fix(adapters): bound Pipedream API responses

### DIFF
--- a/packages/adapters/src/pipedream-connector.test.ts
+++ b/packages/adapters/src/pipedream-connector.test.ts
@@ -2,6 +2,7 @@ import type { AdapterContext } from "@rakazo/adapter-kit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isPipedreamEnabled,
+  MAX_PIPEDREAM_RESPONSE_BYTES,
   PipedreamConnector,
   pipedreamConfigFromEnv,
 } from "./pipedream-connector.js";
@@ -80,6 +81,57 @@ describe("PipedreamConnector", () => {
         context,
       ),
     ).rejects.toThrow("secure HTTPS connect URL");
+  });
+
+  it("rejects an oversized token response before buffering it", async () => {
+    const response = new Response("oversized", {
+      headers: { "content-length": String(MAX_PIPEDREAM_RESPONSE_BYTES + 1) },
+    });
+    const cancel = vi.spyOn(response.body!, "cancel");
+    const connector = new PipedreamConnector(
+      {
+        clientId: "fake-client-id",
+        clientSecret: "fake-client-secret",
+        projectId: "fake-project-id",
+        environment: "development",
+        identitySecret: "fake-identity-secret",
+      },
+      { fetch: vi.fn().mockResolvedValue(response) },
+    );
+
+    await expect(
+      connector.begin(
+        { provider: "gmail", redirectUrl: "https://rakazo.example.test/app" },
+        context,
+      ),
+    ).rejects.toThrow("Pipedream response is too large.");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("caps a chunked API response without a content length", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ access_token: "fake-access-token", expires_in: 3_600 }),
+      )
+      .mockResolvedValueOnce(new Response(new Uint8Array(MAX_PIPEDREAM_RESPONSE_BYTES + 1)));
+    const connector = new PipedreamConnector(
+      {
+        clientId: "fake-client-id",
+        clientSecret: "fake-client-secret",
+        projectId: "fake-project-id",
+        environment: "development",
+        identitySecret: "fake-identity-secret",
+      },
+      { fetch },
+    );
+
+    await expect(
+      connector.begin(
+        { provider: "gmail", redirectUrl: "https://rakazo.example.test/app" },
+        context,
+      ),
+    ).rejects.toThrow("Pipedream response is too large.");
   });
 
   it("uses one opaque external identity across the app catalog and account flow", async () => {

--- a/packages/adapters/src/pipedream-connector.test.ts
+++ b/packages/adapters/src/pipedream-connector.test.ts
@@ -108,6 +108,53 @@ describe("PipedreamConnector", () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 
+  it("rejects oversized Content-Length without waiting on a hanging body cancel", async () => {
+    let cancelStarted = false;
+    const hangingBody = new ReadableStream<Uint8Array>({
+      start() {
+        // never enqueues or closes
+      },
+      cancel() {
+        cancelStarted = true;
+        return new Promise(() => {
+          // never settles
+        });
+      },
+    });
+    const abort = new AbortController();
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ access_token: "fake-access-token", expires_in: 3_600 }),
+      )
+      .mockImplementationOnce(async () => {
+        setTimeout(() => abort.abort(), 20);
+        return new Response(hangingBody, {
+          headers: { "content-length": String(MAX_PIPEDREAM_RESPONSE_BYTES + 1) },
+        });
+      });
+    const connector = new PipedreamConnector(
+      {
+        clientId: "fake-client-id",
+        clientSecret: "fake-client-secret",
+        projectId: "fake-project-id",
+        environment: "development",
+        identitySecret: "fake-identity-secret",
+      },
+      { fetch },
+    );
+
+    const started = Date.now();
+    await expect(
+      connector.begin(
+        { provider: "gmail", redirectUrl: "https://rakazo.example.test/app" },
+        { ...context, signal: abort.signal },
+      ),
+    ).rejects.toThrow("Pipedream response is too large.");
+    expect(cancelStarted).toBe(true);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
   it("caps a chunked API response without a content length", async () => {
     const fetch = vi
       .fn()

--- a/packages/adapters/src/pipedream-connector.test.ts
+++ b/packages/adapters/src/pipedream-connector.test.ts
@@ -134,6 +134,54 @@ describe("PipedreamConnector", () => {
     ).rejects.toThrow("Pipedream response is too large.");
   });
 
+  it("clears a rejected token before reading an oversized 401 response", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ access_token: "rejected-token", expires_in: 3_600 }))
+      .mockResolvedValueOnce(
+        new Response("oversized", {
+          status: 401,
+          headers: { "content-length": String(MAX_PIPEDREAM_RESPONSE_BYTES + 1) },
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({ access_token: "replacement-token", expires_in: 3_600 }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({ connect_link_url: "https://pipedream.example.test/connect" }),
+      );
+    const connector = new PipedreamConnector(
+      {
+        clientId: "fake-client-id",
+        clientSecret: "fake-client-secret",
+        projectId: "fake-project-id",
+        environment: "development",
+        identitySecret: "fake-identity-secret",
+      },
+      { fetch },
+    );
+
+    await expect(
+      connector.begin(
+        { provider: "gmail", redirectUrl: "https://rakazo.example.test/app" },
+        context,
+      ),
+    ).rejects.toThrow("Pipedream response is too large.");
+    await expect(
+      connector.begin(
+        { provider: "gmail", redirectUrl: "https://rakazo.example.test/app" },
+        context,
+      ),
+    ).resolves.toEqual({
+      authorizationUrl: "https://pipedream.example.test/connect?app=gmail",
+      state: "gmail",
+    });
+    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(fetch.mock.calls[3]?.[1]?.headers).toEqual(
+      expect.objectContaining({ authorization: "Bearer replacement-token" }),
+    );
+  });
+
   it("uses one opaque external identity across the app catalog and account flow", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     vi.stubGlobal(

--- a/packages/adapters/src/pipedream-connector.ts
+++ b/packages/adapters/src/pipedream-connector.ts
@@ -19,11 +19,13 @@ import {
   type RemoteTransportDependencies,
 } from "./remote-mcp.js";
 import { isVitestRuntime } from "./test-runtime.js";
+import { readBodyCapped } from "./web-ssrf.js";
 
 const API_BASE = "https://api.pipedream.com";
 const MCP_ENDPOINT = "https://remote.mcp.pipedream.net/v3";
 const DIRECTORY_TTL_MS = 10 * 60_000;
 const REQUEST_TIMEOUT_MS = 30_000;
+export const MAX_PIPEDREAM_RESPONSE_BYTES = 2 * 1024 * 1024;
 
 export interface PipedreamConnectorConfig {
   clientId: string;
@@ -326,6 +328,7 @@ export class PipedreamConnector implements ManagedConnectorProvider {
     signal?: AbortSignal,
   ): Promise<T> {
     const token = await this.token();
+    const requestAbort = combineSignals(signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS));
     const response = await (this.dependencies.fetch ?? globalThis.fetch)(`${API_BASE}${path}`, {
       ...init,
       headers: {
@@ -334,9 +337,9 @@ export class PipedreamConnector implements ManagedConnectorProvider {
         "x-pd-environment": this.config.environment,
         ...init.headers,
       },
-      signal: combineSignals(signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)),
+      signal: requestAbort,
     });
-    const body = await response.text();
+    const body = await readPipedreamBody(response, requestAbort);
     if (!response.ok) {
       if (response.status === 401) this.accessToken = undefined;
       throw new Error(
@@ -360,6 +363,7 @@ export class PipedreamConnector implements ManagedConnectorProvider {
   }
 
   private async fetchToken(): Promise<string> {
+    const requestAbort = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
     const response = await (this.dependencies.fetch ?? globalThis.fetch)(
       `${API_BASE}/v1/oauth/token`,
       {
@@ -371,10 +375,10 @@ export class PipedreamConnector implements ManagedConnectorProvider {
           client_secret: this.config.clientSecret,
           scope: "connect:*",
         }),
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        signal: requestAbort,
       },
     );
-    const body = (await response.json()) as {
+    const body = JSON.parse(await readPipedreamBody(response, requestAbort)) as {
       access_token?: string;
       expires_in?: number;
       error?: string;
@@ -387,5 +391,22 @@ export class PipedreamConnector implements ManagedConnectorProvider {
       expiresAt: Date.now() + (body.expires_in ?? 3_600) * 1_000,
     };
     return body.access_token;
+  }
+}
+
+async function readPipedreamBody(response: Response, signal: AbortSignal): Promise<string> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > MAX_PIPEDREAM_RESPONSE_BYTES) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error("Pipedream response is too large.");
+  }
+  try {
+    const bytes = await readBodyCapped(response, MAX_PIPEDREAM_RESPONSE_BYTES, signal);
+    return new TextDecoder().decode(bytes);
+  } catch (error) {
+    if (error instanceof Error && error.message === "Response is too large") {
+      throw new Error("Pipedream response is too large.");
+    }
+    throw error;
   }
 }

--- a/packages/adapters/src/pipedream-connector.ts
+++ b/packages/adapters/src/pipedream-connector.ts
@@ -19,7 +19,7 @@ import {
   type RemoteTransportDependencies,
 } from "./remote-mcp.js";
 import { isVitestRuntime } from "./test-runtime.js";
-import { readBodyCapped } from "./web-ssrf.js";
+import { readBodyCapped, withAbort } from "./web-ssrf.js";
 
 const API_BASE = "https://api.pipedream.com";
 const MCP_ENDPOINT = "https://remote.mcp.pipedream.net/v3";
@@ -397,7 +397,12 @@ export class PipedreamConnector implements ManagedConnectorProvider {
 async function readPipedreamBody(response: Response, signal: AbortSignal): Promise<string> {
   const declared = Number(response.headers.get("content-length") ?? 0);
   if (Number.isFinite(declared) && declared > MAX_PIPEDREAM_RESPONSE_BYTES) {
-    await response.body?.cancel().catch(() => undefined);
+    const cancel = response.body?.cancel() ?? Promise.resolve();
+    // A hanging cancel must not outlive the shared deadline.
+    await withAbort(
+      cancel.catch(() => undefined),
+      signal,
+    ).catch(() => undefined);
     throw new Error("Pipedream response is too large.");
   }
   try {

--- a/packages/adapters/src/pipedream-connector.ts
+++ b/packages/adapters/src/pipedream-connector.ts
@@ -339,9 +339,9 @@ export class PipedreamConnector implements ManagedConnectorProvider {
       },
       signal: requestAbort,
     });
+    if (response.status === 401) this.accessToken = undefined;
     const body = await readPipedreamBody(response, requestAbort);
     if (!response.ok) {
-      if (response.status === 401) this.accessToken = undefined;
       throw new Error(
         sanitizeConnectorError(`Pipedream returned HTTP ${response.status}: ${body}`, [token]),
       );


### PR DESCRIPTION
## Why

Pipedream API and OAuth token responses were buffered without a size limit. A faulty upstream could make connector catalog, account, authorization, revoke, or token operations consume unbounded memory even though the requests themselves had deadlines.

## What changed

- cap Pipedream API and token bodies at 2 MiB
- reject oversized declared bodies before buffering and cancel their streams
- enforce the same cap while consuming responses without Content-Length
- share each request deadline with its response-body read
- retain the existing sanitized provider error handling

## Tests

- focused Pipedream tests: 10 passed
- full adapters suite: 1103 passed, 7 skipped
- adapters TypeScript check passed
- Biome check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pipedream response bodies are now limited to 2 MiB to prevent oversized responses from affecting requests.
  * Oversized responses are rejected early, including responses delivered in chunks without a declared size.
  * Improved cancellation and timeout handling prevents requests from hanging during interrupted or oversized responses.
  * Failed authentication responses now properly clear invalid tokens, allowing subsequent requests to obtain a replacement token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->