### PR TITLE
fix(adapters): bound Anthropic OAuth responses

### DIFF
--- a/packages/adapters/src/pi-anthropic-oauth.test.ts
+++ b/packages/adapters/src/pi-anthropic-oauth.test.ts
@@ -1,6 +1,9 @@
 import type { AuthInteraction } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
-import { createManualAnthropicOAuthLogin } from "./pi-anthropic-oauth.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createManualAnthropicOAuthLogin,
+  MAX_ANTHROPIC_TOKEN_RESPONSE_BYTES,
+} from "./pi-anthropic-oauth.js";
 
 describe("manual Anthropic OAuth", () => {
   it("runs concurrent paste-back flows without binding a callback port", async () => {
@@ -50,10 +53,90 @@ describe("manual Anthropic OAuth", () => {
     ).rejects.toThrow(/state mismatch/i);
     expect(requested).toBe(false);
   });
+
+  it("rejects and cancels a declared oversized token response", async () => {
+    const response = new Response("oversized", {
+      headers: { "content-length": String(MAX_ANTHROPIC_TOKEN_RESPONSE_BYTES + 1) },
+    });
+    const cancel = vi.spyOn(response.body!, "cancel");
+    const login = createManualAnthropicOAuthLogin({
+      fetch: vi.fn().mockResolvedValue(response),
+      createVerifier: () => "expected-state",
+    });
+
+    await expect(login(interactionFor("code#expected-state"))).rejects.toThrow(
+      "Anthropic token exchange response is too large.",
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("does not wait past cancellation when an oversized body cancel hangs", async () => {
+    let cancelStarted = false;
+    const hangingBody = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelStarted = true;
+        return new Promise(() => undefined);
+      },
+    });
+    const abort = new AbortController();
+    const login = createManualAnthropicOAuthLogin({
+      fetch: vi.fn(async () => {
+        setTimeout(() => abort.abort(), 20);
+        return new Response(hangingBody, {
+          headers: { "content-length": String(MAX_ANTHROPIC_TOKEN_RESPONSE_BYTES + 1) },
+        });
+      }),
+      createVerifier: () => "expected-state",
+    });
+
+    const started = Date.now();
+    await expect(login(interactionFor("code#expected-state", abort.signal))).rejects.toThrow(
+      "Anthropic token exchange response is too large.",
+    );
+    expect(cancelStarted).toBe(true);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  it("caps a streamed token response without a content length", async () => {
+    const login = createManualAnthropicOAuthLogin({
+      fetch: vi
+        .fn()
+        .mockResolvedValue(new Response(new Uint8Array(MAX_ANTHROPIC_TOKEN_RESPONSE_BYTES + 1))),
+      createVerifier: () => "expected-state",
+    });
+
+    await expect(login(interactionFor("code#expected-state"))).rejects.toThrow(
+      "Anthropic token exchange response is too large.",
+    );
+  });
+
+  it("uses the request deadline while reading the token response", async () => {
+    const requestSignals: AbortSignal[] = [];
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("{"));
+        },
+      }),
+    );
+    const fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      requestSignals.push(init?.signal as AbortSignal);
+      return response;
+    });
+    const login = createManualAnthropicOAuthLogin({
+      fetch: fetch as typeof globalThis.fetch,
+      createVerifier: () => "expected-state",
+    });
+    const controller = new AbortController();
+    const result = login(interactionFor("code#expected-state", controller.signal));
+    controller.abort(new Error("login cancelled"));
+
+    await expect(result).rejects.toThrow("login cancelled");
+    expect(requestSignals[0]?.aborted).toBe(true);
+  });
 });
 
-function interactionFor(input: string): AuthInteraction {
-  const signal = new AbortController().signal;
+function interactionFor(input: string, signal = new AbortController().signal): AuthInteraction {
   return {
     signal,
     async prompt() {

--- a/packages/adapters/src/pi-anthropic-oauth.ts
+++ b/packages/adapters/src/pi-anthropic-oauth.ts
@@ -1,11 +1,13 @@
 import { createHash, randomBytes } from "node:crypto";
 import type { AuthInteraction, OAuthCredential } from "@earendil-works/pi-ai";
+import { readBodyCapped, withAbort } from "./web-ssrf.js";
 
 const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
 const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
 const REDIRECT_URI = "http://localhost:53692/callback";
 const SCOPES =
   "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+export const MAX_ANTHROPIC_TOKEN_RESPONSE_BYTES = 64 * 1024;
 
 // Public OAuth client identifier used by Claude Code. This is not a client secret.
 const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
@@ -52,6 +54,7 @@ export function createManualAnthropicOAuthLogin(options: ManualAnthropicOAuthOpt
       throw new Error("OAuth state mismatch.");
     }
 
+    const requestSignal = AbortSignal.any([signal, AbortSignal.timeout(30_000)]);
     const response = await request(TOKEN_URL, {
       method: "POST",
       headers: {
@@ -66,13 +69,13 @@ export function createManualAnthropicOAuthLogin(options: ManualAnthropicOAuthOpt
         redirect_uri: REDIRECT_URI,
         code_verifier: verifier,
       }),
-      signal: AbortSignal.any([signal, AbortSignal.timeout(30_000)]),
+      signal: requestSignal,
     });
     if (!response.ok) {
       throw new Error(`Anthropic token exchange failed (${response.status}). Start sign-in again.`);
     }
 
-    const body = (await response.json()) as unknown;
+    const body = await readTokenResponse(response, requestSignal);
     if (!body || typeof body !== "object") {
       throw new Error("Anthropic token exchange returned an invalid credential.");
     }
@@ -97,6 +100,27 @@ export function createManualAnthropicOAuthLogin(options: ManualAnthropicOAuthOpt
       expires: Date.now() + credential.expires_in * 1000 - 5 * 60 * 1000,
     };
   };
+}
+
+async function readTokenResponse(response: Response, signal: AbortSignal): Promise<unknown> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > MAX_ANTHROPIC_TOKEN_RESPONSE_BYTES) {
+    const cancel = response.body?.cancel() ?? Promise.resolve();
+    await withAbort(
+      cancel.catch(() => undefined),
+      signal,
+    ).catch(() => undefined);
+    throw new Error("Anthropic token exchange response is too large.");
+  }
+  try {
+    const bytes = await readBodyCapped(response, MAX_ANTHROPIC_TOKEN_RESPONSE_BYTES, signal);
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch (error) {
+    if (error instanceof Error && error.message === "Response is too large") {
+      throw new Error("Anthropic token exchange response is too large.");
+    }
+    throw error;
+  }
 }
 
 function parseAuthorizationInput(input: string): { code?: string; state?: string } {


### PR DESCRIPTION
## Why

The manual Anthropic OAuth exchange parsed a successful token response with unbounded `response.json()`. A compromised or malfunctioning endpoint could make the desktop process buffer an arbitrarily large body during sign-in.

## What

- cap successful token responses at 64 KiB using the shared streaming body reader
- reject both oversized `Content-Length` responses and oversized chunked responses
- reuse the OAuth request deadline while consuming the body
- bound body cancellation so a hanging `cancel()` cannot outlive the sign-in operation
- add deterministic regression coverage for declared, streamed, and stalled-cancellation cases

## Tests

- `pnpm exec vitest run packages/adapters/src/pi-anthropic-oauth.test.ts` (6 passed)
- `pnpm --filter @rakazo/adapters test` (1118 passed, 7 skipped)
- `pnpm --filter @rakazo/adapters exec tsc --noEmit`
- `pnpm exec biome check packages/adapters/src/pi-anthropic-oauth.ts packages/adapters/src/pi-anthropic-oauth.test.ts`

No UI changes; screenshots are not applicable.
