### PR TITLE
fix(desktop): harden private state reads

### DIFF
--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -112,6 +112,21 @@ describe("ensureStackEnv", () => {
     await expect(ensureStackEnv(dir, "POSTGRES_PASSWORD=\n", fakeHex)).resolves.toBe("kept");
     await expect(readFile(path.join(dir, STACK_ENV_FILE), "utf8")).resolves.toBe("sentinel\n");
   });
+
+  it.runIf(process.platform !== "win32")(
+    "replaces a symlinked .env without touching its target",
+    async () => {
+      const target = path.join(dir, "outside.env");
+      await writeFile(target, "sentinel\n", "utf8");
+      await symlink(target, path.join(dir, STACK_ENV_FILE));
+
+      await expect(ensureStackEnv(dir, "POSTGRES_PASSWORD=\n", fakeHex)).resolves.toBe("created");
+      await expect(readFile(path.join(dir, STACK_ENV_FILE), "utf8")).resolves.toBe(
+        `POSTGRES_PASSWORD=${"ab".repeat(16)}\n`,
+      );
+      await expect(readFile(target, "utf8")).resolves.toBe("sentinel\n");
+    },
+  );
 });
 
 describe("stack identity", () => {
@@ -136,6 +151,24 @@ describe("stack identity", () => {
     await writeFile(path.join(dir, STACK_TOKEN_FILE), "not-a-token\n", "utf8");
     await expect(ensureStackToken(dir, fakeHex)).resolves.toBe("ab".repeat(32));
   });
+
+  it("does not buffer an oversized stack token", async () => {
+    await writeFile(path.join(dir, STACK_TOKEN_FILE), "a".repeat(1025), "utf8");
+    await expect(readStackToken(dir)).resolves.toBeNull();
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not reuse a stack token through a final symlink",
+    async () => {
+      const target = path.join(dir, "outside-token");
+      await writeFile(target, `${"cd".repeat(32)}\n`, "utf8");
+      await symlink(target, path.join(dir, STACK_TOKEN_FILE));
+
+      await expect(readStackToken(dir)).resolves.toBeNull();
+      await expect(ensureStackToken(dir, fakeHex)).resolves.toBe("ab".repeat(32));
+      await expect(readFile(target, "utf8")).resolves.toBe(`${"cd".repeat(32)}\n`);
+    },
+  );
 });
 
 describe("reduceStackState", () => {

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readFile, stat } from "node:fs/promises";
+import { copyFile, lstat, mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import type { DesktopLocalStackState } from "@rakazo/contracts";
 import {
@@ -10,7 +10,7 @@ import {
   type RunDockerResult,
   resolveDockerBinary,
 } from "./docker-cli.js";
-import { writePrivateFile } from "./setup-store.js";
+import { readPrivateFile, writePrivateFile } from "./setup-store.js";
 
 export const STACK_DIR_NAME = "stack";
 export const STACK_COMPOSE_FILE = "docker-compose.images.yml";
@@ -28,6 +28,7 @@ const PULL_TIMEOUT_MS = 30 * 60_000;
 const UP_TIMEOUT_MS = (COMPOSE_WAIT_TIMEOUT_S + 60) * 1_000;
 const LOGS_TIMEOUT_MS = 15_000;
 const STOP_TIMEOUT_MS = 90_000;
+const MAX_STACK_TOKEN_BYTES = 1024;
 
 /** The compose project lives under the app's user data, next to the `.env` it generates. */
 export function stackDir(userDataDir: string): string {
@@ -99,23 +100,21 @@ export async function ensureStackEnv(
 ): Promise<"kept" | "created"> {
   const destination = path.join(dir, STACK_ENV_FILE);
   try {
-    await stat(destination);
-    return "kept";
+    const info = await lstat(destination);
+    if (!info.isSymbolicLink()) return "kept";
   } catch {
-    await writePrivateFile(destination, renderStackEnv(template, randomHex));
-    return "created";
+    // Missing files are created below.
   }
+  await writePrivateFile(destination, renderStackEnv(template, randomHex));
+  return "created";
 }
 
 const STACK_TOKEN = /^[a-f0-9]{64}$/;
 
 export async function readStackToken(dir: string): Promise<string | null> {
-  try {
-    const token = (await readFile(path.join(dir, STACK_TOKEN_FILE), "utf8")).trim();
-    return STACK_TOKEN.test(token) ? token : null;
-  } catch {
-    return null;
-  }
+  const raw = await readPrivateFile(path.join(dir, STACK_TOKEN_FILE), MAX_STACK_TOKEN_BYTES);
+  const token = raw?.trim() ?? "";
+  return STACK_TOKEN.test(token) ? token : null;
 }
 
 /** Creates an app-private identity without placing it in the user-editable Compose env file. */

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -92,7 +92,7 @@ export function renderStackEnv(template: string, randomHex: (bytes: number) => s
   return rendered.join("\n");
 }
 
-/** Never overwrites an existing `.env`: it holds the database password and auth secrets. */
+/** Keeps an existing regular `.env`, but replaces a final symlink instead of trusting its target. */
 export async function ensureStackEnv(
   dir: string,
   template: string,

--- a/apps/desktop/src/setup-store.test.ts
+++ b/apps/desktop/src/setup-store.test.ts
@@ -49,6 +49,21 @@ describe("setup store", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "does not load setup through a final symlink",
+    async () => {
+      const target = path.join(userData, "linked-setup.json");
+      await writeFile(
+        target,
+        JSON.stringify({ mode: "existing", serverUrl: "https://rakazo.example.com" }),
+        "utf8",
+      );
+      await symlink(target, setupFilePath(userData));
+
+      await expect(readSetup(userData)).resolves.toBeNull();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "replaces a final symlink instead of overwriting its target",
     async () => {
       const victim = path.join(userData, "victim.txt");
@@ -67,6 +82,11 @@ describe("setup store", () => {
 
   it("falls back to setup when the saved file is corrupt", async () => {
     await writeFile(setupFilePath(userData), "{ not json", "utf8");
+    await expect(readSetup(userData)).resolves.toBeNull();
+  });
+
+  it("does not buffer an oversized saved setup", async () => {
+    await writeFile(setupFilePath(userData), " ".repeat(64 * 1024 + 1), "utf8");
     await expect(readSetup(userData)).resolves.toBeNull();
   });
 });

--- a/apps/desktop/src/setup-store.ts
+++ b/apps/desktop/src/setup-store.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import type { DesktopSetup } from "@rakazo/contracts";
 import { parseStoredSetup, SETUP_FILE_NAME, serializeSetup } from "./setup-config.js";
+
+const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
+const O_NONBLOCK = constants.O_NONBLOCK ?? 0;
+const MAX_SETUP_BYTES = 64 * 1024;
 
 export function setupFilePath(userDataDir: string): string {
   return path.join(userDataDir, SETUP_FILE_NAME);
@@ -10,13 +15,34 @@ export function setupFilePath(userDataDir: string): string {
 
 /** Returns null when setup has not run yet, or when the saved file is unusable. */
 export async function readSetup(userDataDir: string): Promise<DesktopSetup | null> {
-  let raw: string;
+  const raw = await readPrivateFile(setupFilePath(userDataDir), MAX_SETUP_BYTES);
+  if (raw === null) return null;
+  return parseStoredSetup(raw);
+}
+
+/** Reads a bounded regular file without accepting a final symlink. */
+export async function readPrivateFile(file: string, maxBytes: number): Promise<string | null> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
   try {
-    raw = await readFile(setupFilePath(userDataDir), "utf8");
+    const before = await lstat(file);
+    if (!before.isFile() || before.isSymbolicLink()) return null;
+    handle = await open(file, constants.O_RDONLY | O_NOFOLLOW | O_NONBLOCK);
+    const after = await handle.stat();
+    if (!after.isFile() || before.dev !== after.dev || before.ino !== after.ino) return null;
+
+    const buffer = Buffer.alloc(maxBytes + 1);
+    let offset = 0;
+    while (offset < buffer.byteLength) {
+      const { bytesRead } = await handle.read(buffer, offset, buffer.byteLength - offset, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    return offset > maxBytes ? null : buffer.subarray(0, offset).toString("utf8");
   } catch {
     return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
   }
-  return parseStoredSetup(raw);
 }
 
 export async function writeSetup(userDataDir: string, setup: DesktopSetup): Promise<void> {


### PR DESCRIPTION
## Why

Desktop setup and managed-stack token reads used path-based `readFile()`, which followed a final symbolic link and could buffer an unbounded file. The managed stack also treated a symlinked private `.env` as an existing trusted file.

## What

- read private state through a bounded regular-file helper using `lstat`, `O_NOFOLLOW`, and post-open identity checks
- cap saved setup at 64 KiB and the stack token at 1 KiB
- reject symlinked setup and token files
- atomically replace a symlinked managed-stack `.env` without modifying its target
- add regression tests for symlinks and oversized private state

## Tests

- `pnpm exec vitest run apps/desktop/src/setup-store.test.ts apps/desktop/src/local-stack.test.ts` (53 passed)
- `pnpm --filter @rakazo/desktop test` (198 passed)
- `pnpm --filter @rakazo/desktop check`
- `pnpm exec biome check apps/desktop/src/setup-store.ts apps/desktop/src/setup-store.test.ts apps/desktop/src/local-stack.ts apps/desktop/src/local-stack.test.ts`

No UI changes; screenshots are not applicable.
