### PR TITLE
fix(adapters): bound Expo push responses

### DIFF
--- a/packages/adapters/src/expo-push.test.ts
+++ b/packages/adapters/src/expo-push.test.ts
@@ -7,6 +7,7 @@ import {
   ExpoPushProvider,
   expoPushErrorMessage,
   loadPushToken,
+  MAX_EXPO_PUSH_RESPONSE_BYTES,
   savePushToken,
 } from "./expo-push.js";
 
@@ -26,11 +27,7 @@ const notifyContext = {
 };
 
 function jsonResponse(body: unknown, status = 200) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => body,
-  };
+  return Response.json(body, { status });
 }
 
 describe("expo push tickets", () => {
@@ -153,6 +150,110 @@ describe("expo push", () => {
         notifyContext,
       ),
     ).rejects.toThrow("boom");
+  });
+
+  it("rejects and cancels a declared oversized response", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-push-"));
+    dirs.push(dataDir);
+    await savePushToken(dataDir, "user-1", "ExponentPushToken[test]");
+    const response = new Response("oversized", {
+      headers: { "content-length": String(MAX_EXPO_PUSH_RESPONSE_BYTES + 1) },
+    });
+    const cancel = vi.spyOn(response.body!, "cancel");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+
+    await expect(
+      new ExpoPushProvider(dataDir).send(
+        { kind: "completion", title: "done", body: "ok", botId: "b", threadId: "t" },
+        notifyContext,
+      ),
+    ).rejects.toThrow("Expo push response is too large.");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("does not wait past cancellation when an oversized body cancel hangs", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-push-"));
+    dirs.push(dataDir);
+    await savePushToken(dataDir, "user-1", "ExponentPushToken[test]");
+    let cancelStarted = false;
+    const hangingBody = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelStarted = true;
+        return new Promise(() => undefined);
+      },
+    });
+    const abort = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        setTimeout(() => abort.abort(), 20);
+        return new Response(hangingBody, {
+          headers: { "content-length": String(MAX_EXPO_PUSH_RESPONSE_BYTES + 1) },
+        });
+      }),
+    );
+
+    const started = Date.now();
+    await expect(
+      new ExpoPushProvider(dataDir).send(
+        { kind: "completion", title: "done", body: "ok", botId: "b", threadId: "t" },
+        { ...notifyContext, signal: abort.signal },
+      ),
+    ).rejects.toThrow("Expo push response is too large.");
+    expect(cancelStarted).toBe(true);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  it("caps a streamed response without a content length", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-push-"));
+    dirs.push(dataDir);
+    await savePushToken(dataDir, "user-1", "ExponentPushToken[test]");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(new Uint8Array(MAX_EXPO_PUSH_RESPONSE_BYTES + 1))),
+    );
+
+    await expect(
+      new ExpoPushProvider(dataDir).send(
+        { kind: "completion", title: "done", body: "ok", botId: "b", threadId: "t" },
+        notifyContext,
+      ),
+    ).rejects.toThrow("Expo push response is too large.");
+  });
+
+  it("rejects malformed successful responses", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-push-"));
+    dirs.push(dataDir);
+    await savePushToken(dataDir, "user-1", "ExponentPushToken[test]");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("not json")));
+
+    await expect(
+      new ExpoPushProvider(dataDir).send(
+        { kind: "completion", title: "done", body: "ok", botId: "b", threadId: "t" },
+        notifyContext,
+      ),
+    ).rejects.toThrow("Expo push returned an invalid response.");
+  });
+
+  it("passes caller cancellation to the Expo request", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-push-"));
+    dirs.push(dataDir);
+    await savePushToken(dataDir, "user-1", "ExponentPushToken[test]");
+    const controller = new AbortController();
+    controller.abort(new Error("notification cancelled"));
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.signal?.aborted).toBe(true);
+      throw init?.signal?.reason;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      new ExpoPushProvider(dataDir).send(
+        { kind: "completion", title: "done", body: "ok", botId: "b", threadId: "t" },
+        { ...notifyContext, signal: controller.signal },
+      ),
+    ).rejects.toThrow("notification cancelled");
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("throws when the Expo request never reaches the network", async () => {

--- a/packages/adapters/src/expo-push.ts
+++ b/packages/adapters/src/expo-push.ts
@@ -7,8 +7,12 @@ import type {
   NotificationProvider,
 } from "@rakazo/adapter-kit";
 import { getLogger } from "@rakazo/logging";
+import { combineSignals } from "./connector-safety.js";
+import { readBodyCapped, withAbort } from "./web-ssrf.js";
 
 const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
+const EXPO_PUSH_TIMEOUT_MS = 15_000;
+export const MAX_EXPO_PUSH_RESPONSE_BYTES = 64 * 1024;
 
 export function pushTokenPath(dataDir: string, userId: string) {
   return path.join(dataDir, "push-tokens", `${userId}.txt`);
@@ -98,6 +102,7 @@ export class ExpoPushProvider implements NotificationProvider {
   async send(message: NotificationMessage, context: AdapterContext): Promise<void> {
     const token = await loadPushToken(this.dataDir, context.userId);
     if (!token) return;
+    const signal = combineSignals(context.signal, AbortSignal.timeout(EXPO_PUSH_TIMEOUT_MS));
     let response: Response;
     try {
       response = await fetch("https://exp.host/--/api/v2/push/send", {
@@ -111,15 +116,42 @@ export class ExpoPushProvider implements NotificationProvider {
           tag: message.threadId,
           data: { kind: message.kind, botId: message.botId, threadId: message.threadId },
         }),
+        signal,
       });
     } catch (error) {
       getLogger().error("expo push request failed", error);
       throw error;
     }
-    const body = await response.json().catch(() => undefined);
+    const body = await readExpoPushBody(response, signal);
+    if (response.ok && body === undefined) {
+      throw new Error("Expo push returned an invalid response.");
+    }
     const failure = expoPushErrorMessage(body, response.status);
     if (!failure) return;
     getLogger().error(failure);
     throw new Error(failure);
+  }
+}
+
+async function readExpoPushBody(response: Response, signal: AbortSignal): Promise<unknown> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > MAX_EXPO_PUSH_RESPONSE_BYTES) {
+    const cancel = response.body?.cancel() ?? Promise.resolve();
+    await withAbort(
+      cancel.catch(() => undefined),
+      signal,
+    ).catch(() => undefined);
+    throw new Error("Expo push response is too large.");
+  }
+  try {
+    const bytes = await readBodyCapped(response, MAX_EXPO_PUSH_RESPONSE_BYTES, signal);
+    if (bytes.byteLength === 0) return undefined;
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch (error) {
+    if (error instanceof Error && error.message === "Response is too large") {
+      throw new Error("Expo push response is too large.");
+    }
+    if (error instanceof SyntaxError) return undefined;
+    throw error;
   }
 }


### PR DESCRIPTION
## Why

The Expo notification adapter buffered provider JSON without a size limit and did not pass the operation cancellation signal to the request. A stalled or oversized provider response could keep notification delivery alive after its caller was cancelled, while malformed successful JSON could be treated as delivered.

## What

- share the caller signal and a 15-second deadline across the Expo request and response body read
- cap declared and streamed response bodies at 64 KiB
- bound response-body cancellation so a hanging `cancel()` cannot outlive the operation
- reject malformed successful JSON while retaining generic HTTP failures for malformed error bodies
- add deterministic coverage for cancellation, declared and streamed limits, and malformed success responses

## Tests

- `pnpm exec vitest run packages/adapters/src/expo-push.test.ts` (14 passed)
- `pnpm --filter @rakazo/adapters test` (1119 passed, 7 skipped)
- `pnpm --filter @rakazo/adapters exec tsc --noEmit`
- `pnpm exec biome check packages/adapters/src/expo-push.ts packages/adapters/src/expo-push.test.ts`

No UI changes; screenshots are not applicable.
