### PR TITLE
fix(api): avoid hanging on oversized webhook bodies

### DIFF
--- a/apps/api/src/webhook.test.ts
+++ b/apps/api/src/webhook.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   formatWebhookPrompt,
   mountWebhookHttpRoutes,
+  readBoundedBody,
   WEBHOOK_MAX_BODY_BYTES,
   WEBHOOK_SECRET_KIND,
   type WebhookDeps,
@@ -246,4 +247,34 @@ describe("inbound webhook HTTP route", () => {
     expect(res.status).toBe(413);
     expect(deps.sendUserMessage).not.toHaveBeenCalled();
   });
+
+  it.each(["declared", "streamed"] as const)(
+    "does not wait on a hanging body cancel for %s oversize",
+    async (kind) => {
+      let cancelStarted = false;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(WEBHOOK_MAX_BODY_BYTES + 1));
+        },
+        cancel() {
+          cancelStarted = true;
+          return new Promise(() => undefined);
+        },
+      });
+      const request = new Request("https://rakazo.example.test/webhook", {
+        method: "POST",
+        headers:
+          kind === "declared"
+            ? { "content-length": String(WEBHOOK_MAX_BODY_BYTES + 1) }
+            : undefined,
+        body,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+
+      const started = Date.now();
+      await expect(readBoundedBody(request, WEBHOOK_MAX_BODY_BYTES)).resolves.toBeNull();
+      expect(cancelStarted).toBe(true);
+      expect(Date.now() - started).toBeLessThan(500);
+    },
+  );
 });

--- a/apps/api/src/webhook.test.ts
+++ b/apps/api/src/webhook.test.ts
@@ -271,10 +271,8 @@ describe("inbound webhook HTTP route", () => {
         duplex: "half",
       } as RequestInit & { duplex: "half" });
 
-      const started = Date.now();
       await expect(readBoundedBody(request, WEBHOOK_MAX_BODY_BYTES)).resolves.toBeNull();
       expect(cancelStarted).toBe(true);
-      expect(Date.now() - started).toBeLessThan(500);
     },
   );
 });

--- a/apps/api/src/webhook.ts
+++ b/apps/api/src/webhook.ts
@@ -47,6 +47,7 @@ export async function readBoundedBody(request: Request, maxBytes: number): Promi
   if (contentLengthHeader !== null) {
     const contentLength = Number(contentLengthHeader);
     if (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > maxBytes) {
+      cancelBody(request.body);
       return null;
     }
   }
@@ -63,7 +64,7 @@ export async function readBoundedBody(request: Request, maxBytes: number): Promi
       if (done) break;
       bytes += value.byteLength;
       if (bytes > maxBytes) {
-        await reader.cancel();
+        cancelBody(reader);
         return null;
       }
       body += decoder.decode(value, { stream: true });
@@ -71,6 +72,14 @@ export async function readBoundedBody(request: Request, maxBytes: number): Promi
     return body + decoder.decode();
   } finally {
     reader.releaseLock();
+  }
+}
+
+function cancelBody(body: { cancel(): Promise<void> } | null): void {
+  try {
+    void body?.cancel().catch(() => undefined);
+  } catch {
+    // Best-effort cleanup must not delay the 413 response.
   }
 }
 


### PR DESCRIPTION
## Why

The authenticated webhook route awaited `ReadableStream.cancel()` after detecting an oversized body. A hostile or broken stream whose cancellation never settles could therefore prevent the handler from returning its 413 response. Declared oversized bodies were rejected without even starting best-effort cleanup.

## What

- start best-effort cancellation for invalid declared lengths and streamed overflow
- never await untrusted cancellation promises before returning the rejection response
- swallow synchronous and asynchronous cancellation failures
- add deterministic coverage for hanging cancellation in both declared and streamed oversize paths

## Tests

- `pnpm exec vitest run apps/api/src/webhook.test.ts` (12 passed)
- `pnpm --filter @rakazo/api test` (189 passed)
- `pnpm --filter @rakazo/api check`
- `pnpm exec biome check apps/api/src/webhook.ts apps/api/src/webhook.test.ts`

No UI changes; screenshots are not applicable.
