### PR TITLE
fix(www): avoid hanging on oversized waitlist bodies

### DIFF
--- a/apps/www/api/waitlist.ts
+++ b/apps/www/api/waitlist.ts
@@ -27,7 +27,7 @@ async function readBody(request: Request): Promise<string | null> {
       if (done) break;
       bytes += value.byteLength;
       if (bytes > MAX_BODY_BYTES) {
-        await reader.cancel();
+        cancelBody(reader);
         return null;
       }
       body += decoder.decode(value, { stream: true });
@@ -35,6 +35,14 @@ async function readBody(request: Request): Promise<string | null> {
     return body + decoder.decode();
   } finally {
     reader.releaseLock();
+  }
+}
+
+function cancelBody(body: { cancel(): Promise<void> } | null): void {
+  try {
+    void body?.cancel().catch(() => undefined);
+  } catch {
+    // Best-effort cleanup must not delay the rejection response.
   }
 }
 
@@ -47,6 +55,7 @@ async function fetchWaitlist(request: Request) {
   if (contentLengthHeader !== null) {
     const contentLength = Number(contentLengthHeader);
     if (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > MAX_BODY_BYTES) {
+      cancelBody(request.body);
       return json(400, { error: "Invalid request" });
     }
   }

--- a/apps/www/src/waitlist.test.ts
+++ b/apps/www/src/waitlist.test.ts
@@ -69,6 +69,34 @@ describe("waitlist", () => {
     expect(response.status).toBe(400);
   });
 
+  it.each(["declared", "streamed"] as const)(
+    "does not wait on a hanging body cancel for %s oversize",
+    async (kind) => {
+      let cancelStarted = false;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(2_049));
+        },
+        cancel() {
+          cancelStarted = true;
+          return new Promise(() => undefined);
+        },
+      });
+      const request = new Request("https://rakazo.com/api/waitlist", {
+        method: "POST",
+        headers: kind === "declared" ? { "content-length": "2049" } : undefined,
+        body,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+
+      const started = Date.now();
+      const response = await waitlistFunction.fetch(request);
+      expect(response.status).toBe(400);
+      expect(cancelStarted).toBe(true);
+      expect(Date.now() - started).toBeLessThan(500);
+    },
+  );
+
   it("silently accepts submissions that fill the bot trap", async () => {
     const request = new Request("https://rakazo.com/api/waitlist", {
       method: "POST",

--- a/apps/www/src/waitlist.test.ts
+++ b/apps/www/src/waitlist.test.ts
@@ -89,11 +89,9 @@ describe("waitlist", () => {
         duplex: "half",
       } as RequestInit & { duplex: "half" });
 
-      const started = Date.now();
       const response = await waitlistFunction.fetch(request);
       expect(response.status).toBe(400);
       expect(cancelStarted).toBe(true);
-      expect(Date.now() - started).toBeLessThan(500);
     },
   );
 


### PR DESCRIPTION
## Why

The public waitlist endpoint awaited `ReadableStream.cancel()` after detecting a streamed body over its 2 KiB limit. A request stream whose cancellation never settles could keep the serverless invocation open instead of returning the existing 400 response. Declared oversized bodies also skipped best-effort cleanup.

## What

- start best-effort cancellation for invalid declared lengths and streamed overflow
- return the existing rejection immediately without awaiting an untrusted cancellation promise
- swallow synchronous and asynchronous cancellation failures
- add deterministic coverage for hanging cancellation in both oversize paths

## Tests

- `pnpm exec vitest run apps/www/src/waitlist.test.ts` (8 passed)
- `pnpm exec vitest run apps/www/src` (29 passed)
- `pnpm --filter @rakazo/www check`
- `pnpm --filter @rakazo/www build`

No UI changes; screenshots are not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of oversized or invalid waitlist submissions so requests return a validation error without hanging.
  - Ensured streamed request bodies are canceled promptly, even when cleanup cannot complete normally.

- **Tests**
  - Added coverage for oversized streamed requests with and without declared content lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->