### PR TITLE
fix(mobile): parse Better Auth cookies defensively

### DIFF
--- a/apps/mobile/lib/session.test.ts
+++ b/apps/mobile/lib/session.test.ts
@@ -92,17 +92,37 @@ describe("auth response token parsing", () => {
     );
   });
 
-  it("falls back to and decodes the Better Auth session cookie", () => {
+  it.each(["better-auth.session_token", "__Secure-better-auth.session_token"])(
+    "falls back to and decodes the %s cookie",
+    (name) => {
+      const response = new Response(null, {
+        headers: { "set-cookie": `${name}=abc%2F123%3D; Path=/; HttpOnly` },
+      });
+
+      expect(tokenFromAuthResponse(response, {})).toBe("abc/123=");
+    },
+  );
+
+  it("finds a secure session after another Set-Cookie value", () => {
     const response = new Response(null, {
-      headers: { "set-cookie": "better-auth.session_token=abc%2F123%3D; Path=/; HttpOnly" },
+      headers: {
+        "set-cookie":
+          "other=value; Path=/, __Secure-better-auth.session_token=secure-token; Path=/; HttpOnly",
+      },
     });
 
-    expect(tokenFromAuthResponse(response, {})).toBe("abc/123=");
+    expect(tokenFromAuthResponse(response, {})).toBe("secure-token");
   });
 
   it("rejects unrelated cookies and malformed response bodies", () => {
-    const response = new Response(null, { headers: { "set-cookie": "other=value; Path=/" } });
-    expect(tokenFromAuthResponse(response, { token: 123 })).toBe("");
-    expect(tokenFromAuthResponse(response, null)).toBe("");
+    const unrelated = new Response(null, {
+      headers: { "set-cookie": "notbetter-auth.session_token=attacker; Path=/" },
+    });
+    const malformed = new Response(null, {
+      headers: { "set-cookie": "better-auth.session_token=bad%ZZ; Path=/" },
+    });
+    expect(tokenFromAuthResponse(unrelated, { token: 123 })).toBe("");
+    expect(tokenFromAuthResponse(unrelated, null)).toBe("");
+    expect(tokenFromAuthResponse(malformed, {})).toBe("");
   });
 });

--- a/apps/mobile/lib/session.ts
+++ b/apps/mobile/lib/session.ts
@@ -70,8 +70,13 @@ export function tokenFromAuthResponse(res: Response, body: unknown) {
   const fromJson = jsonToken(body);
   if (fromJson) return fromJson;
   const cookies = res.headers.get("set-cookie") ?? "";
-  const match = cookies.match(/better-auth\.session_token=([^;]+)/);
-  return match?.[1] ? decodeURIComponent(match[1]) : "";
+  const encoded = cookies.match(/(?:^|,\s*)(?:__Secure-)?better-auth\.session_token=([^;,]*)/)?.[1];
+  if (!encoded) return "";
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return "";
+  }
 }
 
 function jsonToken(body: unknown): string {


### PR DESCRIPTION
## Why

The mobile auth fallback matched `better-auth.session_token` anywhere inside a cookie name and decoded it without handling malformed percent escapes. That could accept an unrelated lookalike cookie or throw `URIError` during otherwise successful sign-in. Production Better Auth responses may also use the explicit `__Secure-` prefix.

## What

- match only the exact Better Auth session cookie or its supported `__Secure-` form
- find the session cookie after another merged `Set-Cookie` value
- fail closed when the cookie value contains malformed percent encoding
- retain JSON-token precedence and percent decoding for valid cookie tokens

## Tests

- `pnpm exec vitest run apps/mobile/lib/session.test.ts` (11 passed)
- `pnpm --filter @rakazo/mobile test` (160 passed)
- `pnpm exec tsc --noEmit -p apps/mobile/tsconfig.json`
- `pnpm exec biome check apps/mobile/lib/session.ts apps/mobile/lib/session.test.ts`

No UI changes; screenshots are not applicable.
