### PR TITLE
Surface delegated bot summaries and recover blank chats

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -146,7 +146,12 @@ import {
   UpdaterProxyError,
 } from "./server-update.js";
 import { assertTeachingSendAllowed, createTaughtSkillsService } from "./taught-skills.js";
-import { isPeerRun, loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
+import {
+  isPeerRun,
+  isUserVisiblePeerRunEvent,
+  loadAllMessages,
+  loadMessagePage,
+} from "./thread-message-pages.js";
 import {
   reactToThreadMessage,
   resolveThreadTarget,
@@ -1060,25 +1065,9 @@ export function createRouter(deps: RouterDeps) {
           context.signal,
         )) {
           if (await isPeerRun(deps.prisma, event.runId, peerRunCache)) {
-            // Keep terminal peer-run events so clients can clear working state.
-            // Keep compact peer receipts for mobile; drop peer activity/replies.
-            const isTerminal =
-              event.type === "run.completed" ||
-              event.type === "run.failed" ||
-              event.type === "run.cancelled";
-            const blocks = event.payload.blocks;
-            const isReceipt =
-              (event.type === "thread.message.created" ||
-                event.type === "thread.message.updated") &&
-              Array.isArray(blocks) &&
-              blocks.some(
-                (block) =>
-                  !!block &&
-                  typeof block === "object" &&
-                  "kind" in block &&
-                  (block.kind === "bot_message_received" || block.kind === "bot_message_sent"),
-              );
-            if (!isTerminal && !isReceipt) continue;
+            // Keep terminal state, compact receipts, and actionable takeover
+            // requests; drop ordinary peer activity and worker narration.
+            if (!isUserVisiblePeerRunEvent(event)) continue;
           }
           yield event;
         }

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -13,7 +13,7 @@ describe("thread message pages", () => {
     expect(findUnique).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps peer receipt rows when filtering peer-run output from pages", async () => {
+  it("keeps peer receipts and final owner summaries while filtering peer activity", async () => {
     const findMany = vi.fn(async () => [
       {
         id: "message-reply",
@@ -66,10 +66,11 @@ describe("thread message pages", () => {
     expect(page.messages.map((message) => message.id)).toEqual([
       "message-user",
       "message-received",
+      "message-reply",
     ]);
   });
 
-  it("filters peer-run output when its receipt is outside the loaded page", async () => {
+  it("keeps a peer-run owner summary when its receipt is outside the loaded page", async () => {
     const findMany = vi.fn(async () => [
       {
         id: "message-peer",
@@ -101,10 +102,10 @@ describe("thread message pages", () => {
 
     const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
 
-    expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
+    expect(page.messages.map((message) => message.id)).toEqual(["message-user", "message-peer"]);
   });
 
-  it("omits peer around-page targets from the normal transcript", async () => {
+  it("keeps a peer summary around-page target but omits peer activity", async () => {
     const findMany = vi.fn(async () => [
       {
         id: "message-user",
@@ -152,7 +153,10 @@ describe("thread message pages", () => {
       seq: 6,
     });
 
-    expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
+    expect(page.messages.map((message) => message.id)).toEqual([
+      "message-user",
+      "message-peer-target",
+    ]);
     expect(runFindMany).toHaveBeenCalled();
   });
 
@@ -213,6 +217,7 @@ describe("thread message pages", () => {
     expect(page.messages.map((message) => message.id)).toEqual([
       "message-user",
       "message-peer-receipt",
+      "message-peer-text",
     ]);
   });
 
@@ -246,13 +251,13 @@ describe("thread message pages", () => {
     expect(page.messages.map((message) => message.id)).toEqual(["message-peer"]);
   });
 
-  it("scans past a page containing only peer-run output", async () => {
+  it("scans past a page containing only peer-run activity", async () => {
     const row = (seq: number, runId: string) => ({
       id: `message-${seq}`,
       threadId: "thread-1",
       seq,
       role: "bot",
-      blocks: [{ kind: "text", text: String(seq) }],
+      blocks: [{ kind: "steps", steps: [{ label: String(seq), count: 1 }] }],
       botId: "bot-1",
       replyToMessageId: null,
       runId,

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -142,6 +142,36 @@ describe("thread message pages", () => {
     expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
   });
 
+  it("projects mixed peer-run finals down to owner-facing text", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        id: "message-peer",
+        threadId: "thread-1",
+        seq: 1,
+        role: "bot",
+        blocks: [
+          { kind: "steps", steps: [{ label: "Message bot", count: 1 }] },
+          { kind: "text", text: "Engineer finished the review." },
+        ],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-peer",
+        clientNonce: null,
+        createdAt: new Date("2026-08-16T00:00:01.000Z"),
+      },
+    ]);
+    const prisma = {
+      message: { findMany },
+      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+    } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
+
+    expect(page.messages[0]?.blocks).toEqual([
+      { kind: "text", text: "Engineer finished the review." },
+    ]);
+  });
+
   it("keeps a peer summary around-page target but omits peer activity", async () => {
     const findMany = vi.fn(async () => [
       {

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -194,6 +194,55 @@ describe("thread message pages", () => {
     expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
   });
 
+  it("keeps untagged mid-turn peer narration out when a later terminal summary exists", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        id: "message-summary",
+        threadId: "thread-1",
+        seq: 3,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Coder finished the review." }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-peer",
+        clientNonce: null,
+        createdAt: new Date("2026-08-16T00:00:03.000Z"),
+      },
+      {
+        id: "message-progress",
+        threadId: "thread-1",
+        seq: 2,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Still drafting the report." }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-peer",
+        clientNonce: null,
+        createdAt: new Date("2026-08-16T00:00:02.000Z"),
+      },
+      {
+        id: "message-user",
+        threadId: "thread-1",
+        seq: 1,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Visible answer" }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-user",
+        clientNonce: null,
+        createdAt: new Date("2026-08-16T00:00:01.000Z"),
+      },
+    ]);
+    const prisma = {
+      message: { findMany },
+      run: { findMany: vi.fn(async () => [peerRun()]) },
+    } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 3);
+
+    expect(page.messages.map((message) => message.id)).toEqual(["message-user", "message-summary"]);
+  });
+
   it("projects mixed peer-run finals down to owner-facing text", async () => {
     const findMany = vi.fn(async () => [
       {

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -2,6 +2,23 @@ import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import { isPeerRun, loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
 
+function peerRun(intent: "request" | "result" = "result") {
+  return {
+    id: "run-peer",
+    sourceMessage: {
+      blocks: [
+        {
+          kind: "bot_message_received",
+          fromBotId: "bot-2",
+          fromBotName: "Coder",
+          text: intent === "request" ? "Check this." : "Done.",
+          intent,
+        },
+      ],
+    },
+  };
+}
+
 describe("thread message pages", () => {
   it("caches peer-run classification for live events", async () => {
     const findUnique = vi.fn(async () => ({ trigger: "bot_message" }));
@@ -58,7 +75,7 @@ describe("thread message pages", () => {
     ]);
     const prisma = {
       message: { findMany },
-      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+      run: { findMany: vi.fn(async () => [peerRun()]) },
     } as unknown as PrismaClient;
 
     const page = await loadMessagePage(prisma, "thread-1", undefined, 3);
@@ -97,12 +114,47 @@ describe("thread message pages", () => {
     ]);
     const prisma = {
       message: { findMany },
-      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+      run: { findMany: vi.fn(async () => [peerRun()]) },
     } as unknown as PrismaClient;
 
     const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
 
     expect(page.messages.map((message) => message.id)).toEqual(["message-user", "message-peer"]);
+  });
+
+  it("hides an assigned worker's final reply from the normal transcript", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        id: "message-worker-reply",
+        threadId: "thread-1",
+        seq: 2,
+        role: "bot",
+        blocks: [{ kind: "text", text: "The check passed." }],
+        botId: "bot-worker",
+        replyToMessageId: null,
+        runId: "run-peer",
+        createdAt: new Date("2026-08-16T00:00:02.000Z"),
+      },
+      {
+        id: "message-user",
+        threadId: "thread-1",
+        seq: 1,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Older visible answer" }],
+        botId: "bot-worker",
+        replyToMessageId: null,
+        runId: "run-user",
+        createdAt: new Date("2026-08-16T00:00:01.000Z"),
+      },
+    ]);
+    const prisma = {
+      message: { findMany },
+      run: { findMany: vi.fn(async () => [peerRun("request")]) },
+    } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
+
+    expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
   });
 
   it("filters mid-turn peer narration identified by its durable nonce", async () => {
@@ -134,7 +186,7 @@ describe("thread message pages", () => {
     ]);
     const prisma = {
       message: { findMany },
-      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+      run: { findMany: vi.fn(async () => [peerRun()]) },
     } as unknown as PrismaClient;
 
     const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
@@ -162,7 +214,7 @@ describe("thread message pages", () => {
     ]);
     const prisma = {
       message: { findMany },
-      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+      run: { findMany: vi.fn(async () => [peerRun()]) },
     } as unknown as PrismaClient;
 
     const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
@@ -209,7 +261,7 @@ describe("thread message pages", () => {
       },
     ]);
     const count = vi.fn(async () => 1);
-    const runFindMany = vi.fn(async () => [{ id: "run-peer" }]);
+    const runFindMany = vi.fn(async () => [peerRun()]);
     const prisma = {
       message: { findMany, count },
       run: { findMany: runFindMany },
@@ -273,7 +325,7 @@ describe("thread message pages", () => {
     const count = vi.fn(async () => 0);
     const prisma = {
       message: { findMany, count },
-      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+      run: { findMany: vi.fn(async () => [peerRun()]) },
     } as unknown as PrismaClient;
 
     const page = await loadMessagePage(prisma, "thread-1", undefined, 4, {

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -243,6 +243,51 @@ describe("thread message pages", () => {
     expect(page.messages.map((message) => message.id)).toEqual(["message-user", "message-summary"]);
   });
 
+  it("hides paginated peer narration when its terminal summary is on a newer page", async () => {
+    const progress = {
+      id: "message-progress",
+      threadId: "thread-1",
+      seq: 2,
+      role: "bot",
+      blocks: [{ kind: "text", text: "Still drafting the report." }],
+      botId: "bot-1",
+      replyToMessageId: null,
+      runId: "run-peer",
+      clientNonce: null,
+      createdAt: new Date("2026-08-16T00:00:02.000Z"),
+    };
+    const summary = {
+      ...progress,
+      id: "message-summary",
+      seq: 3,
+      blocks: [{ kind: "text", text: "Coder finished the review." }],
+      createdAt: new Date("2026-08-16T00:00:03.000Z"),
+    };
+    const visible = {
+      ...progress,
+      id: "message-user",
+      seq: 1,
+      blocks: [{ kind: "text", text: "Visible answer" }],
+      runId: "run-user",
+      createdAt: new Date("2026-08-16T00:00:01.000Z"),
+    };
+    const findMany = vi.fn(async (query: { where?: { runId?: unknown } }) =>
+      query.where?.runId ? [progress, summary] : [progress, visible],
+    );
+    const prisma = {
+      message: { findMany },
+      run: { findMany: vi.fn(async () => [peerRun()]) },
+    } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", 3, 2);
+
+    expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
+    expect(findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ where: { runId: { in: ["run-peer"] } } }),
+    );
+  });
+
   it("projects mixed peer-run finals down to owner-facing text", async () => {
     const findMany = vi.fn(async () => [
       {

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -105,6 +105,43 @@ describe("thread message pages", () => {
     expect(page.messages.map((message) => message.id)).toEqual(["message-user", "message-peer"]);
   });
 
+  it("filters mid-turn peer narration identified by its durable nonce", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        id: "message-progress",
+        threadId: "thread-1",
+        seq: 2,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Still checking." }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-peer",
+        clientNonce: "user-progress:run-peer:0:test",
+        createdAt: new Date("2026-08-16T00:00:02.000Z"),
+      },
+      {
+        id: "message-user",
+        threadId: "thread-1",
+        seq: 1,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Visible answer" }],
+        botId: "bot-1",
+        replyToMessageId: null,
+        runId: "run-user",
+        clientNonce: null,
+        createdAt: new Date("2026-08-16T00:00:01.000Z"),
+      },
+    ]);
+    const prisma = {
+      message: { findMany },
+      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+    } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
+
+    expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
+  });
+
   it("keeps a peer summary around-page target but omits peer activity", async () => {
     const findMany = vi.fn(async () => [
       {

--- a/apps/api/src/thread-message-pages.test.ts
+++ b/apps/api/src/thread-message-pages.test.ts
@@ -1,6 +1,11 @@
 import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
-import { isPeerRun, loadAllMessages, loadMessagePage } from "./thread-message-pages.js";
+import {
+  isPeerRun,
+  isUserVisiblePeerRunEvent,
+  loadAllMessages,
+  loadMessagePage,
+} from "./thread-message-pages.js";
 
 function peerRun(intent: "request" | "result" = "result") {
   return {
@@ -20,6 +25,26 @@ function peerRun(intent: "request" | "result" = "result") {
 }
 
 describe("thread message pages", () => {
+  it("keeps takeover events visible for peer-triggered runs", () => {
+    expect(
+      isUserVisiblePeerRunEvent({
+        type: "thread.message.created",
+        payload: {
+          blocks: [{ kind: "computer", state: "Ready", text: "Please complete login." }],
+        },
+      }),
+    ).toBe(true);
+    expect(isUserVisiblePeerRunEvent({ type: "computer.takeover.requested", payload: {} })).toBe(
+      true,
+    );
+    expect(
+      isUserVisiblePeerRunEvent({
+        type: "thread.message.created",
+        payload: { blocks: [{ kind: "text", text: "Private worker narration." }] },
+      }),
+    ).toBe(false);
+  });
+
   it("caches peer-run classification for live events", async () => {
     const findUnique = vi.fn(async () => ({ trigger: "bot_message" }));
     const prisma = { run: { findUnique } } as unknown as PrismaClient;
@@ -155,6 +180,44 @@ describe("thread message pages", () => {
     const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
 
     expect(page.messages.map((message) => message.id)).toEqual(["message-user"]);
+  });
+
+  it("keeps an assigned worker's takeover request in the normal transcript", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        id: "message-takeover",
+        threadId: "thread-1",
+        seq: 2,
+        role: "bot",
+        blocks: [{ kind: "computer", state: "Ready", text: "Please complete the staging login." }],
+        botId: "bot-worker",
+        replyToMessageId: null,
+        runId: "run-peer",
+        createdAt: new Date("2026-08-16T00:00:02.000Z"),
+      },
+      {
+        id: "message-user",
+        threadId: "thread-1",
+        seq: 1,
+        role: "bot",
+        blocks: [{ kind: "text", text: "Older visible answer" }],
+        botId: "bot-worker",
+        replyToMessageId: null,
+        runId: "run-user",
+        createdAt: new Date("2026-08-16T00:00:01.000Z"),
+      },
+    ]);
+    const prisma = {
+      message: { findMany },
+      run: { findMany: vi.fn(async () => [peerRun("request")]) },
+    } as unknown as PrismaClient;
+
+    const page = await loadMessagePage(prisma, "thread-1", undefined, 2);
+
+    expect(page.messages.map((message) => message.id)).toEqual([
+      "message-user",
+      "message-takeover",
+    ]);
   });
 
   it("filters mid-turn peer narration identified by its durable nonce", async () => {

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -1,8 +1,36 @@
 import type { MessageBlock, ThreadMessage, ThreadMessagePage } from "@rakazo/contracts";
-import { isPeerReceiptBlocks, isPeerReportBlocks, terminalPeerSummaryIndexes } from "@rakazo/core";
+import {
+  isPeerReceiptBlocks,
+  isPeerReportBlocks,
+  isTakeoverRequestBlocks,
+  terminalPeerSummaryIndexes,
+} from "@rakazo/core";
 import type { Prisma, PrismaClient } from "@rakazo/db";
 
 type MessageDb = PrismaClient | Prisma.TransactionClient;
+
+export function isUserVisiblePeerRunEvent(event: {
+  type: string;
+  payload: { blocks?: unknown };
+}): boolean {
+  if (
+    event.type === "run.completed" ||
+    event.type === "run.failed" ||
+    event.type === "run.cancelled" ||
+    event.type === "computer.takeover.requested"
+  ) {
+    return true;
+  }
+  if (event.type !== "thread.message.created" && event.type !== "thread.message.updated") {
+    return false;
+  }
+  const blocks = event.payload.blocks;
+  if (!Array.isArray(blocks)) return false;
+  return (
+    isPeerReceiptBlocks(blocks as MessageBlock[]) ||
+    isTakeoverRequestBlocks(blocks as MessageBlock[])
+  );
+}
 
 export async function loadMessagePage(
   prisma: MessageDb,
@@ -149,6 +177,7 @@ async function withoutPeerRunMessages<
     // result/status/fyi may publish a final report to the user; a worker woken
     // by a request/question remains private to the peer exchange.
     const blocks = row.blocks as MessageBlock[];
+    if (isTakeoverRequestBlocks(blocks)) return [row];
     if (
       blocks.some(
         (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -1,5 +1,5 @@
 import type { MessageBlock, ThreadMessage, ThreadMessagePage } from "@rakazo/contracts";
-import { isPeerReceiptBlocks, isPeerSummaryMessage } from "@rakazo/core";
+import { isPeerReceiptBlocks, isPeerReportBlocks, isPeerSummaryMessage } from "@rakazo/core";
 import type { Prisma, PrismaClient } from "@rakazo/db";
 
 type MessageDb = PrismaClient | Prisma.TransactionClient;
@@ -35,9 +35,9 @@ export async function loadMessagePage(
       const hasOlder = first
         ? (await prisma.message.count({ where: { threadId, seq: { lt: first.seq } } })) > 0
         : false;
-      // Peer activity stays out of the normal transcript. Receipts and the
-      // receiving bot's final owner-facing summary remain; full peer history
-      // belongs in the bot-messages overlay (includePeerRuns).
+      // Peer activity stays out of the normal transcript. Receipts and a
+      // coordinator's user-facing report remain; assigned workers' replies
+      // belong in the bot-messages overlay (includePeerRuns).
       const messages = includePeerRuns ? rows : await withoutPeerRunMessages(prisma, rows);
       return {
         threadId,
@@ -100,13 +100,25 @@ async function withoutPeerRunMessages<
   if (runIds.length === 0) return rows;
   const peerRuns = await prisma.run.findMany({
     where: { id: { in: runIds }, trigger: "bot_message" },
-    select: { id: true },
+    select: { id: true, sourceMessage: { select: { blocks: true } } },
   });
   const peerRunIds = new Set(peerRuns.map((run) => run.id));
+  const peerReportRunIds = new Set(
+    peerRuns
+      .filter((run) =>
+        isPeerReportBlocks(
+          Array.isArray(run.sourceMessage?.blocks)
+            ? (run.sourceMessage.blocks as MessageBlock[])
+            : [],
+        ),
+      )
+      .map((run) => run.id),
+  );
   return rows.flatMap((row) => {
     if (!row.runId || !peerRunIds.has(row.runId)) return [row];
-    // Keep compact sent/received receipts and the bot's final summary for its
-    // owner. Tool activity and the underlying peer exchange stay hidden.
+    // Keep compact sent/received receipts. Only a coordinator woken by a
+    // result/status/fyi may publish a final report to the user; a worker woken
+    // by a request/question remains private to the peer exchange.
     const blocks = row.blocks as MessageBlock[];
     if (
       blocks.some(
@@ -115,7 +127,11 @@ async function withoutPeerRunMessages<
     ) {
       return [row];
     }
-    if (!isPeerSummaryMessage({ blocks, clientNonce: row.clientNonce })) return [];
+    if (
+      !peerReportRunIds.has(row.runId) ||
+      !isPeerSummaryMessage({ blocks, clientNonce: row.clientNonce })
+    )
+      return [];
 
     // A terminal peer message can also contain steps/tool activity. Only the
     // owner-facing text belongs in the normal transcript.

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -95,6 +95,7 @@ export async function loadAllMessages(
 
 async function withoutPeerRunMessages<
   T extends {
+    id: string;
     runId: string | null;
     seq?: number;
     clientNonce?: string | null;
@@ -119,8 +120,16 @@ async function withoutPeerRunMessages<
       )
       .map((run) => run.id),
   );
+  const peerReportMessages =
+    peerReportRunIds.size > 0
+      ? await prisma.message.findMany({
+          where: { runId: { in: [...peerReportRunIds] } },
+          orderBy: { seq: "asc" },
+          select: { id: true, runId: true, seq: true, clientNonce: true, blocks: true },
+        })
+      : [];
   const terminalSummaryIndexes = terminalPeerSummaryIndexes(
-    rows.map((row) => ({
+    peerReportMessages.map((row) => ({
       runId: row.runId ?? undefined,
       seq: row.seq,
       clientNonce: row.clientNonce,
@@ -128,7 +137,13 @@ async function withoutPeerRunMessages<
     })),
     peerReportRunIds,
   );
-  return rows.flatMap((row, index) => {
+  const terminalSummaryIds = new Set(
+    [...terminalSummaryIndexes].flatMap((index) => {
+      const message = peerReportMessages[index];
+      return message ? [message.id] : [];
+    }),
+  );
+  return rows.flatMap((row) => {
     if (!row.runId || !peerRunIds.has(row.runId)) return [row];
     // Keep compact sent/received receipts. Only a coordinator woken by a
     // result/status/fyi may publish a final report to the user; a worker woken
@@ -141,7 +156,7 @@ async function withoutPeerRunMessages<
     ) {
       return [row];
     }
-    if (!peerReportRunIds.has(row.runId) || !terminalSummaryIndexes.has(index)) return [];
+    if (!peerReportRunIds.has(row.runId) || !terminalSummaryIds.has(row.id)) return [];
 
     // A terminal peer message can also contain steps/tool activity. Only the
     // owner-facing text belongs in the normal transcript.

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -103,16 +103,26 @@ async function withoutPeerRunMessages<
     select: { id: true },
   });
   const peerRunIds = new Set(peerRuns.map((run) => run.id));
-  return rows.filter((row) => {
-    if (!row.runId || !peerRunIds.has(row.runId)) return true;
+  return rows.flatMap((row) => {
+    if (!row.runId || !peerRunIds.has(row.runId)) return [row];
     // Keep compact sent/received receipts and the bot's final summary for its
     // owner. Tool activity and the underlying peer exchange stay hidden.
     const blocks = row.blocks as MessageBlock[];
-    return (
+    if (
       blocks.some(
         (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",
-      ) || isPeerSummaryMessage({ blocks, clientNonce: row.clientNonce })
+      )
+    ) {
+      return [row];
+    }
+    if (!isPeerSummaryMessage({ blocks, clientNonce: row.clientNonce })) return [];
+
+    // A terminal peer message can also contain steps/tool activity. Only the
+    // owner-facing text belongs in the normal transcript.
+    const summaryBlocks = blocks.filter(
+      (block) => block.kind === "text" && block.text.trim().length > 0,
     );
+    return [{ ...row, blocks: summaryBlocks as Prisma.JsonValue } as T];
   });
 }
 

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -1,5 +1,5 @@
 import type { MessageBlock, ThreadMessage, ThreadMessagePage } from "@rakazo/contracts";
-import { isPeerReceiptBlocks } from "@rakazo/core";
+import { isPeerReceiptBlocks, isPeerSummaryBlocks } from "@rakazo/core";
 import type { Prisma, PrismaClient } from "@rakazo/db";
 
 type MessageDb = PrismaClient | Prisma.TransactionClient;
@@ -35,9 +35,9 @@ export async function loadMessagePage(
       const hasOlder = first
         ? (await prisma.message.count({ where: { threadId, seq: { lt: first.seq } } })) > 0
         : false;
-      // Peer text/activity stays out of the normal transcript (including the
-      // around target). Receipts remain via withoutPeerRunMessages; full peer
-      // history belongs in the bot-messages overlay (includePeerRuns).
+      // Peer activity stays out of the normal transcript. Receipts and the
+      // receiving bot's final owner-facing summary remain; full peer history
+      // belongs in the bot-messages overlay (includePeerRuns).
       const messages = includePeerRuns ? rows : await withoutPeerRunMessages(prisma, rows);
       return {
         threadId,
@@ -106,10 +106,13 @@ async function withoutPeerRunMessages<T extends { runId: string | null; blocks: 
   const peerRunIds = new Set(peerRuns.map((run) => run.id));
   return rows.filter((row) => {
     if (!row.runId || !peerRunIds.has(row.runId)) return true;
-    // Keep compact sent/received receipts; clients render them as chips.
+    // Keep compact sent/received receipts and the bot's final summary for its
+    // owner. Tool activity and the underlying peer exchange stay hidden.
     const blocks = row.blocks as MessageBlock[];
-    return blocks.some(
-      (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",
+    return (
+      blocks.some(
+        (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",
+      ) || isPeerSummaryBlocks(blocks)
     );
   });
 }

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -1,5 +1,5 @@
 import type { MessageBlock, ThreadMessage, ThreadMessagePage } from "@rakazo/contracts";
-import { isPeerReceiptBlocks, isPeerSummaryBlocks } from "@rakazo/core";
+import { isPeerReceiptBlocks, isPeerSummaryMessage } from "@rakazo/core";
 import type { Prisma, PrismaClient } from "@rakazo/db";
 
 type MessageDb = PrismaClient | Prisma.TransactionClient;
@@ -93,10 +93,9 @@ export async function loadAllMessages(
   return pages.reverse().flat();
 }
 
-async function withoutPeerRunMessages<T extends { runId: string | null; blocks: Prisma.JsonValue }>(
-  prisma: MessageDb,
-  rows: T[],
-): Promise<T[]> {
+async function withoutPeerRunMessages<
+  T extends { runId: string | null; clientNonce?: string | null; blocks: Prisma.JsonValue },
+>(prisma: MessageDb, rows: T[]): Promise<T[]> {
   const runIds = [...new Set(rows.flatMap((row) => (row.runId ? [row.runId] : [])))];
   if (runIds.length === 0) return rows;
   const peerRuns = await prisma.run.findMany({
@@ -112,7 +111,7 @@ async function withoutPeerRunMessages<T extends { runId: string | null; blocks: 
     return (
       blocks.some(
         (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",
-      ) || isPeerSummaryBlocks(blocks)
+      ) || isPeerSummaryMessage({ blocks, clientNonce: row.clientNonce })
     );
   });
 }

--- a/apps/api/src/thread-message-pages.ts
+++ b/apps/api/src/thread-message-pages.ts
@@ -1,5 +1,5 @@
 import type { MessageBlock, ThreadMessage, ThreadMessagePage } from "@rakazo/contracts";
-import { isPeerReceiptBlocks, isPeerReportBlocks, isPeerSummaryMessage } from "@rakazo/core";
+import { isPeerReceiptBlocks, isPeerReportBlocks, terminalPeerSummaryIndexes } from "@rakazo/core";
 import type { Prisma, PrismaClient } from "@rakazo/db";
 
 type MessageDb = PrismaClient | Prisma.TransactionClient;
@@ -94,7 +94,12 @@ export async function loadAllMessages(
 }
 
 async function withoutPeerRunMessages<
-  T extends { runId: string | null; clientNonce?: string | null; blocks: Prisma.JsonValue },
+  T extends {
+    runId: string | null;
+    seq?: number;
+    clientNonce?: string | null;
+    blocks: Prisma.JsonValue;
+  },
 >(prisma: MessageDb, rows: T[]): Promise<T[]> {
   const runIds = [...new Set(rows.flatMap((row) => (row.runId ? [row.runId] : [])))];
   if (runIds.length === 0) return rows;
@@ -114,7 +119,16 @@ async function withoutPeerRunMessages<
       )
       .map((run) => run.id),
   );
-  return rows.flatMap((row) => {
+  const terminalSummaryIndexes = terminalPeerSummaryIndexes(
+    rows.map((row) => ({
+      runId: row.runId ?? undefined,
+      seq: row.seq,
+      clientNonce: row.clientNonce,
+      blocks: row.blocks as MessageBlock[],
+    })),
+    peerReportRunIds,
+  );
+  return rows.flatMap((row, index) => {
     if (!row.runId || !peerRunIds.has(row.runId)) return [row];
     // Keep compact sent/received receipts. Only a coordinator woken by a
     // result/status/fyi may publish a final report to the user; a worker woken
@@ -127,11 +141,7 @@ async function withoutPeerRunMessages<
     ) {
       return [row];
     }
-    if (
-      !peerReportRunIds.has(row.runId) ||
-      !isPeerSummaryMessage({ blocks, clientNonce: row.clientNonce })
-    )
-      return [];
+    if (!peerReportRunIds.has(row.runId) || !terminalSummaryIndexes.has(index)) return [];
 
     // A terminal peer message can also contain steps/tool activity. Only the
     // owner-facing text belongs in the normal transcript.

--- a/apps/web/e2e/peer-messages.spec.ts
+++ b/apps/web/e2e/peer-messages.spec.ts
@@ -94,9 +94,6 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
   await expect(view.getByRole("textbox")).toHaveCount(0);
   await expect(view.getByText("Loading")).toHaveCount(0);
   const peerTranscript = view.getByTestId("peer-conversation-transcript");
-  await peerTranscript.evaluate((element) => {
-    element.scrollTop = element.scrollHeight;
-  });
   await expect
     .poll(() =>
       peerTranscript.evaluate(

--- a/apps/web/src/lib/link-abort-signal.test.ts
+++ b/apps/web/src/lib/link-abort-signal.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { linkAbortSignal } from "./link-abort-signal.js";
+
+describe("linkAbortSignal", () => {
+  it("runs onAbort immediately when the source has already aborted", () => {
+    const source = new AbortController();
+    source.abort();
+    const onAbort = vi.fn();
+
+    const unlink = linkAbortSignal(source.signal, onAbort);
+
+    expect(onAbort).toHaveBeenCalledTimes(1);
+    unlink();
+  });
+
+  it("runs onAbort when the source aborts later", () => {
+    const source = new AbortController();
+    const onAbort = vi.fn();
+
+    linkAbortSignal(source.signal, onAbort);
+    expect(onAbort).not.toHaveBeenCalled();
+    source.abort();
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run onAbort after unlink", () => {
+    const source = new AbortController();
+    const onAbort = vi.fn();
+
+    const unlink = linkAbortSignal(source.signal, onAbort);
+    unlink();
+    source.abort();
+    expect(onAbort).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/link-abort-signal.ts
+++ b/apps/web/src/lib/link-abort-signal.ts
@@ -1,0 +1,9 @@
+/** Subscribe to `source` abort, or run immediately if it already aborted. */
+export function linkAbortSignal(source: AbortSignal, onAbort: () => void): () => void {
+  if (source.aborted) {
+    onAbort();
+    return () => {};
+  }
+  source.addEventListener("abort", onAbort, { once: true });
+  return () => source.removeEventListener("abort", onAbort);
+}

--- a/apps/web/src/lib/peer-messages.test.ts
+++ b/apps/web/src/lib/peer-messages.test.ts
@@ -2,8 +2,13 @@ import type { ThreadMessage } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
 import { peerConversations, peerMessagesFrom } from "./peer-messages.js";
 
-function message(id: string, createdAt: string, blocks: ThreadMessage["blocks"]): ThreadMessage {
-  return { id, threadId: "t_1", seq: 1, role: "bot", blocks, createdAt };
+function message(
+  id: string,
+  createdAt: string,
+  blocks: ThreadMessage["blocks"],
+  options: Pick<ThreadMessage, "role" | "runId"> = { role: "bot" },
+): ThreadMessage {
+  return { id, threadId: "t_1", seq: 1, blocks, createdAt, ...options };
 }
 
 const sentToAnalyst = message("m_1", "2026-08-25T10:00:00.000Z", [
@@ -30,6 +35,47 @@ describe("peer conversations", () => {
     expect(conversations[0]?.peerBotName).toBe("Analyst");
     expect(conversations[0]?.messages).toHaveLength(2);
     expect(conversations[0]?.lastText).toBe("done");
+  });
+
+  it("includes the generated reply from a bot-message run", () => {
+    const received = message(
+      "m_4",
+      "2026-08-25T10:03:00.000Z",
+      [
+        {
+          kind: "bot_message_received",
+          fromBotId: "b_2",
+          fromBotName: "Analyst",
+          text: "status?",
+        },
+      ],
+      { role: "user", runId: "run-peer" },
+    );
+    const generatedReply = message(
+      "m_5",
+      "2026-08-25T10:04:00.000Z",
+      [
+        { kind: "steps", steps: [{ label: "Research", count: 1 }], durationMs: 100 },
+        { kind: "text", text: "The report is ready." },
+      ],
+      { role: "bot", runId: "run-peer" },
+    );
+
+    expect(peerMessagesFrom([received, generatedReply])).toEqual([
+      expect.objectContaining({ direction: "received", text: "status?" }),
+      expect.objectContaining({ direction: "sent", text: "The report is ready." }),
+    ]);
+  });
+
+  it("does not attribute ordinary bot text to a peer conversation", () => {
+    const generatedReply = message(
+      "m_5",
+      "2026-08-25T10:04:00.000Z",
+      [{ kind: "text", text: "Visible human reply" }],
+      { role: "bot", runId: "run-human" },
+    );
+
+    expect(peerMessagesFrom([generatedReply])).toEqual([]);
   });
 
   it("orders conversations by most recent activity", () => {

--- a/apps/web/src/lib/peer-messages.test.ts
+++ b/apps/web/src/lib/peer-messages.test.ts
@@ -67,6 +67,41 @@ describe("peer conversations", () => {
     ]);
   });
 
+  it("does not duplicate a generated reply that was explicitly sent to the same peer", () => {
+    const received = message(
+      "m_4",
+      "2026-08-25T10:03:00.000Z",
+      [
+        {
+          kind: "bot_message_received",
+          fromBotId: "b_2",
+          fromBotName: "Analyst",
+          text: "status?",
+        },
+      ],
+      { role: "user", runId: "run-peer" },
+    );
+    const generatedReply = message(
+      "m_5",
+      "2026-08-25T10:04:00.000Z",
+      [{ kind: "text", text: "NO-SHIP" }],
+      { role: "bot", runId: "run-peer" },
+    );
+    const sentReceipt = message(
+      "m_6",
+      "2026-08-25T10:04:00.018Z",
+      [{ kind: "bot_message_sent", toBotId: "b_2", toBotName: "Analyst", text: "NO-SHIP" }],
+      { role: "bot", runId: "run-peer" },
+    );
+
+    const peerMessages = peerMessagesFrom([received, generatedReply, sentReceipt]);
+
+    expect(peerMessages).toHaveLength(2);
+    expect(peerMessages.filter((entry) => entry.text === "NO-SHIP")).toEqual([
+      expect.objectContaining({ messageId: "m_6", direction: "sent" }),
+    ]);
+  });
+
   it("does not attribute ordinary bot text to a peer conversation", () => {
     const generatedReply = message(
       "m_5",

--- a/apps/web/src/lib/peer-messages.test.ts
+++ b/apps/web/src/lib/peer-messages.test.ts
@@ -1,6 +1,6 @@
 import type { ThreadMessage } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
-import { peerConversations, peerMessagesFrom } from "./peer-messages.js";
+import { hasPeerConversation, peerConversations, peerMessagesFrom } from "./peer-messages.js";
 
 function message(
   id: string,
@@ -90,5 +90,18 @@ describe("peer conversations", () => {
 
   it("finds nothing in a thread with no peer traffic", () => {
     expect(peerConversations([plainText])).toEqual([]);
+  });
+});
+
+describe("hasPeerConversation", () => {
+  it("is true when the selected peer appears in loaded pages", () => {
+    expect(hasPeerConversation([sentToAnalyst, replyFromAnalyst, plainText], "b_2")).toBe(true);
+  });
+
+  it("is false when loaded pages only contain other peers", () => {
+    const other = message("m_other", "2026-08-25T09:00:00.000Z", [
+      { kind: "bot_message_sent", toBotId: "b_9", toBotName: "Other", text: "hi" },
+    ]);
+    expect(hasPeerConversation([other], "b_2")).toBe(false);
   });
 });

--- a/apps/web/src/lib/peer-messages.ts
+++ b/apps/web/src/lib/peer-messages.ts
@@ -103,3 +103,11 @@ export function peerConversations(messages: readonly ThreadMessage[]): PeerConve
   }
   return [...byPeer.values()].sort((a, b) => b.lastAt.localeCompare(a.lastAt));
 }
+
+/** True when loaded history already includes the selected peer exchange. */
+export function hasPeerConversation(
+  messages: readonly ThreadMessage[],
+  peerBotId: string,
+): boolean {
+  return peerConversations(messages).some((entry) => entry.peerBotId === peerBotId);
+}

--- a/apps/web/src/lib/peer-messages.ts
+++ b/apps/web/src/lib/peer-messages.ts
@@ -23,9 +23,25 @@ export function isPeerBlock(block: MessageBlock): block is PeerBlock {
   return block.kind === "bot_message_sent" || block.kind === "bot_message_received";
 }
 
+function sentReplyKey(runId: string, peerBotId: string, text: string): string {
+  return `${runId}\0${peerBotId}\0${text.trim()}`;
+}
+
 export function peerMessagesFrom(messages: readonly ThreadMessage[]): PeerMessage[] {
   const collected: PeerMessage[] = [];
   const receivedPeerByRun = new Map<string, { id: string; name: string }>();
+  const explicitSentReplies = new Set<string>();
+
+  // The explicit sent receipt can be published after the run's final text, so
+  // index the full history before deciding whether a generated reply is needed.
+  for (const message of messages) {
+    if (!message.runId) continue;
+    for (const block of message.blocks) {
+      if (block.kind !== "bot_message_sent") continue;
+      explicitSentReplies.add(sentReplyKey(message.runId, block.toBotId, block.text));
+    }
+  }
+
   for (const message of messages) {
     for (const block of message.blocks) {
       if (!isPeerBlock(block)) continue;
@@ -65,7 +81,9 @@ export function peerMessagesFrom(messages: readonly ThreadMessage[]): PeerMessag
         .flatMap((block) => (block.kind === "text" ? [block.text] : []))
         .join("\n\n")
         .trim();
-      if (text) {
+      const alreadySent =
+        message.runId && explicitSentReplies.has(sentReplyKey(message.runId, replyPeer.id, text));
+      if (text && !alreadySent) {
         collected.push({
           messageId: message.id,
           direction: "sent",

--- a/apps/web/src/lib/peer-messages.ts
+++ b/apps/web/src/lib/peer-messages.ts
@@ -25,9 +25,16 @@ export function isPeerBlock(block: MessageBlock): block is PeerBlock {
 
 export function peerMessagesFrom(messages: readonly ThreadMessage[]): PeerMessage[] {
   const collected: PeerMessage[] = [];
+  const receivedPeerByRun = new Map<string, { id: string; name: string }>();
   for (const message of messages) {
     for (const block of message.blocks) {
       if (!isPeerBlock(block)) continue;
+      if (block.kind === "bot_message_received" && message.runId) {
+        receivedPeerByRun.set(message.runId, {
+          id: block.fromBotId,
+          name: block.fromBotName,
+        });
+      }
       collected.push(
         block.kind === "bot_message_sent"
           ? {
@@ -47,6 +54,27 @@ export function peerMessagesFrom(messages: readonly ThreadMessage[]): PeerMessag
               createdAt: message.createdAt,
             },
       );
+    }
+
+    // A bot_message-triggered run stores its generated reply as ordinary bot
+    // text on the same run. Preserve that outgoing reply in the dedicated peer
+    // conversation as well as its concise summary in the human transcript.
+    const replyPeer = message.runId ? receivedPeerByRun.get(message.runId) : undefined;
+    if (message.role === "bot" && replyPeer) {
+      const text = message.blocks
+        .flatMap((block) => (block.kind === "text" ? [block.text] : []))
+        .join("\n\n")
+        .trim();
+      if (text) {
+        collected.push({
+          messageId: message.id,
+          direction: "sent",
+          peerBotId: replyPeer.id,
+          peerBotName: replyPeer.name,
+          text,
+          createdAt: message.createdAt,
+        });
+      }
     }
   }
   return collected;

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -41,8 +41,7 @@ export function PeerMessagesOverlay({
 
   useEffect(() => {
     let cancelled = false;
-    const abort = new AbortController();
-    const timeout = window.setTimeout(() => abort.abort(), 15_000);
+    const lifecycleAbort = new AbortController();
     setHistoryReady(false);
     setHistoryFailed(false);
     setMessages([]);
@@ -50,28 +49,31 @@ export function PeerMessagesOverlay({
       let before: number | undefined;
       let collected: ThreadMessage[] = [];
       do {
-        const page = await rpc.threads.messages(
-          { botId, before, includePeerRuns: true },
-          { signal: abort.signal },
-        );
+        const pageAbort = new AbortController();
+        const abortPage = () => pageAbort.abort();
+        lifecycleAbort.signal.addEventListener("abort", abortPage, { once: true });
+        const timeout = window.setTimeout(abortPage, 15_000);
+        const page = await rpc.threads
+          .messages({ botId, before, includePeerRuns: true }, { signal: pageAbort.signal })
+          .finally(() => {
+            window.clearTimeout(timeout);
+            lifecycleAbort.signal.removeEventListener("abort", abortPage);
+          });
         if (cancelled) return;
         collected = [...page.messages, ...collected];
         before = page.olderCursor ?? undefined;
       } while (before !== undefined);
       if (cancelled) return;
-      window.clearTimeout(timeout);
       setMessages(collected);
       setHistoryReady(true);
     })().catch(() => {
       if (cancelled) return;
-      window.clearTimeout(timeout);
       setHistoryFailed(true);
       setHistoryReady(true);
     });
     return () => {
       cancelled = true;
-      window.clearTimeout(timeout);
-      abort.abort();
+      lifecycleAbort.abort();
     };
   }, [botId, reloadKey]);
 

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -41,14 +41,18 @@ export function PeerMessagesOverlay({
 
   useEffect(() => {
     let cancelled = false;
+    let historyDeadlineReached = false;
+    let collected: ThreadMessage[] = [];
     const lifecycleAbort = new AbortController();
-    const historyTimeout = window.setTimeout(() => lifecycleAbort.abort(), 60_000);
+    const historyTimeout = window.setTimeout(() => {
+      historyDeadlineReached = true;
+      lifecycleAbort.abort();
+    }, 60_000);
     setHistoryReady(false);
     setHistoryFailed(false);
     setMessages([]);
     void (async () => {
       let before: number | undefined;
-      let collected: ThreadMessage[] = [];
       do {
         const pageAbort = new AbortController();
         const abortPage = () => pageAbort.abort();
@@ -70,7 +74,11 @@ export function PeerMessagesOverlay({
     })()
       .catch(() => {
         if (cancelled) return;
-        setHistoryFailed(true);
+        if (historyDeadlineReached && collected.length > 0) {
+          setMessages(collected);
+        } else {
+          setHistoryFailed(true);
+        }
         setHistoryReady(true);
       })
       .finally(() => window.clearTimeout(historyTimeout));

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -3,7 +3,7 @@ import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type { ThreadMessage } from "@rakazo/contracts";
 import { BotAvatar, Button, Dialog, DialogClose, DialogContent, DialogTitle } from "@rakazo/ui-web";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { peerConversations } from "../lib/peer-messages";
+import { hasPeerConversation, peerConversations } from "../lib/peer-messages";
 import { rpc } from "../lib/rpc";
 
 /**
@@ -74,7 +74,12 @@ export function PeerMessagesOverlay({
     })()
       .catch(() => {
         if (cancelled) return;
-        if (historyDeadlineReached && collected.length > 0) {
+        // Deadline with pages: show only if the selected peer is present; else Retry.
+        if (
+          historyDeadlineReached &&
+          collected.length > 0 &&
+          hasPeerConversation(collected, peerBotId)
+        ) {
           setMessages(collected);
         } else {
           setHistoryFailed(true);
@@ -87,7 +92,7 @@ export function PeerMessagesOverlay({
       window.clearTimeout(historyTimeout);
       lifecycleAbort.abort();
     };
-  }, [botId, reloadKey]);
+  }, [botId, peerBotId, reloadKey]);
 
   useLayoutEffect(() => {
     const element = transcriptRef.current;

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -42,6 +42,7 @@ export function PeerMessagesOverlay({
   useEffect(() => {
     let cancelled = false;
     const lifecycleAbort = new AbortController();
+    const historyTimeout = window.setTimeout(() => lifecycleAbort.abort(), 60_000);
     setHistoryReady(false);
     setHistoryFailed(false);
     setMessages([]);
@@ -66,13 +67,16 @@ export function PeerMessagesOverlay({
       if (cancelled) return;
       setMessages(collected);
       setHistoryReady(true);
-    })().catch(() => {
-      if (cancelled) return;
-      setHistoryFailed(true);
-      setHistoryReady(true);
-    });
+    })()
+      .catch(() => {
+        if (cancelled) return;
+        setHistoryFailed(true);
+        setHistoryReady(true);
+      })
+      .finally(() => window.clearTimeout(historyTimeout));
     return () => {
       cancelled = true;
+      window.clearTimeout(historyTimeout);
       lifecycleAbort.abort();
     };
   }, [botId, reloadKey]);

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -3,6 +3,7 @@ import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type { ThreadMessage } from "@rakazo/contracts";
 import { BotAvatar, Button, Dialog, DialogClose, DialogContent, DialogTitle } from "@rakazo/ui-web";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { linkAbortSignal } from "../lib/link-abort-signal";
 import { hasPeerConversation, peerConversations } from "../lib/peer-messages";
 import { rpc } from "../lib/rpc";
 
@@ -57,13 +58,15 @@ export function PeerMessagesOverlay({
       const loadPage = async (target: { before?: number; around?: { messageId: string } }) => {
         const pageAbort = new AbortController();
         const abortPage = () => pageAbort.abort();
-        lifecycleAbort.signal.addEventListener("abort", abortPage, { once: true });
+        // If the cumulative deadline already fired between pages, abort now —
+        // a late addEventListener would miss the abort and wait on the page timer.
+        const unlink = linkAbortSignal(lifecycleAbort.signal, abortPage);
         const timeout = window.setTimeout(abortPage, 15_000);
         return rpc.threads
           .messages({ botId, ...target, includePeerRuns: true }, { signal: pageAbort.signal })
           .finally(() => {
             window.clearTimeout(timeout);
-            lifecycleAbort.signal.removeEventListener("abort", abortPage);
+            unlink();
           });
       };
 
@@ -75,6 +78,10 @@ export function PeerMessagesOverlay({
 
       let before: number | undefined;
       do {
+        if (cancelled) return;
+        if (historyDeadlineReached || lifecycleAbort.signal.aborted) {
+          throw new DOMException("Peer history deadline reached", "AbortError");
+        }
         const page = await loadPage(before === undefined ? {} : { before });
         if (cancelled) return;
         const merged = new Map(collected.map((message) => [message.id, message]));

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -17,6 +17,7 @@ export function PeerMessagesOverlay({
   peerBotId,
   peerBotName: initialPeerBotName,
   peerBotColor,
+  anchorMessageId,
   onClose,
 }: {
   botId: string;
@@ -25,6 +26,7 @@ export function PeerMessagesOverlay({
   peerBotId: string;
   peerBotName: string;
   peerBotColor: string;
+  anchorMessageId: string;
   onClose: () => void;
 }) {
   const { t } = useLingui();
@@ -52,20 +54,32 @@ export function PeerMessagesOverlay({
     setHistoryFailed(false);
     setMessages([]);
     void (async () => {
-      let before: number | undefined;
-      do {
+      const loadPage = async (target: { before?: number; around?: { messageId: string } }) => {
         const pageAbort = new AbortController();
         const abortPage = () => pageAbort.abort();
         lifecycleAbort.signal.addEventListener("abort", abortPage, { once: true });
         const timeout = window.setTimeout(abortPage, 15_000);
-        const page = await rpc.threads
-          .messages({ botId, before, includePeerRuns: true }, { signal: pageAbort.signal })
+        return rpc.threads
+          .messages({ botId, ...target, includePeerRuns: true }, { signal: pageAbort.signal })
           .finally(() => {
             window.clearTimeout(timeout);
             lifecycleAbort.signal.removeEventListener("abort", abortPage);
           });
+      };
+
+      // Seed the transcript around the receipt the user clicked. Even when a
+      // very large history hits the total deadline, the selected exchange is
+      // therefore present in the partial transcript we render.
+      const anchorPage = await loadPage({ around: { messageId: anchorMessageId } });
+      collected = [...anchorPage.messages];
+
+      let before: number | undefined;
+      do {
+        const page = await loadPage(before === undefined ? {} : { before });
         if (cancelled) return;
-        collected = [...page.messages, ...collected];
+        const merged = new Map(collected.map((message) => [message.id, message]));
+        for (const message of page.messages) merged.set(message.id, message);
+        collected = [...merged.values()].sort((a, b) => a.seq - b.seq);
         before = page.olderCursor ?? undefined;
       } while (before !== undefined);
       if (cancelled) return;
@@ -92,7 +106,7 @@ export function PeerMessagesOverlay({
       window.clearTimeout(historyTimeout);
       lifecycleAbort.abort();
     };
-  }, [botId, peerBotId, reloadKey]);
+  }, [anchorMessageId, botId, peerBotId, reloadKey]);
 
   useLayoutEffect(() => {
     const element = transcriptRef.current;

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -2,7 +2,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type { ThreadMessage } from "@rakazo/contracts";
 import { BotAvatar, Button, Dialog, DialogClose, DialogContent, DialogTitle } from "@rakazo/ui-web";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { peerConversations } from "../lib/peer-messages";
 import { rpc } from "../lib/rpc";
 
@@ -31,39 +31,55 @@ export function PeerMessagesOverlay({
   const [messages, setMessages] = useState<readonly ThreadMessage[]>([]);
   const [historyReady, setHistoryReady] = useState(false);
   const [historyFailed, setHistoryFailed] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
   const conversation = useMemo(() => {
     if (!historyReady) return null;
     return peerConversations(messages).find((entry) => entry.peerBotId === peerBotId) ?? null;
   }, [historyReady, messages, peerBotId]);
   const peerBotName = conversation?.peerBotName ?? initialPeerBotName;
-  const loadRef = useRef({ botId });
+  const transcriptRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let cancelled = false;
-    const { botId: id } = loadRef.current;
+    const abort = new AbortController();
+    const timeout = window.setTimeout(() => abort.abort(), 15_000);
     setHistoryReady(false);
     setHistoryFailed(false);
+    setMessages([]);
     void (async () => {
       let before: number | undefined;
       let collected: ThreadMessage[] = [];
       do {
-        const page = await rpc.threads.messages({ botId: id, before, includePeerRuns: true });
+        const page = await rpc.threads.messages(
+          { botId, before, includePeerRuns: true },
+          { signal: abort.signal },
+        );
         if (cancelled) return;
         collected = [...page.messages, ...collected];
         before = page.olderCursor ?? undefined;
       } while (before !== undefined);
       if (cancelled) return;
+      window.clearTimeout(timeout);
       setMessages(collected);
       setHistoryReady(true);
     })().catch(() => {
       if (cancelled) return;
+      window.clearTimeout(timeout);
       setHistoryFailed(true);
       setHistoryReady(true);
     });
     return () => {
       cancelled = true;
+      window.clearTimeout(timeout);
+      abort.abort();
     };
-  }, []);
+  }, [botId, reloadKey]);
+
+  useLayoutEffect(() => {
+    const element = transcriptRef.current;
+    if (!conversation || !element) return;
+    element.scrollTop = element.scrollHeight;
+  }, [conversation]);
 
   const title = `${botName} · ${peerBotName}`;
 
@@ -100,7 +116,16 @@ export function PeerMessagesOverlay({
           </div>
         ) : historyFailed ? (
           <div className="grid flex-1 place-items-center px-8 text-center text-[13.5px] text-muted-foreground/80">
-            <Trans>Could not load this chat.</Trans>
+            <div className="flex flex-col items-center gap-3">
+              <Trans>Could not load this chat.</Trans>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setReloadKey((value) => value + 1)}
+              >
+                <Trans>Retry</Trans>
+              </Button>
+            </div>
           </div>
         ) : !conversation || conversation.messages.length === 0 ? (
           <div className="grid flex-1 place-items-center px-8 text-center text-[13.5px] text-muted-foreground/80">
@@ -108,6 +133,7 @@ export function PeerMessagesOverlay({
           </div>
         ) : (
           <div
+            ref={transcriptRef}
             data-testid="peer-conversation-transcript"
             className="rk-scroll flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
           >

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1749,6 +1749,29 @@ export function ShellPage() {
   const jumpToMessageRef = useRef(jumpToMessage);
   jumpToMessageRef.current = jumpToMessage;
 
+  useEffect(() => {
+    const refreshActiveTranscript = () => {
+      if (document.visibilityState !== "visible") return;
+      const currentGroupId = activeGroupId.current;
+      if (currentGroupId) {
+        void refreshGroupThreadRef.current(currentGroupId).catch(() => undefined);
+        return;
+      }
+      const currentBotId = activeBotId.current;
+      if (currentBotId) {
+        void refreshThreadRef.current(currentBotId).catch(() => undefined);
+      }
+    };
+    window.addEventListener("focus", refreshActiveTranscript);
+    window.addEventListener("online", refreshActiveTranscript);
+    document.addEventListener("visibilitychange", refreshActiveTranscript);
+    return () => {
+      window.removeEventListener("focus", refreshActiveTranscript);
+      window.removeEventListener("online", refreshActiveTranscript);
+      document.removeEventListener("visibilitychange", refreshActiveTranscript);
+    };
+  }, []);
+
   const mentionBotsKey = useMemo(
     () => bots.map((bot) => `${bot.id}:${bot.name}`).join(","),
     [bots],
@@ -3169,6 +3192,7 @@ export function ShellPage() {
           scrollRef={messageScroll}
           artifactTarget={transcriptArtifactTarget}
           messages={transcriptMessages}
+          loading={!activeSnapshot}
           olderCursor={activeSnapshot?.olderCursor ?? null}
           loadingOlder={loadingOlder}
           answerableAskMessageId={answerableAskMessageId}
@@ -4077,6 +4101,7 @@ const Transcript = memo(function Transcript({
   scrollRef,
   artifactTarget,
   messages,
+  loading,
   olderCursor,
   loadingOlder,
   answerableAskMessageId,
@@ -4101,6 +4126,7 @@ const Transcript = memo(function Transcript({
   scrollRef: RefObject<HTMLDivElement | null>;
   artifactTarget: ArtifactTarget;
   messages: ThreadMessage[];
+  loading: boolean;
   olderCursor: number | null;
   loadingOlder: boolean;
   answerableAskMessageId: string | null;
@@ -4245,6 +4271,11 @@ const Transcript = memo(function Transcript({
         }}
         className="rk-scroll flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-4 py-5 md:px-7 md:py-6"
       >
+        {loading ? (
+          <div className="grid min-h-full place-items-center text-[13.5px] text-muted-foreground/80">
+            <Trans>Loading…</Trans>
+          </div>
+        ) : null}
         {olderCursor != null ? (
           <button
             type="button"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -338,6 +338,7 @@ export function ShellPage() {
   const [peerConversation, setPeerConversation] = useState<{
     peerBotId: string;
     peerBotName: string;
+    messageId: string;
   } | null>(null);
   const [routines, setRoutines] = useState<Routine[]>([]);
   const [routinesBotId, setRoutinesBotId] = useState<string | null>(null);
@@ -3914,6 +3915,7 @@ export function ShellPage() {
             botColor={active.color}
             peerBotId={peerConversation.peerBotId}
             peerBotName={peerConversation.peerBotName}
+            anchorMessageId={peerConversation.messageId}
             peerBotColor={
               resolveTranscriptBot(peerConversation.peerBotId)?.color ?? FALLBACK_BOT_COLOR
             }
@@ -4147,7 +4149,7 @@ const Transcript = memo(function Transcript({
   onReply: (message: ThreadMessage) => void;
   onReact: (message: ThreadMessage) => Promise<void>;
   onJumpToMessage: (messageId: string) => void;
-  onOpenPeerMessages: (peer: { peerBotId: string; peerBotName: string }) => void;
+  onOpenPeerMessages: (peer: { peerBotId: string; peerBotName: string; messageId: string }) => void;
   memberName?: (botId: string | undefined) => string | undefined;
   peerBot: (botId: string) => { color: string; status?: string } | undefined;
   onRefresh: () => Promise<void>;
@@ -5242,7 +5244,7 @@ const MessageView = memo(function MessageView({
   message: ThreadMessage;
   onAnswer: (message: ThreadMessage, text: string) => Promise<void>;
   onOpenBot: (botId: string) => void;
-  onOpenPeerMessages: (peer: { peerBotId: string; peerBotName: string }) => void;
+  onOpenPeerMessages: (peer: { peerBotId: string; peerBotName: string; messageId: string }) => void;
   speakerName?: string;
   memberName?: (botId: string | undefined) => string | undefined;
   peerBot: (botId: string) => { color: string; status?: string } | undefined;
@@ -5354,7 +5356,9 @@ const MessageView = memo(function MessageView({
               color={peerBot(peerBotId)?.color ?? FALLBACK_BOT_COLOR}
               identity={peerBotId}
               label={label}
-              onClick={() => onOpenPeerMessages({ peerBotId, peerBotName: peer })}
+              onClick={() =>
+                onOpenPeerMessages({ peerBotId, peerBotName: peer, messageId: message.id })
+              }
             />
           );
         }

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -1750,22 +1750,31 @@ export function ShellPage() {
   jumpToMessageRef.current = jumpToMessage;
 
   useEffect(() => {
+    let activeRefresh: AbortController | undefined;
     const refreshActiveTranscript = () => {
       if (document.visibilityState !== "visible") return;
+      activeRefresh?.abort();
+      const controller = new AbortController();
+      activeRefresh = controller;
       const currentGroupId = activeGroupId.current;
       if (currentGroupId) {
-        void refreshGroupThreadRef.current(currentGroupId).catch(() => undefined);
+        void refreshGroupThreadRef
+          .current(currentGroupId, threadSnapshotSignal(controller.signal))
+          .catch(() => undefined);
         return;
       }
       const currentBotId = activeBotId.current;
       if (currentBotId) {
-        void refreshThreadRef.current(currentBotId).catch(() => undefined);
+        void refreshThreadRef
+          .current(currentBotId, threadSnapshotSignal(controller.signal))
+          .catch(() => undefined);
       }
     };
     window.addEventListener("focus", refreshActiveTranscript);
     window.addEventListener("online", refreshActiveTranscript);
     document.addEventListener("visibilitychange", refreshActiveTranscript);
     return () => {
+      activeRefresh?.abort();
       window.removeEventListener("focus", refreshActiveTranscript);
       window.removeEventListener("online", refreshActiveTranscript);
       document.removeEventListener("visibilitychange", refreshActiveTranscript);

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -3223,7 +3223,16 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 flushPendingTools();
                 if (!(await renewRunLease(deps, runId, workerId, fence))) return;
                 if (messageSegments.length > 0) {
-                  await publishMessage(deps, run, "bot", redactBlocks(messageSegments, runSecrets));
+                  await publishMessage(
+                    deps,
+                    run,
+                    "bot",
+                    redactBlocks(messageSegments, runSecrets),
+                    undefined,
+                    run.trigger === "bot_message"
+                      ? userProgressClientNonce(run.id, midTurnProgressCount++)
+                      : undefined,
+                  );
                 }
                 await workspaceCheckpoint.flush();
                 terminalCheckpointComplete = true;

--- a/packages/adapters/src/user-progress.ts
+++ b/packages/adapters/src/user-progress.ts
@@ -1,5 +1,7 @@
 import type { MessageBlock } from "@rakazo/contracts";
-import { isToolActivityBlock } from "@rakazo/core";
+import { isToolActivityBlock, USER_PROGRESS_CLIENT_NONCE_PREFIX } from "@rakazo/core";
+
+export { isUserProgressClientNonce, USER_PROGRESS_CLIENT_NONCE_PREFIX } from "@rakazo/core";
 
 /** Keep mid-turn progress beats short; prefer a few high-signal updates. */
 export const USER_PROGRESS_MESSAGE_MAX_LENGTH = 500;
@@ -16,17 +18,10 @@ export function clampUserProgressMessage(text: string): string {
  * as a durable mid-turn message. Tool/step blocks stay for the final publish.
  */
 
-/** clientNonce prefix for mid-turn progress messages (reconciler uses this). */
-export const USER_PROGRESS_CLIENT_NONCE_PREFIX = "user-progress:";
-
 export function userProgressClientNonce(runId: string, index = 0): string {
   // Include entropy so a resumed executor turn cannot reuse an earlier nonce
   // (threadId + clientNonce is unique).
   return `${USER_PROGRESS_CLIENT_NONCE_PREFIX}${runId}:${index}:${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 10)}`;
-}
-
-export function isUserProgressClientNonce(clientNonce: string | null | undefined): boolean {
-  return Boolean(clientNonce?.startsWith(USER_PROGRESS_CLIENT_NONCE_PREFIX));
 }
 
 export function extractNarrationText(

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -25,6 +25,7 @@ const peerExchange = [
       fromBotId: "coder",
       fromBotName: "Coder",
       text: "Done.",
+      intent: "result",
     },
   ]),
   message("activity", "run-peer", [{ kind: "steps", steps: [{ label: "Message bot", count: 1 }] }]),
@@ -41,6 +42,23 @@ describe("user-visible messages", () => {
     ]);
   });
 
+  it("keeps an assigned worker's reply out of the user transcript", () => {
+    const workerExchange = [
+      message("received", "run-worker", [
+        {
+          kind: "bot_message_received" as const,
+          fromBotId: "coordinator",
+          fromBotName: "Coordinator",
+          text: "Check this.",
+          intent: "request" as const,
+        },
+      ]),
+      message("reply", "run-worker", [{ kind: "text", text: "The check passed." }]),
+    ];
+
+    expect(userVisibleMessages(workerExchange).map((item) => item.id)).toEqual([]);
+  });
+
   it("keeps compact peer receipts when includePeerReceipts is set", () => {
     expect(
       userVisibleMessages(peerExchange, { includePeerReceipts: true }).map((item) => item.id),
@@ -54,7 +72,10 @@ describe("user-visible messages", () => {
     ];
 
     expect(
-      userVisibleMessages(messages, { knownPeerRunIds: ["run-peer"] }).map((item) => item.id),
+      userVisibleMessages(messages, {
+        knownPeerRunIds: ["run-peer"],
+        knownPeerReportRunIds: ["run-peer"],
+      }).map((item) => item.id),
     ).toEqual(["reply", "answer"]);
   });
 

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -59,6 +59,26 @@ describe("user-visible messages", () => {
     expect(userVisibleMessages(workerExchange).map((item) => item.id)).toEqual([]);
   });
 
+  it("keeps an assigned worker's takeover request visible", () => {
+    const workerExchange = [
+      message("received", "run-worker", [
+        {
+          kind: "bot_message_received",
+          fromBotId: "coordinator",
+          fromBotName: "Coordinator",
+          text: "Check staging.",
+          intent: "request",
+        },
+      ]),
+      message("takeover", "run-worker", [
+        { kind: "computer", state: "Ready", text: "Please complete the staging login." },
+      ]),
+      message("reply", "run-worker", [{ kind: "text", text: "Waiting for login." }]),
+    ];
+
+    expect(userVisibleMessages(workerExchange).map((item) => item.id)).toEqual(["takeover"]);
+  });
+
   it("keeps compact peer receipts when includePeerReceipts is set", () => {
     expect(
       userVisibleMessages(peerExchange, { includePeerReceipts: true }).map((item) => item.id),

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -33,14 +33,18 @@ const peerExchange = [
 ];
 
 describe("user-visible messages", () => {
-  it("keeps bot-to-bot exchanges out of the user transcript", () => {
-    expect(userVisibleMessages(peerExchange).map((item) => item.id)).toEqual(["user", "answer"]);
+  it("keeps a bot's final peer-work summary without exposing the peer exchange", () => {
+    expect(userVisibleMessages(peerExchange).map((item) => item.id)).toEqual([
+      "user",
+      "reply",
+      "answer",
+    ]);
   });
 
   it("keeps compact peer receipts when includePeerReceipts is set", () => {
     expect(
       userVisibleMessages(peerExchange, { includePeerReceipts: true }).map((item) => item.id),
-    ).toEqual(["user", "sent", "received", "answer"]);
+    ).toEqual(["user", "sent", "received", "reply", "answer"]);
   });
 
   it("uses authoritative peer run ids when the receipt is outside the loaded page", () => {
@@ -51,6 +55,6 @@ describe("user-visible messages", () => {
 
     expect(
       userVisibleMessages(messages, { knownPeerRunIds: ["run-peer"] }).map((item) => item.id),
-    ).toEqual(["answer"]);
+    ).toEqual(["reply", "answer"]);
   });
 });

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -89,4 +89,64 @@ describe("user-visible messages", () => {
       userVisibleMessages([progress], { knownPeerRunIds: ["run-peer"] }).map((item) => item.id),
     ).toEqual([]);
   });
+
+  it("keeps untagged mid-turn text on a peer-report run hidden while a terminal summary still shows", () => {
+    const messages = [
+      {
+        ...message("received", "run-peer", [
+          {
+            kind: "bot_message_received" as const,
+            fromBotId: "coder",
+            fromBotName: "Coder",
+            text: "Done.",
+            intent: "result" as const,
+          },
+        ]),
+        seq: 1,
+      },
+      {
+        ...message("progress", "run-peer", [
+          { kind: "text" as const, text: "Still drafting the report." },
+        ]),
+        seq: 2,
+      },
+      {
+        ...message("summary", "run-peer", [
+          { kind: "text" as const, text: "Coder finished the review." },
+        ]),
+        seq: 3,
+      },
+    ];
+
+    expect(userVisibleMessages(messages).map((item) => item.id)).toEqual(["summary"]);
+  });
+
+  it("picks the latest peer summary by seq when messages are newest-first", () => {
+    const messages = [
+      {
+        ...message("summary", "run-peer", [{ kind: "text" as const, text: "Final report." }]),
+        seq: 3,
+      },
+      {
+        ...message("progress", "run-peer", [
+          { kind: "text" as const, text: "Still drafting the report." },
+        ]),
+        seq: 2,
+      },
+      {
+        ...message("received", "run-peer", [
+          {
+            kind: "bot_message_received" as const,
+            fromBotId: "coder",
+            fromBotName: "Coder",
+            text: "Done.",
+            intent: "result" as const,
+          },
+        ]),
+        seq: 1,
+      },
+    ];
+
+    expect(userVisibleMessages(messages).map((item) => item.id)).toEqual(["summary"]);
+  });
 });

--- a/packages/core/src/message-visibility.test.ts
+++ b/packages/core/src/message-visibility.test.ts
@@ -57,4 +57,15 @@ describe("user-visible messages", () => {
       userVisibleMessages(messages, { knownPeerRunIds: ["run-peer"] }).map((item) => item.id),
     ).toEqual(["reply", "answer"]);
   });
+
+  it("keeps mid-turn peer narration hidden", () => {
+    const progress = {
+      ...message("progress", "run-peer", [{ kind: "text" as const, text: "Still checking." }]),
+      clientNonce: "user-progress:run-peer:0:test",
+    };
+
+    expect(
+      userVisibleMessages([progress], { knownPeerRunIds: ["run-peer"] }).map((item) => item.id),
+    ).toEqual([]);
+  });
 });

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -32,6 +32,11 @@ export function isPeerReceiptBlocks(blocks: readonly MessageBlock[]): boolean {
   );
 }
 
+/** A computer card requires the owner to take over and must never be hidden. */
+export function isTakeoverRequestBlocks(blocks: readonly MessageBlock[]): boolean {
+  return blocks.some((block) => block.kind === "computer");
+}
+
 /** A peer wake that reports information back, rather than assigning hidden work. */
 export function isPeerReportBlocks(blocks: readonly MessageBlock[]): boolean {
   return blocks.some(
@@ -110,6 +115,7 @@ export function userVisibleMessages<T extends PresentableMessage>(
   const terminalSummaryIndexes = terminalPeerSummaryIndexes(messages, peerReportRunIds);
 
   return messages.filter((message, index) => {
+    if (isTakeoverRequestBlocks(message.blocks)) return true;
     if (isPeerReceiptBlocks(message.blocks)) return includePeerReceipts;
     if (!message.runId || !peerRunIds.has(message.runId)) return true;
     return peerReportRunIds.has(message.runId) && terminalSummaryIndexes.has(index);

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -21,7 +21,12 @@ export function isPeerReceiptBlocks(blocks: readonly MessageBlock[]): boolean {
   );
 }
 
-/** Drop peer-run activity/replies; optionally keep sent/received receipt rows. */
+/** A bot's final summary after peer work, without the underlying peer transcript. */
+export function isPeerSummaryBlocks(blocks: readonly MessageBlock[]): boolean {
+  return blocks.some((block) => block.kind === "text" && block.text.trim().length > 0);
+}
+
+/** Drop peer-run activity; keep final summaries and optionally compact receipt rows. */
 export function userVisibleMessages<T extends PresentableMessage>(
   messages: readonly T[],
   options: UserVisibleMessagesOptions = {},
@@ -36,6 +41,7 @@ export function userVisibleMessages<T extends PresentableMessage>(
 
   return messages.filter((message) => {
     if (isPeerReceiptBlocks(message.blocks)) return includePeerReceipts;
-    return !message.runId || !peerRunIds.has(message.runId);
+    if (!message.runId || !peerRunIds.has(message.runId)) return true;
+    return isPeerSummaryBlocks(message.blocks);
   });
 }

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -20,11 +20,22 @@ export type UserVisibleMessagesOptions = {
   includePeerReceipts?: boolean;
   /** Peer-run ids from `run.trigger === "bot_message"` when receipts may be out of window. */
   knownPeerRunIds?: Iterable<string>;
+  /** Peer-run ids woken by a result/status/fyi that should report to the user. */
+  knownPeerReportRunIds?: Iterable<string>;
 };
 
 export function isPeerReceiptBlocks(blocks: readonly MessageBlock[]): boolean {
   return blocks.some(
     (block) => block.kind === "bot_message_sent" || block.kind === "bot_message_received",
+  );
+}
+
+/** A peer wake that reports information back, rather than assigning hidden work. */
+export function isPeerReportBlocks(blocks: readonly MessageBlock[]): boolean {
+  return blocks.some(
+    (block) =>
+      block.kind === "bot_message_received" &&
+      (block.intent === "result" || block.intent === "status" || block.intent === "fyi"),
   );
 }
 
@@ -48,10 +59,16 @@ export function userVisibleMessages<T extends PresentableMessage>(
       .flatMap((message) => (message.runId ? [message.runId] : [])),
   ]);
   const includePeerReceipts = options.includePeerReceipts === true;
+  const peerReportRunIds = new Set([
+    ...(options.knownPeerReportRunIds ?? []),
+    ...messages
+      .filter((message) => isPeerReportBlocks(message.blocks))
+      .flatMap((message) => (message.runId ? [message.runId] : [])),
+  ]);
 
   return messages.filter((message) => {
     if (isPeerReceiptBlocks(message.blocks)) return includePeerReceipts;
     if (!message.runId || !peerRunIds.has(message.runId)) return true;
-    return isPeerSummaryMessage(message);
+    return peerReportRunIds.has(message.runId) && isPeerSummaryMessage(message);
   });
 }

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -2,6 +2,8 @@ import type { MessageBlock } from "@rakazo/contracts";
 
 type PresentableMessage = {
   runId?: string;
+  /** Present when callers can distinguish later messages across sort orders. */
+  seq?: number;
   clientNonce?: string | null;
   blocks: readonly MessageBlock[];
 };
@@ -39,12 +41,52 @@ export function isPeerReportBlocks(blocks: readonly MessageBlock[]): boolean {
   );
 }
 
-/** A bot's terminal summary after peer work, without mid-turn narration. */
+/**
+ * Candidate owner-facing text on a peer report run (not tagged mid-turn progress).
+ * Callers must still pick the latest candidate per run — earlier untagged narration
+ * is not itself a durable terminal summary.
+ */
 export function isPeerSummaryMessage(message: PresentableMessage): boolean {
   return (
     !isUserProgressClientNonce(message.clientNonce) &&
     message.blocks.some((block) => block.kind === "text" && block.text.trim().length > 0)
   );
+}
+
+function isLaterPeerSummary(
+  candidate: PresentableMessage,
+  candidateIndex: number,
+  current: PresentableMessage,
+  currentIndex: number,
+): boolean {
+  if (typeof candidate.seq === "number" && typeof current.seq === "number") {
+    return candidate.seq >= current.seq;
+  }
+  return candidateIndex >= currentIndex;
+}
+
+/**
+ * Indices of the latest peer-summary candidate per peer-report run.
+ * Prefers higher `seq` when present so desc and asc collections agree.
+ */
+export function terminalPeerSummaryIndexes(
+  messages: readonly PresentableMessage[],
+  peerReportRunIds: ReadonlySet<string>,
+): Set<number> {
+  const latestIndexByRunId = new Map<string, number>();
+  messages.forEach((message, index) => {
+    if (!message.runId || !peerReportRunIds.has(message.runId)) return;
+    if (isPeerReceiptBlocks(message.blocks)) return;
+    if (!isPeerSummaryMessage(message)) return;
+    const currentIndex = latestIndexByRunId.get(message.runId);
+    if (
+      currentIndex === undefined ||
+      isLaterPeerSummary(message, index, messages[currentIndex]!, currentIndex)
+    ) {
+      latestIndexByRunId.set(message.runId, index);
+    }
+  });
+  return new Set(latestIndexByRunId.values());
 }
 
 /** Drop peer-run activity; keep final summaries and optionally compact receipt rows. */
@@ -65,10 +107,11 @@ export function userVisibleMessages<T extends PresentableMessage>(
       .filter((message) => isPeerReportBlocks(message.blocks))
       .flatMap((message) => (message.runId ? [message.runId] : [])),
   ]);
+  const terminalSummaryIndexes = terminalPeerSummaryIndexes(messages, peerReportRunIds);
 
-  return messages.filter((message) => {
+  return messages.filter((message, index) => {
     if (isPeerReceiptBlocks(message.blocks)) return includePeerReceipts;
     if (!message.runId || !peerRunIds.has(message.runId)) return true;
-    return peerReportRunIds.has(message.runId) && isPeerSummaryMessage(message);
+    return peerReportRunIds.has(message.runId) && terminalSummaryIndexes.has(index);
   });
 }

--- a/packages/core/src/message-visibility.ts
+++ b/packages/core/src/message-visibility.ts
@@ -2,8 +2,15 @@ import type { MessageBlock } from "@rakazo/contracts";
 
 type PresentableMessage = {
   runId?: string;
+  clientNonce?: string | null;
   blocks: readonly MessageBlock[];
 };
+
+export const USER_PROGRESS_CLIENT_NONCE_PREFIX = "user-progress:";
+
+export function isUserProgressClientNonce(clientNonce: string | null | undefined): boolean {
+  return Boolean(clientNonce?.startsWith(USER_PROGRESS_CLIENT_NONCE_PREFIX));
+}
 
 export type UserVisibleMessagesOptions = {
   /**
@@ -21,9 +28,12 @@ export function isPeerReceiptBlocks(blocks: readonly MessageBlock[]): boolean {
   );
 }
 
-/** A bot's final summary after peer work, without the underlying peer transcript. */
-export function isPeerSummaryBlocks(blocks: readonly MessageBlock[]): boolean {
-  return blocks.some((block) => block.kind === "text" && block.text.trim().length > 0);
+/** A bot's terminal summary after peer work, without mid-turn narration. */
+export function isPeerSummaryMessage(message: PresentableMessage): boolean {
+  return (
+    !isUserProgressClientNonce(message.clientNonce) &&
+    message.blocks.some((block) => block.kind === "text" && block.text.trim().length > 0)
+  );
 }
 
 /** Drop peer-run activity; keep final summaries and optionally compact receipt rows. */
@@ -42,6 +52,6 @@ export function userVisibleMessages<T extends PresentableMessage>(
   return messages.filter((message) => {
     if (isPeerReceiptBlocks(message.blocks)) return includePeerReceipts;
     if (!message.runId || !peerRunIds.has(message.runId)) return true;
-    return isPeerSummaryBlocks(message.blocks);
+    return isPeerSummaryMessage(message);
   });
 }

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -311,7 +311,11 @@ describe("createRepos.listSpaceBotsForSpaces", () => {
         runs: [{ status: "running" }],
       },
     ]);
-    const repos = createRepos({ bot: { findMany } } as unknown as PrismaClient);
+    const runFindMany = vi.fn(async () => []);
+    const repos = createRepos({
+      bot: { findMany },
+      run: { findMany: runFindMany },
+    } as unknown as PrismaClient);
 
     await expect(repos.listSpaceBotsForSpaces(actor, ["ws-2"])).resolves.toEqual([
       {
@@ -336,6 +340,46 @@ describe("createRepos.listSpaceBotsForSpaces", () => {
     expect(query.select).not.toHaveProperty("description");
     expect(query.select).not.toHaveProperty("instructions");
     expect(query.select).not.toHaveProperty("computer");
+  });
+
+  it("keeps assigned worker replies out of cross-space sidebar previews", async () => {
+    const botFindMany = vi.fn(async () => [
+      {
+        id: "bot-2",
+        spaceId: "ws-2",
+        name: "Support",
+        title: "Customer support",
+        color: "#123456",
+        notifyOnFinish: false,
+        pinned: true,
+        sectionId: null,
+        updatedAt: new Date("2026-08-20T00:00:00.000Z"),
+        thread: {
+          unread: true,
+          messages: [
+            {
+              runId: "run-peer",
+              clientNonce: null,
+              blocks: [{ kind: "text", text: "Private worker result" }],
+            },
+            {
+              runId: "run-user",
+              clientNonce: null,
+              blocks: [{ kind: "text", text: "Older visible answer" }],
+            },
+          ],
+        },
+        runs: [],
+      },
+    ]);
+    const repos = createRepos({
+      bot: { findMany: botFindMany },
+      run: { findMany: vi.fn(async () => [peerRun("request")]) },
+    } as unknown as PrismaClient);
+
+    await expect(repos.listSpaceBotsForSpaces(actor, ["ws-2"])).resolves.toEqual([
+      expect.objectContaining({ preview: "Older visible answer" }),
+    ]);
   });
 });
 

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -256,6 +256,7 @@ describe("createRepos.listBots", () => {
       where: { threadId: "thread-1", seq: { lt: 20 } },
       orderBy: { seq: "desc" },
       take: 16,
+      select: { seq: true, blocks: true, runId: true, clientNonce: true },
     });
   });
 
@@ -388,6 +389,58 @@ describe("createRepos.listSpaceBotsForSpaces", () => {
         }),
       }),
     );
+  });
+
+  it("scans older messages when the newest cross-space window is only peer output", async () => {
+    const messageFindMany = vi.fn(async () => [
+      {
+        seq: 1,
+        runId: "run-user",
+        clientNonce: null,
+        blocks: [{ kind: "text", text: "Older visible answer" }],
+      },
+    ]);
+    const botFindMany = vi.fn(async () => [
+      {
+        id: "bot-2",
+        spaceId: "ws-2",
+        name: "Support",
+        title: "Customer support",
+        color: "#123456",
+        notifyOnFinish: false,
+        pinned: true,
+        sectionId: null,
+        updatedAt: new Date("2026-08-20T00:00:00.000Z"),
+        thread: {
+          id: "thread-2",
+          unread: true,
+          messages: [
+            {
+              seq: 20,
+              runId: "run-peer",
+              clientNonce: null,
+              blocks: [{ kind: "steps", steps: [{ label: "Peer work", count: 1 }] }],
+            },
+          ],
+        },
+        runs: [],
+      },
+    ]);
+    const repos = createRepos({
+      bot: { findMany: botFindMany },
+      run: { findMany: vi.fn(async () => [{ id: "run-peer" }]) },
+      message: { findMany: messageFindMany },
+    } as unknown as PrismaClient);
+
+    await expect(repos.listSpaceBotsForSpaces(actor, ["ws-2"])).resolves.toEqual([
+      expect.objectContaining({ preview: "Older visible answer" }),
+    ]);
+    expect(messageFindMany).toHaveBeenCalledWith({
+      where: { threadId: "thread-2", seq: { lt: 20 } },
+      orderBy: { seq: "desc" },
+      take: 16,
+      select: { seq: true, blocks: true, runId: true, clientNonce: true },
+    });
   });
 
   it("keeps assigned worker replies out of cross-space sidebar previews", async () => {

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -482,6 +482,51 @@ describe("createRepos.listSpaceBotsForSpaces", () => {
       expect.objectContaining({ preview: "Older visible answer" }),
     ]);
   });
+
+  it("shows assigned worker takeover requests in cross-space sidebar previews", async () => {
+    const botFindMany = vi.fn(async () => [
+      {
+        id: "bot-2",
+        spaceId: "ws-2",
+        name: "Support",
+        title: "Customer support",
+        color: "#123456",
+        notifyOnFinish: false,
+        pinned: true,
+        sectionId: null,
+        updatedAt: new Date("2026-08-20T00:00:00.000Z"),
+        thread: {
+          unread: true,
+          messages: [
+            {
+              seq: 2,
+              runId: "run-peer",
+              clientNonce: null,
+              blocks: [
+                {
+                  kind: "computer",
+                  state: "Ready",
+                  text: "Please complete the staging login.",
+                },
+              ],
+            },
+          ],
+        },
+        runs: [{ status: "waiting_takeover" }],
+      },
+    ]);
+    const repos = createRepos({
+      bot: { findMany: botFindMany },
+      run: { findMany: vi.fn(async () => [peerRun("request")]) },
+    } as unknown as PrismaClient);
+
+    await expect(repos.listSpaceBotsForSpaces(actor, ["ws-2"])).resolves.toEqual([
+      expect.objectContaining({
+        preview: "Please complete the staging login.",
+        status: "waiting_takeover",
+      }),
+    ]);
+  });
 });
 
 describe("createRepos.reorderBots", () => {

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -338,7 +338,14 @@ describe("createRepos.listSpaceBotsForSpaces", () => {
         updatedAt: new Date("2026-08-20T00:00:00.000Z"),
         thread: {
           unread: true,
-          messages: [{ blocks: [{ kind: "text", text: "Waiting for a reply" }] }],
+          messages: [
+            {
+              seq: 1,
+              runId: null,
+              clientNonce: null,
+              blocks: [{ kind: "text", text: "Waiting for a reply" }],
+            },
+          ],
         },
         runs: [{ status: "running" }],
       },
@@ -372,6 +379,15 @@ describe("createRepos.listSpaceBotsForSpaces", () => {
     expect(query.select).not.toHaveProperty("description");
     expect(query.select).not.toHaveProperty("instructions");
     expect(query.select).not.toHaveProperty("computer");
+    expect(query.select.thread).toEqual(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          messages: expect.objectContaining({
+            select: { seq: true, blocks: true, runId: true, clientNonce: true },
+          }),
+        }),
+      }),
+    );
   });
 
   it("keeps assigned worker replies out of cross-space sidebar previews", async () => {

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -128,6 +128,38 @@ describe("createRepos.listBots", () => {
     );
   });
 
+  it("prefers the latest peer-report summary over earlier untagged mid-turn narration", async () => {
+    const findMany = vi.fn(async () => [
+      {
+        ...baseBot,
+        thread: {
+          ...baseBot.thread,
+          messages: [
+            {
+              seq: 3,
+              runId: "run-peer",
+              blocks: [{ kind: "text", text: "Coder finished the review." }],
+            },
+            {
+              seq: 2,
+              runId: "run-peer",
+              blocks: [{ kind: "text", text: "Still drafting the report." }],
+            },
+            { seq: 1, runId: "run-user", blocks: [{ kind: "text", text: "Visible answer" }] },
+          ],
+        },
+      },
+    ]);
+    const prisma = {
+      bot: { findMany },
+      run: { findMany: vi.fn(async () => [peerRun()]) },
+    };
+
+    await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([
+      expect.objectContaining({ preview: "Coder finished the review." }),
+    ]);
+  });
+
   it("uses a peer-work summary when the receipt is outside the preview window", async () => {
     const prisma = {
       bot: {

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -59,7 +59,7 @@ describe("createRepos.listBots", () => {
     ]);
   });
 
-  it("keeps bot-to-bot run output out of sidebar previews", async () => {
+  it("uses a bot's final peer-work summary in sidebar previews", async () => {
     const findMany = vi.fn(async () => [
       {
         ...baseBot,
@@ -96,7 +96,7 @@ describe("createRepos.listBots", () => {
     };
 
     await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([
-      expect.objectContaining({ preview: "Visible answer" }),
+      expect.objectContaining({ preview: "Echoed peer reply" }),
     ]);
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -111,7 +111,7 @@ describe("createRepos.listBots", () => {
     );
   });
 
-  it("skips a peer-run preview tail when the receipt is outside the window", async () => {
+  it("uses a peer-work summary when the receipt is outside the preview window", async () => {
     const prisma = {
       bot: {
         findMany: vi.fn(async () => [
@@ -139,7 +139,7 @@ describe("createRepos.listBots", () => {
     };
 
     await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([
-      expect.objectContaining({ preview: "Visible answer" }),
+      expect.objectContaining({ preview: "Echoed peer reply" }),
     ]);
   });
 
@@ -158,7 +158,7 @@ describe("createRepos.listBots", () => {
                 {
                   seq: 20,
                   runId: "run-peer",
-                  blocks: [{ kind: "text", text: "Echoed peer reply" }],
+                  blocks: [{ kind: "steps", steps: [{ label: "Peer work", count: 1 }] }],
                 },
               ],
             },
@@ -185,10 +185,34 @@ describe("createRepos.listBots", () => {
 
   it("uses a visible message from the fourth older window for preview", async () => {
     const peerWindows = [
-      [{ seq: 80, runId: "run-peer", blocks: [{ kind: "text", text: "peer 80" }] }],
-      [{ seq: 60, runId: "run-peer", blocks: [{ kind: "text", text: "peer 60" }] }],
-      [{ seq: 40, runId: "run-peer", blocks: [{ kind: "text", text: "peer 40" }] }],
-      [{ seq: 20, runId: "run-peer", blocks: [{ kind: "text", text: "peer 20" }] }],
+      [
+        {
+          seq: 80,
+          runId: "run-peer",
+          blocks: [{ kind: "steps", steps: [{ label: "peer 80", count: 1 }] }],
+        },
+      ],
+      [
+        {
+          seq: 60,
+          runId: "run-peer",
+          blocks: [{ kind: "steps", steps: [{ label: "peer 60", count: 1 }] }],
+        },
+      ],
+      [
+        {
+          seq: 40,
+          runId: "run-peer",
+          blocks: [{ kind: "steps", steps: [{ label: "peer 40", count: 1 }] }],
+        },
+      ],
+      [
+        {
+          seq: 20,
+          runId: "run-peer",
+          blocks: [{ kind: "steps", steps: [{ label: "peer 20", count: 1 }] }],
+        },
+      ],
       [{ seq: 1, runId: "run-user", blocks: [{ kind: "text", text: "Fourth-window answer" }] }],
     ];
     let windowIndex = 0;

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -46,6 +46,23 @@ function reposFor(memoryScope: string | null) {
   return createRepos(prisma as unknown as PrismaClient);
 }
 
+function peerRun(intent: "request" | "result" = "result") {
+  return {
+    id: "run-peer",
+    sourceMessage: {
+      blocks: [
+        {
+          kind: "bot_message_received",
+          fromBotId: "bot-2",
+          fromBotName: "Coder",
+          text: intent === "request" ? "Check this." : "Done.",
+          intent,
+        },
+      ],
+    },
+  };
+}
+
 describe("createRepos.listBots", () => {
   it("passes memoryScope through as null when unset", async () => {
     await expect(reposFor(null).listBots(actor)).resolves.toEqual([
@@ -91,7 +108,7 @@ describe("createRepos.listBots", () => {
         findMany,
       },
       run: {
-        findMany: vi.fn(async () => [{ id: "run-peer" }]),
+        findMany: vi.fn(async () => [peerRun()]),
       },
     };
 
@@ -131,7 +148,7 @@ describe("createRepos.listBots", () => {
         ]),
       },
       run: {
-        findMany: vi.fn(async () => [{ id: "run-peer" }]),
+        findMany: vi.fn(async () => [peerRun()]),
       },
       message: {
         findMany: vi.fn(async () => []),
@@ -140,6 +157,33 @@ describe("createRepos.listBots", () => {
 
     await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([
       expect.objectContaining({ preview: "Echoed peer reply" }),
+    ]);
+  });
+
+  it("keeps an assigned worker's reply out of sidebar previews", async () => {
+    const prisma = {
+      bot: {
+        findMany: vi.fn(async () => [
+          {
+            ...baseBot,
+            thread: {
+              ...baseBot.thread,
+              messages: [
+                {
+                  runId: "run-peer",
+                  blocks: [{ kind: "text", text: "The check passed." }],
+                },
+                { runId: "run-user", blocks: [{ kind: "text", text: "Older visible answer" }] },
+              ],
+            },
+          },
+        ]),
+      },
+      run: { findMany: vi.fn(async () => [peerRun("request")]) },
+    };
+
+    await expect(createRepos(prisma as unknown as PrismaClient).listBots(actor)).resolves.toEqual([
+      expect.objectContaining({ preview: "Older visible answer" }),
     ]);
   });
 

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -6,7 +6,7 @@ import {
   type MessageBlock,
   type SpaceBot,
 } from "@rakazo/contracts";
-import { userVisibleMessages } from "@rakazo/core";
+import { isPeerReportBlocks, userVisibleMessages } from "@rakazo/core";
 import type { PrismaClient } from "./client.js";
 import { type ComputerMode, ensureComputerRecord, parseComputerMode } from "./computers.js";
 import { createThreadMessageInTransaction } from "./messages.js";
@@ -253,10 +253,21 @@ export function createRepos(prisma: PrismaClient) {
       const peerRuns = candidateRunIds.length
         ? await prisma.run.findMany({
             where: { id: { in: candidateRunIds }, trigger: "bot_message" },
-            select: { id: true },
+            select: { id: true, sourceMessage: { select: { blocks: true } } },
           })
         : [];
       const peerRunIds = new Set(peerRuns.map((run) => run.id));
+      const peerReportRunIds = new Set(
+        peerRuns
+          .filter((run) =>
+            isPeerReportBlocks(
+              Array.isArray(run.sourceMessage?.blocks)
+                ? (run.sourceMessage.blocks as MessageBlock[])
+                : [],
+            ),
+          )
+          .map((run) => run.id),
+      );
       return Promise.all(
         bots.map(async (bot) => {
           let messages = bot.thread?.messages ?? [];
@@ -268,9 +279,20 @@ export function createRepos(prisma: PrismaClient) {
             if (windowRunIds.length > 0) {
               const morePeers = await prisma.run.findMany({
                 where: { id: { in: windowRunIds }, trigger: "bot_message" },
-                select: { id: true },
+                select: { id: true, sourceMessage: { select: { blocks: true } } },
               });
-              for (const run of morePeers) peerRunIds.add(run.id);
+              for (const run of morePeers) {
+                peerRunIds.add(run.id);
+                if (
+                  isPeerReportBlocks(
+                    Array.isArray(run.sourceMessage?.blocks)
+                      ? (run.sourceMessage.blocks as MessageBlock[])
+                      : [],
+                  )
+                ) {
+                  peerReportRunIds.add(run.id);
+                }
+              }
             }
             const visible = userVisibleMessages(
               messages.map((message) => ({
@@ -278,7 +300,7 @@ export function createRepos(prisma: PrismaClient) {
                 blocks: message.blocks as MessageBlock[],
                 runId: message.runId ?? undefined,
               })),
-              { knownPeerRunIds: peerRunIds },
+              { knownPeerRunIds: peerRunIds, knownPeerReportRunIds: peerReportRunIds },
             );
             preview = previewFromBlocks(visible[0]?.blocks);
             if (preview || messages.length === 0 || !bot.thread || attempt === 4) break;

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -206,8 +206,8 @@ export function createRepos(prisma: PrismaClient) {
           select: { id: true, sourceMessage: { select: { blocks: true } } },
         })
       : [];
-    const peerRunIds = new Set(peerRuns.map((run) => run.id));
-    const peerReportRunIds = new Set(
+    const peerRunIds = new Set<string>(peerRuns.map((run) => run.id));
+    const peerReportRunIds = new Set<string>(
       peerRuns
         .filter((run) =>
           isPeerReportBlocks(
@@ -353,8 +353,8 @@ export function createRepos(prisma: PrismaClient) {
             select: { id: true, sourceMessage: { select: { blocks: true } } },
           })
         : [];
-      const peerRunIds = new Set(peerRuns.map((run) => run.id));
-      const peerReportRunIds = new Set(
+      const peerRunIds = new Set<string>(peerRuns.map((run) => run.id));
+      const peerReportRunIds = new Set<string>(
         peerRuns
           .filter((run) =>
             isPeerReportBlocks(

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -16,6 +16,68 @@ import { activeRunSelection, previewFromBlocks } from "./thread-listing.js";
 /** Newest messages loaded for sidebar preview; enough to skip a short peer-run tail. */
 const SIDEBAR_PREVIEW_MESSAGE_WINDOW = 16;
 
+type SidebarPreviewMessage = {
+  seq: number;
+  blocks: unknown;
+  runId: string | null;
+  clientNonce?: string | null;
+};
+
+/** Newest-window preview with bounded older scans after peer filtering. */
+async function resolveSidebarPreview(
+  prisma: PrismaClient,
+  threadId: string,
+  initialMessages: SidebarPreviewMessage[],
+  peerRunIds: Set<string>,
+  peerReportRunIds: Set<string>,
+): Promise<string> {
+  let messages = initialMessages;
+  let preview = "";
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const windowRunIds = [
+      ...new Set(messages.flatMap((message) => (message.runId ? [message.runId] : []))),
+    ].filter((runId) => !peerRunIds.has(runId));
+    if (windowRunIds.length > 0) {
+      const morePeers = await prisma.run.findMany({
+        where: { id: { in: windowRunIds }, trigger: "bot_message" },
+        select: { id: true, sourceMessage: { select: { blocks: true } } },
+      });
+      for (const run of morePeers) {
+        peerRunIds.add(run.id);
+        if (
+          isPeerReportBlocks(
+            Array.isArray(run.sourceMessage?.blocks)
+              ? (run.sourceMessage.blocks as MessageBlock[])
+              : [],
+          )
+        ) {
+          peerReportRunIds.add(run.id);
+        }
+      }
+    }
+    const visible = userVisibleMessages(
+      messages.map((message) => ({
+        ...message,
+        blocks: message.blocks as MessageBlock[],
+        runId: message.runId ?? undefined,
+      })),
+      { knownPeerRunIds: peerRunIds, knownPeerReportRunIds: peerReportRunIds },
+    );
+    preview = previewFromBlocks(visible[0]?.blocks);
+    if (preview || messages.length === 0 || attempt === 4) break;
+    const oldest = messages[messages.length - 1];
+    if (!oldest) break;
+    messages = await prisma.message.findMany({
+      where: { threadId, seq: { lt: oldest.seq } },
+      orderBy: { seq: "desc" },
+      take: SIDEBAR_PREVIEW_MESSAGE_WINDOW,
+      select: { seq: true, blocks: true, runId: true, clientNonce: true },
+    });
+    if (messages.length === 0) break;
+  }
+  return preview;
+}
+
 function mapBot(
   bot: {
     id: string;
@@ -118,6 +180,7 @@ export function createRepos(prisma: PrismaClient) {
         updatedAt: true,
         thread: {
           select: {
+            id: true,
             unread: true,
             messages: {
               orderBy: { seq: "desc" },
@@ -155,31 +218,32 @@ export function createRepos(prisma: PrismaClient) {
         )
         .map((run) => run.id),
     );
-    return bots.map((bot) => {
-      if (!bot.thread) throw new IsolationError("Bot is missing its thread");
-      const visibleMessages = userVisibleMessages(
-        bot.thread.messages.map((message) => ({
-          ...message,
-          blocks: message.blocks as MessageBlock[],
-          runId: message.runId ?? undefined,
-        })),
-        { knownPeerRunIds: peerRunIds, knownPeerReportRunIds: peerReportRunIds },
-      );
-      return {
-        id: bot.id,
-        spaceId: bot.spaceId,
-        name: bot.name,
-        title: bot.title,
-        color: bot.color,
-        notifyOnFinish: bot.notifyOnFinish,
-        pinned: bot.pinned,
-        sectionId: bot.sectionId,
-        unread: bot.thread.unread,
-        preview: previewFromBlocks(visibleMessages[0]?.blocks),
-        status: bot.runs[0]?.status ?? "idle",
-        updatedAt: bot.updatedAt.toISOString(),
-      };
-    });
+    return Promise.all(
+      bots.map(async (bot) => {
+        if (!bot.thread) throw new IsolationError("Bot is missing its thread");
+        const preview = await resolveSidebarPreview(
+          prisma,
+          bot.thread.id,
+          bot.thread.messages,
+          peerRunIds,
+          peerReportRunIds,
+        );
+        return {
+          id: bot.id,
+          spaceId: bot.spaceId,
+          name: bot.name,
+          title: bot.title,
+          color: bot.color,
+          notifyOnFinish: bot.notifyOnFinish,
+          pinned: bot.pinned,
+          sectionId: bot.sectionId,
+          unread: bot.thread.unread,
+          preview,
+          status: bot.runs[0]?.status ?? "idle",
+          updatedAt: bot.updatedAt.toISOString(),
+        };
+      }),
+    );
   }
 
   return {
@@ -303,49 +367,14 @@ export function createRepos(prisma: PrismaClient) {
       );
       return Promise.all(
         bots.map(async (bot) => {
-          let messages = bot.thread?.messages ?? [];
-          let preview = "";
-          for (let attempt = 0; attempt < 5; attempt++) {
-            const windowRunIds = [
-              ...new Set(messages.flatMap((message) => (message.runId ? [message.runId] : []))),
-            ].filter((runId) => !peerRunIds.has(runId));
-            if (windowRunIds.length > 0) {
-              const morePeers = await prisma.run.findMany({
-                where: { id: { in: windowRunIds }, trigger: "bot_message" },
-                select: { id: true, sourceMessage: { select: { blocks: true } } },
-              });
-              for (const run of morePeers) {
-                peerRunIds.add(run.id);
-                if (
-                  isPeerReportBlocks(
-                    Array.isArray(run.sourceMessage?.blocks)
-                      ? (run.sourceMessage.blocks as MessageBlock[])
-                      : [],
-                  )
-                ) {
-                  peerReportRunIds.add(run.id);
-                }
-              }
-            }
-            const visible = userVisibleMessages(
-              messages.map((message) => ({
-                ...message,
-                blocks: message.blocks as MessageBlock[],
-                runId: message.runId ?? undefined,
-              })),
-              { knownPeerRunIds: peerRunIds, knownPeerReportRunIds: peerReportRunIds },
-            );
-            preview = previewFromBlocks(visible[0]?.blocks);
-            if (preview || messages.length === 0 || !bot.thread || attempt === 4) break;
-            const oldest = messages[messages.length - 1];
-            if (!oldest) break;
-            messages = await prisma.message.findMany({
-              where: { threadId: bot.thread.id, seq: { lt: oldest.seq } },
-              orderBy: { seq: "desc" },
-              take: SIDEBAR_PREVIEW_MESSAGE_WINDOW,
-            });
-            if (messages.length === 0) break;
-          }
+          if (!bot.thread) throw new IsolationError("Bot is missing its thread");
+          const preview = await resolveSidebarPreview(
+            prisma,
+            bot.thread.id,
+            bot.thread.messages,
+            peerRunIds,
+            peerReportRunIds,
+          );
           return mapBot(bot, preview, bot.runs[0]?.status ?? "idle");
         }),
       );

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -121,8 +121,8 @@ export function createRepos(prisma: PrismaClient) {
             unread: true,
             messages: {
               orderBy: { seq: "desc" },
-              take: 1,
-              select: { blocks: true },
+              take: SIDEBAR_PREVIEW_MESSAGE_WINDOW,
+              select: { blocks: true, runId: true, clientNonce: true },
             },
           },
         },
@@ -130,8 +130,41 @@ export function createRepos(prisma: PrismaClient) {
       },
       orderBy: [{ pinned: "desc" }, { position: "asc" }, { createdAt: "asc" }],
     });
+    const candidateRunIds = [
+      ...new Set(
+        bots.flatMap((bot) =>
+          (bot.thread?.messages ?? []).flatMap((message) => (message.runId ? [message.runId] : [])),
+        ),
+      ),
+    ];
+    const peerRuns = candidateRunIds.length
+      ? await prisma.run.findMany({
+          where: { id: { in: candidateRunIds }, trigger: "bot_message" },
+          select: { id: true, sourceMessage: { select: { blocks: true } } },
+        })
+      : [];
+    const peerRunIds = new Set(peerRuns.map((run) => run.id));
+    const peerReportRunIds = new Set(
+      peerRuns
+        .filter((run) =>
+          isPeerReportBlocks(
+            Array.isArray(run.sourceMessage?.blocks)
+              ? (run.sourceMessage.blocks as MessageBlock[])
+              : [],
+          ),
+        )
+        .map((run) => run.id),
+    );
     return bots.map((bot) => {
       if (!bot.thread) throw new IsolationError("Bot is missing its thread");
+      const visibleMessages = userVisibleMessages(
+        bot.thread.messages.map((message) => ({
+          ...message,
+          blocks: message.blocks as MessageBlock[],
+          runId: message.runId ?? undefined,
+        })),
+        { knownPeerRunIds: peerRunIds, knownPeerReportRunIds: peerReportRunIds },
+      );
       return {
         id: bot.id,
         spaceId: bot.spaceId,
@@ -142,7 +175,7 @@ export function createRepos(prisma: PrismaClient) {
         pinned: bot.pinned,
         sectionId: bot.sectionId,
         unread: bot.thread.unread,
-        preview: previewFromBlocks(bot.thread.messages[0]?.blocks),
+        preview: previewFromBlocks(visibleMessages[0]?.blocks),
         status: bot.runs[0]?.status ?? "idle",
         updatedAt: bot.updatedAt.toISOString(),
       };

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -122,7 +122,7 @@ export function createRepos(prisma: PrismaClient) {
             messages: {
               orderBy: { seq: "desc" },
               take: SIDEBAR_PREVIEW_MESSAGE_WINDOW,
-              select: { blocks: true, runId: true, clientNonce: true },
+              select: { seq: true, blocks: true, runId: true, clientNonce: true },
             },
           },
         },


### PR DESCRIPTION
## Why

When a delegated bot returned a status or result, the receiving coordinator woke and generated the owner-facing summary the prompt required, but every message from that bot-triggered run was filtered out of the normal transcript and sidebar preview. The owner saw only a compact peer receipt and could miss a completed step or decision request entirely.

The delegated worker's own reply should remain private to the peer exchange. Only the coordinator that receives a result, status, or FYI should publish the user-facing summary in its normal chat.

Separately, a transient local API or Docker interruption could leave the web/Electron transcript blank. Returning to the app refreshed navigation but did not explicitly refresh the selected chat, and the peer viewer could remain on an indefinite loading screen.

## What changed

- Keep a coordinator's final report visible after it is awakened by a peer result, status, or FYI.
- Keep a worker's response private when it was awakened by a peer request or question, including normal transcripts and every sidebar preview.\n- Always surface actionable computer-takeover cards and takeover events, even when a coordinator delegated the work.
- Tag the loop-guard's pre-terminal peer narration as progress so it cannot be mistaken for a final coordinator report.
- Include generated replies in the optional view-only peer transcript, collapse an identical explicit same-run reply into one bubble, and open that view at its newest message.
- Time out failed peer-history loads and reveal a **Retry** action only after failure.
- Refresh the selected bot or group transcript when the window regains focus, the page becomes visible, or the browser reports that connectivity returned.
- Show the existing **Loading…** state instead of an unexplained blank transcript while a selected chat is being recovered.

The added **Retry** label is necessary because recovery requires a user action after the bounded request fails. It is revealed only in the failure state; removing it would require closing and reopening the viewer.

## Testing

- 42 focused visibility, message-page, sidebar-preview, progress, and takeover tests passed.
- A local live-data check confirmed that an assigned worker's reply is absent from its normal transcript and sidebar preview while the coordinator's summary remains visible.
- The web unit suite passed with 202 tests, including the duplicate peer-reply regression.
- Affected core and database type checks passed.
- Biome formatting and lint checks passed for all changed files.
- The peer-message E2E verifies that the view-only transcript opens already scrolled to the latest message; CI will run the Electron/web E2E and publish its screenshot.

The full workspace dependency install was not run locally because the repository's minimum-release-age policy rejected several Expo lockfile entries published within its cutoff. That safety policy was not bypassed. The older local test image also has a pre-existing API contract mismatch outside these files, so CI is authoritative for the full API and adapter type checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved peer-conversation history with clearer incoming and outgoing message attribution.
  - Takeover requests remain visible in transcripts and previews.
  - Added automatic transcript refresh when returning to the app, regaining focus, or reconnecting.
  - Added loading indicators, retry support, timeout handling, anchored history loading, and automatic scrolling.
  - Added detection for existing peer conversations.

- **Bug Fixes**
  - Peer activity is hidden while final owner-facing summaries remain visible, including across paginated history.
  - Prevented duplicate peer messages and improved handling of mixed peer messages, assigned-worker replies, and progress updates.
  - Improved cancellation of interrupted history and transcript refresh requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->