### PR TITLE
fix(adapters): bound sandbox error responses

### DIFF
--- a/packages/adapters/src/docker-sandbox.test.ts
+++ b/packages/adapters/src/docker-sandbox.test.ts
@@ -1,6 +1,6 @@
 import type { ProcessEvent } from "@rakazo/adapter-kit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DockerSandboxProvider } from "./docker-sandbox.js";
+import { DockerSandboxProvider, MAX_SANDBOX_ERROR_RESPONSE_BYTES } from "./docker-sandbox.js";
 
 const context = {
   operationId: "docker-test",
@@ -120,6 +120,51 @@ describe("Docker sandbox", () => {
     await expect(provider.destroy(computer, context)).rejects.toThrow(
       "sandbox destroy failed: 500 boom",
     );
+  });
+
+  it("does not buffer an oversized supervisor error body", async () => {
+    const cancel = vi.fn();
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(new ReadableStream({ cancel }), {
+          status: 500,
+          headers: { "content-length": String(MAX_SANDBOX_ERROR_RESPONSE_BYTES + 1) },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new DockerSandboxProvider("http://supervisor.test", "test-token");
+    const computer = {
+      id: "computer",
+      botId: "bot",
+      kind: "docker",
+      providerRef: "computer",
+    } as const;
+
+    await expect(provider.stop(computer, context)).rejects.toThrow("sandbox stop failed: 500");
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+
+  it("stops reading a streamed supervisor error at the byte limit", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(MAX_SANDBOX_ERROR_RESPONSE_BYTES + 1));
+            },
+          }),
+          { status: 500 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new DockerSandboxProvider("http://supervisor.test", "test-token");
+
+    await expect(
+      provider.stop(
+        { id: "computer", botId: "bot", kind: "docker", providerRef: "computer" },
+        context,
+      ),
+    ).rejects.toThrow("sandbox stop failed: 500");
   });
 
   it("treats a computer the supervisor no longer knows as already stopped and destroyed", async () => {

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -22,12 +22,33 @@ import {
   computerObservation,
   normalizeWorkspacePath,
 } from "./computer-support.js";
+import { readBodyCapped } from "./web-ssrf.js";
 
-async function safeBody(res: Response): Promise<string> {
+export const MAX_SANDBOX_ERROR_RESPONSE_BYTES = 8 * 1024;
+const SANDBOX_ERROR_RESPONSE_TIMEOUT_MS = 1_000;
+
+async function safeBody(res: Response, signal?: AbortSignal): Promise<string> {
+  const declared = Number(res.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > MAX_SANDBOX_ERROR_RESPONSE_BYTES) {
+    cancelResponseBody(res);
+    return "";
+  }
   try {
-    return (await res.text()).slice(0, 200);
+    const readSignal = signal
+      ? AbortSignal.any([signal, AbortSignal.timeout(SANDBOX_ERROR_RESPONSE_TIMEOUT_MS)])
+      : AbortSignal.timeout(SANDBOX_ERROR_RESPONSE_TIMEOUT_MS);
+    const bytes = await readBodyCapped(res, MAX_SANDBOX_ERROR_RESPONSE_BYTES, readSignal);
+    return new TextDecoder().decode(bytes).slice(0, 200);
   } catch {
     return "";
+  }
+}
+
+function cancelResponseBody(res: Response): void {
+  try {
+    void Promise.resolve(res.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Error diagnostics are best-effort and must not delay the operation failure.
   }
 }
 
@@ -98,7 +119,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       signal: context.signal,
     });
     if (!res.ok) {
-      const detail = await res.text().catch(() => "");
+      const detail = await safeBody(res, context.signal);
       throw new Error(`sandbox provision failed: ${res.status} ${detail}`.trim());
     }
     const body = (await res.json()) as { id: string; resumed?: boolean };
@@ -155,7 +176,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       signal: context.signal,
     });
     if (!res.ok) {
-      const detail = await res.text().catch(() => "");
+      const detail = await safeBody(res, context.signal);
       if (/cannot allocate another screen/i.test(detail)) {
         throw new Error("This Team Computer cannot allocate another screen.");
       }
@@ -197,7 +218,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       signal: context.signal,
     });
     if (!res.ok) {
-      const detail = await res.text().catch(() => "");
+      const detail = await safeBody(res, context.signal);
       throw new Error(`sandbox input failed: ${res.status} ${detail}`.trim());
     }
   }
@@ -210,7 +231,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     });
     if (!res.ok)
       throw new Error(
-        `sandbox observation failed: ${res.status} ${await res.text().catch(() => "")}`.trim(),
+        `sandbox observation failed: ${res.status} ${await safeBody(res, context.signal)}`.trim(),
       );
     const body = (await res.json()) as {
       image: string;
@@ -243,7 +264,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     });
     if (!res.ok)
       throw new Error(
-        `sandbox action failed: ${res.status} ${await res.text().catch(() => "")}`.trim(),
+        `sandbox action failed: ${res.status} ${await safeBody(res, context.signal)}`.trim(),
       );
     const body = (await res.json()) as {
       completed: number;
@@ -298,7 +319,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       { headers: this.headers(context, computer.botId), signal: context.signal },
     );
     if (!res.ok) {
-      const detail = await res.text().catch(() => "");
+      const detail = await safeBody(res, context.signal);
       throw new Error(`sandbox file read failed: ${res.status} ${detail}`.trim());
     }
     const body = (await res.json()) as { content: string };
@@ -354,7 +375,9 @@ export class DockerSandboxProvider implements SandboxProvider {
     });
     // 404 means the supervisor no longer has the container, which is the state we want.
     if (!res.ok && res.status !== 404) {
-      throw new Error(`sandbox stop failed: ${res.status} ${await safeBody(res)}`.trim());
+      throw new Error(
+        `sandbox stop failed: ${res.status} ${await safeBody(res, context.signal)}`.trim(),
+      );
     }
   }
 
@@ -365,7 +388,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       signal: context.signal,
     });
     if (!res.ok && res.status !== 404) {
-      throw new Error(`sandbox destroy failed: ${res.status} ${await safeBody(res)}`.trim());
+      throw new Error(
+        `sandbox destroy failed: ${res.status} ${await safeBody(res, context.signal)}`.trim(),
+      );
     }
   }
 


### PR DESCRIPTION
## Why

Docker sandbox failures were read with response.text() before trimming the diagnostic. A broken or hostile supervisor could make any error path buffer an unbounded response, and a stalled diagnostic body could delay the real operation failure.

## What

- Bound supervisor error bodies to 8 KiB and one second before retaining the existing 200-character diagnostic.
- Apply the bounded reader to provision, screen, input, observation, action, file-read, stop, and destroy failures.
- Release declared-oversized bodies best-effort without waiting on cancellation.
- Keep existing status-only fallback errors when diagnostics cannot be read safely.

## Tests

- Adapters unit suite: 1,130 passed and 7 skipped.
- Adapters TypeScript check.
- Biome check for the changed files.

No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized sandbox error responses to prevent excessive buffering.
  * Added time limits and byte caps when reading error details.
  * Ensured streaming error responses stop at the configured limit, improving reliability during failed sandbox operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->