### PR TITLE
fix(www): time out GitHub star lookups

### DIFF
--- a/apps/www/src/github.test.ts
+++ b/apps/www/src/github.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchGithubStars,
+  formatStarCount,
+  GITHUB_STARS_TIMEOUT_MS,
+} from "./github.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("GitHub stars", () => {
+  it("returns a numeric count and formats compact labels", async () => {
+    const fetchImpl = vi.fn(async () => Response.json({ stargazers_count: 12_345 }));
+
+    await expect(fetchGithubStars(fetchImpl as unknown as typeof fetch)).resolves.toBe(12_345);
+    expect(formatStarCount(999)).toBe("999");
+    expect(formatStarCount(1_250)).toBe("1.3k");
+    expect(formatStarCount(12_345)).toBe("12k");
+  });
+
+  it("returns the fallback when GitHub does not settle before the deadline", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Promise<Response>(() => undefined),
+    );
+
+    const pending = fetchGithubStars(fetchImpl as typeof fetch);
+    await vi.advanceTimersByTimeAsync(GITHUB_STARS_TIMEOUT_MS);
+
+    await expect(pending).resolves.toBeNull();
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+});

--- a/apps/www/src/github.ts
+++ b/apps/www/src/github.ts
@@ -1,21 +1,60 @@
 import { GITHUB_API_REPO } from "./site";
 
-export async function fetchGithubStars(): Promise<number | null> {
+export const GITHUB_STARS_TIMEOUT_MS = 5_000;
+
+export async function fetchGithubStars(fetchImpl: typeof fetch = fetch): Promise<number | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GITHUB_STARS_TIMEOUT_MS);
   try {
-    const response = await fetch(GITHUB_API_REPO, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "User-Agent": "rakazo-www",
-      },
-    });
+    const response = await withAbort(
+      fetchImpl(GITHUB_API_REPO, {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "User-Agent": "rakazo-www",
+        },
+        signal: controller.signal,
+      }),
+      controller.signal,
+    );
     if (!response.ok) {
+      cancelResponseBody(response);
       return null;
     }
-    const payload = (await response.json()) as { stargazers_count?: unknown };
+    const payload = (await withAbort(response.json(), controller.signal)) as {
+      stargazers_count?: unknown;
+    };
     return typeof payload.stargazers_count === "number" ? payload.stargazers_count : null;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
+}
+
+function cancelResponseBody(response: Response): void {
+  try {
+    void Promise.resolve(response.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Best-effort release only; cancellation must not delay static rendering.
+  }
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason ?? new Error("Request timed out"));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason ?? new Error("Request timed out"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 export function formatStarCount(count: number): string {


### PR DESCRIPTION
## Why

Several static pages await the GitHub star lookup while rendering. The request had no deadline, so a stalled GitHub API or fetch implementation could hang the website build instead of using the existing fallback label.

## What

- Give the fetch and JSON body read one five-second deadline.
- Race the operation against the deadline even when an injected fetch ignores its signal.
- Release non-success response bodies best-effort.
- Preserve the existing null fallback for timeout, network, status, and parsing failures.

## Tests

- WWW unit suite: 31 passed.
- Astro check: no errors, warnings, or hints.
- Astro production build: 8 pages built successfully.

No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub star count loading reliability by enforcing a timeout for slow or unresponsive requests.
  - Added safer handling for failed requests, invalid responses, and interrupted loading, preserving the existing fallback behavior.

- **Tests**
  - Added coverage for star count formatting, successful responses, timeout scenarios, request cancellation, and cleanup of pending timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->