### PR TITLE
fix(adapters): avoid waiting on response cancellation

### DIFF
--- a/packages/adapters/src/web-ssrf.test.ts
+++ b/packages/adapters/src/web-ssrf.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { assertSafeWebUrl, fetchSafeWebText, isBlockedHostname } from "./web-ssrf.js";
 
 const publicResolver = async () => [{ address: "203.0.113.10", family: 4 as const }];
@@ -181,6 +181,22 @@ describe("web SSRF policy", () => {
     await expect(readBodyCapped(response, 500)).rejects.toThrow(/too large/i);
     // Second chunk already exceeds; a third pull must not be needed.
     expect(pulls).toBeLessThanOrEqual(2);
+  });
+
+  it("readBodyCapped does not wait for a hanging stream cancellation", async () => {
+    const { readBodyCapped } = await import("./web-ssrf.js");
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(501));
+        },
+        cancel,
+      }),
+    );
+
+    await expect(readBodyCapped(response, 500)).rejects.toThrow(/too large/i);
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("accepts a streamed body that stays under maxBytes", async () => {

--- a/packages/adapters/src/web-ssrf.ts
+++ b/packages/adapters/src/web-ssrf.ts
@@ -211,15 +211,13 @@ async function cancelResponseBody(response: Response, signal: AbortSignal): Prom
   ).catch(() => undefined);
 }
 
-/** Best-effort cancel that never waits past an already-fired deadline. */
-async function cancelReader(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  signal?: AbortSignal,
-): Promise<void> {
-  await withAbort(
-    reader.cancel().catch(() => undefined),
-    signal,
-  ).catch(() => undefined);
+/** Best-effort release; an untrusted stream cancellation must never delay the caller. */
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    void Promise.resolve(reader.cancel()).catch(() => undefined);
+  } catch {
+    // sync throw from an injected stream
+  }
 }
 
 /** Read the body as a stream and abort once maxBytes is exceeded (DoS guard). */
@@ -246,13 +244,12 @@ export async function readBodyCapped(
       if (!value?.byteLength) continue;
       total += value.byteLength;
       if (total > maxBytes) {
-        await cancelReader(reader, signal);
         throw new Error("Response is too large");
       }
       chunks.push(value);
     }
   } catch (error) {
-    await cancelReader(reader, signal);
+    cancelReader(reader);
     throw error;
   } finally {
     try {


### PR DESCRIPTION
## Why

The shared capped response reader awaited ReadableStream cancellation after detecting an oversized or failed body. Callers without a deadline could therefore hang forever after the byte guard had already decided to reject, while deadline-bound callers could still wait out the rest of the deadline.

## What

- Make reader cancellation fire-and-forget.
- Suppress both synchronous and asynchronous cancellation failures.
- Route over-limit and read failures through one cancellation path.
- Add deterministic regression coverage with a cancellation promise that never settles.

## Tests

- Adapters unit suite: 1,129 passed and 7 skipped.
- Adapters TypeScript check.
- Biome check for the changed files.

No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of responses that exceed the allowed size limit.
  * Oversized or unresponsive streams now fail promptly instead of waiting indefinitely during cleanup.
  * Preserved the original “response too large” error while ensuring stream cancellation is attempted safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->