### PR TITLE
fix(adapters): avoid hanging on oversized voice responses

### DIFF
--- a/packages/adapters/src/voice-http.test.ts
+++ b/packages/adapters/src/voice-http.test.ts
@@ -43,11 +43,11 @@ describe("speechUploadName", () => {
 });
 
 describe("readVoiceJson", () => {
-  it("rejects an oversized provider response before buffering it", async () => {
-    const response = new Response("oversized", {
+  it("rejects an oversized provider response without waiting for cancellation", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
+    const response = new Response(new ReadableStream({ cancel }), {
       headers: { "content-length": String(MAX_VOICE_JSON_BYTES + 1) },
     });
-    const cancel = vi.spyOn(response.body!, "cancel");
 
     await expect(readVoiceJson(response)).rejects.toThrow("Voice response is too large.");
     expect(cancel).toHaveBeenCalledOnce();

--- a/packages/adapters/src/voice-http.ts
+++ b/packages/adapters/src/voice-http.ts
@@ -20,7 +20,7 @@ async function readVoiceBytes(
 ): Promise<Uint8Array> {
   const declared = Number(res.headers?.get("content-length") ?? 0);
   if (Number.isFinite(declared) && declared > maxBytes) {
-    await res.body?.cancel().catch(() => undefined);
+    cancelResponseBody(res);
     throw new Error("Voice response is too large.");
   }
   try {
@@ -30,6 +30,14 @@ async function readVoiceBytes(
       throw new Error("Voice response is too large.");
     }
     throw error;
+  }
+}
+
+function cancelResponseBody(res: Response): void {
+  try {
+    void Promise.resolve(res.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Provider response cleanup is best-effort and must not delay the size error.
   }
 }
 


### PR DESCRIPTION
## Why

Voice response limits rejected an oversized declared body only after awaiting provider-controlled stream cancellation. If cancellation never settled, voice verification or synthesis could hang even though the response was already known to be too large.

## What

- Start oversized voice body cancellation without awaiting it.
- Suppress synchronous and asynchronous cancellation failures.
- Keep the existing size error and response limits unchanged.
- Make the regression test use a cancellation promise that never settles.

## Tests

- Adapters unit suite: 1,128 passed and 7 skipped.
- Focused voice tests: 21 passed.
- Adapters TypeScript check.
- Biome check for the changed files.

No UI changes.