### PR TITLE
fix(mobile): bound custom server probes

### DIFF
--- a/apps/mobile/lib/endpoint.test.ts
+++ b/apps/mobile/lib/endpoint.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  API_PROBE_TIMEOUT_MS,
   apiBaseWarning,
   defaultApiBase,
   displayApiHost,
@@ -10,6 +11,11 @@ import {
   probeApiBase,
   usesCustomApiBase,
 } from "./endpoint.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 describe("normalizeApiBase", () => {
   it("trims, adds https, and keeps only the origin", () => {
@@ -109,6 +115,38 @@ describe("probeApiBase", () => {
     ) as unknown as typeof fetch;
     await expect(probeApiBase("https://example.com", fetchImpl)).resolves.toMatchObject({
       ok: false,
+    });
+  });
+
+  it("returns a failure when an injected fetch ignores the probe signal", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn(
+      (_input: RequestInfo | URL, _init?: RequestInit) => new Promise<Response>(() => undefined),
+    );
+
+    const pending = probeApiBase("https://app.example.com", fetchImpl as typeof fetch);
+    await vi.advanceTimersByTimeAsync(API_PROBE_TIMEOUT_MS);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      error: "Could not reach that server",
+    });
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  it("returns a failure when a health response body never settles", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: () => new Promise<unknown>(() => undefined),
+    }));
+
+    const pending = probeApiBase("https://app.example.com", fetchImpl as unknown as typeof fetch);
+    await vi.advanceTimersByTimeAsync(API_PROBE_TIMEOUT_MS);
+
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      error: "Could not reach that server",
     });
   });
 });

--- a/apps/mobile/lib/endpoint.ts
+++ b/apps/mobile/lib/endpoint.ts
@@ -2,6 +2,7 @@ import { t } from "./i18n";
 
 const LOCAL_API = "http://127.0.0.1:3100";
 const DEFAULT_API = process.env.EXPO_PUBLIC_API_URL ?? LOCAL_API;
+export const API_PROBE_TIMEOUT_MS = 8_000;
 
 export type EndpointResult = { ok: true; url: string } | { ok: false; error: string };
 
@@ -62,19 +63,29 @@ export async function probeApiBase(
   const parsed = normalizeApiBase(input);
   if (!parsed.ok) return parsed;
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 8_000);
+  const timer = setTimeout(() => controller.abort(), API_PROBE_TIMEOUT_MS);
   try {
-    const res = await fetchImpl(`${parsed.url}/rpc/health`, {
-      method: "POST",
-      headers: { "content-type": "application/json", origin: "rakazo://" },
-      body: JSON.stringify({ json: {} }),
-      signal: controller.signal,
-    });
-    const body = (await res.json().catch(() => ({}))) as {
+    const res = await withAbort(
+      fetchImpl(`${parsed.url}/rpc/health`, {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: "rakazo://" },
+        body: JSON.stringify({ json: {} }),
+        signal: controller.signal,
+      }),
+      controller.signal,
+    );
+    if (!res.ok) {
+      cancelResponseBody(res);
+      return { ok: false, error: t("That URL did not look like a Rakazo server") };
+    }
+    const body = (await withAbort(
+      res.json().catch(() => ({})),
+      controller.signal,
+    )) as {
       json?: { ok?: boolean };
       error?: { message?: string };
     };
-    if (!res.ok || body.error || body.json?.ok !== true) {
+    if (body.error || body.json?.ok !== true) {
       return { ok: false, error: t("That URL did not look like a Rakazo server") };
     }
     return parsed;
@@ -83,6 +94,32 @@ export async function probeApiBase(
   } finally {
     clearTimeout(timer);
   }
+}
+
+function cancelResponseBody(response: Response): void {
+  try {
+    void Promise.resolve(response.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Probe cleanup is best-effort and must not delay the fallback result.
+  }
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason ?? new Error("Request timed out"));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason ?? new Error("Request timed out"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 function originOnly(value: string) {


### PR DESCRIPTION
## Why

The custom-server probe created an eight-second abort signal but awaited fetch and JSON parsing directly. A fetch implementation or response body that ignored the signal could leave the sign-in flow waiting indefinitely instead of returning the existing unreachable-server result.

## What

- Race response acquisition and JSON parsing against one eight-second probe deadline.
- Avoid parsing non-success responses and release their bodies best-effort.
- Preserve the current user-facing validation and fallback messages.
- Add deterministic fake-timer coverage for fetch and response-body hangs.

## Tests

- Mobile unit suite: 162 passed.
- Mobile dependency and TypeScript check.
- Biome check for the changed files.

No UI changes.