### PR TITLE
fix(mobile): bound voice response reads

### DIFF
--- a/apps/mobile/lib/voice.test.ts
+++ b/apps/mobile/lib/voice.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureApiRequestContext, currentApiBase, rpc } from "./api";
-import { speakText } from "./voice";
+import {
+  MAX_VOICE_AUDIO_BYTES,
+  speakText,
+  speakUtterance,
+  VOICE_RESPONSE_TIMEOUT_MS,
+} from "./voice";
 
 vi.mock("expo-file-system", () => ({ File: class {}, Paths: {} }));
 vi.mock("./api", () => ({
@@ -43,6 +48,7 @@ describe("mobile speech", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -69,5 +75,46 @@ describe("mobile speech", () => {
       expect(url).toBe("https://support.example/api/voice/speak");
       expect(init?.headers).toMatchObject(requestContext.headers);
     }
+  });
+
+  it("rejects oversized audio without waiting for response cancellation", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new ReadableStream({ cancel }), {
+            headers: { "content-length": String(MAX_VOICE_AUDIO_BYTES + 1) },
+          }),
+      ),
+    );
+
+    await expect(
+      speakUtterance("Hello.", { requestContext: await captureApiRequestContext() }),
+    ).rejects.toThrow("Voice response is too large.");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("times out while a voice response body is stalled", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              pull: () => new Promise<void>(() => undefined),
+            }),
+          ),
+      ),
+    );
+
+    const pending = speakUtterance("Hello.", {
+      requestContext: await captureApiRequestContext(),
+    });
+    const rejected = expect(pending).rejects.toThrow("Voice request timed out.");
+    await vi.advanceTimersByTimeAsync(VOICE_RESPONSE_TIMEOUT_MS);
+
+    await rejected;
   });
 });

--- a/apps/mobile/lib/voice.ts
+++ b/apps/mobile/lib/voice.ts
@@ -9,6 +9,9 @@ import {
 import { t } from "./i18n";
 
 type SpeechOptions = { voiceId?: string; botId?: string };
+export const VOICE_RESPONSE_TIMEOUT_MS = 70_000;
+export const MAX_VOICE_AUDIO_BYTES = 16 * 1024 * 1024;
+const MAX_VOICE_ERROR_BYTES = 64 * 1024;
 
 export async function speakText(text: string, opts: SpeechOptions = {}): Promise<boolean> {
   const requestContext = await captureApiRequestContext();
@@ -28,20 +31,29 @@ export async function speakUtterance(
   text: string,
   opts: SpeechOptions & { requestContext?: ApiRequestContext } = {},
 ): Promise<Uint8Array> {
-  const res = await fetch(`${opts.requestContext?.apiBase ?? currentApiBase()}/api/voice/speak`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      origin: "rakazo://",
-      ...(opts.requestContext?.headers ?? (await authHeaders())),
-    },
-    body: JSON.stringify({ text, voiceId: opts.voiceId, botId: opts.botId }),
-  });
-  if (!res.ok) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new Error(body.error ?? `Voice failed (${res.status})`);
+  const deadline = requestDeadline(VOICE_RESPONSE_TIMEOUT_MS);
+  try {
+    const res = await withAbort(
+      fetch(`${opts.requestContext?.apiBase ?? currentApiBase()}/api/voice/speak`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "rakazo://",
+          ...(opts.requestContext?.headers ?? (await authHeaders())),
+        },
+        body: JSON.stringify({ text, voiceId: opts.voiceId, botId: opts.botId }),
+        signal: deadline.signal,
+      }),
+      deadline.signal,
+    );
+    if (!res.ok) {
+      const body = await readVoiceError(res, deadline.signal);
+      throw new Error(body.error ?? `Voice failed (${res.status})`);
+    }
+    return await readResponseBytes(res, MAX_VOICE_AUDIO_BYTES, deadline.signal);
+  } finally {
+    deadline.dispose();
   }
-  return new Uint8Array(await res.arrayBuffer());
 }
 
 export async function playMpeg(bytes: Uint8Array): Promise<void> {
@@ -136,4 +148,113 @@ function bytesToBase64(bytes: Uint8Array): string {
     binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
   }
   return btoa(binary);
+}
+
+function requestDeadline(timeoutMs: number) {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error("Voice request timed out.")),
+    timeoutMs,
+  );
+  return {
+    signal: controller.signal,
+    dispose() {
+      clearTimeout(timer);
+    },
+  };
+}
+
+async function readVoiceError(
+  response: Response,
+  signal: AbortSignal,
+): Promise<{ error?: string }> {
+  const bytes = await readResponseBytes(response, MAX_VOICE_ERROR_BYTES, signal);
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as { error?: string }) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function readResponseBytes(
+  response: Response,
+  maxBytes: number,
+  signal: AbortSignal,
+): Promise<Uint8Array> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    cancelResponse(response);
+    throw new Error("Voice response is too large.");
+  }
+  if (!response.body) {
+    const buffer = await withAbort(response.arrayBuffer(), signal);
+    if (buffer.byteLength > maxBytes) throw new Error("Voice response is too large.");
+    return new Uint8Array(buffer);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await withAbort(reader.read(), signal);
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+      if (total > maxBytes) throw new Error("Voice response is too large.");
+      chunks.push(value);
+    }
+  } catch (error) {
+    cancelReader(reader);
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // already cancelled or released
+    }
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason ?? new Error("Voice request aborted."));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason ?? new Error("Voice request aborted."));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function cancelResponse(response: Response): void {
+  try {
+    void Promise.resolve(response.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Response cleanup is best-effort.
+  }
+}
+
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    void Promise.resolve(reader.cancel()).catch(() => undefined);
+  } catch {
+    // Response cleanup is best-effort.
+  }
 }


### PR DESCRIPTION
## Why

Mobile voice playback used unbounded response.json and response.arrayBuffer reads with no request deadline. A custom server that returned headers but stalled the body could leave speech playback pending indefinitely, while an oversized audio response could be buffered into memory.

## What

- apply one 70-second deadline across fetch and body consumption
- stream successful audio with a 16 MiB ceiling
- cap error JSON at 64 KiB
- race body reads against the deadline even when a fetch implementation ignores cancellation
- make stream cancellation best-effort so cleanup cannot delay the user-visible error

## Tests

- pnpm --filter @rakazo/mobile test (164 passed)
- pnpm --filter @rakazo/mobile check
- pnpm exec biome check apps/mobile/lib/voice.ts apps/mobile/lib/voice.test.ts