### PR TITLE
fix(web): bound voice response reads

### DIFF
--- a/apps/web/src/lib/tts.test.ts
+++ b/apps/web/src/lib/tts.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { Speaker } from "./tts.js";
+import { MAX_VOICE_AUDIO_BYTES, Speaker, VOICE_RESPONSE_TIMEOUT_MS } from "./tts.js";
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
@@ -96,5 +97,54 @@ describe("Speaker", () => {
     expect(headers.get("x-rakazo-space-id")).toBe("space-support");
     expect(headers.get("content-type")).toBe("application/json");
     expect(prepare.mock.calls[0]?.[3]).toBe("space-support");
+  });
+
+  it("rejects oversized audio without waiting for response cancellation", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new ReadableStream({ cancel }), {
+            headers: { "content-length": String(MAX_VOICE_AUDIO_BYTES + 1) },
+          }),
+      ),
+    );
+    const speaker = new Speaker();
+    vi.spyOn(
+      speaker as unknown as { prepare: () => Promise<string[]> },
+      "prepare",
+    ).mockResolvedValue(["Hello."]);
+
+    await expect(speaker.speak("Hello.")).resolves.toBeUndefined();
+
+    expect(speaker.state.error).toBe("Voice response is too large.");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("times out while a voice response body is stalled", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              pull: () => new Promise<void>(() => undefined),
+            }),
+          ),
+      ),
+    );
+    const speaker = new Speaker();
+    vi.spyOn(
+      speaker as unknown as { prepare: () => Promise<string[]> },
+      "prepare",
+    ).mockResolvedValue(["Hello."]);
+
+    const pending = speaker.speak("Hello.");
+    await vi.advanceTimersByTimeAsync(VOICE_RESPONSE_TIMEOUT_MS);
+    await pending;
+
+    expect(speaker.state.error).toBe("Voice request timed out.");
   });
 });

--- a/apps/web/src/lib/tts.ts
+++ b/apps/web/src/lib/tts.ts
@@ -19,6 +19,9 @@ interface SpeakOptions {
 type TtsErrorBody = { error?: string };
 
 const IDLE: SpeechSnapshot = { status: "idle" };
+export const VOICE_RESPONSE_TIMEOUT_MS = 70_000;
+export const MAX_VOICE_AUDIO_BYTES = 16 * 1024 * 1024;
+const MAX_VOICE_ERROR_BYTES = 64 * 1024;
 
 export class Speaker {
   private snapshot: SpeechSnapshot = IDLE;
@@ -163,18 +166,28 @@ export class Speaker {
     signal: AbortSignal,
     spaceId: string | null,
   ): Promise<Blob> {
-    const res = await fetch("/api/voice/speak", {
-      method: "POST",
-      headers: withSpaceHeaders({ "content-type": "application/json" }, spaceId),
-      credentials: "include",
-      body: JSON.stringify({ text, voiceId: opts.voiceId, botId: opts.botId }),
-      signal,
-    });
-    if (!res.ok) {
-      const body: TtsErrorBody = await res.json().catch(() => ({}));
-      throw new Error(body.error ?? `the voice service returned ${res.status}`);
+    const deadline = requestDeadline(signal, VOICE_RESPONSE_TIMEOUT_MS);
+    try {
+      const res = await withAbort(deadline.signal, () =>
+        fetch("/api/voice/speak", {
+          method: "POST",
+          headers: withSpaceHeaders({ "content-type": "application/json" }, spaceId),
+          credentials: "include",
+          body: JSON.stringify({ text, voiceId: opts.voiceId, botId: opts.botId }),
+          signal: deadline.signal,
+        }),
+      );
+      if (!res.ok) {
+        const body = await readVoiceError(res, deadline.signal);
+        throw new Error(body.error ?? `the voice service returned ${res.status}`);
+      }
+      const bytes = await readResponseBytes(res, MAX_VOICE_AUDIO_BYTES, deadline.signal);
+      return new Blob([new Uint8Array(bytes)], {
+        type: res.headers.get("content-type") ?? "audio/mpeg",
+      });
+    } finally {
+      deadline.dispose();
     }
-    return res.blob();
   }
 
   private play(blob: Blob, live: () => boolean): Promise<boolean> {
@@ -223,4 +236,96 @@ function withAbort<T>(signal: AbortSignal, run: () => Promise<T>): Promise<T> {
       },
     );
   });
+}
+
+function requestDeadline(parent: AbortSignal, timeoutMs: number) {
+  const controller = new AbortController();
+  const abortFromParent = () => controller.abort(parent.reason);
+  if (parent.aborted) abortFromParent();
+  else parent.addEventListener("abort", abortFromParent, { once: true });
+  const timer = setTimeout(
+    () => controller.abort(new Error("Voice request timed out.")),
+    timeoutMs,
+  );
+  return {
+    signal: controller.signal,
+    dispose() {
+      clearTimeout(timer);
+      parent.removeEventListener("abort", abortFromParent);
+    },
+  };
+}
+
+async function readVoiceError(response: Response, signal: AbortSignal): Promise<TtsErrorBody> {
+  const bytes = await readResponseBytes(response, MAX_VOICE_ERROR_BYTES, signal);
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as TtsErrorBody) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function readResponseBytes(
+  response: Response,
+  maxBytes: number,
+  signal: AbortSignal,
+): Promise<Uint8Array> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    cancelResponse(response);
+    throw new Error("Voice response is too large.");
+  }
+  if (!response.body) {
+    const buffer = await withAbort(signal, () => response.arrayBuffer());
+    if (buffer.byteLength > maxBytes) throw new Error("Voice response is too large.");
+    return new Uint8Array(buffer);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await withAbort(signal, () => reader.read());
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+      if (total > maxBytes) throw new Error("Voice response is too large.");
+      chunks.push(value);
+    }
+  } catch (error) {
+    cancelReader(reader);
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // already cancelled or released
+    }
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function cancelResponse(response: Response): void {
+  try {
+    void Promise.resolve(response.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Response cleanup is best-effort.
+  }
+}
+
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    void Promise.resolve(reader.cancel()).catch(() => undefined);
+  } catch {
+    // Response cleanup is best-effort.
+  }
 }


### PR DESCRIPTION
## Why

The browser voice request could receive response headers and then wait forever for a stalled body. Successful audio was also buffered without a size limit, so a broken or misconfigured server could hold the speaker in preparing state or consume unbounded memory.

## What

- apply one 70-second deadline across fetch and body consumption
- stream successful audio with the same 16 MiB ceiling enforced by the provider boundary
- cap error JSON at 64 KiB
- make response cancellation best-effort so a hostile cancel implementation cannot delay the error
- preserve the response content type when constructing the playback blob

## Tests

- pnpm --filter @rakazo/web test (196 passed)
- pnpm --filter @rakazo/web check
- pnpm exec biome check apps/web/src/lib/tts.ts apps/web/src/lib/tts.test.ts