### PR TITLE
fix(desktop): avoid hanging on oversized probes

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -33,6 +33,7 @@ import {
   normalizeServerUrl,
   parseSetupInput,
   probeFailureMessage,
+  readProbeJson,
   resolveStartupTarget,
   safeExternalUrl,
   servesBundledRenderer,
@@ -51,7 +52,6 @@ const PERFORMANCE_USER_DATA = process.env.RAKAZO_PERFORMANCE_USER_DATA;
 /** Test hook: where the app-managed stack answers. Mode `new` still requires loopback. */
 const LOCAL_WEB_URL = process.env.RAKAZO_LOCAL_WEB_URL?.trim() || DEFAULT_LOCAL_WEB_URL;
 const PROBE_TIMEOUT_MS = 8_000;
-const PROBE_RESPONSE_LIMIT_BYTES = 64 * 1024;
 const DESKTOP_STACK_PROBE_PATH = "/.well-known/rakazo-desktop-stack";
 const DESKTOP_STACK_TOKEN_HEADER = "x-rakazo-desktop-stack-token";
 let mainWindow: BrowserWindow | null = null;
@@ -669,7 +669,7 @@ async function probeServer(rawUrl: string, signal?: AbortSignal): Promise<Deskto
         error: `The server answered with HTTP ${response.status}.`,
       };
     }
-    const health = await limitedJson(response);
+    const health = await readProbeJson(response);
     if (!isRakazoHealth(health)) {
       return {
         ok: false,
@@ -708,35 +708,7 @@ async function probeManagedStack(
       signal: signal ? AbortSignal.any([timeout, signal]) : timeout,
     });
     if (!response.ok) return null;
-    return desktopStackImageTag(await limitedJson(response));
-  } catch {
-    return null;
-  }
-}
-
-async function limitedJson(response: Response): Promise<unknown> {
-  if (response.body === null) return null;
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let size = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    size += value.byteLength;
-    if (size > PROBE_RESPONSE_LIMIT_BYTES) {
-      await reader.cancel();
-      return null;
-    }
-    chunks.push(value);
-  }
-  const body = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  try {
-    return JSON.parse(new TextDecoder().decode(body));
+    return desktopStackImageTag(await readProbeJson(response));
   } catch {
     return null;
   }

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_LOCAL_WEB_URL,
   desktopStackImageTag,
@@ -6,9 +6,11 @@ import {
   managedLocalOpenUrl,
   maySendDesktopStackToken,
   normalizeServerUrl,
+  PROBE_RESPONSE_LIMIT_BYTES,
   parseSetupInput,
   parseStoredSetup,
   probeFailureMessage,
+  readProbeJson,
   resolveStartupTarget,
   safeExternalUrl,
   serializeSetup,
@@ -213,6 +215,35 @@ describe("managed stack response", () => {
     expect(desktopStackImageTag({ ok: true, imageTag: "" })).toBeNull();
     expect(desktopStackImageTag({ ok: false, imageTag: "v0.2.0" })).toBeNull();
     expect(desktopStackImageTag({ json: { ok: true, imageTag: "v0.2.0" } })).toBeNull();
+  });
+
+  it("parses a bounded JSON probe response", async () => {
+    await expect(readProbeJson(Response.json({ ok: true }))).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects a declared oversized response without waiting for cancellation", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
+    const response = new Response(new ReadableStream({ cancel }), {
+      headers: { "content-length": String(PROBE_RESPONSE_LIMIT_BYTES + 1) },
+    });
+
+    await expect(readProbeJson(response)).resolves.toBeNull();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a streamed oversized response without waiting for cancellation", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(PROBE_RESPONSE_LIMIT_BYTES + 1));
+        },
+        cancel,
+      }),
+    );
+
+    await expect(readProbeJson(response)).resolves.toBeNull();
+    expect(cancel).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -4,6 +4,7 @@ import type { DesktopSetup, DesktopStackProbeResponse } from "@rakazo/contracts"
 
 /** Where `pnpm dev` serves the Rakazo web app on this machine. */
 export const DEFAULT_LOCAL_WEB_URL = "http://127.0.0.1:5173";
+export const PROBE_RESPONSE_LIMIT_BYTES = 64 * 1024;
 
 export const SETUP_FILE_NAME = "setup.json";
 
@@ -184,6 +185,69 @@ export function desktopStackImageTag(value: unknown): string | null {
   if (typeof value !== "object" || value === null) return null;
   const { ok, imageTag } = value as Partial<DesktopStackProbeResponse>;
   return ok === true && typeof imageTag === "string" && imageTag !== "" ? imageTag : null;
+}
+
+/** Reads a small probe response without letting an untrusted stream stall on cleanup. */
+export async function readProbeJson(response: Response): Promise<unknown> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > PROBE_RESPONSE_LIMIT_BYTES) {
+    cancelResponse(response);
+    return null;
+  }
+  if (response.body === null) return null;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > PROBE_RESPONSE_LIMIT_BYTES) {
+        cancelReader(reader);
+        return null;
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    cancelReader(reader);
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // already cancelled or released
+    }
+  }
+
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(body));
+  } catch {
+    return null;
+  }
+}
+
+function cancelResponse(response: Response): void {
+  try {
+    void Promise.resolve(response.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Probe cleanup is best-effort.
+  }
+}
+
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    void Promise.resolve(reader.cancel()).catch(() => undefined);
+  } catch {
+    // Probe cleanup is best-effort.
+  }
 }
 
 function isLoopbackHost(hostname: string) {


### PR DESCRIPTION
## Why

Desktop startup probes already stopped buffering after 64 KiB, but the oversize path awaited ReadableStream.cancel. A remote or custom Rakazo endpoint with a cancel implementation that never settled could therefore hang the probe instead of returning an invalid-server result. Declared oversized bodies were also read before being rejected.

## What

- move bounded probe parsing into the pure setup-config module
- reject an oversized Content-Length before reading the body
- keep the 64 KiB streaming ceiling
- cancel declared and streamed oversized bodies without awaiting untrusted cleanup
- retain null results for invalid or oversized probe JSON

## Tests

- pnpm --filter @rakazo/desktop test (203 passed)
- pnpm --filter @rakazo/desktop check
- pnpm exec biome check apps/desktop/src/main.ts apps/desktop/src/setup-config.ts apps/desktop/src/setup-config.test.ts