### PR TITLE
fix(adapters): bound screen release cleanup

### DIFF
--- a/packages/adapters/src/docker-sandbox.test.ts
+++ b/packages/adapters/src/docker-sandbox.test.ts
@@ -1,6 +1,10 @@
 import type { ProcessEvent } from "@rakazo/adapter-kit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DockerSandboxProvider, MAX_SANDBOX_ERROR_RESPONSE_BYTES } from "./docker-sandbox.js";
+import {
+  DockerSandboxProvider,
+  MAX_SANDBOX_ERROR_RESPONSE_BYTES,
+  SCREEN_RELEASE_TIMEOUT_MS,
+} from "./docker-sandbox.js";
 
 const context = {
   operationId: "docker-test",
@@ -13,7 +17,10 @@ const context = {
 };
 
 describe("Docker sandbox", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
 
   it("sends the bounded timeout to the supervisor and preserves its honest result", async () => {
     const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
@@ -94,7 +101,28 @@ describe("Docker sandbox", () => {
     ).resolves.toBeUndefined();
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(fetchMock.mock.calls[0]?.[1]).not.toHaveProperty("signal");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).not.toBe(abort.signal);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
+  });
+
+  it("bounds screen release even when fetch ignores cancellation", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Promise<Response>(() => undefined),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new DockerSandboxProvider("http://supervisor.test", "test-token");
+
+    const pending = provider.releaseScreen(
+      { id: "computer", botId: "home-bot", kind: "docker", providerRef: "computer" },
+      context,
+    );
+    const rejected = expect(pending).rejects.toThrow("sandbox screen release timed out");
+    await vi.advanceTimersByTimeAsync(SCREEN_RELEASE_TIMEOUT_MS);
+
+    await rejected;
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
 
   it("surfaces a supervisor failure from stop and destroy instead of swallowing it", async () => {

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -22,9 +22,10 @@ import {
   computerObservation,
   normalizeWorkspacePath,
 } from "./computer-support.js";
-import { readBodyCapped } from "./web-ssrf.js";
+import { readBodyCapped, withAbort } from "./web-ssrf.js";
 
 export const MAX_SANDBOX_ERROR_RESPONSE_BYTES = 8 * 1024;
+export const SCREEN_RELEASE_TIMEOUT_MS = 8_000;
 const SANDBOX_ERROR_RESPONSE_TIMEOUT_MS = 1_000;
 
 async function safeBody(res: Response, signal?: AbortSignal): Promise<string> {
@@ -358,12 +359,22 @@ export class DockerSandboxProvider implements SandboxProvider {
 
   async releaseScreen(computer: ComputerRef, context: AdapterContext): Promise<void> {
     if (!context.botId) return;
-    const res = await fetch(this.url(`/computers/${computer.id}/screen`), {
-      method: "DELETE",
-      headers: this.headers(context, computer.botId),
-    });
-    if (!res.ok && res.status !== 404) {
-      throw new Error(`sandbox screen release failed: ${res.status}`);
+    // Run cancellation must not skip cleanup, but cleanup still needs its own deadline.
+    const deadline = requestDeadline(SCREEN_RELEASE_TIMEOUT_MS, "sandbox screen release timed out");
+    try {
+      const res = await withAbort(
+        fetch(this.url(`/computers/${computer.id}/screen`), {
+          method: "DELETE",
+          headers: this.headers(context, computer.botId),
+          signal: deadline.signal,
+        }),
+        deadline.signal,
+      );
+      if (!res.ok && res.status !== 404) {
+        throw new Error(`sandbox screen release failed: ${res.status}`);
+      }
+    } finally {
+      deadline.dispose();
     }
   }
 
@@ -422,6 +433,17 @@ export class DockerSandboxProvider implements SandboxProvider {
       for (const file of batch) yield file;
     }
   }
+}
+
+function requestDeadline(timeoutMs: number, message: string) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(message)), timeoutMs);
+  return {
+    signal: controller.signal,
+    dispose() {
+      clearTimeout(timer);
+    },
+  };
 }
 
 function dockerCwd(cwd: string | undefined) {


### PR DESCRIPTION
## Why

Docker screen release intentionally ignores the completed run abort signal so cleanup still reaches the supervisor. That request had no independent deadline, however, so a stalled supervisor or fetch implementation could leave run cleanup pending forever.

## What

- give screen release its own 8-second AbortController deadline
- race fetch against that deadline even when an injected fetch ignores its signal
- continue ignoring the already-fired run signal so cleanup is still attempted
- dispose the deadline timer after every success or failure

## Tests

- pnpm --filter @rakazo/adapters test (1132 passed, 7 skipped)
- pnpm --filter @rakazo/adapters check
- focused Docker sandbox tests (9 passed)
- pnpm exec biome check packages/adapters/src/docker-sandbox.ts packages/adapters/src/docker-sandbox.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Screen release operations now remain reliable when a run is cancelled.
  - Added an independent timeout to prevent releases from hanging indefinitely.
  - Requests are cancelled automatically when the release timeout is reached.
  - Screen cleanup now completes correctly when the resource is already unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->