### PR TITLE
fix(web): bound transcription response reads

### DIFF
--- a/apps/web/src/lib/dictation.test.ts
+++ b/apps/web/src/lib/dictation.test.ts
@@ -230,6 +230,52 @@ describe("Dictation recorder fallback", () => {
     expect(dictation.state.error).toBe("Transcription request timed out.");
   });
 
+  it("surfaces timeout when fetch rejects with AbortError", async () => {
+    // Browsers reject aborted fetch with DOMException AbortError. Matching token
+    // means the deadline fired (stop() bumps token first), so this must not stay
+    // stuck on "transcribing".
+    const fetchMock = vi.fn(async () => {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    });
+    stubRecorderFallback(fetchMock);
+    const dictation = new Dictation();
+
+    await dictation.listen({ mode: "hold", transcribe: true, onFinal: () => undefined });
+    dictation.submitHold();
+
+    await vi.waitFor(() => expect(dictation.state.error).toBe("Transcription request timed out."));
+    expect(dictation.state.status).toBe("idle");
+  });
+
+  it("stays silent when stop cancels an in-flight transcription", async () => {
+    const fetchMock = vi.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            },
+            { once: true },
+          );
+        }),
+    );
+    stubRecorderFallback(fetchMock);
+    const dictation = new Dictation();
+
+    await dictation.listen({ mode: "hold", transcribe: true, onFinal: () => undefined });
+    dictation.submitHold();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(dictation.state.status).toBe("transcribing");
+
+    dictation.stop("cancel");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(dictation.state.status).toBe("idle");
+    expect(dictation.state.error).toBeUndefined();
+  });
+
   it("ignores leftover audio from a replaced recorder", async () => {
     const track = { stop: vi.fn() };
     vi.stubGlobal("navigator", {

--- a/apps/web/src/lib/dictation.test.ts
+++ b/apps/web/src/lib/dictation.test.ts
@@ -1,11 +1,42 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { Dictation } from "./dictation.js";
+import {
+  Dictation,
+  MAX_TRANSCRIPTION_RESPONSE_BYTES,
+  TRANSCRIPTION_RESPONSE_TIMEOUT_MS,
+} from "./dictation.js";
 
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   vi.useRealTimers();
 });
+
+function stubRecorderFallback(fetchMock: ReturnType<typeof vi.fn>) {
+  const track = { stop: vi.fn() };
+  vi.stubGlobal("navigator", {
+    mediaDevices: {
+      getUserMedia: vi.fn(async () => ({ getTracks: () => [track] })),
+    },
+    language: "en-US",
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal(
+    "MediaRecorder",
+    class {
+      state = "inactive";
+      ondataavailable: ((event: { data: Blob }) => void) | null = null;
+      onstop: (() => void) | null = null;
+      start() {
+        this.state = "recording";
+      }
+      stop() {
+        this.state = "inactive";
+        this.ondataavailable?.({ data: new Blob(["audio"], { type: "audio/webm" }) });
+        this.onstop?.();
+      }
+    },
+  );
+}
 
 describe("Dictation recorder fallback", () => {
   it("stops tracks if hold-to-talk is cancelled while the mic prompt is open", async () => {
@@ -64,11 +95,7 @@ describe("Dictation recorder fallback", () => {
           init?.signal?.addEventListener("abort", () =>
             reject(Object.assign(new Error("Aborted"), { name: "AbortError" })),
           );
-          transcribe = (body) =>
-            resolve({
-              ok: true,
-              json: async () => body,
-            } as Response);
+          transcribe = (body) => resolve(Response.json(body));
         }),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -126,10 +153,9 @@ describe("Dictation recorder fallback", () => {
       },
       language: "en-US",
     });
-    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({
-      ok: true,
-      json: async () => ({ text: "hello" }),
-    }));
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      Response.json({ text: "hello" }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     class FakeRecorder {
@@ -163,6 +189,47 @@ describe("Dictation recorder fallback", () => {
     expect(headers.get("content-type")).toBe("application/json");
   });
 
+  it("rejects oversized transcription responses without waiting for cancellation", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(new ReadableStream({ cancel }), {
+          headers: { "content-length": String(MAX_TRANSCRIPTION_RESPONSE_BYTES + 1) },
+        }),
+    );
+    stubRecorderFallback(fetchMock);
+    const dictation = new Dictation();
+
+    await dictation.listen({ mode: "hold", transcribe: true, onFinal: () => undefined });
+    dictation.submitHold();
+
+    await vi.waitFor(() =>
+      expect(dictation.state.error).toBe("Transcription response is too large."),
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("times out while a transcription response body is stalled", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream({
+            pull: () => new Promise<void>(() => undefined),
+          }),
+        ),
+    );
+    stubRecorderFallback(fetchMock);
+    const dictation = new Dictation();
+
+    await dictation.listen({ mode: "hold", transcribe: true, onFinal: () => undefined });
+    dictation.submitHold();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(TRANSCRIPTION_RESPONSE_TIMEOUT_MS);
+
+    expect(dictation.state.error).toBe("Transcription request timed out.");
+  });
+
   it("ignores leftover audio from a replaced recorder", async () => {
     const track = { stop: vi.fn() };
     vi.stubGlobal("navigator", {
@@ -171,10 +238,9 @@ describe("Dictation recorder fallback", () => {
       },
       language: "en-US",
     });
-    const fetchMock = vi.fn(async (_url: string, _init?: { body?: string }) => ({
-      ok: true,
-      json: async () => ({ text: "ok" }),
-    }));
+    const fetchMock = vi.fn(async (_url: string, _init?: { body?: string }) =>
+      Response.json({ text: "ok" }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const recorders: Array<{
@@ -278,10 +344,7 @@ describe("Dictation recorder fallback", () => {
       },
       language: "en-US",
     });
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ text: "hello" }),
-    }));
+    const fetchMock = vi.fn(async () => Response.json({ text: "hello" }));
     vi.stubGlobal("fetch", fetchMock);
 
     const onFinal = vi.fn();
@@ -348,10 +411,7 @@ describe("Dictation recorder fallback", () => {
       },
       language: "en-US",
     });
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ text: "later" }),
-    }));
+    const fetchMock = vi.fn(async () => Response.json({ text: "later" }));
     vi.stubGlobal("fetch", fetchMock);
 
     const recorders: Array<{

--- a/apps/web/src/lib/dictation.ts
+++ b/apps/web/src/lib/dictation.ts
@@ -25,6 +25,8 @@ interface SpeechRecognitionLike {
 const IDLE: DictationSnapshot = { status: "idle", transcript: "" };
 const ENDPOINT_TICK_MS = 80;
 const SILENCE_RMS = 0.035;
+export const TRANSCRIPTION_RESPONSE_TIMEOUT_MS = 70_000;
+export const MAX_TRANSCRIPTION_RESPONSE_BYTES = 64 * 1024;
 const ENDPOINT_UNSUPPORTED =
   "This browser can't detect when you stop talking. Use Chrome, the desktop app, or hold-to-talk in the composer.";
 
@@ -297,18 +299,25 @@ export class Dictation {
     this.set({ status: "transcribing", transcript: this.snapshot.transcript });
     const abort = new AbortController();
     this.transcribeAbort = abort;
+    const timer = setTimeout(
+      () => abort.abort(new Error("Transcription request timed out.")),
+      TRANSCRIPTION_RESPONSE_TIMEOUT_MS,
+    );
     try {
       const audioBase64 = await blobToBase64(blob);
       if (this.token !== mine) return;
-      const res = await fetch("/api/voice/transcribe", {
-        method: "POST",
-        headers: withSpaceHeaders({ "content-type": "application/json" }, spaceId),
-        credentials: "include",
-        body: JSON.stringify({ audioBase64, mimeType: blob.type }),
-        signal: abort.signal,
-      });
+      const res = await withAbort(
+        fetch("/api/voice/transcribe", {
+          method: "POST",
+          headers: withSpaceHeaders({ "content-type": "application/json" }, spaceId),
+          credentials: "include",
+          body: JSON.stringify({ audioBase64, mimeType: blob.type }),
+          signal: abort.signal,
+        }),
+        abort.signal,
+      );
       if (this.token !== mine) return;
-      const body = (await res.json().catch(() => ({}))) as { text?: string; error?: string };
+      const body = await readTranscriptionBody(res, abort.signal);
       if (this.token !== mine) return;
       if (!res.ok) {
         this.set({ ...IDLE, error: body.error ?? "Could not transcribe that recording." });
@@ -322,6 +331,9 @@ export class Dictation {
         ...IDLE,
         error: error instanceof Error ? error.message : "Could not transcribe that recording.",
       });
+    } finally {
+      clearTimeout(timer);
+      if (this.transcribeAbort === abort) this.transcribeAbort = null;
     }
   }
 
@@ -348,6 +360,103 @@ async function blobToBase64(blob: Blob): Promise<string> {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary);
+}
+
+async function readTranscriptionBody(
+  response: Response,
+  signal: AbortSignal,
+): Promise<{ text?: string; error?: string }> {
+  const declared = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > MAX_TRANSCRIPTION_RESPONSE_BYTES) {
+    cancelResponse(response);
+    throw new Error("Transcription response is too large.");
+  }
+  const bytes = await readResponseBytes(response, signal);
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+    return parsed && typeof parsed === "object"
+      ? (parsed as { text?: string; error?: string })
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function readResponseBytes(response: Response, signal: AbortSignal): Promise<Uint8Array> {
+  if (!response.body) {
+    const buffer = await withAbort(response.arrayBuffer(), signal);
+    if (buffer.byteLength > MAX_TRANSCRIPTION_RESPONSE_BYTES) {
+      throw new Error("Transcription response is too large.");
+    }
+    return new Uint8Array(buffer);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await withAbort(reader.read(), signal);
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+      if (total > MAX_TRANSCRIPTION_RESPONSE_BYTES) {
+        throw new Error("Transcription response is too large.");
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    cancelReader(reader);
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // already cancelled or released
+    }
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason ?? new Error("Request aborted."));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason ?? new Error("Request aborted."));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function cancelResponse(response: Response): void {
+  try {
+    void Promise.resolve(response.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Response cleanup is best-effort.
+  }
+}
+
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    void Promise.resolve(reader.cancel()).catch(() => undefined);
+  } catch {
+    // Response cleanup is best-effort.
+  }
 }
 
 export const dictation = new Dictation();

--- a/apps/web/src/lib/dictation.ts
+++ b/apps/web/src/lib/dictation.ts
@@ -316,7 +316,10 @@ export class Dictation {
         }),
         abort.signal,
       );
-      if (this.token !== mine) return;
+      if (this.token !== mine) {
+        cancelResponse(res);
+        return;
+      }
       const body = await readTranscriptionBody(res, abort.signal);
       if (this.token !== mine) return;
       if (!res.ok) {
@@ -325,8 +328,18 @@ export class Dictation {
       }
       this.finish(body.text ?? "", mine);
     } catch (error) {
+      // User cancel bumps token in stop() before aborting, so a matching token
+      // means the deadline timer fired. Browsers may reject fetch as AbortError
+      // instead of signal.reason; surface the timeout either way.
       if (this.token !== mine) return;
-      if (error instanceof Error && error.name === "AbortError") return;
+      const timedOut =
+        (abort.signal.reason instanceof Error &&
+          abort.signal.reason.message === "Transcription request timed out.") ||
+        (error instanceof Error && error.message === "Transcription request timed out.");
+      if (timedOut || (error instanceof Error && error.name === "AbortError")) {
+        this.set({ ...IDLE, error: "Transcription request timed out." });
+        return;
+      }
       this.set({
         ...IDLE,
         error: error instanceof Error ? error.message : "Could not transcribe that recording.",
@@ -437,7 +450,8 @@ function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
       },
       (error: unknown) => {
         signal.removeEventListener("abort", onAbort);
-        reject(error);
+        // Prefer abort reason over a bare AbortError from fetch/read.
+        reject(signal.aborted ? (signal.reason ?? error) : error);
       },
     );
   });


### PR DESCRIPTION
## Why

Browser dictation could receive transcription response headers and then remain in transcribing state forever if the body stalled. It also parsed response JSON without a size ceiling, so a broken or misconfigured server could buffer an unbounded response.

## What

- apply one 70-second deadline across transcription fetch and body consumption
- cap transcription JSON at 64 KiB while streaming
- reject declared oversized responses before reading
- make response cancellation best-effort so cleanup cannot delay the error
- clear the active transcription controller after every terminal path

## Tests

- pnpm --filter @rakazo/web test (196 passed)
- pnpm --filter @rakazo/web check
- focused dictation tests (10 passed)
- pnpm exec biome check apps/web/src/lib/dictation.ts apps/web/src/lib/dictation.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transcription requests now time out after 70 seconds when responses stall.
  * Oversized transcription responses are rejected at the 64 KiB limit.
  * Timed-out requests are cancelled and cleaned up reliably.
  * Timeout errors are reported clearly instead of being silently ignored.
  * Cancelling an in-progress transcription no longer incorrectly displays an error.
  * Improved handling of response-reading failures and cancelled requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->