### PR TITLE
fix(api): bound voice request bodies

### DIFF
--- a/apps/api/src/http-body.ts
+++ b/apps/api/src/http-body.ts
@@ -1,0 +1,41 @@
+/** Reads a request body without buffering more than maxBytes. */
+export async function readBoundedBody(request: Request, maxBytes: number): Promise<string | null> {
+  const contentLengthHeader = request.headers.get("content-length");
+  if (contentLengthHeader !== null) {
+    const contentLength = Number(contentLengthHeader);
+    if (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > maxBytes) {
+      cancelBody(request.body);
+      return null;
+    }
+  }
+
+  if (!request.body) return "";
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let body = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > maxBytes) {
+        cancelBody(reader);
+        return null;
+      }
+      body += decoder.decode(value, { stream: true });
+    }
+    return body + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function cancelBody(body: { cancel(): Promise<void> } | null): void {
+  try {
+    void body?.cancel().catch(() => undefined);
+  } catch {
+    // Best-effort cleanup must not delay the 413 response.
+  }
+}

--- a/apps/api/src/voice.test.ts
+++ b/apps/api/src/voice.test.ts
@@ -1,6 +1,13 @@
+import type { Actor } from "@rakazo/contracts";
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
-import { mountVoiceHttpRoutes, toVoiceStatus, type VoiceDeps } from "./voice.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  MAX_SPEAK_REQUEST_BYTES,
+  MAX_TRANSCRIBE_REQUEST_BYTES,
+  mountVoiceHttpRoutes,
+  toVoiceStatus,
+  type VoiceDeps,
+} from "./voice.js";
 
 describe("toVoiceStatus", () => {
   it("treats a saved key without a voice as configured but not ready", () => {
@@ -45,5 +52,62 @@ describe("voice HTTP routes", () => {
     });
     expect(speak.status).toBe(401);
     expect(transcribe.status).toBe(401);
+  });
+
+  it.each([
+    ["/api/voice/speak", MAX_SPEAK_REQUEST_BYTES],
+    ["/api/voice/transcribe", MAX_TRANSCRIBE_REQUEST_BYTES],
+  ])(
+    "rejects a declared oversized body on %s without waiting for cancellation",
+    async (path, max) => {
+      const cancel = vi.fn(() => new Promise<void>(() => undefined));
+      const request = new Request(`http://localhost${path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(max + 1),
+        },
+        body: new ReadableStream({ cancel }),
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+      const app = new Hono();
+      mountVoiceHttpRoutes(
+        app,
+        {} as VoiceDeps,
+        async () => ({ userId: "user", spaceId: "space" }) as Actor,
+      );
+
+      const response = await app.request(request);
+
+      expect(response.status).toBe(413);
+      await expect(response.json()).resolves.toEqual({ error: "Request body is too large." });
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("stops reading a streamed oversized speak body", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => undefined));
+    const request = new Request("http://localhost/api/voice/speak", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(MAX_SPEAK_REQUEST_BYTES + 1));
+        },
+        cancel,
+      }),
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+    const app = new Hono();
+    mountVoiceHttpRoutes(
+      app,
+      {} as VoiceDeps,
+      async () => ({ userId: "user", spaceId: "space" }) as Actor,
+    );
+
+    const response = await app.request(request);
+
+    expect(response.status).toBe(413);
+    expect(cancel).toHaveBeenCalledOnce();
   });
 });

--- a/apps/api/src/voice.ts
+++ b/apps/api/src/voice.ts
@@ -23,6 +23,7 @@ import {
   selectSpaceVoicePreference,
 } from "@rakazo/db";
 import type { Context, Hono } from "hono";
+import { readBoundedBody } from "./http-body.js";
 import { withSerializableRetry } from "./serializable-retry.js";
 
 export interface VoiceDeps {
@@ -33,6 +34,8 @@ export interface VoiceDeps {
 export { listVoiceCatalog };
 
 const SPEAK_TIMEOUT_MS = 60_000;
+export const MAX_SPEAK_REQUEST_BYTES = 16 * 1024;
+export const MAX_TRANSCRIBE_REQUEST_BYTES = 4 * Math.ceil(MAX_TRANSCRIBE_BYTES / 3) + 1024;
 
 export function voiceContext(actor: Actor, signal?: AbortSignal): AdapterContext {
   return {
@@ -266,7 +269,9 @@ export function mountVoiceHttpRoutes(
   app.post("/api/voice/speak", async (c) => {
     const actor = await authenticate(c);
     if (!actor) return c.json({ error: "Unauthorized" }, 401);
-    const body = await c.req.json().catch(() => ({}));
+    const raw = await readBoundedBody(c.req.raw, MAX_SPEAK_REQUEST_BYTES);
+    if (raw === null) return c.json({ error: "Request body is too large." }, 413);
+    const body = parseVoiceRequestBody(raw);
     try {
       const clip = await synthesizeVoice(deps, actor, {
         text: String((body as { text?: unknown }).text ?? ""),
@@ -294,7 +299,9 @@ export function mountVoiceHttpRoutes(
   app.post("/api/voice/transcribe", async (c) => {
     const actor = await authenticate(c);
     if (!actor) return c.json({ error: "Unauthorized" }, 401);
-    const body = await c.req.json().catch(() => ({}));
+    const raw = await readBoundedBody(c.req.raw, MAX_TRANSCRIBE_REQUEST_BYTES);
+    if (raw === null) return c.json({ error: "Request body is too large." }, 413);
+    const body = parseVoiceRequestBody(raw);
     const audioBase64 = String((body as { audioBase64?: unknown }).audioBase64 ?? "");
     try {
       const audio = decodeAudioBase64(audioBase64);
@@ -308,6 +315,17 @@ export function mountVoiceHttpRoutes(
       return voiceHttpError(c, error);
     }
   });
+}
+
+function parseVoiceRequestBody(raw: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
 }
 
 function optionalString(value: unknown): string | undefined {

--- a/apps/api/src/webhook.test.ts
+++ b/apps/api/src/webhook.test.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import { describe, expect, it, vi } from "vitest";
+import { readBoundedBody } from "./http-body.js";
 import {
   formatWebhookPrompt,
   mountWebhookHttpRoutes,
-  readBoundedBody,
   WEBHOOK_MAX_BODY_BYTES,
   WEBHOOK_SECRET_KIND,
   type WebhookDeps,

--- a/apps/api/src/webhook.ts
+++ b/apps/api/src/webhook.ts
@@ -6,6 +6,7 @@ import { hasValidBearerToken } from "@rakazo/core";
 import type { PrismaClient } from "@rakazo/db";
 import { getLogger } from "@rakazo/logging";
 import type { Hono } from "hono";
+import { readBoundedBody } from "./http-body.js";
 
 export const WEBHOOK_MAX_BODY_BYTES = 64 * 1024;
 export const WEBHOOK_SECRET_KIND = "webhook";
@@ -40,47 +41,6 @@ export function formatWebhookPrompt(payload: Record<string, unknown>): string {
 
 export function webhookPath(botId: string): string {
   return `/api/v1/bots/${botId}/webhook`;
-}
-
-export async function readBoundedBody(request: Request, maxBytes: number): Promise<string | null> {
-  const contentLengthHeader = request.headers.get("content-length");
-  if (contentLengthHeader !== null) {
-    const contentLength = Number(contentLengthHeader);
-    if (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > maxBytes) {
-      cancelBody(request.body);
-      return null;
-    }
-  }
-
-  if (!request.body) return "";
-
-  const reader = request.body.getReader();
-  const decoder = new TextDecoder();
-  let bytes = 0;
-  let body = "";
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      bytes += value.byteLength;
-      if (bytes > maxBytes) {
-        cancelBody(reader);
-        return null;
-      }
-      body += decoder.decode(value, { stream: true });
-    }
-    return body + decoder.decode();
-  } finally {
-    reader.releaseLock();
-  }
-}
-
-function cancelBody(body: { cancel(): Promise<void> } | null): void {
-  try {
-    void body?.cancel().catch(() => undefined);
-  } catch {
-    // Best-effort cleanup must not delay the 413 response.
-  }
 }
 
 function parseWebhookPayload(


### PR DESCRIPTION
## Why

The authenticated voice HTTP routes parsed request JSON before enforcing any body limit. The speak route only needs a short utterance, while the transcription route accepts at most 8 MiB of decoded audio, but either endpoint could first buffer a much larger declared or chunked JSON payload.

## What

- move the existing bounded request reader into a neutral HTTP helper shared with webhooks
- cap speak request JSON at 16 KiB
- cap transcription JSON at the maximum 8 MiB audio base64 expansion plus JSON overhead
- return 413 before provider or database work for declared and streamed overflow
- keep cancellation best-effort so a stalled request-body cancel cannot delay the response

## Tests

- pnpm --filter @rakazo/api test (194 passed)
- pnpm --filter @rakazo/api check
- focused voice and webhook tests (19 passed)
- pnpm exec biome check on all changed API files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Voice speak and transcribe requests now enforce maximum body sizes.
  - Oversized requests are rejected with a clear “Request body is too large.” message and a 413 response.
  - Large streamed requests stop processing promptly instead of continuing to consume the request.
  - Invalid or malformed voice request payloads are handled safely without causing unexpected failures.

- **Refactor**
  - Request body size handling is now shared across applicable API endpoints for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->