### PR TITLE
fix(mobile): bound sign-out requests

### DIFF
--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -249,6 +249,23 @@ describe("mobile API authentication", () => {
     expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith("rakazo.session_token");
   });
 
+  it("clears the local session when the sign-out request stalls", async () => {
+    vi.useFakeTimers();
+    vi.mocked(SecureStore.getItemAsync).mockResolvedValue("session-token");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ json: null }))
+      .mockImplementationOnce(() => new Promise<Response>(() => undefined));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = signOut();
+    await vi.advanceTimersByTimeAsync(8_000);
+    await pending;
+
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith("rakazo.session_token");
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith("rakazo.space_id");
+  });
+
   it("unregisters push delivery before deleting the account", async () => {
     vi.mocked(SecureStore.getItemAsync).mockResolvedValue("session-token");
     const fetchMock = vi

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -359,13 +359,41 @@ export async function changePassword(currentPassword: string, newPassword: strin
 export async function signOut() {
   await rpc("notifications/unregisterPush").catch(() => undefined);
   const headers = await authHeaders();
-  await fetch(`${currentApiBase()}/api/auth/sign-out`, {
-    method: "POST",
-    headers: { "content-type": "application/json", origin: "rakazo://", ...headers },
-  }).catch(() => undefined);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RPC_TIMEOUT_MS);
+  try {
+    await withAbort(
+      fetch(`${currentApiBase()}/api/auth/sign-out`, {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: "rakazo://", ...headers },
+        signal: controller.signal,
+      }),
+      controller.signal,
+    ).catch(() => undefined);
+  } finally {
+    clearTimeout(timer);
+  }
   const sessionCleared = await clearSessionToken();
   const spaceCleared = await clearSpace();
   if (!sessionCleared || !spaceCleared) throw new Error(t("Could not clear the local session"));
+}
+
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason ?? new Error("Request timed out"));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason ?? new Error("Request timed out"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 export async function deleteAccount(password: string) {


### PR DESCRIPTION
## Why

Mobile sign-out waits for the remote session invalidation before clearing local credentials. Unlike the preceding push-unregistration RPC, that request had no deadline, so an offline or unresponsive custom server could prevent the user from signing out locally.

## What

- Give the remote sign-out request the existing 8-second mobile RPC deadline.
- Race the fetch against its abort signal so cleanup proceeds even when a fetch implementation ignores cancellation.
- Preserve best-effort remote invalidation and always continue to local credential cleanup.
- Add a deterministic stalled-request regression test.

## Tests

- `pnpm exec vitest run apps/mobile/lib/api.test.ts` (51 passed)
- `pnpm --filter @rakazo/mobile test` (165 passed)
- `pnpm --filter @rakazo/mobile check`
- `pnpm exec biome check apps/mobile/lib/api.ts apps/mobile/lib/api.test.ts`