### PR TITLE
fix(mobile): handle immediate audio completion

### DIFF
--- a/apps/mobile/lib/voice.test.ts
+++ b/apps/mobile/lib/voice.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureApiRequestContext, currentApiBase, rpc } from "./api";
 import {
   MAX_VOICE_AUDIO_BYTES,
+  playMpeg,
   speakText,
   speakUtterance,
   VOICE_RESPONSE_TIMEOUT_MS,
@@ -75,6 +76,21 @@ describe("mobile speech", () => {
       expect(url).toBe("https://support.example/api/voice/speak");
       expect(init?.headers).toMatchObject(requestContext.headers);
     }
+  });
+
+  it("listens for an HTML audio clip ending before playback starts", async () => {
+    class ImmediateAudio {
+      onended: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      async play() {
+        expect(this.onended).toBeTypeOf("function");
+        this.onended?.();
+      }
+    }
+    vi.stubGlobal("Audio", ImmediateAudio);
+
+    await expect(playMpeg(new Uint8Array([1, 2, 3]))).resolves.toBeUndefined();
   });
 
   it("rejects oversized audio without waiting for response cancellation", async () => {

--- a/apps/mobile/lib/voice.ts
+++ b/apps/mobile/lib/voice.ts
@@ -70,10 +70,27 @@ async function playWithHtmlAudio(AudioCtor: typeof Audio, bytes: Uint8Array): Pr
   const url = URL.createObjectURL(blob);
   try {
     const audio = new AudioCtor(url);
-    await audio.play();
     await new Promise<void>((resolve, reject) => {
-      audio.onended = () => resolve();
-      audio.onerror = () => reject(new Error(t("Could not play that clip.")));
+      let settled = false;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        audio.onended = null;
+        audio.onerror = null;
+        if (error) reject(error);
+        else resolve();
+      };
+      audio.onended = () => finish();
+      audio.onerror = () => finish(new Error(t("Could not play that clip.")));
+      try {
+        void audio
+          .play()
+          .catch((error: unknown) =>
+            finish(error instanceof Error ? error : new Error(t("Could not play that clip."))),
+          );
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(t("Could not play that clip.")));
+      }
     });
   } finally {
     URL.revokeObjectURL(url);


### PR DESCRIPTION
## Why

The mobile web-compatible audio path started playback before registering its completion handlers. A short clip can therefore finish synchronously, lose the `ended` event, and leave speech playback waiting forever.

## What

- Register HTML audio completion and error handlers before calling `play()`.
- Settle the playback promise exactly once and clear handlers on every terminal path.
- Handle both synchronous and asynchronous playback-start failures.
- Add a regression test with an audio implementation that completes immediately.

## Tests

- `pnpm exec vitest run apps/mobile/lib/voice.test.ts`
- `pnpm --filter @rakazo/mobile test` (165 passed)
- `pnpm --filter @rakazo/mobile check`
- `pnpm exec biome check apps/mobile/lib/voice.ts apps/mobile/lib/voice.test.ts`