### PR TITLE
fix(computer): bind pending takeover so Skip/I'm done work (#658)

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -3850,35 +3850,52 @@ async function bindWaitingTakeoverToControl(
     controlRunId: string | null;
   },
 ): Promise<void> {
-  const executionLease = await deps.prisma.computerExecutionLease.findUnique({
-    where: { computerId_botId: { computerId: input.computerId, botId: input.botId } },
-  });
-  if (!executionLease) return;
-  const executionRun = await deps.prisma.run.findUnique({
-    where: { id: executionLease.runId },
-    select: { botId: true, status: true },
-  });
-  const waitingForTakeover =
-    executionRun?.botId === input.botId && executionRun.status === "waiting_takeover";
-  if (!waitingForTakeover) return;
-  if (input.controlRunId === executionLease.runId) return;
+  await deps.prisma.$transaction(async (tx) => {
+    // Lock the execution lease so a reclaimed fence/run cannot be bound by a stale read.
+    const locked = await tx.$queryRaw<Array<{ runId: string; fence: number }>>`
+      SELECT "runId", fence FROM computer_execution_leases
+      WHERE "computerId" = ${input.computerId} AND "botId" = ${input.botId}
+      FOR UPDATE`;
+    const executionLease = locked[0];
+    if (!executionLease) return;
 
-  const bound = await deps.prisma.computer.updateMany({
-    where: {
-      id: input.computerId,
-      controlLeaseId: input.controlLeaseId,
-      controlBotId: input.botId,
-    },
-    data: { controlRunId: executionLease.runId },
-  });
-  if (bound.count !== 1 || !input.threadId) return;
+    const executionRun = await tx.run.findUnique({
+      where: { id: executionLease.runId },
+      select: { botId: true, status: true },
+    });
+    const waitingForTakeover =
+      executionRun?.botId === input.botId && executionRun.status === "waiting_takeover";
+    if (!waitingForTakeover) return;
+    if (input.controlRunId === executionLease.runId) return;
 
-  await deps.events.append({
-    spaceId: input.spaceId,
-    threadId: input.threadId,
-    botId: input.botId,
-    type: "computer.takeover.granted",
-    payload: { leaseId: input.controlLeaseId, takeoverRequested: true },
+    // Confirm the locked lease row still matches before writing controlRunId.
+    const leaseStillCurrent = await tx.computerExecutionLease.count({
+      where: {
+        computerId: input.computerId,
+        botId: input.botId,
+        runId: executionLease.runId,
+        fence: executionLease.fence,
+      },
+    });
+    if (leaseStillCurrent !== 1) return;
+
+    const bound = await tx.computer.updateMany({
+      where: {
+        id: input.computerId,
+        controlLeaseId: input.controlLeaseId,
+        controlBotId: input.botId,
+      },
+      data: { controlRunId: executionLease.runId },
+    });
+    if (bound.count !== 1 || !input.threadId) return;
+
+    await deps.events.append({
+      spaceId: input.spaceId,
+      threadId: input.threadId,
+      botId: input.botId,
+      type: "computer.takeover.granted",
+      payload: { leaseId: input.controlLeaseId, takeoverRequested: true },
+    });
   });
 }
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1428,6 +1428,14 @@ export function createRouter(deps: RouterDeps) {
           throw new ORPCError("BAD_REQUEST", { message: "computer must be running" });
         }
         if (hasActiveComputerControl(bot.computer) && bot.computer.controlBotId === bot.id) {
+          await bindWaitingTakeoverToControl(deps, {
+            spaceId: context.actor.spaceId,
+            threadId: bot.thread?.id,
+            botId: bot.id,
+            computerId: bot.computer.id,
+            controlLeaseId: bot.computer.controlLeaseId!,
+            controlRunId: bot.computer.controlRunId,
+          });
           await scheduleComputerControlExpiry(
             deps.jobs,
             bot.computer.id,
@@ -1512,6 +1520,16 @@ export function createRouter(deps: RouterDeps) {
             where: { id: bot.computer.id },
           });
           if (!hasActiveComputerControl(current)) throw new ORPCError("CONFLICT");
+          if (current.controlBotId === bot.id) {
+            await bindWaitingTakeoverToControl(deps, {
+              spaceId: context.actor.spaceId,
+              threadId: bot.thread?.id,
+              botId: bot.id,
+              computerId: current.id,
+              controlLeaseId: current.controlLeaseId!,
+              controlRunId: current.controlRunId,
+            });
+          }
           await scheduleComputerControlExpiry(
             deps.jobs,
             current.id,
@@ -3817,6 +3835,51 @@ async function expireStaleComputerControl(
     return true;
   }
   return clearInactiveUserComputerControl(deps.prisma, computer.id).catch(() => false);
+}
+
+/** When the user already holds control during waiting_takeover, bind controlRunId so
+ * takeoverRequested becomes true and release can resume the waiting run. */
+async function bindWaitingTakeoverToControl(
+  deps: RouterDeps,
+  input: {
+    spaceId: string;
+    threadId: string | null | undefined;
+    botId: string;
+    computerId: string;
+    controlLeaseId: string;
+    controlRunId: string | null;
+  },
+): Promise<void> {
+  const executionLease = await deps.prisma.computerExecutionLease.findUnique({
+    where: { computerId_botId: { computerId: input.computerId, botId: input.botId } },
+  });
+  if (!executionLease) return;
+  const executionRun = await deps.prisma.run.findUnique({
+    where: { id: executionLease.runId },
+    select: { botId: true, status: true },
+  });
+  const waitingForTakeover =
+    executionRun?.botId === input.botId && executionRun.status === "waiting_takeover";
+  if (!waitingForTakeover) return;
+  if (input.controlRunId === executionLease.runId) return;
+
+  const bound = await deps.prisma.computer.updateMany({
+    where: {
+      id: input.computerId,
+      controlLeaseId: input.controlLeaseId,
+      controlBotId: input.botId,
+    },
+    data: { controlRunId: executionLease.runId },
+  });
+  if (bound.count !== 1 || !input.threadId) return;
+
+  await deps.events.append({
+    spaceId: input.spaceId,
+    threadId: input.threadId,
+    botId: input.botId,
+    type: "computer.takeover.granted",
+    payload: { leaseId: input.controlLeaseId, takeoverRequested: true },
+  });
 }
 
 async function computerScreenContext(

--- a/apps/web/src/lib/thread-events.test.ts
+++ b/apps/web/src/lib/thread-events.test.ts
@@ -1324,11 +1324,35 @@ describe("computer event reduction", () => {
     expect(computerTakeoverBlocked(computer({ busyBotName: "Writer" }), "completed")).toBe(false);
   });
 
-  it("clears the busy bot when takeover is requested or granted", () => {
-    const busy = computer({ state: "running", busyBotName: "Writer" });
+  it("marks takeover requested and clears control unless the lease was retained", () => {
+    const busy = computer({ state: "running", busyBotName: "Writer", controlHolder: "bot" });
     expect(
       reduceComputerStatus(busy, event({ type: "computer.takeover.requested", payload: {} })),
-    ).toMatchObject({ busyBotName: null });
+    ).toMatchObject({
+      busyBotName: null,
+      takeoverRequested: true,
+      controlHolder: "none",
+      controlBotId: null,
+    });
+    expect(
+      reduceComputerStatus(
+        computer({
+          state: "running",
+          controlHolder: "user",
+          controlBotId: "bot-1",
+          takeoverRequested: false,
+        }),
+        event({
+          type: "computer.takeover.requested",
+          payload: { retainedControl: true },
+        }),
+      ),
+    ).toMatchObject({
+      controlHolder: "user",
+      controlBotId: "bot-1",
+      takeoverRequested: true,
+      busyBotName: null,
+    });
     expect(
       reduceComputerStatus(
         busy,

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -533,7 +533,21 @@ export function reduceComputerStatus(
   if (!prev) return prev;
   if (!isComputerStatusEvent(event)) return prev;
   if (event.type === "computer.takeover.requested") {
-    return prev.busyBotName === null ? prev : { ...prev, busyBotName: null };
+    const retainedControl = event.payload.retainedControl === true;
+    const next = {
+      ...prev,
+      busyBotName: null,
+      takeoverRequested: true,
+      ...(retainedControl
+        ? {}
+        : { controlHolder: "none" as const, controlBotId: null }),
+    };
+    return prev.busyBotName === next.busyBotName &&
+      prev.takeoverRequested === next.takeoverRequested &&
+      prev.controlHolder === next.controlHolder &&
+      prev.controlBotId === next.controlBotId
+      ? prev
+      : next;
   }
   if (event.type === "computer.takeover.granted") {
     const takeoverRequested = event.payload.takeoverRequested === true;

--- a/apps/web/src/lib/thread-events.ts
+++ b/apps/web/src/lib/thread-events.ts
@@ -538,9 +538,7 @@ export function reduceComputerStatus(
       ...prev,
       busyBotName: null,
       takeoverRequested: true,
-      ...(retainedControl
-        ? {}
-        : { controlHolder: "none" as const, controlBotId: null }),
+      ...(retainedControl ? {} : { controlHolder: "none" as const, controlBotId: null }),
     };
     return prev.busyBotName === next.busyBotName &&
       prev.takeoverRequested === next.takeoverRequested &&

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -3960,9 +3960,15 @@ export function ShellPage() {
                 </span>
               )}
               {!recordingSkill && hasControl ? (
-                <span className="rounded-full bg-success/15 px-[11px] py-1 text-[13px] text-success">
-                  <Trans>You have control</Trans>
-                </span>
+                computer?.takeoverRequested ? (
+                  <span className="rounded-full bg-warning/15 px-[11px] py-1 text-[13px] text-warning">
+                    <Trans>Needs you</Trans>
+                  </span>
+                ) : (
+                  <span className="rounded-full bg-success/15 px-[11px] py-1 text-[13px] text-success">
+                    <Trans>You have control</Trans>
+                  </span>
+                )
               ) : null}
             </div>
             <div className="flex items-center gap-3">
@@ -5571,7 +5577,13 @@ const MessageView = memo(function MessageView({
                 <span className="text-[15px] font-medium text-foreground">
                   <Trans>Computer</Trans>
                 </span>
-                <span className="rounded-full bg-success/15 px-[11px] py-1 text-[13px] text-success">
+                <span
+                  className={
+                    block.state === "Needs you"
+                      ? "rounded-full bg-warning/15 px-[11px] py-1 text-[13px] text-warning"
+                      : "rounded-full bg-success/15 px-[11px] py-1 text-[13px] text-success"
+                  }
+                >
                   {block.state}
                 </span>
               </div>

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -3160,19 +3160,8 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 pendingProgress = "";
               }
               await publishMessage(deps, run, "bot", [
-                { kind: "computer", state: "Ready", text: safeReason },
+                { kind: "computer", state: "Needs you", text: safeReason },
               ]);
-              await deps.prisma.computer.updateMany({
-                where: { id: storedComputer.id },
-                data: {
-                  state: "running",
-                  controlHolder: "none",
-                  controlLeaseId: null,
-                  controlLeaseExpiresAt: null,
-                  controlBotId: null,
-                  controlRunId: null,
-                },
-              });
               await workspaceCheckpoint.flush();
               if (!(await holdComputerExecutionLeaseForTakeover(deps.prisma, computerLease))) {
                 throw new Error("Computer lease expired before takeover");
@@ -3186,6 +3175,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 leaseOwner: workerId,
                 leaseFence: fence,
                 reason: safeReason,
+                computerId: storedComputer.id,
               });
               if (!paused) return;
               retainComputerLease = true;

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -432,7 +432,7 @@ describe("pauseRunForInput", () => {
 });
 
 describe("pauseRunForTakeover", () => {
-  it("stores the paused run, attempt, and takeover event in one transaction", async () => {
+  it("stores the paused run, attempt, computer takeover mark, and event in one transaction", async () => {
     const fanout = new TestFanout();
     const publish = vi.spyOn(fanout, "publish");
     const tx = {
@@ -442,6 +442,15 @@ describe("pauseRunForTakeover", () => {
         findUnique: vi.fn().mockResolvedValue({ status: "waiting_takeover" }),
       },
       attempt: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      computer: {
+        findFirst: vi.fn().mockResolvedValue({
+          controlHolder: "none",
+          controlBotId: null,
+          controlLeaseId: null,
+          controlLeaseExpiresAt: null,
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
       thread: { update: vi.fn().mockResolvedValue({ nextEventSeq: 8 }) },
       event: {
         create: vi.fn(async ({ data }: { data: { seq: number; type: string } }) => ({
@@ -467,6 +476,7 @@ describe("pauseRunForTakeover", () => {
           leaseOwner: "worker-1",
           leaseFence: 3,
           reason: "Sign in",
+          computerId: "computer-1",
         },
         fanout,
       ),
@@ -486,15 +496,88 @@ describe("pauseRunForTakeover", () => {
     expect(tx.attempt.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ status: "waiting_takeover" }) }),
     );
+    expect(tx.computer.updateMany).toHaveBeenCalledWith({
+      where: { id: "computer-1", spaceId: "workspace-1" },
+      data: {
+        state: "running",
+        controlHolder: "none",
+        controlLeaseId: null,
+        controlLeaseExpiresAt: null,
+        controlBotId: null,
+        controlRunId: "run-1",
+      },
+    });
     expect(tx.event.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           type: "computer.takeover.requested",
-          payload: { reason: "Sign in" },
+          payload: {
+            reason: "Sign in",
+            takeoverRequested: true,
+            retainedControl: false,
+          },
         }),
       }),
     );
     expect(publish).toHaveBeenCalledWith("thread:thread-1", JSON.stringify({ cursor: 7 }));
+  });
+
+  it("keeps an active user control lease and only binds controlRunId", async () => {
+    const expiresAt = new Date(Date.now() + 60_000);
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "thread-1" }]),
+      run: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUnique: vi.fn().mockResolvedValue({ status: "waiting_takeover" }),
+      },
+      attempt: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      computer: {
+        findFirst: vi.fn().mockResolvedValue({
+          controlHolder: "user",
+          controlBotId: "bot-1",
+          controlLeaseId: "lease-1",
+          controlLeaseExpiresAt: expiresAt,
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      thread: { update: vi.fn().mockResolvedValue({ nextEventSeq: 8 }) },
+      event: {
+        create: vi.fn(async ({ data }: { data: { seq: number; type: string } }) => ({
+          ...event(data.seq),
+          type: data.type,
+        })),
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      pauseRunForTakeover(prisma, {
+        spaceId: "workspace-1",
+        threadId: "thread-1",
+        botId: "bot-1",
+        runId: "run-1",
+        attemptId: "attempt-1",
+        leaseOwner: "worker-1",
+        leaseFence: 3,
+        reason: "Sign in",
+        computerId: "computer-1",
+      }),
+    ).resolves.toBe(true);
+
+    expect(tx.computer.updateMany).toHaveBeenCalledWith({
+      where: { id: "computer-1", spaceId: "workspace-1" },
+      data: { state: "running", controlRunId: "run-1" },
+    });
+    expect(tx.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          payload: expect.objectContaining({ retainedControl: true, takeoverRequested: true }),
+        }),
+      }),
+    );
   });
 });
 

--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -579,6 +579,64 @@ describe("pauseRunForTakeover", () => {
       }),
     );
   });
+
+  it("preserves another bot's active user lease and only binds controlRunId", async () => {
+    const expiresAt = new Date(Date.now() + 60_000);
+    const tx = {
+      $queryRaw: vi.fn().mockResolvedValue([{ id: "computer-1" }]),
+      run: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUnique: vi.fn().mockResolvedValue({ status: "waiting_takeover" }),
+      },
+      attempt: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      computer: {
+        findFirst: vi.fn().mockResolvedValue({
+          controlHolder: "user",
+          controlBotId: "other-bot",
+          controlLeaseId: "lease-other",
+          controlLeaseExpiresAt: expiresAt,
+        }),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      thread: { update: vi.fn().mockResolvedValue({ nextEventSeq: 8 }) },
+      event: {
+        create: vi.fn(async ({ data }: { data: { seq: number; type: string } }) => ({
+          ...event(data.seq),
+          type: data.type,
+        })),
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+    } as unknown as PrismaClient;
+
+    await expect(
+      pauseRunForTakeover(prisma, {
+        spaceId: "workspace-1",
+        threadId: "thread-1",
+        botId: "bot-1",
+        runId: "run-1",
+        attemptId: "attempt-1",
+        leaseOwner: "worker-1",
+        leaseFence: 3,
+        reason: "Sign in",
+        computerId: "computer-1",
+      }),
+    ).resolves.toBe(true);
+
+    expect(tx.computer.updateMany).toHaveBeenCalledWith({
+      where: { id: "computer-1", spaceId: "workspace-1" },
+      data: { state: "running", controlRunId: "run-1" },
+    });
+    expect(tx.event.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          payload: expect.objectContaining({ retainedControl: false, takeoverRequested: true }),
+        }),
+      }),
+    );
+  });
 });
 
 describe("answerRunInput", () => {

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -171,6 +171,8 @@ export interface PauseRunForTakeover {
   leaseOwner: string;
   leaseFence: number;
   reason: string;
+  /** Computer that should expose the pending takeover to the UI via controlRunId. */
+  computerId: string;
 }
 
 export interface AnswerRunInput {
@@ -772,13 +774,51 @@ export async function pauseRunForTakeover(
     });
     if (attempt.count !== 1) throw new Error("Active run attempt was not available to pause");
 
+    const now = new Date();
+    const computer = await tx.computer.findFirst({
+      where: { id: input.computerId, spaceId: input.spaceId },
+      select: {
+        controlHolder: true,
+        controlBotId: true,
+        controlLeaseId: true,
+        controlLeaseExpiresAt: true,
+      },
+    });
+    // Keep an active user lease so Skip / I'm done appear immediately; otherwise clear
+    // stale control but always bind controlRunId so takeoverRequested is true.
+    const retainControl = Boolean(
+      computer?.controlHolder === "user" &&
+        computer.controlBotId === input.botId &&
+        computer.controlLeaseId &&
+        computer.controlLeaseExpiresAt &&
+        computer.controlLeaseExpiresAt.getTime() > now.getTime(),
+    );
+    const marked = await tx.computer.updateMany({
+      where: { id: input.computerId, spaceId: input.spaceId },
+      data: retainControl
+        ? { state: "running", controlRunId: input.runId }
+        : {
+            state: "running",
+            controlHolder: "none",
+            controlLeaseId: null,
+            controlLeaseExpiresAt: null,
+            controlBotId: null,
+            controlRunId: input.runId,
+          },
+    });
+    if (marked.count !== 1) throw new Error("Computer was not available to mark for takeover");
+
     const waitingEvent = await appendEventInTransaction(tx, {
       spaceId: input.spaceId,
       threadId: input.threadId,
       botId: input.botId,
       type: "computer.takeover.requested",
       runId: input.runId,
-      payload: { reason: input.reason },
+      payload: {
+        reason: input.reason,
+        takeoverRequested: true,
+        retainedControl: retainControl,
+      },
     });
     await tx.event.deleteMany({ where: { runId: input.runId, type: "thread.progress" } });
     return { threadId: waitingEvent.threadId, seq: waitingEvent.seq };

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -775,6 +775,9 @@ export async function pauseRunForTakeover(
     if (attempt.count !== 1) throw new Error("Active run attempt was not available to pause");
 
     const now = new Date();
+    // Serialize with concurrent computer/takeover grants that mutate the same row.
+    await tx.$queryRaw`
+      SELECT id FROM computers WHERE id = ${input.computerId} AND "spaceId" = ${input.spaceId} FOR UPDATE`;
     const computer = await tx.computer.findFirst({
       where: { id: input.computerId, spaceId: input.spaceId },
       select: {
@@ -784,27 +787,32 @@ export async function pauseRunForTakeover(
         controlLeaseExpiresAt: true,
       },
     });
-    // Keep an active user lease so Skip / I'm done appear immediately; otherwise clear
-    // stale control but always bind controlRunId so takeoverRequested is true.
-    const retainControl = Boolean(
+    const activeUserLease = Boolean(
       computer?.controlHolder === "user" &&
-        computer.controlBotId === input.botId &&
         computer.controlLeaseId &&
         computer.controlLeaseExpiresAt &&
         computer.controlLeaseExpiresAt.getTime() > now.getTime(),
     );
+    // Keep an active same-bot user lease so Skip / I'm done appear immediately.
+    // Preserve another bot's active lease — computer/takeover owns revocation.
+    // Otherwise clear stale control, but always bind controlRunId so takeoverRequested is true.
+    const retainControl = Boolean(activeUserLease && computer?.controlBotId === input.botId);
+    const preserveForeignLease = Boolean(
+      activeUserLease && computer?.controlBotId && computer.controlBotId !== input.botId,
+    );
     const marked = await tx.computer.updateMany({
       where: { id: input.computerId, spaceId: input.spaceId },
-      data: retainControl
-        ? { state: "running", controlRunId: input.runId }
-        : {
-            state: "running",
-            controlHolder: "none",
-            controlLeaseId: null,
-            controlLeaseExpiresAt: null,
-            controlBotId: null,
-            controlRunId: input.runId,
-          },
+      data:
+        retainControl || preserveForeignLease
+          ? { state: "running", controlRunId: input.runId }
+          : {
+              state: "running",
+              controlHolder: "none",
+              controlLeaseId: null,
+              controlLeaseExpiresAt: null,
+              controlBotId: null,
+              controlRunId: input.runId,
+            },
     });
     if (marked.count !== 1) throw new Error("Computer was not available to mark for takeover");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

When a bot called `request_takeover`, the run moved to `waiting_takeover` and chat showed the ask-style message, but the computer row never recorded a pending takeover. `controlRunId` stayed null, so `takeoverRequested` was false and the release panel only showed Release/Stop. Releasing then left the run stuck forever.

## What changed

- `pauseRunForTakeover` marks the computer with `controlRunId` for the waiting run (so `takeoverRequested` is true), locks the computer row during the transition, keeps an active same-bot control lease when present, and preserves another bot’s active lease.
- The `computer.takeover.requested` event carries `takeoverRequested` / `retainedControl`; the web reducer updates computer status accordingly.
- `computer.takeover` early-return paths bind `controlRunId` only after locking the execution lease and confirming its `runId`/`fence`, so release can resume the correct waiting run.
- Chat/computer chrome show a “Needs you” status while takeover is pending.
- Tests cover bind vs retain, foreign-lease preservation, and UI status reduction.

## How it was tested

- Unit: `packages/db/src/events.test.ts` (`pauseRunForTakeover`, including foreign active lease)
- Unit: `apps/web/src/lib/thread-events.test.ts` (takeover requested reduction)
- Unit: `apps/api/src/computer-status.test.ts` (existing `takeoverRequested` from `controlRunId`)
- CI: lint, typecheck, unit tests, postgres journeys, web e2e

Closes #658

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f223e68-ebc0-4fb1-8cb6-f05fbfa2ba55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f223e68-ebc0-4fb1-8cb6-f05fbfa2ba55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Computer takeover status now distinguishes between “Needs you” and “You have control.”
  - Takeover requests are tracked and linked to the waiting run.
  - Existing user control is preserved when appropriate during takeover requests.

- **Bug Fixes**
  - Releasing control now correctly resumes runs waiting for takeover.
  - Stale control information is cleared when control is not retained.
  - Computer status no longer incorrectly resets to “Ready” during takeover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->