### PR TITLE
Add bot color picker to settings

### DIFF
--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -1,4 +1,5 @@
 import {
+  BOT_COLORS,
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
   BOT_TITLE_MAX_LENGTH,
@@ -7,7 +8,8 @@ import {
 } from "@rakazo/contracts";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
-import { Pressable, ScrollView, Text, TextInput } from "react-native";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { BotAvatar } from "../components/bot-avatar";
 import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
@@ -25,6 +27,7 @@ export default function BotSettingsScreen() {
   const [name, setName] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [color, setColor] = useState<string>(BOT_COLORS[0]);
   const [computerMode, setComputerMode] = useState<ComputerMode>("team");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
@@ -37,6 +40,7 @@ export default function BotSettingsScreen() {
         setName(next.name);
         setTitle(next.title);
         setDescription(next.description ?? "");
+        setColor(next.color);
         setComputerMode(next.computerMode);
       })
       .catch((err) => setError(err instanceof Error ? err.message : t("Could not load bot")));
@@ -54,6 +58,7 @@ export default function BotSettingsScreen() {
         title?: string;
         description?: string;
         instructions?: string;
+        color?: string;
       } = { botId };
       if (profile.name !== bot.name) input.name = profile.name;
       if (profile.title !== bot.title) input.title = profile.title;
@@ -62,6 +67,7 @@ export default function BotSettingsScreen() {
         // Keep instructions in sync with description (same as web BotSettings).
         input.instructions = profile.instructions;
       }
+      if (color !== bot.color) input.color = color;
       if (computerMode !== bot.computerMode) {
         await rpc("bots/setComputer", { botId, mode: computerMode });
       }
@@ -86,6 +92,11 @@ export default function BotSettingsScreen() {
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
       >
+        {bot ? (
+          <View style={{ alignItems: "center", marginBottom: 24 }}>
+            <BotAvatar color={color} identity={bot.id} size={64} status={bot.status} />
+          </View>
+        ) : null}
         <Text style={{ color: "#85858A", fontSize: 14 }}>{t("Name")}</Text>
         <TextInput
           value={name}
@@ -134,6 +145,31 @@ export default function BotSettingsScreen() {
             textAlignVertical: "top",
           }}
         />
+        <Text style={{ color: "#85858A", marginTop: 16, fontSize: 14 }}>{t("Color")}</Text>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: 10, marginTop: 8 }}
+          accessibilityRole="radiogroup"
+        >
+          {BOT_COLORS.map((option, index) => (
+            <Pressable
+              key={option}
+              accessibilityRole="radio"
+              accessibilityLabel={t("Color {number}", { number: index + 1 })}
+              accessibilityState={{ checked: color === option }}
+              onPress={() => setColor(option)}
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: 18,
+                backgroundColor: option,
+                borderWidth: 3,
+                borderColor: color === option ? tokens.foreground : "transparent",
+              }}
+            />
+          ))}
+        </ScrollView>
         <ComputerModePicker value={computerMode} onChange={setComputerMode} />
         {error ? <Text style={{ color: "#EF4444", marginTop: 16 }}>{error}</Text> : null}
         <Pressable

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -70,6 +70,8 @@ export const ZH_MESSAGES: Record<string, string> = {
   "Close computer": "关闭电脑",
   "Close preview": "关闭预览",
   Code: "验证码",
+  Color: "颜色",
+  "Color {number}": "颜色 {number}",
   Completed: "已完成",
   Computer: "电脑",
   "Confirm password": "确认密码",

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -67,7 +67,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   await nameInput.fill("Researcher");
   await titleInput.fill(longTitle);
   await descriptionInput.fill("Finds reliable sources and turns them into concise briefs.");
-  await page.getByRole("radio", { name: "Color 2" }).click();
+  await page.getByRole("radio", { name: "Color 7" }).click();
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(botList.getByRole("button", { name: /^Researcher/ })).toBeVisible();
   await expect(page.getByPlaceholder("Message Researcher")).toBeVisible();
@@ -79,7 +79,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
     "Finds reliable sources and turns them into concise briefs.",
   );
   const settings = page.getByTestId("bot-settings");
-  await expect(settings.getByRole("radio", { name: "Color 2" })).toBeChecked();
+  await expect(settings.getByRole("radio", { name: "Color 7" })).toBeChecked();
   const modelSelect = settings.locator("label:has-text('Model') select");
   const teamComputer = settings.getByRole("button", { name: "Team" });
   const openWork = settings.getByTestId("bot-scratchpad");

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -67,6 +67,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   await nameInput.fill("Researcher");
   await titleInput.fill(longTitle);
   await descriptionInput.fill("Finds reliable sources and turns them into concise briefs.");
+  await page.getByRole("radio", { name: "Color 2" }).click();
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(botList.getByRole("button", { name: /^Researcher/ })).toBeVisible();
   await expect(page.getByPlaceholder("Message Researcher")).toBeVisible();
@@ -78,6 +79,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
     "Finds reliable sources and turns them into concise briefs.",
   );
   const settings = page.getByTestId("bot-settings");
+  await expect(settings.getByRole("radio", { name: "Color 2" })).toBeChecked();
   const modelSelect = settings.locator("label:has-text('Model') select");
   const teamComputer = settings.getByRole("button", { name: "Team" });
   const openWork = settings.getByTestId("bot-scratchpad");

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -710,6 +710,16 @@ msgstr ""
 msgid "Collapse {0}"
 msgstr ""
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Farbe"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Farbe {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr ""

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -710,6 +710,16 @@ msgstr "Code"
 msgid "Collapse {0}"
 msgstr "Collapse {0}"
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Color"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Color {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr "Coming soon"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -710,6 +710,16 @@ msgstr "Código"
 msgid "Collapse {0}"
 msgstr "Contraer {0}"
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Color"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Color {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr "Próximamente"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -710,6 +710,16 @@ msgstr ""
 msgid "Collapse {0}"
 msgstr ""
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "रंग"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "रंग {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -710,6 +710,16 @@ msgstr "Code"
 msgid "Collapse {0}"
 msgstr "{0} 접기"
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "색상"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "색상 {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr "준비 중"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -710,6 +710,16 @@ msgstr ""
 msgid "Collapse {0}"
 msgstr ""
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Cor"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Cor {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -710,6 +710,16 @@ msgstr ""
 msgid "Collapse {0}"
 msgstr ""
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Renk"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Renk {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr ""

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -710,6 +710,16 @@ msgstr "代码"
 msgid "Collapse {0}"
 msgstr "折叠 {0}"
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "颜色"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "颜色 {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr "即将推出"

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -10,6 +10,7 @@ import type {
   VoiceInfo,
 } from "@rakazo/contracts";
 import {
+  BOT_COLORS,
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
   BOT_TITLE_MAX_LENGTH,
@@ -183,6 +184,7 @@ export function BotSettings({
     title?: string;
     description?: string;
     instructions?: string;
+    color?: string;
     computerMode: ComputerMode;
     memoryScope?: "isolated" | "shared" | null;
     autoSpeak?: boolean;
@@ -199,6 +201,7 @@ export function BotSettings({
   const [name, setName] = useState(bot.name);
   const [title, setTitle] = useState(bot.title);
   const [description, setDescription] = useState(bot.description);
+  const [color, setColor] = useState(bot.color);
   const [computerMode, setComputerMode] = useState(bot.computerMode);
   const [memoryScope, setMemoryScope] = useState(bot.memoryScope);
   const [autoSpeak, setAutoSpeak] = useState(bot.autoSpeak);
@@ -287,7 +290,7 @@ export function BotSettings({
   return (
     <div data-testid="bot-settings">
       <div className="flex justify-center">
-        <BotAvatar color={bot.color} identity={bot.id} size={64} status={bot.status} />
+        <BotAvatar color={color} identity={bot.id} size={64} status={bot.status} />
       </div>
       <label htmlFor={`${ids}-name`} className="mt-6 block text-[14px] text-muted-foreground">
         <Trans>Name</Trans>
@@ -320,6 +323,31 @@ export function BotSettings({
           className="mt-2"
         />
       </label>
+      <div className={fieldLabelClass}>
+        <Trans>Color</Trans>
+        <div className="mt-2 flex flex-wrap gap-2" role="radiogroup" aria-label={t`Color`}>
+          {BOT_COLORS.map((option, index) => (
+            <label key={option} className="cursor-pointer rounded-full">
+              <input
+                className="peer sr-only"
+                type="radio"
+                name={`${ids}-color`}
+                value={option}
+                checked={color === option}
+                aria-label={t`Color ${index + 1}`}
+                onChange={() => setColor(option)}
+              />
+              <span
+                aria-hidden="true"
+                className={`block size-8 rounded-full border-2 ring-offset-card transition-transform hover:scale-105 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2 ${
+                  color === option ? "border-foreground" : "border-transparent"
+                }`}
+                style={{ backgroundColor: option }}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
       <details data-testid="bot-settings-advanced" className="group mt-5">
         <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-[14px] text-muted-foreground">
           <span className="text-muted-foreground">
@@ -456,6 +484,7 @@ export function BotSettings({
               title: nextTitle,
               description: nextDescription,
               instructions: nextDescription,
+              color,
               computerMode,
               memoryScope,
               autoSpeak,

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -327,24 +327,19 @@ export function BotSettings({
         <Trans>Color</Trans>
         <div className="mt-2 flex flex-wrap gap-2" role="radiogroup" aria-label={t`Color`}>
           {BOT_COLORS.map((option, index) => (
-            <label key={option} className="cursor-pointer rounded-full">
-              <input
-                className="peer sr-only"
-                type="radio"
-                name={`${ids}-color`}
-                value={option}
-                checked={color === option}
-                aria-label={t`Color ${index + 1}`}
-                onChange={() => setColor(option)}
-              />
-              <span
-                aria-hidden="true"
-                className={`block size-8 rounded-full border-2 ring-offset-card transition-transform hover:scale-105 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2 ${
-                  color === option ? "border-foreground" : "border-transparent"
-                }`}
-                style={{ backgroundColor: option }}
-              />
-            </label>
+            <input
+              key={option}
+              className={`size-8 cursor-pointer appearance-none rounded-full border-2 ring-offset-card transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                color === option ? "border-foreground" : "border-transparent"
+              }`}
+              type="radio"
+              name={`${ids}-color`}
+              value={option}
+              checked={color === option}
+              aria-label={t`Color ${index + 1}`}
+              style={{ backgroundColor: option }}
+              onChange={() => setColor(option)}
+            />
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Why

Bots already have identity colors, but there was no settings control for changing them. This makes the existing color palette user-selectable without changing bot behavior or interrupting active work.

## What changed

- Add the seven existing bot colors to web and Electron bot settings.
- Add the same picker to native mobile bot settings.
- Preview the selected color on the bot avatar before saving.
- Persist the selection through the existing bot update endpoint.
- Add accessible radio labels and translated catalog entries.
- Extend the browser editing journey to verify the selected color persists.

Visible copy: `Color`. Screen-reader choices use `Color 1` through `Color 7`; these labels are necessary because color-only controls need accessible names and cannot be hidden until later without making the picker unusable.

## Testing

- Web and mobile type checks pass.
- 366 web/mobile unit tests pass.
- Formatting and catalog compilation pass.
- CI browser coverage opens the bot settings screen, changes the color, saves, reopens settings, and verifies the selection.

CI screenshot: [`27a-settings-panel` in the Playwright artifact](https://github.com/elie222/rakazo/actions/runs/33947202658/artifacts/9963777237).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bot color selection in web and mobile settings.
  - Added a live avatar preview showing the selected color.
  - Selected colors are saved and retained when settings are reopened.

- **Localization**
  - Added translations for color labels across supported languages.

- **Tests**
  - Updated coverage to verify that a bot’s selected color persists after saving and reopening its settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->