### PR TITLE
fix(computer): recover a computer a crashed worker left booting

### DIFF
--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -1051,6 +1051,84 @@ describe("computer replacement", () => {
     ).rejects.toBeInstanceOf(ComputerBusyError);
   });
 
+  it("resets a computer a crashed worker left booting", async () => {
+    // No live lease from anyone else: the worker that set "booting" is gone, so Reset must
+    // reach the claim instead of answering "Computer is busy" for good.
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "",
+          kind: "fake",
+          scope: "dedicated",
+          state: "booting",
+          controlLeaseId: null,
+        }),
+        updateMany,
+      },
+      computerExecutionLease: { findFirst: vi.fn().mockResolvedValue(null) },
+      run: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "reset",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+    expect(updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ state: "booting" }) }),
+    );
+  });
+
+  it("refuses a booting computer another bot is still holding", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: "",
+          kind: "fake",
+          scope: "team",
+          state: "booting",
+          controlLeaseId: null,
+        }),
+        updateMany,
+      },
+      computerExecutionLease: {
+        findFirst: vi.fn().mockResolvedValue({ id: "lease-other-bot" }),
+      },
+      run: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient;
+
+    await expect(
+      replaceComputer(
+        {
+          prisma,
+          sandbox: new FakeSandboxProvider(),
+          home: {} as AgentHomeStore,
+          jobs: {} as JobPublisher,
+          events: {} as ThreadEvents,
+        },
+        "computer-1",
+        "reset",
+        context,
+      ),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
   it("rejects replacement while the target bot has an active run", async () => {
     const prisma = {
       computer: {

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -107,7 +107,9 @@ describe("computer provisioning", () => {
     // any booting row and wrongly claim (count 1 below).
     const updateMany = vi.fn().mockImplementation(async (args: { where: { OR?: unknown[] } }) => {
       const booting = (args.where.OR ?? []).find(
-        (clause): clause is { state: string; executionLeases?: { none?: { expiresAt?: unknown } } } =>
+        (
+          clause,
+        ): clause is { state: string; executionLeases?: { none?: { expiresAt?: unknown } } } =>
           typeof clause === "object" &&
           clause !== null &&
           "state" in clause &&

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -101,8 +101,21 @@ describe("computer provisioning", () => {
     }
   });
 
-  it("fences booting reclaim on live leases even without screenLeaseId", async () => {
-    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+  it("does not claim when screenLeaseId is missing and a live foreign lease exists", async () => {
+    // Live foreign lease present: Prisma matches the booting branch only when the where
+    // requires no live leases (heldByNobodyElse(null)). Returning {} there would match
+    // any booting row and wrongly claim (count 1 below).
+    const updateMany = vi.fn().mockImplementation(async (args: { where: { OR?: unknown[] } }) => {
+      const booting = (args.where.OR ?? []).find(
+        (clause): clause is { state: string; executionLeases?: { none?: { expiresAt?: unknown } } } =>
+          typeof clause === "object" &&
+          clause !== null &&
+          "state" in clause &&
+          (clause as { state?: string }).state === "booting",
+      );
+      const none = booting?.executionLeases?.none;
+      return { count: none?.expiresAt != null ? 0 : 1 };
+    });
     const prisma = {
       computer: {
         findUniqueOrThrow: vi.fn().mockResolvedValue({

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -91,6 +91,7 @@ describe("computer provisioning", () => {
           where: {
             id: "computer-1",
             state: "booting",
+            executionLeases: { none: { expiresAt: { gt: expect.any(Date) } } },
             bots: { some: { id: "bot-1", archivedAt: null } },
           },
         }),
@@ -98,6 +99,72 @@ describe("computer provisioning", () => {
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }
+  });
+
+  it("fences booting reclaim on live leases even without screenLeaseId", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const prisma = {
+      computer: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: "computer-1",
+          homeKey: "bot-1",
+          providerRef: null,
+          kind: "cloud",
+          scope: "dedicated",
+          state: "stopped",
+          controlLeaseId: null,
+        }),
+        updateMany,
+      },
+    } as unknown as PrismaClient;
+    const deps = {
+      prisma,
+      sandbox: {} as SandboxProvider,
+      home: {} as AgentHomeStore,
+      jobs: {} as JobPublisher,
+      events: {} as ThreadEvents,
+    };
+
+    await expect(provisionComputer(deps, "computer-1", context)).rejects.toBeInstanceOf(
+      ComputerBusyError,
+    );
+    expect(updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            {
+              state: "booting",
+              executionLeases: { none: { expiresAt: { gt: expect.any(Date) } } },
+            },
+          ]),
+        }),
+      }),
+    );
+
+    updateMany.mockClear();
+    await expect(
+      provisionComputer(deps, "computer-1", {
+        ...context,
+        screenLeaseId: "run-1:3",
+      }),
+    ).rejects.toBeInstanceOf(ComputerBusyError);
+    expect(updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            {
+              state: "booting",
+              executionLeases: {
+                none: {
+                  expiresAt: { gt: expect.any(Date) },
+                  NOT: { runId: "run-1", fence: 3 },
+                },
+              },
+            },
+          ]),
+        }),
+      }),
+    );
   });
 
   it.each([
@@ -482,7 +549,11 @@ describe("computer provisioning", () => {
         errors: [prepareError, rollbackError],
       });
       expect(updateMany).toHaveBeenLastCalledWith({
-        where: { id: "computer-1", state: "booting" },
+        where: {
+          id: "computer-1",
+          state: "booting",
+          executionLeases: { none: { expiresAt: { gt: expect.any(Date) } } },
+        },
         data: {
           state: "error",
           providerRef: "new-provider-1",

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -32,42 +32,19 @@ const RELEASED_EXECUTION_LEASE_AT = new Date(0);
 const BOOT_WAIT_ATTEMPTS = 40;
 const BOOT_WAIT_MS = 250;
 
-/**
- * "Nobody but us holds this computer."
- *
- * Whoever moves a computer to "booting" holds its execution lease for the whole provision,
- * renewed on the run heartbeat, so a booting row whose only live lease is our own belongs to
- * a worker that died between the claim and its own failure handler. Before this nothing
- * cleared that state -- the claim took only stopped/suspended/error rows and replaceComputer
- * refused a booting one -- so the computer stayed wedged for good and every run on its bot
- * retried forever.
- *
- * The same predicate guards the writes that end a boot. Reclaiming means two workers can
- * briefly believe they own one row: ours, and one merely paused past its lease. Writing
- * unconditionally would let the late one overwrite the winner's providerRef and leak its box,
- * which is how the orphaned sandboxes that exhaust a Docker host pile up. A lease that merely
- * expired without being taken still passes, so a slow manual boot that never heartbeats keeps
- * working.
- */
+/** No live execution lease except our own (when screenLeaseId is set). */
 function heldByNobodyElse(lease: { ownerId: string; fence: number } | null) {
-  if (!lease) return {};
   return {
     executionLeases: {
       none: {
         expiresAt: { gt: new Date() },
-        NOT: { runId: lease.ownerId, fence: lease.fence },
+        ...(lease ? { NOT: { runId: lease.ownerId, fence: lease.fence } } : {}),
       },
     },
   };
 }
 
-/**
- * A live execution lease held by some OTHER bot on this computer.
- *
- * runComputerReplace already holds the lease for its own bot, so "any live lease" would
- * always be true there; a shared Team Computer mid-boot for a different bot must still be
- * refused.
- */
+/** True when another bot still holds a live execution lease on this computer. */
 async function hasForeignExecutionLease(
   prisma: PrismaClient,
   computerId: string,
@@ -523,10 +500,7 @@ export async function replaceComputer(
   if (existing.state === "suspending") {
     throw new ComputerBusyError();
   }
-  // "booting" is reachable here only through runComputerReplace, which already holds this
-  // computer's execution lease -- and it could only take that once the booting worker's own
-  // lease expired. Refusing it left Reset answering "Computer is busy" forever, with no way
-  // back short of editing the row by hand. The claim below still fences on the state we read.
+  // Allow Reset on a stale "booting" row unless another bot still holds a live lease.
   if (
     existing.state === "booting" &&
     (await hasForeignExecutionLease(deps.prisma, computerId, botId))

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -6,7 +6,7 @@ import type {
   JobPublisher,
   SandboxProvider,
 } from "@rakazo/adapter-kit";
-import { ACTIVE_RUN_STATUSES, screenLeaseId } from "@rakazo/core";
+import { ACTIVE_RUN_STATUSES, parseScreenLeaseId, screenLeaseId } from "@rakazo/core";
 import {
   expireComputerExecutionLeases,
   type PrismaClient,
@@ -31,6 +31,54 @@ const EXECUTION_LEASE_MS = 5 * 60_000;
 const RELEASED_EXECUTION_LEASE_AT = new Date(0);
 const BOOT_WAIT_ATTEMPTS = 40;
 const BOOT_WAIT_MS = 250;
+
+/**
+ * "Nobody but us holds this computer."
+ *
+ * Whoever moves a computer to "booting" holds its execution lease for the whole provision,
+ * renewed on the run heartbeat, so a booting row whose only live lease is our own belongs to
+ * a worker that died between the claim and its own failure handler. Before this nothing
+ * cleared that state -- the claim took only stopped/suspended/error rows and replaceComputer
+ * refused a booting one -- so the computer stayed wedged for good and every run on its bot
+ * retried forever.
+ *
+ * The same predicate guards the writes that end a boot. Reclaiming means two workers can
+ * briefly believe they own one row: ours, and one merely paused past its lease. Writing
+ * unconditionally would let the late one overwrite the winner's providerRef and leak its box,
+ * which is how the orphaned sandboxes that exhaust a Docker host pile up. A lease that merely
+ * expired without being taken still passes, so a slow manual boot that never heartbeats keeps
+ * working.
+ */
+function heldByNobodyElse(lease: { ownerId: string; fence: number } | null) {
+  if (!lease) return {};
+  return {
+    executionLeases: {
+      none: {
+        expiresAt: { gt: new Date() },
+        NOT: { runId: lease.ownerId, fence: lease.fence },
+      },
+    },
+  };
+}
+
+/**
+ * A live execution lease held by some OTHER bot on this computer.
+ *
+ * runComputerReplace already holds the lease for its own bot, so "any live lease" would
+ * always be true there; a shared Team Computer mid-boot for a different bot must still be
+ * refused.
+ */
+async function hasForeignExecutionLease(
+  prisma: PrismaClient,
+  computerId: string,
+  botId: string,
+): Promise<boolean> {
+  const live = await prisma.computerExecutionLease.findFirst({
+    where: { computerId, botId: { not: botId }, expiresAt: { gt: new Date() } },
+    select: { id: true },
+  });
+  return live !== null;
+}
 
 export class ComputerBusyError extends Error {
   constructor() {
@@ -76,10 +124,15 @@ export async function provisionComputer(
     existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
   }
 
+  // The execution lease this caller already holds, as it stamped it into the context.
+  const bootLease = context.screenLeaseId ? parseScreenLeaseId(context.screenLeaseId) : null;
   const claimed = await deps.prisma.computer.updateMany({
     where: {
       id: computerId,
-      state: { in: ["stopped", "suspended", "error"] },
+      OR: [
+        { state: { in: ["stopped", "suspended", "error"] } },
+        { state: "booting", ...heldByNobodyElse(bootLease) },
+      ],
       ...(context.botId ? { bots: { some: { id: context.botId, archivedAt: null } } } : {}),
     },
     data: { state: "booting" },
@@ -118,6 +171,7 @@ export async function provisionComputer(
       where: {
         id: computerId,
         state: "booting",
+        ...heldByNobodyElse(bootLease),
         ...(context.botId ? { bots: { some: { id: context.botId, archivedAt: null } } } : {}),
       },
       data: {
@@ -145,7 +199,7 @@ export async function provisionComputer(
       : undefined;
     try {
       await deps.prisma.computer.updateMany({
-        where: { id: computerId, state: "booting" },
+        where: { id: computerId, state: "booting", ...heldByNobodyElse(bootLease) },
         data: {
           state: "error",
           ...(rollbackError && provisioned
@@ -466,7 +520,17 @@ export async function replaceComputer(
   if (hasActiveComputerControl(existing)) {
     throw new ComputerBusyError();
   }
-  if (existing.state === "booting" || existing.state === "suspending") {
+  if (existing.state === "suspending") {
+    throw new ComputerBusyError();
+  }
+  // "booting" is reachable here only through runComputerReplace, which already holds this
+  // computer's execution lease -- and it could only take that once the booting worker's own
+  // lease expired. Refusing it left Reset answering "Computer is busy" forever, with no way
+  // back short of editing the row by hand. The claim below still fences on the state we read.
+  if (
+    existing.state === "booting" &&
+    (await hasForeignExecutionLease(deps.prisma, computerId, botId))
+  ) {
     throw new ComputerBusyError();
   }
 

--- a/packages/core/src/events.test.ts
+++ b/packages/core/src/events.test.ts
@@ -719,8 +719,8 @@ describe("sanitizeUtf16ForJson", () => {
     expect(
       sanitizeJsonValue({
         outer: {
-          ["meta\uD83D"]: "ok",
-          ["meta\uDE00"]: "also",
+          "meta\uD83D": "ok",
+          "meta\uDE00": "also",
         },
       }),
     ).toEqual({

--- a/packages/testkit/src/executor-lifecycle.test.ts
+++ b/packages/testkit/src/executor-lifecycle.test.ts
@@ -534,6 +534,61 @@ describeIntegration("run executor lifecycle", () => {
     expect(await handles.prisma.run.count({ where: { threadId: thread.id } })).toBe(2);
   });
 
+  it("recovers a computer a crashed worker left booting", async () => {
+    const seeded = await seedRun("stale-boot", "write a file that says recovered");
+    const bot = await handles.prisma.bot.findUniqueOrThrow({ where: { id: seeded.bot.id } });
+    const computerId = bot.computerId!;
+    expect(computerId).toBeTruthy();
+
+    // A worker killed between the boot claim and its own failure handler: the row keeps
+    // "booting" and its execution lease is gone. Nothing used to clear that, so every run
+    // on this bot retried forever.
+    await handles.prisma.computerExecutionLease.deleteMany({ where: { computerId } });
+    await handles.prisma.computer.update({
+      where: { id: computerId },
+      data: { state: "booting", providerRef: "" },
+    });
+
+    await handles.executor.continueRun(seeded.run.id, "worker-stale-boot");
+
+    const computer = await handles.prisma.computer.findUniqueOrThrow({
+      where: { id: computerId },
+    });
+    expect(computer.state).toBe("running");
+    const run = await handles.prisma.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
+    expect(run.status).toBe("completed");
+  });
+
+  it("leaves a booting computer alone while its worker still holds the lease", async () => {
+    const seeded = await seedRun("live-boot", "write a file that says waited");
+    const bot = await handles.prisma.bot.findUniqueOrThrow({ where: { id: seeded.bot.id } });
+    const computerId = bot.computerId!;
+
+    await handles.prisma.computerExecutionLease.deleteMany({ where: { computerId } });
+    await handles.prisma.computerExecutionLease.create({
+      data: {
+        computerId,
+        botId: "another-bot",
+        runId: "run-still-booting",
+        fence: 1,
+        expiresAt: new Date(Date.now() + 5 * 60_000),
+      },
+    });
+    await handles.prisma.computer.update({
+      where: { id: computerId },
+      data: { state: "booting", providerRef: "" },
+    });
+
+    await handles.executor.continueRun(seeded.run.id, "worker-live-boot");
+
+    const computer = await handles.prisma.computer.findUniqueOrThrow({
+      where: { id: computerId },
+    });
+    expect(computer.state).toBe("booting");
+    const run = await handles.prisma.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
+    expect(run.status).not.toBe("completed");
+  });
+
   async function seedRun(
     label: string,
     prompt: string,


### PR DESCRIPTION
## Why

A worker that dies between the boot claim and its own failure handler leaves the computer row at `booting`. Nothing clears it: `provisionComputer` claims only `stopped`/`suspended`/`error`, and `replaceComputer` refuses a booting row outright. That computer is then wedged permanently — every run on the bot waits out the 10s boot poll, fails its claim, requeues, repeats. The bot answers nothing, and **Reset in bot settings replies "Computer is busy" forever**, so there is no way back for a user short of editing the row by hand.

Seen in the wild on a self-hosted deployment: one bot went silent for hours (23 consecutive `setup_failed` attempts, each 11.1s ≈ `BOOT_WAIT_ATTEMPTS * BOOT_WAIT_MS`) while another bot on the same deployment, whose computer was already `running` and so took the `reconnectComputer` path, kept working normally.

## What

The boot's owner is already identifiable: whoever sets `booting` holds that computer's execution lease for the whole provision — the executor renews it on the run heartbeat, and the manual boot / teaching paths hold theirs until provisioning returns. So a booting row whose only live lease is the caller's own has no owner left to finish it.

- `provisionComputer` also claims a `booting` row held by nobody else.
- Both writes that end a boot (activation, and the failure record) carry the same predicate, so a worker merely paused past its lease cannot overwrite the new owner's `providerRef` and leak its box — which is how orphaned sandboxes that exhaust a Docker host pile up in the first place.
- `replaceComputer` accepts a `booting` row unless another bot holds a live lease, so Reset stops being a dead end on a shared Team Computer.

A lease that merely expired without being taken over still passes, so a slow manual boot that never heartbeats keeps working.

## Tests

- `packages/testkit/src/executor-lifecycle.test.ts` (Postgres, real Prisma filters): a crashed boot is recovered and the run completes; a boot another bot still holds is left alone. The first fails without the claim change — the computer stays `booting` and the run never completes — and passes with it.
- `packages/adapters/src/computer-lifecycle.test.ts`: Reset reaches the claim on an abandoned boot, and is still refused while a different bot holds a live lease.

Full unit suite: 2677 passed, 1 pre-existing failure (`sandbox-conformance`, local Docker image) that reproduces unchanged on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reset can recover computers left in a booting state when no active execution lease remains.
  - Booting computers remain protected when another bot holds a live execution lease, preventing conflicting recovery attempts.
  - Runs can resume and complete after recovering an abandoned booting computer.
  - Provisioning and replacement flows consistently respect active execution leases during boot, activation, rollback, and reset decisions.
  - Lease checks correctly handle recovery attempts when no matching lease identifier is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->