### PR TITLE
Fix unsupported computer URLs on mobile

### DIFF
--- a/apps/mobile/lib/computer.test.ts
+++ b/apps/mobile/lib/computer.test.ts
@@ -56,6 +56,13 @@ describe("embeddableScreenUrl", () => {
   it("returns null when there is no screen", () => {
     expect(embeddableScreenUrl(null, "http://127.0.0.1:3100")).toBeNull();
   });
+
+  it("does not send unsupported fixture URLs to the native WebView", () => {
+    expect(
+      embeddableScreenUrl("fake://screen/fake-team-home/researcher", "http://10.0.2.2:3100"),
+    ).toBeNull();
+    expect(embeddableScreenUrl("not a URL", "http://10.0.2.2:3100")).toBeNull();
+  });
 });
 
 describe("computer copy", () => {

--- a/apps/mobile/lib/computer.ts
+++ b/apps/mobile/lib/computer.ts
@@ -48,13 +48,14 @@ export function embeddableScreenUrl(url: string | null, apiBase: string): string
   if (!url) return null;
   try {
     const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
     const api = new URL(apiBase);
     if (isLocalHostname(parsed.hostname) && !isLocalHostname(api.hostname)) {
       parsed.hostname = api.hostname;
     }
     return parsed.toString();
   } catch {
-    return url;
+    return null;
   }
 }
 


### PR DESCRIPTION
## Why

The screenshot catalog exposed Android WebView’s browser error page when the fake computer provider returned its internal `fake://` screen reference. Unsupported or malformed screen references should fall back to the native computer placeholder instead of being handed to WebView.

## What changed

- allow only HTTP and HTTPS computer screen URLs in the mobile WebView
- return the existing native placeholder for internal or malformed screen references
- cover the fake-provider URL and malformed input with a deterministic regression test

No product UI copy changed.

## Testing

- all mobile unit tests passed (25 files, 167 tests)
- mobile TypeScript check passed
- targeted formatting and diff validation passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unsupported or invalid screen URLs are now rejected instead of being forwarded to the native WebView.
  - Only HTTP and HTTPS screen URLs are accepted; loopback URL handling remains unchanged.

- **Tests**
  - Added coverage for unsupported URL schemes and invalid URL strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->