### PR TITLE
Publish Android screenshot galleries

### DIFF
--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: mobile-android-screenshots
+  group: mobile-android-screenshots-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -137,6 +137,21 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: bash .github/scripts/capture-mobile-android-screenshots.sh
 
+      - name: Publish screenshot gallery
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.S3_REGION }}
+          AWS_EC2_METADATA_DISABLED: "true"
+          S3_BUCKET: ${{ vars.S3_BUCKET }}
+          S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}
+          PLAYWRIGHT_PUBLIC_BASE_URL: ${{ vars.PLAYWRIGHT_PUBLIC_BASE_URL }}
+          MOBILE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          MOBILE_RUN_ID: ${{ github.run_id }}
+          MOBILE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MOBILE_SHA: ${{ github.sha }}
+        run: bash scripts/publish-mobile-screenshot-gallery.sh
+
       - name: Upload screenshots and diagnostics
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -8,7 +8,7 @@ permissions:
 
 concurrency:
   group: mobile-android-screenshots
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   screenshots:

--- a/.github/workflows/mobile-android-screenshots.yml
+++ b/.github/workflows/mobile-android-screenshots.yml
@@ -8,7 +8,7 @@ permissions:
 
 concurrency:
   group: mobile-android-screenshots
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   screenshots:

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -11,14 +11,14 @@ tags:
 - extendedWaitUntil:
     visible: "Sign up for Rakazo"
     timeout: 30000
-- takeScreenshot: "screenshots/02-sign-up"
+- takeScreenshot: "02-sign-up"
 - tapOn: "Sign in"
 - assertVisible: "Sign in to Rakazo"
-- takeScreenshot: "screenshots/01-sign-in"
+- takeScreenshot: "01-sign-in"
 
 - tapOn: "Use a custom server"
 - assertVisible: "Server"
-- takeScreenshot: "screenshots/03-server"
+- takeScreenshot: "03-server"
 - tapOn: "Cancel"
 
 - tapOn: "Email"
@@ -34,13 +34,13 @@ tags:
 - extendedWaitUntil:
     visible: "Researcher"
     timeout: 30000
-- takeScreenshot: "screenshots/04-inbox"
+- takeScreenshot: "04-inbox"
 
 - tapOn: "Activity"
 - extendedWaitUntil:
     visible: "Recent"
     timeout: 10000
-- takeScreenshot: "screenshots/05-activity"
+- takeScreenshot: "05-activity"
 
 - tapOn: "Search"
 - inputText: "fixture"
@@ -48,28 +48,28 @@ tags:
 - extendedWaitUntil:
     visible: "Weekly fixture review"
     timeout: 10000
-- takeScreenshot: "screenshots/06-search-results"
+- takeScreenshot: "06-search-results"
 
 - openLink: "rakazo:///new"
 - assertVisible: "Name this bot"
-- takeScreenshot: "screenshots/07-new-bot"
+- takeScreenshot: "07-new-bot"
 
 - openLink: "rakazo:///new-group"
 - assertVisible: "Name this group"
-- takeScreenshot: "screenshots/08-new-group"
+- takeScreenshot: "08-new-group"
 
 - openLink: "rakazo:///new-space"
 - assertVisible: "Customer support"
-- takeScreenshot: "screenshots/09-new-space"
+- takeScreenshot: "09-new-space"
 
 - openLink: "rakazo:///account"
 - extendedWaitUntil:
     visible: "Change password"
     timeout: 10000
-- takeScreenshot: "screenshots/10-account"
+- takeScreenshot: "10-account"
 - tapOn: "Change password"
 - assertVisible: "Current password"
-- takeScreenshot: "screenshots/10b-change-password"
+- takeScreenshot: "10b-change-password"
 - back
 
 - openLink: "rakazo:///models"
@@ -79,68 +79,68 @@ tags:
 - scrollUntilVisible:
     element: "Show more"
     direction: DOWN
-- takeScreenshot: "screenshots/11-models"
+- takeScreenshot: "11-models"
 - tapOn: "Show more"
 - scrollUntilVisible:
     element: "Show less"
     direction: DOWN
-- takeScreenshot: "screenshots/11b-all-providers"
+- takeScreenshot: "11b-all-providers"
 
 - openLink: "rakazo:///voice"
 - extendedWaitUntil:
     visible: "Scripted"
     timeout: 10000
-- takeScreenshot: "screenshots/12-voice"
+- takeScreenshot: "12-voice"
 
 - openLink: "rakazo:///integrations"
 - extendedWaitUntil:
     visible: "Search apps"
     timeout: 10000
-- takeScreenshot: "screenshots/13-integrations"
+- takeScreenshot: "13-integrations"
 - tapOn:
     id: "integrations-advanced"
 - assertVisible: "Add MCP server"
-- takeScreenshot: "screenshots/14-integrations-advanced"
+- takeScreenshot: "14-integrations-advanced"
 
 - openLink: "rakazo:///thread?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
 - extendedWaitUntil:
     visible: "The fixture workspace is ready."
     timeout: 10000
-- takeScreenshot: "screenshots/15-thread"
+- takeScreenshot: "15-thread"
 - tapOn: "Bot actions"
 - assertVisible: "Clear conversation"
-- takeScreenshot: "screenshots/16-bot-actions"
+- takeScreenshot: "16-bot-actions"
 - back
 
 - openLink: "rakazo:///bot-settings?botId=${RAKAZO_SCREENSHOT_BOT_ID}"
 - extendedWaitUntil:
     visible: "Researcher"
     timeout: 10000
-- takeScreenshot: "screenshots/17-bot-settings"
+- takeScreenshot: "17-bot-settings"
 
 - openLink: "rakazo:///computer?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
 - extendedWaitUntil:
     visible: "Take control"
     timeout: 10000
-- takeScreenshot: "screenshots/18-computer"
+- takeScreenshot: "18-computer"
 
 - openLink: "rakazo:///group-thread?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}&name=Launch%20team"
 - extendedWaitUntil:
     visible: "The fixture launch plan is ready."
     timeout: 10000
-- takeScreenshot: "screenshots/19-group-thread"
+- takeScreenshot: "19-group-thread"
 
 - openLink: "rakazo:///group-settings?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}"
 - extendedWaitUntil:
     visible: "Delete group"
     timeout: 10000
-- takeScreenshot: "screenshots/20-group-settings"
+- takeScreenshot: "20-group-settings"
 
 - openLink: "rakazo:///routine?botId=${RAKAZO_SCREENSHOT_BOT_ID}&botName=Researcher&routineId=${RAKAZO_SCREENSHOT_ROUTINE_ID}"
 - extendedWaitUntil:
     visible: "Weekly fixture review"
     timeout: 10000
-- takeScreenshot: "screenshots/21-routine"
+- takeScreenshot: "21-routine"
 
 # Verify saved appearance changes on already-mounted screens and modal routes.
 - openLink: "rakazo:///account"
@@ -148,38 +148,38 @@ tags:
     visible: "Dark"
     timeout: 10000
 - tapOn: "Dark"
-- takeScreenshot: "screenshots/22-account-dark"
+- takeScreenshot: "22-account-dark"
 
 - openLink: "rakazo:///new"
 - assertVisible: "Name this bot"
-- takeScreenshot: "screenshots/23-new-bot-dark"
+- takeScreenshot: "23-new-bot-dark"
 
 - openLink: "rakazo:///new-group"
 - assertVisible: "Name this group"
-- takeScreenshot: "screenshots/24-new-group-dark"
+- takeScreenshot: "24-new-group-dark"
 
 - openLink: "rakazo:///new-space"
 - assertVisible: "Customer support"
-- takeScreenshot: "screenshots/25-new-space-dark"
+- takeScreenshot: "25-new-space-dark"
 
 - openLink: "rakazo:///thread?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
 - extendedWaitUntil:
     visible: "The fixture workspace is ready."
     timeout: 10000
-- takeScreenshot: "screenshots/26-thread-dark"
+- takeScreenshot: "26-thread-dark"
 
 - openLink: "rakazo:///group-thread?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}&name=Launch%20team"
 - extendedWaitUntil:
     visible: "The fixture launch plan is ready."
     timeout: 10000
-- takeScreenshot: "screenshots/27-group-thread-dark"
+- takeScreenshot: "27-group-thread-dark"
 
 - openLink: "rakazo:///group-settings?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}"
 - assertVisible: "Delete group"
-- takeScreenshot: "screenshots/28-group-settings-dark"
+- takeScreenshot: "28-group-settings-dark"
 
 - openLink: "rakazo:///account"
 - tapOn: "Light"
 - openLink: "rakazo:///thread?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
 - assertVisible: "The fixture workspace is ready."
-- takeScreenshot: "screenshots/29-thread-light-restored"
+- takeScreenshot: "29-thread-light-restored"

--- a/apps/mobile/e2e/README.md
+++ b/apps/mobile/e2e/README.md
@@ -37,5 +37,5 @@ local session and endpoint data; it does not delete server-side bots.
 ## Screenshot catalog
 
 Run **Actions → mobile Android screenshots → Run workflow** to build the app, seed an isolated fake
-workspace, capture light and dark Android emulator views, and upload the screenshots and Maestro report for
-seven days. It uses no repository secrets or hosted providers.
+workspace, capture light and dark Android emulator views, upload diagnostics for seven days, and publish a
+persistent gallery beside the Playwright reports.

--- a/packages/testkit/src/cli/generate-mobile-screenshot-gallery.ts
+++ b/packages/testkit/src/cli/generate-mobile-screenshot-gallery.ts
@@ -1,0 +1,76 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  MAX_PLAYWRIGHT_SCREENSHOT_BYTES,
+  type MobileScreenshot,
+  renderMobileScreenshotGallery,
+  screenshotTitleFromFileName,
+} from "../playwright-report-dashboard.js";
+import { validatePngScreenshot } from "../png-validation.js";
+
+const [screenshotsPath, galleryPath] = process.argv.slice(2);
+const MAX_SCREENSHOT_COUNT = 100;
+
+if (!screenshotsPath || !galleryPath) {
+  throw new Error("Usage: generate-mobile-screenshot-gallery <screenshots-path> <gallery-path>");
+}
+
+const screenshotsUrl = getHttpsEnvironmentVariable("MOBILE_SCREENSHOTS_URL");
+const entries = (await readdir(screenshotsPath, { withFileTypes: true }))
+  .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".png"))
+  .sort((left, right) => left.name.localeCompare(right.name));
+
+if (entries.length === 0 || entries.length > MAX_SCREENSHOT_COUNT) {
+  throw new Error(`Expected between 1 and ${MAX_SCREENSHOT_COUNT} mobile screenshots`);
+}
+
+const imagesPath = path.join(galleryPath, "images");
+await mkdir(imagesPath, { recursive: true });
+
+let totalBytes = 0;
+const screenshots: MobileScreenshot[] = [];
+for (const entry of entries) {
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*\.png$/i.test(entry.name)) {
+    throw new Error(`Unsafe mobile screenshot filename: ${entry.name}`);
+  }
+  const sourcePath = path.join(screenshotsPath, entry.name);
+  const screenshot = await readFile(sourcePath);
+  validatePngScreenshot(screenshot, sourcePath);
+  totalBytes += screenshot.byteLength;
+  if (totalBytes > MAX_PLAYWRIGHT_SCREENSHOT_BYTES) {
+    throw new Error("Mobile screenshot catalog exceeds its size limit");
+  }
+  await writeFile(path.join(imagesPath, entry.name), screenshot);
+  screenshots.push({
+    fileName: `images/${entry.name}`,
+    source: entry.name,
+    title: screenshotTitleFromFileName(entry.name),
+  });
+}
+
+await writeFile(
+  path.join(galleryPath, "index.html"),
+  renderMobileScreenshotGallery({
+    createdAt: new Date().toISOString(),
+    runUrl: getHttpsEnvironmentVariable("MOBILE_RUN_URL"),
+    screenshots,
+    screenshotsUrl,
+    sha: getEnvironmentVariable("MOBILE_SHA"),
+  }),
+);
+
+console.log(`Mobile screenshot gallery generated with ${screenshots.length} views.`);
+
+function getEnvironmentVariable(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function getHttpsEnvironmentVariable(name: string): string {
+  const value = getEnvironmentVariable(name);
+  if (!URL.canParse(value) || new URL(value).protocol !== "https:") {
+    throw new Error(`${name} must use HTTPS`);
+  }
+  return value;
+}

--- a/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
+++ b/packages/testkit/src/cli/generate-playwright-report-dashboard.ts
@@ -9,6 +9,7 @@ import {
   type PlaywrightScreenshot,
   renderPlaywrightDashboard,
   renderScreenshotGallery,
+  screenshotTitleFromFileName,
   shouldPublishStableMainBaseline,
   updatePlaywrightHistory,
   validatePlaywrightScreenshotBudget,
@@ -138,7 +139,7 @@ async function collectScreenshots(
       hash: createHash("sha256").update(screenshot).digest("hex"),
       source,
       testId: testIdFromSource(source),
-      title: titleFromFileName(baseName),
+      title: screenshotTitleFromFileName(baseName),
     });
   }
   return screenshots;
@@ -177,13 +178,6 @@ async function findPngFiles(
 
 function sanitizeFileName(fileName: string): string {
   return fileName.replaceAll(/[^a-zA-Z0-9._-]/g, "-");
-}
-
-function titleFromFileName(fileName: string): string {
-  return fileName
-    .replace(/\.png$/i, "")
-    .replace(/^\d+-/, "")
-    .replaceAll(/[-_]+/g, " ");
 }
 
 function testIdFromSource(source: string): string {

--- a/packages/testkit/src/playwright-report-dashboard.test.ts
+++ b/packages/testkit/src/playwright-report-dashboard.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_PLAYWRIGHT_SCREENSHOT_COUNT,
   type PlaywrightRun,
   type PlaywrightScreenshot,
+  renderMobileScreenshotGallery,
   renderPlaywrightDashboard,
   renderScreenshotGallery,
   shouldPublishStableMainBaseline,
@@ -351,6 +352,34 @@ describe("renderScreenshotGallery", () => {
     expect(html).toContain("Automatic failure capture");
     expect(html).toContain('data-filter="all" aria-pressed="true"');
     expect(html).toContain('data-filter="new" aria-pressed="false" disabled');
+  });
+
+  it("renders the same responsive gallery as a mobile catalog without review controls", () => {
+    const html = renderMobileScreenshotGallery({
+      createdAt: "2026-08-16T10:00:00.000Z",
+      runUrl: "https://github.com/example/repository/actions/runs/200",
+      screenshots: [
+        {
+          fileName: "images/01-inbox.png",
+          source: "01-inbox.png",
+          title: "inbox",
+        },
+      ],
+      screenshotsUrl: "https://example.com/playwright/mobile-android/runs/200-1/index.html",
+      sha: "abcdef1234567890",
+    });
+
+    expect(html).toContain("<h1>Android screenshots</h1>");
+    expect(html).toContain("<strong>inbox</strong>");
+    expect(html).toContain(
+      'src="https://example.com/playwright/mobile-android/runs/200-1/images/01-inbox.png"',
+    );
+    expect(html).not.toContain('class="badges"');
+    expect(html).not.toContain("SHA-256");
+    expect(html).not.toContain("NO BASELINE");
+    expect(html).not.toContain('class="filters"');
+    expect(html).not.toContain('document.querySelectorAll("figure")');
+    expect(html).not.toContain("All runs");
   });
 });
 

--- a/packages/testkit/src/playwright-report-dashboard.ts
+++ b/packages/testkit/src/playwright-report-dashboard.ts
@@ -49,6 +49,8 @@ export type PlaywrightScreenshotManifest = {
 
 export type PlaywrightScreenshotMetadata = Omit<PlaywrightScreenshot, "comparison" | "fileName">;
 
+export type MobileScreenshot = Pick<PlaywrightScreenshot, "fileName" | "source" | "title">;
+
 export function validatePlaywrightScreenshotBudget(count: number, totalBytes: number): void {
   if (count > MAX_PLAYWRIGHT_SCREENSHOT_COUNT) {
     throw new Error(
@@ -68,6 +70,13 @@ export function classifyPlaywrightScreenshot(
   const baseName = fileName.split(/[\\/]/).at(-1) ?? fileName;
   if (/^test-finished(?:-\d+)?\.png$/i.test(baseName)) return undefined;
   return /^test-failed(?:-\d+)?\.png$/i.test(baseName) ? "failure" : "checkpoint";
+}
+
+export function screenshotTitleFromFileName(fileName: string): string {
+  return fileName
+    .replace(/\.png$/i, "")
+    .replace(/^\d+-/, "")
+    .replaceAll(/[-_]+/g, " ");
 }
 
 export function createScreenshotManifest(
@@ -374,52 +383,90 @@ export function renderScreenshotGallery(input: {
   screenshotsUrl: string;
   sha: string;
 }): string {
+  return renderGalleryPage({ ...input, presentation: "review" });
+}
+
+export function renderMobileScreenshotGallery(input: {
+  createdAt: string;
+  runUrl: string;
+  screenshots: MobileScreenshot[];
+  screenshotsUrl: string;
+  sha: string;
+}): string {
+  return renderGalleryPage({ ...input, presentation: "mobile" });
+}
+
+type GalleryInput =
+  | ({
+      presentation: "review";
+    } & Parameters<typeof renderScreenshotGallery>[0])
+  | {
+      createdAt: string;
+      presentation: "mobile";
+      runUrl: string;
+      screenshots: MobileScreenshot[];
+      screenshotsUrl: string;
+      sha: string;
+    };
+
+function renderGalleryPage(input: GalleryInput): string {
+  const mobile = input.presentation === "mobile";
   const galleryBaseUrl = new URL(".", input.screenshotsUrl);
+  const reviewScreenshots = mobile ? [] : input.screenshots;
   const counts = {
-    changed: input.screenshots.filter((screenshot) => screenshot.comparison === "changed").length,
-    failed: input.screenshots.filter((screenshot) => screenshot.captureType === "failure").length,
-    new: input.screenshots.filter((screenshot) => screenshot.comparison === "new").length,
+    changed: reviewScreenshots.filter((screenshot) => screenshot.comparison === "changed").length,
+    failed: reviewScreenshots.filter((screenshot) => screenshot.captureType === "failure").length,
+    new: reviewScreenshots.filter((screenshot) => screenshot.comparison === "new").length,
   };
-  const reviewCount = input.screenshots.filter(
+  const reviewCount = reviewScreenshots.filter(
     (screenshot) =>
       screenshot.captureType === "failure" ||
       screenshot.comparison === "changed" ||
       screenshot.comparison === "new",
   ).length;
-  const defaultFilter = !input.baselineAvailable ? "all" : counts.new > 0 ? "new" : "review";
-  const screenshots = input.screenshots
-    .map((screenshot, index) => {
-      const imageUrl = new URL(screenshot.fileName, galleryBaseUrl).toString();
-      const badges = [
-        screenshot.captureType === "failure"
-          ? '<span class="badge failure">FAILED</span>'
-          : '<span class="badge checkpoint">CHECKPOINT</span>',
-        screenshot.comparison === "new"
-          ? '<span class="badge new">NEW</span>'
-          : screenshot.comparison === "changed"
-            ? '<span class="badge changed">CHANGED</span>'
-            : screenshot.comparison === "unchanged"
-              ? '<span class="badge unchanged">UNCHANGED</span>'
-              : '<span class="badge unavailable">NO BASELINE</span>',
-      ].join("");
-      return `
-        <figure data-capture="${screenshot.captureType}" data-comparison="${screenshot.comparison}">
-          <a href="${escapeHtml(imageUrl)}" target="_blank" rel="noreferrer">
-            <img src="${escapeHtml(imageUrl)}" alt="${escapeHtml(screenshot.title)}" loading="lazy" />
-          </a>
-          <figcaption>
-            <span class="number">${String(index + 1).padStart(2, "0")}</span>
-            <span class="caption-copy">
-              <span class="badges">${badges}</span>
-              <strong>${escapeHtml(screenshot.title)}</strong>
-              <small>${screenshot.captureType === "failure" ? "Automatic failure capture" : "Intentional test checkpoint"} · ${escapeHtml(screenshot.testId)}</small>
-              <small title="${escapeHtml(screenshot.source)}">${escapeHtml(screenshot.source)}</small>
-              <small>SHA-256 ${escapeHtml(screenshot.hash.slice(0, 12))}</small>
-            </span>
-          </figcaption>
-        </figure>`;
-    })
-    .join("");
+  const defaultFilter = mobile
+    ? "all"
+    : !input.baselineAvailable
+      ? "all"
+      : counts.new > 0
+        ? "new"
+        : "review";
+  const screenshots = (
+    mobile
+      ? input.screenshots.map((screenshot, index) =>
+          renderGalleryFigure(screenshot, index, galleryBaseUrl),
+        )
+      : input.screenshots.map((screenshot, index) =>
+          renderGalleryFigure(screenshot, index, galleryBaseUrl, screenshot),
+        )
+  ).join("");
+  const filterScript = mobile
+    ? ""
+    : `
+    const figures = Array.from(document.querySelectorAll("figure"));
+    const filters = Array.from(document.querySelectorAll(".filter"));
+    const filterEmpty = document.querySelector(".filter-empty");
+
+    function setFilter(filter) {
+      let visible = 0;
+      for (const figure of figures) {
+        const show = filter === "all" ||
+          (filter === "review" && (figure.dataset.capture === "failure" || ["new", "changed"].includes(figure.dataset.comparison))) ||
+          (filter === "failed" && figure.dataset.capture === "failure") ||
+          filter === figure.dataset.capture || filter === figure.dataset.comparison;
+        figure.hidden = !show;
+        if (show) visible += 1;
+      }
+      for (const button of filters) {
+        button.setAttribute("aria-pressed", String(button.dataset.filter === filter));
+      }
+      if (filterEmpty) filterEmpty.hidden = visible !== 0;
+    }
+
+    setFilter(${JSON.stringify(defaultFilter)});
+    for (const filter of filters) {
+      filter.addEventListener("click", () => setFilter(filter.dataset.filter));
+    }`;
 
   return `<!doctype html>
 <html lang="en">
@@ -427,7 +474,7 @@ export function renderScreenshotGallery(input: {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="color-scheme" content="dark" />
-  <title>Run screenshots · Rakazo</title>
+  <title>${mobile ? "Android screenshots" : "Run screenshots"} · Rakazo</title>
   <style>
     ${SHARED_PAGE_STYLES}
     body { margin: 0; min-height: 100vh; background: radial-gradient(circle at top, #312e81 0, #09090b 36rem); }
@@ -479,22 +526,22 @@ export function renderScreenshotGallery(input: {
     <header>
       <div>
         <p class="eyebrow">Rakazo · visual review</p>
-        <h1>${input.pullRequestNumber ? `PR #${input.pullRequestNumber} screenshots` : "Run screenshots"}</h1>
-        <p class="subtitle">Review intentional checkpoints separately from automatic failure captures.</p>
+        <h1>${mobile ? "Android screenshots" : input.pullRequestNumber ? `PR #${input.pullRequestNumber} screenshots` : "Run screenshots"}</h1>
+        ${mobile ? "" : '<p class="subtitle">Review intentional checkpoints separately from automatic failure captures.</p>'}
       </div>
       <div class="actions">
-        ${input.reportUrl ? `<a class="button" href="${escapeHtml(input.reportUrl)}">Full report</a>` : ""}
-        ${input.pullRequestUrl ? `<a class="button" href="${escapeHtml(input.pullRequestUrl)}">PR #${input.pullRequestNumber}</a>` : ""}
+        ${!mobile && input.reportUrl ? `<a class="button" href="${escapeHtml(input.reportUrl)}">Full report</a>` : ""}
+        ${!mobile && input.pullRequestUrl ? `<a class="button" href="${escapeHtml(input.pullRequestUrl)}">PR #${input.pullRequestNumber}</a>` : ""}
         <a class="button" href="${escapeHtml(input.runUrl)}">GitHub Actions</a>
-        <a class="button" href="${escapeHtml(input.dashboardUrl)}">All runs</a>
+        ${mobile ? "" : `<a class="button" href="${escapeHtml(input.dashboardUrl)}">All runs</a>`}
       </div>
     </header>
     <div class="toolbar">
       <section class="meta">
-        <span class="pill">${escapeHtml(input.result)}</span>
+        ${mobile ? "" : `<span class="pill">${escapeHtml(input.result)}</span>`}
         <span class="pill">${escapeHtml(input.sha.slice(0, 7))}</span>
         <span class="pill">${input.screenshots.length} screenshots</span>
-        <span class="pill">${input.baselineAvailable ? "Compared with latest successful main run" : "No comparable main baseline"}</span>
+        ${mobile ? "" : `<span class="pill">${input.baselineAvailable ? "Compared with latest successful main run" : "No comparable main baseline"}</span>`}
         <span class="pill">${escapeHtml(new Date(input.createdAt).toLocaleString("en-US", { timeZone: "UTC" }))} UTC</span>
       </section>
       ${
@@ -517,7 +564,7 @@ export function renderScreenshotGallery(input: {
       }
     </div>
     ${
-      screenshots
+      screenshots && !mobile
         ? `<nav class="filters" aria-label="Screenshot filters">
       <button class="filter" type="button" data-filter="all" aria-pressed="${String(defaultFilter === "all")}">All (${input.screenshots.length})</button>
       <button class="filter" type="button" data-filter="review" aria-pressed="${String(defaultFilter === "review")}">Review changes (${reviewCount})</button>
@@ -528,13 +575,10 @@ export function renderScreenshotGallery(input: {
         : ""
     }
     ${screenshots ? `<section class="gallery">${screenshots}</section>` : '<div class="empty">No screenshots were produced by this run.</div>'}
-    ${screenshots ? '<div class="empty filter-empty" hidden>No screenshots match this filter.</div>' : ""}
+    ${screenshots && !mobile ? '<div class="empty filter-empty" hidden>No screenshots match this filter.</div>' : ""}
   </main>
   <script>
     const gallery = document.querySelector(".gallery");
-    const figures = Array.from(document.querySelectorAll("figure"));
-    const filters = Array.from(document.querySelectorAll(".filter"));
-    const filterEmpty = document.querySelector(".filter-empty");
     const viewOptions = Array.from(document.querySelectorAll(".view-option"));
     const storageKey = "rakazo-playwright-gallery-columns";
 
@@ -563,29 +607,50 @@ export function renderScreenshotGallery(input: {
       option.addEventListener("click", () => setGalleryColumns(option.dataset.columns, true));
     }
 
-    function setFilter(filter) {
-      let visible = 0;
-      for (const figure of figures) {
-        const show = filter === "all" ||
-          (filter === "review" && (figure.dataset.capture === "failure" || ["new", "changed"].includes(figure.dataset.comparison))) ||
-          (filter === "failed" && figure.dataset.capture === "failure") ||
-          filter === figure.dataset.capture || filter === figure.dataset.comparison;
-        figure.hidden = !show;
-        if (show) visible += 1;
-      }
-      for (const button of filters) {
-        button.setAttribute("aria-pressed", String(button.dataset.filter === filter));
-      }
-      if (filterEmpty) filterEmpty.hidden = visible !== 0;
-    }
-
-    setFilter(${JSON.stringify(defaultFilter)});
-    for (const filter of filters) {
-      filter.addEventListener("click", () => setFilter(filter.dataset.filter));
-    }
+    ${filterScript}
   </script>
 </body>
 </html>`;
+}
+
+function renderGalleryFigure(
+  screenshot: MobileScreenshot,
+  index: number,
+  galleryBaseUrl: URL,
+  review?: Pick<PlaywrightScreenshot, "captureType" | "comparison" | "hash" | "testId">,
+): string {
+  const imageUrl = new URL(screenshot.fileName, galleryBaseUrl).toString();
+  const badges = review
+    ? [
+        review.captureType === "failure"
+          ? '<span class="badge failure">FAILED</span>'
+          : '<span class="badge checkpoint">CHECKPOINT</span>',
+        review.comparison === "new"
+          ? '<span class="badge new">NEW</span>'
+          : review.comparison === "changed"
+            ? '<span class="badge changed">CHANGED</span>'
+            : review.comparison === "unchanged"
+              ? '<span class="badge unchanged">UNCHANGED</span>'
+              : '<span class="badge unavailable">NO BASELINE</span>',
+      ].join("")
+    : "";
+
+  return `
+        <figure${review ? ` data-capture="${review.captureType}" data-comparison="${review.comparison}"` : ""}>
+          <a href="${escapeHtml(imageUrl)}" target="_blank" rel="noreferrer">
+            <img src="${escapeHtml(imageUrl)}" alt="${escapeHtml(screenshot.title)}" loading="lazy" />
+          </a>
+          <figcaption>
+            <span class="number">${String(index + 1).padStart(2, "0")}</span>
+            <span class="caption-copy">
+              ${badges ? `<span class="badges">${badges}</span>` : ""}
+              <strong>${escapeHtml(screenshot.title)}</strong>
+              ${review ? `<small>${review.captureType === "failure" ? "Automatic failure capture" : "Intentional test checkpoint"} · ${escapeHtml(review.testId)}</small>` : ""}
+              <small title="${escapeHtml(screenshot.source)}">${escapeHtml(screenshot.source)}</small>
+              ${review ? `<small>SHA-256 ${escapeHtml(review.hash.slice(0, 12))}</small>` : ""}
+            </span>
+          </figcaption>
+        </figure>`;
 }
 
 function isPlaywrightRun(value: unknown): value is PlaywrightRun {

--- a/scripts/publish-mobile-screenshot-gallery.sh
+++ b/scripts/publish-mobile-screenshot-gallery.sh
@@ -51,15 +51,7 @@ aws s3 cp \
   --endpoint-url "$S3_ENDPOINT" \
   --content-type "text/html" \
   --cache-control "public,max-age=31536000,immutable"
-aws s3 cp \
-  "$gallery_dir/index.html" \
-  "$bucket_uri/index.html" \
-  --endpoint-url "$S3_ENDPOINT" \
-  --content-type "text/html" \
-  --cache-control "no-store"
-
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  printf '### Android screenshots\n- [Screenshot gallery](%s)\n- [Latest gallery](%s/index.html)\n' \
-    "$gallery_url" \
-    "$public_base_url" >> "$GITHUB_STEP_SUMMARY"
+  printf '### Android screenshots\n- [Screenshot gallery](%s)\n' \
+    "$gallery_url" >> "$GITHUB_STEP_SUMMARY"
 fi

--- a/scripts/publish-mobile-screenshot-gallery.sh
+++ b/scripts/publish-mobile-screenshot-gallery.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
+: "${S3_BUCKET:?S3_BUCKET is required}"
+: "${S3_ENDPOINT:?S3_ENDPOINT is required}"
+: "${PLAYWRIGHT_PUBLIC_BASE_URL:?PLAYWRIGHT_PUBLIC_BASE_URL is required}"
+: "${MOBILE_RUN_ATTEMPT:?MOBILE_RUN_ATTEMPT is required}"
+: "${MOBILE_RUN_ID:?MOBILE_RUN_ID is required}"
+: "${MOBILE_RUN_URL:?MOBILE_RUN_URL is required}"
+: "${MOBILE_SHA:?MOBILE_SHA is required}"
+
+if [[ ! "$S3_BUCKET" =~ ^[a-zA-Z0-9.-]+$ ]]; then
+  echo "S3_BUCKET contains invalid characters." >&2
+  exit 1
+fi
+
+case "$S3_ENDPOINT" in
+  https://*) ;;
+  *) echo "S3_ENDPOINT must use HTTPS." >&2; exit 1 ;;
+esac
+
+case "$PLAYWRIGHT_PUBLIC_BASE_URL" in
+  https://*) ;;
+  *) echo "PLAYWRIGHT_PUBLIC_BASE_URL must use HTTPS." >&2; exit 1 ;;
+esac
+
+run_key="${MOBILE_RUN_ID}-${MOBILE_RUN_ATTEMPT}"
+bucket_uri="s3://${S3_BUCKET}/playwright/mobile-android"
+public_base_url="${PLAYWRIGHT_PUBLIC_BASE_URL%/}/mobile-android"
+gallery_url="$public_base_url/runs/$run_key/index.html"
+gallery_dir="$GITHUB_WORKSPACE/.tmp/mobile-screenshot-gallery"
+
+MOBILE_SCREENSHOTS_URL="$gallery_url" \
+  pnpm exec tsx packages/testkit/src/cli/generate-mobile-screenshot-gallery.ts \
+    test-report/mobile-screenshots/screenshots \
+    "$gallery_dir"
+
+aws s3 cp \
+  "$gallery_dir/images/" \
+  "$bucket_uri/runs/$run_key/images/" \
+  --recursive \
+  --endpoint-url "$S3_ENDPOINT" \
+  --content-type "image/png" \
+  --no-guess-mime-type \
+  --cache-control "public,max-age=31536000,immutable"
+aws s3 cp \
+  "$gallery_dir/index.html" \
+  "$bucket_uri/runs/$run_key/index.html" \
+  --endpoint-url "$S3_ENDPOINT" \
+  --content-type "text/html" \
+  --cache-control "public,max-age=31536000,immutable"
+aws s3 cp \
+  "$gallery_dir/index.html" \
+  "$bucket_uri/index.html" \
+  --endpoint-url "$S3_ENDPOINT" \
+  --content-type "text/html" \
+  --cache-control "no-store"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  printf '### Android screenshots\n- [Screenshot gallery](%s)\n- [Latest gallery](%s/index.html)\n' \
+    "$gallery_url" \
+    "$public_base_url" >> "$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
## Why

Mobile screenshot artifacts expire and require downloading an archive to review. Their extra nested `screenshots/screenshots` directory also makes the archive harder to browse.

## What changed

- publish successful manual Android captures to the existing Hetzner-backed report storage at an immutable per-run URL
- reuse the responsive Playwright gallery layout through a mobile-specific renderer
- validate and bound PNG input before publishing
- flatten Maestro output to `screenshots/*.png`
- isolate workflow concurrency per branch so separate manual captures do not cancel each other

## Testing

- [live Android gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/mobile-android/runs/33970256740-2/index.html) published by the manual emulator workflow
- generated the current renderer with all 31 light and dark views from a current-base Android artifact
- verified the live computer view uses the native fallback instead of Chromium's unsupported-URL page
- verified a retry restored the APK cache and skipped the release build
- testkit tests and TypeScript checks passed
- repository TypeScript checks passed
- repository lint completed with pre-existing warnings only
- workflow and Maestro YAML parsed successfully; publisher shell syntax passed

## Visible copy

Adds `Android screenshots` as the gallery heading. The heading is necessary to identify the catalog; hiding it until interaction would leave the page without context. All other gallery labels reuse the existing report UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent Android screenshot gallery alongside Playwright reports.
  * Added responsive gallery views with screenshot titles and source links.
  * Expanded screenshot coverage to include dark mode, password changes, all model providers, and additional bot, group, space, thread, and settings views.
  * Added validation for screenshot files and gallery publishing inputs.

* **Documentation**
  * Updated screenshot workflow documentation to describe light and dark emulator coverage, diagnostics retention, and the published gallery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->