### PR TITLE
docs: align setup Node versions with package engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ the `https://` address.
 
 ## Local development (source checkout)
 
-You need Node.js 22+, pnpm 9, and Docker.
+You need Node.js matching `^22.22.2 || ^24.0.0 || >=26.0.0`, plus pnpm 9 and Docker.
 
 ```bash
 git clone https://github.com/elie222/rakazo.git

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -94,7 +94,7 @@ Do not ask me to invent `BETTER_AUTH_SECRET` or `ENCRYPTION_KEY`; generate stron
 Preflight:
 
 - Verify Git, Node.js, pnpm, Docker, and Docker Compose.
-- Use Node.js 22 LTS (at least 22.12) and the repository-declared pnpm 9.15.0. Do not silently use pnpm 10 or 11: newer pnpm versions can reject this lockfile or rewrite it. Prefer Corepack; if Corepack is unavailable, use `npx --yes pnpm@9.15.0` for repo commands rather than globally installing a different version. Show the effective versions.
+- Use a Node.js version matching the repository engine (`^22.22.2 || ^24.0.0 || >=26.0.0`) and the repository-declared pnpm 9.15.0. Do not silently use pnpm 10 or 11: newer pnpm versions can reject this lockfile or rewrite it. Prefer Corepack; if Corepack is unavailable, use `npx --yes pnpm@9.15.0` for repo commands rather than globally installing a different version. Show the effective versions.
 - Verify the Docker daemon is running.
 - Check whether `127.0.0.1` ports 5433, 3100, 5173, and 7091 are available. Resolve conflicts without touching unrelated workloads.
 


### PR DESCRIPTION
## Why

The source-checkout guides currently accept Node versions that the package engine rejects, so a documented setup can fail before development starts.

Fixes #587.

## What

- use the exact `package.json` Node engine range in the README
- give coding agents the same exact preflight requirement in `SETUP_PROMPT.md`
- avoid broad `22+` wording that accidentally includes unsupported 23.x and 25.x releases

## Tests

- compared both documented ranges against `package.json#engines.node`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated local development setup instructions to require Node.js `^22.22.2 || ^24.0.0 || >=26.0.0`.
  - Aligned source-checkout guidance with the repository’s supported Node.js versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->