### PR TITLE
fix(web): remove the first-bot profile form from onboarding

### DIFF
--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -50,7 +50,7 @@ export async function completeOnboarding(page: Page, testInfo?: TestInfo) {
       .catch(() => false)
   ) {
     if (testInfo) await captureScreenshot(page, testInfo, "03-create-first-bot");
-    await page.locator("label:has-text('Name') input").fill("Chief");
+    await expect(page.getByRole("textbox")).toHaveCount(0);
     const created = page.waitForResponse(
       (response) => response.url().includes("/rpc/bots/create") && response.ok(),
     );

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -4,7 +4,7 @@ import {
   openAiCompatibleConnectReady,
   openAiCompatibleProbeSuccessMessage,
 } from "@rakazo/contracts";
-import { Button, Input, NativeSelect, NativeSelectOption, Textarea } from "@rakazo/ui-web";
+import { Button, Input, NativeSelect, NativeSelectOption } from "@rakazo/ui-web";
 import { Check } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -32,9 +32,6 @@ export function OnboardingPage() {
   const [probeModels, setProbeModels] = useState<string[]>([]);
   const [probedBaseUrl, setProbedBaseUrl] = useState<string | null>(null);
   const [probing, setProbing] = useState(false);
-  const [name, setName] = useState("");
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [needsModel, setNeedsModel] = useState(false);
@@ -217,10 +214,10 @@ export function OnboardingPage() {
     setError(null);
     try {
       const bot = await rpc.bots.create({
-        name: name.trim(),
-        title,
-        description,
-        instructions: description,
+        name: "Chief",
+        title: "",
+        description: "",
+        instructions: "",
         notifyOnFinish: true,
       });
       // Onboarding continues conversationally in the thread: greeting first,
@@ -583,45 +580,8 @@ export function OnboardingPage() {
             <h1 className="text-[32px] font-medium text-foreground">
               <Trans>Create your first bot</Trans>
             </h1>
-            <label htmlFor={`${fieldId}-name`} className="mt-8 block text-sm text-muted-foreground">
-              <Trans>Name</Trans>
-              <Input
-                id={`${fieldId}-name`}
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder={t`Name this bot`}
-                className="mt-2"
-              />
-            </label>
-            <label
-              htmlFor={`${fieldId}-title`}
-              className="mt-4 block text-sm text-muted-foreground"
-            >
-              <Trans>Title</Trans>
-              <Input
-                id={`${fieldId}-title`}
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder={t`Describe what this bot does`}
-                className="mt-2"
-              />
-            </label>
-            <label
-              htmlFor={`${fieldId}-description`}
-              className="mt-4 block text-sm text-muted-foreground"
-            >
-              <Trans>Description</Trans>
-              <Textarea
-                id={`${fieldId}-description`}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder={t`What this bot is for`}
-                rows={4}
-                className="mt-2"
-              />
-            </label>
             {error ? <p className="mt-3 text-sm text-destructive">{error}</p> : null}
-            <Button className="mt-6" disabled={!name.trim()} onClick={() => void createBot()}>
+            <Button className="mt-8" onClick={() => void createBot()}>
               <Trans>Continue</Trans>
             </Button>
           </div>


### PR DESCRIPTION
## Why

First-run users currently have to fill three profile fields before they can reach the product. The profile can be edited later, so this adds friction without helping the first run.

This addresses the first-bot form part of #553.

## What

- remove the name, title, and description form from the first-bot step
- create the initial bot with the existing `Chief` default and an empty optional profile
- update the onboarding E2E helper to assert the form stays absent

## Tests

- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web test` (200 tests)
- `pnpm exec biome check apps/web/src/pages/Onboarding.tsx apps/web/e2e/helpers.ts`
- CI: lint, typecheck, unit tests, Postgres journeys, production builds, and Web E2E all pass

## Screenshots

- [Playwright screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/665/index.html)
- [CI run](https://github.com/elie222/rakazo/actions/runs/33969409579)