### PR TITLE
Fix mobile themes, layouts, and settings

### DIFF
--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -110,7 +110,7 @@ tags:
 - tapOn: "Bot actions"
 - assertVisible: "Clear conversation"
 - takeScreenshot: "screenshots/16-bot-actions"
-- tapOn: "Cancel"
+- back
 
 - openLink: "rakazo:///bot-settings?botId=${RAKAZO_SCREENSHOT_BOT_ID}"
 - extendedWaitUntil:

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -64,15 +64,27 @@ tags:
 
 - openLink: "rakazo:///account"
 - extendedWaitUntil:
-    visible: "Password"
+    visible: "Change password"
     timeout: 10000
 - takeScreenshot: "screenshots/10-account"
+- tapOn: "Change password"
+- assertVisible: "Current password"
+- takeScreenshot: "screenshots/10b-change-password"
+- back
 
 - openLink: "rakazo:///models"
 - extendedWaitUntil:
     visible: "Active model"
     timeout: 10000
+- scrollUntilVisible:
+    element: "Show more"
+    direction: DOWN
 - takeScreenshot: "screenshots/11-models"
+- tapOn: "Show more"
+- scrollUntilVisible:
+    element: "Show less"
+    direction: DOWN
+- takeScreenshot: "screenshots/11b-all-providers"
 
 - openLink: "rakazo:///voice"
 - extendedWaitUntil:
@@ -129,3 +141,45 @@ tags:
     visible: "Weekly fixture review"
     timeout: 10000
 - takeScreenshot: "screenshots/21-routine"
+
+# Verify saved appearance changes on already-mounted screens and modal routes.
+- openLink: "rakazo:///account"
+- extendedWaitUntil:
+    visible: "Dark"
+    timeout: 10000
+- tapOn: "Dark"
+- takeScreenshot: "screenshots/22-account-dark"
+
+- openLink: "rakazo:///new"
+- assertVisible: "Name this bot"
+- takeScreenshot: "screenshots/23-new-bot-dark"
+
+- openLink: "rakazo:///new-group"
+- assertVisible: "Name this group"
+- takeScreenshot: "screenshots/24-new-group-dark"
+
+- openLink: "rakazo:///new-space"
+- assertVisible: "Customer support"
+- takeScreenshot: "screenshots/25-new-space-dark"
+
+- openLink: "rakazo:///thread?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
+- extendedWaitUntil:
+    visible: "The fixture workspace is ready."
+    timeout: 10000
+- takeScreenshot: "screenshots/26-thread-dark"
+
+- openLink: "rakazo:///group-thread?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}&name=Launch%20team"
+- extendedWaitUntil:
+    visible: "The fixture launch plan is ready."
+    timeout: 10000
+- takeScreenshot: "screenshots/27-group-thread-dark"
+
+- openLink: "rakazo:///group-settings?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}"
+- assertVisible: "Delete group"
+- takeScreenshot: "screenshots/28-group-settings-dark"
+
+- openLink: "rakazo:///account"
+- tapOn: "Light"
+- openLink: "rakazo:///thread?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
+- assertVisible: "The fixture workspace is ready."
+- takeScreenshot: "screenshots/29-thread-light-restored"

--- a/apps/mobile/.maestro/smoke.yaml
+++ b/apps/mobile/.maestro/smoke.yaml
@@ -36,7 +36,8 @@ name: Rakazo mobile smoke
 - pressKey: Enter
 - assertVisible: ${RAKAZO_E2E_MESSAGE}
 
-- tapOn: "Open computer →"
+- tapOn: "Bot actions"
+- tapOn: "Open computer"
 - extendedWaitUntil:
     visible: "Open computer"
     timeout: 30000

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,4 +1,3 @@
-import { lightTokens } from "@rakazo/ui-tokens";
 import { DarkTheme, Stack, ThemeProvider } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useMemo, useState } from "react";
@@ -7,7 +6,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { AvatarStyleProvider } from "../components/avatar-style";
 import { currentApiBase, loadApiBase, loadSessionToken, selectedSpaceId } from "../lib/api";
-import { loadAppearancePreference } from "../lib/appearance";
+import { loadAppearancePreference, mobileTokens } from "../lib/appearance";
 import { bootstrapI18n, useI18n } from "../lib/i18n";
 import {
   configureForegroundNotifications,
@@ -17,35 +16,23 @@ import { native, useResolvedAppearance } from "../lib/native";
 
 configureForegroundNotifications();
 
-const lightTheme = {
-  ...DarkTheme,
-  dark: false,
-  colors: {
-    ...DarkTheme.colors,
-    primary: lightTokens.primary,
-    background: lightTokens.background,
-    card: lightTokens.background,
-    text: lightTokens.foreground,
-    border: lightTokens.border,
-    notification: lightTokens.foreground,
-  },
-};
-
 export default function Layout() {
   const { t } = useI18n();
   const [ready, setReady] = useState(false);
   const resolved = useResolvedAppearance();
   const navigationTheme = useMemo(() => {
-    const base = resolved === "light" ? lightTheme : DarkTheme;
+    const tokens = mobileTokens();
     return {
-      ...base,
+      ...DarkTheme,
+      dark: resolved === "dark",
       colors: {
-        ...base.colors,
-        background: String(native.page),
-        card: String(native.page),
-        text: String(native.label),
-        border: "transparent",
-        primary: String(native.label),
+        ...DarkTheme.colors,
+        background: tokens.background,
+        card: tokens.background,
+        text: tokens.foreground,
+        border: tokens.border,
+        primary: tokens.primary,
+        notification: tokens.foreground,
       },
     };
   }, [resolved]);
@@ -74,8 +61,8 @@ export default function Layout() {
               <StatusBar style={resolved === "light" ? "dark" : "light"} />
               <Stack
                 screenOptions={{
-                  headerStyle: { backgroundColor: String(native.page) },
-                  headerTintColor: String(native.label),
+                  headerStyle: { backgroundColor: navigationTheme.colors.background },
+                  headerTintColor: navigationTheme.colors.text,
                   headerShadowVisible: false,
                   headerBackButtonDisplayMode: "minimal",
                   contentStyle: { backgroundColor: String(native.page) },
@@ -84,6 +71,15 @@ export default function Layout() {
                 <Stack.Screen name="index" options={{ headerShown: false, title: "Rakazo" }} />
                 <Stack.Screen name="sign-in" options={{ headerShown: false }} />
                 <Stack.Screen name="account" options={{ title: t("Account") }} />
+                <Stack.Screen
+                  name="change-password"
+                  options={{
+                    title: t("Change password"),
+                    presentation: "formSheet",
+                    sheetAllowedDetents: [0.6, 1],
+                    sheetGrabberVisible: true,
+                  }}
+                />
                 <Stack.Screen name="models" options={{ title: t("Models") }} />
                 <Stack.Screen name="voice" options={{ title: t("Voice") }} />
                 <Stack.Screen name="integrations" options={{ title: t("Integrations") }} />

--- a/apps/mobile/app/account.tsx
+++ b/apps/mobile/app/account.tsx
@@ -1,6 +1,6 @@
 import type { AvatarStyle } from "@rakazo/contracts";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -18,7 +18,6 @@ import { useAvatarStyle } from "../components/avatar-style";
 import { BotAvatar } from "../components/bot-avatar";
 import type { MobileBot } from "../lib/api";
 import {
-  changePassword as changeAccountPassword,
   currentApiBase,
   deleteAccount,
   loadSessionToken,
@@ -29,8 +28,8 @@ import {
 } from "../lib/api";
 import {
   getCachedAppearancePreference,
+  mobileTokens,
   setAppearancePreference,
-  subscribeAppearance,
 } from "../lib/appearance";
 import { explicitSignInRoute } from "../lib/auth-routing";
 import { confirmDeleteBot } from "../lib/bot-lifecycle";
@@ -66,11 +65,6 @@ export default function Account() {
   const [notificationPending, setNotificationPending] = useState(false);
   const [notificationError, setNotificationError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [currentPassword, setCurrentPassword] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [passwordConfirmation, setPasswordConfirmation] = useState("");
-  const [passwordPending, setPasswordPending] = useState(false);
-  const [passwordMessage, setPasswordMessage] = useState<string | null>(null);
   const [archivedBots, setArchivedBots] = useState<MobileBot[]>([]);
   const [usage, setUsage] = useState<{
     runs: number;
@@ -78,11 +72,7 @@ export default function Account() {
     outputTokens: number;
   } | null>(null);
   const { avatarStyle, updateAvatarStyle } = useAvatarStyle();
-  const appearance = useSyncExternalStore(
-    subscribeAppearance,
-    getCachedAppearancePreference,
-    () => "system" as const,
-  );
+  const appearance = getCachedAppearancePreference();
   const styles = useThemedStyles(createAccountStyles);
 
   useEffect(() => {
@@ -156,26 +146,6 @@ export default function Account() {
     }
   }
 
-  async function handlePasswordChange() {
-    if (newPassword !== passwordConfirmation) {
-      setPasswordMessage(t("Passwords do not match"));
-      return;
-    }
-    setPasswordPending(true);
-    setPasswordMessage(null);
-    try {
-      await changeAccountPassword(currentPassword, newPassword);
-      setCurrentPassword("");
-      setNewPassword("");
-      setPasswordConfirmation("");
-      setPasswordMessage(t("Password updated"));
-    } catch (cause) {
-      setPasswordMessage(cause instanceof Error ? cause.message : t("Could not change password"));
-    } finally {
-      setPasswordPending(false);
-    }
-  }
-
   async function updateNotifications(next: LiveNotificationSettings) {
     const previous = notifications;
     setNotifications(next);
@@ -244,44 +214,14 @@ export default function Account() {
         </View>
         {focus !== "usage" ? usageBlock : null}
 
-        <View accessibilityLabel={t("Password")} style={styles.profile}>
-          <Text style={styles.settingsTitle}>{t("Password")}</Text>
-          <AccountPasswordInput
-            label={t("Current password")}
-            value={currentPassword}
-            onChange={setCurrentPassword}
-            autoComplete="current-password"
-          />
-          <AccountPasswordInput
-            label={t("New password")}
-            value={newPassword}
-            onChange={setNewPassword}
-            autoComplete="new-password"
-          />
-          <AccountPasswordInput
-            label={t("Confirm password")}
-            value={passwordConfirmation}
-            onChange={setPasswordConfirmation}
-            autoComplete="new-password"
-          />
-          {passwordMessage ? <Text style={styles.passwordMessage}>{passwordMessage}</Text> : null}
-          <Pressable
-            accessibilityRole="button"
-            disabled={passwordPending || !currentPassword || newPassword.length < 8}
-            onPress={() => void handlePasswordChange()}
-            style={({ pressed }) => [
-              styles.changePasswordButton,
-              (passwordPending || !currentPassword || newPassword.length < 8) && styles.disabled,
-              pressed && styles.pressed,
-            ]}
-          >
-            {passwordPending ? (
-              <ActivityIndicator color={native.label} />
-            ) : (
-              <Text style={styles.changePasswordLabel}>{t("Change password")}</Text>
-            )}
-          </Pressable>
-        </View>
+        <Pressable
+          accessibilityRole="button"
+          onPress={() => router.push("/change-password")}
+          style={({ pressed }) => [styles.settingsButton, pressed && styles.pressed]}
+        >
+          <Text style={styles.settingsTitle}>{t("Change password")}</Text>
+          <Text style={styles.chevron}>›</Text>
+        </Pressable>
 
         <View accessibilityLabel={t("Appearance")} style={styles.avatarSection}>
           <Text style={styles.settingsTitle}>{t("Appearance")}</Text>
@@ -427,14 +367,16 @@ export default function Account() {
               onPress={() => void openPromotedNotificationSettings()}
               style={{ minHeight: 44, justifyContent: "center" }}
             >
-              <Text style={{ color: "#4C8DFF", fontSize: 14 }}>{t("Live update settings")}</Text>
+              <Text style={{ color: native.label, fontSize: 14 }}>{t("Live update settings")}</Text>
             </Pressable>
             <Pressable
               accessibilityRole="button"
               onPress={() => void openLiveNotificationSettings()}
               style={{ minHeight: 44, justifyContent: "center" }}
             >
-              <Text style={{ color: "#4C8DFF", fontSize: 14 }}>{t("Notification settings")}</Text>
+              <Text style={{ color: native.label, fontSize: 14 }}>
+                {t("Notification settings")}
+              </Text>
             </Pressable>
             {notificationError ? <Text style={styles.error}>{notificationError}</Text> : null}
           </View>
@@ -553,7 +495,7 @@ export default function Account() {
             ]}
           >
             {pending ? (
-              <ActivityIndicator color="#FFFFFF" />
+              <ActivityIndicator color={mobileTokens().destructiveForeground} />
             ) : (
               <Text style={styles.deleteLabel}>{t("Delete account")}</Text>
             )}
@@ -601,35 +543,8 @@ function NotificationSwitch({
   );
 }
 
-function AccountPasswordInput({
-  label,
-  value,
-  onChange,
-  autoComplete,
-}: {
-  label: string;
-  value: string;
-  onChange: (value: string) => void;
-  autoComplete: "current-password" | "new-password";
-}) {
-  const styles = useThemedStyles(createAccountStyles);
-  return (
-    <TextInput
-      accessibilityLabel={label}
-      autoCapitalize="none"
-      autoComplete={autoComplete}
-      autoCorrect={false}
-      onChangeText={onChange}
-      placeholder={label}
-      placeholderTextColor={native.tertiaryLabel}
-      secureTextEntry
-      style={styles.accountPassword}
-      value={value}
-    />
-  );
-}
-
 function createAccountStyles() {
+  const tokens = mobileTokens();
   return StyleSheet.create({
     screen: {
       flex: 1,
@@ -694,7 +609,7 @@ function createAccountStyles() {
       fontWeight: "600",
     },
     archivedDeleteLabel: {
-      color: "#FF6961",
+      color: tokens.destructive,
       fontSize: 14,
     },
     settingsButton: {
@@ -779,32 +694,6 @@ function createAccountStyles() {
       fontSize: 13,
       marginTop: 3,
     },
-    accountPassword: {
-      minHeight: 46,
-      borderRadius: 12,
-      backgroundColor: native.fillPressed,
-      color: native.label,
-      paddingHorizontal: 14,
-      marginTop: 8,
-    },
-    passwordMessage: {
-      color: native.secondaryLabel,
-      fontSize: 13,
-      marginTop: 8,
-    },
-    changePasswordButton: {
-      minHeight: 44,
-      borderRadius: 12,
-      alignItems: "center",
-      justifyContent: "center",
-      backgroundColor: native.fillPressed,
-      marginTop: 10,
-    },
-    changePasswordLabel: {
-      color: native.label,
-      fontSize: 15,
-      fontWeight: "600",
-    },
     chevron: {
       color: native.secondaryLabel,
       fontSize: 28,
@@ -814,11 +703,11 @@ function createAccountStyles() {
       marginTop: 12,
       borderRadius: 16,
       borderWidth: StyleSheet.hairlineWidth,
-      borderColor: "#5A2426",
+      borderColor: tokens.destructive,
       padding: 18,
     },
     dangerTitle: {
-      color: "#FF6961",
+      color: tokens.destructive,
       fontSize: 17,
       fontWeight: "600",
     },
@@ -838,7 +727,7 @@ function createAccountStyles() {
       fontSize: 16,
     },
     error: {
-      color: "#FF6961",
+      color: tokens.destructive,
       fontSize: 14,
       marginTop: 10,
     },
@@ -847,11 +736,11 @@ function createAccountStyles() {
       borderRadius: 12,
       alignItems: "center",
       justifyContent: "center",
-      backgroundColor: "#C9363E",
+      backgroundColor: tokens.destructive,
       marginTop: 14,
     },
     deleteLabel: {
-      color: "#FFFFFF",
+      color: tokens.destructiveForeground,
       fontSize: 16,
       fontWeight: "700",
     },

--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -11,13 +11,14 @@ import { Pressable, ScrollView, Text, TextInput } from "react-native";
 import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
-import { tokens } from "../lib/theme";
+import { useMobileTokens } from "../lib/native";
 
 type BotSettingsRecord = MobileBot & {
   description?: string;
 };
 
 export default function BotSettingsScreen() {
+  const tokens = useMobileTokens();
   const { t } = useI18n();
   const router = useRouter();
   const { botId } = useLocalSearchParams<{ botId: string }>();
@@ -86,69 +87,73 @@ export default function BotSettingsScreen() {
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
       >
-        <Text style={{ color: "#85858A", fontSize: 14 }}>{t("Name")}</Text>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>{t("Name")}</Text>
         <TextInput
           value={name}
           maxLength={BOT_NAME_MAX_LENGTH}
           onChangeText={setName}
           placeholder={t("Name this bot")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           style={{
             marginTop: 8,
-            backgroundColor: "#1A1A1D",
+            backgroundColor: tokens.muted,
             borderRadius: 11,
             padding: 16,
-            color: "#ECECEE",
+            color: tokens.foreground,
           }}
         />
-        <Text style={{ color: "#85858A", marginTop: 16, fontSize: 14 }}>{t("Title")}</Text>
+        <Text style={{ color: tokens.mutedForeground, marginTop: 16, fontSize: 14 }}>
+          {t("Title")}
+        </Text>
         <TextInput
           value={title}
           maxLength={BOT_TITLE_MAX_LENGTH}
           onChangeText={setTitle}
           placeholder={t("Describe what this bot does")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           style={{
             marginTop: 8,
-            backgroundColor: "#1A1A1D",
+            backgroundColor: tokens.muted,
             borderRadius: 11,
             padding: 16,
-            color: "#ECECEE",
+            color: tokens.foreground,
           }}
         />
-        <Text style={{ color: "#85858A", marginTop: 16, fontSize: 14 }}>{t("Description")}</Text>
+        <Text style={{ color: tokens.mutedForeground, marginTop: 16, fontSize: 14 }}>
+          {t("Description")}
+        </Text>
         <TextInput
           value={description}
           maxLength={BOT_DESCRIPTION_MAX_LENGTH}
           onChangeText={setDescription}
           placeholder={t("What this bot is for")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           multiline
           style={{
             marginTop: 8,
-            backgroundColor: "#1A1A1D",
+            backgroundColor: tokens.muted,
             borderRadius: 11,
             padding: 16,
-            color: "#ECECEE",
+            color: tokens.foreground,
             minHeight: 120,
             textAlignVertical: "top",
           }}
         />
         <ComputerModePicker value={computerMode} onChange={setComputerMode} />
-        {error ? <Text style={{ color: "#EF4444", marginTop: 16 }}>{error}</Text> : null}
+        {error ? <Text style={{ color: tokens.destructive, marginTop: 16 }}>{error}</Text> : null}
         <Pressable
           onPress={() => void save()}
           disabled={!name.trim() || pending || !bot}
           style={{
             marginTop: 24,
-            backgroundColor: "#F1F1EF",
+            backgroundColor: tokens.primary,
             borderRadius: 11,
             padding: 16,
             alignItems: "center",
             opacity: !name.trim() || pending || !bot ? 0.4 : 1,
           }}
         >
-          <Text style={{ color: "#17171A", fontSize: 16 }}>
+          <Text style={{ color: tokens.primaryForeground, fontSize: 16 }}>
             {pending ? t("Saving…") : t("Save")}
           </Text>
         </Pressable>

--- a/apps/mobile/app/change-password.tsx
+++ b/apps/mobile/app/change-password.tsx
@@ -1,0 +1,176 @@
+import { Stack, useRouter } from "expo-router";
+import { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { changePassword } from "../lib/api";
+import { mobileTokens } from "../lib/appearance";
+import { useI18n } from "../lib/i18n";
+import { native, useThemedStyles } from "../lib/native";
+
+export default function ChangePassword() {
+  const router = useRouter();
+  const { t } = useI18n();
+  const styles = useThemedStyles(createStyles);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmation, setConfirmation] = useState("");
+  const [pending, setPending] = useState(false);
+  const submitting = useRef(false);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  const [error, setError] = useState<string | null>(null);
+  const ready = !!currentPassword && newPassword.length >= 8 && !!confirmation;
+
+  function close() {
+    if (router.canGoBack()) router.back();
+    else router.replace("/account");
+  }
+
+  async function save() {
+    if (!ready || submitting.current) return;
+    if (newPassword !== confirmation) {
+      setError(t("Passwords do not match"));
+      return;
+    }
+    submitting.current = true;
+    setPending(true);
+    setError(null);
+    try {
+      await changePassword(currentPassword, newPassword);
+      if (!mounted.current) return;
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmation("");
+      close();
+      Alert.alert(t("Password updated"));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : t("Could not change password"));
+    } finally {
+      submitting.current = false;
+      setPending(false);
+    }
+  }
+
+  return (
+    <SafeAreaView edges={["bottom"]} style={styles.screen}>
+      <Stack.Screen
+        options={{
+          headerLeft: () => (
+            <Pressable accessibilityRole="button" onPress={close} style={styles.cancel}>
+              <Text style={styles.cancelLabel}>{t("Cancel")}</Text>
+            </Pressable>
+          ),
+        }}
+      />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={styles.screen}
+      >
+        <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={styles.content}>
+          {[
+            {
+              label: t("Current password"),
+              value: currentPassword,
+              onChange: setCurrentPassword,
+              current: true,
+            },
+            {
+              label: t("New password"),
+              value: newPassword,
+              onChange: setNewPassword,
+              current: false,
+            },
+            {
+              label: t("Confirm password"),
+              value: confirmation,
+              onChange: setConfirmation,
+              current: false,
+            },
+          ].map((field) => (
+            <TextInput
+              key={field.label}
+              accessibilityLabel={field.label}
+              autoCapitalize="none"
+              autoComplete={field.current ? "current-password" : "new-password"}
+              autoCorrect={false}
+              editable={!pending}
+              onChangeText={field.onChange}
+              placeholder={field.label}
+              placeholderTextColor={native.tertiaryLabel}
+              secureTextEntry
+              style={styles.input}
+              value={field.value}
+            />
+          ))}
+          {error ? (
+            <Text accessibilityRole="alert" style={styles.error}>
+              {error}
+            </Text>
+          ) : null}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t("Change password")}
+            disabled={pending || !ready}
+            onPress={() => void save()}
+            style={({ pressed }) => [
+              styles.button,
+              (pending || !ready) && styles.disabled,
+              pressed && styles.pressed,
+            ]}
+          >
+            {pending ? (
+              <ActivityIndicator color={mobileTokens().primaryForeground} />
+            ) : (
+              <Text style={styles.buttonLabel}>{t("Change password")}</Text>
+            )}
+          </Pressable>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles() {
+  const tokens = mobileTokens();
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: native.page },
+    content: { padding: 20, gap: 12 },
+    cancel: { minHeight: 44, justifyContent: "center", paddingEnd: 16 },
+    cancelLabel: { color: native.label, fontSize: 17 },
+    input: {
+      minHeight: 48,
+      borderRadius: 12,
+      backgroundColor: native.fill,
+      color: native.label,
+      paddingHorizontal: 14,
+      paddingVertical: 12,
+      fontSize: 16,
+    },
+    error: { color: tokens.destructive, fontSize: 14 },
+    button: {
+      minHeight: 48,
+      borderRadius: 12,
+      backgroundColor: tokens.primary,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    buttonLabel: { color: tokens.primaryForeground, fontSize: 16, fontWeight: "600" },
+    disabled: { opacity: 0.45 },
+    pressed: { opacity: 0.7 },
+  });
+}

--- a/apps/mobile/app/computer.tsx
+++ b/apps/mobile/app/computer.tsx
@@ -23,10 +23,11 @@ import {
   SCREEN_URL_OPEN_ATTEMPTS,
 } from "../lib/computer";
 import { useI18n } from "../lib/i18n";
-import { tokens } from "../lib/theme";
+import { useMobileTokens } from "../lib/native";
 
 export default function Computer() {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const navigation = useNavigation();
   const { botId, name: nameParam } = useLocalSearchParams<{ botId?: string; name?: string }>();
   const name = nameParam || t("Bot");
@@ -41,6 +42,8 @@ export default function Computer() {
   const autoBooted = useRef<string | null>(null);
 
   const embeddedScreenUrl = embeddableScreenUrl(screenUrl, currentApiBase());
+  useEffect(() => setScreenError(null), [embeddedScreenUrl]);
+
   const hasControl = computer?.controlHolder === "user" && computer.controlBotId === botId;
   const label = computerLabel(computer?.mode, name);
 
@@ -174,22 +177,24 @@ export default function Computer() {
     screenError ?? previewPlaceholder(computer?.state, booting, name, computer?.mode);
 
   return (
-    <View style={{ flex: 1, backgroundColor: "#0A0A0B", padding: 24 }}>
-      {error ? <Text style={{ color: "#85858A", marginBottom: 12 }}>{error}</Text> : null}
+    <View style={{ flex: 1, backgroundColor: tokens.background, padding: 24 }}>
+      {error ? (
+        <Text style={{ color: tokens.mutedForeground, marginBottom: 12 }}>{error}</Text>
+      ) : null}
       <View
         style={{
           flex: 1,
           minHeight: 220,
           borderRadius: 14,
           overflow: "hidden",
-          backgroundColor: "#0E0E10",
+          backgroundColor: tokens.card,
         }}
       >
         {computerOpen ? (
           <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
-            <Text style={{ color: "#6C6C70" }}>{t("Open in full window")}</Text>
+            <Text style={{ color: tokens.mutedForeground }}>{t("Open in full window")}</Text>
           </View>
-        ) : computer?.state === "running" && embeddedScreenUrl ? (
+        ) : computer?.state === "running" && embeddedScreenUrl && !screenError ? (
           <ScreenWebView
             url={embeddedScreenUrl}
             interactive={false}
@@ -201,7 +206,9 @@ export default function Computer() {
           />
         ) : (
           <View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 16 }}>
-            <Text style={{ color: "#6C6C70", textAlign: "center" }}>{placeholder}</Text>
+            <Text style={{ color: tokens.mutedForeground, textAlign: "center" }}>
+              {placeholder}
+            </Text>
           </View>
         )}
         <Pressable
@@ -219,7 +226,9 @@ export default function Computer() {
           gap: 12,
         }}
       >
-        <Text style={{ color: "#85858A", flex: 1 }}>{controlLabel(computer, name, botId)}</Text>
+        <Text style={{ color: tokens.mutedForeground, flex: 1 }}>
+          {controlLabel(computer, name, botId)}
+        </Text>
         {hasControl ? (
           <ComputerReleaseActions
             takeoverRequested={computer?.takeoverRequested ?? false}
@@ -229,13 +238,13 @@ export default function Computer() {
           <Pressable
             onPress={() => void openComputer()}
             style={{
-              backgroundColor: "#1A1A1D",
+              backgroundColor: tokens.muted,
               paddingHorizontal: 14,
               paddingVertical: 10,
               borderRadius: 12,
             }}
           >
-            <Text style={{ color: "#ECECEE" }}>{t("Take control")}</Text>
+            <Text style={{ color: tokens.foreground }}>{t("Take control")}</Text>
           </Pressable>
         )}
       </View>
@@ -255,23 +264,6 @@ export default function Computer() {
         disabled={switching}
         onChange={(mode) => void setComputerMode(mode)}
       />
-      <View
-        style={{
-          marginTop: 18,
-          borderRadius: 12,
-          borderWidth: 1,
-          borderColor: "#232326",
-          padding: 14,
-          gap: 8,
-        }}
-      >
-        <Text style={{ color: "#85858A", fontSize: 14 }}>{t("Teach a task")}</Text>
-        <Text style={{ color: "#6C6C70", fontSize: 13.5, lineHeight: 20 }}>
-          {t(
-            "Recording a live demonstration needs desktop or web with the full computer view. You can still ask this bot to run saved skills from chat.",
-          )}
-        </Text>
-      </View>
 
       <Modal
         visible={booting || computerOpen}
@@ -287,7 +279,7 @@ export default function Computer() {
               edges={["top", "left", "right"]}
               style={{
                 flex: 1,
-                backgroundColor: "rgba(4,4,5,0.96)",
+                backgroundColor: tokens.background,
                 alignItems: "center",
                 justifyContent: "center",
                 gap: 22,
@@ -295,7 +287,12 @@ export default function Computer() {
               }}
             >
               <Text
-                style={{ color: "#F1F1F2", fontSize: 19, fontWeight: "500", textAlign: "center" }}
+                style={{
+                  color: tokens.foreground,
+                  fontSize: 19,
+                  fontWeight: "500",
+                  textAlign: "center",
+                }}
               >
                 {t("Booting {label}", { label })}
               </Text>
@@ -306,7 +303,7 @@ export default function Computer() {
                   maxWidth: 420,
                   overflow: "hidden",
                   borderRadius: 999,
-                  backgroundColor: "#232327",
+                  backgroundColor: tokens.muted,
                 }}
               >
                 <View
@@ -314,7 +311,7 @@ export default function Computer() {
                     height: "100%",
                     width: "66%",
                     borderRadius: 999,
-                    backgroundColor: "#F1F1EF",
+                    backgroundColor: tokens.primary,
                   }}
                 />
               </View>
@@ -329,7 +326,7 @@ export default function Computer() {
                   justifyContent: "space-between",
                   gap: 12,
                   borderBottomWidth: 1,
-                  borderBottomColor: "#171719",
+                  borderBottomColor: tokens.border,
                   paddingHorizontal: 18,
                   paddingVertical: 14,
                 }}
@@ -337,7 +334,7 @@ export default function Computer() {
                 <View style={{ flex: 1, minWidth: 0, gap: 8 }}>
                   <Text
                     numberOfLines={1}
-                    style={{ color: "#ECECEE", fontSize: 15.5, fontWeight: "500" }}
+                    style={{ color: tokens.foreground, fontSize: 15.5, fontWeight: "500" }}
                   >
                     {label}
                   </Text>
@@ -346,12 +343,12 @@ export default function Computer() {
                       style={{
                         alignSelf: "flex-start",
                         borderRadius: 999,
-                        backgroundColor: "rgba(48,162,75,0.14)",
+                        backgroundColor: tokens.muted,
                         paddingHorizontal: 11,
                         paddingVertical: 4,
                       }}
                     >
-                      <Text style={{ color: "#4ECB71", fontSize: 13 }}>
+                      <Text style={{ color: tokens.success, fontSize: 13 }}>
                         {t("You have control")}
                       </Text>
                     </View>
@@ -373,7 +370,7 @@ export default function Computer() {
                       hitSlop={8}
                       style={{
                         borderWidth: 1,
-                        borderColor: "#26262A",
+                        borderColor: tokens.border,
                         paddingHorizontal: 12,
                         paddingVertical: 8,
                         borderRadius: 10,
@@ -381,7 +378,7 @@ export default function Computer() {
                         justifyContent: "center",
                       }}
                     >
-                      <Text style={{ color: "#ECECEE" }}>{t("Take control")}</Text>
+                      <Text style={{ color: tokens.foreground }}>{t("Take control")}</Text>
                     </Pressable>
                   )}
                   <Pressable
@@ -395,12 +392,17 @@ export default function Computer() {
                       justifyContent: "center",
                     }}
                   >
-                    <NativeSymbol ios="xmark" android="close" size={16} color="#85858A" />
+                    <NativeSymbol
+                      ios="xmark"
+                      android="close"
+                      size={16}
+                      color={tokens.mutedForeground}
+                    />
                   </Pressable>
                 </View>
               </SafeAreaView>
-              <View style={{ flex: 1, backgroundColor: "#0E0E10" }}>
-                {computer?.state === "running" && embeddedScreenUrl ? (
+              <View style={{ flex: 1, backgroundColor: tokens.card }}>
+                {computer?.state === "running" && embeddedScreenUrl && !screenError ? (
                   <ScreenWebView
                     url={embeddedScreenUrl}
                     interactive={hasControl}
@@ -414,10 +416,8 @@ export default function Computer() {
                   <View
                     style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 16 }}
                   >
-                    <Text style={{ color: "#6C6C70", textAlign: "center" }}>
-                      {computer?.state === "suspended"
-                        ? t("Computer is asleep")
-                        : computerLabel(computer?.mode, name)}
+                    <Text style={{ color: tokens.mutedForeground, textAlign: "center" }}>
+                      {placeholder}
                     </Text>
                   </View>
                 )}
@@ -438,6 +438,7 @@ function ComputerReleaseActions({
   onRelease: (reason?: ComputerReleaseReason) => Promise<void>;
 }) {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const actions: Array<{ label: string; reason?: ComputerReleaseReason; primary?: boolean }> =
     takeoverRequested
       ? [
@@ -457,14 +458,16 @@ function ComputerReleaseActions({
             minHeight: 44,
             justifyContent: "center",
             borderWidth: 1,
-            borderColor: action.primary ? "#F1F1EF" : "#26262A",
-            backgroundColor: action.primary ? "#F1F1EF" : "#1A1A1D",
+            borderColor: action.primary ? tokens.primary : tokens.border,
+            backgroundColor: action.primary ? tokens.primary : tokens.muted,
             paddingHorizontal: 12,
             paddingVertical: 8,
             borderRadius: 10,
           }}
         >
-          <Text style={{ color: action.primary ? "#17171A" : "#ECECEE" }}>{action.label}</Text>
+          <Text style={{ color: action.primary ? tokens.primaryForeground : tokens.foreground }}>
+            {action.label}
+          </Text>
         </Pressable>
       ))}
     </View>
@@ -480,11 +483,12 @@ function ScreenWebView({
   interactive: boolean;
   onError: () => void;
 }) {
+  const tokens = useMobileTokens();
   return (
     <WebView
       key={url}
       source={{ uri: url }}
-      style={{ flex: 1, backgroundColor: "#000" }}
+      style={{ flex: 1, backgroundColor: tokens.background }}
       pointerEvents={interactive ? "auto" : "none"}
       javaScriptEnabled
       domStorageEnabled

--- a/apps/mobile/app/group-settings.tsx
+++ b/apps/mobile/app/group-settings.tsx
@@ -2,13 +2,14 @@ import { GROUP_MEMBER_MAX, GROUP_MEMBER_MIN } from "@rakazo/contracts";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Alert, Pressable, ScrollView, Text, TextInput } from "react-native";
-import { BotAvatar } from "../components/bot-avatar";
+import { BotMemberPicker } from "../components/bot-member-picker";
 import { type MobileBot, type MobileGroup, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
-import { tokens } from "../lib/theme";
+import { useMobileTokens } from "../lib/native";
 
 export default function GroupSettingsScreen() {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const router = useRouter();
   const { groupId } = useLocalSearchParams<{ groupId: string }>();
   const [group, setGroup] = useState<MobileGroup | null>(null);
@@ -35,14 +36,6 @@ export default function GroupSettingsScreen() {
       })
       .catch((err) => setError(err instanceof Error ? err.message : t("Could not load group")));
   }, [groupId]);
-
-  function toggle(botId: string) {
-    setSelected((current) => {
-      if (current.includes(botId)) return current.filter((id) => id !== botId);
-      if (current.length >= GROUP_MEMBER_MAX) return current;
-      return [...current, botId];
-    });
-  }
 
   async function save() {
     if (!groupId || !group || pending) return;
@@ -89,39 +82,31 @@ export default function GroupSettingsScreen() {
         style={{ flex: 1, backgroundColor: tokens.background }}
         contentContainerStyle={{ padding: 24 }}
       >
-        <Text style={{ color: "#85858A", fontSize: 14 }}>{t("Name")}</Text>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>{t("Name")}</Text>
         <TextInput
           value={name}
           onChangeText={setName}
           placeholder={t("Group name")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           style={{
             marginTop: 8,
-            backgroundColor: "#1A1A1D",
+            backgroundColor: tokens.muted,
             borderRadius: 11,
             padding: 14,
-            color: "#ECECEE",
+            color: tokens.foreground,
             fontSize: 16,
           }}
         />
-        <Text style={{ color: "#85858A", fontSize: 14, marginTop: 20 }}>
-          {t("Members ({min}–{max})", { min: GROUP_MEMBER_MIN, max: GROUP_MEMBER_MAX })}
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14, marginTop: 20 }}>
+          {t("Members")}
         </Text>
-        {bots.map((bot) => {
-          const checked = selected.includes(bot.id);
-          return (
-            <Pressable
-              key={bot.id}
-              onPress={() => toggle(bot.id)}
-              style={{ flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 12 }}
-            >
-              <BotAvatar color={bot.color} identity={bot.id} size={34} status={bot.status} />
-              <Text style={{ flex: 1, color: "#ECECEE", fontSize: 16 }}>{bot.name}</Text>
-              <Text style={{ color: "#6C6C70" }}>{checked ? "✓" : ""}</Text>
-            </Pressable>
-          );
-        })}
-        {error ? <Text style={{ color: "#FF6B6B", marginTop: 12 }}>{error}</Text> : null}
+        <BotMemberPicker
+          bots={bots}
+          selected={selected}
+          onChange={setSelected}
+          disabled={pending}
+        />
+        {error ? <Text style={{ color: tokens.destructive, marginTop: 12 }}>{error}</Text> : null}
         <Pressable
           onPress={() => void save()}
           disabled={
@@ -132,7 +117,7 @@ export default function GroupSettingsScreen() {
           }
           style={{
             marginTop: 24,
-            backgroundColor: "#8B5CF6",
+            backgroundColor: tokens.primary,
             opacity:
               !name.trim() ||
               selected.length < GROUP_MEMBER_MIN ||
@@ -145,7 +130,7 @@ export default function GroupSettingsScreen() {
             alignItems: "center",
           }}
         >
-          <Text style={{ color: "#FFF", fontSize: 16, fontWeight: "600" }}>
+          <Text style={{ color: tokens.primaryForeground, fontSize: 16, fontWeight: "600" }}>
             {pending ? t("Saving…") : t("Save")}
           </Text>
         </Pressable>
@@ -155,12 +140,12 @@ export default function GroupSettingsScreen() {
             marginTop: 16,
             borderRadius: 11,
             borderWidth: 1,
-            borderColor: "#3A2020",
+            borderColor: tokens.border,
             padding: 14,
             alignItems: "center",
           }}
         >
-          <Text style={{ color: "#FF6B6B", fontSize: 16 }}>{t("Delete group")}</Text>
+          <Text style={{ color: tokens.destructive, fontSize: 16 }}>{t("Delete group")}</Text>
         </Pressable>
       </ScrollView>
     </>

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -6,6 +6,7 @@ import {
   type SpaceGroup,
 } from "@rakazo/contracts";
 import { groupBotsForSidebar } from "@rakazo/core";
+import { botColors } from "@rakazo/ui-tokens";
 import { Redirect, useFocusEffect, useRouter } from "expo-router";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -45,6 +46,7 @@ import {
   selectInitialSpace,
   selectSpace,
 } from "../lib/api";
+import { mobileTokens, resolveMobileAppearance } from "../lib/appearance";
 import { allowFocusPrompt, scheduleFocusPrompt } from "../lib/focus-prompt";
 import { t, useI18n } from "../lib/i18n";
 import { botTag, filterBots, formatThreadTime, userInitials } from "../lib/inbox";
@@ -55,7 +57,7 @@ import { registerPushToken } from "../lib/push";
 import { querySpaceSearch } from "../lib/search";
 import { mobileSearchDestination } from "../lib/search-destination";
 
-const FALLBACK_COLOR = "#9B5CF6";
+const FALLBACK_COLOR = botColors[3];
 
 type InboxItem =
   | { type: "bot"; bot: MobileBot | SpaceBot }
@@ -72,6 +74,8 @@ async function openMobileSpace(spaceId: string | undefined, open: () => void) {
 }
 
 export default function Home() {
+  const tokens = mobileTokens();
+  const appearance = resolveMobileAppearance();
   const styles = useThemedStyles(createHomeStyles);
   const { t, locale } = useI18n();
   const [bots, setBots] = useState<MobileBot[]>([]);
@@ -366,7 +370,7 @@ export default function Home() {
               ios={activityMode ? "bell.fill" : "bell"}
               android={activityMode ? "notifications" : "notifications-outline"}
               size={17}
-              color={activityMode ? "#FFFFFF" : "#8E8E93"}
+              color={activityMode ? tokens.primaryForeground : tokens.foreground}
             />
           </CircleButton>
           <CircleButton
@@ -403,11 +407,11 @@ export default function Home() {
           value={query}
           onChangeText={setQuery}
           placeholder={t("Search")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           autoCorrect={false}
           autoCapitalize="none"
           returnKeyType="search"
-          keyboardAppearance="dark"
+          keyboardAppearance={appearance}
           clearButtonMode="while-editing"
           style={styles.searchField}
         />
@@ -426,7 +430,7 @@ export default function Home() {
         }}
         keyboardDismissMode="interactive"
         keyboardShouldPersistTaps="handled"
-        indicatorStyle="white"
+        indicatorStyle={appearance === "dark" ? "white" : "black"}
         contentContainerStyle={styles.list}
         refreshControl={
           <RefreshControl
@@ -436,8 +440,8 @@ export default function Home() {
               void loadActivity();
             }}
             tintColor={native.secondaryLabel}
-            colors={["#8E8E93"]}
-            progressBackgroundColor="#1C1C1E"
+            colors={[tokens.mutedForeground]}
+            progressBackgroundColor={tokens.muted}
           />
         }
         ListHeaderComponent={
@@ -445,7 +449,7 @@ export default function Home() {
           !searching &&
           !query.trim() &&
           (activity.active.length > 0 || activity.recent.length > 0) ? (
-            <ActivitySection activity={activity} />
+            <ActivitySection activity={activity} bots={bots} />
           ) : null
         }
         ListEmptyComponent={
@@ -549,12 +553,15 @@ export default function Home() {
 
 function ActivitySection({
   activity,
+  bots,
 }: {
   activity: { active: RunActivityRow[]; recent: RunActivityRow[] };
+  bots: MobileBot[];
 }) {
   const styles = useThemedStyles(createHomeStyles);
   const { t } = useI18n();
   const router = useRouter();
+  const botsById = useMemo(() => new Map(bots.map((bot) => [bot.id, bot])), [bots]);
   const openRun = (run: RunActivityRow) => {
     if (run.groupId) {
       router.push({
@@ -572,7 +579,12 @@ function ActivitySection({
         <>
           <Text style={styles.sectionHeading}>{t("Now")}</Text>
           {activity.active.map((run) => (
-            <ActivityRow key={run.runId} run={run} onPress={() => openRun(run)} />
+            <ActivityRow
+              key={run.runId}
+              run={run}
+              bot={botsById.get(run.botId)}
+              onPress={() => openRun(run)}
+            />
           ))}
         </>
       ) : null}
@@ -582,7 +594,12 @@ function ActivitySection({
             {t("Recent")}
           </Text>
           {activity.recent.map((run) => (
-            <ActivityRow key={run.runId} run={run} onPress={() => openRun(run)} />
+            <ActivityRow
+              key={run.runId}
+              run={run}
+              bot={botsById.get(run.botId)}
+              onPress={() => openRun(run)}
+            />
           ))}
         </>
       ) : null}
@@ -590,28 +607,86 @@ function ActivitySection({
   );
 }
 
-function ActivityRow({ run, onPress }: { run: RunActivityRow; onPress: () => void }) {
-  const styles = useThemedStyles(createHomeStyles);
+function ActivityRow({
+  run,
+  bot,
+  onPress,
+}: {
+  run: RunActivityRow;
+  bot?: MobileBot;
+  onPress: () => void;
+}) {
   const title = run.groupName ? `${run.botName} · ${run.groupName}` : run.botName;
   const status = activityStatusLabel(run.status);
   const preview = run.promptSnippet ? `${run.promptSnippet} · ${status}` : status;
-  const activityLabel = `${title}, ${status}`;
+  return (
+    <ConversationRow
+      title={title}
+      preview={preview}
+      time={formatActivityRelativeTime(run.updatedAt)}
+      accessibilityLabel={`${title}, ${status}`}
+      onPress={onPress}
+      avatar={
+        <BotAvatar identity={run.botId} color={bot?.color ?? FALLBACK_COLOR} status={run.status} />
+      }
+    />
+  );
+}
+
+function ConversationRow({
+  title,
+  preview,
+  time,
+  avatar,
+  tag,
+  unread,
+  onPress,
+  onLongPress,
+  accessibilityLabel,
+  accessibilityHint,
+}: {
+  title: string;
+  preview: string;
+  time: string;
+  avatar: ReactNode;
+  tag?: string | null;
+  unread?: boolean;
+  onPress: () => void;
+  onLongPress?: () => void;
+  accessibilityLabel: string;
+  accessibilityHint?: string;
+}) {
+  const styles = useThemedStyles(createHomeStyles);
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={activityLabel}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={accessibilityHint}
       onPress={onPress}
+      onLongPress={onLongPress}
       style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
     >
-      <View style={styles.activityDot} />
+      {avatar}
       <View style={styles.rowBody}>
         <View style={styles.rowTop}>
-          <Text style={styles.name} numberOfLines={1}>
-            {title}
-          </Text>
-          <Text style={styles.time}>{formatActivityRelativeTime(run.updatedAt)}</Text>
+          <View style={styles.titleRow}>
+            <Text style={styles.name} numberOfLines={1} ellipsizeMode="tail">
+              {title}
+            </Text>
+            {tag ? (
+              <View style={styles.tag}>
+                <Text style={styles.tagLabel} numberOfLines={1}>
+                  {tag}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+          <View style={styles.rowMeta}>
+            {time ? <Text style={styles.time}>{time}</Text> : null}
+            {unread ? <View accessibilityElementsHidden style={styles.unreadDot} /> : null}
+          </View>
         </View>
-        <Text style={styles.preview} numberOfLines={1}>
+        <Text style={[styles.preview, unread && styles.unreadPreview]} numberOfLines={1}>
           {preview}
         </Text>
       </View>
@@ -681,7 +756,6 @@ function BotRow({
   onPress: () => void;
   onLongPress?: () => void;
 }) {
-  const styles = useThemedStyles(createHomeStyles);
   const { t } = useI18n();
   const preview = previewSnippet(bot.preview, 40) || bot.title || t("No messages yet");
   const time = bot.updatedAt ? formatThreadTime(bot.updatedAt) : "";
@@ -698,49 +772,27 @@ function BotRow({
     .filter(Boolean)
     .join(", ");
   return (
-    <Pressable
+    <ConversationRow
+      title={bot.name}
+      preview={preview}
+      time={time}
+      tag={tag}
+      unread={bot.unread}
       accessibilityLabel={label}
       accessibilityHint={
         onLongPress ? t("Long press to pin, move, or silence notifications") : undefined
       }
       onPress={onPress}
       onLongPress={onLongPress}
-      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-    >
-      <BotAvatar
-        color={bot.color || FALLBACK_COLOR}
-        identity={bot.id}
-        status={bot.status}
-        muted={!bot.notifyOnFinish}
-      />
-      <View style={styles.rowBody}>
-        <View style={styles.rowTop}>
-          <View style={styles.titleRow}>
-            <Text style={styles.name} numberOfLines={1} ellipsizeMode="tail">
-              {bot.name}
-            </Text>
-            {tag ? (
-              <View style={styles.tag}>
-                <Text style={styles.tagLabel} numberOfLines={1} ellipsizeMode="tail">
-                  {tag}
-                </Text>
-              </View>
-            ) : null}
-          </View>
-          <View style={styles.rowMeta}>
-            {time ? <Text style={styles.time}>{time}</Text> : null}
-            {bot.unread ? <View accessibilityElementsHidden style={styles.unreadDot} /> : null}
-          </View>
-        </View>
-        <Text
-          style={[styles.preview, bot.unread && styles.unreadPreview]}
-          numberOfLines={1}
-          ellipsizeMode="tail"
-        >
-          {preview}
-        </Text>
-      </View>
-    </Pressable>
+      avatar={
+        <BotAvatar
+          color={bot.color || FALLBACK_COLOR}
+          identity={bot.id}
+          status={bot.status}
+          muted={!bot.notifyOnFinish}
+        />
+      }
+    />
   );
 }
 
@@ -753,41 +805,29 @@ function GroupRow({
   onPress: () => void;
   onLongPress?: () => void;
 }) {
-  const styles = useThemedStyles(createHomeStyles);
   const { t } = useI18n();
   const preview =
     previewSnippet(group.preview, 40) || group.members.map((member) => member.name).join(", ");
   const time = group.updatedAt ? formatThreadTime(group.updatedAt) : "";
   return (
-    <Pressable
+    <ConversationRow
+      title={group.name}
+      preview={preview}
+      time={time}
+      unread={group.unread}
       accessibilityLabel={[group.name, group.unread ? t("unread") : null, time, preview]
         .filter(Boolean)
         .join(", ")}
+      accessibilityHint={onLongPress ? t("Long press to pin or move to a section") : undefined}
       onPress={onPress}
       onLongPress={onLongPress}
-      accessibilityHint={onLongPress ? t("Long press to pin or move to a section") : undefined}
-      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
-    >
-      <GroupAvatar members={group.members} size={54} />
-      <View style={styles.rowBody}>
-        <View style={styles.rowTop}>
-          <Text style={styles.name} numberOfLines={1}>
-            {group.name}
-          </Text>
-          <View style={styles.rowMeta}>
-            {time ? <Text style={styles.time}>{time}</Text> : null}
-            {group.unread ? <View accessibilityElementsHidden style={styles.unreadDot} /> : null}
-          </View>
-        </View>
-        <Text style={[styles.preview, group.unread && styles.unreadPreview]} numberOfLines={1}>
-          {preview}
-        </Text>
-      </View>
-    </Pressable>
+      avatar={<GroupAvatar members={group.members} size={54} />}
+    />
   );
 }
 
 function createHomeStyles() {
+  const tokens = mobileTokens();
   return StyleSheet.create({
     screen: {
       flex: 1,
@@ -823,7 +863,7 @@ function createHomeStyles() {
       backgroundColor: native.fill,
     },
     circleAccent: {
-      backgroundColor: "#4C8DFF",
+      backgroundColor: tokens.primary,
     },
     profileInitials: {
       color: native.label,
@@ -833,7 +873,9 @@ function createHomeStyles() {
     searchField: {
       marginHorizontal: 16,
       marginBottom: 8,
-      height: 36,
+      minHeight: 44,
+      paddingVertical: 10,
+      textAlignVertical: "center",
       borderRadius: 10,
       backgroundColor: native.fill,
       color: native.label,
@@ -926,7 +968,7 @@ function createHomeStyles() {
       width: 8,
       height: 8,
       borderRadius: 4,
-      backgroundColor: "#8B5CF6",
+      backgroundColor: tokens.foreground,
     },
     sectionHeading: {
       color: native.secondaryLabel,
@@ -944,13 +986,6 @@ function createHomeStyles() {
     },
     activityGap: {
       paddingTop: 16,
-    },
-    activityDot: {
-      width: 8,
-      height: 8,
-      borderRadius: 4,
-      backgroundColor: "#8B5CF6",
-      marginTop: 6,
     },
     groupAvatar: {
       width: 48,

--- a/apps/mobile/app/integrations.tsx
+++ b/apps/mobile/app/integrations.tsx
@@ -20,7 +20,9 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { ConnectorIcon } from "../components/connector-icon";
 import { rpc } from "../lib/api";
+import { mobileTokens } from "../lib/appearance";
 import { useI18n } from "../lib/i18n";
 import { loadLastBotId } from "../lib/last-bot";
 import { native, useThemedStyles } from "../lib/native";
@@ -214,8 +216,6 @@ export default function Integrations() {
   return (
     <SafeAreaView edges={["bottom"]} style={styles.screen}>
       <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={styles.content}>
-        <Text style={styles.explanation}>{t("Connect apps.")}</Text>
-
         <TextInput
           value={query}
           onChangeText={(value) => {
@@ -256,6 +256,7 @@ export default function Integrations() {
                         disabled ? { opacity: 0.7 } : null,
                       ]}
                     >
+                      <ConnectorIcon name={tile.label} logo={item?.logo} />
                       <View style={styles.grow}>
                         <Text numberOfLines={1} style={styles.title}>
                           {tile.label}
@@ -291,6 +292,7 @@ export default function Integrations() {
                   key={key}
                   style={[styles.row, catalogColumns === 2 ? styles.catalogCell : null]}
                 >
+                  <ConnectorIcon name={item.name} logo={item.logo} />
                   <View style={styles.grow}>
                     <Text numberOfLines={1} style={styles.title}>
                       {item.name}
@@ -472,10 +474,10 @@ export default function Integrations() {
 }
 
 function createIntegrationsStyles() {
+  const tokens = mobileTokens();
   return StyleSheet.create({
     screen: { flex: 1, backgroundColor: native.page },
     content: { padding: 20, gap: 14 },
-    explanation: { color: native.secondaryLabel, fontSize: 14, lineHeight: 20 },
     section: { color: native.secondaryLabel, fontSize: 14, fontWeight: "600", marginTop: 10 },
     actions: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
     smallButton: {
@@ -514,8 +516,8 @@ function createIntegrationsStyles() {
     title: { color: native.label, fontSize: 15, fontWeight: "600" },
     secondary: { color: native.secondaryLabel, fontSize: 13 },
     link: { color: native.label, fontSize: 14, fontWeight: "600" },
-    remove: { color: "#E96B6B", fontSize: 14, fontWeight: "600" },
-    error: { color: "#E96B6B", fontSize: 14 },
+    remove: { color: tokens.destructive, fontSize: 14, fontWeight: "600" },
+    error: { color: tokens.destructive, fontSize: 14 },
     advancedToggle: {
       marginTop: 8,
       minHeight: 44,

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -4,6 +4,7 @@ import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
   openAiCompatibleConnectReady,
 } from "@rakazo/contracts";
+import { featuredModelProviders } from "@rakazo/core";
 import { useFocusEffect } from "expo-router";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
@@ -18,6 +19,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { type MobileMe, type MobileModel, type MobileModelCredential, rpc } from "../lib/api";
+import { mobileTokens } from "../lib/appearance";
 import { useI18n } from "../lib/i18n";
 import {
   cancelModelOAuthAttempt,
@@ -38,6 +40,7 @@ export default function Models() {
   const [credentials, setCredentials] = useState<MobileModelCredential[]>([]);
   const [me, setMe] = useState<MobileMe | null>(null);
   const [provider, setProvider] = useState("");
+  const [showAllProviders, setShowAllProviders] = useState(false);
   const [modelId, setModelId] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
@@ -137,6 +140,19 @@ export default function Models() {
       entries,
     }));
   }, [catalog]);
+  const featuredProviders = useMemo(
+    () =>
+      featuredModelProviders(
+        groups.map((group) => group.entries[0]!),
+        provider,
+      ),
+    [groups, provider],
+  );
+  const visibleGroups = useMemo(() => {
+    if (showAllProviders) return groups;
+    const byId = new Map(groups.map((group) => [group.id, group]));
+    return featuredProviders.map((entry) => byId.get(entry.provider)!);
+  }, [groups, featuredProviders, showAllProviders]);
   const modelsForProvider = catalog.filter((entry) => entry.provider === provider);
   const selected = modelsForProvider.find((entry) => entry.id === modelId) ?? modelsForProvider[0];
   const isOpenAiCompatible = provider === OPENAI_COMPATIBLE_PROVIDER_ID;
@@ -408,12 +424,13 @@ export default function Models() {
 
         <Text style={styles.sectionTitle}>{t("Providers")}</Text>
         <View style={styles.card}>
-          {groups.map((group) => {
+          {visibleGroups.map((group) => {
             const connected = credentials.some((entry) => entry.provider === group.id);
             return (
               <Pressable
                 key={group.id}
                 accessibilityRole="button"
+                accessibilityState={{ selected: group.id === provider }}
                 onPress={() => chooseProvider(group.id)}
                 style={({ pressed }) => [
                   styles.providerRow,
@@ -433,6 +450,18 @@ export default function Models() {
               </Pressable>
             );
           })}
+          {groups.length > featuredProviders.length ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityState={{ expanded: showAllProviders }}
+              onPress={() => setShowAllProviders((value) => !value)}
+              style={styles.providerRow}
+            >
+              <Text style={styles.providerName}>
+                {showAllProviders ? t("Show less") : t("Show more")}
+              </Text>
+            </Pressable>
+          ) : null}
         </View>
 
         {selected ? (
@@ -768,6 +797,7 @@ export default function Models() {
 }
 
 function createModelsStyles() {
+  const tokens = mobileTokens();
   return StyleSheet.create({
     screen: {
       flex: 1,
@@ -836,7 +866,7 @@ function createModelsStyles() {
       fontWeight: "600",
     },
     connected: {
-      color: "#4ECB71",
+      color: tokens.success,
       fontSize: 13,
     },
     modelRow: {
@@ -870,7 +900,7 @@ function createModelsStyles() {
       fontSize: 15,
     },
     selectedRow: {
-      backgroundColor: "#222225",
+      backgroundColor: tokens.accent,
     },
     billing: {
       color: native.secondaryLabel,
@@ -965,12 +995,12 @@ function createModelsStyles() {
       fontWeight: "600",
     },
     error: {
-      color: "#FF6961",
+      color: tokens.destructive,
       fontSize: 14,
       marginTop: 4,
     },
     notice: {
-      color: "#4ECB71",
+      color: tokens.success,
       fontSize: 14,
       marginTop: 4,
     },

--- a/apps/mobile/app/new-group.tsx
+++ b/apps/mobile/app/new-group.tsx
@@ -2,13 +2,14 @@ import { GROUP_MEMBER_MAX, GROUP_MEMBER_MIN } from "@rakazo/contracts";
 import { Stack, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Pressable, ScrollView, Text, TextInput } from "react-native";
-import { BotAvatar } from "../components/bot-avatar";
+import { BotMemberPicker } from "../components/bot-member-picker";
 import { type MobileBot, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
-import { tokens } from "../lib/theme";
+import { useMobileTokens } from "../lib/native";
 
 export default function NewGroup() {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const router = useRouter();
   const [bots, setBots] = useState<MobileBot[]>([]);
   const [name, setName] = useState("");
@@ -21,14 +22,6 @@ export default function NewGroup() {
       .then((nextBots) => setBots(nextBots.filter((bot) => !bot.archivedAt)))
       .catch(() => undefined);
   }, []);
-
-  function toggle(botId: string) {
-    setSelected((current) => {
-      if (current.includes(botId)) return current.filter((id) => id !== botId);
-      if (current.length >= GROUP_MEMBER_MAX) return current;
-      return [...current, botId];
-    });
-  }
 
   async function create() {
     if (
@@ -63,44 +56,31 @@ export default function NewGroup() {
         style={{ flex: 1, backgroundColor: tokens.background }}
         contentContainerStyle={{ padding: 24 }}
       >
-        <Text style={{ color: "#85858A", fontSize: 14 }}>{t("Name")}</Text>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>{t("Name")}</Text>
         <TextInput
           value={name}
           onChangeText={setName}
           placeholder={t("Name this group")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           style={{
             marginTop: 8,
-            backgroundColor: "#1A1A1D",
+            backgroundColor: tokens.muted,
             borderRadius: 11,
             padding: 14,
-            color: "#ECECEE",
+            color: tokens.foreground,
             fontSize: 16,
           }}
         />
-        <Text style={{ color: "#85858A", fontSize: 14, marginTop: 20 }}>
-          {t("Members ({min}–{max})", { min: GROUP_MEMBER_MIN, max: GROUP_MEMBER_MAX })}
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14, marginTop: 20 }}>
+          {t("Members")}
         </Text>
-        {bots.map((bot) => {
-          const checked = selected.includes(bot.id);
-          return (
-            <Pressable
-              key={bot.id}
-              onPress={() => toggle(bot.id)}
-              style={{
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 12,
-                paddingVertical: 12,
-              }}
-            >
-              <BotAvatar color={bot.color} identity={bot.id} size={34} status={bot.status} />
-              <Text style={{ flex: 1, color: "#ECECEE", fontSize: 16 }}>{bot.name}</Text>
-              <Text style={{ color: "#6C6C70" }}>{checked ? "✓" : ""}</Text>
-            </Pressable>
-          );
-        })}
-        {error ? <Text style={{ color: "#FF6B6B", marginTop: 12 }}>{error}</Text> : null}
+        <BotMemberPicker
+          bots={bots}
+          selected={selected}
+          onChange={setSelected}
+          disabled={pending}
+        />
+        {error ? <Text style={{ color: tokens.destructive, marginTop: 12 }}>{error}</Text> : null}
         <Pressable
           onPress={() => void create()}
           disabled={
@@ -111,7 +91,7 @@ export default function NewGroup() {
           }
           style={{
             marginTop: 24,
-            backgroundColor: "#8B5CF6",
+            backgroundColor: tokens.primary,
             opacity:
               !name.trim() ||
               selected.length < GROUP_MEMBER_MIN ||
@@ -124,7 +104,7 @@ export default function NewGroup() {
             alignItems: "center",
           }}
         >
-          <Text style={{ color: "#FFF", fontSize: 16, fontWeight: "600" }}>
+          <Text style={{ color: tokens.primaryForeground, fontSize: 16, fontWeight: "600" }}>
             {pending ? t("Creating…") : t("Create group")}
           </Text>
         </Pressable>

--- a/apps/mobile/app/new-space.tsx
+++ b/apps/mobile/app/new-space.tsx
@@ -1,13 +1,14 @@
 import type { Space } from "@rakazo/contracts";
 import { Stack, useRouter } from "expo-router";
 import { useState } from "react";
-import { Alert, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { Alert, Pressable, ScrollView, Text, TextInput } from "react-native";
 import { rpc, selectSpace } from "../lib/api";
 import { useI18n } from "../lib/i18n";
-import { tokens } from "../lib/theme";
+import { useMobileTokens } from "../lib/native";
 
 export default function NewSpace() {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const router = useRouter();
   const [name, setName] = useState("");
   const [pending, setPending] = useState(false);
@@ -41,11 +42,12 @@ export default function NewSpace() {
           headerLeft: () => (
             <Pressable
               onPress={() => router.back()}
-              hitSlop={12}
+              hitSlop={8}
+              style={{ paddingEnd: 20, paddingVertical: 8 }}
               accessibilityRole="button"
               accessibilityLabel={t("Cancel")}
             >
-              <Text style={{ color: "#0A84FF", fontSize: 17 }}>{t("Cancel")}</Text>
+              <Text style={{ color: tokens.foreground, fontSize: 17 }}>{t("Cancel")}</Text>
             </Pressable>
           ),
         }}
@@ -55,53 +57,42 @@ export default function NewSpace() {
         contentContainerStyle={{ padding: 24 }}
         keyboardShouldPersistTaps="handled"
       >
-        <View
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>{t("Name")}</Text>
+        <TextInput
+          autoFocus
+          value={name}
+          maxLength={60}
+          onChangeText={setName}
+          onSubmitEditing={() => void create()}
+          placeholder={t("Customer support")}
+          placeholderTextColor={tokens.mutedForeground}
+          returnKeyType="done"
           style={{
-            borderWidth: 1,
-            borderColor: "#343438",
-            borderRadius: 16,
-            backgroundColor: "#1A1A1D",
-            padding: 18,
+            marginTop: 8,
+            backgroundColor: tokens.muted,
+            borderRadius: 11,
+            padding: 14,
+            color: tokens.foreground,
+            fontSize: 16,
+          }}
+        />
+        {error ? <Text style={{ color: tokens.destructive, marginTop: 14 }}>{error}</Text> : null}
+        <Pressable
+          onPress={() => void create()}
+          disabled={!name.trim() || pending}
+          style={{
+            marginTop: 20,
+            backgroundColor: tokens.primary,
+            borderRadius: 11,
+            padding: 14,
+            alignItems: "center",
+            opacity: !name.trim() || pending ? 0.4 : 1,
           }}
         >
-          <Text style={{ color: "#F1F1F2", fontSize: 18, fontWeight: "600" }}>{t("Space")}</Text>
-          <Text style={{ color: "#85858A", fontSize: 14, marginTop: 20 }}>{t("Name")}</Text>
-          <TextInput
-            autoFocus
-            value={name}
-            maxLength={60}
-            onChangeText={setName}
-            onSubmitEditing={() => void create()}
-            placeholder={t("Customer support")}
-            placeholderTextColor="#6C6C70"
-            returnKeyType="done"
-            style={{
-              marginTop: 8,
-              backgroundColor: "#101012",
-              borderRadius: 11,
-              padding: 14,
-              color: "#ECECEE",
-              fontSize: 16,
-            }}
-          />
-          {error ? <Text style={{ color: "#EF4444", marginTop: 14 }}>{error}</Text> : null}
-          <Pressable
-            onPress={() => void create()}
-            disabled={!name.trim() || pending}
-            style={{
-              marginTop: 20,
-              backgroundColor: "#8B5CF6",
-              borderRadius: 999,
-              padding: 14,
-              alignItems: "center",
-              opacity: !name.trim() || pending ? 0.4 : 1,
-            }}
-          >
-            <Text style={{ color: "#090A12", fontSize: 16, fontWeight: "600" }}>
-              {pending ? t("Creating…") : t("Create space")}
-            </Text>
-          </Pressable>
-        </View>
+          <Text style={{ color: tokens.primaryForeground, fontSize: 16, fontWeight: "600" }}>
+            {pending ? t("Creating…") : t("Create space")}
+          </Text>
+        </Pressable>
       </ScrollView>
     </>
   );

--- a/apps/mobile/app/new.tsx
+++ b/apps/mobile/app/new.tsx
@@ -12,10 +12,11 @@ import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
 import { allowFocusPrompt, scheduleFocusPrompt } from "../lib/focus-prompt";
 import { useI18n } from "../lib/i18n";
-import { tokens } from "../lib/theme";
+import { useMobileTokens } from "../lib/native";
 
 export default function NewBot() {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const router = useRouter();
   const [name, setName] = useState("");
   const [title, setTitle] = useState("");
@@ -72,11 +73,12 @@ export default function NewBot() {
           headerLeft: () => (
             <Pressable
               onPress={close}
-              hitSlop={12}
+              hitSlop={8}
+              style={{ paddingEnd: 20, paddingVertical: 8 }}
               accessibilityRole="button"
               accessibilityLabel={t("Cancel")}
             >
-              <Text style={{ color: "#0A84FF", fontSize: 17 }}>{t("Cancel")}</Text>
+              <Text style={{ color: tokens.foreground, fontSize: 17 }}>{t("Cancel")}</Text>
             </Pressable>
           ),
         }}
@@ -87,69 +89,73 @@ export default function NewBot() {
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
       >
-        <Text style={{ color: "#85858A", fontSize: 14 }}>{t("Name")}</Text>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>{t("Name")}</Text>
         <TextInput
           value={name}
           maxLength={BOT_NAME_MAX_LENGTH}
           onChangeText={setName}
           placeholder={t("Name this bot")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           style={{
             marginTop: 8,
-            backgroundColor: "#1A1A1D",
+            backgroundColor: tokens.muted,
             borderRadius: 11,
             padding: 16,
-            color: "#ECECEE",
+            color: tokens.foreground,
           }}
         />
-        <Text style={{ color: "#85858A", marginTop: 16, fontSize: 14 }}>{t("Title")}</Text>
+        <Text style={{ color: tokens.mutedForeground, marginTop: 16, fontSize: 14 }}>
+          {t("Title")}
+        </Text>
         <TextInput
           value={title}
           maxLength={BOT_TITLE_MAX_LENGTH}
           onChangeText={setTitle}
           placeholder={t("Describe what this bot does")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           style={{
             marginTop: 8,
-            backgroundColor: "#1A1A1D",
+            backgroundColor: tokens.muted,
             borderRadius: 11,
             padding: 16,
-            color: "#ECECEE",
+            color: tokens.foreground,
           }}
         />
-        <Text style={{ color: "#85858A", marginTop: 16, fontSize: 14 }}>{t("Description")}</Text>
+        <Text style={{ color: tokens.mutedForeground, marginTop: 16, fontSize: 14 }}>
+          {t("Description")}
+        </Text>
         <TextInput
           value={description}
           maxLength={BOT_DESCRIPTION_MAX_LENGTH}
           onChangeText={setDescription}
           placeholder={t("What this bot is for")}
-          placeholderTextColor="#6C6C70"
+          placeholderTextColor={tokens.mutedForeground}
           multiline
           style={{
             marginTop: 8,
-            backgroundColor: "#1A1A1D",
+            backgroundColor: tokens.muted,
             borderRadius: 11,
             padding: 16,
-            color: "#ECECEE",
+            color: tokens.foreground,
             minHeight: 120,
             textAlignVertical: "top",
           }}
         />
         <ComputerModePicker value={computerMode} onChange={setComputerMode} />
-        {error ? <Text style={{ color: "#EF4444", marginTop: 16 }}>{error}</Text> : null}
+        {error ? <Text style={{ color: tokens.destructive, marginTop: 16 }}>{error}</Text> : null}
         <Pressable
           onPress={() => void create()}
           disabled={!name.trim() || pending}
           style={{
             marginTop: 24,
-            backgroundColor: "#F1F1EF",
+            backgroundColor: tokens.primary,
             borderRadius: 11,
             padding: 16,
             alignItems: "center",
             opacity: !name.trim() || pending ? 0.4 : 1,
           }}
         >
-          <Text style={{ color: "#17171A", fontSize: 16 }}>
+          <Text style={{ color: tokens.primaryForeground, fontSize: 16 }}>
             {pending ? t("Creating…") : t("Create")}
           </Text>
         </Pressable>

--- a/apps/mobile/app/routine.tsx
+++ b/apps/mobile/app/routine.tsx
@@ -4,9 +4,10 @@ import { useEffect, useState } from "react";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
 import { rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
-import { tokens } from "../lib/theme";
+import { useMobileTokens } from "../lib/native";
 
 export default function RoutineDetail() {
+  const tokens = useMobileTokens();
   const { t } = useI18n();
   const { botId, botName, routineId } = useLocalSearchParams<{
     botId?: string;
@@ -52,40 +53,47 @@ export default function RoutineDetail() {
       contentContainerStyle={{ padding: 24, gap: 18 }}
     >
       <Stack.Screen options={{ title: routine?.name ?? t("Routine") }} />
-      {loading ? <ActivityIndicator color="#85858A" /> : null}
-      {error ? <Text style={{ color: "#EF4444", fontSize: 15 }}>{error}</Text> : null}
+      {loading ? <ActivityIndicator color={tokens.mutedForeground} /> : null}
+      {error ? <Text style={{ color: tokens.destructive, fontSize: 15 }}>{error}</Text> : null}
       {routine ? (
         <>
           <View
             style={{
               borderRadius: 16,
               borderWidth: 1,
-              borderColor: "#26262A",
-              backgroundColor: "#17171A",
+              borderColor: tokens.border,
+              backgroundColor: tokens.card,
               padding: 18,
               gap: 8,
             }}
           >
-            <Text style={{ color: "#ECECEE", fontSize: 20, fontWeight: "600" }}>
+            <Text style={{ color: tokens.foreground, fontSize: 20, fontWeight: "600" }}>
               {routine.name}
             </Text>
-            <Text style={{ color: routine.active ? "#4ECB71" : "#85858A", fontSize: 14 }}>
+            <Text
+              style={{
+                color: routine.active ? tokens.success : tokens.mutedForeground,
+                fontSize: 14,
+              }}
+            >
               {routine.active ? t("Active") : t("Paused")} · {routine.crons.join(", ")} ·{" "}
               {routine.timezone}
             </Text>
           </View>
           <View style={{ gap: 8 }}>
-            <Text style={{ color: "#85858A", fontSize: 13, textTransform: "uppercase" }}>
+            <Text
+              style={{ color: tokens.mutedForeground, fontSize: 13, textTransform: "uppercase" }}
+            >
               {t("Prompt")}
             </Text>
             <Text
               selectable
               style={{
-                color: "#DFDFE2",
+                color: tokens.foreground,
                 fontSize: 15,
                 lineHeight: 23,
                 borderRadius: 16,
-                backgroundColor: "#17171A",
+                backgroundColor: tokens.card,
                 padding: 18,
               }}
             >
@@ -103,11 +111,11 @@ export default function RoutineDetail() {
             style={{
               alignItems: "center",
               borderRadius: 12,
-              backgroundColor: "#F1F1EF",
+              backgroundColor: tokens.primary,
               padding: 14,
             }}
           >
-            <Text style={{ color: "#17171A", fontSize: 15, fontWeight: "600" }}>
+            <Text style={{ color: tokens.primaryForeground, fontSize: 15, fontWeight: "600" }}>
               {t("Open conversation")}
             </Text>
           </Pressable>

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -1,5 +1,4 @@
 import { Redirect, useLocalSearchParams, useRouter } from "expo-router";
-import { StatusBar } from "expo-status-bar";
 import { useEffect, useState } from "react";
 import {
   AccessibilityInfo,
@@ -34,9 +33,11 @@ import {
 } from "../lib/api";
 import { type AuthMode, initialAuthMode } from "../lib/auth-routing";
 import { useI18n } from "../lib/i18n";
+import { useMobileTokens } from "../lib/native";
 
 export default function SignIn() {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const router = useRouter();
   const { mode: requestedMode } = useLocalSearchParams<{ mode?: string | string[] }>();
   const [mode, setMode] = useState<AuthMode>(() => initialAuthMode(requestedMode));
@@ -78,8 +79,15 @@ export default function SignIn() {
 
   if (!ready) {
     return (
-      <View style={{ flex: 1, backgroundColor: "#F7F7F4", justifyContent: "center", padding: 24 }}>
-        <Text style={{ color: "#6E6E68", textAlign: "center" }}>{t("Loading…")}</Text>
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: tokens.background,
+          justifyContent: "center",
+          padding: 24,
+        }}
+      >
+        <Text style={{ color: tokens.mutedForeground, textAlign: "center" }}>{t("Loading…")}</Text>
       </View>
     );
   }
@@ -115,8 +123,7 @@ export default function SignIn() {
   const custom = usesCustomApiBase(apiBase);
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: "#F7F7F4" }}>
-      <StatusBar style="dark" />
+    <SafeAreaView style={{ flex: 1, backgroundColor: tokens.background }}>
       <KeyboardAvoidingView
         style={{ flex: 1 }}
         behavior={Platform.OS === "ios" ? "padding" : undefined}
@@ -136,7 +143,7 @@ export default function SignIn() {
               <Text
                 accessibilityRole="header"
                 style={{
-                  color: "#1B1B1E",
+                  color: tokens.foreground,
                   fontSize: 32,
                   fontWeight: "500",
                   textAlign: "center",
@@ -159,7 +166,7 @@ export default function SignIn() {
                       setResetSent(false);
                     }}
                   >
-                    <Text style={{ color: "#1B1B1E", fontSize: 15, fontWeight: "600" }}>
+                    <Text style={{ color: tokens.foreground, fontSize: 15, fontWeight: "600" }}>
                       {t("Back to sign in")}
                     </Text>
                   </Pressable>
@@ -170,15 +177,15 @@ export default function SignIn() {
                     <TextInput
                       autoComplete="name"
                       placeholder={t("Name")}
-                      placeholderTextColor="#8C8C86"
+                      placeholderTextColor={tokens.mutedForeground}
                       value={name}
                       onChangeText={setName}
                       style={{
                         marginTop: 28,
-                        backgroundColor: "#F1F1ED",
+                        backgroundColor: tokens.muted,
                         borderRadius: 13,
                         padding: 16,
-                        color: "#1B1B1E",
+                        color: tokens.foreground,
                       }}
                     />
                   ) : null}
@@ -187,17 +194,36 @@ export default function SignIn() {
                     autoComplete="email"
                     keyboardType="email-address"
                     placeholder={t("Email")}
-                    placeholderTextColor="#8C8C86"
+                    placeholderTextColor={tokens.mutedForeground}
                     value={email}
                     onChangeText={setEmail}
                     style={{
                       marginTop: mode === "up" ? 12 : 28,
-                      backgroundColor: "#F1F1ED",
+                      backgroundColor: tokens.muted,
                       borderRadius: 13,
                       padding: 16,
-                      color: "#1B1B1E",
+                      color: tokens.foreground,
                     }}
                   />
+                  {mode !== "forgot" ? (
+                    <TextInput
+                      autoComplete={mode === "in" ? "current-password" : "new-password"}
+                      placeholder={t("Password")}
+                      placeholderTextColor={tokens.mutedForeground}
+                      returnKeyType="go"
+                      secureTextEntry
+                      value={password}
+                      onChangeText={setPassword}
+                      onSubmitEditing={() => void submit()}
+                      style={{
+                        marginTop: 12,
+                        backgroundColor: tokens.muted,
+                        borderRadius: 13,
+                        padding: 16,
+                        color: tokens.foreground,
+                      }}
+                    />
+                  ) : null}
                   {mode === "in" && reset?.passwordReset && reset.resetUrl ? (
                     <Pressable
                       accessibilityRole="button"
@@ -208,44 +234,27 @@ export default function SignIn() {
                       }}
                       style={{ alignSelf: "flex-end", marginTop: 10 }}
                     >
-                      <Text style={{ color: "#1B1B1E", fontSize: 14, fontWeight: "600" }}>
+                      <Text style={{ color: tokens.foreground, fontSize: 14, fontWeight: "600" }}>
                         {t("Forgot password?")}
                       </Text>
                     </Pressable>
                   ) : null}
-                  {mode !== "forgot" ? (
-                    <TextInput
-                      autoComplete={mode === "in" ? "current-password" : "new-password"}
-                      placeholder={t("Password")}
-                      placeholderTextColor="#8C8C86"
-                      returnKeyType="go"
-                      secureTextEntry
-                      value={password}
-                      onChangeText={setPassword}
-                      onSubmitEditing={() => void submit()}
-                      style={{
-                        marginTop: 12,
-                        backgroundColor: "#F1F1ED",
-                        borderRadius: 13,
-                        padding: 16,
-                        color: "#1B1B1E",
-                      }}
-                    />
+                  {error ? (
+                    <Text style={{ color: tokens.destructive, marginTop: 12 }}>{error}</Text>
                   ) : null}
-                  {error ? <Text style={{ color: "#B91C1C", marginTop: 12 }}>{error}</Text> : null}
                   <Pressable
                     accessibilityRole="button"
                     onPress={() => void submit()}
                     disabled={pending}
                     style={{
                       marginTop: 16,
-                      backgroundColor: "#121215",
+                      backgroundColor: tokens.primary,
                       borderRadius: 13,
                       padding: 18,
                       alignItems: "center",
                     }}
                   >
-                    <Text style={{ color: "#FBFBF9", fontSize: 17 }}>
+                    <Text style={{ color: tokens.primaryForeground, fontSize: 17 }}>
                       {pending
                         ? t("Working…")
                         : mode === "in"
@@ -263,7 +272,7 @@ export default function SignIn() {
                       marginTop: 24,
                     }}
                   >
-                    <Text style={{ color: "#8C8C86", fontSize: 15 }}>
+                    <Text style={{ color: tokens.mutedForeground, fontSize: 15 }}>
                       {mode === "in"
                         ? t("Don’t have an account?")
                         : mode === "up"
@@ -279,7 +288,7 @@ export default function SignIn() {
                       }}
                       style={{ marginLeft: 5 }}
                     >
-                      <Text style={{ color: "#1B1B1E", fontSize: 15, fontWeight: "600" }}>
+                      <Text style={{ color: tokens.foreground, fontSize: 15, fontWeight: "600" }}>
                         {mode === "in"
                           ? t("Sign up")
                           : mode === "up"
@@ -309,13 +318,17 @@ export default function SignIn() {
             >
               {custom ? (
                 <>
-                  <Text style={{ color: "#A8A8A2", fontSize: 12 }}>{t("Custom server")}</Text>
-                  <Text style={{ color: "#6E6E68", fontSize: 13, marginTop: 2 }}>
+                  <Text style={{ color: tokens.mutedForeground, fontSize: 12 }}>
+                    {t("Custom server")}
+                  </Text>
+                  <Text style={{ color: tokens.mutedForeground, fontSize: 13, marginTop: 2 }}>
                     {displayApiHost(apiBase)}
                   </Text>
                 </>
               ) : (
-                <Text style={{ color: "#A8A8A2", fontSize: 13 }}>{t("Use a custom server")}</Text>
+                <Text style={{ color: tokens.mutedForeground, fontSize: 13 }}>
+                  {t("Use a custom server")}
+                </Text>
               )}
             </Pressable>
           </View>
@@ -346,6 +359,7 @@ function ServerSheet({
   onSaved: (url: string) => void;
 }) {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const [draft, setDraft] = useState(current);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
@@ -403,7 +417,7 @@ function ServerSheet({
       onRequestClose={onClose}
     >
       <KeyboardAvoidingView
-        style={{ flex: 1, backgroundColor: "#F7F7F4" }}
+        style={{ flex: 1, backgroundColor: tokens.background }}
         behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
         <SafeAreaView style={{ flex: 1, paddingHorizontal: 24, paddingTop: 12 }}>
@@ -415,19 +429,21 @@ function ServerSheet({
             }}
           >
             <Pressable onPress={onClose} hitSlop={8}>
-              <Text style={{ color: "#6E6E68", fontSize: 17 }}>{t("Cancel")}</Text>
+              <Text style={{ color: tokens.mutedForeground, fontSize: 17 }}>{t("Cancel")}</Text>
             </Pressable>
-            <Text style={{ color: "#1B1B1E", fontSize: 17, fontWeight: "600" }}>{t("Server")}</Text>
+            <Text style={{ color: tokens.foreground, fontSize: 17, fontWeight: "600" }}>
+              {t("Server")}
+            </Text>
             <Pressable onPress={() => void save()} disabled={pending} hitSlop={8}>
-              <Text style={{ color: "#1B1B1E", fontSize: 17, fontWeight: "600" }}>
+              <Text style={{ color: tokens.foreground, fontSize: 17, fontWeight: "600" }}>
                 {pending ? t("Checking…") : t("Save")}
               </Text>
             </Pressable>
           </View>
-          <Text style={{ color: "#6E6E68", marginTop: 28, fontSize: 15, lineHeight: 22 }}>
-            {t(
-              "Point this app at your self-hosted Rakazo origin, the same HTTPS URL you open in a browser.",
-            )}
+          <Text
+            style={{ color: tokens.mutedForeground, marginTop: 28, fontSize: 15, lineHeight: 22 }}
+          >
+            {t("Enter your Rakazo server address.")}
           </Text>
           <TextInput
             autoCapitalize="none"
@@ -438,7 +454,7 @@ function ServerSheet({
             returnKeyType="go"
             onSubmitEditing={() => void save()}
             placeholder={defaultApiBase()}
-            placeholderTextColor="#8C8C86"
+            placeholderTextColor={tokens.mutedForeground}
             value={draft}
             onChangeText={(value) => {
               setDraft(value);
@@ -446,24 +462,28 @@ function ServerSheet({
             }}
             style={{
               marginTop: 20,
-              backgroundColor: "#F1F1ED",
+              backgroundColor: tokens.muted,
               borderRadius: 13,
               padding: 16,
-              color: "#1B1B1E",
+              color: tokens.foreground,
               fontSize: 16,
             }}
           />
           {warning ? (
-            <Text style={{ color: "#8C8C86", marginTop: 12, fontSize: 13 }}>{warning}</Text>
+            <Text style={{ color: tokens.mutedForeground, marginTop: 12, fontSize: 13 }}>
+              {warning}
+            </Text>
           ) : null}
-          {error ? <Text style={{ color: "#B91C1C", marginTop: 12 }}>{error}</Text> : null}
+          {error ? <Text style={{ color: tokens.destructive, marginTop: 12 }}>{error}</Text> : null}
           {usesCustomApiBase(current) || draft.trim() !== current ? (
             <Pressable
               onPress={() => void restoreDefault()}
               disabled={pending}
               style={{ marginTop: 28, alignItems: "center" }}
             >
-              <Text style={{ color: "#6E6E68", fontSize: 15 }}>{t("Use default server")}</Text>
+              <Text style={{ color: tokens.mutedForeground, fontSize: 15 }}>
+                {t("Use default server")}
+              </Text>
             </Pressable>
           ) : null}
         </SafeAreaView>

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -25,17 +25,20 @@ import {
   truncateSlashDescription,
   userVisibleMessages,
 } from "@rakazo/core";
-import { Link, useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
+import { useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useHeaderHeight } from "expo-router/react-navigation";
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
+  ActionSheetIOS,
   ActivityIndicator,
   Alert,
   AppState,
   FlatList,
   Image,
+  Modal,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
+  Platform,
   Pressable,
   ScrollView,
   Text,
@@ -88,7 +91,7 @@ import {
   isCenteredAgentEvent,
   messagePresentationSegments,
 } from "../lib/message-presentation";
-import { native, useResolvedAppearance } from "../lib/native";
+import { native, useMobileTokens, useResolvedAppearance } from "../lib/native";
 import {
   type PickedAttachment,
   pickDocuments,
@@ -155,7 +158,7 @@ function isWorkingStatus(status: string | undefined): boolean {
 type NotificationRouteState = "loading" | "ready" | "failed";
 
 export default function ThreadRoute() {
-  useResolvedAppearance();
+  const tokens = useMobileTokens();
   const { t } = useI18n();
   const router = useRouter();
   const { spaceId } = useLocalSearchParams<{ spaceId?: string | string[] }>();
@@ -194,13 +197,18 @@ export default function ThreadRoute() {
   if (routeState === "ready" && !invalidSpaceId && routeMatchesSelectedSpace) return <Thread />;
   return (
     <View
-      style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: "#000" }}
+      style={{
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: tokens.background,
+      }}
     >
       {routeState === "loading" ? (
-        <ActivityIndicator color="#ECECEE" />
+        <ActivityIndicator color={tokens.foreground} />
       ) : (
         <Pressable accessibilityRole="button" onPress={() => router.replace("/")}>
-          <Text style={{ color: "#ECECEE", fontSize: 16 }}>{t("Return to inbox")}</Text>
+          <Text style={{ color: tokens.foreground, fontSize: 16 }}>{t("Return to inbox")}</Text>
         </Pressable>
       )}
     </View>
@@ -208,6 +216,9 @@ export default function ThreadRoute() {
 }
 
 function Thread() {
+  const colorScheme = useResolvedAppearance();
+  const tokens = mobileTokens();
+  const [botActionsOpen, setBotActionsOpen] = useState(false);
   const { t } = useI18n();
   const navigation = useNavigation();
   const router = useRouter();
@@ -482,7 +493,10 @@ function Thread() {
               muted={!currentBot.notifyOnFinish}
             />
           ) : null}
-          <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 18, fontWeight: "600" }}>
+          <Text
+            numberOfLines={1}
+            style={{ color: tokens.foreground, fontSize: 18, fontWeight: "600" }}
+          >
             {name || t("Thread")}
           </Text>
         </View>
@@ -499,15 +513,37 @@ function Thread() {
               })
             }
           >
-            <NativeSymbol ios="gearshape" android="settings-outline" size={21} color="#ECECEE" />
+            <NativeSymbol
+              ios="gearshape"
+              android="settings-outline"
+              size={21}
+              color={tokens.foreground}
+            />
           </Pressable>
         ) : (
           <Pressable accessibilityLabel={t("Bot actions")} hitSlop={8} onPress={showBotActions}>
-            <NativeSymbol ios="ellipsis" android="ellipsis-horizontal" size={21} color="#ECECEE" />
+            <NativeSymbol
+              ios="ellipsis"
+              android="ellipsis-horizontal"
+              size={21}
+              color={tokens.foreground}
+            />
           </Pressable>
         ),
     });
-  }, [botId, currentBot, currentBotStatus, groupId, inGroup, name, navigation, router, t]);
+  }, [
+    botId,
+    currentBot,
+    currentBotStatus,
+    groupId,
+    inGroup,
+    name,
+    navigation,
+    router,
+    t,
+    tokens,
+    colorScheme,
+  ]);
 
   function leaveBot() {
     router.dismissAll();
@@ -531,49 +567,67 @@ function Thread() {
       );
   }
 
+  const botActions = [
+    {
+      text: t("Open computer"),
+      onPress: () =>
+        router.push({
+          pathname: "/computer",
+          params: { botId: botId ?? "", name: name ?? t("Bot") },
+        }),
+    },
+    {
+      text: t("Clear conversation"),
+      destructive: true,
+      onPress: () =>
+        Alert.alert(
+          t("Clear conversation?"),
+          t(
+            "This removes every message and stops current work. The bot, computer, memory, and routines are kept.",
+          ),
+          [
+            { text: t("Cancel"), style: "cancel" },
+            { text: t("Clear"), style: "destructive", onPress: clearConversation },
+          ],
+        ),
+    },
+    {
+      text: t("Archive"),
+      onPress: () =>
+        void rpc("bots/archive", { botId })
+          .then(leaveBot)
+          .catch((error) =>
+            Alert.alert(
+              t("Could not archive bot"),
+              error instanceof Error ? error.message : t("Try again."),
+            ),
+          ),
+    },
+    {
+      text: t("Delete…"),
+      destructive: true,
+      onPress: () => confirmDeleteBot({ id: botId ?? "", name: name || t("Bot") }, leaveBot),
+    },
+  ];
+
   function showBotActions() {
     if (!botId) return;
-    const bot = { id: botId, name: name || t("Bot") };
-    Alert.alert(bot.name, t("Archive keeps everything and can be undone. Delete is permanent."), [
-      { text: t("Cancel"), style: "cancel" },
-      {
-        text: t("Clear conversation"),
-        style: "destructive",
-        onPress: () => {
-          Alert.alert(
-            t("Clear conversation?"),
-            t(
-              "This removes every message and stops current work. The bot, computer, memory, and routines are kept.",
-            ),
-            [
-              { text: t("Cancel"), style: "cancel" },
-              {
-                text: t("Clear"),
-                style: "destructive",
-                onPress: clearConversation,
-              },
-            ],
-          );
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: name || t("Bot"),
+          userInterfaceStyle: colorScheme,
+          options: [...botActions.map((action) => action.text), t("Cancel")],
+          cancelButtonIndex: botActions.length,
+          destructiveButtonIndex: botActions.flatMap((action, index) =>
+            action.destructive ? [index] : [],
+          ),
         },
-      },
-      {
-        text: t("Archive"),
-        onPress: () =>
-          void rpc("bots/archive", { botId })
-            .then(leaveBot)
-            .catch((error) =>
-              Alert.alert(
-                t("Could not archive bot"),
-                error instanceof Error ? error.message : t("Try again."),
-              ),
-            ),
-      },
-      {
-        text: t("Delete…"),
-        style: "destructive",
-        onPress: () => confirmDeleteBot(bot, leaveBot),
-      },
-    ]);
+        (index) => botActions[index]?.onPress(),
+      );
+      return;
+    }
+    setBotActionsOpen(true);
   }
 
   async function refresh() {
@@ -1237,7 +1291,7 @@ function Thread() {
         {activityBotId ? (
           <View style={{ paddingTop: 22 }}>
             <BotAvatar
-              color={activityBot?.color ?? "#85858A"}
+              color={activityBot?.color ?? tokens.mutedForeground}
               identity={activityBotId}
               size={inGroup ? 20 : 28}
               status={activityStatus}
@@ -1266,7 +1320,7 @@ function Thread() {
             }}
           >
             <Pressable accessibilityLabel={t("Reply")} onPress={() => setReplyTarget(message)}>
-              <Text style={{ color: "#6C6C70", fontSize: 12 }}>{t("Reply")}</Text>
+              <Text style={{ color: tokens.mutedForeground, fontSize: 12 }}>{t("Reply")}</Text>
             </Pressable>
             {canReactToThreadMessage(message) ? (
               <Pressable
@@ -1274,7 +1328,12 @@ function Thread() {
                 accessibilityState={{ selected: Boolean(message.thumbsUp) }}
                 onPress={() => void reactToMessage(message)}
               >
-                <Text style={{ color: message.thumbsUp ? "#E9C46A" : "#6C6C70", fontSize: 13 }}>
+                <Text
+                  style={{
+                    color: message.thumbsUp ? tokens.warning : tokens.mutedForeground,
+                    fontSize: 13,
+                  }}
+                >
                   👍
                 </Text>
               </Pressable>
@@ -1318,7 +1377,7 @@ function Thread() {
           size={28}
           status={currentBotStatus}
         />
-        <Text style={{ color: "#85858A", fontSize: 13.5 }}>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 13.5 }}>
           {t("{name} is working", { name: currentBot.name })}
         </Text>
       </View>
@@ -1345,7 +1404,7 @@ function Thread() {
             </View>
           ))}
         </View>
-        <Text style={{ color: "#85858A", fontSize: 13.5, flexShrink: 1 }}>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 13.5, flexShrink: 1 }}>
           {workingGroupBots.length === 1
             ? t("{name} is working", { name: workingGroupBots[0]?.name ?? t("Agent") })
             : t("{count} agents working", { count: workingGroupBots.length })}
@@ -1364,7 +1423,7 @@ function Thread() {
           paddingVertical: 10,
         }}
       >
-        <Text style={{ color: "#85858A", fontSize: 13 }}>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 13 }}>
           {loadingOlder ? t("Loading…") : t("Load earlier messages")}
         </Text>
       </Pressable>
@@ -1374,10 +1433,12 @@ function Thread() {
     <KeyboardAvoidingView
       behavior="height"
       keyboardVerticalOffset={headerHeight}
-      style={{ flex: 1, backgroundColor: "#000", paddingHorizontal: 20 }}
+      style={{ flex: 1, backgroundColor: tokens.background, paddingHorizontal: 20 }}
     >
-      {error ? <Text style={{ color: "#8E8E93", marginTop: 12 }}>{error}</Text> : null}
-      {runError ? <Text style={{ color: "#EF4444", marginTop: 12 }}>{runError}</Text> : null}
+      {error ? <Text style={{ color: tokens.mutedForeground, marginTop: 12 }}>{error}</Text> : null}
+      {runError ? (
+        <Text style={{ color: tokens.destructive, marginTop: 12 }}>{runError}</Text>
+      ) : null}
       <View style={{ flex: 1, position: "relative" }}>
         {showPinnedPage ? (
           <ScrollView
@@ -1463,7 +1524,7 @@ function Thread() {
               ios="arrow.down"
               android="arrow-down"
               size={18}
-              color={mobileTokens().foreground}
+              color={tokens.foreground}
             />
             {threadScrollState.unread ? (
               <View
@@ -1474,7 +1535,7 @@ function Thread() {
                   width: 8,
                   height: 8,
                   borderRadius: 4,
-                  backgroundColor: "#4C8DFF",
+                  backgroundColor: tokens.primary,
                 }}
               />
             ) : null}
@@ -1488,8 +1549,8 @@ function Thread() {
               marginTop: 12,
               borderRadius: 14,
               borderWidth: 1,
-              borderColor: "#26262A",
-              backgroundColor: "#17171A",
+              borderColor: tokens.border,
+              backgroundColor: tokens.card,
               paddingHorizontal: 12,
               paddingVertical: 10,
               flexDirection: "row",
@@ -1498,18 +1559,22 @@ function Thread() {
             }}
           >
             <View style={{ flex: 1 }}>
-              <Text style={{ color: "#85858A", fontSize: 12 }}>{t("Replying to")}</Text>
-              <Text style={{ color: "#C9C9CE", fontSize: 13 }} numberOfLines={1}>
+              <Text style={{ color: tokens.mutedForeground, fontSize: 12 }}>
+                {t("Replying to")}
+              </Text>
+              <Text style={{ color: tokens.foreground, fontSize: 13 }} numberOfLines={1}>
                 {previewMessageText(replyTarget)}
               </Text>
             </View>
             <Pressable accessibilityLabel={t("Cancel reply")} onPress={() => setReplyTarget(null)}>
-              <Text style={{ color: "#85858A" }}>✕</Text>
+              <Text style={{ color: tokens.mutedForeground }}>✕</Text>
             </Pressable>
           </View>
         ) : null}
         {attachmentNotice ? (
-          <Text style={{ color: "#D6CFA0", marginTop: 12, fontSize: 13 }}>{attachmentNotice}</Text>
+          <Text style={{ color: tokens.warning, marginTop: 12, fontSize: 13 }}>
+            {attachmentNotice}
+          </Text>
         ) : null}
         {activePendingAttachments.length ? (
           <View
@@ -1529,8 +1594,8 @@ function Thread() {
                   gap: 8,
                   borderRadius: 999,
                   borderWidth: 1,
-                  borderColor: "#26262A",
-                  backgroundColor: "#17171A",
+                  borderColor: tokens.border,
+                  backgroundColor: tokens.card,
                   paddingHorizontal: 12,
                   paddingVertical: 8,
                 }}
@@ -1541,9 +1606,9 @@ function Thread() {
                     style={{ width: 28, height: 28, borderRadius: 6 }}
                   />
                 ) : (
-                  <Text style={{ color: "#C9C9CE" }}>📎</Text>
+                  <Text style={{ color: tokens.foreground }}>📎</Text>
                 )}
-                <Text style={{ color: "#C9C9CE", maxWidth: 140 }} numberOfLines={1}>
+                <Text style={{ color: tokens.foreground, maxWidth: 140 }} numberOfLines={1}>
                   {attachment.name}
                 </Text>
                 <Pressable
@@ -1554,7 +1619,12 @@ function Thread() {
                     )
                   }
                 >
-                  <NativeSymbol ios="xmark" android="close" size={14} color="#85858A" />
+                  <NativeSymbol
+                    ios="xmark"
+                    android="close"
+                    size={14}
+                    color={tokens.mutedForeground}
+                  />
                 </Pressable>
               </View>
             ))}
@@ -1567,8 +1637,8 @@ function Thread() {
               marginTop: 12,
               borderRadius: 14,
               borderWidth: 1,
-              borderColor: "#26262A",
-              backgroundColor: "#17171A",
+              borderColor: tokens.border,
+              backgroundColor: tokens.card,
               overflow: "hidden",
             }}
           >
@@ -1587,12 +1657,12 @@ function Thread() {
               >
                 <MentionOptionIcon mention={mention} />
                 <View style={{ flex: 1, minWidth: 0 }}>
-                  <Text style={{ color: "#ECECEE", fontSize: 14 }}>@{mention.name}</Text>
+                  <Text style={{ color: tokens.foreground, fontSize: 14 }}>@{mention.name}</Text>
                   {mention.subtitle ? (
                     <Text
                       numberOfLines={1}
                       style={{
-                        color: "#85858A",
+                        color: tokens.mutedForeground,
                         fontSize: 12.5,
                         marginTop: 2,
                       }}
@@ -1612,8 +1682,8 @@ function Thread() {
               marginTop: 12,
               borderRadius: 14,
               borderWidth: 1,
-              borderColor: "#26262A",
-              backgroundColor: "#17171A",
+              borderColor: tokens.border,
+              backgroundColor: tokens.card,
               overflow: "hidden",
             }}
           >
@@ -1630,12 +1700,17 @@ function Thread() {
                   paddingVertical: 10,
                 }}
               >
-                <NativeSymbol ios="cube" android="cube-outline" size={16} color="#9A9AA0" />
+                <NativeSymbol
+                  ios="cube"
+                  android="cube-outline"
+                  size={16}
+                  color={tokens.mutedForeground}
+                />
                 <View style={{ flex: 1, minWidth: 0 }}>
-                  <Text style={{ color: "#ECECEE", fontSize: 14 }}>{skill.name}</Text>
+                  <Text style={{ color: tokens.foreground, fontSize: 14 }}>{skill.name}</Text>
                   <Text
                     numberOfLines={1}
-                    style={{ color: "#85858A", fontSize: 12.5, marginTop: 2 }}
+                    style={{ color: tokens.mutedForeground, fontSize: 12.5, marginTop: 2 }}
                   >
                     {truncateSlashDescription(skill.description)}
                   </Text>
@@ -1659,9 +1734,9 @@ function Thread() {
                   ios="gearshape"
                   android="settings-outline"
                   size={16}
-                  color="#9A9AA0"
+                  color={tokens.mutedForeground}
                 />
-                <Text style={{ color: "#ECECEE", fontSize: 14 }}>{t(action.label)}</Text>
+                <Text style={{ color: tokens.foreground, fontSize: 14 }}>{t(action.label)}</Text>
               </Pressable>
             ))}
           </View>
@@ -1682,12 +1757,12 @@ function Thread() {
               height: 44,
               borderRadius: 22,
               borderWidth: 1,
-              borderColor: "#26262A",
+              borderColor: tokens.border,
               alignItems: "center",
               justifyContent: "center",
             }}
           >
-            <NativeSymbol ios="plus" android="add" size={18} color="#9A9AA0" />
+            <NativeSymbol ios="plus" android="add" size={18} color={tokens.mutedForeground} />
           </Pressable>
           <View
             style={{
@@ -1696,7 +1771,7 @@ function Thread() {
               flexWrap: "wrap",
               alignItems: "center",
               gap: 6,
-              backgroundColor: "#131315",
+              backgroundColor: tokens.card,
               borderRadius: 20,
               paddingHorizontal: 10,
               paddingVertical: 8,
@@ -1710,15 +1785,23 @@ function Thread() {
                   flexDirection: "row",
                   alignItems: "center",
                   gap: 6,
-                  backgroundColor: "#1C1C1F",
+                  backgroundColor: tokens.muted,
                   borderRadius: 999,
                   paddingHorizontal: 10,
                   paddingVertical: 5,
                   maxWidth: "100%",
                 }}
               >
-                <NativeSymbol ios="cube" android="cube-outline" size={13} color="#B0B0B6" />
-                <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13, flexShrink: 1 }}>
+                <NativeSymbol
+                  ios="cube"
+                  android="cube-outline"
+                  size={13}
+                  color={tokens.mutedForeground}
+                />
+                <Text
+                  numberOfLines={1}
+                  style={{ color: tokens.foreground, fontSize: 13, flexShrink: 1 }}
+                >
                   {selectedSkill.name}
                 </Text>
                 <Pressable
@@ -1726,7 +1809,12 @@ function Thread() {
                   hitSlop={8}
                   onPress={() => setSelectedSkill(null)}
                 >
-                  <NativeSymbol ios="xmark" android="close" size={12} color="#85858A" />
+                  <NativeSymbol
+                    ios="xmark"
+                    android="close"
+                    size={12}
+                    color={tokens.mutedForeground}
+                  />
                 </Pressable>
               </View>
             ) : null}
@@ -1738,7 +1826,7 @@ function Thread() {
                   flexDirection: "row",
                   alignItems: "center",
                   gap: 6,
-                  backgroundColor: "#1C1C1F",
+                  backgroundColor: tokens.muted,
                   borderRadius: 999,
                   paddingHorizontal: 10,
                   paddingVertical: 5,
@@ -1746,7 +1834,10 @@ function Thread() {
                 }}
               >
                 <MentionChipIcon mention={mention} />
-                <Text numberOfLines={1} style={{ color: "#ECECEE", fontSize: 13, flexShrink: 1 }}>
+                <Text
+                  numberOfLines={1}
+                  style={{ color: tokens.foreground, fontSize: 13, flexShrink: 1 }}
+                >
                   {mention.name}
                 </Text>
                 <Pressable
@@ -1760,7 +1851,12 @@ function Thread() {
                     )
                   }
                 >
-                  <NativeSymbol ios="xmark" android="close" size={12} color="#85858A" />
+                  <NativeSymbol
+                    ios="xmark"
+                    android="close"
+                    size={12}
+                    color={tokens.mutedForeground}
+                  />
                 </Pressable>
               </View>
             ))}
@@ -1784,8 +1880,8 @@ function Thread() {
                     ? t("Message {name}", { name })
                     : t("Message…")
               }
-              placeholderTextColor="#6C6C70"
-              keyboardAppearance="dark"
+              placeholderTextColor={tokens.mutedForeground}
+              keyboardAppearance={colorScheme}
               multiline
               textAlignVertical="center"
               blurOnSubmit={false}
@@ -1793,7 +1889,7 @@ function Thread() {
                 flexGrow: 1,
                 flexShrink: 1,
                 minWidth: 96,
-                color: "#ECECEE",
+                color: tokens.foreground,
                 paddingVertical: 2,
                 maxHeight: 100,
                 writingDirection: "auto",
@@ -1805,7 +1901,7 @@ function Thread() {
             disabled={sending || !canSend}
             onPress={() => void send()}
             style={{
-              backgroundColor: "#F1F1EF",
+              backgroundColor: tokens.primary,
               borderRadius: 22,
               width: 44,
               height: 44,
@@ -1814,7 +1910,12 @@ function Thread() {
               opacity: sending || !canSend ? 0.5 : 1,
             }}
           >
-            <NativeSymbol ios="arrow.up" android="arrow-up" size={18} color="#17171A" />
+            <NativeSymbol
+              ios="arrow.up"
+              android="arrow-up"
+              size={18}
+              color={tokens.primaryForeground}
+            />
           </Pressable>
           {working ? (
             <Pressable
@@ -1822,7 +1923,7 @@ function Thread() {
               disabled={sending}
               onPress={() => void stop()}
               style={{
-                borderColor: "#34343A",
+                borderColor: tokens.border,
                 borderWidth: 1,
                 borderRadius: 22,
                 width: 44,
@@ -1832,24 +1933,57 @@ function Thread() {
                 opacity: sending ? 0.5 : 1,
               }}
             >
-              <NativeSymbol ios="stop.fill" android="stop" size={15} color="#C9C9CE" />
+              <NativeSymbol ios="stop.fill" android="stop" size={15} color={tokens.foreground} />
             </Pressable>
           ) : null}
         </View>
-        {!inGroup ? (
-          <Link
-            href={{
-              pathname: "/computer",
-              params: { botId: botId ?? "", name: name ?? t("Bot") },
-            }}
-            asChild
-          >
-            <Pressable style={{ marginTop: 16 }}>
-              <Text style={{ color: "#C9C9CE" }}>{t("Open computer →")}</Text>
-            </Pressable>
-          </Link>
-        ) : null}
       </View>
+      <Modal
+        visible={botActionsOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setBotActionsOpen(false)}
+      >
+        <View
+          style={{
+            flex: 1,
+            justifyContent: "center",
+            padding: 24,
+            backgroundColor: tokens.overlay,
+          }}
+        >
+          <Pressable
+            accessibilityLabel={t("Cancel")}
+            onPress={() => setBotActionsOpen(false)}
+            style={{ position: "absolute", top: 0, right: 0, bottom: 0, left: 0 }}
+          />
+          <View
+            accessibilityViewIsModal
+            style={{ backgroundColor: tokens.popover, borderRadius: 24, paddingVertical: 12 }}
+          >
+            {botActions.map((action) => (
+              <Pressable
+                key={action.text}
+                accessibilityRole="button"
+                onPress={() => {
+                  setBotActionsOpen(false);
+                  action.onPress();
+                }}
+                style={{ minHeight: 56, justifyContent: "center", paddingHorizontal: 24 }}
+              >
+                <Text
+                  style={{
+                    color: action.destructive ? tokens.destructive : tokens.popoverForeground,
+                    fontSize: 16,
+                  }}
+                >
+                  {action.text}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      </Modal>
       {markdownPreview && artifactTarget ? (
         <MarkdownArtifactPreview
           threadTarget={artifactTarget}
@@ -1862,8 +1996,11 @@ function Thread() {
 }
 
 function MentionOptionIcon({ mention }: { mention: ComposerMention }) {
+  const tokens = useMobileTokens();
   if (mention.kind === "routine") {
-    return <NativeSymbol ios="clock" android="time-outline" size={16} color="#9A9AA0" />;
+    return (
+      <NativeSymbol ios="clock" android="time-outline" size={16} color={tokens.mutedForeground} />
+    );
   }
   if (mention.kind === "connector") {
     return (
@@ -1871,7 +2008,7 @@ function MentionOptionIcon({ mention }: { mention: ComposerMention }) {
         ios="puzzlepiece.extension"
         android="extension-puzzle-outline"
         size={16}
-        color="#9A9AA0"
+        color={tokens.mutedForeground}
       />
     );
   }
@@ -1882,12 +2019,12 @@ function MentionOptionIcon({ mention }: { mention: ComposerMention }) {
           width: 16,
           height: 16,
           borderRadius: 8,
-          backgroundColor: "#2A2A2E",
+          backgroundColor: tokens.muted,
           alignItems: "center",
           justifyContent: "center",
         }}
       >
-        <Text style={{ color: "#C9C9CE", fontSize: 9 }}>G</Text>
+        <Text style={{ color: tokens.foreground, fontSize: 9 }}>G</Text>
       </View>
     );
   }
@@ -1898,12 +2035,12 @@ function MentionOptionIcon({ mention }: { mention: ComposerMention }) {
           width: 16,
           height: 16,
           borderRadius: 8,
-          backgroundColor: "#2A2A2E",
+          backgroundColor: tokens.muted,
           alignItems: "center",
           justifyContent: "center",
         }}
       >
-        <Text style={{ color: "#C9C9CE", fontSize: 9 }}>@</Text>
+        <Text style={{ color: tokens.foreground, fontSize: 9 }}>@</Text>
       </View>
     );
   }
@@ -1913,15 +2050,18 @@ function MentionOptionIcon({ mention }: { mention: ComposerMention }) {
         width: 16,
         height: 16,
         borderRadius: 4,
-        backgroundColor: mention.color ?? "#85858A",
+        backgroundColor: mention.color ?? tokens.mutedForeground,
       }}
     />
   );
 }
 
 function MentionChipIcon({ mention }: { mention: ComposerMention }) {
+  const tokens = useMobileTokens();
   if (mention.kind === "routine") {
-    return <NativeSymbol ios="clock" android="time-outline" size={13} color="#B0B0B6" />;
+    return (
+      <NativeSymbol ios="clock" android="time-outline" size={13} color={tokens.mutedForeground} />
+    );
   }
   if (mention.kind === "connector") {
     return (
@@ -1929,7 +2069,7 @@ function MentionChipIcon({ mention }: { mention: ComposerMention }) {
         ios="puzzlepiece.extension"
         android="extension-puzzle-outline"
         size={13}
-        color="#B0B0B6"
+        color={tokens.mutedForeground}
       />
     );
   }
@@ -1940,12 +2080,12 @@ function MentionChipIcon({ mention }: { mention: ComposerMention }) {
           width: 14,
           height: 14,
           borderRadius: 7,
-          backgroundColor: "#2A2A2E",
+          backgroundColor: tokens.muted,
           alignItems: "center",
           justifyContent: "center",
         }}
       >
-        <Text style={{ color: "#C9C9CE", fontSize: 9 }}>
+        <Text style={{ color: tokens.foreground, fontSize: 9 }}>
           {mention.kind === "group" ? "G" : "@"}
         </Text>
       </View>
@@ -1957,7 +2097,7 @@ function MentionChipIcon({ mention }: { mention: ComposerMention }) {
         width: 14,
         height: 14,
         borderRadius: 4,
-        backgroundColor: mention.color ?? "#85858A",
+        backgroundColor: mention.color ?? tokens.mutedForeground,
       }}
     />
   );
@@ -2023,6 +2163,8 @@ const MessageBubble = memo(function MessageBubble({
   onPreviewMarkdown: (target: MarkdownArtifactPreviewTarget) => void;
   onSpeak?: (message: MobileMessage) => void;
 }) {
+  const colorScheme = useResolvedAppearance();
+  const tokens = mobileTokens();
   const { t } = useI18n();
   const [peerExpanded, setPeerExpanded] = useState(false);
   const artifactTarget: MobileArtifactTarget = groupId ? { groupId } : { botId };
@@ -2078,7 +2220,7 @@ const MessageBubble = memo(function MessageBubble({
     const peerColor =
       bots.find((bot) => bot.id === peerBotId)?.color ??
       members?.find((member) => member.botId === peerBotId)?.color ??
-      "#85858A";
+      tokens.mutedForeground;
     // Compact receipt only: peer bodies stay out of the human thread.
     // Full view-only peer chat is web-first; mobile keeps the chip without expand.
     return (
@@ -2095,7 +2237,10 @@ const MessageBubble = memo(function MessageBubble({
         }}
       >
         <BotAvatar color={peerColor} identity={peerBotId} size={16} />
-        <Text numberOfLines={1} style={{ color: "#85858A", fontSize: 13.5, flexShrink: 1 }}>
+        <Text
+          numberOfLines={1}
+          style={{ color: tokens.mutedForeground, fontSize: 13.5, flexShrink: 1 }}
+        >
           {label}
         </Text>
       </View>
@@ -2108,7 +2253,7 @@ const MessageBubble = memo(function MessageBubble({
   if (channelMessage) {
     return (
       <View style={{ width: "100%", paddingVertical: 4, alignItems: "center" }}>
-        <Text style={{ color: "#85858A", fontSize: 13.5, textAlign: "center" }}>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 13.5, textAlign: "center" }}>
           {messagingProviderLabel(channelMessage.provider)} · {channelMessage.fromLabel}:{" "}
           {channelMessage.text}
         </Text>
@@ -2127,8 +2272,8 @@ const MessageBubble = memo(function MessageBubble({
           width: "90%",
           borderRadius: 18,
           borderWidth: 1,
-          borderColor: "#232326",
-          backgroundColor: "#17171A",
+          borderColor: tokens.border,
+          backgroundColor: tokens.card,
           paddingHorizontal: 16,
           paddingVertical: 14,
         }}
@@ -2140,12 +2285,12 @@ const MessageBubble = memo(function MessageBubble({
             gap: 8,
           }}
         >
-          <Text style={{ color: "#ECECEE", fontSize: 15, fontWeight: "600" }}>
+          <Text style={{ color: tokens.foreground, fontSize: 15, fontWeight: "600" }}>
             {special.name || t("subagent")}
           </Text>
           <Text
             style={{
-              color: failed ? "#EF4444" : running ? "#F5A03C" : "#4ECB71",
+              color: failed ? tokens.destructive : running ? tokens.warning : tokens.success,
               fontSize: 13,
             }}
           >
@@ -2159,11 +2304,13 @@ const MessageBubble = memo(function MessageBubble({
           </Text>
         </View>
         {special.task ? (
-          <Text style={{ color: "#85858A", marginTop: 8, fontSize: 13.5 }}>{special.task}</Text>
+          <Text style={{ color: tokens.mutedForeground, marginTop: 8, fontSize: 13.5 }}>
+            {special.task}
+          </Text>
         ) : null}
         {special.result || special.progress ? (
           <View style={{ marginTop: 8 }}>
-            <ChatMarkdown streaming={running}>
+            <ChatMarkdown palette={tokens} colorScheme={colorScheme} streaming={running}>
               {special.result || special.progress || ""}
             </ChatMarkdown>
           </View>
@@ -2181,8 +2328,8 @@ const MessageBubble = memo(function MessageBubble({
           width: "90%",
           borderRadius: 18,
           borderWidth: 1,
-          borderColor: "#232326",
-          backgroundColor: "#17171A",
+          borderColor: tokens.border,
+          backgroundColor: tokens.card,
           paddingHorizontal: 16,
           paddingVertical: 14,
           opacity: removed ? 0.6 : 1,
@@ -2195,10 +2342,10 @@ const MessageBubble = memo(function MessageBubble({
             gap: 8,
           }}
         >
-          <Text style={{ color: "#ECECEE", fontSize: 15, fontWeight: "600" }}>
+          <Text style={{ color: tokens.foreground, fontSize: 15, fontWeight: "600" }}>
             {special.name || t("Bot")}
           </Text>
-          <Text style={{ color: removed ? "#EF4444" : "#4ECB71", fontSize: 13 }}>
+          <Text style={{ color: removed ? tokens.destructive : tokens.success, fontSize: 13 }}>
             {special.status === "archived"
               ? t("archived")
               : special.status === "deleted"
@@ -2208,7 +2355,7 @@ const MessageBubble = memo(function MessageBubble({
         </View>
         <Text
           style={{
-            color: "#A8A8AD",
+            color: tokens.mutedForeground,
             marginTop: 8,
             fontSize: 14.5,
             lineHeight: 21,
@@ -2243,21 +2390,21 @@ const MessageBubble = memo(function MessageBubble({
             width: "90%",
             borderRadius: 18,
             borderWidth: 1,
-            borderColor: "#232326",
-            backgroundColor: "#17171A",
+            borderColor: tokens.border,
+            backgroundColor: tokens.card,
             paddingHorizontal: 16,
             paddingVertical: 14,
           }}
         >
           {askBlock.text ? (
-            <Text style={{ color: "#ECECEE", fontSize: 15.5, lineHeight: 23 }}>
+            <Text style={{ color: tokens.foreground, fontSize: 15.5, lineHeight: 23 }}>
               {askBlock.text}
             </Text>
           ) : null}
           {askBlock.detail ? (
             <Text
               style={{
-                color: "#85858A",
+                color: tokens.mutedForeground,
                 marginTop: 8,
                 fontSize: 12.5,
                 fontFamily: "Menlo",
@@ -2270,7 +2417,7 @@ const MessageBubble = memo(function MessageBubble({
           {askBlock.status === "answered" ? (
             <Text
               style={{
-                color: "#4ECB71",
+                color: tokens.success,
                 marginTop: 12,
                 fontSize: 13.5,
                 fontWeight: "600",
@@ -2288,7 +2435,7 @@ const MessageBubble = memo(function MessageBubble({
               onAnswer={(answer) => onAnswer(message, answer)}
             />
           ) : (
-            <Text style={{ color: "#85858A", marginTop: 12, fontSize: 13.5 }}>
+            <Text style={{ color: tokens.mutedForeground, marginTop: 12, fontSize: 13.5 }}>
               {t("No longer active")}
             </Text>
           )}
@@ -2319,25 +2466,33 @@ const MessageBubble = memo(function MessageBubble({
           maxWidth: "100%",
           borderRadius: 20,
           borderWidth: 1,
-          borderColor: "#26262A",
-          backgroundColor: message.role === "user" ? "#F1F1EF" : "#1A1A1D",
+          borderColor: tokens.border,
+          backgroundColor: message.role === "user" ? tokens.primary : tokens.muted,
           paddingHorizontal: 14,
           paddingVertical: 12,
           gap: 8,
         }}
       >
         {speaker ? (
-          <Text style={{ color: "#85858A", fontSize: 12.5, fontWeight: "600" }}>{speaker}</Text>
+          <Text style={{ color: tokens.mutedForeground, fontSize: 12.5, fontWeight: "600" }}>
+            {speaker}
+          </Text>
         ) : null}
         {replyPreview ? (
-          <Text style={{ color: "#85858A", fontSize: 12.5 }} numberOfLines={2}>
+          <Text
+            style={{
+              color: message.role === "user" ? tokens.primaryForeground : tokens.mutedForeground,
+              fontSize: 12.5,
+            }}
+            numberOfLines={2}
+          >
             {previewMessageText(replyPreview)}
           </Text>
         ) : null}
         {caption ? (
           <Text
             style={{
-              color: message.role === "user" ? "#1A1A1A" : "#DFDFE2",
+              color: message.role === "user" ? tokens.primaryForeground : tokens.foreground,
               fontSize: 15,
             }}
           >
@@ -2366,7 +2521,7 @@ const MessageBubble = memo(function MessageBubble({
             >
               <Text
                 style={{
-                  color: message.role === "user" ? "#1A1A1A" : "#DFDFE2",
+                  color: message.role === "user" ? tokens.primaryForeground : tokens.foreground,
                   fontSize: 15,
                 }}
               >
@@ -2400,14 +2555,21 @@ const MessageBubble = memo(function MessageBubble({
             >
               <Text
                 style={{
-                  color: message.role === "user" ? "#1A1A1A" : "#DFDFE2",
+                  color: message.role === "user" ? tokens.primaryForeground : tokens.foreground,
                   fontSize: 15,
                 }}
               >
                 📎 {attachment.name ?? t("File")}
               </Text>
               {attachment.size ? (
-                <Text style={{ color: "#85858A", marginTop: 4, fontSize: 13 }}>
+                <Text
+                  style={{
+                    color:
+                      message.role === "user" ? tokens.primaryForeground : tokens.mutedForeground,
+                    marginTop: 4,
+                    fontSize: 13,
+                  }}
+                >
                   {attachment.mimeType ?? "file"} · {attachment.size} bytes
                 </Text>
               ) : null}
@@ -2457,49 +2619,77 @@ function MessageTextCard({
   replyPreview?: MobileMessage;
   onSpeak?: () => void;
 }) {
+  const colorScheme = useResolvedAppearance();
+  const tokens = mobileTokens();
   const { t } = useI18n();
   const contentText = blockText(message);
   if (!contentText) return null;
   return (
-    <View
+    <Pressable
+      onLongPress={
+        onSpeak
+          ? () =>
+              Alert.alert("", undefined, [
+                { text: t("Speak message"), onPress: onSpeak },
+                { text: t("Cancel"), style: "cancel" },
+              ])
+          : undefined
+      }
+      accessibilityActions={onSpeak ? [{ name: "speak", label: t("Speak message") }] : undefined}
+      onAccessibilityAction={
+        onSpeak
+          ? (event) => {
+              if (event.nativeEvent.actionName === "speak") onSpeak();
+            }
+          : undefined
+      }
       style={{
         flexShrink: 1,
         minWidth: 0,
         maxWidth: "100%",
-        backgroundColor: message.role === "user" ? "#F1F1EF" : "#1A1A1D",
+        backgroundColor: message.role === "user" ? tokens.primary : tokens.muted,
         padding: 12,
         borderRadius: 20,
       }}
     >
       {speaker ? (
-        <Text style={{ color: "#85858A", fontSize: 12.5, fontWeight: "600", marginBottom: 4 }}>
+        <Text
+          style={{
+            color: tokens.mutedForeground,
+            fontSize: 12.5,
+            fontWeight: "600",
+            marginBottom: 4,
+          }}
+        >
           {speaker}
         </Text>
       ) : null}
       {replyPreview ? (
-        <Text style={{ color: "#85858A", fontSize: 12.5, marginBottom: 6 }} numberOfLines={2}>
+        <Text
+          style={{
+            color: message.role === "user" ? tokens.primaryForeground : tokens.mutedForeground,
+            fontSize: 12.5,
+            marginBottom: 6,
+          }}
+          numberOfLines={2}
+        >
           {previewMessageText(replyPreview)}
         </Text>
       ) : null}
       {message.role === "user" ? (
-        <Text style={{ color: "#1A1A1A", fontSize: 15.5, lineHeight: 23 }}>{contentText}</Text>
+        <Text style={{ color: tokens.primaryForeground, fontSize: 15.5, lineHeight: 23 }}>
+          {contentText}
+        </Text>
       ) : (
-        <>
-          <ChatMarkdown streaming={message.id.startsWith("progress:")}>{contentText}</ChatMarkdown>
-          {onSpeak ? (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={t("Speak message")}
-              onPress={onSpeak}
-              hitSlop={8}
-              style={{ marginTop: 8 }}
-            >
-              <Text style={{ color: "#85858A", fontSize: 13 }}>{t("Speak")}</Text>
-            </Pressable>
-          ) : null}
-        </>
+        <ChatMarkdown
+          palette={tokens}
+          colorScheme={colorScheme}
+          streaming={message.id.startsWith("progress:")}
+        >
+          {contentText}
+        </ChatMarkdown>
       )}
-    </View>
+    </Pressable>
   );
 }
 
@@ -2514,6 +2704,8 @@ function AgentEventLabel({
   expanded: boolean;
   onToggle: () => void;
 }) {
+  const colorScheme = useResolvedAppearance();
+  const tokens = mobileTokens();
   const { t } = useI18n();
   return (
     <Pressable
@@ -2522,7 +2714,9 @@ function AgentEventLabel({
       accessibilityLabel={expanded ? t("Hide {label}", { label }) : t("Show {label}", { label })}
       style={{ width: "100%", paddingVertical: 4, alignItems: "center" }}
     >
-      <Text style={{ color: "#85858A", fontSize: 13.5, textAlign: "center" }}>↔ {label}</Text>
+      <Text style={{ color: tokens.mutedForeground, fontSize: 13.5, textAlign: "center" }}>
+        ↔ {label}
+      </Text>
       {expanded && detail ? (
         <View
           style={{
@@ -2530,13 +2724,15 @@ function AgentEventLabel({
             marginTop: 6,
             borderRadius: 14,
             borderWidth: 1,
-            borderColor: "#26262A",
-            backgroundColor: "#101012",
+            borderColor: tokens.border,
+            backgroundColor: tokens.card,
             paddingHorizontal: 14,
             paddingVertical: 10,
           }}
         >
-          <ChatMarkdown>{detail}</ChatMarkdown>
+          <ChatMarkdown palette={tokens} colorScheme={colorScheme}>
+            {detail}
+          </ChatMarkdown>
         </View>
       ) : null}
     </Pressable>
@@ -2552,6 +2748,7 @@ function AskBlock({
   canAnswer: boolean;
   onAnswer: (answer: string) => Promise<void>;
 }) {
+  const tokens = useMobileTokens();
   const { t } = useI18n();
   const [answer, setAnswer] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -2580,17 +2777,21 @@ function AskBlock({
         width: "90%",
         borderRadius: 18,
         borderWidth: 1,
-        borderColor: "#2D2D31",
-        backgroundColor: "#17171A",
+        borderColor: tokens.border,
+        backgroundColor: tokens.card,
         paddingHorizontal: 16,
         paddingVertical: 14,
         gap: 10,
       }}
     >
-      <Text style={{ color: "#ECECEE", fontSize: 15.5, fontWeight: "600" }}>{ask.text}</Text>
-      {ask.detail ? <Text style={{ color: "#85858A", fontSize: 13.5 }}>{ask.detail}</Text> : null}
+      <Text style={{ color: tokens.foreground, fontSize: 15.5, fontWeight: "600" }}>
+        {ask.text}
+      </Text>
+      {ask.detail ? (
+        <Text style={{ color: tokens.mutedForeground, fontSize: 13.5 }}>{ask.detail}</Text>
+      ) : null}
       {answered ? (
-        <Text style={{ color: "#4ECB71", fontSize: 14 }}>
+        <Text style={{ color: tokens.success, fontSize: 14 }}>
           {secretInput
             ? t("Submitted")
             : t("Answered: {answer}", { answer: ask.answer ?? t("Done") })}
@@ -2602,7 +2803,7 @@ function AskBlock({
             value={answer}
             onChangeText={setAnswer}
             placeholder={secretInput ? t("Code") : t("Type your answer")}
-            placeholderTextColor="#6C6C70"
+            placeholderTextColor={tokens.mutedForeground}
             secureTextEntry={secretInput}
             autoComplete="off"
             onSubmitEditing={() => void submit()}
@@ -2610,8 +2811,8 @@ function AskBlock({
               minHeight: 42,
               borderRadius: 12,
               borderWidth: 1,
-              borderColor: "#35353A",
-              color: "#ECECEE",
+              borderColor: tokens.border,
+              color: tokens.foreground,
               paddingHorizontal: 12,
               paddingVertical: 9,
             }}
@@ -2624,23 +2825,23 @@ function AskBlock({
             style={{
               alignSelf: "flex-end",
               borderRadius: 999,
-              backgroundColor: "#ECECEE",
+              backgroundColor: tokens.foreground,
               opacity: (secretInput ? answer.length === 0 : !answer.trim()) || submitting ? 0.5 : 1,
               paddingHorizontal: 16,
               paddingVertical: 9,
             }}
           >
-            <Text style={{ color: "#17171A", fontWeight: "600" }}>
+            <Text style={{ color: tokens.primaryForeground, fontWeight: "600" }}>
               {submitting ? t("Sending…") : t("Send answer")}
             </Text>
           </Pressable>
         </>
       ) : (
-        <Text style={{ color: "#85858A", fontSize: 13.5 }}>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 13.5 }}>
           {t("Waiting for this bot’s response.")}
         </Text>
       )}
-      {error ? <Text style={{ color: "#EF4444", fontSize: 13 }}>{error}</Text> : null}
+      {error ? <Text style={{ color: tokens.destructive, fontSize: 13 }}>{error}</Text> : null}
     </View>
   );
 }

--- a/apps/mobile/app/voice.tsx
+++ b/apps/mobile/app/voice.tsx
@@ -125,7 +125,6 @@ export default function VoiceSettings() {
       if (!ready) {
         throw new Error(t("Connect a voice provider first."));
       }
-      setNotice(t("If you heard that, voice is ready."));
     } catch (err) {
       setError(err instanceof Error ? err.message : t("Could not play a sample"));
     } finally {
@@ -136,14 +135,9 @@ export default function VoiceSettings() {
   return (
     <SafeAreaView edges={["bottom"]} style={styles.screen}>
       <ScrollView contentContainerStyle={styles.content}>
-        {loading ? <ActivityIndicator color="#ECECEE" /> : null}
+        {loading ? <ActivityIndicator color={native.secondaryLabel} /> : null}
         {error ? <Text style={styles.error}>{error}</Text> : null}
         {notice ? <Text style={styles.notice}>{notice}</Text> : null}
-        <Text style={styles.lede}>
-          {t(
-            "Bring your own key. ElevenLabs, OpenAI, and Cartesia all plug into the same speak buttons.",
-          )}
-        </Text>
         {catalog.map((entry) => {
           const connected = credentials.some((cred) => cred.provider === entry.id);
           return (
@@ -168,7 +162,6 @@ export default function VoiceSettings() {
         })}
         {selected ? (
           <>
-            <Text style={styles.help}>{selected.description}</Text>
             <TextInput
               accessibilityLabel={t("API key")}
               autoCapitalize="none"
@@ -178,7 +171,7 @@ export default function VoiceSettings() {
               value={apiKey}
               onChangeText={setApiKey}
               placeholder={credential ? t("Paste a replacement key") : t("Paste your API key")}
-              placeholderTextColor="#6C6C70"
+              placeholderTextColor={native.tertiaryLabel}
               secureTextEntry
               style={styles.input}
               textContentType="none"
@@ -225,7 +218,6 @@ function createVoiceStyles() {
   return StyleSheet.create({
     screen: { flex: 1, backgroundColor: native.page },
     content: { padding: 20, gap: 10 },
-    lede: { color: native.secondaryLabel, fontSize: 14, lineHeight: 20, marginBottom: 8 },
     error: { color: tokens.destructive, marginBottom: 8 },
     notice: { color: tokens.success, marginBottom: 8 },
     card: {
@@ -238,7 +230,6 @@ function createVoiceStyles() {
     cardActive: { borderColor: tokens.ring, backgroundColor: tokens.muted },
     cardTitle: { color: native.label, fontSize: 16 },
     cardMeta: { color: native.tertiaryLabel, marginTop: 4, fontSize: 12 },
-    help: { color: native.secondaryLabel, fontSize: 13.5, lineHeight: 20, marginTop: 8 },
     input: {
       marginTop: 8,
       borderRadius: 12,

--- a/apps/mobile/components/AppConnectCard.tsx
+++ b/apps/mobile/components/AppConnectCard.tsx
@@ -5,7 +5,7 @@ import { ActivityIndicator, Linking, Pressable, Text, View } from "react-native"
 import { rpc } from "../lib/api";
 import { appConnectPresentation } from "../lib/app-connect";
 import { useI18n } from "../lib/i18n";
-import { native } from "../lib/native";
+import { native, useMobileTokens } from "../lib/native";
 
 export function AppConnectCard({
   botId,
@@ -15,6 +15,7 @@ export function AppConnectCard({
   block: Extract<MessageBlock, { kind: "app_connect" }>;
 }) {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const [busy, setBusy] = useState(false);
   const [localStatus, setLocalStatus] = useState<"pending" | "connected">(block.status);
   const [error, setError] = useState<string | null>(null);
@@ -77,8 +78,8 @@ export function AppConnectCard({
         width: "90%",
         borderRadius: 18,
         borderWidth: 1,
-        borderColor: "#232326",
-        backgroundColor: "#17171A",
+        borderColor: tokens.border,
+        backgroundColor: tokens.card,
         paddingHorizontal: 16,
         paddingVertical: 14,
         gap: 8,
@@ -90,18 +91,20 @@ export function AppConnectCard({
             width: 40,
             height: 40,
             borderRadius: 10,
-            backgroundColor: "#30356A",
+            backgroundColor: tokens.muted,
             alignItems: "center",
             justifyContent: "center",
           }}
         >
-          <Text style={{ color: "#E2E4FF", fontSize: 15, fontWeight: "600" }}>
+          <Text style={{ color: tokens.foreground, fontSize: 15, fontWeight: "600" }}>
             {block.name.slice(0, 1).toUpperCase()}
           </Text>
         </View>
         <View style={{ flex: 1, gap: 2 }}>
-          <Text style={{ color: "#ECECEE", fontSize: 15, fontWeight: "600" }}>{view.title}</Text>
-          <Text style={{ color: "#85858A", fontSize: 13.5 }} numberOfLines={2}>
+          <Text style={{ color: tokens.foreground, fontSize: 15, fontWeight: "600" }}>
+            {view.title}
+          </Text>
+          <Text style={{ color: tokens.mutedForeground, fontSize: 13.5 }} numberOfLines={2}>
             {view.description}
           </Text>
         </View>
@@ -129,12 +132,12 @@ export function AppConnectCard({
             )}
           </Pressable>
         ) : (
-          <Text style={{ color: "#4ECB71", fontSize: 13.5, fontWeight: "600" }}>
+          <Text style={{ color: tokens.success, fontSize: 13.5, fontWeight: "600" }}>
             {view.actionLabel}
           </Text>
         )}
       </View>
-      {error ? <Text style={{ color: "#E96B6B", fontSize: 13 }}>{error}</Text> : null}
+      {error ? <Text style={{ color: tokens.destructive, fontSize: 13 }}>{error}</Text> : null}
     </View>
   );
 }

--- a/apps/mobile/components/bot-member-picker.tsx
+++ b/apps/mobile/components/bot-member-picker.tsx
@@ -1,0 +1,44 @@
+import { GROUP_MEMBER_MAX } from "@rakazo/contracts";
+import { StyleSheet, Switch, Text, View } from "react-native";
+import type { MobileBot } from "../lib/api";
+import { useMobileTokens } from "../lib/native";
+import { BotAvatar } from "./bot-avatar";
+
+export function BotMemberPicker({
+  bots,
+  selected,
+  onChange,
+  disabled = false,
+}: {
+  bots: MobileBot[];
+  selected: string[];
+  onChange: (botIds: string[]) => void;
+  disabled?: boolean;
+}) {
+  const tokens = useMobileTokens();
+  return bots.map((bot) => {
+    const checked = selected.includes(bot.id);
+    return (
+      <View key={bot.id} style={styles.row}>
+        <BotAvatar color={bot.color} identity={bot.id} size={34} status={bot.status} />
+        <Text style={[styles.name, { color: tokens.foreground }]}>{bot.name}</Text>
+        <Switch
+          accessibilityLabel={bot.name}
+          value={checked}
+          disabled={disabled || (!checked && selected.length >= GROUP_MEMBER_MAX)}
+          trackColor={{ false: tokens.border, true: tokens.primary }}
+          thumbColor={checked ? tokens.primaryForeground : tokens.foreground}
+          onValueChange={(next) => {
+            if (next && selected.length >= GROUP_MEMBER_MAX) return;
+            onChange(next ? [...selected, bot.id] : selected.filter((id) => id !== bot.id));
+          }}
+        />
+      </View>
+    );
+  });
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 12 },
+  name: { flex: 1, fontSize: 16 },
+});

--- a/apps/mobile/components/computer-maintenance-actions.tsx
+++ b/apps/mobile/components/computer-maintenance-actions.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Alert, Pressable, Text, View } from "react-native";
 import { rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
+import { useMobileTokens } from "../lib/native";
 
 type Action = "recover" | "reset" | "update";
 
@@ -16,6 +17,7 @@ export function ComputerMaintenanceActions({
   onChanged: () => Promise<void>;
 }) {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   const [pending, setPending] = useState<Action | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,7 +58,7 @@ export function ComputerMaintenanceActions({
         onPress={() => void run("recover")}
         style={{ opacity: busy || pending !== null ? 0.4 : 1 }}
       >
-        <Text style={{ color: "#85858A", fontSize: 14 }}>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>
           {pending === "recover" ? t("Recovering…") : t("Recover computer")}
         </Text>
       </Pressable>
@@ -65,7 +67,7 @@ export function ComputerMaintenanceActions({
         onPress={confirmReset}
         style={{ opacity: busy || pending !== null ? 0.4 : 1 }}
       >
-        <Text style={{ color: "#85858A", fontSize: 14 }}>
+        <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>
           {pending === "reset" ? t("Resetting…") : t("Reset computer")}
         </Text>
       </Pressable>
@@ -75,12 +77,12 @@ export function ComputerMaintenanceActions({
           onPress={() => void run("update")}
           style={{ opacity: busy || pending !== null ? 0.4 : 1 }}
         >
-          <Text style={{ color: "#85858A", fontSize: 14 }}>
+          <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>
             {pending === "update" ? t("Updating…") : t("Update computer")}
           </Text>
         </Pressable>
       ) : null}
-      {error ? <Text style={{ color: "#EF4444", fontSize: 13 }}>{error}</Text> : null}
+      {error ? <Text style={{ color: tokens.destructive, fontSize: 13 }}>{error}</Text> : null}
     </View>
   );
 }

--- a/apps/mobile/components/computer-mode-picker.tsx
+++ b/apps/mobile/components/computer-mode-picker.tsx
@@ -1,6 +1,7 @@
 import type { ComputerMode } from "@rakazo/contracts";
 import { Pressable, Text, View } from "react-native";
 import { useI18n } from "../lib/i18n";
+import { useMobileTokens } from "../lib/native";
 
 export function ComputerModePicker({
   value,
@@ -12,9 +13,12 @@ export function ComputerModePicker({
   disabled?: boolean;
 }) {
   const { t } = useI18n();
+  const tokens = useMobileTokens();
   return (
     <View style={{ marginTop: 16 }}>
-      <Text style={{ color: "#85858A", marginBottom: 8, fontSize: 14 }}>{t("Computer")}</Text>
+      <Text style={{ color: tokens.mutedForeground, marginBottom: 8, fontSize: 14 }}>
+        {t("Computer")}
+      </Text>
       <View style={{ flexDirection: "row", gap: 8 }}>
         {(["team", "dedicated"] as const).map((mode) => (
           <Pressable
@@ -27,14 +31,14 @@ export function ComputerModePicker({
               flex: 1,
               alignItems: "center",
               borderWidth: 1,
-              borderColor: value === mode ? "#6C6C70" : "#26262A",
-              backgroundColor: value === mode ? "#1A1A1D" : "transparent",
+              borderColor: value === mode ? tokens.mutedForeground : tokens.border,
+              backgroundColor: value === mode ? tokens.muted : "transparent",
               borderRadius: 11,
               paddingVertical: 12,
               opacity: disabled ? 0.5 : 1,
             }}
           >
-            <Text style={{ color: value === mode ? "#ECECEE" : "#85858A" }}>
+            <Text style={{ color: value === mode ? tokens.foreground : tokens.mutedForeground }}>
               {mode === "team" ? t("Team") : t("Private")}
             </Text>
           </Pressable>

--- a/apps/mobile/components/connector-icon.tsx
+++ b/apps/mobile/components/connector-icon.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { Image, StyleSheet, Text, View } from "react-native";
+import { SvgUri } from "react-native-svg";
+import { native, useThemedStyles } from "../lib/native";
+
+/** Use the catalog artwork, matching web, with a local fallback for missing logos. */
+export function ConnectorIcon({ name, logo }: { name: string; logo?: string | null }) {
+  const styles = useThemedStyles(createStyles);
+  const [failedLogo, setFailedLogo] = useState<string | null>(null);
+  const uri = logo && logo !== failedLogo ? logo : null;
+  return (
+    <View
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      style={styles.frame}
+    >
+      {uri ? (
+        /\.svg(?:[?#]|$)/i.test(uri) ? (
+          <SvgUri uri={uri} width={28} height={28} onError={() => setFailedLogo(uri)} />
+        ) : (
+          <Image
+            source={{ uri }}
+            resizeMode="contain"
+            onError={() => setFailedLogo(uri)}
+            style={styles.image}
+          />
+        )
+      ) : (
+        <Text style={styles.letter}>{name[0]}</Text>
+      )}
+    </View>
+  );
+}
+
+function createStyles() {
+  return StyleSheet.create({
+    frame: {
+      width: 36,
+      height: 36,
+      borderRadius: 10,
+      backgroundColor: native.fillPressed,
+      alignItems: "center",
+      justifyContent: "center",
+      overflow: "hidden",
+    },
+    image: { width: 28, height: 28 },
+    letter: { color: native.label, fontSize: 16, fontWeight: "600" },
+  });
+}

--- a/apps/mobile/components/markdown-artifact-preview.tsx
+++ b/apps/mobile/components/markdown-artifact-preview.tsx
@@ -1,12 +1,14 @@
 import { ChatMarkdown } from "@rakazo/chat-ui/native";
 import { useEffect, useState } from "react";
 import { Alert, Modal, Pressable, SafeAreaView, ScrollView, Text, View } from "react-native";
+import { mobileTokens } from "../lib/appearance";
 import {
   type MobileArtifactTarget,
   openMobileArtifact,
   readMobileArtifactText,
 } from "../lib/artifact-open";
 import { useI18n } from "../lib/i18n";
+import { useResolvedAppearance } from "../lib/native";
 import { NativeSymbol } from "./native-symbol";
 
 export type MarkdownArtifactPreviewTarget = {
@@ -25,6 +27,8 @@ export function MarkdownArtifactPreview({
   onClose: () => void;
 }) {
   const { t } = useI18n();
+  const colorScheme = useResolvedAppearance();
+  const tokens = mobileTokens();
   const [state, setState] = useState<
     | { status: "loading" }
     | { status: "ready"; markdown: string }
@@ -55,20 +59,20 @@ export function MarkdownArtifactPreview({
 
   return (
     <Modal animationType="fade" presentationStyle="fullScreen" onRequestClose={onClose}>
-      <SafeAreaView style={{ flex: 1, backgroundColor: "#0D0D0F" }}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: tokens.background }}>
         <View
           style={{
             height: 54,
             flexDirection: "row",
             alignItems: "center",
             borderBottomWidth: 1,
-            borderBottomColor: "#27272B",
+            borderBottomColor: tokens.border,
             paddingHorizontal: 12,
           }}
         >
           <Text
             numberOfLines={1}
-            style={{ flex: 1, color: "#E7E7E9", fontSize: 15, fontWeight: "500" }}
+            style={{ flex: 1, color: tokens.foreground, fontSize: 15, fontWeight: "500" }}
           >
             {target.name}
           </Text>
@@ -94,7 +98,7 @@ export function MarkdownArtifactPreview({
               ios="square.and.arrow.up"
               android="share-social-outline"
               size={19}
-              color="#A8A8AD"
+              color={tokens.mutedForeground}
             />
           </Pressable>
           <Pressable
@@ -103,26 +107,30 @@ export function MarkdownArtifactPreview({
             onPress={onClose}
             style={{ padding: 10 }}
           >
-            <NativeSymbol ios="xmark" android="close" size={19} color="#A8A8AD" />
+            <NativeSymbol ios="xmark" android="close" size={19} color={tokens.mutedForeground} />
           </Pressable>
         </View>
         <ScrollView contentContainerStyle={{ paddingHorizontal: 24, paddingVertical: 28 }}>
           {state.status === "loading" ? (
-            <Text style={{ color: "#85858A", fontSize: 15 }}>{t("Loading preview…")}</Text>
+            <Text style={{ color: tokens.mutedForeground, fontSize: 15 }}>
+              {t("Loading preview…")}
+            </Text>
           ) : state.status === "error" ? (
             <View
               style={{
                 borderRadius: 14,
                 borderWidth: 1,
-                borderColor: "#5A2A2A",
-                backgroundColor: "#2A1717",
+                borderColor: tokens.destructive,
+                backgroundColor: tokens.card,
                 padding: 14,
               }}
             >
-              <Text style={{ color: "#FCA5A5", fontSize: 15 }}>{state.message}</Text>
+              <Text style={{ color: tokens.destructive, fontSize: 15 }}>{state.message}</Text>
             </View>
           ) : (
-            <ChatMarkdown>{state.markdown}</ChatMarkdown>
+            <ChatMarkdown palette={tokens} colorScheme={colorScheme}>
+              {state.markdown}
+            </ChatMarkdown>
           )}
         </ScrollView>
       </SafeAreaView>

--- a/apps/mobile/components/native-symbol.tsx
+++ b/apps/mobile/components/native-symbol.tsx
@@ -1,26 +1,30 @@
 import Ionicons from "@react-native-vector-icons/ionicons";
 import { SymbolView } from "expo-symbols";
 import type { ComponentProps } from "react";
+import type { ColorValue } from "react-native";
+import { useMobileTokens } from "../lib/native";
 
 export function NativeSymbol({
   ios,
   android,
   size = 18,
-  color = "#fff",
+  color,
 }: {
   ios: string;
   android: ComponentProps<typeof Ionicons>["name"];
   size?: number;
-  color?: string;
+  color?: ColorValue;
 }) {
+  const tokens = useMobileTokens();
+  const tint = color ?? tokens.foreground;
   return (
     <SymbolView
       name={ios as never}
       size={size}
-      tintColor={color}
+      tintColor={tint}
       weight="medium"
       resizeMode="scaleAspectFit"
-      fallback={<Ionicons name={android} size={size} color={color} />}
+      fallback={<Ionicons name={android} size={size} color={tint} />}
     />
   );
 }

--- a/apps/mobile/e2e/README.md
+++ b/apps/mobile/e2e/README.md
@@ -37,5 +37,5 @@ local session and endpoint data; it does not delete server-side bots.
 ## Screenshot catalog
 
 Run **Actions → mobile Android screenshots → Run workflow** to build the app, seed an isolated fake
-workspace, capture 21 Android emulator views, and upload the screenshots and Maestro report for
+workspace, capture light and dark Android emulator views, and upload the screenshots and Maestro report for
 seven days. It uses no repository secrets or hosted providers.

--- a/apps/mobile/lib/appearance.test.ts
+++ b/apps/mobile/lib/appearance.test.ts
@@ -45,6 +45,21 @@ describe("mobile appearance", () => {
     await setAppearancePreference("system");
   });
 
+  it("notifies mounted navigation when the saved preference loads", async () => {
+    const { UI_APPEARANCE_STORAGE_KEY, lightTokens } = await import("@rakazo/ui-tokens");
+    const { loadAppearancePreference, mobileTokens, subscribeAppearance } = await import(
+      "./appearance"
+    );
+    store.set(UI_APPEARANCE_STORAGE_KEY, "light");
+    const listener = vi.fn();
+    subscribeAppearance(listener);
+
+    await loadAppearancePreference();
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(mobileTokens()).toEqual(lightTokens);
+  });
+
   it("notifies subscribers when the OS scheme flips under System preference", async () => {
     const { resolveMobileAppearance, subscribeAppearance } = await import("./appearance");
     const listener = vi.fn();

--- a/apps/mobile/lib/appearance.ts
+++ b/apps/mobile/lib/appearance.ts
@@ -29,6 +29,7 @@ export async function loadAppearancePreference(): Promise<AppearancePreference> 
   } catch {
     memoryPreference = memoryPreference ?? "system";
   }
+  notify();
   return memoryPreference;
 }
 

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -220,6 +220,8 @@ export const ZH_MESSAGES: Record<string, string> = {
   "Loading…": "正在加载…",
   "Long press to pin or move to a section": "长按可置顶或移动到分组",
   "Long press to pin, move, or silence notifications": "长按可置顶、移动或静音通知",
+  "Enter your Rakazo server address.": "输入你的 Rakazo 服务器地址。",
+  "Show less": "收起",
   Members: "成员",
   "Members ({min}–{max})": "成员（{min}–{max}）",
   "Message…": "发消息…",

--- a/apps/mobile/lib/native.ts
+++ b/apps/mobile/lib/native.ts
@@ -1,3 +1,4 @@
+import { tokensForAppearance } from "@rakazo/ui-tokens";
 import { useMemo, useSyncExternalStore } from "react";
 import { type ColorValue, Platform, PlatformColor } from "react-native";
 import {
@@ -8,12 +9,12 @@ import {
   subscribeAppearance,
 } from "./appearance";
 
-function systemColor(iosName: string, lightFallback: string, darkFallback: string): ColorValue {
+function systemColor(iosName: string, fallback: string): ColorValue {
   // PlatformColor follows the OS scheme, not an explicit app Light/Dark choice.
   if (Platform.OS === "ios" && getCachedAppearancePreference() === "system") {
     return PlatformColor(iosName);
   }
-  return resolveMobileAppearance() === "light" ? lightFallback : darkFallback;
+  return fallback;
 }
 
 /** Theme-aware native colors backed by shared tokens (+ iOS platform colors in System). */
@@ -22,30 +23,41 @@ export const native = {
     return mobileTokens().background;
   },
   get fill() {
-    return systemColor("tertiarySystemFill", mobileTokens().muted, "#1C1C1E");
+    return systemColor("tertiarySystemFill", mobileTokens().muted);
   },
   get fillPressed() {
-    return systemColor("secondarySystemFill", mobileTokens().accent, "#2C2C2E");
+    return systemColor("secondarySystemFill", mobileTokens().accent);
   },
   get label() {
-    return systemColor("label", mobileTokens().foreground, "#FFFFFF");
+    return systemColor("label", mobileTokens().foreground);
   },
   get secondaryLabel() {
-    return systemColor("secondaryLabel", mobileTokens().mutedForeground, "#8E8E93");
+    return systemColor("secondaryLabel", mobileTokens().mutedForeground);
   },
   get tertiaryLabel() {
-    return systemColor("tertiaryLabel", mobileTokens().mutedForeground, "#6C6C70");
+    return systemColor("tertiaryLabel", mobileTokens().mutedForeground);
   },
 } as const;
 
-export function useResolvedAppearance(): ResolvedAppearance {
-  // Snapshot the resolved light/dark value, not the preference. Preference stays
-  // "system" across OS scheme flips, so a preference snapshot would skip rerenders.
-  return useSyncExternalStore(subscribeAppearance, resolveMobileAppearance, () => "dark" as const);
+function appearanceSnapshot(): string {
+  return `${getCachedAppearancePreference()}:${resolveMobileAppearance()}`;
 }
 
-/** Rebuild styles when the resolved appearance changes (avoids frozen StyleSheet snapshots). */
+export function useResolvedAppearance(): ResolvedAppearance {
+  // Include the preference: System -> Light must replace iOS PlatformColor
+  // objects even when both currently resolve to light.
+  useSyncExternalStore(subscribeAppearance, appearanceSnapshot, () => "system:dark");
+  return resolveMobileAppearance();
+}
+
+/** Rebuild styles for palette changes and switches to/from iOS system colors. */
 export function useThemedStyles<T>(factory: () => T): T {
   const resolved = useResolvedAppearance();
-  return useMemo(factory, [resolved]);
+  const preference = getCachedAppearancePreference();
+  return useMemo(factory, [resolved, preference]);
+}
+
+/** Subscribe custom surfaces to the same appearance as native navigation. */
+export function useMobileTokens() {
+  return tokensForAppearance(useResolvedAppearance());
 }

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -4,16 +4,13 @@ import {
   openAiCompatibleConnectReady,
   openAiCompatibleProbeSuccessMessage,
 } from "@rakazo/contracts";
+import { featuredModelProviders, selectedProviderOutsideSearchResults } from "@rakazo/core";
 import { Button, Input, NativeSelect, NativeSelectOption, Textarea } from "@rakazo/ui-web";
 import { Check } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { localizedProviderHint } from "../lib/localized-provider-hint";
 import type { ModelCatalogEntry } from "../lib/model-auth";
-import {
-  featuredModelProviders,
-  selectedProviderOutsideSearchResults,
-} from "../lib/onboarding-providers";
 import { rpc } from "../lib/rpc";
 import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run --root ../.. packages/chat-ui/src"
   },
   "dependencies": {
+    "@rakazo/ui-tokens": "workspace:*",
     "@ronradtke/react-native-markdown-display": "^9.0.3",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"

--- a/packages/chat-ui/src/markdown.native.tsx
+++ b/packages/chat-ui/src/markdown.native.tsx
@@ -1,103 +1,106 @@
+import { type ColorTokens, darkTokens, type ResolvedAppearance } from "@rakazo/ui-tokens";
 import Markdown, {
   MarkdownStream,
   type RenderRules,
 } from "@ronradtke/react-native-markdown-display";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { Linking, StyleSheet, Text, View } from "react-native";
 import type { ChatMarkdownProps } from "./markdown";
 import { sanitizeMarkdownUrl } from "./markdown";
 
-const styles = StyleSheet.create({
-  body: {
-    color: "#DFDFE2",
-    fontSize: 15.5,
-    lineHeight: 23,
-    width: "100%",
-    minWidth: 0,
-    flexShrink: 1,
-  },
-  paragraph: {
-    marginTop: 0,
-    marginBottom: 9,
-    width: "100%",
-    flexShrink: 1,
-  },
-  heading1: {
-    color: "#F3F3F4",
-    fontSize: 21,
-    lineHeight: 27,
-    marginTop: 10,
-    marginBottom: 5,
-  },
-  heading2: {
-    color: "#F3F3F4",
-    fontSize: 19,
-    lineHeight: 25,
-    marginTop: 10,
-    marginBottom: 5,
-  },
-  heading3: {
-    color: "#F3F3F4",
-    fontSize: 17,
-    lineHeight: 23,
-    marginTop: 8,
-    marginBottom: 4,
-  },
-  strong: {
-    color: "#F3F3F4",
-    fontWeight: "700",
-  },
-  link: {
-    color: "#86B7FF",
-    textDecorationLine: "underline",
-    marginBottom: 0,
-  },
-  code_inline: {
-    color: "#ECECEE",
-    backgroundColor: "#101012",
-    borderColor: "#34343A",
-    borderWidth: StyleSheet.hairlineWidth,
-    padding: 0,
-    paddingHorizontal: 4,
-    paddingVertical: 1,
-    borderRadius: 4,
-  },
-  code_block: {
-    color: "#ECECEE",
-    backgroundColor: "#0E0E10",
-    borderColor: "#2D2D32",
-  },
-  fence: {
-    backgroundColor: "#0E0E10",
-    borderColor: "#2D2D32",
-  },
-  fence_code: {
-    backgroundColor: "#0E0E10",
-  },
-  blockquote: {
-    backgroundColor: "transparent",
-    borderLeftColor: "#55555C",
-  },
-  table: {
-    borderColor: "#34343A",
-  },
-  tr: {
-    borderColor: "#34343A",
-  },
-  hr: {
-    backgroundColor: "#34343A",
-  },
-  bullet_list_content: {
-    flex: 1,
-    flexShrink: 1,
-    minWidth: 0,
-  },
-  ordered_list_content: {
-    flex: 1,
-    flexShrink: 1,
-    minWidth: 0,
-  },
-});
+function markdownStyles(palette: ColorTokens) {
+  return StyleSheet.create({
+    body: {
+      color: palette.foreground,
+      fontSize: 15.5,
+      lineHeight: 23,
+      width: "100%",
+      minWidth: 0,
+      flexShrink: 1,
+    },
+    paragraph: {
+      marginTop: 0,
+      marginBottom: 9,
+      width: "100%",
+      flexShrink: 1,
+    },
+    heading1: {
+      color: palette.foreground,
+      fontSize: 21,
+      lineHeight: 27,
+      marginTop: 10,
+      marginBottom: 5,
+    },
+    heading2: {
+      color: palette.foreground,
+      fontSize: 19,
+      lineHeight: 25,
+      marginTop: 10,
+      marginBottom: 5,
+    },
+    heading3: {
+      color: palette.foreground,
+      fontSize: 17,
+      lineHeight: 23,
+      marginTop: 8,
+      marginBottom: 4,
+    },
+    strong: {
+      color: palette.foreground,
+      fontWeight: "700",
+    },
+    link: {
+      color: palette.link,
+      textDecorationLine: "underline",
+      marginBottom: 0,
+    },
+    code_inline: {
+      color: palette.foreground,
+      backgroundColor: palette.background,
+      borderColor: palette.border,
+      borderWidth: StyleSheet.hairlineWidth,
+      padding: 0,
+      paddingHorizontal: 4,
+      paddingVertical: 1,
+      borderRadius: 4,
+    },
+    code_block: {
+      color: palette.foreground,
+      backgroundColor: palette.background,
+      borderColor: palette.border,
+    },
+    fence: {
+      backgroundColor: palette.background,
+      borderColor: palette.border,
+    },
+    fence_code: {
+      backgroundColor: palette.background,
+    },
+    blockquote: {
+      backgroundColor: "transparent",
+      borderLeftColor: palette.border,
+    },
+    table: {
+      borderColor: palette.border,
+    },
+    tr: {
+      borderColor: palette.border,
+    },
+    hr: {
+      backgroundColor: palette.border,
+    },
+    bullet_list_content: {
+      flex: 1,
+      flexShrink: 1,
+      minWidth: 0,
+    },
+    ordered_list_content: {
+      flex: 1,
+      flexShrink: 1,
+      minWidth: 0,
+    },
+  });
+}
 
 async function openSafeLink(url: string) {
   const safeUrl = sanitizeMarkdownUrl(url);
@@ -125,9 +128,12 @@ const renderRules: RenderRules = {
 export const ChatMarkdown = memo(function ChatMarkdown({
   children,
   streaming = false,
-}: ChatMarkdownProps) {
+  palette = darkTokens,
+  colorScheme = "dark",
+}: ChatMarkdownProps & { palette?: ColorTokens; colorScheme?: ResolvedAppearance }) {
+  const styles = useMemo(() => markdownStyles(palette), [palette]);
   const sharedProps = {
-    colorScheme: "dark" as const,
+    colorScheme,
     style: styles,
     rules: renderRules,
     allowedImageHandlers: ["https://", "http://"],
@@ -140,7 +146,7 @@ export const ChatMarkdown = memo(function ChatMarkdown({
   return (
     <View style={layout.wrap}>
       {streaming ? (
-        <MarkdownStream {...sharedProps} cursorColor="#85858A" streaming>
+        <MarkdownStream {...sharedProps} cursorColor={palette.mutedForeground} streaming>
           {children}
         </MarkdownStream>
       ) : (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from "./message-visibility.js";
 export * from "./messaging-commands.js";
 export * from "./messaging-prompts.js";
 export * from "./model-oauth.js";
+export * from "./model-providers.js";
 export * from "./run-state.js";
 export * from "./sandbox-command.js";
 export * from "./screen-lease.js";

--- a/packages/core/src/model-providers.test.ts
+++ b/packages/core/src/model-providers.test.ts
@@ -1,9 +1,6 @@
 import type { ModelCatalogEntry } from "@rakazo/contracts";
 import { describe, expect, it } from "vitest";
-import {
-  featuredModelProviders,
-  selectedProviderOutsideSearchResults,
-} from "./onboarding-providers";
+import { featuredModelProviders, selectedProviderOutsideSearchResults } from "./model-providers.js";
 
 function provider(provider: string): ModelCatalogEntry {
   return {

--- a/packages/core/src/model-providers.ts
+++ b/packages/core/src/model-providers.ts
@@ -12,7 +12,7 @@ export const POPULAR_MODEL_PROVIDER_IDS = [
 const DEFAULT_PROVIDER_COUNT = POPULAR_MODEL_PROVIDER_IDS.length;
 const POPULAR_MODEL_PROVIDER_ID_SET = new Set<string>(POPULAR_MODEL_PROVIDER_IDS);
 
-/** Keep onboarding short while ensuring a deployment's current default is never hidden. */
+/** Keep provider selection short while ensuring a deployment's current default is never hidden. */
 export function featuredModelProviders(
   providers: readonly ModelCatalogEntry[],
   selectedProvider: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,6 +637,9 @@ importers:
 
   packages/chat-ui:
     dependencies:
+      '@rakazo/ui-tokens':
+        specifier: workspace:*
+        version: link:../ui-tokens
       '@ronradtke/react-native-markdown-display':
         specifier: ^9.0.3
         version: 9.0.3(@expo/config-plugins@57.0.9(typescript@6.0.3))(react-native@0.86.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.2(@babel/core@7.29.7))(@types/react@19.2.18)(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
Mobile screens mixed fixed dark colors with light navigation, hid icons against pale buttons, clipped search text, and kept secondary controls on the main screens.

This change uses the shared appearance palette across forms, threads, markdown, computer views, and settings; fixes password-link and Cancel spacing; and reuses one inbox/activity row layout. Password changes open a native sheet, providers start with the same popular choices as web, integrations render catalog icons, and group selection uses native switches. Computer access moves into the thread menu, message speech moves to long-press/accessibility actions, and redundant voice, member-count, and teaching copy is removed.

Copy: “Enter your Rakazo server address.” replaces the technical server explanation and appears only after opening custom-server settings, where the address needs identification. “Show more” and “Show less” reveal/collapse the provider catalog; these controls are needed to keep the initial list short while leaving every provider reachable. Other labels are reused or moved into the relevant sheet/menu.

Validation: 565 mobile and shared-package tests passed; repository lint and full typechecking passed. Android screenshot coverage now includes the password sheet, expanded providers, dark creation/thread screens, and switching back to light mode. The iOS sheet and action sheet are native-only and are not captured by the Android CI workflow; no unrelated web screenshot is substituted. The [Android screenshot workflow](https://github.com/elie222/rakazo/actions/runs/33970181602) passed and all 31 captures were visually reviewed.

[Download the CI Android screenshots](https://github.com/elie222/rakazo/actions/runs/33970181602/artifacts/9970754820). Key frames: `06-search-results.png`, `07-new-bot.png`, `10b-change-password.png`, `11-models.png`, `15-thread.png`, `16-bot-actions.png`, `20-group-settings.png`, `26-thread-dark.png`, and `29-thread-light-restored.png`. Integration fixtures omit logo URLs, so their screenshots exercise the initials fallback. Android keyboard appearance remains controlled by the system keyboard.

All PR checks passed. Greptile and CodeRabbit completed without actionable findings.
