### PR TITLE
fix(computer): keep takeover runs off foreign control leases

### DIFF
--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -580,7 +580,7 @@ describe("pauseRunForTakeover", () => {
     );
   });
 
-  it("preserves another bot's active user lease and only binds controlRunId", async () => {
+  it("preserves another bot's active user lease without binding this run to it", async () => {
     const expiresAt = new Date(Date.now() + 60_000);
     const tx = {
       $queryRaw: vi.fn().mockResolvedValue([{ id: "computer-1" }]),
@@ -627,7 +627,7 @@ describe("pauseRunForTakeover", () => {
 
     expect(tx.computer.updateMany).toHaveBeenCalledWith({
       where: { id: "computer-1", spaceId: "workspace-1" },
-      data: { state: "running", controlRunId: "run-1" },
+      data: { state: "running" },
     });
     expect(tx.event.create).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -794,17 +794,20 @@ export async function pauseRunForTakeover(
         computer.controlLeaseExpiresAt.getTime() > now.getTime(),
     );
     // Keep an active same-bot user lease so Skip / I'm done appear immediately.
-    // Preserve another bot's active lease — computer/takeover owns revocation.
-    // Otherwise clear stale control, but always bind controlRunId so takeoverRequested is true.
+    // Preserve another bot's active lease — computer/takeover owns revocation. Do not attach
+    // this run to that lease: release validates controlBotId and could clear the binding without
+    // resuming the waiting run. The requesting bot's takeover flow binds it after revocation.
+    // Otherwise clear stale control, but bind controlRunId so takeoverRequested is true.
     const retainControl = Boolean(activeUserLease && computer?.controlBotId === input.botId);
     const preserveForeignLease = Boolean(
       activeUserLease && computer?.controlBotId && computer.controlBotId !== input.botId,
     );
     const marked = await tx.computer.updateMany({
       where: { id: input.computerId, spaceId: input.spaceId },
-      data:
-        retainControl || preserveForeignLease
-          ? { state: "running", controlRunId: input.runId }
+      data: retainControl
+        ? { state: "running", controlRunId: input.runId }
+        : preserveForeignLease
+          ? { state: "running" }
           : {
               state: "running",
               controlHolder: "none",


### PR DESCRIPTION
## Why

The #658 fix correctly binds a waiting takeover run to an existing same-bot user lease. In a shared Team Computer, however, a different bot can still own the active user lease. Binding the requesting bot's run to that foreign lease breaks the release invariant: releasing the owner bot clears controlRunId, but cannot resume a run owned by the requester, leaving it in waiting_takeover.

## What

- Preserve an active foreign user lease without attaching the requesting bot's run to it.
- Let the existing takeover flow revoke the foreign lease and bind the waiting run to the new same-bot lease.
- Tighten the transaction test to assert that foreign lease ownership never receives another bot's run binding.

## Tests

- pnpm --filter @rakazo/db test
- pnpm --filter @rakazo/db check
- pnpm exec biome check packages/db/src/events.ts packages/db/src/events.test.ts

Follow-up to #658.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved takeover handling when a computer has an active user lease owned by another bot.
  - Preserved the existing lease without incorrectly assigning control to the current run.
  - Added test coverage to verify that foreign active leases remain unchanged during takeover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->