### PR TITLE
fix(computer): keep takeover leases with their winner

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1519,17 +1519,17 @@ export function createRouter(deps: RouterDeps) {
           const current = await deps.prisma.computer.findUniqueOrThrow({
             where: { id: bot.computer.id },
           });
-          if (!hasActiveComputerControl(current)) throw new ORPCError("CONFLICT");
-          if (current.controlBotId === bot.id) {
-            await bindWaitingTakeoverToControl(deps, {
-              spaceId: context.actor.spaceId,
-              threadId: bot.thread?.id,
-              botId: bot.id,
-              computerId: current.id,
-              controlLeaseId: current.controlLeaseId!,
-              controlRunId: current.controlRunId,
-            });
+          if (!hasActiveComputerControl(current) || current.controlBotId !== bot.id) {
+            throw new ORPCError("CONFLICT", { message: "Computer control changed; try again" });
           }
+          await bindWaitingTakeoverToControl(deps, {
+            spaceId: context.actor.spaceId,
+            threadId: bot.thread?.id,
+            botId: bot.id,
+            computerId: current.id,
+            controlLeaseId: current.controlLeaseId!,
+            controlRunId: current.controlRunId,
+          });
           await scheduleComputerControlExpiry(
             deps.jobs,
             current.id,

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -876,6 +876,7 @@ describeJourneys("required product journeys", () => {
     const bothRevocationsReached = new Promise<void>((resolve) => {
       releaseRevocations = resolve;
     });
+    const barrierTimeout = setTimeout(releaseRevocations, 1_000);
     sandbox.setScreenControl = async (_computer, interactive, _context, controlToken) => {
       expect(interactive).toBe(false);
       expect(controlToken).toBe(writerLease.leaseId);
@@ -891,6 +892,8 @@ describeJourneys("required product journeys", () => {
         raw(app, cookie, "computer/takeover", { botId: analyst.id }),
       ]);
     } finally {
+      clearTimeout(barrierTimeout);
+      releaseRevocations();
       sandbox.setScreenControl = originalSetScreenControl;
     }
 

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -837,6 +837,78 @@ describeJourneys("required product journeys", () => {
     ).toBe(releaseEventsBefore + 1);
   });
 
+  it("4e: concurrent Team takeovers never return another bot's lease", async () => {
+    const cookie = await signup(
+      app,
+      `takeover-owner-race-j-${stamp}@rakazo.test`,
+      "Takeover Owner Race",
+    );
+    const writer = await rpc<Bot>(app, cookie, "bots/create", {
+      name: "Writer",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const researcher = await rpc<Bot>(app, cookie, "bots/create", {
+      name: "Researcher",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+    const analyst = await rpc<Bot>(app, cookie, "bots/create", {
+      name: "Analyst",
+      title: "",
+      description: "",
+      instructions: "",
+      notifyOnFinish: true,
+    });
+
+    await rpc(app, cookie, "computer/boot", { botId: writer.id });
+    const writerLease = await rpc<{ leaseId: string }>(app, cookie, "computer/takeover", {
+      botId: writer.id,
+    });
+
+    const originalSetScreenControl = sandbox.setScreenControl;
+    let revocations = 0;
+    let releaseRevocations!: () => void;
+    const bothRevocationsReached = new Promise<void>((resolve) => {
+      releaseRevocations = resolve;
+    });
+    sandbox.setScreenControl = async (_computer, interactive, _context, controlToken) => {
+      expect(interactive).toBe(false);
+      expect(controlToken).toBe(writerLease.leaseId);
+      revocations += 1;
+      if (revocations === 2) releaseRevocations();
+      await bothRevocationsReached;
+    };
+
+    let responses: Response[] = [];
+    try {
+      responses = await Promise.all([
+        raw(app, cookie, "computer/takeover", { botId: researcher.id }),
+        raw(app, cookie, "computer/takeover", { botId: analyst.id }),
+      ]);
+    } finally {
+      sandbox.setScreenControl = originalSetScreenControl;
+    }
+
+    expect(revocations).toBe(2);
+    expect(responses.map((response) => response.status).sort()).toEqual([200, 409]);
+    const computer = await prisma.computer.findFirstOrThrow({
+      where: { bots: { some: { id: writer.id } } },
+      select: { controlBotId: true, controlLeaseId: true },
+    });
+    const winner = computer.controlBotId === researcher.id ? researcher : analyst;
+    const successfulResponse = responses.find((response) => response.status === 200)!;
+    await expect(successfulResponse.clone().json()).resolves.toMatchObject({
+      json: { leaseId: computer.controlLeaseId },
+    });
+
+    await rpc(app, cookie, "computer/release", { botId: winner.id });
+  });
+
   it("5: a routine wakes the bot and posts into the existing thread", async () => {
     const cookie = await signup(app, `routine-j-${stamp}@rakazo.test`, "Routine");
     const bot = await rpc<Bot>(app, cookie, "bots/create", {


### PR DESCRIPTION
## Why

Follow-up to the real shared-Team-Computer failure reported in #658. Two replacement takeovers can race after both observe the same previous user lease. One request wins the compare-and-set; the loser currently returns the winner's active lease ID, even though `controlBotId` belongs to the other bot. The losing screen then appears to have control but cannot use or release that lease.

## What

- Return an idempotent active lease only when it is owned by the requested bot.
- Return `CONFLICT` when another bot won the takeover race, without exposing that bot's lease ID.
- Add a deterministic three-bot product journey that barriers both revocations, races the two replacement takeovers, and verifies exactly one success, one conflict, and a response lease matching the persisted winner.

## Tests

- `pnpm exec biome check apps/api/src/router.ts packages/testkit/src/journeys.test.ts`
- `pnpm --filter @rakazo/api check`
- `pnpm --filter @rakazo/testkit check`
- `git diff --check`

The Postgres journey is compiled locally and will execute in the repository Postgres journeys CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent computer takeovers to prevent control from being assigned to the wrong bot.
  * Conflicting takeover attempts now return a clear conflict error instead of proceeding silently.
  * Ensured successful takeovers are linked to the correct control lease.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->