### PR TITLE
feat(integrations): add optional catalog feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,8 @@ RAKAZO_LOCAL_MAX_TOKENS=4096
 RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=
 E2B_API_KEY=
 COMPOSIO_API_KEY=
-# Optional integrations.sh-compatible discovery feed. May point to a self-hosted mirror.
+# Optional integrations.sh-compatible catalog base URL (Rakazo appends api/search).
+# Example: https://integrations.sh/ or a self-hosted mirror base, not the full search endpoint.
 INTEGRATIONS_CATALOG_URL=
 # Optional alternative managed connector provider.
 PIPEDREAM_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,8 @@ RAKAZO_LOCAL_MAX_TOKENS=4096
 RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=
 E2B_API_KEY=
 COMPOSIO_API_KEY=
+# Optional integrations.sh-compatible discovery feed. May point to a self-hosted mirror.
+INTEGRATIONS_CATALOG_URL=
 # Optional alternative managed connector provider.
 PIPEDREAM_CLIENT_ID=
 PIPEDREAM_CLIENT_SECRET=

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -377,6 +377,7 @@ export async function createApp(
       updaterUrl: env.updaterUrl,
       updaterToken: env.updaterToken,
       imageTag: env.imageTag,
+      integrationsCatalogUrl: env.integrationsCatalogUrl,
     },
   });
   const rpc = new RPCHandler(router, {

--- a/apps/api/src/env.test.ts
+++ b/apps/api/src/env.test.ts
@@ -28,6 +28,14 @@ describe("loadEnv", () => {
     expect(env.wakeupDriver).toBe("memory");
   });
 
+  it("loads an optional integrations catalog mirror", () => {
+    expect(loadEnv(base).integrationsCatalogUrl).toBeUndefined();
+    expect(
+      loadEnv({ ...base, INTEGRATIONS_CATALOG_URL: " https://catalog.example.test/feed " })
+        .integrationsCatalogUrl,
+    ).toBe("https://catalog.example.test/feed");
+  });
+
   it("falls back to none when a remote provider key is missing", () => {
     expect(
       loadEnv({

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -41,6 +41,8 @@ export interface AppEnv {
   boxApiKey: string | undefined;
   boxApiUrl: string | undefined;
   composioApiKey: string | undefined;
+  /** Optional integrations.sh-compatible catalog base URL. */
+  integrationsCatalogUrl: string | undefined;
   pipedreamClientId: string | undefined;
   pipedreamClientSecret: string | undefined;
   pipedreamProjectId: string | undefined;
@@ -125,6 +127,7 @@ export function loadEnv(source: NodeJS.ProcessEnv = process.env): AppEnv {
     boxApiKey: source.BOX_API_KEY,
     boxApiUrl: source.BOX_API_URL ?? source.BOX_BASE_URL,
     composioApiKey: source.COMPOSIO_API_KEY,
+    integrationsCatalogUrl: optional(source.INTEGRATIONS_CATALOG_URL),
     pipedreamClientId: optional(source.PIPEDREAM_CLIENT_ID),
     pipedreamClientSecret: optional(source.PIPEDREAM_CLIENT_SECRET),
     pipedreamProjectId: optional(source.PIPEDREAM_PROJECT_ID),

--- a/apps/api/src/integration-catalog.test.ts
+++ b/apps/api/src/integration-catalog.test.ts
@@ -3,9 +3,10 @@ import { searchIntegrationCatalog } from "./integration-catalog.js";
 
 describe("searchIntegrationCatalog", () => {
   it("normalizes an integrations.sh-compatible feed and keeps unsupported surfaces visible", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
       const url = new URL(input instanceof Request ? input.url : input.toString());
       expect(url.href).toBe("https://mirror.example/catalog/api/search?q=github.com&limit=8");
+      expect(init?.redirect).toBe("manual");
       return Response.json({
         results: [
           {
@@ -118,6 +119,62 @@ describe("searchIntegrationCatalog", () => {
           new Response("", { headers: { "content-length": String(RESPONSE_SIZE_OVER_LIMIT) } }),
       }),
     ).rejects.toThrow("too large");
+  });
+
+  it("rejects redirect responses instead of following them", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (_input, init) => {
+      expect(init?.redirect).toBe("manual");
+      return new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data" },
+      });
+    });
+
+    await expect(
+      searchIntegrationCatalog({
+        baseUrl: "https://mirror.example/catalog",
+        query: "github.com",
+        signal: new AbortController().signal,
+        fetch,
+      }),
+    ).rejects.toThrow("redirects are not allowed");
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("allows an admin-configured private catalog base", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      expect(url.href).toBe("http://10.0.0.5:8080/catalog/api/search?q=github.com&limit=8");
+      expect(init?.redirect).toBe("manual");
+      return Response.json({
+        results: [
+          {
+            domain: "github.com",
+            name: "GitHub",
+            description: "LAN mirror",
+            url: "http://10.0.0.5:8080/github.com/",
+            surfaces: [],
+          },
+        ],
+      });
+    });
+
+    await expect(
+      searchIntegrationCatalog({
+        baseUrl: "http://10.0.0.5:8080/catalog",
+        query: "github.com",
+        signal: new AbortController().signal,
+        fetch,
+      }),
+    ).resolves.toEqual([
+      {
+        domain: "github.com",
+        name: "GitHub",
+        description: "LAN mirror",
+        pageUrl: "http://10.0.0.5:8080/github.com/",
+        surfaces: [],
+      },
+    ]);
   });
 });
 

--- a/apps/api/src/integration-catalog.test.ts
+++ b/apps/api/src/integration-catalog.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { searchIntegrationCatalog } from "./integration-catalog.js";
+
+describe("searchIntegrationCatalog", () => {
+  it("normalizes an integrations.sh-compatible feed and keeps unsupported surfaces visible", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      expect(url.href).toBe("https://mirror.example/catalog/api/search?q=github.com&limit=8");
+      return Response.json({
+        results: [
+          {
+            domain: "github.com",
+            name: "GitHub",
+            description: "Developer platform",
+            url: "https://mirror.example/github.com/",
+            surfaces: [
+              {
+                kind: "mcp",
+                slug: "github-mcp",
+                url: "https://api.githubcopilot.com/mcp/",
+                auth: {
+                  kind: "mixed",
+                  header: "Authorization: Bearer {pat}",
+                  note: "OAuth or PAT",
+                },
+              },
+              {
+                kind: "openapi",
+                slug: "github-rest",
+                url: "https://example.test/openapi.json",
+                auth: { kind: "token", header: "x-api-key: {token}" },
+              },
+              { kind: "graphql", slug: "github-graphql", url: "javascript:alert(1)" },
+              { kind: "cli", slug: "github-cli" },
+            ],
+          },
+        ],
+      });
+    });
+
+    await expect(
+      searchIntegrationCatalog({
+        baseUrl: "https://mirror.example/catalog",
+        query: "github.com",
+        signal: new AbortController().signal,
+        fetch,
+      }),
+    ).resolves.toEqual([
+      {
+        domain: "github.com",
+        name: "GitHub",
+        description: "Developer platform",
+        pageUrl: "https://mirror.example/github.com/",
+        surfaces: [
+          {
+            kind: "mcp",
+            slug: "github-mcp",
+            source: "https://api.githubcopilot.com/mcp/",
+            auth: { type: "bearer", headerName: null, note: "OAuth or PAT" },
+          },
+          {
+            kind: "openapi",
+            slug: "github-rest",
+            source: "https://example.test/openapi.json",
+            auth: { type: "header", headerName: "x-api-key", note: null },
+          },
+          {
+            kind: "graphql",
+            slug: "github-graphql",
+            source: null,
+            auth: null,
+          },
+          { kind: "cli", slug: "github-cli", source: null, auth: null },
+        ],
+      },
+    ]);
+  });
+
+  it("does not contact the feed for an empty query", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    await expect(
+      searchIntegrationCatalog({
+        baseUrl: "not a URL",
+        query: "  ",
+        signal: new AbortController().signal,
+        fetch,
+      }),
+    ).resolves.toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-HTTP feeds and malformed payloads", async () => {
+    await expect(
+      searchIntegrationCatalog({
+        baseUrl: "file:///tmp/catalog",
+        query: "github.com",
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow("must use HTTP or HTTPS");
+
+    await expect(
+      searchIntegrationCatalog({
+        baseUrl: "https://mirror.example/",
+        query: "github.com",
+        signal: new AbortController().signal,
+        fetch: async () => Response.json({ nope: true }),
+      }),
+    ).rejects.toThrow("invalid response");
+  });
+
+  it("rejects oversized responses before reading them", async () => {
+    await expect(
+      searchIntegrationCatalog({
+        baseUrl: "https://mirror.example/",
+        query: "github.com",
+        signal: new AbortController().signal,
+        fetch: async () =>
+          new Response("", { headers: { "content-length": String(RESPONSE_SIZE_OVER_LIMIT) } }),
+      }),
+    ).rejects.toThrow("too large");
+  });
+});
+
+const RESPONSE_SIZE_OVER_LIMIT = 1_000_001;

--- a/apps/api/src/integration-catalog.ts
+++ b/apps/api/src/integration-catalog.ts
@@ -1,0 +1,138 @@
+import type { IntegrationCatalogResult, IntegrationCatalogSurface } from "@rakazo/contracts";
+
+const RESPONSE_LIMIT = 1_000_000;
+const SEARCH_LIMIT = 8;
+const SURFACE_LIMIT = 24;
+
+export async function searchIntegrationCatalog(input: {
+  baseUrl: string;
+  query: string;
+  signal: AbortSignal;
+  fetch?: typeof globalThis.fetch;
+}): Promise<IntegrationCatalogResult[]> {
+  const query = input.query.trim();
+  if (!query) return [];
+
+  const baseUrl = new URL(input.baseUrl);
+  if (baseUrl.protocol !== "http:" && baseUrl.protocol !== "https:") {
+    throw new Error("Integration catalog URL must use HTTP or HTTPS");
+  }
+  if (!baseUrl.pathname.endsWith("/")) baseUrl.pathname += "/";
+  const searchUrl = new URL("api/search", baseUrl);
+  searchUrl.searchParams.set("q", query);
+  searchUrl.searchParams.set("limit", String(SEARCH_LIMIT));
+
+  const response = await (input.fetch ?? globalThis.fetch)(searchUrl, {
+    headers: { accept: "application/json" },
+    signal: AbortSignal.any([input.signal, AbortSignal.timeout(5_000)]),
+  });
+  if (!response.ok) throw new Error(`Integration catalog returned HTTP ${response.status}`);
+  const body = await readBoundedResponse(response);
+
+  const payload: unknown = JSON.parse(body);
+  if (!isRecord(payload) || !Array.isArray(payload.results)) {
+    throw new Error("Integration catalog returned an invalid response");
+  }
+  return payload.results.slice(0, SEARCH_LIMIT).flatMap(normalizeResult);
+}
+
+async function readBoundedResponse(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > RESPONSE_LIMIT) {
+    throw new Error("Integration catalog response is too large");
+  }
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let body = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > RESPONSE_LIMIT) {
+        await reader.cancel();
+        throw new Error("Integration catalog response is too large");
+      }
+      body += decoder.decode(value, { stream: true });
+    }
+    return body + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function normalizeResult(value: unknown): IntegrationCatalogResult[] {
+  if (!isRecord(value)) return [];
+  const domain = shortString(value.domain, 253);
+  if (!domain) return [];
+  const surfaces = Array.isArray(value.surfaces)
+    ? value.surfaces.slice(0, SURFACE_LIMIT).flatMap(normalizeSurface)
+    : [];
+  return [
+    {
+      domain,
+      name: shortString(value.name, 120) ?? domain,
+      description: shortString(value.description, 500) ?? "",
+      pageUrl: httpUrl(value.url),
+      surfaces,
+    },
+  ];
+}
+
+function normalizeSurface(value: unknown): IntegrationCatalogSurface[] {
+  if (!isRecord(value)) return [];
+  const kind = value.kind;
+  if (kind !== "mcp" && kind !== "openapi" && kind !== "graphql" && kind !== "cli") return [];
+  const slug = shortString(value.slug, 120);
+  if (!slug) return [];
+  return [
+    {
+      kind,
+      slug,
+      source: httpUrl(value.url),
+      auth: normalizeAuth(value.auth),
+    },
+  ];
+}
+
+function normalizeAuth(value: unknown): IntegrationCatalogSurface["auth"] {
+  if (!isRecord(value)) return null;
+  const kind = shortString(value.kind, 40)?.toLowerCase();
+  const note = shortString(value.note, 500) ?? null;
+  if (kind === "none") return { type: "none", headerName: null, note };
+
+  const header = shortString(value.header, 200);
+  const headerName = header?.split(":", 1)[0]?.trim() || null;
+  if (headerName?.toLowerCase() === "authorization" && /:\s*bearer\b/i.test(header ?? "")) {
+    return { type: "bearer", headerName: null, note };
+  }
+  if (headerName) return { type: "header", headerName, note };
+  if (kind && ["bearer", "token", "mixed", "oauth", "oauth2"].includes(kind)) {
+    return { type: "bearer", headerName: null, note };
+  }
+  return note ? { type: "bearer", headerName: null, note } : null;
+}
+
+function shortString(value: unknown, limit: number): string | null {
+  if (typeof value !== "string") return null;
+  const result = value.trim();
+  return result ? result.slice(0, limit) : null;
+}
+
+function httpUrl(value: unknown): string | null {
+  const candidate = shortString(value, 2_048);
+  if (!candidate) return null;
+  try {
+    const url = new URL(candidate);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/api/src/integration-catalog.ts
+++ b/apps/api/src/integration-catalog.ts
@@ -22,10 +22,17 @@ export async function searchIntegrationCatalog(input: {
   searchUrl.searchParams.set("q", query);
   searchUrl.searchParams.set("limit", String(SEARCH_LIMIT));
 
+  // Admin-configured bases may be private (LAN mirrors). Do not reuse connector
+  // SSRF checks that block private hosts. Still refuse redirects so a mirror
+  // cannot bounce the server onto cloud metadata or another host.
   const response = await (input.fetch ?? globalThis.fetch)(searchUrl, {
     headers: { accept: "application/json" },
+    redirect: "manual",
     signal: AbortSignal.any([input.signal, AbortSignal.timeout(5_000)]),
   });
+  if (response.type === "opaqueredirect" || (response.status >= 300 && response.status < 400)) {
+    throw new Error("Integration catalog redirects are not allowed");
+  }
   if (!response.ok) throw new Error(`Integration catalog returned HTTP ${response.status}`);
   const body = await readBoundedResponse(response);
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -127,6 +127,7 @@ import {
   resolveBusyBotName,
   toComputerStatus,
 } from "./computer-status.js";
+import { searchIntegrationCatalog } from "./integration-catalog.js";
 import { buildMcpUpdateMaterial } from "./mcp-material.js";
 import {
   disconnectMemoryProvider,
@@ -421,6 +422,7 @@ export interface RouterDeps {
     updaterUrl?: string;
     updaterToken?: string;
     imageTag?: string;
+    integrationsCatalogUrl?: string;
   };
 }
 
@@ -2365,6 +2367,23 @@ export function createRouter(deps: RouterDeps) {
           config: row.config as Record<string, unknown>,
           createdAt: row.createdAt.toISOString(),
         }));
+      }),
+      catalogSearch: authed.capabilities.catalogSearch.handler(async ({ context, input }) => {
+        const baseUrl = deps.env.integrationsCatalogUrl;
+        if (!baseUrl) return { enabled: false, results: [] };
+        try {
+          const results = await searchIntegrationCatalog({
+            baseUrl,
+            query: input.query,
+            signal: context.signal ?? new AbortController().signal,
+            fetch: deps.remoteConnectors?.fetch,
+          });
+          return { enabled: true, results };
+        } catch (error) {
+          throw new ORPCError("BAD_GATEWAY", {
+            message: error instanceof Error ? error.message : "Integration catalog search failed",
+          });
+        }
       }),
       install: authed.capabilities.install.handler(async ({ context, input }) => {
         let source = input.source.trim();

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -245,6 +245,12 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await expect(feed.getByRole("button", { name: "OPENAPI · Add", exact: true })).toBeVisible();
   await expect(feed.getByRole("button", { name: "GRAPHQL · Manual", exact: true })).toBeDisabled();
   await expect(feed.getByRole("button", { name: "CLI · Manual", exact: true })).toBeDisabled();
+  // Editing the query must drop prior results so a stale Add cannot run for the old domain.
+  await feed.getByRole("textbox", { name: "Integration domain" }).fill("gitlab.com");
+  await expect(feed.getByText("GitHub", { exact: true })).toBeHidden();
+  await feed.getByRole("textbox", { name: "Integration domain" }).fill("github.com");
+  await feed.getByRole("button", { name: "Search", exact: true }).click();
+  await expect(feed.getByText("GitHub", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11c-catalog-feed");
 
   await feed.getByRole("button", { name: "MCP · Add", exact: true }).click();

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -227,6 +227,34 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await expect(page.getByText("Tool sources", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "MCP servers", exact: true })).toBeHidden();
   // Thin Advanced smoke only. GraphQL install and order screenshots live in graphql-integrations.spec.ts.
+  await expect(page.getByTestId("integrations-catalog-feed")).toBeVisible();
+  // Catalog search remains optional and manual MCP → OpenAPI → GraphQL → Treg stays available.
+  const advancedActions = advanced.locator("button");
+  await expect(advancedActions.nth(0)).toHaveText("MCP servers");
+  await expect(advancedActions.nth(1)).toHaveText("Search");
+  await expect(advancedActions.nth(2)).toHaveText("Add MCP server");
+  await expect(advancedActions.nth(3)).toHaveText("Add OpenAPI");
+  await expect(advancedActions.nth(4)).toHaveText("Add GraphQL");
+  await expect(advancedActions.nth(5)).toHaveText("Add Treg");
+
+  await page.getByRole("textbox", { name: "Integration domain" }).fill("github.com");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  const feed = page.getByTestId("integrations-catalog-feed");
+  await expect(feed.getByText("GitHub", { exact: true })).toBeVisible();
+  await expect(feed.getByRole("button", { name: "MCP · Add", exact: true })).toBeVisible();
+  await expect(feed.getByRole("button", { name: "OPENAPI · Add", exact: true })).toBeVisible();
+  await expect(feed.getByRole("button", { name: "GRAPHQL · Manual", exact: true })).toBeDisabled();
+  await expect(feed.getByRole("button", { name: "CLI · Manual", exact: true })).toBeDisabled();
+  await captureScreenshot(page, testInfo, "11c-catalog-feed");
+
+  await feed.getByRole("button", { name: "MCP · Add", exact: true }).click();
+  await expect(page.getByPlaceholder("Display name")).toHaveValue("GitHub");
+  await expect(page.getByPlaceholder("https://example.com/mcp")).toHaveValue(
+    "https://mcp.example.test/mcp",
+  );
+  await expect(page.locator("select")).toHaveValue("bearer");
+  await page.getByRole("button", { name: "Cancel", exact: true }).click();
+
   await page.getByRole("button", { name: "Add Treg", exact: true }).click();
   await page.getByPlaceholder("Treg token").fill("fake-treg-browser-credential");
   await page.getByRole("button", { name: "Verify and add", exact: true }).click();
@@ -260,7 +288,7 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await expect(
     page.getByText(/MCP · https:\/\/executor\.example\.test\/mcp · credential saved/),
   ).toBeVisible();
-  await captureScreenshot(page, testInfo, "11c-provider-emulators");
+  await captureScreenshot(page, testInfo, "11d-provider-emulators");
 
   await page.getByRole("button", { name: "Close integrations" }).click();
 

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -228,18 +228,18 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await expect(page.getByRole("button", { name: "MCP servers", exact: true })).toBeHidden();
   // Thin Advanced smoke only. GraphQL install and order screenshots live in graphql-integrations.spec.ts.
   await expect(page.getByTestId("integrations-catalog-feed")).toBeVisible();
-  // Catalog search remains optional and manual MCP → OpenAPI → GraphQL → Treg stays available.
-  const advancedActions = advanced.locator("button");
-  await expect(advancedActions.nth(0)).toHaveText("MCP servers");
-  await expect(advancedActions.nth(1)).toHaveText("Search");
-  await expect(advancedActions.nth(2)).toHaveText("Add MCP server");
-  await expect(advancedActions.nth(3)).toHaveText("Add OpenAPI");
-  await expect(advancedActions.nth(4)).toHaveText("Add GraphQL");
-  await expect(advancedActions.nth(5)).toHaveText("Add Treg");
+  // Catalog Search is optional chrome; add buttons stay MCP → OpenAPI → GraphQL → Executor → Treg.
+  const advancedActions = advanced.getByTestId("integrations-advanced-add").locator("button");
+  await expect(advancedActions).toHaveCount(5);
+  await expect(advancedActions.nth(0)).toHaveText("Add MCP server");
+  await expect(advancedActions.nth(1)).toHaveText("Add OpenAPI");
+  await expect(advancedActions.nth(2)).toHaveText("Add GraphQL");
+  await expect(advancedActions.nth(3)).toHaveText("Add Executor");
+  await expect(advancedActions.nth(4)).toHaveText("Add Treg");
 
-  await page.getByRole("textbox", { name: "Integration domain" }).fill("github.com");
-  await page.getByRole("button", { name: "Search", exact: true }).click();
   const feed = page.getByTestId("integrations-catalog-feed");
+  await feed.getByRole("textbox", { name: "Integration domain" }).fill("github.com");
+  await feed.getByRole("button", { name: "Search", exact: true }).click();
   await expect(feed.getByText("GitHub", { exact: true })).toBeVisible();
   await expect(feed.getByRole("button", { name: "MCP · Add", exact: true })).toBeVisible();
   await expect(feed.getByRole("button", { name: "OPENAPI · Add", exact: true })).toBeVisible();

--- a/apps/web/e2e/graphql-integrations.spec.ts
+++ b/apps/web/e2e/graphql-integrations.spec.ts
@@ -17,19 +17,21 @@ test("advanced GraphQL install shows Add GraphQL in MCP, OpenAPI, GraphQL, Execu
     (element as HTMLDetailsElement).open = true;
   });
 
+  await expect(page.getByRole("button", { name: "MCP servers", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add MCP server", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add OpenAPI", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add GraphQL", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add Executor", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add Treg", exact: true })).toBeVisible();
 
-  const advancedActions = page.getByTestId("integrations-advanced-add").locator("button");
+  // Catalog Search (when enabled) lives outside this group and must not affect add order.
+  const advancedActions = advanced.getByTestId("integrations-advanced-add").locator("button");
+  await expect(advancedActions).toHaveCount(5);
   await expect(advancedActions.nth(0)).toHaveText("Add MCP server");
   await expect(advancedActions.nth(1)).toHaveText("Add OpenAPI");
   await expect(advancedActions.nth(2)).toHaveText("Add GraphQL");
   await expect(advancedActions.nth(3)).toHaveText("Add Executor");
   await expect(advancedActions.nth(4)).toHaveText("Add Treg");
-  await expect(advancedActions).toHaveCount(5);
   await expect(page.getByRole("button", { name: "Manage MCP servers", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "01-graphql-advanced-order");
 

--- a/apps/web/e2e/graphql-integrations.spec.ts
+++ b/apps/web/e2e/graphql-integrations.spec.ts
@@ -17,12 +17,13 @@ test("advanced GraphQL install shows Add GraphQL in MCP, OpenAPI, GraphQL, Execu
     (element as HTMLDetailsElement).open = true;
   });
 
-  await expect(page.getByRole("button", { name: "MCP servers", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Manage MCP servers", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add MCP server", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add OpenAPI", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add GraphQL", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add Executor", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add Treg", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "MCP servers", exact: true })).toBeHidden();
 
   // Catalog Search (when enabled) lives outside this group and must not affect add order.
   const advancedActions = advanced.getByTestId("integrations-advanced-add").locator("button");
@@ -32,7 +33,6 @@ test("advanced GraphQL install shows Add GraphQL in MCP, OpenAPI, GraphQL, Execu
   await expect(advancedActions.nth(2)).toHaveText("Add GraphQL");
   await expect(advancedActions.nth(3)).toHaveText("Add Executor");
   await expect(advancedActions.nth(4)).toHaveText("Add Treg");
-  await expect(page.getByRole("button", { name: "Manage MCP servers", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "01-graphql-advanced-order");
 
   await page.getByRole("button", { name: "Add GraphQL", exact: true }).click();

--- a/apps/web/src/lib/optional-catalog-feed.test.ts
+++ b/apps/web/src/lib/optional-catalog-feed.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { optionalCatalogFeedProbe } from "./optional-catalog-feed";
+
+describe("optionalCatalogFeedProbe", () => {
+  it("returns the probe result when the configured feed is available", async () => {
+    await expect(
+      optionalCatalogFeedProbe(
+        Promise.resolve({ enabled: true, results: [{ domain: "github.com" }] }),
+      ),
+    ).resolves.toEqual({ enabled: true, results: [{ domain: "github.com" }] });
+  });
+
+  it("treats an unavailable configured feed as disabled instead of rejecting", async () => {
+    await expect(
+      optionalCatalogFeedProbe(Promise.reject(new Error("BAD_GATEWAY"))),
+    ).resolves.toEqual({ enabled: false, results: [] });
+  });
+});

--- a/apps/web/src/lib/optional-catalog-feed.ts
+++ b/apps/web/src/lib/optional-catalog-feed.ts
@@ -1,0 +1,6 @@
+/** Soft-fail the optional integrations catalog probe so core catalog load stays available. */
+export function optionalCatalogFeedProbe<T extends { enabled: boolean; results: unknown[] }>(
+  probe: Promise<T>,
+): Promise<T | { enabled: false; results: [] }> {
+  return probe.catch(() => ({ enabled: false, results: [] }));
+}

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -1,5 +1,11 @@
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
-import type { CapabilityInstall, Connection, ConnectionCatalogItem } from "@rakazo/contracts";
+import type {
+  CapabilityInstall,
+  Connection,
+  ConnectionCatalogItem,
+  IntegrationCatalogResult,
+  IntegrationCatalogSurface,
+} from "@rakazo/contracts";
 import {
   abortableDelay,
   buildFeaturedConnectorTiles,
@@ -102,10 +108,11 @@ export function PluginsOverlay({
   const connectionAttempt = useRef<AbortController | null>(null);
 
   async function refresh() {
-    const [items, installs, rows] = await Promise.all([
+    const [items, installs, rows, catalogFeed] = await Promise.all([
       rpc.connections.catalog({}),
       rpc.capabilities.list(),
       rpc.connections.list(),
+      rpc.capabilities.catalogSearch({ query: "" }),
     ]);
     setCatalog(items);
     setConnections(rows);
@@ -790,6 +797,7 @@ export function PluginsOverlay({
                   if (!(event.currentTarget as HTMLDetailsElement).open) {
                     setSourceKind(null);
                     setSourceError(null);
+                    setSourceHint(null);
                     setSourceName("");
                     setSourceUrl("");
                     setCredential("");
@@ -808,7 +816,104 @@ export function PluginsOverlay({
                 </summary>
 
                 <div className="mt-4 space-y-4">
-                  <div className="flex flex-wrap gap-2" data-testid="integrations-advanced-add">
+                  {catalogFeedEnabled ? (
+                    <Card data-testid="integrations-catalog-feed">
+                      <CardHeader>
+                        <CardTitle>
+                          <Trans>Search by domain</Trans>
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="space-y-3">
+                        <form
+                          className="flex gap-2"
+                          onSubmit={(event) => {
+                            event.preventDefault();
+                            void searchCatalogFeed();
+                          }}
+                        >
+                          <Input
+                            value={catalogFeedQuery}
+                            disabled={catalogFeedPending}
+                            onChange={(event) => {
+                              setCatalogFeedQuery(event.target.value);
+                              setCatalogFeedSearched(false);
+                            }}
+                            placeholder="github.com"
+                            aria-label={t`Integration domain`}
+                          />
+                          <Button
+                            type="submit"
+                            variant="secondary"
+                            className="rounded-full"
+                            size="sm"
+                            disabled={!catalogFeedQuery.trim() || catalogFeedPending}
+                          >
+                            {catalogFeedPending ? <Trans>Searching…</Trans> : <Trans>Search</Trans>}
+                          </Button>
+                        </form>
+                        {catalogFeedError ? (
+                          <p className="text-sm text-destructive">{catalogFeedError}</p>
+                        ) : null}
+                        {catalogFeedSearched &&
+                        !catalogFeedPending &&
+                        catalogFeedResults.length === 0 ? (
+                          <p className="text-sm text-muted-foreground">
+                            <Trans>No results</Trans>
+                          </p>
+                        ) : null}
+                        {catalogFeedResults.map((result) => (
+                          <div
+                            key={`${result.domain}:${result.name}:${result.pageUrl ?? ""}`}
+                            className="rounded-xl border border-border/70 p-3"
+                          >
+                            <div className="font-medium text-foreground">
+                              {result.pageUrl ? (
+                                <a
+                                  href={result.pageUrl}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="hover:underline"
+                                >
+                                  {result.name}
+                                </a>
+                              ) : (
+                                result.name
+                              )}
+                            </div>
+                            <div className="text-xs text-muted-foreground">{result.domain}</div>
+                            {result.description ? (
+                              <p className="mt-2 text-sm leading-5 text-muted-foreground">
+                                {result.description}
+                              </p>
+                            ) : null}
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              {result.surfaces.map((surface) => {
+                                const canAdd =
+                                  Boolean(surface.source) &&
+                                  (surface.kind === "mcp" || surface.kind === "openapi");
+                                return (
+                                  <Button
+                                    key={`${result.domain}:${surface.slug}`}
+                                    type="button"
+                                    variant="secondary"
+                                    className="rounded-full"
+                                    size="sm"
+                                    disabled={!canAdd}
+                                    title={canAdd ? undefined : t`Manual setup required`}
+                                    onClick={() => beginCatalogSurface(result, surface)}
+                                  >
+                                    {surface.kind.toUpperCase()} · {canAdd ? t`Add` : t`Manual`}
+                                  </Button>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        ))}
+                      </CardContent>
+                    </Card>
+                  ) : null}
+
+                  <div data-testid="integrations-advanced-add" className="flex flex-wrap gap-2">
                     <Button
                       type="button"
                       variant="secondary"
@@ -945,6 +1050,9 @@ export function PluginsOverlay({
                             and are never returned to clients or exposed to the model.
                           </Trans>
                         </p>
+                        {sourceHint ? (
+                          <p className="text-xs leading-5 text-muted-foreground">{sourceHint}</p>
+                        ) : null}
                         <div className="flex gap-2">
                           <Button
                             type="button"

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -31,6 +31,7 @@ import {
 } from "@rakazo/ui-web";
 import { ChevronDown, ChevronLeft, ChevronUp, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { optionalCatalogFeedProbe } from "../lib/optional-catalog-feed";
 import { rpc } from "../lib/rpc";
 
 type SourceKind = "treg" | "executor" | "mcp" | "api" | "graphql";
@@ -112,7 +113,7 @@ export function PluginsOverlay({
       rpc.connections.catalog({}),
       rpc.capabilities.list(),
       rpc.connections.list(),
-      rpc.capabilities.catalogSearch({ query: "" }),
+      optionalCatalogFeedProbe(rpc.capabilities.catalogSearch({ query: "" })),
     ]);
     setCatalog(items);
     setConnections(rows);

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -86,6 +86,13 @@ export function PluginsOverlay({
   const [pending, setPending] = useState<string | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [sourceError, setSourceError] = useState<string | null>(null);
+  const [sourceHint, setSourceHint] = useState<string | null>(null);
+  const [catalogFeedEnabled, setCatalogFeedEnabled] = useState(false);
+  const [catalogFeedQuery, setCatalogFeedQuery] = useState("");
+  const [catalogFeedResults, setCatalogFeedResults] = useState<IntegrationCatalogResult[]>([]);
+  const [catalogFeedError, setCatalogFeedError] = useState<string | null>(null);
+  const [catalogFeedPending, setCatalogFeedPending] = useState(false);
+  const [catalogFeedSearched, setCatalogFeedSearched] = useState(false);
   const [loading, setLoading] = useState(true);
   const [detailKey, setDetailKey] = useState<{ connectorId: string; slug: string } | null>(null);
   const [tools, setTools] = useState<ConnectionTool[]>([]);
@@ -116,6 +123,7 @@ export function PluginsOverlay({
         (install) => install.kind === "mcp" || install.kind === "api" || install.kind === "graphql",
       ),
     );
+    setCatalogFeedEnabled(catalogFeed.enabled);
     return items;
   }
 
@@ -317,11 +325,43 @@ export function PluginsOverlay({
   function beginSource(kind: SourceKind) {
     setSourceKind(kind);
     setSourceError(null);
+    setSourceHint(null);
     setSourceName(kind === "treg" ? "Treg" : kind === "executor" ? "Executor" : "");
     setSourceUrl(kind === "treg" ? "https://treg.to/mcp/" : "");
     setCredential("");
     setAuthType(kind === "treg" || kind === "executor" ? "bearer" : "none");
     setAuthName("x-api-key");
+  }
+
+  async function searchCatalogFeed() {
+    setCatalogFeedError(null);
+    setCatalogFeedPending(true);
+    setCatalogFeedSearched(false);
+    setCatalogFeedResults([]);
+    try {
+      const response = await rpc.capabilities.catalogSearch({ query: catalogFeedQuery });
+      setCatalogFeedResults(response.results);
+      setCatalogFeedSearched(true);
+    } catch (err) {
+      setCatalogFeedError(err instanceof Error ? err.message : t`Could not search catalog`);
+    } finally {
+      setCatalogFeedPending(false);
+    }
+  }
+
+  function beginCatalogSurface(
+    result: IntegrationCatalogResult,
+    surface: IntegrationCatalogSurface,
+  ) {
+    if (!surface.source || (surface.kind !== "mcp" && surface.kind !== "openapi")) return;
+    setSourceKind(surface.kind === "mcp" ? "mcp" : "api");
+    setSourceName(result.name);
+    setSourceUrl(surface.source);
+    setCredential("");
+    setAuthType(surface.auth?.type ?? "none");
+    setAuthName(surface.auth?.headerName ?? "x-api-key");
+    setSourceHint(surface.auth?.note ?? null);
+    setSourceError(null);
   }
 
   async function installSource() {

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -837,6 +837,8 @@ export function PluginsOverlay({
                             disabled={catalogFeedPending}
                             onChange={(event) => {
                               setCatalogFeedQuery(event.target.value);
+                              setCatalogFeedResults([]);
+                              setCatalogFeedError(null);
                               setCatalogFeedSearched(false);
                             }}
                             placeholder="github.com"

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -53,6 +53,8 @@ OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
 # User-connected public OpenAI-compatible hosts need =1 (default: private/loopback only).
 # RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1
+# Optional integrations.sh-compatible discovery feed. May point to a self-hosted mirror.
+# INTEGRATIONS_CATALOG_URL=
 
 # Optional outbound HTTP(S) proxy for api/worker containers (Mainland / corporate).
 # Leave blank unless you need egress through a proxy. Uppercase or lowercase keys work.

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -53,7 +53,8 @@ OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
 # User-connected public OpenAI-compatible hosts need =1 (default: private/loopback only).
 # RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1
-# Optional integrations.sh-compatible discovery feed. May point to a self-hosted mirror.
+# Optional integrations.sh-compatible catalog base URL (Rakazo appends api/search).
+# Example: https://integrations.sh/ or a self-hosted mirror base, not the full search endpoint.
 # INTEGRATIONS_CATALOG_URL=
 
 # Optional outbound HTTP(S) proxy for api/worker containers (Mainland / corporate).

--- a/packages/adapters/src/third-party-connector-emulator.ts
+++ b/packages/adapters/src/third-party-connector-emulator.ts
@@ -2,6 +2,7 @@ import type { ResolveHostname } from "./remote-mcp.js";
 
 type EmulatorRecord =
   | { provider: "pipedream"; operation: string; app?: string }
+  | { provider: "catalog"; operation: "search"; query: string }
   | {
       provider: "mcp";
       operation: string;
@@ -40,8 +41,42 @@ export class ThirdPartyConnectorEmulator {
     }
     if (url.hostname === "api.example.test") return this.openapi(url, init);
     if (url.hostname === "graphql.example.test") return this.graphql(url, init);
+    if (url.hostname === "catalog.example.test") return this.catalog(url);
     throw new Error(`Third-party connector emulator received unexpected URL ${url}`);
   };
+
+  private async catalog(url: URL): Promise<Response> {
+    if (url.pathname !== "/api/search") return new Response(null, { status: 404 });
+    const query = url.searchParams.get("q") ?? "";
+    this.records.push({ provider: "catalog", operation: "search", query });
+    if (!query.toLowerCase().includes("github")) return Response.json({ results: [] });
+    return Response.json({
+      results: [
+        {
+          domain: "github.com",
+          name: "GitHub",
+          description: "Repository automation surfaces",
+          url: "https://integrations.example.test/github.com/",
+          surfaces: [
+            {
+              kind: "mcp",
+              slug: "github-mcp",
+              url: "https://mcp.example.test/mcp",
+              auth: { kind: "token", header: "Authorization: Bearer {token}" },
+            },
+            {
+              kind: "openapi",
+              slug: "github-openapi",
+              url: "https://api.example.test/openapi.json",
+              auth: { kind: "token", header: "Authorization: Bearer {token}" },
+            },
+            { kind: "graphql", slug: "github-graphql", url: "https://api.github.test/graphql" },
+            { kind: "cli", slug: "github-cli" },
+          ],
+        },
+      ],
+    });
+  }
 
   private async pipedream(url: URL, init?: RequestInit): Promise<Response> {
     const method = init?.method ?? "GET";

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -578,6 +578,29 @@ export const CapabilityInstallSchema = z.object({
 });
 export type CapabilityInstall = z.infer<typeof CapabilityInstallSchema>;
 
+export const IntegrationCatalogSurfaceSchema = z.object({
+  kind: z.enum(["mcp", "openapi", "graphql", "cli"]),
+  slug: z.string(),
+  source: z.string().nullable(),
+  auth: z
+    .object({
+      type: z.enum(["none", "bearer", "header"]),
+      headerName: z.string().nullable(),
+      note: z.string().nullable(),
+    })
+    .nullable(),
+});
+export type IntegrationCatalogSurface = z.infer<typeof IntegrationCatalogSurfaceSchema>;
+
+export const IntegrationCatalogResultSchema = z.object({
+  domain: z.string(),
+  name: z.string(),
+  description: z.string(),
+  pageUrl: z.string().nullable(),
+  surfaces: z.array(IntegrationCatalogSurfaceSchema),
+});
+export type IntegrationCatalogResult = z.infer<typeof IntegrationCatalogResultSchema>;
+
 export type { McpTransport } from "./mcp.js";
 
 const McpServerBaseInput = z.object({

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -31,6 +31,7 @@ import {
   ExternalConversationPolicySchema,
   GroupDetailSchema,
   GroupSchema,
+  IntegrationCatalogResultSchema,
   McpServerConfigInput,
   McpServerSchema,
   MemoryDocumentSchema,
@@ -472,6 +473,12 @@ export const appContract = {
   },
   capabilities: {
     list: oc.output(z.array(CapabilityInstallSchema)),
+    catalogSearch: oc.input(z.object({ query: z.string().trim().max(253).default("") })).output(
+      z.object({
+        enabled: z.boolean(),
+        results: z.array(IntegrationCatalogResultSchema),
+      }),
+    ),
     install: oc
       .input(
         z.object({

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -155,6 +155,7 @@ async function main() {
         fetch: thirdParties.fetch,
         resolveHostname: thirdParties.resolveHostname,
       },
+      integrationsCatalogUrl: "https://catalog.example.test/",
     });
     let activeRequests = 0;
     const requestWaiters = new Set<() => void>();

--- a/packages/testkit/src/pin-test-env.test.ts
+++ b/packages/testkit/src/pin-test-env.test.ts
@@ -14,6 +14,7 @@ describeFast("pnpm test emulator pin", () => {
 
   it("does not keep a live Composio key in the test process", () => {
     expect(process.env.COMPOSIO_API_KEY).toBeUndefined();
+    expect(process.env.INTEGRATIONS_CATALOG_URL).toBeUndefined();
   });
 
   itOffline(

--- a/packages/testkit/src/pin-test-env.ts
+++ b/packages/testkit/src/pin-test-env.ts
@@ -9,6 +9,7 @@ if (!process.env.VERIFY_PROVIDERS) {
   delete process.env.CURSOR_API_KEY;
   process.env.WAKEUP_DRIVER = "memory";
   delete process.env.COMPOSIO_API_KEY;
+  delete process.env.INTEGRATIONS_CATALOG_URL;
   if (!process.env.VERIFY_DATABASE) {
     delete process.env.DATABASE_URL;
     delete process.env.REALTIME_DATABASE_URL;


### PR DESCRIPTION
Closes #413

## Why

Self-hosted deployments can install MCP and OpenAPI sources manually, but cannot discover a domain's published agent surfaces from the integrations screen. This adds discovery without making a hosted catalog part of Rakazo's runtime or weakening source verification.

## What changed

- add an opt-in `INTEGRATIONS_CATALOG_URL` setting for integrations.sh-compatible feeds, including self-hosted mirrors
- expose bounded, authenticated catalog search through Rakazo rather than coupling runtime execution to the feed
- let users search by domain and prefill the existing verified MCP/OpenAPI installer
- keep GraphQL/CLI surfaces visible but explicitly non-installable until Rakazo supports those source kinds
- leave every manual MCP/OpenAPI/Treg path unchanged when the feed is disabled or unavailable

Catalog responses are normalized and bounded to 1 MB, 8 results, 24 surfaces per result, and a five-second timeout. Feed-provided source URLs still pass through the existing MCP/OpenAPI verification and encrypted credential flow before persistence.

## UI copy

New visible copy is: “Search by domain”, “Search”, “Searching…”, “No results”, “[KIND] · Add”, and “[KIND] · Manual”. “Integration domain” is the accessible input name, and “Manual setup required” explains disabled GraphQL/CLI actions.

The heading distinguishes this domain-surface feed from the app search above it. Search/action labels are necessary control names; progress and empty states appear only after the matching action; Manual prevents unsupported surfaces from looking installable. The entire card is already hidden unless an operator configures a feed and a user opens Advanced, so delaying it further would leave an unlabeled control or ambiguous disabled actions rather than remove persistent chrome.

## Validation

- Biome on all changed TypeScript files
- TypeScript checks for contracts, adapters, API, web, and testkit
- 24 focused Vitest assertions (catalog parser/bounds, environment loading, emulator pin)
- live compatibility smoke against `https://integrations.sh/api/search`
- emulator-backed Playwright journey added for CI, including the screenshot gallery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added catalog search to Advanced integrations, including Executor integrations.
  * Prefill supported integration forms with names, URLs, and authentication details.
  * Added agent secret management, external-conversation policy updates, and team-chat bot routing.
  * Improved connector account and connection lifecycle management.

* **Configuration**
  * Added optional catalog base URL configuration.

* **Reliability**
  * Added request validation, size limits, timeout handling, and redirect protection.
  * Catalog failures now fail softly without disrupting core functionality.
  * Changing searches clears previous results to prevent stale entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->