### PR TITLE
Polish mobile sign-in and reveal message actions on long press

### DIFF
--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -106,7 +106,31 @@ tags:
 - extendedWaitUntil:
     visible: "The fixture workspace is ready."
     timeout: 10000
+- assertNotVisible: "Add thumbs-up"
+- assertNotVisible: "Remove thumbs-up"
+- assertNotVisible: "Reply"
 - takeScreenshot: "screenshots/15-thread"
+- longPressOn: "The fixture workspace is ready."
+- assertVisible: "Add thumbs-up"
+- assertVisible: "Reply"
+- assertVisible: "Speak message"
+- takeScreenshot: "screenshots/15b-message-actions"
+- tapOn: "Add thumbs-up"
+- extendedWaitUntil:
+    visible: "Remove thumbs-up"
+    timeout: 10000
+- assertNotVisible: "Reply"
+- takeScreenshot: "screenshots/15c-message-reaction"
+- tapOn: "Remove thumbs-up"
+- extendedWaitUntil:
+    notVisible: "Remove thumbs-up"
+    timeout: 10000
+- longPressOn: "Summarize the fixture launch checklist."
+- assertVisible: "Add thumbs-up"
+- assertNotVisible: "Speak message"
+- tapOn: "Reply"
+- assertVisible: "Replying to"
+- tapOn: "Cancel reply"
 - tapOn: "Bot actions"
 - assertVisible: "Clear conversation"
 - takeScreenshot: "screenshots/16-bot-actions"
@@ -128,7 +152,19 @@ tags:
 - extendedWaitUntil:
     visible: "The fixture launch plan is ready."
     timeout: 10000
+- assertNotVisible: "Add thumbs-up"
+- assertNotVisible: "Reply"
 - takeScreenshot: "screenshots/19-group-thread"
+- longPressOn: "The fixture launch plan is ready."
+- assertVisible: "Add thumbs-up"
+- tapOn: "Add thumbs-up"
+- extendedWaitUntil:
+    visible: "Remove thumbs-up"
+    timeout: 10000
+- tapOn: "Remove thumbs-up"
+- extendedWaitUntil:
+    notVisible: "Remove thumbs-up"
+    timeout: 10000
 
 - openLink: "rakazo:///group-settings?groupId=${RAKAZO_SCREENSHOT_GROUP_ID}"
 - extendedWaitUntil:

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -224,21 +224,6 @@ export default function SignIn() {
                       }}
                     />
                   ) : null}
-                  {mode === "in" && reset?.passwordReset && reset.resetUrl ? (
-                    <Pressable
-                      accessibilityRole="button"
-                      hitSlop={8}
-                      onPress={() => {
-                        setMode("forgot");
-                        setError(null);
-                      }}
-                      style={{ alignSelf: "flex-end", marginTop: 10 }}
-                    >
-                      <Text style={{ color: tokens.foreground, fontSize: 14, fontWeight: "600" }}>
-                        {t("Forgot password?")}
-                      </Text>
-                    </Pressable>
-                  ) : null}
                   {error ? (
                     <Text style={{ color: tokens.destructive, marginTop: 12 }}>{error}</Text>
                   ) : null}
@@ -264,6 +249,21 @@ export default function SignIn() {
                             : t("Send reset link")}
                     </Text>
                   </Pressable>
+                  {mode === "in" && reset?.passwordReset && reset.resetUrl ? (
+                    <Pressable
+                      accessibilityRole="button"
+                      hitSlop={8}
+                      onPress={() => {
+                        setMode("forgot");
+                        setError(null);
+                      }}
+                      style={{ alignSelf: "center", marginTop: 16 }}
+                    >
+                      <Text style={{ color: tokens.foreground, fontSize: 14, fontWeight: "600" }}>
+                        {t("Forgot password?")}
+                      </Text>
+                    </Pressable>
+                  ) : null}
                   <View
                     style={{
                       flexDirection: "row",

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -40,6 +40,7 @@ import {
   type NativeSyntheticEvent,
   Platform,
   Pressable,
+  type PressableProps,
   ScrollView,
   Text,
   TextInput,
@@ -1250,7 +1251,46 @@ function Thread() {
     }
   }
 
+  function messageActionProps(message: MobileMessage): MessageActionProps {
+    const actions = [
+      { name: "reply", text: t("Reply"), onPress: () => setReplyTarget(message) },
+      ...(canReactToThreadMessage(message)
+        ? [
+            {
+              name: "react",
+              text: message.thumbsUp ? t("Remove thumbs-up") : t("Add thumbs-up"),
+              onPress: () => void reactToMessage(message),
+            },
+          ]
+        : []),
+      ...(message.role === "bot" && blockText(message)
+        ? [{ name: "speak", text: t("Speak message"), onPress: () => void speak(message) }]
+        : []),
+    ];
+    return {
+      onLongPress: () => {
+        if (Platform.OS === "ios") {
+          ActionSheetIOS.showActionSheetWithOptions(
+            {
+              options: [...actions.map((action) => action.text), t("Cancel")],
+              cancelButtonIndex: actions.length,
+              userInterfaceStyle: colorScheme,
+            },
+            (index) => actions[index]?.onPress(),
+          );
+        } else {
+          Alert.alert("", undefined, actions, { cancelable: true });
+        }
+      },
+      accessibilityActions: actions.map((action) => ({ name: action.name, label: action.text })),
+      onAccessibilityAction: (event) => {
+        actions.find((action) => action.name === event.nativeEvent.actionName)?.onPress();
+      },
+    };
+  }
+
   function renderMessageRow(message: MobileMessage, options?: { enableJump?: boolean }) {
+    const actionProps = messageActionProps(message);
     const activityBotId =
       !inGroup && message.role === "bot" && message.id.startsWith("progress:")
         ? (message.botId ?? botId)
@@ -1310,51 +1350,39 @@ function Thread() {
             flexShrink: 1,
           }}
         >
-          <View
-            style={{
-              alignSelf: message.role === "user" ? "flex-end" : "flex-start",
-              flexDirection: "row",
-              alignItems: "center",
-              gap: 12,
-              marginBottom: 4,
-            }}
-          >
-            <Pressable accessibilityLabel={t("Reply")} onPress={() => setReplyTarget(message)}>
-              <Text style={{ color: tokens.mutedForeground, fontSize: 12 }}>{t("Reply")}</Text>
+          <Pressable accessible={false} {...actionProps}>
+            <MessageBubble
+              botId={botId ?? snap?.members?.[0]?.botId ?? ""}
+              groupId={groupId}
+              message={message}
+              botName={name}
+              bots={mentionBots}
+              members={snap?.members}
+              replyPreview={
+                message.replyToMessageId ? messagesById.get(message.replyToMessageId) : undefined
+              }
+              canAnswer={message.id === answerableAskMessageId}
+              onAnswer={answerMessage}
+              onOpenBot={openBot}
+              onPreviewMarkdown={setMarkdownPreview}
+              actionProps={actionProps}
+            />
+          </Pressable>
+          {canReactToThreadMessage(message) && message.thumbsUp ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={t("Remove thumbs-up")}
+              accessibilityState={{ selected: true }}
+              onPress={() => void reactToMessage(message)}
+              hitSlop={8}
+              style={{
+                alignSelf: message.role === "user" ? "flex-end" : "flex-start",
+                marginTop: 4,
+              }}
+            >
+              <Text style={{ color: tokens.warning, fontSize: 13 }}>👍</Text>
             </Pressable>
-            {canReactToThreadMessage(message) ? (
-              <Pressable
-                accessibilityLabel={message.thumbsUp ? t("Remove thumbs-up") : t("Add thumbs-up")}
-                accessibilityState={{ selected: Boolean(message.thumbsUp) }}
-                onPress={() => void reactToMessage(message)}
-              >
-                <Text
-                  style={{
-                    color: message.thumbsUp ? tokens.warning : tokens.mutedForeground,
-                    fontSize: 13,
-                  }}
-                >
-                  👍
-                </Text>
-              </Pressable>
-            ) : null}
-          </View>
-          <MessageBubble
-            botId={botId ?? snap?.members?.[0]?.botId ?? ""}
-            groupId={groupId}
-            message={message}
-            botName={name}
-            bots={mentionBots}
-            members={snap?.members}
-            replyPreview={
-              message.replyToMessageId ? messagesById.get(message.replyToMessageId) : undefined
-            }
-            canAnswer={message.id === answerableAskMessageId}
-            onAnswer={answerMessage}
-            onOpenBot={openBot}
-            onPreviewMarkdown={setMarkdownPreview}
-            onSpeak={message.role === "bot" ? speak : undefined}
-          />
+          ) : null}
         </View>
       </View>
     );
@@ -2136,6 +2164,11 @@ async function speakMessage(botId: string, message: MobileMessage) {
   }
 }
 
+type MessageActionProps = Pick<
+  PressableProps,
+  "onLongPress" | "accessibilityActions" | "onAccessibilityAction"
+>;
+
 const MessageBubble = memo(function MessageBubble({
   botId,
   botName,
@@ -2148,7 +2181,7 @@ const MessageBubble = memo(function MessageBubble({
   onAnswer,
   onOpenBot,
   onPreviewMarkdown,
-  onSpeak,
+  actionProps,
 }: {
   botId: string;
   botName?: string;
@@ -2161,7 +2194,7 @@ const MessageBubble = memo(function MessageBubble({
   onAnswer: (message: MobileMessage, answer: string) => Promise<void>;
   onOpenBot: (botId: string, name: string) => void;
   onPreviewMarkdown: (target: MarkdownArtifactPreviewTarget) => void;
-  onSpeak?: (message: MobileMessage) => void;
+  actionProps: MessageActionProps;
 }) {
   const colorScheme = useResolvedAppearance();
   const tokens = mobileTokens();
@@ -2502,6 +2535,7 @@ const MessageBubble = memo(function MessageBubble({
         {attachments.map((attachment, index) =>
           attachment.kind === "image" ? (
             <Pressable
+              {...actionProps}
               key={`${attachment.artifactId ?? attachment.name ?? "image"}-${index}`}
               onPress={() =>
                 attachment.artifactId
@@ -2530,6 +2564,7 @@ const MessageBubble = memo(function MessageBubble({
             </Pressable>
           ) : (
             <Pressable
+              {...actionProps}
               key={`${attachment.artifactId ?? attachment.name ?? "file"}-${index}`}
               onPress={() =>
                 attachment.artifactId
@@ -2586,10 +2621,6 @@ const MessageBubble = memo(function MessageBubble({
   const speaker =
     message.role === "bot" ? (memberName(members, message.botId) ?? botName) : undefined;
   const firstContent = segments.findIndex((segment) => segment.kind === "content");
-  const lastContent = segments.reduce(
-    (last, segment, index) => (segment.kind === "content" ? index : last),
-    -1,
-  );
   return (
     <View style={{ gap: 8, width: "100%" }}>
       {segments.map((segment, index) => (
@@ -2598,7 +2629,7 @@ const MessageBubble = memo(function MessageBubble({
           message={{ ...message, blocks: segment.blocks }}
           speaker={index === firstContent ? speaker : undefined}
           replyPreview={index === firstContent ? replyPreview : undefined}
-          onSpeak={index === lastContent && onSpeak ? () => onSpeak(message) : undefined}
+          actionProps={actionProps}
         />
       ))}
       {appConnectBlocks.map((block, index) => (
@@ -2612,37 +2643,20 @@ function MessageTextCard({
   message,
   speaker,
   replyPreview,
-  onSpeak,
+  actionProps,
 }: {
   message: MobileMessage;
   speaker?: string;
   replyPreview?: MobileMessage;
-  onSpeak?: () => void;
+  actionProps: MessageActionProps;
 }) {
   const colorScheme = useResolvedAppearance();
   const tokens = mobileTokens();
-  const { t } = useI18n();
   const contentText = blockText(message);
   if (!contentText) return null;
   return (
     <Pressable
-      onLongPress={
-        onSpeak
-          ? () =>
-              Alert.alert("", undefined, [
-                { text: t("Speak message"), onPress: onSpeak },
-                { text: t("Cancel"), style: "cancel" },
-              ])
-          : undefined
-      }
-      accessibilityActions={onSpeak ? [{ name: "speak", label: t("Speak message") }] : undefined}
-      onAccessibilityAction={
-        onSpeak
-          ? (event) => {
-              if (event.nativeEvent.actionName === "speak") onSpeak();
-            }
-          : undefined
-      }
+      {...actionProps}
       style={{
         flexShrink: 1,
         minWidth: 0,

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -2449,6 +2449,13 @@ const MessageBubble = memo(function MessageBubble({
     return (
       <View style={{ gap: 8, width: "100%" }}>
         <View
+          accessible={!askBlock.text && !askBlock.detail}
+          accessibilityActions={
+            !askBlock.text && !askBlock.detail ? actionProps.accessibilityActions : undefined
+          }
+          onAccessibilityAction={
+            !askBlock.text && !askBlock.detail ? actionProps.onAccessibilityAction : undefined
+          }
           style={{
             width: "90%",
             borderRadius: 18,
@@ -2469,9 +2476,10 @@ const MessageBubble = memo(function MessageBubble({
           ) : null}
           {askBlock.detail ? (
             <Text
+              {...(askBlock.text ? {} : actionProps)}
               style={{
                 color: tokens.mutedForeground,
-                marginTop: 8,
+                marginTop: askBlock.text ? 8 : 0,
                 fontSize: 12.5,
                 fontFamily: "Menlo",
                 lineHeight: 20,

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1359,7 +1359,7 @@ function Thread() {
             flexShrink: 1,
           }}
         >
-          <Pressable accessible={false} {...actionProps}>
+          <Pressable accessible={false} onLongPress={actionProps.onLongPress}>
             <MessageBubble
               botId={botId ?? snap?.members?.[0]?.botId ?? ""}
               groupId={groupId}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -1279,7 +1279,12 @@ function Thread() {
             (index) => actions[index]?.onPress(),
           );
         } else {
-          Alert.alert("", undefined, actions, { cancelable: true });
+          Alert.alert(
+            "",
+            undefined,
+            [...actions, { text: t("Cancel"), style: "cancel" }],
+            { cancelable: true },
+          );
         }
       },
       accessibilityActions: actions.map((action) => ({ name: action.name, label: action.text })),

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -2449,13 +2449,6 @@ const MessageBubble = memo(function MessageBubble({
     return (
       <View style={{ gap: 8, width: "100%" }}>
         <View
-          accessible={!askBlock.text && !askBlock.detail}
-          accessibilityActions={
-            !askBlock.text && !askBlock.detail ? actionProps.accessibilityActions : undefined
-          }
-          onAccessibilityAction={
-            !askBlock.text && !askBlock.detail ? actionProps.onAccessibilityAction : undefined
-          }
           style={{
             width: "90%",
             borderRadius: 18,
@@ -2490,6 +2483,7 @@ const MessageBubble = memo(function MessageBubble({
           ) : null}
           {askBlock.status === "answered" ? (
             <Text
+              {...actionProps}
               style={{
                 color: tokens.success,
                 marginTop: 12,
@@ -2506,10 +2500,15 @@ const MessageBubble = memo(function MessageBubble({
           ) : canAnswer && onAnswer ? (
             <AskActions
               actions={askBlock.actions}
+              accessibilityActions={actionProps.accessibilityActions}
+              onAccessibilityAction={actionProps.onAccessibilityAction}
               onAnswer={(answer) => onAnswer(message, answer)}
             />
           ) : (
-            <Text style={{ color: tokens.mutedForeground, marginTop: 12, fontSize: 13.5 }}>
+            <Text
+              {...actionProps}
+              style={{ color: tokens.mutedForeground, marginTop: 12, fontSize: 13.5 }}
+            >
               {t("No longer active")}
             </Text>
           )}

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -40,10 +40,10 @@ import {
   type NativeSyntheticEvent,
   Platform,
   Pressable,
-  type PressableProps,
   ScrollView,
   Text,
   TextInput,
+  type TextProps,
   View,
 } from "react-native";
 import { KeyboardAvoidingView } from "react-native-keyboard-controller";
@@ -1279,10 +1279,14 @@ function Thread() {
             (index) => actions[index]?.onPress(),
           );
         } else {
+          // Android alerts allow at most three buttons; Back/outside tap always dismisses.
           Alert.alert(
             "",
             undefined,
-            [...actions, { text: t("Cancel"), style: "cancel" }],
+            [
+              ...actions,
+              ...(actions.length < 3 ? [{ text: t("Cancel"), style: "cancel" as const }] : []),
+            ],
             { cancelable: true },
           );
         }
@@ -2170,7 +2174,7 @@ async function speakMessage(botId: string, message: MobileMessage) {
 }
 
 type MessageActionProps = Pick<
-  PressableProps,
+  TextProps,
   "onLongPress" | "accessibilityActions" | "onAccessibilityAction"
 >;
 
@@ -2220,11 +2224,18 @@ const MessageBubble = memo(function MessageBubble({
       <View style={{ gap: 8, width: "100%" }}>
         <AskBlock
           ask={ask}
+          actionProps={actionProps}
           canAnswer={canAnswer}
           onAnswer={(answer) => onAnswer(message, answer)}
         />
         {appConnectBlocks.map((block, index) => (
-          <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
+          <AppConnectCard
+            key={`${block.provider}-${index}`}
+            botId={cardBotId}
+            block={block}
+            accessibilityActions={actionProps.accessibilityActions}
+            onAccessibilityAction={actionProps.onAccessibilityAction}
+          />
         ))}
       </View>
     );
@@ -2235,6 +2246,7 @@ const MessageBubble = memo(function MessageBubble({
     const to = memberName(members, handoff.toBotId) ?? t("bot");
     return (
       <AgentEventLabel
+        actionProps={actionProps}
         label={t("{from} messaged {to}", { from, to })}
         detail={handoff.text}
         expanded={peerExpanded}
@@ -2262,7 +2274,8 @@ const MessageBubble = memo(function MessageBubble({
     // Compact receipt only: peer bodies stay out of the human thread.
     // Full view-only peer chat is web-first; mobile keeps the chip without expand.
     return (
-      <View
+      <Pressable
+        {...actionProps}
         accessible
         accessibilityLabel={label}
         style={{
@@ -2281,7 +2294,7 @@ const MessageBubble = memo(function MessageBubble({
         >
           {label}
         </Text>
-      </View>
+      </Pressable>
     );
   }
   const channelMessage = message.blocks.find(
@@ -2290,12 +2303,15 @@ const MessageBubble = memo(function MessageBubble({
   );
   if (channelMessage) {
     return (
-      <View style={{ width: "100%", paddingVertical: 4, alignItems: "center" }}>
+      <Pressable
+        {...actionProps}
+        style={{ width: "100%", paddingVertical: 4, alignItems: "center" }}
+      >
         <Text style={{ color: tokens.mutedForeground, fontSize: 13.5, textAlign: "center" }}>
           {messagingProviderLabel(channelMessage.provider)} · {channelMessage.fromLabel}:{" "}
           {channelMessage.text}
         </Text>
-      </View>
+      </Pressable>
     );
   }
   const special = message.blocks.find(
@@ -2305,7 +2321,8 @@ const MessageBubble = memo(function MessageBubble({
     const running = special.status === "running";
     const failed = special.status === "failed";
     return (
-      <View
+      <Pressable
+        {...actionProps}
         style={{
           width: "90%",
           borderRadius: 18,
@@ -2353,15 +2370,17 @@ const MessageBubble = memo(function MessageBubble({
             </ChatMarkdown>
           </View>
         ) : null}
-      </View>
+      </Pressable>
     );
   }
   if (special?.kind === "child_bot") {
     const removed = special.status === "deleted" || special.status === "archived";
     return (
       <Pressable
-        disabled={removed}
-        onPress={() => onOpenBot(special.botId ?? "", special.name ?? t("Bot"))}
+        {...actionProps}
+        onPress={
+          removed ? undefined : () => onOpenBot(special.botId ?? "", special.name ?? t("Bot"))
+        }
         style={{
           width: "90%",
           borderRadius: 18,
@@ -2412,7 +2431,13 @@ const MessageBubble = memo(function MessageBubble({
     return (
       <View style={{ gap: 8, width: "100%" }}>
         {appConnectBlocks.map((block, index) => (
-          <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
+          <AppConnectCard
+            key={`${block.provider}-${index}`}
+            botId={cardBotId}
+            block={block}
+            accessibilityActions={actionProps.accessibilityActions}
+            onAccessibilityAction={actionProps.onAccessibilityAction}
+          />
         ))}
       </View>
     );
@@ -2435,7 +2460,10 @@ const MessageBubble = memo(function MessageBubble({
           }}
         >
           {askBlock.text ? (
-            <Text style={{ color: tokens.foreground, fontSize: 15.5, lineHeight: 23 }}>
+            <Text
+              {...actionProps}
+              style={{ color: tokens.foreground, fontSize: 15.5, lineHeight: 23 }}
+            >
               {askBlock.text}
             </Text>
           ) : null}
@@ -2479,7 +2507,13 @@ const MessageBubble = memo(function MessageBubble({
           )}
         </View>
         {appConnectBlocks.map((block, index) => (
-          <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
+          <AppConnectCard
+            key={`${block.provider}-${index}`}
+            botId={cardBotId}
+            block={block}
+            accessibilityActions={actionProps.accessibilityActions}
+            onAccessibilityAction={actionProps.onAccessibilityAction}
+          />
         ))}
       </View>
     );
@@ -2617,7 +2651,13 @@ const MessageBubble = memo(function MessageBubble({
           ),
         )}
         {appConnectBlocks.map((block, index) => (
-          <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
+          <AppConnectCard
+            key={`${block.provider}-${index}`}
+            botId={cardBotId}
+            block={block}
+            accessibilityActions={actionProps.accessibilityActions}
+            onAccessibilityAction={actionProps.onAccessibilityAction}
+          />
         ))}
       </View>
     );
@@ -2638,7 +2678,13 @@ const MessageBubble = memo(function MessageBubble({
         />
       ))}
       {appConnectBlocks.map((block, index) => (
-        <AppConnectCard key={`${block.provider}-${index}`} botId={cardBotId} block={block} />
+        <AppConnectCard
+          key={`${block.provider}-${index}`}
+          botId={cardBotId}
+          block={block}
+          accessibilityActions={actionProps.accessibilityActions}
+          onAccessibilityAction={actionProps.onAccessibilityAction}
+        />
       ))}
     </View>
   );
@@ -2717,17 +2763,20 @@ function AgentEventLabel({
   detail,
   expanded,
   onToggle,
+  actionProps,
 }: {
   label: string;
   detail?: string;
   expanded: boolean;
   onToggle: () => void;
+  actionProps: MessageActionProps;
 }) {
   const colorScheme = useResolvedAppearance();
   const tokens = mobileTokens();
   const { t } = useI18n();
   return (
     <Pressable
+      {...actionProps}
       onPress={onToggle}
       accessibilityRole="button"
       accessibilityLabel={expanded ? t("Hide {label}", { label }) : t("Show {label}", { label })}
@@ -2762,10 +2811,12 @@ function AskBlock({
   ask,
   canAnswer,
   onAnswer,
+  actionProps,
 }: {
   ask: Extract<MobileMessage["blocks"][number], { kind: "ask" }>;
   canAnswer: boolean;
   onAnswer: (answer: string) => Promise<void>;
+  actionProps: MessageActionProps;
 }) {
   const tokens = useMobileTokens();
   const { t } = useI18n();
@@ -2803,7 +2854,10 @@ function AskBlock({
         gap: 10,
       }}
     >
-      <Text style={{ color: tokens.foreground, fontSize: 15.5, fontWeight: "600" }}>
+      <Text
+        {...actionProps}
+        style={{ color: tokens.foreground, fontSize: 15.5, fontWeight: "600" }}
+      >
         {ask.text}
       </Text>
       {ask.detail ? (

--- a/apps/mobile/components/AppConnectCard.tsx
+++ b/apps/mobile/components/AppConnectCard.tsx
@@ -1,7 +1,7 @@
 import type { MessageBlock } from "@rakazo/contracts";
 import { abortableDelay } from "@rakazo/core";
 import { useEffect, useRef, useState } from "react";
-import { ActivityIndicator, Linking, Pressable, Text, View } from "react-native";
+import { ActivityIndicator, Linking, Pressable, Text, View, type ViewProps } from "react-native";
 import { rpc } from "../lib/api";
 import { appConnectPresentation } from "../lib/app-connect";
 import { useI18n } from "../lib/i18n";
@@ -10,9 +10,13 @@ import { native, useMobileTokens } from "../lib/native";
 export function AppConnectCard({
   botId,
   block,
+  accessibilityActions,
+  onAccessibilityAction,
 }: {
   botId: string;
   block: Extract<MessageBlock, { kind: "app_connect" }>;
+  accessibilityActions?: ViewProps["accessibilityActions"];
+  onAccessibilityAction?: ViewProps["onAccessibilityAction"];
 }) {
   const { t } = useI18n();
   const tokens = useMobileTokens();
@@ -101,7 +105,11 @@ export function AppConnectCard({
           </Text>
         </View>
         <View style={{ flex: 1, gap: 2 }}>
-          <Text style={{ color: tokens.foreground, fontSize: 15, fontWeight: "600" }}>
+          <Text
+            accessibilityActions={accessibilityActions}
+            onAccessibilityAction={onAccessibilityAction}
+            style={{ color: tokens.foreground, fontSize: 15, fontWeight: "600" }}
+          >
             {view.title}
           </Text>
           <Text style={{ color: tokens.mutedForeground, fontSize: 13.5 }} numberOfLines={2}>

--- a/apps/mobile/components/AskActions.tsx
+++ b/apps/mobile/components/AskActions.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Alert, Pressable, Text, View } from "react-native";
+import { Alert, Pressable, Text, View, type ViewProps } from "react-native";
 import { mobileTokens } from "../lib/appearance";
 import { useI18n } from "../lib/i18n";
 
@@ -15,10 +15,14 @@ export function AskActions({
   actions,
   disabled,
   onAnswer,
+  accessibilityActions,
+  onAccessibilityAction,
 }: {
   actions: AskAction[];
   disabled?: boolean;
   onAnswer: (answer: string) => Promise<void>;
+  accessibilityActions?: ViewProps["accessibilityActions"];
+  onAccessibilityAction?: ViewProps["onAccessibilityAction"];
 }) {
   const { t } = useI18n();
   const tokens = mobileTokens();
@@ -47,6 +51,8 @@ export function AskActions({
         return (
           <Pressable
             key={action.id}
+            accessibilityActions={accessibilityActions}
+            onAccessibilityAction={onAccessibilityAction}
             disabled={disabled || submitting}
             onPress={() => void submit(action.id)}
             style={{


### PR DESCRIPTION
## Why

The mobile sign-in form separates the password field from its primary action, and every chat message displays Reply and an unused thumbs-up control. Keep sign-in focused and messages quiet until actions are needed.

## What changed

- Center “Forgot password?” below the Sign in button.
- Reveal Reply, thumbs-up, and available Speak actions on long press using native menus in direct and group chats. Keep only added reactions visible below messages, with tap to remove.
- Preserve screen-reader actions and attachment taps.

Existing copy “Forgot password?”, “Reply”, “Add thumbs-up”, “Remove thumbs-up”, “Speak message”, and “Cancel” is reused. Recovery remains visible below sign-in so it can be found without a failed login; message action labels appear only when requested and identify their actions.

## Validation

- Mobile dependency checks and TypeScript checks pass.
- All 168 mobile unit tests pass.
- Formatting and diff checks pass.
- Extended the Android Maestro flow to verify hidden actions, long press, reaction add/remove in direct and group chats, and replying to a user message.
- Android Maestro interaction checks and screenshot capture pass, including direct/group reaction add/remove and user-message reply. Screenshots cover the final mobile code; the subsequent main merge changes only computer-control backend logic and its tests.
- Full CI lint, typecheck, unit tests, database journeys, production builds, desktop smoke, web E2E, and image validation pass.
- This change affects native mobile UI; web and Electron UI are unchanged.

## Android screenshots

[Gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/mobile-android/runs/33976970339-1/index.html) · [CI run](https://github.com/elie222/rakazo/actions/runs/33976970339)

- [Sign in](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/mobile-android/runs/33976970339-1/images/01-sign-in.png)
- [Thread](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/mobile-android/runs/33976970339-1/images/15-thread.png)
- [Long-press actions](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/mobile-android/runs/33976970339-1/images/15b-message-actions.png)
- [Added reaction](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/mobile-android/runs/33976970339-1/images/15c-message-reaction.png)
