### PR TITLE
docs(setup): match the declared Node engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ the `https://` address.
 
 ## Local development (source checkout)
 
-You need Node.js 22+, pnpm 9, and Docker.
+You need Node.js 22.22.2 or newer in the 22.x line, Node.js 24.x, or Node.js 26+;
+pnpm 9; and Docker. Node.js 23.x and 25.x are not supported.
 
 ```bash
 git clone https://github.com/elie222/rakazo.git

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -94,7 +94,7 @@ Do not ask me to invent `BETTER_AUTH_SECRET` or `ENCRYPTION_KEY`; generate stron
 Preflight:
 
 - Verify Git, Node.js, pnpm, Docker, and Docker Compose.
-- Use Node.js 22 LTS (at least 22.12) and the repository-declared pnpm 9.15.0. Do not silently use pnpm 10 or 11: newer pnpm versions can reject this lockfile or rewrite it. Prefer Corepack; if Corepack is unavailable, use `npx --yes pnpm@9.15.0` for repo commands rather than globally installing a different version. Show the effective versions.
+- Use Node.js 22.22.2 or newer in the 22.x line, Node.js 24.x, or Node.js 26+; Node.js 23.x and 25.x are not supported. Use the repository-declared pnpm 9.15.0. Do not silently use pnpm 10 or 11: newer pnpm versions can reject this lockfile or rewrite it. Prefer Corepack; if Corepack is unavailable, use `npx --yes pnpm@9.15.0` for repo commands rather than globally installing a different version. Show the effective versions.
 - Verify the Docker daemon is running.
 - Check whether `127.0.0.1` ports 5433, 3100, 5173, and 7091 are available. Resolve conflicts without touching unrelated workloads.
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -591,7 +591,7 @@ To run a hosted product (same codebase):
 
 1. Push `main` (this checkout may be ahead of GitHub).
 2. Provision managed Postgres 16 and run `pnpm db:migrate`.
-3. Run **API** and **worker** as always-on Node 22 services (Fly machines, a VM, ECS, k8s). Not lambda-style request handlers.
+3. Run **API** and **worker** as always-on services using Node.js 22.22.2 or newer in the 22.x line, Node.js 24.x, or Node.js 26+ (Fly machines, a VM, ECS, k8s). Node.js 23.x and 25.x are not supported. Not lambda-style request handlers.
 4. Persist and back up `DATA_DIR` (bot homes, browser profiles, artifacts). Today the concrete store is a local filesystem (`LocalAgentHomeStore`), so attach a Rakazo-owned durable volume shared by API and worker processes. The storage contract is separate from the computer-provider contract, but an object-storage implementation is not wired yet.
 5. Choose computers: **`SANDBOX_PROVIDER=e2b`**, `daytona`, or `box` with the matching provider key for a public or multi-user production service. Each Team or Private Computer reconnects to its sandbox id (`providerRef`), while workspace state is checkpointed outside the provider at run completion, explicit stop, and idle suspension. If that sandbox is gone—or the deployment changes providers—the replacement is hydrated from Rakazo's copy. Idle computers pause after `SANDBOX_IDLE_MS` (default 10 minutes) and resume on the next message or Take control. Docker remains the local and trusted single-machine default.
 6. A Hetzner CX22 (2 vCPU / 4 GB) is enough for API + worker + Postgres when E2B owns the desktops. 2 GB works for a quiet box; 8 GB is only needed if you also run Docker computers on that same machine.


### PR DESCRIPTION
## Why

The source-checkout docs currently accept Node.js 22+ or 22.12+, while `package.json` only declares `^22.22.2 || ^24.0.0 || >=26.0.0`. That can send users into an install with an unsupported 22.x release and also implies unsupported 23.x/25.x releases.

Closes #587.

## What

- Replace the broad version guidance with “Node.js 22.22.2 or newer in the 22.x line, Node.js 24.x, or Node.js 26+”.
- State explicitly that “Node.js 23.x and 25.x are not supported.”
- Apply the same contract to README local development, the coding-agent setup prompt, and hosted API/worker guidance.

The exact visible wording is necessary here because it mirrors the machine-enforced engine ranges without the ambiguity of “22+”; the explicit exclusions keep users from reading the prose as any later major.

## Test

- Parsed `package.json` and asserted the declared engine remains `^22.22.2 || ^24.0.0 || >=26.0.0`.
- Asserted all three setup documents contain the supported ranges and the 23.x/25.x exclusions.
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated local development, setup, and self-hosting requirements to support Node.js 22.22.2+ (22.x), 24.x, or 26+.
  - Clarified that Node.js 23.x and 25.x are not supported.
  - Retained the existing pnpm 9 and Docker requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->