### PR TITLE
fix(integrations): support multiple named accounts

### DIFF
--- a/apps/api/src/router.test.ts
+++ b/apps/api/src/router.test.ts
@@ -404,7 +404,125 @@ describe("connections.complete", () => {
       { state: "gmail-state", code: "123456" },
       expect.objectContaining({ spaceId: "workspace-1", userId: "user-1" }),
     );
-    expect(connectionReady).toHaveBeenCalled();
+    expect(connectionReady).toHaveBeenCalledWith(
+      expect.objectContaining({ spaceId: "workspace-1", userId: "user-1" }),
+      "gmail",
+      "gmail-state",
+    );
+  });
+});
+
+describe("connections account identity", () => {
+  const actor = {
+    spaceId: "workspace-1",
+    userId: "user-1",
+    email: "user@rakazo.test",
+    isDeploymentOwner: true,
+  } satisfies Actor;
+
+  it("passes the user label to the provider when beginning a connection", async () => {
+    const begin = vi.fn().mockResolvedValue({
+      authorizationUrl: "https://auth.example/connect",
+      state: "ca-project-a",
+    });
+    const update = vi.fn().mockResolvedValue({});
+    const prisma = {
+      connection: {
+        create: vi.fn().mockResolvedValue({ id: "conn-1" }),
+        update,
+      },
+    } as unknown as PrismaClient;
+    const deps = {
+      prisma,
+      connectors: { managed: vi.fn(() => ({ begin })) },
+      env: {
+        defaultProvider: "fake",
+        defaultModel: "fake-model",
+        webOrigin: "https://rakazo.example",
+        screenProxySecret: "fake-test-secret",
+        sandboxProvider: "fake",
+      },
+      dataDir: "/tmp/rakazo-router-test",
+    } as unknown as RouterDeps;
+    const handler = new RPCHandler(createRouter(deps));
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/connections/begin", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          json: {
+            connectorId: "composio",
+            provider: "gmail",
+            displayName: "Project A",
+          },
+        }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(begin).toHaveBeenCalledWith(
+      {
+        provider: "gmail",
+        redirectUrl: "https://rakazo.example/app",
+        alias: "Project A",
+      },
+      expect.objectContaining({ userId: "user-1" }),
+    );
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "conn-1" },
+      data: {
+        status: "pending",
+        providerRef: "ca-project-a",
+        metadata: { state: "ca-project-a" },
+      },
+    });
+  });
+
+  it("revokes only the selected provider account reference", async () => {
+    const revoke = vi.fn().mockResolvedValue(undefined);
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const prisma = {
+      connection: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "conn-work",
+          connectorId: "composio",
+          provider: "gmail",
+          providerRef: "ca-work",
+        }),
+        updateMany,
+      },
+    } as unknown as PrismaClient;
+    const deps = {
+      prisma,
+      connectors: { managed: vi.fn(() => ({ revoke })) },
+      env: {
+        defaultProvider: "fake",
+        defaultModel: "fake-model",
+        webOrigin: "https://rakazo.example",
+        screenProxySecret: "fake-test-secret",
+        sandboxProvider: "fake",
+      },
+      dataDir: "/tmp/rakazo-router-test",
+    } as unknown as RouterDeps;
+    const handler = new RPCHandler(createRouter(deps));
+
+    const { response } = await handler.handle(
+      new Request("http://127.0.0.1/rpc/connections/revoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ json: { connectionId: "conn-work" } }),
+      }),
+      { prefix: "/rpc", context: { actor } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(revoke).toHaveBeenCalledWith("ca-work", expect.objectContaining({ userId: "user-1" }));
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: "conn-work", spaceId: "workspace-1", userId: "user-1" },
+      data: { status: "revoked" },
+    });
   });
 });
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -188,7 +188,7 @@ async function reconcilePendingConnections(
         connectorId,
         status: { in: ["pending", "connected"] },
       },
-      select: { id: true, provider: true, displayName: true, status: true },
+      select: { id: true, provider: true, providerRef: true, displayName: true, status: true },
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     })
   ).filter((row: { provider: string }) =>
@@ -2874,7 +2874,11 @@ export function createRouter(deps: RouterDeps) {
         });
         try {
           const auth = await connector.begin(
-            { provider: input.provider, redirectUrl: `${deps.env.webOrigin}/app` },
+            {
+              provider: input.provider,
+              redirectUrl: `${deps.env.webOrigin}/app`,
+              alias: input.displayName,
+            },
             connectionContext(context.actor, "connections.begin", context.signal),
           );
           await deps.prisma.connection.update({
@@ -2925,6 +2929,7 @@ export function createRouter(deps: RouterDeps) {
           const ready = await connector.connectionReady(
             connectionContext(context.actor, "connections.complete", context.signal),
             existing.provider,
+            existing.providerRef ?? undefined,
           );
           if (ready) {
             row = await deps.prisma.connection.update({
@@ -2960,7 +2965,7 @@ export function createRouter(deps: RouterDeps) {
           }
           try {
             await connector.revoke(
-              row.provider,
+              row.providerRef ?? row.provider,
               connectionContext(context.actor, "connections.revoke", context.signal),
             );
           } catch (error) {

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -150,27 +150,50 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   ).toBeHidden();
   await captureScreenshot(page, testInfo, "11-plugins-catalog");
 
-  // Nearest ancestor with an Add/Remove control (featured tile or catalog row).
+  // Nearest ancestor with an account manager control (featured tile or catalog row).
   const gmailRow = featured
     .getByText("Gmail", { exact: true })
     .locator("xpath=ancestor::*[.//button][1]");
   await gmailRow.getByRole("button", { name: "Add", exact: true }).click();
-  await expect(gmailRow.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
+  await gmailRow.getByRole("textbox", { name: "Account label" }).fill("Personal");
+  await gmailRow.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect(gmailRow.getByRole("button", { name: "Manage", exact: true })).toBeVisible();
+  await expect(gmailRow.getByText("Personal", { exact: true })).toBeVisible();
+
+  await gmailRow.getByRole("button", { name: "Add another account", exact: true }).click();
+  await gmailRow.getByRole("textbox", { name: "Account label" }).fill("Work");
+  await gmailRow.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect(gmailRow.getByText("Personal", { exact: true })).toBeVisible();
+  await expect(gmailRow.getByText("Work", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11a-connected-plugins");
 
-  await gmailRow.getByRole("button", { name: "Remove", exact: true }).click();
+  await gmailRow
+    .getByText("Personal", { exact: true })
+    .locator("xpath=ancestor::*[.//button][1]")
+    .getByRole("button", { name: "Remove", exact: true })
+    .click();
+  await expect(gmailRow.getByText("Work", { exact: true })).toBeVisible();
+  await gmailRow
+    .getByText("Work", { exact: true })
+    .locator("xpath=ancestor::*[.//button][1]")
+    .getByRole("button", { name: "Remove", exact: true })
+    .click();
+  await gmailRow.getByRole("button", { name: "Done", exact: true }).click();
   await expect(gmailRow.getByRole("button", { name: "Add", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "11b-connected-plugins-empty");
 
   const linearRow = page
     .getByText("Linear", { exact: true })
     .locator("xpath=ancestor::*[.//button][1]");
-  const connectPopup = page.waitForEvent("popup");
   await linearRow.getByRole("button", { name: "Add", exact: true }).click();
+  await linearRow.getByRole("textbox", { name: "Account label" }).fill("Project A");
+  const connectPopup = page.waitForEvent("popup");
+  await linearRow.getByRole("button", { name: "Connect", exact: true }).click();
   const popup = await connectPopup;
   await popup.close();
-  await expect(linearRow.getByRole("button", { name: "Remove", exact: true })).toBeVisible();
+  await expect(linearRow.getByRole("button", { name: "Manage", exact: true })).toBeVisible();
   await linearRow.getByRole("button", { name: "Remove", exact: true }).click();
+  await linearRow.getByRole("button", { name: "Done", exact: true }).click();
   await expect(linearRow.getByRole("button", { name: "Add", exact: true })).toBeVisible();
 
   const advanced = page.getByTestId("integrations-advanced");

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import type { CapabilityInstall, ConnectionCatalogItem } from "@rakazo/contracts";
+import type { CapabilityInstall, Connection, ConnectionCatalogItem } from "@rakazo/contracts";
 import {
   abortableDelay,
   buildFeaturedConnectorTiles,
@@ -32,17 +32,6 @@ function itemKey(item: Pick<ConnectionCatalogItem, "connectorId" | "slug">) {
   return `${item.connectorId}:${item.slug}`;
 }
 
-function markConnected(
-  items: ConnectionCatalogItem[],
-  connectorId: string,
-  slug: string,
-  connected: boolean,
-) {
-  return items.map((entry) =>
-    entry.connectorId === connectorId && entry.slug === slug ? { ...entry, connected } : entry,
-  );
-}
-
 export function PluginsOverlay({
   onClose,
   onOpenMcp,
@@ -56,6 +45,7 @@ export function PluginsOverlay({
   const [query, setQuery] = useState("");
   const [visibleCount, setVisibleCount] = useState(CONNECTION_CATALOG_PAGE_SIZE);
   const [catalog, setCatalog] = useState<ConnectionCatalogItem[]>([]);
+  const [connections, setConnections] = useState<Connection[]>([]);
   const [sources, setSources] = useState<CapabilityInstall[]>([]);
   const [sourceKind, setSourceKind] = useState<SourceKind | null>(null);
   const [sourceName, setSourceName] = useState("");
@@ -64,17 +54,22 @@ export function PluginsOverlay({
   const [authType, setAuthType] = useState<"none" | "bearer" | "header">("bearer");
   const [authName, setAuthName] = useState("x-api-key");
   const [pending, setPending] = useState<string | null>(null);
+  const [managing, setManaging] = useState<string | null>(null);
+  const [draftLabel, setDraftLabel] = useState("");
+  const [showConnectForm, setShowConnectForm] = useState(false);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [sourceError, setSourceError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const connectionAttempt = useRef<AbortController | null>(null);
 
   async function refresh() {
-    const [items, installs] = await Promise.all([
+    const [items, installs, rows] = await Promise.all([
       rpc.connections.catalog({}),
       rpc.capabilities.list(),
+      rpc.connections.list(),
     ]);
     setCatalog(items);
+    setConnections(rows);
     setSources(installs.filter((install) => install.kind === "mcp" || install.kind === "api"));
     return items;
   }
@@ -101,11 +96,9 @@ export function PluginsOverlay({
       .catch(() => undefined);
   }
 
-  function setItemConnected(item: ConnectionCatalogItem, connected: boolean) {
-    setCatalog((prev) => markConnected(prev, item.connectorId, item.slug, connected));
-  }
-
   async function connect(item: ConnectionCatalogItem) {
+    const label = draftLabel.trim();
+    if (!label) return;
     connectionAttempt.current?.abort();
     const controller = new AbortController();
     connectionAttempt.current = controller;
@@ -116,14 +109,16 @@ export function PluginsOverlay({
       const started = await rpc.connections.begin({
         connectorId: item.connectorId,
         provider: item.slug,
-        displayName: item.name,
+        displayName: label,
       });
       if (started.authorizationUrl)
         window.open(started.authorizationUrl, "rakazo-plugin-connect", "noopener,noreferrer");
       if (item.noAuth && !started.authorizationUrl) {
         if (controller.signal.aborted) return;
-        setItemConnected(item, true);
+        await refresh();
         void notifyAppConnected(item);
+        setShowConnectForm(false);
+        setDraftLabel("");
         return;
       }
       for (let i = 0; i < 45; i += 1) {
@@ -133,8 +128,10 @@ export function PluginsOverlay({
           .catch(() => undefined);
         if (row?.status === "connected") {
           if (controller.signal.aborted) return;
-          setItemConnected(item, true);
+          await refresh();
           void notifyAppConnected(item);
+          setShowConnectForm(false);
+          setDraftLabel("");
           return;
         }
         await abortableDelay(2_000, controller.signal);
@@ -154,27 +151,120 @@ export function PluginsOverlay({
     }
   }
 
-  async function revoke(item: ConnectionCatalogItem) {
+  async function revoke(row: Connection) {
     setCatalogError(null);
-    const key = itemKey(item);
-    setPending(key);
+    setPending(`connection:${row.id}`);
     try {
-      const rows = await rpc.connections.list();
-      const matches = rows.filter(
-        (entry) => entry.connectorId === item.connectorId && entry.provider === item.slug,
-      );
-      const row =
-        matches.find((entry) => entry.status === "connected") ??
-        matches.find((entry) => entry.status === "pending") ??
-        matches.find((entry) => entry.status === "error");
-      if (!row) throw new Error(t`No connection record found for ${item.name}.`);
       await rpc.connections.revoke({ connectionId: row.id });
-      setItemConnected(item, false);
+      await refresh();
     } catch (err) {
       setCatalogError(err instanceof Error ? err.message : t`Could not revoke connection`);
     } finally {
       setPending(null);
     }
+  }
+
+  function connectionRows(item: ConnectionCatalogItem) {
+    return connections.filter(
+      (row) =>
+        row.connectorId === item.connectorId &&
+        row.provider.toLowerCase() === item.slug.toLowerCase() &&
+        row.status !== "revoked",
+    );
+  }
+
+  function openManager(item: ConnectionCatalogItem) {
+    const key = itemKey(item);
+    const rows = connectionRows(item);
+    setManaging(key);
+    setShowConnectForm(rows.length === 0);
+    setDraftLabel("");
+  }
+
+  function renderConnectionManager(item: ConnectionCatalogItem) {
+    const key = itemKey(item);
+    if (managing !== key) return null;
+    const rows = connectionRows(item);
+    return (
+      <div
+        className="ml-12 mt-1 space-y-2 rounded-xl bg-muted/40 p-3"
+        data-testid={`accounts-${key}`}
+      >
+        {rows.map((row) => (
+          <div key={row.id} className="flex items-center gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm text-foreground">{row.displayName}</div>
+              {row.status !== "connected" ? (
+                <div className="text-xs capitalize text-muted-foreground">{row.status}</div>
+              ) : null}
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={pending === `connection:${row.id}`}
+              onClick={() => void revoke(row)}
+            >
+              {pending === `connection:${row.id}` ? (
+                <Trans>Removing…</Trans>
+              ) : (
+                <Trans>Remove</Trans>
+              )}
+            </Button>
+          </div>
+        ))}
+
+        {showConnectForm ? (
+          <div className="flex items-center gap-2">
+            <Input
+              autoFocus
+              value={draftLabel}
+              onChange={(event) => setDraftLabel(event.target.value)}
+              aria-label={t`Account label`}
+              placeholder={t`Account label, e.g. Personal`}
+              className="h-9"
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={!draftLabel.trim() || pending === key}
+              onClick={() => void connect(item)}
+            >
+              {pending === key ? <Trans>Connecting…</Trans> : <Trans>Connect</Trans>}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setShowConnectForm(false);
+                setDraftLabel("");
+                if (rows.length === 0) setManaging(null);
+              }}
+            >
+              <Trans>Cancel</Trans>
+            </Button>
+          </div>
+        ) : (
+          <div className="flex gap-2">
+            {item.connectorId === "composio" && !item.noAuth ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowConnectForm(true)}
+              >
+                <Trans>Add another account</Trans>
+              </Button>
+            ) : null}
+            <Button type="button" variant="ghost" size="sm" onClick={() => setManaging(null)}>
+              <Trans>Done</Trans>
+            </Button>
+          </div>
+        )}
+      </div>
+    );
   }
 
   function beginSource(kind: SourceKind) {
@@ -288,57 +378,48 @@ export function PluginsOverlay({
                     const disabled = tile.missing || !item;
                     const connected = item?.connected ?? false;
                     return (
-                      <div
-                        key={key}
-                        className={`flex min-w-0 items-center gap-3 rounded-xl px-2.5 py-2 ${
-                          disabled ? "opacity-70" : ""
-                        }`}
-                      >
-                        {item?.logo ? (
-                          <img
-                            src={item.logo}
-                            alt=""
-                            loading="lazy"
-                            decoding="async"
-                            className="h-9 w-9 shrink-0 rounded-xl bg-accent object-contain"
-                          />
-                        ) : (
-                          <div className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-accent text-sm font-semibold text-foreground">
-                            {tile.label[0]}
-                          </div>
-                        )}
-                        <div className="min-w-0 flex-1">
-                          <div className="truncate text-[15px] font-medium text-foreground">
-                            {tile.label}
-                          </div>
-                          {disabled ? (
-                            <div className="truncate text-[12.5px] text-muted-foreground">
-                              <Trans>Not in the plugin catalog</Trans>
+                      <div key={key} className={disabled ? "opacity-70" : ""}>
+                        <div className="flex min-w-0 items-center gap-3 rounded-xl px-2.5 py-2">
+                          {item?.logo ? (
+                            <img
+                              src={item.logo}
+                              alt=""
+                              loading="lazy"
+                              decoding="async"
+                              className="h-9 w-9 shrink-0 rounded-xl bg-accent object-contain"
+                            />
+                          ) : (
+                            <div className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-accent text-sm font-semibold text-foreground">
+                              {tile.label[0]}
                             </div>
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[15px] font-medium text-foreground">
+                              {tile.label}
+                            </div>
+                            {disabled ? (
+                              <div className="truncate text-[12.5px] text-muted-foreground">
+                                <Trans>Not in the plugin catalog</Trans>
+                              </div>
+                            ) : null}
+                          </div>
+                          {item && !tile.missing ? (
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              className="rounded-full"
+                              size="sm"
+                              onClick={() => openManager(item)}
+                            >
+                              {connected || connectionRows(item).length > 0 ? (
+                                <Trans>Manage</Trans>
+                              ) : (
+                                <Trans>Add</Trans>
+                              )}
+                            </Button>
                           ) : null}
                         </div>
-                        {item && !tile.missing ? (
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            className="rounded-full"
-                            size="sm"
-                            disabled={pending === key}
-                            onClick={() => void (connected ? revoke(item) : connect(item))}
-                          >
-                            {pending === key ? (
-                              connected ? (
-                                <Trans>Removing…</Trans>
-                              ) : (
-                                <Trans>Adding…</Trans>
-                              )
-                            ) : connected ? (
-                              <Trans>Remove</Trans>
-                            ) : (
-                              <Trans>Add</Trans>
-                            )}
-                          </Button>
-                        ) : null}
+                        {item && !tile.missing ? renderConnectionManager(item) : null}
                       </div>
                     );
                   })}
@@ -362,45 +443,41 @@ export function PluginsOverlay({
               {rendered.map((item) => {
                 const key = itemKey(item);
                 return (
-                  <div key={key} className="flex min-w-0 items-center gap-3 rounded-xl px-2.5 py-2">
-                    {item.logo ? (
-                      <img
-                        src={item.logo}
-                        alt=""
-                        loading="lazy"
-                        decoding="async"
-                        className="h-9 w-9 shrink-0 rounded-xl bg-accent object-contain"
-                      />
-                    ) : (
-                      <div className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-accent text-sm font-semibold text-foreground">
-                        {item.name[0]}
-                      </div>
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-[15px] font-medium text-foreground">
-                        {item.name}
-                      </div>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      className="rounded-full"
-                      size="sm"
-                      disabled={pending === key}
-                      onClick={() => void (item.connected ? revoke(item) : connect(item))}
-                    >
-                      {pending === key ? (
-                        item.connected ? (
-                          <Trans>Removing…</Trans>
-                        ) : (
-                          <Trans>Adding…</Trans>
-                        )
-                      ) : item.connected ? (
-                        <Trans>Remove</Trans>
+                  <div key={key}>
+                    <div className="flex min-w-0 items-center gap-3 rounded-xl px-2.5 py-2">
+                      {item.logo ? (
+                        <img
+                          src={item.logo}
+                          alt=""
+                          loading="lazy"
+                          decoding="async"
+                          className="h-9 w-9 shrink-0 rounded-xl bg-accent object-contain"
+                        />
                       ) : (
-                        <Trans>Add</Trans>
+                        <div className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-accent text-sm font-semibold text-foreground">
+                          {item.name[0]}
+                        </div>
                       )}
-                    </Button>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[15px] font-medium text-foreground">
+                          {item.name}
+                        </div>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        className="rounded-full"
+                        size="sm"
+                        onClick={() => openManager(item)}
+                      >
+                        {item.connected || connectionRows(item).length > 0 ? (
+                          <Trans>Manage</Trans>
+                        ) : (
+                          <Trans>Add</Trans>
+                        )}
+                      </Button>
+                    </div>
+                    {renderConnectionManager(item)}
                   </div>
                 );
               })}

--- a/packages/adapter-kit/src/interfaces.ts
+++ b/packages/adapter-kit/src/interfaces.ts
@@ -148,7 +148,7 @@ export interface ConnectorProvider {
 export interface ConnectionAuthProvider {
   describe(): AdapterDescriptor<{ oauth: boolean }>;
   begin(
-    request: { provider: string; redirectUrl: string },
+    request: { provider: string; redirectUrl: string; alias?: string },
     context: AdapterContext,
   ): Promise<{ authorizationUrl: string | null; state: string }>;
   complete(
@@ -164,7 +164,11 @@ export interface ManagedConnectorProvider
     Omit<ConnectionAuthProvider, "describe"> {
   catalog(context: AdapterContext, query?: string): Promise<ConnectorCatalogItem[]>;
   listConnectedExternalIds(context: AdapterContext): Promise<string[]>;
-  connectionReady(context: AdapterContext, externalId: string): Promise<boolean>;
+  connectionReady(
+    context: AdapterContext,
+    externalId: string,
+    connectionRef?: string,
+  ): Promise<boolean>;
   warmDirectory?(): Promise<void>;
 }
 

--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -20,7 +20,14 @@ import {
 import { DestinationEmulator } from "./destination-emulator.js";
 
 const composioSdkState = vi.hoisted(() => ({
+  accounts: [] as Array<{
+    id: string;
+    status: string;
+    toolkit: { slug: string };
+  }>,
+  authorizations: [] as Array<{ toolkit: string; options: Record<string, unknown> }>,
   created: [] as Array<{ userId: string; config: Record<string, unknown> }>,
+  deleted: [] as string[],
   directoryFails: false,
   executions: [] as Array<{ tool: string; args: Record<string, unknown> }>,
   sessions: new Map<
@@ -38,6 +45,14 @@ const composioSdkState = vi.hoisted(() => ({
         cursor?: string;
       }>;
       tools?: () => Promise<unknown[]>;
+      authorize?: (
+        toolkit: string,
+        options: Record<string, unknown>,
+      ) => Promise<{
+        id: string;
+        redirectUrl: string;
+        waitForConnection: () => Promise<void>;
+      }>;
       execute?: (
         tool: string,
         args: Record<string, unknown>,
@@ -52,6 +67,17 @@ const composioSdkState = vi.hoisted(() => ({
 
 vi.mock("@composio/core", () => ({
   Composio: class {
+    readonly connectedAccounts = {
+      list: async () => ({
+        items: composioSdkState.accounts,
+        nextCursor: undefined,
+        totalPages: 1,
+      }),
+      delete: async (id: string) => {
+        composioSdkState.deleted.push(id);
+      },
+    };
+
     readonly sessions = {
       use: async (sessionId: string) => {
         const session = composioSdkState.sessions.get(sessionId);
@@ -66,6 +92,14 @@ vi.mock("@composio/core", () => ({
       if (toolkits.length === 0) {
         const session = {
           sessionId: "catalog-session",
+          authorize: async (toolkit: string, options: Record<string, unknown>) => {
+            composioSdkState.authorizations.push({ toolkit, options });
+            return {
+              id: "ca-new",
+              redirectUrl: "https://auth.example/connect",
+              waitForConnection: async () => undefined,
+            };
+          },
           toolkits: async () => {
             if (composioSdkState.directoryFails) throw new Error("directory unavailable");
             return {
@@ -241,6 +275,9 @@ describe("composio tool mapping", () => {
     expect(executeSessionKey(["hackernews", "gmail", "hackernews"])).toBe("gmail,hackernews");
     expect(executeSessionKey(["github", "GITHUB"])).toBe("github");
     expect(executeSessionKey([])).toBe("");
+    expect(executeSessionKey(["GMAIL"], { GMAIL: ["ca-work", "ca-personal", "ca-work"] })).toBe(
+      "GMAIL|GMAIL:ca-personal,ca-work",
+    );
   });
 
   it("uses catalog-canonical toolkit slugs without preloading every tool", async () => {
@@ -333,6 +370,106 @@ describe("composio tool mapping", () => {
     }
   });
 
+  it("pins every named account and enables explicit multi-account selection", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+
+    const connector = new ComposioConnector();
+    const context = {
+      operationId: "composio-multi-account",
+      traceId: "composio-multi-account",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: "connection-personal",
+          connectorId: "composio",
+          externalId: "github",
+          displayName: "Personal",
+          providerRef: "ca-personal",
+        },
+        {
+          id: "connection-work",
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "Work",
+          providerRef: "ca-work",
+        },
+      ],
+    } satisfies AdapterContext;
+
+    await connector.discoverTools(context);
+
+    expect(composioSdkState.created.at(-1)).toMatchObject({
+      userId: "user-1",
+      config: {
+        toolkits: ["GITHUB"],
+        connectedAccounts: { GITHUB: ["ca-personal", "ca-work"] },
+        multiAccount: {
+          enable: true,
+          maxAccountsPerToolkit: 10,
+          requireExplicitSelection: true,
+        },
+      },
+    });
+  });
+
+  it("uses the label as the Composio account alias", async () => {
+    composioSdkState.authorizations.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+    const connector = new ComposioConnector();
+    const context = {
+      operationId: "composio-alias",
+      traceId: "composio-alias",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+    } satisfies AdapterContext;
+
+    await expect(
+      connector.begin(
+        {
+          provider: "GMAIL",
+          redirectUrl: "https://rakazo.example/app",
+          alias: "Project A",
+        },
+        context,
+      ),
+    ).resolves.toEqual({
+      authorizationUrl: "https://auth.example/connect",
+      state: "ca-new",
+    });
+    expect(composioSdkState.authorizations).toEqual([
+      {
+        toolkit: "GMAIL",
+        options: { callbackUrl: "https://rakazo.example/app", alias: "Project A" },
+      },
+    ]);
+  });
+
+  it("checks and revokes the exact account owned by the user", async () => {
+    composioSdkState.accounts = [
+      { id: "ca-personal", status: "ACTIVE", toolkit: { slug: "GMAIL" } },
+      { id: "ca-work", status: "ACTIVE", toolkit: { slug: "GMAIL" } },
+    ];
+    composioSdkState.deleted.length = 0;
+    const connector = new ComposioConnector();
+    const context = {
+      operationId: "composio-exact-account",
+      traceId: "composio-exact-account",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+    } satisfies AdapterContext;
+
+    await expect(connector.connectionReady(context, "gmail", "ca-work")).resolves.toBe(true);
+    await connector.revoke("ca-work", context);
+    expect(composioSdkState.deleted).toEqual(["ca-work"]);
+  });
+
   it("merges live Composio slugs onto pending DB plugin rows", () => {
     const merged = mergeConnectedPlugins(
       [
@@ -367,6 +504,7 @@ describe("composio tool mapping", () => {
     expect(needsLivePluginSync([{ status: "connected" }, { status: "revoked" }])).toBe(false);
     expect(needsLivePluginSync([{ status: "pending" }])).toBe(true);
     expect(needsLivePluginSync([{ status: "error" }])).toBe(true);
+    expect(needsLivePluginSync([{ status: "pending", providerRef: "ca-new" }])).toBe(false);
   });
 
   it("keeps DB-connected plugins when live Composio listing is empty", () => {
@@ -433,6 +571,30 @@ describe("composio tool mapping", () => {
       connectIds: ["row-gmail"],
       revokeIds: ["row-dup", "row-err"],
     });
+  });
+
+  it("never reconciles account-scoped rows from a slug-only live listing", () => {
+    expect(
+      planLiveConnectionSync(
+        [
+          {
+            id: "row-personal",
+            provider: "gmail",
+            providerRef: "ca-personal",
+            status: "connected",
+            displayName: "Personal",
+          },
+          {
+            id: "row-work",
+            provider: "gmail",
+            providerRef: "ca-work",
+            status: "pending",
+            displayName: "Work",
+          },
+        ],
+        ["gmail"],
+      ),
+    ).toEqual({ connectIds: [], revokeIds: [] });
   });
 
   it("filters the catalog by name or slug", () => {

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -1,6 +1,7 @@
 import { Composio } from "@composio/core";
 import type {
   AdapterContext,
+  ConnectedConnector,
   ConnectorCall,
   ConnectorCatalogItem,
   ConnectorEvent,
@@ -106,14 +107,22 @@ function composioSlugKey(slug: string): string {
   return slug.trim().toLowerCase();
 }
 
-export function executeSessionKey(toolkits: string[]): string {
+export function executeSessionKey(
+  toolkits: string[],
+  connectedAccounts: Record<string, string[]> = {},
+): string {
   const unique = new Map<string, string>();
   for (const slug of toolkits) {
     const trimmed = slug.trim();
     const key = composioSlugKey(trimmed);
     if (key && !unique.has(key)) unique.set(key, trimmed);
   }
-  return [...unique.values()].sort().join(",");
+  const toolkitKey = [...unique.values()].sort().join(",");
+  const accountKey = Object.entries(connectedAccounts)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([toolkit, ids]) => `${toolkit}:${[...new Set(ids)].sort().join(",")}`)
+    .join(";");
+  return accountKey ? `${toolkitKey}|${accountKey}` : toolkitKey;
 }
 
 export type PluginConnectionRow = {
@@ -121,10 +130,15 @@ export type PluginConnectionRow = {
   provider: string;
   status: string;
   displayName: string;
+  providerRef?: string | null;
 };
 
-export function needsLivePluginSync(rows: { status: string }[]): boolean {
-  return rows.some((row) => row.status === "pending" || row.status === "error");
+export function needsLivePluginSync(
+  rows: { status: string; providerRef?: string | null }[],
+): boolean {
+  return rows.some(
+    (row) => (row.status === "pending" || row.status === "error") && !row.providerRef,
+  );
 }
 
 export function mergeConnectedPlugins(
@@ -155,6 +169,10 @@ export function planLiveConnectionSync(
   rows: PluginConnectionRow[],
   liveSlugs: string[],
 ): { connectIds: string[]; revokeIds: string[] } {
+  // A providerRef identifies one specific account. A slug-only live listing
+  // cannot safely reconcile (or discard) those rows when several accounts use
+  // the same toolkit, so only migrate legacy rows that predate account refs.
+  const legacyRows = rows.filter((row) => !row.providerRef);
   const live = new Set(liveSlugs.map(composioSlugKey).filter(Boolean));
   const connectIds: string[] = [];
   const connectedProviders = new Set(
@@ -162,7 +180,7 @@ export function planLiveConnectionSync(
   );
   for (const slug of live) {
     if (connectedProviders.has(slug)) continue;
-    const matches = rows.filter((row) => composioSlugKey(row.provider) === slug);
+    const matches = legacyRows.filter((row) => composioSlugKey(row.provider) === slug);
     const reusable =
       matches.find((row) => row.status === "pending" || row.status === "error") ??
       matches.find((row) => row.status === "revoked") ??
@@ -172,7 +190,7 @@ export function planLiveConnectionSync(
     connectedProviders.add(slug);
   }
   const connectIdSet = new Set(connectIds);
-  const revokeIds = rows
+  const revokeIds = legacyRows
     .filter(
       (row) => (row.status === "pending" || row.status === "error") && !connectIdSet.has(row.id),
     )
@@ -207,14 +225,42 @@ export class ComposioConnector implements ComposioProvider {
     const session = await composio.create(userId, {
       manageConnections: false,
       sandbox: { enable: false },
+      multiAccount: {
+        enable: true,
+        maxAccountsPerToolkit: 10,
+        requireExplicitSelection: true,
+      },
     });
     this.catalogSessions.set(userId, session.sessionId);
     return session;
   }
 
-  async sessionForExecute(userId: string, toolkits: string[]): Promise<ComposioSession> {
-    const canonicalToolkits = await this.canonicalizeToolkits(toolkits);
-    const key = executeSessionKey(canonicalToolkits);
+  async sessionForExecute(
+    userId: string,
+    connections: ReturnType<typeof connectedComposioConnections>,
+  ): Promise<ComposioSession> {
+    const canonicalToolkits = await this.canonicalizeToolkits(
+      connections.map((connection) => connection.externalId),
+    );
+    const canonicalByKey = new Map(
+      canonicalToolkits.map((toolkit) => [composioSlugKey(toolkit), toolkit]),
+    );
+    const connectedAccounts: Record<string, string[]> = {};
+    for (const connection of connections) {
+      if (!connection.providerRef) continue;
+      // No-auth toolkits use the toolkit slug itself as their local state.
+      // Only real connected-account IDs may be pinned into a router session.
+      if (composioSlugKey(connection.providerRef) === composioSlugKey(connection.externalId)) {
+        continue;
+      }
+      const toolkit = canonicalByKey.get(composioSlugKey(connection.externalId));
+      if (!toolkit) continue;
+      const ids = connectedAccounts[toolkit] ?? [];
+      ids.push(connection.providerRef);
+      connectedAccounts[toolkit] = ids;
+    }
+    for (const ids of Object.values(connectedAccounts)) ids.sort();
+    const key = executeSessionKey(canonicalToolkits, connectedAccounts);
     if (!key) return this.sessionFor(userId);
     const composio = this.sdk();
     const existing = this.executeSessions.get(userId);
@@ -229,6 +275,12 @@ export class ComposioConnector implements ComposioProvider {
       manageConnections: false,
       sandbox: { enable: false },
       toolkits: canonicalToolkits,
+      ...(Object.keys(connectedAccounts).length > 0 ? { connectedAccounts } : {}),
+      multiAccount: {
+        enable: true,
+        maxAccountsPerToolkit: 10,
+        requireExplicitSelection: true,
+      },
     });
     this.executeSessions.set(userId, { sessionId: session.sessionId, key });
     return session;
@@ -290,9 +342,9 @@ export class ComposioConnector implements ComposioProvider {
   }
 
   async discoverTools(context: AdapterContext): Promise<ConnectorTool[]> {
-    const toolkits = connectedComposioExternalIds(context);
-    if (toolkits.length === 0) return [];
-    const session = await this.sessionForExecute(context.userId, toolkits);
+    const connections = connectedComposioConnections(context);
+    if (connections.length === 0) return [];
+    const session = await this.sessionForExecute(context.userId, connections);
     const raw = await session.tools();
     return asConnectorTools(raw);
   }
@@ -301,7 +353,7 @@ export class ComposioConnector implements ComposioProvider {
     try {
       const session = await this.sessionForExecute(
         context.userId,
-        connectedComposioExternalIds(context),
+        connectedComposioConnections(context),
       );
       const result = await session.execute(call.tool, call.args ?? {});
       if (result.error) {
@@ -322,13 +374,14 @@ export class ComposioConnector implements ComposioProvider {
   }
 
   async begin(
-    request: { provider: string; redirectUrl: string },
+    request: { provider: string; redirectUrl: string; alias?: string },
     context: AdapterContext,
   ): Promise<{ authorizationUrl: string | null; state: string }> {
     const session = await this.sessionFor(context.userId);
     try {
       const connectionRequest = await session.authorize(request.provider, {
         callbackUrl: request.redirectUrl,
+        alias: request.alias,
       });
       if (!connectionRequest.redirectUrl) {
         await connectionRequest.waitForConnection(20_000).catch(() => undefined);
@@ -345,7 +398,20 @@ export class ComposioConnector implements ComposioProvider {
     }
   }
 
-  async connectionReady(context: AdapterContext, slug: string): Promise<boolean> {
+  async connectionReady(
+    context: AdapterContext,
+    slug: string,
+    connectionRef?: string,
+  ): Promise<boolean> {
+    if (connectionRef) {
+      const account = await this.connectedAccount(context.userId, connectionRef);
+      if (account) {
+        return (
+          account.status === "ACTIVE" &&
+          composioSlugKey(account.toolkit.slug) === composioSlugKey(slug)
+        );
+      }
+    }
     const session = await this.sessionFor(context.userId);
     const page = await session.toolkits({ search: slug, limit: 50 });
     const match = page.items.find((item) => composioSlugKey(item.slug) === composioSlugKey(slug));
@@ -361,8 +427,25 @@ export class ComposioConnector implements ComposioProvider {
   }
 
   async revoke(connectionRef: string, context: AdapterContext): Promise<void> {
-    const accountId = await this.connectedAccountId(context.userId, connectionRef);
+    const exact = await this.connectedAccount(context.userId, connectionRef);
+    const accountId = exact?.id ?? (await this.connectedAccountId(context.userId, connectionRef));
     if (accountId) await this.sdk().connectedAccounts.delete(accountId);
+  }
+
+  private async connectedAccount(userId: string, accountId: string) {
+    let cursor: string | undefined;
+    for (let pageIndex = 0; pageIndex < 200; pageIndex += 1) {
+      const page = await this.sdk().connectedAccounts.list({
+        userIds: [userId],
+        limit: 100,
+        cursor,
+      });
+      const account = page.items.find((item) => item.id === accountId);
+      if (account) return account;
+      cursor = page.nextCursor ?? undefined;
+      if (!cursor) return undefined;
+    }
+    return undefined;
   }
 
   async connectedAccountId(userId: string, slug: string): Promise<string | undefined> {
@@ -485,13 +568,15 @@ function isManagedConnectorProvider(
   );
 }
 
-function connectedComposioExternalIds(context: AdapterContext): string[] {
+function connectedComposioConnections(context: AdapterContext): ConnectedConnector[] {
   return (
-    context.connectedConnections
-      ?.filter((connection) => connection.connectorId === "composio")
-      .map((connection) => connection.externalId) ??
-    context.connectedProviders ??
-    []
+    context.connectedConnections?.filter((connection) => connection.connectorId === "composio") ??
+    (context.connectedProviders ?? []).map((externalId) => ({
+      id: `legacy:${externalId}`,
+      connectorId: "composio",
+      externalId,
+      displayName: externalId,
+    }))
   );
 }
 

--- a/packages/adapters/src/composio-emulator.test.ts
+++ b/packages/adapters/src/composio-emulator.test.ts
@@ -31,7 +31,14 @@ describe("ComposioEmulator", () => {
 
   it("isolates connection state by user and supports revoke", async () => {
     const emulator = new ComposioEmulator();
-    await emulator.begin({ provider: "GMAIL", redirectUrl: "http://example.test" }, context);
+    const personal = await emulator.begin(
+      { provider: "GMAIL", redirectUrl: "http://example.test", alias: "Personal" },
+      context,
+    );
+    const work = await emulator.begin(
+      { provider: "GMAIL", redirectUrl: "http://example.test", alias: "Work" },
+      context,
+    );
 
     await expect(emulator.connectionReady(context, "GMAIL")).resolves.toBe(true);
     await expect(emulator.listConnectedSlugs(context.userId)).resolves.toEqual(["GMAIL"]);
@@ -42,7 +49,9 @@ describe("ComposioEmulator", () => {
       expect.objectContaining({ slug: "GMAIL", connected: true }),
     ]);
 
-    await emulator.revoke("GMAIL", context);
+    await emulator.revoke(personal.state, context);
+    await expect(emulator.connectionReady(context, "GMAIL", work.state)).resolves.toBe(true);
+    await emulator.revoke(work.state, context);
     await expect(emulator.connectionReady(context, "GMAIL")).resolves.toBe(false);
   });
 

--- a/packages/adapters/src/composio-emulator.ts
+++ b/packages/adapters/src/composio-emulator.ts
@@ -26,7 +26,8 @@ const DEFAULT_CATALOG: ReadonlyArray<Omit<ComposioCatalogItem, "connected">> = [
 
 /** Deterministic, offline Composio catalog and connection emulator for product tests. */
 export class ComposioEmulator implements ComposioProvider {
-  private readonly connectedByUser = new Map<string, Set<string>>();
+  private readonly connectedByUser = new Map<string, Map<string, Set<string>>>();
+  private connectionOrdinal = 0;
   private githubReleases: EmulatedGithubRelease[] = [...DEFAULT_RAKAZO_EMULATED_RELEASES];
   readonly executions: Array<{
     userId: string;
@@ -62,9 +63,12 @@ export class ComposioEmulator implements ComposioProvider {
   }
 
   async catalog(context: AdapterContext, query?: string) {
-    const connected = this.connectedByUser.get(context.userId) ?? new Set<string>();
+    const connected = this.connectedByUser.get(context.userId) ?? new Map<string, Set<string>>();
     return filterCatalog(
-      this.directory.map((item) => ({ ...item, connected: connected.has(item.slug) })),
+      this.directory.map((item) => ({
+        ...item,
+        connected: (connected.get(item.slug)?.size ?? 0) > 0,
+      })),
       query ?? "",
     ).map((item) => ({ ...item, connectorId: "composio" }));
   }
@@ -72,7 +76,9 @@ export class ComposioEmulator implements ComposioProvider {
   async warmDirectory(): Promise<void> {}
 
   async listConnectedSlugs(userId: string): Promise<string[]> {
-    return [...(this.connectedByUser.get(userId) ?? [])];
+    return [...(this.connectedByUser.get(userId)?.entries() ?? [])]
+      .filter(([, refs]) => refs.size > 0)
+      .map(([slug]) => slug);
   }
 
   async listConnectedExternalIds(context: AdapterContext): Promise<string[]> {
@@ -122,17 +128,26 @@ export class ComposioEmulator implements ComposioProvider {
   }
 
   async begin(
-    request: { provider: string; redirectUrl: string },
+    request: { provider: string; redirectUrl: string; alias?: string },
     context: AdapterContext,
   ): Promise<{ authorizationUrl: string | null; state: string }> {
-    const connected = this.connectedByUser.get(context.userId) ?? new Set<string>();
-    connected.add(request.provider);
+    const connected = this.connectedByUser.get(context.userId) ?? new Map<string, Set<string>>();
+    const refs = connected.get(request.provider) ?? new Set<string>();
+    this.connectionOrdinal += 1;
+    const ref = `${request.provider}:${this.connectionOrdinal}`;
+    refs.add(ref);
+    connected.set(request.provider, refs);
     this.connectedByUser.set(context.userId, connected);
-    return { authorizationUrl: null, state: request.provider };
+    return { authorizationUrl: null, state: ref };
   }
 
-  async connectionReady(context: AdapterContext, slug: string): Promise<boolean> {
-    return this.connectedByUser.get(context.userId)?.has(slug) ?? false;
+  async connectionReady(
+    context: AdapterContext,
+    slug: string,
+    connectionRef?: string,
+  ): Promise<boolean> {
+    const refs = this.connectedByUser.get(context.userId)?.get(slug);
+    return connectionRef ? (refs?.has(connectionRef) ?? false) : (refs?.size ?? 0) > 0;
   }
 
   async complete(
@@ -143,7 +158,17 @@ export class ComposioEmulator implements ComposioProvider {
   }
 
   async revoke(connectionRef: string, context: AdapterContext): Promise<void> {
-    this.connectedByUser.get(context.userId)?.delete(connectionRef);
+    const connected = this.connectedByUser.get(context.userId);
+    if (!connected) return;
+    if (connected.has(connectionRef)) {
+      connected.delete(connectionRef);
+      return;
+    }
+    for (const [slug, refs] of connected) {
+      if (!refs.delete(connectionRef)) continue;
+      if (refs.size === 0) connected.delete(slug);
+      return;
+    }
   }
 
   private executeGithub(tool: string, args: Record<string, unknown>): Record<string, unknown> {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -945,7 +945,8 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const connectedPlugins = storedConnections.filter(
           (connection) =>
             connection.status === "connected" ||
-            activeKeys.has(`${connection.connectorId}:${connection.provider}`),
+            (!connection.providerRef &&
+              activeKeys.has(`${connection.connectorId}:${connection.provider}`)),
         );
         const context = {
           operationId: runId,

--- a/packages/adapters/src/run-secret.test.ts
+++ b/packages/adapters/src/run-secret.test.ts
@@ -144,7 +144,7 @@ describe("reconcileManagedConnection", () => {
       ),
     ).resolves.toBe("connected");
 
-    expect(connectionReady).toHaveBeenCalled();
+    expect(connectionReady).toHaveBeenCalledWith(context, "gmail", undefined);
     expect(prisma.connection.update).toHaveBeenCalledWith({
       where: { id: "conn-1" },
       data: { status: "connected" },
@@ -200,6 +200,7 @@ describe("tryCompleteConnectionWithCode", () => {
       },
     });
     expect(complete).toHaveBeenCalledWith({ state: "gmail-state", code: "123456" }, context);
+    expect(connectionReady).toHaveBeenCalledWith(context, "gmail", "gmail-state");
     expect(prisma.connection.update).toHaveBeenCalledWith({
       where: { id: "conn-1" },
       data: { status: "connected" },

--- a/packages/adapters/src/run-secret.ts
+++ b/packages/adapters/src/run-secret.ts
@@ -89,7 +89,11 @@ export async function reconcileManagedConnection(
   const connector = connectors?.managed(row.connectorId);
   if (!connector) return "pending";
   try {
-    const ready = await connector.connectionReady(context, row.provider);
+    const ready = await connector.connectionReady(
+      context,
+      row.provider,
+      row.providerRef ?? undefined,
+    );
     if (ready) {
       await prisma.connection.update({
         where: { id: row.id },
@@ -160,7 +164,11 @@ export async function tryCompleteConnectionWithCode(
   const state = row.providerRef ?? row.provider;
   try {
     await connector.complete({ state, code }, context);
-    const ready = await connector.connectionReady(context, row.provider);
+    const ready = await connector.connectionReady(
+      context,
+      row.provider,
+      row.providerRef ?? undefined,
+    );
     if (ready) {
       await prisma.connection.update({
         where: { id: row.id },


### PR DESCRIPTION
## Why

Closes #583. A connected toolkit currently collapses to one boolean in the Integrations UI, and slug-only reconciliation cannot distinguish two accounts for the same app. That prevents users from adding, naming, selecting, or independently removing a second Gmail account.

## What

- add a progressive account manager to each integration: users label an account before connecting, can add another Composio account, and remove one account without removing its siblings
- pass the label to Composio as the account alias and preserve the returned connected-account ID as the account-scoped reference
- enable Composio multi-account router sessions, pin every active account ID, and require explicit account selection when a toolkit has multiple accounts
- reconcile readiness and revocation by the exact account reference while retaining slug-only fallback for legacy rows and no-auth toolkits
- keep pending account-scoped rows out of execution and out of legacy slug-only reconciliation
- extend the deterministic Composio emulator and the golden browser journey to cover two named Gmail accounts

User-facing copy is intentionally compact and only appears after the user opens an integration. `Manage` replaces the destructive one-click `Remove`; `Account label`, `Connect`, `Add another account`, and `Done` describe the minimum account-management actions requested in #583. `Connecting…` distinguishes the OAuth wait from the existing source-install `Adding…` state.

## Test

- `pnpm --filter @rakazo/adapter-kit check`
- `pnpm --filter @rakazo/adapters check`
- `pnpm --filter @rakazo/api check`
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/testkit check`
- `pnpm --filter @rakazo/adapters test` (1,136 passed, 7 skipped)
- `pnpm --filter @rakazo/api test` (196 passed)
- `pnpm --filter @rakazo/web test` (195 passed)
- `pnpm --filter @rakazo/testkit test` (49 passed, 98 database/runtime-gated skipped)
- `pnpm exec biome check` on all 12 changed files
- `git diff --check`

The updated Playwright golden journey is included for CI to exercise and capture the named two-account UI against the repository's database-backed harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Manage multiple accounts per integration, each with a custom label.
  - Connect, view, and remove individual accounts without affecting others.
  - Integration screens now show **Add** or **Manage** actions and list connected accounts.
  - Account-specific connection status and authorization are preserved across sessions.

- **Bug Fixes**
  - Revoking one account no longer disconnects other accounts for the same provider.
  - Connection readiness and synchronization now target the correct account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->