### PR TITLE
fix(adapters): bound Docker supervisor responses

### DIFF
--- a/packages/adapters/src/docker-sandbox.test.ts
+++ b/packages/adapters/src/docker-sandbox.test.ts
@@ -88,7 +88,7 @@ describe("Docker sandbox", () => {
           new Response(
             new ReadableStream({
               start(controller) {
-                controller.enqueue(new Uint8Array(1027));
+                controller.enqueue(new Uint8Array(1029));
               },
               cancel,
             }),
@@ -104,8 +104,32 @@ describe("Docker sandbox", () => {
         context,
         { maxBytes: 1 },
       ),
-    ).rejects.toThrow("sandbox response exceeds 1026 bytes");
+    ).rejects.toThrow("sandbox response exceeds 1028 bytes");
     await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+
+  it("accepts a valid encoded envelope above the generic response cap", async () => {
+    const maxBytes = 13 * 1024 * 1024;
+    const encodedLimit = Math.ceil(maxBytes / 3) * 4 + 1024;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response('{"content":""}', {
+            headers: { "content-length": String(encodedLimit) },
+          }),
+      ),
+    );
+    const provider = new DockerSandboxProvider("http://supervisor.test", "test-token");
+
+    await expect(
+      provider.readFile(
+        { id: "computer", botId: "bot", kind: "docker", providerRef: "computer" },
+        "large.bin",
+        context,
+        { maxBytes },
+      ),
+    ).resolves.toEqual(new Uint8Array());
   });
 
   it("releases this bot's screen assignment through the supervisor", async () => {

--- a/packages/adapters/src/docker-sandbox.test.ts
+++ b/packages/adapters/src/docker-sandbox.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DockerSandboxProvider,
   MAX_SANDBOX_ERROR_RESPONSE_BYTES,
+  MAX_SANDBOX_SUCCESS_RESPONSE_BYTES,
   SCREEN_RELEASE_TIMEOUT_MS,
 } from "./docker-sandbox.js";
 
@@ -57,6 +58,54 @@ describe("Docker sandbox", () => {
       "x-request-id": expect.any(String),
       traceparent: expect.stringMatching(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/),
     });
+  });
+
+  it("rejects a declared oversized success response without buffering it", async () => {
+    const cancel = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new ReadableStream({ cancel }), {
+            headers: { "content-length": String(MAX_SANDBOX_SUCCESS_RESPONSE_BYTES + 1) },
+          }),
+      ),
+    );
+    const provider = new DockerSandboxProvider("http://supervisor.test", "test-token");
+
+    await expect(
+      provider.provision({ botId: "bot", homePath: "/tmp/bot" }, context),
+    ).rejects.toThrow(`sandbox response exceeds ${MAX_SANDBOX_SUCCESS_RESPONSE_BYTES} bytes`);
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+
+  it("stops a streamed file response at the caller-derived encoded limit", async () => {
+    const cancel = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new Uint8Array(1027));
+              },
+              cancel,
+            }),
+          ),
+      ),
+    );
+    const provider = new DockerSandboxProvider("http://supervisor.test", "test-token");
+
+    await expect(
+      provider.readFile(
+        { id: "computer", botId: "bot", kind: "docker", providerRef: "computer" },
+        "small.txt",
+        context,
+        { maxBytes: 1 },
+      ),
+    ).rejects.toThrow("sandbox response exceeds 1026 bytes");
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
   });
 
   it("releases this bot's screen assignment through the supervisor", async () => {

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -83,7 +83,10 @@ async function readSandboxJson<T>(
 
 function encodedFileResponseLimit(maxBytes: number | undefined): number {
   if (maxBytes === undefined) return MAX_SANDBOX_SUCCESS_RESPONSE_BYTES;
-  return Math.min(MAX_SANDBOX_SUCCESS_RESPONSE_BYTES, Math.ceil((maxBytes * 4) / 3) + 1024);
+  // An explicit file limit is already the caller's memory-safety contract.
+  // Account for base64 expansion plus the small JSON envelope without applying
+  // the generic response cap, which would reject valid files above ~12 MiB.
+  return Math.ceil(maxBytes / 3) * 4 + 1024;
 }
 
 export class DockerSandboxProvider implements SandboxProvider {

--- a/packages/adapters/src/docker-sandbox.ts
+++ b/packages/adapters/src/docker-sandbox.ts
@@ -25,8 +25,10 @@ import {
 import { readBodyCapped, withAbort } from "./web-ssrf.js";
 
 export const MAX_SANDBOX_ERROR_RESPONSE_BYTES = 8 * 1024;
+export const MAX_SANDBOX_SUCCESS_RESPONSE_BYTES = 16 * 1024 * 1024;
 export const SCREEN_RELEASE_TIMEOUT_MS = 8_000;
 const SANDBOX_ERROR_RESPONSE_TIMEOUT_MS = 1_000;
+const SANDBOX_SUCCESS_RESPONSE_TIMEOUT_MS = 30_000;
 
 async function safeBody(res: Response, signal?: AbortSignal): Promise<string> {
   const declared = Number(res.headers.get("content-length") ?? 0);
@@ -51,6 +53,37 @@ function cancelResponseBody(res: Response): void {
   } catch {
     // Error diagnostics are best-effort and must not delay the operation failure.
   }
+}
+
+async function readSandboxJson<T>(
+  res: Response,
+  signal: AbortSignal,
+  maxBytes = MAX_SANDBOX_SUCCESS_RESPONSE_BYTES,
+): Promise<T> {
+  const declared = Number(res.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    cancelResponseBody(res);
+    throw new Error(`sandbox response exceeds ${maxBytes} bytes`);
+  }
+  const readSignal = AbortSignal.any([
+    signal,
+    AbortSignal.timeout(SANDBOX_SUCCESS_RESPONSE_TIMEOUT_MS),
+  ]);
+  let bytes: Uint8Array;
+  try {
+    bytes = await readBodyCapped(res, maxBytes, readSignal);
+  } catch (error) {
+    if (error instanceof Error && error.message === "Response is too large") {
+      throw new Error(`sandbox response exceeds ${maxBytes} bytes`, { cause: error });
+    }
+    throw error;
+  }
+  return JSON.parse(new TextDecoder().decode(bytes)) as T;
+}
+
+function encodedFileResponseLimit(maxBytes: number | undefined): number {
+  if (maxBytes === undefined) return MAX_SANDBOX_SUCCESS_RESPONSE_BYTES;
+  return Math.min(MAX_SANDBOX_SUCCESS_RESPONSE_BYTES, Math.ceil((maxBytes * 4) / 3) + 1024);
 }
 
 export class DockerSandboxProvider implements SandboxProvider {
@@ -123,7 +156,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       const detail = await safeBody(res, context.signal);
       throw new Error(`sandbox provision failed: ${res.status} ${detail}`.trim());
     }
-    const body = (await res.json()) as { id: string; resumed?: boolean };
+    const body = await readSandboxJson<{ id: string; resumed?: boolean }>(res, context.signal);
     return {
       id: body.id,
       botId: request.botId,
@@ -155,7 +188,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       yield { type: "exit", code: 1 };
       return;
     }
-    const body = (await res.json()) as { stdout: string; stderr: string; code: number };
+    const body = await readSandboxJson<{ stdout: string; stderr: string; code: number }>(
+      res,
+      context.signal,
+    );
     if (body.stdout) yield { type: "stdout", data: body.stdout };
     if (body.stderr) yield { type: "stderr", data: body.stderr };
     yield { type: "exit", code: body.code };
@@ -183,7 +219,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
       return { url: null, mimeType: "text/html", close: async () => undefined };
     }
-    const body = (await res.json()) as { screenUrl?: string };
+    const body = await readSandboxJson<{ screenUrl?: string }>(res, context.signal);
     return {
       url: body.screenUrl ?? this.url(`/computers/${computer.id}/screen`),
       mimeType: "text/html",
@@ -234,14 +270,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       throw new Error(
         `sandbox observation failed: ${res.status} ${await safeBody(res, context.signal)}`.trim(),
       );
-    const body = (await res.json()) as {
+    const body = await readSandboxJson<{
       image: string;
       mimeType: "image/png" | "image/jpeg";
       width: number;
       height: number;
       cursor?: { x: number; y: number };
       activeWindow?: { id: string; title?: string };
-    };
+    }>(res, context.signal);
     return computerObservation(Uint8Array.from(Buffer.from(body.image, "base64")), {
       mimeType: body.mimeType,
       width: body.width,
@@ -267,7 +303,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       throw new Error(
         `sandbox action failed: ${res.status} ${await safeBody(res, context.signal)}`.trim(),
       );
-    const body = (await res.json()) as {
+    const body = await readSandboxJson<{
       completed: number;
       observation?: {
         image: string;
@@ -277,7 +313,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         cursor?: { x: number; y: number };
         activeWindow?: { id: string; title?: string };
       };
-    };
+    }>(res, context.signal);
     return {
       completed: body.completed,
       ...(body.observation
@@ -302,7 +338,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       { headers: this.headers(context, computer.botId), signal: context.signal },
     );
     if (!res.ok) throw new Error(`sandbox file listing failed: ${res.status}`);
-    return (await res.json()) as ComputerFileEntry[];
+    return readSandboxJson<ComputerFileEntry[]>(res, context.signal);
   }
 
   async readFile(
@@ -323,7 +359,11 @@ export class DockerSandboxProvider implements SandboxProvider {
       const detail = await safeBody(res, context.signal);
       throw new Error(`sandbox file read failed: ${res.status} ${detail}`.trim());
     }
-    const body = (await res.json()) as { content: string };
+    const body = await readSandboxJson<{ content: string }>(
+      res,
+      context.signal,
+      encodedFileResponseLimit(maxBytes),
+    );
     return Uint8Array.from(Buffer.from(body.content, "base64"));
   }
 


### PR DESCRIPTION
## Why

Successful responses from the Docker sandbox supervisor were still parsed with unbounded `Response.json()` calls. A compromised, buggy, or mismatched supervisor could therefore make the API/worker buffer an arbitrary response for provision, command execution, screen operations, observations, actions, file listing, or file reads.

This follows the repository feedback to batch same-theme response-bound changes behind one shared helper instead of opening one PR per endpoint.

## What

- add one streaming `readSandboxJson` helper with a 16 MiB success-response cap and a 30-second body-read deadline
- reject oversized declared bodies before buffering and stop streamed bodies as soon as they cross the cap
- route all seven Docker supervisor JSON response call sites through the helper
- derive a tighter base64-envelope cap when `readFile` already has a caller-provided byte limit
- keep the existing small, short-deadline error-body path unchanged

No user-facing copy is changed. The new error text is operator-facing and includes only the enforced byte limit.

## Test

- `pnpm exec vitest run packages/adapters/src/docker-sandbox.test.ts` (11 passed)
- `pnpm --filter @rakazo/adapters test` (1,134 passed, 7 skipped)
- `pnpm --filter @rakazo/adapters check`
- `pnpm exec biome check packages/adapters/src/docker-sandbox.ts packages/adapters/src/docker-sandbox.test.ts`
- `git diff --check`

Regression coverage verifies both an oversized declared response (including body cancellation) and a streamed file response crossing the caller-derived encoded limit.
