### PR TITLE
fix(composio): route tools across connected accounts

### DIFF
--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -286,6 +286,13 @@ describe("composio tool mapping", () => {
           providerRef: "ca-work",
         },
         {
+          id: "connection-personal-dup",
+          connectorId: "composio",
+          externalId: "GitHub",
+          displayName: "Personal again",
+          providerRef: "ca-personal",
+        },
+        {
           id: "connection-noauth",
           connectorId: "composio",
           externalId: "GITHUB",
@@ -295,9 +302,11 @@ describe("composio tool mapping", () => {
       ],
     });
 
-    expect(composioSdkState.created.at(-1)).toMatchObject({
+    expect(composioSdkState.created.at(-1)).toEqual({
       userId: "user-1",
       config: {
+        manageConnections: false,
+        sandbox: { enable: false },
         toolkits: ["GITHUB"],
         connectedAccounts: { GITHUB: ["ca-personal", "ca-work"] },
         multiAccount: {
@@ -305,6 +314,80 @@ describe("composio tool mapping", () => {
           maxAccountsPerToolkit: 10,
           requireExplicitSelection: true,
         },
+      },
+    });
+  });
+
+  it("pins a single concrete account without enabling multi-account mode", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+
+    const connector = new ComposioConnector();
+    await connector.discoverTools({
+      operationId: "composio-single-account",
+      traceId: "composio-single-account",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: "connection-work",
+          connectorId: "composio",
+          externalId: "gmail",
+          displayName: "Work",
+          providerRef: "ca-work",
+        },
+      ],
+    });
+
+    expect(composioSdkState.created.at(-1)).toEqual({
+      userId: "user-1",
+      config: {
+        manageConnections: false,
+        sandbox: { enable: false },
+        toolkits: ["GMAIL"],
+        connectedAccounts: { GMAIL: ["ca-work"] },
+      },
+    });
+  });
+
+  it("omits connectedAccounts and multiAccount for legacy slug-only refs", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+
+    const connector = new ComposioConnector();
+    await connector.discoverTools({
+      operationId: "composio-legacy-only",
+      traceId: "composio-legacy-only",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: "connection-legacy",
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "Legacy",
+          providerRef: "github",
+        },
+        {
+          id: "connection-hackernews",
+          connectorId: "composio",
+          externalId: "hackernews",
+          displayName: "Hacker News",
+          providerRef: "HACKERNEWS",
+        },
+      ],
+    });
+
+    expect(composioSdkState.created.at(-1)).toEqual({
+      userId: "user-1",
+      config: {
+        manageConnections: false,
+        sandbox: { enable: false },
+        toolkits: ["GITHUB", "HACKERNEWS"],
       },
     });
   });

--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -253,6 +253,60 @@ describe("composio tool mapping", () => {
     expect(executeSessionKey(["hackernews", "gmail", "hackernews"])).toBe("gmail,hackernews");
     expect(executeSessionKey(["github", "GITHUB"])).toBe("github");
     expect(executeSessionKey([])).toBe("");
+    expect(executeSessionKey(["GMAIL"], { GMAIL: ["ca-work", "ca-personal", "ca-work"] })).toBe(
+      "GMAIL|GMAIL:ca-personal,ca-work",
+    );
+  });
+
+  it("pins every connected account into multi-account execute sessions", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+
+    const connector = new ComposioConnector();
+    await connector.discoverTools({
+      operationId: "composio-multi-account",
+      traceId: "composio-multi-account",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: "connection-personal",
+          connectorId: "composio",
+          externalId: "github",
+          displayName: "Personal",
+          providerRef: "ca-personal",
+        },
+        {
+          id: "connection-work",
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "Work",
+          providerRef: "ca-work",
+        },
+        {
+          id: "connection-noauth",
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "Legacy",
+          providerRef: "github",
+        },
+      ],
+    });
+
+    expect(composioSdkState.created.at(-1)).toMatchObject({
+      userId: "user-1",
+      config: {
+        toolkits: ["GITHUB"],
+        connectedAccounts: { GITHUB: ["ca-personal", "ca-work"] },
+        multiAccount: {
+          enable: true,
+          maxAccountsPerToolkit: 10,
+          requireExplicitSelection: true,
+        },
+      },
+    });
   });
 
   it("uses catalog-canonical toolkit slugs without preloading every tool", async () => {

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -244,7 +244,7 @@ export class ComposioConnector implements ComposioProvider {
     const canonicalByKey = new Map(
       canonicalToolkits.map((toolkit) => [composioSlugKey(toolkit), toolkit]),
     );
-    const connectedAccounts: Record<string, string[]> = {};
+    const accountIdsByToolkit = new Map<string, Set<string>>();
     for (const connection of connections) {
       const accountId = connection.providerRef?.trim();
       if (!accountId) continue;
@@ -253,9 +253,13 @@ export class ComposioConnector implements ComposioProvider {
       if (composioSlugKey(accountId) === composioSlugKey(connection.externalId)) continue;
       const toolkit = canonicalByKey.get(composioSlugKey(connection.externalId));
       if (!toolkit) continue;
-      const ids = connectedAccounts[toolkit] ?? [];
-      ids.push(accountId);
-      connectedAccounts[toolkit] = ids;
+      const ids = accountIdsByToolkit.get(toolkit) ?? new Set<string>();
+      ids.add(accountId);
+      accountIdsByToolkit.set(toolkit, ids);
+    }
+    const connectedAccounts: Record<string, string[]> = {};
+    for (const [toolkit, ids] of accountIdsByToolkit) {
+      connectedAccounts[toolkit] = [...ids].sort();
     }
     const key = executeSessionKey(canonicalToolkits, connectedAccounts);
     if (!key) return this.sessionFor(userId);
@@ -268,16 +272,24 @@ export class ComposioConnector implements ComposioProvider {
         this.executeSessions.delete(userId);
       }
     }
+    // Non-multi-account sessions cap connectedAccounts at one id per toolkit.
+    // requireExplicitSelection would also break single-account / no-auth
+    // execute paths that do not pass an account parameter.
+    const needsMultiAccount = Object.values(connectedAccounts).some((ids) => ids.length >= 2);
     const session = await composio.create(userId, {
       manageConnections: false,
       sandbox: { enable: false },
       toolkits: canonicalToolkits,
       ...(Object.keys(connectedAccounts).length > 0 ? { connectedAccounts } : {}),
-      multiAccount: {
-        enable: true,
-        maxAccountsPerToolkit: 10,
-        requireExplicitSelection: true,
-      },
+      ...(needsMultiAccount
+        ? {
+            multiAccount: {
+              enable: true,
+              maxAccountsPerToolkit: 10,
+              requireExplicitSelection: true,
+            },
+          }
+        : {}),
     });
     this.executeSessions.set(userId, { sessionId: session.sessionId, key });
     return session;

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -2,6 +2,7 @@ import console from "node:console";
 import { Composio } from "@composio/core";
 import type {
   AdapterContext,
+  ConnectedConnector,
   ConnectorCall,
   ConnectorCatalogItem,
   ConnectorEvent,
@@ -105,14 +106,22 @@ function composioSlugKey(slug: string): string {
   return slug.trim().toLowerCase();
 }
 
-export function executeSessionKey(toolkits: string[]): string {
+export function executeSessionKey(
+  toolkits: string[],
+  connectedAccounts: Record<string, string[]> = {},
+): string {
   const unique = new Map<string, string>();
   for (const slug of toolkits) {
     const trimmed = slug.trim();
     const key = composioSlugKey(trimmed);
     if (key && !unique.has(key)) unique.set(key, trimmed);
   }
-  return [...unique.values()].sort().join(",");
+  const toolkitKey = [...unique.values()].sort().join(",");
+  const accountKey = Object.entries(connectedAccounts)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([toolkit, ids]) => `${toolkit}:${[...new Set(ids)].sort().join(",")}`)
+    .join(";");
+  return accountKey ? `${toolkitKey}|${accountKey}` : toolkitKey;
 }
 
 export type PluginConnectionRow = {
@@ -225,9 +234,30 @@ export class ComposioConnector implements ComposioProvider {
     return session;
   }
 
-  async sessionForExecute(userId: string, toolkits: string[]): Promise<ComposioSession> {
-    const canonicalToolkits = await this.canonicalizeToolkits(toolkits);
-    const key = executeSessionKey(canonicalToolkits);
+  async sessionForExecute(
+    userId: string,
+    connections: ReturnType<typeof connectedComposioConnections>,
+  ): Promise<ComposioSession> {
+    const canonicalToolkits = await this.canonicalizeToolkits(
+      connections.map((connection) => connection.externalId),
+    );
+    const canonicalByKey = new Map(
+      canonicalToolkits.map((toolkit) => [composioSlugKey(toolkit), toolkit]),
+    );
+    const connectedAccounts: Record<string, string[]> = {};
+    for (const connection of connections) {
+      const accountId = connection.providerRef?.trim();
+      if (!accountId) continue;
+      // No-auth and legacy rows store the toolkit slug rather than a remote
+      // connected-account id. Only concrete account ids can scope a session.
+      if (composioSlugKey(accountId) === composioSlugKey(connection.externalId)) continue;
+      const toolkit = canonicalByKey.get(composioSlugKey(connection.externalId));
+      if (!toolkit) continue;
+      const ids = connectedAccounts[toolkit] ?? [];
+      ids.push(accountId);
+      connectedAccounts[toolkit] = ids;
+    }
+    const key = executeSessionKey(canonicalToolkits, connectedAccounts);
     if (!key) return this.sessionFor(userId);
     const composio = this.sdk();
     const existing = this.executeSessions.get(userId);
@@ -242,6 +272,12 @@ export class ComposioConnector implements ComposioProvider {
       manageConnections: false,
       sandbox: { enable: false },
       toolkits: canonicalToolkits,
+      ...(Object.keys(connectedAccounts).length > 0 ? { connectedAccounts } : {}),
+      multiAccount: {
+        enable: true,
+        maxAccountsPerToolkit: 10,
+        requireExplicitSelection: true,
+      },
     });
     this.executeSessions.set(userId, { sessionId: session.sessionId, key });
     return session;
@@ -303,9 +339,9 @@ export class ComposioConnector implements ComposioProvider {
   }
 
   async discoverTools(context: AdapterContext): Promise<ConnectorTool[]> {
-    const toolkits = connectedComposioExternalIds(context);
-    if (toolkits.length === 0) return [];
-    const session = await this.sessionForExecute(context.userId, toolkits);
+    const connections = connectedComposioConnections(context);
+    if (connections.length === 0) return [];
+    const session = await this.sessionForExecute(context.userId, connections);
     const raw = await session.tools();
     return asConnectorTools(raw);
   }
@@ -314,7 +350,7 @@ export class ComposioConnector implements ComposioProvider {
     try {
       const session = await this.sessionForExecute(
         context.userId,
-        connectedComposioExternalIds(context),
+        connectedComposioConnections(context),
       );
       const result = await session.execute(call.tool, call.args ?? {});
       if (result.error) {
@@ -598,13 +634,15 @@ function isManagedConnectorProvider(
   );
 }
 
-function connectedComposioExternalIds(context: AdapterContext): string[] {
+function connectedComposioConnections(context: AdapterContext): ConnectedConnector[] {
   return (
-    context.connectedConnections
-      ?.filter((connection) => connection.connectorId === "composio")
-      .map((connection) => connection.externalId) ??
-    context.connectedProviders ??
-    []
+    context.connectedConnections?.filter((connection) => connection.connectorId === "composio") ??
+    (context.connectedProviders ?? []).map((externalId) => ({
+      id: `legacy:${externalId}`,
+      connectorId: "composio",
+      externalId,
+      displayName: externalId,
+    }))
   );
 }
 


### PR DESCRIPTION
## Why

Issue #583 asks for multiple named accounts of the same integration. PR #589 adds the account rows and labels, but its Composio execute session is still scoped only by toolkit. That leaves concrete providerRef account identities out of tool discovery and execution, so two connected Gmail accounts cannot be routed explicitly.

## What

- build Composio execute sessions from connected account rows, not only toolkit slugs
- pass concrete account IDs through connectedAccounts and enable explicit multi-account selection
- include account IDs in the execute-session cache key so account changes rebuild the session
- ignore legacy and no-auth refs whose value is only the toolkit slug
- cover stable keying and the exact multi-account session configuration

No user-facing copy is added or changed.

## Test

- pnpm exec vitest run packages/adapters/src/composio-connector.test.ts (26 passed)
- pnpm --filter @rakazo/adapters test (1056 passed, 7 skipped)
- pnpm --filter @rakazo/adapters check
- pnpm exec biome check packages/adapters/src/composio-connector.ts packages/adapters/src/composio-connector.test.ts
- git diff --check
