### PR TITLE
fix(supervisor): reject computer control redirects

### DIFF
--- a/infra/sandboxes/supervisor/src/computer-control.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-control.test.ts
@@ -1,0 +1,116 @@
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { controlDesktop } from "./index.js";
+import {
+  attemptComputerControl,
+  preferComputerControl,
+  shouldReplayComputerActions,
+} from "./supervisor-logic.js";
+
+const token = "test-computer-control-token";
+const actions = [{ kind: "key" as const, key: "Enter" }];
+const observation = { image: "ZmFrZQ==", mimeType: "image/png", width: 1, height: 1 };
+const servers: http.Server[] = [];
+
+async function listen(handler: http.RequestListener) {
+  const server = http.createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("expected a TCP address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+          server.closeAllConnections();
+        }),
+    ),
+  );
+});
+
+describe("computer control HTTP boundary", () => {
+  it.each([false, true])("preserves direct desktop responses (observe=%s)", async (observe) => {
+    const requests: Array<{ url?: string; method?: string; authorization?: string; body: string }> =
+      [];
+    const result = { completed: 1, ...(observe ? { observation } : {}) };
+    const origin = await listen(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      requests.push({
+        url: req.url,
+        method: req.method,
+        authorization: req.headers.authorization,
+        body: Buffer.concat(chunks).toString(),
+      });
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(result));
+    });
+
+    await expect(
+      controlDesktop({ url: `${origin}/v1/desktop`, token }, actions, ":2", observe, 25),
+    ).resolves.toEqual(result);
+    expect(requests).toEqual([
+      {
+        url: "/v1/desktop",
+        method: "POST",
+        authorization: `Bearer ${token}`,
+        body: JSON.stringify({
+          steps: [{ argv: ["env", "DISPLAY=:2", "xdotool", "key", "--clearmodifiers", "Return"] }],
+          display: ":2",
+          observe,
+          settleMs: 25,
+        }),
+      },
+    ]);
+  });
+
+  describe.each([301, 302, 303, 307, 308])("HTTP %s", (status) => {
+    it.each(["same origin", "other origin"])(
+      "never contacts a redirect target on the %s or replays actions",
+      async (destination) => {
+        const targetRequests: Array<{ method?: string; authorization?: string }> = [];
+        const target: http.RequestListener = (req, res) => {
+          targetRequests.push({ method: req.method, authorization: req.headers.authorization });
+          // Even a response matching the control contract must never be accepted
+          // from another endpoint. These servers are loopback-only fake services.
+          res.setHeader("content-type", "application/json");
+          res.end(JSON.stringify({ completed: 1, observation }));
+        };
+        const location =
+          destination === "same origin" ? "/other-endpoint" : `${await listen(target)}/v1/desktop`;
+        let controlRequests = 0;
+        const origin = await listen((req, res) => {
+          if (req.url !== "/v1/desktop") return target(req, res);
+          controlRequests += 1;
+          req.resume();
+          res.writeHead(status, { location });
+          res.end();
+        });
+        const endpoint = { url: `${origin}/v1/desktop`, token };
+
+        const attempt = await attemptComputerControl(() =>
+          controlDesktop(endpoint, actions, ":1", false, 0),
+        );
+        expect(targetRequests).toEqual([]);
+        expect(attempt.status).toBe("failed");
+        expect(shouldReplayComputerActions(attempt)).toBe(false);
+
+        // Observation may fall back to Docker exec on the original computer.
+        const fallbackObservation = { source: "original-computer" };
+        await expect(
+          preferComputerControl(
+            async () => (await controlDesktop(endpoint, [], ":1", true, 0)).observation,
+            async () => fallbackObservation,
+          ),
+        ).resolves.toEqual(fallbackObservation);
+        expect(targetRequests).toEqual([]);
+        expect(controlRequests).toBe(2);
+      },
+    );
+  });
+});

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -760,7 +760,7 @@ function computerControlEndpoint(info: Docker.ContainerInspectInfo) {
   });
 }
 
-async function controlDesktop(
+export async function controlDesktop(
   endpoint: { url: string; token: string },
   actions: Array<z.infer<typeof computerActionSchema>>,
   display: string,
@@ -771,6 +771,9 @@ async function controlDesktop(
   try {
     response = await fetch(endpoint.url, {
       method: "POST",
+      // The computer can replace its listener; keep requests on the inspected
+      // computer's fixed endpoint instead of following it across sandbox networks.
+      redirect: "error",
       headers: {
         authorization: `Bearer ${endpoint.token}`,
         "content-type": "application/json",


### PR DESCRIPTION
## Why

A compromised Docker computer can replace its desktop control listener and redirect the next authorized observation or action. The supervisor currently follows that response using its own network access, escaping the initially inspected computer and fixed desktop endpoint. In the isolated Compose topology, the supervisor joins every computer network and also has access to its own loopback and application network.

The issue is present on current main. The listener and bot commands share the container user; dropping capabilities and forbidding privilege escalation do not prevent same-user listener replacement. The shell lifecycle filter blocks common command spellings but is not an operating-system boundary for arbitrary programs. Supervisor bearer authentication and bot/Space label checks authorize the initial request, not its redirect destination.

Assessed severity: **Medium**, with deployment-dependent higher impact if sensitive unauthenticated HTTP services are reachable. This demonstrates constrained server-side request forgery, not host takeover: other computers require different control tokens, supervisor operations require a separate service credential and identity headers, cross-origin fetch redirects remove Authorization, and HTTP redirects cannot access the Docker Unix socket. Responses must pass the control JSON/completion checks; ordinary bodies are not returned intact, though error details can surface through actions. The default remote-provider production topology does not use this Docker control path; host-run Docker Desktop setups may already fall back when container IPs are unreachable.

Checked the existing loopback-control, Team desktop, resource-limit, and supervisor-response-bounds proposals; none rejects these redirects.

## What changed

Reject redirects in the desktop control fetch, keeping requests on the Docker-inspected address, control port, and fixed endpoint. Redirect rejection remains an action failure, preventing unsafe replay. Observations retain their existing Docker-exec fallback on the original computer. No provider contracts or UI copy change.

## Validation

- Deterministic local HTTP tests with fake tokens and responses cover 301, 302, 303, 307, and 308, both relative endpoint changes and a second origin. Each verifies zero requests to the redirect target, no action replay, and observation fallback. Direct requests retain their method, token, mapped actions, and response.
- Before the fix, all ten redirect cases failed by contacting the forbidden target. The reproduction observed GET for 301/302/303, POST for 307/308, and removal of Authorization across origins.
- After the fix, all twelve regression tests pass. The supervisor suite passes 84 tests, with one existing Linux-only test skipped. Supervisor typechecking and repository lint pass; lint reports existing warnings outside this change.
- No production services or local Electron E2E were used. Docker network reachability was traced from the checked-in topology; the HTTP reproduction uses loopback servers rather than live containers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Desktop control requests no longer follow redirects to unintended endpoints.
  - Desktop actions are not replayed after a redirect, helping prevent duplicate interactions.
  - Observation now falls back to the original computer when a redirect occurs.

- **Tests**
  - Added coverage for direct desktop control responses, request parameters, redirect handling, and observation fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->