### PR TITLE
fix(mcp): bind transport exceptions to the resource origin

### DIFF
--- a/packages/adapters/src/mcp-connector.test.ts
+++ b/packages/adapters/src/mcp-connector.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { allowlistDrift, McpConnector } from "./mcp-connector.js";
+import { type McpOAuthBroker, StoredMcpOAuthProvider } from "./mcp-oauth.js";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -382,6 +383,92 @@ describe("MCP connector session cache", () => {
     expect(state.calls).toEqual(["__catalog_search", "__catalog_load", "__catalog_execute"]);
     await connector.close();
   });
+
+  it.each(["localhost", "127.0.0.1", "[::1]"])(
+    "blocks OAuth rediscovery to HTTP %s after invalid_client from a public server",
+    async (host) => {
+      const requests: Request[] = [];
+      const metadataUrl = `http://${host}:8123/private-probe`;
+      const provider = new StoredMcpOAuthProvider(
+        "server-1",
+        {
+          oauth: {
+            redirectUri: "https://app.example.test/mcp/oauth/callback",
+            tokens: {
+              access_token: "fake-stale-access",
+              refresh_token: "fake-refresh",
+              token_type: "bearer",
+            },
+            clientInformation: { client_id: "fake-client" },
+            discoveryState: {
+              authorizationServerUrl: "https://auth.example.test",
+              resourceMetadata: {
+                resource: SERVER.endpoint,
+                authorization_servers: ["https://auth.example.test"],
+              },
+              authorizationServerMetadata: {
+                issuer: "https://auth.example.test",
+                authorization_endpoint: "https://auth.example.test/authorize",
+                token_endpoint: "https://auth.example.test/token",
+                response_types_supported: ["code"],
+              },
+            },
+          },
+        },
+        async () => undefined,
+      );
+      const invalidate = vi.spyOn(provider, "invalidateCredentials");
+      const connector = new McpConnector(
+        { botMcpServer: { findMany: vi.fn().mockResolvedValue([ASSIGNMENT]) } } as never,
+        {} as never,
+        {
+          network: {
+            resolveHostname: async () => [{ address: "203.0.113.10", family: 4 }],
+            fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+              const request = new Request(input, init);
+              requests.push(request);
+              if (request.url === SERVER.endpoint) {
+                return new Response(null, {
+                  status: 401,
+                  headers: { "WWW-Authenticate": `Bearer resource_metadata="${metadataUrl}"` },
+                });
+              }
+              if (request.url === "https://auth.example.test/token") {
+                return Response.json({ error: "invalid_client" }, { status: 400 });
+              }
+              return new Response(null, { status: 404 });
+            }),
+          },
+        },
+        { providerFor: vi.fn().mockResolvedValue(provider) } as unknown as McpOAuthBroker,
+      );
+
+      try {
+        await expect(
+          connector.discoverTools({
+            spaceId: "w1",
+            userId: "u1",
+            botId: "bot-1",
+            signal: new AbortController().signal,
+          } as never),
+        ).resolves.toEqual([]);
+
+        expect(requests.slice(0, 2).map((request) => `${request.method} ${request.url}`)).toEqual([
+          `POST ${SERVER.endpoint}`,
+          "POST https://auth.example.test/token",
+        ]);
+        expect(invalidate).toHaveBeenCalledWith("all");
+        expect(requests.some((request) => request.url === metadataUrl)).toBe(false);
+        // The endpoint-origin compatibility retry remains allowed, through remote policy.
+        expect(
+          requests.some((request) => request.url === "https://mcp.example.test/private-probe"),
+        ).toBe(true);
+        expect(requests.every((request) => new URL(request.url).protocol === "https:")).toBe(true);
+      } finally {
+        await connector.close();
+      }
+    },
+  );
 
   it("connects to an explicitly configured localhost HTTP server", async () => {
     const state = { failNext: false, initializations: 0 };

--- a/packages/adapters/src/mcp-connector.ts
+++ b/packages/adapters/src/mcp-connector.ts
@@ -300,7 +300,7 @@ export class McpConnector implements ConnectorProvider {
         };
         await session.connectRemote({
           url: server.endpoint,
-          urlPolicy: { allowHttpLocalhost: true, allowLocalHttpCredentials: localHttp },
+          urlPolicy: { allowHttpLocalhost: localHttp, allowLocalHttpCredentials: localHttp },
           transport: server.transport === "sse" ? "sse" : "streamable-http",
           allowLegacySse: server.transport === "sse",
           headerPolicy: { headers },

--- a/packages/adapters/src/mcp-transport.test.ts
+++ b/packages/adapters/src/mcp-transport.test.ts
@@ -62,6 +62,175 @@ describe("MCP transport seam", () => {
     await expect(session.callTool("echo")).rejects.toThrow("not connected");
   });
 
+  it("preserves SDK session and protocol headers after stateful initialization", async () => {
+    const requests: Request[] = [];
+    const session = new McpSession();
+    try {
+      await session.connectRemote({
+        url: "https://mcp.example.test/mcp",
+        network: {
+          ...TEST_NETWORK,
+          fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+            const request = new Request(input, init);
+            requests.push(request);
+            const message = request.method === "POST" ? await request.json() : undefined;
+            if (message?.method === "initialize") {
+              return Response.json(
+                {
+                  jsonrpc: "2.0",
+                  id: message.id,
+                  result: {
+                    protocolVersion: "2025-11-25",
+                    capabilities: { tools: {} },
+                    serverInfo: { name: "fake-stateful-server", version: "1" },
+                  },
+                },
+                { headers: { "Mcp-Session-Id": "fake-session" } },
+              );
+            }
+            if (
+              request.headers.get("mcp-session-id") !== "fake-session" ||
+              request.headers.get("mcp-protocol-version") !== "2025-11-25"
+            ) {
+              return new Response(null, { status: 400 });
+            }
+            if (request.method === "GET") return new Response(null, { status: 405 });
+            if (message?.method === "tools/list") {
+              return Response.json({ jsonrpc: "2.0", id: message.id, result: { tools: [] } });
+            }
+            return new Response(null, { status: 202 });
+          }),
+        },
+      });
+
+      await expect(session.listTools()).resolves.toEqual({ tools: [] });
+      expect(requests[0]?.headers.has("mcp-session-id")).toBe(false);
+      expect(requests.length).toBeGreaterThanOrEqual(3);
+      expect(
+        requests
+          .slice(1)
+          .every((request) => request.headers.get("mcp-session-id") === "fake-session"),
+      ).toBe(true);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it.each([
+    ["https://mcp.example.test/mcp", "http://localhost:8123"],
+    ["https://mcp.example.test/mcp", "http://127.0.0.1:8123"],
+    ["https://mcp.example.test/mcp", "http://[::1]:8123"],
+    ["https://localhost:8123/mcp", "http://localhost:8123"],
+    ["http://localhost:8123/mcp", "http://localhost:8124"],
+    ["http://localhost:8123/mcp", "http://127.0.0.1:8123"],
+    ["http://[::1]:8123/mcp", "http://[::1]:8124"],
+  ])("does not extend the local exception from %s to %s", async (resource, origin) => {
+    const fetchImpl = vi.fn();
+    const safeFetch = secureFetch(
+      new URL(resource),
+      { allowHttpLocalhost: true, allowLocalHttpCredentials: true },
+      {},
+      { fetch: fetchImpl, ...TEST_NETWORK },
+    );
+    try {
+      await expect(safeFetch(`${origin}/.well-known/oauth-protected-resource`)).rejects.toThrow(
+        "HTTPS",
+      );
+      await expect(
+        safeFetch(`${origin}/token`, { method: "POST", body: "fake-token-body" }),
+      ).rejects.toThrow("HTTPS");
+      expect(fetchImpl).not.toHaveBeenCalled();
+    } finally {
+      await safeFetch.close();
+    }
+  });
+
+  it.each(["localhost", "127.0.0.1", "[::1]"])(
+    "allows explicitly configured HTTP %s discovery and token traffic on the same origin",
+    async (host) => {
+      const origin = `http://${host}:8123`;
+      const fetchImpl = vi.fn(async () => Response.json({ ok: true }));
+      const resolveHostname = vi.fn();
+      const safeFetch = secureFetch(
+        new URL(`${origin}/mcp`),
+        { allowHttpLocalhost: true },
+        {},
+        { fetch: fetchImpl, resolveHostname },
+      );
+      try {
+        await expect(
+          safeFetch(`${origin}/.well-known/oauth-protected-resource`),
+        ).resolves.toHaveProperty("ok", true);
+        await expect(
+          safeFetch(`${origin}/token`, { method: "POST", body: "fake-token-body" }),
+        ).resolves.toHaveProperty("ok", true);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        expect(resolveHostname).not.toHaveBeenCalled();
+      } finally {
+        await safeFetch.close();
+      }
+    },
+  );
+
+  it.each(["https://localhost:8123", "https://127.0.0.1:8123", "https://private.example.test"])(
+    "applies remote network policy to discovery and token traffic at %s",
+    async (origin) => {
+      const fetchImpl = vi.fn();
+      const safeFetch = secureFetch(
+        new URL("http://localhost:8123/mcp"),
+        { allowHttpLocalhost: true },
+        {},
+        {
+          fetch: fetchImpl,
+          resolveHostname: async () => [{ address: "10.0.0.1", family: 4 }],
+        },
+      );
+      try {
+        await expect(safeFetch(`${origin}/.well-known/oauth-protected-resource`)).rejects.toThrow(
+          "private",
+        );
+        await expect(
+          safeFetch(`${origin}/token`, { method: "POST", body: "fake-token-body" }),
+        ).rejects.toThrow("private");
+        expect(fetchImpl).not.toHaveBeenCalled();
+      } finally {
+        await safeFetch.close();
+      }
+    },
+  );
+
+  it("keeps SDK protocol headers on the resource origin and strips them on other origins", async () => {
+    const safeFetch = secureFetch(
+      new URL("https://mcp.example.test/mcp"),
+      {},
+      {},
+      {
+        ...TEST_NETWORK,
+        fetch: vi.fn(async (_input: string | URL | Request, init?: RequestInit) =>
+          Response.json(Object.fromEntries(new Headers(init?.headers))),
+        ),
+      },
+    );
+    const headers = {
+      "mcp-session-id": "fake-session",
+      "mcp-protocol-version": "2025-11-25",
+      "last-event-id": "fake-event",
+    };
+    try {
+      await expect(
+        (await safeFetch("https://mcp.example.test/mcp", { headers })).json(),
+      ).resolves.toEqual(headers);
+      await expect(
+        (await safeFetch("https://auth.example.test/discovery", { headers })).json(),
+      ).resolves.toEqual({});
+      await expect(
+        (await safeFetch("https://mcp.example.test:8443/discovery", { headers })).json(),
+      ).resolves.toEqual({});
+    } finally {
+      await safeFetch.close();
+    }
+  });
+
   it("lets the SDK refresh a rejected token, persist rotation, and retry the MCP request", async () => {
     const resourceHeaders: string[] = [];
     const persisted: unknown[] = [];

--- a/packages/adapters/src/mcp-transport.ts
+++ b/packages/adapters/src/mcp-transport.ts
@@ -21,7 +21,7 @@ export type McpRemoteTransport = "streamable-http" | "sse";
 export interface McpUrlPolicy {
   /** Maximum URL length accepted before any network request. */
   maxUrlLength?: number;
-  /** Permit plain HTTP only for explicitly local hosts. */
+  /** Permit plain HTTP only on the configured loopback resource's exact origin. */
   allowHttpLocalhost?: boolean;
   /** Permit configured credentials on an explicitly local HTTP endpoint. */
   allowLocalHttpCredentials?: boolean;
@@ -70,6 +70,7 @@ export interface McpClientOptions {
 }
 
 const DEFAULT_HEADERS = ["accept", "content-type", "authorization", "user-agent"];
+const RESOURCE_HEADERS = new Set(["mcp-session-id", "mcp-protocol-version", "last-event-id"]);
 const DEFAULT_MAX_URL_LENGTH = 2_048;
 
 function validateUrl(raw: string | URL, policy: McpUrlPolicy = {}): URL {
@@ -97,6 +98,12 @@ export function secureFetch(
   headerPolicy: McpHeaderPolicy = {},
   network: RemoteTransportDependencies = {},
 ): SafeRemoteFetch {
+  const localOrigin =
+    urlPolicy.allowHttpLocalhost === true &&
+    resourceUrl.protocol === "http:" &&
+    isLocalMcpHost(resourceUrl.hostname)
+      ? resourceUrl.origin
+      : undefined;
   const allowed = new Set(
     [
       ...DEFAULT_HEADERS,
@@ -124,11 +131,18 @@ export function secureFetch(
   );
   const request = async (input: Request | URL | string, init?: RequestInit): Promise<Response> => {
     const source = new Request(input, init);
-    const url = validateUrl(source.url, urlPolicy);
+    // OAuth challenges and rediscovery can supply new URLs. Only the explicitly
+    // configured local resource origin (including port) may bypass remote policy.
+    const url = validateUrl(source.url, {
+      ...urlPolicy,
+      allowHttpLocalhost: new URL(source.url).origin === localOrigin,
+    });
     const headers = new Headers();
     for (const [name, value] of source.headers) {
       const normalized = name.toLowerCase();
-      if (!allowed.has(normalized)) continue;
+      if (RESOURCE_HEADERS.has(normalized)) {
+        if (url.origin !== resourceUrl.origin) continue;
+      } else if (!allowed.has(normalized)) continue;
       if (url.origin !== resourceUrl.origin && configuredCredentialValues.has(value)) continue;
       headers.set(name, value);
     }


### PR DESCRIPTION
## Why

An assigned public MCP server could make runtime OAuth rediscovery fetch an HTTP loopback URL after rejecting a refresh with `invalid_client`. Runtime connections enabled the local HTTP exception even for public resources, bypassing the remote network policy. OAuth setup already used the stricter policy; existing credential filtering did not prevent the runtime request. The verified impact is an unintended local HTTP request, with further impact dependent on services reachable from that process.

The same transport filter also removed SDK session and protocol headers, causing stateful MCP servers to fail immediately after initialization.

## What changed

- Enable local HTTP only for an explicitly configured local resource and enforce its exact origin, including port, on every request. All other discovery and token traffic remains subject to the existing remote network policy.
- Preserve configured local MCP access and credentials, public OAuth refresh, and the endpoint-origin compatibility fallback.
- Preserve SDK session, protocol-version, and replay headers only on the configured resource origin.

## Validation

- Reproduced the loopback request with the pinned SDK before the fix for localhost, IPv4, and IPv6; all three regression cases now pass without contacting local services.
- Reproduced stateful initialization failure before the fix; the SDK now initializes and lists tools successfully with the required headers.
- All 73 focused MCP transport, connector, OAuth, and remote-network tests pass. Coverage includes rejected cross-port/local-origin requests, discovery and token policy, local credentials, and cross-origin header stripping. New regressions use fake data and injected network responses.
- Adapter typecheck and repository lint pass; lint reports existing warnings outside this change. No production systems or local Electron Playwright suite were used.
- Checked current main and existing MCP fixes; no overlapping open fix was found. No UI copy changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted unencrypted HTTP access to the configured local MCP resource origin, while continuing to support approved localhost connections.
  * Improved security for remote MCP requests by applying network and origin checks consistently during discovery and token exchanges.
  * Preserved required MCP session and protocol headers on the resource origin while preventing them from being sent to other origins.
  * Prevented OAuth token rediscovery after an `invalid_client` refresh failure and invalidated affected credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->