### PR TITLE
fix(memory): restrict local providers to deployment owners

### DIFF
--- a/apps/api/src/persist-memory-provider-config.test.ts
+++ b/apps/api/src/persist-memory-provider-config.test.ts
@@ -7,6 +7,7 @@ const actor = {
   email: "a@b.com",
   isDeploymentOwner: false,
 };
+const deploymentOwner = { ...actor, isDeploymentOwner: true };
 
 function makeDeps(
   overrides: {
@@ -86,6 +87,84 @@ function connectionInput(mode: "cloud" | "local", baseUrl?: string) {
 }
 
 describe("persistMemoryProviderConfig", () => {
+  it("rejects unknown providers as bad requests without probing or writing", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { deps, transaction } = makeDeps();
+    try {
+      await expect(
+        persistMemoryProviderConfig(deps as never, actor, {
+          ...connectionInput("cloud"),
+          provider: "unknown-provider",
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(transaction).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it.each(["#", "?action=delete", "?"])(
+    "rejects ambiguous local URLs even for the deployment owner: %s",
+    async (suffix) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const { deps, transaction } = makeDeps();
+      try {
+        await expect(
+          persistMemoryProviderConfig(
+            deps as never,
+            deploymentOwner,
+            connectionInput("local", `http://127.0.0.1:8123/internal-action${suffix}`),
+          ),
+        ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(transaction).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    },
+  );
+
+  it.each(["http://127.0.0.1:8123/internal-action#", "http://localhost:6767"])(
+    "rejects ordinary Space owners before any local probe or write: %s",
+    async (baseUrl) => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response("[]"));
+      vi.stubGlobal("fetch", fetchMock);
+      const { deps, transaction } = makeDeps();
+      try {
+        await expect(
+          persistMemoryProviderConfig(deps as never, actor, connectionInput("local", baseUrl)),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(deps.secrets.put).not.toHaveBeenCalled();
+        expect(transaction).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    },
+  );
+
+  it("still requires Space ownership for a deployment owner", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { deps, transaction } = makeDeps({ spaceOwner: false });
+    try {
+      await expect(
+        persistMemoryProviderConfig(
+          deps as never,
+          deploymentOwner,
+          connectionInput("local", "http://localhost:6767"),
+        ),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(transaction).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("rejects non-owners before probing or writing Space configuration", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
@@ -103,7 +182,7 @@ describe("persistMemoryProviderConfig", () => {
   it("rejects local mode without a baseUrl, without touching the database", async () => {
     const { deps, upsert } = makeDeps();
     await expect(
-      persistMemoryProviderConfig(deps as never, actor, connectionInput("local")),
+      persistMemoryProviderConfig(deps as never, deploymentOwner, connectionInput("local")),
     ).rejects.toThrow(/baseUrl/);
     expect(upsert).not.toHaveBeenCalled();
   });
@@ -115,7 +194,7 @@ describe("persistMemoryProviderConfig", () => {
     await expect(
       persistMemoryProviderConfig(
         deps as never,
-        actor,
+        deploymentOwner,
         connectionInput("local", "http://169.254.169.254/latest/meta-data/"),
       ),
     ).rejects.toThrow(/loopback/);
@@ -128,7 +207,7 @@ describe("persistMemoryProviderConfig", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
     const { deps, upsert } = makeDeps();
     await expect(
-      persistMemoryProviderConfig(deps as never, actor, {
+      persistMemoryProviderConfig(deps as never, deploymentOwner, {
         ...connectionInput("local", "http://localhost:6767"),
         credentials: { apiKey: "sm_bad_key" },
       }),
@@ -144,7 +223,7 @@ describe("persistMemoryProviderConfig", () => {
 
     await persistMemoryProviderConfig(
       deps as never,
-      actor,
+      deploymentOwner,
       connectionInput("local", "http://[::1]:6767"),
     );
 

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -47,6 +47,7 @@ import {
   McpOAuthBroker,
   type MemoryProviderResolver,
   mapScratchpadItem,
+  memoryProviderRequiresDeploymentOwner,
   modelCredentialDto,
   type PiOAuthLogins,
   planLiveConnectionSync,
@@ -4037,11 +4038,21 @@ export async function persistMemoryProviderConfig(
   },
 ) {
   await requireSpaceOwner(deps.prisma, actor);
-  const prepared = await prepareMemoryProviderConnection(input).catch((error: unknown) => {
+  let prepared: Awaited<ReturnType<typeof prepareMemoryProviderConnection>>;
+  try {
+    if (
+      memoryProviderRequiresDeploymentOwner(input.provider, input.settings) &&
+      !actor.isDeploymentOwner
+    ) {
+      throw new ORPCError("FORBIDDEN");
+    }
+    prepared = await prepareMemoryProviderConnection(input);
+  } catch (error) {
+    if (error instanceof ORPCError) throw error;
     throw new ORPCError("BAD_REQUEST", {
       message: error instanceof Error ? error.message : "Memory provider connection failed",
     });
-  });
+  }
   const stored = await deps.secrets.put(JSON.stringify(prepared.credentials), {
     operationId: "memory-provider-config",
     traceId: "memory-provider-config",

--- a/packages/adapters/src/memory-provider-factory.test.ts
+++ b/packages/adapters/src/memory-provider-factory.test.ts
@@ -1,32 +1,97 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMemoryProvider, SpaceMemoryProviderResolver } from "./memory-provider-factory.js";
 
-function resolverFor(plaintext: string) {
+function resolverFor(
+  plaintext: string,
+  options: { mode?: "cloud" | "local"; ownerUserId?: string | null; baseUrl?: string } = {},
+) {
   const prisma = {
     spaceMemoryConfig: {
       findUnique: vi.fn(async () => ({
+        userId: "config-author",
         provider: "supermemory",
-        settings: { mode: "cloud", baseUrl: "https://api.supermemory.ai" },
+        settings: {
+          mode: options.mode ?? "cloud",
+          baseUrl: options.baseUrl ?? "https://api.supermemory.ai",
+        },
         defaultMemoryScope: "shared",
         secret: { ciphertext: "encrypted" },
       })),
+    },
+    deploymentSettings: {
+      findUnique: vi.fn(async () => ({ ownerUserId: options.ownerUserId ?? null })),
     },
   };
   const secrets = { load: vi.fn(() => plaintext) };
   return {
     resolver: new SpaceMemoryProviderResolver(prisma as never, secrets as never),
     secrets,
+    prisma,
   };
 }
 
+afterEach(() => vi.unstubAllGlobals());
+
 describe("SpaceMemoryProviderResolver", () => {
+  it.each([null, "another-user"])(
+    "disables saved local configurations without current deployment-owner authorization: %s",
+    async (ownerUserId) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      const { resolver, secrets } = resolverFor("sm_fake_key", {
+        mode: "local",
+        baseUrl: "http://127.0.0.1:8123/internal-action#",
+        ownerUserId,
+      });
+
+      await expect(resolver.resolve("workspace-1")).resolves.toBeNull();
+      expect(secrets.load).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retains deployment-owner-configured local memory for Space members", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ results: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { resolver } = resolverFor("sm_fake_key", {
+      mode: "local",
+      baseUrl: "http://localhost:6767/memory/",
+      ownerUserId: "config-author",
+    });
+    const configured = await resolver.resolve("workspace-1");
+    await configured!.provider.recall(
+      { query: "project", scope: "isolated", botId: "bot-1", limit: 1 },
+      {
+        operationId: "op-1",
+        traceId: "trace-1",
+        spaceId: "workspace-1",
+        userId: "space-member",
+        signal: new AbortController().signal,
+      },
+    );
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:6767/memory/v4/search");
+  });
+
+  it("rejects ambiguous persisted URLs even when the deployment owner configured them", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { resolver } = resolverFor("sm_fake_key", {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:8123/internal-action#",
+      ownerUserId: "config-author",
+    });
+    await expect(resolver.resolve("workspace-1")).rejects.toThrow(/base URL/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("loads generic JSON credential payloads", async () => {
-    const { resolver } = resolverFor(JSON.stringify({ apiKey: "sm_json_key" }));
+    const { resolver, prisma } = resolverFor(JSON.stringify({ apiKey: "sm_json_key" }));
 
     const configured = await resolver.resolve("workspace-1");
 
     expect(configured?.provider.describe().id).toBe("supermemory");
     expect(configured?.defaultScope).toBe("shared");
+    expect(prisma.deploymentSettings.findUnique).not.toHaveBeenCalled();
   });
 
   it("keeps legacy raw Supermemory credentials usable after the schema migration", async () => {

--- a/packages/adapters/src/memory-provider-factory.ts
+++ b/packages/adapters/src/memory-provider-factory.ts
@@ -6,6 +6,7 @@ import {
   decodeLegacySupermemoryCredentials,
   prepareSupermemoryConnection,
   SUPERMEMORY_PROVIDER_ID,
+  supermemoryRequiresDeploymentOwner,
 } from "./supermemory-memory-provider.js";
 
 export interface MemoryProviderConnectionInput {
@@ -30,6 +31,7 @@ export interface MemoryProviderResolver {
 }
 
 interface MemoryProviderAdapter {
+  requiresDeploymentOwner(settings: Record<string, string>): boolean;
   prepare(
     settings: Record<string, string>,
     credentials: Record<string, string>,
@@ -45,6 +47,7 @@ const MEMORY_PROVIDER_ADAPTERS: ReadonlyMap<string, MemoryProviderAdapter> = new
   [
     SUPERMEMORY_PROVIDER_ID,
     {
+      requiresDeploymentOwner: supermemoryRequiresDeploymentOwner,
       prepare: prepareSupermemoryConnection,
       create: createSupermemoryProvider,
       decodeLegacyCredentials: decodeLegacySupermemoryCredentials,
@@ -56,6 +59,14 @@ function memoryProviderAdapter(provider: string): MemoryProviderAdapter {
   const adapter = MEMORY_PROVIDER_ADAPTERS.get(provider);
   if (!adapter) throw new Error(`Unknown memory provider "${provider}".`);
   return adapter;
+}
+
+/** Adapters classify their settings; callers enforce the deployment trust boundary. */
+export function memoryProviderRequiresDeploymentOwner(
+  provider: string,
+  settings: Record<string, string>,
+): boolean {
+  return memoryProviderAdapter(provider).requiresDeploymentOwner(settings);
 }
 
 export async function prepareMemoryProviderConnection(
@@ -99,7 +110,7 @@ function decodeCredentials(provider: string, plaintext: string): Record<string, 
 
 export class SpaceMemoryProviderResolver implements MemoryProviderResolver {
   constructor(
-    private readonly prisma: Pick<PrismaClient, "spaceMemoryConfig">,
+    private readonly prisma: Pick<PrismaClient, "spaceMemoryConfig" | "deploymentSettings">,
     private readonly secrets: EncryptedSecretStore,
   ) {}
 
@@ -109,12 +120,21 @@ export class SpaceMemoryProviderResolver implements MemoryProviderResolver {
       include: { secret: true },
     });
     if (!config) return null;
+    const settings = toStringRecord(config.settings);
+    if (memoryProviderRequiresDeploymentOwner(config.provider, settings)) {
+      const deployment = await this.prisma.deploymentSettings.findUnique({
+        where: { id: "default" },
+        select: { ownerUserId: true },
+      });
+      // Also disable pre-existing local configurations authored outside the deployment boundary.
+      if (!deployment?.ownerUserId || deployment.ownerUserId !== config.userId) return null;
+    }
     const credentials = decodeCredentials(
       config.provider,
       this.secrets.load(config.secret.ciphertext, config.secret.id),
     );
     return {
-      provider: createMemoryProvider(config.provider, toStringRecord(config.settings), credentials),
+      provider: createMemoryProvider(config.provider, settings, credentials),
       defaultScope: config.defaultMemoryScope === "shared" ? "shared" : "isolated",
     };
   }

--- a/packages/adapters/src/supermemory-client.test.ts
+++ b/packages/adapters/src/supermemory-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   deleteSupermemoryContainer,
   MAX_MEMORY_CONTENT_CHARS,
@@ -12,6 +12,61 @@ import {
 } from "./supermemory-client.js";
 
 const config = { baseUrl: "http://localhost:6767", apiKey: "sm_test_key" };
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Supermemory request URLs", () => {
+  const operations = [
+    { method: "GET", path: "/v3/container-tags/list", request: probeSupermemory },
+    {
+      method: "POST",
+      path: "/v4/search",
+      request: (connection: typeof config) => searchSupermemory("query", "fake:tag", connection),
+    },
+    {
+      method: "POST",
+      path: "/v4/memories",
+      request: (connection: typeof config) => saveSupermemoryMemory("fact", "fake:tag", connection),
+    },
+    {
+      method: "DELETE",
+      path: "/v3/container-tags/fake%3Atag",
+      request: (connection: typeof config) => deleteSupermemoryContainer("fake:tag", connection),
+    },
+  ];
+
+  it.each([
+    "http://127.0.0.1:8123/internal-action#",
+    "http://127.0.0.1:8123/internal-action#ignored",
+    "http://127.0.0.1:8123/internal-action?",
+    "http://127.0.0.1:8123/internal-action?action=delete",
+    "http://fake:credential@localhost:6767",
+    "file:///fake-memory",
+  ])("rejects ambiguous base URLs before every transport call: %s", async (baseUrl) => {
+    const fetchMock = vi.fn().mockImplementation(async () => Response.json({ results: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+    for (const { request } of operations) {
+      expect(await request({ ...config, baseUrl })).toMatchObject({ ok: false });
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["", "/", "/memory", "/memory/"])(
+    "preserves the base prefix and provider route for every method: %s",
+    async (prefix) => {
+      const fetchMock = vi.fn().mockImplementation(async () => Response.json({ results: [] }));
+      vi.stubGlobal("fetch", fetchMock);
+      for (const { request, method, path } of operations) {
+        expect(await request({ ...config, baseUrl: `http://[::1]:6767${prefix}` })).toMatchObject({
+          ok: true,
+        });
+        const [url, init] = fetchMock.mock.lastCall!;
+        expect(url).toBe(`http://[::1]:6767${prefix.replace(/\/$/, "")}${path}`);
+        expect(init).toMatchObject({ method, redirect: "error" });
+      }
+    },
+  );
+});
 
 describe("searchSupermemory", () => {
   it("posts the query and container tag, returning search results on success", async () => {

--- a/packages/adapters/src/supermemory-client.ts
+++ b/packages/adapters/src/supermemory-client.ts
@@ -29,6 +29,30 @@ export interface SupermemoryConnectionConfig {
   apiKey: string;
 }
 
+/** Base URLs are route prefixes, never credentials or request query/fragment state. */
+export function parseSupermemoryBaseUrl(baseUrl: string): URL {
+  const url = new URL(baseUrl);
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username ||
+    url.password ||
+    // search/hash are empty for a bare ?/#, but those delimiters still swallow appended routes.
+    url.href.includes("?") ||
+    url.href.includes("#")
+  ) {
+    throw new Error(
+      "Memory base URL must use HTTP(S) without credentials, a query, or a fragment.",
+    );
+  }
+  return url;
+}
+
+function requestUrl(baseUrl: string, path: string): string {
+  const url = parseSupermemoryBaseUrl(baseUrl);
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}${path}`;
+  return url.href;
+}
+
 function requestSignal(signal?: AbortSignal): AbortSignal {
   const timeout = AbortSignal.timeout(SUPERMEMORY_TIMEOUT_MS);
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
@@ -81,7 +105,7 @@ export async function searchSupermemory(
 ): Promise<SupermemorySearchResponse> {
   try {
     const requestAbort = requestSignal(signal);
-    const response = await fetch(`${config.baseUrl}/v4/search`, {
+    const response = await fetch(requestUrl(config.baseUrl, "/v4/search"), {
       method: "POST",
       headers: authHeaders(config),
       body: JSON.stringify({
@@ -174,7 +198,7 @@ export async function deleteSupermemoryContainer(
 ): Promise<SupermemorySaveResponse> {
   try {
     const response = await fetch(
-      `${config.baseUrl}/v3/container-tags/${encodeURIComponent(containerTag)}`,
+      requestUrl(config.baseUrl, `/v3/container-tags/${encodeURIComponent(containerTag)}`),
       {
         method: "DELETE",
         headers: { Authorization: `Bearer ${config.apiKey}` },
@@ -202,7 +226,7 @@ export async function saveSupermemoryMemory(
     return { ok: false, error: "Supermemory save skipped: memory content is empty." };
   }
   try {
-    const response = await fetch(`${config.baseUrl}/v4/memories`, {
+    const response = await fetch(requestUrl(config.baseUrl, "/v4/memories"), {
       method: "POST",
       headers: authHeaders(config),
       body: JSON.stringify({ containerTag, memories: [{ content: memory, isStatic: false }] }),
@@ -248,7 +272,7 @@ export async function probeSupermemory(
   config: SupermemoryConnectionConfig,
 ): Promise<SupermemoryProbeResponse> {
   try {
-    const response = await fetch(`${config.baseUrl}/v3/container-tags/list`, {
+    const response = await fetch(requestUrl(config.baseUrl, "/v3/container-tags/list"), {
       method: "GET",
       headers: authHeaders(config),
       redirect: "error",

--- a/packages/adapters/src/supermemory-memory-provider.ts
+++ b/packages/adapters/src/supermemory-memory-provider.ts
@@ -9,6 +9,7 @@ import type {
 } from "@rakazo/adapter-kit";
 import {
   deleteSupermemoryContainer,
+  parseSupermemoryBaseUrl,
   probeSupermemory,
   type SupermemoryConnectionConfig,
   saveSupermemoryMemoryToContainers,
@@ -17,6 +18,10 @@ import {
 
 export const SUPERMEMORY_PROVIDER_ID = "supermemory";
 export const SUPERMEMORY_CLOUD_BASE_URL = "https://api.supermemory.ai";
+
+export function supermemoryRequiresDeploymentOwner(settings: Record<string, string>): boolean {
+  return settings.mode === "local";
+}
 
 function isLoopbackBaseUrl(url: string): boolean {
   try {
@@ -53,6 +58,7 @@ function parseSupermemoryConnection(
   if (mode === "local" && !isLoopbackBaseUrl(baseUrl)) {
     throw new Error("Local mode requires a loopback address (localhost, 127.0.0.1, or ::1).");
   }
+  parseSupermemoryBaseUrl(baseUrl);
   return { mode, baseUrl, apiKey };
 }
 


### PR DESCRIPTION
## Why

Space ownership does not authorize access to the deployment's loopback services. Previously an ordinary signed-in Space owner could initiate a local memory connection probe, and a base URL containing a query or fragment could change the requested route. A successful probe could also leave that destination available to later memory operations.

This is a confirmed SSRF boundary issue. Its impact depends on services in the API or worker network namespace accepting the constrained requests; redirects are already rejected, cloud mode has a fixed destination, and the supplied Compose deployments isolate the supervisor in a separate container with bearer authentication. Critical impact or code execution is not demonstrated.

## What changed

- Let adapters declare when deployment-owner authorization is required, and enforce it before probing or saving local memory settings while retaining the Space-owner check.
- Recheck saved local configurations against their author's current deployment-owner authority before decrypting credentials or creating a provider. Older local configurations authored by ordinary users remain disabled until the deployment owner reconnects them.
- Reject credentials, queries, and fragments in base URLs, including empty query/fragment delimiters. Construct every provider request through URL pathname handling, preserving custom ports, IPv6, and path prefixes.
- Keep cloud connections available to Space owners and keep authorized local memory available to Space members. The shared backend covers web, desktop, mobile, and workers.

The only new user-facing copy is "Memory base URL must use HTTP(S) without credentials, a query, or a fragment." It appears only after invalid input; removing it would leave the user without the information needed to correct the URL. There is no persistent UI addition.

## Validation

The regression tests failed against the original authorization and URL behavior before the fix. With the fix, all 313 tests in the API and related memory/auth suites pass using fake values and mocked transports. Coverage includes denied probes and writes, persisted configuration authorization, GET/POST/DELETE routes, invalid URL delimiters, IPv6/path prefixes, and cloud compatibility. API, worker, and adapter typechecks and lint checks for all changed files pass. No production services or local Electron E2E were used.

Checked current main and open memory-related pull requests; no overlapping fix was found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deployment-owner-controlled local memory provider configurations.
  * Local configurations can be used by authorized Space members once enabled by the deployment owner.

* **Bug Fixes**
  * Improved validation for memory provider URLs, rejecting ambiguous, insecure, or unsupported addresses.
  * Prevented unauthorized users from configuring deployment-owned providers.
  * Improved error handling for invalid provider configurations, with clearer request rejection responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->