### PR TITLE
fix(composio): route tools across connected accounts

### DIFF
--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -288,6 +288,13 @@ describe("composio tool mapping", () => {
           providerRef: "ca-work",
         },
         {
+          id: "connection-personal-dup",
+          connectorId: "composio",
+          externalId: "GitHub",
+          displayName: "Personal again",
+          providerRef: "ca-personal",
+        },
+        {
           id: "connection-noauth",
           connectorId: "composio",
           externalId: "GITHUB",
@@ -297,9 +304,11 @@ describe("composio tool mapping", () => {
       ],
     });
 
-    expect(composioSdkState.created.at(-1)).toMatchObject({
+    expect(composioSdkState.created.at(-1)).toEqual({
       userId: "user-1",
       config: {
+        manageConnections: false,
+        sandbox: { enable: false },
         toolkits: ["GITHUB"],
         connectedAccounts: { GITHUB: ["ca-personal", "ca-work"] },
         multiAccount: {
@@ -307,6 +316,80 @@ describe("composio tool mapping", () => {
           maxAccountsPerToolkit: 10,
           requireExplicitSelection: true,
         },
+      },
+    });
+  });
+
+  it("pins a single concrete account without enabling multi-account mode", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+
+    const connector = new ComposioConnector();
+    await connector.discoverTools({
+      operationId: "composio-single-account",
+      traceId: "composio-single-account",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: "connection-work",
+          connectorId: "composio",
+          externalId: "gmail",
+          displayName: "Work",
+          providerRef: "ca-work",
+        },
+      ],
+    });
+
+    expect(composioSdkState.created.at(-1)).toEqual({
+      userId: "user-1",
+      config: {
+        manageConnections: false,
+        sandbox: { enable: false },
+        toolkits: ["GMAIL"],
+        connectedAccounts: { GMAIL: ["ca-work"] },
+      },
+    });
+  });
+
+  it("omits connectedAccounts and multiAccount for legacy slug-only refs", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+
+    const connector = new ComposioConnector();
+    await connector.discoverTools({
+      operationId: "composio-legacy-only",
+      traceId: "composio-legacy-only",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: "connection-legacy",
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "Legacy",
+          providerRef: "github",
+        },
+        {
+          id: "connection-hackernews",
+          connectorId: "composio",
+          externalId: "hackernews",
+          displayName: "Hacker News",
+          providerRef: "HACKERNEWS",
+        },
+      ],
+    });
+
+    expect(composioSdkState.created.at(-1)).toEqual({
+      userId: "user-1",
+      config: {
+        manageConnections: false,
+        sandbox: { enable: false },
+        toolkits: ["GITHUB", "HACKERNEWS"],
       },
     });
   });

--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -255,6 +255,60 @@ describe("composio tool mapping", () => {
     expect(executeSessionKey(["hackernews", "gmail", "hackernews"])).toBe("gmail,hackernews");
     expect(executeSessionKey(["github", "GITHUB"])).toBe("github");
     expect(executeSessionKey([])).toBe("");
+    expect(executeSessionKey(["GMAIL"], { GMAIL: ["ca-work", "ca-personal", "ca-work"] })).toBe(
+      "GMAIL|GMAIL:ca-personal,ca-work",
+    );
+  });
+
+  it("pins every connected account into multi-account execute sessions", async () => {
+    composioSdkState.created.length = 0;
+    composioSdkState.sessions.clear();
+    composioToolkitDirectory.invalidate();
+
+    const connector = new ComposioConnector();
+    await connector.discoverTools({
+      operationId: "composio-multi-account",
+      traceId: "composio-multi-account",
+      spaceId: "workspace",
+      userId: "user-1",
+      signal: new AbortController().signal,
+      connectedConnections: [
+        {
+          id: "connection-personal",
+          connectorId: "composio",
+          externalId: "github",
+          displayName: "Personal",
+          providerRef: "ca-personal",
+        },
+        {
+          id: "connection-work",
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "Work",
+          providerRef: "ca-work",
+        },
+        {
+          id: "connection-noauth",
+          connectorId: "composio",
+          externalId: "GITHUB",
+          displayName: "Legacy",
+          providerRef: "github",
+        },
+      ],
+    });
+
+    expect(composioSdkState.created.at(-1)).toMatchObject({
+      userId: "user-1",
+      config: {
+        toolkits: ["GITHUB"],
+        connectedAccounts: { GITHUB: ["ca-personal", "ca-work"] },
+        multiAccount: {
+          enable: true,
+          maxAccountsPerToolkit: 10,
+          requireExplicitSelection: true,
+        },
+      },
+    });
   });
 
   it("uses catalog-canonical toolkit slugs without preloading every tool", async () => {

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -245,7 +245,7 @@ export class ComposioConnector implements ComposioProvider {
     const canonicalByKey = new Map(
       canonicalToolkits.map((toolkit) => [composioSlugKey(toolkit), toolkit]),
     );
-    const connectedAccounts: Record<string, string[]> = {};
+    const accountIdsByToolkit = new Map<string, Set<string>>();
     for (const connection of connections) {
       const accountId = connection.providerRef?.trim();
       if (!accountId) continue;
@@ -254,9 +254,13 @@ export class ComposioConnector implements ComposioProvider {
       if (composioSlugKey(accountId) === composioSlugKey(connection.externalId)) continue;
       const toolkit = canonicalByKey.get(composioSlugKey(connection.externalId));
       if (!toolkit) continue;
-      const ids = connectedAccounts[toolkit] ?? [];
-      ids.push(accountId);
-      connectedAccounts[toolkit] = ids;
+      const ids = accountIdsByToolkit.get(toolkit) ?? new Set<string>();
+      ids.add(accountId);
+      accountIdsByToolkit.set(toolkit, ids);
+    }
+    const connectedAccounts: Record<string, string[]> = {};
+    for (const [toolkit, ids] of accountIdsByToolkit) {
+      connectedAccounts[toolkit] = [...ids].sort();
     }
     const key = executeSessionKey(canonicalToolkits, connectedAccounts);
     if (!key) return this.sessionFor(userId);
@@ -269,16 +273,24 @@ export class ComposioConnector implements ComposioProvider {
         this.executeSessions.delete(userId);
       }
     }
+    // Non-multi-account sessions cap connectedAccounts at one id per toolkit.
+    // requireExplicitSelection would also break single-account / no-auth
+    // execute paths that do not pass an account parameter.
+    const needsMultiAccount = Object.values(connectedAccounts).some((ids) => ids.length >= 2);
     const session = await composio.create(userId, {
       manageConnections: false,
       sandbox: { enable: false },
       toolkits: canonicalToolkits,
       ...(Object.keys(connectedAccounts).length > 0 ? { connectedAccounts } : {}),
-      multiAccount: {
-        enable: true,
-        maxAccountsPerToolkit: 10,
-        requireExplicitSelection: true,
-      },
+      ...(needsMultiAccount
+        ? {
+            multiAccount: {
+              enable: true,
+              maxAccountsPerToolkit: 10,
+              requireExplicitSelection: true,
+            },
+          }
+        : {}),
     });
     this.executeSessions.set(userId, { sessionId: session.sessionId, key });
     return session;

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -1,6 +1,7 @@
 import { Composio } from "@composio/core";
 import type {
   AdapterContext,
+  ConnectedConnector,
   ConnectorCall,
   ConnectorCatalogItem,
   ConnectorEvent,
@@ -106,14 +107,22 @@ function composioSlugKey(slug: string): string {
   return slug.trim().toLowerCase();
 }
 
-export function executeSessionKey(toolkits: string[]): string {
+export function executeSessionKey(
+  toolkits: string[],
+  connectedAccounts: Record<string, string[]> = {},
+): string {
   const unique = new Map<string, string>();
   for (const slug of toolkits) {
     const trimmed = slug.trim();
     const key = composioSlugKey(trimmed);
     if (key && !unique.has(key)) unique.set(key, trimmed);
   }
-  return [...unique.values()].sort().join(",");
+  const toolkitKey = [...unique.values()].sort().join(",");
+  const accountKey = Object.entries(connectedAccounts)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([toolkit, ids]) => `${toolkit}:${[...new Set(ids)].sort().join(",")}`)
+    .join(";");
+  return accountKey ? `${toolkitKey}|${accountKey}` : toolkitKey;
 }
 
 export type PluginConnectionRow = {
@@ -226,9 +235,30 @@ export class ComposioConnector implements ComposioProvider {
     return session;
   }
 
-  async sessionForExecute(userId: string, toolkits: string[]): Promise<ComposioSession> {
-    const canonicalToolkits = await this.canonicalizeToolkits(toolkits);
-    const key = executeSessionKey(canonicalToolkits);
+  async sessionForExecute(
+    userId: string,
+    connections: ReturnType<typeof connectedComposioConnections>,
+  ): Promise<ComposioSession> {
+    const canonicalToolkits = await this.canonicalizeToolkits(
+      connections.map((connection) => connection.externalId),
+    );
+    const canonicalByKey = new Map(
+      canonicalToolkits.map((toolkit) => [composioSlugKey(toolkit), toolkit]),
+    );
+    const connectedAccounts: Record<string, string[]> = {};
+    for (const connection of connections) {
+      const accountId = connection.providerRef?.trim();
+      if (!accountId) continue;
+      // No-auth and legacy rows store the toolkit slug rather than a remote
+      // connected-account id. Only concrete account ids can scope a session.
+      if (composioSlugKey(accountId) === composioSlugKey(connection.externalId)) continue;
+      const toolkit = canonicalByKey.get(composioSlugKey(connection.externalId));
+      if (!toolkit) continue;
+      const ids = connectedAccounts[toolkit] ?? [];
+      ids.push(accountId);
+      connectedAccounts[toolkit] = ids;
+    }
+    const key = executeSessionKey(canonicalToolkits, connectedAccounts);
     if (!key) return this.sessionFor(userId);
     const composio = this.sdk();
     const existing = this.executeSessions.get(userId);
@@ -243,6 +273,12 @@ export class ComposioConnector implements ComposioProvider {
       manageConnections: false,
       sandbox: { enable: false },
       toolkits: canonicalToolkits,
+      ...(Object.keys(connectedAccounts).length > 0 ? { connectedAccounts } : {}),
+      multiAccount: {
+        enable: true,
+        maxAccountsPerToolkit: 10,
+        requireExplicitSelection: true,
+      },
     });
     this.executeSessions.set(userId, { sessionId: session.sessionId, key });
     return session;
@@ -304,9 +340,9 @@ export class ComposioConnector implements ComposioProvider {
   }
 
   async discoverTools(context: AdapterContext): Promise<ConnectorTool[]> {
-    const toolkits = connectedComposioExternalIds(context);
-    if (toolkits.length === 0) return [];
-    const session = await this.sessionForExecute(context.userId, toolkits);
+    const connections = connectedComposioConnections(context);
+    if (connections.length === 0) return [];
+    const session = await this.sessionForExecute(context.userId, connections);
     const raw = await session.tools();
     return asConnectorTools(raw);
   }
@@ -315,7 +351,7 @@ export class ComposioConnector implements ComposioProvider {
     try {
       const session = await this.sessionForExecute(
         context.userId,
-        connectedComposioExternalIds(context),
+        connectedComposioConnections(context),
       );
       const result = await session.execute(call.tool, call.args ?? {});
       if (result.error) {
@@ -602,13 +638,15 @@ function isManagedConnectorProvider(
   );
 }
 
-function connectedComposioExternalIds(context: AdapterContext): string[] {
+function connectedComposioConnections(context: AdapterContext): ConnectedConnector[] {
   return (
-    context.connectedConnections
-      ?.filter((connection) => connection.connectorId === "composio")
-      .map((connection) => connection.externalId) ??
-    context.connectedProviders ??
-    []
+    context.connectedConnections?.filter((connection) => connection.connectorId === "composio") ??
+    (context.connectedProviders ?? []).map((externalId) => ({
+      id: `legacy:${externalId}`,
+      connectorId: "composio",
+      externalId,
+      displayName: externalId,
+    }))
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Issue #583 needs multiple named accounts of the same integration. PR #589 adds the account rows and labels, but Composio execute sessions were still toolkit-scoped only, so concrete `providerRef` account IDs never reached session create / tool discovery.

## What

- Build Composio execute sessions from connection rows (not only toolkit slugs)
- Pass concrete account IDs via `connectedAccounts`; enable `multiAccount` / `requireExplicitSelection` only when a toolkit has 2+ concrete account IDs
- Deduplicate and sort account IDs so session config matches the cache key
- Skip legacy/no-auth refs whose `providerRef` is only the toolkit slug
- Rebased onto #589 tip `be609cab` (main sync + lint/P1 / logging + router fixes)

## Note on #676

This replaces community PR #676 for stack purposes. A force-push to `fetw882:fix/multiaccount-connection-routing` failed because the #589 tip includes workflow file updates and the GitHub App token lacks `workflows` permission on the fork. Same commits/content; base remains `cursor/multi-account-same-integration-c2f8`.

No user-facing copy is added or changed.

## Test

- `pnpm exec vitest run packages/adapters/src/composio-connector.test.ts` (30 passed)
- Biome check on touched files
- No composio-specific `tsc` errors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18447e25-5b68-43c4-9363-a0f6180894d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18447e25-5b68-43c4-9363-a0f6180894d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

