### PR TITLE
fix(supervisor): copy packages/logging into the supervisor image

### DIFF
--- a/infra/sandboxes/supervisor/Dockerfile
+++ b/infra/sandboxes/supervisor/Dockerfile
@@ -4,6 +4,7 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY patches patches
 COPY packages/contracts packages/contracts
 COPY packages/core packages/core
+COPY packages/logging packages/logging
 COPY infra/sandboxes/supervisor infra/sandboxes/supervisor
 RUN corepack enable && pnpm install --frozen-lockfile --prod --filter "@rakazo/sandbox-supervisor..."
 WORKDIR /app/infra/sandboxes/supervisor


### PR DESCRIPTION
#605 added structured logging and made the sandbox supervisor depend on the new @rakazo/logging workspace package, but the supervisor image's Dockerfile was not extended to copy the package into the build. The image still builds because the filtered frozen install creates the workspace symlink without checking that the target directory exists, so the failure only surfaces at runtime: the supervisor exits immediately with ERR_MODULE_NOT_FOUND for @rakazo/logging and restarts in a crash loop. Because the supervisor owns the bot computer containers, the API's computer boot and screen URL requests fail while it is down, so any Docker deployment rebuilt after #605 cannot turn computers on.

Copy packages/logging alongside the other workspace packages the supervisor already consumes. The package has no workspace dependencies of its own, so this single line is sufficient.

Validation: reproduced the failure on the pre-fix Dockerfile — an image built from it contains only contracts and core under packages/, and the supervisor crash-loops with the module-not-found error while the API logs failed fetches to the supervisor for computer boot and screen URL RPCs. With the added COPY, the image builds cleanly, @rakazo/logging resolves under the real tsx entrypoint, and startup proceeds past module resolution into environment validation. No overlapping open or merged fix was found before opening this PR.

Final validation: CI passed lint, typecheck, the full unit suite, Postgres journeys, production builds, and web E2E. Greptile and CodeRabbit reviewed the PR without blocking findings, and no review threads remain.