### PR TITLE
fix: copy packages/logging into supervisor and updater images

### DIFF
--- a/infra/sandboxes/supervisor/Dockerfile
+++ b/infra/sandboxes/supervisor/Dockerfile
@@ -4,6 +4,7 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY patches patches
 COPY packages/contracts packages/contracts
 COPY packages/core packages/core
+COPY packages/logging packages/logging
 COPY infra/sandboxes/supervisor infra/sandboxes/supervisor
 RUN corepack enable && pnpm install --frozen-lockfile --prod --filter "@rakazo/sandbox-supervisor..."
 WORKDIR /app/infra/sandboxes/supervisor

--- a/infra/updater/Dockerfile
+++ b/infra/updater/Dockerfile
@@ -18,6 +18,7 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY patches patches
 COPY packages/contracts packages/contracts
 COPY packages/core packages/core
+COPY packages/logging packages/logging
 COPY infra/updater infra/updater
 RUN corepack enable && pnpm install --frozen-lockfile --prod --filter "@rakazo/updater..."
 WORKDIR /app/infra/updater


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After structured logging landed, `@rakazo/sandbox-supervisor` and `@rakazo/updater` depend on `@rakazo/logging`, but their filtered Dockerfiles only copied `contracts` and `core`. Image builds still succeed (pnpm leaves a dangling workspace symlink), then crash-loop at runtime with `ERR_MODULE_NOT_FOUND`, which takes down computer boot/screen RPCs for Docker deploys (and would leave the updater unable to start for the same reason).

## What

- Cherry-picked Keith Wickramasekara ([kwickramasekara](https://github.com/kwickramasekara))’s supervisor fix from https://github.com/elie222/rakazo/pull/683: `COPY packages/logging packages/logging` in `infra/sandboxes/supervisor/Dockerfile`.
- Same one-line COPY in `infra/updater/Dockerfile`. `packages/logging` has no workspace deps, so one COPY is enough. Compose Dockerfiles are unchanged (they already COPY the whole tree).

This PR supersedes #683 (cannot push the contributor fork from this environment).

## How tested

Diff-only verification: both Dockerfiles now COPY `packages/logging` beside `contracts`/`core` before the filtered `pnpm install`. No UI change; no screenshot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26e3672b-b805-4a56-a390-90755fb6d3e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26e3672b-b805-4a56-a390-90755fb6d3e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container builds by ensuring the shared logging package is available during dependency installation for sandbox supervisor and updater services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->