### PR TITLE
fix(desktop): restrict browser permissions to the connected app

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -24,6 +24,7 @@ import {
   immutableRendererAsset,
   isRendererAssetMiss,
 } from "./renderer-assets.js";
+import { installSessionPermissions } from "./session-permissions.js";
 import {
   DEFAULT_LOCAL_WEB_URL,
   desktopStackImageTag,
@@ -55,6 +56,7 @@ const PROBE_TIMEOUT_MS = 8_000;
 const DESKTOP_STACK_PROBE_PATH = "/.well-known/rakazo-desktop-stack";
 const DESKTOP_STACK_TOKEN_HEADER = "x-rakazo-desktop-stack-token";
 let mainWindow: BrowserWindow | null = null;
+const appWindowTargets = new WeakMap<BrowserWindow, string>();
 let setupWindow: BrowserWindow | null = null;
 const bundledRendererInstallations = new Set<string>();
 let currentSetup: DesktopSetup | null = null;
@@ -91,6 +93,14 @@ if (PERFORMANCE_USER_DATA) {
 }
 app.once("will-finish-launching", () => markOnce("rk:main:will-finish-launching"));
 app.once("ready", () => markOnce("rk:main:ready"));
+// Includes fresh partitions and popup-created sessions, before they load remote content.
+app.on("session-created", (value) => installSessionPermissions(value, permissionTarget));
+
+function permissionTarget() {
+  if (mainWindow === null || mainWindow.isDestroyed()) return null;
+  const url = appWindowTargets.get(mainWindow);
+  return url === undefined ? null : { webContents: mainWindow.webContents, url };
+}
 
 function markOnce(name: string) {
   if (performance.getEntriesByName(name).length === 0) performance.mark(name);
@@ -225,6 +235,7 @@ function createWindow(url: string, partition: string | null) {
     },
   });
   mainWindow = win;
+  appWindowTargets.set(win, url);
   const targetOrigin = safeOrigin(url);
   // Intentional OAuth flows open the provider's authorize page via a named
   // window; give those and same-origin popups a normal frame. Everything else
@@ -871,6 +882,7 @@ function safeOrigin(targetUrl: string) {
 }
 
 app.whenReady().then(async () => {
+  installSessionPermissions(session.defaultSession, permissionTarget);
   const userDataDir = app.getPath("userData");
   localStack = new LocalStackController({
     platform: process.platform,

--- a/apps/desktop/src/session-permissions.test.ts
+++ b/apps/desktop/src/session-permissions.test.ts
@@ -64,16 +64,34 @@ function policyFixture(url = appUrl) {
 }
 
 describe("desktop session permissions", () => {
-  it.each([appUrl, "http://127.0.0.1:5173/chat", "http://localhost:5173/chat"])(
-    "preserves microphone, notifications and copy in the connected app at %s",
-    (url) => {
-      const policy = policyFixture(url);
-      for (const permission of ["media", "notifications", "clipboard-sanitized-write"] as const) {
-        expect(policy.request(permission)).toBe(true);
-        expect(policy.check(permission)).toBe(true);
-      }
-    },
-  );
+  it.each([
+    appUrl,
+    "http://127.0.0.1:5173/chat",
+    "http://localhost:5173/chat",
+    "http://[::1]:5173/chat",
+    "https://192.168.1.20:3100/chat",
+  ])("preserves microphone, notifications and copy in the connected app at %s", (url) => {
+    const policy = policyFixture(url);
+    for (const permission of ["media", "notifications", "clipboard-sanitized-write"] as const) {
+      expect(policy.request(permission)).toBe(true);
+      expect(policy.check(permission)).toBe(true);
+    }
+  });
+
+  it.each([
+    "http://192.168.1.20:3100/chat",
+    "http://10.0.0.20:3100/chat",
+    "http://[fd00::20]:3100/chat",
+    "http://server.local:3100/chat",
+    "http://app.example.test/chat",
+  ])("denies permissions to a connected app over non-loopback HTTP: %s", (url) => {
+    const policy = policyFixture(url);
+    for (const permission of ["media", "notifications", "clipboard-sanitized-write"] as const) {
+      expect(policy.request(permission)).toBe(false);
+      expect(policy.check(permission)).toBe(false);
+    }
+    expect(policy.check("notifications", { embeddingOrigin: url }, null)).toBe(false);
+  });
 
   it.each([
     "rakazo-model-oauth",

--- a/apps/desktop/src/session-permissions.test.ts
+++ b/apps/desktop/src/session-permissions.test.ts
@@ -1,0 +1,233 @@
+import type { Session, WebContents } from "electron";
+import { describe, expect, it, vi } from "vitest";
+import { installSessionPermissions } from "./session-permissions.js";
+import { shouldOpenInAppPopup } from "./window-open.js";
+
+const appUrl = "https://app.example.test/chat";
+const providerUrl = "https://provider.example.test/authorize";
+type RequestHandler = NonNullable<Parameters<Session["setPermissionRequestHandler"]>[0]>;
+type CheckHandler = NonNullable<Parameters<Session["setPermissionCheckHandler"]>[0]>;
+
+function policyFixture(url = appUrl) {
+  const setPermissionRequestHandler = vi.fn<Session["setPermissionRequestHandler"]>();
+  const setPermissionCheckHandler = vi.fn<Session["setPermissionCheckHandler"]>();
+  const session = {
+    setPermissionRequestHandler,
+    setPermissionCheckHandler,
+  } as unknown as Session;
+  const contents = {
+    session,
+    isDestroyed: vi.fn(() => false),
+    getURL: vi.fn(() => url),
+  } as unknown as WebContents;
+  let app: { webContents: WebContents; url: string } | null = { webContents: contents, url };
+  installSessionPermissions(session, () => app);
+  const requestHandler = setPermissionRequestHandler.mock.calls[0]?.[0] as RequestHandler;
+  const checkHandler = setPermissionCheckHandler.mock.calls[0]?.[0] as CheckHandler;
+  return {
+    contents,
+    session,
+    setApp: (next: typeof app) => {
+      app = next;
+    },
+    request(
+      permission: Parameters<RequestHandler>[1] = "media",
+      details: Partial<Parameters<RequestHandler>[3]> = {},
+      sender = contents,
+    ) {
+      const callback = vi.fn();
+      requestHandler(sender, permission, callback, {
+        requestingUrl: url,
+        isMainFrame: true,
+        securityOrigin: new URL(url).origin,
+        mediaTypes: ["audio"],
+        ...details,
+      });
+      expect(callback).toHaveBeenCalledExactlyOnceWith(expect.any(Boolean));
+      return callback.mock.calls[0]?.[0];
+    },
+    check(
+      permission: Parameters<CheckHandler>[1] = "media",
+      details: Partial<Parameters<CheckHandler>[3]> = {},
+      sender: WebContents | null = contents,
+      requestingOrigin = new URL(url).origin,
+    ) {
+      return checkHandler(sender, permission, requestingOrigin, {
+        requestingUrl: url,
+        isMainFrame: true,
+        securityOrigin: new URL(url).origin,
+        mediaType: "audio",
+        ...details,
+      });
+    },
+  };
+}
+
+describe("desktop session permissions", () => {
+  it.each([appUrl, "http://127.0.0.1:5173/chat", "http://localhost:5173/chat"])(
+    "preserves microphone, notifications and copy in the connected app at %s",
+    (url) => {
+      const policy = policyFixture(url);
+      for (const permission of ["media", "notifications", "clipboard-sanitized-write"] as const) {
+        expect(policy.request(permission)).toBe(true);
+        expect(policy.check(permission)).toBe(true);
+      }
+    },
+  );
+
+  it.each([
+    "rakazo-model-oauth",
+    "rakazo-mcp-oauth",
+    "rakazo-app-connect",
+    "rakazo-plugin-connect",
+  ])("allows %s navigation without granting permissions to its popup", (name) => {
+    const policy = policyFixture();
+    expect(shouldOpenInAppPopup(new URL(appUrl).origin, providerUrl, name)).toBe(true);
+    const popup = { ...policy.contents, getURL: () => providerUrl } as WebContents;
+    for (const permission of ["media", "notifications", "clipboard-sanitized-write"] as const) {
+      expect(policy.request(permission, { requestingUrl: providerUrl }, popup)).toBe(false);
+      expect(policy.check(permission, { requestingUrl: providerUrl }, popup)).toBe(false);
+      // A same-origin callback or forged first-party URL does not turn a popup into the app.
+      expect(policy.request(permission, {}, popup)).toBe(false);
+      expect(policy.check(permission, {}, popup)).toBe(false);
+    }
+  });
+
+  it("denies both same-origin and third-party subframes", () => {
+    const policy = policyFixture();
+    for (const requestingUrl of [appUrl, providerUrl]) {
+      expect(policy.request("media", { requestingUrl, isMainFrame: false })).toBe(false);
+      expect(policy.check("media", { requestingUrl, isMainFrame: false })).toBe(false);
+      expect(policy.check("media", { requestingUrl, isMainFrame: false }, null)).toBe(false);
+    }
+  });
+
+  it.each([
+    "https://app.example.test.attacker.test/chat",
+    "https://app.example.test:444/chat",
+    "http://app.example.test/chat",
+    "https://app.example.test@attacker.test/chat",
+    "blob:https://app.example.test/id",
+    "data:text/html,example",
+    "about:blank",
+    "file:///example.html",
+    "not a url",
+    "null",
+    "",
+  ])("rejects untrusted or opaque requesting origins: %s", (url) => {
+    const policy = policyFixture();
+    expect(policy.request("media", { requestingUrl: url })).toBe(false);
+    expect(policy.request("media", { securityOrigin: url })).toBe(false);
+    expect(policy.check("media", {}, policy.contents, url)).toBe(false);
+    expect(policy.check("media", { requestingUrl: url })).toBe(false);
+    expect(policy.check("media", { securityOrigin: url })).toBe(false);
+    expect(policy.check("media", { embeddingOrigin: url })).toBe(false);
+  });
+
+  it.each([undefined, [], ["video"], ["audio", "video"], ["unknown"]])(
+    "rejects camera and ambiguous media requests: %j",
+    (mediaTypes) => {
+      expect(policyFixture().request("media", { mediaTypes })).toBe(false);
+    },
+  );
+
+  it.each([undefined, "video", "unknown"])("rejects media checks for %s", (mediaType) => {
+    expect(policyFixture().check("media", { mediaType })).toBe(false);
+  });
+
+  it("fails closed when frame or media origin metadata is missing", () => {
+    const policy = policyFixture();
+    expect(policy.request("media", { securityOrigin: undefined })).toBe(false);
+    expect(policy.request("media", { requestingUrl: undefined })).toBe(false);
+    expect(policy.request("media", { isMainFrame: undefined })).toBe(false);
+    expect(policy.check("media", { requestingUrl: undefined })).toBe(false);
+    expect(policy.check("media", { isMainFrame: undefined })).toBe(false);
+  });
+
+  it.each([
+    "clipboard-read",
+    "display-capture",
+    "geolocation",
+    "fullscreen",
+    "fileSystem",
+    "openExternal",
+    "storage-access",
+    "unknown",
+  ] as const)("denies unused permission %s even in the app", (permission) => {
+    const policy = policyFixture();
+    expect(policy.request(permission)).toBe(false);
+    // Electron's request/check permission unions differ; unknown strings must also fail closed.
+    expect(policy.check(permission as Parameters<CheckHandler>[1])).toBe(false);
+  });
+
+  it("handles origin-only notification checks without allowing other capabilities", () => {
+    const policy = policyFixture();
+    const details = {
+      requestingUrl: undefined,
+      isMainFrame: false,
+      securityOrigin: undefined,
+      embeddingOrigin: new URL(appUrl).origin,
+    };
+    expect(policy.check("notifications", details, null)).toBe(true);
+    expect(policy.check("media", details, null)).toBe(false);
+    expect(policy.check("clipboard-sanitized-write", details, null)).toBe(false);
+    expect(policy.check("notifications", details, null, providerUrl)).toBe(false);
+    expect(policy.check("notifications", { ...details, embeddingOrigin: providerUrl }, null)).toBe(
+      false,
+    );
+    expect(policy.check("notifications", { ...details, embeddingOrigin: undefined }, null)).toBe(
+      false,
+    );
+  });
+
+  it("denies setup and storage probes before an app exists", () => {
+    const policy = policyFixture();
+    policy.setApp(null);
+    expect(policy.request()).toBe(false);
+    expect(policy.check()).toBe(false);
+    expect(policy.check("notifications", { embeddingOrigin: appUrl }, null)).toBe(false);
+  });
+
+  it("revokes grants if the app is destroyed or navigates to another origin", () => {
+    const policy = policyFixture();
+    vi.mocked(policy.contents.getURL).mockReturnValue(providerUrl);
+    expect(policy.request()).toBe(false);
+    expect(policy.check()).toBe(false);
+    vi.mocked(policy.contents.getURL).mockReturnValue(appUrl);
+    vi.mocked(policy.contents.isDestroyed).mockReturnValue(true);
+    expect(policy.request()).toBe(false);
+    expect(policy.check()).toBe(false);
+  });
+
+  it.each(["data:text/html,example", "file:///example.html", "not a url"])(
+    "does not trust an opaque or invalid configured target: %s",
+    (url) => {
+      const policy = policyFixture();
+      policy.setApp({ webContents: policy.contents, url });
+      vi.mocked(policy.contents.getURL).mockReturnValue(url);
+      expect(policy.request()).toBe(false);
+      expect(policy.check()).toBe(false);
+    },
+  );
+
+  it("does not carry grants across server switches, even in the legacy default session", () => {
+    const policy = policyFixture();
+    const nextContents = { ...policy.contents, getURL: () => providerUrl } as WebContents;
+    policy.setApp({ webContents: nextContents, url: providerUrl });
+    expect(policy.request()).toBe(false);
+    expect(policy.check()).toBe(false);
+    expect(policy.check("notifications", { embeddingOrigin: appUrl }, null)).toBe(false);
+    policy.setApp({ webContents: policy.contents, url: appUrl });
+    expect(policy.request()).toBe(true);
+    expect(policy.check()).toBe(true);
+  });
+
+  it("does not grant permissions through a different session partition", () => {
+    const policy = policyFixture();
+    const other = policyFixture();
+    policy.setApp({ webContents: other.contents, url: appUrl });
+    expect(policy.request("media", {}, other.contents)).toBe(false);
+    expect(policy.check("media", {}, other.contents)).toBe(false);
+    expect(policy.check("notifications", { embeddingOrigin: appUrl }, null)).toBe(false);
+  });
+});

--- a/apps/desktop/src/session-permissions.ts
+++ b/apps/desktop/src/session-permissions.ts
@@ -1,4 +1,5 @@
 import type { Session, WebContents } from "electron";
+import { isLoopbackHost } from "./setup-config.js";
 
 type AppPermissionTarget = {
   webContents: WebContents;
@@ -9,7 +10,10 @@ function httpOrigin(value: string | undefined): string | null {
   if (!value) return null;
   try {
     const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:" ? url.origin : null;
+    // LAN HTTP remains a supported server target, but cannot safely receive host permissions.
+    return url.protocol === "https:" || (url.protocol === "http:" && isLoopbackHost(url.hostname))
+      ? url.origin
+      : null;
   } catch {
     return null;
   }

--- a/apps/desktop/src/session-permissions.ts
+++ b/apps/desktop/src/session-permissions.ts
@@ -1,0 +1,86 @@
+import type { Session, WebContents } from "electron";
+
+type AppPermissionTarget = {
+  webContents: WebContents;
+  url: string;
+};
+
+function httpOrigin(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Install before loading any content, including setup, storage probes and OAuth popups. */
+export function installSessionPermissions(
+  targetSession: Session,
+  getApp: () => AppPermissionTarget | null,
+) {
+  function currentApp() {
+    const app = getApp();
+    if (!app || app.webContents.isDestroyed() || app.webContents.session !== targetSession) {
+      return null;
+    }
+    const origin = httpOrigin(app.url);
+    if (origin === null || httpOrigin(app.webContents.getURL()) !== origin) return null;
+    return { ...app, origin };
+  }
+
+  targetSession.setPermissionRequestHandler((contents, permission, callback, details) => {
+    const app = currentApp();
+    if (
+      !app ||
+      contents !== app.webContents ||
+      !details.isMainFrame ||
+      httpOrigin(details.requestingUrl) !== app.origin
+    ) {
+      callback(false);
+      return;
+    }
+
+    if (permission === "media") {
+      // Dictation needs only the microphone. OS consent still applies after this grant.
+      callback(
+        "securityOrigin" in details &&
+          httpOrigin(details.securityOrigin) === app.origin &&
+          "mediaTypes" in details &&
+          (details.mediaTypes?.length ?? 0) > 0 &&
+          details.mediaTypes?.every((type) => type === "audio") === true,
+      );
+      return;
+    }
+    callback(permission === "notifications" || permission === "clipboard-sanitized-write");
+  });
+
+  targetSession.setPermissionCheckHandler((contents, permission, requestingOrigin, details) => {
+    const app = currentApp();
+    if (!app || httpOrigin(requestingOrigin) !== app.origin) return false;
+    if (
+      (details.embeddingOrigin !== undefined &&
+        httpOrigin(details.embeddingOrigin) !== app.origin) ||
+      (details.securityOrigin !== undefined && httpOrigin(details.securityOrigin) !== app.origin)
+    ) {
+      return false;
+    }
+
+    // Electron can check notifications without a WebContents. Require both origins;
+    // never extend this origin-only exception to capture, clipboard or other permissions.
+    if (contents === null) {
+      return permission === "notifications" && httpOrigin(details.embeddingOrigin) === app.origin;
+    }
+    if (
+      contents !== app.webContents ||
+      !details.isMainFrame ||
+      httpOrigin(details.requestingUrl) !== app.origin
+    ) {
+      return false;
+    }
+
+    if (permission === "media") return details.mediaType === "audio";
+    return permission === "notifications" || permission === "clipboard-sanitized-write";
+  });
+}

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -250,7 +250,7 @@ function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
   }
 }
 
-function isLoopbackHost(hostname: string) {
+export function isLoopbackHost(hostname: string) {
   const host = unbracketedHost(hostname);
   if (host === "localhost" || host.endsWith(".localhost")) return true;
   if (isIP(host) === 4) return host.startsWith("127.");


### PR DESCRIPTION
## Why

Desktop OAuth popups can reach third-party HTTPS pages, including authorization endpoints supplied by an MCP server. The desktop installed neither a permission request handler nor a permission check handler. Electron therefore automatically granted browser permissions to those pages ([documented default](https://www.electronjs.org/docs/latest/tutorial/security#5-handle-session-permission-requests-from-remote-content)). The existing external-link and OAuth URL validation fixes do not restrict session permissions.

This is a medium-severity desktop privacy issue: exploitation requires reaching attacker-controlled content through an allowed OAuth flow. Clipboard disclosure and microphone/camera capture are potential impacts; capture remains subject to applicable OS consent and device availability. This does not demonstrate an OS-consent bypass or native code execution. Web and mobile do not use this Electron policy.

## What changed

- Install default-deny request and check handlers before content loads, covering the default session, legacy profiles, storage probes, and new partitions.
- Allow microphone-only media, notifications, and sanitized clipboard writes for the current app window at its configured HTTPS or loopback HTTP origin. Non-loopback HTTP connections remain supported without host permission grants. Validate frame, origin, window, and session identity; reject camera and ambiguous media requests.
- Handle Electron's origin-only notification checks without extending that exception to microphone or clipboard access. Server switches and destroyed/navigated windows cannot retain the previous app's grants.
- Preserve HTTP(S) OAuth popup navigation and callbacks. Popups and embedded frames receive no automatic host capture or clipboard grants. Embedded bot screens also lose automatic host clipboard/fullscreen access: granting those capabilities to embedded content needs a separate consent policy. App-level copying remains available.

## Validation

- Deterministic offline tests invoke the installed Electron handlers and cover all named OAuth flows, first-party microphone/notifications/copy, origin spoofing, subframes, camera/mixed media, missing metadata, origin-only checks, and session/server transitions.
- All 247 desktop unit tests passed with two workers on the initial fix. After restricting non-loopback HTTP grants, all 95 focused permission and setup tests passed, including seven added transport cases. Desktop typecheck and focused Biome checks passed after the update.
- Final CI passed: lint, typechecking, unit tests, production builds, Electron smoke tests, database journeys, Web E2E, macOS setup screenshot, and image validation. No live microphone, camera, production service, or OS-consent test was run locally.
- No UI copy or visual layout changes.

## Review

Greptile reviewed the final commit without findings. CodeRabbit confirmed that the HTTPS-or-loopback restriction and regression tests address its finding; the thread is resolved. A full CodeRabbit re-review of the follow-up commit was rate-limited by the service.
