### PR TITLE
fix(adapters): handle detached catalog refresh failures

### DIFF
--- a/packages/adapters/src/composio-catalog-cache.test.ts
+++ b/packages/adapters/src/composio-catalog-cache.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { setImmediate } from "node:timers/promises";
+import { promisify } from "node:util";
+import { describe, expect, it, vi } from "vitest";
 import {
   createToolkitDirectoryCache,
   mergeCatalogWithConnected,
@@ -62,5 +65,73 @@ describe("composio toolkit directory cache", () => {
     );
     expect(items.find((item) => item.slug === "github")?.connected).toBe(false);
     expect(items.find((item) => item.slug === "hackernews")?.connected).toBe(true);
+  });
+
+  it("handles detached refresh rejection in a real Node process", async () => {
+    const moduleUrl = new URL("./composio-catalog-cache.ts", import.meta.url).href;
+    const { stdout } = await promisify(execFile)(
+      process.execPath,
+      [
+        "--unhandled-rejections=strict",
+        "--import=tsx",
+        "--input-type=module",
+        "--eval",
+        `
+          import { setImmediate } from "node:timers/promises";
+          import { createToolkitDirectoryCache } from ${JSON.stringify(moduleUrl)};
+          let now = 0;
+          const cache = createToolkitDirectoryCache({ ttlMs: 10, now: () => now });
+          await cache.get(async () => []);
+          now = 10;
+          await cache.get(async () => { throw new Error("directory unavailable"); });
+          await setImmediate();
+          console.log("refresh failure handled");
+        `,
+      ],
+      { timeout: 10_000, env: { ...process.env, NODE_OPTIONS: "" } },
+    );
+    expect(stdout.trim()).toBe("refresh failure handled");
+  });
+
+  it("keeps stale items after a failed refresh and retries on the next read", async () => {
+    let now = 0;
+    const cache = createToolkitDirectoryCache({ ttlMs: 10, now: () => now });
+    const first = await cache.get(async () => [
+      { slug: "gmail", name: "Gmail", logo: null, noAuth: false },
+    ]);
+    now = 10;
+    let rejectRefresh: (error: Error) => void = () => undefined;
+    const refresh = new Promise<typeof first>((_resolve, reject) => {
+      rejectRefresh = reject;
+    });
+    const loader = vi.fn(() => refresh);
+
+    expect(await cache.get(loader)).toBe(first);
+    expect(await cache.get(loader)).toBe(first);
+    expect(loader).toHaveBeenCalledTimes(1);
+    rejectRefresh(new Error("directory unavailable"));
+    await setImmediate();
+    expect(cache.peek()).toBe(first);
+
+    const updated = [{ slug: "slack", name: "Slack", logo: null, noAuth: false }];
+    const retry = vi.fn(async () => updated);
+    expect(await cache.get(retry)).toBe(first);
+    await setImmediate();
+    expect(await cache.get(retry)).toBe(updated);
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["throw", "reject"])("propagates a cold-load %s and allows retry", async (failure) => {
+    const cache = createToolkitDirectoryCache();
+    const error = new Error("directory unavailable");
+    await expect(
+      cache.get(() => {
+        if (failure === "throw") throw error;
+        return Promise.reject(error);
+      }),
+    ).rejects.toBe(error);
+    expect(cache.peek()).toBeUndefined();
+    const items = [{ slug: "gmail", name: "Gmail", logo: null, noAuth: false }];
+    expect(await cache.get(async () => items)).toBe(items);
   });
 });

--- a/packages/adapters/src/composio-catalog-cache.ts
+++ b/packages/adapters/src/composio-catalog-cache.ts
@@ -20,6 +20,10 @@ export function mergeCatalogWithConnected(
   }));
 }
 
+/**
+ * Coalesces directory loads and serves stale entries during refreshes. Failed
+ * refreshes preserve stale entries for later retries; cold-load errors propagate.
+ */
 export function createToolkitDirectoryCache(opts?: { ttlMs?: number; now?: () => number }) {
   const ttlMs = opts?.ttlMs ?? COMPOSIO_DIRECTORY_TTL_MS;
   const now = opts?.now ?? Date.now;

--- a/packages/adapters/src/composio-catalog-cache.ts
+++ b/packages/adapters/src/composio-catalog-cache.ts
@@ -45,7 +45,10 @@ export function createToolkitDirectoryCache(opts?: { ttlMs?: number; now?: () =>
     async get(loader: () => Promise<ToolkitDirectoryEntry[]>): Promise<ToolkitDirectoryEntry[]> {
       if (!entry) return load(loader);
       if (now() - entry.fetchedAt < ttlMs) return entry.items;
-      if (!inflight) void load(loader);
+      if (!inflight) {
+        // Keep stale items on failure; load clears inflight so a later read can retry.
+        void load(loader).catch(() => undefined);
+      }
       return entry.items;
     },
     invalidate() {


### PR DESCRIPTION
A failed Composio directory refresh can terminate the API or worker after a previously loaded cache expires. Normal authenticated catalog requests or connected-tool activity can trigger this during an upstream failure. This is a moderate availability issue confined to deployments using the optional Composio provider; the detached rejection escapes the callers' existing error handling.

Catch rejection only at the background refresh boundary. Keep returning stale entries while refreshing, leave them intact after failure, and let the next read retry. Cold-cache load errors still reach their caller. The change is confined to the shared adapter cache and does not overlap the account-routing work in #682 or the optional catalog feed in #670.

Validation: an offline subprocess importing the actual cache exited with an unhandled rejection before the fix under both default and strict Node handling, and exited successfully after the fix. Regression coverage checks process survival under strict handling, refresh coalescing, stale-data retention, retry recovery, and synchronous/asynchronous cold-load errors. Focused cache and connector tests, changed-file lint, and changed-file TypeScript checks pass. No external catalog or production service was called; full integration and Electron E2E coverage runs in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented background catalog refresh failures from causing unhandled errors.
  * Continued serving previously loaded items when a refresh fails.
  * Allowed subsequent reads to retry failed refreshes.
  * Prevented duplicate refresh attempts while one is already in progress.
  * Preserved error reporting for failures during the initial catalog load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->