### PR TITLE
fix(db): bound failed steering continuations

### DIFF
--- a/packages/db/src/events.test.ts
+++ b/packages/db/src/events.test.ts
@@ -83,6 +83,7 @@ describe("finalizeRun", () => {
       $queryRaw: vi.fn(async () => []),
       run: {
         findUnique: vi.fn(async () => ({ status: "running" })),
+        findUniqueOrThrow: vi.fn(async () => ({ sourceMessage: null })),
         findFirst: vi.fn(async () => null),
         updateMany: vi.fn(async () => ({ count: 1 })),
       },

--- a/packages/db/src/events.ts
+++ b/packages/db/src/events.ts
@@ -1052,8 +1052,17 @@ async function finalizeRunOnce(
         data: { runId: null },
       });
     } else {
+      const { sourceMessage } = await tx.run.findUniqueOrThrow({
+        where: { id: input.runId },
+        select: { sourceMessage: { select: { seq: true } } },
+      });
+      // A continuation's source is the newest steering it was created for. Only newer
+      // messages justify another run after failure, even if setup failed before claiming.
       await tx.steeringMessage.updateMany({
-        where: { runId: input.runId },
+        where: {
+          runId: input.runId,
+          message: sourceMessage ? { seq: { gt: sourceMessage.seq } } : undefined,
+        },
         data: { runId: null },
       });
     }

--- a/packages/testkit/src/executor-lifecycle.test.ts
+++ b/packages/testkit/src/executor-lifecycle.test.ts
@@ -333,8 +333,14 @@ describeIntegration("run executor lifecycle", () => {
     expect(userMessages[0]!.seq).toBeLessThan(userMessages[1]!.seq);
   });
 
-  it("requeues steering claimed by a failed attempt without duplicating it", async () => {
-    const seeded = await seedRun("steering-failure", "start the analysis", {
+  it.each([
+    { claim: false, fresh: false, outcome: "failed" as const },
+    { claim: true, fresh: false, outcome: "failed" as const },
+    { claim: false, fresh: true, outcome: "failed" as const },
+    { claim: true, fresh: true, outcome: "failed" as const },
+    { claim: true, fresh: false, outcome: "completed" as const },
+  ])("bounds steering recovery ($claim, $fresh, $outcome)", async ({ claim, fresh, outcome }) => {
+    const seeded = await seedRun(`steering-${claim}-${fresh}-${outcome}`, "start the analysis", {
       status: "running",
       leaseOwner: "failure-worker",
       leaseFence: 4,
@@ -393,6 +399,78 @@ describeIntegration("run executor lifecycle", () => {
     await expect(
       handles.prisma.steeringMessage.findFirstOrThrow({ where: { botId: seeded.bot.id } }),
     ).resolves.toMatchObject({ runId: continuationRunId, claimedAt: null });
+
+    const lease = { leaseOwner: "failure-worker", leaseFence: 1 };
+    async function startContinuation(runId: string) {
+      const run = await handles.prisma.run.update({
+        where: { id: runId },
+        data: { status: "running", ...lease },
+      });
+      const attempt = await handles.prisma.attempt.create({
+        data: { runId, fence: lease.leaseFence, status: "running" },
+      });
+      return {
+        spaceId: run.spaceId,
+        botId: run.botId,
+        threadId: run.threadId,
+        taskId: run.taskId,
+        runId,
+        attemptId: attempt.id,
+        ...lease,
+      };
+    }
+
+    const continuation = await startContinuation(continuationRunId!);
+    if (claim) {
+      await expect(events.claimSteering({ ...continuation, seenIds: [] })).resolves.toHaveLength(1);
+    }
+    // A failure before claimSteering (such as missing model configuration) must also stop.
+    const freshMessage = fresh
+      ? await events.sendUserMessage({
+          spaceId: seeded.me.spaceId,
+          threadId: seeded.thread.id,
+          botId: seeded.bot.id,
+          userId: seeded.me.userId,
+          blocks: [{ kind: "text", text: "Try this new instruction." }],
+          prompt: "Try this new instruction.",
+          trigger: "follow_up",
+        })
+      : null;
+    const recovered = await events.finalizeRun({
+      ...continuation,
+      ...(outcome === "completed"
+        ? { outcome, blocks: [] }
+        : { outcome, error: "provider failed" }),
+    });
+    if (!recovered) throw new Error("Expected the continuation to finalize");
+    if (freshMessage) {
+      expect(recovered.continuationRunId).toEqual(expect.any(String));
+      const next = await startContinuation(recovered.continuationRunId!);
+      await expect(events.claimSteering({ ...next, seenIds: [] })).resolves.toEqual([
+        expect.objectContaining({ messageId: freshMessage.messageId }),
+      ]);
+      await expect(
+        events.finalizeRun({ ...next, outcome: "failed", error: "provider failed" }),
+      ).resolves.toEqual({ continuationRunId: null });
+    } else {
+      expect(recovered.continuationRunId).toBeNull();
+    }
+    expect(await handles.prisma.run.count({ where: { botId: seeded.bot.id } })).toBe(fresh ? 3 : 2);
+    expect(
+      await handles.prisma.run.count({ where: { botId: seeded.bot.id, status: "queued" } }),
+    ).toBe(0);
+    // Settled steering cannot be reclaimed by unrelated future runs; chat history is retained.
+    expect(
+      await handles.prisma.steeringMessage.count({ where: { botId: seeded.bot.id, runId: null } }),
+    ).toBe(0);
+    expect(
+      await handles.prisma.message.count({ where: { threadId: seeded.thread.id, role: "user" } }),
+    ).toBe(fresh ? 2 : 1);
+    if (outcome === "completed") {
+      expect(await handles.prisma.steeringMessage.count({ where: { botId: seeded.bot.id } })).toBe(
+        0,
+      );
+    }
   });
 
   it("discards pending steering when the user stops active work", async () => {


### PR DESCRIPTION
## Why

A message sent while a bot is busy becomes durable steering. Terminal failure currently releases the entire steering batch and creates a new follow-up run, including steering already claimed or used to create the failing continuation. A persistent configuration or provider failure can therefore keep creating new run and job identities without further input.

This is a moderate availability and potential cost amplification issue in the shared backend used by web, desktop, mobile, and configured inbound messaging. It requires permission to send to the affected bot, pending steering, and a persistent failure. The lifecycle is reproducible with local fixtures; no paid provider or live queue is needed.

## Changes

Use the existing source-message sequence as the boundary when releasing steering from a failed run. Only newer steering can justify another continuation. Exhausted steering remains attached to the failed run, and its user messages remain in chat history. Preserve the first recovery after an original failure, new steering during recovery, and successful completion cleanup.

No schema, dependency, or UI changes.

## Validation

- Against unchanged main, four failure regression cases fail by creating an unwanted continuation or reclaiming exhausted steering; the successful recovery control passes.
- Updated PostgreSQL lifecycle coverage checks failure before and after claiming, genuinely new steering, repeated failure, retained history, and successful recovery using fake providers.
- All eight focused steering PostgreSQL lifecycle cases pass with the fix. Seventy related event, executor, and runtime unit tests pass with one worker.
- Formatting and whitespace checks pass.
- Database and testkit TypeScript checks pass. Electron E2E was not run locally.
- [CI](https://github.com/elie222/rakazo/actions/runs/33991658195) passes the full unit suite, PostgreSQL journeys, web E2E, type checks, lint, and production builds. Container image validation also passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved steering-message recovery after a failed run by preserving the continuation’s source message and detaching only newer steering messages.
  - Corrected recovery behavior across failed and completed runs, including scenarios involving claimed steering and newly arrived user messages.

- **Tests**
  - Expanded lifecycle coverage for continuation runs and steering-message handling across multiple outcomes and conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->