### PR TITLE
fix(adapters): settle runtime work on stream cancellation

### DIFF
--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -209,6 +209,7 @@ import {
   secretPausedToolResult,
   tryCompleteConnectionWithCode,
 } from "./run-secret.js";
+import { withRuntimeCleanup } from "./runtime-stream.js";
 import {
   cancelScheduleFromTool,
   createScheduleFromTool,
@@ -1390,6 +1391,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           args: Record<string, unknown>,
           executionId: string,
         ) => {
+          context.signal.throwIfAborted();
           if (handedOff) {
             return { error: "This stage was handed off. End the turn without more tool calls." };
           }
@@ -2930,7 +2932,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             );
 
         try {
-          for await (const event of deps.runtime.run(
+          const runtimeEvents = deps.runtime.run(
             {
               botId: bot.id,
               threadId: thread.id,
@@ -3037,7 +3039,8 @@ export function createRunExecutor(deps: ExecutorDeps) {
                   },
             },
             context,
-          )) {
+          );
+          for await (const event of withRuntimeCleanup(runtimeEvents, runAbortController)) {
             if (approvalPausePending) return;
             if (!leaseValid) return;
             const now = Date.now();
@@ -3319,7 +3322,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
             }
           }
 
-          if (approvalPausePending) return;
+          if (approvalPausePending || !leaseValid) return;
           approvedEffectReplays.assertDrained();
           pendingProgress += progressRedactor.finish();
           await flushProgress();

--- a/packages/adapters/src/pi-runtime-cancellation.test.ts
+++ b/packages/adapters/src/pi-runtime-cancellation.test.ts
@@ -1,0 +1,270 @@
+import type { AgentRunRequest } from "@rakazo/adapter-kit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fake = vi.hoisted(() => {
+  function deferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>((done) => {
+      resolve = done;
+    });
+    return { promise, resolve };
+  }
+  type Tool = {
+    name: string;
+    execute(id: string, args: Record<string, unknown>): Promise<unknown>;
+  };
+  class Agent {
+    state = { messages: [], errorMessage: undefined };
+    aborted = deferred();
+    release = deferred();
+    idle = deferred();
+    settled = false;
+    listener?: (event: unknown) => void;
+    tools: Tool[];
+    abort = vi.fn(() => this.aborted.resolve());
+
+    constructor(options: { initialState: { tools: Tool[] } }) {
+      this.tools = options.initialState.tools;
+      state.agents.push(this);
+    }
+    subscribe(listener: (event: unknown) => void) {
+      this.listener = listener;
+    }
+    async prompt() {
+      try {
+        this.listener?.({
+          type: "message_update",
+          assistantMessageEvent: { type: "text_delta", delta: "started" },
+        });
+        if (state.delegate && state.agents[0] === this) {
+          await this.tools
+            .find((tool) => tool.name === "run_subagent")!
+            .execute("child", {
+              task: "fake task",
+            });
+        }
+        await this.release.promise;
+      } finally {
+        this.settled = true;
+        this.idle.resolve();
+      }
+    }
+    async waitForIdle() {
+      await this.idle.promise;
+    }
+  }
+  const state = { agents: [] as Agent[], delegate: false };
+  return { Agent, state, deferred };
+});
+
+vi.mock("@earendil-works/pi-agent-core", () => ({ Agent: fake.Agent }));
+vi.mock("@earendil-works/pi-ai/providers/all", () => ({
+  builtinModels: () => ({
+    getModel: () => ({ provider: "test", id: "fake-model" }),
+    streamSimple: () => {
+      throw new Error("No model requests are allowed");
+    },
+  }),
+}));
+vi.mock("./pi-local-provider.js", () => ({
+  registerLocalProvider: (models: unknown) => models,
+}));
+vi.mock("./pi-openai-compatible-provider.js", () => ({
+  OPENAI_COMPATIBLE_PROVIDER_ID: "openai-compatible",
+  registerOpenAiCompatibleCatalog: (models: unknown) => models,
+  registerOpenAiCompatibleRuntime: (models: unknown) => models,
+}));
+
+import { PiAgentRuntime } from "./pi-runtime.js";
+
+const request: AgentRunRequest = {
+  botId: "bot",
+  threadId: "thread",
+  runId: "run",
+  prompt: "fake task",
+  instructions: "test",
+  history: [],
+  tools: [],
+  model: { provider: "test", id: "fake-model" },
+};
+
+async function microtasks() {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+describe("Pi runtime cancellation", () => {
+  beforeEach(() => {
+    fake.state.agents = [];
+    fake.state.delegate = false;
+  });
+  afterEach(async () => {
+    for (const agent of fake.state.agents) agent.release.resolve();
+    await microtasks();
+  });
+
+  it.each([false, true])(
+    "aborts and settles stream closure with external signal=%s",
+    async (external) => {
+      const runtime = new PiAgentRuntime();
+      const controller = new AbortController();
+      const stream = runtime
+        .run(request, external ? { signal: controller.signal } : undefined)
+        [Symbol.asyncIterator]();
+      await stream.next();
+      const agent = fake.state.agents[0]!;
+      let closed = false;
+      const closing = stream.return!().then(() => {
+        closed = true;
+      });
+      await microtasks();
+      expect(agent.abort).toHaveBeenCalled();
+      expect(closed).toBe(false);
+      expect(controller.signal.aborted).toBe(false);
+      agent.release.resolve();
+      await closing;
+      expect(agent.settled).toBe(true);
+    },
+  );
+
+  it("closes a quiet stream even when next is already pending", async () => {
+    const runtime = new PiAgentRuntime();
+    const stream = runtime.run(request)[Symbol.asyncIterator]();
+    await stream.next();
+    const next = stream.next();
+    const closing = stream.return!();
+    await microtasks();
+    const agent = fake.state.agents[0]!;
+    expect(agent.abort).toHaveBeenCalled();
+    agent.release.resolve();
+    await Promise.all([next, closing]);
+    expect(agent.settled).toBe(true);
+  });
+
+  it("runtime.abort still cancels with a supplied context and awaits work", async () => {
+    const runtime = new PiAgentRuntime();
+    const stream = runtime
+      .run(request, { signal: new AbortController().signal })
+      [Symbol.asyncIterator]();
+    await stream.next();
+    let stopped = false;
+    const stopping = runtime.abort(request.runId).then(() => {
+      stopped = true;
+    });
+    await microtasks();
+    const agent = fake.state.agents[0]!;
+    expect(agent.abort).toHaveBeenCalled();
+    expect(stopped).toBe(false);
+    agent.release.resolve();
+    await stopping;
+    expect(agent.settled).toBe(true);
+    await stream.return!();
+  });
+
+  it("propagates external abort and does not finish before the agent settles", async () => {
+    const controller = new AbortController();
+    const runtime = new PiAgentRuntime();
+    const stream = runtime.run(request, { signal: controller.signal })[Symbol.asyncIterator]();
+    await stream.next();
+    controller.abort();
+    const agent = fake.state.agents[0]!;
+    expect(agent.abort).toHaveBeenCalled();
+    let closed = false;
+    const closing = stream.return!().then(() => {
+      closed = true;
+    });
+    await microtasks();
+    expect(closed).toBe(false);
+    agent.release.resolve();
+    await closing;
+    expect(agent.settled).toBe(true);
+  });
+
+  it("does not start a prompt after cancellation during asynchronous setup", async () => {
+    const setup = fake.deferred();
+    const runtime = new PiAgentRuntime();
+    const stream = runtime
+      .run({
+        ...request,
+        claimSteering: async () => {
+          await setup.promise;
+          return [];
+        },
+      })
+      [Symbol.asyncIterator]();
+    const first = stream.next();
+    const closing = stream.return!();
+    setup.resolve();
+    await Promise.all([first, closing]);
+    expect(fake.state.agents.every((agent) => !agent.listener)).toBe(true);
+  });
+
+  it("does not dispatch another tool after cancellation", async () => {
+    const executeTool = vi.fn();
+    const runtime = new PiAgentRuntime();
+    const stream = runtime.run({ ...request, executeTool })[Symbol.asyncIterator]();
+    await stream.next();
+    const stopping = runtime.abort(request.runId);
+    const agent = fake.state.agents[0]!;
+    await expect(
+      agent.tools.find((tool) => tool.name === "shell")!.execute("late", { command: "true" }),
+    ).rejects.toThrow();
+    expect(executeTool).not.toHaveBeenCalled();
+    agent.release.resolve();
+    await stopping;
+    await stream.return!();
+  });
+
+  it("settles work before propagating a consumer's injected error", async () => {
+    const runtime = new PiAgentRuntime();
+    const stream = runtime.run(request)[Symbol.asyncIterator]();
+    await stream.next();
+    const failure = new Error("consumer failed");
+    let finished = false;
+    const closing = stream.throw!(failure).catch((error) => {
+      finished = true;
+      return error;
+    });
+    await microtasks();
+    const agent = fake.state.agents[0]!;
+    expect(agent.abort).toHaveBeenCalled();
+    expect(finished).toBe(false);
+    agent.release.resolve();
+    expect(await closing).toBe(failure);
+    expect(agent.settled).toBe(true);
+  });
+
+  it("aborts and settles nested agent work before returning", async () => {
+    fake.state.delegate = true;
+    const runtime = new PiAgentRuntime();
+    const stream = runtime.run(request)[Symbol.asyncIterator]();
+    await stream.next();
+    await microtasks();
+    expect(fake.state.agents).toHaveLength(2);
+    let closed = false;
+    const closing = stream.return!().then(() => {
+      closed = true;
+    });
+    await microtasks();
+    for (const agent of fake.state.agents) expect(agent.abort).toHaveBeenCalled();
+    expect(closed).toBe(false);
+    for (const agent of fake.state.agents) agent.release.resolve();
+    await closing;
+    expect(fake.state.agents.every((agent) => agent.settled)).toBe(true);
+  });
+
+  it("does not erase a replacement attempt when the previous stream closes", async () => {
+    const runtime = new PiAgentRuntime();
+    const first = runtime.run(request)[Symbol.asyncIterator]();
+    await first.next();
+    const second = runtime.run(request)[Symbol.asyncIterator]();
+    await second.next();
+    fake.state.agents[0]!.release.resolve();
+    await first.return!();
+    const stopping = runtime.abort(request.runId);
+    await microtasks();
+    expect(fake.state.agents[1]!.abort).toHaveBeenCalled();
+    fake.state.agents[1]!.release.resolve();
+    await stopping;
+    await second.return!();
+  });
+});

--- a/packages/adapters/src/pi-runtime-thinking-level.test.ts
+++ b/packages/adapters/src/pi-runtime-thinking-level.test.ts
@@ -11,6 +11,7 @@ const fakeAgentState = vi.hoisted(() => ({
   }>,
   sessionIds: [] as Array<string | undefined>,
   failPrompt: false,
+  abortCalls: 0,
 }));
 
 type FakeAgentTool = {
@@ -44,7 +45,9 @@ vi.mock("@earendil-works/pi-agent-core", () => ({
       await runSubagent?.execute("subagent-call", { name: "helper", task: "help" });
     }
     async waitForIdle() {}
-    abort() {}
+    abort() {
+      fakeAgentState.abortCalls += 1;
+    }
   },
 }));
 
@@ -182,13 +185,14 @@ describe("Pi agent thinking level", () => {
 
   it("removes the abort listener when prompting fails", async () => {
     const controller = new AbortController();
-    const removeEventListener = vi.spyOn(controller.signal, "removeEventListener");
+    fakeAgentState.abortCalls = 0;
     fakeAgentState.failPrompt = true;
 
     await expect(runWithModel("plain-model", "test", controller.signal)).rejects.toThrow(
       "prompt failed",
     );
 
-    expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    controller.abort();
+    expect(fakeAgentState.abortCalls).toBe(0);
   });
 });

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -30,7 +30,7 @@ import {
 } from "./pi-openai-compatible-provider.js";
 import { textContentArg } from "./tool-text.js";
 
-const running = new Map<string, AbortController>();
+const running = new Map<string, { controller: AbortController; work: Promise<void> }>();
 // Built on first use, not at module load: entry points call loadRootEnv() after
 // their imports, and ESM hoists those imports, so module-level env reads here
 // would run before .env is loaded and miss the local provider entirely.
@@ -79,16 +79,43 @@ export class PiAgentRuntime implements AgentRuntime {
   }
 
   async abort(runId: string): Promise<void> {
-    running.get(runId)?.abort();
+    const active = running.get(runId);
+    active?.controller.abort();
+    await active?.work;
   }
 
-  async *run(
+  run(
     request: AgentRunRequest,
     context?: Partial<AdapterContext>,
-  ): AsyncIterable<AgentRuntimeEvent> {
+  ): AsyncIterableIterator<AgentRuntimeEvent> {
     const controller = new AbortController();
-    running.set(request.runId, controller);
-    const signal = context?.signal ?? controller.signal;
+    const events = this.runEvents(request, controller, context);
+    return {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next: () => events.next(),
+      return: () => {
+        // An async generator queues return() behind a pending next(). Abort
+        // immediately so a quiet model request can settle that pending read.
+        controller.abort();
+        return events.return();
+      },
+      throw: (error) => {
+        controller.abort();
+        return events.throw(error);
+      },
+    };
+  }
+
+  private async *runEvents(
+    request: AgentRunRequest,
+    controller: AbortController,
+    context?: Partial<AdapterContext>,
+  ): AsyncGenerator<AgentRuntimeEvent, void> {
+    const signal = context?.signal
+      ? AbortSignal.any([controller.signal, context.signal])
+      : controller.signal;
     const queue = createQueue();
 
     const work = (async () => {
@@ -264,9 +291,12 @@ export class PiAgentRuntime implements AgentRuntime {
         ]);
         try {
           await agent.prompt(initialPrompt, images?.length ? images : undefined);
-          await agent.waitForIdle();
         } finally {
-          signal.removeEventListener("abort", onAbort);
+          try {
+            await agent.waitForIdle();
+          } finally {
+            signal.removeEventListener("abort", onAbort);
+          }
         }
 
         // Budget abort stops the agent underneath the model, which leaves
@@ -307,12 +337,15 @@ export class PiAgentRuntime implements AgentRuntime {
         queue.close();
       }
     })();
+    const active = { controller, work };
+    running.set(request.runId, active);
 
     try {
       yield* queue.iterate();
-      await work;
     } finally {
-      running.delete(request.runId);
+      controller.abort();
+      await work;
+      if (running.get(request.runId) === active) running.delete(request.runId);
     }
   }
 }
@@ -632,6 +665,7 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
       return raw as never;
     },
     execute: async (toolCallId, params) => {
+      host.signal.throwIfAborted();
       const args = (params ?? {}) as Record<string, unknown>;
       const executionId =
         toolCallId || `${host.request.runId}:${tool.name}:${host.toolCallSeq.value++}`;
@@ -825,9 +859,15 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
     }
     const onAbort = () => nested.abort();
     host.signal.addEventListener("abort", onAbort);
-    await nested.prompt(task || "Complete the delegated task.");
-    await nested.waitForIdle();
-    host.signal.removeEventListener("abort", onAbort);
+    try {
+      await nested.prompt(task || "Complete the delegated task.");
+    } finally {
+      try {
+        await nested.waitForIdle();
+      } finally {
+        host.signal.removeEventListener("abort", onAbort);
+      }
+    }
     // Shared-budget abort leaves errorMessage on the nested agent; surface it as a
     // completed stop rather than a failed subagent chip.
     const budgetExceeded = host.toolCallBudget.exceeded;

--- a/packages/adapters/src/runtime-stream.test.ts
+++ b/packages/adapters/src/runtime-stream.test.ts
@@ -1,0 +1,78 @@
+import type { AgentRuntimeEvent } from "@rakazo/adapter-kit";
+import { describe, expect, it, vi } from "vitest";
+import { withRuntimeCleanup } from "./runtime-stream.js";
+
+describe("executor runtime cleanup", () => {
+  it.each(["cancelled", "lease lost", "pause", "consumer error"])(
+    "settles runtime and tool work before ownership cleanup on %s",
+    async (reason) => {
+      const controller = new AbortController();
+      const order: string[] = [];
+      let finishTool!: () => void;
+      const tool = new Promise<void>((resolve) => {
+        finishTool = resolve;
+      });
+      controller.signal.addEventListener("abort", () => {
+        order.push("abort");
+      });
+      async function* runtime(): AsyncIterable<AgentRuntimeEvent> {
+        try {
+          yield { type: "text", text: "started" };
+        } finally {
+          order.push("closing");
+          await tool;
+          order.push("settled");
+        }
+      }
+      const consume = async () => {
+        try {
+          for await (const _event of withRuntimeCleanup(runtime(), controller)) {
+            if (reason === "consumer error") throw new Error("consumer failed");
+            if (reason === "lease lost") controller.abort();
+            return;
+          }
+        } finally {
+          order.push("release ownership");
+        }
+      };
+      const consuming = consume().catch((error: Error) => error.message);
+      await vi.waitFor(() => expect(order).toEqual(["abort", "closing"]));
+      finishTool();
+      expect(await consuming).toBe(reason === "consumer error" ? "consumer failed" : undefined);
+      expect(order).toEqual(["abort", "closing", "settled", "release ownership"]);
+    },
+  );
+
+  it("keeps the context usable for checkpoints after normal completion", async () => {
+    const controller = new AbortController();
+    async function* runtime(): AsyncIterable<AgentRuntimeEvent> {
+      yield { type: "done" };
+    }
+    for await (const _event of withRuntimeCleanup(runtime(), controller)) {
+      // Consume the runtime normally.
+    }
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it("cancels tool work and closes the iterator after a runtime failure", async () => {
+    const controller = new AbortController();
+    const close = vi.fn(async () => {
+      expect(controller.signal.aborted).toBe(true);
+      return { done: true as const, value: undefined };
+    });
+    const events = {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          throw new Error("runtime failed");
+        },
+        return: close,
+      }),
+    };
+    const consume = async () => {
+      for await (const _event of withRuntimeCleanup(events, controller)) {
+      }
+    };
+    await expect(consume()).rejects.toThrow("runtime failed");
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/adapters/src/runtime-stream.ts
+++ b/packages/adapters/src/runtime-stream.ts
@@ -1,0 +1,27 @@
+import type { AgentRuntimeEvent } from "@rakazo/adapter-kit";
+
+/** Cancel executor tool work before closing an interrupted runtime's iterator. */
+export async function* withRuntimeCleanup(
+  events: AsyncIterable<AgentRuntimeEvent>,
+  controller: AbortController,
+): AsyncIterable<AgentRuntimeEvent> {
+  const iterator = events[Symbol.asyncIterator]();
+  let complete = false;
+  try {
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) {
+        complete = true;
+        return;
+      }
+      yield next.value;
+    }
+  } finally {
+    if (!complete) {
+      // for-await's implicit return() would otherwise run before the executor's
+      // finally, potentially waiting on a tool whose signal is still live.
+      controller.abort();
+      await iterator.return?.();
+    }
+  }
+}


### PR DESCRIPTION
## Why

Stopping consumption of a Pi run could leave its model and tool work executing after the worker released its screen and computer lease. A supplied context signal also replaced the runtime's own cancellation signal, making `runtime.abort()` ineffective in normal executor use. This affects already-running Pi-backed bots across clients sharing the backend. The realistic impact is continued resource use or tool effects after cancellation; it is not an unauthenticated entry point.

Validated against current main, including the earlier sandbox-process teardown and cancellation-finalization fixes. Those changes do not settle the detached Pi agent loop. Three deterministic regression cases fail against the original runtime because cancellation never reaches the fake agent.

## What changed

- Compose caller and runtime cancellation, abort immediately when an iterator is closed (including a pending event read), and await the agent work before dropping run tracking.
- Await nested-agent shutdown and remove abort listeners even when prompting fails. Keep a replacement attempt's tracking when an older stream closes.
- Cancel executor tool work before closing an interrupted runtime iterator, reject new tool calls after cancellation, and stop post-stream processing after lease loss. Normal completion keeps its context available for checkpoints; existing pause/resume behavior remains intact.

This fixes worker/runtime cleanup. Cross-process Stop detection still uses the existing event and lease checks, including the heartbeat for quiet streams. Cancellation cannot undo an external effect already accepted by a provider; work that ignores cancellation must settle before this worker finishes cleanup.

## Validation

- All 106 focused tests passed with one worker, covering Pi runtime behavior, cancellation ordering, executor behavior, approval replay, protected-input pauses, and scripted runs. All model work in the new tests is fake and offline.
- Adapter TypeScript checks, targeted Biome checks, and whitespace checks passed.
- CI passed: repository lint and typechecks, unit tests, Postgres journeys, production builds with Electron smoke tests, Web E2E, and container image validation. No UI changes.
