### PR TITLE
fix(adapters): enforce approvals for read-only connector tools

### DIFF
--- a/packages/adapters/src/executor-readonly-approval.test.ts
+++ b/packages/adapters/src/executor-readonly-approval.test.ts
@@ -1,0 +1,317 @@
+import type { AgentRunRequest, ConnectorCall, ConnectorTool } from "@rakazo/adapter-kit";
+import type { ActionApprovalRule } from "@rakazo/core";
+import { approvalEffectKey } from "@rakazo/core/node/approval-effect-key";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isApprovalPausedResult } from "./approval-effect.js";
+import { runAutoReviewJudge } from "./auto-review.js";
+import { createRunExecutor } from "./executor.js";
+import { catalogEntries, resolveCatalogCall } from "./lazy-tool-catalog.js";
+
+vi.mock("./computer-lifecycle.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./computer-lifecycle.js")>()),
+  acquireComputerExecutionLease: async () => null,
+  provisionComputer: async () => ({ id: "computer-1", kind: "desktop" }),
+}));
+
+vi.mock("./auto-review.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auto-review.js")>()),
+  resolveAutoReviewChecker: () => ({ provider: "scripted", model: "checker" }),
+  isAutoReviewCheckerConfigured: () => true,
+  runAutoReviewJudge: vi.fn(),
+}));
+
+type Effect = {
+  id: string;
+  kind: string;
+  idempotencyKey: string;
+  status: string;
+  request: unknown;
+  result?: unknown;
+  reviewDecision?: string;
+};
+
+function fixture({
+  name = "demo_get_item",
+  catalog = false,
+  rules = [] as ActionApprovalRule[],
+  autoReview = false,
+} = {}) {
+  const tool: ConnectorTool = {
+    name,
+    description: "Read an item",
+    readOnly: true,
+    inputSchema: {
+      type: "object",
+      properties: { id: { type: "string" } },
+      required: ["id"],
+    },
+    route: { connectorId: "demo", resourceId: "resource-1", toolName: name },
+  };
+  const effects: Effect[] = [];
+  const results: unknown[] = [];
+  const run = {
+    id: "run-1",
+    botId: "bot-1",
+    threadId: "thread-1",
+    taskId: "task-1",
+    spaceId: "space-1",
+    userId: "user-1",
+    status: "queued",
+    trigger: "user",
+    leaseFence: 0,
+  };
+  const externalEffect = {
+    findMany: vi.fn(async () => effects.filter((effect) => effect.status === "approved")),
+    findUnique: vi.fn(
+      async ({ where }: { where: { id?: string; idempotencyKey?: string } }) =>
+        effects.find((effect) =>
+          where.id ? effect.id === where.id : effect.idempotencyKey === where.idempotencyKey,
+        ) ?? null,
+    ),
+    create: vi.fn(async ({ data }: { data: Omit<Effect, "id"> }) => {
+      const effect = { ...data, id: `effect-${effects.length + 1}` };
+      effects.push(effect);
+      return { ...effect };
+    }),
+    update: vi.fn(async ({ where, data }: { where: { id: string }; data: Partial<Effect> }) => {
+      Object.assign(effects.find((effect) => effect.id === where.id)!, data);
+    }),
+    updateMany: vi.fn(
+      async ({ where, data }: { where: { id: string; status: string }; data: Partial<Effect> }) => {
+        const effect = effects.find(
+          (effect) => effect.id === where.id && effect.status === where.status,
+        );
+        if (!effect) return { count: 0 };
+        Object.assign(effect, data);
+        return { count: 1 };
+      },
+    ),
+  };
+  const prisma = {
+    run: {
+      findUnique: vi.fn(async () => run),
+      findUniqueOrThrow: vi.fn(async () => run),
+      updateMany: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        Object.assign(run, data);
+        return { count: 1 };
+      }),
+    },
+    bot: {
+      findUniqueOrThrow: vi.fn(async () => ({
+        id: run.botId,
+        name: "Assistant",
+        title: "Assistant",
+        description: "Test assistant",
+        computerId: "computer-1",
+        computer: { id: "computer-1", scope: "dedicated" },
+      })),
+      findMany: vi.fn(async () => []),
+    },
+    attempt: {
+      create: vi.fn(async () => ({ id: "attempt-1" })),
+      update: vi.fn(),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
+    thread: { findUniqueOrThrow: vi.fn(async () => ({ id: run.threadId, groupId: null })) },
+    message: { findMany: vi.fn(async () => []) },
+    task: { findUniqueOrThrow: vi.fn(async () => ({ id: run.taskId, prompt: "Read the item" })) },
+    connection: { findMany: vi.fn(async () => []) },
+    spaceModelPreference: { findFirst: vi.fn(async () => null) },
+    userModelCredential: { findFirst: vi.fn(async () => null) },
+    deploymentSettings: {
+      findUnique: vi.fn(async () => ({
+        defaultModelProvider: "scripted",
+        defaultModelId: "scripted",
+      })),
+    },
+    taughtSkill: { findMany: vi.fn(async () => []) },
+    agentSkill: { findMany: vi.fn(async () => []) },
+    scratchpadItem: { findMany: vi.fn(async () => []) },
+    actionApprovalRule: { findMany: vi.fn(async () => rules) },
+    actionAutoReviewPreference: { findUnique: vi.fn(async () => ({ enabled: autoReview })) },
+    externalEffect,
+  };
+  const pauseRunForInput = vi.fn(async () => {
+    run.status = "waiting_input";
+    return true;
+  });
+  const finalizeRun = vi.fn(async () => ({ continuationRunId: null }));
+  const execute = vi.fn(async function* (call: ConnectorCall) {
+    yield { type: "result" as const, data: { item: call.args.id } };
+  });
+  let calls = [{ args: { id: "item-1" }, executionId: "call-1" }];
+  const runtimeRun = vi.fn(async function* (request: AgentRunRequest) {
+    for (const call of calls) {
+      const result = await request.executeTool!(
+        catalog ? "demo_execute_tool" : name,
+        catalog ? { id: `resource-1:${name}`, arguments: call.args } : call.args,
+        call.executionId,
+      );
+      results.push(result);
+      if (isApprovalPausedResult(result)) return;
+    }
+    yield { type: "done" as const, text: "Done" };
+  });
+  const executor = createRunExecutor({
+    prisma,
+    runtime: { describe: () => ({ capabilities: { scripted: false } }), run: runtimeRun },
+    connector: {
+      discoverTools: async () =>
+        catalog
+          ? [
+              {
+                name: "demo_execute_tool",
+                description: "Execute a catalog tool",
+                inputSchema: { type: "object" },
+                route: { connectorId: "demo", toolName: "__catalog_execute" },
+              },
+            ]
+          : [tool],
+      resolveCall: async (call: ConnectorCall) =>
+        catalog ? resolveCatalogCall(call, catalogEntries([tool])) : undefined,
+      execute,
+    },
+    sandbox: { describe: () => ({ capabilities: { graphical: false } }) },
+    memory: { read: async () => ({ documents: [] }) },
+    memoryProviders: { resolve: async () => null },
+    events: { append: vi.fn(async () => undefined), pauseRunForInput, finalizeRun },
+    jobs: { enqueue: vi.fn(async () => undefined) },
+    secrets: [],
+  } as unknown as Parameters<typeof createRunExecutor>[0]);
+  return {
+    effects,
+    results,
+    execute,
+    pauseRunForInput,
+    setCalls(next: typeof calls) {
+      calls = next;
+    },
+    async run() {
+      run.status = "queued";
+      await executor.continueRun(run.id, "worker-1");
+      expect(runtimeRun).toHaveBeenCalled();
+      expect(prisma.attempt.update).not.toHaveBeenCalled();
+      expect(finalizeRun).not.toHaveBeenCalledWith(expect.objectContaining({ outcome: "failed" }));
+    },
+  };
+}
+
+describe("connector read-only metadata and approval enforcement", () => {
+  beforeEach(() => {
+    vi.mocked(runAutoReviewJudge).mockReset();
+  });
+
+  describe.each([false, true])("catalog = %s", (catalog) => {
+    it.each(["tool", "connector"] as const)(
+      "honors an explicit %s approval rule",
+      async (matchKind) => {
+        const f = fixture({
+          catalog,
+          autoReview: true,
+          rules: [
+            {
+              effect: "require_approval",
+              matchKind,
+              matchValue: matchKind === "tool" ? "demo_get_item" : "demo",
+            },
+          ],
+        });
+        await f.run();
+        expect(f.execute).not.toHaveBeenCalled();
+        expect(f.pauseRunForInput).toHaveBeenCalledOnce();
+        expect(f.pauseRunForInput).toHaveBeenCalledWith(
+          expect.objectContaining({
+            blocks: [expect.objectContaining({ kind: "ask", approvalEffectId: f.effects[0]!.id })],
+          }),
+        );
+        expect(isApprovalPausedResult(f.results[0])).toBe(true);
+        expect(runAutoReviewJudge).not.toHaveBeenCalled();
+      },
+    );
+
+    it("replays the approved arguments once and returns the result on retry", async () => {
+      const f = fixture({
+        catalog,
+        rules: [{ effect: "require_approval", matchKind: "tool", matchValue: "demo_get_item" }],
+      });
+      await f.run();
+      expect(f.effects).toHaveLength(1);
+      f.effects[0]!.status = "approved";
+      f.setCalls([
+        { args: { id: "model-reconstructed" }, executionId: "call-2" },
+        { args: { id: "item-1" }, executionId: "call-3" },
+      ]);
+      await f.run();
+      expect(f.execute).toHaveBeenCalledOnce();
+      expect(f.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: { id: "item-1" },
+          executionId: approvalEffectKey("run-1", "demo_get_item", { id: "item-1" }),
+        }),
+        expect.anything(),
+      );
+      expect(f.effects).toHaveLength(1);
+      expect(f.effects[0]!.status).toBe("completed");
+      expect(f.results.slice(1)).toEqual([{ item: "item-1" }, { item: "item-1" }]);
+      expect(f.pauseRunForInput).toHaveBeenCalledOnce();
+    });
+
+    it("honors a persisted denial on a new tool call id", async () => {
+      const f = fixture({
+        catalog,
+        rules: [{ effect: "require_approval", matchKind: "tool", matchValue: "demo_get_item" }],
+      });
+      await f.run();
+      expect(f.effects).toHaveLength(1);
+      f.effects[0]!.status = "denied";
+      f.setCalls([{ args: { id: "item-1" }, executionId: "call-2" }]);
+      await f.run();
+      expect(f.execute).not.toHaveBeenCalled();
+      expect(f.results.at(-1)).toEqual({ error: "User denied this action." });
+      expect(f.pauseRunForInput).toHaveBeenCalledOnce();
+    });
+
+    it("allows ordinary reads without approval or automatic review", async () => {
+      const f = fixture({ catalog, autoReview: true });
+      f.setCalls([
+        { args: { id: "item-1" }, executionId: "call-1" },
+        { args: { id: "item-1" }, executionId: "call-2" },
+      ]);
+      await f.run();
+      expect(f.execute).toHaveBeenCalledTimes(2);
+      expect(f.results).toEqual([{ item: "item-1" }, { item: "item-1" }]);
+      expect(f.pauseRunForInput).not.toHaveBeenCalled();
+      expect(runAutoReviewJudge).not.toHaveBeenCalled();
+    });
+
+    it("keeps an explicit allow rule ahead of automatic review", async () => {
+      const f = fixture({
+        catalog,
+        name: "demo_send_message",
+        autoReview: true,
+        rules: [{ effect: "always_allow", matchKind: "tool", matchValue: "demo_send_message" }],
+      });
+      await f.run();
+      expect(f.execute).toHaveBeenCalledOnce();
+      expect(f.pauseRunForInput).not.toHaveBeenCalled();
+      expect(runAutoReviewJudge).not.toHaveBeenCalled();
+    });
+
+    it.each(["ask", "error", "pass"] as const)(
+      "honors automatic review %s despite a read-only hint",
+      async (decision) => {
+        vi.mocked(runAutoReviewJudge).mockResolvedValue({
+          decision,
+          reason: "Review result",
+          model: "scripted/checker",
+        });
+        const f = fixture({ catalog, name: "demo_send_message", autoReview: true });
+        await f.run();
+        expect(runAutoReviewJudge).toHaveBeenCalledOnce();
+        expect(f.effects[0]?.reviewDecision).toBe(decision);
+        expect(f.execute).toHaveBeenCalledTimes(decision === "pass" ? 1 : 0);
+        expect(f.pauseRunForInput).toHaveBeenCalledTimes(decision === "pass" ? 0 : 1);
+      },
+    );
+  });
+});

--- a/packages/adapters/src/executor-readonly-approval.test.ts
+++ b/packages/adapters/src/executor-readonly-approval.test.ts
@@ -271,6 +271,24 @@ describe("connector read-only metadata and approval enforcement", () => {
       expect(f.pauseRunForInput).toHaveBeenCalledOnce();
     });
 
+    it("consumes the saved approval after the user chooses always allow", async () => {
+      const rules: ActionApprovalRule[] = [
+        { effect: "require_approval", matchKind: "tool", matchValue: "demo_get_item" },
+      ];
+      const f = fixture({ catalog, rules });
+      await f.run();
+      expect(f.effects).toHaveLength(1);
+      f.effects[0]!.status = "approved";
+      rules[0]!.effect = "always_allow";
+      f.setCalls([{ args: { id: "model-reconstructed" }, executionId: "call-2" }]);
+      await f.run();
+      expect(f.execute).toHaveBeenCalledOnce();
+      expect(f.results.at(-1)).toEqual({ item: "item-1" });
+      expect(f.effects).toHaveLength(1);
+      expect(f.effects[0]!.status).toBe("completed");
+      expect(f.pauseRunForInput).toHaveBeenCalledOnce();
+    });
+
     it("allows ordinary reads without approval or automatic review", async () => {
       const f = fixture({ catalog, autoReview: true });
       f.setCalls([

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1221,9 +1221,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const connectorSchemas = new Map(
           exposedConnectorTools.map((tool) => [tool.name, tool.inputSchema] as const),
         );
-        const readOnlyConnectorTools = new Set(
-          exposedConnectorTools.filter((tool) => tool.readOnly).map((tool) => tool.name),
-        );
         let approvalRulesPromise: Promise<ActionApprovalRule[]> | undefined;
         const loadApprovalRules = () => {
           approvalRulesPromise ??= deps.prisma.actionApprovalRule
@@ -1418,7 +1415,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
           let catalogRemapped = false;
           let resolvedToolSchema: Record<string, unknown> | undefined;
           let effectRequest: unknown = args;
-          let connectorReadOnly = readOnlyConnectorTools.has(name);
           if (connectorCall.route && deps.connector?.resolveCall) {
             try {
               const resolved = await deps.connector.resolveCall(connectorCall, context);
@@ -1446,7 +1442,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
                     : undefined,
                 );
                 connectorCall = resolved.call;
-                connectorReadOnly = resolved.tool.readOnly === true;
               }
             } catch (error) {
               return { error: sanitizeConnectorError(error) };
@@ -1612,10 +1607,10 @@ export function createRunExecutor(deps: ExecutorDeps) {
             name === "request_secret" || needsApprovalEarly || requiresApprovalByDefault
               ? approvalEffectKey(runId, replayEffectToolName, args)
               : executionId;
-          const applied =
-            READ_ONLY_AGENT_TOOLS.has(name) || connectorReadOnly
-              ? undefined
-              : await recordEffect(deps, run, replayEffectToolName, effectKey, effectRequest);
+          // Connector read-only hints must not bypass approval, review, or replay decisions.
+          const applied = READ_ONLY_AGENT_TOOLS.has(name)
+            ? undefined
+            : await recordEffect(deps, run, replayEffectToolName, effectKey, effectRequest);
 
           const runAutoReview = async () => {
             if (!checker) return;

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -1603,8 +1603,12 @@ export function createRunExecutor(deps: ExecutorDeps) {
           let reviewReason: string | undefined;
           let gateDecision: "ask" | "allow" = plan === "ask" ? "ask" : "allow";
           const needsApprovalEarly = plan === "ask" || plan === "judge";
+          // A resumed approval keeps its key even if "Always allow" changed the policy.
           const effectKey =
-            name === "request_secret" || needsApprovalEarly || requiresApprovalByDefault
+            nextApprovedTool ||
+            name === "request_secret" ||
+            needsApprovalEarly ||
+            requiresApprovalByDefault
               ? approvalEffectKey(runId, replayEffectToolName, args)
               : executionId;
           // Connector read-only hints must not bypass approval, review, or replay decisions.


### PR DESCRIPTION
## Why

A connector tool that advertises `readOnly: true` can run despite a matching require-approval rule. Remote MCP `readOnlyHint` flows into this metadata. The executor resolves the approval policy correctly, but skips the effect record that enforces approval and automatic review.

This is a conditional, medium-severity approval bypass: a configured connector must advertise the hint and its tool must be invoked. Impact depends on the connected tool's permissions. The shared executor affects web, desktop, and mobile. Current main and existing approval PRs were checked before implementing this fix.

## What changed

Record connector calls through the existing effect lifecycle regardless of read-only metadata. Explicit approval rules, persisted denials, exact approved replay, and automatic-review decisions now take effect on both direct and lazy-catalog calls. Resumed approvals retain their stable effect key when choosing Always allow changes the rule, so the approved record is consumed rather than left available for another replay. Existing rule precedence and default read behavior are preserved: ordinary reads run without prompts and separate read calls still execute independently.

The operational tradeoff is additional effect records for connector reads. Built-in tool policy and run cancellation are unchanged.

## Validation

- Reproduced the bypass on unchanged main with offline executor tests: explicit approval and automatic-review cases failed while ordinary reads passed.
- All 93 focused approval, replay, and automatic-review tests pass, including 20 new executor regressions covering direct and catalog routes.
- Adapter typecheck and focused Biome checks pass.
- No live services or production data were used. Tests ran with one worker. Full-suite and Electron verification are left to CI.
