### PR TITLE
fix(core): disable unsafe chart links

### DIFF
--- a/apps/web/e2e/chart-links.spec.ts
+++ b/apps/web/e2e/chart-links.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot } from "./helpers";
+
+const fixture = "/e2e/fixtures/chart-links.html";
+
+test("chart links cannot execute script when clicked or expanded", async ({ page }, testInfo) => {
+  for (const inspect of ["0", "1"]) {
+    for (const href of [
+      'javascript:void(document.body.dataset.plotExecuted="yes")',
+      ' \u0000\u001fJaVa\tScRi\nPt:void(document.body.dataset.plotExecuted="yes")',
+      'javascript:%76oid(document.body.dataset.plotExecuted="yes")',
+      "data:text/html,<script>document.body.dataset.plotExecuted='yes'</script>",
+      "file:///example.txt",
+    ]) {
+      await page.goto(`${fixture}?${new URLSearchParams({ href, inspect })}`);
+      const circle = page.locator("svg circle").first();
+      await expect(circle).toBeVisible();
+      const assertInert = async () => {
+        const links = page.locator("svg a");
+        expect(await links.count()).toBeGreaterThan(0);
+        expect(
+          await links.evaluateAll((anchors) =>
+            anchors.every(
+              (anchor) =>
+                !anchor.hasAttribute("href") &&
+                !anchor.hasAttributeNS("http://www.w3.org/1999/xlink", "href"),
+            ),
+          ),
+        ).toBe(true);
+        await expect(page.locator("body")).not.toHaveAttribute("data-plot-executed");
+      };
+      await assertInert();
+      await circle.click();
+      // Hover inspection still works, without reintroducing unsafe links.
+      if (inspect === "1") await expect(page.locator('[aria-label="tip"]')).toBeVisible();
+      await assertInert();
+      await page.getByRole("button", { name: "Expand", exact: true }).click();
+      const dialog = page.getByRole("dialog");
+      await expect(dialog.locator("svg circle")).toBeVisible();
+      await dialog.locator("svg circle").click();
+      await assertInert();
+      await expect(page).toHaveURL(`${fixture}?${new URLSearchParams({ href, inspect })}`);
+      await page.getByRole("button", { name: "Close chart" }).click();
+    }
+  }
+  await captureScreenshot(page, testInfo, "chart-with-inert-link");
+});
+
+test("chart links retain supported URLs and browser encoding semantics", async ({ page }) => {
+  await page.route("https://example.test/**", (route) =>
+    route.fulfill({ body: "Chart destination" }),
+  );
+  await page.route("**/e2e/fixtures/java*", (route) =>
+    route.fulfill({ body: "Chart destination" }),
+  );
+  for (const href of [
+    "https://example.test/chart?a=1&b=2",
+    "mailto:chart@example.test",
+    "tel:+15555550123",
+    "#details",
+    "java&#x73;cript:void(0)",
+    "javascript%3Avoid(0)",
+    "java%73cript:void(0)",
+  ]) {
+    await page.goto(`${fixture}?${new URLSearchParams({ href })}`);
+    const link = page.locator("svg a").first();
+    await expect(link).toBeVisible();
+    expect(
+      await link.evaluate((anchor) =>
+        anchor.getAttributeNS("http://www.w3.org/1999/xlink", "href"),
+      ),
+    ).toBe(href);
+    const destination = new URL(href, page.url());
+    expect(destination.protocol).not.toBe("javascript:");
+    if (destination.protocol === "http:" || destination.protocol === "https:") {
+      await link.locator("circle").click();
+      await expect(page).toHaveURL(destination.href);
+      await expect(page.locator("body")).not.toHaveAttribute("data-plot-executed");
+    }
+  }
+});

--- a/apps/web/e2e/fixtures/chart-links.html
+++ b/apps/web/e2e/fixtures/chart-links.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chart links</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./chart-links.tsx"></script>
+  </body>
+</html>

--- a/apps/web/e2e/fixtures/chart-links.tsx
+++ b/apps/web/e2e/fixtures/chart-links.tsx
@@ -1,0 +1,37 @@
+import { setupI18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { createRoot } from "react-dom/client";
+import { ChartBlockView } from "../../src/pages/shell/message-cards";
+import "../../src/styles.css";
+
+const params = new URLSearchParams(location.search);
+const href = params.get("href") ?? "#details";
+const i18n = setupI18n({ locale: "en", messages: { en: {} } });
+
+createRoot(document.getElementById("root")!).render(
+  <I18nProvider i18n={i18n}>
+    <main className="min-h-screen bg-background p-8 text-foreground">
+      <ChartBlockView
+        name="chart.png"
+        spec={{
+          title: "Linked chart",
+          marks: [
+            {
+              type: "dot",
+              options: {
+                x: "x",
+                y: "y",
+                href: "url",
+                fill: "currentColor",
+                r: 12,
+                tip: params.get("inspect") === "1",
+              },
+            },
+          ],
+        }}
+        data={[{ x: 1, y: 1, url: href }]}
+      />
+      <div id="details">Chart details</div>
+    </main>
+  </I18nProvider>,
+);

--- a/packages/adapters/src/plot-tool.test.ts
+++ b/packages/adapters/src/plot-tool.test.ts
@@ -1,6 +1,7 @@
 import { JSDOM } from "jsdom";
 import { describe, expect, it } from "vitest";
 import {
+  buildPlotParts,
   CHART_CATALOG,
   PLOT_TOOL_GUIDE,
   type PlotSpec,
@@ -45,6 +46,99 @@ describe("render_plot", () => {
 
     expect(() => renderPlotSpecToSvg(spec, penguinish, dom())).not.toThrow();
     expect(color.legend).toBe(true);
+  });
+
+  const xlink = "http://www.w3.org/1999/xlink";
+  const linkedDot = { type: "dot", options: { x: "x", y: "y", href: "url" } };
+
+  function expectInertLinks(element: Element) {
+    const links = Array.from(element.querySelectorAll("a"));
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      expect(link.hasAttribute("href")).toBe(false);
+      expect(link.hasAttributeNS(xlink, "href")).toBe(false);
+      expect(link.childElementCount).toBeGreaterThan(0);
+    }
+  }
+
+  it.each([
+    "javascript:void(0)",
+    "JaVaScRiPt:void(0)",
+    " \u0000\u001fjavascript:void(0)",
+    "java\tscr\ript:\nvoid(0)",
+    "javascript:%76oid(0)",
+    "data:text/html,<script>void(0)</script>",
+    "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>",
+    "vbscript:msgbox(1)",
+    "file:///example.txt",
+    "blob:https://example.test/chart",
+    "custom:launch",
+    "https://[invalid",
+  ])("makes unsafe or malformed chart links inert: %j", (url) => {
+    const spec = { marks: [linkedDot] };
+    const data = [{ x: 1, y: 2, url }];
+    const { plotted } = buildPlotParts(spec, data, dom());
+    expectInertLinks(plotted);
+    expect(plotted.querySelectorAll("circle")).toHaveLength(1);
+    const svg = renderPlotSpecToSvg(spec, data, dom());
+    expectInertLinks(
+      new JSDOM(svg, { contentType: "image/svg+xml" }).window.document.documentElement,
+    );
+    expect(data[0].url).toBe(url);
+    expect(linkedDot.options.href).toBe("url");
+  });
+
+  it.each([
+    "https://example.test/chart?a=1&b=2",
+    "HTTP://example.test/chart",
+    "//example.test/chart",
+    "/charts/1",
+    "../charts/1",
+    "?chart=1",
+    "#details",
+    "mailto:chart@example.test",
+    "tel:+15555550123",
+    // DOM attributes are not entity-decoded or percent-decoded into a scheme.
+    "java&#x73;cript:void(0)",
+    "javascript%3Avoid(0)",
+    "java%73cript:void(0)",
+  ])("preserves supported links without changing URL interpretation: %j", (url) => {
+    const spec = { marks: [linkedDot] };
+    const data = [{ x: 1, y: 2, url }];
+    const { plotted } = buildPlotParts(spec, data, dom());
+    expect(plotted.querySelector("a")?.getAttributeNS(xlink, "href")).toBe(url);
+    const svg = renderPlotSpecToSvg(spec, data, dom());
+    const parsed = new JSDOM(svg, { contentType: "image/svg+xml" }).window.document;
+    const link = parsed.querySelector("a");
+    expect(link?.getAttributeNS(xlink, "href") ?? link?.getAttribute("href")).toBe(url);
+  });
+
+  it("checks resolved links from nested, per-mark, array, scaled, and transformed channels", () => {
+    const url = "javascript:void(0)";
+    const data = [{ x: 1, y: 2, url }];
+    const specs: PlotSpec[] = [
+      { data, marks: [linkedDot] },
+      { marks: [{ ...linkedDot, data }] },
+      { data, marks: [{ type: "dot", options: { x: "x", y: "y", href: [url] } }] },
+      {
+        data,
+        marks: [{ type: "dot", options: { x: "x", y: "y", href: { value: "url", scale: null } } }],
+      },
+      {
+        data,
+        color: { type: "ordinal", domain: [1], range: [url] },
+        marks: [{ type: "dot", options: { x: "x", y: "y", href: { value: "x", scale: "color" } } }],
+      },
+      {
+        data,
+        marks: [
+          { ...linkedDot, transform: { name: "groupX", outputs: { y: "sum", href: "first" } } },
+        ],
+      },
+    ];
+    for (const spec of specs) {
+      expectInertLinks(buildPlotParts(spec, undefined, dom()).plotted);
+    }
   });
 
   it("supports transforms: binned histogram and grouped stacked bars", () => {

--- a/packages/adapters/src/plot-tool.test.ts
+++ b/packages/adapters/src/plot-tool.test.ts
@@ -84,7 +84,7 @@ describe("render_plot", () => {
     expectInertLinks(
       new JSDOM(svg, { contentType: "image/svg+xml" }).window.document.documentElement,
     );
-    expect(data[0].url).toBe(url);
+    expect(data).toEqual([{ x: 1, y: 2, url }]);
     expect(linkedDot.options.href).toBe("url");
   });
 

--- a/packages/core/src/plot/plot-spec.ts
+++ b/packages/core/src/plot/plot-spec.ts
@@ -264,6 +264,31 @@ export function parsePlotData(name: string, content: string): unknown[] {
 
 const XMLNS = "http://www.w3.org/2000/xmlns/";
 
+function isSafePlotLink(href: string): boolean {
+  try {
+    // Use the URL parser's control-character and scheme handling. The fixed
+    // base allows relative links even in the server's about:blank document;
+    // retain the original attribute so clients resolve it against their page.
+    const { protocol } = new URL(href, "https://plot.invalid/");
+    return ["http:", "https:", "mailto:", "tel:"].includes(protocol);
+  } catch {
+    return false;
+  }
+}
+
+function sanitizePlotLinks(plotted: Element): void {
+  // Inspect the resolved output: href can come from columns, per-mark arrays,
+  // channel objects, scales, or transforms. Check both href and xlink:href
+  // before either mounting the live plot or serializing it for export.
+  for (const anchor of Array.from(plotted.querySelectorAll("a"))) {
+    for (const attribute of Array.from(anchor.attributes)) {
+      if (attribute.localName === "href" && !isSafePlotLink(attribute.value)) {
+        anchor.removeAttributeNode(attribute);
+      }
+    }
+  }
+}
+
 export type PlotParts = {
   /** The rendered element (an <svg>, or a <figure> wrapping one). */
   plotted: Element;
@@ -319,6 +344,7 @@ export function buildPlotParts(
     ...(overrides.height ? { height: overrides.height } : {}),
     marks: marks.map((mark) => buildMark(mark, sharedData, normalizeData)),
   });
+  sanitizePlotLinks(plotted);
   const svg = plotted.tagName === "svg" ? plotted : plotted.querySelector("svg");
   if (!svg) throw new Error("Plot did not produce an SVG element");
   const width = Number(svg.getAttribute("width") ?? overrides.width ?? spec.width ?? 640);


### PR DESCRIPTION
Charts can carry links supplied through bot-generated specs or external data. Previously, the shared renderer preserved executable SVG links, so activating a crafted mark could run JavaScript in the signed-in app context. This is interaction-dependent stored XSS: an attacker must influence a published chart and induce link activation. The live web UI and Electron's shared web UI use this renderer; mobile currently displays a text placeholder, and PNG exports are inert.

Filter resolved anchor URLs in the shared plot renderer before mounting or serialization. Allow HTTP, HTTPS, mail, telephone, and relative links using browser-compatible URL parsing; remove unsafe or malformed href attributes while preserving chart marks and caller-owned data. Filtering the output covers data columns, per-mark arrays, channel objects, scales, transforms, and previously saved specs. No product UI copy is added.

Validation:
- Confirmed JavaScript execution in headless Chromium with the original renderer, including mixed-case/control-character schemes and percent-encoded script text; the payload only set a test marker.
- All 41 focused plot tests pass, covering live output, serialized SVG, legitimate links, channel variants, existing chart examples, and PNG rendering.
- Both focused Chromium tests pass through the real chart component, including link activation with hover inspection enabled and disabled, expanded charts, hover redraws, and intercepted legitimate/encoded-relative navigation.
- Core and adapters type checking, changed-file lint, and diff whitespace checks pass. Local tests use a single worker; CI runs the broader suites and Electron E2E.

[CI screenshot: chart with its unsafe link disabled](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33991962382-1/screenshots/images/099-chart-with-inert-link.png).

All CI checks pass on the final commit, including web and Electron E2E. Greptile reviewed the final commit without actionable findings. CodeRabbit could not review because its quota was exhausted; a retry after the initially reported cooldown was also rate-limited. The PR remains unmerged with auto-merge disabled.
