### PR TITLE
fix(computer): preserve live work during reconnect and update

### DIFF
--- a/packages/adapters/src/computer-idle.test.ts
+++ b/packages/adapters/src/computer-idle.test.ts
@@ -12,13 +12,7 @@ import {
   sandboxIdleMs,
   sleepComputerIfIdle,
 } from "./computer-idle.js";
-import {
-  e2bCreateOptions,
-  isUnreachableTransportError,
-  isUnrecoverableSandboxError,
-  openDesktopBrowser,
-  openDesktopUrl,
-} from "./e2b-sandbox.js";
+import { e2bCreateOptions, openDesktopBrowser, openDesktopUrl } from "./e2b-sandbox.js";
 
 describe("sandbox idle", () => {
   it("defaults to ten minutes when SANDBOX_IDLE_MS is unset", () => {
@@ -378,18 +372,6 @@ describe("e2b create options", () => {
     expect(opts.lifecycle).toEqual({ onTimeout: "pause", autoResume: false });
     expect(opts.timeoutMs).toBe(sandboxIdleMs());
     expect(opts.metadata.botId).toBe("bot-1");
-  });
-
-  it("only recreates when the sandbox is actually gone", () => {
-    expect(isUnrecoverableSandboxError(new Error("sandbox not found"))).toBe(true);
-    expect(isUnrecoverableSandboxError(new Error("ECONNRESET"))).toBe(false);
-    // Transient transport codes must not satisfy the replaceComputer predicate: otherwise
-    // update mode swallows a checkpoint blip, destroys the old box, and drops uncommitted work.
-    const reset = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
-    expect(isUnrecoverableSandboxError(reset)).toBe(false);
-    expect(isUnreachableTransportError(reset)).toBe(true);
-    expect(isUnrecoverableSandboxError(new Error("fetch failed"))).toBe(false);
-    expect(isUnreachableTransportError(new Error("fetch failed"))).toBe(true);
   });
 
   it("opens a browser on a new desktop", async () => {

--- a/packages/adapters/src/computer-lifecycle.test.ts
+++ b/packages/adapters/src/computer-lifecycle.test.ts
@@ -91,6 +91,8 @@ describe("computer provisioning", () => {
           where: {
             id: "computer-1",
             state: "booting",
+            providerRef: "provider-1",
+            kind: "cloud",
             bots: { some: { id: "bot-1", archivedAt: null } },
           },
         }),
@@ -130,8 +132,14 @@ describe("computer provisioning", () => {
       const prisma = {
         computer: {
           findUniqueOrThrow: vi.fn().mockResolvedValue(original),
-          update: vi.fn().mockRejectedValue(failure),
-          updateMany: vi.fn(),
+          updateMany:
+            stage === "record"
+              ? vi
+                  .fn()
+                  .mockResolvedValueOnce({ count: 1 })
+                  .mockRejectedValueOnce(failure)
+                  .mockResolvedValue({ count: 1 })
+              : vi.fn().mockResolvedValue({ count: 1 }),
         },
       } as unknown as PrismaClient;
       const sandbox = {
@@ -164,8 +172,10 @@ describe("computer provisioning", () => {
         expect(sandbox.releaseScreen).toHaveBeenCalledExactlyOnceWith(ref, context);
         expect(sandbox.destroy).toHaveBeenCalledExactlyOnceWith(ref, context);
         expect(sandbox.stop).not.toHaveBeenCalled();
-        expect(prisma.computer.updateMany).not.toHaveBeenCalled();
-        if (stage !== "record") expect(prisma.computer.update).not.toHaveBeenCalled();
+        expect(prisma.computer.updateMany).toHaveBeenLastCalledWith({
+          where: { id: "computer-1", state: "booting", providerRef: "provider-1", kind: "box" },
+          data: { state: "running" },
+        });
         expect(original).toMatchObject({
           state: "running",
           kind: "box",
@@ -200,7 +210,7 @@ describe("computer provisioning", () => {
       computer: {
         findUniqueOrThrow: vi.fn().mockResolvedValue(original),
         update: vi.fn(),
-        updateMany: vi.fn(),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
     } as unknown as PrismaClient;
     const sandbox = {
@@ -230,7 +240,7 @@ describe("computer provisioning", () => {
       expect(sandbox.stop).not.toHaveBeenCalled();
       expect(sandbox.destroy).not.toHaveBeenCalled();
       expect(prisma.computer.update).not.toHaveBeenCalled();
-      expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+      expect(prisma.computer.updateMany).toHaveBeenCalledTimes(2);
     } finally {
       await rm(dataDir, { recursive: true, force: true });
     }
@@ -267,10 +277,13 @@ describe("computer provisioning", () => {
             state: "running",
             controlLeaseId: null,
           }),
-          updateMany: vi.fn(),
-          update: vi.fn(async () => {
-            expect(await sandbox.readFile(ref, "notes/keep.txt", context)).toEqual(saved);
-          }),
+          updateMany: vi
+            .fn()
+            .mockResolvedValueOnce({ count: 1 })
+            .mockImplementation(async () => {
+              expect(await sandbox.readFile(ref, "notes/keep.txt", context)).toEqual(saved);
+              return { count: 1 };
+            }),
         },
       } as unknown as PrismaClient;
 
@@ -292,14 +305,16 @@ describe("computer provisioning", () => {
         ).resolves.toEqual(ref);
         expect(prepare).toHaveBeenCalledWith(ref, context);
         expect(await sandbox.readFile(ref, "notes/keep.txt", context)).toEqual(saved);
-        if (next.providerRef === "provider-1" && next.kind === "box") {
-          expect(prisma.computer.update).not.toHaveBeenCalled();
-        } else {
-          expect(prisma.computer.update).toHaveBeenCalledWith({
-            where: { id: "computer-1" },
-            data: { providerRef: next.providerRef, kind: next.kind },
-          });
-        }
+        expect(prisma.computer.updateMany).toHaveBeenLastCalledWith({
+          where: {
+            id: "computer-1",
+            state: "booting",
+            providerRef: "provider-1",
+            kind: "box",
+            bots: { some: { id: "bot-1", archivedAt: null } },
+          },
+          data: { state: "running", providerRef: next.providerRef, kind: next.kind },
+        });
         expect(destroy).not.toHaveBeenCalled();
         expect(stop).not.toHaveBeenCalled();
       } finally {
@@ -482,7 +497,7 @@ describe("computer provisioning", () => {
         errors: [prepareError, rollbackError],
       });
       expect(updateMany).toHaveBeenLastCalledWith({
-        where: { id: "computer-1", state: "booting" },
+        where: { id: "computer-1", state: "booting", providerRef: null, kind: "e2b" },
         data: {
           state: "error",
           providerRef: "new-provider-1",
@@ -519,7 +534,7 @@ describe("computer provisioning", () => {
             state: "running",
             controlLeaseId: null,
           }),
-          updateMany: vi.fn(),
+          updateMany: vi.fn().mockResolvedValue({ count: 1 }),
           update: vi.fn(),
         },
       } as unknown as PrismaClient;
@@ -553,7 +568,7 @@ describe("computer provisioning", () => {
         expect(sandbox.importWorkspace).not.toHaveBeenCalled();
         expect(sandbox.destroy).not.toHaveBeenCalled();
         expect(sandbox.stop).not.toHaveBeenCalled();
-        expect(prisma.computer.updateMany).not.toHaveBeenCalled();
+        expect(prisma.computer.updateMany).toHaveBeenCalledTimes(2);
         expect(prisma.computer.update).not.toHaveBeenCalled();
       } finally {
         await rm(dataDir, { recursive: true, force: true });

--- a/packages/adapters/src/computer-lifecycle.ts
+++ b/packages/adapters/src/computer-lifecycle.ts
@@ -24,7 +24,6 @@ import {
   ensureComputerWorkspaceLayout,
   restoreComputerWorkspace,
 } from "./computer-workspace.js";
-import { isUnrecoverableSandboxError } from "./e2b-sandbox.js";
 import { resolveAgentHomePath } from "./home.js";
 
 const EXECUTION_LEASE_MS = 5 * 60_000;
@@ -65,21 +64,22 @@ export async function provisionComputer(
   const homePath = resolveAgentHomePath(deps.home, existing.homeKey, deps.dataDir ?? "./data");
   await mkdir(homePath, { recursive: true });
 
-  if (existing.state === "running" && existing.providerRef) {
-    return reconnectComputer(deps, existing, homePath, context);
-  }
   if (existing.state === "booting" || existing.state === "suspending") {
-    const ready = await waitForComputerReady(deps.prisma, computerId, context);
-    if (ready?.state === "running" && ready.providerRef) {
-      return reconnectComputer(deps, ready, homePath, context);
-    }
-    existing = await deps.prisma.computer.findUniqueOrThrow({ where: { id: computerId } });
+    existing = await waitForComputerReady(deps.prisma, computerId, context);
+  }
+  if (!["running", "stopped", "suspended", "error"].includes(existing.state)) {
+    throw new ComputerBusyError();
   }
 
+  const reconnecting = existing.state === "running" && Boolean(existing.providerRef);
+  // Reconnect can allocate a replacement too. Claim it before any provider call,
+  // and compare the observed reference so a delayed caller cannot replace a winner.
+  const previousRef = { providerRef: existing.providerRef, kind: existing.kind };
   const claimed = await deps.prisma.computer.updateMany({
     where: {
       id: computerId,
-      state: { in: ["stopped", "suspended", "error"] },
+      state: existing.state,
+      ...previousRef,
       ...(context.botId ? { bots: { some: { id: context.botId, archivedAt: null } } } : {}),
     },
     data: { state: "booting" },
@@ -118,19 +118,24 @@ export async function provisionComputer(
       where: {
         id: computerId,
         state: "booting",
+        ...previousRef,
         ...(context.botId ? { bots: { some: { id: context.botId, archivedAt: null } } } : {}),
       },
       data: {
         state: "running",
         providerRef: ref.providerRef,
         kind: ref.kind,
-        controlHolder: activeControl ? "user" : controlHolder,
-        ...(!activeControl
+        ...(!reconnecting
           ? {
-              controlLeaseId: null,
-              controlLeaseExpiresAt: null,
-              controlBotId: null,
-              controlRunId: null,
+              controlHolder: activeControl ? "user" : controlHolder,
+              ...(!activeControl
+                ? {
+                    controlLeaseId: null,
+                    controlLeaseExpiresAt: null,
+                    controlBotId: null,
+                    controlRunId: null,
+                  }
+                : {}),
             }
           : {}),
       },
@@ -140,15 +145,17 @@ export async function provisionComputer(
     }
     return ref;
   } catch (error) {
-    const rollbackError = provisioned
-      ? await rollbackProvisionedComputer(deps.sandbox, provisioned, context, error)
-      : undefined;
+    // A failed reconnect never owns an existing workspace, even if setup failed.
+    const rollbackError =
+      provisioned && (!reconnecting || provisioned.fresh === true)
+        ? await rollbackProvisionedComputer(deps.sandbox, provisioned, context, error)
+        : undefined;
     try {
       await deps.prisma.computer.updateMany({
-        where: { id: computerId, state: "booting" },
+        where: { id: computerId, state: "booting", ...previousRef },
         data: {
-          state: "error",
-          ...(rollbackError && provisioned
+          state: reconnecting ? "running" : "error",
+          ...(!reconnecting && rollbackError && provisioned
             ? { providerRef: provisioned.providerRef, kind: provisioned.kind }
             : {}),
         },
@@ -167,73 +174,6 @@ export async function provisionComputer(
     }
     throw error;
   }
-}
-
-async function reconnectComputer(
-  deps: {
-    prisma: PrismaClient;
-    sandbox: SandboxProvider;
-    home: AgentHomeStore;
-    dataDir?: string;
-  },
-  computer: {
-    id: string;
-    homeKey: string;
-    providerRef: string | null;
-    kind: string;
-    scope: string;
-  },
-  homePath: string,
-  context: AdapterContext,
-): Promise<ComputerRef> {
-  const ref = await deps.sandbox.provision(
-    {
-      botId: computer.homeKey,
-      homePath,
-      providerRef: computer.providerRef ?? undefined,
-      providerKind: computer.kind as ComputerRef["kind"],
-    },
-    context,
-  );
-  const changedProvider = ref.providerRef !== computer.providerRef || ref.kind !== computer.kind;
-  const needsWorkspaceRestore = ref.fresh === true || changedProvider;
-  const ownsRef = ref.fresh === true;
-  try {
-    await deps.sandbox.prepare(ref, context);
-    if (needsWorkspaceRestore) {
-      await restoreComputerWorkspace(deps.home, deps.sandbox, computer.homeKey, ref, context);
-    }
-    await ensureComputerWorkspaceLayout(
-      deps.sandbox,
-      ref,
-      parseComputerMode(computer.scope),
-      context.botId,
-      context,
-    );
-    if (changedProvider) {
-      await deps.prisma.computer.update({
-        where: { id: computer.id },
-        data: {
-          providerRef: ref.providerRef,
-          kind: ref.kind,
-        },
-      });
-    }
-  } catch (error) {
-    // Only tear down a sandbox this reconnect created. A pre-existing ref
-    // (fresh: false) may belong to the user even when providerRef changed.
-    const rollbackError = ownsRef
-      ? await rollbackProvisionedComputer(deps.sandbox, ref, context, error)
-      : undefined;
-    if (rollbackError) {
-      throw new AggregateError(
-        [error, rollbackError],
-        "Computer reconnection failed and its replacement could not be rolled back",
-      );
-    }
-    throw error;
-  }
-  return ref;
 }
 
 async function waitForComputerReady(
@@ -504,11 +444,12 @@ export async function replaceComputer(
 
   const oldRef = existing.providerRef ? toComputerRef(existing) : null;
   try {
-    if (oldRef && existing.state === "running" && mode !== "reset") {
+    // Retry the checkpoint even after an earlier update left the row in error.
+    if (oldRef && (mode === "update" || (existing.state === "running" && mode === "recover"))) {
       try {
         await checkpointAndRecordComputerWorkspace(deps, existing, oldRef, context);
       } catch (error) {
-        if (mode !== "recover" && !isUnrecoverableSandboxError(error)) throw error;
+        if (mode !== "recover") throw error;
       }
     }
     if (oldRef) {
@@ -516,7 +457,7 @@ export async function replaceComputer(
       try {
         await deps.sandbox.destroy(oldRef, context);
       } catch (error) {
-        if (mode !== "recover" && !isUnrecoverableSandboxError(error)) throw error;
+        if (mode !== "recover") throw error;
       }
     }
     await deps.prisma.computer.update({

--- a/packages/adapters/src/computer-recovery.test.ts
+++ b/packages/adapters/src/computer-recovery.test.ts
@@ -213,4 +213,25 @@ describe("computer recovery preserves live work", () => {
       expect(await deps.home.readFile("bot", "notes.txt", context)).toBe("live work");
     },
   );
+
+  it("resets a missing computer after idempotent provider teardown", async () => {
+    const { deps, row, first } = await fixture();
+    await deps.sandbox.destroy(first, context);
+    const updated = await replaceComputer(deps, row.id, "reset", context);
+    expect(updated.fresh).toBe(true);
+    expect(row).toMatchObject({ state: "running", providerRef: updated.providerRef });
+    expect(
+      new TextDecoder().decode(await deps.sandbox.readFile(updated, "notes.txt", context)),
+    ).toBe("checkpoint");
+  });
+
+  it("preserves the reference when reset teardown fails ambiguously", async () => {
+    const { deps, row, first } = await fixture();
+    const failure = new Error("404: configuration file not found");
+    vi.spyOn(deps.sandbox, "destroy").mockRejectedValue(failure);
+    const provision = vi.spyOn(deps.sandbox, "provision");
+    await expect(replaceComputer(deps, row.id, "reset", context)).rejects.toBe(failure);
+    expect(provision).not.toHaveBeenCalled();
+    expect(row.providerRef).toBe(first.providerRef);
+  });
 });

--- a/packages/adapters/src/computer-recovery.test.ts
+++ b/packages/adapters/src/computer-recovery.test.ts
@@ -1,0 +1,216 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { AdapterContext, JobPublisher, SandboxProvider } from "@rakazo/adapter-kit";
+import type { PrismaClient, ThreadEvents } from "@rakazo/db";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ComputerBusyError, provisionComputer, replaceComputer } from "./computer-lifecycle.js";
+import { DesktopSandboxProvider } from "./desktop-sandbox.js";
+import { FakeSandboxProvider } from "./fake-sandbox.js";
+import { LocalAgentHomeStore } from "./home.js";
+
+const context = {
+  operationId: "recovery",
+  traceId: "recovery",
+  spaceId: "space",
+  userId: "user",
+  botId: "bot",
+  signal: new AbortController().signal,
+} satisfies AdapterContext;
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixture(provider: "fake" | "desktop" = "fake") {
+  const root = await mkdtemp(path.join(tmpdir(), "rakazo-recovery-"));
+  roots.push(root);
+  const sandbox: SandboxProvider =
+    provider === "desktop" ? new DesktopSandboxProvider({ root }) : new FakeSandboxProvider();
+  const home = new LocalAgentHomeStore(path.join(root, "homes"));
+  const first = await sandbox.provision({ botId: "bot", homePath: root }, context);
+  await home.writeFile("bot", "notes.txt", "checkpoint", context);
+  await sandbox.writeFile(
+    first,
+    { path: "notes.txt", content: new TextEncoder().encode("live work") },
+    context,
+  );
+  const row = {
+    id: "computer",
+    homeKey: "bot",
+    scope: "dedicated",
+    state: "running",
+    providerRef: first.providerRef as string | null,
+    kind: first.kind,
+    controlHolder: "none",
+    controlLeaseId: null,
+    homeRevision: "saved",
+  };
+  // Model the atomic scalar predicates used by claims, including stale references.
+  const computer = {
+    findUniqueOrThrow: vi.fn(async () => ({ ...row })),
+    updateMany: vi.fn(async ({ where, data }) => {
+      const matches = ["id", "state", "providerRef", "kind"].every(
+        (key) => !(key in where) || where[key] === row[key as keyof typeof row],
+      );
+      if (!matches) return { count: 0 };
+      Object.assign(row, data);
+      return { count: 1 };
+    }),
+    update: vi.fn(async ({ data }) => Object.assign(row, data)),
+  };
+  const deps = {
+    prisma: {
+      computer,
+      run: { findFirst: vi.fn().mockResolvedValue(null) },
+    } as unknown as PrismaClient,
+    sandbox,
+    home,
+    jobs: {} as JobPublisher,
+    events: {} as ThreadEvents,
+    dataDir: root,
+  };
+  return { deps, row, computer, first, root };
+}
+
+describe("computer recovery preserves live work", () => {
+  it("claims a running computer before concurrent workers can create competing replacements", async () => {
+    const { deps, row, computer, first } = await fixture();
+    await deps.sandbox.destroy(first, context);
+    row.providerRef = "missing-provider";
+    // Both workers read the original row before either claims it.
+    const original = { ...row };
+    computer.findUniqueOrThrow.mockResolvedValue(original);
+    const provision = vi.spyOn(deps.sandbox, "provision");
+    const restore = vi.spyOn(deps.sandbox, "importWorkspace");
+    const results = await Promise.allSettled([
+      provisionComputer(deps, row.id, context),
+      provisionComputer(deps, row.id, { ...context, botId: "other-bot" }),
+    ]);
+    const successful = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(successful).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.reason).toBeInstanceOf(ComputerBusyError);
+    expect(provision).toHaveBeenCalledOnce();
+    expect(restore).toHaveBeenCalledOnce();
+    expect(row.providerRef).toBe(successful[0]?.value.providerRef);
+    expect(row.state).toBe("running");
+  });
+
+  it("rejects a delayed reconnect whose original reference was already replaced", async () => {
+    const { deps, row, computer, first } = await fixture();
+    await deps.sandbox.destroy(first, context);
+    row.providerRef = "missing-provider";
+    const stale = { ...row };
+    const winner = await provisionComputer(deps, row.id, context);
+    await deps.sandbox.writeFile(
+      winner,
+      { path: "notes.txt", content: new TextEncoder().encode("winner work") },
+      context,
+    );
+    computer.findUniqueOrThrow.mockResolvedValue(stale);
+    const provision = vi.spyOn(deps.sandbox, "provision");
+    await expect(provisionComputer(deps, row.id, context)).rejects.toBeInstanceOf(
+      ComputerBusyError,
+    );
+    expect(provision).not.toHaveBeenCalled();
+    expect(row.providerRef).toBe(winner.providerRef);
+    expect(
+      new TextDecoder().decode(await deps.sandbox.readFile(winner, "notes.txt", context)),
+    ).toBe("winner work");
+  });
+
+  it("preserves the reference and workspace through an uncertain reconnect and a retry", async () => {
+    const { deps, row, first } = await fixture();
+    const error = new Error("fetch failed");
+    vi.spyOn(deps.sandbox, "provision").mockRejectedValueOnce(error);
+    const restore = vi.spyOn(deps.sandbox, "importWorkspace");
+    const destroy = vi.spyOn(deps.sandbox, "destroy");
+    await expect(provisionComputer(deps, row.id, context)).rejects.toBe(error);
+    expect(row).toMatchObject({ state: "running", providerRef: first.providerRef });
+    const reconnected = await provisionComputer(deps, row.id, context);
+    expect(reconnected).toMatchObject({ providerRef: first.providerRef, fresh: false });
+    expect(restore).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+    expect(
+      new TextDecoder().decode(await deps.sandbox.readFile(reconnected, "notes.txt", context)),
+    ).toBe("live work");
+  });
+
+  it.each(["running", "error", "stopped", "suspended"])(
+    "reconnects desktop files after an adapter restart from %s without importing an old checkpoint",
+    async (state) => {
+      const { deps, row, root, first } = await fixture("desktop");
+      row.state = state;
+      deps.sandbox = new DesktopSandboxProvider({ root });
+      const restore = vi.spyOn(deps.sandbox, "importWorkspace");
+      const reconnected = await provisionComputer(deps, row.id, context);
+      expect(reconnected).toMatchObject({ providerRef: first.providerRef, fresh: false });
+      expect(restore).not.toHaveBeenCalled();
+      expect(
+        new TextDecoder().decode(await deps.sandbox.readFile(reconnected, "notes.txt", context)),
+      ).toBe("live work");
+    },
+  );
+
+  it("restores the checkpoint when a desktop workspace is actually absent after restart", async () => {
+    const { deps, row, root, first } = await fixture("desktop");
+    expect(first.fresh).toBe(true);
+    await rm(first.providerRef, { recursive: true });
+    deps.sandbox = new DesktopSandboxProvider({ root });
+    const reconnected = await provisionComputer(deps, row.id, context);
+    expect(reconnected).toMatchObject({ providerRef: first.providerRef, fresh: true });
+    expect(
+      new TextDecoder().decode(await deps.sandbox.readFile(reconnected, "notes.txt", context)),
+    ).toBe("checkpoint");
+  });
+
+  it.each([
+    "Path notes.txt not found",
+    "404: file not found",
+    "command not found",
+    "checkpoint directory does not exist",
+    "export process killed",
+    "ECONNRESET",
+    "Sandbox not found",
+  ])("aborts update and its retry when checkpoint fails with %s", async (message) => {
+    const { deps, row, first } = await fixture();
+    const error = new Error(message);
+    vi.spyOn(deps.sandbox, "exportWorkspace").mockImplementation(async function* () {
+      yield { path: "notes.txt", content: new TextEncoder().encode("incomplete checkpoint") };
+      throw error;
+    });
+    const destroy = vi.spyOn(deps.sandbox, "destroy");
+    const provision = vi.spyOn(deps.sandbox, "provision");
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await expect(replaceComputer(deps, row.id, "update", context)).rejects.toBe(error);
+      expect(row).toMatchObject({
+        state: "error",
+        providerRef: first.providerRef,
+        homeRevision: "saved",
+      });
+    }
+    expect(destroy).not.toHaveBeenCalled();
+    expect(provision).not.toHaveBeenCalled();
+    expect(new TextDecoder().decode(await deps.sandbox.readFile(first, "notes.txt", context))).toBe(
+      "live work",
+    );
+    expect(await deps.home.readFile("bot", "notes.txt", context)).toBe("checkpoint");
+  });
+
+  it.each(["running", "error"])(
+    "updates a %s computer only after saving its current workspace",
+    async (state) => {
+      const { deps, row } = await fixture();
+      row.state = state;
+      const updated = await replaceComputer(deps, row.id, "update", context);
+      expect(updated.fresh).toBe(true);
+      expect(row).toMatchObject({ state: "running", providerRef: updated.providerRef });
+      expect(
+        new TextDecoder().decode(await deps.sandbox.readFile(updated, "notes.txt", context)),
+      ).toBe("live work");
+      expect(await deps.home.readFile("bot", "notes.txt", context)).toBe("live work");
+    },
+  );
+});

--- a/packages/adapters/src/daytona-sandbox.test.ts
+++ b/packages/adapters/src/daytona-sandbox.test.ts
@@ -212,6 +212,22 @@ describe("DaytonaSandboxProvider", () => {
     await expect(provider.stop(computer, context)).resolves.toBeUndefined();
   });
 
+  it("accepts definitive deletion while preserving transient teardown failures", async () => {
+    const fixture = daytonaFixture();
+    const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);
+    const computer = await provider.provision({ botId: "bot-a", homePath: "/unused" }, context);
+    const failure = new Error("temporary Daytona outage");
+    fixture.deleteSandbox.mockRejectedValueOnce(failure).mockRejectedValueOnce({ statusCode: 404 });
+
+    await expect(provider.destroy(computer, context)).rejects.toBe(failure);
+    await expect(provider.destroy(computer, context)).resolves.toBeUndefined();
+    expect(fixture.deleteSandbox).toHaveBeenCalledTimes(2);
+    // Subsequent teardown can also observe the missing resource during lookup.
+    fixture.get.mockRejectedValueOnce({ statusCode: 404 });
+    await expect(provider.destroy(computer, context)).resolves.toBeUndefined();
+    expect(fixture.deleteSandbox).toHaveBeenCalledTimes(2);
+  });
+
   it("gives Team bots distinct Daytona previews without a second computerUse.start", async () => {
     const fixture = daytonaFixture();
     const provider = new DaytonaSandboxProvider({ apiKey: "test-key" }, fixture.client);

--- a/packages/adapters/src/daytona-sandbox.ts
+++ b/packages/adapters/src/daytona-sandbox.ts
@@ -534,7 +534,12 @@ export class DaytonaSandboxProvider implements SandboxProvider {
       ),
     );
     this.forget(id);
-    await sandbox.delete(120, true);
+    try {
+      await sandbox.delete(120, true);
+    } catch (error) {
+      // Deletion is idempotent even when the sandbox disappears after lookup.
+      if (!isUnrecoverableDaytonaError(error)) throw error;
+    }
   }
 
   private ref(sandbox: Sandbox, botId: string, fresh: boolean): ComputerRef {

--- a/packages/adapters/src/desktop-sandbox.ts
+++ b/packages/adapters/src/desktop-sandbox.ts
@@ -96,13 +96,15 @@ export class DesktopSandboxProvider implements SandboxProvider {
       return { ...existing.ref, fresh: false };
     }
     const id = `desktop-${request.botId}`;
-    await mkdir(home, { recursive: true });
+    // Recursive mkdir returns undefined when the directory already exists. This
+    // survives adapter/process restarts and distinguishes live files from a new home.
+    const created = await mkdir(home, { recursive: true });
     const ref: ComputerRef = {
       id,
       botId: request.botId,
       kind: "desktop",
       providerRef: home,
-      fresh: true,
+      fresh: created !== undefined,
     };
     this.boxes.set(id, {
       ref,

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -7,7 +7,6 @@ import {
   type E2BSandboxSdk,
   ensureE2BPrimaryViewCommand,
   isSandboxGoneError,
-  isUnrecoverableSandboxError,
 } from "./e2b-sandbox.js";
 import { noVncProxyProcessPattern } from "./extra-displays.js";
 
@@ -129,29 +128,66 @@ describe("E2B computer backend", () => {
     expect(shouldSkipPortableWorkspaceFile(".browser-profiles/chromium/SingletonLock")).toBe(true);
   });
 
-  it("boots a fresh sandbox when reconnecting to a dead one fails with fetch failed", async () => {
+  it.each([
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "EAI_AGAIN",
+    "EHOSTUNREACH",
+    "ENETUNREACH",
+    "ENOTFOUND",
+    "UND_ERR_CONNECT_TIMEOUT",
+    "UND_ERR_SOCKET",
+    undefined,
+  ])("preserves an existing sandbox after a %s transport failure", async (code) => {
     const desktop = { sandboxId: "fresh-e2b-box" } as unknown as Sandbox;
+    const failure = new Error("fetch failed", {
+      cause: Object.assign(new Error("transport unavailable"), { code }),
+    });
     const sdk: E2BSandboxSdk = {
       create: vi.fn(async () => desktop),
-      connect: vi.fn(async () => {
-        throw new Error("fetch failed", {
-          cause: Object.assign(new Error("getaddrinfo ENOTFOUND dead-e2b-box.e2b.app"), {
-            code: "ENOTFOUND",
-          }),
-        });
-      }),
+      connect: vi.fn().mockRejectedValueOnce(failure).mockResolvedValue({ sandboxId: "existing" }),
       pause: vi.fn(async () => undefined),
     };
     const provider = new E2BSandboxProvider("test-key", sdk);
 
-    const computer = await provider.provision(
-      { botId: "bot-1", homePath: "/unused", providerRef: "dead-e2b-box", providerKind: "e2b" },
-      context,
-    );
+    const request = {
+      botId: "bot-1",
+      homePath: "/unused",
+      providerRef: "existing",
+      providerKind: "e2b" as const,
+    };
+    await expect(provider.provision(request, context)).rejects.toBe(failure);
+    expect(sdk.create).not.toHaveBeenCalled();
+    await expect(provider.provision(request, context)).resolves.toMatchObject({
+      providerRef: "existing",
+      fresh: false,
+    });
+    expect(sdk.create).not.toHaveBeenCalled();
+  });
 
-    expect(sdk.create).toHaveBeenCalledTimes(1);
-    expect(computer.providerRef).toBe("fresh-e2b-box");
-    expect(computer.fresh).toBe(true);
+  it("creates a replacement when the provider confirms the sandbox no longer exists", async () => {
+    const sdk: E2BSandboxSdk = {
+      create: vi.fn().mockResolvedValue({ sandboxId: "replacement" }),
+      connect: vi.fn().mockRejectedValue(
+        Object.assign(new Error("Sandbox not found"), {
+          name: "SandboxNotFoundError",
+        }),
+      ),
+      pause: vi.fn(),
+    };
+    const provider = new E2BSandboxProvider("test-key", sdk);
+    await expect(
+      provider.provision(
+        {
+          botId: "bot-1",
+          homePath: "/unused",
+          providerRef: "missing",
+          providerKind: "e2b",
+        },
+        context,
+      ),
+    ).resolves.toMatchObject({ providerRef: "replacement", fresh: true });
+    expect(sdk.create).toHaveBeenCalledOnce();
   });
 
   it("gives screen setup commands a real timeout and surfaces a failed one as unavailable", async () => {
@@ -809,7 +845,6 @@ describe("sandbox-gone detection", () => {
   it("recognises every sandbox-gone wording", () => {
     for (const error of gone) {
       expect(isSandboxGoneError(error), error.message).toBe(true);
-      expect(isUnrecoverableSandboxError(error), error.message).toBe(true);
     }
   });
 
@@ -819,10 +854,8 @@ describe("sandbox-gone detection", () => {
     }
   });
 
-  it("leaves the transport split alone", () => {
-    // a blip is handled by isUnreachableTransportError, and must never read as gone
+  it("does not interpret a transport failure as sandbox loss", () => {
     expect(isSandboxGoneError(new Error("fetch failed"))).toBe(false);
-    expect(isUnrecoverableSandboxError(new Error("fetch failed"))).toBe(false);
   });
 
   it("drops a cached handle whose sandbox died and reconnects", async () => {

--- a/packages/adapters/src/e2b-sandbox.test.ts
+++ b/packages/adapters/src/e2b-sandbox.test.ts
@@ -1,4 +1,5 @@
-import { type Sandbox, TimeoutError } from "@e2b/desktop";
+import { createServer } from "node:http";
+import { Sandbox, TimeoutError } from "@e2b/desktop";
 import { describe, expect, it, vi } from "vitest";
 import { ComputerScreenUnavailableError } from "./computer-screens.js";
 import { shouldSkipPortableWorkspaceFile } from "./computer-workspace.js";
@@ -189,6 +190,49 @@ describe("E2B computer backend", () => {
     ).resolves.toMatchObject({ providerRef: "replacement", fresh: true });
     expect(sdk.create).toHaveBeenCalledOnce();
   });
+
+  it.each([404, 503])(
+    "uses SDK deletion semantics for a cached handle receiving %s",
+    async (status) => {
+      const requests: string[] = [];
+      const server = createServer((request, response) => {
+        requests.push(`${request.method} ${request.url}`);
+        response.writeHead(status, { "content-type": "application/json" });
+        response.end(JSON.stringify({ code: status, message: "sandbox unavailable" }));
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") throw new Error("Missing test server address");
+        const desktop = new Sandbox({
+          sandboxId: "expired",
+          envdVersion: "0.1.0",
+          apiKey: "test-key",
+          validateApiKey: false,
+          debug: false,
+          proxy: "",
+          apiUrl: `http://127.0.0.1:${address.port}`,
+        });
+        const sdk: E2BSandboxSdk = {
+          create: vi.fn().mockResolvedValue(desktop),
+          connect: vi.fn(),
+          pause: vi.fn(),
+        };
+        const provider = new E2BSandboxProvider("test-key", sdk);
+        const computer = await provider.provision({ botId: "bot", homePath: "/unused" }, context);
+        if (status === 404) {
+          await expect(provider.destroy(computer, context)).resolves.toBeUndefined();
+        } else {
+          await expect(provider.destroy(computer, context)).rejects.toThrow();
+        }
+        expect(requests).toEqual(["DELETE /sandboxes/expired"]);
+        expect(sdk.connect).not.toHaveBeenCalled();
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  );
 
   it("gives screen setup commands a real timeout and surfaces a failed one as unavailable", async () => {
     const run = vi.fn(async (_command: string, opts?: { timeoutMs?: number }) => {

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -71,42 +71,6 @@ export function e2bCreateOptions(botId: string, apiKey: string) {
   };
 }
 
-// A sandbox that has expired stops resolving as a host, so reaching it fails at the socket
-// rather than with a 404. undici reports every one of those as a bare "fetch failed" and
-// hides the errno on the cause chain. Used only by provision reconnect: replaceComputer must
-// not treat these as permanent, or an update-mode checkpoint blip destroys the old box
-// without committing workspace changes that exist only there.
-const SANDBOX_UNREACHABLE_CODES = new Set([
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "EAI_AGAIN",
-  "EHOSTUNREACH",
-  "ENETUNREACH",
-  "ENOTFOUND",
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_SOCKET",
-]);
-
-export function isUnreachableTransportError(error: unknown): boolean {
-  for (let current = error; current instanceof Error; current = current.cause) {
-    const code = (current as { code?: unknown }).code;
-    if (typeof code === "string" && SANDBOX_UNREACHABLE_CODES.has(code)) return true;
-    if (current.message === "fetch failed") return true;
-  }
-  return false;
-}
-
-/**
- * True when the sandbox is permanently gone (404 / killed / not found). Used by
- * replaceComputer to decide whether to swallow checkpoint/destroy failures.
- * Transient transport errors stay recoverable so update/reset can abort without
- * discarding an uncommitted workspace on a still-reachable box.
- */
-export function isUnrecoverableSandboxError(error: unknown): boolean {
-  if (LEGACY_GONE_MESSAGE.test(errorMessage(error))) return true;
-  return isSandboxGoneError(error);
-}
-
 // How the E2B SDK words a sandbox that no longer exists. It does not always say "not found":
 // an expired sandbox surfaces as a TimeoutError about the *sandbox* timeout (502 / Unavailable
 // from envd), which used to read as a live sandbox and left every later call throwing forever.
@@ -114,14 +78,7 @@ const SANDBOX_GONE_MESSAGE =
   /probably not running anymore|likely due to sandbox timeout|killed or reached its end of life|sandbox [^:]{0,60}not found|sandbox [^:]{0,60}does not exist/i;
 // The same words from a live sandbox: a missing binary or a missing file inside it.
 const SHELL_MISSING_TARGET = /command not found|no such file|^path .* not found/i;
-const LEGACY_GONE_MESSAGE =
-  /not found|does not exist|404|not_found|killed|doesn't exist|sandbox not found/i;
-
-/**
- * Narrower than isUnrecoverableSandboxError: the provider itself said this sandbox is gone.
- * A missing binary or a missing file inside a live sandbox is not proof of death, so callers
- * that persist "the sandbox is gone" must use this one.
- */
+/** Only provider-specific evidence of sandbox loss permits automatic replacement. */
 export function isSandboxGoneError(error: unknown): boolean {
   const message = errorMessage(error);
   if (SHELL_MISSING_TARGET.test(message)) return false;
@@ -303,10 +260,8 @@ export class E2BSandboxProvider implements SandboxProvider {
         };
       } catch (error) {
         this.boxes.delete(request.providerRef);
-        // Permanent gone (404/killed) or unreachable transport: boot fresh. Other errors rethrow.
-        if (!isUnrecoverableSandboxError(error) && !isUnreachableTransportError(error)) {
-          throw error;
-        }
+        // A transport failure says nothing about the workspace still on the server.
+        if (!isSandboxGoneError(error)) throw error;
       }
     }
     const desktop = await this.sdk.create(e2bCreateOptions(request.botId, this.apiKey));

--- a/packages/adapters/src/e2b-sandbox.ts
+++ b/packages/adapters/src/e2b-sandbox.ts
@@ -645,6 +645,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     ]);
     this.forget(id);
     await settleForTeardown(pending);
+    // The SDK returns false when the sandbox is already gone; teardown is complete.
     await desktop?.kill();
   }
 

--- a/packages/adapters/src/sandbox-faults.test.ts
+++ b/packages/adapters/src/sandbox-faults.test.ts
@@ -123,7 +123,7 @@ describe.each([
     expect((await provider.observe(computer, context)).activeWindow).toEqual(before.activeWindow);
   });
 
-  it("stops idempotently, resumes the same machine, and provisions fresh after destroy", async () => {
+  it("stops idempotently and reports whether provisioning reuses workspace files", async () => {
     const provider = await makeProvider();
     const request = { botId: "lifecycle", homePath: "/unused" };
     const first = await provisionPrepared(provider, request, context);
@@ -148,7 +148,18 @@ describe.each([
     await provider.destroy(resumed, context);
     await provider.destroy(resumed, context);
     const replacement = await provisionPrepared(provider, request, context);
-    expect(replacement.fresh).toBe(true);
+    if (provider instanceof DesktopSandboxProvider) {
+      // A configured desktop root retains its workspace through destroy.
+      expect(replacement.fresh).toBe(false);
+      expect(
+        new TextDecoder().decode(await provider.readFile(replacement, "state.txt", context)),
+      ).toBe("preserved");
+    } else {
+      expect(replacement.fresh).toBe(true);
+      await expect(provider.readFile(replacement, "state.txt", context)).rejects.toThrow(
+        /not found/i,
+      );
+    }
     await provider.destroy(replacement, context);
   });
 


### PR DESCRIPTION
## Why

Reconnect and update must preserve work newer than the durable checkpoint. Four paths could lose access to that work: an E2B transport failure could allocate a replacement, concurrent reconnects could overwrite the saved provider reference, a missing-file checkpoint error could let update destroy the computer, and a desktop adapter restart could restore an old checkpoint over existing files.

These are conditional data-integrity and availability defects, assessed as medium severity. They require the affected provider, overlapping authorized lifecycle operations, or a checkpoint failure/restart; this review found no unauthenticated takeover path. The shared lifecycle affects every client using the backend; the E2B and desktop changes apply only when those providers are selected.

## What changed

- F086: propagate uncertain E2B reconnect errors and allow retry against the existing reference. Automatic replacement uses the existing sandbox-specific loss detection instead of generic transport or missing-resource text.
- F103: reconnect through the same database boot claim as provisioning. Compare the previous provider reference and kind on claim, activation, and failure recording. Preserve an existing workspace when reconnect setup fails.
- F104: require a successful checkpoint before update teardown, including retries from an error state. Ambiguous teardown failures also abort update/reset. Explicit recovery retains its existing fallback behavior.
- F121: use directory creation to distinguish a new desktop workspace from one that survived an adapter restart, so existing files are not restored from an older checkpoint.

The lifecycle no longer imports E2B error classification. Daytona also treats a resource that disappears between lookup and deletion as already deleted, while preserving transient teardown errors. No provider contract, database migration, or UI copy is added.

Checked current main and existing PRs before implementation. #661 covers abandoned boot claims after a worker crash; it does not fix these running reconnect, checkpoint, or desktop paths. This PR leaves that recovery work separate.

## Validation

- All 143 focused lifecycle, recovery, E2B, Daytona, idle, and sandbox conformance unit tests pass with two workers. Regressions use fake providers, injected SDK responses, and temporary workspaces.
- Thirteen targeted regression cases fail against the original main implementation, covering all four findings.
- Adapters typecheck and the workspace typecheck pass. Repository lint passes with existing warnings.
- Offline cases cover reconnect transport errors and retry, concurrent/stale references, preservation after desktop restart, restoration when the directory is absent, partial checkpoint failures and update retries, and successful checkpoint-before-update behavior.
- Actual E2B SDK deletion is tested against a temporary local HTTP fixture: missing-sandbox deletion succeeds and service failure propagates.
- No live providers or production systems were used. Electron E2E is left to CI.

## Final CI and review

Lint, typecheck, the full unit suite, Postgres journeys, web E2E, production builds including Electron smoke, and all three image validation jobs pass on the latest commit. Greptile completed its latest review with no remaining blockers; all review threads are resolved. CodeRabbit ended its runs without a review because the shared review quota was exhausted, despite reporting a successful check status.

The PR remains open and unmerged, with auto-merge disabled.
