### PR TITLE
fix(screen): sandbox proxied documents on direct navigation

### DIFF
--- a/apps/web/e2e/screen-proxy-isolation.spec.ts
+++ b/apps/web/e2e/screen-proxy-isolation.spec.ts
@@ -1,0 +1,183 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createServer as createHttpServer, type Server } from "node:http";
+import type { AddressInfo, Server as NetServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { createServer, type Plugin, preview, type ViteDevServer } from "vite";
+import { addScreenProxyCapability } from "../../api/src/screen-proxy";
+
+const secret = "fake-screen-proxy-browser-test-secret";
+const screenHtml = `<!doctype html><title>Fake screen</title>
+<script type="module">
+  import { loaded } from './core/rfb.js';
+  const attempt = (read) => { try { return read(); } catch { return 'blocked'; } };
+  const result = {
+    asset: loaded,
+    cookie: attempt(() => document.cookie),
+    storage: attempt(() => localStorage.getItem('app-data')),
+    parent: attempt(() => parent.document.title),
+    api: await fetch('/session', { credentials: 'include' }).then(r => r.text()).catch(() => 'blocked'),
+  };
+  const socketUrl = new URL('./websockify', location.href);
+  socketUrl.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const socket = new WebSocket(socketUrl);
+  socket.onmessage = (event) => {
+    result.socket = event.data;
+    socket.close();
+    document.body.textContent = JSON.stringify(result);
+  };
+</script><body></body>`;
+
+async function listen(server: NetServer) {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+async function close(server: Server) {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+}
+
+for (const mode of ["development", "preview"] as const) {
+  test.describe(`screen response isolation in ${mode}`, () => {
+    let origin: string;
+    let screenUrl: string;
+    let stop: () => Promise<void>;
+
+    test.beforeAll(async () => {
+      const root = await mkdtemp(path.join(tmpdir(), "rakazo-screen-test-"));
+      await mkdir(path.join(root, "dist"));
+      const upstream = createHttpServer((req, res) => {
+        // Even a listener explicitly requesting same-origin access cannot loosen the proxy policy.
+        res.setHeader(
+          "Content-Security-Policy",
+          `sandbox allow-scripts allow-same-origin allow-pointer-lock; frame-ancestors ${origin}`,
+        );
+        res.setHeader("Set-Cookie", "app-session=attacker; Path=/");
+        if (req.url === "/core/rfb.js") {
+          res.setHeader("Content-Type", "text/javascript");
+          res.end('export const loaded = "module loaded";');
+        } else {
+          res.setHeader("Content-Type", "text/html");
+          res.end(screenHtml);
+        }
+      });
+      upstream.on("upgrade", (req, socket) => {
+        const accept = createHash("sha1")
+          .update(`${req.headers["sec-websocket-key"]}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+          .digest("base64");
+        socket.write(
+          `HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\nSet-Cookie: app-session=attacker; Path=/\r\n\r\n`,
+        );
+        socket.write(Buffer.from([0x81, 2, 111, 107]));
+        socket.on("data", () => socket.end(Buffer.from([0x88, 0])));
+        socket.on("error", () => socket.destroy());
+      });
+      const upstreamOrigin = await listen(upstream);
+
+      const appFixture: Plugin = {
+        name: "fake-app-origin",
+        configureServer: installApp,
+        configurePreviewServer: installApp,
+      };
+      function installApp(server: Pick<ViteDevServer, "middlewares">) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url === "/app") {
+            res.setHeader("Content-Type", "text/html");
+            res.end(
+              '<!doctype html><title>Fake app</title><body><script>localStorage.setItem("app-data", "private-app-data"); document.cookie = "app-session=fake-session; Path=/";</script></body>',
+            );
+          } else if (req.url === "/session") {
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify({ cookie: req.headers.cookie ?? null }));
+          } else next();
+        });
+      }
+      const previousSecret = process.env.SCREEN_PROXY_SECRET;
+      process.env.SCREEN_PROXY_SECRET = secret;
+      try {
+        // Load the real configuration: both production and development hooks must install the policy.
+        const config = {
+          root,
+          configFile: path.resolve(import.meta.dirname, "../vite.config.ts"),
+          mode: "test",
+          plugins: [appFixture],
+          logLevel: "silent" as const,
+          server: { host: "127.0.0.1", port: 0, hmr: false as const },
+          preview: { host: "127.0.0.1", port: 0 },
+        };
+        const server = mode === "development" ? await createServer(config) : await preview(config);
+        // listen() replaces zero with Vite's default port; bind the HTTP server directly instead.
+        if ("listen" in server) await listen(server.httpServer!);
+        origin = `http://127.0.0.1:${(server.httpServer!.address() as AddressInfo).port}`;
+        // Exercise the same capability issuer used by the production API, with a configured web origin.
+        screenUrl = addScreenProxyCapability(`${upstreamOrigin}/embed.html`, secret, origin);
+        stop = async () => {
+          await server.close();
+          await close(upstream);
+          await rm(root, { recursive: true, force: true });
+        };
+      } finally {
+        if (previousSecret === undefined) delete process.env.SCREEN_PROXY_SECRET;
+        else process.env.SCREEN_PROXY_SECRET = previousSecret;
+      }
+    });
+
+    test.afterAll(async () => {
+      await stop?.();
+    });
+
+    test("direct navigation cannot read application data while assets and WebSockets work", async ({
+      page,
+    }) => {
+      await page.goto(`${origin}/app`);
+      const response = await page.goto(screenUrl);
+      await expect(page.locator("body")).toContainText('"socket":"ok"');
+      const result = JSON.parse(await page.locator("body").innerText());
+      expect(result).toMatchObject({
+        asset: "module loaded",
+        socket: "ok",
+        cookie: "blocked",
+        storage: "blocked",
+        api: "blocked",
+      });
+      expect(response?.headers()["content-security-policy"]).toContain(
+        "sandbox allow-scripts allow-pointer-lock",
+      );
+      expect(
+        (await page.context().cookies(origin)).find((c) => c.name === "app-session")?.value,
+      ).toBe("fake-session");
+    });
+
+    for (const sandbox of ["allow-scripts allow-pointer-lock", null]) {
+      test(`iframe remains isolated with sandbox attribute ${sandbox ?? "absent"}`, async ({
+        page,
+      }) => {
+        await page.goto(`${origin}/app`);
+        await page.evaluate(
+          ({ url, sandbox }) => {
+            const frame = document.createElement("iframe");
+            if (sandbox !== null) frame.setAttribute("sandbox", sandbox);
+            frame.src = url;
+            document.body.append(frame);
+          },
+          { url: screenUrl, sandbox },
+        );
+        const body = page.frameLocator("iframe").locator("body");
+        await expect(body).toContainText('"socket":"ok"');
+        expect(JSON.parse(await body.innerText())).toEqual({
+          asset: "module loaded",
+          socket: "ok",
+          cookie: "blocked",
+          storage: "blocked",
+          parent: "blocked",
+          api: "blocked",
+        });
+      });
+    }
+  });
+}

--- a/apps/web/playwright.screen-proxy.config.ts
+++ b/apps/web/playwright.screen-proxy.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "@playwright/test";
+
+// These local fixtures exercise the real Vite proxy without starting an API, database, or Electron.
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "screen-proxy-isolation.spec.ts",
+  workers: 1,
+  use: { headless: true },
+});

--- a/apps/web/src/screen-proxy.test.ts
+++ b/apps/web/src/screen-proxy.test.ts
@@ -1,11 +1,6 @@
 import { createCipheriv, createHash, createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import {
-  resolveNovncTarget,
-  safeProxyHeaders,
-  safeProxyResponseHeaders,
-  stripSensitiveHandshakeHeaders,
-} from "./screen-proxy.js";
+import { resolveNovncTarget, safeProxyHeaders } from "./screen-proxy.js";
 
 function signedPath(
   port: number,
@@ -125,24 +120,5 @@ describe("noVNC proxy authorization", () => {
         "sec-websocket-key": "key",
       }),
     ).toEqual({ upgrade: "websocket", "sec-websocket-key": "key" });
-  });
-
-  it("does not accept cookie or site-data mutations from a bot computer", () => {
-    expect(
-      safeProxyResponseHeaders({
-        ":status": "200",
-        "content-type": "text/html",
-        "set-cookie": ["session=attacker"],
-        "clear-site-data": '"cookies"',
-      }),
-    ).toEqual({ "content-type": "text/html" });
-
-    const handshake = Buffer.from(
-      "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nSet-Cookie: session=attacker\r\n\r\nframe",
-      "latin1",
-    );
-    expect(stripSensitiveHandshakeHeaders(handshake)?.toString("latin1")).toBe(
-      "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\nframe",
-    );
   });
 });

--- a/apps/web/src/screen-proxy.ts
+++ b/apps/web/src/screen-proxy.ts
@@ -8,7 +8,6 @@ const SENSITIVE_FORWARD_HEADERS = new Set([
   "proxy-authenticate",
   "proxy-authorization",
 ]);
-const SENSITIVE_RESPONSE_HEADERS = new Set(["clear-site-data", "set-cookie", "set-cookie2"]);
 const SCREEN_PROXY_CIPHER = "aes-256-gcm";
 
 export function resolveNovncTarget(url: string | undefined, secret: string, now = Date.now()) {
@@ -132,32 +131,4 @@ export function safeProxyHeaders(headers: IncomingHttpHeaders) {
       );
     }),
   );
-}
-
-export function safeProxyResponseHeaders(headers: IncomingHttpHeaders) {
-  return Object.fromEntries(
-    Object.entries(headers).filter(([key, value]) => {
-      return (
-        value != null &&
-        !isHttp2PseudoHeader(key) &&
-        !SENSITIVE_RESPONSE_HEADERS.has(key.toLowerCase())
-      );
-    }),
-  );
-}
-
-export function stripSensitiveHandshakeHeaders(response: Buffer) {
-  const end = response.indexOf("\r\n\r\n");
-  if (end < 0) return null;
-  const lines = response.subarray(0, end).toString("latin1").split("\r\n");
-  const safeLines = lines.filter((line, index) => {
-    if (index === 0) return true;
-    const separator = line.indexOf(":");
-    const name = separator < 0 ? line : line.slice(0, separator);
-    return !SENSITIVE_RESPONSE_HEADERS.has(name.trim().toLowerCase());
-  });
-  return Buffer.concat([
-    Buffer.from(`${safeLines.join("\r\n")}\r\n\r\n`, "latin1"),
-    response.subarray(end + 4),
-  ]);
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,16 +6,15 @@ import path from "node:path";
 import tls from "node:tls";
 import { lingui } from "@lingui/vite-plugin";
 import type { DesktopStackProbeResponse } from "@rakazo/contracts";
+import {
+  safeScreenProxyResponseHeaders,
+  stripSensitiveHandshakeHeaders,
+} from "@rakazo/core/node/screen-proxy-response";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv, type PreviewServer, type ViteDevServer } from "vite";
 import { resolveScreenProxySecret } from "../../packages/core/src/secrets-guard.ts";
-import {
-  resolveNovncTarget,
-  safeProxyHeaders,
-  safeProxyResponseHeaders,
-  stripSensitiveHandshakeHeaders,
-} from "./src/screen-proxy.js";
+import { resolveNovncTarget, safeProxyHeaders } from "./src/screen-proxy.js";
 
 const webPort = Number(process.env.WEB_PORT ?? 5173);
 const DESKTOP_STACK_PROBE_PATH = "/.well-known/rakazo-desktop-stack";
@@ -81,10 +80,7 @@ function attachNovncProxy(server: ViteDevServer | PreviewServer, secret: string)
         ...(target.protocol === "https:" ? { servername: target.hostname } : {}),
       },
       (incoming) => {
-        res.writeHead(incoming.statusCode ?? 502, {
-          ...safeProxyResponseHeaders(incoming.headers),
-          "access-control-allow-origin": "*",
-        });
+        res.writeHead(incoming.statusCode ?? 502, safeScreenProxyResponseHeaders(incoming.headers));
         incoming.pipe(res);
       },
     );

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,11 @@
       "development": "./src/approval-effect-key.ts",
       "default": "./src/approval-effect-key.ts"
     },
+    "./node/screen-proxy-response": {
+      "types": "./src/node/screen-proxy-response.ts",
+      "development": "./src/node/screen-proxy-response.ts",
+      "default": "./src/node/screen-proxy-response.ts"
+    },
     "./plot": {
       "types": "./src/plot/plot-spec.ts",
       "development": "./src/plot/plot-spec.ts",

--- a/packages/core/src/node/screen-proxy-response.test.ts
+++ b/packages/core/src/node/screen-proxy-response.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  safeScreenProxyResponseHeaders,
+  stripSensitiveHandshakeHeaders,
+} from "./screen-proxy-response.js";
+
+describe("screen proxy response isolation", () => {
+  it.each(["text/html", "application/xhtml+xml", "image/svg+xml", "text/javascript", undefined])(
+    "sandboxes every response, including direct navigation with content type %s",
+    (contentType) => {
+      const headers = safeScreenProxyResponseHeaders({ "content-type": contentType });
+      expect(headers["content-security-policy"]).toEqual([
+        "sandbox allow-scripts allow-pointer-lock",
+      ]);
+      expect(headers["access-control-allow-origin"]).toBe("*");
+      expect(headers["content-type"]).toBe(contentType);
+    },
+  );
+
+  it("retains upstream restrictions as separate policies that cannot loosen the sandbox", () => {
+    const policies = [
+      "sandbox allow-same-origin allow-scripts",
+      "frame-ancestors https://app.example",
+    ];
+    expect(safeScreenProxyResponseHeaders({ "Content-Security-Policy": policies })).toEqual({
+      "content-security-policy": [...policies, "sandbox allow-scripts allow-pointer-lock"],
+      "access-control-allow-origin": "*",
+    });
+    expect(policies).toHaveLength(2);
+    expect(
+      safeScreenProxyResponseHeaders({ "content-security-policy": "script-src 'self'" })[
+        "content-security-policy"
+      ],
+    ).toEqual(["script-src 'self'", "sandbox allow-scripts allow-pointer-lock"]);
+  });
+
+  it("preserves asset and framing headers while dropping origin mutations and pseudo-headers", () => {
+    expect(
+      safeScreenProxyResponseHeaders({
+        ":status": "200",
+        "content-type": "text/javascript",
+        "content-encoding": "gzip",
+        "cache-control": "max-age=3600",
+        "x-frame-options": "SAMEORIGIN",
+        "Set-Cookie": ["session=attacker"],
+        "set-cookie2": "session=attacker",
+        "Clear-Site-Data": '"cookies"',
+        "access-control-allow-origin": "https://upstream.example",
+      }),
+    ).toEqual({
+      "content-type": "text/javascript",
+      "content-encoding": "gzip",
+      "cache-control": "max-age=3600",
+      "x-frame-options": "SAMEORIGIN",
+      "content-security-policy": ["sandbox allow-scripts allow-pointer-lock"],
+      "access-control-allow-origin": "*",
+    });
+  });
+
+  it("preserves WebSocket negotiation and bytes without accepting origin mutations", () => {
+    const handshake = Buffer.from(
+      'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: fake-accept\r\nSet-Cookie: session=attacker\r\nClear-Site-Data: "cookies"\r\n\r\n\u0082\u0001x',
+      "latin1",
+    );
+    expect(stripSensitiveHandshakeHeaders(handshake)?.toString("latin1")).toBe(
+      "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: fake-accept\r\n\r\n\u0082\u0001x",
+    );
+    expect(stripSensitiveHandshakeHeaders(Buffer.from("HTTP/1.1 101"))).toBeNull();
+  });
+});

--- a/packages/core/src/node/screen-proxy-response.ts
+++ b/packages/core/src/node/screen-proxy-response.ts
@@ -1,0 +1,41 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+const SENSITIVE_RESPONSE_HEADERS = new Set(["clear-site-data", "set-cookie", "set-cookie2"]);
+const SCREEN_SANDBOX = "sandbox allow-scripts allow-pointer-lock";
+
+/** Screen listeners are untrusted even when their capability URL is opened outside an iframe. */
+export function safeScreenProxyResponseHeaders(headers: IncomingHttpHeaders) {
+  const safe: IncomingHttpHeaders = {};
+  const policies: string[] = [];
+  for (const [key, value] of Object.entries(headers)) {
+    const name = key.toLowerCase();
+    if (value == null || name.startsWith(":") || SENSITIVE_RESPONSE_HEADERS.has(name)) continue;
+    if (name === "content-security-policy") {
+      policies.push(...(Array.isArray(value) ? value : [value]));
+    } else {
+      safe[name] = value;
+    }
+  }
+  // Separate CSP policies intersect. An upstream allow-same-origin cannot relax this sandbox,
+  // and existing provider restrictions (including frame-ancestors) remain in force.
+  safe["content-security-policy"] = [...policies, SCREEN_SANDBOX];
+  // Module imports from the opaque sandbox origin still need access to noVNC assets.
+  safe["access-control-allow-origin"] = "*";
+  return safe;
+}
+
+export function stripSensitiveHandshakeHeaders(response: Buffer) {
+  const end = response.indexOf("\r\n\r\n");
+  if (end < 0) return null;
+  const lines = response.subarray(0, end).toString("latin1").split("\r\n");
+  const safeLines = lines.filter((line, index) => {
+    if (index === 0) return true;
+    const separator = line.indexOf(":");
+    const name = separator < 0 ? line : line.slice(0, separator);
+    return !SENSITIVE_RESPONSE_HEADERS.has(name.trim().toLowerCase());
+  });
+  return Buffer.concat([
+    Buffer.from(`${safeLines.join("\r\n")}\r\n\r\n`, "latin1"),
+    response.subarray(end + 4),
+  ]);
+}


### PR DESCRIPTION
Screen HTML served behind a signed capability URL inherits the application origin when opened directly, bypassing the iframe sandbox. A controlled screen listener and a signed-in user opening a valid capability URL can therefore expose app-origin data and authenticated API responses. This is a conditional high-impact issue; changing desktop pixels alone is insufficient, and Docker already mounts bundled noVNC files read-only.

Add a shared response policy in `@rakazo/core` that enforces `sandbox allow-scripts allow-pointer-lock` as a separate CSP policy on every proxied HTTP response. Existing upstream CSP and framing restrictions remain intact, and upstream policy cannot restore same-origin access. Keep module CORS access, response cookie filtering, and WebSocket negotiation intact.

Production Compose serves screen content through Vite preview; the API issues capabilities using the configured web origin and does not have a separate screen response route. The same policy covers development, production preview, and proxied URLs loaded by web, Electron, and mobile. The browser regressions exercise the real Vite configuration with API-issued capabilities and local fake listeners.

Validation:

- Seventeen focused unit tests passed for capability issuance, authorization, response isolation, and handshake filtering.
- Six headless Chromium regressions passed with one worker, covering direct navigation and frames with and without the iframe sandbox in development and preview. Module imports, WebSocket traffic, and configured framing remain usable while cookie, storage, parent-DOM, and app-response reads are blocked.
- Removing only the response sandbox made both direct-navigation tests fail by exposing fake cookie, storage, and authenticated response data; restoring it passed the suite.
- Core and web typechecks, a standalone typecheck of the new browser fixtures, and lint of changed files passed.
- An additional standalone check of the Vite configuration reports existing `protocol` property typing errors in target resolution; the configuration is outside the normal web typecheck. Provider-backed and native rendering were not exercised locally; Electron E2E remains with CI.
