### PR TITLE
Support Qwen thinking through existing compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,9 @@ RAKAZO_LOCAL_MODELS=
 RAKAZO_LOCAL_MODELS_URL=http://127.0.0.1:11434/v1
 RAKAZO_LOCAL_CONTEXT_WINDOW=32768
 RAKAZO_LOCAL_MAX_TOKENS=4096
+# Optional exact model IDs using Qwen chat-template thinking (comma-separated).
+# Applies to local and user-connected OpenAI-compatible models. Restart after changing.
+RAKAZO_OPENAI_COMPAT_QWEN_MODELS=
 # Allow user-connected OpenAI-compatible endpoints on public hostnames (default: private/loopback only).
 RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=
 E2B_API_KEY=

--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -1,10 +1,61 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+import type { ModelCatalogEntry } from "@rakazo/contracts";
+import { captureScreenshot, completeOnboarding, rpc, signup } from "./helpers";
 
 const LOCAL_MODEL_ID = "rakazo-e2e-local";
 const LOCAL_MODEL_REPLY = "OpenAI-compatible endpoint verified end to end.";
+
+test("custom reasoning models keep endpoint choices scoped and save thinking", async ({
+  page,
+}, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `qwen-model-${stamp}@rakazo.test`, "password12", "Qwen model");
+  await completeOnboarding(page);
+  await rpc(page, "models/connect", {
+    provider: "openai-compatible",
+    baseUrl: "http://127.0.0.1:8090/v1",
+    modelId: "test-qwen",
+  });
+  // The adapter tests verify this metadata comes from the operator's opt-in.
+  // Supply it here without changing the shared test server's environment.
+  await page.route("**/rpc/models/list", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as { json: ModelCatalogEntry[] };
+    const template = body.json.find((entry) => entry.provider === "openai-compatible")!;
+    for (const id of ["test-qwen", "other-endpoint-model"]) {
+      body.json.push({
+        ...template,
+        id,
+        label: id,
+        placeholder: true,
+        reasoning: true,
+        thinkingLevels: ["off", "minimal", "low", "medium", "high"],
+      });
+    }
+    await route.fulfill({ response, json: body });
+  });
+  await page.reload();
+  await page.locator("main").getByRole("button", { name: "Chief", exact: true }).click();
+  const settings = page.getByTestId("bot-settings");
+  await settings.getByText("Advanced", { exact: true }).click();
+  const model = settings.getByLabel("Model", { exact: true });
+  await expect(model).toContainText("test-qwen");
+  await expect(model).not.toContainText("other-endpoint-model");
+  const thinking = settings.getByLabel("Thinking", { exact: true });
+  await thinking.selectOption("low");
+  await captureScreenshot(page, testInfo, "openai-compatible-qwen-thinking");
+  const saved = page.waitForResponse(
+    (response) => response.url().includes("/rpc/bots/update") && response.ok(),
+  );
+  await settings.getByRole("button", { name: "Save", exact: true }).click();
+  await saved;
+  await page.reload();
+  await page.locator("main").getByRole("button", { name: "Chief", exact: true }).click();
+  await settings.getByText("Advanced", { exact: true }).click();
+  await expect(thinking).toHaveValue("low");
+});
 
 test("connects, lists, and uses an OpenAI-compatible endpoint", async ({ page }, testInfo) => {
   const server = createServer((request, response) => {

--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -45,6 +45,7 @@ test("custom reasoning models keep endpoint choices scoped and save thinking", a
   await expect(model).not.toContainText("other-endpoint-model");
   const thinking = settings.locator("label:has-text('Thinking') select");
   await thinking.selectOption("low");
+  await thinking.scrollIntoViewIfNeeded();
   await captureScreenshot(page, testInfo, "openai-compatible-qwen-thinking");
   const saved = page.waitForResponse(
     (response) => response.url().includes("/rpc/bots/update") && response.ok(),

--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -13,17 +13,16 @@ test("custom reasoning models keep endpoint choices scoped and save thinking", a
   const stamp = Date.now();
   await signup(page, `qwen-model-${stamp}@rakazo.test`, "password12", "Qwen model");
   await completeOnboarding(page);
-  await rpc(page, "models/connect", {
-    provider: "openai-compatible",
-    baseUrl: "http://127.0.0.1:8090/v1",
-    modelId: "test-qwen",
-  });
-  // The adapter tests verify this metadata comes from the operator's opt-in.
-  // Supply it here without changing the shared test server's environment.
+  // Inject catalog metadata before reload/settings so thinking levels are present
+  // when Advanced opens. Adapter tests cover the operator env opt-in itself.
   await page.route("**/rpc/models/list", async (route) => {
     const response = await route.fetch();
     const body = (await response.json()) as { json: ModelCatalogEntry[] };
-    const template = body.json.find((entry) => entry.provider === "openai-compatible")!;
+    const template = body.json.find((entry) => entry.provider === "openai-compatible");
+    if (!template) {
+      await route.fulfill({ response });
+      return;
+    }
     for (const id of ["test-qwen", "other-endpoint-model"]) {
       body.json.push({
         ...template,
@@ -36,14 +35,31 @@ test("custom reasoning models keep endpoint choices scoped and save thinking", a
     }
     await route.fulfill({ response, json: body });
   });
+  // Keyless connect: no live mock server required for openai-compatible credentials.
+  await rpc(page, "models/connect", {
+    provider: "openai-compatible",
+    baseUrl: "http://127.0.0.1:8090/v1",
+    modelId: "test-qwen",
+  });
   await page.reload();
   await page.locator("main").getByRole("button", { name: "Chief", exact: true }).click();
   const settings = page.getByTestId("bot-settings");
-  await settings.getByText("Advanced", { exact: true }).click();
-  const model = settings.locator("label:has-text('Model') select");
+  await expect(settings).toBeVisible();
+  const advanced = settings.getByTestId("bot-settings-advanced");
+  await advanced.evaluate((element) => {
+    (element as HTMLDetailsElement).open = true;
+  });
+  // NativeSelect sits inside a wrapping <label>, so label text includes option
+  // copy and getByLabel(..., { exact: true }) misses the control. Use the
+  // combobox accessible name, matching other model E2E tests.
+  const model = settings.getByRole("combobox", { name: "Model", exact: true });
+  await expect(model).toBeVisible();
   await expect(model).toContainText("test-qwen");
   await expect(model).not.toContainText("other-endpoint-model");
-  const thinking = settings.locator("label:has-text('Thinking') select");
+  // Value key — not a /test-qwen/ label match, which also hits "Space default (test-qwen)".
+  await model.selectOption("openai-compatible::test-qwen");
+  const thinking = settings.getByRole("combobox", { name: "Thinking", exact: true });
+  await expect(thinking).toBeVisible();
   await thinking.selectOption("low");
   await thinking.scrollIntoViewIfNeeded();
   await captureScreenshot(page, testInfo, "openai-compatible-qwen-thinking");
@@ -54,7 +70,10 @@ test("custom reasoning models keep endpoint choices scoped and save thinking", a
   await saved;
   await page.reload();
   await page.locator("main").getByRole("button", { name: "Chief", exact: true }).click();
-  await settings.getByText("Advanced", { exact: true }).click();
+  await expect(settings).toBeVisible();
+  await advanced.evaluate((element) => {
+    (element as HTMLDetailsElement).open = true;
+  });
   await expect(thinking).toHaveValue("low");
 });
 

--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -40,10 +40,10 @@ test("custom reasoning models keep endpoint choices scoped and save thinking", a
   await page.locator("main").getByRole("button", { name: "Chief", exact: true }).click();
   const settings = page.getByTestId("bot-settings");
   await settings.getByText("Advanced", { exact: true }).click();
-  const model = settings.getByLabel("Model", { exact: true });
+  const model = settings.locator("label:has-text('Model') select");
   await expect(model).toContainText("test-qwen");
   await expect(model).not.toContainText("other-endpoint-model");
-  const thinking = settings.getByLabel("Thinking", { exact: true });
+  const thinking = settings.locator("label:has-text('Thinking') select");
   await thinking.selectOption("low");
   await captureScreenshot(page, testInfo, "openai-compatible-qwen-thinking");
   const saved = page.waitForResponse(

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -234,6 +234,26 @@ loopback, RFC1918, and `host.docker.internal` targets. To permit public hostname
 only to public addresses; redirects and DNS answers that reach private or link-local networks are
 rejected.
 
+For models whose server uses Qwen chat-template thinking, opt in by exact server model ID:
+
+```env
+RAKAZO_OPENAI_COMPAT_QWEN_MODELS=qwen3:4b,my-qwen-model
+```
+
+Set this on both the API and worker and restart them. It applies to the existing `local` and
+`openai-compatible` providers, across all endpoints using those IDs; it does not connect an
+endpoint or choose a default model. Use the normal URL, model ID, and optional-key connection
+flow above. Unlisted models keep their existing reasoning behavior.
+
+Opted-in models default to medium thinking. Web and desktop expose the existing **Thinking**
+control in a bot's advanced settings; mobile runs inherit the same backend policy. Rakazo sends
+`enable_thinking`, `preserve_thinking`, and the requested `reasoning_effort` inside
+`chat_template_kwargs`. Minimal/low map to `low`, medium to `medium`, and high to `xhigh` for
+Qwen effort templates. Off sends `enable_thinking: false` and omits the effort. Older Qwen
+templates may use only the on/off flag. The server must have its model's reasoning and tool-call
+parsers enabled; this setting does not install or configure the server. Existing token limits
+still apply, and an effort level is not a separate reasoning-token budget.
+
 Do not commit `.env`. Never put `COMPOSIO_API_KEY`, OpenRouter keys, or provider tokens in git, logs, or chat.
 
 ## Choosing a computer provider

--- a/packages/adapters/src/openai-compatible-thinking.test.ts
+++ b/packages/adapters/src/openai-compatible-thinking.test.ts
@@ -1,0 +1,165 @@
+import { type Model, Type } from "@earendil-works/pi-ai";
+import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildModelConnectPlaintext } from "./model-connect.js";
+import { openAiCompatibleThinking, qwenModelIds } from "./openai-compatible-thinking.js";
+import { registerLocalProvider } from "./pi-local-provider.js";
+import { registerOpenAiCompatibleRuntime } from "./pi-openai-compatible-provider.js";
+
+const modelId = "test-qwen";
+const baseUrl = "http://127.0.0.1:8090/v1";
+
+beforeEach(() => {
+  vi.stubEnv("RAKAZO_OPENAI_COMPAT_QWEN_MODELS", modelId);
+  vi.stubEnv("RAKAZO_LOCAL_MODELS", modelId);
+  vi.stubEnv("RAKAZO_LOCAL_MODELS_URL", baseUrl);
+  vi.stubEnv("RAKAZO_LOCAL_CONTEXT_WINDOW", "32768");
+  vi.stubEnv("RAKAZO_LOCAL_MAX_TOKENS", "4096");
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+it("requires an exact opt-in and trims and deduplicates configured IDs", () => {
+  vi.stubEnv("RAKAZO_OPENAI_COMPAT_QWEN_MODELS", " test-qwen, ,test-qwen,other ");
+  expect(qwenModelIds()).toEqual([modelId, "other"]);
+  expect(openAiCompatibleThinking("test-qwen-extra").reasoning).toBe(false);
+  expect(openAiCompatibleThinking("Test-qwen").reasoning).toBe(false);
+  vi.stubEnv("RAKAZO_OPENAI_COMPAT_QWEN_MODELS", "");
+  expect(openAiCompatibleThinking(modelId)).toEqual({
+    reasoning: false,
+    compat: { supportsDeveloperRole: false, supportsReasoningEffort: false },
+  });
+});
+
+it("keeps the existing keyless connection format", () => {
+  const plaintext = buildModelConnectPlaintext({ provider: "openai-compatible", baseUrl, modelId });
+  expect(plaintext).toContain(baseUrl);
+  expect(plaintext).not.toContain("apiKey");
+});
+
+type Payload = {
+  model: string;
+  stream: boolean;
+  messages: Array<{ role: string }>;
+  tools: Array<{ function: { name: string } }>;
+  chat_template_kwargs?: Record<string, unknown>;
+  reasoning_effort?: string;
+};
+
+function fixtureResponse(): Response {
+  const deltas = [
+    { reasoning_content: "Check the fixture." },
+    { content: "Ready." },
+    {
+      tool_calls: [
+        {
+          index: 0,
+          id: "call_test",
+          type: "function",
+          function: { name: "lookup", arguments: '{"value":' },
+        },
+      ],
+    },
+    { tool_calls: [{ index: 0, function: { arguments: "42}" } }] },
+  ];
+  const chunks = [...deltas, {}].map((delta, index) => ({
+    id: "fixture",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: modelId,
+    choices: [{ index: 0, delta, finish_reason: index === deltas.length ? "tool_calls" : null }],
+  }));
+  return new Response(
+    `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`,
+    {
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}
+
+describe.each(["local", "openai-compatible"] as const)("%s thinking transport", (provider) => {
+  async function capture(reasoning?: "minimal" | "low" | "medium" | "high") {
+    let payload: Payload | undefined;
+    const mockFetch = vi.fn<typeof fetch>(async (input, init) => {
+      expect(String(input)).toBe(`${baseUrl}/chat/completions`);
+      payload = JSON.parse(String(init?.body)) as Payload;
+      return fixtureResponse();
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    const models =
+      provider === "local"
+        ? registerLocalProvider(builtinModels())
+        : registerOpenAiCompatibleRuntime(builtinModels(), { modelId, baseUrl });
+    const model = models.getModel(provider, modelId) as Model<"openai-completions">;
+    const stream = models.streamSimple(
+      model,
+      {
+        systemPrompt: "Use the fixture.",
+        messages: [{ role: "user", content: "Look it up.", timestamp: 1 }],
+        tools: [
+          {
+            name: "lookup",
+            description: "Look up a fixture",
+            parameters: Type.Object({ value: Type.Number() }),
+          },
+        ],
+      },
+      { reasoning, fetch: mockFetch },
+    );
+    const events = [];
+    for await (const event of stream) events.push(event.type);
+    const result = await stream.result();
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(result.stopReason).toBe("toolUse");
+    return { payload: payload!, result, events };
+  }
+
+  it.each([
+    ["minimal", "low"],
+    ["low", "low"],
+    ["medium", "medium"],
+    ["high", "xhigh"],
+  ] as const)("sends %s as explicit Qwen effort %s", async (level, effort) => {
+    const { payload } = await capture(level);
+    expect(payload.chat_template_kwargs).toEqual({
+      enable_thinking: true,
+      reasoning_effort: effort,
+      preserve_thinking: true,
+    });
+    expect(payload.reasoning_effort).toBeUndefined();
+  });
+
+  it("turns thinking off explicitly without sending an effort", async () => {
+    const { payload } = await capture();
+    expect(payload.chat_template_kwargs).toEqual({
+      enable_thinking: false,
+      preserve_thinking: true,
+    });
+  });
+
+  it("leaves unconfigured models free of Qwen-specific request fields", async () => {
+    vi.stubEnv("RAKAZO_OPENAI_COMPAT_QWEN_MODELS", "");
+    const { payload } = await capture("high");
+    expect(payload.chat_template_kwargs).toBeUndefined();
+    expect(payload.reasoning_effort).toBeUndefined();
+  });
+
+  it("streams system-role requests, reasoning, text and fragmented tool arguments", async () => {
+    const { payload, result, events } = await capture("medium");
+    expect(payload.messages[0]?.role).toBe("system");
+    expect(payload.stream).toBe(true);
+    expect(payload.tools[0]?.function.name).toBe("lookup");
+    expect(events).toEqual(
+      expect.arrayContaining(["thinking_delta", "text_delta", "toolcall_delta", "done"]),
+    );
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "thinking", thinking: "Check the fixture." }),
+        expect.objectContaining({ type: "text", text: "Ready." }),
+        expect.objectContaining({ type: "toolCall", name: "lookup", arguments: { value: 42 } }),
+      ]),
+    );
+  });
+});

--- a/packages/adapters/src/openai-compatible-thinking.ts
+++ b/packages/adapters/src/openai-compatible-thinking.ts
@@ -1,0 +1,40 @@
+import type { Model } from "@earendil-works/pi-ai";
+
+/** Exact server model IDs; compatibility is an operator choice, never inferred from a name. */
+export function qwenModelIds(): string[] {
+  return [
+    ...new Set(
+      (process.env.RAKAZO_OPENAI_COMPAT_QWEN_MODELS ?? "")
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+export function openAiCompatibleThinking(
+  modelId: string,
+): Pick<Model<"openai-completions">, "reasoning" | "compat" | "thinkingLevelMap"> {
+  const compat = { supportsDeveloperRole: false, supportsReasoningEffort: false };
+  if (!qwenModelIds().includes(modelId)) return { reasoning: false, compat };
+  return {
+    reasoning: true,
+    compat: {
+      ...compat,
+      thinkingFormat: "chat-template",
+      chatTemplateKwargs: {
+        enable_thinking: { $var: "thinking.enabled" },
+        reasoning_effort: { $var: "thinking.effort", omitWhenOff: true },
+        preserve_thinking: true,
+      },
+    },
+    // Qwen effort templates accept low, medium, and xhigh. Older Qwen
+    // templates use only enable_thinking and ignore the effort value.
+    thinkingLevelMap: {
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "xhigh",
+    },
+  };
+}

--- a/packages/adapters/src/pi-local-provider.ts
+++ b/packages/adapters/src/pi-local-provider.ts
@@ -5,6 +5,7 @@ import {
   type Provider,
 } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+import { openAiCompatibleThinking } from "./openai-compatible-thinking.js";
 
 /**
  * Local OpenAI-compatible model server (Ollama, LM Studio, llama.cpp, MLX).
@@ -68,7 +69,7 @@ function localModel(id: string): Model<"openai-completions"> {
     api: "openai-completions",
     provider: LOCAL_PROVIDER_ID,
     baseUrl: localBaseUrl(),
-    reasoning: false,
+    ...openAiCompatibleThinking(id),
     input: ["text"],
     // Runs on the operator's own hardware, so there is nothing to bill.
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/packages/adapters/src/pi-models.test.ts
+++ b/packages/adapters/src/pi-models.test.ts
@@ -2,6 +2,24 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { catalogModelLabel, listPiCatalog, scriptedCatalogEntry } from "./pi-models.js";
 
 describe("Pi model catalog", () => {
+  it("exposes opted-in thinking without advertising models on every custom endpoint", async () => {
+    vi.stubEnv("RAKAZO_OPENAI_COMPAT_QWEN_MODELS", "test-qwen,test-qwen");
+    vi.stubEnv("RAKAZO_LOCAL_MODELS", "test-qwen");
+    vi.resetModules();
+    const { listPiCatalog } = await import("./pi-models.js");
+    const catalog = listPiCatalog();
+    const custom = catalog.filter((entry) => entry.provider === "openai-compatible");
+    expect(custom.map((entry) => entry.id)).toEqual(["custom", "test-qwen"]);
+    expect(custom.every((entry) => entry.placeholder)).toBe(true);
+    expect(custom[1]).toMatchObject({
+      reasoning: true,
+      thinkingLevels: ["off", "minimal", "low", "medium", "high"],
+    });
+    expect(
+      catalog.find((entry) => entry.provider === "local" && entry.id === "test-qwen"),
+    ).toMatchObject({ reasoning: true });
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();

--- a/packages/adapters/src/pi-models.ts
+++ b/packages/adapters/src/pi-models.ts
@@ -4,7 +4,6 @@ import type { ModelOAuthSignInMode, ThinkingLevel } from "@rakazo/contracts";
 import { LOCAL_PROVIDER_ID, registerLocalProvider } from "./pi-local-provider.js";
 import { SUBSCRIPTION_SIGN_IN_PROVIDERS } from "./pi-oauth.js";
 import {
-  OPENAI_COMPATIBLE_CATALOG_MODEL_ID,
   OPENAI_COMPATIBLE_PROVIDER_ID,
   registerOpenAiCompatibleCatalog,
 } from "./pi-openai-compatible-provider.js";
@@ -67,7 +66,9 @@ function buildPiCatalog(): PiCatalogEntry[] {
         signIn: signInMeta?.mode,
         reasoning: Boolean(model.reasoning),
         thinkingLevels,
-        ...(model.id === OPENAI_COMPATIBLE_CATALOG_MODEL_ID ? { placeholder: true } : {}),
+        // Compatibility metadata does not prove a model is served by a user's
+        // endpoint. Keep each custom connection scoped to its entered model ID.
+        ...(provider.id === OPENAI_COMPATIBLE_PROVIDER_ID ? { placeholder: true } : {}),
       });
     }
   }

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -16,6 +16,7 @@ import {
   isPrivateAddress,
   type ResolveHostname,
 } from "./network-address.js";
+import { openAiCompatibleThinking, qwenModelIds } from "./openai-compatible-thinking.js";
 import {
   assertAllowedOpenAiCompatibleRequestUrl,
   assertAllowedOpenAiCompatibleUrl,
@@ -47,15 +48,11 @@ function openAiCompatibleModel(id: string, baseUrl: string): Model<"openai-compl
     api: "openai-completions",
     provider: OPENAI_COMPATIBLE_PROVIDER_ID,
     baseUrl,
-    reasoning: false,
+    ...openAiCompatibleThinking(id),
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MAX_TOKENS,
-    compat: {
-      supportsDeveloperRole: false,
-      supportsReasoningEffort: false,
-    },
   };
 }
 
@@ -215,6 +212,9 @@ export function openAiCompatibleCatalogProvider(): Provider {
       ...openAiCompatibleModel(OPENAI_COMPATIBLE_CATALOG_MODEL_ID, OPENAI_COMPAT_BASE),
       name: "Custom model id",
     },
+    ...qwenModelIds()
+      .filter((id) => id !== OPENAI_COMPATIBLE_CATALOG_MODEL_ID)
+      .map((id) => openAiCompatibleModel(id, OPENAI_COMPAT_BASE)),
   ]);
 }
 


### PR DESCRIPTION
## Why

Self-hosted Qwen servers can default to excessive thinking when the client omits their chat-template effort setting. The generic OpenAI-compatible connection already supports these endpoints, so reasoning compatibility belongs there instead of a separate MLX provider.

## What changed

- Add one optional operator setting, `RAKAZO_OPENAI_COMPAT_QWEN_MODELS`, containing exact server model IDs. Unlisted models retain their existing reasoning behavior.
- Share Qwen compatibility between the existing local and OpenAI-compatible adapters. Send explicit on/off and effort in `chat_template_kwargs`; map low/medium/high to Qwen's low/medium/xhigh vocabulary.
- Preserve the existing URL, model ID, optional-key connection flow. Catalog metadata enables existing thinking controls without advertising additional models on an unrelated endpoint.
- Document setup, restart requirements, server parser requirements, and mobile inheritance of the backend policy. Effort is not a separate reasoning-token budget.

No new interface strings or settings screens. The existing “Thinking” control remains inside bot “Advanced” settings and appears only when the selected model supports it. A web test covers keyless connection, endpoint-scoped choices, persistence, and the corresponding screenshot.

Follows the compatibility findings from #514.

## Validation

- Seventy-four focused offline tests passed, including request payloads for each effort, explicit off, unchanged unconfigured requests, streamed reasoning/text, and fragmented tool arguments through both adapters.
- Repository-wide typecheck passed. Lint passed with existing warnings.
- The broader adapter suite passed 1,298 tests; one Docker conformance test failed during sandbox provisioning, with seven tests skipped. The same failure was reproduced on the untouched base commit.
- Desktop Electron E2E was not run locally. CI passed lint, typecheck, builds, unit tests, Postgres journeys, web E2E, and image validation. The earlier group-chat journey failure passed on subsequent CI runs.

Both Greptile and CodeRabbit completed review with no actionable code findings. CodeRabbit retains a non-blocking docstring-coverage advisory.

[CI screenshot: Qwen model and Thinking control](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/33996351126-1/screenshots/images/153-openai-compatible-qwen-thinking.png) · [Passing CI run](https://github.com/elie222/rakazo/actions/runs/33996351126)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional support for Qwen chat-template thinking on selected OpenAI-compatible and local models.
  - Configure eligible model IDs using `RAKAZO_OPENAI_COMPAT_QWEN_MODELS`.
  - Reasoning controls now map to Qwen effort levels, including explicit off mode.
  - Selected custom models appear with appropriate reasoning options and preserve saved thinking settings.

- **Documentation**
  - Added self-hosting guidance covering configuration, supported endpoints, defaults, and restart requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->