### PR TITLE
docs: trim duplication and unfinished deployment notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Notable product changes in Rakazo. This is for people following the repo, not a dump of every commit. GitHub Releases still mark tagged builds.
+Notable product changes in Rakazo. See GitHub Releases for tagged builds.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
@@ -8,24 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- The phone surface became a multi-platform messaging surface built on the open-source Chat SDK. Slack, WhatsApp Business Cloud, and Telegram DMs now work alongside iMessage/SMS (Sendblue). Link a chat app to your account from Messaging settings on the web: pick a bot, send the short-lived code to the line, and that conversation reaches that bot — each app can point at a different bot. Unknown senders are ignored unless `MESSAGING_OPEN_SIGNUP=true`, which restores the old text-first auto-provisioning (and is the only mode that needs the deployment model key). Webhooks move to `/api/v1/messaging/webhook/<provider>` (the old Sendblue path still works), and each platform mounts when its env credentials are set — see `.env.example`. Group channels remain iMessage-only for now; other platforms are 1:1 until their channel semantics are mapped.
+- Connect Slack, WhatsApp Business Cloud, or Telegram DMs to a bot from Messaging settings, alongside iMessage/SMS. Each app can use a different bot. Group conversations remain iMessage-only.
 - Model picker includes Grok 4.6 (xAI) and Ox Alpha Free / GLM-5.3 (OpenCode Go).
 
 ### Added
 
-- Voice mode: speak replies, hold-to-talk dictation, and half-duplex calls. Speech sits behind a `VoiceProvider` interface (ElevenLabs, OpenAI, Cartesia) so the product is not tied to one vendor. Keys stay on the server.
-- Electron first-run: Docker (default) or this Mac. This Mac runs the bot shell as you, with working directories under your home folder. macOS does not show its own permission dialog; the consent is Rakazo's. The choice is owner-only and is refused when `SANDBOX_PROVIDER` is not `docker` (so E2B and test fakes cannot enable it).
-- GitHub Copilot and SuperGrok / X Premium sign-in via Pi device-code OAuth (`openai-codex`, `github-copilot`, `xai`). Claude Pro is still omitted because Pi's Claude login uses a localhost callback that does not work from the web app.
+- Voice mode: spoken replies, hold-to-talk dictation, and half-duplex calls with ElevenLabs, OpenAI, or Cartesia.
+- Desktop owners using Docker can opt into running bot shell commands directly on their computer. This grants access under the owner's OS account; see [computer providers](docs/self-host.md#choosing-a-computer-provider).
+- GitHub Copilot and SuperGrok / X Premium sign-in for model access.
 - Spawn peer bots (each with its own thread and computer) and short-lived in-thread subagents.
 - ChatGPT Plus or Pro sign-in for model access.
 - Mobile: point the app at a self-hosted API origin, a native iOS inbox, and take control of the live desktop.
 - Provider-neutral integrations: managed apps through Composio or Pipedream Connect, plus encrypted user-installed Treg, HTTPS MCP, and OpenAPI tool sources on web and mobile.
-- Revoke for connected Composio plugins.
+- Disconnect connected Composio plugins.
 - Routines in plain language instead of raw cron.
 
 ### Removed
 
-- Unused Grant folder picker in the desktop app. Bots never got a host folder that way.
+- Nonfunctional Grant folder picker in the desktop app.
+
+### Messaging upgrade notes
+
+- Webhooks use `/api/v1/messaging/webhook/<provider>`; the previous Sendblue path remains supported.
+- Configure credentials for each messaging provider in `.env`; see [.env.example](.env.example).
+- Unknown senders are ignored by default. `MESSAGING_OPEN_SIGNUP=true` restores automatic account
+  creation from incoming messages and requires a deployment model key.
 
 ## [0.1.0-beta] - 2026-08-13
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,8 @@ Thanks for helping improve Rakazo. Keep changes focused and testable.
 
 ## Run locally
 
-See [README.md](README.md) for full details. Quick start from the repo root:
-
-```bash
-cp .env.example .env
-# Set BETTER_AUTH_SECRET and ENCRYPTION_KEY to long random strings.
-docker compose --env-file .env -f infra/compose/docker-compose.yml up postgres -d
-pnpm install
-pnpm db:generate
-pnpm db:migrate
-pnpm sandbox:build
-pnpm dev
-```
+Follow the [source checkout setup](README.md#local-development-source-checkout) for prerequisites,
+required secrets, and startup commands.
 
 ## Checks before you open a PR
 
@@ -25,12 +15,28 @@ pnpm dev
 | `pnpm test:integration` | Postgres via Testcontainers: product journeys, authorization, executor lifecycle, Graphile / LISTEN/NOTIFY. Needs Docker. |
 | `pnpm test:e2e` | Playwright against the emulated API. Needs Docker. |
 | `pnpm test:topology` | Local product-path smoke: Docker computer + Graphile worker recovery. Needs Docker. Not PR CI. |
-| `pnpm test:canary` | Live OpenRouter / E2B canaries. Needs keys. Not PR CI. |
-| `pnpm test:computer` | Real vision model + E2B desktop. Needs keys; see README. Not PR CI. |
+| `pnpm test:canary` | Live provider canaries. Needs keys. Not PR CI. |
+| `pnpm test:computer` | Real vision model + E2B desktop. Needs keys; see [computer verification](docs/computer-runtime.md#verification). Not PR CI. |
 | `pnpm check` | TypeScript (`tsc`) across the monorepo. |
 | `pnpm lint` | Biome lint and format check. |
 
 CI runs `pnpm lint`, `pnpm check`, production builds (including Electron preload smoke), `pnpm test`, `pnpm test:integration`, and `pnpm test:e2e` on every PR.
+
+## Optional live-provider checks
+
+The default Playwright suite uses the fake sandbox. To run the same scripted-agent suite against
+real computers, set the matching `E2B_API_KEY`, `DAYTONA_API_KEY`, or `BOX_API_KEY` and choose a provider:
+
+```bash
+pnpm test:e2e -- --sandbox=e2b
+pnpm test:e2e -- --sandbox=daytona
+pnpm test:e2e -- --sandbox=box
+```
+
+The Playwright workflow also accepts these providers through its manual **Sandbox provider** input.
+These runs provision real machines and destroy them after the suite. Automatic runs use `fake`.
+For the separate real-model desktop acceptance test, see
+[computer verification](docs/computer-runtime.md#verification).
 
 ## Secrets and configuration
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,6 @@ marketing pages stay English.
 
 ## Development
 
-Rakazo is a TypeScript monorepo built with React, Electron, Expo, Hono, Postgres, Prisma, Graphile
-Worker, and Pi.
-
 ```text
 apps/       web, api, worker, desktop, mobile, and public website
 packages/   domain, contracts, persistence, adapters, UI, and test tooling
@@ -183,19 +180,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development workflow and test m
 
 ## Documentation
 
-```bash
-pnpm test              # unit, property, and in-process contract tests
-pnpm test:integration  # Postgres journeys, Graphile jobs, LISTEN/NOTIFY
-pnpm test:e2e          # Playwright against the emulated stack
-pnpm test:e2e -- --sandbox=e2b # the same deterministic suite against real E2B
-pnpm test:e2e -- --sandbox=daytona # the same suite against real Daytona
-pnpm test:e2e -- --sandbox=box # the same suite against real Box
-pnpm test:topology     # local Docker + Graphile worker recovery (needs Docker)
-pnpm test:canary       # live OpenRouter / E2B / Box canaries
-# explicit real vision-model + real E2B desktop acceptance test:
-COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm test:computer
-```
-
 - [Self-hosting](./docs/self-host.md)
 - [Computer runtime and isolation](./docs/computer-runtime.md)
 - [Desktop releases](./docs/desktop-release.md)
@@ -204,9 +188,6 @@ COMPUTER_E2E_MODEL=<vision-capable-openrouter-model-id> pnpm test:computer
 
 ## Contributing
 
-The Playwright workflow can also be started manually with **Sandbox provider** set to `e2b`, `daytona`, or `box`.
-Those options require `E2B_API_KEY`, `DAYTONA_API_KEY`, or `BOX_API_KEY`, keep the deterministic scripted agent runtime, and destroy
-the provider machines after the run. The default and all automatic runs remain on `fake`.
 Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull
 request. For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) instead of filing a public
 issue.

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -89,12 +89,12 @@ Before making changes, ask me these concise questions:
 3. Do I want a managed app catalog? If yes, choose Composio (`COMPOSIO_API_KEY`) or Pipedream Connect (`PIPEDREAM_CLIENT_ID`, `PIPEDREAM_CLIENT_SECRET`, and `PIPEDREAM_PROJECT_ID`); otherwise leave them empty. Explain that this is optional and that users can still add Treg, HTTPS MCP, or OpenAPI sources in the app.
 4. Set up the web app only (recommended), or also launch the Electron desktop shell after the web stack works?
 
-Do not ask me to invent `BETTER_AUTH_SECRET` or `ENCRYPTION_KEY`; generate strong random local values yourself. If I choose an API key, let me enter it through an available secure secret mechanism or directly into `.env`; never echo it back. OAuth or device-code sign-in must remain under my control.
+Generate the required application secrets with openssl; do not ask me to invent them. If I choose an API key, let me enter it through an available secure secret mechanism or directly into `.env`; never echo it back. OAuth or device-code sign-in must remain under my control.
 
 Preflight:
 
 - Verify Git, Node.js, pnpm, Docker, and Docker Compose.
-- Use Node.js 22.22.2 or newer in the 22.x line, Node.js 24.x, or Node.js 26+; Node.js 23.x and 25.x are not supported. Use the repository-declared pnpm 9.15.0. Do not silently use pnpm 10 or 11: newer pnpm versions can reject this lockfile or rewrite it. Prefer Corepack; if Corepack is unavailable, use `npx --yes pnpm@9.15.0` for repo commands rather than globally installing a different version. Show the effective versions.
+- Use a Node.js version supported by `engines.node` and the pnpm version declared in `packageManager` in the root `package.json`. Prefer Corepack; if unavailable, use `npx --yes pnpm@<declared-version>` instead of globally installing a different version. Show the effective versions.
 - Verify the Docker daemon is running.
 - Check whether `127.0.0.1` ports 5433, 3100, 5173, and 7091 are available. Resolve conflicts without touching unrelated workloads.
 
@@ -102,13 +102,13 @@ Setup:
 
 1. Clone the repository if needed and enter its root.
 2. Read `AGENTS.md`, `README.md`, `.env.example`, and the root `package.json` before acting. Follow repository instructions if they have changed since this prompt was written.
-3. If `.env` does not exist, copy `.env.example` to `.env`. Generate independent random values of at least 32 bytes for `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY`. Keep local defaults for Postgres, origins, Pi, Docker, and Graphile unless the preflight found a conflict. Add only the model and managed-connector credentials I selected. Leave optional credentials blank.
+3. If `.env` does not exist, copy `.env.example` to `.env`. Generate `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `SCREEN_PROXY_SECRET`, and `SANDBOX_SUPERVISOR_TOKEN` independently with `openssl rand -hex 32` (64 hex characters each). Keep local defaults for Postgres, origins, Pi, Docker, and Graphile unless the preflight found a conflict. Add only the model and managed-connector credentials I selected. Leave optional credentials blank.
 4. Confirm `.env` is ignored and that no secret-bearing file is staged.
 5. Start only local Postgres:
 
    `docker compose --env-file .env -f infra/compose/docker-compose.yml up postgres -d`
 
-6. With pnpm 9.15.0, run:
+6. With the repository-declared pnpm version, run:
 
    `pnpm install --frozen-lockfile`
    `pnpm db:generate`

--- a/docs/self-host-restricted-network.md
+++ b/docs/self-host-restricted-network.md
@@ -1,30 +1,72 @@
-# Self-host restricted-network map
+# Self-hosting on restricted networks
 
-Operator map for Mainland / corporate / flaky-registry installs.
-Do not bake vendor CDN hostnames into defaults.
+Use a mirror you control or pre-copy files when GitHub or container registries are unreachable.
+These settings change downloads; model and remote-computer providers still need network access.
 
-Canonical detail lives in [self-host.md](./self-host.md), especially
-[Restricted networks / mirror downloads](./self-host.md#restricted-networks--mirror-downloads).
-Stage A bootstrap discoverability is also summarized in the [README](../README.md).
+| Failure | Setting or action |
+| --- | --- |
+| Cannot fetch the installer | Download it from your mirror or copy it locally |
+| Cannot fetch Compose files | `RAKAZO_DOWNLOAD_BASE`, `--local`, or `RAKAZO_DOWNLOAD_SKIP_EXISTING=1` |
+| Cannot pull app or computer images | `RAKAZO_IMAGE`, `RAKAZO_IMAGE_TAG`, `RAKAZO_COMPUTER_IMAGE`, `RAKAZO_COMPUTER_IMAGE_TAG` |
+| Cannot pull Postgres or busybox | `POSTGRES_IMAGE`, `BUSYBOX_IMAGE`, or Docker daemon `registry-mirrors` |
 
-## Install stages (A → C)
+## Installer script
 
-| Stage | Failure looks like | First move |
-| --- | --- | --- |
-| A: fetch installer | curl to raw GitHub fails | [`RAKAZO_INSTALLER_URL`](./self-host.md#restricted-networks--mirror-downloads) or pre-copy the script ([README](../README.md)) |
-| B: Compose + env example | curl under `infra/compose` fails | [`RAKAZO_DOWNLOAD_BASE`](./self-host.md#restricted-networks--mirror-downloads), [`--local`](./self-host.md#restricted-networks--mirror-downloads), or [`RAKAZO_DOWNLOAD_SKIP_EXISTING=1`](./self-host.md#restricted-networks--mirror-downloads) |
-| C: image pull | GHCR / Hub pull fails | [`RAKAZO_*_IMAGE*`](./self-host.md#restricted-networks--mirror-downloads), [`POSTGRES_IMAGE`](../infra/compose/docker-compose.images.yml) / [`BUSYBOX_IMAGE`](../infra/compose/docker-compose.images.yml); optional daemon `registry-mirrors` ([how](./self-host.md#restricted-networks--mirror-downloads); base example [docker-daemon.json](../infra/compose/docker-daemon.json)) |
+When raw GitHub is unreachable, download the installer from your mirror:
 
-## Decision tree
+```bash
+export RAKAZO_INSTALLER_URL=https://example.com/mirror/rakazo/infra/compose/install-images.sh
+mkdir -p rakazo && cd rakazo &&
+curl -fsSLO "${RAKAZO_INSTALLER_URL}" &&
+bash install-images.sh
+```
 
-1. Cannot download the installer script → Stage A mirror / local copy.
-2. Installer runs but cannot fetch Compose YAML → Stage B base or `--local`.
-3. Compose pull fails on app/computer → GHCR mirror env (`RAKAZO_IMAGE`, `RAKAZO_IMAGE_TAG`, `RAKAZO_COMPUTER_IMAGE`, `RAKAZO_COMPUTER_IMAGE_TAG`).
-4. Pull fails only on Postgres/busybox → Hub overrides (`POSTGRES_IMAGE` / `BUSYBOX_IMAGE`) or daemon `registry-mirrors`.
-5. Stack is up but bots cannot call models / remote sandboxes → day-2 egress and [computer provider](./self-host.md#choosing-a-computer-provider) choice; local `SANDBOX_PROVIDER=docker` still needs a computer image.
-6. Arm host + mysterious computer crash → pin both image tags to one multi-arch release ([Published images and tags](./self-host.md#published-images-and-tags)).
+`RAKAZO_INSTALLER_URL` is used by this curl command; it is not an installer setting.
 
-For Hub pulls, prefer `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` when you can vendor those images. If you need a daemon mirror instead, merge a `registry-mirrors` array into your Docker daemon JSON (start from [docker-daemon.json](../infra/compose/docker-daemon.json); do not commit vendor CDN hostnames as repo defaults), then restart Docker so the change takes effect:
+## Compose files
+
+To mirror `docker-compose.images.yml` and `.env.images.example`, point the installer at an HTTPS
+mirror of `infra/compose`:
+
+```bash
+export RAKAZO_DOWNLOAD_BASE=https://example.com/mirror/rakazo/infra/compose
+bash install-images.sh
+```
+
+Trailing slashes are trimmed; non-HTTPS bases are rejected. Downloads use bounded retries.
+
+To reuse files already present in the working directory:
+
+```bash
+# Place docker-compose.images.yml and .env.images.example in this directory first.
+bash install-images.sh --local --prepare-only
+# Equivalent environment setting:
+RAKAZO_DOWNLOAD_SKIP_EXISTING=1 bash install-images.sh --prepare-only
+```
+
+Missing files are still downloaded. `--prepare-only` creates `.env` without starting the stack;
+edit it as needed, then run `bash install-images.sh --local` to start using the local files.
+
+## Container images
+
+After `--prepare-only`, set image overrides in `.env` and rerun the installer (keep `--local` if
+using pre-copied Compose files):
+
+```env
+RAKAZO_IMAGE=registry.example.com/mirror/rakazo/app
+RAKAZO_IMAGE_TAG=edge
+RAKAZO_COMPUTER_IMAGE=registry.example.com/mirror/rakazo/computer
+RAKAZO_COMPUTER_IMAGE_TAG=edge
+POSTGRES_IMAGE=registry.example.com/mirror/postgres:16
+BUSYBOX_IMAGE=registry.example.com/mirror/busybox:1
+```
+
+Mirror both app and computer images and pair their tags to the same published version. Arm64
+hosts need multi-architecture tags; see [published images and tags](./self-host.md#published-images-and-tags).
+Image overrides are defined in [docker-compose.images.yml](../infra/compose/docker-compose.images.yml).
+
+For Docker Hub images, you can instead merge `registry-mirrors` into the Docker daemon's existing
+JSON configuration, then restart Docker:
 
 ```json
 {
@@ -32,17 +74,9 @@ For Hub pulls, prefer `POSTGRES_IMAGE` / `BUSYBOX_IMAGE` when you can vendor tho
 }
 ```
 
-## Related guides
+See the [base daemon configuration](../infra/compose/docker-daemon.json). Docker Hub mirrors do not
+replace the GHCR image overrides above.
 
-Focused `docs/self-host-*.md` satellites may land later. Until then, use these existing pages:
-
-| Topic | Doc |
-| --- | --- |
-| Restricted networks / Stages A-C | [Restricted networks / mirror downloads](./self-host.md#restricted-networks--mirror-downloads) |
-| Published images (no checkout) | [Published images (no checkout)](./self-host.md#published-images-no-checkout) |
-| Tags, arm64 pairing, digests | [Published images and tags](./self-host.md#published-images-and-tags) |
-| Sandbox / computer providers | [Choosing a computer provider](./self-host.md#choosing-a-computer-provider) |
-| Stage A installer discoverability | [README](../README.md) |
-| Compose image overrides (`POSTGRES_IMAGE`, `BUSYBOX_IMAGE`, app/computer) | [docker-compose.images.yml](../infra/compose/docker-compose.images.yml) |
-| Example Docker daemon config (add `registry-mirrors` locally if Hub is blocked) | [docker-daemon.json](../infra/compose/docker-daemon.json) |
-| Full self-host narrative | [self-host.md](./self-host.md) |
+Once downloads work, continue with [published-image setup](./self-host.md#published-images-no-checkout).
+For hosts without external provider access, use local Docker computers and an operator-controlled
+model endpoint; see the [self-hosting guide](./self-host.md).

--- a/docs/self-host-sandbox-providers.md
+++ b/docs/self-host-sandbox-providers.md
@@ -1,24 +1,20 @@
 # Self-host sandbox / computer providers
 
-How `SANDBOX_PROVIDER` chooses where each bot's **computer** runs. New file
-only; does not edit `docs/self-host.md`.
-
-`GET /health` reports the effective provider as `sandbox` (see
-`docs/self-host-health-checks.md` when present). HTTP 200 alone is not enough:
-confirm the JSON `sandbox` field matches the provider you set. A **missing**
-remote key falls back to `sandbox: "none"` while `/health` still returns 200.
-A present but **invalid** key still reports the chosen provider; `/health` will
-not catch that until provisioning fails.
+`SANDBOX_PROVIDER` selects where bot computers run. Workspace bots share a Team Computer by
+default; Private Computers are optional. See [computer runtime and isolation](./computer-runtime.md)
+for the sharing and persistence contract.
 
 ## Quick pick
 
 | Goal | Set | Also need |
 | --- | --- | --- |
-| Default self-host (local Docker desktop per bot) | `SANDBOX_PROVIDER=docker` | `SANDBOX_SUPERVISOR_TOKEN`, computer image, Docker socket for supervisor |
+| Local Docker computers | `SANDBOX_PROVIDER=docker` | `SANDBOX_SUPERVISOR_TOKEN`, computer image, Docker socket for supervisor |
 | UI only, no computers | `SANDBOX_PROVIDER=none` | No provider credential; published-images Compose still requires `SANDBOX_SUPERVISOR_TOKEN` |
 | Managed remote desktop | `e2b` / `daytona` / `box` | `SANDBOX_SUPERVISOR_TOKEN` (published-images Compose), matching API key (and optional URL knobs for Daytona/Box) |
 
-Published-images `infra/compose/.env.images.example` defaults to **`docker`**.
+Published-images [Compose](../infra/compose/docker-compose.images.yml) defaults to **`docker`**.
+It always starts the supervisor and requires `SANDBOX_SUPERVISOR_TOKEN`, including for `none`
+and remote providers. This stack credential does not replace a remote provider's API key.
 
 ## `docker` (in-stack supervisor)
 
@@ -45,11 +41,7 @@ Signup and local Docker computers work **without** an E2B (or other remote) acco
 
 ## `none`
 
-Boots API/web without computer provisioning. Use when Docker/supervisor is
-unavailable and you only need the control plane.
-
-Published-images Compose still requires `SANDBOX_SUPERVISOR_TOKEN` and starts
-the supervisor service even when `SANDBOX_PROVIDER=none`.
+Runs API/web without provisioning bot computers.
 
 ## Remote providers
 
@@ -65,10 +57,7 @@ Remote paths still need a working API/worker; they do not replace Postgres or
 the web UI. They require egress to the provider. For air-gapped hosts prefer
 `docker` with pre-loaded images, or `none`.
 
-Published-images Compose (`docker-compose.images.yml`) still requires
-`SANDBOX_SUPERVISOR_TOKEN` and always starts the supervisor service (api/worker
-depend on it). The token is a Compose stack requirement; it does not replace
-the remote API key.
+## Verify a provider change
 
 After changing provider or keys (from the published-images drop directory that
 holds `docker-compose.images.yml` and `.env`):
@@ -79,6 +68,6 @@ curl -fsS http://127.0.0.1:3100/health
 ```
 
 Confirm `sandbox` equals the intended provider (`e2b`, `daytona`, or `box`).
-HTTP 200 with `sandbox: "none"` means computers are disabled because the remote
-key is missing, not a successful remote setup. A present but invalid key still
-reports the chosen provider on `/health`; provisioning fails later.
+HTTP 200 alone does not verify a remote provider: a missing API key falls back to `sandbox: "none"`.
+A present but invalid key still reports the selected provider. Open a bot's computer to verify
+provisioning and desktop access.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -23,69 +23,11 @@ customize the public URL, image tag, or optional providers before startup, run
 `bash install-images.sh --prepare-only`, edit `.env`, then run `bash install-images.sh`.
 Flags may be combined in either order: `--prepare-only`, `--local`.
 
-### Restricted networks / mirror downloads
-
-Stage B of the installer (Compose YAML and `.env.images.example`) downloads from
-`DOWNLOAD_BASE`. Override it with a generic HTTPS mirror of `infra/compose` — do not rely on
-vendor-specific CDN defaults:
-
-```bash
-export RAKAZO_DOWNLOAD_BASE=https://example.com/mirror/rakazo/infra/compose
-bash install-images.sh
-```
-
-Trailing slashes on `RAKAZO_DOWNLOAD_BASE` are trimmed; non-HTTPS bases are rejected. Downloads
-use finite curl retries (`--retry 3 --retry-delay 2 --retry-all-errors` when supported).
-
-To reuse files already present in the working directory (skip curl when the target exists), set
-`RAKAZO_DOWNLOAD_SKIP_EXISTING=1` and/or pass `--local`:
-
-```bash
-# after placing docker-compose.images.yml and .env.images.example locally
-bash install-images.sh --local --prepare-only
-# or
-RAKAZO_DOWNLOAD_SKIP_EXISTING=1 bash install-images.sh --prepare-only
-```
-
-If skip mode is on and a required file is missing, the installer still downloads it (or fails with
-the URL in the error).
-
-Stage A (fetching `install-images.sh` itself) is separate. When raw GitHub is unreachable, point the
-bootstrap curl at your mirror of the installer script, for example:
-
-```bash
-export RAKAZO_INSTALLER_URL=https://example.com/mirror/rakazo/infra/compose/install-images.sh
-mkdir -p rakazo && cd rakazo &&
-curl -fsSLO "${RAKAZO_INSTALLER_URL}" &&
-bash install-images.sh
-```
-
-Stage C (`docker compose pull`) uses `RAKAZO_IMAGE`, `RAKAZO_IMAGE_TAG`,
-`RAKAZO_COMPUTER_IMAGE`, and `RAKAZO_COMPUTER_IMAGE_TAG` (defaults
-`ghcr.io/elie222/rakazo/{app,computer}`). When GHCR is unreachable, override those
-four in `.env` to a registry you control — keep app and computer on the same
-mirror. Do not rely on vendor-specific CDN defaults:
-
-```env
-RAKAZO_IMAGE=registry.example.com/mirror/elie222/rakazo/app
-RAKAZO_IMAGE_TAG=edge
-RAKAZO_COMPUTER_IMAGE=registry.example.com/mirror/elie222/rakazo/computer
-RAKAZO_COMPUTER_IMAGE_TAG=edge
-```
-
-After `--prepare-only`, edit `.env` then rerun `bash install-images.sh` (or
-`docker compose --env-file .env -f docker-compose.images.yml pull`). Arm64 tag
-pairing is unchanged — set both tags to the same published multi-arch release
-(see [Published images and tags](#published-images-and-tags)).
-
-`postgres:16` and `busybox:1` still pull from Docker Hub. Stage C does not cover
-them; configure the Docker daemon `registry-mirrors` or vendor those images.
-
 `SANDBOX_PROVIDER` defaults to `docker`. The images Compose file runs a sandbox supervisor
 (from the app image, on the internal network only) and pulls `ghcr.io/elie222/rakazo/computer`.
 Signup and local Docker computers work without an E2B account. Optional remote providers: set
-`SANDBOX_PROVIDER` to `e2b`, `daytona`, or `box` and add the matching API key. Compose requires
-`SANDBOX_SUPERVISOR_TOKEN` for the Docker path; leave it empty and `compose up` fails closed.
+`SANDBOX_PROVIDER` to `e2b`, `daytona`, or `box` and add the matching API key. The published-images
+Compose stack requires `SANDBOX_SUPERVISOR_TOKEN` for every provider; leave it empty and `compose up` fails closed.
 
 Optional: set `OPENROUTER_API_KEY` or connect a model in the UI after signup.
 
@@ -111,6 +53,11 @@ Open **Agent computer** on a bot, or send a message that uses the desktop, to se
 the local Docker computer. For in-stack Caddy plus remote E2B computers, use the
 [production Compose](#public-single-vm-deployment) path and `infra/compose/Caddyfile.prod`
 instead of this host proxy.
+
+### Restricted networks / mirror downloads
+
+If the installer, Compose downloads, or image pulls are blocked, use the
+[restricted-network guide](./self-host-restricted-network.md) for mirror settings and local files.
 
 ## Docker Compose (single machine)
 
@@ -264,6 +211,8 @@ The Electron desktop app is a client of the same API. Docker and E2B still apply
 - **None** boots the product without a computer host (fallback when Docker/supervisor is not
   configured, or when a remote provider is selected without its API key).
 
+For provider configuration and health checks, see the [provider setup guide](./self-host-sandbox-providers.md).
+
 ## Backup
 
 ```bash
@@ -345,9 +294,6 @@ curl --fail https://app.example.com/health
 **Build, do not pull, for a first deployment.** `RAKAZO_IMAGE_TAG` ships as `local`, a tag no
 registry serves, so the commands above build `api`, `worker`, and `web` from the checkout you just
 cloned. The opt-in command under [Updater sidecar](#updater-sidecar) builds `updater` when needed.
-Running `docker compose … pull` first — as earlier versions of this page told you to — fails outright
-with `error from registry: denied` whenever the tag you are on has not been published, and there is
-nothing to fall back to.
 
 Passing `GIT_SHA` is what makes `GET /health` report a `"revision"`; a locally built image has no
 other way to know its commit. Prebuilt images from the registry bake it in at publish time, so when
@@ -605,23 +551,18 @@ least 32 characters in production). It must differ from `BETTER_AUTH_SECRET`,
 `SANDBOX_SUPERVISOR_TOKEN`, and `SCREEN_PROXY_SECRET`. Leave the profile disabled if you would
 rather not grant the capability.
 
-## What “Rakazo Cloud” still needs
+## Other deployment layouts
 
-The product cannot be “pushed live” as a Vercel serverless app. Graphile Worker, Postgres `LISTEN`, Pi runs, and Docker computers need durable processes and a sandbox host.
+API and worker need always-on processes; serverless request handlers are not sufficient. Use a
+Node.js version supported by the root `package.json`, Postgres 16 and a persistent `DATA_DIR` volume shared by API and worker, with encrypted off-host
+backups. The current home store uses a local filesystem, so deployments on separate hosts need a
+shared filesystem; an object-storage adapter is not available yet.
 
-To run a hosted product (same codebase):
+Use the same HTTPS origin for the web app, `/api`, and `/rpc`. Preserve the authenticated screen
+proxy routes. Choose a [computer provider](#choosing-a-computer-provider) appropriate to the
+service's trust boundary, and configure registration through the deployment owner's Settings.
+The optional marketing site in `apps/www` can be hosted separately.
 
-1. Push `main` (this checkout may be ahead of GitHub).
-2. Provision managed Postgres 16 and run `pnpm db:migrate`.
-3. Run **API** and **worker** as always-on services using Node.js 22.22.2 or newer in the 22.x line, Node.js 24.x, or Node.js 26+ (Fly machines, a VM, ECS, k8s). Node.js 23.x and 25.x are not supported. Not lambda-style request handlers.
-4. Persist and back up `DATA_DIR` (bot homes, browser profiles, artifacts). Today the concrete store is a local filesystem (`LocalAgentHomeStore`), so attach a Rakazo-owned durable volume shared by API and worker processes. The storage contract is separate from the computer-provider contract, but an object-storage implementation is not wired yet.
-5. Choose computers: **`SANDBOX_PROVIDER=e2b`**, `daytona`, or `box` with the matching provider key for a public or multi-user production service. Each Team or Private Computer reconnects to its sandbox id (`providerRef`), while workspace state is checkpointed outside the provider at run completion, explicit stop, and idle suspension. If that sandbox is gone—or the deployment changes providers—the replacement is hydrated from Rakazo's copy. Idle computers pause after `SANDBOX_IDLE_MS` (default 10 minutes) and resume on the next message or Take control. Docker remains the local and trusted single-machine default.
-6. A Hetzner CX22 (2 vCPU / 4 GB) is enough for API + worker + Postgres when E2B owns the desktops. 2 GB works for a quiet box; 8 GB is only needed if you also run Docker computers on that same machine.
-7. Set public HTTPS `WEB_ORIGIN` / `BETTER_AUTH_URL` / `API_URL`, secrets, and an OpenRouter (or other Pi) deployment key if you want to skip per-user model keys.
-8. Put the web app behind the same origin as `/api` and `/rpc` (Vite preview proxy, or a reverse proxy). Docker noVNC connections use short-lived signed `/novnc/*` capabilities; do not replace that route with an unrestricted port proxy.
-9. Deploy `apps/www` to your public website and point `app.example.com` (or similar) at the product origin.
-10. Turn on `SIGNUP_ALLOWLIST` until you want open registration. There is no Rakazo-managed model billing in version 1 — users bring keys.
-
-Expo / desktop installers are clients of that origin (`EXPO_PUBLIC_API_URL`, `RAKAZO_WEB_URL`). They are not a Cloud control plane.
+## Connect mobile clients
 
 The iOS and Android app can also point at a self-hosted origin at runtime. On the sign-in screen, tap **Use a custom server** and enter the same HTTPS origin as `WEB_ORIGIN` (for example `https://app.example.com`). Store builds still default to `EXPO_PUBLIC_API_URL`; the in-app setting is an override for people running their own API. Changing the server signs the device out of any previous session.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -96,8 +96,8 @@ the first account is registered.
 With a nonempty signup allowlist, users—including existing accounts—must verify their email to sign
 in. Configure SMTP below before enabling an allowlist or upgrading an allowlisted deployment.
 
-To set up without email, leave the allowlist empty, register the owner locally, then disable
-registration in Settings before exposing the server to the network.
+For a public deployment, configure SMTP and an allowlist before the first account is registered.
+Keep an installation without email on a trusted local network.
 
 ### Verification and password recovery email
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -89,7 +89,9 @@ WEB_ORIGIN=https://app.example.com
 API_URL=https://app.example.com
 ```
 
-Cookies and CORS follow those origins. `SIGNUPS_ENABLED` / `SIGNUP_ALLOWLIST` seed the initial deployment settings. After initialization, the deployment owner's Settings values are the effective signup policy.
+Cookies and CORS follow those origins. `SIGNUPS_ENABLED` / `SIGNUP_ALLOWLIST` seed the signup
+policy during deployment initialization. They are not reapplied on restart, so configure them before
+the first account is registered.
 
 With a nonempty signup allowlist, users—including existing accounts—must verify their email to sign
 in. Configure SMTP below before enabling an allowlist or upgrading an allowlisted deployment.
@@ -560,7 +562,8 @@ shared filesystem; an object-storage adapter is not available yet.
 
 Use the same HTTPS origin for the web app, `/api`, and `/rpc`. Preserve the authenticated screen
 proxy routes. Choose a [computer provider](#choosing-a-computer-provider) appropriate to the
-service's trust boundary, and configure registration through the deployment owner's Settings.
+service's trust boundary, and configure registration before initialization with `SIGNUPS_ENABLED`
+and `SIGNUP_ALLOWLIST`.
 The optional marketing site in `apps/www` can be hosted separately.
 
 ## Connect mobile clients

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -90,13 +90,13 @@ API_URL=https://app.example.com
 ```
 
 Cookies and CORS follow those origins. `SIGNUPS_ENABLED` / `SIGNUP_ALLOWLIST` seed the signup
-policy during deployment initialization. They are not reapplied on restart, so configure them before
-the first account is registered.
+policy when the API starts for the first time. They are not reapplied on restart, so configure them
+before that first start.
 
 With a nonempty signup allowlist, users—including existing accounts—must verify their email to sign
 in. Configure SMTP below before enabling an allowlist or upgrading an allowlisted deployment.
 
-For a public deployment, configure SMTP and an allowlist before the first account is registered.
+For a public deployment, configure SMTP and an allowlist before the API's first start.
 Keep an installation without email on a trusted local network.
 
 ### Verification and password recovery email
@@ -562,8 +562,8 @@ shared filesystem; an object-storage adapter is not available yet.
 
 Use the same HTTPS origin for the web app, `/api`, and `/rpc`. Preserve the authenticated screen
 proxy routes. Choose a [computer provider](#choosing-a-computer-provider) appropriate to the
-service's trust boundary, and configure registration before initialization with `SIGNUPS_ENABLED`
-and `SIGNUP_ALLOWLIST`.
+service's trust boundary, and configure `SIGNUPS_ENABLED` and `SIGNUP_ALLOWLIST` before the API's
+first start.
 The optional marketing site in `apps/www` can be hosted separately.
 
 ## Connect mobile clients


### PR DESCRIPTION
## Why

Public docs repeat setup and test instructions and include unfinished deployment notes. This makes the installation path harder to follow and lets requirements drift between guides.

## What changed

- Keep the README technical, removing only duplicate stack/test text and moving optional live-provider test instructions into CONTRIBUTING.
- Consolidate mirror instructions in the existing restricted-network guide, preserving the original self-hosting anchor as a link to it.
- Remove draft notes and repeated provider explanations; retain health verification, deployment requirements, backups, and host-access guidance.
- Point the setup prompt at repository-declared tool versions and include all four application secrets in its generation step.
- Shorten changelog feature entries and separate the messaging upgrade instructions.

Only Markdown documentation changes; application UI and marketing copy are unchanged.

## Validation

- Checked local links and heading anchors in all seven changed documents.
- Checked shell syntax in fenced examples with documented placeholders substituted, and parsed JSON examples.
- Checked changed configuration guidance against the installer, Compose file, package manifest, and Playwright workflow.
- Git whitespace checks pass. Runtime tests were not run locally for this documentation-only change.
- CI passed lint, typecheck, production builds, unit tests, Postgres journeys, and web E2E. The preview deployment also passed.
- CodeRabbit explicitly skipped automated review because this PR is a draft; there are no review threads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for self-hosting on restricted networks, including offline setup, image mirroring, and Docker registry configuration.
  - Updated sandbox provider documentation with Team Computer defaults, verification steps, and fallback behavior.
  - Clarified published-image requirements, provider setup, deployment layouts, and mobile client configuration.
  - Expanded contributor guidance for live-provider checks and streamlined local development instructions.
  - Added messaging upgrade notes covering webhook paths, provider credentials, and unknown-sender handling.

- **Setup**
  - Setup instructions now use the repository’s declared Node.js and pnpm versions and generate all required application secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->