### PR TITLE
Simplify backend model selection, memory configuration, and sidebar queries

### DIFF
--- a/apps/api/src/memory-provider-config.ts
+++ b/apps/api/src/memory-provider-config.ts
@@ -1,0 +1,144 @@
+import { ORPCError } from "@orpc/server";
+import type { SecretStore } from "@rakazo/adapter-kit";
+import {
+  memoryProviderRequiresDeploymentOwner,
+  prepareMemoryProviderConnection,
+  toStringRecord,
+} from "@rakazo/adapters";
+import type { Actor } from "@rakazo/contracts";
+import { findSpaceMemoryConfig, Prisma, type PrismaClient } from "@rakazo/db";
+import { withSerializableRetry } from "./serializable-retry.js";
+
+export interface MemoryProviderConfigDeps {
+  prisma: PrismaClient;
+  secrets: Pick<SecretStore, "put">;
+}
+
+async function requireSpaceOwner(prisma: PrismaClient, actor: Actor): Promise<void> {
+  const member = await prisma.spaceMember.findUnique({
+    where: { spaceId_userId: { spaceId: actor.spaceId, userId: actor.userId } },
+    select: { role: true },
+  });
+  const roles = member?.role.split(",").map((role) => role.trim());
+  if (!roles?.includes("owner")) throw new ORPCError("FORBIDDEN");
+}
+
+export async function persistMemoryProviderConfig(
+  deps: MemoryProviderConfigDeps,
+  actor: Actor,
+  input: {
+    provider: string;
+    settings: Record<string, string>;
+    credentials: Record<string, string>;
+    defaultMemoryScope: "isolated" | "shared";
+  },
+) {
+  await requireSpaceOwner(deps.prisma, actor);
+  let prepared: Awaited<ReturnType<typeof prepareMemoryProviderConnection>>;
+  try {
+    if (
+      memoryProviderRequiresDeploymentOwner(input.provider, input.settings) &&
+      !actor.isDeploymentOwner
+    ) {
+      throw new ORPCError("FORBIDDEN");
+    }
+    prepared = await prepareMemoryProviderConnection(input);
+  } catch (error) {
+    if (error instanceof ORPCError) throw error;
+    throw new ORPCError("BAD_REQUEST", {
+      message: error instanceof Error ? error.message : "Memory provider connection failed",
+    });
+  }
+  const stored = await deps.secrets.put(JSON.stringify(prepared.credentials), {
+    operationId: "memory-provider-config",
+    traceId: "memory-provider-config",
+    spaceId: actor.spaceId,
+    userId: actor.userId,
+    signal: new AbortController().signal,
+  });
+  const config = await withSerializableRetry(() =>
+    deps.prisma.$transaction(
+      async (tx) => {
+        const existing = await findSpaceMemoryConfig(tx, actor.spaceId);
+        const secret = await tx.secret.create({
+          data: {
+            id: stored.id,
+            userId: actor.userId,
+            spaceId: actor.spaceId,
+            kind: "memory-provider",
+            ciphertext: stored.ciphertext,
+          },
+        });
+        const updated = await tx.spaceMemoryConfig.upsert({
+          where: { spaceId: actor.spaceId },
+          create: {
+            spaceId: actor.spaceId,
+            userId: actor.userId,
+            provider: prepared.provider,
+            settings: prepared.settings,
+            secretId: secret.id,
+            defaultMemoryScope: input.defaultMemoryScope,
+          },
+          update: {
+            userId: actor.userId,
+            provider: prepared.provider,
+            settings: prepared.settings,
+            secretId: secret.id,
+            defaultMemoryScope: input.defaultMemoryScope,
+          },
+        });
+        if (existing && existing.secretId !== secret.id) {
+          await tx.secret.deleteMany({ where: { id: existing.secretId } });
+        }
+        return updated;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    ),
+  );
+  return serializeSpaceMemoryConfig(config);
+}
+
+export async function updateMemoryProviderDefaultScope(
+  deps: MemoryProviderConfigDeps,
+  actor: Actor,
+  defaultMemoryScope: "isolated" | "shared",
+) {
+  await requireSpaceOwner(deps.prisma, actor);
+  const existing = await findSpaceMemoryConfig(deps.prisma, actor.spaceId);
+  if (!existing) throw new ORPCError("NOT_FOUND");
+  const updated = await deps.prisma.spaceMemoryConfig.update({
+    where: { id: existing.id },
+    data: { defaultMemoryScope },
+  });
+  return serializeSpaceMemoryConfig(updated);
+}
+
+export function serializeSpaceMemoryConfig(config: {
+  provider: string;
+  settings: unknown;
+  defaultMemoryScope: string;
+  updatedAt: Date;
+}) {
+  return {
+    provider: config.provider,
+    settings: toStringRecord(config.settings),
+    defaultMemoryScope: config.defaultMemoryScope as "isolated" | "shared",
+    updatedAt: config.updatedAt.toISOString(),
+  };
+}
+
+export async function disconnectMemoryProvider(deps: MemoryProviderConfigDeps, actor: Actor) {
+  await requireSpaceOwner(deps.prisma, actor);
+  await withSerializableRetry(() =>
+    deps.prisma.$transaction(
+      async (tx) => {
+        const existing = await findSpaceMemoryConfig(tx, actor.spaceId);
+        if (!existing) return;
+        await tx.spaceMemoryConfig.delete({ where: { id: existing.id } });
+        await tx.secret.deleteMany({ where: { id: existing.secretId } });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    ),
+  );
+  return { ok: true as const };
+}

--- a/apps/api/src/persist-memory-provider-config.test.ts
+++ b/apps/api/src/persist-memory-provider-config.test.ts
@@ -1,5 +1,10 @@
+import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
-import { persistMemoryProviderConfig, updateMemoryProviderDefaultScope } from "./router.js";
+import {
+  disconnectMemoryProvider,
+  persistMemoryProviderConfig,
+  updateMemoryProviderDefaultScope,
+} from "./memory-provider-config.js";
 
 const actor = {
   userId: "user-1",
@@ -47,6 +52,7 @@ function makeDeps(
       updatedAt: new Date("2026-08-20T00:00:00.000Z"),
     },
   );
+  const deleteConfig = vi.fn().mockResolvedValue({ id: "cfg-1" });
   const prisma = {
     spaceMember: {
       findUnique: vi
@@ -55,7 +61,7 @@ function makeDeps(
           overrides.spaceOwner === false ? null : { role: overrides.memberRole ?? "owner" },
         ),
     },
-    spaceMemoryConfig: { findUnique, update, upsert },
+    spaceMemoryConfig: { findUnique, update, upsert, delete: deleteConfig },
     secret: { create: secretCreate, deleteMany: secretDeleteMany },
     $transaction: vi.fn(),
   };
@@ -63,7 +69,7 @@ function makeDeps(
     callback(prisma),
   );
   const deps = {
-    prisma,
+    prisma: prisma as unknown as PrismaClient,
     secrets: { put: vi.fn().mockResolvedValue({ id: "secret-new", ciphertext: "cipher" }) },
   };
   return {
@@ -73,6 +79,7 @@ function makeDeps(
     findUnique,
     upsert,
     update,
+    deleteConfig,
     transaction: prisma.$transaction,
   };
 }
@@ -93,7 +100,7 @@ describe("persistMemoryProviderConfig", () => {
     const { deps, transaction } = makeDeps();
     try {
       await expect(
-        persistMemoryProviderConfig(deps as never, actor, {
+        persistMemoryProviderConfig(deps, actor, {
           ...connectionInput("cloud"),
           provider: "unknown-provider",
         }),
@@ -114,7 +121,7 @@ describe("persistMemoryProviderConfig", () => {
       try {
         await expect(
           persistMemoryProviderConfig(
-            deps as never,
+            deps,
             deploymentOwner,
             connectionInput("local", `http://127.0.0.1:8123/internal-action${suffix}`),
           ),
@@ -135,7 +142,7 @@ describe("persistMemoryProviderConfig", () => {
       const { deps, transaction } = makeDeps();
       try {
         await expect(
-          persistMemoryProviderConfig(deps as never, actor, connectionInput("local", baseUrl)),
+          persistMemoryProviderConfig(deps, actor, connectionInput("local", baseUrl)),
         ).rejects.toMatchObject({ code: "FORBIDDEN" });
         expect(fetchMock).not.toHaveBeenCalled();
         expect(deps.secrets.put).not.toHaveBeenCalled();
@@ -153,7 +160,7 @@ describe("persistMemoryProviderConfig", () => {
     try {
       await expect(
         persistMemoryProviderConfig(
-          deps as never,
+          deps,
           deploymentOwner,
           connectionInput("local", "http://localhost:6767"),
         ),
@@ -171,7 +178,7 @@ describe("persistMemoryProviderConfig", () => {
     const { deps, upsert } = makeDeps({ spaceOwner: false });
 
     await expect(
-      persistMemoryProviderConfig(deps as never, actor, connectionInput("cloud")),
+      persistMemoryProviderConfig(deps, actor, connectionInput("cloud")),
     ).rejects.toThrow();
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -182,7 +189,7 @@ describe("persistMemoryProviderConfig", () => {
   it("rejects local mode without a baseUrl, without touching the database", async () => {
     const { deps, upsert } = makeDeps();
     await expect(
-      persistMemoryProviderConfig(deps as never, deploymentOwner, connectionInput("local")),
+      persistMemoryProviderConfig(deps, deploymentOwner, connectionInput("local")),
     ).rejects.toThrow(/baseUrl/);
     expect(upsert).not.toHaveBeenCalled();
   });
@@ -193,7 +200,7 @@ describe("persistMemoryProviderConfig", () => {
     const { deps, upsert } = makeDeps();
     await expect(
       persistMemoryProviderConfig(
-        deps as never,
+        deps,
         deploymentOwner,
         connectionInput("local", "http://169.254.169.254/latest/meta-data/"),
       ),
@@ -207,7 +214,7 @@ describe("persistMemoryProviderConfig", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
     const { deps, upsert } = makeDeps();
     await expect(
-      persistMemoryProviderConfig(deps as never, deploymentOwner, {
+      persistMemoryProviderConfig(deps, deploymentOwner, {
         ...connectionInput("local", "http://localhost:6767"),
         credentials: { apiKey: "sm_bad_key" },
       }),
@@ -222,7 +229,7 @@ describe("persistMemoryProviderConfig", () => {
     const { deps, upsert } = makeDeps();
 
     await persistMemoryProviderConfig(
-      deps as never,
+      deps,
       deploymentOwner,
       connectionInput("local", "http://[::1]:6767"),
     );
@@ -235,11 +242,7 @@ describe("persistMemoryProviderConfig", () => {
   it("connects cloud mode, defaulting the base URL, and returns the serialized config", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("[]", { status: 200 })));
     const { deps, upsert, transaction } = makeDeps();
-    const result = await persistMemoryProviderConfig(
-      deps as never,
-      actor,
-      connectionInput("cloud"),
-    );
+    const result = await persistMemoryProviderConfig(deps, actor, connectionInput("cloud"));
     expect(upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { spaceId: "ws-1" },
@@ -264,12 +267,46 @@ describe("persistMemoryProviderConfig", () => {
     const { deps, secretDeleteMany } = makeDeps({
       existing: { id: "cfg-1", secretId: "secret-old" },
     });
-    await persistMemoryProviderConfig(deps as never, actor, {
+    await persistMemoryProviderConfig(deps, actor, {
       ...connectionInput("cloud"),
       credentials: { apiKey: "sm_new_key_12345" },
     });
     expect(secretDeleteMany).toHaveBeenCalledWith({ where: { id: "secret-old" } });
     vi.unstubAllGlobals();
+  });
+});
+
+describe("disconnectMemoryProvider", () => {
+  it("rejects non-owners before opening a transaction", async () => {
+    const { deps, transaction, secretDeleteMany } = makeDeps({ spaceOwner: false });
+
+    await expect(disconnectMemoryProvider(deps, actor)).rejects.toThrow();
+
+    expect(transaction).not.toHaveBeenCalled();
+    expect(secretDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("disconnects an existing provider and removes its secret in the same transaction", async () => {
+    const { deps, transaction, deleteConfig, secretDeleteMany } = makeDeps({
+      existing: { id: "cfg-1", secretId: "secret-old" },
+    });
+
+    await expect(disconnectMemoryProvider(deps, actor)).resolves.toEqual({ ok: true });
+
+    expect(transaction).toHaveBeenCalledExactlyOnceWith(expect.any(Function), {
+      isolationLevel: "Serializable",
+    });
+    expect(deleteConfig).toHaveBeenCalledWith({ where: { id: "cfg-1" } });
+    expect(secretDeleteMany).toHaveBeenCalledWith({ where: { id: "secret-old" } });
+  });
+
+  it("leaves secrets untouched when no provider is configured", async () => {
+    const { deps, deleteConfig, secretDeleteMany } = makeDeps();
+
+    await expect(disconnectMemoryProvider(deps, actor)).resolves.toEqual({ ok: true });
+
+    expect(deleteConfig).not.toHaveBeenCalled();
+    expect(secretDeleteMany).not.toHaveBeenCalled();
   });
 });
 
@@ -280,7 +317,7 @@ describe("updateMemoryProviderDefaultScope", () => {
       memberRole: "owner,admin",
     });
 
-    await updateMemoryProviderDefaultScope(deps as never, actor, "shared");
+    await updateMemoryProviderDefaultScope(deps, actor, "shared");
 
     expect(update).toHaveBeenCalled();
   });
@@ -290,7 +327,7 @@ describe("updateMemoryProviderDefaultScope", () => {
       existing: { id: "cfg-1", secretId: "secret-existing" },
     });
 
-    const result = await updateMemoryProviderDefaultScope(deps as never, actor, "shared");
+    const result = await updateMemoryProviderDefaultScope(deps, actor, "shared");
 
     expect(update).toHaveBeenCalledWith({
       where: { id: "cfg-1" },
@@ -307,9 +344,7 @@ describe("updateMemoryProviderDefaultScope", () => {
       spaceOwner: false,
     });
 
-    await expect(
-      updateMemoryProviderDefaultScope(deps as never, actor, "shared"),
-    ).rejects.toThrow();
+    await expect(updateMemoryProviderDefaultScope(deps, actor, "shared")).rejects.toThrow();
     expect(update).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -47,12 +47,10 @@ import {
   McpOAuthBroker,
   type MemoryProviderResolver,
   mapScratchpadItem,
-  memoryProviderRequiresDeploymentOwner,
   modelCredentialDto,
   type PiOAuthLogins,
   planLiveConnectionSync,
   prepareApiInstall,
-  prepareMemoryProviderConnection,
   probeOpenAiCompatibleModels,
   provisionComputer,
   type RemoteConnectorDependencies,
@@ -69,7 +67,6 @@ import {
   serializeModelSecret,
   takeoverLeaseMs,
   toComputerRef,
-  toStringRecord,
   touchRunningComputer,
   verifyMcpInstall,
 } from "@rakazo/adapters";
@@ -128,6 +125,12 @@ import {
   toComputerStatus,
 } from "./computer-status.js";
 import { buildMcpUpdateMaterial } from "./mcp-material.js";
+import {
+  disconnectMemoryProvider,
+  persistMemoryProviderConfig,
+  serializeSpaceMemoryConfig,
+  updateMemoryProviderDefaultScope,
+} from "./memory-provider-config.js";
 import {
   chooseFocus,
   dismissFocus,
@@ -1875,21 +1878,9 @@ export function createRouter(deps: RouterDeps) {
       setDefaultScope: authed.memory.setDefaultScope.handler(async ({ context, input }) =>
         updateMemoryProviderDefaultScope(deps, context.actor, input.defaultMemoryScope),
       ),
-      disconnectProvider: authed.memory.disconnectProvider.handler(async ({ context }) => {
-        await requireSpaceOwner(deps.prisma, context.actor);
-        await withSerializableRetry(() =>
-          deps.prisma.$transaction(
-            async (tx) => {
-              const existing = await findSpaceMemoryConfig(tx, context.actor.spaceId);
-              if (!existing) return;
-              await tx.spaceMemoryConfig.delete({ where: { id: existing.id } });
-              await tx.secret.deleteMany({ where: { id: existing.secretId } });
-            },
-            { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-          ),
-        );
-        return { ok: true as const };
-      }),
+      disconnectProvider: authed.memory.disconnectProvider.handler(async ({ context }) =>
+        disconnectMemoryProvider(deps, context.actor),
+      ),
     },
     routines: {
       list: authed.routines.list.handler(async ({ context, input }) => {
@@ -4016,119 +4007,6 @@ async function persistModelCredential(
     ),
   );
   return modelCredentialDto(cred, input.plaintext);
-}
-
-async function requireSpaceOwner(prisma: PrismaClient, actor: Actor): Promise<void> {
-  const member = await prisma.spaceMember.findUnique({
-    where: { spaceId_userId: { spaceId: actor.spaceId, userId: actor.userId } },
-    select: { role: true },
-  });
-  const roles = member?.role.split(",").map((role) => role.trim());
-  if (!roles?.includes("owner")) throw new ORPCError("FORBIDDEN");
-}
-
-export async function persistMemoryProviderConfig(
-  deps: RouterDeps,
-  actor: Actor,
-  input: {
-    provider: string;
-    settings: Record<string, string>;
-    credentials: Record<string, string>;
-    defaultMemoryScope: "isolated" | "shared";
-  },
-) {
-  await requireSpaceOwner(deps.prisma, actor);
-  let prepared: Awaited<ReturnType<typeof prepareMemoryProviderConnection>>;
-  try {
-    if (
-      memoryProviderRequiresDeploymentOwner(input.provider, input.settings) &&
-      !actor.isDeploymentOwner
-    ) {
-      throw new ORPCError("FORBIDDEN");
-    }
-    prepared = await prepareMemoryProviderConnection(input);
-  } catch (error) {
-    if (error instanceof ORPCError) throw error;
-    throw new ORPCError("BAD_REQUEST", {
-      message: error instanceof Error ? error.message : "Memory provider connection failed",
-    });
-  }
-  const stored = await deps.secrets.put(JSON.stringify(prepared.credentials), {
-    operationId: "memory-provider-config",
-    traceId: "memory-provider-config",
-    spaceId: actor.spaceId,
-    userId: actor.userId,
-    signal: new AbortController().signal,
-  });
-  const config = await withSerializableRetry(() =>
-    deps.prisma.$transaction(
-      async (tx) => {
-        const existing = await findSpaceMemoryConfig(tx, actor.spaceId);
-        const secret = await tx.secret.create({
-          data: {
-            id: stored.id,
-            userId: actor.userId,
-            spaceId: actor.spaceId,
-            kind: "memory-provider",
-            ciphertext: stored.ciphertext,
-          },
-        });
-        const updated = await tx.spaceMemoryConfig.upsert({
-          where: { spaceId: actor.spaceId },
-          create: {
-            spaceId: actor.spaceId,
-            userId: actor.userId,
-            provider: prepared.provider,
-            settings: prepared.settings,
-            secretId: secret.id,
-            defaultMemoryScope: input.defaultMemoryScope,
-          },
-          update: {
-            userId: actor.userId,
-            provider: prepared.provider,
-            settings: prepared.settings,
-            secretId: secret.id,
-            defaultMemoryScope: input.defaultMemoryScope,
-          },
-        });
-        if (existing && existing.secretId !== secret.id) {
-          await tx.secret.deleteMany({ where: { id: existing.secretId } });
-        }
-        return updated;
-      },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-    ),
-  );
-  return serializeSpaceMemoryConfig(config);
-}
-
-export async function updateMemoryProviderDefaultScope(
-  deps: RouterDeps,
-  actor: Actor,
-  defaultMemoryScope: "isolated" | "shared",
-) {
-  await requireSpaceOwner(deps.prisma, actor);
-  const existing = await findSpaceMemoryConfig(deps.prisma, actor.spaceId);
-  if (!existing) throw new ORPCError("NOT_FOUND");
-  const updated = await deps.prisma.spaceMemoryConfig.update({
-    where: { id: existing.id },
-    data: { defaultMemoryScope },
-  });
-  return serializeSpaceMemoryConfig(updated);
-}
-
-function serializeSpaceMemoryConfig(config: {
-  provider: string;
-  settings: unknown;
-  defaultMemoryScope: string;
-  updatedAt: Date;
-}) {
-  return {
-    provider: config.provider,
-    settings: toStringRecord(config.settings),
-    defaultMemoryScope: config.defaultMemoryScope as "isolated" | "shared",
-    updatedAt: config.updatedAt.toISOString(),
-  };
 }
 
 function throwIfAborted(signal?: AbortSignal) {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -180,6 +180,7 @@ import {
 import { loadAgentMemoryContext } from "./memory-context.js";
 import type { MemoryProviderResolver } from "./memory-provider-factory.js";
 import { selectMemoryTools } from "./memory-tools.js";
+import { selectConfiguredModel } from "./model-selection.js";
 import {
   filterImageReturningComputerTools,
   IMAGE_RETURNING_COMPUTER_TOOLS,
@@ -588,21 +589,15 @@ export function createRunExecutor(deps: ExecutorDeps) {
         findDefaultModelCredential(deps.prisma, scope),
         deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
       ]);
-      // Keep provider/model/credential as one unit — never pair an override
-      // provider with a Space or deployment secret from another provider.
-      const useOverride = Boolean(hasOverride && overrideCredential);
-      const credential = useOverride ? overrideCredential : defaultCredential;
-      const deployment = deps.deploymentModelKey ? resolveDeploymentModel() : null;
-      let provider =
-        (useOverride ? override!.modelProvider : null) ??
-        credential?.provider ??
-        settings?.defaultModelProvider ??
-        deployment?.provider;
-      let id =
-        (useOverride ? override!.modelId : null) ??
-        credential?.defaultModel ??
-        settings?.defaultModelId ??
-        deployment?.model;
+      const selected = selectConfiguredModel({
+        bot: override,
+        overrideCredential,
+        defaultCredential,
+        settings,
+        deployment: deps.deploymentModelKey ? resolveDeploymentModel() : null,
+      });
+      const { credential, thinkingLevel } = selected;
+      let { provider, id } = selected;
       if (!provider || !id) {
         const runtimeFallback = runtimeFallbackModel(deps.runtime);
         provider ??= runtimeFallback?.provider;
@@ -622,12 +617,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         id,
         apiKey: resolved.oauth ? undefined : resolved.apiKey,
         baseUrl: resolved.baseUrl,
-        thinkingLevel:
-          // Apply bot thinking with a successful override or Space default.
-          // Drop it only when an override existed but its credential was missing.
-          hasOverride && !useOverride
-            ? null
-            : ((override?.thinkingLevel as AgentRunRequest["model"]["thinkingLevel"]) ?? null),
+        thinkingLevel,
         oauth: resolved.oauth
           ? { credential: resolved.oauth, persist: resolved.persistOAuth }
           : undefined,
@@ -929,10 +919,6 @@ export function createRunExecutor(deps: ExecutorDeps) {
           hasModelOverride && bot.modelProvider
             ? await findModelCredential(deps.prisma, run, bot.modelProvider)
             : null;
-        // Keep provider/model/credential as one unit — never use the Space
-        // default secret for a different override provider.
-        const useModelOverride = Boolean(hasModelOverride && overrideCredential);
-        const credential = useModelOverride ? overrideCredential! : defaultCredential;
         runAbortController = new AbortController();
         if (!leaseValid) runAbortController.abort();
         const composioRows = storedConnections.filter(
@@ -1095,18 +1081,16 @@ export function createRunExecutor(deps: ExecutorDeps) {
         }
         const runDeployment = deps.deploymentModelKey ? resolveDeploymentModel() : null;
         const runtimeFallback = runtimeFallbackModel(deps.runtime);
-        const runModelProvider =
-          (useModelOverride ? bot.modelProvider : null) ??
-          credential?.provider ??
-          settings?.defaultModelProvider ??
-          runDeployment?.provider ??
-          runtimeFallback?.provider;
-        const runModelId =
-          (useModelOverride ? bot.modelId : null) ??
-          credential?.defaultModel ??
-          settings?.defaultModelId ??
-          runDeployment?.model ??
-          runtimeFallback?.id;
+        const selected = selectConfiguredModel({
+          bot,
+          overrideCredential,
+          defaultCredential,
+          settings,
+          deployment: runDeployment,
+        });
+        const { credential, thinkingLevel } = selected;
+        const runModelProvider = selected.provider ?? runtimeFallback?.provider;
+        const runModelId = selected.id ?? runtimeFallback?.id;
         if (!runModelProvider || !runModelId) {
           const failed = await deps.events.finalizeRun({
             spaceId: run.spaceId,
@@ -2984,10 +2968,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 id: runModelId,
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 baseUrl: resolved.baseUrl,
-                thinkingLevel:
-                  hasModelOverride && !useModelOverride
-                    ? null
-                    : ((bot.thinkingLevel as AgentRunRequest["model"]["thinkingLevel"]) ?? null),
+                thinkingLevel,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }
                   : undefined,

--- a/packages/adapters/src/model-selection.test.ts
+++ b/packages/adapters/src/model-selection.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { selectConfiguredModel } from "./model-selection.js";
+
+type SelectionInput = Parameters<typeof selectConfiguredModel>[0];
+
+function credential(provider: string, defaultModel: string | null) {
+  return {
+    id: `credential-${provider}`,
+    userId: "user-1",
+    provider,
+    label: provider,
+    secretId: `secret-${provider}`,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    isDefault: false,
+    defaultModel,
+  };
+}
+
+const spaceCredential = credential("space-provider", "space-model");
+const overrideCredential = credential("bot-provider", "stored-model");
+const bot = { modelProvider: "bot-provider", modelId: "bot-model", thinkingLevel: "high" };
+const defaults: SelectionInput = {
+  bot: null,
+  overrideCredential: null,
+  defaultCredential: spaceCredential,
+  settings: { defaultModelProvider: "settings-provider", defaultModelId: "settings-model" },
+  deployment: { provider: "deployment-provider", model: "deployment-model" },
+};
+
+describe("configured model selection", () => {
+  it.each<{
+    name: string;
+    input: Partial<SelectionInput>;
+    expected: ReturnType<typeof selectConfiguredModel>;
+  }>([
+    {
+      name: "uses the bot's model with its own credential",
+      input: { bot, overrideCredential },
+      expected: {
+        provider: "bot-provider",
+        id: "bot-model",
+        credential: overrideCredential,
+        thinkingLevel: "high",
+      },
+    },
+    {
+      name: "drops override thinking when its provider has no credential",
+      input: { bot },
+      expected: {
+        provider: "space-provider",
+        id: "space-model",
+        credential: spaceCredential,
+        thinkingLevel: null,
+      },
+    },
+    {
+      name: "keeps bot thinking with the Space default",
+      input: { bot: { modelProvider: null, modelId: null, thinkingLevel: "high" } },
+      expected: {
+        provider: "space-provider",
+        id: "space-model",
+        credential: spaceCredential,
+        thinkingLevel: "high",
+      },
+    },
+    {
+      name: "does not select an incomplete bot override",
+      input: { bot: { ...bot, modelId: null }, overrideCredential },
+      expected: {
+        provider: "space-provider",
+        id: "space-model",
+        credential: spaceCredential,
+        thinkingLevel: "high",
+      },
+    },
+    {
+      name: "uses settings before deployment defaults without inventing a credential",
+      input: { defaultCredential: null },
+      expected: {
+        provider: "settings-provider",
+        id: "settings-model",
+        credential: null,
+        thinkingLevel: null,
+      },
+    },
+    {
+      name: "uses deployment defaults when no stored configuration exists",
+      input: { defaultCredential: null, settings: null },
+      expected: {
+        provider: "deployment-provider",
+        id: "deployment-model",
+        credential: null,
+        thinkingLevel: null,
+      },
+    },
+    {
+      name: "leaves missing configuration for the caller's runtime fallback or failure path",
+      input: { defaultCredential: null, settings: null, deployment: null },
+      expected: {
+        provider: undefined,
+        id: undefined,
+        credential: null,
+        thinkingLevel: null,
+      },
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(selectConfiguredModel({ ...defaults, ...input })).toEqual(expected);
+  });
+});

--- a/packages/adapters/src/model-selection.ts
+++ b/packages/adapters/src/model-selection.ts
@@ -1,0 +1,41 @@
+import type { AgentRunRequest } from "@rakazo/adapter-kit";
+import type { findDefaultModelCredential } from "@rakazo/db";
+
+type ModelCredential = Awaited<ReturnType<typeof findDefaultModelCredential>>;
+
+/** Select configuration without loading secrets or applying a runtime-specific fallback. */
+export function selectConfiguredModel(input: {
+  bot: {
+    modelProvider: string | null;
+    modelId: string | null;
+    thinkingLevel: string | null;
+  } | null;
+  overrideCredential: ModelCredential;
+  defaultCredential: ModelCredential;
+  settings: { defaultModelProvider: string | null; defaultModelId: string | null } | null;
+  deployment: { provider: string; model: string } | null;
+}) {
+  const { bot, overrideCredential, defaultCredential, settings, deployment } = input;
+  const hasOverride = Boolean(bot?.modelProvider && bot.modelId);
+  // The override provider, model and credential must win together.
+  const useOverride = Boolean(hasOverride && overrideCredential);
+  const credential = useOverride ? overrideCredential : defaultCredential;
+  return {
+    provider:
+      (useOverride ? bot!.modelProvider : null) ??
+      credential?.provider ??
+      settings?.defaultModelProvider ??
+      deployment?.provider,
+    id:
+      (useOverride ? bot!.modelId : null) ??
+      credential?.defaultModel ??
+      settings?.defaultModelId ??
+      deployment?.model,
+    credential,
+    // Preserve bot thinking for the Space default; drop it for an unavailable override.
+    thinkingLevel:
+      hasOverride && !useOverride
+        ? null
+        : ((bot?.thinkingLevel as AgentRunRequest["model"]["thinkingLevel"]) ?? null),
+  };
+}

--- a/packages/db/src/repos.test.ts
+++ b/packages/db/src/repos.test.ts
@@ -59,6 +59,79 @@ describe("createRepos.listBots", () => {
     ]);
   });
 
+  it("classifies initial preview runs once across bots, including non-peer results", async () => {
+    const prisma = {
+      bot: {
+        findMany: vi.fn(async () =>
+          ["one", "two"].map((id) => ({
+            ...baseBot,
+            id,
+            thread: {
+              ...baseBot.thread,
+              id: `thread-${id}`,
+              messages: [{ runId: `run-${id}`, blocks: [{ kind: "text", text: `Answer ${id}` }] }],
+            },
+          })),
+        ),
+      },
+      run: { findMany: vi.fn(async () => []) },
+    };
+
+    const bots = await createRepos(prisma as unknown as PrismaClient).listBots(actor);
+
+    expect(bots.map((bot) => bot.preview)).toEqual(["Answer one", "Answer two"]);
+    expect(prisma.run.findMany).toHaveBeenCalledExactlyOnceWith({
+      where: { id: { in: ["run-one", "run-two"] }, trigger: "bot_message" },
+      select: { id: true },
+    });
+  });
+
+  it("classifies unseen runs in older pages and retains negative results between pages", async () => {
+    const prisma = {
+      bot: {
+        findMany: vi.fn(async () => [
+          {
+            ...baseBot,
+            thread: {
+              ...baseBot.thread,
+              messages: [
+                { seq: 30, runId: "peer-new", blocks: [{ kind: "text", text: "Hidden" }] },
+              ],
+            },
+          },
+        ]),
+      },
+      run: {
+        findMany: vi
+          .fn()
+          .mockResolvedValueOnce([{ id: "peer-new" }])
+          .mockResolvedValueOnce([{ id: "peer-old" }]),
+      },
+      message: {
+        findMany: vi
+          .fn()
+          .mockResolvedValueOnce([
+            { seq: 20, runId: "peer-old", blocks: [{ kind: "text", text: "Also hidden" }] },
+            { seq: 19, runId: "user-old", blocks: [] },
+          ])
+          .mockResolvedValueOnce([
+            { seq: 10, runId: "peer-old", blocks: [{ kind: "text", text: "Still hidden" }] },
+            { seq: 9, runId: "user-old", blocks: [{ kind: "text", text: "Visible answer" }] },
+          ]),
+      },
+    };
+
+    const bots = await createRepos(prisma as unknown as PrismaClient).listBots(actor);
+
+    expect(bots[0]?.preview).toBe("Visible answer");
+    expect(prisma.run.findMany).toHaveBeenCalledTimes(2);
+    expect(prisma.run.findMany).toHaveBeenNthCalledWith(2, {
+      where: { id: { in: ["peer-old", "user-old"] }, trigger: "bot_message" },
+      select: { id: true },
+    });
+    expect(prisma.message.findMany).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps bot-to-bot run output out of sidebar previews", async () => {
     const findMany = vi.fn(async () => [
       {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -257,6 +257,8 @@ export function createRepos(prisma: PrismaClient) {
           })
         : [];
       const peerRunIds = new Set(peerRuns.map((run) => run.id));
+      // Cache negative results too; ordinary runs were already checked in the batch above.
+      const checkedRunIds = new Set(candidateRunIds);
       return Promise.all(
         bots.map(async (bot) => {
           let messages = bot.thread?.messages ?? [];
@@ -264,13 +266,14 @@ export function createRepos(prisma: PrismaClient) {
           for (let attempt = 0; attempt < 5; attempt++) {
             const windowRunIds = [
               ...new Set(messages.flatMap((message) => (message.runId ? [message.runId] : []))),
-            ].filter((runId) => !peerRunIds.has(runId));
+            ].filter((runId) => !checkedRunIds.has(runId));
             if (windowRunIds.length > 0) {
               const morePeers = await prisma.run.findMany({
                 where: { id: { in: windowRunIds }, trigger: "bot_message" },
                 select: { id: true },
               });
               for (const run of morePeers) peerRunIds.add(run.id);
+              for (const runId of windowRunIds) checkedRunIds.add(runId);
             }
             const visible = userVisibleMessages(
               messages.map((message) => ({


### PR DESCRIPTION
## Why

Model selection is maintained twice in the run executor, memory provider configuration is coupled to the entire API router, and sidebar refreshes repeat run classification queries whose results are already known. These make routine changes harder to review and maintain.

## Changes

- Share configured model and credential selection between model resolution and run execution, preserving precedence, thinking levels, runtime fallbacks, and secret handling.
- Extract memory provider configuration into a service with database and secret-writing dependencies, preserving authorization, validation, secret rotation, and transaction boundaries.
- Reuse positive and negative sidebar run classifications across preview pages so ordinary conversations do not trigger redundant per-bot lookups.
- Cover model precedence, sidebar query counts and visibility, and memory-provider disconnection with deterministic tests.

## Validation

- CI passed: lint, typechecking, unit tests, Postgres journeys, production builds with the Electron smoke test, web E2E, and container image validation.
- Project-wide typechecking passed.
- Project-wide lint passed with existing warnings.
- Full unit run: 3,024 passed and 122 skipped. One Docker supervisor conformance test failed because its test home path was rejected; the same failure was reproduced on main in a separate checkout.
- All changed-area tests passed, including the upstream deployment-owner authorization cases.
- Independent reuse, quality, and efficiency reviews found no actionable issues.
