### PR TITLE
feat: choose computer mode when creating or spawning bots

### DIFF
--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -90,9 +90,13 @@ export async function captureScreenshot(page: Page, testInfo: TestInfo, name: st
   await testInfo.attach(name, { contentType: "image/png", path: screenshotPath });
 }
 
-export async function openNewBot(page: Page) {
+export async function openNewBot(page: Page, computerMode: "team" | "dedicated" = "team") {
   await page.getByTestId("create-menu-trigger").click();
   await page.getByTestId("create-new-bot").click();
+  await expect(page.getByTestId("create-bot-computer")).toBeVisible();
+  await page
+    .getByTestId(computerMode === "team" ? "create-bot-team" : "create-bot-private")
+    .click();
 }
 
 export async function openNewGroup(page: Page) {

--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -4,6 +4,7 @@ import {
   completeOnboarding,
   createBotFromPicker,
   openNewBot,
+  rpc,
   signup,
 } from "./helpers";
 
@@ -22,6 +23,12 @@ test("create opens empty chat, picker lists bots, and sidebar collapses", async 
   await expect(picker.getByTestId("create-new-bot")).toBeVisible();
   await expect(picker.getByText("Chief", { exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "plus-picker-bots");
+
+  await picker.getByTestId("create-new-bot").click();
+  await expect(picker.getByTestId("create-bot-computer")).toBeVisible();
+  await expect(picker.getByTestId("create-bot-team")).toBeVisible();
+  await expect(picker.getByTestId("create-bot-private")).toBeVisible();
+  await captureScreenshot(page, testInfo, "plus-picker-computer-mode");
   await page.keyboard.press("Escape");
 
   await createBotFromPicker(page);
@@ -72,4 +79,21 @@ test("later bot waits before showing the focus card; sending cancels it", async 
   await page.keyboard.press("Enter");
   await page.clock.fastForward(12_000);
   await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
+});
+
+test("plus picker can create a Private computer bot", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `new-bot-private-${stamp}@rakazo.test`, "password12", "New Bot Private");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  await openNewBot(page, "dedicated");
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await expect(page.getByPlaceholder("Message New Bot")).toBeVisible();
+  await captureScreenshot(page, testInfo, "create-private-computer-bot");
+
+  const botId = page.url().split("/").pop()!;
+  const bots = await rpc<Array<{ id: string; computerMode: string }>>(page, "bots/list", {});
+  expect(bots.find((bot) => bot.id === botId)?.computerMode).toBe("dedicated");
 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2286,7 +2286,7 @@ export function ShellPage() {
     await refreshBots().catch(() => undefined);
   }
 
-  async function createBotQuick() {
+  async function createBotQuick(computerMode: ComputerMode = "team") {
     if (creatingBotRef.current) return;
     creatingBotRef.current = true;
     try {
@@ -2294,7 +2294,7 @@ export function ShellPage() {
         name: "New Bot",
         title: "",
         description: "",
-        computerMode: "team",
+        computerMode,
       });
     } catch (error) {
       // Keep the current chat open when create fails, but surface the error.
@@ -2580,9 +2580,9 @@ export function ShellPage() {
                 >
                   <BotCreatePicker
                     bots={bots}
-                    onCreateBot={() => {
+                    onCreateBot={(computerMode) => {
                       setCreateMenuOpen(false);
-                      void createBotQuick();
+                      void createBotQuick(computerMode);
                     }}
                     onOpenBot={(id) => {
                       setCreateMenuOpen(false);

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import type { Bot } from "@rakazo/contracts";
+import type { Bot, ComputerMode } from "@rakazo/contracts";
 import {
   BotAvatar,
   Command,
@@ -9,7 +9,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@rakazo/ui-web";
-import { Lock, Plus } from "lucide-react";
+import { ArrowLeft, Lock, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 
 export function BotCreatePicker({
@@ -20,13 +20,14 @@ export function BotCreatePicker({
   onCreateSpace,
 }: {
   bots: Bot[];
-  onCreateBot: () => void;
+  onCreateBot: (computerMode: ComputerMode) => void;
   onOpenBot: (botId: string) => void;
   onCreateGroup: () => void;
   onCreateSpace: () => void;
 }) {
   const { t } = useLingui();
   const [query, setQuery] = useState("");
+  const [step, setStep] = useState<"pick" | "computer">("pick");
   const needle = query.trim().toLowerCase();
   const matched = useMemo(() => {
     if (!needle) return bots;
@@ -38,6 +39,45 @@ export function BotCreatePicker({
     !needle ||
     "create new bot".includes(needle) ||
     needle.split(/\s+/).every((part) => "create new bot".includes(part));
+
+  if (step === "computer") {
+    return (
+      <div data-testid="bot-create-picker" className="w-[min(320px,calc(100vw-2rem))]">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <button
+            type="button"
+            data-testid="create-bot-computer-back"
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={t`Back`}
+            onClick={() => setStep("pick")}
+          >
+            <ArrowLeft size={16} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+          <span className="text-[13px] text-muted-foreground">
+            <Trans>Computer</Trans>
+          </span>
+        </div>
+        <div data-testid="create-bot-computer" className="grid grid-cols-2 gap-2 p-3">
+          <button
+            type="button"
+            data-testid="create-bot-team"
+            className="rounded-lg border border-border px-3 py-2 text-[14px] text-foreground hover:border-foreground/40"
+            onClick={() => onCreateBot("team")}
+          >
+            <Trans>Team</Trans>
+          </button>
+          <button
+            type="button"
+            data-testid="create-bot-private"
+            className="rounded-lg border border-border px-3 py-2 text-[14px] text-foreground hover:border-foreground/40"
+            onClick={() => onCreateBot("dedicated")}
+          >
+            <Trans>Private</Trans>
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div data-testid="bot-create-picker" className="w-[min(320px,calc(100vw-2rem))]">
@@ -63,7 +103,7 @@ export function BotCreatePicker({
               <CommandItem
                 value="create-new-bot"
                 data-testid="create-new-bot"
-                onSelect={() => onCreateBot()}
+                onSelect={() => setStep("computer")}
                 className="gap-2"
               >
                 <Plus size={16} strokeWidth={1.8} aria-hidden="true" />

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -681,6 +681,12 @@ export const builtinAgentTools: ConnectorTool[] = [
           type: "string",
           description: "Optional first task to run in the new bot's thread.",
         },
+        computer_mode: {
+          type: "string",
+          enum: ["team", "dedicated"],
+          description:
+            "Optional. team shares one screen with other Team bots; dedicated (Private) gets its own. Defaults to team.",
+        },
       },
       required: ["name"],
     },

--- a/packages/adapters/src/child-bots.test.ts
+++ b/packages/adapters/src/child-bots.test.ts
@@ -5,7 +5,7 @@ import type {
   JobPublisher,
   SandboxProvider,
 } from "@rakazo/adapter-kit";
-import type { PrismaClient } from "@rakazo/db";
+import type { createRepos, PrismaClient } from "@rakazo/db";
 import { describe, expect, it, vi } from "vitest";
 import {
   archiveBot,
@@ -93,6 +93,54 @@ describe("spawned bot creation", () => {
       threadId: "thread-1",
     });
     expect(enqueue).toHaveBeenCalledOnce();
+  });
+
+  it("passes computerMode through to createBot", async () => {
+    const createBot = vi.fn().mockResolvedValue({
+      id: "child-2",
+      name: "Painter",
+      title: "",
+      threadId: "thread-2",
+    });
+    const createReposSpy = vi.spyOn(await import("@rakazo/db"), "createRepos").mockReturnValue({
+      createBot,
+    } as unknown as ReturnType<typeof createRepos>);
+
+    const result = await spawnBot(
+      {
+        prisma: {} as PrismaClient,
+        jobs: { enqueue: vi.fn() } as unknown as JobPublisher,
+      },
+      {
+        spawnedBy: {
+          id: "parent-1",
+          name: "Chief",
+          spaceId: "workspace-1",
+          userId: "user-1",
+        },
+        runId: "run-1",
+        spawnKey: "tool-call-2",
+        name: "Painter",
+        computerMode: "dedicated",
+      },
+    );
+
+    expect(createBot).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", spaceId: "workspace-1" }),
+      expect.objectContaining({
+        name: "Painter",
+        computerMode: "dedicated",
+        parentBotId: "parent-1",
+      }),
+    );
+    expect(result).toEqual({
+      ok: true,
+      botId: "child-2",
+      name: "Painter",
+      title: "",
+      threadId: "thread-2",
+    });
+    createReposSpy.mockRestore();
   });
 });
 describe("spawned bot archival", () => {

--- a/packages/adapters/src/child-bots.ts
+++ b/packages/adapters/src/child-bots.ts
@@ -7,7 +7,7 @@ import type {
   SandboxProvider,
 } from "@rakazo/adapter-kit";
 import { routineJobKey, runContinueJob, runJobKey } from "@rakazo/adapter-kit";
-import { type Actor, type Bot, GROUP_MEMBER_MIN } from "@rakazo/contracts";
+import { type Actor, type Bot, type ComputerMode, GROUP_MEMBER_MIN } from "@rakazo/contracts";
 import { ACTIVE_RUN_STATUSES } from "@rakazo/core";
 import {
   computerScopeKey,
@@ -51,6 +51,7 @@ export async function spawnBot(
     title?: string;
     instructions?: string;
     prompt?: string;
+    computerMode?: ComputerMode;
   },
 ) {
   const name = input.name.trim();
@@ -73,6 +74,7 @@ export async function spawnBot(
       notifyOnFinish: true,
       parentBotId: input.spawnedBy.id,
       spawnKey: input.spawnKey,
+      computerMode: input.computerMode,
       initialMessage: {
         role: "system",
         blocks: [{ kind: "meta", text: `Created by ${input.spawnedBy.name}` }],

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2772,6 +2772,17 @@ export function createRunExecutor(deps: ExecutorDeps) {
             }
           }
           if (name === "spawn_bot") {
+            const computerModeArg = args.computer_mode;
+            let computerMode: "team" | "dedicated" | undefined;
+            if (computerModeArg != null && computerModeArg !== "") {
+              const value = String(computerModeArg);
+              if (value !== "team" && value !== "dedicated") {
+                return finish({
+                  error: 'computer_mode must be "team" or "dedicated".',
+                });
+              }
+              computerMode = value;
+            }
             const spawned = await spawnBot(deps, {
               spawnedBy: {
                 id: bot.id,
@@ -2785,6 +2796,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
               title: args.title ? String(args.title) : undefined,
               instructions: args.instructions ? String(args.instructions) : undefined,
               prompt: args.prompt ? String(args.prompt) : undefined,
+              computerMode,
             });
             if ("error" in spawned) return finish(spawned);
             if (!(await persistEffectResult(spawned))) return uncertainEffectResult(name);

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -652,6 +652,7 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
           title: raw.title ? String(raw.title) : "",
           instructions: raw.instructions ? String(raw.instructions) : "",
           prompt: raw.prompt ? String(raw.prompt) : "",
+          computer_mode: raw.computer_mode ? String(raw.computer_mode) : "",
         };
       }
       if (tool.name === "create_space") {
@@ -973,6 +974,7 @@ function builtinParameters(tool: ConnectorTool) {
       title: Type.Optional(Type.String()),
       instructions: Type.Optional(Type.String()),
       prompt: Type.Optional(Type.String()),
+      computer_mode: Type.Optional(Type.Union([Type.Literal("team"), Type.Literal("dedicated")])),
     });
   }
   if (tool.name === "create_space") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
New bots from the + picker and from `spawn_bot` always landed on Team computer. Team shares one graphical session, so bots meant for concurrent GUI work failed until someone switched each bot to Private in settings.

## What changed
- **+ picker:** after “Create new Bot”, choose **Team** or **Private** (default path still Team). Short labels only.
- **`spawn_bot`:** optional `computer_mode` (`team` | `dedicated`) passed through to bot creation; invalid values error; omitted keeps Team.
- **Tests:** unit coverage that `spawnBot` forwards `computerMode`; Playwright opens the creation flow showing the computer-mode control (CI gallery frame) and creates a Private bot via the picker.

## Copy added
- `Computer`
- `Team`
- `Private`
- `Back` (aria-label)

Necessary so the choice is visible at create time. Revealing only later in settings leaves concurrent GUI spawns broken until a manual fix.

## Testing
- `vitest run packages/adapters/src/child-bots.test.ts` (12 passed)
- Playwright E2E updates in `new-bot-ux.spec.ts` for CI (not run locally for screenshots)

Fixes #706

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e7b574d-f3ac-4a57-887d-3e03fa706426?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e7b574d-f3ac-4a57-887d-3e03fa706426&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-step bot creation flow with selectable Team and Private computer modes.
  * Quick bot creation now supports choosing the computer mode.
  * Bot spawning now supports an optional computer mode selection, defaulting to Team.

* **Bug Fixes**
  * Added validation for unsupported computer mode values, with a clear error message when invalid input is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->