### PR TITLE
fix(messaging): preserve per-message transport labels

### DIFF
--- a/apps/api/src/messaging-inbound.test.ts
+++ b/apps/api/src/messaging-inbound.test.ts
@@ -274,6 +274,7 @@ const dmEvent = {
 
 const groupEvent = {
   ...dmEvent,
+  transport: "SMS",
   threadId: "sendblue:grp-1",
   isDirect: false,
   channelName: "Family",
@@ -683,6 +684,7 @@ describe("createMessagingInboundHandler channel routing", () => {
         {
           kind: "channel_message",
           provider: "sendblue",
+          transport: "SMS",
           channelId: "ch-1",
           fromAddress: "+15551111111",
           fromLabel: "Alice",

--- a/apps/api/src/messaging-inbound.ts
+++ b/apps/api/src/messaging-inbound.ts
@@ -447,6 +447,7 @@ async function handleChannelEvent(
   const block: MessageBlock = {
     kind: "channel_message",
     provider: event.provider,
+    ...(event.transport ? { transport: event.transport } : {}),
     channelId: channel.id,
     fromAddress: event.from,
     fromLabel,

--- a/apps/mobile/app/thread.tsx
+++ b/apps/mobile/app/thread.tsx
@@ -2147,7 +2147,9 @@ function previewMessageText(message: MobileMessage): string {
   const text = message.blocks
     .flatMap((block) => {
       if (block.kind === "channel_message" && block.text) {
-        return [`${messagingProviderLabel(block.provider)} · ${block.fromLabel}: ${block.text}`];
+        return [
+          `${messagingProviderLabel(block.provider, block.transport)} · ${block.fromLabel}: ${block.text}`,
+        ];
       }
       return block.kind === "text" && block.text ? [block.text] : [];
     })
@@ -2311,8 +2313,8 @@ const MessageBubble = memo(function MessageBubble({
         style={{ width: "100%", paddingVertical: 4, alignItems: "center" }}
       >
         <Text style={{ color: tokens.mutedForeground, fontSize: 13.5, textAlign: "center" }}>
-          {messagingProviderLabel(channelMessage.provider)} · {channelMessage.fromLabel}:{" "}
-          {channelMessage.text}
+          {messagingProviderLabel(channelMessage.provider, channelMessage.transport)} ·{" "}
+          {channelMessage.fromLabel}: {channelMessage.text}
         </Text>
       </Pressable>
     );
@@ -2593,7 +2595,9 @@ const MessageBubble = memo(function MessageBubble({
   const caption = message.blocks
     .flatMap((block) => {
       if (block.kind === "channel_message" && block.text) {
-        return [`${messagingProviderLabel(block.provider)} · ${block.fromLabel}: ${block.text}`];
+        return [
+          `${messagingProviderLabel(block.provider, block.transport)} · ${block.fromLabel}: ${block.text}`,
+        ];
       }
       return block.kind === "text" && block.text ? [block.text] : [];
     })

--- a/apps/mobile/lib/android-platform-contract.test.ts
+++ b/apps/mobile/lib/android-platform-contract.test.ts
@@ -139,6 +139,17 @@ describe("Android mobile platform contract", () => {
     expect(notifications).toContain("dismissNotificationAsync");
   });
 
+  it("renders the per-message transport in every native channel-message path", () => {
+    const thread = readFileSync(resolve(mobileRoot, "app/thread.tsx"), "utf8");
+    expect(
+      thread.match(/messagingProviderLabel\(block\.provider, block\.transport\)/g),
+    ).toHaveLength(2);
+    expect(thread).toContain(
+      "messagingProviderLabel(channelMessage.provider, channelMessage.transport)",
+    );
+    expect(thread).not.toMatch(/messagingProviderLabel\((?:block|channelMessage)\.provider\)/);
+  });
+
   it("reconciles finished agents and opens ordinary chats at the latest message", () => {
     const thread = readFileSync(resolve(mobileRoot, "app/thread.tsx"), "utf8");
     const scroll = readFileSync(resolve(mobileRoot, "lib/thread-scroll.ts"), "utf8");

--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -965,6 +965,7 @@ describe("mobile thread event reduction", () => {
           {
             kind: "channel_message",
             provider: "sendblue",
+            transport: "SMS",
             channelId: "ch-1",
             fromAddress: "+15551234567",
             fromLabel: "Alex",
@@ -972,7 +973,7 @@ describe("mobile thread event reduction", () => {
           },
         ]),
       ),
-    ).toBe("iMessage · Alex: Hello from the group");
+    ).toBe("SMS · Alex: Hello from the group");
     expect(
       blockText(
         mobileMessage("channel-2", [

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -569,7 +569,10 @@ const MESSAGING_PROVIDER_LABELS: Record<string, string> = {
   telegram: "Telegram",
 };
 
-export function messagingProviderLabel(provider: string): string {
+export function messagingProviderLabel(provider: string, transport?: string): string {
+  if (provider === "sendblue" && ["iMessage", "SMS", "RCS"].includes(transport ?? "")) {
+    return transport!;
+  }
   return MESSAGING_PROVIDER_LABELS[provider] ?? provider;
 }
 
@@ -577,7 +580,7 @@ export function blockText(message: MobileMessage) {
   return message.blocks
     .map((block) => {
       if (block.kind === "channel_message") {
-        return `${messagingProviderLabel(block.provider)} · ${block.fromLabel}: ${block.text}`;
+        return `${messagingProviderLabel(block.provider, block.transport)} · ${block.fromLabel}: ${block.text}`;
       }
       if (block.kind === "cloud_agent")
         return `${block.title}: ${block.status}${block.prUrl ? ` ${block.prUrl}` : ""}`;

--- a/apps/web/e2e/messaging-transport.spec.ts
+++ b/apps/web/e2e/messaging-transport.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+test("labels a Sendblue group message with its actual transport", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `messaging-transport-${stamp}@rakazo.test`, "password12", "Transport E2E");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  await page.route("**/rpc/threads/get", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as {
+      json?: { threadId: string; cursor: number; messages: unknown[] };
+    };
+    if (body.json) {
+      const seq = body.json.cursor + 1;
+      body.json.cursor = seq;
+      body.json.messages.push({
+        id: `transport-message-${stamp}`,
+        threadId: body.json.threadId,
+        seq,
+        role: "system",
+        blocks: [
+          {
+            kind: "channel_message",
+            provider: "sendblue",
+            transport: "SMS",
+            channelId: `transport-channel-${stamp}`,
+            fromAddress: "+15551234567",
+            fromLabel: "Alice",
+            text: "Dinner is at seven.",
+          },
+        ],
+        createdAt: new Date().toISOString(),
+      });
+    }
+    await route.fulfill({
+      status: response.status(),
+      headers: response.headers(),
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  const transportMessage = page.getByText("SMS · Alice: Dinner is at seven.");
+  await expect(transportMessage).toBeVisible();
+  await captureScreenshot(page, testInfo, "sendblue-sms-transport");
+});

--- a/apps/web/src/lib/message-text.test.ts
+++ b/apps/web/src/lib/message-text.test.ts
@@ -26,6 +26,7 @@ describe("copyableMessageText", () => {
           {
             kind: "channel_message",
             provider: "sendblue",
+            transport: "RCS",
             channelId: "ch-1",
             fromAddress: "+15551234567",
             fromLabel: "Alice",
@@ -34,6 +35,24 @@ describe("copyableMessageText", () => {
           },
         ]),
       ),
-    ).toBe("iMessage · Alice: dinner at 7?");
+    ).toBe("RCS · Alice: dinner at 7?");
+  });
+
+  it("falls back to the provider label for unknown transport values", () => {
+    expect(
+      copyableMessageText(
+        message([
+          {
+            kind: "channel_message",
+            provider: "sendblue",
+            transport: "email",
+            channelId: "ch-1",
+            fromAddress: "+15551234567",
+            fromLabel: "Alice",
+            text: "hello",
+          },
+        ]),
+      ),
+    ).toBe("iMessage · Alice: hello");
   });
 });

--- a/apps/web/src/lib/message-text.ts
+++ b/apps/web/src/lib/message-text.ts
@@ -1,12 +1,12 @@
 import type { ThreadMessage } from "@rakazo/contracts";
-import { providerLabel } from "./messaging";
+import { messageProviderLabel } from "./messaging";
 
 /** Plain message text for clipboard copy — text/ask/progress only, no chrome. */
 export function copyableMessageText(message: ThreadMessage): string {
   return message.blocks
     .map((block) => {
       if (block.kind === "channel_message") {
-        return `${providerLabel(block.provider)} · ${block.fromLabel}: ${block.text}`;
+        return `${messageProviderLabel(block.provider, block.transport)} · ${block.fromLabel}: ${block.text}`;
       }
       if (block.kind === "text" || block.kind === "progress" || block.kind === "ask") {
         return block.text;

--- a/apps/web/src/lib/messaging.ts
+++ b/apps/web/src/lib/messaging.ts
@@ -9,3 +9,11 @@ const PROVIDER_LABELS: Record<string, string> = {
 export function providerLabel(provider: string): string {
   return PROVIDER_LABELS[provider] ?? provider;
 }
+
+/** Per-message provider label, narrowed to a recognized transport when available. */
+export function messageProviderLabel(provider: string, transport?: string): string {
+  if (provider === "sendblue" && ["iMessage", "SMS", "RCS"].includes(transport ?? "")) {
+    return transport!;
+  }
+  return providerLabel(provider);
+}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -145,7 +145,7 @@ import { dictation } from "../lib/dictation";
 import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { localTimezone } from "../lib/local-timezone";
 import { copyableMessageText } from "../lib/message-text";
-import { providerLabel } from "../lib/messaging";
+import { messageProviderLabel } from "../lib/messaging";
 import { isFileDrag, revokePendingAttachmentPreviews } from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
 import { clearSpaceSelection, rpc, selectedSpaceId, selectSpace } from "../lib/rpc";
@@ -5335,7 +5335,8 @@ const MessageView = memo(function MessageView({
               className="flex items-center justify-center gap-2 py-1 text-[13.5px] text-muted-foreground"
             >
               <span>
-                {providerLabel(block.provider)} · {block.fromLabel}: {block.text}
+                {messageProviderLabel(block.provider, block.transport)} · {block.fromLabel}:{" "}
+                {block.text}
               </span>
             </div>
           );

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -523,6 +523,8 @@ export interface MessagingSendResult {
 export interface MessagingInboundMessage {
   type: "message";
   provider: string;
+  /** Per-message transport when one provider spans multiple networks (for example SMS vs RCS). */
+  transport?: string;
   /** Provider message id; drives replay-safe client nonces downstream. */
   handle: string;
   /** Opaque conversation id — pass back to sendToThread to reply. */

--- a/packages/adapters/src/chat-sdk-surface.test.ts
+++ b/packages/adapters/src/chat-sdk-surface.test.ts
@@ -136,6 +136,7 @@ describe("ChatSdkMessagingSurface inbound", () => {
     const { surface, events } = createSurface({
       participants: (raw) => (raw as { roster: string[] }).roster,
       channelName: () => "The Group",
+      transport: () => "SMS",
     });
     await surface.handleWebhook(
       "mock",
@@ -148,6 +149,7 @@ describe("ChatSdkMessagingSurface inbound", () => {
         isDirect: false,
         participants: ["+15551111111", "+15552222222"],
         channelName: "The Group",
+        transport: "SMS",
         content: "group hello",
       }),
     ]);

--- a/packages/adapters/src/chat-sdk-surface.ts
+++ b/packages/adapters/src/chat-sdk-surface.ts
@@ -41,6 +41,8 @@ export interface MessagingPlatform {
   participants?: (raw: unknown) => string[];
   /** Group display name from the raw inbound payload. */
   channelName?: (raw: unknown) => string | null;
+  /** User-facing transport carried by the raw message when it differs from the provider. */
+  transport?: (raw: unknown) => string | null;
 }
 
 /**
@@ -208,9 +210,11 @@ export class ChatSdkMessagingSurface implements MessagingSurface {
     const isDirect = thread.isDM;
     if (!isDirect && !platform.capabilities.groups) return null;
     const fromLabel = message.author.fullName || message.author.userName || null;
+    const transport = platform.transport?.(message.raw) ?? null;
     return {
       type: "message",
       provider,
+      ...(transport ? { transport } : {}),
       handle: message.id,
       threadId: thread.id,
       isDirect,

--- a/packages/adapters/src/messaging-platforms.test.ts
+++ b/packages/adapters/src/messaging-platforms.test.ts
@@ -106,6 +106,15 @@ describe("sendblue platform hooks", () => {
     expect(sendblue.channelName!(null)).toBeNull();
   });
 
+  it("accepts only supported per-message transports", () => {
+    for (const service of ["iMessage", "SMS", "RCS"]) {
+      expect(sendblue.transport!({ service })).toBe(service);
+    }
+    expect(sendblue.transport!({ service: "email" })).toBeNull();
+    expect(sendblue.transport!({ service: 42 })).toBeNull();
+    expect(sendblue.transport!(null)).toBeNull();
+  });
+
   it("derives deterministic provider-prefixed direct thread ids", () => {
     expect(sendblue.directThreadId!("+15551234567")).toMatch(/^sendblue:/);
     expect(sendblue.adapter.isDM?.(sendblue.directThreadId!("+15551234567"))).toBe(true);

--- a/packages/adapters/src/messaging-platforms.ts
+++ b/packages/adapters/src/messaging-platforms.ts
@@ -85,6 +85,7 @@ export function messagingPlatformsFromEnv(env: MessagingEnvironmentValues): Mess
       peekStatus: (payload) => parseSendblueStatus(payload),
       participants: (raw) => sendblueParticipants(raw, lineNumber),
       channelName: (raw) => sendblueGroupName(raw),
+      transport: (raw) => sendblueTransport(raw),
     });
   }
 
@@ -182,4 +183,10 @@ function sendblueGroupName(raw: unknown): string | null {
   if (typeof raw !== "object" || raw === null) return null;
   const name = (raw as { group_display_name?: unknown }).group_display_name;
   return typeof name === "string" && name ? name : null;
+}
+
+function sendblueTransport(raw: unknown): string | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const service = (raw as { service?: unknown }).service;
+  return service === "iMessage" || service === "SMS" || service === "RCS" ? service : null;
 }

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -235,6 +235,8 @@ export const MessageBlock = z.discriminatedUnion("kind", [
     /** A group-chat message delivered into a member bot's own thread. */
     kind: z.literal("channel_message"),
     provider: z.string(),
+    /** Per-message network when a provider spans multiple transports. */
+    transport: z.string().optional(),
     channelId: Id,
     fromAddress: z.string(),
     fromLabel: z.string(),


### PR DESCRIPTION
## Why

Sendblue webhook payloads already distinguish `iMessage`, `SMS`, and `RCS`, but Rakazo discarded that field and labeled every Sendblue message as iMessage. This follows the explicit maintainer feedback in [#444](https://github.com/elie222/rakazo/pull/444#discussion_r3898766803): per-message transport is now carried through the block contract instead of inferred from the provider.

## What

- Preserve a validated optional transport on inbound messaging events and channel-message blocks.
- Extract only the documented Sendblue transport values (`iMessage`, `SMS`, `RCS`).
- Show the actual transport in web, mobile, and copied message text, with the existing provider label as the fallback for old or unknown payloads.
- Add a web E2E fixture that renders an SMS message and captures the `sendblue-sms-transport` screenshot in CI.

The only visible copy change is the transport label itself; it corrects a message previously shown as the wrong channel.

## Tests

- `pnpm exec vitest run packages/adapters/src/messaging-platforms.test.ts packages/adapters/src/chat-sdk-surface.test.ts apps/api/src/messaging-inbound.test.ts apps/web/src/lib/message-text.test.ts apps/mobile/lib/api.test.ts apps/mobile/lib/android-platform-contract.test.ts` (138 tests)
- Typecheck: adapter-kit, contracts, adapters, API, web, and mobile
- Biome on all touched source and test files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Messages from multi-transport providers now display their actual transport, such as **SMS**, **RCS**, or **iMessage**, across web and mobile.
  - Transport details are preserved for group-message fan-out and message copying.
  - Supported inbound messaging integrations can identify the transport used for each message.

- **Bug Fixes**
  - Improved attribution for Sendblue messages so SMS and RCS conversations are no longer incorrectly labeled as iMessage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->