### PR TITLE
fix(composio): surface authorization cancel failures

### DIFF
--- a/packages/adapters/src/composio-connector.test.ts
+++ b/packages/adapters/src/composio-connector.test.ts
@@ -363,6 +363,43 @@ describe("composio tool mapping", () => {
     expect(deleted).toEqual(["req-pending-1"]);
   });
 
+  it.each([{ status: 404 }, { statusCode: 404 }])(
+    "ignores missing authorization requests during cancellation (%o)",
+    async (notFound) => {
+      composioSdkState.connectedAccounts.delete = async () => {
+        throw Object.assign(new Error("not found"), notFound);
+      };
+      const connector = new ComposioConnector();
+
+      await expect(
+        connector.cancelAuthorizationRequest("req-missing", {
+          operationId: "test",
+          traceId: "test",
+          spaceId: "workspace",
+          userId: "user-1",
+          signal: new AbortController().signal,
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it("surfaces authorization cancellation failures for router fallback", async () => {
+    composioSdkState.connectedAccounts.delete = async () => {
+      throw Object.assign(new Error("service unavailable"), { status: 503 });
+    };
+    const connector = new ComposioConnector();
+
+    await expect(
+      connector.cancelAuthorizationRequest("req-pending-1", {
+        operationId: "test",
+        traceId: "test",
+        spaceId: "workspace",
+        userId: "user-1",
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow("service unavailable");
+  });
+
   it("resolves authorization-request ids before deleting on revoke", async () => {
     const deleted: string[] = [];
     const waited: string[] = [];

--- a/packages/adapters/src/composio-connector.ts
+++ b/packages/adapters/src/composio-connector.ts
@@ -451,9 +451,11 @@ export class ComposioConnector implements ComposioProvider {
     // Connection-request ids are connected-account nanoids. Delete directly so a
     // revoke-win begin does not wait for OAuth to finish, and the authorization
     // URL cannot later create an untracked remote. Ignore missing ids.
-    await this.sdk()
-      .connectedAccounts.delete(id, { signal: context.signal })
-      .catch(() => undefined);
+    try {
+      await this.sdk().connectedAccounts.delete(id, { signal: context.signal });
+    } catch (error) {
+      if (!isComposioNotFoundError(error)) throw error;
+    }
   }
 
   /**
@@ -493,6 +495,12 @@ export class ComposioConnector implements ComposioProvider {
     this.client ??= new Composio();
     return this.client;
   }
+}
+
+function isComposioNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { status?: unknown; statusCode?: unknown };
+  return candidate.status === 404 || candidate.statusCode === 404;
 }
 
 export class ConnectorRegistry implements ConnectorProvider {


### PR DESCRIPTION
## Why

The multi-account implementation for the real user report in #583 cancels a pending Composio authorization before attempting the router's fallback revoke. `cancelAuthorizationRequest` currently converts every deletion failure into success, so a timeout, network error, or provider 5xx prevents that fallback and can leave an untracked authorization that completes later.

This addresses the still-valid CodeRabbit review finding on [#589](https://github.com/elie222/rakazo/pull/589) against the current branch.

## What

- Ignore only Composio's two documented 404 shapes (`status` and wrapped `statusCode`) when the pending request is already gone.
- Re-throw every other deletion failure so the existing router fallback revoke path runs.
- Cover successful cancellation, missing requests, and service failures.

No user-visible copy changes.

## Tests

- `pnpm exec vitest run packages/adapters/src/composio-connector.test.ts` (30 tests)
- Biome on the touched connector source and tests

Advances #583.
