### PR TITLE
fix(adapters): bound Box deletion and error reads

### DIFF
--- a/packages/adapters/src/box-errors.test.ts
+++ b/packages/adapters/src/box-errors.test.ts
@@ -104,4 +104,24 @@ describe("Box API errors", () => {
     );
     expect(cancel).toHaveBeenCalledOnce();
   });
+
+  it("falls back to the HTTP status when an error body stalls", async () => {
+    const cancel = vi.fn();
+    const controller = new AbortController();
+    const response = new Response(
+      new ReadableStream({
+        pull: () => new Promise<void>(() => undefined),
+        cancel,
+      }),
+      { status: 504 },
+    );
+
+    const pending = boxResponseError(response, "fake-key", controller.signal);
+    controller.abort(new DOMException("Timed out", "TimeoutError"));
+
+    await expect(pending).resolves.toMatchObject({
+      message: "Box API request failed (HTTP 504)",
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/adapters/src/box-errors.ts
+++ b/packages/adapters/src/box-errors.ts
@@ -1,5 +1,9 @@
 import { ResponseError } from "@asciidev/box-sdk";
 import { redactSecrets } from "@rakazo/core";
+import { readBodyCapped } from "./web-ssrf.js";
+
+const MAX_BOX_ERROR_RESPONSE_BYTES = 16 * 1024;
+const BOX_ERROR_RESPONSE_TIMEOUT_MS = 2_000;
 
 /** Keep HTTP failures actionable without changing the SDK's status-based recovery contract. */
 export function wrapBoxCall<Args extends unknown[], Result>(
@@ -16,8 +20,12 @@ export function wrapBoxCall<Args extends unknown[], Result>(
   };
 }
 
-export async function boxResponseError(response: Response, apiKey: string): Promise<ResponseError> {
-  const body = await readErrorBody(response);
+export async function boxResponseError(
+  response: Response,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<ResponseError> {
+  const body = await readErrorBody(response, signal);
   const code = safeIdentifier(body?.code);
   const requestId = safeIdentifier(body?.requestId);
   const prefix = `Box API request failed (HTTP ${response.status}${code ? `, ${code}` : ""})`;
@@ -43,27 +51,20 @@ function safeIdentifier(value: unknown): string | undefined {
   return typeof value === "string" && /^[a-zA-Z0-9_.-]{1,128}$/.test(value) ? value : undefined;
 }
 
-async function readErrorBody(response: Response): Promise<Record<string, unknown> | undefined> {
-  const reader = response.body?.getReader();
-  if (!reader) return undefined;
+async function readErrorBody(
+  response: Response,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown> | undefined> {
+  const readSignal = signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(BOX_ERROR_RESPONSE_TIMEOUT_MS)])
+    : AbortSignal.timeout(BOX_ERROR_RESPONSE_TIMEOUT_MS);
   try {
-    const chunks: Uint8Array[] = [];
-    let size = 0;
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      size += value.byteLength;
-      if (size > 16_384) return undefined;
-      chunks.push(value);
-    }
-    const body: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    const bytes = await readBodyCapped(response, MAX_BOX_ERROR_RESPONSE_BYTES, readSignal);
+    const body: unknown = JSON.parse(new TextDecoder().decode(bytes));
     return body !== null && typeof body === "object" && !Array.isArray(body)
       ? (body as Record<string, unknown>)
       : undefined;
   } catch {
     return undefined;
-  } finally {
-    await reader.cancel().catch(() => undefined);
-    reader.releaseLock();
   }
 }

--- a/packages/adapters/src/box-sandbox.test.ts
+++ b/packages/adapters/src/box-sandbox.test.ts
@@ -1,5 +1,5 @@
 import type { Command200Response } from "@asciidev/box-sdk";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BoxSandboxProvider,
   type BoxSandboxSdk,
@@ -15,6 +15,11 @@ const context = {
   botId: "bot-a",
   signal: new AbortController().signal,
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("BoxSandboxProvider", () => {
   it("creates no-env boxes and implements execution and file operations", async () => {
@@ -300,6 +305,60 @@ describe("BoxSandboxProvider", () => {
     expect(fixture.stop).toHaveBeenCalledWith({ boxId: "bx_testbox2" }, { signal: context.signal });
     await provider.destroy(computer, context);
     expect(fixture.deleteBox).toHaveBeenCalledWith("bx_testbox2");
+  });
+
+  it("bounds a stalled permanent-delete request", async () => {
+    const deadline = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+    const fetchMock = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" });
+
+    const pending = provider.destroy(
+      { id: "box-test", providerRef: "box-test", botId: "bot-test", kind: "box" },
+      context,
+    );
+    deadline.abort(new DOMException("Timed out", "TimeoutError"));
+
+    await expect(pending).rejects.toThrow("Box box-test was not deleted within 60 seconds");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(deadline.signal);
+  });
+
+  it("keeps the same deadline on permanent-delete status polling", async () => {
+    const deadline = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 202 }))
+      .mockImplementationOnce(
+        async (_url: string | URL | Request, init?: RequestInit): Promise<Response> =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+              once: true,
+            });
+          }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = new BoxSandboxProvider({ apiKey: "test-key" });
+
+    const pending = provider.destroy(
+      { id: "box-test", providerRef: "box-test", botId: "bot-test", kind: "box" },
+      context,
+    );
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    deadline.abort(new DOMException("Timed out", "TimeoutError"));
+
+    await expect(pending).rejects.toThrow("Box box-test was not deleted within 60 seconds");
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(deadline.signal);
+    expect(fetchMock.mock.calls[1]?.[1]?.signal).toBe(deadline.signal);
   });
 
   it("recognizes provider 404 errors without swallowing transient failures", () => {

--- a/packages/adapters/src/box-sandbox.ts
+++ b/packages/adapters/src/box-sandbox.ts
@@ -41,6 +41,7 @@ import {
   PORTABLE_TRANSFER_BATCH_BYTES,
   shouldSkipPortableWorkspaceFile,
 } from "./computer-workspace.js";
+import { withAbort } from "./web-ssrf.js";
 
 const BOX_API_BASE = "https://ascii.dev/api/box/v1";
 const BOX_WORKSPACE = "/home/user/rakazo-home";
@@ -48,6 +49,7 @@ const BOX_BROWSER_PROFILES = `${BOX_WORKSPACE}/.browser-profiles`;
 const BOX_READY_TIMEOUT_MS = 5 * 60_000;
 const BOX_API_COMMAND_TIMEOUT_SECONDS = 600;
 const BOX_TTL_SECONDS = 2 * 60 * 60;
+const BOX_DELETE_TIMEOUT_MS = 60_000;
 const BOX_EXPORT_CONCURRENCY = 16;
 const BOX_SCREEN_LEASE_PATH = "/tmp/rakazo-screen-lease";
 
@@ -891,25 +893,30 @@ function createBoxSdk(config: { apiKey: string; apiUrl?: string }): BoxSandboxSd
     deleteBox: async (boxId: string) => {
       const url = `${apiUrl}/boxes/${encodeURIComponent(boxId)}`;
       const headers = { Authorization: `Bearer ${config.apiKey}` };
-      const response = await fetch(url, {
-        method: "DELETE",
-        headers: {
-          ...headers,
-          "X-Ascii-Confirm-Delete": boxId,
-        },
-      });
-      if (response.status === 404) return;
-      if (!response.ok) {
-        throw await boxResponseError(response, config.apiKey);
-      }
-      const deadline = Date.now() + 60_000;
-      while (Date.now() < deadline) {
-        const status = await fetch(url, { headers });
-        if (status.status === 404) return;
-        if (!status.ok) {
-          throw await boxResponseError(status, config.apiKey);
+      const signal = AbortSignal.timeout(BOX_DELETE_TIMEOUT_MS);
+      try {
+        const response = await fetch(url, {
+          method: "DELETE",
+          headers: {
+            ...headers,
+            "X-Ascii-Confirm-Delete": boxId,
+          },
+          signal,
+        });
+        if (response.status === 404) return;
+        if (!response.ok) {
+          throw await boxResponseError(response, config.apiKey, signal);
         }
-        await delay(500);
+        while (!signal.aborted) {
+          const status = await fetch(url, { headers, signal });
+          if (status.status === 404) return;
+          if (!status.ok) {
+            throw await boxResponseError(status, config.apiKey, signal);
+          }
+          await withAbort(delay(500), signal);
+        }
+      } catch (error) {
+        if (!signal.aborted || error !== signal.reason) throw error;
       }
       throw new Error(`Box ${boxId} was not deleted within 60 seconds`);
     },


### PR DESCRIPTION
## Why

Box permanent deletion claims a 60-second limit, but the initial DELETE, status polling requests, and error-body reads could each wait forever. A stalled provider could therefore hang computer destruction or any SDK-backed failure path past the advertised deadline.

## What

- Apply one 60-second deadline to the Box DELETE request, every status poll, and the polling delay.
- Reuse the bounded response-body reader for Box errors with a 16 KiB cap and a two-second read deadline.
- Preserve useful redacted upstream details when the body is valid, and fall back to the HTTP status when it is oversized, malformed, or stalled.
- Cover a stalled DELETE, a stalled status poll, and a stalled error stream with deterministic tests.

## Tests

- Full adapters suite: 121 files passed, 1,357 tests passed (4 files / 26 tests skipped by their existing environment gates)
- `@rakazo/adapters` TypeScript check
- Biome and diff checks on the touched files

No UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Box API errors when responses are delayed, incomplete, oversized, or unavailable.
  - Box deletion requests now stop automatically after 60 seconds if the service does not respond.
  - Deletion status checks continue until completion and correctly handle already-deleted items.
  - Non-timeout deletion errors continue to be reported instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->