### PR TITLE
feat(bots): choose model during creation

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -765,6 +765,7 @@ export function createRouter(deps: RouterDeps) {
                 deps.prisma,
                 context.actor,
                 effectiveProvider,
+                effectiveModelId,
               );
               if (credential && credential.defaultModel === effectiveModelId) {
                 const secret = await deps.prisma.secret.findFirst({

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -68,6 +68,7 @@ import {
   takeoverLeaseMs,
   toComputerRef,
   touchRunningComputer,
+  validateConnectedModelChoice,
   verifyMcpInstall,
 } from "@rakazo/adapters";
 import type { Auth } from "@rakazo/auth";
@@ -672,9 +673,18 @@ export function createRouter(deps: RouterDeps) {
         if (!found) throw new IsolationError();
         return found;
       }),
-      create: authed.bots.create.handler(async ({ context, input }) =>
-        repos.createBot(context.actor, input),
-      ),
+      create: authed.bots.create.handler(async ({ context, input }) => {
+        if (input.modelProvider && input.modelId) {
+          const error = await validateConnectedModelChoice(
+            deps.prisma,
+            context.actor,
+            input.modelProvider,
+            input.modelId,
+          );
+          if (error) throw new ORPCError("BAD_REQUEST", { message: error });
+        }
+        return repos.createBot(context.actor, input);
+      }),
       duplicate: authed.bots.duplicate.handler(async ({ context, input }) => {
         const source = await repos.getBot(context.actor, input.botId);
         const duplicate = await repos.createBot(context.actor, {
@@ -728,21 +738,13 @@ export function createRouter(deps: RouterDeps) {
           if (!section) throw new IsolationError();
         }
         if (input.modelProvider && input.modelId) {
-          const credential = await findModelCredential(
+          const error = await validateConnectedModelChoice(
             deps.prisma,
             context.actor,
             input.modelProvider,
+            input.modelId,
           );
-          if (!credential) {
-            throw new ORPCError("BAD_REQUEST", { message: "Connect that model provider first" });
-          }
-          const knownModels = [...listPiCatalog(), scriptedCatalogEntry];
-          const inCatalog = knownModels.some(
-            (item) => item.provider === input.modelProvider && item.id === input.modelId,
-          );
-          if (!inCatalog && credential.defaultModel !== input.modelId) {
-            throw new ORPCError("BAD_REQUEST", { message: "Unknown model for that provider" });
-          }
+          if (error) throw new ORPCError("BAD_REQUEST", { message: error });
         }
         const thinkingLevel = input.thinkingLevel;
         if (input.thinkingLevel) {

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -90,12 +90,22 @@ export async function captureScreenshot(page: Page, testInfo: TestInfo, name: st
   await testInfo.attach(name, { contentType: "image/png", path: screenshotPath });
 }
 
-export async function openNewBot(page: Page, computerMode: "team" | "dedicated" = "team") {
+export async function openNewBot(
+  page: Page,
+  computerMode: "team" | "dedicated" = "team",
+  model?: { provider: string; modelId: string },
+) {
   await page.getByTestId("create-menu-trigger").click();
   await page.getByTestId("create-new-bot").click();
   await expect(page.getByTestId("create-bot-computer")).toBeVisible();
   await page
     .getByTestId(computerMode === "team" ? "create-bot-team" : "create-bot-private")
+    .click();
+  await expect(page.getByTestId("create-bot-model")).toBeVisible();
+  await page
+    .getByTestId(
+      model ? `create-bot-model-${model.provider}::${model.modelId}` : "create-bot-model-default",
+    )
     .click();
 }
 

--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -29,6 +29,10 @@ test("create opens empty chat, picker lists bots, and sidebar collapses", async 
   await expect(picker.getByTestId("create-bot-team")).toBeVisible();
   await expect(picker.getByTestId("create-bot-private")).toBeVisible();
   await captureScreenshot(page, testInfo, "plus-picker-computer-mode");
+  await picker.getByTestId("create-bot-team").click();
+  await expect(picker.getByTestId("create-bot-model")).toBeVisible();
+  await expect(picker.getByTestId("create-bot-model-default")).toBeVisible();
+  await captureScreenshot(page, testInfo, "plus-picker-model");
   await page.keyboard.press("Escape");
 
   await createBotFromPicker(page);
@@ -96,4 +100,32 @@ test("plus picker can create a Private computer bot", async ({ page }, testInfo)
   const botId = page.url().split("/").pop()!;
   const bots = await rpc<Array<{ id: string; computerMode: string }>>(page, "bots/list", {});
   expect(bots.find((bot) => bot.id === botId)?.computerMode).toBe("dedicated");
+});
+
+test("plus picker can create a bot with a connected model", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `new-bot-model-${stamp}@rakazo.test`, "password12", "New Bot Model");
+  await completeOnboarding(page);
+  await rpc(page, "models/connect", {
+    provider: "xai",
+    apiKey: "fake-xai-key-not-real",
+    label: "xAI",
+    modelId: "grok-4.6",
+  });
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  await openNewBot(page, "team", { provider: "xai", modelId: "grok-4.6" });
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await expect(page.getByPlaceholder("Message New Bot")).toBeVisible();
+  await captureScreenshot(page, testInfo, "create-bot-with-model");
+
+  const botId = page.url().split("/").pop()!;
+  const bots = await rpc<
+    Array<{ id: string; modelProvider: string | null; modelId: string | null }>
+  >(page, "bots/list", {});
+  expect(bots.find((bot) => bot.id === botId)).toMatchObject({
+    modelProvider: "xai",
+    modelId: "grok-4.6",
+  });
 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -188,7 +188,7 @@ import {
 } from "./RoutineEditor";
 import { SpaceSearchResults } from "./SpaceSearch";
 import { BotSettings, CreateBotForm } from "./shell/bot-panel";
-import { BotCreatePicker } from "./shell/bot-picker";
+import { BotCreatePicker, type BotCreateSelection } from "./shell/bot-picker";
 import { CommandPalette, isCommandPaletteHotkey } from "./shell/command-palette";
 import {
   ClearConversationDialog,
@@ -2240,12 +2240,16 @@ export function ShellPage() {
     title: string;
     description: string;
     computerMode: ComputerMode;
+    modelProvider?: string;
+    modelId?: string;
   }) {
     const isFirstBot = botsRef.current.length === 0;
     const bot = await rpc.bots.create({
       ...normalizeCreateBotProfile(input),
       notifyOnFinish: true,
       computerMode: input.computerMode,
+      modelProvider: input.modelProvider,
+      modelId: input.modelId,
     });
     setBots((current) =>
       current.some((item) => item.id === bot.id) ? current : [bot, ...current],
@@ -2286,7 +2290,7 @@ export function ShellPage() {
     await refreshBots().catch(() => undefined);
   }
 
-  async function createBotQuick(computerMode: ComputerMode = "team") {
+  async function createBotQuick(selection: BotCreateSelection = { computerMode: "team" }) {
     if (creatingBotRef.current) return;
     creatingBotRef.current = true;
     try {
@@ -2294,7 +2298,9 @@ export function ShellPage() {
         name: "New Bot",
         title: "",
         description: "",
-        computerMode,
+        computerMode: selection.computerMode,
+        modelProvider: selection.modelProvider,
+        modelId: selection.modelId,
       });
     } catch (error) {
       // Keep the current chat open when create fails, but surface the error.
@@ -2580,9 +2586,9 @@ export function ShellPage() {
                 >
                   <BotCreatePicker
                     bots={bots}
-                    onCreateBot={(computerMode) => {
+                    onCreateBot={(selection) => {
                       setCreateMenuOpen(false);
-                      void createBotQuick(computerMode);
+                      void createBotQuick(selection);
                     }}
                     onOpenBot={(id) => {
                       setCreateMenuOpen(false);

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -28,6 +28,12 @@ import {
 import { X } from "lucide-react";
 import { lazy, Suspense, useEffect, useId, useState } from "react";
 import { rpc } from "../../lib/rpc";
+import {
+  catalogLabel,
+  connectedModelOptions,
+  modelOptionKey,
+  parseModelOptionKey,
+} from "./model-options";
 
 const ScratchpadSection = lazy(() =>
   import("../ScratchpadSection").then((module) => ({ default: module.ScratchpadSection })),
@@ -239,44 +245,7 @@ export function BotSettings({
       .catch(() => undefined);
   }, []);
 
-  const connectedOptions: Array<{
-    key: string;
-    provider: string;
-    modelId: string;
-    label: string;
-  }> = [];
-  const seenOptions = new Set<string>();
-  for (const credential of credentials) {
-    const providerModels = catalog.filter(
-      (entry) => entry.provider === credential.provider && !entry.placeholder,
-    );
-    const credentialInCatalog = Boolean(
-      credential.modelId && providerModels.some((entry) => entry.id === credential.modelId),
-    );
-    // Catalog providers expand to every model for that connection. Free-form
-    // credentials (model id not in the catalog) stay a single connected pair.
-    const options =
-      credential.modelId && !credentialInCatalog
-        ? [
-            {
-              key: modelOptionKey(credential.provider, credential.modelId),
-              provider: credential.provider,
-              modelId: credential.modelId,
-              label: `${credential.label} · ${credential.modelId}`,
-            },
-          ]
-        : providerModels.map((entry) => ({
-            key: modelOptionKey(entry.provider, entry.id),
-            provider: entry.provider,
-            modelId: entry.id,
-            label: `${entry.providerName ?? entry.provider} · ${entry.label}`,
-          }));
-    for (const option of options) {
-      if (seenOptions.has(option.key)) continue;
-      seenOptions.add(option.key);
-      connectedOptions.push(option);
-    }
-  }
+  const connectedOptions = connectedModelOptions(credentials, catalog);
 
   const effectiveProvider = modelKey
     ? parseModelOptionKey(modelKey)?.provider
@@ -518,10 +487,6 @@ export function BotSettings({
   );
 }
 
-function modelOptionKey(provider: string, modelId: string) {
-  return `${provider}::${modelId}`;
-}
-
 function thinkingLevelLabel(level: ThinkingLevel) {
   if (level === "xhigh") return t`Extra high`;
   if (level === "low") return t`Low`;
@@ -530,19 +495,4 @@ function thinkingLevelLabel(level: ThinkingLevel) {
   if (level === "minimal") return t`Minimal`;
   if (level === "max") return t`Max`;
   return `${level.slice(0, 1).toUpperCase()}${level.slice(1)}`;
-}
-
-function parseModelOptionKey(key: string) {
-  const separator = key.indexOf("::");
-  if (separator <= 0) return null;
-  return { provider: key.slice(0, separator), modelId: key.slice(separator + 2) };
-}
-
-function catalogLabel(
-  catalog: ModelCatalogEntry[],
-  provider: string | null | undefined,
-  modelId: string,
-) {
-  if (!provider) return undefined;
-  return catalog.find((entry) => entry.provider === provider && entry.id === modelId)?.label;
 }

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -9,8 +9,8 @@ import {
   CommandList,
   CommandSeparator,
 } from "@rakazo/ui-web";
-import { ArrowLeft, Lock, Plus } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, LoaderCircle, Lock, Plus, RotateCw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { rpc } from "../../lib/rpc";
 import { connectedModelOptions } from "./model-options";
 
@@ -39,14 +39,22 @@ export function BotCreatePicker({
   const [computerMode, setComputerMode] = useState<ComputerMode>("team");
   const [credentials, setCredentials] = useState<ModelCredential[]>([]);
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
-  useEffect(() => {
+  const [modelMetadataStatus, setModelMetadataStatus] = useState<"loading" | "ready" | "error">(
+    "loading",
+  );
+  const loadModelMetadata = useCallback(() => {
+    setModelMetadataStatus("loading");
     void Promise.all([rpc.models.credentials(), rpc.models.list()])
       .then(([nextCredentials, nextCatalog]) => {
         setCredentials(nextCredentials);
         setCatalog(nextCatalog);
+        setModelMetadataStatus("ready");
       })
-      .catch(() => undefined);
+      .catch(() => setModelMetadataStatus("error"));
   }, []);
+  useEffect(() => {
+    loadModelMetadata();
+  }, [loadModelMetadata]);
   const modelOptions = connectedModelOptions(credentials, catalog);
   const needle = query.trim().toLowerCase();
   const matched = useMemo(() => {
@@ -87,22 +95,33 @@ export function BotCreatePicker({
               >
                 <Trans>Space default</Trans>
               </CommandItem>
-              {modelOptions.map((option) => (
-                <CommandItem
-                  key={option.key}
-                  value={option.key}
-                  data-testid={`create-bot-model-${option.key}`}
-                  onSelect={() =>
-                    onCreateBot({
-                      computerMode,
-                      modelProvider: option.provider,
-                      modelId: option.modelId,
-                    })
-                  }
-                >
-                  {option.label}
+              {modelMetadataStatus === "loading" ? (
+                <div className="flex justify-center py-2 text-muted-foreground">
+                  <LoaderCircle size={16} className="animate-spin" aria-label={t`Loading…`} />
+                </div>
+              ) : modelMetadataStatus === "error" ? (
+                <CommandItem value="retry-models" onSelect={loadModelMetadata} className="gap-2">
+                  <RotateCw size={15} strokeWidth={1.8} aria-hidden="true" />
+                  <Trans>Retry now</Trans>
                 </CommandItem>
-              ))}
+              ) : (
+                modelOptions.map((option) => (
+                  <CommandItem
+                    key={option.key}
+                    value={option.key}
+                    data-testid={`create-bot-model-${option.key}`}
+                    onSelect={() =>
+                      onCreateBot({
+                        computerMode,
+                        modelProvider: option.provider,
+                        modelId: option.modelId,
+                      })
+                    }
+                  >
+                    {option.label}
+                  </CommandItem>
+                ))
+              )}
             </CommandGroup>
           </CommandList>
         </Command>

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import type { Bot, ComputerMode } from "@rakazo/contracts";
+import type { Bot, ComputerMode, ModelCatalogEntry, ModelCredential } from "@rakazo/contracts";
 import {
   BotAvatar,
   Command,
@@ -10,7 +10,15 @@ import {
   CommandSeparator,
 } from "@rakazo/ui-web";
 import { ArrowLeft, Lock, Plus } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { rpc } from "../../lib/rpc";
+import { connectedModelOptions } from "./model-options";
+
+export type BotCreateSelection = {
+  computerMode: ComputerMode;
+  modelProvider?: string;
+  modelId?: string;
+};
 
 export function BotCreatePicker({
   bots,
@@ -20,14 +28,26 @@ export function BotCreatePicker({
   onCreateSpace,
 }: {
   bots: Bot[];
-  onCreateBot: (computerMode: ComputerMode) => void;
+  onCreateBot: (selection: BotCreateSelection) => void;
   onOpenBot: (botId: string) => void;
   onCreateGroup: () => void;
   onCreateSpace: () => void;
 }) {
   const { t } = useLingui();
   const [query, setQuery] = useState("");
-  const [step, setStep] = useState<"pick" | "computer">("pick");
+  const [step, setStep] = useState<"pick" | "computer" | "model">("pick");
+  const [computerMode, setComputerMode] = useState<ComputerMode>("team");
+  const [credentials, setCredentials] = useState<ModelCredential[]>([]);
+  const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
+  useEffect(() => {
+    void Promise.all([rpc.models.credentials(), rpc.models.list()])
+      .then(([nextCredentials, nextCatalog]) => {
+        setCredentials(nextCredentials);
+        setCatalog(nextCatalog);
+      })
+      .catch(() => undefined);
+  }, []);
+  const modelOptions = connectedModelOptions(credentials, catalog);
   const needle = query.trim().toLowerCase();
   const matched = useMemo(() => {
     if (!needle) return bots;
@@ -39,6 +59,56 @@ export function BotCreatePicker({
     !needle ||
     "create new bot".includes(needle) ||
     needle.split(/\s+/).every((part) => "create new bot".includes(part));
+
+  if (step === "model") {
+    return (
+      <div data-testid="bot-create-picker" className="w-[min(320px,calc(100vw-2rem))]">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <button
+            type="button"
+            data-testid="create-bot-model-back"
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={t`Back`}
+            onClick={() => setStep("computer")}
+          >
+            <ArrowLeft size={16} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+          <span className="text-[13px] text-muted-foreground">
+            <Trans>Model</Trans>
+          </span>
+        </div>
+        <Command className="rounded-none border-0 bg-transparent p-0">
+          <CommandList data-testid="create-bot-model" className="max-h-72 p-1">
+            <CommandGroup>
+              <CommandItem
+                value="space-default"
+                data-testid="create-bot-model-default"
+                onSelect={() => onCreateBot({ computerMode })}
+              >
+                <Trans>Space default</Trans>
+              </CommandItem>
+              {modelOptions.map((option) => (
+                <CommandItem
+                  key={option.key}
+                  value={option.key}
+                  data-testid={`create-bot-model-${option.key}`}
+                  onSelect={() =>
+                    onCreateBot({
+                      computerMode,
+                      modelProvider: option.provider,
+                      modelId: option.modelId,
+                    })
+                  }
+                >
+                  {option.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </div>
+    );
+  }
 
   if (step === "computer") {
     return (
@@ -62,7 +132,10 @@ export function BotCreatePicker({
             type="button"
             data-testid="create-bot-team"
             className="rounded-lg border border-border px-3 py-2 text-[14px] text-foreground hover:border-foreground/40"
-            onClick={() => onCreateBot("team")}
+            onClick={() => {
+              setComputerMode("team");
+              setStep("model");
+            }}
           >
             <Trans>Team</Trans>
           </button>
@@ -70,7 +143,10 @@ export function BotCreatePicker({
             type="button"
             data-testid="create-bot-private"
             className="rounded-lg border border-border px-3 py-2 text-[14px] text-foreground hover:border-foreground/40"
-            onClick={() => onCreateBot("dedicated")}
+            onClick={() => {
+              setComputerMode("dedicated");
+              setStep("model");
+            }}
           >
             <Trans>Private</Trans>
           </button>

--- a/apps/web/src/pages/shell/model-options.test.ts
+++ b/apps/web/src/pages/shell/model-options.test.ts
@@ -60,4 +60,19 @@ describe("connected model options", () => {
       },
     ]);
   });
+
+  it("keeps distinct free-form models from legacy same-provider credentials", () => {
+    expect(
+      connectedModelOptions(
+        [
+          credential({ modelId: "private-model-a" }),
+          credential({ id: "credential-2", modelId: "private-model-b" }),
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      expect.objectContaining({ key: "xai::private-model-a" }),
+      expect.objectContaining({ key: "xai::private-model-b" }),
+    ]);
+  });
 });

--- a/apps/web/src/pages/shell/model-options.test.ts
+++ b/apps/web/src/pages/shell/model-options.test.ts
@@ -1,0 +1,63 @@
+import type { ModelCatalogEntry, ModelCredential } from "@rakazo/contracts";
+import { describe, expect, it } from "vitest";
+import { connectedModelOptions } from "./model-options";
+
+function credential(input: Partial<ModelCredential> = {}): ModelCredential {
+  return {
+    id: "credential-1",
+    provider: "xai",
+    label: "xAI",
+    hasKey: true,
+    isDefault: true,
+    ...input,
+  };
+}
+
+const catalog: ModelCatalogEntry[] = [
+  {
+    provider: "xai",
+    providerName: "xAI",
+    id: "grok-4.6",
+    label: "Grok 4.6",
+    billing: "User key",
+  },
+  {
+    provider: "anthropic",
+    providerName: "Anthropic",
+    id: "claude-opus-4-6",
+    label: "Claude Opus 4.6",
+    billing: "User key",
+  },
+];
+
+describe("connected model options", () => {
+  it("only exposes catalog models backed by a connected provider", () => {
+    expect(connectedModelOptions([credential()], catalog)).toEqual([
+      {
+        key: "xai::grok-4.6",
+        provider: "xai",
+        modelId: "grok-4.6",
+        label: "xAI · Grok 4.6",
+      },
+    ]);
+  });
+
+  it("keeps a free-form connected model without duplicating it", () => {
+    expect(
+      connectedModelOptions(
+        [
+          credential({ modelId: "private-model" }),
+          credential({ id: "credential-2", modelId: "private-model" }),
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        key: "xai::private-model",
+        provider: "xai",
+        modelId: "private-model",
+        label: "xAI · private-model",
+      },
+    ]);
+  });
+});

--- a/apps/web/src/pages/shell/model-options.ts
+++ b/apps/web/src/pages/shell/model-options.ts
@@ -1,0 +1,65 @@
+import type { ModelCatalogEntry, ModelCredential } from "@rakazo/contracts";
+
+export type ConnectedModelOption = {
+  key: string;
+  provider: string;
+  modelId: string;
+  label: string;
+};
+
+export function modelOptionKey(provider: string, modelId: string) {
+  return `${provider}::${modelId}`;
+}
+
+export function parseModelOptionKey(key: string) {
+  const separator = key.indexOf("::");
+  if (separator <= 0) return null;
+  return { provider: key.slice(0, separator), modelId: key.slice(separator + 2) };
+}
+
+export function connectedModelOptions(
+  credentials: ModelCredential[],
+  catalog: ModelCatalogEntry[],
+): ConnectedModelOption[] {
+  const connected: ConnectedModelOption[] = [];
+  const seen = new Set<string>();
+  for (const credential of credentials) {
+    const providerModels = catalog.filter(
+      (entry) => entry.provider === credential.provider && !entry.placeholder,
+    );
+    const credentialInCatalog = Boolean(
+      credential.modelId && providerModels.some((entry) => entry.id === credential.modelId),
+    );
+    const options =
+      credential.modelId && !credentialInCatalog
+        ? [
+            {
+              key: modelOptionKey(credential.provider, credential.modelId),
+              provider: credential.provider,
+              modelId: credential.modelId,
+              label: `${credential.label} · ${credential.modelId}`,
+            },
+          ]
+        : providerModels.map((entry) => ({
+            key: modelOptionKey(entry.provider, entry.id),
+            provider: entry.provider,
+            modelId: entry.id,
+            label: `${entry.providerName ?? entry.provider} · ${entry.label}`,
+          }));
+    for (const option of options) {
+      if (seen.has(option.key)) continue;
+      seen.add(option.key);
+      connected.push(option);
+    }
+  }
+  return connected;
+}
+
+export function catalogLabel(
+  catalog: ModelCatalogEntry[],
+  provider: string | null | undefined,
+  modelId: string,
+) {
+  if (!provider) return undefined;
+  return catalog.find((entry) => entry.provider === provider && entry.id === modelId)?.label;
+}

--- a/packages/adapters/src/builtin-tools.ts
+++ b/packages/adapters/src/builtin-tools.ts
@@ -687,6 +687,14 @@ export const builtinAgentTools: ConnectorTool[] = [
           description:
             "Optional. team shares one screen with other Team bots; dedicated (Private) gets its own. Defaults to team.",
         },
+        model_provider: {
+          type: "string",
+          description: "Optional connected model provider. Set together with model_id.",
+        },
+        model_id: {
+          type: "string",
+          description: "Optional model id from that provider. Set together with model_provider.",
+        },
       },
       required: ["name"],
     },

--- a/packages/adapters/src/child-bots.test.ts
+++ b/packages/adapters/src/child-bots.test.ts
@@ -109,6 +109,7 @@ describe("spawned bot creation", () => {
     const result = await spawnBot(
       {
         prisma: {
+          bot: { findUnique: vi.fn().mockResolvedValue(null) },
           spaceModelPreference: {
             findFirst: vi.fn().mockResolvedValue({
               credential: { provider: "xai" },
@@ -169,7 +170,12 @@ describe("spawned bot creation", () => {
     };
     expect(
       await spawnBot(
-        { prisma: {} as PrismaClient, jobs: { enqueue: vi.fn() } as unknown as JobPublisher },
+        {
+          prisma: {
+            bot: { findUnique: vi.fn().mockResolvedValue(null) },
+          } as unknown as PrismaClient,
+          jobs: { enqueue: vi.fn() } as unknown as JobPublisher,
+        },
         { ...input, modelProvider: "xai" },
       ),
     ).toEqual({ error: "model_provider and model_id must both be set." });
@@ -178,6 +184,7 @@ describe("spawned bot creation", () => {
       await spawnBot(
         {
           prisma: {
+            bot: { findUnique: vi.fn().mockResolvedValue(null) },
             spaceModelPreference: { findFirst: vi.fn().mockResolvedValue(null) },
             userModelCredential: { findFirst: vi.fn().mockResolvedValue(null) },
           } as unknown as PrismaClient,
@@ -186,6 +193,56 @@ describe("spawned bot creation", () => {
         { ...input, modelProvider: "xai", modelId: "grok-4.6" },
       ),
     ).toEqual({ error: "Connect that model provider first" });
+  });
+
+  it("returns an existing child on retry even if the model provider is disconnected", async () => {
+    const findUnique = vi.fn().mockResolvedValue({
+      id: "child-1",
+      name: "Scout",
+      title: "Venue researcher",
+      thread: { id: "thread-1" },
+    });
+    const enqueue = vi.fn().mockResolvedValue(undefined);
+    const preferenceFindFirst = vi.fn().mockResolvedValue(null);
+    const credentialFindFirst = vi.fn().mockResolvedValue(null);
+
+    const result = await spawnBot(
+      {
+        prisma: {
+          bot: { findUnique },
+          spaceModelPreference: { findFirst: preferenceFindFirst },
+          userModelCredential: { findFirst: credentialFindFirst },
+          run: { findUnique: vi.fn().mockResolvedValue({ id: "child-run-1" }) },
+        } as unknown as PrismaClient,
+        jobs: { enqueue } as unknown as JobPublisher,
+      },
+      {
+        spawnedBy: {
+          id: "parent-1",
+          name: "Chief",
+          spaceId: "workspace-1",
+          userId: "user-1",
+        },
+        runId: "run-retry-disconnected",
+        spawnKey: "tool-call-1",
+        name: "Scout",
+        prompt: "Continue",
+        modelProvider: "xai",
+        modelId: "grok-4.6",
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      duplicate: true,
+      botId: "child-1",
+      name: "Scout",
+      title: "Venue researcher",
+      threadId: "thread-1",
+    });
+    expect(preferenceFindFirst).not.toHaveBeenCalled();
+    expect(credentialFindFirst).not.toHaveBeenCalled();
+    expect(enqueue).toHaveBeenCalledOnce();
   });
 });
 describe("spawned bot archival", () => {

--- a/packages/adapters/src/child-bots.test.ts
+++ b/packages/adapters/src/child-bots.test.ts
@@ -95,7 +95,7 @@ describe("spawned bot creation", () => {
     expect(enqueue).toHaveBeenCalledOnce();
   });
 
-  it("passes computerMode through to createBot", async () => {
+  it("passes computer and connected model choices through to createBot", async () => {
     const createBot = vi.fn().mockResolvedValue({
       id: "child-2",
       name: "Painter",
@@ -108,7 +108,15 @@ describe("spawned bot creation", () => {
 
     const result = await spawnBot(
       {
-        prisma: {} as PrismaClient,
+        prisma: {
+          spaceModelPreference: {
+            findFirst: vi.fn().mockResolvedValue({
+              credential: { provider: "xai" },
+              modelId: "grok-4.6",
+              isDefault: true,
+            }),
+          },
+        } as unknown as PrismaClient,
         jobs: { enqueue: vi.fn() } as unknown as JobPublisher,
       },
       {
@@ -122,6 +130,8 @@ describe("spawned bot creation", () => {
         spawnKey: "tool-call-2",
         name: "Painter",
         computerMode: "dedicated",
+        modelProvider: "xai",
+        modelId: "grok-4.6",
       },
     );
 
@@ -130,6 +140,8 @@ describe("spawned bot creation", () => {
       expect.objectContaining({
         name: "Painter",
         computerMode: "dedicated",
+        modelProvider: "xai",
+        modelId: "grok-4.6",
         parentBotId: "parent-1",
       }),
     );
@@ -141,6 +153,39 @@ describe("spawned bot creation", () => {
       threadId: "thread-2",
     });
     createReposSpy.mockRestore();
+  });
+
+  it("rejects incomplete or disconnected model choices", async () => {
+    const input = {
+      spawnedBy: {
+        id: "parent-1",
+        name: "Chief",
+        spaceId: "workspace-1",
+        userId: "user-1",
+      },
+      runId: "run-1",
+      spawnKey: "tool-call-model",
+      name: "Scout",
+    };
+    expect(
+      await spawnBot(
+        { prisma: {} as PrismaClient, jobs: { enqueue: vi.fn() } as unknown as JobPublisher },
+        { ...input, modelProvider: "xai" },
+      ),
+    ).toEqual({ error: "model_provider and model_id must both be set." });
+
+    expect(
+      await spawnBot(
+        {
+          prisma: {
+            spaceModelPreference: { findFirst: vi.fn().mockResolvedValue(null) },
+            userModelCredential: { findFirst: vi.fn().mockResolvedValue(null) },
+          } as unknown as PrismaClient,
+          jobs: { enqueue: vi.fn() } as unknown as JobPublisher,
+        },
+        { ...input, modelProvider: "xai", modelId: "grok-4.6" },
+      ),
+    ).toEqual({ error: "Connect that model provider first" });
   });
 });
 describe("spawned bot archival", () => {

--- a/packages/adapters/src/child-bots.ts
+++ b/packages/adapters/src/child-bots.ts
@@ -22,6 +22,7 @@ import { getLogger } from "@rakazo/logging";
 import { toComputerRef } from "./computer-support.js";
 import { checkpointAndRecordComputerWorkspace } from "./computer-workspace.js";
 import { resolveAgentHomePath } from "./home.js";
+import { validateConnectedModelChoice } from "./model-selection.js";
 
 export function confirmSpawnedBotName(confirmName: string, botName: string) {
   if (confirmName !== botName) {
@@ -52,10 +53,17 @@ export async function spawnBot(
     instructions?: string;
     prompt?: string;
     computerMode?: ComputerMode;
+    modelProvider?: string;
+    modelId?: string;
   },
 ) {
   const name = input.name.trim();
   if (!name) return { error: "Bot name is required." };
+  const modelProvider = input.modelProvider?.trim() ?? "";
+  const modelId = input.modelId?.trim() ?? "";
+  if (Boolean(modelProvider) !== Boolean(modelId)) {
+    return { error: "model_provider and model_id must both be set." };
+  }
 
   const actor: Actor = {
     userId: input.spawnedBy.userId,
@@ -63,6 +71,10 @@ export async function spawnBot(
     email: "",
     isDeploymentOwner: false,
   };
+  if (modelProvider && modelId) {
+    const error = await validateConnectedModelChoice(deps.prisma, actor, modelProvider, modelId);
+    if (error) return { error };
+  }
   let duplicate = false;
   let created: Pick<Bot, "id" | "name" | "title" | "threadId">;
   try {
@@ -75,6 +87,8 @@ export async function spawnBot(
       parentBotId: input.spawnedBy.id,
       spawnKey: input.spawnKey,
       computerMode: input.computerMode,
+      modelProvider: modelProvider || undefined,
+      modelId: modelId || undefined,
       initialMessage: {
         role: "system",
         blocks: [{ kind: "meta", text: `Created by ${input.spawnedBy.name}` }],

--- a/packages/adapters/src/child-bots.ts
+++ b/packages/adapters/src/child-bots.ts
@@ -71,41 +71,20 @@ export async function spawnBot(
     email: "",
     isDeploymentOwner: false,
   };
-  if (modelProvider && modelId) {
-    const error = await validateConnectedModelChoice(deps.prisma, actor, modelProvider, modelId);
-    if (error) return { error };
-  }
+  // Recover an existing bot for this spawn key before model validation so identical
+  // retries still return it even if the provider was disconnected after the first create.
+  const existing = await deps.prisma.bot.findUnique({
+    where: {
+      spaceId_spawnKey: {
+        spaceId: input.spawnedBy.spaceId,
+        spawnKey: input.spawnKey,
+      },
+    },
+    include: { thread: true },
+  });
   let duplicate = false;
   let created: Pick<Bot, "id" | "name" | "title" | "threadId">;
-  try {
-    created = await createRepos(deps.prisma).createBot(actor, {
-      name,
-      title: (input.title ?? "").trim(),
-      description: "",
-      instructions: (input.instructions ?? "").trim(),
-      notifyOnFinish: true,
-      parentBotId: input.spawnedBy.id,
-      spawnKey: input.spawnKey,
-      computerMode: input.computerMode,
-      modelProvider: modelProvider || undefined,
-      modelId: modelId || undefined,
-      initialMessage: {
-        role: "system",
-        blocks: [{ kind: "meta", text: `Created by ${input.spawnedBy.name}` }],
-        runId: input.runId,
-      },
-    });
-  } catch (error) {
-    const existing = await deps.prisma.bot.findUnique({
-      where: {
-        spaceId_spawnKey: {
-          spaceId: input.spawnedBy.spaceId,
-          spawnKey: input.spawnKey,
-        },
-      },
-      include: { thread: true },
-    });
-    if (!existing) throw error;
+  if (existing) {
     if (!existing.thread) throw new Error(`Spawned bot ${existing.id} is missing its thread`);
     duplicate = true;
     created = {
@@ -114,6 +93,49 @@ export async function spawnBot(
       title: existing.title,
       threadId: existing.thread.id,
     };
+  } else {
+    if (modelProvider && modelId) {
+      const error = await validateConnectedModelChoice(deps.prisma, actor, modelProvider, modelId);
+      if (error) return { error };
+    }
+    try {
+      created = await createRepos(deps.prisma).createBot(actor, {
+        name,
+        title: (input.title ?? "").trim(),
+        description: "",
+        instructions: (input.instructions ?? "").trim(),
+        notifyOnFinish: true,
+        parentBotId: input.spawnedBy.id,
+        spawnKey: input.spawnKey,
+        computerMode: input.computerMode,
+        modelProvider: modelProvider || undefined,
+        modelId: modelId || undefined,
+        initialMessage: {
+          role: "system",
+          blocks: [{ kind: "meta", text: `Created by ${input.spawnedBy.name}` }],
+          runId: input.runId,
+        },
+      });
+    } catch (error) {
+      const raced = await deps.prisma.bot.findUnique({
+        where: {
+          spaceId_spawnKey: {
+            spaceId: input.spawnedBy.spaceId,
+            spawnKey: input.spawnKey,
+          },
+        },
+        include: { thread: true },
+      });
+      if (!raced) throw error;
+      if (!raced.thread) throw new Error(`Spawned bot ${raced.id} is missing its thread`);
+      duplicate = true;
+      created = {
+        id: raced.id,
+        name: raced.name,
+        title: raced.title,
+        threadId: raced.thread.id,
+      };
+    }
   }
 
   const prompt = (input.prompt ?? "").trim();

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -2783,6 +2783,11 @@ export function createRunExecutor(deps: ExecutorDeps) {
               }
               computerMode = value;
             }
+            const modelProvider = args.model_provider ? String(args.model_provider).trim() : "";
+            const modelId = args.model_id ? String(args.model_id).trim() : "";
+            if (Boolean(modelProvider) !== Boolean(modelId)) {
+              return finish({ error: "model_provider and model_id must both be set." });
+            }
             const spawned = await spawnBot(deps, {
               spawnedBy: {
                 id: bot.id,
@@ -2797,6 +2802,8 @@ export function createRunExecutor(deps: ExecutorDeps) {
               instructions: args.instructions ? String(args.instructions) : undefined,
               prompt: args.prompt ? String(args.prompt) : undefined,
               computerMode,
+              modelProvider: modelProvider || undefined,
+              modelId: modelId || undefined,
             });
             if ("error" in spawned) return finish(spawned);
             if (!(await persistEffectResult(spawned))) return uncertainEffectResult(name);

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -608,7 +608,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
       const hasOverride = Boolean(override?.modelProvider && override.modelId);
       const [overrideCredential, defaultCredential, settings] = await Promise.all([
         hasOverride
-          ? findModelCredential(deps.prisma, scope, override!.modelProvider!)
+          ? findModelCredential(deps.prisma, scope, override!.modelProvider!, override!.modelId)
           : Promise.resolve(null),
         findDefaultModelCredential(deps.prisma, scope),
         deps.prisma.deploymentSettings.findUnique({ where: { id: "default" } }),
@@ -942,7 +942,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         const hasModelOverride = Boolean(bot.modelProvider && bot.modelId);
         const overrideCredential =
           hasModelOverride && bot.modelProvider
-            ? await findModelCredential(deps.prisma, run, bot.modelProvider)
+            ? await findModelCredential(deps.prisma, run, bot.modelProvider, bot.modelId)
             : null;
         runAbortController = new AbortController();
         if (!leaseValid) runAbortController.abort();

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -58,6 +58,7 @@ export * from "./messaging-context.js";
 export * from "./messaging-delivery.js";
 export * from "./messaging-platforms.js";
 export * from "./model-connect.js";
+export * from "./model-selection.js";
 export * from "./model-vision.js";
 export * from "./none-sandbox.js";
 export * from "./openai-compatible-url.js";

--- a/packages/adapters/src/model-selection.test.ts
+++ b/packages/adapters/src/model-selection.test.ts
@@ -131,13 +131,17 @@ describe("connected model validation", () => {
       validateConnectedModelChoice(catalogPrisma, actor, "xai", "not-a-model"),
     ).resolves.toBe("Unknown model for that provider");
 
+    const customPreferences = [
+      {
+        credential: credential("openai-compatible", "newest-model"),
+        isDefault: true,
+        modelId: "newest-model",
+      },
+      { id: "older-choice" },
+    ];
     const customPrisma = {
       spaceModelPreference: {
-        findFirst: async () => ({
-          credential: credential("openai-compatible", "private-model"),
-          isDefault: false,
-          modelId: "private-model",
-        }),
+        findFirst: async () => customPreferences.shift() ?? null,
       },
     } as unknown as PrismaClient;
     await expect(

--- a/packages/adapters/src/model-selection.test.ts
+++ b/packages/adapters/src/model-selection.test.ts
@@ -1,5 +1,7 @@
+import type { Actor } from "@rakazo/contracts";
+import type { PrismaClient } from "@rakazo/db";
 import { describe, expect, it } from "vitest";
-import { selectConfiguredModel } from "./model-selection.js";
+import { selectConfiguredModel, validateConnectedModelChoice } from "./model-selection.js";
 
 type SelectionInput = Parameters<typeof selectConfiguredModel>[0];
 
@@ -106,5 +108,48 @@ describe("configured model selection", () => {
     },
   ])("$name", ({ input, expected }) => {
     expect(selectConfiguredModel({ ...defaults, ...input })).toEqual(expected);
+  });
+});
+
+describe("connected model validation", () => {
+  const actor: Actor = {
+    userId: "user-1",
+    spaceId: "space-1",
+    email: "user@example.test",
+    isDeploymentOwner: false,
+  };
+
+  it("accepts catalog and saved free-form models but rejects unavailable choices", async () => {
+    const catalogPrisma = {
+      spaceModelPreference: { findFirst: async () => null },
+      userModelCredential: { findFirst: async () => credential("xai", null) },
+    } as unknown as PrismaClient;
+    await expect(
+      validateConnectedModelChoice(catalogPrisma, actor, "xai", "grok-4.6"),
+    ).resolves.toBeUndefined();
+    await expect(
+      validateConnectedModelChoice(catalogPrisma, actor, "xai", "not-a-model"),
+    ).resolves.toBe("Unknown model for that provider");
+
+    const customPrisma = {
+      spaceModelPreference: {
+        findFirst: async () => ({
+          credential: credential("openai-compatible", "private-model"),
+          isDefault: false,
+          modelId: "private-model",
+        }),
+      },
+    } as unknown as PrismaClient;
+    await expect(
+      validateConnectedModelChoice(customPrisma, actor, "openai-compatible", "private-model"),
+    ).resolves.toBeUndefined();
+
+    const disconnectedPrisma = {
+      spaceModelPreference: { findFirst: async () => null },
+      userModelCredential: { findFirst: async () => null },
+    } as unknown as PrismaClient;
+    await expect(
+      validateConnectedModelChoice(disconnectedPrisma, actor, "anthropic", "claude-opus-4-6"),
+    ).resolves.toBe("Connect that model provider first");
   });
 });

--- a/packages/adapters/src/model-selection.ts
+++ b/packages/adapters/src/model-selection.ts
@@ -20,9 +20,17 @@ export async function validateConnectedModelChoice(
   const inCatalog = [...listPiCatalog(), scriptedCatalogEntry].some(
     (item) => item.provider === provider && item.id === modelId,
   );
-  return !inCatalog && credential.defaultModel !== modelId
-    ? "Unknown model for that provider"
-    : undefined;
+  if (inCatalog) return undefined;
+  const savedChoice = await prisma.spaceModelPreference.findFirst({
+    where: {
+      spaceId: actor.spaceId,
+      userId: actor.userId,
+      modelId,
+      credential: { userId: actor.userId, provider },
+    },
+    select: { id: true },
+  });
+  return savedChoice ? undefined : "Unknown model for that provider";
 }
 
 /** Select configuration without loading secrets or applying a runtime-specific fallback. */

--- a/packages/adapters/src/model-selection.ts
+++ b/packages/adapters/src/model-selection.ts
@@ -1,7 +1,29 @@
 import type { AgentRunRequest } from "@rakazo/adapter-kit";
-import type { findDefaultModelCredential } from "@rakazo/db";
+import type { Actor } from "@rakazo/contracts";
+import {
+  type findDefaultModelCredential,
+  findModelCredential,
+  type PrismaClient,
+} from "@rakazo/db";
+import { listPiCatalog, scriptedCatalogEntry } from "./pi-models.js";
 
 type ModelCredential = Awaited<ReturnType<typeof findDefaultModelCredential>>;
+
+export async function validateConnectedModelChoice(
+  prisma: PrismaClient,
+  actor: Actor,
+  provider: string,
+  modelId: string,
+) {
+  const credential = await findModelCredential(prisma, actor, provider);
+  if (!credential) return "Connect that model provider first";
+  const inCatalog = [...listPiCatalog(), scriptedCatalogEntry].some(
+    (item) => item.provider === provider && item.id === modelId,
+  );
+  return !inCatalog && credential.defaultModel !== modelId
+    ? "Unknown model for that provider"
+    : undefined;
+}
 
 /** Select configuration without loading secrets or applying a runtime-specific fallback. */
 export function selectConfiguredModel(input: {

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -653,6 +653,8 @@ function toAgentTool(tool: ConnectorTool, host: ToolHost, exposedName: string): 
           instructions: raw.instructions ? String(raw.instructions) : "",
           prompt: raw.prompt ? String(raw.prompt) : "",
           computer_mode: raw.computer_mode ? String(raw.computer_mode) : "",
+          model_provider: raw.model_provider ? String(raw.model_provider) : "",
+          model_id: raw.model_id ? String(raw.model_id) : "",
         };
       }
       if (tool.name === "create_space") {
@@ -975,6 +977,8 @@ function builtinParameters(tool: ConnectorTool) {
       instructions: Type.Optional(Type.String()),
       prompt: Type.Optional(Type.String()),
       computer_mode: Type.Optional(Type.Union([Type.Literal("team"), Type.Literal("dedicated")])),
+      model_provider: Type.Optional(Type.String()),
+      model_id: Type.Optional(Type.String()),
     });
   }
   if (tool.name === "create_space") {

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -184,15 +184,27 @@ export const BOT_TITLE_MAX_LENGTH = 500;
 export const BOT_DESCRIPTION_MAX_LENGTH = 4000;
 export const BOT_INSTRUCTIONS_MAX_LENGTH = 20000;
 
-export const CreateBotInput = z.object({
-  name: z.string().trim().min(1).max(BOT_NAME_MAX_LENGTH),
-  title: z.string().max(BOT_TITLE_MAX_LENGTH).default(""),
-  description: z.string().max(BOT_DESCRIPTION_MAX_LENGTH).default(""),
-  instructions: z.string().max(BOT_INSTRUCTIONS_MAX_LENGTH).default(""),
-  notifyOnFinish: z.boolean().default(true),
-  color: z.string().optional(),
-  computerMode: ComputerModeSchema.default("team"),
-});
+export const CreateBotInput = z
+  .object({
+    name: z.string().trim().min(1).max(BOT_NAME_MAX_LENGTH),
+    title: z.string().max(BOT_TITLE_MAX_LENGTH).default(""),
+    description: z.string().max(BOT_DESCRIPTION_MAX_LENGTH).default(""),
+    instructions: z.string().max(BOT_INSTRUCTIONS_MAX_LENGTH).default(""),
+    notifyOnFinish: z.boolean().default(true),
+    color: z.string().optional(),
+    computerMode: ComputerModeSchema.default("team"),
+    modelProvider: z.string().trim().min(1).max(80).optional(),
+    modelId: z.string().trim().min(1).max(200).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if ((value.modelProvider === undefined) !== (value.modelId === undefined)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "modelProvider and modelId must both be set",
+        path: [value.modelProvider === undefined ? "modelProvider" : "modelId"],
+      });
+    }
+  });
 export type CreateBotInput = z.infer<typeof CreateBotInput>;
 
 export function normalizeCreateBotProfile(

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -69,6 +69,18 @@ describe("contracts", () => {
     expect(parsed.notifyOnFinish).toBe(true);
   });
 
+  it("accepts only complete model overrides when creating bots", () => {
+    expect(
+      CreateBotInput.safeParse({
+        name: "Chief",
+        modelProvider: "xai",
+        modelId: "grok-4.6",
+      }).success,
+    ).toBe(true);
+    expect(CreateBotInput.safeParse({ name: "Chief", modelProvider: "xai" }).success).toBe(false);
+    expect(CreateBotInput.safeParse({ name: "Chief", modelId: "grok-4.6" }).success).toBe(false);
+  });
+
   it("normalizes bot creation fields without losing the longer instruction copy", () => {
     const profile = normalizeCreateBotProfile({
       name: `  ${"N".repeat(100)}  `,

--- a/packages/db/src/model-credentials.test.ts
+++ b/packages/db/src/model-credentials.test.ts
@@ -43,6 +43,51 @@ describe("findModelCredential", () => {
       orderBy: newestModelCredentialOrder,
     });
   });
+
+  it("prefers the preference that owns a free-form modelId over the provider default", async () => {
+    const matching = {
+      credential: {
+        id: "credential-other",
+        userId: "user",
+        provider: "openai-compatible",
+        label: "Other",
+        secretId: "secret-other",
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      },
+      isDefault: false,
+      modelId: "other-model",
+    };
+    const preferenceFindFirst = vi.fn().mockResolvedValue(matching);
+    const prisma = {
+      spaceModelPreference: { findFirst: preferenceFindFirst },
+      userModelCredential: { findFirst: vi.fn() },
+    } as unknown as PrismaClient;
+
+    await expect(
+      findModelCredential(
+        prisma,
+        { userId: "user", spaceId: "space" },
+        "openai-compatible",
+        "other-model",
+      ),
+    ).resolves.toEqual({
+      ...matching.credential,
+      isDefault: false,
+      defaultModel: "other-model",
+    });
+    expect(preferenceFindFirst).toHaveBeenCalledWith({
+      where: {
+        userId: "user",
+        spaceId: "space",
+        modelId: "other-model",
+        credential: { provider: "openai-compatible" },
+      },
+      include: { credential: true },
+      orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }, { id: "desc" }],
+    });
+    expect(preferenceFindFirst).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("selectSpaceModelPreference", () => {

--- a/packages/db/src/model-credentials.ts
+++ b/packages/db/src/model-credentials.ts
@@ -93,7 +93,23 @@ export async function findModelCredential(
   prisma: PrismaClient,
   scope: ModelCredentialScope,
   provider: string,
+  modelId?: string | null,
 ) {
+  // When a bot selects a free-form model, prefer the preference that owns that modelId
+  // so runtime uses the same credential the picker advertised.
+  if (modelId) {
+    const matching = await prisma.spaceModelPreference.findFirst({
+      where: {
+        spaceId: scope.spaceId,
+        userId: scope.userId,
+        modelId,
+        credential: { provider },
+      },
+      include: { credential: true },
+      orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }, { id: "desc" }],
+    });
+    if (matching) return withModelPreference(matching);
+  }
   const preference = await prisma.spaceModelPreference.findFirst({
     where: {
       spaceId: scope.spaceId,

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -943,7 +943,7 @@ describeWithDatabase("API authorization and resource isolation", () => {
       modelProvider: "anthropic",
       modelId: "claude-opus-4-6",
     });
-    expect(disconnectedCreate.status).toBeGreaterThanOrEqual(400);
+    expect(disconnectedCreate.status).toBe(400);
     expect(await disconnectedCreate.text()).toMatch(/connect/i);
 
     const partialClear = await raw(app, cookie, "bots/update", {

--- a/packages/testkit/src/authorization.test.ts
+++ b/packages/testkit/src/authorization.test.ts
@@ -892,6 +892,18 @@ describeWithDatabase("API authorization and resource isolation", () => {
       modelId: "grok-4.6",
     });
 
+    const createdWithModel = await rpc<
+      Bot & { modelProvider: string | null; modelId: string | null }
+    >(app, cookie, "bots/create", {
+      ...botInput("Created with model"),
+      modelProvider: "xai",
+      modelId: "grok-4.6",
+    });
+    expect(createdWithModel).toMatchObject({
+      modelProvider: "xai",
+      modelId: "grok-4.6",
+    });
+
     const updated = await rpc<
       Bot & {
         modelProvider: string | null;
@@ -925,6 +937,14 @@ describeWithDatabase("API authorization and resource isolation", () => {
     });
     expect(disconnected.status).toBeGreaterThanOrEqual(400);
     expect(await disconnected.text()).toMatch(/connect/i);
+
+    const disconnectedCreate = await raw(app, cookie, "bots/create", {
+      ...botInput("Disconnected model"),
+      modelProvider: "anthropic",
+      modelId: "claude-opus-4-6",
+    });
+    expect(disconnectedCreate.status).toBeGreaterThanOrEqual(400);
+    expect(await disconnectedCreate.text()).toMatch(/connect/i);
 
     const partialClear = await raw(app, cookie, "bots/update", {
       botId: bot.id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Creating a bot from the quick picker (and via `spawn_bot`) only chose computer mode. Choosing a connected model at create time was missing, so every new bot fell back to the Space default until someone opened settings.

This PR ports and finishes https://github.com/elie222/rakazo/pull/712 from fork `fetw882/rakazo` (`feat/bot-create-model`). Cloud agents cannot start from that fork ref, so the in-repo port is `pr-712-bot-create-model` (same tip as this PR head).

**Please close #712 as superseded** (coordinator).

## What changed

- Optional paired `modelProvider` / `modelId` on bot create (API, contracts, persistence).
- Progressive model step in the web create picker (Space default + connected catalog / free-form options), with loading and retry when credentials+catalog are still settling or fail.
- Shared connected-model option construction with bot settings.
- Server validation for create/update/`spawn_bot` connected choices.
- **Credential alignment (new Greptile P1):** runtime `findModelCredential` prefers the space preference that owns the selected free-form `modelId` for that provider, so picker, validation, and execution use the same API key. Catalog models still fall back to preferred/newest provider credential.
- **CodeRabbit:** `spawnBot` recovers an existing `spaceId_spawnKey` bot before model validation (retries succeed even if the provider was disconnected after the first create); disconnected create asserts HTTP 400.

## Branch note

- Coordinator branch: `pr-712-bot-create-model` (pushed, same SHA).
- This PR head: `cursor/pr-712-bot-create-model-a81a` (mirror for the cloud PR tool’s `cursor/` prefix requirement).

## Review notes for coordinator

- Original Greptile P1/P2 on #712 were fixed in `7669cea6` by fetw882.
- New Greptile P1 (credential/model ownership diverge) fixed here via approach A.
- CodeRabbit spawn ordering + `toBe(400)` fixed here.
- Review threads on fork PR #712 should be closed with the PR; this head supersedes that ref.

## Visible copy

The visible copy is **Model**, **Space default**, and failure-only **Retry now**; the loading state uses the accessible **Loading…** label. Model names the progressive choice, Space default preserves existing inheritance explicitly, Retry now prevents a metadata failure from looking like an empty model list, and Loading… exposes the in-flight state. All reuse existing product copy and appear only after the user chooses to create a bot.

## Test plan

- Unit: `@rakazo/db` `model-credentials` (modelId-aware lookup), `@rakazo/adapters` `model-selection` + `child-bots` (including disconnected-provider spawn retry).
- Existing web E2E for create picker model step retained; no agent-machine screenshots.

Stacked on `cursor/bot-computer-mode-at-create-6426` (same base as #712). Do not merge to main from this PR alone.

Aikido MCP scan was not run (sign-in required in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-227ab6ba-e48c-4760-a88c-0edf0cfba81a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-227ab6ba-e48c-4760-a88c-0edf0cfba81a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
