### PR TITLE
fix(graphql): reject malformed success payloads

### DIFF
--- a/packages/adapters/src/graphql-connectors.test.ts
+++ b/packages/adapters/src/graphql-connectors.test.ts
@@ -516,6 +516,46 @@ describe("GraphQL execution failures", () => {
     ).rejects.toThrow(/HTTP 500/);
   });
 
+  it("throws when a successful GraphQL HTTP response is not JSON", async () => {
+    const operation = importGraphqlSchema(STAR_WARS_INTROSPECTION)[0]!;
+    await expect(
+      executeGraphqlOperation(
+        "https://graphql.example.test/graphql",
+        { auth: { type: "none" }, headers: {}, operations: [operation] },
+        operation,
+        {},
+        undefined,
+        new AbortController().signal,
+        {
+          fetch: async () =>
+            new Response("<html>upstream unavailable</html>", {
+              status: 200,
+              headers: { "content-type": "text/html" },
+            }),
+          resolveHostname: async () => [{ address: "203.0.113.10", family: 4 as const }],
+        },
+      ),
+    ).rejects.toThrow(/not valid JSON/);
+  });
+
+  it("throws when a successful GraphQL HTTP response is not a JSON object", async () => {
+    const operation = importGraphqlSchema(STAR_WARS_INTROSPECTION)[0]!;
+    await expect(
+      executeGraphqlOperation(
+        "https://graphql.example.test/graphql",
+        { auth: { type: "none" }, headers: {}, operations: [operation] },
+        operation,
+        {},
+        undefined,
+        new AbortController().signal,
+        {
+          fetch: async () => Response.json("temporarily unavailable"),
+          resolveHostname: async () => [{ address: "203.0.113.10", family: 4 as const }],
+        },
+      ),
+    ).rejects.toThrow(/not a JSON object/);
+  });
+
   it("yields type error from InstalledConnectorProvider on GraphQL errors array", async () => {
     const events = await executeGraphqlProvider(async () =>
       Response.json({ errors: [{ message: "Field 'hello' is required" }], data: null }),
@@ -534,6 +574,20 @@ describe("GraphQL execution failures", () => {
     expect(events[0]).toMatchObject({ type: "error" });
     expect(events[0]).not.toMatchObject({ type: "result" });
     expect(String((events[0] as { message?: string }).message)).toMatch(/HTTP 502/);
+  });
+
+  it("yields type error from InstalledConnectorProvider on malformed success payload", async () => {
+    const events = await executeGraphqlProvider(
+      async () =>
+        new Response("<html>upstream unavailable</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "error" });
+    expect(events[0]).not.toMatchObject({ type: "result" });
+    expect(String((events[0] as { message?: string }).message)).toMatch(/not valid JSON/);
   });
 });
 

--- a/packages/adapters/src/graphql-connectors.test.ts
+++ b/packages/adapters/src/graphql-connectors.test.ts
@@ -556,6 +556,26 @@ describe("GraphQL execution failures", () => {
     ).rejects.toThrow(/not a JSON object/);
   });
 
+  it("preserves a bounded result for oversized successful responses", async () => {
+    const operation = importGraphqlSchema(STAR_WARS_INTROSPECTION)[0]!;
+    const result = await executeGraphqlOperation(
+      "https://graphql.example.test/graphql",
+      { auth: { type: "none" }, headers: {}, operations: [operation] },
+      operation,
+      {},
+      undefined,
+      new AbortController().signal,
+      {
+        fetch: async () => Response.json({ data: { value: "x".repeat(1_000_000) } }),
+        resolveHostname: async () => [{ address: "203.0.113.10", family: 4 as const }],
+      },
+    );
+
+    expect(result).toMatchObject({ status: 200, truncated: true });
+    expect((result as { data: unknown }).data).toEqual(expect.any(String));
+    expect((result as { data: string }).data.length).toBeLessThanOrEqual(1_000_000);
+  });
+
   it("yields type error from InstalledConnectorProvider on GraphQL errors array", async () => {
     const events = await executeGraphqlProvider(async () =>
       Response.json({ errors: [{ message: "Field 'hello' is required" }], data: null }),

--- a/packages/adapters/src/graphql-connectors.test.ts
+++ b/packages/adapters/src/graphql-connectors.test.ts
@@ -576,6 +576,68 @@ describe("GraphQL execution failures", () => {
     expect((result as { data: string }).data.length).toBeLessThanOrEqual(1_000_000);
   });
 
+  it("rejects malformed responses that exceed the result limit", async () => {
+    const operation = importGraphqlSchema(STAR_WARS_INTROSPECTION)[0]!;
+    await expect(
+      executeGraphqlOperation(
+        "https://graphql.example.test/graphql",
+        { auth: { type: "none" }, headers: {}, operations: [operation] },
+        operation,
+        {},
+        undefined,
+        new AbortController().signal,
+        {
+          fetch: async () =>
+            new Response(`<html>${"x".repeat(1_000_000)}</html>`, {
+              status: 200,
+              headers: { "content-type": "text/html" },
+            }),
+          resolveHostname: async () => [{ address: "203.0.113.10", family: 4 as const }],
+        },
+      ),
+    ).rejects.toThrow(/not valid JSON/);
+  });
+
+  it("rejects GraphQL errors that exceed the result limit", async () => {
+    const operation = importGraphqlSchema(STAR_WARS_INTROSPECTION)[0]!;
+    await expect(
+      executeGraphqlOperation(
+        "https://graphql.example.test/graphql",
+        { auth: { type: "none" }, headers: {}, operations: [operation] },
+        operation,
+        {},
+        undefined,
+        new AbortController().signal,
+        {
+          fetch: async () =>
+            Response.json({
+              errors: [{ message: "Oversized operation failed" }],
+              padding: "x".repeat(1_000_000),
+            }),
+          resolveHostname: async () => [{ address: "203.0.113.10", family: 4 as const }],
+        },
+      ),
+    ).rejects.toThrow(/Oversized operation failed/);
+  });
+
+  it("rejects responses that exceed the validation limit", async () => {
+    const operation = importGraphqlSchema(STAR_WARS_INTROSPECTION)[0]!;
+    await expect(
+      executeGraphqlOperation(
+        "https://graphql.example.test/graphql",
+        { auth: { type: "none" }, headers: {}, operations: [operation] },
+        operation,
+        {},
+        undefined,
+        new AbortController().signal,
+        {
+          fetch: async () => Response.json({ data: { value: "x".repeat(2_000_000) } }),
+          resolveHostname: async () => [{ address: "203.0.113.10", family: 4 as const }],
+        },
+      ),
+    ).rejects.toThrow(/validation limit/);
+  });
+
   it("yields type error from InstalledConnectorProvider on GraphQL errors array", async () => {
     const events = await executeGraphqlProvider(async () =>
       Response.json({ errors: [{ message: "Field 'hello' is required" }], data: null }),

--- a/packages/adapters/src/graphql-connectors.ts
+++ b/packages/adapters/src/graphql-connectors.ts
@@ -321,16 +321,22 @@ export async function executeGraphqlOperation(
       signal: combineSignals(signal, AbortSignal.timeout(30_000)),
     });
     const { text, truncated } = await readBoundedText(response, 1_000_000);
-    let payload: unknown = text;
+    let payload: unknown;
     try {
-      payload = text ? JSON.parse(text) : null;
+      payload = JSON.parse(text);
     } catch {
-      // Keep non-JSON GraphQL responses as bounded text.
+      if (!response.ok) {
+        throw new Error(`GraphQL request returned HTTP ${response.status}`);
+      }
+      throw new Error("GraphQL response was not valid JSON");
     }
     if (!response.ok) {
       throw new Error(`GraphQL request returned HTTP ${response.status}`);
     }
     const record = asRecord(payload);
+    if (!record) {
+      throw new Error("GraphQL response was not a JSON object");
+    }
     const graphqlErrors = Array.isArray(record?.errors) ? record.errors : [];
     if (graphqlErrors.length > 0) {
       const first = asRecord(graphqlErrors[0]);

--- a/packages/adapters/src/graphql-connectors.ts
+++ b/packages/adapters/src/graphql-connectors.ts
@@ -321,17 +321,17 @@ export async function executeGraphqlOperation(
       signal: combineSignals(signal, AbortSignal.timeout(30_000)),
     });
     const { text, truncated } = await readBoundedText(response, 1_000_000);
+    if (!response.ok) {
+      throw new Error(`GraphQL request returned HTTP ${response.status}`);
+    }
+    if (truncated) {
+      return { status: response.status, data: text, truncated: true };
+    }
     let payload: unknown;
     try {
       payload = JSON.parse(text);
     } catch {
-      if (!response.ok) {
-        throw new Error(`GraphQL request returned HTTP ${response.status}`);
-      }
       throw new Error("GraphQL response was not valid JSON");
-    }
-    if (!response.ok) {
-      throw new Error(`GraphQL request returned HTTP ${response.status}`);
     }
     const record = asRecord(payload);
     if (!record) {
@@ -349,7 +349,6 @@ export async function executeGraphqlOperation(
     return {
       status: response.status,
       data: record?.data ?? payload,
-      ...(truncated ? { truncated: true } : {}),
     };
   } finally {
     await safeFetch.close().catch(() => undefined);

--- a/packages/adapters/src/graphql-connectors.ts
+++ b/packages/adapters/src/graphql-connectors.ts
@@ -8,6 +8,8 @@ import {
 
 const HeaderValue = z.string().max(2_048);
 const MAX_GRAPHQL_SELECTION_CHARS = 6_000;
+const MAX_GRAPHQL_RESULT_BYTES = 1_000_000;
+const MAX_GRAPHQL_VALIDATION_BYTES = 2_000_000;
 const HeaderName = z
   .string()
   .min(1)
@@ -320,12 +322,15 @@ export async function executeGraphqlOperation(
       body: JSON.stringify({ query: document, variables, operationName: opName }),
       signal: combineSignals(signal, AbortSignal.timeout(30_000)),
     });
-    const { text, truncated } = await readBoundedText(response, 1_000_000);
+    const { text, truncated: validationTruncated } = await readBoundedText(
+      response,
+      MAX_GRAPHQL_VALIDATION_BYTES,
+    );
     if (!response.ok) {
       throw new Error(`GraphQL request returned HTTP ${response.status}`);
     }
-    if (truncated) {
-      return { status: response.status, data: text, truncated: true };
+    if (validationTruncated) {
+      throw new Error("GraphQL response exceeded the validation limit");
     }
     let payload: unknown;
     try {
@@ -345,6 +350,10 @@ export async function executeGraphqlOperation(
           ? first.message
           : "GraphQL operation failed";
       throw new Error(message);
+    }
+    const bounded = boundUtf8Text(text, MAX_GRAPHQL_RESULT_BYTES);
+    if (bounded.truncated) {
+      return { status: response.status, data: bounded.text, truncated: true };
     }
     return {
       status: response.status,
@@ -602,6 +611,23 @@ async function readBoundedText(
     bytes += value.byteLength;
     text += decoder.decode(value, { stream: true });
   }
+}
+
+function boundUtf8Text(value: string, maximumBytes: number): { text: string; truncated: boolean } {
+  const encoded = new TextEncoder().encode(value);
+  if (encoded.byteLength <= maximumBytes) return { text: value, truncated: false };
+  let end = maximumBytes;
+  while (end > 0) {
+    try {
+      return {
+        text: new TextDecoder("utf-8", { fatal: true }).decode(encoded.subarray(0, end)),
+        truncated: true,
+      };
+    } catch {
+      end -= 1;
+    }
+  }
+  return { text: "", truncated: true };
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {


### PR DESCRIPTION
## Why

A GraphQL endpoint, authentication proxy, or CDN can return HTTP 200 with HTML or another malformed payload. The execution path kept that body as a value, so the installed connector emitted a successful tool result even though no GraphQL operation result existed. For external mutations, that can mislead the agent about whether an action succeeded.

This is a focused follow-up to #474 and addresses the remaining malformed-response finding in [the automated review](https://github.com/elie222/rakazo/pull/474#discussion_r3942196939).

## What changed

- reject non-JSON payloads and non-object JSON from complete successful GraphQL responses
- validate successful responses in a bounded 2 MB window before limiting model-visible results to the existing 1 MB output bound
- reject responses beyond the validation ceiling instead of emitting an unvalidated success
- preserve status-based errors for non-successful HTTP responses without exposing response bodies
- cover direct execution and installed-provider error events so malformed payloads cannot surface as results

## Test plan

- `pnpm exec vitest run --root ../.. packages/adapters/src/graphql-connectors.test.ts` (20 passed)
- `pnpm --filter @rakazo/adapters test` (104 files passed, 995 tests passed, configured skips unchanged)
- `pnpm --filter @rakazo/adapters check`
- `pnpm lint` (passes; existing repository warnings remain)