### PR TITLE
fix(http): bound remaining JSON response reads

### DIFF
--- a/apps/mobile/lib/api.test.ts
+++ b/apps/mobile/lib/api.test.ts
@@ -8,6 +8,8 @@ import {
   currentApiBase,
   deleteAccount,
   loadApiBase,
+  MAX_MOBILE_AUTH_RESPONSE_BYTES,
+  MAX_MOBILE_RPC_RESPONSE_BYTES,
   type MobileMessage,
   type MobileSnapshot,
   mergeMobileSnapshot,
@@ -195,6 +197,40 @@ describe("mobile API authentication", () => {
     expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
   });
 
+  it("does not retain an oversized sign-in response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(
+          { token: "must-not-be-read" },
+          { headers: { "content-length": String(MAX_MOBILE_AUTH_RESPONSE_BYTES + 1) } },
+        ),
+      ),
+    );
+
+    await expect(signIn("ada@example.com", "correct horse")).rejects.toThrow(
+      `exceeds ${MAX_MOBILE_AUTH_RESPONSE_BYTES} bytes`,
+    );
+    expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+
+  it("times out and cancels a stalled sign-in response body", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(new ReadableStream({ cancel }))),
+    );
+
+    const pending = signIn("ada@example.com", "correct horse");
+    const rejection = expect(pending).rejects.toThrow("Request timed out");
+    await vi.advanceTimersByTimeAsync(8_000);
+
+    await rejection;
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+
   it("clears the local session even when the sign-out request fails", async () => {
     vi.mocked(SecureStore.getItemAsync).mockResolvedValue("session-token");
     vi.stubGlobal(
@@ -304,6 +340,20 @@ describe("mobile API authentication", () => {
       }),
     );
     await expect(rpc("bots/get", { botId: "missing" })).rejects.toThrow("Bot does not exist");
+  });
+
+  it("rejects an oversized RPC response before parsing it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(
+          { json: { ok: true } },
+          { headers: { "content-length": String(MAX_MOBILE_RPC_RESPONSE_BYTES + 1) } },
+        ),
+      ),
+    );
+
+    await expect(rpc("bots/get")).rejects.toThrow(`exceeds ${MAX_MOBILE_RPC_RESPONSE_BYTES} bytes`);
   });
 
   it("shares the selected space with direct API requests", async () => {

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -16,6 +16,7 @@ import {
   mergeThreadHistory,
   prependThreadHistoryPage,
   progressMessageId,
+  readBoundedJsonResponse,
   reduceLiveMessageBlocks,
   runFailureError,
   signupRequiresEmailVerification,
@@ -39,6 +40,8 @@ const ENDPOINT_KEY = "rakazo.api_base";
 const SPACE_KEY = "rakazo.space_id";
 const SPACE_ROLLBACK_KEY = "rakazo.space_rollback";
 const RPC_TIMEOUT_MS = 8_000;
+export const MAX_MOBILE_AUTH_RESPONSE_BYTES = 256 * 1024;
+export const MAX_MOBILE_RPC_RESPONSE_BYTES = 16 * 1024 * 1024;
 
 let cachedApiBase: string | undefined;
 let cachedSpaceId = "";
@@ -298,16 +301,19 @@ async function authenticateWithEmail(
   action: "sign-in" | "sign-up",
   input: { email: string; password: string; name?: string },
 ) {
-  const res = await fetch(`${currentApiBase()}/api/auth/${action}/email`, {
-    method: "POST",
-    headers: { "content-type": "application/json", origin: "rakazo://" },
-    body: JSON.stringify(input),
-  });
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok) {
+  const { response, body } = await fetchMobileJson<unknown>(
+    `${currentApiBase()}/api/auth/${action}/email`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "rakazo://" },
+      body: JSON.stringify(input),
+    },
+    {},
+  );
+  if (!response.ok) {
     throw new Error(responseErrorMessage(body, `Could not ${action.replace("-", " ")}`));
   }
-  const token = tokenFromAuthResponse(res, body);
+  const token = tokenFromAuthResponse(response, body);
   if (action === "sign-up" && signupRequiresEmailVerification(body))
     return { verificationRequired: true };
   if (!token)
@@ -334,31 +340,72 @@ export function signUp(email: string, password: string, name: string) {
 export type PasswordResetCapabilities = { passwordReset: boolean; resetUrl: string | null };
 
 export async function passwordResetCapabilities(): Promise<PasswordResetCapabilities> {
-  const response = await fetch(`${currentApiBase()}/api/auth/capabilities`, {
-    headers: { origin: "rakazo://" },
-  });
+  const { response, body } = await fetchMobileJson<PasswordResetCapabilities>(
+    `${currentApiBase()}/api/auth/capabilities`,
+    { headers: { origin: "rakazo://" } },
+  );
   if (!response.ok) throw new Error("Could not load password recovery settings");
-  return (await response.json()) as PasswordResetCapabilities;
+  return body;
 }
 
 export async function requestPasswordReset(email: string, redirectTo: string): Promise<void> {
-  const response = await fetch(`${currentApiBase()}/api/auth/request-password-reset`, {
-    method: "POST",
-    headers: { "content-type": "application/json", origin: "rakazo://" },
-    body: JSON.stringify({ email, redirectTo }),
-  });
-  const body = await response.json().catch(() => ({}));
+  const { response, body } = await fetchMobileJson<unknown>(
+    `${currentApiBase()}/api/auth/request-password-reset`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "rakazo://" },
+      body: JSON.stringify({ email, redirectTo }),
+    },
+    {},
+  );
   if (!response.ok) throw new Error(responseErrorMessage(body, t("Could not send reset email")));
 }
 
 export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
-  const response = await fetch(`${currentApiBase()}/api/auth/change-password`, {
-    method: "POST",
-    headers: { "content-type": "application/json", origin: "rakazo://", ...(await authHeaders()) },
-    body: JSON.stringify({ currentPassword, newPassword, revokeOtherSessions: true }),
-  });
-  const body = await response.json().catch(() => ({}));
+  const { response, body } = await fetchMobileJson<unknown>(
+    `${currentApiBase()}/api/auth/change-password`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "rakazo://",
+        ...(await authHeaders()),
+      },
+      body: JSON.stringify({ currentPassword, newPassword, revokeOtherSessions: true }),
+    },
+    {},
+  );
   if (!response.ok) throw new Error(responseErrorMessage(body, t("Could not change password")));
+}
+
+async function fetchMobileJson<T>(
+  input: Parameters<typeof fetch>[0],
+  init: RequestInit,
+  invalidJsonFallback?: T,
+): Promise<{ response: Response; body: T }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("Request timed out")), RPC_TIMEOUT_MS);
+  try {
+    const response = await withAbort(
+      fetch(input, { ...init, signal: controller.signal }),
+      controller.signal,
+    );
+    try {
+      const body = await readBoundedJsonResponse<T>(
+        response,
+        MAX_MOBILE_AUTH_RESPONSE_BYTES,
+        controller.signal,
+      );
+      return { response, body };
+    } catch (error) {
+      if (invalidJsonFallback !== undefined && error instanceof SyntaxError) {
+        return { response, body: invalidJsonFallback };
+      }
+      throw error;
+    }
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export async function signOut() {
@@ -403,13 +450,20 @@ function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
 
 export async function deleteAccount(password: string) {
   await rpc("notifications/unregisterPush").catch(() => undefined);
-  const res = await fetch(`${currentApiBase()}/api/auth/delete-user`, {
-    method: "POST",
-    headers: { "content-type": "application/json", origin: "rakazo://", ...(await authHeaders()) },
-    body: JSON.stringify({ password }),
-  });
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok) {
+  const { response, body } = await fetchMobileJson<unknown>(
+    `${currentApiBase()}/api/auth/delete-user`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "rakazo://",
+        ...(await authHeaders()),
+      },
+      body: JSON.stringify({ password }),
+    },
+    {},
+  );
+  if (!response.ok) {
     throw new Error(responseErrorMessage(body, t("Could not delete account")));
   }
   await clearSessionToken();
@@ -442,7 +496,11 @@ export async function rpc<T>(
       body: JSON.stringify({ json: body }),
       signal: controller.signal,
     });
-    const parsed = (await res.json()) as { json?: T; error?: { message?: string } };
+    const parsed = await readBoundedJsonResponse<{ json?: T; error?: { message?: string } }>(
+      res,
+      MAX_MOBILE_RPC_RESPONSE_BYTES,
+      controller.signal,
+    );
     if (!res.ok || parsed.error) throw new Error(parsed.error?.message ?? `rpc ${proc} failed`);
     return parsed.json as T;
   } finally {

--- a/apps/mobile/lib/endpoint.test.ts
+++ b/apps/mobile/lib/endpoint.test.ts
@@ -7,6 +7,7 @@ import {
   apiBaseWarning,
   defaultApiBase,
   displayApiHost,
+  MAX_API_PROBE_RESPONSE_BYTES,
   normalizeApiBase,
   probeApiBase,
   usesCustomApiBase,
@@ -118,6 +119,20 @@ describe("probeApiBase", () => {
     });
   });
 
+  it("rejects an oversized health response", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ json: { ok: true } }), {
+          headers: { "content-length": String(MAX_API_PROBE_RESPONSE_BYTES + 1) },
+        }),
+    ) as unknown as typeof fetch;
+
+    await expect(probeApiBase("https://app.example.com", fetchImpl)).resolves.toMatchObject({
+      ok: false,
+      error: "Could not reach that server",
+    });
+  });
+
   it("returns a failure when an injected fetch ignores the probe signal", async () => {
     vi.useFakeTimers();
     const fetchImpl = vi.fn(
@@ -136,18 +151,17 @@ describe("probeApiBase", () => {
 
   it("returns a failure when a health response body never settles", async () => {
     vi.useFakeTimers();
-    const fetchImpl = vi.fn(async () => ({
-      ok: true,
-      json: () => new Promise<unknown>(() => undefined),
-    }));
+    const cancel = vi.fn();
+    const fetchImpl = vi.fn(async () => new Response(new ReadableStream({ cancel })));
 
-    const pending = probeApiBase("https://app.example.com", fetchImpl as unknown as typeof fetch);
+    const pending = probeApiBase("https://app.example.com", fetchImpl as typeof fetch);
     await vi.advanceTimersByTimeAsync(API_PROBE_TIMEOUT_MS);
 
     await expect(pending).resolves.toMatchObject({
       ok: false,
       error: "Could not reach that server",
     });
+    expect(cancel).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/mobile/lib/endpoint.ts
+++ b/apps/mobile/lib/endpoint.ts
@@ -1,10 +1,13 @@
+import { readBoundedJsonResponse } from "@rakazo/core";
 import { t } from "./i18n";
 
 const LOCAL_API = "http://127.0.0.1:3100";
 const DEFAULT_API = process.env.EXPO_PUBLIC_API_URL ?? LOCAL_API;
 export const API_PROBE_TIMEOUT_MS = 8_000;
+export const MAX_API_PROBE_RESPONSE_BYTES = 64 * 1024;
 
 export type EndpointResult = { ok: true; url: string } | { ok: false; error: string };
+type HealthResponse = { json?: { ok?: boolean }; error?: { message?: string } };
 
 export function defaultApiBase() {
   return originOnly(DEFAULT_API) ?? LOCAL_API;
@@ -78,13 +81,17 @@ export async function probeApiBase(
       cancelResponseBody(res);
       return { ok: false, error: t("That URL did not look like a Rakazo server") };
     }
-    const body = (await withAbort(
-      res.json().catch(() => ({})),
-      controller.signal,
-    )) as {
-      json?: { ok?: boolean };
-      error?: { message?: string };
-    };
+    let body: HealthResponse;
+    try {
+      body = await readBoundedJsonResponse<HealthResponse>(
+        res,
+        MAX_API_PROBE_RESPONSE_BYTES,
+        controller.signal,
+      );
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      body = {};
+    }
     if (body.error || body.json?.ok !== true) {
       return { ok: false, error: t("That URL did not look like a Rakazo server") };
     }

--- a/apps/web/src/pages/Auth.tsx
+++ b/apps/web/src/pages/Auth.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import { signupRequiresEmailVerification } from "@rakazo/core";
+import { readBoundedJsonResponse, signupRequiresEmailVerification } from "@rakazo/core";
 import { Button, Input, Label } from "@rakazo/ui-web";
 import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -12,6 +12,8 @@ type PasswordResetCapabilities = { passwordReset: boolean; resetUrl: string | nu
 
 const fieldClass = "mt-2 h-12 rounded-xl px-4 text-base md:text-base";
 const submitClass = "mt-3 h-12 w-full rounded-xl text-base";
+const AUTH_CAPABILITIES_TIMEOUT_MS = 8_000;
+const MAX_AUTH_CAPABILITIES_RESPONSE_BYTES = 64 * 1024;
 
 export function AuthPage({ mode }: { mode: AuthMode }) {
   const { t } = useLingui();
@@ -41,17 +43,26 @@ export function AuthPage({ mode }: { mode: AuthMode }) {
   useEffect(() => {
     if (mode === "up") return;
     let active = true;
-    void fetch("/api/auth/capabilities")
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), AUTH_CAPABILITIES_TIMEOUT_MS);
+    void fetch("/api/auth/capabilities", { signal: controller.signal })
       .then(async (response) => {
         if (!response.ok) throw new Error("Could not load authentication capabilities");
-        return (await response.json()) as PasswordResetCapabilities;
+        return readBoundedJsonResponse<PasswordResetCapabilities>(
+          response,
+          MAX_AUTH_CAPABILITIES_RESPONSE_BYTES,
+          controller.signal,
+        );
       })
       .then((capabilities) => {
         if (active) setReset(capabilities);
       })
-      .catch(() => undefined);
+      .catch(() => undefined)
+      .finally(() => clearTimeout(timer));
     return () => {
       active = false;
+      clearTimeout(timer);
+      controller.abort();
     };
   }, [mode]);
 

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@astrojs/react": "^6.0.2",
     "@astrojs/sitemap": "3.7.3",
+    "@rakazo/core": "workspace:*",
     "@rakazo/ui-web": "workspace:*",
     "@vercel/functions": "3.9.5",
     "astro": "^7.2.1",

--- a/apps/www/src/github.test.ts
+++ b/apps/www/src/github.test.ts
@@ -3,6 +3,7 @@ import {
   fetchGithubStars,
   formatStarCount,
   GITHUB_STARS_TIMEOUT_MS,
+  MAX_GITHUB_STARS_RESPONSE_BYTES,
 } from "./github.js";
 
 afterEach(() => {
@@ -31,5 +32,16 @@ describe("GitHub stars", () => {
 
     await expect(pending).resolves.toBeNull();
     expect(fetchImpl.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  it("returns the fallback for an oversized GitHub response", async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json(
+        { stargazers_count: 12_345 },
+        { headers: { "content-length": String(MAX_GITHUB_STARS_RESPONSE_BYTES + 1) } },
+      ),
+    );
+
+    await expect(fetchGithubStars(fetchImpl as unknown as typeof fetch)).resolves.toBeNull();
   });
 });

--- a/apps/www/src/github.ts
+++ b/apps/www/src/github.ts
@@ -1,6 +1,8 @@
+import { readBoundedJsonResponse } from "@rakazo/core";
 import { GITHUB_API_REPO } from "./site";
 
 export const GITHUB_STARS_TIMEOUT_MS = 5_000;
+export const MAX_GITHUB_STARS_RESPONSE_BYTES = 64 * 1024;
 
 export async function fetchGithubStars(fetchImpl: typeof fetch = fetch): Promise<number | null> {
   const controller = new AbortController();
@@ -20,9 +22,9 @@ export async function fetchGithubStars(fetchImpl: typeof fetch = fetch): Promise
       cancelResponseBody(response);
       return null;
     }
-    const payload = (await withAbort(response.json(), controller.signal)) as {
+    const payload = await readBoundedJsonResponse<{
       stargazers_count?: unknown;
-    };
+    }>(response, MAX_GITHUB_STARS_RESPONSE_BYTES, controller.signal);
     return typeof payload.stargazers_count === "number" ? payload.stargazers_count : null;
   } catch {
     return null;

--- a/infra/sandboxes/supervisor/src/computer-control.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-control.test.ts
@@ -4,7 +4,7 @@ import {
   publishedLoopbackControlHostPort,
   resolveComputerControlEndpoint,
 } from "./computer-spec.js";
-import { controlDesktop } from "./index.js";
+import { controlDesktop, MAX_COMPUTER_CONTROL_RESPONSE_BYTES } from "./index.js";
 import {
   attemptComputerControl,
   preferComputerControl,
@@ -104,6 +104,21 @@ describe("computer control HTTP boundary", () => {
       controlDesktop({ ...endpoint, token: "wrong-token" }, actions, ":1", false, 0),
     ).rejects.toThrow();
     expect(authorizations).toEqual([`Bearer ${token}`, "Bearer wrong-token"]);
+  });
+
+  it("rejects an oversized computer-control response before reading it", async () => {
+    const origin = await listen((req, res) => {
+      req.resume();
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "content-length": String(MAX_COMPUTER_CONTROL_RESPONSE_BYTES + 1),
+      });
+      res.end("{}");
+    });
+
+    await expect(
+      controlDesktop({ url: `${origin}/v1/desktop`, token }, actions, ":1", false, 0),
+    ).rejects.toThrow(`exceeds ${MAX_COMPUTER_CONTROL_RESPONSE_BYTES} bytes`);
   });
 
   describe.each([301, 302, 303, 307, 308])("HTTP %s", (status) => {

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -5,7 +5,11 @@ import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
-import { boundedSandboxCommandTimeoutMs, resolveSupervisorToken } from "@rakazo/core";
+import {
+  boundedSandboxCommandTimeoutMs,
+  readBoundedJsonResponse,
+  resolveSupervisorToken,
+} from "@rakazo/core";
 import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 import { SERVICE_NAMES } from "@rakazo/logging";
 import { createRootLogger } from "@rakazo/logging/axiom";
@@ -776,6 +780,8 @@ function computerControlEndpoint(info: Docker.ContainerInspectInfo) {
   });
 }
 
+export const MAX_COMPUTER_CONTROL_RESPONSE_BYTES = 16 * 1024 * 1024;
+
 export async function controlDesktop(
   endpoint: { url: string; token: string },
   actions: Array<z.infer<typeof computerActionSchema>>,
@@ -783,6 +789,7 @@ export async function controlDesktop(
   observe: boolean,
   settleMs: number,
 ) {
+  const signal = AbortSignal.timeout(computerControlTimeoutMs(actions, settleMs));
   let response: Response;
   try {
     response = await fetch(endpoint.url, {
@@ -800,7 +807,7 @@ export async function controlDesktop(
         observe,
         settleMs,
       }),
-      signal: AbortSignal.timeout(computerControlTimeoutMs(actions, settleMs)),
+      signal,
     });
   } catch (error) {
     if (isComputerControlUnavailable(error)) {
@@ -810,11 +817,11 @@ export async function controlDesktop(
     }
     throw error;
   }
-  const payload = (await response.json()) as {
+  const payload = await readBoundedJsonResponse<{
     completed?: unknown;
     observation?: unknown;
     error?: unknown;
-  };
+  }>(response, MAX_COMPUTER_CONTROL_RESPONSE_BYTES, signal);
   if (!response.ok) throw new Error(String(payload.error ?? "computer control failed"));
   if (typeof payload.completed !== "number")
     throw new Error("computer control returned no completion count");
@@ -823,6 +830,7 @@ export async function controlDesktop(
     ...(payload.observation ? { observation: payload.observation } : {}),
   };
 }
+
 const SCREEN_READY_TIMEOUT_MS = 45_000;
 
 // Docker publishes a container's port mapping (or assigns its internal IP)

--- a/packages/core/src/http-response.test.ts
+++ b/packages/core/src/http-response.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { ResponseBodyTooLargeError, readBoundedJsonResponse } from "./http-response.js";
+
+describe("readBoundedJsonResponse", () => {
+  it("parses a fragmented JSON response", async () => {
+    const encoder = new TextEncoder();
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('{"ok":'));
+          controller.enqueue(encoder.encode("true}"));
+          controller.close();
+        },
+      }),
+    );
+
+    await expect(readBoundedJsonResponse(response, 64)).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects and cancels a response with an oversized declared length", async () => {
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream({ cancel }), {
+      headers: { "content-length": "65" },
+    });
+
+    await expect(readBoundedJsonResponse(response, 64)).rejects.toBeInstanceOf(
+      ResponseBodyTooLargeError,
+    );
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+
+  it("rejects and cancels a streamed response that crosses the limit", async () => {
+    const cancel = vi.fn();
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(65));
+        },
+        cancel,
+      }),
+    );
+
+    await expect(readBoundedJsonResponse(response, 64)).rejects.toBeInstanceOf(
+      ResponseBodyTooLargeError,
+    );
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+
+  it("aborts a stalled body read", async () => {
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream({ cancel }));
+    const controller = new AbortController();
+    const pending = readBoundedJsonResponse(response, 64, controller.signal);
+
+    controller.abort(new Error("request timed out"));
+
+    await expect(pending).rejects.toThrow("request timed out");
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+
+  it("rejects malformed JSON after a complete bounded read", async () => {
+    await expect(readBoundedJsonResponse(new Response("not-json"), 64)).rejects.toBeInstanceOf(
+      SyntaxError,
+    );
+  });
+});

--- a/packages/core/src/http-response.ts
+++ b/packages/core/src/http-response.ts
@@ -1,0 +1,97 @@
+export class ResponseBodyTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Response body exceeds ${maxBytes} bytes`);
+    this.name = "ResponseBodyTooLargeError";
+  }
+}
+
+export async function readBoundedJsonResponse<T>(
+  response: Response,
+  maxBytes: number,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error("Response body limit must be a positive integer");
+  }
+  const declared = Number(response.headers.get("content-length") ?? Number.NaN);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    cancelResponseBody(response);
+    throw new ResponseBodyTooLargeError(maxBytes);
+  }
+  if (!response.body) return JSON.parse("") as T;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await readWithAbort(reader, signal);
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        cancelReader(reader);
+        throw new ResponseBodyTooLargeError(maxBytes);
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    cancelReader(reader);
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // The reader may already be cancelled or released.
+    }
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return JSON.parse(new TextDecoder().decode(bytes)) as T;
+}
+
+function readWithAbort(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal?: AbortSignal,
+): ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]> {
+  if (!signal) return reader.read();
+  if (signal.aborted) return Promise.reject(signal.reason ?? new Error("Request aborted"));
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      cancelReader(reader);
+      reject(signal.reason ?? new Error("Request aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    reader.read().then(
+      (result) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(result);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function cancelResponseBody(response: Response): void {
+  try {
+    void Promise.resolve(response.body?.cancel()).catch(() => undefined);
+  } catch {
+    // Cancellation is best-effort and must not delay the bounded failure.
+  }
+}
+
+function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    void Promise.resolve(reader.cancel()).catch(() => undefined);
+  } catch {
+    // Cancellation is best-effort and must not delay the bounded failure.
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from "./cron.js";
 export * from "./events.js";
 export * from "./featured-connectors.js";
 export * from "./group-mentions.js";
+export * from "./http-response.js";
 export * from "./mcp.js";
 export * from "./message-pages.js";
 export * from "./message-visibility.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
       '@astrojs/sitemap':
         specifier: 3.7.3
         version: 3.7.3
+      '@rakazo/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@rakazo/ui-web':
         specifier: workspace:*
         version: link:../../packages/ui-web


### PR DESCRIPTION
## Why

Several remaining production clients still buffered JSON responses without a shared size limit. A misconfigured or compromised upstream could therefore keep a request open indefinitely or make the web, mobile, or supervisor process retain an unexpectedly large body.

## What

- add a shared `readBoundedJsonResponse` helper that enforces declared and streamed byte limits, honors abort signals, and cancels oversized or stalled bodies without waiting on cancellation
- apply it as one grouped change to mobile authentication/RPC/server probing, web authentication capabilities, website GitHub metadata, and supervisor computer-control responses
- keep endpoint-specific budgets: 64 KiB for capability/metadata probes, 256 KiB for mobile auth, and 16 MiB for RPC/computer-control payloads
- add regression coverage for fragmented JSON, declared and streamed overflow, malformed JSON, abort/cancellation, mobile auth timeouts, and each integrated boundary

## Test

- `pnpm check` (22/22 tasks)
- `pnpm lint` (passes; existing repository warnings only)
- `pnpm --filter @rakazo/core test` (402 tests)
- `pnpm --filter @rakazo/mobile test` (175 tests)
- `pnpm --filter @rakazo/sandbox-supervisor test` (114 passed, 1 skipped)
- `pnpm exec vitest run apps/www/src/github.test.ts` (3 tests)

No UI copy or visual behavior changes.
