### PR TITLE
fix: stop Settings password autofill landing in sidebar Search

### DIFF
--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -138,6 +138,24 @@ test("changes and recovers an email password", async ({ page }, testInfo) => {
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   const settings = page.getByTestId("user-settings");
   await expect(settings).toBeVisible();
+  await expect(page.getByTestId("sidebar-search").locator("input")).toHaveAttribute(
+    "autocomplete",
+    "off",
+  );
+  await expect(settings.locator('input[name="username"]')).toHaveAttribute(
+    "autocomplete",
+    "username",
+  );
+  await expect(settings.locator('input[name="username"]')).toHaveValue(email);
+  await expect(settings.getByLabel("Current password")).toHaveAttribute(
+    "autocomplete",
+    "current-password",
+  );
+  await expect(settings.getByLabel("New password")).toHaveAttribute("autocomplete", "new-password");
+  await expect(settings.getByLabel("Confirm password")).toHaveAttribute(
+    "autocomplete",
+    "new-password",
+  );
   await settings.getByLabel("Current password").fill(originalPassword);
   await settings.getByLabel("New password").fill(changedPassword);
   await settings.getByLabel("Confirm password").fill(changedPassword);

--- a/apps/web/e2e/auth-lifecycle.spec.ts
+++ b/apps/web/e2e/auth-lifecycle.spec.ts
@@ -142,6 +142,10 @@ test("changes and recovers an email password", async ({ page }, testInfo) => {
     "autocomplete",
     "off",
   );
+  await expect(page.getByTestId("sidebar-search").locator("input")).toHaveAttribute(
+    "name",
+    "sidebar-search",
+  );
   await expect(settings.locator('input[name="username"]')).toHaveAttribute(
     "autocomplete",
     "username",

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -129,7 +129,7 @@ export function AccountSettingsOverlay({
           {email ? <p className="mt-1 text-[13px] text-muted-foreground/70">{email}</p> : null}
         </section>
 
-        <ChangePasswordSection />
+        <ChangePasswordSection email={email} />
 
         {messagingEnabled && onOpenMessaging ? (
           <section className="mt-5 rounded-xl border border-border px-4 py-4">
@@ -257,7 +257,7 @@ export function AccountSettingsOverlay({
   );
 }
 
-function ChangePasswordSection() {
+function ChangePasswordSection({ email }: { email?: string | null }) {
   const { t } = useLingui();
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -302,6 +302,16 @@ function ChangePasswordSection() {
         <Trans>Password</Trans>
       </h3>
       <div className="mt-3 grid gap-3">
+        <input
+          type="text"
+          name="username"
+          autoComplete="username"
+          value={email ?? ""}
+          readOnly
+          tabIndex={-1}
+          aria-hidden="true"
+          className="sr-only"
+        />
         <SettingsPasswordInput
           label={t`Current password`}
           autoComplete="current-password"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2482,6 +2482,8 @@ export function ShellPage() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={t`Search`}
+            autoComplete="off"
+            name="sidebar-search"
           />
         </InputGroup>
         <div className="rk-scroll flex flex-1 flex-col gap-0.5 overflow-y-auto px-2.5 pb-2.5">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Opening profile Settings made the browser password manager dump the saved email into the sidebar Search box behind the dialog. Search is not a credential field; the password form also had no username field for the manager to bind to.

Fixes #721

## What changed
- Sidebar Search now sets `autoComplete="off"` and a non-credential `name`, matching other non-credential inputs in the app.
- Settings password change includes a visually hidden, read-only username field filled with the account email so managers associate credentials with that form instead of Search.

## Testing
- Extended the auth lifecycle E2E password-change coverage to assert Search `autocomplete="off"` / `name="sidebar-search"` and the Settings username / password autocomplete attributes.
- CI Web E2E passed, including the password-change path: [password changed](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34026960860-1/screenshots/images/072-41-password-changed.png)
- Did not capture local screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4877a71d-eefe-4059-98d5-df1cbc5b5963?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4877a71d-eefe-4059-98d5-df1cbc5b5963&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved password manager support in account settings by correctly identifying the username, current password, and new password fields.
  - Prevented browser autocomplete from suggesting saved values in the sidebar search field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->