### PR TITLE
Add bot color picker to settings

### DIFF
--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -1,4 +1,5 @@
 import {
+  BOT_COLORS,
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
   BOT_TITLE_MAX_LENGTH,
@@ -7,7 +8,8 @@ import {
 } from "@rakazo/contracts";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
-import { Pressable, ScrollView, Text, TextInput } from "react-native";
+import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { BotAvatar } from "../components/bot-avatar";
 import { ComputerModePicker } from "../components/computer-mode-picker";
 import { type MobileBot, rpc } from "../lib/api";
 import { useI18n } from "../lib/i18n";
@@ -26,6 +28,7 @@ export default function BotSettingsScreen() {
   const [name, setName] = useState("");
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [color, setColor] = useState<string>(BOT_COLORS[0]);
   const [computerMode, setComputerMode] = useState<ComputerMode>("team");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
@@ -38,6 +41,7 @@ export default function BotSettingsScreen() {
         setName(next.name);
         setTitle(next.title);
         setDescription(next.description ?? "");
+        setColor(next.color);
         setComputerMode(next.computerMode);
       })
       .catch((err) => setError(err instanceof Error ? err.message : t("Could not load bot")));
@@ -55,6 +59,7 @@ export default function BotSettingsScreen() {
         title?: string;
         description?: string;
         instructions?: string;
+        color?: string;
       } = { botId };
       if (profile.name !== bot.name) input.name = profile.name;
       if (profile.title !== bot.title) input.title = profile.title;
@@ -63,6 +68,7 @@ export default function BotSettingsScreen() {
         // Keep instructions in sync with description (same as web BotSettings).
         input.instructions = profile.instructions;
       }
+      if (color !== bot.color) input.color = color;
       if (computerMode !== bot.computerMode) {
         await rpc("bots/setComputer", { botId, mode: computerMode });
       }
@@ -87,6 +93,11 @@ export default function BotSettingsScreen() {
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
       >
+        {bot ? (
+          <View style={{ alignItems: "center", marginBottom: 24 }}>
+            <BotAvatar color={color} identity={bot.id} size={64} status={bot.status} />
+          </View>
+        ) : null}
         <Text style={{ color: tokens.mutedForeground, fontSize: 14 }}>{t("Name")}</Text>
         <TextInput
           value={name}
@@ -139,6 +150,33 @@ export default function BotSettingsScreen() {
             textAlignVertical: "top",
           }}
         />
+        <Text style={{ color: tokens.mutedForeground, marginTop: 16, fontSize: 14 }}>
+          {t("Color")}
+        </Text>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: 10, marginTop: 8 }}
+          accessibilityRole="radiogroup"
+        >
+          {BOT_COLORS.map((option, index) => (
+            <Pressable
+              key={option}
+              accessibilityRole="radio"
+              accessibilityLabel={t("Color {number}", { number: index + 1 })}
+              accessibilityState={{ checked: color === option }}
+              onPress={() => setColor(option)}
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: 18,
+                backgroundColor: option,
+                borderWidth: 3,
+                borderColor: color === option ? tokens.foreground : "transparent",
+              }}
+            />
+          ))}
+        </ScrollView>
         <ComputerModePicker value={computerMode} onChange={setComputerMode} />
         {error ? <Text style={{ color: tokens.destructive, marginTop: 16 }}>{error}</Text> : null}
         <Pressable

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -81,6 +81,8 @@ export const ZH_MESSAGES: Record<string, string> = {
   "Close computer": "关闭电脑",
   "Close preview": "关闭预览",
   Code: "验证码",
+  Color: "颜色",
+  "Color {number}": "颜色 {number}",
   Completed: "已完成",
   Computer: "电脑",
   "Confirm password": "确认密码",

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -67,7 +67,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   await nameInput.fill("Researcher");
   await titleInput.fill(longTitle);
   await descriptionInput.fill("Finds reliable sources and turns them into concise briefs.");
-  await page.getByRole("radio", { name: "Color 2" }).click();
+  await page.getByRole("radio", { name: "Color 7" }).click();
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(botList.getByRole("button", { name: /^Researcher/ })).toBeVisible();
   await expect(page.getByPlaceholder("Message Researcher")).toBeVisible();
@@ -79,7 +79,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
     "Finds reliable sources and turns them into concise briefs.",
   );
   const settings = page.getByTestId("bot-settings");
-  await expect(settings.getByRole("radio", { name: "Color 2" })).toBeChecked();
+  await expect(settings.getByRole("radio", { name: "Color 7" })).toBeChecked();
   const modelSelect = settings.locator("label:has-text('Model') select");
   const teamComputer = settings.getByRole("button", { name: "Team" });
   const openWork = settings.getByTestId("bot-scratchpad");

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -67,6 +67,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   await nameInput.fill("Researcher");
   await titleInput.fill(longTitle);
   await descriptionInput.fill("Finds reliable sources and turns them into concise briefs.");
+  await page.getByRole("radio", { name: "Color 2" }).click();
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(botList.getByRole("button", { name: /^Researcher/ })).toBeVisible();
   await expect(page.getByPlaceholder("Message Researcher")).toBeVisible();
@@ -78,6 +79,7 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
     "Finds reliable sources and turns them into concise briefs.",
   );
   const settings = page.getByTestId("bot-settings");
+  await expect(settings.getByRole("radio", { name: "Color 2" })).toBeChecked();
   const modelSelect = settings.locator("label:has-text('Model') select");
   const teamComputer = settings.getByRole("button", { name: "Team" });
   const openWork = settings.getByTestId("bot-scratchpad");

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -710,6 +710,16 @@ msgstr "Code"
 msgid "Collapse {0}"
 msgstr ""
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Farbe"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Farbe {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr ""

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -710,6 +710,16 @@ msgstr "Code"
 msgid "Collapse {0}"
 msgstr "Collapse {0}"
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Color"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Color {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr "Coming soon"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -710,6 +710,16 @@ msgstr "Código"
 msgid "Collapse {0}"
 msgstr "Contraer {0}"
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Color"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Color {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr "Próximamente"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -710,6 +710,16 @@ msgstr "कोड"
 msgid "Collapse {0}"
 msgstr ""
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "रंग"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "रंग {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr ""

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -710,6 +710,16 @@ msgstr "코드"
 msgid "Collapse {0}"
 msgstr "{0} 접기"
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "색상"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "색상 {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr "준비 중"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -710,6 +710,16 @@ msgstr "Código"
 msgid "Collapse {0}"
 msgstr ""
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Cor"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Cor {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr ""

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -710,6 +710,16 @@ msgstr "Kod"
 msgid "Collapse {0}"
 msgstr ""
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "Renk"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "Renk {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr ""

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -710,6 +710,16 @@ msgstr "代码"
 msgid "Collapse {0}"
 msgstr "折叠 {0}"
 
+#: src/pages/shell/bot-panel.tsx:327
+#: src/pages/shell/bot-panel.tsx:328
+msgid "Color"
+msgstr "颜色"
+
+#. placeholder {0}: index + 1
+#: src/pages/shell/bot-panel.tsx:337
+msgid "Color {0}"
+msgstr "颜色 {0}"
+
 #: src/pages/RoutineEditor.tsx:387
 msgid "Coming soon"
 msgstr "即将推出"

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -342,24 +342,19 @@ export function BotSettings({
         <Trans>Color</Trans>
         <div className="mt-2 flex flex-wrap gap-2" role="radiogroup" aria-label={t`Color`}>
           {BOT_COLORS.map((option, index) => (
-            <label key={option} className="cursor-pointer rounded-full">
-              <input
-                className="peer sr-only"
-                type="radio"
-                name={`${ids}-color`}
-                value={option}
-                checked={color === option}
-                aria-label={t`Color ${index + 1}`}
-                onChange={() => setColor(option)}
-              />
-              <span
-                aria-hidden="true"
-                className={`block size-8 rounded-full border-2 ring-offset-card transition-transform hover:scale-105 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2 ${
-                  color === option ? "border-foreground" : "border-transparent"
-                }`}
-                style={{ backgroundColor: option }}
-              />
-            </label>
+            <input
+              key={option}
+              className={`size-8 cursor-pointer appearance-none rounded-full border-2 ring-offset-card transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                color === option ? "border-foreground" : "border-transparent"
+              }`}
+              type="radio"
+              name={`${ids}-color`}
+              value={option}
+              checked={color === option}
+              aria-label={t`Color ${index + 1}`}
+              style={{ backgroundColor: option }}
+              onChange={() => setColor(option)}
+            />
           ))}
         </div>
       </div>

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -11,6 +11,7 @@ import type {
   VoiceInfo,
 } from "@rakazo/contracts";
 import {
+  BOT_COLORS,
   BOT_DESCRIPTION_MAX_LENGTH,
   BOT_NAME_MAX_LENGTH,
   BOT_TITLE_MAX_LENGTH,
@@ -190,6 +191,7 @@ export function BotSettings({
     title?: string;
     description?: string;
     instructions?: string;
+    color?: string;
     computerMode: ComputerMode;
     memoryScope?: "isolated" | "shared" | null;
     autoSpeak?: boolean;
@@ -207,6 +209,7 @@ export function BotSettings({
   const [name, setName] = useState(bot.name);
   const [title, setTitle] = useState(bot.title);
   const [description, setDescription] = useState(bot.description);
+  const [color, setColor] = useState(bot.color);
   const [computerMode, setComputerMode] = useState(bot.computerMode);
   const [memoryScope, setMemoryScope] = useState(bot.memoryScope);
   const [autoSpeak, setAutoSpeak] = useState(bot.autoSpeak);
@@ -302,7 +305,7 @@ export function BotSettings({
   return (
     <div data-testid="bot-settings">
       <div className="flex justify-center">
-        <BotAvatar color={bot.color} identity={bot.id} size={64} status={bot.status} />
+        <BotAvatar color={color} identity={bot.id} size={64} status={bot.status} />
       </div>
       <label htmlFor={`${ids}-name`} className="mt-6 block text-[14px] text-muted-foreground">
         <Trans>Name</Trans>
@@ -335,6 +338,31 @@ export function BotSettings({
           className="mt-2"
         />
       </label>
+      <div className={fieldLabelClass}>
+        <Trans>Color</Trans>
+        <div className="mt-2 flex flex-wrap gap-2" role="radiogroup" aria-label={t`Color`}>
+          {BOT_COLORS.map((option, index) => (
+            <label key={option} className="cursor-pointer rounded-full">
+              <input
+                className="peer sr-only"
+                type="radio"
+                name={`${ids}-color`}
+                value={option}
+                checked={color === option}
+                aria-label={t`Color ${index + 1}`}
+                onChange={() => setColor(option)}
+              />
+              <span
+                aria-hidden="true"
+                className={`block size-8 rounded-full border-2 ring-offset-card transition-transform hover:scale-105 peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2 ${
+                  color === option ? "border-foreground" : "border-transparent"
+                }`}
+                style={{ backgroundColor: option }}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
       <details
         data-testid="bot-settings-advanced"
         className="group mt-5"
@@ -480,6 +508,7 @@ export function BotSettings({
               title: nextTitle,
               description: nextDescription,
               instructions: nextDescription,
+              color,
               computerMode,
               memoryScope,
               autoSpeak,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Bot settings could not change identity color after creation. This restores the color picker on web/Electron and mobile so bots can update among the seven existing identity colors, with live avatar preview and persistence via `bots/update`.

Supersedes #660 (cross-repo tip could not be force-pushed: GitHub App rejected the fork update for missing `workflows` permission after rebasing onto current `main`).

## What changed

- Web/Electron bot settings: color radiogroup (7 `BOT_COLORS`), live `BotAvatar` preview, save includes `color`
- Mobile bot settings: same picker + avatar preview, using semantic tokens
- Locale strings for Color / Color {n}
- bot-crud E2E selects Color 7 and asserts it stays checked after save

Conflict resolution on rebase onto current `main`: kept main’s Advanced `onToggle` / lazy Knowledge section behavior in `bot-panel.tsx`, and kept mobile semantic tokens (no hardcoded hex) while preserving the picker feature.

Co-authored-by: Baker Helton <baker.helton@icloud.com>

## How tested

- Rebased #660’s two commits onto current `origin/main` and resolved conflicts in `bot-panel.tsx` and mobile `bot-settings.tsx`
- Verified final tip includes clickable color swatches, Color 7 E2E assertions, locale additions, and token-based mobile styling
- Did not run desktop Playwright e2e locally (CI virtual-display job covers that)
- No agent-machine screenshots captured
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-947e0902-4e39-4f5f-b67d-28e48545c538?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-947e0902-4e39-4f5f-b67d-28e48545c538&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bot color customization in web and mobile settings.
  * Added a color preview and selectable color options with accessibility support.
  * Selected colors are saved and preserved when reopening bot settings.

* **Documentation**
  * Added translations for color labels across supported languages.

* **Tests**
  * Added coverage verifying bot color selection persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->