### PR TITLE
docs(self-host): slim OpenAI-compatible public gate note

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -171,7 +171,8 @@ RAKAZO_LOCAL_MAX_TOKENS=4096
 ```
 
 The loopback default is suitable when running Rakazo from a source checkout. From containers,
-prefer `host.docker.internal` or a stable LAN RFC1918 address (not Compose service DNS alone).
+prefer `host.docker.internal` (Desktop, or Linux with `host-gateway`) or a stable LAN RFC1918
+address (not Compose service DNS alone).
 Only configure an endpoint you control: prompts, attachments, and tool results sent to that model
 leave Rakazo through this URL. Leave `RAKAZO_LOCAL_MODELS` blank to disable the provider.
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -171,16 +171,16 @@ RAKAZO_LOCAL_MAX_TOKENS=4096
 ```
 
 The loopback default is suitable when running Rakazo from a source checkout. From containers,
-prefer `host.docker.internal` (Desktop, or Linux with `host-gateway`) or a stable LAN RFC1918
-address (not Compose service DNS alone).
+prefer a stable LAN RFC1918 address (not Compose service DNS alone). `host.docker.internal`
+works on Desktop; on Linux it needs an explicit `host-gateway` mapping.
 Only configure an endpoint you control: prompts, attachments, and tool results sent to that model
 leave Rakazo through this URL. Leave `RAKAZO_LOCAL_MODELS` blank to disable the provider.
 
 Each user can also connect their own OpenAI-compatible endpoint from **Connect a model** /
 **Settings → Models** on web and mobile. Choose **OpenAI-compatible**, enter the server base URL
 (for example `http://127.0.0.1:8000/v1`), the exact model id, and an optional API key.
-Public hosts need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1`. Private, loopback, and
-`host.docker.internal` targets do not.
+Public hosts and ordinary hostnames need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1`. Literal private
+IP, loopback, and `host.docker.internal` targets do not.
 
 For servers that accept standard `reasoning_effort`, enable **Supports thinking** under
 **Advanced** when connecting. The setting is saved on the connection (no env var or restart).

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -170,19 +170,16 @@ RAKAZO_LOCAL_CONTEXT_WINDOW=32768
 RAKAZO_LOCAL_MAX_TOKENS=4096
 ```
 
-The loopback default is suitable when running Rakazo from a source checkout. In Docker Compose,
-use the model server's Compose service name or another address reachable from the containers.
+The loopback default is suitable when running Rakazo from a source checkout. From containers,
+prefer `host.docker.internal` or a stable LAN RFC1918 address (not Compose service DNS alone).
 Only configure an endpoint you control: prompts, attachments, and tool results sent to that model
 leave Rakazo through this URL. Leave `RAKAZO_LOCAL_MODELS` blank to disable the provider.
 
 Each user can also connect their own OpenAI-compatible endpoint from **Connect a model** /
 **Settings → Models** on web and mobile. Choose **OpenAI-compatible**, enter the server base URL
-(for example `http://127.0.0.1:8000/v1` for Rapid-MLX, Ollama, LM Studio, llama.cpp, or vLLM),
-the exact model id from that server, and an optional API key. By default Rakazo only allows
-loopback, RFC1918, and `host.docker.internal` targets. To permit public hostnames, set
-`RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1` in the deployment environment. Public hostnames must resolve
-only to public addresses; redirects and DNS answers that reach private or link-local networks are
-rejected.
+(for example `http://127.0.0.1:8000/v1`), the exact model id, and an optional API key.
+Public hosts need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1`. Private, loopback, and
+`host.docker.internal` targets do not.
 
 For servers that accept standard `reasoning_effort`, enable **Supports thinking** under
 **Advanced** when connecting. The setting is saved on the connection (no env var or restart).

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -171,8 +171,8 @@ RAKAZO_LOCAL_MAX_TOKENS=4096
 ```
 
 The loopback default is suitable when running Rakazo from a source checkout. From containers,
-prefer a stable LAN RFC1918 address (not Compose service DNS alone). `host.docker.internal`
-works on Desktop; on Linux it needs an explicit `host-gateway` mapping.
+prefer a stable LAN RFC1918 address (not Compose service DNS alone). On Docker Desktop,
+`host.docker.internal` also works.
 Only configure an endpoint you control: prompts, attachments, and tool results sent to that model
 leave Rakazo through this URL. Leave `RAKAZO_LOCAL_MODELS` blank to disable the provider.
 

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -51,6 +51,8 @@ SANDBOX_PROVIDER=docker
 # Optional model / integration keys
 OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
+# User-connected public OpenAI-compatible hosts need =1 (default: private/loopback only).
+# RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=
 
 # Optional outbound HTTP(S) proxy for api/worker containers (Mainland / corporate).
 # Leave blank unless you need egress through a proxy. Uppercase or lowercase keys work.

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -52,7 +52,7 @@ SANDBOX_PROVIDER=docker
 OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
 # User-connected public OpenAI-compatible hosts need =1 (default: private/loopback only).
-# RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=
+# RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1
 
 # Optional outbound HTTP(S) proxy for api/worker containers (Mainland / corporate).
 # Leave blank unless you need egress through a proxy. Uppercase or lowercase keys work.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Published-images operators hit “Public model endpoints are blocked” with no hint that `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1` exists, and the Compose docs pointed at service DNS that the SSRF gate rejects. A short note is enough; a separate essay page is noise.

## What changed

- Comment `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=` in `infra/compose/.env.images.example`.
- Shorten the OpenAI-compatible note in `docs/self-host.md`: public hosts and ordinary hostnames need the gate; literal private IP / loopback / `host.docker.internal` do not; from containers prefer a stable LAN RFC1918 address (not Compose service DNS alone). On Docker Desktop, `host.docker.internal` also works.
- No `docs/self-host-openai-compatible.md` page and no links to one.

Supersedes #577.

## How tested

- Diff review only (docs / env example). Confirmed no remaining references to a separate OpenAI-compatible self-host page.
- Addressed Greptile feedback: hostname vs literal private IP, and avoid recommending unresolved `host.docker.internal` on Linux published-image stacks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14b1368a-20e8-4ca0-a6e8-00cca68beaa3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14b1368a-20e8-4ca0-a6e8-00cca68beaa3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated self-hosting guidance for configuring local models, including recommended network addresses for different Docker environments.
  - Clarified access requirements for user-connected OpenAI-compatible endpoints, including when public host access must be enabled.
  - Updated the example environment configuration to show the required opt-in value for enabling public endpoint access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->