### PR TITLE
fix(web): drop confusing Advanced MCP servers chip

### DIFF
--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -218,13 +218,14 @@ test("takeover, routine, plugins, and export are reachable", async ({ page }, te
   await advanced.evaluate((element) => {
     (element as HTMLDetailsElement).open = true;
   });
-  await expect(page.getByRole("button", { name: "MCP servers", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Manage MCP servers", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add MCP server", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add OpenAPI", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add GraphQL", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add Executor", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add Treg", exact: true })).toBeVisible();
   await expect(page.getByText("Tool sources", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "MCP servers", exact: true })).toBeHidden();
   // Thin Advanced smoke only. GraphQL install and order screenshots live in graphql-integrations.spec.ts.
   await page.getByRole("button", { name: "Add Treg", exact: true }).click();
   await page.getByPlaceholder("Treg token").fill("fake-treg-browser-credential");

--- a/apps/web/e2e/graphql-integrations.spec.ts
+++ b/apps/web/e2e/graphql-integrations.spec.ts
@@ -23,13 +23,14 @@ test("advanced GraphQL install shows Add GraphQL in MCP, OpenAPI, GraphQL, Execu
   await expect(page.getByRole("button", { name: "Add Executor", exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Add Treg", exact: true })).toBeVisible();
 
-  const advancedActions = advanced.locator("button");
-  await expect(advancedActions.nth(0)).toHaveText("MCP servers");
-  await expect(advancedActions.nth(1)).toHaveText("Add MCP server");
-  await expect(advancedActions.nth(2)).toHaveText("Add OpenAPI");
-  await expect(advancedActions.nth(3)).toHaveText("Add GraphQL");
-  await expect(advancedActions.nth(4)).toHaveText("Add Executor");
-  await expect(advancedActions.nth(5)).toHaveText("Add Treg");
+  const advancedActions = page.getByTestId("integrations-advanced-add").locator("button");
+  await expect(advancedActions.nth(0)).toHaveText("Add MCP server");
+  await expect(advancedActions.nth(1)).toHaveText("Add OpenAPI");
+  await expect(advancedActions.nth(2)).toHaveText("Add GraphQL");
+  await expect(advancedActions.nth(3)).toHaveText("Add Executor");
+  await expect(advancedActions.nth(4)).toHaveText("Add Treg");
+  await expect(advancedActions).toHaveCount(5);
+  await expect(page.getByRole("button", { name: "Manage MCP servers", exact: true })).toBeVisible();
   await captureScreenshot(page, testInfo, "01-graphql-advanced-order");
 
   await page.getByRole("button", { name: "Add GraphQL", exact: true }).click();

--- a/apps/web/e2e/mcp-oauth.spec.ts
+++ b/apps/web/e2e/mcp-oauth.spec.ts
@@ -87,7 +87,7 @@ test("connects an MCP server through the OAuth popup callback", async ({ page },
   await page.getByTestId("integrations-advanced").evaluate((element) => {
     (element as HTMLDetailsElement).open = true;
   });
-  await page.getByRole("button", { name: "MCP servers", exact: true }).click();
+  await page.getByRole("button", { name: "Manage MCP servers", exact: true }).click();
   await expect(page.getByRole("heading", { name: "MCP servers" })).toBeVisible();
   await expect(page.getByText("Linear MCP", { exact: true })).toBeVisible();
   await expect(page.getByLabel("Access token (optional)")).toBeHidden();

--- a/apps/web/scripts/translations-de.json
+++ b/apps/web/scripts/translations-de.json
@@ -333,6 +333,7 @@
   "Local": "Lokal",
   "Log out": "Abmelden",
   "Low": "Niedrig",
+  "Manage MCP servers": "MCP-Server verwalten",
   "Manage the Space semantic memory provider.": "Verwalte den Anbieter für semantische Erinnerungen des Arbeitsbereichs.",
   "Mark as Read": "Als gelesen markieren",
   "Mark as Unread": "Als ungelesen markieren",

--- a/apps/web/scripts/translations-es.json
+++ b/apps/web/scripts/translations-es.json
@@ -396,6 +396,7 @@
   "Local": "Local",
   "Log out": "Cerrar sesión",
   "Low": "Bajo",
+  "Manage MCP servers": "Gestionar servidores MCP",
   "Manage messaging settings": "Administrar configuración de mensajería",
   "Manage the Space semantic memory provider.": "Administra el proveedor de memoria semántica del Space.",
   "Mark as Read": "Marcar como leído",

--- a/apps/web/scripts/translations-hi.json
+++ b/apps/web/scripts/translations-hi.json
@@ -327,6 +327,7 @@
   "Local": "लोकल",
   "Log out": "लॉग आउट",
   "Low": "निम्न",
+  "Manage MCP servers": "MCP सर्वर प्रबंधित करें",
   "Manage the Space semantic memory provider.": "वर्कस्पेस के सिमेंटिक मेमोरी प्रोवाइडर को प्रबंधित करें।",
   "Mark as Read": "पढ़ा हुआ चिह्नित करें",
   "Mark as Unread": "अपठित चिह्नित करें",

--- a/apps/web/scripts/translations-ko.json
+++ b/apps/web/scripts/translations-ko.json
@@ -333,6 +333,7 @@
   "Local": "로컬",
   "Log out": "로그아웃",
   "Low": "낮음",
+  "Manage MCP servers": "MCP 서버 관리",
   "Manage the Space semantic memory provider.": "작업공간에서 사용할 장기 기억 서비스를 관리합니다.",
   "Mark as Read": "읽음으로 표시",
   "Mark as Unread": "읽지 않음으로 표시",

--- a/apps/web/scripts/translations-pt-BR.json
+++ b/apps/web/scripts/translations-pt-BR.json
@@ -327,6 +327,7 @@
   "Local": "Local",
   "Log out": "Sair",
   "Low": "Baixo",
+  "Manage MCP servers": "Gerenciar servidores MCP",
   "Manage the Space semantic memory provider.": "Gerencie o provedor de memória semântica do espaço de trabalho.",
   "Mark as Read": "Marcar como Lido",
   "Mark as Unread": "Marcar como Não Lida",

--- a/apps/web/scripts/translations-tr.json
+++ b/apps/web/scripts/translations-tr.json
@@ -329,6 +329,7 @@
   "Local": "Yerel",
   "Log out": "Çıkış yap",
   "Low": "Düşük",
+  "Manage MCP servers": "MCP sunucularını yönet",
   "Manage the Space semantic memory provider.": "Çalışma alanının semantik hafıza sağlayıcısını yönet.",
   "Mark as Read": "Okundu olarak işaretle",
   "Mark as Unread": "Okunmadı olarak işaretle",

--- a/apps/web/scripts/translations-zh-CN.json
+++ b/apps/web/scripts/translations-zh-CN.json
@@ -680,6 +680,7 @@
   "Leave": "退出",
   "Linear issue": "Linear 工单",
   "Link a chat app": "关联聊天应用",
+  "Manage MCP servers": "管理 MCP 服务器",
   "Manage messaging settings": "管理消息设置",
   "Mentions": "提及",
   "Message composer": "消息输入框",

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -1825,8 +1825,11 @@ msgstr "Als ungelesen markieren"
 msgid "Max"
 msgstr "Max."
 
+#: src/pages/PluginsOverlay.tsx:987
+msgid "Manage MCP servers"
+msgstr "MCP-Server verwalten"
+
 #: src/pages/McpServersOverlay.tsx:255
-#: src/pages/PluginsOverlay.tsx:759
 msgid "MCP servers"
 msgstr "MCP-Server"
 

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1825,8 +1825,11 @@ msgstr "Mark as Unread"
 msgid "Max"
 msgstr "Max"
 
+#: src/pages/PluginsOverlay.tsx:987
+msgid "Manage MCP servers"
+msgstr "Manage MCP servers"
+
 #: src/pages/McpServersOverlay.tsx:255
-#: src/pages/PluginsOverlay.tsx:759
 msgid "MCP servers"
 msgstr "MCP servers"
 

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1795,8 +1795,11 @@ msgstr "Marcar como no leído"
 msgid "Max"
 msgstr "Máx."
 
+#: src/pages/PluginsOverlay.tsx:987
+msgid "Manage MCP servers"
+msgstr "Gestionar servidores MCP"
+
 #: src/pages/McpServersOverlay.tsx:255
-#: src/pages/PluginsOverlay.tsx:456
 msgid "MCP servers"
 msgstr "Servidores MCP"
 

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -1825,8 +1825,11 @@ msgstr "अपठित चिह्नित करें"
 msgid "Max"
 msgstr "अधिकतम"
 
+#: src/pages/PluginsOverlay.tsx:987
+msgid "Manage MCP servers"
+msgstr "MCP सर्वर प्रबंधित करें"
+
 #: src/pages/McpServersOverlay.tsx:255
-#: src/pages/PluginsOverlay.tsx:759
 msgid "MCP servers"
 msgstr "MCP सर्वर"
 

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -1825,8 +1825,11 @@ msgstr "읽지 않음으로 표시"
 msgid "Max"
 msgstr "최대"
 
+#: src/pages/PluginsOverlay.tsx:987
+msgid "Manage MCP servers"
+msgstr "MCP 서버 관리"
+
 #: src/pages/McpServersOverlay.tsx:255
-#: src/pages/PluginsOverlay.tsx:759
 msgid "MCP servers"
 msgstr "MCP 서버"
 

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -1825,8 +1825,11 @@ msgstr "Marcar como Não Lida"
 msgid "Max"
 msgstr "Máximo"
 
+#: src/pages/PluginsOverlay.tsx:987
+msgid "Manage MCP servers"
+msgstr "Gerenciar servidores MCP"
+
 #: src/pages/McpServersOverlay.tsx:255
-#: src/pages/PluginsOverlay.tsx:759
 msgid "MCP servers"
 msgstr "Servidores MCP"
 

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -1825,8 +1825,11 @@ msgstr "Okunmadı olarak işaretle"
 msgid "Max"
 msgstr "Maksimum"
 
+#: src/pages/PluginsOverlay.tsx:987
+msgid "Manage MCP servers"
+msgstr "MCP sunucularını yönet"
+
 #: src/pages/McpServersOverlay.tsx:255
-#: src/pages/PluginsOverlay.tsx:759
 msgid "MCP servers"
 msgstr "MCP sunucuları"
 

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -1825,8 +1825,11 @@ msgstr "标为未读"
 msgid "Max"
 msgstr "最大"
 
+#: src/pages/PluginsOverlay.tsx:987
+msgid "Manage MCP servers"
+msgstr "管理 MCP 服务器"
+
 #: src/pages/McpServersOverlay.tsx:255
-#: src/pages/PluginsOverlay.tsx:759
 msgid "MCP servers"
 msgstr "MCP 服务器"
 

--- a/apps/web/src/pages/PluginsOverlay.tsx
+++ b/apps/web/src/pages/PluginsOverlay.tsx
@@ -768,19 +768,7 @@ export function PluginsOverlay({
                 </summary>
 
                 <div className="mt-4 space-y-4">
-                  {onOpenMcp ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="rounded-full"
-                      size="sm"
-                      onClick={onOpenMcp}
-                    >
-                      <Trans>MCP servers</Trans>
-                    </Button>
-                  ) : null}
-
-                  <div className="flex flex-wrap gap-2">
+                  <div className="flex flex-wrap gap-2" data-testid="integrations-advanced-add">
                     <Button
                       type="button"
                       variant="secondary"
@@ -988,6 +976,17 @@ export function PluginsOverlay({
                         </Button>
                       </div>
                     ))}
+                    {onOpenMcp ? (
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="xs"
+                        className="mt-2 px-0 text-muted-foreground"
+                        onClick={onOpenMcp}
+                      >
+                        <Trans>Manage MCP servers</Trans>
+                      </Button>
+                    ) : null}
                   </div>
                 </div>
               </details>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Integrations → Advanced showed a lone outline **MCP servers** chip above the Add row. It looked like a category, not an action, and sat next to **Add MCP server**, so the two controls competed for the same idea.

## What changed

- Removed the outline **MCP servers** chip from Advanced.
- Left the Add row as: Add MCP server → Add OpenAPI → Add GraphQL → Add Executor → Add Treg.
- Kept `McpServersOverlay` (stdio local servers, OAuth, bot assignment) reachable via a text link under Tool sources: **Manage MCP servers**.
- Updated Advanced-order and MCP OAuth e2e coverage; refreshed Lingui catalogs and translation seeds for the new string.

New copy: `Manage MCP servers`. Needed because the manage overlay is still the only place for stdio/local MCP and OAuth reconnect, and a text link under Tool sources is clearer than a fake category chip. Hiding it entirely would strand that flow; putting it in the Add row would recreate the same confusion.

## How to test

- Open Integrations → Advanced: only the five Add chips appear in order; no outline MCP servers chip.
- Under Tool sources, use Manage MCP servers and confirm the MCP overlay opens (stdio tabs, existing servers, OAuth actions).
- CI e2e: `graphql-integrations` Advanced-order frame, plus golden Advanced smoke and mcp-oauth entry via the new link.

## Screenshots

Advanced order after the fix (CI E2E):

<img alt="Advanced Add row order without MCP servers chip" src="https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34043224999-1/screenshots/images/002-01-graphql-advanced-order.png" />

[Screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/729/index.html)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e507c4d-cc2c-47a9-90fe-2b54376d36db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e507c4d-cc2c-47a9-90fe-2b54376d36db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated “Manage MCP servers” link below installed tool sources.
  - Added support for multiple integration accounts, including renaming and removal.
  - Added integration detail views and connector tool visibility for connected integrations.
  - Added translations for the new management label across supported languages.

- **Bug Fixes**
  - Updated integration and OAuth flows to use the revised MCP server management control.
  - Improved integration action ordering and MCP management visibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->