### PR TITLE
fix(settings): surface per-bot model choice

### DIFF
--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -140,6 +140,8 @@ tags:
 - extendedWaitUntil:
     visible: "Researcher"
     timeout: 10000
+- assertVisible: "Model"
+- assertVisible: "Space default"
 - takeScreenshot: "17-bot-settings"
 
 - openLink: "rakazo:///computer?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"

--- a/apps/mobile/app/bot-settings.tsx
+++ b/apps/mobile/app/bot-settings.tsx
@@ -6,12 +6,24 @@ import {
   type ComputerMode,
   normalizeCreateBotProfile,
 } from "@rakazo/contracts";
+import {
+  connectedModelOptions,
+  modelCatalogLabel,
+  modelOptionKey,
+  parseModelOptionKey,
+} from "@rakazo/core";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { BotAvatar } from "../components/bot-avatar";
 import { ComputerModePicker } from "../components/computer-mode-picker";
-import { type MobileBot, rpc } from "../lib/api";
+import {
+  type MobileBot,
+  type MobileMe,
+  type MobileModel,
+  type MobileModelCredential,
+  rpc,
+} from "../lib/api";
 import { useI18n } from "../lib/i18n";
 import { useMobileTokens } from "../lib/native";
 
@@ -30,6 +42,12 @@ export default function BotSettingsScreen() {
   const [description, setDescription] = useState("");
   const [color, setColor] = useState<string>(BOT_COLORS[0]);
   const [computerMode, setComputerMode] = useState<ComputerMode>("team");
+  const [modelKey, setModelKey] = useState("");
+  const [models, setModels] = useState<MobileModel[]>([]);
+  const [credentials, setCredentials] = useState<MobileModelCredential[]>([]);
+  const [me, setMe] = useState<MobileMe | null>(null);
+  const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const [modelError, setModelError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
@@ -43,9 +61,44 @@ export default function BotSettingsScreen() {
         setDescription(next.description ?? "");
         setColor(next.color);
         setComputerMode(next.computerMode);
+        setModelKey(
+          next.modelProvider && next.modelId
+            ? modelOptionKey(next.modelProvider, next.modelId)
+            : "",
+        );
       })
       .catch((err) => setError(err instanceof Error ? err.message : t("Could not load bot")));
   }, [botId]);
+
+  useEffect(() => {
+    void Promise.all([
+      rpc<MobileMe>("me"),
+      rpc<MobileModel[]>("models/list"),
+      rpc<MobileModelCredential[]>("models/credentials"),
+    ])
+      .then(([nextMe, nextModels, nextCredentials]) => {
+        setMe(nextMe);
+        setModels(nextModels);
+        setCredentials(nextCredentials);
+      })
+      .catch(() => setModelError(t("Could not load model choices")));
+  }, []);
+
+  const connectedOptions = connectedModelOptions(credentials, models);
+  const defaultModelLabel = me?.defaultModel
+    ? `${t("Space default")} (${modelCatalogLabel(models, me.defaultProvider, me.defaultModel) ?? me.defaultModel})`
+    : t("Space default");
+  const storedOption =
+    modelKey && !connectedOptions.some((option) => option.key === modelKey)
+      ? { key: modelKey, label: parseModelOptionKey(modelKey)?.modelId ?? modelKey }
+      : null;
+  const modelOptions = [
+    { key: "", label: defaultModelLabel },
+    ...(storedOption ? [storedOption] : []),
+    ...connectedOptions.map((option) => ({ key: option.key, label: option.label })),
+  ];
+  const selectedModelLabel =
+    modelOptions.find((option) => option.key === modelKey)?.label ?? defaultModelLabel;
 
   async function save() {
     if (!botId || !bot || pending) return;
@@ -60,6 +113,8 @@ export default function BotSettingsScreen() {
         description?: string;
         instructions?: string;
         color?: string;
+        modelProvider?: string | null;
+        modelId?: string | null;
       } = { botId };
       if (profile.name !== bot.name) input.name = profile.name;
       if (profile.title !== bot.title) input.title = profile.title;
@@ -69,6 +124,13 @@ export default function BotSettingsScreen() {
         input.instructions = profile.instructions;
       }
       if (color !== bot.color) input.color = color;
+      const selectedModel = modelKey ? parseModelOptionKey(modelKey) : null;
+      const nextModelProvider = selectedModel?.provider ?? null;
+      const nextModelId = selectedModel?.modelId ?? null;
+      if (nextModelProvider !== bot.modelProvider || nextModelId !== bot.modelId) {
+        input.modelProvider = nextModelProvider;
+        input.modelId = nextModelId;
+      }
       if (computerMode !== bot.computerMode) {
         await rpc("bots/setComputer", { botId, mode: computerMode });
       }
@@ -150,6 +212,96 @@ export default function BotSettingsScreen() {
             textAlignVertical: "top",
           }}
         />
+        <Text style={{ color: tokens.mutedForeground, marginTop: 16, fontSize: 14 }}>
+          {t("Model")}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={t("Model")}
+          accessibilityState={{ expanded: modelPickerOpen }}
+          onPress={() => setModelPickerOpen((open) => !open)}
+          style={{
+            marginTop: 8,
+            minHeight: 52,
+            backgroundColor: tokens.muted,
+            borderRadius: 11,
+            paddingHorizontal: 16,
+            paddingVertical: 12,
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <Text style={{ color: tokens.foreground, fontSize: 15, flex: 1 }}>
+            {selectedModelLabel}
+          </Text>
+          <Text style={{ color: tokens.mutedForeground, fontSize: 18 }}>
+            {modelPickerOpen ? "⌃" : "⌄"}
+          </Text>
+        </Pressable>
+        {modelPickerOpen ? (
+          <View
+            accessibilityRole="radiogroup"
+            style={{
+              marginTop: 8,
+              borderRadius: 11,
+              overflow: "hidden",
+              backgroundColor: tokens.muted,
+            }}
+          >
+            {modelOptions.map((option, index) => (
+              <Pressable
+                key={option.key || "space-default"}
+                accessibilityRole="radio"
+                accessibilityLabel={option.label}
+                accessibilityState={{ checked: option.key === modelKey }}
+                onPress={() => {
+                  setModelKey(option.key);
+                  setModelPickerOpen(false);
+                }}
+                style={{
+                  minHeight: 52,
+                  paddingHorizontal: 16,
+                  paddingVertical: 12,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: 12,
+                  borderBottomWidth: index === modelOptions.length - 1 ? 0 : 1,
+                  borderBottomColor: tokens.background,
+                }}
+              >
+                <View
+                  style={{
+                    width: 20,
+                    height: 20,
+                    borderRadius: 10,
+                    borderWidth: 1,
+                    borderColor: tokens.mutedForeground,
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  {option.key === modelKey ? (
+                    <View
+                      style={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: 5,
+                        backgroundColor: tokens.foreground,
+                      }}
+                    />
+                  ) : null}
+                </View>
+                <Text style={{ color: tokens.foreground, fontSize: 15, flex: 1 }}>
+                  {option.label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+        {modelError ? (
+          <Text style={{ color: tokens.destructive, marginTop: 8 }}>{modelError}</Text>
+        ) : null}
         <Text style={{ color: tokens.mutedForeground, marginTop: 16, fontSize: 14 }}>
           {t("Color")}
         </Text>

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -528,6 +528,8 @@ export type MobileBot = Pick<
   | "unread"
   | "updatedAt"
   | "computerMode"
+  | "modelProvider"
+  | "modelId"
 > &
   Partial<Pick<Bot, "parentBotId" | "spaceId">>;
 

--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -84,7 +84,8 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   const teamComputer = settings.getByRole("button", { name: "Team" });
   const openWork = settings.getByTestId("bot-scratchpad");
   await expect(teamComputer).toBeHidden();
-  await expect(modelSelect).toBeHidden();
+  await expect(modelSelect).toBeVisible();
+  await expect(modelSelect).toContainText("Space default");
   await expect(openWork).toBeHidden();
   await expect(settings.getByRole("button", { name: "Save", exact: true })).toBeVisible();
   await expect(settings.getByRole("button", { name: "Recover computer" })).toHaveCount(0);
@@ -95,7 +96,6 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
   await expect(teamComputer).toBeVisible();
   await expect(openWork).toBeVisible();
   await expect(modelSelect).toBeVisible();
-  await expect(modelSelect).toContainText("Space default");
   await captureScreenshot(page, testInfo, "27a-bot-settings-model");
   await page.getByRole("button", { name: "Show computer" }).click();
   const sidePanel = page.getByTestId("side-panel");

--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -41,9 +41,7 @@ test("custom connections persist reasoning support and bot thinking", async ({
   const settings = page.getByTestId("bot-settings");
   await expect(settings).toBeVisible();
   const advanced = settings.getByTestId("bot-settings-advanced");
-  await advanced.evaluate((element) => {
-    (element as HTMLDetailsElement).open = true;
-  });
+  await expect(advanced).not.toHaveAttribute("open", "");
   // NativeSelect sits inside a wrapping <label>, so label text includes option
   // copy and getByLabel(..., { exact: true }) misses the control. Use the
   // combobox accessible name, matching other model E2E tests.
@@ -65,9 +63,7 @@ test("custom connections persist reasoning support and bot thinking", async ({
   await page.reload();
   await page.locator("main").getByRole("button", { name: "Chief", exact: true }).click();
   await expect(settings).toBeVisible();
-  await advanced.evaluate((element) => {
-    (element as HTMLDetailsElement).open = true;
-  });
+  await expect(advanced).not.toHaveAttribute("open", "");
   await expect(thinking).toHaveValue("low");
 });
 

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -17,6 +17,12 @@ import {
   BOT_TITLE_MAX_LENGTH,
 } from "@rakazo/contracts";
 import {
+  connectedModelOptions,
+  modelCatalogLabel,
+  modelOptionKey,
+  parseModelOptionKey,
+} from "@rakazo/core";
+import {
   BotAvatar,
   Button,
   Input,
@@ -242,44 +248,7 @@ export function BotSettings({
       .catch(() => undefined);
   }, []);
 
-  const connectedOptions: Array<{
-    key: string;
-    provider: string;
-    modelId: string;
-    label: string;
-  }> = [];
-  const seenOptions = new Set<string>();
-  for (const credential of credentials) {
-    const providerModels = catalog.filter(
-      (entry) => entry.provider === credential.provider && !entry.placeholder,
-    );
-    const credentialInCatalog = Boolean(
-      credential.modelId && providerModels.some((entry) => entry.id === credential.modelId),
-    );
-    // Catalog providers expand to every model for that connection. Free-form
-    // credentials (model id not in the catalog) stay a single connected pair.
-    const options =
-      credential.modelId && !credentialInCatalog
-        ? [
-            {
-              key: modelOptionKey(credential.provider, credential.modelId),
-              provider: credential.provider,
-              modelId: credential.modelId,
-              label: `${credential.label} · ${credential.modelId}`,
-            },
-          ]
-        : providerModels.map((entry) => ({
-            key: modelOptionKey(entry.provider, entry.id),
-            provider: entry.provider,
-            modelId: entry.id,
-            label: `${entry.providerName ?? entry.provider} · ${entry.label}`,
-          }));
-    for (const option of options) {
-      if (seenOptions.has(option.key)) continue;
-      seenOptions.add(option.key);
-      connectedOptions.push(option);
-    }
-  }
+  const connectedOptions = connectedModelOptions(credentials, catalog);
 
   const effectiveProvider = modelKey
     ? parseModelOptionKey(modelKey)?.provider
@@ -338,6 +307,53 @@ export function BotSettings({
           className="mt-2"
         />
       </label>
+      <label htmlFor={`${ids}-model`} className={fieldLabelClass}>
+        <Trans>Model</Trans>
+        <NativeSelect
+          id={`${ids}-model`}
+          className="mt-2 w-full"
+          value={modelKey}
+          onChange={(event) => {
+            setModelKey(event.target.value);
+            setThinkingLevel("");
+          }}
+        >
+          <NativeSelectOption value="">
+            {t`Space default`}
+            {me?.defaultModel
+              ? ` (${modelCatalogLabel(catalog, me.defaultProvider, me.defaultModel) ?? me.defaultModel})`
+              : ""}
+          </NativeSelectOption>
+          {modelKey && !connectedOptions.some((option) => option.key === modelKey) ? (
+            <NativeSelectOption value={modelKey}>
+              {parseModelOptionKey(modelKey)?.modelId ?? modelKey}
+            </NativeSelectOption>
+          ) : null}
+          {connectedOptions.map((option) => (
+            <NativeSelectOption key={option.key} value={option.key}>
+              {option.label}
+            </NativeSelectOption>
+          ))}
+        </NativeSelect>
+      </label>
+      {thinkingOptions.length ? (
+        <label htmlFor={`${ids}-thinking`} className={fieldLabelClass}>
+          <Trans>Thinking</Trans>
+          <NativeSelect
+            id={`${ids}-thinking`}
+            className="mt-2 w-full"
+            value={thinkingLevel}
+            onChange={(event) => setThinkingLevel(event.target.value)}
+          >
+            <NativeSelectOption value="">{t`Default (medium)`}</NativeSelectOption>
+            {thinkingOptions.map((level) => (
+              <NativeSelectOption key={level} value={level}>
+                {thinkingLevelLabel(level)}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </label>
+      ) : null}
       <div className={fieldLabelClass}>
         <Trans>Color</Trans>
         <div className="mt-2 flex flex-wrap gap-2" role="radiogroup" aria-label={t`Color`}>
@@ -380,53 +396,6 @@ export function BotSettings({
             <KnowledgeSection botId={bot.id} onSkillsChange={onSkillsChange} />
           ) : null}
         </Suspense>
-        <label htmlFor={`${ids}-model`} className={fieldLabelClass}>
-          <Trans>Model</Trans>
-          <NativeSelect
-            id={`${ids}-model`}
-            className="mt-2 w-full"
-            value={modelKey}
-            onChange={(event) => {
-              setModelKey(event.target.value);
-              setThinkingLevel("");
-            }}
-          >
-            <NativeSelectOption value="">
-              {t`Space default`}
-              {me?.defaultModel
-                ? ` (${catalogLabel(catalog, me.defaultProvider, me.defaultModel) ?? me.defaultModel})`
-                : ""}
-            </NativeSelectOption>
-            {modelKey && !connectedOptions.some((option) => option.key === modelKey) ? (
-              <NativeSelectOption value={modelKey}>
-                {parseModelOptionKey(modelKey)?.modelId ?? modelKey}
-              </NativeSelectOption>
-            ) : null}
-            {connectedOptions.map((option) => (
-              <NativeSelectOption key={option.key} value={option.key}>
-                {option.label}
-              </NativeSelectOption>
-            ))}
-          </NativeSelect>
-        </label>
-        {thinkingOptions.length ? (
-          <label htmlFor={`${ids}-thinking`} className={fieldLabelClass}>
-            <Trans>Thinking</Trans>
-            <NativeSelect
-              id={`${ids}-thinking`}
-              className="mt-2 w-full"
-              value={thinkingLevel}
-              onChange={(event) => setThinkingLevel(event.target.value)}
-            >
-              <NativeSelectOption value="">{t`Default (medium)`}</NativeSelectOption>
-              {thinkingOptions.map((level) => (
-                <NativeSelectOption key={level} value={level}>
-                  {thinkingLevelLabel(level)}
-                </NativeSelectOption>
-              ))}
-            </NativeSelect>
-          </label>
-        ) : null}
         {memoryProviderConfigured ? (
           <div className="mt-4 text-[14px] text-muted-foreground">
             <Trans>Memory scope</Trans>
@@ -542,10 +511,6 @@ export function BotSettings({
   );
 }
 
-function modelOptionKey(provider: string, modelId: string) {
-  return `${provider}::${modelId}`;
-}
-
 function thinkingLevelLabel(level: ThinkingLevel) {
   if (level === "xhigh") return t`Extra high`;
   if (level === "low") return t`Low`;
@@ -554,19 +519,4 @@ function thinkingLevelLabel(level: ThinkingLevel) {
   if (level === "minimal") return t`Minimal`;
   if (level === "max") return t`Max`;
   return `${level.slice(0, 1).toUpperCase()}${level.slice(1)}`;
-}
-
-function parseModelOptionKey(key: string) {
-  const separator = key.indexOf("::");
-  if (separator <= 0) return null;
-  return { provider: key.slice(0, separator), modelId: key.slice(separator + 2) };
-}
-
-function catalogLabel(
-  catalog: ModelCatalogEntry[],
-  provider: string | null | undefined,
-  modelId: string,
-) {
-  if (!provider) return undefined;
-  return catalog.find((entry) => entry.provider === provider && entry.id === modelId)?.label;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from "./message-visibility.js";
 export * from "./messaging-commands.js";
 export * from "./messaging-prompts.js";
 export * from "./model-oauth.js";
+export * from "./model-options.js";
 export * from "./model-probe.js";
 export * from "./model-providers.js";
 export * from "./response-bytes.js";

--- a/packages/core/src/model-options.test.ts
+++ b/packages/core/src/model-options.test.ts
@@ -1,0 +1,109 @@
+import type { ModelCatalogEntry, ModelCredential } from "@rakazo/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  connectedModelOptions,
+  modelCatalogLabel,
+  modelOptionKey,
+  parseModelOptionKey,
+} from "./model-options.js";
+
+const catalog = [
+  {
+    provider: "openai",
+    providerName: "OpenAI",
+    id: "gpt-5",
+    label: "GPT-5",
+    billing: "metered",
+    auth: "api-key",
+  },
+  {
+    provider: "openai",
+    providerName: "OpenAI",
+    id: "coming-soon",
+    label: "Coming soon",
+    billing: "metered",
+    auth: "api-key",
+    placeholder: true,
+  },
+] satisfies ModelCatalogEntry[];
+
+it("round-trips model option keys", () => {
+  const key = modelOptionKey("openai-compatible", "org/model::preview");
+  expect(parseModelOptionKey(key)).toEqual({
+    provider: "openai-compatible",
+    modelId: "org/model::preview",
+  });
+  expect(parseModelOptionKey("missing-separator")).toBeNull();
+  expect(parseModelOptionKey("provider::")).toBeNull();
+});
+
+describe("connectedModelOptions", () => {
+  it("expands catalog credentials and excludes placeholders", () => {
+    const credentials = [
+      {
+        id: "credential-1",
+        provider: "openai",
+        label: "OpenAI",
+        hasKey: true,
+        isDefault: true,
+      },
+    ] satisfies ModelCredential[];
+
+    expect(connectedModelOptions(credentials, catalog)).toEqual([
+      {
+        key: "openai::gpt-5",
+        provider: "openai",
+        modelId: "gpt-5",
+        label: "OpenAI · GPT-5",
+      },
+    ]);
+  });
+
+  it("keeps free-form credentials as their connected provider/model pair", () => {
+    const credentials = [
+      {
+        provider: "openai-compatible",
+        label: "Local server",
+        hasKey: true,
+        isDefault: false,
+        id: "credential-2",
+        modelId: "qwen3",
+      },
+    ] satisfies ModelCredential[];
+
+    expect(connectedModelOptions(credentials, catalog)).toEqual([
+      {
+        key: "openai-compatible::qwen3",
+        provider: "openai-compatible",
+        modelId: "qwen3",
+        label: "Local server · qwen3",
+      },
+    ]);
+  });
+
+  it("deduplicates credentials for the same provider", () => {
+    const credentials = [
+      {
+        id: "credential-1",
+        provider: "openai",
+        label: "OpenAI",
+        hasKey: true,
+        isDefault: true,
+      },
+      {
+        id: "credential-2",
+        provider: "openai",
+        label: "OpenAI again",
+        hasKey: true,
+        isDefault: false,
+      },
+    ] satisfies ModelCredential[];
+
+    expect(connectedModelOptions(credentials, catalog)).toHaveLength(1);
+  });
+});
+
+it("finds the catalog label for a provider/model pair", () => {
+  expect(modelCatalogLabel(catalog, "openai", "gpt-5")).toBe("GPT-5");
+  expect(modelCatalogLabel(catalog, "other", "gpt-5")).toBeUndefined();
+});

--- a/packages/core/src/model-options.ts
+++ b/packages/core/src/model-options.ts
@@ -1,0 +1,72 @@
+import type { ModelCatalogEntry, ModelCredential } from "@rakazo/contracts";
+
+export type ConnectedModelOption = {
+  key: string;
+  provider: string;
+  modelId: string;
+  label: string;
+};
+
+export function modelOptionKey(provider: string, modelId: string) {
+  return `${provider}::${modelId}`;
+}
+
+export function parseModelOptionKey(key: string) {
+  const separator = key.indexOf("::");
+  if (separator <= 0) return null;
+  const provider = key.slice(0, separator);
+  const modelId = key.slice(separator + 2);
+  if (!modelId) return null;
+  return { provider, modelId };
+}
+
+export function modelCatalogLabel(
+  catalog: readonly ModelCatalogEntry[],
+  provider: string | null | undefined,
+  modelId: string | null | undefined,
+) {
+  if (!provider || !modelId) return undefined;
+  return catalog.find((entry) => entry.provider === provider && entry.id === modelId)?.label;
+}
+
+/** Models that can be selected without asking the user to connect another provider. */
+export function connectedModelOptions(
+  credentials: readonly ModelCredential[],
+  catalog: readonly ModelCatalogEntry[],
+): ConnectedModelOption[] {
+  const result: ConnectedModelOption[] = [];
+  const seen = new Set<string>();
+
+  for (const credential of credentials) {
+    const providerModels = catalog.filter(
+      (entry) => entry.provider === credential.provider && !entry.placeholder,
+    );
+    const credentialInCatalog = Boolean(
+      credential.modelId && providerModels.some((entry) => entry.id === credential.modelId),
+    );
+    const options =
+      credential.modelId && !credentialInCatalog
+        ? [
+            {
+              key: modelOptionKey(credential.provider, credential.modelId),
+              provider: credential.provider,
+              modelId: credential.modelId,
+              label: `${credential.label} · ${credential.modelId}`,
+            },
+          ]
+        : providerModels.map((entry) => ({
+            key: modelOptionKey(entry.provider, entry.id),
+            provider: entry.provider,
+            modelId: entry.id,
+            label: `${entry.providerName ?? entry.provider} · ${entry.label}`,
+          }));
+
+    for (const option of options) {
+      if (seen.has(option.key)) continue;
+      seen.add(option.key);
+      result.push(option);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Why

#719 reports that the existing per-bot model override is effectively undiscoverable: web hides it in a collapsed Advanced section, while mobile does not expose it at all.

## What

- show Model and conditional Thinking controls at the top level of web bot settings
- add an accessible mobile model picker with Space default and connected-model choices
- save and clear mobile bot overrides through the existing paired modelProvider/modelId contract
- share the connected-model option rules across web and mobile, including free-form endpoints, placeholders, and deduplication
- update web E2E and mobile screenshot coverage for the visible top-level control

## Test

- pnpm check (22/22 tasks)
- pnpm --filter @rakazo/core test (41 files, 434 tests)
- pnpm lint (passes; 25 existing warnings)

Closes #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model selection to mobile bot settings, including the space default and connected models.
  * Saved model choices now persist when bot settings are updated.
  * Model and thinking controls are now available directly in the main bot settings area instead of Advanced settings.
  * Connected models display catalog names when available, with suitable labels for custom connections.

* **Bug Fixes**
  * Preserved saved model selections even when their connection is no longer active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->