### PR TITLE
test(compose): run installer smokes in CI

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -33,6 +33,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  installer-smoke:
+    name: Compose installer smokes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - run: bash infra/compose/run-smokes.sh
+
   validate:
     name: Validate ${{ matrix.name }} image
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Why

Compose installer smoke scripts cover offline startup, proxy precedence, and mirrored-image startup documentation, but they currently run only when invoked locally. Regressions in these shell-only paths can therefore pass pull-request CI.

## What changed

- add a lightweight `Compose installer smokes` job to the compose/image workflow
- run the existing aggregate smoke runner on relevant pull requests
- keep the job independent of Node and Docker setup, with read-only permissions and a five-minute timeout

Follow-up to #534.

## Tests

- `pnpm test:compose-smoke` (all four smoke scripts passed)
- workflow YAML parsed successfully
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated smoke testing for the Compose installer on pull requests.
  * Installer checks now run with a five-minute timeout and read-only repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->