### PR TITLE
fix(api): map ComputerBusyError on direct boot callers

### DIFF
--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1437,6 +1437,11 @@ export function createRouter(deps: RouterDeps) {
             screenLeaseId: screenLeaseIdForRun(lease, manualRunId),
           });
           scheduleComputerSleep(deps.jobs, bot.computer.id);
+        } catch (error) {
+          if (error instanceof ComputerBusyError) {
+            throw new ORPCError("CONFLICT", { message: "Computer is busy" });
+          }
+          throw error;
         } finally {
           await releaseComputerExecutionLease(deps.prisma, lease);
         }

--- a/apps/api/src/taught-skills.ts
+++ b/apps/api/src/taught-skills.ts
@@ -10,6 +10,8 @@ import {
 import {
   acquireComputerExecutionLease,
   appendRecordingEvent,
+  ComputerBusyError,
+  type ComputerExecutionLease,
   captureTeachingSnapshot,
   completeTeachingSession,
   emptyRecording,
@@ -144,16 +146,29 @@ async function ensureGraphicalComputer(
   if (bot.computer.state !== "running" || !bot.computer.providerRef) {
     const ctx = computerContext(actor, bot.id, "skills.start");
     const manualRunId = `teach:${randomUUID()}`;
-    const lease = await acquireComputerExecutionLease(deps.prisma, {
-      computerId: bot.computer.id,
-      runId: manualRunId,
-      botId: bot.id,
-    });
+    let lease: ComputerExecutionLease | null;
+    try {
+      lease = await acquireComputerExecutionLease(deps.prisma, {
+        computerId: bot.computer.id,
+        runId: manualRunId,
+        botId: bot.id,
+      });
+    } catch (error) {
+      if (error instanceof ComputerBusyError) {
+        throw new ORPCError("CONFLICT", { message: "Computer is busy" });
+      }
+      throw error;
+    }
     try {
       await provisionComputer(deps, bot.computer.id, {
         ...ctx,
         screenLeaseId: screenLeaseIdForRun(lease, manualRunId),
       });
+    } catch (error) {
+      if (error instanceof ComputerBusyError) {
+        throw new ORPCError("CONFLICT", { message: "Computer is busy" });
+      }
+      throw error;
     } finally {
       await releaseComputerExecutionLease(deps.prisma, lease);
     }

--- a/packages/testkit/src/executor-lifecycle.test.ts
+++ b/packages/testkit/src/executor-lifecycle.test.ts
@@ -776,9 +776,15 @@ describeIntegration("run executor lifecycle", () => {
         expiresAt: new Date(Date.now() + 5 * 60_000),
       },
     });
+    // Age past BOOT_CLAIM_STALE_MS so reclaim reaches the live foreign-lease check
+    // instead of refusing on a fresh mid-provision stamp.
     await handles.prisma.computer.update({
       where: { id: computerId },
-      data: { state: "booting", providerRef: "" },
+      data: {
+        state: "booting",
+        providerRef: "",
+        updatedAt: new Date(Date.now() - (5 * 60_000 + 1_000)),
+      },
     });
 
     try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After #727, `provisionComputer` can raise `ComputerBusyError` when a computer is mid-boot (including a fresh `booting` row). The executor path already requeues on that. Manual boot and teaching provision did not: they only mapped busy from lease acquire, so a concurrent provision could surface as an uncaught API failure instead of the established retryable conflict.

The live-boot journey also set `booting` without aging `updatedAt`, so Prisma `@updatedAt` kept the stamp fresh and the test never reached the live foreign-lease guard it was meant to cover.

## What changed

- `computer.boot` maps `ComputerBusyError` from `provisionComputer` to `CONFLICT` / `"Computer is busy"`, matching recover/reset/update.
- `ensureGraphicalComputer` does the same for lease acquire and provision.
- Ages the live-boot journey stamp past `BOOT_CLAIM_STALE_MS` so reclaim hits the foreign-lease path.

## How tested

- `pnpm exec biome check` on the three touched files
- `pnpm --filter @rakazo/adapters test -- computer-lifecycle.test.ts computer-recovery.test.ts` (passed)

Aikido SAST was not run: the Aikido MCP requires interactive sign-in in this environment.

Follow-up to CodeRabbit review on #727 (merged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-835e14bc-46b4-41f6-a638-81bc1c3bb60a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-835e14bc-46b4-41f6-a638-81bc1c3bb60a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when a computer is already busy during boot or setup. Users now receive a clear conflict error instead of an unhandled failure.
  - Prevented active computers from being incorrectly reclaimed while still managed by another worker.

- **Tests**
  - Updated lifecycle coverage for stale boot recovery and active lease protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->