### PR TITLE
fix(web): recover stalled peer history

### DIFF
--- a/apps/web/src/lib/peer-history.test.ts
+++ b/apps/web/src/lib/peer-history.test.ts
@@ -1,0 +1,84 @@
+import type { ThreadMessage } from "@rakazo/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadPeerHistory } from "./peer-history";
+
+function message(id: string, seq: number): ThreadMessage {
+  return { id, seq } as ThreadMessage;
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("peer history loading", () => {
+  it("collects paginated messages in chronological page order", async () => {
+    const loadPage = vi
+      .fn()
+      .mockResolvedValueOnce({ messages: [message("new", 2)], olderCursor: 2 })
+      .mockResolvedValueOnce({ messages: [message("old", 1)], olderCursor: null });
+
+    const messages = await loadPeerHistory({
+      signal: new AbortController().signal,
+      loadPage,
+    });
+
+    expect(messages.map(({ id }) => id)).toEqual(["old", "new"]);
+    expect(loadPage.mock.calls.map(([before]) => before)).toEqual([undefined, 2]);
+  });
+
+  it("aborts a page that never settles before the full-history deadline", async () => {
+    vi.useFakeTimers();
+    const loadPage = vi.fn(
+      (_before: number | undefined, signal: AbortSignal) =>
+        new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    );
+
+    const loading = loadPeerHistory({
+      signal: new AbortController().signal,
+      loadPage,
+      pageTimeoutMs: 100,
+      totalTimeoutMs: 1_000,
+    });
+    const rejected = expect(loading).rejects.toMatchObject({ name: "TimeoutError" });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejected;
+  });
+
+  it("bounds the full-history scan independently of the per-page timeout", async () => {
+    vi.useFakeTimers();
+    const loadPage = vi.fn(
+      (_before: number | undefined, signal: AbortSignal) =>
+        new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    );
+
+    const loading = loadPeerHistory({
+      signal: new AbortController().signal,
+      loadPage,
+      pageTimeoutMs: 1_000,
+      totalTimeoutMs: 100,
+    });
+    const rejected = expect(loading).rejects.toMatchObject({ name: "TimeoutError" });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejected;
+  });
+
+  it("aborts an in-flight page when the viewer closes", async () => {
+    const lifecycle = new AbortController();
+    const loadPage = vi.fn(
+      (_before: number | undefined, signal: AbortSignal) =>
+        new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    );
+
+    const loading = loadPeerHistory({ signal: lifecycle.signal, loadPage });
+    const rejected = expect(loading).rejects.toMatchObject({ name: "AbortError" });
+    lifecycle.abort();
+
+    await rejected;
+  });
+});

--- a/apps/web/src/lib/peer-history.ts
+++ b/apps/web/src/lib/peer-history.ts
@@ -1,0 +1,35 @@
+import type { ThreadMessage } from "@rakazo/contracts";
+
+const PEER_HISTORY_PAGE_TIMEOUT_MS = 15_000;
+const PEER_HISTORY_TOTAL_TIMEOUT_MS = 60_000;
+
+type PeerHistoryPage = {
+  messages: ThreadMessage[];
+  olderCursor: number | null;
+};
+
+/** Load every peer-history page without allowing one request or the full scan to hang forever. */
+export async function loadPeerHistory({
+  signal,
+  loadPage,
+  pageTimeoutMs = PEER_HISTORY_PAGE_TIMEOUT_MS,
+  totalTimeoutMs = PEER_HISTORY_TOTAL_TIMEOUT_MS,
+}: {
+  signal: AbortSignal;
+  loadPage: (before: number | undefined, signal: AbortSignal) => Promise<PeerHistoryPage>;
+  pageTimeoutMs?: number;
+  totalTimeoutMs?: number;
+}): Promise<ThreadMessage[]> {
+  const deadline = AbortSignal.timeout(totalTimeoutMs);
+  let before: number | undefined;
+  let collected: ThreadMessage[] = [];
+  do {
+    const page = await loadPage(
+      before,
+      AbortSignal.any([signal, deadline, AbortSignal.timeout(pageTimeoutMs)]),
+    );
+    collected = [...page.messages, ...collected];
+    before = page.olderCursor ?? undefined;
+  } while (before !== undefined);
+  return collected;
+}

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -2,7 +2,8 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { ChatMarkdown } from "@rakazo/chat-ui/web";
 import type { ThreadMessage } from "@rakazo/contracts";
 import { BotAvatar, Button, Dialog, DialogClose, DialogContent, DialogTitle } from "@rakazo/ui-web";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { loadPeerHistory } from "../lib/peer-history";
 import { peerConversations } from "../lib/peer-messages";
 import { rpc } from "../lib/rpc";
 
@@ -31,39 +32,37 @@ export function PeerMessagesOverlay({
   const [messages, setMessages] = useState<readonly ThreadMessage[]>([]);
   const [historyReady, setHistoryReady] = useState(false);
   const [historyFailed, setHistoryFailed] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
   const conversation = useMemo(() => {
     if (!historyReady) return null;
     return peerConversations(messages).find((entry) => entry.peerBotId === peerBotId) ?? null;
   }, [historyReady, messages, peerBotId]);
   const peerBotName = conversation?.peerBotName ?? initialPeerBotName;
-  const loadRef = useRef({ botId });
 
   useEffect(() => {
-    let cancelled = false;
-    const { botId: id } = loadRef.current;
+    const abort = new AbortController();
     setHistoryReady(false);
     setHistoryFailed(false);
-    void (async () => {
-      let before: number | undefined;
-      let collected: ThreadMessage[] = [];
-      do {
-        const page = await rpc.threads.messages({ botId: id, before, includePeerRuns: true });
-        if (cancelled) return;
-        collected = [...page.messages, ...collected];
-        before = page.olderCursor ?? undefined;
-      } while (before !== undefined);
-      if (cancelled) return;
-      setMessages(collected);
-      setHistoryReady(true);
-    })().catch(() => {
-      if (cancelled) return;
-      setHistoryFailed(true);
-      setHistoryReady(true);
-    });
+    setMessages([]);
+    void loadPeerHistory({
+      signal: abort.signal,
+      loadPage: (before, signal) =>
+        rpc.threads.messages({ botId, before, includePeerRuns: true }, { signal }),
+    })
+      .then((loaded) => {
+        if (abort.signal.aborted) return;
+        setMessages(loaded);
+        setHistoryReady(true);
+      })
+      .catch(() => {
+        if (abort.signal.aborted) return;
+        setHistoryFailed(true);
+        setHistoryReady(true);
+      });
     return () => {
-      cancelled = true;
+      abort.abort();
     };
-  }, []);
+  }, [botId, reloadKey]);
 
   const title = `${botName} · ${peerBotName}`;
 
@@ -100,7 +99,16 @@ export function PeerMessagesOverlay({
           </div>
         ) : historyFailed ? (
           <div className="grid flex-1 place-items-center px-8 text-center text-[13.5px] text-muted-foreground/80">
-            <Trans>Could not load this chat.</Trans>
+            <div className="flex flex-col items-center gap-3">
+              <Trans>Could not load this chat.</Trans>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setReloadKey((value) => value + 1)}
+              >
+                <Trans>Retry now</Trans>
+              </Button>
+            </div>
           </div>
         ) : !conversation || conversation.messages.length === 0 ? (
           <div className="grid flex-1 place-items-center px-8 text-center text-[13.5px] text-muted-foreground/80">


### PR DESCRIPTION
## Why

The view-only peer chat loads every history page before rendering. A stalled local API or Docker-backed request can therefore leave the overlay on `Loading…` forever, with no way to recover short of closing it. This is the remaining focused recovery problem from #643; normal bot and group transcripts already retry through the shared thread subscription.

## What changed

- bound each peer-history page request to 15 seconds and the complete scan to 60 seconds
- abort in-flight history work when the overlay closes or switches bots
- replace a timed-out load with the existing `Could not load this chat.` state and a `Retry now` action
- keep pagination order and peer-message visibility unchanged

`Retry now` is necessary only after a bounded load fails; it is hidden during normal loading and after success. It reuses existing localized copy.

Follow-up to #643.

## Tests

- focused peer-history tests: 4 passed
- web unit suite: 203 passed
- web typecheck
- web production build
- Biome on changed files
- `git diff --check`

The failure-only UI is not reachable in the deterministic browser journey without introducing an artificial transport stall, so no unrelated success-state screenshot is attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Peer message history now loads across all available pages in chronological order.
  - Added separate safeguards for individual page loads and the overall history-loading process.
  - Added a retry option when loading peer history fails.

- **Bug Fixes**
  - History loading now cancels safely when the overlay closes or a new request starts.
  - History refreshes correctly when the selected peer changes or a retry is requested.

- **Tests**
  - Added coverage for pagination, timeouts, cancellation, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->