### PR TITLE
Fix live computer acceptance recovery path

### DIFF
--- a/docs/agent-verification.md
+++ b/docs/agent-verification.md
@@ -66,6 +66,21 @@ remove credentials and unstable identifiers, and encode meaningful state
 transitions. Resolve fresh page references instead of replaying old reference
 IDs. For coordinate scenarios, control the viewport and fixture layout.
 
+## Live computer acceptance
+
+Run a vision-capable model through OpenRouter against a real E2B desktop:
+
+```bash
+COMPUTER_E2E_MODEL=openai/gpt-5.6-luna pnpm test:computer
+```
+
+This opt-in test requires `OPENROUTER_API_KEY` and `E2B_API_KEY` and incurs
+inference and sandbox usage. It checks visual observation, a real browser click,
+terminal access and exact file contents. It then destroys the sandbox outside
+the app and calls `computer/recover`, requiring a new sandbox with the saved
+file restored. `computer/boot` returns the stored running state and does not
+request recovery from an externally deleted sandbox.
+
 ## Real-model quality
 
 List the cases without inference:

--- a/packages/testkit/src/computer-use.e2e.test.ts
+++ b/packages/testkit/src/computer-use.e2e.test.ts
@@ -141,19 +141,21 @@ describeLive("real model and E2B computer journey", () => {
 
     const originalRef = computer.providerRef;
     await handles.sandbox.destroy(computer, testContext(bot.id));
-    await rpc(handles.app, cookie, "computer/boot", { botId: bot.id });
+    // Simulate loss outside the app: the stored state still says running, so use
+    // recovery to replace the missing sandbox and restore its checkpoint.
+    await rpc(handles.app, cookie, "computer/recover", { botId: bot.id });
     const replacementBot = await handles.prisma.bot.findUniqueOrThrow({
       where: { id: bot.id },
       include: { computer: true },
     });
     const replacement = replacementBot.computer!;
-    expect(replacement.providerRef).not.toBe(originalRef);
     computer = {
       id: replacement.providerRef!,
       providerRef: replacement.providerRef!,
       botId: replacement.homeKey,
       kind: "e2b",
     };
+    expect(replacement.providerRef).not.toBe(originalRef);
     const restored = await rpc<{ content: string }>(handles.app, cookie, "computer/readFile", {
       botId: bot.id,
       path: "results/llm-confirmed.txt",


### PR DESCRIPTION
The live computer acceptance test deleted a sandbox outside the app, then called boot. Boot returns the stored running state, so the replacement assertion failed without exercising recovery.

Call the public recovery operation after sandbox loss, retain the replacement reference before assertions for cleanup, and document running GPT 5.6 Luna through OpenRouter. The test still requires a different sandbox and exact restored file contents; no assertion has been relaxed.

Validation: testkit type checking and all 73 lifecycle/recovery unit tests passed. Two live GPT 5.6 Luna runs through OpenRouter completed real E2B observation, clicking, shell access and the required file writes. The corrected journey reached recovery but received a server error. A subsequent diagnostic without model inference confirmed that E2B rejects new sandbox provisioning. Full live recovery remains unverified until provisioning is available; this is not reported as a passing live test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for an opt-in live computer acceptance test covering visual observation, browser interaction, terminal access, file verification, and sandbox recovery behavior.

- **Tests**
  - Updated sandbox-loss coverage to use the recovery operation, restore the checkpoint, and verify that a replacement sandbox is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->