### PR TITLE
Use Box for live computer acceptance tests

### DIFF
--- a/docs/agent-verification.md
+++ b/docs/agent-verification.md
@@ -12,7 +12,7 @@ model can demonstrate that it chooses a useful action for a natural request.
 | Computer replay | Pi, browser tool handlers, page state | Model endpoint, browser and sandbox | `pnpm test` |
 | Docker computer replay | Pi, supervisor, Chromium, page helper, downloads and files | Model endpoint, local fixture website | `pnpm test:computer-replay` |
 | Agent quality | Product API, Postgres, executor, Pi, real model | Sandbox and connected services | `pnpm test:evals --live ...` |
-| Vision acceptance | Product API, Pi, real vision model, E2B desktop | Fixture website | `pnpm test:computer` |
+| Vision acceptance | Product API, Pi, real vision model, Box or E2B desktop | Fixture website | `pnpm test:computer` |
 
 Default and PR tests never require paid inference. The nightly topology job also
 runs the Docker replay. Real-model quality runs are separate nightly evidence,
@@ -68,18 +68,26 @@ IDs. For coordinate scenarios, control the viewport and fixture layout.
 
 ## Live computer acceptance
 
-Run a vision-capable model through OpenRouter against a real E2B desktop:
+Run a vision-capable model through OpenRouter against a real Box desktop:
 
 ```bash
 COMPUTER_E2E_MODEL=openai/gpt-5.6-luna pnpm test:computer
+# Run the same checks against E2B when provider-specific verification is needed:
+COMPUTER_E2E_MODEL=openai/gpt-5.6-luna pnpm test:computer --sandbox e2b
 ```
 
-This opt-in test requires `OPENROUTER_API_KEY` and `E2B_API_KEY` and incurs
-inference and sandbox usage. It checks visual observation, a real browser click,
+Box is the default regardless of the application's sandbox setting. This opt-in
+test requires `OPENROUTER_API_KEY` and the selected sandbox's credential
+(`BOX_API_KEY` or `E2B_API_KEY`) and incurs inference and sandbox usage.
+It checks visual observation, a real browser click,
 terminal access and exact file contents. It then destroys the sandbox outside
 the app and calls `computer/recover`, requiring a new sandbox with the saved
 file restored. `computer/boot` returns the stored running state and does not
 request recovery from an externally deleted sandbox.
+
+Both providers run the same assertions. This journey does not cover PTY sessions
+or multiple screens, which Box does not support. Provider conformance tests
+remain separate. Live runs retain error logs to diagnose provider failures.
 
 ## Real-model quality
 

--- a/packages/testkit/src/cli/computer.ts
+++ b/packages/testkit/src/cli/computer.ts
@@ -2,13 +2,17 @@ import { execFileSync } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { parseArgs } from "node:util";
 import { loadRootEnv } from "@rakazo/core/node/load-root-env";
 import { PostgreSqlContainer } from "@testcontainers/postgresql";
+import { computerTestSandbox } from "../computer-test-config.js";
 import { runProcess } from "./process.js";
 
 async function main() {
+  const { values } = parseArgs({ options: { sandbox: { type: "string", default: "box" } } });
+  const sandbox = computerTestSandbox(values.sandbox);
   loadRootEnv();
-  for (const key of ["E2B_API_KEY", "OPENROUTER_API_KEY", "COMPUTER_E2E_MODEL"]) {
+  for (const key of [sandbox.apiKeyEnv, "OPENROUTER_API_KEY", "COMPUTER_E2E_MODEL"]) {
     if (!process.env[key]) throw new Error(`${key} is required`);
   }
   const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-computer-e2e-run-"));
@@ -19,9 +23,12 @@ async function main() {
     REALTIME_DATABASE_URL: database.getConnectionUri(),
     RUN_COMPUTER_E2E: "1",
     VERIFY_PROVIDERS: "1",
+    VERIFY_LOGGING: "1",
+    LOG_LEVEL: "error",
+    LOG_FORMAT: "json",
     COMPOSIO_API_KEY: "",
     WAKEUP_DRIVER: "memory",
-    SANDBOX_PROVIDER: "e2b",
+    SANDBOX_PROVIDER: sandbox.provider,
     AGENT_RUNTIME: "pi",
     BETTER_AUTH_SECRET: "computer-e2e-auth-secret-32chars",
     ENCRYPTION_KEY: "computer-e2e-encryption-key-32chars",

--- a/packages/testkit/src/computer-test-config.ts
+++ b/packages/testkit/src/computer-test-config.ts
@@ -1,0 +1,5 @@
+export function computerTestSandbox(provider = "box") {
+  if (provider === "box") return { provider, apiKeyEnv: "BOX_API_KEY" } as const;
+  if (provider === "e2b") return { provider, apiKeyEnv: "E2B_API_KEY" } as const;
+  throw new Error("Live computer tests support --sandbox box or --sandbox e2b");
+}

--- a/packages/testkit/src/computer-use.e2e.test.ts
+++ b/packages/testkit/src/computer-use.e2e.test.ts
@@ -3,18 +3,29 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { ComputerRef, SandboxProvider } from "@rakazo/adapter-kit";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { computerTestSandbox } from "./computer-test-config.js";
 import { sessionCookieHeader } from "./index.js";
 
 const live = process.env.RUN_COMPUTER_E2E === "1";
 const describeLive = live ? describe : describe.skip;
 
-describeLive("real model and E2B computer journey", () => {
+describeLive("real model and sandbox computer journey", () => {
   let dataDir: string | undefined;
   let handles: Awaited<ReturnType<typeof import("../../../apps/api/src/app.ts")["createApp"]>>;
   let computer: ComputerRef | undefined;
+  let sandboxProvider: "box" | "e2b";
+  let botId: string | undefined;
+  let runId: string | undefined;
 
   beforeAll(async () => {
-    for (const key of ["DATABASE_URL", "E2B_API_KEY", "OPENROUTER_API_KEY", "COMPUTER_E2E_MODEL"]) {
+    const sandbox = computerTestSandbox(process.env.SANDBOX_PROVIDER);
+    sandboxProvider = sandbox.provider;
+    for (const key of [
+      "DATABASE_URL",
+      sandbox.apiKeyEnv,
+      "OPENROUTER_API_KEY",
+      "COMPUTER_E2E_MODEL",
+    ]) {
       if (!process.env[key]) throw new Error(`${key} is required for pnpm test:computer`);
     }
     dataDir = mkdtempSync(path.join(tmpdir(), "rakazo-computer-e2e-"));
@@ -22,9 +33,11 @@ describeLive("real model and E2B computer journey", () => {
     handles = await createApp({
       databaseUrl: process.env.DATABASE_URL!,
       dataDir,
-      sandboxProvider: "e2b",
+      sandboxProvider,
       agentRuntime: "pi",
       e2bApiKey: process.env.E2B_API_KEY,
+      boxApiKey: process.env.BOX_API_KEY,
+      boxApiUrl: process.env.BOX_API_URL ?? process.env.BOX_BASE_URL,
       openRouterKey: process.env.OPENROUTER_API_KEY,
       defaultProvider: "openrouter",
       defaultModel: process.env.COMPUTER_E2E_MODEL,
@@ -40,12 +53,32 @@ describeLive("real model and E2B computer journey", () => {
   }, 120_000);
 
   afterAll(async () => {
-    if (computer) {
-      await handles.sandbox.destroy(computer, testContext(computer.botId)).catch(() => undefined);
+    try {
+      try {
+        if (runId) await handles.runtime.abort(runId);
+        const bot = botId
+          ? await handles.prisma.bot.findUnique({
+              where: { id: botId },
+              include: { computer: true },
+            })
+          : undefined;
+        const stored = bot?.computer;
+        if (stored?.providerRef) {
+          computer = {
+            id: stored.providerRef,
+            providerRef: stored.providerRef,
+            botId: stored.homeKey,
+            kind: sandboxProvider,
+          };
+        }
+      } finally {
+        if (computer) await handles.sandbox.destroy(computer, testContext(botId ?? computer.botId));
+      }
+    } finally {
+      await handles?.stop().catch(() => undefined);
+      if (dataDir) rmSync(dataDir, { recursive: true, force: true });
     }
-    await handles?.stop().catch(() => undefined);
-    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
-  });
+  }, 120_000);
 
   it("observes and clicks a real browser, then uses terminal and files", async () => {
     const stamp = Date.now();
@@ -68,6 +101,7 @@ describeLive("real model and E2B computer journey", () => {
         "This is an acceptance test. Follow the requested computer tool sequence exactly and do not claim a visual action succeeded until its result is visible.",
       notifyOnFinish: false,
     });
+    botId = bot.id;
     await rpc(handles.app, cookie, "computer/boot", { botId: bot.id });
     const storedBot = await handles.prisma.bot.findUniqueOrThrow({
       where: { id: bot.id },
@@ -78,7 +112,7 @@ describeLive("real model and E2B computer journey", () => {
       id: stored.providerRef!,
       providerRef: stored.providerRef!,
       botId: stored.homeKey,
-      kind: "e2b",
+      kind: sandboxProvider,
     };
     await installVisualFixture(handles.sandbox, computer);
 
@@ -92,6 +126,7 @@ describeLive("real model and E2B computer journey", () => {
         "Finally use write_file to create results/llm-confirmed.txt containing exactly visual-e2e-ok.",
       ].join(" "),
     });
+    runId = sent.runId;
     const completedRun = await waitForRun(
       () =>
         handles.prisma.run.findUnique({
@@ -153,7 +188,7 @@ describeLive("real model and E2B computer journey", () => {
       id: replacement.providerRef!,
       providerRef: replacement.providerRef!,
       botId: replacement.homeKey,
-      kind: "e2b",
+      kind: sandboxProvider,
     };
     expect(replacement.providerRef).not.toBe(originalRef);
     const restored = await rpc<{ content: string }>(handles.app, cookie, "computer/readFile", {


### PR DESCRIPTION
Live computer acceptance required E2B even though the same journey can run through the existing Box adapter. Use Box by default so routine live verification can use the preferred sandbox provider, while keeping E2B selectable with `--sandbox e2b` for adapter-specific checks.

The CLI validates only the selected sandbox credential. The journey keeps all observation, click, shell, exact-file and sandbox-recovery assertions. Teardown aborts any active model run, reloads the current sandbox reference, attempts deletion even if the lookup fails, and surfaces deletion failures. Live runs enable error logging for provider diagnosis. Documentation describes the default and the PTY/multiple-screen capabilities this journey does not cover.

Validation: two complete live GPT 5.6 Luna runs through OpenRouter and Box passed, including deletion, a new sandbox and exact restored file contents. All 62 focused Box/conformance/recovery tests, testkit type checking and formatting checks passed. The second run also completed the updated teardown successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Vision acceptance tests now support both Box and E2B sandbox providers.
  - Box is the default provider, with E2B available as an opt-in option.
  - Both providers run the same test assertions and preserve diagnostic logs from live runs.

- **Documentation**
  - Updated setup guidance to list required OpenRouter and provider-specific sandbox credentials.
  - Clarified supported scenarios and limitations, including the lack of PTY session and multi-screen coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->