### PR TITLE
fix(api): preserve run teardown across cancellation races

### DIFF
--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -1003,7 +1003,7 @@ describe("sendThreadMessage", () => {
 });
 
 describe("stopThreadRuns", () => {
-  it("releases every active group member screen immediately", async () => {
+  it("snapshots active group screens before cancelled workers can clear their leases", async () => {
     const releaseScreen = vi.fn().mockResolvedValue(undefined);
     const execute = vi.fn(async function* () {
       yield { type: "exit", code: 0 };
@@ -1011,18 +1011,12 @@ describe("stopThreadRuns", () => {
     const transaction = {
       $queryRaw: vi.fn(),
       run: {
-        findMany: vi.fn().mockResolvedValue([
+        updateManyAndReturn: vi.fn().mockResolvedValue([
           { id: "run-a", botId: "bot-a" },
           { id: "run-b", botId: "bot-b" },
         ]),
-        updateMany: vi.fn().mockResolvedValue({ count: 2 }),
       },
       steeringMessage: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
-    };
-    const prisma = {
-      $transaction: vi.fn(async (callback: (client: typeof transaction) => unknown) =>
-        callback(transaction),
-      ),
       computer: {
         findMany: vi.fn().mockResolvedValue([
           {
@@ -1042,13 +1036,25 @@ describe("stopThreadRuns", () => {
             executionRunId: "run-b",
           },
         ]),
-        updateMany: vi.fn().mockResolvedValue({ count: 2 }),
       },
       computerExecutionLease: {
         findMany: vi.fn().mockResolvedValue([
           { computerId: "computer-db-a", runId: "run-a", fence: 2 },
           { computerId: "computer-db-b", runId: "run-b", fence: 4 },
         ]),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof transaction) => unknown) =>
+        callback(transaction),
+      ),
+      // Simulate workers clearing execution columns as soon as the transaction
+      // commits. A post-commit lookup would now miss both sandboxes.
+      computer: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn().mockResolvedValue({ count: 2 }),
+      },
+      computerExecutionLease: {
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
       },
       event: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
@@ -1103,6 +1109,7 @@ describe("stopThreadRuns", () => {
         screenLeaseId: "run-b:4",
       }),
     );
+    expect(prisma.computer.findMany).not.toHaveBeenCalled();
     expect(prisma.computerExecutionLease.updateMany).toHaveBeenCalledWith({
       where: { runId: { in: ["run-a", "run-b"] } },
       data: { expiresAt: new Date(0) },

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -1130,4 +1130,99 @@ describe("stopThreadRuns", () => {
       expect.objectContaining({ where: { executionRunId: { in: ["run-a", "run-b"] } } }),
     );
   });
+
+  it("does not tear down a stale legacy execution run when the lease owns a cancelled run", async () => {
+    const releaseScreen = vi.fn().mockResolvedValue(undefined);
+    const execute = vi.fn(async function* () {
+      yield { type: "exit", code: 0 };
+    });
+    const transaction = {
+      $queryRaw: vi.fn(),
+      run: {
+        updateManyAndReturn: vi.fn().mockResolvedValue([{ id: "run-a", botId: "bot-a" }]),
+      },
+      steeringMessage: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+      computer: {
+        // Selected via lease for cancelled run A, but legacy columns still name
+        // unrelated live run B. Legacy teardown must not cancel/release B.
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "computer-db-a",
+            homeKey: "home-a",
+            kind: "fake",
+            providerRef: "computer-a",
+            executionBotId: "bot-b",
+            executionRunId: "run-b",
+          },
+        ]),
+      },
+      computerExecutionLease: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            { computerId: "computer-db-a", botId: "bot-a", runId: "run-a", fence: 2 },
+          ]),
+      },
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof transaction) => unknown) =>
+        callback(transaction),
+      ),
+      computer: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      computerExecutionLease: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      event: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    } as unknown as PrismaClient;
+    const actor = {
+      spaceId: "workspace-1",
+      userId: "user-1",
+    } as Actor;
+    const target = {
+      kind: "group",
+      groupId: "group-1",
+      groupName: "Test group",
+      threadId: "thread-1",
+      members: [],
+      memberBotIds: ["bot-a", "bot-b"],
+    } satisfies ThreadTarget;
+
+    await stopThreadRuns(
+      { prisma, sandbox: { releaseScreen, execute } as unknown as SandboxProvider },
+      actor,
+      target,
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ providerRef: "computer-a" }),
+      expect.objectContaining({
+        argv: expect.arrayContaining(["rakazo-cancel-run-work", "computer-db-a", "run-a"]),
+      }),
+      expect.objectContaining({ cancelRunWork: true, runId: "run-a", botId: "bot-a" }),
+    );
+    expect(execute).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        argv: expect.arrayContaining(["rakazo-cancel-run-work", "computer-db-a", "run-b"]),
+      }),
+      expect.anything(),
+    );
+    expect(releaseScreen).toHaveBeenCalledTimes(1);
+    expect(releaseScreen).toHaveBeenCalledWith(
+      expect.objectContaining({ providerRef: "computer-a" }),
+      expect.objectContaining({
+        botId: "bot-a",
+        runId: "run-a",
+        screenLeaseId: "run-a:2",
+      }),
+    );
+    expect(releaseScreen).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ runId: "run-b" }),
+    );
+  });
 });

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -1018,29 +1018,38 @@ describe("stopThreadRuns", () => {
       },
       steeringMessage: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
       computer: {
-        findMany: vi.fn().mockResolvedValue([
-          {
-            id: "computer-db-a",
-            homeKey: "home-a",
-            kind: "fake",
-            providerRef: "computer-a",
-            executionBotId: "bot-a",
-            executionRunId: "run-a",
-          },
-          {
-            id: "computer-db-b",
-            homeKey: "home-b",
-            kind: "fake",
-            providerRef: "computer-b",
-            executionBotId: "bot-b",
-            executionRunId: "run-b",
-          },
-        ]),
+        // Production team ownership is lease-only: Computer.executionRunId stays null.
+        findMany: vi.fn().mockImplementation(async ({ where }: { where: { OR?: unknown[] } }) => {
+          expect(where.OR).toEqual(
+            expect.arrayContaining([
+              { id: { in: expect.arrayContaining(["computer-db-a", "computer-db-b"]) } },
+              { executionRunId: { in: ["run-a", "run-b"] } },
+            ]),
+          );
+          return [
+            {
+              id: "computer-db-a",
+              homeKey: "home-a",
+              kind: "fake",
+              providerRef: "computer-a",
+              executionBotId: null,
+              executionRunId: null,
+            },
+            {
+              id: "computer-db-b",
+              homeKey: "home-b",
+              kind: "fake",
+              providerRef: "computer-b",
+              executionBotId: null,
+              executionRunId: null,
+            },
+          ];
+        }),
       },
       computerExecutionLease: {
         findMany: vi.fn().mockResolvedValue([
-          { computerId: "computer-db-a", runId: "run-a", fence: 2 },
-          { computerId: "computer-db-b", runId: "run-b", fence: 4 },
+          { computerId: "computer-db-a", botId: "bot-a", runId: "run-a", fence: 2 },
+          { computerId: "computer-db-b", botId: "bot-b", runId: "run-b", fence: 4 },
         ]),
       },
     };
@@ -1048,11 +1057,11 @@ describe("stopThreadRuns", () => {
       $transaction: vi.fn(async (callback: (client: typeof transaction) => unknown) =>
         callback(transaction),
       ),
-      // Simulate workers clearing execution columns as soon as the transaction
-      // commits. A post-commit lookup would now miss both sandboxes.
+      // Simulate workers clearing leases / execution columns as soon as the
+      // transaction commits. A post-commit lookup would now miss both sandboxes.
       computer: {
         findMany: vi.fn().mockResolvedValue([]),
-        updateMany: vi.fn().mockResolvedValue({ count: 2 }),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
       },
       computerExecutionLease: {
         updateMany: vi.fn().mockResolvedValue({ count: 2 }),
@@ -1078,13 +1087,17 @@ describe("stopThreadRuns", () => {
       target,
     );
 
+    expect(transaction.computerExecutionLease.findMany).toHaveBeenCalledWith({
+      where: { runId: { in: ["run-a", "run-b"] } },
+      select: { computerId: true, botId: true, runId: true, fence: true },
+    });
     expect(execute).toHaveBeenCalledTimes(2);
     expect(execute).toHaveBeenCalledWith(
       expect.objectContaining({ providerRef: "computer-a" }),
       expect.objectContaining({
         argv: expect.arrayContaining(["rakazo-cancel-run-work", "computer-db-a", "run-a"]),
       }),
-      expect.objectContaining({ cancelRunWork: true, runId: "run-a" }),
+      expect.objectContaining({ cancelRunWork: true, runId: "run-a", botId: "bot-a" }),
     );
     expect(releaseScreen).toHaveBeenCalledTimes(2);
     expect(releaseScreen).toHaveBeenCalledWith(

--- a/apps/api/src/thread-target.test.ts
+++ b/apps/api/src/thread-target.test.ts
@@ -1003,7 +1003,7 @@ describe("sendThreadMessage", () => {
 });
 
 describe("stopThreadRuns", () => {
-  it("snapshots active group screens before cancelled workers can clear their leases", async () => {
+  it("snapshots every lease when group members share a team computer", async () => {
     const releaseScreen = vi.fn().mockResolvedValue(undefined);
     const execute = vi.fn(async function* () {
       yield { type: "exit", code: 0 };
@@ -1022,24 +1022,16 @@ describe("stopThreadRuns", () => {
         findMany: vi.fn().mockImplementation(async ({ where }: { where: { OR?: unknown[] } }) => {
           expect(where.OR).toEqual(
             expect.arrayContaining([
-              { id: { in: expect.arrayContaining(["computer-db-a", "computer-db-b"]) } },
+              { id: { in: ["computer-db-team"] } },
               { executionRunId: { in: ["run-a", "run-b"] } },
             ]),
           );
           return [
             {
-              id: "computer-db-a",
-              homeKey: "home-a",
+              id: "computer-db-team",
+              homeKey: "home-team",
               kind: "fake",
-              providerRef: "computer-a",
-              executionBotId: null,
-              executionRunId: null,
-            },
-            {
-              id: "computer-db-b",
-              homeKey: "home-b",
-              kind: "fake",
-              providerRef: "computer-b",
+              providerRef: "computer-team",
               executionBotId: null,
               executionRunId: null,
             },
@@ -1048,8 +1040,8 @@ describe("stopThreadRuns", () => {
       },
       computerExecutionLease: {
         findMany: vi.fn().mockResolvedValue([
-          { computerId: "computer-db-a", botId: "bot-a", runId: "run-a", fence: 2 },
-          { computerId: "computer-db-b", botId: "bot-b", runId: "run-b", fence: 4 },
+          { computerId: "computer-db-team", botId: "bot-a", runId: "run-a", fence: 2 },
+          { computerId: "computer-db-team", botId: "bot-b", runId: "run-b", fence: 4 },
         ]),
       },
     };
@@ -1093,15 +1085,22 @@ describe("stopThreadRuns", () => {
     });
     expect(execute).toHaveBeenCalledTimes(2);
     expect(execute).toHaveBeenCalledWith(
-      expect.objectContaining({ providerRef: "computer-a" }),
+      expect.objectContaining({ providerRef: "computer-team" }),
       expect.objectContaining({
-        argv: expect.arrayContaining(["rakazo-cancel-run-work", "computer-db-a", "run-a"]),
+        argv: expect.arrayContaining(["rakazo-cancel-run-work", "computer-db-team", "run-a"]),
       }),
       expect.objectContaining({ cancelRunWork: true, runId: "run-a", botId: "bot-a" }),
     );
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ providerRef: "computer-team" }),
+      expect.objectContaining({
+        argv: expect.arrayContaining(["rakazo-cancel-run-work", "computer-db-team", "run-b"]),
+      }),
+      expect.objectContaining({ cancelRunWork: true, runId: "run-b", botId: "bot-b" }),
+    );
     expect(releaseScreen).toHaveBeenCalledTimes(2);
     expect(releaseScreen).toHaveBeenCalledWith(
-      expect.objectContaining({ providerRef: "computer-a" }),
+      expect.objectContaining({ providerRef: "computer-team" }),
       expect.objectContaining({
         spaceId: "workspace-1",
         userId: "user-1",
@@ -1112,7 +1111,7 @@ describe("stopThreadRuns", () => {
       }),
     );
     expect(releaseScreen).toHaveBeenCalledWith(
-      expect.objectContaining({ providerRef: "computer-b" }),
+      expect.objectContaining({ providerRef: "computer-team" }),
       expect.objectContaining({
         spaceId: "workspace-1",
         userId: "user-1",

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -910,11 +910,25 @@ export async function stopThreadRuns(
       },
     });
     // Snapshot teardown coordinates before commit. Once cancellation becomes
-    // visible, a worker can release its execution columns immediately; a
+    // visible, a worker can release its lease / execution columns immediately; a
     // later lookup would then miss the sandbox work this request must stop.
+    // Team ownership lives on ComputerExecutionLease; Computer.executionRunId is
+    // only a legacy secondary path and is not written by current acquisition.
+    const leases = ids.length
+      ? await tx.computerExecutionLease.findMany({
+          where: { runId: { in: ids } },
+          select: { computerId: true, botId: true, runId: true, fence: true },
+        })
+      : [];
+    const leaseComputerIds = [...new Set(leases.map((lease) => lease.computerId))];
     const computers = ids.length
       ? await tx.computer.findMany({
-          where: { executionRunId: { in: ids } },
+          where:
+            leaseComputerIds.length > 0
+              ? {
+                  OR: [{ id: { in: leaseComputerIds } }, { executionRunId: { in: ids } }],
+                }
+              : { executionRunId: { in: ids } },
           select: {
             id: true,
             homeKey: true,
@@ -925,34 +939,59 @@ export async function stopThreadRuns(
           },
         })
       : [];
-    const leases = ids.length
-      ? await tx.computerExecutionLease.findMany({
-          where: { runId: { in: ids } },
-          select: { computerId: true, runId: true, fence: true },
-        })
-      : [];
     return { runIds: ids, computers, leases };
   });
   // Keep the DB lease until after teardown so a replacement run cannot claim the
   // screen while we still need the cancelled run's screenLeaseId to release it.
-  const leaseByComputerId = new Map(leases.map((lease) => [lease.computerId, lease]));
+  const computerById = new Map(computers.map((computer) => [computer.id, computer]));
+  const teardownTargets: Array<{
+    computer: (typeof computers)[number];
+    botId: string;
+    runId: string;
+    lease: (typeof leases)[number] | null;
+  }> = [];
+  const seenTargets = new Set<string>();
+  for (const lease of leases) {
+    const computer = computerById.get(lease.computerId);
+    if (!computer) continue;
+    const key = `${computer.id}:${lease.runId}`;
+    if (seenTargets.has(key)) continue;
+    seenTargets.add(key);
+    teardownTargets.push({
+      computer,
+      botId: lease.botId,
+      runId: lease.runId,
+      lease,
+    });
+  }
+  for (const computer of computers) {
+    if (!computer.executionBotId || !computer.executionRunId) continue;
+    const key = `${computer.id}:${computer.executionRunId}`;
+    if (seenTargets.has(key)) continue;
+    seenTargets.add(key);
+    teardownTargets.push({
+      computer,
+      botId: computer.executionBotId,
+      runId: computer.executionRunId,
+      lease: null,
+    });
+  }
   await Promise.all(
-    computers.map(async (computer) => {
-      if (!computer.providerRef || !computer.executionBotId || !computer.executionRunId) return;
-      const lease = leaseByComputerId.get(computer.id) ?? null;
+    teardownTargets.map(async ({ computer, botId, runId, lease }) => {
+      if (!computer.providerRef) return;
       const context = {
         operationId: "stop",
         traceId: "stop",
         spaceId: actor.spaceId,
         userId: actor.userId,
-        botId: computer.executionBotId,
-        runId: computer.executionRunId,
-        screenLeaseId: screenLeaseIdForRun(lease, computer.executionRunId),
+        botId,
+        runId,
+        screenLeaseId: screenLeaseIdForRun(lease, runId),
         cancelRunWork: true,
         signal: new AbortController().signal,
       };
       const ref = toComputerRef(computer);
-      await cancelComputerRunWork(deps.sandbox, ref, computer.id, computer.executionRunId, context);
+      await cancelComputerRunWork(deps.sandbox, ref, computer.id, runId, context);
       await deps.sandbox.releaseScreen?.(ref, context).catch(() => undefined);
     }),
   );

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -892,50 +892,49 @@ export async function stopThreadRuns(
   actor: Actor,
   target: ThreadTarget,
 ) {
-  const runIds = await deps.prisma.$transaction(async (tx) => {
+  const { runIds, computers, leases } = await deps.prisma.$transaction(async (tx) => {
     await tx.$queryRaw`SELECT id FROM threads WHERE id = ${target.threadId} FOR UPDATE`;
-    const ids = (
-      await tx.run.findMany({
-        where: {
-          threadId: target.threadId,
-          status: { in: [...ACTIVE_RUN_STATUSES] },
-        },
-        select: { id: true },
-      })
-    ).map((run) => run.id);
-    await tx.run.updateMany({
-      where: { id: { in: ids }, status: { in: [...ACTIVE_RUN_STATUSES] } },
+    const cancelled = await tx.run.updateManyAndReturn({
+      where: {
+        threadId: target.threadId,
+        status: { in: [...ACTIVE_RUN_STATUSES] },
+      },
       data: { status: "cancelled", completedAt: new Date() },
+      select: { id: true },
     });
+    const ids = cancelled.map((run) => run.id);
     await tx.steeringMessage.deleteMany({
       where: {
         botId: { in: target.kind === "bot" ? [target.botId] : target.memberBotIds },
         message: { threadId: target.threadId },
       },
     });
-    return ids;
+    // Snapshot teardown coordinates before commit. Once cancellation becomes
+    // visible, a worker can release its execution columns immediately; a
+    // later lookup would then miss the sandbox work this request must stop.
+    const computers = ids.length
+      ? await tx.computer.findMany({
+          where: { executionRunId: { in: ids } },
+          select: {
+            id: true,
+            homeKey: true,
+            kind: true,
+            providerRef: true,
+            executionBotId: true,
+            executionRunId: true,
+          },
+        })
+      : [];
+    const leases = ids.length
+      ? await tx.computerExecutionLease.findMany({
+          where: { runId: { in: ids } },
+          select: { computerId: true, runId: true, fence: true },
+        })
+      : [];
+    return { runIds: ids, computers, leases };
   });
-  const computers = runIds.length
-    ? await deps.prisma.computer.findMany({
-        where: { executionRunId: { in: runIds } },
-        select: {
-          id: true,
-          homeKey: true,
-          kind: true,
-          providerRef: true,
-          executionBotId: true,
-          executionRunId: true,
-        },
-      })
-    : [];
   // Keep the DB lease until after teardown so a replacement run cannot claim the
   // screen while we still need the cancelled run's screenLeaseId to release it.
-  const leases = runIds.length
-    ? await deps.prisma.computerExecutionLease.findMany({
-        where: { runId: { in: runIds } },
-        select: { computerId: true, runId: true, fence: true },
-      })
-    : [];
   const leaseByComputerId = new Map(leases.map((lease) => [lease.computerId, lease]));
   await Promise.all(
     computers.map(async (computer) => {

--- a/apps/api/src/thread-target.ts
+++ b/apps/api/src/thread-target.ts
@@ -964,8 +964,14 @@ export async function stopThreadRuns(
       lease,
     });
   }
+  const cancelledRunIds = new Set(runIds);
   for (const computer of computers) {
     if (!computer.executionBotId || !computer.executionRunId) continue;
+    // Computers may enter the snapshot via a cancelled lease while
+    // Computer.executionRunId still points at an unrelated live run. Only treat
+    // the legacy columns as a teardown target when they belong to a run we
+    // cancelled in this transaction.
+    if (!cancelledRunIds.has(computer.executionRunId)) continue;
     const key = `${computer.id}:${computer.executionRunId}`;
     if (seenTargets.has(key)) continue;
     seenTargets.add(key);


### PR DESCRIPTION
## Why

Follow-up to the real-world process leak reported in #499 and the teardown added in #513.

`stopThreadRuns` currently commits the `cancelled` status before looking up the computers and execution leases to tear down. As soon as that status becomes visible, a worker can release its execution columns. The post-commit lookup then sees no computer, so the stop request can miss the sandbox work it was supposed to terminate.

## What

- atomically transition active runs with `updateManyAndReturn`
- snapshot computer teardown coordinates and execution lease fences in the same transaction
- perform sandbox cancellation and screen release from that snapshot after commit
- restrict cleanup to runs that were actually transitioned to `cancelled`

## Tests

- `pnpm exec vitest run apps/api/src/thread-target.test.ts packages/adapters/src/computer-idle.test.ts packages/adapters/src/computer-lifecycle.test.ts packages/adapters/src/docker-sandbox.test.ts packages/testkit/src/executor-lifecycle.test.ts` (107 passed, 20 skipped)
- `pnpm --filter @rakazo/api test` (237 passed)
- `pnpm --filter @rakazo/api check`
- `pnpm exec biome check apps/api/src/thread-target.ts apps/api/src/thread-target.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread run cancellation reliability by capturing cleanup details atomically.
  - Ensured cancellation releases all affected screens, including multiple runs sharing the same computer.
  - Prevented cleanup details from being lost when worker leases are cleared.
  - Ensured cancellation only stops and releases resources belonging to the cancelled run, avoiding interference with unrelated active runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->