### PR TITLE
feat(web): streamline first-run onboarding

### DIFF
--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -37,7 +37,6 @@ export async function completeOnboarding(page: Page, testInfo?: TestInfo) {
       .catch(() => false)
   ) {
     if (testInfo) await captureScreenshot(page, testInfo, "03-create-first-bot");
-    await page.locator("label:has-text('Name') input").fill("Chief");
     const created = page.waitForResponse(
       (response) => response.url().includes("/rpc/bots/create") && response.ok(),
     );

--- a/apps/web/e2e/onboarding-model-auto-skip.spec.ts
+++ b/apps/web/e2e/onboarding-model-auto-skip.spec.ts
@@ -26,5 +26,15 @@ test("onboarding skips model connect when a default model is already available",
   });
   await expect(page.getByRole("heading", { name: "Connect a model" })).toBeHidden();
   await expect(page.getByRole("button", { name: "Skip for now" })).toBeHidden();
+  await expect(page.getByRole("textbox", { name: "Name" })).toHaveCount(0);
+  await expect(page.getByRole("textbox", { name: "Title" })).toHaveCount(0);
+  await expect(page.getByRole("textbox", { name: "Description" })).toHaveCount(0);
   await captureScreenshot(page, testInfo, "onboarding-model-auto-skip");
+
+  const createRequest = page.waitForRequest("**/rpc/bots/create");
+  await page.getByRole("button", { name: "Continue" }).click();
+  expect((await createRequest).postDataJSON()).toMatchObject({
+    json: { name: "Chief", title: "", description: "", instructions: "" },
+  });
+  await expect(page.getByRole("combobox", { name: "Message Chief" })).toBeVisible();
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -49,8 +49,16 @@ test("onboarding uses compact model selects without misleading latest labels", a
   const discovered = page.getByRole("combobox", { name: "Models from server" });
   await expect(discovered).toBeVisible();
   await discovered.click();
+  const discoveredModel = (await page.getByRole("option").allTextContents()).find(
+    (label) => label !== "Other model…",
+  );
+  expect(discoveredModel).toBeTruthy();
   await page.getByRole("option", { name: "Other model…" }).click();
-  await expect(page.getByLabel("Model id")).toBeVisible();
+  const manualModel = page.getByLabel("Model id");
+  await manualModel.fill(discoveredModel!);
+  await expect(manualModel).toBeVisible();
+  await manualModel.fill(`${discoveredModel}-custom`);
+  await expect(manualModel).toHaveValue(`${discoveredModel}-custom`);
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -63,9 +63,13 @@ test("onboarding uses compact model selects without misleading latest labels", a
   await manualModel.fill("probed-model");
   await expect(manualModel).toBeVisible();
   await expect(manualModel).toHaveValue("probed-model");
+  // Re-probe while the typed id matches a discovered model must stay freeform.
+  await page.getByRole("button", { name: "Find models" }).click();
+  await expect(manualModel).toBeVisible();
+  await expect(manualModel).toHaveValue("probed-model");
+  await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);
   await manualModel.fill("probed-model-custom");
   await expect(manualModel).toHaveValue("probed-model-custom");
-  await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { captureScreenshot, signup } from "./helpers";
 
-test("onboarding model list never labels an older model the latest one", async ({
+test("onboarding uses compact model selects without misleading latest labels", async ({
   page,
 }, testInfo) => {
   await page.route("**/rpc/me", async (route) => {
@@ -19,47 +19,26 @@ test("onboarding model list never labels an older model the latest one", async (
     timeout: 20_000,
   });
 
-  await expect(page.getByRole("button", { name: /OpenRouter/ })).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
-  await expect(page.getByRole("button", { name: /ChatGPT.*ChatGPT Plus\/Pro/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Vercel AI Gateway/ })).toBeVisible();
-  await captureScreenshot(page, testInfo, "onboarding-popular-providers");
-  await page.getByRole("button", { name: "Show all providers" }).click();
-  await page.getByPlaceholder("Search providers and models").fill("anthropic");
-  await expect(page.getByRole("button", { name: /OpenRouter/ })).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
-  await page
-    .getByRole("button", { name: /Anthropic/ })
-    .first()
-    .click();
-  await expect(page.getByRole("button", { name: /Anthropic/ }).first()).toHaveAttribute(
-    "aria-pressed",
-    "true",
-  );
+  const provider = page.getByRole("combobox", { name: "Provider" });
+  await expect(provider).toContainText("OpenRouter");
+  await provider.click();
+  await expect(page.getByRole("option", { name: "ChatGPT" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "Vercel AI Gateway" })).toBeVisible();
+  await page.getByRole("option", { name: "Anthropic" }).click();
+  await expect(provider).toContainText("Anthropic");
 
   const models = page.getByRole("combobox", { name: "Model", exact: true });
-  const labels = await models.getByRole("option").allTextContents();
+  await models.click();
+  const labels = await page.getByRole("option").allTextContents();
   // "latest" is an upstream alias marker, so it lands on families like Claude Opus 4.5 while
   // newer models carry no marker. Rendered as-is it tells the user the opposite of the truth.
   expect(labels.filter((label) => /\blatest\b/i.test(label))).toEqual([]);
 
-  // Select a non-default model before filtering the active provider out of the results.
+  // Select a non-default model and keep its user-facing alias visible in the compact trigger.
   const alias = labels.find((label) => label.includes("(auto-updates)"));
   expect(alias).toBeTruthy();
-  await models.selectOption({ label: alias! });
-  const selectedModelId = await models.inputValue();
-
-  await page.getByPlaceholder("Search providers and models").fill("no-provider-or-model");
-  const selectedProvider = page.getByRole("button", { name: /Anthropic.*Selected/ });
-  await expect(selectedProvider).toHaveAttribute("aria-pressed", "true");
-  await expect(page.getByText("No providers found")).toBeVisible();
-  await selectedProvider.click();
-  await expect(models).toHaveValue(selectedModelId);
-  await page.getByPlaceholder("Search providers and models").fill("anthropic");
+  await page.getByRole("option", { name: alias! }).click();
+  await expect(models).toContainText(alias!);
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -42,23 +42,30 @@ test("onboarding uses compact model selects without misleading latest labels", a
   await page.getByRole("option", { name: alias! }).click();
   await expect(models).toContainText(alias!);
 
+  await page.route("**/rpc/models/probeOpenAiCompatible", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ json: { models: ["probed-model"] } }),
+    });
+  });
   await provider.click();
   await page.getByRole("option", { name: "OpenAI-compatible" }).click();
   await page.getByLabel("OpenAI-compatible server URL").fill("http://127.0.0.1:8090/v1");
   await page.getByRole("button", { name: "Find models" }).click();
   const discovered = page.getByRole("combobox", { name: "Models from server" });
   await expect(discovered).toBeVisible();
+  await expect(discovered).toContainText("probed-model");
   await discovered.click();
-  const discoveredModel = (await page.getByRole("option").allTextContents()).find(
-    (label) => label !== "Other model…",
-  );
-  expect(discoveredModel).toBeTruthy();
   await page.getByRole("option", { name: "Other model…" }).click();
   const manualModel = page.getByLabel("Model id");
-  await manualModel.fill(discoveredModel!);
   await expect(manualModel).toBeVisible();
-  await manualModel.fill(`${discoveredModel}-custom`);
-  await expect(manualModel).toHaveValue(`${discoveredModel}-custom`);
+  // Typing a discovered id (or its prefix) must keep the freeform field.
+  await manualModel.fill("probed-model");
+  await expect(manualModel).toBeVisible();
+  await expect(manualModel).toHaveValue("probed-model");
+  await manualModel.fill("probed-model-custom");
+  await expect(manualModel).toHaveValue("probed-model-custom");
+  await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -51,13 +51,20 @@ test("onboarding uses compact model selects without misleading latest labels", a
   await provider.click();
   await page.getByRole("option", { name: "OpenAI-compatible" }).click();
   await page.getByLabel("OpenAI-compatible server URL").fill("http://127.0.0.1:8090/v1");
+  const manualModel = page.getByLabel("Model id");
+  await expect(manualModel).toBeVisible();
+  // Typing before the first probe must keep freeform even if the probe returns that id.
+  await manualModel.fill("probed-model");
   await page.getByRole("button", { name: "Find models" }).click();
+  await expect(manualModel).toBeVisible();
+  await expect(manualModel).toHaveValue("probed-model");
+  await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Use a found model" }).click();
   const discovered = page.getByRole("combobox", { name: "Models from server" });
   await expect(discovered).toBeVisible();
   await expect(discovered).toContainText("probed-model");
   await discovered.click();
   await page.getByRole("option", { name: "Other model…" }).click();
-  const manualModel = page.getByLabel("Model id");
   await expect(manualModel).toBeVisible();
   // Typing a discovered id (or its prefix) must keep the freeform field.
   await manualModel.fill("probed-model");

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -21,11 +21,13 @@ test("onboarding uses compact model selects without misleading latest labels", a
 
   const provider = page.getByRole("combobox", { name: "Provider" });
   await expect(provider).toContainText("OpenRouter");
+  await page.getByLabel("API key").fill("openrouter-only-key");
   await provider.click();
   await expect(page.getByRole("option", { name: "ChatGPT" })).toBeVisible();
   await expect(page.getByRole("option", { name: "Vercel AI Gateway" })).toBeVisible();
   await page.getByRole("option", { name: "Anthropic" }).click();
   await expect(provider).toContainText("Anthropic");
+  await expect(page.getByLabel(/API key/)).toHaveValue("");
 
   const models = page.getByRole("combobox", { name: "Model", exact: true });
   await models.click();
@@ -39,6 +41,16 @@ test("onboarding uses compact model selects without misleading latest labels", a
   expect(alias).toBeTruthy();
   await page.getByRole("option", { name: alias! }).click();
   await expect(models).toContainText(alias!);
+
+  await provider.click();
+  await page.getByRole("option", { name: "OpenAI-compatible" }).click();
+  await page.getByLabel("OpenAI-compatible server URL").fill("http://127.0.0.1:8090/v1");
+  await page.getByRole("button", { name: "Find models" }).click();
+  const discovered = page.getByRole("combobox", { name: "Models from server" });
+  await expect(discovered).toBeVisible();
+  await discovered.click();
+  await page.getByRole("option", { name: "Other model…" }).click();
+  await expect(page.getByLabel("Model id")).toBeVisible();
 
   await captureScreenshot(page, testInfo, "onboarding-model-labels");
 });

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -68,6 +68,12 @@ test("onboarding uses compact model selects without misleading latest labels", a
   await expect(manualModel).toBeVisible();
   await expect(manualModel).toHaveValue("probed-model");
   await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);
+  // Editing the server URL must not drop Other model… mode either.
+  await page.getByLabel("OpenAI-compatible server URL").fill("http://127.0.0.1:8091/v1");
+  await page.getByRole("button", { name: "Find models" }).click();
+  await expect(manualModel).toBeVisible();
+  await expect(manualModel).toHaveValue("probed-model");
+  await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);
   await manualModel.fill("probed-model-custom");
   await expect(manualModel).toHaveValue("probed-model-custom");
 

--- a/apps/web/e2e/onboarding-model-labels.spec.ts
+++ b/apps/web/e2e/onboarding-model-labels.spec.ts
@@ -55,7 +55,9 @@ test("onboarding uses compact model selects without misleading latest labels", a
   await expect(manualModel).toBeVisible();
   // Typing before the first probe must keep freeform even if the probe returns that id.
   await manualModel.fill("probed-model");
+  const firstProbeResponse = page.waitForResponse("**/rpc/models/probeOpenAiCompatible");
   await page.getByRole("button", { name: "Find models" }).click();
+  await firstProbeResponse;
   await expect(manualModel).toBeVisible();
   await expect(manualModel).toHaveValue("probed-model");
   await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);
@@ -71,13 +73,17 @@ test("onboarding uses compact model selects without misleading latest labels", a
   await expect(manualModel).toBeVisible();
   await expect(manualModel).toHaveValue("probed-model");
   // Re-probe while the typed id matches a discovered model must stay freeform.
+  const reProbeResponse = page.waitForResponse("**/rpc/models/probeOpenAiCompatible");
   await page.getByRole("button", { name: "Find models" }).click();
+  await reProbeResponse;
   await expect(manualModel).toBeVisible();
   await expect(manualModel).toHaveValue("probed-model");
   await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);
   // Editing the server URL must not drop Other model… mode either.
   await page.getByLabel("OpenAI-compatible server URL").fill("http://127.0.0.1:8091/v1");
+  const editedUrlProbeResponse = page.waitForResponse("**/rpc/models/probeOpenAiCompatible");
   await page.getByRole("button", { name: "Find models" }).click();
+  await editedUrlProbeResponse;
   await expect(manualModel).toBeVisible();
   await expect(manualModel).toHaveValue("probed-model");
   await expect(page.getByRole("combobox", { name: "Models from server" })).toHaveCount(0);

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -169,7 +169,11 @@ export function OnboardingPage() {
         setModelId((current) => {
           const trimmed = current.trim();
           const next = trimmed || models[0] || "";
-          setManualModelId(Boolean(trimmed) && !models.includes(trimmed));
+          // Stay in manual entry across re-probes so a typed id that matches a
+          // discovered model cannot yank the freeform field back to the Select.
+          setManualModelId(
+            (wasManual) => wasManual || (Boolean(trimmed) && !models.includes(trimmed)),
+          );
           return next;
         });
         setNotice(openAiCompatibleProbeSuccessMessage(models.length));

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -21,6 +21,8 @@ import type { ModelCatalogEntry } from "../lib/model-auth";
 import { rpc } from "../lib/rpc";
 import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 
+const CUSTOM_MODEL_OPTION = "__rakazo_custom_model__";
+
 export function OnboardingPage() {
   const { t } = useLingui();
   const navigate = useNavigate();
@@ -118,6 +120,7 @@ export function OnboardingPage() {
     if (nextProvider === provider) return;
     cancelOAuthAttempt();
     setProvider(nextProvider);
+    setApiKey("");
     setModelId(
       nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID
         ? ""
@@ -270,7 +273,13 @@ export function OnboardingPage() {
                       <Trans>Model</Trans>
                     </span>
                     {probeModels.length && probeModels.includes(modelId) ? (
-                      <Select value={modelId} onValueChange={(value) => setModelId(String(value))}>
+                      <Select
+                        value={modelId}
+                        onValueChange={(value) => {
+                          const next = String(value);
+                          setModelId(next === CUSTOM_MODEL_OPTION ? "" : next);
+                        }}
+                      >
                         <SelectTrigger aria-label={t`Models from server`} className="mt-2 w-full">
                           <SelectValue />
                         </SelectTrigger>
@@ -280,6 +289,9 @@ export function OnboardingPage() {
                               {id}
                             </SelectItem>
                           ))}
+                          <SelectItem value={CUSTOM_MODEL_OPTION}>
+                            <Trans>Other model…</Trans>
+                          </SelectItem>
                         </SelectContent>
                       </Select>
                     ) : (

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -339,7 +339,10 @@ export function OnboardingPage() {
                     ) : (
                       <Input
                         value={modelId}
-                        onChange={(e) => setModelId(e.target.value)}
+                        onChange={(e) => {
+                          setManualModelId(true);
+                          setModelId(e.target.value);
+                        }}
                         aria-label={t`Model id`}
                         placeholder="exact-model-id"
                         className="mt-2"

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -23,6 +23,10 @@ import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
 
 const CUSTOM_MODEL_OPTION = "__rakazo_custom_model__";
 
+function providerLabel(entry: ModelCatalogEntry): string {
+  return entry.provider === "openai-codex" ? "ChatGPT" : (entry.providerName ?? entry.provider);
+}
+
 export function OnboardingPage() {
   const { t } = useLingui();
   const navigate = useNavigate();
@@ -104,6 +108,23 @@ export function OnboardingPage() {
     modelId,
     probedBaseUrl,
   });
+  const otherModelLabel = t`Other model…`;
+  // Base UI Select.Value only resolves labels when Root gets `items`.
+  const providerItems = useMemo(
+    () => providers.map((entry) => ({ value: entry.provider, label: providerLabel(entry) })),
+    [providers],
+  );
+  const modelItems = useMemo(
+    () => modelsForProvider.map((entry) => ({ value: entry.id, label: entry.label })),
+    [modelsForProvider],
+  );
+  const probeModelItems = useMemo(
+    () => [
+      ...probeModels.map((id) => ({ value: id, label: id })),
+      { value: CUSTOM_MODEL_OPTION, label: otherModelLabel },
+    ],
+    [otherModelLabel, probeModels],
+  );
 
   function updateBaseUrl(nextBaseUrl: string) {
     setBaseUrl(nextBaseUrl);
@@ -145,8 +166,12 @@ export function OnboardingPage() {
       apiKey,
       request: rpc.models.probeOpenAiCompatible,
       onSuccess: (models) => {
-        setManualModelId(false);
-        setModelId((current) => current.trim() || models[0] || "");
+        setModelId((current) => {
+          const trimmed = current.trim();
+          const next = trimmed || models[0] || "";
+          setManualModelId(Boolean(trimmed) && !models.includes(trimmed));
+          return next;
+        });
         setNotice(openAiCompatibleProbeSuccessMessage(models.length));
       },
       onError: (err) =>
@@ -233,16 +258,18 @@ export function OnboardingPage() {
               <span>
                 <Trans>Provider</Trans>
               </span>
-              <Select value={provider} onValueChange={(value) => selectProvider(String(value))}>
+              <Select
+                value={provider}
+                onValueChange={(value) => selectProvider(String(value))}
+                items={providerItems}
+              >
                 <SelectTrigger aria-label={t`Provider`} className="mt-2 w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   {providers.map((entry) => (
                     <SelectItem key={entry.provider} value={entry.provider}>
-                      {entry.provider === "openai-codex"
-                        ? "ChatGPT"
-                        : (entry.providerName ?? entry.provider)}
+                      {providerLabel(entry)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -276,7 +303,7 @@ export function OnboardingPage() {
                     <span className="font-medium">
                       <Trans>Model</Trans>
                     </span>
-                    {probeModels.length && !manualModelId && probeModels.includes(modelId) ? (
+                    {probeModels.length && !manualModelId ? (
                       <Select
                         value={modelId}
                         onValueChange={(value) => {
@@ -285,9 +312,11 @@ export function OnboardingPage() {
                             setManualModelId(true);
                             setModelId("");
                           } else {
+                            setManualModelId(false);
                             setModelId(next);
                           }
                         }}
+                        items={probeModelItems}
                       >
                         <SelectTrigger aria-label={t`Models from server`} className="mt-2 w-full">
                           <SelectValue />
@@ -312,7 +341,7 @@ export function OnboardingPage() {
                         className="mt-2"
                       />
                     )}
-                    {probeModels.length && !probeModels.includes(modelId) ? (
+                    {probeModels.length && manualModelId ? (
                       <Button
                         variant="link"
                         size="xs"
@@ -341,9 +370,12 @@ export function OnboardingPage() {
                   <Select
                     value={selected?.id ?? modelId}
                     onValueChange={(value) => {
+                      const next = String(value);
+                      if (next === modelId) return;
                       cancelOAuthAttempt();
-                      setModelId(String(value));
+                      setModelId(next);
                     }}
+                    items={modelItems}
                   >
                     <SelectTrigger aria-label={t`Model`} className="mt-2 w-full">
                       <SelectValue />

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -34,6 +34,7 @@ export function OnboardingPage() {
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [reasoning, setReasoning] = useState(false);
+  const [manualModelId, setManualModelId] = useState(false);
   const [{ models: probeModels, baseUrl: probedBaseUrl, probing }, setProbe] =
     useState(initialModelProbeState);
   const [modelProbe] = useState(() => createModelProbe(setProbe));
@@ -106,6 +107,7 @@ export function OnboardingPage() {
 
   function updateBaseUrl(nextBaseUrl: string) {
     setBaseUrl(nextBaseUrl);
+    setManualModelId(false);
     resetOpenAiCompatibleProbe();
     setError(null);
     setNotice(null);
@@ -128,6 +130,7 @@ export function OnboardingPage() {
     );
     setBaseUrl("");
     setReasoning(false);
+    setManualModelId(false);
     resetOpenAiCompatibleProbe();
     setError(null);
     setNotice(null);
@@ -142,6 +145,7 @@ export function OnboardingPage() {
       apiKey,
       request: rpc.models.probeOpenAiCompatible,
       onSuccess: (models) => {
+        setManualModelId(false);
         setModelId((current) => current.trim() || models[0] || "");
         setNotice(openAiCompatibleProbeSuccessMessage(models.length));
       },
@@ -272,12 +276,17 @@ export function OnboardingPage() {
                     <span className="font-medium">
                       <Trans>Model</Trans>
                     </span>
-                    {probeModels.length && probeModels.includes(modelId) ? (
+                    {probeModels.length && !manualModelId && probeModels.includes(modelId) ? (
                       <Select
                         value={modelId}
                         onValueChange={(value) => {
                           const next = String(value);
-                          setModelId(next === CUSTOM_MODEL_OPTION ? "" : next);
+                          if (next === CUSTOM_MODEL_OPTION) {
+                            setManualModelId(true);
+                            setModelId("");
+                          } else {
+                            setModelId(next);
+                          }
                         }}
                       >
                         <SelectTrigger aria-label={t`Models from server`} className="mt-2 w-full">
@@ -308,7 +317,10 @@ export function OnboardingPage() {
                         variant="link"
                         size="xs"
                         className="mt-2 px-0 text-muted-foreground"
-                        onClick={() => setModelId(probeModels[0] ?? "")}
+                        onClick={() => {
+                          setManualModelId(false);
+                          setModelId(probeModels[0] ?? "");
+                        }}
                       >
                         <Trans>Use a found model</Trans>
                       </Button>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -4,24 +4,19 @@ import {
   openAiCompatibleConnectReady,
   openAiCompatibleProbeSuccessMessage,
 } from "@rakazo/contracts";
-import {
-  createModelProbe,
-  featuredModelProviders,
-  initialModelProbeState,
-  selectedProviderOutsideSearchResults,
-} from "@rakazo/core";
+import { createModelProbe, initialModelProbeState } from "@rakazo/core";
 import {
   Button,
   Input,
   ModelThinkingOptions,
-  NativeSelect,
-  NativeSelectOption,
-  Textarea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@rakazo/ui-web";
-import { Check } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { localizedProviderHint } from "../lib/localized-provider-hint";
 import type { ModelCatalogEntry } from "../lib/model-auth";
 import { rpc } from "../lib/rpc";
 import { useModelOAuthSignIn } from "../lib/use-model-oauth-signin";
@@ -32,8 +27,6 @@ export function OnboardingPage() {
   const fieldId = useId();
   const [step, setStep] = useState<"loading" | "model" | "bot">("loading");
   const [catalog, setCatalog] = useState<ModelCatalogEntry[]>([]);
-  const [query, setQuery] = useState("");
-  const [showAllProviders, setShowAllProviders] = useState(false);
   const [provider, setProvider] = useState("openrouter");
   const [modelId, setModelId] = useState("deepseek/deepseek-v4-flash-0731");
   const [apiKey, setApiKey] = useState("");
@@ -43,9 +36,7 @@ export function OnboardingPage() {
     useState(initialModelProbeState);
   const [modelProbe] = useState(() => createModelProbe(setProbe));
   const resetOpenAiCompatibleProbe = modelProbe.reset;
-  const [name, setName] = useState("");
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
+  const [creatingBot, setCreatingBot] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -95,38 +86,6 @@ export function OnboardingPage() {
     return [...seen.values()];
   }, [catalog]);
 
-  const filteredProviders = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return providers;
-    const matching = new Set(
-      catalog
-        .filter((entry) =>
-          `${entry.provider} ${entry.providerName ?? ""} ${entry.label} ${entry.id} ${entry.billing} ${entry.oauthLabel ?? ""}`
-            .toLowerCase()
-            .includes(q),
-        )
-        .map((entry) => entry.provider),
-    );
-    return providers.filter((entry) => matching.has(entry.provider));
-  }, [catalog, providers, query]);
-
-  const displayedProviders = useMemo(
-    () => (showAllProviders ? filteredProviders : featuredModelProviders(providers, provider)),
-    [filteredProviders, provider, providers, showAllProviders],
-  );
-
-  const selectedProviderOutsideResults = useMemo(
-    () =>
-      showAllProviders
-        ? selectedProviderOutsideSearchResults(filteredProviders, providers, provider)
-        : undefined,
-    [filteredProviders, provider, providers, showAllProviders],
-  );
-
-  const providerRows = selectedProviderOutsideResults
-    ? [selectedProviderOutsideResults, ...displayedProviders]
-    : displayedProviders;
-
   const modelsForProvider = useMemo(
     () => catalog.filter((entry) => entry.provider === provider),
     [catalog, provider],
@@ -153,6 +112,22 @@ export function OnboardingPage() {
   function updateApiKey(nextApiKey: string) {
     setApiKey(nextApiKey);
     resetOpenAiCompatibleProbe();
+  }
+
+  function selectProvider(nextProvider: string) {
+    if (nextProvider === provider) return;
+    cancelOAuthAttempt();
+    setProvider(nextProvider);
+    setModelId(
+      nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID
+        ? ""
+        : (catalog.find((item) => item.provider === nextProvider)?.id ?? ""),
+    );
+    setBaseUrl("");
+    setReasoning(false);
+    resetOpenAiCompatibleProbe();
+    setError(null);
+    setNotice(null);
   }
 
   async function probeServerModels() {
@@ -207,13 +182,15 @@ export function OnboardingPage() {
   }
 
   async function createBot() {
+    if (creatingBot) return;
+    setCreatingBot(true);
     setError(null);
     try {
       const bot = await rpc.bots.create({
-        name: name.trim(),
-        title,
-        description,
-        instructions: description,
+        name: "Chief",
+        title: "",
+        description: "",
+        instructions: "",
         notifyOnFinish: true,
       });
       // Onboarding continues conversationally in the thread: greeting first,
@@ -227,6 +204,7 @@ export function OnboardingPage() {
       }
       navigate(`/app/${bot.id}`);
     } catch (err) {
+      setCreatingBot(false);
       setError(err instanceof Error ? err.message : t`Could not create your bot`);
     }
   }
@@ -244,102 +222,25 @@ export function OnboardingPage() {
             <h1 className="text-[32px] font-medium text-foreground">
               <Trans>Connect a model</Trans>
             </h1>
-            <div className="mt-8 flex items-center justify-between gap-4">
-              <p className="text-sm font-medium text-foreground">
+            <div className="mt-8 block text-sm font-medium text-foreground">
+              <span>
                 <Trans>Provider</Trans>
-              </p>
-              <Button
-                variant="link"
-                size="xs"
-                className="px-0 text-muted-foreground"
-                onClick={() => {
-                  setShowAllProviders((current) => !current);
-                  setQuery("");
-                }}
-              >
-                {showAllProviders ? (
-                  <Trans>Show popular providers</Trans>
-                ) : (
-                  <Trans>Show all providers</Trans>
-                )}
-              </Button>
+              </span>
+              <Select value={provider} onValueChange={(value) => selectProvider(String(value))}>
+                <SelectTrigger aria-label={t`Provider`} className="mt-2 w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {providers.map((entry) => (
+                    <SelectItem key={entry.provider} value={entry.provider}>
+                      {entry.provider === "openai-codex"
+                        ? "ChatGPT"
+                        : (entry.providerName ?? entry.provider)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
-            {showAllProviders ? (
-              <Input
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                aria-label={t`Search providers and models`}
-                placeholder={t`Search providers and models`}
-                className="mt-3"
-              />
-            ) : null}
-            <fieldset
-              aria-label={t`Model providers`}
-              className={`mt-3 overflow-y-auto rounded-xl border border-border ${
-                showAllProviders ? "max-h-64" : ""
-              }`}
-            >
-              {providerRows.map((entry) => {
-                const isSelected = entry.provider === provider;
-                const isOutsideSearchResults =
-                  entry.provider === selectedProviderOutsideResults?.provider;
-                return (
-                  <button
-                    key={entry.provider}
-                    type="button"
-                    aria-pressed={isSelected}
-                    onClick={() => {
-                      if (isSelected) return;
-                      cancelOAuthAttempt();
-                      setProvider(entry.provider);
-                      setModelId(
-                        entry.provider === OPENAI_COMPATIBLE_PROVIDER_ID
-                          ? ""
-                          : (catalog.find((item) => item.provider === entry.provider)?.id ?? ""),
-                      );
-                      setBaseUrl("");
-                      setReasoning(false);
-                      resetOpenAiCompatibleProbe();
-                      setError(null);
-                      setNotice(null);
-                    }}
-                    className={`flex min-h-11 w-full items-center gap-3 border-b border-border px-3.5 py-2.5 text-left last:border-0 ${
-                      isSelected ? "bg-muted" : "hover:bg-accent"
-                    }`}
-                  >
-                    <span className="flex min-w-0 flex-1 items-center gap-2">
-                      <span
-                        className={`truncate text-[15px] text-foreground ${isSelected ? "font-medium" : ""}`}
-                      >
-                        {entry.provider === "openai-codex"
-                          ? "ChatGPT"
-                          : (entry.providerName ?? entry.provider)}
-                      </span>
-                      {isOutsideSearchResults ? (
-                        <span className="shrink-0 text-[11px] text-muted-foreground">
-                          <Trans>Selected</Trans>
-                        </span>
-                      ) : null}
-                    </span>
-                    <span className="text-[12px] text-muted-foreground">
-                      {localizedProviderHint(entry)}
-                    </span>
-                    <span className="flex size-5 shrink-0 items-center justify-center" aria-hidden>
-                      {isSelected ? (
-                        <span className="flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                          <Check className="size-3" strokeWidth={2.5} />
-                        </span>
-                      ) : null}
-                    </span>
-                  </button>
-                );
-              })}
-              {displayedProviders.length === 0 ? (
-                <p className="px-3.5 py-6 text-center text-sm text-muted-foreground">
-                  <Trans>No providers found</Trans>
-                </p>
-              ) : null}
-            </fieldset>
             <div className="mt-6 block text-sm text-foreground">
               {isOpenAiCompatible ? (
                 <>
@@ -355,14 +256,6 @@ export function OnboardingPage() {
                       className="mt-2"
                     />
                   </label>
-                  <details className="mt-2 text-[13px] leading-[1.5] text-muted-foreground">
-                    <summary className="w-fit cursor-pointer select-none">
-                      <Trans>Setup help</Trans>
-                    </summary>
-                    <p className="mt-1">
-                      {t`Paste the OpenAI-compatible address from your server. Rakazo adds /v1 if needed.`}
-                    </p>
-                  </details>
                   <div className="mt-3">
                     <Button
                       variant="outline"
@@ -377,21 +270,18 @@ export function OnboardingPage() {
                       <Trans>Model</Trans>
                     </span>
                     {probeModels.length && probeModels.includes(modelId) ? (
-                      <NativeSelect
-                        value={modelId}
-                        onChange={(e) => setModelId(e.target.value)}
-                        aria-label={t`Models from server`}
-                        className="mt-2 w-full"
-                      >
-                        {probeModels.map((id) => (
-                          <NativeSelectOption key={id} value={id}>
-                            {id}
-                          </NativeSelectOption>
-                        ))}
-                        <NativeSelectOption value="">
-                          <Trans>Other model…</Trans>
-                        </NativeSelectOption>
-                      </NativeSelect>
+                      <Select value={modelId} onValueChange={(value) => setModelId(String(value))}>
+                        <SelectTrigger aria-label={t`Models from server`} className="mt-2 w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {probeModels.map((id) => (
+                            <SelectItem key={id} value={id}>
+                              {id}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     ) : (
                       <Input
                         value={modelId}
@@ -424,21 +314,24 @@ export function OnboardingPage() {
                   <span className="font-medium">
                     <Trans>Model</Trans>
                   </span>
-                  <NativeSelect
+                  <Select
                     value={selected?.id ?? modelId}
-                    onChange={(e) => {
+                    onValueChange={(value) => {
                       cancelOAuthAttempt();
-                      setModelId(e.target.value);
+                      setModelId(String(value));
                     }}
-                    aria-label={t`Model`}
-                    className="mt-2 w-full"
                   >
-                    {modelsForProvider.map((entry) => (
-                      <NativeSelectOption key={`${entry.provider}:${entry.id}`} value={entry.id}>
-                        {entry.label}
-                      </NativeSelectOption>
-                    ))}
-                  </NativeSelect>
+                    <SelectTrigger aria-label={t`Model`} className="mt-2 w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {modelsForProvider.map((entry) => (
+                        <SelectItem key={`${entry.provider}:${entry.id}`} value={entry.id}>
+                          {entry.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </>
               )}
             </div>
@@ -546,14 +439,7 @@ export function OnboardingPage() {
                   />
                 </label>
               )
-            ) : subscriptionSignIn ? null : (
-              <p className="mt-4 text-sm text-muted-foreground">
-                <Trans>
-                  This provider cannot paste a key here. Skip if this deployment already has
-                  credentials.
-                </Trans>
-              </p>
-            )}
+            ) : null}
             {notice ? <p className="mt-3 text-sm text-success">{notice}</p> : null}
             {error ? <p className="mt-3 text-sm text-destructive">{error}</p> : null}
             <div className="mt-6 flex gap-3">
@@ -571,46 +457,9 @@ export function OnboardingPage() {
             <h1 className="text-[32px] font-medium text-foreground">
               <Trans>Create your first bot</Trans>
             </h1>
-            <label htmlFor={`${fieldId}-name`} className="mt-8 block text-sm text-muted-foreground">
-              <Trans>Name</Trans>
-              <Input
-                id={`${fieldId}-name`}
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder={t`Name this bot`}
-                className="mt-2"
-              />
-            </label>
-            <label
-              htmlFor={`${fieldId}-title`}
-              className="mt-4 block text-sm text-muted-foreground"
-            >
-              <Trans>Title</Trans>
-              <Input
-                id={`${fieldId}-title`}
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder={t`Describe what this bot does`}
-                className="mt-2"
-              />
-            </label>
-            <label
-              htmlFor={`${fieldId}-description`}
-              className="mt-4 block text-sm text-muted-foreground"
-            >
-              <Trans>Description</Trans>
-              <Textarea
-                id={`${fieldId}-description`}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder={t`What this bot is for`}
-                rows={4}
-                className="mt-2"
-              />
-            </label>
             {error ? <p className="mt-3 text-sm text-destructive">{error}</p> : null}
-            <Button className="mt-6" disabled={!name.trim()} onClick={() => void createBot()}>
-              <Trans>Continue</Trans>
+            <Button className="mt-8" disabled={creatingBot} onClick={() => void createBot()}>
+              {creatingBot ? <Trans>Creating…</Trans> : <Trans>Continue</Trans>}
             </Button>
           </div>
         ) : null}

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -128,7 +128,7 @@ export function OnboardingPage() {
 
   function updateBaseUrl(nextBaseUrl: string) {
     setBaseUrl(nextBaseUrl);
-    setManualModelId(false);
+    // Keep Other model… mode across URL edits; only provider change clears it.
     resetOpenAiCompatibleProbe();
     setError(null);
     setNotice(null);


### PR DESCRIPTION
## Why

The first-run path currently asks users to complete a bot profile form before they can reach the conversational setup, while model connection expands providers into a large list with a second native model picker. This is the onboarding noise called out in #553.

## What

- replace the provider list/search surface with the existing shadcn Select
- use the same Select surface for catalog and discovered model choices
- remove optional setup/explainer copy from the primary path
- replace the Name/Title/Description form with one-click creation of the existing `Chief` first-bot identity
- keep the conversational focus and app-connection onboarding unchanged after creation
- update the golden onboarding helpers and add request-payload coverage for form-free creation

## Tests

- `pnpm exec biome check apps/web/src/pages/Onboarding.tsx apps/web/e2e/helpers.ts apps/web/e2e/onboarding-model-labels.spec.ts apps/web/e2e/onboarding-model-auto-skip.spec.ts`
- `pnpm --filter @rakazo/web check`
- `pnpm --filter @rakazo/web test` (203 passed)
- `pnpm --filter @rakazo/web build`

The changed onboarding frames are captured by the Web E2E screenshot jobs in CI.

Closes #553.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Provider and model selection now use compact dropdowns with clearer model aliases.
  - OpenAI-compatible providers can display models discovered from a server.
  - Manual model entry remains available through “Other model…”.
  - Bot creation prevents duplicate submissions and shows a creating state.
  - Skipping model setup completes onboarding with a default “Chief” bot and opens its messaging view.

- **Changes**
  - Onboarding creates a default bot without requesting a name, title, or description.
  - Switching providers clears the API key and model-specific settings.
  - Discovered models can be replaced with a manually entered model ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->