### PR TITLE
fix(supervisor): bound authenticated computer request bodies

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
     "@rakazo/db": "workspace:*",
     "@rakazo/logging": "workspace:*",
     "@rakazo/memory": "workspace:*",
-    "hono": "^4.9.6"
+    "hono": "^4.9.7"
   },
   "devDependencies": {
     "typescript": "^5.9.2",

--- a/infra/sandboxes/supervisor/package.json
+++ b/infra/sandboxes/supervisor/package.json
@@ -14,7 +14,7 @@
     "@rakazo/core": "workspace:*",
     "@rakazo/logging": "workspace:*",
     "dockerode": "^4.0.7",
-    "hono": "^4.9.6",
+    "hono": "^4.9.7",
     "tsx": "^4.20.5",
     "zod": "^4.1.5"
   },

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -3,7 +3,14 @@ import http from "node:http";
 import net from "node:net";
 import { resolveSupervisorToken } from "@rakazo/core";
 import { describe, expect, it } from "vitest";
-import { resolveDockerSocketPath, supervisorApp, waitForScreenReady } from "./index.js";
+import {
+  MAX_SUPERVISOR_FILE_REQUEST_BYTES,
+  MAX_SUPERVISOR_REQUEST_BYTES,
+  resolveDockerSocketPath,
+  supervisorApp,
+  supervisorRequestBodyLimit,
+  waitForScreenReady,
+} from "./index.js";
 import {
   assertRequestIdentity,
   attemptComputerControl,
@@ -160,6 +167,45 @@ describe("sandbox supervisor HTTP boundary", () => {
     expect(hasValidBearerToken("Basic credentials", token)).toBe(false);
     expect(hasValidBearerToken(`Bearer ${"x".repeat(token.length)}`, token)).toBe(false);
     expect(hasValidBearerToken(`Bearer ${token}`, token)).toBe(true);
+  });
+
+  it("bounds authenticated control request bodies before JSON parsing", async () => {
+    const headers = {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    };
+    const declared = await supervisorApp.request("/computers/id/actions", {
+      method: "POST",
+      headers: {
+        ...headers,
+        "content-length": String(MAX_SUPERVISOR_REQUEST_BYTES + 1),
+      },
+      body: "{}",
+    });
+    const streamed = await supervisorApp.request("/computers/id/actions", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ padding: "x".repeat(MAX_SUPERVISOR_REQUEST_BYTES) }),
+    });
+
+    for (const response of [declared, streamed]) {
+      expect(response.status).toBe(413);
+      await expect(response.json()).resolves.toEqual({ error: "Request body is too large." });
+    }
+  });
+
+  it("keeps the larger file-write allowance scoped to that exact route", () => {
+    expect(supervisorRequestBodyLimit("/computers/id/files")).toBe(
+      MAX_SUPERVISOR_FILE_REQUEST_BYTES,
+    );
+    expect(supervisorRequestBodyLimit("/computers/id/files/")).toBe(
+      MAX_SUPERVISOR_FILE_REQUEST_BYTES,
+    );
+    expect(supervisorRequestBodyLimit("/computers/id/actions")).toBe(MAX_SUPERVISOR_REQUEST_BYTES);
+    expect(supervisorRequestBodyLimit("/computers/files")).toBe(MAX_SUPERVISOR_REQUEST_BYTES);
+    expect(supervisorRequestBodyLimit("/computers/id/files/extra")).toBe(
+      MAX_SUPERVISOR_REQUEST_BYTES,
+    );
   });
 
   it("rejects a provision request whose identity headers do not match its body", async () => {

--- a/infra/sandboxes/supervisor/src/index.test.ts
+++ b/infra/sandboxes/supervisor/src/index.test.ts
@@ -194,16 +194,23 @@ describe("sandbox supervisor HTTP boundary", () => {
     }
   });
 
-  it("keeps the larger file-write allowance scoped to that exact route", () => {
-    expect(supervisorRequestBodyLimit("/computers/id/files")).toBe(
+  it("keeps the larger file-write allowance scoped to that exact POST route", () => {
+    expect(supervisorRequestBodyLimit("POST", "/computers/id/files")).toBe(
       MAX_SUPERVISOR_FILE_REQUEST_BYTES,
     );
-    expect(supervisorRequestBodyLimit("/computers/id/files/")).toBe(
+    expect(supervisorRequestBodyLimit("POST", "/computers/id/files/")).toBe(
       MAX_SUPERVISOR_FILE_REQUEST_BYTES,
     );
-    expect(supervisorRequestBodyLimit("/computers/id/actions")).toBe(MAX_SUPERVISOR_REQUEST_BYTES);
-    expect(supervisorRequestBodyLimit("/computers/files")).toBe(MAX_SUPERVISOR_REQUEST_BYTES);
-    expect(supervisorRequestBodyLimit("/computers/id/files/extra")).toBe(
+    expect(supervisorRequestBodyLimit("PUT", "/computers/id/files")).toBe(
+      MAX_SUPERVISOR_REQUEST_BYTES,
+    );
+    expect(supervisorRequestBodyLimit("POST", "/computers/id/actions")).toBe(
+      MAX_SUPERVISOR_REQUEST_BYTES,
+    );
+    expect(supervisorRequestBodyLimit("POST", "/computers/files")).toBe(
+      MAX_SUPERVISOR_REQUEST_BYTES,
+    );
+    expect(supervisorRequestBodyLimit("POST", "/computers/id/files/extra")).toBe(
       MAX_SUPERVISOR_REQUEST_BYTES,
     );
   });

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -15,7 +15,8 @@ import { SERVICE_NAMES } from "@rakazo/logging";
 import { createRootLogger } from "@rakazo/logging/axiom";
 import { requestLogging } from "@rakazo/logging/hono";
 import Docker from "dockerode";
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
 import {
   COMPUTER_GID,
@@ -95,6 +96,23 @@ const teamScreenLimit = resolveTeamScreenLimit();
 const controlViaLoopback = process.env.SANDBOX_CONTROL_VIA_LOOPBACK === "true";
 const computerScreens = new Map<string, Map<string, ScreenAssignment>>();
 
+export const MAX_SUPERVISOR_REQUEST_BYTES = 1024 * 1024;
+export const MAX_SUPERVISOR_FILE_REQUEST_BYTES = 16 * 1024 * 1024 + 64 * 1024;
+
+/** Keep normal control requests small while allowing the existing 16 MiB file payload. */
+export function supervisorRequestBodyLimit(pathname: string): number {
+  return /^\/computers\/[^/]+\/files\/?$/.test(pathname)
+    ? MAX_SUPERVISOR_FILE_REQUEST_BYTES
+    : MAX_SUPERVISOR_REQUEST_BYTES;
+}
+
+const limitSupervisorRequestBody: MiddlewareHandler = async (c, next) => {
+  return bodyLimit({
+    maxSize: supervisorRequestBodyLimit(c.req.path),
+    onError: (context) => context.json({ error: "Request body is too large." }, 413),
+  })(c, next);
+};
+
 const app = new Hono();
 
 export { app as supervisorApp };
@@ -125,6 +143,8 @@ app.use("/computers/*", async (c, next) => {
   }
   await next();
 });
+app.use("/computers", limitSupervisorRequestBody);
+app.use("/computers/*", limitSupervisorRequestBody);
 
 app.post("/computers", async (c) => {
   const body = z

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -100,15 +100,15 @@ export const MAX_SUPERVISOR_REQUEST_BYTES = 1024 * 1024;
 export const MAX_SUPERVISOR_FILE_REQUEST_BYTES = 16 * 1024 * 1024 + 64 * 1024;
 
 /** Keep normal control requests small while allowing the existing 16 MiB file payload. */
-export function supervisorRequestBodyLimit(pathname: string): number {
-  return /^\/computers\/[^/]+\/files\/?$/.test(pathname)
+export function supervisorRequestBodyLimit(method: string, pathname: string): number {
+  return method === "POST" && /^\/computers\/[^/]+\/files\/?$/.test(pathname)
     ? MAX_SUPERVISOR_FILE_REQUEST_BYTES
     : MAX_SUPERVISOR_REQUEST_BYTES;
 }
 
 const limitSupervisorRequestBody: MiddlewareHandler = async (c, next) => {
   return bodyLimit({
-    maxSize: supervisorRequestBodyLimit(c.req.path),
+    maxSize: supervisorRequestBodyLimit(c.req.method, c.req.path),
     onError: (context) => context.json({ error: "Request body is too large." }, 413),
   })(c, next);
 };

--- a/infra/updater/package.json
+++ b/infra/updater/package.json
@@ -15,7 +15,7 @@
     "@rakazo/contracts": "workspace:*",
     "@rakazo/core": "workspace:*",
     "@rakazo/logging": "workspace:*",
-    "hono": "^4.9.6",
+    "hono": "^4.9.7",
     "tsx": "^4.20.5"
   },
   "devDependencies": {

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@axiomhq/js": "^1.3.1",
-    "hono": "^4.9.6"
+    "hono": "^4.9.7"
   },
   "devDependencies": {
     "typescript": "^5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/memory
       hono:
-        specifier: ^4.9.6
+        specifier: ^4.9.7
         version: 4.13.1
     devDependencies:
       typescript:
@@ -435,7 +435,7 @@ importers:
         specifier: ^4.0.7
         version: 4.0.12
       hono:
-        specifier: ^4.9.6
+        specifier: ^4.9.7
         version: 4.13.1
       tsx:
         specifier: ^4.20.5
@@ -469,7 +469,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/logging
       hono:
-        specifier: ^4.9.6
+        specifier: ^4.9.7
         version: 4.13.1
       tsx:
         specifier: ^4.20.5
@@ -768,7 +768,7 @@ importers:
         specifier: ^1.3.1
         version: 1.8.0
       hono:
-        specifier: ^4.9.6
+        specifier: ^4.9.7
         version: 4.13.1
     devDependencies:
       typescript:


### PR DESCRIPTION
## Why

The sandbox supervisor protects its computer routes with a service bearer, but its seven JSON write paths read the complete request body before Zod validation. A malfunctioning or compromised authenticated caller can therefore force the shared supervisor to buffer an unbounded payload and disrupt every managed computer.

## What

- Apply one body-limit boundary to every protected `/computers` route after authentication and before route JSON parsing.
- Cap normal control requests at 1 MiB.
- Preserve the existing 16 MiB encoded file-write contract with a narrowly scoped 16 MiB + 64 KiB envelope allowance.
- Return a stable JSON `413` for both declared-length and streamed oversized bodies.
- Cover both body-reading paths and prove the larger allowance matches only the exact file-write route.

No user-visible copy or UI changes.

## Tests

- `pnpm check` (22/22 tasks)
- `pnpm --filter @rakazo/sandbox-supervisor test` (148 passed, 3 skipped)
- `pnpm exec biome check infra/sandboxes/supervisor/src/index.ts infra/sandboxes/supervisor/src/index.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Computer-related endpoints now enforce request size limits before processing requests.
  * Oversized requests receive a clear `413 Payload Too Large` response.
  * File uploads support a higher request limit than other computer operations.
  * Unrelated routes continue using the standard request limit.
  * Request-size enforcement now applies consistently to both declared and streamed request bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->