### PR TITLE
chore: prepare desktop 0.1.2 and mobile 1.0.1 releases

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rakazo/desktop",
   "productName": "Rakazo",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/main.js",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -4,7 +4,7 @@
     "slug": "rakazo",
     "owner": "inbox-zero",
     "scheme": "rakazo",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "userInterfaceStyle": "dark",
     "icon": "./assets/icon.png",


### PR DESCRIPTION
Prepare the next stable desktop and server release and a fresh mobile native runtime. Native dependencies have changed since the previous mobile store builds, so the mobile update needs new binaries.

Bump the desktop version to 0.1.2 for the v0.1.2 release tag and the Expo app version to 1.0.1 so new builds and compatible OTA updates share a new runtime. EAS production build numbers remain remotely managed and auto-incremented.

Validation: Expo dependency compatibility check passed; all 255 desktop unit tests passed. Full CI must pass before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the desktop app version to 0.1.2.
  - Updated the mobile app version to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->