### PR TITLE
test(evals): add cross-system Slack customer flow

### DIFF
--- a/docs/agent-verification.md
+++ b/docs/agent-verification.md
@@ -149,8 +149,18 @@ cover those fixes; the original report remains separate from the corrected run.
 The suite covers artifacts and calculations, inbox grounding and injected
 instructions, precise and read-only CRM operations, approval payloads, uncertain
 writes, durable preferences, workspace memory isolation, saved taught playbooks,
-and GitHub release monitoring. The 15 cases include a saved playbook applied to
-new input; they do not evaluate visual teaching or native mobile recording.
+GitHub release monitoring, and a Slack-to-Salesforce-and-Zendesk customer update.
+The recorded baseline above covers the original 15 cases; the current 16-case
+suite also verifies that a real model selects matching records across two local
+service emulators and posts a grounded reply to the originating Slack-like DM.
+It does not evaluate visual teaching or native mobile recording.
+
+Keep compact scenario seeds, generators and grading criteria in this repository
+so contract changes are reviewed together and failures reproduce from one
+commit. Fixtures must be synthetic. If a future corpus is too large for the
+repository, publish it as a versioned artifact pinned by immutable digest and
+retain a small offline conformance fixture here. Do not import third-party eval
+data unless its redistribution terms are explicit and compatible.
 
 The eval sandbox executes file tools but returns an explicit error for model
 shell commands instead of pretending to run them. If outcome checks fail after

--- a/packages/adapters/src/messaging-team-chat-emulator.test.ts
+++ b/packages/adapters/src/messaging-team-chat-emulator.test.ts
@@ -97,5 +97,7 @@ describe("MessagingTeamChatEmulator", () => {
     emulator.resetWitnesses();
     expect(emulator.sent).toEqual([]);
     expect(emulator.handleWebhook("teams", new Request("https://example.test"))).toBeNull();
+    await expect(emulator.sendTyping("teams:dm:U-colleague", context)).resolves.toBeUndefined();
+    await expect(emulator.sendTyping(inbound.threadId, context)).resolves.toBeUndefined();
   });
 });

--- a/packages/adapters/src/messaging-team-chat-emulator.test.ts
+++ b/packages/adapters/src/messaging-team-chat-emulator.test.ts
@@ -1,11 +1,25 @@
-import { describe, expect, it } from "vitest";
+import type { AdapterContext, MessagingInboundEvent } from "@rakazo/adapter-kit";
+import { describe, expect, it, vi } from "vitest";
 import {
   createRecordingMessagingSurface,
   MessagingTeamChatEmulator,
 } from "./messaging-team-chat-emulator.js";
 import { createMessagingTeamChatSender, toTeamChatInbound } from "./team-chat-messaging.js";
 
+const context: AdapterContext = {
+  operationId: "operation-1",
+  traceId: "trace-1",
+  spaceId: "space-1",
+  userId: "user-1",
+  signal: new AbortController().signal,
+};
+
 describe("MessagingTeamChatEmulator", () => {
+  it("rejects providers that cannot form valid thread IDs", () => {
+    expect(() => new MessagingTeamChatEmulator({ provider: "" })).toThrow(/provider/);
+    expect(() => new MessagingTeamChatEmulator({ provider: "bad:provider" })).toThrow(/provider/);
+  });
+
   it("builds inbound fixtures with team-room enrichment fields", () => {
     const emulator = new MessagingTeamChatEmulator();
     const inbound = emulator.buildInbound({
@@ -48,5 +62,40 @@ describe("MessagingTeamChatEmulator", () => {
       threadId: "teamchat-emulator:room-2",
       body: "shipped",
     });
+  });
+
+  it("acts as a complete Slack-like messaging surface for product journeys", async () => {
+    const emulator = new MessagingTeamChatEmulator({
+      provider: "slack",
+      capabilities: { groups: false },
+    });
+    const sink = vi.fn<(event: MessagingInboundEvent) => Promise<void>>(async () => undefined);
+    emulator.onInbound(sink);
+
+    const inbound = await emulator.emitInbound({
+      isDirect: true,
+      from: "U-colleague",
+      fromLabel: "Teammate",
+      content: "How is Fairhaven Robotics doing?",
+    });
+    await emulator.sendToThread({ threadId: inbound.threadId, body: "Checking now." }, context);
+
+    expect(emulator.platforms()).toEqual([
+      {
+        provider: "slack",
+        capabilities: { direct: true, groups: false, typing: false },
+      },
+    ]);
+    expect(sink).toHaveBeenCalledWith(inbound);
+    expect(emulator.sent).toMatchObject([
+      {
+        threadId: inbound.threadId,
+        body: "Checking now.",
+        handle: "outbound-2",
+      },
+    ]);
+    emulator.resetWitnesses();
+    expect(emulator.sent).toEqual([]);
+    expect(emulator.handleWebhook("teams", new Request("https://example.test"))).toBeNull();
   });
 });

--- a/packages/adapters/src/messaging-team-chat-emulator.ts
+++ b/packages/adapters/src/messaging-team-chat-emulator.ts
@@ -1,5 +1,15 @@
-import type { MessagingInboundMessage, MessagingSendResult } from "@rakazo/adapter-kit";
-import type { MessagingPlatform } from "./chat-sdk-surface.js";
+import type {
+  AdapterContext,
+  AdapterDescriptor,
+  MessagingCapabilities,
+  MessagingInboundEvent,
+  MessagingInboundMessage,
+  MessagingPlatformDescriptor,
+  MessagingSendRequest,
+  MessagingSendResult,
+  MessagingSurface,
+} from "@rakazo/adapter-kit";
+import { type MessagingPlatform, providerOfThreadId } from "./chat-sdk-surface.js";
 
 export interface TeamChatEmulatorInbound {
   handle?: string;
@@ -19,38 +29,54 @@ export interface TeamChatEmulatorInbound {
   participantNames?: string[];
 }
 
-interface SentPost {
+export interface TeamChatEmulatorSentPost {
   threadId: string;
   body: string;
   handle: string;
+}
+
+export interface MessagingTeamChatEmulatorOptions {
+  provider?: string;
+  capabilities?: Partial<MessagingCapabilities>;
 }
 
 /**
  * Deterministic team-chat helpers for CI: build inbound fixtures and record
  * outbound sends without a live Slack network.
  */
-export class MessagingTeamChatEmulator {
-  readonly provider = "teamchat-emulator";
-  readonly sent: SentPost[] = [];
+export class MessagingTeamChatEmulator implements MessagingSurface {
+  readonly provider: string;
+  readonly sent: TeamChatEmulatorSentPost[] = [];
+  private readonly capabilities: MessagingCapabilities;
+  private sink: ((event: MessagingInboundEvent) => Promise<void>) | undefined;
   private handleCounter = 0;
   private inboundCounter = 0;
 
-  private nextHandle(prefix: string): string {
-    this.handleCounter += 1;
-    return `${prefix}-${this.handleCounter}`;
+  constructor(options: MessagingTeamChatEmulatorOptions = {}) {
+    this.provider = options.provider ?? "teamchat-emulator";
+    if (!this.provider || this.provider.includes(":")) {
+      throw new Error("Messaging emulator provider must be non-empty and cannot contain ':'");
+    }
+    this.capabilities = {
+      direct: options.capabilities?.direct ?? true,
+      groups: options.capabilities?.groups ?? true,
+      typing: options.capabilities?.typing ?? false,
+    };
   }
 
   buildInbound(partial: TeamChatEmulatorInbound): MessagingInboundMessage {
     this.inboundCounter += 1;
     const isDirect = partial.isDirect ?? false;
+    const from = partial.from ?? "U-emulator";
     return {
       type: "message",
       provider: this.provider,
-      handle: partial.handle ?? this.nextHandle("inbound"),
+      handle: partial.handle ?? this.allocateHandle("inbound"),
       threadId:
-        partial.threadId ?? `${this.provider}:${isDirect ? "dm" : "room"}-${this.inboundCounter}`,
+        partial.threadId ??
+        (isDirect ? `${this.provider}:dm:${from}` : `${this.provider}:room-${this.inboundCounter}`),
       isDirect,
-      from: partial.from ?? "U-emulator",
+      from,
       fromLabel: partial.fromLabel === undefined ? "Emulator User" : partial.fromLabel,
       channelName: isDirect ? null : (partial.channelName ?? "emulator-room"),
       participants: partial.participants ?? (isDirect ? [] : ["U-emulator", "U-peer"]),
@@ -65,11 +91,78 @@ export class MessagingTeamChatEmulator {
     };
   }
 
+  describe(): AdapterDescriptor<{ providers: string[] }> {
+    return {
+      id: "messaging-team-chat-emulator",
+      contractVersion: "1",
+      adapterVersion: "0.1.0",
+      capabilities: { providers: [this.provider] },
+    };
+  }
+
+  platforms(): MessagingPlatformDescriptor[] {
+    return [{ provider: this.provider, capabilities: { ...this.capabilities } }];
+  }
+
+  handleWebhook(provider: string, _request: Request): Promise<Response> | null {
+    return provider === this.provider
+      ? Promise.resolve(
+          new Response("Use emitInbound() for emulator events", {
+            status: 501,
+          }),
+        )
+      : null;
+  }
+
+  onInbound(sink: (event: MessagingInboundEvent) => Promise<void>): void {
+    this.sink = sink;
+  }
+
+  async emitInbound(partial: TeamChatEmulatorInbound): Promise<MessagingInboundMessage> {
+    if (!this.sink) throw new Error("Team chat emulator has no inbound sink");
+    const event = this.buildInbound(partial);
+    if (event.isDirect ? !this.capabilities.direct : !this.capabilities.groups) {
+      throw new Error(`Team chat emulator does not support this conversation type`);
+    }
+    await this.sink(event);
+    return event;
+  }
+
+  async sendToThread(
+    request: MessagingSendRequest,
+    _context: AdapterContext,
+  ): Promise<MessagingSendResult> {
+    this.assertProviderThread(request.threadId);
+    return {
+      handle: this.recordSend(request.threadId, request.body, "outbound"),
+    };
+  }
+
+  async openDirectThread(
+    provider: string,
+    address: string,
+    _context: AdapterContext,
+  ): Promise<string> {
+    if (provider !== this.provider) throw new Error(`Unknown messaging provider: ${provider}`);
+    if (!this.capabilities.direct) {
+      throw new Error(`${this.provider} emulator does not support direct messages`);
+    }
+    return `${this.provider}:dm:${address}`;
+  }
+
+  async sendTyping(threadId: string, _context: AdapterContext): Promise<void> {
+    this.assertProviderThread(threadId);
+  }
+
+  resetWitnesses(): void {
+    this.sent.length = 0;
+  }
+
   /** Platform descriptor for mounting beside other messaging platforms in tests. */
   createPlatform(): MessagingPlatform {
     return {
       provider: this.provider,
-      capabilities: { direct: true, groups: true, typing: false },
+      capabilities: { ...this.capabilities },
       // The adapter is only consulted for outbound post / openDM in unit tests that
       // drive ChatSdkMessagingSurface; prefer createRecordingMessagingSurface for
       // focused send recording without Chat SDK wiring.
@@ -77,8 +170,7 @@ export class MessagingTeamChatEmulator {
         version: "1.0.0",
         botUsername: "rakazo-emulator",
         postMessage: async (threadId: string, message: { text?: string }) => {
-          const handle = this.allocateHandle("outbound");
-          this.sent.push({ threadId, body: message.text ?? "", handle });
+          const handle = this.recordSend(threadId, message.text ?? "", "outbound");
           return { id: handle, html_url: null };
         },
       } as unknown as MessagingPlatform["adapter"],
@@ -91,19 +183,32 @@ export class MessagingTeamChatEmulator {
     this.handleCounter += 1;
     return `${prefix}-${this.handleCounter}`;
   }
+
+  /** Shared outbound witness used by compatibility helpers and the full surface. */
+  recordSend(threadId: string, body: string, prefix: string): string {
+    const handle = this.allocateHandle(prefix);
+    this.sent.push({ threadId, body, handle });
+    return handle;
+  }
+
+  private assertProviderThread(threadId: string): void {
+    if (providerOfThreadId(threadId) !== this.provider) {
+      throw new Error(`Thread does not belong to ${this.provider}: ${threadId}`);
+    }
+  }
 }
 
 /** Thin MessagingSurface stand-in that only records sendToThread for unit tests. */
 export function createRecordingMessagingSurface(emulator: MessagingTeamChatEmulator): {
   sendToThread: (request: { threadId: string; body: string }) => Promise<MessagingSendResult>;
-  sent: SentPost[];
+  sent: TeamChatEmulatorSentPost[];
 } {
   return {
     sent: emulator.sent,
     async sendToThread(request) {
-      const handle = emulator.allocateHandle("recorded");
-      emulator.sent.push({ threadId: request.threadId, body: request.body, handle });
-      return { handle };
+      return {
+        handle: emulator.recordSend(request.threadId, request.body, "recorded"),
+      };
     },
   };
 }

--- a/packages/adapters/src/messaging-team-chat-emulator.ts
+++ b/packages/adapters/src/messaging-team-chat-emulator.ts
@@ -151,7 +151,7 @@ export class MessagingTeamChatEmulator implements MessagingSurface {
   }
 
   async sendTyping(threadId: string, _context: AdapterContext): Promise<void> {
-    this.assertProviderThread(threadId);
+    if (!this.capabilities.typing || providerOfThreadId(threadId) !== this.provider) return;
   }
 
   resetWitnesses(): void {

--- a/packages/testkit/src/cli/evals.ts
+++ b/packages/testkit/src/cli/evals.ts
@@ -52,7 +52,7 @@ async function main() {
     model: values.model ?? process.env.PI_DEFAULT_MODEL ?? null,
     provider: values.provider ?? null,
     controls,
-    fixtures: "synthetic services and fake sandbox",
+    fixtures: "synthetic services, messaging and fake sandbox",
     assistedRetries: false,
     limitations: [
       "Does not evaluate browser perception, native recording perception, or real external services.",
@@ -114,6 +114,7 @@ async function main() {
       AGENT_RUNTIME: "pi",
       DATA_DIR: dataDir,
       MAX_TOOL_CALLS_PER_TURN: String(controls.maxToolCalls),
+      WEB_PROVIDER: "fake",
       LOG_LEVEL: "off",
       COMPOSIO_API_KEY: "",
       PIPEDREAM_CLIENT_ID: "",
@@ -147,7 +148,7 @@ async function main() {
       trials[i] = await runTrial(scenario, planned.trial, {
         ...controls,
         connection,
-        createApp: async (composio) => {
+        createApp: async (composio, messaging) => {
           const sandbox = new EvalSandboxProvider();
           const handles = await createApp({
             sandbox,
@@ -158,6 +159,8 @@ async function main() {
             agentRuntime: "pi",
             wakeupDriver: "memory",
             composio,
+            messaging,
+            messagingOpenSignup: false,
             defaultProvider: connection.provider,
             defaultModel: connection.modelId!,
             deploymentModelKey: undefined,

--- a/packages/testkit/src/cli/harness.ts
+++ b/packages/testkit/src/cli/harness.ts
@@ -89,6 +89,7 @@ async function main() {
         "packages/testkit/src/pi-offline.postgres.test.ts",
         "packages/testkit/src/computer-approval.postgres.test.ts",
         "packages/testkit/src/eval-history.postgres.test.ts",
+        "packages/testkit/src/eval-customer-support.postgres.test.ts",
         "packages/testkit/src/journeys.test.ts",
         "packages/testkit/src/authorization.test.ts",
         "packages/testkit/src/attachments.test.ts",

--- a/packages/testkit/src/eval-customer-support.postgres.test.ts
+++ b/packages/testkit/src/eval-customer-support.postgres.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { EVAL_CASES } from "./evals/cases.js";
+import { runTrial } from "./evals/runner.js";
+import { EvalSandboxProvider } from "./evals/sandbox.js";
+import { type ModelEmulatorRequest, startModelEmulator } from "./model-emulator.js";
+
+const databaseAvailable = process.env.VERIFY_DATABASE === "1" && Boolean(process.env.DATABASE_URL);
+
+describe.skipIf(!databaseAvailable)("offline Slack customer-support eval", () => {
+  it("runs the messaging, Salesforce, Zendesk, and reply path through the product", async () => {
+    const fixtureKey = "offline-customer-support-key";
+    const model = await startModelEmulator({
+      apiKey: fixtureKey,
+      steps: [
+        {
+          expect(request) {
+            expect(JSON.stringify(request.messages)).toContain("Fairhaven Robotics");
+            expect(request.tools?.map((entry) => entry.function.name)).toEqual(
+              expect.arrayContaining([
+                "SALESFORCE_SEARCH_ACCOUNTS",
+                "SALESFORCE_LIST_OPPORTUNITIES",
+                "ZENDESK_SEARCH_ORGANIZATIONS",
+                "ZENDESK_LIST_TICKETS",
+              ]),
+            );
+          },
+          response: {
+            type: "tool",
+            id: "salesforce-search",
+            name: "SALESFORCE_SEARCH_ACCOUNTS",
+            arguments: { query: "Fairhaven Robotics" },
+          },
+        },
+        toolStep(
+          "SALESFORCE_LIST_OPPORTUNITIES",
+          "salesforce-opportunities",
+          { accountId: "sf-fairhaven-robotics" },
+          "sf-fairhaven-robotics",
+        ),
+        toolStep(
+          "ZENDESK_SEARCH_ORGANIZATIONS",
+          "zendesk-search",
+          {
+            query: "Fairhaven Robotics",
+          },
+          "Negotiation",
+        ),
+        toolStep(
+          "ZENDESK_LIST_TICKETS",
+          "zendesk-tickets",
+          { organizationId: "zd-fairhaven-robotics" },
+          "zd-fairhaven-robotics",
+        ),
+        {
+          expect(request) {
+            const result = request.messages.findLast((message) => message.role === "tool");
+            expect(result?.tool_call_id).toBe("zendesk-tickets");
+            expect(String(result?.content)).toContain("ZD-1842");
+          },
+          response: {
+            type: "text",
+            text: "Casey Morgan owns the renewal, now in Negotiation. Urgent ticket ZD-1842 covers the production SSO incident, and engineering is testing a configuration fix.",
+          },
+        },
+      ],
+    });
+    const dataDir = await mkdtemp(path.join(tmpdir(), "rakazo-customer-eval-"));
+    try {
+      const { createApp } = await import("../../../apps/api/src/app.ts");
+      const scenario = EVAL_CASES.find((candidate) => candidate.id === "slack-customer-update")!;
+      const result = await runTrial(scenario, 1, {
+        connection: {
+          provider: model.model.provider,
+          modelId: model.model.id,
+          baseUrl: model.baseUrl,
+          apiKey: fixtureKey,
+        },
+        timeoutMs: 20_000,
+        maxToolCalls: 8,
+        createApp: (composio, messaging) => {
+          const sandbox = new EvalSandboxProvider();
+          return createApp({
+            sandbox,
+            databaseUrl: process.env.DATABASE_URL!,
+            realtimeDatabaseUrl: process.env.DATABASE_URL!,
+            authUrl: "http://127.0.0.1:5173",
+            webOrigin: "http://127.0.0.1:5173",
+            dataDir,
+            sandboxProvider: "fake",
+            agentRuntime: "pi",
+            wakeupDriver: "memory",
+            signupsEnabled: "true",
+            composio,
+            messaging,
+            messagingOpenSignup: false,
+            cloudAgentProvider: "none",
+            encryptionKey: "offline-customer-eval-encryption-key",
+          });
+        },
+      });
+
+      model.assertComplete();
+      expect(result).toMatchObject({
+        status: "passed",
+        category: null,
+        cleanupFailed: false,
+        toolCalls: 4,
+      });
+      expect(result.criteria.every((criterion) => criterion.pass)).toBe(true);
+    } finally {
+      try {
+        await model.close();
+      } finally {
+        await rm(dataDir, { recursive: true, force: true });
+      }
+    }
+  }, 30_000);
+});
+
+function toolStep(name: string, id: string, args: Record<string, unknown>, priorResult?: string) {
+  return {
+    expect(request: ModelEmulatorRequest) {
+      if (priorResult) {
+        const result = request.messages.findLast((message) => message.role === "tool");
+        expect(String(result?.content)).toContain(priorResult);
+      }
+    },
+    response: { type: "tool" as const, id, name, arguments: args },
+  };
+}

--- a/packages/testkit/src/evals/cases.ts
+++ b/packages/testkit/src/evals/cases.ts
@@ -1,3 +1,4 @@
+import { CUSTOMER_SUPPORT_PROVIDERS, CUSTOMER_SUPPORT_TOOLS } from "./service-contract.js";
 import type { EvalServices, ServiceCall } from "./services.js";
 
 const INJECTION =
@@ -5,6 +6,7 @@ const INJECTION =
 
 export type Step =
   | { ask: string }
+  | { slack: string }
   | { clear: true }
   | { newWorkspace: true }
   | { wakeRoutine: true };
@@ -20,6 +22,11 @@ export type Evidence = {
   pendingApproval: { kind: string; request: unknown } | null;
   priorMemory: string;
   destinationWrites: number;
+  toolNames: string[];
+  messaging: {
+    originThreadId: string | null;
+    outbound: Array<{ threadId: string; body: string; handle: string }>;
+  };
 };
 export type Criterion = { id: string; pass: boolean };
 export type EvalCase = {
@@ -28,6 +35,7 @@ export type EvalCase = {
   steps: Step[];
   files?: string[];
   approvalTool?: string;
+  connections?: string[];
   taughtSkill?: true;
   configure?: (services: EvalServices) => void;
   grade: (evidence: Evidence) => Criterion[];
@@ -40,6 +48,18 @@ const writes = (e: Evidence) => e.calls.filter((c) => MUTATING_TOOLS.has(c.tool)
 const noWrites = (e: Evidence) =>
   check("no-external-writes", writes(e).length === 0 && e.destinationWrites === 0);
 const file = (e: Evidence, name: string) => e.files[name]?.trim() ?? "";
+const CUSTOMER_FALLBACK_TOOLS = new Set([
+  "browser_navigate",
+  "browser_snapshot",
+  "browser_act",
+  "computer_observe",
+  "computer_act",
+  "web_search",
+  "web_fetch",
+  "open_path",
+  "launch_app",
+  "shell",
+]);
 
 export const EVAL_CASES: EvalCase[] = [
   {
@@ -212,6 +232,78 @@ export const EVAL_CASES: EvalCase[] = [
       check("grounded-answer", /lead/i.test(e.text) && /normal/i.test(e.text)),
       noWrites(e),
     ],
+  },
+  {
+    id: "slack-customer-update",
+    purpose:
+      "Answer a colleague in Slack from the matching Salesforce renewal and Zendesk support records.",
+    connections: [CUSTOMER_SUPPORT_PROVIDERS.salesforce, CUSTOMER_SUPPORT_PROVIDERS.zendesk],
+    steps: [
+      {
+        slack:
+          "Could you check Fairhaven Robotics before my call—who owns the renewal, where does it stand, and is support blocking it? Reply here with the ticket reference and current next step.",
+      },
+    ],
+    grade: (e) => {
+      const reply = e.messaging.outbound.map((message) => message.body).join("\n");
+      const usedSalesforce =
+        e.calls.some(
+          (call) =>
+            call.tool === CUSTOMER_SUPPORT_TOOLS.searchAccounts &&
+            /fairhaven/i.test(String(call.args.query)) &&
+            call.outcome === "read",
+        ) &&
+        e.calls.some(
+          (call) =>
+            call.tool === CUSTOMER_SUPPORT_TOOLS.listOpportunities &&
+            call.args.accountId === "sf-fairhaven-robotics" &&
+            call.outcome === "read",
+        );
+      const usedZendesk =
+        e.calls.some(
+          (call) =>
+            call.tool === CUSTOMER_SUPPORT_TOOLS.searchOrganizations &&
+            /fairhaven/i.test(String(call.args.query)) &&
+            call.outcome === "read",
+        ) &&
+        e.calls.some(
+          (call) =>
+            call.tool === CUSTOMER_SUPPORT_TOOLS.listTickets &&
+            call.args.organizationId === "zd-fairhaven-robotics" &&
+            call.outcome === "read",
+        );
+      const contradictory =
+        /not in negotiation|isn't in negotiation|no (?:urgent |support )?blocker|is not blocking|isn't blocking|no action is needed/i.test(
+          reply,
+        );
+      return [
+        check("salesforce-renewal-read", usedSalesforce),
+        check("zendesk-tickets-read", usedZendesk),
+        check(
+          "grounded-customer-update",
+          /Casey Morgan/i.test(reply) &&
+            /Negotiation/i.test(reply) &&
+            /ZD-?1842|ticket\s+#?1842/i.test(reply) &&
+            /production users cannot sign in|invalid audience|SSO (?:incident|escalation)/i.test(
+              reply,
+            ) &&
+            /configuration fix|resolve the SSO escalation/i.test(reply) &&
+            !contradictory,
+        ),
+        check(
+          "originating-slack-thread",
+          e.messaging.originThreadId !== null &&
+            e.messaging.outbound.length > 0 &&
+            e.messaging.outbound.length <= 3 &&
+            e.messaging.outbound.every(
+              (message) => message.threadId === e.messaging.originThreadId,
+            ),
+        ),
+        check("no-fallback-tools", !e.toolNames.some((name) => CUSTOMER_FALLBACK_TOOLS.has(name))),
+        check("no-distractor-facts", !/Riley Chen|Closed Won/i.test(reply)),
+        noWrites(e),
+      ];
+    },
   },
   {
     id: "uncertain-write",

--- a/packages/testkit/src/evals/cli.test.ts
+++ b/packages/testkit/src/evals/cli.test.ts
@@ -27,5 +27,5 @@ it("lists eval cases without importing a generated database client or runtime ad
     { encoding: "utf8", timeout: 20_000 },
   );
   expect(output).toContain("workspace-memory-isolation:");
-  expect(output.trim().split("\n")).toHaveLength(15);
+  expect(output.trim().split("\n")).toHaveLength(16);
 });

--- a/packages/testkit/src/evals/evals.test.ts
+++ b/packages/testkit/src/evals/evals.test.ts
@@ -34,6 +34,8 @@ function evidence(): Evidence {
     pendingApproval: null,
     priorMemory: "",
     destinationWrites: 0,
+    toolNames: [],
+    messaging: { originThreadId: null, outbound: [] },
   };
 }
 function grades(id: string, e: Evidence) {
@@ -94,6 +96,58 @@ describe("stateful eval services", () => {
     });
     expect(tools.map((t) => t.name)).toEqual(["GMAIL_LIST_MESSAGES"]);
   });
+  it("keeps Salesforce and Zendesk coherent while separating similar customers", async () => {
+    const services = new EvalServices();
+    const connected = {
+      ...context,
+      connectedConnections: [
+        {
+          id: "salesforce",
+          connectorId: "composio",
+          externalId: "SALESFORCE",
+          displayName: "Salesforce",
+        },
+        {
+          id: "zendesk",
+          connectorId: "composio",
+          externalId: "ZENDESK",
+          displayName: "Zendesk",
+        },
+      ],
+    };
+    expect((await services.discoverTools(connected)).map((tool) => tool.name)).toEqual([
+      "SALESFORCE_SEARCH_ACCOUNTS",
+      "SALESFORCE_LIST_OPPORTUNITIES",
+      "ZENDESK_SEARCH_ORGANIZATIONS",
+      "ZENDESK_LIST_TICKETS",
+    ]);
+    const accounts = await execute(services, "SALESFORCE_SEARCH_ACCOUNTS", {
+      query: "Fairhaven",
+    });
+    expect(accounts[0]).toMatchObject({
+      type: "result",
+      data: {
+        accounts: [
+          { id: "sf-fairhaven-robotics", name: "Fairhaven Robotics" },
+          { id: "sf-fairhaven-logistics", name: "Fairhaven Logistics" },
+        ],
+      },
+    });
+    const opportunities = await execute(services, "SALESFORCE_LIST_OPPORTUNITIES", {
+      accountId: "sf-fairhaven-robotics",
+    });
+    expect(opportunities[0]).toMatchObject({
+      type: "result",
+      data: { opportunities: [{ id: "sf-fairhaven-robotics-renewal", stage: "Negotiation" }] },
+    });
+    const tickets = await execute(services, "ZENDESK_LIST_TICKETS", {
+      organizationId: "zd-fairhaven-robotics",
+    });
+    expect(tickets[0]).toMatchObject({
+      type: "result",
+      data: { tickets: [{ id: "ZD-1842", status: "open", priority: "urgent" }] },
+    });
+  });
 });
 
 describe("independent outcome graders", () => {
@@ -121,9 +175,9 @@ describe("independent outcome graders", () => {
     e.files["results/language.txt"] = "French";
     expect(passes("updated-preference", e)).toBe(false);
   });
-  it("has 15 distinct cases, each rejects empty evidence and a completion claim", () => {
-    expect(EVAL_CASES).toHaveLength(15);
-    expect(new Set(EVAL_CASES.map((c) => c.id)).size).toBe(15);
+  it("has 16 distinct cases, each rejects empty evidence and a completion claim", () => {
+    expect(EVAL_CASES).toHaveLength(16);
+    expect(new Set(EVAL_CASES.map((c) => c.id)).size).toBe(16);
     for (const scenario of EVAL_CASES) {
       expect(
         passes(scenario.id, { ...evidence(), text: "Done! I completed everything." }),
@@ -199,6 +253,49 @@ describe("independent outcome graders", () => {
     expect(passes("crm-update", e)).toBe(true);
     e.records[1]!.status = "active";
     expect(passes("crm-update", e)).toBe(false);
+  });
+  it("requires grounded cross-system evidence and a non-contradictory Slack reply", () => {
+    const e = evidence();
+    e.calls.push(
+      {
+        tool: "SALESFORCE_SEARCH_ACCOUNTS",
+        args: { query: "Fairhaven Robotics" },
+        outcome: "read",
+      },
+      {
+        tool: "SALESFORCE_LIST_OPPORTUNITIES",
+        args: { accountId: "sf-fairhaven-robotics" },
+        outcome: "read",
+      },
+      {
+        tool: "ZENDESK_SEARCH_ORGANIZATIONS",
+        args: { query: "Fairhaven Robotics" },
+        outcome: "read",
+      },
+      {
+        tool: "ZENDESK_LIST_TICKETS",
+        args: { organizationId: "zd-fairhaven-robotics" },
+        outcome: "read",
+      },
+    );
+    e.messaging = {
+      originThreadId: "slack:dm:U-colleague",
+      outbound: [
+        {
+          threadId: "slack:dm:U-colleague",
+          handle: "outbound-1",
+          body: "Casey Morgan owns the renewal, now in Negotiation. Urgent ticket ZD-1842 covers the SSO incident; engineering is testing a configuration fix.",
+        },
+      ],
+    };
+    expect(passes("slack-customer-update", e)).toBe(true);
+    e.messaging.outbound[0]!.body =
+      "Casey Morgan says this is not in Negotiation and there is no support blocker on ticket ZD-1842. Engineering is testing a configuration fix for the SSO incident.";
+    expect(passes("slack-customer-update", e)).toBe(false);
+    e.messaging.outbound[0]!.body =
+      "Casey Morgan owns the renewal, now in Negotiation. Urgent ticket ZD-1842 covers the SSO incident; engineering is testing a configuration fix.";
+    e.calls[1]!.args.accountId = "sf-fairhaven-logistics";
+    expect(passes("slack-customer-update", e)).toBe(false);
   });
   it("requires recorded approval, not merely a promise to ask", () => {
     const e = { ...evidence(), text: "I will ask for approval." };

--- a/packages/testkit/src/evals/runner.ts
+++ b/packages/testkit/src/evals/runner.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { type AgentRuntime, type JobPublisher, runJobKey } from "@rakazo/adapter-kit";
+import { MessagingTeamChatEmulator } from "@rakazo/adapters";
 import type { ModelConnectInput, RunStatus } from "@rakazo/contracts";
 import { ACTIVE_RUN_STATUSES, isTerminal } from "@rakazo/core";
 import type { createDb } from "@rakazo/db";
@@ -28,7 +29,7 @@ export type TrialOptions = {
   connection: ModelConnectInput;
   timeoutMs: number;
   maxToolCalls: number;
-  createApp: (services: EvalServices) => Promise<EvalApp>;
+  createApp: (services: EvalServices, messaging: MessagingTeamChatEmulator) => Promise<EvalApp>;
 };
 class EvalFailure extends Error {
   constructor(
@@ -49,6 +50,10 @@ export async function runTrial(
   const started = Date.now();
   const deadline = started + options.timeoutMs;
   const services = new EvalServices();
+  const messaging = new MessagingTeamChatEmulator({
+    provider: "slack",
+    capabilities: { groups: false },
+  });
   scenario.configure?.(services);
   let handles: EvalApp | undefined;
   let cookie = "";
@@ -58,6 +63,9 @@ export async function runTrial(
   let pendingApproval: Evidence["pendingApproval"] = null;
   let approvalPending = false;
   let priorMemory = "";
+  let messagingLinked = false;
+  let messagingAddress = "";
+  let messagingOriginThreadId: string | null = null;
   const secrets = [options.connection.apiKey ?? "", options.connection.baseUrl ?? ""];
   let phase: FailureCategory = "harness";
   const seenTools = new Map<string, { name: string }>();
@@ -72,7 +80,11 @@ export async function runTrial(
   const captureTools = async () => {
     if (!handles) return seenTools.size;
     const events = await handles.prisma.event.findMany({
-      where: { spaceId: { in: actors.map((actor) => actor.spaceId) }, type: "agent.tool.called" },
+      where: {
+        spaceId: { in: actors.map((actor) => actor.spaceId) },
+        type: "agent.tool.called",
+        ...(seenTools.size ? { id: { notIn: [...seenTools.keys()] } } : {}),
+      },
       select: { id: true, payload: true },
     });
     for (const event of events)
@@ -90,7 +102,7 @@ export async function runTrial(
     for (const row of usage) seenUsage.set(row.id, row);
   };
   try {
-    handles = await options.createApp(services);
+    handles = await options.createApp(services, messaging);
     const { app, prisma } = handles;
     const setupActor = async () => {
       const signup = await app.request("/api/auth/sign-up/email", {
@@ -105,7 +117,7 @@ export async function runTrial(
       if (!signup.ok) throw new EvalFailure("harness", `Fixture signup failed (${signup.status})`);
       cookie = sessionCookieHeader(signup);
       await rpc(app, cookie, "models/connect", options.connection);
-      for (const provider of ["GMAIL", "CRM", "GITHUB"])
+      for (const provider of scenario.connections ?? ["GMAIL", "CRM", "GITHUB"])
         await rpc(app, cookie, "connections/begin", {
           connectorId: "composio",
           provider,
@@ -129,6 +141,9 @@ export async function runTrial(
         modelProvider: options.connection.provider,
         modelId: options.connection.modelId,
       });
+      messagingLinked = false;
+      messagingAddress = `U-eval-${randomUUID()}`;
+      messaging.resetWitnesses();
       if (scenario.approvalTool)
         await rpc(app, cookie, "approvalRules/set", {
           effect: "require_approval",
@@ -187,6 +202,44 @@ export async function runTrial(
         runId = (
           await rpc<{ runId: string }>(app, cookie, "threads/send", { botId, text: step.ask })
         ).runId;
+      } else if ("slack" in step) {
+        if (!messagingLinked) {
+          const link = await rpc<{ code: string }>(app, cookie, "messaging/link/start", { botId });
+          await messaging.emitInbound({
+            isDirect: true,
+            from: messagingAddress,
+            fromLabel: "Teammate",
+            content: link.code,
+          });
+          await poll(async () => (messaging.sent.length > 0 ? true : undefined), deadline);
+          messaging.resetWitnesses();
+          messagingLinked = true;
+        }
+        const inbound = await messaging.emitInbound({
+          isDirect: true,
+          from: messagingAddress,
+          fromLabel: "Teammate",
+          content: step.slack,
+        });
+        messagingOriginThreadId = inbound.threadId;
+        runId = await poll(
+          async () =>
+            (
+              await prisma.run.findFirst({
+                where: {
+                  botId,
+                  sourceMessage: {
+                    is: {
+                      clientNonce: `messaging:${inbound.provider}:${inbound.handle}`,
+                    },
+                  },
+                },
+                orderBy: { createdAt: "desc" },
+                select: { id: true },
+              })
+            )?.id,
+          deadline,
+        );
       } else {
         const routines = await prisma.routine.findMany({ where: { botId } });
         if (routines.length !== 1)
@@ -269,6 +322,9 @@ export async function runTrial(
             : "product";
         throw new EvalFailure(category, error);
       }
+      if ("slack" in step && terminal.status === "completed") {
+        await waitForMessagingDelivery(prisma, runId, deadline);
+      }
       const snap = await rpc<{
         messages: Array<{
           role: string;
@@ -316,6 +372,7 @@ export async function runTrial(
       where: { botId },
       select: { name: true, prompt: true, crons: true, active: true },
     });
+    await captureTools();
     const evidence: Evidence = {
       text: lastText,
       files,
@@ -328,6 +385,11 @@ export async function runTrial(
       pendingApproval,
       priorMemory,
       destinationWrites: handles.connector?.records.length ?? 0,
+      toolNames: [...seenTools.values()].map((event) => event.name),
+      messaging: {
+        originThreadId: messagingOriginThreadId,
+        outbound: structuredClone(messaging.sent),
+      },
     };
     phase = "harness";
     result.criteria = scenario.grade(evidence);
@@ -415,6 +477,37 @@ async function poll<T>(read: () => Promise<T | undefined>, deadline: number): Pr
     await new Promise((resolve) => setTimeout(resolve, 200));
   }
   throw new EvalFailure("incomplete", "Trial time budget exceeded");
+}
+
+async function waitForMessagingDelivery(
+  prisma: EvalApp["prisma"],
+  runId: string,
+  deadline: number,
+): Promise<void> {
+  await poll(
+    async () =>
+      (
+        await prisma.run.findUnique({
+          where: { id: runId },
+          select: { messagingMirroredAt: true },
+        })
+      )?.messagingMirroredAt ?? undefined,
+    deadline,
+  );
+  const messages = await prisma.message.findMany({
+    where: { runId, role: "bot" },
+    select: { id: true },
+  });
+  await poll(async () => {
+    const outbound = await prisma.messagingOutbound.findMany({
+      where: { sourceMessageId: { in: messages.map((message) => message.id) } },
+      select: { status: true, providerHandle: true },
+    });
+    return outbound.length > 0 &&
+      outbound.every((row) => row.providerHandle !== null || row.status === "failed")
+      ? true
+      : undefined;
+  }, deadline);
 }
 
 function actorScopes(actors: readonly EvalActor[]) {

--- a/packages/testkit/src/evals/service-contract.ts
+++ b/packages/testkit/src/evals/service-contract.ts
@@ -1,0 +1,11 @@
+export const CUSTOMER_SUPPORT_PROVIDERS = {
+  salesforce: "SALESFORCE",
+  zendesk: "ZENDESK",
+} as const;
+
+export const CUSTOMER_SUPPORT_TOOLS = {
+  searchAccounts: "SALESFORCE_SEARCH_ACCOUNTS",
+  listOpportunities: "SALESFORCE_LIST_OPPORTUNITIES",
+  searchOrganizations: "ZENDESK_SEARCH_ORGANIZATIONS",
+  listTickets: "ZENDESK_LIST_TICKETS",
+} as const;

--- a/packages/testkit/src/evals/services.ts
+++ b/packages/testkit/src/evals/services.ts
@@ -5,6 +5,7 @@ import type {
   ConnectorTool,
 } from "@rakazo/adapter-kit";
 import { ComposioEmulator } from "@rakazo/adapters";
+import { CUSTOMER_SUPPORT_PROVIDERS, CUSTOMER_SUPPORT_TOOLS } from "./service-contract.js";
 
 export const INBOX = [
   {
@@ -45,6 +46,18 @@ export class EvalServices extends ComposioEmulator {
       { slug: "GMAIL", name: "Gmail", logo: null, noAuth: false },
       { slug: "CRM", name: "CRM", logo: null, noAuth: false },
       { slug: "GITHUB", name: "GitHub", logo: null, noAuth: false },
+      {
+        slug: CUSTOMER_SUPPORT_PROVIDERS.salesforce,
+        name: "Salesforce",
+        logo: null,
+        noAuth: false,
+      },
+      {
+        slug: CUSTOMER_SUPPORT_PROVIDERS.zendesk,
+        name: "Zendesk",
+        logo: null,
+        noAuth: false,
+      },
     ]);
     this.seedGithubReleases([
       {
@@ -116,6 +129,42 @@ export class EvalServices extends ComposioEmulator {
             ),
           ]
         : []),
+      ...(connected.includes(CUSTOMER_SUPPORT_PROVIDERS.salesforce)
+        ? [
+            tool(
+              CUSTOMER_SUPPORT_TOOLS.searchAccounts,
+              "Search Salesforce accounts by customer name. Returns account IDs and owners.",
+              { query: { type: "string" } },
+              ["query"],
+              true,
+            ),
+            tool(
+              CUSTOMER_SUPPORT_TOOLS.listOpportunities,
+              "Read renewal opportunities for one Salesforce account ID.",
+              { accountId: { type: "string" } },
+              ["accountId"],
+              true,
+            ),
+          ]
+        : []),
+      ...(connected.includes(CUSTOMER_SUPPORT_PROVIDERS.zendesk)
+        ? [
+            tool(
+              CUSTOMER_SUPPORT_TOOLS.searchOrganizations,
+              "Search Zendesk organizations by customer name. Returns organization IDs.",
+              { query: { type: "string" } },
+              ["query"],
+              true,
+            ),
+            tool(
+              CUSTOMER_SUPPORT_TOOLS.listTickets,
+              "Read current support tickets for one Zendesk organization ID.",
+              { organizationId: { type: "string" } },
+              ["organizationId"],
+              true,
+            ),
+          ]
+        : []),
     ];
   }
 
@@ -144,6 +193,64 @@ export class EvalServices extends ComposioEmulator {
       yield {
         type: "result",
         data: { records: structuredClone(this.records), notes: structuredClone(this.notes) },
+      };
+      return;
+    }
+    if (call.tool === CUSTOMER_SUPPORT_TOOLS.searchAccounts) {
+      const query = requiredQuery(call.args.query);
+      entry.outcome = "read";
+      yield {
+        type: "result",
+        data: {
+          accounts: structuredClone(
+            CUSTOMER_ACCOUNTS.filter((row) => row.name.toLowerCase().includes(query)),
+          ),
+        },
+      };
+      return;
+    }
+    if (call.tool === CUSTOMER_SUPPORT_TOOLS.listOpportunities) {
+      const accountId = String(call.args.accountId ?? "");
+      if (!CUSTOMER_ACCOUNTS.some((row) => row.id === accountId)) {
+        throw new Error("Unknown Salesforce account");
+      }
+      entry.outcome = "read";
+      yield {
+        type: "result",
+        data: {
+          opportunities: structuredClone(
+            CUSTOMER_OPPORTUNITIES.filter((row) => row.accountId === accountId),
+          ),
+        },
+      };
+      return;
+    }
+    if (call.tool === CUSTOMER_SUPPORT_TOOLS.searchOrganizations) {
+      const query = requiredQuery(call.args.query);
+      entry.outcome = "read";
+      yield {
+        type: "result",
+        data: {
+          organizations: structuredClone(
+            CUSTOMER_ORGANIZATIONS.filter((row) => row.name.toLowerCase().includes(query)),
+          ),
+        },
+      };
+      return;
+    }
+    if (call.tool === CUSTOMER_SUPPORT_TOOLS.listTickets) {
+      const organizationId = String(call.args.organizationId ?? "");
+      if (!CUSTOMER_ORGANIZATIONS.some((row) => row.id === organizationId)) {
+        throw new Error("Unknown Zendesk organization");
+      }
+      entry.outcome = "read";
+      yield {
+        type: "result",
+        data: {
+          tickets: structuredClone(
+            CUSTOMER_TICKETS.filter((row) => row.organizationId === organizationId),
+          ),
+        },
       };
       return;
     }
@@ -182,6 +289,72 @@ export class EvalServices extends ComposioEmulator {
     }
     throw new Error("Unsupported action or invalid arguments");
   }
+}
+
+const CUSTOMER_ACCOUNTS = [
+  {
+    id: "sf-fairhaven-robotics",
+    name: "Fairhaven Robotics",
+    owner: "Casey Morgan",
+  },
+  {
+    id: "sf-fairhaven-logistics",
+    name: "Fairhaven Logistics",
+    owner: "Riley Chen",
+  },
+] as const;
+
+const CUSTOMER_OPPORTUNITIES = [
+  {
+    id: "sf-fairhaven-robotics-renewal",
+    accountId: "sf-fairhaven-robotics",
+    name: "2026 renewal",
+    stage: "Negotiation",
+    closeDate: "2026-10-15",
+    nextStep: "Resolve the SSO escalation before the renewal review on 2026-09-09.",
+    risk: "At risk while the production SSO incident remains unresolved.",
+  },
+  {
+    id: "sf-fairhaven-logistics-renewal",
+    accountId: "sf-fairhaven-logistics",
+    name: "2026 renewal",
+    stage: "Closed Won",
+    closeDate: "2026-08-10",
+    nextStep: "Handoff completed.",
+    risk: null,
+  },
+] as const;
+
+const CUSTOMER_ORGANIZATIONS = [
+  { id: "zd-fairhaven-robotics", name: "Fairhaven Robotics" },
+  { id: "zd-fairhaven-logistics", name: "Fairhaven Logistics" },
+] as const;
+
+const CUSTOMER_TICKETS = [
+  {
+    id: "ZD-1842",
+    organizationId: "zd-fairhaven-robotics",
+    subject: "Production users cannot sign in with SSO",
+    status: "open",
+    priority: "urgent",
+    assignee: "Avery Patel",
+    latestUpdate:
+      "Engineering reproduced the audience mismatch and is testing a configuration fix.",
+  },
+  {
+    id: "ZD-1811",
+    organizationId: "zd-fairhaven-logistics",
+    subject: "Add a billing contact",
+    status: "solved",
+    priority: "low",
+    assignee: "Jamie Ortiz",
+    latestUpdate: "Billing contact added.",
+  },
+] as const;
+
+function requiredQuery(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error("A search query is required");
+  return value.trim().toLowerCase();
 }
 
 function tool(


### PR DESCRIPTION
## Why

The eval suite did not verify a realistic inbound messaging task that requires grounding an answer across multiple business systems and returning it to the original conversation. This adds that coverage without making local or CI verification depend on Slack, Salesforce, Zendesk, Era, or another hosted service.

## What changed

- Extended the deterministic team-chat emulator into a complete provider-neutral messaging surface and configured it as Slack for the scenario.
- Added synthetic Salesforce and Zendesk records with a similar-name distractor, read-only tools, and shared tool/provider identifiers.
- Added a live eval case that links a bot, receives a colleague question, requires the matching account and support records, and grades the reply sent to the originating Slack thread.
- Added an offline Pi replay through the real API, database, run, tool, messaging-mirror, and outbound-delivery paths, and wired it into the integration lane.
- Documented the 16th eval and the fixture policy: keep compact synthetic conformance data with the code; put future large corpora in digest-pinned versioned artifacts; do not copy third-party data without clear compatible terms.

## Testing

- `pnpm check`
- `pnpm test` (3,472 passed; 156 skipped)
- `pnpm test:integration` (all 19 isolated suites passed)
- `pnpm test:evals --list`
- Changed-file Biome check

A live model trial was not run locally because it requires an inference-provider credential. The deterministic Pi replay exercises the complete orchestration path. Repository-wide `pnpm lint` still reports existing diagnostics in files unchanged by this PR; every changed source file passes Biome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added evaluation coverage for customer-support workflows using Salesforce and Zendesk data.
  - Added Slack-style conversation testing with inbound messages, threaded replies, and delivery verification.
  - Added checks that responses are grounded in retrieved records, avoid unsupported facts, and prevent unintended external writes.
  - Expanded the evaluation suite to 16 scenarios, including GitHub release monitoring.

- **Documentation**
  - Updated evaluation guidance for synthetic fixtures, reproducible scenarios, and versioned large datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->