### PR TITLE
fix(api): bound framework-parsed request bodies

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -80,6 +80,7 @@ import { cors } from "hono/cors";
 import { type AppEnv, loadEnv } from "./env.js";
 import { createMessagingInboundHandler } from "./messaging-inbound.js";
 import { mountMessagingWebhookRoutes } from "./messaging-webhook.js";
+import { mountApiRequestBodyLimits } from "./request-body-limit.js";
 import { createRouter } from "./router.js";
 import { TeamChatBridge } from "./team-chat-bridge.js";
 import { ModelTeamChatEngagementJudge } from "./team-chat-judge.js";
@@ -422,6 +423,7 @@ export async function createApp(
         }),
     );
   }
+  mountApiRequestBodyLimits(app);
   app.on(["GET", "POST"], "/api/auth/*", async (c) => {
     const path = new URL(c.req.url).pathname.replace("/api/auth", "");
     if (blockedAuthPaths.some((blocked) => path.startsWith(blocked))) {

--- a/apps/api/src/request-body-limit.test.ts
+++ b/apps/api/src/request-body-limit.test.ts
@@ -61,18 +61,21 @@ describe("API request body limits", () => {
     expect(parse).not.toHaveBeenCalled();
   });
 
-  it("rejects an invalid declared length before the route parser", async () => {
-    const { app, parse } = testApp(8);
-    const response = await app.request("/parse", {
-      method: "POST",
-      headers: { "content-type": "application/json", "content-length": "invalid" },
-      body: "{}",
-    });
+  it.each(["", "8.0", "0x8", "invalid"])(
+    "rejects invalid declared length %j before the route parser",
+    async (contentLength) => {
+      const { app, parse } = testApp(8);
+      const response = await app.request("/parse", {
+        method: "POST",
+        headers: { "content-type": "application/json", "content-length": contentLength },
+        body: "{}",
+      });
 
-    expect(response.status).toBe(413);
-    await expect(response.json()).resolves.toEqual({ error: "Request body is too large." });
-    expect(parse).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(413);
+      await expect(response.json()).resolves.toEqual({ error: "Request body is too large." });
+      expect(parse).not.toHaveBeenCalled();
+    },
+  );
 
   it("stops an oversized streamed body before the route parser", async () => {
     const cancel = vi.fn();

--- a/apps/api/src/request-body-limit.test.ts
+++ b/apps/api/src/request-body-limit.test.ts
@@ -1,0 +1,112 @@
+import { ATTACHMENT_MAX_BASE64_LENGTH } from "@rakazo/contracts";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import {
+  MAX_AUTH_REQUEST_BYTES,
+  MAX_RPC_REQUEST_BYTES,
+  mountApiRequestBodyLimits,
+  requestBodyLimit,
+} from "./request-body-limit.js";
+
+function testApp(maxSize: number, parse = vi.fn(async (request: Request) => request.json())) {
+  const app = new Hono();
+  app.use("/*", requestBodyLimit(maxSize));
+  app.post("/parse", async (c) => c.json(await parse(c.req.raw)));
+  return { app, parse };
+}
+
+describe("API request body limits", () => {
+  it("keeps the RPC allowance above the largest supported attachment envelope", () => {
+    expect(MAX_RPC_REQUEST_BYTES).toBeGreaterThan(ATTACHMENT_MAX_BASE64_LENGTH);
+    expect(MAX_AUTH_REQUEST_BYTES).toBeLessThan(MAX_RPC_REQUEST_BYTES);
+  });
+
+  it("mounts the limits on Auth and RPC without intercepting independently bounded routes", async () => {
+    const parse = vi.fn(async (request: Request) => request.json());
+    const app = new Hono();
+    mountApiRequestBodyLimits(app);
+    app.post("/api/auth/sign-in/email", async (c) => c.json(await parse(c.req.raw)));
+    app.post("/rpc/test", async (c) => c.json(await parse(c.req.raw)));
+    app.post("/api/voice/speak", async (c) => c.json(await parse(c.req.raw)));
+
+    const request = (path: string, contentLength: number) =>
+      app.request(path, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(contentLength),
+        },
+        body: "{}",
+      });
+    const auth = await request("/api/auth/sign-in/email", MAX_AUTH_REQUEST_BYTES + 1);
+    const rpc = await request("/rpc/test", MAX_RPC_REQUEST_BYTES + 1);
+    const voice = await request("/api/voice/speak", MAX_RPC_REQUEST_BYTES + 1);
+
+    expect(auth.status).toBe(413);
+    expect(rpc.status).toBe(413);
+    expect(voice.status).toBe(200);
+    expect(parse).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an oversized declared body before the route parser", async () => {
+    const { app, parse } = testApp(8);
+    const response = await app.request("/parse", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": "9" },
+      body: JSON.stringify({ ok: true }),
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "Request body is too large." });
+    expect(parse).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid declared length before the route parser", async () => {
+    const { app, parse } = testApp(8);
+    const response = await app.request("/parse", {
+      method: "POST",
+      headers: { "content-type": "application/json", "content-length": "invalid" },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "Request body is too large." });
+    expect(parse).not.toHaveBeenCalled();
+  });
+
+  it("stops an oversized streamed body before the route parser", async () => {
+    const cancel = vi.fn();
+    const { app, parse } = testApp(8);
+    const response = await app.request(
+      new Request("http://localhost/parse", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"value":"'));
+            controller.enqueue(new TextEncoder().encode('too large"}'));
+          },
+          cancel,
+        }),
+        duplex: "half",
+      } as RequestInit & { duplex: "half" }),
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "Request body is too large." });
+    expect(parse).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("passes bodies at the configured boundary to the route parser", async () => {
+    const { app, parse } = testApp(2);
+    const response = await app.request("/parse", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(200);
+    expect(parse).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/request-body-limit.ts
+++ b/apps/api/src/request-body-limit.ts
@@ -1,0 +1,68 @@
+import type { Hono, MiddlewareHandler } from "hono";
+
+export const MAX_AUTH_REQUEST_BYTES = 64 * 1024;
+export const MAX_RPC_REQUEST_BYTES = 16 * 1024 * 1024;
+
+/** Bound JSON entry points before their framework parsers buffer the request. */
+export function requestBodyLimit(maxSize: number): MiddlewareHandler {
+  if (!Number.isSafeInteger(maxSize) || maxSize <= 0) {
+    throw new Error("Request body limit must be a positive integer");
+  }
+  return async (c, next) => {
+    const request = c.req.raw;
+    if (!request.body) return next();
+
+    const contentLength = request.headers.get("content-length");
+    if (contentLength !== null && !request.headers.has("transfer-encoding")) {
+      const declared = Number(contentLength);
+      if (!Number.isSafeInteger(declared) || declared < 0 || declared > maxSize) {
+        cancelBody(request.body);
+        return c.json({ error: "Request body is too large." }, 413);
+      }
+      return next();
+    }
+
+    const reader = request.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let size = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        size += value.byteLength;
+        if (size > maxSize) {
+          cancelBody(reader);
+          return c.json({ error: "Request body is too large." }, 413);
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    c.req.raw = new Request(request, {
+      body: new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      }),
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+    return next();
+  };
+}
+
+function cancelBody(body: { cancel(): Promise<void> }): void {
+  try {
+    void body.cancel().catch(() => undefined);
+  } catch {
+    // Best-effort release must not delay the bounded rejection.
+  }
+}
+
+/** Install limits only on framework-parsed JSON surfaces with known payload contracts. */
+export function mountApiRequestBodyLimits(app: Hono): void {
+  app.use("/api/auth/*", requestBodyLimit(MAX_AUTH_REQUEST_BYTES));
+  app.use("/rpc/*", requestBodyLimit(MAX_RPC_REQUEST_BYTES));
+}

--- a/apps/api/src/request-body-limit.ts
+++ b/apps/api/src/request-body-limit.ts
@@ -14,7 +14,7 @@ export function requestBodyLimit(maxSize: number): MiddlewareHandler {
 
     const contentLength = request.headers.get("content-length");
     if (contentLength !== null && !request.headers.has("transfer-encoding")) {
-      const declared = Number(contentLength);
+      const declared = /^[0-9]+$/.test(contentLength) ? Number(contentLength) : Number.NaN;
       if (!Number.isSafeInteger(declared) || declared < 0 || declared > maxSize) {
         cancelBody(request.body);
         return c.json({ error: "Request body is too large." }, 413);


### PR DESCRIPTION
## Why

Better Auth and oRPC currently receive request streams without a byte ceiling before their framework parsers consume them. An unauthenticated auth caller or authenticated abnormal client can therefore keep the API buffering an oversized declared or chunked JSON body. RPC still needs to accept the existing 10 MiB attachment envelope.

## What

- cap Better Auth request bodies at 64 KiB and all RPC bodies at 16 MiB
- reject malformed, oversized declared, and oversized streamed bodies with stable JSON 413 before route parsers run
- cancel over-budget streams and replay accepted chunked bodies to downstream parsers
- keep independently bounded voice and webhook routes outside this middleware
- add regression tests for declared, streamed, exact-boundary, and route-scoping behavior

## Tests

- `pnpm --filter @rakazo/api check`
- `pnpm --filter @rakazo/api test`
- `pnpm check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication and RPC endpoints now enforce request body size limits.
  * Oversized, streamed, or invalidly declared requests are rejected with a `413` response before further processing.
  * Valid requests at or below the configured limits continue to be handled normally.
  * Voice synthesis requests retain their independent size limits.
  * Invalid `Content-Length` values, including fractional, hexadecimal, or empty values, are rejected consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->