### PR TITLE
Fix desktop startup collisions and leaked computer networks

### DIFF
--- a/apps/desktop/e2e/local-stack.spec.ts
+++ b/apps/desktop/e2e/local-stack.spec.ts
@@ -119,7 +119,7 @@ async function writeFakeDocker(mode: FakeDockerMode) {
 }
 
 async function launch(mode: FakeDockerMode | "missing") {
-  const env = { ...process.env, RAKAZO_PERFORMANCE_USER_DATA: userData };
+  const env: NodeJS.ProcessEnv = { ...process.env, RAKAZO_PERFORMANCE_USER_DATA: userData };
   // A stale RAKAZO_WEB_URL from the developer's shell would bypass setup entirely.
   delete env.RAKAZO_WEB_URL;
   return electron.launch({

--- a/apps/desktop/e2e/local-stack.spec.ts
+++ b/apps/desktop/e2e/local-stack.spec.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
-import { createServer, type Server } from "node:http";
+import { createServer, type RequestListener, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { type ElectronApplication, _electron as electron, expect, test } from "@playwright/test";
@@ -10,7 +10,13 @@ const STACK_PROBE_PATH = "/.well-known/rakazo-desktop-stack";
 const STACK_TOKEN_HEADER = "x-rakazo-desktop-stack-token";
 const COMPOSE_DIR = path.resolve(import.meta.dirname, "..", "..", "..", "infra", "compose");
 
-type FakeDockerMode = "ok" | "daemon-down" | "pull-fails";
+type FakeDockerMode =
+  | "ok"
+  | "daemon-down"
+  | "pull-fails"
+  | "pool-exhausted"
+  | "port-conflict"
+  | "ports-exhausted";
 
 let server: Server;
 let serverUrl: string;
@@ -78,6 +84,14 @@ function fakeDockerLog() {
  */
 async function writeFakeDocker(mode: FakeDockerMode) {
   const script = path.join(userData, "fake-docker.sh");
+  let up = '  up) echo "Container rakazo-web-1 Started"; exit 0 ;;';
+  if (mode === "pool-exhausted") {
+    up = '  up) echo "all predefined address pools have been fully subnetted" >&2; exit 1 ;;';
+  } else if (mode === "ports-exhausted") {
+    up = '  up) echo "port is already allocated" >&2; exit 1 ;;';
+  } else if (mode === "port-conflict") {
+    up = `  up) if [ ! -f '${path.join(userData, "port-conflict")}' ]; then touch '${path.join(userData, "port-conflict")}'; echo "port is already allocated" >&2; exit 1; fi; echo "Container rakazo-web-1 Started"; exit 0 ;;`;
+  }
   const lines = [
     "#!/bin/sh",
     `printf '%s | %s | %s\\n' "$PWD" "$RAKAZO_IMAGE_TAG" "$*" >> '${fakeDockerLog()}'`,
@@ -94,7 +108,7 @@ async function writeFakeDocker(mode: FakeDockerMode) {
     mode === "pull-fails"
       ? '    echo "Error response from daemon: manifest unknown" >&2; exit 1 ;;'
       : '    echo "app Pulled"; sleep 2; echo "computer Pulled"; exit 0 ;;',
-    '  up) echo "Container rakazo-web-1 Started"; exit 0 ;;',
+    up,
     '  logs) echo "web-1 | listening"; exit 0 ;;',
     "esac",
     "exit 0",
@@ -376,4 +390,62 @@ test("an existing stack .env is never rewritten", async () => {
   await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
 
   await expect(readFile(path.join(stackDir, ".env"), "utf8")).resolves.toBe(sentinel);
+});
+
+test("exhausted address pools explain recovery", async () => {
+  app = await launch("pool-exhausted");
+  const setup = await app.firstWindow();
+  await setup.getByRole("button", { name: "Continue" }).click();
+  await expect(setup.locator("#stack-phase")).toHaveText(
+    "Docker has no free network address pools. Remove unused Docker networks or expand Docker’s address pools, then retry.",
+  );
+  await expect(setup.getByRole("button", { name: "Retry" })).toBeEnabled();
+  await setup.screenshot({
+    path: path.join(import.meta.dirname, "screenshots", "09-setup-address-pool-exhausted.png"),
+  });
+});
+
+test("a port conflict opens and saves the replacement managed origin", async () => {
+  app = await launch("port-conflict");
+  const setup = await app.firstWindow();
+  const appWindowPromise = app.waitForEvent("window");
+  await setup.getByRole("button", { name: "Continue" }).click();
+  const urlFile = path.join(userData, "stack", ".desktop-web-url");
+  let replacementUrl = "";
+  await expect
+    .poll(async () => {
+      replacementUrl = await readFile(urlFile, "utf8").catch(() => "");
+      return replacementUrl !== "" && replacementUrl !== serverUrl;
+    })
+    .toBe(true);
+  // Stand in for the web container Docker would bind to the selected port.
+  const replacement = createServer(server.listeners("request")[0] as RequestListener);
+  await new Promise<void>((resolve) =>
+    replacement.listen(Number(new URL(replacementUrl).port), "127.0.0.1", resolve),
+  );
+  try {
+    const appWindow = await appWindowPromise;
+    await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
+    await expect.poll(savedSetup).toEqual({ mode: "new", serverUrl: replacementUrl });
+    expect((await readLog()).filter((line) => line.includes(" up -d"))).toHaveLength(2);
+  } finally {
+    replacement.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      replacement.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
+test("repeated port conflicts stop with a retry action", async () => {
+  app = await launch("ports-exhausted");
+  const setup = await app.firstWindow();
+  await setup.getByRole("button", { name: "Continue" }).click();
+  await expect(setup.locator("#stack-phase")).toHaveText(
+    "Could not bind a local port after retrying. Retry to choose another port.",
+  );
+  await expect(setup.getByRole("button", { name: "Retry" })).toBeEnabled();
+  expect((await readLog()).filter((line) => line.includes(" up -d"))).toHaveLength(3);
+  await setup.screenshot({
+    path: path.join(import.meta.dirname, "screenshots", "10-setup-ports-unavailable.png"),
+  });
 });

--- a/apps/desktop/src/docker-cli.test.ts
+++ b/apps/desktop/src/docker-cli.test.ts
@@ -133,6 +133,14 @@ describe("classifyDockerFailure", () => {
     ["net/http: TLS handshake timeout", "network"],
     ["Bind for 127.0.0.1:5173 failed: port is already allocated", "port-in-use"],
     ["listen tcp 127.0.0.1:3100: bind: address already in use", "port-in-use"],
+    [
+      "Error response from daemon: all predefined address pools have been fully subnetted",
+      "address-pool-exhausted",
+    ],
+    [
+      "could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network",
+      "address-pool-exhausted",
+    ],
     ["something else entirely", "other"],
   ])("classifies %j as %s", (output, kind) => {
     expect(classifyDockerFailure(output)).toBe(kind);

--- a/apps/desktop/src/docker-cli.ts
+++ b/apps/desktop/src/docker-cli.ts
@@ -210,6 +210,7 @@ export type DockerFailureKind =
   | "compose-missing"
   | "image-not-found"
   | "network"
+  | "address-pool-exhausted"
   | "port-in-use"
   | "other";
 
@@ -242,6 +243,10 @@ const NETWORK = [
   "network is unreachable",
   "context deadline exceeded",
 ];
+const ADDRESS_POOL_EXHAUSTED = [
+  "all predefined address pools have been fully subnetted",
+  "could not find an available, non-overlapping ipv4 address pool",
+];
 const PORT_IN_USE = ["address already in use", "port is already allocated", "bind for 127.0.0.1"];
 
 /** Docker output can contain paths and hostnames, so callers map kinds to fixed messages. */
@@ -253,6 +258,7 @@ export function classifyDockerFailure(output: string): DockerFailureKind {
   if (matches(COMPOSE_MISSING)) return "compose-missing";
   if (matches(PORT_IN_USE)) return "port-in-use";
   if (matches(IMAGE_NOT_FOUND)) return "image-not-found";
+  if (matches(ADDRESS_POOL_EXHAUSTED)) return "address-pool-exhausted";
   if (matches(NETWORK)) return "network";
   return "other";
 }

--- a/apps/desktop/src/local-stack-networking.test.ts
+++ b/apps/desktop/src/local-stack-networking.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { allocateLoopbackPort, readStackWebUrl, STACK_WEB_URL_FILE } from "./local-stack.js";
+import { DEFAULT_LOCAL_WEB_URL } from "./setup-config.js";
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), "stack-networking-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("managed stack address", () => {
+  it("keeps the desktop default separate from development", () => {
+    expect(DEFAULT_LOCAL_WEB_URL).toBe("http://127.0.0.1:45173");
+  });
+
+  it("restores a previously selected loopback port", async () => {
+    await writeFile(path.join(dir, STACK_WEB_URL_FILE), "http://127.0.0.1:49152");
+    expect(await readStackWebUrl(dir, DEFAULT_LOCAL_WEB_URL)).toBe("http://127.0.0.1:49152");
+  });
+
+  it.each([
+    "http://example.com:49152",
+    "http://192.168.1.2:49152",
+    "http://127.0.0.1:65536",
+    "http://127.0.0.1:01024",
+    "http://127.0.0.1:80",
+    "http://127.0.0.1:49152/path",
+    "http://user:password@127.0.0.1:49152",
+    "http://127.0.0.1:49152\n",
+    "x".repeat(129),
+  ])("rejects an invalid persisted origin: %s", async (url) => {
+    await writeFile(path.join(dir, STACK_WEB_URL_FILE), url);
+    expect(await readStackWebUrl(dir, DEFAULT_LOCAL_WEB_URL)).toBe(DEFAULT_LOCAL_WEB_URL);
+  });
+
+  it("does not follow a symlink to an address file", async () => {
+    await writeFile(path.join(dir, "other"), "http://127.0.0.1:49152");
+    await symlink(path.join(dir, "other"), path.join(dir, STACK_WEB_URL_FILE));
+    expect(await readStackWebUrl(dir, DEFAULT_LOCAL_WEB_URL)).toBe(DEFAULT_LOCAL_WEB_URL);
+  });
+
+  it("allocates an unprivileged local port", async () => {
+    const port = await allocateLoopbackPort();
+    expect(port).toBeGreaterThanOrEqual(1024);
+    expect(port).toBeLessThanOrEqual(65535);
+  });
+});

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -239,7 +239,7 @@ describe("stackFailureMessage", () => {
   });
 
   it("points at the ports for a port clash", () => {
-    expect(stackFailureMessage("port-in-use", "starting", "edge")).toContain("5173 or 3100");
+    expect(stackFailureMessage("port-in-use", "starting", "edge")).toContain("local port");
   });
 
   it("explains the docker group for socket permission errors", () => {
@@ -303,6 +303,7 @@ describe("LocalStackController", () => {
       platform: "linux",
       env: { PATH: "/usr/bin", HOME: "/home/me", OPENROUTER_API_KEY: "sk-secret" },
       exists: (file) => file === "/usr/bin/docker",
+      allocatePort: async () => 45174,
       stackDir: path.join(root, "stack"),
       resourceDir: COMPOSE_DIR,
       localWebUrl: "http://127.0.0.1:5173",
@@ -398,7 +399,14 @@ describe("LocalStackController", () => {
     const commands = calls.filter(
       (call) => call.args[0] === "compose" && call.args[1] !== "version",
     );
-    expect(commands.map((call) => call.args[7])).toEqual(["pull", "up", "logs", "stop"]);
+    expect(commands.map((call) => call.args[7])).toEqual([
+      "pull",
+      "up",
+      "up",
+      "up",
+      "logs",
+      "stop",
+    ]);
     for (const call of commands) {
       expect(call.args.slice(5, 7)).toEqual(["--project-name", "rakazo-desktop"]);
       expect(call.env).not.toHaveProperty("COMPOSE_PROJECT_NAME");
@@ -523,17 +531,66 @@ describe("LocalStackController", () => {
     });
   });
 
+  it("retries port conflicts on a new origin and uses it for auth, health, and saved launches", async () => {
+    let starts = 0;
+    const probed: string[] = [];
+    const stack = controller(
+      {
+        probe: async (url) => {
+          probed.push(url);
+          return "v1.2.3";
+        },
+      },
+      (args) => {
+        if (args[7] === "up" && starts++ === 0)
+          return { code: 1, stderr: "port is already allocated" };
+        return ok(args);
+      },
+    );
+    expect((await stack.start()).phase).toBe("ready");
+    expect(starts).toBe(2);
+    expect(probed).toEqual(["http://127.0.0.1:45174"]);
+    expect(stack.webUrl()).toBe("http://127.0.0.1:45174");
+    expect(calls.filter((call) => call.args[7] === "pull")).toHaveLength(1);
+    expect(
+      calls.filter((call) => call.args[7] === "up").map((call) => call.env.RAKAZO_WEB_PORT),
+    ).toEqual(["5173", "45174"]);
+    expect(calls.at(-1)?.env).toMatchObject({
+      RAKAZO_API_PORT: "0",
+      WEB_ORIGIN: stack.webUrl(),
+      BETTER_AUTH_URL: stack.webUrl(),
+      API_URL: stack.webUrl(),
+    });
+    expect(await readFile(path.join(root, "stack", ".desktop-web-url"), "utf8")).toBe(
+      stack.webUrl(),
+    );
+    expect(await stack.matchesDesiredStack()).toBe(true);
+    expect(probed.at(-1)).toBe(stack.webUrl());
+  });
+
+  it("bounds retries when another process repeatedly takes the selected port", async () => {
+    const stack = controller({}, (args) =>
+      args[7] === "up" ? { code: 1, stderr: "port is already allocated" } : ok(args),
+    );
+    expect(await stack.start()).toMatchObject({
+      phase: "failed",
+      message: expect.stringContaining("local port"),
+    });
+    expect(calls.filter((call) => call.args[7] === "up")).toHaveLength(3);
+    expect(phases).not.toContain("waiting-healthy");
+  });
+
   it("collects service logs when up fails", async () => {
     const stack = controller({}, (args) => {
       if (args[7] === "up") {
-        return { code: 1, stderr: "port is already allocated", lines: ["web Error"] };
+        return { code: 1, stderr: "service exited", lines: ["web Error"] };
       }
       if (args[7] === "logs") return { lines: ["web-1 | EADDRINUSE"] };
       return ok(args);
     });
     const state = await stack.start();
     expect(state.phase).toBe("failed");
-    expect(state.message).toContain("5173 or 3100");
+    expect(state.message).toContain("did not start");
     expect(state.output).toEqual([
       "app Pulled",
       "computer Pulled",
@@ -542,6 +599,34 @@ describe("LocalStackController", () => {
     ]);
     expect(calls.at(-1)?.args.slice(7)).toEqual(["logs", "--tail", "30", "--no-color"]);
   });
+
+  it.each(["stdout", "stderr"] as const)(
+    "explains exhausted address pools from %s and can retry after recovery",
+    async (stream) => {
+      let exhausted = true;
+      const stack = controller({}, (args) => {
+        if (args[7] === "up" && exhausted) {
+          return {
+            code: 1,
+            [stream]:
+              "failed to create network rakazo-desktop_data: Error response from daemon: all predefined address pools have been fully subnetted",
+          };
+        }
+        return ok(args);
+      });
+      expect(await stack.start()).toMatchObject({
+        phase: "failed",
+        message:
+          "Docker has no free network address pools. Remove unused Docker networks or expand Docker’s address pools, then retry.",
+      });
+      expect(phases).not.toContain("waiting-healthy");
+      expect(calls.every((call) => call.args[0] === "compose" || call.args[0] === "info")).toBe(
+        true,
+      );
+      exhausted = false;
+      expect(await stack.start()).toMatchObject({ phase: "ready", message: null });
+    },
+  );
 
   it("fails when the web app never answers after up", async () => {
     let probes = 0;

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -1,4 +1,5 @@
 import { copyFile, lstat, mkdir, readFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import path from "node:path";
 import type { DesktopLocalStackState } from "@rakazo/contracts";
 import {
@@ -17,10 +18,36 @@ export const STACK_PROJECT_NAME = "rakazo-desktop";
 export const STACK_COMPOSE_FILE = "docker-compose.images.yml";
 export const STACK_ENV_TEMPLATE = ".env.images.example";
 export const STACK_ENV_FILE = ".env";
+export const STACK_WEB_URL_FILE = ".desktop-web-url";
 export const STACK_TOKEN_FILE = ".desktop-stack-token";
 export const STACK_OUTPUT_LINES = 20;
 export const STACK_HEALTH_TIMEOUT_MS = 120_000;
 export const COMPOSE_WAIT_TIMEOUT_S = 300;
+
+export async function readStackWebUrl(dir: string, fallback: string): Promise<string> {
+  const raw = await readPrivateFile(path.join(dir, STACK_WEB_URL_FILE), 128);
+  const match = raw?.match(/^http:\/\/127\.0\.0\.1:(\d{4,5})$/);
+  const port = Number(match?.[1]);
+  return match && port >= 1024 && port <= 65535 && raw === `http://127.0.0.1:${port}`
+    ? raw
+    : fallback;
+}
+
+/** Docker owns the final bind; a racing listener is handled by bounded up retries. */
+export async function allocateLoopbackPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close((error) => {
+        if (error) reject(error);
+        else if (address && typeof address !== "string") resolve(address.port);
+        else reject(new Error("No loopback port allocated."));
+      });
+    });
+  });
+}
 
 const HEALTH_POLL_INTERVAL_MS = 2_000;
 const COMPOSE_VERSION_TIMEOUT_MS = 15_000;
@@ -200,7 +227,9 @@ export function stackFailureMessage(
     case "image-not-found":
       return `Images for ${imageTag} are not published yet. Try again in a few minutes.`;
     case "port-in-use":
-      return "Port 5173 or 3100 is already in use on this computer. Stop what is using it, then retry.";
+      return "Could not bind a local port after retrying. Retry to choose another port.";
+    case "address-pool-exhausted":
+      return "Docker has no free network address pools. Remove unused Docker networks or expand Docker’s address pools, then retry.";
     case "network":
       return "Could not reach the image registry. Check the internet connection, then retry.";
     case "daemon-down":
@@ -233,6 +262,7 @@ export interface LocalStackDeps {
   stackDir: string;
   resourceDir: string;
   localWebUrl: string;
+  allocatePort?: () => Promise<number>;
   imageTag: string;
   /** Returns the authenticated running image tag, or null for any other listener. */
   probe: (url: string, signal: AbortSignal, token: string) => Promise<string | null>;
@@ -260,6 +290,7 @@ function defaultSleep(ms: number, signal: AbortSignal) {
  */
 export class LocalStackController {
   private current: DesktopLocalStackState;
+  private currentWebUrl: string;
   private currentStackToken: string | null = null;
   private running: Promise<DesktopLocalStackState> | null = null;
   private stopping: Promise<DesktopLocalStackState> | null = null;
@@ -270,6 +301,11 @@ export class LocalStackController {
 
   constructor(private readonly deps: LocalStackDeps) {
     this.current = initialStackState(deps.imageTag);
+    this.currentWebUrl = deps.localWebUrl;
+  }
+
+  webUrl(): string {
+    return this.currentWebUrl;
   }
 
   state(): DesktopLocalStackState {
@@ -277,7 +313,7 @@ export class LocalStackController {
   }
 
   /** Fast path for launch: only a stack with our private token and desired image may be reused. */
-  async matchesDesiredStack(url = this.deps.localWebUrl): Promise<boolean> {
+  async matchesDesiredStack(url = this.currentWebUrl): Promise<boolean> {
     const token = await readStackToken(this.deps.stackDir);
     if (token === null) return false;
     this.currentStackToken = token;
@@ -429,7 +465,19 @@ export class LocalStackController {
     const upArgs = composeSupportsWaitTimeout(version.stdout)
       ? ["up", "-d", "--wait", "--wait-timeout", String(COMPOSE_WAIT_TIMEOUT_S)]
       : ["up", "-d"];
-    const up = await this.compose(binary, upArgs, UP_TIMEOUT_MS, signal);
+    await writePrivateFile(path.join(this.deps.stackDir, STACK_WEB_URL_FILE), this.currentWebUrl);
+    let up = await this.compose(binary, upArgs, UP_TIMEOUT_MS, signal);
+    for (
+      let retry = 0;
+      retry < 2 && !interrupted(signal, up) && up.code !== 0 && failureKind(up) === "port-in-use";
+      retry += 1
+    ) {
+      const port = await (this.deps.allocatePort ?? allocateLoopbackPort)();
+      if (signal.aborted) break;
+      this.currentWebUrl = `http://127.0.0.1:${port}`;
+      await writePrivateFile(path.join(this.deps.stackDir, STACK_WEB_URL_FILE), this.currentWebUrl);
+      up = await this.compose(binary, upArgs, UP_TIMEOUT_MS, signal);
+    }
     if (interrupted(signal, up)) return this.push({ type: "failed", message: START_INTERRUPTED });
     if (up.code !== 0) {
       // Best effort: recent service logs usually name the failing service.
@@ -445,9 +493,7 @@ export class LocalStackController {
     const sleep = this.deps.sleep ?? defaultSleep;
     const deadline = Date.now() + (this.deps.healthTimeoutMs ?? STACK_HEALTH_TIMEOUT_MS);
     while (!signal.aborted) {
-      if (
-        (await this.deps.probe(this.deps.localWebUrl, signal, stackToken)) === this.deps.imageTag
-      ) {
+      if ((await this.deps.probe(this.currentWebUrl, signal, stackToken)) === this.deps.imageTag) {
         this.push({ type: "ready" });
         return;
       }
@@ -471,6 +517,12 @@ export class LocalStackController {
         ...(this.currentStackToken === null
           ? {}
           : { RAKAZO_DESKTOP_STACK_TOKEN: this.currentStackToken }),
+        RAKAZO_WEB_PORT: new URL(this.currentWebUrl).port || "80",
+        // Only web needs a stable host address. Docker allocates the API host port.
+        RAKAZO_API_PORT: "0",
+        BETTER_AUTH_URL: this.currentWebUrl,
+        WEB_ORIGIN: this.currentWebUrl,
+        API_URL: this.currentWebUrl,
         COMPOSE_PROGRESS: "plain",
       }),
       timeoutMs,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -12,6 +12,7 @@ import {
 import { DOCKER_INSTALL_LINKS, isDesktopSetupLink, runDocker } from "./docker-cli.js";
 import {
   LocalStackController,
+  readStackWebUrl,
   resolveImageTag,
   stackDir,
   stackResourceDir,
@@ -895,7 +896,9 @@ app.whenReady().then(async () => {
       resourcesPath: process.resourcesPath,
       appPath: app.getAppPath(),
     }),
-    localWebUrl: LOCAL_WEB_URL,
+    localWebUrl:
+      process.env.RAKAZO_LOCAL_WEB_URL?.trim() ||
+      (await readStackWebUrl(stackDir(userDataDir), LOCAL_WEB_URL)),
     imageTag: resolveImageTag({
       version: app.getVersion(),
       packaged: app.isPackaged,
@@ -970,7 +973,7 @@ app.whenReady().then(async () => {
   ipcMain.handle("desktop.setup.state", (event) => {
     if (!fromSetupWindow(event)) return null;
     return {
-      defaultLocalUrl: LOCAL_WEB_URL,
+      defaultLocalUrl: localStack.webUrl(),
       saved: currentSetup,
       error: setupError ?? undefined,
     };
@@ -999,10 +1002,10 @@ app.whenReady().then(async () => {
         };
       }
 
-      // Managed stacks authenticate LOCAL_WEB_URL only; never open a different loopback.
+      // Only open the exact origin selected and authenticated by the managed stack.
       let openSetup = setup;
       if (setup.mode === "new") {
-        const managedUrl = managedLocalOpenUrl(setup.serverUrl, LOCAL_WEB_URL);
+        const managedUrl = managedLocalOpenUrl(setup.serverUrl, localStack.webUrl());
         if (managedUrl === null || !(await localStack.matchesDesiredStack())) {
           return {
             ok: false,
@@ -1109,7 +1112,7 @@ app.whenReady().then(async () => {
     showSetupWindow();
   } else if (target.source === "saved") {
     if (currentSetup?.mode === "new") {
-      const managedUrl = managedLocalOpenUrl(target.url, LOCAL_WEB_URL);
+      const managedUrl = managedLocalOpenUrl(target.url, localStack.webUrl());
       const managedStackReady =
         managedUrl !== null ? await localStack.matchesDesiredStack() : false;
       if (managedStackReady && managedUrl !== null) {

--- a/apps/desktop/src/setup-config.test.ts
+++ b/apps/desktop/src/setup-config.test.ts
@@ -69,8 +69,8 @@ describe("server address normalization", () => {
 
 describe("managed local open URL", () => {
   it("returns the authenticated managed origin when the request matches", () => {
-    expect(managedLocalOpenUrl("http://127.0.0.1:5173/", DEFAULT_LOCAL_WEB_URL)).toBe(
-      "http://127.0.0.1:5173",
+    expect(managedLocalOpenUrl(`${DEFAULT_LOCAL_WEB_URL}/`, DEFAULT_LOCAL_WEB_URL)).toBe(
+      DEFAULT_LOCAL_WEB_URL,
     );
     expect(managedLocalOpenUrl("http://127.0.0.1:5199", "http://127.0.0.1:5199/path?x=1")).toBe(
       "http://127.0.0.1:5199",

--- a/apps/desktop/src/setup-config.ts
+++ b/apps/desktop/src/setup-config.ts
@@ -2,8 +2,8 @@ import { createHash } from "node:crypto";
 import { isIP } from "node:net";
 import type { DesktopSetup, DesktopStackProbeResponse } from "@rakazo/contracts";
 
-/** Where `pnpm dev` serves the Rakazo web app on this machine. */
-export const DEFAULT_LOCAL_WEB_URL = "http://127.0.0.1:5173";
+/** Managed desktop origin; development keeps its usual web/API ports. */
+export const DEFAULT_LOCAL_WEB_URL = "http://127.0.0.1:45173";
 export const PROBE_RESPONSE_LIMIT_BYTES = 64 * 1024;
 
 export const SETUP_FILE_NAME = "setup.json";

--- a/apps/desktop/src/setup.js
+++ b/apps/desktop/src/setup.js
@@ -130,6 +130,9 @@
         renderStack(stack);
         if (TERMINAL_PHASES.has(stack.phase)) {
           if (stack.phase === "ready" && selectedMode() === "new") {
+            const current = await bridge.state();
+            if (selectedMode() !== "new") return;
+            defaultLocalUrl = current.defaultLocalUrl;
             await save("new", defaultLocalUrl);
           }
           return;

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -4,7 +4,7 @@ The signed-in product is a long-running API, a Graphile Worker, Postgres, and a 
 
 ## Local (source checkout)
 
-Same as the README quick start: `.env` from `.env.example`, Postgres via Compose, `pnpm sandbox:build`, `pnpm dev`, then [http://127.0.0.1:5173](http://127.0.0.1:5173). Electron: `pnpm --filter @rakazo/desktop dev` while that stack is up, choosing **Existing instance** with that address. The desktop app's **This computer** option instead installs and runs the published images itself with Docker Compose (see [Published images](#published-images-no-checkout)), which clashes with `pnpm dev` on port 5173.
+Same as the README quick start: `.env` from `.env.example`, Postgres via Compose, `pnpm sandbox:build`, `pnpm dev`, then [http://127.0.0.1:5173](http://127.0.0.1:5173). Electron: `pnpm --filter @rakazo/desktop dev` while that stack is up, choosing **Existing instance** with that address. The desktop app's **This computer** option instead installs and runs the published images itself with Docker Compose (see [Published images](#published-images-no-checkout)), using port 45173 by default so it can run alongside `pnpm dev`. If that port is occupied, the app selects and remembers another loopback port. The managed API gets a Docker-assigned loopback port; all desktop traffic uses the web origin.
 
 ## Published images (no checkout)
 

--- a/infra/compose/docker-compose.images.yml
+++ b/infra/compose/docker-compose.images.yml
@@ -36,12 +36,14 @@ services:
   computer:
     image: ${RAKAZO_COMPUTER_IMAGE:-ghcr.io/elie222/rakazo/computer}:${RAKAZO_COMPUTER_IMAGE_TAG:-edge}
     command: ["true"]
+    network_mode: none
     restart: "no"
 
   data-init:
     # Optional Hub override; unset keeps busybox:1.
     image: ${BUSYBOX_IMAGE:-busybox:1}
     command: ["chown", "-R", "1000:1000", "/data"]
+    network_mode: none
     restart: "no"
     volumes:
       - appdata:/data
@@ -116,6 +118,9 @@ services:
     environment:
       NODE_ENV: production
       API_HOST: "0.0.0.0"
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://127.0.0.1:5173}
+      WEB_ORIGIN: ${WEB_ORIGIN:-http://127.0.0.1:5173}
+      API_URL: ${API_URL:-http://127.0.0.1:5173}
       DATABASE_URL: postgres://${POSTGRES_USER:-rakazo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-rakazo}
       DATA_DIR: /data
       SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-docker}
@@ -133,7 +138,7 @@ services:
       https_proxy: ${https_proxy:-${HTTPS_PROXY:-}}
       no_proxy: ${no_proxy:-${NO_PROXY:-}}
     ports:
-      - "127.0.0.1:3100:3100"
+      - "127.0.0.1:${RAKAZO_API_PORT:-3100}:3100"
     volumes:
       - appdata:/data
     networks:
@@ -225,7 +230,7 @@ services:
       RAKAZO_IMAGE_TAG: ${RAKAZO_IMAGE_TAG:-edge}
       SCREEN_PROXY_SECRET: ${SCREEN_PROXY_SECRET:?Set SCREEN_PROXY_SECRET in .env}
     ports:
-      - "127.0.0.1:5173:5173"
+      - "127.0.0.1:${RAKAZO_WEB_PORT:-5173}:5173"
     networks:
       - app
     depends_on:

--- a/infra/sandboxes/supervisor/src/computer-loopback.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-loopback.test.ts
@@ -327,6 +327,29 @@ describe("provisioning network rollback", () => {
     );
   });
 
+  it("preserves the existing computer when its replacement network cannot be allocated", async () => {
+    fixture();
+    const existing = {
+      id: "existing-computer",
+      remove: vi.fn().mockResolvedValue(undefined),
+      inspect: vi.fn().mockResolvedValue({
+        Image: "old-image",
+        Config: {
+          Labels: { "rakazo.managed": "true", "rakazo.botId": "bot", "rakazo.spaceId": "space" },
+        },
+        HostConfig: { PortBindings: {} },
+      }),
+    };
+    mocks.docker.listContainers.mockResolvedValue([{ Id: existing.id }]);
+    mocks.docker.getContainer.mockReturnValue(existing);
+    mocks.docker.createNetwork.mockRejectedValue(new Error("address pools exhausted"));
+    const response = await provision();
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "address pools exhausted" });
+    expect(existing.remove).not.toHaveBeenCalled();
+    expect(mocks.docker.createContainer).not.toHaveBeenCalled();
+  });
+
   it("does not remove an existing network after failed creation", async () => {
     const { network } = fixture();
     mocks.docker.createNetwork.mockRejectedValue(new Error("network already exists"));

--- a/infra/sandboxes/supervisor/src/computer-loopback.test.ts
+++ b/infra/sandboxes/supervisor/src/computer-loopback.test.ts
@@ -238,6 +238,7 @@ describe("computer loopback provision lifecycle", () => {
     });
     expect(response.status).toBe(200);
     if (resumed) {
+      expect(mocks.docker.createNetwork).not.toHaveBeenCalled();
       expect(existing.start).toHaveBeenCalledOnce();
       expect(existing.remove).not.toHaveBeenCalled();
       expect(mocks.docker.createContainer).not.toHaveBeenCalled();
@@ -253,5 +254,114 @@ describe("computer loopback provision lifecycle", () => {
         expect.stringMatching(/^RAKAZO_COMPUTER_CONTROL_TOKEN=.+/),
       );
     }
+  });
+});
+
+describe("provisioning network rollback", () => {
+  function fixture() {
+    const network = { remove: vi.fn().mockResolvedValue(undefined) };
+    const container = {
+      id: "new-computer",
+      start: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(undefined),
+    };
+    mocks.docker.getImage.mockReturnValue({ inspect: vi.fn().mockResolvedValue({ Id: "image" }) });
+    mocks.docker.listContainers.mockResolvedValue([]);
+    mocks.docker.createNetwork.mockResolvedValue(network);
+    mocks.docker.createContainer.mockResolvedValue(container);
+    return { network, container };
+  }
+
+  async function provision(homePath = path.join(process.env.DATA_DIR!, "homes", "bot")) {
+    const { supervisorApp } = await import("./index.js");
+    return supervisorApp.request("/computers", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${resolveSupervisorToken(process.env)}`,
+        "content-type": "application/json",
+        "x-rakazo-bot-id": "bot",
+        "x-rakazo-space-id": "space",
+      },
+      body: JSON.stringify({ botId: "bot", spaceId: "space", homePath }),
+    });
+  }
+
+  it("does not allocate a network for an invalid home", async () => {
+    fixture();
+    expect((await provision("/invalid-home")).status).toBe(500);
+    expect(mocks.docker.createNetwork).not.toHaveBeenCalled();
+  });
+
+  it("does not allocate a network when home validation fails", async () => {
+    fixture();
+    mocks.assertHomeWritable.mockRejectedValue(new Error("home is not writable"));
+    expect((await provision()).status).toBe(500);
+    expect(mocks.docker.createNetwork).not.toHaveBeenCalled();
+  });
+
+  it("removes the new network on every failed container creation, then can retry", async () => {
+    const { network } = fixture();
+    mocks.docker.createContainer.mockRejectedValue(new Error("container creation failed"));
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const response = await provision();
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "container creation failed" });
+      expect(network.remove).toHaveBeenCalledTimes(attempt + 1);
+      expect(network.remove).toHaveBeenLastCalledWith();
+    }
+    const { network: retryNetwork } = fixture();
+    expect((await provision()).status).toBe(200);
+    expect(retryNetwork.remove).not.toHaveBeenCalled();
+  });
+
+  it("removes a failed new container before its new network", async () => {
+    const { network, container } = fixture();
+    container.start.mockRejectedValue(new Error("container start failed"));
+    const response = await provision();
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "container start failed" });
+    expect(container.remove).toHaveBeenCalledExactlyOnceWith();
+    expect(network.remove).toHaveBeenCalledExactlyOnceWith();
+    expect(container.remove.mock.invocationCallOrder[0]).toBeLessThan(
+      network.remove.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("does not remove an existing network after failed creation", async () => {
+    const { network } = fixture();
+    mocks.docker.createNetwork.mockRejectedValue(new Error("network already exists"));
+    mocks.docker.createContainer.mockRejectedValue(new Error("container creation failed"));
+    expect((await provision()).status).toBe(500);
+    expect(network.remove).not.toHaveBeenCalled();
+  });
+
+  it("preserves the provision error if Docker refuses cleanup of active resources", async () => {
+    const { network, container } = fixture();
+    container.start.mockRejectedValue(new Error("start response lost"));
+    container.remove.mockRejectedValue(new Error("container is running"));
+    network.remove.mockRejectedValue(new Error("network has active endpoints"));
+    const response = await provision();
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "start response lost" });
+    expect(container.remove).toHaveBeenCalledExactlyOnceWith();
+    expect(network.remove).toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it("does not allocate or delete the shared internal network", async () => {
+    fixture();
+    vi.stubEnv("SANDBOX_SCREEN_NETWORK", "internal");
+    vi.stubEnv("HOSTNAME", "supervisor");
+    mocks.docker.getContainer.mockReturnValue({
+      inspect: vi.fn().mockResolvedValue({
+        NetworkSettings: { Networks: { shared: {} } },
+        Mounts: [],
+      }),
+    });
+    mocks.docker.createContainer.mockRejectedValue(new Error("container creation failed"));
+    const response = await provision();
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "container creation failed" });
+    expect(mocks.docker.createContainer).toHaveBeenCalledOnce();
+    expect(mocks.docker.createNetwork).not.toHaveBeenCalled();
   });
 });

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -208,14 +208,14 @@ app.post("/computers", async (c) => {
           ? COMPUTER_GID
           : hostGid;
       await assertComputerHomeWritable(serviceHomePath, effectiveUid, effectiveGid);
-      if (existing) {
-        await existing.remove({ force: true }).catch(() => undefined);
-      }
       const name = containerNameFor(body.botId);
       const createdNetwork =
         screenNetworkMode === "internal" ? undefined : await ensureBotNetwork(body.botId);
       let container: Docker.Container | undefined;
       try {
+        if (existing) {
+          await existing.remove({ force: true }).catch(() => undefined);
+        }
         container = await docker.createContainer(
           containerCreateOptions({
             name,

--- a/infra/sandboxes/supervisor/src/index.ts
+++ b/infra/sandboxes/supervisor/src/index.ts
@@ -162,7 +162,7 @@ app.post("/computers", async (c) => {
     return await withBotLifecycleLock(body.botId, async () => {
       await ensureComputerImage();
       const runtimeInfo = await inspectSupervisorContainer();
-      const networkMode = await computerNetworkName(body.botId, runtimeInfo);
+      const networkMode = computerNetworkName(body.botId, runtimeInfo);
       const serviceHomePath = path.resolve(body.homePath);
       assertBotHomePath(serviceHomePath, body.botId);
       const hostUid = process.getuid?.();
@@ -212,20 +212,31 @@ app.post("/computers", async (c) => {
         await existing.remove({ force: true }).catch(() => undefined);
       }
       const name = containerNameFor(body.botId);
-      const container = await docker.createContainer(
-        containerCreateOptions({
-          name,
-          image: COMPUTER_IMAGE,
-          botId: body.botId,
-          spaceId: body.spaceId,
-          homePath,
-          user: computerUser,
-          networkMode,
-          controlToken: randomUUID(),
-          publishControlPort: controlViaLoopback,
-        }),
-      );
-      await container.start();
+      const createdNetwork =
+        screenNetworkMode === "internal" ? undefined : await ensureBotNetwork(body.botId);
+      let container: Docker.Container | undefined;
+      try {
+        container = await docker.createContainer(
+          containerCreateOptions({
+            name,
+            image: COMPUTER_IMAGE,
+            botId: body.botId,
+            spaceId: body.spaceId,
+            homePath,
+            user: computerUser,
+            networkMode,
+            controlToken: randomUUID(),
+            publishControlPort: controlViaLoopback,
+          }),
+        );
+        await container.start();
+      } catch (error) {
+        // Never force removal: a lost start response may hide a running computer.
+        // Docker also refuses network removal while any endpoint is attached.
+        await container?.remove().catch(() => undefined);
+        await createdNetwork?.remove().catch(() => undefined);
+        throw error;
+      }
       return c.json({
         id: container.id,
         image: COMPUTER_IMAGE,
@@ -1098,7 +1109,7 @@ async function setInteractiveScreen(
 // one another (Docker's default "bridge" network allows any container to
 // dial any other container's exposed ports, which would let one bot's
 // computer reach another bot's desktop/VNC endpoint with no authentication).
-async function computerNetworkName(botId: string, info: Docker.ContainerInspectInfo | undefined) {
+function computerNetworkName(botId: string, info: Docker.ContainerInspectInfo | undefined) {
   if (screenNetworkMode === "internal") {
     // The supervisor itself runs in this shared network in that topology and
     // needs to address child containers by their in-network IP, so children
@@ -1108,7 +1119,7 @@ async function computerNetworkName(botId: string, info: Docker.ContainerInspectI
   if (screenNetworkMode === "isolated" && !info) {
     throw new Error("isolated Compose screens require a containerized supervisor");
   }
-  return ensureBotNetwork(botId);
+  return computerNetworkNameFor(botId);
 }
 
 async function connectComposeScreenPeers(networkName: string, info: Docker.ContainerInspectInfo) {
@@ -1139,13 +1150,12 @@ async function connectComposeScreenPeers(networkName: string, info: Docker.Conta
 
 async function ensureBotNetwork(botId: string) {
   const name = computerNetworkNameFor(botId);
-  await docker
+  return docker
     .createNetwork({ Name: name, Driver: "bridge", CheckDuplicate: true })
     .catch((error) => {
       // Existing networks and concurrent provision requests are both safe.
       if (!/already exists/i.test(String(error))) throw error;
     });
-  return name;
 }
 
 async function removeBotNetwork(botId: string) {

--- a/infra/updater/src/compose-images.test.ts
+++ b/infra/updater/src/compose-images.test.ts
@@ -14,6 +14,8 @@ interface ComposeService {
   ports?: unknown[];
   user?: string;
   restart?: string;
+  network_mode?: string;
+  networks?: string[];
 }
 
 const repoRoot = path.resolve(import.meta.dirname, "../../..");
@@ -116,6 +118,16 @@ describe("the images compose file", () => {
     }
   });
 
+  it("does not allocate a default network for offline init services", () => {
+    for (const name of ["computer", "data-init"]) {
+      expect(compose.services[name]?.network_mode).toBe("none");
+      expect(compose.services[name]?.networks).toBeUndefined();
+    }
+    for (const name of ["postgres", ...appServices]) {
+      expect(compose.services[name]?.networks?.length).toBeGreaterThan(0);
+    }
+  });
+
   it("never builds from a checkout", () => {
     for (const service of Object.values(compose.services)) {
       expect(service.build).toBeUndefined();
@@ -153,7 +165,11 @@ describe("the images compose file", () => {
   });
 
   it("publishes the web UI on loopback only", () => {
-    expect(compose.services.web?.ports).toEqual(["127.0.0.1:5173:5173"]);
+    expect(compose.services.web?.ports).toEqual(["127.0.0.1:${RAKAZO_WEB_PORT:-5173}:5173"]);
+    expect(compose.services.api?.ports).toEqual(["127.0.0.1:${RAKAZO_API_PORT:-3100}:3100"]);
+    for (const key of ["BETTER_AUTH_URL", "WEB_ORIGIN", "API_URL"]) {
+      expect(compose.services.api?.environment?.[key]).toBe(`\${${key}:-http://127.0.0.1:5173}`);
+    }
     expect(compose.services.postgres?.ports).toBeUndefined();
     expect(compose.services.supervisor?.ports).toBeUndefined();
   });


### PR DESCRIPTION
## Why

Local desktop startup can fail when development servers occupy its ports or Docker runs out of network address pools. Failed computer provisioning can contribute to exhaustion by leaving a newly allocated network behind.

## Changes

- Allocate bot networks after home validation. Roll back newly created containers and networks on provisioning failure without forcing removal of running containers or disconnecting active endpoints. Preserve existing and shared networks, and keep the existing computer if replacement-network allocation fails.
- Give the managed desktop stack a separate default web port, allocate its API host port dynamically, and retry web-port conflicts twice. Persist the selected loopback origin and use it consistently for authentication, health checks, setup, and reopening.
- Keep standalone Compose port defaults, and remove the unnecessary default network used by offline initialization services.

Error copy appears only after the relevant failure:

> Docker has no free network address pools. Remove unused Docker networks or expand Docker’s address pools, then retry.

This replaces the generic startup error because retrying without freeing address space cannot recover.

> Could not bind a local port after retrying. Retry to choose another port.

This replaces fixed-port advice after automatic recovery is exhausted. Removing it would leave no explanation for the stopped startup. Both messages are already disclosed only when needed.

## Validation

Regression tests were observed failing before the fixes. All 441 targeted desktop, supervisor, and Compose tests pass; opt-in Docker integration tests remain skipped. Repository-wide typecheck and lint pass, and the new Electron test code typechecks. Docker Compose configuration validates both standalone defaults and managed ports/auth origins without starting services.

CI Electron coverage passes for replacement-origin opening/saving, bounded port retries, and address-pool errors. The [CI screenshot artifact](https://github.com/elie222/rakazo/actions/runs/34069487996/artifacts/10000077047) contains `09-setup-address-pool-exhausted.png` and `10-setup-ports-unavailable.png`; both were visually checked.
