### PR TITLE
fix(web): single Close button in view-only peer chat

### DIFF
--- a/apps/web/e2e/peer-messages.spec.ts
+++ b/apps/web/e2e/peer-messages.spec.ts
@@ -88,6 +88,7 @@ test("shows peer chips in transcript and opens view-only peer chat", async ({ pa
   await expect(view).toBeVisible();
   await expect(view.getByRole("heading", { name: /Chief · Researcher/ })).toBeVisible();
   await expect(view.getByText("This chat is view-only")).toBeVisible();
+  await expect(view.getByRole("button", { name: "Close" })).toHaveCount(1);
   await expect(view.getByText("peer-exchange-alpha").first()).toBeVisible({
     timeout: 30_000,
   });

--- a/apps/web/src/pages/PeerMessagesOverlay.tsx
+++ b/apps/web/src/pages/PeerMessagesOverlay.tsx
@@ -144,13 +144,10 @@ export function PeerMessagesOverlay({
           </div>
         )}
 
-        <div className="flex items-center justify-between gap-4 border-t border-sidebar-border px-[18px] py-3.5">
+        <div className="flex items-center gap-4 border-t border-sidebar-border px-[18px] py-3.5">
           <p className="text-[13.5px] text-muted-foreground/80">
             <Trans>This chat is view-only</Trans>
           </p>
-          <DialogClose render={<Button variant="outline" size="sm" />}>
-            <Trans>Close</Trans>
-          </DialogClose>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
Fixes #754.

Why: the view-only bot-to-bot transcript showed two Close buttons performing the identical dismiss action — redundant chrome in a dialog that only closes a view, never deletes.

What changed:
- Removed the footer Close button from PeerMessagesOverlay; kept the header Close (standard dialog placement) and the "This chat is view-only" note.
- Extended the peer-messages e2e spec to assert exactly one Close button in the view.

How tested:
- Biome check clean on both touched files (run via the repo-local binary; the pnpm wrapper OOMs on this machine).
- Web typecheck passes (tsc --noEmit).
- peer-messages e2e spec passes offline via the testkit harness (scripted runtime, fake sandbox): 1 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Updates**
  - Simplified the view-only chat footer to display only its informational message.
  - The dialog’s Close button remains available in the header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->