### PR TITLE
fix(web): paste images into the composer as attachments

### DIFF
--- a/apps/web/e2e/composer-paste.spec.ts
+++ b/apps/web/e2e/composer-paste.spec.ts
@@ -42,3 +42,25 @@ test("pasting text into the composer still inserts text", async ({ page, context
   await page.keyboard.press("ControlOrMeta+v");
   await expect(composer).toHaveValue("pasted words");
 });
+
+test("pasting an image with text keeps the attachment and inserts text", async ({ page }) => {
+  const composer = await openComposer(page);
+  await composer.click();
+  await page.evaluate(() => {
+    const target = document.querySelector("textarea[name='chat-message']");
+    if (!(target instanceof HTMLTextAreaElement)) throw new Error("composer textarea not found");
+    const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+    const file = new File([bytes], "mixed.png", { type: "image/png" });
+    const clipboardData = {
+      files: [file],
+      types: ["Files", "text/plain"],
+      items: [{ kind: "file" }, { kind: "string" }],
+      getData: (type: string) => (type === "text/plain" ? "caption text" : ""),
+    };
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", { value: clipboardData });
+    target.dispatchEvent(event);
+  });
+  await expect(page.getByRole("button", { name: "Remove mixed.png" })).toBeVisible();
+  await expect(composer).toHaveValue("caption text");
+});

--- a/apps/web/e2e/composer-paste.spec.ts
+++ b/apps/web/e2e/composer-paste.spec.ts
@@ -1,0 +1,44 @@
+import { expect, type Page, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+async function openComposer(page: Page) {
+  const stamp = Date.now();
+  await signup(page, `composer-paste-${stamp}@rakazo.test`, "password12", "Paste Test");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+  const composer = page.getByRole("combobox", { name: /Message/ });
+  await expect(composer).toBeVisible();
+  return composer;
+}
+
+test("pasting an image into the composer creates an attachment", async ({ page }, testInfo) => {
+  const composer = await openComposer(page);
+  await composer.click();
+  await page.evaluate(() => {
+    const target = document.querySelector("textarea[name='chat-message']");
+    if (!target) throw new Error("composer textarea not found");
+    const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+    const file = new File([bytes], "paste.png", { type: "image/png" });
+    const clipboardData = {
+      files: [file],
+      types: ["Files"],
+      items: [{ kind: "file" }],
+      getData: () => "",
+    };
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", { value: clipboardData });
+    target.dispatchEvent(event);
+  });
+  await expect(page.getByRole("button", { name: "Remove paste.png" })).toBeVisible();
+  await captureScreenshot(page, testInfo, "composer-paste-attachment");
+});
+
+test("pasting text into the composer still inserts text", async ({ page, context }) => {
+  const composer = await openComposer(page);
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.evaluate(() => navigator.clipboard.writeText("pasted words"));
+  await composer.click();
+  await page.keyboard.press("ControlOrMeta+v");
+  await expect(composer).toHaveValue("pasted words");
+});

--- a/apps/web/src/lib/pending-attachments.test.ts
+++ b/apps/web/src/lib/pending-attachments.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
-import { isFileDrag, revokePendingAttachmentPreviews } from "./pending-attachments.js";
+import { isFileDrag, isFilePaste, revokePendingAttachmentPreviews } from "./pending-attachments.js";
+
+function fileList(length: number) {
+  return { length } as unknown as FileList;
+}
+
+function pasteData(files: number, itemKinds: string[] = []) {
+  return {
+    files: fileList(files),
+    items: itemKinds.map((kind) => ({ kind })),
+  } as unknown as DataTransfer;
+}
 
 function dragData(types: string[], itemKinds: string[] = []) {
   return {
@@ -20,6 +31,22 @@ describe("isFileDrag", () => {
   it("ignores text and other drags", () => {
     expect(isFileDrag(dragData(["text/plain"], ["string"]))).toBe(false);
     expect(isFileDrag(null)).toBe(false);
+  });
+});
+
+describe("isFilePaste", () => {
+  it("recognizes pasted files", () => {
+    expect(isFilePaste(pasteData(1))).toBe(true);
+  });
+
+  it("recognizes file items when the file list is empty", () => {
+    expect(isFilePaste(pasteData(0, ["file"]))).toBe(true);
+  });
+
+  it("ignores text-only pastes", () => {
+    expect(isFilePaste(pasteData(0, ["string"]))).toBe(false);
+    expect(isFilePaste(null)).toBe(false);
+    expect(isFilePaste(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/pending-attachments.test.ts
+++ b/apps/web/src/lib/pending-attachments.test.ts
@@ -39,8 +39,8 @@ describe("isFilePaste", () => {
     expect(isFilePaste(pasteData(1))).toBe(true);
   });
 
-  it("recognizes file items when the file list is empty", () => {
-    expect(isFilePaste(pasteData(0, ["file"]))).toBe(true);
+  it("ignores file-kind items when the file list is empty", () => {
+    expect(isFilePaste(pasteData(0, ["file"]))).toBe(false);
   });
 
   it("ignores text-only pastes", () => {

--- a/apps/web/src/lib/pending-attachments.ts
+++ b/apps/web/src/lib/pending-attachments.ts
@@ -14,10 +14,9 @@ export function isFilePaste(
   clipboardData: Pick<DataTransfer, "files" | "items"> | null | undefined,
 ): boolean {
   if (!clipboardData) return false;
-  return (
-    (clipboardData.files?.length ?? 0) > 0 ||
-    Array.from(clipboardData.items ?? []).some((item) => item.kind === "file")
-  );
+  // Require a non-empty FileList. Some browsers advertise file-kind items with
+  // an empty files list; those must not intercept native text paste.
+  return (clipboardData.files?.length ?? 0) > 0;
 }
 
 export function revokePendingAttachmentPreviews(

--- a/apps/web/src/lib/pending-attachments.ts
+++ b/apps/web/src/lib/pending-attachments.ts
@@ -10,6 +10,16 @@ export function isFileDrag(dataTransfer: Pick<DataTransfer, "types" | "items"> |
   );
 }
 
+export function isFilePaste(
+  clipboardData: Pick<DataTransfer, "files" | "items"> | null | undefined,
+): boolean {
+  if (!clipboardData) return false;
+  return (
+    (clipboardData.files?.length ?? 0) > 0 ||
+    Array.from(clipboardData.items ?? []).some((item) => item.kind === "file")
+  );
+}
+
 export function revokePendingAttachmentPreviews(
   attachments: readonly PendingAttachmentPreview[],
 ): void {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -4575,9 +4575,20 @@ const Composer = memo(function Composer({
 
   function handlePaste(event: ClipboardEvent<HTMLTextAreaElement>) {
     const clipboardData = event.clipboardData;
+    // Only intercept real FileList pastes; leave text-only / empty-files native.
     if (disabled || !clipboardData || !isFilePaste(clipboardData)) return;
     event.preventDefault();
     void onAttachmentPick(clipboardData.files);
+    const text = clipboardData.getData("text/plain");
+    if (!text) return;
+    const textarea = event.currentTarget;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    updateDraft(`${draft.slice(0, start)}${text}${draft.slice(end)}`);
+    const caret = start + text.length;
+    window.requestAnimationFrame(() => {
+      textareaRef.current?.setSelectionRange(caret, caret);
+    });
   }
 
   const showComposerPlaceholder =

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -104,6 +104,7 @@ import {
   X,
 } from "lucide-react";
 import {
+  type ClipboardEvent,
   type DragEvent,
   lazy,
   type MutableRefObject,
@@ -153,7 +154,11 @@ import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { localTimezone } from "../lib/local-timezone";
 import { copyableMessageText } from "../lib/message-text";
 import { messageProviderLabel } from "../lib/messaging";
-import { isFileDrag, revokePendingAttachmentPreviews } from "../lib/pending-attachments";
+import {
+  isFileDrag,
+  isFilePaste,
+  revokePendingAttachmentPreviews,
+} from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
 import { clearSpaceSelection, rpc, selectedSpaceId, selectSpace } from "../lib/rpc";
 import { readSeenRunErrorIds, rememberSeenRunErrorId } from "../lib/run-error-storage";
@@ -4568,6 +4573,13 @@ const Composer = memo(function Composer({
     if (!disabled) void onAttachmentPick(dataTransfer.files);
   }
 
+  function handlePaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    const clipboardData = event.clipboardData;
+    if (disabled || !clipboardData || !isFilePaste(clipboardData)) return;
+    event.preventDefault();
+    void onAttachmentPick(clipboardData.files);
+  }
+
   const showComposerPlaceholder =
     draft.length === 0 && selectedSkill === null && selectedMentions.length === 0;
   const replyName = replyTarget ? (replyTargetName ?? previewMessageText(replyTarget)) : "";
@@ -4840,6 +4852,7 @@ const Composer = memo(function Composer({
             ref={textareaRef}
             value={draft}
             onChange={(event) => updateDraft(event.target.value)}
+            onPaste={handlePaste}
             onKeyDown={(event) => {
               if (
                 event.key === "Backspace" &&


### PR DESCRIPTION
Fixes #756.

Why: the composer is a plain text box with no paste handling, so pasting an image (e.g. a screenshot) is silently ignored. Images only got in via drag-and-drop or the attach button.

What changed:
- Composer textarea now handles paste: when the clipboard carries files, they go through the existing pending-attachment path (same count/size/type validation and skipped-file notice as drag-and-drop and the file picker). Text-only pastes are untouched and insert natively.
- Added an isFilePaste helper next to isFileDrag with unit tests.
- New composer-paste e2e spec: image paste creates the attachment chip; text paste still inserts text.

How tested:
- New unit tests for isFilePaste plus existing pending-attachments suite: 7 passed.
- Biome check clean on all touched files; web typecheck passes (tsc --noEmit).
- composer-paste e2e spec passes offline via the testkit harness (scripted runtime, fake sandbox): 2 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pasting files directly into the message composer.
  - Pasted files are added as removable attachments before sending.
  - Text-only clipboard content continues to paste normally.
  - When a paste includes both an image and text, the image is attached and the text is inserted at the cursor.

- **Tests**
  - Added coverage for file pasting, mixed image-and-text pastes, text pasting, empty clipboard data, and attachment removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->