### PR TITLE
fix(web): paste clipboard images into the composer as attachments (#756)

### DIFF
--- a/apps/web/src/lib/pending-attachments.test.ts
+++ b/apps/web/src/lib/pending-attachments.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { isFileDrag, revokePendingAttachmentPreviews } from "./pending-attachments.js";
+import {
+  filesFromClipboard,
+  isFileDrag,
+  revokePendingAttachmentPreviews,
+} from "./pending-attachments.js";
 
 function dragData(types: string[], itemKinds: string[] = []) {
   return {
@@ -20,6 +24,54 @@ describe("isFileDrag", () => {
   it("ignores text and other drags", () => {
     expect(isFileDrag(dragData(["text/plain"], ["string"]))).toBe(false);
     expect(isFileDrag(null)).toBe(false);
+  });
+});
+
+describe("filesFromClipboard", () => {
+  it("returns an empty list when clipboard has no file payload", () => {
+    expect(filesFromClipboard(null)).toEqual([]);
+    expect(
+      filesFromClipboard({
+        files: [] as unknown as FileList,
+        items: [{ kind: "string", getAsFile: () => null }] as unknown as DataTransferItemList,
+      }),
+    ).toEqual([]);
+  });
+
+  it("prefers clipboard.files when present", () => {
+    const file = new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+    const files = {
+      length: 1,
+      0: file,
+      item: (index: number) => (index === 0 ? file : null),
+      [Symbol.iterator]: function* () {
+        yield file;
+      },
+    } as unknown as FileList;
+
+    expect(filesFromClipboard({ files, items: null })).toEqual([file]);
+  });
+
+  it("reads file items and names unnamed screenshot pastes", () => {
+    const unnamed = new File([new Uint8Array([9])], "", { type: "image/png" });
+    const named = new File([new Uint8Array([8])], "notes.txt", { type: "text/plain" });
+    const items = [
+      { kind: "string", getAsFile: () => null },
+      { kind: "file", getAsFile: () => unnamed },
+      { kind: "file", getAsFile: () => named },
+    ] as unknown as DataTransferItemList;
+
+    const result = filesFromClipboard({ files: null, items });
+    expect(result).toHaveLength(2);
+    expect(result[0]?.name).toBe("paste-1.png");
+    expect(result[0]?.type).toBe("image/png");
+    expect(result[1]).toBe(named);
+  });
+
+  it("uses jpg for jpeg clipboard images without a name", () => {
+    const unnamed = new File([new Uint8Array([1])], "   ", { type: "image/jpeg" });
+    const items = [{ kind: "file", getAsFile: () => unnamed }] as unknown as DataTransferItemList;
+    expect(filesFromClipboard({ items })[0]?.name).toBe("paste-1.jpg");
   });
 });
 

--- a/apps/web/src/lib/pending-attachments.ts
+++ b/apps/web/src/lib/pending-attachments.ts
@@ -10,6 +10,48 @@ export function isFileDrag(dataTransfer: Pick<DataTransfer, "types" | "items"> |
   );
 }
 
+type ClipboardFileSource = {
+  files?: FileList | null;
+  items?: DataTransferItemList | ArrayLike<DataTransferItem> | null;
+};
+
+function extensionForMimeType(mimeType: string): string {
+  const subtype = mimeType.split("/")[1]?.split("+")[0]?.toLowerCase();
+  if (!subtype) return "bin";
+  if (subtype === "jpeg") return "jpg";
+  return subtype;
+}
+
+function nameForClipboardFile(file: File, index: number): string {
+  if (file.name.trim()) return file.name;
+  return `paste-${index + 1}.${extensionForMimeType(file.type)}`;
+}
+
+function withClipboardFileName(file: File, index: number): File {
+  const name = nameForClipboardFile(file, index);
+  if (name === file.name) return file;
+  return new File([file], name, { type: file.type, lastModified: file.lastModified });
+}
+
+/** Collect clipboard file items for the composer attachment path. */
+export function filesFromClipboard(clipboardData: ClipboardFileSource | null): File[] {
+  if (!clipboardData) return [];
+
+  const fromFiles = clipboardData.files ? Array.from(clipboardData.files) : [];
+  if (fromFiles.length) {
+    return fromFiles.map((file, index) => withClipboardFileName(file, index));
+  }
+
+  const items = clipboardData.items ? Array.from(clipboardData.items) : [];
+  const files: File[] = [];
+  for (const item of items) {
+    if (item.kind !== "file") continue;
+    const file = item.getAsFile();
+    if (file) files.push(withClipboardFileName(file, files.length));
+  }
+  return files;
+}
+
 export function revokePendingAttachmentPreviews(
   attachments: readonly PendingAttachmentPreview[],
 ): void {

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -104,6 +104,7 @@ import {
   X,
 } from "lucide-react";
 import {
+  type ClipboardEvent,
   type DragEvent,
   lazy,
   type MutableRefObject,
@@ -153,7 +154,11 @@ import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { localTimezone } from "../lib/local-timezone";
 import { copyableMessageText } from "../lib/message-text";
 import { messageProviderLabel } from "../lib/messaging";
-import { isFileDrag, revokePendingAttachmentPreviews } from "../lib/pending-attachments";
+import {
+  filesFromClipboard,
+  isFileDrag,
+  revokePendingAttachmentPreviews,
+} from "../lib/pending-attachments";
 import { markAfterPaint, markOnce } from "../lib/performance";
 import { clearSpaceSelection, rpc, selectedSpaceId, selectSpace } from "../lib/rpc";
 import { readSeenRunErrorIds, rememberSeenRunErrorId } from "../lib/run-error-storage";
@@ -1801,7 +1806,7 @@ export function ShellPage() {
     [t],
   );
   const onAttachmentPick = useCallback(
-    async (files: FileList | null) => {
+    async (files: FileList | readonly File[] | null) => {
       const threadKey = activeGroupId.current ?? activeBotId.current;
       if (!threadKey || !files?.length) return;
       const existing = attachmentsForThread(pendingAttachments, threadKey);
@@ -4321,7 +4326,7 @@ const Composer = memo(function Composer({
   onDismissError: () => void;
   sending: boolean;
   fileInputRef: RefObject<HTMLInputElement | null>;
-  onAttachmentPick: (files: FileList | null) => void | Promise<void>;
+  onAttachmentPick: (files: FileList | readonly File[] | null) => void | Promise<void>;
   onRemoveAttachment: (attachment: PendingAttachment) => void;
   onSend: (text: string, mentions?: ComposerMention[]) => Promise<void>;
   onStop: () => Promise<void>;
@@ -4566,6 +4571,27 @@ const Composer = memo(function Composer({
     dragDepth.current = 0;
     setDraggingFiles(false);
     if (!disabled) void onAttachmentPick(dataTransfer.files);
+  }
+
+  function handlePaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    if (disabled) return;
+    const files = filesFromClipboard(event.clipboardData);
+    if (!files.length) return;
+    event.preventDefault();
+    void onAttachmentPick(files);
+    const text = event.clipboardData?.getData("text/plain") ?? "";
+    if (!text) return;
+    const el = textareaRef.current;
+    const start = el?.selectionStart ?? draft.length;
+    const end = el?.selectionEnd ?? draft.length;
+    const next = `${draft.slice(0, start)}${text}${draft.slice(end)}`;
+    const caret = start + text.length;
+    updateDraft(next);
+    window.requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.setSelectionRange(caret, caret);
+    });
   }
 
   const showComposerPlaceholder =
@@ -4840,6 +4866,7 @@ const Composer = memo(function Composer({
             ref={textareaRef}
             value={draft}
             onChange={(event) => updateDraft(event.target.value)}
+            onPaste={handlePaste}
             onKeyDown={(event) => {
               if (
                 event.key === "Backspace" &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #756.

## Why

Pasting an image into the chat composer did nothing. Browsers cannot put image clipboard data into a plain text field without app code, so screenshots only worked via drag-and-drop or the attach button.

## What changed

- Composer textarea `onPaste` extracts clipboard files via `filesFromClipboard` and feeds them into the existing `onAttachmentPick` path (same count, size, and MIME validation).
- Unnamed screenshot pastes get a synthetic name (`paste-1.png`) so chips and upload names stay readable.
- Text-only paste is unchanged. When a paste includes both files and plain text, files attach and the text is still inserted.
- Unit coverage for clipboard file extraction (including item-only pastes when `clipboardData.files` is empty).

## Tests

- `pnpm --filter @rakazo/web exec vitest run src/lib/pending-attachments.test.ts` (8 passed)
- `pnpm exec biome check` clean on the touched files

No new user-facing copy. No local screenshots; attach UI is unchanged beyond attaching on paste.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8940a84-0e8b-42e8-891a-8b93cf9af272?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8940a84-0e8b-42e8-891a-8b93cf9af272&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for pasting file attachments directly into the composer.
  - Pasted files now follow the same validation and attachment handling as uploaded or dragged files.
  - Pasted text is inserted at the current cursor position.
  - Unnamed pasted images receive appropriate fallback filenames, including `.jpg` for JPEG images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->