### PR TITLE
fix(web): open CreateBotForm when creating a later bot from +

### DIFF
--- a/apps/web/e2e/bot-crud.spec.ts
+++ b/apps/web/e2e/bot-crud.spec.ts
@@ -28,12 +28,18 @@ test("bot creation, editing, and deletion persist", async ({ page }, testInfo) =
     resolveCreateAborted();
   });
   await openNewBot(page);
+  const form = page.getByTestId("create-bot-form");
+  await form.locator("label:has-text('Name') input").fill("New Bot");
+  await form.getByRole("button", { name: "Create", exact: true }).click();
   await createAborted;
-  // Instant create stays in chat; failed create leaves the current bot open.
+  // Failed create keeps the form open on the current bot chat.
   await expect(page.getByPlaceholder("Message Chief")).toBeVisible();
-  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
+  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "create");
+  await expect(page.getByTestId("create-bot-error")).toBeVisible();
   expect(createFailed).toBe(true);
   await page.unroute("**/rpc/bots/create");
+  await page.getByRole("button", { name: "Cancel new bot" }).click();
+  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
 
   let failedPostCreateRefresh = false;
   await page.route("**/rpc/spaces/list", async (route) => {

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -77,13 +77,11 @@ export async function captureScreenshot(page: Page, testInfo: TestInfo, name: st
   await testInfo.attach(name, { contentType: "image/png", path: screenshotPath });
 }
 
-export async function openNewBot(page: Page, computerMode: "team" | "dedicated" = "team") {
+export async function openNewBot(page: Page) {
   await page.getByTestId("create-menu-trigger").click();
   await page.getByTestId("create-new-bot").click();
-  await expect(page.getByTestId("create-bot-computer")).toBeVisible();
-  await page
-    .getByTestId(computerMode === "team" ? "create-bot-team" : "create-bot-private")
-    .click();
+  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "create");
+  await expect(page.getByTestId("create-bot-form")).toBeVisible();
 }
 
 export async function openNewGroup(page: Page) {
@@ -96,9 +94,32 @@ export async function openNewSpace(page: Page) {
   await page.getByTestId("create-new-space").click();
 }
 
-/** Instant-create a bot from the + picker and wait for its chat (side panel closed). */
-export async function createBotFromPicker(page: Page) {
+/** Open the create form from the + picker, submit, and wait for the new chat. */
+export async function createBotFromPicker(
+  page: Page,
+  options: {
+    name?: string;
+    title?: string;
+    description?: string;
+    computerMode?: "team" | "dedicated";
+  } = {},
+) {
+  const name = options.name ?? "New Bot";
   await openNewBot(page);
+  const form = page.getByTestId("create-bot-form");
+  await form.locator("label:has-text('Name') input").fill(name);
+  if (options.title != null) {
+    await form.locator("label:has-text('Title') input").fill(options.title);
+  }
+  if (options.description != null) {
+    await form.locator("label:has-text('Description') textarea").fill(options.description);
+  }
+  if (options.computerMode === "dedicated") {
+    await form.getByTestId("create-bot-private").click();
+  } else if (options.computerMode === "team") {
+    await form.getByTestId("create-bot-team").click();
+  }
+  await form.getByRole("button", { name: "Create", exact: true }).click();
   await page.waitForURL(/\/app\/[^/]+$/);
   await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
 }

--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -8,7 +8,7 @@ import {
   signup,
 } from "./helpers";
 
-test("create opens empty chat, picker lists bots, and sidebar collapses", async ({
+test("create opens form, then empty chat; picker lists bots; sidebar collapses", async ({
   page,
 }, testInfo) => {
   const stamp = Date.now();
@@ -25,13 +25,20 @@ test("create opens empty chat, picker lists bots, and sidebar collapses", async 
   await captureScreenshot(page, testInfo, "plus-picker-bots");
 
   await picker.getByTestId("create-new-bot").click();
-  await expect(picker.getByTestId("create-bot-computer")).toBeVisible();
-  await expect(picker.getByTestId("create-bot-team")).toBeVisible();
-  await expect(picker.getByTestId("create-bot-private")).toBeVisible();
-  await captureScreenshot(page, testInfo, "plus-picker-computer-mode");
-  await page.keyboard.press("Escape");
+  const form = page.getByTestId("create-bot-form");
+  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "create");
+  await expect(form).toBeVisible();
+  await expect(form.locator("label:has-text('Name') input")).toBeVisible();
+  await expect(form.locator("label:has-text('Title') input")).toBeVisible();
+  await expect(form.locator("label:has-text('Description') textarea")).toBeVisible();
+  await expect(form.getByTestId("create-bot-computer")).toBeVisible();
+  await expect(form.getByTestId("create-bot-team")).toBeVisible();
+  await expect(form.getByTestId("create-bot-private")).toBeVisible();
+  await captureScreenshot(page, testInfo, "create-bot-form");
 
-  await createBotFromPicker(page);
+  await form.locator("label:has-text('Name') input").fill("New Bot");
+  await form.getByRole("button", { name: "Create", exact: true }).click();
+  await page.waitForURL(/\/app\/[^/]+$/);
   await expect(page.getByPlaceholder("Message New Bot")).toBeVisible();
   await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
   await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
@@ -61,8 +68,7 @@ test("later bot waits before showing the focus card; sending cancels it", async 
   await expect(page.getByText("What do you want me on first?", { exact: true })).toBeVisible();
 
   await page.clock.install();
-  await openNewBot(page);
-  await page.waitForURL(/\/app\/[^/]+$/);
+  await createBotFromPicker(page);
   await expect(page.getByPlaceholder("Message New Bot")).toBeVisible();
   await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
 
@@ -71,8 +77,7 @@ test("later bot waits before showing the focus card; sending cancels it", async 
   await page.clock.fastForward(1_500);
   await expect(page.getByText("What do you want me on first?", { exact: true })).toBeVisible();
 
-  await openNewBot(page);
-  await page.waitForURL(/\/app\/[^/]+$/);
+  await createBotFromPicker(page, { name: "Later Bot" });
   await expect(page.getByText("What do you want me on first?", { exact: true })).toHaveCount(0);
   const composer = page.getByPlaceholder(/Message/);
   await composer.fill("I'll set this up myself");
@@ -88,12 +93,37 @@ test("plus picker can create a Private computer bot", async ({ page }, testInfo)
   await page.goto("/app");
   await page.waitForURL(/\/app\/[^/]+$/);
 
-  await openNewBot(page, "dedicated");
-  await page.waitForURL(/\/app\/[^/]+$/);
+  await createBotFromPicker(page, { computerMode: "dedicated" });
   await expect(page.getByPlaceholder("Message New Bot")).toBeVisible();
   await captureScreenshot(page, testInfo, "create-private-computer-bot");
 
   const botId = page.url().split("/").pop()!;
   const bots = await rpc<Array<{ id: string; computerMode: string }>>(page, "bots/list", {});
   expect(bots.find((bot) => bot.id === botId)?.computerMode).toBe("dedicated");
+});
+
+test("second bot from plus opens create form before persist", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `second-bot-form-${stamp}@rakazo.test`, "password12", "Second Bot Form");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  await openNewBot(page);
+  const form = page.getByTestId("create-bot-form");
+  await expect(form).toBeVisible();
+  await form.locator("label:has-text('Name') input").fill("Researcher");
+  await form.locator("label:has-text('Title') input").fill("Finds sources");
+  await form.locator("label:has-text('Description') textarea").fill("Briefs from the web.");
+  await captureScreenshot(page, testInfo, "second-bot-create-form");
+
+  const create = page.waitForResponse(
+    (response) => response.url().includes("/rpc/bots/create") && response.ok(),
+  );
+  await form.getByRole("button", { name: "Create", exact: true }).click();
+  await create;
+  await page.waitForURL(/\/app\/[^/]+$/);
+  await expect(page.getByPlaceholder("Message Researcher")).toBeVisible();
+  await expect(page.getByTestId("side-panel")).toHaveAttribute("data-panel", "closed");
+  await captureScreenshot(page, testInfo, "second-bot-created");
 });

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2463,6 +2463,7 @@ export function ShellPage() {
                     bots={bots}
                     onCreateBot={() => {
                       setCreateMenuOpen(false);
+                      setMobileSidebarOpen(false);
                       setPanel("create");
                     }}
                     onOpenBot={(id) => {
@@ -2472,10 +2473,12 @@ export function ShellPage() {
                     }}
                     onCreateGroup={() => {
                       setCreateMenuOpen(false);
+                      setMobileSidebarOpen(false);
                       setPanel("create-group");
                     }}
                     onCreateSpace={() => {
                       setCreateMenuOpen(false);
+                      setMobileSidebarOpen(false);
                       setNewSpaceOpen(true);
                     }}
                   />

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -440,7 +440,6 @@ export function ShellPage() {
   const [botsSidebarCollapsed, setBotsSidebarCollapsed] = useState(false);
   const focusPromptAbortRef = useRef<AbortController | null>(null);
   const focusPromptBotIdRef = useRef<string | null>(null);
-  const creatingBotRef = useRef(false);
   const botsSidebarEdgeDragRef = useRef<{ startX: number; mode: "expand" | "collapse" } | null>(
     null,
   );
@@ -2175,24 +2174,6 @@ export function ShellPage() {
     await refreshBots().catch(() => undefined);
   }
 
-  async function createBotQuick(computerMode: ComputerMode = "team") {
-    if (creatingBotRef.current) return;
-    creatingBotRef.current = true;
-    try {
-      await createBot({
-        name: "New Bot",
-        title: "",
-        description: "",
-        computerMode,
-      });
-    } catch (error) {
-      // Keep the current chat open when create fails, but surface the error.
-      setSendError(error instanceof Error ? error.message : t`Could not create bot`);
-    } finally {
-      creatingBotRef.current = false;
-    }
-  }
-
   async function bootComputer({
     takeControl,
     overlay,
@@ -2480,9 +2461,9 @@ export function ShellPage() {
                 >
                   <BotCreatePicker
                     bots={bots}
-                    onCreateBot={(computerMode) => {
+                    onCreateBot={() => {
                       setCreateMenuOpen(false);
-                      void createBotQuick(computerMode);
+                      setPanel("create");
                     }}
                     onOpenBot={(id) => {
                       setCreateMenuOpen(false);

--- a/apps/web/src/pages/shell/bot-panel.tsx
+++ b/apps/web/src/pages/shell/bot-panel.tsx
@@ -43,9 +43,13 @@ const fieldLabelClass = "mt-4 block text-[14px] text-muted-foreground";
 function ComputerModePicker({
   value,
   onChange,
+  teamTestId,
+  privateTestId,
 }: {
   value: ComputerMode;
   onChange: (value: ComputerMode) => void;
+  teamTestId?: string;
+  privateTestId?: string;
 }) {
   return (
     <div className="mt-4">
@@ -58,6 +62,7 @@ function ComputerModePicker({
             key={mode}
             variant="outline"
             pressed={value === mode}
+            data-testid={mode === "team" ? teamTestId : privateTestId}
             onPressedChange={(pressed) => {
               if (pressed) onChange(mode);
             }}
@@ -111,7 +116,7 @@ export function CreateBotForm({
   }
 
   return (
-    <div>
+    <div data-testid="create-bot-form">
       <div className="mb-4 flex items-center justify-between">
         <span className="text-[13.5px] text-muted-foreground">
           <Trans>New bot</Trans>
@@ -163,7 +168,14 @@ export function CreateBotForm({
           className="mt-2"
         />
       </label>
-      <ComputerModePicker value={computerMode} onChange={setComputerMode} />
+      <div data-testid="create-bot-computer">
+        <ComputerModePicker
+          value={computerMode}
+          onChange={setComputerMode}
+          teamTestId="create-bot-team"
+          privateTestId="create-bot-private"
+        />
+      </div>
       <Button
         className="mt-5"
         disabled={!name.trim() || submitting}

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -1,5 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import type { Bot, ComputerMode } from "@rakazo/contracts";
+import type { Bot } from "@rakazo/contracts";
 import {
   BotAvatar,
   Command,
@@ -9,7 +9,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@rakazo/ui-web";
-import { ArrowLeft, Lock, Plus } from "lucide-react";
+import { Lock, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 
 export function BotCreatePicker({
@@ -20,14 +20,13 @@ export function BotCreatePicker({
   onCreateSpace,
 }: {
   bots: Bot[];
-  onCreateBot: (computerMode: ComputerMode) => void;
+  onCreateBot: () => void;
   onOpenBot: (botId: string) => void;
   onCreateGroup: () => void;
   onCreateSpace: () => void;
 }) {
   const { t } = useLingui();
   const [query, setQuery] = useState("");
-  const [step, setStep] = useState<"pick" | "computer">("pick");
   const needle = query.trim().toLowerCase();
   const matched = useMemo(() => {
     if (!needle) return bots;
@@ -39,45 +38,6 @@ export function BotCreatePicker({
     !needle ||
     "create new bot".includes(needle) ||
     needle.split(/\s+/).every((part) => "create new bot".includes(part));
-
-  if (step === "computer") {
-    return (
-      <div data-testid="bot-create-picker" className="w-[min(320px,calc(100vw-2rem))]">
-        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
-          <button
-            type="button"
-            data-testid="create-bot-computer-back"
-            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-            aria-label={t`Back`}
-            onClick={() => setStep("pick")}
-          >
-            <ArrowLeft size={16} strokeWidth={1.8} aria-hidden="true" />
-          </button>
-          <span className="text-[13px] text-muted-foreground">
-            <Trans>Computer</Trans>
-          </span>
-        </div>
-        <div data-testid="create-bot-computer" className="grid grid-cols-2 gap-2 p-3">
-          <button
-            type="button"
-            data-testid="create-bot-team"
-            className="rounded-lg border border-border px-3 py-2 text-[14px] text-foreground hover:border-foreground/40"
-            onClick={() => onCreateBot("team")}
-          >
-            <Trans>Team</Trans>
-          </button>
-          <button
-            type="button"
-            data-testid="create-bot-private"
-            className="rounded-lg border border-border px-3 py-2 text-[14px] text-foreground hover:border-foreground/40"
-            onClick={() => onCreateBot("dedicated")}
-          >
-            <Trans>Private</Trans>
-          </button>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div data-testid="bot-create-picker" className="w-[min(320px,calc(100vw-2rem))]">
@@ -103,7 +63,7 @@ export function BotCreatePicker({
               <CommandItem
                 value="create-new-bot"
                 data-testid="create-new-bot"
-                onSelect={() => setStep("computer")}
+                onSelect={() => onCreateBot()}
                 className="gap-2"
               >
                 <Plus size={16} strokeWidth={1.8} aria-hidden="true" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After the first bot exists, the sidebar **+** menu created another bot immediately as a placeholder named "New Bot" with empty title/description. Users had to open the profile afterward to rename. `CreateBotForm` already existed but that path never opened it.

## What changed

- **+ → Create new Bot** closes the picker and opens the existing `CreateBotForm` (name, title, description, computer mode) before `bots/create`.
- Removed the picker’s intermediate computer-mode step and the instant `createBotQuick` path; computer mode lives on the form.
- On narrow viewports, dismiss the mobile sidebar when opening create surfaces so the form is not covered.
- Updated web Playwright helpers and specs so subsequent-bot creation fills the form; added a second-bot create-form test that uses the existing screenshot checkpoint pattern for CI feature frames.

## How tested

- `pnpm --filter @rakazo/web check`
- `biome check` on the touched files
- CI Web E2E passed on this branch
- Feature frame: [second bot create form](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34082137546-1/screenshots/images/180-second-bot-create-form.png) ([gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/760/index.html))

Fixes #755

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9adaaf2d-9e01-45a3-a32c-f421aceb143a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9adaaf2d-9e01-45a3-a32c-f421aceb143a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated bot creation form that appears before opening the new bot chat.
  * Added support for configuring bot name, title, description, and computer mode before submission.
  * Streamlined bot creation by opening the full form directly from the creation menu.

* **Bug Fixes**
  * Bot creation errors now keep the form open and display an error while preserving the current chat.
  * Added the ability to cancel a failed bot creation and close the form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->