### PR TITLE
fix(web): use Lucide search icon in sidebar search

### DIFF
--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -97,6 +97,7 @@ import {
   Plus,
   Puzzle,
   Reply,
+  Search,
   Settings,
   Smile,
   Square,
@@ -2498,7 +2499,7 @@ export function ShellPage() {
         </div>
         <InputGroup data-testid="sidebar-search" className="mx-2.5 mb-3 w-auto rounded-xl bg-card">
           <InputGroupAddon>
-            <span aria-hidden="true">⌕</span>
+            <Search size={16} strokeWidth={1.8} aria-hidden="true" />
           </InputGroupAddon>
           <InputGroupInput
             value={query}


### PR DESCRIPTION
## Why
The sidebar search field rendered its magnifier as a raw Unicode glyph (⌕) in a plain span, which came out tiny and off-baseline compared to every other stroke icon in the sidebar.

## What
- Replaced the text glyph in the sidebar-search InputGroupAddon with Lucide's Search icon (size 16, strokeWidth 1.8), matching neighboring icon sizing.
- Added Search to the existing lucide-react import in Shell.tsx.

## How tested
- Biome check on Shell.tsx: clean.
- tsc --noEmit (web): clean.
- Web unit tests: 38 files / 207 tests pass.
- CI: all checks green (Lint, Typecheck, Unit tests, Postgres journeys, Web E2E, Greptile 5/5 with no actionable findings, CodeRabbit with no actionable comments).
- E2E screenshots: [Playwright gallery for this PR](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/763/index.html) (sidebar search is covered by ui-appearance.spec.ts).