### PR TITLE
fix(db): keep a deleted bot's token spend and its attribution

### DIFF
--- a/packages/db/prisma/migrations/20260907130000_usage_records_keep_bot_attribution/migration.sql
+++ b/packages/db/prisma/migrations/20260907130000_usage_records_keep_bot_attribution/migration.sql
@@ -1,0 +1,27 @@
+-- Keep a bot's token spend, and the knowledge of which bot spent it, after the bot is deleted.
+--
+-- usage_records_botId_fkey was ON DELETE CASCADE, so `bots/remove` erased the bot's usage rows
+-- along with everything else. #30 catalogued the cascade breadth (thread, messages, events,
+-- runs, effects, memory, computer, routines, artifacts) and #40 answered it with the
+-- bot_deletions tombstone, treating that breadth as a design call. usage_records was not in
+-- that list: it is not conversation state that a user chooses to discard, it is the record of
+-- what the bot cost, and deleting a bot should not be a way to erase it.
+--
+-- ON DELETE SET NULL was considered and rejected. Deleting a bot also deletes its runs, which
+-- fires usage_records_runId_fkey (already SET NULL), so botId and runId would BOTH come back
+-- NULL and the row would keep only space, user, model and token counts. The money survives and
+-- the attribution does not, which makes "which bot spent what" unanswerable one column later.
+--
+-- So: no foreign key. A financial row must not cascade, blank or fail because of a lifecycle
+-- event on its subject. This is the same shape the codebase already uses elsewhere for an
+-- identity column that has to outlive its row.
+--
+-- Consequence accepted: botId may dangle. BotDeletion.id IS the bot id, so a deleted bot's
+-- name stays reachable through a LEFT JOIN. No index is added on botId: nothing queries per
+-- bot today, and the foreign key never provided one either (Postgres does not index a
+-- referencing column).
+--
+-- runs keep cascading on purpose, so external_effects still follow their run: journey 10
+-- asserts a removed bot's runs are gone, and that stays true.
+
+ALTER TABLE "usage_records" DROP CONSTRAINT "usage_records_botId_fkey";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -356,7 +356,6 @@ model Bot {
   agentHome         AgentHome?
   browserProfile    BrowserProfile?
   artifacts         Artifact[]
-  usageRecords      UsageRecord[]
   tasks             Task[]
   runs              Run[]
   steeringMessages  SteeringMessage[]
@@ -941,8 +940,15 @@ model UsageRecord {
   id           String   @id @default(cuid())
   spaceId      String
   space        Space    @relation(fields: [spaceId], references: [id], onDelete: Cascade)
+  /// Which bot spent this. Deliberately NOT a relation: a usage row is spend that really
+  /// happened, and no lifecycle event on the bot may delete it or blank its attribution.
+  /// `Cascade` erased the row; `SetNull` would erase the attribution instead, and because
+  /// deleting a bot also deletes its runs, `runId` goes null in the same breath — the row
+  /// would keep only space, user, model and token counts.
+  ///
+  /// So the id outlives the bot and may dangle. Read it with a LEFT JOIN; `BotDeletion.id`
+  /// IS the bot id, so a deleted bot's name is still reachable for display.
   botId        String?
-  bot          Bot?     @relation(fields: [botId], references: [id], onDelete: Cascade)
   userId       String
   runId        String?
   run          Run?     @relation(fields: [runId], references: [id], onDelete: SetNull)

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -1321,6 +1321,23 @@ describeJourneys("required product journeys", () => {
     });
     const home = path.join(dataDir, "homes", gone.id);
     expect(existsSync(home)).toBe(true);
+    // Spend that really happened. The scripted runtime emits no usage event, so the row is
+    // written directly, the same way this file creates runs and tasks elsewhere.
+    const goneBotRow = await prisma.bot.findUniqueOrThrow({
+      where: { id: gone.id },
+      select: { spaceId: true, userId: true },
+    });
+    const goneSpend = await prisma.usageRecord.create({
+      data: {
+        spaceId: goneBotRow.spaceId,
+        botId: gone.id,
+        userId: goneBotRow.userId,
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        inputTokens: 1200,
+        outputTokens: 340,
+      },
+    });
 
     const stolen = await raw(app, bob, "bots/archive", { botId: gone.id });
     expect(stolen.status).toBeGreaterThanOrEqual(400);
@@ -1355,6 +1372,11 @@ describeJourneys("required product journeys", () => {
     });
     expect(await prisma.artifact.findUnique({ where: { id: goneArtifact.id } })).toBeNull();
     expect(existsSync(home)).toBe(false);
+    // Deleting a bot must not erase what it cost, nor which bot cost it. botId has no foreign
+    // key, so it outlives the bot and stays joinable against bot_deletions for the name.
+    expect(
+      await prisma.usageRecord.findUniqueOrThrow({ where: { id: goneSpend.id } }),
+    ).toMatchObject({ botId: gone.id, inputTokens: 1200, outputTokens: 340 });
 
     await rpc(app, ada, "bots/remove", { botId: forget.id, deleteMemories: true });
     expect(await prisma.memoryDocument.findUnique({ where: { id: forgetMemory.id } })).toBeNull();

--- a/packages/testkit/src/journeys.test.ts
+++ b/packages/testkit/src/journeys.test.ts
@@ -1367,7 +1367,11 @@ describeJourneys("required product journeys", () => {
       scope: "user",
       content: "important retained context",
     });
+    // The name is the half that makes a detached usage row readable: bot_deletions is keyed by
+    // the bot id, so a per-bot spend report can still label spend that belongs to a bot that
+    // no longer exists.
     expect(await prisma.botDeletion.findUniqueOrThrow({ where: { id: gone.id } })).toMatchObject({
+      name: "Gone",
       memoriesPreserved: true,
     });
     expect(await prisma.artifact.findUnique({ where: { id: goneArtifact.id } })).toBeNull();


### PR DESCRIPTION
## Problem

`usage_records_botId_fkey` is `ON DELETE CASCADE`, so `bots/remove` erases a bot's token-usage rows along with everything else.

#30 catalogued the cascade breadth — thread, messages, events, runs, effects, memory, computer, routines, artifacts — and #40 answered it with the `bot_deletions` tombstone, treating that breadth as a design call. That reading is right for conversation state a user knowingly discards. `usage_records` was not in that list, and it is a different kind of row: it is the record of what the bot *cost*. Deleting a bot should not be a way to erase it.

Measured on a real row:

```
INSERT usage_records (botId=<bot>, runId=<run>, 1200 in / 340 out)   → botId set, runId set
DELETE FROM bots WHERE id = <bot>
                                                                     → row gone
```

## Why not `SET NULL`

Tried first, rejected. Deleting a bot also deletes its runs, which fires `usage_records_runId_fkey` (already `SET NULL`), so **both** `botId` and `runId` come back `NULL` and the row keeps only space, user, model and token counts:

```
                                                     → botId: NULL, runId: NULL, tokens: 1200
```

The money survives and the attribution does not, which makes "which bot spent what" unanswerable one column later. For a per-bot spend view that is the same loss, just slower.

## Change

Drop the foreign key. No `CASCADE`, no `SET NULL`, no FK at all — a financial row should not cascade, blank, or fail because of a lifecycle event on its subject.

- `ALTER TABLE "usage_records" DROP CONSTRAINT "usage_records_botId_fkey"` (one migration)
- `UsageRecord.bot` relation removed from the schema, `botId String?` kept as a plain column; the `Bot.usageRecords` back-relation goes with it. Nothing in the tree traverses either — `usage.list` and `usage.summary` read the scalar and query by `spaceId` + `userId`.

Consequence accepted and documented in the schema: `botId` may dangle. `BotDeletion.id` **is** the bot id, so a deleted bot's name stays reachable:

```sql
SELECT u."botId", COALESCE(b.name, d.name) AS bot,
       SUM(u."inputTokens" + u."outputTokens") AS tokens
FROM usage_records u
LEFT JOIN bots b          ON b.id = u."botId"
LEFT JOIN bot_deletions d ON d.id = u."botId"
WHERE u."spaceId" = $1 AND u."createdAt" > now() - interval '30 days'
GROUP BY 1, 2;
```

No index is added on `botId`: nothing queries per bot today, and the FK never provided one either — Postgres does not index a referencing column.

`runs` keep cascading on purpose, so `external_effects` still follow their run. Journey 10 asserts a removed bot's runs are gone and that stays true.

## Verification

| Check | Result |
| --- | --- |
| `pnpm check` | 22/22 tasks |
| `pnpm lint` | clean on changed files (21 pre-existing warnings elsewhere) |
| `pnpm test` | 347 files, 3549 passed, 156 skipped |
| `pnpm test:integration` | every file passed, no failures |
| journeys, fresh Postgres | 34/34 |

Journey 10 now writes a usage row before the permanent delete and asserts it survives with its `botId` intact. Reverting **only** the migration and re-running on a fresh database fails that one assertion and nothing else:

```
FAIL  journeys.test.ts > 10: bots can be archived safely and deleted with or without their memories
      Tests  1 failed | 33 passed (34)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Usage and spend records now remain available after a bot is deleted.
  - Historical records retain the deleted bot’s identifier and token counts for accurate attribution.
  - Bot names remain retrievable for retained records when deletion attribution is available.
  - Run-related external effects continue to be removed when their associated runs are deleted.
  - Bot deletion no longer removes historical usage data, preserving accurate reporting and attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->