### PR TITLE
fix(web): label picker rows as create actions with icons

### DIFF
--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -1201,6 +1201,14 @@ msgstr "Konto erstellen"
 msgid "Create group"
 msgstr "Gruppe erstellen"
 
+#: src/pages/shell/bot-picker.tsx:95
+msgid "Create new Group"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:104
+msgid "Create new Space"
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -1201,13 +1201,17 @@ msgstr "Konto erstellen"
 msgid "Create group"
 msgstr "Gruppe erstellen"
 
+#: src/pages/shell/bot-picker.tsx:70
+msgid "Create new Bot"
+msgstr "Neuen Bot erstellen"
+
 #: src/pages/shell/bot-picker.tsx:95
 msgid "Create new Group"
-msgstr ""
+msgstr "Neue Gruppe erstellen"
 
 #: src/pages/shell/bot-picker.tsx:104
 msgid "Create new Space"
-msgstr ""
+msgstr "Neuen Space erstellen"
 
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1201,6 +1201,14 @@ msgstr "Create account"
 msgid "Create group"
 msgstr "Create group"
 
+#: src/pages/shell/bot-picker.tsx:95
+msgid "Create new Group"
+msgstr "Create new Group"
+
+#: src/pages/shell/bot-picker.tsx:104
+msgid "Create new Space"
+msgstr "Create new Space"
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1201,6 +1201,10 @@ msgstr "Create account"
 msgid "Create group"
 msgstr "Create group"
 
+#: src/pages/shell/bot-picker.tsx:70
+msgid "Create new Bot"
+msgstr "Create new Bot"
+
 #: src/pages/shell/bot-picker.tsx:95
 msgid "Create new Group"
 msgstr "Create new Group"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1175,13 +1175,17 @@ msgstr "Crear cuenta"
 msgid "Create group"
 msgstr "Crear grupo"
 
+#: src/pages/shell/bot-picker.tsx:70
+msgid "Create new Bot"
+msgstr "Crear nuevo bot"
+
 #: src/pages/shell/bot-picker.tsx:95
 msgid "Create new Group"
-msgstr ""
+msgstr "Crear nuevo grupo"
 
 #: src/pages/shell/bot-picker.tsx:104
 msgid "Create new Space"
-msgstr ""
+msgstr "Crear nuevo space"
 
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1175,6 +1175,14 @@ msgstr "Crear cuenta"
 msgid "Create group"
 msgstr "Crear grupo"
 
+#: src/pages/shell/bot-picker.tsx:95
+msgid "Create new Group"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:104
+msgid "Create new Space"
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -1201,13 +1201,17 @@ msgstr "खाता बनाएं"
 msgid "Create group"
 msgstr "समूह बनाएं"
 
+#: src/pages/shell/bot-picker.tsx:70
+msgid "Create new Bot"
+msgstr "नया बॉट बनाएं"
+
 #: src/pages/shell/bot-picker.tsx:95
 msgid "Create new Group"
-msgstr ""
+msgstr "नया समूह बनाएं"
 
 #: src/pages/shell/bot-picker.tsx:104
 msgid "Create new Space"
-msgstr ""
+msgstr "नया स्पेस बनाएं"
 
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -1201,6 +1201,14 @@ msgstr "खाता बनाएं"
 msgid "Create group"
 msgstr "समूह बनाएं"
 
+#: src/pages/shell/bot-picker.tsx:95
+msgid "Create new Group"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:104
+msgid "Create new Space"
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -1201,6 +1201,14 @@ msgstr "계정 만들기"
 msgid "Create group"
 msgstr "그룹 만들기"
 
+#: src/pages/shell/bot-picker.tsx:95
+msgid "Create new Group"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:104
+msgid "Create new Space"
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -1201,13 +1201,17 @@ msgstr "계정 만들기"
 msgid "Create group"
 msgstr "그룹 만들기"
 
+#: src/pages/shell/bot-picker.tsx:70
+msgid "Create new Bot"
+msgstr "새 Bot 만들기"
+
 #: src/pages/shell/bot-picker.tsx:95
 msgid "Create new Group"
-msgstr ""
+msgstr "새 그룹 만들기"
 
 #: src/pages/shell/bot-picker.tsx:104
 msgid "Create new Space"
-msgstr ""
+msgstr "새 스페이스 만들기"
 
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -1201,13 +1201,17 @@ msgstr "Criar Conta"
 msgid "Create group"
 msgstr "Criar grupo"
 
+#: src/pages/shell/bot-picker.tsx:70
+msgid "Create new Bot"
+msgstr "Criar novo bot"
+
 #: src/pages/shell/bot-picker.tsx:95
 msgid "Create new Group"
-msgstr ""
+msgstr "Criar novo grupo"
 
 #: src/pages/shell/bot-picker.tsx:104
 msgid "Create new Space"
-msgstr ""
+msgstr "Criar novo space"
 
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -1201,6 +1201,14 @@ msgstr "Criar Conta"
 msgid "Create group"
 msgstr "Criar grupo"
 
+#: src/pages/shell/bot-picker.tsx:95
+msgid "Create new Group"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:104
+msgid "Create new Space"
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -1201,13 +1201,17 @@ msgstr "Hesap oluştur"
 msgid "Create group"
 msgstr "Grup oluştur"
 
+#: src/pages/shell/bot-picker.tsx:70
+msgid "Create new Bot"
+msgstr "Yeni bot oluştur"
+
 #: src/pages/shell/bot-picker.tsx:95
 msgid "Create new Group"
-msgstr ""
+msgstr "Yeni grup oluştur"
 
 #: src/pages/shell/bot-picker.tsx:104
 msgid "Create new Space"
-msgstr ""
+msgstr "Yeni space oluştur"
 
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -1201,6 +1201,14 @@ msgstr "Hesap oluştur"
 msgid "Create group"
 msgstr "Grup oluştur"
 
+#: src/pages/shell/bot-picker.tsx:95
+msgid "Create new Group"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:104
+msgid "Create new Space"
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -1201,13 +1201,17 @@ msgstr "创建账户"
 msgid "Create group"
 msgstr "创建群组"
 
+#: src/pages/shell/bot-picker.tsx:70
+msgid "Create new Bot"
+msgstr "新建 Bot"
+
 #: src/pages/shell/bot-picker.tsx:95
 msgid "Create new Group"
-msgstr ""
+msgstr "新建群组"
 
 #: src/pages/shell/bot-picker.tsx:104
 msgid "Create new Space"
-msgstr ""
+msgstr "新建工作区"
 
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -1201,6 +1201,14 @@ msgstr "创建账户"
 msgid "Create group"
 msgstr "创建群组"
 
+#: src/pages/shell/bot-picker.tsx:95
+msgid "Create new Group"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:104
+msgid "Create new Space"
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -9,7 +9,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@rakazo/ui-web";
-import { Lock, Plus } from "lucide-react";
+import { Lock, Plus, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 
 export function BotCreatePicker({
@@ -89,8 +89,10 @@ export function BotCreatePicker({
               value="create-group"
               data-testid="create-new-group"
               onSelect={() => onCreateGroup()}
+              className="gap-2"
             >
-              <Trans>New group</Trans>
+              <Users size={16} strokeWidth={1.8} aria-hidden="true" />
+              <Trans>Create new Group</Trans>
             </CommandItem>
             <CommandItem
               value="create-space"
@@ -99,7 +101,7 @@ export function BotCreatePicker({
               className="gap-2"
             >
               <Lock size={14} strokeWidth={1.8} aria-hidden="true" />
-              <Trans>New space</Trans>
+              <Trans>Create new Space</Trans>
             </CommandItem>
           </CommandGroup>
         </CommandList>


### PR DESCRIPTION
## Why
In the bot picker menu, the bottom rows read as plain nouns ('New group' with no icon, 'New space') while the sibling row is a clear create-action ('+ Create new Bot'). The group row looked like a list entry rather than something to click.

## What
- 'New group' -> 'Create new Group' with a Users icon, matching the create-row pattern (icon + gap-2, same sizing as the Plus icon above).
- 'New space' -> 'Create new Space' (lock icon unchanged).
- Casing follows the existing 'Create new Bot' pattern (entity capitalized). The create-space dialog title ('New space') is intentionally untouched — different surface.
- Test IDs and values unchanged, so existing e2e selectors still apply.
- Locale catalogs: both msgids added to all 8 catalogs; maintainer commit 6ac27f3 filled in all non-English translations (plus backfilled the missing 'Create new Bot' entry).

## How tested
- Biome check on bot-picker.tsx: clean.
- tsc --noEmit (web): clean.
- Web unit tests: 38 files / 207 tests pass.
- intl:compile: clean.
- CI: all checks green including Web E2E; Greptile findings addressed (catalog entries present, translations filled).
- E2E screenshots: [Playwright gallery for this PR](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/767/index.html).