### PR TITLE
feat(web): separate sidebar and user bubbles with grey tones

### DIFF
--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2497,7 +2497,10 @@ export function ShellPage() {
             </Popover>
           </div>
         </div>
-        <InputGroup data-testid="sidebar-search" className="mx-2.5 mb-3 w-auto rounded-xl bg-card">
+        <InputGroup
+          data-testid="sidebar-search"
+          className="mx-2.5 mb-3 w-auto rounded-xl bg-card dark:bg-input"
+        >
           <InputGroupAddon>
             <Search size={16} strokeWidth={1.8} aria-hidden="true" />
           </InputGroupAddon>
@@ -2645,8 +2648,8 @@ export function ShellPage() {
                           } ${
                             (item.kind === "bot" && !inGroup && active?.id === item.chat.id) ||
                             (item.kind === "group" && inGroup && activeGroup?.id === item.chat.id)
-                              ? "bg-card"
-                              : "hover:bg-background"
+                              ? "bg-sidebar-accent"
+                              : "hover:bg-muted"
                           }`}
                           style={{
                             opacity:
@@ -2748,7 +2751,7 @@ export function ShellPage() {
                 type="button"
                 aria-expanded={archivedOpen}
                 onClick={() => setArchivedOpen((open) => !open)}
-                className="flex w-full items-center justify-between rounded-lg px-2.5 py-2 text-[13.5px] text-muted-foreground hover:bg-background"
+                className="flex w-full items-center justify-between rounded-lg px-2.5 py-2 text-[13.5px] text-muted-foreground hover:bg-muted"
               >
                 <span>
                   <Trans>Archived</Trans>
@@ -2830,7 +2833,7 @@ export function ShellPage() {
         <button
           type="button"
           onClick={() => setPluginsOpen(true)}
-          className="mx-3 mb-1 flex items-center gap-3 rounded-[11px] px-2.5 py-2 hover:bg-background"
+          className="mx-3 mb-1 flex items-center gap-3 rounded-[11px] px-2.5 py-2 hover:bg-muted"
         >
           <span className="grid h-[30px] w-[30px] place-items-center rounded-full bg-muted text-foreground/75">
             <Puzzle size={15} strokeWidth={1.7} />
@@ -5499,7 +5502,7 @@ const MessageView = memo(function MessageView({
             <div key={i} className="flex w-fit max-w-full justify-end">
               <div
                 data-testid="message-user-bubble"
-                className="max-w-full whitespace-pre-wrap wrap-anywhere rounded-[20px] bg-secondary px-[18px] py-3 text-[15.5px] leading-[1.45] text-secondary-foreground"
+                className="max-w-full whitespace-pre-wrap wrap-anywhere rounded-[20px] bg-chat-user px-[18px] py-3 text-[15.5px] leading-[1.45] text-chat-user-foreground"
                 dir="auto"
               >
                 {block.text}

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -2541,7 +2541,7 @@ export function ShellPage() {
                       <div className="pt-2">
                         <button
                           type="button"
-                          className="flex w-full items-center justify-between gap-2 rounded-lg px-2.5 py-1.5 text-[12.5px] font-medium text-muted-foreground/80 hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-ring"
+                          className="flex w-full items-center justify-between gap-2 rounded-lg px-2.5 py-1.5 text-[12.5px] font-medium text-muted-foreground/80 hover:bg-sidebar-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-ring"
                           onClick={() => {
                             if (group.emptySpaceId) {
                               openSpaceChat(group.emptySpaceId, "/onboarding");
@@ -2649,7 +2649,7 @@ export function ShellPage() {
                             (item.kind === "bot" && !inGroup && active?.id === item.chat.id) ||
                             (item.kind === "group" && inGroup && activeGroup?.id === item.chat.id)
                               ? "bg-sidebar-accent"
-                              : "hover:bg-muted"
+                              : "hover:bg-sidebar-accent"
                           }`}
                           style={{
                             opacity:
@@ -2751,7 +2751,7 @@ export function ShellPage() {
                 type="button"
                 aria-expanded={archivedOpen}
                 onClick={() => setArchivedOpen((open) => !open)}
-                className="flex w-full items-center justify-between rounded-lg px-2.5 py-2 text-[13.5px] text-muted-foreground hover:bg-muted"
+                className="flex w-full items-center justify-between rounded-lg px-2.5 py-2 text-[13.5px] text-muted-foreground hover:bg-sidebar-accent"
               >
                 <span>
                   <Trans>Archived</Trans>
@@ -2833,7 +2833,7 @@ export function ShellPage() {
         <button
           type="button"
           onClick={() => setPluginsOpen(true)}
-          className="mx-3 mb-1 flex items-center gap-3 rounded-[11px] px-2.5 py-2 hover:bg-muted"
+          className="mx-3 mb-1 flex items-center gap-3 rounded-[11px] px-2.5 py-2 hover:bg-sidebar-accent"
         >
           <span className="grid h-[30px] w-[30px] place-items-center rounded-full bg-muted text-foreground/75">
             <Puzzle size={15} strokeWidth={1.7} />

--- a/packages/ui-tokens/src/appearance.test.ts
+++ b/packages/ui-tokens/src/appearance.test.ts
@@ -59,6 +59,15 @@ describe("appearance preference", () => {
     expect(dark.secondaryForeground).not.toBe(dark.primaryForeground);
   });
 
+  it("separates user bubbles from bot bubbles and the sidebar from the app", () => {
+    const dark = tokensForAppearance("dark");
+    const light = tokensForAppearance("light");
+    expect(dark.chatUser).not.toBe(dark.muted);
+    expect(light.chatUser).not.toBe(light.muted);
+    expect(dark.sidebar).not.toBe(dark.background);
+    expect(light.sidebar).not.toBe(light.background);
+  });
+
   it("tolerates a throwing localStorage getter", () => {
     const desc = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
     Object.defineProperty(globalThis, "localStorage", {

--- a/packages/ui-tokens/src/index.ts
+++ b/packages/ui-tokens/src/index.ts
@@ -22,6 +22,8 @@ export type ColorTokens = {
   primaryForeground: string;
   secondary: string;
   secondaryForeground: string;
+  chatUser: string;
+  chatUserForeground: string;
   muted: string;
   mutedForeground: string;
   accent: string;
@@ -55,6 +57,8 @@ export const darkTokens = {
   primaryForeground: "#1A1A1A",
   secondary: "#1A1A1D",
   secondaryForeground: "#ECECEE",
+  chatUser: "#2B2B31",
+  chatUserForeground: "#ECECEE",
   muted: "#1A1A1D",
   mutedForeground: "#85858A",
   accent: "#202023",
@@ -64,10 +68,10 @@ export const darkTokens = {
   border: "#26262A",
   input: "#2A2A2E",
   ring: "#A6A6AD",
-  sidebar: "#0B0B0C",
+  sidebar: "#17171A",
   sidebarForeground: "#ECECEE",
-  sidebarBorder: "#171719",
-  sidebarAccent: "#141416",
+  sidebarBorder: "#26262A",
+  sidebarAccent: "#232329",
   sidebarAccentForeground: "#ECECEE",
   link: "#86B7FF",
   success: "#4ECB71",
@@ -88,6 +92,8 @@ export const lightTokens = {
   primaryForeground: "#F1F1EF",
   secondary: "#F0F0ED",
   secondaryForeground: "#1A1A1A",
+  chatUser: "#E2E2DC",
+  chatUserForeground: "#1A1A1A",
   muted: "#F0F0ED",
   mutedForeground: "#6C6C70",
   accent: "#EAEAE6",

--- a/packages/ui-tokens/src/tokens.css
+++ b/packages/ui-tokens/src/tokens.css
@@ -13,6 +13,8 @@
   --primary-foreground: #1a1a1a;
   --secondary: #1a1a1d;
   --secondary-foreground: #ececee;
+  --chat-user: #2b2b31;
+  --chat-user-foreground: #ececee;
   --muted: #1a1a1d;
   --muted-foreground: #85858a;
   --accent: #202023;
@@ -22,10 +24,10 @@
   --border: #26262a;
   --input: #2a2a2e;
   --ring: #a6a6ad;
-  --sidebar: #0b0b0c;
+  --sidebar: #17171a;
   --sidebar-foreground: #ececee;
-  --sidebar-border: #171719;
-  --sidebar-accent: #141416;
+  --sidebar-border: #26262a;
+  --sidebar-accent: #232329;
   --sidebar-accent-foreground: #ececee;
   --link: #86b7ff;
   --success: #4ecb71;
@@ -48,6 +50,8 @@
   --primary-foreground: #f1f1ef;
   --secondary: #f0f0ed;
   --secondary-foreground: #1a1a1a;
+  --chat-user: #e2e2dc;
+  --chat-user-foreground: #1a1a1a;
   --muted: #f0f0ed;
   --muted-foreground: #6c6c70;
   --accent: #eaeae6;

--- a/packages/ui-web/src/styles.css
+++ b/packages/ui-web/src/styles.css
@@ -17,6 +17,8 @@
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
+  --color-chat-user: var(--chat-user);
+  --color-chat-user-foreground: var(--chat-user-foreground);
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);


### PR DESCRIPTION
## Why
In dark mode the whole window reads as one flat black surface: the sidebar sits at #0B0B0C against a #0D0D0E background, and user messages use the exact same fill as bot messages (secondary and muted are both #1A1A1D), so the two speakers are indistinguishable.

## What
- Sidebar (dark) lifted to a soft grey (#17171A) with a readable edge (sidebar-border) and selected/hover tone (sidebar-accent). The footer (Integrations + profile row) lives in the same sidebar container, so it follows automatically.
- New semantic `chatUser`/`chatUserForeground` tokens in `@rakazo/ui-tokens` (both palettes) for user message bubbles; bot bubbles stay on muted. Dark user bubble is a soft grey (#2B2B31), light is the equivalent grey step (#E2E2DC).
- Sidebar search keeps its lighter pill in dark mode (`dark:bg-input`) so it does not sink into the new sidebar grey; selected bot row and all sidebar hovers use `bg-sidebar-accent`/`hover:bg-sidebar-accent` so selection and hover stay lighter than the sidebar in both themes (Greptile 4/5 feedback on weak hover separation, addressed).
- Token test now guards the separation (user bubble != bot bubble, sidebar != background, both themes).

## How tested
- `pnpm exec vitest run packages/ui-tokens/src/appearance.test.ts` — 10 pass.
- `pnpm --filter @rakazo/ui-tokens check`, `pnpm --filter @rakazo/web check`, Biome on all touched files — clean.
- `pnpm --filter @rakazo/web build` — succeeds; verified `bg-chat-user`, `bg-sidebar-accent`, and both theme values for `--sidebar`/`--chat-user` are present in the built CSS.
- No user-facing copy added or changed, so no locale updates.
- CI: all checks green (Lint, Typecheck, Unit tests, Postgres journeys, Web E2E, Greptile 5/5, CodeRabbit with no actionable comments).
- E2E screenshots: [Playwright gallery for this PR](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/768/index.html) (sidebar search covered by ui-appearance.spec.ts, bubbles by message-hover-actions.spec.ts).