### PR TITLE
feat(web): explain groups and spaces in create picker

### DIFF
--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -72,8 +72,10 @@ test("picker rows explain groups and spaces", async ({ page }, testInfo) => {
   await expect(picker).toBeVisible();
 
   await picker.getByTestId("create-new-group").hover();
+  const groupInfo = picker.getByTestId("picker-info-group");
+  await expect.poll(() => groupInfo.evaluate((el) => getComputedStyle(el).opacity)).toBe("1");
   await captureScreenshot(page, testInfo, "picker-group-info-hover");
-  await picker.getByTestId("picker-info-group").click();
+  await groupInfo.click();
   const dialog = page.getByTestId("picker-info-dialog");
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText("Groups", { exact: true })).toBeVisible();
@@ -84,8 +86,11 @@ test("picker rows explain groups and spaces", async ({ page }, testInfo) => {
   await expect(dialog).toBeHidden();
 
   await page.getByTestId("create-menu-trigger").click();
+  const spaceInfo = picker.getByTestId("picker-info-space");
+  await expect.poll(() => spaceInfo.evaluate((el) => getComputedStyle(el).opacity)).toBe("0");
   await picker.getByTestId("create-new-space").hover();
-  await picker.getByTestId("picker-info-space").click();
+  await expect.poll(() => spaceInfo.evaluate((el) => getComputedStyle(el).opacity)).toBe("1");
+  await spaceInfo.click();
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText("Spaces", { exact: true })).toBeVisible();
   await expect(dialog).toContainText("private workspace");

--- a/apps/web/e2e/new-bot-ux.spec.ts
+++ b/apps/web/e2e/new-bot-ux.spec.ts
@@ -60,6 +60,40 @@ test("create opens form, then empty chat; picker lists bots; sidebar collapses",
   await captureScreenshot(page, testInfo, "bots-sidebar-expanded");
 });
 
+test("picker rows explain groups and spaces", async ({ page }, testInfo) => {
+  const stamp = Date.now();
+  await signup(page, `picker-info-${stamp}@rakazo.test`, "password12", "Picker Info");
+  await completeOnboarding(page);
+  await page.goto("/app");
+  await page.waitForURL(/\/app\/[^/]+$/);
+
+  await page.getByTestId("create-menu-trigger").click();
+  const picker = page.getByTestId("bot-create-picker");
+  await expect(picker).toBeVisible();
+
+  await picker.getByTestId("create-new-group").hover();
+  await captureScreenshot(page, testInfo, "picker-group-info-hover");
+  await picker.getByTestId("picker-info-group").click();
+  const dialog = page.getByTestId("picker-info-dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Groups", { exact: true })).toBeVisible();
+  await expect(dialog).toContainText("shared thread");
+  await expect(page.getByTestId("side-panel")).not.toHaveAttribute("data-panel", "create-group");
+  await captureScreenshot(page, testInfo, "picker-group-info-dialog");
+  await dialog.getByRole("button", { name: "Close" }).click();
+  await expect(dialog).toBeHidden();
+
+  await page.getByTestId("create-menu-trigger").click();
+  await picker.getByTestId("create-new-space").hover();
+  await picker.getByTestId("picker-info-space").click();
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Spaces", { exact: true })).toBeVisible();
+  await expect(dialog).toContainText("private workspace");
+  await captureScreenshot(page, testInfo, "picker-space-info-dialog");
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+});
+
 test("later bot waits before showing the focus card; sending cancels it", async ({ page }) => {
   const stamp = Date.now();
   await signup(page, `focus-delay-${stamp}@rakazo.test`, "password12", "Focus Delay");

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -1213,6 +1213,32 @@ msgstr "Neue Gruppe erstellen"
 msgid "Create new Space"
 msgstr "Neuen Space erstellen"
 
+#: src/pages/shell/bot-picker.tsx:105
+#: src/pages/shell/bot-picker.tsx:106
+msgid "About groups"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:133
+#: src/pages/shell/bot-picker.tsx:134
+msgid "About spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Groups"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:136
+msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:141
+msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1213,6 +1213,32 @@ msgstr "Create new Group"
 msgid "Create new Space"
 msgstr "Create new Space"
 
+#: src/pages/shell/bot-picker.tsx:105
+#: src/pages/shell/bot-picker.tsx:106
+msgid "About groups"
+msgstr "About groups"
+
+#: src/pages/shell/bot-picker.tsx:133
+#: src/pages/shell/bot-picker.tsx:134
+msgid "About spaces"
+msgstr "About spaces"
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Groups"
+msgstr "Groups"
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Spaces"
+msgstr "Spaces"
+
+#: src/pages/shell/dialogs.tsx:136
+msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgstr "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+
+#: src/pages/shell/dialogs.tsx:141
+msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+msgstr "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1187,6 +1187,32 @@ msgstr "Crear nuevo grupo"
 msgid "Create new Space"
 msgstr "Crear nuevo space"
 
+#: src/pages/shell/bot-picker.tsx:105
+#: src/pages/shell/bot-picker.tsx:106
+msgid "About groups"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:133
+#: src/pages/shell/bot-picker.tsx:134
+msgid "About spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Groups"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:136
+msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:141
+msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -1213,6 +1213,32 @@ msgstr "नया समूह बनाएं"
 msgid "Create new Space"
 msgstr "नया स्पेस बनाएं"
 
+#: src/pages/shell/bot-picker.tsx:105
+#: src/pages/shell/bot-picker.tsx:106
+msgid "About groups"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:133
+#: src/pages/shell/bot-picker.tsx:134
+msgid "About spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Groups"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:136
+msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:141
+msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -1213,6 +1213,32 @@ msgstr "새 그룹 만들기"
 msgid "Create new Space"
 msgstr "새 스페이스 만들기"
 
+#: src/pages/shell/bot-picker.tsx:105
+#: src/pages/shell/bot-picker.tsx:106
+msgid "About groups"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:133
+#: src/pages/shell/bot-picker.tsx:134
+msgid "About spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Groups"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:136
+msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:141
+msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -1213,6 +1213,32 @@ msgstr "Criar novo grupo"
 msgid "Create new Space"
 msgstr "Criar novo space"
 
+#: src/pages/shell/bot-picker.tsx:105
+#: src/pages/shell/bot-picker.tsx:106
+msgid "About groups"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:133
+#: src/pages/shell/bot-picker.tsx:134
+msgid "About spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Groups"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:136
+msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:141
+msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -1213,6 +1213,32 @@ msgstr "Yeni grup oluştur"
 msgid "Create new Space"
 msgstr "Yeni space oluştur"
 
+#: src/pages/shell/bot-picker.tsx:105
+#: src/pages/shell/bot-picker.tsx:106
+msgid "About groups"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:133
+#: src/pages/shell/bot-picker.tsx:134
+msgid "About spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Groups"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:136
+msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:141
+msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -1213,6 +1213,32 @@ msgstr "新建群组"
 msgid "Create new Space"
 msgstr "新建工作区"
 
+#: src/pages/shell/bot-picker.tsx:105
+#: src/pages/shell/bot-picker.tsx:106
+msgid "About groups"
+msgstr ""
+
+#: src/pages/shell/bot-picker.tsx:133
+#: src/pages/shell/bot-picker.tsx:134
+msgid "About spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Groups"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:131
+msgid "Spaces"
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:136
+msgid "One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat."
+msgstr ""
+
+#: src/pages/shell/dialogs.tsx:141
+msgid "A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal."
+msgstr ""
+
 #: src/pages/RoutineEditor.tsx:114
 #: src/pages/RoutineEditor.tsx:115
 msgid "Create Routine"

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -210,6 +210,7 @@ import {
   DeleteItemDialog,
   NewBotSectionDialog,
   NewSpaceDialog,
+  PickerInfoDialog,
 } from "./shell/dialogs";
 import {
   AppConnectCard,
@@ -451,6 +452,7 @@ export function ShellPage() {
     null,
   );
   const [newSpaceOpen, setNewSpaceOpen] = useState(false);
+  const [pickerInfoTopic, setPickerInfoTopic] = useState<"group" | "space" | null>(null);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
 
   useEffect(() => {
@@ -2491,6 +2493,16 @@ export function ShellPage() {
                       setMobileSidebarOpen(false);
                       setNewSpaceOpen(true);
                     }}
+                    onShowGroupInfo={() => {
+                      setCreateMenuOpen(false);
+                      setMobileSidebarOpen(false);
+                      setPickerInfoTopic("group");
+                    }}
+                    onShowSpaceInfo={() => {
+                      setCreateMenuOpen(false);
+                      setMobileSidebarOpen(false);
+                      setPickerInfoTopic("space");
+                    }}
                   />
                 </PopoverContent>
               ) : null}
@@ -3689,6 +3701,10 @@ export function ShellPage() {
               window.location.assign("/onboarding");
             }}
           />
+        ) : null}
+
+        {pickerInfoTopic ? (
+          <PickerInfoDialog topic={pickerInfoTopic} onClose={() => setPickerInfoTopic(null)} />
         ) : null}
 
         {clearTarget ? (

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -112,7 +112,7 @@ export function BotCreatePicker({
                   onShowGroupInfo();
                 }}
                 onKeyDown={(event) => event.stopPropagation()}
-                className="-mr-1 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring [@media(hover:none)]:opacity-70"
+                className="-mr-1 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring [@media(any-pointer:coarse)]:opacity-70"
               >
                 <Info size={14} strokeWidth={1.8} aria-hidden="true" />
               </button>
@@ -140,7 +140,7 @@ export function BotCreatePicker({
                   onShowSpaceInfo();
                 }}
                 onKeyDown={(event) => event.stopPropagation()}
-                className="-mr-1 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring [@media(hover:none)]:opacity-70"
+                className="-mr-1 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring [@media(any-pointer:coarse)]:opacity-70"
               >
                 <Info size={14} strokeWidth={1.8} aria-hidden="true" />
               </button>

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -9,7 +9,7 @@ import {
   CommandList,
   CommandSeparator,
 } from "@rakazo/ui-web";
-import { Lock, Plus, Users } from "lucide-react";
+import { Info, Lock, Plus, Users } from "lucide-react";
 import { useMemo, useState } from "react";
 
 export function BotCreatePicker({
@@ -18,12 +18,16 @@ export function BotCreatePicker({
   onOpenBot,
   onCreateGroup,
   onCreateSpace,
+  onShowGroupInfo,
+  onShowSpaceInfo,
 }: {
   bots: Bot[];
   onCreateBot: () => void;
   onOpenBot: (botId: string) => void;
   onCreateGroup: () => void;
   onCreateSpace: () => void;
+  onShowGroupInfo: () => void;
+  onShowSpaceInfo: () => void;
 }) {
   const { t } = useLingui();
   const [query, setQuery] = useState("");
@@ -89,19 +93,57 @@ export function BotCreatePicker({
               value="create-group"
               data-testid="create-new-group"
               onSelect={() => onCreateGroup()}
-              className="gap-2"
+              className="gap-2 data-selected:[&_button]:opacity-100"
             >
               <Users size={16} strokeWidth={1.8} aria-hidden="true" />
-              <Trans>Create new Group</Trans>
+              <span className="min-w-0 flex-1 truncate">
+                <Trans>Create new Group</Trans>
+              </span>
+              <button
+                type="button"
+                data-testid="picker-info-group"
+                aria-label={t`About groups`}
+                title={t`About groups`}
+                onPointerDown={(event) => event.stopPropagation()}
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  onShowGroupInfo();
+                }}
+                onKeyDown={(event) => event.stopPropagation()}
+                className="-mr-1 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring [@media(hover:none)]:opacity-70"
+              >
+                <Info size={14} strokeWidth={1.8} aria-hidden="true" />
+              </button>
             </CommandItem>
             <CommandItem
               value="create-space"
               data-testid="create-new-space"
               onSelect={() => onCreateSpace()}
-              className="gap-2"
+              className="gap-2 data-selected:[&_button]:opacity-100"
             >
               <Lock size={14} strokeWidth={1.8} aria-hidden="true" />
-              <Trans>Create new Space</Trans>
+              <span className="min-w-0 flex-1 truncate">
+                <Trans>Create new Space</Trans>
+              </span>
+              <button
+                type="button"
+                data-testid="picker-info-space"
+                aria-label={t`About spaces`}
+                title={t`About spaces`}
+                onPointerDown={(event) => event.stopPropagation()}
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  onShowSpaceInfo();
+                }}
+                onKeyDown={(event) => event.stopPropagation()}
+                className="-mr-1 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring [@media(hover:none)]:opacity-70"
+              >
+                <Info size={14} strokeWidth={1.8} aria-hidden="true" />
+              </button>
             </CommandItem>
           </CommandGroup>
         </CommandList>

--- a/apps/web/src/pages/shell/bot-picker.tsx
+++ b/apps/web/src/pages/shell/bot-picker.tsx
@@ -93,7 +93,7 @@ export function BotCreatePicker({
               value="create-group"
               data-testid="create-new-group"
               onSelect={() => onCreateGroup()}
-              className="gap-2 data-selected:[&_button]:opacity-100"
+              className="gap-2"
             >
               <Users size={16} strokeWidth={1.8} aria-hidden="true" />
               <span className="min-w-0 flex-1 truncate">
@@ -112,7 +112,7 @@ export function BotCreatePicker({
                   onShowGroupInfo();
                 }}
                 onKeyDown={(event) => event.stopPropagation()}
-                className="-mr-1 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring [@media(any-pointer:coarse)]:opacity-70"
+                className="-mr-2 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring"
               >
                 <Info size={14} strokeWidth={1.8} aria-hidden="true" />
               </button>
@@ -121,7 +121,7 @@ export function BotCreatePicker({
               value="create-space"
               data-testid="create-new-space"
               onSelect={() => onCreateSpace()}
-              className="gap-2 data-selected:[&_button]:opacity-100"
+              className="gap-2"
             >
               <Lock size={14} strokeWidth={1.8} aria-hidden="true" />
               <span className="min-w-0 flex-1 truncate">
@@ -140,7 +140,7 @@ export function BotCreatePicker({
                   onShowSpaceInfo();
                 }}
                 onKeyDown={(event) => event.stopPropagation()}
-                className="-mr-1 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring [@media(any-pointer:coarse)]:opacity-70"
+                className="-mr-2 shrink-0 rounded p-1 text-muted-foreground/70 opacity-0 transition-opacity duration-150 group-focus-within/command-item:opacity-100 group-hover/command-item:opacity-100 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-ring"
               >
                 <Info size={14} strokeWidth={1.8} aria-hidden="true" />
               </button>

--- a/apps/web/src/pages/shell/dialogs.tsx
+++ b/apps/web/src/pages/shell/dialogs.tsx
@@ -18,7 +18,7 @@ import {
   DialogTitle,
   Input,
 } from "@rakazo/ui-web";
-import { Lock } from "lucide-react";
+import { Lock, Users } from "lucide-react";
 import { useId, useState } from "react";
 
 /** Each dialog is mounted only while open, so `open` is always true and the
@@ -91,6 +91,59 @@ export function NewSpaceDialog({
             {saving ? <Trans>Creating…</Trans> : <Trans>Create space</Trans>}
           </Button>
         </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function PickerInfoDialog({
+  topic,
+  onClose,
+}: {
+  topic: "group" | "space";
+  onClose: () => void;
+}) {
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent data-testid="picker-info-dialog">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2.5">
+            {topic === "group" ? (
+              <Users
+                size={17}
+                strokeWidth={1.8}
+                className="text-muted-foreground"
+                aria-hidden="true"
+              />
+            ) : (
+              <Lock
+                size={17}
+                strokeWidth={1.8}
+                className="text-muted-foreground"
+                aria-hidden="true"
+              />
+            )}
+            {topic === "group" ? <Trans>Groups</Trans> : <Trans>Spaces</Trans>}
+          </DialogTitle>
+          <DialogDescription>
+            {topic === "group" ? (
+              <Trans>
+                One conversation with 2–6 of your bots in a shared thread. Name the group, pick its
+                members, and they all reply in the same chat.
+              </Trans>
+            ) : (
+              <Trans>
+                A separate, private workspace with its own bots and groups. Use spaces to keep
+                contexts apart, such as work and personal.
+              </Trans>
+            )}
+          </DialogDescription>
+        </DialogHeader>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Why

'Create new Group' and 'Create new Space' sit next to each other in the + picker with no in-app explanation of what either does or how they differ, so users have to guess before creating one.

## What

- Hovering (or keyboard-highlighting) the Group/Space picker row reveals a muted info icon; it stays hidden otherwise and is always visible on touch devices.
- Clicking the icon closes the picker menu and opens a dialog describing that feature. The dialog reuses the shared Dialog chrome, so it gets the standard X button, overlay click-off, Escape, and open/close animation for free.
- Copies the row's own icon into the dialog title (Users for groups, Lock for spaces).

New user-facing copy (English; other locales ship empty msgstr per the established pattern):

- 'About groups' / 'About spaces' (info-button labels)
- 'Groups' — 'One conversation with 2–6 of your bots in a shared thread. Name the group, pick its members, and they all reply in the same chat.'
- 'Spaces' — 'A separate, private workspace with its own bots and groups. Use spaces to keep contexts apart, such as work and personal.'

The copy is necessary because there is currently no in-app text anywhere explaining groups vs spaces; it cannot be removed or left as persistent text because the picker rows must stay one-line actions — so it is disclosed progressively behind the info icon and shown only on demand.

## How tested

- `pnpm --filter @rakazo/web check` clean; Biome clean on all touched files.
- `lingui compile` passes with the six new msgids hand-added to all eight catalogs.
- New E2E test 'picker rows explain groups and spaces' in `new-bot-ux.spec.ts`: hovers each row, opens each dialog, asserts the explanation text, closes via X (groups) and Escape (spaces), and asserts opening info does not start group creation. Passed locally via the e2e harness, as did the rest of `new-bot-ux` except one clock-based test that failed once under full-file load and passed on re-run (flaky, unrelated).
- Web production build greps confirm the new hover/focus/selected/touch utilities made it into the output CSS.
- Gallery: https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/prs/769/index.html (see picker-group-info-hover, picker-group-info-dialog, picker-space-info-dialog)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added informational buttons for Groups and Spaces in the bot creation picker.
  * Added dialogs explaining Groups and Spaces with distinct content and icons.
  * Informational controls appear on hover or keyboard focus and can be dismissed with the close button or Escape.
  * Added interface text entries for the new information and creation flows across supported language catalogs.

* **Tests**
  * Added end-to-end coverage verifying informational controls at expected hover states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
