### PR TITLE
feat: configure per-connection image limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,8 @@ AGENT_RUNTIME=pi
 WAKEUP_DRIVER=graphile
 # Pause or stop computers after this many idle ms. Minimum 30000.
 SANDBOX_IDLE_MS=600000
-# Comma-separated model ids on the local / openai-compatible endpoints that accept images.
+# Comma-separated model ids on centrally managed local / openai-compatible endpoints that accept images.
+# User-connected OpenAI-compatible models use the per-connection Supports images setting instead.
 # Declared ids get input ["text","image"] so screenshot computer tools stay available.
 RAKAZO_LOCAL_VISION_MODELS=
 RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS=

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -649,6 +649,7 @@ export function createRouter(deps: RouterDeps) {
           plaintext,
           label: input.label,
           modelId: input.modelId,
+          supportsImages: input.supportsImages,
           signal: context.signal,
         });
       }),
@@ -4692,6 +4693,7 @@ async function persistModelCredential(
     plaintext: string;
     label?: string;
     modelId?: string;
+    supportsImages?: boolean;
     signal?: AbortSignal;
   },
 ) {
@@ -4730,6 +4732,7 @@ async function persistModelCredential(
                 provider: input.provider,
                 label: input.label ?? input.provider,
                 secretId: secret.id,
+                supportsImages: input.supportsImages ?? false,
               },
             })
           : await tx.userModelCredential.update({
@@ -4737,6 +4740,9 @@ async function persistModelCredential(
               data: {
                 label: input.label ?? input.provider,
                 secretId: secret.id,
+                ...(input.supportsImages !== undefined
+                  ? { supportsImages: input.supportsImages }
+                  : {}),
               },
             });
         throwIfAborted(input.signal);

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -294,9 +294,7 @@ export default function Models() {
               modelId: modelId.trim(),
               reasoning,
               supportsImages,
-              maxImagesPerPrompt: supportsImages
-                ? parsedMaxImagesPerPrompt
-                : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
+              maxImagesPerPrompt: supportsImages ? parsedMaxImagesPerPrompt : undefined,
               apiKey: apiKey.trim() || undefined,
               label: selected.providerName ?? selected.provider,
             }

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -1,5 +1,6 @@
 import type { ModelOAuthBegin } from "@rakazo/contracts";
 import {
+  DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
   OPENAI_COMPATIBLE_BASE_URL_HINT,
   OPENAI_COMPATIBLE_PROVIDER_ID,
   openAiCompatibleConnectReady,
@@ -47,6 +48,9 @@ export default function Models() {
   const [baseUrl, setBaseUrl] = useState("");
   const [reasoning, setReasoning] = useState(false);
   const [supportsImages, setSupportsImages] = useState(false);
+  const [maxImagesPerPrompt, setMaxImagesPerPrompt] = useState(
+    String(DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT),
+  );
   const [showEndpointHelp, setShowEndpointHelp] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
@@ -113,6 +117,9 @@ export default function Models() {
       setBaseUrl(nextCredential?.baseUrl ?? "");
       setReasoning(nextCredential?.reasoning ?? false);
       setSupportsImages(nextCredential?.supportsImages ?? false);
+      setMaxImagesPerPrompt(
+        String(nextCredential?.maxImagesPerPrompt ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT),
+      );
     }
   }, []);
 
@@ -195,6 +202,9 @@ export default function Models() {
     setProvider(nextProvider);
     setReasoning(nextCredential?.reasoning ?? false);
     setSupportsImages(nextCredential?.supportsImages ?? false);
+    setMaxImagesPerPrompt(
+      String(nextCredential?.maxImagesPerPrompt ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT),
+    );
     setModelId(
       nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID
         ? (nextCredential?.modelId ?? "")
@@ -261,6 +271,16 @@ export default function Models() {
     } else if (!apiKey.trim()) {
       return;
     }
+    const parsedMaxImagesPerPrompt = Number(maxImagesPerPrompt);
+    if (
+      supportsImages &&
+      (!Number.isInteger(parsedMaxImagesPerPrompt) ||
+        parsedMaxImagesPerPrompt < 1 ||
+        parsedMaxImagesPerPrompt > 1000)
+    ) {
+      setError(t("Enter a whole number from 1 to 1000 for the image limit."));
+      return;
+    }
     setError(null);
     setNotice(null);
     setPending("connect");
@@ -274,6 +294,9 @@ export default function Models() {
               modelId: modelId.trim(),
               reasoning,
               supportsImages,
+              maxImagesPerPrompt: supportsImages
+                ? parsedMaxImagesPerPrompt
+                : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
               apiKey: apiKey.trim() || undefined,
               label: selected.providerName ?? selected.provider,
             }
@@ -582,6 +605,20 @@ export default function Models() {
                       value={supportsImages}
                       onValueChange={setSupportsImages}
                       disabled={busy}
+                    />
+                  </View>
+                ) : null}
+                {showAdvanced && supportsImages ? (
+                  <View style={styles.modelRow}>
+                    <Text style={styles.modelLabel}>{t("Maximum images per request")}</Text>
+                    <TextInput
+                      accessibilityLabel={t("Maximum images per request")}
+                      editable={!busy}
+                      keyboardType="number-pad"
+                      maxLength={4}
+                      onChangeText={setMaxImagesPerPrompt}
+                      style={[styles.keyInput, styles.maxImagesInput]}
+                      value={maxImagesPerPrompt}
                     />
                   </View>
                 ) : null}
@@ -983,6 +1020,12 @@ function createModelsStyles() {
       paddingHorizontal: 14,
       marginTop: 4,
       fontSize: 16,
+    },
+    maxImagesInput: {
+      width: 72,
+      height: 40,
+      marginTop: 0,
+      textAlign: "center",
     },
     primaryButton: {
       minHeight: 48,

--- a/apps/mobile/app/models.tsx
+++ b/apps/mobile/app/models.tsx
@@ -46,6 +46,7 @@ export default function Models() {
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [reasoning, setReasoning] = useState(false);
+  const [supportsImages, setSupportsImages] = useState(false);
   const [showEndpointHelp, setShowEndpointHelp] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
@@ -111,6 +112,7 @@ export default function Models() {
     if (nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID) {
       setBaseUrl(nextCredential?.baseUrl ?? "");
       setReasoning(nextCredential?.reasoning ?? false);
+      setSupportsImages(nextCredential?.supportsImages ?? false);
     }
   }, []);
 
@@ -192,6 +194,7 @@ export default function Models() {
     const nextCredential = credentials.find((entry) => entry.provider === nextProvider);
     setProvider(nextProvider);
     setReasoning(nextCredential?.reasoning ?? false);
+    setSupportsImages(nextCredential?.supportsImages ?? false);
     setModelId(
       nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID
         ? (nextCredential?.modelId ?? "")
@@ -270,6 +273,7 @@ export default function Models() {
               baseUrl: effectiveBaseUrl,
               modelId: modelId.trim(),
               reasoning,
+              supportsImages,
               apiKey: apiKey.trim() || undefined,
               label: selected.providerName ?? selected.provider,
             }
@@ -566,6 +570,17 @@ export default function Models() {
                       accessibilityLabel={t("Supports thinking")}
                       value={reasoning}
                       onValueChange={setReasoning}
+                      disabled={busy}
+                    />
+                  </View>
+                ) : null}
+                {showAdvanced ? (
+                  <View style={styles.modelRow}>
+                    <Text style={styles.modelLabel}>{t("Supports images")}</Text>
+                    <Switch
+                      accessibilityLabel={t("Supports images")}
+                      value={supportsImages}
+                      onValueChange={setSupportsImages}
                       disabled={busy}
                     />
                   </View>

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -435,6 +435,7 @@ export const ZH_MESSAGES: Record<string, string> = {
   "Add a voice provider in Voice settings.": "请先在语音设置中添加语音提供商。",
   Advanced: "高级",
   "Supports thinking": "支持思考",
+  "Supports images": "支持图像",
   Agent: "智能体",
   archived: "已归档",
   Attachment: "附件",

--- a/apps/mobile/lib/locales/zh.ts
+++ b/apps/mobile/lib/locales/zh.ts
@@ -436,6 +436,9 @@ export const ZH_MESSAGES: Record<string, string> = {
   Advanced: "高级",
   "Supports thinking": "支持思考",
   "Supports images": "支持图像",
+  "Maximum images per request": "每次请求的最大图像数",
+  "Enter a whole number from 1 to 1000 for the image limit.":
+    "请输入 1 到 1000 之间的整数作为图像限制。",
   Agent: "智能体",
   archived: "已归档",
   Attachment: "附件",

--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -20,22 +20,26 @@ test("custom connections persist reasoning support and bot thinking", async ({
   await page.getByLabel("OpenAI-compatible server URL").fill("http://127.0.0.1:8090/v1");
   await page.getByLabel("Model id").fill("arbitrary-model");
   await expect(page.getByRole("checkbox", { name: "Supports thinking" })).toBeHidden();
+  await expect(page.getByRole("checkbox", { name: "Supports images" })).toBeHidden();
   await page.getByText("Advanced", { exact: true }).click();
   await page.getByRole("checkbox", { name: "Supports thinking" }).check();
+  await page.getByRole("checkbox", { name: "Supports images" }).check();
   await captureScreenshot(page, testInfo, "openai-compatible-thinking-connection");
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(page.getByText("Saved.", { exact: true })).toBeVisible();
-  const credentials = await rpc<Array<{ modelId?: string; reasoning?: boolean }>>(
-    page,
-    "models/credentials",
-    {},
-  );
+  const credentials = await rpc<
+    Array<{ modelId?: string; reasoning?: boolean; supportsImages?: boolean }>
+  >(page, "models/credentials", {});
   expect(credentials.find((entry) => entry.modelId === "arbitrary-model")?.reasoning).toBe(true);
+  expect(credentials.find((entry) => entry.modelId === "arbitrary-model")?.supportsImages).toBe(
+    true,
+  );
   await page.reload();
   await page.getByRole("button", { name: new RegExp(userName) }).click();
   await page.getByRole("button", { name: "Models", exact: true }).click();
   await page.getByText("Advanced", { exact: true }).click();
   await expect(page.getByRole("checkbox", { name: "Supports thinking" })).toBeChecked();
+  await expect(page.getByRole("checkbox", { name: "Supports images" })).toBeChecked();
   await page.getByRole("button", { name: "Close model settings" }).click();
   await page.locator("main").getByRole("button", { name: "Chief", exact: true }).click();
   const settings = page.getByTestId("bot-settings");

--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -24,15 +24,24 @@ test("custom connections persist reasoning support and bot thinking", async ({
   await page.getByText("Advanced", { exact: true }).click();
   await page.getByRole("checkbox", { name: "Supports thinking" }).check();
   await page.getByRole("checkbox", { name: "Supports images" }).check();
+  await page.getByLabel("Maximum images per request").fill("1");
   await captureScreenshot(page, testInfo, "openai-compatible-thinking-connection");
   await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(page.getByText("Saved.", { exact: true })).toBeVisible();
   const credentials = await rpc<
-    Array<{ modelId?: string; reasoning?: boolean; supportsImages?: boolean }>
+    Array<{
+      modelId?: string;
+      reasoning?: boolean;
+      supportsImages?: boolean;
+      maxImagesPerPrompt?: number;
+    }>
   >(page, "models/credentials", {});
   expect(credentials.find((entry) => entry.modelId === "arbitrary-model")?.reasoning).toBe(true);
   expect(credentials.find((entry) => entry.modelId === "arbitrary-model")?.supportsImages).toBe(
     true,
+  );
+  expect(credentials.find((entry) => entry.modelId === "arbitrary-model")?.maxImagesPerPrompt).toBe(
+    1,
   );
   await page.reload();
   await page.getByRole("button", { name: new RegExp(userName) }).click();
@@ -40,6 +49,7 @@ test("custom connections persist reasoning support and bot thinking", async ({
   await page.getByText("Advanced", { exact: true }).click();
   await expect(page.getByRole("checkbox", { name: "Supports thinking" })).toBeChecked();
   await expect(page.getByRole("checkbox", { name: "Supports images" })).toBeChecked();
+  await expect(page.getByLabel("Maximum images per request")).toHaveValue("1");
   await page.getByRole("button", { name: "Close model settings" }).click();
   await page.locator("main").getByRole("button", { name: "Chief", exact: true }).click();
   const settings = page.getByTestId("bot-settings");

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3304,7 +3304,7 @@ msgstr "Unterstützt Denkmodus"
 #: src/pages/ModelSettingsOverlay.tsx:508
 #: src/pages/Onboarding.tsx:425
 msgid "Supports images"
-msgstr ""
+msgstr "Unterstützt Bilder"
 
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"

--- a/apps/web/src/locales/de/messages.po
+++ b/apps/web/src/locales/de/messages.po
@@ -3301,6 +3301,11 @@ msgstr "Skills"
 msgid "Supports thinking"
 msgstr "Unterstützt Denkmodus"
 
+#: src/pages/ModelSettingsOverlay.tsx:508
+#: src/pages/Onboarding.tsx:425
+msgid "Supports images"
+msgstr ""
+
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"
 msgstr "GraphQL hinzufügen"
@@ -3324,4 +3329,3 @@ msgstr "Executor verbinden"
 #: src/pages/PluginsOverlay.tsx
 msgid "Executor token"
 msgstr "Executor-Token"
-

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -3301,6 +3301,11 @@ msgstr "Skills"
 msgid "Supports thinking"
 msgstr "Supports thinking"
 
+#: src/pages/ModelSettingsOverlay.tsx:508
+#: src/pages/Onboarding.tsx:425
+msgid "Supports images"
+msgstr "Supports images"
+
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"
 msgstr "Add GraphQL"
@@ -3324,4 +3329,3 @@ msgstr "Connect Executor"
 #: src/pages/PluginsOverlay.tsx
 msgid "Executor token"
 msgstr "Executor token"
-

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3264,7 +3264,7 @@ msgstr "Admite razonamiento"
 #: src/pages/ModelSettingsOverlay.tsx:508
 #: src/pages/Onboarding.tsx:425
 msgid "Supports images"
-msgstr ""
+msgstr "Admite imágenes"
 
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -3261,6 +3261,11 @@ msgstr "Habilidades"
 msgid "Supports thinking"
 msgstr "Admite razonamiento"
 
+#: src/pages/ModelSettingsOverlay.tsx:508
+#: src/pages/Onboarding.tsx:425
+msgid "Supports images"
+msgstr ""
+
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"
 msgstr "Añadir GraphQL"
@@ -3284,4 +3289,3 @@ msgstr "Conectar Executor"
 #: src/pages/PluginsOverlay.tsx
 msgid "Executor token"
 msgstr "Token de Executor"
-

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3301,6 +3301,11 @@ msgstr "स्किल्स"
 msgid "Supports thinking"
 msgstr "सोचने की क्षमता का समर्थन करता है"
 
+#: src/pages/ModelSettingsOverlay.tsx:508
+#: src/pages/Onboarding.tsx:425
+msgid "Supports images"
+msgstr ""
+
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"
 msgstr "GraphQL जोड़ें"
@@ -3324,4 +3329,3 @@ msgstr "Executor कनेक्ट करें"
 #: src/pages/PluginsOverlay.tsx
 msgid "Executor token"
 msgstr "Executor टोकन"
-

--- a/apps/web/src/locales/hi/messages.po
+++ b/apps/web/src/locales/hi/messages.po
@@ -3304,7 +3304,7 @@ msgstr "सोचने की क्षमता का समर्थन क�
 #: src/pages/ModelSettingsOverlay.tsx:508
 #: src/pages/Onboarding.tsx:425
 msgid "Supports images"
-msgstr ""
+msgstr "छवियों का समर्थन"
 
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3304,7 +3304,7 @@ msgstr "사고 모드 지원"
 #: src/pages/ModelSettingsOverlay.tsx:508
 #: src/pages/Onboarding.tsx:425
 msgid "Supports images"
-msgstr ""
+msgstr "이미지 지원"
 
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"

--- a/apps/web/src/locales/ko/messages.po
+++ b/apps/web/src/locales/ko/messages.po
@@ -3301,6 +3301,11 @@ msgstr "스킬"
 msgid "Supports thinking"
 msgstr "사고 모드 지원"
 
+#: src/pages/ModelSettingsOverlay.tsx:508
+#: src/pages/Onboarding.tsx:425
+msgid "Supports images"
+msgstr ""
+
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"
 msgstr "GraphQL 추가"
@@ -3324,4 +3329,3 @@ msgstr "Executor 연결"
 #: src/pages/PluginsOverlay.tsx
 msgid "Executor token"
 msgstr "Executor 토큰"
-

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3304,7 +3304,7 @@ msgstr "Suporta raciocínio"
 #: src/pages/ModelSettingsOverlay.tsx:508
 #: src/pages/Onboarding.tsx:425
 msgid "Supports images"
-msgstr ""
+msgstr "Suporta imagens"
 
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"

--- a/apps/web/src/locales/pt-BR/messages.po
+++ b/apps/web/src/locales/pt-BR/messages.po
@@ -3301,6 +3301,11 @@ msgstr "Habilidades"
 msgid "Supports thinking"
 msgstr "Suporta raciocínio"
 
+#: src/pages/ModelSettingsOverlay.tsx:508
+#: src/pages/Onboarding.tsx:425
+msgid "Supports images"
+msgstr ""
+
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"
 msgstr "Adicionar GraphQL"
@@ -3324,4 +3329,3 @@ msgstr "Conectar Executor"
 #: src/pages/PluginsOverlay.tsx
 msgid "Executor token"
 msgstr "Token do Executor"
-

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3301,6 +3301,11 @@ msgstr "Beceriler"
 msgid "Supports thinking"
 msgstr "Düşünmeyi destekler"
 
+#: src/pages/ModelSettingsOverlay.tsx:508
+#: src/pages/Onboarding.tsx:425
+msgid "Supports images"
+msgstr ""
+
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"
 msgstr "GraphQL ekle"
@@ -3324,4 +3329,3 @@ msgstr "Executor'a bağlan"
 #: src/pages/PluginsOverlay.tsx
 msgid "Executor token"
 msgstr "Executor belirteci"
-

--- a/apps/web/src/locales/tr/messages.po
+++ b/apps/web/src/locales/tr/messages.po
@@ -3304,7 +3304,7 @@ msgstr "Düşünmeyi destekler"
 #: src/pages/ModelSettingsOverlay.tsx:508
 #: src/pages/Onboarding.tsx:425
 msgid "Supports images"
-msgstr ""
+msgstr "Görüntüleri destekler"
 
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3304,7 +3304,7 @@ msgstr "支持思考"
 #: src/pages/ModelSettingsOverlay.tsx:508
 #: src/pages/Onboarding.tsx:425
 msgid "Supports images"
-msgstr ""
+msgstr "支持图片"
 
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"

--- a/apps/web/src/locales/zh-CN/messages.po
+++ b/apps/web/src/locales/zh-CN/messages.po
@@ -3301,6 +3301,11 @@ msgstr "技能"
 msgid "Supports thinking"
 msgstr "支持思考"
 
+#: src/pages/ModelSettingsOverlay.tsx:508
+#: src/pages/Onboarding.tsx:425
+msgid "Supports images"
+msgstr ""
+
 #: src/pages/PluginsOverlay.tsx:486
 msgid "Add GraphQL"
 msgstr "添加 GraphQL"
@@ -3324,4 +3329,3 @@ msgstr "连接 Executor"
 #: src/pages/PluginsOverlay.tsx
 msgid "Executor token"
 msgstr "Executor 令牌"
-

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -283,9 +283,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
               modelId: modelId.trim(),
               reasoning,
               supportsImages,
-              maxImagesPerPrompt: supportsImages
-                ? parsedMaxImagesPerPrompt
-                : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
+              maxImagesPerPrompt: supportsImages ? parsedMaxImagesPerPrompt : undefined,
               apiKey: apiKey.trim() || undefined,
               label: selected.providerName ?? selected.provider,
             }

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -1,6 +1,7 @@
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import type { Me } from "@rakazo/contracts";
 import {
+  DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
   OPENAI_COMPATIBLE_PROVIDER_ID,
   openAiCompatibleConnectReady,
   openAiCompatibleProbeSuccessMessage,
@@ -46,6 +47,9 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [baseUrl, setBaseUrl] = useState("");
   const [reasoning, setReasoning] = useState(false);
   const [supportsImages, setSupportsImages] = useState(false);
+  const [maxImagesPerPrompt, setMaxImagesPerPrompt] = useState(
+    String(DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT),
+  );
   const [{ models: probeModels, baseUrl: probedBaseUrl, probing }, setProbe] =
     useState(initialModelProbeState);
   const [modelProbe] = useState(() => createModelProbe(setProbe));
@@ -114,6 +118,9 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
         setBaseUrl(nextCredential?.baseUrl ?? "");
         setReasoning(nextCredential?.reasoning ?? false);
         setSupportsImages(nextCredential?.supportsImages ?? false);
+        setMaxImagesPerPrompt(
+          String(nextCredential?.maxImagesPerPrompt ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT),
+        );
       }
     }
   }
@@ -194,6 +201,9 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     setProvider(nextProvider);
     setReasoning(nextCredential?.reasoning ?? false);
     setSupportsImages(nextCredential?.supportsImages ?? false);
+    setMaxImagesPerPrompt(
+      String(nextCredential?.maxImagesPerPrompt ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT),
+    );
     setModelId(
       nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID
         ? (nextCredential?.modelId ?? "")
@@ -251,6 +261,16 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     } else if (!apiKey.trim()) {
       return;
     }
+    const parsedMaxImagesPerPrompt = Number(maxImagesPerPrompt);
+    if (
+      supportsImages &&
+      (!Number.isInteger(parsedMaxImagesPerPrompt) ||
+        parsedMaxImagesPerPrompt < 1 ||
+        parsedMaxImagesPerPrompt > 1000)
+    ) {
+      setError(t`Enter a whole number from 1 to 1000 for the image limit.`);
+      return;
+    }
     setError(null);
     setNotice(null);
     setPending("connect");
@@ -263,6 +283,9 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
               modelId: modelId.trim(),
               reasoning,
               supportsImages,
+              maxImagesPerPrompt: supportsImages
+                ? parsedMaxImagesPerPrompt
+                : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
               apiKey: apiKey.trim() || undefined,
               label: selected.providerName ?? selected.provider,
             }
@@ -506,6 +529,13 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                           setNotice(null);
                         }}
                         imagesLabel={t`Supports images`}
+                        maxImagesPerPrompt={maxImagesPerPrompt}
+                        onMaxImagesPerPromptChange={(value) => {
+                          selectionRevisionRef.current += 1;
+                          setMaxImagesPerPrompt(value);
+                          setNotice(null);
+                        }}
+                        maxImagesLabel={t`Maximum images per request`}
                       />
                     </>
                   ) : (

--- a/apps/web/src/pages/ModelSettingsOverlay.tsx
+++ b/apps/web/src/pages/ModelSettingsOverlay.tsx
@@ -45,6 +45,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [reasoning, setReasoning] = useState(false);
+  const [supportsImages, setSupportsImages] = useState(false);
   const [{ models: probeModels, baseUrl: probedBaseUrl, probing }, setProbe] =
     useState(initialModelProbeState);
   const [modelProbe] = useState(() => createModelProbe(setProbe));
@@ -112,6 +113,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
       if (nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID) {
         setBaseUrl(nextCredential?.baseUrl ?? "");
         setReasoning(nextCredential?.reasoning ?? false);
+        setSupportsImages(nextCredential?.supportsImages ?? false);
       }
     }
   }
@@ -191,6 +193,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
     const nextCredential = credentials.find((entry) => entry.provider === nextProvider);
     setProvider(nextProvider);
     setReasoning(nextCredential?.reasoning ?? false);
+    setSupportsImages(nextCredential?.supportsImages ?? false);
     setModelId(
       nextProvider === OPENAI_COMPATIBLE_PROVIDER_ID
         ? (nextCredential?.modelId ?? "")
@@ -259,6 +262,7 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
               baseUrl: effectiveBaseUrl,
               modelId: modelId.trim(),
               reasoning,
+              supportsImages,
               apiKey: apiKey.trim() || undefined,
               label: selected.providerName ?? selected.provider,
             }
@@ -495,6 +499,13 @@ export function ModelSettingsOverlay({ onClose }: { onClose: () => void }) {
                         disabled={busy}
                         advancedLabel={t`Advanced`}
                         thinkingLabel={t`Supports thinking`}
+                        supportsImages={supportsImages}
+                        onSupportsImagesChange={(value) => {
+                          selectionRevisionRef.current += 1;
+                          setSupportsImages(value);
+                          setNotice(null);
+                        }}
+                        imagesLabel={t`Supports images`}
                       />
                     </>
                   ) : (

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -1,5 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
+  DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
   OPENAI_COMPATIBLE_PROVIDER_ID,
   openAiCompatibleConnectReady,
   openAiCompatibleProbeSuccessMessage,
@@ -40,6 +41,9 @@ export function OnboardingPage() {
   const [baseUrl, setBaseUrl] = useState("");
   const [reasoning, setReasoning] = useState(false);
   const [supportsImages, setSupportsImages] = useState(false);
+  const [maxImagesPerPrompt, setMaxImagesPerPrompt] = useState(
+    String(DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT),
+  );
   const [{ models: probeModels, baseUrl: probedBaseUrl, probing }, setProbe] =
     useState(initialModelProbeState);
   const [modelProbe] = useState(() => createModelProbe(setProbe));
@@ -177,12 +181,25 @@ export function OnboardingPage() {
     setError(null);
     try {
       if (isOpenAiCompatible) {
+        const parsedMaxImagesPerPrompt = Number(maxImagesPerPrompt);
+        if (
+          supportsImages &&
+          (!Number.isInteger(parsedMaxImagesPerPrompt) ||
+            parsedMaxImagesPerPrompt < 1 ||
+            parsedMaxImagesPerPrompt > 1000)
+        ) {
+          setError(t`Enter a whole number from 1 to 1000 for the image limit.`);
+          return;
+        }
         await rpc.models.connect({
           provider,
           baseUrl: baseUrl.trim(),
           modelId: modelId.trim(),
           reasoning,
           supportsImages,
+          maxImagesPerPrompt: supportsImages
+            ? parsedMaxImagesPerPrompt
+            : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
           apiKey: apiKey.trim() || undefined,
           label: selected?.providerName ?? provider,
         });
@@ -423,6 +440,9 @@ export function OnboardingPage() {
                     supportsImages={supportsImages}
                     onSupportsImagesChange={setSupportsImages}
                     imagesLabel={t`Supports images`}
+                    maxImagesPerPrompt={maxImagesPerPrompt}
+                    onMaxImagesPerPromptChange={setMaxImagesPerPrompt}
+                    maxImagesLabel={t`Maximum images per request`}
                   />
                 </>
               ) : (

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -197,9 +197,7 @@ export function OnboardingPage() {
           modelId: modelId.trim(),
           reasoning,
           supportsImages,
-          maxImagesPerPrompt: supportsImages
-            ? parsedMaxImagesPerPrompt
-            : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
+          maxImagesPerPrompt: supportsImages ? parsedMaxImagesPerPrompt : undefined,
           apiKey: apiKey.trim() || undefined,
           label: selected?.providerName ?? provider,
         });

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -39,6 +39,7 @@ export function OnboardingPage() {
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [reasoning, setReasoning] = useState(false);
+  const [supportsImages, setSupportsImages] = useState(false);
   const [{ models: probeModels, baseUrl: probedBaseUrl, probing }, setProbe] =
     useState(initialModelProbeState);
   const [modelProbe] = useState(() => createModelProbe(setProbe));
@@ -181,6 +182,7 @@ export function OnboardingPage() {
           baseUrl: baseUrl.trim(),
           modelId: modelId.trim(),
           reasoning,
+          supportsImages,
           apiKey: apiKey.trim() || undefined,
           label: selected?.providerName ?? provider,
         });
@@ -299,6 +301,7 @@ export function OnboardingPage() {
                       );
                       setBaseUrl("");
                       setReasoning(false);
+                      setSupportsImages(false);
                       resetOpenAiCompatibleProbe();
                       setError(null);
                       setNotice(null);
@@ -417,6 +420,9 @@ export function OnboardingPage() {
                     onReasoningChange={setReasoning}
                     advancedLabel={t`Advanced`}
                     thinkingLabel={t`Supports thinking`}
+                    supportsImages={supportsImages}
+                    onSupportsImagesChange={setSupportsImages}
+                    imagesLabel={t`Supports images`}
                   />
                 </>
               ) : (

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -197,8 +197,10 @@ Each user can also connect their own OpenAI-compatible endpoint from **Connect a
 **Settings → Models** on web and mobile. Choose **OpenAI-compatible**, enter the server base URL
 (for example `http://127.0.0.1:8000/v1`), the exact model id, and an optional API key.
 Public hosts and ordinary hostnames need `RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1` and HTTPS.
-Literal private IP, loopback, and `host.docker.internal` targets do not. To mark user-connected
-openai-compatible model ids as vision-capable (so screenshot computer tools stay available), set
+Literal private IP, loopback, and `host.docker.internal` targets do not. If that endpoint's model
+accepts images, enable **Supports images** under **Advanced** when connecting so attachments and
+screenshot computer tools stay available. Existing connections default to disabled. For centrally
+managed endpoints, the deployment-wide fallback remains
 `RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS=gpt4o-vision,llava`.
 
 For servers that accept standard `reasoning_effort`, enable **Supports thinking** under

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -51,7 +51,8 @@ SANDBOX_PROVIDER=docker
 # Optional model / integration keys
 OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
-# Comma-separated model ids on the local / openai-compatible endpoints that accept images.
+# Comma-separated model ids on centrally managed local / openai-compatible endpoints that accept images.
+# User-connected OpenAI-compatible models use the per-connection Supports images setting instead.
 # Declared ids get input ["text","image"] so screenshot computer tools stay available.
 RAKAZO_LOCAL_VISION_MODELS=
 RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS=

--- a/infra/compose/.env.images.example
+++ b/infra/compose/.env.images.example
@@ -51,6 +51,10 @@ SANDBOX_PROVIDER=docker
 # Optional model / integration keys
 OPENROUTER_API_KEY=
 COMPOSIO_API_KEY=
+# Comma-separated model ids on the local / openai-compatible endpoints that accept images.
+# Declared ids get input ["text","image"] so screenshot computer tools stay available.
+RAKAZO_LOCAL_VISION_MODELS=
+RAKAZO_OPENAI_COMPATIBLE_VISION_MODELS=
 # User-connected public OpenAI-compatible hosts need =1 (default: private/loopback only).
 # RAKAZO_OPENAI_COMPAT_ALLOW_PUBLIC=1
 # Optional integrations.sh-compatible catalog base URL (Rakazo appends api/search).

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -336,6 +336,8 @@ export interface AgentRunRequest {
     reasoning?: boolean;
     /** Whether this custom connection accepts image input. */
     acceptsImages?: boolean;
+    /** Maximum number of image inputs the model connection accepts in one request. */
+    maxImagesPerPrompt?: number;
     /** Preferred thinking effort for reasoning models; clamped to the model’s supported set. */
     thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
     /** In-process OAuth credential from the encrypted store for this run. */

--- a/packages/adapter-kit/src/types.ts
+++ b/packages/adapter-kit/src/types.ts
@@ -334,6 +334,8 @@ export interface AgentRunRequest {
     baseUrl?: string;
     /** Whether this custom connection accepts standard reasoning_effort. */
     reasoning?: boolean;
+    /** Whether this custom connection accepts image input. */
+    acceptsImages?: boolean;
     /** Preferred thinking effort for reasoning models; clamped to the model’s supported set. */
     thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
     /** In-process OAuth credential from the encrypted store for this run. */

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -1059,6 +1059,7 @@ description: Prepare standup notes
       kind: "openai_compatible",
       baseUrl: "http://127.0.0.1:8000/v1",
       visionModelIds: ["bot-vision-model"],
+      maxImagesPerPrompt: 1,
     });
     const bot = {
       modelProvider: provider,
@@ -1089,6 +1090,7 @@ description: Prepare standup notes
       provider,
       id: "bot-vision-model",
       acceptsImages: true,
+      maxImagesPerPrompt: 1,
     });
 
     bot.modelId = "text-only-model";

--- a/packages/adapters/src/executor.test.ts
+++ b/packages/adapters/src/executor.test.ts
@@ -12,6 +12,7 @@ import {
   settleSteeringAttachmentLoads,
   threadContextForRun,
 } from "./executor.js";
+import { serializeModelSecret } from "./pi-oauth.js";
 
 describe("run workspace checkpoint", () => {
   it("skips clean turns and flushes once after a mutation", async () => {
@@ -1037,6 +1038,67 @@ description: Prepare standup notes
         where: expect.objectContaining({ credential: { provider: "xai" } }),
       }),
     );
+  });
+
+  it("keeps image support for a separately enabled bot model override", async () => {
+    const provider = "openai-compatible";
+    const findFirst = vi.fn(
+      async (args: { where: { credential?: { provider?: string }; isDefault?: boolean } }) => {
+        if (args.where.credential?.provider === provider || args.where.isDefault) {
+          return modelPreference({
+            provider,
+            secretId: "secret-openai-compatible",
+            modelId: "space-model",
+            isDefault: Boolean(args.where.isDefault),
+          });
+        }
+        return null;
+      },
+    );
+    const plaintext = serializeModelSecret({
+      kind: "openai_compatible",
+      baseUrl: "http://127.0.0.1:8000/v1",
+      visionModelIds: ["bot-vision-model"],
+    });
+    const bot = {
+      modelProvider: provider,
+      modelId: "bot-vision-model",
+      thinkingLevel: null,
+    };
+    const prisma = {
+      bot: { findFirst: vi.fn(async () => bot) },
+      spaceModelPreference: { findFirst },
+      userModelCredential: { findFirst: vi.fn(async () => null) },
+      deploymentSettings: { findUnique: vi.fn(async () => null) },
+      secret: {
+        findFirst: vi.fn(async () => ({
+          id: "secret-openai-compatible",
+          ciphertext: plaintext,
+        })),
+        findUnique: vi.fn(async () => null),
+      },
+    } as unknown as PrismaClient;
+    const executor = createRunExecutor({
+      prisma,
+      secretStore: { load: vi.fn(() => plaintext), put: vi.fn() },
+    } as unknown as Parameters<typeof createRunExecutor>[0]);
+
+    await expect(
+      executor.resolveModel({ userId: "user-1", spaceId: "ws-1", botId: "bot-1" }),
+    ).resolves.toMatchObject({
+      provider,
+      id: "bot-vision-model",
+      acceptsImages: true,
+    });
+
+    bot.modelId = "text-only-model";
+    await expect(
+      executor.resolveModel({ userId: "user-1", spaceId: "ws-1", botId: "bot-1" }),
+    ).resolves.toMatchObject({
+      provider,
+      id: "text-only-model",
+      acceptsImages: false,
+    });
   });
 
   it("falls back to the Space default when the override provider has no credential", async () => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -30,6 +30,7 @@ import {
   ATTACHMENT_MAX_BYTES,
   BotSecretName,
   BotSecretSubmission,
+  OPENAI_COMPATIBLE_PROVIDER_ID,
   isAttachmentImageMimeType,
 } from "@rakazo/contracts";
 import {
@@ -655,6 +656,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         scope.spaceId,
         credential,
         provider,
+        id,
       );
       return {
         provider,
@@ -1198,6 +1200,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
           run.spaceId,
           credential,
           runModelProvider,
+          runModelId,
           (values) => runSecrets.push(...values),
         );
         runSecrets.push(...resolved.redact);
@@ -1706,6 +1709,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 run.spaceId,
                 reviewCredential,
                 checker.provider,
+                checker.model,
                 (values) => runSecrets.push(...values),
               );
               const judge = await runAutoReviewJudge({
@@ -4188,8 +4192,14 @@ async function resolveModelKey(
   deps: ExecutorDeps,
   userId: string,
   spaceId: string,
-  credential: { secretId: string; provider: string; supportsImages?: boolean } | null,
+  credential: {
+    secretId: string;
+    provider: string;
+    defaultModel?: string | null;
+    supportsImages?: boolean;
+  } | null,
   provider: string,
+  modelId: string,
   registerSecrets?: (values: string[]) => void,
 ): Promise<{
   apiKey?: string;
@@ -4236,7 +4246,10 @@ async function resolveModelKey(
         baseUrl,
         reasoning:
           resolved.secret.kind === "openai_compatible" ? resolved.secret.reasoning : undefined,
-        acceptsImages: credential.supportsImages,
+        acceptsImages:
+          credential.provider === OPENAI_COMPATIBLE_PROVIDER_ID &&
+          credential.supportsImages === true &&
+          credential.defaultModel?.trim() === modelId.trim(),
         oauth,
         persistOAuth: oauth
           ? async (next) => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -666,6 +666,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         baseUrl: resolved.baseUrl,
         reasoning: resolved.reasoning,
         acceptsImages: resolved.acceptsImages,
+        maxImagesPerPrompt: resolved.maxImagesPerPrompt,
         thinkingLevel,
         oauth: resolved.oauth
           ? { credential: resolved.oauth, persist: resolved.persistOAuth }
@@ -3188,6 +3189,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 baseUrl: resolved.baseUrl,
                 reasoning: resolved.reasoning,
                 acceptsImages: resolved.acceptsImages,
+                maxImagesPerPrompt: resolved.maxImagesPerPrompt,
                 thinkingLevel,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }
@@ -4207,6 +4209,7 @@ async function resolveModelKey(
   baseUrl?: string;
   reasoning?: boolean;
   acceptsImages?: boolean;
+  maxImagesPerPrompt?: number;
   oauth?: AgentModelOAuthCredential;
   persistOAuth?: (credential: AgentModelOAuthCredential) => Promise<void>;
   redact: string[];
@@ -4257,6 +4260,10 @@ async function resolveModelKey(
         reasoning:
           resolved.secret.kind === "openai_compatible" ? resolved.secret.reasoning : undefined,
         acceptsImages,
+        maxImagesPerPrompt:
+          resolved.secret.kind === "openai_compatible"
+            ? resolved.secret.maxImagesPerPrompt
+            : undefined,
         oauth,
         persistOAuth: oauth
           ? async (next) => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -662,6 +662,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         apiKey: resolved.oauth ? undefined : resolved.apiKey,
         baseUrl: resolved.baseUrl,
         reasoning: resolved.reasoning,
+        acceptsImages: resolved.acceptsImages,
         thinkingLevel,
         oauth: resolved.oauth
           ? { credential: resolved.oauth, persist: resolved.persistOAuth }
@@ -1239,7 +1240,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
         // vision-capable default was gated as "scripted" and lost its screenshot tools.
         const acceptsImages =
           deps.runtime.describe().capabilities.scripted ||
-          modelAcceptsImageInput(runModelProvider, runModelId);
+          modelAcceptsImageInput(runModelProvider, runModelId, resolved.acceptsImages);
         const groupContext = thread.groupId
           ? await loadGroupContext(deps.prisma, thread.groupId, { id: bot.id, name: bot.name })
           : undefined;
@@ -3181,6 +3182,7 @@ export function createRunExecutor(deps: ExecutorDeps) {
                 apiKey: resolved.oauth ? undefined : resolved.apiKey,
                 baseUrl: resolved.baseUrl,
                 reasoning: resolved.reasoning,
+                acceptsImages: resolved.acceptsImages,
                 thinkingLevel,
                 oauth: resolved.oauth
                   ? { credential: resolved.oauth, persist: resolved.persistOAuth }
@@ -4186,13 +4188,14 @@ async function resolveModelKey(
   deps: ExecutorDeps,
   userId: string,
   spaceId: string,
-  credential: { secretId: string; provider: string } | null,
+  credential: { secretId: string; provider: string; supportsImages?: boolean } | null,
   provider: string,
   registerSecrets?: (values: string[]) => void,
 ): Promise<{
   apiKey?: string;
   baseUrl?: string;
   reasoning?: boolean;
+  acceptsImages?: boolean;
   oauth?: AgentModelOAuthCredential;
   persistOAuth?: (credential: AgentModelOAuthCredential) => Promise<void>;
   redact: string[];
@@ -4233,6 +4236,7 @@ async function resolveModelKey(
         baseUrl,
         reasoning:
           resolved.secret.kind === "openai_compatible" ? resolved.secret.reasoning : undefined,
+        acceptsImages: credential.supportsImages,
         oauth,
         persistOAuth: oauth
           ? async (next) => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -217,6 +217,7 @@ import {
   IMAGE_RETURNING_COMPUTER_TOOLS,
   MODEL_CANNOT_SEE_MESSAGE,
   modelAcceptsImageInput,
+  modelIdSupportsImages,
 } from "./model-vision.js";
 import { toOAuthCredential } from "./pi-credentials.js";
 import {
@@ -4241,15 +4242,21 @@ async function resolveModelKey(
       const oauth = resolved.secret.kind === "oauth" ? resolved.secret.credential : undefined;
       const baseUrl =
         resolved.secret.kind === "openai_compatible" ? resolved.secret.baseUrl : undefined;
+      const acceptsImages =
+        credential.provider === OPENAI_COMPATIBLE_PROVIDER_ID &&
+        resolved.secret.kind === "openai_compatible" &&
+        (modelIdSupportsImages(resolved.secret.visionModelIds, modelId) ||
+          // Legacy secrets have no per-model list, so keep their existing
+          // capability scoped to the model saved in the space preference.
+          (resolved.secret.visionModelIds === undefined &&
+            credential.supportsImages === true &&
+            credential.defaultModel?.trim() === modelId.trim()));
       return {
         apiKey: resolved.apiKey,
         baseUrl,
         reasoning:
           resolved.secret.kind === "openai_compatible" ? resolved.secret.reasoning : undefined,
-        acceptsImages:
-          credential.provider === OPENAI_COMPATIBLE_PROVIDER_ID &&
-          credential.supportsImages === true &&
-          credential.defaultModel?.trim() === modelId.trim(),
+        acceptsImages,
         oauth,
         persistOAuth: oauth
           ? async (next) => {

--- a/packages/adapters/src/executor.ts
+++ b/packages/adapters/src/executor.ts
@@ -30,8 +30,8 @@ import {
   ATTACHMENT_MAX_BYTES,
   BotSecretName,
   BotSecretSubmission,
-  OPENAI_COMPATIBLE_PROVIDER_ID,
   isAttachmentImageMimeType,
+  OPENAI_COMPATIBLE_PROVIDER_ID,
 } from "@rakazo/contracts";
 import {
   type ActionApprovalRule,

--- a/packages/adapters/src/model-connect.test.ts
+++ b/packages/adapters/src/model-connect.test.ts
@@ -25,6 +25,7 @@ describe("modelCredentialDto", () => {
       label: "Local MLX",
       hasKey: true,
       isDefault: true,
+      supportsImages: false,
       baseUrl: "https://example.invalid/v1",
       modelId: "qwen3-4b",
       reasoning: false,

--- a/packages/adapters/src/model-connect.test.ts
+++ b/packages/adapters/src/model-connect.test.ts
@@ -33,6 +33,30 @@ describe("modelCredentialDto", () => {
     });
   });
 
+  it("projects image support for the selected model only", () => {
+    const plaintext = serializeModelSecret({
+      kind: "openai_compatible",
+      baseUrl: "https://example.invalid/v1",
+      visionModelIds: ["vision-model", "another-vision-model"],
+    });
+    const row = {
+      id: "cred-vision",
+      provider: "openai-compatible",
+      label: "Vision server",
+      isDefault: true,
+      supportsImages: false,
+    };
+
+    expect(modelCredentialDto({ ...row, defaultModel: "vision-model" }, plaintext)).toMatchObject({
+      supportsImages: true,
+      modelId: "vision-model",
+    });
+    expect(modelCredentialDto({ ...row, defaultModel: "text-model" }, plaintext)).toMatchObject({
+      supportsImages: false,
+      modelId: "text-model",
+    });
+  });
+
   it("exposes defaultModel as modelId for provider credentials", () => {
     expect(
       modelCredentialDto({
@@ -112,6 +136,25 @@ describe("compatible connection updates", () => {
         buildModelConnectPlaintext({ ...input, baseUrl: "http://localhost:8001/v1" }, previous),
       ),
     ).not.toHaveProperty("apiKey");
+  });
+
+  it("keeps image capability scoped to each explicitly enabled model", () => {
+    const vision = buildModelConnectPlaintext({ ...input, supportsImages: true });
+    const text = buildModelConnectPlaintext(
+      { ...input, modelId: "text-model", supportsImages: false },
+      vision,
+    );
+    const nextVision = buildModelConnectPlaintext(
+      { ...input, modelId: "another-vision-model", supportsImages: true },
+      text,
+    );
+
+    expect(parseModelSecret(text)).toMatchObject({
+      visionModelIds: ["arbitrary-model"],
+    });
+    expect(parseModelSecret(nextVision)).toMatchObject({
+      visionModelIds: ["arbitrary-model", "another-vision-model"],
+    });
   });
   it.each(["", "fake-replacement-key"])(
     "honors an explicit key replacement or removal",

--- a/packages/adapters/src/model-connect.test.ts
+++ b/packages/adapters/src/model-connect.test.ts
@@ -57,6 +57,27 @@ describe("modelCredentialDto", () => {
     });
   });
 
+  it("projects the configured image limit for an OpenAI-compatible connection", () => {
+    const plaintext = serializeModelSecret({
+      kind: "openai_compatible",
+      baseUrl: "https://example.invalid/v1",
+      maxImagesPerPrompt: 1,
+    });
+
+    expect(
+      modelCredentialDto(
+        {
+          id: "cred-one-image",
+          provider: "openai-compatible",
+          label: "Single-image server",
+          isDefault: true,
+          defaultModel: "custom-vision-model",
+        },
+        plaintext,
+      ),
+    ).toMatchObject({ maxImagesPerPrompt: 1 });
+  });
+
   it("exposes defaultModel as modelId for provider credentials", () => {
     expect(
       modelCredentialDto({
@@ -155,6 +176,16 @@ describe("compatible connection updates", () => {
     expect(parseModelSecret(nextVision)).toMatchObject({
       visionModelIds: ["arbitrary-model", "another-vision-model"],
     });
+  });
+  it("persists the image limit while preserving it on connection updates", () => {
+    const configured = buildModelConnectPlaintext({
+      ...input,
+      maxImagesPerPrompt: 1,
+    });
+    const updated = buildModelConnectPlaintext({ ...input, reasoning: false }, configured);
+
+    expect(parseModelSecret(configured)).toMatchObject({ maxImagesPerPrompt: 1 });
+    expect(parseModelSecret(updated)).toMatchObject({ maxImagesPerPrompt: 1 });
   });
   it.each(["", "fake-replacement-key"])(
     "honors an explicit key replacement or removal",

--- a/packages/adapters/src/model-connect.ts
+++ b/packages/adapters/src/model-connect.ts
@@ -1,6 +1,7 @@
 import { getSupportedThinkingLevels } from "@earendil-works/pi-ai";
 import type { ModelConnectInput, ModelCredential, ThinkingLevel } from "@rakazo/contracts";
 import { OPENAI_COMPATIBLE_PROVIDER_ID as CONTRACT_OPENAI_COMPAT } from "@rakazo/contracts";
+import { modelIdSupportsImages, updateModelImageCapabilities } from "./model-vision.js";
 import { parseModelSecret, type StoredModelSecret, serializeModelSecret } from "./pi-oauth.js";
 import {
   OPENAI_COMPATIBLE_PROVIDER_ID,
@@ -15,22 +16,29 @@ export function buildModelConnectPlaintext(
   if (input.provider === OPENAI_COMPATIBLE_PROVIDER_ID) {
     const prepared = prepareOpenAiCompatibleConnect(input);
     const previous = previousPlaintext ? parseModelSecret(previousPlaintext) : undefined;
-    if (
-      input.apiKey === undefined &&
-      previous?.kind === "openai_compatible" &&
-      previous.baseUrl === prepared.baseUrl
-    ) {
+    const sameEndpoint =
+      previous?.kind === "openai_compatible" && previous.baseUrl === prepared.baseUrl;
+    if (input.apiKey === undefined && sameEndpoint) {
       // Revalidate the inherited key too: public endpoints must still use HTTPS.
       prepared.apiKey = prepareOpenAiCompatibleConnect({
         ...input,
         apiKey: previous.apiKey,
       }).apiKey;
     }
+    const previousVisionModelIds = sameEndpoint ? previous.visionModelIds : undefined;
+    const visionModelIds = updateModelImageCapabilities(
+      previousVisionModelIds,
+      prepared.modelId,
+      input.supportsImages,
+    );
     const secret: StoredModelSecret = {
       kind: "openai_compatible",
       baseUrl: prepared.baseUrl,
       ...(input.reasoning !== undefined ? { reasoning: input.reasoning } : {}),
       ...(prepared.apiKey ? { apiKey: prepared.apiKey } : {}),
+      ...(input.supportsImages !== undefined || previousVisionModelIds !== undefined
+        ? { visionModelIds }
+        : {}),
     };
     return serializeModelSecret(secret);
   }
@@ -70,6 +78,10 @@ export function modelCredentialDto(
   if (parsed.kind !== "openai_compatible") return compatibleCredential;
   return {
     ...compatibleCredential,
+    supportsImages:
+      parsed.visionModelIds !== undefined
+        ? modelIdSupportsImages(parsed.visionModelIds, row.defaultModel)
+        : compatibleCredential.supportsImages,
     baseUrl: parsed.baseUrl,
     reasoning: parsed.reasoning ?? false,
     thinkingLevels: getSupportedThinkingLevels(

--- a/packages/adapters/src/model-connect.ts
+++ b/packages/adapters/src/model-connect.ts
@@ -48,6 +48,7 @@ export function modelCredentialDto(
     label: string;
     isDefault: boolean;
     defaultModel?: string | null;
+    supportsImages?: boolean;
   },
   plaintext?: string,
 ): ModelCredential {
@@ -59,11 +60,16 @@ export function modelCredentialDto(
     isDefault: row.isDefault,
     ...(row.defaultModel ? { modelId: row.defaultModel } : {}),
   };
-  if (row.provider !== CONTRACT_OPENAI_COMPAT || !plaintext) return credential;
-  const parsed = parseModelSecret(plaintext);
-  if (parsed.kind !== "openai_compatible") return credential;
-  return {
+  if (row.provider !== CONTRACT_OPENAI_COMPAT) return credential;
+  const compatibleCredential = {
     ...credential,
+    supportsImages: row.supportsImages ?? false,
+  };
+  if (!plaintext) return compatibleCredential;
+  const parsed = parseModelSecret(plaintext);
+  if (parsed.kind !== "openai_compatible") return compatibleCredential;
+  return {
+    ...compatibleCredential,
     baseUrl: parsed.baseUrl,
     reasoning: parsed.reasoning ?? false,
     thinkingLevels: getSupportedThinkingLevels(

--- a/packages/adapters/src/model-connect.ts
+++ b/packages/adapters/src/model-connect.ts
@@ -26,6 +26,8 @@ export function buildModelConnectPlaintext(
       }).apiKey;
     }
     const previousVisionModelIds = sameEndpoint ? previous.visionModelIds : undefined;
+    const maxImagesPerPrompt =
+      input.maxImagesPerPrompt ?? (sameEndpoint ? previous.maxImagesPerPrompt : undefined);
     const visionModelIds = updateModelImageCapabilities(
       previousVisionModelIds,
       prepared.modelId,
@@ -39,6 +41,7 @@ export function buildModelConnectPlaintext(
       ...(input.supportsImages !== undefined || previousVisionModelIds !== undefined
         ? { visionModelIds }
         : {}),
+      ...(maxImagesPerPrompt !== undefined ? { maxImagesPerPrompt } : {}),
     };
     return serializeModelSecret(secret);
   }
@@ -84,6 +87,9 @@ export function modelCredentialDto(
         : compatibleCredential.supportsImages,
     baseUrl: parsed.baseUrl,
     reasoning: parsed.reasoning ?? false,
+    ...(parsed.maxImagesPerPrompt !== undefined
+      ? { maxImagesPerPrompt: parsed.maxImagesPerPrompt }
+      : {}),
     thinkingLevels: getSupportedThinkingLevels(
       openAiCompatibleModel(row.defaultModel ?? "custom", parsed.baseUrl, parsed.reasoning),
     ) as ThinkingLevel[],

--- a/packages/adapters/src/model-modalities.test.ts
+++ b/packages/adapters/src/model-modalities.test.ts
@@ -38,6 +38,15 @@ describe("operator-declared vision modalities", () => {
     });
   });
 
+  it("allows a connected model to declare image input without an environment variable", async () => {
+    await withEnv({ [VISION_ENV]: undefined }, async () => {
+      const { modelAcceptsImageInput } = await import("./model-vision.js");
+      expect(modelAcceptsImageInput(OPENAI_COMPATIBLE_PROVIDER_ID, "arbitrary-model", true)).toBe(
+        true,
+      );
+    });
+  });
+
   it("lets the vision gate see a declared openai-compatible vision model", async () => {
     await withEnv({ [VISION_ENV]: "gpt4o-vision, another-vision " }, async () => {
       const { modelAcceptsImageInput } = await import("./model-vision.js");

--- a/packages/adapters/src/model-vision.test.ts
+++ b/packages/adapters/src/model-vision.test.ts
@@ -5,7 +5,9 @@ import {
   IMAGE_RETURNING_COMPUTER_TOOLS,
   MODEL_CANNOT_SEE_MESSAGE,
   modelAcceptsImageInput,
+  modelIdSupportsImages,
   resolveModelRefForVisionCheck,
+  updateModelImageCapabilities,
 } from "./model-vision.js";
 
 describe("model vision gating for computer tools", () => {
@@ -44,6 +46,17 @@ describe("model vision gating for computer tools", () => {
 
   it("treats unknown models as text-only", () => {
     expect(modelAcceptsImageInput("openrouter", "rakazo-test/unknown-future-model")).toBe(false);
+  });
+
+  it("keeps explicit image capability scoped to the selected model", () => {
+    const enabled = updateModelImageCapabilities(
+      [" vision-model ", "text-model"],
+      "text-model",
+      false,
+    );
+    expect(enabled).toEqual(["vision-model"]);
+    expect(modelIdSupportsImages(enabled, "vision-model")).toBe(true);
+    expect(modelIdSupportsImages(enabled, "text-model")).toBe(false);
   });
 
   it("omits image-returning computer tools for text-only models", () => {

--- a/packages/adapters/src/model-vision.ts
+++ b/packages/adapters/src/model-vision.ts
@@ -18,6 +18,36 @@ export const MODEL_CANNOT_SEE_MESSAGE = "This bot's model cannot see; pick a vis
 
 const SCRIPTED_DEFAULT_MODEL_ID = "deepseek/deepseek-v4-flash-0731";
 
+/** Return whether a model id is explicitly enabled for image input on a connection. */
+export function modelIdSupportsImages(
+  modelIds: readonly string[] | undefined,
+  modelId: string | null | undefined,
+): boolean {
+  const normalizedModelId = modelId?.trim();
+  return Boolean(
+    normalizedModelId && modelIds?.some((candidate) => candidate.trim() === normalizedModelId),
+  );
+}
+
+/** Update the explicit per-model image capability without disturbing other model ids. */
+export function updateModelImageCapabilities(
+  modelIds: readonly string[] | undefined,
+  modelId: string | null | undefined,
+  supportsImages: boolean | undefined,
+): string[] {
+  const next = new Set(
+    (modelIds ?? [])
+      .map((candidate) => candidate.trim())
+      .filter((candidate) => candidate.length > 0),
+  );
+  const normalizedModelId = modelId?.trim();
+  if (normalizedModelId && supportsImages !== undefined) {
+    if (supportsImages) next.add(normalizedModelId);
+    else next.delete(normalizedModelId);
+  }
+  return [...next];
+}
+
 let catalogModelsCache: Models | undefined;
 
 function catalogModels(): Models {

--- a/packages/adapters/src/model-vision.ts
+++ b/packages/adapters/src/model-vision.ts
@@ -48,11 +48,17 @@ export function resolveModelRefForVisionCheck(
  * Whether the selected model accepts image input, per the Pi model catalog's
  * declared `input` modalities. Unknown models are treated as text-only.
  * The `scripted` placeholder is resolved the same way Pi does (env default /
- * DeepSeek fallback) before the catalog check.
+ * DeepSeek fallback) before the catalog check. An explicit connection capability
+ * override is honored for OpenAI-compatible models.
  */
-export function modelAcceptsImageInput(provider: string, modelId: string): boolean {
+export function modelAcceptsImageInput(
+  provider: string,
+  modelId: string,
+  acceptsImages = false,
+): boolean {
   const resolved = resolveModelRefForVisionCheck(provider, modelId);
   if (!resolved.provider || !resolved.id) return false;
+  if (acceptsImages && resolved.provider === OPENAI_COMPATIBLE_PROVIDER_ID) return true;
 
   const models = catalogModels();
   let model = models.getModel(resolved.provider, resolved.id);

--- a/packages/adapters/src/pi-oauth.ts
+++ b/packages/adapters/src/pi-oauth.ts
@@ -52,7 +52,13 @@ const SIGN_IN_START_WAIT_MS = 30_000;
 export type StoredModelSecret =
   | { kind: "api_key"; key: string }
   | { kind: "oauth"; credential: OAuthCredential }
-  | { kind: "openai_compatible"; baseUrl: string; apiKey?: string; reasoning?: boolean };
+  | {
+      kind: "openai_compatible";
+      baseUrl: string;
+      apiKey?: string;
+      reasoning?: boolean;
+      visionModelIds?: string[];
+    };
 
 export type PiOAuthConnected = {
   status: "connected";
@@ -120,11 +126,18 @@ export function parseModelSecret(plaintext: string): StoredModelSecret {
         parsed.baseUrl.trim()
       ) {
         const apiKey = typeof parsed.apiKey === "string" ? parsed.apiKey : undefined;
+        const visionModelIds = Array.isArray(parsed.visionModelIds)
+          ? parsed.visionModelIds.filter(
+              (modelId): modelId is string =>
+                typeof modelId === "string" && modelId.trim().length > 0,
+            )
+          : undefined;
         return {
           kind: "openai_compatible",
           baseUrl: parsed.baseUrl.trim(),
           ...(apiKey ? { apiKey } : {}),
           ...(typeof parsed.reasoning === "boolean" ? { reasoning: parsed.reasoning } : {}),
+          ...(visionModelIds ? { visionModelIds } : {}),
         };
       }
       if (
@@ -150,6 +163,7 @@ export function serializeModelSecret(secret: StoredModelSecret): string {
       baseUrl: secret.baseUrl,
       ...(secret.apiKey ? { apiKey: secret.apiKey } : {}),
       ...(secret.reasoning !== undefined ? { reasoning: secret.reasoning } : {}),
+      ...(secret.visionModelIds !== undefined ? { visionModelIds: secret.visionModelIds } : {}),
     });
   }
   return secret.key;

--- a/packages/adapters/src/pi-oauth.ts
+++ b/packages/adapters/src/pi-oauth.ts
@@ -58,6 +58,7 @@ export type StoredModelSecret =
       apiKey?: string;
       reasoning?: boolean;
       visionModelIds?: string[];
+      maxImagesPerPrompt?: number;
     };
 
 export type PiOAuthConnected = {
@@ -132,12 +133,20 @@ export function parseModelSecret(plaintext: string): StoredModelSecret {
                 typeof modelId === "string" && modelId.trim().length > 0,
             )
           : undefined;
+        const maxImagesPerPrompt =
+          typeof parsed.maxImagesPerPrompt === "number" &&
+          Number.isInteger(parsed.maxImagesPerPrompt) &&
+          parsed.maxImagesPerPrompt >= 1 &&
+          parsed.maxImagesPerPrompt <= 1000
+            ? parsed.maxImagesPerPrompt
+            : undefined;
         return {
           kind: "openai_compatible",
           baseUrl: parsed.baseUrl.trim(),
           ...(apiKey ? { apiKey } : {}),
           ...(typeof parsed.reasoning === "boolean" ? { reasoning: parsed.reasoning } : {}),
           ...(visionModelIds ? { visionModelIds } : {}),
+          ...(maxImagesPerPrompt !== undefined ? { maxImagesPerPrompt } : {}),
         };
       }
       if (
@@ -164,6 +173,9 @@ export function serializeModelSecret(secret: StoredModelSecret): string {
       ...(secret.apiKey ? { apiKey: secret.apiKey } : {}),
       ...(secret.reasoning !== undefined ? { reasoning: secret.reasoning } : {}),
       ...(secret.visionModelIds !== undefined ? { visionModelIds: secret.visionModelIds } : {}),
+      ...(secret.maxImagesPerPrompt !== undefined
+        ? { maxImagesPerPrompt: secret.maxImagesPerPrompt }
+        : {}),
     });
   }
   return secret.key;

--- a/packages/adapters/src/pi-openai-compatible-provider.ts
+++ b/packages/adapters/src/pi-openai-compatible-provider.ts
@@ -260,11 +260,11 @@ export function registerOpenAiCompatibleCatalog(models: MutableModels): MutableM
 /** Register a concrete model + base URL for an agent run. */
 export function registerOpenAiCompatibleRuntime(
   models: MutableModels,
-  opts: { modelId: string; baseUrl: string; reasoning?: boolean },
+  opts: { modelId: string; baseUrl: string; reasoning?: boolean; acceptsImages?: boolean },
 ): MutableModels {
   const baseUrl = normalizeOpenAiCompatibleBaseUrl(opts.baseUrl);
   const modelId = opts.modelId.trim();
-  const acceptsImages = openAiCompatibleVisionModelIds().has(modelId);
+  const acceptsImages = opts.acceptsImages || openAiCompatibleVisionModelIds().has(modelId);
   models.setProvider(
     openAiCompatibleProvider([
       openAiCompatibleModel(modelId, baseUrl, opts.reasoning, acceptsImages),

--- a/packages/adapters/src/pi-runtime-computer.test.ts
+++ b/packages/adapters/src/pi-runtime-computer.test.ts
@@ -149,7 +149,7 @@ describe("Pi computer tool dispatch", () => {
     expect(events.at(-1)?.type).toBe("done");
   });
 
-  it("keeps only the two latest computer screenshots in model context", () => {
+  it("keeps the two latest computer screenshots by default", () => {
     const messages = ["frame-1", "frame-2", "frame-3"].map((frameId) => ({
       role: "toolResult" as const,
       toolCallId: frameId,
@@ -169,6 +169,57 @@ describe("Pi computer tool dispatch", () => {
         (message as (typeof messages)[number]).content.some((part) => part.type === "image"),
       ),
     ).toEqual([false, true, true]);
+  });
+
+  it("honors a model-specific one-image limit", () => {
+    const messages = ["frame-1", "frame-2", "frame-3"].map((frameId) => ({
+      role: "toolResult" as const,
+      toolCallId: frameId,
+      toolName: "computer_observe",
+      content: [
+        { type: "text" as const, text: frameId },
+        { type: "image" as const, data: frameId, mimeType: "image/png" as const },
+      ],
+      details: { frameId },
+      isError: false,
+      timestamp: 1,
+    }));
+
+    const pruned = pruneComputerScreenshotContext(messages, 1);
+    expect(
+      pruned.map((message) =>
+        (message as (typeof messages)[number]).content.some((part) => part.type === "image"),
+      ),
+    ).toEqual([false, false, true]);
+  });
+
+  it("reserves the image budget for user attachments", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [{ type: "image" as const, data: "user-image", mimeType: "image/png" as const }],
+        timestamp: 1,
+      },
+      ...["frame-1", "frame-2"].map((frameId) => ({
+        role: "toolResult" as const,
+        toolCallId: frameId,
+        toolName: "computer_observe",
+        content: [
+          { type: "text" as const, text: frameId },
+          { type: "image" as const, data: frameId, mimeType: "image/png" as const },
+        ],
+        details: { frameId },
+        isError: false,
+        timestamp: 1,
+      })),
+    ];
+
+    const pruned = pruneComputerScreenshotContext(messages, 2);
+    expect(
+      pruned.map((message) =>
+        (message as (typeof messages)[number]).content.some((part) => part.type === "image"),
+      ),
+    ).toEqual([true, false, true]);
   });
 
   it("reuses the message array when no screenshot needs pruning", () => {

--- a/packages/adapters/src/pi-runtime-computer.test.ts
+++ b/packages/adapters/src/pi-runtime-computer.test.ts
@@ -222,6 +222,60 @@ describe("Pi computer tool dispatch", () => {
     ).toEqual([true, false, true]);
   });
 
+  it("rejects user images that exceed a configured model limit", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "image" as const, data: "user-image-1", mimeType: "image/png" as const },
+          { type: "image" as const, data: "user-image-2", mimeType: "image/png" as const },
+        ],
+        timestamp: 1,
+      },
+    ];
+
+    expect(() => pruneComputerScreenshotContext(messages, 1)).toThrow(
+      "the prompt contains 2 non-screenshot images",
+    );
+  });
+
+  it("does not apply the default screenshot retention to user images", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "image" as const, data: "user-image-1", mimeType: "image/png" as const },
+          { type: "image" as const, data: "user-image-2", mimeType: "image/png" as const },
+          { type: "image" as const, data: "user-image-3", mimeType: "image/png" as const },
+        ],
+        timestamp: 1,
+      },
+      ...["frame-1", "frame-2", "frame-3"].map((frameId) => ({
+        role: "toolResult" as const,
+        toolCallId: frameId,
+        toolName: "computer_observe",
+        content: [
+          { type: "text" as const, text: frameId },
+          { type: "image" as const, data: frameId, mimeType: "image/png" as const },
+        ],
+        details: { frameId },
+        isError: false,
+        timestamp: 1,
+      })),
+    ];
+
+    const pruned = pruneComputerScreenshotContext(messages);
+    expect(pruned[0]).toBe(messages[0]);
+    expect((pruned[0] as (typeof messages)[number]).content).toHaveLength(3);
+    expect(
+      pruned
+        .slice(1)
+        .map((message) =>
+          (message as (typeof messages)[number]).content.some((part) => part.type === "image"),
+        ),
+    ).toEqual([false, true, true]);
+  });
+
   it("reuses the message array when no screenshot needs pruning", () => {
     const messages = [
       {

--- a/packages/adapters/src/pi-runtime-models.test.ts
+++ b/packages/adapters/src/pi-runtime-models.test.ts
@@ -30,6 +30,24 @@ describe("request model catalogs", () => {
       "http://127.0.0.1:8002/v1",
     );
   });
+
+  it("applies a connected model's image capability to the runtime model", () => {
+    const models = modelsForRequest(
+      {
+        model: {
+          provider: OPENAI_COMPATIBLE_PROVIDER_ID,
+          id: "vision-model",
+          baseUrl: "http://127.0.0.1:8000/v1",
+          acceptsImages: true,
+        },
+      },
+      OPENAI_COMPATIBLE_PROVIDER_ID,
+    );
+
+    expect(models.getModel(OPENAI_COMPATIBLE_PROVIDER_ID, "vision-model")?.input).toContain(
+      "image",
+    );
+  });
 });
 
 it.each([true, false, undefined])(

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -406,6 +406,7 @@ export function modelsForRequest(
       modelId: request.model.id,
       baseUrl: request.model.baseUrl,
       reasoning: request.model.reasoning,
+      acceptsImages: request.model.acceptsImages,
     });
   }
   return catalogModels();

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -196,10 +196,7 @@ export class PiAgentRuntime implements AgentRuntime {
             models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
           getApiKey: async () => apiKey,
           transformContext: async (messages) =>
-            pruneComputerScreenshotContext(
-              messages,
-              request.model.maxImagesPerPrompt ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
-            ),
+            pruneComputerScreenshotContext(messages, request.model.maxImagesPerPrompt),
           prepareNextTurnWithContext: async () => {
             if (!request.claimSteering) return undefined;
             const steering = await request.claimSteering([...seenSteeringIds]);
@@ -792,10 +789,7 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
       host.models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
     getApiKey: async () => host.apiKey,
     transformContext: async (messages) =>
-      pruneComputerScreenshotContext(
-        messages,
-        host.request.model.maxImagesPerPrompt ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
-      ),
+      pruneComputerScreenshotContext(messages, host.request.model.maxImagesPerPrompt),
     initialState: {
       systemPrompt: [
         `You are a Rakazo subagent named "${name}".`,
@@ -1006,15 +1000,28 @@ function builtinParameters(tool: ConnectorTool) {
 /** Keep recent visual state while respecting an optional model image budget. */
 export function pruneComputerScreenshotContext(
   messages: AgentMessage[],
-  maxImagesPerPrompt = DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
+  maxImagesPerPrompt?: number,
 ): AgentMessage[] {
-  let remaining = Number.isFinite(maxImagesPerPrompt)
-    ? Math.max(0, Math.floor(maxImagesPerPrompt))
-    : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT;
-  for (const message of messages) {
-    if (!isComputerScreenshotMessage(message)) remaining -= imagePartCount(message);
+  const imageLimit =
+    maxImagesPerPrompt === undefined
+      ? undefined
+      : Number.isFinite(maxImagesPerPrompt)
+        ? Math.max(0, Math.floor(maxImagesPerPrompt))
+        : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT;
+  let remaining = imageLimit ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT;
+  if (imageLimit !== undefined) {
+    const nonScreenshotImages = messages.reduce(
+      (count, message) =>
+        isComputerScreenshotMessage(message) ? count : count + imagePartCount(message),
+      0,
+    );
+    if (nonScreenshotImages > imageLimit) {
+      throw new Error(
+        `The configured model image limit is ${imageLimit}, but the prompt contains ${nonScreenshotImages} non-screenshot images.`,
+      );
+    }
+    remaining = imageLimit - nonScreenshotImages;
   }
-  remaining = Math.max(0, remaining);
   let transformed: AgentMessage[] | undefined;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];

--- a/packages/adapters/src/pi-runtime.ts
+++ b/packages/adapters/src/pi-runtime.ts
@@ -18,6 +18,7 @@ import type {
   AgentToolExecutionResult,
   ConnectorTool,
 } from "@rakazo/adapter-kit";
+import { DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT } from "@rakazo/contracts";
 import { getLogger } from "@rakazo/logging";
 import { isToolPauseResult } from "./approval-effect.js";
 import { builtinAgentTools, DELEGATION_TOOL_NAMES } from "./builtin-tools.js";
@@ -194,7 +195,11 @@ export class PiAgentRuntime implements AgentRuntime {
           streamFn: (m, ctx, options) =>
             models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
           getApiKey: async () => apiKey,
-          transformContext: async (messages) => pruneComputerScreenshotContext(messages),
+          transformContext: async (messages) =>
+            pruneComputerScreenshotContext(
+              messages,
+              request.model.maxImagesPerPrompt ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
+            ),
           prepareNextTurnWithContext: async () => {
             if (!request.claimSteering) return undefined;
             const steering = await request.claimSteering([...seenSteeringIds]);
@@ -786,7 +791,11 @@ async function executeSubagent(host: ToolHost, executionId: string, args: Record
     streamFn: (m, ctx, options) =>
       host.models.streamSimple(m, ctx, reliableStreamOptions(m, options)),
     getApiKey: async () => host.apiKey,
-    transformContext: async (messages) => pruneComputerScreenshotContext(messages),
+    transformContext: async (messages) =>
+      pruneComputerScreenshotContext(
+        messages,
+        host.request.model.maxImagesPerPrompt ?? DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
+      ),
     initialState: {
       systemPrompt: [
         `You are a Rakazo subagent named "${name}".`,
@@ -994,18 +1003,25 @@ function builtinParameters(tool: ConnectorTool) {
   return undefined;
 }
 
-/** Keep recent visual state without repeatedly resending every earlier full screenshot. */
+/** Keep recent visual state while respecting an optional model image budget. */
 export function pruneComputerScreenshotContext(
   messages: AgentMessage[],
-  screenshotsToKeep = 2,
+  maxImagesPerPrompt = DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT,
 ): AgentMessage[] {
-  let remaining = Math.max(0, screenshotsToKeep);
+  let remaining = Number.isFinite(maxImagesPerPrompt)
+    ? Math.max(0, Math.floor(maxImagesPerPrompt))
+    : DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT;
+  for (const message of messages) {
+    if (!isComputerScreenshotMessage(message)) remaining -= imagePartCount(message);
+  }
+  remaining = Math.max(0, remaining);
   let transformed: AgentMessage[] | undefined;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (!isComputerScreenshotMessage(message)) continue;
-    if (remaining > 0) {
-      remaining -= 1;
+    const images = imagePartCount(message);
+    if (remaining >= images) {
+      remaining -= images;
       continue;
     }
     transformed ??= [...messages];
@@ -1015,6 +1031,14 @@ export function pruneComputerScreenshotContext(
     };
   }
   return transformed ?? messages;
+}
+
+function imagePartCount(message: AgentMessage): number {
+  if (!("content" in message) || !Array.isArray(message.content)) return 0;
+  return message.content.filter(
+    (part: unknown) =>
+      part !== null && typeof part === "object" && "type" in part && part.type === "image",
+  ).length;
 }
 
 function isComputerScreenshotMessage(

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -826,6 +826,7 @@ export const ModelCredentialSchema = z.object({
   baseUrl: z.string().optional(),
   modelId: z.string().optional(),
   reasoning: z.boolean().optional(),
+  supportsImages: z.boolean().optional(),
   thinkingLevels: z.array(ThinkingLevelSchema).optional(),
 });
 export type ModelCredential = z.infer<typeof ModelCredentialSchema>;
@@ -840,6 +841,7 @@ export const ModelConnectInputSchema = z
     label: z.string().optional(),
     modelId: z.string().optional(),
     reasoning: z.boolean().optional(),
+    supportsImages: z.boolean().optional(),
   })
   .superRefine((value, ctx) => {
     if (value.provider === OPENAI_COMPATIBLE_PROVIDER_ID) {

--- a/packages/contracts/src/domain.ts
+++ b/packages/contracts/src/domain.ts
@@ -817,6 +817,9 @@ export const ThreadSnapshotSchema = z.object({
 });
 export type ThreadSnapshot = z.infer<typeof ThreadSnapshotSchema>;
 
+/** Default visual context retained when a model connection has no image-limit override. */
+export const DEFAULT_MODEL_MAX_IMAGES_PER_PROMPT = 2;
+
 export const ModelCredentialSchema = z.object({
   id: Id,
   provider: z.string(),
@@ -827,6 +830,7 @@ export const ModelCredentialSchema = z.object({
   modelId: z.string().optional(),
   reasoning: z.boolean().optional(),
   supportsImages: z.boolean().optional(),
+  maxImagesPerPrompt: z.number().int().min(1).max(1000).optional(),
   thinkingLevels: z.array(ThinkingLevelSchema).optional(),
 });
 export type ModelCredential = z.infer<typeof ModelCredentialSchema>;
@@ -842,6 +846,7 @@ export const ModelConnectInputSchema = z
     modelId: z.string().optional(),
     reasoning: z.boolean().optional(),
     supportsImages: z.boolean().optional(),
+    maxImagesPerPrompt: z.number().int().min(1).max(1000).optional(),
   })
   .superRefine((value, ctx) => {
     if (value.provider === OPENAI_COMPATIBLE_PROVIDER_ID) {

--- a/packages/db/prisma/migrations/20260907020000_user_model_vision/migration.sql
+++ b/packages/db/prisma/migrations/20260907020000_user_model_vision/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user_model_credentials"
+ADD COLUMN "supportsImages" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -252,6 +252,7 @@ model UserModelCredential {
   provider    String
   label       String
   secretId    String
+  supportsImages Boolean              @default(false)
   createdAt   DateTime               @default(now())
   updatedAt   DateTime               @updatedAt
   preferences SpaceModelPreference[]

--- a/packages/ui-web/src/model-thinking-options.tsx
+++ b/packages/ui-web/src/model-thinking-options.tsx
@@ -4,17 +4,24 @@ import { Checkbox } from "./components/ui/checkbox.js";
 export function ModelThinkingOptions({
   reasoning,
   onReasoningChange,
+  supportsImages,
+  onSupportsImagesChange,
   disabled,
   advancedLabel,
   thinkingLabel,
+  imagesLabel,
 }: {
   reasoning: boolean;
   onReasoningChange: (reasoning: boolean) => void;
+  supportsImages?: boolean;
+  onSupportsImagesChange?: (supportsImages: boolean) => void;
   disabled?: boolean;
   advancedLabel: string;
   thinkingLabel: string;
+  imagesLabel?: string;
 }) {
   const id = useId();
+  const imagesId = useId();
   return (
     <details className="mt-4 text-sm text-muted-foreground">
       <summary className="cursor-pointer">{advancedLabel}</summary>
@@ -27,6 +34,17 @@ export function ModelThinkingOptions({
         />
         {thinkingLabel}
       </label>
+      {onSupportsImagesChange ? (
+        <label htmlFor={imagesId} className="mt-3 flex items-center gap-2">
+          <Checkbox
+            id={imagesId}
+            checked={supportsImages === true}
+            onCheckedChange={(checked) => onSupportsImagesChange(checked === true)}
+            disabled={disabled}
+          />
+          {imagesLabel}
+        </label>
+      ) : null}
     </details>
   );
 }

--- a/packages/ui-web/src/model-thinking-options.tsx
+++ b/packages/ui-web/src/model-thinking-options.tsx
@@ -1,27 +1,35 @@
 import { useId } from "react";
 import { Checkbox } from "./components/ui/checkbox.js";
+import { Input } from "./components/ui/input.js";
 
 export function ModelThinkingOptions({
   reasoning,
   onReasoningChange,
   supportsImages,
   onSupportsImagesChange,
+  maxImagesPerPrompt,
+  onMaxImagesPerPromptChange,
   disabled,
   advancedLabel,
   thinkingLabel,
   imagesLabel,
+  maxImagesLabel,
 }: {
   reasoning: boolean;
   onReasoningChange: (reasoning: boolean) => void;
   supportsImages?: boolean;
   onSupportsImagesChange?: (supportsImages: boolean) => void;
+  maxImagesPerPrompt?: string;
+  onMaxImagesPerPromptChange?: (maxImagesPerPrompt: string) => void;
   disabled?: boolean;
   advancedLabel: string;
   thinkingLabel: string;
   imagesLabel?: string;
+  maxImagesLabel?: string;
 }) {
   const id = useId();
   const imagesId = useId();
+  const maxImagesId = useId();
   return (
     <details className="mt-4 text-sm text-muted-foreground">
       <summary className="cursor-pointer">{advancedLabel}</summary>
@@ -43,6 +51,24 @@ export function ModelThinkingOptions({
             disabled={disabled}
           />
           {imagesLabel}
+        </label>
+      ) : null}
+      {supportsImages && onMaxImagesPerPromptChange ? (
+        <label htmlFor={maxImagesId} className="mt-3 flex items-center gap-2">
+          <span className="min-w-0 flex-1">{maxImagesLabel}</span>
+          <Input
+            id={maxImagesId}
+            type="number"
+            inputMode="numeric"
+            min={1}
+            max={1000}
+            step={1}
+            value={maxImagesPerPrompt ?? ""}
+            onChange={(event) => onMaxImagesPerPromptChange(event.target.value)}
+            disabled={disabled}
+            aria-label={maxImagesLabel}
+            className="h-8 w-20 text-center text-foreground"
+          />
         </label>
       ) : null}
     </details>


### PR DESCRIPTION
## Why\n\nSome OpenAI-compatible multimodal endpoints reject requests containing more images than their server configuration allows. Rakazo keeps two recent computer screenshots by default, which fails on endpoints limited to one image. This preserves Rakazo's default behavior while allowing affected connections to opt into their endpoint's limit.\n\nvLLM documents the corresponding server option as --limit-mm-per-prompt: https://github.com/vllm-project/vllm/blob/main/docs/benchmarking/cli.md#multi-modal-benchmark\n\n## What changed\n\n- Added optional maxImagesPerPrompt to model connection credentials and runtime requests.\n- Added the Advanced setting "Maximum images per request" to web onboarding/settings and mobile Models.\n- Pruned older computer screenshots within the configured budget while reserving capacity for user-provided images.\n- Preserved the setting through encrypted connection updates.\n- Added coverage for default behavior, one-image overrides, attachment budgeting, runtime propagation, and persistence.\n\nThe visible copy "Maximum images per request" is necessary to expose an endpoint-specific capability; keeping it behind Advanced limits persistent UI noise.\n\n## Testing\n\n- Full adapters test suite: 1,519 passed, 25 skipped.\n- Adapters, web, and mobile type checks passed.\n- Targeted formatting and diff checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configure image support per OpenAI-compatible model connection.
  - Set a maximum of 1–1,000 images per request.
  - Image settings persist across connection updates and reloads.
  - Requests now enforce configured image limits, including screenshot context.
  - Centrally managed endpoints retain environment-based image configuration.

- **Documentation**
  - Updated self-hosting and environment configuration guidance.

- **Localization**
  - Added “Supports images” translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->