### PR TITLE
Record Android live status demo for store review

### DIFF
--- a/apps/mobile/.maestro/notification-demo.yaml
+++ b/apps/mobile/.maestro/notification-demo.yaml
@@ -39,8 +39,9 @@ name: Android live working status demonstration
     timeout: 30000
 - pressKey: HOME
 - swipe:
-    start: "50%, 0%"
+    start: "50%, 1%"
     end: "50%, 80%"
+    duration: 1000
 - extendedWaitUntil:
     visible: "Researcher is working"
     timeout: 30000
@@ -60,8 +61,9 @@ name: Android live working status demonstration
 - tapOn: "Live working status"
 - pressKey: HOME
 - swipe:
-    start: "50%, 0%"
+    start: "50%, 1%"
     end: "50%, 80%"
+    duration: 1000
 - assertNotVisible: "Researcher is working"
 - takeScreenshot: "31-live-working-stopped"
 - stopRecording

--- a/apps/mobile/.maestro/notification-demo.yaml
+++ b/apps/mobile/.maestro/notification-demo.yaml
@@ -5,6 +5,15 @@ name: Android live working status demonstration
     clearState: true
     permissions:
       notifications: allow
+# A cold API 34 emulator can show a launcher ANR over the healthy app.
+- extendedWaitUntil:
+    visible: "Sign up for Rakazo|Pixel Launcher isn't responding"
+    timeout: 30000
+- runFlow:
+    when:
+      visible: "Pixel Launcher isn't responding"
+    commands:
+      - tapOn: "Close app"
 - extendedWaitUntil:
     visible: "Sign up for Rakazo"
     timeout: 30000

--- a/apps/mobile/.maestro/notification-demo.yaml
+++ b/apps/mobile/.maestro/notification-demo.yaml
@@ -1,0 +1,67 @@
+appId: com.rakazo.app
+name: Android live working status demonstration
+---
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- extendedWaitUntil:
+    visible: "Sign up for Rakazo"
+    timeout: 30000
+- tapOn: "Sign in"
+- tapOn: "Email"
+- inputText: ${RAKAZO_SCREENSHOT_EMAIL}
+- tapOn: "Password"
+- inputText: ${RAKAZO_SCREENSHOT_PASSWORD}
+- hideKeyboard
+- tapOn: "Sign in"
+- extendedWaitUntil:
+    visible: "Researcher"
+    timeout: 30000
+
+# Only the public demo is recorded; sign-in uses disposable fixture credentials.
+- startRecording: ${RAKAZO_NOTIFICATION_VIDEO}
+- openLink: "rakazo:///account"
+- scrollUntilVisible:
+    element: "Live working status"
+    direction: DOWN
+- tapOn: "Live working status"
+- openLink: "rakazo:///thread?botId=${RAKAZO_SCREENSHOT_BOT_ID}&name=Researcher"
+- extendedWaitUntil:
+    visible: "Message Researcher"
+    timeout: 10000
+- tapOn: "Message Researcher"
+- inputText: "Review the launch checklist and keep working until I stop you."
+- hideKeyboard
+- tapOn: "Send"
+- extendedWaitUntil:
+    visible: "Stop"
+    timeout: 30000
+- pressKey: HOME
+- swipe:
+    start: "50%, 0%"
+    end: "50%, 80%"
+- extendedWaitUntil:
+    visible: "Researcher is working"
+    timeout: 30000
+- takeScreenshot: "30-live-working-notification"
+- tapOn: "Researcher is working"
+- extendedWaitUntil:
+    visible: "Stop"
+    timeout: 10000
+- tapOn: "Stop"
+- extendedWaitUntil:
+    notVisible: "Stop"
+    timeout: 30000
+- openLink: "rakazo:///account"
+- scrollUntilVisible:
+    element: "Live working status"
+    direction: DOWN
+- tapOn: "Live working status"
+- pressKey: HOME
+- swipe:
+    start: "50%, 0%"
+    end: "50%, 80%"
+- assertNotVisible: "Researcher is working"
+- takeScreenshot: "31-live-working-stopped"
+- stopRecording

--- a/apps/mobile/.maestro/notification-demo.yaml
+++ b/apps/mobile/.maestro/notification-demo.yaml
@@ -38,13 +38,19 @@ name: Android live working status demonstration
     visible: "Stop"
     timeout: 30000
 - pressKey: HOME
-- swipe:
-    start: "50%, 1%"
-    end: "50%, 80%"
-    duration: 1000
+# Status-bar swipe is flaky on API 34 emulators; expand via host adb helper instead.
+- repeat:
+    times: 8
+    while:
+      notVisible: "Researcher is working"
+    commands:
+      - evalScript: ${output.expandNotifications = http.get(RAKAZO_EXPAND_NOTIFICATIONS_URL)}
+      - assertTrue: ${output.expandNotifications.ok}
+      - waitForAnimationToEnd:
+          timeout: 2000
 - extendedWaitUntil:
     visible: "Researcher is working"
-    timeout: 30000
+    timeout: 5000
 - takeScreenshot: "30-live-working-notification"
 - tapOn: "Researcher is working"
 - extendedWaitUntil:
@@ -60,10 +66,10 @@ name: Android live working status demonstration
     direction: DOWN
 - tapOn: "Live working status"
 - pressKey: HOME
-- swipe:
-    start: "50%, 1%"
-    end: "50%, 80%"
-    duration: 1000
+- evalScript: ${output.expandNotifications = http.get(RAKAZO_EXPAND_NOTIFICATIONS_URL)}
+- assertTrue: ${output.expandNotifications.ok}
+- waitForAnimationToEnd:
+    timeout: 2000
 - assertNotVisible: "Researcher is working"
 - takeScreenshot: "31-live-working-stopped"
 - stopRecording

--- a/apps/mobile/.maestro/notification-demo.yaml
+++ b/apps/mobile/.maestro/notification-demo.yaml
@@ -79,6 +79,9 @@ name: Android live working status demonstration
 - assertTrue: ${output.expandNotifications.ok}
 - waitForAnimationToEnd:
     timeout: 2000
+- extendedWaitUntil:
+    visible: "Internet"
+    timeout: 5000
 - assertNotVisible: "Researcher is working"
 - takeScreenshot: "31-live-working-stopped"
 - stopRecording

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -113,8 +113,11 @@ tags:
 - longPressOn: "The fixture workspace is ready."
 - assertVisible: "Add thumbs-up"
 - assertVisible: "Reply"
-- assertVisible: "Speak message"
 - takeScreenshot: "15b-message-actions"
+- tapOn: "More"
+- assertVisible: "Speak message"
+- back
+- longPressOn: "The fixture workspace is ready."
 - tapOn: "Add thumbs-up"
 - extendedWaitUntil:
     visible: "Remove thumbs-up"

--- a/apps/mobile/.maestro/screenshots.yaml
+++ b/apps/mobile/.maestro/screenshots.yaml
@@ -8,6 +8,15 @@ tags:
     permissions:
       notifications: deny
 
+# A cold API 34 emulator can show a launcher ANR over the healthy app.
+- extendedWaitUntil:
+    visible: "Sign up for Rakazo|Pixel Launcher isn't responding"
+    timeout: 30000
+- runFlow:
+    when:
+      visible: "Pixel Launcher isn't responding"
+    commands:
+      - tapOn: "Close app"
 - extendedWaitUntil:
     visible: "Sign up for Rakazo"
     timeout: 30000

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -25,6 +25,7 @@ const WEB_ORIGIN = "http://127.0.0.1:5180";
 
 type App = { request: (input: string, init?: RequestInit) => Response | Promise<Response> };
 
+/** Capture app screenshots and the notification demo against an isolated, disposable backend. */
 async function main() {
   process.chdir(ROOT);
   configureEnvironment();

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { mkdir, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
@@ -20,7 +21,10 @@ const FLOW_DIR = path.join(ROOT, "apps", "mobile", ".maestro");
 const EMAIL = "mobile-screenshots@example.test";
 const PASSWORD = "test-password-123";
 const API_PORT = 3110;
+const DEVICE_CONTROL_PORT = 3111;
 const HOST_API_URL = `http://127.0.0.1:${API_PORT}`;
+const DEVICE_CONTROL_URL = `http://127.0.0.1:${DEVICE_CONTROL_PORT}`;
+const EXPAND_NOTIFICATIONS_URL = `${DEVICE_CONTROL_URL}/expand-notifications`;
 const WEB_ORIGIN = "http://127.0.0.1:5180";
 
 type App = { request: (input: string, init?: RequestInit) => Response | Promise<Response> };
@@ -71,6 +75,7 @@ async function main() {
     hostname: "0.0.0.0",
     port: API_PORT,
   });
+  const deviceControl = startDeviceControlServer();
 
   try {
     await waitForHealth(`${HOST_API_URL}/health`, 15_000);
@@ -101,6 +106,8 @@ async function main() {
           `RAKAZO_SCREENSHOT_ROUTINE_ID=${fixture.routineId}`,
           "-e",
           `RAKAZO_NOTIFICATION_VIDEO=${path.join(REPORT_DIR, "notification-demo")}`,
+          "-e",
+          `RAKAZO_EXPAND_NOTIFICATIONS_URL=${EXPAND_NOTIFICATIONS_URL}`,
           path.join(FLOW_DIR, `${flow}.yaml`),
         ],
         process.env,
@@ -115,9 +122,36 @@ async function main() {
       server.close(() => resolve());
       server.closeAllConnections();
     });
+    await new Promise<void>((resolve, reject) => {
+      deviceControl.close((error) => (error ? reject(error) : resolve()));
+    }).catch(() => undefined);
     await handles.stop().catch(() => undefined);
     await rm(DATA_DIR, { recursive: true, force: true });
   }
+}
+
+/** Maestro host-side helper: expand the Android shade without flaky status-bar swipes. */
+function startDeviceControlServer(): Server {
+  const server = createServer((req, res) => {
+    try {
+      if (req.method === "GET" && req.url === "/expand-notifications") {
+        execFileSync("adb", ["shell", "cmd", "statusbar", "expand-notifications"], {
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        res.end("ok");
+        return;
+      }
+      res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      res.end("not found");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
+      res.end(message);
+    }
+  });
+  server.listen(DEVICE_CONTROL_PORT, "127.0.0.1");
+  return server;
 }
 
 function configureEnvironment() {

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import path from "node:path";
@@ -133,22 +133,20 @@ async function main() {
 /** Maestro host-side helper: expand the Android shade without flaky status-bar swipes. */
 function startDeviceControlServer(): Server {
   const server = createServer((req, res) => {
-    try {
-      if (req.method === "GET" && req.url === "/expand-notifications") {
-        execFileSync("adb", ["shell", "cmd", "statusbar", "expand-notifications"], {
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
-        res.end("ok");
-        return;
-      }
+    if (req.method !== "GET" || req.url !== "/expand-notifications") {
       res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
       res.end("not found");
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      res.writeHead(500, { "content-type": "text/plain; charset=utf-8" });
-      res.end(message);
+      return;
     }
+    execFile(
+      "adb",
+      ["shell", "cmd", "statusbar", "expand-notifications"],
+      { timeout: 5_000 },
+      (error) => {
+        res.writeHead(error ? 500 : 200, { "content-type": "text/plain; charset=utf-8" });
+        res.end(error ? "Could not expand notifications" : "ok");
+      },
+    );
   });
   server.listen(DEVICE_CONTROL_PORT, "127.0.0.1");
   return server;

--- a/packages/testkit/src/cli/mobile-screenshots.ts
+++ b/packages/testkit/src/cli/mobile-screenshots.ts
@@ -16,7 +16,7 @@ import { runProcess } from "./process.js";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
 const REPORT_DIR = path.join(ROOT, "test-report", "mobile-screenshots");
 const DATA_DIR = path.join(ROOT, ".tmp", "mobile-screenshots-data");
-const FLOW = path.join(ROOT, "apps", "mobile", ".maestro", "screenshots.yaml");
+const FLOW_DIR = path.join(ROOT, "apps", "mobile", ".maestro");
 const EMAIL = "mobile-screenshots@example.test";
 const PASSWORD = "test-password-123";
 const API_PORT = 3110;
@@ -73,34 +73,38 @@ async function main() {
 
   try {
     await waitForHealth(`${HOST_API_URL}/health`, 15_000);
-    await runProcess(
-      "maestro",
-      [
-        "test",
-        "--no-ansi",
-        "--flatten-debug-output",
-        "--debug-output",
-        path.join(REPORT_DIR, "debug"),
-        "--test-output-dir",
-        REPORT_DIR,
-        "--format",
-        "HTML",
-        "--output",
-        path.join(REPORT_DIR, "report.html"),
-        "-e",
-        `RAKAZO_SCREENSHOT_EMAIL=${EMAIL}`,
-        "-e",
-        `RAKAZO_SCREENSHOT_PASSWORD=${PASSWORD}`,
-        "-e",
-        `RAKAZO_SCREENSHOT_BOT_ID=${fixture.botId}`,
-        "-e",
-        `RAKAZO_SCREENSHOT_GROUP_ID=${fixture.groupId}`,
-        "-e",
-        `RAKAZO_SCREENSHOT_ROUTINE_ID=${fixture.routineId}`,
-        FLOW,
-      ],
-      process.env,
-    );
+    for (const flow of ["screenshots", "notification-demo"]) {
+      await runProcess(
+        "maestro",
+        [
+          "test",
+          "--no-ansi",
+          "--flatten-debug-output",
+          "--debug-output",
+          path.join(REPORT_DIR, "debug", flow),
+          "--test-output-dir",
+          REPORT_DIR,
+          "--format",
+          "HTML",
+          "--output",
+          path.join(REPORT_DIR, `${flow}.html`),
+          "-e",
+          `RAKAZO_SCREENSHOT_EMAIL=${EMAIL}`,
+          "-e",
+          `RAKAZO_SCREENSHOT_PASSWORD=${PASSWORD}`,
+          "-e",
+          `RAKAZO_SCREENSHOT_BOT_ID=${fixture.botId}`,
+          "-e",
+          `RAKAZO_SCREENSHOT_GROUP_ID=${fixture.groupId}`,
+          "-e",
+          `RAKAZO_SCREENSHOT_ROUTINE_ID=${fixture.routineId}`,
+          "-e",
+          `RAKAZO_NOTIFICATION_VIDEO=${path.join(REPORT_DIR, "notification-demo")}`,
+          path.join(FLOW_DIR, `${flow}.yaml`),
+        ],
+        process.env,
+      );
+    }
     await writeFile(
       path.join(REPORT_DIR, "summary.json"),
       `${JSON.stringify({ ok: true }, null, 2)}\n`,

--- a/scripts/publish-mobile-screenshot-gallery.sh
+++ b/scripts/publish-mobile-screenshot-gallery.sh
@@ -55,3 +55,17 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   printf '### Android screenshots\n- [Screenshot gallery](%s)\n' \
     "$gallery_url" >> "$GITHUB_STEP_SUMMARY"
 fi
+
+video_path="test-report/mobile-screenshots/notification-demo.mp4"
+if [[ -f "$video_path" ]]; then
+  aws s3 cp \
+    "$video_path" \
+    "$bucket_uri/runs/$run_key/notification-demo.mp4" \
+    --endpoint-url "$S3_ENDPOINT" \
+    --content-type "video/mp4" \
+    --cache-control "public,max-age=31536000,immutable"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf -- '- [Live working status video](%s)\n' \
+      "$public_base_url/runs/$run_key/notification-demo.mp4" >> "$GITHUB_STEP_SUMMARY"
+  fi
+fi


### PR DESCRIPTION
Why: Android store review needs a reproducible demonstration of the foreground notification service.

The Android emulator workflow now records enabling live working status, starting a task, viewing and opening its background notification, stopping the task, and disabling live status. It uses the real app and backend with the existing deterministic runtime and disposable fixture data. The MP4 is retained with diagnostics and published beside the screenshot gallery.

The flow handles the emulator’s launcher startup dialog and Android’s paginated message actions. A loopback helper opens the notification shade through a bounded asynchronous adb command, and the flow positively verifies the shade before checking notification removal.

Validation: All CI checks and both automated reviews passed, with all review findings resolved. Both mobile flows passed in the [Android emulator run](https://github.com/elie222/rakazo/actions/runs/34115602966). The resulting 84-second MP4 and notification screenshots were visually inspected, and the public video URL returns video content. No product UI changes.

- [Notification demo](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/mobile-android/runs/34115602966-1/notification-demo.mp4)
- [Screenshot gallery](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/mobile-android/runs/34115602966-1/index.html)
