### PR TITLE
fix(auth): trust localhost↔127.0.0.1 twins for local Better Auth origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 NODE_ENV=development
 DATABASE_URL=postgres://rakazo:rakazo@127.0.0.1:5433/rakazo
 BETTER_AUTH_SECRET=replace-with-32-plus-character-secret
+# Local loopback: localhost and 127.0.0.1 are interchangeable browser hosts.
 BETTER_AUTH_URL=http://127.0.0.1:5173
 API_URL=http://127.0.0.1:3100
 # Listener address. Keep loopback unless a container or trusted reverse proxy must reach the API.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -4,7 +4,7 @@ The signed-in product is a long-running API, a Graphile Worker, Postgres, and a 
 
 ## Local (source checkout)
 
-Same as the README quick start: `.env` from `.env.example`, Postgres via Compose, `pnpm sandbox:build`, `pnpm dev`, then [http://127.0.0.1:5173](http://127.0.0.1:5173). Electron: `pnpm --filter @rakazo/desktop dev` while that stack is up, choosing **Existing instance** with that address. The desktop app's **This computer** option instead installs and runs the published images itself with Docker Compose (see [Published images](#published-images-no-checkout)), using port 45173 by default so it can run alongside `pnpm dev`. If that port is occupied, the app selects and remembers another loopback port. The managed API gets a Docker-assigned loopback port; all desktop traffic uses the web origin.
+Same as the README quick start: `.env` from `.env.example`, Postgres via Compose, `pnpm sandbox:build`, `pnpm dev`, then [http://127.0.0.1:5173](http://127.0.0.1:5173) (or `http://localhost:5173` — both loopback hosts are trusted). Electron: `pnpm --filter @rakazo/desktop dev` while that stack is up, choosing **Existing instance** with that address. The desktop app's **This computer** option instead installs and runs the published images itself with Docker Compose (see [Published images](#published-images-no-checkout)), using port 45173 by default so it can run alongside `pnpm dev`. If that port is occupied, the app selects and remembers another loopback port. The managed API gets a Docker-assigned loopback port; all desktop traffic uses the web origin.
 
 ## Published images (no checkout)
 

--- a/packages/auth/src/identity-trust.test.ts
+++ b/packages/auth/src/identity-trust.test.ts
@@ -14,7 +14,19 @@ vi.mock("better-auth/adapters/prisma", async () => {
 });
 vi.mock("@rakazo/db", () => ({ bootstrapUserSpace: vi.fn(async () => ({ spaceId: "space-1" })) }));
 
-function fixture({ allowlist = "", delivery = true } = {}) {
+function fixture({
+  allowlist = "",
+  delivery = true,
+  baseURL = "http://auth.example.test",
+  webOrigin = "http://web.example.test",
+  requestOrigin,
+}: {
+  allowlist?: string;
+  delivery?: boolean;
+  baseURL?: string;
+  webOrigin?: string;
+  requestOrigin?: string;
+} = {}) {
   const data: Record<string, Record<string, unknown>[]> = {
     user: [],
     account: [],
@@ -43,8 +55,8 @@ function fixture({ allowlist = "", delivery = true } = {}) {
   });
   const auth = createAuth(prisma as never, {
     secret: "offline-auth-secret-at-least-32-characters",
-    baseURL: "http://auth.example.test",
-    webOrigin: "http://web.example.test",
+    baseURL,
+    webOrigin,
     signupsEnabled: "true",
     signupAllowlist: "",
     email: delivery
@@ -63,11 +75,11 @@ function fixture({ allowlist = "", delivery = true } = {}) {
   });
   const request = (path: string, body?: unknown, token?: string) =>
     auth.handler(
-      new Request(`http://auth.example.test/api/auth${path}`, {
+      new Request(`${baseURL}/api/auth${path}`, {
         method: body ? "POST" : "GET",
         headers: {
           "content-type": "application/json",
-          origin: "http://web.example.test",
+          origin: requestOrigin ?? webOrigin,
           ...(token ? { authorization: `Bearer ${token}` } : {}),
         },
         body: body ? JSON.stringify(body) : undefined,
@@ -94,6 +106,28 @@ function fixture({ allowlist = "", delivery = true } = {}) {
 }
 
 beforeEach(() => vi.clearAllMocks());
+
+describe("loopback trusted origins", () => {
+  it("accepts Origin localhost when webOrigin is 127.0.0.1", async () => {
+    const f = fixture({
+      delivery: false,
+      baseURL: "http://127.0.0.1:5173",
+      webOrigin: "http://127.0.0.1:5173",
+      requestOrigin: "http://localhost:5173",
+    });
+    expect((await f.signup()).status).toBe(200);
+  });
+
+  it("accepts Origin 127.0.0.1 when webOrigin is localhost", async () => {
+    const f = fixture({
+      delivery: false,
+      baseURL: "http://localhost:5173",
+      webOrigin: "http://localhost:5173",
+      requestOrigin: "http://127.0.0.1:5173",
+    });
+    expect((await f.signup()).status).toBe(200);
+  });
+});
 
 describe("identity trust through auth endpoints", () => {
   it("keeps first-owner bootstrap and password signup available without email for open deployments", async () => {

--- a/packages/auth/src/index.test.ts
+++ b/packages/auth/src/index.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it, vi } from "vitest";
-import { blockedAuthPaths, passwordResetEmail, resolveSignupPolicy } from "./index.js";
+import {
+  blockedAuthPaths,
+  buildTrustedOrigins,
+  passwordResetEmail,
+  resolveSignupPolicy,
+} from "./index.js";
 
 describe("auth policy", () => {
   it("blocks invitation and org-creation paths in version 1", () => {
     expect(blockedAuthPaths.some((path) => path.includes("invite"))).toBe(true);
     expect(blockedAuthPaths.some((path) => path.includes("create"))).toBe(true);
+  });
+});
+
+describe("buildTrustedOrigins", () => {
+  it("adds the localhost twin for a 127.0.0.1 web origin", () => {
+    expect(
+      buildTrustedOrigins({
+        webOrigin: "http://127.0.0.1:5173",
+        baseURL: "http://127.0.0.1:5173",
+      }),
+    ).toEqual(expect.arrayContaining(["http://127.0.0.1:5173", "http://localhost:5173"]));
+  });
+
+  it("keeps extraOrigins and does not twin non-loopback hosts", () => {
+    expect(
+      buildTrustedOrigins({
+        webOrigin: "https://app.example.test",
+        baseURL: "https://api.example.test",
+        extraOrigins: ["https://extra.example.test"],
+      }),
+    ).toEqual(["https://app.example.test", "https://api.example.test", "https://extra.example.test"]);
   });
 });
 

--- a/packages/auth/src/index.test.ts
+++ b/packages/auth/src/index.test.ts
@@ -30,7 +30,11 @@ describe("buildTrustedOrigins", () => {
         baseURL: "https://api.example.test",
         extraOrigins: ["https://extra.example.test"],
       }),
-    ).toEqual(["https://app.example.test", "https://api.example.test", "https://extra.example.test"]);
+    ).toEqual([
+      "https://app.example.test",
+      "https://api.example.test",
+      "https://extra.example.test",
+    ]);
   });
 });
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -40,7 +40,7 @@ export function createAuth(prisma: PrismaClient, env: AuthEnv) {
     appName: "Rakazo",
     secret: env.secret,
     baseURL: env.baseURL,
-    trustedOrigins: [env.webOrigin, env.baseURL, ...(env.extraOrigins ?? [])],
+    trustedOrigins: buildTrustedOrigins(env),
     database: prismaAdapter(prisma, { provider: "postgresql" }),
     emailAndPassword: {
       enabled: true,
@@ -252,6 +252,35 @@ function escapeHtml(value: string): string {
 }
 
 export type Auth = ReturnType<typeof createAuth>;
+
+/** Assemble Better Auth trustedOrigins, adding localhost↔127.0.0.1 twins for loopback. */
+export function buildTrustedOrigins(env: Pick<AuthEnv, "webOrigin" | "baseURL" | "extraOrigins">) {
+  const configured = [env.webOrigin, env.baseURL, ...(env.extraOrigins ?? [])];
+  const twins = [env.webOrigin, env.baseURL].flatMap(loopbackTwinOrigins);
+  return [...new Set([...configured, ...twins])];
+}
+
+function isLoopbackHost(host: string): boolean {
+  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+}
+
+/** Same-scheme/port localhost and 127.0.0.1 variants when `origin` is loopback. */
+function loopbackTwinOrigins(origin: string): string[] {
+  try {
+    const url = new URL(origin);
+    if (!isLoopbackHost(url.hostname)) return [];
+    const twins: string[] = [];
+    for (const host of ["localhost", "127.0.0.1"] as const) {
+      if (host === url.hostname) continue;
+      const twin = new URL(origin);
+      twin.hostname = host;
+      twins.push(twin.origin);
+    }
+    return twins;
+  } catch {
+    return [];
+  }
+}
 
 export const blockedAuthPaths = [
   "/organization/create",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Local `pnpm dev` configures `WEB_ORIGIN` / `BETTER_AUTH_URL` as `http://127.0.0.1:5173`, but opening the app as `http://localhost:5173` sends a different browser `Origin`. CORS already accepts either loopback host, while Better Auth `trustedOrigins` did not, so sign-up / sign-in failed with `Invalid origin` and HTTP 403 on `POST /api/auth/*`.

Fixes #762

## What changed

- In `@rakazo/auth`, assemble `trustedOrigins` via `buildTrustedOrigins`: for loopback `webOrigin` / `baseURL` (`localhost`, `127.0.0.1`, `::1` / `[::1]`), also trust the same-scheme/port `localhost`↔`127.0.0.1` twin. `extraOrigins` unchanged; non-loopback hosts are not expanded.
- Offline Better Auth fixture tests cover both twin directions; unit coverage asserts twins for loopback and no expansion for public hosts.
- Short notes in `.env.example` and `docs/self-host.md` that both loopback hosts are fine locally.

## How tested

- `pnpm --filter @rakazo/auth test` — all 16 tests passed
- `pnpm --filter @rakazo/auth check` — TypeScript clean

**Copy added**

- `.env.example`: `Local loopback: localhost and 127.0.0.1 are interchangeable browser hosts.`
- `docs/self-host.md`: `(or http://localhost:5173 — both loopback hosts are trusted)`

Necessary so local docs match the trusted-origin behavior; removing either leaves the default `.env`/`127.0.0.1` URL looking exclusive of `localhost`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcca8b40-ca96-4aaa-b88b-c766fde17368?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcca8b40-ca96-4aaa-b88b-c766fde17368&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local self-hosted setups now recognize `localhost` and `127.0.0.1` as interchangeable trusted browser hosts.
  * Trusted local origins are deduplicated while preserving additional configured origins.
  * Signup and authentication now work consistently when switching between supported loopback URLs.

* **Documentation**
  * Updated self-hosting guidance and environment configuration comments to clarify supported loopback URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->