### PR TITLE
Use one composer microphone for voice and simplify settings

### DIFF
--- a/apps/web/e2e/bot-organization.spec.ts
+++ b/apps/web/e2e/bot-organization.spec.ts
@@ -169,7 +169,7 @@ test("chat composer controls are vertically centered", async ({ page }) => {
   await completeOnboarding(page);
 
   const centers = await page.getByTestId("composer-bar").evaluate((composer) =>
-    ["Attach file", "Dictate", "Message Chief", "Send"].map((label) => {
+    ["Attach file", "Message Chief", "Send"].map((label) => {
       const element = composer.querySelector<HTMLElement>(`[aria-label="${label}"]`);
       if (!element) throw new Error(`Missing composer control: ${label}`);
       const box = element.getBoundingClientRect();

--- a/apps/web/e2e/bot-organization.spec.ts
+++ b/apps/web/e2e/bot-organization.spec.ts
@@ -169,7 +169,7 @@ test("chat composer controls are vertically centered", async ({ page }) => {
   await completeOnboarding(page);
 
   const centers = await page.getByTestId("composer-bar").evaluate((composer) =>
-    ["Attach file", "Message Chief", "Send"].map((label) => {
+    ["Attach file", "Message Chief", "Voice", "Send"].map((label) => {
       const element = composer.querySelector<HTMLElement>(`[aria-label="${label}"]`);
       if (!element) throw new Error(`Missing composer control: ${label}`);
       const box = element.getBoundingClientRect();

--- a/apps/web/e2e/golden.spec.ts
+++ b/apps/web/e2e/golden.spec.ts
@@ -372,6 +372,10 @@ test("sign-in, spawn, and stop work in the shell", async ({ page }, testInfo) =>
   await expect(page.getByRole("button", { name: "Send", exact: true })).toBeVisible();
   await composer.fill("Use the newer report and keep the answer short.");
   await page.keyboard.press("Tab");
+  await expect(
+    page.getByTestId("composer-bar").getByRole("button", { name: "Voice", exact: true }),
+  ).toBeFocused();
+  await page.keyboard.press("Tab");
   await expect(page.getByRole("button", { name: "Send", exact: true })).toBeFocused();
   await page.keyboard.press("Enter");
   await expect(

--- a/apps/web/e2e/voice.spec.ts
+++ b/apps/web/e2e/voice.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { completeOnboarding, rpc, signup } from "./helpers";
 
-test("voice settings connect a key, speak a reply, and open a call", async ({ page }) => {
+test("voice settings connect a key, speak a reply, and open a call", async ({ page }, testInfo) => {
   const stamp = Date.now();
   const userName = `Voice ${stamp}`;
   await signup(page, `voice-${stamp}@rakazo.test`, "password12", userName);
@@ -9,7 +9,12 @@ test("voice settings connect a key, speak a reply, and open a call", async ({ pa
 
   await page.getByRole("button", { name: "Call" }).click();
   await expect(page.getByTestId("voice-settings")).toBeVisible();
-  await expect(page.getByText("Not configured")).toBeVisible();
+  await expect(page.getByLabel("API key", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Dictate", exact: true })).toHaveCount(0);
+  await testInfo.attach("voice-settings", {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  });
   await page.getByRole("button", { name: "Close voice settings" }).click();
   await expect(page.getByTestId("voice-settings")).toHaveCount(0);
 
@@ -27,7 +32,7 @@ test("voice settings connect a key, speak a reply, and open a call", async ({ pa
   await apiKeyInput.fill("fake-scripted-voice-key");
   await page.getByRole("button", { name: "Connect" }).click();
   await expect(page.getByText("Connected", { exact: true }).first()).toBeVisible();
-  await expect(page.getByText(/Connected · Scripted/)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Replace key" })).toBeVisible();
 
   const spoken = page.waitForResponse(
     (response) => response.url().includes("/api/voice/speak") && response.ok(),
@@ -60,6 +65,11 @@ test("voice settings connect a key, speak a reply, and open a call", async ({ pa
   );
   await speakReply.click();
   await replySpoken;
+
+  await page.getByRole("button", { name: new RegExp(userName) }).click();
+  await page.getByRole("button", { name: "Voice", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Replace key" })).toBeVisible();
+  await page.getByRole("button", { name: "Close voice settings" }).click();
 
   await page.getByRole("button", { name: "Call" }).click();
   await expect(page.getByTestId("call-view")).toBeVisible();

--- a/apps/web/e2e/voice.spec.ts
+++ b/apps/web/e2e/voice.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { completeOnboarding, rpc, signup } from "./helpers";
+import { captureScreenshot, completeOnboarding, rpc, signup } from "./helpers";
 
 test("voice settings connect a key, speak a reply, and open a call", async ({ page }, testInfo) => {
   const stamp = Date.now();
@@ -7,14 +7,19 @@ test("voice settings connect a key, speak a reply, and open a call", async ({ pa
   await signup(page, `voice-${stamp}@rakazo.test`, "password12", userName);
   await completeOnboarding(page);
 
-  await page.getByRole("button", { name: "Call" }).click();
+  await expect(page.getByRole("button", { name: "Call", exact: true })).toHaveCount(0);
+  await expect(
+    page.getByTestId("composer-bar").getByRole("button", { name: "Voice", exact: true }),
+  ).toHaveCount(1);
+  await captureScreenshot(page, testInfo, "voice-composer");
+  await page
+    .getByTestId("composer-bar")
+    .getByRole("button", { name: "Voice", exact: true })
+    .click();
   await expect(page.getByTestId("voice-settings")).toBeVisible();
   await expect(page.getByLabel("API key", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Dictate", exact: true })).toHaveCount(0);
-  await testInfo.attach("voice-settings", {
-    body: await page.screenshot(),
-    contentType: "image/png",
-  });
+  await captureScreenshot(page, testInfo, "voice-settings");
   await page.getByRole("button", { name: "Close voice settings" }).click();
   await expect(page.getByTestId("voice-settings")).toHaveCount(0);
 
@@ -24,7 +29,10 @@ test("voice settings connect a key, speak a reply, and open a call", async ({ pa
   expect(preparedOff.ready).toBe(false);
 
   await page.getByRole("button", { name: new RegExp(userName) }).click();
-  await page.getByRole("button", { name: "Voice", exact: true }).click();
+  await page
+    .locator('[data-slot="popover-content"]')
+    .getByRole("button", { name: "Voice", exact: true })
+    .click();
   await expect(page.getByTestId("voice-settings")).toBeVisible();
   await page.getByRole("button", { name: /Scripted/ }).click();
   const apiKeyInput = page.getByPlaceholder(/Paste your API key/);
@@ -67,11 +75,17 @@ test("voice settings connect a key, speak a reply, and open a call", async ({ pa
   await replySpoken;
 
   await page.getByRole("button", { name: new RegExp(userName) }).click();
-  await page.getByRole("button", { name: "Voice", exact: true }).click();
+  await page
+    .locator('[data-slot="popover-content"]')
+    .getByRole("button", { name: "Voice", exact: true })
+    .click();
   await expect(page.getByRole("button", { name: "Replace key" })).toBeVisible();
   await page.getByRole("button", { name: "Close voice settings" }).click();
 
-  await page.getByRole("button", { name: "Call" }).click();
+  await page
+    .getByTestId("composer-bar")
+    .getByRole("button", { name: "Voice", exact: true })
+    .click();
   await expect(page.getByTestId("call-view")).toBeVisible();
   await expect(page.getByRole("button", { name: "Hang up" })).toBeVisible();
   await page.getByRole("button", { name: "Hang up" }).click();

--- a/apps/web/src/lib/desktop.test.ts
+++ b/apps/web/src/lib/desktop.test.ts
@@ -68,7 +68,7 @@ describe("window chrome", () => {
     );
     expect(shell).toContain('className="app-no-drag grid h-8 w-8');
     expect(shell).toContain('className="app-no-drag flex min-w-0 items-center gap-3"');
-    expect(shell.match(/className="app-no-drag grid h-\[30px\] w-\[34px\]/g)).toHaveLength(2);
+    expect(shell.match(/className="app-no-drag grid h-\[30px\] w-\[34px\]/g)).toHaveLength(1);
   });
 });
 

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -88,11 +88,11 @@ import {
   LogOut,
   Maximize2,
   Menu,
+  Mic,
   Monitor,
   MoreHorizontal,
   PanelLeftClose,
   Paperclip,
-  Phone,
   Plus,
   Puzzle,
   Reply,
@@ -3014,24 +3014,6 @@ export function ShellPage() {
             </button>
           </div>
           <div className="flex items-center gap-1">
-            {!inGroup && active ? (
-              <button
-                type="button"
-                title={voiceStatus?.ready ? t`Call` : t`Set up voice to call`}
-                aria-label={t`Call`}
-                onClick={() => {
-                  if (!voiceStatus?.ready) {
-                    setVoiceOpen(true);
-                    return;
-                  }
-                  setCallOpen(true);
-                }}
-                data-active={callOpen ? "" : undefined}
-                className="app-no-drag grid h-[30px] w-[34px] place-items-center rounded-[9px] hover:bg-accent data-active:bg-accent"
-              >
-                <Phone size={16} strokeWidth={1.6} className="text-foreground/75" />
-              </button>
-            ) : null}
             {!inGroup ? (
               <button
                 type="button"
@@ -3103,6 +3085,17 @@ export function ShellPage() {
           onRemoveAttachment={removeAttachment}
           onSend={sendMessage}
           onStop={stopRun}
+          onVoice={
+            !inGroup && active
+              ? () => {
+                  if (!voiceStatus?.ready) {
+                    setVoiceOpen(true);
+                    return;
+                  }
+                  setCallOpen(true);
+                }
+              : undefined
+          }
           replyTarget={activeReplyTarget}
           replyTargetName={replyTargetName}
           onClearReply={() => setReplyTarget(null)}
@@ -4261,6 +4254,7 @@ const Composer = memo(function Composer({
   onRemoveAttachment,
   onSend,
   onStop,
+  onVoice,
   replyTarget,
   replyTargetName,
   onClearReply,
@@ -4285,6 +4279,7 @@ const Composer = memo(function Composer({
   onRemoveAttachment: (attachment: PendingAttachment) => void;
   onSend: (text: string, mentions?: ComposerMention[]) => Promise<void>;
   onStop: () => Promise<void>;
+  onVoice?: () => void;
   replyTarget?: ThreadMessage | null;
   replyTargetName?: string;
   onClearReply?: () => void;
@@ -4851,6 +4846,19 @@ const Composer = memo(function Composer({
             className="max-h-32 min-h-[24px] min-w-[8rem] flex-1 resize-none overflow-y-auto bg-transparent py-0.5 text-[15.5px] leading-6 text-foreground outline-none placeholder:text-muted-foreground disabled:opacity-40"
           />
         </div>
+        {onVoice ? (
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label={t`Voice`}
+            title={t`Voice`}
+            disabled={disabled}
+            onClick={onVoice}
+            className="rounded-full text-foreground/75"
+          >
+            <Mic size={16} strokeWidth={1.8} />
+          </Button>
+        ) : null}
         {running ? (
           <>
             <Button

--- a/apps/web/src/pages/Shell.tsx
+++ b/apps/web/src/pages/Shell.tsx
@@ -88,7 +88,6 @@ import {
   LogOut,
   Maximize2,
   Menu,
-  Mic,
   Monitor,
   MoreHorizontal,
   PanelLeftClose,
@@ -150,7 +149,6 @@ import {
   shouldNotifyBrowser,
 } from "../lib/browser-notifications";
 import { loadComputerScreen } from "../lib/computer-screen";
-import { dictation } from "../lib/dictation";
 import { scheduleFocusPrompt } from "../lib/focus-prompt";
 import { localTimezone } from "../lib/local-timezone";
 import { copyableMessageText } from "../lib/message-text";
@@ -436,8 +434,6 @@ export function ShellPage() {
   const [callOpen, setCallOpen] = useState(false);
   const [voiceStatus, setVoiceStatus] = useState<VoiceStatus | null>(null);
   const [speakingMessageId, setSpeakingMessageId] = useState<string | null>(null);
-  const [dictating, setDictating] = useState(false);
-  const [dictationError, setDictationError] = useState<string | null>(null);
   const [dismissedRunErrorIds, setDismissedRunErrorIds] =
     useState<ReadonlySet<string>>(readSeenRunErrorIds);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -1039,14 +1035,8 @@ export function ShellPage() {
     const unsubSpeech = speaker.subscribe((state) => {
       setSpeakingMessageId(state.status === "idle" ? null : (state.messageId ?? null));
     });
-    const unsubDictation = dictation.subscribe((state) => {
-      setDictating(state.status === "listening" || state.status === "transcribing");
-      if (state.error) setDictationError(state.error);
-      else if (state.status === "listening") setDictationError(null);
-    });
     return () => {
       unsubSpeech();
-      unsubDictation();
     };
   }, []);
 
@@ -1575,7 +1565,7 @@ export function ShellPage() {
   const transcriptRunning = workingRuns.length > 0;
   const composerRunning = currentRuns.some((run) => isActive(run.status));
   const runError = threadRunError(activeSnapshot, dismissedRunErrorIds);
-  const displayedRunError = !sendError && !dictationError ? runError : null;
+  const displayedRunError = !sendError ? runError : null;
   const displayedRunErrorId = displayedRunError ? (activeSnapshot?.run?.id ?? null) : null;
   const handleRunErrorPresented = useCallback((runId: string) => {
     rememberSeenRunErrorId(runId);
@@ -2361,7 +2351,6 @@ export function ShellPage() {
     // one on screen; otherwise a live run would be silenced before it has even failed.
     const failedRunId = displayedRunErrorId;
     setSendError(null);
-    setDictationError(null);
     if (failedRunId) {
       rememberSeenRunErrorId(failedRunId);
       setDismissedRunErrorIds((current) => new Set(current).add(failedRunId));
@@ -3104,7 +3093,6 @@ export function ShellPage() {
           pendingAttachments={activePendingAttachments}
           attachmentNotice={attachmentNotice}
           sendError={sendError}
-          dictationError={dictationError}
           runError={displayedRunError}
           runErrorId={displayedRunErrorId}
           onRunErrorPresented={handleRunErrorPresented}
@@ -3140,16 +3128,6 @@ export function ShellPage() {
                 .catch(() => undefined);
             }
           }}
-          dictating={dictating}
-          transcribe={Boolean(voiceStatus?.transcribe)}
-          onDictateStart={(onFinal) => {
-            void dictation.listen({
-              mode: "hold",
-              transcribe: Boolean(voiceStatus?.transcribe),
-              onFinal,
-            });
-          }}
-          onDictateStop={() => dictation.submitHold()}
         />
       </main>
 
@@ -4273,7 +4251,6 @@ const Composer = memo(function Composer({
   pendingAttachments,
   attachmentNotice,
   sendError,
-  dictationError,
   runError,
   runErrorId,
   onRunErrorPresented,
@@ -4291,10 +4268,6 @@ const Composer = memo(function Composer({
   agentSkills,
   onSlashOpen,
   onSlashAction,
-  dictating,
-  transcribe,
-  onDictateStart,
-  onDictateStop,
 }: {
   activeName?: string;
   running: boolean;
@@ -4302,7 +4275,6 @@ const Composer = memo(function Composer({
   pendingAttachments: PendingAttachment[];
   attachmentNotice: string | null;
   sendError: string | null;
-  dictationError: string | null;
   runError: string | null;
   runErrorId: string | null;
   onRunErrorPresented: (runId: string) => void;
@@ -4320,10 +4292,6 @@ const Composer = memo(function Composer({
   agentSkills?: AgentSkillCatalogEntry[];
   onSlashOpen?: () => void;
   onSlashAction?: (action: SlashActionId) => void;
-  dictating: boolean;
-  transcribe: boolean;
-  onDictateStart: (onFinal: (text: string) => void) => void;
-  onDictateStop: () => void;
 }) {
   const { t } = useLingui();
   const [draft, setDraft] = useState("");
@@ -4590,14 +4558,14 @@ const Composer = memo(function Composer({
         draggingFiles ? "rounded-[14px] ring-2 ring-inset ring-ring" : ""
       }`}
     >
-      {sendError || dictationError || runError ? (
+      {sendError || runError ? (
         <div
           ref={runErrorRef}
           role="alert"
           data-testid="composer-error"
           className="mb-3 flex items-center gap-2 rounded-[14px] border border-destructive/40 bg-destructive/10 px-4 py-2 text-[13px] text-destructive"
         >
-          <span className="min-w-0 flex-1">{sendError ?? dictationError ?? runError}</span>
+          <span className="min-w-0 flex-1">{sendError ?? runError}</span>
           <button
             type="button"
             aria-label={t`Dismiss error`}
@@ -4768,32 +4736,6 @@ const Composer = memo(function Composer({
           className="rounded-full text-foreground/75"
         >
           <Plus size={17} strokeWidth={1.8} />
-        </Button>
-        <Button
-          variant="outline"
-          size="icon"
-          aria-label={dictating ? t`Stop dictation` : t`Dictate`}
-          onMouseDown={(event) => {
-            event.preventDefault();
-            onDictateStart((text) => setDraft((current) => `${current} ${text}`.trim()));
-          }}
-          onMouseUp={onDictateStop}
-          onMouseLeave={() => {
-            if (dictating) onDictateStop();
-          }}
-          onTouchStart={(event) => {
-            event.preventDefault();
-            onDictateStart((text) => setDraft((current) => `${current} ${text}`.trim()));
-          }}
-          onTouchEnd={onDictateStop}
-          className={`rounded-full ${
-            dictating
-              ? "border-success bg-success/15 text-success hover:bg-success/15 hover:text-success"
-              : "text-foreground/75"
-          }`}
-          title={transcribe ? t`Hold to talk` : t`Hold to talk (on-device dictation)`}
-        >
-          <Mic size={16} strokeWidth={1.8} />
         </Button>
         <div className="flex min-w-0 flex-1 flex-wrap items-end gap-1.5">
           {selectedSkill ? (

--- a/apps/web/src/pages/VoiceSettingsOverlay.tsx
+++ b/apps/web/src/pages/VoiceSettingsOverlay.tsx
@@ -5,7 +5,6 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
-  DialogDescription,
   DialogTitle,
   Field,
   FieldLabel,
@@ -136,6 +135,7 @@ export function VoiceSettingsOverlay({ onClose }: { onClose: () => void }) {
     >
       <DialogContent
         data-testid="voice-settings"
+        aria-describedby={undefined}
         showCloseButton={false}
         className="flex h-[min(680px,calc(100%-2rem))] w-[920px] flex-col gap-0 overflow-hidden rounded-2xl p-0 sm:h-[min(680px,calc(100%-5rem))] sm:max-w-[calc(100%-5rem)]"
       >
@@ -144,16 +144,6 @@ export function VoiceSettingsOverlay({ onClose }: { onClose: () => void }) {
             <DialogTitle className="text-2xl font-medium text-foreground">
               <Trans>Voice</Trans>
             </DialogTitle>
-            <DialogDescription className="mt-1 text-[13.5px] text-muted-foreground/70">
-              {loading ? (
-                <Trans>Loading voice providers…</Trans>
-              ) : (
-                <Trans>
-                  Bring your own key. The provider is swappable; your bots keep the same speak and
-                  call buttons.
-                </Trans>
-              )}
-            </DialogDescription>
           </div>
           <DialogClose
             aria-label={t`Close voice settings`}
@@ -161,24 +151,6 @@ export function VoiceSettingsOverlay({ onClose }: { onClose: () => void }) {
           >
             <XIcon />
           </DialogClose>
-        </div>
-
-        <div className="mx-6 mt-5 rounded-xl border border-border px-4 py-3 sm:mx-8">
-          <div className="text-[12.5px] uppercase tracking-[0.08em] text-muted-foreground/80">
-            <Trans>Active voice</Trans>
-          </div>
-          <div className="mt-1 text-[16px] text-foreground">
-            {status?.ready
-              ? voiceOptions.find((voice) => voice.id === status.voiceId)?.label || status.voiceId
-              : status?.configured
-                ? t`Pick a voice`
-                : t`Not configured`}
-          </div>
-          <div className="mt-1 text-[13px] text-muted-foreground">
-            {selected?.name ?? status?.provider ?? (
-              <Trans>Connect ElevenLabs, OpenAI, or Cartesia</Trans>
-            )}
-          </div>
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-hidden px-6 py-6 sm:px-8 md:flex-row">
@@ -228,31 +200,15 @@ export function VoiceSettingsOverlay({ onClose }: { onClose: () => void }) {
           </div>
 
           <div className="rk-scroll min-h-0 min-w-0 flex-1 overflow-y-auto">
+            {loading ? (
+              <p className="text-sm text-muted-foreground">
+                <Trans>Loading voice providers…</Trans>
+              </p>
+            ) : null}
             {error ? <p className="mb-4 text-sm text-destructive">{error}</p> : null}
             {notice ? <p className="mb-4 text-sm text-success">{notice}</p> : null}
             {selected ? (
               <>
-                <p className="text-[13.5px] leading-[1.5] text-muted-foreground">
-                  {selected.description}
-                </p>
-                <div className="mt-5 rounded-xl border border-border px-4 py-3">
-                  <div className="text-[12.5px] uppercase tracking-[0.08em] text-muted-foreground/80">
-                    <Trans>Personal credential</Trans>
-                  </div>
-                  <div className="mt-1 text-[15px] text-foreground">
-                    {credential ? (
-                      <Trans>Connected · {selected.name}</Trans>
-                    ) : (
-                      <Trans>Not connected</Trans>
-                    )}
-                  </div>
-                  <div className="mt-1 text-[13px] text-muted-foreground">
-                    <Trans>
-                      Keys stay on the server. The app only learns whether a provider is configured.
-                    </Trans>
-                  </div>
-                </div>
-
                 <Field className="mt-5">
                   <FieldLabel htmlFor={apiKeyId}>
                     <Trans>API key</Trans>


### PR DESCRIPTION
Voice had two entry points and a settings dialog that repeated information already shown by its controls.

Use one microphone beside Send in the web and Electron composer. Tapping it opens voice settings until a provider is ready, then starts voice mode. Remove the header phone button and hold-to-dictate behavior. Voice settings remain available through the regular menu. Group chats retain their existing lack of voice-mode support.

Trim voice settings to provider selection, key entry, voice selection, and a sample button. Remove introductory copy, the active-voice summary, provider descriptions, and the credential explanation. The microphone uses “Voice” as its accessible name and hover tooltip: an icon-only control needs a name for assistive technology, and the tooltip is revealed only on hover. No persistent explanatory copy is added.

Validation: web type checking, formatting checks, and all 207 web unit tests passed. Updated E2E coverage checks the microphone position, setup routing, settings reopening, and voice mode, and captures both the composer and settings. All CI checks passed on the final commit, including web E2E. Both automated reviews completed without actionable findings.

[CI screenshots](https://github.com/elie222/rakazo/actions/runs/34123172497/artifacts/10019260236): open the Playwright report and select the `voice-settings` and `voice-composer` attachments in the passing voice workflow test. The settings image is `playwright-report/data/3ddbc1c9f57d53d7f3d5720877cb37cb6871f08b.png`; the composer image is `playwright-report/data/e7b47302fbdf9cb323aeeac508617852b023dde9.png`.
