### PR TITLE
Show desktop updates and offer restart from the app

### DIFF
--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -121,7 +121,7 @@ describe("reduceUpdateState", () => {
       availableVersion: "0.2.0",
       percent: 100,
     });
-    expect(state.message).toContain("Restart Rakazo");
+    expect(state.message).toBeNull();
   });
 
   it("clamps progress to a percentage while downloading", () => {
@@ -412,6 +412,29 @@ describe("DesktopUpdateController", () => {
     expect(await controller.install()).toMatchObject({ phase: "ready", message: null });
     expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(3);
     expect(fake.updater.downloadUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports asynchronous installation errors and permits retry", async () => {
+    const onInstallFailure = vi.fn();
+    const fake = fakeUpdater();
+    const controller = new DesktopUpdateController(
+      packaged,
+      async () => fake.updater,
+      clock,
+      onInstallFailure,
+    );
+    await controller.check(false);
+    fake.emit("update-downloaded", { version: "0.2.0" });
+    await controller.install();
+    fake.emit("error", new Error("installer failed after returning"));
+    expect(controller.state()).toMatchObject({
+      phase: "ready",
+      message: "The update could not be completed. Try again later.",
+    });
+    expect(onInstallFailure).toHaveBeenCalledTimes(1);
+    await controller.install();
+    expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(2);
+    expect(controller.state().message).toBeNull();
   });
 
   it("lets a manual check escape a prior empty-feed freeze", async () => {

--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -404,9 +404,13 @@ describe("DesktopUpdateController", () => {
       phase: "ready",
       message: "The update could not be completed. Try again later.",
     });
+    expect(await controller.install()).toMatchObject({
+      phase: "ready",
+      message: "The update could not be completed. Try again later.",
+    });
     vi.mocked(fake.updater.quitAndInstall).mockImplementation(() => undefined);
-    expect(await controller.install()).toMatchObject({ phase: "ready" });
-    expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(2);
+    expect(await controller.install()).toMatchObject({ phase: "ready", message: null });
+    expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(3);
     expect(fake.updater.downloadUpdate).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -182,7 +182,7 @@ describe("reduceUpdateState", () => {
     expect(ready).toMatchObject({ phase: "ready", availableVersion: "0.2.0", percent: 100 });
   });
 
-  it("lets an install failure leave the ready phase", () => {
+  it("keeps a verified download ready after an install failure", () => {
     const failed = apply([
       { type: "downloaded", version: "0.2.0" },
       {
@@ -193,7 +193,7 @@ describe("reduceUpdateState", () => {
       },
     ]);
     expect(failed).toMatchObject({
-      phase: "error",
+      phase: "ready",
       availableVersion: "0.2.0",
       message: "The update could not be completed. Try again later.",
     });
@@ -381,7 +381,7 @@ describe("DesktopUpdateController", () => {
     expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(1);
   });
 
-  it("reports install failures instead of staying ready", async () => {
+  it("retries installation after a synchronous failure without downloading again", async () => {
     let fake: ReturnType<typeof fakeUpdater>;
     fake = fakeUpdater({
       checkForUpdates: vi.fn(async () => {
@@ -401,10 +401,13 @@ describe("DesktopUpdateController", () => {
 
     const state = await controller.install();
     expect(state).toMatchObject({
-      phase: "error",
+      phase: "ready",
       message: "The update could not be completed. Try again later.",
     });
-    expect(await controller.install()).toMatchObject({ phase: "error" });
+    vi.mocked(fake.updater.quitAndInstall).mockImplementation(() => undefined);
+    expect(await controller.install()).toMatchObject({ phase: "ready" });
+    expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(2);
+    expect(fake.updater.downloadUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("lets a manual check escape a prior empty-feed freeze", async () => {

--- a/apps/desktop/src/auto-update.test.ts
+++ b/apps/desktop/src/auto-update.test.ts
@@ -416,7 +416,16 @@ describe("DesktopUpdateController", () => {
 
   it("reports asynchronous installation errors and permits retry", async () => {
     const onInstallFailure = vi.fn();
-    const fake = fakeUpdater();
+    let fake: ReturnType<typeof fakeUpdater>;
+    fake = fakeUpdater({
+      checkForUpdates: vi.fn(async () => {
+        fake.emit("checking-for-update");
+        fake.emit("update-available", { version: "0.2.0" });
+      }),
+      downloadUpdate: vi.fn(async () => {
+        fake.emit("update-downloaded", { version: "0.2.0" });
+      }),
+    });
     const controller = new DesktopUpdateController(
       packaged,
       async () => fake.updater,
@@ -424,17 +433,44 @@ describe("DesktopUpdateController", () => {
       onInstallFailure,
     );
     await controller.check(false);
-    fake.emit("update-downloaded", { version: "0.2.0" });
-    await controller.install();
+    await vi.waitFor(() => expect(controller.state().phase).toBe("ready"));
+
+    expect(await controller.install()).toMatchObject({ phase: "ready", message: null });
+    expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(1);
+
     fake.emit("error", new Error("installer failed after returning"));
     expect(controller.state()).toMatchObject({
       phase: "ready",
+      availableVersion: "0.2.0",
       message: "The update could not be completed. Try again later.",
     });
     expect(onInstallFailure).toHaveBeenCalledTimes(1);
-    await controller.install();
+
+    expect(await controller.install()).toMatchObject({ phase: "ready", message: null });
     expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(2);
-    expect(controller.state().message).toBeNull();
+    expect(fake.updater.downloadUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores late updater errors while ready when install was never started", async () => {
+    let fake: ReturnType<typeof fakeUpdater>;
+    fake = fakeUpdater({
+      checkForUpdates: vi.fn(async () => {
+        fake.emit("checking-for-update");
+        fake.emit("update-available", { version: "0.2.0" });
+      }),
+      downloadUpdate: vi.fn(async () => {
+        fake.emit("update-downloaded", { version: "0.2.0" });
+      }),
+    });
+    const controller = new DesktopUpdateController(packaged, async () => fake.updater, clock);
+    await controller.check(false);
+    await vi.waitFor(() => expect(controller.state().phase).toBe("ready"));
+    const ready = controller.state();
+
+    fake.emit("error", new Error("socket hang up"));
+    expect(controller.state()).toEqual(ready);
+    expect(await controller.install()).toMatchObject({ phase: "ready", message: null });
+    expect(fake.updater.quitAndInstall).toHaveBeenCalledTimes(1);
   });
 
   it("lets a manual check escape a prior empty-feed freeze", async () => {

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -142,7 +142,7 @@ export function reduceUpdateState(
         phase: "ready",
         availableVersion: event.version,
         percent: 100,
-        message: "Restart Rakazo to finish the update.",
+        message: null,
       };
     case "failed": {
       // electron-updater can emit late errors after a verified download; keep installable
@@ -258,6 +258,7 @@ export class DesktopUpdateController {
     private readonly environment: UpdaterEnvironment,
     private readonly loadUpdater: () => Promise<ElectronAutoUpdater>,
     private readonly clock: UpdateClock = systemClock,
+    private readonly onInstallFailure?: () => void,
   ) {
     this.current = initialUpdateState(environment);
   }
@@ -315,9 +316,7 @@ export class DesktopUpdateController {
             });
           }
         });
-        updater.on("error", (error) =>
-          this.push({ type: "failed", error, userInitiated: this.checkWasRequested }),
-        );
+        updater.on("error", (error) => this.fail(error));
         return updater;
       })
       .catch((error: unknown) => {
@@ -397,6 +396,18 @@ export class DesktopUpdateController {
     return this.current;
   }
 
+  private fail(error: unknown) {
+    const installFailed = this.installStarted;
+    if (installFailed) this.installStarted = false;
+    this.push({
+      type: "failed",
+      error,
+      userInitiated: this.checkWasRequested || installFailed,
+      installFailed,
+    });
+    if (installFailed) this.onInstallFailure?.();
+  }
+
   async install() {
     if (this.installStarted || this.current.phase !== "ready") return this.current;
     const updater = await this.updater();
@@ -408,8 +419,7 @@ export class DesktopUpdateController {
     try {
       updater.quitAndInstall();
     } catch (error) {
-      this.installStarted = false;
-      this.push({ type: "failed", error, userInitiated: true, installFailed: true });
+      this.fail(error);
     }
     return this.current;
   }

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -404,6 +404,7 @@ export class DesktopUpdateController {
       return this.current;
     }
     this.installStarted = true;
+    this.current = { ...this.current, message: null };
     try {
       updater.quitAndInstall();
     } catch (error) {

--- a/apps/desktop/src/auto-update.ts
+++ b/apps/desktop/src/auto-update.ts
@@ -146,9 +146,15 @@ export function reduceUpdateState(
       };
     case "failed": {
       // electron-updater can emit late errors after a verified download; keep installable
-      // state unless this failure came from quitAndInstall itself.
+      // state. A synchronous install failure can retry the same verified download.
       if (state.phase === "ready" && event.installFailed !== true) return state;
       const failure = classifyUpdaterFailure(event.error);
+      if (state.phase === "ready" && event.installFailed === true) {
+        return {
+          ...state,
+          message: failure.message ?? "The update could not be completed. Try again later.",
+        };
+      }
       if (failure.kind === "no-releases" && state.phase === "checking") {
         return {
           ...state,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -80,10 +80,17 @@ const updaterEnvironment = {
   version: app.getVersion(),
   disabled: process.env.RAKAZO_DISABLE_AUTO_UPDATE === "1",
 };
-const desktopUpdater = new DesktopUpdateController(updaterEnvironment, async () => {
-  const module = await import("electron-updater");
-  return (module.default ?? module).autoUpdater as unknown as ElectronAutoUpdater;
-});
+const desktopUpdater = new DesktopUpdateController(
+  updaterEnvironment,
+  async () => {
+    const module = await import("electron-updater");
+    return (module.default ?? module).autoUpdater as unknown as ElectronAutoUpdater;
+  },
+  undefined,
+  () => {
+    quitting = false;
+  },
+);
 let launchUpdateCheckScheduled = false;
 let localStack: LocalStackController;
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -966,9 +966,9 @@ app.whenReady().then(async () => {
     }
     quitting = true;
     const state = await desktopUpdater.install();
-    // Install failures leave ready via installFailed; also clear quitting if still ready
-    // is no longer true for any other reason.
-    if (state.phase !== "ready") quitting = false;
+    // A failed install stays ready for retry but reports a message. Restore normal
+    // window behavior while the user keeps working after that failure.
+    if (state.phase !== "ready" || state.message !== null) quitting = false;
     return state;
   });
   ipcMain.handle("desktop.setup.state", (event) => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -318,6 +318,7 @@ function createWindow(url: string, partition: string | null) {
   if (!launchUpdateCheckScheduled) {
     launchUpdateCheckScheduled = true;
     setTimeout(() => void desktopUpdater.check(false), LAUNCH_CHECK_DELAY_MS).unref();
+    setInterval(() => void desktopUpdater.check(false), 60 * 60 * 1_000).unref();
   }
   return { loaded, win };
 }

--- a/apps/web/e2e/desktop-update.spec.ts
+++ b/apps/web/e2e/desktop-update.spec.ts
@@ -39,10 +39,11 @@ test("desktop update can be checked, deferred, and installed from settings", asy
             return state;
           },
           install: async () => {
-            if (++installAttempts === 1) {
+            if (++installAttempts <= 2) {
               state = { ...state, message: "The update could not be completed. Try again later." };
               return state;
             }
+            state = { ...state, message: null };
             document.documentElement.dataset.updateInstalled = "true";
             return state;
           },
@@ -67,16 +68,21 @@ test("desktop update can be checked, deferred, and installed from settings", asy
   const prompt = page.getByRole("complementary", { name: "Desktop update" });
   await expect(prompt).toBeVisible({ timeout: 10_000 });
   await captureScreenshot(page, testInfo, "desktop-update-ready");
+  await prompt.getByRole("button", { name: "Restart to update" }).click();
+  await expect(prompt.getByRole("status")).toHaveText(
+    "The update could not be completed. Try again later.",
+  );
+  await prompt.getByRole("button", { name: "Restart to update" }).click();
+  await expect(prompt.getByRole("status")).toHaveText(
+    "The update could not be completed. Try again later.",
+  );
   await prompt.getByRole("button", { name: "Later" }).click();
   await expect(prompt).toHaveCount(0);
   await page.getByTestId("user-menu-trigger").click();
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   await expect(settings.getByRole("button", { name: "Restart to update" })).toBeVisible();
+  await settings.scrollIntoViewIfNeeded();
   await captureScreenshot(page, testInfo, "desktop-update-settings");
-  await settings.getByRole("button", { name: "Restart to update" }).click();
-  await expect(settings.getByRole("status")).toHaveText(
-    "The update could not be completed. Try again later.",
-  );
   await settings.getByRole("button", { name: "Restart to update" }).click();
   await expect(page.locator("html")).toHaveAttribute("data-update-installed", "true");
 });

--- a/apps/web/e2e/desktop-update.spec.ts
+++ b/apps/web/e2e/desktop-update.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+import { captureScreenshot, completeOnboarding, signup } from "./helpers";
+
+test("desktop update can be checked, deferred, and installed from settings", async ({
+  page,
+}, testInfo) => {
+  await page.addInitScript(() => {
+    let state = {
+      phase: "idle",
+      currentVersion: "0.1.2",
+      availableVersion: null as string | null,
+      percent: null as number | null,
+      message: null as string | null,
+      checkedAt: null as string | null,
+    };
+    Object.defineProperty(window, "rakazoDesktop", {
+      value: {
+        platform: "darwin",
+        window: {
+          close: async () => {},
+          minimize: async () => {},
+          toggleMaximize: async () => {},
+          state: async () => ({ minimized: false, maximized: false, fullScreen: false }),
+        },
+        oauth: { onCallback: () => () => {} },
+        update: {
+          state: async () => state,
+          check: async () => {
+            state = { ...state, phase: "downloading", availableVersion: "0.1.3", percent: 50 };
+            setTimeout(() => {
+              state = { ...state, phase: "ready", percent: 100 };
+            }, 3_000);
+            return state;
+          },
+          install: async () => {
+            document.documentElement.dataset.updateInstalled = "true";
+            return state;
+          },
+        },
+      },
+    });
+  });
+  const stamp = Date.now();
+  await signup(page, `desktop-update-${stamp}@rakazo.test`, "password12", "Update Tester");
+  await completeOnboarding(page);
+  await expect(page.getByRole("complementary", { name: "Desktop update" })).toHaveCount(0);
+  await page.getByTestId("user-menu-trigger").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  const settings = page.getByTestId("desktop-update-settings");
+  await expect(settings.getByText("v0.1.2")).toBeVisible();
+  await settings.getByRole("button", { name: "Check for updates" }).click();
+  await expect(settings.getByRole("button", { name: "Downloading…" })).toBeDisabled();
+  await page.keyboard.press("Escape");
+  const prompt = page.getByRole("complementary", { name: "Desktop update" });
+  await expect(prompt).toBeVisible({ timeout: 10_000 });
+  await captureScreenshot(page, testInfo, "desktop-update-ready");
+  await prompt.getByRole("button", { name: "Later" }).click();
+  await expect(prompt).toHaveCount(0);
+  await page.getByTestId("user-menu-trigger").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await expect(settings.getByRole("button", { name: "Restart to update" })).toBeVisible();
+  await captureScreenshot(page, testInfo, "desktop-update-settings");
+  await settings.getByRole("button", { name: "Restart to update" }).click();
+  await expect(page.locator("html")).toHaveAttribute("data-update-installed", "true");
+});
+
+test("ordinary web sessions do not show desktop update controls", async ({ page }) => {
+  await signup(page, `web-update-${Date.now()}@rakazo.test`, "password12", "Web Tester");
+  await completeOnboarding(page);
+  await page.getByTestId("user-menu-trigger").click();
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await expect(page.getByTestId("desktop-update-settings")).toHaveCount(0);
+  await expect(page.getByRole("complementary", { name: "Desktop update" })).toHaveCount(0);
+});

--- a/apps/web/e2e/desktop-update.spec.ts
+++ b/apps/web/e2e/desktop-update.spec.ts
@@ -6,13 +6,14 @@ test("desktop update can be checked, deferred, and installed from settings", asy
 }, testInfo) => {
   await page.addInitScript(() => {
     let installAttempts = 0;
+    let checks = 0;
     let state = {
       phase: "idle",
       currentVersion: "0.1.2",
       availableVersion: null as string | null,
       percent: null as number | null,
       message: null as string | null,
-      checkedAt: null as string | null,
+      checkedAt: "2026-01-01T00:00:00.000Z",
     };
     Object.defineProperty(window, "rakazoDesktop", {
       value: {
@@ -27,6 +28,10 @@ test("desktop update can be checked, deferred, and installed from settings", asy
         update: {
           state: async () => state,
           check: async () => {
+            if (++checks === 1) {
+              state = { ...state, checkedAt: "2026-01-01T00:01:00.000Z" };
+              return state;
+            }
             state = { ...state, phase: "downloading", availableVersion: "0.1.3", percent: 50 };
             setTimeout(() => {
               state = { ...state, phase: "ready", percent: 100 };
@@ -53,6 +58,9 @@ test("desktop update can be checked, deferred, and installed from settings", asy
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   const settings = page.getByTestId("desktop-update-settings");
   await expect(settings.getByText("v0.1.2")).toBeVisible();
+  await expect(settings.getByText("Up to date", { exact: true })).toHaveCount(0);
+  await settings.getByRole("button", { name: "Check for updates" }).click();
+  await expect(settings.getByRole("status")).toHaveText("Up to date");
   await settings.getByRole("button", { name: "Check for updates" }).click();
   await expect(settings.getByRole("button", { name: "Downloading…" })).toBeDisabled();
   await page.keyboard.press("Escape");

--- a/apps/web/e2e/desktop-update.spec.ts
+++ b/apps/web/e2e/desktop-update.spec.ts
@@ -40,7 +40,13 @@ test("desktop update can be checked, deferred, and installed from settings", asy
           },
           install: async () => {
             if (++installAttempts <= 2) {
-              state = { ...state, message: "The update could not be completed. Try again later." };
+              state = { ...state, message: null };
+              setTimeout(() => {
+                state = {
+                  ...state,
+                  message: "The update could not be completed. Try again later.",
+                };
+              }, 100);
               return state;
             }
             state = { ...state, message: null };

--- a/apps/web/e2e/desktop-update.spec.ts
+++ b/apps/web/e2e/desktop-update.spec.ts
@@ -5,6 +5,7 @@ test("desktop update can be checked, deferred, and installed from settings", asy
   page,
 }, testInfo) => {
   await page.addInitScript(() => {
+    let installAttempts = 0;
     let state = {
       phase: "idle",
       currentVersion: "0.1.2",
@@ -33,6 +34,10 @@ test("desktop update can be checked, deferred, and installed from settings", asy
             return state;
           },
           install: async () => {
+            if (++installAttempts === 1) {
+              state = { ...state, message: "The update could not be completed. Try again later." };
+              return state;
+            }
             document.documentElement.dataset.updateInstalled = "true";
             return state;
           },
@@ -60,6 +65,10 @@ test("desktop update can be checked, deferred, and installed from settings", asy
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   await expect(settings.getByRole("button", { name: "Restart to update" })).toBeVisible();
   await captureScreenshot(page, testInfo, "desktop-update-settings");
+  await settings.getByRole("button", { name: "Restart to update" }).click();
+  await expect(settings.getByRole("status")).toHaveText(
+    "The update could not be completed. Try again later.",
+  );
   await settings.getByRole("button", { name: "Restart to update" }).click();
   await expect(page.locator("html")).toHaveAttribute("data-update-installed", "true");
 });

--- a/apps/web/e2e/messaging-settings.spec.ts
+++ b/apps/web/e2e/messaging-settings.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { captureScreenshot, completeOnboarding, signup } from "./helpers";
 
+test.afterEach(async ({ page }) => {
+  // Polling can leave a route.fetch response in use when the assertions finish.
+  await page.unrouteAll({ behavior: "wait" });
+});
+
 /**
  * The messaging surface is env-gated off in E2E (no platform credentials),
  * so the surface RPCs are fulfilled with fixture data. The screen itself —

--- a/apps/web/src/components/DesktopUpdates.tsx
+++ b/apps/web/src/components/DesktopUpdates.tsx
@@ -105,9 +105,9 @@ export function DesktopUpdatesProvider({ children }: { children: ReactNode }) {
               <Trans>Later</Trans>
             </Button>
           </div>
-          {error ? (
+          {error || state.message ? (
             <p role="status" className="mt-2 text-sm">
-              {error}
+              {error ?? state.message}
             </p>
           ) : null}
         </aside>

--- a/apps/web/src/components/DesktopUpdates.tsx
+++ b/apps/web/src/components/DesktopUpdates.tsx
@@ -1,0 +1,150 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { DesktopUpdateState } from "@rakazo/contracts";
+import { Button } from "@rakazo/ui-web";
+import { createContext, type ReactNode, useContext, useEffect, useRef, useState } from "react";
+import { desktopBridge } from "../lib/desktop";
+
+function useDesktopUpdates() {
+  const { t } = useLingui();
+  const bridge = desktopBridge()?.update;
+  const [state, setState] = useState<DesktopUpdateState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pending = useRef(false);
+  const revision = useRef(0);
+
+  useEffect(() => {
+    if (!bridge) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout>;
+    async function refresh() {
+      const started = revision.current;
+      try {
+        const next = await bridge!.state();
+        if (!stopped && started === revision.current && !pending.current) setState(next);
+      } catch {
+        // A disappearing bridge during shutdown should not interrupt the app.
+      } finally {
+        if (!stopped) timer = setTimeout(refresh, 2_000);
+      }
+    }
+    void refresh();
+    return () => {
+      stopped = true;
+      clearTimeout(timer);
+    };
+  }, [bridge]);
+
+  async function act(action: "check" | "install") {
+    if (!bridge || pending.current) return;
+    pending.current = true;
+    revision.current++;
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await bridge[action]();
+      setState(next);
+      if (next.phase === "error") setError(next.message);
+    } catch {
+      setError(t`Could not complete the update. Try again.`);
+    } finally {
+      revision.current++;
+      pending.current = false;
+      setBusy(false);
+    }
+  }
+  return { state, busy, error, act };
+}
+
+const UpdatesContext = createContext<ReturnType<typeof useDesktopUpdates> | null>(null);
+
+export function DesktopUpdatesProvider({ children }: { children: ReactNode }) {
+  const { t } = useLingui();
+  const updates = useDesktopUpdates();
+  const [dismissed, setDismissed] = useState<string | null>(null);
+  const { state, busy, error, act } = updates;
+  return (
+    <UpdatesContext.Provider value={updates}>
+      {children}
+      {state &&
+      (state.phase === "ready" || (error && state.availableVersion)) &&
+      dismissed !== state.availableVersion ? (
+        <aside
+          aria-label={t`Desktop update`}
+          aria-live="polite"
+          className="fixed bottom-4 right-4 z-50 max-w-[calc(100vw-2rem)] rounded-xl border border-border bg-card p-3 text-card-foreground shadow-lg"
+        >
+          <div className="flex items-center gap-2">
+            <Button
+              disabled={busy}
+              onClick={() => void act(state.phase === "ready" ? "install" : "check")}
+            >
+              {state.phase === "ready" ? (
+                <Trans>Restart to update</Trans>
+              ) : (
+                <Trans>Check for updates</Trans>
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              disabled={busy}
+              onClick={() => setDismissed(state.availableVersion)}
+            >
+              <Trans>Later</Trans>
+            </Button>
+          </div>
+          {error ? (
+            <p role="status" className="mt-2 text-sm">
+              {error}
+            </p>
+          ) : null}
+        </aside>
+      ) : null}
+    </UpdatesContext.Provider>
+  );
+}
+
+export function DesktopUpdateSection() {
+  const updates = useContext(UpdatesContext);
+  if (!updates?.state) return null;
+  const { state, busy, error, act } = updates;
+  const ready = state.phase === "ready";
+  const downloading = state.phase === "available" || state.phase === "downloading";
+  return (
+    <section
+      data-testid="desktop-update-settings"
+      className="mt-5 rounded-xl border border-border px-4 py-4"
+    >
+      <h3 className="text-[15px] font-medium text-foreground">
+        <Trans>Desktop app</Trans>
+      </h3>
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <span className="text-sm text-muted-foreground">v{state.currentVersion}</span>
+        <Button
+          variant="outline"
+          disabled={busy || downloading || state.phase === "checking"}
+          onClick={() => void act(ready ? "install" : "check")}
+        >
+          {ready ? (
+            <Trans>Restart to update</Trans>
+          ) : downloading ? (
+            <Trans>Downloading…</Trans>
+          ) : busy || state.phase === "checking" ? (
+            <Trans>Checking…</Trans>
+          ) : (
+            <Trans>Check for updates</Trans>
+          )}
+        </Button>
+      </div>
+      <p role="status" className="mt-2 text-sm text-muted-foreground">
+        {error ??
+          state.message ??
+          (downloading ? (
+            `${state.percent ?? 0}%`
+          ) : state.phase === "idle" && state.checkedAt ? (
+            <Trans>Up to date</Trans>
+          ) : null)}
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/DesktopUpdates.tsx
+++ b/apps/web/src/components/DesktopUpdates.tsx
@@ -44,7 +44,9 @@ function useDesktopUpdates() {
     try {
       const next = await bridge[action]();
       setState(next);
-      if (next.phase === "error") setError(next.message);
+      if (next.phase === "error" || (action === "install" && next.message !== state?.message)) {
+        setError(next.message);
+      }
     } catch {
       setError(t`Could not complete the update. Try again.`);
     } finally {

--- a/apps/web/src/components/DesktopUpdates.tsx
+++ b/apps/web/src/components/DesktopUpdates.tsx
@@ -54,7 +54,7 @@ function useDesktopUpdates() {
       ) {
         setConfirmedCheck(next.checkedAt);
       }
-      if (next.phase === "error" || (action === "install" && next.message !== state?.message)) {
+      if (next.phase === "error" || action === "install") {
         setError(next.message);
       }
     } catch {

--- a/apps/web/src/components/DesktopUpdates.tsx
+++ b/apps/web/src/components/DesktopUpdates.tsx
@@ -9,6 +9,7 @@ function useDesktopUpdates() {
   const bridge = desktopBridge()?.update;
   const [state, setState] = useState<DesktopUpdateState | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmedCheck, setConfirmedCheck] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const pending = useRef(false);
   const revision = useRef(0);
@@ -41,9 +42,18 @@ function useDesktopUpdates() {
     revision.current++;
     setBusy(true);
     setError(null);
+    if (action === "check") setConfirmedCheck(null);
     try {
       const next = await bridge[action]();
       setState(next);
+      if (
+        action === "check" &&
+        next.phase === "idle" &&
+        !next.message &&
+        next.checkedAt !== state?.checkedAt
+      ) {
+        setConfirmedCheck(next.checkedAt);
+      }
       if (next.phase === "error" || (action === "install" && next.message !== state?.message)) {
         setError(next.message);
       }
@@ -55,7 +65,7 @@ function useDesktopUpdates() {
       setBusy(false);
     }
   }
-  return { state, busy, error, act };
+  return { state, busy, error, act, confirmedCheck };
 }
 
 const UpdatesContext = createContext<ReturnType<typeof useDesktopUpdates> | null>(null);
@@ -109,7 +119,7 @@ export function DesktopUpdatesProvider({ children }: { children: ReactNode }) {
 export function DesktopUpdateSection() {
   const updates = useContext(UpdatesContext);
   if (!updates?.state) return null;
-  const { state, busy, error, act } = updates;
+  const { state, busy, error, act, confirmedCheck } = updates;
   const ready = state.phase === "ready";
   const downloading = state.phase === "available" || state.phase === "downloading";
   return (
@@ -143,7 +153,7 @@ export function DesktopUpdateSection() {
           state.message ??
           (downloading ? (
             `${state.percent ?? 0}%`
-          ) : state.phase === "idle" && state.checkedAt ? (
+          ) : state.phase === "idle" && confirmedCheck && state.checkedAt === confirmedCheck ? (
             <Trans>Up to date</Trans>
           ) : null)}
       </p>

--- a/apps/web/src/components/DesktopUpdates.tsx
+++ b/apps/web/src/components/DesktopUpdates.tsx
@@ -22,7 +22,16 @@ function useDesktopUpdates() {
       const started = revision.current;
       try {
         const next = await bridge!.state();
-        if (!stopped && started === revision.current && !pending.current) setState(next);
+        if (!stopped && started === revision.current && !pending.current) {
+          setState((current) =>
+            current &&
+            Object.entries(next).every(
+              ([key, value]) => current[key as keyof DesktopUpdateState] === value,
+            )
+              ? current
+              : next,
+          );
+        }
       } catch {
         // A disappearing bridge during shutdown should not interrupt the app.
       } finally {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode, useEffect, useLayoutEffect } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
+import { DesktopUpdatesProvider } from "./components/DesktopUpdates";
 import { I18nBootstrap } from "./components/I18nBootstrap";
 import { applyUiDirection } from "./lib/apply-ui-direction";
 import { markAfterPaint, markOnce } from "./lib/performance";
@@ -34,7 +35,9 @@ createRoot(document.getElementById("root")!).render(
     <AppearanceSync />
     <I18nBootstrap>
       <BrowserRouter>
-        <App />
+        <DesktopUpdatesProvider>
+          <App />
+        </DesktopUpdatesProvider>
       </BrowserRouter>
     </I18nBootstrap>
   </StrictMode>,

--- a/apps/web/src/pages/AccountSettingsOverlay.tsx
+++ b/apps/web/src/pages/AccountSettingsOverlay.tsx
@@ -26,6 +26,7 @@ import {
   ComputersUnavailableHint,
   computersAreUnavailable,
 } from "../components/ComputersUnavailableHint";
+import { DesktopUpdateSection } from "../components/DesktopUpdates";
 import { SoftwareUpdateSection } from "../components/SoftwareUpdateSection";
 import { authClient } from "../lib/auth";
 import { getActiveUiLocale, setUiLocale } from "../lib/i18n";
@@ -217,6 +218,7 @@ export function AccountSettingsOverlay({
           </p>
         </div>
 
+        <DesktopUpdateSection />
         <SoftwareUpdateSection isDeploymentOwner={isDeploymentOwner} />
 
         {isDeploymentOwner && computersAreUnavailable(sandboxProvider) ? (


### PR DESCRIPTION
## Why
Desktop releases download silently, leaving people unaware that an update is ready. An app left open also misses releases published after its launch check.

## What changed
Show a dismissible restart action once a desktop download is ready, and expose the installed version, manual checking, download progress, and restart action in account settings. The desktop process checks hourly as well as at launch. Installation failures keep the verified download ready for retry, including asynchronous updater errors; normal window behavior is restored after failure. Existing backend validation and installation remain authoritative. Browser and mobile sessions do not show desktop controls.

## UI copy
“Restart to update” names the action and appears only when installation is ready. “Later” lets people keep working. “Desktop app” distinguishes the desktop binary from the existing server update settings; it appears only in desktop account settings. “Check for updates”, “Checking…”, “Downloading…”, and “Up to date” identify the requested action and its result, only within those settings. “Could not complete the update. Try again.” appears only after a failed bridge operation. “The update could not be completed. Try again later.” is the existing sanitized installer error, now visible only when installation fails. “Desktop update” is the prompt's accessible name. The installed version and download percentage identify the current build and progress. Removing these labels would obscure the controls or their outcome; explanatory copy is otherwise omitted.

## Validation
All 276 desktop unit tests passed locally, along with the repository-wide typecheck and lint (existing warnings only). Both new browser tests passed in CI, covering manual checks, background discovery, download progress, dismissal, repeated asynchronous installation failures, retry, and browser-session exclusion. All CI checks passed, including the full browser suite, production builds, Electron smoke, unit tests, typechecks, and integration tests. Both automated reviews completed with no unresolved findings. CI exposed a messaging-settings teardown race: an in-flight route response was disposed when the test ended. The messaging fixture now waits for active route handlers before teardown without changing its assertions; the full browser suite passed with that fix.

CI screenshots: [ready prompt](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34136398848-1/screenshots/images/125-desktop-update-ready.png) · [settings with installation retry](https://rakazogithubactions.fsn1.your-objectstorage.com/playwright/runs/34136398848-1/screenshots/images/126-desktop-update-settings.png).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop update management in Account Settings, including version details, status, download progress, errors, and available actions.
  * Added dismissible notifications for available updates and update activity.
  * Desktop apps now check for updates periodically while running.

* **Bug Fixes**
  * Prevented overlapping update actions and ignored outdated status results.
  * Failed installations remain available for retry without downloading again.
  * Update failures restore normal window behavior and provide clearer status messages.
  * Improved status handling after downloads and asynchronous installation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


