### PR TITLE
Show real setup progress and keep the panel alive during long pulls

### DIFF
--- a/apps/desktop/e2e/local-stack.spec.ts
+++ b/apps/desktop/e2e/local-stack.spec.ts
@@ -172,6 +172,8 @@ test("This computer installs and starts the stack, then opens the app", async ()
   await expect(setup.locator("#stack-output")).toBeHidden();
   await setup.screenshot({
     path: path.join(import.meta.dirname, "screenshots", "06-setup-installing.png"),
+    // Fast-forward the bar's width transition so the artifact shows the value, not a frame of it.
+    animations: "disabled",
   });
   await setup.getByRole("button", { name: "Technical details" }).click();
   await expect(setup.locator("#stack-output")).toContainText("app Pulled");

--- a/apps/desktop/e2e/local-stack.spec.ts
+++ b/apps/desktop/e2e/local-stack.spec.ts
@@ -107,7 +107,7 @@ async function writeFakeDocker(mode: FakeDockerMode) {
     "  pull)",
     mode === "pull-fails"
       ? '    echo "Error response from daemon: manifest unknown" >&2; exit 1 ;;'
-      : '    echo "app Pulled"; sleep 2; echo "computer Pulled"; exit 0 ;;',
+      : '    echo " a235d761c5d1 Downloading 59.47MB"; echo " a235d761c5d1 Downloading 412.3MB"; echo "app Pulled"; sleep 2; echo "computer Pulled"; exit 0 ;;',
     up,
     '  logs) echo "web-1 | listening"; exit 0 ;;',
     "esac",
@@ -164,12 +164,17 @@ test("This computer installs and starts the stack, then opens the app", async ()
 
   const appWindowPromise = app.waitForEvent("window");
   await setup.getByRole("button", { name: "Continue" }).click();
-  await expect(setup.locator("#stack-phase")).toHaveText("Downloading Rakazo images…");
-  await expect(setup.locator("#stack-output")).toContainText("app Pulled");
+  await expect(setup.locator("#stack-phase")).toHaveText("Downloading Rakazo…");
   await expect(setup.getByRole("button", { name: "Continue" })).toBeDisabled();
+  // Docker output stays behind the details toggle; the phase, the bar, and the size show by default.
+  await expect(setup.locator("#stack-detail")).toHaveText("412 MB downloaded");
+  await expect(setup.locator("#stack-progress")).toBeVisible();
+  await expect(setup.locator("#stack-output")).toBeHidden();
   await setup.screenshot({
     path: path.join(import.meta.dirname, "screenshots", "06-setup-installing.png"),
   });
+  await setup.getByRole("button", { name: "Technical details" }).click();
+  await expect(setup.locator("#stack-output")).toContainText("app Pulled");
 
   const appWindow = await appWindowPromise;
   await expect(appWindow.getByText(APP_MARKER)).toBeVisible();
@@ -229,7 +234,7 @@ test("switching to Existing instance while the stack starts keeps that choice", 
   const setup = await app.firstWindow();
 
   await setup.getByRole("button", { name: "Continue" }).click();
-  await expect(setup.locator("#stack-phase")).toHaveText("Downloading Rakazo images…");
+  await expect(setup.locator("#stack-phase")).toHaveText("Downloading Rakazo…");
 
   // Fake docker sleeps during pull; leave This computer before ready so followStack must not save.
   await setup.getByRole("radio", { name: /Existing instance/ }).check();

--- a/apps/desktop/src/local-stack.test.ts
+++ b/apps/desktop/src/local-stack.test.ts
@@ -196,6 +196,25 @@ describe("reduceStackState", () => {
     expect(state.phase).toBe("ready");
   });
 
+  it("sums the largest size each layer reports and clears it for the next attempt", () => {
+    let state = reduceStackState(start, { type: "check-start" });
+    state = reduceStackState(state, { type: "pull-start" });
+    for (const line of [
+      " a235d761c5d1 Downloading 59.47MB",
+      " a235d761c5d1 Downloading 1.02GB",
+      // Out-of-order and repeated lines must never walk the total backwards.
+      " a235d761c5d1 Downloading 900MB",
+      " 37d39b5cad9d Downloading 491.5kB",
+      " 37d39b5cad9d Extracting 491.5kB",
+      " app Pulled",
+    ]) {
+      state = reduceStackState(state, { type: "output", line });
+    }
+    expect(state.layerBytes).toEqual({ a235d761c5d1: 1.02e9, "37d39b5cad9d": 491_500 });
+
+    expect(reduceStackState(state, { type: "check-start" }).layerBytes).toEqual({});
+  });
+
   it("keeps only the last lines of output", () => {
     let state = reduceStackState(start, { type: "check-start" });
     state = reduceStackState(state, { type: "pull-start" });
@@ -325,6 +344,24 @@ describe("LocalStackController", () => {
     const stack = new LocalStackController(deps);
     return stack;
   }
+
+  it("pushes every state change so the setup window is never left waiting on a poll", async () => {
+    const pushed: string[] = [];
+    const stack = controller({ onState: (state) => pushed.push(state.phase) });
+
+    await stack.start();
+    expect(pushed).toEqual([
+      "checking-docker",
+      "preparing",
+      "pulling",
+      "pulling",
+      "pulling",
+      "starting",
+      "starting",
+      "waiting-healthy",
+      "ready",
+    ]);
+  });
 
   it("installs the compose project and walks every phase to ready", async () => {
     const stack = controller();

--- a/apps/desktop/src/local-stack.ts
+++ b/apps/desktop/src/local-stack.ts
@@ -171,7 +171,22 @@ export type LocalStackEvent =
   | { type: "failed"; message: string };
 
 export function initialStackState(imageTag: string): DesktopLocalStackState {
-  return { phase: "idle", message: null, output: [], imageTag };
+  return { phase: "idle", message: null, output: [], layerBytes: {}, imageTag };
+}
+
+/** `COMPOSE_PROGRESS=plain` reports a layer's downloaded size and never its total. */
+const PULL_PROGRESS = /^\s*(\S+)\s+Downloading\s+([\d.]+)\s*([kKMG]?B)\b/;
+const BYTE_UNITS: Record<string, number> = { B: 1, kB: 1e3, MB: 1e6, GB: 1e9 };
+
+/** Layers report a growing size, so the largest value seen for a layer is what it has pulled. */
+function reduceLayerBytes(layerBytes: Record<string, number>, line: string) {
+  const match = PULL_PROGRESS.exec(line);
+  if (match === null) return layerBytes;
+  const layer = match[1] ?? "";
+  const unit = match[3] === "KB" ? "kB" : (match[3] ?? "");
+  const bytes = Number(match[2]) * (BYTE_UNITS[unit] ?? 0);
+  if (!Number.isFinite(bytes) || bytes <= (layerBytes[layer] ?? 0)) return layerBytes;
+  return { ...layerBytes, [layer]: bytes };
 }
 
 export function reduceStackState(
@@ -179,7 +194,7 @@ export function reduceStackState(
   event: LocalStackEvent,
 ): DesktopLocalStackState {
   if (event.type === "check-start") {
-    return { ...state, phase: "checking-docker", message: null, output: [] };
+    return { ...state, phase: "checking-docker", message: null, output: [], layerBytes: {} };
   }
   // Terminal phases only leave through the next check-start.
   if (state.phase === "ready" || state.phase === "failed") return state;
@@ -204,7 +219,11 @@ export function reduceStackState(
       ) {
         return state;
       }
-      return { ...state, output: [...state.output, event.line].slice(-STACK_OUTPUT_LINES) };
+      return {
+        ...state,
+        output: [...state.output, event.line].slice(-STACK_OUTPUT_LINES),
+        layerBytes: reduceLayerBytes(state.layerBytes, event.line),
+      };
     case "ready":
       return { ...state, phase: "ready", message: null };
     case "failed":
@@ -267,6 +286,8 @@ export interface LocalStackDeps {
   /** Returns the authenticated running image tag, or null for any other listener. */
   probe: (url: string, signal: AbortSignal, token: string) => Promise<string | null>;
   randomHex: (bytes: number) => string;
+  /** Called on every state change so the setup window is pushed progress instead of polling for it. */
+  onState?: (state: DesktopLocalStackState) => void;
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
   healthTimeoutMs?: number;
 }
@@ -371,15 +392,22 @@ export class LocalStackController {
   private async runStop(): Promise<DesktopLocalStackState> {
     const binary = resolveDockerBinary(this.deps.platform, this.deps.env, this.deps.exists);
     const stopped = binary === null ? null : await this.compose(binary, ["stop"], STOP_TIMEOUT_MS);
-    this.current =
+    this.setState(
       stopped?.code === 0
         ? initialStackState(this.deps.imageTag)
-        : { ...this.current, phase: "failed", message: STOP_FAILED };
+        : { ...this.current, phase: "failed", message: STOP_FAILED },
+    );
     return this.current;
   }
 
   private push(event: LocalStackEvent) {
-    this.current = reduceStackState(this.current, event);
+    this.setState(reduceStackState(this.current, event));
+  }
+
+  private setState(next: DesktopLocalStackState) {
+    if (next === this.current) return;
+    this.current = next;
+    this.deps.onState?.(next);
   }
 
   private async run(): Promise<DesktopLocalStackState> {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -564,6 +564,8 @@ function createSetupWindow() {
       nodeIntegration: false,
       contextIsolation: true,
       sandbox: true,
+      // A long pull runs while this window sits behind others; throttled timers would freeze it.
+      backgroundThrottling: false,
     },
   });
   setupWindow = win;
@@ -914,6 +916,11 @@ app.whenReady().then(async () => {
     }),
     probe: (url, signal, token) => probeManagedStack(url, token, signal),
     randomHex: (bytes) => randomBytes(bytes).toString("hex"),
+    onState: (state) => {
+      if (setupWindow !== null && !setupWindow.isDestroyed()) {
+        setupWindow.webContents.send("desktop.setup.stack.changed", state);
+      }
+    },
   });
   currentSetup = await readSetup(userDataDir);
   const target = resolveStartupTarget({

--- a/apps/desktop/src/preload.test.ts
+++ b/apps/desktop/src/preload.test.ts
@@ -89,7 +89,7 @@ describe("desktop preload bridge", () => {
 
 describe("setup preload bridge", () => {
   it("exposes only the first-run setup operations", async () => {
-    const { invoke, exposeInMainWorld } = runPreload("setup-preload.cjs");
+    const { invoke, on, exposeInMainWorld } = runPreload("setup-preload.cjs");
 
     expect(exposeInMainWorld).toHaveBeenCalledTimes(1);
     const [globalName, bridge] = exposeInMainWorld.mock.calls[0] as [string, RakazoSetup];
@@ -104,7 +104,7 @@ describe("setup preload bridge", () => {
       "state",
       "test",
     ]);
-    expect(Object.keys(bridge.stack).sort()).toEqual(["start", "state"]);
+    expect(Object.keys(bridge.stack).sort()).toEqual(["onChange", "start", "state"]);
 
     await bridge.state();
     await bridge.test("http://127.0.0.1:5173");
@@ -123,5 +123,12 @@ describe("setup preload bridge", () => {
       "desktop.setup.stack.start",
     ]);
     expect(invoke).toHaveBeenCalledWith("desktop.setup.openLink", "orbstack");
+
+    const listener = vi.fn();
+    bridge.stack.onChange(listener);
+    const [channel, handler] = on.mock.calls.at(-1) as [string, (...args: unknown[]) => void];
+    expect(channel).toBe("desktop.setup.stack.changed");
+    handler({}, { phase: "pulling" });
+    expect(listener).toHaveBeenCalledWith({ phase: "pulling" });
   });
 });

--- a/apps/desktop/src/setup-preload.cjs
+++ b/apps/desktop/src/setup-preload.cjs
@@ -10,5 +10,8 @@ contextBridge.exposeInMainWorld("rakazoSetup", {
   stack: {
     state: () => ipcRenderer.invoke("desktop.setup.stack.state"),
     start: () => ipcRenderer.invoke("desktop.setup.stack.start"),
+    onChange: (listener) => {
+      ipcRenderer.on("desktop.setup.stack.changed", (_event, state) => listener(state));
+    },
   },
 });

--- a/apps/desktop/src/setup.css
+++ b/apps/desktop/src/setup.css
@@ -166,11 +166,90 @@ html[data-platform="darwin"] .titlebar {
   border-color: var(--ring);
 }
 
+.stack-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .stack-phase {
   margin: 0;
   min-height: 20px;
   font-size: 13px;
   color: var(--foreground);
+}
+
+.icon-button {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: none;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.icon-button:hover,
+.icon-button[aria-expanded="true"] {
+  color: var(--foreground);
+  background: var(--accent);
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.icon-button svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.progress {
+  margin-top: 10px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--accent);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0;
+  border-radius: inherit;
+  background: var(--primary);
+  transition: width 400ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-fill {
+    transition: none;
+  }
+}
+
+.stack-detail {
+  margin: 8px 0 0;
+  min-height: 18px;
+  font-size: 12px;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
+/* No size to report (a failure, or before the first layer): take no room. */
+.stack-detail:empty {
+  margin: 0;
+  min-height: 0;
 }
 
 .stack-phase[data-tone="error"] {

--- a/apps/desktop/src/setup.html
+++ b/apps/desktop/src/setup.html
@@ -37,7 +37,26 @@
 
         <section id="panel-new" class="panel">
           <div id="stack" hidden>
-            <p id="stack-phase" class="stack-phase" role="status" aria-live="polite"></p>
+            <div class="stack-head">
+              <p id="stack-phase" class="stack-phase" role="status" aria-live="polite"></p>
+              <button
+                id="stack-details"
+                class="icon-button"
+                type="button"
+                aria-controls="stack-output"
+                aria-expanded="false"
+                aria-label="Technical details"
+                title="Technical details"
+              >
+                <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                  <path d="M3.5 4.5 7 8l-3.5 3.5M8.5 11.5H13" />
+                </svg>
+              </button>
+            </div>
+            <div id="stack-progress" class="progress" hidden>
+              <div id="stack-progress-fill" class="progress-fill"></div>
+            </div>
+            <p id="stack-detail" class="stack-detail"></p>
             <pre id="stack-output" class="stack-output" hidden></pre>
             <div id="stack-docker-help" class="stack-help" hidden>
               <button class="link" type="button" data-link="docker-desktop">Docker Desktop</button>

--- a/apps/desktop/src/setup.html
+++ b/apps/desktop/src/setup.html
@@ -53,7 +53,16 @@
                 </svg>
               </button>
             </div>
-            <div id="stack-progress" class="progress" hidden>
+            <div
+              id="stack-progress"
+              class="progress"
+              role="progressbar"
+              aria-label="Setup progress"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="0"
+              hidden
+            >
               <div id="stack-progress-fill" class="progress-fill"></div>
             </div>
             <p id="stack-detail" class="stack-detail"></p>

--- a/apps/desktop/src/setup.js
+++ b/apps/desktop/src/setup.js
@@ -9,6 +9,10 @@
   const stackSection = document.getElementById("stack");
   const stackPhase = document.getElementById("stack-phase");
   const stackOutput = document.getElementById("stack-output");
+  const stackDetail = document.getElementById("stack-detail");
+  const stackDetails = document.getElementById("stack-details");
+  const stackProgress = document.getElementById("stack-progress");
+  const stackProgressFill = document.getElementById("stack-progress-fill");
   const stackDockerHelp = document.getElementById("stack-docker-help");
   const status = document.getElementById("status");
   const checkButton = document.getElementById("check");
@@ -17,12 +21,12 @@
 
   const STACK_POLL_MS = 1000;
   const PHASE_LABELS = {
-    "checking-docker": "Checking Docker…",
-    preparing: "Preparing…",
-    pulling: "Downloading Rakazo images…",
-    starting: "Starting services…",
-    "waiting-healthy": "Waiting for Rakazo to answer…",
-    ready: "Rakazo is running.",
+    "checking-docker": "Getting ready…",
+    preparing: "Getting ready…",
+    pulling: "Downloading Rakazo…",
+    starting: "Starting Rakazo…",
+    "waiting-healthy": "Almost ready…",
+    ready: "Rakazo is ready.",
   };
   const TERMINAL_PHASES = new Set([
     "idle",
@@ -31,9 +35,25 @@
     "ready",
     "failed",
   ]);
+  const PHASE_PROGRESS = {
+    "checking-docker": 0.06,
+    preparing: 0.12,
+    pulling: 0.2,
+    starting: 0.82,
+    "waiting-healthy": 0.92,
+    ready: 1,
+  };
+  /** Docker reports bytes pulled but never a total, so the bar approaches the next phase without reaching it. */
+  const PULL_SPAN = 0.6;
+  const PULL_SCALE_BYTES = 1.2e9;
 
   let defaultLocalUrl = "";
   let stackPolling = false;
+  let lastStack = null;
+  let lastProgress = 0;
+  let detailsOpen = false;
+  /** Resolves the poll wait early when the main process pushes a new state. */
+  let wakePoll = null;
 
   function selectedMode() {
     const checked = form.querySelector('input[name="mode"]:checked');
@@ -69,7 +89,56 @@
     return phase === "docker-missing" || phase === "docker-not-running";
   }
 
+  function downloadedBytes(stack) {
+    return Object.values(stack.layerBytes ?? {}).reduce((total, bytes) => total + bytes, 0);
+  }
+
+  function formatBytes(bytes) {
+    if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(1)} GB`;
+    if (bytes >= 1e6) return `${Math.round(bytes / 1e6)} MB`;
+    return `${Math.round(bytes / 1e3)} kB`;
+  }
+
+  function progressFor(stack) {
+    const base = PHASE_PROGRESS[stack.phase] ?? 0;
+    if (stack.phase !== "pulling") return base;
+    return base + PULL_SPAN * (1 - Math.exp(-downloadedBytes(stack) / PULL_SCALE_BYTES));
+  }
+
+  function renderProgress(stack) {
+    const running = stack.phase in PHASE_PROGRESS;
+    stackProgress.hidden = !running;
+    if (!running) {
+      lastProgress = 0;
+      stackProgressFill.style.width = "0%";
+      return;
+    }
+    // A retry restarts at its phase; otherwise the bar only ever moves forward.
+    lastProgress =
+      stack.phase === "checking-docker"
+        ? progressFor(stack)
+        : Math.max(lastProgress, progressFor(stack));
+    stackProgressFill.style.width = `${(lastProgress * 100).toFixed(1)}%`;
+  }
+
+  function renderDetails(stack) {
+    const bytes = stack.phase === "pulling" ? downloadedBytes(stack) : 0;
+    stackDetail.textContent = bytes > 0 ? `${formatBytes(bytes)} downloaded` : "";
+
+    const hasOutput = stack.output.length > 0;
+    // A failure asks the person to read the output, so open it for them.
+    if (stack.phase === "failed" && hasOutput) detailsOpen = true;
+    stackDetails.hidden = !hasOutput;
+    stackDetails.setAttribute("aria-expanded", String(detailsOpen && hasOutput));
+    stackOutput.hidden = !(detailsOpen && hasOutput);
+    if (!stackOutput.hidden) {
+      stackOutput.textContent = stack.output.join("\n");
+      stackOutput.scrollTop = stackOutput.scrollHeight;
+    }
+  }
+
   function renderStack(stack) {
+    lastStack = stack;
     const { phase } = stack;
     stackSection.hidden = phase === "idle";
     if (phase === "idle") {
@@ -82,14 +151,8 @@
     else if (phase === "ready") stackPhase.setAttribute("data-tone", "ok");
     else stackPhase.removeAttribute("data-tone");
 
-    const showOutput =
-      (phase === "pulling" || phase === "starting" || phase === "failed") &&
-      stack.output.length > 0;
-    stackOutput.hidden = !showOutput;
-    if (showOutput) {
-      stackOutput.textContent = stack.output.join("\n");
-      stackOutput.scrollTop = stackOutput.scrollHeight;
-    }
+    renderProgress(stack);
+    renderDetails(stack);
     stackDockerHelp.hidden = !isDockerPhase(phase);
 
     if (isDockerPhase(phase)) continueButton.textContent = "Check again";
@@ -111,6 +174,21 @@
       lockMode(false);
       setBusy(false);
     }
+  }
+
+  /** Wakes on the next pushed state, and on the timer if a push is ever missed. */
+  function waitForStackChange() {
+    return new Promise((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        if (wakePoll === finish) wakePoll = null;
+        resolve();
+      };
+      wakePoll = finish;
+      setTimeout(finish, STACK_POLL_MS);
+    });
   }
 
   /**
@@ -137,7 +215,7 @@
           }
           return;
         }
-        await new Promise((resolve) => setTimeout(resolve, STACK_POLL_MS));
+        await waitForStackChange();
       }
     } catch {
       setStatus("Could not follow the local stack. Try again.", "error");
@@ -151,7 +229,9 @@
     setStatus("");
     setBusy(true);
     try {
-      renderStack(await bridge.stack.start());
+      // A queued start still reads `idle`; leave the panel as it is and let the follow render it.
+      const started = await bridge.stack.start();
+      if (started !== null && started.phase !== "idle") renderStack(started);
     } catch {
       setStatus("Could not start the local stack. Try again.", "error");
       setBusy(false);
@@ -198,6 +278,11 @@
     void check();
   });
 
+  stackDetails.addEventListener("click", () => {
+    detailsOpen = !detailsOpen;
+    if (lastStack !== null) renderDetails(lastStack);
+  });
+
   stackDockerHelp.addEventListener("click", (event) => {
     const link = event.target instanceof HTMLElement ? event.target.dataset.link : undefined;
     if (link) void bridge.openLink(link);
@@ -217,6 +302,15 @@
     else void save("existing", serverUrl.value);
   });
 
+  /** Pushed state keeps progress moving even when the OS throttles this window's timers. */
+  function watchStack() {
+    bridge.stack.onChange(() => {
+      wakePoll?.();
+      // A follow that ended on an error restarts here instead of leaving the panel frozen.
+      if (!stackPolling && selectedMode() === "new") void followStack();
+    });
+  }
+
   async function init() {
     if (bridge === undefined) {
       setStatus("Setup bridge unavailable.", "error");
@@ -224,6 +318,7 @@
       return;
     }
 
+    watchStack();
     try {
       const state = await bridge.state();
       if (state === null) throw new Error("Setup is not active");

--- a/apps/desktop/src/setup.js
+++ b/apps/desktop/src/setup.js
@@ -52,6 +52,8 @@
   let lastStack = null;
   let lastProgress = 0;
   let detailsOpen = false;
+  /** Set when a failure opened the output; a retry closes it again, a person's own click does not. */
+  let detailsOpenedByFailure = false;
   /** Resolves the poll wait early when the main process pushes a new state. */
   let wakePoll = null;
 
@@ -96,7 +98,8 @@
   function formatBytes(bytes) {
     if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(1)} GB`;
     if (bytes >= 1e6) return `${Math.round(bytes / 1e6)} MB`;
-    return `${Math.round(bytes / 1e3)} kB`;
+    if (bytes >= 1e3) return `${Math.round(bytes / 1e3)} kB`;
+    return `${Math.round(bytes)} B`;
   }
 
   function progressFor(stack) {
@@ -118,16 +121,26 @@
       stack.phase === "checking-docker"
         ? progressFor(stack)
         : Math.max(lastProgress, progressFor(stack));
-    stackProgressFill.style.width = `${(lastProgress * 100).toFixed(1)}%`;
+    const percent = (lastProgress * 100).toFixed(1);
+    stackProgressFill.style.width = `${percent}%`;
+    stackProgress.setAttribute("aria-valuenow", percent);
   }
 
   function renderDetails(stack) {
     const bytes = stack.phase === "pulling" ? downloadedBytes(stack) : 0;
     stackDetail.textContent = bytes > 0 ? `${formatBytes(bytes)} downloaded` : "";
 
+    // A new attempt clears the output, so drop an expansion the person did not ask for.
+    if (stack.phase === "checking-docker" && detailsOpenedByFailure) {
+      detailsOpen = false;
+      detailsOpenedByFailure = false;
+    }
     const hasOutput = stack.output.length > 0;
     // A failure asks the person to read the output, so open it for them.
-    if (stack.phase === "failed" && hasOutput) detailsOpen = true;
+    if (stack.phase === "failed" && hasOutput && !detailsOpen) {
+      detailsOpen = true;
+      detailsOpenedByFailure = true;
+    }
     stackDetails.hidden = !hasOutput;
     stackDetails.setAttribute("aria-expanded", String(detailsOpen && hasOutput));
     stackOutput.hidden = !(detailsOpen && hasOutput);
@@ -280,6 +293,7 @@
 
   stackDetails.addEventListener("click", () => {
     detailsOpen = !detailsOpen;
+    detailsOpenedByFailure = false;
     if (lastStack !== null) renderDetails(lastStack);
   });
 
@@ -306,8 +320,12 @@
   function watchStack() {
     bridge.stack.onChange(() => {
       wakePoll?.();
-      // A follow that ended on an error restarts here instead of leaving the panel frozen.
-      if (!stackPolling && selectedMode() === "new") void followStack();
+      // A follow that ended on an error restarts here instead of leaving the panel frozen;
+      // hold the controls until it has rendered the state it is restarting on.
+      if (!stackPolling && selectedMode() === "new") {
+        setBusy(true);
+        void followStack();
+      }
     });
   }
 

--- a/packages/contracts/src/desktop.ts
+++ b/packages/contracts/src/desktop.ts
@@ -109,6 +109,8 @@ export interface DesktopLocalStackState {
   message: string | null;
   /** Bounded tail of docker output for the current attempt. */
   output: string[];
+  /** Bytes pulled per image layer in the current attempt; the sum is the only progress Docker reports. */
+  layerBytes: Record<string, number>;
   /** Image tag this app launches (`v<app version>` for installed builds, `edge` otherwise). */
   imageTag: string;
 }
@@ -133,5 +135,7 @@ export interface RakazoSetup {
     state: () => Promise<DesktopLocalStackState>;
     /** Starts (or retries) the stack; a no-op while a start is already in flight. */
     start: () => Promise<DesktopLocalStackState>;
+    /** Fires on every state change so progress never depends on a renderer timer. */
+    onChange: (listener: (state: DesktopLocalStackState) => void) => void;
   };
 }


### PR DESCRIPTION
## Why

On first run the setup screen showed a wall of raw docker output and nothing else, which is unreadable for a non-technical person; worse, the panel was driven only by a renderer `setTimeout` poll, so an unfocused window (Chromium throttles background timers) or a single failed poll froze the display mid-download and left Continue enabled while the pull was still running.

## What changed

The panel now shows a phase line, a progress bar fed by the bytes docker reports per layer, and the size downloaded so far, with the docker output moved behind a small terminal-icon toggle that opens itself on failure; the main process pushes every stack state change to the setup window, the window no longer throttles timers in the background, and a follow that ends on an error restarts on the next pushed change. Docker reports bytes pulled but never a total, so the pull segment of the bar approaches the next phase asymptotically instead of showing an invented percentage.

## Copy

Phase copy is one line at a time and replaces the previous technical wording: "Getting ready…" (was "Checking Docker…" / "Preparing…"), "Downloading Rakazo…" (was "Downloading Rakazo images…"), "Starting Rakazo…" (was "Starting services…"), "Almost ready…" (was "Waiting for Rakazo to answer…"), "Rakazo is ready." (was "Rakazo is running."). The one added string is the progress detail, "412 MB downloaded", which is the only real progress docker gives and cannot be inferred from the bar alone; the details toggle is an icon with the accessible name "Technical details", so the docker log is revealed only when someone asks for it rather than shown to everyone by default.

## Testing

Desktop unit tests and the typecheck pass locally, including new tests for the per-layer byte accounting (largest value per layer, cleared per attempt) and for the state-push sequence through a full start. The Electron e2e now asserts the collapsed output, the progress bar, and the downloaded size, and its fake docker emits download lines, so CI's `06-setup-installing.png` screenshot shows the new panel; I also rendered the setup window headlessly against a stubbed bridge to check the downloading and failed layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live download progress tracking during local stack setup.
  * Added an expandable Technical details panel for viewing setup output.
  * Setup status now updates automatically without waiting for periodic polling.
  * Added clearer download phase messaging and progress indicators.

* **Bug Fixes**
  * Improved setup responsiveness by forwarding stack state changes immediately.
  * Preserved accurate progress when download updates arrive out of order or repeat.
  * Setup details now reset appropriately when retrying after a failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->